### PR TITLE
fix: remove raw prompt content from websocket logging

### DIFF
--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -533,7 +533,11 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
       return;
     }
 
-    console.log("Sending prompt:", content, "with model:", model, "reasoning:", reasoningEffort);
+    console.log("Sending prompt", {
+      contentLength: content.length,
+      model,
+      reasoningEffort,
+    });
 
     // Optimistically set isProcessing for immediate feedback
     // Server will confirm with processing_status message


### PR DESCRIPTION
## What changed
- Replaced client-side prompt logging to avoid printing full prompt text in the browser console.
- Logging now emits only non-sensitive metadata (`contentLength`, `model`, and `reasoningEffort`).

## Why
User prompts can include sensitive data. Removing raw prompt content from logs reduces the risk of accidental exposure in browser logs, screenshots, and debugging traces.

## Scope
- `packages/web/src/hooks/use-session-socket.ts`
- No behavior changes to prompt sending; this is a logging-safety improvement only.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/b09d612033d31b167fa2a50be8a9d257)*