### PR TITLE
refactor(modal-infra): use tempfile module for session ID file path

### DIFF
--- a/packages/modal-infra/src/sandbox/bridge.py
+++ b/packages/modal-infra/src/sandbox/bridge.py
@@ -15,6 +15,7 @@ import json
 import os
 import secrets
 import subprocess
+import tempfile
 import time
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -136,7 +137,7 @@ class AgentBridge:
 
         # Session state
         self.opencode_session_id: str | None = None
-        self.session_id_file = Path("/tmp/opencode-session-id")
+        self.session_id_file = Path(tempfile.gettempdir()) / "opencode-session-id"
         self.repo_path = Path("/workspace")
 
         # HTTP client for OpenCode API


### PR DESCRIPTION
## Summary
- Replace hardcoded `/tmp` path with Python's `tempfile.gettempdir()` for the session ID file
- Improves cross-platform compatibility by using the platform-appropriate temporary directory
- Follows Python best practices for temporary file handling

## Test plan
- [ ] Verify Modal deployment succeeds
- [ ] Confirm session ID file is created in the appropriate temp directory