### PR TITLE
docs(modal-infra): fix README accuracy issues

### DIFF
--- a/packages/modal-infra/README.md
+++ b/packages/modal-infra/README.md
@@ -9,7 +9,7 @@ This package provides the data plane for Open-Inspect:
 - **Sandboxes**: Isolated development environments running OpenCode
 - **Images**: Pre-built container images with all development tools
 - **Snapshots**: Filesystem snapshots for fast startup and session persistence
-- **Scheduler**: Automatic image rebuilding every 30 minutes
+- **Scheduler**: Image rebuilding infrastructure (currently disabled)
 
 ## Architecture
 
@@ -53,7 +53,7 @@ Base image definition with:
 
 ### Scheduler (`src/scheduler/`)
 
-- **image_builder.py**: Scheduled image rebuilds (every 30 min)
+- **image_builder.py**: Image rebuild infrastructure (scheduling currently disabled)
 
 ## Usage
 
@@ -85,12 +85,18 @@ See `.env.example` for a full list of environment variables.
 ### Deploy
 
 ```bash
-# Deploy the app
-modal deploy src/
+# Deploy the app (recommended)
+modal deploy deploy.py
 
-# Or run locally for development
+# Alternative: deploy the src package directly
+modal deploy -m src
+
+# Run locally for development
 modal run src/
 ```
+
+> **Note**: Never deploy `src/app.py` directly - it only defines the app and shared resources.
+> Use `deploy.py` or `-m src` to ensure all function modules are registered.
 
 ### Register a Repository
 
@@ -158,7 +164,7 @@ Set via Modal secrets:
 
 | Criterion | Test Method |
 |-----------|-------------|
-| Base image builds | `modal run src/images/base.py` |
+| App deploys successfully | `modal deploy deploy.py` completes without errors |
 | Sandbox starts from snapshot | Time `create_sandbox()` after warm |
 | Git sync completes | Verify HEAD matches origin |
 | OpenCode server responds | `curl localhost:4096/global/health` |


### PR DESCRIPTION
## Summary

- Update scheduler description to note it's currently disabled (cron is commented out in `image_builder.py`)
- Change recommended deploy command from `modal deploy src/` to `modal deploy deploy.py` to match project conventions
- Add warning note against deploying `app.py` directly
- Update verification criteria to use `deploy.py` instead of running `images/base.py` directly

## Context

The README had several inaccuracies compared to the actual codebase:

1. **Scheduler timing**: Claimed "automatic image rebuilding every 30 minutes" but the cron schedule is actually commented out in `src/scheduler/image_builder.py:311-317`

2. **Deploy command**: Recommended `modal deploy src/` but `deploy.py` is the proper entry point per project conventions (also documented in root CLAUDE.md)

3. **Verification criteria**: Listed `modal run src/images/base.py` which is not a standard way to test image builds

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes  
- [x] `ruff check` and `ruff format --check` pass
- [x] `pytest tests/` passes (1 pre-existing failure unrelated to docs)