### PR TITLE
Add WebSocket integration tests for client and sandbox flows

### DIFF
--- a/packages/control-plane/test/integration/helpers.ts
+++ b/packages/control-plane/test/integration/helpers.ts
@@ -1,4 +1,4 @@
-import { env, runInDurableObject } from "cloudflare:test";
+import { SELF, env, runInDurableObject } from "cloudflare:test";
 import type { SessionDO } from "../../src/session/durable-object";
 
 /**
@@ -98,6 +98,154 @@ export async function seedMessage(
       msg.status,
       msg.createdAt,
       msg.startedAt ?? null
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a session using idFromName() so the worker's /sessions/:name/ws
+ * route can locate the DO via the same name. Returns stub + sessionName.
+ */
+export async function initNamedSession(
+  sessionName: string,
+  overrides?: {
+    repoOwner?: string;
+    repoName?: string;
+    repoId?: number;
+    title?: string;
+    model?: string;
+    userId?: string;
+    githubLogin?: string;
+  }
+) {
+  const id = env.SESSION.idFromName(sessionName);
+  const stub = env.SESSION.get(id);
+  const defaults = {
+    sessionName,
+    repoOwner: "acme",
+    repoName: "web-app",
+    repoId: 12345,
+    userId: "user-1",
+    ...overrides,
+  };
+  const res = await stub.fetch("http://internal/internal/init", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(defaults),
+  });
+  if (res.status !== 200) throw new Error(`Init failed: ${res.status}`);
+  return { stub, id, sessionName };
+}
+
+/**
+ * Collect JSON messages from a WebSocket until a predicate matches or timeout.
+ * Starts listening immediately — call BEFORE sending the message that triggers responses.
+ */
+export function collectMessages(
+  ws: WebSocket,
+  opts?: { until?: (msg: Record<string, unknown>) => boolean; timeoutMs?: number }
+): Promise<Record<string, unknown>[]> {
+  return new Promise((resolve) => {
+    const messages: Record<string, unknown>[] = [];
+    const timeout = opts?.timeoutMs ?? 2000;
+    const timer = setTimeout(() => resolve(messages), timeout);
+
+    ws.addEventListener("message", (event) => {
+      const msg = JSON.parse(typeof event.data === "string" ? event.data : "{}");
+      messages.push(msg);
+      if (opts?.until?.(msg)) {
+        clearTimeout(timer);
+        resolve(messages);
+      }
+    });
+  });
+}
+
+/**
+ * Open a client WebSocket via SELF.fetch (full worker routing path).
+ * Optionally subscribe by generating a WS token and completing the subscribe flow.
+ */
+export async function openClientWs(
+  sessionName: string,
+  opts?: { subscribe?: boolean; userId?: string }
+) {
+  const response = await SELF.fetch(`https://test.local/sessions/${sessionName}/ws`, {
+    headers: { Upgrade: "websocket" },
+  });
+
+  const ws = response.webSocket;
+  if (!ws) throw new Error("No webSocket on response");
+  ws.accept();
+
+  if (!opts?.subscribe) {
+    return { ws };
+  }
+
+  // Generate a WS token via the DO
+  const id = env.SESSION.idFromName(sessionName);
+  const stub = env.SESSION.get(id);
+  const tokenRes = await stub.fetch("http://internal/internal/ws-token", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ userId: opts.userId ?? "user-1" }),
+  });
+  const { token, participantId } = await tokenRes.json<{
+    token: string;
+    participantId: string;
+  }>();
+
+  // Start collecting BEFORE sending subscribe to avoid race
+  const collector = collectMessages(ws, {
+    until: (msg) => msg.type === "replay_complete",
+  });
+
+  ws.send(
+    JSON.stringify({
+      type: "subscribe",
+      token,
+      clientId: `test-client-${Date.now()}`,
+    })
+  );
+
+  const messages = await collector;
+  return { ws, token, participantId, messages };
+}
+
+/**
+ * Open a sandbox WebSocket via SELF.fetch (full worker routing path).
+ * Returns the WebSocket (or null if upgrade failed) and the raw response.
+ */
+export async function openSandboxWs(
+  sessionName: string,
+  opts: { authToken: string; sandboxId: string }
+) {
+  const response = await SELF.fetch(`https://test.local/sessions/${sessionName}/ws?type=sandbox`, {
+    headers: {
+      Upgrade: "websocket",
+      Authorization: `Bearer ${opts.authToken}`,
+      "X-Sandbox-ID": opts.sandboxId,
+    },
+  });
+  return { ws: response.webSocket ?? null, response };
+}
+
+/**
+ * Seed auth_token and modal_sandbox_id on the sandbox row so sandbox
+ * WebSocket auth can pass.
+ */
+export async function seedSandboxAuth(
+  stub: DurableObjectStub,
+  opts: { authToken: string; sandboxId: string }
+): Promise<void> {
+  await runInDurableObject(stub, (instance: SessionDO) => {
+    instance.ctx.storage.sql.exec(
+      "UPDATE sandbox SET auth_token = ?, modal_sandbox_id = ?",
+      opts.authToken,
+      opts.sandboxId
     );
   });
 }

