### PR TITLE
docs: remove volume_name from Terraform module example

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -305,8 +305,6 @@ module "modal" {
   deploy_path   = "${path.root}/../../../packages/modal-infra"
   deploy_module = "deploy"
 
-  volume_name = "my-volume"
-
   secrets = [
     {
       name = "my-secret"


### PR DESCRIPTION
Follow-up to #529 — removes the stale `volume_name` parameter from the Terraform README module usage example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the example Terraform configuration in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->