### PR TITLE
refactor: extract session messages handler and service

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -73,30 +73,8 @@ import { PresenceService } from "./presence-service";
 import { SessionMessageQueue } from "./message-queue";
 import { SessionSandboxEventProcessor } from "./sandbox-events";
 import { createSessionInternalRoutes } from "./http/routes";
-
-/**
- * Valid event types for filtering.
- * Includes both external types (from types.ts) and internal types used by the sandbox.
- */
-const VALID_EVENT_TYPES = [
-  "tool_call",
-  "tool_result",
-  "token",
-  "error",
-  "git_sync",
-  "step_start",
-  "step_finish",
-  "execution_complete",
-  "heartbeat",
-  "push_complete",
-  "push_error",
-  "user_message",
-] as const;
-
-/**
- * Valid message statuses for filtering.
- */
-const VALID_MESSAGE_STATUSES = ["pending", "processing", "completed", "failed"] as const;
+import { createMessagesHandler, type MessagesHandler } from "./http/handlers/messages.handler";
+import { MessageService } from "./services/message.service";
 
 /**
  * Timeout for WebSocket authentication (in milliseconds).
@@ -135,6 +113,10 @@ export class SessionDO extends DurableObject<Env> {
   private _presenceService: PresenceService | null = null;
   // Message queue service (lazily initialized)
   private _messageQueue: SessionMessageQueue | null = null;
+  // Message service (lazily initialized)
+  private _messageService: MessageService | null = null;
+  // Messages handler (lazily initialized)
+  private _messagesHandler: MessagesHandler | null = null;
   // Sandbox event processor (lazily initialized)
   private _sandboxEventProcessor: SessionSandboxEventProcessor | null = null;
 
@@ -142,14 +124,14 @@ export class SessionDO extends DurableObject<Env> {
   private readonly routes = createSessionInternalRoutes({
     init: (request) => this.handleInit(request),
     state: () => this.handleGetState(),
-    prompt: (request) => this.handleEnqueuePrompt(request),
-    stop: () => this.handleStop(),
+    prompt: (request) => this.messagesHandler.enqueuePrompt(request),
+    stop: () => this.messagesHandler.stop(),
     sandboxEvent: (request) => this.handleSandboxEvent(request),
     listParticipants: () => this.handleListParticipants(),
     addParticipant: (request) => this.handleAddParticipant(request),
-    listEvents: (_request, url) => this.handleListEvents(url),
-    listArtifacts: () => this.handleListArtifacts(),
-    listMessages: (_request, url) => this.handleListMessages(url),
+    listEvents: (_request, url) => this.messagesHandler.listEvents(url),
+    listArtifacts: () => this.messagesHandler.listArtifacts(),
+    listMessages: (_request, url) => this.messagesHandler.listMessages(url),
     createPr: (request) => this.handleCreatePR(request),
     wsToken: (request) => this.handleGenerateWsToken(request),
     archive: (request) => this.handleArchive(request),
@@ -308,6 +290,30 @@ export class SessionDO extends DurableObject<Env> {
     }
 
     return this._messageQueue;
+  }
+
+  private get messageService(): MessageService {
+    if (!this._messageService) {
+      this._messageService = new MessageService({
+        repository: this.repository,
+        messageQueue: this.messageQueue,
+        stopExecution: () => this.stopExecution(),
+        parseArtifactMetadata: (artifact) => this.parseArtifactMetadata(artifact),
+      });
+    }
+
+    return this._messageService;
+  }
+
+  private get messagesHandler(): MessagesHandler {
+    if (!this._messagesHandler) {
+      this._messagesHandler = createMessagesHandler({
+        messageService: this.messageService,
+        getLog: () => this.log,
+      });
+    }
+
+    return this._messagesHandler;
   }
 
   private get sandboxEventProcessor(): SessionSandboxEventProcessor {
@@ -1666,32 +1672,6 @@ export class SessionDO extends DurableObject<Env> {
     });
   }
 
-  private async handleEnqueuePrompt(request: Request): Promise<Response> {
-    try {
-      const body = (await request.json()) as {
-        content: string;
-        authorId: string;
-        source: string;
-        model?: string;
-        reasoningEffort?: string;
-        attachments?: Array<{ type: string; name: string; url?: string }>;
-        callbackContext?: Record<string, unknown>;
-      };
-
-      return Response.json(await this.messageQueue.enqueuePromptFromApi(body));
-    } catch (error) {
-      this.log.error("handleEnqueuePrompt error", {
-        error: error instanceof Error ? error : String(error),
-      });
-      throw error;
-    }
-  }
-
-  private async handleStop(): Promise<Response> {
-    await this.stopExecution();
-    return Response.json({ status: "stopping" });
-  }
-
   private async handleSandboxEvent(request: Request): Promise<Response> {
     const event = (await request.json()) as SandboxEvent;
     await this.processSandboxEvent(event);
@@ -1736,83 +1716,6 @@ export class SessionDO extends DurableObject<Env> {
     });
 
     return Response.json({ id, status: "added" });
-  }
-
-  private handleListEvents(url: URL): Response {
-    const cursor = url.searchParams.get("cursor");
-    const limit = Math.min(parseInt(url.searchParams.get("limit") ?? "50"), 200);
-    const type = url.searchParams.get("type");
-    const messageId = url.searchParams.get("message_id");
-
-    // Validate type parameter if provided
-    if (type && !VALID_EVENT_TYPES.includes(type as (typeof VALID_EVENT_TYPES)[number])) {
-      return Response.json({ error: `Invalid event type: ${type}` }, { status: 400 });
-    }
-
-    const events = this.repository.listEvents({ cursor, limit, type, messageId });
-    const hasMore = events.length > limit;
-
-    if (hasMore) events.pop();
-
-    return Response.json({
-      events: events.map((e) => ({
-        id: e.id,
-        type: e.type,
-        data: JSON.parse(e.data),
-        messageId: e.message_id,
-        createdAt: e.created_at,
-      })),
-      cursor: events.length > 0 ? events[events.length - 1].created_at.toString() : undefined,
-      hasMore,
-    });
-  }
-
-  private handleListArtifacts(): Response {
-    const artifacts = this.repository.listArtifacts();
-
-    return Response.json({
-      artifacts: artifacts.map((a) => ({
-        id: a.id,
-        type: a.type,
-        url: a.url,
-        metadata: this.parseArtifactMetadata(a),
-        createdAt: a.created_at,
-      })),
-    });
-  }
-
-  private handleListMessages(url: URL): Response {
-    const cursor = url.searchParams.get("cursor");
-    const limit = Math.min(parseInt(url.searchParams.get("limit") ?? "50"), 100);
-    const status = url.searchParams.get("status");
-
-    // Validate status parameter if provided
-    if (
-      status &&
-      !VALID_MESSAGE_STATUSES.includes(status as (typeof VALID_MESSAGE_STATUSES)[number])
-    ) {
-      return Response.json({ error: `Invalid message status: ${status}` }, { status: 400 });
-    }
-
-    const messages = this.repository.listMessages({ cursor, limit, status });
-    const hasMore = messages.length > limit;
-
-    if (hasMore) messages.pop();
-
-    return Response.json({
-      messages: messages.map((m) => ({
-        id: m.id,
-        authorId: m.author_id,
-        content: m.content,
-        source: m.source,
-        status: m.status,
-        createdAt: m.created_at,
-        startedAt: m.started_at,
-        completedAt: m.completed_at,
-      })),
-      cursor: messages.length > 0 ? messages[messages.length - 1].created_at.toString() : undefined,
-      hasMore,
-    });
   }
 
   /**

--- a/packages/control-plane/src/session/http/handlers/messages.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/messages.handler.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Logger } from "../../../logger";
+import { createMessagesHandler } from "./messages.handler";
+import type { MessageService } from "../../services/message.service";
+
+function createHandler() {
+  const messageService = {
+    enqueuePrompt: vi.fn(),
+    stop: vi.fn(),
+    listEvents: vi.fn(),
+    listArtifacts: vi.fn(),
+    listMessages: vi.fn(),
+  } as unknown as MessageService;
+
+  const log = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  } as unknown as Logger;
+
+  return {
+    handler: createMessagesHandler({
+      messageService,
+      getLog: () => log,
+    }),
+    messageService,
+    log,
+  };
+}
+
+describe("createMessagesHandler", () => {
+  it("enqueues prompt and returns queued response", async () => {
+    const { handler, messageService } = createHandler();
+    vi.mocked(messageService.enqueuePrompt).mockResolvedValue({
+      messageId: "msg-1",
+      status: "queued",
+    });
+
+    const response = await handler.enqueuePrompt(
+      new Request("http://internal/internal/prompt", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          content: "hello",
+          authorId: "user-1",
+          source: "web",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ messageId: "msg-1", status: "queued" });
+    expect(messageService.enqueuePrompt).toHaveBeenCalledWith({
+      content: "hello",
+      authorId: "user-1",
+      source: "web",
+    });
+  });
+
+  it("logs and rethrows when enqueue prompt parsing fails", async () => {
+    const { handler, log } = createHandler();
+
+    await expect(
+      handler.enqueuePrompt(
+        new Request("http://internal/internal/prompt", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: "{invalid",
+        })
+      )
+    ).rejects.toBeTruthy();
+
+    expect(log.error).toHaveBeenCalledWith(
+      "handleEnqueuePrompt error",
+      expect.objectContaining({ error: expect.anything() })
+    );
+  });
+
+  it("returns 400 for invalid event type", async () => {
+    const { handler } = createHandler();
+
+    const response = handler.listEvents(new URL("http://internal/internal/events?type=invalid"));
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid event type: invalid" });
+  });
+
+  it("maps listEvents response", async () => {
+    const { handler, messageService } = createHandler();
+    vi.mocked(messageService.listEvents).mockReturnValue({
+      events: [
+        {
+          id: "e1",
+          type: "token",
+          data: '{"x":1}',
+          message_id: "m1",
+          created_at: 1000,
+        },
+      ],
+      cursor: "1000",
+      hasMore: false,
+    });
+
+    const response = handler.listEvents(new URL("http://internal/internal/events?limit=10"));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      events: [{ id: "e1", type: "token", data: { x: 1 }, messageId: "m1", createdAt: 1000 }],
+      cursor: "1000",
+      hasMore: false,
+    });
+  });
+
+  it("returns artifacts from service unchanged", async () => {
+    const { handler, messageService } = createHandler();
+    vi.mocked(messageService.listArtifacts).mockReturnValue({
+      artifacts: [
+        {
+          id: "a1",
+          type: "pr",
+          url: "https://example.com",
+          metadata: null,
+          createdAt: 1,
+        },
+      ],
+    });
+
+    const response = handler.listArtifacts();
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      artifacts: [
+        {
+          id: "a1",
+          type: "pr",
+          url: "https://example.com",
+          metadata: null,
+          createdAt: 1,
+        },
+      ],
+    });
+  });
+
+  it("returns 400 for invalid message status", async () => {
+    const { handler } = createHandler();
+
+    const response = handler.listMessages(
+      new URL("http://internal/internal/messages?status=invalid")
+    );
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid message status: invalid" });
+  });
+
+  it("maps listMessages response", async () => {
+    const { handler, messageService } = createHandler();
+    vi.mocked(messageService.listMessages).mockReturnValue({
+      messages: [
+        {
+          id: "m1",
+          author_id: "p1",
+          content: "hello",
+          source: "web",
+          model: null,
+          reasoning_effort: null,
+          attachments: null,
+          callback_context: null,
+          status: "completed",
+          error_message: null,
+          created_at: 1000,
+          started_at: 1100,
+          completed_at: 1200,
+        },
+      ],
+      cursor: "1000",
+      hasMore: false,
+    });
+
+    const response = handler.listMessages(new URL("http://internal/internal/messages?limit=10"));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      messages: [
+        {
+          id: "m1",
+          authorId: "p1",
+          content: "hello",
+          source: "web",
+          status: "completed",
+          createdAt: 1000,
+          startedAt: 1100,
+          completedAt: 1200,
+        },
+      ],
+      cursor: "1000",
+      hasMore: false,
+    });
+  });
+
+  it("returns stopping status for stop endpoint", async () => {
+    const { handler, messageService } = createHandler();
+    vi.mocked(messageService.stop).mockResolvedValue({ status: "stopping" });
+
+    const response = await handler.stop();
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: "stopping" });
+  });
+});

--- a/packages/control-plane/src/session/http/handlers/messages.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/messages.handler.ts
@@ -1,0 +1,118 @@
+import type { Logger } from "../../../logger";
+import type { EnqueuePromptRequest, MessageService } from "../../services/message.service";
+
+/**
+ * Valid event types for filtering.
+ * Includes both external types (from types.ts) and internal types used by the sandbox.
+ */
+const VALID_EVENT_TYPES = [
+  "tool_call",
+  "tool_result",
+  "token",
+  "error",
+  "git_sync",
+  "step_start",
+  "step_finish",
+  "execution_complete",
+  "heartbeat",
+  "push_complete",
+  "push_error",
+  "user_message",
+] as const;
+
+/**
+ * Valid message statuses for filtering.
+ */
+const VALID_MESSAGE_STATUSES = ["pending", "processing", "completed", "failed"] as const;
+
+export interface MessagesHandlerDeps {
+  messageService: MessageService;
+  getLog: () => Logger;
+}
+
+export interface MessagesHandler {
+  enqueuePrompt: (request: Request) => Promise<Response>;
+  stop: () => Promise<Response>;
+  listEvents: (url: URL) => Response;
+  listArtifacts: () => Response;
+  listMessages: (url: URL) => Response;
+}
+
+export function createMessagesHandler(deps: MessagesHandlerDeps): MessagesHandler {
+  return {
+    async enqueuePrompt(request: Request): Promise<Response> {
+      try {
+        const body = (await request.json()) as EnqueuePromptRequest;
+        return Response.json(await deps.messageService.enqueuePrompt(body));
+      } catch (error) {
+        deps.getLog().error("handleEnqueuePrompt error", {
+          error: error instanceof Error ? error : String(error),
+        });
+        throw error;
+      }
+    },
+
+    async stop(): Promise<Response> {
+      return Response.json(await deps.messageService.stop());
+    },
+
+    listEvents(url: URL): Response {
+      const cursor = url.searchParams.get("cursor");
+      const limit = Math.min(parseInt(url.searchParams.get("limit") ?? "50"), 200);
+      const type = url.searchParams.get("type");
+      const messageId = url.searchParams.get("message_id");
+
+      if (type && !VALID_EVENT_TYPES.includes(type as (typeof VALID_EVENT_TYPES)[number])) {
+        return Response.json({ error: `Invalid event type: ${type}` }, { status: 400 });
+      }
+
+      const result = deps.messageService.listEvents({ cursor, limit, type, messageId });
+
+      return Response.json({
+        events: result.events.map((event) => ({
+          id: event.id,
+          type: event.type,
+          data: JSON.parse(event.data),
+          messageId: event.message_id,
+          createdAt: event.created_at,
+        })),
+        cursor: result.cursor,
+        hasMore: result.hasMore,
+      });
+    },
+
+    listArtifacts(): Response {
+      return Response.json(deps.messageService.listArtifacts());
+    },
+
+    listMessages(url: URL): Response {
+      const cursor = url.searchParams.get("cursor");
+      const limit = Math.min(parseInt(url.searchParams.get("limit") ?? "50"), 100);
+      const status = url.searchParams.get("status");
+
+      if (
+        status &&
+        !VALID_MESSAGE_STATUSES.includes(status as (typeof VALID_MESSAGE_STATUSES)[number])
+      ) {
+        return Response.json({ error: `Invalid message status: ${status}` }, { status: 400 });
+      }
+
+      const result = deps.messageService.listMessages({ cursor, limit, status });
+
+      return Response.json({
+        messages: result.messages.map((message) => ({
+          id: message.id,
+          authorId: message.author_id,
+          content: message.content,
+          source: message.source,
+          status: message.status,
+          createdAt: message.created_at,
+          startedAt: message.started_at,
+          completedAt: message.completed_at,
+        })),
+        cursor: result.cursor,
+        hasMore: result.hasMore,
+      });
+    },
+  };
+}

