### PR TITLE
fix: validate snapshot store path segments

### DIFF
--- a/packages/modal-infra/src/registry/store.py
+++ b/packages/modal-infra/src/registry/store.py
@@ -31,7 +31,7 @@ class SnapshotStore:
         self.snapshots_path.mkdir(parents=True, exist_ok=True)
         self.repos_path.mkdir(parents=True, exist_ok=True)
 
-    _VALID_PATH_SEGMENT_RE = re.compile(r"^[a-zA-Z0-9._-]+$")
+    _VALID_PATH_SEGMENT_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
 
     def _validate_path_segment(self, name: str, value: str) -> str:
         """Ensure filesystem path segments cannot escape the storage root."""
@@ -77,9 +77,12 @@ class SnapshotStore:
 
     def get_latest_snapshot(self, repo_owner: str, repo_name: str) -> Snapshot | None:
         """Get the latest ready snapshot for a repository."""
-        repo_dir = self._repo_snapshot_dir(repo_owner, repo_name)
-        latest_file = repo_dir / "latest.json"
+        try:
+            repo_dir = self._repo_snapshot_dir(repo_owner, repo_name)
+        except ValueError:
+            return None
 
+        latest_file = repo_dir / "latest.json"
         if not latest_file.exists():
             return None
 
@@ -91,8 +94,12 @@ class SnapshotStore:
 
     def get_snapshot(self, snapshot_id: str, repo_owner: str, repo_name: str) -> Snapshot | None:
         """Get a specific snapshot by ID."""
-        repo_dir = self._repo_snapshot_dir(repo_owner, repo_name)
-        snapshot_id = self._validate_path_segment("snapshot_id", snapshot_id)
+        try:
+            repo_dir = self._repo_snapshot_dir(repo_owner, repo_name)
+            snapshot_id = self._validate_path_segment("snapshot_id", snapshot_id)
+        except ValueError:
+            return None
+
         snapshot_file = repo_dir / "history" / f"{snapshot_id}.json"
 
         if not snapshot_file.exists():
@@ -111,8 +118,12 @@ class SnapshotStore:
         repo_name: str,
     ) -> SnapshotMetadata | None:
         """Get metadata for a specific snapshot."""
-        repo_dir = self._repo_snapshot_dir(repo_owner, repo_name)
-        snapshot_id = self._validate_path_segment("snapshot_id", snapshot_id)
+        try:
+            repo_dir = self._repo_snapshot_dir(repo_owner, repo_name)
+            snapshot_id = self._validate_path_segment("snapshot_id", snapshot_id)
+        except ValueError:
+            return None
+
         metadata_file = repo_dir / "history" / f"{snapshot_id}.metadata.json"
 
         if not metadata_file.exists():
@@ -131,7 +142,11 @@ class SnapshotStore:
         limit: int = 10,
     ) -> list[Snapshot]:
         """List recent snapshots for a repository."""
-        repo_dir = self._repo_snapshot_dir(repo_owner, repo_name)
+        try:
+            repo_dir = self._repo_snapshot_dir(repo_owner, repo_name)
+        except ValueError:
+            return []
+
         history_dir = repo_dir / "history"
 
         if not history_dir.exists():
@@ -160,7 +175,11 @@ class SnapshotStore:
         max_age_days: int = 7,
     ) -> int:
         """Clean up expired snapshots. Returns count of deleted snapshots."""
-        repo_dir = self._repo_snapshot_dir(repo_owner, repo_name)
+        try:
+            repo_dir = self._repo_snapshot_dir(repo_owner, repo_name)
+        except ValueError:
+            return 0
+
         history_dir = repo_dir / "history"
 
         if not history_dir.exists():
@@ -176,11 +195,12 @@ class SnapshotStore:
             try:
                 data = json.loads(file.read_text())
                 snapshot = Snapshot.model_validate(data)
+                snapshot_id = self._validate_path_segment("snapshot_id", snapshot.id)
 
                 if snapshot.created_at < cutoff:
                     file.unlink()
                     # Also delete metadata file
-                    metadata_file = history_dir / f"{snapshot.id}.metadata.json"
+                    metadata_file = history_dir / f"{snapshot_id}.metadata.json"
                     if metadata_file.exists():
                         metadata_file.unlink()
                     deleted += 1
@@ -199,7 +219,11 @@ class SnapshotStore:
 
     def get_repository(self, repo_owner: str, repo_name: str) -> Repository | None:
         """Get repository configuration."""
-        repo_owner, repo_name = self._validate_repo_identifiers(repo_owner, repo_name)
+        try:
+            repo_owner, repo_name = self._validate_repo_identifiers(repo_owner, repo_name)
+        except ValueError:
+            return None
+
         repo_file = self.repos_path / f"{repo_owner}_{repo_name}.json"
 
         if not repo_file.exists():
@@ -226,7 +250,11 @@ class SnapshotStore:
 
     def delete_repository(self, repo_owner: str, repo_name: str) -> bool:
         """Delete a repository configuration. Returns True if deleted."""
