### PR TITLE
feat: add fetchUser GraphQL query to Linear client

### DIFF
--- a/packages/linear-bot/src/utils/linear-client.test.ts
+++ b/packages/linear-bot/src/utils/linear-client.test.ts
@@ -72,4 +72,14 @@ describe("fetchUser", () => {
     const result = await fetchUser(client, "user-1");
     expect(result).toBeNull();
   });
+
+  it("returns null on GraphQL errors payload", async () => {
+    mockFetchResponse({
+      data: null,
+      errors: [{ message: "Not authorized" }],
+    });
+
+    const result = await fetchUser(client, "user-1");
+    expect(result).toBeNull();
+  });
 });

--- a/packages/linear-bot/src/utils/linear-client.test.ts
+++ b/packages/linear-bot/src/utils/linear-client.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchUser } from "./linear-client";
+import type { LinearApiClient } from "./linear-client";
+
+const client: LinearApiClient = { accessToken: "test-token" };
+
+function mockFetchResponse(data: unknown): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(data),
+    })
+  );
+}
+
+describe("fetchUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns user with name and email", async () => {
+    mockFetchResponse({
+      data: {
+        user: { id: "user-1", name: "Alice", email: "alice@example.com" },
+      },
+    });
+
+    const result = await fetchUser(client, "user-1");
+    expect(result).toEqual({
+      id: "user-1",
+      name: "Alice",
+      email: "alice@example.com",
+    });
+  });
+
+  it("returns null email when user has no email", async () => {
+    mockFetchResponse({
+      data: {
+        user: { id: "user-2", name: "Bob", email: null },
+      },
+    });
+
+    const result = await fetchUser(client, "user-2");
+    expect(result).toEqual({
+      id: "user-2",
+      name: "Bob",
+      email: null,
+    });
+  });
+
+  it("returns null when user is not found", async () => {
+    mockFetchResponse({ data: { user: null } });
+
+    const result = await fetchUser(client, "nonexistent");
+    expect(result).toBeNull();
+  });
+
+  it("returns null on API error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      })
+    );
+
+    const result = await fetchUser(client, "user-1");
+    expect(result).toBeNull();
+  });
+});

--- a/packages/linear-bot/src/utils/linear-client.ts
+++ b/packages/linear-bot/src/utils/linear-client.ts
@@ -147,7 +147,14 @@ async function linearGraphQL(
     throw new Error(`Linear API error: ${res.status}`);
   }
 
-  return (await res.json()) as Record<string, unknown>;
+  const json = (await res.json()) as Record<string, unknown>;
+
+  if (Array.isArray(json.errors) && json.errors.length > 0) {
+    const msg = (json.errors[0] as { message?: string }).message ?? "Unknown GraphQL error";
+    throw new Error(`Linear GraphQL error: ${msg}`);
+  }
+
+  return json;
 }
 
 // ─── Agent Activities ────────────────────────────────────────────────────────

--- a/packages/linear-bot/src/utils/linear-client.ts
+++ b/packages/linear-bot/src/utils/linear-client.ts
@@ -322,6 +322,47 @@ export async function getRepoSuggestions(
   }
 }
 
+// ─── User Lookup ────────────────────────────────────────────────────────────
+
+/**
+ * Fetch a Linear user by ID. Returns name and email for identity linking.
+ */
+export async function fetchUser(
+  client: LinearApiClient,
+  userId: string
+): Promise<{ id: string; name: string; email: string | null } | null> {
+  try {
+    const data = await linearGraphQL(
+      client,
+      `
+      query FetchUser($id: String!) {
+        user(id: $id) {
+          id
+          name
+          email
+        }
+      }
+    `,
+      { id: userId }
+    );
+
+    const user = (data as { data?: { user?: Record<string, unknown> } }).data?.user;
+    if (!user) return null;
+
+    return {
+      id: user.id as string,
+      name: user.name as string,
+      email: (user.email as string) ?? null,
+    };
+  } catch (err) {
+    log.error("linear.fetch_user", {
+      user_id: userId,
+      error: err instanceof Error ? err : new Error(String(err)),
+    });
+    return null;
+  }
+}
+
 // ─── Webhook Verification ────────────────────────────────────────────────────
 
 export async function verifyLinearWebhook(


### PR DESCRIPTION
## Summary

- Adds `fetchUser(client, userId)` to `linear-client.ts` — queries Linear's `user(id:)` GraphQL endpoint to resolve name and email
- Follows the same pattern as `fetchIssueDetails`: try/catch with error logging, returns `null` on failure
- Includes 4 tests: success with email, null email, user not found, API error

**Pre-step 7** of the unified user model migration ([pre-steps doc](https://github.com/ColeMurray/background-agents/blob/main/docs/internal/2026-04-21-unified-user-model-pre-steps.md#pre-step-7-add-a-fetchuser-graphql-query-to-the-linear-client)). The main migration will call `fetchUser(client, webhook.appUserId)` before session creation to resolve identity for linking — having the query function already in place keeps that PR focused on wiring.

## Test plan

- [x] `npm run typecheck -w @open-inspect/linear-bot` passes
- [x] `npm test -w @open-inspect/linear-bot` — all 94 tests pass (90 existing + 4 new)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user retrieval from Linear with normalized {id, name, email|null} responses and safe error handling that returns null on failure.

* **Tests**
  * Added thorough tests for user retrieval covering success, null fields, missing user, network errors, and GraphQL errors; tests isolate and restore global fetch between cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->