### PR TITLE
fix: declare plugin deps in .opencode/package.json to avoid npm reify

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -305,10 +305,15 @@ class SandboxSupervisor:
             except Exception as e:
                 self.log.warn("opencode.symlink_error", exc=e)
 
-        # Minimal package.json
+        # List dependencies in package.json so OpenCode sees them as declared.
+        # The node_modules symlink already points to the global install, so npm
+        # finds them satisfied without a network fetch.
         package_json = opencode_dir / "package.json"
         if not package_json.exists():
-            package_json.write_text('{"name": "opencode-tools", "type": "module"}')
+            package_json.write_text(
+                '{"name": "opencode-tools", "type": "module",'
+                ' "dependencies": {"@opencode-ai/plugin": "*", "zod": "*"}}'
+            )
 
     def _install_bin_scripts(self) -> None:
         """Install standalone CLI scripts into /usr/local/bin.


### PR DESCRIPTION
## Summary

- Adds `@opencode-ai/plugin` and `zod` as dependencies in the `package.json` that `_install_tools()` writes to `.opencode/`.

## Why

On first boot from a repo image, OpenCode runs `npm reify` during session creation when it discovers `@opencode-ai/plugin` is imported by tools but not declared in `package.json`. The `node_modules` symlink to global modules is already in place, but without the dep in `package.json`, OpenCode treats it as undeclared and reifies anyway.

The reify duration varies between 2-22s depending on npm registry latency. When slow, it can exceed the bridge's HTTP request timeout for the `POST /session` call to OpenCode, causing the first prompt to fail with `outcome=failure` before the agent does any work. Subsequent prompts succeed because the reify result is cached in the snapshot.

With the deps declared in `package.json`, npm sees them as already satisfied via the symlink and skips the reify entirely.

## Test plan

- [x] Python syntax and ruff lint pass
- [ ] Deploy and verify first-boot session creation no longer logs `node_modules missing, reifying` or `dependency not in lock file, reifying`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox environment now includes enhanced plugin and validation support, expanding available development tools and capabilities for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->