### PR TITLE
fix: exclude bot and automation sessions from analytics

### DIFF
--- a/packages/control-plane/src/db/analytics-store.ts
+++ b/packages/control-plane/src/db/analytics-store.ts
@@ -61,7 +61,8 @@ export class AnalyticsStore {
            COALESCE(SUM(CASE WHEN status = 'archived' THEN 1 ELSE 0 END), 0) AS archived_count,
            COALESCE(SUM(CASE WHEN status = 'cancelled' THEN 1 ELSE 0 END), 0) AS cancelled_count
          FROM sessions
-         WHERE created_at >= ? AND created_at < ?`
+         WHERE created_at >= ? AND created_at < ?
+           AND spawn_source = 'user'`
       )
       .bind(filters.startAt, filters.endAt)
       .first<SummaryRow>();
@@ -95,6 +96,7 @@ export class AnalyticsStore {
            COUNT(*) AS count
          FROM sessions
          WHERE created_at >= ? AND created_at < ?
+           AND spawn_source = 'user'
          GROUP BY date, group_key
          ORDER BY date ASC, group_key ASC`
       )
@@ -145,6 +147,7 @@ export class AnalyticsStore {
            MAX(updated_at) AS last_active
          FROM sessions
          WHERE created_at >= ? AND created_at < ?
+           AND spawn_source = 'user'
          GROUP BY key
          ORDER BY sessions DESC, key ASC`
       )

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -2,7 +2,13 @@
  * API router for Open-Inspect Control Plane.
  */
 
-import type { ArtifactResponse, Env, CreateSessionRequest, CreateSessionResponse } from "./types";
+import type {
+  ArtifactResponse,
+  Env,
+  CreateSessionRequest,
+  CreateSessionResponse,
+  SpawnSource,
+} from "./types";
 import { generateId, encryptToken } from "./auth/crypto";
 import { verifyInternalToken } from "./auth/internal";
 import {
@@ -710,6 +716,7 @@ async function handleCreateSession(
     scmLogin?: string;
     scmName?: string;
     scmEmail?: string;
+    spawnSource?: SpawnSource;
   };
 
   if (!body.repoOwner || !body.repoName) {
@@ -810,6 +817,7 @@ async function handleCreateSession(
           scmUserId,
           codeServerEnabled,
           sandboxSettings,
+          spawnSource: body.spawnSource,
         }),
       },
       ctx
@@ -850,6 +858,7 @@ async function handleCreateSession(
     reasoningEffort,
     baseBranch: body.branch || defaultBranch || "main",
     status: "created",
+    spawnSource: body.spawnSource,
     scmLogin: scmLogin || null,
     createdAt: now,
     updatedAt: now,

--- a/packages/github-bot/src/handlers.ts
+++ b/packages/github-bot/src/handlers.ts
@@ -40,6 +40,7 @@ async function createSession(
     title: params.title,
     model: params.model,
     scmLogin: params.scmLogin,
+    spawnSource: "github-bot",
   };
   if (params.reasoningEffort) {
     body.reasoningEffort = params.reasoningEffort;

--- a/packages/github-bot/test/handlers.test.ts
+++ b/packages/github-bot/test/handlers.test.ts
@@ -199,6 +199,7 @@ describe("handlePullRequestOpened", () => {
     expect(sessionBody.repoName).toBe("widgets");
     expect(sessionBody.title).toContain("Review PR #42");
     expect(sessionBody.scmLogin).toBe("alice");
+    expect(sessionBody.spawnSource).toBe("github-bot");
 
     const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
     expect(promptBody.source).toBe("github");
@@ -366,6 +367,7 @@ describe("handleReviewRequested", () => {
     expect(sessionBody.repoName).toBe("widgets");
     expect(sessionBody.title).toContain("Review PR #42");
     expect(sessionBody.scmLogin).toBe("alice");
+    expect(sessionBody.spawnSource).toBe("github-bot");
 
     // Verify prompt sending
     const promptCall = cpFetch.mock.calls[1];
@@ -459,6 +461,7 @@ describe("handleIssueComment", () => {
 
     const sessionBody = JSON.parse(cpFetch.mock.calls[0][1].body);
     expect(sessionBody.scmLogin).toBe("bob");
+    expect(sessionBody.spawnSource).toBe("github-bot");
 
     const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
     expect(promptBody.content).toContain("please fix the error handling");
@@ -549,6 +552,7 @@ describe("handleReviewComment", () => {
 
     const sessionBody = JSON.parse(cpFetch.mock.calls[0][1].body);
     expect(sessionBody.scmLogin).toBe("carol");
+    expect(sessionBody.spawnSource).toBe("github-bot");
 
     const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
     expect(promptBody.content).toContain("src/cache.ts");

--- a/packages/linear-bot/src/webhook-handler.ts
+++ b/packages/linear-bot/src/webhook-handler.ts
@@ -494,6 +494,7 @@ async function handleNewSession(
       title: `${issue.identifier}: ${issue.title}`,
       model,
       reasoningEffort,
+      spawnSource: "linear-bot",
     }),
   });
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -41,7 +41,13 @@ export type EventType =
   | "push_error"
   | "user_message";
 export type ParticipantRole = "owner" | "member";
-export type SpawnSource = "user" | "agent" | "automation" | "github-bot";
+export type SpawnSource =
+  | "user"
+  | "agent"
+  | "automation"
+  | "github-bot"
+  | "linear-bot"
+  | "slack-bot";
 export type ConfidenceLevel = "high" | "medium" | "low";
 
 // Participant in a session

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -41,7 +41,7 @@ export type EventType =
   | "push_error"
   | "user_message";
 export type ParticipantRole = "owner" | "member";
-export type SpawnSource = "user" | "agent" | "automation";
+export type SpawnSource = "user" | "agent" | "automation" | "github-bot";
 export type ConfidenceLevel = "high" | "medium" | "low";
 
 // Participant in a session

--- a/packages/slack-bot/src/index.ts
+++ b/packages/slack-bot/src/index.ts
@@ -106,6 +106,7 @@ async function createSession(
         model,
         reasoningEffort,
         branch,
+        spawnSource: "slack-bot",
       }),
     });
 


### PR DESCRIPTION
## Summary

- Analytics dashboard was mixing automated sessions (github-bot, linear-bot, slack-bot, scheduled automations, agent-spawned children) with user-initiated sessions, distorting usage metrics
- Adds "github-bot", "linear-bot", and "slack-bot" to the SpawnSource type — all three bots now pass their respective spawn source when creating sessions (previously defaulted to "user")
- Control plane router now accepts an optional spawnSource field on POST /sessions, threading it through to both the DO init and D1 index
- All three analytics SQL queries (getSummary, getTimeseries, getBreakdown) now filter to spawn_source = "user", excluding bot, automation, and agent-spawned sessions

## Test plan

- [x] All 965 control-plane unit tests pass
- [x] All 100 github-bot tests pass, including new spawnSource assertions
- [x] All 90 linear-bot tests pass
- [x] All 44 slack-bot tests pass
- [x] TypeScript typecheck passes for all affected packages
- [ ] After deploy, verify analytics dashboard no longer shows bot/automation sessions
- [ ] Verify bot sessions are created with correct spawn_source values in D1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now record a spawn source for bot origins (GitHub, Linear, Slack) in addition to existing sources.

* **Changes**
  * Analytics views (totals, timeseries, breakdowns) now only include user-spawned sessions.

* **Tests**
  * Updated tests to verify session spawn-source is set for GitHub bot flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->