### PR TITLE
fix: preserve chronological position of deduplicated token events

### DIFF
--- a/packages/web/src/app/session/[id]/page.tsx
+++ b/packages/web/src/app/session/[id]/page.tsx
@@ -408,21 +408,20 @@ function SessionContent({
           filteredEvents.push(event);
         }
       } else if (event.type === "token" && event.messageId) {
-        // Deduplicate tokens by messageId - keep latest (most complete cumulative text)
+        // Deduplicate tokens by messageId - keep latest at its chronological position
         const existingIdx = seenTokens.get(event.messageId);
         if (existingIdx !== undefined) {
-          filteredEvents[existingIdx] = event;
-        } else {
-          seenTokens.set(event.messageId, filteredEvents.length);
-          filteredEvents.push(event);
+          filteredEvents[existingIdx] = null as unknown as SandboxEvent;
         }
+        seenTokens.set(event.messageId, filteredEvents.length);
+        filteredEvents.push(event);
       } else {
         // All other events (user_message, git_sync, etc.) - add as-is
         filteredEvents.push(event);
       }
     }
 
-    return groupEvents(filteredEvents);
+    return groupEvents(filteredEvents.filter(Boolean) as SandboxEvent[]);
   }, [events]);
 
   return (


### PR DESCRIPTION
## Summary

Fixes a regression from #63 where the assistant's complete response text rendered above tool calls instead of below them.

The previous token dedup replaced content at the first token's array slot. Since the first token for a message appears before tool calls but the final cumulative token appears after them, this placed the complete response text before all tool call cards in the UI.

**Fix**: Instead of replacing at the first occurrence's position, null out the old slot and push the latest token at its actual chronological position. Nulls are filtered out before grouping.

## Before/After

**Before**: Summary response appears above tool calls
**After**: Summary response appears at its correct position after tool calls

## Test plan

- [x] `npm run typecheck -w @open-inspect/web`
- [x] `npm run test -w @open-inspect/web`
- [x] `npm run build -w @open-inspect/web`
- [ ] Verify in browser: load a session with tool calls and confirm the assistant response appears after them