### PR TITLE
refactor: make _install_mcp_packages async

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -51,6 +51,7 @@ class SandboxSupervisor:
     DEFAULT_START_TIMEOUT_SECONDS = 120
     CLONE_DEPTH_COMMITS = 100
     SIDECAR_TIMEOUT_SECONDS = 5
+    MCP_PACKAGE_INSTALL_TIMEOUT_SECONDS = 180
 
     def __init__(self):
         self.opencode_process: asyncio.subprocess.Process | None = None
@@ -439,7 +440,7 @@ class SandboxSupervisor:
     # removing the check — the package name comes from user-supplied config.
     _NPM_PKG_RE = re.compile(r"^(@[\w.-]+/)?[\w][\w.-]*(@[\w.-]+)?$")
 
-    def _install_mcp_packages(self, servers: list[dict]) -> None:
+    async def _install_mcp_packages(self, servers: list[dict]) -> None:
         """Pre-install npm packages for local MCP servers that use npx."""
         packages: list[str] = []
         for server in servers:
@@ -476,23 +477,33 @@ class SandboxSupervisor:
             return
 
         self.log.info("mcp.install_packages", packages=packages)
-        import subprocess
-
         try:
-            result = subprocess.run(
-                ["npm", "install", "-g", *packages],
-                capture_output=True,
-                text=True,
-                timeout=180,
+            proc = await asyncio.create_subprocess_exec(
+                "npm",
+                "install",
+                "-g",
+                *packages,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
             )
-            if result.returncode == 0:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=self.MCP_PACKAGE_INSTALL_TIMEOUT_SECONDS
+            )
+            if proc.returncode == 0:
                 self.log.info("mcp.packages_installed", packages=packages)
             else:
                 self.log.warn(
                     "mcp.packages_install_failed",
                     packages=packages,
-                    stderr=result.stderr[:500],
+                    stderr=(stderr or b"").decode()[:500],
                 )
+        except TimeoutError:
+            self.log.warn(
+                "mcp.packages_install_timeout",
+                packages=packages,
+                timeout_seconds=self.MCP_PACKAGE_INSTALL_TIMEOUT_SECONDS,
+            )
+            proc.kill()
         except Exception as e:
             self.log.warn("mcp.packages_install_error", packages=packages, exc=str(e))
 
@@ -627,7 +638,7 @@ class SandboxSupervisor:
         # Inject MCP servers
         mcp_servers = self._resolve_mcp_servers()
         if mcp_servers:
-            self._install_mcp_packages(mcp_servers)
+            await self._install_mcp_packages(mcp_servers)
             mcp_config = self._build_mcp_config(mcp_servers)
             if mcp_config:
                 opencode_config["mcp"] = mcp_config

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -504,6 +504,7 @@ class SandboxSupervisor:
                 timeout_seconds=self.MCP_PACKAGE_INSTALL_TIMEOUT_SECONDS,
             )
             proc.kill()
