### PR TITLE
refactor(slack-bot): replace console.* with structured JSON logging

### DIFF
--- a/packages/slack-bot/src/completion/extractor.ts
+++ b/packages/slack-bot/src/completion/extractor.ts
@@ -11,6 +11,9 @@ import type {
   ArtifactInfo,
 } from "../types";
 import { generateInternalToken } from "../utils/internal";
+import { createLogger } from "../logger";
+
+const log = createLogger("extractor");
 
 /**
  * Tool names to include in summary display.
@@ -29,8 +32,11 @@ const EVENTS_PAGE_LIMIT = 200;
 export async function extractAgentResponse(
   env: Env,
   sessionId: string,
-  messageId: string
+  messageId: string,
+  traceId?: string
 ): Promise<AgentResponse> {
+  const startTime = Date.now();
+  const base = { trace_id: traceId, session_id: sessionId, message_id: messageId };
   try {
     // Build auth headers
     const headers: Record<string, string> = {
@@ -39,6 +45,9 @@ export async function extractAgentResponse(
     if (env.INTERNAL_CALLBACK_SECRET) {
       const authToken = await generateInternalToken(env.INTERNAL_CALLBACK_SECRET);
       headers["Authorization"] = `Bearer ${authToken}`;
+    }
+    if (traceId) {
+      headers["x-trace-id"] = traceId;
     }
 
     // Fetch all events for this message, paginating if necessary
@@ -56,7 +65,12 @@ export async function extractAgentResponse(
       const response = await env.CONTROL_PLANE.fetch(url.toString(), { headers });
 
       if (!response.ok) {
-        console.error(`Failed to fetch events: ${response.status}`);
+        log.error("control_plane.fetch_events", {
+          ...base,
+          outcome: "error",
+          http_status: response.status,
+          duration_ms: Date.now() - startTime,
+        });
         return { textContent: "", toolCalls: [], artifacts: [], success: false };
       }
 
@@ -94,6 +108,16 @@ export async function extractAgentResponse(
     // Check for completion event to get success status
     const completionEvent = allEvents.find((e) => e.type === "execution_complete");
 
+    log.info("control_plane.fetch_events", {
+      ...base,
+      outcome: "success",
+      event_count: allEvents.length,
+      tool_call_count: toolCalls.length,
+      artifact_count: artifacts.length,
+      has_text: Boolean(textContent),
+      duration_ms: Date.now() - startTime,
+    });
+
     return {
       textContent,
       toolCalls,
@@ -101,7 +125,12 @@ export async function extractAgentResponse(
       success: Boolean(completionEvent?.data.success),
     };
   } catch (error) {
-    console.error("Error extracting agent response:", error);
+    log.error("control_plane.fetch_events", {
+      ...base,
+      outcome: "error",
+      error: error instanceof Error ? error : new Error(String(error)),
+      duration_ms: Date.now() - startTime,
+    });
     return { textContent: "", toolCalls: [], artifacts: [], success: false };
   }
 }

--- a/packages/slack-bot/src/logger.ts
+++ b/packages/slack-bot/src/logger.ts
@@ -1,0 +1,116 @@
+/**
+ * Structured JSON logger for the Slack bot Cloudflare Worker.
+ *
+ * Mirrors the control-plane logger contract so that logs from both services
+ * share the same envelope and can be queried uniformly.
+ *
+ * - Outputs flat JSON lines indexed by Cloudflare Workers Logs.
+ * - Uses console.warn/console.error for severity semantics in tooling/alerts,
+ *   while keeping the JSON `level` field for programmatic filtering.
+ * - JSON.stringify is wrapped in try/catch so a logging failure never crashes
+ *   a request.
+ * - Reserved keys (`level`, `component`, `msg`, `ts`, `service`, `event`)
+ *   cannot be overwritten by context or data.
+ */
+
+const LEVELS = { debug: 0, info: 1, warn: 2, error: 3 } as const;
+type LogLevel = keyof typeof LEVELS;
+
+/** Keys that the logger owns — context and data cannot overwrite these. */
+const RESERVED_KEYS = new Set(["level", "component", "msg", "ts", "service", "event"]);
+
+/** Map log level to the appropriate console method for severity semantics. */
+const CONSOLE_METHOD: Record<LogLevel, "log" | "warn" | "error"> = {
+  debug: "log",
+  info: "log",
+  warn: "warn",
+  error: "error",
+};
+
+export interface Logger {
+  debug(msg: string, data?: Record<string, unknown>): void;
+  info(msg: string, data?: Record<string, unknown>): void;
+  warn(msg: string, data?: Record<string, unknown>): void;
+  error(msg: string, data?: Record<string, unknown>): void;
+  child(context: Record<string, unknown>): Logger;
+}
+
+/** Strip reserved keys from a record so callers cannot overwrite logger-owned fields. */
+function stripReserved(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(obj)) {
+    if (!RESERVED_KEYS.has(key)) {
+      out[key] = obj[key];
+    }
+  }
+  return out;
+}
+
+export function createLogger(
+  component: string,
+  context: Record<string, unknown> = {},
+  minLevel: LogLevel = "info"
+): Logger {
+  // Pre-strip reserved keys from the base context once at creation time.
+  const safeContext = stripReserved(context);
+
+  const emit = (level: LogLevel, msg: string, data?: Record<string, unknown>) => {
+    if (LEVELS[level] < LEVELS[minLevel]) return;
+
+    const extra: Record<string, unknown> = data ? stripReserved(data) : {};
+    if (extra.error instanceof Error) {
+      const err = extra.error;
+      extra.error_message = err.message;
+      extra.error_stack = err.stack;
+      extra.error_type = err.constructor.name;
+      if ("code" in err && typeof (err as Record<string, unknown>).code === "string") {
+        extra.error_code = (err as Record<string, unknown>).code;
+      }
+      delete extra.error;
+    }
+
+    try {
+      console[CONSOLE_METHOD[level]](
+        JSON.stringify({
+          level,
+          service: "slack-bot",
+          component,
+          msg,
+          ...safeContext,
+          ...extra,
+          ts: Date.now(),
+        })
+      );
+    } catch {
+      // Fallback for bigint, circular references, or other stringify failures.
+      console.error(
+        JSON.stringify({
+          level: "error",
+          service: "slack-bot",
+          component,
+          msg: "LOG_SERIALIZE_FAILURE",
+          original_msg: msg,
+          original_level: level,
+          ts: Date.now(),
+        })
+      );
+    }
+  };
+
+  return {
+    debug: (msg, data) => emit("debug", msg, data),
+    info: (msg, data) => emit("info", msg, data),
+    warn: (msg, data) => emit("warn", msg, data),
+    error: (msg, data) => emit("error", msg, data),
+    child: (childCtx) =>
+      createLogger(component, { ...safeContext, ...stripReserved(childCtx) }, minLevel),
+  };
+}
+
+/**
+ * Parse a LOG_LEVEL env var string into a valid LogLevel, defaulting to "info".
+ */
+export function parseLogLevel(value?: string): LogLevel {
+  if (value && Object.prototype.hasOwnProperty.call(LEVELS, value)) return value as LogLevel;
+  return "info";
+}

