### PR TITLE
feat: add user_id-based analytics with LEFT JOIN users

### DIFF
--- a/packages/control-plane/src/db/analytics-store.ts
+++ b/packages/control-plane/src/db/analytics-store.ts
@@ -37,6 +37,7 @@ interface TimeseriesRow {
 
 interface BreakdownRow {
   key: string;
+  display_name?: string;
   sessions: number;
   completed: number;
   failed: number;
@@ -59,7 +60,7 @@ export class AnalyticsStore {
       .prepare(
         `SELECT
            COUNT(*) AS total_sessions,
-           COUNT(DISTINCT CASE WHEN scm_login IS NOT NULL AND scm_login != '' THEN scm_login END) AS active_users,
+           COUNT(DISTINCT COALESCE(user_id, NULLIF(scm_login, ''))) AS active_users,
            COALESCE(SUM(total_cost), 0) AS total_cost,
            COALESCE(SUM(pr_count), 0) AS total_prs,
            COALESCE(SUM(CASE WHEN status = 'created' THEN 1 ELSE 0 END), 0) AS created_count,
@@ -102,13 +103,14 @@ export class AnalyticsStore {
     const result = await this.db
       .prepare(
         `SELECT
-           date(created_at / 1000, 'unixepoch') AS date,
-           COALESCE(NULLIF(scm_login, ''), 'unknown') AS group_key,
+           date(s.created_at / 1000, 'unixepoch') AS date,
+           COALESCE(u.display_name, NULLIF(s.scm_login, ''), 'unknown') AS group_key,
            COUNT(*) AS count
-         FROM sessions
-         WHERE created_at >= ? AND created_at < ?
-           AND spawn_source IN (${placeholders})
-         GROUP BY date, group_key
+         FROM sessions s
+         LEFT JOIN users u ON s.user_id = u.id
+         WHERE s.created_at >= ? AND s.created_at < ?
+           AND s.spawn_source IN (${placeholders})
+         GROUP BY date, COALESCE(s.user_id, '__unlinked__' || COALESCE(s.scm_login, '__none__'))
          ORDER BY date ASC, group_key ASC`
       )
       .bind(filters.startAt, filters.endAt, ...sources)
@@ -135,10 +137,19 @@ export class AnalyticsStore {
     filters: AnalyticsFilters,
     by: AnalyticsBreakdownBy
   ): Promise<AnalyticsBreakdownResponse> {
-    const groupExpression =
-      by === "user"
-        ? "COALESCE(NULLIF(scm_login, ''), 'unknown')"
-        : "repo_owner || '/' || repo_name";
+    const isUserBreakdown = by === "user";
+
+    const groupExpression = isUserBreakdown
+      ? "COALESCE(s.user_id, NULLIF(s.scm_login, ''), '__unknown__')"
+      : "s.repo_owner || '/' || s.repo_name";
+
+    const displayNameSelect = isUserBreakdown
+      ? "COALESCE(u.display_name, NULLIF(s.scm_login, ''), 'Unknown user') AS display_name,"
+      : "";
+
+    const joinClause = isUserBreakdown ? "LEFT JOIN users u ON s.user_id = u.id" : "";
+
+    const orderTail = isUserBreakdown ? "display_name ASC" : "key ASC";
 
     const sources = filters.spawnSources ?? HUMAN_SPAWN_SOURCES;
     const placeholders = sources.map(() => "?").join(", ");
@@ -147,6 +158,7 @@ export class AnalyticsStore {
       .prepare(
         `SELECT
            ${groupExpression} AS key,
+           ${displayNameSelect}
            COUNT(*) AS sessions,
            COALESCE(SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END), 0) AS completed,
            COALESCE(SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END), 0) AS failed,
@@ -158,18 +170,20 @@ export class AnalyticsStore {
              AVG(CASE WHEN status IN ('completed', 'failed', 'cancelled') THEN active_duration_ms END),
              0
            ) AS avg_duration,
-           MAX(updated_at) AS last_active
-         FROM sessions
-         WHERE created_at >= ? AND created_at < ?
-           AND spawn_source IN (${placeholders})
+           MAX(s.updated_at) AS last_active
+         FROM sessions s
+         ${joinClause}
+         WHERE s.created_at >= ? AND s.created_at < ?
+           AND s.spawn_source IN (${placeholders})
          GROUP BY key
-         ORDER BY sessions DESC, key ASC`
+         ORDER BY sessions DESC, ${orderTail}`
       )
       .bind(filters.startAt, filters.endAt, ...sources)
       .all<BreakdownRow>();
 
     const entries: AnalyticsBreakdownEntry[] = (result.results ?? []).map((row) => ({
       key: row.key,
+      ...(row.display_name != null && { displayName: row.display_name }),
       sessions: row.sessions,
       completed: row.completed,
       failed: row.failed,

--- a/packages/control-plane/src/db/analytics-store.ts
+++ b/packages/control-plane/src/db/analytics-store.ts
@@ -120,7 +120,7 @@ export class AnalyticsStore {
     for (const row of result.results ?? []) {
       const lastPoint = series[series.length - 1];
       if (lastPoint?.date === row.date) {
-        lastPoint.groups[row.group_key] = row.count;
+        lastPoint.groups[row.group_key] = (lastPoint.groups[row.group_key] ?? 0) + row.count;
         continue;
       }
 
@@ -140,7 +140,7 @@ export class AnalyticsStore {
     const isUserBreakdown = by === "user";
 
     const groupExpression = isUserBreakdown
-      ? "COALESCE(s.user_id, NULLIF(s.scm_login, ''), '__unknown__')"
+      ? "COALESCE(s.user_id, NULLIF(s.scm_login, ''), 'unknown')"
       : "s.repo_owner || '/' || s.repo_name";
 
     const displayNameSelect = isUserBreakdown

--- a/packages/control-plane/src/db/analytics-store.ts
+++ b/packages/control-plane/src/db/analytics-store.ts
@@ -60,6 +60,10 @@ export class AnalyticsStore {
       .prepare(
         `SELECT
            COUNT(*) AS total_sessions,
+           -- Uses user_id when available, falls back to scm_login for unlinked sessions.
+           -- During the Phase 4→6 rollout window, the same person may appear under both
+           -- keys (scm_login on old sessions, user_id on new), temporarily inflating this
+           -- count. Resolves once the Phase 6 backfill populates user_id on historical rows.
            COUNT(DISTINCT COALESCE(user_id, NULLIF(scm_login, ''))) AS active_users,
            COALESCE(SUM(total_cost), 0) AS total_cost,
            COALESCE(SUM(pr_count), 0) AS total_prs,
@@ -104,7 +108,7 @@ export class AnalyticsStore {
       .prepare(
         `SELECT
            date(s.created_at / 1000, 'unixepoch') AS date,
-           COALESCE(u.display_name, NULLIF(s.scm_login, ''), 'unknown') AS group_key,
+           COALESCE(MAX(NULLIF(u.display_name, '')), MAX(NULLIF(s.scm_login, '')), 'unknown') AS group_key,
            COUNT(*) AS count
          FROM sessions s
          LEFT JOIN users u ON s.user_id = u.id
@@ -144,7 +148,7 @@ export class AnalyticsStore {
       : "s.repo_owner || '/' || s.repo_name";
 
     const displayNameSelect = isUserBreakdown
-      ? "COALESCE(u.display_name, NULLIF(s.scm_login, ''), 'Unknown user') AS display_name,"
+      ? "COALESCE(MAX(NULLIF(u.display_name, '')), MAX(NULLIF(s.scm_login, '')), 'Unknown user') AS display_name,"
       : "";
 
     const joinClause = isUserBreakdown ? "LEFT JOIN users u ON s.user_id = u.id" : "";

--- a/packages/control-plane/test/integration/analytics.test.ts
+++ b/packages/control-plane/test/integration/analytics.test.ts
@@ -26,6 +26,7 @@ async function seedSession(
     repoOwner: string;
     repoName: string;
     scmLogin: string | null;
+    userId?: string | null;
     spawnSource?: SpawnSource;
     status: "created" | "active" | "completed" | "failed" | "archived" | "cancelled";
     createdAt: number;
@@ -47,6 +48,7 @@ async function seedSession(
     status: input.status,
     spawnSource: input.spawnSource,
     scmLogin: input.scmLogin,
+    userId: input.userId,
     createdAt: input.createdAt,
     updatedAt: input.updatedAt,
   });
@@ -57,6 +59,19 @@ async function seedSession(
     messageCount: input.messageCount,
     prCount: input.prCount,
   });
+}
+
+async function seedUser(
+  db: D1Database,
+  user: { id: string; displayName: string; email?: string }
+): Promise<void> {
+  const now = Date.now();
+  await db
+    .prepare(
+      "INSERT INTO users (id, display_name, email, avatar_url, created_at, updated_at) VALUES (?, ?, ?, NULL, ?, ?)"
+    )
+    .bind(user.id, user.displayName, user.email ?? null, now, now)
+    .run();
 }
 
 describe("Analytics API", () => {
@@ -341,6 +356,7 @@ describe("Analytics API", () => {
     expect(body.entries).toEqual([
       {
         key: "alice",
+        displayName: "alice",
         sessions: 2,
         completed: 1,
         failed: 0,
@@ -352,19 +368,8 @@ describe("Analytics API", () => {
         lastActive: aliceCreatedAt + 2_000,
       },
       {
-        key: "bob",
-        sessions: 1,
-        completed: 0,
-        failed: 1,
-        cancelled: 0,
-        cost: 0.75,
-        prs: 0,
-        messageCount: 2,
-        avgDuration: 50_000,
-        lastActive: bobFailedAt + 3_000,
-      },
-      {
-        key: "unknown",
+        key: "__unknown__",
+        displayName: "Unknown user",
         sessions: 1,
         completed: 0,
         failed: 0,
@@ -374,6 +379,19 @@ describe("Analytics API", () => {
         messageCount: 0,
         avgDuration: 0,
         lastActive: unknownActiveAt + 4_000,
+      },
+      {
+        key: "bob",
+        displayName: "bob",
+        sessions: 1,
+        completed: 0,
+        failed: 1,
+        cancelled: 0,
+        cost: 0.75,
+        prs: 0,
+        messageCount: 2,
+        avgDuration: 50_000,
+        lastActive: bobFailedAt + 3_000,
       },
     ]);
   });
@@ -603,9 +621,125 @@ describe("Analytics API", () => {
     const keys = breakdown.entries.map((e) => e.key);
     expect(keys).toContain("alice");
     expect(keys).toContain("bob");
-    expect(keys).toContain("unknown"); // slack + linear sessions with no scm_login
+    expect(keys).toContain("__unknown__"); // slack + linear sessions with no scm_login
 
     const totalBreakdownSessions = breakdown.entries.reduce((n, e) => n + e.sessions, 0);
     expect(totalBreakdownSessions).toBe(4);
+  });
+
+  it("groups sessions by user_id and shows display name from users table", async () => {
+    const store = new SessionIndexStore(env.DB);
+    const now = Date.now();
+
+    // Seed a user in the users table
+    await seedUser(env.DB, {
+      id: "user-abc",
+      displayName: "Alice Smith",
+      email: "alice@acme.test",
+    });
+
+    // Two sessions with the same user_id but different scm_logins → should merge
+    await seedSession(store, {
+      id: "alice-web",
+      repoOwner: "acme",
+      repoName: "app",
+      scmLogin: "alice",
+      userId: "user-abc",
+      status: "completed",
+      createdAt: now - 2 * 24 * 60 * 60 * 1000,
+      updatedAt: now - 2 * 24 * 60 * 60 * 1000 + 1_000,
+      totalCost: 1,
+      activeDurationMs: 100_000,
+      messageCount: 5,
+      prCount: 1,
+    });
+    await seedSession(store, {
+      id: "alice-github",
+      repoOwner: "acme",
+      repoName: "app",
+      scmLogin: "alice-gh",
+      userId: "user-abc",
+      status: "completed",
+      createdAt: now - 24 * 60 * 60 * 1000,
+      updatedAt: now - 24 * 60 * 60 * 1000 + 2_000,
+      totalCost: 0.5,
+      activeDurationMs: 50_000,
+      messageCount: 3,
+      prCount: 0,
+    });
+
+    // Session without user_id falls back to scm_login key
+    await seedSession(store, {
+      id: "bob-unlinked",
+      repoOwner: "acme",
+      repoName: "app",
+      scmLogin: "bob",
+      status: "failed",
+      createdAt: now - 3 * 24 * 60 * 60 * 1000,
+      updatedAt: now - 3 * 24 * 60 * 60 * 1000 + 3_000,
+      totalCost: 0.25,
+      activeDurationMs: 30_000,
+      messageCount: 2,
+      prCount: 0,
+    });
+
+    // Breakdown: user_id sessions merge under canonical ID with display name
+    const breakdownRes = await SELF.fetch(
+      "https://test.local/analytics/breakdown?days=30&by=user",
+      { headers: await authHeaders() }
+    );
+    expect(breakdownRes.status).toBe(200);
+    const breakdown = await breakdownRes.json<AnalyticsBreakdownResponse>();
+
+    expect(breakdown.entries).toEqual([
+      {
+        key: "user-abc",
+        displayName: "Alice Smith",
+        sessions: 2,
+        completed: 2,
+        failed: 0,
+        cancelled: 0,
+        cost: 1.5,
+        prs: 1,
+        messageCount: 8,
+        avgDuration: 75_000,
+        lastActive: now - 24 * 60 * 60 * 1000 + 2_000,
+      },
+      {
+        key: "bob",
+        displayName: "bob",
+        sessions: 1,
+        completed: 0,
+        failed: 1,
+        cancelled: 0,
+        cost: 0.25,
+        prs: 0,
+        messageCount: 2,
+        avgDuration: 30_000,
+        lastActive: now - 3 * 24 * 60 * 60 * 1000 + 3_000,
+      },
+    ]);
+
+    // Summary: activeUsers counts distinct user_id (alice's 2 sessions = 1 user)
+    const summaryRes = await SELF.fetch("https://test.local/analytics/summary?days=30", {
+      headers: await authHeaders(),
+    });
+    expect(summaryRes.status).toBe(200);
+    const summary = await summaryRes.json<AnalyticsSummaryResponse>();
+    expect(summary.activeUsers).toBe(2); // user-abc + bob
+
+    // Timeseries: uses display name from users table
+    const timeseriesRes = await SELF.fetch("https://test.local/analytics/timeseries?days=30", {
+      headers: await authHeaders(),
+    });
+    expect(timeseriesRes.status).toBe(200);
+    const timeseries = await timeseriesRes.json<AnalyticsTimeseriesResponse>();
+
+    // All Alice's sessions should appear under "Alice Smith", not "alice"/"alice-gh"
+    const allGroups = timeseries.series.flatMap((s) => Object.keys(s.groups));
+    expect(allGroups).toContain("Alice Smith");
+    expect(allGroups).not.toContain("alice");
+    expect(allGroups).not.toContain("alice-gh");
+    expect(allGroups).toContain("bob");
   });
 });

--- a/packages/control-plane/test/integration/analytics.test.ts
+++ b/packages/control-plane/test/integration/analytics.test.ts
@@ -368,7 +368,7 @@ describe("Analytics API", () => {
         lastActive: aliceCreatedAt + 2_000,
       },
       {
-        key: "__unknown__",
+        key: "unknown",
         displayName: "Unknown user",
         sessions: 1,
         completed: 0,
@@ -621,7 +621,7 @@ describe("Analytics API", () => {
     const keys = breakdown.entries.map((e) => e.key);
     expect(keys).toContain("alice");
     expect(keys).toContain("bob");
-    expect(keys).toContain("__unknown__"); // slack + linear sessions with no scm_login
+    expect(keys).toContain("unknown"); // slack + linear sessions with no scm_login
 
     const totalBreakdownSessions = breakdown.entries.reduce((n, e) => n + e.sessions, 0);
     expect(totalBreakdownSessions).toBe(4);
@@ -741,5 +741,57 @@ describe("Analytics API", () => {
     expect(allGroups).not.toContain("alice");
     expect(allGroups).not.toContain("alice-gh");
     expect(allGroups).toContain("bob");
+  });
+
+  it("sums timeseries counts when distinct users share the same display name", async () => {
+    const store = new SessionIndexStore(env.DB);
+    const now = Date.now();
+    const dayAgo = now - 24 * 60 * 60 * 1000;
+
+    // Two distinct users with the same display name
+    await seedUser(env.DB, { id: "user-alex-1", displayName: "Alex" });
+    await seedUser(env.DB, { id: "user-alex-2", displayName: "Alex" });
+
+    await seedSession(store, {
+      id: "alex1-session",
+      repoOwner: "acme",
+      repoName: "app",
+      scmLogin: "alex-one",
+      userId: "user-alex-1",
+      status: "completed",
+      createdAt: dayAgo,
+      updatedAt: dayAgo + 1_000,
+      totalCost: 1,
+      activeDurationMs: 100_000,
+      messageCount: 5,
+      prCount: 1,
+    });
+    await seedSession(store, {
+      id: "alex2-session",
+      repoOwner: "acme",
+      repoName: "app",
+      scmLogin: "alex-two",
+      userId: "user-alex-2",
+      status: "completed",
+      createdAt: dayAgo + 60_000,
+      updatedAt: dayAgo + 61_000,
+      totalCost: 0.5,
+      activeDurationMs: 50_000,
+      messageCount: 3,
+      prCount: 0,
+    });
+
+    const res = await SELF.fetch("https://test.local/analytics/timeseries?days=7", {
+      headers: await authHeaders(),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json<AnalyticsTimeseriesResponse>();
+
+    // Both sessions land on the same date with the same "Alex" label
+    const dayBucket = dateBucket(dayAgo);
+    const dayEntry = body.series.find((s) => s.date === dayBucket);
+    expect(dayEntry).toBeDefined();
+    // Reducer must sum, not overwrite: 1 + 1 = 2
+    expect(dayEntry!.groups["Alex"]).toBe(2);
   });
 });

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -631,6 +631,7 @@ export interface AnalyticsTimeseriesResponse {
 
 export interface AnalyticsBreakdownEntry {
   key: string;
+  displayName?: string;
   sessions: number;
   completed: number;
   failed: number;


### PR DESCRIPTION
## Summary

Phase 3 of the unified user model migration ([ColeMurray/background-agents#523](https://github.com/ColeMurray/background-agents/issues/523)). Rewrites analytics queries to use the canonical `user_id` for user attribution via `LEFT JOIN users`, replacing the previous `scm_login`-only approach.

- **`getSummary`**: `active_users` uses `COALESCE(user_id, scm_login)` — prefers canonical identity, falls back to SCM login for unlinked sessions
- **`getTimeseries`**: `LEFT JOIN users` for display name labels; groups by `user_id` when available (merging sessions across different `scm_login` values for the same user)
- **`getBreakdown` (by user)**: `LEFT JOIN users`, returns `displayName` from users table; key is `user_id` (stable canonical ID) with `scm_login` fallback
- **`getBreakdown` (by repo)**: Unchanged — no JOIN needed
- **Shared type**: Adds optional `displayName` to `AnalyticsBreakdownEntry`

### Backward compatibility

All queries are backward-compatible for sessions without `user_id` (all current sessions, until Phase 4 wires identity forwarding from each bot):

- Summary `activeUsers`: `COALESCE(user_id, scm_login)` → falls back to `scm_login` → identical count
- Timeseries group labels: `COALESCE(display_name, scm_login, 'unknown')` → same labels as today
- Breakdown keys: `COALESCE(user_id, scm_login, '__unknown__')` → same keys as today for linked sessions; `'unknown'` → `'__unknown__'` for the sentinel (frontend will be updated in Phase 6, PR 13)

### Depends on

- Phase 1: ColeMurray/background-agents#538 (merged) — D1 schema with `users` table
- Phase 2: ColeMurray/background-agents#550 (merged) — `user_id` column in `SessionIndexStore`

## Test plan

- [x] Integration tests: all 6 analytics tests pass (324 total integration tests)
- [x] New test: seeds `users` table + sessions with `user_id`, verifies merged breakdown entry with `displayName` from users table, correct `activeUsers` count, and timeseries group labels
- [x] Existing tests updated for `__unknown__` sentinel and `displayName` in breakdown responses
- [x] Unit tests: 994 pass
- [x] Typecheck: clean across control-plane and web packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Breakdown entries can include optional human-readable user display names.

* **Bug Fixes**
  * Active user counts and timeseries now consolidate by canonical user identity rather than raw SCM logins, producing more accurate counts and aggregated series.
  * Timeseries aggregation now sums multiple rows for the same date/label instead of overwriting.

* **Tests**
  * Added integration tests for identity consolidation, display-name labeling, and correct timeseries aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->