### PR TITLE
feat: add GPT 5.4 to supported model lists

### DIFF
--- a/docs/OPENAI_MODELS.md
+++ b/docs/OPENAI_MODELS.md
@@ -12,6 +12,7 @@ how to configure your deployment to use them.
 | Model         | Description                    |
 | ------------- | ------------------------------ |
 | GPT 5.2       | Fast baseline model (400K ctx) |
+| GPT 5.4       | Latest flagship model          |
 | GPT 5.2 Codex | Optimized for code tasks       |
 | GPT 5.3 Codex | Latest codex variant           |
 

--- a/packages/control-plane/src/utils/models.test.ts
+++ b/packages/control-plane/src/utils/models.test.ts
@@ -35,6 +35,7 @@ describe("model utilities", () => {
 
     it("returns true for OpenAI models", () => {
       expect(isValidModel("openai/gpt-5.2")).toBe(true);
+      expect(isValidModel("openai/gpt-5.4")).toBe(true);
       expect(isValidModel("openai/gpt-5.2-codex")).toBe(true);
       expect(isValidModel("openai/gpt-5.3-codex")).toBe(true);
       expect(isValidModel("openai/gpt-5.3-codex-spark")).toBe(true);
@@ -92,6 +93,11 @@ describe("model utilities", () => {
       expect(extractProviderAndModel("openai/gpt-5.2")).toEqual({
         provider: "openai",
         model: "gpt-5.2",
+      });
+
+      expect(extractProviderAndModel("openai/gpt-5.4")).toEqual({
+        provider: "openai",
+        model: "gpt-5.4",
       });
 
       expect(extractProviderAndModel("openai/gpt-5.2-codex")).toEqual({
@@ -229,6 +235,7 @@ describe("model utilities", () => {
 
     it("returns true for OpenAI models with reasoning config", () => {
       expect(supportsReasoning("openai/gpt-5.2")).toBe(true);
+      expect(supportsReasoning("openai/gpt-5.4")).toBe(true);
       expect(supportsReasoning("openai/gpt-5.2-codex")).toBe(true);
       expect(supportsReasoning("openai/gpt-5.3-codex")).toBe(true);
       expect(supportsReasoning("openai/gpt-5.3-codex-spark")).toBe(true);
@@ -262,8 +269,9 @@ describe("model utilities", () => {
       expect(getDefaultReasoningEffort("openai/gpt-5.3-codex-spark")).toBe("high");
     });
 
-    it("returns undefined for GPT 5.2 (no default)", () => {
+    it("returns undefined for GPT 5.2 and GPT 5.4 (no default)", () => {
       expect(getDefaultReasoningEffort("openai/gpt-5.2")).toBeUndefined();
+      expect(getDefaultReasoningEffort("openai/gpt-5.4")).toBeUndefined();
     });
 
     it("returns undefined for invalid models", () => {
@@ -305,6 +313,14 @@ describe("model utilities", () => {
 
     it("returns config for GPT 5.2 with none effort", () => {
       const config = getReasoningConfig("openai/gpt-5.2");
+      expect(config).toEqual({
+        efforts: ["none", "low", "medium", "high", "xhigh"],
+        default: undefined,
+      });
+    });
+
+    it("returns config for GPT 5.4 with none effort", () => {
+      const config = getReasoningConfig("openai/gpt-5.4");
       expect(config).toEqual({
         efforts: ["none", "low", "medium", "high", "xhigh"],
         default: undefined,
@@ -355,10 +371,12 @@ describe("model utilities", () => {
       expect(isValidReasoningEffort("openai/gpt-5.3-codex", "max")).toBe(false);
       expect(isValidReasoningEffort("openai/gpt-5.3-codex-spark", "max")).toBe(false);
       expect(isValidReasoningEffort("openai/gpt-5.2", "max")).toBe(false);
+      expect(isValidReasoningEffort("openai/gpt-5.4", "max")).toBe(false);
     });
 
-    it("returns true for none on GPT 5.2 only", () => {
+    it("returns true for none on GPT 5.x baseline models", () => {
       expect(isValidReasoningEffort("openai/gpt-5.2", "none")).toBe(true);
+      expect(isValidReasoningEffort("openai/gpt-5.4", "none")).toBe(true);
       expect(isValidReasoningEffort("openai/gpt-5.2-codex", "none")).toBe(false);
     });
 
@@ -389,6 +407,7 @@ describe("model utilities", () => {
 
     it("passes through OpenAI models unchanged", () => {
       expect(normalizeModelId("openai/gpt-5.2")).toBe("openai/gpt-5.2");
+      expect(normalizeModelId("openai/gpt-5.4")).toBe("openai/gpt-5.4");
       expect(normalizeModelId("openai/gpt-5.2-codex")).toBe("openai/gpt-5.2-codex");
       expect(normalizeModelId("openai/gpt-5.3-codex")).toBe("openai/gpt-5.3-codex");
       expect(normalizeModelId("openai/gpt-5.3-codex-spark")).toBe("openai/gpt-5.3-codex-spark");

--- a/packages/linear-bot/README.md
+++ b/packages/linear-bot/README.md
@@ -126,7 +126,7 @@ On any Linear issue:
 - Assign the issue to `OpenInspect` → agent picks it up
 - Agent status is visible directly in Linear (thinking, working, done)
 - Add a `model:<name>` label to override the model (e.g., `model:opus`, `model:sonnet`,
-  `model:haiku`, `model:gpt-5.2-codex`)
+  `model:haiku`, `model:gpt-5.4`, `model:gpt-5.2-codex`)
 
 ## Repo Resolution
 

--- a/packages/linear-bot/src/__tests__/pure-functions.test.ts
+++ b/packages/linear-bot/src/__tests__/pure-functions.test.ts
@@ -18,6 +18,10 @@ describe("extractModelFromLabels", () => {
     expect(extractModelFromLabels([{ name: "Model:Sonnet" }])).toBe("anthropic/claude-sonnet-4-5");
   });
 
+  it("returns GPT 5.4 for model:gpt-5.4 label", () => {
+    expect(extractModelFromLabels([{ name: "model:gpt-5.4" }])).toBe("openai/gpt-5.4");
+  });
+
   it("returns null for unknown model label", () => {
     expect(extractModelFromLabels([{ name: "model:unknown-model" }])).toBeNull();
   });

--- a/packages/linear-bot/src/model-resolution.ts
+++ b/packages/linear-bot/src/model-resolution.ts
@@ -34,6 +34,7 @@ const MODEL_LABEL_MAP: Record<string, string> = {
   opus: "anthropic/claude-opus-4-5",
   "opus-4-6": "anthropic/claude-opus-4-6",
   "gpt-5.2": "openai/gpt-5.2",
+  "gpt-5.4": "openai/gpt-5.4",
   "gpt-5.2-codex": "openai/gpt-5.2-codex",
   "gpt-5.3-codex": "openai/gpt-5.3-codex",
 };

--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -23,8 +23,8 @@ SANDBOX_DIR = Path(__file__).parent.parent / "sandbox"
 OPENCODE_VERSION = "latest"
 
 # Cache buster - change this to force Modal image rebuild
-# v39: Install gh CLI for agent-direct GitHub interaction
-CACHE_BUSTER = "v39-gh-cli"
+# v40: Pull latest OpenCode with GPT-5.4 codex allowlist support
+CACHE_BUSTER = "v40-gpt-5-4"
 
 # Base image with all development tools
 base_image = (

--- a/packages/modal-infra/src/sandbox/codex-auth-plugin.ts
+++ b/packages/modal-infra/src/sandbox/codex-auth-plugin.ts
@@ -19,6 +19,7 @@ const ALLOWED_MODELS = new Set([
   "gpt-5.1-codex-max",
   "gpt-5.1-codex-mini",
   "gpt-5.2",
+  "gpt-5.4",
   "gpt-5.2-codex",
   "gpt-5.3-codex",
   "gpt-5.3-codex-spark",

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -16,6 +16,7 @@ export const VALID_MODELS = [
   "anthropic/claude-opus-4-5",
   "anthropic/claude-opus-4-6",
   "openai/gpt-5.2",
+  "openai/gpt-5.4",
   "openai/gpt-5.2-codex",
   "openai/gpt-5.3-codex",
   "openai/gpt-5.3-codex-spark",
@@ -56,6 +57,7 @@ export const MODEL_REASONING_CONFIG: Partial<Record<ValidModel, ModelReasoningCo
   "anthropic/claude-opus-4-5": { efforts: ["high", "max"], default: "max" },
   "anthropic/claude-opus-4-6": { efforts: ["low", "medium", "high", "max"], default: "high" },
   "openai/gpt-5.2": { efforts: ["none", "low", "medium", "high", "xhigh"], default: undefined },
+  "openai/gpt-5.4": { efforts: ["none", "low", "medium", "high", "xhigh"], default: undefined },
   "openai/gpt-5.2-codex": { efforts: ["low", "medium", "high", "xhigh"], default: "high" },
   "openai/gpt-5.3-codex": { efforts: ["low", "medium", "high", "xhigh"], default: "high" },
   "openai/gpt-5.3-codex-spark": { efforts: ["low", "medium", "high", "xhigh"], default: "high" },
@@ -110,6 +112,7 @@ export const MODEL_OPTIONS: ModelCategory[] = [
     category: "OpenAI",
     models: [
       { id: "openai/gpt-5.2", name: "GPT 5.2", description: "400K context, fast" },
+      { id: "openai/gpt-5.4", name: "GPT 5.4", description: "Latest flagship model" },
       { id: "openai/gpt-5.2-codex", name: "GPT 5.2 Codex", description: "Optimized for code" },
       { id: "openai/gpt-5.3-codex", name: "GPT 5.3 Codex", description: "Latest codex" },
       {
@@ -140,6 +143,7 @@ export const DEFAULT_ENABLED_MODELS: ValidModel[] = [
   "anthropic/claude-opus-4-5",
   "anthropic/claude-opus-4-6",
   "openai/gpt-5.2",
+  "openai/gpt-5.4",
   "openai/gpt-5.2-codex",
   "openai/gpt-5.3-codex",
   "openai/gpt-5.3-codex-spark",


### PR DESCRIPTION
## Summary
- Add `openai/gpt-5.4` across shared model configuration so it appears in model selectors, is considered valid, and has baseline GPT-5 reasoning effort support.
- Update Codex auth allowlists in the sandbox plugin so OpenCode can pass through `gpt-5.4` requests without filtering them out.
- Bump the Modal image `CACHE_BUSTER` to force a rebuild and pull a fresh OpenCode install that includes upstream GPT-5.4 Codex support.
- Extend model resolution/tests/docs to include GPT-5.4 (Linear label mapping, control-plane model utility tests, and OpenAI models docs).

## Validation
- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/control-plane -- src/utils/models.test.ts`
- `npm test -w @open-inspect/linear-bot -- src/__tests__/pure-functions.test.ts`

## Research Notes
- Confirmed in OpenCode upstream releases that v1.2.19 added `gpt-5.4` to the Codex allowed models list.
- This change aligns Open-Inspect's allowlists/model registry with that upstream support and ensures new sandbox images pick up an updated OpenCode binary.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/28b1deb342e3119b611e2bdbc1481ba5)*