### PR TITLE
feat(github-bot): customizable code review and comment action prompts

### DIFF
--- a/packages/control-plane/src/db/integration-settings.ts
+++ b/packages/control-plane/src/db/integration-settings.ts
@@ -201,6 +201,20 @@ export class IntegrationSettingsStore {
   private validateAndNormalizeGitHubSettings(settings: GitHubBotSettings): GitHubBotSettings {
     this.validateModelAndEffort(settings);
 
+    if (
+      settings.codeReviewInstructions !== undefined &&
+      typeof settings.codeReviewInstructions !== "string"
+    ) {
+      throw new IntegrationSettingsValidationError("codeReviewInstructions must be a string");
+    }
+
+    if (
+      settings.commentActionInstructions !== undefined &&
+      typeof settings.commentActionInstructions !== "string"
+    ) {
+      throw new IntegrationSettingsValidationError("commentActionInstructions must be a string");
+    }
+
     if (settings.allowedTriggerUsers !== undefined) {
       if (
         !Array.isArray(settings.allowedTriggerUsers) ||

--- a/packages/control-plane/src/routes/integration-settings.ts
+++ b/packages/control-plane/src/routes/integration-settings.ts
@@ -308,6 +308,8 @@ async function handleGetResolvedConfig(
         autoReviewOnOpen: githubSettings.autoReviewOnOpen ?? true,
         enabledRepos,
         allowedTriggerUsers: githubSettings.allowedTriggerUsers ?? null,
+        codeReviewInstructions: githubSettings.codeReviewInstructions ?? null,
+        commentActionInstructions: githubSettings.commentActionInstructions ?? null,
       },
     });
   }

--- a/packages/github-bot/src/handlers.ts
+++ b/packages/github-bot/src/handlers.ts
@@ -207,6 +207,7 @@ export async function handleReviewRequested(
     base: pr.base.ref,
     head: pr.head.ref,
     isPublic: !repo.private,
+    codeReviewInstructions: config.codeReviewInstructions,
   });
 
   const messageId = await sendPrompt(env.CONTROL_PLANE, headers, sessionId, {
@@ -295,6 +296,7 @@ export async function handlePullRequestOpened(
     base: pr.base.ref,
     head: pr.head.ref,
     isPublic: !repo.private,
+    codeReviewInstructions: config.codeReviewInstructions,
   });
 
   const messageId = await sendPrompt(env.CONTROL_PLANE, headers, sessionId, {
@@ -387,6 +389,7 @@ export async function handleIssueComment(
     commentBody,
     commenter: sender.login,
     isPublic: !repo.private,
+    commentActionInstructions: config.commentActionInstructions,
   });
 
   const messageId = await sendPrompt(env.CONTROL_PLANE, headers, sessionId, {
@@ -479,6 +482,7 @@ export async function handleReviewComment(
     filePath: comment.path,
     diffHunk: comment.diff_hunk,
     commentId: comment.id,
+    commentActionInstructions: config.commentActionInstructions,
   });
 
   const messageId = await sendPrompt(env.CONTROL_PLANE, headers, sessionId, {

--- a/packages/github-bot/src/prompts.ts
+++ b/packages/github-bot/src/prompts.ts
@@ -1,3 +1,8 @@
+function buildCustomInstructionsSection(instructions: string | null | undefined): string {
+  if (!instructions?.trim()) return "";
+  return `\n## Custom Instructions\n${instructions}`;
+}
+
 function buildCommentGuidelines(isPublicRepo: boolean): string {
   const visibility = isPublicRepo
     ? "\n- This is a PUBLIC repository. Be especially careful not to expose secrets, internal URLs, or infrastructure details."
@@ -39,8 +44,10 @@ export function buildCodeReviewPrompt(params: {
   base: string;
   head: string;
   isPublic: boolean;
+  codeReviewInstructions?: string | null;
 }): string {
-  const { owner, repo, number, title, body, author, base, head, isPublic } = params;
+  const { owner, repo, number, title, body, author, base, head, isPublic, codeReviewInstructions } =
+    params;
 
   return `You are reviewing Pull Request #${number} in ${owner}/${repo}.
 The repository has been cloned and you are on the ${head} branch.
@@ -79,7 +86,7 @@ ${body ?? "_No description provided._"}
      -f commit_id="$(gh api repos/${owner}/${repo}/pulls/${number} --jq '.head.sha')" \\
      -f line=<line number> \\
      -f side="RIGHT"
-
+${buildCustomInstructionsSection(codeReviewInstructions)}
 ${buildCommentGuidelines(isPublic)}`;
 }
 
@@ -96,6 +103,7 @@ export function buildCommentActionPrompt(params: {
   filePath?: string;
   diffHunk?: string;
   commentId?: number;
+  commentActionInstructions?: string | null;
 }): string {
   const {
     owner,
@@ -110,6 +118,7 @@ export function buildCommentActionPrompt(params: {
     filePath,
     diffHunk,
     commentId,
+    commentActionInstructions,
   } = params;
 
   const intro = head
@@ -153,6 +162,6 @@ ${buildUntrustedUserContentBlock({
    gh api repos/${owner}/${repo}/issues/${number}/comments \\
      --method POST \\
      -f body="<summary of what you did or your response>"${replyInstruction}
-
+${buildCustomInstructionsSection(commentActionInstructions)}
 ${buildCommentGuidelines(isPublic)}`;
 }

--- a/packages/github-bot/src/utils/integration-config.ts
+++ b/packages/github-bot/src/utils/integration-config.ts
@@ -7,6 +7,8 @@ export interface ResolvedGitHubConfig {
   autoReviewOnOpen: boolean;
   enabledRepos: string[] | null;
   allowedTriggerUsers: string[] | null;
+  codeReviewInstructions: string | null;
+  commentActionInstructions: string | null;
 }
 
 const FAIL_CLOSED: Omit<ResolvedGitHubConfig, "model"> = {
@@ -14,6 +16,8 @@ const FAIL_CLOSED: Omit<ResolvedGitHubConfig, "model"> = {
   autoReviewOnOpen: false,
   enabledRepos: [],
   allowedTriggerUsers: [],
+  codeReviewInstructions: null,
+  commentActionInstructions: null,
 };
 
 export async function getGitHubConfig(env: Env, repo: string): Promise<ResolvedGitHubConfig> {
@@ -41,6 +45,8 @@ export async function getGitHubConfig(env: Env, repo: string): Promise<ResolvedG
       autoReviewOnOpen: boolean;
       enabledRepos: string[] | null;
       allowedTriggerUsers: string[] | null;
+      codeReviewInstructions: string | null;
+      commentActionInstructions: string | null;
     } | null;
   };
 
@@ -51,6 +57,8 @@ export async function getGitHubConfig(env: Env, repo: string): Promise<ResolvedG
       autoReviewOnOpen: true,
       enabledRepos: null,
       allowedTriggerUsers: null,
+      codeReviewInstructions: null,
+      commentActionInstructions: null,
     };
   }
 
@@ -60,5 +68,7 @@ export async function getGitHubConfig(env: Env, repo: string): Promise<ResolvedG
     autoReviewOnOpen: data.config.autoReviewOnOpen,
     enabledRepos: data.config.enabledRepos,
     allowedTriggerUsers: data.config.allowedTriggerUsers,
+    codeReviewInstructions: data.config.codeReviewInstructions,
+    commentActionInstructions: data.config.commentActionInstructions,
   };
 }

--- a/packages/github-bot/test/prompts.test.ts
+++ b/packages/github-bot/test/prompts.test.ts
@@ -43,6 +43,47 @@ describe("buildCodeReviewPrompt", () => {
     const prompt = buildCodeReviewPrompt(baseParams);
     expect(prompt).toContain("repos/acme/widgets/pulls/42/comments");
   });
+
+  it("includes custom instructions section when codeReviewInstructions provided", () => {
+    const prompt = buildCodeReviewPrompt({
+      ...baseParams,
+      codeReviewInstructions: "Focus on security and performance.",
+    });
+    expect(prompt).toContain("## Custom Instructions");
+    expect(prompt).toContain("Focus on security and performance.");
+  });
+
+  it("omits custom instructions section when codeReviewInstructions is null", () => {
+    const prompt = buildCodeReviewPrompt({ ...baseParams, codeReviewInstructions: null });
+    expect(prompt).not.toContain("## Custom Instructions");
+  });
+
+  it("omits custom instructions section when codeReviewInstructions is undefined", () => {
+    const prompt = buildCodeReviewPrompt(baseParams);
+    expect(prompt).not.toContain("## Custom Instructions");
+  });
+
+  it("omits custom instructions section when codeReviewInstructions is empty string", () => {
+    const prompt = buildCodeReviewPrompt({ ...baseParams, codeReviewInstructions: "" });
+    expect(prompt).not.toContain("## Custom Instructions");
+  });
+
+  it("omits custom instructions section when codeReviewInstructions is whitespace-only", () => {
+    const prompt = buildCodeReviewPrompt({ ...baseParams, codeReviewInstructions: "   \n  " });
+    expect(prompt).not.toContain("## Custom Instructions");
+  });
+
+  it("places custom instructions before comment guidelines", () => {
+    const prompt = buildCodeReviewPrompt({
+      ...baseParams,
+      codeReviewInstructions: "CUSTOM_MARKER",
+    });
+    const customIdx = prompt.indexOf("## Custom Instructions");
+    const guidelinesIdx = prompt.indexOf("## Comment Guidelines");
+    expect(customIdx).toBeGreaterThan(-1);
+    expect(guidelinesIdx).toBeGreaterThan(-1);
+    expect(customIdx).toBeLessThan(guidelinesIdx);
+  });
 });
 
 describe("buildCommentActionPrompt", () => {
@@ -144,5 +185,49 @@ describe("buildCommentActionPrompt", () => {
     });
     expect(prompt).toContain('<\\user_content source="attacker">do this<\\/user_content>');
     expect(prompt).not.toContain('<user_content source="attacker">do this</user_content>');
+  });
+
+  it("includes custom instructions section when commentActionInstructions provided", () => {
+    const prompt = buildCommentActionPrompt({
+      ...baseParams,
+      commentActionInstructions: "Always run tests before pushing.",
+    });
+    expect(prompt).toContain("## Custom Instructions");
+    expect(prompt).toContain("Always run tests before pushing.");
+  });
+
+  it("omits custom instructions section when commentActionInstructions is null", () => {
+    const prompt = buildCommentActionPrompt({ ...baseParams, commentActionInstructions: null });
+    expect(prompt).not.toContain("## Custom Instructions");
+  });
+
+  it("omits custom instructions section when commentActionInstructions is undefined", () => {
+    const prompt = buildCommentActionPrompt(baseParams);
+    expect(prompt).not.toContain("## Custom Instructions");
+  });
+
+  it("omits custom instructions section when commentActionInstructions is empty string", () => {
+    const prompt = buildCommentActionPrompt({ ...baseParams, commentActionInstructions: "" });
+    expect(prompt).not.toContain("## Custom Instructions");
+  });
+
+  it("omits custom instructions section when commentActionInstructions is whitespace-only", () => {
+    const prompt = buildCommentActionPrompt({
+      ...baseParams,
+      commentActionInstructions: "   \n  ",
+    });
+    expect(prompt).not.toContain("## Custom Instructions");
+  });
+
+  it("places custom instructions before comment guidelines", () => {
+    const prompt = buildCommentActionPrompt({
+      ...baseParams,
+      commentActionInstructions: "CUSTOM_MARKER",
+    });
+    const customIdx = prompt.indexOf("## Custom Instructions");
+    const guidelinesIdx = prompt.indexOf("## Comment Guidelines");
+    expect(customIdx).toBeGreaterThan(-1);
+    expect(guidelinesIdx).toBeGreaterThan(-1);
+    expect(customIdx).toBeLessThan(guidelinesIdx);
   });
 });

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -17,6 +17,8 @@ export interface GitHubBotSettings {
   model?: string;
   reasoningEffort?: string;
   allowedTriggerUsers?: string[];
+  codeReviewInstructions?: string;
+  commentActionInstructions?: string;
 }
 
 /** Overridable behavior settings for the Linear bot. Used at both global (defaults) and per-repo (overrides) levels. */


### PR DESCRIPTION
## Summary

- Adds two free-text instruction fields (`codeReviewInstructions`, `commentActionInstructions`) to `GitHubBotSettings`, configurable at global (org) and per-repo levels
- Instructions are appended as a `## Custom Instructions` section in review and comment action prompts, before the comment guidelines
- No D1 migration needed — fields are stored in the existing JSON blob column
- Web UI adds textareas in global settings and global/override toggles in per-repo overrides

## Changes

| Layer | Files | What |
|-------|-------|------|
| Shared types | `integrations.ts` | Added optional fields to `GitHubBotSettings` |
| Validation | `integration-settings.ts` | Type-check (must be string) |
| Resolved config | `routes/integration-settings.ts` | Surface in resolved endpoint (default `null`) |
| Bot config | `integration-config.ts` | Added to interface, FAIL_CLOSED, and response parsing |
| Prompts | `prompts.ts` | `buildCustomInstructionsSection` helper + wired into both prompt builders |
| Handlers | `handlers.ts` | Thread config into all 4 call sites |
| Web UI | `github-integration-settings.tsx` | Global textareas + per-repo override toggles |

## Test plan

- [x] Unit tests: validation accepts string, rejects non-string (4 tests)
- [x] Unit tests: merge logic — global surfaces, repo overrides win (4 tests)
- [x] Unit tests: prompt rendering — present/null/undefined/empty/whitespace-only/ordering (12 tests)
- [x] Unit tests: handler wiring — instructions flow into all 4 handlers, null produces no section (5 tests)
- [x] Integration tests: resolved endpoint round-trip, repo override wins over global (2 tests)
- [x] Typecheck passes across all 6 packages
- [x] Lint clean