### PR TITLE
refactor: phase 4 spacing and polish

### DIFF
--- a/packages/web/src/app/(app)/analytics/page.tsx
+++ b/packages/web/src/app/(app)/analytics/page.tsx
@@ -8,6 +8,7 @@ import { AnalyticsTimeseriesChart } from "@/components/analytics/timeseries-char
 import { AnalyticsUserTable } from "@/components/analytics/user-table";
 import { useSidebarContext } from "@/components/sidebar-layout";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { SidebarIcon } from "@/components/ui/icons";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
@@ -61,19 +62,20 @@ export default function AnalyticsPage() {
       {!isOpen && (
         <header className="border-b border-border-muted flex-shrink-0">
           <div className="px-4 py-3">
-            <button
+            <Button
+              variant="ghost"
+              size="icon"
               onClick={toggle}
-              className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition"
               title={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
               aria-label={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
             >
               <SidebarIcon className="w-4 h-4" />
-            </button>
+            </Button>
           </div>
         </header>
       )}
 
-      <div className="flex-1 overflow-y-auto p-6 sm:p-8">
+      <div className="flex-1 overflow-y-auto p-8">
         <div className="relative z-10 mx-auto max-w-7xl space-y-6">
           <div className="relative overflow-hidden rounded-xl border border-border-muted bg-card px-5 py-5 sm:px-6 sm:py-6">
             <div className="pointer-events-none absolute inset-y-0 right-0 w-1/3 bg-[linear-gradient(135deg,var(--accent-muted),transparent)] opacity-70" />

--- a/packages/web/src/app/(app)/automations/[id]/page.tsx
+++ b/packages/web/src/app/(app)/automations/[id]/page.tsx
@@ -112,7 +112,7 @@ export default function AutomationDetailPage({ params }: { params: Promise<{ id:
         </header>
       )}
 
-      <div className="flex-1 overflow-y-auto px-4 py-6 sm:p-8">
+      <div className="flex-1 overflow-y-auto p-8">
         <div className="max-w-3xl mx-auto">
           {actionError && (
             <ErrorBanner className="mb-4" role="alert">

--- a/packages/web/src/components/automations/automation-form.tsx
+++ b/packages/web/src/components/automations/automation-form.tsx
@@ -181,12 +181,12 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
       {/* Trigger Type */}
       {mode === "create" ? (
         <div>
-          <label className="block text-sm font-medium text-foreground mb-2">Trigger Type</label>
+          <label className="block text-sm font-medium text-foreground mb-1.5">Trigger Type</label>
           <TriggerTypeSelector value={triggerType} onChange={setTriggerType} />
         </div>
       ) : (
         <div>
-          <label className="block text-sm font-medium text-foreground mb-1">Trigger Type</label>
+          <label className="block text-sm font-medium text-foreground mb-1.5">Trigger Type</label>
           <div className="text-sm text-muted-foreground px-3 py-2 border border-border-muted rounded-md bg-muted/30">
             {{
               schedule: "Schedule",
@@ -202,7 +202,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
 
       {/* Name */}
       <div>
-        <label className="block text-sm font-medium text-foreground mb-1">Name</label>
+        <label className="block text-sm font-medium text-foreground mb-1.5">Name</label>
         <Input
           type="text"
           value={name}
@@ -215,7 +215,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
 
       {/* Repository */}
       <div>
-        <label className="block text-sm font-medium text-foreground mb-1">Repository</label>
+        <label className="block text-sm font-medium text-foreground mb-1.5">Repository</label>
         <Combobox
           value={selectedRepo}
           onChange={handleRepoChange}
@@ -245,7 +245,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
 
       {/* Branch */}
       <div>
-        <label className="block text-sm font-medium text-foreground mb-1">Branch</label>
+        <label className="block text-sm font-medium text-foreground mb-1.5">Branch</label>
         <Combobox
           value={baseBranch}
           onChange={setBaseBranch}
@@ -270,7 +270,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
 
       {/* Model */}
       <div>
-        <label className="block text-sm font-medium text-foreground mb-1">Model</label>
+        <label className="block text-sm font-medium text-foreground mb-1.5">Model</label>
         <Combobox
           value={model}
           onChange={(nextModel) => {
@@ -299,7 +299,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
       </div>
 
       <div>
-        <label className="block text-sm font-medium text-foreground mb-1">Reasoning Effort</label>
+        <label className="block text-sm font-medium text-foreground mb-1.5">Reasoning Effort</label>
         <Select
           value={reasoningConfig ? reasoningEffort || DEFAULT_REASONING_VALUE : ""}
           onValueChange={(value) =>
@@ -327,11 +327,11 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
       {isSchedule && (
         <>
           <div>
-            <label className="block text-sm font-medium text-foreground mb-1">Schedule</label>
+            <label className="block text-sm font-medium text-foreground mb-1.5">Schedule</label>
             <CronPicker value={scheduleCron} onChange={setScheduleCron} timezone={scheduleTz} />
           </div>
           <div>
-            <label className="block text-sm font-medium text-foreground mb-1">Timezone</label>
+            <label className="block text-sm font-medium text-foreground mb-1.5">Timezone</label>
             <Combobox
               value={scheduleTz}
               onChange={setScheduleTz}
@@ -356,7 +356,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
       {/* Event type selector (for Sentry) */}
       {triggerType === "sentry" && eventTypes.length > 0 && (
         <div>
-          <label className="block text-sm font-medium text-foreground mb-1">Event Type</label>
+          <label className="block text-sm font-medium text-foreground mb-1.5">Event Type</label>
           <Select value={eventType} onValueChange={setEventType}>
             <SelectTrigger className="w-full">
               <SelectValue placeholder="Select event type..." />
@@ -376,7 +376,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
       {/* Sentry Client Secret (create mode only) */}
       {triggerType === "sentry" && mode === "create" && (
         <div>
-          <label className="block text-sm font-medium text-foreground mb-1">
+          <label className="block text-sm font-medium text-foreground mb-1.5">
             Sentry Client Secret
           </label>
           <Input
@@ -396,7 +396,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
       {/* Conditions (for non-schedule types) */}
       {!isSchedule && TRIGGER_TYPE_TO_SOURCE[triggerType] && (
         <div>
-          <label className="block text-sm font-medium text-foreground mb-1">
+          <label className="block text-sm font-medium text-foreground mb-1.5">
             Conditions
             <span className="text-xs text-muted-foreground ml-1 font-normal">(optional)</span>
           </label>
@@ -410,7 +410,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
 
       {/* Instructions */}
       <div>
-        <label className="block text-sm font-medium text-foreground mb-1">Instructions</label>
+        <label className="block text-sm font-medium text-foreground mb-1.5">Instructions</label>
         <Textarea
           value={instructions}
           onChange={(e) => setInstructions(e.target.value)}
@@ -429,7 +429,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
       </div>
 
       {/* Submit */}
-      <div className="flex justify-end gap-3">
+      <div className="flex justify-end gap-2">
         <Button
           type="submit"
           disabled={

--- a/packages/web/src/components/settings/appearance-settings.tsx
+++ b/packages/web/src/components/settings/appearance-settings.tsx
@@ -68,7 +68,7 @@ export function AppearanceSettings() {
           Customize how code is displayed in sessions.
         </p>
 
-        <div className="border border-border rounded-md divide-y divide-border">
+        <div className="border border-border rounded-md divide-y divide-border-muted">
           {/* Color scheme mode toggle */}
           <div className="flex items-center justify-between px-4 py-3">
             <div>

--- a/packages/web/src/components/settings/data-controls-settings.tsx
+++ b/packages/web/src/components/settings/data-controls-settings.tsx
@@ -95,7 +95,7 @@ export function DataControlsSettings() {
             No archived sessions. Sessions you archive will appear here.
           </div>
         ) : (
-          <div className="border border-border rounded-md divide-y divide-border">
+          <div className="border border-border rounded-md divide-y divide-border-muted">
             {sessions.map((session) => (
               <ArchivedSessionRow
                 key={session.id}

--- a/packages/web/src/components/settings/keyboard-shortcuts-settings.tsx
+++ b/packages/web/src/components/settings/keyboard-shortcuts-settings.tsx
@@ -11,7 +11,7 @@ export function KeyboardShortcutsSettings() {
         Use shortcuts for quick navigation and sending prompts.
       </p>
 
-      <div className="border border-border rounded-md divide-y divide-border">
+      <div className="border border-border rounded-md divide-y divide-border-muted">
         <ShortcutRow label="Send prompt" shortcut={SHORTCUT_LABELS.SEND_PROMPT} />
         <ShortcutRow label="Command menu" shortcut={SHORTCUT_LABELS.COMMAND_MENU} />
         <ShortcutRow label="New session" shortcut={SHORTCUT_LABELS.NEW_SESSION} />

--- a/packages/web/src/components/settings/mcp-servers-settings.tsx
+++ b/packages/web/src/components/settings/mcp-servers-settings.tsx
@@ -270,7 +270,7 @@ function McpServerForm({
   return (
     <>
       <div>
-        <Label className="mb-1">Name</Label>
+        <Label className="mb-1.5">Name</Label>
         <Input
           value={form.name}
           onChange={(e) => setForm({ ...form, name: e.target.value })}
@@ -279,7 +279,7 @@ function McpServerForm({
       </div>
 
       <div>
-        <Label className="mb-1">Type</Label>
+        <Label className="mb-1.5">Type</Label>
         <div className="flex gap-2">
           <button
             onClick={() => setForm({ ...form, type: "local" })}
@@ -308,7 +308,7 @@ function McpServerForm({
 
       {form.type === "remote" ? (
         <div>
-          <Label className="mb-1">URL</Label>
+          <Label className="mb-1.5">URL</Label>
           <Input
             type="url"
             value={form.url}
@@ -318,7 +318,7 @@ function McpServerForm({
         </div>
       ) : (
         <div>
-          <Label className="mb-1">Command</Label>
+          <Label className="mb-1.5">Command</Label>
           <Input
             value={form.command}
             onChange={(e) => setForm({ ...form, command: e.target.value })}
@@ -337,7 +337,7 @@ function McpServerForm({
       />
 
       <div>
-        <Label className="mb-2">Availability</Label>
+        <Label className="mb-1.5">Availability</Label>
         <div className="space-y-2 mb-2">
           <RadioCard
             name={`scope-mode-${radioPrefix}`}
@@ -658,7 +658,7 @@ export function McpServersSettings() {
 
                 {/* Expanded edit form */}
                 {isExpanded && editing === server.id && (
-                  <div className="px-4 pb-4 pt-3 border-t border-border space-y-4">
+                  <div className="px-4 pb-4 pt-3 border-t border-border-muted space-y-4">
                     <McpServerForm
                       form={form}
                       setForm={setForm}

--- a/packages/web/src/components/settings/secrets-settings.tsx
+++ b/packages/web/src/components/settings/secrets-settings.tsx
@@ -30,7 +30,7 @@ export function SecretsSettings() {
       </p>
 
       {/* Repo selector */}
-      <div className="mb-4">
+      <div className="mb-6">
         <label className="block text-sm font-medium text-foreground mb-1.5">Repository</label>
         <Combobox
           value={selectedRepo}

--- a/packages/web/src/components/sidebar/collapsible-section.tsx
+++ b/packages/web/src/components/sidebar/collapsible-section.tsx
@@ -20,7 +20,7 @@ export function CollapsibleSection({
     <div className="border-b border-border-muted last:border-b-0">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium text-foreground hover:bg-muted transition-colors"
+        className="flex items-center justify-between w-full px-4 py-4 text-sm font-medium text-foreground hover:bg-muted transition-colors"
       >
         <span>{title}</span>
         <ChevronDownIcon

--- a/packages/web/src/components/ui/dialog.tsx
+++ b/packages/web/src/components/ui/dialog.tsx
@@ -50,10 +50,7 @@ DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return (
-    <div
-      className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)}
-      {...props}
-    />
+    <div className={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...props} />
   );
 }
 


### PR DESCRIPTION
## Summary
- Standardize label-to-input gap to `mb-1.5` across automation-form (14 labels) and mcp-servers-settings (5 labels)
- Fix secrets-settings repo selector gap from `mb-4` to `mb-6` to match sandbox-settings
- Standardize content padding to `p-8` (analytics, automation detail)
- Align collapsible section header padding to `py-4` (was `py-3`)
- Standardize row separators to `divide-border-muted` (appearance, keyboard shortcuts, data controls)
- Unify `DialogHeader` and `AlertDialogHeader` spacing to `space-y-2`
- Standardize automation form submit button gap to `gap-2`
- Migrate analytics page sidebar toggle to `Button` component

## Test plan
- [ ] Verify label-to-input spacing is consistent across automation form and MCP settings
- [ ] Verify secrets and sandbox settings repo selectors have matching description-to-content gaps
- [ ] Verify analytics and automation detail pages have consistent p-8 padding
- [ ] Verify collapsible sections in right sidebar align with non-collapsible sections
- [ ] Verify row separators use subtle border-muted across all settings panels
- [ ] Verify dialog and alert-dialog headers have matching space-y-2 spacing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined UI spacing and padding across analytics, automations, and settings pages for improved visual consistency.
  * Updated divider colors in settings components for better visual hierarchy.
  * Adjusted form label spacing and button gaps throughout the application.
  * Enhanced dialog header and collapsible section spacing.

* **Refactor**
  * Standardized button component usage in analytics page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->