### PR TITLE
Fix modal deployment + update docs on ruff

### DIFF
--- a/.openinspect/setup.sh
+++ b/.openinspect/setup.sh
@@ -108,7 +108,10 @@ if [ -d "$MODAL_DIR" ]; then
   if command -v python3 &>/dev/null; then
     setup_python
   else
-    info "python3 not found — skipping optional modal-infra Python setup."
+    warn "python3 not found — skipping modal-infra Python setup."
+    warn "The pre-commit hook runs ruff from packages/modal-infra/.venv/bin/ruff."
+    warn "If you commit Python files without the venv, the hook will fail."
+    warn "Install Python 3.12+ and re-run this script to fix it."
   fi
 fi
 

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -24,10 +24,13 @@ Required:
 - npm
 - Git
 
-Optional (needed for `modal-infra` development):
+Required if you will commit Python files (pre-commit hooks run `ruff` from the venv):
 
 - Python `3.12+`
 - `uv` (recommended) or `pip`
+
+Optional (needed to run or deploy Modal sandboxes):
+
 - Modal CLI (`modal`)
 
 Optional (needed for full deployment):

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
       "prettier --write"
     ],
     "packages/modal-infra/**/*.py": [
-      "ruff check --fix",
-      "ruff format"
+      "packages/modal-infra/.venv/bin/ruff check --fix",
+      "packages/modal-infra/.venv/bin/ruff format"
     ]
   }
 }

--- a/packages/modal-infra/deploy.py
+++ b/packages/modal-infra/deploy.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 # Add src to path so imports work
 sys.path.insert(0, str(Path(__file__).parent / "src"))
+# Add sandbox_runtime so app.py can import it (used to locate the runtime bundle)
+sys.path.insert(0, str(Path(__file__).parent.parent / "sandbox-runtime" / "src"))
 
 # Import the app
 # Import modules to register functions with the app


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Python 3.12+ is required for pre-commit hooks when committing Python files.
  * Reorganized setup prerequisites to distinguish required vs. optional dependencies.
  * Clarified Modal CLI is optional for running/deploying sandboxes.

* **Chores**
  * Enhanced setup validation messages with explicit guidance for resolving pre-commit failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->