### PR TITLE
fix: normalize git branch names

### DIFF
--- a/packages/control-plane/src/source-control/branch-resolution.test.ts
+++ b/packages/control-plane/src/source-control/branch-resolution.test.ts
@@ -6,6 +6,10 @@ describe("sanitizeBranchName", () => {
     expect(sanitizeBranchName("feature/test")).toBe("feature/test");
   });
 
+  it("normalizes valid branch names to lowercase", () => {
+    expect(sanitizeBranchName(" Feature/Test ")).toBe("feature/test");
+  });
+
   it("rejects invalid or unsafe branch names", () => {
     expect(sanitizeBranchName("")).toBeNull();
     expect(sanitizeBranchName("HEAD")).toBeNull();
@@ -17,7 +21,7 @@ describe("sanitizeBranchName", () => {
 describe("resolveHeadBranchForPr", () => {
   it("prefers request branch when valid", () => {
     const result = resolveHeadBranchForPr({
-      requestedHeadBranch: "feature/requested",
+      requestedHeadBranch: "Feature/Requested",
       sessionBranchName: "feature/session",
       generatedBranchName: "open-inspect/session-1",
       baseBranch: "main",
@@ -30,7 +34,7 @@ describe("resolveHeadBranchForPr", () => {
   it("falls back to session branch when requested branch is invalid", () => {
     const result = resolveHeadBranchForPr({
       requestedHeadBranch: "feature invalid",
-      sessionBranchName: "feature/session",
+      sessionBranchName: "Feature/Session",
       generatedBranchName: "open-inspect/session-1",
       baseBranch: "main",
     });
@@ -41,8 +45,8 @@ describe("resolveHeadBranchForPr", () => {
 
   it("skips branches that match base and falls back to generated branch", () => {
     const result = resolveHeadBranchForPr({
-      requestedHeadBranch: "main",
-      sessionBranchName: " main ",
+      requestedHeadBranch: "Main",
+      sessionBranchName: " Main ",
       generatedBranchName: "open-inspect/session-1",
       baseBranch: "main",
     });

--- a/packages/control-plane/src/source-control/branch-resolution.ts
+++ b/packages/control-plane/src/source-control/branch-resolution.ts
@@ -40,7 +40,7 @@ export function sanitizeBranchName(name: string | null | undefined): string | nu
     return null;
   }
 
-  return trimmed;
+  return normalizeBranchName(trimmed);
 }
 
 /**

--- a/packages/shared/src/git.test.ts
+++ b/packages/shared/src/git.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractSessionIdFromBranch,
+  generateBranchName,
+  isInspectBranch,
+  normalizeBranchName,
+} from "./git";
+
+describe("normalizeBranchName", () => {
+  it("trims and lowercases branch names", () => {
+    expect(normalizeBranchName(" Feature/Test ")).toBe("feature/test");
+  });
+});
+
+describe("generateBranchName", () => {
+  it("generates lowercase open-inspect branches", () => {
+    expect(generateBranchName("Session-ABC")).toBe("open-inspect/session-abc");
+  });
+});
+
+describe("extractSessionIdFromBranch", () => {
+  it("extracts lowercase session IDs from inspect branches", () => {
+    expect(extractSessionIdFromBranch(" Open-Inspect/Session-ABC ")).toBe("session-abc");
+  });
+});
+
+describe("isInspectBranch", () => {
+  it("matches inspect branches case-insensitively", () => {
+    expect(isInspectBranch(" OPEN-INSPECT/Session-ABC ")).toBe(true);
+  });
+});

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -8,6 +8,13 @@
 export const BRANCH_PREFIX = "open-inspect";
 
 /**
+ * Normalize a git branch name for consistent Open-Inspect branch handling.
+ */
+export function normalizeBranchName(branchName: string): string {
+  return branchName.trim().toLowerCase();
+}
+
+/**
  * Generate a branch name for a session.
  *
  * @param sessionId - Session ID
@@ -16,7 +23,7 @@ export const BRANCH_PREFIX = "open-inspect";
  */
 export function generateBranchName(sessionId: string, _title?: string): string {
   // Use just session ID to keep it short and unique
-  return `${BRANCH_PREFIX}/${sessionId}`;
+  return normalizeBranchName(`${BRANCH_PREFIX}/${sessionId}`);
 }
 
 /**
@@ -27,15 +34,16 @@ export function generateBranchName(sessionId: string, _title?: string): string {
  */
 export function extractSessionIdFromBranch(branchName: string): string | null {
   const prefix = `${BRANCH_PREFIX}/`;
-  if (!branchName.startsWith(prefix)) {
+  const normalizedBranchName = normalizeBranchName(branchName);
+  if (!normalizedBranchName.startsWith(prefix)) {
     return null;
   }
-  return branchName.slice(prefix.length);
+  return normalizedBranchName.slice(prefix.length);
 }
 
 /**
  * Check if a branch name is an Open-Inspect branch.
  */
 export function isInspectBranch(branchName: string): boolean {
-  return branchName.startsWith(`${BRANCH_PREFIX}/`);
+  return normalizeBranchName(branchName).startsWith(`${BRANCH_PREFIX}/`);
 }


### PR DESCRIPTION
We had an issue with git branch names not always following best practices and issues with filesystem case insensitivity. This addresses those issues.