### PR TITLE
Fix ActionBar horizontal overflow on narrow screens

### DIFF
--- a/packages/web/src/components/action-bar.tsx
+++ b/packages/web/src/components/action-bar.tsx
@@ -47,10 +47,10 @@ export function ActionBar({
 
   // Shared button style for bordered pill buttons
   const pillButtonClass =
-    "flex items-center gap-1.5 px-3 py-1.5 text-sm text-foreground border border-border hover:bg-muted transition-colors";
+    "flex shrink-0 items-center gap-1.5 whitespace-nowrap px-3 py-1.5 text-sm text-foreground border border-border hover:bg-muted transition-colors";
 
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex flex-wrap items-center gap-2">
       {/* View Preview */}
       {previewArtifact?.url && (
         <a
@@ -91,7 +91,7 @@ export function ActionBar({
       </button>
 
       {/* More menu */}
-      <div className="relative">
+      <div className="relative shrink-0">
         <button
           onClick={() => setIsMenuOpen(!isMenuOpen)}
           className="flex items-center justify-center w-8 h-8 text-muted-foreground hover:text-foreground border border-border hover:bg-muted transition-colors"


### PR DESCRIPTION
## Summary
- add `flex-wrap` to the ActionBar container so action buttons flow to a second line instead of overflowing
- keep action pills and the More trigger as non-shrinking items to preserve button integrity while wrapping
- prevent pill labels from breaking within buttons by applying `whitespace-nowrap`

## Testing
- not run (UI-only class change)

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/420de61e30faf07e08beb6d4674e82e6)*