### PR TITLE
fix: add working_dir to d1_migrations provisioner

### DIFF
--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -75,7 +75,8 @@ resource "null_resource" "d1_migrations" {
   }
 
   provisioner "local-exec" {
-    command = "bash ${var.project_root}/scripts/d1-migrate.sh ${cloudflare_d1_database.main.name} ${var.project_root}/terraform/d1/migrations"
+    command     = "bash ${var.project_root}/scripts/d1-migrate.sh ${cloudflare_d1_database.main.name} ${var.project_root}/terraform/d1/migrations"
+    working_dir = var.project_root
 
     environment = {
       CLOUDFLARE_ACCOUNT_ID = var.cloudflare_account_id


### PR DESCRIPTION
## Summary
- The `d1_migrations` Terraform `local-exec` provisioner was failing in CI with `wrangler: not found` because it ran from `terraform/environments/production/` where `npx` couldn't resolve the `wrangler` binary
- Adds `working_dir = var.project_root` so `npx wrangler` finds the binary in the project root's `node_modules/.bin/`

## Test plan
- [ ] Merge and sync to prod — verify the Terraform CI workflow passes with D1 migrations succeeding