### PR TITLE
feat: GitHub bot for automated PR reviews and comment actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,9 @@ jobs:
       - name: Run control-plane integration tests
         run: npm run test:integration -w @open-inspect/control-plane
 
+      - name: Run github-bot tests
+        run: npm test -w @open-inspect/github-bot
+
       - name: Run web tests
         run: npm test -w @open-inspect/web
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -8,6 +8,7 @@ on:
       - "scripts/**"
       - "packages/control-plane/**"
       - "packages/slack-bot/**"
+      - "packages/github-bot/**"
       - "packages/modal-infra/**"
       - "packages/shared/**"
       - ".github/workflows/terraform.yml"
@@ -18,6 +19,7 @@ on:
       - "scripts/**"
       - "packages/control-plane/**"
       - "packages/slack-bot/**"
+      - "packages/github-bot/**"
       - "packages/modal-infra/**"
       - "packages/shared/**"
       - ".github/workflows/terraform.yml"
@@ -134,6 +136,7 @@ jobs:
           npm run build -w @open-inspect/shared
           npm run build -w @open-inspect/control-plane
           npm run build -w @open-inspect/slack-bot
+          npm run build -w @open-inspect/github-bot
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -182,6 +185,9 @@ jobs:
           TF_VAR_allowed_users: ${{ secrets.ALLOWED_USERS }}
           TF_VAR_allowed_email_domains: ${{ secrets.ALLOWED_EMAIL_DOMAINS }}
           TF_VAR_deployment_name: ${{ secrets.DEPLOYMENT_NAME }}
+          TF_VAR_enable_github_bot: "${{ secrets.ENABLE_GITHUB_BOT || 'false' }}"
+          TF_VAR_github_webhook_secret: ${{ secrets.GH_WEBHOOK_SECRET }}
+          TF_VAR_github_bot_username: ${{ secrets.GH_BOT_USERNAME }}
 
       - name: Post Plan Results
         uses: actions/github-script@v7
@@ -243,6 +249,7 @@ jobs:
           npm run build -w @open-inspect/shared
           npm run build -w @open-inspect/control-plane
           npm run build -w @open-inspect/slack-bot
+          npm run build -w @open-inspect/github-bot
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -293,6 +300,9 @@ jobs:
           TF_VAR_allowed_users: ${{ secrets.ALLOWED_USERS }}
           TF_VAR_allowed_email_domains: ${{ secrets.ALLOWED_EMAIL_DOMAINS }}
           TF_VAR_deployment_name: ${{ secrets.DEPLOYMENT_NAME }}
