### PR TITLE
feat(web): support Google OAuth as alternative auth provider

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -205,6 +205,37 @@ You should now have:
 
 ---
 
+## Step 3b: Google OAuth (Alternative to GitHub OAuth)
+
+If you prefer Google authentication instead of GitHub OAuth, set `AUTH_PROVIDER=google` in your web
+app environment. This is useful for organizations that use Google Workspace and don't need GitHub
+user OAuth for PR creation (the GitHub App token handles SCM operations instead).
+
+1. Go to [Google Cloud Console → Credentials](https://console.cloud.google.com/apis/credentials)
+2. Click **"Create Credentials"** → **"OAuth client ID"**
+3. Select **"Web application"**
+4. Add your web app URL to **Authorized redirect URIs**:
+   - `{your-web-app-url}/api/auth/callback/google`
+5. Note the **Client ID** and **Client Secret**
+
+Add to your `terraform.tfvars`:
+
+```hcl
+auth_provider           = "google"
+google_client_id        = "your-client-id.apps.googleusercontent.com"
+google_client_secret    = "GOCSPX-your-secret"
+google_workspace_domain = "example.com"  # optional: restrict to your Workspace domain
+```
+
+When using Google auth:
+
+- `ALLOWED_USERS` accepts **email addresses** (not GitHub usernames)
+- `ALLOWED_EMAIL_DOMAINS` works the same way
+- PR creation uses the **GitHub App token** (not user OAuth)
+- Leave both allowlists empty to allow all authenticated users
+
+---
+
 ## Step 4: Create Slack App (Optional)
 
 Skip this step if you don't need Slack integration.

--- a/packages/web/.env.example
+++ b/packages/web/.env.example
@@ -1,6 +1,17 @@
-# GitHub OAuth (create at https://github.com/settings/developers)
+# Auth Provider: "github" (default) or "google"
+AUTH_PROVIDER=github
+
+# GitHub OAuth (required when AUTH_PROVIDER=github)
+# Create at https://github.com/settings/developers
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
+
+# Google OAuth (required when AUTH_PROVIDER=google)
+# Create at https://console.cloud.google.com/apis/credentials
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+# Optional: restrict sign-in to a Google Workspace domain (e.g., "example.com")
+GOOGLE_WORKSPACE_DOMAIN=
 
 # NextAuth (generate with: openssl rand -base64 32)
 NEXTAUTH_URL=http://localhost:3000
@@ -14,6 +25,7 @@ NEXT_PUBLIC_WS_URL=wss://open-inspect-control-plane.YOUR-ACCOUNT.workers.dev
 # Generate with: openssl rand -base64 32
 INTERNAL_CALLBACK_SECRET=
 
-# Access Control (comma-separated, leave empty to allow all GitHub users)
+# Access Control (comma-separated, leave empty to allow all users)
+# ALLOWED_USERS accepts GitHub usernames (AUTH_PROVIDER=github) or email addresses (AUTH_PROVIDER=google)
 ALLOWED_EMAIL_DOMAINS=
 ALLOWED_USERS=

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -10,7 +10,6 @@ import { useSidebar } from "@/hooks/use-sidebar";
 import { useIsMobile } from "@/hooks/use-media-query";
 import { useGlobalShortcuts } from "@/hooks/use-global-shortcuts";
 import { SIDEBAR_SESSIONS_KEY, type SessionListResponse } from "@/lib/session-list";
-import { GitHubIcon } from "@/components/ui/icons";
 
 interface SidebarContextValue {
   isOpen: boolean;
@@ -93,11 +92,10 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
           Background coding agent for your team. Ship faster with AI-powered code changes.
         </p>
         <button
-          onClick={() => signIn("github")}
+          onClick={() => signIn()}
           className="flex items-center gap-2 bg-primary text-primary-foreground px-6 py-3 font-medium hover:opacity-90 transition"
         >
-          <GitHubIcon className="w-5 h-5" />
-          Sign in with GitHub
+          Sign in
         </button>
       </div>
     );

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -92,7 +92,7 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
           Background coding agent for your team. Ship faster with AI-powered code changes.
         </p>
         <button
-          onClick={() => signIn()}
+          onClick={() => signIn(undefined, { callbackUrl: "/" })}
           className="flex items-center gap-2 bg-primary text-primary-foreground px-6 py-3 font-medium hover:opacity-90 transition"
         >
           Sign in

--- a/packages/web/src/lib/access-control.test.ts
+++ b/packages/web/src/lib/access-control.test.ts
@@ -64,6 +64,22 @@ describe("checkAccessAllowed", () => {
     });
   });
 
