### PR TITLE
chore(modal-infra): raise root log level from DEBUG to INFO

### DIFF
--- a/packages/modal-infra/src/sandbox/log_config.py
+++ b/packages/modal-infra/src/sandbox/log_config.py
@@ -83,7 +83,7 @@ def configure_logging() -> None:
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(JSONFormatter())
     logging.root.handlers = [handler]
-    logging.root.setLevel(logging.DEBUG)
+    logging.root.setLevel(logging.INFO)
 
 
 class StructuredLogger:

--- a/packages/modal-infra/tests/test_log_config.py
+++ b/packages/modal-infra/tests/test_log_config.py
@@ -167,7 +167,7 @@ class TestConfigureLogging:
         configure_logging()
         assert len(logging.root.handlers) == 1
         assert isinstance(logging.root.handlers[0].formatter, JSONFormatter)
-        assert logging.root.level == logging.DEBUG
+        assert logging.root.level == logging.INFO
 
     def test_replaces_existing_handlers(self):
         logging.root.addHandler(logging.StreamHandler())


### PR DESCRIPTION
## Summary
- Raises the root Python log level from `DEBUG` to `INFO` in `configure_logging()`
- Suppresses noisy third-party debug logs (hpack, httpx, websockets, h2) that were drowning out application logs
- Updates the corresponding test assertion

## Test plan
- [x] `pytest tests/test_log_config.py` passes