### PR TITLE
fix: add ENABLE_DURABLE_OBJECT_BINDINGS to terraform CI workflow

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -210,6 +210,7 @@ jobs:
           TF_VAR_linear_client_secret: ${{ secrets.LINEAR_CLIENT_SECRET }}
           TF_VAR_linear_webhook_secret: ${{ secrets.LINEAR_WEBHOOK_SECRET }}
           TF_VAR_web_platform: "${{ secrets.WEB_PLATFORM || 'vercel' }}"
+          TF_VAR_enable_durable_object_bindings: "${{ secrets.ENABLE_DURABLE_OBJECT_BINDINGS || 'true' }}"
 
       - name: Post Plan Results
         uses: actions/github-script@v7
@@ -333,6 +334,7 @@ jobs:
           TF_VAR_linear_client_secret: ${{ secrets.LINEAR_CLIENT_SECRET }}
           TF_VAR_linear_webhook_secret: ${{ secrets.LINEAR_WEBHOOK_SECRET }}
           TF_VAR_web_platform: "${{ secrets.WEB_PLATFORM || 'vercel' }}"
+          TF_VAR_enable_durable_object_bindings: "${{ secrets.ENABLE_DURABLE_OBJECT_BINDINGS || 'true' }}"
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
 


### PR DESCRIPTION
## Summary
- Adds `TF_VAR_enable_durable_object_bindings` env var to both the Plan and Apply steps in the Terraform CI workflow
- Defaults to `true` via `secrets.ENABLE_DURABLE_OBJECT_BINDINGS || 'true'`
- Synced from prod where this was already applied

## Test plan
- [ ] Verify Terraform Plan step receives the variable
- [ ] Verify Terraform Apply step receives the variable