### PR TITLE
feat: add global secrets backend

### DIFF
--- a/packages/control-plane/src/db/global-secrets.test.ts
+++ b/packages/control-plane/src/db/global-secrets.test.ts
@@ -1,0 +1,213 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { webcrypto } from "node:crypto";
+import { GlobalSecretsStore } from "./global-secrets";
+import { SecretsValidationError } from "./secrets-validation";
+import { generateEncryptionKey } from "../auth/crypto";
+
+let didPolyfillCrypto = false;
+
+beforeAll(() => {
+  if (!(globalThis as { crypto?: typeof webcrypto }).crypto) {
+    Object.defineProperty(globalThis, "crypto", { value: webcrypto, configurable: true });
+    didPolyfillCrypto = true;
+  }
+});
+
+afterAll(() => {
+  if (didPolyfillCrypto) {
+    Object.defineProperty(globalThis, "crypto", { value: undefined, configurable: true });
+  }
+});
+
+type GlobalSecretRow = {
+  key: string;
+  encrypted_value: string;
+  created_at: number;
+  updated_at: number;
+};
+
+const QUERY_PATTERNS = {
+  SELECT_EXISTING_KEYS: /^SELECT key FROM global_secrets$/,
+  SELECT_KEYS_WITH_METADATA: /^SELECT key, created_at, updated_at FROM global_secrets/,
+  SELECT_KEYS_WITH_VALUES: /^SELECT key, encrypted_value FROM global_secrets$/,
+  UPSERT_SECRET: /^INSERT INTO global_secrets/,
+  DELETE_SECRET: /^DELETE FROM global_secrets/,
+} as const;
+
+function normalizeQuery(query: string): string {
+  return query.replace(/\s+/g, " ").trim();
+}
+
+class FakeD1Database {
+  private rows = new Map<string, GlobalSecretRow>();
+
+  prepare(query: string) {
+    return new FakePreparedStatement(this, query);
+  }
+
+  all(query: string, _args: unknown[]) {
+    const normalized = normalizeQuery(query);
+
+    if (QUERY_PATTERNS.SELECT_KEYS_WITH_METADATA.test(normalized)) {
+      return Array.from(this.rows.values())
+        .sort((a, b) => a.key.localeCompare(b.key))
+        .map((row) => ({
+          key: row.key,
+          created_at: row.created_at,
+          updated_at: row.updated_at,
+        }));
+    }
+
+    if (QUERY_PATTERNS.SELECT_KEYS_WITH_VALUES.test(normalized)) {
+      return Array.from(this.rows.values()).map((row) => ({
+        key: row.key,
+        encrypted_value: row.encrypted_value,
+      }));
+    }
+
+    if (QUERY_PATTERNS.SELECT_EXISTING_KEYS.test(normalized)) {
+      return Array.from(this.rows.values()).map((row) => ({ key: row.key }));
+    }
+
+    throw new Error(`Unexpected SELECT query: ${query}`);
+  }
+
+  run(query: string, args: unknown[]) {
+    const normalized = normalizeQuery(query);
+
+    if (QUERY_PATTERNS.UPSERT_SECRET.test(normalized)) {
+      const [key, encryptedValue, createdAt, updatedAt] = args as [string, string, number, number];
+      const existing = this.rows.get(key);
+      const created_at = existing ? existing.created_at : createdAt;
+      this.rows.set(key, {
+        key,
+        encrypted_value: encryptedValue,
+        created_at,
+        updated_at: updatedAt,
+      });
+      return { meta: { changes: 1 } };
+    }
+
+    if (QUERY_PATTERNS.DELETE_SECRET.test(normalized)) {
+      const [key] = args as [string];
+      const existed = this.rows.delete(key);
+      return { meta: { changes: existed ? 1 : 0 } };
+    }
+
+    throw new Error(`Unexpected mutation query: ${query}`);
+  }
+
+  async batch(statements: FakePreparedStatement[]) {
+    return statements.map((stmt) => stmt.runSync());
+  }
+}
+
+class FakePreparedStatement {
+  private bound: unknown[] = [];
+
+  constructor(
+    private db: FakeD1Database,
+    private query: string
+  ) {}
+
+  bind(...args: unknown[]) {
+    this.bound = args;
+    return this;
+  }
+
+  async all<T>() {
+    return { results: this.db.all(this.query, this.bound) as T[] };
+  }
+
+  runSync() {
+    return this.db.run(this.query, this.bound);
+  }
+
+  async run() {
+    return this.runSync();
+  }
+}
+
+describe("GlobalSecretsStore", () => {
+  let db: FakeD1Database;
+  let store: GlobalSecretsStore;
+
+  beforeEach(() => {
+    db = new FakeD1Database();
+    store = new GlobalSecretsStore(db as unknown as D1Database, generateEncryptionKey());
+  });
+
+  it("encrypts and decrypts values", async () => {
+    await store.setSecrets({ FOO: "bar" });
+    const secrets = await store.getDecryptedSecrets();
+    expect(secrets).toEqual({ FOO: "bar" });
+  });
+
+  it("normalizes keys and updates existing secrets", async () => {
+    const first = await store.setSecrets({ foo: "one" });
+    expect(first.created).toBe(1);
+    expect(first.updated).toBe(0);
+
+    const second = await store.setSecrets({ FOO: "two" });
+    expect(second.created).toBe(0);
+    expect(second.updated).toBe(1);
+
+    const secrets = await store.getDecryptedSecrets();
+    expect(secrets).toEqual({ FOO: "two" });
+  });
+
+  it("rejects reserved keys", async () => {
+    await expect(store.setSecrets({ PATH: "nope" })).rejects.toBeInstanceOf(SecretsValidationError);
+  });
+
+  it("rejects invalid key patterns", async () => {
+    await expect(store.setSecrets({ "1BAD": "nope" })).rejects.toBeInstanceOf(
+      SecretsValidationError
+    );
+  });
+
+  it("enforces value size limits", async () => {
+    const bigValue = "a".repeat(16385);
+    await expect(store.setSecrets({ BIG: bigValue })).rejects.toBeInstanceOf(
+      SecretsValidationError
+    );
+  });
+
+  it("enforces total size limits", async () => {
+    const largeA = "a".repeat(40000);
+    const largeB = "b".repeat(30000);
+    await expect(store.setSecrets({ A: largeA, B: largeB })).rejects.toBeInstanceOf(
+      SecretsValidationError
+    );
+  });
+
+  it("enforces per-scope secret limit", async () => {
+    const many: Record<string, string> = {};
+    for (let i = 0; i < 50; i++) {
+      many[`KEY_${i}`] = "x";
+    }
+    await store.setSecrets(many);
+
+    await expect(store.setSecrets({ EXTRA: "y" })).rejects.toBeInstanceOf(SecretsValidationError);
+  });
+
+  it("lists keys with metadata", async () => {
+    await store.setSecrets({ ALPHA: "1", BETA: "2" });
+    const keys = await store.listSecretKeys();
+    expect(keys.map((k) => k.key)).toEqual(["ALPHA", "BETA"]);
+    expect(keys[0].createdAt).toBeTypeOf("number");
+  });
+
+  it("deletes secrets by key", async () => {
+    await store.setSecrets({ ALPHA: "1" });
+    const deleted = await store.deleteSecret("alpha");
+    expect(deleted).toBe(true);
+    const secrets = await store.getDecryptedSecrets();
+    expect(secrets).toEqual({});
+  });
+
+  it("returns false when deleting nonexistent key", async () => {
+    const deleted = await store.deleteSecret("NOPE");
+    expect(deleted).toBe(false);
+  });
+});

