### PR TITLE
fix: clear stale spawn error when sandbox connects

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -1204,11 +1204,12 @@ export class SandboxLifecycleManager {
 
   /**
    * Notify the manager that a sandbox has connected.
-   * Resets the in-memory spawning flag to allow future spawns.
+   * Resets the in-memory spawning flag and clears any stale spawn error.
    *
    * Called by SessionDO when sandbox WebSocket connects successfully.
    */
   onSandboxConnected(): void {
     this.isSpawningSandbox = false;
+    this.storage.setLastSpawnError(null, null);
   }
 }

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -310,7 +310,7 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
           cursorRef.current = data.replay?.cursor ?? null;
           setReplaying(false);
 
-          if (data.spawnError) {
+          if (data.spawnError && data.state?.sandboxStatus === "failed") {
             console.error("Sandbox spawn error:", data.spawnError);
             setSessionState((prev) => (prev ? { ...prev, sandboxStatus: "failed" } : null));
           }


### PR DESCRIPTION
## Summary

- **Control plane**: `onSandboxConnected()` now calls `setLastSpawnError(null, null)` to clear the stale error from the DB when a sandbox successfully connects, not just the in-memory spawning flag.
- **Web client**: The `subscribed` message handler now only overrides `sandboxStatus` to `"failed"` when `data.state.sandboxStatus` is actually `"failed"`, rather than unconditionally whenever `spawnError` is truthy.

These two bugs combined caused the UI to show "failed" even when a sandbox recovered from a transient Modal 524 error and was actively running.

## Test plan

- [x] Control-plane unit tests pass (991 tests)
- [x] Web unit tests pass (185 tests)
- [x] TypeScript type-check passes for both packages
- [ ] Verify in staging: trigger a session, observe that after sandbox connects, `sandboxStatus` shows "ready" even if a prior spawn attempt failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved sandbox connection error state management — spawn errors are now properly cleared when sandboxes successfully reconnect.
* Enhanced sandbox failure detection — sandbox status is now correctly marked as failed only when both spawn errors and failed status conditions are present, reducing false failure reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->