### PR TITLE
fix: add deployment_name variable to terraform workflow

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -178,6 +178,7 @@ jobs:
           TF_VAR_modal_api_secret: ${{ secrets.MODAL_API_SECRET }}
           TF_VAR_allowed_users: ${{ secrets.ALLOWED_USERS }}
           TF_VAR_allowed_email_domains: ${{ secrets.ALLOWED_EMAIL_DOMAINS }}
+          TF_VAR_deployment_name: ${{ secrets.DEPLOYMENT_NAME }}
 
       - name: Post Plan Results
         uses: actions/github-script@v7
@@ -287,6 +288,7 @@ jobs:
           TF_VAR_modal_api_secret: ${{ secrets.MODAL_API_SECRET }}
           TF_VAR_allowed_users: ${{ secrets.ALLOWED_USERS }}
           TF_VAR_allowed_email_domains: ${{ secrets.ALLOWED_EMAIL_DOMAINS }}
+          TF_VAR_deployment_name: ${{ secrets.DEPLOYMENT_NAME }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -145,6 +145,9 @@ The GitHub Actions workflow (`.github/workflows/terraform.yml`) automates:
 Add these secrets to your repository settings:
 
 ```
+# Deployment
+DEPLOYMENT_NAME          # Unique name for your deployment (e.g., 'acme', 'johndoe')
+
 # Cloudflare
 CLOUDFLARE_API_TOKEN
 CLOUDFLARE_ACCOUNT_ID


### PR DESCRIPTION
## Summary
- Adds `TF_VAR_deployment_name` environment variable to both plan and apply steps in the Terraform workflow
- This variable is required for Terraform to configure unique resource names and URLs (e.g., `open-inspect-{deployment_name}.vercel.app`)

## Test plan
- [ ] Verify the workflow passes validation
- [ ] Deployers should add `DEPLOYMENT_NAME` to their GitHub repo secrets