### PR TITLE
Add linear-bot to Terraform CI workflow

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -9,6 +9,7 @@ on:
       - "packages/control-plane/**"
       - "packages/slack-bot/**"
       - "packages/github-bot/**"
+      - "packages/linear-bot/**"
       - "packages/modal-infra/**"
       - "packages/shared/**"
       - ".github/workflows/terraform.yml"
@@ -20,6 +21,7 @@ on:
       - "packages/control-plane/**"
       - "packages/slack-bot/**"
       - "packages/github-bot/**"
+      - "packages/linear-bot/**"
       - "packages/modal-infra/**"
       - "packages/shared/**"
       - ".github/workflows/terraform.yml"
@@ -137,6 +139,7 @@ jobs:
           npm run build -w @open-inspect/control-plane
           npm run build -w @open-inspect/slack-bot
           npm run build -w @open-inspect/github-bot
+          npm run build -w @open-inspect/linear-bot
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -188,6 +191,10 @@ jobs:
           TF_VAR_enable_github_bot: "${{ secrets.ENABLE_GITHUB_BOT || 'false' }}"
           TF_VAR_github_webhook_secret: ${{ secrets.GH_WEBHOOK_SECRET }}
           TF_VAR_github_bot_username: ${{ secrets.GH_BOT_USERNAME }}
+          TF_VAR_enable_linear_bot: "${{ secrets.ENABLE_LINEAR_BOT || 'false' }}"
+          TF_VAR_linear_client_id: ${{ secrets.LINEAR_CLIENT_ID }}
+          TF_VAR_linear_client_secret: ${{ secrets.LINEAR_CLIENT_SECRET }}
+          TF_VAR_linear_webhook_secret: ${{ secrets.LINEAR_WEBHOOK_SECRET }}
 
       - name: Post Plan Results
         uses: actions/github-script@v7
@@ -250,6 +257,7 @@ jobs:
           npm run build -w @open-inspect/control-plane
           npm run build -w @open-inspect/slack-bot
           npm run build -w @open-inspect/github-bot
+          npm run build -w @open-inspect/linear-bot
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -303,6 +311,10 @@ jobs:
           TF_VAR_enable_github_bot: "${{ secrets.ENABLE_GITHUB_BOT || 'false' }}"
           TF_VAR_github_webhook_secret: ${{ secrets.GH_WEBHOOK_SECRET }}
           TF_VAR_github_bot_username: ${{ secrets.GH_BOT_USERNAME }}
+          TF_VAR_enable_linear_bot: "${{ secrets.ENABLE_LINEAR_BOT || 'false' }}"
+          TF_VAR_linear_client_id: ${{ secrets.LINEAR_CLIENT_ID }}
+          TF_VAR_linear_client_secret: ${{ secrets.LINEAR_CLIENT_SECRET }}
+          TF_VAR_linear_webhook_secret: ${{ secrets.LINEAR_WEBHOOK_SECRET }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
 


### PR DESCRIPTION
## Summary
- Add `packages/linear-bot/**` to trigger paths (push + PR) so linear-bot changes trigger Terraform
- Add `npm run build -w @open-inspect/linear-bot` to build steps in both plan and apply jobs
- Add `TF_VAR_enable_linear_bot`, `TF_VAR_linear_client_id`, `TF_VAR_linear_client_secret`, and `TF_VAR_linear_webhook_secret` env vars to both plan and apply jobs

This is fully opt-in — `enable_linear_bot` defaults to `false` via `${{ secrets.ENABLE_LINEAR_BOT || 'false' }}`, so existing deployments without Linear secrets configured are unaffected.

## Test plan
- [ ] Verify CI passes on this PR (validate + plan jobs should succeed with empty Linear secrets)
- [ ] After merge, set `ENABLE_LINEAR_BOT=true` + Linear secrets in GitHub Actions to deploy