### PR TITLE
docs: document inbound webhook automations

### DIFF
--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -4,15 +4,15 @@ Automations let you run coding agents either on a recurring schedule or when an 
 arrives. Define the repository, branch, model, and instructions once, then Open-Inspect starts a new
 session whenever the trigger fires.
 
-Current trigger types:
+Trigger types:
 
-| Trigger Type        | Description                               |
-| ------------------- | ----------------------------------------- |
-| **Schedule**        | Run on a cron schedule                    |
-| **Inbound Webhook** | Trigger from any system with an HTTP POST |
-| **Sentry Alert**    | Trigger from a Sentry Custom Integration  |
-| **GitHub Event**    | Planned                                   |
-| **Linear Event**    | Planned                                   |
+| Trigger Type        | Description                               | Availability |
+| ------------------- | ----------------------------------------- | ------------ |
+| **Schedule**        | Run on a cron schedule                    | Available    |
+| **Inbound Webhook** | Trigger from any system with an HTTP POST | Available    |
+| **Sentry Alert**    | Trigger from a Sentry Custom Integration  | Available    |
+| **GitHub Event**    | Trigger on GitHub activity                | Planned      |
+| **Linear Event**    | Trigger on Linear activity                | Planned      |
 
 Common use cases include nightly dependency updates, reacting to deploy or incident events, triaging
 new Sentry issues, and recurring report generation.
@@ -164,6 +164,9 @@ event. Re-sending the same `idempotencyKey` will not create duplicate runs.
 The `idempotencyKey` remains in the stored webhook body, but it is omitted from the context block
 shown to the agent.
 
+If you do not provide an `idempotencyKey`, each webhook delivery gets its own concurrency key. That
+means separate deliveries for the same automation can run at the same time.
+
 ### Responses
 
 Successful requests return JSON in this shape:
@@ -293,8 +296,13 @@ Automations display one of three statuses:
 
 ## Concurrent Runs
 
-Only one run per automation can be active at a time. If a trigger fires while a previous run is
-still in progress, the new run is recorded as **Skipped** with reason "concurrent run active".
+For scheduled and manual triggers, only one run per automation can be active at a time. If one of
+those triggers fires while a previous run is still in progress, the new run is recorded as
+**Skipped** with reason "concurrent run active".
+
+Event-driven automations use concurrency keys instead. For inbound webhooks, retries with the same
+`idempotencyKey` are treated as the same event, but separate deliveries without a shared
+`idempotencyKey` can overlap.
 
 This prevents overlapping sessions from interfering with each other on the same repository.
 
@@ -318,12 +326,12 @@ auto-pause threshold.
 
 ## Limits
 
-| Limit                                  | Value             |
-| -------------------------------------- | ----------------- |
-| Automation name length                 | 200 characters    |
-| Instructions length                    | 10,000 characters |
-| Minimum schedule interval              | 15 minutes        |
-| Webhook payload size                   | 64 KB             |
-| Concurrent runs per automation         | 1                 |
-| Consecutive failures before auto-pause | 3                 |
-| Run execution timeout                  | 90 minutes        |
+| Limit                                  | Value                                |
+| -------------------------------------- | ------------------------------------ |
+| Automation name length                 | 200 characters                       |
+| Instructions length                    | 10,000 characters                    |
+| Minimum schedule interval              | 15 minutes                           |
+| Webhook payload size                   | 64 KB                                |
+| Concurrent runs per automation         | 1 for scheduled/manual triggers only |
+| Consecutive failures before auto-pause | 3                                    |
+| Run execution timeout                  | 90 minutes                           |

--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -1,11 +1,21 @@
 # Automations
 
-Automations let you run coding agents on a recurring schedule. Define a task, pick a repository and
-branch, set a cron schedule, and Open-Inspect will spawn a new session at each scheduled time — no
-manual triggering required.
+Automations let you run coding agents either on a recurring schedule or when an external event
+arrives. Define the repository, branch, model, and instructions once, then Open-Inspect starts a new
+session whenever the trigger fires.
 
