### PR TITLE
refactor: unify session DO internal endpoint contracts

### DIFF
--- a/packages/control-plane/src/router.spawn-child.test.ts
+++ b/packages/control-plane/src/router.spawn-child.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { handleRequest } from "./router";
 import { generateInternalToken } from "./auth/internal";
 import { SessionIndexStore } from "./db/session-index";
+import { SessionInternalPaths } from "./session/contracts";
 
 vi.mock("./db/session-index", () => ({
   SessionIndexStore: vi.fn(),
@@ -66,8 +67,8 @@ describe("handleSpawnChild prompt enqueue handling", () => {
     const childStub: DurableObjectStub = {
       fetch: vi.fn(async (request: Request) => {
         const path = new URL(request.url).pathname;
-        if (path === "/internal/init") return Response.json({ status: "ok" });
-        if (path === "/internal/prompt")
+        if (path === SessionInternalPaths.init) return Response.json({ status: "ok" });
+        if (path === SessionInternalPaths.prompt)
           return Response.json({ messageId: "msg-1", status: "queued" });
         return Response.json({ error: "unexpected" }, { status: 404 });
       }),
@@ -105,8 +106,8 @@ describe("handleSpawnChild prompt enqueue handling", () => {
     const childStub: DurableObjectStub = {
       fetch: vi.fn(async (request: Request) => {
         const path = new URL(request.url).pathname;
-        if (path === "/internal/init") return Response.json({ status: "ok" });
-        if (path === "/internal/prompt") {
+        if (path === SessionInternalPaths.init) return Response.json({ status: "ok" });
+        if (path === SessionInternalPaths.prompt) {
           return Response.json({ error: "enqueue failed" }, { status: 503 });
         }
         return Response.json({ error: "unexpected" }, { status: 404 });

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -12,6 +12,7 @@ import {
 } from "./source-control";
 import { SessionIndexStore } from "./db/session-index";
 import { UserScmTokenStore, DEFAULT_TOKEN_LIFETIME_MS } from "./db/user-scm-tokens";
+import { buildSessionInternalUrl, SessionInternalPaths } from "./session/contracts";
 
 import {
   getValidModelOrDefault,
@@ -237,7 +238,7 @@ async function verifySandboxAuth(
 
   const verifyResponse = await stub.fetch(
     internalRequest(
-      "http://internal/internal/verify-sandbox-token",
+      buildSessionInternalUrl(SessionInternalPaths.verifySandboxToken),
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -680,7 +681,7 @@ async function handleCreateSession(
   // Initialize session with user info and optional encrypted token
   const initResponse = await stub.fetch(
     internalRequest(
-      "http://internal/internal/init",
+      buildSessionInternalUrl(SessionInternalPaths.init),
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -746,7 +747,7 @@ async function handleGetSession(
   const stub = env.SESSION.get(doId);
 
   const response = await stub.fetch(
-    internalRequest("http://internal/internal/state", undefined, ctx)
+    internalRequest(buildSessionInternalUrl(SessionInternalPaths.state), undefined, ctx)
   );
 
   if (!response.ok) {
@@ -803,7 +804,7 @@ async function handleSessionPrompt(
 
   const response = await stub.fetch(
     internalRequest(
-      "http://internal/internal/prompt",
+      buildSessionInternalUrl(SessionInternalPaths.prompt),
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -846,7 +847,9 @@ async function handleSessionStop(
   const stub = getSessionStub(env, match);
   if (!stub) return error("Session ID required");
 
-  return stub.fetch(internalRequest("http://internal/internal/stop", { method: "POST" }, ctx));
+  return stub.fetch(
+    internalRequest(buildSessionInternalUrl(SessionInternalPaths.stop), { method: "POST" }, ctx)
+  );
 }
 
 async function handleSessionEvents(
@@ -860,7 +863,11 @@ async function handleSessionEvents(
 
   const url = new URL(request.url);
   return stub.fetch(
-    internalRequest(`http://internal/internal/events${url.search}`, undefined, ctx)
+    internalRequest(
+      buildSessionInternalUrl(SessionInternalPaths.events, url.search),
+      undefined,
+      ctx
+    )
   );
 }
 
@@ -873,7 +880,9 @@ async function handleSessionArtifacts(
   const stub = getSessionStub(env, match);
   if (!stub) return error("Session ID required");
 
-  return stub.fetch(internalRequest("http://internal/internal/artifacts", undefined, ctx));
+  return stub.fetch(
+    internalRequest(buildSessionInternalUrl(SessionInternalPaths.artifacts), undefined, ctx)
+  );
 }
 
 async function handleSessionParticipants(
@@ -885,7 +894,9 @@ async function handleSessionParticipants(
   const stub = getSessionStub(env, match);
   if (!stub) return error("Session ID required");
 
-  return stub.fetch(internalRequest("http://internal/internal/participants", undefined, ctx));
+  return stub.fetch(
+    internalRequest(buildSessionInternalUrl(SessionInternalPaths.participants), undefined, ctx)
+  );
 }
 
 async function handleAddParticipant(
@@ -904,7 +915,7 @@ async function handleAddParticipant(
 
   const response = await stub.fetch(
     internalRequest(
-      "http://internal/internal/participants",
+      buildSessionInternalUrl(SessionInternalPaths.participants),
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -928,7 +939,11 @@ async function handleSessionMessages(
 
   const url = new URL(request.url);
   return stub.fetch(
-    internalRequest(`http://internal/internal/messages${url.search}`, undefined, ctx)
+    internalRequest(
+      buildSessionInternalUrl(SessionInternalPaths.messages, url.search),
+      undefined,
+      ctx
+    )
   );
 }
 
@@ -970,7 +985,7 @@ async function handleCreatePR(
 
   const response = await stub.fetch(
     internalRequest(
-      "http://internal/internal/create-pr",
+      buildSessionInternalUrl(SessionInternalPaths.createPr),
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -998,7 +1013,11 @@ async function handleOpenAITokenRefresh(
   if (!stub) return error("Session ID required");
 
   return stub.fetch(
-    internalRequest("http://internal/internal/openai-token-refresh", { method: "POST" }, ctx)
+    internalRequest(
+      buildSessionInternalUrl(SessionInternalPaths.openaiTokenRefresh),
+      { method: "POST" },
+      ctx
+    )
   );
 }
 
@@ -1089,7 +1108,7 @@ async function handleSessionWsToken(
   const response = await ctx.metrics.time("do_fetch", () =>
     stub.fetch(
       internalRequest(
-        "http://internal/internal/ws-token",
+        buildSessionInternalUrl(SessionInternalPaths.wsToken),
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -1135,7 +1154,7 @@ async function handleArchiveSession(
 
   const response = await stub.fetch(
     internalRequest(
-      "http://internal/internal/archive",
+      buildSessionInternalUrl(SessionInternalPaths.archive),
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -1180,7 +1199,7 @@ async function handleUnarchiveSession(
 
   const response = await stub.fetch(
     internalRequest(
-      "http://internal/internal/unarchive",
+      buildSessionInternalUrl(SessionInternalPaths.unarchive),
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -1244,7 +1263,7 @@ async function handleSpawnChild(
   const parentStub = env.SESSION.get(parentDoId);
 
   const spawnContextRes = await parentStub.fetch(
-    internalRequest("http://internal/internal/spawn-context", undefined, ctx)
+    internalRequest(buildSessionInternalUrl(SessionInternalPaths.spawnContext), undefined, ctx)
   );
 
   if (!spawnContextRes.ok) {
@@ -1285,7 +1304,7 @@ async function handleSpawnChild(
   // Initialize child DO
   const initResponse = await childStub.fetch(
     internalRequest(
-      "http://internal/internal/init",
+      buildSessionInternalUrl(SessionInternalPaths.init),
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -1338,7 +1357,7 @@ async function handleSpawnChild(
   try {
     promptResponse = await childStub.fetch(
       internalRequest(
-        "http://internal/internal/prompt",
+        buildSessionInternalUrl(SessionInternalPaths.prompt),
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -1382,7 +1401,7 @@ async function handleSpawnChild(
     parentStub
       .fetch(
         internalRequest(
-          "http://internal/internal/child-session-update",
+          buildSessionInternalUrl(SessionInternalPaths.childSessionUpdate),
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -1439,7 +1458,7 @@ async function handleGetChild(
   const childStub = env.SESSION.get(childDoId);
 
   const response = await childStub.fetch(
-    internalRequest("http://internal/internal/child-summary", undefined, ctx)
+    internalRequest(buildSessionInternalUrl(SessionInternalPaths.childSummary), undefined, ctx)
   );
 
   return response;
@@ -1466,7 +1485,7 @@ async function handleCancelChild(
   const childStub = env.SESSION.get(childDoId);
 
   const response = await childStub.fetch(
-    internalRequest("http://internal/internal/cancel", { method: "POST" }, ctx)
+    internalRequest(buildSessionInternalUrl(SessionInternalPaths.cancel), { method: "POST" }, ctx)
   );
 
   // Update D1 status if cancel succeeded

--- a/packages/control-plane/src/session/contracts.test.ts
+++ b/packages/control-plane/src/session/contracts.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { SessionInternalPaths } from "./contracts";
+
+describe("session internal endpoint contracts", () => {
+  it("uses contract constants in SessionDO and router for known endpoints", () => {
+    const routerSource = readFileSync(new URL("../router.ts", import.meta.url), "utf8");
+    const durableObjectSource = readFileSync(
+      new URL("./durable-object.ts", import.meta.url),
+      "utf8"
+    );
+
+    const routerEndpointKeys: Array<keyof typeof SessionInternalPaths> = [
+      "verifySandboxToken",
+      "init",
+      "state",
+      "prompt",
+      "stop",
+      "events",
+      "artifacts",
+      "participants",
+      "messages",
+      "createPr",
+      "openaiTokenRefresh",
+      "wsToken",
+      "archive",
+      "unarchive",
+      "spawnContext",
+      "childSessionUpdate",
+      "childSummary",
+      "cancel",
+    ];
+
+    for (const endpointKey of routerEndpointKeys) {
+      expect(routerSource).toContain(`SessionInternalPaths.${endpointKey}`);
+    }
+
+    for (const endpointKey of Object.keys(SessionInternalPaths) as Array<
+      keyof typeof SessionInternalPaths
+    >) {
+      expect(durableObjectSource).toContain(`SessionInternalPaths.${endpointKey}`);
+    }
+
+    expect(routerSource).not.toContain("http://internal/internal/");
+    expect(durableObjectSource).not.toContain('"/internal/');
+    expect(durableObjectSource).not.toContain("'/internal/");
+  });
+});

--- a/packages/control-plane/src/session/contracts.ts
+++ b/packages/control-plane/src/session/contracts.ts
@@ -1,0 +1,34 @@
+/**
+ * Contract constants for Session Durable Object internal endpoints.
+ * Router and SessionDO must both import these to prevent path drift.
+ */
+
+export const SessionInternalPaths = {
+  init: "/internal/init",
+  state: "/internal/state",
+  prompt: "/internal/prompt",
+  stop: "/internal/stop",
+  sandboxEvent: "/internal/sandbox-event",
+  participants: "/internal/participants",
+  events: "/internal/events",
+  artifacts: "/internal/artifacts",
+  messages: "/internal/messages",
+  createPr: "/internal/create-pr",
+  wsToken: "/internal/ws-token",
+  archive: "/internal/archive",
+  unarchive: "/internal/unarchive",
+  verifySandboxToken: "/internal/verify-sandbox-token",
+  openaiTokenRefresh: "/internal/openai-token-refresh",
+  spawnContext: "/internal/spawn-context",
+  childSummary: "/internal/child-summary",
+  cancel: "/internal/cancel",
+  childSessionUpdate: "/internal/child-session-update",
+} as const;
+
+export type SessionInternalPath = (typeof SessionInternalPaths)[keyof typeof SessionInternalPaths];
+
+const INTERNAL_ORIGIN = "http://internal";
+
+export function buildSessionInternalUrl(path: SessionInternalPath, search?: string): string {
+  return `${INTERNAL_ORIGIN}${path}${search ?? ""}`;
+}

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -9,6 +9,7 @@
 
 import { DurableObject } from "cloudflare:workers";
 import { initSchema } from "./schema";
+import { buildSessionInternalUrl, SessionInternalPaths } from "./contracts";
 import { generateId, hashToken, timingSafeEqual } from "../auth/crypto";
 import { getGitHubAppConfig } from "../auth/github-app";
 import { createModalClient } from "../sandbox/client";
@@ -147,52 +148,88 @@ export class SessionDO extends DurableObject<Env> {
 
   // Route table for internal API endpoints
   private readonly routes: InternalRoute[] = [
-    { method: "POST", path: "/internal/init", handler: (req) => this.handleInit(req) },
-    { method: "GET", path: "/internal/state", handler: () => this.handleGetState() },
-    { method: "POST", path: "/internal/prompt", handler: (req) => this.handleEnqueuePrompt(req) },
-    { method: "POST", path: "/internal/stop", handler: () => this.handleStop() },
+    { method: "POST", path: SessionInternalPaths.init, handler: (req) => this.handleInit(req) },
+    { method: "GET", path: SessionInternalPaths.state, handler: () => this.handleGetState() },
     {
       method: "POST",
-      path: "/internal/sandbox-event",
+      path: SessionInternalPaths.prompt,
+      handler: (req) => this.handleEnqueuePrompt(req),
+    },
+    { method: "POST", path: SessionInternalPaths.stop, handler: () => this.handleStop() },
+    {
+      method: "POST",
+      path: SessionInternalPaths.sandboxEvent,
       handler: (req) => this.handleSandboxEvent(req),
     },
-    { method: "GET", path: "/internal/participants", handler: () => this.handleListParticipants() },
-    {
-      method: "POST",
-      path: "/internal/participants",
-      handler: (req) => this.handleAddParticipant(req),
-    },
-    { method: "GET", path: "/internal/events", handler: (_, url) => this.handleListEvents(url) },
-    { method: "GET", path: "/internal/artifacts", handler: () => this.handleListArtifacts() },
     {
       method: "GET",
-      path: "/internal/messages",
+      path: SessionInternalPaths.participants,
+      handler: () => this.handleListParticipants(),
+    },
+    {
+      method: "POST",
+      path: SessionInternalPaths.participants,
+      handler: (req) => this.handleAddParticipant(req),
+    },
+    {
+      method: "GET",
+      path: SessionInternalPaths.events,
+      handler: (_, url) => this.handleListEvents(url),
+    },
+    {
+      method: "GET",
+      path: SessionInternalPaths.artifacts,
+      handler: () => this.handleListArtifacts(),
+    },
+    {
+      method: "GET",
+      path: SessionInternalPaths.messages,
       handler: (_, url) => this.handleListMessages(url),
     },
-    { method: "POST", path: "/internal/create-pr", handler: (req) => this.handleCreatePR(req) },
     {
       method: "POST",
-      path: "/internal/ws-token",
+      path: SessionInternalPaths.createPr,
+      handler: (req) => this.handleCreatePR(req),
+    },
+    {
+      method: "POST",
+      path: SessionInternalPaths.wsToken,
       handler: (req) => this.handleGenerateWsToken(req),
     },
-    { method: "POST", path: "/internal/archive", handler: (req) => this.handleArchive(req) },
-    { method: "POST", path: "/internal/unarchive", handler: (req) => this.handleUnarchive(req) },
     {
       method: "POST",
-      path: "/internal/verify-sandbox-token",
+      path: SessionInternalPaths.archive,
+      handler: (req) => this.handleArchive(req),
+    },
+    {
+      method: "POST",
+      path: SessionInternalPaths.unarchive,
+      handler: (req) => this.handleUnarchive(req),
+    },
+    {
+      method: "POST",
+      path: SessionInternalPaths.verifySandboxToken,
       handler: (req) => this.handleVerifySandboxToken(req),
     },
     {
       method: "POST",
-      path: "/internal/openai-token-refresh",
+      path: SessionInternalPaths.openaiTokenRefresh,
       handler: () => this.handleOpenAITokenRefresh(),
     },
-    { method: "GET", path: "/internal/spawn-context", handler: () => this.handleGetSpawnContext() },
-    { method: "GET", path: "/internal/child-summary", handler: () => this.handleGetChildSummary() },
-    { method: "POST", path: "/internal/cancel", handler: () => this.handleCancel() },
+    {
+      method: "GET",
+      path: SessionInternalPaths.spawnContext,
+      handler: () => this.handleGetSpawnContext(),
+    },
+    {
+      method: "GET",
+      path: SessionInternalPaths.childSummary,
+      handler: () => this.handleGetChildSummary(),
+    },
+    { method: "POST", path: SessionInternalPaths.cancel, handler: () => this.handleCancel() },
     {
       method: "POST",
-      path: "/internal/child-session-update",
+      path: SessionInternalPaths.childSessionUpdate,
       handler: (req) => this.handleChildSessionUpdate(req),
     },
   ];
@@ -1284,7 +1321,7 @@ export class SessionDO extends DurableObject<Env> {
     this.ctx.waitUntil(
       parentStub
         .fetch(
-          new Request("http://internal/internal/child-session-update", {
+          new Request(buildSessionInternalUrl(SessionInternalPaths.childSessionUpdate), {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({


### PR DESCRIPTION
## Summary
- add `packages/control-plane/src/session/contracts.ts` as the single source of truth for SessionDO internal endpoint paths
- replace internal endpoint string literals in SessionDO route definitions and parent notification call sites
- replace internal endpoint URL literals in `packages/control-plane/src/router.ts` with contract-based URL construction
- add a contract drift guard test and update spawn-child unit tests to reference contract constants

## Why
This is the first low-risk slice from `docs/internal/refactor-do-design.md` (Phase 1 / recommended first PR), removing path drift risk between `SessionDO` and `router.ts` before larger extractions.

## Testing
- `npm test -w @open-inspect/control-plane`
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/durable-object.test.ts test/integration/session-lifecycle.test.ts`
