### PR TITLE
fix: apply missed Ruff formatting in sandbox runtime test

### DIFF
--- a/packages/sandbox-runtime/tests/test_codex_auth_plugin_setup.py
+++ b/packages/sandbox-runtime/tests/test_codex_auth_plugin_setup.py
@@ -91,7 +91,10 @@ class TestCodexAuthPluginSetup:
             patch.dict("os.environ", {"OPENAI_OAUTH_REFRESH_TOKEN": "rt_real_secret"}, clear=False),
             patch("sandbox_runtime.entrypoint.Path") as mock_path,
             patch("sandbox_runtime.entrypoint.shutil.copy") as mock_copy,
-            patch("sandbox_runtime.entrypoint.asyncio.create_subprocess_exec", AsyncMock(return_value=fake_proc)),
+            patch(
+                "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
+                AsyncMock(return_value=fake_proc),
+            ),
             patch(
                 "sandbox_runtime.entrypoint.asyncio.create_task",
                 side_effect=lambda coro: coro.close(),


### PR DESCRIPTION
## Summary
- apply the missing Ruff line wrap in `packages/sandbox-runtime/tests/test_codex_auth_plugin_setup.py`
- resolve the formatting regression that slipped into `#492` without changing runtime behavior

## Testing
- `PYTHONPATH=src uv run --no-project --with ruff ruff format --check .`
- `PYTHONPATH=src uv run --no-project --with pytest --with pytest-asyncio pytest tests/test_codex_auth_plugin_setup.py`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/11c9a36184283240e00740328e6b0400)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test mocking setup formatting with no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->