### PR TITLE
fix: add sender.id to GitHub webhook payload types

### DIFF
--- a/packages/github-bot/src/types.ts
+++ b/packages/github-bot/src/types.ts
@@ -53,7 +53,7 @@ export interface PullRequestOpenedPayload {
     draft: boolean;
   };
   repository: { owner: { login: string }; name: string; private: boolean };
-  sender: { login: string };
+  sender: { login: string; id: number };
 }
 
 export interface ReviewRequestedPayload {
@@ -68,7 +68,7 @@ export interface ReviewRequestedPayload {
   };
   requested_reviewer?: { login: string };
   repository: { owner: { login: string }; name: string; private: boolean };
-  sender: { login: string };
+  sender: { login: string; id: number };
 }
 
 export interface IssueCommentPayload {
@@ -84,7 +84,7 @@ export interface IssueCommentPayload {
     user: { login: string };
   };
   repository: { owner: { login: string }; name: string; private: boolean };
-  sender: { login: string };
+  sender: { login: string; id: number };
 }
 
 export interface ReviewCommentPayload {
@@ -104,5 +104,5 @@ export interface ReviewCommentPayload {
     user: { login: string };
   };
   repository: { owner: { login: string }; name: string; private: boolean };
-  sender: { login: string };
+  sender: { login: string; id: number };
 }

--- a/packages/github-bot/test/handlers.test.ts
+++ b/packages/github-bot/test/handlers.test.ts
@@ -109,7 +109,7 @@ const pullRequestOpenedPayload: PullRequestOpenedPayload = {
     draft: false,
   },
   repository: { owner: { login: "acme" }, name: "widgets", private: false },
-  sender: { login: "alice" },
+  sender: { login: "alice", id: 1001 },
 };
 
 const reviewRequestedPayload: ReviewRequestedPayload = {
@@ -124,7 +124,7 @@ const reviewRequestedPayload: ReviewRequestedPayload = {
   },
   requested_reviewer: { login: "test-bot[bot]" },
   repository: { owner: { login: "acme" }, name: "widgets", private: false },
-  sender: { login: "alice" },
+  sender: { login: "alice", id: 1001 },
 };
 
 const issueCommentPayload: IssueCommentPayload = {
@@ -140,7 +140,7 @@ const issueCommentPayload: IssueCommentPayload = {
     user: { login: "bob" },
   },
   repository: { owner: { login: "acme" }, name: "widgets", private: false },
-  sender: { login: "bob" },
+  sender: { login: "bob", id: 1002 },
 };
 
 const reviewCommentPayload: ReviewCommentPayload = {
@@ -160,7 +160,7 @@ const reviewCommentPayload: ReviewCommentPayload = {
     user: { login: "carol" },
   },
   repository: { owner: { login: "acme" }, name: "widgets", private: false },
-  sender: { login: "carol" },
+  sender: { login: "carol", id: 1003 },
 };
 
 beforeEach(() => {
@@ -503,7 +503,7 @@ describe("handleIssueComment", () => {
     const log = createMockLogger();
     const payload: IssueCommentPayload = {
       ...issueCommentPayload,
-      sender: { login: "test-bot[bot]" },
+      sender: { login: "test-bot[bot]", id: 2001 },
     };
 
     const result = await handleIssueComment(env, log, payload, "trace-2");
@@ -580,7 +580,7 @@ describe("handleReviewComment", () => {
     const log = createMockLogger();
     const payload: ReviewCommentPayload = {
       ...reviewCommentPayload,
-      sender: { login: "test-bot[bot]" },
+      sender: { login: "test-bot[bot]", id: 2001 },
     };
 
     const result = await handleReviewComment(env, log, payload, "trace-3");


### PR DESCRIPTION
## Summary

- Adds `id: number` to `sender` on all 4 webhook payload types: `PullRequestOpenedPayload`, `ReviewRequestedPayload`, `IssueCommentPayload`, `ReviewCommentPayload`
- GitHub webhooks include `sender.id` (numeric user ID) alongside `sender.login` — the type definitions were missing it
- Type-only change, no runtime behavior change

**Pre-step 3** of the unified user model migration ([pre-steps doc](https://github.com/ColeMurray/background-agents/blob/main/docs/internal/2026-04-21-unified-user-model-pre-steps.md#pre-step-3-add-senderid-to-github-bot-webhook-payload-types)). The main migration will forward `sender.id` as `actorProviderUserId` for consistent identity linking with the web OAuth path (which already uses the numeric GitHub user ID).

## Test plan

- [x] `npm run typecheck -w @open-inspect/github-bot` passes
- [x] `npm test -w @open-inspect/github-bot` — all 100 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal webhook payloads to include sender numeric identifiers alongside existing login names.
  * Aligned test fixtures and loop-prevention tests with the updated payload shape to ensure consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->