### PR TITLE
fix: pass sender login as scmLogin in github-bot session creation

### DIFF
--- a/packages/github-bot/src/handlers.ts
+++ b/packages/github-bot/src/handlers.ts
@@ -31,6 +31,7 @@ async function createSession(
     title: string;
     model: string;
     reasoningEffort?: string | null;
+    scmLogin: string;
   }
 ): Promise<string> {
   const body: Record<string, unknown> = {
@@ -38,6 +39,7 @@ async function createSession(
     repoName: params.repoName,
     title: params.title,
     model: params.model,
+    scmLogin: params.scmLogin,
   };
   if (params.reasoningEffort) {
     body.reasoningEffort = params.reasoningEffort;
@@ -204,6 +206,7 @@ export async function handleReviewRequested(
     title: `GitHub: Review PR #${pr.number}`,
     model: config.model,
     reasoningEffort: config.reasoningEffort,
+    scmLogin: sender.login,
   });
   log.info("session.created", { ...meta, session_id: sessionId, action: "review" });
 
@@ -300,6 +303,7 @@ export async function handlePullRequestOpened(
     title: `GitHub: Review PR #${pr.number}`,
     model: config.model,
     reasoningEffort: config.reasoningEffort,
+    scmLogin: sender.login,
   });
   log.info("session.created", { ...meta, session_id: sessionId, action: "auto_review" });
 
@@ -402,6 +406,7 @@ export async function handleIssueComment(
     title: `GitHub: PR #${issue.number} comment`,
     model: config.model,
     reasoningEffort: config.reasoningEffort,
+    scmLogin: sender.login,
   });
   log.info("session.created", { ...meta, session_id: sessionId, action: "comment" });
 
@@ -497,6 +502,7 @@ export async function handleReviewComment(
     title: `GitHub: PR #${pr.number} review comment`,
     model: config.model,
     reasoningEffort: config.reasoningEffort,
+    scmLogin: sender.login,
   });
   log.info("session.created", { ...meta, session_id: sessionId, action: "review_comment" });
 

--- a/packages/github-bot/test/handlers.test.ts
+++ b/packages/github-bot/test/handlers.test.ts
@@ -198,6 +198,7 @@ describe("handlePullRequestOpened", () => {
     expect(sessionBody.repoOwner).toBe("acme");
     expect(sessionBody.repoName).toBe("widgets");
     expect(sessionBody.title).toContain("Review PR #42");
+    expect(sessionBody.scmLogin).toBe("alice");
 
     const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
     expect(promptBody.source).toBe("github");
@@ -364,6 +365,7 @@ describe("handleReviewRequested", () => {
     expect(sessionBody.repoOwner).toBe("acme");
     expect(sessionBody.repoName).toBe("widgets");
     expect(sessionBody.title).toContain("Review PR #42");
+    expect(sessionBody.scmLogin).toBe("alice");
 
     // Verify prompt sending
     const promptCall = cpFetch.mock.calls[1];
@@ -455,6 +457,9 @@ describe("handleIssueComment", () => {
     const cpFetch = getControlPlaneFetch(env);
     expect(cpFetch).toHaveBeenCalledTimes(2);
 
+    const sessionBody = JSON.parse(cpFetch.mock.calls[0][1].body);
+    expect(sessionBody.scmLogin).toBe("bob");
+
     const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
     expect(promptBody.content).toContain("please fix the error handling");
     expect(promptBody.content).not.toContain("@test-bot[bot]");
@@ -541,6 +546,10 @@ describe("handleReviewComment", () => {
     );
 
     const cpFetch = getControlPlaneFetch(env);
+
+    const sessionBody = JSON.parse(cpFetch.mock.calls[0][1].body);
+    expect(sessionBody.scmLogin).toBe("carol");
+
     const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
     expect(promptBody.content).toContain("src/cache.ts");
     expect(promptBody.content).toContain("const cache = new Map()");


### PR DESCRIPTION
## Summary

- GitHub bot sessions were created without `scmLogin`, causing them to appear as "unknown" in the analytics dashboard
- All four webhook handlers (`handleReviewRequested`, `handlePullRequestOpened`, `handleIssueComment`, `handleReviewComment`) now pass `sender.login` from the webhook payload as `scmLogin` when creating sessions via the control plane
- The control plane already accepts `scmLogin` as an optional field on `POST /sessions` — no backend changes needed

## Test plan

- [x] All 100 github-bot tests pass, including new `scmLogin` assertions on all four handler happy paths
- [x] TypeScript typecheck passes
- [ ] After deploy, verify new github-bot sessions show the sender's GitHub login in analytics instead of "unknown"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal session creation to include GitHub sender identification.

* **Tests**
  * Added validation that GitHub sender login data is properly included in session payloads across all webhook handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->