### PR TITLE
fix: bridge WS disconnect — event buffer + prompt task decoupling

### DIFF
--- a/packages/modal-infra/src/sandbox/bridge.py
+++ b/packages/modal-infra/src/sandbox/bridge.py
@@ -11,6 +11,7 @@ This module handles:
 
 import argparse
 import asyncio
+import contextlib
 import json
 import os
 import secrets
@@ -131,6 +132,14 @@ class AgentBridge:
     OPENCODE_REQUEST_TIMEOUT = 10.0
     PROMPT_MAX_DURATION = 5400.0
     MAX_PENDING_PART_EVENTS = 2000
+    MAX_EVENT_BUFFER_SIZE = 1000
+    CRITICAL_EVENT_TYPES: ClassVar[set[str]] = {
+        "execution_complete",
+        "error",
+        "snapshot_ready",
+        "push_complete",
+        "push_error",
+    }
 
     def __init__(
         self,
@@ -176,6 +185,12 @@ class AgentBridge:
 
         # Track the current prompt task so _handle_stop can cancel it
         self._current_prompt_task: asyncio.Task[None] | None = None
+
+        # Event buffer: survives WS reconnection, flushed on reconnect
+        self._event_buffer: list[dict[str, Any]] = []
+
+        # Tracks the message ID of the currently executing prompt
+        self._inflight_message_id: str | None = None
 
     @property
     def ws_url(self) -> str:
@@ -254,6 +269,11 @@ class AgentBridge:
                 await asyncio.sleep(delay)
 
         finally:
+            # Cancel any in-flight prompt task before closing resources
+            if self._current_prompt_task and not self._current_prompt_task.done():
+                self._current_prompt_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await self._current_prompt_task
             if self.http_client:
                 await self.http_client.aclose()
 
@@ -308,6 +328,8 @@ class AgentBridge:
                     }
                 )
 
+                await self._flush_event_buffer()
+
                 heartbeat_task = asyncio.create_task(self._heartbeat_loop())
                 background_tasks: set[asyncio.Task[None]] = set()
 
@@ -357,27 +379,65 @@ class AgentBridge:
                 )
 
     async def _send_event(self, event: dict[str, Any]) -> None:
-        """Send event to control plane."""
+        """Send event to control plane, buffering if WS is unavailable."""
         event_type = event.get("type", "unknown")
-
-        if not self.ws:
-            self.log.debug("bridge.send_failed", event_type=event_type, reason="ws_none")
-            return
-        if self.ws.state != State.OPEN:
-            self.log.debug(
-                "bridge.send_failed",
-                event_type=event_type,
-                reason=f"ws_state_{self.ws.state}",
-            )
-            return
-
         event["sandboxId"] = self.sandbox_id
         event["timestamp"] = event.get("timestamp", time.time())
+
+        if not self.ws or self.ws.state != State.OPEN:
+            self._buffer_event(event)
+            return
 
         try:
             await self.ws.send(json.dumps(event))
         except Exception as e:
