### PR TITLE
fix: send reasoning effort at session creation and store in D1 index

### DIFF
--- a/packages/control-plane/src/db/session-index.test.ts
+++ b/packages/control-plane/src/db/session-index.test.ts
@@ -8,6 +8,7 @@ type SessionRow = {
   repo_owner: string;
   repo_name: string;
   model: string;
+  reasoning_effort: string | null;
   status: string;
   created_at: number;
   updated_at: number;
@@ -77,16 +78,18 @@ class FakeD1Database {
     const normalized = normalizeQuery(query);
 
     if (QUERY_PATTERNS.INSERT_SESSION.test(normalized)) {
-      const [id, title, repoOwner, repoName, model, status, createdAt, updatedAt] = args as [
-        string,
-        string | null,
-        string,
-        string,
-        string,
-        string,
-        number,
-        number,
-      ];
+      const [id, title, repoOwner, repoName, model, reasoningEffort, status, createdAt, updatedAt] =
+        args as [
+          string,
+          string | null,
+          string,
+          string,
+          string,
+          string | null,
+          string,
+          number,
+          number,
+        ];
       // INSERT OR IGNORE — skip if exists
       if (!this.rows.has(id)) {
         this.rows.set(id, {
@@ -95,6 +98,7 @@ class FakeD1Database {
           repo_owner: repoOwner,
           repo_name: repoName,
           model,
+          reasoning_effort: reasoningEffort,
           status,
           created_at: createdAt,
           updated_at: updatedAt,
@@ -190,6 +194,7 @@ function makeSession(overrides: Partial<SessionEntry> = {}): SessionEntry {
     repoOwner: "owner",
     repoName: "repo",
     model: "anthropic/claude-haiku-4-5",
+    reasoningEffort: null,
     status: "created",
     createdAt: 1000,
     updatedAt: 1000,

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -4,6 +4,7 @@ export interface SessionEntry {
   repoOwner: string;
   repoName: string;
   model: string;
+  reasoningEffort: string | null;
   status: string;
   createdAt: number;
   updatedAt: number;
@@ -15,6 +16,7 @@ interface SessionRow {
   repo_owner: string;
   repo_name: string;
   model: string;
+  reasoning_effort: string | null;
   status: string;
   created_at: number;
   updated_at: number;
@@ -42,6 +44,7 @@ function toEntry(row: SessionRow): SessionEntry {
     repoOwner: row.repo_owner,
     repoName: row.repo_name,
     model: row.model,
+    reasoningEffort: row.reasoning_effort,
     status: row.status,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
@@ -54,8 +57,8 @@ export class SessionIndexStore {
   async create(session: SessionEntry): Promise<void> {
     await this.db
       .prepare(
-        `INSERT OR IGNORE INTO sessions (id, title, repo_owner, repo_name, model, status, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+        `INSERT OR IGNORE INTO sessions (id, title, repo_owner, repo_name, model, reasoning_effort, status, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .bind(
         session.id,
@@ -63,6 +66,7 @@ export class SessionIndexStore {
         session.repoOwner.toLowerCase(),
         session.repoName.toLowerCase(),
         session.model,
+        session.reasoningEffort,
         session.status,
         session.createdAt,
         session.updatedAt

--- a/packages/control-plane/test/integration/d1-session-index.test.ts
+++ b/packages/control-plane/test/integration/d1-session-index.test.ts
@@ -16,6 +16,7 @@ describe("D1 SessionIndexStore", () => {
       repoOwner: "acme",
       repoName: "web-app",
       model: "anthropic/claude-haiku-4-5",
+      reasoningEffort: "max",
       status: "created",
       createdAt: now,
       updatedAt: now,
@@ -27,6 +28,7 @@ describe("D1 SessionIndexStore", () => {
     expect(session!.title).toBe("Test Session");
     expect(session!.repoOwner).toBe("acme");
     expect(session!.repoName).toBe("web-app");
+    expect(session!.reasoningEffort).toBe("max");
     expect(session!.status).toBe("created");
   });
 
@@ -40,6 +42,7 @@ describe("D1 SessionIndexStore", () => {
       repoOwner: "acme",
       repoName: "api",
       model: "anthropic/claude-haiku-4-5",
+      reasoningEffort: null,
       status: "active",
       createdAt: now,
       updatedAt: now,
@@ -51,6 +54,7 @@ describe("D1 SessionIndexStore", () => {
       repoOwner: "acme",
       repoName: "api",
       model: "anthropic/claude-haiku-4-5",
+      reasoningEffort: null,
       status: "completed",
       createdAt: now - 1000,
       updatedAt: now - 1000,
@@ -64,6 +68,50 @@ describe("D1 SessionIndexStore", () => {
     expect(allResult.total).toBe(2);
   });
 
+  it("stores and returns reasoning effort", async () => {
+    const store = new SessionIndexStore(env.DB);
+    const now = Date.now();
+
+    await store.create({
+      id: "session-with-effort",
+      title: null,
+      repoOwner: "acme",
+      repoName: "api",
+      model: "anthropic/claude-sonnet-4-5",
+      reasoningEffort: "high",
+      status: "created",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const session = await store.get("session-with-effort");
+    expect(session!.reasoningEffort).toBe("high");
+
+    const result = await store.list({});
+    const listed = result.sessions.find((s) => s.id === "session-with-effort");
+    expect(listed!.reasoningEffort).toBe("high");
+  });
+
+  it("stores null reasoning effort when not provided", async () => {
+    const store = new SessionIndexStore(env.DB);
+    const now = Date.now();
+
+    await store.create({
+      id: "session-no-effort",
+      title: null,
+      repoOwner: "acme",
+      repoName: "api",
+      model: "anthropic/claude-haiku-4-5",
+      reasoningEffort: null,
+      status: "created",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const session = await store.get("session-no-effort");
+    expect(session!.reasoningEffort).toBeNull();
+  });
+
   it("deletes a session", async () => {
     const store = new SessionIndexStore(env.DB);
     const now = Date.now();
@@ -74,6 +122,7 @@ describe("D1 SessionIndexStore", () => {
       repoOwner: "acme",
       repoName: "web-app",
       model: "anthropic/claude-haiku-4-5",
+      reasoningEffort: null,
       status: "created",
       createdAt: now,
       updatedAt: now,

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -95,6 +95,7 @@ export default function Home() {
             repoOwner: owner,
             repoName: name,
             model: selectedModel,
+            reasoningEffort,
           }),
           signal: abortController.signal,
         });
@@ -128,7 +129,7 @@ export default function Home() {
 
     sessionCreationPromise.current = promise;
     return promise;
-  }, [selectedRepo, selectedModel, pendingSessionId]);
+  }, [selectedRepo, selectedModel, reasoningEffort, pendingSessionId]);
 
   const handleModelChange = useCallback((model: string) => {
     setSelectedModel(model);

--- a/terraform/d1/migrations/0005_add_reasoning_effort_to_sessions.sql
+++ b/terraform/d1/migrations/0005_add_reasoning_effort_to_sessions.sql
@@ -1,0 +1,3 @@
+-- Add reasoning_effort to session index for consistency with model field.
+-- Both are session-level defaults that can be overridden per-message.
+ALTER TABLE sessions ADD COLUMN reasoning_effort TEXT;


### PR DESCRIPTION
## Summary

- **Homepage bug**: `createSessionForWarming()` was not including `reasoningEffort` in the POST body, so the session-level default was always `null`. The session page would fall back to the model default instead of the user's selection (e.g., user picks "xhigh" but sees "high").
- **D1 session index**: Added `reasoning_effort` column to the D1 `sessions` table for consistency with `model` — both are session-level defaults that can be overridden per-message.
- **Router cleanup**: Hoisted model/reasoning-effort validation above the DO init call to avoid duplicate `getValidModelOrDefault()` computation.

## Changes

| File | Change |
|------|--------|
| `packages/web/src/app/page.tsx` | Add `reasoningEffort` to session creation body + `useCallback` deps |
| `packages/control-plane/src/db/session-index.ts` | Add `reasoningEffort` to `SessionEntry`, `SessionRow`, `toEntry()`, `create()` |
| `packages/control-plane/src/router.ts` | Validate + pass `reasoningEffort` to D1 index; hoist model validation |
| `terraform/d1/migrations/0005_add_reasoning_effort_to_sessions.sql` | `ALTER TABLE sessions ADD COLUMN reasoning_effort TEXT` |
| `packages/control-plane/src/db/session-index.test.ts` | Update fake D1 and fixtures for new column |
| `packages/control-plane/test/integration/d1-session-index.test.ts` | Add reasoning effort test cases |

## Test plan

- [x] 409 unit tests pass
- [x] 85 integration tests pass (including new D1 reasoning effort tests)
- [ ] Manual: select non-default reasoning effort on homepage → verify session page shows correct value