### PR TITLE
fix(modal-infra): guard _current_prompt_task against overlap

### DIFF
--- a/packages/modal-infra/src/sandbox/bridge.py
+++ b/packages/modal-infra/src/sandbox/bridge.py
@@ -396,7 +396,8 @@ class AgentBridge:
             self._current_prompt_task = task
 
             def handle_task_exception(t: asyncio.Task[None], mid: str = message_id) -> None:
-                self._current_prompt_task = None
+                if self._current_prompt_task is t:
+                    self._current_prompt_task = None
                 if t.cancelled():
                     asyncio.create_task(
                         self._send_event(


### PR DESCRIPTION
When two `prompt` commands overlap, the older task’s done-callback could clear `_current_prompt_task` after a newer prompt has already started. That breaks `stop`, since `_handle_stop` cancels `_current_prompt_task`.

This change only clears `_current_prompt_task` if the finished task is still the current one, and adds a regression test to ensure an older completion can’t wipe out a newer active prompt task.
