### PR TITLE
fix: stop tracking generated next-env.d.ts in web

### DIFF
--- a/packages/web/.gitignore
+++ b/packages/web/.gitignore
@@ -3,3 +3,4 @@
 .open-next
 .dev.vars
 wrangler.production.toml
+next-env.d.ts

--- a/packages/web/next-env.d.ts
+++ b/packages/web/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -10,7 +10,7 @@
     "start": "next start",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "next typegen && tsc --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest"


### PR DESCRIPTION
## Summary
- Add `next-env.d.ts` to `packages/web/.gitignore` so the generated Next.js file is not checked into source control.
- Remove the tracked `packages/web/next-env.d.ts` file from the repository.
- Update the web package `typecheck` script to run `next typegen` before `tsc --noEmit`, ensuring CI typecheck regenerates Next.js type artifacts first.

## Validation
- Ran `npm run typecheck -w @open-inspect/web` successfully.
- Confirmed route/type generation runs before TypeScript checking.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/1ed7b79bfff9f2eb3befbdbdc5d99189)*