### PR TITLE
fix: close sidebar on mobile when starting a new session

### DIFF
--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -36,8 +36,11 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
   const sidebar = useSidebar();
   const isMobile = useIsMobile();
   const handleNewSession = useCallback(() => {
+    if (isMobile) {
+      sidebar.close();
+    }
     router.push("/");
-  }, [router]);
+  }, [isMobile, router, sidebar]);
 
   useGlobalShortcuts({
     enabled: status === "authenticated" && Boolean(session),


### PR DESCRIPTION
## Summary
- Close the sidebar before navigating to the new-session page when the new session action is triggered on mobile.
- Keep desktop behavior unchanged, so only mobile users get the flow improvement.
- Ensure the shortcut-driven new session action and the sidebar plus button both use the same mobile-close behavior.

## Testing
- `npm test -w @open-inspect/web`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/453569de2b2e2d32a2c9c8b94af00de2)*