### PR TITLE
feat(control-plane): add unit tests for core utilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,11 @@ jobs:
       - name: Build shared package
         run: npm run build -w @open-inspect/shared
 
-      - name: Run tests
-        run: npm test -w @open-inspect/control-plane -- --passWithNoTests
+      - name: Run control-plane tests
+        run: npm test -w @open-inspect/control-plane
+
+      - name: Run web tests
+        run: npm test -w @open-inspect/web
 
   test-python:
     name: Test (Python)

--- a/packages/control-plane/src/auth/crypto.test.ts
+++ b/packages/control-plane/src/auth/crypto.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import { encryptToken, decryptToken, generateEncryptionKey, generateId, hashToken } from "./crypto";
+
+describe("crypto", () => {
+  describe("generateEncryptionKey", () => {
+    it("generates a base64-encoded 32-byte key", () => {
+      const key = generateEncryptionKey();
+
+      // Decode and verify length
+      const decoded = Uint8Array.from(atob(key), (c) => c.charCodeAt(0));
+      expect(decoded.length).toBe(32);
+    });
+
+    it("generates unique keys each time", () => {
+      const key1 = generateEncryptionKey();
+      const key2 = generateEncryptionKey();
+
+      expect(key1).not.toBe(key2);
+    });
+  });
+
+  describe("generateId", () => {
+    it("generates a hex string of default length (16 bytes = 32 chars)", () => {
+      const id = generateId();
+
+      expect(id).toMatch(/^[0-9a-f]{32}$/);
+    });
+
+    it("generates a hex string of specified length", () => {
+      const id8 = generateId(8);
+      const id32 = generateId(32);
+
+      expect(id8).toMatch(/^[0-9a-f]{16}$/);
+      expect(id32).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("generates unique IDs each time", () => {
+      const id1 = generateId();
+      const id2 = generateId();
+
+      expect(id1).not.toBe(id2);
+    });
+  });
+
+  describe("encryptToken / decryptToken", () => {
+    it("encrypts and decrypts a token successfully", async () => {
+      const key = generateEncryptionKey();
+      const originalToken = "gho_abc123xyz";
+
+      const encrypted = await encryptToken(originalToken, key);
+      const decrypted = await decryptToken(encrypted, key);
+
+      expect(decrypted).toBe(originalToken);
+    });
+
+    it("produces different ciphertext each time (random IV)", async () => {
+      const key = generateEncryptionKey();
+      const token = "gho_abc123xyz";
+
+      const encrypted1 = await encryptToken(token, key);
+      const encrypted2 = await encryptToken(token, key);
+
+      // Same plaintext should produce different ciphertext due to random IV
+      expect(encrypted1).not.toBe(encrypted2);
+
+      // But both should decrypt to the same value
+      expect(await decryptToken(encrypted1, key)).toBe(token);
+      expect(await decryptToken(encrypted2, key)).toBe(token);
+    });
+
+    it("handles empty string", async () => {
+      const key = generateEncryptionKey();
+
+      const encrypted = await encryptToken("", key);
+      const decrypted = await decryptToken(encrypted, key);
+
+      expect(decrypted).toBe("");
+    });
+
+    it("handles long tokens", async () => {
+      const key = generateEncryptionKey();
+      const longToken = "a".repeat(10000);
+
+      const encrypted = await encryptToken(longToken, key);
+      const decrypted = await decryptToken(encrypted, key);
+
+      expect(decrypted).toBe(longToken);
+    });
+
+    it("handles special characters and unicode", async () => {
+      const key = generateEncryptionKey();
+      const specialToken = "token_with_special_chars!@#$%^&*()_+-=[]{}|;':\",./<>?`~";
+      const unicodeToken = "token_with_unicode_🔐🔑";
+
+      const encryptedSpecial = await encryptToken(specialToken, key);
+      const encryptedUnicode = await encryptToken(unicodeToken, key);
+
+      expect(await decryptToken(encryptedSpecial, key)).toBe(specialToken);
+      expect(await decryptToken(encryptedUnicode, key)).toBe(unicodeToken);
+    });
+
+    it("fails to decrypt with wrong key", async () => {
+      const key1 = generateEncryptionKey();
+      const key2 = generateEncryptionKey();
+      const token = "gho_abc123xyz";
+
+      const encrypted = await encryptToken(token, key1);
+
+      // Decryption with wrong key should throw
+      await expect(decryptToken(encrypted, key2)).rejects.toThrow();
+    });
+
+    it("fails to decrypt corrupted ciphertext", async () => {
+      const key = generateEncryptionKey();
+      const token = "gho_abc123xyz";
+
+      const encrypted = await encryptToken(token, key);
+
+      // Corrupt the ciphertext by changing a character
+      const corrupted = encrypted.slice(0, -5) + "XXXXX";
+
+      await expect(decryptToken(corrupted, key)).rejects.toThrow();
+    });
+  });
+
+  describe("hashToken", () => {
+    it("produces a 64-character hex string (SHA-256)", async () => {
+      const hash = await hashToken("test_token");
+
+      expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("is deterministic (same input = same output)", async () => {
+      const hash1 = await hashToken("test_token");
+      const hash2 = await hashToken("test_token");
+
+      expect(hash1).toBe(hash2);
+    });
+
+    it("produces different hashes for different inputs", async () => {
+      const hash1 = await hashToken("token1");
+      const hash2 = await hashToken("token2");
+
+      expect(hash1).not.toBe(hash2);
+    });
+
+    it("handles empty string", async () => {
+      const hash = await hashToken("");
+
+      // SHA-256 of empty string is a known value
+      expect(hash).toBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+    });
+  });
+});

--- a/packages/control-plane/src/auth/github-app.test.ts
+++ b/packages/control-plane/src/auth/github-app.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { isGitHubAppConfigured, getGitHubAppConfig } from "./github-app";
+
+describe("github-app utilities", () => {
+  describe("isGitHubAppConfigured", () => {
+    it("returns true when all credentials are present", () => {
+      const env = {
+        GITHUB_APP_ID: "12345",
+        GITHUB_APP_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\nkey\n-----END PRIVATE KEY-----",
+        GITHUB_APP_INSTALLATION_ID: "67890",
+      };
+
+      expect(isGitHubAppConfigured(env)).toBe(true);
+    });
+
+    it("returns false when GITHUB_APP_ID is missing", () => {
+      const env = {
+        GITHUB_APP_PRIVATE_KEY: "key",
+        GITHUB_APP_INSTALLATION_ID: "67890",
+      };
+
+      expect(isGitHubAppConfigured(env)).toBe(false);
+    });
+
+    it("returns false when GITHUB_APP_PRIVATE_KEY is missing", () => {
+      const env = {
+        GITHUB_APP_ID: "12345",
+        GITHUB_APP_INSTALLATION_ID: "67890",
+      };
+
+      expect(isGitHubAppConfigured(env)).toBe(false);
+    });
+
+    it("returns false when GITHUB_APP_INSTALLATION_ID is missing", () => {
+      const env = {
+        GITHUB_APP_ID: "12345",
+        GITHUB_APP_PRIVATE_KEY: "key",
+      };
+
+      expect(isGitHubAppConfigured(env)).toBe(false);
+    });
+
+    it("returns false when all credentials are missing", () => {
+      expect(isGitHubAppConfigured({})).toBe(false);
+    });
+
+    it("returns false for empty string values", () => {
+      const env = {
+        GITHUB_APP_ID: "",
+        GITHUB_APP_PRIVATE_KEY: "key",
+        GITHUB_APP_INSTALLATION_ID: "67890",
+      };
+
+      expect(isGitHubAppConfigured(env)).toBe(false);
+    });
+  });
+
+  describe("getGitHubAppConfig", () => {
+    it("returns config when all credentials are present", () => {
+      const env = {
+        GITHUB_APP_ID: "12345",
+        GITHUB_APP_PRIVATE_KEY: "-----BEGIN PRIVATE KEY-----\nkey\n-----END PRIVATE KEY-----",
+        GITHUB_APP_INSTALLATION_ID: "67890",
+      };
+
+      const config = getGitHubAppConfig(env);
+
+      expect(config).toEqual({
+        appId: "12345",
+        privateKey: "-----BEGIN PRIVATE KEY-----\nkey\n-----END PRIVATE KEY-----",
+        installationId: "67890",
+      });
+    });
+
+    it("returns null when credentials are incomplete", () => {
+      expect(getGitHubAppConfig({})).toBeNull();
+      expect(
+        getGitHubAppConfig({
+          GITHUB_APP_ID: "12345",
+        })
+      ).toBeNull();
+      expect(
+        getGitHubAppConfig({
+          GITHUB_APP_ID: "12345",
+          GITHUB_APP_PRIVATE_KEY: "key",
+        })
+      ).toBeNull();
+    });
+  });
+});

--- a/packages/control-plane/src/realtime/events.test.ts
+++ b/packages/control-plane/src/realtime/events.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getEventCategory, shouldPersistEvent, TokenAggregator } from "./events";
+
+describe("event utilities", () => {
+  describe("getEventCategory", () => {
+    it("categorizes execution events", () => {
+      expect(getEventCategory("token")).toBe("execution");
+      expect(getEventCategory("tool_call")).toBe("execution");
+      expect(getEventCategory("tool_result")).toBe("execution");
+      expect(getEventCategory("execution_complete")).toBe("execution");
+    });
+
+    it("categorizes git events", () => {
+      expect(getEventCategory("git_sync")).toBe("git");
+    });
+
+    it("categorizes artifact events", () => {
+      expect(getEventCategory("artifact")).toBe("artifact");
+    });
+
+    it("categorizes unknown events as system", () => {
+      expect(getEventCategory("heartbeat")).toBe("system");
+      expect(getEventCategory("error")).toBe("system");
+      expect(getEventCategory("unknown_event")).toBe("system");
+      expect(getEventCategory("")).toBe("system");
+    });
+  });
+
+  describe("shouldPersistEvent", () => {
+    it("returns false for heartbeat events", () => {
+      expect(shouldPersistEvent("heartbeat")).toBe(false);
+    });
+
+    it("returns true for all other events", () => {
+      expect(shouldPersistEvent("token")).toBe(true);
+      expect(shouldPersistEvent("tool_call")).toBe(true);
+      expect(shouldPersistEvent("tool_result")).toBe(true);
+      expect(shouldPersistEvent("execution_complete")).toBe(true);
+      expect(shouldPersistEvent("git_sync")).toBe(true);
+      expect(shouldPersistEvent("artifact")).toBe(true);
+      expect(shouldPersistEvent("error")).toBe(true);
+      expect(shouldPersistEvent("unknown")).toBe(true);
+    });
+  });
+});
+
+describe("TokenAggregator", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("flushes tokens after timeout", () => {
+    const flushCallback = vi.fn();
+    const aggregator = new TokenAggregator(50, 100);
+    aggregator.onFlush(flushCallback);
+
+    aggregator.add("Hello", "msg-1");
+    aggregator.add(" ", "msg-1");
+    aggregator.add("World", "msg-1");
+
+    // Before timeout, callback not called
+    expect(flushCallback).not.toHaveBeenCalled();
+
+    // After timeout, tokens are flushed
+    vi.advanceTimersByTime(50);
+    expect(flushCallback).toHaveBeenCalledTimes(1);
+    expect(flushCallback).toHaveBeenCalledWith("Hello World", "msg-1");
+  });
+
+  it("flushes when buffer reaches max size", () => {
+    const flushCallback = vi.fn();
+    const aggregator = new TokenAggregator(50, 5); // max 5 tokens
+    aggregator.onFlush(flushCallback);
+
+    // Add 5 tokens (should trigger flush)
+    aggregator.add("a", "msg-1");
+    aggregator.add("b", "msg-1");
+    aggregator.add("c", "msg-1");
+    aggregator.add("d", "msg-1");
+    aggregator.add("e", "msg-1");
+
+    expect(flushCallback).toHaveBeenCalledTimes(1);
+    expect(flushCallback).toHaveBeenCalledWith("abcde", "msg-1");
+  });
+
+  it("flushes when message ID changes", () => {
+    const flushCallback = vi.fn();
+    const aggregator = new TokenAggregator(50, 100);
+    aggregator.onFlush(flushCallback);
+
+    aggregator.add("Hello", "msg-1");
+    aggregator.add(" World", "msg-1");
+
+    // Change message ID - should flush previous buffer
+    aggregator.add("New", "msg-2");
+
+    expect(flushCallback).toHaveBeenCalledTimes(1);
+    expect(flushCallback).toHaveBeenCalledWith("Hello World", "msg-1");
+
+    // Advance timer to flush the new message
+    vi.advanceTimersByTime(50);
+    expect(flushCallback).toHaveBeenCalledTimes(2);
+    expect(flushCallback).toHaveBeenCalledWith("New", "msg-2");
+  });
+
+  it("concatenates tokens correctly", () => {
+    const flushCallback = vi.fn();
+    const aggregator = new TokenAggregator(50, 100);
+    aggregator.onFlush(flushCallback);
+
+    aggregator.add("The ", "msg-1");
+    aggregator.add("quick ", "msg-1");
+    aggregator.add("brown ", "msg-1");
+    aggregator.add("fox", "msg-1");
+
+    vi.advanceTimersByTime(50);
+    expect(flushCallback).toHaveBeenCalledWith("The quick brown fox", "msg-1");
+  });
+
+  it("manual flush clears buffer and timer", () => {
+    const flushCallback = vi.fn();
+    const aggregator = new TokenAggregator(50, 100);
+    aggregator.onFlush(flushCallback);
+
+    aggregator.add("Hello", "msg-1");
+    aggregator.flush();
+
+    expect(flushCallback).toHaveBeenCalledTimes(1);
+    expect(flushCallback).toHaveBeenCalledWith("Hello", "msg-1");
+
+    // Advancing timers should not trigger another flush
+    vi.advanceTimersByTime(100);
+    expect(flushCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it("flush does nothing when buffer is empty", () => {
+    const flushCallback = vi.fn();
+    const aggregator = new TokenAggregator(50, 100);
+    aggregator.onFlush(flushCallback);
+
+    aggregator.flush();
+    expect(flushCallback).not.toHaveBeenCalled();
+  });
+
+  it("destroy flushes remaining tokens and clears callback", () => {
+    const flushCallback = vi.fn();
+    const aggregator = new TokenAggregator(50, 100);
+    aggregator.onFlush(flushCallback);
+
+    aggregator.add("Final", "msg-1");
+    aggregator.destroy();
+
+    expect(flushCallback).toHaveBeenCalledWith("Final", "msg-1");
+
+    // After destroy, callback should be null so subsequent flushes do nothing
+    aggregator.add("More", "msg-2");
+    vi.advanceTimersByTime(50);
+    expect(flushCallback).toHaveBeenCalledTimes(1); // Still only called once
+  });
+
+  it("handles multiple flush cycles", () => {
+    const flushCallback = vi.fn();
+    const aggregator = new TokenAggregator(50, 100);
+    aggregator.onFlush(flushCallback);
+
+    // First cycle
+    aggregator.add("First", "msg-1");
+    vi.advanceTimersByTime(50);
+    expect(flushCallback).toHaveBeenNthCalledWith(1, "First", "msg-1");
+
+    // Second cycle
+    aggregator.add("Second", "msg-2");
+    vi.advanceTimersByTime(50);
+    expect(flushCallback).toHaveBeenNthCalledWith(2, "Second", "msg-2");
+
+    expect(flushCallback).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses default values when not specified", () => {
+    const flushCallback = vi.fn();
+    const aggregator = new TokenAggregator(); // default: 50ms, 100 tokens
+    aggregator.onFlush(flushCallback);
+
+    aggregator.add("test", "msg-1");
+
+    // Default 50ms timeout
+    vi.advanceTimersByTime(50);
+    expect(flushCallback).toHaveBeenCalled();
+  });
+});

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -14,6 +14,7 @@ import { generateInstallationToken, getGitHubAppConfig } from "../auth/github-ap
 import { createModalClient } from "../sandbox/client";
 import { createPullRequest, getRepository } from "../auth/pr";
 import { generateBranchName, generateInternalToken } from "@open-inspect/shared";
+import { DEFAULT_MODEL, isValidModel, extractProviderAndModel } from "../utils/models";
 import type {
   Env,
   ClientInfo,
@@ -50,12 +51,6 @@ function getGitHubAvatarUrl(githubLogin: string | null | undefined): string | un
 }
 
 /**
- * Valid model names for the LLM.
- */
-const VALID_MODELS = ["claude-haiku-4-5", "claude-sonnet-4-5", "claude-opus-4-5"] as const;
-type ValidModel = (typeof VALID_MODELS)[number];
-
-/**
  * Valid event types for filtering.
  * Includes both external types (from types.ts) and internal types used by the sandbox.
  */
@@ -77,37 +72,12 @@ const VALID_EVENT_TYPES = [
 const VALID_MESSAGE_STATUSES = ["pending", "processing", "completed", "failed"] as const;
 
 /**
- * Check if a model name is valid.
- */
-function isValidModel(model: string): model is ValidModel {
-  return VALID_MODELS.includes(model as ValidModel);
-}
-
-/**
- * Default model to use when none specified or invalid.
- */
-const DEFAULT_MODEL: ValidModel = "claude-haiku-4-5";
-
-/**
  * Timeout for WebSocket authentication (in milliseconds).
  * Client WebSockets must send a valid 'subscribe' message within this time
  * or the connection will be closed. This prevents resource abuse from
  * unauthenticated connections that never complete the handshake.
  */
 const WS_AUTH_TIMEOUT_MS = 30000; // 30 seconds
-
-/**
- * Extract provider and model from a model ID.
- * Models with "/" have embedded provider (kept for backward compatibility with existing sessions).
- * Models like "claude-haiku-4-5" use "anthropic" as default provider.
- */
-function extractProviderAndModel(modelId: string): { provider: string; model: string } {
-  if (modelId.includes("/")) {
-    const [provider, ...modelParts] = modelId.split("/");
-    return { provider, model: modelParts.join("/") };
-  }
-  return { provider: "anthropic", model: modelId };
-}
 
 /**
  * Route definition for internal API endpoints.

--- a/packages/control-plane/src/utils/models.test.ts
+++ b/packages/control-plane/src/utils/models.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_MODEL,
+  isValidModel,
+  extractProviderAndModel,
+  getValidModelOrDefault,
+} from "./models";
+
+describe("model utilities", () => {
+  describe("DEFAULT_MODEL", () => {
+    it("is a valid model", () => {
+      expect(isValidModel(DEFAULT_MODEL)).toBe(true);
+    });
+  });
+
+  describe("isValidModel", () => {
+    it("returns true for valid models", () => {
+      expect(isValidModel("claude-haiku-4-5")).toBe(true);
+      expect(isValidModel("claude-sonnet-4-5")).toBe(true);
+      expect(isValidModel("claude-opus-4-5")).toBe(true);
+    });
+
+    it("returns false for invalid models", () => {
+      expect(isValidModel("gpt-4")).toBe(false);
+      expect(isValidModel("claude-3-opus")).toBe(false);
+      expect(isValidModel("haiku")).toBe(false);
+      expect(isValidModel("")).toBe(false);
+      expect(isValidModel("invalid")).toBe(false);
+    });
+
+    it("is case-sensitive", () => {
+      expect(isValidModel("Claude-Haiku-4-5")).toBe(false);
+      expect(isValidModel("CLAUDE-HAIKU-4-5")).toBe(false);
+    });
+
+    it("handles legacy model names", () => {
+      // Old model names should not be valid
+      expect(isValidModel("claude-3-haiku")).toBe(false);
+      expect(isValidModel("claude-3-5-sonnet")).toBe(false);
+    });
+  });
+
+  describe("extractProviderAndModel", () => {
+    it("extracts provider and model from slash-separated format", () => {
+      const result = extractProviderAndModel("anthropic/claude-3-opus");
+
+      expect(result).toEqual({
+        provider: "anthropic",
+        model: "claude-3-opus",
+      });
+    });
+
+    it("handles multiple slashes (joins remaining parts)", () => {
+      const result = extractProviderAndModel("provider/model/version");
+
+      expect(result).toEqual({
+        provider: "provider",
+        model: "model/version",
+      });
+    });
+
+    it("defaults to anthropic for models without slash", () => {
+      const result = extractProviderAndModel("claude-haiku-4-5");
+
+      expect(result).toEqual({
+        provider: "anthropic",
+        model: "claude-haiku-4-5",
+      });
+    });
+
+    it("handles all valid model formats", () => {
+      expect(extractProviderAndModel("claude-haiku-4-5")).toEqual({
+        provider: "anthropic",
+        model: "claude-haiku-4-5",
+      });
+
+      expect(extractProviderAndModel("claude-sonnet-4-5")).toEqual({
+        provider: "anthropic",
+        model: "claude-sonnet-4-5",
+      });
+
+      expect(extractProviderAndModel("claude-opus-4-5")).toEqual({
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+      });
+    });
+
+    it("handles edge cases", () => {
+      // Empty string
+      expect(extractProviderAndModel("")).toEqual({
+        provider: "anthropic",
+        model: "",
+      });
+
+      // Single slash at start
+      expect(extractProviderAndModel("/model")).toEqual({
+        provider: "",
+        model: "model",
+      });
+
+      // Slash at end
+      expect(extractProviderAndModel("provider/")).toEqual({
+        provider: "provider",
+        model: "",
+      });
+    });
+  });
+
+  describe("getValidModelOrDefault", () => {
+    it("returns the model if valid", () => {
+      expect(getValidModelOrDefault("claude-haiku-4-5")).toBe("claude-haiku-4-5");
+      expect(getValidModelOrDefault("claude-sonnet-4-5")).toBe("claude-sonnet-4-5");
+      expect(getValidModelOrDefault("claude-opus-4-5")).toBe("claude-opus-4-5");
+    });
+
+    it("returns default for invalid model", () => {
+      expect(getValidModelOrDefault("invalid-model")).toBe(DEFAULT_MODEL);
+      expect(getValidModelOrDefault("gpt-4")).toBe(DEFAULT_MODEL);
+    });
+
+    it("returns default for undefined", () => {
+      expect(getValidModelOrDefault(undefined)).toBe(DEFAULT_MODEL);
+    });
+
+    it("returns default for null", () => {
+      expect(getValidModelOrDefault(null)).toBe(DEFAULT_MODEL);
+    });
+
+    it("returns default for empty string", () => {
+      expect(getValidModelOrDefault("")).toBe(DEFAULT_MODEL);
+    });
+  });
+});

--- a/packages/control-plane/src/utils/models.ts
+++ b/packages/control-plane/src/utils/models.ts
@@ -1,0 +1,53 @@
+/**
+ * Model validation and extraction utilities.
+ *
+ * Centralizes model-related logic to ensure consistent validation
+ * across session initialization and message processing.
+ */
+
+/**
+ * Valid model names supported by the system.
+ */
+export const VALID_MODELS = ["claude-haiku-4-5", "claude-sonnet-4-5", "claude-opus-4-5"] as const;
+
+export type ValidModel = (typeof VALID_MODELS)[number];
+
+/**
+ * Default model to use when none specified or invalid.
+ */
+export const DEFAULT_MODEL: ValidModel = "claude-haiku-4-5";
+
+/**
+ * Check if a model name is valid.
+ */
+export function isValidModel(model: string): model is ValidModel {
+  return VALID_MODELS.includes(model as ValidModel);
+}
+
+/**
+ * Extract provider and model from a model ID.
+ *
+ * Models with "/" have embedded provider (kept for backward compatibility with existing sessions).
+ * Models like "claude-haiku-4-5" use "anthropic" as default provider.
+ *
+ * @example
+ * extractProviderAndModel("claude-haiku-4-5") // { provider: "anthropic", model: "claude-haiku-4-5" }
+ * extractProviderAndModel("anthropic/claude-3-opus") // { provider: "anthropic", model: "claude-3-opus" }
+ */
+export function extractProviderAndModel(modelId: string): { provider: string; model: string } {
+  if (modelId.includes("/")) {
+    const [provider, ...modelParts] = modelId.split("/");
+    return { provider, model: modelParts.join("/") };
+  }
+  return { provider: "anthropic", model: modelId };
+}
+
+/**
+ * Get a valid model or fall back to default.
+ */
+export function getValidModelOrDefault(model: string | undefined | null): ValidModel {
+  if (model && isValidModel(model)) {
+    return model;
+  }
+  return DEFAULT_MODEL;
+}

--- a/packages/control-plane/src/utils/repo.test.ts
+++ b/packages/control-plane/src/utils/repo.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { normalizeRepoId, getRepoMetadataKey } from "./repo";
+
+describe("repo utilities", () => {
+  describe("normalizeRepoId", () => {
+    it("converts owner and name to lowercase", () => {
+      expect(normalizeRepoId("MyOrg", "MyRepo")).toBe("myorg/myrepo");
+    });
+
+    it("formats as owner/name", () => {
+      expect(normalizeRepoId("owner", "repo")).toBe("owner/repo");
+    });
+  });
+
+  describe("getRepoMetadataKey", () => {
+    it("returns correct KV key format", () => {
+      expect(getRepoMetadataKey("owner", "repo")).toBe("repo:metadata:owner/repo");
+    });
+
+    it("normalizes owner and name in the key", () => {
+      expect(getRepoMetadataKey("MyOrg", "MyRepo")).toBe("repo:metadata:myorg/myrepo");
+    });
+
+    it("produces consistent keys for different case variations", () => {
+      const key1 = getRepoMetadataKey("GitHub", "OpenInspect");
+      const key2 = getRepoMetadataKey("github", "openinspect");
+      const key3 = getRepoMetadataKey("GITHUB", "OPENINSPECT");
+
+      expect(key1).toBe(key2);
+      expect(key2).toBe(key3);
+    });
+  });
+});

--- a/packages/control-plane/vitest.config.ts
+++ b/packages/control-plane/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

Adds 59 unit tests to the control-plane package, focusing on security-critical and business-critical pure functions.

### Test Coverage

| File | Tests | Focus |
|------|-------|-------|
| `crypto.test.ts` | 16 | Token encryption/decryption, key generation, hashing |
| `models.test.ts` | 15 | Model validation and provider extraction |
| `events.test.ts` | 15 | Event categorization, TokenAggregator batching |
| `github-app.test.ts` | 8 | GitHub App configuration validation |
| `repo.test.ts` | 5 | Repository ID normalization |

### Changes

- **New tests** for `crypto.ts`, `models.ts`, `repo.ts`, `events.ts`, `github-app.ts`
- **Extracted `models.ts`** from `durable-object.ts` for testability
- **Updated CI** to run control-plane and web tests (removed `--passWithNoTests`)
- **Added `vitest.config.ts`** for control-plane package

### Why These Tests

Focused on high-value, pure functions that are:
- **Security-critical**: Token encryption, hashing
- **Business-critical**: Model validation, event categorization
- **Data integrity**: Repository normalization for consistent KV storage

Intentionally avoided low-value tests (testing constants, language primitives, or platform APIs).

## Test plan

- [x] `npm test -w @open-inspect/control-plane` passes (59 tests)
- [x] `npm run typecheck -w @open-inspect/control-plane` passes
- [x] `npm run build -w @open-inspect/control-plane` passes