### PR TITLE
refactor: extract integration-settings routes and types

### DIFF
--- a/packages/control-plane/src/routes/shared.ts
+++ b/packages/control-plane/src/routes/shared.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared route primitives used by all route modules.
+ */
+
+import type { CorrelationContext } from "../logger";
+import type { RequestMetrics } from "../db/instrumented-d1";
+import type { Env } from "../types";
+
+/**
+ * Request context with correlation IDs and per-request metrics.
+ */
+export type RequestContext = CorrelationContext & {
+  metrics: RequestMetrics;
+  /** Worker ExecutionContext for waitUntil (background tasks). */
+  executionCtx?: ExecutionContext;
+};
+
+/**
+ * Route configuration.
+ */
+export interface Route {
+  method: string;
+  pattern: RegExp;
+  handler: (
+    request: Request,
+    env: Env,
+    match: RegExpMatchArray,
+    ctx: RequestContext
+  ) => Promise<Response>;
+}
+
+/**
+ * Parse route pattern into regex.
+ */
+export function parsePattern(pattern: string): RegExp {
+  const regexPattern = pattern.replace(/:(\w+)/g, "(?<$1>[^/]+)");
+  return new RegExp(`^${regexPattern}$`);
+}
+
+/**
+ * Create JSON response.
+ */
+export function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Create error response.
+ */
+export function error(message: string, status = 400): Response {
+  return json({ error: message }, status);
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -247,42 +247,4 @@ export interface ListSessionsResponse {
   hasMore: boolean;
 }
 
-// Integration settings types
-
-export type IntegrationId = "github";
-
-/** Enforces the common shape for all integration configurations. */
-export interface IntegrationEntry<TRepo extends object = Record<string, unknown>> {
-  global: {
-    enabledRepos?: string[];
-    defaults?: TRepo;
-  };
-  repo: TRepo;
-}
-
-/** Overridable behavior settings for the GitHub bot. Used at both global (defaults) and per-repo (overrides) levels. */
-export interface GitHubBotSettings {
-  autoReviewOnOpen?: boolean;
-  model?: string;
-  reasoningEffort?: string;
-}
-
-/** Maps each integration ID to its global and per-repo settings types. */
-export interface IntegrationSettingsMap {
-  github: IntegrationEntry<GitHubBotSettings>;
-}
-
-/** Derived type for the GitHub bot global config. */
-export type GitHubGlobalConfig = IntegrationSettingsMap["github"]["global"];
-
-export const INTEGRATION_DEFINITIONS: {
-  id: IntegrationId;
-  name: string;
-  description: string;
-}[] = [
-  {
-    id: "github",
-    name: "GitHub Bot",
-    description: "Automated PR reviews and comment-triggered actions",
-  },
-];
+export * from "./integrations";

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -1,0 +1,39 @@
+// Integration settings types
+
+export type IntegrationId = "github";
+
+/** Enforces the common shape for all integration configurations. */
+export interface IntegrationEntry<TRepo extends object = Record<string, unknown>> {
+  global: {
+    enabledRepos?: string[];
+    defaults?: TRepo;
+  };
+  repo: TRepo;
+}
+
+/** Overridable behavior settings for the GitHub bot. Used at both global (defaults) and per-repo (overrides) levels. */
+export interface GitHubBotSettings {
+  autoReviewOnOpen?: boolean;
+  model?: string;
+  reasoningEffort?: string;
+}
+
+/** Maps each integration ID to its global and per-repo settings types. */
+export interface IntegrationSettingsMap {
+  github: IntegrationEntry<GitHubBotSettings>;
+}
+
+/** Derived type for the GitHub bot global config. */
+export type GitHubGlobalConfig = IntegrationSettingsMap["github"]["global"];
+
+export const INTEGRATION_DEFINITIONS: {
+  id: IntegrationId;
+  name: string;
+  description: string;
+}[] = [
+  {
+    id: "github",
+    name: "GitHub Bot",
+    description: "Automated PR reviews and comment-triggered actions",
+  },
+];


### PR DESCRIPTION
## Summary
- Extract integration types (`IntegrationId`, `GitHubBotSettings`, `INTEGRATION_DEFINITIONS`, etc.) from `types.ts` into `types/integrations.ts`, converting `types.ts` to a `types/` directory module with a re-export
- Extract all 8 integration-settings route handlers and route table entries from `router.ts` into `routes/integration-settings.ts`, with shared route primitives (`Route`, `RequestContext`, `parsePattern`, `json`, `error`) in `routes/utils.ts`
- Reduces `router.ts` by ~390 lines and establishes the pattern for future route/type extractions

## Test plan
- [x] `npm run build -w @open-inspect/shared` — shared types compile
- [x] `npm run typecheck -w @open-inspect/control-plane` — no broken imports
- [x] `npm run typecheck -w @open-inspect/web` — web UI still resolves shared types
- [x] `npm run test -w @open-inspect/control-plane` — 461 unit tests pass
- [x] Integration tests — 100 tests pass
- [x] `npm run lint` — no lint errors