### PR TITLE
fix: short-circuit disabled automations in webhook handlers

### DIFF
--- a/packages/control-plane/src/webhooks/automation-webhook.ts
+++ b/packages/control-plane/src/webhooks/automation-webhook.ts
@@ -5,9 +5,12 @@
 import { normalizeWebhookEvent } from "@open-inspect/shared";
 import { AutomationStore } from "../db/automation-store";
 import { verifyWebhookApiKey } from "../auth/webhook-key";
+import { createLogger } from "../logger";
 import type { Route, RequestContext } from "../routes/shared";
 import { parsePattern, json, error } from "../routes/shared";
 import type { Env } from "../types";
+
+const logger = createLogger("webhook:automation");
 
 /** Maximum webhook payload size (64KB). */
 const MAX_PAYLOAD_SIZE = 64 * 1024;
@@ -16,36 +19,56 @@ async function handleAutomationWebhook(
   request: Request,
   env: Env,
   match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const automationId = match.groups?.id;
   if (!automationId) return error("Automation ID required", 400);
 
-  // 1. Validate content type
-  const contentType = request.headers.get("content-type");
-  if (!contentType?.includes("application/json")) {
-    return error("Content-Type must be application/json", 415);
-  }
-
-  // 2. Validate API key
-  const authHeader = request.headers.get("authorization");
-  const apiKey = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
-  if (!apiKey) return error("Missing API key", 401);
-
-  // 3. Look up automation
+  // 1. Look up automation
   const store = new AutomationStore(env.DB);
   const automation = await store.getById(automationId);
   if (!automation || automation.trigger_type !== "webhook") {
     return error("Not found", 404);
   }
 
+  // 1a. Short-circuit disabled automations before any auth or body work
+  if (automation.enabled !== 1) {
+    logger.info("Webhook skipped: automation disabled", {
+      event: "webhook.skipped",
+      automation_id: automationId,
+      reason: "disabled",
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return json({ ok: true, triggered: 0, skipped: 1 });
+  }
+
   if (!automation.trigger_auth_data) {
     return error("Webhook not configured", 500);
   }
 
+  // 2. Validate content type
+  const contentType = request.headers.get("content-type");
+  if (!contentType?.includes("application/json")) {
+    return error("Content-Type must be application/json", 415);
+  }
+
+  // 3. Validate API key
+  const authHeader = request.headers.get("authorization");
+  const apiKey = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
+  if (!apiKey) return error("Missing API key", 401);
+
   // 4. Verify API key
   const valid = await verifyWebhookApiKey(apiKey, automation.trigger_auth_data);
-  if (!valid) return error("Invalid API key", 401);
+  if (!valid) {
+    logger.warn("Webhook auth failed", {
+      event: "webhook.auth_failed",
+      automation_id: automationId,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return error("Invalid API key", 401);
+  }
 
   // 5. Parse body — fast-path reject on Content-Length before reading
   const contentLength = parseInt(request.headers.get("content-length") ?? "0", 10);
@@ -86,6 +109,16 @@ async function handleAutomationWebhook(
   });
 
   const result = await response.json<{ triggered: number; skipped: number }>();
+
+  logger.info("Webhook processed", {
+    event: "webhook.processed",
+    automation_id: automationId,
+    triggered: result.triggered,
+    skipped: result.skipped,
+    request_id: ctx.request_id,
+    trace_id: ctx.trace_id,
+  });
+
   return json({ ok: true, ...result }, response.status === 200 ? 200 : response.status);
 }
 

--- a/packages/control-plane/src/webhooks/sentry.ts
+++ b/packages/control-plane/src/webhooks/sentry.ts
@@ -6,9 +6,12 @@
 import { verifySentrySignature, normalizeSentryEvent } from "@open-inspect/shared";
 import { AutomationStore } from "../db/automation-store";
 import { decryptSentrySecret } from "../auth/webhook-key";
+import { createLogger } from "../logger";
 import type { Route, RequestContext } from "../routes/shared";
 import { parsePattern, json, error } from "../routes/shared";
 import type { Env } from "../types";
+
+const logger = createLogger("webhook:sentry");
 
 /** Maximum Sentry webhook payload size (256KB — Sentry payloads with stack traces can be large). */
 const MAX_PAYLOAD_SIZE = 256 * 1024;
@@ -17,7 +20,7 @@ async function handleSentryWebhook(
   request: Request,
   env: Env,
   match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const automationId = match.groups?.id;
   if (!automationId) return error("Automation ID required", 400);
@@ -27,6 +30,18 @@ async function handleSentryWebhook(
   const automation = await store.getById(automationId);
   if (!automation || automation.trigger_type !== "sentry") {
     return error("Not found", 404);
+  }
+
+  // 1a. Short-circuit disabled automations before expensive crypto
+  if (automation.enabled !== 1) {
+    logger.info("Webhook skipped: automation disabled", {
+      event: "webhook.skipped",
+      automation_id: automationId,
+      reason: "disabled",
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return json({ ok: true, triggered: 0, skipped: 1 });
   }
 
   if (!automation.trigger_auth_data) {
@@ -62,10 +77,16 @@ async function handleSentryWebhook(
 
   const valid = await verifySentrySignature(body, signature, secret);
   if (!valid) {
+    logger.warn("Webhook auth failed", {
+      event: "webhook.auth_failed",
+      automation_id: automationId,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
     return error("Invalid signature", 401);
   }
 
-  // 3. Parse and normalize
+  // 4. Parse and normalize
   let payload: Record<string, unknown>;
   try {
     payload = JSON.parse(body) as Record<string, unknown>;
@@ -78,7 +99,7 @@ async function handleSentryWebhook(
     return json({ ok: true, skipped: true });
   }
 
-  // 4. Forward to SchedulerDO
+  // 5. Forward to SchedulerDO
   if (!env.SCHEDULER) {
     return error("Scheduler not configured", 503);
   }
@@ -93,6 +114,16 @@ async function handleSentryWebhook(
   });
 
   const result = await response.json<{ triggered: number; skipped: number }>();
+
+  logger.info("Webhook processed", {
+    event: "webhook.processed",
+    automation_id: automationId,
+    triggered: result.triggered,
+    skipped: result.skipped,
+    request_id: ctx.request_id,
+    trace_id: ctx.trace_id,
+  });
+
   return json({ ok: true, ...result }, response.status === 200 ? 200 : response.status);
 }
 

--- a/packages/control-plane/test/integration/webhooks.test.ts
+++ b/packages/control-plane/test/integration/webhooks.test.ts
@@ -204,6 +204,44 @@ describe("POST /webhooks/sentry/:id", () => {
 
     expect(response.status).toBe(404);
   });
+
+  it("returns 200 with skipped: 1 for disabled automation", async () => {
+    const automation = await createSentryAutomation({ enabled: 0 });
+    const body = JSON.stringify(sentryIssuePayload);
+    const signature = await signSentryPayload(body, SENTRY_TEST_SECRET);
+
+    const response = await SELF.fetch(`https://test.local/webhooks/sentry/${automation.id}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "sentry-hook-signature": signature,
+      },
+      body,
+    });
+
+    expect(response.status).toBe(200);
+    const result = await response.json<{ ok: boolean; triggered: number; skipped: number }>();
+    expect(result.ok).toBe(true);
+    expect(result.skipped).toBe(1);
+    expect(result.triggered).toBe(0);
+  });
+
+  it("returns 404 for soft-deleted automation", async () => {
+    const automation = await createSentryAutomation({ deleted_at: Date.now() });
+    const body = JSON.stringify(sentryIssuePayload);
+    const signature = await signSentryPayload(body, SENTRY_TEST_SECRET);
+
+    const response = await SELF.fetch(`https://test.local/webhooks/sentry/${automation.id}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "sentry-hook-signature": signature,
+      },
+      body,
+    });
+
+    expect(response.status).toBe(404);
+  });
 });
 
 // ─── Automation webhook tests ─────────────────────────────────────────────────
@@ -351,5 +389,57 @@ describe("POST /webhooks/automation/:id", () => {
     });
 
     expect(response.status).toBe(413);
+  });
+
+  it("returns 200 with skipped: 1 for disabled automation", async () => {
+    const automation = await createWebhookAutomation({ enabled: 0 });
+
+    const response = await SELF.fetch(`https://test.local/webhooks/automation/${automation.id}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${TEST_API_KEY}`,
+      },
+      body: JSON.stringify({ action: "deploy" }),
+    });
+
+    expect(response.status).toBe(200);
+    const result = await response.json<{ ok: boolean; triggered: number; skipped: number }>();
+    expect(result.ok).toBe(true);
+    expect(result.skipped).toBe(1);
+    expect(result.triggered).toBe(0);
+  });
+
+  it("skips auth verification for disabled automation (invalid key still returns 200)", async () => {
+    const automation = await createWebhookAutomation({ enabled: 0 });
+
+    const response = await SELF.fetch(`https://test.local/webhooks/automation/${automation.id}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer totally-wrong-key",
+      },
+      body: JSON.stringify({ action: "deploy" }),
+    });
+
+    expect(response.status).toBe(200);
+    const result = await response.json<{ ok: boolean; triggered: number; skipped: number }>();
+    expect(result.ok).toBe(true);
+    expect(result.skipped).toBe(1);
+  });
+
+  it("returns 404 for soft-deleted automation", async () => {
+    const automation = await createWebhookAutomation({ deleted_at: Date.now() });
+
+    const response = await SELF.fetch(`https://test.local/webhooks/automation/${automation.id}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${TEST_API_KEY}`,
+      },
+      body: JSON.stringify({ action: "deploy" }),
+    });
+
+    expect(response.status).toBe(404);
   });
 });


