### PR TITLE
[feat] Add analytics dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2745,6 +2745,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3475,6 +3476,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3497,6 +3499,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3519,6 +3522,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3535,6 +3539,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3551,6 +3556,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3567,6 +3573,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3583,6 +3590,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3599,6 +3607,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3615,6 +3624,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3631,6 +3641,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3647,6 +3658,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3663,6 +3675,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3679,6 +3692,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3701,6 +3715,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3723,6 +3738,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3745,6 +3761,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3767,6 +3784,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3789,6 +3807,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3811,6 +3830,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3833,6 +3853,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3855,6 +3876,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -3874,6 +3896,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3893,6 +3916,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3912,6 +3936,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -6215,6 +6240,42 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
@@ -7372,7 +7433,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -7561,6 +7627,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -7665,6 +7794,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -9316,6 +9451,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -9444,6 +9700,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
@@ -9954,6 +10216,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -10299,7 +10571,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/execa": {
@@ -11332,6 +11603,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -11395,6 +11676,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -14628,7 +14918,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-markdown": {
@@ -14656,6 +14945,29 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-remove-scroll": {
@@ -14770,6 +15082,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -14782,6 +15124,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -14934,6 +15291,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.5",
@@ -16181,6 +16544,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -16832,6 +17201,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {
@@ -19750,6 +20141,7 @@
         "react-dom": "^19.0.0",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^4.9.0",
+        "recharts": "^3.8.1",
         "rehype-highlight": "^7.0.2",
         "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -44,6 +44,7 @@
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.9.0",
+    "recharts": "^3.8.1",
     "rehype-highlight": "^7.0.2",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",

--- a/packages/web/src/app/(app)/analytics/page.test.tsx
+++ b/packages/web/src/app/(app)/analytics/page.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, within, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import type {
+  AnalyticsBreakdownResponse,
+  AnalyticsSummaryResponse,
+  AnalyticsTimeseriesResponse,
+} from "@open-inspect/shared";
+import AnalyticsPage from "./page";
+
+expect.extend(matchers);
+
+const { mockUseAnalyticsDashboard, mockUseSidebarContext } = vi.hoisted(() => ({
+  mockUseAnalyticsDashboard: vi.fn(),
+  mockUseSidebarContext: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-analytics", () => ({
+  useAnalyticsDashboard: mockUseAnalyticsDashboard,
+}));
+
+vi.mock("@/components/sidebar-layout", () => ({
+  useSidebarContext: mockUseSidebarContext,
+}));
+
+vi.mock("@/components/analytics/summary-cards", () => ({
+  AnalyticsSummaryCards: () => <div data-testid="analytics-summary-cards" />,
+}));
+
+vi.mock("@/components/analytics/timeseries-chart", () => ({
+  AnalyticsTimeseriesChart: () => <div data-testid="analytics-timeseries-chart" />,
+}));
+
+vi.mock("@/components/analytics/repo-bar-chart", () => ({
+  AnalyticsRepoBarChart: () => <div data-testid="analytics-repo-chart" />,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const summary: AnalyticsSummaryResponse = {
+  totalSessions: 13,
+  activeUsers: 3,
+  totalCost: 12.5,
+  avgCost: 0.96,
+  totalPrs: 4,
+  statusBreakdown: {
+    created: 0,
+    active: 1,
+    completed: 10,
+    failed: 1,
+    archived: 0,
+    cancelled: 1,
+  },
+};
+
+const timeseries: AnalyticsTimeseriesResponse = {
+  series: [
+    {
+      date: "2026-04-10",
+      groups: {
+        zoe: 2,
+        anna: 1,
+      },
+    },
+  ],
+};
+
+const repoBreakdown: AnalyticsBreakdownResponse = {
+  entries: [
+    {
+      key: "open-inspect/background-agents",
+      sessions: 8,
+      completed: 7,
+      failed: 1,
+      cancelled: 0,
+      cost: 8.25,
+      prs: 3,
+      messageCount: 42,
+      avgDuration: 120000,
+      lastActive: Date.UTC(2026, 3, 12),
+    },
+  ],
+};
+
+const userBreakdown: AnalyticsBreakdownResponse = {
+  entries: [
+    {
+      key: "zoe",
+      sessions: 8,
+      completed: 7,
+      failed: 1,
+      cancelled: 0,
+      cost: 8.25,
+      prs: 3,
+      messageCount: 42,
+      avgDuration: 120000,
+      lastActive: Date.UTC(2026, 3, 12),
+    },
+    {
+      key: "anna",
+      sessions: 3,
+      completed: 2,
+      failed: 0,
+      cancelled: 1,
+      cost: 2.1,
+      prs: 1,
+      messageCount: 14,
+      avgDuration: 60000,
+      lastActive: Date.UTC(2026, 3, 10),
+    },
+    {
+      key: "mike",
+      sessions: 1,
+      completed: 1,
+      failed: 0,
+      cancelled: 0,
+      cost: 0.4,
+      prs: 0,
+      messageCount: 3,
+      avgDuration: 15000,
+      lastActive: Date.UTC(2026, 3, 9),
+    },
+  ],
+};
+
+function renderPage() {
+  mockUseSidebarContext.mockReturnValue({
+    isOpen: true,
+    toggle: vi.fn(),
+  });
+
+  mockUseAnalyticsDashboard.mockImplementation(() => ({
+    summary,
+    timeseries,
+    repoBreakdown,
+    userBreakdown,
+    loading: false,
+    error: undefined,
+  }));
+
+  return render(<AnalyticsPage />);
+}
+
+function getUserRows() {
+  const rows = within(screen.getByRole("table")).getAllByRole("row");
+  return rows.slice(1);
+}
+
+describe("AnalyticsPage", () => {
+  it("refetches analytics when the selected range changes", async () => {
+    const user = userEvent.setup();
+
+    renderPage();
+
+    expect(mockUseAnalyticsDashboard).toHaveBeenCalledWith(30);
+
+    await user.click(screen.getByRole("radio", { name: "7d" }));
+
+    await waitFor(() => {
+      expect(mockUseAnalyticsDashboard).toHaveBeenLastCalledWith(7);
+    });
+  });
+
+  it("re-sorts the per-user table when a header is clicked", async () => {
+    const user = userEvent.setup();
+
+    renderPage();
+
+    let rows = getUserRows();
+    expect(within(rows[0]).getByText("zoe")).toBeInTheDocument();
+    expect(within(rows[1]).getByText("anna")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /user/i }));
+
+    rows = getUserRows();
+    expect(within(rows[0]).getByText("anna")).toBeInTheDocument();
+    expect(within(rows[1]).getByText("mike")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /user/i }));
+
+    rows = getUserRows();
+    expect(within(rows[0]).getByText("zoe")).toBeInTheDocument();
+    expect(within(rows[1]).getByText("mike")).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/app/(app)/analytics/page.test.tsx
+++ b/packages/web/src/app/(app)/analytics/page.test.tsx
@@ -189,4 +189,28 @@ describe("AnalyticsPage", () => {
     expect(within(rows[0]).getByText("zoe")).toBeInTheDocument();
     expect(within(rows[1]).getByText("mike")).toBeInTheDocument();
   });
+
+  it("shows the alert without rendering widgets when loading fails with no cached data", () => {
+    mockUseSidebarContext.mockReturnValue({
+      isOpen: true,
+      toggle: vi.fn(),
+    });
+
+    mockUseAnalyticsDashboard.mockImplementation(() => ({
+      summary: undefined,
+      timeseries: undefined,
+      repoBreakdown: undefined,
+      userBreakdown: undefined,
+      loading: false,
+      error: new Error("request failed"),
+    }));
+
+    render(<AnalyticsPage />);
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.queryByTestId("analytics-summary-cards")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("analytics-timeseries-chart")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("analytics-repo-chart")).not.toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
 });

--- a/packages/web/src/app/(app)/analytics/page.tsx
+++ b/packages/web/src/app/(app)/analytics/page.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { AnalyticsDays } from "@open-inspect/shared";
+import { AnalyticsRepoBarChart } from "@/components/analytics/repo-bar-chart";
+import { AnalyticsSummaryCards } from "@/components/analytics/summary-cards";
+import { AnalyticsTimeseriesChart } from "@/components/analytics/timeseries-chart";
+import { AnalyticsUserTable } from "@/components/analytics/user-table";
+import { useSidebarContext } from "@/components/sidebar-layout";
+import { Badge } from "@/components/ui/badge";
+import { SidebarIcon } from "@/components/ui/icons";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { useAnalyticsDashboard } from "@/hooks/use-analytics";
+import {
+  ANALYTICS_DAYS,
+  ANALYTICS_RANGE_LABELS,
+  formatAnalyticsCount,
+  sortAnalyticsUserEntries,
+  type AnalyticsSortDirection,
+  type AnalyticsUserSortKey,
+} from "@/lib/analytics";
+import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
+
+export default function AnalyticsPage() {
+  const { isOpen, toggle } = useSidebarContext();
+  const [days, setDays] = useState<AnalyticsDays>(30);
+  const [sortKey, setSortKey] = useState<AnalyticsUserSortKey>("sessions");
+  const [sortDirection, setSortDirection] = useState<AnalyticsSortDirection>("desc");
+  const { summary, timeseries, repoBreakdown, userBreakdown, loading, error } =
+    useAnalyticsDashboard(days);
+
+  const sortedUserEntries = useMemo(
+    () =>
+      userBreakdown
+        ? sortAnalyticsUserEntries(userBreakdown.entries, sortKey, sortDirection)
+        : undefined,
+    [sortDirection, sortKey, userBreakdown?.entries]
+  );
+
+  function handleSort(nextKey: AnalyticsUserSortKey) {
+    if (nextKey === sortKey) {
+      setSortDirection((current) => (current === "desc" ? "asc" : "desc"));
+      return;
+    }
+
+    setSortKey(nextKey);
+    setSortDirection(nextKey === "user" ? "asc" : "desc");
+  }
+
+  return (
+    <div className="relative h-full flex flex-col overflow-hidden">
+      <div className="pointer-events-none absolute -right-20 top-8 h-56 w-56 rounded-full bg-accent-muted blur-3xl" />
+      <div className="pointer-events-none absolute left-20 top-40 h-40 w-40 rounded-full bg-muted blur-3xl" />
+
+      {!isOpen && (
+        <header className="border-b border-border-muted flex-shrink-0">
+          <div className="px-4 py-3">
+            <button
+              onClick={toggle}
+              className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition"
+              title={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
+              aria-label={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
+            >
+              <SidebarIcon className="w-4 h-4" />
+            </button>
+          </div>
+        </header>
+      )}
+
+      <div className="flex-1 overflow-y-auto p-6 sm:p-8">
+        <div className="relative z-10 mx-auto max-w-7xl space-y-6">
+          <div className="relative overflow-hidden rounded-xl border border-border-muted bg-card px-5 py-5 sm:px-6 sm:py-6">
+            <div className="pointer-events-none absolute inset-y-0 right-0 w-1/3 bg-[linear-gradient(135deg,var(--accent-muted),transparent)] opacity-70" />
+
+            <div className="relative flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
+              <div className="space-y-3">
+                <div className="inline-flex items-center gap-2 rounded-full border border-border-muted bg-background px-3 py-1 text-xs uppercase tracking-[0.16em] text-secondary-foreground">
+                  Usage analytics
+                </div>
+                <div>
+                  <h1 className="text-3xl font-semibold text-foreground">Analytics</h1>
+                  <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
+                    Usage metrics across sessions, repositories, and users. PR counts currently
+                    reflect pull requests created through the platform&apos;s built-in flow, and
+                    legacy sessions may show zero cost, PR, or duration values.
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Badge variant="info">Refreshes every 30s</Badge>
+                  <Badge variant="default">Includes legacy sessions</Badge>
+                  {summary ? (
+                    <Badge variant="pr-open">
+                      {formatAnalyticsCount(summary.totalSessions)} sessions in range
+                    </Badge>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="min-w-0 xl:w-[18rem]">
+                <div className="rounded-lg border border-border-muted bg-background p-4">
+                  <div className="text-xs uppercase tracking-[0.16em] text-secondary-foreground">
+                    Time range
+                  </div>
+                  <div className="mt-3">
+                    <ToggleGroup
+                      type="single"
+                      value={String(days)}
+                      onValueChange={(value) => {
+                        if (!value) return;
+                        setDays(Number(value) as AnalyticsDays);
+                      }}
+                      variant="outline"
+                      size="sm"
+                      className="grid grid-cols-4 gap-1 rounded-md bg-card p-1"
+                    >
+                      {ANALYTICS_DAYS.map((range) => (
+                        <ToggleGroupItem
+                          key={range}
+                          value={String(range)}
+                          aria-label={ANALYTICS_RANGE_LABELS[range]}
+                        >
+                          {ANALYTICS_RANGE_LABELS[range]}
+                        </ToggleGroupItem>
+                      ))}
+                    </ToggleGroup>
+                  </div>
+                  <div className="mt-3 text-xs leading-5 text-muted-foreground">
+                    All charts and tables re-filter instantly when the selected range changes.
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {error ? (
+            <div
+              role="alert"
+              className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-950/30 dark:text-red-300"
+            >
+              Analytics failed to load. The page will retry automatically, or you can refresh.
+            </div>
+          ) : null}
+
+          <AnalyticsSummaryCards days={days} summary={summary} loading={loading} />
+
+          <div className="grid gap-6 xl:grid-cols-[minmax(0,1.6fr)_minmax(320px,1fr)]">
+            <AnalyticsTimeseriesChart series={timeseries?.series} loading={loading} />
+            <AnalyticsRepoBarChart entries={repoBreakdown?.entries} loading={loading} />
+          </div>
+
+          <AnalyticsUserTable
+            entries={sortedUserEntries}
+            loading={loading}
+            sortKey={sortKey}
+            sortDirection={sortDirection}
+            onSort={handleSort}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/app/(app)/analytics/page.tsx
+++ b/packages/web/src/app/(app)/analytics/page.tsx
@@ -13,6 +13,7 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { useAnalyticsDashboard } from "@/hooks/use-analytics";
 import {
   ANALYTICS_DAYS,
+  ANALYTICS_REFRESH_INTERVAL_MS,
   ANALYTICS_RANGE_LABELS,
   formatAnalyticsCount,
   sortAnalyticsUserEntries,
@@ -28,13 +29,11 @@ export default function AnalyticsPage() {
   const [sortDirection, setSortDirection] = useState<AnalyticsSortDirection>("desc");
   const { summary, timeseries, repoBreakdown, userBreakdown, loading, error } =
     useAnalyticsDashboard(days);
+  const userEntries = userBreakdown?.entries;
 
   const sortedUserEntries = useMemo(
-    () =>
-      userBreakdown
-        ? sortAnalyticsUserEntries(userBreakdown.entries, sortKey, sortDirection)
-        : undefined,
-    [sortDirection, sortKey, userBreakdown?.entries]
+    () => (userEntries ? sortAnalyticsUserEntries(userEntries, sortKey, sortDirection) : undefined),
+    [sortDirection, sortKey, userEntries]
   );
 
   function handleSort(nextKey: AnalyticsUserSortKey) {
@@ -86,7 +85,9 @@ export default function AnalyticsPage() {
                   </p>
                 </div>
                 <div className="flex flex-wrap gap-2">
-                  <Badge variant="info">Refreshes every 30s</Badge>
+                  <Badge variant="info">
+                    Refreshes every {ANALYTICS_REFRESH_INTERVAL_MS / 1000}s
+                  </Badge>
                   <Badge variant="default">Includes legacy sessions</Badge>
                   {summary ? (
                     <Badge variant="pr-open">

--- a/packages/web/src/app/(app)/analytics/page.tsx
+++ b/packages/web/src/app/(app)/analytics/page.tsx
@@ -35,6 +35,12 @@ export default function AnalyticsPage() {
     () => (userEntries ? sortAnalyticsUserEntries(userEntries, sortKey, sortDirection) : undefined),
     [sortDirection, sortKey, userEntries]
   );
+  const hasCachedData = Boolean(
+    summary ||
+    timeseries?.series?.length ||
+    repoBreakdown?.entries?.length ||
+    sortedUserEntries?.length
+  );
 
   function handleSort(nextKey: AnalyticsUserSortKey) {
     if (nextKey === sortKey) {
@@ -142,20 +148,24 @@ export default function AnalyticsPage() {
             </div>
           ) : null}
 
-          <AnalyticsSummaryCards days={days} summary={summary} loading={loading} />
+          {!error || hasCachedData ? (
+            <>
+              <AnalyticsSummaryCards days={days} summary={summary} loading={loading} />
 
-          <div className="grid gap-6 xl:grid-cols-[minmax(0,1.6fr)_minmax(320px,1fr)]">
-            <AnalyticsTimeseriesChart series={timeseries?.series} loading={loading} />
-            <AnalyticsRepoBarChart entries={repoBreakdown?.entries} loading={loading} />
-          </div>
+              <div className="grid gap-6 xl:grid-cols-[minmax(0,1.6fr)_minmax(320px,1fr)]">
+                <AnalyticsTimeseriesChart series={timeseries?.series} loading={loading} />
+                <AnalyticsRepoBarChart entries={repoBreakdown?.entries} loading={loading} />
+              </div>
 
-          <AnalyticsUserTable
-            entries={sortedUserEntries}
-            loading={loading}
-            sortKey={sortKey}
-            sortDirection={sortDirection}
-            onSort={handleSort}
-          />
+              <AnalyticsUserTable
+                entries={sortedUserEntries}
+                loading={loading}
+                sortKey={sortKey}
+                sortDirection={sortDirection}
+                onSort={handleSort}
+              />
+            </>
+          ) : null}
         </div>
       </div>
     </div>

--- a/packages/web/src/components/analytics/repo-bar-chart.tsx
+++ b/packages/web/src/components/analytics/repo-bar-chart.tsx
@@ -74,7 +74,10 @@ export function AnalyticsRepoBarChart({ entries, loading }: RepoBarChartProps) {
   }
 
   const chartHeight = Math.max(260, entries.length * 44);
-  const leadRepo = entries[0];
+  const leadRepo = entries.reduce(
+    (top, entry) => (entry.sessions > top.sessions ? entry : top),
+    entries[0]
+  );
   const chartData = entries.map((entry) => ({
     repo: entry.key,
     sessions: entry.sessions,

--- a/packages/web/src/components/analytics/repo-bar-chart.tsx
+++ b/packages/web/src/components/analytics/repo-bar-chart.tsx
@@ -1,0 +1,156 @@
+import type { TooltipContentProps } from "recharts";
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import type { AnalyticsBreakdownResponse } from "@open-inspect/shared";
+import { formatAnalyticsCount } from "@/lib/analytics";
+import { formatSessionCost } from "@/lib/session-cost";
+
+interface RepoBarChartProps {
+  entries?: AnalyticsBreakdownResponse["entries"];
+  loading: boolean;
+}
+
+interface RepoChartRow {
+  repo: string;
+  sessions: number;
+  cost: number;
+  prs: number;
+  messageCount: number;
+}
+
+function RepoChartTooltip({ active, payload }: TooltipContentProps) {
+  const row = payload?.[0]?.payload as RepoChartRow | undefined;
+
+  if (!active || !row) {
+    return null;
+  }
+
+  return (
+    <div className="min-w-[13rem] rounded-md border border-border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-md">
+      <div className="font-medium text-foreground">{row.repo}</div>
+      <div className="mt-2 grid gap-1.5">
+        <div className="flex items-center justify-between gap-4">
+          <span className="text-muted-foreground">Sessions</span>
+          <span className="font-medium text-foreground">{formatAnalyticsCount(row.sessions)}</span>
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <span className="text-muted-foreground">Cost</span>
+          <span className="font-medium text-foreground">{formatSessionCost(row.cost)}</span>
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <span className="text-muted-foreground">PRs</span>
+          <span className="font-medium text-foreground">{formatAnalyticsCount(row.prs)}</span>
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <span className="text-muted-foreground">Messages</span>
+          <span className="font-medium text-foreground">
+            {formatAnalyticsCount(row.messageCount)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AnalyticsRepoBarChart({ entries, loading }: RepoBarChartProps) {
+  if (loading && !entries) {
+    return (
+      <div className="rounded-md border border-border-muted bg-card p-5 animate-pulse">
+        <div className="h-4 w-44 rounded bg-muted" />
+        <div className="mt-2 h-4 w-64 rounded bg-muted" />
+        <div className="mt-6 h-[320px] rounded bg-muted" />
+      </div>
+    );
+  }
+
+  if (!entries?.length) {
+    return (
+      <div className="rounded-md border border-border-muted bg-card p-5">
+        <div className="text-lg font-semibold text-foreground">Sessions by Repository</div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          No repository data found for this range.
+        </p>
+      </div>
+    );
+  }
+
+  const chartHeight = Math.max(260, entries.length * 44);
+  const leadRepo = entries[0];
+  const chartData = entries.map((entry) => ({
+    repo: entry.key,
+    sessions: entry.sessions,
+    cost: entry.cost,
+    prs: entry.prs,
+    messageCount: entry.messageCount,
+  }));
+
+  return (
+    <div className="rounded-md border border-border-muted bg-card p-5">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">Sessions by Repository</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Horizontal distribution of session volume across repositories.
+          </p>
+        </div>
+        <div className="grid gap-2 sm:min-w-[15rem] sm:grid-cols-2">
+          <div className="rounded-md border border-border-muted bg-background px-3 py-3">
+            <div className="text-[11px] uppercase tracking-[0.14em] text-secondary-foreground">
+              Tracked repos
+            </div>
+            <div className="mt-2 text-lg font-semibold text-foreground">
+              {formatAnalyticsCount(entries.length)}
+            </div>
+          </div>
+          <div className="rounded-md border border-border-muted bg-background px-3 py-3">
+            <div className="text-[11px] uppercase tracking-[0.14em] text-secondary-foreground">
+              Top repo
+            </div>
+            <div className="mt-2 truncate text-sm font-semibold text-foreground">
+              {leadRepo.key}
+            </div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              {formatAnalyticsCount(leadRepo.sessions)} sessions
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-6 max-h-[420px] overflow-y-auto rounded-lg border border-border-muted bg-background p-3 pr-2 sm:p-4">
+        <div style={{ height: chartHeight }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={chartData}
+              layout="vertical"
+              margin={{ top: 8, right: 12, left: 12, bottom: 0 }}
+            >
+              <CartesianGrid stroke="var(--border)" horizontal={false} />
+              <XAxis
+                type="number"
+                allowDecimals={false}
+                axisLine={false}
+                tickLine={false}
+                tick={{ fill: "var(--muted-foreground)", fontSize: 12 }}
+              />
+              <YAxis
+                type="category"
+                dataKey="repo"
+                width={180}
+                axisLine={false}
+                tickLine={false}
+                tick={{ fill: "var(--foreground)", fontSize: 12 }}
+              />
+              <Tooltip
+                cursor={{ fill: "var(--accent-muted)" }}
+                content={(props) => <RepoChartTooltip {...props} />}
+              />
+              <Bar dataKey="sessions" fill="var(--accent)" radius={[0, 4, 4, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+      <div className="mt-3 text-xs text-muted-foreground">
+        The bars reflect session volume, and hover details include cost, PR totals, and messages.
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/analytics/summary-cards.tsx
+++ b/packages/web/src/components/analytics/summary-cards.tsx
@@ -1,0 +1,123 @@
+import type { AnalyticsDays, AnalyticsSummaryResponse } from "@open-inspect/shared";
+import { formatSessionCost } from "@/lib/session-cost";
+import { formatAnalyticsCount } from "@/lib/analytics";
+
+interface SummaryCardsProps {
+  days: AnalyticsDays;
+  summary?: AnalyticsSummaryResponse;
+  loading: boolean;
+}
+
+function SummaryCard({ label, value, hint }: { label: string; value: string; hint: string }) {
+  return (
+    <div className="relative overflow-hidden rounded-md border border-border-muted bg-card p-4">
+      <div className="absolute inset-x-0 top-0 h-px bg-[linear-gradient(90deg,transparent,var(--accent),transparent)]" />
+      <div className="text-xs uppercase tracking-[0.16em] text-secondary-foreground">{label}</div>
+      <div className="mt-3 text-2xl font-semibold text-foreground">{value}</div>
+      <div className="mt-2 text-sm text-muted-foreground">{hint}</div>
+    </div>
+  );
+}
+
+export function AnalyticsSummaryCards({ days, summary, loading }: SummaryCardsProps) {
+  if (loading && !summary) {
+    return (
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+        {Array.from({ length: 5 }).map((_, index) => (
+          <div
+            key={index}
+            className="rounded-md border border-border-muted bg-card p-4 animate-pulse"
+          >
+            <div className="h-3 w-24 rounded bg-muted" />
+            <div className="mt-4 h-7 w-20 rounded bg-muted" />
+            <div className="mt-3 h-4 w-32 rounded bg-muted" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (!summary) return null;
+
+  const statusTiles = [
+    ["completed", summary.statusBreakdown.completed, "bg-success"],
+    ["active", summary.statusBreakdown.active, "bg-blue-500"],
+    ["created", summary.statusBreakdown.created, "bg-secondary-foreground"],
+    ["failed", summary.statusBreakdown.failed, "bg-red-600"],
+    ["cancelled", summary.statusBreakdown.cancelled, "bg-red-400"],
+    ["archived", summary.statusBreakdown.archived, "bg-muted-foreground"],
+  ] as const;
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+        <SummaryCard
+          label="Total Sessions"
+          value={formatAnalyticsCount(summary.totalSessions)}
+          hint={`Across the last ${days} days`}
+        />
+        <SummaryCard
+          label="Active Users"
+          value={formatAnalyticsCount(summary.activeUsers)}
+          hint="Distinct SCM logins"
+        />
+        <SummaryCard
+          label="Total Cost"
+          value={formatSessionCost(summary.totalCost)}
+          hint="Summed across sessions"
+        />
+        <SummaryCard
+          label="Avg Cost / Session"
+          value={formatSessionCost(summary.avgCost)}
+          hint="Average per session"
+        />
+        <SummaryCard
+          label="PRs Created"
+          value={formatAnalyticsCount(summary.totalPrs)}
+          hint="Platform-tracked PR artifacts"
+        />
+      </div>
+
+      <div className="rounded-md border border-border-muted bg-card px-4 py-3">
+        <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <div className="text-xs uppercase tracking-[0.16em] text-secondary-foreground">
+              Status Mix
+            </div>
+            <div className="mt-1 text-sm text-muted-foreground">
+              Session states within the selected window.
+            </div>
+          </div>
+        </div>
+        <div className="mt-4 grid gap-2 sm:grid-cols-2 xl:grid-cols-6">
+          {statusTiles.map(([label, count, barClass]) => {
+            const width =
+              summary.totalSessions > 0
+                ? Math.max((count / summary.totalSessions) * 100, count > 0 ? 8 : 0)
+                : 0;
+
+            return (
+              <div
+                key={label}
+                className="rounded-md border border-border-muted bg-background px-3 py-3"
+              >
+                <div className="text-[11px] uppercase tracking-[0.14em] text-secondary-foreground">
+                  {label}
+                </div>
+                <div className="mt-2 text-lg font-semibold text-foreground">
+                  {formatAnalyticsCount(count)}
+                </div>
+                <div className="mt-3 h-1.5 rounded-full bg-muted">
+                  <div
+                    className={`h-full rounded-full ${barClass}`}
+                    style={{ width: `${width}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/analytics/timeseries-chart.tsx
+++ b/packages/web/src/components/analytics/timeseries-chart.tsx
@@ -1,3 +1,4 @@
+import { useId } from "react";
 import {
   Area,
   AreaChart,
@@ -34,6 +35,8 @@ const SERIES_COLORS = [
 ];
 
 export function AnalyticsTimeseriesChart({ series, loading }: TimeseriesChartProps) {
+  const chartIdPrefix = useId().replace(/[^a-zA-Z0-9_-]/g, "");
+
   if (loading && !series) {
     return (
       <div className="rounded-md border border-border-muted bg-card p-5 animate-pulse">
@@ -56,6 +59,11 @@ export function AnalyticsTimeseriesChart({ series, loading }: TimeseriesChartPro
   const { data, groupKeys } = buildTimeseriesChartData(series);
   const previewGroups = groupKeys.slice(0, 5);
   const hiddenGroups = Math.max(groupKeys.length - previewGroups.length, 0);
+
+  function getGradientId(groupKey: string, index: number) {
+    const safeKey = groupKey.replace(/[^a-zA-Z0-9_-]/g, "-");
+    return `${chartIdPrefix}-analytics-series-${index}-${safeKey}`;
+  }
 
   return (
     <div className="rounded-md border border-border-muted bg-card p-5">
@@ -81,15 +89,9 @@ export function AnalyticsTimeseriesChart({ series, loading }: TimeseriesChartPro
               <defs>
                 {groupKeys.map((groupKey, index) => {
                   const color = SERIES_COLORS[index % SERIES_COLORS.length];
+                  const gradientId = getGradientId(groupKey, index);
                   return (
-                    <linearGradient
-                      key={groupKey}
-                      id={`analytics-series-${groupKey}`}
-                      x1="0"
-                      y1="0"
-                      x2="0"
-                      y2="1"
-                    >
+                    <linearGradient key={groupKey} id={gradientId} x1="0" y1="0" x2="0" y2="1">
                       <stop offset="5%" stopColor={color} stopOpacity={0.32} />
                       <stop offset="95%" stopColor={color} stopOpacity={0.06} />
                     </linearGradient>
@@ -127,6 +129,7 @@ export function AnalyticsTimeseriesChart({ series, loading }: TimeseriesChartPro
               />
               {groupKeys.map((groupKey, index) => {
                 const color = SERIES_COLORS[index % SERIES_COLORS.length];
+                const gradientId = getGradientId(groupKey, index);
                 return (
                   <Area
                     key={groupKey}
@@ -134,7 +137,7 @@ export function AnalyticsTimeseriesChart({ series, loading }: TimeseriesChartPro
                     dataKey={groupKey}
                     stackId="sessions"
                     stroke={color}
-                    fill={`url(#analytics-series-${groupKey})`}
+                    fill={`url(#${gradientId})`}
                     strokeWidth={2}
                     dot={false}
                     activeDot={{ r: 3 }}

--- a/packages/web/src/components/analytics/timeseries-chart.tsx
+++ b/packages/web/src/components/analytics/timeseries-chart.tsx
@@ -1,0 +1,153 @@
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { AnalyticsTimeseriesResponse } from "@open-inspect/shared";
+import { Badge } from "@/components/ui/badge";
+import {
+  buildTimeseriesChartData,
+  formatAnalyticsCount,
+  formatAnalyticsLongDate,
+} from "@/lib/analytics";
+
+interface TimeseriesChartProps {
+  series?: AnalyticsTimeseriesResponse["series"];
+  loading: boolean;
+}
+
+const SERIES_COLORS = [
+  "var(--accent)",
+  "#28c840",
+  "#3b82f6",
+  "#c08429",
+  "#ef4444",
+  "#0f766e",
+  "#8b5cf6",
+  "#ea580c",
+  "#14b8a6",
+  "#e11d48",
+];
+
+export function AnalyticsTimeseriesChart({ series, loading }: TimeseriesChartProps) {
+  if (loading && !series) {
+    return (
+      <div className="rounded-md border border-border-muted bg-card p-5 animate-pulse">
+        <div className="h-4 w-40 rounded bg-muted" />
+        <div className="mt-2 h-4 w-72 rounded bg-muted" />
+        <div className="mt-6 h-[320px] rounded bg-muted" />
+      </div>
+    );
+  }
+
+  if (!series?.length) {
+    return (
+      <div className="rounded-md border border-border-muted bg-card p-5">
+        <div className="text-lg font-semibold text-foreground">Sessions Over Time</div>
+        <p className="mt-1 text-sm text-muted-foreground">No sessions found for this range.</p>
+      </div>
+    );
+  }
+
+  const { data, groupKeys } = buildTimeseriesChartData(series);
+  const previewGroups = groupKeys.slice(0, 5);
+  const hiddenGroups = Math.max(groupKeys.length - previewGroups.length, 0);
+
+  return (
+    <div className="rounded-md border border-border-muted bg-card p-5">
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">Sessions Over Time</h2>
+          <p className="text-sm text-muted-foreground">Daily session counts stacked by user.</p>
+        </div>
+        <div className="flex flex-wrap gap-2 pt-2 sm:justify-end">
+          {previewGroups.map((groupKey) => (
+            <Badge key={groupKey} variant="default">
+              {groupKey}
+            </Badge>
+          ))}
+          {hiddenGroups > 0 ? <Badge variant="pr-draft">+{hiddenGroups} more</Badge> : null}
+        </div>
+      </div>
+
+      <div className="mt-6 rounded-lg border border-border-muted bg-background p-3 sm:p-4">
+        <div className="h-[320px]">
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart data={data} margin={{ top: 8, right: 12, left: 0, bottom: 0 }}>
+              <defs>
+                {groupKeys.map((groupKey, index) => {
+                  const color = SERIES_COLORS[index % SERIES_COLORS.length];
+                  return (
+                    <linearGradient
+                      key={groupKey}
+                      id={`analytics-series-${groupKey}`}
+                      x1="0"
+                      y1="0"
+                      x2="0"
+                      y2="1"
+                    >
+                      <stop offset="5%" stopColor={color} stopOpacity={0.32} />
+                      <stop offset="95%" stopColor={color} stopOpacity={0.06} />
+                    </linearGradient>
+                  );
+                })}
+              </defs>
+              <CartesianGrid stroke="var(--border)" vertical={false} />
+              <XAxis
+                dataKey="label"
+                axisLine={false}
+                tickLine={false}
+                tick={{ fill: "var(--muted-foreground)", fontSize: 12 }}
+              />
+              <YAxis
+                allowDecimals={false}
+                axisLine={false}
+                tickLine={false}
+                tick={{ fill: "var(--muted-foreground)", fontSize: 12 }}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: "var(--popover)",
+                  border: "1px solid var(--border)",
+                  borderRadius: "6px",
+                  color: "var(--popover-foreground)",
+                }}
+                labelFormatter={(_, payload) => {
+                  const rowDate = payload?.[0]?.payload?.date;
+                  return typeof rowDate === "string" ? formatAnalyticsLongDate(rowDate) : "";
+                }}
+                formatter={(value, name) => {
+                  const count = typeof value === "number" ? value : Number(value ?? 0);
+                  return [formatAnalyticsCount(count), String(name)];
+                }}
+              />
+              {groupKeys.map((groupKey, index) => {
+                const color = SERIES_COLORS[index % SERIES_COLORS.length];
+                return (
+                  <Area
+                    key={groupKey}
+                    type="monotone"
+                    dataKey={groupKey}
+                    stackId="sessions"
+                    stroke={color}
+                    fill={`url(#analytics-series-${groupKey})`}
+                    strokeWidth={2}
+                    dot={false}
+                    activeDot={{ r: 3 }}
+                  />
+                );
+              })}
+            </AreaChart>
+          </ResponsiveContainer>
+        </div>
+      </div>
+      <div className="mt-3 text-xs text-muted-foreground">
+        Hover the chart to inspect stacked daily counts for each user.
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/analytics/user-table.test.tsx
+++ b/packages/web/src/components/analytics/user-table.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { AnalyticsUserTable } from "./user-table";
+
+expect.extend(matchers);
+
+describe("AnalyticsUserTable", () => {
+  it("uses the real completion rate for the progress bar width", () => {
+    const { container } = render(
+      <AnalyticsUserTable
+        entries={[
+          {
+            key: "zoe",
+            sessions: 20,
+            completed: 1,
+            failed: 8,
+            cancelled: 1,
+            cost: 3.5,
+            prs: 1,
+            messageCount: 12,
+            avgDuration: 90_000,
+            lastActive: Date.UTC(2026, 3, 12),
+          },
+        ]}
+        loading={false}
+        sortKey="completionRate"
+        sortDirection="desc"
+        onSort={() => {}}
+      />
+    );
+
+    expect(screen.getByText("10%")).toBeInTheDocument();
+    const progressBar = container.querySelector(".bg-accent");
+    expect(progressBar).toHaveStyle({ width: "10%" });
+  });
+});

--- a/packages/web/src/components/analytics/user-table.tsx
+++ b/packages/web/src/components/analytics/user-table.tsx
@@ -1,0 +1,277 @@
+import type { AnalyticsBreakdownEntry, AnalyticsBreakdownResponse } from "@open-inspect/shared";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ChevronDownIcon, ChevronUpIcon } from "@/components/ui/icons";
+import {
+  formatAnalyticsCount,
+  formatAnalyticsDuration,
+  formatCompletionRate,
+  getCompletionRate,
+  type AnalyticsSortDirection,
+  type AnalyticsUserSortKey,
+} from "@/lib/analytics";
+import { cn } from "@/lib/utils";
+import { formatSessionCost } from "@/lib/session-cost";
+import { formatRelativeTime } from "@/lib/time";
+
+interface UserTableProps {
+  entries?: AnalyticsBreakdownResponse["entries"];
+  loading: boolean;
+  sortKey: AnalyticsUserSortKey;
+  sortDirection: AnalyticsSortDirection;
+  onSort: (key: AnalyticsUserSortKey) => void;
+}
+
+function SortButton({
+  label,
+  sortKey,
+  activeKey,
+  direction,
+  onClick,
+  align = "left",
+}: {
+  label: string;
+  sortKey: AnalyticsUserSortKey;
+  activeKey: AnalyticsUserSortKey;
+  direction: AnalyticsSortDirection;
+  onClick: (key: AnalyticsUserSortKey) => void;
+  align?: "left" | "right";
+}) {
+  const isActive = activeKey === sortKey;
+  const Icon = direction === "asc" ? ChevronUpIcon : ChevronDownIcon;
+
+  return (
+    <Button
+      variant="ghost"
+      size="xs"
+      className={align === "right" ? "ml-auto" : "-ml-2"}
+      onClick={() => onClick(sortKey)}
+    >
+      <span className="inline-flex items-center gap-1">
+        {label}
+        {isActive ? <Icon className="h-3 w-3" /> : null}
+      </span>
+    </Button>
+  );
+}
+
+function UserCell({ entry }: { entry: AnalyticsBreakdownEntry }) {
+  const isUnknown = entry.key === "unknown";
+  const label = isUnknown ? "Unknown user" : entry.key;
+  const initial = label[0]?.toUpperCase() ?? "?";
+
+  return (
+    <div className="flex items-center gap-3">
+      <div
+        className={cn(
+          "flex h-8 w-8 items-center justify-center rounded-full border text-xs font-semibold",
+          isUnknown
+            ? "border-border-muted bg-muted text-muted-foreground"
+            : "border-border-muted bg-accent-muted text-foreground"
+        )}
+      >
+        {initial}
+      </div>
+      <div className="min-w-0">
+        <div className="truncate font-medium text-foreground">{label}</div>
+        <div className="text-xs text-muted-foreground">
+          {isUnknown ? "Sessions without SCM login" : "Tracked user activity"}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SessionsCell({ entry }: { entry: AnalyticsBreakdownEntry }) {
+  return (
+    <div className="min-w-[11rem]">
+      <div className="font-medium text-foreground">{formatAnalyticsCount(entry.sessions)}</div>
+      <div className="mt-2 flex flex-wrap gap-1">
+        <Badge variant="pr-merged">{formatAnalyticsCount(entry.completed)} completed</Badge>
+        {entry.failed > 0 ? (
+          <Badge variant="pr-closed">{formatAnalyticsCount(entry.failed)} failed</Badge>
+        ) : null}
+        {entry.cancelled > 0 ? (
+          <Badge variant="pr-draft">{formatAnalyticsCount(entry.cancelled)} cancelled</Badge>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function CompletionRateCell({ entry }: { entry: AnalyticsBreakdownEntry }) {
+  const ratio = getCompletionRate(entry);
+  const width = ratio > 0 ? Math.max(Math.round(ratio * 100), 10) : 0;
+
+  return (
+    <div className="ml-auto flex w-24 flex-col items-end">
+      <span className="text-foreground">{formatCompletionRate(entry)}</span>
+      <div className="mt-2 h-1.5 w-full rounded-full bg-muted">
+        <div className="h-full rounded-full bg-accent" style={{ width: `${width}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export function AnalyticsUserTable({
+  entries,
+  loading,
+  sortKey,
+  sortDirection,
+  onSort,
+}: UserTableProps) {
+  if (loading && !entries) {
+    return (
+      <div className="rounded-md border border-border-muted bg-card p-5 animate-pulse">
+        <div className="h-4 w-36 rounded bg-muted" />
+        <div className="mt-2 h-4 w-64 rounded bg-muted" />
+        <div className="mt-6 h-56 rounded bg-muted" />
+      </div>
+    );
+  }
+
+  if (!entries?.length) {
+    return (
+      <div className="rounded-md border border-border-muted bg-card p-5">
+        <div className="text-lg font-semibold text-foreground">Per-User Breakdown</div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          No user analytics found for this range.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-md border border-border-muted bg-card">
+      <div className="border-b border-border-muted px-5 py-4">
+        <h2 className="text-lg font-semibold text-foreground">Per-User Breakdown</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Sortable usage metrics without ranking or gamification.
+        </p>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full border-collapse text-sm">
+          <thead className="bg-card">
+            <tr className="border-b border-border-muted text-left text-secondary-foreground">
+              <th className="px-5 py-3">
+                <SortButton
+                  label="User"
+                  sortKey="user"
+                  activeKey={sortKey}
+                  direction={sortDirection}
+                  onClick={onSort}
+                />
+              </th>
+              <th className="px-5 py-3">
+                <SortButton
+                  label="Sessions"
+                  sortKey="sessions"
+                  activeKey={sortKey}
+                  direction={sortDirection}
+                  onClick={onSort}
+                />
+              </th>
+              <th className="px-5 py-3 text-right">
+                <SortButton
+                  label="Completion Rate"
+                  sortKey="completionRate"
+                  activeKey={sortKey}
+                  direction={sortDirection}
+                  onClick={onSort}
+                  align="right"
+                />
+              </th>
+              <th className="px-5 py-3 text-right">
+                <SortButton
+                  label="PRs"
+                  sortKey="prs"
+                  activeKey={sortKey}
+                  direction={sortDirection}
+                  onClick={onSort}
+                  align="right"
+                />
+              </th>
+              <th className="px-5 py-3 text-right">
+                <SortButton
+                  label="Messages"
+                  sortKey="messageCount"
+                  activeKey={sortKey}
+                  direction={sortDirection}
+                  onClick={onSort}
+                  align="right"
+                />
+              </th>
+              <th className="px-5 py-3 text-right">
+                <SortButton
+                  label="Total Cost"
+                  sortKey="cost"
+                  activeKey={sortKey}
+                  direction={sortDirection}
+                  onClick={onSort}
+                  align="right"
+                />
+              </th>
+              <th className="px-5 py-3 text-right">
+                <SortButton
+                  label="Avg Duration"
+                  sortKey="avgDuration"
+                  activeKey={sortKey}
+                  direction={sortDirection}
+                  onClick={onSort}
+                  align="right"
+                />
+              </th>
+              <th className="px-5 py-3 text-right">
+                <SortButton
+                  label="Last Active"
+                  sortKey="lastActive"
+                  activeKey={sortKey}
+                  direction={sortDirection}
+                  onClick={onSort}
+                  align="right"
+                />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((entry) => (
+              <tr
+                key={entry.key}
+                className="border-b border-border-muted last:border-b-0 hover:bg-muted/50"
+              >
+                <td className="px-5 py-4">
+                  <UserCell entry={entry} />
+                </td>
+                <td className="px-5 py-4">
+                  <SessionsCell entry={entry} />
+                </td>
+                <td className="px-5 py-4 text-right">
+                  <CompletionRateCell entry={entry} />
+                </td>
+                <td className="px-5 py-4 text-right text-foreground">
+                  {formatAnalyticsCount(entry.prs)}
+                </td>
+                <td className="px-5 py-4 text-right text-foreground">
+                  {formatAnalyticsCount(entry.messageCount)}
+                </td>
+                <td className="px-5 py-4 text-right text-foreground">
+                  {formatSessionCost(entry.cost)}
+                </td>
+                <td className="px-5 py-4 text-right text-foreground">
+                  {entry.avgDuration > 0 ? formatAnalyticsDuration(entry.avgDuration) : "—"}
+                </td>
+                <td className="px-5 py-4 text-right text-muted-foreground">
+                  {formatRelativeTime(entry.lastActive)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="border-t border-border-muted px-5 py-3 text-xs text-muted-foreground">
+        Click any column heading to change the sort order.
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/analytics/user-table.tsx
+++ b/packages/web/src/components/analytics/user-table.tsx
@@ -120,6 +120,14 @@ export function AnalyticsUserTable({
   sortDirection,
   onSort,
 }: UserTableProps) {
+  function getAriaSort(column: AnalyticsUserSortKey): "ascending" | "descending" | "none" {
+    if (sortKey !== column) {
+      return "none";
+    }
+
+    return sortDirection === "asc" ? "ascending" : "descending";
+  }
+
   if (loading && !entries) {
     return (
       <div className="rounded-md border border-border-muted bg-card p-5 animate-pulse">
@@ -154,7 +162,7 @@ export function AnalyticsUserTable({
         <table className="min-w-full border-collapse text-sm">
           <thead className="bg-card">
             <tr className="border-b border-border-muted text-left text-secondary-foreground">
-              <th className="px-5 py-3">
+              <th className="px-5 py-3" aria-sort={getAriaSort("user")}>
                 <SortButton
                   label="User"
                   sortKey="user"
@@ -163,7 +171,7 @@ export function AnalyticsUserTable({
                   onClick={onSort}
                 />
               </th>
-              <th className="px-5 py-3">
+              <th className="px-5 py-3" aria-sort={getAriaSort("sessions")}>
                 <SortButton
                   label="Sessions"
                   sortKey="sessions"
@@ -172,7 +180,7 @@ export function AnalyticsUserTable({
                   onClick={onSort}
                 />
               </th>
-              <th className="px-5 py-3 text-right">
+              <th className="px-5 py-3 text-right" aria-sort={getAriaSort("completionRate")}>
                 <SortButton
                   label="Completion Rate"
                   sortKey="completionRate"
@@ -182,7 +190,7 @@ export function AnalyticsUserTable({
                   align="right"
                 />
               </th>
-              <th className="px-5 py-3 text-right">
+              <th className="px-5 py-3 text-right" aria-sort={getAriaSort("prs")}>
                 <SortButton
                   label="PRs"
                   sortKey="prs"
@@ -192,7 +200,7 @@ export function AnalyticsUserTable({
                   align="right"
                 />
               </th>
-              <th className="px-5 py-3 text-right">
+              <th className="px-5 py-3 text-right" aria-sort={getAriaSort("messageCount")}>
                 <SortButton
                   label="Messages"
                   sortKey="messageCount"
@@ -202,7 +210,7 @@ export function AnalyticsUserTable({
                   align="right"
                 />
               </th>
-              <th className="px-5 py-3 text-right">
+              <th className="px-5 py-3 text-right" aria-sort={getAriaSort("cost")}>
                 <SortButton
                   label="Total Cost"
                   sortKey="cost"
@@ -212,7 +220,7 @@ export function AnalyticsUserTable({
                   align="right"
                 />
               </th>
-              <th className="px-5 py-3 text-right">
+              <th className="px-5 py-3 text-right" aria-sort={getAriaSort("avgDuration")}>
                 <SortButton
                   label="Avg Duration"
                   sortKey="avgDuration"
@@ -222,7 +230,7 @@ export function AnalyticsUserTable({
                   align="right"
                 />
               </th>
-              <th className="px-5 py-3 text-right">
+              <th className="px-5 py-3 text-right" aria-sort={getAriaSort("lastActive")}>
                 <SortButton
                   label="Last Active"
                   sortKey="lastActive"

--- a/packages/web/src/components/analytics/user-table.tsx
+++ b/packages/web/src/components/analytics/user-table.tsx
@@ -101,7 +101,7 @@ function SessionsCell({ entry }: { entry: AnalyticsBreakdownEntry }) {
 
 function CompletionRateCell({ entry }: { entry: AnalyticsBreakdownEntry }) {
   const ratio = getCompletionRate(entry);
-  const width = ratio > 0 ? Math.max(Math.round(ratio * 100), 10) : 0;
+  const width = Math.min(100, Math.max(0, Math.round(ratio * 100)));
 
   return (
     <div className="ml-auto flex w-24 flex-col items-end">

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -22,6 +22,7 @@ import {
   SettingsIcon,
   AutomationsIcon,
   BranchIcon,
+  DataControlsIcon,
 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -271,6 +272,17 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
         >
           <AutomationsIcon className="w-4 h-4" />
           Automations
+        </Link>
+        <Link
+          href="/analytics"
+          className={`flex items-center gap-2 px-3 py-1.5 text-sm rounded-md transition ${
+            pathname?.startsWith("/analytics")
+              ? "text-foreground bg-muted"
+              : "text-muted-foreground hover:text-foreground hover:bg-muted"
+          }`}
+        >
+          <DataControlsIcon className="w-4 h-4" />
+          Analytics
         </Link>
       </div>
 

--- a/packages/web/src/hooks/use-analytics.ts
+++ b/packages/web/src/hooks/use-analytics.ts
@@ -1,0 +1,47 @@
+import { useSession } from "next-auth/react";
+import useSWR from "swr";
+import type {
+  AnalyticsBreakdownResponse,
+  AnalyticsDays,
+  AnalyticsSummaryResponse,
+  AnalyticsTimeseriesResponse,
+} from "@open-inspect/shared";
+import { ANALYTICS_REFRESH_INTERVAL_MS } from "@/lib/analytics";
+
+export function useAnalyticsDashboard(days: AnalyticsDays) {
+  const { data: session } = useSession();
+  const refreshInterval = ANALYTICS_REFRESH_INTERVAL_MS;
+
+  const summary = useSWR<AnalyticsSummaryResponse>(
+    session ? `/api/analytics/summary?days=${days}` : null,
+    { refreshInterval }
+  );
+
+  const timeseries = useSWR<AnalyticsTimeseriesResponse>(
+    session ? `/api/analytics/timeseries?days=${days}` : null,
+    { refreshInterval }
+  );
+
+  const repos = useSWR<AnalyticsBreakdownResponse>(
+    session ? `/api/analytics/breakdown?days=${days}&by=repo` : null,
+    { refreshInterval }
+  );
+
+  const users = useSWR<AnalyticsBreakdownResponse>(
+    session ? `/api/analytics/breakdown?days=${days}&by=user` : null,
+    { refreshInterval }
+  );
+
+  return {
+    summary: summary.data,
+    timeseries: timeseries.data,
+    repoBreakdown: repos.data,
+    userBreakdown: users.data,
+    loading:
+      (!summary.data && summary.isLoading) ||
+      (!timeseries.data && timeseries.isLoading) ||
+      (!repos.data && repos.isLoading) ||
+      (!users.data && users.isLoading),
+    error: summary.error ?? timeseries.error ?? repos.error ?? users.error,
+  };
+}

--- a/packages/web/src/lib/analytics.test.ts
+++ b/packages/web/src/lib/analytics.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   buildTimeseriesChartData,
+  formatAnalyticsDate,
   formatAnalyticsDuration,
+  formatAnalyticsLongDate,
   formatCompletionRate,
   sortAnalyticsUserEntries,
 } from "./analytics";
@@ -88,5 +90,10 @@ describe("analytics utilities", () => {
     expect(formatAnalyticsDuration(4_000)).toBe("4s");
     expect(formatAnalyticsDuration(125_000)).toBe("2m 5s");
     expect(formatAnalyticsDuration(3_900_000)).toBe("1h 5m");
+  });
+
+  it("falls back to the raw value for invalid analytics dates", () => {
+    expect(formatAnalyticsDate("not-a-date")).toBe("not-a-date");
+    expect(formatAnalyticsLongDate("not-a-date")).toBe("not-a-date");
   });
 });

--- a/packages/web/src/lib/analytics.test.ts
+++ b/packages/web/src/lib/analytics.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTimeseriesChartData,
+  formatAnalyticsDuration,
+  formatCompletionRate,
+  sortAnalyticsUserEntries,
+} from "./analytics";
+
+describe("analytics utilities", () => {
+  it("builds chart data with zero-filled group values", () => {
+    const result = buildTimeseriesChartData([
+      { date: "2026-04-10", groups: { alice: 2, bob: 1 } },
+      { date: "2026-04-11", groups: { alice: 1, charlie: 3 } },
+    ]);
+
+    expect(result.groupKeys).toEqual(["alice", "charlie", "bob"]);
+    expect(result.data).toEqual([
+      {
+        date: "2026-04-10",
+        label: "Apr 10",
+        alice: 2,
+        charlie: 0,
+        bob: 1,
+      },
+      {
+        date: "2026-04-11",
+        label: "Apr 11",
+        alice: 1,
+        charlie: 3,
+        bob: 0,
+      },
+    ]);
+  });
+
+  it("formats completion rate from terminal sessions only", () => {
+    expect(
+      formatCompletionRate({
+        key: "alice",
+        sessions: 7,
+        completed: 3,
+        failed: 1,
+        cancelled: 2,
+        cost: 1.5,
+        prs: 1,
+        messageCount: 10,
+        avgDuration: 15_000,
+        lastActive: 100,
+      })
+    ).toBe("50%");
+  });
+
+  it("sorts user entries by completion rate descending", () => {
+    const result = sortAnalyticsUserEntries(
+      [
+        {
+          key: "alice",
+          sessions: 4,
+          completed: 3,
+          failed: 1,
+          cancelled: 0,
+          cost: 0,
+          prs: 0,
+          messageCount: 0,
+          avgDuration: 0,
+          lastActive: 1,
+        },
+        {
+          key: "bob",
+          sessions: 3,
+          completed: 1,
+          failed: 1,
+          cancelled: 1,
+          cost: 0,
+          prs: 0,
+          messageCount: 0,
+          avgDuration: 0,
+          lastActive: 2,
+        },
+      ],
+      "completionRate",
+      "desc"
+    );
+
+    expect(result.map((entry) => entry.key)).toEqual(["alice", "bob"]);
+  });
+
+  it("formats durations compactly", () => {
+    expect(formatAnalyticsDuration(4_000)).toBe("4s");
+    expect(formatAnalyticsDuration(125_000)).toBe("2m 5s");
+    expect(formatAnalyticsDuration(3_900_000)).toBe("1h 5m");
+  });
+});

--- a/packages/web/src/lib/analytics.ts
+++ b/packages/web/src/lib/analytics.ts
@@ -41,8 +41,9 @@ const LONG_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
 
 const INTEGER_FORMATTER = new Intl.NumberFormat("en-US");
 
-function parseAnalyticsDate(value: string): Date {
-  return new Date(`${value}T00:00:00Z`);
+function parseAnalyticsDate(value: string): Date | null {
+  const date = new Date(`${value}T00:00:00Z`);
+  return Number.isNaN(date.getTime()) ? null : date;
 }
 
 export function formatAnalyticsCount(value: number): string {
@@ -50,11 +51,13 @@ export function formatAnalyticsCount(value: number): string {
 }
 
 export function formatAnalyticsDate(value: string): string {
-  return SHORT_DATE_FORMATTER.format(parseAnalyticsDate(value));
+  const parsed = parseAnalyticsDate(value);
+  return parsed ? SHORT_DATE_FORMATTER.format(parsed) : value;
 }
 
 export function formatAnalyticsLongDate(value: string): string {
-  return LONG_DATE_FORMATTER.format(parseAnalyticsDate(value));
+  const parsed = parseAnalyticsDate(value);
+  return parsed ? LONG_DATE_FORMATTER.format(parsed) : value;
 }
 
 export function formatAnalyticsDuration(durationMs: number): string {

--- a/packages/web/src/lib/analytics.ts
+++ b/packages/web/src/lib/analytics.ts
@@ -1,0 +1,159 @@
+import type {
+  AnalyticsBreakdownEntry,
+  AnalyticsDays,
+  AnalyticsTimeseriesResponse,
+} from "@open-inspect/shared";
+
+export const ANALYTICS_REFRESH_INTERVAL_MS = 30_000;
+export const ANALYTICS_DAYS: AnalyticsDays[] = [7, 14, 30, 90];
+
+export const ANALYTICS_RANGE_LABELS: Record<AnalyticsDays, string> = {
+  7: "7d",
+  14: "14d",
+  30: "30d",
+  90: "90d",
+};
+
+export type AnalyticsUserSortKey =
+  | "user"
+  | "sessions"
+  | "completionRate"
+  | "prs"
+  | "messageCount"
+  | "cost"
+  | "avgDuration"
+  | "lastActive";
+
+export type AnalyticsSortDirection = "asc" | "desc";
+
+const SHORT_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  timeZone: "UTC",
+});
+
+const LONG_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  timeZone: "UTC",
+});
+
+const INTEGER_FORMATTER = new Intl.NumberFormat("en-US");
+
+function parseAnalyticsDate(value: string): Date {
+  return new Date(`${value}T00:00:00Z`);
+}
+
+export function formatAnalyticsCount(value: number): string {
+  return INTEGER_FORMATTER.format(value);
+}
+
+export function formatAnalyticsDate(value: string): string {
+  return SHORT_DATE_FORMATTER.format(parseAnalyticsDate(value));
+}
+
+export function formatAnalyticsLongDate(value: string): string {
+  return LONG_DATE_FORMATTER.format(parseAnalyticsDate(value));
+}
+
+export function formatAnalyticsDuration(durationMs: number): string {
+  const totalSeconds = Math.max(0, Math.round(durationMs / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  if (minutes > 0) {
+    return seconds > 0 && minutes < 5 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  }
+  return `${seconds}s`;
+}
+
+export function getCompletionRate(entry: AnalyticsBreakdownEntry): number {
+  const terminalSessions = entry.completed + entry.failed + entry.cancelled;
+  return terminalSessions > 0 ? entry.completed / terminalSessions : 0;
+}
+
+export function formatCompletionRate(entry: AnalyticsBreakdownEntry): string {
+  return `${Math.round(getCompletionRate(entry) * 100)}%`;
+}
+
+export function buildTimeseriesChartData(series: AnalyticsTimeseriesResponse["series"]): {
+  data: Array<Record<string, number | string>>;
+  groupKeys: string[];
+} {
+  const totals = new Map<string, number>();
+
+  for (const point of series) {
+    for (const [groupKey, count] of Object.entries(point.groups)) {
+      totals.set(groupKey, (totals.get(groupKey) ?? 0) + count);
+    }
+  }
+
+  const groupKeys = Array.from(totals.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([groupKey]) => groupKey);
+
+  const data = series.map((point) => {
+    const row: Record<string, number | string> = {
+      date: point.date,
+      label: formatAnalyticsDate(point.date),
+    };
+
+    for (const groupKey of groupKeys) {
+      row[groupKey] = point.groups[groupKey] ?? 0;
+    }
+
+    return row;
+  });
+
+  return { data, groupKeys };
+}
+
+export function sortAnalyticsUserEntries(
+  entries: AnalyticsBreakdownEntry[],
+  sortKey: AnalyticsUserSortKey,
+  direction: AnalyticsSortDirection
+): AnalyticsBreakdownEntry[] {
+  const multiplier = direction === "asc" ? 1 : -1;
+
+  return [...entries].sort((left, right) => {
+    let comparison = 0;
+
+    switch (sortKey) {
+      case "user":
+        comparison = left.key.localeCompare(right.key);
+        break;
+      case "completionRate":
+        comparison = getCompletionRate(left) - getCompletionRate(right);
+        break;
+      case "sessions":
+        comparison = left.sessions - right.sessions;
+        break;
+      case "prs":
+        comparison = left.prs - right.prs;
+        break;
+      case "messageCount":
+        comparison = left.messageCount - right.messageCount;
+        break;
+      case "cost":
+        comparison = left.cost - right.cost;
+        break;
+      case "avgDuration":
+        comparison = left.avgDuration - right.avgDuration;
+        break;
+      case "lastActive":
+        comparison = left.lastActive - right.lastActive;
+        break;
+    }
+
+    if (comparison === 0) {
+      return left.key.localeCompare(right.key);
+    }
+
+    return comparison * multiplier;
+  });
+}


### PR DESCRIPTION
## What changed
- add a new `/analytics` page with a 7d/14d/30d/90d range selector and 30s SWR refresh
- render analytics summary cards, a user-stacked sessions-over-time area chart, a repository bar chart, and a sortable per-user table
- add a shared web analytics hook and client-side formatting/sorting helpers for dashboard data
- add the `/analytics` entry to the app sidebar navigation
- add `recharts` for the dashboard visualizations
- add a focused jsdom test for range switching and table sorting
- address review follow-ups by making the repo chart tooltip show cost/PR/message details and by clarifying that the dashboard includes legacy sessions

## Why
Phase 2 exposed the analytics API. This PR implements phase 3 so users can actually inspect usage trends, repository activity, and per-user breakdowns from the web app.

## Notes
- repository visualization ships as a horizontal bar chart to handle long `owner/repo` labels more clearly than a donut
- PR metrics still reflect the platform's built-in PR creation flow only
- legacy sessions are included in-range, so older rows may still show zero-valued cost, PR, or duration fields

## Validation
- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/web`
- `npm test -w @open-inspect/web -- 'src/app/(app)/analytics/page.test.tsx' 'src/lib/analytics.test.ts' 'src/lib/analytics-query.test.ts' 'src/app/api/analytics/summary/route.test.ts' 'src/app/api/analytics/timeseries/route.test.ts' 'src/app/api/analytics/breakdown/route.test.ts'`
- `npm run build -w @open-inspect/web`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an analytics dashboard: time-range selector, summary metrics, sessions timeseries, repository breakdown, and a sortable per-user table.

* **Dependencies**
  * Added Recharts for chart visualizations.

* **Tests**
  * New tests for the analytics page, charts, table, and utility functions to validate sorting, formatting, and error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->