### PR TITLE
feat: ACK mechanism for critical WebSocket events

### DIFF
--- a/packages/control-plane/src/session/types.ts
+++ b/packages/control-plane/src/session/types.ts
@@ -135,7 +135,17 @@ export interface ShutdownCommand {
   type: "shutdown";
 }
 
-export type SandboxCommand = PromptCommand | StopCommand | SnapshotCommand | ShutdownCommand;
+export interface AckCommand {
+  type: "ack";
+  ackId: string;
+}
+
+export type SandboxCommand =
+  | PromptCommand
+  | StopCommand
+  | SnapshotCommand
+  | ShutdownCommand
+  | AckCommand;
 
 // Internal session update types
 

--- a/packages/modal-infra/src/sandbox/bridge.py
+++ b/packages/modal-infra/src/sandbox/bridge.py
@@ -193,6 +193,10 @@ class AgentBridge:
         # Event buffer: survives WS reconnection, flushed on reconnect
         self._event_buffer: list[dict[str, Any]] = []
 
+        # Pending ACKs: events sent but not yet acknowledged by the control plane.
+        # Keyed by ackId, re-sent on reconnect until the DO confirms receipt.
+        self._pending_acks: dict[str, dict[str, Any]] = {}
+
         # Tracks the message ID of the currently executing prompt
         self._inflight_message_id: str | None = None
 
@@ -332,7 +336,8 @@ class AgentBridge:
                     }
                 )
 
-                await self._flush_event_buffer()
+                just_flushed = await self._flush_event_buffer()
+                await self._flush_pending_acks(skip_ack_ids=just_flushed)
 
                 heartbeat_task = asyncio.create_task(self._heartbeat_loop())
                 background_tasks: set[asyncio.Task[None]] = set()
@@ -388,23 +393,35 @@ class AgentBridge:
         event["sandboxId"] = self.sandbox_id
         event["timestamp"] = event.get("timestamp", time.time())
 
+        is_critical = event_type in self.CRITICAL_EVENT_TYPES
+        if is_critical and "ackId" not in event:
+            event["ackId"] = self._make_ack_id(event)
+
         if not self.ws or self.ws.state != State.OPEN:
             self._buffer_event(event)
             return
 
         try:
             await self.ws.send(json.dumps(event))
+            if is_critical:
+                self._pending_acks[event["ackId"]] = event
         except Exception as e:
             self.log.warn("bridge.send_error", event_type=event_type, exc=e)
             self._buffer_event(event)
 
-    async def _flush_event_buffer(self) -> None:
-        """Flush buffered events to the control plane after reconnect."""
+    async def _flush_event_buffer(self) -> set[str]:
+        """Flush buffered events to the control plane after reconnect.
+
+        Returns the set of ackIds that were added to _pending_acks during this
+        flush, so the caller can skip them in _flush_pending_acks (avoiding
+        double-send on the same reconnect).
+        """
         if not self._event_buffer:
-            return
+            return set()
 
         self.log.info("bridge.flush_buffer_start", buffer_size=len(self._event_buffer))
         flushed = 0
+        just_added: set[str] = set()
         while self._event_buffer:
             event = self._event_buffer[0]
             if not self.ws or self.ws.state != State.OPEN:
@@ -413,6 +430,10 @@ class AgentBridge:
                 await self.ws.send(json.dumps(event))
                 self._event_buffer.pop(0)
                 flushed += 1
+                # Track critical events sent from buffer as pending ACKs
+                if event.get("type") in self.CRITICAL_EVENT_TYPES and "ackId" in event:
+                    self._pending_acks[event["ackId"]] = event
+                    just_added.add(event["ackId"])
             except Exception as e:
                 self.log.warn("bridge.flush_send_error", exc=e)
                 break
@@ -422,6 +443,7 @@ class AgentBridge:
             flushed=flushed,
             remaining=len(self._event_buffer),
         )
