### PR TITLE
Remove logpush flag that requires Enterprise plan

### DIFF
--- a/terraform/modules/cloudflare-worker/main.tf
+++ b/terraform/modules/cloudflare-worker/main.tf
@@ -50,8 +50,6 @@ resource "cloudflare_worker" "this" {
     enabled = true
   }
 
-  logpush = true
-
   observability = {
     enabled            = true
     head_sampling_rate = 1


### PR DESCRIPTION
## Summary

- Removes `logpush = true` from the `cloudflare_worker` resource, which requires a Cloudflare Enterprise plan and fails with error 10023 on non-Enterprise accounts
- The `observability.logs` block (added in #24) is sufficient for persistent log access in the Cloudflare dashboard

## Context

After deploying #24, `terraform apply` fails with:

```
Error: 10023 - You do not have access to use Logpush.
Please ensure it is enabled. If you are an Enterprise user,
reach out to your account team.
```

## Test plan

- [ ] Run `terraform plan` to confirm no errors
- [ ] Run `terraform apply` and verify the worker updates successfully
- [ ] Confirm logs are visible in Cloudflare dashboard under Workers & Pages > Worker > Logs