### PR TITLE
[feat] Add analytics API routes

### DIFF
--- a/packages/control-plane/src/db/analytics-store.ts
+++ b/packages/control-plane/src/db/analytics-store.ts
@@ -1,0 +1,169 @@
+import type {
+  AnalyticsBreakdownBy,
+  AnalyticsBreakdownEntry,
+  AnalyticsBreakdownResponse,
+  AnalyticsSummaryResponse,
+  AnalyticsTimeseriesResponse,
+} from "@open-inspect/shared";
+
+export interface AnalyticsFilters {
+  startAt: number;
+  endAt: number;
+}
+
+interface SummaryRow {
+  total_sessions: number;
+  active_users: number;
+  total_cost: number;
+  total_prs: number;
+  created_count: number;
+  active_count: number;
+  completed_count: number;
+  failed_count: number;
+  archived_count: number;
+  cancelled_count: number;
+}
+
+interface TimeseriesRow {
+  date: string;
+  group_key: string;
+  count: number;
+}
+
+interface BreakdownRow {
+  key: string;
+  sessions: number;
+  completed: number;
+  failed: number;
+  cancelled: number;
+  cost: number;
+  prs: number;
+  message_count: number;
+  avg_duration: number;
+  last_active: number;
+}
+
+export class AnalyticsStore {
+  constructor(private readonly db: D1Database) {}
+
+  async getSummary(filters: AnalyticsFilters): Promise<AnalyticsSummaryResponse> {
+    const result = await this.db
+      .prepare(
+        `SELECT
+           COUNT(*) AS total_sessions,
+           COUNT(DISTINCT CASE WHEN scm_login IS NOT NULL AND scm_login != '' THEN scm_login END) AS active_users,
+           COALESCE(SUM(total_cost), 0) AS total_cost,
+           COALESCE(SUM(pr_count), 0) AS total_prs,
+           COALESCE(SUM(CASE WHEN status = 'created' THEN 1 ELSE 0 END), 0) AS created_count,
+           COALESCE(SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END), 0) AS active_count,
+           COALESCE(SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END), 0) AS completed_count,
+           COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) AS failed_count,
+           COALESCE(SUM(CASE WHEN status = 'archived' THEN 1 ELSE 0 END), 0) AS archived_count,
+           COALESCE(SUM(CASE WHEN status = 'cancelled' THEN 1 ELSE 0 END), 0) AS cancelled_count
+         FROM sessions
+         WHERE created_at >= ? AND created_at < ?`
+      )
+      .bind(filters.startAt, filters.endAt)
+      .first<SummaryRow>();
+
+    const totalSessions = result?.total_sessions ?? 0;
+    const totalCost = result?.total_cost ?? 0;
+
+    return {
+      totalSessions,
+      activeUsers: result?.active_users ?? 0,
+      totalCost,
+      avgCost: totalSessions > 0 ? totalCost / totalSessions : 0,
+      totalPrs: result?.total_prs ?? 0,
+      statusBreakdown: {
+        created: result?.created_count ?? 0,
+        active: result?.active_count ?? 0,
+        completed: result?.completed_count ?? 0,
+        failed: result?.failed_count ?? 0,
+        archived: result?.archived_count ?? 0,
+        cancelled: result?.cancelled_count ?? 0,
+      },
+    };
+  }
+
+  async getTimeseries(filters: AnalyticsFilters): Promise<AnalyticsTimeseriesResponse> {
+    const result = await this.db
+      .prepare(
+        `SELECT
+           date(created_at / 1000, 'unixepoch') AS date,
+           COALESCE(NULLIF(scm_login, ''), 'unknown') AS group_key,
+           COUNT(*) AS count
+         FROM sessions
+         WHERE created_at >= ? AND created_at < ?
+         GROUP BY date, group_key
+         ORDER BY date ASC, group_key ASC`
+      )
+      .bind(filters.startAt, filters.endAt)
+      .all<TimeseriesRow>();
+
+    const series: AnalyticsTimeseriesResponse["series"] = [];
+    for (const row of result.results ?? []) {
+      const lastPoint = series[series.length - 1];
+      if (lastPoint?.date === row.date) {
+        lastPoint.groups[row.group_key] = row.count;
+        continue;
+      }
+
+      series.push({
+        date: row.date,
+        groups: { [row.group_key]: row.count },
+      });
+    }
+
+    return { series };
+  }
+
+  async getBreakdown(
+    filters: AnalyticsFilters,
+    by: AnalyticsBreakdownBy
+  ): Promise<AnalyticsBreakdownResponse> {
+    const groupExpression =
+      by === "user"
+        ? "COALESCE(NULLIF(scm_login, ''), 'unknown')"
+        : "repo_owner || '/' || repo_name";
+
+    const result = await this.db
+      .prepare(
+        `SELECT
+           ${groupExpression} AS key,
+           COUNT(*) AS sessions,
+           COALESCE(SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END), 0) AS completed,
+           COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) AS failed,
+           COALESCE(SUM(CASE WHEN status = 'cancelled' THEN 1 ELSE 0 END), 0) AS cancelled,
+           COALESCE(SUM(total_cost), 0) AS cost,
+           COALESCE(SUM(pr_count), 0) AS prs,
+           COALESCE(SUM(message_count), 0) AS message_count,
+           COALESCE(
+             AVG(CASE WHEN status IN ('completed', 'failed', 'cancelled') THEN active_duration_ms END),
+             0
+           ) AS avg_duration,
+           MAX(updated_at) AS last_active
+         FROM sessions
+         WHERE created_at >= ? AND created_at < ?
+         GROUP BY key
+         ORDER BY sessions DESC, key ASC`
+      )
+      .bind(filters.startAt, filters.endAt)
+      .all<BreakdownRow>();
+
+    const entries: AnalyticsBreakdownEntry[] = (result.results ?? []).map((row) => ({
+      key: row.key,
+      sessions: row.sessions,
+      completed: row.completed,
+      failed: row.failed,
+      cancelled: row.cancelled,
+      cost: row.cost,
+      prs: row.prs,
+      messageCount: row.message_count,
+      avgDuration: row.avg_duration,
+      lastActive: row.last_active,
+    }));
+
+    return { entries };
+  }
+}

