### PR TITLE
refactor: extract session lifecycle handler

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -78,6 +78,10 @@ import {
 } from "./http/handlers/child-sessions.handler";
 import { createSandboxHandler, type SandboxHandler } from "./http/handlers/sandbox.handler";
 import { createWsTokenHandler, type WsTokenHandler } from "./http/handlers/ws-token.handler";
+import {
+  createSessionLifecycleHandler,
+  type SessionLifecycleHandler,
+} from "./http/handlers/session-lifecycle.handler";
 import { MessageService } from "./services/message.service";
 
 /**
@@ -94,9 +98,6 @@ const WS_AUTH_TIMEOUT_MS = 30000; // 30 seconds
  * the client to fetch a fresh token on reconnect.
  */
 const WS_TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
-
-/** Statuses that indicate a session has reached a final state and cannot be cancelled. */
-const TERMINAL_STATUSES = new Set(["completed", "archived", "cancelled", "failed"]);
 
 export class SessionDO extends DurableObject<Env> {
   private sql: SqlStorage;
@@ -127,13 +128,15 @@ export class SessionDO extends DurableObject<Env> {
   private _sandboxHandler: SandboxHandler | null = null;
   // WebSocket token handler (lazily initialized)
   private _wsTokenHandler: WsTokenHandler | null = null;
+  // Session lifecycle handler (lazily initialized)
+  private _sessionLifecycleHandler: SessionLifecycleHandler | null = null;
   // Sandbox event processor (lazily initialized)
   private _sandboxEventProcessor: SessionSandboxEventProcessor | null = null;
 
   // Internal HTTP route table (transport wiring only; handlers remain on SessionDO).
   private readonly routes = createSessionInternalRoutes({
     init: (request) => this.handleInit(request),
-    state: () => this.handleGetState(),
+    state: () => this.sessionLifecycleHandler.getState(),
     prompt: (request) => this.messagesHandler.enqueuePrompt(request),
     stop: () => this.messagesHandler.stop(),
     sandboxEvent: (request) => this.sandboxHandler.sandboxEvent(request),
@@ -144,13 +147,13 @@ export class SessionDO extends DurableObject<Env> {
     listMessages: (_request, url) => this.messagesHandler.listMessages(url),
     createPr: (request) => this.handleCreatePR(request),
     wsToken: (request) => this.wsTokenHandler.generateWsToken(request),
-    archive: (request) => this.handleArchive(request),
-    unarchive: (request) => this.handleUnarchive(request),
+    archive: (request) => this.sessionLifecycleHandler.archive(request),
+    unarchive: (request) => this.sessionLifecycleHandler.unarchive(request),
     verifySandboxToken: (request) => this.sandboxHandler.verifySandboxToken(request),
     openaiTokenRefresh: () => this.sandboxHandler.openaiTokenRefresh(),
     spawnContext: () => this.childSessionsHandler.getSpawnContext(),
     childSummary: () => this.childSessionsHandler.getChildSummary(),
-    cancel: () => this.handleCancel(),
+    cancel: () => this.sessionLifecycleHandler.cancel(),
     childSessionUpdate: (request) => this.childSessionsHandler.childSessionUpdate(request),
   });
 
@@ -381,6 +384,24 @@ export class SessionDO extends DurableObject<Env> {
     }
 
     return this._wsTokenHandler;
+  }
+
+  private get sessionLifecycleHandler(): SessionLifecycleHandler {
+    if (!this._sessionLifecycleHandler) {
+      this._sessionLifecycleHandler = createSessionLifecycleHandler({
+        getSession: () => this.getSession(),
+        getSandbox: () => this.getSandbox(),
+        getPublicSessionId: (session) => this.getPublicSessionId(session),
+        getParticipantByUserId: (userId) => this.participantService.getByUserId(userId),
+        transitionSessionStatus: (status) => this.transitionSessionStatus(status),
+        stopExecution: (options) => this.stopExecution(options),
+        getSandboxSocket: () => this.wsManager.getSandboxSocket(),
+        sendToSandbox: (ws, message) => this.wsManager.send(ws, message),
+        updateSandboxStatus: (status) => this.updateSandboxStatus(status),
+      });
+    }
+
+    return this._sessionLifecycleHandler;
   }
 
   private get sandboxEventProcessor(): SessionSandboxEventProcessor {
@@ -1609,41 +1630,6 @@ export class SessionDO extends DurableObject<Env> {
     return Response.json({ sessionId, status: "created" });
   }
 
-  private handleGetState(): Response {
-    const session = this.getSession();
-    if (!session) {
-      return new Response("Session not found", { status: 404 });
-    }
-
-    const sandbox = this.getSandbox();
-
-    return Response.json({
-      id: this.getPublicSessionId(session),
-      title: session.title,
-      repoOwner: session.repo_owner,
-      repoName: session.repo_name,
-      baseBranch: session.base_branch,
-      branchName: session.branch_name,
-      baseSha: session.base_sha,
-      currentSha: session.current_sha,
-      opencodeSessionId: session.opencode_session_id,
-      status: session.status,
-      model: session.model,
-      reasoningEffort: session.reasoning_effort ?? undefined,
-      createdAt: session.created_at,
-      updatedAt: session.updated_at,
-      sandbox: sandbox
-        ? {
-            id: sandbox.id,
-            modalSandboxId: sandbox.modal_sandbox_id,
-            status: sandbox.status,
-            gitSyncStatus: sandbox.git_sync_status,
-            lastHeartbeat: sandbox.last_heartbeat,
-          }
-        : null,
-    });
-  }
-
   private handleListParticipants(): Response {
     const participants = this.repository.listParticipants();
 
@@ -1743,97 +1729,5 @@ export class SessionDO extends DurableObject<Env> {
       });
       return null;
     }
-  }
-
-  /**
-   * Handle archive session request.
-   * Only session participants are authorized to archive.
-   */
-  private async handleArchive(request: Request): Promise<Response> {
-    const session = this.getSession();
-    if (!session) {
-      return Response.json({ error: "Session not found" }, { status: 404 });
-    }
-
-    // Verify user is a participant (fail closed)
-    let body: { userId?: string };
-    try {
-      body = (await request.json()) as { userId?: string };
-    } catch {
-      return Response.json({ error: "Invalid request body" }, { status: 400 });
-    }
-
-    if (!body.userId) {
-      return Response.json({ error: "userId is required" }, { status: 400 });
-    }
-
-    const participant = this.participantService.getByUserId(body.userId);
-    if (!participant) {
-      return Response.json({ error: "Not authorized to archive this session" }, { status: 403 });
-    }
-
-    await this.transitionSessionStatus("archived");
-
-    return Response.json({ status: "archived" });
-  }
-
-  /**
-   * Handle unarchive session request.
-   * Only session participants are authorized to unarchive.
-   */
-  private async handleUnarchive(request: Request): Promise<Response> {
-    const session = this.getSession();
-    if (!session) {
-      return Response.json({ error: "Session not found" }, { status: 404 });
-    }
-
-    // Verify user is a participant (fail closed)
-    let body: { userId?: string };
-    try {
-      body = (await request.json()) as { userId?: string };
-    } catch {
-      return Response.json({ error: "Invalid request body" }, { status: 400 });
-    }
-
-    if (!body.userId) {
-      return Response.json({ error: "userId is required" }, { status: 400 });
-    }
-
-    const participant = this.participantService.getByUserId(body.userId);
-    if (!participant) {
-      return Response.json({ error: "Not authorized to unarchive this session" }, { status: 403 });
-    }
-
-    await this.transitionSessionStatus("active");
-
-    return Response.json({ status: "active" });
-  }
-
-  private async handleCancel(): Promise<Response> {
-    const session = this.getSession();
-    if (!session) {
-      return Response.json({ error: "Session not found" }, { status: 404 });
-    }
-
-    if (TERMINAL_STATUSES.has(session.status)) {
-      return Response.json({ error: `Session already ${session.status}` }, { status: 409 });
-    }
-
-    // Stop any in-flight message processing without emitting intermediate "failed".
-    await this.stopExecution({ suppressStatusReconcile: true });
-
-    await this.transitionSessionStatus("cancelled");
-
-    // Stop sandbox if running
-    const sandbox = this.getSandbox();
-    if (sandbox && sandbox.status !== "stopped" && sandbox.status !== "failed") {
-      const sandboxWs = this.wsManager.getSandboxSocket();
-      if (sandboxWs) {
-        this.wsManager.send(sandboxWs, { type: "shutdown" });
-      }
-      this.updateSandboxStatus("stopped");
-    }
-
-    return Response.json({ status: "cancelled" });
   }
 }

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ParticipantRow, SandboxRow, SessionRow } from "../../types";
+import { createSessionLifecycleHandler } from "./session-lifecycle.handler";
+
+function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
+  return {
+    id: "session-1",
+    session_name: "public-session-1",
+    title: "Session title",
+    repo_owner: "acme",
+    repo_name: "repo",
+    repo_id: 1,
+    base_branch: "main",
+    branch_name: "feature/test",
+    base_sha: "base-sha",
+    current_sha: "head-sha",
+    opencode_session_id: "oc-1",
+    model: "anthropic/claude-haiku-4-5",
+    reasoning_effort: "high",
+    status: "active",
+    parent_session_id: null,
+    spawn_source: "user",
+    spawn_depth: 0,
+    created_at: 1000,
+    updated_at: 2000,
+    ...overrides,
+  };
+}
+
+function createSandbox(overrides: Partial<SandboxRow> = {}): SandboxRow {
+  return {
+    id: "sandbox-1",
+    modal_sandbox_id: "modal-1",
+    modal_object_id: null,
+    snapshot_id: null,
+    snapshot_image_id: null,
+    auth_token: null,
+    auth_token_hash: null,
+    status: "running",
+    git_sync_status: "pending",
+    last_heartbeat: 999,
+    last_activity: null,
+    last_spawn_error: null,
+    last_spawn_error_at: null,
+    created_at: 1,
+    ...overrides,
+  };
+}
+
+function createParticipant(overrides: Partial<ParticipantRow> = {}): ParticipantRow {
+  return {
+    id: "participant-1",
+    user_id: "user-1",
+    scm_user_id: null,
+    scm_login: "octocat",
+    scm_email: "octocat@example.com",
+    scm_name: "The Octocat",
+    role: "member",
+    scm_access_token_encrypted: null,
+    scm_refresh_token_encrypted: null,
+    scm_token_expires_at: null,
+    ws_auth_token: null,
+    ws_token_created_at: null,
+    joined_at: 1,
+    ...overrides,
+  };
+}
+
+function createHandler() {
+  const getSession = vi.fn<() => SessionRow | null>();
+  const getSandbox = vi.fn<() => SandboxRow | null>();
+  const getPublicSessionId = vi.fn<(session: SessionRow) => string>();
+  const getParticipantByUserId = vi.fn<(userId: string) => ParticipantRow | null>();
+  const transitionSessionStatus = vi.fn<(status: SessionRow["status"]) => Promise<boolean>>();
+  const stopExecution = vi.fn();
+  const getSandboxSocket = vi.fn<() => WebSocket | null>();
+  const sendToSandbox = vi.fn();
+  const updateSandboxStatus = vi.fn();
+
+  const handler = createSessionLifecycleHandler({
+    getSession,
+    getSandbox,
+    getPublicSessionId,
+    getParticipantByUserId,
+    transitionSessionStatus,
+    stopExecution,
+    getSandboxSocket,
+    sendToSandbox,
+    updateSandboxStatus,
+  });
+
+  return {
+    handler,
+    getSession,
+    getSandbox,
+    getPublicSessionId,
+    getParticipantByUserId,
+    transitionSessionStatus,
+    stopExecution,
+    getSandboxSocket,
+    sendToSandbox,
+    updateSandboxStatus,
+  };
+}
+
+describe("createSessionLifecycleHandler", () => {
+  it("returns 404 state response when session is missing", async () => {
+    const { handler, getSession } = createHandler();
+    getSession.mockReturnValue(null);
+
+    const response = handler.getState();
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe("Session not found");
+  });
+
+  it("maps state response with sandbox details", async () => {
+    const { handler, getSession, getSandbox, getPublicSessionId } = createHandler();
+    getSession.mockReturnValue(createSession());
+    getSandbox.mockReturnValue(createSandbox());
+    getPublicSessionId.mockReturnValue("public-session-1");
+
+    const response = handler.getState();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      id: "public-session-1",
+      title: "Session title",
+      repoOwner: "acme",
+      repoName: "repo",
+      baseBranch: "main",
+      branchName: "feature/test",
+      baseSha: "base-sha",
+      currentSha: "head-sha",
+      opencodeSessionId: "oc-1",
+      status: "active",
+      model: "anthropic/claude-haiku-4-5",
+      reasoningEffort: "high",
+      createdAt: 1000,
+      updatedAt: 2000,
+      sandbox: {
+        id: "sandbox-1",
+        modalSandboxId: "modal-1",
+        status: "running",
+        gitSyncStatus: "pending",
+        lastHeartbeat: 999,
+      },
+    });
+  });
+
+  it("returns 400 for invalid archive body", async () => {
+    const { handler, getSession } = createHandler();
+    getSession.mockReturnValue(createSession());
+
+    const response = await handler.archive(
+      new Request("http://internal/internal/archive", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{invalid",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid request body" });
+  });
+
+  it("returns 403 when archive user is not a participant", async () => {
+    const { handler, getSession, getParticipantByUserId } = createHandler();
+    getSession.mockReturnValue(createSession());
+    getParticipantByUserId.mockReturnValue(null);
+
+    const response = await handler.archive(
+      new Request("http://internal/internal/archive", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ userId: "user-1" }),
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "Not authorized to archive this session" });
+  });
+
+  it("archives successfully for participant", async () => {
+    const { handler, getSession, getParticipantByUserId, transitionSessionStatus } =
+      createHandler();
+    getSession.mockReturnValue(createSession());
+    getParticipantByUserId.mockReturnValue(createParticipant());
+    transitionSessionStatus.mockResolvedValue(true);
+
+    const response = await handler.archive(
+      new Request("http://internal/internal/archive", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ userId: "user-1" }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: "archived" });
+    expect(transitionSessionStatus).toHaveBeenCalledWith("archived");
+  });
+
+  it("unarchives successfully for participant", async () => {
+    const { handler, getSession, getParticipantByUserId, transitionSessionStatus } =
+      createHandler();
+    getSession.mockReturnValue(createSession({ status: "archived" }));
+    getParticipantByUserId.mockReturnValue(createParticipant());
+    transitionSessionStatus.mockResolvedValue(true);
+
+    const response = await handler.unarchive(
+      new Request("http://internal/internal/unarchive", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ userId: "user-1" }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: "active" });
+    expect(transitionSessionStatus).toHaveBeenCalledWith("active");
+  });
+
+  it("returns 409 when cancelling terminal session", async () => {
+    const { handler, getSession } = createHandler();
+    getSession.mockReturnValue(createSession({ status: "completed" }));
+
+    const response = await handler.cancel();
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ error: "Session already completed" });
+  });
+
+  it("cancels and shuts down running sandbox", async () => {
+    const {
+      handler,
+      getSession,
+      getSandbox,
+      stopExecution,
+      transitionSessionStatus,
+      getSandboxSocket,
+      sendToSandbox,
+      updateSandboxStatus,
+    } = createHandler();
+    const ws = {} as WebSocket;
+    getSession.mockReturnValue(createSession({ status: "active" }));
+    getSandbox.mockReturnValue(createSandbox({ status: "running" }));
+    stopExecution.mockResolvedValue(undefined);
+    transitionSessionStatus.mockResolvedValue(true);
+    getSandboxSocket.mockReturnValue(ws);
+
+    const response = await handler.cancel();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: "cancelled" });
+    expect(stopExecution).toHaveBeenCalledWith({ suppressStatusReconcile: true });
+    expect(transitionSessionStatus).toHaveBeenCalledWith("cancelled");
+    expect(sendToSandbox).toHaveBeenCalledWith(ws, { type: "shutdown" });
+    expect(updateSandboxStatus).toHaveBeenCalledWith("stopped");
+  });
+});

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
@@ -1,0 +1,150 @@
+import type { ParticipantRow, SandboxRow, SessionRow } from "../../types";
+import type { SandboxStatus, SessionStatus } from "../../../types";
+
+const TERMINAL_STATUSES = new Set<SessionStatus>(["completed", "archived", "cancelled", "failed"]);
+
+export interface SessionLifecycleHandlerDeps {
+  getSession: () => SessionRow | null;
+  getSandbox: () => SandboxRow | null;
+  getPublicSessionId: (session: SessionRow) => string;
+  getParticipantByUserId: (userId: string) => ParticipantRow | null;
+  transitionSessionStatus: (status: SessionStatus) => Promise<boolean>;
+  stopExecution: (options?: { suppressStatusReconcile?: boolean }) => Promise<void>;
+  getSandboxSocket: () => WebSocket | null;
+  sendToSandbox: (ws: WebSocket, message: string | object) => boolean;
+  updateSandboxStatus: (status: SandboxStatus) => void;
+}
+
+export interface SessionLifecycleHandler {
+  getState: () => Response;
+  archive: (request: Request) => Promise<Response>;
+  unarchive: (request: Request) => Promise<Response>;
+  cancel: () => Promise<Response>;
+}
+
+function parseUserIdBody(body: unknown): { userId?: string } {
+  return body as { userId?: string };
+}
+
+export function createSessionLifecycleHandler(
+  deps: SessionLifecycleHandlerDeps
+): SessionLifecycleHandler {
+  return {
+    getState(): Response {
+      const session = deps.getSession();
+      if (!session) {
+        return new Response("Session not found", { status: 404 });
+      }
+
+      const sandbox = deps.getSandbox();
+
+      return Response.json({
+        id: deps.getPublicSessionId(session),
+        title: session.title,
+        repoOwner: session.repo_owner,
+        repoName: session.repo_name,
+        baseBranch: session.base_branch,
+        branchName: session.branch_name,
+        baseSha: session.base_sha,
+        currentSha: session.current_sha,
+        opencodeSessionId: session.opencode_session_id,
+        status: session.status,
+        model: session.model,
+        reasoningEffort: session.reasoning_effort ?? undefined,
+        createdAt: session.created_at,
+        updatedAt: session.updated_at,
+        sandbox: sandbox
+          ? {
+              id: sandbox.id,
+              modalSandboxId: sandbox.modal_sandbox_id,
+              status: sandbox.status,
+              gitSyncStatus: sandbox.git_sync_status,
+              lastHeartbeat: sandbox.last_heartbeat,
+            }
+          : null,
+      });
+    },
+
+    async archive(request: Request): Promise<Response> {
+      const session = deps.getSession();
+      if (!session) {
+        return Response.json({ error: "Session not found" }, { status: 404 });
+      }
+
+      let body: { userId?: string };
+      try {
+        body = parseUserIdBody(await request.json());
+      } catch {
+        return Response.json({ error: "Invalid request body" }, { status: 400 });
+      }
+
+      if (!body.userId) {
+        return Response.json({ error: "userId is required" }, { status: 400 });
+      }
+
+      const participant = deps.getParticipantByUserId(body.userId);
+      if (!participant) {
+        return Response.json({ error: "Not authorized to archive this session" }, { status: 403 });
+      }
+
+      await deps.transitionSessionStatus("archived");
+
+      return Response.json({ status: "archived" });
+    },
+
+    async unarchive(request: Request): Promise<Response> {
+      const session = deps.getSession();
+      if (!session) {
+        return Response.json({ error: "Session not found" }, { status: 404 });
+      }
+
+      let body: { userId?: string };
+      try {
+        body = parseUserIdBody(await request.json());
+      } catch {
+        return Response.json({ error: "Invalid request body" }, { status: 400 });
+      }
+
+      if (!body.userId) {
+        return Response.json({ error: "userId is required" }, { status: 400 });
+      }
+
+      const participant = deps.getParticipantByUserId(body.userId);
+      if (!participant) {
+        return Response.json(
+          { error: "Not authorized to unarchive this session" },
+          { status: 403 }
+        );
+      }
+
+      await deps.transitionSessionStatus("active");
+
+      return Response.json({ status: "active" });
+    },
+
+    async cancel(): Promise<Response> {
+      const session = deps.getSession();
+      if (!session) {
+        return Response.json({ error: "Session not found" }, { status: 404 });
+      }
+
+      if (TERMINAL_STATUSES.has(session.status)) {
+        return Response.json({ error: `Session already ${session.status}` }, { status: 409 });
+      }
+
+      await deps.stopExecution({ suppressStatusReconcile: true });
+      await deps.transitionSessionStatus("cancelled");
+
+      const sandbox = deps.getSandbox();
+      if (sandbox && sandbox.status !== "stopped" && sandbox.status !== "failed") {
+        const sandboxWs = deps.getSandboxSocket();
+        if (sandboxWs) {
+          deps.sendToSandbox(sandboxWs, { type: "shutdown" });
+        }
+        deps.updateSandboxStatus("stopped");
+      }
+
+      return Response.json({ status: "cancelled" });
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- extract session lifecycle transport handlers into `packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts`
- move route wiring for `state`, `archive`, `unarchive`, and `cancel` to the new lifecycle handler
- preserve existing behavior for participant checks, status transitions, and cancel shutdown semantics
- add focused unit tests for lifecycle handler behavior parity

## Testing
- `npm test -w @open-inspect/control-plane -- src/session/http/handlers/session-lifecycle.handler.test.ts src/session/http/handlers/ws-token.handler.test.ts src/session/http/handlers/sandbox.handler.test.ts src/session/http/handlers/child-sessions.handler.test.ts src/session/http/handlers/messages.handler.test.ts src/session/http/routes.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
