### PR TITLE
refactor: extract alarm handling from SessionDO

### DIFF
--- a/packages/control-plane/src/session/alarm/handler.test.ts
+++ b/packages/control-plane/src/session/alarm/handler.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Logger } from "../../logger";
+import { createAlarmHandler } from "./handler";
+
+function createHandler() {
+  const repository = {
+    getProcessingMessageWithStartedAt: vi.fn(),
+  };
+  const messageQueue = {
+    failStuckProcessingMessage: vi.fn<() => Promise<void>>().mockResolvedValue(),
+  };
+  const lifecycleManager = {
+    handleAlarm: vi.fn<() => Promise<void>>().mockResolvedValue(),
+  };
+  const now = vi.fn(() => 2000);
+  const log = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  } as unknown as Logger;
+
+  const handler = createAlarmHandler({
+    repository,
+    messageQueue,
+    lifecycleManager,
+    executionTimeoutMs: 1000,
+    now,
+    getLog: () => log,
+  });
+
+  return {
+    handler,
+    repository,
+    messageQueue,
+    lifecycleManager,
+    now,
+    log,
+  };
+}
+
+describe("createAlarmHandler", () => {
+  it("delegates to lifecycle manager when no processing message exists", async () => {
+    const { handler, repository, messageQueue, lifecycleManager, now } = createHandler();
+    repository.getProcessingMessageWithStartedAt.mockReturnValue(null);
+
+    await handler.handle();
+
+    expect(now).not.toHaveBeenCalled();
+    expect(messageQueue.failStuckProcessingMessage).not.toHaveBeenCalled();
+    expect(lifecycleManager.handleAlarm).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fail processing message when execution timeout is not reached", async () => {
+    const { handler, repository, messageQueue, lifecycleManager, log } = createHandler();
+    repository.getProcessingMessageWithStartedAt.mockReturnValue({
+      id: "message-1",
+      started_at: 1500,
+    });
+
+    await handler.handle();
+
+    expect(log.warn).not.toHaveBeenCalled();
+    expect(messageQueue.failStuckProcessingMessage).not.toHaveBeenCalled();
+    expect(lifecycleManager.handleAlarm).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails stuck processing message when execution timeout is reached", async () => {
+    const { handler, repository, messageQueue, lifecycleManager, log } = createHandler();
+    repository.getProcessingMessageWithStartedAt.mockReturnValue({
+      id: "message-1",
+      started_at: 500,
+    });
+
+    await handler.handle();
+
+    expect(log.warn).toHaveBeenCalledWith("Execution timeout: message stuck in processing", {
+      event: "execution.timeout",
+      message_id: "message-1",
+      elapsed_ms: 1500,
+      timeout_ms: 1000,
+    });
+    expect(messageQueue.failStuckProcessingMessage).toHaveBeenCalledTimes(1);
+    expect(lifecycleManager.handleAlarm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/control-plane/src/session/alarm/handler.ts
+++ b/packages/control-plane/src/session/alarm/handler.ts
@@ -1,0 +1,55 @@
+import type { Logger } from "../../logger";
+import { evaluateExecutionTimeout } from "../../sandbox/lifecycle/decisions";
+import type { SandboxLifecycleManager } from "../../sandbox/lifecycle/manager";
+import type { SessionMessageQueue } from "../message-queue";
+import type { SessionRepository } from "../repository";
+
+export interface AlarmHandlerDeps {
+  repository: Pick<SessionRepository, "getProcessingMessageWithStartedAt">;
+  messageQueue: Pick<SessionMessageQueue, "failStuckProcessingMessage">;
+  lifecycleManager: Pick<SandboxLifecycleManager, "handleAlarm">;
+  executionTimeoutMs: number;
+  now: () => number;
+  getLog: () => Logger;
+}
+
+export interface AlarmHandler {
+  handle: () => Promise<void>;
+}
+
+/**
+ * Durable Object alarm handler.
+ *
+ * Checks for stuck processing messages (defense-in-depth execution timeout)
+ * before delegating to lifecycle alarm processing.
+ */
+export function createAlarmHandler(deps: AlarmHandlerDeps): AlarmHandler {
+  return {
+    async handle(): Promise<void> {
+      // Execution timeout check: if a message has been in 'processing' longer than
+      // the configured timeout, fail it. This is idempotent - if the message was
+      // already failed (by onSandboxTerminating or a prior alarm),
+      // getProcessingMessageWithStartedAt() returns null.
+      const processing = deps.repository.getProcessingMessageWithStartedAt();
+      if (processing?.started_at) {
+        const now = deps.now();
+        const result = evaluateExecutionTimeout(
+          processing.started_at,
+          { timeoutMs: deps.executionTimeoutMs },
+          now
+        );
+        if (result.isTimedOut) {
+          deps.getLog().warn("Execution timeout: message stuck in processing", {
+            event: "execution.timeout",
+            message_id: processing.id,
+            elapsed_ms: result.elapsedMs,
+            timeout_ms: deps.executionTimeoutMs,
+          });
+          await deps.messageQueue.failStuckProcessingMessage();
+        }
+      }
+
+      await deps.lifecycleManager.handleAlarm();
+    },
+  };
+}

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -28,10 +28,7 @@ import {
 } from "../sandbox/lifecycle/manager";
 import { RepoImageStore } from "../db/repo-images";
 import { SessionIndexStore } from "../db/session-index";
-import {
-  evaluateExecutionTimeout,
-  DEFAULT_EXECUTION_TIMEOUT_MS,
-} from "../sandbox/lifecycle/decisions";
+import { DEFAULT_EXECUTION_TIMEOUT_MS } from "../sandbox/lifecycle/decisions";
 import {
   createSourceControlProvider as createSourceControlProviderImpl,
   resolveScmProviderFromEnv,
@@ -85,6 +82,7 @@ import {
   type ParticipantsHandler,
 } from "./http/handlers/participants.handler";
 import { MessageService } from "./services/message.service";
+import { createAlarmHandler, type AlarmHandler } from "./alarm/handler";
 
 /**
  * Timeout for WebSocket authentication (in milliseconds).
@@ -136,6 +134,8 @@ export class SessionDO extends DurableObject<Env> {
   private _pullRequestHandler: PullRequestHandler | null = null;
   // Participants handler (lazily initialized)
   private _participantsHandler: ParticipantsHandler | null = null;
+  // Alarm handler (lazily initialized)
+  private _alarmHandler: AlarmHandler | null = null;
   // Sandbox event processor (lazily initialized)
   private _sandboxEventProcessor: SessionSandboxEventProcessor | null = null;
 
@@ -465,6 +465,21 @@ export class SessionDO extends DurableObject<Env> {
     }
 
     return this._participantsHandler;
+  }
+
+  private get alarmHandler(): AlarmHandler {
+    if (!this._alarmHandler) {
+      this._alarmHandler = createAlarmHandler({
+        repository: this.repository,
+        messageQueue: this.messageQueue,
+        lifecycleManager: this.lifecycleManager,
+        executionTimeoutMs: this.executionTimeoutMs,
+        now: () => Date.now(),
+        getLog: () => this.log,
+      });
+    }
+
+    return this._alarmHandler;
   }
 
   private get sandboxEventProcessor(): SessionSandboxEventProcessor {
@@ -898,31 +913,7 @@ export class SessionDO extends DurableObject<Env> {
    */
   async alarm(): Promise<void> {
     this.ensureInitialized();
-
-    // Execution timeout check: if a message has been in 'processing' longer than
-    // the configured timeout, fail it. This is idempotent — if the message was
-    // already failed (by onSandboxTerminating or a prior alarm), getProcessingMessageWithStartedAt()
-    // returns null and we skip straight to handleAlarm().
-    const processing = this.repository.getProcessingMessageWithStartedAt();
-    if (processing?.started_at) {
-      const now = Date.now();
-      const result = evaluateExecutionTimeout(
-        processing.started_at,
-        { timeoutMs: this.executionTimeoutMs },
-        now
-      );
-      if (result.isTimedOut) {
-        this.log.warn("Execution timeout: message stuck in processing", {
-          event: "execution.timeout",
-          message_id: processing.id,
-          elapsed_ms: result.elapsedMs,
-          timeout_ms: this.executionTimeoutMs,
-        });
-        await this.messageQueue.failStuckProcessingMessage();
-      }
-    }
-
-    await this.lifecycleManager.handleAlarm();
+    await this.alarmHandler.handle();
   }
 
   /**


### PR DESCRIPTION
## Summary
- extract Durable Object alarm timeout logic into a dedicated `session/alarm/handler.ts` module
- add focused unit tests covering timeout and lifecycle delegation behavior
- make `SessionDO.alarm()` a thin delegation to the alarm handler

## Testing
- `npm test -w @open-inspect/control-plane -- src/session/alarm/handler.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
