### PR TITLE
fix(web): keep sub-task timestamps inline in session lists

### DIFF
--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -352,9 +352,9 @@ function ChildSessionListItem({
         isActive ? "border-l-accent bg-accent-muted" : "border-l-transparent hover:bg-muted"
       }`}
     >
-      <div className="truncate text-xs font-medium text-foreground">{displayTitle}</div>
-      <div className="flex items-center gap-1 mt-0.5 text-xs text-muted-foreground">
-        <span>{relativeTime}</span>
+      <div className="flex items-center gap-1.5 text-xs">
+        <span className="truncate font-medium text-foreground">{displayTitle}</span>
+        <span className="shrink-0 text-muted-foreground">{relativeTime}</span>
       </div>
     </Link>
   );

--- a/packages/web/src/components/sidebar/child-sessions-section.tsx
+++ b/packages/web/src/components/sidebar/child-sessions-section.tsx
@@ -50,15 +50,17 @@ export function ChildSessionsSection({ sessionId }: ChildSessionsSectionProps) {
             className="block p-2 hover:bg-muted transition-colors rounded"
           >
             <div className="flex items-center justify-between gap-2">
-              <span className="text-sm truncate">
-                {child.title || `${child.repoOwner}/${child.repoName}`}
-              </span>
+              <div className="flex min-w-0 items-center gap-1.5">
+                <span className="text-sm truncate">
+                  {child.title || `${child.repoOwner}/${child.repoName}`}
+                </span>
+                <span className="text-xs text-muted-foreground shrink-0">
+                  {formatRelativeTime(child.updatedAt || child.createdAt)}
+                </span>
+              </div>
               <Badge variant={statusBadgeVariant(child.status)} className="shrink-0">
                 {child.status}
               </Badge>
-            </div>
-            <div className="text-xs text-muted-foreground mt-0.5">
-              {formatRelativeTime(child.updatedAt || child.createdAt)}
             </div>
           </Link>
         ))}


### PR DESCRIPTION
## Summary
- Render sub-task timestamps inline with the title in the right sidebar `Sub-tasks` list to reduce row height.
- Render nested child session timestamps inline with the title in the main session sidebar for a denser hierarchy view.
- Preserve truncation and status badge layout so long titles still behave correctly while saving vertical space.

## Validation
- Ran `npm run typecheck -w @open-inspect/web` successfully.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/d5f64ff54ad605906a94abe21901f833)*