### PR TITLE
fix: speed up sandbox boot readiness

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -268,6 +268,9 @@ class SandboxSupervisor:
                 return True
             if not await self._clone_repo():
                 return False
+            # git clone already checks out the requested branch, so an immediate
+            # fetch + checkout just adds another round trip on the cold path.
+            return True
 
         return await self._update_existing_repo()
 
@@ -1080,7 +1083,15 @@ class SandboxSupervisor:
                 await self.shutdown_event.wait()
                 return
 
-            # Phase 3.5: Start optional sidecars (best-effort, non-fatal)
+            # Phase 4: Start OpenCode server (in repo directory)
+            await self.start_opencode()
+            opencode_ready = True
+
+            # Phase 5: Start bridge (after OpenCode is ready)
+            await self.start_bridge()
+
+            # Phase 5.5: Start optional sidecars only after OpenCode is ready.
+            # These are useful, but they should never delay first-prompt readiness.
             for sidecar_name, starter in (
                 ("code_server", self.start_code_server),
                 ("ttyd", self.start_ttyd),
@@ -1099,13 +1110,6 @@ class SandboxSupervisor:
                         await self.start_ttyd_proxy()
                     except Exception as e:
                         self.log.warn("ttyd_proxy.start_failed", exc=e)
-
-            # Phase 4: Start OpenCode server (in repo directory)
-            await self.start_opencode()
-            opencode_ready = True
-
-            # Phase 5: Start bridge (after OpenCode is ready)
-            await self.start_bridge()
 
             # Emit sandbox.startup wide event
             duration_ms = int((time.time() - startup_start) * 1000)

--- a/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
+++ b/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
@@ -319,6 +319,52 @@ class TestNormalMode:
         clone_args = clone_calls[0]
         assert "100" in clone_args, f"Expected --depth 100 in clone args, got {clone_args}"
 
+    @pytest.mark.asyncio
+    async def test_fresh_clone_skips_redundant_fetch_and_checkout(self, base_env, tmp_path):
+        """Fresh clone should not immediately do an extra fetch + checkout."""
+        supervisor = _make_supervisor(base_env)
+        supervisor.repo_path = tmp_path / "nonexistent"
+
+        all_calls = []
+
+        async def fake_subprocess(*args, **kwargs):
+            all_calls.append(args)
+            mock_proc = MagicMock()
+            mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+            mock_proc.wait = AsyncMock(return_value=0)
+            mock_proc.returncode = 0
+            return mock_proc
+
+        supervisor.run_setup_script = AsyncMock(return_value=True)
+        supervisor.run_start_script = AsyncMock(return_value=True)
+        supervisor.start_opencode = AsyncMock()
+        supervisor.start_bridge = AsyncMock()
+        supervisor.monitor_processes = AsyncMock()
+        supervisor.shutdown = AsyncMock()
+
+        with (
+            patch.dict(os.environ, base_env, clear=False),
+            patch(
+                "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
+                side_effect=fake_subprocess,
+            ),
+        ):
+            await supervisor.run()
+
+        git_calls = [args for args in all_calls if args and args[0] == "git"]
+        assert git_calls == [
+            (
+                "git",
+                "clone",
+                "--depth",
+                "100",
+                "--branch",
+                "main",
+                "https://github.com/acme/my-repo.git",
+                str(supervisor.repo_path),
+            )
+        ]
+
 
 class TestSnapshotRestoreMode:
     """RESTORED_FROM_SNAPSHOT=true: update repo (best-effort) + start hook, skip setup."""

--- a/packages/sandbox-runtime/tests/test_setup_script.py
+++ b/packages/sandbox-runtime/tests/test_setup_script.py
@@ -303,6 +303,60 @@ class TestSetupInRun:
                 call_order.append(name)
         assert call_order == ["run_setup_script", "run_start_script", "start_opencode"]
 
+    async def test_run_starts_sidecars_after_bridge(self, tmp_path):
+        sup = _make_supervisor(tmp_path)
+
+        call_order = []
+
+        async def mark(name):
+            call_order.append(name)
+
+        async def mark_setup_script():
+            await mark("run_setup_script")
+            return True
+
+        async def mark_start_script():
+            await mark("run_start_script")
+            return True
+
+        async def mark_start_opencode():
+            await mark("start_opencode")
+
+        async def mark_start_bridge():
+            await mark("start_bridge")
+
+        async def mark_start_code_server():
+            await mark("start_code_server")
+
+        async def mark_start_ttyd():
+            await mark("start_ttyd")
+
+        sup.perform_git_sync = AsyncMock(return_value=True)
+        sup.run_setup_script = AsyncMock(side_effect=mark_setup_script)
+        sup.run_start_script = AsyncMock(side_effect=mark_start_script)
+        sup.start_opencode = AsyncMock(side_effect=mark_start_opencode)
+        sup.start_bridge = AsyncMock(side_effect=mark_start_bridge)
+        sup.start_code_server = AsyncMock(side_effect=mark_start_code_server)
+        sup.start_ttyd = AsyncMock(side_effect=mark_start_ttyd)
+        sup.monitor_processes = AsyncMock()
+        sup.ttyd_process = None
+
+        with (
+            patch.dict("os.environ", {"RESTORED_FROM_SNAPSHOT": "false"}, clear=False),
+            patch("asyncio.get_event_loop") as mock_loop,
+        ):
+            mock_loop.return_value.add_signal_handler = MagicMock()
+            await sup.run()
+
+        assert call_order == [
+            "run_setup_script",
+            "run_start_script",
+            "start_opencode",
+            "start_bridge",
+            "start_code_server",
+            "start_ttyd",
+        ]
+
     async def test_run_skips_setup_on_snapshot_restore(self, tmp_path):
         sup = _make_supervisor(tmp_path)
 


### PR DESCRIPTION
## Summary
- stop doing a redundant `git fetch` and `git checkout` immediately after a fresh clone in the sandbox supervisor
- start optional sidecars like `code-server` and `ttyd` only after OpenCode and the bridge are ready so first-prompt readiness is not blocked
- add regression tests covering the fresh-clone git path and the updated startup ordering

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/e0e320380a10efbf165cc829d2fe3788)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Removed redundant git operations during fresh repository clones, reducing startup overhead.

* **Improvements**
  * Reordered initialization sequence to start core runtime services before optional components, improving startup consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->