### PR TITLE
fix: respect image_build_enabled toggle when selecting pre-built images

### DIFF
--- a/packages/control-plane/src/db/repo-images.test.ts
+++ b/packages/control-plane/src/db/repo-images.test.ts
@@ -24,9 +24,9 @@ const QUERY_PATTERNS = {
   DELETE_BY_ID: /^DELETE FROM repo_images WHERE id = \?$/,
   UPDATE_FAILED: /^UPDATE repo_images SET status = 'failed', error_message = \? WHERE id = \?$/,
   SELECT_LATEST_READY:
-    /^SELECT \* FROM repo_images WHERE repo_owner = \? AND repo_name = \? AND status = 'ready' ORDER BY created_at DESC LIMIT 1$/,
+    /^SELECT ri\.\* FROM repo_images ri INNER JOIN repo_metadata rm ON ri\.repo_owner = rm\.repo_owner AND ri\.repo_name = rm\.repo_name WHERE ri\.repo_owner = \? AND ri\.repo_name = \? AND ri\.status = 'ready' AND rm\.image_build_enabled = 1 ORDER BY ri\.created_at DESC LIMIT 1$/,
   SELECT_LATEST_READY_WITH_BRANCH:
-    /^SELECT \* FROM repo_images WHERE repo_owner = \? AND repo_name = \? AND base_branch = \? AND status = 'ready' ORDER BY created_at DESC LIMIT 1$/,
+    /^SELECT ri\.\* FROM repo_images ri INNER JOIN repo_metadata rm ON ri\.repo_owner = rm\.repo_owner AND ri\.repo_name = rm\.repo_name WHERE ri\.repo_owner = \? AND ri\.repo_name = \? AND ri\.base_branch = \? AND ri\.status = 'ready' AND rm\.image_build_enabled = 1 ORDER BY ri\.created_at DESC LIMIT 1$/,
   SELECT_STATUS:
     /^SELECT \* FROM repo_images WHERE repo_owner = \? AND repo_name = \? ORDER BY created_at DESC LIMIT 10$/,
   SELECT_ALL_STATUS: /^SELECT \* FROM repo_images ORDER BY created_at DESC LIMIT 100$/,
@@ -41,6 +41,18 @@ function normalizeQuery(query: string): string {
 
 class FakeD1Database {
   private rows = new Map<string, RepoImageRow>();
+  private repoMetadata = new Map<string, { image_build_enabled: number }>();
+
+  setImageBuildEnabled(repoOwner: string, repoName: string, enabled: boolean) {
+    this.repoMetadata.set(`${repoOwner.toLowerCase()}/${repoName.toLowerCase()}`, {
+      image_build_enabled: enabled ? 1 : 0,
+    });
+  }
+
+  private isImageBuildEnabled(repoOwner: string, repoName: string): boolean {
+    const meta = this.repoMetadata.get(`${repoOwner.toLowerCase()}/${repoName.toLowerCase()}`);
+    return meta?.image_build_enabled === 1;
+  }
 
   prepare(query: string) {
     return new FakePreparedStatement(this, query);
@@ -74,6 +86,7 @@ class FakeD1Database {
 
     if (QUERY_PATTERNS.SELECT_LATEST_READY_WITH_BRANCH.test(normalized)) {
       const [owner, name, branch] = args as [string, string, string];
+      if (!this.isImageBuildEnabled(owner, name)) return null;
       let latest: RepoImageRow | null = null;
       for (const row of this.rows.values()) {
         if (
@@ -92,6 +105,7 @@ class FakeD1Database {
 
     if (QUERY_PATTERNS.SELECT_LATEST_READY.test(normalized)) {
       const [owner, name] = args as [string, string];
+      if (!this.isImageBuildEnabled(owner, name)) return null;
       let latest: RepoImageRow | null = null;
       for (const row of this.rows.values()) {
         if (row.repo_owner === owner && row.repo_name === name && row.status === "ready") {
@@ -301,6 +315,7 @@ describe("RepoImageStore", () => {
 
   describe("markReady", () => {
     it("updates build to ready with provider image details", async () => {
+      db.setImageBuildEnabled("acme", "repo", true);
       await store.registerBuild({
         id: "img-1",
         repoOwner: "acme",
@@ -321,6 +336,7 @@ describe("RepoImageStore", () => {
     });
 
     it("replaces previous ready image and returns its ID", async () => {
+      db.setImageBuildEnabled("acme", "repo", true);
       await store.registerBuild({
         id: "img-old",
         repoOwner: "acme",
@@ -384,11 +400,13 @@ describe("RepoImageStore", () => {
 
   describe("getLatestReady", () => {
     it("returns null when no ready images exist", async () => {
+      db.setImageBuildEnabled("acme", "repo", true);
       const result = await store.getLatestReady("acme", "repo");
       expect(result).toBeNull();
     });
 
     it("returns null when only building/failed images exist", async () => {
+      db.setImageBuildEnabled("acme", "repo", true);
       await store.registerBuild({
         id: "img-1",
         repoOwner: "acme",
@@ -401,6 +419,7 @@ describe("RepoImageStore", () => {
     });
 
     it("returns the most recent ready image", async () => {
+      db.setImageBuildEnabled("acme", "repo", true);
       await store.registerBuild({
         id: "img-1",
         repoOwner: "acme",
@@ -415,7 +434,36 @@ describe("RepoImageStore", () => {
       expect(result!.provider_image_id).toBe("modal-img-1");
     });
 
+    it("returns null when image_build_enabled is false", async () => {
+      db.setImageBuildEnabled("acme", "repo", false);
+      await store.registerBuild({
+        id: "img-1",
+        repoOwner: "acme",
+        repoName: "repo",
+        baseBranch: "main",
+      });
+      await store.markReady("img-1", "modal-img-1", "sha1", 30);
+
+      const result = await store.getLatestReady("acme", "repo");
+      expect(result).toBeNull();
+    });
+
+    it("returns null when no repo_metadata row exists", async () => {
+      // No setImageBuildEnabled call — simulates repo with no metadata
+      await store.registerBuild({
+        id: "img-1",
+        repoOwner: "acme",
+        repoName: "repo",
+        baseBranch: "main",
+      });
+      await store.markReady("img-1", "modal-img-1", "sha1", 30);
+
+      const result = await store.getLatestReady("acme", "repo");
+      expect(result).toBeNull();
+    });
+
     it("is case-insensitive for repo owner and name", async () => {
+      db.setImageBuildEnabled("acme", "repo", true);
       await store.registerBuild({
         id: "img-1",
         repoOwner: "acme",
@@ -429,6 +477,7 @@ describe("RepoImageStore", () => {
     });
 
     it("filters by baseBranch when provided", async () => {
+      db.setImageBuildEnabled("acme", "repo", true);
       await store.registerBuild({
         id: "img-main",
         repoOwner: "acme",
@@ -470,6 +519,7 @@ describe("RepoImageStore", () => {
 
   describe("markReady branch isolation", () => {
     it("only replaces the previous ready image on the same branch", async () => {
+      db.setImageBuildEnabled("acme", "repo", true);
       // Build and mark ready on main
       await store.registerBuild({
         id: "img-main",

--- a/packages/control-plane/src/db/repo-images.ts
+++ b/packages/control-plane/src/db/repo-images.ts
@@ -90,14 +90,22 @@ export class RepoImageStore {
     if (baseBranch) {
       return this.db
         .prepare(
-          "SELECT * FROM repo_images WHERE repo_owner = ? AND repo_name = ? AND base_branch = ? AND status = 'ready' ORDER BY created_at DESC LIMIT 1"
+          `SELECT ri.* FROM repo_images ri
+           INNER JOIN repo_metadata rm ON ri.repo_owner = rm.repo_owner AND ri.repo_name = rm.repo_name
+           WHERE ri.repo_owner = ? AND ri.repo_name = ? AND ri.base_branch = ? AND ri.status = 'ready'
+           AND rm.image_build_enabled = 1
+           ORDER BY ri.created_at DESC LIMIT 1`
         )
         .bind(repoOwner.toLowerCase(), repoName.toLowerCase(), baseBranch)
         .first<RepoImage>();
     }
     return this.db
       .prepare(
-        "SELECT * FROM repo_images WHERE repo_owner = ? AND repo_name = ? AND status = 'ready' ORDER BY created_at DESC LIMIT 1"
+        `SELECT ri.* FROM repo_images ri
+         INNER JOIN repo_metadata rm ON ri.repo_owner = rm.repo_owner AND ri.repo_name = rm.repo_name
+         WHERE ri.repo_owner = ? AND ri.repo_name = ? AND ri.status = 'ready'
+         AND rm.image_build_enabled = 1
+         ORDER BY ri.created_at DESC LIMIT 1`
       )
       .bind(repoOwner.toLowerCase(), repoName.toLowerCase())
       .first<RepoImage>();

--- a/packages/control-plane/test/integration/repo-images.test.ts
+++ b/packages/control-plane/test/integration/repo-images.test.ts
@@ -7,10 +7,12 @@ import { cleanD1Tables } from "./cleanup";
 
 describe("D1 RepoImageStore", () => {
   let store: RepoImageStore;
+  let metadataStore: RepoMetadataStore;
 
   beforeEach(async () => {
     await cleanD1Tables();
     store = new RepoImageStore(env.DB);
+    metadataStore = new RepoMetadataStore(env.DB);
   });
 
   it("registerBuild creates a building row", async () => {
@@ -36,6 +38,7 @@ describe("D1 RepoImageStore", () => {
   });
 
   it("markReady updates build with provider image details", async () => {
+    await metadataStore.setImageBuildEnabled("acme", "repo", true);
     await store.registerBuild({
       id: "img-1",
       repoOwner: "acme",
@@ -55,6 +58,7 @@ describe("D1 RepoImageStore", () => {
   });
 
   it("markReady replaces previous ready image", async () => {
+    await metadataStore.setImageBuildEnabled("acme", "repo", true);
     await store.registerBuild({
       id: "img-old",
       repoOwner: "acme",
@@ -97,11 +101,13 @@ describe("D1 RepoImageStore", () => {
   });
 
   it("getLatestReady returns null when no ready images", async () => {
+    await metadataStore.setImageBuildEnabled("acme", "repo", true);
     const result = await store.getLatestReady("acme", "repo");
     expect(result).toBeNull();
   });
 
   it("getLatestReady ignores building and failed images", async () => {
+    await metadataStore.setImageBuildEnabled("acme", "repo", true);
     await store.registerBuild({
       id: "img-building",
       repoOwner: "acme",
@@ -121,6 +127,7 @@ describe("D1 RepoImageStore", () => {
   });
 
   it("getLatestReady is case-insensitive", async () => {
+    await metadataStore.setImageBuildEnabled("acme", "repo", true);
     await store.registerBuild({
       id: "img-1",
       repoOwner: "Acme",
@@ -130,6 +137,41 @@ describe("D1 RepoImageStore", () => {
     await store.markReady("img-1", "modal-img-1", "sha1", 30);
 
     const result = await store.getLatestReady("ACME", "REPO");
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe("img-1");
+  });
+
+  it("getLatestReady returns null when image_build_enabled is false", async () => {
+    await metadataStore.setImageBuildEnabled("acme", "repo", false);
+    await store.registerBuild({
+      id: "img-1",
+      repoOwner: "acme",
+      repoName: "repo",
+      baseBranch: "main",
+    });
+    await store.markReady("img-1", "modal-img-1", "sha1", 30);
+
+    const result = await store.getLatestReady("acme", "repo");
+    expect(result).toBeNull();
+  });
+
+  it("getLatestReady returns image after re-enabling builds", async () => {
+    await metadataStore.setImageBuildEnabled("acme", "repo", true);
+    await store.registerBuild({
+      id: "img-1",
+      repoOwner: "acme",
+      repoName: "repo",
+      baseBranch: "main",
+    });
+    await store.markReady("img-1", "modal-img-1", "sha1", 30);
+
+    // Disable — image should not be returned
+    await metadataStore.setImageBuildEnabled("acme", "repo", false);
+    expect(await store.getLatestReady("acme", "repo")).toBeNull();
+
+    // Re-enable — same image should be returned immediately
+    await metadataStore.setImageBuildEnabled("acme", "repo", true);
+    const result = await store.getLatestReady("acme", "repo");
     expect(result).not.toBeNull();
     expect(result!.id).toBe("img-1");
   });
@@ -203,6 +245,8 @@ describe("D1 RepoImageStore", () => {
   });
 
   it("different repos have independent images", async () => {
+    await metadataStore.setImageBuildEnabled("acme", "repo-a", true);
+    await metadataStore.setImageBuildEnabled("acme", "repo-b", true);
     await store.registerBuild({
       id: "img-a",
       repoOwner: "acme",
@@ -236,13 +280,16 @@ async function authHeaders(): Promise<Record<string, string>> {
 
 describe("Repo image HTTP routes", () => {
   let store: RepoImageStore;
+  let metadataStore: RepoMetadataStore;
 
   beforeEach(async () => {
     await cleanD1Tables();
     store = new RepoImageStore(env.DB);
+    metadataStore = new RepoMetadataStore(env.DB);
   });
 
   it("POST /repo-images/build-complete marks build as ready", async () => {
+    await metadataStore.setImageBuildEnabled("acme", "repo", true);
     await store.registerBuild({
       id: "img-test-1",
       repoOwner: "acme",


### PR DESCRIPTION
## Summary

- Fixes a bug where disabling pre-built images via the toggle (`PUT /repo-images/toggle`) still caused sandboxes to use stale pre-built images instead of falling back to `base_image`
- The `image_build_enabled` flag in `repo_metadata` was only checked by the scheduler (to stop new builds), but never at spawn time when selecting which image to use
- `getLatestReady()` now INNER JOINs `repo_metadata` to only return images when `image_build_enabled = 1`
- Non-destructive: re-enabling pre-builds immediately restores the existing image without requiring a rebuild

## Test plan

- [x] Unit tests: added "returns null when image_build_enabled is false" and "returns null when no repo_metadata row exists"
- [x] Integration tests: added "returns null when image_build_enabled is false" and "returns image after re-enabling builds" (toggle off → null → toggle on → image returned)
- [x] All 794 unit tests pass
- [x] All 234 integration tests pass (workerd/Miniflare with real D1)