### PR TITLE
refactor: extract createSession helper in Linear bot

### DIFF
--- a/packages/linear-bot/src/webhook-handler.ts
+++ b/packages/linear-bot/src/webhook-handler.ts
@@ -128,6 +128,44 @@ async function getAuthHeaders(env: Env, traceId?: string): Promise<Record<string
   };
 }
 
+/**
+ * Create a session via the control plane.
+ */
+async function createSession(
+  env: Env,
+  params: {
+    repoOwner: string;
+    repoName: string;
+    title: string;
+    model: string;
+    reasoningEffort?: string;
+  },
+  traceId?: string
+): Promise<{ ok: true; sessionId: string } | { ok: false; status: number; body: string }> {
+  const headers = await getAuthHeaders(env, traceId);
+  const response = await env.CONTROL_PLANE.fetch("https://internal/sessions", {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      ...params,
+      spawnSource: "linear-bot",
+    }),
+  });
+
+  if (!response.ok) {
+    let body = "";
+    try {
+      body = await response.text();
+    } catch {
+      /* ignore */
+    }
+    return { ok: false, status: response.status, body };
+  }
+
+  const result = (await response.json()) as { sessionId: string };
+  return { ok: true, sessionId: result.sessionId };
+}
+
 // ─── Sub-handlers ────────────────────────────────────────────────────────────
 
 async function handleStop(webhook: AgentSessionWebhook, env: Env, traceId: string): Promise<void> {
@@ -483,44 +521,36 @@ async function handleNewSession(
     true
   );
 
-  const headers = await getAuthHeaders(env, traceId);
-
-  const sessionRes = await env.CONTROL_PLANE.fetch("https://internal/sessions", {
-    method: "POST",
-    headers,
-    body: JSON.stringify({
-      repoOwner,
-      repoName,
+  const sessionResult = await createSession(
+    env,
+    {
+      repoOwner: repoOwner!,
+      repoName: repoName!,
       title: `${issue.identifier}: ${issue.title}`,
       model,
       reasoningEffort,
-      spawnSource: "linear-bot",
-    }),
-  });
+    },
+    traceId
+  );
 
-  if (!sessionRes.ok) {
-    let sessionErrBody = "";
-    try {
-      sessionErrBody = await sessionRes.text();
-    } catch {
-      /* ignore */
-    }
+  if (!sessionResult.ok) {
     await emitAgentActivity(client, agentSessionId, {
       type: "error",
-      body: `Failed to create a coding session.\n\n\`HTTP ${sessionRes.status}: ${sessionErrBody.slice(0, 200)}\``,
+      body: `Failed to create a coding session.\n\n\`HTTP ${sessionResult.status}: ${sessionResult.body.slice(0, 200)}\``,
     });
     log.error("control_plane.create_session", {
       trace_id: traceId,
       issue_identifier: issue.identifier,
       repo: repoFullName,
-      http_status: sessionRes.status,
-      response_body: sessionErrBody.slice(0, 500),
+      http_status: sessionResult.status,
+      response_body: sessionResult.body.slice(0, 500),
       duration_ms: Date.now() - startTime,
     });
     return;
   }
 
-  const session = (await sessionRes.json()) as { sessionId: string };
+  const headers = await getAuthHeaders(env, traceId);
+  const session = sessionResult;
 
   await storeIssueSession(env, issue.id, {
     sessionId: session.sessionId,


### PR DESCRIPTION
## Summary

- Extracts the inline `fetch("https://internal/sessions", ...)` in `handleNewSession` into a dedicated `createSession` helper
- Returns a discriminated union (`{ ok: true, sessionId }` | `{ ok: false, status, body }`) so the caller retains full error context for activity messages and logging
- The Linear bot was the only bot without a `createSession` helper — Slack and GitHub bots already had one

**Pre-step 6** of the unified user model migration ([pre-steps doc](https://github.com/ColeMurray/background-agents/blob/main/docs/internal/2026-04-21-unified-user-model-pre-steps.md#pre-step-6-extract-a-createsession-helper-in-the-linear-bot)). The main migration will add `actor*` identity parameters to this helper's interface — having the function already extracted keeps that PR focused on identity resolution logic.

## Test plan

- [x] `npm run typecheck -w @open-inspect/linear-bot` passes
- [x] `npm test -w @open-inspect/linear-bot` — all 90 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal session creation and error handling with unified error reporting patterns for better reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->