### PR TITLE
refactor: extract CallbackNotificationService from SessionDO

### DIFF
--- a/packages/control-plane/src/session/callback-notification-service.test.ts
+++ b/packages/control-plane/src/session/callback-notification-service.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Logger } from "../logger";
+import {
+  CallbackNotificationService,
+  type CallbackRepository,
+  type CallbackServiceEnv,
+  type CallbackServiceDeps,
+} from "./callback-notification-service";
+
+// ---- Mock factories ----
+
+function createMockLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(() => createMockLogger()),
+  };
+}
+
+function createMockRepository(): CallbackRepository {
+  return {
+    getMessageCallbackContext: vi.fn(() => null),
+    getSession: vi.fn(() => null),
+  };
+}
+
+function createMockFetcher(): Fetcher {
+  return { fetch: vi.fn() } as unknown as Fetcher;
+}
+
+function createTestHarness(overrides?: { env?: Partial<CallbackServiceEnv> }) {
+  const log = createMockLogger();
+  const repository = createMockRepository();
+
+  const slackBot = createMockFetcher();
+  const linearBot = createMockFetcher();
+
+  const env: CallbackServiceEnv = {
+    INTERNAL_CALLBACK_SECRET: "test-secret",
+    SLACK_BOT: slackBot,
+    LINEAR_BOT: linearBot,
+    ...overrides?.env,
+  };
+
+  const deps: CallbackServiceDeps = {
+    repository,
+    env,
+    log,
+    getSessionId: () => "session-123",
+  };
+
+  return {
+    service: new CallbackNotificationService(deps),
+    repository,
+    log,
+    env,
+    slackBot,
+    linearBot,
+  };
+}
+
+// ---- Tests ----
+
+describe("CallbackNotificationService", () => {
+  let harness: ReturnType<typeof createTestHarness>;
+
+  beforeEach(() => {
+    harness = createTestHarness();
+  });
+
+  describe("notifyComplete", () => {
+    it("skips when no callback context", async () => {
+      vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue(null);
+
+      await harness.service.notifyComplete("msg-1", true);
+
+      expect(harness.log.debug).toHaveBeenCalledWith(
+        "No callback context for message, skipping notification",
+        expect.objectContaining({ message_id: "msg-1" })
+      );
+      expect(
+        (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
+      ).not.toHaveBeenCalled();
+    });
+
+    it("skips when callback_context is null on the message", async () => {
+      vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: null,
+        source: "slack",
+      });
+
+      await harness.service.notifyComplete("msg-1", true);
+
+      expect(
+        (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
+      ).not.toHaveBeenCalled();
+    });
+
+    it("skips when no INTERNAL_CALLBACK_SECRET", async () => {
+      const h = createTestHarness({ env: { INTERNAL_CALLBACK_SECRET: undefined } });
+      vi.mocked(h.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: JSON.stringify({ channel: "C123" }),
+        source: "slack",
+      });
+
+      await h.service.notifyComplete("msg-1", true);
+
+      expect(
+        (h.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
+      ).not.toHaveBeenCalled();
+    });
+
+    it("skips when no binding for source", async () => {
+      const h = createTestHarness({
+        env: { SLACK_BOT: undefined, LINEAR_BOT: undefined },
+      });
+      vi.mocked(h.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: JSON.stringify({ channel: "C123" }),
+        source: "slack",
+      });
+
+      await h.service.notifyComplete("msg-1", true);
+
+      expect(h.log.debug).toHaveBeenCalledWith(
+        "No callback binding for source, skipping notification",
+        expect.objectContaining({ message_id: "msg-1", source: "slack" })
+      );
+    });
+
+    it("calls binding with signed payload on success", async () => {
+      vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: JSON.stringify({ channel: "C123", threadTs: "1234.5678" }),
+        source: "slack",
+      });
+
+      const mockResponse = new Response("ok", { status: 200 });
+      vi.mocked(
+        (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
+      ).mockResolvedValue(mockResponse);
+
+      await harness.service.notifyComplete("msg-1", true);
+
+      const fetchMock = (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch;
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://internal/callbacks/complete",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+
+      // Verify payload shape
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body).toMatchObject({
+        sessionId: "session-123",
+        messageId: "msg-1",
+        success: true,
+        context: { channel: "C123", threadTs: "1234.5678" },
+      });
+      expect(body.signature).toEqual(expect.any(String));
+      expect(body.timestamp).toEqual(expect.any(Number));
+
+      expect(harness.log.info).toHaveBeenCalledWith(
+        "Callback succeeded",
+        expect.objectContaining({ message_id: "msg-1", source: "slack" })
+      );
+    });
+
+    it("retries once on fetch failure", async () => {
+      vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: JSON.stringify({ channel: "C123" }),
+        source: "slack",
+      });
+
+      const fetchMock = vi.mocked(
+        (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
+      );
+      fetchMock
+        .mockRejectedValueOnce(new Error("network error"))
+        .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+      await harness.service.notifyComplete("msg-1", true);
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(harness.log.info).toHaveBeenCalledWith(
+        "Callback succeeded",
+        expect.objectContaining({ message_id: "msg-1" })
+      );
+    });
+
+    it("routes to LINEAR_BOT for linear source", async () => {
+      vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: JSON.stringify({ issueId: "LIN-123" }),
+        source: "linear",
+      });
+
+      const mockResponse = new Response("ok", { status: 200 });
+      vi.mocked(
+        (harness.linearBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
+      ).mockResolvedValue(mockResponse);
+
+      await harness.service.notifyComplete("msg-1", false);
+
+      const linearFetch = (harness.linearBot as unknown as { fetch: ReturnType<typeof vi.fn> })
+        .fetch;
+      expect(linearFetch).toHaveBeenCalledTimes(1);
+
+      const slackFetch = (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch;
+      expect(slackFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("notifyToolCall", () => {
+    it("skips when throttled (< 3s since last call)", async () => {
+      vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: JSON.stringify({ channel: "C123" }),
+        source: "slack",
+      });
+
+      const fetchMock = vi.mocked(
+        (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
+      );
+      fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
+
+      // First call should go through
+      await harness.service.notifyToolCall("msg-1", { type: "tool_call", tool: "bash" });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // Second call within 3s should be throttled
+      await harness.service.notifyToolCall("msg-1", { type: "tool_call", tool: "read" });
+      expect(fetchMock).toHaveBeenCalledTimes(1); // still 1
+    });
+
+    it("fires callback on first call", async () => {
+      vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: JSON.stringify({ channel: "C123" }),
+        source: "slack",
+      });
+
+      const fetchMock = vi.mocked(
+        (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
+      );
+      fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
+
+      await harness.service.notifyToolCall("msg-1", {
+        type: "tool_call",
+        tool: "bash",
+        args: { cmd: "ls" },
+        call_id: "call-1",
+        status: "running",
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://internal/callbacks/tool_call",
+        expect.objectContaining({ method: "POST" })
+      );
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body).toMatchObject({
+        sessionId: "session-123",
+        tool: "bash",
+        args: { cmd: "ls" },
+        callId: "call-1",
+        status: "running",
+        context: { channel: "C123" },
+      });
+      expect(body.signature).toEqual(expect.any(String));
+    });
+
+    it("skips when no callback context", async () => {
+      vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue(null);
+
+      await harness.service.notifyToolCall("msg-1", { type: "tool_call", tool: "bash" });
+
+      const fetchMock = (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch;
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("skips when no secret configured", async () => {
+      const h = createTestHarness({ env: { INTERNAL_CALLBACK_SECRET: undefined } });
+      vi.mocked(h.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: JSON.stringify({ channel: "C123" }),
+        source: "slack",
+      });
+
+      await h.service.notifyToolCall("msg-1", { type: "tool_call", tool: "bash" });
+
+      const fetchMock = (h.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch;
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/control-plane/src/session/callback-notification-service.ts
+++ b/packages/control-plane/src/session/callback-notification-service.ts
@@ -1,0 +1,237 @@
+/**
+ * CallbackNotificationService - Slack/Linear bot callback notifications.
+ *
+ * Extracted from SessionDO to reduce its size. Handles:
+ * - Notifying originating clients (Slack, Linear) on execution completion
+ * - Throttled tool-call progress callbacks
+ * - HMAC payload signing for callback authentication
+ */
+
+import type { Logger } from "../logger";
+import type { SessionRow } from "./types";
+
+/**
+ * Narrow repository interface — only the methods CallbackNotificationService needs.
+ */
+export interface CallbackRepository {
+  getMessageCallbackContext(
+    messageId: string
+  ): { callback_context: string | null; source: string | null } | null;
+  getSession(): SessionRow | null;
+}
+
+/**
+ * Narrow env interface — only the bindings CallbackNotificationService needs.
+ */
+export interface CallbackServiceEnv {
+  INTERNAL_CALLBACK_SECRET?: string;
+  SLACK_BOT?: Fetcher;
+  LINEAR_BOT?: Fetcher;
+}
+
+/**
+ * Dependencies injected into CallbackNotificationService.
+ */
+export interface CallbackServiceDeps {
+  repository: CallbackRepository;
+  env: CallbackServiceEnv;
+  log: Logger;
+  getSessionId: () => string;
+}
+
+export class CallbackNotificationService {
+  private readonly repository: CallbackRepository;
+  private readonly env: CallbackServiceEnv;
+  private readonly log: Logger;
+  private readonly getSessionId: () => string;
+  private _lastToolCallCallbackTs = 0;
+
+  constructor(deps: CallbackServiceDeps) {
+    this.repository = deps.repository;
+    this.env = deps.env;
+    this.log = deps.log;
+    this.getSessionId = deps.getSessionId;
+  }
+
+  /**
+   * Generate HMAC signature for callback payload.
+   */
+  private async signPayload(data: object, secret: string): Promise<string> {
+    const encoder = new TextEncoder();
+    const key = await crypto.subtle.importKey(
+      "raw",
+      encoder.encode(secret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"]
+    );
+    const signatureData = encoder.encode(JSON.stringify(data));
+    const sig = await crypto.subtle.sign("HMAC", key, signatureData);
+    return Array.from(new Uint8Array(sig))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+  }
+
+  /**
+   * Resolve the callback service binding based on the message source.
+   * Returns the appropriate Fetcher for the originating client.
+   */
+  private getBinding(source: string | null): Fetcher | undefined {
+    switch (source) {
+      case "linear":
+        return this.env.LINEAR_BOT;
+      case "slack":
+        return this.env.SLACK_BOT;
+      default:
+        // Default to SLACK_BOT for backward compatibility (web sources, etc.)
+        return this.env.SLACK_BOT;
+    }
+  }
+
+  /**
+   * Notify the originating client of completion with retry.
+   * Routes to the correct service binding based on the message source.
+   */
+  async notifyComplete(messageId: string, success: boolean): Promise<void> {
+    // Safely query for callback context
+    const message = this.repository.getMessageCallbackContext(messageId);
+    if (!message?.callback_context) {
+      this.log.debug("No callback context for message, skipping notification", {
+        message_id: messageId,
+      });
+      return;
+    }
+    if (!this.env.INTERNAL_CALLBACK_SECRET) {
+      this.log.debug("INTERNAL_CALLBACK_SECRET not configured, skipping notification");
+      return;
+    }
+
+    // Resolve the callback binding based on message source
+    const source = message.source ?? null;
+    const binding = this.getBinding(source);
+    if (!binding) {
+      this.log.debug("No callback binding for source, skipping notification", {
+        message_id: messageId,
+        source,
+      });
+      return;
+    }
+
+    const sessionId = this.getSessionId();
+
+    const context = JSON.parse(message.callback_context);
+    const timestamp = Date.now();
+
+    // Build payload without signature
+    const payloadData = {
+      sessionId,
+      messageId,
+      success,
+      timestamp,
+      context,
+    };
+
+    // Sign the payload
+    const signature = await this.signPayload(payloadData, this.env.INTERNAL_CALLBACK_SECRET);
+
+    const payload = { ...payloadData, signature };
+
+    // Try with retry (max 2 attempts)
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        const response = await binding.fetch("https://internal/callbacks/complete", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+
+        if (response.ok) {
+          this.log.info("Callback succeeded", { message_id: messageId, source });
+          return;
+        }
+
+        const responseText = await response.text();
+        this.log.error("Callback failed", {
+          message_id: messageId,
+          source,
+          status: response.status,
+          response_text: responseText,
+        });
+      } catch (e) {
+        this.log.error("Callback attempt failed", {
+          message_id: messageId,
+          source,
+          attempt: attempt + 1,
+          error: e instanceof Error ? e : String(e),
+        });
+      }
+
+      // Wait before retry
+      if (attempt < 1) {
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+    }
+
+    this.log.error("Failed to notify callback client after retries", {
+      message_id: messageId,
+      source,
+    });
+  }
+
+  /**
+   * Notify the originating client of a tool_call event (best-effort, throttled).
+   * Max 1 callback per 3 seconds per session.
+   */
+  async notifyToolCall(
+    messageId: string,
+    event: {
+      type: string;
+      tool?: string;
+      args?: Record<string, unknown>;
+      call_id?: string;
+      status?: string;
+    }
+  ): Promise<void> {
+    // Throttle: max 1 per 3 seconds
+    const now = Date.now();
+    if (now - this._lastToolCallCallbackTs < 3000) return;
+    this._lastToolCallCallbackTs = now;
+
+    const message = this.repository.getMessageCallbackContext(messageId);
+    if (!message?.callback_context) return;
+    if (!this.env.INTERNAL_CALLBACK_SECRET) return;
+
+    const source = message.source ?? null;
+    const binding = this.getBinding(source);
+    if (!binding) return;
+
+    const sessionId = this.getSessionId();
+    const context = JSON.parse(message.callback_context);
+
+    const payloadData = {
+      sessionId,
+      tool: event.tool ?? "unknown",
+      args: event.args ?? {},
+      callId: event.call_id ?? "",
+      status: event.status,
+      timestamp: now,
+      context,
+    };
+
+    const signature = await this.signPayload(payloadData, this.env.INTERNAL_CALLBACK_SECRET);
+    const payload = { ...payloadData, signature };
+
+    try {
+      await binding.fetch("https://internal/callbacks/tool_call", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+    } catch (e) {
+      this.log.debug("Tool call callback failed (best-effort)", {
+        message_id: messageId,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+}

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -60,6 +60,7 @@ import { GlobalSecretsStore } from "../db/global-secrets";
 import { mergeSecrets } from "../db/secrets-validation";
 import { OpenAITokenRefreshService } from "./openai-token-refresh-service";
 import { ParticipantService, getGitHubAvatarUrl } from "./participant-service";
+import { CallbackNotificationService } from "./callback-notification-service";
 
 /**
  * Valid event types for filtering.
@@ -120,7 +121,8 @@ export class SessionDO extends DurableObject<Env> {
   private _sourceControlProvider: SourceControlProvider | null = null;
   // Participant service (lazily initialized)
   private _participantService: ParticipantService | null = null;
-  private _lastToolCallCallbackTs = 0;
+  // Callback notification service (lazily initialized)
+  private _callbackService: CallbackNotificationService | null = null;
 
   // Route table for internal API endpoints
   private readonly routes: InternalRoute[] = [
@@ -208,6 +210,24 @@ export class SessionDO extends DurableObject<Env> {
       });
     }
     return this._participantService;
+  }
+
+  /**
+   * Get the callback notification service, creating it lazily if needed.
+   */
+  private get callbackService(): CallbackNotificationService {
+    if (!this._callbackService) {
+      this._callbackService = new CallbackNotificationService({
+        repository: this.repository,
+        env: this.env,
+        log: this.log,
+        getSessionId: () => {
+          const session = this.getSession();
+          return session?.session_name || session?.id || this.ctx.id.toString();
+        },
+      });
+    }
+    return this._callbackService;
   }
 
   /**
@@ -1106,7 +1126,7 @@ export class SessionDO extends DurableObject<Env> {
 
       // Fire-and-forget tool_call callback to originating client (e.g. linear-bot)
       if (messageId && event.status === "running") {
-        this.ctx.waitUntil(this.notifyCallbackToolCall(messageId, event).catch(() => {}));
+        this.ctx.waitUntil(this.callbackService.notifyToolCall(messageId, event).catch(() => {}));
       }
       return;
     }
@@ -1162,7 +1182,7 @@ export class SessionDO extends DurableObject<Env> {
 
         this.broadcast({ type: "sandbox_event", event });
         this.broadcast({ type: "processing_status", isProcessing: this.getIsProcessing() });
-        this.ctx.waitUntil(this.notifyCallbackClient(completionMessageId, event.success));
+        this.ctx.waitUntil(this.callbackService.notifyComplete(completionMessageId, event.success));
       } else {
         // Stopped path: message was already marked failed by stopExecution()
         this.log.info("prompt.complete", {
@@ -1444,7 +1464,7 @@ export class SessionDO extends DurableObject<Env> {
 
       // Notify slack-bot now because the bridge's late execution_complete will hit
       // the "already_stopped" branch in processSandboxEvent() which skips notification.
-      this.ctx.waitUntil(this.notifyCallbackClient(processingMessage.id, false));
+      this.ctx.waitUntil(this.callbackService.notifyComplete(processingMessage.id, false));
     }
 
     // Immediate client feedback
@@ -1769,190 +1789,6 @@ export class SessionDO extends DurableObject<Env> {
 
   private updateSandboxStatus(status: string): void {
     this.repository.updateSandboxStatus(status as SandboxStatus);
-  }
-
-  /**
-   * Generate HMAC signature for callback payload.
-   */
-  private async signCallback(data: object, secret: string): Promise<string> {
-    const encoder = new TextEncoder();
-    const key = await crypto.subtle.importKey(
-      "raw",
-      encoder.encode(secret),
-      { name: "HMAC", hash: "SHA-256" },
-      false,
-      ["sign"]
-    );
-    const signatureData = encoder.encode(JSON.stringify(data));
-    const sig = await crypto.subtle.sign("HMAC", key, signatureData);
-    return Array.from(new Uint8Array(sig))
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("");
-  }
-
-  /**
-   * Resolve the callback service binding based on the message source.
-   * Returns the appropriate Fetcher for the originating client.
-   */
-  private getCallbackBinding(source: string | null): Fetcher | undefined {
-    switch (source) {
-      case "linear":
-        return this.env.LINEAR_BOT;
-      case "slack":
-        return this.env.SLACK_BOT;
-      default:
-        // Default to SLACK_BOT for backward compatibility (web sources, etc.)
-        return this.env.SLACK_BOT;
-    }
-  }
-
-  /**
-   * Notify the originating client of completion with retry.
-   * Routes to the correct service binding based on the message source.
-   */
-  private async notifyCallbackClient(messageId: string, success: boolean): Promise<void> {
-    // Safely query for callback context
-    const message = this.repository.getMessageCallbackContext(messageId);
-    if (!message?.callback_context) {
-      this.log.debug("No callback context for message, skipping notification", {
-        message_id: messageId,
-      });
-      return;
-    }
-    if (!this.env.INTERNAL_CALLBACK_SECRET) {
-      this.log.debug("INTERNAL_CALLBACK_SECRET not configured, skipping notification");
-      return;
-    }
-
-    // Resolve the callback binding based on message source
-    const source = message.source ?? null;
-    const binding = this.getCallbackBinding(source);
-    if (!binding) {
-      this.log.debug("No callback binding for source, skipping notification", {
-        message_id: messageId,
-        source,
-      });
-      return;
-    }
-
-    const session = this.getSession();
-    const sessionId = session?.session_name || session?.id || this.ctx.id.toString();
-
-    const context = JSON.parse(message.callback_context);
-    const timestamp = Date.now();
-
-    // Build payload without signature
-    const payloadData = {
-      sessionId,
-      messageId,
-      success,
-      timestamp,
-      context,
-    };
-
-    // Sign the payload
-    const signature = await this.signCallback(payloadData, this.env.INTERNAL_CALLBACK_SECRET);
-
-    const payload = { ...payloadData, signature };
-
-    // Try with retry (max 2 attempts)
-    for (let attempt = 0; attempt < 2; attempt++) {
-      try {
-        const response = await binding.fetch("https://internal/callbacks/complete", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(payload),
-        });
-
-        if (response.ok) {
-          this.log.info("Callback succeeded", { message_id: messageId, source });
-          return;
-        }
-
-        const responseText = await response.text();
-        this.log.error("Callback failed", {
-          message_id: messageId,
-          source,
-          status: response.status,
-          response_text: responseText,
-        });
-      } catch (e) {
-        this.log.error("Callback attempt failed", {
-          message_id: messageId,
-          source,
-          attempt: attempt + 1,
-          error: e instanceof Error ? e : String(e),
-        });
-      }
-
-      // Wait before retry
-      if (attempt < 1) {
-        await new Promise((r) => setTimeout(r, 1000));
-      }
-    }
-
-    this.log.error("Failed to notify callback client after retries", {
-      message_id: messageId,
-      source,
-    });
-  }
-
-  /**
-   * Notify the originating client of a tool_call event (best-effort, throttled).
-   * Max 1 callback per 3 seconds per session.
-   */
-  private async notifyCallbackToolCall(
-    messageId: string,
-    event: {
-      type: string;
-      tool?: string;
-      args?: Record<string, unknown>;
-      call_id?: string;
-      status?: string;
-    }
-  ): Promise<void> {
-    // Throttle: max 1 per 3 seconds
-    const now = Date.now();
-    if (now - this._lastToolCallCallbackTs < 3000) return;
-    this._lastToolCallCallbackTs = now;
-
-    const message = this.repository.getMessageCallbackContext(messageId);
-    if (!message?.callback_context) return;
-    if (!this.env.INTERNAL_CALLBACK_SECRET) return;
-
-    const source = message.source ?? null;
-    const binding = this.getCallbackBinding(source);
-    if (!binding) return;
-
-    const session = this.getSession();
-    const sessionId = session?.session_name || session?.id || this.ctx.id.toString();
-    const context = JSON.parse(message.callback_context);
-
-    const payloadData = {
-      sessionId,
-      tool: event.tool ?? "unknown",
-      args: event.args ?? {},
-      callId: event.call_id ?? "",
-      status: event.status,
-      timestamp: now,
-      context,
-    };
-
-    const signature = await this.signCallback(payloadData, this.env.INTERNAL_CALLBACK_SECRET);
-    const payload = { ...payloadData, signature };
-
-    try {
-      await binding.fetch("https://internal/callbacks/tool_call", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-    } catch (e) {
-      this.log.debug("Tool call callback failed (best-effort)", {
-        message_id: messageId,
-        error: e instanceof Error ? e.message : String(e),
-      });
-    }
   }
 
   // HTTP handlers


### PR DESCRIPTION
## Summary

- Extracts Slack/Linear callback notification logic from `SessionDO` into a standalone `CallbackNotificationService` class (~183 lines removed from DO)
- Follows the same narrow-interface + lazy-getter pattern established by `ParticipantService` in #165
- Adds 11 unit tests covering all skip conditions, routing, retry, throttling, and payload signing

## Test plan

- [x] `npm run typecheck -w @open-inspect/control-plane` — passes
- [x] `npm run test -w @open-inspect/control-plane` — 491 tests pass (27 files)
- [x] `npm run test:integration -w @open-inspect/control-plane` — 100 tests pass (16 files)
- [x] `npm run lint -w @open-inspect/control-plane` — clean