### PR TITLE
fix: add comment guidelines to GitHub bot prompts

### DIFF
--- a/packages/github-bot/src/handlers.ts
+++ b/packages/github-bot/src/handlers.ts
@@ -206,6 +206,7 @@ export async function handleReviewRequested(
     author: pr.user.login,
     base: pr.base.ref,
     head: pr.head.ref,
+    isPublic: !repo.private,
   });
 
   const messageId = await sendPrompt(env.CONTROL_PLANE, headers, sessionId, {
@@ -289,6 +290,7 @@ export async function handlePullRequestOpened(
     author: pr.user.login,
     base: pr.base.ref,
     head: pr.head.ref,
+    isPublic: !repo.private,
   });
 
   const messageId = await sendPrompt(env.CONTROL_PLANE, headers, sessionId, {
@@ -380,6 +382,7 @@ export async function handleIssueComment(
     title: issue.title,
     commentBody,
     commenter: sender.login,
+    isPublic: !repo.private,
   });
 
   const messageId = await sendPrompt(env.CONTROL_PLANE, headers, sessionId, {
@@ -468,6 +471,7 @@ export async function handleReviewComment(
     head: pr.head.ref,
     commentBody,
     commenter: sender.login,
+    isPublic: !repo.private,
     filePath: comment.path,
     diffHunk: comment.diff_hunk,
     commentId: comment.id,

--- a/packages/github-bot/src/types.ts
+++ b/packages/github-bot/src/types.ts
@@ -49,7 +49,7 @@ export interface PullRequestOpenedPayload {
     base: { ref: string };
     draft: boolean;
   };
-  repository: { owner: { login: string }; name: string };
+  repository: { owner: { login: string }; name: string; private: boolean };
   sender: { login: string };
 }
 
@@ -64,7 +64,7 @@ export interface ReviewRequestedPayload {
     base: { ref: string };
   };
   requested_reviewer?: { login: string };
-  repository: { owner: { login: string }; name: string };
+  repository: { owner: { login: string }; name: string; private: boolean };
   sender: { login: string };
 }
 
@@ -80,7 +80,7 @@ export interface IssueCommentPayload {
     body: string;
     user: { login: string };
   };
-  repository: { owner: { login: string }; name: string };
+  repository: { owner: { login: string }; name: string; private: boolean };
   sender: { login: string };
 }
 
@@ -100,6 +100,6 @@ export interface ReviewCommentPayload {
     position: number | null;
     user: { login: string };
   };
-  repository: { owner: { login: string }; name: string };
+  repository: { owner: { login: string }; name: string; private: boolean };
   sender: { login: string };
 }


### PR DESCRIPTION
## Summary
- Add comment guidelines to both `buildCodeReviewPrompt` and `buildCommentActionPrompt` instructing the agent to:
  - Summarize command output ("All 559 tests pass") instead of pasting raw terminal logs
  - Avoid leaking internal infrastructure details (sandbox IDs, object IDs, log output)
  - Compose its full response before posting any comments
- Thread repo visibility (`repository.private`) from webhook payloads into prompts so the agent is extra cautious on public repos
- Addresses feedback from [PR #200](https://github.com/ColeMurray/background-agents/pull/200) where the bot dumped the entire test suite output into a PR comment

## Test plan
- [x] `tsc --noEmit` passes for `@open-inspect/github-bot`
- [x] `eslint` passes on all changed files
- [ ] Verify on a real PR that the bot summarizes test/typecheck results instead of pasting raw output