### PR TITLE
chore(web): remove small dead web UI code paths

### DIFF
--- a/packages/web/src/components/tool-call-group.tsx
+++ b/packages/web/src/components/tool-call-group.tsx
@@ -34,8 +34,6 @@ export const ToolCallGroup = memo(
 
     const formatted = formatToolGroup(events);
     const firstEvent = events[0];
-    const _lastEvent = events[events.length - 1];
-
     const time = new Date(firstEvent.timestamp * 1000).toLocaleTimeString([], {
       hour: "2-digit",
       minute: "2-digit",

--- a/packages/web/src/lib/control-plane.ts
+++ b/packages/web/src/lib/control-plane.ts
@@ -37,7 +37,7 @@ function getInternalSecret(): string {
  *
  * @returns Headers object with Content-Type and Authorization
  */
-export async function getControlPlaneHeaders(): Promise<HeadersInit> {
+async function getControlPlaneHeaders(): Promise<HeadersInit> {
   const secret = getInternalSecret();
   const token = await generateInternalToken(secret);
 

--- a/packages/web/src/lib/tasks.ts
+++ b/packages/web/src/lib/tasks.ts
@@ -46,27 +46,3 @@ export function extractLatestTasks(events: SandboxEvent[]): Task[] {
     activeForm: todo.activeForm,
   }));
 }
-
-/**
- * Get task counts by status
- */
-export function getTaskCounts(tasks: Task[]): {
-  total: number;
-  pending: number;
-  inProgress: number;
-  completed: number;
-} {
-  return {
-    total: tasks.length,
-    pending: tasks.filter((t) => t.status === "pending").length,
-    inProgress: tasks.filter((t) => t.status === "in_progress").length,
-    completed: tasks.filter((t) => t.status === "completed").length,
-  };
-}
-
-/**
- * Get the currently active task (in_progress status)
- */
-export function getCurrentTask(tasks: Task[]): Task | null {
-  return tasks.find((t) => t.status === "in_progress") || null;
-}

--- a/packages/web/src/lib/tool-formatters.ts
+++ b/packages/web/src/lib/tool-formatters.ts
@@ -199,9 +199,6 @@ export function formatToolGroup(events: SandboxEvent[]): {
   // Build summary based on tool type
   switch (toolName) {
     case "Read": {
-      const _files = events
-        .map((e) => basename(e.args?.file_path as string | undefined))
-        .filter(Boolean);
       return {
         toolName: "Read",
         count,


### PR DESCRIPTION
## Summary
- remove an unused local in `tool-call-group.tsx` and simplify the `Read` branch in `formatToolGroup` by deleting an unused intermediate variable
- make `getControlPlaneHeaders` private since it is only used internally by `controlPlaneFetch`
- delete unreferenced task helper exports (`getTaskCounts`, `getCurrentTask`) from `tasks.ts` to reduce dead utility surface

## Validation
- attempted `pnpm lint` and `pnpm typecheck` in `packages/web`, but this environment is missing local binaries (`eslint` and `tsc` were not found)

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/02e47b2df5f9b4270e381152ef0e8da8)*