### PR DESCRIPTION
## What changed

Both the generic automation webhook handler (`/webhooks/automation/:id`) and the Sentry webhook handler (`/webhooks/sentry/:id`) now **short-circuit disabled automations** before performing any expensive crypto work (SHA-256 hashing, HMAC signature verification, AES decryption). Previously, disabled automations would proceed through the full auth pipeline before the SchedulerDO would eventually reject them downstream.

Additionally:
- **Structured logging** added to both handlers for observability: `webhook.skipped`, `webhook.auth_failed`, `webhook.processed` events with automation ID, request/trace correlation
- **5 new integration tests** covering disabled and soft-deleted automation edge cases
- **Consistent `enabled` check** using `automation.enabled !== 1` (matches SchedulerDO pattern) instead of truthy coercion

### Files changed

| File | Change |
|------|--------|
| `packages/control-plane/src/webhooks/automation-webhook.ts` | Disabled early-return, reordered steps (lookup → enabled check → auth), structured logging |
| `packages/control-plane/src/webhooks/sentry.ts` | Disabled early-return after lookup, structured logging |
| `packages/control-plane/test/integration/webhooks.test.ts` | 5 new tests: disabled + soft-deleted for both handlers, auth-skip regression test |

## How to use this feature

### Webhook automations

Create a webhook automation via the API or UI, then POST to the endpoint with a Bearer token:

