### PR TITLE
Introduce .vercelignore pattern to prevent uploading unnecessary files to Ignore

### DIFF
--- a/packages/.vercelignore
+++ b/packages/.vercelignore
@@ -1,6 +1,0 @@
-# Ignore everything (folders and files) on root only
-/*
-# Don't ignore these two directories
-!web
-!shared
-


### PR DESCRIPTION
Previously, files were uploaded to Vercel that weren't necessary to serve this project, including files like terraform.tfvars. This addresses that with the .vercelignore files.