### PR TITLE
fix: close mobile sidebar on sidebar navigation

### DIFF
--- a/packages/web/src/components/session-sidebar.test.tsx
+++ b/packages/web/src/components/session-sidebar.test.tsx
@@ -139,6 +139,7 @@ describe("SessionSidebar", () => {
 
   it("navigates directly on mobile tap without opening rename actions", async () => {
     mockUseIsMobile.mockReturnValue(true);
+    const onSessionSelect = vi.fn();
 
     render(
       <SWRConfig
@@ -148,7 +149,7 @@ describe("SessionSidebar", () => {
           revalidateOnFocus: false,
         }}
       >
-        <SessionSidebar onSessionSelect={vi.fn()} />
+        <SessionSidebar onSessionSelect={onSessionSelect} />
       </SWRConfig>
     );
 
@@ -156,6 +157,31 @@ describe("SessionSidebar", () => {
     fireEvent.click(link);
 
     expect(screen.queryByText("Rename")).not.toBeInTheDocument();
+    expect(onSessionSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the sidebar on mobile when using non-session navigation links", () => {
+    mockUseIsMobile.mockReturnValue(true);
+    const onSessionSelect = vi.fn();
+
+    render(
+      <SWRConfig
+        value={{
+          fallback: { [SIDEBAR_SESSIONS_KEY]: { sessions: [createSession(1)], hasMore: false } },
+          dedupingInterval: 0,
+          revalidateOnFocus: false,
+        }}
+      >
+        <SessionSidebar onSessionSelect={onSessionSelect} />
+      </SWRConfig>
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: /^inspect$/i }));
+    fireEvent.click(screen.getByTitle("Settings"));
+    fireEvent.click(screen.getByRole("link", { name: /automations/i }));
+    fireEvent.click(screen.getByRole("link", { name: /analytics/i }));
+
+    expect(onSessionSelect).toHaveBeenCalledTimes(4);
   });
 
   it("opens rename actions on mobile long press", async () => {

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -216,6 +216,12 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
 
   const currentSessionId = pathname?.startsWith("/session/") ? pathname.split("/")[2] : null;
 
+  const handleNavigationSelect = useCallback(() => {
+    if (isMobile) {
+      onSessionSelect?.();
+    }
+  }, [isMobile, onSessionSelect]);
+
   return (
     <aside className="w-72 h-dvh flex flex-col border-r border-border-muted bg-background">
       {/* Header */}
@@ -230,7 +236,7 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
           >
             <SidebarIcon className="w-4 h-4" />
           </Button>
-          <Link href="/" className="flex items-center gap-2">
+          <Link href="/" onClick={handleNavigationSelect} className="flex items-center gap-2">
             <InspectIcon className="w-5 h-5" />
             <span className="font-semibold text-foreground">Inspect</span>
           </Link>
@@ -247,6 +253,7 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
           </Button>
           <Link
             href="/settings"
+            onClick={handleNavigationSelect}
             className={`p-1.5 transition ${
               pathname === "/settings"
                 ? "text-foreground bg-muted"
@@ -264,6 +271,7 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
       <div className="px-3 pt-2 pb-1 flex flex-col gap-0.5">
         <Link
           href="/automations"
+          onClick={handleNavigationSelect}
           className={`flex items-center gap-2 px-3 py-1.5 text-sm rounded-md transition ${
             pathname?.startsWith("/automations")
               ? "text-foreground bg-muted"
@@ -275,6 +283,7 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
         </Link>
         <Link
           href="/analytics"
+          onClick={handleNavigationSelect}
           className={`flex items-center gap-2 px-3 py-1.5 text-sm rounded-md transition ${
             pathname?.startsWith("/analytics")
               ? "text-foreground bg-muted"


### PR DESCRIPTION
## Summary
- close the mobile sidebar when users tap the non-session navigation links in the session sidebar
- align `Inspect`, `Settings`, `Automations`, and `Analytics` with the existing mobile close behavior already used by session items
- add sidebar component coverage to verify those links invoke the close callback on mobile

## Testing
- `npm test -w @open-inspect/web -- src/components/session-sidebar.test.tsx`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/1230cbfd8eef8bb0c4288ceaca339292)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session sidebar navigation behavior on mobile devices—navigation links now properly trigger session selection when clicked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->