### PR TITLE
refactor: extract pull request handler

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -82,6 +82,10 @@ import {
   createSessionLifecycleHandler,
   type SessionLifecycleHandler,
 } from "./http/handlers/session-lifecycle.handler";
+import {
+  createPullRequestHandler,
+  type PullRequestHandler,
+} from "./http/handlers/pull-request.handler";
 import { MessageService } from "./services/message.service";
 
 /**
@@ -130,6 +134,8 @@ export class SessionDO extends DurableObject<Env> {
   private _wsTokenHandler: WsTokenHandler | null = null;
   // Session lifecycle handler (lazily initialized)
   private _sessionLifecycleHandler: SessionLifecycleHandler | null = null;
+  // Pull request handler (lazily initialized)
+  private _pullRequestHandler: PullRequestHandler | null = null;
   // Sandbox event processor (lazily initialized)
   private _sandboxEventProcessor: SessionSandboxEventProcessor | null = null;
 
@@ -145,7 +151,7 @@ export class SessionDO extends DurableObject<Env> {
     listEvents: (_request, url) => this.messagesHandler.listEvents(url),
     listArtifacts: () => this.messagesHandler.listArtifacts(),
     listMessages: (_request, url) => this.messagesHandler.listMessages(url),
-    createPr: (request) => this.handleCreatePR(request),
+    createPr: (request) => this.pullRequestHandler.createPr(request),
     wsToken: (request) => this.wsTokenHandler.generateWsToken(request),
     archive: (request) => this.sessionLifecycleHandler.archive(request),
     unarchive: (request) => this.sessionLifecycleHandler.unarchive(request),
@@ -402,6 +408,41 @@ export class SessionDO extends DurableObject<Env> {
     }
 
     return this._sessionLifecycleHandler;
+  }
+
+  private get pullRequestHandler(): PullRequestHandler {
+    if (!this._pullRequestHandler) {
+      this._pullRequestHandler = createPullRequestHandler({
+        getSession: () => this.getSession(),
+        getPromptingParticipantForPR: () => this.participantService.getPromptingParticipantForPR(),
+        resolveAuthForPR: (participant) => this.participantService.resolveAuthForPR(participant),
+        getSessionUrl: (session) => {
+          const sessionId = session.session_name || session.id;
+          const webAppUrl = this.env.WEB_APP_URL || this.env.WORKER_URL || "";
+          return webAppUrl + "/session/" + sessionId;
+        },
+        createPullRequest: async (input) => {
+          const pullRequestService = new SessionPullRequestService({
+            repository: this.repository,
+            sourceControlProvider: this.sourceControlProvider,
+            log: this.log,
+            generateId: () => generateId(),
+            pushBranchToRemote: (headBranch, pushSpec) =>
+              this.pushBranchToRemote(headBranch, pushSpec),
+            broadcastArtifactCreated: (artifact) => {
+              this.broadcast({
+                type: "artifact_created",
+                artifact,
+              });
+            },
+          });
+
+          return pullRequestService.createPullRequest(input);
+        },
+      });
+    }
+
+    return this._pullRequestHandler;
   }
 
   private get sandboxEventProcessor(): SessionSandboxEventProcessor {
@@ -1642,74 +1683,6 @@ export class SessionDO extends DurableObject<Env> {
         role: p.role,
         joinedAt: p.joined_at,
       })),
-    });
-  }
-
-  /**
-   * Handle PR creation request.
-   * Resolves prompting participant and auth in DO, then delegates PR orchestration.
-   */
-  private async handleCreatePR(request: Request): Promise<Response> {
-    const body = (await request.json()) as {
-      title: string;
-      body: string;
-      baseBranch?: string;
-      headBranch?: string;
-    };
-
-    const session = this.getSession();
-    if (!session) {
-      return Response.json({ error: "Session not found" }, { status: 404 });
-    }
-
-    const promptingParticipantResult = await this.participantService.getPromptingParticipantForPR();
-    if (!promptingParticipantResult.participant) {
-      return Response.json(
-        { error: promptingParticipantResult.error },
-        { status: promptingParticipantResult.status }
-      );
-    }
-
-    const promptingParticipant = promptingParticipantResult.participant;
-    const authResolution = await this.participantService.resolveAuthForPR(promptingParticipant);
-    if ("error" in authResolution) {
-      return Response.json({ error: authResolution.error }, { status: authResolution.status });
-    }
-
-    const sessionId = session.session_name || session.id;
-    const webAppUrl = this.env.WEB_APP_URL || this.env.WORKER_URL || "";
-    const sessionUrl = webAppUrl + "/session/" + sessionId;
-
-    const pullRequestService = new SessionPullRequestService({
-      repository: this.repository,
-      sourceControlProvider: this.sourceControlProvider,
-      log: this.log,
-      generateId: () => generateId(),
-      pushBranchToRemote: (headBranch, pushSpec) => this.pushBranchToRemote(headBranch, pushSpec),
-      broadcastArtifactCreated: (artifact) => {
-        this.broadcast({
-          type: "artifact_created",
-          artifact,
-        });
-      },
-    });
-
-    const result = await pullRequestService.createPullRequest({
-      ...body,
-      baseBranch: body.baseBranch || session.base_branch,
-      promptingUserId: promptingParticipant.user_id,
-      promptingAuth: authResolution.auth,
-      sessionUrl,
-    });
-
-    if (result.kind === "error") {
-      return Response.json({ error: result.error }, { status: result.status });
-    }
-
-    return Response.json({
-      prNumber: result.prNumber,
-      prUrl: result.prUrl,
-      state: result.state,
     });
   }
 

