### PR TITLE
Fix footer selector overflow on small screens

### DIFF
--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -433,19 +433,21 @@ function HomeContent({
                 </div>
 
                 {/* Footer row with repo and model selectors */}
-                <div className="flex items-center justify-between px-4 py-2 border-t border-border-muted">
+                <div className="flex flex-col gap-2 px-4 py-2 border-t border-border-muted sm:flex-row sm:items-center sm:justify-between sm:gap-0">
                   {/* Left side - Repo selector + Model selector */}
-                  <div className="flex items-center gap-4">
+                  <div className="flex flex-wrap items-center gap-2 sm:gap-4 min-w-0">
                     {/* Repo selector */}
-                    <div className="relative" ref={repoDropdownRef}>
+                    <div className="relative min-w-0" ref={repoDropdownRef}>
                       <button
                         type="button"
                         onClick={() => !creating && setRepoDropdownOpen(!repoDropdownOpen)}
                         disabled={creating || loadingRepos}
-                        className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
+                        className="flex max-w-full items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
                       >
                         <RepoIcon />
-                        <span>{loadingRepos ? "Loading..." : displayRepoName}</span>
+                        <span className="truncate max-w-[12rem] sm:max-w-none">
+                          {loadingRepos ? "Loading..." : displayRepoName}
+                        </span>
                         <ChevronIcon />
                       </button>
 
@@ -506,15 +508,17 @@ function HomeContent({
                     </div>
 
                     {/* Model selector */}
-                    <div className="relative" ref={modelDropdownRef}>
+                    <div className="relative min-w-0" ref={modelDropdownRef}>
                       <button
                         type="button"
                         onClick={() => !creating && setModelDropdownOpen(!modelDropdownOpen)}
                         disabled={creating}
-                        className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
+                        className="flex max-w-full items-center gap-1 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
                       >
                         <ModelIcon />
-                        <span>{formatModelNameLower(selectedModel)}</span>
+                        <span className="truncate max-w-[9rem] sm:max-w-none">
+                          {formatModelNameLower(selectedModel)}
+                        </span>
                       </button>
 
                       {modelDropdownOpen && (
@@ -567,7 +571,9 @@ function HomeContent({
                   </div>
 
                   {/* Right side - Agent label */}
-                  <span className="text-sm text-muted-foreground">build agent</span>
+                  <span className="hidden sm:inline text-sm text-muted-foreground">
+                    build agent
+                  </span>
                 </div>
               </div>
 

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -642,20 +642,22 @@ function SessionContent({
             </div>
 
             {/* Footer row with model selector, reasoning pills, and agent label */}
-            <div className="flex items-center justify-between px-4 py-2 border-t border-border-muted">
+            <div className="flex flex-col gap-2 px-4 py-2 border-t border-border-muted sm:flex-row sm:items-center sm:justify-between sm:gap-0">
               {/* Left side - Model selector + Reasoning pills */}
-              <div className="flex items-center gap-4">
-                <div className="relative" ref={modelDropdownRef}>
+              <div className="flex flex-wrap items-center gap-2 sm:gap-4 min-w-0">
+                <div className="relative min-w-0" ref={modelDropdownRef}>
                   <button
                     type="button"
                     onClick={() => !isProcessing && setModelDropdownOpen(!modelDropdownOpen)}
                     disabled={isProcessing}
-                    className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
+                    className="flex max-w-full items-center gap-1 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
                   >
                     <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
                       <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
                     </svg>
-                    <span>{formatModelNameLower(selectedModel)}</span>
+                    <span className="truncate max-w-[9rem] sm:max-w-none">
+                      {formatModelNameLower(selectedModel)}
+                    </span>
                   </button>
 
                   {/* Dropdown menu */}
@@ -697,7 +699,7 @@ function SessionContent({
               </div>
 
               {/* Right side - Agent label */}
-              <span className="text-sm text-muted-foreground">build agent</span>
+              <span className="hidden sm:inline text-sm text-muted-foreground">build agent</span>
             </div>
           </div>
         </form>


### PR DESCRIPTION
## Summary
- Update footer control rows on both home and session pages to be mobile-first stacked layouts and desktop row layouts.
- Allow selector groups to wrap on small screens and add truncation guards for repo/model labels so long names do not force horizontal overflow.
- Hide the `build agent` footer label on mobile to reclaim space while preserving the current desktop presentation.

## Validation
- Ran `npx eslint "packages/web/src/app/(app)/page.tsx" "packages/web/src/app/(app)/session/[id]/page.tsx"`.
- Verified pre-commit hooks (`eslint --fix` and `prettier --write`) completed successfully during commit.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/70af88d0fe8357c2a4c4203238afb0e8)*