### PR TITLE
feat(web): promote SidebarLayout to route group layout and add SWR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9619,6 +9619,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.0.tgz",
+      "integrity": "sha512-sUlC20T8EOt1pHmDiqueUWMmRRX03W7w5YxovWX7VR2KHEPCTMly85x05vpkP5i6Bu4h44ePSMD9Tc+G2MItFw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
@@ -10163,6 +10176,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -12059,7 +12081,8 @@
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
         "rehype-sanitize": "^6.0.0",
-        "remark-gfm": "^4.0.1"
+        "remark-gfm": "^4.0.1",
+        "swr": "^2.4.0"
       },
       "devDependencies": {
         "@types/node": "^22.10.5",

--- a/packages/web/next-env.d.ts
+++ b/packages/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -21,7 +21,8 @@
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
     "rehype-sanitize": "^6.0.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "swr": "^2.4.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",

--- a/packages/web/src/app/(app)/layout.tsx
+++ b/packages/web/src/app/(app)/layout.tsx
@@ -1,0 +1,5 @@
+import { SidebarLayout } from "@/components/sidebar-layout";
+
+export default function AppLayout({ children }: { children: React.ReactNode }) {
+  return <SidebarLayout>{children}</SidebarLayout>;
+}

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -2,9 +2,10 @@
 
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
+import { mutate } from "swr";
 import { useState, useEffect, useRef, useCallback } from "react";
 import Link from "next/link";
-import { SidebarLayout, useSidebarContext } from "@/components/sidebar-layout";
+import { useSidebarContext } from "@/components/sidebar-layout";
 import { formatModelNameLower } from "@/lib/format";
 import {
   DEFAULT_MODEL,
@@ -29,7 +30,7 @@ const LAST_SELECTED_MODEL_STORAGE_KEY = "open-inspect-last-selected-model";
 const LAST_SELECTED_REASONING_EFFORT_STORAGE_KEY = "open-inspect-last-selected-reasoning-effort";
 
 export default function Home() {
-  const { data: session, status } = useSession();
+  const { data: session } = useSession();
   const router = useRouter();
   const [repos, setRepos] = useState<Repo[]>([]);
   const [loadingRepos, setLoadingRepos] = useState(false);
@@ -249,6 +250,7 @@ export default function Home() {
       });
 
       if (res.ok) {
+        mutate("/api/sessions");
         router.push(`/session/${sessionId}`);
       } else {
         const data = await res.json();
@@ -261,35 +263,25 @@ export default function Home() {
     }
   };
 
-  if (status === "loading") {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-foreground" />
-      </div>
-    );
-  }
-
   return (
-    <SidebarLayout>
-      <HomeContent
-        isAuthenticated={!!session}
-        repos={repos}
-        loadingRepos={loadingRepos}
-        selectedRepo={selectedRepo}
-        setSelectedRepo={setSelectedRepo}
-        selectedModel={selectedModel}
-        setSelectedModel={handleModelChange}
-        reasoningEffort={reasoningEffort}
-        setReasoningEffort={setReasoningEffort}
-        prompt={prompt}
-        handlePromptChange={handlePromptChange}
-        creating={creating}
-        isCreatingSession={isCreatingSession}
-        error={error}
-        handleSubmit={handleSubmit}
-        modelOptions={enabledModelOptions}
-      />
-    </SidebarLayout>
+    <HomeContent
+      isAuthenticated={!!session}
+      repos={repos}
+      loadingRepos={loadingRepos}
+      selectedRepo={selectedRepo}
+      setSelectedRepo={setSelectedRepo}
+      selectedModel={selectedModel}
+      setSelectedModel={handleModelChange}
+      reasoningEffort={reasoningEffort}
+      setReasoningEffort={setReasoningEffort}
+      prompt={prompt}
+      handlePromptChange={handlePromptChange}
+      creating={creating}
+      isCreatingSession={isCreatingSession}
+      error={error}
+      handleSubmit={handleSubmit}
+      modelOptions={enabledModelOptions}
+    />
   );
 }
 

--- a/packages/web/src/app/(app)/settings/page.tsx
+++ b/packages/web/src/app/(app)/settings/page.tsx
@@ -1,21 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import { SidebarLayout, useSidebarContext } from "@/components/sidebar-layout";
+import { useSidebarContext } from "@/components/sidebar-layout";
 import { SettingsNav, type SettingsCategory } from "@/components/settings/settings-nav";
 import { SecretsSettings } from "@/components/settings/secrets-settings";
 import { ModelsSettings } from "@/components/settings/models-settings";
 import { DataControlsSettings } from "@/components/settings/data-controls-settings";
 
 export default function SettingsPage() {
-  return (
-    <SidebarLayout>
-      <SettingsContent />
-    </SidebarLayout>
-  );
-}
-
-function SettingsContent() {
   const { isOpen, toggle } = useSidebarContext();
   const [activeCategory, setActiveCategory] = useState<SettingsCategory>("secrets");
 

--- a/packages/web/src/components/settings/data-controls-settings.tsx
+++ b/packages/web/src/components/settings/data-controls-settings.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
+import { mutate } from "swr";
 import type { SessionItem } from "@/components/session-sidebar";
 import { formatRelativeTime } from "@/lib/time";
 
@@ -52,7 +53,9 @@ export function DataControlsSettings() {
     setSessions((prev) => prev.filter((s) => s.id !== sessionId));
     try {
       const res = await fetch(`/api/sessions/${sessionId}/unarchive`, { method: "POST" });
-      if (!res.ok) {
+      if (res.ok) {
+        mutate("/api/sessions");
+      } else {
         // Re-fetch on failure to restore correct state
         fetchArchivedSessions(0, false);
       }

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -11,13 +11,23 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
-    "plugins": [{ "name": "next" }],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
     "paths": {
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary

- Moves pages (`/`, `/session/[id]`, `/settings`) into a Next.js `(app)` route group so `SidebarLayout` persists across navigations instead of remounting on every page change. This eliminates redundant `/api/sessions` fetches, DOM destruction/recreation, and sidebar state resets.
- Replaces manual `useState`/`useEffect` session fetching in the sidebar with [SWR](https://swr.vercel.app/) for request deduplication and stale-while-revalidate caching.
- Adds explicit `mutate("/api/sessions")` calls at all session mutation points (create, archive, unarchive) to keep the sidebar list in sync without refetching on every navigation.

## Test plan

- [ ] `/` renders Home with sidebar
- [ ] `/session/[id]` renders Session with sidebar
- [ ] `/settings` renders Settings with sidebar
- [ ] `/access-denied` renders without sidebar (unchanged, outside route group)
- [ ] Navigate between pages — sidebar does NOT remount (no flash, no loading spinner)
- [ ] Create a new session — new session appears in sidebar after redirect
- [ ] Archive a session — session disappears from sidebar active list
- [ ] Unarchive a session (from session page or data controls) — session reappears in sidebar
- [ ] Sidebar open/close state persists across navigations
- [ ] Tab away and back — session list refreshes (SWR `revalidateOnFocus`)