### PR TITLE
feat: add users/user_identities schema and UserStore class

### DIFF
--- a/packages/control-plane/src/db/user-store.ts
+++ b/packages/control-plane/src/db/user-store.ts
@@ -1,0 +1,331 @@
+import { generateId } from "../auth/crypto";
+
+// ── Public types ────────────────────────────────────────────────────
+
+export interface ProviderIdentity {
+  provider: "github" | "slack" | "linear";
+  providerUserId: string;
+  providerLogin?: string;
+  providerEmail?: string;
+  displayName?: string;
+  avatarUrl?: string;
+}
+
+export interface ResolvedUser {
+  id: string;
+  displayName: string | null;
+  email: string | null;
+  isNew: boolean;
+}
+
+export interface User {
+  id: string;
+  displayName: string | null;
+  email: string | null;
+  avatarUrl: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface UserIdentity {
+  id: string;
+  userId: string;
+  provider: string;
+  providerUserId: string;
+  providerLogin: string | null;
+  providerEmail: string | null;
+  createdAt: number;
+}
+
+export interface NewUser {
+  displayName?: string;
+  email?: string;
+  avatarUrl?: string;
+}
+
+export interface NewUserIdentity {
+  userId: string;
+  provider: string;
+  providerUserId: string;
+  providerLogin?: string;
+  providerEmail?: string;
+}
+
+export interface UserUpdate {
+  displayName?: string;
+  avatarUrl?: string;
+  email?: string;
+}
+
+// ── Row types (D1 snake_case) ───────────────────────────────────────
+
+interface UserRow {
+  id: string;
+  display_name: string | null;
+  email: string | null;
+  avatar_url: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+interface UserIdentityRow {
+  id: string;
+  user_id: string;
+  provider: string;
+  provider_user_id: string;
+  provider_login: string | null;
+  provider_email: string | null;
+  created_at: number;
+}
+
+// ── Row mappers ─────────────────────────────────────────────────────
+
+function toUser(row: UserRow): User {
+  return {
+    id: row.id,
+    displayName: row.display_name,
+    email: row.email,
+    avatarUrl: row.avatar_url,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function toUserIdentity(row: UserIdentityRow): UserIdentity {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    provider: row.provider,
+    providerUserId: row.provider_user_id,
+    providerLogin: row.provider_login,
+    providerEmail: row.provider_email,
+    createdAt: row.created_at,
+  };
+}
+
+// ── UserStore ───────────────────────────────────────────────────────
+
+export class UserStore {
+  constructor(private readonly db: D1Database) {}
+
+  /**
+   * Core resolution entry point. Finds or creates a canonical user for the
+   * given provider identity, with automatic email-based cross-provider linking.
+   *
+   * On UNIQUE constraint violation (concurrent race), retries the lookup once.
+   */
+  async resolveOrCreateUser(identity: ProviderIdentity): Promise<ResolvedUser> {
+    try {
+      return await this.doResolveOrCreate(identity);
+    } catch (err) {
+      if (isUniqueConstraintError(err)) {
+        return await this.doResolveOrCreate(identity);
+      }
+      throw err;
+    }
+  }
+
+  async getUserById(userId: string): Promise<User | null> {
+    const row = await this.db
+      .prepare("SELECT * FROM users WHERE id = ?")
+      .bind(userId)
+      .first<UserRow>();
+    return row ? toUser(row) : null;
+  }
+
+  async getUserByEmail(email: string): Promise<User | null> {
+    const row = await this.db
+      .prepare("SELECT * FROM users WHERE email = ?")
+      .bind(email.toLowerCase())
+      .first<UserRow>();
+    return row ? toUser(row) : null;
+  }
+
+  async getIdentity(provider: string, providerUserId: string): Promise<UserIdentity | null> {
+    const row = await this.db
+      .prepare("SELECT * FROM user_identities WHERE provider = ? AND provider_user_id = ?")
+      .bind(provider, providerUserId)
+      .first<UserIdentityRow>();
+    return row ? toUserIdentity(row) : null;
+  }
+
+  async getIdentitiesForUser(userId: string): Promise<UserIdentity[]> {
+    const result = await this.db
+      .prepare("SELECT * FROM user_identities WHERE user_id = ?")
+      .bind(userId)
+      .all<UserIdentityRow>();
+    return (result.results ?? []).map(toUserIdentity);
+  }
+
+  async createUser(user: NewUser): Promise<User> {
+    const id = generateId();
+    const now = Date.now();
+    const email = user.email?.toLowerCase() ?? null;
+
+    await this.db
+      .prepare(
+        "INSERT INTO users (id, display_name, email, avatar_url, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
+      )
+      .bind(id, user.displayName ?? null, email, user.avatarUrl ?? null, now, now)
+      .run();
+
+    return {
+      id,
+      displayName: user.displayName ?? null,
+      email,
+      avatarUrl: user.avatarUrl ?? null,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  async createIdentity(identity: NewUserIdentity): Promise<UserIdentity> {
+    const id = generateId();
+    const now = Date.now();
+    const email = identity.providerEmail?.toLowerCase() ?? null;
+
+    await this.db
+      .prepare(
+        "INSERT INTO user_identities (id, user_id, provider, provider_user_id, provider_login, provider_email, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+      )
+      .bind(
+        id,
+        identity.userId,
+        identity.provider,
+        identity.providerUserId,
+        identity.providerLogin ?? null,
+        email,
+        now
+      )
+      .run();
+
+    return {
+      id,
+      userId: identity.userId,
+      provider: identity.provider,
+      providerUserId: identity.providerUserId,
+      providerLogin: identity.providerLogin ?? null,
+      providerEmail: email,
+      createdAt: now,
+    };
+  }
+
+  async updateUser(userId: string, updates: UserUpdate): Promise<void> {
+    const sets: string[] = [];
+    const values: (string | number | null)[] = [];
+
+    if (updates.displayName !== undefined) {
+      sets.push("display_name = ?");
+      values.push(updates.displayName);
+    }
+    if (updates.avatarUrl !== undefined) {
+      sets.push("avatar_url = ?");
+      values.push(updates.avatarUrl);
+    }
+    if (updates.email !== undefined) {
+      sets.push("email = ?");
+      values.push(updates.email.toLowerCase());
+    }
+
+    if (sets.length === 0) return;
+
+    sets.push("updated_at = ?");
+    values.push(Date.now());
+    values.push(userId);
+
+    await this.db
+      .prepare(`UPDATE users SET ${sets.join(", ")} WHERE id = ?`)
+      .bind(...values)
+      .run();
+  }
+
+  // ── Private ─────────────────────────────────────────────────────
+
+  private async doResolveOrCreate(identity: ProviderIdentity): Promise<ResolvedUser> {
+    const normalizedEmail = identity.providerEmail?.toLowerCase() ?? null;
+
+    // Step 1: Look up by provider identity
+    const existing = await this.getIdentity(identity.provider, identity.providerUserId);
+
+    if (existing) {
+      // Step 2: Existing identity → load linked user, update if needed
+      const user = await this.getUserById(existing.userId);
+      if (!user) {
+        throw new Error(`Orphaned identity ${existing.id}: user ${existing.userId} not found`);
+      }
+
+      const updates: UserUpdate = {};
+      if (identity.displayName && identity.displayName !== user.displayName) {
+        updates.displayName = identity.displayName;
+      }
+      if (identity.avatarUrl && identity.avatarUrl !== user.avatarUrl) {
+        updates.avatarUrl = identity.avatarUrl;
+      }
+
+      // Step 2c: Backfill email if user has none and provider now has one
+      if (!user.email && normalizedEmail) {
+        const emailOwner = await this.getUserByEmail(normalizedEmail);
+        if (!emailOwner) {
+          updates.email = normalizedEmail;
+        }
+      }
+
+      if (Object.keys(updates).length > 0) {
+        await this.updateUser(user.id, updates);
+      }
+
+      return {
+        id: user.id,
+        displayName: updates.displayName ?? user.displayName,
+        email: updates.email ?? user.email,
+        isNew: false,
+      };
+    }
+
+    // Step 3: No identity found — try email-based cross-provider linking
+    if (normalizedEmail) {
+      const emailUser = await this.getUserByEmail(normalizedEmail);
+      if (emailUser) {
+        await this.createIdentity({
+          userId: emailUser.id,
+          provider: identity.provider,
+          providerUserId: identity.providerUserId,
+          providerLogin: identity.providerLogin,
+          providerEmail: normalizedEmail,
+        });
+        return {
+          id: emailUser.id,
+          displayName: emailUser.displayName,
+          email: emailUser.email,
+          isNew: false,
+        };
+      }
+    }
+
+    // Step 4: Brand new user
+    const newUser = await this.createUser({
+      displayName: identity.displayName,
+      email: normalizedEmail ?? undefined,
+      avatarUrl: identity.avatarUrl,
+    });
+
+    await this.createIdentity({
+      userId: newUser.id,
+      provider: identity.provider,
+      providerUserId: identity.providerUserId,
+      providerLogin: identity.providerLogin,
+      providerEmail: normalizedEmail ?? undefined,
+    });
+
+    return {
+      id: newUser.id,
+      displayName: newUser.displayName,
+      email: newUser.email,
+      isNew: true,
+    };
+  }
+}
+
+function isUniqueConstraintError(err: unknown): boolean {
+  return err instanceof Error && err.message.includes("UNIQUE constraint failed");
+}

--- a/packages/control-plane/src/db/user-store.ts
+++ b/packages/control-plane/src/db/user-store.ts
@@ -254,6 +254,11 @@ export class UserStore {
         throw new Error(`Orphaned identity ${existing.id}: user ${existing.userId} not found`);
       }
 
+      // Step 2a: Refresh identity-level metadata (provider_login, provider_email)
+      // so getIdentity() and getIdentitiesForUser() return current values.
+      await this.refreshIdentityMetadata(existing, identity.providerLogin, normalizedEmail);
+
+      // Step 2b: User-level updates (display_name, avatar_url)
       const updates: UserUpdate = {};
       if (identity.displayName && identity.displayName !== user.displayName) {
         updates.displayName = identity.displayName;
@@ -265,11 +270,27 @@ export class UserStore {
       // Step 2c: Backfill email if user has none and provider now has one.
       // The check-then-update is racy (a concurrent writer could claim the email
       // between the SELECT and UPDATE), but the outer retry in resolveOrCreateUser
-      // handles this: on retry, emailOwner is non-null and the backfill is skipped.
+      // handles this: on retry, emailOwner is non-null and we re-link instead.
       if (!user.email && normalizedEmail) {
         const emailOwner = await this.getUserByEmail(normalizedEmail);
         if (!emailOwner) {
           updates.email = normalizedEmail;
+        } else if (emailOwner.id !== user.id) {
+          // Another user owns this email — re-link this identity to that user.
+          // This prevents permanent identity splits when e.g. a Slack identity
+          // (created without email) later discovers the same email that a GitHub
+          // identity already registered. Same principle as step 3 (email-based
+          // cross-provider linking) but for existing identities.
+          await this.db
+            .prepare("UPDATE user_identities SET user_id = ? WHERE id = ?")
+            .bind(emailOwner.id, existing.id)
+            .run();
+          return {
+            id: emailOwner.id,
+            displayName: emailOwner.displayName,
+            email: emailOwner.email,
+            isNew: false,
+          };
         }
       }
 
@@ -341,6 +362,37 @@ export class UserStore {
       email: normalizedEmail,
       isNew: true,
     };
+  }
+
+  /**
+   * Update identity-level metadata (provider_login, provider_email) if
+   * the provider now reports newer values than what's stored. This keeps
+   * getIdentity() and getIdentitiesForUser() accurate across repeat sign-ins.
+   */
+  private async refreshIdentityMetadata(
+    existing: UserIdentity,
+    providerLogin: string | undefined,
+    normalizedEmail: string | null
+  ): Promise<void> {
+    const sets: string[] = [];
+    const values: (string | null)[] = [];
+
+    if (providerLogin && providerLogin !== existing.providerLogin) {
+      sets.push("provider_login = ?");
+      values.push(providerLogin);
+    }
+    if (normalizedEmail && normalizedEmail !== existing.providerEmail) {
+      sets.push("provider_email = ?");
+      values.push(normalizedEmail);
+    }
+
+    if (sets.length === 0) return;
+
+    values.push(existing.id);
+    await this.db
+      .prepare(`UPDATE user_identities SET ${sets.join(", ")} WHERE id = ?`)
+      .bind(...values)
+      .run();
   }
 }
 

--- a/packages/control-plane/src/db/user-store.ts
+++ b/packages/control-plane/src/db/user-store.ts
@@ -262,7 +262,10 @@ export class UserStore {
         updates.avatarUrl = identity.avatarUrl;
       }
 
-      // Step 2c: Backfill email if user has none and provider now has one
+      // Step 2c: Backfill email if user has none and provider now has one.
+      // The check-then-update is racy (a concurrent writer could claim the email
+      // between the SELECT and UPDATE), but the outer retry in resolveOrCreateUser
+      // handles this: on retry, emailOwner is non-null and the backfill is skipped.
       if (!user.email && normalizedEmail) {
         const emailOwner = await this.getUserByEmail(normalizedEmail);
         if (!emailOwner) {
@@ -302,30 +305,46 @@ export class UserStore {
       }
     }
 
-    // Step 4: Brand new user
-    const newUser = await this.createUser({
-      displayName: identity.displayName,
-      email: normalizedEmail ?? undefined,
-      avatarUrl: identity.avatarUrl,
-    });
+    // Step 4: Brand new user — batch user + identity creation so a UNIQUE
+    // failure on the identity INSERT rolls back the user INSERT, preventing
+    // orphaned user rows under concurrent requests.
+    const userId = generateId();
+    const identityId = generateId();
+    const now = Date.now();
+    const displayName = identity.displayName ?? null;
+    const avatarUrl = identity.avatarUrl ?? null;
 
-    await this.createIdentity({
-      userId: newUser.id,
-      provider: identity.provider,
-      providerUserId: identity.providerUserId,
-      providerLogin: identity.providerLogin,
-      providerEmail: normalizedEmail ?? undefined,
-    });
+    await this.db.batch([
+      this.db
+        .prepare(
+          "INSERT INTO users (id, display_name, email, avatar_url, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
+        )
+        .bind(userId, displayName, normalizedEmail, avatarUrl, now, now),
+      this.db
+        .prepare(
+          "INSERT INTO user_identities (id, user_id, provider, provider_user_id, provider_login, provider_email, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+        )
+        .bind(
+          identityId,
+          userId,
+          identity.provider,
+          identity.providerUserId,
+          identity.providerLogin ?? null,
+          normalizedEmail,
+          now
+        ),
+    ]);
 
     return {
-      id: newUser.id,
-      displayName: newUser.displayName,
-      email: newUser.email,
+      id: userId,
+      displayName,
+      email: normalizedEmail,
       isNew: true,
     };
   }
 }
 
 function isUniqueConstraintError(err: unknown): boolean {
-  return err instanceof Error && err.message.includes("UNIQUE constraint failed");
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.toLowerCase().includes("unique constraint failed");
 }

--- a/packages/control-plane/test/integration/cleanup.ts
+++ b/packages/control-plane/test/integration/cleanup.ts
@@ -6,6 +6,6 @@ import { env } from "cloudflare:test";
  */
 export async function cleanD1Tables(): Promise<void> {
   await env.DB.exec(
-    "DELETE FROM user_identities; DELETE FROM users; DELETE FROM automation_runs; DELETE FROM automations; DELETE FROM sessions; DELETE FROM repo_metadata; DELETE FROM repo_secrets; DELETE FROM global_secrets; DELETE FROM integration_settings; DELETE FROM integration_repo_settings; DELETE FROM repo_images; DELETE FROM mcp_servers;"
+    "DELETE FROM automation_runs; DELETE FROM automations; DELETE FROM sessions; DELETE FROM user_scm_tokens; DELETE FROM repo_metadata; DELETE FROM repo_secrets; DELETE FROM global_secrets; DELETE FROM integration_settings; DELETE FROM integration_repo_settings; DELETE FROM repo_images; DELETE FROM mcp_servers; DELETE FROM user_identities; DELETE FROM users;"
   );
 }

--- a/packages/control-plane/test/integration/cleanup.ts
+++ b/packages/control-plane/test/integration/cleanup.ts
@@ -6,6 +6,6 @@ import { env } from "cloudflare:test";
  */
 export async function cleanD1Tables(): Promise<void> {
   await env.DB.exec(
-    "DELETE FROM automation_runs; DELETE FROM automations; DELETE FROM sessions; DELETE FROM repo_metadata; DELETE FROM repo_secrets; DELETE FROM global_secrets; DELETE FROM integration_settings; DELETE FROM integration_repo_settings; DELETE FROM repo_images; DELETE FROM mcp_servers;"
+    "DELETE FROM user_identities; DELETE FROM users; DELETE FROM automation_runs; DELETE FROM automations; DELETE FROM sessions; DELETE FROM repo_metadata; DELETE FROM repo_secrets; DELETE FROM global_secrets; DELETE FROM integration_settings; DELETE FROM integration_repo_settings; DELETE FROM repo_images; DELETE FROM mcp_servers;"
   );
 }

--- a/packages/control-plane/test/integration/user-store.test.ts
+++ b/packages/control-plane/test/integration/user-store.test.ts
@@ -56,6 +56,7 @@ describe("UserStore", () => {
         providerUserId: "12345",
         displayName: "Alice",
       });
+      const beforeUpdate = await store.getUserById(first.id);
 
       const second = await store.resolveOrCreateUser({
         provider: "github",
@@ -69,6 +70,7 @@ describe("UserStore", () => {
 
       const user = await store.getUserById(first.id);
       expect(user!.displayName).toBe("Alice Updated");
+      expect(user!.updatedAt).toBeGreaterThanOrEqual(beforeUpdate!.updatedAt);
     });
 
     it("links new identity to existing user by matching email", async () => {
@@ -157,6 +159,32 @@ describe("UserStore", () => {
 
       const user = await store.getUserById(result.id);
       expect(user!.avatarUrl).toBe("https://avatars.example.com/alice.png");
+    });
+
+    it("concurrent calls for same identity resolve to same user without orphans", async () => {
+      const identity = {
+        provider: "github" as const,
+        providerUserId: "race-123",
+        displayName: "Racer",
+      };
+
+      const [a, b] = await Promise.all([
+        store.resolveOrCreateUser(identity),
+        store.resolveOrCreateUser(identity),
+      ]);
+
+      // Both resolve to the same canonical user
+      expect(a.id).toBe(b.id);
+
+      // Exactly one identity row exists (no duplicates)
+      const identities = await store.getIdentitiesForUser(a.id);
+      expect(identities).toHaveLength(1);
+
+      // No orphaned user rows — count all users in the table
+      const allUsers = await env.DB.prepare("SELECT COUNT(*) as cnt FROM users").first<{
+        cnt: number;
+      }>();
+      expect(allUsers!.cnt).toBe(1);
     });
   });
 

--- a/packages/control-plane/test/integration/user-store.test.ts
+++ b/packages/control-plane/test/integration/user-store.test.ts
@@ -1,0 +1,248 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { env } from "cloudflare:test";
+import { UserStore } from "../../src/db/user-store";
+import { cleanD1Tables } from "./cleanup";
+
+describe("UserStore", () => {
+  let store: UserStore;
+
+  beforeEach(async () => {
+    await cleanD1Tables();
+    store = new UserStore(env.DB);
+  });
+
+  // ── resolveOrCreateUser ─────────────────────────────────────────
+
+  describe("resolveOrCreateUser", () => {
+    it("creates a new user with no email", async () => {
+      const result = await store.resolveOrCreateUser({
+        provider: "github",
+        providerUserId: "12345",
+        displayName: "Alice",
+      });
+
+      expect(result.isNew).toBe(true);
+      expect(result.displayName).toBe("Alice");
+      expect(result.email).toBeNull();
+
+      const user = await store.getUserById(result.id);
+      expect(user).not.toBeNull();
+      expect(user!.displayName).toBe("Alice");
+      expect(user!.email).toBeNull();
+    });
+
+    it("creates a new user with email normalized to lowercase", async () => {
+      const result = await store.resolveOrCreateUser({
+        provider: "github",
+        providerUserId: "12345",
+        displayName: "Alice",
+        providerEmail: "Alice@Example.COM",
+      });
+
+      expect(result.isNew).toBe(true);
+      expect(result.email).toBe("alice@example.com");
+
+      const user = await store.getUserById(result.id);
+      expect(user!.email).toBe("alice@example.com");
+
+      // Identity email is also normalized
+      const identity = await store.getIdentity("github", "12345");
+      expect(identity!.providerEmail).toBe("alice@example.com");
+    });
+
+    it("returns existing user for known identity and updates display_name", async () => {
+      const first = await store.resolveOrCreateUser({
+        provider: "github",
+        providerUserId: "12345",
+        displayName: "Alice",
+      });
+
+      const second = await store.resolveOrCreateUser({
+        provider: "github",
+        providerUserId: "12345",
+        displayName: "Alice Updated",
+      });
+
+      expect(second.id).toBe(first.id);
+      expect(second.isNew).toBe(false);
+      expect(second.displayName).toBe("Alice Updated");
+
+      const user = await store.getUserById(first.id);
+      expect(user!.displayName).toBe("Alice Updated");
+    });
+
+    it("links new identity to existing user by matching email", async () => {
+      const github = await store.resolveOrCreateUser({
+        provider: "github",
+        providerUserId: "gh-123",
+        displayName: "Alice",
+        providerEmail: "alice@example.com",
+      });
+
+      const slack = await store.resolveOrCreateUser({
+        provider: "slack",
+        providerUserId: "USLACK456",
+        displayName: "Alice (Slack)",
+        providerEmail: "alice@example.com",
+      });
+
+      expect(slack.id).toBe(github.id);
+      expect(slack.isNew).toBe(false);
+
+      const identities = await store.getIdentitiesForUser(github.id);
+      expect(identities).toHaveLength(2);
+      expect(identities.map((i) => i.provider).sort()).toEqual(["github", "slack"]);
+    });
+
+    it("backfills email on existing user when email becomes available", async () => {
+      // Create user without email (e.g. Slack bot before users:read.email scope)
+      const first = await store.resolveOrCreateUser({
+        provider: "slack",
+        providerUserId: "UABC",
+        displayName: "Alice",
+      });
+      expect(first.email).toBeNull();
+
+      // Same identity, now with email
+      const second = await store.resolveOrCreateUser({
+        provider: "slack",
+        providerUserId: "UABC",
+        displayName: "Alice",
+        providerEmail: "alice@example.com",
+      });
+
+      expect(second.id).toBe(first.id);
+      expect(second.email).toBe("alice@example.com");
+
+      const user = await store.getUserById(first.id);
+      expect(user!.email).toBe("alice@example.com");
+    });
+
+    it("skips email update when another user already owns the email", async () => {
+      // User A owns the email
+      await store.resolveOrCreateUser({
+        provider: "github",
+        providerUserId: "gh-111",
+        displayName: "User A",
+        providerEmail: "shared@example.com",
+      });
+
+      // User B has no email
+      const userB = await store.resolveOrCreateUser({
+        provider: "slack",
+        providerUserId: "slack-222",
+        displayName: "User B",
+      });
+      expect(userB.email).toBeNull();
+
+      // User B's provider now reports the same email — should NOT update
+      const userBRetry = await store.resolveOrCreateUser({
+        provider: "slack",
+        providerUserId: "slack-222",
+        displayName: "User B",
+        providerEmail: "shared@example.com",
+      });
+
+      expect(userBRetry.id).toBe(userB.id);
+      expect(userBRetry.email).toBeNull();
+    });
+
+    it("stores avatar_url on new user", async () => {
+      const result = await store.resolveOrCreateUser({
+        provider: "github",
+        providerUserId: "12345",
+        displayName: "Alice",
+        avatarUrl: "https://avatars.example.com/alice.png",
+      });
+
+      const user = await store.getUserById(result.id);
+      expect(user!.avatarUrl).toBe("https://avatars.example.com/alice.png");
+    });
+  });
+
+  // ── getUserById ─────────────────────────────────────────────────
+
+  describe("getUserById", () => {
+    it("returns user when found", async () => {
+      const created = await store.resolveOrCreateUser({
+        provider: "github",
+        providerUserId: "12345",
+        displayName: "Alice",
+        providerEmail: "alice@example.com",
+      });
+
+      const user = await store.getUserById(created.id);
+      expect(user).not.toBeNull();
+      expect(user!.id).toBe(created.id);
+      expect(user!.displayName).toBe("Alice");
+      expect(user!.email).toBe("alice@example.com");
+      expect(user!.createdAt).toBeTypeOf("number");
+      expect(user!.updatedAt).toBeTypeOf("number");
+    });
+
+    it("returns null when not found", async () => {
+      const user = await store.getUserById("nonexistent");
+      expect(user).toBeNull();
+    });
+  });
+
+  // ── getIdentitiesForUser ────────────────────────────────────────
+
+  describe("getIdentitiesForUser", () => {
+    it("returns all identities for a user", async () => {
+      const user = await store.resolveOrCreateUser({
+        provider: "github",
+        providerUserId: "gh-123",
+        displayName: "Alice",
+        providerEmail: "alice@example.com",
+      });
+
+      // Second identity linked via email
+      await store.resolveOrCreateUser({
+        provider: "slack",
+        providerUserId: "slack-456",
+        providerEmail: "alice@example.com",
+      });
+
+      const identities = await store.getIdentitiesForUser(user.id);
+      expect(identities).toHaveLength(2);
+
+      const github = identities.find((i) => i.provider === "github")!;
+      expect(github.providerUserId).toBe("gh-123");
+      expect(github.providerEmail).toBe("alice@example.com");
+
+      const slack = identities.find((i) => i.provider === "slack")!;
+      expect(slack.providerUserId).toBe("slack-456");
+    });
+
+    it("returns empty array when user has no identities", async () => {
+      const identities = await store.getIdentitiesForUser("nonexistent");
+      expect(identities).toEqual([]);
+    });
+  });
+
+  // ── getIdentity ─────────────────────────────────────────────────
+
+  describe("getIdentity", () => {
+    it("returns identity when found", async () => {
+      await store.resolveOrCreateUser({
+        provider: "github",
+        providerUserId: "12345",
+        displayName: "Alice",
+        providerLogin: "alice",
+      });
+
+      const identity = await store.getIdentity("github", "12345");
+      expect(identity).not.toBeNull();
+      expect(identity!.provider).toBe("github");
+      expect(identity!.providerUserId).toBe("12345");
+      expect(identity!.providerLogin).toBe("alice");
+      expect(identity!.createdAt).toBeTypeOf("number");
+    });
+
+    it("returns null when not found", async () => {
+      const identity = await store.getIdentity("github", "nonexistent");
+      expect(identity).toBeNull();
+    });
+  });
+});

--- a/packages/control-plane/test/integration/user-store.test.ts
+++ b/packages/control-plane/test/integration/user-store.test.ts
@@ -120,33 +120,66 @@ describe("UserStore", () => {
       expect(user!.email).toBe("alice@example.com");
     });
 
-    it("skips email update when another user already owns the email", async () => {
-      // User A owns the email
+    it("refreshes identity metadata on repeat sign-in", async () => {
+      // Create user without email or login
       await store.resolveOrCreateUser({
+        provider: "slack",
+        providerUserId: "UABC",
+        displayName: "Alice",
+      });
+
+      const before = await store.getIdentity("slack", "UABC");
+      expect(before!.providerEmail).toBeNull();
+      expect(before!.providerLogin).toBeNull();
+
+      // Same identity, now with email and login (after Slack scope added)
+      await store.resolveOrCreateUser({
+        provider: "slack",
+        providerUserId: "UABC",
+        displayName: "Alice",
+        providerLogin: "alice.smith",
+        providerEmail: "alice@example.com",
+      });
+
+      const after = await store.getIdentity("slack", "UABC");
+      expect(after!.providerEmail).toBe("alice@example.com");
+      expect(after!.providerLogin).toBe("alice.smith");
+    });
+
+    it("re-links identity to email-owning user when email conflict is discovered", async () => {
+      // User A owns the email (e.g. GitHub login)
+      const userA = await store.resolveOrCreateUser({
         provider: "github",
         providerUserId: "gh-111",
         displayName: "User A",
         providerEmail: "shared@example.com",
       });
 
-      // User B has no email
+      // User B created without email (e.g. Slack before users:read.email scope)
       const userB = await store.resolveOrCreateUser({
         provider: "slack",
         providerUserId: "slack-222",
         displayName: "User B",
       });
       expect(userB.email).toBeNull();
+      expect(userB.id).not.toBe(userA.id);
 
-      // User B's provider now reports the same email — should NOT update
-      const userBRetry = await store.resolveOrCreateUser({
+      // User B's provider now reports the same email — identity should
+      // re-link to User A (same principle as step 3 email-based linking)
+      const result = await store.resolveOrCreateUser({
         provider: "slack",
         providerUserId: "slack-222",
         displayName: "User B",
         providerEmail: "shared@example.com",
       });
 
-      expect(userBRetry.id).toBe(userB.id);
-      expect(userBRetry.email).toBeNull();
+      expect(result.id).toBe(userA.id);
+      expect(result.email).toBe("shared@example.com");
+
+      // Both identities now belong to User A
+      const identities = await store.getIdentitiesForUser(userA.id);
+      expect(identities).toHaveLength(2);
+      expect(identities.map((i) => i.provider).sort()).toEqual(["github", "slack"]);
     });
 
     it("stores avatar_url on new user", async () => {

--- a/terraform/d1/migrations/0019_create_users.sql
+++ b/terraform/d1/migrations/0019_create_users.sql
@@ -1,0 +1,46 @@
+-- Unified user model: canonical user records and cross-provider identity linking.
+-- See docs/internal/2026-04-21-unified-user-model-implementation-plan.md
+
+-- Canonical user record (one per person across all providers)
+CREATE TABLE IF NOT EXISTS users (
+  id           TEXT    PRIMARY KEY,
+  display_name TEXT,
+  email        TEXT,
+  avatar_url   TEXT,
+  created_at   INTEGER NOT NULL,
+  updated_at   INTEGER NOT NULL
+);
+
+-- Partial unique index on email: allows multiple NULL emails,
+-- enforces uniqueness for non-NULL values. COLLATE NOCASE is a
+-- safety net; all writes normalize to lowercase.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email
+  ON users(email COLLATE NOCASE) WHERE email IS NOT NULL;
+
+-- Links provider identities (GitHub, Slack, Linear) to canonical users
+CREATE TABLE IF NOT EXISTS user_identities (
+  id               TEXT PRIMARY KEY,
+  user_id          TEXT NOT NULL,
+  provider         TEXT NOT NULL,
+  provider_user_id TEXT NOT NULL,
+  provider_login   TEXT,
+  provider_email   TEXT,
+  created_at       INTEGER NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_identities_provider
+  ON user_identities(provider, provider_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_user_identities_user
+  ON user_identities(user_id);
+
+-- Extend existing tables with nullable user_id column
+ALTER TABLE sessions ADD COLUMN user_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_sessions_user_id
+  ON sessions(user_id, created_at DESC);
+
+ALTER TABLE user_scm_tokens ADD COLUMN user_id TEXT;
+
+ALTER TABLE automations ADD COLUMN user_id TEXT;


### PR DESCRIPTION
## Summary

Phase 1 of the unified user model migration ([#523](https://github.com/ColeMurray/background-agents/issues/523)). Adds the data foundation for cross-provider identity linking — **no runtime behavior changes**.

- **D1 migration `0019_create_users.sql`**: creates `users` and `user_identities` tables with partial unique email index (`COLLATE NOCASE`), unique provider identity index, and adds nullable `user_id` columns to `sessions`, `user_scm_tokens`, and `automations`
- **`UserStore` class** with `resolveOrCreateUser` algorithm: identity lookup → email-based cross-provider linking → new user creation. Handles email normalization (lowercase) and concurrent request races via UNIQUE constraint retry
- **13 integration tests** covering: new user (with/without email), existing identity (display name update), email-based cross-provider linking, email backfill, email conflict detection, avatar storage, and all CRUD operations
- **Integration test cleanup** updated for new tables (FK-respecting delete order)

### Why this is safe to deploy alone

- Empty tables and NULL columns have zero runtime cost
- No existing code references the new tables or columns
- All 991 unit tests and 318 integration tests pass

### What's next

This is the first PR of the [phased implementation plan](https://github.com/ColeMurray/background-agents/blob/main/docs/internal/2026-04-21-unified-user-model-phased-implementation.md). Next: Phase 2 (SessionIndexStore `user_id`, `handleCreateSession` wiring, `handleSpawnChild` inheritance).

## Test plan

- [x] `npm run typecheck -w @open-inspect/control-plane` — clean
- [x] `npm run test -w @open-inspect/control-plane` — 991 passed
- [x] `npm run test:integration -w @open-inspect/control-plane` — 318 passed (13 new)
- [ ] Verify migration applies cleanly in staging D1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Canonical user accounts with multi‑provider identity linking, automatic account creation, email‑based linking, and email backfill; user profiles store display name, email, and avatar.

* **Database**
  * Added users and user_identities tables; sessions and token records can reference users; unique email indexing for non‑NULL emails.

* **Tests**
  * Integration suite for creation, linking, updates, backfill, concurrency; test cleanup now clears user-related tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->