### PR TITLE
chore: explicitly opt-in to allow all users

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -396,13 +396,18 @@ project_root    = "../../../"
 enable_durable_object_bindings = false
 enable_service_bindings        = false
 
-# Access Control (at least one recommended for security)
+# Access Control (set at least one allowlist for production)
 allowed_users         = "your-github-username"  # Comma-separated GitHub usernames, or empty
 allowed_email_domains = ""                      # Comma-separated domains (e.g., "example.com,corp.io")
+
+# Explicitly opt into open access only if you want any authenticated GitHub user
+# to be able to sign in when both allowlists are empty.
+unsafe_allow_all_users = false
 ```
 
 > **Note**: Review `allowed_users` and `allowed_email_domains` carefully - these control who can
-> sign in. If both are empty, any GitHub user can access your deployment.
+> sign in. Terraform now fails if both are empty unless you explicitly set
+> `unsafe_allow_all_users = true`.
 
 ---
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -81,18 +81,20 @@ GITHUB_CLIENT_SECRET=your_github_app_client_secret
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=your_random_secret  # Generate: openssl rand -base64 32
 
-# Access Control (optional - leave empty to allow all authenticated users)
+# Access Control
 ALLOWED_USERS=username1,username2          # Comma-separated GitHub usernames
 ALLOWED_EMAIL_DOMAINS=example.com,corp.io  # Comma-separated email domains
+UNSAFE_ALLOW_ALL_USERS=false               # Set true to explicitly allow all users when both lists are empty
 
 # Control Plane
 CONTROL_PLANE_URL=http://localhost:8787
 NEXT_PUBLIC_WS_URL=ws://localhost:8787
 ```
 
-> **Access Control**: If both `ALLOWED_USERS` and `ALLOWED_EMAIL_DOMAINS` are empty, any
-> authenticated GitHub user can access the application. If either is set, users must match at least
-> one condition (username in allowed list OR email domain in allowed list).
+> **Access Control**: If both `ALLOWED_USERS` and `ALLOWED_EMAIL_DOMAINS` are empty, sign-in is
+> denied unless `UNSAFE_ALLOW_ALL_USERS=true`. For Terraform-managed production deploys, Terraform
+> also fails validation unless you set at least one allowlist or explicitly opt in with
+> `unsafe_allow_all_users = true`.
 
 ### Development
 

