### PR TITLE
fix: propagate user secrets to prebuild step

### DIFF
--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -98,6 +98,7 @@ export interface BuildRepoImageRequest {
   defaultBranch?: string;
   buildId: string;
   callbackUrl: string;
+  userEnvVars?: Record<string, string>;
 }
 
 export interface BuildRepoImageResponse {
@@ -547,6 +548,7 @@ export class ModalClient {
           default_branch: request.defaultBranch || "main",
           build_id: request.buildId,
           callback_url: request.callbackUrl,
+          user_env_vars: request.userEnvVars,
         }),
       });
 

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -200,6 +200,7 @@ class SandboxManager:
         repo_name: str,
         default_branch: str = "main",
         clone_token: str = "",
+        user_env_vars: dict[str, str] | None = None,
     ) -> SandboxHandle:
         """
         Create a sandbox specifically for image building.
@@ -215,14 +216,20 @@ class SandboxManager:
         start_time = time.time()
         sandbox_id = f"build-{repo_owner}-{repo_name}-{int(time.time() * 1000)}"
 
-        env_vars: dict[str, str] = {
+        # Prepare environment variables (user vars first, system vars override)
+        env_vars: dict[str, str] = {}
+
+        if user_env_vars:
+            env_vars.update(user_env_vars)
+
+        env_vars.update({
             "PYTHONUNBUFFERED": "1",
             "SANDBOX_ID": sandbox_id,
             "REPO_OWNER": repo_owner,
             "REPO_NAME": repo_name,
             "IMAGE_BUILD_MODE": "true",
             "SESSION_CONFIG": json.dumps({"branch": default_branch}),
-        }
+        })
 
         self._inject_vcs_env_vars(env_vars, clone_token or None)
 

--- a/packages/modal-infra/src/scheduler/image_builder.py
+++ b/packages/modal-infra/src/scheduler/image_builder.py
@@ -183,6 +183,7 @@ async def build_repo_image(
     default_branch: str = "main",
     callback_url: str = "",
     build_id: str = "",
+    user_env_vars: dict[str, str] | None = None,
 ) -> None:
     """
     Async worker: create build sandbox, await exit, snapshot, callback.
@@ -196,6 +197,7 @@ async def build_repo_image(
         default_branch: Branch to clone and build
         callback_url: URL to POST success result to
         build_id: Build identifier from the control plane
+        user_env_vars: User-defined env vars
     """
     from ..sandbox.manager import SandboxManager
 
@@ -224,6 +226,7 @@ async def build_repo_image(
             repo_name=repo_name,
             default_branch=default_branch,
             clone_token=clone_token,
+            user_env_vars=user_env_vars,
         )
 
         # 3. Stream stdout until build completes (sandbox stays alive for snapshotting)

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -605,6 +605,7 @@ async def api_build_repo_image(
         default_branch = request.get("default_branch", "main")
         build_id = request.get("build_id", "")
         callback_url = request.get("callback_url", "")
+        user_env_vars = request.get("user_env_vars") or None
 
         if not repo_owner or not repo_name:
             raise HTTPException(status_code=400, detail="repo_owner and repo_name are required")
@@ -619,6 +620,7 @@ async def api_build_repo_image(
             default_branch=default_branch,
             callback_url=callback_url,
             build_id=build_id,
+            user_env_vars=user_env_vars,
         )
 
         return {


### PR DESCRIPTION
I noticed that user defined secrets are not sent to modal for prebuild step, this was causing `npm install` to fail as my repo needs a node token in the environment to install private packages.

This PR attempts to resolve this by ensuring that secrets are propagated to the prebuild step.