+          TF_VAR_enable_github_bot: "${{ secrets.ENABLE_GITHUB_BOT || 'false' }}"
+          TF_VAR_github_webhook_secret: ${{ secrets.GH_WEBHOOK_SECRET }}
+          TF_VAR_github_bot_username: ${{ secrets.GH_BOT_USERNAME }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,15 @@ Push (PR creation):  Control plane → generate fresh token → WebSocket → sa
 PR API:              Control plane → user OAuth token → GitHub API (server-side only)
 ```
 
+## CI/CD
+
+Pushing to `main` automatically deploys all services if their files changed:
+
+- **Terraform** (control plane + D1 migrations) — runs on changes to `terraform/` or
+  `packages/control-plane/`
+- **Vercel** (web app) — runs on changes to `packages/web/`
+- **Modal** (data plane) — runs on changes to `packages/modal-infra/`
+
 ## Control Plane (Cloudflare Workers)
 
 ### Deployment

--- a/package-lock.json
+++ b/package-lock.json
@@ -2397,6 +2397,10 @@
       "resolved": "packages/control-plane",
       "link": true
     },
+    "node_modules/@open-inspect/github-bot": {
+      "resolved": "packages/github-bot",
+      "link": true
+    },
     "node_modules/@open-inspect/shared": {
       "resolved": "packages/shared",
       "link": true
@@ -12034,6 +12038,20 @@
         "typescript": "^5.7.2",
         "vitest": "^2.1.8",
         "wrangler": "^3.99.0"
+      }
+    },
+    "packages/github-bot": {
+      "name": "@open-inspect/github-bot",
+      "version": "0.1.0",
+      "dependencies": {
+        "@cloudflare/workers-types": "^4.20241230.0",
+        "@open-inspect/shared": "file:../shared",
+        "hono": "^4.11.7"
+      },
+      "devDependencies": {
+        "esbuild": "^0.25.0",
+        "typescript": "^5.7.2",
+        "vitest": "^2.1.8"
       }
     },
     "packages/opencode-plugin": {

--- a/packages/github-bot/README.md
+++ b/packages/github-bot/README.md
@@ -1,0 +1,239 @@
+# GitHub Bot
+
+A stateless Cloudflare Worker that translates GitHub webhook events into Open-Inspect coding agent
+sessions. It provides two capabilities:
+
+1. **Code Review** — Assign the bot as a PR reviewer; it performs an automated code review and
+   submits structured feedback.
+2. **Comment-Triggered Actions** — @mention the bot in a PR comment; it reads the PR context and
+   executes the requested action (typically making code changes and pushing commits).
+
+The bot is a **webhook-to-session translator** — it verifies webhooks, posts an acknowledgment
+reaction, creates a session via the control plane, and sends a prompt. The agent in the sandbox
+handles all GitHub interaction (posting reviews, comments, pushing code) directly using the `gh`
+CLI.
+
+## Architecture
+
+```
+                 ┌─────────────┐
+                 │   GitHub    │
+                 │  Webhooks   │
+                 └──────┬──────┘
+                        │ POST /webhooks/github
+                        v
+                 ┌──────────────┐   service binding    ┌─────────────────┐
+                 │  GitHub Bot  │ ───────────────────>  │  Control Plane  │
+                 │   Worker     │                       │    Worker       │
+                 └──────┬───────┘                       └────────┬────────┘
+                  eyes  │                                        │
+               reaction │                                        │ DO / D1
+                        v                                        v
+                 ┌──────────────┐                         ┌──────────────┐
+                 │   GitHub     │  <─── gh CLI ─────────  │    Modal     │
+                 │   REST API   │                         │   Sandbox    │
+                 └──────────────┘                         └──────────────┘
+```
+
+Key design decisions:
+
+- **Unidirectional service binding**: The bot calls the control plane to create sessions and send
+  prompts. There is no reverse binding — the agent posts results to GitHub directly from the
+  sandbox.
+- **No session reuse**: Every webhook event creates a fresh session. Git provides continuity (the
+  agent clones the latest branch state). No KV state, no TTLs, no staleness.
+- **No PR context fetching**: The bot only uses metadata already in the webhook payload. The agent
+  gathers additional context (diffs, prior comments, file contents) itself using `gh` CLI.
+
+## Deployment
+
+The bot is deployed via Terraform as a standalone Cloudflare Worker alongside the existing workers.
+
+**Two-phase deployment** (same pattern as the Slack bot):
+
+1. Deploy with `enable_service_bindings = false` (creates the worker)
+2. Set `enable_service_bindings = true` and apply again (adds the `CONTROL_PLANE` binding)
+
+### Environment Bindings
+
+| Binding                      | Type                  | Description                                                                         |
+| ---------------------------- | --------------------- | ----------------------------------------------------------------------------------- |
+| `CONTROL_PLANE`              | Service binding       | Fetcher to the control plane worker                                                 |
+| `DEPLOYMENT_NAME`            | Plain text            | Deployment identifier for logging                                                   |
+| `DEFAULT_MODEL`              | Plain text            | Model ID for new sessions (e.g., `anthropic/claude-haiku-4-5`)                      |
+| `GITHUB_BOT_USERNAME`        | Plain text            | Bot's GitHub login (e.g., `my-app[bot]`) for @mention detection and loop prevention |
+| `GITHUB_APP_ID`              | Secret                | GitHub App ID for JWT generation                                                    |
+| `GITHUB_APP_PRIVATE_KEY`     | Secret                | GitHub App private key (must be PKCS#8 format)                                      |
+| `GITHUB_APP_INSTALLATION_ID` | Secret                | GitHub App installation ID for token exchange                                       |
+| `GITHUB_WEBHOOK_SECRET`      | Secret                | Shared secret for verifying webhook signatures                                      |
+| `INTERNAL_CALLBACK_SECRET`   | Secret                | Shared secret for HMAC auth to the control plane                                    |
+| `LOG_LEVEL`                  | Plain text (optional) | Log level override (`debug`, `info`, `warn`, `error`)                               |
+
+### GitHub App Configuration
+
+The existing GitHub App needs these additions:
+
+**Permissions**: `Pull requests: Read & write`, `Issues: Read & write`
+
+**Event subscriptions**: `Pull request`, `Issue comment`, `Pull request review comment`
+
+**Webhook URL**: `https://open-inspect-github-bot-{suffix}.{account}.workers.dev/webhooks/github`
+
+**Webhook secret**: Must match `GITHUB_WEBHOOK_SECRET` in the Terraform configuration.
+
+### Sandbox Prerequisites
+
+For the agent to interact with GitHub from the sandbox, two prerequisites must be met:
+
+1. **`gh` CLI** installed in the Modal sandbox image (`packages/modal-infra/src/images/base.py`)
+2. **`GITHUB_TOKEN`** injected as an environment variable at sandbox spawn time by the lifecycle
+   manager
+
+## Webhook Events
+
+| Event                         | Action             | Trigger                     | Handler                   |
+| ----------------------------- | ------------------ | --------------------------- | ------------------------- |
+| `pull_request`                | `opened`           | Non-draft PR opened         | `handlePullRequestOpened` |
+| `pull_request`                | `review_requested` | Bot assigned as reviewer    | `handleReviewRequested`   |
+| `issue_comment`               | `created`          | @mention in a PR comment    | `handleIssueComment`      |
+| `pull_request_review_comment` | `created`          | @mention in a review thread | `handleReviewComment`     |
+
+All events are processed asynchronously via `executionCtx.waitUntil()`. The webhook endpoint returns
+200 immediately after signature verification.
+
+### Handler Flows
+
+**Pull Request Opened (Auto-Review):**
+
+1. Check `pull_request.draft` — skip draft PRs
+2. Check `pull_request.user.login !== GITHUB_BOT_USERNAME` — prevent loops on bot-created PRs
+3. Post eyes reaction on the PR (fire-and-forget)
+4. Create session via control plane
+5. Send code review prompt (includes PR metadata + `gh` CLI instructions)
+
+**Review Requested:**
+
+1. Check `requested_reviewer.login` matches `GITHUB_BOT_USERNAME` — return early if not
+2. Post eyes reaction on the PR (fire-and-forget)
+3. Create session via control plane
+4. Send code review prompt (includes PR metadata + `gh` CLI instructions)
+
+**Issue Comment:**
+
+1. Check `issue.pull_request` exists — ignore non-PR comments
+2. Check comment body contains `@{GITHUB_BOT_USERNAME}` — ignore if no mention
+3. Check `sender.login !== GITHUB_BOT_USERNAME` — prevent loops
+4. Strip @mention, post eyes reaction, create session, send comment action prompt
+
+**Review Comment:** Same as issue comment, but the prompt additionally includes `filePath`,
+`diffHunk`, and `commentId` for thread-specific context and reply threading.
+
+## Authentication
+
+### Webhook Verification
+
+Incoming webhooks are verified using HMAC-SHA256 with `GITHUB_WEBHOOK_SECRET`:
+
+1. Compute `HMAC-SHA256(secret, raw_body)`
+2. Compare against `X-Hub-Signature-256` header using constant-time comparison
+3. Reject with 401 on mismatch
+
+### GitHub App Tokens
+
+The bot generates a GitHub App installation token for posting acknowledgment reactions:
+
+```
+Private key → JWT (RS256, 10-min expiry) → Installation access token (1-hour TTL)
+```
+
+The token generation code is duplicated from the control plane (`src/auth/github-app.ts`) rather
+than extracted to `@open-inspect/shared`, because it uses Cloudflare Workers' `crypto.subtle` API
+for RSA key import.
+
+### Control Plane Auth
+
+Requests to the control plane use HMAC tokens generated from `INTERNAL_CALLBACK_SECRET` (same
+mechanism as the Slack bot). The token is sent as a `Bearer` token in the `Authorization` header.
+
+## Prompt Construction
+
+Two prompt templates in `src/prompts.ts`:
+
+**`buildCodeReviewPrompt`** — Includes PR title, body, author, branches, and instructions to:
+
+- Run `gh pr diff` for the full diff
+- Submit a review via `gh api .../reviews`
+- Post inline comments via `gh api .../comments`
+
+**`buildCommentActionPrompt`** — Includes the user's request (with @mention stripped) and
+instructions to:
+
+- Check prior conversation via `gh pr view --comments`
+- Make code changes and push, or respond with analysis
+- Post a summary comment via `gh api .../issues/{n}/comments`
+- Reply to a specific review thread (when `commentId` is present)
+
+The prompts embed only metadata from the webhook payload. The agent gathers everything else.
+
+## Observability
+
+All log entries are structured JSON with `trace_id` for cross-service correlation:
+
+```
+GitHub webhook → Bot (trace_id generated) → Control plane (trace_id in x-trace-id header) → Sandbox
+```
+
+Key log events:
+
+| Event                       | Level | When                                       |
+| --------------------------- | ----- | ------------------------------------------ |
+| `webhook.received`          | info  | Webhook arrives (event type, repo, action) |
+| `webhook.signature_invalid` | warn  | Signature verification fails               |
+| `webhook.ignored`           | debug | Event doesn't match any handler            |
+| `session.created`           | info  | Session created via control plane          |
+| `prompt.sent`               | info  | Prompt delivered to session                |
+| `acknowledgment.posted`     | debug | Eyes reaction posted                       |
+| `acknowledgment.failed`     | warn  | Reaction failed (non-blocking)             |
+
+## Development
+
+```bash
+# Install dependencies (from repo root)
+npm install
+
+# Build
+npm run build -w @open-inspect/github-bot
+
+# Run tests (46 tests)
+npm run test -w @open-inspect/github-bot
+
+# Type check
+npm run typecheck -w @open-inspect/github-bot
+
+# Lint
+npm run lint -w @open-inspect/github-bot
+```
+
+Tests run in Node.js via Vitest (no `@cloudflare/vitest-pool-workers` needed — the bot has no
+Durable Objects or D1). All tests are deterministic and run without network access.
+
+## Package Structure
+
+```
+src/
+├── index.ts          # Hono app, routes, webhook endpoint, event routing
+├── types.ts          # Env bindings, webhook payload types
+├── verify.ts         # HMAC-SHA256 webhook signature verification
+├── handlers.ts       # Event handlers (review, issue comment, review comment)
+├── prompts.ts        # Prompt construction for code review and comment actions
+├── github-auth.ts    # GitHub App JWT + installation token generation, reaction posting
+├── logger.ts         # Structured JSON logger (mirrors control plane format)
+└── utils/
+    └── internal.ts   # Re-exports generateInternalToken from @open-inspect/shared
+test/
+├── verify.test.ts    # Signature verification (8 tests)
+├── webhook.test.ts   # Endpoint routing and integration (6 tests)
+├── prompts.test.ts   # Prompt construction (10 tests)
+├── github-auth.test.ts # JWT generation and reactions (7 tests)
+└── handlers.test.ts  # Event handler flows and edge cases (15 tests)
+```

--- a/packages/github-bot/package.json
+++ b/packages/github-bot/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@open-inspect/github-bot",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "esbuild src/index.ts --bundle --format=esm --outfile=dist/index.js --platform=browser --target=es2022 --external:cloudflare:* --external:node:*",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src/",
+    "lint:fix": "eslint src/ --fix"
+  },
+  "dependencies": {
+    "@cloudflare/workers-types": "^4.20241230.0",
+    "@open-inspect/shared": "file:../shared",
+    "hono": "^4.11.7"
+  },
+  "devDependencies": {
+    "esbuild": "^0.25.0",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/github-bot/src/github-auth.ts
+++ b/packages/github-bot/src/github-auth.ts
@@ -1,0 +1,108 @@
+export interface GitHubAppConfig {
+  appId: string;
+  privateKey: string;
+  installationId: string;
+}
+
+function base64UrlEncode(input: Uint8Array | string): string {
+  const bytes = typeof input === "string" ? new TextEncoder().encode(input) : input;
+  const base64 = btoa(String.fromCharCode(...bytes));
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+function parsePemPrivateKey(pem: string): Uint8Array {
+  const pemContents = pem
+    .replace(/-----BEGIN RSA PRIVATE KEY-----/g, "")
+    .replace(/-----END RSA PRIVATE KEY-----/g, "")
+    .replace(/-----BEGIN PRIVATE KEY-----/g, "")
+    .replace(/-----END PRIVATE KEY-----/g, "")
+    .replace(/\s/g, "");
+
+  const binaryString = atob(pemContents);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  return bytes;
+}
+
+async function importPrivateKey(pem: string): Promise<CryptoKey> {
+  const keyData = parsePemPrivateKey(pem);
+  try {
+    return await crypto.subtle.importKey(
+      "pkcs8",
+      keyData,
+      { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+      false,
+      ["sign"]
+    );
+  } catch {
+    throw new Error(
+      "Unable to import private key. Ensure it is in PKCS#8 format. " +
+        "Convert with: openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in key.pem -out key-pkcs8.pem"
+    );
+  }
+}
+
+export async function generateAppJwt(appId: string, privateKey: string): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "RS256", typ: "JWT" };
+  const payload = { iat: now - 60, exp: now + 600, iss: appId };
+
+  const encodedHeader = base64UrlEncode(JSON.stringify(header));
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+
+  const key = await importPrivateKey(privateKey);
+  const signature = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    key,
+    new TextEncoder().encode(signingInput)
+  );
+
+  return `${signingInput}.${base64UrlEncode(new Uint8Array(signature))}`;
+}
+
+async function getInstallationToken(jwt: string, installationId: string): Promise<string> {
+  const url = `https://api.github.com/app/installations/${installationId}/access_tokens`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "Open-Inspect",
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Failed to get installation token: ${response.status} ${error}`);
+  }
+
+  const data = (await response.json()) as { token: string };
+  return data.token;
+}
+
+export async function generateInstallationToken(config: GitHubAppConfig): Promise<string> {
+  const jwt = await generateAppJwt(config.appId, config.privateKey);
+  return getInstallationToken(jwt, config.installationId);
+}
+
+export async function postReaction(token: string, url: string, content: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "Open-Inspect",
+      },
+      body: JSON.stringify({ content }),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}

--- a/packages/github-bot/src/handlers.ts
+++ b/packages/github-bot/src/handlers.ts
@@ -1,0 +1,369 @@
+import type {
+  Env,
+  PullRequestOpenedPayload,
+  ReviewRequestedPayload,
+  IssueCommentPayload,
+  ReviewCommentPayload,
+} from "./types";
+import type { Logger } from "./logger";
+import { generateInstallationToken, postReaction } from "./github-auth";
+import { buildCodeReviewPrompt, buildCommentActionPrompt } from "./prompts";
+import { generateInternalToken } from "./utils/internal";
+
+async function getAuthHeaders(env: Env, traceId: string): Promise<Record<string, string>> {
+  const token = await generateInternalToken(env.INTERNAL_CALLBACK_SECRET);
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+    "x-trace-id": traceId,
+  };
+}
+
+async function createSession(
+  controlPlane: Fetcher,
+  headers: Record<string, string>,
+  params: { repoOwner: string; repoName: string; title: string; model: string }
+): Promise<string> {
+  const response = await controlPlane.fetch("https://internal/sessions", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(params),
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Session creation failed: ${response.status} ${body}`);
+  }
+  const result = (await response.json()) as { sessionId: string };
+  return result.sessionId;
+}
+
+async function sendPrompt(
+  controlPlane: Fetcher,
+  headers: Record<string, string>,
+  sessionId: string,
+  params: { content: string; authorId: string }
+): Promise<string> {
+  const response = await controlPlane.fetch(`https://internal/sessions/${sessionId}/prompt`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ ...params, source: "github" }),
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Prompt delivery failed: ${response.status} ${body}`);
+  }
+  const result = (await response.json()) as { messageId: string };
+  return result.messageId;
+}
+
+function stripMention(body: string, botUsername: string): string {
+  const escaped = botUsername.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return body.replace(new RegExp(`@${escaped}`, "gi"), "").trim();
+}
+
+function fireAndForgetReaction(
+  log: Logger,
+  token: string,
+  url: string,
+  meta: Record<string, unknown>
+): void {
+  postReaction(token, url, "eyes").then(
+    (ok) => {
+      if (ok) log.debug("acknowledgment.posted", meta);
+      else log.warn("acknowledgment.failed", meta);
+    },
+    () => log.warn("acknowledgment.failed", meta)
+  );
+}
+
+export async function handleReviewRequested(
+  env: Env,
+  log: Logger,
+  payload: ReviewRequestedPayload,
+  traceId: string
+): Promise<void> {
+  const { pull_request: pr, repository: repo, requested_reviewer } = payload;
+  const owner = repo.owner.login;
+  const repoName = repo.name;
+
+  if (requested_reviewer?.login !== env.GITHUB_BOT_USERNAME) {
+    log.debug("handler.review_not_for_bot", {
+      trace_id: traceId,
+      requested_reviewer: requested_reviewer?.login,
+    });
+    return;
+  }
+
+  const [ghToken, headers] = await Promise.all([
+    generateInstallationToken({
+      appId: env.GITHUB_APP_ID,
+      privateKey: env.GITHUB_APP_PRIVATE_KEY,
+      installationId: env.GITHUB_APP_INSTALLATION_ID,
+    }),
+    getAuthHeaders(env, traceId),
+  ]);
+
+  const meta = { trace_id: traceId, repo: `${owner}/${repoName}`, pull_number: pr.number };
+  fireAndForgetReaction(
+    log,
+    ghToken,
+    `https://api.github.com/repos/${owner}/${repoName}/issues/${pr.number}/reactions`,
+    meta
+  );
+
+  const sessionId = await createSession(env.CONTROL_PLANE, headers, {
+    repoOwner: owner,
+    repoName,
+    title: `GitHub: Review PR #${pr.number}`,
+    model: env.DEFAULT_MODEL,
+  });
+  log.info("session.created", { ...meta, session_id: sessionId, action: "review" });
+
+  const prompt = buildCodeReviewPrompt({
+    owner,
+    repo: repoName,
+    number: pr.number,
+    title: pr.title,
+    body: pr.body,
+    author: pr.user.login,
+    base: pr.base.ref,
+    head: pr.head.ref,
+  });
+
+  const messageId = await sendPrompt(env.CONTROL_PLANE, headers, sessionId, {
+    content: prompt,
+    authorId: `github:${payload.sender.login}`,
+  });
+  log.info("prompt.sent", {
+    ...meta,
+    session_id: sessionId,
+    message_id: messageId,
+    source: "github",
+    content_length: prompt.length,
+  });
+}
+
+export async function handlePullRequestOpened(
+  env: Env,
+  log: Logger,
+  payload: PullRequestOpenedPayload,
+  traceId: string
+): Promise<void> {
+  const { pull_request: pr, repository: repo } = payload;
+  const owner = repo.owner.login;
+  const repoName = repo.name;
+
+  if (pr.draft) {
+    log.debug("handler.draft_pr_skipped", { trace_id: traceId, pull_number: pr.number });
+    return;
+  }
+
+  if (pr.user.login === env.GITHUB_BOT_USERNAME) {
+    log.debug("handler.self_pr_ignored", { trace_id: traceId, pull_number: pr.number });
+    return;
+  }
+
+  const [ghToken, headers] = await Promise.all([
+    generateInstallationToken({
+      appId: env.GITHUB_APP_ID,
+      privateKey: env.GITHUB_APP_PRIVATE_KEY,
+      installationId: env.GITHUB_APP_INSTALLATION_ID,
+    }),
+    getAuthHeaders(env, traceId),
+  ]);
+
+  const meta = { trace_id: traceId, repo: `${owner}/${repoName}`, pull_number: pr.number };
+  fireAndForgetReaction(
+    log,
+    ghToken,
+    `https://api.github.com/repos/${owner}/${repoName}/issues/${pr.number}/reactions`,
+    meta
+  );
+
+  const sessionId = await createSession(env.CONTROL_PLANE, headers, {
+    repoOwner: owner,
+    repoName,
+    title: `GitHub: Review PR #${pr.number}`,
+    model: env.DEFAULT_MODEL,
+  });
+  log.info("session.created", { ...meta, session_id: sessionId, action: "auto_review" });
+
+  const prompt = buildCodeReviewPrompt({
+    owner,
+    repo: repoName,
+    number: pr.number,
+    title: pr.title,
+    body: pr.body,
+    author: pr.user.login,
+    base: pr.base.ref,
+    head: pr.head.ref,
+  });
+
+  const messageId = await sendPrompt(env.CONTROL_PLANE, headers, sessionId, {
+    content: prompt,
+    authorId: `github:${payload.sender.login}`,
+  });
+  log.info("prompt.sent", {
+    ...meta,
+    session_id: sessionId,
+    message_id: messageId,
+    source: "github",
+    content_length: prompt.length,
+  });
+}
+
+export async function handleIssueComment(
+  env: Env,
+  log: Logger,
+  payload: IssueCommentPayload,
+  traceId: string
+): Promise<void> {
+  const { issue, comment, repository: repo, sender } = payload;
+  const owner = repo.owner.login;
+  const repoName = repo.name;
+
+  if (!issue.pull_request) {
+    log.debug("handler.not_a_pr", { trace_id: traceId, issue_number: issue.number });
+    return;
+  }
+
+  if (!comment.body.toLowerCase().includes(`@${env.GITHUB_BOT_USERNAME.toLowerCase()}`)) {
+    log.debug("handler.no_mention", {
+      trace_id: traceId,
+      issue_number: issue.number,
+      sender: sender.login,
+    });
+    return;
+  }
+
+  if (sender.login === env.GITHUB_BOT_USERNAME) {
+    log.debug("handler.self_comment_ignored", { trace_id: traceId });
+    return;
+  }
+
+  const commentBody = stripMention(comment.body, env.GITHUB_BOT_USERNAME);
+
+  const [ghToken, headers] = await Promise.all([
+    generateInstallationToken({
+      appId: env.GITHUB_APP_ID,
+      privateKey: env.GITHUB_APP_PRIVATE_KEY,
+      installationId: env.GITHUB_APP_INSTALLATION_ID,
+    }),
+    getAuthHeaders(env, traceId),
+  ]);
+
+  const meta = { trace_id: traceId, repo: `${owner}/${repoName}`, pull_number: issue.number };
+  fireAndForgetReaction(
+    log,
+    ghToken,
+    `https://api.github.com/repos/${owner}/${repoName}/issues/comments/${comment.id}/reactions`,
+    meta
+  );
+
+  const sessionId = await createSession(env.CONTROL_PLANE, headers, {
+    repoOwner: owner,
+    repoName,
+    title: `GitHub: PR #${issue.number} comment`,
+    model: env.DEFAULT_MODEL,
+  });
+  log.info("session.created", { ...meta, session_id: sessionId, action: "comment" });
+
+  const prompt = buildCommentActionPrompt({
+    owner,
+    repo: repoName,
+    number: issue.number,
+    title: issue.title,
+    commentBody,
+    commenter: sender.login,
+  });
+
+  const messageId = await sendPrompt(env.CONTROL_PLANE, headers, sessionId, {
+    content: prompt,
+    authorId: `github:${sender.login}`,
+  });
+  log.info("prompt.sent", {
+    ...meta,
+    session_id: sessionId,
+    message_id: messageId,
+    source: "github",
+    content_length: prompt.length,
+  });
+}
+
+export async function handleReviewComment(
+  env: Env,
+  log: Logger,
+  payload: ReviewCommentPayload,
+  traceId: string
+): Promise<void> {
+  const { pull_request: pr, comment, repository: repo, sender } = payload;
+  const owner = repo.owner.login;
+  const repoName = repo.name;
+
+  if (!comment.body.toLowerCase().includes(`@${env.GITHUB_BOT_USERNAME.toLowerCase()}`)) {
+    log.debug("handler.no_mention", {
+      trace_id: traceId,
+      pull_number: pr.number,
+      sender: sender.login,
+    });
+    return;
+  }
+
+  if (sender.login === env.GITHUB_BOT_USERNAME) {
+    log.debug("handler.self_comment_ignored", { trace_id: traceId });
+    return;
+  }
+
+  const commentBody = stripMention(comment.body, env.GITHUB_BOT_USERNAME);
+
+  const [ghToken, headers] = await Promise.all([
+    generateInstallationToken({
+      appId: env.GITHUB_APP_ID,
+      privateKey: env.GITHUB_APP_PRIVATE_KEY,
+      installationId: env.GITHUB_APP_INSTALLATION_ID,
+    }),
+    getAuthHeaders(env, traceId),
+  ]);
+
+  const meta = { trace_id: traceId, repo: `${owner}/${repoName}`, pull_number: pr.number };
+  fireAndForgetReaction(
+    log,
+    ghToken,
+    `https://api.github.com/repos/${owner}/${repoName}/pulls/comments/${comment.id}/reactions`,
+    meta
+  );
+
+  const sessionId = await createSession(env.CONTROL_PLANE, headers, {
+    repoOwner: owner,
+    repoName,
+    title: `GitHub: PR #${pr.number} review comment`,
+    model: env.DEFAULT_MODEL,
+  });
+  log.info("session.created", { ...meta, session_id: sessionId, action: "review_comment" });
+
+  const prompt = buildCommentActionPrompt({
+    owner,
+    repo: repoName,
+    number: pr.number,
+    title: pr.title,
+    base: pr.base.ref,
+    head: pr.head.ref,
+    commentBody,
+    commenter: sender.login,
+    filePath: comment.path,
+    diffHunk: comment.diff_hunk,
+    commentId: comment.id,
+  });
+
+  const messageId = await sendPrompt(env.CONTROL_PLANE, headers, sessionId, {
+    content: prompt,
+    authorId: `github:${sender.login}`,
+  });
+  log.info("prompt.sent", {
+    ...meta,
+    session_id: sessionId,
+    message_id: messageId,
+    source: "github",
+    content_length: prompt.length,
+  });
+}

