### PR TITLE
Improve archive flow with confirmation and post-archive redirect

### DIFF
--- a/packages/web/src/components/action-bar.tsx
+++ b/packages/web/src/components/action-bar.tsx
@@ -36,6 +36,13 @@ export function ActionBar({
   const isArchived = sessionStatus === "archived";
 
   const handleArchiveToggle = async () => {
+    if (!isArchived) {
+      const confirmed = window.confirm(
+        "Archive this session? You can restore archived sessions from Settings > Data Controls."
+      );
+      if (!confirmed) return;
+    }
+
     setIsArchiving(true);
     try {
       if (isArchived && onUnarchive) {


### PR DESCRIPTION
## Summary
- add a confirmation prompt before archiving a session so it does not feel like an accidental delete action
- update session archive handling to redirect to the home view after successful archive, preventing users from remaining on a now-hidden session page
- keep sidebar session data in sync by continuing to revalidate `/api/sessions` after archive/unarchive actions

## Testing
- npm run typecheck (packages/web)
- npm run test (packages/web)

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/bc1b59dc6ed0c5716f71b195322cb9b3)*