### PR TITLE
fix: align shared contracts for session and bot types

### DIFF
--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -1,4 +1,4 @@
-import type { SessionStatus } from "@open-inspect/shared";
+import type { SessionStatus, SpawnSource } from "@open-inspect/shared";
 
 export interface SessionEntry {
   id: string;
@@ -10,7 +10,7 @@ export interface SessionEntry {
   baseBranch: string | null;
   status: SessionStatus;
   parentSessionId?: string | null;
-  spawnSource?: "user" | "agent";
+  spawnSource?: SpawnSource;
   spawnDepth?: number;
   createdAt: number;
   updatedAt: number;
@@ -26,7 +26,7 @@ interface SessionRow {
   base_branch: string | null;
   status: SessionStatus;
   parent_session_id: string | null;
-  spawn_source: "user" | "agent";
+  spawn_source: SpawnSource;
   spawn_depth: number;
   created_at: number;
   updated_at: number;

--- a/packages/control-plane/src/logger.ts
+++ b/packages/control-plane/src/logger.ts
@@ -126,4 +126,8 @@ export interface CorrelationContext {
   trace_id: string;
   /** Per-hop request ID (short UUID), propagated via x-request-id header */
   request_id: string;
+  /** Optional session ID for deeper correlation in downstream services. */
+  session_id?: string;
+  /** Optional sandbox ID for sandbox-scoped operations. */
+  sandbox_id?: string;
 }

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -7,7 +7,7 @@
 
 import { generateInternalToken } from "@open-inspect/shared";
 import { createLogger } from "../logger";
-import type { CorrelationContext } from "./provider";
+import type { CorrelationContext } from "../logger";
 
 const log = createLogger("modal-client");
 

--- a/packages/control-plane/src/sandbox/provider.ts
+++ b/packages/control-plane/src/sandbox/provider.ts
@@ -5,6 +5,8 @@
  * enabling unit testing and future provider support.
  */
 
+import type { CorrelationContext } from "../logger";
+
 /** Default sandbox lifetime in seconds (2 hours). */
 export const DEFAULT_SANDBOX_TIMEOUT_SECONDS = 7200;
 
@@ -19,18 +21,6 @@ export interface SandboxProviderCapabilities {
   supportsRestore: boolean;
   /** Whether the provider supports pre-warming sandboxes */
   supportsWarm: boolean;
-}
-
-/**
- * Optional request correlation context propagated to provider calls.
- *
- * Use snake_case to match transport headers (`x-trace-id`, `x-request-id`).
- */
-export interface CorrelationContext {
-  trace_id?: string;
-  request_id?: string;
-  session_id?: string;
-  sandbox_id?: string;
 }
 
 /**

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -53,6 +53,7 @@ import type {
   SessionStatus,
   SandboxStatus,
   ParticipantRole,
+  SpawnSource,
 } from "../types";
 import type { SpawnContext } from "@open-inspect/shared";
 import type { SessionRow, ArtifactRow, SandboxRow } from "./types";
@@ -1570,7 +1571,7 @@ export class SessionDO extends DurableObject<Env> {
       scmToken?: string | null; // Plain SCM token (will be encrypted)
       scmTokenEncrypted?: string | null; // Pre-encrypted SCM token
       parentSessionId?: string | null;
-      spawnSource?: "user" | "agent";
+      spawnSource?: SpawnSource;
       spawnDepth?: number;
     };
 

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -20,6 +20,7 @@ import type {
   MessageStatus,
   MessageSource,
   ParticipantRole,
+  SpawnSource,
   ArtifactType,
   SandboxEvent,
 } from "../types";
@@ -66,7 +67,7 @@ export interface UpsertSessionData {
   reasoningEffort?: string | null;
   status: SessionStatus;
   parentSessionId?: string | null;
-  spawnSource?: "user" | "agent";
+  spawnSource?: SpawnSource;
   spawnDepth?: number;
   createdAt: number;
   updatedAt: number;

--- a/packages/control-plane/src/session/types.ts
+++ b/packages/control-plane/src/session/types.ts
@@ -10,9 +10,11 @@ import type {
   MessageStatus,
   MessageSource,
   ParticipantRole,
+  SpawnSource,
   ArtifactType,
   EventType,
 } from "../types";
+import type { GitPushSpec } from "../source-control";
 
 // Database row types (match SQLite schema)
 
@@ -32,7 +34,7 @@ export interface SessionRow {
   reasoning_effort: string | null; // Reasoning effort level (e.g., "high", "max")
   status: SessionStatus;
   parent_session_id: string | null;
-  spawn_source: "user" | "agent";
+  spawn_source: SpawnSource;
   spawn_depth: number;
   created_at: number;
   updated_at: number;
@@ -136,12 +138,18 @@ export interface AckCommand {
   ackId: string;
 }
 
+export interface PushCommand {
+  type: "push";
+  pushSpec: GitPushSpec;
+}
+
 export type SandboxCommand =
   | PromptCommand
   | StopCommand
   | SnapshotCommand
   | ShutdownCommand
-  | AckCommand;
+  | AckCommand
+  | PushCommand;
 
 // Internal session update types
 

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -23,6 +23,7 @@ export type {
   MessageStatus,
   ParticipantRole,
   ParticipantPresence,
+  SpawnSource,
   SandboxEvent,
   SandboxStatus,
   ServerMessage,

--- a/packages/linear-bot/src/classifier/index.ts
+++ b/packages/linear-bot/src/classifier/index.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Env, RepoConfig, ClassificationResult } from "../types";
+import type { ConfidenceLevel } from "@open-inspect/shared";
 import { getAvailableRepos, buildRepoDescriptions } from "./repos";
 import { createLogger } from "../logger";
 
@@ -13,7 +14,7 @@ const CLASSIFY_REPO_TOOL_NAME = "classify_repository";
 
 interface ClassifyToolInput {
   repoId: string | null;
-  confidence: "high" | "medium" | "low";
+  confidence: ConfidenceLevel;
   reasoning: string;
   alternatives: string[];
 }
@@ -135,7 +136,7 @@ async function callAnthropic(apiKey: string, prompt: string): Promise<ClassifyTo
   const input = toolBlock.input as Record<string, unknown>;
   return {
     repoId: input.repoId === null ? null : typeof input.repoId === "string" ? input.repoId : null,
-    confidence: (input.confidence as "high" | "medium" | "low") || "low",
+    confidence: (input.confidence as ConfidenceLevel) || "low",
     reasoning: String(input.reasoning || ""),
     alternatives: Array.isArray(input.alternatives)
       ? input.alternatives.filter((a): a is string => typeof a === "string")

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -140,7 +140,7 @@ export interface ToolCallCallback {
 
 // ─── Classification Types ────────────────────────────────────────────────────
 
-export type { ClassificationResult } from "@open-inspect/shared";
+export type { ClassificationResult, ConfidenceLevel } from "@open-inspect/shared";
 
 // ─── Event / Artifact Types ──────────────────────────────────────────────────
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -41,6 +41,8 @@ export type EventType =
   | "push_error"
   | "user_message";
 export type ParticipantRole = "owner" | "member";
+export type SpawnSource = "user" | "agent";
+export type ConfidenceLevel = "high" | "medium" | "low";
 
 // Participant in a session
 export interface SessionParticipant {
@@ -65,7 +67,7 @@ export interface Session {
   opencodeSessionId: string | null;
   status: SessionStatus;
   parentSessionId: string | null;
-  spawnSource: "user" | "agent";
+  spawnSource: SpawnSource;
   spawnDepth: number;
   createdAt: number;
   updatedAt: number;
@@ -128,7 +130,7 @@ export interface PullRequest {
   title: string;
   body: string;
   url: string;
-  state: "open" | "closed" | "merged";
+  state: "open" | "closed" | "merged" | "draft";
   headRef: string;
   baseRef: string;
   createdAt: string;
@@ -376,7 +378,7 @@ export interface ControlPlaneReposResponse {
 
 export interface ClassificationResult {
   repo: RepoConfig | null;
-  confidence: "high" | "medium" | "low";
+  confidence: ConfidenceLevel;
   reasoning: string;
   alternatives?: RepoConfig[];
   needsClarification: boolean;

--- a/packages/slack-bot/src/classifier/index.ts
+++ b/packages/slack-bot/src/classifier/index.ts
@@ -7,6 +7,7 @@
 
 import Anthropic from "@anthropic-ai/sdk";
 import type { Env, RepoConfig, ThreadContext, ClassificationResult } from "../types";
+import type { ConfidenceLevel } from "@open-inspect/shared";
 import { getAvailableRepos, buildRepoDescriptions, getReposByChannel } from "./repos";
 import { createLogger } from "../logger";
 
@@ -107,7 +108,7 @@ Return your decision by calling the ${CLASSIFY_REPO_TOOL_NAME} tool with:
  */
 interface LLMResponse {
   repoId: string | null;
-  confidence: "high" | "medium" | "low";
+  confidence: ConfidenceLevel;
   reasoning: string;
   alternatives: string[];
 }

--- a/packages/slack-bot/src/types/index.ts
+++ b/packages/slack-bot/src/types/index.ts
@@ -53,7 +53,7 @@ export interface ThreadContext {
 /**
  * Result of repository classification.
  */
-export type { ClassificationResult } from "@open-inspect/shared";
+export type { ClassificationResult, ConfidenceLevel } from "@open-inspect/shared";
 
 /**
  * Slack event types.

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -28,7 +28,7 @@ interface Message {
 
 type SessionState = SharedSessionState;
 type Participant = ParticipantPresence;
-type WsMessage = ServerMessage | { type: "artifact_updated"; artifact: Artifact };
+type WsMessage = ServerMessage;
 
 interface UseSessionSocketReturn {
   connected: boolean;
@@ -307,10 +307,6 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
             }
             return [...prev, toUiArtifact(data.artifact)];
           });
-          break;
-
-        case "artifact_updated":
-          setArtifacts((prev) => prev.map((a) => (a.id === data.artifact.id ? data.artifact : a)));
           break;
 
         case "session_status":


### PR DESCRIPTION
## Summary
- Add missing shared type contracts: `SpawnSource`, `ConfidenceLevel`, and `PullRequest.state` support for `draft`.
- Update control-plane session and DB typing to use `SpawnSource`, and extend `SandboxCommand` with a typed `push` command.
- Remove duplicated `CorrelationContext` definitions by using the logger definition for sandbox provider/client paths.
- Remove web socket handling for a phantom `artifact_updated` message that is not part of shared `ServerMessage`.
- Update Slack and Linear classifier typing to consume shared `ConfidenceLevel`.

## Validation
- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run typecheck -w @open-inspect/web`
- `npm run typecheck -w @open-inspect/slack-bot`
- `npm run typecheck -w @open-inspect/linear-bot`
- `npm test -w @open-inspect/control-plane -- src/session/sandbox-events.test.ts`
- `npm test -w @open-inspect/slack-bot -- src/classifier`
- `npm test -w @open-inspect/linear-bot`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/00885d45001d38128af53bed6a3638c0)*