--- a/packages/control-plane/src/router.analytics.test.ts
+++ b/packages/control-plane/src/router.analytics.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateInternalToken } from "./auth/internal";
+import { handleRequest } from "./router";
+
+const mockStore = {
+  getSummary: vi.fn(),
+  getTimeseries: vi.fn(),
+  getBreakdown: vi.fn(),
+};
+
+vi.mock("./db/analytics-store", () => ({
+  AnalyticsStore: vi.fn().mockImplementation(() => mockStore),
+}));
+
+describe("analytics router integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("serves analytics routes even when the SCM provider is not github", async () => {
+    mockStore.getSummary.mockResolvedValue({
+      totalSessions: 1,
+      activeUsers: 1,
+      totalCost: 0,
+      avgCost: 0,
+      totalPrs: 0,
+      statusBreakdown: {
+        created: 1,
+        active: 0,
+        completed: 0,
+        failed: 0,
+        archived: 0,
+        cancelled: 0,
+      },
+    });
+
+    const env = {
+      INTERNAL_CALLBACK_SECRET: "test-secret",
+      SCM_PROVIDER: "gitlab",
+      DB: {
+        prepare: vi.fn(),
+        batch: vi.fn(),
+        exec: vi.fn(),
+        dump: vi.fn(),
+      },
+    };
+
+    const token = await generateInternalToken(env.INTERNAL_CALLBACK_SECRET);
+    const response = await handleRequest(
+      new Request("https://test.local/analytics/summary", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }),
+      env as never
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      totalSessions: 1,
+      activeUsers: 1,
+      totalCost: 0,
+      avgCost: 0,
+      totalPrs: 0,
+      statusBreakdown: {
+        created: 1,
+        active: 0,
+        completed: 0,
+        failed: 0,
+        archived: 0,
+        cancelled: 0,
+      },
+    });
+  });
+});

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -55,6 +55,7 @@ import { reposRoutes } from "./routes/repos";
 import { repoImageRoutes } from "./routes/repo-images";
 import { secretsRoutes } from "./routes/secrets";
 import { automationRoutes } from "./routes/automations";
+import { analyticsRoutes } from "./routes/analytics";
 import { webhookRoutes } from "./webhooks";
 
 const logger = createLogger("router");
@@ -241,6 +242,10 @@ function isSandboxAuthRoute(path: string): boolean {
   return SANDBOX_AUTH_ROUTES.some((pattern) => pattern.test(path));
 }
 
