### PR TITLE
fix: add email to Slack getUserInfo return type

### DIFF
--- a/packages/slack-bot/src/utils/slack-client.ts
+++ b/packages/slack-bot/src/utils/slack-client.ts
@@ -237,6 +237,7 @@ export async function getUserInfo(
     profile?: {
       display_name?: string;
       real_name?: string;
+      email?: string;
     };
   };
   error?: string;
@@ -256,6 +257,7 @@ export async function getUserInfo(
       profile?: {
         display_name?: string;
         real_name?: string;
+        email?: string;
       };
     };
     error?: string;


### PR DESCRIPTION
## Summary

- Adds `email?: string` to the `profile` type in `getUserInfo` (both the return annotation and the response cast)
- The Slack `users.info` API returns `profile.email` when the `users:read.email` scope is present — the type was missing this field
- Type-only change, no runtime behavior change

**Pre-step 2** of the unified user model migration ([pre-steps doc](https://github.com/ColeMurray/background-agents/blob/main/docs/internal/2026-04-21-unified-user-model-pre-steps.md#pre-step-2-add-email-to-the-slack-getuserinfo-return-type)). The main migration will read `email` from `getUserInfo` for identity linking — having the type already in place keeps that PR focused on logic, not type definitions.

## Test plan

- [x] `npm run typecheck -w @open-inspect/slack-bot` passes
- [x] `npm test -w @open-inspect/slack-bot` — all 44 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack bot user profile queries now include email information in addition to existing user details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->