### PR TITLE
ci: add web build check to TypeScript pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,28 @@ jobs:
       - name: TypeCheck all packages
         run: npm run typecheck
 
+  build-web:
+    name: Build (Web)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared package
+        run: npm run build -w @open-inspect/shared
+
+      - name: Build web package
+        run: npm run build -w @open-inspect/web
+
   lint-python:
     name: Lint & Format (Python)
     runs-on: ubuntu-latest
@@ -110,7 +132,7 @@ jobs:
   test-typescript:
     name: Test (TypeScript)
     runs-on: ubuntu-latest
-    needs: [lint-typescript, typecheck-typescript]
+    needs: [lint-typescript, typecheck-typescript, build-web]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- add a dedicated `Build (Web)` CI job that runs `npm run build -w @open-inspect/web`
- keep shared package build as a prerequisite inside the same job
- require the new build job before running `Test (TypeScript)`

## Why
- ensures CI validates production web build behavior, not only lint/typecheck/tests
- catches build-time regressions earlier in pull requests

## Validation
- `npm run build -w @open-inspect/shared`
- `npm run build -w @open-inspect/web`
- `npx prettier --check .github/workflows/ci.yml`