--- a/packages/github-bot/src/index.ts
+++ b/packages/github-bot/src/index.ts
@@ -1,0 +1,107 @@
+/**
+ * Open-Inspect GitHub Bot Worker
+ *
+ * Cloudflare Worker that handles GitHub webhook events and provides
+ * automated code review and comment-triggered actions via the coding agent.
+ */
+
+import { Hono } from "hono";
+import type {
+  Env,
+  PullRequestOpenedPayload,
+  ReviewRequestedPayload,
+  IssueCommentPayload,
+  ReviewCommentPayload,
+} from "./types";
+import type { Logger } from "./logger";
+import { createLogger, parseLogLevel } from "./logger";
+import { verifyWebhookSignature } from "./verify";
+import {
+  handlePullRequestOpened,
+  handleReviewRequested,
+  handleIssueComment,
+  handleReviewComment,
+} from "./handlers";
+
+const app = new Hono<{ Bindings: Env }>();
+
+app.get("/health", (c) => c.json({ status: "healthy", service: "open-inspect-github-bot" }));
+
+app.post("/webhooks/github", async (c) => {
+  const log = createLogger("webhook", {}, parseLogLevel(c.env.LOG_LEVEL));
+
+  const rawBody = await c.req.text();
+  const signature = c.req.header("X-Hub-Signature-256") ?? null;
+  const event = c.req.header("X-GitHub-Event");
+  const deliveryId = c.req.header("X-GitHub-Delivery");
+
+  const valid = await verifyWebhookSignature(c.env.GITHUB_WEBHOOK_SECRET, rawBody, signature);
+  if (!valid) {
+    log.warn("webhook.signature_invalid", { delivery_id: deliveryId });
+    return c.json({ error: "invalid signature" }, 401);
+  }
+
+  const payload = JSON.parse(rawBody);
+  const traceId = crypto.randomUUID();
+
+  log.info("webhook.received", {
+    event_type: event,
+    delivery_id: deliveryId,
+    trace_id: traceId,
+    repo: payload?.repository
+      ? `${payload.repository.owner?.login}/${payload.repository.name}`
+      : undefined,
+    action: payload?.action,
+  });
+
+  c.executionCtx.waitUntil(
+    handleWebhook(c.env, log, event, payload, traceId, deliveryId).catch((err) => {
+      log.error("webhook.processing_error", {
+        trace_id: traceId,
+        delivery_id: deliveryId,
+        error: err instanceof Error ? err : new Error(String(err)),
+      });
+    })
+  );
+
+  return c.json({ ok: true });
+});
+
+async function handleWebhook(
+  env: Env,
+  log: Logger,
+  event: string | undefined,
+  payload: unknown,
+  traceId: string,
+  deliveryId: string | undefined
+): Promise<void> {
+  const p = payload as Record<string, unknown>;
+  switch (event) {
+    case "pull_request":
+      if (p.action === "opened") {
+        return handlePullRequestOpened(env, log, payload as PullRequestOpenedPayload, traceId);
+      }
+      if (p.action === "review_requested") {
+        return handleReviewRequested(env, log, payload as ReviewRequestedPayload, traceId);
+      }
+      break;
+    case "issue_comment":
+      if (p.action === "created") {
+        return handleIssueComment(env, log, payload as IssueCommentPayload, traceId);
+      }
+      break;
+    case "pull_request_review_comment":
+      if (p.action === "created") {
+        return handleReviewComment(env, log, payload as ReviewCommentPayload, traceId);
+      }
+      break;
+  }
+  log.debug("webhook.ignored", {
+    event_type: event,
+    action: p?.action,
+    trace_id: traceId,
+    delivery_id: deliveryId,
+  });
+}
+
+export default app;