--- a/packages/web/src/lib/access-control.test.ts
+++ b/packages/web/src/lib/access-control.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseAllowlist, checkAccessAllowed } from "./access-control";
+import { parseAllowlist, parseBooleanEnv, checkAccessAllowed } from "./access-control";
 
 describe("parseAllowlist", () => {
   it("returns empty array for undefined", () => {
@@ -31,10 +31,33 @@ describe("parseAllowlist", () => {
   });
 });
 
+describe("parseBooleanEnv", () => {
+  it("returns false for undefined and empty values", () => {
+    expect(parseBooleanEnv(undefined)).toBe(false);
+    expect(parseBooleanEnv("")).toBe(false);
+    expect(parseBooleanEnv("   ")).toBe(false);
+  });
+
+  it("returns true only for true", () => {
+    expect(parseBooleanEnv("true")).toBe(true);
+    expect(parseBooleanEnv(" TRUE ")).toBe(true);
+    expect(parseBooleanEnv("false")).toBe(false);
+    expect(parseBooleanEnv("1")).toBe(false);
+  });
+});
+
 describe("checkAccessAllowed", () => {
   describe("when both allowlists are empty", () => {
-    it("allows all users", () => {
-      const config = { allowedDomains: [], allowedUsers: [] };
+    it("denies all users by default", () => {
+      const config = { allowedDomains: [], allowedUsers: [], unsafeAllowAllUsers: false };
+
+      expect(checkAccessAllowed(config, {})).toBe(false);
+      expect(checkAccessAllowed(config, { githubUsername: "anyuser" })).toBe(false);
+      expect(checkAccessAllowed(config, { email: "anyone@example.com" })).toBe(false);
+    });
+
+    it("allows all users when unsafeAllowAllUsers is enabled", () => {
+      const config = { allowedDomains: [], allowedUsers: [], unsafeAllowAllUsers: true };
 
       expect(checkAccessAllowed(config, {})).toBe(true);
       expect(checkAccessAllowed(config, { githubUsername: "anyuser" })).toBe(true);
@@ -43,7 +66,11 @@ describe("checkAccessAllowed", () => {
   });
 
   describe("when allowedUsers is set", () => {
-    const config = { allowedDomains: [], allowedUsers: ["alloweduser"] };
+    const config = {
+      allowedDomains: [],
+      allowedUsers: ["alloweduser"],
+      unsafeAllowAllUsers: false,
+    };
 
     it("allows users in the list", () => {
       expect(checkAccessAllowed(config, { githubUsername: "alloweduser" })).toBe(true);
@@ -65,7 +92,11 @@ describe("checkAccessAllowed", () => {
   });
 
   describe("when allowedDomains is set", () => {
-    const config = { allowedDomains: ["company.com"], allowedUsers: [] };
+    const config = {
+      allowedDomains: ["company.com"],
+      allowedUsers: [],
+      unsafeAllowAllUsers: false,
+    };
 
     it("allows users with matching email domain", () => {
       expect(checkAccessAllowed(config, { email: "user@company.com" })).toBe(true);
@@ -89,6 +120,7 @@ describe("checkAccessAllowed", () => {
     const config = {
       allowedDomains: ["company.com"],
       allowedUsers: ["specialuser"],
+      unsafeAllowAllUsers: false,
     };
 
     it("allows users matching username", () => {
@@ -129,6 +161,7 @@ describe("checkAccessAllowed", () => {
     const config = {
       allowedDomains: ["company.com", "partner.org"],
       allowedUsers: ["admin", "developer"],
+      unsafeAllowAllUsers: false,
     };
 
     it("allows any user from the list", () => {

--- a/packages/web/src/lib/access-control.ts
+++ b/packages/web/src/lib/access-control.ts
@@ -1,6 +1,7 @@
 export interface AccessControlConfig {
   allowedDomains: string[];
   allowedUsers: string[];
+  unsafeAllowAllUsers: boolean;
 }
 
 export interface AccessCheckParams {
@@ -19,11 +20,15 @@ export function parseAllowlist(value: string | undefined): string[] {
     .filter(Boolean);
 }
 
+export function parseBooleanEnv(value: string | undefined): boolean {
+  return value?.trim().toLowerCase() === "true";
+}
+
 /**
  * Check if a user is allowed to sign in based on access control configuration.
  *
  * Returns true if:
- * - Both allowlists are empty (no restrictions)
+ * - Both allowlists are empty and unsafeAllowAllUsers is true
  * - User's GitHub username is in allowedUsers
  * - User's email domain is in allowedDomains
  *
@@ -34,11 +39,12 @@ export function checkAccessAllowed(
   params: AccessCheckParams
 ): boolean {
   const { allowedDomains, allowedUsers } = config;
+  const { unsafeAllowAllUsers } = config;
   const { githubUsername, email } = params;
 
-  // No restrictions if both lists are empty
+  // Empty allowlists only permit sign-in when explicitly enabled.
   if (allowedDomains.length === 0 && allowedUsers.length === 0) {
-    return true;
+    return unsafeAllowAllUsers;
   }
 
   // Check explicit user allowlist (GitHub username)

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -1,6 +1,6 @@
 import type { NextAuthOptions } from "next-auth";
 import GitHubProvider from "next-auth/providers/github";
-import { checkAccessAllowed, parseAllowlist } from "./access-control";
+import { checkAccessAllowed, parseAllowlist, parseBooleanEnv } from "./access-control";
 
 // Extend NextAuth types to include GitHub-specific user info
 declare module "next-auth" {
@@ -43,6 +43,7 @@ export const authOptions: NextAuthOptions = {
       const config = {
         allowedDomains: parseAllowlist(process.env.ALLOWED_EMAIL_DOMAINS),
         allowedUsers: parseAllowlist(process.env.ALLOWED_USERS),
+        unsafeAllowAllUsers: parseBooleanEnv(process.env.UNSAFE_ALLOW_ALL_USERS),
       };
 
       const githubProfile = profile as { login?: string };

--- a/terraform/environments/production/checks.tf
+++ b/terraform/environments/production/checks.tf
@@ -16,8 +16,8 @@ check "access_controls_configured" {
   assert {
     condition = (
       var.unsafe_allow_all_users ||
-      length(trimspace(var.allowed_users)) > 0 ||
-      length(trimspace(var.allowed_email_domains)) > 0
+      length([for item in split(",", var.allowed_users) : trimspace(item) if trimspace(item) != ""]) > 0 ||
+      length([for item in split(",", var.allowed_email_domains) : trimspace(item) if trimspace(item) != ""]) > 0
     )
     error_message = "At least one access control allowlist must be configured. Set allowed_users or allowed_email_domains, or set unsafe_allow_all_users = true to explicitly allow all authenticated GitHub users."
   }

--- a/terraform/environments/production/checks.tf
+++ b/terraform/environments/production/checks.tf
@@ -11,3 +11,14 @@ check "vercel_url_matches" {
     error_message = "Vercel assigned URL '${var.web_platform == "vercel" && length(module.web_app) > 0 ? module.web_app[0].production_url : "n/a"}' but local.web_app_url is '${local.web_app_url}'. Update locals or set a custom domain."
   }
 }
+
+check "access_controls_configured" {
+  assert {
+    condition = (
+      var.unsafe_allow_all_users ||
+      length(trimspace(var.allowed_users)) > 0 ||
+      length(trimspace(var.allowed_email_domains)) > 0
+    )
+    error_message = "At least one access control allowlist must be configured. Set allowed_users or allowed_email_domains, or set unsafe_allow_all_users = true to explicitly allow all authenticated GitHub users."
+  }
+}

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -194,10 +194,14 @@ enable_service_bindings = false
 # Access Control
 # =============================================================================
 # Comma-separated list of GitHub usernames allowed to sign in
-# Leave empty to allow all GitHub users
+# Set at least one access-control allowlist unless you intentionally opt into
+# open access with unsafe_allow_all_users = true.
 allowed_users = ""
 
 # Comma-separated list of email domains allowed to sign in
-# Leave empty to allow all email domains
 # Example: "example.com,corp.io"
 allowed_email_domains = ""
+
+# Explicitly bypass the Terraform access-control safety check and allow any
+# authenticated GitHub user to sign in when both allowlists are empty.
+unsafe_allow_all_users = false

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -382,13 +382,19 @@ variable "r2_media_location" {
 # =============================================================================
 
 variable "allowed_users" {
-  description = "Comma-separated list of GitHub usernames allowed to sign in (empty = allow all)"
+  description = "Comma-separated list of GitHub usernames allowed to sign in. Leave empty only when allowed_email_domains is set or unsafe_allow_all_users is true."
   type        = string
   default     = ""
 }
 
 variable "allowed_email_domains" {
-  description = "Comma-separated list of email domains allowed to sign in (e.g., 'example.com,corp.io'). Empty = allow all domains."
+  description = "Comma-separated list of email domains allowed to sign in (e.g., 'example.com,corp.io'). Leave empty only when allowed_users is set or unsafe_allow_all_users is true."
   type        = string
   default     = ""
+}
+
+variable "unsafe_allow_all_users" {
+  description = "Bypass Terraform's access-control safety check and allow any authenticated GitHub user to sign in when both allowlists are empty. Set to true only for intentionally open deployments."
+  type        = bool
+  default     = false
 }

--- a/terraform/environments/production/web-cloudflare.tf
+++ b/terraform/environments/production/web-cloudflare.tf
@@ -71,6 +71,7 @@ resource "local_file" "web_app_wrangler_production" {
     NEXT_PUBLIC_SANDBOX_PROVIDER = "${var.sandbox_provider}"
     ALLOWED_USERS = "${var.allowed_users}"
     ALLOWED_EMAIL_DOMAINS = "${var.allowed_email_domains}"
+    UNSAFE_ALLOW_ALL_USERS = "${tostring(var.unsafe_allow_all_users)}"
 
     [assets]
     directory = ".open-next/assets"

--- a/terraform/environments/production/web-vercel.tf
+++ b/terraform/environments/production/web-vercel.tf
@@ -81,5 +81,11 @@ module "web_app" {
       targets   = ["production", "preview"]
       sensitive = false
     },
+    {
+      key       = "UNSAFE_ALLOW_ALL_USERS"
+      value     = tostring(var.unsafe_allow_all_users)
+      targets   = ["production", "preview"]
+      sensitive = false
+    },
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit unsafe_allow_all_users option (default: false) to opt into allowing all authenticated GitHub users when allowlists are empty.

* **Behavior Change**
  * Default access now denies sign-in when both user and email allowlists are empty unless the new option is enabled.

* **Deployment / Validation**
  * Production deploys now validate access-control configuration and will fail unless an allowlist is set or the new option is enabled.

* **Documentation**
  * Updated docs and READMEs to explain the new option and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->