### PR TITLE
refactor: VCS-neutral sandbox git operations

### DIFF
--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -165,7 +165,7 @@ async def api_create_sandbox(
             session_config=session_config,
             control_plane_url=control_plane_url,
             sandbox_auth_token=request.get("sandbox_auth_token"),
-            github_app_token=github_app_token,
+            clone_token=github_app_token,
             user_env_vars=request.get("user_env_vars") or None,
         )
 
@@ -530,7 +530,7 @@ async def api_restore_sandbox(
             sandbox_id=sandbox_id,
             control_plane_url=control_plane_url,
             sandbox_auth_token=sandbox_auth_token,
-            github_app_token=github_app_token,
+            clone_token=github_app_token,
             user_env_vars=user_env_vars,
             timeout_seconds=timeout_seconds,
         )

--- a/packages/modal-infra/tests/test_entrypoint_urls.py
+++ b/packages/modal-infra/tests/test_entrypoint_urls.py
@@ -1,0 +1,94 @@
+"""Tests for SandboxSupervisor._build_repo_url()."""
+
+from unittest.mock import patch
+
+from src.sandbox.entrypoint import SandboxSupervisor
+
+
+def _make_supervisor(env_overrides: dict[str, str] | None = None) -> SandboxSupervisor:
+    """Create a SandboxSupervisor with controlled env vars."""
+    base_env = {
+        "SANDBOX_ID": "test-sandbox",
+        "CONTROL_PLANE_URL": "https://cp.example.com",
+        "SANDBOX_AUTH_TOKEN": "tok",
+        "REPO_OWNER": "acme",
+        "REPO_NAME": "app",
+    }
+    if env_overrides:
+        base_env.update(env_overrides)
+    with patch.dict("os.environ", base_env, clear=True):
+        return SandboxSupervisor()
+
+
+class TestBuildRepoUrl:
+    def test_github_authenticated(self):
+        sup = _make_supervisor(
+            {
+                "VCS_HOST": "github.com",
+                "VCS_CLONE_USERNAME": "x-access-token",
+                "VCS_CLONE_TOKEN": "ghp_abc123",
+            }
+        )
+        url = sup._build_repo_url()
+        assert url == "https://x-access-token:ghp_abc123@github.com/acme/app.git"
+
+    def test_github_unauthenticated(self):
+        sup = _make_supervisor(
+            {
+                "VCS_HOST": "github.com",
+                "VCS_CLONE_USERNAME": "x-access-token",
+            }
+        )
+        url = sup._build_repo_url()
+        assert url == "https://github.com/acme/app.git"
+
+    def test_bitbucket_authenticated(self):
+        sup = _make_supervisor(
+            {
+                "VCS_HOST": "bitbucket.org",
+                "VCS_CLONE_USERNAME": "x-token-auth",
+                "VCS_CLONE_TOKEN": "bb_token_xyz",
+            }
+        )
+        url = sup._build_repo_url()
+        assert url == "https://x-token-auth:bb_token_xyz@bitbucket.org/acme/app.git"
+
+    def test_bitbucket_unauthenticated(self):
+        sup = _make_supervisor(
+            {
+                "VCS_HOST": "bitbucket.org",
+                "VCS_CLONE_USERNAME": "x-token-auth",
+            }
+        )
+        url = sup._build_repo_url()
+        assert url == "https://bitbucket.org/acme/app.git"
+
+    def test_authenticated_false_with_token(self):
+        """authenticated=False returns unauthenticated URL even when token is present."""
+        sup = _make_supervisor(
+            {
+                "VCS_HOST": "github.com",
+                "VCS_CLONE_USERNAME": "x-access-token",
+                "VCS_CLONE_TOKEN": "ghp_abc123",
+            }
+        )
+        url = sup._build_repo_url(authenticated=False)
+        assert url == "https://github.com/acme/app.git"
+
+    def test_defaults_to_github(self):
+        """No VCS_* env vars → falls back to github.com defaults."""
+        sup = _make_supervisor()
+        url = sup._build_repo_url()
+        assert url == "https://github.com/acme/app.git"
+
+    def test_legacy_github_app_token_fallback(self):
+        """VCS_CLONE_TOKEN unset, GITHUB_APP_TOKEN set → uses legacy fallback."""
+        sup = _make_supervisor(
+            {
+                "VCS_HOST": "github.com",
+                "VCS_CLONE_USERNAME": "x-access-token",
+                "GITHUB_APP_TOKEN": "ghp_legacy",
+            }
+        )
+        url = sup._build_repo_url()
+        assert url == "https://x-access-token:ghp_legacy@github.com/acme/app.git"


### PR DESCRIPTION
## Summary

Prep for Bitbucket integration (PR #177). Refactors the sandbox manager and entrypoint to use VCS-provider-neutral env vars derived from the deployment-level `SCM_PROVIDER` env var, so the sandbox pipeline works for any provider without hardcoding `github.com` or `x-access-token`.

- **manager.py**: Rename `SandboxConfig.github_app_token` → `clone_token`, inject `VCS_HOST`/`VCS_CLONE_USERNAME`/`VCS_CLONE_TOKEN` in both `create_sandbox()` and `restore_from_snapshot()`, gate `GITHUB_APP_TOKEN`/`GITHUB_TOKEN` on `scm_provider == "github"`
- **entrypoint.py**: Read VCS_* env vars (with fallback to `GITHUB_APP_TOKEN`), add `_build_repo_url()` helper replacing 3 inline URL constructions
- **web_api.py**: Update 2 callers for renamed `clone_token` field

**Prerequisite**: `SCM_PROVIDER` must be added to the `internal-api` Modal secret in Terraform before Bitbucket deployments work. Existing GitHub deployments are unaffected (defaults to `"github"`).

## Test plan

- [x] All 154 tests pass (142 existing + 12 new)
- [x] `ruff check` and `ruff format` clean
- [ ] Verify GitHub deployment still works (default path, no `SCM_PROVIDER` needed)
- [ ] After Terraform adds `SCM_PROVIDER=bitbucket`, verify Bitbucket clone URLs are correct