### PR TITLE
fix: fetch github email using api to resolve attribution for github private emails

### DIFF
--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -72,16 +72,23 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
   callbacks: {
-    async signIn({ profile, user }) {
+    async signIn({ profile, user, account }) {
       const config = {
         allowedDomains: parseAllowlist(process.env.ALLOWED_EMAIL_DOMAINS),
         allowedUsers: parseAllowlist(process.env.ALLOWED_USERS),
       };
 
       const githubProfile = profile as { login?: string };
+
+      // Resolve the real email even when the GitHub profile email is private.
+      let email = user.email ?? undefined;
+      if (!email && account?.access_token) {
+        email = (await fetchGitHubPrimaryEmail(account.access_token)) ?? undefined;
+      }
+
       const isAllowed = checkAccessAllowed(config, {
         githubUsername: githubProfile.login,
-        email: user.email ?? undefined,
+        email,
       });
 
       if (!isAllowed) {


### PR DESCRIPTION
This fixes a bug where, if a user's GitHub email is set to private, we are unable to get the user's email. This results in a commit where the name is correct but the email is not (it would fall back on the default open inspect email).

This causes issues with git attribution, which were originally observed because Vercel preview builds would not work, because Vercel would not recognize that the PR author is part of the Vercel team.