### PR TITLE
Add useMediaQuery/useIsMobile responsive hooks

### DIFF
--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -7,6 +7,7 @@ import { useSession, signOut } from "next-auth/react";
 import useSWR from "swr";
 import { formatRelativeTime, isInactiveSession } from "@/lib/time";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
+import { useIsMobile } from "@/hooks/use-media-query";
 
 export interface SessionItem {
   id: string;
@@ -39,6 +40,7 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
   const { data: authSession } = useSession();
   const pathname = usePathname();
   const [searchQuery, setSearchQuery] = useState("");
+  const isMobile = useIsMobile();
 
   const { data: sessions = [], isLoading: loading } = useSWR<SessionItem[]>(
     authSession ? "/api/sessions" : null,
@@ -176,6 +178,7 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
                 key={session.id}
                 session={session}
                 isActive={session.id === currentSessionId}
+                isMobile={isMobile}
                 onSessionSelect={onSessionSelect}
               />
             ))}
@@ -193,6 +196,7 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
                     key={session.id}
                     session={session}
                     isActive={session.id === currentSessionId}
+                    isMobile={isMobile}
                     onSessionSelect={onSessionSelect}
                   />
                 ))}
@@ -208,10 +212,12 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
 function SessionListItem({
   session,
   isActive,
+  isMobile,
   onSessionSelect,
 }: {
   session: SessionItem;
   isActive: boolean;
+  isMobile: boolean;
   onSessionSelect?: () => void;
 }) {
   const timestamp = session.updatedAt || session.createdAt;
@@ -222,7 +228,7 @@ function SessionListItem({
     <Link
       href={buildSessionHref(session)}
       onClick={() => {
-        if (window.matchMedia("(max-width: 767px)").matches) {
+        if (isMobile) {
           onSessionSelect?.();
         }
       }}

--- a/packages/web/src/hooks/use-media-query.ts
+++ b/packages/web/src/hooks/use-media-query.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+const MOBILE_BREAKPOINT = "(max-width: 767px)";
+
+/**
+ * Subscribe to a CSS media query and return whether it currently matches.
+ * Returns `false` during SSR / before hydration to avoid mismatch.
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    setMatches(mql.matches);
+
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [query]);
+
+  return matches;
+}
+
+/** Convenience wrapper: true when viewport width ≤ 767px. */
+export function useIsMobile(): boolean {
+  return useMediaQuery(MOBILE_BREAKPOINT);
+}


### PR DESCRIPTION
## Summary
- Add `useMediaQuery(query)` and `useIsMobile()` hooks in `packages/web/src/hooks/use-media-query.ts` with SSR-safe hydration (starts `false`, syncs in `useEffect`)
- Refactor the inline `window.matchMedia("(max-width: 767px)")` call in `SessionListItem` to use `useIsMobile()`
- Foundation for upcoming mobile improvements (sidebar overlay, footer stacking, right sidebar access, etc.)

## Test plan
- [ ] Verify sidebar auto-closes on session select when viewport ≤ 767px
- [ ] Verify sidebar does NOT auto-close on session select when viewport > 767px
- [ ] Verify no hydration mismatch warnings in console on initial load