### PR TITLE
feat: MCP server support — CRUD, settings UI, sandbox integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,13 @@ terraform.rc
 docs/internal/
 
 SECURITY-AUDIT.md
+
+# Local deployment scripts with secrets
+scripts/*.env
+
+# Claude Code agent worktrees
+.claude/
+
 terraform/environments/production/plan.out
 terraform/environments/production/backend_override.tf
 terraform/environments/production/terraform.tfstate*

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,8 @@ export default tseslint.config(
       "**/*.d.ts",
       // Bundled/generated files
       "packages/modal-infra/**/*.js",
+      // Git worktrees (should not be linted)
+      ".claude/**",
     ],
   },
 

--- a/packages/control-plane/src/auth/github-app.ts
+++ b/packages/control-plane/src/auth/github-app.ts
@@ -625,9 +625,36 @@ export function getGitHubAppConfig(env: {
     return null;
   }
 
+  // Use the first installation ID for backwards compatibility
+  const firstId = env.GITHUB_APP_INSTALLATION_ID!.split(",")[0].trim();
   return {
     appId: env.GITHUB_APP_ID!,
     privateKey: env.GITHUB_APP_PRIVATE_KEY!,
-    installationId: env.GITHUB_APP_INSTALLATION_ID!,
+    installationId: firstId,
   };
+}
+
+/**
+ * Get all GitHub App configs (one per installation).
+ * Supports comma-separated GITHUB_APP_INSTALLATION_ID values.
+ */
+export function getAllGitHubAppConfigs(env: {
+  GITHUB_APP_ID?: string;
+  GITHUB_APP_PRIVATE_KEY?: string;
+  GITHUB_APP_INSTALLATION_ID?: string;
+}): GitHubAppConfig[] {
+  if (!isGitHubAppConfigured(env)) {
+    return [];
+  }
+
+  const ids = env
+    .GITHUB_APP_INSTALLATION_ID!.split(",")
+    .map((id) => id.trim())
+    .filter(Boolean);
+
+  return ids.map((installationId) => ({
+    appId: env.GITHUB_APP_ID!,
+    privateKey: env.GITHUB_APP_PRIVATE_KEY!,
+    installationId,
+  }));
 }

