### PR TITLE
refactor(control-plane): deduplicate shared session API types

### DIFF
--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -1,3 +1,5 @@
+import type { SessionStatus } from "@open-inspect/shared";
+
 export interface SessionEntry {
   id: string;
   title: string | null;
@@ -6,7 +8,7 @@ export interface SessionEntry {
   model: string;
   reasoningEffort: string | null;
   baseBranch: string | null;
-  status: string;
+  status: SessionStatus;
   parentSessionId?: string | null;
   spawnSource?: "user" | "agent";
   spawnDepth?: number;
@@ -22,7 +24,7 @@ interface SessionRow {
   model: string;
   reasoning_effort: string | null;
   base_branch: string | null;
-  status: string;
+  status: SessionStatus;
   parent_session_id: string | null;
   spawn_source: "user" | "agent";
   spawn_depth: number;
@@ -31,8 +33,8 @@ interface SessionRow {
 }
 
 export interface ListSessionsOptions {
-  status?: string;
-  excludeStatus?: string;
+  status?: SessionStatus;
+  excludeStatus?: SessionStatus;
   repoOwner?: string;
   repoName?: string;
   limit?: number;
@@ -150,7 +152,7 @@ export class SessionIndexStore {
     };
   }
 
-  async updateStatus(id: string, status: string, updatedAt = Date.now()): Promise<boolean> {
+  async updateStatus(id: string, status: SessionStatus, updatedAt = Date.now()): Promise<boolean> {
     // Protect against out-of-order async writes by only applying monotonic updated_at values.
     const result = await this.db
       .prepare("UPDATE sessions SET status = ?, updated_at = ? WHERE id = ? AND updated_at <= ?")

--- a/packages/control-plane/src/session/types.ts
+++ b/packages/control-plane/src/session/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type {
+  Attachment,
   SessionStatus,
   SandboxStatus,
   GitSyncStatus,
@@ -115,12 +116,7 @@ export interface PromptCommand {
     scmName: string | null;
     scmEmail: string | null;
   };
-  attachments?: Array<{
-    type: string;
-    name: string;
-    url?: string;
-    content?: string;
-  }>;
+  attachments?: Attachment[];
 }
 
 export interface StopCommand {

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -7,6 +7,7 @@ import type {
   EventType,
   MessageSource,
   MessageStatus,
+  ParticipantRole,
   SessionStatus,
 } from "@open-inspect/shared";
 
@@ -14,10 +15,13 @@ export type {
   ArtifactType,
   Attachment,
   ClientMessage,
+  CreateSessionRequest,
+  CreateSessionResponse,
   EventType,
   GitSyncStatus,
   MessageSource,
   MessageStatus,
+  ParticipantRole,
   ParticipantPresence,
   SandboxEvent,
   SandboxStatus,
@@ -72,9 +76,6 @@ export interface Env {
   LOG_LEVEL?: string; // "debug" | "info" | "warn" | "error" (default: "info")
 }
 
-// Participant role
-export type ParticipantRole = "owner" | "member";
-
 // Client info (stored in DO memory)
 export interface ClientInfo {
   participantId: string;
@@ -86,21 +87,6 @@ export interface ClientInfo {
   clientId: string;
   ws: WebSocket;
   lastFetchHistoryAt?: number;
-}
-
-// API response types
-export interface CreateSessionRequest {
-  repoOwner: string;
-  repoName: string;
-  title?: string;
-  model?: string; // LLM model to use (e.g., "anthropic/claude-haiku-4-5", "anthropic/claude-sonnet-4-5")
-  reasoningEffort?: string; // Reasoning effort level (e.g., "high", "max")
-  branch?: string; // Git branch to work on (defaults to repo's default branch)
-}
-
-export interface CreateSessionResponse {
-  sessionId: string;
-  status: SessionStatus;
 }
 
 export interface SessionResponse {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -27,6 +27,7 @@ export type MessageStatus = "pending" | "processing" | "completed" | "failed";
 export type MessageSource = "web" | "slack" | "linear" | "extension" | "github";
 export type ArtifactType = "pr" | "screenshot" | "preview" | "branch";
 export type EventType = "tool_call" | "tool_result" | "token" | "error" | "git_sync";
+export type ParticipantRole = "owner" | "member";
 
 // Participant in a session
 export interface SessionParticipant {
@@ -35,7 +36,7 @@ export interface SessionParticipant {
   scmLogin: string | null;
   scmName: string | null;
   scmEmail: string | null;
-  role: "owner" | "member";
+  role: ParticipantRole;
 }
 
 // Session state


### PR DESCRIPTION
## Summary
- remove duplicated `CreateSessionRequest` and `CreateSessionResponse` definitions from control-plane and re-export the shared types directly
- export a reusable `ParticipantRole` type from `@open-inspect/shared` and update control-plane to consume it instead of defining its own role union
- tighten control-plane session typing by using shared `SessionStatus` in the session index store and shared `Attachment` for prompt command attachments
- add query-param validation for `status` and `excludeStatus` in list sessions so typed status filters remain safe and explicit

## Validation
- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm test -w @open-inspect/control-plane -- src/db/session-index.test.ts`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/f5c03548196a612243cf1fa55c6af896)*