### PR TITLE
Fix model selection dropdown overflowing off-screen

### DIFF
--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -522,7 +522,7 @@ function HomeContent({
                       </button>
 
                       {modelDropdownOpen && (
-                        <div className="absolute bottom-full left-0 mb-2 w-56 bg-background shadow-lg border border-border py-1 z-50">
+                        <div className="absolute bottom-full left-0 mb-2 w-56 max-h-72 overflow-y-auto bg-background shadow-lg border border-border py-1 z-50">
                           {modelOptions.map((group, groupIdx) => (
                             <div key={group.category}>
                               <div


### PR DESCRIPTION
## Summary
- Add `max-h-72 overflow-y-auto` to the model selection dropdown to prevent it from growing unbounded and overflowing past the top of the viewport
- Mirrors the existing pattern used by the repo dropdown (`max-h-56 overflow-y-auto`)
- Single-line CSS class change in `packages/web/src/app/(app)/page.tsx`

## Test plan
- [ ] `npm run build -w @open-inspect/web` passes (verified)
- [ ] Open the home page and confirm the model dropdown is scrollable when many models are enabled
- [ ] Verify dropdown stays within viewport bounds on smaller screens