### PR TITLE
fix(terraform): make linear bot deployment opt-in

### DIFF
--- a/terraform/environments/production/outputs.tf
+++ b/terraform/environments/production/outputs.tf
@@ -37,22 +37,22 @@ output "slack_bot_worker_name" {
 
 output "linear_kv_id" {
   description = "Linear KV namespace ID"
-  value       = module.linear_kv.namespace_id
+  value       = var.enable_linear_bot ? module.linear_kv[0].namespace_id : null
 }
 
 output "linear_bot_worker_name" {
   description = "Linear bot worker name"
-  value       = module.linear_bot_worker.worker_name
+  value       = var.enable_linear_bot ? module.linear_bot_worker[0].worker_name : null
 }
 
 output "linear_bot_webhook_url" {
   description = "Linear bot webhook URL (set in Linear OAuth Application webhook config)"
-  value       = "${module.linear_bot_worker.worker_url}/webhook"
+  value       = var.enable_linear_bot ? "${module.linear_bot_worker[0].worker_url}/webhook" : null
 }
 
 output "linear_bot_oauth_authorize_url" {
   description = "Visit this URL to install the Linear agent in your workspace (requires admin)"
-  value       = "${module.linear_bot_worker.worker_url}/oauth/authorize"
+  value       = var.enable_linear_bot ? "${module.linear_bot_worker[0].worker_url}/oauth/authorize" : null
 }
 
 output "github_bot_worker_name" {

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -94,6 +94,8 @@ slack_signing_secret = ""
 # in your workspace (requires admin permissions).
 # Leave empty to disable Linear integration.
 
+enable_linear_bot = false
+
 linear_client_id = ""        # OAuth Application Client ID
 linear_client_secret = ""    # OAuth Application Client Secret
 linear_webhook_secret = ""   # Webhook Signing Secret from the application config

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -135,6 +135,21 @@ variable "slack_signing_secret" {
 # Linear Agent Credentials
 # =============================================================================
 
+variable "enable_linear_bot" {
+  description = "Enable the Linear bot worker. Requires linear_client_id, linear_client_secret, and linear_webhook_secret."
+  type        = bool
+  default     = false
+
+  validation {
+    condition = var.enable_linear_bot == false || (
+      length(var.linear_client_id) > 0 &&
+      length(var.linear_client_secret) > 0 &&
+      length(var.linear_webhook_secret) > 0
+    )
+    error_message = "When enable_linear_bot is true, linear_client_id, linear_client_secret, and linear_webhook_secret must be non-empty."
+  }
+}
+
 variable "linear_client_id" {
   description = "Linear OAuth Application Client ID (from Settings → API → Applications)"
   type        = string


### PR DESCRIPTION
## Why
Terraform was always attempting to deploy the Linear bot worker, which caused `terraform apply` failures when `packages/linear-bot/dist/index.js` was not present and Linear integration was not intended to be enabled.

## What changed
- Added `enable_linear_bot` (default `false`) with validation requiring Linear OAuth/webhook credentials when enabled.
- Gated Linear resources with `count`:
  - `module.linear_kv`
  - `null_resource.linear_bot_build`
  - `module.linear_bot_worker`
- Made the control plane `LINEAR_BOT` service binding conditional so it is only configured when Linear bot is enabled.
- Updated Linear-related outputs to return `null` when Linear bot is disabled.
- Documented the new toggle in `terraform.tfvars.example`.

## Result
Linear worker infrastructure is now optional and no longer deploys by default, aligning behavior with optional integration expectations and preventing missing-bundle failures in non-Linear deployments.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/5bd1639e366ae58924f25b65f1e695c4)*