### PR TITLE
feat: track processing state server-side for accurate thinking indicator

### DIFF
--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -115,7 +115,8 @@ export type ServerMessage =
   | { type: "snapshot_saved"; imageId: string; reason: string }
   | { type: "sandbox_restored"; message: string }
   | { type: "sandbox_warning"; message: string }
-  | { type: "session_status"; status: SessionStatus };
+  | { type: "session_status"; status: SessionStatus }
+  | { type: "processing_status"; isProcessing: boolean };
 
 // Sandbox events (from Modal)
 export type SandboxEvent =
@@ -201,6 +202,7 @@ export interface SessionState {
   sandboxStatus: SandboxStatus;
   messageCount: number;
   createdAt: number;
+  isProcessing: boolean;
 }
 
 // Participant presence


### PR DESCRIPTION
## Summary

This PR moves the `isProcessing` state from client-side event computation to server-side tracking, fixing several issues with the "Thinking..." indicator in the session UI.

## Problem

The previous client-side approach computed `isProcessing` by checking if the last `user_message` event had a subsequent `execution_complete`. This had several issues:

1. **Initial prompt from home page:** When users submit their first prompt from the home page and navigate to the session page, the client-side state didn't survive navigation, so "Thinking..." never showed
2. **Cancelled requests:** If stop was sent without the sandbox responding with `execution_complete`, page refresh would incorrectly show "thinking" state forever
3. **Multiplayer inconsistency:** Other clients joining the session wouldn't see accurate processing state

## Solution

Make the server the source of truth for processing state:

- **Control Plane:**
  - Add `isProcessing: boolean` to `SessionState` interface
  - Add `processing_status` WebSocket message type
  - Query message status from DB (`SELECT ... WHERE status = 'processing'`)
  - Broadcast when message starts processing and on `execution_complete`

- **Web Client:**
  - Read `isProcessing` from server-provided session state
  - Handle `processing_status` message to update state in real-time
  - Optimistic update in `sendPrompt` for immediate feedback on follow-up messages
  - Remove local event-based computation

## Benefits

- All clients see accurate, consistent processing state
- Page refresh correctly reflects whether the agent is actually working
- Works correctly for initial prompts submitted before WebSocket connection
- Multiplayer-ready: all participants see the same state

## Test Plan

- [ ] Submit prompt from home page → navigate to session → verify "Thinking..." shows
- [ ] Submit follow-up prompt on session page → verify "Thinking..." shows immediately
- [ ] Wait for execution to complete → verify "Thinking..." disappears
- [ ] Refresh page during processing → verify "Thinking..." shows correctly
- [ ] Click stop during processing → wait for completion → verify "Thinking..." disappears
- [ ] Open session in two browser tabs → verify both show consistent state