--- a/packages/control-plane/src/session/services/message.service.test.ts
+++ b/packages/control-plane/src/session/services/message.service.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ArtifactRow, EventRow, MessageRow } from "../types";
+import type { SessionRepository } from "../repository";
+import type { SessionMessageQueue } from "../message-queue";
+import { MessageService } from "./message.service";
+
+function createService() {
+  const repository = {
+    listEvents: vi.fn(),
+    listArtifacts: vi.fn(),
+    listMessages: vi.fn(),
+  } as unknown as SessionRepository;
+
+  const messageQueue = {
+    enqueuePromptFromApi: vi.fn(),
+  } as unknown as SessionMessageQueue;
+
+  const stopExecution = vi.fn();
+  const parseArtifactMetadata = vi.fn();
+
+  return {
+    service: new MessageService({
+      repository,
+      messageQueue,
+      stopExecution,
+      parseArtifactMetadata,
+    }),
+    repository,
+    messageQueue,
+    stopExecution,
+    parseArtifactMetadata,
+  };
+}
+
+describe("MessageService", () => {
+  it("delegates enqueuePrompt to SessionMessageQueue", async () => {
+    const { service, messageQueue } = createService();
+    vi.mocked(messageQueue.enqueuePromptFromApi).mockResolvedValue({
+      messageId: "msg-1",
+      status: "queued",
+    });
+
+    const result = await service.enqueuePrompt({
+      content: "hello",
+      authorId: "user-1",
+      source: "web",
+    });
+
+    expect(result).toEqual({ messageId: "msg-1", status: "queued" });
+    expect(messageQueue.enqueuePromptFromApi).toHaveBeenCalledWith({
+      content: "hello",
+      authorId: "user-1",
+      source: "web",
+    });
+  });
+
+  it("stops execution and returns stopping status", async () => {
+    const { service, stopExecution } = createService();
+    const result = await service.stop();
+
+    expect(result).toEqual({ status: "stopping" });
+    expect(stopExecution).toHaveBeenCalledTimes(1);
+  });
+
+  it("paginates events with hasMore and cursor", () => {
+    const { service, repository } = createService();
+    const events: EventRow[] = [
+      { id: "e3", type: "token", data: "{}", message_id: "m1", created_at: 3000 },
+      { id: "e2", type: "token", data: "{}", message_id: "m1", created_at: 2000 },
+      { id: "e1", type: "token", data: "{}", message_id: "m1", created_at: 1000 },
+    ];
+    vi.mocked(repository.listEvents).mockReturnValue(events);
+
+    const result = service.listEvents({ cursor: null, limit: 2, type: "token", messageId: "m1" });
+
+    expect(result.hasMore).toBe(true);
+    expect(result.cursor).toBe("2000");
+    expect(result.events).toHaveLength(2);
+    expect(repository.listEvents).toHaveBeenCalledWith({
+      cursor: null,
+      limit: 2,
+      type: "token",
+      messageId: "m1",
+    });
+  });
+
+  it("maps artifacts and delegates metadata parsing", () => {
+    const { service, repository, parseArtifactMetadata } = createService();
+    const artifacts: ArtifactRow[] = [
+      {
+        id: "a1",
+        type: "pr",
+        url: "https://example.com/pr/1",
+        metadata: '{"key":"value"}',
+        created_at: 1000,
+      },
+    ];
+    vi.mocked(repository.listArtifacts).mockReturnValue(artifacts);
+    vi.mocked(parseArtifactMetadata).mockReturnValue({ key: "value" });
+
+    const result = service.listArtifacts();
+
+    expect(result).toEqual({
+      artifacts: [
+        {
+          id: "a1",
+          type: "pr",
+          url: "https://example.com/pr/1",
+          metadata: { key: "value" },
+          createdAt: 1000,
+        },
+      ],
+    });
+    expect(parseArtifactMetadata).toHaveBeenCalledWith(artifacts[0]);
+  });
+
+  it("paginates messages with hasMore and cursor", () => {
+    const { service, repository } = createService();
+    const messages: MessageRow[] = [
+      {
+        id: "m3",
+        author_id: "p1",
+        content: "3",
+        source: "web",
+        model: null,
+        reasoning_effort: null,
+        attachments: null,
+        callback_context: null,
+        status: "pending",
+        error_message: null,
+        created_at: 3000,
+        started_at: null,
+        completed_at: null,
+      },
+      {
+        id: "m2",
+        author_id: "p1",
+        content: "2",
+        source: "web",
+        model: null,
+        reasoning_effort: null,
+        attachments: null,
+        callback_context: null,
+        status: "pending",
+        error_message: null,
+        created_at: 2000,
+        started_at: null,
+        completed_at: null,
+      },
+      {
+        id: "m1",
+        author_id: "p1",
+        content: "1",
+        source: "web",
+        model: null,
+        reasoning_effort: null,
+        attachments: null,
+        callback_context: null,
+        status: "pending",
+        error_message: null,
+        created_at: 1000,
+        started_at: null,
+        completed_at: null,
+      },
+    ];
+    vi.mocked(repository.listMessages).mockReturnValue(messages);
+
+    const result = service.listMessages({ cursor: null, limit: 2, status: "pending" });
+
+    expect(result.hasMore).toBe(true);
+    expect(result.cursor).toBe("2000");
+    expect(result.messages).toHaveLength(2);
+    expect(repository.listMessages).toHaveBeenCalledWith({
+      cursor: null,
+      limit: 2,
+      status: "pending",
+    });
+  });
+});