+        return just_added
 
     def _buffer_event(self, event: dict[str, Any]) -> None:
         """Buffer an event for later delivery after WS reconnect."""
@@ -441,6 +463,52 @@ class AgentBridge:
             "bridge.event_buffered",
             event_type=event.get("type", "unknown"),
             buffer_size=len(self._event_buffer),
+        )
+
+    @staticmethod
+    def _make_ack_id(event: dict[str, Any]) -> str:
+        """Generate a deterministic ack ID for a critical event.
+
+        Format: "{type}:{messageId}" for events with messageId,
+        "{type}:{random_hex}" for events without (e.g., snapshot_ready).
+        Deterministic IDs give natural deduplication on the DO side.
+        """
+        event_type = event.get("type", "unknown")
+        message_id = event.get("messageId")
+        if message_id:
+            return f"{event_type}:{message_id}"
+        return f"{event_type}:{secrets.token_hex(8)}"
+
+    async def _flush_pending_acks(self, skip_ack_ids: set[str] | None = None) -> None:
+        """Re-send unacknowledged critical events on a new WS connection.
+
+        Events stay in _pending_acks until the DO sends an ACK command.
+
+        Args:
+            skip_ack_ids: ackIds to skip (already sent during _flush_event_buffer
+                          on this same reconnect).
+        """
+        if not self._pending_acks:
+            return
+
+        self.log.info("bridge.flush_pending_acks_start", count=len(self._pending_acks))
+        resent = 0
+        for ack_id, event in list(self._pending_acks.items()):
+            if skip_ack_ids and ack_id in skip_ack_ids:
+                continue
+            if not self.ws or self.ws.state != State.OPEN:
+                break
+            try:
+                await self.ws.send(json.dumps(event))
+                resent += 1
+            except Exception as e:
+                self.log.warn("bridge.flush_pending_ack_error", ack_id=ack_id, exc=e)
+                break
+
+        self.log.info(
+            "bridge.flush_pending_acks_complete",
+            resent=resent,
+            total=len(self._pending_acks),
         )
 
     async def _handle_command(self, cmd: dict[str, Any]) -> asyncio.Task[None] | None:
@@ -500,6 +568,11 @@ class AgentBridge:
             self.git_sync_complete.set()
         elif cmd_type == "push":
             await self._handle_push(cmd)
+        elif cmd_type == "ack":
+            ack_id = cmd.get("ackId")
+            if ack_id and ack_id in self._pending_acks:
+                del self._pending_acks[ack_id]
+                self.log.debug("bridge.ack_received", ack_id=ack_id)
         else:
             self.log.debug("bridge.unknown_command", cmd_type=cmd_type)
         return None

