### PR TITLE
fix(web): display execution errors to users

### DIFF
--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -160,6 +160,7 @@ export type SandboxEvent =
       type: "execution_complete";
       messageId: string;
       success: boolean;
+      error?: string;
       sandboxId: string;
       timestamp: number;
     }

--- a/packages/web/src/app/session/[id]/page.tsx
+++ b/packages/web/src/app/session/[id]/page.tsx
@@ -651,6 +651,7 @@ function EventItem({
     args?: Record<string, unknown>;
     result?: string;
     error?: string;
+    success?: boolean;
     status?: string;
     timestamp: number;
     author?: {
@@ -738,6 +739,15 @@ function EventItem({
       );
 
     case "execution_complete":
+      if (event.success === false) {
+        return (
+          <div className="flex items-center gap-2 text-sm text-red-600 dark:text-red-400">
+            <span className="w-2 h-2 rounded-full bg-red-500" />
+            Execution failed{event.error ? `: ${event.error}` : ""}
+            <span className="text-xs text-secondary-foreground">{time}</span>
+          </div>
+        );
+      }
       return (
         <div className="flex items-center gap-2 text-sm text-success">
           <span className="w-2 h-2 rounded-full bg-success" />

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -28,6 +28,7 @@ interface SandboxEvent {
   callId?: string;
   result?: string;
   error?: string;
+  success?: boolean;
   status?: string;
   sha?: string;
   timestamp: number;

--- a/packages/web/src/lib/tool-formatters.ts
+++ b/packages/web/src/lib/tool-formatters.ts
@@ -7,6 +7,7 @@ export interface SandboxEvent {
   callId?: string;
   result?: string;
   error?: string;
+  success?: boolean;
   status?: string;
   output?: string;
   sha?: string;


### PR DESCRIPTION
## Summary

- When the bridge sends `execution_complete` with `success: false` (e.g., LLM request timeout), the web UI was rendering a green "Execution complete" message identical to a successful run
- The `error` field was being transmitted correctly through the entire pipeline (bridge → control plane → web client) but ignored in the frontend rendering
- Adds `error` field to the `execution_complete` variant of `SandboxEvent` in the control plane types, adds `success` field to client-side `SandboxEvent` interfaces, and updates the `EventItem` component to render failed executions with a red error indicator and the error message

## Test plan

- [ ] Trigger an LLM timeout or other execution error and verify the UI shows "Execution failed: \<error message\>" in red instead of green "Execution complete"
- [ ] Verify successful executions still render as green "Execution complete"
- [ ] Verify historical events without a `success` field (pre-fix) still render as "Execution complete" (not incorrectly as errors)