### PR TITLE
feat(modal-infra): add jq to sandbox base image

### DIFF
--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -23,8 +23,8 @@ SANDBOX_DIR = Path(__file__).parent.parent / "sandbox"
 OPENCODE_VERSION = "latest"
 
 # Cache buster - change this to force Modal image rebuild
-# v34: Replace print() with structured JSON logging in sandbox code
-CACHE_BUSTER = "v34-structured-logging"
+# v35: Add jq to base image
+CACHE_BUSTER = "v35-add-jq"
 
 # Base image with all development tools
 base_image = (
@@ -37,6 +37,7 @@ base_image = (
         "ca-certificates",
         "gnupg",
         "openssh-client",
+        "jq",
         "unzip",  # Required for Bun installation
         # For Playwright
         "libnss3",


### PR DESCRIPTION
## Summary
- Adds `jq` to the `apt_install` list in the Modal base image so it's available in sandboxes for JSON processing
- Bumps `CACHE_BUSTER` to `v35-add-jq` to trigger an image rebuild on next deploy

## Test plan
- [ ] Deploy with `modal deploy deploy.py` from `packages/modal-infra`
- [ ] Verify `jq --version` works inside a sandbox