### PR TITLE
fix: dummy vercel api token has to be 24 chars long to pass validation

### DIFF
--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -25,10 +25,10 @@ variable "cloudflare_worker_subdomain" {
 }
 
 variable "vercel_api_token" {
-  description = "Vercel API token (required only when web_platform = 'vercel'). Do NOT set to empty string — the Vercel provider validates this on init even when no Vercel resources are created. Leave unset to use the dummy default."
+  description = "Vercel API token (required only when web_platform = 'vercel'). Do NOT set to empty string — the Vercel provider validates this on init even when no Vercel resources are created. Leave unset to use the built-in dummy token for Cloudflare-only deployments."
   type        = string
   sensitive   = true
-  default     = "unused"
+  default     = "000000000000000000000000"
 }
 
 variable "vercel_team_id" {

--- a/terraform/environments/production/versions.tf
+++ b/terraform/environments/production/versions.tf
@@ -30,8 +30,9 @@ provider "cloudflare" {
 }
 
 # NOTE: The Vercel provider validates api_token on init even when web_platform = "cloudflare"
-# and no Vercel resources are created. The default value "unused" satisfies the provider's
-# non-empty check. Do not set vercel_api_token to "" in tfvars when using Cloudflare.
+# and no Vercel resources are created. The default value is a dummy 24-character lowercase hex
+# token that satisfies provider format validation. Do not set vercel_api_token to "" in tfvars
+# when using Cloudflare.
 provider "vercel" {
   api_token = var.vercel_api_token
   team      = var.web_platform == "vercel" ? var.vercel_team_id : null


### PR DESCRIPTION
It seems like vercel changed validation, and now also checks if the token is 24 chars long

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default dummy Vercel API token used for Cloudflare-only deployments.
  * Clarified deployment guidance: leaving the Vercel API token unset will use the built-in dummy token and avoid setting an empty token in environment overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->