### PR TITLE
fix: stabilize sandbox lifecycle contract across control-plane and modal-infra

### DIFF
--- a/docs/PHASE3_SANDBOX_LIFECYCLE_NOTES.md
+++ b/docs/PHASE3_SANDBOX_LIFECYCLE_NOTES.md
@@ -1,0 +1,34 @@
+## Phase 3: Sandbox Lifecycle Contract Stabilization
+
+### Decisions
+
+- **Timeout propagation**: `timeout_seconds` is now validated and forwarded through
+  `api_create_sandbox` into `SandboxConfig.timeout_seconds`, preserving caller intent for fresh
+  sandbox creates.
+- **Restore branch propagation**: restore now carries `session_config.branch` into sandbox
+  `SESSION_CONFIG`, so restored sandboxes keep branch context identical to fresh spawns.
+- **Error contract normalization**: Modal web APIs now return a consistent response shape for
+  failures:
+  - HTTP non-2xx status
+  - `{ "success": false, "error": { "code", "message", "status_code", "details?" } }`
+- **Control-plane client hardening**:
+  - request timeouts for all Modal API calls
+  - bounded retries only on safe paths (`health`, `getLatestSnapshot`, `deleteProviderImage`)
+  - structured error parsing for non-2xx responses and `success: false` bodies
+- **Correlation IDs**: lifecycle manager now generates and passes correlation context (`trace_id`,
+  `request_id`, `session_id`, `sandbox_id`) consistently for spawn/restore/snapshot provider calls.
+
+### Risks
+
+- Error body format changed from string-only errors to structured errors. Existing clients that
+  assume `error` is always a string must parse either shape.
+- Retry behavior, while bounded and limited to safe operations, slightly increases upstream request
+  volume during transient failures.
+
+### Rollout Considerations
+
+- Deploy control-plane and modal-infra changes together to maximize compatibility.
+- Monitor 4xx/5xx rates and timeout/retry logs (`modal.request`, `modal.http_request`) after rollout
+  to validate improved resilience.
+- Keep an eye on warning logs from local Modal test execution; these are expected in unit tests
+  invoking `.local`.

--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ModalClient } from "./client";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("ModalClient", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("parses structured API errors for non-2xx responses", async () => {
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () =>
+        jsonResponse(
+          {
+            success: false,
+            error: {
+              code: "service_unavailable",
+              message: "Modal unavailable",
+              status_code: 503,
+            },
+          },
+          503
+        )
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new ModalClient("test-secret", "test-workspace");
+
+    await expect(
+      client.createSandbox({
+        sessionId: "session-1",
+        sandboxId: "sandbox-1",
+        repoOwner: "acme",
+        repoName: "repo",
+        controlPlaneUrl: "https://control.example",
+        sandboxAuthToken: "sandbox-token",
+      })
+    ).rejects.toMatchObject({
+      name: "ModalApiError",
+      status: 503,
+      code: "service_unavailable",
+      message: "Modal unavailable",
+    });
+  });
+
+  it("retries getLatestSnapshot once on transient 503", async () => {
+    const fetchMock = vi
+      .fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
+      .mockResolvedValueOnce(jsonResponse({ success: false, error: { message: "temporary" } }, 503))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          success: true,
+          data: {
+            id: "snap-1",
+            repoOwner: "acme",
+            repoName: "repo",
+            baseSha: "abc123",
+            status: "ready",
+            createdAt: "2026-01-01T00:00:00Z",
+          },
+        })
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new ModalClient("test-secret", "test-workspace");
+    const snapshot = await client.getLatestSnapshot("acme", "repo");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(snapshot?.id).toBe("snap-1");
+  });
+
+  it("sends correlation headers on snapshot restore", async () => {
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () =>
+        jsonResponse({ success: true, data: { sandbox_id: "sandbox-1", modal_object_id: "obj-1" } })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new ModalClient("test-secret", "test-workspace");
+
+    await client.restoreSandbox(
+      {
+        snapshotImageId: "img-1",
+        sessionId: "session-1",
+        sandboxId: "sandbox-1",
+        sandboxAuthToken: "sandbox-token",
+        controlPlaneUrl: "https://control.example",
+        repoOwner: "acme",
+        repoName: "repo",
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      },
+      {
+        trace_id: "trace-123",
+        request_id: "request-456",
+        session_id: "session-1",
+        sandbox_id: "sandbox-1",
+      }
+    );
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["x-trace-id"]).toBe("trace-123");
+    expect(headers["x-request-id"]).toBe("request-456");
+    expect(headers["x-session-id"]).toBe("session-1");
+    expect(headers["x-sandbox-id"]).toBe("sandbox-1");
+  });
+
+  it("forwards timeout_seconds in create sandbox payload", async () => {
+    const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () =>
+        jsonResponse({
+          success: true,
+          data: {
+            sandbox_id: "sandbox-1",
+            modal_object_id: "obj-1",
+            status: "created",
+            created_at: 123,
+          },
+        })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new ModalClient("test-secret", "test-workspace");
+    await client.createSandbox({
+      sessionId: "session-1",
+      sandboxId: "sandbox-1",
+      repoOwner: "acme",
+      repoName: "repo",
+      controlPlaneUrl: "https://control.example",
+      sandboxAuthToken: "sandbox-token",
+      timeoutSeconds: 3600,
+    });
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const payload = JSON.parse((init.body as string) ?? "{}");
+    expect(payload.timeout_seconds).toBe(3600);
+  });
+});

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -410,12 +410,14 @@ class SandboxManager:
             provider = session_config.get("provider", "anthropic")
             model = session_config.get("model", "claude-sonnet-4-6")
             session_id = session_config.get("session_id", "")
