### PR TITLE
feat: multi-installation GitHub App support + images search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ terraform/environments/production/plan.out
 terraform/environments/production/backend_override.tf
 terraform/environments/production/terraform.tfstate*
 terraform/environments/production/.terraform*
+scripts/deploy-cf.sh

--- a/packages/control-plane/src/auth/github-app.test.ts
+++ b/packages/control-plane/src/auth/github-app.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, it, expect, vi } from "vitest";
 import {
   isGitHubAppConfigured,
   getGitHubAppConfig,
+  getAllGitHubAppConfigs,
   getCachedInstallationToken,
   INSTALLATION_TOKEN_CACHE_MAX_AGE_MS,
   INSTALLATION_TOKEN_MIN_REMAINING_MS,
@@ -114,6 +115,102 @@ describe("github-app utilities", () => {
           GITHUB_APP_PRIVATE_KEY: "key",
         })
       ).toBeNull();
+    });
+  });
+
+  describe("getGitHubAppConfig with comma-separated IDs", () => {
+    const baseEnv = {
+      GITHUB_APP_ID: "123",
+      GITHUB_APP_PRIVATE_KEY: "key",
+    };
+
+    it("returns the first installation ID when comma-separated", () => {
+      const config = getGitHubAppConfig({
+        ...baseEnv,
+        GITHUB_APP_INSTALLATION_ID: "111,222",
+      });
+      expect(config?.installationId).toBe("111");
+    });
+
+    it("trims whitespace from the first ID", () => {
+      const config = getGitHubAppConfig({
+        ...baseEnv,
+        GITHUB_APP_INSTALLATION_ID: " 111 , 222 ",
+      });
+      expect(config?.installationId).toBe("111");
+    });
+
+    it("returns null when first ID is empty (trailing comma)", () => {
+      const config = getGitHubAppConfig({
+        ...baseEnv,
+        GITHUB_APP_INSTALLATION_ID: ",222",
+      });
+      expect(config).toBeNull();
+    });
+
+    it("returns null when all IDs are whitespace", () => {
+      const config = getGitHubAppConfig({
+        ...baseEnv,
+        GITHUB_APP_INSTALLATION_ID: " , , ",
+      });
+      expect(config).toBeNull();
+    });
+  });
+
+  describe("getAllGitHubAppConfigs", () => {
+    const baseEnv = {
+      GITHUB_APP_ID: "123",
+      GITHUB_APP_PRIVATE_KEY: "key",
+    };
+
+    it("returns one config per installation ID", () => {
+      const configs = getAllGitHubAppConfigs({
+        ...baseEnv,
+        GITHUB_APP_INSTALLATION_ID: "111,222",
+      });
+      expect(configs).toHaveLength(2);
+      expect(configs[0].installationId).toBe("111");
+      expect(configs[1].installationId).toBe("222");
+    });
+
+    it("trims whitespace from IDs", () => {
+      const configs = getAllGitHubAppConfigs({
+        ...baseEnv,
+        GITHUB_APP_INSTALLATION_ID: " 111 , 222 ",
+      });
+      expect(configs[0].installationId).toBe("111");
+      expect(configs[1].installationId).toBe("222");
+    });
+
+    it("filters out empty IDs from trailing commas", () => {
+      const configs = getAllGitHubAppConfigs({
+        ...baseEnv,
+        GITHUB_APP_INSTALLATION_ID: "111,,222,",
+      });
+      expect(configs).toHaveLength(2);
+      expect(configs[0].installationId).toBe("111");
+      expect(configs[1].installationId).toBe("222");
+    });
+
+    it("returns empty array for whitespace-only IDs", () => {
+      const configs = getAllGitHubAppConfigs({
+        ...baseEnv,
+        GITHUB_APP_INSTALLATION_ID: " , , ",
+      });
+      expect(configs).toHaveLength(0);
+    });
+
+    it("returns empty array when not configured", () => {
+      expect(getAllGitHubAppConfigs({})).toEqual([]);
+    });
+
+    it("handles single ID without commas", () => {
+      const configs = getAllGitHubAppConfigs({
+        ...baseEnv,
+        GITHUB_APP_INSTALLATION_ID: "111",
+      });
+      expect(configs).toHaveLength(1);
+      expect(configs[0].installationId).toBe("111");
     });
   });
 

