### PR TITLE
feat: automate Daytona snapshot builds in Terraform

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -289,10 +289,10 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install sandbox infrastructure dependencies
+      - name: Install Modal CLI and dependencies
         run: |
           pip install -e packages/sandbox-runtime
-          pip install modal fastapi pydantic httpx PyJWT 'daytona==0.161.0'
+          pip install modal fastapi pydantic httpx PyJWT
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -218,6 +218,7 @@ jobs:
           TF_VAR_daytona_api_url: ${{ secrets.DAYTONA_API_URL }}
           TF_VAR_daytona_api_key: ${{ secrets.DAYTONA_API_KEY }}
           TF_VAR_daytona_base_snapshot: ${{ secrets.DAYTONA_BASE_SNAPSHOT }}
+          TF_VAR_daytona_target: ${{ secrets.DAYTONA_TARGET }}
 
       - name: Post Plan Results
         uses: actions/github-script@v7
@@ -348,6 +349,7 @@ jobs:
           TF_VAR_daytona_api_url: ${{ secrets.DAYTONA_API_URL }}
           TF_VAR_daytona_api_key: ${{ secrets.DAYTONA_API_KEY }}
           TF_VAR_daytona_base_snapshot: ${{ secrets.DAYTONA_BASE_SNAPSHOT }}
+          TF_VAR_daytona_target: ${{ secrets.DAYTONA_TARGET }}
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -11,6 +11,7 @@ on:
       - "packages/github-bot/**"
       - "packages/linear-bot/**"
       - "packages/modal-infra/**"
+      - "packages/daytona-infra/**"
       - "packages/sandbox-runtime/**"
       - "packages/shared/**"
       - "packages/web/**" # Web app deployed via Terraform when web_platform = "cloudflare"
@@ -25,6 +26,7 @@ on:
       - "packages/github-bot/**"
       - "packages/linear-bot/**"
       - "packages/modal-infra/**"
+      - "packages/daytona-infra/**"
       - "packages/sandbox-runtime/**"
       - "packages/shared/**"
       - "packages/web/**"
@@ -286,10 +288,10 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install Modal CLI and dependencies
+      - name: Install sandbox infrastructure dependencies
         run: |
           pip install -e packages/sandbox-runtime
-          pip install modal fastapi pydantic httpx PyJWT
+          pip install modal fastapi pydantic httpx PyJWT 'daytona==0.161.0'
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/terraform/environments/production/daytona.tf
+++ b/terraform/environments/production/daytona.tf
@@ -1,0 +1,36 @@
+# =============================================================================
+# Daytona Sandbox Infrastructure
+# =============================================================================
+
+# Calculate hash of Daytona snapshot source files for change detection.
+# Includes daytona-infra (image definition) and sandbox-runtime (copied into image).
+data "external" "daytona_source_hash" {
+  count = local.use_daytona_backend ? 1 : 0
+
+  program = ["bash", "-c", <<-EOF
+    cd ${var.project_root}
+    if command -v sha256sum &> /dev/null; then
+      hash=$(find packages/daytona-infra/src packages/sandbox-runtime/src \
+        -type f \( -name "*.py" -o -name "*.js" -o -name "*.ts" \) \
+        -exec sha256sum {} \; | sort | sha256sum | cut -d' ' -f1)
+    else
+      hash=$(find packages/daytona-infra/src packages/sandbox-runtime/src \
+        -type f \( -name "*.py" -o -name "*.js" -o -name "*.ts" \) \
+        -exec shasum -a 256 {} \; | sort | shasum -a 256 | cut -d' ' -f1)
+    fi
+    echo "{\"hash\": \"$hash\"}"
+  EOF
+  ]
+}
+
+module "daytona_infra" {
+  count  = local.use_daytona_backend ? 1 : 0
+  source = "../../modules/daytona-infra"
+
+  api_key       = var.daytona_api_key
+  api_url       = var.daytona_api_url
+  target        = var.daytona_target
+  snapshot_name = var.daytona_base_snapshot
+  deploy_path   = "${var.project_root}/packages/daytona-infra"
+  source_hash   = data.external.daytona_source_hash[0].result.hash
+}

--- a/terraform/environments/production/workers-control-plane.tf
+++ b/terraform/environments/production/workers-control-plane.tf
@@ -120,5 +120,6 @@ module "control_plane_worker" {
     module.session_index_kv,
     null_resource.d1_migrations,
     module.linear_bot_worker,
+    module.daytona_infra,
   ]
 }

--- a/terraform/modules/daytona-infra/main.tf
+++ b/terraform/modules/daytona-infra/main.tf
@@ -16,12 +16,11 @@ resource "null_resource" "daytona_snapshot" {
     interpreter = ["bash"]
 
     environment = {
-      DAYTONA_API_KEY        = var.api_key
-      DAYTONA_API_URL        = var.api_url
-      DAYTONA_TARGET         = var.target
-      DAYTONA_BASE_SNAPSHOT  = var.snapshot_name
-      DEPLOY_PATH            = var.deploy_path
-      OPEN_INSPECT_REPO_ROOT = dirname(dirname(var.deploy_path))
+      DAYTONA_API_KEY       = var.api_key
+      DAYTONA_API_URL       = var.api_url
+      DAYTONA_TARGET        = var.target
+      DAYTONA_BASE_SNAPSHOT = var.snapshot_name
+      DEPLOY_PATH           = var.deploy_path
     }
   }
 }