+function isScmAgnosticRoute(path: string): boolean {
+  return /^\/analytics\/(summary|timeseries|breakdown)$/.test(path);
+}
+
 function enforceImplementedScmProvider(
   path: string,
   env: Env,
@@ -248,7 +253,7 @@ function enforceImplementedScmProvider(
 ): Response | null {
   try {
     const provider = resolveDeploymentScmProvider(env);
-    if (provider !== "github" && !isPublicRoute(path)) {
+    if (provider !== "github" && !isPublicRoute(path) && !isScmAgnosticRoute(path)) {
       logger.warn("SCM provider not implemented", {
         event: "scm.provider_not_implemented",
         scm_provider: provider,
@@ -529,6 +534,9 @@ const routes: Route[] = [
 
   // Automations
   ...automationRoutes,
+
+  // Analytics
+  ...analyticsRoutes,
 
   // Webhooks (public routes — auth handled per-route)
   ...webhookRoutes,

--- a/packages/control-plane/src/routes/analytics.test.ts
+++ b/packages/control-plane/src/routes/analytics.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { analyticsRoutes } from "./analytics";
+import type { RequestContext } from "./shared";
+import type { Env } from "../types";
+
+const FIXED_NOW = 1_700_000_000_000;
+
+const mockStore = {
+  getSummary: vi.fn(),
+  getTimeseries: vi.fn(),
+  getBreakdown: vi.fn(),
+};
+
+vi.mock("../db/analytics-store", () => ({
+  AnalyticsStore: vi.fn().mockImplementation(() => mockStore),
+}));
+
+function getHandler(method: string, path: string) {
+  const pathname = new URL(`https://test.local${path}`).pathname;
+  for (const route of analyticsRoutes) {
+    if (route.method === method && route.pattern.test(pathname)) {
+      const match = pathname.match(route.pattern)!;
+      return { handler: route.handler, match };
+    }
+  }
+
+  throw new Error(`No route found for ${method} ${path}`);
+}
+
+function createEnv(): Env {
+  return {
+    DB: {} as D1Database,
+  } as Env;
+}
+
+function createCtx(): RequestContext {
+  return {
+    trace_id: "trace-1",
+    request_id: "req-1",
+    metrics: {
+      d1Queries: [],
+      spans: {},
+      time: async <T>(_name: string, fn: () => Promise<T>) => fn(),
+      summarize: () => ({}),
+    },
+  };
+}
+
+async function callRoute(method: string, path: string): Promise<Response> {
+  const { handler, match } = getHandler(method, path);
+  return handler(
+    new Request(`https://test.local${path}`, { method }),
+    createEnv(),
+    match,
+    createCtx()
+  );
+}
+
+describe("analytics route handlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("GET /analytics/summary", () => {
+    it("defaults days to 30", async () => {
+      mockStore.getSummary.mockResolvedValue({
+        totalSessions: 12,
+        activeUsers: 4,
+        totalCost: 1.5,
+        avgCost: 0.125,
+        totalPrs: 2,
+        statusBreakdown: {
+          created: 1,
+          active: 2,
+          completed: 5,
+          failed: 2,
+          archived: 1,
+          cancelled: 1,
+        },
+      });
+
+      const response = await callRoute("GET", "/analytics/summary");
+      expect(response.status).toBe(200);
+      expect(mockStore.getSummary).toHaveBeenCalledWith({
+        startAt: FIXED_NOW - 30 * 24 * 60 * 60 * 1000,
+        endAt: FIXED_NOW,
+      });
+    });
+
+    it("returns 400 for invalid days", async () => {
+      const response = await callRoute("GET", "/analytics/summary?days=31");
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: "days must be one of: 7, 14, 30, 90",
+      });
+      expect(mockStore.getSummary).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("GET /analytics/timeseries", () => {
+    it("passes the requested range to the store", async () => {
+      mockStore.getTimeseries.mockResolvedValue({ series: [] });
+
+      const response = await callRoute("GET", "/analytics/timeseries?days=14");
+      expect(response.status).toBe(200);
+      expect(mockStore.getTimeseries).toHaveBeenCalledWith({
+        startAt: FIXED_NOW - 14 * 24 * 60 * 60 * 1000,
+        endAt: FIXED_NOW,
+      });
+    });
+  });
+
+  describe("GET /analytics/breakdown", () => {
+    it("requires a valid by parameter", async () => {
+      const response = await callRoute("GET", "/analytics/breakdown?days=30");
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: "by must be one of: user, repo",
+      });
+    });
+
+    it("returns 400 for invalid by values", async () => {
+      const response = await callRoute("GET", "/analytics/breakdown?days=30&by=status");
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: "by must be one of: user, repo",
+      });
+      expect(mockStore.getBreakdown).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/control-plane/src/routes/analytics.ts
+++ b/packages/control-plane/src/routes/analytics.ts
@@ -1,0 +1,101 @@
+import {
+  ANALYTICS_BREAKDOWN_BY,
+  ANALYTICS_DAYS,
+  type AnalyticsBreakdownBy,
+  type AnalyticsDays,
+} from "@open-inspect/shared";
+import { AnalyticsStore } from "../db/analytics-store";
+import type { Env } from "../types";
+import { type RequestContext, type Route, error, json, parsePattern } from "./shared";
+
+function parseDaysParam(value: string | null): AnalyticsDays | null {
+  if (value === null) return 30;
+
+  const parsed = Number(value);
+  return ANALYTICS_DAYS.includes(parsed as AnalyticsDays) ? (parsed as AnalyticsDays) : null;
+}
+
+function parseBreakdownBy(value: string | null): AnalyticsBreakdownBy | null {
+  if (!value) return null;
+  return ANALYTICS_BREAKDOWN_BY.includes(value as AnalyticsBreakdownBy)
+    ? (value as AnalyticsBreakdownBy)
+    : null;
+}
+
+function getRange(days: AnalyticsDays): { startAt: number; endAt: number } {
+  const endAt = Date.now();
+  const startAt = endAt - days * 24 * 60 * 60 * 1000;
+  return { startAt, endAt };
+}
+
+async function handleSummary(
+  request: Request,
+  env: Env,
+  _match: RegExpMatchArray,
+  _ctx: RequestContext
+): Promise<Response> {
+  const url = new URL(request.url);
+  const days = parseDaysParam(url.searchParams.get("days"));
+  if (!days) {
+    return error(`days must be one of: ${ANALYTICS_DAYS.join(", ")}`, 400);
+  }
+
+  const store = new AnalyticsStore(env.DB);
+  return json(await store.getSummary(getRange(days)));
+}
+
+async function handleTimeseries(
+  request: Request,
+  env: Env,
+  _match: RegExpMatchArray,
+  _ctx: RequestContext
+): Promise<Response> {
+  const url = new URL(request.url);
+  const days = parseDaysParam(url.searchParams.get("days"));
+  if (!days) {
+    return error(`days must be one of: ${ANALYTICS_DAYS.join(", ")}`, 400);
+  }
+
+  const store = new AnalyticsStore(env.DB);
+  return json(await store.getTimeseries(getRange(days)));
+}
+
+async function handleBreakdown(
+  request: Request,
+  env: Env,
+  _match: RegExpMatchArray,
+  _ctx: RequestContext
+): Promise<Response> {
+  const url = new URL(request.url);
+  const days = parseDaysParam(url.searchParams.get("days"));
+  if (!days) {
+    return error(`days must be one of: ${ANALYTICS_DAYS.join(", ")}`, 400);
+  }
+
+  const byParam = url.searchParams.get("by");
+  const by = parseBreakdownBy(byParam);
+  if (!by) {
+    return error(`by must be one of: ${ANALYTICS_BREAKDOWN_BY.join(", ")}`, 400);
+  }
+
+  const store = new AnalyticsStore(env.DB);
+  return json(await store.getBreakdown(getRange(days), by));
+}
+
+export const analyticsRoutes: Route[] = [
+  {
+    method: "GET",
+    pattern: parsePattern("/analytics/summary"),
+    handler: handleSummary,
+  },
+  {
+    method: "GET",
+    pattern: parsePattern("/analytics/timeseries"),
+    handler: handleTimeseries,
+  },
+  {
+    method: "GET",
+    pattern: parsePattern("/analytics/breakdown"),
+    handler: handleBreakdown,
+  },
+];

--- a/packages/control-plane/test/integration/analytics.test.ts
+++ b/packages/control-plane/test/integration/analytics.test.ts
@@ -1,0 +1,488 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { SELF, env } from "cloudflare:test";
+import type {
+  AnalyticsBreakdownResponse,
+  AnalyticsSummaryResponse,
+  AnalyticsTimeseriesResponse,
+} from "@open-inspect/shared";
+import { generateInternalToken } from "../../src/auth/internal";
+import { SessionIndexStore } from "../../src/db/session-index";
+import { cleanD1Tables } from "./cleanup";
+
+async function authHeaders(): Promise<Record<string, string>> {
+  const token = await generateInternalToken(env.INTERNAL_CALLBACK_SECRET!);
+  return { Authorization: `Bearer ${token}` };
+}
+
+function dateBucket(timestamp: number): string {
+  return new Date(timestamp).toISOString().slice(0, 10);
+}
+
+async function seedSession(
+  store: SessionIndexStore,
+  input: {
+    id: string;
+    repoOwner: string;
+    repoName: string;
+    scmLogin: string | null;
+    status: "created" | "active" | "completed" | "failed" | "archived" | "cancelled";
+    createdAt: number;
+    updatedAt: number;
+    totalCost: number;
+    activeDurationMs: number;
+    messageCount: number;
+    prCount: number;
+  }
+): Promise<void> {
+  await store.create({
+    id: input.id,
+    title: input.id,
+    repoOwner: input.repoOwner,
+    repoName: input.repoName,
+    model: "anthropic/claude-haiku-4-5",
+    reasoningEffort: null,
+    baseBranch: "main",
+    status: input.status,
+    scmLogin: input.scmLogin,
+    createdAt: input.createdAt,
+    updatedAt: input.updatedAt,
+  });
+
+  await store.updateMetrics(input.id, {
+    totalCost: input.totalCost,
+    activeDurationMs: input.activeDurationMs,
+    messageCount: input.messageCount,
+    prCount: input.prCount,
+  });
+}
+
+describe("Analytics API", () => {
+  beforeEach(cleanD1Tables);
+
+  it("returns summary metrics for the requested window", async () => {
+    const store = new SessionIndexStore(env.DB);
+    const now = Date.now();
+
+    await seedSession(store, {
+      id: "session-completed",
+      repoOwner: "acme",
+      repoName: "web-app",
+      scmLogin: "alice",
+      status: "completed",
+      createdAt: now - 2 * 24 * 60 * 60 * 1000,
+      updatedAt: now - 2 * 24 * 60 * 60 * 1000 + 1_000,
+      totalCost: 1.5,
+      activeDurationMs: 600_000,
+      messageCount: 10,
+      prCount: 1,
+    });
+    await seedSession(store, {
+      id: "session-failed",
+      repoOwner: "acme",
+      repoName: "api",
+      scmLogin: "bob",
+      status: "failed",
+      createdAt: now - 2 * 24 * 60 * 60 * 1000 + 60_000,
+      updatedAt: now - 2 * 24 * 60 * 60 * 1000 + 2_000,
+      totalCost: 0.5,
+      activeDurationMs: 300_000,
+      messageCount: 4,
+      prCount: 0,
+    });
+    await seedSession(store, {
+      id: "session-cancelled",
+      repoOwner: "acme",
+      repoName: "web-app",
+      scmLogin: "alice",
+      status: "cancelled",
+      createdAt: now - 24 * 60 * 60 * 1000,
+      updatedAt: now - 24 * 60 * 60 * 1000 + 3_000,
+      totalCost: 0.75,
+      activeDurationMs: 120_000,
+      messageCount: 6,
+      prCount: 1,
+    });
+    await seedSession(store, {
+      id: "session-active",
+      repoOwner: "acme",
+      repoName: "api",
+      scmLogin: null,
+      status: "active",
+      createdAt: now - 24 * 60 * 60 * 1000 + 60_000,
+      updatedAt: now - 24 * 60 * 60 * 1000 + 4_000,
+      totalCost: 0,
+      activeDurationMs: 0,
+      messageCount: 0,
+      prCount: 0,
+    });
+    await seedSession(store, {
+      id: "session-created",
+      repoOwner: "acme",
+      repoName: "web-app",
+      scmLogin: "charlie",
+      status: "created",
+      createdAt: now - 5 * 24 * 60 * 60 * 1000,
+      updatedAt: now - 5 * 24 * 60 * 60 * 1000 + 5_000,
+      totalCost: 0,
+      activeDurationMs: 0,
+      messageCount: 0,
+      prCount: 0,
+    });
+    await seedSession(store, {
+      id: "session-archived",
+      repoOwner: "acme",
+      repoName: "api",
+      scmLogin: "bob",
+      status: "archived",
+      createdAt: now - 3 * 24 * 60 * 60 * 1000,
+      updatedAt: now - 3 * 24 * 60 * 60 * 1000 + 6_000,
+      totalCost: 0.25,
+      activeDurationMs: 50_000,
+      messageCount: 1,
+      prCount: 0,
+    });
+    await seedSession(store, {
+      id: "session-old",
+      repoOwner: "acme",
+      repoName: "legacy",
+      scmLogin: "dora",
+      status: "completed",
+      createdAt: now - 45 * 24 * 60 * 60 * 1000,
+      updatedAt: now - 45 * 24 * 60 * 60 * 1000 + 7_000,
+      totalCost: 9.99,
+      activeDurationMs: 999_000,
+      messageCount: 99,
+      prCount: 9,
+    });
+
+    const response = await SELF.fetch("https://test.local/analytics/summary?days=30", {
+      headers: await authHeaders(),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json<AnalyticsSummaryResponse>();
+
+    expect(body).toEqual({
+      totalSessions: 6,
+      activeUsers: 3,
+      totalCost: 3,
+      avgCost: 0.5,
+      totalPrs: 2,
+      statusBreakdown: {
+        created: 1,
+        active: 1,
+        completed: 1,
+        failed: 1,
+        archived: 1,
+        cancelled: 1,
+      },
+    });
+  });
+
+  it("returns daily timeseries grouped by user", async () => {
+    const store = new SessionIndexStore(env.DB);
+    const now = Date.now();
+
+    const completedAt = now - 2 * 24 * 60 * 60 * 1000;
+    const failedAt = completedAt + 60_000;
+    const cancelledAt = now - 24 * 60 * 60 * 1000;
+    const activeAt = cancelledAt + 60_000;
+
+    await seedSession(store, {
+      id: "user-day-a",
+      repoOwner: "acme",
+      repoName: "web-app",
+      scmLogin: "alice",
+      status: "completed",
+      createdAt: completedAt,
+      updatedAt: completedAt + 1_000,
+      totalCost: 1,
+      activeDurationMs: 100_000,
+      messageCount: 1,
+      prCount: 0,
+    });
+    await seedSession(store, {
+      id: "user-day-b",
+      repoOwner: "acme",
+      repoName: "api",
+      scmLogin: "bob",
+      status: "failed",
+      createdAt: failedAt,
+      updatedAt: failedAt + 1_000,
+      totalCost: 1,
+      activeDurationMs: 100_000,
+      messageCount: 1,
+      prCount: 0,
+    });
+    await seedSession(store, {
+      id: "user-day-c",
+      repoOwner: "acme",
+      repoName: "web-app",
+      scmLogin: "alice",
+      status: "cancelled",
+      createdAt: cancelledAt,
+      updatedAt: cancelledAt + 1_000,
+      totalCost: 1,
+      activeDurationMs: 100_000,
+      messageCount: 1,
+      prCount: 0,
+    });
+    await seedSession(store, {
+      id: "user-day-d",
+      repoOwner: "acme",
+      repoName: "api",
+      scmLogin: null,
+      status: "active",
+      createdAt: activeAt,
+      updatedAt: activeAt + 1_000,
+      totalCost: 0,
+      activeDurationMs: 0,
+      messageCount: 0,
+      prCount: 0,
+    });
+
+    const response = await SELF.fetch("https://test.local/analytics/timeseries?days=7", {
+      headers: await authHeaders(),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json<AnalyticsTimeseriesResponse>();
+
+    expect(body.series).toEqual([
+      {
+        date: dateBucket(completedAt),
+        groups: {
+          alice: 1,
+          bob: 1,
+        },
+      },
+      {
+        date: dateBucket(cancelledAt),
+        groups: {
+          alice: 1,
+          unknown: 1,
+        },
+      },
+    ]);
+  });
+
+  it("returns user breakdowns with unknown users grouped together", async () => {
+    const store = new SessionIndexStore(env.DB);
+    const now = Date.now();
+
+    const aliceCompletedAt = now - 2 * 24 * 60 * 60 * 1000;
+    const aliceCreatedAt = now - 24 * 60 * 60 * 1000;
+    const bobFailedAt = now - 3 * 24 * 60 * 60 * 1000;
+    const unknownActiveAt = now - 4 * 24 * 60 * 60 * 1000;
+
+    await seedSession(store, {
+      id: "user-breakdown-alice-completed",
+      repoOwner: "acme",
+      repoName: "web-app",
+      scmLogin: "alice",
+      status: "completed",
+      createdAt: aliceCompletedAt,
+      updatedAt: aliceCompletedAt + 1_000,
+      totalCost: 1.25,
+      activeDurationMs: 100_000,
+      messageCount: 3,
+      prCount: 1,
+    });
+    await seedSession(store, {
+      id: "user-breakdown-alice-created",
+      repoOwner: "acme",
+      repoName: "api",
+      scmLogin: "alice",
+      status: "created",
+      createdAt: aliceCreatedAt,
+      updatedAt: aliceCreatedAt + 2_000,
+      totalCost: 0,
+      activeDurationMs: 0,
+      messageCount: 0,
+      prCount: 0,
+    });
+    await seedSession(store, {
+      id: "user-breakdown-bob-failed",
+      repoOwner: "acme",
+      repoName: "api",
+      scmLogin: "bob",
+      status: "failed",
+      createdAt: bobFailedAt,
+      updatedAt: bobFailedAt + 3_000,
+      totalCost: 0.75,
+      activeDurationMs: 50_000,
+      messageCount: 2,
+      prCount: 0,
+    });
+    await seedSession(store, {
+      id: "user-breakdown-unknown-active",
+      repoOwner: "acme",
+      repoName: "ops",
+      scmLogin: null,
+      status: "active",
+      createdAt: unknownActiveAt,
+      updatedAt: unknownActiveAt + 4_000,
+      totalCost: 0,
+      activeDurationMs: 0,
+      messageCount: 0,
+      prCount: 0,
+    });
+
+    const response = await SELF.fetch("https://test.local/analytics/breakdown?days=30&by=user", {
+      headers: await authHeaders(),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json<AnalyticsBreakdownResponse>();
+
+    expect(body.entries).toEqual([
+      {
+        key: "alice",
+        sessions: 2,
+        completed: 1,
+        failed: 0,
+        cancelled: 0,
+        cost: 1.25,
+        prs: 1,
+        messageCount: 3,
+        avgDuration: 100_000,
+        lastActive: aliceCreatedAt + 2_000,
+      },
+      {
+        key: "bob",
+        sessions: 1,
+        completed: 0,
+        failed: 1,
+        cancelled: 0,
+        cost: 0.75,
+        prs: 0,
+        messageCount: 2,
+        avgDuration: 50_000,
+        lastActive: bobFailedAt + 3_000,
+      },
+      {
+        key: "unknown",
+        sessions: 1,
+        completed: 0,
+        failed: 0,
+        cancelled: 0,
+        cost: 0,
+        prs: 0,
+        messageCount: 0,
+        avgDuration: 0,
+        lastActive: unknownActiveAt + 4_000,
+      },
+    ]);
+  });
+
+  it("returns repository breakdown with terminal-only avg durations", async () => {
+    const store = new SessionIndexStore(env.DB);
+    const now = Date.now();
+
+    const webCreatedAt = now - 2 * 24 * 60 * 60 * 1000;
+    const webCancelledAt = now - 24 * 60 * 60 * 1000;
+    const webPendingAt = now - 12 * 60 * 60 * 1000;
+    const apiFailedAt = now - 3 * 24 * 60 * 60 * 1000;
+    const apiActiveAt = now - 6 * 60 * 60 * 1000;
+
+    await seedSession(store, {
+      id: "repo-web-completed",
+      repoOwner: "acme",
+      repoName: "web-app",
+      scmLogin: "alice",
+      status: "completed",
+      createdAt: webCreatedAt,
+      updatedAt: webCreatedAt + 5_000,
+      totalCost: 1.5,
+      activeDurationMs: 600_000,
+      messageCount: 10,
+      prCount: 1,
+    });
+    await seedSession(store, {
+      id: "repo-web-cancelled",
+      repoOwner: "acme",
+      repoName: "web-app",
+      scmLogin: "alice",
+      status: "cancelled",
+      createdAt: webCancelledAt,
+      updatedAt: webCancelledAt + 6_000,
+      totalCost: 0.75,
+      activeDurationMs: 120_000,
+      messageCount: 6,
+      prCount: 1,
+    });
+    await seedSession(store, {
+      id: "repo-web-created",
+      repoOwner: "acme",
+      repoName: "web-app",
+      scmLogin: "charlie",
+      status: "created",
+      createdAt: webPendingAt,
+      updatedAt: webPendingAt + 10_000,
+      totalCost: 0,
+      activeDurationMs: 0,
+      messageCount: 0,
+      prCount: 0,
+    });
+    await seedSession(store, {
+      id: "repo-api-failed",
+      repoOwner: "acme",
+      repoName: "api",
+      scmLogin: "bob",
+      status: "failed",
+      createdAt: apiFailedAt,
+      updatedAt: apiFailedAt + 7_000,
+      totalCost: 0.5,
+      activeDurationMs: 300_000,
+      messageCount: 4,
+      prCount: 0,
+    });
+    await seedSession(store, {
+      id: "repo-api-active",
+      repoOwner: "acme",
+      repoName: "api",
+      scmLogin: null,
+      status: "active",
+      createdAt: apiActiveAt,
+      updatedAt: apiActiveAt + 8_000,
+      totalCost: 0,
+      activeDurationMs: 0,
+      messageCount: 0,
+      prCount: 0,
+    });
+
+    const response = await SELF.fetch("https://test.local/analytics/breakdown?days=30&by=repo", {
+      headers: await authHeaders(),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json<AnalyticsBreakdownResponse>();
+
+    expect(body.entries).toEqual([
+      {
+        key: "acme/web-app",
+        sessions: 3,
+        completed: 1,
+        failed: 0,
+        cancelled: 1,
+        cost: 2.25,
+        prs: 2,
+        messageCount: 16,
+        avgDuration: 360_000,
+        lastActive: webPendingAt + 10_000,
+      },
+      {
+        key: "acme/api",
+        sessions: 2,
+        completed: 0,
+        failed: 1,
+        cancelled: 0,
+        cost: 0.5,
+        prs: 0,
+        messageCount: 4,
+        avgDuration: 300_000,
+        lastActive: apiActiveAt + 8_000,
+      },
+    ]);
+  });
+});

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -587,6 +587,58 @@ export interface ChildSessionDetail {
   recentEvents: Array<{ type: string; data: unknown; createdAt: number }>;
 }
 
+// ─── Analytics ───────────────────────────────────────────────────────────────
+
+export const ANALYTICS_DAYS = [7, 14, 30, 90] as const;
+export type AnalyticsDays = (typeof ANALYTICS_DAYS)[number];
+
+export const ANALYTICS_BREAKDOWN_BY = ["user", "repo"] as const;
+export type AnalyticsBreakdownBy = (typeof ANALYTICS_BREAKDOWN_BY)[number];
+
+export interface AnalyticsStatusBreakdown {
+  created: number;
+  active: number;
+  completed: number;
+  failed: number;
+  archived: number;
+  cancelled: number;
+}
+
+export interface AnalyticsSummaryResponse {
+  totalSessions: number;
+  activeUsers: number;
+  totalCost: number;
+  avgCost: number;
+  totalPrs: number;
+  statusBreakdown: AnalyticsStatusBreakdown;
+}
+
+export interface AnalyticsTimeseriesPoint {
+  date: string;
+  groups: Record<string, number>;
+}
+
+export interface AnalyticsTimeseriesResponse {
+  series: AnalyticsTimeseriesPoint[];
+}
+
+export interface AnalyticsBreakdownEntry {
+  key: string;
+  sessions: number;
+  completed: number;
+  failed: number;
+  cancelled: number;
+  cost: number;
+  prs: number;
+  messageCount: number;
+  avgDuration: number;
+  lastActive: number;
+}
+
+export interface AnalyticsBreakdownResponse {
+  entries: AnalyticsBreakdownEntry[];
+}
+
 // ─── Automation Engine ────────────────────────────────────────────────────────
 
 export type AutomationTriggerType =

--- a/packages/web/src/app/api/analytics/breakdown/route.test.ts
+++ b/packages/web/src/app/api/analytics/breakdown/route.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  authOptions: {},
+}));
+
+vi.mock("@/lib/control-plane", () => ({
+  controlPlaneFetch: vi.fn(),
+}));
+
+import { getServerSession } from "next-auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+import { GET } from "./route";
+
+describe("analytics breakdown API route", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns 401 when the user session is missing", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+
+    const response = await GET(
+      new Request("http://localhost/api/analytics/breakdown?days=30&by=user") as never
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("forwards only days and by query params", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(Response.json({ entries: [] }, { status: 200 }));
+
+    const response = await GET(
+      new Request("http://localhost/api/analytics/breakdown?days=90&foo=bar&by=repo") as never
+    );
+
+    expect(controlPlaneFetch).toHaveBeenCalledWith("/analytics/breakdown?days=90&by=repo");
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ entries: [] });
+  });
+
+  it("returns 500 when the control plane request throws", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(controlPlaneFetch).mockRejectedValue(new Error("boom"));
+
+    const response = await GET(new Request("http://localhost/api/analytics/breakdown") as never);
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "Failed to fetch analytics breakdown",
+    });
+  });
+});

--- a/packages/web/src/app/api/analytics/breakdown/route.ts
+++ b/packages/web/src/app/api/analytics/breakdown/route.ts
@@ -1,0 +1,24 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+import { buildAnalyticsBreakdownPath } from "@/lib/analytics-query";
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const path = buildAnalyticsBreakdownPath(new URL(request.url).searchParams);
+
+  try {
+    const response = await controlPlaneFetch(path);
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to fetch analytics breakdown:", error);
+    return NextResponse.json({ error: "Failed to fetch analytics breakdown" }, { status: 500 });
+  }
+}

--- a/packages/web/src/app/api/analytics/summary/route.test.ts
+++ b/packages/web/src/app/api/analytics/summary/route.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  authOptions: {},
+}));
+
+vi.mock("@/lib/control-plane", () => ({
+  controlPlaneFetch: vi.fn(),
+}));
+
+import { getServerSession } from "next-auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+import { GET } from "./route";
+
+describe("analytics summary API route", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns 401 when the user session is missing", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+
+    const response = await GET(
+      new Request("http://localhost/api/analytics/summary?days=14") as never
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(controlPlaneFetch).not.toHaveBeenCalled();
+  });
+
+  it("forwards only the allowed summary query params", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(
+      Response.json({ totalSessions: 5 }, { status: 200 })
+    );
+
+    const response = await GET(
+      new Request("http://localhost/api/analytics/summary?debug=true&days=14") as never
+    );
+
+    expect(controlPlaneFetch).toHaveBeenCalledWith("/analytics/summary?days=14");
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ totalSessions: 5 });
+  });
+
+  it("returns 500 when the control plane request throws", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(controlPlaneFetch).mockRejectedValue(new Error("boom"));
+
+    const response = await GET(new Request("http://localhost/api/analytics/summary") as never);
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "Failed to fetch analytics summary" });
+  });
+});

