### PR TITLE
fix: prevent model hydration race with state-based guard

### DIFF
--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -51,7 +51,7 @@ export default function Home() {
   const sessionCreationPromise = useRef<Promise<string | null> | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const pendingConfigRef = useRef<{ repo: string; model: string; branch: string } | null>(null);
-  const hasHydratedModelPreferences = useRef(false);
+  const [hasHydratedModelPreferences, setHasHydratedModelPreferences] = useState(false);
   const { enabledModels, enabledModelOptions } = useEnabledModels();
   const selectedRepoOwner = selectedRepo.split("/")[0] ?? "";
   const selectedRepoName = selectedRepo.split("/")[1] ?? "";
@@ -76,7 +76,7 @@ export default function Home() {
   }, [selectedRepo]);
 
   useEffect(() => {
-    if (enabledModels.length === 0 || hasHydratedModelPreferences.current) return;
+    if (enabledModels.length === 0 || hasHydratedModelPreferences) return;
 
     const storedModel = localStorage.getItem(LAST_SELECTED_MODEL_STORAGE_KEY);
     const selectedModelFromStorage =
@@ -93,11 +93,11 @@ export default function Home() {
 
     setSelectedModel(selectedModelFromStorage);
     setReasoningEffort(reasoningEffortFromStorage);
-    hasHydratedModelPreferences.current = true;
-  }, [enabledModels]);
+    setHasHydratedModelPreferences(true);
+  }, [enabledModels, hasHydratedModelPreferences]);
 
   useEffect(() => {
-    if (!hasHydratedModelPreferences.current) return;
+    if (!hasHydratedModelPreferences) return;
     localStorage.setItem(LAST_SELECTED_MODEL_STORAGE_KEY, selectedModel);
 
     if (reasoningEffort) {
@@ -106,7 +106,7 @@ export default function Home() {
     }
 
     localStorage.removeItem(LAST_SELECTED_REASONING_EFFORT_STORAGE_KEY);
-  }, [selectedModel, reasoningEffort]);
+  }, [hasHydratedModelPreferences, selectedModel, reasoningEffort]);
 
   useEffect(() => {
     if (abortControllerRef.current) {
@@ -179,8 +179,10 @@ export default function Home() {
     return promise;
   }, [selectedRepo, selectedModel, reasoningEffort, selectedBranch, pendingSessionId]);
 
-  // Reset selections when model preferences change
+  // Reset selections when model preferences change (only after hydration)
   useEffect(() => {
+    if (!hasHydratedModelPreferences) return;
+
     if (enabledModels.length > 0 && !enabledModels.includes(selectedModel)) {
       const fallback = enabledModels[0] ?? DEFAULT_MODEL;
       setSelectedModel(fallback);
@@ -191,7 +193,7 @@ export default function Home() {
     if (reasoningEffort && !isValidReasoningEffort(selectedModel, reasoningEffort)) {
       setReasoningEffort(getDefaultReasoningEffort(selectedModel));
     }
-  }, [enabledModels, selectedModel, reasoningEffort]);
+  }, [hasHydratedModelPreferences, enabledModels, selectedModel, reasoningEffort]);
 
   const handleRepoChange = useCallback(
     (repoFullName: string) => {


### PR DESCRIPTION
## Summary

Fixes a race condition where the stored model preference is overwritten on page load in OpenAI-only configurations.

**The bug**: When `enabledModels` loads from SWR, both the hydration effect (reads localStorage) and the reset effect (resets invalid models) fire in the same React commit phase. The hydration effect sets `selectedModel("openai/gpt-5.4")`, but the reset effect's closure still sees the stale `DEFAULT_MODEL` (`"anthropic/claude-sonnet-4-6"`) — which isn't in the OpenAI-only list — so it resets to `enabledModels[0]` (`"openai/gpt-5.2"`). The last batched `setSelectedModel` wins, discarding the user's preference.

**The fix**: Convert `hasHydratedModelPreferences` from a `useRef` to `useState`. With state, the reset effect only runs after hydration's state update has been applied in a subsequent render, where `selectedModel` is already the correct hydrated value.

**Why the previous approach (#335) didn't work**: That PR used a ref-based guard, but refs are synchronous — the reset effect reads `true` in the same flush, while `selectedModel` is still stale from the closure.

## Changes

- `useRef(false)` → `useState(false)` for `hasHydratedModelPreferences`
- Add `if (!hasHydratedModelPreferences) return` guard to the reset effect
- Add `hasHydratedModelPreferences` to all relevant dependency arrays

## Validation

- `npm run typecheck -w @open-inspect/web` — passes
- `npm test -w @open-inspect/web` — 92 tests pass

Closes #335