### PR TITLE
fix: include git stderr in push errors

### DIFF
--- a/packages/modal-infra/src/sandbox/bridge.py
+++ b/packages/modal-infra/src/sandbox/bridge.py
@@ -14,6 +14,7 @@ import asyncio
 import contextlib
 import json
 import os
+import re
 import secrets
 import subprocess
 import tempfile
@@ -208,6 +209,15 @@ class AgentBridge:
         """WebSocket URL for control plane connection."""
         url = self.control_plane_url.replace("https://", "wss://").replace("http://", "ws://")
         return f"{url}/sessions/{self.session_id}/ws?type=sandbox"
+
+    @staticmethod
+    def _redact_git_stderr(stderr_text: str, push_url: str, redacted_push_url: str) -> str:
+        """Redact credential-bearing URLs from git stderr."""
+        redacted_stderr = stderr_text
+        if push_url and redacted_push_url:
+            redacted_stderr = redacted_stderr.replace(push_url, redacted_push_url)
+
+        return re.sub(r"(https?://)([^/\s@]+)@", r"\1***@", redacted_stderr)
 
     async def run(self) -> None:
         """Main bridge loop with reconnection handling.
@@ -1521,16 +1531,21 @@ class AgentBridge:
 
             if result.returncode != 0:
                 stderr_text = _stderr.decode("utf-8", errors="replace").strip() if _stderr else ""
+                redacted_stderr_text = self._redact_git_stderr(
+                    stderr_text,
+                    push_url,
+                    redacted_push_url,
+                )
                 self.log.warn(
                     "git.push_failed",
                     branch_name=branch_name,
-                    stderr=stderr_text,
+                    stderr=redacted_stderr_text,
                 )
                 await self._send_event(
                     {
                         "type": "push_error",
-                        "error": f"Push failed: {stderr_text}"
-                        if stderr_text
+                        "error": f"Push failed: {redacted_stderr_text}"
+                        if redacted_stderr_text
                         else "Push failed - unknown error",
                         "branchName": branch_name,
                         "timestamp": time.time(),

--- a/packages/modal-infra/tests/test_bridge_push.py
+++ b/packages/modal-infra/tests/test_bridge_push.py
@@ -68,7 +68,39 @@ async def test_handle_push_sends_push_complete_on_success(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_handle_push_sends_auth_error_on_nonzero_exit(tmp_path: Path):
+async def test_handle_push_sends_redacted_stderr_on_nonzero_exit(tmp_path: Path):
+    bridge = _create_bridge(tmp_path)
+    bridge._send_event = AsyncMock()
+    process = _fake_process(
+        returncode=1,
+        communicate_result=(
+            b"",
+            b"fatal: Authentication failed for 'https://token@github.com/open-inspect/repo.git'",
+        ),
+    )
+
+    with patch(
+        "src.sandbox.bridge.asyncio.create_subprocess_exec", AsyncMock(return_value=process)
+    ):
+        await bridge._handle_push(_push_command())
+
+    bridge._send_event.assert_awaited_once()
+    await_args = bridge._send_event.await_args
+    assert await_args is not None
+    event = await_args.args[0]
+    assert event["type"] == "push_error"
+    assert (
+        event["error"]
+        == "Push failed: fatal: Authentication failed for 'https://***@github.com/open-inspect/repo.git'"
+    )
+    assert event["branchName"] == "feature/test"
+    assert isinstance(event["timestamp"], float)
+    process.terminate.assert_not_called()
+    process.kill.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_push_sends_unknown_error_when_stderr_is_empty(tmp_path: Path):
     bridge = _create_bridge(tmp_path)
     bridge._send_event = AsyncMock()
     process = _fake_process(returncode=1)
@@ -83,11 +115,9 @@ async def test_handle_push_sends_auth_error_on_nonzero_exit(tmp_path: Path):
     assert await_args is not None
     event = await_args.args[0]
     assert event["type"] == "push_error"
-    assert event["error"] == "Push failed - authentication may be required"
+    assert event["error"] == "Push failed - unknown error"
     assert event["branchName"] == "feature/test"
     assert isinstance(event["timestamp"], float)
-    process.terminate.assert_not_called()
-    process.kill.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- include captured `git push` stderr in the `git.push_failed` warning log so operators can see the real failure cause
- send the same stderr back in the `push_error` event instead of the hardcoded authentication message, with an unknown-error fallback when stderr is empty
- keep the Python typing path safe by guarding against a missing git return code before raising `CalledProcessError`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/0b4634831a3c928e777cc6203f756323)*