### PR TITLE
fix(control-plane): include model in session state sent to frontend

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1446,6 +1446,7 @@ export class SessionDO extends DurableObject<Env> {
       sandboxStatus: sandbox?.status ?? "pending",
       messageCount,
       createdAt: session?.created_at ?? Date.now(),
+      model: session?.model ?? DEFAULT_MODEL,
       isProcessing,
     };
   }
@@ -1950,6 +1951,7 @@ export class SessionDO extends DurableObject<Env> {
       currentSha: session.current_sha,
       opencodeSessionId: session.opencode_session_id,
       status: session.status,
+      model: session.model,
       createdAt: session.created_at,
       updatedAt: session.updated_at,
       sandbox: sandbox

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -209,6 +209,7 @@ export interface SessionState {
   sandboxStatus: SandboxStatus;
   messageCount: number;
   createdAt: number;
+  model?: string;
   isProcessing: boolean;
 }
 


### PR DESCRIPTION
## Summary

- Add `model` field to `SessionState` type so the control plane includes it in WebSocket and HTTP responses
- Include `model` in `getSessionState()` (WebSocket `subscribed` message) with `DEFAULT_MODEL` fallback
- Include `model` in `handleGetState()` HTTP endpoint for consistency

Completes the backend half of the fix started in #47 — the frontend already syncs the model dropdown from `sessionState.model`, but the backend was never sending that field, causing the session page to always show the default model (Haiku).

## Test plan

- [x] `npm run typecheck -w @open-inspect/control-plane` — no type errors
- [x] `npm run test -w @open-inspect/control-plane` — all 227 tests pass
- [ ] Manual: select Sonnet on main page, submit prompt, verify session page shows Sonnet (not Haiku)
- [ ] Manual: refresh session page — model dropdown persists the correct model
- [ ] Manual: switch model mid-session, send another prompt — verify it persists on reload