### PR TITLE
fix(ci): apply terraform fmt and make format check blocking

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -80,7 +80,6 @@ jobs:
         id: fmt
         run: terraform fmt -check -recursive
         working-directory: terraform
-        continue-on-error: true
 
       - name: Terraform Init
         id: init

--- a/terraform/environments/production/locals.tf
+++ b/terraform/environments/production/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  name_suffix = var.deployment_name
-  use_modal_backend = var.sandbox_provider == "modal"
+  name_suffix         = var.deployment_name
+  use_modal_backend   = var.sandbox_provider == "modal"
   use_daytona_backend = var.sandbox_provider == "daytona"
 
   # URLs for cross-service configuration

--- a/terraform/environments/production/web-cloudflare.tf
+++ b/terraform/environments/production/web-cloudflare.tf
@@ -16,7 +16,7 @@ resource "null_resource" "web_app_cloudflare_build" {
 
     environment = {
       # NEXT_PUBLIC_* vars must be set at build time (inlined into client bundle)
-      NEXT_PUBLIC_WS_URL          = local.ws_url
+      NEXT_PUBLIC_WS_URL           = local.ws_url
       NEXT_PUBLIC_SANDBOX_PROVIDER = var.sandbox_provider
     }
   }


### PR DESCRIPTION
## Summary

- Apply `terraform fmt` to `locals.tf` and `web-cloudflare.tf` (alignment whitespace)
- Remove `continue-on-error: true` from the fmt check step so formatting failures block the validate job

## Context

The fmt step was silently failing due to `continue-on-error: true` — it showed a warning icon in the PR comment but didn't block the pipeline. Formatting issues should fail the build.

## Test plan

- [x] Ran `terraform fmt -check -recursive terraform/` locally — passes after formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified Terraform format validation workflow to fail the validation job when format checks fail, rather than allowing them to pass silently.
  * Updated spacing alignment in Terraform configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->