--- a/terraform/modules/daytona-infra/main.tf
+++ b/terraform/modules/daytona-infra/main.tf
@@ -6,6 +6,9 @@ resource "null_resource" "daytona_snapshot" {
   triggers = {
     source_hash   = var.source_hash
     snapshot_name = var.snapshot_name
+    api_url       = var.api_url
+    target        = var.target
+    script_hash   = filesha256("${path.module}/scripts/build-snapshot.sh")
   }
 
   provisioner "local-exec" {

--- a/terraform/modules/daytona-infra/main.tf
+++ b/terraform/modules/daytona-infra/main.tf
@@ -1,0 +1,24 @@
+# Daytona Infrastructure Module
+# Builds the base snapshot used by Daytona sandboxes.
+# Mirrors the pattern of terraform/modules/modal-app/ for Modal deployments.
+
+resource "null_resource" "daytona_snapshot" {
+  triggers = {
+    source_hash   = var.source_hash
+    snapshot_name = var.snapshot_name
+  }
+
+  provisioner "local-exec" {
+    command     = "${path.module}/scripts/build-snapshot.sh"
+    interpreter = ["bash"]
+
+    environment = {
+      DAYTONA_API_KEY        = var.api_key
+      DAYTONA_API_URL        = var.api_url
+      DAYTONA_TARGET         = var.target
+      DAYTONA_BASE_SNAPSHOT  = var.snapshot_name
+      DEPLOY_PATH            = var.deploy_path
+      OPEN_INSPECT_REPO_ROOT = dirname(dirname(var.deploy_path))
+    }
+  }
+}

--- a/terraform/modules/daytona-infra/outputs.tf
+++ b/terraform/modules/daytona-infra/outputs.tf
@@ -1,0 +1,4 @@
+output "snapshot_build_id" {
+  description = "ID of the snapshot build resource (for depends_on references)"
+  value       = null_resource.daytona_snapshot.id
+}

--- a/terraform/modules/daytona-infra/scripts/build-snapshot.sh
+++ b/terraform/modules/daytona-infra/scripts/build-snapshot.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify required environment variables
+if [[ -z "${DAYTONA_API_KEY:-}" ]]; then
+    echo "Error: DAYTONA_API_KEY environment variable is not set"
+    exit 1
+fi
+
+if [[ -z "${DAYTONA_BASE_SNAPSHOT:-}" ]]; then
+    echo "Error: DAYTONA_BASE_SNAPSHOT environment variable is not set"
+    exit 1
+fi
+
+echo "Building Daytona snapshot: ${DAYTONA_BASE_SNAPSHOT}"
+echo "Deploy path: ${DEPLOY_PATH}"
+
+cd "${DEPLOY_PATH}" || {
+    echo "Error: Failed to change directory to ${DEPLOY_PATH}"
+    exit 1
+}
+
+# Install Daytona SDK (the only runtime dependency for bootstrap).
+# Pin the version to avoid surprise breakage from SDK changes.
+pip install --user -q 'daytona==0.161.0'
+
+# --force deletes the existing snapshot before rebuilding,
+# ensuring the create call succeeds even if the name is taken.
+python -m src.bootstrap --force
+
+echo "Daytona snapshot ${DAYTONA_BASE_SNAPSHOT} built successfully"

--- a/terraform/modules/daytona-infra/variables.tf
+++ b/terraform/modules/daytona-infra/variables.tf
@@ -1,0 +1,31 @@
+variable "api_key" {
+  description = "Daytona REST API key"
+  type        = string
+  sensitive   = true
+}
+
+variable "api_url" {
+  description = "Daytona REST API base URL"
+  type        = string
+}
+
+variable "target" {
+  description = "Optional Daytona target name"
+  type        = string
+  default     = ""
+}
+
+variable "snapshot_name" {
+  description = "Name of the Daytona snapshot to create/update"
+  type        = string
+}
+
+variable "deploy_path" {
+  description = "Path to packages/daytona-infra"
+  type        = string
+}
+
+variable "source_hash" {
+  description = "Hash of source files — triggers rebuild when changed"
+  type        = string
+}


### PR DESCRIPTION
## Summary

- Adds `terraform/modules/daytona-infra/` module that rebuilds the Daytona base snapshot via `bootstrap.py --force` when source files change, mirroring the existing `modal-app` module pattern
- Adds `terraform/environments/production/daytona.tf` with source hash change detection (hashes `.py`, `.js`, `.ts` files in `daytona-infra/src` + `sandbox-runtime/src`) and module invocation, count-gated on `local.use_daytona_backend`
- Adds `module.daytona_infra` to the control plane worker's `depends_on` so the snapshot builds before the worker deploys
- Updates CI workflow: adds `packages/daytona-infra/**` trigger path, installs `daytona==0.161.0`, renames pip install step

## Test plan

- [x] `terraform fmt -recursive` — no formatting issues
- [x] `terraform validate` on the module in isolation — passes
- [x] `terraform validate` on the full production environment — passes
- [ ] `terraform plan` with `sandbox_provider=daytona` — shows `daytona_infra` module resources
- [ ] `terraform plan` with `sandbox_provider=modal` — `count=0`, no Daytona resources created
- [ ] `terraform apply` with `sandbox_provider=daytona` — snapshot builds successfully, control plane deploys after

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added sandbox infra module to automate snapshot builds and deployments.
  * CI now triggers for sandbox infra changes and forwards the Daytona target to runs.
  * Deployments detect source changes via content hashing to trigger snapshot rebuilds.
  * Control plane worker provisioning now waits for sandbox infra to be ready.
  * Snapshot builder script installs and pins a specific Daytona SDK before creating snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->