### PR TITLE
feat(modal): write extra tunnel URLs to /workspace/.tunnel-urls inside sandbox

### DIFF
--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -199,6 +199,25 @@ class SandboxManager:
         ttyd_url = resolved.pop(TTYD_PROXY_PORT, None)
         extra_urls = resolved if resolved else None
 
+        # Write tunnel URLs into the sandbox so the coding agent can discover them
+        if extra_urls:
+            lines = [f"{port} {url}" for port, url in sorted(extra_urls.items())]
+            content = "\n".join(lines) + "\n"
+            try:
+                proc = await sandbox.exec.aio(
+                    "bash",
+                    "-c",
+                    f"cat > /workspace/.tunnel-urls << 'EOF'\n{content}EOF",
+                )
+                await proc.wait.aio()
+                log.info(
+                    "tunnel.urls_written",
+                    sandbox_id=sandbox_id,
+                    ports=list(extra_urls.keys()),
+                )
+            except Exception as e:
+                log.warn("tunnel.urls_write_failed", sandbox_id=sandbox_id, exc=e)
+
         return code_server_url, ttyd_url, extra_urls
 
     @staticmethod

--- a/packages/modal-infra/tests/test_tunnel_ports.py
+++ b/packages/modal-infra/tests/test_tunnel_ports.py
@@ -210,6 +210,31 @@ class TestResolveAndSetupTunnels:
         # Should still return the URLs despite the write failure
         assert extra == {3000: "https://tunnel-3000.example.com"}
 
+    @pytest.mark.asyncio
+    async def test_tunnel_file_wait_failure_does_not_raise(self):
+        """If proc.wait raises after exec succeeds, it should log a warning but not raise."""
+        tunnel_urls = {3000: "https://tunnel-3000.example.com"}
+
+        proc = AsyncMock()
+        proc.wait.aio = AsyncMock(side_effect=Exception("wait failed"))
+        sandbox = MagicMock()
+        sandbox.exec = MagicMock()
+        sandbox.exec.aio = AsyncMock(return_value=proc)
+
+        with patch.object(
+            SandboxManager,
+            "_resolve_tunnels",
+            new_callable=AsyncMock,
+            return_value=tunnel_urls,
+        ):
+            _cs_url, _ttyd_url, extra = await SandboxManager._resolve_and_setup_tunnels(
+                sandbox, "sb-1", False, False, [3000]
+            )
+
+        # Should still return the URLs despite the wait failure
+        assert extra == {3000: "https://tunnel-3000.example.com"}
+        sandbox.exec.aio.assert_called_once()
+
 
 class TestCollectExposedPorts:
     """SandboxManager._collect_exposed_ports tests."""

--- a/packages/modal-infra/tests/test_tunnel_ports.py
+++ b/packages/modal-infra/tests/test_tunnel_ports.py
@@ -93,7 +93,10 @@ class TestResolveAndSetupTunnels:
     async def test_resolves_extra_ports(self):
         tunnel_urls = {3000: "https://tunnel-3000.example.com"}
 
+        proc = AsyncMock()
         sandbox = MagicMock()
+        sandbox.exec = MagicMock()
+        sandbox.exec.aio = AsyncMock(return_value=proc)
         with patch.object(
             SandboxManager,
             "_resolve_tunnels",
@@ -115,7 +118,10 @@ class TestResolveAndSetupTunnels:
             3000: "https://tunnel-3000.example.com",
         }
 
+        proc = AsyncMock()
         sandbox = MagicMock()
