### PR TITLE
fix: handle 403 when posting PR comment from fork PRs

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -112,12 +112,20 @@ jobs:
 
             *Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
 
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: output
-            });
+            try {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+              });
+            } catch (error) {
+              if (error.status === 403) {
+                core.notice('Could not post PR comment — GITHUB_TOKEN has read-only access (expected for fork PRs).');
+              } else {
+                throw error;
+              }
+            }
 
   plan:
     name: Plan


### PR DESCRIPTION
## Summary

- The Terraform `validate` job fails for external contributor PRs because GitHub restricts the `GITHUB_TOKEN` to read-only for fork PRs (security measure to prevent forks from modifying the base repo)
- The `createComment` call gets a 403 "Resource not accessible by integration", which fails the entire job even though validation itself passed
- Wraps the comment in a try/catch that emits a `core.notice()` on 403 instead of failing — validation results still show via step outcomes
- The `plan` job is unaffected (already gated on `has-secrets == 'true'`, which is false for forks)

## Test plan

- [ ] Verify the workflow passes on this PR (non-fork, comment should post normally)
- [ ] Verify an external contributor fork PR no longer fails the validate job