### PR TITLE
docs: document .openinspect/setup.sh repository setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,22 @@ await configureGitIdentity({
 });
 ```
 
+### Repository Setup Scripts
+
+Repositories can include a `.openinspect/setup.sh` script for custom environment setup:
+
+```bash
+# .openinspect/setup.sh
+#!/bin/bash
+npm install
+pip install -r requirements.txt
+```
+
+- Runs automatically after git clone, before the agent starts
+- Skipped when restoring from a snapshot (dependencies already installed)
+- Non-blocking: failures are logged but don't prevent the session from starting
+- Default timeout: 5 minutes (configurable via `SETUP_TIMEOUT_SECONDS` environment variable)
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

- Documents the `.openinspect/setup.sh` repository setup script feature in the README
- This feature was added in 9524cfd but was not documented

## Changes

Adds a new "Repository Setup Scripts" section under "Key Features" explaining:
- What the feature does (runs custom setup script after git clone)
- When it runs (after clone, before agent starts)
- When it's skipped (snapshot restore)
- Error handling (non-blocking)
- Timeout configuration

## Test plan

- [x] Verify documentation renders correctly in GitHub markdown preview