### PR TITLE
refactor: remove per-session scm_provider columns

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -48,7 +48,6 @@ function createMockSession(overrides: Partial<SessionRow> = {}): SessionRow {
     status: "active",
     created_at: Date.now() - 60000,
     updated_at: Date.now(),
-    scm_provider: "github",
     ...overrides,
   };
 }

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -293,6 +293,7 @@ export class SessionDO extends DurableObject<Env> {
         wsManager: this.wsManager,
         participantService: this.participantService,
         callbackService: this.callbackService,
+        scmProvider: resolveScmProviderFromEnv(this.env.SCM_PROVIDER),
         getClientInfo: (ws) => this.getClientInfo(ws),
         validateReasoningEffort: (model, effort) => this.validateReasoningEffort(model, effort),
         getSession: () => this.getSession(),
@@ -901,7 +902,7 @@ export class SessionDO extends DurableObject<Env> {
       participantId: participant.id,
       userId: participant.user_id,
       name: participant.scm_name || participant.scm_login || participant.user_id,
-      avatar: getAvatarUrl(participant.scm_login, participant.scm_provider),
+      avatar: getAvatarUrl(participant.scm_login, resolveScmProviderFromEnv(this.env.SCM_PROVIDER)),
       status: "active",
       lastSeen: Date.now(),
       clientId: data.clientId,
@@ -933,7 +934,10 @@ export class SessionDO extends DurableObject<Env> {
       participant: {
         participantId: participant.id,
         name: participant.scm_name || participant.scm_login || participant.user_id,
-        avatar: getAvatarUrl(participant.scm_login, participant.scm_provider),
+        avatar: getAvatarUrl(
+          participant.scm_login,
+          resolveScmProviderFromEnv(this.env.SCM_PROVIDER)
+        ),
       },
       replay,
       spawnError: sandbox?.last_spawn_error ?? null,
@@ -995,7 +999,7 @@ export class SessionDO extends DurableObject<Env> {
       participantId: mapping.participant_id,
       userId: mapping.user_id,
       name: mapping.scm_name || mapping.scm_login || mapping.user_id,
-      avatar: getAvatarUrl(mapping.scm_login, mapping.scm_provider),
+      avatar: getAvatarUrl(mapping.scm_login, resolveScmProviderFromEnv(this.env.SCM_PROVIDER)),
       status: "active",
       lastSeen: Date.now(),
       clientId: mapping.client_id || `client-${Date.now()}`,
@@ -1428,10 +1432,7 @@ export class SessionDO extends DurableObject<Env> {
       scmEmail?: string;
       scmToken?: string | null; // Plain SCM token (will be encrypted)
       scmTokenEncrypted?: string | null; // Pre-encrypted SCM token
-      scmProvider?: "github" | "bitbucket";
     };
-
-    const scmProvider = body.scmProvider ?? "github";
 
     const sessionId = this.ctx.id.toString();
     const sessionName = body.sessionName; // Store the WebSocket routing name
@@ -1473,7 +1474,6 @@ export class SessionDO extends DurableObject<Env> {
       repoId: body.repoId ?? null,
       model,
       reasoningEffort,
-      scmProvider,
       status: "created",
       createdAt: now,
       updatedAt: now,
@@ -1499,7 +1499,6 @@ export class SessionDO extends DurableObject<Env> {
       scmName: body.scmName ?? null,
       scmEmail: body.scmEmail ?? null,
       scmAccessTokenEncrypted: encryptedToken,
-      scmProvider,
       role: "owner",
       joinedAt: now,
     });

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -11,7 +11,6 @@ function createParticipant(overrides: Partial<ParticipantRow> = {}): Participant
     scm_login: "octocat",
     scm_email: null,
     scm_name: "Octo Cat",
-    scm_provider: "github",
     role: "member",
     scm_access_token_encrypted: null,
     scm_refresh_token_encrypted: null,
@@ -41,7 +40,6 @@ function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
     status: "active",
     created_at: 1000,
     updated_at: 1000,
-    scm_provider: "github",
     ...overrides,
   };
 }
@@ -124,6 +122,7 @@ function buildQueue(options?: { getClientInfo?: (ws: WebSocket) => ClientInfo | 
     wsManager: wsManager as never,
     participantService: participantService as never,
     callbackService: callbackService as never,
+    scmProvider: "github",
     getClientInfo: options?.getClientInfo ?? (() => createClientInfo()),
     validateReasoningEffort: vi.fn(() => null),
     getSession: vi.fn(() => createSession()),

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -8,6 +8,7 @@ import {
   isValidModel,
 } from "../utils/models";
 import type { ClientInfo, Env, MessageSource, SandboxEvent, ServerMessage } from "../types";
+import type { SourceControlProviderName } from "../source-control";
 import type { SessionRow, ParticipantRow, SandboxCommand } from "./types";
 import type { SessionRepository } from "./repository";
 import type { SessionWebSocketManager } from "./websocket-manager";
@@ -30,6 +31,7 @@ interface MessageQueueDeps {
   wsManager: SessionWebSocketManager;
   participantService: ParticipantService;
   callbackService: CallbackNotificationService;
+  scmProvider: SourceControlProviderName;
   getClientInfo: (ws: WebSocket) => ClientInfo | null;
   validateReasoningEffort: (model: string, effort: string | undefined) => string | null;
   getSession: () => SessionRow | null;
@@ -279,7 +281,7 @@ export class SessionMessageQueue {
       author: {
         participantId: participant.id,
         name: participant.scm_name || participant.scm_login || participant.user_id,
-        avatar: getAvatarUrl(participant.scm_login, participant.scm_provider),
+        avatar: getAvatarUrl(participant.scm_login, this.deps.scmProvider),
       },
     };
     this.deps.repository.createEvent({

--- a/packages/control-plane/src/session/openai-token-refresh-service.test.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.test.ts
@@ -86,7 +86,6 @@ function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
     status: "active",
     created_at: 1,
     updated_at: 1,
-    scm_provider: "github",
     ...overrides,
   };
 }

--- a/packages/control-plane/src/session/participant-service.test.ts
+++ b/packages/control-plane/src/session/participant-service.test.ts
@@ -46,7 +46,6 @@ function createParticipant(overrides: Partial<ParticipantRow> = {}): Participant
     scm_login: null,
     scm_email: null,
     scm_name: "Test User",
-    scm_provider: "github",
     role: "member",
     scm_access_token_encrypted: null,
     scm_refresh_token_encrypted: null,

--- a/packages/control-plane/src/session/participant-service.ts
+++ b/packages/control-plane/src/session/participant-service.ts
@@ -9,7 +9,7 @@
 
 import { decryptToken, encryptToken } from "../auth/crypto";
 import { refreshAccessToken } from "../auth/github";
-import type { SourceControlAuthContext } from "../source-control";
+import type { SourceControlAuthContext, SourceControlProviderName } from "../source-control";
 import type { Logger } from "../logger";
 import type { ParticipantRow } from "./types";
 import type { CreateParticipantData } from "./repository";
@@ -59,7 +59,7 @@ export interface ParticipantServiceDeps {
  */
 export function getAvatarUrl(
   login: string | null | undefined,
-  provider: "github" | "bitbucket" | null | undefined = "github"
+  provider: SourceControlProviderName = "github"
 ): string | undefined {
   if (!login) return undefined;
   if (provider === "github") return `https://github.com/${login}.png`;
@@ -118,7 +118,6 @@ export class ParticipantService {
       scm_login: null,
       scm_email: null,
       scm_name: name,
-      scm_provider: "github",
       role: "member",
       scm_access_token_encrypted: null,
       scm_refresh_token_encrypted: null,

--- a/packages/control-plane/src/session/pull-request-service.test.ts
+++ b/packages/control-plane/src/session/pull-request-service.test.ts
@@ -37,7 +37,6 @@ function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
     status: "active",
     created_at: 1,
     updated_at: 1,
-    scm_provider: "github",
     ...overrides,
   };
 }

--- a/packages/control-plane/src/session/repository.test.ts
+++ b/packages/control-plane/src/session/repository.test.ts
@@ -99,7 +99,6 @@ describe("SessionRepository", () => {
         null,
         "claude-sonnet-4",
         null,
-        "github",
         "created",
         1000,
         2000,
@@ -349,7 +348,6 @@ describe("SessionRepository", () => {
         "encrypted-token",
         null,
         9000,
-        "github",
         "owner",
         1000,
       ]);
@@ -373,7 +371,6 @@ describe("SessionRepository", () => {
         null,
         null,
         null,
-        "github",
         "member",
         1000,
       ]);

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -37,7 +37,6 @@ export interface WsClientMappingResult {
   user_id: string;
   scm_name: string | null;
   scm_login: string | null;
-  scm_provider: "github" | "bitbucket" | null;
 }
 
 /**
@@ -64,7 +63,6 @@ export interface UpsertSessionData {
   repoId?: number | null;
   model: string;
   reasoningEffort?: string | null;
-  scmProvider?: "github" | "bitbucket";
   status: SessionStatus;
   createdAt: number;
   updatedAt: number;
@@ -93,7 +91,6 @@ export interface CreateParticipantData {
   scmAccessTokenEncrypted?: string | null;
   scmRefreshTokenEncrypted?: string | null;
   scmTokenExpiresAt?: number | null;
-  scmProvider?: "github" | "bitbucket";
   role: ParticipantRole;
   joinedAt: number;
 }
@@ -219,8 +216,8 @@ export class SessionRepository {
 
   upsertSession(data: UpsertSessionData): void {
     this.sql.exec(
-      `INSERT OR REPLACE INTO session (id, session_name, title, repo_owner, repo_name, repo_id, model, reasoning_effort, scm_provider, status, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT OR REPLACE INTO session (id, session_name, title, repo_owner, repo_name, repo_id, model, reasoning_effort, status, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       data.id,
       data.sessionName,
       data.title,
@@ -229,7 +226,6 @@ export class SessionRepository {
       data.repoId ?? null,
       data.model,
       data.reasoningEffort ?? null,
-      data.scmProvider ?? "github",
       data.status,
       data.createdAt,
       data.updatedAt
@@ -394,8 +390,8 @@ export class SessionRepository {
 
   createParticipant(data: CreateParticipantData): void {
     this.sql.exec(
-      `INSERT INTO participants (id, user_id, scm_user_id, scm_login, scm_name, scm_email, scm_access_token_encrypted, scm_refresh_token_encrypted, scm_token_expires_at, scm_provider, role, joined_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO participants (id, user_id, scm_user_id, scm_login, scm_name, scm_email, scm_access_token_encrypted, scm_refresh_token_encrypted, scm_token_expires_at, role, joined_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       data.id,
       data.userId,
       data.scmUserId ?? null,
@@ -405,7 +401,6 @@ export class SessionRepository {
       data.scmAccessTokenEncrypted ?? null,
       data.scmRefreshTokenEncrypted ?? null,
       data.scmTokenExpiresAt ?? null,
-      data.scmProvider ?? "github",
       data.role,
       data.joinedAt
     );
@@ -734,7 +729,7 @@ export class SessionRepository {
 
   getWsClientMapping(wsId: string): WsClientMappingResult | null {
     const result = this.sql.exec(
-      `SELECT m.participant_id, m.client_id, p.user_id, p.scm_name, p.scm_login, p.scm_provider
+      `SELECT m.participant_id, m.client_id, p.user_id, p.scm_name, p.scm_login
        FROM ws_client_mapping m
        JOIN participants p ON m.participant_id = p.id
        WHERE m.ws_id = ?`,

--- a/packages/control-plane/src/session/schema.test.ts
+++ b/packages/control-plane/src/session/schema.test.ts
@@ -63,7 +63,7 @@ describe("applyMigrations", () => {
     const inserts = mock.calls.filter((c) =>
       c.query.includes("INSERT OR IGNORE INTO _schema_migrations")
     );
-    expect(inserts).toHaveLength(22);
+    expect(inserts).toHaveLength(23);
 
     // Verify all 22 IDs are recorded
     const recordedIds = inserts.map((c) => c.params[0]);
@@ -71,7 +71,7 @@ describe("applyMigrations", () => {
   });
 
   it("skips all migrations when fully migrated", () => {
-    // All 22 IDs already applied
+    // All 23 IDs already applied
     const appliedRows = MIGRATIONS.map((m) => ({ id: m.id }));
     mock.setData("SELECT id FROM _schema_migrations", appliedRows);
 
@@ -97,10 +97,10 @@ describe("applyMigrations", () => {
     const inserts = mock.calls.filter((c) =>
       c.query.includes("INSERT OR IGNORE INTO _schema_migrations")
     );
-    expect(inserts).toHaveLength(12); // migrations 11-22
+    expect(inserts).toHaveLength(13); // migrations 11-23
 
     const recordedIds = inserts.map((c) => c.params[0]);
-    expect(recordedIds).toEqual([11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]);
+    expect(recordedIds).toEqual([11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]);
   });
 
   it("rethrows non-duplicate-column errors from string migrations", () => {
@@ -139,11 +139,11 @@ describe("applyMigrations", () => {
     // Should not throw — duplicate column errors are expected
     expect(() => applyMigrations(mock.sql)).not.toThrow();
 
-    // All 22 migrations should still be recorded
+    // All 23 migrations should still be recorded
     const inserts = mock.calls.filter((c) =>
       c.query.includes("INSERT OR IGNORE INTO _schema_migrations")
     );
-    expect(inserts).toHaveLength(22);
+    expect(inserts).toHaveLength(23);
   });
 
   it("is idempotent — calling twice produces no duplicate rows", () => {

--- a/packages/control-plane/src/session/types.ts
+++ b/packages/control-plane/src/session/types.ts
@@ -32,7 +32,6 @@ export interface SessionRow {
   status: SessionStatus;
   created_at: number;
   updated_at: number;
-  scm_provider: "github" | "bitbucket";
 }
 
 export interface ParticipantRow {
@@ -46,7 +45,6 @@ export interface ParticipantRow {
   scm_access_token_encrypted: string | null;
   scm_refresh_token_encrypted: string | null;
   scm_token_expires_at: number | null;
-  scm_provider: "github" | "bitbucket";
   ws_auth_token: string | null; // SHA-256 hash of WebSocket auth token
   ws_token_created_at: number | null; // When the token was generated
   joined_at: number;

--- a/packages/control-plane/src/session/websocket-manager.test.ts
+++ b/packages/control-plane/src/session/websocket-manager.test.ts
@@ -117,7 +117,6 @@ function createMockRepository() {
         user_id: `user-${data.participantId}`,
         scm_name: null,
         scm_login: null,
-        scm_provider: "github",
       });
     },
   } as unknown as SessionRepository;
@@ -442,7 +441,6 @@ describe("SessionWebSocketManagerImpl", () => {
         user_id: "user-1",
         scm_name: "Test",
         scm_login: "testuser",
-        scm_provider: "github",
       };
       mockRepo.addMapping("ws-42", mapping);
 
@@ -501,7 +499,6 @@ describe("SessionWebSocketManagerImpl", () => {
         user_id: "u-1",
         scm_name: null,
         scm_login: null,
-        scm_provider: "github",
       });
 
       expect(manager.hasPersistedMapping("ws-1")).toBe(true);
@@ -622,7 +619,6 @@ describe("SessionWebSocketManagerImpl", () => {
         user_id: "u-1",
         scm_name: null,
         scm_login: null,
-        scm_provider: "github",
       });
 
       const called: WebSocket[] = [];
@@ -660,7 +656,6 @@ describe("SessionWebSocketManagerImpl", () => {
         user_id: "u-2",
         scm_name: null,
         scm_login: null,
-        scm_provider: "github",
       });
 
       // Unauthenticated client (connected but never subscribed)
@@ -723,7 +718,6 @@ describe("SessionWebSocketManagerImpl", () => {
         user_id: "u-1",
         scm_name: null,
         scm_login: null,
-        scm_provider: "github",
       });
 
       await manager.enforceAuthTimeout(ws, "ws-1");


### PR DESCRIPTION
## Summary

- Remove redundant `scm_provider` columns from the `session` and `participants` SQLite tables in Durable Objects
- The SCM provider is a deployment-level setting (`env.SCM_PROVIDER`), not a per-session choice — all callsites now use `resolveScmProviderFromEnv()` instead of reading from per-row storage
- Add migration 23 to `DROP COLUMN scm_provider` on existing DOs

## Context

The `scm_provider` columns were added in migrations 21/22 during the SCM abstraction work, but the actual provider resolution always came from the deployment env var. The per-session columns were only consumed for avatar URL computation (`getAvatarUrl`), making them redundant. This change removes the dead state and threads the deployment-level provider to those callsites.

## Changes

**Types & Schema** (3 files)
- `session/types.ts` — Remove `scm_provider` from `SessionRow` and `ParticipantRow`
- `session/schema.ts` — Remove columns from `SCHEMA_SQL`; add migration 23 to drop columns on existing DOs
- `session/repository.ts` — Remove from `WsClientMappingResult`, `UpsertSessionData`, `CreateParticipantData` interfaces and SQL

**Business Logic** (3 files)
- `session/participant-service.ts` — Use `SourceControlProviderName` type alias in `getAvatarUrl`; remove `scm_provider` from `create()` return
- `session/message-queue.ts` — Add `scmProvider` to deps interface; use deployment provider for avatar URLs
- `session/durable-object.ts` — Remove `scmProvider` from `handleInit` body; use `resolveScmProviderFromEnv(this.env.SCM_PROVIDER)` for avatar URLs in `handleSubscribe`, `getClientInfo`, and message queue deps

**Tests** (8 files)
- Remove `scm_provider` from all mock data across 7 test files
- Add `scmProvider: "github"` to message-queue test deps
- Update migration count assertions in schema tests

## Test plan

- [x] `npm run typecheck` passes
- [x] All 572 unit tests pass
- [ ] Verify avatar URLs still render correctly in web UI after deploy
- [ ] Verify existing sessions with populated `scm_provider` columns work after migration 23 runs