--- a/packages/github-bot/src/logger.ts
+++ b/packages/github-bot/src/logger.ts
@@ -1,0 +1,116 @@
+/**
+ * Structured JSON logger for the GitHub bot Cloudflare Worker.
+ *
+ * Mirrors the control-plane logger contract so that logs from both services
+ * share the same envelope and can be queried uniformly.
+ *
+ * - Outputs flat JSON lines indexed by Cloudflare Workers Logs.
+ * - Uses console.warn/console.error for severity semantics in tooling/alerts,
+ *   while keeping the JSON `level` field for programmatic filtering.
+ * - JSON.stringify is wrapped in try/catch so a logging failure never crashes
+ *   a request.
+ * - Reserved keys (`level`, `component`, `msg`, `ts`, `service`, `event`)
+ *   cannot be overwritten by context or data.
+ */
+
+const LEVELS = { debug: 0, info: 1, warn: 2, error: 3 } as const;
+type LogLevel = keyof typeof LEVELS;
+
+/** Keys that the logger owns — context and data cannot overwrite these. */
+const RESERVED_KEYS = new Set(["level", "component", "msg", "ts", "service", "event"]);
+
+/** Map log level to the appropriate console method for severity semantics. */
+const CONSOLE_METHOD: Record<LogLevel, "log" | "warn" | "error"> = {
+  debug: "log",
+  info: "log",
+  warn: "warn",
+  error: "error",
+};
+
+export interface Logger {
+  debug(msg: string, data?: Record<string, unknown>): void;
+  info(msg: string, data?: Record<string, unknown>): void;
+  warn(msg: string, data?: Record<string, unknown>): void;
+  error(msg: string, data?: Record<string, unknown>): void;
+  child(context: Record<string, unknown>): Logger;
+}
+
+/** Strip reserved keys from a record so callers cannot overwrite logger-owned fields. */
+function stripReserved(obj: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(obj)) {
+    if (!RESERVED_KEYS.has(key)) {
+      out[key] = obj[key];
+    }
+  }
+  return out;
+}
+
+export function createLogger(
+  component: string,
+  context: Record<string, unknown> = {},
+  minLevel: LogLevel = "info"
+): Logger {
+  // Pre-strip reserved keys from the base context once at creation time.
+  const safeContext = stripReserved(context);
+
+  const emit = (level: LogLevel, msg: string, data?: Record<string, unknown>) => {
+    if (LEVELS[level] < LEVELS[minLevel]) return;
+
+    const extra: Record<string, unknown> = data ? stripReserved(data) : {};
+    if (extra.error instanceof Error) {
+      const err = extra.error;
+      extra.error_message = err.message;
+      extra.error_stack = err.stack;
+      extra.error_type = err.constructor.name;
+      if ("code" in err && typeof (err as Record<string, unknown>).code === "string") {
+        extra.error_code = (err as Record<string, unknown>).code;
+      }
+      delete extra.error;
+    }
+
+    try {
+      console[CONSOLE_METHOD[level]](
+        JSON.stringify({
+          level,
+          service: "github-bot",
+          component,
+          msg,
+          ...safeContext,
+          ...extra,
+          ts: Date.now(),
+        })
+      );
+    } catch {
+      // Fallback for bigint, circular references, or other stringify failures.
+      console.error(
+        JSON.stringify({
+          level: "error",
+          service: "github-bot",
+          component,
+          msg: "LOG_SERIALIZE_FAILURE",
+          original_msg: msg,
+          original_level: level,
+          ts: Date.now(),
+        })
+      );
+    }
+  };
+
+  return {
+    debug: (msg, data) => emit("debug", msg, data),
+    info: (msg, data) => emit("info", msg, data),
+    warn: (msg, data) => emit("warn", msg, data),
+    error: (msg, data) => emit("error", msg, data),
+    child: (childCtx) =>
+      createLogger(component, { ...safeContext, ...stripReserved(childCtx) }, minLevel),
+  };
+}
+
+/**
+ * Parse a LOG_LEVEL env var string into a valid LogLevel, defaulting to "info".
+ */
+export function parseLogLevel(value?: string): LogLevel {
+  if (value && Object.prototype.hasOwnProperty.call(LEVELS, value)) return value as LogLevel;
+  return "info";
+}

