### PR TITLE
fix: propagate OpenCode error events to UI correctly

### DIFF
--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -173,6 +173,13 @@ export type SandboxEvent =
       timestamp: number;
     }
   | {
+      type: "error";
+      error: string;
+      messageId: string;
+      sandboxId: string;
+      timestamp: number;
+    }
+  | {
       type: "execution_complete";
       messageId: string;
       success: boolean;

--- a/packages/web/src/app/session/[id]/page.tsx
+++ b/packages/web/src/app/session/[id]/page.tsx
@@ -823,6 +823,15 @@ function EventItem({
         </div>
       );
 
+    case "error":
+      return (
+        <div className="flex items-center gap-2 text-sm text-red-600 dark:text-red-400">
+          <span className="w-2 h-2 rounded-full bg-red-500" />
+          Error{event.error ? `: ${event.error}` : ""}
+          <span className="text-xs text-secondary-foreground">{time}</span>
+        </div>
+      );
+
     case "execution_complete":
       if (event.success === false) {
         return (


### PR DESCRIPTION
## Summary

Fixes a bug where OpenCode errors (e.g. invalid Anthropic API key) were not shown to users. The session would show a green "Execution complete" instead of the actual error.

**Root cause:** Three compounding bugs in the error event pipeline:

- **Bridge error message extraction** (`bridge.py`): OpenCode's `session.error` event uses a NamedError structure `{ name: "APIError", data: { message: "invalid x-api-key" } }`, but the bridge was reading `error.message` (top-level) instead of `error.data.message`. This returned `null`, resulting in "Unknown error".

- **Bridge execution_complete success flag** (`bridge.py`): When the SSE generator yields an error event and returns, the `async for` loop exits normally (no Python exception), so `execution_complete` was always sent with `success: true`. Now tracks whether an error was yielded during streaming and sets `success: false` accordingly.

- **Web client missing error rendering** (`page.tsx`, `types.ts`): The `EventItem` component had no `case "error":` — error events fell through to `default: return null` and were silently dropped. Added error rendering and the type variant.

## Test plan

- [x] Control plane unit tests pass (332 tests)
- [x] Modal infra tests pass (104 tests)
- [x] TypeScript typecheck passes (control-plane + web)
- [ ] Deploy to staging and trigger an invalid API key error to verify the error message appears in the UI
- [ ] Verify that successful executions still show green "Execution complete"