### PR TITLE
fix: use uv sync in setup script for modal-infra deps

### DIFF
--- a/.openinspect/setup.sh
+++ b/.openinspect/setup.sh
@@ -76,6 +76,19 @@ setup_python() {
     return
   fi
 
+  if command -v uv &>/dev/null; then
+    info "Syncing Python dependencies with uv.lock…"
+    (
+      cd "$MODAL_DIR"
+      uv sync --frozen --extra dev
+    )
+    info "Python environment ready (activate with: source packages/modal-infra/.venv/bin/activate)"
+    return
+  fi
+
+  warn "uv not found — falling back to pip editable install."
+  warn "Install uv for lockfile-reproducible Python environments."
+
   if [ ! -d "$MODAL_DIR/.venv" ]; then
     info "Creating virtualenv at packages/modal-infra/.venv…"
     python3 -m venv "$MODAL_DIR/.venv"


### PR DESCRIPTION
## Summary
- update `.openinspect/setup.sh` to prefer `uv sync --frozen --extra dev` for `packages/modal-infra` so setup follows `uv.lock`
- keep a safe fallback to the previous `pip install -e "...[dev]"` flow when `uv` is unavailable
- add clear warnings in fallback mode so contributors know why lockfile drift can still happen

## Why
The setup script previously installed Python dependencies with pip editable mode, which does not enforce `uv.lock` and led to environment drift. Using `uv sync --frozen` makes onboarding reproducible and keeps modal-infra tooling versions aligned with the lockfile.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/2309eff13671b25a367fc5cd4acd8f12)*