-        repo_owner, repo_name = self._validate_repo_identifiers(repo_owner, repo_name)
+        try:
+            repo_owner, repo_name = self._validate_repo_identifiers(repo_owner, repo_name)
+        except ValueError:
+            return False
+
         repo_file = self.repos_path / f"{repo_owner}_{repo_name}.json"
 
         if repo_file.exists():

--- a/packages/modal-infra/tests/test_snapshot_store.py
+++ b/packages/modal-infra/tests/test_snapshot_store.py
@@ -23,26 +23,30 @@ def make_snapshot(*, snapshot_id: str = "snap-123") -> Snapshot:
 class TestSnapshotStorePathValidation:
     """Reject path traversal in snapshot storage identifiers."""
 
-    @pytest.mark.parametrize("repo_owner", ["../evil", "acme/repo", "acme\\repo"])
-    def test_rejects_invalid_repo_owner(self, tmp_path, repo_owner: str):
+    @pytest.mark.parametrize("repo_owner", ["../evil", "..", ".", "acme/repo", "acme\\repo"])
+    def test_invalid_repo_owner_returns_none_for_reads(self, tmp_path, repo_owner: str):
         store = SnapshotStore(base_path=str(tmp_path))
 
-        with pytest.raises(ValueError, match="repo_owner"):
-            store.get_latest_snapshot(repo_owner, "repo")
+        assert store.get_latest_snapshot(repo_owner, "repo") is None
+        assert store.list_snapshots(repo_owner, "repo") == []
+        assert store.get_repository(repo_owner, "repo") is None
+        assert store.delete_repository(repo_owner, "repo") is False
 
-    @pytest.mark.parametrize("repo_name", ["../evil", "repo/name", "repo\\name"])
-    def test_rejects_invalid_repo_name(self, tmp_path, repo_name: str):
+    @pytest.mark.parametrize("repo_name", ["../evil", "..", ".", "repo/name", "repo\\name"])
+    def test_invalid_repo_name_returns_none_for_reads(self, tmp_path, repo_name: str):
         store = SnapshotStore(base_path=str(tmp_path))
 
-        with pytest.raises(ValueError, match="repo_name"):
-            store.get_latest_snapshot("acme", repo_name)
+        assert store.get_latest_snapshot("acme", repo_name) is None
+        assert store.list_snapshots("acme", repo_name) == []
+        assert store.get_repository("acme", repo_name) is None
+        assert store.delete_repository("acme", repo_name) is False
 
-    @pytest.mark.parametrize("snapshot_id", ["../evil", "snap/name", "snap\\name"])
-    def test_rejects_invalid_snapshot_id(self, tmp_path, snapshot_id: str):
+    @pytest.mark.parametrize("snapshot_id", ["../evil", "..", ".", "snap/name", "snap\\name"])
+    def test_invalid_snapshot_id_returns_none_for_reads(self, tmp_path, snapshot_id: str):
         store = SnapshotStore(base_path=str(tmp_path))
 
-        with pytest.raises(ValueError, match="snapshot_id"):
-            store.get_snapshot(snapshot_id, "acme", "repo")
+        assert store.get_snapshot(snapshot_id, "acme", "repo") is None
+        assert store.get_snapshot_metadata(snapshot_id, "acme", "repo") is None
 
     def test_rejects_invalid_snapshot_id_when_saving(self, tmp_path):
         store = SnapshotStore(base_path=str(tmp_path))
@@ -66,3 +70,13 @@ class TestSnapshotStorePathValidation:
         saved_snapshot = store.get_snapshot("snap_1.2-3", "acme", "repo")
         assert saved_snapshot is not None
         assert saved_snapshot.id == snapshot.id
+
+    def test_cleanup_expired_skips_invalid_snapshot_id_in_file_contents(self, tmp_path):
+        store = SnapshotStore(base_path=str(tmp_path))
+        history_dir = tmp_path / "snapshots" / "acme" / "repo" / "history"
+        history_dir.mkdir(parents=True)
+        invalid_snapshot = make_snapshot(snapshot_id="..").model_dump_json(indent=2)
+        (history_dir / "safe-file.json").write_text(invalid_snapshot)
+
+        assert store.cleanup_expired("acme", "repo", max_age_days=0) == 0
+        assert (history_dir / "safe-file.json").exists()


### PR DESCRIPTION
## Summary
- validate `repo_owner`, `repo_name`, and `snapshot_id` against a strict allowlist before using them in `SnapshotStore` filesystem paths
- apply the same validation to repository config file paths so traversal strings cannot escape the store root
- add focused `modal-infra` tests covering rejected traversal attempts and accepted safe identifiers

## Testing
- `uv run pytest tests/test_snapshot_store.py`
- `uv run ruff check src/registry/store.py tests/test_snapshot_store.py`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/548429108caa725cef7ffcafd95f90b9)*