### PR TITLE
fix: reset inactivity timer on intermediate sandbox events

### DIFF
--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -67,11 +67,13 @@ export class SessionSandboxEventProcessor {
     }
 
     if (event.type === "step_start" || event.type === "step_finish") {
+      this.deps.updateLastActivity(now);
       this.deps.broadcast({ type: "sandbox_event", event });
       return;
     }
 
     if (event.type === "tool_call") {
+      this.deps.updateLastActivity(now);
       if (shouldPersistToolCallEvent(event.status)) {
         this.deps.repository.createEvent({
           id: generateId(),


### PR DESCRIPTION
## Summary

- **Root cause**: The DO inactivity timeout (10 min) only reset on `execution_complete` events. When a single prompt ran for >10 minutes (e.g. GPT 5.3 Codex explore subagent taking 11 min), the timeout fired and killed the sandbox despite continuous active work (tool calls, grep, bash, file reads every few seconds).
- **Fix**: `tool_call`, `step_start`, and `step_finish` events now also call `updateLastActivity()`, preventing false inactivity timeouts while the sandbox is doing productive work. If the sandbox truly hangs (no events for 10 min), the timeout still fires correctly.
- **Events intentionally excluded**: `heartbeat` (used for separate liveness tracking) and `token` (too frequent, would mask genuine inactivity).

## Test plan

- [x] 5 new unit tests covering activity reset on `tool_call`, `step_start`, `step_finish`, and verifying `heartbeat`/`token` do NOT reset activity
- [x] All 635 unit tests pass
- [x] All 177 integration tests pass