### PR TITLE
feat: D1 analytics columns + sync plumbing

### DIFF
--- a/packages/control-plane/src/db/session-index.test.ts
+++ b/packages/control-plane/src/db/session-index.test.ts
@@ -16,6 +16,11 @@ type SessionRow = {
   spawn_depth: number;
   automation_id: string | null;
   automation_run_id: string | null;
+  scm_login: string | null;
+  total_cost: number;
+  active_duration_ms: number;
+  message_count: number;
+  pr_count: number;
   created_at: number;
   updated_at: number;
 };
@@ -28,6 +33,7 @@ const QUERY_PATTERNS = {
   UPDATE_STATUS: /^UPDATE sessions SET status = \?/,
   UPDATE_UPDATED_AT: /^UPDATE sessions SET updated_at = \?/,
   UPDATE_TITLE: /^UPDATE sessions SET title = \?/,
+  UPDATE_METRICS: /^UPDATE sessions SET total_cost = \?/,
   DELETE_SESSION: /^DELETE FROM sessions WHERE id = \?$/,
   SELECT_BY_PARENT:
     /^SELECT \* FROM sessions WHERE parent_session_id = \? ORDER BY created_at DESC$/,
@@ -127,6 +133,7 @@ class FakeD1Database {
         spawnDepth,
         automationId,
         automationRunId,
+        scmLogin,
         createdAt,
         updatedAt,
       ] = args as [
@@ -141,6 +148,7 @@ class FakeD1Database {
         string | null,
         "user" | "agent" | "automation",
         number,
+        string | null,
         string | null,
         string | null,
         number,
@@ -162,6 +170,11 @@ class FakeD1Database {
           spawn_depth: spawnDepth,
           automation_id: automationId,
           automation_run_id: automationRunId,
+          scm_login: scmLogin,
+          total_cost: 0,
+          active_duration_ms: 0,
+          message_count: 0,
+          pr_count: 0,
           created_at: createdAt,
           updated_at: updatedAt,
         });
@@ -195,6 +208,25 @@ class FakeD1Database {
       const id = args[0] as string;
       const existed = this.rows.delete(id);
       return { meta: { changes: existed ? 1 : 0 } };
+    }
+
+    if (QUERY_PATTERNS.UPDATE_METRICS.test(normalized)) {
+      const [totalCost, activeDurationMs, messageCount, prCount, id] = args as [
+        number,
+        number,
+        number,
+        number,
+        string,
+      ];
+      const row = this.rows.get(id);
+      if (row) {
+        row.total_cost = totalCost;
+        row.active_duration_ms = activeDurationMs;
+        row.message_count = messageCount;
+        row.pr_count = prCount;
+        return { meta: { changes: 1 } };
+      }
+      return { meta: { changes: 0 } };
     }
 
     if (QUERY_PATTERNS.UPDATE_UPDATED_AT.test(normalized)) {
@@ -320,6 +352,11 @@ describe("SessionIndexStore", () => {
         spawnDepth: 0,
         automationId: null,
         automationRunId: null,
+        scmLogin: null,
+        totalCost: 0,
+        activeDurationMs: 0,
+        messageCount: 0,
+        prCount: 0,
       });
     });
 

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -14,6 +14,11 @@ export interface SessionEntry {
   spawnDepth?: number;
   automationId?: string | null;
   automationRunId?: string | null;
+  scmLogin?: string | null;
+  totalCost?: number;
+  activeDurationMs?: number;
+  messageCount?: number;
+  prCount?: number;
   createdAt: number;
   updatedAt: number;
 }
@@ -32,6 +37,11 @@ interface SessionRow {
   spawn_depth: number;
   automation_id: string | null;
   automation_run_id: string | null;
+  scm_login: string | null;
+  total_cost: number;
+  active_duration_ms: number;
+  message_count: number;
+  pr_count: number;
   created_at: number;
   updated_at: number;
 }
@@ -66,6 +76,11 @@ function toEntry(row: SessionRow): SessionEntry {
     spawnDepth: row.spawn_depth,
     automationId: row.automation_id,
     automationRunId: row.automation_run_id,
+    scmLogin: row.scm_login,
+    totalCost: row.total_cost,
+    activeDurationMs: row.active_duration_ms,
+    messageCount: row.message_count,
+    prCount: row.pr_count,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -77,8 +92,8 @@ export class SessionIndexStore {
   async create(session: SessionEntry): Promise<void> {
     await this.db
       .prepare(
-        `INSERT OR IGNORE INTO sessions (id, title, repo_owner, repo_name, model, reasoning_effort, base_branch, status, parent_session_id, spawn_source, spawn_depth, automation_id, automation_run_id, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        `INSERT OR IGNORE INTO sessions (id, title, repo_owner, repo_name, model, reasoning_effort, base_branch, status, parent_session_id, spawn_source, spawn_depth, automation_id, automation_run_id, scm_login, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .bind(
         session.id,
@@ -94,6 +109,7 @@ export class SessionIndexStore {
         session.spawnDepth ?? 0,
         session.automationId ?? null,
         session.automationRunId ?? null,
+        session.scmLogin ?? null,
         session.createdAt,
         session.updatedAt
       )
@@ -176,6 +192,25 @@ export class SessionIndexStore {
       .bind(status, updatedAt, id, updatedAt)
       .run();
 
+    return (result.meta?.changes ?? 0) > 0;
+  }
+
+  async updateMetrics(
+    id: string,
+    metrics: {
+      totalCost: number;
+      activeDurationMs: number;
+      messageCount: number;
+      prCount: number;
+    }
+  ): Promise<boolean> {
+    const result = await this.db
+      .prepare(
+        `UPDATE sessions SET total_cost = ?, active_duration_ms = ?, message_count = ?, pr_count = ?
+         WHERE id = ?`
+      )
+      .bind(metrics.totalCost, metrics.activeDurationMs, metrics.messageCount, metrics.prCount, id)
+      .run();
     return (result.meta?.changes ?? 0) > 0;
   }
 

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -819,6 +819,7 @@ async function handleCreateSession(
     reasoningEffort,
     baseBranch: body.branch || defaultBranch || "main",
     status: "created",
+    scmLogin: scmLogin || null,
     createdAt: now,
     updatedAt: now,
   });
@@ -1513,6 +1514,7 @@ async function handleSpawnChild(
     parentSessionId: parentId,
     spawnSource: "agent",
     spawnDepth: childDepth,
+    scmLogin: spawnContext.owner.scmLogin || null,
     createdAt: now,
     updatedAt: now,
   });

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -103,6 +103,9 @@ const WS_AUTH_TIMEOUT_MS = 30000; // 30 seconds
  */
 const WS_TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
+/** Statuses that indicate a session is finished — metrics are synced to D1 on these transitions. */
+const TERMINAL_STATUSES: SessionStatus[] = ["completed", "failed", "cancelled"];
+
 export class SessionDO extends DurableObject<Env> {
   private sql: SqlStorage;
   private repository: SessionRepository;
@@ -1447,6 +1450,35 @@ export class SessionDO extends DurableObject<Env> {
     );
   }
 
+  private syncSessionMetrics(sessionId: string): void {
+    if (!this.env.DB) return;
+
+    const session = this.repository.getSession();
+    if (!session) return;
+
+    const messageCount = this.repository.getMessageCount();
+    const activeDurationMs = this.repository.getActiveDurationMs();
+    const artifacts = this.repository.listArtifacts();
+    const prCount = artifacts.filter((a) => a.type === "pr").length;
+
+    const sessionStore = new SessionIndexStore(this.env.DB);
+    this.ctx.waitUntil(
+      sessionStore
+        .updateMetrics(sessionId, {
+          totalCost: session.total_cost,
+          activeDurationMs,
+          messageCount,
+          prCount,
+        })
+        .catch((error) => {
+          this.log.error("session_index.update_metrics.background_error", {
+            session_id: sessionId,
+            error,
+          });
+        })
+    );
+  }
+
   private async transitionSessionStatus(status: SessionStatus): Promise<boolean> {
     const session = this.getSession();
     if (!session) return false;
@@ -1454,6 +1486,9 @@ export class SessionDO extends DurableObject<Env> {
     const publicSessionId = this.getPublicSessionId(session);
     if (session.status === status) {
       this.syncSessionIndexStatus(publicSessionId, status, session.updated_at);
+      if (TERMINAL_STATUSES.includes(status)) {
+        this.syncSessionMetrics(publicSessionId);
+      }
       return false;
     }
 
@@ -1462,6 +1497,10 @@ export class SessionDO extends DurableObject<Env> {
     this.syncSessionIndexStatus(publicSessionId, status, updatedAt);
 
     this.broadcast({ type: "session_status", status });
+
+    if (TERMINAL_STATUSES.includes(status)) {
+      this.syncSessionMetrics(publicSessionId);
+    }
 
     // Notify parent session (if this is a child) so its UI can refresh
     this.notifyParentOfStatusChange(session, publicSessionId, status);

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1465,7 +1465,7 @@ export class SessionDO extends DurableObject<Env> {
     this.ctx.waitUntil(
       sessionStore
         .updateMetrics(sessionId, {
-          totalCost: session.total_cost,
+          totalCost: session.total_cost ?? 0,
           activeDurationMs,
           messageCount,
           prCount,

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -565,6 +565,15 @@ export class SessionRepository {
 
   // === MESSAGES ===
 
+  getActiveDurationMs(): number {
+    const result = this.sql.exec(
+      `SELECT COALESCE(SUM(completed_at - started_at), 0) as duration_ms
+       FROM messages
+       WHERE started_at IS NOT NULL AND completed_at IS NOT NULL`
+    );
+    return (result.one() as { duration_ms: number }).duration_ms;
+  }
+
   getMessageCount(): number {
     const result = this.sql.exec(`SELECT COUNT(*) as count FROM messages`);
     return (result.one() as { count: number }).count;

--- a/packages/control-plane/test/integration/d1-session-index.test.ts
+++ b/packages/control-plane/test/integration/d1-session-index.test.ts
@@ -117,6 +117,141 @@ describe("D1 SessionIndexStore", () => {
     expect(session!.reasoningEffort).toBeNull();
   });
 
+  it("stores and retrieves scmLogin", async () => {
+    const store = new SessionIndexStore(env.DB);
+    const now = Date.now();
+
+    await store.create({
+      id: "session-with-login",
+      title: null,
+      repoOwner: "acme",
+      repoName: "api",
+      model: "anthropic/claude-haiku-4-5",
+      reasoningEffort: null,
+      baseBranch: null,
+      status: "created",
+      scmLogin: "testuser",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const session = await store.get("session-with-login");
+    expect(session).not.toBeNull();
+    expect(session!.scmLogin).toBe("testuser");
+  });
+
+  it("defaults scmLogin to null when omitted", async () => {
+    const store = new SessionIndexStore(env.DB);
+    const now = Date.now();
+
+    await store.create({
+      id: "session-no-login",
+      title: null,
+      repoOwner: "acme",
+      repoName: "api",
+      model: "anthropic/claude-haiku-4-5",
+      reasoningEffort: null,
+      baseBranch: null,
+      status: "created",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const session = await store.get("session-no-login");
+    expect(session).not.toBeNull();
+    expect(session!.scmLogin).toBeNull();
+  });
+
+  it("updates and retrieves session metrics", async () => {
+    const store = new SessionIndexStore(env.DB);
+    const now = Date.now();
+
+    await store.create({
+      id: "session-metrics",
+      title: null,
+      repoOwner: "acme",
+      repoName: "api",
+      model: "anthropic/claude-haiku-4-5",
+      reasoningEffort: null,
+      baseBranch: null,
+      status: "created",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // Verify defaults
+    const before = await store.get("session-metrics");
+    expect(before!.totalCost).toBe(0);
+    expect(before!.activeDurationMs).toBe(0);
+    expect(before!.messageCount).toBe(0);
+    expect(before!.prCount).toBe(0);
+
+    // Update metrics
+    const updated = await store.updateMetrics("session-metrics", {
+      totalCost: 1.25,
+      activeDurationMs: 120000,
+      messageCount: 5,
+      prCount: 1,
+    });
+    expect(updated).toBe(true);
+
+    // Verify updated values
+    const after = await store.get("session-metrics");
+    expect(after!.totalCost).toBe(1.25);
+    expect(after!.activeDurationMs).toBe(120000);
+    expect(after!.messageCount).toBe(5);
+    expect(after!.prCount).toBe(1);
+  });
+
+  it("updateMetrics overwrites on repeated calls (last write wins)", async () => {
+    const store = new SessionIndexStore(env.DB);
+    const now = Date.now();
+
+    await store.create({
+      id: "session-metrics-overwrite",
+      title: null,
+      repoOwner: "acme",
+      repoName: "api",
+      model: "anthropic/claude-haiku-4-5",
+      reasoningEffort: null,
+      baseBranch: null,
+      status: "created",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    await store.updateMetrics("session-metrics-overwrite", {
+      totalCost: 0.5,
+      activeDurationMs: 60000,
+      messageCount: 3,
+      prCount: 0,
+    });
+
+    await store.updateMetrics("session-metrics-overwrite", {
+      totalCost: 1.75,
+      activeDurationMs: 180000,
+      messageCount: 8,
+      prCount: 2,
+    });
+
+    const session = await store.get("session-metrics-overwrite");
+    expect(session!.totalCost).toBe(1.75);
+    expect(session!.activeDurationMs).toBe(180000);
+    expect(session!.messageCount).toBe(8);
+    expect(session!.prCount).toBe(2);
+  });
+
+  it("updateMetrics returns false for non-existent session", async () => {
+    const store = new SessionIndexStore(env.DB);
+    const result = await store.updateMetrics("nonexistent", {
+      totalCost: 1,
+      activeDurationMs: 1000,
+      messageCount: 1,
+      prCount: 0,
+    });
+    expect(result).toBe(false);
+  });
+
   it("deletes a session", async () => {
     const store = new SessionIndexStore(env.DB);
     const now = Date.now();

--- a/terraform/d1/migrations/0017_add_analytics_columns.sql
+++ b/terraform/d1/migrations/0017_add_analytics_columns.sql
@@ -1,0 +1,9 @@
+-- Analytics columns for usage dashboard (forward-looking, no backfill)
+ALTER TABLE sessions ADD COLUMN scm_login TEXT;
+ALTER TABLE sessions ADD COLUMN total_cost REAL NOT NULL DEFAULT 0;
+ALTER TABLE sessions ADD COLUMN active_duration_ms INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sessions ADD COLUMN message_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sessions ADD COLUMN pr_count INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX idx_sessions_scm_login ON sessions(scm_login, created_at DESC);
+CREATE INDEX idx_sessions_created_at ON sessions(created_at DESC);


### PR DESCRIPTION
## Summary

- Adds 5 analytics columns to the D1 session index (`scm_login`, `total_cost`, `active_duration_ms`, `message_count`, `pr_count`) via migration `0017`
- Adds `SessionIndexStore.updateMetrics()` and `SessionRepository.getActiveDurationMs()`
- Syncs metrics from DO → D1 on terminal status transitions (`completed`, `failed`, `cancelled`) using fire-and-forget `waitUntil`
- Passes `scmLogin` at all three D1 creation sites (main session, child spawn, automation defaults to null)
- Forward-looking only — existing sessions retain DEFAULT values (0 / null)

## Test plan

- [x] Unit tests pass (937 tests) — fake D1 updated for new column shape
- [x] Integration tests pass (274 tests) — D1 migration auto-applied
- [x] New tests: `scmLogin` round-trip, null default, `updateMetrics` create/update/overwrite/nonexistent
- [x] Typecheck clean across all packages
- [x] Lint clean on all modified files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions now persist analytics metrics: total cost, active duration, message count, and PR count.
  * Session owner SCM login is captured and stored on session creation.
  * Metrics are automatically synced when sessions reach terminal/completed states.

* **Tests**
  * Added integration and unit tests covering creation, defaults, metric updates, overwrite behavior, and non-existent-session handling.

* **Chores**
  * Database migration added columns and indexes to support the new analytics fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->