--- a/packages/web/src/app/api/analytics/summary/route.ts
+++ b/packages/web/src/app/api/analytics/summary/route.ts
@@ -1,0 +1,24 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+import { buildAnalyticsSummaryPath } from "@/lib/analytics-query";
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const path = buildAnalyticsSummaryPath(new URL(request.url).searchParams);
+
+  try {
+    const response = await controlPlaneFetch(path);
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to fetch analytics summary:", error);
+    return NextResponse.json({ error: "Failed to fetch analytics summary" }, { status: 500 });
+  }
+}

--- a/packages/web/src/app/api/analytics/timeseries/route.test.ts
+++ b/packages/web/src/app/api/analytics/timeseries/route.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  authOptions: {},
+}));
+
+vi.mock("@/lib/control-plane", () => ({
+  controlPlaneFetch: vi.fn(),
+}));
+
+import { getServerSession } from "next-auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+import { GET } from "./route";
+
+describe("analytics timeseries API route", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns 401 when the user session is missing", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+
+    const response = await GET(
+      new Request("http://localhost/api/analytics/timeseries?days=30") as never
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+  });
+
+  it("forwards only the days query param", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(Response.json({ series: [] }, { status: 200 }));
+
+    const response = await GET(
+      new Request("http://localhost/api/analytics/timeseries?trace=1&view=status&days=7") as never
+    );
+
+    expect(controlPlaneFetch).toHaveBeenCalledWith("/analytics/timeseries?days=7");
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ series: [] });
+  });
+
+  it("passes through upstream error statuses", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(
+      Response.json({ error: "Bad request" }, { status: 400 })
+    );
+
+    const response = await GET(
+      new Request("http://localhost/api/analytics/timeseries?days=14") as never
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Bad request" });
+  });
+});

