### PR TITLE
fix: preserve stored model selection on hydration

### DIFF
--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -8,6 +8,7 @@ import Link from "next/link";
 import { useSidebarContext } from "@/components/sidebar-layout";
 import { formatModelNameLower } from "@/lib/format";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
+import { getHydratedSelectedModel, shouldResetSelectedModel } from "@/lib/model-selection";
 import {
   DEFAULT_MODEL,
   getDefaultReasoningEffort,
@@ -78,10 +79,7 @@ export default function Home() {
     if (enabledModels.length === 0 || hasHydratedModelPreferences.current) return;
 
     const storedModel = localStorage.getItem(LAST_SELECTED_MODEL_STORAGE_KEY);
-    const selectedModelFromStorage =
-      storedModel && enabledModels.includes(storedModel)
-        ? storedModel
-        : (enabledModels[0] ?? DEFAULT_MODEL);
+    const selectedModelFromStorage = getHydratedSelectedModel(enabledModels, storedModel);
 
     const storedReasoningEffort = localStorage.getItem(LAST_SELECTED_REASONING_EFFORT_STORAGE_KEY);
     const reasoningEffortFromStorage =
@@ -180,7 +178,9 @@ export default function Home() {
 
   // Reset selections when model preferences change
   useEffect(() => {
-    if (enabledModels.length > 0 && !enabledModels.includes(selectedModel)) {
+    if (
+      shouldResetSelectedModel(enabledModels, selectedModel, hasHydratedModelPreferences.current)
+    ) {
       const fallback = enabledModels[0] ?? DEFAULT_MODEL;
       setSelectedModel(fallback);
       setReasoningEffort(getDefaultReasoningEffort(fallback));

--- a/packages/web/src/lib/model-selection.test.ts
+++ b/packages/web/src/lib/model-selection.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { getHydratedSelectedModel, shouldResetSelectedModel } from "./model-selection";
+
+describe("getHydratedSelectedModel", () => {
+  it("keeps the stored model when it is enabled", () => {
+    expect(getHydratedSelectedModel(["openai/gpt-5.2", "openai/gpt-5.4"], "openai/gpt-5.4")).toBe(
+      "openai/gpt-5.4"
+    );
+  });
+
+  it("falls back to the first enabled model when the stored model is unavailable", () => {
+    expect(
+      getHydratedSelectedModel(["openai/gpt-5.2", "openai/gpt-5.4"], "anthropic/claude-sonnet-4-6")
+    ).toBe("openai/gpt-5.2");
+  });
+});
+
+describe("shouldResetSelectedModel", () => {
+  it("does not reset before model preferences finish hydrating", () => {
+    expect(
+      shouldResetSelectedModel(
+        ["openai/gpt-5.2", "openai/gpt-5.4"],
+        "anthropic/claude-sonnet-4-6",
+        false
+      )
+    ).toBe(false);
+  });
+
+  it("resets after hydration when the current model is no longer enabled", () => {
+    expect(
+      shouldResetSelectedModel(
+        ["openai/gpt-5.2", "openai/gpt-5.4"],
+        "anthropic/claude-sonnet-4-6",
+        true
+      )
+    ).toBe(true);
+  });
+});

--- a/packages/web/src/lib/model-selection.ts
+++ b/packages/web/src/lib/model-selection.ts
@@ -1,0 +1,25 @@
+import { DEFAULT_MODEL } from "@open-inspect/shared";
+
+export function getHydratedSelectedModel(
+  enabledModels: string[],
+  storedModel: string | null,
+  fallbackModel: string = DEFAULT_MODEL
+): string {
+  if (storedModel && enabledModels.includes(storedModel)) {
+    return storedModel;
+  }
+
+  return enabledModels[0] ?? fallbackModel;
+}
+
+export function shouldResetSelectedModel(
+  enabledModels: string[],
+  selectedModel: string,
+  hasHydratedModelPreferences: boolean
+): boolean {
+  return (
+    hasHydratedModelPreferences &&
+    enabledModels.length > 0 &&
+    !enabledModels.includes(selectedModel)
+  );
+}


### PR DESCRIPTION
## Summary
- prevent the new session page from resetting to the first enabled model before saved model preferences finish hydrating from local storage
- extract the home-page model selection logic into a small helper so the hydration and fallback rules stay explicit and easier to maintain
- add focused tests covering the OpenAI-only case where a stored `openai/gpt-5.4` preference should survive even when `openai/gpt-5.2` is the first enabled model

## Validation
- `npm test -w @open-inspect/web -- model-selection.test.ts`
- `npm run typecheck -w @open-inspect/web`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/14cd67e147bb3697f857c4ace0b61060)*