### PR TITLE
Adopt shadcn Input, Textarea, and Checkbox primitives

### DIFF
--- a/packages/web/src/components/automations/cron-picker.tsx
+++ b/packages/web/src/components/automations/cron-picker.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo } from "react";
 import { isValidCron, nextCronOccurrence, describeCron } from "@open-inspect/shared";
 import { RadioCard } from "@/components/ui/form-controls";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -186,12 +187,11 @@ export function CronPicker({ value, onChange, timezone }: CronPickerProps) {
 
       {presetType === "custom" && (
         <div>
-          <input
-            type="text"
+          <Input
             value={customValue}
             onChange={(e) => handleCustomChange(e.target.value)}
             placeholder="0 9 * * 1-5"
-            className="w-full px-3 py-2 text-sm bg-input border border-border focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent placeholder:text-secondary-foreground text-foreground font-mono"
+            className="font-mono placeholder:text-secondary-foreground"
           />
           {customValue && !isValidCron(customValue) && (
             <p className="mt-1 text-xs text-red-500">

--- a/packages/web/src/components/settings/integrations/github-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/github-integration-settings.tsx
@@ -14,8 +14,11 @@ import {
 import { useEnabledModels } from "@/hooks/use-enabled-models";
 import { IntegrationSettingsSkeleton } from "./integration-settings-skeleton";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { RadioCard } from "@/components/ui/form-controls";
+import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
   SelectContent,
@@ -324,11 +327,9 @@ function GlobalSettingsSection({
                       key={repo.fullName}
                       className="flex items-center gap-2 px-4 py-2 hover:bg-muted/50 transition cursor-pointer text-sm"
                     >
-                      <input
-                        type="checkbox"
+                      <Checkbox
                         checked={isChecked}
-                        onChange={() => toggleRepo(repo.fullName)}
-                        className="rounded border-border"
+                        onCheckedChange={() => toggleRepo(repo.fullName)}
                       />
                       <span className="text-foreground">{repo.fullName}</span>
                     </label>
@@ -376,8 +377,7 @@ function GlobalSettingsSection({
         {triggerUserMode === "specific" && (
           <>
             <div className="flex items-center gap-2 mb-2">
-              <input
-                type="text"
+              <Input
                 value={newUsername}
                 onChange={(e) => setNewUsername(e.target.value)}
                 onKeyDown={(e) => {
@@ -387,7 +387,7 @@ function GlobalSettingsSection({
                   }
                 }}
                 placeholder="GitHub username"
-                className="flex-1 px-3 py-1.5 text-sm border border-border rounded-sm bg-background text-foreground placeholder:text-muted-foreground"
+                className="flex-1 h-8"
               />
               <Button size="sm" onClick={addUsername} disabled={!newUsername.trim()}>
                 Add
@@ -437,7 +437,7 @@ function GlobalSettingsSection({
           Custom instructions appended to code review prompts. Use this to focus reviews on specific
           areas or coding standards.
         </p>
-        <textarea
+        <Textarea
           value={codeReviewInstructions}
           onChange={(e) => {
             setCodeReviewInstructions(e.target.value);
@@ -446,7 +446,7 @@ function GlobalSettingsSection({
           }}
           rows={3}
           placeholder="e.g., Focus on security best practices and ensure all API endpoints validate input."
-          className="w-full px-3 py-2 text-sm border border-border rounded-sm bg-background text-foreground placeholder:text-muted-foreground resize-y"
+          className="resize-y"
         />
       </div>
 
@@ -458,7 +458,7 @@ function GlobalSettingsSection({
           Custom instructions appended to comment action prompts (@mention responses). Use this to
           guide how the bot responds to comments.
         </p>
-        <textarea
+        <Textarea
           value={commentActionInstructions}
           onChange={(e) => {
             setCommentActionInstructions(e.target.value);
@@ -467,7 +467,7 @@ function GlobalSettingsSection({
           }}
           rows={3}
           placeholder="e.g., Always run tests before pushing changes. Prefer minimal diffs."
-          className="w-full px-3 py-2 text-sm border border-border rounded-sm bg-background text-foreground placeholder:text-muted-foreground resize-y"
+          className="resize-y"
         />
       </div>
 
@@ -764,8 +764,7 @@ function RepoOverrideRow({
         {triggerUserMode === "override" && (
           <>
             <div className="flex items-center gap-2 mb-1">
-              <input
-                type="text"
+              <Input
                 value={newUsername}
                 onChange={(e) => setNewUsername(e.target.value)}
                 onKeyDown={(e) => {
@@ -775,7 +774,7 @@ function RepoOverrideRow({
                   }
                 }}
                 placeholder="GitHub username"
-                className="flex-1 px-2 py-1 text-xs border border-border rounded-sm bg-background text-foreground placeholder:text-muted-foreground"
+                className="flex-1 h-auto px-2 py-1 text-xs"
               />
               <Button size="sm" onClick={addRepoUsername} disabled={!newUsername.trim()}>
                 Add
@@ -835,7 +834,7 @@ function RepoOverrideRow({
           </Select>
         </div>
         {codeReviewMode === "override" && (
-          <textarea
+          <Textarea
             value={codeReviewInstructions}
             onChange={(e) => {
               setCodeReviewInstructions(e.target.value);
@@ -843,7 +842,7 @@ function RepoOverrideRow({
             }}
             rows={2}
             placeholder="Custom review instructions for this repo..."
-            className="w-full px-2 py-1 text-xs border border-border rounded-sm bg-background text-foreground placeholder:text-muted-foreground resize-y"
+            className="px-2 py-1 text-xs resize-y"
           />
         )}
       </div>
@@ -870,7 +869,7 @@ function RepoOverrideRow({
           </Select>
         </div>
         {commentActionMode === "override" && (
-          <textarea
+          <Textarea
             value={commentActionInstructions}
             onChange={(e) => {
               setCommentActionInstructions(e.target.value);
@@ -878,7 +877,7 @@ function RepoOverrideRow({
             }}
             rows={2}
             placeholder="Custom comment action instructions for this repo..."
-            className="w-full px-2 py-1 text-xs border border-border rounded-sm bg-background text-foreground placeholder:text-muted-foreground resize-y"
+            className="px-2 py-1 text-xs resize-y"
           />
         )}
       </div>

--- a/packages/web/src/components/settings/integrations/linear-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/linear-integration-settings.tsx
@@ -14,6 +14,7 @@ import {
 import { useEnabledModels } from "@/hooks/use-enabled-models";
 import { IntegrationSettingsSkeleton } from "./integration-settings-skeleton";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { RadioCard } from "@/components/ui/form-controls";
 import {
   Select,
@@ -313,28 +314,24 @@ function GlobalSettingsSection({
       <div className="grid sm:grid-cols-2 gap-2 mb-4">
         <label className="flex items-center justify-between px-3 py-2 border border-border rounded-sm cursor-pointer hover:bg-muted/50 transition text-sm">
           <span>Allow user model preferences</span>
-          <input
-            type="checkbox"
+          <Checkbox
             checked={allowUserPreferenceOverride}
-            onChange={() => {
-              setAllowUserPreferenceOverride(!allowUserPreferenceOverride);
+            onCheckedChange={(checked) => {
+              setAllowUserPreferenceOverride(!!checked);
               setDirty(true);
               setError("");
             }}
-            className="rounded border-border"
           />
         </label>
         <label className="flex items-center justify-between px-3 py-2 border border-border rounded-sm cursor-pointer hover:bg-muted/50 transition text-sm">
           <span>Allow model labels (model:*)</span>
-          <input
-            type="checkbox"
+          <Checkbox
             checked={allowLabelModelOverride}
-            onChange={() => {
-              setAllowLabelModelOverride(!allowLabelModelOverride);
+            onCheckedChange={(checked) => {
+              setAllowLabelModelOverride(!!checked);
               setDirty(true);
               setError("");
             }}
-            className="rounded border-border"
           />
         </label>
       </div>
@@ -342,15 +339,13 @@ function GlobalSettingsSection({
       <div className="mb-4">
         <label className="flex items-center justify-between px-3 py-2 border border-border rounded-sm cursor-pointer hover:bg-muted/50 transition text-sm">
           <span>Emit tool progress activities</span>
-          <input
-            type="checkbox"
+          <Checkbox
             checked={emitToolProgressActivities}
-            onChange={() => {
-              setEmitToolProgressActivities(!emitToolProgressActivities);
+            onCheckedChange={(checked) => {
+              setEmitToolProgressActivities(!!checked);
               setDirty(true);
               setError("");
             }}
-            className="rounded border-border"
           />
         </label>
       </div>
@@ -399,11 +394,9 @@ function GlobalSettingsSection({
                       key={repo.fullName}
                       className="flex items-center gap-2 px-4 py-2 hover:bg-muted/50 transition cursor-pointer text-sm"
                     >
-                      <input
-                        type="checkbox"
+                      <Checkbox
                         checked={isChecked}
-                        onChange={() => toggleRepo(repo.fullName)}
-                        className="rounded border-border"
+                        onCheckedChange={() => toggleRepo(repo.fullName)}
                       />
                       <span className="text-foreground">{repo.fullName}</span>
                     </label>
@@ -659,14 +652,12 @@ function RepoOverrideRow({
 
         <label className="flex items-center justify-between px-2 py-1 text-sm border border-border rounded-sm">
           <span>Tool updates</span>
-          <input
-            type="checkbox"
+          <Checkbox
             checked={emitToolProgressActivities}
-            onChange={() => {
-              setEmitToolProgressActivities(!emitToolProgressActivities);
+            onCheckedChange={(checked) => {
+              setEmitToolProgressActivities(!!checked);
               setDirty(true);
             }}
-            className="rounded border-border"
           />
         </label>
       </div>
@@ -674,26 +665,22 @@ function RepoOverrideRow({
       <div className="grid sm:grid-cols-2 gap-2">
         <label className="flex items-center justify-between px-2 py-1 text-sm border border-border rounded-sm">
           <span>User preference override</span>
-          <input
-            type="checkbox"
+          <Checkbox
             checked={allowUserPreferenceOverride}
-            onChange={() => {
-              setAllowUserPreferenceOverride(!allowUserPreferenceOverride);
+            onCheckedChange={(checked) => {
+              setAllowUserPreferenceOverride(!!checked);
               setDirty(true);
             }}
-            className="rounded border-border"
           />
         </label>
         <label className="flex items-center justify-between px-2 py-1 text-sm border border-border rounded-sm">
           <span>Label model override</span>
-          <input
-            type="checkbox"
+          <Checkbox
             checked={allowLabelModelOverride}
-            onChange={() => {
-              setAllowLabelModelOverride(!allowLabelModelOverride);
+            onCheckedChange={(checked) => {
+              setAllowLabelModelOverride(!!checked);
               setDirty(true);
             }}
-            className="rounded border-border"
           />
         </label>
       </div>


### PR DESCRIPTION
## Summary

- **Input**: Replace raw `<input>` elements with the shadcn `<Input>` component in cron-picker (custom expression field) and GitHub integration settings (username entry fields)
- **Textarea**: Replace raw `<textarea>` elements with the shadcn `<Textarea>` component for code review and comment action instruction fields (both global and per-repo)
- **Checkbox**: Replace raw `<input type="checkbox">` with the Radix `<Checkbox>` component for repo selection lists and boolean toggles in both GitHub and Linear integration settings

### What's intentionally NOT migrated
- `sr-only` radio input in `form-controls.tsx` (accessibility-only, no visual styling)
- Combobox search input (specialized ARIA combobox with custom role attributes)
- Inline rename inputs in session sidebar/header (transparent bg, minimal styling for in-place editing)
- Chat prompt textareas on home/session pages (highly custom layout with floating action buttons)

Continues the shadcn/ui design system adoption from PRs #349, #350, #351, #352.

## Test plan
- [ ] Verify cron picker custom expression input renders and validates correctly
- [ ] Verify GitHub username add/remove works in both global and per-repo settings
- [ ] Verify code review and comment action instruction textareas accept input and resize
- [ ] Verify repo selection checkboxes toggle correctly in GitHub and Linear settings
- [ ] Verify boolean toggles (user preferences, label overrides, tool progress) work in Linear settings
- [ ] Visual check: all migrated elements match the design system styling