### PR TITLE
feat: use full IANA timezone list in automations

### DIFF
--- a/packages/web/src/components/automations/automation-form.tsx
+++ b/packages/web/src/components/automations/automation-form.tsx
@@ -13,7 +13,11 @@ import { Textarea } from "@/components/ui/textarea";
 import { RepoIcon, BranchIcon, ModelIcon, ChevronDownIcon } from "@/components/ui/icons";
 import { CronPicker } from "./cron-picker";
 
-const ALL_TIMEZONES = Intl.supportedValuesOf('timeZone');
+const ALL_TIMEZONES = Intl.supportedValuesOf("timeZone");
+const ALL_TIMEZONE_OPTIONS = ALL_TIMEZONES.map((tz) => ({
+  value: tz,
+  label: tz.replace(/_/g, " "),
+}));
 
 export interface AutomationFormValues {
   name: string;
@@ -194,10 +198,8 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
         <Combobox
           value={scheduleTz}
           onChange={setScheduleTz}
-          items={ALL_TIMEZONES.map((tz) => ({
-            value: tz,
-            label: tz.replace(/_/g, " "),
-          }))}
+          items={ALL_TIMEZONE_OPTIONS}
+          maxDisplayed={20}
           searchable
           searchPlaceholder="Search timezones..."
           filterFn={(option, query) =>

--- a/packages/web/src/components/ui/combobox.tsx
+++ b/packages/web/src/components/ui/combobox.tsx
@@ -40,6 +40,7 @@ interface ComboboxProps<T = string> {
   prependContent?: (helpers: { select: (value: T) => void }) => ReactNode;
   disabled?: boolean;
   triggerClassName?: string;
+  maxDisplayed?: number;
 }
 
 export function Combobox<T = string>({
@@ -55,6 +56,7 @@ export function Combobox<T = string>({
   prependContent,
   disabled = false,
   triggerClassName = "",
+  maxDisplayed,
 }: ComboboxProps<T>) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -112,7 +114,38 @@ export function Combobox<T = string>({
     return items.filter((opt) => filterOption(opt, normalizedQuery));
   })();
 
-  const flatOptions = flattenOptions(filteredItems);
+  // Apply maxDisplayed cap to limit rendered DOM nodes
+  const { displayItems, hiddenCount } = (() => {
+    if (!maxDisplayed) return { displayItems: filteredItems, hiddenCount: 0 };
+
+    const allFiltered = flattenOptions(filteredItems);
+    if (allFiltered.length <= maxDisplayed) return { displayItems: filteredItems, hiddenCount: 0 };
+
+    const overflow = allFiltered.length - maxDisplayed;
+
+    if (isGrouped(filteredItems)) {
+      let remaining = maxDisplayed;
+      const truncated: ComboboxGroup<T>[] = [];
+      for (const group of filteredItems) {
+        if (remaining <= 0) break;
+        if (group.options.length <= remaining) {
+          truncated.push(group);
+          remaining -= group.options.length;
+        } else {
+          truncated.push({ ...group, options: group.options.slice(0, remaining) });
+          remaining = 0;
+        }
+      }
+      return { displayItems: truncated, hiddenCount: overflow };
+    }
+
+    return {
+      displayItems: (filteredItems as ComboboxOption<T>[]).slice(0, maxDisplayed),
+      hiddenCount: overflow,
+    };
+  })();
+
+  const flatOptions = flattenOptions(displayItems);
 
   const hasResults = flatOptions.length > 0;
 
@@ -263,9 +296,9 @@ export function Combobox<T = string>({
               <div className="px-3 py-2 text-sm text-muted-foreground">
                 No results match {query.trim()}
               </div>
-            ) : isGrouped(filteredItems) ? (
-              filteredItems.map((group, groupIdx) => {
-                const groupOffset = filteredItems
+            ) : isGrouped(displayItems) ? (
+              displayItems.map((group, groupIdx) => {
+                const groupOffset = displayItems
                   .slice(0, groupIdx)
                   .reduce((sum, g) => sum + g.options.length, 0);
                 return (
@@ -296,7 +329,7 @@ export function Combobox<T = string>({
                 );
               })
             ) : (
-              (filteredItems as ComboboxOption<T>[]).map((option, idx) => (
+              (displayItems as ComboboxOption<T>[]).map((option, idx) => (
                 <OptionButton
                   key={String(option.value)}
                   option={option}
@@ -308,6 +341,11 @@ export function Combobox<T = string>({
                   dataIndex={idx}
                 />
               ))
+            )}
+            {hiddenCount > 0 && (
+              <div className="px-3 py-2 text-xs text-muted-foreground border-t border-border-muted mt-1">
+                Type to search {hiddenCount} more...
+              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
Fixes #382

Replaces the hard-coded `COMMON_TIMEZONES` list with `Intl.supportedValuesOf('timeZone')` to expose the full set of valid IANA timezones in the automation form. The picker remains searchable for good UX.