### PR TITLE
refactor(control-plane): remove double unknown casts for SQLite rows

### DIFF
--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -210,11 +210,15 @@ export interface SqlResult {
 export class SessionRepository {
   constructor(private readonly sql: SqlStorage) {}
 
+  private rows<T>(result: SqlResult): T[] {
+    return result.toArray() as T[];
+  }
+
   // === SESSION ===
 
   getSession(): SessionRow | null {
     const result = this.sql.exec(`SELECT * FROM session LIMIT 1`);
-    const rows = result.toArray() as unknown as SessionRow[];
+    const rows = this.rows<SessionRow>(result);
     return rows[0] ?? null;
   }
 
@@ -274,7 +278,7 @@ export class SessionRepository {
 
   getSandbox(): SandboxRow | null {
     const result = this.sql.exec(`SELECT * FROM sandbox LIMIT 1`);
-    const rows = result.toArray() as unknown as SandboxRow[];
+    const rows = this.rows<SandboxRow>(result);
     return rows[0] ?? null;
   }
 
@@ -282,7 +286,7 @@ export class SessionRepository {
     const result = this.sql.exec(
       `SELECT status, created_at, snapshot_image_id, spawn_failure_count, last_spawn_failure FROM sandbox LIMIT 1`
     );
-    const rows = result.toArray() as unknown as SandboxCircuitBreakerState[];
+    const rows = this.rows<SandboxCircuitBreakerState>(result);
     return rows[0] ?? null;
   }
 
@@ -380,19 +384,19 @@ export class SessionRepository {
 
   getParticipantByUserId(userId: string): ParticipantRow | null {
     const result = this.sql.exec(`SELECT * FROM participants WHERE user_id = ?`, userId);
-    const rows = result.toArray() as unknown as ParticipantRow[];
+    const rows = this.rows<ParticipantRow>(result);
     return rows[0] ?? null;
   }
 
   getParticipantByWsTokenHash(tokenHash: string): ParticipantRow | null {
     const result = this.sql.exec(`SELECT * FROM participants WHERE ws_auth_token = ?`, tokenHash);
-    const rows = result.toArray() as unknown as ParticipantRow[];
+    const rows = this.rows<ParticipantRow>(result);
     return rows[0] ?? null;
   }
 
   getParticipantById(participantId: string): ParticipantRow | null {
     const result = this.sql.exec(`SELECT * FROM participants WHERE id = ?`, participantId);
-    const rows = result.toArray() as unknown as ParticipantRow[];
+    const rows = this.rows<ParticipantRow>(result);
     return rows[0] ?? null;
   }
 
@@ -468,7 +472,7 @@ export class SessionRepository {
 
   listParticipants(): ParticipantRow[] {
     const result = this.sql.exec(`SELECT * FROM participants ORDER BY joined_at`);
-    return result.toArray() as unknown as ParticipantRow[];
+    return this.rows<ParticipantRow>(result);
   }
 
   // === MESSAGES ===
@@ -503,7 +507,7 @@ export class SessionRepository {
     const result = this.sql.exec(
       `SELECT * FROM messages WHERE status = 'pending' ORDER BY created_at ASC LIMIT 1`
     );
-    const rows = result.toArray() as unknown as MessageRow[];
+    const rows = this.rows<MessageRow>(result);
     return rows[0] ?? null;
   }
 
@@ -585,7 +589,7 @@ export class SessionRepository {
     params.push(options.limit + 1);
 
     const result = this.sql.exec(query, ...params);
-    return result.toArray() as unknown as MessageRow[];
+    return this.rows<MessageRow>(result);
   }
 
   // === EVENTS ===
@@ -659,7 +663,7 @@ export class SessionRepository {
     params.push(options.limit + 1);
 
     const result = this.sql.exec(query, ...params);
-    return result.toArray() as unknown as EventRow[];
+    return this.rows<EventRow>(result);
   }
 
   getEventsForReplay(limit: number): EventRow[] {
@@ -670,7 +674,7 @@ export class SessionRepository {
        ) sub ORDER BY created_at ASC, id ASC`,
       limit
     );
-    return result.toArray() as unknown as EventRow[];
+    return this.rows<EventRow>(result);
   }
 
   /**
@@ -685,16 +689,15 @@ export class SessionRepository {
     events: EventRow[];
     hasMore: boolean;
   } {
-    const rows = this.sql
-      .exec(
-        `SELECT * FROM events
+    const result = this.sql.exec(
+      `SELECT * FROM events
          WHERE type != 'heartbeat' AND ((created_at < ?1) OR (created_at = ?1 AND id < ?2))
          ORDER BY created_at DESC, id DESC LIMIT ?3`,
-        cursorTimestamp,
-        cursorId,
-        limit + 1
-      )
-      .toArray() as unknown as EventRow[];
+      cursorTimestamp,
+      cursorId,
+      limit + 1
+    );
+    const rows = this.rows<EventRow>(result);
 
     const hasMore = rows.length > limit;
     if (hasMore) rows.pop();
@@ -719,7 +722,7 @@ export class SessionRepository {
 
   listArtifacts(): ArtifactRow[] {
     const result = this.sql.exec(`SELECT * FROM artifacts ORDER BY created_at DESC`);
-    return result.toArray() as unknown as ArtifactRow[];
+    return this.rows<ArtifactRow>(result);
   }
 
   // === WS CLIENT MAPPING ===
@@ -743,7 +746,7 @@ export class SessionRepository {
        WHERE m.ws_id = ?`,
       wsId
     );
-    const rows = result.toArray() as unknown as WsClientMappingResult[];
+    const rows = this.rows<WsClientMappingResult>(result);
     return rows[0] ?? null;
   }
 


### PR DESCRIPTION
## Summary
- adds a typed `rows<T>()` helper in `SessionRepository` to centralize row conversion from SQLite `toArray()` results
- replaces every `result.toArray() as unknown as ...[]` usage in `packages/control-plane/src/session/repository.ts` with `rows<T>()`
- keeps query behavior unchanged while improving readability and eliminating the repeated double-cast pattern

## Testing
- `npm test -w @open-inspect/control-plane -- src/session/repository.test.ts src/session/stop-execution.test.ts src/session/schema.test.ts`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/829ef885146c1cffa8fc55fefd56b86c)*