### PR TITLE
feat: integrate code-server

### DIFF
--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -45,6 +45,8 @@ export interface CreateSandboxResponse {
   modalObjectId?: string; // Modal's internal object ID for snapshot API
   status: string;
   createdAt: number;
+  codeServerUrl?: string;
+  codeServerPassword?: string;
 }
 
 export interface RestoreSandboxRequest {
@@ -67,6 +69,8 @@ export interface RestoreSandboxResponse {
   sandboxId?: string;
   modalObjectId?: string;
   error?: string;
+  codeServerUrl?: string;
+  codeServerPassword?: string;
 }
 
 export interface SnapshotSandboxRequest {
@@ -259,6 +263,8 @@ export class ModalClient {
         modal_object_id?: string;
         status: string;
         created_at: number;
+        code_server_url?: string;
+        code_server_password?: string;
       }>;
 
       if (!result.success || !result.data) {
@@ -271,6 +277,8 @@ export class ModalClient {
         modalObjectId: result.data.modal_object_id,
         status: result.data.status,
         createdAt: result.data.created_at,
+        codeServerUrl: result.data.code_server_url,
+        codeServerPassword: result.data.code_server_password,
       };
     } finally {
       log.info("modal.request", {
@@ -332,6 +340,8 @@ export class ModalClient {
       const result = (await response.json()) as ModalApiResponse<{
         sandbox_id: string;
         modal_object_id?: string;
+        code_server_url?: string;
+        code_server_password?: string;
       }>;
 
       if (!result.success) {
@@ -343,6 +353,8 @@ export class ModalClient {
         success: true,
         sandboxId: result.data?.sandbox_id,
         modalObjectId: result.data?.modal_object_id,
+        codeServerUrl: result.data?.code_server_url,
+        codeServerPassword: result.data?.code_server_password,
       };
     } finally {
       log.info("modal.request", {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -73,6 +73,8 @@ function createMockSandbox(
     last_activity: Date.now() - 30000,
     last_spawn_error: null,
     last_spawn_error_at: null,
+    code_server_url: null,
+    code_server_password: null,
     created_at: Date.now() - 60000,
     spawn_failure_count: 0,
     last_spawn_failure: 0,
@@ -152,6 +154,13 @@ function createMockStorage(
       if (sandbox) {
         sandbox.last_spawn_error = error;
         sandbox.last_spawn_error_at = timestamp;
+      }
+    }),
+    updateSandboxCodeServer: vi.fn((url: string, password: string) => {
+      calls.push(`updateSandboxCodeServer:${url}`);
+      if (sandbox) {
+        sandbox.code_server_url = url;
+        sandbox.code_server_password = password;
       }
     }),
   };

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -80,6 +80,8 @@ export interface SandboxStorage {
   resetCircuitBreaker(): void;
   /** Persist last spawn error */
   setLastSpawnError(error: string | null, timestamp: number | null): void;
+  /** Update code-server URL and password on the sandbox row */
+  updateSandboxCodeServer(url: string, password: string): void;
 }
 
 /**
@@ -387,6 +389,11 @@ export class SandboxLifecycleManager {
         this.storage.updateSandboxModalObjectId(result.providerObjectId);
       }
 
+      // Store code-server details and push to connected clients
+      if (result.codeServerUrl) {
+        this.storeAndBroadcastCodeServer(result.codeServerUrl, result.codeServerPassword ?? "");
+      }
+
       this.storage.updateSandboxStatus("connecting");
       this.broadcaster.broadcast({ type: "sandbox_status", status: "connecting" });
 
@@ -501,6 +508,11 @@ export class SandboxLifecycleManager {
         // Store provider's internal object ID for future snapshots
         if (result.providerObjectId) {
           this.storage.updateSandboxModalObjectId(result.providerObjectId);
+        }
+
+        // Store code-server details and push to connected clients
+        if (result.codeServerUrl) {
+          this.storeAndBroadcastCodeServer(result.codeServerUrl, result.codeServerPassword ?? "");
         }
 
         this.storage.updateSandboxStatus("connecting");
@@ -799,6 +811,19 @@ export class SandboxLifecycleManager {
    */
   private getConnectedClientCount(): number {
     return this.wsManager.getConnectedClientCount();
+  }
+
+  /**
+   * Store code-server details in the database and push to connected clients.
+   * Shared by doSpawn() and restoreFromSnapshot().
+   */
+  private storeAndBroadcastCodeServer(url: string, password: string): void {
+    this.storage.updateSandboxCodeServer(url, password);
+    this.broadcaster.broadcast({
+      type: "code_server_info",
+      url,
+      password,
+    });
   }
 
   /**

--- a/packages/control-plane/src/sandbox/provider.ts
+++ b/packages/control-plane/src/sandbox/provider.ts
@@ -71,6 +71,10 @@ export interface CreateSandboxResult {
   status: string;
   /** Creation timestamp */
   createdAt: number;
+  /** Code-server tunnel URL (if available) */
+  codeServerUrl?: string;
+  /** Code-server password (if available) */
+  codeServerPassword?: string;
 }
 
 /**
@@ -117,6 +121,10 @@ export interface RestoreResult {
   providerObjectId?: string;
   /** Error message if failed */
   error?: string;
+  /** Code-server tunnel URL (if available) */
+  codeServerUrl?: string;
+  /** Code-server password (if available) */
+  codeServerPassword?: string;
 }
 
 /**

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -81,6 +81,8 @@ export class ModalSandboxProvider implements SandboxProvider {
         providerObjectId: result.modalObjectId,
         status: result.status,
         createdAt: result.createdAt,
+        codeServerUrl: result.codeServerUrl,
+        codeServerPassword: result.codeServerPassword,
       };
     } catch (error) {
       throw this.classifyError("Failed to create sandbox", error);
@@ -115,6 +117,8 @@ export class ModalSandboxProvider implements SandboxProvider {
           success: true,
           sandboxId: result.sandboxId,
           providerObjectId: result.modalObjectId,
+          codeServerUrl: result.codeServerUrl,
+          codeServerPassword: result.codeServerPassword,
         };
       }
 

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -415,6 +415,8 @@ export class SessionDO extends DurableObject<Env> {
       resetCircuitBreaker: () => this.repository.resetCircuitBreaker(),
       setLastSpawnError: (error, timestamp) =>
         this.repository.updateSandboxSpawnError(error, timestamp),
+      updateSandboxCodeServer: (url, password) =>
+        this.repository.updateSandboxCodeServer(url, password),
     };
 
     // Broadcaster adapter
@@ -1337,6 +1339,8 @@ export class SessionDO extends DurableObject<Env> {
       reasoningEffort: session?.reasoning_effort ?? undefined,
       isProcessing,
       parentSessionId: session?.parent_session_id ?? null,
+      codeServerUrl: sandbox?.code_server_url ?? null,
+      codeServerPassword: sandbox?.code_server_password ?? null,
     };
   }
 

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -365,6 +365,14 @@ export class SessionRepository {
     );
   }
 
+  updateSandboxCodeServer(url: string, password: string): void {
+    this.sql.exec(
+      `UPDATE sandbox SET code_server_url = ?, code_server_password = ? WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
+      url,
+      password
+    );
+  }
+
   resetCircuitBreaker(): void {
     this.sql.exec(
       `UPDATE sandbox SET spawn_failure_count = 0 WHERE id = (SELECT id FROM sandbox LIMIT 1)`

--- a/packages/control-plane/src/session/schema.ts
+++ b/packages/control-plane/src/session/schema.ts
@@ -101,6 +101,8 @@ CREATE TABLE IF NOT EXISTS sandbox (
   last_spawn_error_at INTEGER,                      -- Timestamp of last spawn error
   spawn_failure_count INTEGER DEFAULT 0,            -- Circuit breaker: consecutive spawn failures
   last_spawn_failure INTEGER,                       -- Timestamp of last spawn failure
+  code_server_url TEXT,                             -- Code-server tunnel URL (rotates on wake/restore)
+  code_server_password TEXT,                        -- Code-server password (stable per session)
   created_at INTEGER NOT NULL
 );
 
@@ -337,6 +339,14 @@ export const MIGRATIONS: readonly SchemaMigration[] = [
       ALTER TABLE session ADD COLUMN parent_session_id TEXT;
       ALTER TABLE session ADD COLUMN spawn_source TEXT NOT NULL DEFAULT 'user';
       ALTER TABLE session ADD COLUMN spawn_depth INTEGER NOT NULL DEFAULT 0;
+    `,
+  },
+  {
+    id: 26,
+    description: "Add code-server fields to sandbox",
+    run: `
+      ALTER TABLE sandbox ADD COLUMN code_server_url TEXT;
+      ALTER TABLE sandbox ADD COLUMN code_server_password TEXT;
     `,
   },
 ];

--- a/packages/control-plane/src/session/types.ts
+++ b/packages/control-plane/src/session/types.ts
@@ -102,6 +102,8 @@ export interface SandboxRow {
   last_activity: number | null; // Last activity timestamp for inactivity-based snapshot
   last_spawn_error: string | null;
   last_spawn_error_at: number | null;
+  code_server_url: string | null;
+  code_server_password: string | null;
   created_at: number;
 }
 

--- a/packages/control-plane/src/session/websocket-manager.test.ts
+++ b/packages/control-plane/src/session/websocket-manager.test.ts
@@ -164,6 +164,8 @@ function createSandboxRow(modalSandboxId: string): SandboxRow {
     last_activity: null,
     last_spawn_error: null,
     last_spawn_error_at: null,
+    code_server_url: null,
+    code_server_password: null,
     created_at: Date.now(),
   };
 }

--- a/packages/modal-infra/src/functions.py
+++ b/packages/modal-infra/src/functions.py
@@ -106,6 +106,8 @@ async def create_sandbox(
         "sandbox_id": handle.sandbox_id,
         "status": handle.status.value,
         "created_at": handle.created_at,
+        "code_server_url": handle.code_server_url,
+        "code_server_password": handle.code_server_password,
     }
 
 

--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -23,8 +23,8 @@ SANDBOX_DIR = Path(__file__).parent.parent / "sandbox"
 OPENCODE_VERSION = "latest"
 
 # Cache buster - change this to force Modal image rebuild
-# v39: Install gh CLI for agent-direct GitHub interaction
-CACHE_BUSTER = "v39-gh-cli"
+# v40: Install code-server for browser-based VS Code editing
+CACHE_BUSTER = "v40-code-server"
 
 # Base image with all development tools
 base_image = (
@@ -103,6 +103,11 @@ base_image = (
         # Install @opencode-ai/plugin globally for custom tools
         # This ensures tools can import the plugin without needing to run bun add
         "npm install -g @opencode-ai/plugin@latest zod",
+    )
+    # Install code-server for browser-based VS Code editing
+    .run_commands(
+        "curl -fsSL https://code-server.dev/install.sh | sh",
+        "code-server --version",
     )
     # Install Playwright browsers (Chromium only to save space)
     .run_commands(

--- a/packages/modal-infra/src/sandbox/entrypoint.py
+++ b/packages/modal-infra/src/sandbox/entrypoint.py
@@ -39,6 +39,7 @@ class SandboxSupervisor:
 
     # Configuration
     OPENCODE_PORT = 4096
+    CODE_SERVER_PORT = 8080
     HEALTH_CHECK_TIMEOUT = 30.0
     MAX_RESTARTS = 5
     BACKOFF_BASE = 2.0
@@ -52,6 +53,7 @@ class SandboxSupervisor:
     def __init__(self):
         self.opencode_process: asyncio.subprocess.Process | None = None
         self.bridge_process: asyncio.subprocess.Process | None = None
+        self.code_server_process: asyncio.subprocess.Process | None = None
         self.shutdown_event = asyncio.Event()
         self.git_sync_complete = asyncio.Event()
         self.opencode_ready = asyncio.Event()
@@ -313,6 +315,46 @@ class SandboxSupervisor:
         except Exception as e:
             self.log.warn("openai_oauth.setup_error", exc=e)
 
+    async def start_code_server(self) -> None:
+        """Start code-server for browser-based VS Code editing."""
+        password = os.environ.get("CODE_SERVER_PASSWORD")
+        if not password:
+            self.log.info("code_server.skip", reason="no_password")
+            return
+
+        # Use repo path if cloned, otherwise /workspace
+        workdir = self.workspace_path
+        if self.repo_path.exists() and (self.repo_path / ".git").exists():
+            workdir = self.repo_path
+
+        self.code_server_process = await asyncio.create_subprocess_exec(
+            "code-server",
+            "--bind-addr",
+            f"0.0.0.0:{self.CODE_SERVER_PORT}",
+            "--auth",
+            "password",
+            "--disable-telemetry",
+            str(workdir),
+            cwd=workdir,
+            env={**os.environ, "PASSWORD": password},
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+
+        asyncio.create_task(self._forward_code_server_logs())
+        self.log.info("code_server.started", port=self.CODE_SERVER_PORT)
+
+    async def _forward_code_server_logs(self) -> None:
+        """Forward code-server stdout to supervisor stdout."""
+        if not self.code_server_process or not self.code_server_process.stdout:
+            return
+
+        try:
+            async for line in self.code_server_process.stdout:
+                print(f"[code-server] {line.decode().rstrip()}")
+        except Exception as e:
+            print(f"[supervisor] code-server log forwarding error: {e}")
+
     async def start_opencode(self) -> None:
         """Start OpenCode server with configuration."""
         self._setup_openai_oauth()
@@ -487,6 +529,7 @@ class SandboxSupervisor:
         """Monitor child processes and restart on crash."""
         restart_count = 0
         bridge_restart_count = 0
+        code_server_restart_count = 0
 
         while not self.shutdown_event.is_set():
             # Check OpenCode process
@@ -564,6 +607,20 @@ class SandboxSupervisor:
                     )
                     await asyncio.sleep(delay)
                     await self.start_bridge()
+
+            # Check code-server process (non-fatal, best-effort restart)
+            if self.code_server_process and self.code_server_process.returncode is not None:
+                code_server_restart_count += 1
+                self.log.warn(
+                    "code_server.crash",
+                    exit_code=self.code_server_process.returncode,
+                    restart_count=code_server_restart_count,
+                )
+
+                if code_server_restart_count <= self.MAX_RESTARTS:
+                    delay = min(self.BACKOFF_BASE**code_server_restart_count, self.BACKOFF_MAX)
+                    await asyncio.sleep(delay)
+                    await self.start_code_server()
 
             await asyncio.sleep(1.0)
 
@@ -962,6 +1019,9 @@ class SandboxSupervisor:
                 await self.shutdown_event.wait()
                 return
 
+            # Phase 3.5: Start code-server (non-blocking, no health check needed)
+            await self.start_code_server()
+
             # Phase 4: Start OpenCode server (in repo directory)
             await self.start_opencode()
             opencode_ready = True
@@ -1012,6 +1072,14 @@ class SandboxSupervisor:
                 await asyncio.wait_for(self.bridge_process.wait(), timeout=5.0)
             except TimeoutError:
                 self.bridge_process.kill()
+
+        # Terminate code-server
+        if self.code_server_process and self.code_server_process.returncode is None:
+            self.code_server_process.terminate()
+            try:
+                await asyncio.wait_for(self.code_server_process.wait(), timeout=5.0)
+            except TimeoutError:
+                self.code_server_process.kill()
 
         # Terminate OpenCode
         if self.opencode_process and self.opencode_process.returncode is None:

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -12,6 +12,7 @@ Updated: 2026-01-15 to fix Sandbox.create API
 
 import json
 import os
+import secrets
 import time
 from dataclasses import dataclass
 
@@ -25,6 +26,7 @@ from .types import SandboxStatus, SessionConfig
 log = get_logger("manager")
 
 DEFAULT_SANDBOX_TIMEOUT_SECONDS = 7200  # 2 hours
+CODE_SERVER_PORT = 8080
 
 
 @dataclass
@@ -55,6 +57,8 @@ class SandboxHandle:
     created_at: float
     snapshot_id: str | None = None
     modal_object_id: str | None = None  # Modal's internal sandbox ID for API calls
+    code_server_url: str | None = None
+    code_server_password: str | None = None
 
     def get_logs(self) -> str:
         """Get sandbox logs."""
@@ -82,6 +86,31 @@ class SandboxManager:
     def _get_repo_key(self, repo_owner: str, repo_name: str) -> str:
         """Get unique key for a repository."""
         return f"{repo_owner}/{repo_name}"
+
+    @staticmethod
+    def _generate_code_server_credentials(
+        env_vars: dict[str, str],
+    ) -> str:
+        """Generate a code-server password and inject it into env_vars.
+
+        Returns the generated password.
+        """
+        password = secrets.token_urlsafe(16)
+        env_vars["CODE_SERVER_PASSWORD"] = password
+        return password
+
+    @staticmethod
+    def _resolve_code_server_tunnel(
+        sandbox: modal.Sandbox, sandbox_id: str
+    ) -> str | None:
+        """Resolve the code-server tunnel URL from Modal, returning None on failure."""
+        try:
+            tunnel = sandbox.tunnels()[CODE_SERVER_PORT]
+            log.info("code_server.tunnel", sandbox_id=sandbox_id, url=tunnel.url)
+            return tunnel.url
+        except Exception as e:
+            log.warn("code_server.tunnel_error", sandbox_id=sandbox_id, exc=e)
+            return None
 
     @staticmethod
     def _inject_vcs_env_vars(env_vars: dict[str, str], clone_token: str | None) -> None:
@@ -144,6 +173,8 @@ class SandboxManager:
 
         self._inject_vcs_env_vars(env_vars, config.clone_token)
 
+        code_server_password = self._generate_code_server_credentials(env_vars)
+
         if config.session_config:
             env_vars["SESSION_CONFIG"] = config.session_config.model_dump_json()
 
@@ -169,11 +200,13 @@ class SandboxManager:
             timeout=config.timeout_seconds,
             workdir="/workspace",
             env=env_vars,
-            # Note: volumes parameter is not supported in Sandbox.create
+            encrypted_ports=[CODE_SERVER_PORT],
         )
 
         # Get Modal's internal object ID for API calls (snapshot, etc.)
         modal_object_id = sandbox.object_id
+        code_server_url = self._resolve_code_server_tunnel(sandbox, sandbox_id)
+
         duration_ms = int((time.time() - start_time) * 1000)
         log.info(
             "sandbox.create",
@@ -192,6 +225,8 @@ class SandboxManager:
             created_at=time.time(),
             snapshot_id=config.snapshot_id,
             modal_object_id=modal_object_id,
+            code_server_url=code_server_url,
+            code_server_password=code_server_password,
         )
 
     async def create_build_sandbox(
@@ -453,6 +488,8 @@ class SandboxManager:
 
         self._inject_vcs_env_vars(env_vars, clone_token)
 
+        code_server_password = self._generate_code_server_credentials(env_vars)
+
         # Create the sandbox from the snapshot image
         sandbox = modal.Sandbox.create(
             "python",
@@ -464,9 +501,11 @@ class SandboxManager:
             timeout=timeout_seconds,
             workdir="/workspace",
             env=env_vars,
+            encrypted_ports=[CODE_SERVER_PORT],
         )
 
         modal_object_id = sandbox.object_id
+        code_server_url = self._resolve_code_server_tunnel(sandbox, sandbox_id)
 
         duration_ms = int((time.time() - start_time) * 1000)
         log.info(
@@ -487,6 +526,8 @@ class SandboxManager:
             created_at=time.time(),
             snapshot_id=snapshot_image_id,
             modal_object_id=modal_object_id,
+            code_server_url=code_server_url,
+            code_server_password=code_server_password,
         )
 
     async def maintain_warm_pool(

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -171,6 +171,8 @@ async def api_create_sandbox(
                 "modal_object_id": handle.modal_object_id,  # Modal's internal ID for snapshot API
                 "status": handle.status.value,
                 "created_at": handle.created_at,
+                "code_server_url": handle.code_server_url,
+                "code_server_password": handle.code_server_password,
             },
         }
     except Exception as e:
@@ -534,6 +536,8 @@ async def api_restore_sandbox(
                 "sandbox_id": handle.sandbox_id,
                 "modal_object_id": handle.modal_object_id,
                 "status": handle.status.value,
+                "code_server_url": handle.code_server_url,
+                "code_server_password": handle.code_server_password,
             },
         }
     except HTTPException as e:

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -301,6 +301,7 @@ export type ServerMessage =
       status: SessionStatus;
       title: string | null;
     }
+  | { type: "code_server_info"; url: string; password: string }
   | { type: "error"; code: string; message: string };
 
 // Session state sent to clients
@@ -319,6 +320,8 @@ export interface SessionState {
   reasoningEffort?: string;
   isProcessing?: boolean;
   parentSessionId?: string | null;
+  codeServerUrl?: string | null;
+  codeServerPassword?: string | null;
 }
 
 // Participant presence info

--- a/packages/web/src/components/session-right-sidebar.tsx
+++ b/packages/web/src/components/session-right-sidebar.tsx
@@ -7,6 +7,7 @@ import {
   MetadataSection,
   TasksSection,
   FilesChangedSection,
+  CodeServerSection,
 } from "./sidebar";
 import { ChildSessionsSection } from "./sidebar/child-sessions-section";
 import { extractLatestTasks } from "@/lib/tasks";
@@ -65,6 +66,17 @@ export function SessionRightSidebarContent({
           parentSessionId={sessionState.parentSessionId}
         />
       </div>
+
+      {/* Code Server */}
+      {sessionState.codeServerUrl && (
+        <div className="px-4 py-4 border-b border-border-muted">
+          <CodeServerSection
+            url={sessionState.codeServerUrl}
+            password={sessionState.codeServerPassword ?? ""}
+            sandboxStatus={sessionState.sandboxStatus}
+          />
+        </div>
+      )}
 
       {/* Tasks */}
       {tasks.length > 0 && (

--- a/packages/web/src/components/sidebar/code-server-section.tsx
+++ b/packages/web/src/components/sidebar/code-server-section.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import { copyToClipboard } from "@/lib/format";
+import { TerminalIcon, KeyIcon, CheckIcon } from "@/components/ui/icons";
+import type { SandboxStatus } from "@open-inspect/shared";
+
+interface CodeServerSectionProps {
+  url: string;
+  password: string;
+  sandboxStatus: SandboxStatus;
+}
+
+const ACTIVE_STATUSES: Set<SandboxStatus> = new Set(["ready", "running", "snapshotting"]);
+const STARTING_STATUSES: Set<SandboxStatus> = new Set([
+  "pending",
+  "spawning",
+  "connecting",
+  "warming",
+  "syncing",
+]);
+
+export function CodeServerSection({ url, password, sandboxStatus }: CodeServerSectionProps) {
+  const [copiedPassword, setCopiedPassword] = useState(false);
+
+  const isActive = ACTIVE_STATUSES.has(sandboxStatus);
+  const isStarting = STARTING_STATUSES.has(sandboxStatus);
+
+  const handleCopyPassword = async () => {
+    const success = await copyToClipboard(password);
+    if (success) {
+      setCopiedPassword(true);
+      setTimeout(() => setCopiedPassword(false), 2000);
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <TerminalIcon
+        className={`w-4 h-4 shrink-0 ${isActive ? "text-muted-foreground" : "text-muted-foreground/50"}`}
+      />
+      {isActive ? (
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-accent hover:underline truncate"
+        >
+          Open Editor
+        </a>
+      ) : (
+        <span className="text-muted-foreground truncate">
+          {isStarting ? "Editor starting\u2026" : "Editor unavailable"}
+        </span>
+      )}
+      {isActive && (
+        <button
+          onClick={handleCopyPassword}
+          className="p-1 hover:bg-muted transition-colors shrink-0"
+          title={copiedPassword ? "Copied!" : "Copy password"}
+        >
+          {copiedPassword ? (
+            <CheckIcon className="w-3.5 h-3.5 text-success" />
+          ) : (
+            <KeyIcon className="w-3.5 h-3.5 text-secondary-foreground" />
+          )}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/sidebar/index.ts
+++ b/packages/web/src/components/sidebar/index.ts
@@ -3,3 +3,4 @@ export { ParticipantsSection } from "./participants-section";
 export { MetadataSection } from "./metadata-section";
 export { TasksSection } from "./tasks-section";
 export { FilesChangedSection } from "./files-changed-section";
+export { CodeServerSection } from "./code-server-section";

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -294,6 +294,12 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
           setSessionState((prev) => (prev ? { ...prev, sandboxStatus: data.status } : null));
           break;
 
+        case "code_server_info":
+          setSessionState((prev) =>
+            prev ? { ...prev, codeServerUrl: data.url, codeServerPassword: data.password } : null
+          );
+          break;
+
         case "sandbox_ready":
           setSessionState((prev) => (prev ? { ...prev, sandboxStatus: "ready" } : null));
           break;

--- a/terraform/d1/migrations/0013_add_code_server_to_sandbox.sql
+++ b/terraform/d1/migrations/0013_add_code_server_to_sandbox.sql
@@ -1,0 +1,4 @@
+-- Code-server tunnel URL and password on the sandbox table.
+-- URL rotates on every wake/restore; password is stable per session.
+ALTER TABLE sandbox ADD COLUMN code_server_url TEXT;
+ALTER TABLE sandbox ADD COLUMN code_server_password TEXT;


### PR DESCRIPTION
This adds code-server as a first class feature. code-server is served through a modal tunnel, and the url and password are shown in the right sidebar. This closes [286](https://github.com/ColeMurray/background-agents/issues/286)