-Common use cases include nightly dependency updates, periodic code quality sweeps, daily test runs,
-and recurring report generation.
+Current trigger types:
+
+| Trigger Type        | Description                               |
+| ------------------- | ----------------------------------------- |
+| **Schedule**        | Run on a cron schedule                    |
+| **Inbound Webhook** | Trigger from any system with an HTTP POST |
+| **Sentry Alert**    | Trigger from a Sentry Custom Integration  |
+| **GitHub Event**    | Planned                                   |
+| **Linear Event**    | Planned                                   |
+
+Common use cases include nightly dependency updates, reacting to deploy or incident events, triaging
+new Sentry issues, and recurring report generation.
 
 ---
 
@@ -13,22 +23,169 @@ and recurring report generation.
 
 Navigate to **Automations** in the sidebar, then click **Create Automation**.
 
+Start by choosing a **Trigger Type**. The rest of the form adjusts based on that choice.
+
 ### Required Fields
 
-| Field            | Description                                                                                                                                                                         |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Name**         | A short label for the automation (max 200 characters). Appears in the automations list and in session titles prefixed with `[Auto]`.                                                |
-| **Repository**   | The GitHub repository to run against. Only repositories installed on the GitHub App are available. Cannot be changed after creation.                                                |
-| **Schedule**     | When and how often to run. See [Schedule Options](#schedule-options) below.                                                                                                         |
-| **Timezone**     | The IANA timezone for interpreting the schedule. Defaults to your browser's local timezone.                                                                                         |
-| **Instructions** | The prompt sent to the coding agent each time the automation fires (max 10,000 characters). Write this as you would a normal session prompt — be specific about what you want done. |
+| Field            | Description                                                                                                                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Trigger Type** | How the automation starts: schedule, inbound webhook, or Sentry alert.                                                                                                                     |
+| **Name**         | A short label for the automation (max 200 characters). Appears in the automations list and in session titles prefixed with `[Auto]`.                                                       |
+| **Repository**   | The GitHub repository to run against. Only repositories installed on the GitHub App are available. Cannot be changed after creation.                                                       |
+| **Instructions** | The prompt sent to the coding agent each time the automation fires (max 10,000 characters). Write this as you would a normal session prompt and reference the trigger context when useful. |
 
 ### Optional Fields
 
-| Field      | Description                                                                                     |
-| ---------- | ----------------------------------------------------------------------------------------------- |
-| **Branch** | The base branch for each session. Defaults to the repository's default branch (usually `main`). |
-| **Model**  | The AI model to use. Defaults to the system default model.                                      |
+| Field          | Description                                                                                       |
+| -------------- | ------------------------------------------------------------------------------------------------- |
+| **Branch**     | The base branch for each session. Defaults to the repository's default branch (usually `main`).   |
+| **Model**      | The AI model to use. Defaults to the system default model.                                        |
+| **Reasoning**  | Optional reasoning level for models that support it.                                              |
+| **Conditions** | Optional trigger filters for event-driven automations such as inbound webhooks and Sentry alerts. |
+
+### Trigger-Specific Fields
+
+| Trigger Type        | Additional Fields                           |
+| ------------------- | ------------------------------------------- |
+| **Schedule**        | **Schedule** and **Timezone**               |
+| **Inbound Webhook** | No extra required fields                    |
+| **Sentry Alert**    | **Event Type** and **Sentry Client Secret** |
+
+For non-schedule automations, schedule fields are not used.
+
+---
+
+## Inbound Webhooks
+
+Use **Inbound Webhook** when you want any external system to trigger an automation with a JSON
+payload. This is the most flexible event-driven option and works well for internal tools,
+deployments, monitoring systems, scheduled jobs, and custom integrations.
+
+### How It Works
+
+1. Create an automation with **Trigger Type = Inbound Webhook**.
+2. Copy the generated webhook URL and API key shown after creation.
+3. Send an authenticated HTTP `POST` request with a JSON body.
+4. Open-Inspect prepends a webhook context block to your automation instructions and starts a new
+   session if the request matches the automation's conditions.
+
+### Setup Notes
+
+- The webhook URL and API key are shown after the automation is created.
+- The API key is only shown once, so store it when you create the automation.
+- The automation detail page shows the webhook path for reference.
+- Webhook automations do not use schedule or timezone settings.
+
+### Request Requirements
+
+Inbound webhooks must meet all of the following requirements:
+
+| Requirement          | Value                             |
+| -------------------- | --------------------------------- |
+| Method               | `POST`                            |
+| Content-Type         | `application/json`                |
+| Authentication       | `Authorization: Bearer <api-key>` |
+| Maximum payload size | 64 KB                             |
+
+Any valid JSON body is accepted.
+
+Example:
+
+```bash
+curl -X POST "https://<your-worker-url>/webhooks/automation/<automation-id>" \
+  -H "Authorization: Bearer <api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{"event":"deploy.failed","service":"api","environment":"prod"}'
+```
+
+### What the Agent Receives
+
+For each accepted request, Open-Inspect prepends a context block to your instructions that includes:
+
+- The fact that the automation was triggered by an inbound webhook
+- The time the webhook was received
+- The JSON payload, truncated if necessary
+- A warning to treat the payload as untrusted input data, not as instructions
+
+Write your automation instructions assuming the agent will read both your saved prompt and the
+incoming payload together.
+
+### Filtering with Conditions
+
+Webhook automations support one condition type: **JSONPath Filter**.
+
+Use conditions when you want the automation to run only for specific payload shapes or values, such
+as:
+
+- Only production events
+- Only deploy failures
+- Only payloads that include a specific field
+
+Each JSONPath condition contains one or more filters, and **all filters must match** for the
+automation to run.
+
+Supported comparisons:
+
+| Comparison | Meaning                   |
+| ---------- | ------------------------- |
+| `eq`       | Equal to                  |
+| `neq`      | Not equal to              |
+| `gt`       | Greater than              |
+| `gte`      | Greater than or equal to  |
+| `lt`       | Less than                 |
+| `lte`      | Less than or equal to     |
+| `contains` | String contains substring |
+| `exists`   | Field is present          |
+
+Supported path syntax is limited to simple dot notation such as `$.event.type` or
+`$.deployment.environment`.
+
+Not supported:
+
+- Array indexing
+- Recursive descent
+- Full JSONPath expressions
+
+Example filters:
+
+| Goal                             | Filter                          |
+| -------------------------------- | ------------------------------- |
+| Run only for production          | `$.environment eq "production"` |
+| Run only for failed deploys      | `$.status eq "failed"`          |
+| Run only when a field is present | `$.pull_request.number exists`  |
+
+### Idempotency and Duplicate Deliveries
+
+If your sender may retry the same event, include an `idempotencyKey` field in the JSON body.
+
+When present, Open-Inspect uses that value to deduplicate repeated deliveries of the same logical
+event. Re-sending the same `idempotencyKey` will not create duplicate runs.
+
+The `idempotencyKey` remains in the stored webhook body, but it is omitted from the context block
+shown to the agent.
+
+### Responses
+
+Successful requests return JSON in this shape:
+
+```json
+{ "ok": true, "triggered": 1, "skipped": 0 }
+```
+
+`triggered` is the number of automation runs started.
+
+`skipped` is the number of matching runs that were ignored because of duplicate delivery or
+concurrency protection.
+
+### Error Responses
+
+| Status | Meaning                                          |
+| ------ | ------------------------------------------------ |
+| `400`  | Invalid JSON body                                |
+| `401`  | Missing or invalid API key                       |
+| `404`  | Automation not found or not a webhook automation |
+| `413`  | Payload too large                                |
+| `415`  | `Content-Type` was not `application/json`        |
 
 ---
 
@@ -74,22 +231,25 @@ Examples:
 
 ### Pause and Resume
 
-**Pausing** an automation stops it from firing on schedule. No new runs will be created until it is
-resumed. You can pause from the automations list or the detail page.
+**Pausing** an automation stops it from firing. Scheduled automations will not run on their cron,
+and event-driven automations will ignore incoming events until resumed. You can pause from the
+automations list or the detail page.
 
-**Resuming** reactivates the automation and calculates the next run time from the current moment. It
-also resets the consecutive failure counter (see [Auto-Pause](#auto-pause) below).
+**Resuming** reactivates the automation. Scheduled automations calculate the next run time from the
+current moment. Event-driven automations resume listening immediately. Resuming also resets the
+consecutive failure counter (see [Auto-Pause](#auto-pause) below).
 
 ### Trigger Now
 
-Click **Trigger Now** to fire a one-off run immediately, regardless of the schedule. This does not
-affect the next scheduled run time. Manual triggers follow the same concurrency rules as scheduled
-runs — if a run is already active, the trigger is rejected.
+Click **Trigger Now** to fire a one-off run immediately. For scheduled automations, this does not
+affect the next scheduled run time. Manual triggers follow the same concurrency rules as all other
+runs: if a run is already active, the trigger is rejected.
 
 ### Edit
 
-You can change an automation's name, branch, model, schedule, timezone, and instructions at any
-time. The repository cannot be changed after creation.
+You can change an automation's name, branch, model, and instructions at any time. For scheduled
+automations, you can also change the schedule and timezone. The repository cannot be changed after
+creation.
 
 If you update the schedule or timezone, the next run time is recalculated automatically.
 
@@ -125,7 +285,7 @@ Automations display one of three statuses:
 
 | Status       | Meaning                                                                               |
 | ------------ | ------------------------------------------------------------------------------------- |
-| **Enabled**  | Running normally on schedule.                                                         |
+| **Enabled**  | Running normally and ready to respond to its trigger.                                 |
 | **Degraded** | Enabled but has recent consecutive failures. The failure count is shown on the badge. |
 | **Paused**   | Not firing. Either manually paused or auto-paused after repeated failures.            |
 
@@ -133,9 +293,8 @@ Automations display one of three statuses:
 
 ## Concurrent Runs
 
-Only one run per automation can be active at a time. If a scheduled run fires while a previous run
-is still in progress, the new run is recorded as **Skipped** with reason "concurrent run active" and
-the schedule advances to the next occurrence.
+Only one run per automation can be active at a time. If a trigger fires while a previous run is
+still in progress, the new run is recorded as **Skipped** with reason "concurrent run active".
 
 This prevents overlapping sessions from interfering with each other on the same repository.
 
@@ -144,10 +303,10 @@ This prevents overlapping sessions from interfering with each other on the same 
 ## Auto-Pause
 
 If an automation fails **3 consecutive times**, it is automatically paused to prevent runaway
-failures. The status changes to **Paused** and no further runs are scheduled.
+failures. The status changes to **Paused** and no further runs will start until you resume it.
 
-To re-enable the automation, click **Resume**. This resets the failure counter and schedules the
-next run.
+To re-enable the automation, click **Resume**. This resets the failure counter. Scheduled
+automations also compute their next run at that point.
 
 Consecutive failures are tracked across both scheduled and manually triggered runs. A single
 successful run resets the counter to zero.
@@ -164,6 +323,7 @@ auto-pause threshold.
 | Automation name length                 | 200 characters    |
 | Instructions length                    | 10,000 characters |
 | Minimum schedule interval              | 15 minutes        |
+| Webhook payload size                   | 64 KB             |
 | Concurrent runs per automation         | 1                 |
 | Consecutive failures before auto-pause | 3                 |
 | Run execution timeout                  | 90 minutes        |


### PR DESCRIPTION
## Summary
- update the automations guide so it reflects both schedule-based and event-driven triggers instead of only cron-based runs
- add a dedicated inbound webhook section covering setup, authentication, payload requirements, JSONPath filtering, idempotency, and expected responses
- tighten shared automation behavior docs so pause/resume, trigger now, concurrency, auto-pause, and limits are accurate for webhook automations too

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/0d93c0f9ddc5410aa3441561ac964637)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

* Updated automations docs to support scheduled and event-driven triggers (Schedule, Inbound Webhook, Sentry Alert; GitHub/Linear planned).
* Documented trigger-specific creation flow, required fields, optional Reasoning, and Conditions for event-driven triggers.
* Added inbound webhook details: authenticated POST, 64 KB payload limit, JSONPath filtering, idempotencyKey deduplication, and response/error handling.
* Clarified pause/resume, Trigger Now, edit limits, and refined concurrency and limits wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->