### PR TITLE
feat: sidebar overlay drawer mode on mobile

### DIFF
--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -5,6 +5,7 @@ import { useSession, signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { SessionSidebar } from "./session-sidebar";
 import { useSidebar } from "@/hooks/use-sidebar";
+import { useIsMobile } from "@/hooks/use-media-query";
 import { useGlobalShortcuts } from "@/hooks/use-global-shortcuts";
 
 interface SidebarContextValue {
@@ -32,6 +33,7 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
   const { data: session, status } = useSession();
   const router = useRouter();
   const sidebar = useSidebar();
+  const isMobile = useIsMobile();
   const handleNewSession = useCallback(() => {
     router.push("/");
   }, [router]);
@@ -73,11 +75,26 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
   return (
     <SidebarContext.Provider value={sidebar}>
       <div className="flex h-screen overflow-hidden">
-        {/* Sidebar with transition */}
+        {/* Mobile: overlay backdrop */}
+        {isMobile && (
+          <div
+            className={`fixed inset-0 z-30 bg-black/50 transition-opacity duration-200 ${
+              sidebar.isOpen ? "opacity-100" : "opacity-0 pointer-events-none"
+            }`}
+            onClick={sidebar.close}
+          />
+        )}
+        {/* Sidebar: overlay on mobile, push on desktop */}
         <div
-          className={`transition-all duration-200 ease-in-out ${
-            sidebar.isOpen ? "w-72" : "w-0"
-          } flex-shrink-0 overflow-hidden`}
+          className={
+            isMobile
+              ? `fixed inset-y-0 left-0 z-40 w-72 transition-transform duration-200 ease-in-out ${
+                  sidebar.isOpen ? "translate-x-0" : "-translate-x-full"
+                }`
+              : `transition-all duration-200 ease-in-out ${
+                  sidebar.isOpen ? "w-72" : "w-0"
+                } flex-shrink-0 overflow-hidden`
+          }
         >
           <SessionSidebar
             onNewSession={handleNewSession}

--- a/packages/web/src/hooks/use-media-query.ts
+++ b/packages/web/src/hooks/use-media-query.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 
-const MOBILE_BREAKPOINT = "(max-width: 767px)";
+export const MOBILE_BREAKPOINT = "(max-width: 767px)";
 
 /**
  * Subscribe to a CSS media query and return whether it currently matches.

--- a/packages/web/src/hooks/use-sidebar.ts
+++ b/packages/web/src/hooks/use-sidebar.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { MOBILE_BREAKPOINT } from "./use-media-query";
 
 const SIDEBAR_STORAGE_KEY = "open-inspect-sidebar-open";
 
@@ -10,9 +11,14 @@ export function useSidebar() {
 
   // Load initial state from localStorage after hydration
   useEffect(() => {
-    const stored = localStorage.getItem(SIDEBAR_STORAGE_KEY);
-    if (stored !== null) {
-      setIsOpen(stored === "true");
+    const isMobile = window.matchMedia(MOBILE_BREAKPOINT).matches;
+    if (isMobile) {
+      setIsOpen(false);
+    } else {
+      const stored = localStorage.getItem(SIDEBAR_STORAGE_KEY);
+      if (stored !== null) {
+        setIsOpen(stored === "true");
+      }
     }
     setIsHydrated(true);
   }, []);


### PR DESCRIPTION
## Summary

- On mobile viewports (≤767px), the sidebar now renders as a **fixed overlay** with a semi-transparent backdrop instead of pushing main content into an 87px sliver
- Tapping the backdrop closes the sidebar
- Mobile users default to sidebar **closed** on page load, regardless of localStorage preference
- Desktop behavior (push sidebar with width transition) is unchanged

## Changes

- **`use-sidebar.ts`**: Check `matchMedia` on hydration — force sidebar closed on mobile
- **`sidebar-layout.tsx`**: Use `useIsMobile()` to switch between overlay mode (mobile) and push mode (desktop)

## Test plan

- [ ] Desktop (>767px): sidebar pushes content as before, no backdrop visible
- [ ] Mobile (≤767px): sidebar overlays content with dark backdrop
- [ ] Mobile: tapping backdrop closes sidebar
- [ ] Mobile: first visit defaults to sidebar closed
- [ ] Mobile: selecting a session closes sidebar and shows content
- [ ] Resize from mobile → desktop: sidebar reverts to push mode
- [ ] `npm run typecheck -w @open-inspect/web` passes