### PR TITLE
fix: ship codex auth plugin as JavaScript

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -548,11 +548,11 @@ class SandboxSupervisor:
 
         # Deploy codex auth proxy plugin if OpenAI OAuth is configured
         opencode_dir = workdir / ".opencode"
-        plugin_source = Path("/app/sandbox_runtime/plugins/codex-auth-plugin.ts")
+        plugin_source = Path("/app/sandbox_runtime/plugins/codex-auth-plugin.js")
         if plugin_source.exists() and os.environ.get("OPENAI_OAUTH_REFRESH_TOKEN"):
             plugin_dir = opencode_dir / "plugins"
             plugin_dir.mkdir(parents=True, exist_ok=True)
-            shutil.copy(plugin_source, plugin_dir / "codex-auth-plugin.ts")
+            shutil.copy(plugin_source, plugin_dir / "codex-auth-plugin.js")
             self.log.info("openai_oauth.plugin_deployed")
 
         env = {

--- a/packages/sandbox-runtime/src/sandbox_runtime/plugins/codex-auth-plugin.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/plugins/codex-auth-plugin.js
@@ -6,10 +6,9 @@
  * refresh tokens are persisted centrally in D1 rather than being lost when
  * ephemeral sandboxes terminate.
  *
- * Auto-loaded from .opencode/plugins/ — OpenCode discovers project plugins
+ * Auto-loaded from .opencode/plugins/ - OpenCode discovers project plugins
  * and deduplicates by provider ID (last wins), so this replaces the built-in.
  */
-import type { Plugin } from "@opencode-ai/plugin";
 
 const CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses";
 const OAUTH_DUMMY_KEY = "opencode-oauth-dummy-key";
@@ -26,12 +25,12 @@ const ALLOWED_MODELS = new Set([
   "gpt-5.1-codex",
 ]);
 
-// In-memory token cache (reset on sandbox restart — fresh refresh via bridge)
-let cachedAccessToken: string | null = null;
-let cachedAccountId: string | null = null;
+// In-memory token cache (reset on sandbox restart - fresh refresh via bridge)
+let cachedAccessToken = null;
+let cachedAccountId = null;
 let cachedExpiresAt = 0;
 
-function getSessionId(): string {
+function getSessionId() {
   try {
     const config = JSON.parse(process.env.SESSION_CONFIG || "{}");
     return config.sessionId || config.session_id || "";
@@ -40,11 +39,7 @@ function getSessionId(): string {
   }
 }
 
-async function refreshViaControlPlane(): Promise<{
-  access_token: string;
-  expires_in?: number;
-  account_id?: string;
-}> {
+async function refreshViaControlPlane() {
   const controlPlaneUrl = process.env.CONTROL_PLANE_URL;
   const authToken = process.env.SANDBOX_AUTH_TOKEN;
   const sessionId = getSessionId();
@@ -77,18 +72,7 @@ async function refreshViaControlPlane(): Promise<{
   return response.json();
 }
 
-interface OpenAIAuthState {
-  type: string;
-  refresh: string;
-  access: string;
-  expires: number;
-  accountId?: string;
-}
-
-async function ensureAccessToken(
-  getAuth: () => Promise<OpenAIAuthState>,
-  setAuth: (body: OpenAIAuthState) => Promise<void>
-): Promise<{ accessToken: string; accountId: string | null }> {
+async function ensureAccessToken(getAuth, setAuth) {
   const now = Date.now();
 
   // Return cached token if still fresh
@@ -120,7 +104,7 @@ async function ensureAccessToken(
   return { accessToken: cachedAccessToken, accountId: cachedAccountId };
 }
 
-export const CodexAuthProxy: Plugin = async (input) => {
+export const CodexAuthProxy = async (input) => {
   return {
     auth: {
       provider: "openai",
@@ -172,13 +156,13 @@ export const CodexAuthProxy: Plugin = async (input) => {
           };
         }
 
-        const setAuth = async (body: OpenAIAuthState) => {
+        const setAuth = async (body) => {
           await input.client.auth.set({ path: { id: "openai" }, body });
         };
 
         return {
           apiKey: OAUTH_DUMMY_KEY,
-          async fetch(requestInput: RequestInfo | URL, init?: RequestInit) {
+          async fetch(requestInput, init) {
             // Remove dummy API key authorization header
             if (init?.headers) {
               if (init.headers instanceof Headers) {
@@ -189,8 +173,8 @@ export const CodexAuthProxy: Plugin = async (input) => {
                   ([key]) => key.toLowerCase() !== "authorization"
                 );
               } else {
-                delete (init.headers as Record<string, string>)["authorization"];
-                delete (init.headers as Record<string, string>)["Authorization"];
+                delete init.headers["authorization"];
+                delete init.headers["Authorization"];
               }
             }
 
@@ -210,7 +194,7 @@ export const CodexAuthProxy: Plugin = async (input) => {
                   if (value !== undefined) headers.set(key, String(value));
                 }
               } else {
-                for (const [key, value] of Object.entries(init.headers as Record<string, string>)) {
+                for (const [key, value] of Object.entries(init.headers)) {
                   if (value !== undefined) headers.set(key, String(value));
                 }
               }

--- a/packages/sandbox-runtime/tests/test_codex_auth_plugin_setup.py
+++ b/packages/sandbox-runtime/tests/test_codex_auth_plugin_setup.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from sandbox_runtime.entrypoint import SandboxSupervisor
 
@@ -70,3 +70,47 @@ class TestCodexAuthPluginSetup:
         data = json.loads(_auth_file(tmp_path).read_text())
         assert data["openai"]["refresh"] == "managed-by-control-plane"
         assert data["openai"]["accountId"] == "acct_xyz"
+
+    async def test_start_opencode_copies_js_plugin(self, tmp_path):
+        """start_opencode() should deploy the precompiled JS plugin into .opencode/plugins."""
+        sup = _make_supervisor()
+        sup.workspace_path = tmp_path / "workspace"
+        sup.workspace_path.mkdir()
+        sup.repo_path = sup.workspace_path / "app"
+
+        plugin_source = tmp_path / "app" / "sandbox_runtime" / "plugins" / "codex-auth-plugin.js"
+        plugin_source.parent.mkdir(parents=True)
+        plugin_source.write_text("export const CodexAuthProxy = async () => ({});")
+
+        fake_proc = MagicMock()
+        fake_proc.stdout = None
+
+        original_path = Path
+
+        with (
+            patch.dict("os.environ", {"OPENAI_OAUTH_REFRESH_TOKEN": "rt_real_secret"}, clear=False),
+            patch("sandbox_runtime.entrypoint.Path") as mock_path,
+            patch("sandbox_runtime.entrypoint.shutil.copy") as mock_copy,
+            patch("sandbox_runtime.entrypoint.asyncio.create_subprocess_exec", AsyncMock(return_value=fake_proc)),
+            patch(
+                "sandbox_runtime.entrypoint.asyncio.create_task",
+                side_effect=lambda coro: coro.close(),
+            ),
+        ):
+            mock_path.side_effect = lambda p: (
+                plugin_source
+                if p == "/app/sandbox_runtime/plugins/codex-auth-plugin.js"
+                else original_path(p)
+            )
+            sup._setup_openai_oauth = MagicMock()
+            sup._install_tools = MagicMock()
+            sup._install_skills = MagicMock()
+            sup._install_bin_scripts = MagicMock()
+            sup._wait_for_health = AsyncMock()
+
+            await sup.start_opencode()
+
+        mock_copy.assert_called_once_with(
+            plugin_source,
+            sup.workspace_path / ".opencode" / "plugins" / "codex-auth-plugin.js",
+        )


### PR DESCRIPTION
## Summary
- rename the sandbox runtime Codex auth plugin from `.ts` to `.js` and remove the TypeScript-only syntax so OpenCode can import it directly without boot-time transpilation
- update `SandboxSupervisor.start_opencode()` to deploy `codex-auth-plugin.js` into `.opencode/plugins/` when OpenAI OAuth is configured
- add a focused sandbox-runtime test covering JS plugin deployment during OpenCode startup

## Testing
- `PYTHONPATH=src uv run --no-project --with pytest --with pytest-asyncio pytest tests/test_codex_auth_plugin_setup.py tests/test_tool_installation.py`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/6a3ea1bcd2ac73217fcb97acef7b92a6)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated the OpenAI OAuth authentication plugin from TypeScript to JavaScript.
  * Added test coverage for the plugin setup and deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->