### PR TITLE
cleanup: remove unused OAuth endpoints from control plane

### DIFF
--- a/packages/control-plane/README.md
+++ b/packages/control-plane/README.md
@@ -75,14 +75,6 @@ The control plane provides:
 | `/repos/:owner/:name/metadata` | GET    | Get repo metadata    |
 | `/repos/:owner/:name/metadata` | PUT    | Update repo metadata |
 
-### Authentication
-
-| Endpoint                | Method | Description      |
-| ----------------------- | ------ | ---------------- |
-| `/auth/github`          | GET    | Initiate OAuth   |
-| `/auth/github/callback` | GET    | OAuth callback   |
-| `/auth/me`              | GET    | Get current user |
-
 ### Webhooks
 
 | Endpoint           | Method | Description   |


### PR DESCRIPTION
## Summary

- Removes `/auth/github`, `/auth/github/callback`, and `/auth/me` endpoints that were never used
- These endpoints were designed for direct-to-control-plane OAuth but all clients use different auth methods:
  - **Web app**: Uses NextAuth for GitHub OAuth and passes tokens via session creation API
  - **Slack bot**: Uses internal service-to-service authentication (`INTERNAL_CALLBACK_SECRET`)
- Removes related `authSessionId` handling and KV `auth:*` storage code

## Test plan

- [ ] Verify control-plane builds successfully (`npm run build -w @open-inspect/control-plane`)
- [ ] Verify typecheck passes (`npm run typecheck -w @open-inspect/control-plane`)
- [ ] Verify lint passes (`npm run lint -w @open-inspect/control-plane`)
- [ ] Confirm web app authentication still works (uses NextAuth, unaffected)
- [ ] Confirm session creation still works (uses direct `githubToken` param, unaffected)