### PR TITLE
docs: add missing Slack bot OAuth scopes for thread context

### DIFF
--- a/.claude/skills/onboarding/SKILL.md
+++ b/.claude/skills/onboarding/SKILL.md
@@ -145,7 +145,8 @@ cat /tmp/github-app-key-pkcs8.pem
 Guide user:
 
 1. https://api.slack.com/apps → "Create New App" → "From scratch"
-2. OAuth & Permissions → Add scopes: `app_mentions:read`, `chat:write`, `channels:history`
+2. OAuth & Permissions → Add scopes: `app_mentions:read`, `chat:write`, `channels:history`,
+   `channels:read`, `groups:history`, `groups:read`
 3. Install to Workspace, note **Bot Token** (`xoxb-...`)
 4. Basic Information → note **Signing Secret**
 5. **App Home and Event Subscriptions configured AFTER deployment** (worker must be running for URL

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -197,6 +197,9 @@ Skip this step if you don't need Slack integration.
    - `app_mentions:read`
    - `chat:write`
    - `channels:history`
+   - `channels:read`
+   - `groups:history`
+   - `groups:read`
 3. Click **"Install to Workspace"**
 4. Note the **Bot Token** (`xoxb-...`)
 
@@ -603,6 +606,18 @@ ls packages/slack-bot/dist/index.js
 2. Ensure the bot is invited to the channel (`/invite @BotName`)
 3. Check that you're @mentioning the bot in your message
 4. If you updated bot token scopes, reinstall the app to your workspace
+
+### Slack bot ignores thread context
+
+If the bot doesn't see the original message when tagged in a thread reply:
+
+1. Verify the bot has `channels:history` scope (for public channels) and `groups:history` (for
+   private channels). These are required by the `conversations.replies` API to fetch thread
+   messages.
+2. Verify the bot has `channels:read` and `groups:read` scopes. These are required by
+   `conversations.info` to fetch channel name and description for context.
+3. If you added missing scopes, **reinstall the app** to your workspace for the new permissions to
+   take effect.
 
 ### Durable Objects / Service Binding errors
 


### PR DESCRIPTION
## Summary

- Add missing Slack bot OAuth scopes (`channels:read`, `groups:history`, `groups:read`) to deployment documentation
- Add troubleshooting entry for "Slack bot ignores thread context" issue

The Slack bot uses `conversations.replies` (requires `channels:history` / `groups:history`) and `conversations.info` (requires `channels:read` / `groups:read`), but only `channels:history` was documented. The missing scopes cause silent failures when fetching thread context and channel metadata, resulting in the agent not seeing the original message when tagged in a thread reply.

### Files updated
- `docs/GETTING_STARTED.md` — added 3 missing scopes to the bot token scopes list, added troubleshooting section
- `.claude/skills/onboarding/SKILL.md` — added 3 missing scopes to the onboarding guide

## Test plan
- [ ] Verify the new scopes are listed in the Slack App OAuth configuration
- [ ] After adding scopes and reinstalling the app, confirm the bot can fetch thread context when tagged in a reply
- [ ] Test in both public and private channels