### PR TITLE
Fix integrations settings width on desktop

### DIFF
--- a/packages/web/src/app/(app)/settings/page.tsx
+++ b/packages/web/src/app/(app)/settings/page.tsx
@@ -114,7 +114,9 @@ export default function SettingsPage() {
       <div className="flex-1 flex overflow-hidden">
         <SettingsNav activeCategory={activeCategory} onSelect={setActiveCategory} />
         <div className="flex-1 overflow-y-auto p-8">
-          <div className="max-w-2xl">{content}</div>
+          <div className={activeCategory === "integrations" ? "max-w-4xl" : "max-w-2xl"}>
+            {content}
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- The settings page content area was capped at `max-w-2xl` (672px) for all tabs, including integrations
- The integrations tab has its own two-column layout (220px integration list + detail panel), so the 672px cap left only ~428px for the detail panel — making it appear cramped
- Uses `max-w-4xl` (896px) when the integrations tab is active, giving the detail panel ~650px of usable width

## Test plan
- [ ] Open Settings → Integrations on desktop and verify the content area uses more horizontal space
- [ ] Verify other settings tabs (Secrets, Models, etc.) still use the narrower `max-w-2xl` width
- [ ] Check mobile view is unaffected