### PR TITLE
docs: add sandbox-runtime install step to deployment guide

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -61,6 +61,9 @@ brew install python@3.12 uv
 pipx install modal
 modal setup
 
+# Install Python dependencies for Modal deployment
+cd packages/modal-infra && uv sync --frozen --extra dev && cd -
+
 # Wrangler CLI (for initial R2 bucket setup)
 npm install -g wrangler
 ```
@@ -425,11 +428,14 @@ enable_durable_object_bindings = false
 enable_service_bindings        = false
 ```
 
-**Important**: Build the workers before running Terraform (Terraform references the built bundles):
+**Important**: Build the workers and install Python dependencies before running Terraform:
 
 ```bash
-# From the repository root
+# From the repository root — build TypeScript workers (Terraform references the built bundles)
 npm run build -w @open-inspect/control-plane -w @open-inspect/slack-bot -w @open-inspect/github-bot
+
+# Install Python dependencies for Modal deployment (includes sandbox-runtime)
+cd packages/modal-infra && uv sync --frozen --extra dev && cd -
 ```
 
 Then run:
@@ -754,6 +760,20 @@ modal token show
 # View Modal logs
 modal app logs open-inspect
 ```
+
+### Modal deployment fails with "No module named 'sandbox_runtime'"
+
+The `sandbox_runtime` package is a sibling package that must be installed before deploying. From the
+repository root:
+
+```bash
+cd packages/modal-infra && uv sync --frozen --extra dev && cd -
+```
+
+This installs all Modal deployment dependencies including `sandbox_runtime` (resolved via
+`[tool.uv.sources]` in `pyproject.toml`). If you installed Modal via `pipx install modal` alone, it
+runs in an isolated environment that doesn't include project dependencies — the `uv sync` step is
+required.
 
 ### Worker deployment fails / "no such file or directory" for dist/index.js
 


### PR DESCRIPTION
## Summary

- Adds `uv sync --frozen --extra dev` step to Prerequisites and Phase 1 deployment instructions in GETTING_STARTED.md
- Adds dedicated troubleshooting entry for the `No module named 'sandbox_runtime'` error

The deployment guide was missing the Python dependency installation step for Modal. Users following the guide would install `modal` via `pipx` (isolated env) but never install `sandbox_runtime`, which is a sibling package required at deploy time (`deploy.py → src.app → sandbox_runtime`). This caused `terraform apply` to fail with `ModuleNotFoundError`.

The CI workflow already handles this correctly (`pip install -e packages/sandbox-runtime` in `terraform.yml`), but the gap was in the manual deployment docs.

Closes #521

## Test plan

- [ ] Follow the GETTING_STARTED.md guide from scratch and verify `terraform apply` succeeds for Modal deployment
- [ ] Verify `uv sync --frozen --extra dev` in `packages/modal-infra` resolves `sandbox_runtime` via the `[tool.uv.sources]` path dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated prerequisites with new installation steps for dependencies.
  * Reorganized deployment instructions to clarify the correct workflow sequence.
  * Added troubleshooting section addressing deployment failure scenarios and resolution steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->