--- a/packages/github-bot/src/types.ts
+++ b/packages/github-bot/src/types.ts
@@ -1,0 +1,105 @@
+/**
+ * Environment bindings for the GitHub Bot Cloudflare Worker.
+ */
+export interface Env {
+  /** Service binding to the control plane worker. */
+  CONTROL_PLANE: Fetcher;
+
+  /** Deployment name for logging/identification. */
+  DEPLOYMENT_NAME: string;
+
+  /** Default model ID for new sessions. */
+  DEFAULT_MODEL: string;
+
+  /** GitHub App bot username (e.g., "open-inspect-bot[bot]"). */
+  GITHUB_BOT_USERNAME: string;
+
+  /** GitHub App ID for JWT generation. */
+  GITHUB_APP_ID: string;
+
+  /** GitHub App private key (PKCS#8 PEM) for JWT signing. */
+  GITHUB_APP_PRIVATE_KEY: string;
+
+  /** GitHub App installation ID for token exchange. */
+  GITHUB_APP_INSTALLATION_ID: string;
+
+  /** Webhook secret for verifying GitHub webhook signatures. */
+  GITHUB_WEBHOOK_SECRET: string;
+
+  /** Shared secret for HMAC auth to the control plane. */
+  INTERNAL_CALLBACK_SECRET: string;
+
+  /** Optional log level override. */
+  LOG_LEVEL?: string;
+}
+
+/**
+ * Webhook payload types — narrow types extracted from the GitHub webhook
+ * event schema containing only the fields the bot reads.
+ */
+
+export interface PullRequestOpenedPayload {
+  action: "opened";
+  pull_request: {
+    number: number;
+    title: string;
+    body: string | null;
+    user: { login: string };
+    head: { ref: string; sha: string };
+    base: { ref: string };
+    draft: boolean;
+  };
+  repository: { owner: { login: string }; name: string };
+  sender: { login: string };
+}
+
+export interface ReviewRequestedPayload {
+  action: "review_requested";
+  pull_request: {
+    number: number;
+    title: string;
+    body: string | null;
+    user: { login: string };
+    head: { ref: string; sha: string };
+    base: { ref: string };
+  };
+  requested_reviewer?: { login: string };
+  repository: { owner: { login: string }; name: string };
+  sender: { login: string };
+}
+
+export interface IssueCommentPayload {
+  action: "created";
+  issue: {
+    number: number;
+    title: string;
+    pull_request?: { url: string };
+  };
+  comment: {
+    id: number;
+    body: string;
+    user: { login: string };
+  };
+  repository: { owner: { login: string }; name: string };
+  sender: { login: string };
+}
+
+export interface ReviewCommentPayload {
+  action: "created";
+  pull_request: {
+    number: number;
+    title: string;
+    head: { ref: string; sha: string };
+    base: { ref: string };
+  };
+  comment: {
+    id: number;
+    body: string;
+    path: string;
+    diff_hunk: string;
+    position: number | null;
+    user: { login: string };
+  };
+  repository: { owner: { login: string }; name: string };
+  sender: { login: string };
+}

--- a/packages/github-bot/src/utils/internal.ts
+++ b/packages/github-bot/src/utils/internal.ts
@@ -1,0 +1,7 @@
+/**
+ * Internal API authentication for service-to-service calls.
+ *
+ * Re-exports from @open-inspect/shared for consistency across packages.
+ */
+
+export { generateInternalToken } from "@open-inspect/shared";

--- a/packages/github-bot/src/verify.ts
+++ b/packages/github-bot/src/verify.ts
@@ -1,0 +1,44 @@
+export async function verifyWebhookSignature(
+  secret: string,
+  rawBody: string,
+  signatureHeader: string | null
+): Promise<boolean> {
+  if (!signatureHeader || !signatureHeader.startsWith("sha256=")) {
+    return false;
+  }
+
+  const expectedHex = signatureHeader.slice("sha256=".length);
+
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+
+  const signatureBytes = await crypto.subtle.sign("HMAC", key, encoder.encode(rawBody));
+  const computedHex = Array.from(new Uint8Array(signatureBytes))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+
+  return timingSafeEqual(expectedHex, computedHex);
+}
+
+/**
+ * Constant-time string comparison to prevent timing attacks.
+ *
+ * Both inputs are SHA-256 hex digests (always 64 chars), so the length
+ * check is a safety guard, not a timing leak.
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return result === 0;
+}

--- a/packages/github-bot/test/github-auth.test.ts
+++ b/packages/github-bot/test/github-auth.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { generateAppJwt, postReaction } from "../src/github-auth";
+
+/** Generate a PKCS#8 PEM RSA key pair for testing. */
+async function generateTestKeyPair(): Promise<{ privateKeyPem: string }> {
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"]
+  );
+
+  const exported = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(exported)));
+  const lines = base64.match(/.{1,64}/g)!.join("\n");
+  return { privateKeyPem: `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----` };
+}
+
+describe("generateAppJwt", () => {
+  it("produces a valid 3-part JWT", async () => {
+    const { privateKeyPem } = await generateTestKeyPair();
+    const jwt = await generateAppJwt("12345", privateKeyPem);
+
+    const parts = jwt.split(".");
+    expect(parts).toHaveLength(3);
+
+    // Decode header
+    const header = JSON.parse(atob(parts[0].replace(/-/g, "+").replace(/_/g, "/")));
+    expect(header).toEqual({ alg: "RS256", typ: "JWT" });
+
+    // Decode payload
+    const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")));
+    expect(payload.iss).toBe("12345");
+    expect(payload.iat).toBeTypeOf("number");
+    expect(payload.exp).toBeTypeOf("number");
+    expect(payload.exp - payload.iat).toBe(660); // 600 + 60 clock skew
+  });
+
+  it("JWT claims have correct time ranges", async () => {
+    const { privateKeyPem } = await generateTestKeyPair();
+    const now = Math.floor(Date.now() / 1000);
+    const jwt = await generateAppJwt("99", privateKeyPem);
+
+    const payload = JSON.parse(atob(jwt.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")));
+    expect(payload.iat).toBeGreaterThanOrEqual(now - 62);
+    expect(payload.iat).toBeLessThanOrEqual(now - 58);
+    expect(payload.exp).toBeGreaterThanOrEqual(now + 598);
+    expect(payload.exp).toBeLessThanOrEqual(now + 602);
+  });
+});
+
+describe("postReaction", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("calls fetch with correct parameters", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(new Response("", { status: 201 }));
+
+    const url = "https://api.github.com/repos/acme/widgets/issues/42/reactions";
+    await postReaction("test-token", url, "eyes");
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(url, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer test-token",
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "Open-Inspect",
+      },
+      body: JSON.stringify({ content: "eyes" }),
+    });
+  });
+
+  it("returns true on success (201)", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(new Response("", { status: 201 }));
+    const result = await postReaction("tok", "https://api.github.com/test", "eyes");
+    expect(result).toBe(true);
+  });
+
+  it("returns true on 200", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(new Response("", { status: 200 }));
+    const result = await postReaction("tok", "https://api.github.com/test", "eyes");
+    expect(result).toBe(true);
+  });
+
+  it("returns false on 403", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(new Response("Forbidden", { status: 403 }));
+    const result = await postReaction("tok", "https://api.github.com/test", "eyes");
+    expect(result).toBe(false);
+  });
+
+  it("returns false on network error", async () => {
+    vi.mocked(globalThis.fetch).mockRejectedValue(new Error("network error"));
+    const result = await postReaction("tok", "https://api.github.com/test", "eyes");
+    expect(result).toBe(false);
+  });
+});

