### PR TITLE
feat: add agent-browser to sandbox base image

### DIFF
--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -141,7 +141,7 @@ development environment.
 - Debian Linux with common dev tools
 - Node.js 22, Python 3.12, git, curl
 - Package managers: npm, pnpm, pip, uv
-- Playwright + headless Chrome (for visual verification)
+- agent-browser CLI + headless Chrome (for browser automation)
 - OpenCode (the coding agent)
 
 **Why Modal?** Modal sandboxes start near-instantly and support filesystem snapshots. This lets us

--- a/packages/modal-infra/README.md
+++ b/packages/modal-infra/README.md
@@ -37,7 +37,7 @@ Base image definition with:
 - Node.js 22, pnpm, Bun
 - Python 3.12 with uv
 - OpenCode CLI
-- Playwright + headless Chrome
+- agent-browser CLI + headless Chrome
 
 ### Sandbox (`src/sandbox/`)
 

--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -6,7 +6,7 @@ This image provides a complete development environment with:
 - Node.js 22 LTS, pnpm, Bun runtime
 - Python 3.12 with uv
 - OpenCode CLI pre-installed
-- Playwright with headless Chrome for visual verification
+- agent-browser CLI with headless Chrome for browser automation
 - Sandbox entrypoint and bridge code
 """
 
@@ -25,9 +25,12 @@ OPENCODE_VERSION = "latest"
 # code-server version to install (pinned for reproducible images)
 CODE_SERVER_VERSION = "4.109.5"
 
+# agent-browser version to install (pinned for reproducible images)
+AGENT_BROWSER_VERSION = "0.21.2"
+
 # Cache buster - change this to force Modal image rebuild
-# v43: sandbox_runtime package extraction (files moved from /app/sandbox to /app/sandbox_runtime)
-CACHE_BUSTER = "v43-sandbox-runtime-extraction"
+# v44: replace Playwright with agent-browser for browser automation
+CACHE_BUSTER = "v44-agent-browser"
 
 # Base image with all development tools
 base_image = (
@@ -42,7 +45,7 @@ base_image = (
         "openssh-client",
         "jq",
         "unzip",  # Required for Bun installation
-        # For Playwright
+        # Shared libraries required by headless Chromium
         "libnss3",
         "libnspr4",
         "libatk1.0-0",
@@ -93,7 +96,6 @@ base_image = (
         "uv",
         "httpx",
         "websockets",
-        "playwright",
         "pydantic>=2.0",  # Required for sandbox types
         "PyJWT[crypto]",  # For GitHub App token generation (includes cryptography)
     )
@@ -116,10 +118,11 @@ base_image = (
         "rm /tmp/code-server.deb",
         "code-server --version",
     )
-    # Install Playwright browsers (Chromium only to save space)
+    # Install agent-browser CLI and download Chromium
     .run_commands(
-        "playwright install chromium",
-        "playwright install-deps chromium",
+        f"npm install -g agent-browser@{AGENT_BROWSER_VERSION}",
+        "agent-browser install",
+        "agent-browser --version",
     )
     # Create working directories
     .run_commands(
@@ -135,7 +138,6 @@ base_image = (
             "NODE_ENV": "development",
             "PNPM_HOME": "/root/.local/share/pnpm",
             "PATH": "/root/.bun/bin:/root/.local/share/pnpm:/usr/local/bin:/usr/bin:/bin",
-            "PLAYWRIGHT_BROWSERS_PATH": "/root/.cache/ms-playwright",
             "PYTHONPATH": "/app",
             "SANDBOX_VERSION": CACHE_BUSTER,
             # NODE_PATH for globally installed modules (used by custom tools)


### PR DESCRIPTION
## Summary

Replaces #390 with a simpler approach.

- Replace Playwright with `agent-browser` for browser automation in sandboxes
- `agent-browser install` manages its own Chromium binary (Chrome for Testing), eliminating the need for Playwright as a browser downloader
- Remove `playwright` pip dependency (no application code imports it — it was only used to download Chromium)
- Remove `PLAYWRIGHT_BROWSERS_PATH` env var (no longer needed)
- Pin `agent-browser@0.21.2` for reproducible builds

### Why not keep Playwright?

Playwright was only used in this repo as a Chromium downloader (`playwright install chromium`). No Python or JS code imports it. `agent-browser` ships its own browser management (`agent-browser install`), so Playwright becomes redundant. Removing it eliminates a pip dependency and the brittle path-discovery logic from #390.

## Test plan

- [ ] `python -m compileall packages/modal-infra/src` — verify no syntax errors
- [ ] `modal deploy deploy.py` — image builds successfully with agent-browser + Chromium
- [ ] `agent-browser --version` works inside a sandbox
- [ ] `agent-browser navigate about:blank` works inside a sandbox (proves Chromium launches)