### PR TITLE
fix(modal-infra): exit gracefully on HTTP 410 instead of retrying forever

### DIFF
--- a/packages/modal-infra/tests/test_bridge_reconnection.py
+++ b/packages/modal-infra/tests/test_bridge_reconnection.py
@@ -25,6 +25,10 @@ class TestIsFatalConnectionError:
         error_str = "server rejected WebSocket connection: HTTP 401"
         assert bridge._is_fatal_connection_error(error_str) is True
 
+    def test_http_403_is_fatal(self, bridge):
+        error_str = "server rejected WebSocket connection: HTTP 403"
+        assert bridge._is_fatal_connection_error(error_str) is True
+
     def test_http_404_is_fatal(self, bridge):
         error_str = "server rejected WebSocket connection: HTTP 404"
         assert bridge._is_fatal_connection_error(error_str) is True


### PR DESCRIPTION
## Summary

- Fix infinite retry loop when control plane returns HTTP 410 (session terminated)
- Bridge now exits gracefully on fatal HTTP errors (410, 401, 404) instead of retrying forever
- Users can restore sessions by sending a new prompt, which triggers snapshot restoration

## Problem

After deployments or inactivity timeouts, sandboxes would see this pattern indefinitely:
```
[bridge] Connection error: server rejected WebSocket connection: HTTP 410
[bridge] Reconnecting in 60.0s (attempt 11)...
```

The control plane correctly returns 410 when a session is stopped/stale, but the bridge didn't recognize this as a terminal state.

## Solution

- Add `SessionTerminatedError` exception for non-recoverable session termination
- Handle `InvalidStatus` exception to catch HTTP rejection at WebSocket connect time
- Add `_is_fatal_connection_error()` as fallback for string-based detection
- Exit cleanly so Modal can shut down the container

## Test plan

- [x] Added unit tests for `_is_fatal_connection_error()` covering fatal and non-fatal cases
- [x] Added unit tests for `SessionTerminatedError` exception behavior
- [x] All 44 bridge tests pass
- [x] Linting passes