### PR TITLE
feat(web): add archived chats section to settings

### DIFF
--- a/packages/web/src/app/settings/page.tsx
+++ b/packages/web/src/app/settings/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { SidebarLayout, useSidebarContext } from "@/components/sidebar-layout";
 import { SettingsNav, type SettingsCategory } from "@/components/settings/settings-nav";
 import { SecretsSettings } from "@/components/settings/secrets-settings";
+import { DataControlsSettings } from "@/components/settings/data-controls-settings";
 
 export default function SettingsPage() {
   return (
@@ -37,7 +38,10 @@ function SettingsContent() {
       <div className="flex-1 flex overflow-hidden">
         <SettingsNav activeCategory={activeCategory} onSelect={setActiveCategory} />
         <div className="flex-1 overflow-y-auto p-8">
-          <div className="max-w-2xl">{activeCategory === "secrets" && <SecretsSettings />}</div>
+          <div className="max-w-2xl">
+            {activeCategory === "secrets" && <SecretsSettings />}
+            {activeCategory === "data-controls" && <DataControlsSettings />}
+          </div>
         </div>
       </div>
     </div>

--- a/packages/web/src/components/settings/data-controls-settings.tsx
+++ b/packages/web/src/components/settings/data-controls-settings.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import type { SessionItem } from "@/components/session-sidebar";
+import { formatRelativeTime } from "@/lib/time";
+
+const PAGE_SIZE = 20;
+
+export function DataControlsSettings() {
+  const [sessions, setSessions] = useState<SessionItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const [offset, setOffset] = useState(0);
+
+  const fetchArchivedSessions = useCallback(async (currentOffset: number, append: boolean) => {
+    if (append) {
+      setLoadingMore(true);
+    } else {
+      setLoading(true);
+    }
+    try {
+      const res = await fetch(
+        `/api/sessions?status=archived&limit=${PAGE_SIZE}&offset=${currentOffset}`
+      );
+      if (res.ok) {
+        const data = await res.json();
+        const fetched: SessionItem[] = data.sessions || [];
+        setSessions((prev) => (append ? [...prev, ...fetched] : fetched));
+        setHasMore(fetched.length === PAGE_SIZE);
+        setOffset(currentOffset + fetched.length);
+      }
+    } catch (error) {
+      console.error("Failed to fetch archived sessions:", error);
+    } finally {
+      setLoading(false);
+      setLoadingMore(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchArchivedSessions(0, false);
+  }, [fetchArchivedSessions]);
+
+  const handleLoadMore = () => {
+    fetchArchivedSessions(offset, true);
+  };
+
+  const handleUnarchive = async (sessionId: string) => {
+    // Optimistically remove from list
+    setSessions((prev) => prev.filter((s) => s.id !== sessionId));
+    try {
+      const res = await fetch(`/api/sessions/${sessionId}/unarchive`, { method: "POST" });
+      if (!res.ok) {
+        // Re-fetch on failure to restore correct state
+        fetchArchivedSessions(0, false);
+      }
+    } catch {
+      fetchArchivedSessions(0, false);
+    }
+  };
+
+  const sessionCount = sessions.length;
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold text-foreground mb-1">Data Controls</h2>
+      <p className="text-sm text-muted-foreground mb-6">Manage your archived chats and data.</p>
+
+      <div>
+        <h3 className="text-base font-medium text-foreground mb-1">Archived chats</h3>
+        <p className="text-sm text-muted-foreground mb-4">
+          {loading
+            ? "Loading..."
+            : sessionCount === 0
+              ? "No archived sessions"
+              : `${sessionCount}${hasMore ? "+" : ""} archived session${sessionCount !== 1 ? "s" : ""}`}
+        </p>
+
+        {loading ? (
+          <div className="flex justify-center py-8">
+            <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-muted-foreground" />
+          </div>
+        ) : sessions.length === 0 ? (
+          <div className="py-8 text-center text-sm text-muted-foreground">
+            No archived sessions. Sessions you archive will appear here.
+          </div>
+        ) : (
+          <div className="border border-border rounded divide-y divide-border">
+            {sessions.map((session) => (
+              <ArchivedSessionRow
+                key={session.id}
+                session={session}
+                onUnarchive={handleUnarchive}
+              />
+            ))}
+          </div>
+        )}
+
+        {hasMore && !loading && (
+          <button
+            onClick={handleLoadMore}
+            disabled={loadingMore}
+            className="mt-4 w-full py-2 text-sm text-muted-foreground hover:text-foreground border border-border rounded hover:bg-muted transition disabled:opacity-50"
+          >
+            {loadingMore ? "Loading..." : "Load more"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ArchivedSessionRow({
+  session,
+  onUnarchive,
+}: {
+  session: SessionItem;
+  onUnarchive: (id: string) => void;
+}) {
+  const displayTitle = session.title || `${session.repoOwner}/${session.repoName}`;
+  const repoInfo = `${session.repoOwner}/${session.repoName}`;
+  const timestamp = session.updatedAt || session.createdAt;
+  const relativeTime = formatRelativeTime(timestamp);
+
+  return (
+    <div className="group flex items-center justify-between px-4 py-3 hover:bg-muted transition">
+      <Link href={`/session/${session.id}`} className="flex-1 min-w-0 mr-3">
+        <div className="truncate text-sm font-medium text-foreground">{displayTitle}</div>
+        <div className="flex items-center gap-1 mt-0.5 text-xs text-muted-foreground">
+          <span>{relativeTime}</span>
+          <span>&middot;</span>
+          <span className="truncate">{repoInfo}</span>
+        </div>
+      </Link>
+      <button
+        onClick={() => onUnarchive(session.id)}
+        className="flex-shrink-0 px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground border border-border rounded hover:bg-background transition opacity-0 group-hover:opacity-100"
+      >
+        Unarchive
+      </button>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/settings-nav.tsx
+++ b/packages/web/src/components/settings/settings-nav.tsx
@@ -6,6 +6,11 @@ const NAV_ITEMS = [
     label: "Secrets",
     icon: KeyIcon,
   },
+  {
+    id: "data-controls",
+    label: "Data Controls",
+    icon: DataControlsIcon,
+  },
 ] as const;
 
 export type SettingsCategory = (typeof NAV_ITEMS)[number]["id"];
@@ -41,6 +46,24 @@ export function SettingsNav({ activeCategory, onSelect }: SettingsNavProps) {
         })}
       </ul>
     </nav>
+  );
+}
+
+function DataControlsIcon() {
+  return (
+    <svg
+      className="w-4 h-4"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <ellipse cx="12" cy="5" rx="9" ry="3" />
+      <path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3" />
+      <path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5" />
+    </svg>
   );
 }
 


### PR DESCRIPTION
## Summary

- Adds a **Data Controls** section to the Settings page with an "Archived chats" list
- Users can view archived sessions with title, relative time, and repo name
- Each row links to `/session/{id}` and has a hover-visible **Unarchive** button
- Unarchive calls `POST /api/sessions/{id}/unarchive` with optimistic removal
- Supports paginated loading (`limit=20`) with a "Load more" button
- Includes loading spinner and empty state

No backend changes needed — uses existing `GET /sessions?status=archived` and `POST /sessions/{id}/unarchive` APIs.

## Files changed

- `packages/web/src/components/settings/settings-nav.tsx` — added "Data Controls" nav item with database icon
- `packages/web/src/app/settings/page.tsx` — wired up `DataControlsSettings` component
- `packages/web/src/components/settings/data-controls-settings.tsx` — new component for archived chats list

## Test plan

- [ ] Navigate to Settings, confirm "Data Controls" appears in the left nav
- [ ] Click "Data Controls", confirm archived sessions list loads
- [ ] Click an archived session row, confirm it navigates to `/session/{id}`
- [ ] Click Unarchive on a row, confirm it disappears from the list
- [ ] Verify `npm run typecheck -w @open-inspect/web` passes