### PR TITLE
fix(ci): bump Terraform from 1.9.0 to 1.14.8

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -41,7 +41,7 @@ concurrency:
   cancel-in-progress: false # Don't cancel terraform operations
 
 env:
-  TF_VERSION: "1.9.0"
+  TF_VERSION: "1.14.8"
   TF_WORKING_DIR: terraform/environments/production
 
 jobs:

--- a/terraform/environments/production/versions.tf
+++ b/terraform/environments/production/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.9.0"
+  required_version = ">= 1.14.0"
 
   required_providers {
     cloudflare = {


### PR DESCRIPTION
## Summary

- Bumps `TF_VERSION` from 1.9.0 to 1.14.8 in the Terraform CI workflow
- Fixes `Invalid index` error when running `terraform plan/apply` with `web_platform = "cloudflare"`

## Context

Terraform 1.9.0 eagerly evaluates all operands in `||` within `check` block conditions instead of short-circuiting. This causes `module.web_app[0]` in `checks.tf` to fail with `Invalid index: the collection has no elements` when `web_platform = "cloudflare"` (where `module.web_app` is an empty tuple).

Newer Terraform versions (verified on 1.14.x) short-circuit correctly, resolving the issue without needing to modify `checks.tf`.

Identified by #469.

## Test plan

- [x] Reproduced the `Invalid index` error locally with TF 1.9.0 and `web_platform = "cloudflare"`
- [x] Verified TF 1.14.8 resolves the error (condition short-circuits correctly)
- [x] Verified `required_version = ">= 1.9.0"` in `versions.tf` is satisfied by 1.14.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Terraform version requirement to 1.14.0, ensuring infrastructure deployments use the latest toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->