+        sandbox.exec = MagicMock()
+        sandbox.exec.aio = AsyncMock(return_value=proc)
 
         with patch.object(
             SandboxManager,
@@ -129,6 +135,79 @@ class TestResolveAndSetupTunnels:
 
         assert cs_url == "https://cs.example.com"
         assert ttyd_url is None
+        assert extra == {3000: "https://tunnel-3000.example.com"}
+
+    @pytest.mark.asyncio
+    async def test_writes_tunnel_urls_to_sandbox_filesystem(self):
+        """Tunnel URLs should be written to /workspace/.tunnel-urls inside the sandbox."""
+        tunnel_urls = {
+            3000: "https://tunnel-3000.example.com",
+            3001: "https://tunnel-3001.example.com",
+        }
+
+        proc = AsyncMock()
+        sandbox = MagicMock()
+        sandbox.exec = MagicMock()
+        sandbox.exec.aio = AsyncMock(return_value=proc)
+
+        with patch.object(
+            SandboxManager,
+            "_resolve_tunnels",
+            new_callable=AsyncMock,
+            return_value=tunnel_urls,
+        ):
+            await SandboxManager._resolve_and_setup_tunnels(
+                sandbox, "sb-1", False, False, [3000, 3001]
+            )
+
+        sandbox.exec.aio.assert_called_once()
+        args = sandbox.exec.aio.call_args
+        cmd = args[0][2]  # the bash -c argument
+        assert "3000 https://tunnel-3000.example.com" in cmd
+        assert "3001 https://tunnel-3001.example.com" in cmd
+        assert "/workspace/.tunnel-urls" in cmd
+        proc.wait.aio.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_does_not_write_file_when_no_extra_urls(self):
+        """No file should be written when there are no extra tunnel URLs."""
+        sandbox = MagicMock()
+        sandbox.exec = MagicMock()
+        sandbox.exec.aio = AsyncMock()
+
+        with patch.object(
+            SandboxManager,
+            "_resolve_tunnels",
+            new_callable=AsyncMock,
+            return_value={},
+        ):
+            _, _, extra = await SandboxManager._resolve_and_setup_tunnels(
+                sandbox, "sb-1", False, False, [3000]
+            )
+
+        assert extra is None
+        sandbox.exec.aio.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_tunnel_file_write_failure_does_not_raise(self):
+        """If writing the tunnel file fails, it should log a warning but not raise."""
+        tunnel_urls = {3000: "https://tunnel-3000.example.com"}
+
+        sandbox = MagicMock()
+        sandbox.exec = MagicMock()
+        sandbox.exec.aio = AsyncMock(side_effect=Exception("exec failed"))
+
+        with patch.object(
+            SandboxManager,
+            "_resolve_tunnels",
+            new_callable=AsyncMock,
+            return_value=tunnel_urls,
+        ):
+            _cs_url, _ttyd_url, extra = await SandboxManager._resolve_and_setup_tunnels(
+                sandbox, "sb-1", False, False, [3000]
+            )
+
+        # Should still return the URLs despite the write failure
         assert extra == {3000: "https://tunnel-3000.example.com"}
 
 

--- a/packages/modal-infra/tests/test_tunnel_ports.py
+++ b/packages/modal-infra/tests/test_tunnel_ports.py
@@ -197,11 +197,14 @@ class TestResolveAndSetupTunnels:
         sandbox.exec = MagicMock()
         sandbox.exec.aio = AsyncMock(side_effect=Exception("exec failed"))
 
-        with patch.object(
-            SandboxManager,
-            "_resolve_tunnels",
-            new_callable=AsyncMock,
-            return_value=tunnel_urls,
+        with (
+            patch.object(
+                SandboxManager,
+                "_resolve_tunnels",
+                new_callable=AsyncMock,
+                return_value=tunnel_urls,
+            ),
+            patch("src.sandbox.manager.log") as mock_log,
         ):
             _cs_url, _ttyd_url, extra = await SandboxManager._resolve_and_setup_tunnels(
                 sandbox, "sb-1", False, False, [3000]
@@ -209,6 +212,8 @@ class TestResolveAndSetupTunnels:
 
         # Should still return the URLs despite the write failure
         assert extra == {3000: "https://tunnel-3000.example.com"}
+        mock_log.warn.assert_called_once()
+        assert mock_log.warn.call_args[0][0] == "tunnel.urls_write_failed"
 
     @pytest.mark.asyncio
     async def test_tunnel_file_wait_failure_does_not_raise(self):
@@ -221,11 +226,14 @@ class TestResolveAndSetupTunnels:
         sandbox.exec = MagicMock()
         sandbox.exec.aio = AsyncMock(return_value=proc)
 
-        with patch.object(
-            SandboxManager,
-            "_resolve_tunnels",
-            new_callable=AsyncMock,
-            return_value=tunnel_urls,
+        with (
+            patch.object(
+                SandboxManager,
+                "_resolve_tunnels",
+                new_callable=AsyncMock,
+                return_value=tunnel_urls,
+            ),
+            patch("src.sandbox.manager.log") as mock_log,
         ):
             _cs_url, _ttyd_url, extra = await SandboxManager._resolve_and_setup_tunnels(
                 sandbox, "sb-1", False, False, [3000]
@@ -234,6 +242,8 @@ class TestResolveAndSetupTunnels:
         # Should still return the URLs despite the wait failure
         assert extra == {3000: "https://tunnel-3000.example.com"}
         sandbox.exec.aio.assert_called_once()
+        mock_log.warn.assert_called_once()
+        assert mock_log.warn.call_args[0][0] == "tunnel.urls_write_failed"
 
 
 class TestCollectExposedPorts:


### PR DESCRIPTION
## Summary

When extra tunnel ports are configured in Sandbox Settings (e.g. dev server ports
3000, 3001), Modal resolves the tunnel URLs and reports them to the control plane
and web UI. However, the coding agent running inside the sandbox has no way to
discover these URLs — it only sees `localhost`.

This writes the resolved tunnel URLs to `/workspace/.tunnel-urls` inside the sandbox
after `_resolve_and_setup_tunnels` completes, so the agent can read the file and
share public preview URLs with the user.

## Changes

- **`packages/modal-infra/src/sandbox/manager.py`** — after resolving extra tunnel
  URLs in `_resolve_and_setup_tunnels`, write them to `/workspace/.tunnel-urls` via
  `sandbox.exec`. Failures are logged as warnings and do not block sandbox creation.
- **`packages/modal-infra/tests/test_tunnel_ports.py`** — 3 new tests + updated
  mocks on 2 existing tests to account for the new `exec` call.

## File format

One line per port, space-separated:

```
3000 https://abc123.modal.run
3001 https://def456.modal.run
```

## Motivation

Without this, when a user asks the agent to "share a preview URL", the agent can
only respond with `http://localhost:<port>` which is unreachable outside the sandbox.
This is the missing link between the platform-level tunnel resolution and the agent's
ability to surface those URLs.

## Test plan

- [x] `test_writes_tunnel_urls_to_sandbox_filesystem` — verifies exec is called
  with correct file content and path
- [x] `test_does_not_write_file_when_no_extra_urls` — verifies no exec call when
  tunnels resolve empty
- [x] `test_tunnel_file_write_failure_does_not_raise` — verifies exec failures are
  gracefully handled and URLs are still returned
- [ ] Configure tunnel ports (e.g. 3000, 3001) in Sandbox Settings for a repo
- [ ] Start a session and verify `/workspace/.tunnel-urls` exists inside the sandbox
- [ ] Ask the agent to share a preview URL — it should read the file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persist resolved extra tunnel port→URL mappings into the sandbox workspace for sandboxes.

* **Bug Fixes**
  * Writing tunnel mappings is now logged on success; write failures emit warnings and no longer crash or propagate.

* **Tests**
  * Added tests verifying persistence behavior, that writes are invoked and awaited when needed, and that write or wait failures are handled gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->