### PR TITLE
Enable full observability and logging for Cloudflare Workers

### DIFF
--- a/terraform/modules/cloudflare-worker/main.tf
+++ b/terraform/modules/cloudflare-worker/main.tf
@@ -50,8 +50,16 @@ resource "cloudflare_worker" "this" {
     enabled = true
   }
 
+  logpush = true
+
   observability = {
-    enabled = true
+    enabled            = true
+    head_sampling_rate = 1
+    logs = {
+      enabled            = true
+      head_sampling_rate = 1
+      invocation_logs    = true
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Enables persistent log storage and full observability for all Cloudflare Workers deployed via the `cloudflare-worker` Terraform module
- Adds `logpush = true` for external log destination support (e.g., R2, S3, Datadog)
- Configures `observability.logs` with 100% sampling and invocation log capture so logs are available in the Cloudflare dashboard without requiring real-time tailing

## Changes

**`terraform/modules/cloudflare-worker/main.tf`**
- Added `logpush = true` to the `cloudflare_worker` resource
- Expanded `observability` block with `head_sampling_rate = 1` (100% sampling)
- Added nested `observability.logs` block:
  - `enabled = true` — enables persistent Workers Logs
  - `head_sampling_rate = 1` — captures 100% of log events
  - `invocation_logs = true` — logs every invocation including `console.log()` output

## Test plan

- [ ] Run `terraform plan` to verify no unexpected changes
- [ ] Apply to a staging/dev worker and confirm logs appear in the Cloudflare dashboard under **Workers & Pages > Worker > Logs**
- [ ] Verify `console.log()` output from worker code is captured