### PR TITLE
refactor: extract ws token handler

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -77,6 +77,7 @@ import {
   type ChildSessionsHandler,
 } from "./http/handlers/child-sessions.handler";
 import { createSandboxHandler, type SandboxHandler } from "./http/handlers/sandbox.handler";
+import { createWsTokenHandler, type WsTokenHandler } from "./http/handlers/ws-token.handler";
 import { MessageService } from "./services/message.service";
 
 /**
@@ -124,6 +125,8 @@ export class SessionDO extends DurableObject<Env> {
   private _childSessionsHandler: ChildSessionsHandler | null = null;
   // Sandbox handler (lazily initialized)
   private _sandboxHandler: SandboxHandler | null = null;
+  // WebSocket token handler (lazily initialized)
+  private _wsTokenHandler: WsTokenHandler | null = null;
   // Sandbox event processor (lazily initialized)
   private _sandboxEventProcessor: SessionSandboxEventProcessor | null = null;
 
@@ -140,7 +143,7 @@ export class SessionDO extends DurableObject<Env> {
     listArtifacts: () => this.messagesHandler.listArtifacts(),
     listMessages: (_request, url) => this.messagesHandler.listMessages(url),
     createPr: (request) => this.handleCreatePR(request),
-    wsToken: (request) => this.handleGenerateWsToken(request),
+    wsToken: (request) => this.wsTokenHandler.generateWsToken(request),
     archive: (request) => this.handleArchive(request),
     unarchive: (request) => this.handleUnarchive(request),
     verifySandboxToken: (request) => this.sandboxHandler.verifySandboxToken(request),
@@ -363,6 +366,21 @@ export class SessionDO extends DurableObject<Env> {
     }
 
     return this._sandboxHandler;
+  }
+
+  private get wsTokenHandler(): WsTokenHandler {
+    if (!this._wsTokenHandler) {
+      this._wsTokenHandler = createWsTokenHandler({
+        repository: this.repository,
+        getParticipantByUserId: (userId) => this.participantService.getByUserId(userId),
+        generateId: (bytes) => generateId(bytes),
+        hashToken: (token) => hashToken(token),
+        now: () => Date.now(),
+        getLog: () => this.log,
+      });
+    }
+
+    return this._wsTokenHandler;
   }
 
   private get sandboxEventProcessor(): SessionSandboxEventProcessor {
@@ -1725,102 +1743,6 @@ export class SessionDO extends DurableObject<Env> {
       });
       return null;
     }
-  }
-
-  /**
-   * Generate a WebSocket authentication token for a participant.
-   *
-   * This endpoint:
-   * 1. Creates or updates a participant record
-   * 2. Generates a 256-bit random token
-   * 3. Stores the SHA-256 hash in the participant record
-   * 4. Optionally stores encrypted SCM token for PR creation
-   * 5. Returns the plain token to the caller
-   */
-  private async handleGenerateWsToken(request: Request): Promise<Response> {
-    const body = (await request.json()) as {
-      userId: string;
-      scmUserId?: string;
-      scmLogin?: string;
-      scmName?: string;
-      scmEmail?: string;
-      scmTokenEncrypted?: string | null; // Encrypted SCM OAuth token for PR creation
-      scmRefreshTokenEncrypted?: string | null; // Encrypted SCM OAuth refresh token
-      scmTokenExpiresAt?: number | null; // Token expiry timestamp in milliseconds
-    };
-
-    if (!body.userId) {
-      return Response.json({ error: "userId is required" }, { status: 400 });
-    }
-
-    const now = Date.now();
-
-    // Check if participant exists
-    let participant = this.participantService.getByUserId(body.userId);
-
-    if (participant) {
-      // Only accept client tokens if they're newer than what we have in the DB.
-      // The server-side refresh may have rotated tokens, and the client could
-      // be sending stale values from an old session cookie.
-      const clientExpiresAt = body.scmTokenExpiresAt ?? null;
-      const dbExpiresAt = participant.scm_token_expires_at;
-      const clientSentAnyToken =
-        body.scmTokenEncrypted != null || body.scmRefreshTokenEncrypted != null;
-
-      const shouldUpdateTokens =
-        clientSentAnyToken &&
-        (dbExpiresAt == null || (clientExpiresAt != null && clientExpiresAt > dbExpiresAt));
-
-      // If we already have a refresh token (server-side refresh may rotate it),
-      // only accept an incoming refresh token when we're also accepting the
-      // access token update, or when we don't have one yet.
-      const shouldUpdateRefreshToken =
-        body.scmRefreshTokenEncrypted != null &&
-        (participant.scm_refresh_token_encrypted == null || shouldUpdateTokens);
-
-      this.repository.updateParticipantCoalesce(participant.id, {
-        scmUserId: body.scmUserId ?? null,
-        scmLogin: body.scmLogin ?? null,
-        scmName: body.scmName ?? null,
-        scmEmail: body.scmEmail ?? null,
-        scmAccessTokenEncrypted: shouldUpdateTokens ? (body.scmTokenEncrypted ?? null) : null,
-        scmRefreshTokenEncrypted: shouldUpdateRefreshToken
-          ? (body.scmRefreshTokenEncrypted ?? null)
-          : null,
-        scmTokenExpiresAt: shouldUpdateTokens ? clientExpiresAt : null,
-      });
-    } else {
-      // Create new participant with optional SCM token
-      const id = generateId();
-      this.repository.createParticipant({
-        id,
-        userId: body.userId,
-        scmUserId: body.scmUserId ?? null,
-        scmLogin: body.scmLogin ?? null,
-        scmName: body.scmName ?? null,
-        scmEmail: body.scmEmail ?? null,
-        scmAccessTokenEncrypted: body.scmTokenEncrypted ?? null,
-        scmRefreshTokenEncrypted: body.scmRefreshTokenEncrypted ?? null,
-        scmTokenExpiresAt: body.scmTokenExpiresAt ?? null,
-        role: "member",
-        joinedAt: now,
-      });
-      participant = this.participantService.getByUserId(body.userId)!;
-    }
-
-    // Generate a new WebSocket token (32 bytes = 256 bits)
-    const plainToken = generateId(32);
-    const tokenHash = await hashToken(plainToken);
-
-    // Store the hash (invalidates any previous token)
-    this.repository.updateParticipantWsToken(participant.id, tokenHash, now);
-
-    this.log.info("Generated WS token", { participant_id: participant.id, user_id: body.userId });
-
-    return Response.json({
-      token: plainToken,
-      participantId: participant.id,
-    });
   }
 
   /**

--- a/packages/control-plane/src/session/http/handlers/ws-token.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/ws-token.handler.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Logger } from "../../../logger";
+import type { ParticipantRow } from "../../types";
+import { createWsTokenHandler } from "./ws-token.handler";
+
+function createParticipant(overrides: Partial<ParticipantRow> = {}): ParticipantRow {
+  return {
+    id: "participant-1",
+    user_id: "user-1",
+    scm_user_id: "scm-user-1",
+    scm_login: "octocat",
+    scm_email: "octocat@example.com",
+    scm_name: "The Octocat",
+    role: "member",
+    scm_access_token_encrypted: "enc-access",
+    scm_refresh_token_encrypted: "enc-refresh",
+    scm_token_expires_at: 1000,
+    ws_auth_token: null,
+    ws_token_created_at: null,
+    joined_at: 1,
+    ...overrides,
+  };
+}
+
+function createHandler() {
+  const repository = {
+    createParticipant: vi.fn(),
+    updateParticipantCoalesce: vi.fn(),
+    updateParticipantWsToken: vi.fn(),
+  };
+
+  const getParticipantByUserId = vi.fn<(userId: string) => ParticipantRow | null>();
+  const generateId = vi
+    .fn<(bytes?: number) => string>()
+    .mockImplementation((bytes?: number) => (bytes === 32 ? "plain-token" : "participant-1"));
+  const hashToken = vi.fn<(token: string) => Promise<string>>().mockResolvedValue("token-hash");
+  const now = vi.fn(() => 1234);
+  const log = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  } as unknown as Logger;
+
+  const handler = createWsTokenHandler({
+    repository,
+    getParticipantByUserId,
+    generateId,
+    hashToken,
+    now,
+    getLog: () => log,
+  });
+
+  return {
+    handler,
+    repository,
+    getParticipantByUserId,
+    generateId,
+    hashToken,
+    now,
+    log,
+  };
+}
+
+describe("createWsTokenHandler", () => {
+  it("returns 400 when userId is missing", async () => {
+    const { handler } = createHandler();
+
+    const response = await handler.generateWsToken(
+      new Request("http://internal/internal/ws-token", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "userId is required" });
+  });
+
+  it("updates an existing participant and issues a new token", async () => {
+    const { handler, repository, getParticipantByUserId, hashToken, log } = createHandler();
+    const participant = createParticipant({ scm_token_expires_at: 1000 });
+    getParticipantByUserId.mockReturnValue(participant);
+
+    const response = await handler.generateWsToken(
+      new Request("http://internal/internal/ws-token", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          userId: "user-1",
+          scmUserId: "scm-user-1",
+          scmLogin: "octocat-updated",
+          scmName: "Updated Octocat",
+          scmEmail: "updated@example.com",
+          scmTokenEncrypted: "enc-access-new",
+          scmRefreshTokenEncrypted: "enc-refresh-new",
+          scmTokenExpiresAt: 2000,
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      token: "plain-token",
+      participantId: "participant-1",
+    });
+    expect(repository.updateParticipantCoalesce).toHaveBeenCalledWith("participant-1", {
+      scmUserId: "scm-user-1",
+      scmLogin: "octocat-updated",
+      scmName: "Updated Octocat",
+      scmEmail: "updated@example.com",
+      scmAccessTokenEncrypted: "enc-access-new",
+      scmRefreshTokenEncrypted: "enc-refresh-new",
+      scmTokenExpiresAt: 2000,
+    });
+    expect(hashToken).toHaveBeenCalledWith("plain-token");
+    expect(repository.updateParticipantWsToken).toHaveBeenCalledWith(
+      "participant-1",
+      "token-hash",
+      1234
+    );
+    expect(log.info).toHaveBeenCalledWith("Generated WS token", {
+      participant_id: "participant-1",
+      user_id: "user-1",
+    });
+  });
+
+  it("does not overwrite newer existing tokens with stale client values", async () => {
+    const { handler, repository, getParticipantByUserId } = createHandler();
+    const participant = createParticipant({
+      scm_token_expires_at: 5000,
+      scm_refresh_token_encrypted: "server-refresh",
+    });
+    getParticipantByUserId.mockReturnValue(participant);
+
+    const response = await handler.generateWsToken(
+      new Request("http://internal/internal/ws-token", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          userId: "user-1",
+          scmTokenEncrypted: "stale-access",
+          scmRefreshTokenEncrypted: "stale-refresh",
+          scmTokenExpiresAt: 4000,
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(repository.updateParticipantCoalesce).toHaveBeenCalledWith("participant-1", {
+      scmUserId: null,
+      scmLogin: null,
+      scmName: null,
+      scmEmail: null,
+      scmAccessTokenEncrypted: null,
+      scmRefreshTokenEncrypted: null,
+      scmTokenExpiresAt: null,
+    });
+  });
+
+  it("creates a new participant when one does not exist", async () => {
+    const { handler, repository, getParticipantByUserId, generateId } = createHandler();
+    const createdParticipant = createParticipant({ id: "participant-new" });
+    getParticipantByUserId.mockReturnValueOnce(null).mockReturnValueOnce(createdParticipant);
+    generateId.mockReturnValueOnce("participant-new").mockReturnValueOnce("plain-token");
+
+    const response = await handler.generateWsToken(
+      new Request("http://internal/internal/ws-token", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          userId: "user-1",
+          scmUserId: "scm-user-1",
+          scmLogin: "octocat",
+          scmName: "The Octocat",
+          scmEmail: "octocat@example.com",
+          scmTokenEncrypted: "enc-access",
+          scmRefreshTokenEncrypted: "enc-refresh",
+          scmTokenExpiresAt: 2000,
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      token: "plain-token",
+      participantId: "participant-new",
+    });
+    expect(repository.createParticipant).toHaveBeenCalledWith({
+      id: "participant-new",
+      userId: "user-1",
+      scmUserId: "scm-user-1",
+      scmLogin: "octocat",
+      scmName: "The Octocat",
+      scmEmail: "octocat@example.com",
+      scmAccessTokenEncrypted: "enc-access",
+      scmRefreshTokenEncrypted: "enc-refresh",
+      scmTokenExpiresAt: 2000,
+      role: "member",
+      joinedAt: 1234,
+    });
+    expect(repository.updateParticipantWsToken).toHaveBeenCalledWith(
+      "participant-new",
+      "token-hash",
+      1234
+    );
+    expect(getParticipantByUserId).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/control-plane/src/session/http/handlers/ws-token.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/ws-token.handler.ts
@@ -1,0 +1,107 @@
+import type { Logger } from "../../../logger";
+import type { SessionRepository } from "../../repository";
+import type { ParticipantRow } from "../../types";
+
+interface GenerateWsTokenRequest {
+  userId: string;
+  scmUserId?: string;
+  scmLogin?: string;
+  scmName?: string;
+  scmEmail?: string;
+  scmTokenEncrypted?: string | null;
+  scmRefreshTokenEncrypted?: string | null;
+  scmTokenExpiresAt?: number | null;
+}
+
+export interface WsTokenHandlerDeps {
+  repository: Pick<
+    SessionRepository,
+    "createParticipant" | "updateParticipantCoalesce" | "updateParticipantWsToken"
+  >;
+  getParticipantByUserId: (userId: string) => ParticipantRow | null;
+  generateId: (bytes?: number) => string;
+  hashToken: (token: string) => Promise<string>;
+  now: () => number;
+  getLog: () => Logger;
+}
+
+export interface WsTokenHandler {
+  generateWsToken: (request: Request) => Promise<Response>;
+}
+
+export function createWsTokenHandler(deps: WsTokenHandlerDeps): WsTokenHandler {
+  return {
+    async generateWsToken(request: Request): Promise<Response> {
+      const body = (await request.json()) as GenerateWsTokenRequest;
+
+      if (!body.userId) {
+        return Response.json({ error: "userId is required" }, { status: 400 });
+      }
+
+      const now = deps.now();
+      let participant = deps.getParticipantByUserId(body.userId);
+
+      if (participant) {
+        // Only accept client tokens if they're newer than what we have in the DB.
+        // The server-side refresh may have rotated tokens, and the client could
+        // be sending stale values from an old session cookie.
+        const clientExpiresAt = body.scmTokenExpiresAt ?? null;
+        const dbExpiresAt = participant.scm_token_expires_at;
+        const clientSentAnyToken =
+          body.scmTokenEncrypted != null || body.scmRefreshTokenEncrypted != null;
+
+        const shouldUpdateTokens =
+          clientSentAnyToken &&
+          (dbExpiresAt == null || (clientExpiresAt != null && clientExpiresAt > dbExpiresAt));
+
+        // If we already have a refresh token (server-side refresh may rotate it),
+        // only accept an incoming refresh token when we're also accepting the
+        // access token update, or when we don't have one yet.
+        const shouldUpdateRefreshToken =
+          body.scmRefreshTokenEncrypted != null &&
+          (participant.scm_refresh_token_encrypted == null || shouldUpdateTokens);
+
+        deps.repository.updateParticipantCoalesce(participant.id, {
+          scmUserId: body.scmUserId ?? null,
+          scmLogin: body.scmLogin ?? null,
+          scmName: body.scmName ?? null,
+          scmEmail: body.scmEmail ?? null,
+          scmAccessTokenEncrypted: shouldUpdateTokens ? (body.scmTokenEncrypted ?? null) : null,
+          scmRefreshTokenEncrypted: shouldUpdateRefreshToken
+            ? (body.scmRefreshTokenEncrypted ?? null)
+            : null,
+          scmTokenExpiresAt: shouldUpdateTokens ? clientExpiresAt : null,
+        });
+      } else {
+        const id = deps.generateId();
+        deps.repository.createParticipant({
+          id,
+          userId: body.userId,
+          scmUserId: body.scmUserId ?? null,
+          scmLogin: body.scmLogin ?? null,
+          scmName: body.scmName ?? null,
+          scmEmail: body.scmEmail ?? null,
+          scmAccessTokenEncrypted: body.scmTokenEncrypted ?? null,
+          scmRefreshTokenEncrypted: body.scmRefreshTokenEncrypted ?? null,
+          scmTokenExpiresAt: body.scmTokenExpiresAt ?? null,
+          role: "member",
+          joinedAt: now,
+        });
+        participant = deps.getParticipantByUserId(body.userId)!;
+      }
+
+      const plainToken = deps.generateId(32);
+      const tokenHash = await deps.hashToken(plainToken);
+
+      deps.repository.updateParticipantWsToken(participant.id, tokenHash, now);
+      deps
+        .getLog()
+        .info("Generated WS token", { participant_id: participant.id, user_id: body.userId });
+
+      return Response.json({
+        token: plainToken,
+        participantId: participant.id,
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- extract WebSocket token endpoint transport logic into `packages/control-plane/src/session/http/handlers/ws-token.handler.ts`
- wire `SessionDO` route/getter to the new handler for `SessionInternalPaths.wsToken`
- keep existing token coalescing and issuance behavior unchanged
- add focused unit tests for existing-participant and new-participant flows

## Testing
- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/control-plane -- src/session/http/handlers/ws-token.handler.test.ts src/session/http/handlers/sandbox.handler.test.ts src/session/http/handlers/child-sessions.handler.test.ts src/session/http/handlers/messages.handler.test.ts src/session/http/routes.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
