### PR TITLE
refactor: thread slackUserId through Slack bot createSession

### DIFF
--- a/packages/slack-bot/src/index.ts
+++ b/packages/slack-bot/src/index.ts
@@ -83,7 +83,8 @@ async function createSession(
   model: string,
   reasoningEffort: string | undefined,
   branch: string | undefined,
-  traceId?: string
+  traceId?: string,
+  slackUserId?: string
 ): Promise<{ sessionId: string; status: string } | null> {
   const startTime = Date.now();
   const base = {
@@ -93,6 +94,7 @@ async function createSession(
     model,
     reasoning_effort: reasoningEffort,
     branch,
+    slack_user_id: slackUserId,
   };
   try {
     const headers = await getAuthHeaders(env, traceId);
@@ -893,7 +895,8 @@ async function startSessionAndSendPrompt(
     model,
     reasoningEffort,
     branch,
-    traceId
+    traceId,
+    userId
   );
 
   if (!session) {


### PR DESCRIPTION
## Summary

- Adds `slackUserId` parameter to `createSession` in the Slack bot
- Includes `slack_user_id` in structured log metadata for session creation
- The Slack user ID was already available at the call site (`startSessionAndSendPrompt`) but was not passed through to `createSession`
- No control plane changes — the value flows through logging only for now

**Pre-step 5** of the unified user model migration ([pre-steps doc](https://github.com/ColeMurray/background-agents/blob/main/docs/internal/2026-04-21-unified-user-model-pre-steps.md#pre-step-5-thread-userid-through-the-slack-bot-createsession-function)). The main migration will add identity resolution (`getUserInfo`) and forward `actor*` fields through this same parameter path — having the user ID already threaded keeps that PR focused on identity logic.

## Test plan

- [x] `npm run typecheck -w @open-inspect/slack-bot` passes
- [x] `npm test -w @open-inspect/slack-bot` — all 44 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Slack bot session handling to better track user information during session creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->