### PR TITLE
fix: explicitly send spawnSource from web session route

### DIFF
--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -67,6 +67,7 @@ export async function POST(request: NextRequest) {
       reasoningEffort: body.reasoningEffort,
       branch: body.branch,
       title: body.title,
+      spawnSource: "user" as const,
       scmToken: accessToken,
       scmRefreshToken: jwt?.refreshToken as string | undefined,
       scmTokenExpiresAt: jwt?.accessTokenExpiresAt as number | undefined,


### PR DESCRIPTION
## Summary

- Adds `spawnSource: "user"` to the session creation body in `packages/web/src/app/api/sessions/route.ts`
- Previously the web route relied on the control plane defaulting missing `spawnSource` to `"user"` (via `session.spawnSource ?? "user"` in `SessionIndexStore.create()`) — every bot already sends its source explicitly, but the web route did not

**Pre-step 4** of the unified user model migration ([pre-steps doc](https://github.com/ColeMurray/background-agents/blob/main/docs/internal/2026-04-21-unified-user-model-pre-steps.md#pre-step-4-make-the-web-session-route-send-spawnsource-user)). Makes the main migration's diff for this file purely additive (new `actor*` fields) rather than a mix of fixing omissions and adding new fields.

## Test plan

- [x] `npm run typecheck -w @open-inspect/web` passes
- [x] `npm test -w @open-inspect/web` — all 185 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal session tracking mechanisms to enhance monitoring and analytics visibility for session management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->