### PR TITLE
fix: clear stale code-server credentials on sandbox transitions

### DIFF
--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -300,18 +300,20 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
           );
           break;
 
-        case "sandbox_status":
+        case "sandbox_status": {
+          const isTerminal =
+            data.status === "stale" || data.status === "stopped" || data.status === "failed";
           setSessionState((prev) =>
             prev
               ? {
                   ...prev,
                   sandboxStatus: data.status,
-                  codeServerUrl: undefined,
-                  codeServerPassword: undefined,
+                  ...(isTerminal && { codeServerUrl: undefined, codeServerPassword: undefined }),
                 }
               : null
           );
           break;
+        }
 
         case "code_server_info":
           setSessionState((prev) =>
@@ -320,16 +322,7 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
           break;
 
         case "sandbox_ready":
-          setSessionState((prev) =>
-            prev
-              ? {
-                  ...prev,
-                  sandboxStatus: "ready",
-                  codeServerUrl: undefined,
-                  codeServerPassword: undefined,
-                }
-              : null
-          );
+          setSessionState((prev) => (prev ? { ...prev, sandboxStatus: "ready" } : null));
           break;
 
         case "artifact_created":


### PR DESCRIPTION
## Summary

- When a sandbox goes stale/stopped, `clearSandboxCodeServer()` in the lifecycle manager clears the DB but connected clients kept stale `codeServerUrl`/`codeServerPassword` in React state
- If a subsequent sandbox respawned without code-server enabled, the old URL would resurface as a clickable dead "Open Editor" link once the new sandbox reached "ready" status
- Fix: clear code-server fields on `sandbox_spawning`, `sandbox_status`, and `sandbox_ready` so only a fresh `code_server_info` message can populate them

Follow-up to #354.

## Test plan
- [x] 91 web tests pass (1 pre-existing failure unrelated — missing `@radix-ui/react-slot`)
- [x] Typecheck clean (all errors pre-existing radix/sonner type declarations)
- [x] `codeServerUrl`/`codeServerPassword` are optional fields (`string | null | undefined`) — setting to `undefined` correctly hides the `CodeServerSection` in the sidebar