### PR TITLE
Fix github bot depends_on counted resource indexing

### DIFF
--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -281,7 +281,7 @@ module "github_bot_worker" {
   compatibility_date  = "2024-09-23"
   compatibility_flags = ["nodejs_compat"]
 
-  depends_on = [null_resource.github_bot_build, module.control_plane_worker]
+  depends_on = [null_resource.github_bot_build[0], module.control_plane_worker]
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- fix a Terraform dependency reference for `github_bot_worker` to point to the counted resource instance `null_resource.github_bot_build[0]`
- align with Terraform `count` semantics and existing pattern already used for `linear_bot_worker`
- prevent invalid/ambiguous dependency references during plan/apply

## Testing
- not run (Terraform-only one-line configuration fix)

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/4323b1e6c3793abcc82d8a8205193e37)*