### PR TITLE
fix: add connecting timeout watchdog for sandboxes

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/decisions.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.test.ts
@@ -10,12 +10,14 @@ import {
   evaluateSpawnDecision,
   evaluateInactivityTimeout,
   evaluateHeartbeatHealth,
+  evaluateConnectingTimeout,
   evaluateWarmDecision,
   evaluateExecutionTimeout,
   DEFAULT_CIRCUIT_BREAKER_CONFIG,
   DEFAULT_SPAWN_CONFIG,
   DEFAULT_INACTIVITY_CONFIG,
   DEFAULT_HEARTBEAT_CONFIG,
+  DEFAULT_CONNECTING_TIMEOUT_CONFIG,
   DEFAULT_EXECUTION_TIMEOUT_MS,
   type CircuitBreakerState,
   type CircuitBreakerConfig,
@@ -24,6 +26,7 @@ import {
   type InactivityState,
   type InactivityConfig,
   type HeartbeatConfig,
+  type ConnectingTimeoutConfig,
   type WarmState,
   type ExecutionTimeoutConfig,
 } from "./decisions";
@@ -562,6 +565,72 @@ describe("evaluateHeartbeatHealth", () => {
 
   it("uses default config values correctly", () => {
     expect(DEFAULT_HEARTBEAT_CONFIG.timeoutMs).toBe(90000);
+  });
+});
+
+// ==================== Connecting Timeout Tests ====================
+
+describe("evaluateConnectingTimeout", () => {
+  const config: ConnectingTimeoutConfig = DEFAULT_CONNECTING_TIMEOUT_CONFIG;
+
+  it("returns not timed out for non-connecting status", () => {
+    const now = Date.now();
+    const result = evaluateConnectingTimeout("ready", now - 200_000, config, now);
+
+    expect(result.isTimedOut).toBe(false);
+    expect(result.elapsedMs).toBe(0);
+  });
+
+  it("returns not timed out when within timeout window", () => {
+    const now = Date.now();
+    const createdAt = now - 60_000; // 60s ago, well within 120s timeout
+
+    const result = evaluateConnectingTimeout("connecting", createdAt, config, now);
+
+    expect(result.isTimedOut).toBe(false);
+    expect(result.elapsedMs).toBe(60_000);
+  });
+
+  it("returns timed out when past timeout", () => {
+    const now = Date.now();
+    const createdAt = now - 130_000; // 130s ago, past 120s timeout
+
+    const result = evaluateConnectingTimeout("connecting", createdAt, config, now);
+
+    expect(result.isTimedOut).toBe(true);
+    expect(result.elapsedMs).toBe(130_000);
+  });
+
+  it("returns timed out at exact boundary (>=)", () => {
+    const now = Date.now();
+    const createdAt = now - config.timeoutMs; // Exactly at timeout
+
+    const result = evaluateConnectingTimeout("connecting", createdAt, config, now);
+
+    expect(result.isTimedOut).toBe(true);
+    expect(result.elapsedMs).toBe(config.timeoutMs);
+  });
+
+  it("ignores all non-connecting statuses", () => {
+    const now = Date.now();
+    const old = now - 999_999;
+
+    for (const status of [
+      "pending",
+      "spawning",
+      "ready",
+      "running",
+      "stopped",
+      "failed",
+      "stale",
+    ] as const) {
+      const result = evaluateConnectingTimeout(status, old, config, now);
+      expect(result.isTimedOut).toBe(false);
+    }
+  });
+
+  it("uses correct default config value", () => {
+    expect(DEFAULT_CONNECTING_TIMEOUT_CONFIG.timeoutMs).toBe(120_000);
   });
 });
 

--- a/packages/control-plane/src/sandbox/lifecycle/decisions.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.ts
@@ -425,6 +425,69 @@ export function evaluateHeartbeatHealth(
   return { isStale: false };
 }
 
+// ==================== Connecting Timeout ====================
+
+/**
+ * Configuration for the initial-connect watchdog.
+ */
+export interface ConnectingTimeoutConfig {
+  /** Maximum time in ms a sandbox can stay in "connecting" before being failed */
+  timeoutMs: number;
+}
+
+/**
+ * Default connecting timeout: 2 minutes.
+ * Boot sequence (git clone → setup.sh → start.sh → opencode → bridge connect) typically
+ * takes 30–90 seconds. Two minutes provides margin without leaving users waiting too long.
+ */
+export const DEFAULT_CONNECTING_TIMEOUT_CONFIG: ConnectingTimeoutConfig = {
+  timeoutMs: 120_000,
+};
+
+/**
+ * Result of connecting timeout evaluation.
+ */
+export interface ConnectingTimeoutResult {
+  /** Whether the sandbox has exceeded the connecting timeout */
+  isTimedOut: boolean;
+  /** Time elapsed since sandbox was created (ms) */
+  elapsedMs: number;
+}
+
+/**
+ * Evaluate whether a sandbox has been stuck in "connecting" too long.
+ *
+ * After a sandbox is spawned, it must establish a WebSocket connection to the
+ * control plane within the configured timeout. If the bridge never connects
+ * (crash, network failure, etc.), this function detects the timeout so the
+ * alarm handler can fail the sandbox.
+ *
+ * Pure function: no side effects. Safe to call for any status — returns
+ * `isTimedOut: false` for non-connecting sandboxes.
+ *
+ * @param status - Current sandbox status
+ * @param createdAt - Timestamp (ms) when the sandbox was spawned
+ * @param config - Connecting timeout configuration
+ * @param now - Current timestamp (ms)
+ * @returns Whether the sandbox has timed out and how long it's been connecting
+ */
+export function evaluateConnectingTimeout(
+  status: SandboxStatus,
+  createdAt: number,
+  config: ConnectingTimeoutConfig,
+  now: number
+): ConnectingTimeoutResult {
+  if (status !== "connecting") {
+    return { isTimedOut: false, elapsedMs: 0 };
+  }
+
+  const elapsedMs = now - createdAt;
+  return {
+    isTimedOut: elapsedMs >= config.timeoutMs,
+    elapsedMs,
+  };
+}
+
 // ==================== Warm Decision ====================
 
 /**

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -296,6 +296,32 @@ describe("SandboxLifecycleManager", () => {
       ).toBe(true);
     });
 
+    it("schedules connecting timeout alarm after spawn", async () => {
+      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const alarmScheduler = createMockAlarmScheduler();
+      const config = createTestConfig();
+
+      const manager = new SandboxLifecycleManager(
+        createMockProvider(),
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        alarmScheduler,
+        createMockIdGenerator(),
+        config
+      );
+
+      const before = Date.now();
+      await manager.spawnSandbox();
+      const after = Date.now();
+
+      expect(alarmScheduler.alarms.length).toBe(1);
+      const scheduledTime = alarmScheduler.alarms[0];
+      expect(scheduledTime).toBeGreaterThanOrEqual(before + config.connectingTimeout.timeoutMs);
+      expect(scheduledTime).toBeLessThanOrEqual(after + config.connectingTimeout.timeoutMs);
+    });
+
     it("passes user env vars to provider", async () => {
       const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
       const userEnvVars = { DATABASE_URL: "postgres://example" };
@@ -404,6 +430,35 @@ describe("SandboxLifecycleManager", () => {
 
       expect(provider.restoreFromSnapshot).toHaveBeenCalled();
       expect(provider.createSandbox).not.toHaveBeenCalled();
+    });
+
+    it("schedules connecting timeout alarm after restore", async () => {
+      const sandbox = createMockSandbox({
+        status: "stopped",
+        snapshot_image_id: "img-abc123",
+      });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const alarmScheduler = createMockAlarmScheduler();
+      const config = createTestConfig();
+
+      const manager = new SandboxLifecycleManager(
+        createMockProvider(),
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        alarmScheduler,
+        createMockIdGenerator(),
+        config
+      );
+
+      const before = Date.now();
+      await manager.spawnSandbox();
+      const after = Date.now();
+
+      expect(alarmScheduler.alarms.length).toBe(1);
+      const scheduledTime = alarmScheduler.alarms[0];
+      expect(scheduledTime).toBeGreaterThanOrEqual(before + config.connectingTimeout.timeoutMs);
+      expect(scheduledTime).toBeLessThanOrEqual(after + config.connectingTimeout.timeoutMs);
     });
 
     it("stores providerObjectId after successful restore for future snapshots", async () => {
@@ -944,6 +999,94 @@ describe("SandboxLifecycleManager", () => {
 
       await manager.handleAlarm();
       expect(storage.calls).toContain("updateSandboxStatus:stale");
+    });
+
+    it("detects connecting timeout and sets failed", async () => {
+      const now = Date.now();
+      const sandbox = createMockSandbox({
+        status: "connecting" as SandboxStatus,
+        created_at: now - 130_000, // 130s ago, past 120s timeout
+        last_heartbeat: null,
+      });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const broadcaster = createMockBroadcaster();
+      const provider = createMockProvider();
+
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        broadcaster,
+        createMockWebSocketManager(),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.handleAlarm();
+
+      expect(storage.calls).toContain("updateSandboxStatus:failed");
+      expect(storage.calls).toContain("clearSandboxCodeServer");
+      expect(broadcaster.messages.some((m) => (m as { status?: string }).status === "failed")).toBe(
+        true
+      );
+      expect(
+        broadcaster.messages.some((m) => (m as { type?: string }).type === "sandbox_error")
+      ).toBe(true);
+      // Should NOT trigger snapshot (nothing to snapshot)
+      expect(provider.takeSnapshot).not.toHaveBeenCalled();
+    });
+
+    it("does not timeout connecting sandbox within timeout window", async () => {
+      const now = Date.now();
+      const sandbox = createMockSandbox({
+        status: "connecting" as SandboxStatus,
+        created_at: now - 30_000, // 30s ago, well within 120s timeout
+        last_heartbeat: null,
+      });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const alarmScheduler = createMockAlarmScheduler();
+
+      const manager = new SandboxLifecycleManager(
+        createMockProvider(),
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(),
+        alarmScheduler,
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.handleAlarm();
+
+      expect(storage.calls).not.toContain("updateSandboxStatus:failed");
+      // Should schedule a follow-up alarm
+      expect(alarmScheduler.alarms.length).toBe(1);
+    });
+
+    it("calls onSandboxTerminating callback on connecting timeout", async () => {
+      const now = Date.now();
+      const sandbox = createMockSandbox({
+        status: "connecting" as SandboxStatus,
+        created_at: now - 130_000,
+        last_heartbeat: null,
+      });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const onSandboxTerminating = vi.fn().mockResolvedValue(undefined);
+
+      const manager = new SandboxLifecycleManager(
+        createMockProvider(),
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig(),
+        { onSandboxTerminating }
+      );
+
+      await manager.handleAlarm();
+
+      expect(onSandboxTerminating).toHaveBeenCalledOnce();
     });
   });
 

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -18,15 +18,18 @@ import {
   evaluateSpawnDecision,
   evaluateInactivityTimeout,
   evaluateHeartbeatHealth,
+  evaluateConnectingTimeout,
   evaluateWarmDecision,
   DEFAULT_CIRCUIT_BREAKER_CONFIG,
   DEFAULT_SPAWN_CONFIG,
   DEFAULT_INACTIVITY_CONFIG,
   DEFAULT_HEARTBEAT_CONFIG,
+  DEFAULT_CONNECTING_TIMEOUT_CONFIG,
   type CircuitBreakerConfig,
   type SpawnConfig,
   type InactivityConfig,
   type HeartbeatConfig,
+  type ConnectingTimeoutConfig,
 } from "./decisions";
 import { extractProviderAndModel } from "../../utils/models";
 import { createLogger, type Logger } from "../../logger";
@@ -134,6 +137,7 @@ export interface SandboxLifecycleConfig {
   spawn: SpawnConfig;
   inactivity: InactivityConfig;
   heartbeat: HeartbeatConfig;
+  connectingTimeout: ConnectingTimeoutConfig;
   controlPlaneUrl: string;
   /** Default model ID used when the session has no model override. */
   model: string;
@@ -149,6 +153,7 @@ export const DEFAULT_LIFECYCLE_CONFIG: Omit<SandboxLifecycleConfig, "controlPlan
   spawn: DEFAULT_SPAWN_CONFIG,
   inactivity: DEFAULT_INACTIVITY_CONFIG,
   heartbeat: DEFAULT_HEARTBEAT_CONFIG,
+  connectingTimeout: DEFAULT_CONNECTING_TIMEOUT_CONFIG,
 };
 
 /** Child (agent-spawned) sessions get a shorter sandbox timeout. */
