### PR TITLE
refactor: extract child sessions handler

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -56,7 +56,6 @@ import type {
   ParticipantRole,
   SpawnSource,
 } from "../types";
-import type { SpawnContext } from "@open-inspect/shared";
 import type { SessionRow, ArtifactRow, SandboxRow } from "./types";
 import { SessionRepository } from "./repository";
 import { SessionWebSocketManagerImpl, type SessionWebSocketManager } from "./websocket-manager";
@@ -74,6 +73,10 @@ import { SessionMessageQueue } from "./message-queue";
 import { SessionSandboxEventProcessor } from "./sandbox-events";
 import { createSessionInternalRoutes } from "./http/routes";
 import { createMessagesHandler, type MessagesHandler } from "./http/handlers/messages.handler";
+import {
+  createChildSessionsHandler,
+  type ChildSessionsHandler,
+} from "./http/handlers/child-sessions.handler";
 import { MessageService } from "./services/message.service";
 
 /**
@@ -117,6 +120,8 @@ export class SessionDO extends DurableObject<Env> {
   private _messageService: MessageService | null = null;
   // Messages handler (lazily initialized)
   private _messagesHandler: MessagesHandler | null = null;
+  // Child sessions handler (lazily initialized)
+  private _childSessionsHandler: ChildSessionsHandler | null = null;
   // Sandbox event processor (lazily initialized)
   private _sandboxEventProcessor: SessionSandboxEventProcessor | null = null;
 
@@ -138,10 +143,10 @@ export class SessionDO extends DurableObject<Env> {
     unarchive: (request) => this.handleUnarchive(request),
     verifySandboxToken: (request) => this.handleVerifySandboxToken(request),
     openaiTokenRefresh: () => this.handleOpenAITokenRefresh(),
-    spawnContext: () => this.handleGetSpawnContext(),
-    childSummary: () => this.handleGetChildSummary(),
+    spawnContext: () => this.childSessionsHandler.getSpawnContext(),
+    childSummary: () => this.childSessionsHandler.getChildSummary(),
     cancel: () => this.handleCancel(),
-    childSessionUpdate: (request) => this.handleChildSessionUpdate(request),
+    childSessionUpdate: (request) => this.childSessionsHandler.childSessionUpdate(request),
   });
 
   constructor(ctx: DurableObjectState, env: Env) {
@@ -314,6 +319,20 @@ export class SessionDO extends DurableObject<Env> {
     }
 
     return this._messagesHandler;
+  }
+
+  private get childSessionsHandler(): ChildSessionsHandler {
+    if (!this._childSessionsHandler) {
+      this._childSessionsHandler = createChildSessionsHandler({
+        repository: this.repository,
+        getSession: () => this.getSession(),
+        getSandbox: () => this.getSandbox(),
+        getPublicSessionId: (session) => this.getPublicSessionId(session),
+        broadcast: (message) => this.broadcast(message),
+      });
+    }
+
+    return this._childSessionsHandler;
   }
 
   private get sandboxEventProcessor(): SessionSandboxEventProcessor {
@@ -1962,103 +1981,6 @@ export class SessionDO extends DurableObject<Env> {
     await this.transitionSessionStatus("active");
 
     return Response.json({ status: "active" });
-  }
-
-  // --- Sub-session (child) internal handlers ---
-
-  private handleGetSpawnContext(): Response {
-    const session = this.getSession();
-    if (!session) {
-      return Response.json({ error: "Session not found" }, { status: 404 });
-    }
-
-    const participants = this.repository.listParticipants();
-    const owner = participants.find((p) => p.role === "owner");
-    if (!owner) {
-      return Response.json({ error: "No owner participant found" }, { status: 404 });
-    }
-
-    const context: SpawnContext = {
-      repoOwner: session.repo_owner,
-      repoName: session.repo_name,
-      repoId: session.repo_id,
-      model: session.model,
-      reasoningEffort: session.reasoning_effort ?? null,
-      owner: {
-        userId: owner.user_id,
-        scmLogin: owner.scm_login,
-        scmName: owner.scm_name,
-        scmEmail: owner.scm_email,
-        scmAccessTokenEncrypted: owner.scm_access_token_encrypted,
-        scmRefreshTokenEncrypted: owner.scm_refresh_token_encrypted,
-        scmTokenExpiresAt: owner.scm_token_expires_at,
-      },
-    };
-
-    return Response.json(context);
-  }
-
-  private handleGetChildSummary(): Response {
-    const session = this.getSession();
-    if (!session) {
-      return Response.json({ error: "Session not found" }, { status: 404 });
-    }
-
-    const sandbox = this.getSandbox();
-    const artifacts = this.repository.listArtifacts();
-    const allEvents = this.repository.listEvents({ limit: 50 });
-
-    // Filter out noisy event types, take first 5
-    const filteredTypes = new Set(["token", "heartbeat", "step_start", "step_finish"]);
-    const recentEvents = allEvents.filter((e) => !filteredTypes.has(e.type)).slice(0, 5);
-
-    const detail = {
-      session: {
-        id: this.getPublicSessionId(session),
-        title: session.title ?? "",
-        status: session.status,
-        repoOwner: session.repo_owner,
-        repoName: session.repo_name,
-        branchName: session.branch_name,
-        model: session.model,
-        createdAt: session.created_at,
-        updatedAt: session.updated_at,
-      },
-      sandbox: sandbox ? { status: sandbox.status } : null,
-      artifacts: artifacts.map((a) => ({
-        type: a.type,
-        url: a.url ?? "",
-        metadata: a.metadata ? JSON.parse(a.metadata) : null,
-      })),
-      recentEvents: recentEvents.map((e) => ({
-        type: e.type,
-        data: JSON.parse(e.data),
-        createdAt: e.created_at,
-      })),
-    };
-
-    return Response.json(detail);
-  }
-
-  private async handleChildSessionUpdate(request: Request): Promise<Response> {
-    const body = (await request.json()) as {
-      childSessionId: string;
-      status: SessionStatus;
-      title: string | null;
-    };
-
-    if (!body.childSessionId || !body.status) {
-      return Response.json({ error: "childSessionId and status are required" }, { status: 400 });
-    }
-
-    this.broadcast({
-      type: "child_session_update",
-      childSessionId: body.childSessionId,
-      status: body.status,
-      title: body.title ?? null,
-    });
-
-    return Response.json({ ok: true });
   }
 
   private async handleCancel(): Promise<Response> {

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it, vi } from "vitest";
+import { createChildSessionsHandler } from "./child-sessions.handler";
+import type { ArtifactRow, EventRow, ParticipantRow, SandboxRow, SessionRow } from "../../types";
+
+function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
+  return {
+    id: "session-1",
+    session_name: null,
+    title: "Session Title",
+    repo_owner: "acme",
+    repo_name: "repo",
+    repo_id: 123,
+    base_branch: "main",
+    branch_name: "feature/test",
+    base_sha: null,
+    current_sha: null,
+    opencode_session_id: null,
+    model: "anthropic/claude-haiku-4-5",
+    reasoning_effort: null,
+    status: "active",
+    parent_session_id: null,
+    spawn_source: "user",
+    spawn_depth: 0,
+    created_at: 1000,
+    updated_at: 2000,
+    ...overrides,
+  };
+}
+
+function createParticipant(overrides: Partial<ParticipantRow> = {}): ParticipantRow {
+  return {
+    id: "participant-1",
+    user_id: "user-1",
+    scm_user_id: null,
+    scm_login: "octocat",
+    scm_email: "octocat@example.com",
+    scm_name: "The Octocat",
+    role: "owner",
+    scm_access_token_encrypted: "enc-access",
+    scm_refresh_token_encrypted: "enc-refresh",
+    scm_token_expires_at: 1234,
+    ws_auth_token: null,
+    ws_token_created_at: null,
+    joined_at: 1,
+    ...overrides,
+  };
+}
+
+function createSandbox(overrides: Partial<SandboxRow> = {}): SandboxRow {
+  return {
+    id: "sandbox-1",
+    modal_sandbox_id: null,
+    modal_object_id: null,
+    snapshot_id: null,
+    snapshot_image_id: null,
+    auth_token: null,
+    auth_token_hash: null,
+    status: "running",
+    git_sync_status: "pending",
+    last_heartbeat: null,
+    last_activity: null,
+    last_spawn_error: null,
+    last_spawn_error_at: null,
+    created_at: 1,
+    ...overrides,
+  };
+}
+
+function createArtifact(overrides: Partial<ArtifactRow> = {}): ArtifactRow {
+  return {
+    id: "artifact-1",
+    type: "pr",
+    url: "https://example.com/pr/1",
+    metadata: null,
+    created_at: 1,
+    ...overrides,
+  };
+}
+
+function createEvent(overrides: Partial<EventRow> = {}): EventRow {
+  return {
+    id: "event-1",
+    type: "error",
+    data: '{"message":"boom"}',
+    message_id: null,
+    created_at: 1,
+    ...overrides,
+  };
+}
+
+function createHandler() {
+  const repository = {
+    listParticipants: vi.fn(),
+    listArtifacts: vi.fn(),
+    listEvents: vi.fn(),
+  };
+  const getSession = vi.fn<() => SessionRow | null>();
+  const getSandbox = vi.fn<() => SandboxRow | null>();
+  const getPublicSessionId = vi.fn<(session: SessionRow) => string>();
+  const broadcast = vi.fn();
+
+  const handler = createChildSessionsHandler({
+    repository,
+    getSession,
+    getSandbox,
+    getPublicSessionId,
+    broadcast,
+  });
+
+  return {
+    handler,
+    repository,
+    getSession,
+    getSandbox,
+    getPublicSessionId,
+    broadcast,
+  };
+}
+
+describe("createChildSessionsHandler", () => {
+  it("returns 404 when session is missing for spawn context", async () => {
+    const { handler, getSession } = createHandler();
+    getSession.mockReturnValue(null);
+
+    const response = handler.getSpawnContext();
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Session not found" });
+  });
+
+  it("returns 404 when owner participant is missing", async () => {
+    const { handler, getSession, repository } = createHandler();
+    getSession.mockReturnValue(createSession());
+    repository.listParticipants.mockReturnValue([createParticipant({ role: "member" })]);
+
+    const response = handler.getSpawnContext();
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "No owner participant found" });
+  });
+
+  it("maps spawn context from session and owner participant", async () => {
+    const { handler, getSession, repository } = createHandler();
+    getSession.mockReturnValue(createSession({ reasoning_effort: "high" }));
+    repository.listParticipants.mockReturnValue([createParticipant()]);
+
+    const response = handler.getSpawnContext();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      repoOwner: "acme",
+      repoName: "repo",
+      repoId: 123,
+      model: "anthropic/claude-haiku-4-5",
+      reasoningEffort: "high",
+      owner: {
+        userId: "user-1",
+        scmLogin: "octocat",
+        scmName: "The Octocat",
+        scmEmail: "octocat@example.com",
+        scmAccessTokenEncrypted: "enc-access",
+        scmRefreshTokenEncrypted: "enc-refresh",
+        scmTokenExpiresAt: 1234,
+      },
+    });
+  });
+
+  it("returns 404 when session is missing for child summary", async () => {
+    const { handler, getSession } = createHandler();
+    getSession.mockReturnValue(null);
+
+    const response = handler.getChildSummary();
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Session not found" });
+  });
+
+  it("maps child summary and filters noisy events", async () => {
+    const { handler, getSession, getSandbox, getPublicSessionId, repository } = createHandler();
+    getSession.mockReturnValue(createSession());
+    getSandbox.mockReturnValue(createSandbox());
+    getPublicSessionId.mockReturnValue("public-session-1");
+
+    repository.listArtifacts.mockReturnValue([
+      createArtifact({ type: "pr", metadata: '{"number":42}' }),
+      createArtifact({ type: "preview", metadata: null }),
+    ]);
+    repository.listEvents.mockReturnValue([
+      createEvent({ id: "e1", type: "token", data: '{"token":"x"}', created_at: 9 }),
+      createEvent({ id: "e2", type: "error", data: '{"message":"boom"}', created_at: 8 }),
+      createEvent({ id: "e3", type: "heartbeat", data: '{"ok":true}', created_at: 7 }),
+      createEvent({ id: "e4", type: "git_sync", data: '{"state":"done"}', created_at: 6 }),
+      createEvent({ id: "e5", type: "push_error", data: '{"code":"denied"}', created_at: 5 }),
+      createEvent({ id: "e6", type: "step_start", data: '{"step":1}', created_at: 4 }),
+      createEvent({ id: "e7", type: "user_message", data: '{"text":"hi"}', created_at: 3 }),
+      createEvent({ id: "e8", type: "tool_call", data: '{"name":"ls"}', created_at: 2 }),
+      createEvent({
+        id: "e9",
+        type: "execution_complete",
+        data: '{"status":"success"}',
+        created_at: 1,
+      }),
+    ]);
+
+    const response = handler.getChildSummary();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      session: {
+        id: "public-session-1",
+        title: "Session Title",
+        status: "active",
+        repoOwner: "acme",
+        repoName: "repo",
+        branchName: "feature/test",
+        model: "anthropic/claude-haiku-4-5",
+        createdAt: 1000,
+        updatedAt: 2000,
+      },
+      sandbox: { status: "running" },
+      artifacts: [
+        {
+          type: "pr",
+          url: "https://example.com/pr/1",
+          metadata: { number: 42 },
+        },
+        {
+          type: "preview",
+          url: "https://example.com/pr/1",
+          metadata: null,
+        },
+      ],
+      recentEvents: [
+        { type: "error", data: { message: "boom" }, createdAt: 8 },
+        { type: "git_sync", data: { state: "done" }, createdAt: 6 },
+        { type: "push_error", data: { code: "denied" }, createdAt: 5 },
+        { type: "user_message", data: { text: "hi" }, createdAt: 3 },
+        { type: "tool_call", data: { name: "ls" }, createdAt: 2 },
+      ],
+    });
+    expect(repository.listEvents).toHaveBeenCalledWith({ limit: 50 });
+  });
+
+  it("returns 400 when child session update body is missing required fields", async () => {
+    const { handler, broadcast } = createHandler();
+
+    const response = await handler.childSessionUpdate(
+      new Request("http://internal/internal/child-session/update", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ childSessionId: "child-1" }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "childSessionId and status are required" });
+    expect(broadcast).not.toHaveBeenCalled();
+  });
+
+  it("broadcasts child session update when payload is valid", async () => {
+    const { handler, broadcast } = createHandler();
+
+    const response = await handler.childSessionUpdate(
+      new Request("http://internal/internal/child-session/update", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          childSessionId: "child-1",
+          status: "completed",
+          title: "Child title",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(broadcast).toHaveBeenCalledWith({
+      type: "child_session_update",
+      childSessionId: "child-1",
+      status: "completed",
+      title: "Child title",
+    });
+  });
+});

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
@@ -1,0 +1,120 @@
+import type { SpawnContext } from "@open-inspect/shared";
+import type { SessionStatus } from "../../../types";
+import type { SessionRepository } from "../../repository";
+import type { SandboxRow, SessionRow } from "../../types";
+
+export interface ChildSessionsHandlerDeps {
+  repository: Pick<SessionRepository, "listParticipants" | "listArtifacts" | "listEvents">;
+  getSession: () => SessionRow | null;
+  getSandbox: () => SandboxRow | null;
+  getPublicSessionId: (session: SessionRow) => string;
+  broadcast: (message: {
+    type: "child_session_update";
+    childSessionId: string;
+    status: SessionStatus;
+    title: string | null;
+  }) => void;
+}
+
+export interface ChildSessionsHandler {
+  getSpawnContext: () => Response;
+  getChildSummary: () => Response;
+  childSessionUpdate: (request: Request) => Promise<Response>;
+}
+
+export function createChildSessionsHandler(deps: ChildSessionsHandlerDeps): ChildSessionsHandler {
+  return {
+    getSpawnContext(): Response {
+      const session = deps.getSession();
+      if (!session) {
+        return Response.json({ error: "Session not found" }, { status: 404 });
+      }
+
+      const participants = deps.repository.listParticipants();
+      const owner = participants.find((participant) => participant.role === "owner");
+      if (!owner) {
+        return Response.json({ error: "No owner participant found" }, { status: 404 });
+      }
+
+      const context: SpawnContext = {
+        repoOwner: session.repo_owner,
+        repoName: session.repo_name,
+        repoId: session.repo_id,
+        model: session.model,
+        reasoningEffort: session.reasoning_effort ?? null,
+        owner: {
+          userId: owner.user_id,
+          scmLogin: owner.scm_login,
+          scmName: owner.scm_name,
+          scmEmail: owner.scm_email,
+          scmAccessTokenEncrypted: owner.scm_access_token_encrypted,
+          scmRefreshTokenEncrypted: owner.scm_refresh_token_encrypted,
+          scmTokenExpiresAt: owner.scm_token_expires_at,
+        },
+      };
+
+      return Response.json(context);
+    },
+
+    getChildSummary(): Response {
+      const session = deps.getSession();
+      if (!session) {
+        return Response.json({ error: "Session not found" }, { status: 404 });
+      }
+
+      const sandbox = deps.getSandbox();
+      const artifacts = deps.repository.listArtifacts();
+      const allEvents = deps.repository.listEvents({ limit: 50 });
+
+      // Filter out noisy event types and keep the most recent five.
+      const filteredTypes = new Set(["token", "heartbeat", "step_start", "step_finish"]);
+      const recentEvents = allEvents.filter((event) => !filteredTypes.has(event.type)).slice(0, 5);
+
+      return Response.json({
+        session: {
+          id: deps.getPublicSessionId(session),
+          title: session.title ?? "",
+          status: session.status,
+          repoOwner: session.repo_owner,
+          repoName: session.repo_name,
+          branchName: session.branch_name,
+          model: session.model,
+          createdAt: session.created_at,
+          updatedAt: session.updated_at,
+        },
+        sandbox: sandbox ? { status: sandbox.status } : null,
+        artifacts: artifacts.map((artifact) => ({
+          type: artifact.type,
+          url: artifact.url ?? "",
+          metadata: artifact.metadata ? JSON.parse(artifact.metadata) : null,
+        })),
+        recentEvents: recentEvents.map((event) => ({
+          type: event.type,
+          data: JSON.parse(event.data),
+          createdAt: event.created_at,
+        })),
+      });
+    },
+
+    async childSessionUpdate(request: Request): Promise<Response> {
+      const body = (await request.json()) as {
+        childSessionId: string;
+        status: SessionStatus;
+        title: string | null;
+      };
+
+      if (!body.childSessionId || !body.status) {
+        return Response.json({ error: "childSessionId and status are required" }, { status: 400 });
+      }
+
+      deps.broadcast({
+        type: "child_session_update",
+        childSessionId: body.childSessionId,
+        status: body.status,
+        title: body.title ?? null,
+      });
+
+      return Response.json({ ok: true });
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- extract child-session HTTP transport logic into `packages/control-plane/src/session/http/handlers/child-sessions.handler.ts`
- wire `SessionDO` routes for `spawnContext`, `childSummary`, and `childSessionUpdate` to the new handler
- preserve existing response shapes/validation behavior while slimming `SessionDO`
- add focused unit tests for handler behavior parity

## Testing
- `npm test -w @open-inspect/control-plane -- src/session/http/handlers/child-sessions.handler.test.ts src/session/http/handlers/messages.handler.test.ts src/session/http/routes.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`