### PR TITLE
fix: include bot-initiated sessions in analytics

### DIFF
--- a/packages/control-plane/src/db/analytics-store.ts
+++ b/packages/control-plane/src/db/analytics-store.ts
@@ -4,11 +4,16 @@ import type {
   AnalyticsBreakdownResponse,
   AnalyticsSummaryResponse,
   AnalyticsTimeseriesResponse,
+  SpawnSource,
 } from "@open-inspect/shared";
+
+/** Spawn sources that represent direct human-initiated sessions. */
+export const HUMAN_SPAWN_SOURCES: SpawnSource[] = ["user", "slack-bot", "linear-bot", "github-bot"];
 
 export interface AnalyticsFilters {
   startAt: number;
   endAt: number;
+  spawnSources?: SpawnSource[];
 }
 
 interface SummaryRow {
@@ -47,6 +52,9 @@ export class AnalyticsStore {
   constructor(private readonly db: D1Database) {}
 
   async getSummary(filters: AnalyticsFilters): Promise<AnalyticsSummaryResponse> {
+    const sources = filters.spawnSources ?? HUMAN_SPAWN_SOURCES;
+    const placeholders = sources.map(() => "?").join(", ");
+
     const result = await this.db
       .prepare(
         `SELECT
@@ -62,9 +70,9 @@ export class AnalyticsStore {
            COALESCE(SUM(CASE WHEN status = 'cancelled' THEN 1 ELSE 0 END), 0) AS cancelled_count
          FROM sessions
          WHERE created_at >= ? AND created_at < ?
-           AND spawn_source = 'user'`
+           AND spawn_source IN (${placeholders})`
       )
-      .bind(filters.startAt, filters.endAt)
+      .bind(filters.startAt, filters.endAt, ...sources)
       .first<SummaryRow>();
 
     const totalSessions = result?.total_sessions ?? 0;
@@ -88,6 +96,9 @@ export class AnalyticsStore {
   }
 
   async getTimeseries(filters: AnalyticsFilters): Promise<AnalyticsTimeseriesResponse> {
+    const sources = filters.spawnSources ?? HUMAN_SPAWN_SOURCES;
+    const placeholders = sources.map(() => "?").join(", ");
+
     const result = await this.db
       .prepare(
         `SELECT
@@ -96,11 +107,11 @@ export class AnalyticsStore {
            COUNT(*) AS count
          FROM sessions
          WHERE created_at >= ? AND created_at < ?
-           AND spawn_source = 'user'
+           AND spawn_source IN (${placeholders})
          GROUP BY date, group_key
          ORDER BY date ASC, group_key ASC`
       )
-      .bind(filters.startAt, filters.endAt)
+      .bind(filters.startAt, filters.endAt, ...sources)
       .all<TimeseriesRow>();
 
     const series: AnalyticsTimeseriesResponse["series"] = [];
@@ -129,6 +140,9 @@ export class AnalyticsStore {
         ? "COALESCE(NULLIF(scm_login, ''), 'unknown')"
         : "repo_owner || '/' || repo_name";
 
+    const sources = filters.spawnSources ?? HUMAN_SPAWN_SOURCES;
+    const placeholders = sources.map(() => "?").join(", ");
+
     const result = await this.db
       .prepare(
         `SELECT
@@ -147,11 +161,11 @@ export class AnalyticsStore {
            MAX(updated_at) AS last_active
          FROM sessions
          WHERE created_at >= ? AND created_at < ?
-           AND spawn_source = 'user'
+           AND spawn_source IN (${placeholders})
          GROUP BY key
          ORDER BY sessions DESC, key ASC`
       )
-      .bind(filters.startAt, filters.endAt)
+      .bind(filters.startAt, filters.endAt, ...sources)
       .all<BreakdownRow>();
 
     const entries: AnalyticsBreakdownEntry[] = (result.results ?? []).map((row) => ({

--- a/packages/control-plane/src/router.analytics.test.ts
+++ b/packages/control-plane/src/router.analytics.test.ts
@@ -8,9 +8,13 @@ const mockStore = {
   getBreakdown: vi.fn(),
 };
 
-vi.mock("./db/analytics-store", () => ({
-  AnalyticsStore: vi.fn().mockImplementation(() => mockStore),
-}));
+vi.mock("./db/analytics-store", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    AnalyticsStore: vi.fn().mockImplementation(() => mockStore),
+  };
+});
 
 describe("analytics router integration", () => {
   beforeEach(() => {

--- a/packages/control-plane/src/routes/analytics.test.ts
+++ b/packages/control-plane/src/routes/analytics.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { analyticsRoutes } from "./analytics";
+import { HUMAN_SPAWN_SOURCES } from "../db/analytics-store";
 import type { RequestContext } from "./shared";
 import type { Env } from "../types";
 
@@ -11,9 +12,13 @@ const mockStore = {
   getBreakdown: vi.fn(),
 };
 
-vi.mock("../db/analytics-store", () => ({
-  AnalyticsStore: vi.fn().mockImplementation(() => mockStore),
-}));
+vi.mock("../db/analytics-store", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    AnalyticsStore: vi.fn().mockImplementation(() => mockStore),
+  };
+});
 
 function getHandler(method: string, path: string) {
   const pathname = new URL(`https://test.local${path}`).pathname;
@@ -90,6 +95,7 @@ describe("analytics route handlers", () => {
       expect(mockStore.getSummary).toHaveBeenCalledWith({
         startAt: FIXED_NOW - 30 * 24 * 60 * 60 * 1000,
         endAt: FIXED_NOW,
+        spawnSources: HUMAN_SPAWN_SOURCES,
       });
     });
 
@@ -112,6 +118,7 @@ describe("analytics route handlers", () => {
       expect(mockStore.getTimeseries).toHaveBeenCalledWith({
         startAt: FIXED_NOW - 14 * 24 * 60 * 60 * 1000,
         endAt: FIXED_NOW,
+        spawnSources: HUMAN_SPAWN_SOURCES,
       });
     });
   });

--- a/packages/control-plane/src/routes/analytics.ts
+++ b/packages/control-plane/src/routes/analytics.ts
@@ -4,7 +4,7 @@ import {
   type AnalyticsBreakdownBy,
   type AnalyticsDays,
 } from "@open-inspect/shared";
-import { AnalyticsStore } from "../db/analytics-store";
+import { type AnalyticsFilters, AnalyticsStore, HUMAN_SPAWN_SOURCES } from "../db/analytics-store";
 import type { Env } from "../types";
 import { type RequestContext, type Route, error, json, parsePattern } from "./shared";
 
@@ -22,10 +22,10 @@ function parseBreakdownBy(value: string | null): AnalyticsBreakdownBy | null {
     : null;
 }
 
-function getRange(days: AnalyticsDays): { startAt: number; endAt: number } {
+function getFilters(days: AnalyticsDays): AnalyticsFilters {
   const endAt = Date.now();
   const startAt = endAt - days * 24 * 60 * 60 * 1000;
-  return { startAt, endAt };
+  return { startAt, endAt, spawnSources: HUMAN_SPAWN_SOURCES };
 }
 
 async function handleSummary(
@@ -41,7 +41,7 @@ async function handleSummary(
   }
 
   const store = new AnalyticsStore(env.DB);
-  return json(await store.getSummary(getRange(days)));
+  return json(await store.getSummary(getFilters(days)));
 }
 
 async function handleTimeseries(
@@ -57,7 +57,7 @@ async function handleTimeseries(
   }
 
   const store = new AnalyticsStore(env.DB);
-  return json(await store.getTimeseries(getRange(days)));
+  return json(await store.getTimeseries(getFilters(days)));
 }
 
 async function handleBreakdown(
@@ -79,7 +79,7 @@ async function handleBreakdown(
   }
 
   const store = new AnalyticsStore(env.DB);
-  return json(await store.getBreakdown(getRange(days), by));
+  return json(await store.getBreakdown(getFilters(days), by));
 }
 
 export const analyticsRoutes: Route[] = [

--- a/packages/control-plane/test/integration/analytics.test.ts
+++ b/packages/control-plane/test/integration/analytics.test.ts
@@ -4,6 +4,7 @@ import type {
   AnalyticsBreakdownResponse,
   AnalyticsSummaryResponse,
   AnalyticsTimeseriesResponse,
+  SpawnSource,
 } from "@open-inspect/shared";
 import { generateInternalToken } from "../../src/auth/internal";
 import { SessionIndexStore } from "../../src/db/session-index";
@@ -25,6 +26,7 @@ async function seedSession(
     repoOwner: string;
     repoName: string;
     scmLogin: string | null;
+    spawnSource?: SpawnSource;
     status: "created" | "active" | "completed" | "failed" | "archived" | "cancelled";
     createdAt: number;
     updatedAt: number;
@@ -43,6 +45,7 @@ async function seedSession(
     reasoningEffort: null,
     baseBranch: "main",
     status: input.status,
+    spawnSource: input.spawnSource,
     scmLogin: input.scmLogin,
     createdAt: input.createdAt,
     updatedAt: input.updatedAt,
@@ -484,5 +487,125 @@ describe("Analytics API", () => {
         lastActive: apiActiveAt + 8_000,
       },
     ]);
+  });
+
+  it("includes bot-spawned sessions and excludes agent/automation sessions", async () => {
+    const store = new SessionIndexStore(env.DB);
+    const now = Date.now();
+    const base = now - 2 * 24 * 60 * 60 * 1000;
+
+    // Human-initiated sessions (should be included)
+    await seedSession(store, {
+      id: "web-session",
+      repoOwner: "acme",
+      repoName: "app",
+      scmLogin: "alice",
+      spawnSource: "user",
+      status: "completed",
+      createdAt: base,
+      updatedAt: base + 1_000,
+      totalCost: 1,
+      activeDurationMs: 100_000,
+      messageCount: 5,
+      prCount: 1,
+    });
+    await seedSession(store, {
+      id: "slack-session",
+      repoOwner: "acme",
+      repoName: "app",
+      scmLogin: null,
+      spawnSource: "slack-bot",
+      status: "completed",
+      createdAt: base + 60_000,
+      updatedAt: base + 61_000,
+      totalCost: 0.5,
+      activeDurationMs: 50_000,
+      messageCount: 3,
+      prCount: 0,
+    });
+    await seedSession(store, {
+      id: "linear-session",
+      repoOwner: "acme",
+      repoName: "app",
+      scmLogin: null,
+      spawnSource: "linear-bot",
+      status: "failed",
+      createdAt: base + 120_000,
+      updatedAt: base + 121_000,
+      totalCost: 0.25,
+      activeDurationMs: 30_000,
+      messageCount: 2,
+      prCount: 0,
+    });
+    await seedSession(store, {
+      id: "github-session",
+      repoOwner: "acme",
+      repoName: "app",
+      scmLogin: "bob",
+      spawnSource: "github-bot",
+      status: "completed",
+      createdAt: base + 180_000,
+      updatedAt: base + 181_000,
+      totalCost: 0.75,
+      activeDurationMs: 80_000,
+      messageCount: 4,
+      prCount: 1,
+    });
+
+    // Non-human sessions (should be excluded)
+    await seedSession(store, {
+      id: "agent-child",
+      repoOwner: "acme",
+      repoName: "app",
+      scmLogin: "alice",
+      spawnSource: "agent",
+      status: "completed",
+      createdAt: base + 240_000,
+      updatedAt: base + 241_000,
+      totalCost: 2,
+      activeDurationMs: 200_000,
+      messageCount: 10,
+      prCount: 0,
+    });
+    await seedSession(store, {
+      id: "automation-session",
+      repoOwner: "acme",
+      repoName: "app",
+      scmLogin: "alice",
+      spawnSource: "automation",
+      status: "completed",
+      createdAt: base + 300_000,
+      updatedAt: base + 301_000,
+      totalCost: 3,
+      activeDurationMs: 400_000,
+      messageCount: 20,
+      prCount: 2,
+    });
+
+    // Summary should count only the 4 human sessions
+    const summaryRes = await SELF.fetch("https://test.local/analytics/summary?days=7", {
+      headers: await authHeaders(),
+    });
+    expect(summaryRes.status).toBe(200);
+    const summary = await summaryRes.json<AnalyticsSummaryResponse>();
+    expect(summary.totalSessions).toBe(4);
+    expect(summary.activeUsers).toBe(2); // alice + bob (scm_login-based)
+    expect(summary.totalCost).toBe(2.5);
+    expect(summary.totalPrs).toBe(2);
+
+    // Breakdown by user should include bot sessions, not agent/automation
+    const breakdownRes = await SELF.fetch("https://test.local/analytics/breakdown?days=7&by=user", {
+      headers: await authHeaders(),
+    });
+    expect(breakdownRes.status).toBe(200);
+    const breakdown = await breakdownRes.json<AnalyticsBreakdownResponse>();
+
+    const keys = breakdown.entries.map((e) => e.key);
+    expect(keys).toContain("alice");
+    expect(keys).toContain("bob");
+    expect(keys).toContain("unknown"); // slack + linear sessions with no scm_login
+
+    const totalBreakdownSessions = breakdown.entries.reduce((n, e) => n + e.sessions, 0);
+    expect(totalBreakdownSessions).toBe(4);
   });
 });

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -305,8 +305,6 @@ module "modal" {
   deploy_path   = "${path.root}/../../../packages/modal-infra"
   deploy_module = "deploy"
 
-  volume_name = "my-volume"
-
   secrets = [
     {
       name = "my-secret"


### PR DESCRIPTION
## Summary

- Replace hardcoded `AND spawn_source = 'user'` filter in all three analytics SQL queries with a parameterized `IN (...)` clause
- Default to all human-initiated spawn sources: `user`, `slack-bot`, `linear-bot`, `github-bot`
- Agent and automation child sessions remain excluded to avoid double-counting
- Add `spawnSources` to `AnalyticsFilters` interface for future configurability

This is the core symptom of #523 — bot-initiated sessions are invisible in the analytics dashboard because the SQL hardcodes `spawn_source = 'user'`.

## Changes

| File | Change |
|---|---|
| `control-plane/src/db/analytics-store.ts` | Export `HUMAN_SPAWN_SOURCES` constant, add `spawnSources` to `AnalyticsFilters`, parameterize all 3 SQL queries |
| `control-plane/src/routes/analytics.ts` | Rename `getRange` → `getFilters`, pass default `spawnSources` |
| `control-plane/src/routes/analytics.test.ts` | Update mock to preserve real exports, assert `spawnSources` in filter calls |
| `control-plane/src/router.analytics.test.ts` | Same mock fix |
| `control-plane/test/integration/analytics.test.ts` | Add `spawnSource` to seed helper, add test for bot session inclusion / agent exclusion |

## Test plan

- [x] All 991 unit tests pass
- [x] All 5 analytics integration tests pass (including new bot-session test)
- [x] New test seeds sessions with all 6 spawn sources, asserts only 4 human sources appear in summary and breakdown
- [x] Existing tests unchanged — they seed sessions without explicit `spawnSource`, which defaults to `"user"` via `SessionIndexStore`
- [x] Typecheck passes
- [x] Lint passes

Refs #523

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to filter analytics by session origin (human-initiated vs automated sources), enabling more granular insights into user behavior across different session types.

* **Documentation**
  * Updated Terraform configuration examples in README.

* **Tests**
  * Enhanced test coverage for analytics filtering functionality with integration tests validating behavior across multiple session origin types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->