```bash
# Create automation (returns webhookUrl and webhookApiKey)
POST /automations
{
  "name": "AlertManager alerts",
  "triggerType": "webhook",
  "repoOwner": "your-org",
  "repoName": "your-repo",
  "instructions": "Investigate the alert and fix the issue..."
}

# Send webhook (e.g., from AlertManager, Datadog, PagerDuty, etc.)
curl -X POST https://<control-plane>/webhooks/automation/<automationId> \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer <webhookApiKey>" \
  -d '{"alerts": [{"status": "firing", "labels": {"alertname": "HighErrorRate"}}]}'
```

**Key behaviors:**
- **Disabled automation** → `200 { ok: true, triggered: 0, skipped: 1 }` (no crypto work performed)
- **Deleted automation** → `404 Not found`
- **Valid request** → Forwards to SchedulerDO which creates a session with the payload as context
- **Idempotency** → Include `"idempotencyKey": "unique-value"` in the payload root to deduplicate
- **Payload filtering** → Configure JSONPath conditions in `triggerConfig.conditions` to only fire on matching payloads:
  ```json
  {
    "triggerConfig": {
      "conditions": [{
        "type": "jsonpath",
        "value": [{ "path": "$.alerts.0.labels.severity", "comparison": "eq", "value": "critical" }]
      }]
    }
  }
  ```

### Sentry automations

Same pattern but uses Sentry's HMAC signature verification:

```bash
POST /automations
{
  "name": "Sentry error handler",
  "triggerType": "sentry",
  "eventType": "issue.created",
  "sentryClientSecret": "<from Sentry webhook settings>",
  "repoOwner": "your-org",
  "repoName": "your-repo",
  "instructions": "Investigate and fix the Sentry error..."
}
```

Configure the returned `sentryWebhookUrl` in Sentry's webhook integration settings.

### Pausing/resuming

```bash
# Pause — webhooks return 200 skip without crypto work
POST /automations/<id>/pause

# Resume
POST /automations/<id>/resume

# Regenerate API key (invalidates old key)
POST /automations/<id>/regenerate-key
```

## User impact

- Disabled automations no longer waste compute on crypto verification
- Operators get structured log events for debugging webhook delivery issues
- No breaking changes to the webhook API contract

## Migration needed?

N/A

## Release notes draft

Webhook handlers now skip crypto verification for disabled automations and emit structured log events for better observability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled webhook automations now return appropriate skip responses without processing validation work.
  * Soft-deleted automations now correctly return not found responses.

* **Tests**
  * Added integration test coverage for disabled and soft-deleted webhook automation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->