### PR TITLE
fix: service bindings local dev

### DIFF
--- a/packages/web/src/lib/control-plane.ts
+++ b/packages/web/src/lib/control-plane.ts
@@ -73,6 +73,9 @@ function isServiceBinding(value: unknown): value is ServiceBinding {
 async function getServiceBinding(): Promise<ServiceBinding | null> {
   // In local development, always use URL-based fetch — the service binding
   // resolves to a local wrangler proxy that won't be running.
+  // In local development (next dev), always use URL-based fetch. When
+  // @opennextjs/cloudflare is loaded in a Node.js dev server it can return a
+  // stub service binding whose fetch fails with a "no local dev session" error.
   if (process.env.NODE_ENV === "development") {
     return null;
   }


### PR DESCRIPTION
I was following the [local dev guide](https://github.com/ColeMurray/background-agents/blob/main/docs/SETUP_GUIDE.md#path-a-run-the-web-app-locally-recommended-quick-start) and ran into these errors when starting the next app locally:

```sh
Failed to fetch sessions: SyntaxError: Unexpected token 'C', "Couldn't f"... is not valid JSON
    at JSON.parse (<anonymous>)
 GET /api/sessions?limit=50&offset=0&excludeStatus=archived 500 in 1056ms (compile: 76ms, render: 980ms)
Failed to fetch model preferences: SyntaxError: Unexpected token 'C', "Couldn't f"... is not valid JSON
    at JSON.parse (<anonymous>)
 GET /api/model-preferences 500 in 1057ms (compile: 62ms, render: 995ms)
Control plane API error: Couldn't find a local dev session for the "default" entrypoint of service "open-inspect-control-plane-local" to proxy to
 GET /api/repos 503 in 1058ms (compile: 89ms, render: 969ms)
```

this PR fixes this error by returning early when in local development.