### PR TITLE
fix: use project-root-relative paths in d1_migrations command

### DIFF
--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -75,7 +75,7 @@ resource "null_resource" "d1_migrations" {
   }
 
   provisioner "local-exec" {
-    command     = "bash ${var.project_root}/scripts/d1-migrate.sh ${cloudflare_d1_database.main.name} ${var.project_root}/terraform/d1/migrations"
+    command     = "bash scripts/d1-migrate.sh ${cloudflare_d1_database.main.name} terraform/d1/migrations"
     working_dir = var.project_root
 
     environment = {


### PR DESCRIPTION
## Summary
- Follows up on #193 which added `working_dir = var.project_root` to the d1_migrations provisioner
- The command still used `${var.project_root}/scripts/...` paths, which doubled the relative traversal (`../../../` applied twice — once by `working_dir`, once in the command)
- Now uses direct relative paths (`scripts/d1-migrate.sh`, `terraform/d1/migrations`) since `working_dir` already places execution at the project root

## Test plan
- [ ] Merge and sync to prod — verify D1 migrations succeed in Terraform CI