### PR TITLE
Remove OpenCode models from the system

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -52,14 +52,7 @@ function getGitHubAvatarUrl(githubLogin: string | null | undefined): string | un
 /**
  * Valid model names for the LLM.
  */
-const VALID_MODELS = [
-  "claude-haiku-4-5",
-  "claude-sonnet-4-5",
-  "claude-opus-4-5",
-  "opencode/big-pickle",
-  "opencode/glm-4.7-free",
-  "opencode/grok-code",
-] as const;
+const VALID_MODELS = ["claude-haiku-4-5", "claude-sonnet-4-5", "claude-opus-4-5"] as const;
 type ValidModel = (typeof VALID_MODELS)[number];
 
 /**
@@ -105,7 +98,7 @@ const WS_AUTH_TIMEOUT_MS = 30000; // 30 seconds
 
 /**
  * Extract provider and model from a model ID.
- * Models like "opencode/big-pickle" have embedded provider.
+ * Models with "/" have embedded provider (kept for backward compatibility with existing sessions).
  * Models like "claude-haiku-4-5" use "anthropic" as default provider.
  */
 function extractProviderAndModel(modelId: string): { provider: string; model: string } {

--- a/packages/web/src/app/session/[id]/page.tsx
+++ b/packages/web/src/app/session/[id]/page.tsx
@@ -77,14 +77,6 @@ const MODEL_OPTIONS: { category: string; models: ModelOption[] }[] = [
       { id: "claude-sonnet-4-5", name: "claude sonnet 4.5", description: "Balanced performance" },
     ],
   },
-  {
-    category: "OpenCode (Free)",
-    models: [
-      { id: "opencode/big-pickle", name: "big pickle", description: "Free on OpenCode" },
-      { id: "opencode/glm-4.7-free", name: "glm 4.7", description: "Free on OpenCode" },
-      { id: "opencode/grok-code", name: "grok code", description: "Free on OpenCode" },
-    ],
-  },
 ];
 
 function CheckIcon() {

--- a/packages/web/src/app/session/[id]/page.tsx
+++ b/packages/web/src/app/session/[id]/page.tsx
@@ -75,6 +75,7 @@ const MODEL_OPTIONS: { category: string; models: ModelOption[] }[] = [
     models: [
       { id: "claude-haiku-4-5", name: "claude haiku 4.5", description: "Fast and efficient" },
       { id: "claude-sonnet-4-5", name: "claude sonnet 4.5", description: "Balanced performance" },
+      { id: "claude-opus-4-5", name: "claude opus 4.5", description: "Most capable" },
     ],
   },
 ];

--- a/packages/web/src/app/session/new/page.tsx
+++ b/packages/web/src/app/session/new/page.tsx
@@ -28,9 +28,6 @@ export default function NewSessionPage() {
   const models = [
     { id: "claude-haiku-4-5", name: "Claude Haiku 4.5", description: "Fast & affordable" },
     { id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5", description: "Balanced performance" },
-    { id: "opencode/big-pickle", name: "Big Pickle", description: "Free on OpenCode" },
-    { id: "opencode/glm-4.7-free", name: "GLM 4.7", description: "Free on OpenCode" },
-    { id: "opencode/grok-code", name: "Grok Code", description: "Free on OpenCode" },
   ];
 
   useEffect(() => {

--- a/packages/web/src/app/session/new/page.tsx
+++ b/packages/web/src/app/session/new/page.tsx
@@ -28,6 +28,7 @@ export default function NewSessionPage() {
   const models = [
     { id: "claude-haiku-4-5", name: "Claude Haiku 4.5", description: "Fast & affordable" },
     { id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5", description: "Balanced performance" },
+    { id: "claude-opus-4-5", name: "Claude Opus 4.5", description: "Most capable" },
   ];
 
   useEffect(() => {

--- a/packages/web/src/lib/format.ts
+++ b/packages/web/src/lib/format.ts
@@ -7,31 +7,9 @@
  * e.g., "claude-sonnet-4-5" → "Claude Sonnet 4.5"
  * e.g., "claude-haiku-4-5" → "Claude Haiku 4.5"
  * e.g., "claude-opus-4-5" → "Claude Opus 4.5"
- * e.g., "opencode/big-pickle" → "Big Pickle"
- * e.g., "opencode/glm-4.7-free" → "GLM 4.7"
- * e.g., "opencode/grok-code" → "Grok Code"
  */
 export function formatModelName(modelId: string): string {
   if (!modelId) return "Unknown Model";
-
-  // Handle OpenCode models (opencode/model-name)
-  if (modelId.startsWith("opencode/")) {
-    const modelName = modelId.slice("opencode/".length);
-    // Map known OpenCode models to display names
-    const openCodeModels: Record<string, string> = {
-      "big-pickle": "Big Pickle",
-      "glm-4.7-free": "GLM 4.7",
-      "grok-code": "Grok Code",
-    };
-    if (openCodeModels[modelName]) {
-      return openCodeModels[modelName];
-    }
-    // Fallback for unknown OpenCode models
-    return modelName
-      .split("-")
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(" ");
-  }
 
   // Handle common Claude model patterns
   const match = modelId.match(/^claude-(\w+)-(\d+)-(\d+)$/i);
@@ -51,28 +29,9 @@ export function formatModelName(modelId: string): string {
 /**
  * Format model ID to lowercase display format for footer
  * e.g., "claude-sonnet-4-5" → "claude sonnet 4.5"
- * e.g., "opencode/big-pickle" → "big pickle"
- * e.g., "opencode/glm-4.7-free" → "glm 4.7"
- * e.g., "opencode/grok-code" → "grok code"
  */
 export function formatModelNameLower(modelId: string): string {
   if (!modelId) return "unknown model";
-
-  // Handle OpenCode models (opencode/model-name)
-  if (modelId.startsWith("opencode/")) {
-    const modelName = modelId.slice("opencode/".length);
-    // Map known OpenCode models to display names
-    const openCodeModels: Record<string, string> = {
-      "big-pickle": "big pickle",
-      "glm-4.7-free": "glm 4.7",
-      "grok-code": "grok code",
-    };
-    if (openCodeModels[modelName]) {
-      return openCodeModels[modelName];
-    }
-    // Fallback for unknown OpenCode models
-    return modelName.replace(/-/g, " ").toLowerCase();
-  }
 
   const match = modelId.match(/^claude-(\w+)-(\d+)-(\d+)$/i);
   if (match) {


### PR DESCRIPTION
## Summary

- Remove all OpenCode model options (`big-pickle`, `glm-4.7-free`, `grok-code`) from the system
- Clean up associated formatting utilities and UI components
- Retain backward compatibility for existing sessions via `extractProviderAndModel` function

## Changes

- **Control Plane**: Remove models from `VALID_MODELS` array, update comment for `extractProviderAndModel`
- **Web UI**: Remove "OpenCode (Free)" category from model dropdowns in session pages
- **Formatting**: Remove OpenCode-specific handling from `formatModelName` and `formatModelNameLower`

## Test plan

- [ ] Verify model dropdowns only show Claude models
- [ ] Verify existing sessions with OpenCode models (if any) still function correctly
- [ ] Verify control plane rejects new sessions with OpenCode model IDs