### PR TITLE
feat: wire user_id through session creation and child spawn

### DIFF
--- a/packages/control-plane/src/db/session-index.test.ts
+++ b/packages/control-plane/src/db/session-index.test.ts
@@ -17,6 +17,7 @@ type SessionRow = {
   automation_id: string | null;
   automation_run_id: string | null;
   scm_login: string | null;
+  user_id: string | null;
   total_cost: number;
   active_duration_ms: number;
   message_count: number;
@@ -134,6 +135,7 @@ class FakeD1Database {
         automationId,
         automationRunId,
         scmLogin,
+        userId,
         createdAt,
         updatedAt,
       ] = args as [
@@ -148,6 +150,7 @@ class FakeD1Database {
         string | null,
         "user" | "agent" | "automation",
         number,
+        string | null,
         string | null,
         string | null,
         string | null,
@@ -171,6 +174,7 @@ class FakeD1Database {
           automation_id: automationId,
           automation_run_id: automationRunId,
           scm_login: scmLogin,
+          user_id: userId,
           total_cost: 0,
           active_duration_ms: 0,
           message_count: 0,
@@ -353,6 +357,7 @@ describe("SessionIndexStore", () => {
         automationId: null,
         automationRunId: null,
         scmLogin: null,
+        userId: null,
         totalCost: 0,
         activeDurationMs: 0,
         messageCount: 0,
@@ -391,6 +396,22 @@ describe("SessionIndexStore", () => {
       expect(result?.parentSessionId).toBe("parent-1");
       expect(result?.spawnSource).toBe("agent");
       expect(result?.spawnDepth).toBe(1);
+    });
+
+    it("stores userId when provided", async () => {
+      const session = makeSession({ userId: "user-123" });
+      await store.create(session);
+
+      const result = await store.get("test-id");
+      expect(result?.userId).toBe("user-123");
+    });
+
+    it("defaults userId to null when omitted", async () => {
+      const session = makeSession();
+      await store.create(session);
+
+      const result = await store.get("test-id");
+      expect(result?.userId).toBeNull();
     });
   });
 

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -15,6 +15,7 @@ export interface SessionEntry {
   automationId?: string | null;
   automationRunId?: string | null;
   scmLogin?: string | null;
+  userId?: string | null;
   totalCost?: number;
   activeDurationMs?: number;
   messageCount?: number;
@@ -38,6 +39,7 @@ interface SessionRow {
   automation_id: string | null;
   automation_run_id: string | null;
   scm_login: string | null;
+  user_id: string | null;
   total_cost: number;
   active_duration_ms: number;
   message_count: number;
@@ -77,6 +79,7 @@ function toEntry(row: SessionRow): SessionEntry {
     automationId: row.automation_id,
     automationRunId: row.automation_run_id,
     scmLogin: row.scm_login,
+    userId: row.user_id,
     totalCost: row.total_cost,
     activeDurationMs: row.active_duration_ms,
     messageCount: row.message_count,
@@ -92,8 +95,8 @@ export class SessionIndexStore {
   async create(session: SessionEntry): Promise<void> {
     await this.db
       .prepare(
-        `INSERT OR IGNORE INTO sessions (id, title, repo_owner, repo_name, model, reasoning_effort, base_branch, status, parent_session_id, spawn_source, spawn_depth, automation_id, automation_run_id, scm_login, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        `INSERT OR IGNORE INTO sessions (id, title, repo_owner, repo_name, model, reasoning_effort, base_branch, status, parent_session_id, spawn_source, spawn_depth, automation_id, automation_run_id, scm_login, user_id, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .bind(
         session.id,
@@ -110,6 +113,7 @@ export class SessionIndexStore {
         session.automationId ?? null,
         session.automationRunId ?? null,
         session.scmLogin ?? null,
+        session.userId ?? null,
         session.createdAt,
         session.updatedAt
       )

--- a/packages/control-plane/src/router.spawn-child.test.ts
+++ b/packages/control-plane/src/router.spawn-child.test.ts
@@ -28,7 +28,8 @@ describe("handleSpawnChild prompt enqueue handling", () => {
     },
   };
 
-  const makeStore = () => ({
+  const makeStore = (parentUserId: string | null = null) => ({
+    get: vi.fn().mockResolvedValue({ userId: parentUserId }),
     getSpawnDepth: vi.fn().mockResolvedValue(0),
     countActiveChildren: vi.fn().mockResolvedValue(0),
     countTotalChildren: vi.fn().mockResolvedValue(0),
@@ -57,7 +58,7 @@ describe("handleSpawnChild prompt enqueue handling", () => {
   }
 
   it("returns 201 when child prompt enqueue succeeds", async () => {
-    const store = makeStore();
+    const store = makeStore("canonical-user-123");
     vi.mocked(SessionIndexStore).mockImplementation(() => store as never);
 
     const parentStub: DurableObjectStub = {
@@ -90,8 +91,9 @@ describe("handleSpawnChild prompt enqueue handling", () => {
     const payload = await response.json<{ sessionId: string; status: string }>();
     expect(payload.status).toBe("created");
 
-    const createdChildId = store.create.mock.calls[0]?.[0]?.id;
-    expect(createdChildId).toBe(payload.sessionId);
+    const childEntry = store.create.mock.calls[0]?.[0];
+    expect(childEntry?.id).toBe(payload.sessionId);
+    expect(childEntry?.userId).toBe("canonical-user-123");
     expect(store.updateStatus).not.toHaveBeenCalled();
   });
 

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -30,6 +30,7 @@ import {
 import { IntegrationSettingsStore } from "./db/integration-settings";
 import { SessionIndexStore } from "./db/session-index";
 import { UserScmTokenStore, DEFAULT_TOKEN_LIFETIME_MS } from "./db/user-scm-tokens";
+import { UserStore, type ProviderIdentity } from "./db/user-store";
 import { buildSessionInternalUrl, SessionInternalPaths } from "./session/contracts";
 
 import {
@@ -705,6 +706,64 @@ async function handleListSessions(
   });
 }
 
+/**
+ * Derives a ProviderIdentity from spawnSource and the request body.
+ * For GitHub-based callers (web + github-bot), reuses existing scm* fields.
+ * For Slack/Linear bots, uses the actor* fields.
+ * Returns null when no identity can be resolved (e.g. missing userId).
+ */
+function resolveProviderIdentity(
+  spawnSource: SpawnSource,
+  body: {
+    scmUserId?: string;
+    scmLogin?: string;
+    scmName?: string;
+    scmEmail?: string;
+    actorUserId?: string;
+    actorDisplayName?: string;
+    actorEmail?: string;
+    actorAvatarUrl?: string;
+  }
+): ProviderIdentity | null {
+  switch (spawnSource) {
+    case "user":
+    case "github-bot":
+      return body.scmUserId
+        ? {
+            provider: "github",
+            providerUserId: body.scmUserId,
+            providerLogin: body.scmLogin,
+            providerEmail: body.scmEmail,
+            displayName: body.scmName || body.scmLogin,
+          }
+        : null;
+
+    case "slack-bot":
+      return body.actorUserId
+        ? {
+            provider: "slack",
+            providerUserId: body.actorUserId,
+            providerEmail: body.actorEmail,
+            displayName: body.actorDisplayName,
+            avatarUrl: body.actorAvatarUrl,
+          }
+        : null;
+
+    case "linear-bot":
+      return body.actorUserId
+        ? {
+            provider: "linear",
+            providerUserId: body.actorUserId,
+            providerEmail: body.actorEmail,
+            displayName: body.actorDisplayName,
+          }
+        : null;
+
+    default:
+      return null;
+  }
+}
+
 async function handleCreateSession(
   request: Request,
   env: Env,
@@ -721,6 +780,10 @@ async function handleCreateSession(
     scmName?: string;
     scmEmail?: string;
     spawnSource?: SpawnSource;
+    actorUserId?: string;
+    actorDisplayName?: string;
+    actorEmail?: string;
+    actorAvatarUrl?: string;
   };
 
   if (!body.repoOwner || !body.repoName) {
@@ -742,6 +805,24 @@ async function handleCreateSession(
   const { repoId, defaultBranch } = resolved;
 
   const userId = body.userId || "anonymous";
+
+  // Resolve canonical user model ID (for D1 session index).
+  // Best-effort: if resolution fails, the session is created without a user_id.
+  let resolvedUserId: string | null = null;
+  const providerIdentity = resolveProviderIdentity(body.spawnSource ?? "user", body);
+  if (providerIdentity) {
+    try {
+      const userStore = new UserStore(env.DB);
+      const resolvedUser = await userStore.resolveOrCreateUser(providerIdentity);
+      resolvedUserId = resolvedUser.id;
+    } catch (e) {
+      logger.warn("Failed to resolve user identity, session will have no user_id", {
+        error: e instanceof Error ? e : String(e),
+        provider: providerIdentity.provider,
+      });
+    }
+  }
+
   const scmLogin = body.scmLogin;
   const scmName = body.scmName;
   const scmEmail = body.scmEmail;
@@ -864,6 +945,7 @@ async function handleCreateSession(
     status: "created",
     spawnSource: body.spawnSource,
     scmLogin: scmLogin || null,
+    userId: resolvedUserId,
     createdAt: now,
     updatedAt: now,
   });
@@ -1753,6 +1835,10 @@ async function handleSpawnChild(
     return error(`Maximum total children (${MAX_TOTAL_CHILDREN}) reached`, 429);
   }
 
+  // Read parent's canonical user_id from D1 for inheritance
+  const parentSession = await sessionStore.get(parentId);
+  const parentUserId = parentSession?.userId ?? null;
+
   // Get parent context from parent DO
   const parentDoId = env.SESSION.idFromName(parentId);
   const parentStub = env.SESSION.get(parentDoId);
@@ -1862,6 +1948,7 @@ async function handleSpawnChild(
     spawnSource: "agent",
     spawnDepth: childDepth,
     scmLogin: spawnContext.owner.scmLogin || null,
+    userId: parentUserId,
     createdAt: now,
     updatedAt: now,
   });

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -710,7 +710,11 @@ async function handleListSessions(
  * Derives a ProviderIdentity from spawnSource and the request body.
  * For GitHub-based callers (web + github-bot), reuses existing scm* fields.
  * For Slack/Linear bots, uses the actor* fields.
- * Returns null when no identity can be resolved (e.g. missing userId).
+ *
+ * Returns null when the caller hasn't supplied the required provider-specific
+ * ID (scmUserId for GitHub, actorUserId for Slack/Linear). This is expected
+ * during the phased rollout: Phase 2 wires this plumbing, Phase 4 updates
+ * each bot to send identity fields. Until then, bot sessions get user_id = NULL.
  */
 function resolveProviderIdentity(
   spawnSource: SpawnSource,

--- a/packages/control-plane/test/integration/d1-session-index.test.ts
+++ b/packages/control-plane/test/integration/d1-session-index.test.ts
@@ -442,4 +442,51 @@ describe("D1 SessionIndexStore", () => {
       expect(child!.spawnDepth).toBe(1);
     });
   });
+
+  describe("userId", () => {
+    it("stores and retrieves userId", async () => {
+      const store = new SessionIndexStore(env.DB);
+      const now = Date.now();
+
+      await store.create({
+        id: "session-with-user",
+        title: "User-linked session",
+        repoOwner: "acme",
+        repoName: "web-app",
+        model: "anthropic/claude-haiku-4-5",
+        reasoningEffort: null,
+        baseBranch: null,
+        status: "created",
+        userId: "canonical-user-id",
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const session = await store.get("session-with-user");
+      expect(session).not.toBeNull();
+      expect(session!.userId).toBe("canonical-user-id");
+    });
+
+    it("defaults userId to null when omitted", async () => {
+      const store = new SessionIndexStore(env.DB);
+      const now = Date.now();
+
+      await store.create({
+        id: "session-no-user",
+        title: "No user",
+        repoOwner: "acme",
+        repoName: "web-app",
+        model: "anthropic/claude-haiku-4-5",
+        reasoningEffort: null,
+        baseBranch: null,
+        status: "created",
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const session = await store.get("session-no-user");
+      expect(session).not.toBeNull();
+      expect(session!.userId).toBeNull();
+    });
+  });
 });

--- a/packages/control-plane/test/integration/spawn-children.test.ts
+++ b/packages/control-plane/test/integration/spawn-children.test.ts
@@ -11,6 +11,7 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
   async function setupParent(opts?: {
     repoId?: number;
     userId?: string;
+    canonicalUserId?: string;
     scmLogin?: string;
     spawnDepth?: number;
     parentSessionId?: string;
@@ -42,6 +43,7 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
       parentSessionId: opts?.parentSessionId ?? null,
       spawnSource: opts?.spawnSource ?? "user",
       spawnDepth: opts?.spawnDepth ?? 0,
+      userId: opts?.canonicalUserId ?? null,
       createdAt: now,
       updatedAt: now,
     });
@@ -53,6 +55,7 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
     const { parentName, sandboxToken, store } = await setupParent({
       repoId: 12345,
       userId: "user-1",
+      canonicalUserId: "canonical-abc123",
       scmLogin: "acmedev",
     });
 
@@ -81,6 +84,7 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
     expect(child!.spawnDepth).toBe(1);
     expect(child!.repoOwner).toBe("acme");
     expect(child!.repoName).toBe("web-app");
+    expect(child!.userId).toBe("canonical-abc123");
 
     // Verify the child DO was initialized by querying its /internal/state
     const childDoId = env.SESSION.idFromName(body.sessionId);

--- a/packages/control-plane/test/integration/spawn-children.test.ts
+++ b/packages/control-plane/test/integration/spawn-children.test.ts
@@ -97,6 +97,33 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
     expect(state.status).toBe("active");
   });
 
+  it("propagates null userId from parent to child", async () => {
+    const { parentName, sandboxToken, store } = await setupParent({
+      repoId: 12345,
+      userId: "user-1",
+      scmLogin: "acmedev",
+      // canonicalUserId intentionally omitted → null
+    });
+
+    const res = await SELF.fetch(`https://test.local/sessions/${parentName}/children`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${sandboxToken}`,
+      },
+      body: JSON.stringify({
+        title: "Child without user",
+        prompt: "Parent has no canonical userId",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json<{ sessionId: string }>();
+    const child = await store.get(body.sessionId);
+    expect(child).not.toBeNull();
+    expect(child!.userId).toBeNull();
+  });
+
   it("rejects when depth >= 2 (403)", async () => {
     const { parentName, sandboxToken } = await setupParent({
       spawnDepth: 2,


### PR DESCRIPTION
## Summary

Phase 2 of the unified user model migration (#523). Wires the control plane so that session creation resolves a canonical `user_id` and writes it to D1.

- **SessionIndexStore**: adds `userId` to `SessionEntry`, `SessionRow`, `toEntry()`, and `create()` SQL
- **`handleCreateSession`**: new `resolveProviderIdentity(spawnSource, body)` helper derives a `ProviderIdentity` from `spawnSource` — reuses existing `scm*` fields for web/GitHub callers, uses `actor*` fields for Slack/Linear. Calls `UserStore.resolveOrCreateUser()` (best-effort, try/catch) and passes the canonical `userId` to `sessionStore.create()`
- **`handleSpawnChild`**: reads parent's `user_id` from D1 via `sessionStore.get(parentId)` and passes it to the child session

### Design decisions

- **`spawnSource` as provider discriminator** — no redundant `actorProvider` field. `spawnSource` already distinguishes `"user"`, `"github-bot"`, `"slack-bot"`, `"linear-bot"`
- **Reuse `scm*` fields for GitHub** — web and GitHub bot callers need zero new body fields
- **Best-effort resolution** — `resolveOrCreateUser` failure logs a warning and falls back to `user_id = NULL` (session creation is not blocked)
- **D1 read for child inheritance** — `spawnContext.owner.userId` is the provider-specific ID, not the canonical one. The canonical `user_id` lives only in D1's `sessions.user_id` column

### What does NOT change

- DO init body — `userId` in the DO remains the provider-specific value
- No new D1 migration — `sessions.user_id` column already exists from migration 0019
- Scheduler's `sessionStore.create()` — Phase 5 scope

## Test plan

- [x] `SessionIndexStore` unit tests: stores userId when provided, defaults to null when omitted (2 new tests)
- [x] `SessionIndexStore` integration tests: round-trip userId through real D1 (2 new tests)
- [x] `handleSpawnChild` unit test: asserts child inherits `userId` from parent
- [x] `handleSpawnChild` integration test: end-to-end spawn with `canonicalUserId` assertion
- [x] Typecheck clean
- [x] Lint clean
- [x] All 322 integration tests pass
- [x] All 988 unit tests pass (6 pre-existing failures in `models.test.ts` unrelated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions now record a canonical user identity at creation.
  * Spawned child sessions inherit the parent session’s user identity.

* **Tests**
  * Added unit and integration tests ensuring the user identity is stored and retrieved.
  * Tests verify identity propagation to child sessions and that the value defaults to null when absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->