--- a/packages/control-plane/src/auth/github-app.ts
+++ b/packages/control-plane/src/auth/github-app.ts
@@ -615,6 +615,8 @@ export function isGitHubAppConfigured(env: {
 
 /**
  * Get GitHub App config from environment.
+ * Returns config for the first installation ID. Use getAllGitHubAppConfigs
+ * when you need to iterate over multiple installations.
  */
 export function getGitHubAppConfig(env: {
   GITHUB_APP_ID?: string;
@@ -625,9 +627,37 @@ export function getGitHubAppConfig(env: {
     return null;
   }
 
+  const firstInstallationId = env.GITHUB_APP_INSTALLATION_ID!.split(",")[0].trim();
+  if (!firstInstallationId) {
+    return null;
+  }
   return {
     appId: env.GITHUB_APP_ID!,
     privateKey: env.GITHUB_APP_PRIVATE_KEY!,
-    installationId: env.GITHUB_APP_INSTALLATION_ID!,
+    installationId: firstInstallationId,
   };
+}
+
+/**
+ * Get GitHub App configs for ALL installation IDs (comma-separated).
+ * Use this when listing repos or checking access across multiple installations.
+ */
+export function getAllGitHubAppConfigs(env: {
+  GITHUB_APP_ID?: string;
+  GITHUB_APP_PRIVATE_KEY?: string;
+  GITHUB_APP_INSTALLATION_ID?: string;
+}): GitHubAppConfig[] {
+  if (!isGitHubAppConfigured(env)) {
+    return [];
+  }
+
+  return env
+    .GITHUB_APP_INSTALLATION_ID!.split(",")
+    .map((id) => id.trim())
+    .filter((id) => id.length > 0)
+    .map((id) => ({
+      appId: env.GITHUB_APP_ID!,
+      privateKey: env.GITHUB_APP_PRIVATE_KEY!,
+      installationId: id,
+    }));
 }

--- a/packages/control-plane/src/routes/shared.ts
+++ b/packages/control-plane/src/routes/shared.ts
@@ -5,7 +5,7 @@
 import type { CorrelationContext } from "../logger";
 import type { RequestMetrics } from "../db/instrumented-d1";
 import type { Env } from "../types";
-import { getGitHubAppConfig } from "../auth/github-app";
+import { getGitHubAppConfig, getAllGitHubAppConfigs } from "../auth/github-app";
 import {
   createSourceControlProvider,
   resolveScmProviderFromEnv,
@@ -67,11 +67,13 @@ export function error(message: string, status = 400): Response {
  */
 export function createRouteSourceControlProvider(env: Env): SourceControlProvider {
   const appConfig = getGitHubAppConfig(env);
+  const allAppConfigs = getAllGitHubAppConfigs(env);
   const provider = resolveScmProviderFromEnv(env.SCM_PROVIDER);
   return createSourceControlProvider({
     provider,
     github: {
       appConfig: appConfig ?? undefined,
+      allAppConfigs,
       kvCache: env.REPOS_CACHE,
     },
   });

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -11,7 +11,7 @@ import { DurableObject } from "cloudflare:workers";
 import { initSchema } from "./schema";
 import { buildSessionInternalUrl, SessionInternalPaths } from "./contracts";
 import { generateId, hashToken, timingSafeEqual, encryptToken, decryptToken } from "../auth/crypto";
-import { getGitHubAppConfig } from "../auth/github-app";
+import { getGitHubAppConfig, getAllGitHubAppConfigs } from "../auth/github-app";
 import { createModalClient } from "../sandbox/client";
 import { createModalProvider } from "../sandbox/providers/modal-provider";
 import { createLogger, parseLogLevel } from "../logger";
@@ -512,12 +512,14 @@ export class SessionDO extends DurableObject<Env> {
    */
   private createSourceControlProvider(): SourceControlProvider {
     const appConfig = getGitHubAppConfig(this.env);
+    const allAppConfigs = getAllGitHubAppConfigs(this.env);
     const provider = resolveScmProviderFromEnv(this.env.SCM_PROVIDER);
 
     return createSourceControlProviderImpl({
       provider,
       github: {
         appConfig: appConfig ?? undefined,
+        allAppConfigs,
         kvCache: this.env.REPOS_CACHE,
       },
     });

--- a/packages/control-plane/src/source-control/providers/github-provider.test.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.test.ts
@@ -10,9 +10,14 @@ vi.mock("../../auth/github-app", () => ({
   fetchWithTimeout: vi.fn(),
 }));
 
-import { getInstallationRepository, listInstallationRepositories } from "../../auth/github-app";
+import {
+  getInstallationRepository,
+  listInstallationRepositories,
+  getCachedInstallationToken,
+} from "../../auth/github-app";
 
 const mockGetInstallationRepository = vi.mocked(getInstallationRepository);
+const mockGetCachedInstallationToken = vi.mocked(getCachedInstallationToken);
 const mockListInstallationRepositories = vi.mocked(listInstallationRepositories);
 
 const fakeAppConfig = {
@@ -175,5 +180,349 @@ describe("GitHubSourceControlProvider", () => {
     });
 
     expect(spec.force).toBe(false);
+  });
+
+  describe("multi-installation support", () => {
+    const configA = { appId: "123", privateKey: "key", installationId: "aaa" };
+    const configB = { appId: "123", privateKey: "key", installationId: "bbb" };
+
+    it("falls back to appConfig when allAppConfigs is empty array", async () => {
+      const provider = new GitHubSourceControlProvider({
+        appConfig: configA,
+        allAppConfigs: [],
+      });
+
+      mockListInstallationRepositories.mockResolvedValueOnce({
+        repos: [
+          {
+            id: 1,
+            owner: "org",
+            name: "repo",
+            defaultBranch: "main",
+            private: false,
+            fullName: "org/repo",
+            description: null,
+          },
+        ],
+        timing: { tokenGenerationMs: 0, pages: [], totalPages: 0, totalRepos: 0 },
+      });
+
+      const repos = await provider.listRepositories();
+      expect(repos).toHaveLength(1);
+    });
+
+    describe("listRepositories", () => {
+      it("merges repos from multiple installations", async () => {
+        const provider = new GitHubSourceControlProvider({
+          appConfig: configA,
+          allAppConfigs: [configA, configB],
+        });
+
+        mockListInstallationRepositories
+          .mockResolvedValueOnce({
+            repos: [
+              {
+                id: 1,
+                owner: "org",
+                name: "repo-a",
+                defaultBranch: "main",
+                private: false,
+                fullName: "org/repo-a",
+                description: null,
+              },
+            ],
+            timing: { tokenGenerationMs: 0, pages: [], totalPages: 0, totalRepos: 0 },
+          })
+          .mockResolvedValueOnce({
+            repos: [
+              {
+                id: 2,
+                owner: "user",
+                name: "repo-b",
+                defaultBranch: "main",
+                private: false,
+                fullName: "user/repo-b",
+                description: null,
+              },
+            ],
+            timing: { tokenGenerationMs: 0, pages: [], totalPages: 0, totalRepos: 0 },
+          });
+
+        const repos = await provider.listRepositories();
+        expect(repos).toHaveLength(2);
+        expect(repos.map((r) => `${r.owner}/${r.name}`)).toEqual(["org/repo-a", "user/repo-b"]);
+      });
+
+      it("deduplicates repos case-insensitively", async () => {
+        const provider = new GitHubSourceControlProvider({
+          appConfig: configA,
+          allAppConfigs: [configA, configB],
+        });
+
+        mockListInstallationRepositories
+          .mockResolvedValueOnce({
+            repos: [
+              {
+                id: 1,
+                owner: "Org",
+                name: "Shared",
+                defaultBranch: "main",
+                private: false,
+                fullName: "Org/Shared",
+                description: null,
+              },
+            ],
+            timing: { tokenGenerationMs: 0, pages: [], totalPages: 0, totalRepos: 0 },
+          })
+          .mockResolvedValueOnce({
+            repos: [
+              {
+                id: 1,
+                owner: "org",
+                name: "shared",
+                defaultBranch: "main",
+                private: false,
+                fullName: "org/shared",
+                description: null,
+              },
+            ],
+            timing: { tokenGenerationMs: 0, pages: [], totalPages: 0, totalRepos: 0 },
+          });
+
+        const repos = await provider.listRepositories();
+        expect(repos).toHaveLength(1);
+      });
+
+      it("deduplicates repos appearing in multiple installations", async () => {
+        const provider = new GitHubSourceControlProvider({
+          appConfig: configA,
+          allAppConfigs: [configA, configB],
+        });
+
+        const sharedRepo = {
+          id: 1,
+          owner: "org",
+          name: "shared",
+          defaultBranch: "main",
+          private: false,
+          fullName: "org/shared",
+          description: null,
+        };
+        mockListInstallationRepositories
+          .mockResolvedValueOnce({
+            repos: [sharedRepo],
+            timing: { tokenGenerationMs: 0, pages: [], totalPages: 0, totalRepos: 0 },
+          })
+          .mockResolvedValueOnce({
+            repos: [sharedRepo],
+            timing: { tokenGenerationMs: 0, pages: [], totalPages: 0, totalRepos: 0 },
+          });
+
+        const repos = await provider.listRepositories();
+        expect(repos).toHaveLength(1);
+      });
+
+      it("continues when one installation fails", async () => {
+        const provider = new GitHubSourceControlProvider({
+          appConfig: configA,
+          allAppConfigs: [configA, configB],
+        });
+
+        mockListInstallationRepositories
+          .mockRejectedValueOnce(new Error("token expired"))
+          .mockResolvedValueOnce({
+            repos: [
+              {
+                id: 2,
+                owner: "user",
+                name: "repo-b",
+                defaultBranch: "main",
+                private: false,
+                fullName: "user/repo-b",
+                description: null,
+              },
+            ],
+            timing: { tokenGenerationMs: 0, pages: [], totalPages: 0, totalRepos: 0 },
+          });
+
+        const repos = await provider.listRepositories();
+        expect(repos).toHaveLength(1);
+        expect(repos[0].name).toBe("repo-b");
+      });
+    });
+
+    describe("checkRepositoryAccess", () => {
+      it("finds repo in second installation when not in first", async () => {
+        const provider = new GitHubSourceControlProvider({
+          appConfig: configA,
+          allAppConfigs: [configA, configB],
+        });
+
+        mockGetInstallationRepository.mockResolvedValueOnce(null).mockResolvedValueOnce({
+          id: 2,
+          owner: "user",
+          name: "repo",
+          defaultBranch: "main",
+          private: false,
+          fullName: "user/repo",
+          description: null,
+        });
+
+        const result = await provider.checkRepositoryAccess({ owner: "user", name: "repo" });
+        expect(result).not.toBeNull();
+        expect(result?.repoOwner).toBe("user");
+      });
+
+      it("returns null when repo not found in any installation", async () => {
+        const provider = new GitHubSourceControlProvider({
+          appConfig: configA,
+          allAppConfigs: [configA, configB],
+        });
+
+        mockGetInstallationRepository.mockResolvedValue(null);
+
+        const result = await provider.checkRepositoryAccess({ owner: "user", name: "nope" });
+        expect(result).toBeNull();
+      });
+
+      it("throws when first returns null and second throws", async () => {
+        const provider = new GitHubSourceControlProvider({
+          appConfig: configA,
+          allAppConfigs: [configA, configB],
+        });
+
+        mockGetInstallationRepository
+          .mockResolvedValueOnce(null)
+          .mockRejectedValueOnce(new Error("network timeout"));
+
+        await expect(
+          provider.checkRepositoryAccess({ owner: "user", name: "repo" })
+        ).rejects.toThrow("Failed to check repository access across all installations");
+      });
+
+      it("throws when first throws and second returns null", async () => {
+        const provider = new GitHubSourceControlProvider({
+          appConfig: configA,
+          allAppConfigs: [configA, configB],
+        });
+
+        mockGetInstallationRepository
+          .mockRejectedValueOnce(new Error("bad token"))
+          .mockResolvedValueOnce(null);
+
+        await expect(
+          provider.checkRepositoryAccess({ owner: "user", name: "repo" })
+        ).rejects.toThrow("Failed to check repository access across all installations");
+      });
+
+      it("throws when all installations fail with errors", async () => {
+        const provider = new GitHubSourceControlProvider({
+          appConfig: configA,
+          allAppConfigs: [configA, configB],
+        });
+
+        mockGetInstallationRepository.mockRejectedValue(new Error("API down"));
+
+        await expect(
+          provider.checkRepositoryAccess({ owner: "user", name: "repo" })
+        ).rejects.toThrow("Failed to check repository access across all installations");
+      });
+    });
+
+    describe("generatePushAuth", () => {
+      it("uses owning installation token when repo is found", async () => {
+        const provider = new GitHubSourceControlProvider({
+          appConfig: configA,
+          allAppConfigs: [configA, configB],
+        });
+
+        mockGetInstallationRepository.mockResolvedValueOnce(null).mockResolvedValueOnce({
+          id: 1,
+          owner: "user",
+          name: "repo",
+          defaultBranch: "main",
+          private: false,
+          fullName: "user/repo",
+          description: null,
+        });
+        mockGetCachedInstallationToken.mockResolvedValueOnce("token-from-bbb");
+
+        const auth = await provider.generatePushAuth("user", "repo");
+        expect(auth.token).toBe("token-from-bbb");
+        // Token was requested for configB (the one that found the repo)
+        expect(mockGetCachedInstallationToken).toHaveBeenCalledWith(configB);
+      });
+
+      it("propagates token error when owning installation is found", async () => {
+        const provider = new GitHubSourceControlProvider({
+          appConfig: configA,
+          allAppConfigs: [configA, configB],
+        });
+
+        mockGetInstallationRepository.mockResolvedValueOnce({
+          id: 1,
+          owner: "user",
+          name: "repo",
+          defaultBranch: "main",
+          private: false,
+          fullName: "user/repo",
+          description: null,
+        });
+        mockGetCachedInstallationToken.mockRejectedValueOnce(new Error("token fetch failed"));
+
+        await expect(provider.generatePushAuth("user", "repo")).rejects.toThrow(
+          "token fetch failed"
+        );
+      });
+
+      it("falls back to primary when no installation claims the repo", async () => {
+        const provider = new GitHubSourceControlProvider({
+          appConfig: configA,
+          allAppConfigs: [configA, configB],
+        });
+
+        mockGetInstallationRepository.mockResolvedValue(null);
+        mockGetCachedInstallationToken.mockResolvedValueOnce("token-from-aaa");
+
+        const auth = await provider.generatePushAuth("user", "unknown-repo");
+        expect(auth.token).toBe("token-from-aaa");
+        expect(mockGetCachedInstallationToken).toHaveBeenCalledWith(configA);
+      });
+
+      it("falls back to primary when no repo context provided", async () => {
+        const provider = new GitHubSourceControlProvider({
+          appConfig: configA,
+          allAppConfigs: [configA, configB],
+        });
+
+        mockGetCachedInstallationToken.mockResolvedValueOnce("token-primary");
+
+        const auth = await provider.generatePushAuth();
+        expect(auth.token).toBe("token-primary");
+      });
+
+      it("skips errored installations during repo lookup", async () => {
+        const provider = new GitHubSourceControlProvider({
+          appConfig: configA,
+          allAppConfigs: [configA, configB],
+        });
+
+        mockGetInstallationRepository
+          .mockRejectedValueOnce(new Error("bad token"))
+          .mockResolvedValueOnce({
+            id: 1,
+            owner: "user",
+            name: "repo",
+            defaultBranch: "main",
+            private: false,
+            fullName: "user/repo",
+            description: null,
+          });
+        mockGetCachedInstallationToken.mockResolvedValueOnce("token-from-bbb");
+
+        const auth = await provider.generatePushAuth("user", "repo");
+        expect(auth.token).toBe("token-from-bbb");
+      });
+    });
   });
 });

--- a/packages/control-plane/src/source-control/providers/github-provider.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.ts
@@ -45,10 +45,14 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
   readonly name = "github";
 
   private readonly appConfig?: GitHubProviderConfig["appConfig"];
+  private readonly allAppConfigs: NonNullable<GitHubProviderConfig["appConfig"]>[];
   private readonly kvCache?: KVNamespace;
 
   constructor(config: GitHubProviderConfig = {}) {
     this.appConfig = config.appConfig;
+    const filtered = config.allAppConfigs?.filter(Boolean);
+    this.allAppConfigs =
+      filtered && filtered.length > 0 ? filtered : config.appConfig ? [config.appConfig] : [];
     this.kvCache = config.kvCache;
   }
 
@@ -204,108 +208,189 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
    * Check whether a repository is accessible to the GitHub App installation.
    */
   async checkRepositoryAccess(config: GetRepositoryConfig): Promise<RepositoryAccessResult | null> {
-    if (!this.appConfig) {
+    if (this.allAppConfigs.length === 0) {
       throw new SourceControlProviderError(
         "GitHub App not configured - cannot check repository access",
         "permanent"
       );
     }
 
-    try {
-      const repo = await getInstallationRepository(
-        this.appConfig,
-        config.owner,
-        config.name,
-        this.kvCache ? { REPOS_CACHE: this.kvCache } : undefined
-      );
-      if (!repo) {
-        return null;
+    // Try each installation until one has access
+    let lastError: unknown;
+
+    for (const appConfig of this.allAppConfigs) {
+      try {
+        const repo = await getInstallationRepository(
+          appConfig,
+          config.owner,
+          config.name,
+          this.kvCache ? { REPOS_CACHE: this.kvCache } : undefined
+        );
+        if (repo) {
+          return {
+            repoId: repo.id,
+            repoOwner: config.owner.toLowerCase(),
+            repoName: config.name.toLowerCase(),
+            defaultBranch: repo.defaultBranch,
+          };
+        }
+      } catch (error) {
+        // Log and continue to next installation
+        console.warn(
+          `checkRepositoryAccess failed for installation ${appConfig.installationId}: ${error instanceof Error ? error.message : String(error)}`
+        );
+        lastError = error;
       }
-      return {
-        repoId: repo.id,
-        repoOwner: config.owner.toLowerCase(),
-        repoName: config.name.toLowerCase(),
-        defaultBranch: repo.defaultBranch,
-      };
-    } catch (error) {
+    }
+
+    // If any installation errored and none found the repo, propagate the error
+    // rather than silently returning null (which the caller treats as "not found").
+    // The repo might live in the installation that failed.
+    if (lastError) {
       throw SourceControlProviderError.fromFetchError(
-        `Failed to check repository access: ${error instanceof Error ? error.message : String(error)}`,
-        error,
-        extractHttpStatus(error)
+        `Failed to check repository access across all installations: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+        lastError,
+        extractHttpStatus(lastError)
       );
     }
+
+    return null;
   }
 
   /**
    * List all repositories accessible to the GitHub App installation.
    */
   async listRepositories(): Promise<InstallationRepository[]> {
-    if (!this.appConfig) {
+    if (this.allAppConfigs.length === 0) {
       throw new SourceControlProviderError(
         "GitHub App not configured - cannot list repositories",
         "permanent"
       );
     }
 
-    try {
-      const result = await listInstallationRepositories(
-        this.appConfig,
-        this.kvCache ? { REPOS_CACHE: this.kvCache } : undefined
-      );
-      return result.repos;
-    } catch (error) {
+    const seen = new Set<string>();
+    const allRepos: InstallationRepository[] = [];
+    let lastError: unknown;
+    let successCount = 0;
+
+    const results = await Promise.allSettled(
+      this.allAppConfigs.map((appConfig) =>
+        listInstallationRepositories(
+          appConfig,
+          this.kvCache ? { REPOS_CACHE: this.kvCache } : undefined
+        )
+      )
+    );
+
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (result.status === "fulfilled") {
+        successCount++;
+        for (const repo of result.value.repos) {
+          const key = `${repo.owner}/${repo.name}`.toLowerCase();
+          if (!seen.has(key)) {
+            seen.add(key);
+            allRepos.push(repo);
+          }
+        }
+      } else {
+        const installationId = this.allAppConfigs[i].installationId;
+        console.warn(
+          `Failed to list repos for installation ${installationId}: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`
+        );
+        lastError = result.reason;
+      }
+    }
+
+    // If no installation succeeded, surface the error with proper classification
+    if (successCount === 0 && lastError) {
       throw SourceControlProviderError.fromFetchError(
-        `Failed to list repositories: ${error instanceof Error ? error.message : String(error)}`,
-        error,
-        extractHttpStatus(error)
+        `Failed to list repositories: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+        lastError,
+        extractHttpStatus(lastError)
       );
     }
+
+    return allRepos;
   }
 
   /**
    * List branches for a repository.
    */
   async listBranches(config: GetRepositoryConfig): Promise<{ name: string }[]> {
-    if (!this.appConfig) {
+    if (this.allAppConfigs.length === 0) {
       throw new SourceControlProviderError(
         "GitHub App not configured - cannot list branches",
         "permanent"
       );
     }
 
-    try {
-      return await listRepositoryBranches(
-        this.appConfig,
-        config.owner,
-        config.name,
-        this.kvCache ? { REPOS_CACHE: this.kvCache } : undefined
-      );
-    } catch (error) {
-      throw SourceControlProviderError.fromFetchError(
-        `Failed to list branches: ${error instanceof Error ? error.message : String(error)}`,
-        error,
-        extractHttpStatus(error)
-      );
+    let lastError: unknown;
+    for (const appConfig of this.allAppConfigs) {
+      try {
+        return await listRepositoryBranches(
+          appConfig,
+          config.owner,
+          config.name,
+          this.kvCache ? { REPOS_CACHE: this.kvCache } : undefined
+        );
+      } catch (error) {
+        console.warn(
+          `listBranches failed for installation ${appConfig.installationId}: ${error instanceof Error ? error.message : String(error)}`
+        );
+        lastError = error;
+      }
     }
+
+    throw SourceControlProviderError.fromFetchError(
+      `Failed to list branches across all installations: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+      lastError,
+      extractHttpStatus(lastError)
+    );
   }
 
   /**
    * Generate authentication for git push operations using GitHub App.
    */
-  async generatePushAuth(): Promise<GitPushAuthContext> {
-    if (!this.appConfig) {
+  async generatePushAuth(repoOwner?: string, repoName?: string): Promise<GitPushAuthContext> {
+    if (this.allAppConfigs.length === 0) {
       throw new SourceControlProviderError(
         "GitHub App not configured - cannot generate push auth",
         "permanent"
       );
     }
 
+    // If we know the repo, find the owning installation
+    if (repoOwner && repoName) {
+      for (const appConfig of this.allAppConfigs) {
+        let repo: InstallationRepository | null;
+        try {
+          repo = await getInstallationRepository(
+            appConfig,
+            repoOwner,
+            repoName,
+            this.kvCache ? { REPOS_CACHE: this.kvCache } : undefined
+          );
+        } catch {
+          // Repo lookup failed for this installation — try next
+          continue;
+        }
+        if (repo) {
+          // Found the owning installation — token errors must propagate
+          const token = await getCachedInstallationToken(appConfig);
+          return { authType: "app", token };
+        }
+      }
+      // No installation claims this repo
+      console.warn(
+        `generatePushAuth: repo ${repoOwner}/${repoName} not found in any installation, falling back to primary`
+      );
+    }
+
+    // Fallback: use primary installation (no repo context or repo not found)
     try {
-      const token = await getCachedInstallationToken(this.appConfig);
-      return {
-        authType: "app",
-        token,
-      };
+      const token = await getCachedInstallationToken(this.allAppConfigs[0]);
+      return { authType: "app", token };
     } catch (error) {
       throw SourceControlProviderError.fromFetchError(
         `Failed to generate GitHub App token: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/control-plane/src/source-control/providers/types.ts
+++ b/packages/control-plane/src/source-control/providers/types.ts
@@ -8,8 +8,10 @@ import type { GitHubAppConfig } from "../../auth/github-app";
  * Configuration for GitHubSourceControlProvider.
  */
 export interface GitHubProviderConfig {
-  /** GitHub App configuration (required for push auth) */
+  /** GitHub App configuration (required for push auth) — primary installation */
   appConfig?: GitHubAppConfig;
+  /** All GitHub App configs (for multi-installation support) */
+  allAppConfigs?: GitHubAppConfig[];
   /** KV namespace for caching installation tokens */
   kvCache?: KVNamespace;
 }

--- a/packages/control-plane/src/source-control/types.ts
+++ b/packages/control-plane/src/source-control/types.ts
@@ -281,7 +281,7 @@ export interface SourceControlProvider {
    * @returns Git push authentication context with app token
    * @throws SourceControlProviderError
    */
-  generatePushAuth(): Promise<GitPushAuthContext>;
+  generatePushAuth(repoOwner?: string, repoName?: string): Promise<GitPushAuthContext>;
 
   /**
    * Build provider-specific URL for manual pull request creation.

--- a/packages/web/src/components/settings/images-settings.tsx
+++ b/packages/web/src/components/settings/images-settings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import useSWR, { mutate } from "swr";
 import { useRepos } from "@/hooks/use-repos";
 import { Button } from "@/components/ui/button";
@@ -31,8 +31,20 @@ export function ImagesSettings() {
   const [togglingRepos, setTogglingRepos] = useState<Set<string>>(new Set());
   const [triggeringRepos, setTriggeringRepos] = useState<Set<string>>(new Set());
   const [error, setError] = useState("");
+  const [search, setSearch] = useState("");
 
   const loading = reposLoading || imagesLoading;
+
+  const filteredRepos = useMemo(() => {
+    if (!search.trim()) return repos;
+    const q = search.toLowerCase();
+    return repos.filter(
+      (repo) =>
+        repo.name.toLowerCase().includes(q) ||
+        repo.owner.toLowerCase().includes(q) ||
+        `${repo.owner}/${repo.name}`.toLowerCase().includes(q)
+    );
+  }, [repos, search]);
 
   const enabledRepos = new Set(data?.enabledRepos ?? []);
 
@@ -118,6 +130,15 @@ export function ImagesSettings() {
         the default branch changes.
       </p>
 
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search repositories..."
+        aria-label="Search repositories"
+        className="w-full px-3 py-2 mb-4 text-sm bg-background border border-border text-foreground placeholder:text-muted-foreground focus:outline-none focus:border-accent"
+      />
+
       {error && (
         <div className="mb-4 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 px-4 py-3 border border-red-200 dark:border-red-800 text-sm">
           {error}
@@ -125,7 +146,7 @@ export function ImagesSettings() {
       )}
 
       <div className="space-y-2">
-        {repos.map((repo) => {
+        {filteredRepos.map((repo) => {
           const repoKey = `${repo.owner}/${repo.name}`.toLowerCase();
           const isEnabled = enabledRepos.has(repoKey);
           const isToggling = togglingRepos.has(repoKey);
@@ -166,6 +187,11 @@ export function ImagesSettings() {
         })}
       </div>
 
+      {filteredRepos.length === 0 && repos.length > 0 && (
+        <p className="text-sm text-muted-foreground">
+          No repositories matching &ldquo;{search}&rdquo;
+        </p>
+      )}
       {repos.length === 0 && (
         <p className="text-sm text-muted-foreground">
           No repositories found. Install the GitHub App on repositories to get started.


### PR DESCRIPTION
## Changes

### Multi-installation GitHub App support
- `getAllGitHubAppConfigs()` parses comma-separated `GITHUB_APP_INSTALLATION_ID` env var
- `listRepositories()` merges and deduplicates repos across all installations
- `checkRepositoryAccess()` falls back through installations; throws when ALL fail (vs silent null)
- Empty installation IDs filtered out (trailing commas, whitespace)

### Images settings search
- Added search input to filter repositories on the images settings page
- `aria-label` for accessibility

### Tests
- 37 tests covering parsing edge cases, multi-installation fallback, error surfacing, deduplication

### Config
- `terraform.tfvars` updated with comma-separated installation IDs (gitignored)