### PR TITLE
fix: make access control terraform check a hard error

### DIFF
--- a/packages/web/src/lib/access-control.test.ts
+++ b/packages/web/src/lib/access-control.test.ts
@@ -157,6 +157,24 @@ describe("checkAccessAllowed", () => {
     });
   });
 
+  describe("when unsafeAllowAllUsers is true with populated allowlists", () => {
+    const config = {
+      allowedDomains: ["company.com"],
+      allowedUsers: ["specialuser"],
+      unsafeAllowAllUsers: true,
+    };
+
+    it("still enforces the allowlist for matching users", () => {
+      expect(checkAccessAllowed(config, { githubUsername: "specialuser" })).toBe(true);
+      expect(checkAccessAllowed(config, { email: "user@company.com" })).toBe(true);
+    });
+
+    it("denies users not in the allowlist", () => {
+      expect(checkAccessAllowed(config, { githubUsername: "randomuser" })).toBe(false);
+      expect(checkAccessAllowed(config, { email: "user@other.com" })).toBe(false);
+    });
+  });
+
   describe("multiple values in allowlists", () => {
     const config = {
       allowedDomains: ["company.com", "partner.org"],

--- a/packages/web/src/lib/access-control.ts
+++ b/packages/web/src/lib/access-control.ts
@@ -38,8 +38,7 @@ export function checkAccessAllowed(
   config: AccessControlConfig,
   params: AccessCheckParams
 ): boolean {
-  const { allowedDomains, allowedUsers } = config;
-  const { unsafeAllowAllUsers } = config;
+  const { allowedDomains, allowedUsers, unsafeAllowAllUsers } = config;
   const { githubUsername, email } = params;
 
   // Empty allowlists only permit sign-in when explicitly enabled.

--- a/terraform/environments/production/checks.tf
+++ b/terraform/environments/production/checks.tf
@@ -12,13 +12,17 @@ check "vercel_url_matches" {
   }
 }
 
-check "access_controls_configured" {
-  assert {
-    condition = (
-      var.unsafe_allow_all_users ||
-      length([for item in split(",", var.allowed_users) : trimspace(item) if trimspace(item) != ""]) > 0 ||
-      length([for item in split(",", var.allowed_email_domains) : trimspace(item) if trimspace(item) != ""]) > 0
-    )
-    error_message = "At least one access control allowlist must be configured. Set allowed_users or allowed_email_domains, or set unsafe_allow_all_users = true to explicitly allow all authenticated GitHub users."
+# Fail the plan when no access control is configured. Uses terraform_data with a
+# precondition so this is a hard error, not an advisory check-block warning.
+resource "terraform_data" "access_control_gate" {
+  lifecycle {
+    precondition {
+      condition = (
+        var.unsafe_allow_all_users ||
+        length([for item in split(",", var.allowed_users) : trimspace(item) if trimspace(item) != ""]) > 0 ||
+        length([for item in split(",", var.allowed_email_domains) : trimspace(item) if trimspace(item) != ""]) > 0
+      )
+      error_message = "At least one access control allowlist must be configured. Set allowed_users or allowed_email_domains, or set unsafe_allow_all_users = true to explicitly allow all authenticated GitHub users."
+    }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #502 — strengthens the access control guardrails:

- **Replace advisory `check` block with `terraform_data` precondition** — Terraform `check` blocks only produce warnings and don't block `apply`. The new `precondition` on a `terraform_data` resource makes this a hard error that blocks `terraform plan`/`apply` when neither allowlist nor `unsafe_allow_all_users` is configured.
- **Add missing test for `unsafeAllowAllUsers: true` with populated allowlists** — verifies that when both the flag and allowlists are set, the allowlist is still enforced (non-matching users are denied).
- **Combine duplicated destructuring** in `checkAccessAllowed`.

## Test plan

- [x] `npm test -w @open-inspect/web` — 27 tests pass (2 new)
- [x] `terraform fmt -check` — clean
- [ ] Verify `terraform plan` fails when both allowlists are empty and `unsafe_allow_all_users = false`
- [ ] Verify `terraform plan` succeeds when `unsafe_allow_all_users = true` or an allowlist is set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for access control scenarios, including allowlist enforcement behavior with various configuration combinations.

* **Refactor**
  * Optimized access control implementation code structure for improved maintainability.

* **Chores**
  * Updated production infrastructure access control validation to be enforced at deployment-time via infrastructure preconditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->