### PR TITLE
perf(web): memoize EventItem and ToolCallGroup to reduce re-renders

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useParams } from "next/navigation";
 import { mutate } from "swr";
-import { useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo } from "react";
+import { memo, useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo } from "react";
 import { useSessionSocket } from "@/hooks/use-session-socket";
 import { SafeMarkdown } from "@/components/safe-markdown";
 import { ToolCallGroup } from "@/components/tool-call-group";
@@ -789,7 +789,7 @@ function ParticipantsList({
   );
 }
 
-function EventItem({
+const EventItem = memo(function EventItem({
   event,
   currentParticipantId,
 }: {
@@ -974,7 +974,7 @@ function EventItem({
     default:
       return null;
   }
-}
+});
 
 function CopyIcon({ className }: { className?: string }) {
   return (

--- a/packages/web/src/components/tool-call-group.tsx
+++ b/packages/web/src/components/tool-call-group.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { memo, useState } from "react";
 import type { SandboxEvent } from "@/lib/tool-formatters";
 import { formatToolGroup } from "@/lib/tool-formatters";
 import { ToolCallItem } from "./tool-call-item";
@@ -76,68 +76,74 @@ function ToolIcon({ toolName }: { toolName: string }) {
   }
 }
 
-export function ToolCallGroup({ events, groupId }: ToolCallGroupProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
+export const ToolCallGroup = memo(
+  function ToolCallGroup({ events, groupId }: ToolCallGroupProps) {
+    const [isExpanded, setIsExpanded] = useState(false);
+    const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
 
-  const formatted = formatToolGroup(events);
-  const firstEvent = events[0];
-  const _lastEvent = events[events.length - 1];
+    const formatted = formatToolGroup(events);
+    const firstEvent = events[0];
+    const _lastEvent = events[events.length - 1];
 
-  const time = new Date(firstEvent.timestamp * 1000).toLocaleTimeString([], {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-
-  const toggleItem = (itemId: string) => {
-    setExpandedItems((prev) => {
-      const newSet = new Set(prev);
-      if (newSet.has(itemId)) {
-        newSet.delete(itemId);
-      } else {
-        newSet.add(itemId);
-      }
-      return newSet;
+    const time = new Date(firstEvent.timestamp * 1000).toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
     });
-  };
 
-  // For single tool call, render directly without group wrapper
-  if (events.length === 1) {
+    const toggleItem = (itemId: string) => {
+      setExpandedItems((prev) => {
+        const newSet = new Set(prev);
+        if (newSet.has(itemId)) {
+          newSet.delete(itemId);
+        } else {
+          newSet.add(itemId);
+        }
+        return newSet;
+      });
+    };
+
+    // For single tool call, render directly without group wrapper
+    if (events.length === 1) {
+      return (
+        <ToolCallItem
+          event={firstEvent}
+          isExpanded={expandedItems.has(`${groupId}-0`)}
+          onToggle={() => toggleItem(`${groupId}-0`)}
+        />
+      );
+    }
+
     return (
-      <ToolCallItem
-        event={firstEvent}
-        isExpanded={expandedItems.has(`${groupId}-0`)}
-        onToggle={() => toggleItem(`${groupId}-0`)}
-      />
+      <div className="py-1">
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="w-full flex items-center gap-2 text-sm text-left hover:bg-muted px-2 py-1 -mx-2 transition-colors"
+        >
+          <ChevronIcon rotated={isExpanded} />
+          <ToolIcon toolName={formatted.toolName} />
+          <span className="font-medium text-foreground">{formatted.toolName}</span>
+          <span className="text-muted-foreground">{formatted.summary}</span>
+          <span className="text-xs text-secondary-foreground ml-auto flex-shrink-0">{time}</span>
+        </button>
+
+        {isExpanded && (
+          <div className="ml-4 mt-1 pl-2 border-l-2 border-border">
+            {events.map((event, index) => (
+              <ToolCallItem
+                key={`${groupId}-${index}`}
+                event={event}
+                isExpanded={expandedItems.has(`${groupId}-${index}`)}
+                onToggle={() => toggleItem(`${groupId}-${index}`)}
+                showTime={false}
+              />
+            ))}
+          </div>
+        )}
+      </div>
     );
-  }
-
-  return (
-    <div className="py-1">
-      <button
-        onClick={() => setIsExpanded(!isExpanded)}
-        className="w-full flex items-center gap-2 text-sm text-left hover:bg-muted px-2 py-1 -mx-2 transition-colors"
-      >
-        <ChevronIcon rotated={isExpanded} />
-        <ToolIcon toolName={formatted.toolName} />
-        <span className="font-medium text-foreground">{formatted.toolName}</span>
-        <span className="text-muted-foreground">{formatted.summary}</span>
-        <span className="text-xs text-secondary-foreground ml-auto flex-shrink-0">{time}</span>
-      </button>
-
-      {isExpanded && (
-        <div className="ml-4 mt-1 pl-2 border-l-2 border-border">
-          {events.map((event, index) => (
-            <ToolCallItem
-              key={`${groupId}-${index}`}
-              event={event}
-              isExpanded={expandedItems.has(`${groupId}-${index}`)}
-              onToggle={() => toggleItem(`${groupId}-${index}`)}
-              showTime={false}
-            />
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
+  },
+  (prev, next) =>
+    prev.groupId === next.groupId &&
+    prev.events.length === next.events.length &&
+    prev.events.every((e, i) => e === next.events[i])
+);


### PR DESCRIPTION
## Summary

- Wrap `EventItem` in `React.memo` so unchanged items skip re-rendering (and the remark/rehype markdown pipeline) when new events arrive via WebSocket
- Wrap `ToolCallGroup` in `React.memo` with a custom comparator that checks `groupId` and referential equality of each event in the array
- Previously every `setEvents` call triggered O(n) re-renders of the entire event list; now only new or updated items re-render

## Context

Each incoming `sandbox_event` WebSocket message calls `setEvents`, producing a new array reference. This caused `groupedEvents` to recompute and every `EventItem`/`ToolCallGroup` in the list to re-render, even when their data hadn't changed. For `token` events specifically, each re-render re-ran the full `react-markdown` + `remark-gfm` + `rehype-sanitize` pipeline.

The streaming path was already optimized (tokens buffered in a ref, flushed once on `execution_complete`), so this change targets the remaining case: non-streaming events (tool calls, user messages, git sync, etc.) that append to the list.

## Test plan

- [ ] Verify session view renders events correctly (user messages, assistant responses, tool calls, errors)
- [ ] Verify tool call groups expand/collapse normally
- [ ] Verify copy button on messages still works
- [ ] Verify new events append and auto-scroll works
- [ ] Verify older history loads correctly when scrolling up