### PR TITLE
Fix unreadable markdown text in dark mode and code blocks

### DIFF
--- a/packages/web/src/components/safe-markdown.tsx
+++ b/packages/web/src/components/safe-markdown.tsx
@@ -81,7 +81,7 @@ export function SafeMarkdown({ content, className = "" }: SafeMarkdownProps) {
           ),
           // Code blocks with styling
           pre: ({ children, ...props }: ComponentPropsWithoutRef<"pre">) => (
-            <pre className="bg-card p-3 overflow-x-auto text-sm" {...props}>
+            <pre className="bg-card text-foreground p-3 overflow-x-auto text-sm" {...props}>
               {children}
             </pre>
           ),
@@ -97,7 +97,7 @@ export function SafeMarkdown({ content, className = "" }: SafeMarkdownProps) {
               );
             }
             return (
-              <code className="bg-card px-1.5 py-0.5 text-sm" {...props}>
+              <code className="bg-card text-foreground px-1.5 py-0.5 text-sm" {...props}>
                 {children}
               </code>
             );

--- a/packages/web/tailwind.config.ts
+++ b/packages/web/tailwind.config.ts
@@ -2,7 +2,7 @@ import type { Config } from "tailwindcss";
 import typography from "@tailwindcss/typography";
 
 const config: Config = {
-  darkMode: "class",
+  darkMode: "media",
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
## Summary

- **Dark mode fix**: `dark:prose-invert` on the SafeMarkdown wrapper never activated because `darkMode` was set to `"class"` in `tailwind.config.ts` but no `.dark` class was ever added to the DOM. The app relies on `@media (prefers-color-scheme: dark)` for CSS variable switching, so this changes `darkMode` to `"media"` to match.
- **Code block fix**: Custom `<pre>` and inline `<code>` renderers in `safe-markdown.tsx` overrode the background to `bg-card` without setting a text color. This left the prose plugin's light-gray pre-code color (`#e5e7eb`) against a near-white background in light mode. Adds explicit `text-foreground` to both renderers.

## Test plan

- [ ] Verify markdown prose text (paragraphs, headings, lists, bold) is readable in dark mode
- [ ] Verify code blocks (`<pre>`) are readable in both light and dark mode
- [ ] Verify inline code (`<code>`) is readable in both light and dark mode