### PR TITLE
fix: use Open-Inspect fallback identity for commit attribution

### DIFF
--- a/packages/modal-infra/src/sandbox/bridge.py
+++ b/packages/modal-infra/src/sandbox/bridge.py
@@ -32,6 +32,10 @@ from .types import GitUser
 
 configure_logging()
 
+# Fallback git identity when prompt author has no SCM name/email configured.
+# Matches the co-author trailer used in generateCommitMessage (shared/git.ts).
+FALLBACK_GIT_USER = GitUser(name="OpenInspect", email="open-inspect@noreply.github.com")
+
 
 class OpenCodeIdentifier:
     """
@@ -520,13 +524,12 @@ class AgentBridge:
 
         scm_name = author_data.get("scmName")
         scm_email = author_data.get("scmEmail")
-        if scm_name and scm_email:
-            await self._configure_git_identity(
-                GitUser(
-                    name=scm_name,
-                    email=scm_email,
-                )
+        await self._configure_git_identity(
+            GitUser(
+                name=scm_name or FALLBACK_GIT_USER.name,
+                email=scm_email or FALLBACK_GIT_USER.email,
             )
+        )
 
         if not self.opencode_session_id:
             await self._create_opencode_session()

--- a/packages/modal-infra/tests/test_bridge_git_identity.py
+++ b/packages/modal-infra/tests/test_bridge_git_identity.py
@@ -1,0 +1,174 @@
+"""Tests for git identity configuration in bridge prompt handling."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.sandbox.bridge import FALLBACK_GIT_USER, AgentBridge
+
+
+@pytest.fixture
+def bridge() -> AgentBridge:
+    """Create a bridge instance for testing."""
+    b = AgentBridge(
+        sandbox_id="test-sandbox",
+        session_id="test-session",
+        control_plane_url="http://localhost:8787",
+        auth_token="test-token",
+    )
+    b.opencode_session_id = "oc-session-123"
+    return b
+
+
+class TestGitIdentityConfiguration:
+    """Tests for git identity fallback in _handle_prompt."""
+
+    @pytest.mark.asyncio
+    async def test_uses_author_identity_when_provided(self, bridge: AgentBridge):
+        """Should use scmName/scmEmail from the prompt author when both are present."""
+        bridge._configure_git_identity = AsyncMock()
+        bridge._stream_opencode_response_sse = AsyncMock(
+            return_value=AsyncMock(
+                __aiter__=lambda s: s, __anext__=AsyncMock(side_effect=StopAsyncIteration)
+            )
+        )
+        bridge._send_execution_complete = AsyncMock()
+
+        cmd = {
+            "messageId": "msg-1",
+            "content": "fix the bug",
+            "model": "claude-sonnet-4-6",
+            "author": {
+                "userId": "user-1",
+                "scmName": "Jane Dev",
+                "scmEmail": "jane@example.com",
+            },
+        }
+
+        await bridge._handle_prompt(cmd)
+
+        bridge._configure_git_identity.assert_called_once()
+        git_user = bridge._configure_git_identity.call_args[0][0]
+        assert git_user.name == "Jane Dev"
+        assert git_user.email == "jane@example.com"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_both_missing(self, bridge: AgentBridge):
+        """Should use fallback identity when both scmName and scmEmail are null."""
+        bridge._configure_git_identity = AsyncMock()
+        bridge._stream_opencode_response_sse = AsyncMock(
+            return_value=AsyncMock(
+                __aiter__=lambda s: s, __anext__=AsyncMock(side_effect=StopAsyncIteration)
+            )
+        )
+        bridge._send_execution_complete = AsyncMock()
+
+        cmd = {
+            "messageId": "msg-1",
+            "content": "fix the bug",
+            "model": "claude-sonnet-4-6",
+            "author": {
+                "userId": "user-1",
+                "scmName": None,
+                "scmEmail": None,
+            },
+        }
+
+        await bridge._handle_prompt(cmd)
+
+        bridge._configure_git_identity.assert_called_once()
+        git_user = bridge._configure_git_identity.call_args[0][0]
+        assert git_user.name == FALLBACK_GIT_USER.name
+        assert git_user.email == FALLBACK_GIT_USER.email
+
+    @pytest.mark.asyncio
+    async def test_falls_back_email_when_only_email_missing(self, bridge: AgentBridge):
+        """Should use fallback email when scmEmail is null but scmName is present."""
+        bridge._configure_git_identity = AsyncMock()
+        bridge._stream_opencode_response_sse = AsyncMock(
+            return_value=AsyncMock(
+                __aiter__=lambda s: s, __anext__=AsyncMock(side_effect=StopAsyncIteration)
+            )
+        )
+        bridge._send_execution_complete = AsyncMock()
+
+        cmd = {
+            "messageId": "msg-1",
+            "content": "fix the bug",
+            "model": "claude-sonnet-4-6",
+            "author": {
+                "userId": "user-1",
+                "scmName": "Jane Dev",
+                "scmEmail": None,
+            },
+        }
+
+        await bridge._handle_prompt(cmd)
+
+        bridge._configure_git_identity.assert_called_once()
+        git_user = bridge._configure_git_identity.call_args[0][0]
+        assert git_user.name == "Jane Dev"
+        assert git_user.email == FALLBACK_GIT_USER.email
+
+    @pytest.mark.asyncio
+    async def test_falls_back_name_when_only_name_missing(self, bridge: AgentBridge):
+        """Should use fallback name when scmName is null but scmEmail is present."""
+        bridge._configure_git_identity = AsyncMock()
+        bridge._stream_opencode_response_sse = AsyncMock(
+            return_value=AsyncMock(
+                __aiter__=lambda s: s, __anext__=AsyncMock(side_effect=StopAsyncIteration)
+            )
+        )
+        bridge._send_execution_complete = AsyncMock()
+
+        cmd = {
+            "messageId": "msg-1",
+            "content": "fix the bug",
+            "model": "claude-sonnet-4-6",
+            "author": {
+                "userId": "user-1",
+                "scmName": None,
+                "scmEmail": "jane@example.com",
+            },
+        }
+
+        await bridge._handle_prompt(cmd)
+
+        bridge._configure_git_identity.assert_called_once()
+        git_user = bridge._configure_git_identity.call_args[0][0]
+        assert git_user.name == FALLBACK_GIT_USER.name
+        assert git_user.email == "jane@example.com"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_when_no_author_data(self, bridge: AgentBridge):
+        """Should use fallback identity when author dict has no SCM fields."""
+        bridge._configure_git_identity = AsyncMock()
+        bridge._stream_opencode_response_sse = AsyncMock(
+            return_value=AsyncMock(
+                __aiter__=lambda s: s, __anext__=AsyncMock(side_effect=StopAsyncIteration)
+            )
+        )
+        bridge._send_execution_complete = AsyncMock()
+
+        cmd = {
+            "messageId": "msg-1",
+            "content": "fix the bug",
+            "model": "claude-sonnet-4-6",
+            "author": {"userId": "user-1"},
+        }
+
+        await bridge._handle_prompt(cmd)
+
+        bridge._configure_git_identity.assert_called_once()
+        git_user = bridge._configure_git_identity.call_args[0][0]
+        assert git_user.name == FALLBACK_GIT_USER.name
+        assert git_user.email == FALLBACK_GIT_USER.email
+
+
+class TestFallbackGitUserConstant:
+    """Tests for the FALLBACK_GIT_USER constant."""
+
+    def test_fallback_identity_values(self):
+        """Fallback should use Open-Inspect noreply identity."""
+        assert FALLBACK_GIT_USER.name == "OpenInspect"
+        assert FALLBACK_GIT_USER.email == "open-inspect@noreply.github.com"


### PR DESCRIPTION
## Summary

- When `scmName` or `scmEmail` are null in the prompt author data, the bridge now falls back to `Open-Inspect <open-inspect@noreply.github.com>` instead of skipping git identity configuration entirely
- This prevents commits from being attributed to opencode's built-in default identity

**Affected scenarios:**
- GitHub users with private emails (`scmEmail` is null from OAuth)
- Bot-originated sessions (GitHub bot, Slack bot, Linear bot) that don't pass SCM identity
- Any prompt where the participant record has incomplete identity fields

**Changes:**
- `bridge.py`: Add `FALLBACK_GIT_USER` constant, always call `_configure_git_identity` (using fallback for any null fields)
- New `test_bridge_git_identity.py`: 6 tests covering all fallback combinations

## Test plan

- [x] All 219 Python tests pass (`pytest tests/ -v`)
- [x] `ruff check` and `ruff format` clean
- [ ] Verify commits from sessions with full SCM identity still use the user's name/email
- [ ] Verify commits from bot-initiated sessions now show "Open-Inspect" instead of "opencode"