+  describe("when allowedUsers contains email addresses (Google auth)", () => {
+    const config = { allowedDomains: [], allowedUsers: ["alice@company.com"] };
+
+    it("allows users with matching email", () => {
+      expect(checkAccessAllowed(config, { email: "alice@company.com" })).toBe(true);
+    });
+
+    it("allows users with different case email", () => {
+      expect(checkAccessAllowed(config, { email: "Alice@Company.COM" })).toBe(true);
+    });
+
+    it("denies users with non-matching email", () => {
+      expect(checkAccessAllowed(config, { email: "bob@company.com" })).toBe(false);
+    });
+  });
+
   describe("when allowedDomains is set", () => {
     const config = { allowedDomains: ["company.com"], allowedUsers: [] };
 

--- a/packages/web/src/lib/access-control.ts
+++ b/packages/web/src/lib/access-control.ts
@@ -25,6 +25,7 @@ export function parseAllowlist(value: string | undefined): string[] {
  * Returns true if:
  * - Both allowlists are empty (no restrictions)
  * - User's GitHub username is in allowedUsers
+ * - User's email address is in allowedUsers (for Google auth)
  * - User's email domain is in allowedDomains
  *
  * Logic is OR-based: matching either list grants access.
@@ -41,8 +42,11 @@ export function checkAccessAllowed(
     return true;
   }
 
-  // Check explicit user allowlist (GitHub username)
+  // Check explicit user allowlist (GitHub username or email address)
   if (githubUsername && allowedUsers.includes(githubUsername.toLowerCase())) {
+    return true;
+  }
+  if (email && allowedUsers.includes(email.toLowerCase())) {
     return true;
   }
 

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -76,10 +76,9 @@ export const authOptions: NextAuthOptions = {
             return false;
           }
         }
-        return true;
       }
 
-      // GitHub access control
+      // Access control (applies to both providers)
       const config = {
         allowedDomains: parseAllowlist(process.env.ALLOWED_EMAIL_DOMAINS),
         allowedUsers: parseAllowlist(process.env.ALLOWED_USERS),
@@ -87,7 +86,7 @@ export const authOptions: NextAuthOptions = {
 
       const githubProfile = profile as { login?: string };
       return checkAccessAllowed(config, {
-        githubUsername: githubProfile.login,
+        githubUsername: AUTH_PROVIDER === "github" ? githubProfile.login : undefined,
         email: user.email ?? undefined,
       });
     },

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -92,9 +92,14 @@ export const authOptions: NextAuthOptions = {
     },
     async jwt({ token, account, profile }) {
       if (account) {
-        token.accessToken = account.access_token;
-        token.refreshToken = account.refresh_token as string | undefined;
-        token.accessTokenExpiresAt = account.expires_at ? account.expires_at * 1000 : undefined;
+        // Only store OAuth tokens for GitHub — they are used as SCM credentials
+        // for PR creation. Google tokens are not SCM tokens and should not be
+        // passed downstream as scmToken.
+        if (AUTH_PROVIDER === "github") {
+          token.accessToken = account.access_token;
+          token.refreshToken = account.refresh_token as string | undefined;
+          token.accessTokenExpiresAt = account.expires_at ? account.expires_at * 1000 : undefined;
+        }
       }
       if (profile) {
         if (AUTH_PROVIDER === "google") {

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -1,13 +1,21 @@
 import type { NextAuthOptions } from "next-auth";
+import type { Provider } from "next-auth/providers/index";
 import GitHubProvider from "next-auth/providers/github";
+import GoogleProvider from "next-auth/providers/google";
 import { checkAccessAllowed, parseAllowlist } from "./access-control";
 
-// Extend NextAuth types to include GitHub-specific user info
+/**
+ * Auth provider selection.
+ * Set AUTH_PROVIDER=google to use Google OAuth, otherwise GitHub is used.
+ */
+const AUTH_PROVIDER = process.env.AUTH_PROVIDER || "github";
+
+// Extend NextAuth types to include provider-specific user info
 declare module "next-auth" {
   interface Session {
     user: {
-      id?: string; // GitHub user ID
-      login?: string; // GitHub username
+      id?: string;
+      login?: string; // GitHub username (undefined for Google)
       name?: string | null;
       email?: string | null;
       image?: string | null;
@@ -20,65 +28,97 @@ declare module "next-auth/jwt" {
     accessToken?: string;
     refreshToken?: string;
     accessTokenExpiresAt?: number; // Unix timestamp in milliseconds
-    githubUserId?: string;
-    githubLogin?: string;
+    userId?: string;
+    userLogin?: string;
   }
+}
+
+function buildProvider(): Provider {
+  if (AUTH_PROVIDER === "google") {
+    const workspaceDomain = process.env.GOOGLE_WORKSPACE_DOMAIN;
+    return GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      authorization: {
+        params: {
+          // Restrict to a Google Workspace domain if configured
+          ...(workspaceDomain && { hd: workspaceDomain }),
+          prompt: "consent",
+          access_type: "offline",
+          response_type: "code",
+        },
+      },
+    });
+  }
+
+  return GitHubProvider({
+    clientId: process.env.GITHUB_CLIENT_ID!,
+    clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+    authorization: {
+      params: {
+        scope: "read:user user:email repo",
+      },
+    },
+  });
 }
 
 export const authOptions: NextAuthOptions = {
   debug: process.env.NODE_ENV === "development" || process.env.NEXTAUTH_DEBUG === "true",
-  providers: [
-    GitHubProvider({
-      clientId: process.env.GITHUB_CLIENT_ID!,
-      clientSecret: process.env.GITHUB_CLIENT_SECRET!,
-      authorization: {
-        params: {
-          scope: "read:user user:email repo",
-        },
-      },
-    }),
-  ],
+  providers: [buildProvider()],
   callbacks: {
     async signIn({ profile, user }) {
+      // Google Workspace domain check (server-side enforcement)
+      if (AUTH_PROVIDER === "google") {
+        const workspaceDomain = process.env.GOOGLE_WORKSPACE_DOMAIN;
+        if (workspaceDomain && user.email) {
+          const emailDomain = user.email.split("@")[1];
+          if (emailDomain !== workspaceDomain) {
+            return false;
+          }
+        }
+        return true;
+      }
+
+      // GitHub access control
       const config = {
         allowedDomains: parseAllowlist(process.env.ALLOWED_EMAIL_DOMAINS),
         allowedUsers: parseAllowlist(process.env.ALLOWED_USERS),
       };
 
       const githubProfile = profile as { login?: string };
-      const isAllowed = checkAccessAllowed(config, {
+      return checkAccessAllowed(config, {
         githubUsername: githubProfile.login,
         email: user.email ?? undefined,
       });
-
-      if (!isAllowed) {
-        return false;
-      }
-      return true;
     },
     async jwt({ token, account, profile }) {
       if (account) {
         token.accessToken = account.access_token;
         token.refreshToken = account.refresh_token as string | undefined;
-        // expires_at is in seconds, convert to milliseconds (only set if provided)
         token.accessTokenExpiresAt = account.expires_at ? account.expires_at * 1000 : undefined;
       }
       if (profile) {
-        // GitHub profile includes id (numeric) and login (username)
-        const githubProfile = profile as { id?: number; login?: string };
-        if (githubProfile.id) {
-          token.githubUserId = githubProfile.id.toString();
-        }
-        if (githubProfile.login) {
-          token.githubLogin = githubProfile.login;
+        if (AUTH_PROVIDER === "google") {
+          const googleProfile = profile as { sub?: string };
+          if (googleProfile.sub) {
+            token.userId = googleProfile.sub;
+          }
+        } else {
+          const githubProfile = profile as { id?: number; login?: string };
+          if (githubProfile.id) {
+            token.userId = githubProfile.id.toString();
+          }
+          if (githubProfile.login) {
+            token.userLogin = githubProfile.login;
+          }
         }
       }
       return token;
     },
     async session({ session, token }) {
       if (session.user) {
-        session.user.id = token.githubUserId;
-        session.user.login = token.githubLogin;
+        session.user.id = token.userId;
+        session.user.login = token.userLogin;
       }
       return session;
     },


### PR DESCRIPTION
## Why
This is particularly useful for two cases:

- Your company uses Gitlab or another SCM via the recently added support.
- You want to extend usage to users who might not have a Github account (eg. Product Managers, Designers etc) like in the original Inspect design.

## Summary

- Adds `AUTH_PROVIDER` env var to select between `github` (default) and `google` OAuth
- When set to `google`, uses Google OAuth with optional Workspace domain restriction via `GOOGLE_WORKSPACE_DOMAIN`
- `ALLOWED_USERS` now accepts email addresses (for Google auth) in addition to GitHub usernames
- No changes needed for PR creation — when the user has no SCM OAuth token (Google auth case), the existing fallback to the GitHub App token handles it

## Changes

- `auth.ts` — `buildProvider()` selects GitHub or Google based on `AUTH_PROVIDER`. Callbacks handle both provider profile shapes. JWT stores generic `userId`/`userLogin` instead of `githubUserId`/`githubLogin`.
- `access-control.ts` — `checkAccessAllowed` now also checks if `email` is in `allowedUsers` (OR logic with existing GitHub username check)
- `access-control.test.ts` — added tests for email-in-allowedUsers case
- `.env.example` — documented all auth-related env vars for both providers

## Configuration

**GitHub (default, no changes needed):**
```env
AUTH_PROVIDER=github
GITHUB_CLIENT_ID=...
GITHUB_CLIENT_SECRET=...
```

**Google:**
```env
AUTH_PROVIDER=google
GOOGLE_CLIENT_ID=...
GOOGLE_CLIENT_SECRET=...
GOOGLE_WORKSPACE_DOMAIN=example.com  # optional, restricts to Workspace domain
```

## Test plan

- [ ] Default config (no AUTH_PROVIDER set) — GitHub sign-in works as before
- [ ] AUTH_PROVIDER=github — same behavior
- [ ] AUTH_PROVIDER=google — Google sign-in page shown, login works
- [ ] AUTH_PROVIDER=google + GOOGLE_WORKSPACE_DOMAIN — non-domain accounts rejected
- [ ] ALLOWED_USERS with email addresses — only listed emails can sign in (Google)
- [ ] ALLOWED_EMAIL_DOMAINS — domain restriction works for both providers
- [ ] PR creation with Google auth — falls back to GitHub App token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sign in now supports GitHub or Google OAuth; UI shows a generic "Sign in" CTA.

* **Configuration Updates**
  * Added AUTH_PROVIDER (github|google), GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, and optional GOOGLE_WORKSPACE_DOMAIN.
  * Access control interprets allowlists as GitHub usernames for GitHub or email addresses for Google.

* **Tests**
  * Added tests for email-based allowlist behavior.

* **Documentation**
  * Added Google OAuth setup and updated access-control guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->