--- a/packages/control-plane/src/db/global-secrets.ts
+++ b/packages/control-plane/src/db/global-secrets.ts
@@ -1,0 +1,125 @@
+import { encryptToken, decryptToken } from "../auth/crypto";
+import { createLogger } from "../logger";
+import {
+  MAX_TOTAL_VALUE_SIZE,
+  MAX_SECRETS_PER_SCOPE,
+  SecretsValidationError,
+  normalizeKey,
+  validateKey,
+  validateValue,
+} from "./secrets-validation";
+import type { SecretMetadata } from "./secrets-validation";
+
+const log = createLogger("global-secrets");
+
+export class GlobalSecretsStore {
+  constructor(
+    private readonly db: D1Database,
+    private readonly encryptionKey: string
+  ) {}
+
+  async setSecrets(
+    secrets: Record<string, string>
+  ): Promise<{ created: number; updated: number; keys: string[] }> {
+    const now = Date.now();
+
+    const normalized: Record<string, string> = {};
+    let totalValueBytes = 0;
+    for (const [rawKey, value] of Object.entries(secrets)) {
+      const key = normalizeKey(rawKey);
+      validateKey(key);
+      validateValue(value);
+      totalValueBytes += new TextEncoder().encode(value).length;
+      normalized[key] = value;
+    }
+
+    if (totalValueBytes > MAX_TOTAL_VALUE_SIZE) {
+      throw new SecretsValidationError(`Total secret size exceeds ${MAX_TOTAL_VALUE_SIZE} bytes`);
+    }
+
+    const existingKeys = await this.db
+      .prepare("SELECT key FROM global_secrets")
+      .all<{ key: string }>();
+    const existingKeySet = new Set((existingKeys.results || []).map((r) => r.key));
+
+    const incomingKeys = Object.keys(normalized);
+    const netNew = incomingKeys.filter((k) => !existingKeySet.has(k)).length;
+    if (existingKeySet.size + netNew > MAX_SECRETS_PER_SCOPE) {
+      throw new SecretsValidationError(
+        `Global secrets would exceed ${MAX_SECRETS_PER_SCOPE} secrets limit ` +
+          `(current: ${existingKeySet.size}, adding: ${netNew})`
+      );
+    }
+
+    let created = 0;
+    let updated = 0;
+
+    const statements: D1PreparedStatement[] = [];
+    for (const [key, value] of Object.entries(normalized)) {
+      const encrypted = await encryptToken(value, this.encryptionKey);
+      const isNew = !existingKeySet.has(key);
+      if (isNew) created++;
+      else updated++;
+
+      statements.push(
+        this.db
+          .prepare(
+            `INSERT INTO global_secrets (key, encrypted_value, created_at, updated_at)
+             VALUES (?, ?, ?, ?)
+             ON CONFLICT(key) DO UPDATE SET
+               encrypted_value = excluded.encrypted_value,
+               updated_at = excluded.updated_at`
+          )
+          .bind(key, encrypted, now, now)
+      );
+    }
+
+    if (statements.length > 0) {
+      await this.db.batch(statements);
+    }
+
+    return { created, updated, keys: incomingKeys };
+  }
+
+  async listSecretKeys(): Promise<SecretMetadata[]> {
+    const result = await this.db
+      .prepare("SELECT key, created_at, updated_at FROM global_secrets ORDER BY key")
+      .all<{ key: string; created_at: number; updated_at: number }>();
+
+    return (result.results || []).map((row) => ({
+      key: row.key,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
+  }
+
+  async getDecryptedSecrets(): Promise<Record<string, string>> {
+    const result = await this.db
+      .prepare("SELECT key, encrypted_value FROM global_secrets")
+      .all<{ key: string; encrypted_value: string }>();
+
+    const secrets: Record<string, string> = {};
+    for (const row of result.results || []) {
+      try {
+        secrets[row.key] = await decryptToken(row.encrypted_value, this.encryptionKey);
+      } catch (e) {
+        log.error("Failed to decrypt global secret", {
+          key: row.key,
+          error: e instanceof Error ? e.message : String(e),
+        });
+        throw new Error(`Failed to decrypt global secret '${row.key}'`);
+      }
+    }
+
+    return secrets;
+  }
+
+  async deleteSecret(key: string): Promise<boolean> {
+    const result = await this.db
+      .prepare("DELETE FROM global_secrets WHERE key = ?")
+      .bind(normalizeKey(key))
+      .run();
+
+    return (result.meta?.changes ?? 0) > 0;
+  }
+}

--- a/packages/control-plane/test/integration/cleanup.ts
+++ b/packages/control-plane/test/integration/cleanup.ts
@@ -5,5 +5,7 @@ import { env } from "cloudflare:test";
  * isolatedStorage is disabled (see vitest.integration.config.ts).
  */
 export async function cleanD1Tables(): Promise<void> {
-  await env.DB.exec("DELETE FROM sessions; DELETE FROM repo_metadata; DELETE FROM repo_secrets;");
+  await env.DB.exec(
+    "DELETE FROM sessions; DELETE FROM repo_metadata; DELETE FROM repo_secrets; DELETE FROM global_secrets;"
+  );
 }

--- a/packages/control-plane/test/integration/global-secrets.test.ts
+++ b/packages/control-plane/test/integration/global-secrets.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { SELF, env } from "cloudflare:test";
+import { generateInternalToken } from "../../src/auth/internal";
+import { cleanD1Tables } from "./cleanup";
+
+async function authHeaders(): Promise<Record<string, string>> {
+  const token = await generateInternalToken(env.INTERNAL_CALLBACK_SECRET!);
+  return {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+  };
+}
+
+describe("Global secrets API", () => {
+  beforeEach(cleanD1Tables);
+
+  describe("PUT /secrets", () => {
+    it("creates global secrets", async () => {
+      const headers = await authHeaders();
+      const response = await SELF.fetch("https://test.local/secrets", {
+        method: "PUT",
+        headers,
+        body: JSON.stringify({ secrets: { MY_KEY: "my-value" } }),
+      });
+      expect(response.status).toBe(200);
+      const body = await response.json<{ status: string; keys: string[]; created: number }>();
+      expect(body.status).toBe("updated");
+      expect(body.keys).toEqual(["MY_KEY"]);
+      expect(body.created).toBe(1);
+    });
+
+    it("rejects reserved keys", async () => {
+      const headers = await authHeaders();
+      const response = await SELF.fetch("https://test.local/secrets", {
+        method: "PUT",
+        headers,
+        body: JSON.stringify({ secrets: { PATH: "nope" } }),
+      });
+      expect(response.status).toBe(400);
+    });
+
+    it("rejects requests without body", async () => {
+      const headers = await authHeaders();
+      const response = await SELF.fetch("https://test.local/secrets", {
+        method: "PUT",
+        headers,
+        body: JSON.stringify({}),
+      });
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 401 without auth", async () => {
+      const response = await SELF.fetch("https://test.local/secrets", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ secrets: { FOO: "bar" } }),
+      });
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("GET /secrets", () => {
+    it("lists global secret keys", async () => {
+      const headers = await authHeaders();
+
+      // Create secrets first
+      await SELF.fetch("https://test.local/secrets", {
+        method: "PUT",
+        headers,
+        body: JSON.stringify({ secrets: { ALPHA: "1", BETA: "2" } }),
+      });
+
+      const response = await SELF.fetch("https://test.local/secrets", { headers });
+      expect(response.status).toBe(200);
+      const body = await response.json<{ secrets: Array<{ key: string }> }>();
+      expect(body.secrets.map((s) => s.key)).toEqual(["ALPHA", "BETA"]);
+    });
+
+    it("returns empty list when no secrets exist", async () => {
+      const headers = await authHeaders();
+      const response = await SELF.fetch("https://test.local/secrets", { headers });
+      expect(response.status).toBe(200);
+      const body = await response.json<{ secrets: unknown[] }>();
+      expect(body.secrets).toEqual([]);
+    });
+  });
+
+  describe("DELETE /secrets/:key", () => {
+    it("deletes an existing global secret", async () => {
+      const headers = await authHeaders();
+
+      await SELF.fetch("https://test.local/secrets", {
+        method: "PUT",
+        headers,
+        body: JSON.stringify({ secrets: { TO_DELETE: "val" } }),
+      });
+
+      const response = await SELF.fetch("https://test.local/secrets/TO_DELETE", {
+        method: "DELETE",
+        headers,
+      });
+      expect(response.status).toBe(200);
+      const body = await response.json<{ status: string; key: string }>();
+      expect(body.status).toBe("deleted");
+      expect(body.key).toBe("TO_DELETE");
+
+      // Verify it's gone
+      const listRes = await SELF.fetch("https://test.local/secrets", { headers });
+      const listBody = await listRes.json<{ secrets: unknown[] }>();
+      expect(listBody.secrets).toEqual([]);
+    });
+
+    it("returns 404 for nonexistent key", async () => {
+      const headers = await authHeaders();
+      const response = await SELF.fetch("https://test.local/secrets/NOPE", {
+        method: "DELETE",
+        headers,
+      });
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/packages/control-plane/vitest.integration.config.ts
+++ b/packages/control-plane/vitest.integration.config.ts
@@ -1,7 +1,14 @@
 import { defineWorkersConfig, readD1Migrations } from "@cloudflare/vitest-pool-workers/config";
 import path from "path";
+import { webcrypto } from "node:crypto";
 
 const migrationsPath = path.resolve(__dirname, "../../terraform/d1/migrations");
+
+/** Generate a random base64-encoded 32-byte AES key for tests. */
+function generateTestEncryptionKey(): string {
+  const key = webcrypto.getRandomValues(new Uint8Array(32));
+  return Buffer.from(key).toString("base64");
+}
 
 export default defineWorkersConfig(async () => {
   const migrations = await readD1Migrations(migrationsPath);
@@ -27,6 +34,7 @@ export default defineWorkersConfig(async () => {
             bindings: {
               INTERNAL_CALLBACK_SECRET: "test-hmac-secret-for-integration-tests",
               TOKEN_ENCRYPTION_KEY: "test-encryption-key-32chars-long!",
+              REPO_SECRETS_ENCRYPTION_KEY: generateTestEncryptionKey(),
               DEPLOYMENT_NAME: "integration-test",
               MODAL_API_SECRET: "test-modal-api-secret",
               MODAL_WORKSPACE: "test-workspace",

--- a/terraform/d1/migrations/0004_create_global_secrets.sql
+++ b/terraform/d1/migrations/0004_create_global_secrets.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS global_secrets (
+  key             TEXT    NOT NULL PRIMARY KEY,
+  encrypted_value TEXT    NOT NULL,
+  created_at      INTEGER NOT NULL,
+  updated_at      INTEGER NOT NULL
+);


### PR DESCRIPTION
## Summary
- Add `global_secrets` D1 table via migration (`0004_create_global_secrets.sql`)
- Add `GlobalSecretsStore` with encrypted CRUD operations (mirrors `RepoSecretsStore`)
- Add `PUT /secrets`, `GET /secrets`, `DELETE /secrets/:key` API routes
- Unit tests (10) and integration tests (7) with full HMAC auth coverage

## Test plan
- [x] 10 new unit tests pass (`global-secrets.test.ts`)
- [x] 7 new integration tests pass (`global-secrets.test.ts`)
- [x] All existing unit + integration tests still pass
- [x] `npm run typecheck` clean

**PR 2 of 4** in the Global Secrets feature chain. Depends on #92 (merged).