### PR TITLE
fix: improve screenshot upload skill discoverability

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/skills/upload-screenshot/SKILL.md
+++ b/packages/sandbox-runtime/src/sandbox_runtime/skills/upload-screenshot/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: upload-screenshot
+description: Upload an existing screenshot file to the Open-Inspect session
+---
+
+# upload-screenshot
+
+Use this skill when you already have a screenshot file on disk and need to upload it to the
+Open-Inspect session. The screenshot may have been captured by any source: Playwright MCP,
+`agent-browser`, a manual file, or any other tool.
+
+For the full browser-open + capture + upload workflow, use `visual-verification` instead.
+
+## Key Fact
+
+`upload-media` is a **bash command** installed on PATH. Run it with your Bash tool. It is not an MCP
+tool or a tool binding.
+
+## When To Use It
+
+- Upload a screenshot that was already captured (e.g. via Playwright MCP)
+- Upload an image file the user points you to
+- The user says "upload the screenshot" or "upload this image"
+
+## Required Workflow
+
+1. Confirm the screenshot file exists on disk.
+2. Run `upload-media` via Bash with the file path and metadata flags.
+3. Report the returned `artifactId` to the user.
+
+## Command
+
+```bash
+upload-media <file-path> \
+  --caption "Description of screenshot" \
+  --source-url "https://example.com" \
+  [--full-page] \
+  [--annotated] \
+  [--viewport '{"width":1512,"height":982}']
+```
+
+All flags except the file path are optional. Include whichever metadata you know:
+
+- `--caption` — what the screenshot shows
+- `--source-url` — the URL that was captured
+- `--full-page` — set if the screenshot is a full-page capture
+- `--annotated` — set if the screenshot has annotations
+- `--viewport` — JSON object with width and height of the viewport used
+
+## Supported File Types
+
+`.png`, `.jpg` / `.jpeg`, `.webp`
+
+## Success Criteria
+
+The task is not complete until:
+
+1. `upload-media` returned a JSON response containing an `artifactId`.
+2. The `artifactId` is reported to the user.
+3. The response states what was uploaded and the source URL (if known).
+
+## Example
+
+```text
+Uploaded screenshot of the homepage.
+Source: https://example.com
+Uploaded artifact: abc123def456
+```
+
+## Guardrails
+
+- Do not claim the screenshot was uploaded unless `upload-media` returned an artifact ID.
+- If the file does not exist or is not a supported type, report the error instead of retrying
+  silently.
+- If the user needs a full browser workflow (open page, set viewport, capture, upload), delegate to
+  `visual-verification` instead.

--- a/packages/sandbox-runtime/src/sandbox_runtime/skills/visual-verification/SKILL.md
+++ b/packages/sandbox-runtime/src/sandbox_runtime/skills/visual-verification/SKILL.md
@@ -11,6 +11,11 @@ evidence in the Open-Inspect session.
 `agent-browser` remains the low-level browser tool. This skill defines the workflow contract for
 using it reliably.
 
+## Key Fact
+
+`upload-media` is a **bash command** installed on PATH. Run it with your Bash tool, not as an MCP
+tool or tool binding. Example: `upload-media /tmp/screenshot.png --caption "..."`.
+
 ## When To Use It
 
 - Verify a UI change after editing code
@@ -51,6 +56,23 @@ The task is not complete until all of these are true:
   report it.
 - If the screenshot is intended to prove a fix, prefer stating exactly what was checked, not only
   that a screenshot was taken.
+
+## Using Screenshots From Other Sources
+
+If the screenshot already exists as a file — for example, captured via Playwright MCP
+(`playwright_browser_take_screenshot`), a manual capture, or any other tool — skip the
+`agent-browser` steps and upload the file directly:
+
+```bash
+upload-media /path/to/existing-screenshot.png \
+  --caption "Description of what was captured" \
+  --source-url "$URL"
+```
+
+Add `--full-page` or `--viewport '{"width":1512,"height":982}'` as appropriate. The same reporting
+template and guardrails below still apply.
+
+For a dedicated upload-only workflow, see the `upload-screenshot` skill.
 
 ## Recommended Commands
 


### PR DESCRIPTION
## Summary

Fixes a failure pattern where sandbox agents couldn't upload screenshots because:
1. `upload-media` was never identified as a **bash command** — agents looked for it as an MCP tool binding and gave up
2. The `visual-verification` skill assumed `agent-browser` as the only screenshot source, with no path for Playwright MCP or pre-existing files
3. No lightweight "just upload this file" skill existed — the only option was the full verification workflow

### Changes

**`visual-verification` SKILL.md:**
- Added **Key Fact** section explicitly stating `upload-media` is a bash command on PATH
- Added **Using Screenshots From Other Sources** section covering Playwright MCP captures and pre-existing files with a direct upload command pattern

**New `upload-screenshot` skill:**
- Lightweight skill for upload-only workflows — when a screenshot file already exists on disk
- Documents the `upload-media` CLI interface, supported file types, and all metadata flags
- Cross-references `visual-verification` for full browser workflows

### How it was discovered

Observed a session where the agent:
1. Took a screenshot via Playwright MCP successfully
2. Was asked to "upload the screenshot"
3. Failed — asked "where?" because it didn't know about `upload-media`
4. Loaded `visual-verification` skill, then claimed "this session does not expose the upload-media tool"
5. Only succeeded after the user explicitly said "you should be able to directly call the upload-media script"

## Test plan

- [ ] Verify the new `upload-screenshot/SKILL.md` is auto-discovered by `_install_skills()` (it iterates all subdirs with a `SKILL.md`)
- [ ] Existing `test_skills_dir_files_copied` test pattern still passes
- [ ] In a sandbox session: take a screenshot via Playwright MCP, then invoke `upload-screenshot` — agent should call `upload-media` via Bash without confusion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for uploading existing screenshots to Open-Inspect sessions.
  * Updated visual verification documentation with clarifications on command invocation and support for alternative screenshot sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->