### PR TITLE
Refactor OpenAI token refresh into dedicated session service

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -12,11 +12,6 @@ import { initSchema } from "./schema";
 import { generateId, decryptToken, encryptToken, hashToken } from "../auth/crypto";
 import { getGitHubAppConfig, getInstallationRepository } from "../auth/github-app";
 import { refreshAccessToken } from "../auth/github";
-import {
-  refreshOpenAIToken,
-  extractOpenAIAccountId,
-  OpenAITokenRefreshError,
-} from "../auth/openai";
 import { createModalClient } from "../sandbox/client";
 import { createModalProvider } from "../sandbox/providers/modal-provider";
 import { createLogger, parseLogLevel } from "../logger";
@@ -63,6 +58,7 @@ import { SessionPullRequestService } from "./pull-request-service";
 import { RepoSecretsStore } from "../db/repo-secrets";
 import { GlobalSecretsStore } from "../db/global-secrets";
 import { mergeSecrets } from "../db/secrets-validation";
+import { OpenAITokenRefreshService } from "./openai-token-refresh-service";
 
 /**
  * Build GitHub avatar URL from login.
@@ -1627,194 +1623,41 @@ export class SessionDO extends DurableObject<Env> {
   private async handleOpenAITokenRefresh(): Promise<Response> {
     const session = this.getSession();
     if (!session) {
-      return new Response(JSON.stringify({ error: "No session" }), {
-        status: 404,
-        headers: { "Content-Type": "application/json" },
-      });
+      return this.openAIRefreshJsonResponse({ error: "No session" }, 404);
     }
 
     const encryptionKey = this.env.REPO_SECRETS_ENCRYPTION_KEY;
     if (!this.env.DB || !encryptionKey) {
-      return new Response(JSON.stringify({ error: "Secrets not configured" }), {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      });
+      return this.openAIRefreshJsonResponse({ error: "Secrets not configured" }, 500);
     }
 
-    const db = this.env.DB;
+    const service = new OpenAITokenRefreshService(
+      this.env.DB,
+      encryptionKey,
+      (sessionRow) => this.ensureRepoId(sessionRow),
+      this.log
+    );
 
-    const REFRESH_BUFFER_MS = 5 * 60 * 1000;
-
-    type TokenState =
-      | { type: "cached"; accessToken: string; expiresIn: number; accountId?: string }
-      | { type: "refresh"; refreshToken: string; source: "repo" | "global"; repoId: number };
-
-    const checkSecrets = (
-      secrets: Record<string, string>,
-      source: "repo" | "global",
-      repoId: number
-    ): TokenState | null => {
-      if (!secrets.OPENAI_OAUTH_REFRESH_TOKEN) return null;
-      const cachedToken = secrets.OPENAI_OAUTH_ACCESS_TOKEN;
-      const expiresAt = parseInt(secrets.OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT || "0");
-      const now = Date.now();
-      if (cachedToken && expiresAt - now > REFRESH_BUFFER_MS) {
-        return {
-          type: "cached",
-          accessToken: cachedToken,
-          expiresIn: Math.floor((expiresAt - now) / 1000),
-          accountId: secrets.OPENAI_OAUTH_ACCOUNT_ID,
-        };
-      }
-      return { type: "refresh", refreshToken: secrets.OPENAI_OAUTH_REFRESH_TOKEN, source, repoId };
-    };
-
-    const readTokenState = async (): Promise<TokenState | null> => {
-      const repoId = await this.ensureRepoId(session);
-      const repoStore = new RepoSecretsStore(db, encryptionKey);
-      const repoSecrets = await repoStore.getDecryptedSecrets(repoId);
-      const repoResult = checkSecrets(repoSecrets, "repo", repoId);
-      if (repoResult) return repoResult;
-
-      const globalStore = new GlobalSecretsStore(db, encryptionKey);
-      const globalSecrets = await globalStore.getDecryptedSecrets();
-      return checkSecrets(globalSecrets, "global", repoId);
-    };
-
-    let tokenState: Awaited<ReturnType<typeof readTokenState>>;
-    try {
-      tokenState = await readTokenState();
-    } catch (e) {
-      this.log.error("Failed to read OpenAI token state from secrets", {
-        error: e instanceof Error ? e.message : String(e),
-      });
-      return new Response(JSON.stringify({ error: "Failed to read token state" }), {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      });
+    const result = await service.refresh(session);
+    if (!result.ok) {
+      return this.openAIRefreshJsonResponse({ error: result.error }, result.status);
     }
 
-    if (!tokenState) {
-      return new Response(JSON.stringify({ error: "OPENAI_OAUTH_REFRESH_TOKEN not configured" }), {
-        status: 404,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
+    return this.openAIRefreshJsonResponse(
+      {
+        access_token: result.accessToken,
+        expires_in: result.expiresIn,
+        account_id: result.accountId,
+      },
+      200
+    );
+  }
 
-    // Return cached access token if still valid (another DO may have recently refreshed)
-    if (tokenState.type === "cached") {
-      return new Response(
-        JSON.stringify({
-          access_token: tokenState.accessToken,
-          expires_in: tokenState.expiresIn,
-          account_id: tokenState.accountId,
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      );
-    }
-
-    const attemptRefresh = async (
-      refreshToken: string,
-      info: { repoId: number; source: "repo" | "global" }
-    ): Promise<Response> => {
-      const tokens = await refreshOpenAIToken(refreshToken);
-      const accountId = extractOpenAIAccountId(tokens);
-      const expiresAt = Date.now() + (tokens.expires_in ?? 3600) * 1000;
-
-      // Store rotated refresh token + cached access token back to the same store
-      try {
-        const secretsToWrite: Record<string, string> = {
-          OPENAI_OAUTH_REFRESH_TOKEN: tokens.refresh_token,
-          OPENAI_OAUTH_ACCESS_TOKEN: tokens.access_token,
-          OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(expiresAt),
-        };
-        if (accountId) {
-          secretsToWrite.OPENAI_OAUTH_ACCOUNT_ID = accountId;
-        }
-        if (info.source === "repo") {
-          const repoStore = new RepoSecretsStore(db, encryptionKey);
-          await repoStore.setSecrets(
-            info.repoId,
-            session.repo_owner,
-            session.repo_name,
-            secretsToWrite
-          );
-        } else {
-          const globalStore = new GlobalSecretsStore(db, encryptionKey);
-          await globalStore.setSecrets(secretsToWrite);
-        }
-        this.log.info("OpenAI tokens rotated and cached", {
-          source: info.source,
-          has_account_id: !!accountId,
-        });
-      } catch (e) {
-        // Access token is still valid for this session even if we fail to persist
-        this.log.error("Failed to store rotated OpenAI tokens", {
-          error: e instanceof Error ? e.message : String(e),
-        });
-      }
-
-      return new Response(
-        JSON.stringify({
-          access_token: tokens.access_token,
-          expires_in: tokens.expires_in,
-          account_id: accountId,
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      );
-    };
-
-    try {
-      return await attemptRefresh(tokenState.refreshToken, tokenState);
-    } catch (e) {
-      if (e instanceof OpenAITokenRefreshError && e.status === 401) {
-        // Race condition: another DO may have already rotated the token.
-        // Wait briefly, re-read from D1 — the winner's cached access token should be available.
-        this.log.warn("OpenAI refresh got 401, checking for concurrent rotation", {
-          source: tokenState.source,
-        });
-
-        await new Promise((resolve) => setTimeout(resolve, 500));
-
-        try {
-          const reread = await readTokenState();
-          // Another DO already refreshed and cached the access token — use it
-          if (reread?.type === "cached") {
-            this.log.info("Using cached access token from concurrent rotation");
-            return new Response(
-              JSON.stringify({
-                access_token: reread.accessToken,
-                expires_in: reread.expiresIn,
-                account_id: reread.accountId,
-              }),
-              { status: 200, headers: { "Content-Type": "application/json" } }
-            );
-          }
-          // Refresh token changed but no cached access token yet — retry the refresh
-          if (reread?.type === "refresh" && reread.refreshToken !== tokenState.refreshToken) {
-            this.log.info("Detected concurrent token rotation, retrying");
-            return await attemptRefresh(reread.refreshToken, reread);
-          }
-        } catch (retryErr) {
-          this.log.error("Retry after 401 also failed", {
-            error: retryErr instanceof Error ? retryErr.message : String(retryErr),
-          });
-        }
-
-        return new Response(
-          JSON.stringify({ error: "OpenAI token refresh failed: unauthorized" }),
-          { status: 401, headers: { "Content-Type": "application/json" } }
-        );
-      }
-
-      this.log.error("OpenAI token refresh failed", {
-        error: e instanceof Error ? e.message : String(e),
-      });
-      return new Response(JSON.stringify({ error: "OpenAI token refresh failed" }), {
-        status: 502,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
+  private openAIRefreshJsonResponse(body: unknown, status: number): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
   }
 
   private getMessageCount(): number {

--- a/packages/control-plane/src/session/openai-token-refresh-service.test.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Logger } from "../logger";
+import type { Env } from "../types";
+import type { SessionRow } from "./types";
+import { OpenAITokenRefreshService } from "./openai-token-refresh-service";
+import { OpenAITokenRefreshError } from "../auth/openai";
+
+const mockState = vi.hoisted(() => ({
+  repoSecrets: new Map<number, Record<string, string>>(),
+  globalSecrets: {} as Record<string, string>,
+  refreshImpl: vi.fn(),
+  repoWrites: [] as Array<{
+    repoId: number;
+    owner: string;
+    name: string;
+    secrets: Record<string, string>;
+  }>,
+  globalWrites: [] as Array<Record<string, string>>,
+}));
+
+vi.mock("../auth/openai", () => {
+  class MockOpenAITokenRefreshError extends Error {
+    status: number;
+    body: string;
+    constructor(message: string, status: number, body: string) {
+      super(message);
+      this.status = status;
+      this.body = body;
+    }
+  }
+
+  return {
+    OpenAITokenRefreshError: MockOpenAITokenRefreshError,
+    refreshOpenAIToken: (refreshToken: string) => mockState.refreshImpl(refreshToken),
+    extractOpenAIAccountId: (tokens: { account_id?: string }) => tokens.account_id,
+  };
+});
+
+vi.mock("../db/repo-secrets", () => ({
+  RepoSecretsStore: class {
+    async getDecryptedSecrets(repoId: number): Promise<Record<string, string>> {
+      return mockState.repoSecrets.get(repoId) ?? {};
+    }
+
+    async setSecrets(
+      repoId: number,
+      owner: string,
+      name: string,
+      secrets: Record<string, string>
+    ): Promise<void> {
+      mockState.repoWrites.push({ repoId, owner, name, secrets });
+      const existing = mockState.repoSecrets.get(repoId) ?? {};
+      mockState.repoSecrets.set(repoId, { ...existing, ...secrets });
+    }
+  },
+}));
+
+vi.mock("../db/global-secrets", () => ({
+  GlobalSecretsStore: class {
+    async getDecryptedSecrets(): Promise<Record<string, string>> {
+      return mockState.globalSecrets;
+    }
+
+    async setSecrets(secrets: Record<string, string>): Promise<void> {
+      mockState.globalWrites.push(secrets);
+      mockState.globalSecrets = { ...mockState.globalSecrets, ...secrets };
+    }
+  },
+}));
+
+function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
+  return {
+    id: "session-1",
+    session_name: "session-name-1",
+    title: null,
+    repo_owner: "acme",
+    repo_name: "web",
+    repo_id: 123,
+    repo_default_branch: "main",
+    branch_name: null,
+    base_sha: null,
+    current_sha: null,
+    opencode_session_id: null,
+    model: "openai/gpt-5.1",
+    reasoning_effort: null,
+    status: "active",
+    created_at: 1,
+    updated_at: 1,
+    ...overrides,
+  };
+}
+
+function createLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(() => createLogger()),
+  };
+}
+
+describe("OpenAITokenRefreshService", () => {
+  beforeEach(() => {
+    mockState.repoSecrets.clear();
+    mockState.globalSecrets = {};
+    mockState.repoWrites = [];
+    mockState.globalWrites = [];
+    mockState.refreshImpl.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns cached repo access token when it is still valid", async () => {
+    const repoId = 123;
+    mockState.repoSecrets.set(repoId, {
+      OPENAI_OAUTH_REFRESH_TOKEN: "refresh-1",
+      OPENAI_OAUTH_ACCESS_TOKEN: "cached-access",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 15 * 60 * 1000),
+      OPENAI_OAUTH_ACCOUNT_ID: "acct_cached",
+    });
+
+    const service = new OpenAITokenRefreshService(
+      {} as Env["DB"],
+      "enc-key",
+      async () => repoId,
+      createLogger()
+    );
+
+    const result = await service.refresh(createSession());
+
+    expect(result).toEqual({
+      ok: true,
+      accessToken: "cached-access",
+      expiresIn: expect.any(Number),
+      accountId: "acct_cached",
+    });
+    expect(mockState.refreshImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when refresh token is missing in repo and global secrets", async () => {
+    const service = new OpenAITokenRefreshService(
+      {} as Env["DB"],
+      "enc-key",
+      async () => 123,
+      createLogger()
+    );
+
+    const result = await service.refresh(createSession());
+
+    expect(result).toEqual({
+      ok: false,
+      status: 404,
+      error: "OPENAI_OAUTH_REFRESH_TOKEN not configured",
+    });
+  });
+
+  it("refreshes token and persists rotated credentials to repo secrets", async () => {
+    const repoId = 123;
+    mockState.repoSecrets.set(repoId, {
+      OPENAI_OAUTH_REFRESH_TOKEN: "refresh-old",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    });
+    mockState.refreshImpl.mockResolvedValue({
+      access_token: "access-new",
+      refresh_token: "refresh-new",
+      expires_in: 1800,
+      account_id: "acct_new",
+    });
+
+    const service = new OpenAITokenRefreshService(
+      {} as Env["DB"],
+      "enc-key",
+      async () => repoId,
+      createLogger()
+    );
+
+    const result = await service.refresh(createSession());
+
+    expect(result).toEqual({
+      ok: true,
+      accessToken: "access-new",
+      expiresIn: 1800,
+      accountId: "acct_new",
+    });
+    expect(mockState.refreshImpl).toHaveBeenCalledWith("refresh-old");
+    expect(mockState.repoWrites).toHaveLength(1);
+    expect(mockState.repoWrites[0].repoId).toBe(repoId);
+    expect(mockState.repoWrites[0].owner).toBe("acme");
+    expect(mockState.repoWrites[0].name).toBe("web");
+    expect(mockState.repoWrites[0].secrets.OPENAI_OAUTH_REFRESH_TOKEN).toBe("refresh-new");
+    expect(mockState.repoWrites[0].secrets.OPENAI_OAUTH_ACCESS_TOKEN).toBe("access-new");
+  });
+
+  it("uses cached token after concurrent rotation when refresh gets 401", async () => {
+    vi.useFakeTimers();
+
+    const repoId = 123;
+    mockState.repoSecrets.set(repoId, {
+      OPENAI_OAUTH_REFRESH_TOKEN: "refresh-stale",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    });
+
+    mockState.refreshImpl.mockImplementationOnce(async () => {
+      mockState.repoSecrets.set(repoId, {
+        OPENAI_OAUTH_REFRESH_TOKEN: "refresh-rotated",
+        OPENAI_OAUTH_ACCESS_TOKEN: "access-concurrent",
+        OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 60 * 60 * 1000),
+        OPENAI_OAUTH_ACCOUNT_ID: "acct_concurrent",
+      });
+      throw new OpenAITokenRefreshError("unauthorized", 401, "unauthorized");
+    });
+
+    const service = new OpenAITokenRefreshService(
+      {} as Env["DB"],
+      "enc-key",
+      async () => repoId,
+      createLogger()
+    );
+
+    const promise = service.refresh(createSession());
+    await vi.advanceTimersByTimeAsync(500);
+    const result = await promise;
+
+    expect(result).toEqual({
+      ok: true,
+      accessToken: "access-concurrent",
+      expiresIn: expect.any(Number),
+      accountId: "acct_concurrent",
+    });
+    expect(mockState.refreshImpl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/control-plane/src/session/openai-token-refresh-service.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.ts
@@ -1,0 +1,201 @@
+import {
+  refreshOpenAIToken,
+  extractOpenAIAccountId,
+  OpenAITokenRefreshError,
+} from "../auth/openai";
+import { GlobalSecretsStore } from "../db/global-secrets";
+import { RepoSecretsStore } from "../db/repo-secrets";
+import type { Env } from "../types";
+import type { Logger } from "../logger";
+import type { SessionRow } from "./types";
+
+const OPENAI_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
+type OpenAITokenState =
+  | { type: "cached"; accessToken: string; expiresIn: number; accountId?: string }
+  | { type: "refresh"; refreshToken: string; source: "repo" | "global"; repoId: number };
+
+export type OpenAITokenRefreshResult =
+  | { ok: true; accessToken: string; expiresIn?: number; accountId?: string }
+  | { ok: false; status: number; error: string };
+
+export class OpenAITokenRefreshService {
+  constructor(
+    private readonly db: Env["DB"],
+    private readonly encryptionKey: string,
+    private readonly ensureRepoId: (session: SessionRow) => Promise<number>,
+    private readonly log: Logger
+  ) {}
+
+  async refresh(session: SessionRow): Promise<OpenAITokenRefreshResult> {
+    const readTokenState = () => this.readTokenState(session);
+
+    let tokenState: OpenAITokenState | null;
+    try {
+      tokenState = await readTokenState();
+    } catch (e) {
+      this.log.error("Failed to read OpenAI token state from secrets", {
+        error: e instanceof Error ? e.message : String(e),
+      });
+      return { ok: false, status: 500, error: "Failed to read token state" };
+    }
+
+    if (!tokenState) {
+      return { ok: false, status: 404, error: "OPENAI_OAUTH_REFRESH_TOKEN not configured" };
+    }
+
+    if (tokenState.type === "cached") {
+      return {
+        ok: true,
+        accessToken: tokenState.accessToken,
+        expiresIn: tokenState.expiresIn,
+        accountId: tokenState.accountId,
+      };
+    }
+
+    try {
+      return await this.attemptRefresh(tokenState, session);
+    } catch (e) {
+      if (e instanceof OpenAITokenRefreshError && e.status === 401) {
+        return this.handleUnauthorizedRefresh(tokenState, readTokenState, session);
+      }
+
+      this.log.error("OpenAI token refresh failed", {
+        error: e instanceof Error ? e.message : String(e),
+      });
+      return { ok: false, status: 502, error: "OpenAI token refresh failed" };
+    }
+  }
+
+  private getTokenStateFromSecrets(
+    secrets: Record<string, string>,
+    source: "repo" | "global",
+    repoId: number
+  ): OpenAITokenState | null {
+    if (!secrets.OPENAI_OAUTH_REFRESH_TOKEN) {
+      return null;
+    }
+
+    const cachedToken = secrets.OPENAI_OAUTH_ACCESS_TOKEN;
+    const expiresAt = parseInt(secrets.OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT || "0", 10);
+    const now = Date.now();
+
+    if (cachedToken && expiresAt - now > OPENAI_TOKEN_REFRESH_BUFFER_MS) {
+      return {
+        type: "cached",
+        accessToken: cachedToken,
+        expiresIn: Math.floor((expiresAt - now) / 1000),
+        accountId: secrets.OPENAI_OAUTH_ACCOUNT_ID,
+      };
+    }
+
+    return {
+      type: "refresh",
+      refreshToken: secrets.OPENAI_OAUTH_REFRESH_TOKEN,
+      source,
+      repoId,
+    };
+  }
+
+  private async readTokenState(session: SessionRow): Promise<OpenAITokenState | null> {
+    const repoId = await this.ensureRepoId(session);
+
+    const repoStore = new RepoSecretsStore(this.db, this.encryptionKey);
+    const repoSecrets = await repoStore.getDecryptedSecrets(repoId);
+    const repoState = this.getTokenStateFromSecrets(repoSecrets, "repo", repoId);
+    if (repoState) {
+      return repoState;
+    }
+
+    const globalStore = new GlobalSecretsStore(this.db, this.encryptionKey);
+    const globalSecrets = await globalStore.getDecryptedSecrets();
+    return this.getTokenStateFromSecrets(globalSecrets, "global", repoId);
+  }
+
+  private async attemptRefresh(
+    tokenState: Extract<OpenAITokenState, { type: "refresh" }>,
+    session: SessionRow
+  ): Promise<OpenAITokenRefreshResult> {
+    const tokens = await refreshOpenAIToken(tokenState.refreshToken);
+    const accountId = extractOpenAIAccountId(tokens);
+    const expiresAt = Date.now() + (tokens.expires_in ?? 3600) * 1000;
+
+    try {
+      const secretsToWrite: Record<string, string> = {
+        OPENAI_OAUTH_REFRESH_TOKEN: tokens.refresh_token,
+        OPENAI_OAUTH_ACCESS_TOKEN: tokens.access_token,
+        OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(expiresAt),
+      };
+
+      if (accountId) {
+        secretsToWrite.OPENAI_OAUTH_ACCOUNT_ID = accountId;
+      }
+
+      if (tokenState.source === "repo") {
+        const repoStore = new RepoSecretsStore(this.db, this.encryptionKey);
+        await repoStore.setSecrets(
+          tokenState.repoId,
+          session.repo_owner,
+          session.repo_name,
+          secretsToWrite
+        );
+      } else {
+        const globalStore = new GlobalSecretsStore(this.db, this.encryptionKey);
+        await globalStore.setSecrets(secretsToWrite);
+      }
+
+      this.log.info("OpenAI tokens rotated and cached", {
+        source: tokenState.source,
+        has_account_id: !!accountId,
+      });
+    } catch (e) {
+      this.log.error("Failed to store rotated OpenAI tokens", {
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+
+    return {
+      ok: true,
+      accessToken: tokens.access_token,
+      expiresIn: tokens.expires_in,
+      accountId,
+    };
+  }
+
+  private async handleUnauthorizedRefresh(
+    tokenState: Extract<OpenAITokenState, { type: "refresh" }>,
+    readTokenState: () => Promise<OpenAITokenState | null>,
+    session: SessionRow
+  ): Promise<OpenAITokenRefreshResult> {
+    this.log.warn("OpenAI refresh got 401, checking for concurrent rotation", {
+      source: tokenState.source,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    try {
+      const reread = await readTokenState();
+
+      if (reread?.type === "cached") {
+        this.log.info("Using cached access token from concurrent rotation");
+        return {
+          ok: true,
+          accessToken: reread.accessToken,
+          expiresIn: reread.expiresIn,
+          accountId: reread.accountId,
+        };
+      }
+
+      if (reread?.type === "refresh" && reread.refreshToken !== tokenState.refreshToken) {
+        this.log.info("Detected concurrent token rotation, retrying");
+        return this.attemptRefresh(reread, session);
+      }
+    } catch (retryErr) {
+      this.log.error("Retry after 401 also failed", {
+        error: retryErr instanceof Error ? retryErr.message : String(retryErr),
+      });
+    }
+
+    return { ok: false, status: 401, error: "OpenAI token refresh failed: unauthorized" };
+  }
+}


### PR DESCRIPTION
## Summary
- extract OpenAI OAuth refresh logic from `SessionDO.handleOpenAITokenRefresh` into a focused `OpenAITokenRefreshService`
- keep the DO handler thin by delegating refresh orchestration and mapping typed service results into HTTP JSON responses
- add unit tests for cached-token, missing-token, refresh-and-persist, and concurrent-rotation (401 retry) paths

## Testing
- `pnpm run typecheck` (packages/control-plane)
- `pnpm exec vitest run src/session/openai-token-refresh-service.test.ts`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/3819a1df278f6cc3d597f4a409183f6c)*