### PR TITLE
fix: hide archived sessions from sidebar

### DIFF
--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -51,13 +51,15 @@ export function SessionSidebar({ onNewSession, onToggle }: SessionSidebarProps) 
 
   // Sort sessions by updatedAt (most recent first) and filter by search query
   const { activeSessions, inactiveSessions } = useMemo(() => {
-    const filtered = sessions.filter((session) => {
-      if (!searchQuery) return true;
-      const query = searchQuery.toLowerCase();
-      const title = session.title?.toLowerCase() || "";
-      const repo = `${session.repoOwner}/${session.repoName}`.toLowerCase();
-      return title.includes(query) || repo.includes(query);
-    });
+    const filtered = sessions
+      .filter((session) => session.status !== "archived")
+      .filter((session) => {
+        if (!searchQuery) return true;
+        const query = searchQuery.toLowerCase();
+        const title = session.title?.toLowerCase() || "";
+        const repo = `${session.repoOwner}/${session.repoName}`.toLowerCase();
+        return title.includes(query) || repo.includes(query);
+      });
 
     // Sort by updatedAt descending
     const sorted = [...filtered].sort((a, b) => {


### PR DESCRIPTION
## Summary

- Filter archived sessions from the sidebar in the frontend to prevent them from appearing in the session list

## Notes

The backend currently stores session metadata in KV, which doesn't support filtering by value. A proper fix requires migrating session metadata from KV to D1 (which is already in the stack for repo secrets). That migration is tracked separately.

## Test plan

- [x] `npm run typecheck -w @open-inspect/web` passes
- [x] `npm run build -w @open-inspect/web` passes
- [ ] Verify archived sessions no longer appear in the sidebar
- [ ] Verify non-archived sessions continue to display normally