### PR TITLE
feat: minimal mobile header with single status dot

### DIFF
--- a/packages/web/src/app/session/[id]/page.tsx
+++ b/packages/web/src/app/session/[id]/page.tsx
@@ -454,9 +454,20 @@ function SessionContent({
             </div>
           </div>
           <div className="flex items-center gap-4">
-            <ConnectionStatus connected={connected} connecting={connecting} />
-            <SandboxStatus status={sessionState?.sandboxStatus} />
-            <ParticipantsList participants={participants} />
+            {/* Mobile: single combined status dot */}
+            <div className="md:hidden">
+              <CombinedStatusDot
+                connected={connected}
+                connecting={connecting}
+                sandboxStatus={sessionState?.sandboxStatus}
+              />
+            </div>
+            {/* Desktop: full status indicators */}
+            <div className="hidden md:contents">
+              <ConnectionStatus connected={connected} connecting={connecting} />
+              <SandboxStatus status={sessionState?.sandboxStatus} />
+              <ParticipantsList participants={participants} />
+            </div>
           </div>
         </div>
       </header>
@@ -699,6 +710,44 @@ function SandboxStatus({ status }: { status?: string }) {
   };
 
   return <span className={`text-xs ${colors[status] || colors.pending}`}>Sandbox: {status}</span>;
+}
+
+function CombinedStatusDot({
+  connected,
+  connecting,
+  sandboxStatus,
+}: {
+  connected: boolean;
+  connecting: boolean;
+  sandboxStatus?: string;
+}) {
+  let color: string;
+  let pulse = false;
+  let label: string;
+
+  if (!connected && !connecting) {
+    color = "bg-red-500";
+    label = "Disconnected";
+  } else if (connecting) {
+    color = "bg-yellow-500";
+    pulse = true;
+    label = "Connecting...";
+  } else if (sandboxStatus === "failed") {
+    color = "bg-red-500";
+    label = `Connected · Sandbox: ${sandboxStatus}`;
+  } else if (["pending", "warming", "syncing"].includes(sandboxStatus || "")) {
+    color = "bg-yellow-500";
+    label = `Connected · Sandbox: ${sandboxStatus}`;
+  } else {
+    color = "bg-success";
+    label = sandboxStatus ? `Connected · Sandbox: ${sandboxStatus}` : "Connected";
+  }
+
+  return (
+    <span title={label} className="flex items-center">
+      <span className={`w-2.5 h-2.5 rounded-full ${color}${pulse ? " animate-pulse" : ""}`} />
+    </span>
+  );
 }
 
 function ThinkingIndicator() {


### PR DESCRIPTION
## Summary

- On mobile (< `md` breakpoint), replaces the crowded "Connected" text, "Sandbox: ready" text, and participant avatars with a **single colored dot** that encodes combined status
- Dot color: green (all good), yellow/pulsing (connecting or sandbox warming), red (disconnected or sandbox failed)
- Tooltip on hover/tap shows full status text (e.g. "Connected · Sandbox: ready")
- Desktop layout is completely unchanged — all existing indicators remain as-is

## Test plan

- [ ] `npm run typecheck -w @open-inspect/web` passes (verified)
- [ ] Dev server at mobile viewport (< 768px): only a single colored dot in header, no text or avatars
- [ ] Hover/tap dot shows tooltip with full status
- [ ] Resize to >= 768px: full "Connected", "Sandbox: ready", and participant avatars appear as before