### PR TITLE
refactor: extract session init lifecycle handler

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -38,12 +38,7 @@ import {
   type SourceControlProvider,
   type GitPushSpec,
 } from "../source-control";
-import {
-  DEFAULT_MODEL,
-  isValidModel,
-  isValidReasoningEffort,
-  getValidModelOrDefault,
-} from "../utils/models";
+import { DEFAULT_MODEL, isValidReasoningEffort } from "../utils/models";
 import type {
   Env,
   ClientInfo,
@@ -53,7 +48,6 @@ import type {
   SessionState,
   SessionStatus,
   SandboxStatus,
-  SpawnSource,
 } from "../types";
 import type { SessionRow, ArtifactRow, SandboxRow } from "./types";
 import { SessionRepository } from "./repository";
@@ -141,7 +135,7 @@ export class SessionDO extends DurableObject<Env> {
 
   // Internal HTTP route table (transport wiring only; handlers remain on SessionDO).
   private readonly routes = createSessionInternalRoutes({
-    init: (request) => this.handleInit(request),
+    init: (request) => this.sessionLifecycleHandler.init(request),
     state: () => this.sessionLifecycleHandler.getState(),
     prompt: (request) => this.messagesHandler.enqueuePrompt(request),
     stop: () => this.messagesHandler.stop(),
@@ -395,6 +389,18 @@ export class SessionDO extends DurableObject<Env> {
   private get sessionLifecycleHandler(): SessionLifecycleHandler {
     if (!this._sessionLifecycleHandler) {
       this._sessionLifecycleHandler = createSessionLifecycleHandler({
+        repository: this.repository,
+        getDurableObjectId: () => this.ctx.id.toString(),
+        tokenEncryptionKey: this.env.TOKEN_ENCRYPTION_KEY,
+        encryptToken: async (token, encryptionKey) => {
+          const { encryptToken } = await import("../auth/crypto");
+          return encryptToken(token, encryptionKey);
+        },
+        validateReasoningEffort: (model, effort) => this.validateReasoningEffort(model, effort),
+        generateId: (bytes) => generateId(bytes),
+        now: () => Date.now(),
+        scheduleWarmSandbox: () => this.ctx.waitUntil(this.warmSandbox()),
+        getLog: () => this.log,
         getSession: () => this.getSession(),
         getSandbox: () => this.getSandbox(),
         getPublicSessionId: (session) => this.getPublicSessionId(session),
@@ -1566,110 +1572,6 @@ export class SessionDO extends DurableObject<Env> {
   }
 
   // HTTP handlers
-
-  private async handleInit(request: Request): Promise<Response> {
-    const body = (await request.json()) as {
-      sessionName: string; // The name used for WebSocket routing
-      repoOwner: string;
-      repoName: string;
-      repoId?: number;
-      defaultBranch?: string; // Repo's default branch from GitHub
-      branch?: string; // User-selected branch to work on
-      title?: string;
-      model?: string; // LLM model to use
-      reasoningEffort?: string; // Reasoning effort level
-      userId: string;
-      scmLogin?: string;
-      scmName?: string;
-      scmEmail?: string;
-      scmToken?: string | null; // Plain SCM token (will be encrypted)
-      scmTokenEncrypted?: string | null; // Pre-encrypted SCM token
-      parentSessionId?: string | null;
-      spawnSource?: SpawnSource;
-      spawnDepth?: number;
-    };
-
-    const sessionId = this.ctx.id.toString();
-    const sessionName = body.sessionName; // Store the WebSocket routing name
-    const now = Date.now();
-
-    // Encrypt the SCM token if provided in plain text
-    let encryptedToken = body.scmTokenEncrypted ?? null;
-    if (body.scmToken && this.env.TOKEN_ENCRYPTION_KEY) {
-      try {
-        const { encryptToken } = await import("../auth/crypto");
-        encryptedToken = await encryptToken(body.scmToken, this.env.TOKEN_ENCRYPTION_KEY);
-        this.log.debug("Encrypted SCM token for storage");
-      } catch (err) {
-        this.log.error("Failed to encrypt SCM token", {
-          error: err instanceof Error ? err : String(err),
-        });
-      }
-    }
-
-    // Validate and normalize model name if provided
-    const model = getValidModelOrDefault(body.model);
-    if (body.model && !isValidModel(body.model)) {
-      this.log.warn("Invalid model name, using default", {
-        requested_model: body.model,
-        default_model: DEFAULT_MODEL,
-      });
-    }
-
-    // Validate reasoning effort if provided
-    const reasoningEffort = this.validateReasoningEffort(model, body.reasoningEffort);
-
-    // Resolve branch: user-selected branch takes priority, then repo default, then "main"
-    const baseBranch = body.branch || body.defaultBranch || "main";
-
-    // Create session (store both internal ID and external name)
-    this.repository.upsertSession({
-      id: sessionId,
-      sessionName, // Store the session name for WebSocket routing
-      title: body.title ?? null,
-      repoOwner: body.repoOwner,
-      repoName: body.repoName,
-      repoId: body.repoId ?? null,
-      baseBranch,
-      model,
-      reasoningEffort,
-      status: "created",
-      parentSessionId: body.parentSessionId ?? null,
-      spawnSource: body.spawnSource ?? "user",
-      spawnDepth: body.spawnDepth ?? 0,
-      createdAt: now,
-      updatedAt: now,
-    });
-
-    // Create sandbox record
-    // Note: created_at is set to 0 initially so the first spawn isn't blocked by cooldown
-    // It will be updated to the actual spawn time when spawnSandbox() is called
-    const sandboxId = generateId();
-    this.repository.createSandbox({
-      id: sandboxId,
-      status: "pending",
-      gitSyncStatus: "pending",
-      createdAt: 0,
-    });
-
-    // Create owner participant with encrypted SCM token
-    const participantId = generateId();
-    this.repository.createParticipant({
-      id: participantId,
-      userId: body.userId,
-      scmLogin: body.scmLogin ?? null,
-      scmName: body.scmName ?? null,
-      scmEmail: body.scmEmail ?? null,
-      scmAccessTokenEncrypted: encryptedToken,
-      role: "owner",
-      joinedAt: now,
-    });
-
-    this.log.info("Triggering sandbox spawn for new session");
-    this.ctx.waitUntil(this.warmSandbox());
-
-    return Response.json({ sessionId, status: "created" });
-  }
 
   private handleListParticipants(): Response {
     const participants = this.repository.listParticipants();

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ParticipantRow, SandboxRow, SessionRow } from "../../types";
 import { createSessionLifecycleHandler } from "./session-lifecycle.handler";
+import { getValidModelOrDefault } from "../../../utils/models";
 
 function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
   return {
@@ -67,6 +68,24 @@ function createParticipant(overrides: Partial<ParticipantRow> = {}): Participant
 }
 
 function createHandler() {
+  const repository = {
+    upsertSession: vi.fn(),
+    createSandbox: vi.fn(),
+    createParticipant: vi.fn(),
+  };
+  const getDurableObjectId = vi.fn(() => "session-do-id");
+  const encryptToken = vi.fn();
+  const validateReasoningEffort = vi.fn();
+  const generateId = vi.fn();
+  const now = vi.fn(() => 1234);
+  const scheduleWarmSandbox = vi.fn();
+  const log = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  };
   const getSession = vi.fn<() => SessionRow | null>();
   const getSandbox = vi.fn<() => SandboxRow | null>();
   const getPublicSessionId = vi.fn<(session: SessionRow) => string>();
@@ -78,6 +97,15 @@ function createHandler() {
   const updateSandboxStatus = vi.fn();
 
   const handler = createSessionLifecycleHandler({
+    repository,
+    getDurableObjectId,
+    tokenEncryptionKey: "encryption-key",
+    encryptToken,
+    validateReasoningEffort,
+    generateId,
+    now,
+    scheduleWarmSandbox,
+    getLog: () => log,
     getSession,
     getSandbox,
     getPublicSessionId,
@@ -91,6 +119,14 @@ function createHandler() {
 
   return {
     handler,
+    repository,
+    getDurableObjectId,
+    encryptToken,
+    validateReasoningEffort,
+    generateId,
+    now,
+    scheduleWarmSandbox,
+    log,
     getSession,
     getSandbox,
     getPublicSessionId,
@@ -104,6 +140,152 @@ function createHandler() {
 }
 
 describe("createSessionLifecycleHandler", () => {
+  it("initializes session, sandbox, and owner participant", async () => {
+    const {
+      handler,
+      repository,
+      getDurableObjectId,
+      encryptToken,
+      validateReasoningEffort,
+      generateId,
+      scheduleWarmSandbox,
+      log,
+    } = createHandler();
+    getDurableObjectId.mockReturnValue("session-do-id");
+    encryptToken.mockResolvedValue("encrypted-scm-token");
+    validateReasoningEffort.mockReturnValue("high");
+    generateId.mockReturnValueOnce("sandbox-1").mockReturnValueOnce("participant-1");
+
+    const response = await handler.init(
+      new Request("http://internal/internal/init", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          sessionName: "session-public-id",
+          repoOwner: "acme",
+          repoName: "repo",
+          repoId: 123,
+          defaultBranch: "main",
+          branch: "feature/work",
+          title: "Session title",
+          model: "anthropic/claude-haiku-4-5",
+          reasoningEffort: "high",
+          userId: "user-1",
+          scmLogin: "octocat",
+          scmName: "The Octocat",
+          scmEmail: "octocat@example.com",
+          scmToken: "plain-scm-token",
+          parentSessionId: "parent-1",
+          spawnSource: "agent",
+          spawnDepth: 1,
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ sessionId: "session-do-id", status: "created" });
+    expect(repository.upsertSession).toHaveBeenCalledWith({
+      id: "session-do-id",
+      sessionName: "session-public-id",
+      title: "Session title",
+      repoOwner: "acme",
+      repoName: "repo",
+      repoId: 123,
+      baseBranch: "feature/work",
+      model: "anthropic/claude-haiku-4-5",
+      reasoningEffort: "high",
+      status: "created",
+      parentSessionId: "parent-1",
+      spawnSource: "agent",
+      spawnDepth: 1,
+      createdAt: 1234,
+      updatedAt: 1234,
+    });
+    expect(repository.createSandbox).toHaveBeenCalledWith({
+      id: "sandbox-1",
+      status: "pending",
+      gitSyncStatus: "pending",
+      createdAt: 0,
+    });
+    expect(repository.createParticipant).toHaveBeenCalledWith({
+      id: "participant-1",
+      userId: "user-1",
+      scmLogin: "octocat",
+      scmName: "The Octocat",
+      scmEmail: "octocat@example.com",
+      scmAccessTokenEncrypted: "encrypted-scm-token",
+      role: "owner",
+      joinedAt: 1234,
+    });
+    expect(scheduleWarmSandbox).toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith("Triggering sandbox spawn for new session");
+  });
+
+  it("falls back to pre-encrypted token when plain-token encryption fails", async () => {
+    const { handler, repository, encryptToken, validateReasoningEffort, generateId, log } =
+      createHandler();
+    encryptToken.mockRejectedValue(new Error("encrypt failed"));
+    validateReasoningEffort.mockReturnValue(null);
+    generateId.mockReturnValueOnce("sandbox-1").mockReturnValueOnce("participant-1");
+
+    const response = await handler.init(
+      new Request("http://internal/internal/init", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          sessionName: "session-public-id",
+          repoOwner: "acme",
+          repoName: "repo",
+          userId: "user-1",
+          scmToken: "plain-scm-token",
+          scmTokenEncrypted: "existing-encrypted-token",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(repository.createParticipant).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scmAccessTokenEncrypted: "existing-encrypted-token",
+      })
+    );
+    expect(log.error).toHaveBeenCalledWith(
+      "Failed to encrypt SCM token",
+      expect.objectContaining({ error: expect.any(Error) })
+    );
+  });
+
+  it("logs invalid model warning and stores normalized model", async () => {
+    const { handler, repository, validateReasoningEffort, generateId, log } = createHandler();
+    validateReasoningEffort.mockReturnValue(null);
+    generateId.mockReturnValueOnce("sandbox-1").mockReturnValueOnce("participant-1");
+
+    const response = await handler.init(
+      new Request("http://internal/internal/init", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          sessionName: "session-public-id",
+          repoOwner: "acme",
+          repoName: "repo",
+          model: "invalid/model-name",
+          userId: "user-1",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(repository.upsertSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: getValidModelOrDefault("invalid/model-name"),
+      })
+    );
+    expect(log.warn).toHaveBeenCalledWith("Invalid model name, using default", {
+      requested_model: "invalid/model-name",
+      default_model: getValidModelOrDefault("invalid/model-name"),
+    });
+  });
+
   it("returns 404 state response when session is missing", async () => {
     const { handler, getSession } = createHandler();
     getSession.mockReturnValue(null);

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
@@ -1,9 +1,42 @@
+import type { Logger } from "../../../logger";
 import type { ParticipantRow, SandboxRow, SessionRow } from "../../types";
-import type { SandboxStatus, SessionStatus } from "../../../types";
+import type { SandboxStatus, SessionStatus, SpawnSource } from "../../../types";
+import type { SessionRepository } from "../../repository";
+import { getValidModelOrDefault, isValidModel } from "../../../utils/models";
 
 const TERMINAL_STATUSES = new Set<SessionStatus>(["completed", "archived", "cancelled", "failed"]);
 
+interface InitRequest {
+  sessionName: string;
+  repoOwner: string;
+  repoName: string;
+  repoId?: number;
+  defaultBranch?: string;
+  branch?: string;
+  title?: string;
+  model?: string;
+  reasoningEffort?: string;
+  userId: string;
+  scmLogin?: string;
+  scmName?: string;
+  scmEmail?: string;
+  scmToken?: string | null;
+  scmTokenEncrypted?: string | null;
+  parentSessionId?: string | null;
+  spawnSource?: SpawnSource;
+  spawnDepth?: number;
+}
+
 export interface SessionLifecycleHandlerDeps {
+  repository: Pick<SessionRepository, "upsertSession" | "createSandbox" | "createParticipant">;
+  getDurableObjectId: () => string;
+  tokenEncryptionKey?: string;
+  encryptToken: (token: string, encryptionKey: string) => Promise<string>;
+  validateReasoningEffort: (model: string, effort: string | undefined) => string | null;
+  generateId: (bytes?: number) => string;
+  now: () => number;
+  scheduleWarmSandbox: () => void;
+  getLog: () => Logger;
   getSession: () => SessionRow | null;
   getSandbox: () => SandboxRow | null;
   getPublicSessionId: (session: SessionRow) => string;
@@ -16,6 +49,7 @@ export interface SessionLifecycleHandlerDeps {
 }
 
 export interface SessionLifecycleHandler {
+  init: (request: Request) => Promise<Response>;
   getState: () => Response;
   archive: (request: Request) => Promise<Response>;
   unarchive: (request: Request) => Promise<Response>;
@@ -30,6 +64,80 @@ export function createSessionLifecycleHandler(
   deps: SessionLifecycleHandlerDeps
 ): SessionLifecycleHandler {
   return {
+    async init(request: Request): Promise<Response> {
+      const body = (await request.json()) as InitRequest;
+
+      const sessionId = deps.getDurableObjectId();
+      const sessionName = body.sessionName;
+      const now = deps.now();
+
+      let encryptedToken = body.scmTokenEncrypted ?? null;
+      if (body.scmToken && deps.tokenEncryptionKey) {
+        try {
+          encryptedToken = await deps.encryptToken(body.scmToken, deps.tokenEncryptionKey);
+          deps.getLog().debug("Encrypted SCM token for storage");
+        } catch (error) {
+          deps.getLog().error("Failed to encrypt SCM token", {
+            error: error instanceof Error ? error : String(error),
+          });
+        }
+      }
+
+      const model = getValidModelOrDefault(body.model);
+      if (body.model && !isValidModel(body.model)) {
+        deps.getLog().warn("Invalid model name, using default", {
+          requested_model: body.model,
+          default_model: model,
+        });
+      }
+
+      const reasoningEffort = deps.validateReasoningEffort(model, body.reasoningEffort);
+      const baseBranch = body.branch || body.defaultBranch || "main";
+
+      deps.repository.upsertSession({
+        id: sessionId,
+        sessionName,
+        title: body.title ?? null,
+        repoOwner: body.repoOwner,
+        repoName: body.repoName,
+        repoId: body.repoId ?? null,
+        baseBranch,
+        model,
+        reasoningEffort,
+        status: "created",
+        parentSessionId: body.parentSessionId ?? null,
+        spawnSource: body.spawnSource ?? "user",
+        spawnDepth: body.spawnDepth ?? 0,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const sandboxId = deps.generateId();
+      deps.repository.createSandbox({
+        id: sandboxId,
+        status: "pending",
+        gitSyncStatus: "pending",
+        createdAt: 0,
+      });
+
+      const participantId = deps.generateId();
+      deps.repository.createParticipant({
+        id: participantId,
+        userId: body.userId,
+        scmLogin: body.scmLogin ?? null,
+        scmName: body.scmName ?? null,
+        scmEmail: body.scmEmail ?? null,
+        scmAccessTokenEncrypted: encryptedToken,
+        role: "owner",
+        joinedAt: now,
+      });
+
+      deps.getLog().info("Triggering sandbox spawn for new session");
+      deps.scheduleWarmSandbox();
+
+      return Response.json({ sessionId, status: "created" });
+    },
+
     getState(): Response {
       const session = deps.getSession();
       if (!session) {


### PR DESCRIPTION
## Summary
- move the remaining `init` transport logic into `packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts`
- rewire `SessionDO` route wiring to delegate `SessionInternalPaths.init` to the lifecycle handler
- keep behavior parity for token encryption fallback, model normalization/warnings, session + sandbox + owner creation, and warm-sandbox scheduling
- extend lifecycle handler unit tests with focused init-path coverage

## Testing
- `npm test -w @open-inspect/control-plane -- src/session/http/handlers/session-lifecycle.handler.test.ts src/session/http/handlers/pull-request.handler.test.ts src/session/http/handlers/ws-token.handler.test.ts src/session/http/handlers/sandbox.handler.test.ts src/session/http/handlers/child-sessions.handler.test.ts src/session/http/handlers/messages.handler.test.ts src/session/http/routes.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
