### PR TITLE
fix(web): clean up automations list card layout

### DIFF
--- a/packages/web/src/components/automations/automations-list.tsx
+++ b/packages/web/src/components/automations/automations-list.tsx
@@ -6,7 +6,7 @@ import { describeCron } from "@open-inspect/shared";
 import type { Automation } from "@open-inspect/shared";
 import { AutomationStatusBadge } from "@/components/automations/automation-status-badge";
 import { Button } from "@/components/ui/button";
-import { RepoIcon, ClockIcon, BoltIcon } from "@/components/ui/icons";
+import { FolderIcon, ClockIcon, BoltIcon } from "@/components/ui/icons";
 import { formatRelativeTime } from "@/lib/time";
 
 interface AutomationsListProps {
@@ -62,7 +62,7 @@ export function AutomationsList({
               )}
               <Button variant="ghost" size="xs" onClick={() => onTrigger(automation.id)}>
                 <span className="flex items-center gap-1">
-                  <BoltIcon className="w-3 h-3" />
+                  <BoltIcon className="w-3 h-3" aria-hidden="true" />
                   Trigger
                 </span>
               </Button>
@@ -97,11 +97,11 @@ export function AutomationsList({
           {/* Metadata: icon-paired items */}
           <div className="flex flex-wrap items-center gap-x-4 gap-y-1 mt-2 text-xs text-muted-foreground">
             <span className="inline-flex items-center gap-1">
-              <RepoIcon className="w-3 h-3 flex-shrink-0" />
+              <FolderIcon className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
               {automation.repoOwner}/{automation.repoName}
             </span>
             <span className="inline-flex items-center gap-1">
-              <ClockIcon className="w-3 h-3 flex-shrink-0" />
+              <ClockIcon className="w-3 h-3 flex-shrink-0" aria-hidden="true" />
               {automation.scheduleCron
                 ? describeCron(automation.scheduleCron, automation.scheduleTz)
                 : "No schedule"}

--- a/packages/web/src/components/ui/icons.tsx
+++ b/packages/web/src/components/ui/icons.tsx
@@ -1,5 +1,6 @@
 interface IconProps {
   className?: string;
+  "aria-hidden"?: boolean | "true" | "false";
 }
 
 // --- Navigation & Layout ---
@@ -175,9 +176,9 @@ export function MoreIcon({ className }: IconProps) {
 
 // --- Status & Info ---
 
-export function ClockIcon({ className }: IconProps) {
+export function ClockIcon({ className, ...props }: IconProps) {
   return (
-    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" {...props}>
       <circle cx="12" cy="12" r="10" strokeWidth={2} />
       <path strokeLinecap="round" strokeWidth={2} d="M12 6v6l4 2" />
     </svg>
@@ -338,9 +339,9 @@ export function TerminalIcon({ className }: IconProps) {
   );
 }
 
-export function BoltIcon({ className }: IconProps) {
+export function BoltIcon({ className, ...props }: IconProps) {
   return (
-    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" {...props}>
       <path
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -364,9 +365,9 @@ export function GlobeIcon({ className }: IconProps) {
   );
 }
 
-export function FolderIcon({ className }: IconProps) {
+export function FolderIcon({ className, ...props }: IconProps) {
   return (
-    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+    <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" {...props}>
       <path
         strokeLinecap="round"
         strokeLinejoin="round"


### PR DESCRIPTION
## Summary

- **Replace dot-separated metadata** with icon-paired items (`RepoIcon` for repository, `ClockIcon` for schedule) using proper `gap-x-4` spacing instead of `·` separators
- **Remove raw creator ID** display (showed a numeric user ID like "2492022" which added no value in a single-tenant app)
- **Add visual hierarchy** with a `BoltIcon` on the Trigger button and better vertical padding (`py-4` instead of `py-3`)
- **Support wrapping** via `flex-wrap` on the metadata row so items flow naturally on narrower viewports

Before: all metadata crammed into one long `·`-separated line with a raw user ID, tight padding, and no visual cues.

After: clean two-row card — name + status badge on top, icon-paired metadata below with proper spacing.

## Test plan

- [x] `npm run typecheck -w @open-inspect/web` passes
- [x] `npm test -w @open-inspect/web` — all 91 tests pass
- [x] `npm run lint` — clean
- [ ] Visual verification on /automations page in dark and light mode