### PR TITLE
fix(web): replace instant-logout avatar with UserMenu dropdown

### DIFF
--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -234,8 +234,12 @@ function UserMenu({ user }: { user?: { name?: string | null; image?: string | nu
   useEffect(() => {
     if (!open) return;
     function handleClick(e: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node) &&
-          buttonRef.current && !buttonRef.current.contains(e.target as Node)) {
+      if (
+        menuRef.current &&
+        !menuRef.current.contains(e.target as Node) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(e.target as Node)
+      ) {
         setOpen(false);
       }
     }
@@ -272,11 +276,7 @@ function UserMenu({ user }: { user?: { name?: string | null; image?: string | nu
         title={`Signed in as ${user?.name || "User"}`}
       >
         {user?.image ? (
-          <img
-            src={user.image}
-            alt={user.name || "User"}
-            className="w-full h-full object-cover"
-          />
+          <img src={user.image} alt={user.name || "User"} className="w-full h-full object-cover" />
         ) : (
           <span className="w-full h-full rounded-full bg-card flex items-center justify-center text-xs font-medium text-foreground">
             {user?.name?.charAt(0).toUpperCase() || "?"}
@@ -298,8 +298,18 @@ function UserMenu({ user }: { user?: { name?: string | null; image?: string | nu
             onClick={() => signOut()}
             className="w-full flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition"
           >
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15m3-3l3-3m0 0l-3-3m3 3H9" />
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={1.5}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15m3-3l3-3m0 0l-3-3m3 3H9"
+              />
             </svg>
             Sign out
           </button>


### PR DESCRIPTION
The profile avatar in the sidebar triggers sign-out on click with no confirmation. This replaces it with a dropdown menu.

### Changes
- Extract `UserMenu` component from inline avatar button
- Fixed positioning so dropdown escapes sidebar `overflow: hidden`
- Click-outside-to-dismiss
- Dropdown opens below avatar (not above)
- Shows user name + sign out option

<img width="384" height="138" alt="Screenshot 2026-03-13 at 15 31 33" src="https://github.com/user-attachments/assets/a7073f65-b1e9-48b5-913d-43f68d9b92f0" />
