### PR TITLE
feat: make slack-bot worker deployment optional

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -180,6 +180,7 @@ jobs:
           TF_VAR_github_app_id: ${{ secrets.GH_APP_ID }}
           TF_VAR_github_app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           TF_VAR_github_app_installation_id: ${{ secrets.GH_APP_INSTALLATION_ID }}
+          TF_VAR_enable_slack_bot: "${{ secrets.ENABLE_SLACK_BOT || 'true' }}"
           TF_VAR_slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           TF_VAR_slack_signing_secret: ${{ secrets.SLACK_SIGNING_SECRET }}
           TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -301,6 +302,7 @@ jobs:
           TF_VAR_github_app_id: ${{ secrets.GH_APP_ID }}
           TF_VAR_github_app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           TF_VAR_github_app_installation_id: ${{ secrets.GH_APP_INSTALLATION_ID }}
+          TF_VAR_enable_slack_bot: "${{ secrets.ENABLE_SLACK_BOT || 'true' }}"
           TF_VAR_slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
           TF_VAR_slack_signing_secret: ${{ secrets.SLACK_SIGNING_SECRET }}
           TF_VAR_anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -311,7 +311,8 @@ github_app_private_key     = <<-EOF
 -----END PRIVATE KEY-----
 EOF
 
-# Slack (leave as empty strings to disable Slack integration)
+# Slack (set enable_slack_bot = false to disable Slack integration)
+enable_slack_bot     = false
 slack_bot_token      = ""
 slack_signing_secret = ""
 
@@ -580,8 +581,9 @@ Go to your fork's Settings → Secrets and variables → Actions, and add:
 | `GH_APP_ID`                   | GitHub App ID                                                                 |
 | `GH_APP_PRIVATE_KEY`          | GitHub App private key (PKCS#8 format)                                        |
 | `GH_APP_INSTALLATION_ID`      | GitHub App installation ID                                                    |
-| `SLACK_BOT_TOKEN`             | Slack bot token (or empty)                                                    |
-| `SLACK_SIGNING_SECRET`        | Slack signing secret (or empty)                                               |
+| `ENABLE_SLACK_BOT`            | `true` to deploy Slack bot, `false` to skip (default: `true`)                 |
+| `SLACK_BOT_TOKEN`             | Slack bot token (required if enabled)                                         |
+| `SLACK_SIGNING_SECRET`        | Slack signing secret (required if enabled)                                    |
 | `ANTHROPIC_API_KEY`           | Anthropic API key                                                             |
 | `TOKEN_ENCRYPTION_KEY`        | Generated encryption key (OAuth tokens)                                       |
 | `REPO_SECRETS_ENCRYPTION_KEY` | Generated encryption key (repo secrets)                                       |

--- a/terraform/environments/production/outputs.tf
+++ b/terraform/environments/production/outputs.tf
@@ -10,7 +10,7 @@ output "session_index_kv_id" {
 
 output "slack_kv_id" {
   description = "Slack KV namespace ID"
-  value       = module.slack_kv.namespace_id
+  value       = var.enable_slack_bot ? module.slack_kv[0].namespace_id : null
 }
 
 # Cloudflare D1 Database
@@ -32,7 +32,7 @@ output "control_plane_worker_name" {
 
 output "slack_bot_worker_name" {
   description = "Slack bot worker name"
-  value       = module.slack_bot_worker.worker_name
+  value       = var.enable_slack_bot ? module.slack_bot_worker[0].worker_name : null
 }
 
 output "linear_kv_id" {

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -78,7 +78,9 @@ github_app_installation_id = ""
 # Slack App Credentials (Optional)
 # =============================================================================
 # From Slack App dashboard: https://api.slack.com/apps
-# Leave empty to disable Slack integration.
+# Set enable_slack_bot = false to skip deployment.
+
+enable_slack_bot = false
 
 slack_bot_token = ""       # e.g., "xoxb-..."
 slack_signing_secret = ""

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -119,16 +119,29 @@ variable "github_bot_username" {
 # Slack App Credentials
 # =============================================================================
 
+variable "enable_slack_bot" {
+  description = "Enable the Slack bot worker. Set to false to skip deployment."
+  type        = bool
+  default     = true
+
+  validation {
+    condition     = var.enable_slack_bot == false || (length(var.slack_bot_token) > 0 && length(var.slack_signing_secret) > 0)
+    error_message = "When enable_slack_bot is true, slack_bot_token and slack_signing_secret must be non-empty."
+  }
+}
+
 variable "slack_bot_token" {
   description = "Slack Bot OAuth token (xoxb-...)"
   type        = string
   sensitive   = true
+  default     = ""
 }
 
 variable "slack_signing_secret" {
   description = "Slack app signing secret"
   type        = string
   sensitive   = true
+  default     = ""
 }
 
 # =============================================================================


### PR DESCRIPTION
### Summary
Add `enable_slack_bot` flag (default: `false`) to control whether the slack-bot worker and its KV namespace are deployed. When disabled, the control-plane worker drops the `SLACK_BOT` service binding.

### Changes:

Add `enable_slack_bot` variable with credential validation (requires `slack_bot_token` and `slack_signing_secret` when enabled)
Gate `slack_bot_worker`, `slack_kv`, and `slack_bot_build` resources with `count`
Conditionally include `SLACK_BOT` service binding in control-plane worker
Fix circular `depends_on` between control-plane and slack-bot workers that caused a Terraform cycle when `enable_slack_bot = false`