### PR TITLE
refactor: extract participants HTTP handler from SessionDO

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -80,6 +80,10 @@ import {
   createPullRequestHandler,
   type PullRequestHandler,
 } from "./http/handlers/pull-request.handler";
+import {
+  createParticipantsHandler,
+  type ParticipantsHandler,
+} from "./http/handlers/participants.handler";
 import { MessageService } from "./services/message.service";
 
 /**
@@ -130,6 +134,8 @@ export class SessionDO extends DurableObject<Env> {
   private _sessionLifecycleHandler: SessionLifecycleHandler | null = null;
   // Pull request handler (lazily initialized)
   private _pullRequestHandler: PullRequestHandler | null = null;
+  // Participants handler (lazily initialized)
+  private _participantsHandler: ParticipantsHandler | null = null;
   // Sandbox event processor (lazily initialized)
   private _sandboxEventProcessor: SessionSandboxEventProcessor | null = null;
 
@@ -140,7 +146,7 @@ export class SessionDO extends DurableObject<Env> {
     prompt: (request) => this.messagesHandler.enqueuePrompt(request),
     stop: () => this.messagesHandler.stop(),
     sandboxEvent: (request) => this.sandboxHandler.sandboxEvent(request),
-    listParticipants: () => this.handleListParticipants(),
+    listParticipants: () => this.participantsHandler.listParticipants(),
     addParticipant: (request) => this.sandboxHandler.addParticipant(request),
     listEvents: (_request, url) => this.messagesHandler.listEvents(url),
     listArtifacts: () => this.messagesHandler.listArtifacts(),
@@ -449,6 +455,16 @@ export class SessionDO extends DurableObject<Env> {
     }
 
     return this._pullRequestHandler;
+  }
+
+  private get participantsHandler(): ParticipantsHandler {
+    if (!this._participantsHandler) {
+      this._participantsHandler = createParticipantsHandler({
+        repository: this.repository,
+      });
+    }
+
+    return this._participantsHandler;
   }
 
   private get sandboxEventProcessor(): SessionSandboxEventProcessor {
@@ -1572,21 +1588,6 @@ export class SessionDO extends DurableObject<Env> {
   }
 
   // HTTP handlers
-
-  private handleListParticipants(): Response {
-    const participants = this.repository.listParticipants();
-
-    return Response.json({
-      participants: participants.map((p) => ({
-        id: p.id,
-        userId: p.user_id,
-        scmLogin: p.scm_login,
-        scmName: p.scm_name,
-        role: p.role,
-        joinedAt: p.joined_at,
-      })),
-    });
-  }
 
   private parseArtifactMetadata(
     artifact: Pick<ArtifactRow, "id" | "metadata">

--- a/packages/control-plane/src/session/http/handlers/participants.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/participants.handler.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ParticipantRow } from "../../types";
+import { createParticipantsHandler } from "./participants.handler";
+
+function createParticipant(overrides: Partial<ParticipantRow> = {}): ParticipantRow {
+  return {
+    id: "participant-1",
+    user_id: "user-1",
+    scm_user_id: null,
+    scm_login: "octocat",
+    scm_email: "octocat@example.com",
+    scm_name: "The Octocat",
+    role: "member",
+    scm_access_token_encrypted: "enc-access",
+    scm_refresh_token_encrypted: "enc-refresh",
+    scm_token_expires_at: 1234,
+    ws_auth_token: null,
+    ws_token_created_at: null,
+    joined_at: 1,
+    ...overrides,
+  };
+}
+
+function createHandler() {
+  const repository = {
+    listParticipants: vi.fn(),
+  };
+
+  const handler = createParticipantsHandler({ repository });
+
+  return {
+    handler,
+    repository,
+  };
+}
+
+describe("createParticipantsHandler", () => {
+  it("returns an empty list when there are no participants", async () => {
+    const { handler, repository } = createHandler();
+    repository.listParticipants.mockReturnValue([]);
+
+    const response = handler.listParticipants();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ participants: [] });
+  });
+
+  it("maps repository participant rows to API response shape", async () => {
+    const { handler, repository } = createHandler();
+    repository.listParticipants.mockReturnValue([
+      createParticipant(),
+      createParticipant({
+        id: "participant-2",
+        user_id: "user-2",
+        scm_login: "hubot",
+        scm_name: "Hubot",
+        role: "owner",
+        joined_at: 2,
+      }),
+    ]);
+
+    const response = handler.listParticipants();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      participants: [
+        {
+          id: "participant-1",
+          userId: "user-1",
+          scmLogin: "octocat",
+          scmName: "The Octocat",
+          role: "member",
+          joinedAt: 1,
+        },
+        {
+          id: "participant-2",
+          userId: "user-2",
+          scmLogin: "hubot",
+          scmName: "Hubot",
+          role: "owner",
+          joinedAt: 2,
+        },
+      ],
+    });
+  });
+});

--- a/packages/control-plane/src/session/http/handlers/participants.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/participants.handler.ts
@@ -1,0 +1,28 @@
+import type { SessionRepository } from "../../repository";
+
+export interface ParticipantsHandlerDeps {
+  repository: Pick<SessionRepository, "listParticipants">;
+}
+
+export interface ParticipantsHandler {
+  listParticipants: () => Response;
+}
+
+export function createParticipantsHandler(deps: ParticipantsHandlerDeps): ParticipantsHandler {
+  return {
+    listParticipants(): Response {
+      const participants = deps.repository.listParticipants();
+
+      return Response.json({
+        participants: participants.map((participant) => ({
+          id: participant.id,
+          userId: participant.user_id,
+          scmLogin: participant.scm_login,
+          scmName: participant.scm_name,
+          role: participant.role,
+          joinedAt: participant.joined_at,
+        })),
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add a dedicated `participants.handler` for the `GET /internal/participants` response mapping
- add focused unit tests for participant list response shaping
- wire `SessionDO` route dispatch through the new handler and remove inline `handleListParticipants`

## Testing
- `npm test -w @open-inspect/control-plane -- src/session/http/handlers/participants.handler.test.ts src/session/http/routes.test.ts src/session/http/handlers/child-sessions.handler.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`