-            self.log.error("bridge.send_error", event_type=event_type, exc=e)
+            self.log.warn("bridge.send_error", event_type=event_type, exc=e)
+            self._buffer_event(event)
+
+    async def _flush_event_buffer(self) -> None:
+        """Flush buffered events to the control plane after reconnect."""
+        if not self._event_buffer:
+            return
+
+        self.log.info("bridge.flush_buffer_start", buffer_size=len(self._event_buffer))
+        flushed = 0
+        while self._event_buffer:
+            event = self._event_buffer[0]
+            if not self.ws or self.ws.state != State.OPEN:
+                break
+            try:
+                await self.ws.send(json.dumps(event))
+                self._event_buffer.pop(0)
+                flushed += 1
+            except Exception as e:
+                self.log.warn("bridge.flush_send_error", exc=e)
+                break
+
+        self.log.info(
+            "bridge.flush_buffer_complete",
+            flushed=flushed,
+            remaining=len(self._event_buffer),
+        )
+
+    def _buffer_event(self, event: dict[str, Any]) -> None:
+        """Buffer an event for later delivery after WS reconnect."""
+        if len(self._event_buffer) >= self.MAX_EVENT_BUFFER_SIZE:
+            # Evict oldest non-critical event; fall back to oldest if all critical
+            evicted = False
+            for i, buffered in enumerate(self._event_buffer):
+                if buffered.get("type") not in self.CRITICAL_EVENT_TYPES:
+                    self._event_buffer.pop(i)
+                    evicted = True
+                    break
+            if not evicted:
+                self._event_buffer.pop(0)
+
+        self._event_buffer.append(event)
+        self.log.debug(
+            "bridge.event_buffered",
+            event_type=event.get("type", "unknown"),
+            buffer_size=len(self._event_buffer),
+        )
 
     async def _handle_command(self, cmd: dict[str, Any]) -> asyncio.Task[None] | None:
         """Handle command from control plane.
@@ -422,7 +482,10 @@ class AgentBridge:
                     )
 
             task.add_done_callback(handle_task_exception)
-            return task
+            # Don't return the task — prompt tasks must survive WS disconnects.
+            # Returning it would add it to background_tasks, which gets cancelled
+            # in the _connect_and_run finally block on WS close.
+            return None
         elif cmd_type == "stop":
             await self._handle_stop()
         elif cmd_type == "snapshot":
@@ -440,6 +503,7 @@ class AgentBridge:
     async def _handle_prompt(self, cmd: dict[str, Any]) -> None:
         """Handle prompt command - send to OpenCode and stream response."""
         message_id = cmd.get("messageId") or cmd.get("message_id", "unknown")
+        self._inflight_message_id = message_id
         content = cmd.get("content", "")
         model = cmd.get("model")
         reasoning_effort = cmd.get("reasoningEffort")
@@ -1207,6 +1271,8 @@ class AgentBridge:
     async def _handle_shutdown(self) -> None:
         """Handle shutdown command - graceful shutdown."""
         self.log.info("bridge.shutdown_requested")
+        if self._current_prompt_task and not self._current_prompt_task.done():
+            self._current_prompt_task.cancel()
         self.shutdown_event.set()
 
     async def _handle_push(self, cmd: dict[str, Any]) -> None:

--- a/packages/modal-infra/tests/test_bridge_event_buffer.py
+++ b/packages/modal-infra/tests/test_bridge_event_buffer.py
@@ -1,0 +1,344 @@
+"""
+Unit tests for bridge event buffer and prompt task decoupling.
+
+Tests that events are buffered when WS is unavailable, flushed on reconnect,
+and that prompt tasks survive WS disconnects.
+"""
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from websockets import State
+
+from src.sandbox.bridge import AgentBridge
+from tests.conftest import MockResponse
+
+
+class MockHttpClient:
+    """Mock HTTP client for event buffer tests."""
+
+    def __init__(self):
+        self.post_responses: list[Any] = []
+        self.get_responses: list[Any] = []
+        self.sse_events: list[str] = []
+        self._post_call_count = 0
+        self.post_urls: list[str] = []
+
+    async def post(self, url: str, json: dict | None = None, timeout: float = 30.0) -> Any:
+        self._post_call_count += 1
+        self.post_urls.append(url)
+        if self.post_responses:
+            return self.post_responses.pop(0)
+        return MockResponse(204)
+
+    async def get(self, url: str, timeout: float = 10.0) -> Any:
+        if self.get_responses:
+            return self.get_responses.pop(0)
+        return MockResponse(200, [])
+
+    def stream(self, method: str, url: str, timeout: Any = None):
+        return MockSSEResponse(self.sse_events)
+
+    async def aclose(self):
+        pass
+
+
+class MockSSEResponse:
+    """Mock SSE streaming response."""
+
+    def __init__(self, events: list[str], status_code: int = 200):
+        self.status_code = status_code
+        self._events = events
+
+    async def aiter_text(self):
+        for event in self._events:
+            yield event
+            await asyncio.sleep(0)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+def create_sse_event(event_type: str, properties: dict) -> str:
+    """Create an SSE event string."""
+    data = {"type": event_type, "properties": properties}
+    return f"data: {json.dumps(data)}\n\n"
+
+
+@pytest.fixture
+def bridge() -> AgentBridge:
+    """Create a bridge instance for testing."""
+    bridge = AgentBridge(
+        sandbox_id="test-sandbox",
+        session_id="test-session",
+        control_plane_url="http://localhost:8787",
+        auth_token="test-token",
+    )
+    bridge.opencode_session_id = "oc-session-123"
+    bridge.http_client = MockHttpClient()
+    return bridge
+
+
+class TestEventBuffering:
+    """Tests for event buffering when WS is unavailable."""
+
+    @pytest.mark.asyncio
+    async def test_send_event_buffers_when_ws_none(self, bridge: AgentBridge):
+        """Events should be buffered, not dropped, when WS is None."""
+        bridge.ws = None
+
+        await bridge._send_event({"type": "token", "content": "hello"})
+
+        assert len(bridge._event_buffer) == 1
+        assert bridge._event_buffer[0]["type"] == "token"
+        assert bridge._event_buffer[0]["content"] == "hello"
+        # sandboxId and timestamp should be stamped
+        assert bridge._event_buffer[0]["sandboxId"] == "test-sandbox"
+        assert "timestamp" in bridge._event_buffer[0]
+
+    @pytest.mark.asyncio
+    async def test_send_event_buffers_when_ws_not_open(self, bridge: AgentBridge):
+        """Events should be buffered when WS exists but is not OPEN."""
+        mock_ws = MagicMock()
+        mock_ws.state = State.CLOSED
+        bridge.ws = mock_ws
+
+        await bridge._send_event({"type": "execution_complete", "messageId": "msg-1"})
+
+        assert len(bridge._event_buffer) == 1
+        assert bridge._event_buffer[0]["type"] == "execution_complete"
+
+    @pytest.mark.asyncio
+    async def test_send_event_buffers_on_send_exception(self, bridge: AgentBridge):
+        """Events should be buffered when ws.send() throws."""
+        mock_ws = MagicMock()
+        mock_ws.state = State.OPEN
+        mock_ws.send = AsyncMock(side_effect=ConnectionError("broken pipe"))
+        bridge.ws = mock_ws
+
+        await bridge._send_event({"type": "token", "content": "data"})
+
+        assert len(bridge._event_buffer) == 1
+        assert bridge._event_buffer[0]["type"] == "token"
+
+    def test_buffer_overflow_evicts_non_critical_first(self, bridge: AgentBridge):
+        """When buffer is full, non-critical events should be evicted before critical ones."""
+        # Fill buffer with a mix of critical and non-critical events
+        bridge._event_buffer = [
+            {"type": "execution_complete", "messageId": "msg-1"},  # critical
+            {"type": "token", "content": "a"},  # non-critical
+            {"type": "error", "messageId": "msg-2"},  # critical
+        ]
+        bridge.MAX_EVENT_BUFFER_SIZE = 3
+
+        bridge._buffer_event({"type": "snapshot_ready"})
+
+        # Buffer should still be size 3 (one evicted, one added)
+        assert len(bridge._event_buffer) == 3
+        # The non-critical "token" event should have been evicted
+        types = [e["type"] for e in bridge._event_buffer]
+        assert "token" not in types
+        assert "execution_complete" in types
+        assert "error" in types
+        assert "snapshot_ready" in types
+
+    def test_buffer_overflow_evicts_oldest_critical_if_all_critical(self, bridge: AgentBridge):
+        """When all events are critical, oldest gets evicted."""
+        bridge._event_buffer = [
+            {"type": "execution_complete", "messageId": "msg-1"},
+            {"type": "error", "messageId": "msg-2"},
+        ]
+        bridge.MAX_EVENT_BUFFER_SIZE = 2
+
+        bridge._buffer_event({"type": "push_complete"})
+
+        assert len(bridge._event_buffer) == 2
+        # Oldest critical (execution_complete) should be evicted
+        types = [e["type"] for e in bridge._event_buffer]
+        assert "execution_complete" not in types
+        assert "error" in types
+        assert "push_complete" in types
+
+
+class TestEventFlush:
+    """Tests for flushing buffered events on reconnect."""
+
+    @pytest.mark.asyncio
+    async def test_flush_sends_all_and_clears_buffer(self, bridge: AgentBridge):
+        """Flushing should send all buffered events and clear the buffer."""
+        mock_ws = MagicMock()
+        mock_ws.state = State.OPEN
+        sent_data: list[str] = []
+        mock_ws.send = AsyncMock(side_effect=lambda data: sent_data.append(data))
+        bridge.ws = mock_ws
+
+        bridge._event_buffer = [
+            {"type": "token", "content": "a"},
+            {"type": "execution_complete", "messageId": "msg-1"},
+        ]
+
+        await bridge._flush_event_buffer()
+
+        assert len(bridge._event_buffer) == 0
+        assert len(sent_data) == 2
+        assert json.loads(sent_data[0])["type"] == "token"
+        assert json.loads(sent_data[1])["type"] == "execution_complete"
+
+    @pytest.mark.asyncio
+    async def test_flush_stops_on_send_failure(self, bridge: AgentBridge):
+        """Flushing should stop when a send fails, keeping remaining events buffered."""
+        mock_ws = MagicMock()
+        mock_ws.state = State.OPEN
+        call_count = 0
+
+        async def flaky_send(data):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                raise ConnectionError("broken")
+
+        mock_ws.send = flaky_send
+        bridge.ws = mock_ws
+
+        bridge._event_buffer = [
+            {"type": "token", "content": "a"},
+            {"type": "token", "content": "b"},
+            {"type": "execution_complete", "messageId": "msg-1"},
+        ]
+
+        await bridge._flush_event_buffer()
+
+        # First event sent successfully, second failed
+        assert len(bridge._event_buffer) == 2
+        assert bridge._event_buffer[0]["content"] == "b"
+        assert bridge._event_buffer[1]["type"] == "execution_complete"
+
+    @pytest.mark.asyncio
+    async def test_flush_noop_when_buffer_empty(self, bridge: AgentBridge):
+        """Flushing an empty buffer should be a no-op."""
+        assert len(bridge._event_buffer) == 0
+        await bridge._flush_event_buffer()
+        assert len(bridge._event_buffer) == 0
+
+
+class TestPromptTaskDecoupling:
+    """Tests that prompt tasks survive WS disconnects."""
+
+    @pytest.mark.asyncio
+    async def test_prompt_task_survives_ws_disconnect(self, bridge: AgentBridge):
+        """Prompt task should NOT be cancelled when WS disconnects."""
+        prompt_started = asyncio.Event()
+        prompt_can_finish = asyncio.Event()
+
+        async def slow_prompt(cmd):
+            prompt_started.set()
+            await prompt_can_finish.wait()
+
+        bridge._handle_prompt = slow_prompt
+
+        # Start a prompt
+        await bridge._handle_command({"type": "prompt", "messageId": "msg-1", "content": "test"})
+        task = bridge._current_prompt_task
+        assert task is not None
+
+        await prompt_started.wait()
+
+        # Simulate what _connect_and_run's finally block does:
+        # cancel heartbeat + background_tasks, set ws = None.
+        # The prompt task should NOT be in background_tasks anymore.
+        bridge.ws = None
+
+        # The task should still be running
+        assert not task.done()
+
+        # Let it finish
+        prompt_can_finish.set()
+        await task
+        await asyncio.sleep(0)
+
+    @pytest.mark.asyncio
+    async def test_prompt_task_cancelled_on_run_exit(self, bridge: AgentBridge):
+        """run() finally block should cancel the prompt task before closing http_client."""
+        prompt_started = asyncio.Event()
+
+        async def slow_prompt(cmd):
+            prompt_started.set()
+            await asyncio.sleep(3600)
+
+        bridge._handle_prompt = slow_prompt
+
+        await bridge._handle_command({"type": "prompt", "messageId": "msg-1", "content": "test"})
+        task = bridge._current_prompt_task
+        assert task is not None
+
+        await prompt_started.wait()
+
+        # Simulate run() exit: shutdown_event causes loop break, then finally block
+        bridge.shutdown_event.set()
+
+        # run()'s finally block cancels _current_prompt_task
+        await bridge.run()
+
+        assert task.done()
+
+    @pytest.mark.asyncio
+    async def test_execution_complete_buffered_and_flushed(self, bridge: AgentBridge):
+        """execution_complete should be buffered when WS is down and flushed on reconnect."""
+        bridge.ws = None
+
+        # Simulate _handle_prompt completing and sending execution_complete
+        await bridge._send_event(
+            {
+                "type": "execution_complete",
+                "messageId": "msg-1",
+                "success": True,
+            }
+        )
+
+        assert len(bridge._event_buffer) == 1
+        assert bridge._event_buffer[0]["type"] == "execution_complete"
+
+        # Simulate reconnect
+        mock_ws = MagicMock()
+        mock_ws.state = State.OPEN
+        sent_data: list[str] = []
+        mock_ws.send = AsyncMock(side_effect=lambda data: sent_data.append(data))
+        bridge.ws = mock_ws
+
+        await bridge._flush_event_buffer()
+
+        assert len(bridge._event_buffer) == 0
+        assert len(sent_data) == 1
+        parsed = json.loads(sent_data[0])
+        assert parsed["type"] == "execution_complete"
+        assert parsed["messageId"] == "msg-1"
+        assert parsed["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_inflight_message_id_set_on_prompt(self, bridge: AgentBridge):
+        """_handle_prompt should set _inflight_message_id."""
+        http_client = bridge.http_client
+        http_client.sse_events = [
+            create_sse_event("server.connected", {}),
+            create_sse_event("session.idle", {"sessionID": "oc-session-123"}),
+        ]
+
+        await bridge._handle_command({"type": "prompt", "messageId": "msg-42", "content": "test"})
+        task = bridge._current_prompt_task
+        assert task is not None
+
+        # Let the task run so _handle_prompt sets _inflight_message_id
+        await task
+        await asyncio.sleep(0)
+
+        assert bridge._inflight_message_id == "msg-42"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/packages/modal-infra/tests/test_bridge_sse.py
+++ b/packages/modal-infra/tests/test_bridge_sse.py
@@ -1188,7 +1188,7 @@ class TestPromptMaxDuration:
             async for _event in bridge._stream_opencode_response_sse("msg-1", "test"):
                 pass
 
-        assert any(url.endswith("/stop") for url in http_client.post_urls)
+        assert any(url.endswith("/abort") for url in http_client.post_urls)
         assert any(url.endswith("/message") for url in http_client.get_urls)
 
 

--- a/packages/modal-infra/tests/test_bridge_stop.py
+++ b/packages/modal-infra/tests/test_bridge_stop.py
@@ -131,17 +131,21 @@ class TestHandleStop:
             create_sse_event("session.idle", {"sessionID": "oc-session-123"}),
         ]
 
-        # Run a prompt command
-        task = await bridge._handle_command(
+        # _handle_command returns None for prompts (decoupled from WS lifecycle)
+        result = await bridge._handle_command(
             {
                 "type": "prompt",
                 "messageId": "msg-1",
                 "content": "hello",
             }
         )
+        assert result is None
+
+        # But _current_prompt_task should be set
+        task = bridge._current_prompt_task
+        assert task is not None
 
         # Wait for task to complete
-        assert task is not None
         await task
 
         # Give the done callback a chance to fire
@@ -160,7 +164,7 @@ class TestHandleStop:
             create_sse_event("session.idle", {"sessionID": "oc-session-123"}),
         ]
 
-        task = await bridge._handle_command(
+        result = await bridge._handle_command(
             {
                 "type": "prompt",
                 "messageId": "msg-1",
@@ -168,8 +172,11 @@ class TestHandleStop:
             }
         )
 
-        # Task should be set before completion
-        assert bridge._current_prompt_task is task
+        # _handle_command returns None for prompts (not added to background_tasks)
+        assert result is None
+
+        # But _current_prompt_task should be set
+        task = bridge._current_prompt_task
         assert task is not None
 
         # Clean up
@@ -193,22 +200,24 @@ class TestHandleStop:
 
         bridge._handle_prompt = fake_handle_prompt
 
-        old_task = await bridge._handle_command(
+        await bridge._handle_command(
             {
                 "type": "prompt",
                 "messageId": "msg-old",
                 "content": "old",
             }
         )
+        old_task = bridge._current_prompt_task
         assert old_task is not None
 
-        new_task = await bridge._handle_command(
+        await bridge._handle_command(
             {
                 "type": "prompt",
                 "messageId": "msg-new",
                 "content": "new",
             }
         )
+        new_task = bridge._current_prompt_task
         assert new_task is not None
         assert bridge._current_prompt_task is new_task
 
@@ -250,7 +259,7 @@ class TestHandleStop:
 
         http_client.stream = lambda *a, **kw: HangingSSEResponse()
 
-        task = await bridge._handle_command(
+        await bridge._handle_command(
             {
                 "type": "prompt",
                 "messageId": "msg-cancel-test",
@@ -258,6 +267,7 @@ class TestHandleStop:
             }
         )
 
+        task = bridge._current_prompt_task
         assert task is not None
 
         # Let the task start


### PR DESCRIPTION
## Summary

Fixes the root cause of the 2026-02-21 bridge WS disconnect hang incident where a transient WebSocket disconnect (code 1006) between the Modal bridge and Cloudflare control plane caused `execution_complete` to be silently dropped, leaving the session stuck in `processing` for 20 minutes.

**Phase 1 of 2** — Bridge-side fixes:

- **Event buffer**: `_send_event()` now buffers events when WS is unavailable instead of silently dropping them. Buffer (max 1000 events) uses smart eviction that preserves critical events (`execution_complete`, `error`, `snapshot_ready`, `push_complete`, `push_error`). Buffered events are flushed on reconnect.
- **Prompt task decoupling**: Prompt tasks (SSE listener to localhost OpenCode) are no longer cancelled when the WS disconnects. The SSE stream has no dependency on the control plane WS — it runs over HTTP to localhost.
- **Fix `/stop` → `/abort`**: OpenCode only defines `POST /:sessionID/abort`; the `/stop` endpoint was silently 404ing on every stop request.
- **Inflight message tracking**: `_inflight_message_id` survives reconnection for future reconciliation.

## Test plan

- [x] 87 bridge unit tests pass (pytest)
- [ ] Integration tests pass
- [ ] Manual test: deploy, start session, kill bridge WS mid-prompt, verify session recovers on reconnect