### PR TITLE
docs: add missing reactions:write Slack bot scope

### DIFF
--- a/.claude/skills/onboarding/SKILL.md
+++ b/.claude/skills/onboarding/SKILL.md
@@ -146,7 +146,7 @@ Guide user:
 
 1. https://api.slack.com/apps → "Create New App" → "From scratch"
 2. OAuth & Permissions → Add scopes: `app_mentions:read`, `chat:write`, `channels:history`,
-   `channels:read`, `groups:history`, `groups:read`
+   `channels:read`, `groups:history`, `groups:read`, `reactions:write`
 3. Install to Workspace, note **Bot Token** (`xoxb-...`)
 4. Basic Information → note **Signing Secret**
 5. **App Home and Event Subscriptions configured AFTER deployment** (worker must be running for URL

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -200,6 +200,7 @@ Skip this step if you don't need Slack integration.
    - `channels:read`
    - `groups:history`
    - `groups:read`
+   - `reactions:write`
 3. Click **"Install to Workspace"**
 4. Note the **Bot Token** (`xoxb-...`)
 


### PR DESCRIPTION
## Summary
- Added `reactions:write` to the required Slack Bot Token Scopes in `docs/GETTING_STARTED.md` and `.claude/skills/onboarding/SKILL.md`
- The slack bot uses `reactions.add`/`reactions.remove` APIs (added in #104) to show an eyes emoji while processing thread replies, but `reactions:write` was not listed in the setup documentation

## Test plan
- [ ] Verify the GETTING_STARTED.md scopes list now includes `reactions:write`
- [ ] Verify the onboarding skill scopes list now includes `reactions:write`