### PR TITLE
fix: update sidebar timestamp for WebSocket prompts

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -238,6 +238,8 @@ function SessionPageContent() {
 
     sendPrompt(prompt, selectedModel, reasoningEffort);
     setPrompt("");
+    // Revalidate sidebar so this session bubbles to the top
+    mutate("/api/sessions");
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {


### PR DESCRIPTION
## Summary

- PR #125 added `touchUpdatedAt()` to `handleSessionPrompt()` in `router.ts`, but that handler only runs for **HTTP POST** requests (used by the home page for the first prompt on a new session)
- Follow-up prompts from the **session page** are sent over **WebSocket** via `sendPrompt()` in `use-session-socket.ts`, which calls `handlePromptMessage()` in the Durable Object — completely bypassing the HTTP route
- As a result, the D1 `updated_at` timestamp was never updated for follow-up prompts, and sessions did not reorder in the sidebar

### Changes

1. **Control plane** (`durable-object.ts`): Add `touchUpdatedAt()` call inside the DO's `handlePromptMessage` — the actual WebSocket code path for prompts. Uses fire-and-forget via `ctx.waitUntil` (same pattern as the HTTP handler).

2. **Web** (`session/[id]/page.tsx`): Add `mutate("/api/sessions")` after `sendPrompt()` so the sidebar's SWR cache revalidates immediately, rather than waiting for a tab focus event.

## Test plan
- [x] `npm run typecheck -w @open-inspect/control-plane` passes
- [x] `npm run typecheck -w @open-inspect/web` passes
- [x] Existing session-index tests pass (13/13)
- [ ] Deploy and verify: send a prompt on an older session, confirm it moves to top of sidebar immediately