### PR TITLE
feat: expand timezone selection to full IANA list

### DIFF
--- a/packages/web/src/components/automations/automation-form.tsx
+++ b/packages/web/src/components/automations/automation-form.tsx
@@ -13,7 +13,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { RepoIcon, BranchIcon, ModelIcon, ChevronDownIcon } from "@/components/ui/icons";
 import { CronPicker } from "./cron-picker";
 
-const COMMON_TIMEZONES = [
+const FALLBACK_TIMEZONES = [
   "UTC",
   "America/New_York",
   "America/Chicago",
@@ -27,6 +27,11 @@ const COMMON_TIMEZONES = [
   "Asia/Kolkata",
   "Australia/Sydney",
 ];
+
+const ALL_TIMEZONES =
+  typeof Intl.supportedValuesOf === "function"
+    ? ["UTC", ...Intl.supportedValuesOf("timeZone")]
+    : FALLBACK_TIMEZONES;
 
 export interface AutomationFormValues {
   name: string;
@@ -207,7 +212,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
         <Combobox
           value={scheduleTz}
           onChange={setScheduleTz}
-          items={COMMON_TIMEZONES.map((tz) => ({
+          items={ALL_TIMEZONES.map((tz) => ({
             value: tz,
             label: tz.replace(/_/g, " "),
           }))}


### PR DESCRIPTION
## Problem

The automations timezone picker only exposes a hard-coded shortlist of 12 timezones (`COMMON_TIMEZONES`), even though the backend already accepts any valid IANA timezone. Users whose timezone is not in the list cannot select it.

Closes #382

## Changes

Replaced the hard-coded `COMMON_TIMEZONES` with `Intl.supportedValuesOf("timeZone")`, which provides the complete set of IANA timezones supported by the browser runtime. A feature check (`typeof Intl.supportedValuesOf === "function"`) guards against older browsers, falling back to the original shortlist.

- UTC is prepended to always appear first (it is not included in the Intl API output)
- The existing searchable `Combobox` UI is preserved unchanged
- No backend changes needed — the control plane already validates any IANA timezone

## Files Changed

- `packages/web/src/components/automations/automation-form.tsx`