### PR TITLE
feat: add GPT-5.5 model support

### DIFF
--- a/packages/control-plane/src/utils/models.test.ts
+++ b/packages/control-plane/src/utils/models.test.ts
@@ -36,6 +36,7 @@ describe("model utilities", () => {
     it("returns true for OpenAI models", () => {
       expect(isValidModel("openai/gpt-5.2")).toBe(true);
       expect(isValidModel("openai/gpt-5.4")).toBe(true);
+      expect(isValidModel("openai/gpt-5.5")).toBe(true);
       expect(isValidModel("openai/gpt-5.2-codex")).toBe(true);
       expect(isValidModel("openai/gpt-5.3-codex")).toBe(true);
       expect(isValidModel("openai/gpt-5.3-codex-spark")).toBe(true);
@@ -43,6 +44,7 @@ describe("model utilities", () => {
 
     it("accepts bare GPT model names via normalization", () => {
       expect(isValidModel("gpt-5.4")).toBe(true);
+      expect(isValidModel("gpt-5.5")).toBe(true);
       expect(isValidModel("gpt-5.2")).toBe(true);
       expect(isValidModel("gpt-5.2-codex")).toBe(true);
       expect(isValidModel("gpt-5.3-codex")).toBe(true);
@@ -106,6 +108,11 @@ describe("model utilities", () => {
       expect(extractProviderAndModel("openai/gpt-5.4")).toEqual({
         provider: "openai",
         model: "gpt-5.4",
+      });
+
+      expect(extractProviderAndModel("openai/gpt-5.5")).toEqual({
+        provider: "openai",
+        model: "gpt-5.5",
       });
 
       expect(extractProviderAndModel("openai/gpt-5.2-codex")).toEqual({
@@ -210,6 +217,7 @@ describe("model utilities", () => {
 
     it("normalizes bare GPT model names to prefixed format", () => {
       expect(getValidModelOrDefault("gpt-5.4")).toBe("openai/gpt-5.4");
+      expect(getValidModelOrDefault("gpt-5.5")).toBe("openai/gpt-5.5");
       expect(getValidModelOrDefault("gpt-5.2")).toBe("openai/gpt-5.2");
       expect(getValidModelOrDefault("gpt-5.2-codex")).toBe("openai/gpt-5.2-codex");
     });
@@ -250,6 +258,7 @@ describe("model utilities", () => {
     it("returns true for OpenAI models with reasoning config", () => {
       expect(supportsReasoning("openai/gpt-5.2")).toBe(true);
       expect(supportsReasoning("openai/gpt-5.4")).toBe(true);
+      expect(supportsReasoning("openai/gpt-5.5")).toBe(true);
       expect(supportsReasoning("openai/gpt-5.2-codex")).toBe(true);
       expect(supportsReasoning("openai/gpt-5.3-codex")).toBe(true);
       expect(supportsReasoning("openai/gpt-5.3-codex-spark")).toBe(true);
@@ -283,9 +292,10 @@ describe("model utilities", () => {
       expect(getDefaultReasoningEffort("openai/gpt-5.3-codex-spark")).toBe("high");
     });
 
-    it("returns undefined for GPT 5.2 and GPT 5.4 (no default)", () => {
+    it("returns undefined for GPT 5.2, GPT 5.4, and GPT 5.5", () => {
       expect(getDefaultReasoningEffort("openai/gpt-5.2")).toBeUndefined();
       expect(getDefaultReasoningEffort("openai/gpt-5.4")).toBeUndefined();
+      expect(getDefaultReasoningEffort("openai/gpt-5.5")).toBeUndefined();
     });
 
     it("returns undefined for invalid models", () => {
@@ -341,6 +351,14 @@ describe("model utilities", () => {
       });
     });
 
+    it("returns config for GPT 5.5 with none effort", () => {
+      const config = getReasoningConfig("openai/gpt-5.5");
+      expect(config).toEqual({
+        efforts: ["none", "low", "medium", "high", "xhigh"],
+        default: undefined,
+      });
+    });
+
     it("returns undefined for invalid models", () => {
       expect(getReasoningConfig("invalid")).toBeUndefined();
     });
@@ -386,11 +404,13 @@ describe("model utilities", () => {
       expect(isValidReasoningEffort("openai/gpt-5.3-codex-spark", "max")).toBe(false);
       expect(isValidReasoningEffort("openai/gpt-5.2", "max")).toBe(false);
       expect(isValidReasoningEffort("openai/gpt-5.4", "max")).toBe(false);
+      expect(isValidReasoningEffort("openai/gpt-5.5", "max")).toBe(false);
     });
 
     it("returns true for none on GPT 5.x baseline models", () => {
       expect(isValidReasoningEffort("openai/gpt-5.2", "none")).toBe(true);
       expect(isValidReasoningEffort("openai/gpt-5.4", "none")).toBe(true);
+      expect(isValidReasoningEffort("openai/gpt-5.5", "none")).toBe(true);
       expect(isValidReasoningEffort("openai/gpt-5.2-codex", "none")).toBe(false);
     });
 
@@ -422,6 +442,7 @@ describe("model utilities", () => {
     it("passes through OpenAI models unchanged", () => {
       expect(normalizeModelId("openai/gpt-5.2")).toBe("openai/gpt-5.2");
       expect(normalizeModelId("openai/gpt-5.4")).toBe("openai/gpt-5.4");
+      expect(normalizeModelId("openai/gpt-5.5")).toBe("openai/gpt-5.5");
       expect(normalizeModelId("openai/gpt-5.2-codex")).toBe("openai/gpt-5.2-codex");
       expect(normalizeModelId("openai/gpt-5.3-codex")).toBe("openai/gpt-5.3-codex");
       expect(normalizeModelId("openai/gpt-5.3-codex-spark")).toBe("openai/gpt-5.3-codex-spark");
@@ -429,6 +450,7 @@ describe("model utilities", () => {
 
     it("adds openai/ prefix to bare GPT models", () => {
       expect(normalizeModelId("gpt-5.4")).toBe("openai/gpt-5.4");
+      expect(normalizeModelId("gpt-5.5")).toBe("openai/gpt-5.5");
       expect(normalizeModelId("gpt-5.2")).toBe("openai/gpt-5.2");
       expect(normalizeModelId("gpt-5.2-codex")).toBe("openai/gpt-5.2-codex");
     });

--- a/packages/linear-bot/src/__tests__/pure-functions.test.ts
+++ b/packages/linear-bot/src/__tests__/pure-functions.test.ts
@@ -22,6 +22,10 @@ describe("extractModelFromLabels", () => {
     expect(extractModelFromLabels([{ name: "model:gpt-5.4" }])).toBe("openai/gpt-5.4");
   });
 
+  it("returns GPT 5.5 for model:gpt-5.5 label", () => {
+    expect(extractModelFromLabels([{ name: "model:gpt-5.5" }])).toBe("openai/gpt-5.5");
+  });
+
   it("returns null for unknown model label", () => {
     expect(extractModelFromLabels([{ name: "model:unknown-model" }])).toBeNull();
   });

--- a/packages/linear-bot/src/model-resolution.ts
+++ b/packages/linear-bot/src/model-resolution.ts
@@ -35,6 +35,7 @@ const MODEL_LABEL_MAP: Record<string, string> = {
   "opus-4-6": "anthropic/claude-opus-4-6",
   "gpt-5.2": "openai/gpt-5.2",
   "gpt-5.4": "openai/gpt-5.4",
+  "gpt-5.5": "openai/gpt-5.5",
   "gpt-5.2-codex": "openai/gpt-5.2-codex",
   "gpt-5.3-codex": "openai/gpt-5.3-codex",
 };

--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -33,8 +33,8 @@ TTYD_VERSION = "1.7.7"
 TTYD_SHA256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55"
 
 # Cache buster - change this to force Modal image rebuild
-# v46: pre-build OpenCode plugin deps to avoid first-prompt reify
-CACHE_BUSTER = "v46-prebuilt-deps"
+# v47: refresh sandbox image to pull latest OpenCode release
+CACHE_BUSTER = "v47-opencode-refresh"
 
 # Base image with all development tools
 base_image = (

--- a/packages/sandbox-runtime/src/sandbox_runtime/plugins/codex-auth-plugin.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/plugins/codex-auth-plugin.js
@@ -19,6 +19,7 @@ const ALLOWED_MODELS = new Set([
   "gpt-5.1-codex-mini",
   "gpt-5.2",
   "gpt-5.4",
+  "gpt-5.5",
   "gpt-5.2-codex",
   "gpt-5.3-codex",
   "gpt-5.3-codex-spark",

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -17,6 +17,7 @@ export const VALID_MODELS = [
   "anthropic/claude-opus-4-6",
   "openai/gpt-5.2",
   "openai/gpt-5.4",
+  "openai/gpt-5.5",
   "openai/gpt-5.2-codex",
   "openai/gpt-5.3-codex",
   "openai/gpt-5.3-codex-spark",
@@ -58,6 +59,7 @@ export const MODEL_REASONING_CONFIG: Partial<Record<ValidModel, ModelReasoningCo
   "anthropic/claude-opus-4-6": { efforts: ["low", "medium", "high", "max"], default: "high" },
   "openai/gpt-5.2": { efforts: ["none", "low", "medium", "high", "xhigh"], default: undefined },
   "openai/gpt-5.4": { efforts: ["none", "low", "medium", "high", "xhigh"], default: undefined },
+  "openai/gpt-5.5": { efforts: ["none", "low", "medium", "high", "xhigh"], default: undefined },
   "openai/gpt-5.2-codex": { efforts: ["low", "medium", "high", "xhigh"], default: "high" },
   "openai/gpt-5.3-codex": { efforts: ["low", "medium", "high", "xhigh"], default: "high" },
   "openai/gpt-5.3-codex-spark": { efforts: ["low", "medium", "high", "xhigh"], default: "high" },
@@ -112,7 +114,8 @@ export const MODEL_OPTIONS: ModelCategory[] = [
     category: "OpenAI",
     models: [
       { id: "openai/gpt-5.2", name: "GPT 5.2", description: "400K context, fast" },
-      { id: "openai/gpt-5.4", name: "GPT 5.4", description: "Latest flagship model" },
+      { id: "openai/gpt-5.4", name: "GPT 5.4", description: "Flagship model" },
+      { id: "openai/gpt-5.5", name: "GPT 5.5", description: "Latest flagship model" },
       { id: "openai/gpt-5.2-codex", name: "GPT 5.2 Codex", description: "Optimized for code" },
       { id: "openai/gpt-5.3-codex", name: "GPT 5.3 Codex", description: "Latest codex" },
       {
@@ -144,6 +147,7 @@ export const DEFAULT_ENABLED_MODELS: ValidModel[] = [
   "anthropic/claude-opus-4-6",
   "openai/gpt-5.2",
   "openai/gpt-5.4",
+  "openai/gpt-5.5",
   "openai/gpt-5.2-codex",
   "openai/gpt-5.3-codex",
   "openai/gpt-5.3-codex-spark",


### PR DESCRIPTION
## Summary
- add `openai/gpt-5.5` to the shared model registry, default enabled model list, and reasoning validation so it shows up across the product
- allow `model:gpt-5.5` overrides in the Linear bot and permit the new OpenAI model through the sandbox Codex auth plugin
- bump the sandbox image cache buster so Modal rebuilds with the latest OpenCode release

## Testing
- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/control-plane -- src/utils/models.test.ts`
- `npm test -w @open-inspect/linear-bot -- src/__tests__/pure-functions.test.ts`
- `uv sync --extra dev && uv run pytest tests/test_codex_auth_plugin_setup.py`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/dc8e39c002f730cc010915c8c264c422)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPT 5.5 model support across the platform, now available in model selection and enabled by default.
  * GPT 5.5 includes configurable reasoning effort levels matching other GPT-5.x models.
  * Updated GPT 5.4 display label from "Latest flagship model" to "Flagship model".

* **Tests**
  * Extended test coverage for model validation, label resolution, and reasoning support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->