### PR TITLE
fix(ci): guard checks.tf for cloudflare platform and install uv for modal deploy

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -287,10 +287,11 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install Modal CLI and dependencies
+      - name: Install uv, Modal CLI and dependencies
         run: |
-          pip install -e packages/sandbox-runtime
-          pip install modal fastapi pydantic httpx PyJWT
+          pip install uv
+          uv pip install --system -e packages/sandbox-runtime
+          uv pip install --system modal fastapi pydantic httpx PyJWT
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/terraform/environments/production/checks.tf
+++ b/terraform/environments/production/checks.tf
@@ -6,8 +6,8 @@ check "vercel_url_matches" {
     condition = (
       var.web_platform != "vercel" ||
       length(module.web_app) == 0 ||
-      module.web_app[0].production_url == local.web_app_url
+      try(module.web_app[0].production_url, "") == local.web_app_url
     )
-    error_message = "Vercel assigned URL '${var.web_platform == "vercel" && length(module.web_app) > 0 ? module.web_app[0].production_url : "n/a"}' but local.web_app_url is '${local.web_app_url}'. Update locals or set a custom domain."
+    error_message = "Vercel assigned URL '${length(module.web_app) > 0 ? module.web_app[0].production_url : "n/a"}' but local.web_app_url is '${local.web_app_url}'. Update locals or set a custom domain."
   }
 }


### PR DESCRIPTION
## Problem

Two issues in the Terraform CI workflow cause `terraform apply` to fail when deploying with `web_platform = "cloudflare"`:

1. **`checks.tf` — `Invalid index` error**: The `vercel_url_matches` check block accesses `module.web_app[0].production_url`, but when `web_platform = "cloudflare"`, the `web_app` module is not created (`module.web_app` is an empty tuple). Although the condition has a short-circuit guard (`var.web_platform != "vercel"`), Terraform evaluates all expressions in the block — including the `error_message` — which also references `module.web_app[0]` and triggers the error.

2. **`terraform.yml` — `uv: command not found`**: The Modal deploy script (`deploy.sh`) runs `uv run modal deploy`, but the CI workflow only installs Python packages via `pip`. `uv` is never installed, so the deploy step fails.

## Changes

- **`terraform/environments/production/checks.tf`**: Wrap `module.web_app[0]` access in `try()` so the expression gracefully returns a default when the module has no instances. Also simplify the `error_message` guard to use `length(module.web_app) > 0` instead of the redundant `var.web_platform == "vercel"` check.

- **`.github/workflows/terraform.yml`**: Install `uv` via `pip install uv` in the apply job's Python setup step, and use `uv pip install --system` for the remaining dependencies so the environment is consistent with what `deploy.sh` expects.

## Steps to reproduce

1. Set `web_platform = "cloudflare"` in `terraform.tfvars`
2. Run `terraform apply` via CI → fails with `Invalid index: the collection has no elements`
3. Fix checks.tf, re-run → fails with `uv: command not found` during Modal deploy

## Test plan

- [x] Confirmed `Invalid index` error on `web_platform = "cloudflare"` deployment
- [x] Confirmed `uv: command not found` error in CI modal deploy step
- [x] Verified both fixes resolve the errors in CI