### PR TITLE
Redesign integrations settings into scalable provider detail flow

### DIFF
--- a/packages/web/src/components/settings/integrations-settings.tsx
+++ b/packages/web/src/components/settings/integrations-settings.tsx
@@ -1,564 +1,161 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import useSWR, { mutate } from "swr";
-import {
-  MODEL_REASONING_CONFIG,
-  isValidReasoningEffort,
-  type GitHubGlobalConfig,
-  type GitHubBotSettings,
-  type EnrichedRepository,
-  type ValidModel,
-} from "@open-inspect/shared";
-import { useEnabledModels } from "@/hooks/use-enabled-models";
-
-const GLOBAL_SETTINGS_KEY = "/api/integration-settings/github";
-const REPO_SETTINGS_KEY = "/api/integration-settings/github/repos";
-
-interface GlobalResponse {
-  integrationId: string;
-  settings: GitHubGlobalConfig | null;
-}
-
-interface RepoSettingsEntry {
-  repo: string;
-  settings: GitHubBotSettings;
-}
-
-interface RepoListResponse {
-  integrationId: string;
-  repos: RepoSettingsEntry[];
-}
-
-interface ReposResponse {
-  repos: EnrichedRepository[];
-}
+import { useMemo, useState } from "react";
+import { INTEGRATION_DEFINITIONS, type IntegrationId } from "@open-inspect/shared";
+import { useIsMobile } from "@/hooks/use-media-query";
+import { GitHubIntegrationSettings } from "@/components/settings/integrations/github-integration-settings";
 
 export function IntegrationsSettings() {
-  const { data: globalData, isLoading: globalLoading } =
-    useSWR<GlobalResponse>(GLOBAL_SETTINGS_KEY);
-  const { data: repoSettingsData, isLoading: repoSettingsLoading } =
-    useSWR<RepoListResponse>(REPO_SETTINGS_KEY);
-  const { data: reposData } = useSWR<ReposResponse>("/api/repos");
-  const { enabledModelOptions } = useEnabledModels();
+  const isMobile = useIsMobile();
+  const [selectedIntegrationId, setSelectedIntegrationId] = useState<IntegrationId | null>(null);
 
-  const loading = globalLoading || repoSettingsLoading;
+  const integrations = useMemo(() => INTEGRATION_DEFINITIONS, []);
 
-  if (loading) {
+  const activeIntegrationId =
+    selectedIntegrationId ?? (isMobile ? null : (integrations[0]?.id ?? null));
+
+  if (isMobile) {
     return (
-      <div className="flex items-center gap-2 text-muted-foreground">
-        <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
-        Loading integration settings...
+      <div>
+        <h2 className="text-xl font-semibold text-foreground mb-1">Integrations</h2>
+        <p className="text-sm text-muted-foreground mb-6">
+          Choose an integration to configure its connection and behavior.
+        </p>
+
+        {activeIntegrationId ? (
+          <div>
+            <button
+              type="button"
+              onClick={() => setSelectedIntegrationId(null)}
+              className="mb-4 flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition"
+            >
+              <BackIcon />
+              Back to integrations
+            </button>
+            <IntegrationDetail integrationId={activeIntegrationId} />
+          </div>
+        ) : (
+          <IntegrationList
+            integrations={integrations}
+            selectedIntegrationId={selectedIntegrationId}
+            onSelect={setSelectedIntegrationId}
+          />
+        )}
       </div>
     );
   }
 
-  const settings = globalData?.settings;
-  const repoOverrides = repoSettingsData?.repos ?? [];
-  const availableRepos = reposData?.repos ?? [];
-
   return (
     <div>
-      <h2 className="text-xl font-semibold text-foreground mb-1">GitHub Bot</h2>
+      <h2 className="text-xl font-semibold text-foreground mb-1">Integrations</h2>
       <p className="text-sm text-muted-foreground mb-6">
-        Configure automated PR reviews and comment-triggered actions.
+        Choose an integration to configure its connection and behavior.
       </p>
 
-      <GlobalSettingsSection settings={settings} availableRepos={availableRepos} />
-
-      <div className="mt-8 border-t border-border-muted pt-8">
-        <RepoOverridesSection
-          overrides={repoOverrides}
-          availableRepos={availableRepos}
-          enabledModelOptions={enabledModelOptions}
+      <div className="grid grid-cols-[220px_minmax(0,1fr)] gap-6 items-start">
+        <IntegrationList
+          integrations={integrations}
+          selectedIntegrationId={activeIntegrationId}
+          onSelect={setSelectedIntegrationId}
         />
-      </div>
-    </div>
-  );
-}
 
-function GlobalSettingsSection({
-  settings,
-  availableRepos,
-}: {
-  settings: GitHubGlobalConfig | null | undefined;
-  availableRepos: EnrichedRepository[];
-}) {
-  const [autoReviewOnOpen, setAutoReviewOnOpen] = useState(
-    settings?.defaults?.autoReviewOnOpen ?? true
-  );
-  const [enabledRepos, setEnabledRepos] = useState<string[]>(settings?.enabledRepos ?? []);
-  const [allReposMode, setAllReposMode] = useState(settings?.enabledRepos === undefined);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState("");
-  const [success, setSuccess] = useState("");
-  const [dirty, setDirty] = useState(false);
-  const [initialized, setInitialized] = useState(false);
-
-  // Sync SWR data into local state once on initial load
-  useEffect(() => {
-    if (settings !== undefined && !initialized) {
-      if (settings) {
-        setAutoReviewOnOpen(settings.defaults?.autoReviewOnOpen ?? true);
-        setEnabledRepos(settings.enabledRepos ?? []);
-        setAllReposMode(settings.enabledRepos === undefined);
-      }
-      setInitialized(true);
-    }
-  }, [settings, initialized]);
-
-  const isConfigured = settings !== null && settings !== undefined;
-
-  const handleReset = async () => {
-    if (
-      !window.confirm(
-        "Reset all GitHub bot settings to defaults? The bot will respond to all repos with auto-review enabled."
-      )
-    ) {
-      return;
-    }
-
-    setSaving(true);
-    setError("");
-    setSuccess("");
-
-    try {
-      const res = await fetch(GLOBAL_SETTINGS_KEY, { method: "DELETE" });
-
-      if (res.ok) {
-        mutate(GLOBAL_SETTINGS_KEY);
-        setAutoReviewOnOpen(true);
-        setEnabledRepos([]);
-        setAllReposMode(true);
-        setDirty(false);
-        setSuccess("Settings reset to defaults.");
-      } else {
-        const data = await res.json();
-        setError(data.error || "Failed to reset settings");
-      }
-    } catch {
-      setError("Failed to reset settings");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleSave = async () => {
-    setSaving(true);
-    setError("");
-    setSuccess("");
-
-    const body: GitHubGlobalConfig = {
-      defaults: { autoReviewOnOpen },
-    };
-    if (!allReposMode) {
-      body.enabledRepos = enabledRepos;
-    }
-
-    try {
-      const res = await fetch(GLOBAL_SETTINGS_KEY, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ settings: body }),
-      });
-
-      if (res.ok) {
-        mutate(GLOBAL_SETTINGS_KEY);
-        setSuccess("Settings saved.");
-        setDirty(false);
-      } else {
-        const data = await res.json();
-        setError(data.error || "Failed to save settings");
-      }
-    } catch {
-      setError("Failed to save settings");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const toggleRepo = (fullName: string) => {
-    const lower = fullName.toLowerCase();
-    setEnabledRepos((prev) =>
-      prev.includes(lower) ? prev.filter((r) => r !== lower) : [...prev, lower]
-    );
-    setDirty(true);
-    setError("");
-    setSuccess("");
-  };
-
-  return (
-    <div>
-      <h3 className="text-sm font-medium text-foreground uppercase tracking-wider mb-3">
-        Global Settings
-      </h3>
-
-      {error && (
-        <div className="mb-4 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 px-4 py-3 border border-red-200 dark:border-red-800 text-sm">
-          {error}
-        </div>
-      )}
-
-      {success && (
-        <div className="mb-4 bg-green-50 dark:bg-green-900/20 text-green-600 dark:text-green-400 px-4 py-3 border border-green-200 dark:border-green-800 text-sm">
-          {success}
-        </div>
-      )}
-
-      {/* Auto-review toggle */}
-      <label className="flex items-center justify-between px-4 py-3 border border-border hover:bg-muted/50 transition cursor-pointer mb-4">
-        <div>
-          <span className="text-sm font-medium text-foreground">Auto-review new PRs</span>
-          <span className="text-sm text-muted-foreground ml-2">
-            Automatically review non-draft PRs when opened
-          </span>
-        </div>
-        <div className="relative">
-          <input
-            type="checkbox"
-            checked={autoReviewOnOpen}
-            onChange={() => {
-              setAutoReviewOnOpen(!autoReviewOnOpen);
-              setDirty(true);
-              setError("");
-              setSuccess("");
-            }}
-            className="sr-only peer"
-          />
-          <div className="w-9 h-5 bg-muted rounded-full peer-checked:bg-accent transition-colors" />
-          <div className="absolute left-0.5 top-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform peer-checked:translate-x-4" />
-        </div>
-      </label>
-
-      {/* Repo scope */}
-      <div className="mb-4">
-        <div className="flex items-center justify-between mb-2">
-          <span className="text-sm font-medium text-foreground">Enabled Repositories</span>
-          <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
-            <input
-              type="checkbox"
-              checked={allReposMode}
-              onChange={() => {
-                setAllReposMode(!allReposMode);
-                setDirty(true);
-                setError("");
-                setSuccess("");
-              }}
-              className="rounded border-border"
-            />
-            All repos
-          </label>
-        </div>
-
-        {!allReposMode && (
-          <>
-            {availableRepos.length === 0 ? (
-              <p className="text-sm text-muted-foreground px-4 py-3 border border-border">
-                GitHub App not configured — repository filtering unavailable. The bot will respond
-                to all repos.
-              </p>
-            ) : (
-              <div className="border border-border max-h-48 overflow-y-auto">
-                {availableRepos.map((repo) => {
-                  const fullName = repo.fullName.toLowerCase();
-                  const isChecked = enabledRepos.includes(fullName);
-                  return (
-                    <label
-                      key={repo.fullName}
-                      className="flex items-center gap-2 px-4 py-2 hover:bg-muted/50 transition cursor-pointer text-sm"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={isChecked}
-                        onChange={() => toggleRepo(repo.fullName)}
-                        className="rounded border-border"
-                      />
-                      <span className="text-foreground">{repo.fullName}</span>
-                    </label>
-                  );
-                })}
-              </div>
-            )}
-
-            {enabledRepos.length === 0 && availableRepos.length > 0 && (
-              <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
-                No repos selected — the bot will not respond to any webhooks.
-              </p>
-            )}
-          </>
-        )}
-      </div>
-
-      <div className="flex items-center gap-2">
-        <button
-          type="button"
-          onClick={handleSave}
-          disabled={saving || !dirty}
-          className="px-4 py-2 text-sm font-medium text-white bg-accent hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition"
-        >
-          {saving ? "Saving..." : "Save"}
-        </button>
-
-        {isConfigured && (
-          <button
-            type="button"
-            onClick={handleReset}
-            disabled={saving}
-            className="px-4 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/50 disabled:opacity-50 disabled:cursor-not-allowed transition"
-          >
-            Reset to defaults
-          </button>
+        {activeIntegrationId ? (
+          <IntegrationDetail integrationId={activeIntegrationId} />
+        ) : (
+          <EmptyState />
         )}
       </div>
     </div>
   );
 }
 
-function RepoOverridesSection({
-  overrides,
-  availableRepos,
-  enabledModelOptions,
+function IntegrationList({
+  integrations,
+  selectedIntegrationId,
+  onSelect,
 }: {
-  overrides: RepoSettingsEntry[];
-  availableRepos: EnrichedRepository[];
-  enabledModelOptions: { category: string; models: { id: string; name: string }[] }[];
+  integrations: typeof INTEGRATION_DEFINITIONS;
+  selectedIntegrationId: IntegrationId | null;
+  onSelect: (integrationId: IntegrationId) => void;
 }) {
-  const [addingRepo, setAddingRepo] = useState<string>("");
-  const [error, setError] = useState("");
-  const [success, setSuccess] = useState("");
-
-  const overriddenRepos = new Set(overrides.map((o) => o.repo));
-  const availableForOverride = availableRepos.filter(
-    (r) => !overriddenRepos.has(r.fullName.toLowerCase())
-  );
-
-  const handleAdd = async () => {
-    if (!addingRepo) return;
-    const [owner, name] = addingRepo.split("/");
-    setError("");
-    setSuccess("");
-
-    try {
-      const res = await fetch(`/api/integration-settings/github/repos/${owner}/${name}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ settings: {} }),
-      });
-
-      if (res.ok) {
-        mutate(REPO_SETTINGS_KEY);
-        setAddingRepo("");
-        setSuccess("Override added.");
-      } else {
-        const data = await res.json();
-        setError(data.error || "Failed to add override");
-      }
-    } catch {
-      setError("Failed to add override");
-    }
-  };
-
   return (
-    <div>
-      <h3 className="text-sm font-medium text-foreground uppercase tracking-wider mb-1">
-        Per-Repo Model Overrides
-      </h3>
-      <p className="text-sm text-muted-foreground mb-4">
-        Repos without an override use the deployment default.
-      </p>
+    <div className="border border-border-muted rounded-md bg-background">
+      <ul className="divide-y divide-border-muted">
+        {integrations.map((integration) => {
+          const isSelected = integration.id === selectedIntegrationId;
 
-      {error && (
-        <div className="mb-4 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 px-4 py-3 border border-red-200 dark:border-red-800 text-sm">
-          {error}
-        </div>
-      )}
-
-      {success && (
-        <div className="mb-4 bg-green-50 dark:bg-green-900/20 text-green-600 dark:text-green-400 px-4 py-3 border border-green-200 dark:border-green-800 text-sm">
-          {success}
-        </div>
-      )}
-
-      {overrides.length > 0 && (
-        <div className="space-y-2 mb-4">
-          {overrides.map((entry) => (
-            <RepoOverrideRow
-              key={entry.repo}
-              entry={entry}
-              enabledModelOptions={enabledModelOptions}
-              onError={setError}
-              onSuccess={setSuccess}
-            />
-          ))}
-        </div>
-      )}
-
-      {/* Add override */}
-      <div className="flex items-center gap-2">
-        <select
-          value={addingRepo}
-          onChange={(e) => setAddingRepo(e.target.value)}
-          className="flex-1 px-3 py-2 text-sm border border-border bg-background text-foreground"
-        >
-          <option value="">Select a repo...</option>
-          {availableForOverride.map((repo) => (
-            <option key={repo.fullName} value={repo.fullName.toLowerCase()}>
-              {repo.fullName}
-            </option>
-          ))}
-        </select>
-        <button
-          type="button"
-          onClick={handleAdd}
-          disabled={!addingRepo}
-          className="px-4 py-2 text-sm font-medium text-white bg-accent hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition"
-        >
-          Add Override
-        </button>
-      </div>
+          return (
+            <li key={integration.id}>
+              <button
+                type="button"
+                onClick={() => onSelect(integration.id)}
+                className={`w-full text-left px-4 py-3 transition ${
+                  isSelected
+                    ? "bg-muted text-foreground"
+                    : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+                }`}
+                aria-current={isSelected ? "page" : undefined}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <p className="text-sm font-medium">{integration.name}</p>
+                    <p className="text-xs mt-1">{integration.description}</p>
+                  </div>
+                  <ChevronRightIcon className={isSelected ? "text-foreground" : undefined} />
+                </div>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
     </div>
   );
 }
 
-function RepoOverrideRow({
-  entry,
-  enabledModelOptions,
-  onError,
-  onSuccess,
-}: {
-  entry: RepoSettingsEntry;
-  enabledModelOptions: { category: string; models: { id: string; name: string }[] }[];
-  onError: (msg: string) => void;
-  onSuccess: (msg: string) => void;
-}) {
-  const [model, setModel] = useState(entry.settings.model ?? "");
-  const [effort, setEffort] = useState(entry.settings.reasoningEffort ?? "");
-  const [saving, setSaving] = useState(false);
-  const [dirty, setDirty] = useState(false);
+function IntegrationDetail({ integrationId }: { integrationId: IntegrationId }) {
+  if (integrationId === "github") {
+    return <GitHubIntegrationSettings />;
+  }
 
-  const reasoningConfig = model ? MODEL_REASONING_CONFIG[model as ValidModel] : undefined;
+  return <EmptyState />;
+}
 
-  const handleModelChange = (newModel: string) => {
-    setModel(newModel);
-    setDirty(true);
-    // Clear stale effort if invalid for new model
-    if (effort && newModel && !isValidReasoningEffort(newModel, effort)) {
-      setEffort("");
-    }
-  };
-
-  const handleSave = async () => {
-    setSaving(true);
-    onError("");
-    onSuccess("");
-
-    const [owner, name] = entry.repo.split("/");
-    const settings: GitHubBotSettings = {};
-    if (model) settings.model = model;
-    if (effort) settings.reasoningEffort = effort;
-
-    try {
-      const res = await fetch(`/api/integration-settings/github/repos/${owner}/${name}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ settings }),
-      });
-
-      if (res.ok) {
-        mutate(REPO_SETTINGS_KEY);
-        setDirty(false);
-        onSuccess(`Override for ${entry.repo} saved.`);
-      } else {
-        const data = await res.json();
-        onError(data.error || "Failed to save override");
-      }
-    } catch {
-      onError("Failed to save override");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleDelete = async () => {
-    const [owner, name] = entry.repo.split("/");
-    onError("");
-    onSuccess("");
-
-    try {
-      const res = await fetch(`/api/integration-settings/github/repos/${owner}/${name}`, {
-        method: "DELETE",
-      });
-
-      if (res.ok) {
-        mutate(REPO_SETTINGS_KEY);
-        onSuccess(`Override for ${entry.repo} removed.`);
-      } else {
-        const data = await res.json();
-        onError(data.error || "Failed to delete override");
-      }
-    } catch {
-      onError("Failed to delete override");
-    }
-  };
-
+function EmptyState() {
   return (
-    <div className="flex items-center gap-2 px-4 py-3 border border-border">
-      <span className="text-sm font-medium text-foreground min-w-[140px] truncate">
-        {entry.repo}
-      </span>
-
-      <select
-        value={model}
-        onChange={(e) => handleModelChange(e.target.value)}
-        className="flex-1 px-2 py-1 text-sm border border-border bg-background text-foreground"
-      >
-        <option value="">Default model</option>
-        {enabledModelOptions.map((group) => (
-          <optgroup key={group.category} label={group.category}>
-            {group.models.map((m) => (
-              <option key={m.id} value={m.id}>
-                {m.name}
-              </option>
-            ))}
-          </optgroup>
-        ))}
-      </select>
-
-      {reasoningConfig && (
-        <select
-          value={effort}
-          onChange={(e) => {
-            setEffort(e.target.value);
-            setDirty(true);
-          }}
-          className="w-28 px-2 py-1 text-sm border border-border bg-background text-foreground"
-        >
-          <option value="">Default effort</option>
-          {reasoningConfig.efforts.map((e) => (
-            <option key={e} value={e}>
-              {e}
-            </option>
-          ))}
-        </select>
-      )}
-
-      <button
-        type="button"
-        onClick={handleSave}
-        disabled={saving || !dirty}
-        className="px-3 py-1 text-sm font-medium text-white bg-accent hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition"
-      >
-        {saving ? "..." : "Save"}
-      </button>
-
-      <button
-        type="button"
-        onClick={handleDelete}
-        className="px-3 py-1 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition"
-        title="Remove override"
-      >
-        Remove
-      </button>
+    <div className="border border-dashed border-border-muted rounded-md px-6 py-8 text-sm text-muted-foreground">
+      Select an integration to manage its settings.
     </div>
+  );
+}
+
+function BackIcon() {
+  return (
+    <svg
+      className="w-4 h-4"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M15 18l-6-6 6-6" />
+    </svg>
+  );
+}
+
+function ChevronRightIcon({ className = "text-muted-foreground" }: { className?: string }) {
+  return (
+    <svg
+      className={`w-4 h-4 mt-0.5 ${className}`}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M9 18l6-6-6-6" />
+    </svg>
   );
 }

--- a/packages/web/src/components/settings/integrations/github-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/github-integration-settings.tsx
@@ -1,0 +1,600 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import useSWR, { mutate } from "swr";
+import {
+  MODEL_REASONING_CONFIG,
+  isValidReasoningEffort,
+  type EnrichedRepository,
+  type GitHubBotSettings,
+  type GitHubGlobalConfig,
+  type ValidModel,
+} from "@open-inspect/shared";
+import { useEnabledModels } from "@/hooks/use-enabled-models";
+
+const GLOBAL_SETTINGS_KEY = "/api/integration-settings/github";
+const REPO_SETTINGS_KEY = "/api/integration-settings/github/repos";
+
+interface GlobalResponse {
+  settings: GitHubGlobalConfig | null;
+}
+
+interface RepoSettingsEntry {
+  repo: string;
+  settings: GitHubBotSettings;
+}
+
+interface RepoListResponse {
+  repos: RepoSettingsEntry[];
+}
+
+interface ReposResponse {
+  repos: EnrichedRepository[];
+}
+
+export function GitHubIntegrationSettings() {
+  const { data: globalData, isLoading: globalLoading } =
+    useSWR<GlobalResponse>(GLOBAL_SETTINGS_KEY);
+  const { data: repoSettingsData, isLoading: repoSettingsLoading } =
+    useSWR<RepoListResponse>(REPO_SETTINGS_KEY);
+  const { data: reposData } = useSWR<ReposResponse>("/api/repos");
+  const { enabledModelOptions } = useEnabledModels();
+
+  if (globalLoading || repoSettingsLoading) {
+    return (
+      <div className="flex items-center gap-2 text-muted-foreground">
+        <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+        Loading GitHub settings...
+      </div>
+    );
+  }
+
+  const settings = globalData?.settings;
+  const repoOverrides = repoSettingsData?.repos ?? [];
+  const availableRepos = reposData?.repos ?? [];
+
+  return (
+    <div>
+      <h3 className="text-lg font-semibold text-foreground mb-1">GitHub Bot</h3>
+      <p className="text-sm text-muted-foreground mb-6">
+        Configure automated PR reviews and comment-triggered actions.
+      </p>
+
+      <Section
+        title="Connection"
+        description="GitHub App access used for repo discovery and scope."
+      >
+        {availableRepos.length > 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Repository access is available. You can limit the bot to selected repositories below.
+          </p>
+        ) : (
+          <p className="text-sm text-amber-700 bg-amber-50 border border-amber-200 px-4 py-3 rounded-sm">
+            GitHub App is not configured or has no accessible repositories. Repository filtering is
+            currently unavailable.
+          </p>
+        )}
+      </Section>
+
+      <GlobalSettingsSection settings={settings} availableRepos={availableRepos} />
+
+      <Section
+        title="Repository Overrides"
+        description="Set model and reasoning overrides for specific repositories."
+      >
+        <RepoOverridesSection
+          overrides={repoOverrides}
+          availableRepos={availableRepos}
+          enabledModelOptions={enabledModelOptions}
+        />
+      </Section>
+    </div>
+  );
+}
+
+function GlobalSettingsSection({
+  settings,
+  availableRepos,
+}: {
+  settings: GitHubGlobalConfig | null | undefined;
+  availableRepos: EnrichedRepository[];
+}) {
+  const [autoReviewOnOpen, setAutoReviewOnOpen] = useState(
+    settings?.defaults?.autoReviewOnOpen ?? true
+  );
+  const [enabledRepos, setEnabledRepos] = useState<string[]>(settings?.enabledRepos ?? []);
+  const [repoScopeMode, setRepoScopeMode] = useState<"all" | "selected">(
+    settings?.enabledRepos === undefined ? "all" : "selected"
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const [dirty, setDirty] = useState(false);
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    if (settings !== undefined && !initialized) {
+      if (settings) {
+        setAutoReviewOnOpen(settings.defaults?.autoReviewOnOpen ?? true);
+        setEnabledRepos(settings.enabledRepos ?? []);
+        setRepoScopeMode(settings.enabledRepos === undefined ? "all" : "selected");
+      }
+      setInitialized(true);
+    }
+  }, [settings, initialized]);
+
+  const isConfigured = settings !== null && settings !== undefined;
+
+  const handleReset = async () => {
+    if (
+      !window.confirm(
+        "Reset all GitHub bot settings to defaults? The bot will respond to all repos with auto-review enabled."
+      )
+    ) {
+      return;
+    }
+
+    setSaving(true);
+    setError("");
+    setSuccess("");
+
+    try {
+      const res = await fetch(GLOBAL_SETTINGS_KEY, { method: "DELETE" });
+
+      if (res.ok) {
+        mutate(GLOBAL_SETTINGS_KEY);
+        setAutoReviewOnOpen(true);
+        setEnabledRepos([]);
+        setRepoScopeMode("all");
+        setDirty(false);
+        setSuccess("Settings reset to defaults.");
+      } else {
+        const data = await res.json();
+        setError(data.error || "Failed to reset settings");
+      }
+    } catch {
+      setError("Failed to reset settings");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError("");
+    setSuccess("");
+
+    const body: GitHubGlobalConfig = {
+      defaults: { autoReviewOnOpen },
+    };
+
+    if (repoScopeMode === "selected") {
+      body.enabledRepos = enabledRepos;
+    }
+
+    try {
+      const res = await fetch(GLOBAL_SETTINGS_KEY, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ settings: body }),
+      });
+
+      if (res.ok) {
+        mutate(GLOBAL_SETTINGS_KEY);
+        setSuccess("Settings saved.");
+        setDirty(false);
+      } else {
+        const data = await res.json();
+        setError(data.error || "Failed to save settings");
+      }
+    } catch {
+      setError("Failed to save settings");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const toggleRepo = (fullName: string) => {
+    const lower = fullName.toLowerCase();
+    setEnabledRepos((prev) =>
+      prev.includes(lower) ? prev.filter((r) => r !== lower) : [...prev, lower]
+    );
+    setDirty(true);
+    setError("");
+    setSuccess("");
+  };
+
+  return (
+    <Section title="Defaults & Scope" description="Global behavior and repository targeting.">
+      {error && <Message tone="error" text={error} />}
+      {success && <Message tone="success" text={success} />}
+
+      <label className="flex items-center justify-between px-4 py-3 border border-border hover:bg-muted/50 transition cursor-pointer mb-4 rounded-sm">
+        <div>
+          <span className="text-sm font-medium text-foreground">Auto-review new PRs</span>
+          <span className="text-sm text-muted-foreground ml-2">
+            Automatically review non-draft PRs when opened
+          </span>
+        </div>
+        <div className="relative">
+          <input
+            type="checkbox"
+            checked={autoReviewOnOpen}
+            onChange={() => {
+              setAutoReviewOnOpen(!autoReviewOnOpen);
+              setDirty(true);
+              setError("");
+              setSuccess("");
+            }}
+            className="sr-only peer"
+          />
+          <div className="w-9 h-5 bg-muted rounded-full peer-checked:bg-accent transition-colors" />
+          <div className="absolute left-0.5 top-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform peer-checked:translate-x-4" />
+        </div>
+      </label>
+
+      <div className="mb-4">
+        <p className="text-sm font-medium text-foreground mb-2">Repository Scope</p>
+        <div className="grid sm:grid-cols-2 gap-2 mb-3">
+          <label className="flex items-center gap-2 px-3 py-2 border border-border rounded-sm cursor-pointer hover:bg-muted/50 transition text-sm">
+            <input
+              type="radio"
+              name="repo-scope"
+              checked={repoScopeMode === "all"}
+              onChange={() => {
+                setRepoScopeMode("all");
+                setDirty(true);
+                setError("");
+                setSuccess("");
+              }}
+            />
+            All repositories
+          </label>
+          <label className="flex items-center gap-2 px-3 py-2 border border-border rounded-sm cursor-pointer hover:bg-muted/50 transition text-sm">
+            <input
+              type="radio"
+              name="repo-scope"
+              checked={repoScopeMode === "selected"}
+              onChange={() => {
+                setRepoScopeMode("selected");
+                setDirty(true);
+                setError("");
+                setSuccess("");
+              }}
+            />
+            Selected repositories
+          </label>
+        </div>
+
+        {repoScopeMode === "selected" && (
+          <>
+            {availableRepos.length === 0 ? (
+              <p className="text-sm text-muted-foreground px-4 py-3 border border-border rounded-sm">
+                Repository filtering is unavailable because no repositories are accessible.
+              </p>
+            ) : (
+              <div className="border border-border max-h-56 overflow-y-auto rounded-sm">
+                {availableRepos.map((repo) => {
+                  const fullName = repo.fullName.toLowerCase();
+                  const isChecked = enabledRepos.includes(fullName);
+
+                  return (
+                    <label
+                      key={repo.fullName}
+                      className="flex items-center gap-2 px-4 py-2 hover:bg-muted/50 transition cursor-pointer text-sm"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={isChecked}
+                        onChange={() => toggleRepo(repo.fullName)}
+                        className="rounded border-border"
+                      />
+                      <span className="text-foreground">{repo.fullName}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+
+            {enabledRepos.length === 0 && availableRepos.length > 0 && (
+              <p className="text-xs text-amber-700 mt-1">
+                No repositories selected. The bot will not respond to webhooks.
+              </p>
+            )}
+          </>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving || !dirty}
+          className="px-4 py-2 text-sm font-medium text-white bg-accent hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition"
+        >
+          {saving ? "Saving..." : "Save"}
+        </button>
+
+        {isConfigured && (
+          <button
+            type="button"
+            onClick={handleReset}
+            disabled={saving}
+            className="px-4 py-2 text-sm text-red-600 hover:text-red-700 hover:bg-red-50 disabled:opacity-50 disabled:cursor-not-allowed transition"
+          >
+            Reset to defaults
+          </button>
+        )}
+      </div>
+    </Section>
+  );
+}
+
+function RepoOverridesSection({
+  overrides,
+  availableRepos,
+  enabledModelOptions,
+}: {
+  overrides: RepoSettingsEntry[];
+  availableRepos: EnrichedRepository[];
+  enabledModelOptions: { category: string; models: { id: string; name: string }[] }[];
+}) {
+  const [addingRepo, setAddingRepo] = useState("");
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+
+  const overriddenRepos = new Set(overrides.map((o) => o.repo));
+  const availableForOverride = availableRepos.filter(
+    (r) => !overriddenRepos.has(r.fullName.toLowerCase())
+  );
+
+  const handleAdd = async () => {
+    if (!addingRepo) return;
+    const [owner, name] = addingRepo.split("/");
+    setError("");
+    setSuccess("");
+
+    try {
+      const res = await fetch(`/api/integration-settings/github/repos/${owner}/${name}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ settings: {} }),
+      });
+
+      if (res.ok) {
+        mutate(REPO_SETTINGS_KEY);
+        setAddingRepo("");
+        setSuccess("Override added.");
+      } else {
+        const data = await res.json();
+        setError(data.error || "Failed to add override");
+      }
+    } catch {
+      setError("Failed to add override");
+    }
+  };
+
+  return (
+    <div>
+      {error && <Message tone="error" text={error} />}
+      {success && <Message tone="success" text={success} />}
+
+      {overrides.length > 0 ? (
+        <div className="space-y-2 mb-4">
+          {overrides.map((entry) => (
+            <RepoOverrideRow
+              key={entry.repo}
+              entry={entry}
+              enabledModelOptions={enabledModelOptions}
+              onError={setError}
+              onSuccess={setSuccess}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground mb-4">
+          No repository overrides yet. Add one to customize model behavior per repo.
+        </p>
+      )}
+
+      <div className="flex items-center gap-2">
+        <select
+          value={addingRepo}
+          onChange={(e) => setAddingRepo(e.target.value)}
+          className="flex-1 px-3 py-2 text-sm border border-border bg-background text-foreground rounded-sm"
+        >
+          <option value="">Select a repository...</option>
+          {availableForOverride.map((repo) => (
+            <option key={repo.fullName} value={repo.fullName.toLowerCase()}>
+              {repo.fullName}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={handleAdd}
+          disabled={!addingRepo}
+          className="px-4 py-2 text-sm font-medium text-white bg-accent hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition"
+        >
+          Add Override
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function RepoOverrideRow({
+  entry,
+  enabledModelOptions,
+  onError,
+  onSuccess,
+}: {
+  entry: RepoSettingsEntry;
+  enabledModelOptions: { category: string; models: { id: string; name: string }[] }[];
+  onError: (msg: string) => void;
+  onSuccess: (msg: string) => void;
+}) {
+  const [model, setModel] = useState(entry.settings.model ?? "");
+  const [effort, setEffort] = useState(entry.settings.reasoningEffort ?? "");
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+
+  const reasoningConfig = model ? MODEL_REASONING_CONFIG[model as ValidModel] : undefined;
+
+  const handleModelChange = (newModel: string) => {
+    setModel(newModel);
+    setDirty(true);
+
+    if (effort && newModel && !isValidReasoningEffort(newModel, effort)) {
+      setEffort("");
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    onError("");
+    onSuccess("");
+
+    const [owner, name] = entry.repo.split("/");
+    const settings: GitHubBotSettings = {};
+    if (model) settings.model = model;
+    if (effort) settings.reasoningEffort = effort;
+
+    try {
+      const res = await fetch(`/api/integration-settings/github/repos/${owner}/${name}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ settings }),
+      });
+
+      if (res.ok) {
+        mutate(REPO_SETTINGS_KEY);
+        setDirty(false);
+        onSuccess(`Override for ${entry.repo} saved.`);
+      } else {
+        const data = await res.json();
+        onError(data.error || "Failed to save override");
+      }
+    } catch {
+      onError("Failed to save override");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    const [owner, name] = entry.repo.split("/");
+    onError("");
+    onSuccess("");
+
+    try {
+      const res = await fetch(`/api/integration-settings/github/repos/${owner}/${name}`, {
+        method: "DELETE",
+      });
+
+      if (res.ok) {
+        mutate(REPO_SETTINGS_KEY);
+        onSuccess(`Override for ${entry.repo} removed.`);
+      } else {
+        const data = await res.json();
+        onError(data.error || "Failed to delete override");
+      }
+    } catch {
+      onError("Failed to delete override");
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 px-4 py-3 border border-border rounded-sm">
+      <span className="text-sm font-medium text-foreground min-w-[180px] truncate">
+        {entry.repo}
+      </span>
+
+      <select
+        value={model}
+        onChange={(e) => handleModelChange(e.target.value)}
+        className="flex-1 min-w-[180px] px-2 py-1 text-sm border border-border bg-background text-foreground rounded-sm"
+      >
+        <option value="">Default model</option>
+        {enabledModelOptions.map((group) => (
+          <optgroup key={group.category} label={group.category}>
+            {group.models.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name}
+              </option>
+            ))}
+          </optgroup>
+        ))}
+      </select>
+
+      {reasoningConfig && (
+        <select
+          value={effort}
+          onChange={(e) => {
+            setEffort(e.target.value);
+            setDirty(true);
+          }}
+          className="w-36 px-2 py-1 text-sm border border-border bg-background text-foreground rounded-sm"
+        >
+          <option value="">Default effort</option>
+          {reasoningConfig.efforts.map((value) => (
+            <option key={value} value={value}>
+              {value}
+            </option>
+          ))}
+        </select>
+      )}
+
+      <button
+        type="button"
+        onClick={handleSave}
+        disabled={saving || !dirty}
+        className="px-3 py-1 text-sm font-medium text-white bg-accent hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed transition"
+      >
+        {saving ? "..." : "Save"}
+      </button>
+
+      <button
+        type="button"
+        onClick={handleDelete}
+        className="px-3 py-1 text-sm text-red-600 hover:bg-red-50 transition"
+        title="Remove override"
+      >
+        Remove
+      </button>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="border border-border-muted rounded-md p-5 mb-5">
+      <h4 className="text-sm font-semibold uppercase tracking-wider text-foreground mb-1">
+        {title}
+      </h4>
+      <p className="text-sm text-muted-foreground mb-4">{description}</p>
+      {children}
+    </section>
+  );
+}
+
+function Message({ tone, text }: { tone: "error" | "success"; text: string }) {
+  const classes =
+    tone === "error"
+      ? "mb-4 bg-red-50 text-red-700 px-4 py-3 border border-red-200 text-sm rounded-sm"
+      : "mb-4 bg-green-50 text-green-700 px-4 py-3 border border-green-200 text-sm rounded-sm";
+
+  return (
+    <div className={classes} aria-live="polite">
+      {text}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Reworked the Settings → Integrations experience into a scalable master-detail layout with a provider index and dedicated detail view, including mobile list/detail navigation.
- Split GitHub integration settings into a dedicated component with clear sections (Connection, Defaults & Scope, Repository Overrides) to avoid a single monolithic settings surface.
- Updated GitHub scope controls to an explicit "All repositories" vs "Selected repositories" mode and retained existing save/reset/override behavior while improving empty states and feedback messages.

## Validation
- `npm run lint --workspace @open-inspect/web`
- `npm run typecheck --workspace @open-inspect/web`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/f9bc49bda7a30d59313ecf8f17db1fed)*