### PR TITLE
fix: disable OpenCode question tool in headless sandbox

### DIFF
--- a/packages/modal-infra/src/sandbox/entrypoint.py
+++ b/packages/modal-infra/src/sandbox/entrypoint.py
@@ -271,6 +271,12 @@ class SandboxSupervisor:
         env = {
             **os.environ,
             "OPENCODE_CONFIG_CONTENT": json.dumps(opencode_config),
+            # Disable OpenCode's question tool in headless mode. The tool blocks
+            # on a Promise waiting for user input via the HTTP API, but the bridge
+            # has no channel to relay questions to the web client and back. Without
+            # this, the session hangs until the SSE inactivity timeout (120s).
+            # See: https://github.com/anomalyco/opencode/blob/19b1222cd/packages/opencode/src/tool/registry.ts#L100
+            "OPENCODE_CLIENT": "serve",
         }
 
         # Start OpenCode server in the repo directory


### PR DESCRIPTION
## Summary

- Set `OPENCODE_CLIENT=serve` in the sandbox entrypoint to disable OpenCode's question tool in headless mode
- Prevents sessions from hanging for 120s when the model decides to ask the user a question

## Root Cause

OpenCode's [question tool](https://github.com/anomalyco/opencode/blob/19b1222cd/packages/opencode/src/tool/question.ts) calls `Question.ask()` which creates a Promise that blocks indefinitely waiting for a reply via `POST /question/:requestID/reply`. The bridge has no mechanism to detect the pending question, relay it to the web client, or send back an answer. The session hangs until the SSE inactivity timeout (120s).

The question tool is [gated by `OPENCODE_CLIENT`](https://github.com/anomalyco/opencode/blob/19b1222cd/packages/opencode/src/tool/registry.ts#L100) — only `"app"`, `"cli"`, and `"desktop"` clients get it. Since the sandbox never set this env var, it defaulted to `"cli"`, enabling the tool. Setting it to `"serve"` excludes it.

This matches [OpenCode's own approach](https://github.com/anomalyco/opencode/issues/11361) for clients that can't handle interactive input (e.g., ACP/Zed).

## Test plan

- [ ] Deploy to staging and send a prompt that would normally trigger the question tool (e.g., "please use your ask a question tool and ask a question about something")
- [ ] Verify the agent no longer hangs — it should proceed without attempting to ask questions
- [ ] Verify normal prompts still work end-to-end