### PR TITLE
fix(web): require Cmd/Ctrl+Enter to submit prompts

### DIFF
--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -299,7 +299,7 @@ function HomeContent({
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.nativeEvent.isComposing) return;
 
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
       e.preventDefault();
       handleSubmit(e);
     }

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -212,7 +212,7 @@ function SessionPageContent() {
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.nativeEvent.isComposing) return;
 
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
       e.preventDefault();
       handleSubmit(e);
     }

--- a/packages/web/src/components/settings/keyboard-shortcuts-settings.tsx
+++ b/packages/web/src/components/settings/keyboard-shortcuts-settings.tsx
@@ -18,7 +18,7 @@ export function KeyboardShortcutsSettings() {
       </div>
 
       <p className="mt-4 text-sm text-muted-foreground">
-        In the composer, Enter sends and Shift+Enter creates a newline.
+        In the composer, Cmd/Ctrl+Enter sends and Enter creates a newline.
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
- update composer key handling so plain `Enter` no longer submits prompts
- require primary-modifier + `Enter` (`Cmd` on macOS / `Ctrl` elsewhere) for submission on both new-session and session pages
- refresh keyboard shortcut help text to reflect the new behavior (`Cmd/Ctrl+Enter` sends, `Enter` inserts newline)

## Validation
- ran `npm run typecheck -w @open-inspect/web`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/2a7c176216c58386a873468992deabec)*