--- a/packages/modal-infra/tests/test_bridge_ack.py
+++ b/packages/modal-infra/tests/test_bridge_ack.py
@@ -1,0 +1,304 @@
+"""
+Unit tests for the bridge ACK mechanism.
+
+Tests that critical events get ackId attached, are tracked in _pending_acks,
+cleared on ACK command, and re-sent on reconnect via _flush_pending_acks.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from websockets import State
+
+from src.sandbox.bridge import AgentBridge
+
+
+@pytest.fixture
+def bridge() -> AgentBridge:
+    """Create a bridge instance for testing."""
+    b = AgentBridge(
+        sandbox_id="test-sandbox",
+        session_id="test-session",
+        control_plane_url="http://localhost:8787",
+        auth_token="test-token",
+    )
+    b.opencode_session_id = "oc-session-123"
+    return b
+
+
+def _open_ws() -> MagicMock:
+    """Create a mock WebSocket in OPEN state."""
+    ws = MagicMock()
+    ws.state = State.OPEN
+    ws.send = AsyncMock()
+    return ws
+
+
+class TestAckIdGeneration:
+    """Tests for _make_ack_id deterministic ID generation."""
+
+    def test_deterministic_ack_id_with_message_id(self):
+        event = {"type": "execution_complete", "messageId": "msg-1"}
+        ack_id = AgentBridge._make_ack_id(event)
+        assert ack_id == "execution_complete:msg-1"
+
+    def test_random_ack_id_without_message_id(self):
+        event = {"type": "snapshot_ready"}
+        ack_id = AgentBridge._make_ack_id(event)
+        assert ack_id.startswith("snapshot_ready:")
+        # Random suffix should be 16 hex chars
+        suffix = ack_id.split(":", 1)[1]
+        assert len(suffix) == 16
+        int(suffix, 16)  # Should not raise
+
+    def test_random_ack_ids_are_unique(self):
+        event = {"type": "snapshot_ready"}
+        ids = {AgentBridge._make_ack_id(event) for _ in range(10)}
+        assert len(ids) == 10
+
+
+class TestSendCriticalEvent:
+    """Tests that _send_event attaches ackId and tracks critical events."""
+
+    @pytest.mark.asyncio
+    async def test_send_critical_event_attaches_ack_id(self, bridge: AgentBridge):
+        ws = _open_ws()
+        bridge.ws = ws
+
+        await bridge._send_event(
+            {"type": "execution_complete", "messageId": "msg-1", "success": True}
+        )
+
+        sent_data = json.loads(ws.send.call_args[0][0])
+        assert "ackId" in sent_data
+        assert sent_data["ackId"] == "execution_complete:msg-1"
+
+    @pytest.mark.asyncio
+    async def test_send_critical_event_tracked_in_pending_acks(self, bridge: AgentBridge):
+        ws = _open_ws()
+        bridge.ws = ws
+
+        await bridge._send_event(
+            {"type": "execution_complete", "messageId": "msg-1", "success": True}
+        )
+
+        assert "execution_complete:msg-1" in bridge._pending_acks
+        assert bridge._pending_acks["execution_complete:msg-1"]["type"] == "execution_complete"
+
+    @pytest.mark.asyncio
+    async def test_send_non_critical_event_no_ack_id(self, bridge: AgentBridge):
+        ws = _open_ws()
+        bridge.ws = ws
+
+        await bridge._send_event({"type": "token", "content": "hello", "messageId": "msg-1"})
+
+        sent_data = json.loads(ws.send.call_args[0][0])
+        assert "ackId" not in sent_data
+        assert len(bridge._pending_acks) == 0
+
+    @pytest.mark.asyncio
+    async def test_send_failure_buffers_not_pending(self, bridge: AgentBridge):
+        ws = _open_ws()
+        ws.send = AsyncMock(side_effect=ConnectionError("broken pipe"))
+        bridge.ws = ws
+
+        await bridge._send_event(
+            {"type": "execution_complete", "messageId": "msg-1", "success": True}
+        )
+
+        # Should be in buffer, NOT in pending_acks
+        assert len(bridge._event_buffer) == 1
+        assert len(bridge._pending_acks) == 0
+
+    @pytest.mark.asyncio
+    async def test_existing_ack_id_not_overwritten(self, bridge: AgentBridge):
+        ws = _open_ws()
+        bridge.ws = ws
+
+        await bridge._send_event(
+            {
+                "type": "execution_complete",
+                "messageId": "msg-1",
+                "success": True,
+                "ackId": "custom:id",
+            }
+        )
+
+        sent_data = json.loads(ws.send.call_args[0][0])
+        assert sent_data["ackId"] == "custom:id"
+
+
+class TestAckCommand:
+    """Tests for handling ACK commands from control plane."""
+
+    @pytest.mark.asyncio
+    async def test_ack_command_clears_pending(self, bridge: AgentBridge):
+        bridge._pending_acks["execution_complete:msg-1"] = {
+            "type": "execution_complete",
+            "messageId": "msg-1",
+            "ackId": "execution_complete:msg-1",
+        }
+
+        await bridge._handle_command({"type": "ack", "ackId": "execution_complete:msg-1"})
+
+        assert "execution_complete:msg-1" not in bridge._pending_acks
+
+    @pytest.mark.asyncio
+    async def test_ack_command_unknown_id_ignored(self, bridge: AgentBridge):
+        bridge._pending_acks["execution_complete:msg-1"] = {
+            "type": "execution_complete",
+            "ackId": "execution_complete:msg-1",
+        }
+
+        # ACK for a different ID should not affect existing entries
+        await bridge._handle_command({"type": "ack", "ackId": "execution_complete:msg-999"})
+
+        assert "execution_complete:msg-1" in bridge._pending_acks
+
+    @pytest.mark.asyncio
+    async def test_ack_command_missing_ack_id_ignored(self, bridge: AgentBridge):
+        bridge._pending_acks["execution_complete:msg-1"] = {
+            "type": "execution_complete",
+            "ackId": "execution_complete:msg-1",
+        }
+
+        await bridge._handle_command({"type": "ack"})
+
+        assert len(bridge._pending_acks) == 1
+
+
+class TestFlushPendingAcks:
+    """Tests for _flush_pending_acks re-sending on new WS."""
+
+    @pytest.mark.asyncio
+    async def test_flush_pending_acks_resends(self, bridge: AgentBridge):
+        bridge._pending_acks = {
+            "execution_complete:msg-1": {
+                "type": "execution_complete",
+                "messageId": "msg-1",
+                "ackId": "execution_complete:msg-1",
+            },
+            "error:msg-2": {
+                "type": "error",
+                "messageId": "msg-2",
+                "ackId": "error:msg-2",
+            },
+        }
+
+        ws = _open_ws()
+        bridge.ws = ws
+
+        await bridge._flush_pending_acks()
+
+        assert ws.send.call_count == 2
+        # Events should still be in _pending_acks (not removed until ACK arrives)
+        assert len(bridge._pending_acks) == 2
+
+    @pytest.mark.asyncio
+    async def test_flush_pending_acks_noop_when_empty(self, bridge: AgentBridge):
+        ws = _open_ws()
+        bridge.ws = ws
+
+        await bridge._flush_pending_acks()
+
+        ws.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_flush_pending_acks_stops_on_ws_failure(self, bridge: AgentBridge):
+        call_count = 0
+
+        async def fail_on_second(data):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                raise ConnectionError("broken")
+
+        bridge._pending_acks = {
+            "a:1": {"type": "execution_complete", "ackId": "a:1"},
+            "b:2": {"type": "error", "ackId": "b:2"},
+        }
+
+        ws = _open_ws()
+        ws.send = fail_on_second
+        bridge.ws = ws
+
+        await bridge._flush_pending_acks()
+
+        # Both should still be in pending (first sent OK, second failed, but
+        # neither removed — removal only happens on ACK command)
+        assert len(bridge._pending_acks) == 2
+
+
+class TestBufferFlushAddsToPending:
+    """Tests that flushing buffer events adds critical ones to _pending_acks."""
+
+    @pytest.mark.asyncio
+    async def test_buffer_flush_adds_critical_to_pending_acks(self, bridge: AgentBridge):
+        bridge._event_buffer = [
+            {
+                "type": "execution_complete",
+                "messageId": "msg-1",
+                "ackId": "execution_complete:msg-1",
+            },
+            {"type": "token", "content": "hello"},
+        ]
+
+        ws = _open_ws()
+        bridge.ws = ws
+
+        just_added = await bridge._flush_event_buffer()
+
+        assert len(bridge._event_buffer) == 0
+        # Only the critical event should be in pending_acks
+        assert "execution_complete:msg-1" in bridge._pending_acks
+        assert len(bridge._pending_acks) == 1
+        # Return value should contain the ackId just added
+        assert just_added == {"execution_complete:msg-1"}
+
+    @pytest.mark.asyncio
+    async def test_buffer_flush_returns_empty_set_for_non_critical(self, bridge: AgentBridge):
+        bridge._event_buffer = [{"type": "token", "content": "hello"}]
+
+        ws = _open_ws()
+        bridge.ws = ws
+
+        just_added = await bridge._flush_event_buffer()
+
+        assert just_added == set()
+        assert len(bridge._pending_acks) == 0
+
+
+class TestFlushPendingAcksSkip:
+    """Tests that _flush_pending_acks skips ackIds from buffer flush."""
+
+    @pytest.mark.asyncio
+    async def test_skip_ack_ids_prevents_double_send(self, bridge: AgentBridge):
+        """Events just flushed from buffer should not be re-sent by pending ack flush."""
+        bridge._pending_acks = {
+            "execution_complete:msg-1": {
+                "type": "execution_complete",
+                "ackId": "execution_complete:msg-1",
+            },
+            "error:msg-2": {
+                "type": "error",
+                "ackId": "error:msg-2",
+            },
+        }
+
+        ws = _open_ws()
+        bridge.ws = ws
+
+        # Simulate: msg-1 was just flushed from buffer, msg-2 was from a prior send
+        await bridge._flush_pending_acks(skip_ack_ids={"execution_complete:msg-1"})
+
+        # Only msg-2 should have been sent
+        assert ws.send.call_count == 1
+        sent_data = json.loads(ws.send.call_args[0][0])
+        assert sent_data["ackId"] == "error:msg-2"
+        # Both should still be in _pending_acks
+        assert len(bridge._pending_acks) == 2
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

- Adds at-least-once delivery for critical WebSocket events (`execution_complete`, `error`, `snapshot_ready`, `push_complete`, `push_error`) between the Modal bridge and Cloudflare DO
- Bridge attaches deterministic `ackId` to critical events, tracks them in `_pending_acks`, and re-sends on reconnect until the DO confirms receipt via an `ack` command
- Prevents silent event loss during 1006 disconnects caused by DO host migration or code deploys (root cause of a production incident where a session hung for 90 minutes)

### Changes

**Control plane (TypeScript)**
- `types.ts`: Add `AckCommand` to `SandboxCommand` union
- `sandbox-events.ts`: Extract `ackId` from incoming events, send `{ type: "ack", ackId }` back to sandbox after processing critical events
- `sandbox-events.test.ts`: 7 new tests covering ACK for each critical event type, backward compatibility, already-stopped path, and non-critical event exclusion

**Bridge (Python)**
- `bridge.py`: Add `_pending_acks` dict, `_make_ack_id()` for deterministic IDs, attach ackId to critical events on send, handle `ack` command to clear pending, `_flush_pending_acks()` on reconnect with `skip_ack_ids` to prevent double-send
- `test_bridge_ack.py`: 17 new tests covering ackId generation, critical/non-critical event handling, ACK command processing, pending ack flush, buffer flush interaction, and skip-double-send mechanism

### Design decisions

- **Deterministic ackId**: `"{type}:{messageId}"` gives natural dedup on the DO side; random suffix for events without messageId (e.g., `snapshot_ready`)
- **Separate from event buffer**: `_pending_acks` tracks sent-but-unconfirmed events; `_event_buffer` tracks never-sent events. Different concerns, different lifecycles
- **No ACK timeout**: Re-send on reconnect is sufficient. If WS is healthy, ACKs arrive in ms. If it drops, reconnect triggers resend
- **Backward compatible**: DO only sends ACKs when `ackId` is present. Deploy control-plane first, then modal-infra

## Test plan

- [x] TypeScript unit tests pass (`npm test -w @open-inspect/control-plane`)
- [x] Python unit tests pass (`pytest tests/test_bridge_ack.py -v`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Lint passes (ESLint + Prettier + Ruff)
- [ ] Deploy control-plane first, then modal-infra (backward-compatible rollout)
- [ ] Verify in staging: trigger a reconnect and confirm critical events are re-delivered