### PR TITLE
chore: remove unused zustand dependency from web package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11989,35 +11989,6 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
-    "node_modules/zustand": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.10.tgz",
-      "integrity": "sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=18.0.0",
-        "immer": ">=9.0.6",
-        "react": ">=18.0.0",
-        "use-sync-external-store": ">=1.2.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "use-sync-external-store": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/zwitch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
@@ -12088,8 +12059,7 @@
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
         "rehype-sanitize": "^6.0.0",
-        "remark-gfm": "^4.0.1",
-        "zustand": "^5.0.3"
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.5",

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -16,8 +16,7 @@
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
         "rehype-sanitize": "^6.0.0",
-        "remark-gfm": "^4.0.1",
-        "zustand": "^5.0.3"
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@types/node": "^22.10.5",
@@ -5286,35 +5285,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
-    },
-    "node_modules/zustand": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.10.tgz",
-      "integrity": "sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=18.0.0",
-        "immer": ">=9.0.6",
-        "react": ">=18.0.0",
-        "use-sync-external-store": ">=1.2.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "use-sync-external-store": {
-          "optional": true
-        }
-      }
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -21,8 +21,7 @@
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
     "rehype-sanitize": "^6.0.0",
-    "remark-gfm": "^4.0.1",
-    "zustand": "^5.0.3"
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",


### PR DESCRIPTION
## Summary
- remove the unused `zustand` dependency from `packages/web/package.json`
- regenerate both workspace and root lockfiles so `zustand` is fully removed from the install graph
- keep dependency metadata in sync and reduce unnecessary install/bundle surface area

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/555fa8d6e226b3d1476e017cc87ffd0f)*