--- a/packages/web/src/app/api/analytics/timeseries/route.ts
+++ b/packages/web/src/app/api/analytics/timeseries/route.ts
@@ -1,0 +1,24 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+import { buildAnalyticsTimeseriesPath } from "@/lib/analytics-query";
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const path = buildAnalyticsTimeseriesPath(new URL(request.url).searchParams);
+
+  try {
+    const response = await controlPlaneFetch(path);
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to fetch analytics timeseries:", error);
+    return NextResponse.json({ error: "Failed to fetch analytics timeseries" }, { status: 500 });
+  }
+}

--- a/packages/web/src/lib/analytics-query.test.ts
+++ b/packages/web/src/lib/analytics-query.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAnalyticsBreakdownPath,
+  buildAnalyticsSummaryPath,
+  buildAnalyticsTimeseriesPath,
+} from "./analytics-query";
+
+describe("analytics query helpers", () => {
+  it("forwards only days for summary", () => {
+    const searchParams = new URLSearchParams("days=14&debug=true");
+
+    expect(buildAnalyticsSummaryPath(searchParams)).toBe("/analytics/summary?days=14");
+  });
+
+  it("forwards only days for timeseries", () => {
+    const searchParams = new URLSearchParams("view=status&trace=1&days=30");
+
+    expect(buildAnalyticsTimeseriesPath(searchParams)).toBe("/analytics/timeseries?days=30");
+  });
+
+  it("forwards days and by for breakdown in canonical order", () => {
+    const searchParams = new URLSearchParams("by=repo&days=90&extra=true");
+
+    expect(buildAnalyticsBreakdownPath(searchParams)).toBe("/analytics/breakdown?days=90&by=repo");
+  });
+});

