### PR TITLE
fix: keep sidebar reasoning effort label lowercase

### DIFF
--- a/packages/web/src/components/sidebar/metadata-section.tsx
+++ b/packages/web/src/components/sidebar/metadata-section.tsx
@@ -76,7 +76,7 @@ export function MetadataSection({
           <SparkleIcon className="w-4 h-4" />
           <span>
             {formatModelName(model)}
-            {reasoningEffort && <span className="capitalize"> · {reasoningEffort}</span>}
+            {reasoningEffort && <span> · {reasoningEffort}</span>}
           </span>
         </div>
       )}


### PR DESCRIPTION
## Summary
- remove capitalization styling from the sidebar metadata reasoning effort label
- preserve the raw reasoning value (for example, `xhigh`) so it renders as lowercase

## Testing
- not run (UI-only text presentation change)

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/3d3b59c3fb023bd3fbd49bc5148dcb94)*