### PR TITLE
fix(control-plane): fix sandbox restore token_mismatch race condition

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -669,13 +669,14 @@ describe("SandboxLifecycleManager", () => {
       });
       const storage = createMockStorage(createMockSession(), sandbox);
       const broadcaster = createMockBroadcaster();
+      const wsManager = createMockWebSocketManager();
       const provider = createMockProvider();
 
       const manager = new SandboxLifecycleManager(
         provider,
         storage,
         broadcaster,
-        createMockWebSocketManager(),
+        wsManager,
         createMockAlarmScheduler(),
         createMockIdGenerator(),
         createTestConfig()
@@ -687,6 +688,8 @@ describe("SandboxLifecycleManager", () => {
       expect(broadcaster.messages.some((m) => (m as { status?: string }).status === "stale")).toBe(
         true
       );
+      expect(wsManager.sendToSandbox).toHaveBeenCalledWith({ type: "shutdown" });
+      expect(wsManager.closeSandboxWebSocket).toHaveBeenCalledWith(1000, "Heartbeat stale");
     });
 
     it("handles inactivity timeout", async () => {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -569,6 +569,12 @@ export class SandboxLifecycleManager {
       );
       this.storage.updateSandboxStatus("stale");
       this.broadcaster.broadcast({ type: "sandbox_status", status: "stale" });
+
+      // Best-effort shutdown: tell sandbox to exit cleanly (connection may already be dead).
+      // Unlike the inactivity path, we don't await the snapshot first — heartbeat stale means
+      // the connection is likely already lost, so we prioritize status broadcast over sequencing.
+      this.wsManager.sendToSandbox({ type: "shutdown" });
+      this.wsManager.closeSandboxWebSocket(1000, "Heartbeat stale");
       return;
     }
 


### PR DESCRIPTION
## Summary

- Reorder WebSocket validation checks so sandbox ID is checked before auth token. During a restore, stale sandboxes reconnecting with an old ID now get `sandbox_id_mismatch` (403) instead of the misleading `token_mismatch` (401).
- Send best-effort shutdown command and close the WebSocket on the heartbeat stale path, matching the existing inactivity timeout behavior. This gives the bridge a clean exit signal instead of leaving it in a reconnection loop.
- Update the heartbeat stale test to assert shutdown and WebSocket close are called.

## Test plan

- [x] `npx vitest run` in `@open-inspect/control-plane` — all 215 tests pass
- [x] `tsc --noEmit` typecheck passes
- [ ] After deployment, verify restore events log `sandbox_id_mismatch` (not `token_mismatch`) when old sandbox attempts reconnection