### PR TITLE
feat: add GPT 5.3 Codex Spark model support

### DIFF
--- a/packages/control-plane/src/utils/models.test.ts
+++ b/packages/control-plane/src/utils/models.test.ts
@@ -37,6 +37,7 @@ describe("model utilities", () => {
       expect(isValidModel("openai/gpt-5.2")).toBe(true);
       expect(isValidModel("openai/gpt-5.2-codex")).toBe(true);
       expect(isValidModel("openai/gpt-5.3-codex")).toBe(true);
+      expect(isValidModel("openai/gpt-5.3-codex-spark")).toBe(true);
     });
 
     it("returns false for invalid models", () => {
@@ -101,6 +102,11 @@ describe("model utilities", () => {
       expect(extractProviderAndModel("openai/gpt-5.3-codex")).toEqual({
         provider: "openai",
         model: "gpt-5.3-codex",
+      });
+
+      expect(extractProviderAndModel("openai/gpt-5.3-codex-spark")).toEqual({
+        provider: "openai",
+        model: "gpt-5.3-codex-spark",
       });
     });
 
@@ -225,6 +231,7 @@ describe("model utilities", () => {
       expect(supportsReasoning("openai/gpt-5.2")).toBe(true);
       expect(supportsReasoning("openai/gpt-5.2-codex")).toBe(true);
       expect(supportsReasoning("openai/gpt-5.3-codex")).toBe(true);
+      expect(supportsReasoning("openai/gpt-5.3-codex-spark")).toBe(true);
     });
 
     it("returns false for invalid models", () => {
@@ -252,6 +259,7 @@ describe("model utilities", () => {
     it("returns high for OpenAI codex models", () => {
       expect(getDefaultReasoningEffort("openai/gpt-5.2-codex")).toBe("high");
       expect(getDefaultReasoningEffort("openai/gpt-5.3-codex")).toBe("high");
+      expect(getDefaultReasoningEffort("openai/gpt-5.3-codex-spark")).toBe("high");
     });
 
     it("returns undefined for GPT 5.2 (no default)", () => {
@@ -345,6 +353,7 @@ describe("model utilities", () => {
     it("returns false for max on OpenAI models (Anthropic-only)", () => {
       expect(isValidReasoningEffort("openai/gpt-5.2-codex", "max")).toBe(false);
       expect(isValidReasoningEffort("openai/gpt-5.3-codex", "max")).toBe(false);
+      expect(isValidReasoningEffort("openai/gpt-5.3-codex-spark", "max")).toBe(false);
       expect(isValidReasoningEffort("openai/gpt-5.2", "max")).toBe(false);
     });
 
@@ -382,6 +391,7 @@ describe("model utilities", () => {
       expect(normalizeModelId("openai/gpt-5.2")).toBe("openai/gpt-5.2");
       expect(normalizeModelId("openai/gpt-5.2-codex")).toBe("openai/gpt-5.2-codex");
       expect(normalizeModelId("openai/gpt-5.3-codex")).toBe("openai/gpt-5.3-codex");
+      expect(normalizeModelId("openai/gpt-5.3-codex-spark")).toBe("openai/gpt-5.3-codex-spark");
     });
 
     it("passes through unknown models without prefix", () => {

--- a/packages/modal-infra/src/sandbox/codex-auth-plugin.ts
+++ b/packages/modal-infra/src/sandbox/codex-auth-plugin.ts
@@ -21,6 +21,7 @@ const ALLOWED_MODELS = new Set([
   "gpt-5.2",
   "gpt-5.2-codex",
   "gpt-5.3-codex",
+  "gpt-5.3-codex-spark",
   "gpt-5.1-codex",
 ])
 
@@ -137,10 +138,23 @@ export const CodexAuthProxy: Plugin = async (input) => {
           }
         }
 
-        // Inject gpt-5.3-codex if missing
+        // Inject GPT 5.3 Codex models if missing
         if (!provider.models["gpt-5.3-codex"]) {
           provider.models["gpt-5.3-codex"] = {
             name: "GPT 5.3 Codex",
+            attachment: false,
+            reasoning: false,
+            temperature: false,
+            options: {},
+            variants: {},
+            limit: { context: 1000000, output: 1000000 },
+            cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+          }
+        }
+
+        if (!provider.models["gpt-5.3-codex-spark"]) {
+          provider.models["gpt-5.3-codex-spark"] = {
+            name: "GPT 5.3 Codex Spark",
             attachment: false,
             reasoning: false,
             temperature: false,

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -17,6 +17,7 @@ export const VALID_MODELS = [
   "openai/gpt-5.2",
   "openai/gpt-5.2-codex",
   "openai/gpt-5.3-codex",
+  "openai/gpt-5.3-codex-spark",
   "opencode/kimi-k2.5",
   "opencode/minimax-m2.5",
   "opencode/glm-5",
@@ -55,6 +56,7 @@ export const MODEL_REASONING_CONFIG: Partial<Record<ValidModel, ModelReasoningCo
   "openai/gpt-5.2": { efforts: ["none", "low", "medium", "high", "xhigh"], default: undefined },
   "openai/gpt-5.2-codex": { efforts: ["low", "medium", "high", "xhigh"], default: "high" },
   "openai/gpt-5.3-codex": { efforts: ["low", "medium", "high", "xhigh"], default: "high" },
+  "openai/gpt-5.3-codex-spark": { efforts: ["low", "medium", "high", "xhigh"], default: "high" },
 };
 
 export interface ModelDisplayInfo {
@@ -103,6 +105,11 @@ export const MODEL_OPTIONS: ModelCategory[] = [
       { id: "openai/gpt-5.2", name: "GPT 5.2", description: "400K context, fast" },
       { id: "openai/gpt-5.2-codex", name: "GPT 5.2 Codex", description: "Optimized for code" },
       { id: "openai/gpt-5.3-codex", name: "GPT 5.3 Codex", description: "Latest codex" },
+      {
+        id: "openai/gpt-5.3-codex-spark",
+        name: "GPT 5.3 Codex Spark",
+        description: "Low-latency codex variant",
+      },
     ],
   },
   {
@@ -127,6 +134,7 @@ export const DEFAULT_ENABLED_MODELS: ValidModel[] = [
   "openai/gpt-5.2",
   "openai/gpt-5.2-codex",
   "openai/gpt-5.3-codex",
+  "openai/gpt-5.3-codex-spark",
 ];
 
 // === Normalization ===


### PR DESCRIPTION
## Summary
- add `openai/gpt-5.3-codex-spark` to shared model definitions so it is valid, selectable in the UI, and enabled by default
- extend Codex auth plugin allowlist and fallback injection to include `gpt-5.3-codex-spark` for OpenAI OAuth-backed sessions
- add control-plane model utility test coverage for validation, provider extraction, reasoning support, and normalization of the new model ID

## Verification
- `npm run typecheck` in `packages/shared`
- `npm run build` in `packages/shared`
- `npm run test -- src/utils/models.test.ts` in `packages/control-plane`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/2585d5a98a689d3af794feed8f503684)*