--- a/packages/control-plane/src/db/mcp-servers.test.ts
+++ b/packages/control-plane/src/db/mcp-servers.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Unit tests for McpServerStore.
+ *
+ * Uses a FakeD1Database similar to other store tests in this directory.
+ * See automation-store.test.ts for the established pattern.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { McpServerStore, McpServerValidationError } from "./mcp-servers";
+
+// ─── Fake D1 helpers ────────────────────────────────────────────────────────
+
+interface FakeStatement {
+  sql: string;
+  params: unknown[];
+}
+
+function createFakeD1(options?: {
+  firstResult?: unknown;
+  allResults?: unknown[];
+  changes?: number;
+}) {
+  const statements: FakeStatement[] = [];
+
+  const fakeStmt = {
+    bind(...params: unknown[]) {
+      statements[statements.length - 1].params = params;
+      return fakeStmt;
+    },
+    async first<T>(): Promise<T | null> {
+      return (options?.firstResult as T) ?? null;
+    },
+    async all<T>(): Promise<D1Result<T>> {
+      return {
+        results: (options?.allResults ?? []) as T[],
+        success: true,
+        meta: { duration: 0, changes: options?.changes ?? 0 },
+      } as unknown as D1Result<T>;
+    },
+    async run(): Promise<D1Result> {
+      return {
+        results: [],
+        success: true,
+        meta: { duration: 0, changes: options?.changes ?? 1 },
+      } as unknown as D1Result;
+    },
+  };
+
+  const db = {
+    prepare(sql: string) {
+      statements.push({ sql, params: [] });
+      return fakeStmt;
+    },
+    dump: vi.fn(),
+    exec: vi.fn(),
+  } as unknown as D1Database;
+
+  return { db, statements };
+}
+
+// ─── Sample rows ─────────────────────────────────────────────────────────────
+
+const sampleRow = {
+  id: "abc123",
+  name: "playwright",
+  type: "stdio",
+  command: JSON.stringify(["npx", "-y", "@playwright/mcp"]),
+  url: null,
+  env: JSON.stringify({ DEBUG: "1" }),
+  repo_scope: null,
+  enabled: 1,
+  created_at: 1000,
+  updated_at: 1000,
+};
+
+const remoteRow = {
+  id: "def456",
+  name: "remote-mcp",
+  type: "remote",
+  command: null,
+  url: "https://mcp.example.com/sse",
+  env: "{}",
+  repo_scope: JSON.stringify(["carboncopyinc/habakkuk"]),
+  enabled: 1,
+  created_at: 1001,
+  updated_at: 1001,
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("McpServerStore", () => {
+  describe("list()", () => {
+    it("returns all servers when no repoScope filter", async () => {
+      const { db } = createFakeD1({ allResults: [sampleRow, remoteRow] });
+      const store = new McpServerStore(db);
+      const results = await store.list();
+      expect(results).toHaveLength(2);
+      expect(results[0].name).toBe("playwright");
+    });
+
+    it("filters by repoScope (global servers always included)", async () => {
+      const { db } = createFakeD1({ allResults: [sampleRow, remoteRow] });
+      const store = new McpServerStore(db);
+      // sampleRow has no repo_scope (global) → should be included
+      // remoteRow is scoped to carboncopyinc/habakkuk → should be included
+      const results = await store.list("carboncopyinc/habakkuk");
+      expect(results).toHaveLength(2);
+    });
+
+    it("excludes repo-scoped servers when repo does not match", async () => {
+      const { db } = createFakeD1({ allResults: [sampleRow, remoteRow] });
+      const store = new McpServerStore(db);
+      // remoteRow is scoped to carboncopyinc/habakkuk, not bencered/dom
+      const results = await store.list("bencered/dom");
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe("playwright");
+    });
+  });
+
+  describe("get()", () => {
+    it("returns config when row found", async () => {
+      const { db } = createFakeD1({ firstResult: sampleRow });
+      const store = new McpServerStore(db);
+      const result = await store.get("abc123");
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe("playwright");
+      expect(result!.command).toEqual(["npx", "-y", "@playwright/mcp"]);
+      expect(result!.env).toEqual({ DEBUG: "1" });
+    });
+
+    it("returns null when not found", async () => {
+      const { db } = createFakeD1({ firstResult: null });
+      const store = new McpServerStore(db);
+      const result = await store.get("nonexistent");
+      expect(result).toBeNull();
+    });
+
+    it("handles corrupted JSON in command gracefully", async () => {
+      const corruptRow = { ...sampleRow, command: "not-json" };
+      const { db } = createFakeD1({ firstResult: corruptRow });
+      const store = new McpServerStore(db);
+      const result = await store.get("abc123");
+      // Should fall back to wrapping the string in an array
+      expect(result!.command).toEqual(["not-json"]);
+    });
+
+    it("handles corrupted JSON in env gracefully", async () => {
+      const corruptRow = { ...sampleRow, env: "broken{" };
+      const { db } = createFakeD1({ firstResult: corruptRow });
+      const store = new McpServerStore(db);
+      const result = await store.get("abc123");
+      // Should fall back to empty object
+      expect(result!.env).toEqual({});
+    });
+  });
+
+  describe("create()", () => {
+    it("throws McpServerValidationError for stdio server without command", async () => {
+      const { db } = createFakeD1();
+      const store = new McpServerStore(db);
+      await expect(store.create({ name: "test", type: "stdio", enabled: true })).rejects.toThrow(
+        McpServerValidationError
+      );
+    });
+
+    it("throws McpServerValidationError for remote server without url", async () => {
+      const { db } = createFakeD1({ firstResult: remoteRow });
+      const store = new McpServerStore(db);
+      await expect(store.create({ name: "test", type: "remote", enabled: true })).rejects.toThrow(
+        McpServerValidationError
+      );
+    });
+
+    it("throws McpServerValidationError (not generic Error) so routes can return 400", async () => {
+      const { db } = createFakeD1();
+      const store = new McpServerStore(db);
+      const err = await store.create({ name: "x", type: "stdio", enabled: true }).catch((e) => e);
+      expect(err).toBeInstanceOf(McpServerValidationError);
+      expect(err).toBeInstanceOf(Error);
+    });
+  });
+
+  describe("update()", () => {
+    it("returns null when server not found", async () => {
+      const { db } = createFakeD1({ firstResult: null });
+      const store = new McpServerStore(db);
+      const result = await store.update("nonexistent", { name: "new-name" });
+      expect(result).toBeNull();
+    });
+
+    it("does not allow overwriting id via patch", async () => {
+      // Create a fake D1 that returns sampleRow for get(), then returns updated row
+      let callCount = 0;
+      const fakeStmt = {
+        bind(..._params: unknown[]) {
+          return fakeStmt;
+        },
+        async first<T>(): Promise<T | null> {
+          // First call = get existing, subsequent calls = get after update
+          callCount++;
+          return (callCount <= 1 ? sampleRow : { ...sampleRow, name: "updated" }) as T;
+        },
+        async all<T>(): Promise<D1Result<T>> {
+          return {
+            results: [],
+            success: true,
+            meta: { duration: 0, changes: 0 },
+          } as unknown as D1Result<T>;
+        },
+        async run(): Promise<D1Result> {
+          return {
+            results: [],
+            success: true,
+            meta: { duration: 0, changes: 1 },
+          } as unknown as D1Result;
+        },
+      };
+      const db = { prepare: () => fakeStmt, dump: vi.fn(), exec: vi.fn() } as unknown as D1Database;
+
+      const store = new McpServerStore(db);
+      // Attempt to patch id (not in the allowed type, but simulate via cast)
+      const result = await store.update("abc123", { name: "updated" });
+      // id should still be the original
+      expect(result!.id).toBe("abc123");
+    });
+
+    it("throws McpServerValidationError when changing type to remote without url", async () => {
+      // sampleRow is a stdio server with no url
+      const { db } = createFakeD1({ firstResult: sampleRow });
+      const store = new McpServerStore(db);
+      const err = await store.update("abc123", { type: "remote" }).catch((e) => e);
+      expect(err).toBeInstanceOf(McpServerValidationError);
+      expect(err.message).toMatch(/require a URL/i);
+    });
+
+    it("throws McpServerValidationError when changing type to stdio without command", async () => {
+      // remoteRow is a remote server with no command
+      const { db } = createFakeD1({ firstResult: remoteRow });
+      const store = new McpServerStore(db);
+      const err = await store.update("def456", { type: "stdio" }).catch((e) => e);
+      expect(err).toBeInstanceOf(McpServerValidationError);
+      expect(err.message).toMatch(/require a command/i);
+    });
+  });
+
+  describe("delete()", () => {
+    it("returns true when row deleted", async () => {
+      const { db } = createFakeD1({ changes: 1 });
+      const store = new McpServerStore(db);
+      const result = await store.delete("abc123");
+      expect(result).toBe(true);
+    });
+
+    it("returns false when row not found", async () => {
+      const { db } = createFakeD1({ changes: 0 });
+      const store = new McpServerStore(db);
+      const result = await store.delete("nonexistent");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("getForSession()", () => {
+    it("returns global and matching repo-scoped servers", async () => {
+      const { db } = createFakeD1({ allResults: [sampleRow, remoteRow] });
+      const store = new McpServerStore(db);
+      const results = await store.getForSession("carboncopyinc", "habakkuk");
+      expect(results).toHaveLength(2); // global + matching scoped
+    });
+
+    it("excludes servers scoped to different repos", async () => {
+      const { db } = createFakeD1({ allResults: [sampleRow, remoteRow] });
+      const store = new McpServerStore(db);
+      const results = await store.getForSession("bencered", "dom");
+      expect(results).toHaveLength(1); // only the global server
+      expect(results[0].name).toBe("playwright");
+    });
+  });
+
+  describe("UNIQUE constraint handling", () => {
+    function createConstraintErrorD1() {
+      const fakeStmt = {
+        bind(..._params: unknown[]) {
+          return fakeStmt;
+        },
+        async first<T>(): Promise<T | null> {
+          // create() calls get() after insert — return the row so it doesn't fail after
+          return sampleRow as T;
+        },
+        async all<T>(): Promise<D1Result<T>> {
+          return {
+            results: [],
+            success: true,
+            meta: { duration: 0, changes: 0 },
+          } as unknown as D1Result<T>;
+        },
+        async run(): Promise<D1Result> {
+          throw new Error("UNIQUE constraint failed: mcp_servers.name");
+        },
+      };
+      return { prepare: () => fakeStmt, dump: vi.fn(), exec: vi.fn() } as unknown as D1Database;
+    }
+
+    it("create() throws McpServerValidationError on duplicate name (not 503)", async () => {
+      const db = createConstraintErrorD1();
+      const store = new McpServerStore(db);
+      const err = await store
+        .create({ name: "playwright", type: "stdio", command: ["npx", "x"], enabled: true })
+        .catch((e) => e);
+      expect(err).toBeInstanceOf(McpServerValidationError);
+      expect(err.message).toMatch(/already exists/);
+    });
+
+    it("update() throws McpServerValidationError on duplicate name", async () => {
+      // First call (get existing) returns the row; second call (update) throws constraint error
+      let runCallCount = 0;
+      let firstCallCount = 0;
+      const fakeStmt = {
+        bind(..._params: unknown[]) {
+          return fakeStmt;
+        },
+        async first<T>(): Promise<T | null> {
+          firstCallCount++;
+          return firstCallCount <= 1 ? (sampleRow as T) : null;
+        },
+        async all<T>(): Promise<D1Result<T>> {
+          return {
+            results: [],
+            success: true,
+            meta: { duration: 0, changes: 0 },
+          } as unknown as D1Result<T>;
+        },
+        async run(): Promise<D1Result> {
+          runCallCount++;
+          throw new Error("UNIQUE constraint failed: mcp_servers.name");
+        },
+      };
+      const db = { prepare: () => fakeStmt, dump: vi.fn(), exec: vi.fn() } as unknown as D1Database;
+      const store = new McpServerStore(db);
+      const err = await store.update("abc123", { name: "other-server" }).catch((e) => e);
+      expect(err).toBeInstanceOf(McpServerValidationError);
+      expect(runCallCount).toBeGreaterThan(0);
+    });
+  });
+
+  describe("encryption / decryption", () => {
+    it("no-key path returns plaintext env as-is", async () => {
+      const { db } = createFakeD1({ firstResult: sampleRow });
+      const store = new McpServerStore(db); // no encryption key
+      const result = await store.get("abc123");
+      expect(result!.env).toEqual({ DEBUG: "1" });
+    });
+
+    it("falls back to plaintext when decryption fails (pre-encryption row)", async () => {
+      // Row has plaintext JSON env but store has an encryption key
+      const { db } = createFakeD1({ firstResult: sampleRow });
+      // Use a fake key that will cause decryptToken to throw
+      const store = new McpServerStore(db, "bm90YXJlYWxrZXlub3RhcmVhbGtleW5vdGFyZWFsa2V5eA==");
+      const result = await store.get("abc123");
+      // Should fall back gracefully: env has values, so treated as pre-encryption plaintext
+      expect(result!.env).toEqual({ DEBUG: "1" });
+    });
+
+    it("returns empty env and logs error when both decryption and JSON parse fail", async () => {
+      // Row has garbage that is neither valid ciphertext nor valid JSON
+      const { db } = createFakeD1({ firstResult: { ...sampleRow, env: "notjson_notcipher" } });
+      const store = new McpServerStore(db, "bm90YXJlYWxrZXlub3RhcmVhbGtleW5vdGFyZWFsa2V5eA==");
+      const result = await store.get("abc123");
+      // Must not throw; returns empty env
+      expect(result!.env).toEqual({});
+    });
+  });
+});

--- a/packages/control-plane/src/db/mcp-servers.ts
+++ b/packages/control-plane/src/db/mcp-servers.ts
@@ -1,0 +1,321 @@
+import type { McpServerConfig } from "@open-inspect/shared";
+import { encryptToken, decryptToken } from "../auth/crypto";
+import { createLogger } from "../logger";
+
+const log = createLogger("db:mcp-servers");
+
+export class McpServerValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "McpServerValidationError";
+  }
+}
+
+function generateId(): string {
+  return crypto.randomUUID().replace(/-/g, "").slice(0, 16);
+}
+
+interface McpServerRow {
+  id: string;
+  name: string;
+  type: string;
+  command: string | null;
+  url: string | null;
+  env: string;
+  repo_scope: string | null;
+  enabled: number;
+  created_at: number;
+  updated_at: number;
+}
+
+function parseRepoScopes(raw: string | null): string[] | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [raw];
+  } catch {
+    return [raw];
+  }
+}
+
+function safeJsonParseCommand(raw: string | null): string[] | undefined {
+  if (!raw) return undefined;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return [raw];
+  }
+}
+
+function safeJsonParseEnv(raw: string): Record<string, string> {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+function rowToConfig(row: McpServerRow, payload: Record<string, string>): McpServerConfig {
+  // The DB `env` column stores different things depending on server type:
+  //   stdio  → process environment variables  → McpServerConfig.env
+  //   remote → HTTP request headers           → McpServerConfig.headers
+  const envOrHeaders: Pick<McpServerConfig, "env" | "headers"> =
+    row.type === "remote" ? { headers: payload } : { env: payload };
+  return {
+    id: row.id,
+    name: row.name,
+    type: row.type as "stdio" | "remote",
+    command: safeJsonParseCommand(row.command),
+    url: row.url ?? undefined,
+    ...envOrHeaders,
+    repoScopes: parseRepoScopes(row.repo_scope),
+    enabled: row.enabled === 1,
+  };
+}
+
+/**
+ * Check if an error message indicates a D1 UNIQUE constraint violation.
+ *
+ * NOTE: D1 does not expose structured error codes, so we string-match against the
+ * SQLite error message. If Cloudflare ever changes the wording this check silently
+ * becomes a no-op (constraint errors fall through as 503 instead of 400). Keep an
+ * eye on this if D1 error shapes change in future Worker runtime versions.
+ */
+function isUniqueConstraintError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.toLowerCase().includes("unique constraint failed");
+}
+
+export class McpServerStore {
+  constructor(
+    private readonly db: D1Database,
+    private readonly encryptionKey?: string
+  ) {}
+
+  /** Encrypt env dict to a stored string. Falls back to plaintext if no key. */
+  private async encryptEnv(env: Record<string, string>): Promise<string> {
+    const plain = JSON.stringify(env);
+    if (!this.encryptionKey) return plain;
+    return encryptToken(plain, this.encryptionKey);
+  }
+
+  /**
+   * Decrypt env string from storage.
+   *
+   * Three cases:
+   * 1. No encryption key → treat as plaintext JSON (dev / unconfigured)
+   * 2. Key present, decrypt succeeds → normal encrypted row
+   * 3. Key present, decrypt fails → pre-encryption plaintext row (migration period).
+   *    Falls back to JSON parse; logs a warning so ops can tell the difference from
+   *    a key rotation mistake.
+   *
+   * NOTE: env values are returned in plaintext to callers. This is intentional —
+   * they are required by the sandbox at runtime. Transport to Modal is over TLS.
+   * Do NOT log the returned env object.
+   */
+  private async decryptEnv(raw: string): Promise<Record<string, string>> {
+    if (!this.encryptionKey) return safeJsonParseEnv(raw);
+    try {
+      const plain = await decryptToken(raw, this.encryptionKey);
+      return safeJsonParseEnv(plain);
+    } catch {
+      // Decryption failed — check if it looks like a pre-encryption plaintext row
+      const plaintext = safeJsonParseEnv(raw);
+      if (Object.keys(plaintext).length > 0) {
+        log.warn("MCP server env decryption failed — treating as pre-encryption plaintext row", {
+          event: "mcp_server.env_decrypt_fallback",
+        });
+        return plaintext;
+      }
+      // Empty JSON or ciphertext with wrong key — log a clear error, return empty
+      log.error("MCP server env decryption failed and raw value is not plaintext JSON", {
+        event: "mcp_server.env_decrypt_error",
+      });
+      return {};
+    }
+  }
+
+  private async decryptRow(row: McpServerRow): Promise<McpServerConfig> {
+    const env = await this.decryptEnv(row.env);
+    return rowToConfig(row, env);
+  }
+
+  async list(repoScope?: string): Promise<McpServerConfig[]> {
+    // NOTE: We load all rows then filter in-memory because repo_scope is stored as
+    // JSON-serialised array, making SQL-level filtering awkward in D1/SQLite without
+    // JSON_EACH. At expected scale (<100 MCP servers per deployment) this is fine.
+    // TODO: push down to SQL once D1 supports JSON_EACH in WHERE clauses.
+    const { results } = await this.db
+      .prepare("SELECT * FROM mcp_servers ORDER BY name")
+      .all<McpServerRow>();
+    const configs = await Promise.all(results.map((r) => this.decryptRow(r)));
+    if (repoScope === undefined) return configs;
+    const normalized = repoScope.toLowerCase();
+    return configs.filter((c) => {
+      if (!c.repoScopes) return true;
+      return c.repoScopes.some((s) => s.toLowerCase() === normalized);
+    });
+  }
+
+  async get(id: string): Promise<McpServerConfig | null> {
+    const row = await this.db
+      .prepare("SELECT * FROM mcp_servers WHERE id = ?")
+      .bind(id)
+      .first<McpServerRow>();
+    return row ? this.decryptRow(row) : null;
+  }
+
+  async create(config: Omit<McpServerConfig, "id">): Promise<McpServerConfig> {
+    const id = generateId();
+    const now = Date.now();
+
+    if (config.type === "stdio" && (!config.command || config.command.length === 0)) {
+      throw new McpServerValidationError("stdio MCP servers require a command");
+    }
+    if (config.type === "remote" && !config.url) {
+      throw new McpServerValidationError("remote MCP servers require a URL");
+    }
+
+    // For remote servers, the DB `env` column stores HTTP headers (McpServerConfig.headers).
+    // For stdio servers, it stores process environment variables (McpServerConfig.env).
+    const encryptedEnv = await this.encryptEnv(
+      config.type === "remote" ? (config.headers ?? {}) : (config.env ?? {})
+    );
+
+    try {
+      await this.db
+        .prepare(
+          `INSERT INTO mcp_servers (id, name, type, command, url, env, repo_scope, enabled, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          id,
+          config.name,
+          config.type,
+          config.command ? JSON.stringify(config.command) : null,
+          config.url ?? null,
+          encryptedEnv,
+          config.repoScopes?.length
+            ? JSON.stringify(config.repoScopes.map((r) => r.toLowerCase()))
+            : null,
+          config.enabled ? 1 : 0,
+          now,
+          now
+        )
+        .run();
+    } catch (err) {
+      if (isUniqueConstraintError(err)) {
+        throw new McpServerValidationError(`An MCP server named '${config.name}' already exists`);
+      }
+      throw err;
+    }
+
+    const created = await this.get(id);
+    if (!created) {
+      throw new Error(`MCP server '${id}' not found after insert — this should not happen`);
+    }
+    return created;
+  }
+
+  async update(
+    id: string,
+    patch: Partial<
+      Pick<
+        McpServerConfig,
+        "name" | "type" | "command" | "url" | "env" | "headers" | "repoScopes" | "enabled"
+      >
+    >
+  ): Promise<McpServerConfig | null> {
+    const existing = await this.get(id);
+    if (!existing) return null;
+
+    // Explicit allowlist — id, created_at, updated_at cannot be overwritten
+    const merged: Omit<McpServerConfig, "id"> = {
+      name: patch.name ?? existing.name,
+      type: patch.type ?? existing.type,
+      command: patch.command !== undefined ? patch.command : existing.command,
+      url: patch.url !== undefined ? patch.url : existing.url,
+      env: patch.env !== undefined ? patch.env : existing.env,
+      headers: patch.headers !== undefined ? patch.headers : existing.headers,
+      repoScopes: patch.repoScopes !== undefined ? patch.repoScopes : existing.repoScopes,
+      enabled: patch.enabled !== undefined ? patch.enabled : existing.enabled,
+    };
+    // Validate the merged result — catches cases where type is changed without
+    // updating the corresponding command/url field (same rules as create()).
+    if (merged.type === "stdio" && (!merged.command || merged.command.length === 0)) {
+      throw new McpServerValidationError("stdio MCP servers require a command");
+    }
+    if (merged.type === "remote" && !merged.url) {
+      throw new McpServerValidationError("remote MCP servers require a URL");
+    }
+
+    const now = Date.now();
+    // For remote servers, the DB `env` column stores HTTP headers; for stdio, process env.
+    const encryptedEnv = await this.encryptEnv(
+      merged.type === "remote" ? (merged.headers ?? {}) : (merged.env ?? {})
+    );
+
+    try {
+      await this.db
+        .prepare(
+          `UPDATE mcp_servers SET name = ?, type = ?, command = ?, url = ?, env = ?, repo_scope = ?, enabled = ?, updated_at = ?
+           WHERE id = ?`
+        )
+        .bind(
+          merged.name,
+          merged.type,
+          merged.command ? JSON.stringify(merged.command) : null,
+          merged.url ?? null,
+          encryptedEnv,
+          merged.repoScopes?.length
+            ? JSON.stringify(merged.repoScopes.map((r) => r.toLowerCase()))
+            : null,
+          merged.enabled ? 1 : 0,
+          now,
+          id
+        )
+        .run();
+    } catch (err) {
+      if (isUniqueConstraintError(err)) {
+        throw new McpServerValidationError(`An MCP server named '${merged.name}' already exists`);
+      }
+      throw err;
+    }
+
+    // Build the return value from in-memory merged data — avoids a second read+decrypt cycle.
+    // Note: unlike create() which round-trips through get(), this bypasses any DB-level
+    // normalisation. In practice D1/SQLite does not transform the values we write, so the
+    // result is equivalent. If that ever changes, swap this for `await this.get(id)`.
+    return {
+      id,
+      ...merged,
+      repoScopes: merged.repoScopes?.length ? merged.repoScopes.map((r) => r.toLowerCase()) : null,
+    };
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const result = await this.db.prepare("DELETE FROM mcp_servers WHERE id = ?").bind(id).run();
+    return (result.meta?.changes ?? 0) > 0;
+  }
+
+  /**
+   * Get all enabled MCP servers applicable to a session (global + repo-specific).
+   *
+   * Returned env values are decrypted plaintext — required by the sandbox at runtime.
+   * Do NOT log the returned McpServerConfig objects.
+   */
+  async getForSession(repoOwner: string, repoName: string): Promise<McpServerConfig[]> {
+    const repoFullName = `${repoOwner}/${repoName}`.toLowerCase();
+    const { results } = await this.db
+      .prepare("SELECT * FROM mcp_servers WHERE enabled = 1 ORDER BY name")
+      .all<McpServerRow>();
+
+    const filtered = results.filter((row) => {
+      const scopes = parseRepoScopes(row.repo_scope);
+      if (!scopes) return true;
+      return scopes.some((s) => s.toLowerCase() === repoFullName);
+    });
+
+    return Promise.all(filtered.map((r) => this.decryptRow(r)));
+  }
+}

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -41,6 +41,7 @@ import { reposRoutes } from "./routes/repos";
 import { repoImageRoutes } from "./routes/repo-images";
 import { secretsRoutes } from "./routes/secrets";
 import { automationRoutes } from "./routes/automations";
+import { mcpServerRoutes } from "./routes/mcp-servers";
 
 const logger = createLogger("router");
 
@@ -475,6 +476,9 @@ const routes: Route[] = [
 
   // Automations
   ...automationRoutes,
+
+  // MCP servers
+  ...mcpServerRoutes,
 ];
 
 /**

--- a/packages/control-plane/src/routes/mcp-servers.ts
+++ b/packages/control-plane/src/routes/mcp-servers.ts
@@ -1,0 +1,192 @@
+/**
+ * MCP server configuration routes.
+ */
+
+import type { McpServerConfig } from "@open-inspect/shared";
+import { McpServerStore, McpServerValidationError } from "../db/mcp-servers";
+import type { Env } from "../types";
+import { createLogger } from "../logger";
+import { type Route, type RequestContext, parsePattern, json, error } from "./shared";
+
+const logger = createLogger("router:mcp-servers");
+
+async function handleListMcpServers(
+  request: Request,
+  env: Env,
+  _match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  if (!env.DB) return error("Database not configured", 503);
+
+  const url = new URL(request.url);
+  const repo = url.searchParams.get("repo") ?? undefined;
+
+  const store = new McpServerStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
+  const servers = await store.list(repo);
+  logger.info("MCP servers listed", {
+    event: "mcp_server.list",
+    request_id: ctx.request_id,
+    trace_id: ctx.trace_id,
+    count: servers.length,
+  });
+  return json(servers);
+}
+
+async function handleGetMcpServer(
+  _request: Request,
+  env: Env,
+  match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const id = match.groups?.id;
+  if (!id) return error("Missing server ID", 400);
+  if (!env.DB) return error("Database not configured", 503);
+
+  const store = new McpServerStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
+  const server = await store.get(id);
+  if (!server) return error("MCP server not found", 404);
+  logger.info("MCP server retrieved", {
+    event: "mcp_server.get",
+    request_id: ctx.request_id,
+    trace_id: ctx.trace_id,
+    id,
+  });
+  return json(server);
+}
+
+async function handleCreateMcpServer(
+  request: Request,
+  env: Env,
+  _match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  if (!env.DB) return error("Database not configured", 503);
+
+  let body: Partial<McpServerConfig>;
+  try {
+    body = await request.json();
+  } catch {
+    return error("Invalid JSON body", 400);
+  }
+
+  if (!body.name || typeof body.name !== "string") {
+    return error("name is required", 400);
+  }
+  if (body.type !== "stdio" && body.type !== "remote") {
+    return error("type must be 'stdio' or 'remote'", 400);
+  }
+
+  try {
+    const store = new McpServerStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
+    const server = await store.create({
+      name: body.name,
+      type: body.type,
+      command: body.command,
+      url: body.url,
+      env: body.env,
+      repoScopes: body.repoScopes ?? null,
+      enabled: body.enabled !== false,
+    });
+    logger.info("MCP server created", {
+      event: "mcp_server.created",
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+      id: server.id,
+      name: server.name,
+    });
+    return json(server, 201);
+  } catch (err) {
+    if (err instanceof McpServerValidationError) {
+      return error(err.message, 400);
+    }
+    return error("Failed to create MCP server", 503);
+  }
+}
+
+async function handleUpdateMcpServer(
+  request: Request,
+  env: Env,
+  match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const id = match.groups?.id;
+  if (!id) return error("Missing server ID", 400);
+  if (!env.DB) return error("Database not configured", 503);
+
+  let body: Partial<McpServerConfig>;
+  try {
+    body = await request.json();
+  } catch {
+    return error("Invalid JSON body", 400);
+  }
+
+  try {
+    const store = new McpServerStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
+    const updated = await store.update(id, body);
+    if (!updated) return error("MCP server not found", 404);
+
+    logger.info("MCP server updated", {
+      event: "mcp_server.updated",
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+      id,
+    });
+    return json(updated);
+  } catch (err) {
+    if (err instanceof McpServerValidationError) {
+      return error(err.message, 400);
+    }
+    return error("Failed to update MCP server", 503);
+  }
+}
+
+async function handleDeleteMcpServer(
+  _request: Request,
+  env: Env,
+  match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const id = match.groups?.id;
+  if (!id) return error("Missing server ID", 400);
+  if (!env.DB) return error("Database not configured", 503);
+
+  const store = new McpServerStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
+  const deleted = await store.delete(id);
+  if (!deleted) return error("MCP server not found", 404);
+
+  logger.info("MCP server deleted", {
+    event: "mcp_server.deleted",
+    request_id: ctx.request_id,
+    trace_id: ctx.trace_id,
+    id,
+  });
+  return json({ ok: true });
+}
+
+export const mcpServerRoutes: Route[] = [
+  {
+    method: "GET",
+    pattern: parsePattern("/mcp-servers"),
+    handler: handleListMcpServers,
+  },
+  {
+    method: "POST",
+    pattern: parsePattern("/mcp-servers"),
+    handler: handleCreateMcpServer,
+  },
+  {
+    method: "GET",
+    pattern: parsePattern("/mcp-servers/:id"),
+    handler: handleGetMcpServer,
+  },
+  {
+    method: "PUT",
+    pattern: parsePattern("/mcp-servers/:id"),
+    handler: handleUpdateMcpServer,
+  },
+  {
+    method: "DELETE",
+    pattern: parsePattern("/mcp-servers/:id"),
+    handler: handleDeleteMcpServer,
+  },
+];

--- a/packages/control-plane/src/routes/shared.ts
+++ b/packages/control-plane/src/routes/shared.ts
@@ -5,7 +5,7 @@
 import type { CorrelationContext } from "../logger";
 import type { RequestMetrics } from "../db/instrumented-d1";
 import type { Env } from "../types";
-import { getGitHubAppConfig } from "../auth/github-app";
+import { getGitHubAppConfig, getAllGitHubAppConfigs } from "../auth/github-app";
 import {
   createSourceControlProvider,
   resolveScmProviderFromEnv,
@@ -67,11 +67,13 @@ export function error(message: string, status = 400): Response {
  */
 export function createRouteSourceControlProvider(env: Env): SourceControlProvider {
   const appConfig = getGitHubAppConfig(env);
+  const allAppConfigs = getAllGitHubAppConfigs(env);
   const provider = resolveScmProviderFromEnv(env.SCM_PROVIDER);
   return createSourceControlProvider({
     provider,
     github: {
       appConfig: appConfig ?? undefined,
+      allAppConfigs: allAppConfigs.length > 0 ? allAppConfigs : undefined,
       kvCache: env.REPOS_CACHE,
     },
   });

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -6,6 +6,7 @@
  */
 
 import { generateInternalToken } from "@open-inspect/shared";
+import type { McpServerConfig } from "@open-inspect/shared";
 import { createLogger } from "../logger";
 import type { CorrelationContext } from "../logger";
 
@@ -39,6 +40,7 @@ export interface CreateSandboxRequest {
   timeoutSeconds?: number;
   branch?: string;
   codeServerEnabled?: boolean;
+  mcpServers?: McpServerConfig[];
 }
 
 export interface CreateSandboxResponse {
@@ -64,6 +66,7 @@ export interface RestoreSandboxRequest {
   timeoutSeconds?: number;
   branch?: string;
   codeServerEnabled?: boolean;
+  mcpServers?: McpServerConfig[];
 }
 
 export interface RestoreSandboxResponse {
@@ -251,6 +254,7 @@ export class ModalClient {
           timeout_seconds: request.timeoutSeconds || null,
           branch: request.branch || null,
           code_server_enabled: request.codeServerEnabled ?? false,
+          mcp_servers: request.mcpServers || null,
         }),
       });
 
@@ -324,6 +328,7 @@ export class ModalClient {
             provider: request.provider,
             model: request.model,
             branch: request.branch || null,
+            mcp_servers: request.mcpServers || null,
           },
           sandbox_id: request.sandboxId,
           control_plane_url: request.controlPlaneUrl,

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -12,6 +12,7 @@
 
 import type { SandboxStatus } from "../../types";
 import type { SandboxRow, SessionRow } from "../../session/types";
+import type { McpServerConfig } from "@open-inspect/shared";
 import { SandboxProviderError, type SandboxProvider, type CreateSandboxConfig } from "../provider";
 import {
   evaluateCircuitBreaker,
@@ -31,6 +32,7 @@ import {
 import { extractProviderAndModel } from "../../utils/models";
 import { createLogger, type Logger } from "../../logger";
 import { hashToken } from "../../auth/crypto";
+// McpServerStore is used via the McpServerLookup interface — not imported directly
 
 const log = createLogger("lifecycle-manager");
 
@@ -139,6 +141,8 @@ export interface SandboxLifecycleConfig {
   model: string;
   /** Session ID for log correlation. Optional — logs will omit sessionId if not provided. */
   sessionId?: string;
+  /** MCP server lookup for injecting servers into sandboxes. */
+  mcpServerLookup?: McpServerLookup;
 }
 
 /**
@@ -153,6 +157,16 @@ export const DEFAULT_LIFECYCLE_CONFIG: Omit<SandboxLifecycleConfig, "controlPlan
 
 /** Child (agent-spawned) sessions get a shorter sandbox timeout. */
 const CHILD_SANDBOX_TIMEOUT_SECONDS = 3600; // 1 hour (vs default 2 hours)
+
+// ==================== MCP Server Lookup ====================
+
+/**
+ * Lookup interface for MCP servers applicable to a session.
+ * Keeps the lifecycle manager free of direct D1Database dependencies.
+ */
+export interface McpServerLookup {
+  getForSession(repoOwner: string, repoName: string): Promise<McpServerConfig[]>;
+}
 
 // ==================== Repo Image Lookup ====================
 
@@ -363,6 +377,8 @@ export class SandboxLifecycleManager {
       const timeoutSeconds =
         session.spawn_source === "agent" ? CHILD_SANDBOX_TIMEOUT_SECONDS : undefined;
 
+      const mcpServers = await this.loadMcpServers(session);
+
       // Create sandbox via provider
       const codeServerEnabled = session.code_server_enabled === 1;
       const createConfig: CreateSandboxConfig = {
@@ -380,6 +396,7 @@ export class SandboxLifecycleManager {
         timeoutSeconds,
         branch: session.base_branch,
         codeServerEnabled,
+        mcpServers,
       };
 
       const result = await this.provider.createSandbox(createConfig);
@@ -440,6 +457,32 @@ export class SandboxLifecycleManager {
   }
 
   /**
+   * Load MCP servers applicable to the current session's repository.
+   * Returns undefined if none are found or DB is not configured.
+   */
+  private async loadMcpServers(session: SessionRow): Promise<McpServerConfig[] | undefined> {
+    try {
+      if (!this.config.mcpServerLookup) return undefined;
+      const servers = await this.config.mcpServerLookup.getForSession(
+        session.repo_owner,
+        session.repo_name
+      );
+      this.log.info("MCP servers loaded", {
+        event: "mcp.loaded",
+        count: servers?.length ?? 0,
+        names: servers?.map((s) => s.name) ?? [],
+      });
+      return servers?.length ? servers : undefined;
+    } catch (err) {
+      this.log.warn("Failed to load MCP servers", {
+        event: "mcp.load_failed",
+        error: String(err),
+      });
+      return undefined;
+    }
+  }
+
+  /**
    * Restore a sandbox from a filesystem snapshot.
    */
   private async restoreFromSnapshot(snapshotImageId: string): Promise<void> {
@@ -490,6 +533,8 @@ export class SandboxLifecycleManager {
         session.spawn_source === "agent" ? CHILD_SANDBOX_TIMEOUT_SECONDS : undefined;
 
       const codeServerEnabled = session.code_server_enabled === 1;
+      const mcpServers = await this.loadMcpServers(session);
+
       const result = await this.provider.restoreFromSnapshot({
         snapshotImageId,
         sessionId: session.session_name || session.id,
@@ -504,6 +549,7 @@ export class SandboxLifecycleManager {
         timeoutSeconds,
         branch: session.base_branch,
         codeServerEnabled,
+        mcpServers,
       });
 
       if (result.success) {

--- a/packages/control-plane/src/sandbox/provider.ts
+++ b/packages/control-plane/src/sandbox/provider.ts
@@ -6,6 +6,7 @@
  */
 
 import type { CorrelationContext } from "../logger";
+import type { McpServerConfig } from "@open-inspect/shared";
 
 /** Default sandbox lifetime in seconds (2 hours). */
 export const DEFAULT_SANDBOX_TIMEOUT_SECONDS = 7200;
@@ -59,6 +60,8 @@ export interface CreateSandboxConfig {
   branch?: string;
   /** Whether to enable code-server (browser-based editor) in the sandbox */
   codeServerEnabled?: boolean;
+  /** MCP servers to inject into the agent session */
+  mcpServers?: McpServerConfig[];
 }
 
 /**
@@ -107,6 +110,8 @@ export interface RestoreConfig {
   timeoutSeconds?: number;
   /** Git branch to work on (defaults to repo's default branch) */
   branch?: string;
+  /** MCP servers to inject into the sandbox */
+  mcpServers?: McpServerConfig[];
   /** Correlation context for downstream tracing */
   correlation?: CorrelationContext;
   /** Whether to enable code-server (browser-based editor) in the sandbox */

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -73,6 +73,7 @@ export class ModalSandboxProvider implements SandboxProvider {
           timeoutSeconds: config.timeoutSeconds,
           branch: config.branch,
           codeServerEnabled: config.codeServerEnabled,
+          mcpServers: config.mcpServers,
         },
         config.correlation
       );
@@ -110,6 +111,7 @@ export class ModalSandboxProvider implements SandboxProvider {
           timeoutSeconds: config.timeoutSeconds ?? DEFAULT_SANDBOX_TIMEOUT_SECONDS,
           branch: config.branch,
           codeServerEnabled: config.codeServerEnabled,
+          mcpServers: config.mcpServers,
         },
         config.correlation
       );

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -25,8 +25,10 @@ import {
   type AlarmScheduler,
   type IdGenerator,
   type RepoImageLookup,
+  type McpServerLookup,
 } from "../sandbox/lifecycle/manager";
 import { RepoImageStore } from "../db/repo-images";
+import { McpServerStore } from "../db/mcp-servers";
 import { SessionIndexStore } from "../db/session-index";
 import { DEFAULT_EXECUTION_TIMEOUT_MS } from "../sandbox/lifecycle/decisions";
 import {
@@ -606,6 +608,21 @@ export class SessionDO extends DurableObject<Env> {
     const session = this.repository.getSession();
     const sessionId = session?.session_name || session?.id || this.ctx.id.toString();
 
+    // Create D1-backed lookups if database is available
+    let repoImageLookup: RepoImageLookup | undefined;
+    let mcpServerLookup: McpServerLookup | undefined;
+    if (this.env.DB) {
+      const repoImageStore = new RepoImageStore(this.env.DB);
+      repoImageLookup = {
+        getLatestReady: (repoOwner, repoName, baseBranch) =>
+          repoImageStore.getLatestReady(repoOwner, repoName, baseBranch),
+      };
+      const mcpStore = new McpServerStore(this.env.DB, this.env.REPO_SECRETS_ENCRYPTION_KEY);
+      mcpServerLookup = {
+        getForSession: (repoOwner, repoName) => mcpStore.getForSession(repoOwner, repoName),
+      };
+    }
+
     const config = {
       ...DEFAULT_LIFECYCLE_CONFIG,
       controlPlaneUrl,
@@ -615,17 +632,8 @@ export class SessionDO extends DurableObject<Env> {
         ...DEFAULT_LIFECYCLE_CONFIG.inactivity,
         timeoutMs: parseInt(this.env.SANDBOX_INACTIVITY_TIMEOUT_MS || "600000", 10),
       },
+      mcpServerLookup,
     };
-
-    // Create repo image lookup if D1 is available
-    let repoImageLookup: RepoImageLookup | undefined;
-    if (this.env.DB) {
-      const repoImageStore = new RepoImageStore(this.env.DB);
-      repoImageLookup = {
-        getLatestReady: (repoOwner, repoName, baseBranch) =>
-          repoImageStore.getLatestReady(repoOwner, repoName, baseBranch),
-      };
-    }
 
     return new SandboxLifecycleManager(
       provider,

--- a/packages/control-plane/src/source-control/providers/github-provider.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.ts
@@ -45,10 +45,12 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
   readonly name = "github";
 
   private readonly appConfig?: GitHubProviderConfig["appConfig"];
+  private readonly allAppConfigs: NonNullable<GitHubProviderConfig["appConfig"]>[];
   private readonly kvCache?: KVNamespace;
 
   constructor(config: GitHubProviderConfig = {}) {
     this.appConfig = config.appConfig;
+    this.allAppConfigs = config.allAppConfigs ?? (config.appConfig ? [config.appConfig] : []);
     this.kvCache = config.kvCache;
   }
 
@@ -204,93 +206,122 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
    * Check whether a repository is accessible to the GitHub App installation.
    */
   async checkRepositoryAccess(config: GetRepositoryConfig): Promise<RepositoryAccessResult | null> {
-    if (!this.appConfig) {
+    if (this.allAppConfigs.length === 0) {
       throw new SourceControlProviderError(
         "GitHub App not configured - cannot check repository access",
         "permanent"
       );
     }
 
-    try {
-      const repo = await getInstallationRepository(
-        this.appConfig,
-        config.owner,
-        config.name,
-        this.kvCache ? { REPOS_CACHE: this.kvCache } : undefined
-      );
-      if (!repo) {
-        return null;
+    // Try each installation until one has access
+    for (const appConfig of this.allAppConfigs) {
+      try {
+        const repo = await getInstallationRepository(
+          appConfig,
+          config.owner,
+          config.name,
+          this.kvCache ? { REPOS_CACHE: this.kvCache } : undefined
+        );
+        if (repo) {
+          return {
+            repoId: repo.id,
+            repoOwner: config.owner.toLowerCase(),
+            repoName: config.name.toLowerCase(),
+            defaultBranch: repo.defaultBranch,
+          };
+        }
+      } catch {
+        // This installation doesn't have access, try the next one
+        continue;
       }
-      return {
-        repoId: repo.id,
-        repoOwner: config.owner.toLowerCase(),
-        repoName: config.name.toLowerCase(),
-        defaultBranch: repo.defaultBranch,
-      };
-    } catch (error) {
-      throw SourceControlProviderError.fromFetchError(
-        `Failed to check repository access: ${error instanceof Error ? error.message : String(error)}`,
-        error,
-        extractHttpStatus(error)
-      );
     }
+    return null;
   }
 
   /**
    * List all repositories accessible to the GitHub App installation.
    */
   async listRepositories(): Promise<InstallationRepository[]> {
-    if (!this.appConfig) {
+    if (this.allAppConfigs.length === 0) {
       throw new SourceControlProviderError(
         "GitHub App not configured - cannot list repositories",
         "permanent"
       );
     }
 
-    try {
-      const result = await listInstallationRepositories(
-        this.appConfig,
-        this.kvCache ? { REPOS_CACHE: this.kvCache } : undefined
-      );
-      return result.repos;
-    } catch (error) {
+    const seen = new Set<number>();
+    const allRepos: InstallationRepository[] = [];
+    let lastError: unknown;
+
+    for (const appConfig of this.allAppConfigs) {
+      try {
+        const result = await listInstallationRepositories(
+          appConfig,
+          this.kvCache ? { REPOS_CACHE: this.kvCache } : undefined
+        );
+        for (const repo of result.repos) {
+          if (!seen.has(repo.id)) {
+            seen.add(repo.id);
+            allRepos.push(repo);
+          }
+        }
+      } catch (error) {
+        // Log but continue — other installations may still work
+        lastError = error;
+      }
+    }
+
+    if (allRepos.length === 0 && lastError) {
       throw SourceControlProviderError.fromFetchError(
-        `Failed to list repositories: ${error instanceof Error ? error.message : String(error)}`,
-        error,
-        extractHttpStatus(error)
+        `Failed to list repositories: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+        lastError,
+        extractHttpStatus(lastError)
       );
     }
+
+    return allRepos;
   }
 
   /**
    * List branches for a repository.
    */
   async listBranches(config: GetRepositoryConfig): Promise<{ name: string }[]> {
-    if (!this.appConfig) {
+    if (this.allAppConfigs.length === 0) {
       throw new SourceControlProviderError(
         "GitHub App not configured - cannot list branches",
         "permanent"
       );
     }
 
-    try {
-      return await listRepositoryBranches(
-        this.appConfig,
-        config.owner,
-        config.name,
-        this.kvCache ? { REPOS_CACHE: this.kvCache } : undefined
-      );
-    } catch (error) {
-      throw SourceControlProviderError.fromFetchError(
-        `Failed to list branches: ${error instanceof Error ? error.message : String(error)}`,
-        error,
-        extractHttpStatus(error)
-      );
+    // Try each installation — repo may belong to a non-primary installation
+    let lastError: unknown;
+    for (const appConfig of this.allAppConfigs) {
+      try {
+        return await listRepositoryBranches(
+          appConfig,
+          config.owner,
+          config.name,
+          this.kvCache ? { REPOS_CACHE: this.kvCache } : undefined
+        );
+      } catch (err) {
+        lastError = err;
+        continue;
+      }
     }
+
+    throw SourceControlProviderError.fromFetchError(
+      `Failed to list branches: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+      lastError,
+      extractHttpStatus(lastError)
+    );
   }
 
   /**
    * Generate authentication for git push operations using GitHub App.
+   *
+   * TODO: Accept repo owner/name and resolve the correct installation token.
+   * Currently uses the primary installation, which may not have access to
+   * repos on secondary installations.
    */
   async generatePushAuth(): Promise<GitPushAuthContext> {
     if (!this.appConfig) {

--- a/packages/control-plane/src/source-control/providers/types.ts
+++ b/packages/control-plane/src/source-control/providers/types.ts
@@ -8,8 +8,10 @@ import type { GitHubAppConfig } from "../../auth/github-app";
  * Configuration for GitHubSourceControlProvider.
  */
 export interface GitHubProviderConfig {
-  /** GitHub App configuration (required for push auth) */
+  /** GitHub App configuration for the primary installation (required for push auth) */
   appConfig?: GitHubAppConfig;
+  /** All GitHub App configurations (one per installation). Used for listing repos and checking access. */
+  allAppConfigs?: GitHubAppConfig[];
   /** KV namespace for caching installation tokens */
   kvCache?: KVNamespace;
 }

--- a/packages/modal-infra/src/functions.py
+++ b/packages/modal-infra/src/functions.py
@@ -38,6 +38,7 @@ async def create_sandbox(
     provider: str = "anthropic",
     model: str = "claude-sonnet-4-6",
     branch: str | None = None,
+    mcp_servers: list[dict] | None = None,
 ) -> dict:
     """
     Create a new sandbox for a session.
@@ -89,6 +90,7 @@ async def create_sandbox(
         opencode_session_id=opencode_session_id,
         provider=provider,
         model=model,
+        mcp_servers=mcp_servers,
     )
 
     config = SandboxConfig(

--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -100,7 +100,7 @@ base_image = (
     # Install OpenCode CLI and plugin for custom tools
     # CACHE_BUSTER is embedded in a no-op echo so Modal invalidates this layer on bump.
     .run_commands(
-        f"echo 'cache: {CACHE_BUSTER}' > /dev/null",
+        f"echo 'cache: {CACHE_BUSTER}' > /tmp/.cache-buster",
         "npm install -g opencode-ai@latest",
         "opencode --version || echo 'OpenCode installed'",
         # Install @opencode-ai/plugin globally for custom tools
@@ -126,7 +126,7 @@ base_image = (
         "mkdir -p /workspace",
         "mkdir -p /app/plugins",
         "mkdir -p /tmp/opencode",
-        "echo 'Image rebuilt at: v21-force-rebuild' > /app/image-version.txt",
+        "echo 'Image rebuilt at: v1' > /app/image-version.txt",
     )
     # Set environment variables (including cache buster to force rebuild)
     .env(
@@ -143,10 +143,13 @@ base_image = (
         }
     )
     # Add sandbox code to the image (includes plugin at /app/sandbox/inspect-plugin.js)
+    # copy=True bakes files into the image layer so run_commands can follow
     .add_local_dir(
         str(SANDBOX_DIR),
         remote_path="/app/sandbox",
+        copy=True,
     )
+    .run_commands(f"echo 'sandbox_version={CACHE_BUSTER}' > /app/sandbox/.version")
 )
 
 # Image variant optimized for Node.js/TypeScript projects

--- a/packages/modal-infra/src/sandbox/entrypoint.py
+++ b/packages/modal-infra/src/sandbox/entrypoint.py
@@ -14,6 +14,7 @@ Runs as PID 1 inside the sandbox. Responsibilities:
 import asyncio
 import json
 import os
+import re
 import shutil
 import signal
 import time
@@ -89,10 +90,12 @@ class SandboxSupervisor:
             session_id=session_id,
         )
 
+        self.log.info("session_config.loaded", keys=list(self.session_config.keys()))
+
     @property
     def base_branch(self) -> str:
         """The branch to clone/fetch — defaults to 'main'."""
-        return self.session_config.get("branch", "main")
+        return self.session_config.get("branch") or "main"
 
     def _build_repo_url(self, authenticated: bool = True) -> str:
         """Build the HTTPS URL for the repository, optionally with clone credentials."""
@@ -291,25 +294,42 @@ class SandboxSupervisor:
             package_json.write_text('{"name": "opencode-tools", "type": "module"}')
 
     def _setup_openai_oauth(self) -> None:
-        """Write OpenCode auth.json for ChatGPT OAuth if refresh token is configured."""
+        """Write OpenCode auth.json for configured LLM providers.
+
+        Builds a unified auth.json from environment variables:
+        - OPENAI_OAUTH_REFRESH_TOKEN → OpenAI OAuth entry
+        - OPENCODE_ZEN_API_KEY → OpenCode Zen (pay-as-you-go) entry
+        - OPENCODE_GO_API_KEY → OpenCode Go (subscription) entry
+        """
+        auth_data: dict[str, dict] = {}
+
         refresh_token = os.environ.get("OPENAI_OAUTH_REFRESH_TOKEN")
-        if not refresh_token:
-            return
-
-        try:
-            auth_dir = Path.home() / ".local" / "share" / "opencode"
-            auth_dir.mkdir(parents=True, exist_ok=True)
-
-            openai_entry = {
+        if refresh_token:
+            entry: dict = {
                 "type": "oauth",
                 "refresh": "managed-by-control-plane",
                 "access": "",
                 "expires": 0,
             }
-
             account_id = os.environ.get("OPENAI_OAUTH_ACCOUNT_ID")
             if account_id:
-                openai_entry["accountId"] = account_id
+                entry["accountId"] = account_id
+            auth_data["openai"] = entry
+
+        zen_key = os.environ.get("OPENCODE_ZEN_API_KEY")
+        if zen_key:
+            auth_data["opencode"] = {"type": "api", "key": zen_key}
+
+        go_key = os.environ.get("OPENCODE_GO_API_KEY")
+        if go_key:
+            auth_data["opencode-go"] = {"type": "api", "key": go_key}
+
+        if not auth_data:
+            return
+
+        try:
+            auth_dir = Path.home() / ".local" / "share" / "opencode"
+            auth_dir.mkdir(parents=True, exist_ok=True)
 
             auth_file = auth_dir / "auth.json"
             tmp_file = auth_dir / ".auth.json.tmp"
@@ -318,12 +338,12 @@ class SandboxSupervisor:
             # atomically rename so the target is never world-readable.
             fd = os.open(str(tmp_file), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
             try:
-                os.write(fd, json.dumps({"openai": openai_entry}).encode())
+                os.write(fd, json.dumps(auth_data).encode())
             finally:
                 os.close(fd)
             tmp_file.replace(auth_file)
 
-            self.log.info("openai_oauth.setup")
+            self.log.info("openai_oauth.setup", providers=list(auth_data.keys()))
         except Exception as e:
             self.log.warn("openai_oauth.setup_error", exc=e)
 
@@ -367,23 +387,143 @@ class SandboxSupervisor:
         except Exception as e:
             self.log.warn("code_server.log_forward_error", exc=e)
 
+    def _resolve_mcp_servers(self) -> list[dict]:
+        """Resolve MCP servers from session config."""
+        return self.session_config.get("mcp_servers") or []
+
+    # Validates npm package names before passing to `npm install -g`.
+    # Accepts: "package", "@scope/package", "package@1.0.0", "@scope/package@1.0.0"
+    # Rejects anything with shell metacharacters or path traversal sequences.
+    # NOTE: if a legitimate package is rejected, widen this regex rather than
+    # removing the check — the package name comes from user-supplied config.
+    _NPM_PKG_RE = re.compile(r"^(@[\w.-]+/)?[\w.-]+(@[\w.-]+)?$")
+
+    def _install_mcp_packages(self, servers: list[dict]) -> None:
+        """Install npm packages required by STDIO MCP servers.
+
+        For each non-remote server whose command starts with 'npx', installs
+        the package globally so npx doesn't download it at runtime (which can
+        fail or be slow inside sandboxes).
+        """
+        packages: list[str] = []
+        for server in servers:
+            if server.get("type") == "remote":
+                continue
+            cmd = server.get("command", [])
+            if not cmd:
+                continue
+            # npx @scope/package  →  install @scope/package
+            # npx -y @scope/package  →  install @scope/package
+            parts = [c for c in cmd if isinstance(c, str)]
+            if not parts or parts[0] != "npx":
+                continue
+            # Resolve the package name to install.
+            #
+            # Two common npx patterns:
+            #   npx [-y] @scope/pkg          → pkg = @scope/pkg (first non-flag)
+            #   npx -p @scope/pkg binary     → pkg = @scope/pkg (-p value)
+            #
+            # The -p/--package flag explicitly names the package to install,
+            # while the following arg is the binary to run. If we extracted
+            # the binary name instead, npm would install the wrong package.
+            pkg: str | None = None
+            for i, part in enumerate(parts):
+                if part in ("-p", "--package") and i + 1 < len(parts):
+                    pkg = parts[i + 1]
+                    break
+            if pkg is None:
+                non_flags = [p for p in parts[1:] if not p.startswith("-")]
+                pkg = non_flags[0] if non_flags else None
+
+            if pkg:
+                if self._NPM_PKG_RE.match(pkg):
+                    packages.append(pkg)
+                else:
+                    self.log.warn(
+                        "mcp.invalid_package_name",
+                        package=pkg,
+                        note="package skipped — npx will attempt download at runtime",
+                    )
+
+        packages = list(dict.fromkeys(packages))  # deduplicate, preserve order
+        if not packages:
+            return
+
+        self.log.info("mcp.install_packages", packages=packages)
+        import subprocess
+
+        try:
+            result = subprocess.run(
+                ["npm", "install", "-g", *packages],
+                capture_output=True,
+                text=True,
+                timeout=180,
+            )
+            if result.returncode == 0:
+                self.log.info("mcp.packages_installed", packages=packages)
+            else:
+                self.log.warn(
+                    "mcp.packages_install_failed",
+                    packages=packages,
+                    stderr=result.stderr[:500],
+                )
+        except Exception as e:
+            self.log.warn("mcp.packages_install_error", packages=packages, exc=str(e))
+
+    def _build_mcp_config(self, servers: list[dict]) -> dict[str, dict]:
+        """Convert MCP server list to OpenCode mcp config format.
+
+        OpenCode MCP config reference: https://opencode.ai/docs/mcp-servers/
+        - Local servers: {"type": "local", "command": [...], "environment": {...}}
+        - Remote servers: {"type": "remote", "url": "...", "headers": {...}}
+          For remote servers, env vars are mapped to HTTP request headers
+          (e.g. {"Authorization": "Bearer <token>"}). This is the OpenCode-
+          documented way to pass auth credentials to remote MCP endpoints.
+        """
+        config: dict[str, dict] = {}
+        for server in servers:
+            name = server.get("name", "")
+            if not name:
+                continue
+            if server.get("type") == "remote":
+                entry: dict = {"type": "remote", "url": server.get("url", "")}
+                # Remote auth headers — read from `headers` (new) or `env` (legacy fallback).
+                # Do NOT log this value — may contain bearer tokens / API keys.
+                auth_headers = server.get("headers") or server.get("env") or {}
+                if auth_headers:
+                    entry["headers"] = auth_headers
+                config[name] = entry
+            else:
+                entry = {
+                    "type": "local",
+                    "command": server.get("command", []),
+                }
+                if server.get("env"):
+                    entry["environment"] = server["env"]
+                config[name] = entry
+        return config
+
     async def start_opencode(self) -> None:
         """Start OpenCode server with configuration."""
         self._setup_openai_oauth()
         self.log.info("opencode.start")
 
         # Build OpenCode config from session settings
-        # Model format is "provider/model", e.g. "anthropic/claude-sonnet-4-6"
         provider = self.session_config.get("provider", "anthropic")
         model = self.session_config.get("model", "claude-sonnet-4-6")
-        opencode_config = {
+        opencode_config: dict = {
             "model": f"{provider}/{model}",
-            "permission": {
-                "*": {
-                    "*": "allow",
-                },
-            },
+            "permission": {"*": {"*": "allow"}},
         }
+
+        # Inject MCP servers
+        mcp_servers = self._resolve_mcp_servers()
+        if mcp_servers:
+            self._install_mcp_packages(mcp_servers)
+            mcp_config = self._build_mcp_config(mcp_servers)
+            if mcp_config:
+                opencode_config["mcp"] = mcp_config
+                self.log.info("mcp.configured", count=len(mcp_config))
 
         # Determine working directory - use repo path if cloned, otherwise /workspace
         workdir = self.workspace_path
@@ -647,7 +787,7 @@ class SandboxSupervisor:
 
     async def _report_fatal_error(self, message: str) -> None:
         """Report a fatal error to the control plane."""
-        self.log.error("supervisor.fatal", message=message)
+        self.log.error("supervisor.fatal", error_message=message)
 
         if not self.control_plane_url:
             return
@@ -872,9 +1012,9 @@ class SandboxSupervisor:
             else:
                 start_success = None
 
-            # Image build mode: signal completion, then keep sandbox alive for
-            # snapshot_filesystem(). The builder streams stdout, detects this
-            # event, snapshots the running sandbox, then terminates us.
+            # Image build mode: signal completion then keep sandbox alive for
+            # snapshot_filesystem(). MCP packages are not pre-installed during
+            # builds — they are installed at first use via npx at session start.
             if image_build_mode:
                 duration_ms = int((time.time() - startup_start) * 1000)
                 self.log.info("image_build.complete", duration_ms=duration_ms)

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -259,9 +259,12 @@ class SandboxManager:
 
         Like create_sandbox() but:
         - Sets IMAGE_BUILD_MODE=true (exits after setup, no OpenCode/bridge)
-        - No CONTROL_PLANE_URL, SANDBOX_AUTH_TOKEN, or LLM secrets
+        - No SANDBOX_AUTH_TOKEN, CONTROL_PLANE_URL, or LLM secrets
         - Shorter timeout (30 min vs 2 hours)
         - Always uses base_image (builds start from the universal base)
+
+        Note: MCP servers are not available during image builds (no session config).
+        MCP packages are installed at first use via npx instead.
         """
         BUILD_TIMEOUT_SECONDS = 1800
 

--- a/packages/modal-infra/src/sandbox/types.py
+++ b/packages/modal-infra/src/sandbox/types.py
@@ -1,7 +1,7 @@
 """Type definitions for sandbox operations."""
 
 from enum import StrEnum
-from typing import Any
+from typing import Any, TypedDict
 
 from pydantic import BaseModel
 
@@ -106,6 +106,25 @@ class GitUser(BaseModel):
     email: str
 
 
+class McpServerConfig(TypedDict, total=False):
+    """Shape of an MCP server config entry, mirroring the TypeScript McpServerConfig type.
+
+    Fields match packages/shared/src/types/integrations.ts > McpServerConfig.
+    - stdio servers: set command + env (process environment variables)
+    - remote servers: set url + headers (HTTP request headers, e.g. Authorization)
+    """
+
+    id: str
+    name: str
+    type: str  # "stdio" | "remote"
+    command: list[str]
+    url: str
+    env: dict[str, str]  # stdio only — process environment variables
+    headers: dict[str, str]  # remote only — HTTP request headers
+    repoScopes: list[str] | None
+    enabled: bool
+
+
 class SessionConfig(BaseModel):
     """Configuration passed to sandbox for a session."""
 
@@ -117,3 +136,4 @@ class SessionConfig(BaseModel):
     opencode_session_id: str | None = None
     provider: str = "anthropic"
     model: str = "claude-sonnet-4-6"
+    mcp_servers: list[McpServerConfig] | None = None

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -146,6 +146,7 @@ async def api_create_sandbox(
             opencode_session_id=request.get("opencode_session_id"),
             provider=request.get("provider", "anthropic"),
             model=request.get("model", "claude-sonnet-4-6"),
+            mcp_servers=request.get("mcp_servers"),
         )
 
         config = SandboxConfig(

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -47,6 +47,25 @@ export type GitHubGlobalConfig = IntegrationSettingsMap["github"]["global"];
 export type LinearGlobalConfig = IntegrationSettingsMap["linear"]["global"];
 export type CodeServerGlobalConfig = IntegrationSettingsMap["code-server"]["global"];
 
+/** MCP server configuration. */
+export interface McpServerConfig {
+  id: string;
+  name: string;
+  type: "stdio" | "remote";
+  command?: string[];
+  url?: string;
+  /** Process environment variables — only applicable for stdio servers. */
+  env?: Record<string, string>;
+  /**
+   * HTTP request headers — only applicable for remote servers.
+   * Sent with every request to the remote MCP endpoint (e.g. Authorization).
+   * Per OpenCode MCP spec: https://opencode.ai/docs/mcp-servers/#remote
+   */
+  headers?: Record<string, string>;
+  repoScopes?: string[] | null;
+  enabled: boolean;
+}
+
 export const INTEGRATION_DEFINITIONS: {
   id: IntegrationId;
   name: string;

--- a/packages/web/src/app/(app)/settings/page.tsx
+++ b/packages/web/src/app/(app)/settings/page.tsx
@@ -10,6 +10,7 @@ import { DataControlsSettings } from "@/components/settings/data-controls-settin
 import { KeyboardShortcutsSettings } from "@/components/settings/keyboard-shortcuts-settings";
 import { IntegrationsSettings } from "@/components/settings/integrations-settings";
 import { ImagesSettings } from "@/components/settings/images-settings";
+import { McpServersSettings } from "@/components/settings/mcp-servers-settings";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import { SidebarIcon, BackIcon } from "@/components/ui/icons";
 import { useIsMobile } from "@/hooks/use-media-query";
@@ -21,6 +22,7 @@ const CATEGORY_LABELS: Record<SettingsCategory, string> = {
   "keyboard-shortcuts": "Keyboard",
   "data-controls": "Data Controls",
   integrations: "Integrations",
+  "mcp-servers": "MCP Servers",
 };
 
 const VALID_CATEGORIES = new Set<string>([
@@ -30,6 +32,7 @@ const VALID_CATEGORIES = new Set<string>([
   "keyboard-shortcuts",
   "data-controls",
   "integrations",
+  "mcp-servers",
 ]);
 
 function isValidCategory(tab: string | null): tab is SettingsCategory {
@@ -68,6 +71,7 @@ export default function SettingsPage() {
       {activeCategory === "keyboard-shortcuts" && <KeyboardShortcutsSettings />}
       {activeCategory === "data-controls" && <DataControlsSettings />}
       {activeCategory === "integrations" && <IntegrationsSettings />}
+      {activeCategory === "mcp-servers" && <McpServersSettings />}
     </>
   );
 

--- a/packages/web/src/app/api/mcp-servers/[id]/route.ts
+++ b/packages/web/src/app/api/mcp-servers/[id]/route.ts
@@ -1,0 +1,65 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  try {
+    const response = await controlPlaneFetch(`/mcp-servers/${id}`);
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to fetch MCP server:", error);
+    return NextResponse.json({ error: "Failed to fetch MCP server" }, { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  try {
+    const body = await request.json();
+    const response = await controlPlaneFetch(`/mcp-servers/${id}`, {
+      method: "PUT",
+      body: JSON.stringify(body),
+    });
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to update MCP server:", error);
+    return NextResponse.json({ error: "Failed to update MCP server" }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  try {
+    const response = await controlPlaneFetch(`/mcp-servers/${id}`, {
+      method: "DELETE",
+    });
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to delete MCP server:", error);
+    return NextResponse.json({ error: "Failed to delete MCP server" }, { status: 500 });
+  }
+}

--- a/packages/web/src/app/api/mcp-servers/route.ts
+++ b/packages/web/src/app/api/mcp-servers/route.ts
@@ -1,0 +1,43 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const repo = request.nextUrl.searchParams.get("repo");
+    const path = repo ? `/mcp-servers?repo=${encodeURIComponent(repo)}` : "/mcp-servers";
+    const response = await controlPlaneFetch(path);
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to fetch MCP servers:", error);
+    return NextResponse.json({ error: "Failed to fetch MCP servers" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const response = await controlPlaneFetch("/mcp-servers", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to create MCP server:", error);
+    return NextResponse.json({ error: "Failed to create MCP server" }, { status: 500 });
+  }
+}

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -6,10 +6,7 @@ import { authOptions } from "@/lib/auth";
 import { controlPlaneFetch } from "@/lib/control-plane";
 
 export async function GET(request: NextRequest) {
-  const routeStart = Date.now();
-
   const session = await getServerSession(authOptions);
-  const authMs = Date.now() - routeStart;
 
   if (!session) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -20,15 +17,8 @@ export async function GET(request: NextRequest) {
   const path = queryString ? `/sessions?${queryString}` : "/sessions";
 
   try {
-    const fetchStart = Date.now();
     const response = await controlPlaneFetch(path);
-    const fetchMs = Date.now() - fetchStart;
     const data = await response.json();
-    const totalMs = Date.now() - routeStart;
-
-    console.log(
-      `[sessions:GET] total=${totalMs}ms auth=${authMs}ms fetch=${fetchMs}ms status=${response.status}`
-    );
 
     return NextResponse.json(data, { status: response.status });
   } catch (error) {

--- a/packages/web/src/components/settings/mcp-servers-settings.tsx
+++ b/packages/web/src/components/settings/mcp-servers-settings.tsx
@@ -1,0 +1,582 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import type { McpServerConfig } from "@open-inspect/shared";
+import {
+  useMcpServers,
+  createMcpServer,
+  updateMcpServer,
+  deleteMcpServer,
+} from "@/hooks/use-mcp-servers";
+import { useRepos } from "@/hooks/use-repos";
+import { PlusIcon, TerminalIcon, GlobeIcon, ErrorIcon } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+
+type ScopeMode = "global" | "selected";
+
+type FormState = {
+  name: string;
+  type: "stdio" | "remote";
+  command: string;
+  url: string;
+  env: string;
+  repoScopes: string[];
+  scopeMode: ScopeMode;
+  enabled: boolean;
+};
+
+const emptyForm: FormState = {
+  name: "",
+  type: "remote",
+  command: "",
+  url: "",
+  env: "",
+  repoScopes: [],
+  scopeMode: "global",
+  enabled: true,
+};
+
+function configToForm(config: McpServerConfig): FormState {
+  return {
+    name: config.name,
+    type: config.type,
+    command:
+      config.command
+        ?.map((t) =>
+          // Quote any token containing whitespace or shell-special chars so the
+          // display string round-trips correctly through parseCommand().
+          // The command array is always the canonical source of truth.
+          /[\s$`#!&|;<>(){}\\"]/.test(t) ? `"${t.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"` : t
+        )
+        .join(" ") ?? "",
+    url: config.url ?? "",
+    // For remote servers, the relevant key/value pairs are HTTP headers (McpServerConfig.headers).
+    // For stdio servers, they are process environment variables (McpServerConfig.env).
+    env: (() => {
+      const pairs = config.type === "remote" ? config.headers : config.env;
+      return pairs && Object.keys(pairs).length > 0
+        ? Object.entries(pairs)
+            .map(([k, v]) => `${k}=${v}`)
+            .join("\n")
+        : "";
+    })(),
+    repoScopes: config.repoScopes ?? [],
+    scopeMode: config.repoScopes?.length ? "selected" : "global",
+    enabled: config.enabled,
+  };
+}
+
+function parseEnv(envStr: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const line of envStr.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx > 0) {
+      result[trimmed.slice(0, eqIdx)] = trimmed.slice(eqIdx + 1);
+    }
+  }
+  return result;
+}
+
+/** Minimal shell-quote aware parser: respects "..." and '...' grouping. */
+function parseCommand(cmd: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: string | null = null;
+  for (const ch of cmd) {
+    if (quote) {
+      if (ch === quote) {
+        quote = null;
+      } else {
+        current += ch;
+      }
+    } else if (ch === '"' || ch === "'") {
+      quote = ch;
+    } else if (/\s/.test(ch)) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+    } else {
+      current += ch;
+    }
+  }
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+interface McpServerFormProps {
+  form: FormState;
+  setForm: (form: FormState) => void;
+  repos: { fullName: string; private?: boolean }[];
+  loadingRepos: boolean;
+  radioPrefix: string;
+}
+
+function McpServerForm({ form, setForm, repos, loadingRepos, radioPrefix }: McpServerFormProps) {
+  return (
+    <>
+      <div>
+        <label className="block text-sm font-medium text-foreground mb-1">Name</label>
+        <input
+          type="text"
+          value={form.name}
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+          placeholder="e.g. playwright, context7"
+          className="w-full px-3 py-2 text-sm border border-border bg-input text-foreground rounded-sm focus:outline-none focus:border-foreground/30"
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-foreground mb-1">Type</label>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setForm({ ...form, type: "remote" })}
+            className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-sm border transition ${
+              form.type === "remote"
+                ? "border-foreground/30 text-foreground bg-muted"
+                : "border-border text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <GlobeIcon className="w-3.5 h-3.5" />
+            Remote
+          </button>
+          <button
+            onClick={() => setForm({ ...form, type: "stdio" })}
+            className={`flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-sm border transition ${
+              form.type === "stdio"
+                ? "border-foreground/30 text-foreground bg-muted"
+                : "border-border text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <TerminalIcon className="w-3.5 h-3.5" />
+            Stdio
+          </button>
+        </div>
+      </div>
+
+      {form.type === "remote" ? (
+        <div>
+          <label className="block text-sm font-medium text-foreground mb-1">URL</label>
+          <input
+            type="url"
+            value={form.url}
+            onChange={(e) => setForm({ ...form, url: e.target.value })}
+            placeholder="https://mcp.example.com/sse"
+            className="w-full px-3 py-2 text-sm border border-border bg-input text-foreground rounded-sm focus:outline-none focus:border-foreground/30"
+          />
+        </div>
+      ) : (
+        <div>
+          <label className="block text-sm font-medium text-foreground mb-1">Command</label>
+          <input
+            type="text"
+            value={form.command}
+            onChange={(e) => setForm({ ...form, command: e.target.value })}
+            placeholder="npx -y @playwright/mcp"
+            className="w-full px-3 py-2 text-sm border border-border bg-input text-foreground rounded-sm focus:outline-none focus:border-foreground/30"
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            Space-separated command and arguments. Use quotes for arguments with spaces.
+          </p>
+        </div>
+      )}
+
+      <div>
+        <label className="block text-sm font-medium text-foreground mb-1">
+          {form.type === "remote" ? "HTTP Headers" : "Environment Variables"}{" "}
+          <span className="text-muted-foreground font-normal">(optional)</span>
+        </label>
+        <textarea
+          value={form.env}
+          onChange={(e) => setForm({ ...form, env: e.target.value })}
+          placeholder={
+            form.type === "remote"
+              ? "Authorization=Bearer <token>\nX-Custom-Header=value"
+              : "KEY=value\nANOTHER_KEY=value"
+          }
+          rows={3}
+          className="w-full px-3 py-2 text-sm border border-border bg-input text-foreground rounded-sm focus:outline-none focus:border-foreground/30 font-mono"
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-foreground mb-2">Availability</label>
+        <div className="space-y-2 mb-2">
+          <label className="flex items-start gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name={`scope-mode-${radioPrefix}`}
+              checked={form.scopeMode === "global"}
+              onChange={() => setForm({ ...form, scopeMode: "global", repoScopes: [] })}
+              className="mt-0.5"
+            />
+            <div>
+              <span className="text-sm text-foreground">All repositories</span>
+              <p className="text-xs text-muted-foreground">Available in every agent session</p>
+            </div>
+          </label>
+          <label className="flex items-start gap-2 cursor-pointer">
+            <input
+              type="radio"
+              name={`scope-mode-${radioPrefix}`}
+              checked={form.scopeMode === "selected"}
+              onChange={() => setForm({ ...form, scopeMode: "selected" })}
+              className="mt-0.5"
+            />
+            <div>
+              <span className="text-sm text-foreground">Selected repositories only</span>
+              <p className="text-xs text-muted-foreground">
+                Only available in sessions for chosen repos
+              </p>
+            </div>
+          </label>
+        </div>
+
+        {form.scopeMode === "selected" && (
+          <>
+            {loadingRepos ? (
+              <p className="text-sm text-muted-foreground px-3 py-2">Loading repositories...</p>
+            ) : repos.length === 0 ? (
+              <p className="text-sm text-muted-foreground px-3 py-2 border border-border rounded-sm">
+                No repositories available. Connect a GitHub integration first.
+              </p>
+            ) : (
+              <div className="border border-border max-h-40 overflow-y-auto rounded-sm">
+                {repos.map((repo) => {
+                  const fullName = repo.fullName.toLowerCase();
+                  const isChecked = form.repoScopes.includes(fullName);
+                  return (
+                    <label
+                      key={repo.fullName}
+                      className="flex items-center gap-2 px-3 py-2 hover:bg-muted/50 transition cursor-pointer text-sm"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={isChecked}
+                        onChange={() => {
+                          const next = isChecked
+                            ? form.repoScopes.filter((r) => r !== fullName)
+                            : [...form.repoScopes, fullName];
+                          setForm({ ...form, repoScopes: next });
+                        }}
+                        className="rounded border-border"
+                      />
+                      <span className="text-foreground">{repo.fullName}</span>
+                      {repo.private && (
+                        <span className="text-xs text-muted-foreground">private</span>
+                      )}
+                    </label>
+                  );
+                })}
+              </div>
+            )}
+            {form.repoScopes.length === 0 && repos.length > 0 && (
+              <p className="text-xs text-amber-500 mt-1">
+                Select a repository or switch to &quot;All repositories&quot;.
+              </p>
+            )}
+          </>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          id={`mcp-enabled-${radioPrefix}`}
+          checked={form.enabled}
+          onChange={(e) => setForm({ ...form, enabled: e.target.checked })}
+          className="rounded border-border"
+        />
+        <label htmlFor={`mcp-enabled-${radioPrefix}`} className="text-sm text-foreground">
+          Enabled
+        </label>
+      </div>
+    </>
+  );
+}
+
+export function McpServersSettings() {
+  const { servers, loading, mutate } = useMcpServers();
+  const { repos, loading: loadingRepos } = useRepos();
+  const [editing, setEditing] = useState<string | "new" | null>(null);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [form, setForm] = useState<FormState>(emptyForm);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  // Sync SWR background refreshes into the open edit form
+  useEffect(() => {
+    if (editing && editing !== "new") {
+      const current = servers.find((s) => s.id === editing);
+      if (current) setForm(configToForm(current));
+    }
+    // setForm is stable (useState setter), configToForm is a module-level pure fn
+  }, [servers, editing]);
+
+  function startNew() {
+    setExpanded(null);
+    setForm(emptyForm);
+    setEditing("new");
+    setError(null);
+  }
+
+  function startEdit(server: McpServerConfig) {
+    if (expanded === server.id) {
+      setExpanded(null);
+      setEditing(null);
+    } else {
+      setForm(configToForm(server));
+      setEditing(server.id);
+      setExpanded(server.id);
+    }
+    setError(null);
+  }
+
+  function cancel() {
+    setEditing(null);
+    setExpanded(null);
+    setError(null);
+  }
+
+  async function save() {
+    if (!form.name.trim()) {
+      setError("Name is required");
+      return;
+    }
+    if (form.type === "remote" && !form.url.trim()) {
+      setError("URL is required for remote servers");
+      return;
+    }
+    if (form.type === "stdio" && !form.command.trim()) {
+      setError("Command is required for stdio servers");
+      return;
+    }
+
+    setSaving(true);
+    setError(null);
+
+    try {
+      const payload: Partial<McpServerConfig> = {
+        name: form.name.trim(),
+        type: form.type,
+        enabled: form.enabled,
+        repoScopes:
+          form.scopeMode === "selected" && form.repoScopes.length > 0 ? form.repoScopes : null,
+      };
+
+      if (form.type === "remote") {
+        payload.url = form.url.trim();
+        // Remote servers use HTTP headers for auth (e.g. Authorization: Bearer <token>)
+        payload.headers = parseEnv(form.env);
+      } else {
+        payload.command = parseCommand(form.command);
+        payload.env = parseEnv(form.env);
+      }
+
+      if (editing === "new") {
+        await createMcpServer(payload as Omit<McpServerConfig, "id">);
+      } else if (editing) {
+        await updateMcpServer(editing, payload);
+      }
+
+      setEditing(null);
+      mutate();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!window.confirm("Delete this MCP server? This cannot be undone.")) return;
+    try {
+      await deleteMcpServer(id);
+      mutate();
+      if (editing === id) setEditing(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete");
+    }
+  }
+
+  async function handleToggle(server: McpServerConfig) {
+    try {
+      await updateMcpServer(server.id, { enabled: !server.enabled });
+      mutate();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to toggle");
+    }
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <h2 className="text-xl font-semibold text-foreground">MCP Servers</h2>
+        <Button onClick={startNew} variant="outline" size="sm">
+          <span className="inline-flex items-center gap-1">
+            <PlusIcon className="w-3.5 h-3.5" />
+            Add Server
+          </span>
+        </Button>
+      </div>
+      <p className="text-sm text-muted-foreground mb-6">
+        Configure Model Context Protocol servers that are available to agent sessions.
+      </p>
+
+      {error && (
+        <div className="flex items-center gap-2 text-sm text-red-400 mb-4 px-3 py-2 bg-red-400/10 rounded">
+          <ErrorIcon className="w-4 h-4 flex-shrink-0" />
+          {error}
+        </div>
+      )}
+
+      {/* New server form */}
+      {editing === "new" && (
+        <div className="border border-border rounded-md p-4 mb-6 space-y-4">
+          <div className="flex items-center justify-between mb-1">
+            <h3 className="text-sm font-medium text-foreground">New MCP Server</h3>
+            <button
+              onClick={cancel}
+              className="p-1 text-muted-foreground hover:text-foreground transition"
+              aria-label="Close"
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+          <McpServerForm
+            form={form}
+            setForm={setForm}
+            repos={repos}
+            loadingRepos={loadingRepos}
+            radioPrefix="new"
+          />
+          <div className="flex gap-2 pt-2">
+            <Button onClick={save} disabled={saving} size="sm">
+              {saving ? "Saving..." : "Add Server"}
+            </Button>
+            <Button onClick={cancel} variant="outline" size="sm">
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Server list */}
+      {loading ? (
+        <div className="text-sm text-muted-foreground">Loading...</div>
+      ) : servers.length === 0 && editing !== "new" ? (
+        <div className="text-sm text-muted-foreground py-8 text-center">
+          No MCP servers configured. Add one to extend agent capabilities.
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {servers.map((server) => {
+            const isExpanded = expanded === server.id;
+            return (
+              <div
+                key={server.id}
+                className={`border rounded-md transition ${
+                  server.enabled
+                    ? "border-border bg-card"
+                    : "border-border/50 bg-card/50 opacity-60"
+                }`}
+              >
+                {/* Header row */}
+                <div
+                  className="flex items-center justify-between px-4 py-3 cursor-pointer"
+                  onClick={() => startEdit(server)}
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <svg
+                      className={`w-3 h-3 text-muted-foreground flex-shrink-0 transition-transform ${
+                        isExpanded ? "rotate-90" : ""
+                      }`}
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                    </svg>
+                    {server.type === "remote" ? (
+                      <GlobeIcon className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+                    ) : (
+                      <TerminalIcon className="w-4 h-4 text-muted-foreground flex-shrink-0" />
+                    )}
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium text-foreground truncate">
+                        {server.name}
+                      </div>
+                      <div className="text-xs text-muted-foreground truncate">
+                        {server.type === "remote" ? server.url : server.command?.join(" ")}
+                        {server.repoScopes?.length ? (
+                          <span className="ml-2 text-accent">
+                            •{" "}
+                            {server.repoScopes.length === 1
+                              ? server.repoScopes[0]
+                              : `${server.repoScopes.length} repos`}
+                          </span>
+                        ) : (
+                          <span className="ml-2 text-muted-foreground/60">• global</span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div
+                    className="flex items-center gap-1 flex-shrink-0"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <button
+                      onClick={() => handleToggle(server)}
+                      className="px-2 py-1 text-xs text-muted-foreground hover:text-foreground transition"
+                    >
+                      {server.enabled ? "Disable" : "Enable"}
+                    </button>
+                    <button
+                      onClick={() => handleDelete(server.id)}
+                      className="px-2 py-1 text-xs text-red-400 hover:text-red-300 transition"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+
+                {/* Expanded edit form */}
+                {isExpanded && editing === server.id && (
+                  <div className="px-4 pb-4 pt-3 border-t border-border space-y-4">
+                    <McpServerForm
+                      form={form}
+                      setForm={setForm}
+                      repos={repos}
+                      loadingRepos={loadingRepos}
+                      radioPrefix={server.id}
+                    />
+                    <div className="flex gap-2 pt-2">
+                      <Button onClick={save} disabled={saving} size="sm">
+                        {saving ? "Saving..." : "Save Changes"}
+                      </Button>
+                      <Button onClick={cancel} variant="outline" size="sm">
+                        Cancel
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/settings-nav.tsx
+++ b/packages/web/src/components/settings/settings-nav.tsx
@@ -8,6 +8,7 @@ import {
   KeyboardIcon,
   DataControlsIcon,
   IntegrationsIcon,
+  TerminalIcon,
   ChevronRightIcon,
 } from "@/components/ui/icons";
 
@@ -41,6 +42,11 @@ const NAV_ITEMS = [
     id: "integrations",
     label: "Integrations",
     icon: IntegrationsIcon,
+  },
+  {
+    id: "mcp-servers",
+    label: "MCP Servers",
+    icon: TerminalIcon,
   },
 ] as const;
 

--- a/packages/web/src/hooks/use-mcp-servers.ts
+++ b/packages/web/src/hooks/use-mcp-servers.ts
@@ -1,0 +1,58 @@
+import useSWR from "swr";
+import { useSession } from "next-auth/react";
+import type { McpServerConfig } from "@open-inspect/shared";
+
+const MCP_SERVERS_KEY = "/api/mcp-servers";
+
+export function useMcpServers() {
+  const { data: session } = useSession();
+
+  const { data, isLoading, mutate } = useSWR<McpServerConfig[]>(session ? MCP_SERVERS_KEY : null);
+
+  return {
+    servers: data ?? [],
+    loading: isLoading,
+    mutate,
+  };
+}
+
+export async function createMcpServer(
+  config: Omit<McpServerConfig, "id">
+): Promise<McpServerConfig> {
+  const response = await fetch(MCP_SERVERS_KEY, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(config),
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || "Failed to create MCP server");
+  }
+  return response.json();
+}
+
+export async function updateMcpServer(
+  id: string,
+  patch: Partial<McpServerConfig>
+): Promise<McpServerConfig> {
+  const response = await fetch(`${MCP_SERVERS_KEY}/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(patch),
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || "Failed to update MCP server");
+  }
+  return response.json();
+}
+
+export async function deleteMcpServer(id: string): Promise<void> {
+  const response = await fetch(`${MCP_SERVERS_KEY}/${id}`, {
+    method: "DELETE",
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || "Failed to delete MCP server");
+  }
+}

--- a/terraform/d1/migrations/0014_create_mcp_servers.sql
+++ b/terraform/d1/migrations/0014_create_mcp_servers.sql
@@ -1,0 +1,13 @@
+-- MCP server configurations
+CREATE TABLE IF NOT EXISTS mcp_servers (
+  id         TEXT PRIMARY KEY,
+  name       TEXT NOT NULL,
+  type       TEXT NOT NULL CHECK(type IN ('stdio', 'remote')),
+  command    TEXT,
+  url        TEXT,
+  env        TEXT NOT NULL DEFAULT '{}',
+  repo_scope TEXT,
+  enabled    INTEGER NOT NULL DEFAULT 1,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);

--- a/terraform/d1/migrations/0015_mcp_servers_unique_name.sql
+++ b/terraform/d1/migrations/0015_mcp_servers_unique_name.sql
@@ -1,0 +1,3 @@
+-- Add unique constraint on mcp_servers.name to prevent duplicate names
+-- (duplicate names cause the last one to silently win in Python dict builds)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_servers_name ON mcp_servers(name);

--- a/terraform/d1/migrations/0016_mcp_servers_type_constraint.sql
+++ b/terraform/d1/migrations/0016_mcp_servers_type_constraint.sql
@@ -1,0 +1,28 @@
+-- SQLite does not support ALTER TABLE ADD CONSTRAINT, so we recreate the table
+-- to add a structural integrity check: stdio servers must have a command,
+-- remote servers must have a url. The application layer already enforces this
+-- via McpServerValidationError, but the DB constraint is defence-in-depth.
+--
+-- The unique name index from migration 0015 is also recreated here.
+
+CREATE TABLE mcp_servers_new (
+  id         TEXT PRIMARY KEY,
+  name       TEXT NOT NULL,
+  type       TEXT NOT NULL CHECK(type IN ('stdio', 'remote')),
+  command    TEXT,
+  url        TEXT,
+  env        TEXT NOT NULL DEFAULT '{}',
+  repo_scope TEXT,
+  enabled    INTEGER NOT NULL DEFAULT 1,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  CHECK((type = 'stdio' AND command IS NOT NULL) OR (type = 'remote' AND url IS NOT NULL))
+);
+
+INSERT INTO mcp_servers_new SELECT * FROM mcp_servers;
+
+DROP TABLE mcp_servers;
+
+ALTER TABLE mcp_servers_new RENAME TO mcp_servers;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_servers_name ON mcp_servers(name);


### PR DESCRIPTION
## Summary

Adds full MCP (Model Context Protocol) server management: configure servers via the settings UI, persist them in D1, and inject them into agent sandboxes at runtime.

## Changes

### Control Plane
- **D1 migration** (`0014_create_mcp_servers.sql`) — `mcp_servers` table with JSON `repo_scope` column
- **`McpServerStore`** — CRUD operations with repo-scope filtering (JS-side, D1 lacks JSON functions)
- **REST API routes** — `GET/POST /mcp-servers`, `GET/PUT/DELETE /mcp-servers/:id`
- **Lifecycle manager** — `loadMcpServers()` fetches and injects MCP config into sandbox creation
- **Sandbox client/provider** — `mcpServers` field threaded through create/restore requests

### Modal Sandbox
- **`_resolve_mcp_servers()`** — loads from session config or falls back to control plane API
- **`_install_mcp_packages()`** — pre-installs npm packages for stdio servers (`npx` → `npm install -g`)
- **`_build_mcp_config()`** — converts server list to OpenCode config format
- **`_generate_internal_token()`** — HMAC auth for control plane API fallback
- **Image build mode** — pre-installs MCP packages during `modal deploy`
- **`manager.py`** — passes `CONTROL_PLANE_URL` + `INTERNAL_CALLBACK_SECRET` to build sandboxes

### Web Dashboard
- **Settings UI** — accordion-style MCP server editor using shadcn components (`Input`, `Textarea`, `Label`, `Switch`, `Checkbox`, `RadioCard`, `Badge`)
- **SWR hook** (`use-mcp-servers.ts`) — list/create/update/delete with optimistic mutation
- **Next.js API proxy** — `/api/mcp-servers` and `/api/mcp-servers/[id]`
- **Settings nav** — MCP Servers tab added

### Shared
- **`McpServerConfig`** type in `@open-inspect/shared`

### Cleanup
- Removed debug timing instrumentation from sessions route

## Testing
- TypeScript typecheck passes (all workspaces)
- 92 tests pass
- Lint + Prettier clean
- No conflicts with `main`