### PR TITLE
fix: align Linear callback outcomes with agent completion

### DIFF
--- a/packages/linear-bot/src/callbacks.ts
+++ b/packages/linear-bot/src/callbacks.ts
@@ -255,12 +255,13 @@ async function handleCompletionCallback(
           issue_id: context.issueId,
           issue_identifier: context.issueIdentifier,
           agent_session_id: context.agentSessionId,
-          outcome: "success",
+          outcome: payload.success ? "success" : "failed",
           has_pr: agentResponse.artifacts.some((a) => a.type === "pr" && a.url),
           agent_success: payload.success,
           tool_call_count: agentResponse.toolCalls.length,
           artifact_count: agentResponse.artifacts.length,
           delivery: "agent_activity",
+          delivery_outcome: "success",
           duration_ms: Date.now() - startTime,
         });
         return;
@@ -292,9 +293,10 @@ async function handleCompletionCallback(
       trace_id: traceId,
       session_id: sessionId,
       issue_id: context.issueId,
-      outcome: result.success ? "success" : "error",
+      outcome: payload.success ? "success" : "failed",
       agent_success: payload.success,
       delivery: "comment_fallback",
+      delivery_outcome: result.success ? "success" : "error",
       duration_ms: Date.now() - startTime,
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- Update Linear bot completion callback logs so `outcome` reflects the actual agent completion result (`success` vs `failed`) instead of always reporting success on AgentActivity delivery.
- Preserve delivery telemetry by adding `delivery_outcome`, so delivery success/failure remains visible independently from agent completion status.
- Apply the same separation for fallback comment delivery logs to improve observability and alert accuracy.

## Testing
- `npm test -- --run` (in `packages/linear-bot`)
- `npm run typecheck` (in `packages/linear-bot`)


---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/c580c30fe3a2076f82d7801018270c33)*