### PR TITLE
fix: use async Modal sandbox create APIs

### DIFF
--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -159,7 +159,7 @@ class SandboxManager:
 
         # Create the sandbox
         # The entrypoint command is passed as positional args
-        sandbox = modal.Sandbox.create(
+        sandbox = await modal.Sandbox.create.aio(
             "python",
             "-m",
             "sandbox.entrypoint",  # Run the supervisor entrypoint
@@ -235,7 +235,7 @@ class SandboxManager:
 
         self._inject_vcs_env_vars(env_vars, clone_token or None)
 
-        sandbox = modal.Sandbox.create(
+        sandbox = await modal.Sandbox.create.aio(
             "python",
             "-m",
             "sandbox.entrypoint",
@@ -457,7 +457,7 @@ class SandboxManager:
         self._inject_vcs_env_vars(env_vars, clone_token)
 
         # Create the sandbox from the snapshot image
-        sandbox = modal.Sandbox.create(
+        sandbox = await modal.Sandbox.create.aio(
             "python",
             "-m",
             "sandbox.entrypoint",


### PR DESCRIPTION
## Summary
- Replace blocking `modal.Sandbox.create(...)` calls with `await modal.Sandbox.create.aio(...)` inside async sandbox lifecycle methods.
- Update all three sandbox creation paths in `packages/modal-infra/src/sandbox/manager.py` (session create, build sandbox, snapshot restore).
- Remove `AsyncUsageWarning` during image-build sandbox creation and align with Modal's async interface guidance.

## Why
These methods already run in async contexts. Using Modal's blocking API there triggers runtime warnings and can introduce event-loop blocking, so this change keeps sandbox operations non-blocking and consistent with Modal's recommended async usage.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/afe34ff88219b6f186959657f5ec7915)*