### PR TITLE
cleanup: remove unused /sessions/:id/warm endpoint

### DIFF
--- a/packages/control-plane/README.md
+++ b/packages/control-plane/README.md
@@ -54,7 +54,6 @@ The control plane provides:
 | `/sessions`                  | POST      | Create new session       |
 | `/sessions/:id`              | GET       | Get session state        |
 | `/sessions/:id`              | DELETE    | Delete session           |
-| `/sessions/:id/warm`         | POST      | Pre-warm sandbox         |
 | `/sessions/:id/prompt`       | POST      | Enqueue prompt           |
 | `/sessions/:id/stop`         | POST      | Stop execution           |
 | `/sessions/:id/ws`           | WebSocket | Real-time connection     |

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -198,11 +198,6 @@ const routes: Route[] = [
   },
   {
     method: "POST",
-    pattern: parsePattern("/sessions/:id/warm"),
-    handler: handleWarmSession,
-  },
-  {
-    method: "POST",
     pattern: parsePattern("/sessions/:id/prompt"),
     handler: handleSessionPrompt,
   },
@@ -523,18 +518,6 @@ async function handleDeleteSession(
   // when no longer referenced. We could also call a cleanup method on the DO.
 
   return json({ status: "deleted", sessionId });
-}
-
-async function handleWarmSession(
-  request: Request,
-  env: Env,
-  match: RegExpMatchArray
-): Promise<Response> {
-  const sessionId = match.groups?.id;
-  if (!sessionId) return error("Session ID required");
-
-  // TODO: Call Modal to warm sandbox
-  return json({ status: "warming" });
 }
 
 async function handleSessionPrompt(


### PR DESCRIPTION
## Summary

- Removes the `/sessions/:id/warm` endpoint stub that was never implemented
- No clients were calling this endpoint

## Why this is safe

Sandbox warming already works via WebSocket:
1. User types → WebSocket sends `{ type: "typing" }`
2. Durable Object's `handleTyping()` spawns a sandbox proactively
3. UI receives `sandbox_warming` message and shows status

The REST endpoint was a stub returning `{ status: "warming" }` without actually doing anything.

## Test plan

- [x] Verify typecheck passes
- [x] Verify build succeeds  
- [x] Verify lint passes
- [ ] Confirm typing-triggered warming still works (unaffected)