+            branch = session_config.get("branch")
         else:
             repo_owner = session_config.repo_owner
             repo_name = session_config.repo_name
             provider = session_config.provider
             model = session_config.model
             session_id = session_config.session_id
+            branch = session_config.branch
 
         # Use provided sandbox_id or generate one
         if not sandbox_id:
@@ -444,6 +446,7 @@ class SandboxManager:
                         "session_id": session_id,
                         "repo_owner": repo_owner,
                         "repo_name": repo_name,
+                        "branch": branch,
                         "provider": provider,
                         "model": model,
                     }

--- a/packages/modal-infra/tests/test_web_api_contract.py
+++ b/packages/modal-infra/tests/test_web_api_contract.py
@@ -1,0 +1,106 @@
+import json
+
+import pytest
+
+from src import web_api
+
+
+def _parse_json_response(response):
+    if isinstance(response, dict):
+        payload = response
+        status_code = payload.get("error", {}).get("status_code", 200)
+        return payload, status_code
+    payload = json.loads(response.body.decode("utf-8"))
+    return payload, response.status_code
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_forwards_timeout_seconds(monkeypatch):
+    captured = {}
+
+    class FakeHandle:
+        sandbox_id = "sandbox-123"
+        modal_object_id = "modal-123"
+
+        class status:
+            value = "warming"
+
+        created_at = 123.0
+
+    async def fake_create(self, config):
+        captured["timeout_seconds"] = config.timeout_seconds
+        return FakeHandle()
+
+    monkeypatch.setattr("src.web_api.verify_internal_token", lambda _: True)
+    monkeypatch.setattr("src.web_api.validate_control_plane_url", lambda _: True)
+    monkeypatch.setattr("src.sandbox.manager.SandboxManager.create_sandbox", fake_create)
+
+    response = await web_api.api_create_sandbox.local(
+        {
+            "session_id": "sess-1",
+            "repo_owner": "acme",
+            "repo_name": "repo",
+            "control_plane_url": "https://control.example",
+            "sandbox_auth_token": "sandbox-token",
+            "timeout_seconds": 3600,
+        },
+        authorization="Bearer test",
+    )
+
+    body, status_code = _parse_json_response(response)
+    assert status_code == 200
+    assert body["success"] is True
+    assert captured["timeout_seconds"] == 3600
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_invalid_timeout_returns_structured_400(monkeypatch):
+    monkeypatch.setattr("src.web_api.verify_internal_token", lambda _: True)
+    monkeypatch.setattr("src.web_api.validate_control_plane_url", lambda _: True)
+
+    response = await web_api.api_create_sandbox.local(
+        {
+            "session_id": "sess-1",
+            "repo_owner": "acme",
+            "repo_name": "repo",
+            "control_plane_url": "https://control.example",
+            "sandbox_auth_token": "sandbox-token",
+            "timeout_seconds": "not-an-int",
+        },
+        authorization="Bearer test",
+    )
+
+    body, status_code = _parse_json_response(response)
+    assert status_code == 400
+    assert body == {
+        "success": False,
+        "error": {
+            "code": "bad_request",
+            "message": "timeout_seconds must be an integer",
+            "status_code": 400,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_restore_sandbox_auth_failure_returns_structured_401(monkeypatch):
+    monkeypatch.setattr("src.web_api.verify_internal_token", lambda _: False)
+
+    response = await web_api.api_restore_sandbox.local(
+        {
+            "snapshot_image_id": "img-123",
+            "control_plane_url": "https://control.example",
+        },
+        authorization="Bearer invalid",
+    )
+
+    body, status_code = _parse_json_response(response)
+    assert status_code == 401
+    assert body == {
+        "success": False,
+        "error": {
+            "code": "unauthorized",
+            "message": "Unauthorized: Invalid or missing authentication token",
+            "status_code": 401,
+        },
+    }


### PR DESCRIPTION
## Summary
- Fixes fresh sandbox timeout propagation so `timeout_seconds` is validated and forwarded end-to-end from control-plane to Modal sandbox creation.
- Fixes restore branch propagation by preserving `session_config.branch` into restored sandbox `SESSION_CONFIG`.
- Normalizes modal-infra error responses to consistent structured payloads with proper HTTP status codes and updates the control-plane Modal client to parse structured errors.
- Adds reliability controls in the control-plane Modal client: request-level timeouts on all calls and bounded retries on safe operations (`health`, `getLatestSnapshot`, `deleteProviderImage`).
- Ensures correlation IDs are passed consistently for spawn, restore, and snapshot provider paths.

## Testing
- `npm test -w @open-inspect/control-plane -- src/sandbox/lifecycle/decisions.test.ts src/sandbox/lifecycle/manager.test.ts src/sandbox/client.test.ts src/sandbox/providers/modal-provider.test.ts`
- `uv run pytest tests/test_build_sandbox.py tests/test_sandbox_env_vars.py tests/test_web_api_contract.py -v`

## Notes
- Added rollout/risks note: `docs/PHASE3_SANDBOX_LIFECYCLE_NOTES.md`.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/2f6523ef89b3ee6c48c954392fb29406)*