### PR TITLE
fix: match more-menu button height with archive button in action bar

### DIFF
--- a/packages/web/src/components/action-bar.tsx
+++ b/packages/web/src/components/action-bar.tsx
@@ -10,7 +10,7 @@ import {
   LinkIcon,
   GitHubIcon,
 } from "@/components/ui/icons";
-import { buttonVariants } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 
 interface ActionBarProps {
   sessionId: string;
@@ -68,7 +68,7 @@ export function ActionBar({
   });
 
   return (
-    <div className="flex flex-wrap items-center gap-2">
+    <div className="flex flex-wrap items-stretch gap-2">
       {/* View Preview */}
       {previewArtifact?.url && (
         <a
@@ -99,23 +99,27 @@ export function ActionBar({
       )}
 
       {/* Archive/Unarchive */}
-      <button
+      <Button
+        variant="outline"
+        size="sm"
         onClick={handleArchiveToggle}
         disabled={isArchiving}
-        className={`${pillButtonClass} disabled:opacity-50`}
+        className="flex shrink-0 items-center gap-1.5 whitespace-nowrap disabled:opacity-50"
       >
         <ArchiveIcon className="w-4 h-4" />
         <span>{isArchived ? "Unarchive" : "Archive"}</span>
-      </button>
+      </Button>
 
       {/* More menu */}
       <div className="relative shrink-0">
-        <button
+        <Button
+          variant="outline"
+          size="sm"
           onClick={() => setIsMenuOpen(!isMenuOpen)}
-          className="flex items-center justify-center w-8 h-8 text-muted-foreground hover:text-foreground border border-border hover:bg-muted transition-colors"
+          className="flex shrink-0 items-center justify-center !px-2 h-full"
         >
           <MoreIcon className="w-4 h-4" />
-        </button>
+        </Button>
 
         {isMenuOpen && (
           <>


### PR DESCRIPTION
## Summary

- Fix height mismatch between the Archive button and the three-dot more-menu button in the session action bar
- Use the `Button` component for both the Archive and more-menu buttons instead of raw `<button>` elements with `buttonVariants()`
- Change the parent flex container from `items-center` to `items-stretch` so all action bar items share the same height

## Details

The more-menu button used a hardcoded `w-8 h-8` with custom styling, which didn't match the height of the adjacent Archive button (determined by `py-1.5` + `text-sm` line-height from `buttonVariants`). This caused a visible height difference between the two buttons.

The fix uses `items-stretch` on the parent flex container and `h-full` on the more-menu button so it inherits the same height as its siblings. Both buttons now use the `Button` component for consistency, while the `<a>` tag links (View Preview, View PR) continue to use `buttonVariants()` directly since they aren't `<button>` elements.


Before:
<img width="428" height="234" alt="CleanShot 2026-02-25 at 19 45 08@2x" src="https://github.com/user-attachments/assets/c3795ed7-b6ef-469e-ab80-f741594ee264" />
After:
<img width="428" height="234" alt="CleanShot 2026-02-25 at 19 45 50@2x" src="https://github.com/user-attachments/assets/ac5ade3d-6459-4fc0-ba98-0555f50a95fb" />

