### PR TITLE
fix: prevent zombie WebSocket re-adoption after sandbox termination

### DIFF
--- a/packages/control-plane/src/session/websocket-manager.test.ts
+++ b/packages/control-plane/src/session/websocket-manager.test.ts
@@ -340,6 +340,47 @@ describe("SessionWebSocketManagerImpl", () => {
 
       expect(manager.getSandboxSocket()).toBeNull();
     });
+
+    it("returns null and closes zombie WS when sandbox status is stopped", () => {
+      const { manager, sockets, mockRepo } = createManager();
+      const ws = createFakeWebSocket();
+
+      // Simulate: sandbox was stopped (inactivity timeout) but WS close handshake
+      // didn't complete before hibernation, so the WS still appears OPEN.
+      sockets.set(ws, ["sandbox", "sid:sb-1"]);
+      const row = createSandboxRow("sb-1");
+      row.status = "stopped";
+      mockRepo.setSandbox(row);
+
+      expect(manager.getSandboxSocket()).toBeNull();
+      expect(ws.close).toHaveBeenCalledWith(1000, "Sandbox terminated");
+    });
+
+    it("returns null and closes zombie WS when sandbox status is stale", () => {
+      const { manager, sockets, mockRepo } = createManager();
+      const ws = createFakeWebSocket();
+
+      sockets.set(ws, ["sandbox", "sid:sb-1"]);
+      const row = createSandboxRow("sb-1");
+      row.status = "stale";
+      mockRepo.setSandbox(row);
+
+      expect(manager.getSandboxSocket()).toBeNull();
+      expect(ws.close).toHaveBeenCalledWith(1000, "Sandbox terminated");
+    });
+
+    it("returns null and closes zombie WS when sandbox status is failed", () => {
+      const { manager, sockets, mockRepo } = createManager();
+      const ws = createFakeWebSocket();
+
+      sockets.set(ws, ["sandbox", "sid:sb-1"]);
+      const row = createSandboxRow("sb-1");
+      row.status = "failed";
+      mockRepo.setSandbox(row);
+
+      expect(manager.getSandboxSocket()).toBeNull();
+      expect(ws.close).toHaveBeenCalledWith(1000, "Sandbox terminated");
+    });
   });
 
   describe("clearSandboxSocket", () => {

--- a/packages/control-plane/src/session/websocket-manager.ts
+++ b/packages/control-plane/src/session/websocket-manager.ts
@@ -153,6 +153,22 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
     const sandbox = this.repository.getSandbox();
     const expectedSandboxId = sandbox?.modal_sandbox_id;
 
+    // If the sandbox is in a terminal state, don't re-adopt stale WebSockets.
+    // After inactivity timeout or heartbeat stale, the DO closes the WS and sets
+    // status to stopped/stale, but the close handshake may not complete before
+    // hibernation. On wake, the zombie WS still appears OPEN — skip it.
+    const terminalStatuses = ["stopped", "failed", "stale"];
+    if (sandbox && terminalStatuses.includes(sandbox.status)) {
+      // Close any lingering sandbox WebSockets so they don't persist
+      for (const ws of this.ctx.getWebSockets()) {
+        const parsed = this.classify(ws);
+        if (parsed.kind === "sandbox") {
+          this.close(ws, 1000, "Sandbox terminated");
+        }
+      }
+      return null;
+    }
+
     for (const ws of this.ctx.getWebSockets()) {
       const parsed = this.classify(ws);
       if (parsed.kind !== "sandbox" || ws.readyState !== WebSocket.OPEN) continue;


### PR DESCRIPTION
## Summary

- Fixes a bug where the Durable Object re-adopts a stale sandbox WebSocket after waking from hibernation, even though the sandbox has already been terminated.
- After an inactivity timeout (or heartbeat stale), the DO sets sandbox status to `stopped` and initiates a WebSocket close. But if the bridge process exits before the close handshake completes, the zombie WebSocket persists across hibernation with `readyState === OPEN`. On the next wake, `getSandboxSocket()` re-adopts it, causing prompts to be dispatched to a dead sandbox where they hang indefinitely.
- Adds a terminal-status guard to `getSandboxSocket()` hibernation recovery: when status is `stopped`, `failed`, or `stale`, zombie WebSockets are closed and `null` is returned. Subsequent prompts then follow the normal `spawnSandbox()` → `evaluateSpawnDecision()` → `restore` path.

## Test plan

- [x] 3 new unit tests covering stopped, stale, and failed sandbox status scenarios
- [x] All 965 existing control-plane tests pass
- [x] Typecheck passes across all packages
- [ ] Deploy and verify: after inactivity timeout + user reconnect, a follow-up prompt triggers a restore from snapshot instead of hanging on a dead WebSocket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where inactive sandbox connections could persist and be reused inappropriately. Connections are now properly terminated when sandboxes are stopped, stale, or in a failed state.

* **Tests**
  * Added unit tests to verify proper connection recovery handling for inactive sandboxes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->