### PR TITLE
fix: restore git.sync_complete log for prebuild SHA tracking

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -1180,7 +1180,7 @@ class SandboxSupervisor:
                 git_sync_success = await self._update_existing_repo()
             else:
                 git_sync_success = await self.perform_git_sync()
-            if git_sync_success:
+            if image_build_mode and git_sync_success:
                 head_sha = await self._get_head_sha()
                 if head_sha:
                     self.log.info("git.sync_complete", head_sha=head_sha)

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -249,6 +249,26 @@ class SandboxSupervisor:
             self.log.error("git.update_error", exc=e)
             return False
 
+    async def _get_head_sha(self) -> str:
+        """Return the HEAD SHA of the repo, or empty string on failure."""
+        if not self.repo_path.exists():
+            return ""
+        try:
+            result = await asyncio.create_subprocess_exec(
+                "git",
+                "rev-parse",
+                "HEAD",
+                cwd=self.repo_path,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await result.communicate()
+            if result.returncode == 0:
+                return stdout.decode().strip()
+        except Exception as e:
+            self.log.warn("git.rev_parse_error", error=str(e))
+        return ""
+
     async def perform_git_sync(self) -> bool:
         """Clone repository if needed, then sync to the target branch.
 
@@ -1160,6 +1180,10 @@ class SandboxSupervisor:
                 git_sync_success = await self._update_existing_repo()
             else:
                 git_sync_success = await self.perform_git_sync()
+            if git_sync_success:
+                head_sha = await self._get_head_sha()
+                if head_sha:
+                    self.log.info("git.sync_complete", head_sha=head_sha)
             self.git_sync_complete.set()
 
             # Phase 2: Run setup script only for fresh or build boots.

--- a/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
+++ b/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
@@ -151,6 +151,42 @@ class TestImageBuildMode:
         supervisor.start_opencode.assert_not_called()
         supervisor.start_bridge.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_logs_git_sync_complete_with_head_sha(self, build_env, tmp_path):
+        """Build mode should log git.sync_complete with head_sha for the image builder."""
+        supervisor = _make_supervisor(build_env)
+        supervisor.repo_path = tmp_path  # Exists, so _get_head_sha proceeds
+
+        supervisor.perform_git_sync = AsyncMock(return_value=True)
+        supervisor.run_setup_script = AsyncMock(return_value=True)
+        supervisor.shutdown = AsyncMock()
+        supervisor.shutdown_event.set()
+        supervisor.log = MagicMock()
+
+        async def fake_subprocess(*args, **kwargs):
+            mock_proc = MagicMock()
+            mock_proc.communicate = AsyncMock(return_value=(b"abc123def456\n", b""))
+            mock_proc.returncode = 0
+            return mock_proc
+
+        with (
+            patch.dict(os.environ, build_env, clear=False),
+            patch(
+                "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
+                side_effect=fake_subprocess,
+            ),
+        ):
+            await supervisor.run()
+
+        # Verify git.sync_complete was logged with the SHA
+        sync_calls = [
+            c
+            for c in supervisor.log.info.call_args_list
+            if c.args and c.args[0] == "git.sync_complete"
+        ]
+        assert len(sync_calls) == 1
+        assert sync_calls[0].kwargs["head_sha"] == "abc123def456"
+
 
 class TestFromRepoImage:
     """FROM_REPO_IMAGE=true: update repo + start hook, skip setup."""


### PR DESCRIPTION
## Summary

- Restores the `git.sync_complete` structured log event (with `head_sha`) that was removed in #316
- The image builder's `_stream_build_logs` depends on this event to capture the SHA of the built image, which is stored as `base_sha` in D1
- Without it, `base_sha` is always stored as `""`, causing the scheduler's SHA comparison to always mismatch and trigger a rebuild every 30 minutes — even when nothing changed in the repo

### Root cause

PR #316 ("refactor: simplify git sync by extracting shared primitives") removed the `git rev-parse HEAD` call and `git.sync_complete` log from `perform_git_sync()`, classifying it as dead observational code. It was actually a side-channel dependency that the image builder relied on to populate `base_sha`.

### What changed

- Added `_get_head_sha()` helper that runs `git rev-parse HEAD` and returns the SHA
- After successful git sync in `run()`, logs `git.sync_complete` with `head_sha` — restoring the event that `_stream_build_logs` in `image_builder.py` listens for
- Added test verifying the log is emitted during build mode

### D1 evidence

The current ready image for `colemurray/background-agents` has `base_sha: ""`, confirming the SHA was never captured:

```
status: "ready",  base_sha: ""  ← built successfully, SHA empty
status: "failed", base_sha: ""  ← unnecessary rebuild triggered by empty SHA mismatch
```

After this fix deploys, the next build will store the correct SHA and subsequent scheduler ticks will skip the rebuild when nothing has changed.

## Test plan

- [x] New test: `test_logs_git_sync_complete_with_head_sha` verifies the event is logged with the correct SHA
- [x] All 269 sandbox-runtime tests pass
- [x] Ruff lint + format clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Git synchronization now captures and reports the repository HEAD SHA when sync completes successfully, making synchronized code versions more visible in logs.

* **Tests**
  * Added a test validating that the HEAD SHA is captured and logged during git synchronization in build mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->