--- a/packages/control-plane/src/session/http/handlers/pull-request.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/pull-request.handler.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ParticipantRow, SessionRow } from "../../types";
+import { createPullRequestHandler } from "./pull-request.handler";
+
+function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
+  return {
+    id: "session-1",
+    session_name: "public-session-1",
+    title: "Session title",
+    repo_owner: "acme",
+    repo_name: "repo",
+    repo_id: 1,
+    base_branch: "main",
+    branch_name: "feature/test",
+    base_sha: null,
+    current_sha: null,
+    opencode_session_id: null,
+    model: "anthropic/claude-haiku-4-5",
+    reasoning_effort: null,
+    status: "active",
+    parent_session_id: null,
+    spawn_source: "user",
+    spawn_depth: 0,
+    created_at: 1000,
+    updated_at: 2000,
+    ...overrides,
+  };
+}
+
+function createParticipant(overrides: Partial<ParticipantRow> = {}): ParticipantRow {
+  return {
+    id: "participant-1",
+    user_id: "user-1",
+    scm_user_id: "scm-user-1",
+    scm_login: "octocat",
+    scm_email: "octocat@example.com",
+    scm_name: "The Octocat",
+    role: "member",
+    scm_access_token_encrypted: "enc-access",
+    scm_refresh_token_encrypted: "enc-refresh",
+    scm_token_expires_at: 1234,
+    ws_auth_token: null,
+    ws_token_created_at: null,
+    joined_at: 1,
+    ...overrides,
+  };
+}
+
+function createHandler() {
+  const getSession = vi.fn<() => SessionRow | null>();
+  const getPromptingParticipantForPR = vi.fn();
+  const resolveAuthForPR = vi.fn();
+  const getSessionUrl = vi.fn();
+  const createPullRequest = vi.fn();
+
+  const handler = createPullRequestHandler({
+    getSession,
+    getPromptingParticipantForPR,
+    resolveAuthForPR,
+    getSessionUrl,
+    createPullRequest,
+  });
+
+  return {
+    handler,
+    getSession,
+    getPromptingParticipantForPR,
+    resolveAuthForPR,
+    getSessionUrl,
+    createPullRequest,
+  };
+}
+
+describe("createPullRequestHandler", () => {
+  it("returns 404 when session is missing", async () => {
+    const { handler, getSession } = createHandler();
+    getSession.mockReturnValue(null);
+
+    const response = await handler.createPr(
+      new Request("http://internal/internal/create-pr", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title: "PR", body: "desc" }),
+      })
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Session not found" });
+  });
+
+  it("returns prompting participant error payload", async () => {
+    const { handler, getSession, getPromptingParticipantForPR } = createHandler();
+    getSession.mockReturnValue(createSession());
+    getPromptingParticipantForPR.mockResolvedValue({
+      error: "No active prompt found",
+      status: 400,
+    });
+
+    const response = await handler.createPr(
+      new Request("http://internal/internal/create-pr", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title: "PR", body: "desc" }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "No active prompt found" });
+  });
+
+  it("returns auth resolution error payload", async () => {
+    const { handler, getSession, getPromptingParticipantForPR, resolveAuthForPR } = createHandler();
+    const participant = createParticipant();
+    getSession.mockReturnValue(createSession());
+    getPromptingParticipantForPR.mockResolvedValue({ participant });
+    resolveAuthForPR.mockResolvedValue({
+      error: "Token expired",
+      status: 401,
+    });
+
+    const response = await handler.createPr(
+      new Request("http://internal/internal/create-pr", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title: "PR", body: "desc" }),
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({ error: "Token expired" });
+  });
+
+  it("forwards service error and uses session base branch fallback", async () => {
+    const {
+      handler,
+      getSession,
+      getPromptingParticipantForPR,
+      resolveAuthForPR,
+      getSessionUrl,
+      createPullRequest,
+    } = createHandler();
+    const session = createSession({ base_branch: "develop" });
+    const participant = createParticipant({ user_id: "user-123" });
+    getSession.mockReturnValue(session);
+    getPromptingParticipantForPR.mockResolvedValue({ participant });
+    resolveAuthForPR.mockResolvedValue({ auth: { authType: "oauth", token: "token" } });
+    getSessionUrl.mockReturnValue("https://app.example.com/session/public-session-1");
+    createPullRequest.mockResolvedValue({
+      kind: "error",
+      status: 409,
+      error: "PR already exists",
+    });
+
+    const response = await handler.createPr(
+      new Request("http://internal/internal/create-pr", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title: "PR", body: "desc", headBranch: "feature/pr" }),
+      })
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ error: "PR already exists" });
+    expect(createPullRequest).toHaveBeenCalledWith({
+      title: "PR",
+      body: "desc",
+      headBranch: "feature/pr",
+      baseBranch: "develop",
+      promptingUserId: "user-123",
+      promptingAuth: { authType: "oauth", token: "token" },
+      sessionUrl: "https://app.example.com/session/public-session-1",
+    });
+  });
+
+  it("returns mapped success payload", async () => {
+    const {
+      handler,
+      getSession,
+      getPromptingParticipantForPR,
+      resolveAuthForPR,
+      getSessionUrl,
+      createPullRequest,
+    } = createHandler();
+    const session = createSession();
+    const participant = createParticipant();
+    getSession.mockReturnValue(session);
+    getPromptingParticipantForPR.mockResolvedValue({ participant });
+    resolveAuthForPR.mockResolvedValue({ auth: null });
+    getSessionUrl.mockReturnValue("https://app.example.com/session/public-session-1");
+    createPullRequest.mockResolvedValue({
+      kind: "created",
+      prNumber: 42,
+      prUrl: "https://github.com/acme/repo/pull/42",
+      state: "open",
+    });
+
+    const response = await handler.createPr(
+      new Request("http://internal/internal/create-pr", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          title: "PR",
+          body: "desc",
+          baseBranch: "release",
+          headBranch: "feature/pr",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      prNumber: 42,
+      prUrl: "https://github.com/acme/repo/pull/42",
+      state: "open",
+    });
+    expect(createPullRequest).toHaveBeenCalledWith({
+      title: "PR",
+      body: "desc",
+      baseBranch: "release",
+      headBranch: "feature/pr",
+      promptingUserId: "user-1",
+      promptingAuth: null,
+      sessionUrl: "https://app.example.com/session/public-session-1",
+    });
+  });
+});

