### PR TITLE
refactor: simplify git sync by extracting shared primitives

### DIFF
--- a/packages/modal-infra/src/sandbox/entrypoint.py
+++ b/packages/modal-infra/src/sandbox/entrypoint.py
@@ -150,7 +150,9 @@ class SandboxSupervisor:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        await proc.communicate()
+        _stdout, stderr = await proc.communicate()
+        if proc.returncode != 0:
+            self.log.warn("git.set_url_failed", exit_code=proc.returncode, stderr=stderr.decode())
 
     async def _fetch_branch(self, branch: str) -> bool:
         """Fetch a branch with an explicit refspec.
@@ -194,6 +196,7 @@ class SandboxSupervisor:
             self.log.warn(
                 "git.checkout_error",
                 stderr=stderr.decode(),
+                exit_code=result.returncode,
                 target_branch=branch,
             )
             return False
@@ -218,8 +221,7 @@ class SandboxSupervisor:
             branch = self.base_branch
             if not await self._fetch_branch(branch):
                 return False
-            await self._checkout_branch(branch)
-            return True
+            return await self._checkout_branch(branch)
         except Exception as e:
             self.log.error("git.update_error", exc=e)
             return False

--- a/packages/modal-infra/tests/test_entrypoint_build_mode.py
+++ b/packages/modal-infra/tests/test_entrypoint_build_mode.py
@@ -508,6 +508,30 @@ class TestUpdateExistingRepo:
 
         assert result is False
 
+    @pytest.mark.asyncio
+    async def test_returns_false_on_checkout_failure(self, base_env, tmp_path):
+        """Should return False when checkout fails."""
+        supervisor = _make_supervisor(base_env)
+        supervisor.repo_path = tmp_path
+
+        async def fake_subprocess(*args, **kwargs):
+            mock_proc = MagicMock()
+            if "checkout" in args:
+                mock_proc.returncode = 1
+                mock_proc.communicate = AsyncMock(return_value=(b"", b"checkout error"))
+            else:
+                mock_proc.returncode = 0
+                mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+            return mock_proc
+
+        with patch(
+            "src.sandbox.entrypoint.asyncio.create_subprocess_exec",
+            side_effect=fake_subprocess,
+        ):
+            result = await supervisor._update_existing_repo()
+
+        assert result is False
+
 
 class TestPerformGitSync:
     """Test perform_git_sync() — clone + update flow."""


### PR DESCRIPTION
## Summary

The three git sync methods (`perform_git_sync`, `_incremental_git_sync`, `_quick_git_fetch`) each contained copy-pasted implementations of the same git operations — set remote URL, fetch with explicit refspec, checkout branch. This PR extracts shared primitives and consolidates the duplicate code paths.

### What changed

**Extracted 4 git primitives:**
- `_clone_repo()` — shallow clone with depth 100
- `_ensure_remote_auth()` — set remote URL with auth credentials
- `_fetch_branch(branch)` — fetch with explicit refspec (handles shallow/single-branch clones)
- `_checkout_branch(branch)` — `git checkout -B <branch> origin/<branch>`

**Unified `_update_existing_repo()`** — replaces both `_quick_git_fetch()` and `_incremental_git_sync()`. These methods had identical core logic (auth → fetch → checkout) with minor differences in error handling and return types. Now a single 15-line method serves both snapshot-restore and repo-image boot paths.

**Simplified `perform_git_sync()`** — reduced from ~135 lines to ~15 lines by composing `_clone_repo` + `_update_existing_repo`.

**Moved `git_sync_complete.set()` to the caller** — previously set inconsistently (sometimes by the method, sometimes by `run()`). Now always set by `run()` after the git sync phase.

### Bug fix included

The old `_quick_git_fetch` had an unreachable update path: when already on the correct branch, it would detect being N commits behind the remote but never actually update to the latest commit. The new `_update_existing_repo` always fetches and checks out to `origin/<branch>`, ensuring snapshot-restored sandboxes pick up new commits.

### Removed dead code

- Redundant plain `git fetch --quiet origin` in the snapshot path (superseded by the explicit refspec fetch)
- `git rev-parse --abbrev-ref HEAD` branch detection (no longer needed — we always fetch+checkout the target)
- `git rev-list --count HEAD..origin/<branch>` informational check (observational only, no behavioral effect)

### Impact

- **Net: -284 lines** (478 deleted, 194 added)
- `entrypoint.py`: 1077 → 875 lines
- Tests: 26 → 24 tests (consolidated 8 redundant tests into 6, added 1 new failure-path test)

## Test plan

- [x] All 277 modal-infra Python tests pass
- [x] ruff lint + format clean