--- a/packages/slack-bot/src/types/index.ts
+++ b/packages/slack-bot/src/types/index.ts
@@ -26,6 +26,7 @@ export interface Env {
   ANTHROPIC_API_KEY: string;
   CONTROL_PLANE_API_KEY?: string;
   INTERNAL_CALLBACK_SECRET?: string; // For verifying callbacks from control-plane
+  LOG_LEVEL?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add structured JSON logger (`logger.ts`) to the slack-bot package, mirroring the control-plane logging pattern with flat JSON envelopes for Cloudflare Workers Logs
- Replace all `console.log/warn/error` calls across 5 source files with wide-event structured logs including `trace_id`, `duration_ms`, `outcome`, and correlation fields
- Generate `trace_id` at HTTP edge handlers and propagate via `x-trace-id` header to all control-plane service binding calls

This implements Phase 4 of the [Logging Redesign Plan](https://github.com/ColeMurray/open-inspect-claude-prod/blob/main/docs/LOGGING_REDESIGN_PLAN.md).

### Files changed
| File | Change |
|------|--------|
| `logger.ts` | New structured logger with level filtering, Error decomposition, child loggers |
| `index.ts` | Replace console.* in handlers, add trace_id generation and propagation |
| `callbacks.ts` | Replace console.* with wide events, add timing for completion callback |
| `classifier/index.ts` | Thread trace_id through classification, structured error logging |
| `classifier/repos.ts` | Wide events for repo fetching, x-trace-id propagation, structured cache/fallback logging |
| `completion/extractor.ts` | Wide events for event extraction, x-trace-id propagation |
| `types/index.ts` | Add `LOG_LEVEL` to `Env` interface |

## Test plan
- [ ] Verify `npm run build -w @open-inspect/slack-bot` succeeds (confirmed locally)
- [ ] Verify `npm run typecheck` passes
- [ ] Verify `npm run lint` passes (confirmed via lint-staged hooks)
- [ ] Deploy to staging and confirm JSON log lines appear in Cloudflare Workers Logs
- [ ] Verify trace_id propagation by checking that control-plane logs share the same trace_id as originating slack-bot logs
- [ ] Test with `LOG_LEVEL=debug` to confirm level filtering works