### PR TITLE
fix(web): sync model selector with session model on load

### DIFF
--- a/packages/web/src/app/session/[id]/page.tsx
+++ b/packages/web/src/app/session/[id]/page.tsx
@@ -171,6 +171,13 @@ export default function SessionPage() {
   const typingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const modelDropdownRef = useRef<HTMLDivElement>(null);
 
+  // Sync selectedModel with session's model when session state loads
+  useEffect(() => {
+    if (sessionState?.model) {
+      setSelectedModel(sessionState.model);
+    }
+  }, [sessionState?.model]);
+
   // Scroll to bottom when new content arrives
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });


### PR DESCRIPTION
## Summary

- Fixes a bug where the model dropdown on the session page always showed "claude haiku 4.5" regardless of which model the session was created with
- Adds a `useEffect` that syncs `selectedModel` with `sessionState.model` when the session state loads via WebSocket
- Without this fix, follow-up prompts in a session created with e.g. `claude-opus-4-5` would be sent with `claude-haiku-4-5`

## Test plan

- [ ] Create a session with a non-default model (e.g. claude sonnet 4.5 or claude opus 4.5)
- [ ] Navigate to the session page and verify the model dropdown reflects the correct model
- [ ] Switch models manually via dropdown and verify the selection sticks (not overwritten)
- [ ] Send a follow-up prompt and verify the correct model is sent in the WebSocket message