### PR TITLE
chore: remove SCM rename backward-compat and dead code

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ Commits are attributed to the user who sent the prompt:
 ```typescript
 // Configure git identity per prompt
 await configureGitIdentity({
-  name: author.githubName,
-  email: author.githubEmail || generateNoreplyEmail(author.githubId, author.githubLogin),
+  name: author.scmName,
+  email: author.scmEmail,
 });
 ```
 

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -537,17 +537,11 @@ async function handleCreateSession(
   ctx: RequestContext
 ): Promise<Response> {
   const body = (await request.json()) as CreateSessionRequest & {
-    // New field names (preferred)
     scmToken?: string;
     userId?: string;
     scmLogin?: string;
     scmName?: string;
     scmEmail?: string;
-    // Legacy field names (backward compat during rolling deploy, remove after one deploy cycle)
-    githubToken?: string;
-    githubLogin?: string;
-    githubName?: string;
-    githubEmail?: string;
   };
 
   if (!body.repoOwner || !body.repoName) {
@@ -578,12 +572,11 @@ async function handleCreateSession(
     return error(isConfigError ? message : "Failed to resolve repository", 500);
   }
 
-  // Resolve field names (new scm* preferred, github* as backward compat)
   const userId = body.userId || "anonymous";
-  const scmLogin = body.scmLogin ?? body.githubLogin;
-  const scmName = body.scmName ?? body.githubName;
-  const scmEmail = body.scmEmail ?? body.githubEmail;
-  const scmToken = body.scmToken ?? body.githubToken;
+  const scmLogin = body.scmLogin;
+  const scmName = body.scmName;
+  const scmEmail = body.scmEmail;
+  const scmToken = body.scmToken;
   let scmTokenEncrypted: string | null = null;
 
   // If SCM token provided, encrypt it
@@ -936,7 +929,6 @@ async function handleSessionWsToken(
 
   const body = (await request.json()) as {
     userId: string;
-    // New field names (preferred)
     scmUserId?: string;
     scmLogin?: string;
     scmName?: string;
@@ -944,28 +936,19 @@ async function handleSessionWsToken(
     scmToken?: string;
     scmTokenExpiresAt?: number;
     scmRefreshToken?: string;
-    // Legacy field names (backward compat during rolling deploy, remove after one deploy cycle)
-    githubUserId?: string;
-    githubLogin?: string;
-    githubName?: string;
-    githubEmail?: string;
-    githubToken?: string;
-    githubTokenExpiresAt?: number;
-    githubRefreshToken?: string;
   };
 
   if (!body.userId) {
     return error("userId is required");
   }
 
-  // Resolve field names (new scm* preferred, github* as backward compat)
-  const scmUserId = body.scmUserId ?? body.githubUserId;
-  const scmLogin = body.scmLogin ?? body.githubLogin;
-  const scmName = body.scmName ?? body.githubName;
-  const scmEmail = body.scmEmail ?? body.githubEmail;
-  const scmToken = body.scmToken ?? body.githubToken;
-  const scmTokenExpiresAt = body.scmTokenExpiresAt ?? body.githubTokenExpiresAt;
-  const scmRefreshToken = body.scmRefreshToken ?? body.githubRefreshToken;
+  const scmUserId = body.scmUserId;
+  const scmLogin = body.scmLogin;
+  const scmName = body.scmName;
+  const scmEmail = body.scmEmail;
+  const scmToken = body.scmToken;
+  const scmTokenExpiresAt = body.scmTokenExpiresAt;
+  const scmRefreshToken = body.scmRefreshToken;
 
   // Encrypt the SCM tokens if provided
   const { scmTokenEncrypted, scmRefreshTokenEncrypted } = await ctx.metrics.time(

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1599,10 +1599,6 @@ export class SessionDO extends DurableObject<Env> {
       scmName?: string;
       scmEmail?: string;
       role?: string;
-      // Legacy (backward compat)
-      githubLogin?: string;
-      githubName?: string;
-      githubEmail?: string;
     };
 
     const id = generateId();
@@ -1611,9 +1607,9 @@ export class SessionDO extends DurableObject<Env> {
     this.repository.createParticipant({
       id,
       userId: body.userId,
-      scmLogin: body.scmLogin ?? body.githubLogin ?? null,
-      scmName: body.scmName ?? body.githubName ?? null,
-      scmEmail: body.scmEmail ?? body.githubEmail ?? null,
+      scmLogin: body.scmLogin ?? null,
+      scmName: body.scmName ?? null,
+      scmEmail: body.scmEmail ?? null,
       role: (body.role ?? "member") as ParticipantRole,
       joinedAt: now,
     });

--- a/packages/modal-infra/src/sandbox/bridge.py
+++ b/packages/modal-infra/src/sandbox/bridge.py
@@ -518,9 +518,8 @@ class AgentBridge:
             reasoning_effort=reasoning_effort,
         )
 
-        # Read scm* fields (preferred), fall back to legacy github* for rolling deploy compat
-        scm_name = author_data.get("scmName") or author_data.get("githubName")
-        scm_email = author_data.get("scmEmail") or author_data.get("githubEmail")
+        scm_name = author_data.get("scmName")
+        scm_email = author_data.get("scmEmail")
         if scm_name and scm_email:
             await self._configure_git_identity(
                 GitUser(

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -59,56 +59,6 @@ export function generateCommitMessage(
 }
 
 /**
- * Generate a noreply email for users who hide their email.
- *
- * @param githubId - GitHub user ID
- * @param githubLogin - GitHub username
- * @returns GitHub noreply email
- */
-export function generateNoreplyEmail(githubId: number | string, githubLogin: string): string {
-  return `${githubId}+${githubLogin}@users.noreply.github.com`;
-}
-
-/**
- * Get the best email for git commit attribution.
- *
- * Priority:
- * 1. User's public email from GitHub profile
- * 2. User's primary verified email (if accessible)
- * 3. GitHub noreply email
- *
- * @param publicEmail - User's public email (may be null)
- * @param githubId - GitHub user ID
- * @param githubLogin - GitHub username
- * @returns Email to use for commits
- */
-export function getCommitEmail(
-  publicEmail: string | null,
-  githubId: number | string,
-  githubLogin: string
-): string {
-  if (publicEmail) {
-    return publicEmail;
-  }
-  return generateNoreplyEmail(githubId, githubLogin);
-}
-
-/**
- * Create GitUser from GitHub profile data.
- */
-export function createGitUser(
-  githubLogin: string,
-  githubName: string | null,
-  publicEmail: string | null,
-  githubId: number | string
-): GitUser {
-  return {
-    name: githubName || githubLogin,
-    email: getCommitEmail(publicEmail, githubId, githubLogin),
-  };
-}
-
-/**
  * Git environment variables for subprocess.
  */
 export function getGitEnv(user: GitUser): Record<string, string> {

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -47,7 +47,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
 
     const jwt = await getToken({ req: request });
-    const githubToken = jwt?.accessToken as string | undefined;
+    const accessToken = jwt?.accessToken as string | undefined;
 
     // Explicitly pick allowed fields from client body and derive identity
     // from the server-side NextAuth session (not client-supplied data)
@@ -60,7 +60,7 @@ export async function POST(request: NextRequest) {
       model: body.model,
       reasoningEffort: body.reasoningEffort,
       title: body.title,
-      scmToken: githubToken,
+      scmToken: accessToken,
       userId,
       scmLogin: user.login,
       scmName: user.name,


### PR DESCRIPTION
## Summary

- Remove `github*` legacy field fallbacks from `handleCreateSession`, `handleSessionWsToken`, and `handleAddParticipant` that were only needed during the rolling deploy window for PR #203
- Remove three dead functions from `packages/shared/src/git.ts`: `generateNoreplyEmail`, `getCommitEmail`, `createGitUser` (0 external callers)
- Remove `githubName`/`githubEmail` fallbacks in the Python bridge's `_handle_prompt`
- Update README code example to use `scm*` fields
- Rename `githubToken` local variable to `accessToken` in `packages/web/src/app/api/sessions/route.ts`
- Clean up `worktrees/scm-rename` worktree and `rename-github-to-scm` branch

## Test plan

- [x] `npm run build` — all packages build
- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] Control plane unit tests (572 passed)
- [x] Control plane integration tests (108 passed)
- [x] Web tests (34 passed)
- [x] Python tests (142 passed)