--- a/packages/control-plane/test/integration/websocket-client.test.ts
+++ b/packages/control-plane/test/integration/websocket-client.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest";
+import { initNamedSession, openClientWs, collectMessages, seedEvents, queryDO } from "./helpers";
+
+describe("Client WebSocket (via SELF.fetch)", () => {
+  it("upgrade returns 101 with webSocket", async () => {
+    const name = `ws-client-upgrade-${Date.now()}`;
+    await initNamedSession(name);
+
+    const { ws } = await openClientWs(name);
+    expect(ws).not.toBeNull();
+    // Clean up
+    ws.close();
+  });
+
+  it("subscribe with valid token sends subscribed + state", async () => {
+    const name = `ws-client-sub-${Date.now()}`;
+    await initNamedSession(name, { repoOwner: "acme", repoName: "web-app" });
+
+    const { ws, participantId, messages } = await openClientWs(name, { subscribe: true });
+
+    const subscribed = messages!.find((m) => m.type === "subscribed") as Record<string, unknown>;
+    expect(subscribed).toBeDefined();
+    expect(subscribed.sessionId).toEqual(expect.any(String));
+    expect(subscribed.participantId).toBe(participantId);
+
+    const state = subscribed.state as Record<string, unknown>;
+    expect(state.repoOwner).toBe("acme");
+
+    ws.close();
+  });
+
+  it("subscribe with invalid token closes socket 4001", async () => {
+    const name = `ws-client-badtoken-${Date.now()}`;
+    await initNamedSession(name);
+
+    const { ws } = await openClientWs(name);
+
+    const closed = new Promise<{ code: number }>((resolve) => {
+      ws.addEventListener("close", (evt) => resolve({ code: evt.code }));
+    });
+
+    ws.send(
+      JSON.stringify({
+        type: "subscribe",
+        token: "totally-invalid-token",
+        clientId: "test-client",
+      })
+    );
+
+    const { code } = await closed;
+    expect(code).toBe(4001);
+  });
+
+  it("subscribe without token closes socket 4001", async () => {
+    const name = `ws-client-notoken-${Date.now()}`;
+    await initNamedSession(name);
+
+    const { ws } = await openClientWs(name);
+
+    const closed = new Promise<{ code: number }>((resolve) => {
+      ws.addEventListener("close", (evt) => resolve({ code: evt.code }));
+    });
+
+    ws.send(
+      JSON.stringify({
+        type: "subscribe",
+        token: "",
+        clientId: "test-client",
+      })
+    );
+
+    const { code } = await closed;
+    expect(code).toBe(4001);
+  });
+
+  it("subscribe sends replay_complete with hasMore=false for empty session", async () => {
+    const name = `ws-client-replay-empty-${Date.now()}`;
+    await initNamedSession(name);
+
+    const { ws, messages } = await openClientWs(name, { subscribe: true });
+
+    const replayComplete = messages!.find((m) => m.type === "replay_complete") as Record<
+      string,
+      unknown
+    >;
+    expect(replayComplete).toBeDefined();
+    expect(replayComplete.hasMore).toBe(false);
+    expect(replayComplete.cursor).toBeNull();
+
+    ws.close();
+  });
+
+  it("subscribe replays historical events before replay_complete", async () => {
+    const name = `ws-client-replay-events-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+
+    const now = Date.now();
+    await seedEvents(stub, [
+      {
+        id: "ev-1",
+        type: "tool_call",
+        data: JSON.stringify({ type: "tool_call", tool: "read_file" }),
+        createdAt: now - 2000,
+      },
+      {
+        id: "ev-2",
+        type: "tool_result",
+        data: JSON.stringify({ type: "tool_result", result: "ok" }),
+        createdAt: now - 1000,
+      },
+    ]);
+
+    const { ws, messages } = await openClientWs(name, { subscribe: true });
+
+    const types = messages!.map((m) => m.type);
+    const replayIdx = types.indexOf("replay_complete");
+    expect(replayIdx).toBeGreaterThan(0);
+
+    // sandbox_event messages should appear before replay_complete
+    const sandboxEvents = messages!.filter((m, i) => m.type === "sandbox_event" && i < replayIdx);
+    expect(sandboxEvents.length).toBe(2);
+
+    ws.close();
+  });
+
+  it("ping gets pong response", async () => {
+    const name = `ws-client-ping-${Date.now()}`;
+    await initNamedSession(name);
+
+    const { ws } = await openClientWs(name);
+
+    const collector = collectMessages(ws, {
+      until: (msg) => msg.type === "pong",
+      timeoutMs: 2000,
+    });
+
+    ws.send(JSON.stringify({ type: "ping" }));
+
+    const messages = await collector;
+    const pong = messages.find((m) => m.type === "pong");
+    expect(pong).toBeDefined();
+    expect(pong!.timestamp).toEqual(expect.any(Number));
+
+    ws.close();
+  });
+
+  it("prompt via WS creates message and returns prompt_queued", async () => {
+    const name = `ws-client-prompt-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+
+    const { ws } = await openClientWs(name, { subscribe: true });
+
+    const collector = collectMessages(ws, {
+      until: (msg) => msg.type === "prompt_queued",
+      timeoutMs: 2000,
+    });
+
+    ws.send(JSON.stringify({ type: "prompt", content: "Hello from WS test" }));
+
+    const messages = await collector;
+    const queued = messages.find((m) => m.type === "prompt_queued") as Record<string, unknown>;
+    expect(queued).toBeDefined();
+    expect(queued.messageId).toEqual(expect.any(String));
+
+    // Verify message exists in DB
+    const rows = await queryDO<{ id: string; content: string; source: string }>(
+      stub,
+      "SELECT id, content, source FROM messages WHERE id = ?",
+      queued.messageId
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].content).toBe("Hello from WS test");
+    expect(rows[0].source).toBe("web");
+
+    ws.close();
+  });
+
+  it("sandbox event is broadcast to subscribed client", async () => {
+    const name = `ws-client-broadcast-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+
+    // Subscribe a client first
+    const { ws } = await openClientWs(name, { subscribe: true });
+
+    // Listen for the broadcast
+    const collector = collectMessages(ws, {
+      until: (msg) =>
+        msg.type === "sandbox_event" &&
+        (msg.event as Record<string, unknown>)?.type === "tool_call",
+      timeoutMs: 2000,
+    });
+
+    // Post sandbox event via DO internal endpoint (simulates sandbox behavior)
+    await stub.fetch("http://internal/internal/sandbox-event", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        type: "tool_call",
+        tool: "write_file",
+        args: { path: "/src/index.ts" },
+        callId: "c-broadcast",
+        messageId: "msg-broadcast",
+        sandboxId: "sb-1",
+        timestamp: Date.now() / 1000,
+      }),
+    });
+
+    const messages = await collector;
+    const broadcast = messages.find(
+      (m) =>
+        m.type === "sandbox_event" && (m.event as Record<string, unknown>)?.type === "tool_call"
+    );
+    expect(broadcast).toBeDefined();
+    expect((broadcast!.event as Record<string, unknown>).tool).toBe("write_file");
+
+    ws.close();
+  });
+});

--- a/packages/control-plane/test/integration/websocket-sandbox.test.ts
+++ b/packages/control-plane/test/integration/websocket-sandbox.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import { initNamedSession, openSandboxWs, seedSandboxAuth, queryDO } from "./helpers";
+
+const SANDBOX_TOKEN = "test-sandbox-auth-token-abc123";
+const SANDBOX_ID = "sb-integration-test";
+
+describe("Sandbox WebSocket (via SELF.fetch)", () => {
+  it("upgrade with valid auth returns 101", async () => {
+    const name = `ws-sandbox-ok-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    await seedSandboxAuth(stub, { authToken: SANDBOX_TOKEN, sandboxId: SANDBOX_ID });
+
+    const { ws, response } = await openSandboxWs(name, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+    });
+
+    expect(response.status).toBe(101);
+    expect(ws).not.toBeNull();
+    ws!.accept();
+    ws!.close();
+  });
+
+  it("upgrade with wrong token returns 401", async () => {
+    const name = `ws-sandbox-badtoken-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    await seedSandboxAuth(stub, { authToken: SANDBOX_TOKEN, sandboxId: SANDBOX_ID });
+
+    const { ws, response } = await openSandboxWs(name, {
+      authToken: "wrong-token",
+      sandboxId: SANDBOX_ID,
+    });
+
+    expect(response.status).toBe(401);
+    expect(ws).toBeNull();
+  });
+
+  it("upgrade with wrong sandbox ID returns 403", async () => {
+    const name = `ws-sandbox-badid-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    await seedSandboxAuth(stub, { authToken: SANDBOX_TOKEN, sandboxId: SANDBOX_ID });
+
+    const { ws, response } = await openSandboxWs(name, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: "wrong-sandbox-id",
+    });
+
+    expect(response.status).toBe(403);
+    expect(ws).toBeNull();
+  });
+
+  it("upgrade for stopped sandbox returns 410", async () => {
+    const name = `ws-sandbox-stopped-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    await seedSandboxAuth(stub, { authToken: SANDBOX_TOKEN, sandboxId: SANDBOX_ID });
+
+    // Set sandbox status to stopped
+    await queryDO(stub, "UPDATE sandbox SET status = ?", "stopped");
+
+    const { ws, response } = await openSandboxWs(name, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+    });
+
+    expect(response.status).toBe(410);
+    expect(ws).toBeNull();
+  });
+
+  it("sandbox connect sets status to ready", async () => {
+    const name = `ws-sandbox-ready-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    await seedSandboxAuth(stub, { authToken: SANDBOX_TOKEN, sandboxId: SANDBOX_ID });
+
+    // Wait for init's fire-and-forget warmSandbox to fail (no Modal in test env).
+    // The spawn failure sets status to "failed" which we need to happen before
+    // the WS connect sets it to "ready", otherwise the two race.
+    const waitForSpawnToSettle = async () => {
+      for (let i = 0; i < 30; i++) {
+        const rows = await queryDO<{ status: string }>(stub, "SELECT status FROM sandbox");
+        if (rows[0]?.status === "failed") return;
+        await new Promise((r) => setTimeout(r, 100));
+      }
+    };
+    await waitForSpawnToSettle();
+
+    const { ws } = await openSandboxWs(name, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+    });
+    expect(ws).not.toBeNull();
+    ws!.accept();
+
+    // Small delay to ensure DO has processed the connect handler fully
+    await new Promise((r) => setTimeout(r, 100));
+
+    const stateRes = await stub.fetch("http://internal/internal/state");
+    const state = await stateRes.json<{ sandbox: { status: string } }>();
+    expect(state.sandbox.status).toBe("ready");
+
+    ws!.close();
+  });
+
+  it("sandbox WS message is stored as event", async () => {
+    const name = `ws-sandbox-event-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    await seedSandboxAuth(stub, { authToken: SANDBOX_TOKEN, sandboxId: SANDBOX_ID });
+
+    const { ws } = await openSandboxWs(name, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+    });
+    expect(ws).not.toBeNull();
+    ws!.accept();
+
+    // Send a token event via the sandbox WebSocket
+    ws!.send(
+      JSON.stringify({
+        type: "tool_call",
+        tool: "read_file",
+        args: { path: "/src/main.ts" },
+        callId: "call-ws-1",
+        messageId: "msg-ws-1",
+        sandboxId: SANDBOX_ID,
+        timestamp: Date.now() / 1000,
+      })
+    );
+
+    // Allow time for the DO to process the message
+    await new Promise((r) => setTimeout(r, 200));
+
+    const events = await queryDO<{ type: string; data: string }>(
+      stub,
+      "SELECT type, data FROM events WHERE type = ?",
+      "tool_call"
+    );
+
+    const matching = events.filter((e) => {
+      const data = JSON.parse(e.data);
+      return data.callId === "call-ws-1";
+    });
+    expect(matching.length).toBeGreaterThanOrEqual(1);
+
+    ws!.close();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 15 WebSocket integration tests covering client connect/subscribe/auth and sandbox connect/auth flows
- All tests route through `SELF.fetch()` → worker fetch handler → `idFromName()` DO routing → `handleWebSocketUpgrade()`, exercising the identical execution path as production
- Adds 5 reusable WS helpers to `test/integration/helpers.ts`: `initNamedSession`, `collectMessages`, `openClientWs`, `openSandboxWs`, `seedSandboxAuth`
- Brings integration test total from 45 → 60 (386 total with unit tests)

### Client WS tests (9)
- Upgrade returns 101, subscribe with valid/invalid/missing token, `replay_complete` for empty session, historical event replay, ping/pong, prompt via WS, sandbox event broadcast

### Sandbox WS tests (6)
- Valid auth → 101, wrong token → 401, wrong sandbox ID → 403, stopped → 410, connect sets status to ready, WS message stored as event

## Test plan
- [x] `npm test -w @open-inspect/control-plane` — 326 unit tests pass
- [x] `npx vitest run --config vitest.integration.config.ts` — 60 integration tests pass