### PR TITLE
fix: surface agent error messages through callback chain and web UI

### DIFF
--- a/packages/control-plane/src/session/callback-notification-service.ts
+++ b/packages/control-plane/src/session/callback-notification-service.ts
@@ -125,6 +125,7 @@ export class CallbackNotificationService {
       sessionId,
       messageId,
       success,
+      ...(error != null ? { error } : {}),
       timestamp,
       context,
     };

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -232,10 +232,12 @@ export class SessionMessageQueue {
         message_id: processingMessage.id,
       });
 
+      const stopError = "Execution was stopped";
       const syntheticExecutionComplete: Extract<SandboxEvent, { type: "execution_complete" }> = {
         type: "execution_complete",
         messageId: processingMessage.id,
         success: false,
+        error: stopError,
         sandboxId: "",
         timestamp: now / 1000,
       };
@@ -251,7 +253,7 @@ export class SessionMessageQueue {
       });
 
       this.deps.ctx.waitUntil(
-        this.deps.callbackService.notifyComplete(processingMessage.id, false)
+        this.deps.callbackService.notifyComplete(processingMessage.id, false, stopError)
       );
 
       if (!options.suppressStatusReconcile) {
@@ -281,17 +283,21 @@ export class SessionMessageQueue {
 
     this.deps.repository.updateMessageCompletion(processingMessage.id, "failed", now);
 
+    const stuckError = "Execution timed out (stuck processing)";
     const syntheticEvent: Extract<SandboxEvent, { type: "execution_complete" }> = {
       type: "execution_complete",
       messageId: processingMessage.id,
       success: false,
+      error: stuckError,
       sandboxId: "",
       timestamp: now / 1000,
     };
     this.deps.repository.upsertExecutionCompleteEvent(processingMessage.id, syntheticEvent, now);
     this.deps.broadcast({ type: "sandbox_event", event: syntheticEvent });
     this.deps.broadcast({ type: "processing_status", isProcessing: false });
-    this.deps.ctx.waitUntil(this.deps.callbackService.notifyComplete(processingMessage.id, false));
+    this.deps.ctx.waitUntil(
+      this.deps.callbackService.notifyComplete(processingMessage.id, false, stuckError)
+    );
     await this.deps.reconcileSessionStatusAfterExecution(false);
   }
 

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -201,7 +201,7 @@ export class SessionSandboxEventProcessor {
           isProcessing: this.deps.getIsProcessing(),
         });
         this.deps.ctx.waitUntil(
-          this.deps.callbackService.notifyComplete(completionMessageId, event.success)
+          this.deps.callbackService.notifyComplete(completionMessageId, event.success, event.error)
         );
 
         await this.deps.reconcileSessionStatusAfterExecution(event.success);

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -119,6 +119,7 @@ export interface CompletionCallback {
   sessionId: string;
   messageId: string;
   success: boolean;
+  error?: string;
   timestamp: number;
   signature: string;
   context: LinearCallbackContext;

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -604,19 +604,19 @@ class AgentBridge:
             reasoning_effort=reasoning_effort,
         )
 
-        scm_name = author_data.get("scmName")
-        scm_email = author_data.get("scmEmail")
-        await self._configure_git_identity(
-            GitUser(
-                name=scm_name or FALLBACK_GIT_USER.name,
-                email=scm_email or FALLBACK_GIT_USER.email,
-            )
-        )
-
-        if not self.opencode_session_id:
-            await self._create_opencode_session()
-
         try:
+            scm_name = author_data.get("scmName")
+            scm_email = author_data.get("scmEmail")
+            await self._configure_git_identity(
+                GitUser(
+                    name=scm_name or FALLBACK_GIT_USER.name,
+                    email=scm_email or FALLBACK_GIT_USER.email,
+                )
+            )
+
+            if not self.opencode_session_id:
+                await self._create_opencode_session()
+
             had_error = False
             error_message = None
             async for event in self._stream_opencode_response_sse(

--- a/packages/shared/src/completion/extractor.ts
+++ b/packages/shared/src/completion/extractor.ts
@@ -137,8 +137,13 @@ export async function extractAgentResponse(
     const artifacts = await fetchSessionArtifacts(deps, sessionId, headers, base);
     const finalArtifacts = artifacts.length > 0 ? artifacts : eventArtifacts;
 
-    // Check for completion event to get success status
+    // Check for completion event to get success status and error message.
+    // The error may be on execution_complete itself, or on a separate "error" event.
     const completionEvent = allEvents.find((e) => e.type === "execution_complete");
+    const errorEvent = allEvents.find((e) => e.type === "error");
+    const errorMessage =
+      (completionEvent?.data.error != null ? String(completionEvent.data.error) : undefined) ??
+      (errorEvent?.data.error != null ? String(errorEvent.data.error) : undefined);
 
     log.info("control_plane.fetch_events", {
       ...base,
@@ -147,6 +152,7 @@ export async function extractAgentResponse(
       tool_call_count: toolCalls.length,
       artifact_count: finalArtifacts.length,
       has_text: Boolean(textContent),
+      has_error: Boolean(errorMessage),
       duration_ms: Date.now() - startTime,
     });
 
@@ -155,6 +161,7 @@ export async function extractAgentResponse(
       toolCalls,
       artifacts: finalArtifacts,
       success: Boolean(completionEvent?.data.success),
+      error: errorMessage,
     };
   } catch (error) {
     log.error("control_plane.fetch_events", {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -468,6 +468,7 @@ export interface AgentResponse {
   toolCalls: ToolCallSummary[];
   artifacts: ArtifactInfo[];
   success: boolean;
+  error?: string;
 }
 
 export interface UserPreferences {

--- a/packages/slack-bot/src/callbacks.ts
+++ b/packages/slack-bot/src/callbacks.ts
@@ -159,42 +159,45 @@ async function handleCompletionCallback(
     // Fetch events to build response (filtered by messageId directly)
     const agentResponse = await extractAgentResponse(env, sessionId, payload.messageId, traceId);
 
+    // Merge error from callback payload and extracted response
+    const errorMessage = agentResponse.error || payload.error;
+    if (errorMessage && !agentResponse.error) {
+      agentResponse.error = errorMessage;
+    }
+
     // Check if extraction succeeded (has content or was explicitly successful)
     if (!agentResponse.textContent && agentResponse.toolCalls.length === 0 && !payload.success) {
+      const displayError = errorMessage || "Unknown error";
       log.error("callback.complete", {
         ...base,
         outcome: "error",
         error_message: "empty_agent_response",
+        agent_error: displayError,
         duration_ms: Date.now() - startTime,
       });
-      await postMessage(
-        env.SLACK_BOT_TOKEN,
-        context.channel,
-        "The agent completed but I couldn't retrieve the response. Please check the web UI for details.",
-        {
-          thread_ts: context.threadTs,
-          blocks: [
-            {
-              type: "section",
-              text: {
-                type: "mrkdwn",
-                text: ":warning: The agent completed but I couldn't retrieve the response.",
+      await postMessage(env.SLACK_BOT_TOKEN, context.channel, `The agent failed: ${displayError}`, {
+        thread_ts: context.threadTs,
+        blocks: [
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: `:x: *Agent failed:* ${displayError}`,
+            },
+          },
+          {
+            type: "actions",
+            elements: [
+              {
+                type: "button",
+                text: { type: "plain_text", text: "View Session" },
+                url: `${env.WEB_APP_URL}/session/${sessionId}`,
+                action_id: "view_session",
               },
-            },
-            {
-              type: "actions",
-              elements: [
-                {
-                  type: "button",
-                  text: { type: "plain_text", text: "View Session" },
-                  url: `${env.WEB_APP_URL}/session/${sessionId}`,
-                  action_id: "view_session",
-                },
-              ],
-            },
-          ],
-        }
-      );
+            ],
+          },
+        ],
+      });
 
       if (context.reactionMessageTs) {
         await clearThinkingReaction(env, context.channel, context.reactionMessageTs, traceId);

--- a/packages/slack-bot/src/callbacks.ts
+++ b/packages/slack-bot/src/callbacks.ts
@@ -6,7 +6,7 @@ import { computeHmacHex, timingSafeEqual } from "@open-inspect/shared";
 import { Hono } from "hono";
 import type { Env, CompletionCallback } from "./types";
 import { extractAgentResponse } from "./completion/extractor";
-import { buildCompletionBlocks, getFallbackText } from "./completion/blocks";
+import { buildCompletionBlocks, getFallbackText, truncateError } from "./completion/blocks";
 import { postMessage, removeReaction } from "./utils/slack-client";
 import { createLogger } from "./logger";
 
@@ -159,20 +159,18 @@ async function handleCompletionCallback(
     // Fetch events to build response (filtered by messageId directly)
     const agentResponse = await extractAgentResponse(env, sessionId, payload.messageId, traceId);
 
-    // Merge error from callback payload and extracted response
-    const errorMessage = agentResponse.error || payload.error;
-    if (errorMessage && !agentResponse.error) {
-      agentResponse.error = errorMessage;
-    }
+    // Fall back to the callback payload's error if the extractor didn't find one.
+    agentResponse.error = agentResponse.error || payload.error;
+    const errorMessage = agentResponse.error;
 
     // Check if extraction succeeded (has content or was explicitly successful)
     if (!agentResponse.textContent && agentResponse.toolCalls.length === 0 && !payload.success) {
-      const displayError = errorMessage || "Unknown error";
+      const displayError = truncateError(errorMessage || "Unknown error", 2000);
       log.error("callback.complete", {
         ...base,
         outcome: "error",
         error_message: "empty_agent_response",
-        agent_error: displayError,
+        agent_error: errorMessage || "Unknown error",
         duration_ms: Date.now() - startTime,
       });
       await postMessage(env.SLACK_BOT_TOKEN, context.channel, `The agent failed: ${displayError}`, {

--- a/packages/slack-bot/src/completion/blocks.ts
+++ b/packages/slack-bot/src/completion/blocks.ts
@@ -27,6 +27,7 @@ const STATUS_EMOJI = {
  */
 const TRUNCATE_LIMIT = 2000;
 const FALLBACK_TEXT_LIMIT = 150;
+const ERROR_FOOTER_LIMIT = 200;
 
 /**
  * Build Slack blocks for completion message.
@@ -74,7 +75,7 @@ export function buildCompletionBlocks(
   const status = response.success
     ? "Done"
     : response.error
-      ? `Failed: ${response.error}`
+      ? `Failed: ${truncateError(response.error, ERROR_FOOTER_LIMIT)}`
       : "Completed with issues";
   const effortSuffix = context.reasoningEffort ? ` (${context.reasoningEffort})` : "";
   blocks.push({
@@ -139,6 +140,15 @@ function truncateForSlack(text: string, maxLen: number): string {
     return truncated.slice(0, lastPeriod + 1) + "\n\n_...truncated_";
   }
   return truncated + "...\n\n_...truncated_";
+}
+
+/**
+ * Truncate an error string for Slack display, collapsing whitespace.
+ */
+export function truncateError(text: string, maxLen: number): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLen) return normalized;
+  return normalized.slice(0, maxLen - 1) + "…";
 }
 
 function getManualCreatePrUrl(artifacts: AgentResponse["artifacts"]): string | null {

--- a/packages/slack-bot/src/completion/blocks.ts
+++ b/packages/slack-bot/src/completion/blocks.ts
@@ -71,7 +71,11 @@ export function buildCompletionBlocks(
 
   // 4. Status footer
   const emoji = response.success ? STATUS_EMOJI.success : STATUS_EMOJI.warning;
-  const status = response.success ? "Done" : "Completed with issues";
+  const status = response.success
+    ? "Done"
+    : response.error
+      ? `Failed: ${response.error}`
+      : "Completed with issues";
   const effortSuffix = context.reasoningEffort ? ` (${context.reasoningEffort})` : "";
   blocks.push({
     type: "context",

--- a/packages/slack-bot/src/types/index.ts
+++ b/packages/slack-bot/src/types/index.ts
@@ -153,6 +153,7 @@ export interface CompletionCallback {
   sessionId: string;
   messageId: string;
   success: boolean;
+  error?: string;
   timestamp: number;
   signature: string;
   context: SlackCallbackContext;


### PR DESCRIPTION
## Summary

When the sandbox agent fails (e.g., LLM API error, session creation timeout), users only see a generic red "Execution failed" badge in the web UI and a vague "couldn't retrieve the response" message in Slack — with no actionable error information. This required manual log investigation across Cloudflare and Modal to diagnose failures.

**Root cause identified:** `_create_opencode_session()` in the bridge was called outside the `try/except` block, so timeout exceptions bypassed error logging and produced `execution_complete` events with no `error` field. Additionally, the error was dropped at 4 points in the callback chain between the sandbox and Slack/Linear.

**Changes across 4 packages (10 files):**

- **sandbox-runtime (bridge.py):** Move git identity config + session creation inside the `try/except` so all exceptions are caught, logged as `prompt.error`, and included in `execution_complete`
- **control-plane:** Pass `event.error` to `notifyComplete()` in sandbox-events and message-queue; include `error` in callback notification payload; add descriptive errors to synthetic execution_complete events for stopped/stuck processing
- **shared:** Add `error?: string` to `AgentResponse` type; extract error from both `execution_complete` and standalone `error` events in the shared extractor
- **slack-bot:** Show actual error message in both empty-response and completion-with-issues paths; update `CompletionCallback` type
- **linear-bot:** Update `CompletionCallback` type

**Before:** User sees "Execution failed" (no details) / Slack shows "couldn't retrieve the response"
**After:** User sees "Execution failed: <actual error message>" / Slack shows ":x: Agent failed: <actual error message>"

The web UI's `EventItem` component already had conditional rendering for `event.error` — it just was never populated.

## Test plan

- [x] TypeScript typecheck passes across all packages
- [x] ESLint + Prettier pass on changed files
- [x] Ruff check + format pass on bridge.py
- [x] control-plane unit tests pass (991 tests)
- [x] slack-bot tests pass (44 tests)
- [x] shared tests pass (59 tests)
- [x] linear-bot tests pass (90 tests)
- [x] sandbox-runtime Python tests pass (269 tests)
- [ ] Manual test: trigger a session failure and verify error appears in web UI
- [ ] Manual test: trigger a Slack-originated session failure and verify error appears in thread

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Completion callbacks now include optional error details so notifications carry explicit failure reasons.

* **Improvements**
  * Notifications for stopped or timed-out operations show specific messages (e.g., "Execution was stopped", "Execution timed out").
  * Slack and Linear displays now present truncated, normalized error text in failure footers and messages.
  * Logs and agent responses surface an error field for clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->