### PR TITLE
Fix chat message horizontal scrolling on session page

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -637,7 +637,7 @@ function SessionContent({
         <div
           ref={scrollContainerRef}
           onScroll={handleScroll}
-          className="flex-1 overflow-y-auto p-4"
+          className="flex-1 overflow-y-auto overflow-x-hidden p-4"
         >
           <div className="max-w-3xl mx-auto space-y-2">
             {/* Scroll sentinel for loading older history */}

--- a/packages/web/src/components/safe-markdown.tsx
+++ b/packages/web/src/components/safe-markdown.tsx
@@ -62,7 +62,7 @@ interface SafeMarkdownProps {
 
 export function SafeMarkdown({ content, className = "" }: SafeMarkdownProps) {
   return (
-    <div className={`prose prose-sm dark:prose-invert max-w-none ${className}`}>
+    <div className={`prose prose-sm dark:prose-invert max-w-none break-words ${className}`}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[[rehypeSanitize, sanitizeSchema]]}


### PR DESCRIPTION
## Summary
- Added `overflow-x-hidden` to the session timeline scroll container to prevent horizontal scrolling in the chat area
- Added `break-words` to the `SafeMarkdown` prose wrapper so long inline content (file paths, URLs, code spans) wraps at container boundaries instead of overflowing

## Root cause
The `@tailwindcss/typography` prose plugin doesn't set `overflow-wrap` on inline `<code>` elements. Combined with `max-w-none` on the prose wrapper and no horizontal overflow clipping on the scroll container, long inline code content (e.g., file paths like `packages/web/src/app/(app)/session/[id]/page.tsx:645`) pushed the chat area wider than the viewport.

## Test plan
- [ ] Open a session with long assistant messages containing inline code with file paths
- [ ] Verify no horizontal scrollbar appears on the chat timeline
- [ ] Verify code blocks (`<pre>`) still scroll horizontally when content is wide
- [ ] Verify tables still scroll horizontally within their wrapper
- [ ] Test on mobile viewport widths