--- a/packages/control-plane/src/session/services/message.service.ts
+++ b/packages/control-plane/src/session/services/message.service.ts
@@ -1,0 +1,110 @@
+import type { ArtifactRow, EventRow, MessageRow } from "../types";
+import type { SessionRepository } from "../repository";
+import type { SessionMessageQueue } from "../message-queue";
+
+export interface EnqueuePromptRequest {
+  content: string;
+  authorId: string;
+  source: string;
+  model?: string;
+  reasoningEffort?: string;
+  attachments?: Array<{ type: string; name: string; url?: string }>;
+  callbackContext?: Record<string, unknown>;
+}
+
+export interface ListEventsRequest {
+  cursor: string | null;
+  limit: number;
+  type: string | null;
+  messageId: string | null;
+}
+
+export interface ListMessagesRequest {
+  cursor: string | null;
+  limit: number;
+  status: string | null;
+}
+
+interface MessageServiceDeps {
+  repository: SessionRepository;
+  messageQueue: SessionMessageQueue;
+  stopExecution: () => Promise<void>;
+  parseArtifactMetadata: (
+    artifact: Pick<ArtifactRow, "id" | "metadata">
+  ) => Record<string, unknown> | null;
+}
+
+export class MessageService {
+  constructor(private readonly deps: MessageServiceDeps) {}
+
+  enqueuePrompt(request: EnqueuePromptRequest): Promise<{ messageId: string; status: "queued" }> {
+    return this.deps.messageQueue.enqueuePromptFromApi(request);
+  }
+
+  async stop(): Promise<{ status: "stopping" }> {
+    await this.deps.stopExecution();
+    return { status: "stopping" };
+  }
+
+  listEvents(request: ListEventsRequest): {
+    events: EventRow[];
+    cursor: string | undefined;
+    hasMore: boolean;
+  } {
+    const events = this.deps.repository.listEvents({
+      cursor: request.cursor,
+      limit: request.limit,
+      type: request.type,
+      messageId: request.messageId,
+    });
+    const hasMore = events.length > request.limit;
+    if (hasMore) events.pop();
+
+    return {
+      events,
+      cursor: events.length > 0 ? events[events.length - 1].created_at.toString() : undefined,
+      hasMore,
+    };
+  }
+
+  listArtifacts(): {
+    artifacts: Array<{
+      id: string;
+      type: ArtifactRow["type"];
+      url: string | null;
+      metadata: Record<string, unknown> | null;
+      createdAt: number;
+    }>;
+  } {
+    const artifacts = this.deps.repository.listArtifacts();
+    return {
+      artifacts: artifacts.map((artifact) => ({
+        id: artifact.id,
+        type: artifact.type,
+        url: artifact.url,
+        metadata: this.deps.parseArtifactMetadata(artifact),
+        createdAt: artifact.created_at,
+      })),
+    };
+  }
+
+  listMessages(request: ListMessagesRequest): {
+    messages: MessageRow[];
+    cursor: string | undefined;
+    hasMore: boolean;
+  } {
+    const messages = this.deps.repository.listMessages({
+      cursor: request.cursor,
+      limit: request.limit,
+      status: request.status,
+    });
+    const hasMore = messages.length > request.limit;
+    if (hasMore) messages.pop();
+
+    return {
+      messages,
+      cursor: messages.length > 0 ? messages[messages.length - 1].created_at.toString() : undefined,
+      hasMore,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- extract message-domain orchestration into `packages/control-plane/src/session/services/message.service.ts`
- extract message-domain HTTP transport parsing/validation/response mapping into `packages/control-plane/src/session/http/handlers/messages.handler.ts`
- wire SessionDO message routes (`prompt`, `stop`, `events`, `artifacts`, `messages`) to the new handler/service while keeping non-message routes unchanged
- remove duplicated inlined message route methods from `SessionDO`
- add focused unit tests for the new message service and message handler

## Why
This is Phase 3 (messages-first) from `docs/internal/refactor-do-design.md`, done as a small, low-risk slice: transport concerns move out of `SessionDO`, business operations move into a service, and endpoint behavior remains stable.

## Testing
- `npm test -w @open-inspect/control-plane`
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/durable-object.test.ts test/integration/session-lifecycle.test.ts`
