### PR TITLE
Fix linear follow-ups

### DIFF
--- a/packages/linear-bot/src/index.ts
+++ b/packages/linear-bot/src/index.ts
@@ -128,24 +128,20 @@ app.post("/webhook", async (c) => {
   const action = readStringField(payload, "action") ?? "unknown";
 
   if (eventType === "AgentSessionEvent") {
-    // Deduplicate: use agentSession.id + action as key
-    const agentSession = isObjectRecord(payload.agentSession) ? payload.agentSession : undefined;
-    if (agentSession) {
-      const agentSessionId = readStringField(agentSession, "id");
-      if (!agentSessionId) {
-        log.warn("webhook.invalid_payload", {
-          trace_id: traceId,
-          reason: "missing_agent_session_id",
-        });
-        return c.json({ error: "Invalid payload" }, 400);
-      }
+    // Deduplicate by Linear webhook delivery ID.
+    const webhookId = readStringField(payload, "webhookId");
+    if (!webhookId) {
+      log.warn("webhook.invalid_payload", {
+        trace_id: traceId,
+        reason: "missing_webhook_id",
+      });
+      return c.json({ error: "Invalid payload" }, 400);
+    }
 
-      const eventKey = `${agentSessionId}:${action}`;
-      const isDuplicate = await isDuplicateEvent(c.env, eventKey);
-      if (isDuplicate) {
-        log.info("webhook.deduplicated", { trace_id: traceId, event_key: eventKey });
-        return c.json({ ok: true, skipped: true, reason: "duplicate" });
-      }
+    const isDuplicate = await isDuplicateEvent(c.env, webhookId);
+    if (isDuplicate) {
+      log.info("webhook.deduplicated", { trace_id: traceId, event_key: webhookId });
+      return c.json({ ok: true, skipped: true, reason: "duplicate" });
     }
 
     if (!isAgentSessionWebhookPayload(payload)) {

--- a/packages/linear-bot/src/index.ts
+++ b/packages/linear-bot/src/index.ts
@@ -48,9 +48,10 @@ function isAgentSessionWebhookPayload(payload: unknown): payload is AgentSession
   const type = readStringField(payload, "type");
   const action = readStringField(payload, "action");
   const organizationId = readStringField(payload, "organizationId");
+  const webhookId = readStringField(payload, "webhookId");
   const agentSession = payload.agentSession;
 
-  if (!type || !action || !organizationId || !isObjectRecord(agentSession)) {
+  if (!type || !action || !organizationId || !isObjectRecord(agentSession) || !webhookId) {
     return false;
   }
 

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -196,6 +196,7 @@ export interface AgentSessionWebhook {
   type: string;
   action: string;
   organizationId: string;
+  webhookId?: string;
   appUserId?: string;
   agentSession: {
     id: string;

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -196,7 +196,7 @@ export interface AgentSessionWebhook {
   type: string;
   action: string;
   organizationId: string;
-  webhookId?: string;
+  webhookId: string;
   appUserId?: string;
   agentSession: {
     id: string;

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -203,5 +203,10 @@ export interface AgentSessionWebhook {
     comment?: { body: string };
     promptContext?: string;
   };
-  agentActivity?: { body?: string };
+  agentActivity?: {
+    content?: {
+      type?: string;
+      body?: string;
+    };
+  };
 }

--- a/packages/linear-bot/src/webhook-handler.ts
+++ b/packages/linear-bot/src/webhook-handler.ts
@@ -195,8 +195,9 @@ async function handleFollowUp(
   const existingSession = await lookupIssueSession(env, issue.id);
   if (!existingSession) return;
 
-  const followUpContent = agentActivity?.body || comment?.body || "Follow-up on the issue.";
-  const followUpMetadata = agentActivity?.body
+  const followUpContent =
+    agentActivity?.content?.body || comment?.body || "Follow-up on the issue.";
+  const followUpMetadata = agentActivity?.content?.body
     ? { followUpSource: "linear_agent_activity", followUpAuthor: "linear" }
     : { followUpSource: "linear_comment", followUpAuthor: "unknown" };
 


### PR DESCRIPTION
I had issues with Linear followups insides agent session thread where :
1. the first follow-up would be processed but without its content
2. the others would hang in the linear ui 

after some debugging i found the cause and here's how I fixed it :

- read follow-up text from `agentActivity.content.body` for prompted agent-session events (instead of `agentActivity.body` that doesn't exist)
- update dedup logic to check for `webhookId` instead of `agentSession.id:action` because it dropped later follow-ups after the first one
- update types to match linear webhook payload shape

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook deduplication now uses the provider's native delivery identifier, reducing duplicate event processing.
  * Validation tightened to require webhook delivery identifiers for incoming events, preventing malformed deliveries from being accepted.
  * Follow-up handling updated to extract nested agent activity content, improving attribution and prompt content for agent-originated versus comment-originated follow-ups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->