### PR TITLE
refactor: phase 5 accessibility improvements

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -753,6 +753,14 @@ function SessionContent({
                 <h1
                   className="text-sm font-medium text-foreground max-w-40 truncate cursor-text"
                   onClick={handleStartRename}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      handleStartRename();
+                    }
+                  }}
+                  role="button"
+                  tabIndex={0}
                   title="Click to rename"
                 >
                   {resolvedTitle}

--- a/packages/web/src/components/automations/condition-builder.tsx
+++ b/packages/web/src/components/automations/condition-builder.tsx
@@ -185,9 +185,10 @@ function TagInput({
             <button
               type="button"
               onClick={() => removeValue(v)}
+              aria-label={`Remove ${v}`}
               className="text-muted-foreground hover:text-foreground"
             >
-              x
+              ×
             </button>
           </span>
         ))}

--- a/packages/web/src/components/reasoning-effort-pills.tsx
+++ b/packages/web/src/components/reasoning-effort-pills.tsx
@@ -35,6 +35,7 @@ export function ReasoningEffortPills({
       onClick={handleCycle}
       disabled={disabled}
       className="px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground transition disabled:opacity-50 disabled:cursor-not-allowed"
+      aria-label={`Reasoning: ${reasoningEffort ?? config.default ?? "default"} (click to cycle)`}
       title={`Reasoning: ${reasoningEffort ?? config.default ?? "default"} (click to cycle)`}
     >
       {reasoningEffort ?? config.default ?? "default"}

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -361,6 +361,7 @@ function UserMenu({ user }: { user?: { name?: string | null; image?: string | nu
       <DropdownMenuTrigger asChild>
         <button
           className="w-7 h-7 rounded-full overflow-hidden focus:outline-none focus:ring-2 focus:ring-primary"
+          aria-label={`Signed in as ${user?.name || "User"}`}
           title={`Signed in as ${user?.name || "User"}`}
         >
           {user?.image ? (
@@ -663,6 +664,8 @@ function SessionListItem({
             <button
               type="button"
               aria-label="Session actions"
+              aria-hidden={isMobile ? "true" : undefined}
+              tabIndex={isMobile ? -1 : undefined}
               className={`h-6 w-6 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition data-[state=open]:opacity-100 ${
                 isMobile
                   ? "pointer-events-none flex opacity-0"

--- a/packages/web/src/components/settings/mcp-servers-settings.tsx
+++ b/packages/web/src/components/settings/mcp-servers-settings.tsx
@@ -603,8 +603,9 @@ export function McpServersSettings() {
                 }`}
               >
                 {/* Header row */}
-                <div
-                  className="flex items-center justify-between px-4 py-3 cursor-pointer"
+                <button
+                  type="button"
+                  className="flex w-full items-center justify-between px-4 py-3 cursor-pointer text-left"
                   onClick={() => startEdit(server)}
                 >
                   <div className="flex items-center gap-3 min-w-0">
@@ -654,7 +655,7 @@ export function McpServersSettings() {
                       Delete
                     </button>
                   </div>
-                </div>
+                </button>
 
                 {/* Expanded edit form */}
                 {isExpanded && editing === server.id && (

--- a/packages/web/src/components/settings/mcp-servers-settings.tsx
+++ b/packages/web/src/components/settings/mcp-servers-settings.tsx
@@ -603,12 +603,12 @@ export function McpServersSettings() {
                 }`}
               >
                 {/* Header row */}
-                <button
-                  type="button"
-                  className="flex w-full items-center justify-between px-4 py-3 cursor-pointer text-left"
-                  onClick={() => startEdit(server)}
-                >
-                  <div className="flex items-center gap-3 min-w-0">
+                <div className="flex items-center justify-between px-4 py-3">
+                  <button
+                    type="button"
+                    className="flex items-center gap-3 min-w-0 cursor-pointer text-left"
+                    onClick={() => startEdit(server)}
+                  >
                     <ChevronRightIcon
                       className={`w-3 h-3 text-muted-foreground flex-shrink-0 transition-transform ${
                         isExpanded ? "rotate-90" : ""
@@ -637,12 +637,9 @@ export function McpServersSettings() {
                         )}
                       </div>
                     </div>
-                  </div>
+                  </button>
 
-                  <div
-                    className="flex items-center gap-1 flex-shrink-0"
-                    onClick={(e) => e.stopPropagation()}
-                  >
+                  <div className="flex items-center gap-1 flex-shrink-0">
                     <Switch
                       checked={server.enabled}
                       onCheckedChange={() => handleToggle(server)}
@@ -655,7 +652,7 @@ export function McpServersSettings() {
                       Delete
                     </button>
                   </div>
-                </button>
+                </div>
 
                 {/* Expanded edit form */}
                 {isExpanded && editing === server.id && (

--- a/packages/web/src/components/settings/settings-nav.tsx
+++ b/packages/web/src/components/settings/settings-nav.tsx
@@ -115,6 +115,7 @@ export function SettingsNav({ activeCategory, onSelect, onNavigate }: SettingsNa
             <li key={item.id}>
               <button
                 onClick={() => onSelect(item.id)}
+                aria-current={isActive ? "page" : undefined}
                 className={`w-full flex items-center gap-2 px-3 py-2 text-sm rounded transition ${
                   isActive
                     ? "text-foreground bg-muted font-medium"

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -110,6 +110,8 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
             className={`fixed inset-0 z-30 bg-overlay transition-opacity duration-200 ${
               sidebar.isOpen ? "opacity-100" : "opacity-0 pointer-events-none"
             }`}
+            role="presentation"
+            aria-hidden="true"
             onClick={sidebar.close}
           />
         )}


### PR DESCRIPTION
## Summary

Final phase of the design system audit — adds accessibility improvements across the web UI:

- **Session title rename**: Add `role="button"`, `tabIndex`, and `onKeyDown` (Enter/Space) so keyboard users can trigger rename
- **MCP server card header**: Convert clickable `<div>` to `<button>` for native keyboard/screen reader support
- **Settings nav**: Add `aria-current="page"` to the active nav item
- **Reasoning effort pills**: Add `aria-label` alongside existing `title` attribute
- **User menu trigger**: Add `aria-label` alongside existing `title` attribute
- **Session "More" button (mobile)**: Add `aria-hidden="true"` and `tabIndex={-1}` when visually hidden on mobile to prevent screen reader access to non-interactive element
- **Condition builder tag remove**: Add `aria-label="Remove {value}"` and use `×` character instead of `x`
- **Mobile sidebar backdrop**: Add `role="presentation"` and `aria-hidden="true"` to decorative overlay

## Test plan
- [ ] Verify session title rename is triggerable via keyboard (Tab to focus, Enter/Space to activate)
- [ ] Verify MCP server cards expand/collapse via keyboard
- [ ] Verify screen reader announces active settings nav item
- [ ] Verify condition builder remove buttons have accessible labels
- [ ] Build passes with no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard activation and focusability for session titles and navigation items.
  * Added descriptive aria-labels to tag removals, reasoning controls, and user menu trigger for screen readers.
  * Adjusted interactive element semantics and tab behavior in sidebars and settings for clearer keyboard navigation.
  * Marked backdrop and non-interactive controls appropriately to reduce accidental focus and improve assistive-tool behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->