--- a/packages/github-bot/test/handlers.test.ts
+++ b/packages/github-bot/test/handlers.test.ts
@@ -1,0 +1,424 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type {
+  Env,
+  PullRequestOpenedPayload,
+  ReviewRequestedPayload,
+  IssueCommentPayload,
+  ReviewCommentPayload,
+} from "../src/types";
+import type { Logger } from "../src/logger";
+
+vi.mock("../src/github-auth", () => ({
+  generateInstallationToken: vi.fn().mockResolvedValue("test-installation-token"),
+  postReaction: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../src/utils/internal", () => ({
+  generateInternalToken: vi.fn().mockResolvedValue("test-internal-token"),
+}));
+
+import {
+  handlePullRequestOpened,
+  handleReviewRequested,
+  handleIssueComment,
+  handleReviewComment,
+} from "../src/handlers";
+import { generateInstallationToken, postReaction } from "../src/github-auth";
+
+function createMockLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  };
+}
+
+function createMockEnv(): Env {
+  const controlPlaneFetch = vi.fn().mockImplementation((url: string) => {
+    if (url === "https://internal/sessions") {
+      return Promise.resolve(
+        new Response(JSON.stringify({ sessionId: "session-123" }), { status: 200 })
+      );
+    }
+    if (/\/sessions\/.+\/prompt$/.test(url)) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ messageId: "msg-456" }), { status: 200 })
+      );
+    }
+    return Promise.resolve(new Response("Not found", { status: 404 }));
+  });
+
+  return {
+    CONTROL_PLANE: { fetch: controlPlaneFetch } as unknown as Fetcher,
+    DEPLOYMENT_NAME: "test",
+    DEFAULT_MODEL: "anthropic/claude-haiku-4-5",
+    GITHUB_BOT_USERNAME: "test-bot[bot]",
+    GITHUB_APP_ID: "12345",
+    GITHUB_APP_PRIVATE_KEY: "test-key",
+    GITHUB_APP_INSTALLATION_ID: "67890",
+    GITHUB_WEBHOOK_SECRET: "test-secret",
+    INTERNAL_CALLBACK_SECRET: "test-internal-secret",
+    LOG_LEVEL: "error",
+  } as unknown as Env;
+}
+
+function getControlPlaneFetch(env: Env) {
+  return (env.CONTROL_PLANE as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch;
+}
+
+const pullRequestOpenedPayload: PullRequestOpenedPayload = {
+  action: "opened",
+  pull_request: {
+    number: 42,
+    title: "Add caching",
+    body: "Adds Redis caching",
+    user: { login: "alice" },
+    head: { ref: "feature/cache", sha: "abc123" },
+    base: { ref: "main" },
+    draft: false,
+  },
+  repository: { owner: { login: "acme" }, name: "widgets" },
+  sender: { login: "alice" },
+};
+
+const reviewRequestedPayload: ReviewRequestedPayload = {
+  action: "review_requested",
+  pull_request: {
+    number: 42,
+    title: "Add caching",
+    body: "Adds Redis caching",
+    user: { login: "alice" },
+    head: { ref: "feature/cache", sha: "abc123" },
+    base: { ref: "main" },
+  },
+  requested_reviewer: { login: "test-bot[bot]" },
+  repository: { owner: { login: "acme" }, name: "widgets" },
+  sender: { login: "alice" },
+};
+
+const issueCommentPayload: IssueCommentPayload = {
+  action: "created",
+  issue: {
+    number: 42,
+    title: "Add caching",
+    pull_request: { url: "https://api.github.com/repos/acme/widgets/pulls/42" },
+  },
+  comment: {
+    id: 100,
+    body: "@test-bot[bot] please fix the error handling",
+    user: { login: "bob" },
+  },
+  repository: { owner: { login: "acme" }, name: "widgets" },
+  sender: { login: "bob" },
+};
+
+const reviewCommentPayload: ReviewCommentPayload = {
+  action: "created",
+  pull_request: {
+    number: 42,
+    title: "Add caching",
+    head: { ref: "feature/cache", sha: "abc123" },
+    base: { ref: "main" },
+  },
+  comment: {
+    id: 200,
+    body: "@test-bot[bot] can you fix this?",
+    path: "src/cache.ts",
+    diff_hunk: "@@ -10,3 +10,5 @@\n+const cache = new Map();",
+    position: 5,
+    user: { login: "carol" },
+  },
+  repository: { owner: { login: "acme" }, name: "widgets" },
+  sender: { login: "carol" },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(generateInstallationToken).mockResolvedValue("test-installation-token");
+  vi.mocked(postReaction).mockResolvedValue(true);
+});
+
+describe("handlePullRequestOpened", () => {
+  it("creates session, posts reaction, and sends code review prompt", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+
+    await handlePullRequestOpened(env, log, pullRequestOpenedPayload, "trace-0");
+
+    expect(generateInstallationToken).toHaveBeenCalled();
+    expect(postReaction).toHaveBeenCalledWith(
+      "test-installation-token",
+      "https://api.github.com/repos/acme/widgets/issues/42/reactions",
+      "eyes"
+    );
+
+    const cpFetch = getControlPlaneFetch(env);
+    expect(cpFetch).toHaveBeenCalledTimes(2);
+
+    const sessionBody = JSON.parse(cpFetch.mock.calls[0][1].body);
+    expect(sessionBody.repoOwner).toBe("acme");
+    expect(sessionBody.repoName).toBe("widgets");
+    expect(sessionBody.title).toContain("Review PR #42");
+
+    const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
+    expect(promptBody.source).toBe("github");
+    expect(promptBody.authorId).toBe("github:alice");
+    expect(promptBody.content).toContain("Pull Request #42");
+
+    expect(log.info).toHaveBeenCalledWith(
+      "session.created",
+      expect.objectContaining({ action: "auto_review" })
+    );
+  });
+
+  it("returns early for draft PRs", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+    const payload: PullRequestOpenedPayload = {
+      ...pullRequestOpenedPayload,
+      pull_request: { ...pullRequestOpenedPayload.pull_request, draft: true },
+    };
+
+    await handlePullRequestOpened(env, log, payload, "trace-0");
+
+    expect(generateInstallationToken).not.toHaveBeenCalled();
+    expect(getControlPlaneFetch(env)).not.toHaveBeenCalled();
+    expect(log.debug).toHaveBeenCalledWith("handler.draft_pr_skipped", expect.anything());
+  });
+
+  it("returns early if PR is from the bot (loop prevention)", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+    const payload: PullRequestOpenedPayload = {
+      ...pullRequestOpenedPayload,
+      pull_request: {
+        ...pullRequestOpenedPayload.pull_request,
+        user: { login: "test-bot[bot]" },
+      },
+    };
+
+    await handlePullRequestOpened(env, log, payload, "trace-0");
+
+    expect(generateInstallationToken).not.toHaveBeenCalled();
+    expect(log.debug).toHaveBeenCalledWith("handler.self_pr_ignored", expect.anything());
+  });
+});
+
+describe("handleReviewRequested", () => {
+  it("creates session, posts reaction, and sends prompt", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+
+    await handleReviewRequested(env, log, reviewRequestedPayload, "trace-1");
+
+    expect(generateInstallationToken).toHaveBeenCalledWith({
+      appId: "12345",
+      privateKey: "test-key",
+      installationId: "67890",
+    });
+
+    expect(postReaction).toHaveBeenCalledWith(
+      "test-installation-token",
+      "https://api.github.com/repos/acme/widgets/issues/42/reactions",
+      "eyes"
+    );
+
+    const cpFetch = getControlPlaneFetch(env);
+    expect(cpFetch).toHaveBeenCalledTimes(2);
+
+    // Verify session creation
+    const sessionCall = cpFetch.mock.calls[0];
+    expect(sessionCall[0]).toBe("https://internal/sessions");
+    const sessionBody = JSON.parse(sessionCall[1].body);
+    expect(sessionBody.repoOwner).toBe("acme");
+    expect(sessionBody.repoName).toBe("widgets");
+    expect(sessionBody.title).toContain("Review PR #42");
+
+    // Verify prompt sending
+    const promptCall = cpFetch.mock.calls[1];
+    expect(promptCall[0]).toBe("https://internal/sessions/session-123/prompt");
+    const promptBody = JSON.parse(promptCall[1].body);
+    expect(promptBody.source).toBe("github");
+    expect(promptBody.authorId).toBe("github:alice");
+    expect(promptBody.content).toContain("Pull Request #42");
+    expect(promptBody.content).toContain("acme/widgets");
+    expect(promptBody.content).toContain("gh pr diff 42");
+
+    // Verify logging
+    expect(log.info).toHaveBeenCalledWith(
+      "session.created",
+      expect.objectContaining({
+        session_id: "session-123",
+        action: "review",
+      })
+    );
+    expect(log.info).toHaveBeenCalledWith(
+      "prompt.sent",
+      expect.objectContaining({
+        session_id: "session-123",
+        message_id: "msg-456",
+      })
+    );
+  });
+
+  it("returns early if reviewer is not the bot", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+    const payload = { ...reviewRequestedPayload, requested_reviewer: { login: "someone-else" } };
+
+    await handleReviewRequested(env, log, payload, "trace-1");
+
+    expect(generateInstallationToken).not.toHaveBeenCalled();
+    expect(getControlPlaneFetch(env)).not.toHaveBeenCalled();
+    expect(log.debug).toHaveBeenCalledWith("handler.review_not_for_bot", expect.anything());
+  });
+
+  it("returns early if no reviewer specified", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+    const payload = { ...reviewRequestedPayload, requested_reviewer: undefined };
+
+    await handleReviewRequested(env, log, payload, "trace-1");
+
+    expect(generateInstallationToken).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleIssueComment", () => {
+  it("creates session and sends prompt for PR comment with @mention", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+
+    await handleIssueComment(env, log, issueCommentPayload, "trace-2");
+
+    expect(postReaction).toHaveBeenCalledWith(
+      "test-installation-token",
+      "https://api.github.com/repos/acme/widgets/issues/comments/100/reactions",
+      "eyes"
+    );
+
+    const cpFetch = getControlPlaneFetch(env);
+    expect(cpFetch).toHaveBeenCalledTimes(2);
+
+    const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
+    expect(promptBody.content).toContain("please fix the error handling");
+    expect(promptBody.content).not.toContain("@test-bot[bot]");
+    expect(promptBody.authorId).toBe("github:bob");
+  });
+
+  it("returns early if not a PR", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+    const payload: IssueCommentPayload = {
+      ...issueCommentPayload,
+      issue: { number: 42, title: "Bug report", pull_request: undefined },
+    };
+
+    await handleIssueComment(env, log, payload, "trace-2");
+
+    expect(generateInstallationToken).not.toHaveBeenCalled();
+    expect(log.debug).toHaveBeenCalledWith("handler.not_a_pr", expect.anything());
+  });
+
+  it("returns early if no @mention", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+    const payload: IssueCommentPayload = {
+      ...issueCommentPayload,
+      comment: { ...issueCommentPayload.comment, body: "just a regular comment" },
+    };
+
+    await handleIssueComment(env, log, payload, "trace-2");
+
+    expect(generateInstallationToken).not.toHaveBeenCalled();
+  });
+
+  it("returns early if comment is from the bot (loop prevention)", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+    const payload: IssueCommentPayload = {
+      ...issueCommentPayload,
+      sender: { login: "test-bot[bot]" },
+    };
+
+    await handleIssueComment(env, log, payload, "trace-2");
+
+    expect(generateInstallationToken).not.toHaveBeenCalled();
+    expect(log.debug).toHaveBeenCalledWith("handler.self_comment_ignored", expect.anything());
+  });
+});
+
+describe("handleReviewComment", () => {
+  it("creates session and sends prompt with file context", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+
+    await handleReviewComment(env, log, reviewCommentPayload, "trace-3");
+
+    expect(postReaction).toHaveBeenCalledWith(
+      "test-installation-token",
+      "https://api.github.com/repos/acme/widgets/pulls/comments/200/reactions",
+      "eyes"
+    );
+
+    const cpFetch = getControlPlaneFetch(env);
+    const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
+    expect(promptBody.content).toContain("src/cache.ts");
+    expect(promptBody.content).toContain("const cache = new Map()");
+    expect(promptBody.content).toContain("comments/200/replies");
+    expect(promptBody.authorId).toBe("github:carol");
+  });
+
+  it("returns early if no @mention", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+    const payload: ReviewCommentPayload = {
+      ...reviewCommentPayload,
+      comment: { ...reviewCommentPayload.comment, body: "just a comment" },
+    };
+
+    await handleReviewComment(env, log, payload, "trace-3");
+
+    expect(generateInstallationToken).not.toHaveBeenCalled();
+  });
+
+  it("returns early if comment is from the bot (loop prevention)", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+    const payload: ReviewCommentPayload = {
+      ...reviewCommentPayload,
+      sender: { login: "test-bot[bot]" },
+    };
+
+    await handleReviewComment(env, log, payload, "trace-3");
+
+    expect(generateInstallationToken).not.toHaveBeenCalled();
+  });
+});
+
+describe("error handling", () => {
+  it("throws when session creation fails", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+    getControlPlaneFetch(env).mockResolvedValue(
+      new Response("Internal Server Error", { status: 500 })
+    );
+
+    await expect(
+      handleReviewRequested(env, log, reviewRequestedPayload, "trace-err")
+    ).rejects.toThrow("Session creation failed: 500");
+  });
+
+  it("proceeds with session even if reaction fails", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+    vi.mocked(postReaction).mockResolvedValue(false);
+
+    await handleReviewRequested(env, log, reviewRequestedPayload, "trace-reaction");
+
+    // Session should still be created despite reaction failure
+    expect(getControlPlaneFetch(env)).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/github-bot/test/prompts.test.ts
+++ b/packages/github-bot/test/prompts.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { buildCodeReviewPrompt, buildCommentActionPrompt } from "../src/prompts";
+
+describe("buildCodeReviewPrompt", () => {
+  const baseParams = {
+    owner: "acme",
+    repo: "widgets",
+    number: 42,
+    title: "Add caching layer",
+    body: "This PR adds Redis caching to the API.",
+    author: "alice",
+    base: "main",
+    head: "feature/cache",
+  };
+
+  it("includes all fields in the prompt", () => {
+    const prompt = buildCodeReviewPrompt(baseParams);
+    expect(prompt).toContain("Pull Request #42");
+    expect(prompt).toContain("acme/widgets");
+    expect(prompt).toContain("feature/cache");
+    expect(prompt).toContain("Add caching layer");
+    expect(prompt).toContain("@alice");
+    expect(prompt).toContain("main ← feature/cache");
+    expect(prompt).toContain("This PR adds Redis caching to the API.");
+    expect(prompt).toContain("gh pr diff 42");
+    expect(prompt).toContain("gh api repos/acme/widgets/pulls/42/reviews");
+  });
+
+  it("handles null body gracefully", () => {
+    const prompt = buildCodeReviewPrompt({ ...baseParams, body: null });
+    expect(prompt).toContain("_No description provided._");
+    expect(prompt).not.toContain("null");
+  });
+
+  it("handles multiline body", () => {
+    const body = "## Summary\n\n- Added caching\n- Updated tests\n\n## Notes\nSee RFC-123";
+    const prompt = buildCodeReviewPrompt({ ...baseParams, body });
+    expect(prompt).toContain(body);
+  });
+
+  it("includes inline comment instructions with correct repo path", () => {
+    const prompt = buildCodeReviewPrompt(baseParams);
+    expect(prompt).toContain("repos/acme/widgets/pulls/42/comments");
+  });
+});
+
+describe("buildCommentActionPrompt", () => {
+  const baseParams = {
+    owner: "acme",
+    repo: "widgets",
+    number: 42,
+    commentBody: "please add error handling",
+    commenter: "bob",
+    title: "Add caching layer",
+    base: "main",
+    head: "feature/cache",
+  };
+
+  it("includes all fields in the prompt", () => {
+    const prompt = buildCommentActionPrompt(baseParams);
+    expect(prompt).toContain("Pull Request #42");
+    expect(prompt).toContain("acme/widgets");
+    expect(prompt).toContain("feature/cache");
+    expect(prompt).toContain("Add caching layer");
+    expect(prompt).toContain("main ← feature/cache");
+    expect(prompt).toContain('@bob says: "please add error handling"');
+    expect(prompt).toContain("gh pr diff 42");
+    expect(prompt).toContain("gh pr view 42 --comments");
+  });
+
+  it("works without title, base, or head (issue comment case)", () => {
+    const prompt = buildCommentActionPrompt({
+      owner: "acme",
+      repo: "widgets",
+      number: 42,
+      commentBody: "fix the bug",
+      commenter: "bob",
+    });
+    expect(prompt).toContain("Pull Request #42");
+    expect(prompt).toContain("acme/widgets");
+    expect(prompt).not.toContain("PR Details");
+    expect(prompt).not.toContain("undefined");
+    expect(prompt).toContain('@bob says: "fix the bug"');
+  });
+
+  it("includes title when provided without base/head", () => {
+    const prompt = buildCommentActionPrompt({
+      owner: "acme",
+      repo: "widgets",
+      number: 42,
+      commentBody: "fix it",
+      commenter: "bob",
+      title: "Fix bug",
+    });
+    expect(prompt).toContain("## PR Details");
+    expect(prompt).toContain("Fix bug");
+    expect(prompt).not.toContain("Branch");
+  });
+
+  it("includes file path and diff hunk for review comments", () => {
+    const prompt = buildCommentActionPrompt({
+      ...baseParams,
+      filePath: "src/cache.ts",
+      diffHunk: "@@ -10,3 +10,5 @@\n+const cache = new Map();",
+      commentId: 999,
+    });
+    expect(prompt).toContain("## Code Location");
+    expect(prompt).toContain("`src/cache.ts`");
+    expect(prompt).toContain("const cache = new Map()");
+    expect(prompt).toContain("pulls/42/comments/999/replies");
+  });
+
+  it("omits code location and reply instruction when not provided", () => {
+    const prompt = buildCommentActionPrompt(baseParams);
+    expect(prompt).not.toContain("## Code Location");
+    expect(prompt).not.toContain("reply to the specific review thread");
+  });
+
+  it("includes summary comment instruction with correct repo path", () => {
+    const prompt = buildCommentActionPrompt(baseParams);
+    expect(prompt).toContain("repos/acme/widgets/issues/42/comments");
+  });
+});

--- a/packages/github-bot/test/verify.test.ts
+++ b/packages/github-bot/test/verify.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { verifyWebhookSignature } from "../src/verify";
+
+/** Generate a valid GitHub webhook signature for a given secret and body. */
+async function sign(secret: string, body: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(body));
+  const hex = Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `sha256=${hex}`;
+}
+
+describe("verifyWebhookSignature", () => {
+  const secret = "test-webhook-secret";
+
+  it("accepts a valid signature", async () => {
+    const body = '{"action":"created"}';
+    const signature = await sign(secret, body);
+    expect(await verifyWebhookSignature(secret, body, signature)).toBe(true);
+  });
+
+  it("rejects an invalid signature", async () => {
+    const body = '{"action":"created"}';
+    const signature = "sha256=0000000000000000000000000000000000000000000000000000000000000000";
+    expect(await verifyWebhookSignature(secret, body, signature)).toBe(false);
+  });
+
+  it("rejects a null signature header", async () => {
+    expect(await verifyWebhookSignature(secret, "body", null)).toBe(false);
+  });
+
+  it("rejects a wrong prefix", async () => {
+    const body = '{"action":"created"}';
+    const signature = await sign(secret, body);
+    const sha1Signature = signature.replace("sha256=", "sha1=");
+    expect(await verifyWebhookSignature(secret, body, sha1Signature)).toBe(false);
+  });
+
+  it("rejects a tampered payload", async () => {
+    const body = '{"action":"created"}';
+    const signature = await sign(secret, body);
+    const tampered = '{"action":"deleted"}';
+    expect(await verifyWebhookSignature(secret, tampered, signature)).toBe(false);
+  });
+
+  it("accepts an empty body with valid signature", async () => {
+    const body = "";
+    const signature = await sign(secret, body);
+    expect(await verifyWebhookSignature(secret, body, signature)).toBe(true);
+  });
+
+  it("rejects an empty signature header", async () => {
+    expect(await verifyWebhookSignature(secret, "body", "")).toBe(false);
+  });
+
+  it("rejects signature with correct prefix but wrong hash", async () => {
+    const body = '{"action":"created"}';
+    const wrongSecret = "wrong-secret";
+    const signature = await sign(wrongSecret, body);
+    expect(await verifyWebhookSignature(secret, body, signature)).toBe(false);
+  });
+});

--- a/packages/github-bot/test/webhook.test.ts
+++ b/packages/github-bot/test/webhook.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Env } from "../src/types";
+import app from "../src/index";
+
+/** Generate a valid GitHub webhook signature for a given secret and body. */
+async function sign(secret: string, body: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(body));
+  const hex = Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `sha256=${hex}`;
+}
+
+const SECRET = "test-webhook-secret";
+
+function makeEnv() {
+  return {
+    GITHUB_WEBHOOK_SECRET: SECRET,
+    GITHUB_BOT_USERNAME: "test-bot[bot]",
+    DEPLOYMENT_NAME: "test",
+    DEFAULT_MODEL: "anthropic/claude-haiku-4-5",
+    LOG_LEVEL: "error",
+  } as unknown as Env;
+}
+
+function makeCtx() {
+  return {
+    waitUntil: vi.fn(),
+    passThroughOnException: vi.fn(),
+  };
+}
+
+describe("POST /webhooks/github", () => {
+  it("returns 401 for invalid signature", async () => {
+    const body = '{"action":"created"}';
+    const res = await app.fetch(
+      new Request("http://localhost/webhooks/github", {
+        method: "POST",
+        body,
+        headers: {
+          "X-Hub-Signature-256": "sha256=invalid",
+          "X-GitHub-Event": "issue_comment",
+        },
+      }),
+      makeEnv(),
+      makeCtx()
+    );
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json).toEqual({ error: "invalid signature" });
+  });
+
+  it("returns 401 for missing signature", async () => {
+    const res = await app.fetch(
+      new Request("http://localhost/webhooks/github", {
+        method: "POST",
+        body: "{}",
+        headers: { "X-GitHub-Event": "push" },
+      }),
+      makeEnv(),
+      makeCtx()
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 and calls waitUntil for valid webhook", async () => {
+    const body = JSON.stringify({
+      action: "review_requested",
+      repository: { owner: { login: "test" }, name: "repo" },
+    });
+    const signature = await sign(SECRET, body);
+    const ctx = makeCtx();
+
+    const res = await app.fetch(
+      new Request("http://localhost/webhooks/github", {
+        method: "POST",
+        body,
+        headers: {
+          "X-Hub-Signature-256": signature,
+          "X-GitHub-Event": "pull_request",
+          "X-GitHub-Delivery": "delivery-123",
+        },
+      }),
+      makeEnv(),
+      ctx
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(ctx.waitUntil).toHaveBeenCalledOnce();
+  });
+
+  it("returns 200 for unhandled event type", async () => {
+    const body = '{"action":"opened"}';
+    const signature = await sign(SECRET, body);
+    const ctx = makeCtx();
+
+    const res = await app.fetch(
+      new Request("http://localhost/webhooks/github", {
+        method: "POST",
+        body,
+        headers: {
+          "X-Hub-Signature-256": signature,
+          "X-GitHub-Event": "push",
+        },
+      }),
+      makeEnv(),
+      ctx
+    );
+
+    expect(res.status).toBe(200);
+    expect(ctx.waitUntil).toHaveBeenCalledOnce();
+  });
+
+  it("returns 200 for handled event with non-matching action", async () => {
+    const body = JSON.stringify({
+      action: "closed",
+      repository: { owner: { login: "test" }, name: "repo" },
+    });
+    const signature = await sign(SECRET, body);
+    const ctx = makeCtx();
+
+    const res = await app.fetch(
+      new Request("http://localhost/webhooks/github", {
+        method: "POST",
+        body,
+        headers: {
+          "X-Hub-Signature-256": signature,
+          "X-GitHub-Event": "pull_request",
+        },
+      }),
+      makeEnv(),
+      ctx
+    );
+
+    expect(res.status).toBe(200);
+    expect(ctx.waitUntil).toHaveBeenCalledOnce();
+  });
+});
+
+describe("GET /health", () => {
+  it("returns healthy status", async () => {
+    const res = await app.fetch(new Request("http://localhost/health"), makeEnv(), makeCtx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      status: "healthy",
+      service: "open-inspect-github-bot",
+    });
+  });
+});