--- a/packages/web/src/lib/analytics-query.ts
+++ b/packages/web/src/lib/analytics-query.ts
@@ -1,0 +1,13 @@
+import { buildControlPlanePath } from "./control-plane-query";
+
+export function buildAnalyticsSummaryPath(searchParams: URLSearchParams): string {
+  return buildControlPlanePath("/analytics/summary", searchParams, ["days"]);
+}
+
+export function buildAnalyticsTimeseriesPath(searchParams: URLSearchParams): string {
+  return buildControlPlanePath("/analytics/timeseries", searchParams, ["days"]);
+}
+
+export function buildAnalyticsBreakdownPath(searchParams: URLSearchParams): string {
+  return buildControlPlanePath("/analytics/breakdown", searchParams, ["days", "by"]);
+}


### PR DESCRIPTION
## What changed
- add shared analytics request/response types for summary, timeseries, and breakdown data
- add a new `AnalyticsStore` in the control plane with D1-backed summary, timeseries, and breakdown queries
- add authenticated control-plane analytics routes and register them in the main router
- add authenticated Next.js proxy routes under `/api/analytics/*`
- add route, router, integration, and web proxy tests for the new analytics endpoints

## Why
Phase 1 added the analytics columns and sync plumbing. This PR implements phase 2 so the web app can fetch usage analytics data from the control plane without exposing D1 directly.

## Notes
- timeseries is user-grouped only; the earlier status-grouped mode was removed
- analytics currently include legacy sessions in-range, so older rows with pre-phase-1 defaults may understate cost, PR, and duration metrics until newer data dominates
- this PR does not add the `/analytics` UI yet; it only exposes the API surface for phase 3

## Validation
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run typecheck -w @open-inspect/web`
- `npm test -w @open-inspect/control-plane -- src/routes/analytics.test.ts src/router.analytics.test.ts`
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/analytics.test.ts`
- `npm test -w @open-inspect/web -- src/lib/analytics-query.test.ts src/app/api/analytics/summary/route.test.ts src/app/api/analytics/timeseries/route.test.ts src/app/api/analytics/breakdown/route.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added analytics API with three endpoints: `/analytics/summary` (aggregated metrics), `/analytics/timeseries` (daily trends by user), and `/analytics/breakdown` (metrics grouped by user or repository). Accessible to authenticated users through the web API.

* **Tests**
  * Added comprehensive test coverage for all analytics endpoints and backend store functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->