--- a/packages/control-plane/src/session/http/handlers/pull-request.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/pull-request.handler.ts
@@ -1,0 +1,75 @@
+import type { SourceControlAuthContext } from "../../../source-control";
+import type { CreatePullRequestInput, CreatePullRequestResult } from "../../pull-request-service";
+import type { ParticipantRow, SessionRow } from "../../types";
+
+interface CreatePrRequest {
+  title: string;
+  body: string;
+  baseBranch?: string;
+  headBranch?: string;
+}
+
+type PromptingParticipantResult =
+  | { participant: ParticipantRow; error?: never; status?: never }
+  | { participant?: never; error: string; status: number };
+
+type ResolveAuthForPrResult =
+  | { auth: SourceControlAuthContext | null; error?: never; status?: never }
+  | { auth?: never; error: string; status: number };
+
+export interface PullRequestHandlerDeps {
+  getSession: () => SessionRow | null;
+  getPromptingParticipantForPR: () => Promise<PromptingParticipantResult>;
+  resolveAuthForPR: (participant: ParticipantRow) => Promise<ResolveAuthForPrResult>;
+  getSessionUrl: (session: SessionRow) => string;
+  createPullRequest: (input: CreatePullRequestInput) => Promise<CreatePullRequestResult>;
+}
+
+export interface PullRequestHandler {
+  createPr: (request: Request) => Promise<Response>;
+}
+
+export function createPullRequestHandler(deps: PullRequestHandlerDeps): PullRequestHandler {
+  return {
+    async createPr(request: Request): Promise<Response> {
+      const body = (await request.json()) as CreatePrRequest;
+
+      const session = deps.getSession();
+      if (!session) {
+        return Response.json({ error: "Session not found" }, { status: 404 });
+      }
+
+      const promptingParticipantResult = await deps.getPromptingParticipantForPR();
+      if (!promptingParticipantResult.participant) {
+        return Response.json(
+          { error: promptingParticipantResult.error },
+          { status: promptingParticipantResult.status }
+        );
+      }
+
+      const promptingParticipant = promptingParticipantResult.participant;
+      const authResolution = await deps.resolveAuthForPR(promptingParticipant);
+      if ("error" in authResolution) {
+        return Response.json({ error: authResolution.error }, { status: authResolution.status });
+      }
+
+      const result = await deps.createPullRequest({
+        ...body,
+        baseBranch: body.baseBranch || session.base_branch,
+        promptingUserId: promptingParticipant.user_id,
+        promptingAuth: authResolution.auth,
+        sessionUrl: deps.getSessionUrl(session),
+      });
+
+      if (result.kind === "error") {
+        return Response.json({ error: result.error }, { status: result.status });
+      }
+
+      return Response.json({
+        prNumber: result.prNumber,
+        prUrl: result.prUrl,
+        state: result.state,
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- extract create-PR transport logic into `packages/control-plane/src/session/http/handlers/pull-request.handler.ts`
- wire `SessionDO` route/getter to the new pull-request handler for `SessionInternalPaths.createPr`
- preserve existing participant/auth resolution and PR orchestration behavior
- add focused unit tests covering handler error/success mapping and request translation

## Testing
- `npm test -w @open-inspect/control-plane -- src/session/http/handlers/pull-request.handler.test.ts src/session/http/handlers/session-lifecycle.handler.test.ts src/session/http/handlers/ws-token.handler.test.ts src/session/http/handlers/sandbox.handler.test.ts src/session/http/handlers/child-sessions.handler.test.ts src/session/http/handlers/messages.handler.test.ts src/session/http/routes.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