--- a/packages/github-bot/tsconfig.json
+++ b/packages/github-bot/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/packages/github-bot/vitest.config.ts
+++ b/packages/github-bot/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ["src/**/*.test.ts", "test/**/*.test.ts"],
+  },
+});

--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -23,8 +23,8 @@ SANDBOX_DIR = Path(__file__).parent.parent / "sandbox"
 OPENCODE_VERSION = "latest"
 
 # Cache buster - change this to force Modal image rebuild
-# v38: Rebuild to pick up latest OpenCode with GPT 5.3 Codex Spark support
-CACHE_BUSTER = "v38-opencode-codex-spark"
+# v39: Install gh CLI for agent-direct GitHub interaction
+CACHE_BUSTER = "v39-gh-cli"
 
 # Base image with all development tools
 base_image = (
@@ -55,6 +55,15 @@ base_image = (
         "libasound2",
         "libpango-1.0-0",
         "libcairo2",
+    )
+    # Install GitHub CLI (for agent-direct GitHub interaction via gh API)
+    .run_commands(
+        "curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg"
+        " | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg",
+        "echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg]"
+        " https://cli.github.com/packages stable main'"
+        " > /etc/apt/sources.list.d/github-cli.list",
+        "apt-get update && apt-get install -y gh && rm -rf /var/lib/apt/lists/*",
     )
     # Install Node.js 22 LTS
     .run_commands(

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -121,9 +121,10 @@ class SandboxManager:
             }
         )
 
