### PR TITLE
fix: reconcile child task completion status

### DIFF
--- a/packages/control-plane/test/integration/do-internal-routes.test.ts
+++ b/packages/control-plane/test/integration/do-internal-routes.test.ts
@@ -51,7 +51,9 @@ describe("DO internal sub-session routes", () => {
 
   describe("GET /internal/child-summary", () => {
     it("returns ChildSessionDetail shape with session, sandbox, artifacts, and events", async () => {
+      const sessionName = `child-summary-${Date.now()}`;
       const { stub } = await initSession({
+        sessionName,
         repoOwner: "acme",
         repoName: "web-app",
         title: "Child task",
@@ -101,6 +103,7 @@ describe("DO internal sub-session routes", () => {
 
       // Session info
       expect(detail.session).toBeDefined();
+      expect(detail.session.id).toBe(sessionName);
       expect(detail.session.repoOwner).toBe("acme");
       expect(detail.session.title).toBe("Child task");
       expect(detail.session.status).toBe("created");


### PR DESCRIPTION
## Summary
- reconcile child session status to terminal on `execution_complete` and sync status into the session index
- return the external session/task ID (`session_name`) from child summary instead of the internal DO ID
- harden `get-task-status` to always print the requested task ID and infer DONE from `execution_complete` for backward compatibility
- add integration coverage for child completion status reconciliation and child summary ID behavior

## Testing
- `npm run test:integration -w @open-inspect/control-plane -- do-internal-routes.test.ts child-session-ops.test.ts`
- `npm run build -w @open-inspect/shared && npm run typecheck -w @open-inspect/control-plane`
- `node --check packages/modal-infra/src/sandbox/tools/get-task-status.js`