@@ -403,6 +408,11 @@ export class SandboxLifecycleManager {
       this.storage.updateSandboxStatus("connecting");
       this.broadcaster.broadcast({ type: "sandbox_status", status: "connecting" });
 
+      // Schedule connecting timeout watchdog — if the bridge doesn't connect
+      // within the allowed window, handleAlarm() will fail the sandbox.
+      // This alarm is naturally replaced by the inactivity alarm on successful connect.
+      await this.alarmScheduler.scheduleAlarm(Date.now() + this.config.connectingTimeout.timeoutMs);
+
       // Reset circuit breaker on successful spawn initiation
       this.storage.resetCircuitBreaker();
     } catch (error) {
@@ -525,6 +535,12 @@ export class SandboxLifecycleManager {
 
         this.storage.updateSandboxStatus("connecting");
         this.broadcaster.broadcast({ type: "sandbox_status", status: "connecting" });
+
+        // Schedule connecting timeout watchdog (same as doSpawn)
+        await this.alarmScheduler.scheduleAlarm(
+          Date.now() + this.config.connectingTimeout.timeoutMs
+        );
+
         this.broadcaster.broadcast({
           type: "sandbox_restored",
           message: "Session restored from snapshot",
@@ -662,7 +678,33 @@ export class SandboxLifecycleManager {
       return;
     }
 
-    // Check heartbeat health first
+    // Check connecting timeout — sandbox failed to connect within allowed time
+    const connectingResult = evaluateConnectingTimeout(
+      sandbox.status as SandboxStatus,
+      sandbox.created_at,
+      this.config.connectingTimeout,
+      now
+    );
+
+    if (connectingResult.isTimedOut) {
+      this.log.warn("Connecting timeout", {
+        event: "sandbox.connecting_timeout",
+        elapsed_ms: connectingResult.elapsedMs,
+        timeout_ms: this.config.connectingTimeout.timeoutMs,
+      });
+      await this.callbacks.onSandboxTerminating?.();
+      this.storage.updateSandboxStatus("failed");
+      this.storage.clearSandboxCodeServer();
+      this.broadcaster.broadcast({ type: "sandbox_status", status: "failed" });
+      this.broadcaster.broadcast({
+        type: "sandbox_error",
+        error:
+          "Sandbox failed to connect within the allowed time. It will be retried on your next message.",
+      });
+      return;
+    }
+
+    // Check heartbeat health
     const heartbeatHealth = evaluateHeartbeatHealth(
       sandbox.last_heartbeat,
       this.config.heartbeat,


### PR DESCRIPTION
## Summary

Fixes #396 — a sandbox that fails before its bridge WebSocket connects to the control plane stays stuck in `"connecting"` forever.

**Root cause**: Three gaps conspired to create an infinite loop:
1. No alarm was scheduled after `doSpawn()` / `restoreFromSnapshot()` set status to `"connecting"`
2. `evaluateHeartbeatHealth()` treated `lastHeartbeat == null` as "not stale" (sandbox may still be starting)
3. `evaluateInactivityTimeout()` only checked `ready`/`running` — `"connecting"` fell through to "reschedule in 30s" forever

**Fix**: Add a 2-minute initial-connect watchdog:
- **`evaluateConnectingTimeout()`** — new pure decision function in `decisions.ts` that detects when a sandbox has been in `"connecting"` longer than the configured timeout (default: 120s)
- **Alarm scheduling** — both `doSpawn()` and `restoreFromSnapshot()` now schedule an alarm at `now + connectingTimeoutMs` after setting status to `"connecting"`. This alarm is naturally replaced by the inactivity alarm when the bridge connects successfully.
- **`handleAlarm()` check** — evaluates connecting timeout before heartbeat/inactivity checks. On timeout: sets status to `"failed"`, broadcasts `sandbox_error` with a user-friendly message, calls `onSandboxTerminating` callback. No snapshot is triggered (sandbox never connected, nothing to preserve).

**Why `"failed"` and not `"stale"`**: The sandbox never connected — there's no running process to snapshot. `"failed"` allows `evaluateSpawnDecision()` to auto-retry or restore from snapshot on the next user interaction.

## Test plan

- [x] `evaluateConnectingTimeout` — 6 unit tests: non-connecting status, within window, past timeout, exact boundary, all non-connecting statuses, default config value
- [x] `handleAlarm` connecting timeout — 3 tests: detects timeout + sets failed, within-window sandbox is not failed, `onSandboxTerminating` callback fires
- [x] Alarm scheduling — 2 tests: spawn path schedules alarm, restore path schedules alarm
- [x] All 812 control-plane unit tests pass
- [x] Pre-existing type errors are unrelated (automation/linear integration WIP)