### PR TITLE
Refactor sidebar toggle icon into shared component

### DIFF
--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -6,6 +6,7 @@ import { mutate } from "swr";
 import { useState, useEffect, useRef, useCallback } from "react";
 import Link from "next/link";
 import { useSidebarContext } from "@/components/sidebar-layout";
+import { SidebarToggleIcon } from "@/components/sidebar-toggle-icon";
 import { formatModelNameLower } from "@/lib/format";
 import {
   DEFAULT_MODEL,
@@ -571,23 +572,6 @@ function HomeContent({
         </div>
       </div>
     </div>
-  );
-}
-
-function SidebarToggleIcon() {
-  return (
-    <svg
-      className="w-4 h-4"
-      fill="none"
-      stroke="currentColor"
-      viewBox="0 0 24 24"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <rect x="3" y="3" width="18" height="18" rx="2" />
-      <line x1="9" y1="3" x2="9" y2="21" />
-    </svg>
   );
 }
 

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -16,6 +16,7 @@ import { useSessionSocket } from "@/hooks/use-session-socket";
 import { SafeMarkdown } from "@/components/safe-markdown";
 import { ToolCallGroup } from "@/components/tool-call-group";
 import { useSidebarContext } from "@/components/sidebar-layout";
+import { SidebarToggleIcon } from "@/components/sidebar-toggle-icon";
 import { SessionRightSidebar } from "@/components/session-right-sidebar";
 import { ActionBar } from "@/components/action-bar";
 import { copyToClipboard, formatModelNameLower } from "@/lib/format";
@@ -698,23 +699,6 @@ function SessionContent({
         </form>
       </footer>
     </div>
-  );
-}
-
-function SidebarToggleIcon() {
-  return (
-    <svg
-      className="w-4 h-4"
-      fill="none"
-      stroke="currentColor"
-      viewBox="0 0 24 24"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <rect x="3" y="3" width="18" height="18" rx="2" />
-      <line x1="9" y1="3" x2="9" y2="21" />
-    </svg>
   );
 }
 

--- a/packages/web/src/app/(app)/settings/page.tsx
+++ b/packages/web/src/app/(app)/settings/page.tsx
@@ -6,6 +6,7 @@ import { SettingsNav, type SettingsCategory } from "@/components/settings/settin
 import { SecretsSettings } from "@/components/settings/secrets-settings";
 import { ModelsSettings } from "@/components/settings/models-settings";
 import { DataControlsSettings } from "@/components/settings/data-controls-settings";
+import { SidebarToggleIcon } from "@/components/sidebar-toggle-icon";
 
 export default function SettingsPage() {
   const { isOpen, toggle } = useSidebarContext();
@@ -39,22 +40,5 @@ export default function SettingsPage() {
         </div>
       </div>
     </div>
-  );
-}
-
-function SidebarToggleIcon() {
-  return (
-    <svg
-      className="w-4 h-4"
-      fill="none"
-      stroke="currentColor"
-      viewBox="0 0 24 24"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <rect x="3" y="3" width="18" height="18" rx="2" />
-      <line x1="9" y1="3" x2="9" y2="21" />
-    </svg>
   );
 }

--- a/packages/web/src/components/sidebar-toggle-icon.tsx
+++ b/packages/web/src/components/sidebar-toggle-icon.tsx
@@ -1,0 +1,16 @@
+export function SidebarToggleIcon() {
+  return (
+    <svg
+      className="w-4 h-4"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <line x1="9" y1="3" x2="9" y2="21" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract the duplicated `SidebarToggleIcon` SVG into a single shared component at `packages/web/src/components/sidebar-toggle-icon.tsx`.
- Update the app home page, session page, and settings page to import and use the shared icon component.
- Remove three copy-pasted local icon implementations to keep UI behavior consistent and reduce maintenance overhead.

## Testing
- Pre-commit hooks ran `eslint --fix` and `prettier --write` on modified TSX files during commit.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/ae7436f7c6984060ed63a0b597334cfa)*