### PR TITLE
fix: show full pre-built image build errors

### DIFF
--- a/packages/web/src/components/settings/images-settings.tsx
+++ b/packages/web/src/components/settings/images-settings.tsx
@@ -5,6 +5,7 @@ import useSWR, { mutate } from "swr";
 import { useRepos } from "@/hooks/use-repos";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { RefreshIcon } from "@/components/ui/icons";
 import { formatRelativeTime } from "@/lib/time";
 import { supportsRepoImages } from "@/lib/sandbox-provider";
@@ -238,9 +239,21 @@ function ImageStatus({ image, isEnabled }: { image: RepoImage | undefined; isEna
           <span className="text-xs text-foreground">Failed</span>
         </div>
         {image.error_message && (
-          <span className="text-xs text-muted-foreground truncate max-w-[200px] block">
-            {image.error_message}
-          </span>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className="text-xs text-muted-foreground truncate max-w-[200px] block cursor-help"
+                  title={image.error_message}
+                >
+                  {image.error_message}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-md overflow-visible whitespace-pre-wrap break-words">
+                {image.error_message}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         )}
       </div>
     );

--- a/packages/web/src/components/settings/images-settings.tsx
+++ b/packages/web/src/components/settings/images-settings.tsx
@@ -127,67 +127,69 @@ export function ImagesSettings() {
   }
 
   return (
-    <div>
-      <h2 className="text-xl font-semibold text-foreground mb-1">Pre-Built Images</h2>
-      <p className="text-sm text-muted-foreground mb-6">
-        Enable pre-built images to speed up sandbox creation. Images are rebuilt automatically when
-        the default branch changes.
-      </p>
-
-      {error && (
-        <div className="mb-4 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 px-4 py-3 border border-red-200 dark:border-red-800 text-sm">
-          {error}
-        </div>
-      )}
-
-      <div className="space-y-2">
-        {repos.map((repo) => {
-          const repoKey = `${repo.owner}/${repo.name}`.toLowerCase();
-          const isEnabled = enabledRepos.has(repoKey);
-          const isToggling = togglingRepos.has(repoKey);
-          const isTriggering = triggeringRepos.has(repoKey);
-          const image = getLatestImage(repo.owner, repo.name);
-
-          return (
-            <div
-              key={repo.id}
-              className="flex items-center justify-between px-4 py-3 border border-border hover:bg-muted/50 transition"
-            >
-              <div className="flex items-center gap-3 min-w-0">
-                <Switch
-                  checked={isEnabled}
-                  onCheckedChange={(checked) => handleToggle(repo.owner, repo.name, checked)}
-                  disabled={isToggling}
-                  aria-label={`Toggle pre-built images for ${repo.owner}/${repo.name}`}
-                />
-                <span className="text-sm font-medium text-foreground truncate">
-                  {repo.owner}/{repo.name}
-                </span>
-              </div>
-
-              <div className="flex items-center gap-3 flex-shrink-0 ml-4">
-                <ImageStatus image={image} isEnabled={isEnabled} />
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => handleTrigger(repo.owner, repo.name)}
-                  disabled={!isEnabled || isTriggering || image?.status === "building"}
-                  title="Rebuild image"
-                >
-                  <RefreshIcon className={`w-4 h-4 ${isTriggering ? "animate-spin" : ""}`} />
-                </Button>
-              </div>
-            </div>
-          );
-        })}
-      </div>
-
-      {repos.length === 0 && (
-        <p className="text-sm text-muted-foreground">
-          No repositories found. Install the GitHub App on repositories to get started.
+    <TooltipProvider>
+      <div>
+        <h2 className="text-xl font-semibold text-foreground mb-1">Pre-Built Images</h2>
+        <p className="text-sm text-muted-foreground mb-6">
+          Enable pre-built images to speed up sandbox creation. Images are rebuilt automatically
+          when the default branch changes.
         </p>
-      )}
-    </div>
+
+        {error && (
+          <div className="mb-4 bg-red-50 dark:bg-red-900/20 text-red-600 dark:text-red-400 px-4 py-3 border border-red-200 dark:border-red-800 text-sm">
+            {error}
+          </div>
+        )}
+
+        <div className="space-y-2">
+          {repos.map((repo) => {
+            const repoKey = `${repo.owner}/${repo.name}`.toLowerCase();
+            const isEnabled = enabledRepos.has(repoKey);
+            const isToggling = togglingRepos.has(repoKey);
+            const isTriggering = triggeringRepos.has(repoKey);
+            const image = getLatestImage(repo.owner, repo.name);
+
+            return (
+              <div
+                key={repo.id}
+                className="flex items-center justify-between px-4 py-3 border border-border hover:bg-muted/50 transition"
+              >
+                <div className="flex items-center gap-3 min-w-0">
+                  <Switch
+                    checked={isEnabled}
+                    onCheckedChange={(checked) => handleToggle(repo.owner, repo.name, checked)}
+                    disabled={isToggling}
+                    aria-label={`Toggle pre-built images for ${repo.owner}/${repo.name}`}
+                  />
+                  <span className="text-sm font-medium text-foreground truncate">
+                    {repo.owner}/{repo.name}
+                  </span>
+                </div>
+
+                <div className="flex items-center gap-3 flex-shrink-0 ml-4">
+                  <ImageStatus image={image} isEnabled={isEnabled} />
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => handleTrigger(repo.owner, repo.name)}
+                    disabled={!isEnabled || isTriggering || image?.status === "building"}
+                    title="Rebuild image"
+                  >
+                    <RefreshIcon className={`w-4 h-4 ${isTriggering ? "animate-spin" : ""}`} />
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {repos.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            No repositories found. Install the GitHub App on repositories to get started.
+          </p>
+        )}
+      </div>
+    </TooltipProvider>
   );
 }
 
@@ -239,21 +241,16 @@ function ImageStatus({ image, isEnabled }: { image: RepoImage | undefined; isEna
           <span className="text-xs text-foreground">Failed</span>
         </div>
         {image.error_message && (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span
-                  className="text-xs text-muted-foreground truncate max-w-[200px] block cursor-help"
-                  title={image.error_message}
-                >
-                  {image.error_message}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent className="max-w-md overflow-visible whitespace-pre-wrap break-words">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="text-xs text-muted-foreground truncate max-w-[200px] block cursor-help">
                 {image.error_message}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-md overflow-visible whitespace-pre-wrap break-words">
+              {image.error_message}
+            </TooltipContent>
+          </Tooltip>
         )}
       </div>
     );


### PR DESCRIPTION
## Summary
- keep the pre-built images settings row compact while preserving access to the full failed build error
- show the complete `error_message` in a tooltip and native title instead of only a hard-truncated preview
- preserve the existing backend behavior since the full error is already stored and returned by the API

## Testing
- npm run typecheck -w @open-inspect/web

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/e14ae075af43ea8d7b8ad3700e5e393d)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tooltip support in Images settings to let users view full error details on hover.

* **Bug Fixes**
  * Replaced truncated inline error text with an interactive tooltip that preserves formatting and shows the complete message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->