+            await proc.wait()
         except Exception as e:
             self.log.warn("mcp.packages_install_error", packages=packages, exc=str(e))
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -486,7 +486,7 @@ class SandboxSupervisor:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            stdout, stderr = await asyncio.wait_for(
+            _stdout, stderr = await asyncio.wait_for(
                 proc.communicate(), timeout=self.MCP_PACKAGE_INSTALL_TIMEOUT_SECONDS
             )
             if proc.returncode == 0:

--- a/packages/sandbox-runtime/tests/test_mcp.py
+++ b/packages/sandbox-runtime/tests/test_mcp.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -49,78 +49,87 @@ class TestResolveMcpServers:
 
 
 class TestInstallMcpPackages:
-    def test_extracts_package_from_npx_command(self):
+    def _mock_proc(self, returncode=0):
+        """Create a mock async subprocess with the given return code."""
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.returncode = returncode
+        proc.kill = MagicMock()
+        proc.wait = AsyncMock()
+        return proc
+
+    async def test_extracts_package_from_npx_command(self):
         sup = _make_supervisor()
         servers = [{"type": "local", "command": ["npx", "-y", "@playwright/mcp"]}]
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
-            sup._install_mcp_packages(servers)
-            mock_run.assert_called_once()
-            args = mock_run.call_args[0][0]
-            assert args == ["npm", "install", "-g", "@playwright/mcp"]
+        mock_proc = self._mock_proc()
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await sup._install_mcp_packages(servers)
+            mock_exec.assert_called_once()
+            args = mock_exec.call_args[0]
+            assert list(args) == ["npm", "install", "-g", "@playwright/mcp"]
 
-    def test_extracts_package_from_npx_p_flag(self):
+    async def test_extracts_package_from_npx_p_flag(self):
         sup = _make_supervisor()
         servers = [{"type": "local", "command": ["npx", "-p", "@scope/pkg", "binary"]}]
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
-            sup._install_mcp_packages(servers)
-            args = mock_run.call_args[0][0]
-            assert args == ["npm", "install", "-g", "@scope/pkg"]
+        mock_proc = self._mock_proc()
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await sup._install_mcp_packages(servers)
+            args = mock_exec.call_args[0]
+            assert list(args) == ["npm", "install", "-g", "@scope/pkg"]
 
-    def test_skips_remote_servers(self):
+    async def test_skips_remote_servers(self):
         sup = _make_supervisor()
         servers = [{"type": "remote", "url": "https://mcp.example.com", "command": ["npx", "x"]}]
-        with patch("subprocess.run") as mock_run:
-            sup._install_mcp_packages(servers)
-            mock_run.assert_not_called()
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            await sup._install_mcp_packages(servers)
+            mock_exec.assert_not_called()
 
-    def test_skips_servers_without_npx(self):
+    async def test_skips_servers_without_npx(self):
         sup = _make_supervisor()
         servers = [{"type": "local", "command": ["node", "server.js"]}]
-        with patch("subprocess.run") as mock_run:
-            sup._install_mcp_packages(servers)
-            mock_run.assert_not_called()
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            await sup._install_mcp_packages(servers)
+            mock_exec.assert_not_called()
 
-    def test_skips_servers_without_command(self):
+    async def test_skips_servers_without_command(self):
         sup = _make_supervisor()
         servers = [{"type": "local"}]
-        with patch("subprocess.run") as mock_run:
-            sup._install_mcp_packages(servers)
-            mock_run.assert_not_called()
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            await sup._install_mcp_packages(servers)
+            mock_exec.assert_not_called()
 
-    def test_rejects_invalid_package_names(self):
+    async def test_rejects_invalid_package_names(self):
         sup = _make_supervisor()
         servers = [{"type": "local", "command": ["npx", "../../../etc/passwd"]}]
-        with patch("subprocess.run") as mock_run:
-            sup._install_mcp_packages(servers)
-            mock_run.assert_not_called()
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            await sup._install_mcp_packages(servers)
+            mock_exec.assert_not_called()
 
-    def test_rejects_shell_metacharacters(self):
+    async def test_rejects_shell_metacharacters(self):
         sup = _make_supervisor()
         servers = [{"type": "local", "command": ["npx", "pkg; rm -rf /"]}]
-        with patch("subprocess.run") as mock_run:
-            sup._install_mcp_packages(servers)
-            mock_run.assert_not_called()
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            await sup._install_mcp_packages(servers)
+            mock_exec.assert_not_called()
 
-    def test_deduplicates_packages(self):
+    async def test_deduplicates_packages(self):
         sup = _make_supervisor()
         servers = [
             {"type": "local", "command": ["npx", "-y", "@playwright/mcp"]},
             {"type": "local", "command": ["npx", "@playwright/mcp"]},
         ]
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(returncode=0)
-            sup._install_mcp_packages(servers)
-            args = mock_run.call_args[0][0]
+        mock_proc = self._mock_proc()
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec:
+            await sup._install_mcp_packages(servers)
+            args = mock_exec.call_args[0]
             # Should only have one instance of @playwright/mcp
-            assert args == ["npm", "install", "-g", "@playwright/mcp"]
+            assert list(args) == ["npm", "install", "-g", "@playwright/mcp"]
 
-    def test_noop_when_no_servers(self):
+    async def test_noop_when_no_servers(self):
         sup = _make_supervisor()
-        with patch("subprocess.run") as mock_run:
-            sup._install_mcp_packages([])
-            mock_run.assert_not_called()
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            await sup._install_mcp_packages([])
+            mock_exec.assert_not_called()
 
 
 # ─── _build_mcp_config ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Convert `_install_mcp_packages` from blocking `subprocess.run` to `asyncio.create_subprocess_exec`
- Extract timeout to `MCP_PACKAGE_INSTALL_TIMEOUT_SECONDS = 180` class constant, following the existing `DEFAULT_START_TIMEOUT_SECONDS` pattern
- Use `asyncio.wait_for` for timeout enforcement with explicit `proc.kill()` on timeout
- Unblocks the event loop during npm install so signal handlers (SIGTERM/SIGINT) remain responsive during sandbox startup

Follow-up from [PR #497 review feedback](https://github.com/ColeMurray/background-agents/pull/497#discussion_r3105937508).

## Test plan

- [ ] Deploy to sandbox and verify MCP package pre-install still works (`npx -y @playwright/mcp`)
- [ ] Verify timeout logging on slow/stuck installs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Package installation now runs non-blocking, improving responsiveness and startup reliability.

* **Bug Fixes**
  * Improved timeout handling for package installs with clearer failure reporting and safer termination of stalled installs, reducing hangs and partial failures.

* **Tests**
  * Installation tests updated to validate the new asynchronous install flow using async-aware mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->