### PR TITLE
feat(web): adopt shadcn primitives across existing UI

### DIFF
--- a/packages/web/src/components/action-bar.tsx
+++ b/packages/web/src/components/action-bar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { toast } from "sonner";
 import type { Artifact } from "@/types/session";
 import {
   GlobeIcon,
@@ -11,6 +12,22 @@ import {
   GitHubIcon,
 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 interface ActionBarProps {
   sessionId: string;
@@ -27,8 +44,8 @@ export function ActionBar({
   onArchive,
   onUnarchive,
 }: ActionBarProps) {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isArchiving, setIsArchiving] = useState(false);
+  const [showArchiveDialog, setShowArchiveDialog] = useState(false);
 
   const prArtifact = artifacts.find((a) => a.type === "pr");
   const previewArtifact = artifacts.find((a) => a.type === "preview");
@@ -37,19 +54,23 @@ export function ActionBar({
 
   const handleArchiveToggle = async () => {
     if (!isArchived) {
-      const confirmed = window.confirm(
-        "Archive this session? You can restore archived sessions from Settings > Data Controls."
-      );
-      if (!confirmed) return;
+      setShowArchiveDialog(true);
+      return;
     }
 
     setIsArchiving(true);
     try {
-      if (isArchived && onUnarchive) {
-        await onUnarchive();
-      } else if (!isArchived && onArchive) {
-        await onArchive();
-      }
+      if (onUnarchive) await onUnarchive();
+    } finally {
+      setIsArchiving(false);
+    }
+  };
+
+  const handleConfirmArchive = async () => {
+    setShowArchiveDialog(false);
+    setIsArchiving(true);
+    try {
+      if (onArchive) await onArchive();
     } finally {
       setIsArchiving(false);
     }
@@ -58,84 +79,86 @@ export function ActionBar({
   const handleCopyLink = async () => {
     const url = `${window.location.origin}/session/${sessionId}`;
     await navigator.clipboard.writeText(url);
-    setIsMenuOpen(false);
+    toast.success("Link copied to clipboard");
   };
 
   return (
-    <div className="flex flex-wrap items-stretch gap-2">
-      {/* View Preview */}
-      {previewArtifact?.url && (
-        <Button variant="outline" size="sm" className="gap-1.5" asChild>
-          <a href={previewArtifact.url} target="_blank" rel="noopener noreferrer">
-            <GlobeIcon className="w-4 h-4" />
-            <span>View preview</span>
-            {previewArtifact.metadata?.previewStatus === "outdated" && (
-              <span className="text-xs text-yellow-600 dark:text-yellow-400">(outdated)</span>
-            )}
-          </a>
-        </Button>
-      )}
+    <>
+      <div className="flex flex-wrap items-stretch gap-2">
+        {/* View Preview */}
+        {previewArtifact?.url && (
+          <Button variant="outline" size="sm" className="gap-1.5" asChild>
+            <a href={previewArtifact.url} target="_blank" rel="noopener noreferrer">
+              <GlobeIcon className="w-4 h-4" />
+              <span>View preview</span>
+              {previewArtifact.metadata?.previewStatus === "outdated" && (
+                <span className="text-xs text-yellow-600 dark:text-yellow-400">(outdated)</span>
+              )}
+            </a>
+          </Button>
+        )}
 
-      {/* View PR */}
-      {prArtifact?.url && (
-        <Button variant="outline" size="sm" className="gap-1.5" asChild>
-          <a href={prArtifact.url} target="_blank" rel="noopener noreferrer">
-            <GitPrIcon className="w-4 h-4" />
-            <span>View PR</span>
-          </a>
-        </Button>
-      )}
+        {/* View PR */}
+        {prArtifact?.url && (
+          <Button variant="outline" size="sm" className="gap-1.5" asChild>
+            <a href={prArtifact.url} target="_blank" rel="noopener noreferrer">
+              <GitPrIcon className="w-4 h-4" />
+              <span>View PR</span>
+            </a>
+          </Button>
+        )}
 
-      {/* Archive/Unarchive */}
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={handleArchiveToggle}
-        disabled={isArchiving}
-        className="flex shrink-0 items-center gap-1.5 whitespace-nowrap disabled:opacity-50"
-      >
-        <ArchiveIcon className="w-4 h-4" />
-        <span>{isArchived ? "Unarchive" : "Archive"}</span>
-      </Button>
-
-      {/* More menu */}
-      <div className="relative shrink-0">
+        {/* Archive/Unarchive */}
         <Button
           variant="outline"
           size="sm"
-          onClick={() => setIsMenuOpen(!isMenuOpen)}
-          className="flex shrink-0 items-center justify-center !px-2 h-full"
+          onClick={handleArchiveToggle}
+          disabled={isArchiving}
+          className="gap-1.5"
         >
-          <MoreIcon className="w-4 h-4" />
+          <ArchiveIcon className="w-4 h-4" />
+          <span>{isArchived ? "Unarchive" : "Archive"}</span>
         </Button>
 
-        {isMenuOpen && (
-          <>
-            <div className="fixed inset-0 z-10" onClick={() => setIsMenuOpen(false)} />
-            <div className="absolute bottom-full right-0 mb-2 w-48 bg-background shadow-lg border border-border py-1 z-20">
-              <button
-                onClick={handleCopyLink}
-                className="w-full flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-muted"
-              >
-                <LinkIcon className="w-4 h-4" />
-                Copy link
-              </button>
-              {prArtifact?.url && (
-                <a
-                  href={prArtifact.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="w-full flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-muted"
-                  onClick={() => setIsMenuOpen(false)}
-                >
+        {/* More menu */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="sm" className="!px-2">
+              <MoreIcon className="w-4 h-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" side="top">
+            <DropdownMenuItem onClick={handleCopyLink}>
+              <LinkIcon className="w-4 h-4" />
+              Copy link
+            </DropdownMenuItem>
+            {prArtifact?.url && (
+              <DropdownMenuItem asChild>
+                <a href={prArtifact.url} target="_blank" rel="noopener noreferrer">
                   <GitHubIcon className="w-4 h-4" />
                   View in GitHub
                 </a>
-              )}
-            </div>
-          </>
-        )}
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
-    </div>
+
+      <AlertDialog open={showArchiveDialog} onOpenChange={setShowArchiveDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Archive session</AlertDialogTitle>
+            <AlertDialogDescription>
+              Archive this session? You can restore archived sessions from Settings &gt; Data
+              Controls.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmArchive}>Archive</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/packages/web/src/components/automations/automation-form.tsx
+++ b/packages/web/src/components/automations/automation-form.tsx
@@ -8,6 +8,8 @@ import { useEnabledModels } from "@/hooks/use-enabled-models";
 import { formatModelNameLower } from "@/lib/format";
 import { Combobox, type ComboboxGroup } from "@/components/ui/combobox";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { RepoIcon, BranchIcon, ModelIcon, ChevronDownIcon } from "@/components/ui/icons";
 import { CronPicker } from "./cron-picker";
 
@@ -103,14 +105,13 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
       {/* Name */}
       <div>
         <label className="block text-sm font-medium text-foreground mb-1">Name</label>
-        <input
+        <Input
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="Daily code review"
           maxLength={200}
           required
-          className="w-full px-3 py-2 text-sm bg-input border border-border focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent placeholder:text-secondary-foreground text-foreground"
         />
       </div>
 
@@ -227,14 +228,14 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
       {/* Instructions */}
       <div>
         <label className="block text-sm font-medium text-foreground mb-1">Instructions</label>
-        <textarea
+        <Textarea
           value={instructions}
           onChange={(e) => setInstructions(e.target.value)}
           placeholder="Run the test suite and fix any failing tests. If all tests pass, look for TODO comments and address the most impactful one."
           maxLength={10000}
           required
           rows={6}
-          className="w-full px-3 py-2 text-sm bg-input border border-border focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent placeholder:text-secondary-foreground text-foreground resize-y"
+          className="resize-y"
         />
       </div>
 

--- a/packages/web/src/components/secrets-editor.tsx
+++ b/packages/web/src/components/secrets-editor.tsx
@@ -2,7 +2,9 @@
 
 import { useCallback, useEffect, useMemo, useState, type ClipboardEvent } from "react";
 import useSWR, { mutate } from "swr";
+import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 
 import { normalizeKey, parseMaybeEnvContent, type ParsedEnvEntry } from "@/lib/env-paste";
 
@@ -90,7 +92,6 @@ export function SecretsEditor({
   const [rows, setRows] = useState<SecretRow[]>([]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
-  const [success, setSuccess] = useState("");
   const [deletingKey, setDeletingKey] = useState<string | null>(null);
 
   const isGlobal = scope === "global";
@@ -203,7 +204,7 @@ export function SecretsEditor({
 
       const imported = `Imported ${valid.length} secret${valid.length === 1 ? "" : "s"} from paste`;
       const skippedMsg = skipped > 0 ? ` (skipped ${skipped} reserved)` : "";
-      setSuccess(imported + skippedMsg);
+      toast.success(imported + skippedMsg);
     },
     [applyEnvEntries]
   );
@@ -223,7 +224,6 @@ export function SecretsEditor({
     const normalizedKey = normalizeKey(row.key);
     setDeletingKey(normalizedKey);
     setError("");
-    setSuccess("");
 
     try {
       const response = await fetch(`${apiBase}/${normalizedKey}`, {
@@ -231,13 +231,13 @@ export function SecretsEditor({
       });
       const data = await response.json();
       if (!response.ok) {
-        setError(data?.error || "Failed to delete secret");
+        toast.error(data?.error || "Failed to delete secret");
         return;
       }
-      setSuccess(`Deleted ${normalizedKey}`);
+      toast.success(`Deleted ${normalizedKey}`);
       mutate(apiBase);
     } catch {
-      setError("Failed to delete secret");
+      toast.error("Failed to delete secret");
     } finally {
       setDeletingKey(null);
     }
@@ -247,7 +247,6 @@ export function SecretsEditor({
     if (!ready) return;
 
     setError("");
-    setSuccess("");
 
     const entries = rows
       .filter((row) => row.value.trim().length > 0)
@@ -258,7 +257,7 @@ export function SecretsEditor({
       }));
 
     if (entries.length === 0) {
-      setSuccess("No changes to save");
+      toast("No changes to save");
       return;
     }
 
@@ -320,14 +319,14 @@ export function SecretsEditor({
       const data = await response.json();
 
       if (!response.ok) {
-        setError(data?.error || "Failed to update secrets");
+        toast.error(data?.error || "Failed to update secrets");
         return;
       }
 
-      setSuccess("Secrets updated");
+      toast.success("Secrets updated");
       mutate(apiBase);
     } catch {
-      setError("Failed to update secrets");
+      toast.error("Failed to update secrets");
     } finally {
       setSaving(false);
     }
@@ -372,7 +371,7 @@ export function SecretsEditor({
             {rows.map((row) => (
               <div key={row.id} className="flex flex-col gap-2 border border-border-muted p-2">
                 <div className="flex flex-wrap gap-2">
-                  <input
+                  <Input
                     type="text"
                     value={row.key}
                     onChange={(e) => {
@@ -394,9 +393,9 @@ export function SecretsEditor({
                     placeholder="KEY_NAME"
                     disabled={disabled || row.existing}
                     onPaste={handlePasteIntoRow}
-                    className="flex-1 min-w-[160px] bg-input border border-border px-2 py-1 text-xs text-foreground disabled:opacity-60"
+                    className="flex-1 min-w-[160px] h-auto px-2 py-1 text-xs"
                   />
-                  <input
+                  <Input
                     type="password"
                     value={row.value}
                     onChange={(e) => {
@@ -408,7 +407,7 @@ export function SecretsEditor({
                     placeholder={row.existing ? "••••••••" : "value"}
                     disabled={disabled}
                     onPaste={handlePasteIntoRow}
-                    className="flex-1 min-w-[200px] bg-input border border-border px-2 py-1 text-xs text-foreground disabled:opacity-60"
+                    className="flex-1 min-w-[200px] h-auto px-2 py-1 text-xs"
                   />
                   <button
                     type="button"
@@ -446,12 +445,12 @@ export function SecretsEditor({
                         Global
                       </Badge>
                       <span className="text-xs text-foreground font-mono">{g.key}</span>
-                      <input
+                      <Input
                         type="password"
                         value=""
                         placeholder="••••••••"
                         disabled
-                        className="flex-1 min-w-[200px] bg-input border border-border px-2 py-1 text-xs text-foreground disabled:opacity-60"
+                        className="flex-1 min-w-[200px] h-auto px-2 py-1 text-xs"
                       />
                       {overridden && (
                         <span className="text-[10px] text-muted-foreground">
@@ -466,7 +465,6 @@ export function SecretsEditor({
           )}
 
           {error && <p className="mt-3 text-xs text-red-500">{error}</p>}
-          {success && <p className="mt-3 text-xs text-green-600">{success}</p>}
 
           <div className="mt-3 flex items-center gap-2">
             <button

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -24,6 +24,15 @@ import {
   BranchIcon,
 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import type { Session } from "@open-inspect/shared";
 
 export type SessionItem = Session;
@@ -264,12 +273,11 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
 
       {/* Search */}
       <div className="px-3 py-2">
-        <input
+        <Input
           type="text"
           placeholder="Search sessions..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          className="w-full px-3 py-2 text-sm bg-input border border-border focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent placeholder:text-secondary-foreground text-foreground"
         />
       </div>
 
@@ -333,96 +341,49 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
 }
 
 function UserMenu({ user }: { user?: { name?: string | null; image?: string | null } | null }) {
-  const [open, setOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const [menuPos, setMenuPos] = useState<{ top: number; left: number } | null>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    function handleClick(e: MouseEvent) {
-      if (
-        menuRef.current &&
-        !menuRef.current.contains(e.target as Node) &&
-        buttonRef.current &&
-        !buttonRef.current.contains(e.target as Node)
-      ) {
-        setOpen(false);
-      }
-    }
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === "Escape") setOpen(false);
-    }
-    document.addEventListener("mousedown", handleClick);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handleClick);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [open]);
-
-  function toggle() {
-    if (!open && buttonRef.current) {
-      const rect = buttonRef.current.getBoundingClientRect();
-      setMenuPos({
-        top: rect.bottom + 4,
-        left: rect.left,
-      });
-    }
-    setOpen((v) => !v);
-  }
-
   return (
-    <>
-      <button
-        ref={buttonRef}
-        onClick={toggle}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        className="w-7 h-7 rounded-full overflow-hidden focus:outline-none focus:ring-2 focus:ring-primary"
-        title={`Signed in as ${user?.name || "User"}`}
-      >
-        {user?.image ? (
-          <img src={user.image} alt={user.name || "User"} className="w-full h-full object-cover" />
-        ) : (
-          <span className="w-full h-full rounded-full bg-card flex items-center justify-center text-xs font-medium text-foreground">
-            {user?.name?.charAt(0).toUpperCase() || "?"}
-          </span>
-        )}
-      </button>
-      {open && menuPos && (
-        <div
-          ref={menuRef}
-          role="menu"
-          className="fixed w-48 rounded-md border border-border bg-background shadow-lg py-1 z-[100]"
-          style={{ top: menuPos.top, left: Math.min(menuPos.left, window.innerWidth - 200) }}
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          className="w-7 h-7 rounded-full overflow-hidden focus:outline-none focus:ring-2 focus:ring-primary"
+          title={`Signed in as ${user?.name || "User"}`}
         >
-          <div className="px-3 py-2 border-b border-border">
-            <p className="text-sm font-medium text-foreground truncate">{user?.name || "User"}</p>
-          </div>
-          <button
-            role="menuitem"
-            onClick={() => signOut()}
-            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition"
+          {user?.image ? (
+            <img
+              src={user.image}
+              alt={user.name || "User"}
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <span className="w-full h-full rounded-full bg-card flex items-center justify-center text-xs font-medium text-foreground">
+              {user?.name?.charAt(0).toUpperCase() || "?"}
+            </span>
+          )}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" sideOffset={4}>
+        <DropdownMenuLabel className="font-medium truncate">
+          {user?.name || "User"}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={() => signOut()}>
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.5}
           >
-            <svg
-              className="w-4 h-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={1.5}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15m3-3l3-3m0 0l-3-3m3 3H9"
-              />
-            </svg>
-            Sign out
-          </button>
-        </div>
-      )}
-    </>
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15m3-3l3-3m0 0l-3-3m3 3H9"
+            />
+          </svg>
+          Sign out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -478,7 +439,6 @@ function SessionListItem({
   const repoInfo = `${session.repoOwner}/${session.repoName}`;
   // Orphan child (parent filtered out) — show a subtle badge
   const isOrphanChild = session.parentSessionId && session.spawnSource === "agent";
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [isRenaming, setIsRenaming] = useState(false);
   const [title, setTitle] = useState(displayTitle);
 
@@ -490,7 +450,6 @@ function SessionListItem({
 
   const handleStartRename = () => {
     setTitle(displayTitle);
-    setIsMenuOpen(false);
     setIsRenaming(true);
   };
 
@@ -614,35 +573,20 @@ function SessionListItem({
       )}
 
       <div className="absolute inset-y-0 right-2 flex items-start pt-2">
-        <button
-          type="button"
-          aria-label="Session actions"
-          aria-haspopup="menu"
-          aria-expanded={isMenuOpen}
-          onClick={() => setIsMenuOpen((prev) => !prev)}
-          className={`h-6 w-6 flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition ${
-            isMenuOpen
-              ? "opacity-100"
-              : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
-          }`}
-        >
-          <MoreIcon className="w-4 h-4" />
-        </button>
-
-        {isMenuOpen && (
-          <>
-            <div className="fixed inset-0 z-10" onClick={() => setIsMenuOpen(false)} />
-            <div className="absolute right-0 top-8 w-36 bg-background border border-border shadow-lg py-1 z-20">
-              <button
-                type="button"
-                onClick={handleStartRename}
-                className="w-full text-left px-3 py-2 text-sm text-foreground hover:bg-muted"
-              >
-                Rename
-              </button>
-            </div>
-          </>
-        )}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              aria-label="Session actions"
+              className="h-6 w-6 flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 data-[state=open]:opacity-100"
+            >
+              <MoreIcon className="w-4 h-4" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={handleStartRename}>Rename</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
     </div>
   );

--- a/packages/web/src/components/settings/data-controls-settings.tsx
+++ b/packages/web/src/components/settings/data-controls-settings.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from "react";
 import Link from "next/link";
 import useSWR, { mutate } from "swr";
+import { toast } from "sonner";
 import { buildSessionHref, type SessionItem } from "@/components/session-sidebar";
 import { SIDEBAR_SESSIONS_KEY } from "@/lib/session-list";
 import { formatRelativeTime } from "@/lib/time";
@@ -54,12 +55,15 @@ export function DataControlsSettings() {
     try {
       const res = await fetch(`/api/sessions/${sessionId}/unarchive`, { method: "POST" });
       if (res.ok) {
+        toast.success("Session unarchived");
         mutate(SIDEBAR_SESSIONS_KEY);
         mutate(ARCHIVED_SESSIONS_KEY);
       } else {
+        toast.error("Failed to unarchive session");
         mutate(ARCHIVED_SESSIONS_KEY);
       }
     } catch {
+      toast.error("Failed to unarchive session");
       mutate(ARCHIVED_SESSIONS_KEY);
     }
   };

--- a/packages/web/src/components/settings/integrations/github-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/github-integration-settings.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, type ReactNode } from "react";
 import useSWR, { mutate } from "swr";
+import { toast } from "sonner";
 import {
   MODEL_REASONING_CONFIG,
   isValidReasoningEffort,
@@ -14,6 +15,16 @@ import { useEnabledModels } from "@/hooks/use-enabled-models";
 import { IntegrationSettingsSkeleton } from "./integration-settings-skeleton";
 import { Button } from "@/components/ui/button";
 import { RadioCard, Select } from "@/components/ui/form-controls";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 const GLOBAL_SETTINGS_KEY = "/api/integration-settings/github";
 const REPO_SETTINGS_KEY = "/api/integration-settings/github/repos";
@@ -119,9 +130,9 @@ function GlobalSettingsSection({
   const [newUsername, setNewUsername] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
-  const [success, setSuccess] = useState("");
   const [dirty, setDirty] = useState(false);
   const [initialized, setInitialized] = useState(false);
+  const [showResetDialog, setShowResetDialog] = useState(false);
 
   useEffect(() => {
     if (settings !== undefined && !initialized) {
@@ -142,18 +153,13 @@ function GlobalSettingsSection({
 
   const isConfigured = settings !== null && settings !== undefined;
 
-  const handleReset = async () => {
-    if (
-      !window.confirm(
-        "Reset all GitHub bot settings to defaults? The bot will respond to all repos with auto-review enabled."
-      )
-    ) {
-      return;
-    }
+  const handleReset = () => {
+    setShowResetDialog(true);
+  };
 
+  const handleConfirmReset = async () => {
     setSaving(true);
     setError("");
-    setSuccess("");
 
     try {
       const res = await fetch(GLOBAL_SETTINGS_KEY, { method: "DELETE" });
@@ -169,13 +175,13 @@ function GlobalSettingsSection({
         setCommentActionInstructions("");
         setNewUsername("");
         setDirty(false);
-        setSuccess("Settings reset to defaults.");
+        toast.success("Settings reset to defaults.");
       } else {
         const data = await res.json();
-        setError(data.error || "Failed to reset settings");
+        toast.error(data.error || "Failed to reset settings");
       }
     } catch {
-      setError("Failed to reset settings");
+      toast.error("Failed to reset settings");
     } finally {
       setSaving(false);
     }
@@ -184,7 +190,6 @@ function GlobalSettingsSection({
   const handleSave = async () => {
     setSaving(true);
     setError("");
-    setSuccess("");
 
     const body: GitHubGlobalConfig = {
       defaults: {
@@ -208,14 +213,14 @@ function GlobalSettingsSection({
 
       if (res.ok) {
         mutate(GLOBAL_SETTINGS_KEY);
-        setSuccess("Settings saved.");
+        toast.success("Settings saved.");
         setDirty(false);
       } else {
         const data = await res.json();
-        setError(data.error || "Failed to save settings");
+        toast.error(data.error || "Failed to save settings");
       }
     } catch {
-      setError("Failed to save settings");
+      toast.error("Failed to save settings");
     } finally {
       setSaving(false);
     }
@@ -228,7 +233,6 @@ function GlobalSettingsSection({
       setNewUsername("");
       setDirty(true);
       setError("");
-      setSuccess("");
     }
   };
 
@@ -239,13 +243,11 @@ function GlobalSettingsSection({
     );
     setDirty(true);
     setError("");
-    setSuccess("");
   };
 
   return (
     <Section title="Defaults & Scope" description="Global behavior and repository targeting.">
       {error && <Message tone="error" text={error} />}
-      {success && <Message tone="success" text={success} />}
 
       <label className="flex items-center justify-between px-4 py-3 border border-border hover:bg-muted/50 transition cursor-pointer mb-4 rounded-sm">
         <div>
@@ -262,7 +264,6 @@ function GlobalSettingsSection({
               setAutoReviewOnOpen(!autoReviewOnOpen);
               setDirty(true);
               setError("");
-              setSuccess("");
             }}
             className="sr-only peer"
           />
@@ -281,7 +282,6 @@ function GlobalSettingsSection({
               setRepoScopeMode("all");
               setDirty(true);
               setError("");
-              setSuccess("");
             }}
             label="All repositories"
             description="Bot responds in every accessible repository."
@@ -293,7 +293,6 @@ function GlobalSettingsSection({
               setRepoScopeMode("selected");
               setDirty(true);
               setError("");
-              setSuccess("");
             }}
             label="Selected repositories"
             description="Bot only responds in the allowlisted repositories."
@@ -349,7 +348,6 @@ function GlobalSettingsSection({
               setTriggerUserMode("write_access");
               setDirty(true);
               setError("");
-              setSuccess("");
             }}
             label="All users with write access"
             description="Anyone with write permission on the repo can trigger the bot."
@@ -361,7 +359,6 @@ function GlobalSettingsSection({
               setTriggerUserMode("specific");
               setDirty(true);
               setError("");
-              setSuccess("");
             }}
             label="Only specific users"
             description="Only listed GitHub usernames can trigger the bot."
@@ -403,7 +400,6 @@ function GlobalSettingsSection({
                         setAllowedTriggerUsers((prev) => prev.filter((u) => u !== user));
                         setDirty(true);
                         setError("");
-                        setSuccess("");
                       }}
                       className="text-muted-foreground hover:text-foreground ml-0.5"
                       aria-label={`Remove ${user}`}
@@ -439,7 +435,6 @@ function GlobalSettingsSection({
             setCodeReviewInstructions(e.target.value);
             setDirty(true);
             setError("");
-            setSuccess("");
           }}
           rows={3}
           placeholder="e.g., Focus on security best practices and ensure all API endpoints validate input."
@@ -461,7 +456,6 @@ function GlobalSettingsSection({
             setCommentActionInstructions(e.target.value);
             setDirty(true);
             setError("");
-            setSuccess("");
           }}
           rows={3}
           placeholder="e.g., Always run tests before pushing changes. Prefer minimal diffs."
@@ -480,6 +474,22 @@ function GlobalSettingsSection({
           </Button>
         )}
       </div>
+
+      <AlertDialog open={showResetDialog} onOpenChange={setShowResetDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Reset to defaults</AlertDialogTitle>
+            <AlertDialogDescription>
+              Reset all GitHub bot settings to defaults? The bot will respond to all repos with
+              auto-review enabled.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmReset}>Reset</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Section>
   );
 }
@@ -494,8 +504,6 @@ function RepoOverridesSection({
   enabledModelOptions: { category: string; models: { id: string; name: string }[] }[];
 }) {
   const [addingRepo, setAddingRepo] = useState("");
-  const [error, setError] = useState("");
-  const [success, setSuccess] = useState("");
 
   const overriddenRepos = new Set(overrides.map((o) => o.repo));
   const availableForOverride = availableRepos.filter(
@@ -505,8 +513,6 @@ function RepoOverridesSection({
   const handleAdd = async () => {
     if (!addingRepo) return;
     const [owner, name] = addingRepo.split("/");
-    setError("");
-    setSuccess("");
 
     try {
       const res = await fetch(`/api/integration-settings/github/repos/${owner}/${name}`, {
@@ -518,21 +524,18 @@ function RepoOverridesSection({
       if (res.ok) {
         mutate(REPO_SETTINGS_KEY);
         setAddingRepo("");
-        setSuccess("Override added.");
+        toast.success("Override added.");
       } else {
         const data = await res.json();
-        setError(data.error || "Failed to add override");
+        toast.error(data.error || "Failed to add override");
       }
     } catch {
-      setError("Failed to add override");
+      toast.error("Failed to add override");
     }
   };
 
   return (
     <div>
-      {error && <Message tone="error" text={error} />}
-      {success && <Message tone="success" text={success} />}
-
       {overrides.length > 0 ? (
         <div className="space-y-2 mb-4">
           {overrides.map((entry) => (
@@ -540,8 +543,6 @@ function RepoOverridesSection({
               key={entry.repo}
               entry={entry}
               enabledModelOptions={enabledModelOptions}
-              onError={setError}
-              onSuccess={setSuccess}
             />
           ))}
         </div>
@@ -575,13 +576,9 @@ function RepoOverridesSection({
 function RepoOverrideRow({
   entry,
   enabledModelOptions,
-  onError,
-  onSuccess,
 }: {
   entry: RepoSettingsEntry;
   enabledModelOptions: { category: string; models: { id: string; name: string }[] }[];
-  onError: (msg: string) => void;
-  onSuccess: (msg: string) => void;
 }) {
   const [model, setModel] = useState(entry.settings.model ?? "");
   const [effort, setEffort] = useState(entry.settings.reasoningEffort ?? "");
@@ -620,8 +617,6 @@ function RepoOverrideRow({
 
   const handleSave = async () => {
     setSaving(true);
-    onError("");
-    onSuccess("");
 
     const [owner, name] = entry.repo.split("/");
     const settings: GitHubBotSettings = {};
@@ -642,13 +637,13 @@ function RepoOverrideRow({
       if (res.ok) {
         mutate(REPO_SETTINGS_KEY);
         setDirty(false);
-        onSuccess(`Override for ${entry.repo} saved.`);
+        toast.success(`Override for ${entry.repo} saved.`);
       } else {
         const data = await res.json();
-        onError(data.error || "Failed to save override");
+        toast.error(data.error || "Failed to save override");
       }
     } catch {
-      onError("Failed to save override");
+      toast.error("Failed to save override");
     } finally {
       setSaving(false);
     }
@@ -656,8 +651,6 @@ function RepoOverrideRow({
 
   const handleDelete = async () => {
     const [owner, name] = entry.repo.split("/");
-    onError("");
-    onSuccess("");
 
     try {
       const res = await fetch(`/api/integration-settings/github/repos/${owner}/${name}`, {
@@ -666,13 +659,13 @@ function RepoOverrideRow({
 
       if (res.ok) {
         mutate(REPO_SETTINGS_KEY);
-        onSuccess(`Override for ${entry.repo} removed.`);
+        toast.success(`Override for ${entry.repo} removed.`);
       } else {
         const data = await res.json();
-        onError(data.error || "Failed to delete override");
+        toast.error(data.error || "Failed to delete override");
       }
     } catch {
-      onError("Failed to delete override");
+      toast.error("Failed to delete override");
     }
   };
 

--- a/packages/web/src/components/settings/integrations/linear-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/linear-integration-settings.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, type ReactNode } from "react";
 import useSWR, { mutate } from "swr";
+import { toast } from "sonner";
 import {
   MODEL_REASONING_CONFIG,
   isValidReasoningEffort,
@@ -14,6 +15,16 @@ import { useEnabledModels } from "@/hooks/use-enabled-models";
 import { IntegrationSettingsSkeleton } from "./integration-settings-skeleton";
 import { Button } from "@/components/ui/button";
 import { RadioCard, Select } from "@/components/ui/form-controls";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 
 const GLOBAL_SETTINGS_KEY = "/api/integration-settings/linear";
 const REPO_SETTINGS_KEY = "/api/integration-settings/linear/repos";
@@ -119,9 +130,9 @@ function GlobalSettingsSection({
   );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
-  const [success, setSuccess] = useState("");
   const [dirty, setDirty] = useState(false);
   const [initialized, setInitialized] = useState(false);
+  const [showResetDialog, setShowResetDialog] = useState(false);
 
   useEffect(() => {
     if (settings !== undefined && !initialized) {
@@ -144,14 +155,13 @@ function GlobalSettingsSection({
   const resetNotice =
     "Reset all Linear settings to defaults? This enables both label/user model overrides.";
 
-  const handleReset = async () => {
-    if (!window.confirm(resetNotice)) {
-      return;
-    }
+  const handleReset = () => {
+    setShowResetDialog(true);
+  };
 
+  const handleConfirmReset = async () => {
     setSaving(true);
     setError("");
-    setSuccess("");
 
     try {
       const res = await fetch(GLOBAL_SETTINGS_KEY, { method: "DELETE" });
@@ -166,13 +176,13 @@ function GlobalSettingsSection({
         setAllowLabelModelOverride(true);
         setEmitToolProgressActivities(true);
         setDirty(false);
-        setSuccess("Settings reset to defaults.");
+        toast.success("Settings reset to defaults.");
       } else {
         const data = await res.json();
-        setError(data.error || "Failed to reset settings");
+        toast.error(data.error || "Failed to reset settings");
       }
     } catch {
-      setError("Failed to reset settings");
+      toast.error("Failed to reset settings");
     } finally {
       setSaving(false);
     }
@@ -181,7 +191,6 @@ function GlobalSettingsSection({
   const handleSave = async () => {
     setSaving(true);
     setError("");
-    setSuccess("");
 
     const defaults: LinearBotSettings = {
       allowUserPreferenceOverride,
@@ -206,14 +215,14 @@ function GlobalSettingsSection({
 
       if (res.ok) {
         mutate(GLOBAL_SETTINGS_KEY);
-        setSuccess("Settings saved.");
+        toast.success("Settings saved.");
         setDirty(false);
       } else {
         const data = await res.json();
-        setError(data.error || "Failed to save settings");
+        toast.error(data.error || "Failed to save settings");
       }
     } catch {
-      setError("Failed to save settings");
+      toast.error("Failed to save settings");
     } finally {
       setSaving(false);
     }
@@ -226,7 +235,6 @@ function GlobalSettingsSection({
     );
     setDirty(true);
     setError("");
-    setSuccess("");
   };
 
   return (
@@ -235,7 +243,6 @@ function GlobalSettingsSection({
       description="Global model, fallback behavior, and repository targeting."
     >
       {error && <Message tone="error" text={error} />}
-      {success && <Message tone="success" text={success} />}
 
       <div className="grid sm:grid-cols-2 gap-3 mb-4">
         <label className="text-sm">
@@ -250,7 +257,6 @@ function GlobalSettingsSection({
               }
               setDirty(true);
               setError("");
-              setSuccess("");
             }}
             className="w-full"
           >
@@ -275,7 +281,6 @@ function GlobalSettingsSection({
               setEffort(e.target.value);
               setDirty(true);
               setError("");
-              setSuccess("");
             }}
             disabled={!reasoningConfig}
             className="w-full"
@@ -300,7 +305,6 @@ function GlobalSettingsSection({
               setAllowUserPreferenceOverride(!allowUserPreferenceOverride);
               setDirty(true);
               setError("");
-              setSuccess("");
             }}
             className="rounded border-border"
           />
@@ -314,7 +318,6 @@ function GlobalSettingsSection({
               setAllowLabelModelOverride(!allowLabelModelOverride);
               setDirty(true);
               setError("");
-              setSuccess("");
             }}
             className="rounded border-border"
           />
@@ -331,7 +334,6 @@ function GlobalSettingsSection({
               setEmitToolProgressActivities(!emitToolProgressActivities);
               setDirty(true);
               setError("");
-              setSuccess("");
             }}
             className="rounded border-border"
           />
@@ -348,7 +350,6 @@ function GlobalSettingsSection({
               setRepoScopeMode("all");
               setDirty(true);
               setError("");
-              setSuccess("");
             }}
             label="All repositories"
             description="Linear events can run against every accessible repository."
@@ -360,7 +361,6 @@ function GlobalSettingsSection({
               setRepoScopeMode("selected");
               setDirty(true);
               setError("");
-              setSuccess("");
             }}
             label="Selected repositories"
             description="Linear events run only for repositories in the allowlist."
@@ -417,6 +417,19 @@ function GlobalSettingsSection({
           </Button>
         )}
       </div>
+
+      <AlertDialog open={showResetDialog} onOpenChange={setShowResetDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Reset to defaults</AlertDialogTitle>
+            <AlertDialogDescription>{resetNotice}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmReset}>Reset</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Section>
   );
 }
@@ -431,8 +444,6 @@ function RepoOverridesSection({
   enabledModelOptions: { category: string; models: { id: string; name: string }[] }[];
 }) {
   const [addingRepo, setAddingRepo] = useState("");
-  const [error, setError] = useState("");
-  const [success, setSuccess] = useState("");
 
   const overriddenRepos = new Set(overrides.map((o) => o.repo));
   const availableForOverride = availableRepos.filter(
@@ -442,8 +453,6 @@ function RepoOverridesSection({
   const handleAdd = async () => {
     if (!addingRepo) return;
     const [owner, name] = addingRepo.split("/");
-    setError("");
-    setSuccess("");
 
     try {
       const res = await fetch(`/api/integration-settings/linear/repos/${owner}/${name}`, {
@@ -455,21 +464,18 @@ function RepoOverridesSection({
       if (res.ok) {
         mutate(REPO_SETTINGS_KEY);
         setAddingRepo("");
-        setSuccess("Override added.");
+        toast.success("Override added.");
       } else {
         const data = await res.json();
-        setError(data.error || "Failed to add override");
+        toast.error(data.error || "Failed to add override");
       }
     } catch {
-      setError("Failed to add override");
+      toast.error("Failed to add override");
     }
   };
 
   return (
     <div>
-      {error && <Message tone="error" text={error} />}
-      {success && <Message tone="success" text={success} />}
-
       {overrides.length > 0 ? (
         <div className="space-y-2 mb-4">
           {overrides.map((entry) => (
@@ -477,8 +483,6 @@ function RepoOverridesSection({
               key={entry.repo}
               entry={entry}
               enabledModelOptions={enabledModelOptions}
-              onError={setError}
-              onSuccess={setSuccess}
             />
           ))}
         </div>
@@ -512,13 +516,9 @@ function RepoOverridesSection({
 function RepoOverrideRow({
   entry,
   enabledModelOptions,
-  onError,
-  onSuccess,
 }: {
   entry: RepoSettingsEntry;
   enabledModelOptions: { category: string; models: { id: string; name: string }[] }[];
-  onError: (msg: string) => void;
-  onSuccess: (msg: string) => void;
 }) {
   const [model, setModel] = useState(entry.settings.model ?? "");
   const [effort, setEffort] = useState(entry.settings.reasoningEffort ?? "");
@@ -547,8 +547,6 @@ function RepoOverrideRow({
 
   const handleSave = async () => {
     setSaving(true);
-    onError("");
-    onSuccess("");
 
     const [owner, name] = entry.repo.split("/");
     const settings: LinearBotSettings = {
@@ -569,13 +567,13 @@ function RepoOverrideRow({
       if (res.ok) {
         mutate(REPO_SETTINGS_KEY);
         setDirty(false);
-        onSuccess(`Override for ${entry.repo} saved.`);
+        toast.success(`Override for ${entry.repo} saved.`);
       } else {
         const data = await res.json();
-        onError(data.error || "Failed to save override");
+        toast.error(data.error || "Failed to save override");
       }
     } catch {
-      onError("Failed to save override");
+      toast.error("Failed to save override");
     } finally {
       setSaving(false);
     }
@@ -583,8 +581,6 @@ function RepoOverrideRow({
 
   const handleDelete = async () => {
     const [owner, name] = entry.repo.split("/");
-    onError("");
-    onSuccess("");
 
     try {
       const res = await fetch(`/api/integration-settings/linear/repos/${owner}/${name}`, {
@@ -593,13 +589,13 @@ function RepoOverrideRow({
 
       if (res.ok) {
         mutate(REPO_SETTINGS_KEY);
-        onSuccess(`Override for ${entry.repo} removed.`);
+        toast.success(`Override for ${entry.repo} removed.`);
       } else {
         const data = await res.json();
-        onError(data.error || "Failed to delete override");
+        toast.error(data.error || "Failed to delete override");
       }
     } catch {
-      onError("Failed to delete override");
+      toast.error("Failed to delete override");
     }
   };
 

--- a/packages/web/src/components/settings/models-settings.tsx
+++ b/packages/web/src/components/settings/models-settings.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import useSWR, { mutate } from "swr";
+import { toast } from "sonner";
 import { MODEL_OPTIONS, DEFAULT_ENABLED_MODELS } from "@open-inspect/shared";
 import { MODEL_PREFERENCES_KEY } from "@/hooks/use-enabled-models";
 import { Button } from "@/components/ui/button";
@@ -11,8 +12,6 @@ export function ModelsSettings() {
   const [enabledModels, setEnabledModels] = useState<Set<string>>(new Set(DEFAULT_ENABLED_MODELS));
   const [initialized, setInitialized] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState("");
-  const [success, setSuccess] = useState("");
   const [dirty, setDirty] = useState(false);
 
   // Sync SWR data into local state once on initial load
@@ -33,8 +32,6 @@ export function ModelsSettings() {
       return next;
     });
     setDirty(true);
-    setError("");
-    setSuccess("");
   };
 
   const toggleCategory = (category: (typeof MODEL_OPTIONS)[number], enable: boolean) => {
@@ -51,14 +48,10 @@ export function ModelsSettings() {
       return next;
     });
     setDirty(true);
-    setError("");
-    setSuccess("");
   };
 
   const handleSave = async () => {
     setSaving(true);
-    setError("");
-    setSuccess("");
 
     try {
       const res = await fetch("/api/model-preferences", {
@@ -69,14 +62,14 @@ export function ModelsSettings() {
 
       if (res.ok) {
         mutate(MODEL_PREFERENCES_KEY);
-        setSuccess("Model preferences saved.");
+        toast.success("Model preferences saved.");
         setDirty(false);
       } else {
         const data = await res.json();
-        setError(data.error || "Failed to save preferences");
+        toast.error(data.error || "Failed to save preferences");
       }
     } catch {
-      setError("Failed to save preferences");
+      toast.error("Failed to save preferences");
     } finally {
       setSaving(false);
     }
@@ -97,18 +90,6 @@ export function ModelsSettings() {
       <p className="text-sm text-muted-foreground mb-6">
         Choose which models appear in the model selector across the web UI and Slack bot.
       </p>
-
-      {error && (
-        <div className="mb-4 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 px-4 py-3 border border-red-200 dark:border-red-800 text-sm">
-          {error}
-        </div>
-      )}
-
-      {success && (
-        <div className="mb-4 bg-green-50 dark:bg-green-900/20 text-green-600 dark:text-green-400 px-4 py-3 border border-green-200 dark:border-green-800 text-sm">
-          {success}
-        </div>
-      )}
 
       <div className="space-y-6">
         {MODEL_OPTIONS.map((group) => {


### PR DESCRIPTION
## Summary

Follows up on #349 by replacing hand-rolled UI patterns with the new shadcn/Radix primitives.

**AlertDialog** (replaces `window.confirm()`):
- Archive session confirmation in action bar
- Reset settings confirmation in GitHub integration settings
- Reset settings confirmation in Linear integration settings

**DropdownMenu** (replaces hand-rolled `useState` + absolute-positioned menus):
- "More actions" menu in action bar (copy link, view in GitHub)
- User avatar menu in sidebar (sign out) — removes ~60 lines of manual outside-click/escape/viewport-clamping logic
- Per-session context menu in sidebar (rename)

**Input / Textarea** (replaces raw `<input>` / `<textarea>`):
- Sidebar search field
- Secrets editor key/value fields
- Automation form name and instructions fields

**Toast via Sonner** (replaces inline `success`/`error` state banners):
- Secrets editor: save, delete, paste import feedback
- Models settings: save preferences
- Data controls: unarchive session
- GitHub integration settings: save, reset
- Linear integration settings: save, reset
- Action bar: copy link to clipboard

Net change: **-60 lines** — hand-rolled logic replaced with accessible, keyboard-navigable primitives.

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes (only pre-existing `use-session-socket.ts` error)
- [x] `npm test` passes (92/92)
- [ ] Visual check: archive session shows AlertDialog instead of browser confirm
- [ ] Visual check: action bar "more" menu opens as DropdownMenu
- [ ] Visual check: sidebar user menu opens as DropdownMenu
- [ ] Visual check: toast notifications appear for save/delete/copy actions
- [ ] Keyboard nav: DropdownMenu items navigable with arrow keys, dismiss with Escape