### PR TITLE
fix: skip resolved/ignored Sentry issues in webhook normalizer

### DIFF
--- a/packages/shared/src/triggers/sentry/normalizer.test.ts
+++ b/packages/shared/src/triggers/sentry/normalizer.test.ts
@@ -130,6 +130,36 @@ describe("normalizeSentryEvent", () => {
     expect(normalizeSentryEvent(warningPayload)).toBeNull();
   });
 
+  it("returns null for resolved issue action", () => {
+    const resolvedPayload = {
+      ...issueAlertPayload,
+      action: "resolved",
+    };
+    expect(normalizeSentryEvent(resolvedPayload)).toBeNull();
+  });
+
+  it("returns null for issue with resolved status", () => {
+    const resolvedPayload = {
+      ...issueAlertPayload,
+      data: {
+        ...issueAlertPayload.data,
+        issue: { ...issueAlertPayload.data.issue, status: "resolved" },
+      },
+    };
+    expect(normalizeSentryEvent(resolvedPayload)).toBeNull();
+  });
+
+  it("returns null for issue with ignored status", () => {
+    const ignoredPayload = {
+      ...issueAlertPayload,
+      data: {
+        ...issueAlertPayload.data,
+        issue: { ...issueAlertPayload.data.issue, status: "ignored" },
+      },
+    };
+    expect(normalizeSentryEvent(ignoredPayload)).toBeNull();
+  });
+
   it("returns null for unrecognized payload shapes", () => {
     expect(normalizeSentryEvent({ action: "unknown" })).toBeNull();
     expect(normalizeSentryEvent({})).toBeNull();

--- a/packages/shared/src/triggers/sentry/normalizer.ts
+++ b/packages/shared/src/triggers/sentry/normalizer.ts
@@ -80,6 +80,12 @@ export function normalizeSentryEvent(
   if (isIssueAlertPayload(payload)) {
     const p = payload as unknown as SentryIssueAlertPayload;
     const issue = p.data.issue;
+
+    // Skip resolved/ignored issues — only act on new or regressed issues
+    if (p.action === "resolved" || issue.status === "resolved" || issue.status === "ignored") {
+      return null;
+    }
+
     const isRegression = p.action === "regression" || issue.status === "regressed";
     const eventType = isRegression ? "issue.regression" : "issue.created";
     const triggerKey = isRegression


### PR DESCRIPTION
## Summary
- Resolved and ignored Sentry issues were being misclassified as `issue.created` events, triggering workflows when they shouldn't
- Added early return in `normalizeSentryEvent` to skip payloads with `action: "resolved"`, `status: "resolved"`, or `status: "ignored"`
- Added 3 test cases covering all three skip conditions

## Test plan
- [x] Existing normalizer tests pass (5/5)
- [x] New tests for resolved action, resolved status, and ignored status pass (3/3)
- [ ] Verify in staging that resolving a Sentry issue no longer triggers an automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sentry webhooks for resolved or ignored issues are now properly filtered and won't create unwanted automation events.

* **Tests**
  * Expanded test coverage for Sentry issue filtering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->