-        # Add GitHub App token if available (for git sync operations)
+        # Add GitHub App token if available (for git sync operations and gh CLI)
         if config.github_app_token:
             env_vars["GITHUB_APP_TOKEN"] = config.github_app_token
+            env_vars["GITHUB_TOKEN"] = config.github_app_token
 
         if config.session_config:
             env_vars["SESSION_CONFIG"] = config.session_config.model_dump_json()
@@ -358,6 +359,7 @@ class SandboxManager:
 
         if github_app_token:
             env_vars["GITHUB_APP_TOKEN"] = github_app_token
+            env_vars["GITHUB_TOKEN"] = github_app_token
 
         # Create the sandbox from the snapshot image
         sandbox = modal.Sandbox.create(

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -20,6 +20,7 @@ locals {
   # Worker script paths (deterministic output locations)
   control_plane_script_path = "${var.project_root}/packages/control-plane/dist/index.js"
   slack_bot_script_path     = "${var.project_root}/packages/slack-bot/dist/index.js"
+  github_bot_script_path    = "${var.project_root}/packages/github-bot/dist/index.js"
 }
 
 # =============================================================================
@@ -215,6 +216,57 @@ module "slack_bot_worker" {
   depends_on = [null_resource.slack_bot_build, module.slack_kv, module.control_plane_worker]
 }
 
+# Build github-bot worker bundle (only runs during apply, not plan)
+resource "null_resource" "github_bot_build" {
+  count = var.enable_github_bot ? 1 : 0
+
+  triggers = {
+    always_run = timestamp()
+  }
+
+  provisioner "local-exec" {
+    command     = "npm run build"
+    working_dir = "${var.project_root}/packages/github-bot"
+  }
+}
+
+module "github_bot_worker" {
+  count  = var.enable_github_bot ? 1 : 0
+  source = "../../modules/cloudflare-worker"
+
+  account_id  = var.cloudflare_account_id
+  worker_name = "open-inspect-github-bot-${local.name_suffix}"
+  script_path = local.github_bot_script_path
+
+  service_bindings = [
+    {
+      binding_name = "CONTROL_PLANE"
+      service_name = "open-inspect-control-plane-${local.name_suffix}"
+    }
+  ]
+
+  enable_service_bindings = var.enable_service_bindings
+
+  plain_text_bindings = [
+    { name = "DEPLOYMENT_NAME", value = var.deployment_name },
+    { name = "DEFAULT_MODEL", value = "anthropic/claude-haiku-4-5" },
+    { name = "GITHUB_BOT_USERNAME", value = var.github_bot_username },
+  ]
+
+  secrets = [
+    { name = "GITHUB_APP_ID", value = var.github_app_id },
+    { name = "GITHUB_APP_PRIVATE_KEY", value = var.github_app_private_key },
+    { name = "GITHUB_APP_INSTALLATION_ID", value = var.github_app_installation_id },
+    { name = "GITHUB_WEBHOOK_SECRET", value = var.github_webhook_secret },
+    { name = "INTERNAL_CALLBACK_SECRET", value = var.internal_callback_secret },
+  ]
+
+  compatibility_date  = "2024-09-23"
+  compatibility_flags = ["nodejs_compat"]
+
+  depends_on = [null_resource.github_bot_build, module.control_plane_worker]
+}
+
 # =============================================================================
 # Vercel Web App
 # =============================================================================
@@ -346,8 +398,8 @@ module "modal_app" {
     {
       name = "internal-api"
       values = {
-        MODAL_API_SECRET             = var.modal_api_secret
-        ALLOWED_CONTROL_PLANE_HOSTS  = local.control_plane_host
+        MODAL_API_SECRET            = var.modal_api_secret
+        ALLOWED_CONTROL_PLANE_HOSTS = local.control_plane_host
       }
     }
   ]

--- a/terraform/environments/production/outputs.tf
+++ b/terraform/environments/production/outputs.tf
@@ -35,6 +35,11 @@ output "slack_bot_worker_name" {
   value       = module.slack_bot_worker.worker_name
 }
 
+output "github_bot_worker_name" {
+  description = "GitHub bot worker name"
+  value       = var.enable_github_bot ? module.github_bot_worker[0].worker_name : null
+}
+
 # Vercel Web App
 output "web_app_url" {
   description = "Vercel web app URL"

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -88,6 +88,34 @@ variable "github_app_installation_id" {
 }
 
 # =============================================================================
+# GitHub Bot Configuration
+# =============================================================================
+
+variable "enable_github_bot" {
+  description = "Enable the GitHub bot worker. Requires github_webhook_secret and github_bot_username."
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = var.enable_github_bot == false || (length(var.github_webhook_secret) > 0 && length(var.github_bot_username) > 0)
+    error_message = "When enable_github_bot is true, github_webhook_secret and github_bot_username must be non-empty."
+  }
+}
+
+variable "github_webhook_secret" {
+  description = "Shared secret for verifying GitHub webhook signatures (generate with: openssl rand -hex 32)"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "github_bot_username" {
+  description = "GitHub App bot username for @mention detection (e.g., 'my-app[bot]')"
+  type        = string
+  default     = ""
+}
+
+# =============================================================================
 # Slack App Credentials
 # =============================================================================
 

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,3 @@
+import { defineWorkspace } from "vitest/config";
+
+export default defineWorkspace(["packages/*/vitest.config.ts"]);


### PR DESCRIPTION
## Summary
- Add `@open-inspect/github-bot` Cloudflare Worker that translates GitHub webhook events into coding agent sessions
- **Auto-review**: automatically reviews non-draft PRs when opened (skips drafts and bot-created PRs)
- **Review requested**: reviews PRs when the bot is assigned as reviewer
- **Comment actions**: @mention the bot in PR comments to trigger actions (code changes, analysis)
- **Review thread replies**: @mention in review comments with file-specific context (path, diff hunk, thread ID)
- Opt-in Terraform deployment via `enable_github_bot` variable (default `false`)
- Install `gh` CLI in Modal sandbox image for agent-side GitHub interaction
- Inject `GITHUB_TOKEN` at sandbox spawn time for authenticated git/API access
- CI integration: github-bot tests in CI pipeline, Terraform workflow triggers on bot changes
- Documentation updates to Getting Started guide and onboarding skill
- 46 unit tests covering all handlers, webhook verification, prompt construction, and auth

## Test plan
- [x] 46 unit tests pass (`npm test -w @open-inspect/github-bot`)
- [x] TypeScript type check passes
- [x] Smoke-tested in production: auto-review on PR open, @mention comment flow, review thread replies