### PR TITLE
feat: forward identity fields from all bots to control plane

### DIFF
--- a/packages/github-bot/src/handlers.ts
+++ b/packages/github-bot/src/handlers.ts
@@ -32,6 +32,7 @@ async function createSession(
     model: string;
     reasoningEffort?: string | null;
     scmLogin: string;
+    scmUserId: string;
   }
 ): Promise<string> {
   const body: Record<string, unknown> = {
@@ -40,6 +41,7 @@ async function createSession(
     title: params.title,
     model: params.model,
     scmLogin: params.scmLogin,
+    scmUserId: params.scmUserId,
     spawnSource: "github-bot",
   };
   if (params.reasoningEffort) {
@@ -208,6 +210,7 @@ export async function handleReviewRequested(
     model: config.model,
     reasoningEffort: config.reasoningEffort,
     scmLogin: sender.login,
+    scmUserId: String(sender.id),
   });
   log.info("session.created", { ...meta, session_id: sessionId, action: "review" });
 
@@ -305,6 +308,7 @@ export async function handlePullRequestOpened(
     model: config.model,
     reasoningEffort: config.reasoningEffort,
     scmLogin: sender.login,
+    scmUserId: String(sender.id),
   });
   log.info("session.created", { ...meta, session_id: sessionId, action: "auto_review" });
 
@@ -408,6 +412,7 @@ export async function handleIssueComment(
     model: config.model,
     reasoningEffort: config.reasoningEffort,
     scmLogin: sender.login,
+    scmUserId: String(sender.id),
   });
   log.info("session.created", { ...meta, session_id: sessionId, action: "comment" });
 
@@ -504,6 +509,7 @@ export async function handleReviewComment(
     model: config.model,
     reasoningEffort: config.reasoningEffort,
     scmLogin: sender.login,
+    scmUserId: String(sender.id),
   });
   log.info("session.created", { ...meta, session_id: sessionId, action: "review_comment" });
 

--- a/packages/github-bot/test/handlers.test.ts
+++ b/packages/github-bot/test/handlers.test.ts
@@ -199,6 +199,7 @@ describe("handlePullRequestOpened", () => {
     expect(sessionBody.repoName).toBe("widgets");
     expect(sessionBody.title).toContain("Review PR #42");
     expect(sessionBody.scmLogin).toBe("alice");
+    expect(sessionBody.scmUserId).toBe("1001");
     expect(sessionBody.spawnSource).toBe("github-bot");
 
     const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
@@ -367,6 +368,7 @@ describe("handleReviewRequested", () => {
     expect(sessionBody.repoName).toBe("widgets");
     expect(sessionBody.title).toContain("Review PR #42");
     expect(sessionBody.scmLogin).toBe("alice");
+    expect(sessionBody.scmUserId).toBe("1001");
     expect(sessionBody.spawnSource).toBe("github-bot");
 
     // Verify prompt sending
@@ -461,6 +463,7 @@ describe("handleIssueComment", () => {
 
     const sessionBody = JSON.parse(cpFetch.mock.calls[0][1].body);
     expect(sessionBody.scmLogin).toBe("bob");
+    expect(sessionBody.scmUserId).toBe("1002");
     expect(sessionBody.spawnSource).toBe("github-bot");
 
     const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
@@ -552,6 +555,7 @@ describe("handleReviewComment", () => {
 
     const sessionBody = JSON.parse(cpFetch.mock.calls[0][1].body);
     expect(sessionBody.scmLogin).toBe("carol");
+    expect(sessionBody.scmUserId).toBe("1003");
     expect(sessionBody.spawnSource).toBe("github-bot");
 
     const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);

--- a/packages/linear-bot/src/webhook-handler.ts
+++ b/packages/linear-bot/src/webhook-handler.ts
@@ -487,10 +487,12 @@ async function handleNewSession(
     return;
   }
 
-  // ─── Resolve model ────────────────────────────────────────────────────
+  // ─── Resolve user preferences and identity ────────────────────────────
 
   let userModel: string | undefined;
   let userReasoningEffort: string | undefined;
+  let actorDisplayName: string | undefined;
+  let actorEmail: string | undefined;
   const appUserId = webhook.appUserId;
   if (appUserId) {
     const prefs = await getUserPreferences(env, appUserId);
@@ -498,6 +500,10 @@ async function handleNewSession(
       userModel = prefs.model;
     }
     userReasoningEffort = prefs?.reasoningEffort;
+
+    const linearUser = await fetchUser(client, appUserId);
+    actorDisplayName = linearUser?.name;
+    actorEmail = linearUser?.email ?? undefined;
   }
 
   const labelModel = extractModelFromLabels(labels);
@@ -511,16 +517,6 @@ async function handleNewSession(
     userReasoningEffort,
     labelModel,
   });
-
-  // ─── Resolve user identity ─────────────────────────────────────────────
-
-  let actorDisplayName: string | undefined;
-  let actorEmail: string | undefined;
-  if (appUserId) {
-    const linearUser = await fetchUser(client, appUserId);
-    actorDisplayName = linearUser?.name;
-    actorEmail = linearUser?.email ?? undefined;
-  }
 
   // ─── Create session ───────────────────────────────────────────────────
 

--- a/packages/linear-bot/src/webhook-handler.ts
+++ b/packages/linear-bot/src/webhook-handler.ts
@@ -14,6 +14,7 @@ import {
   getLinearClient,
   emitAgentActivity,
   fetchIssueDetails,
+  fetchUser,
   updateAgentSession,
   getRepoSuggestions,
 } from "./utils/linear-client";
@@ -139,6 +140,9 @@ async function createSession(
     title: string;
     model: string;
     reasoningEffort?: string;
+    actorUserId?: string;
+    actorDisplayName?: string;
+    actorEmail?: string;
   },
   traceId?: string
 ): Promise<{ ok: true; sessionId: string } | { ok: false; status: number; body: string }> {
@@ -508,6 +512,16 @@ async function handleNewSession(
     labelModel,
   });
 
+  // ─── Resolve user identity ─────────────────────────────────────────────
+
+  let actorDisplayName: string | undefined;
+  let actorEmail: string | undefined;
+  if (appUserId) {
+    const linearUser = await fetchUser(client, appUserId);
+    actorDisplayName = linearUser?.name;
+    actorEmail = linearUser?.email ?? undefined;
+  }
+
   // ─── Create session ───────────────────────────────────────────────────
 
   await updateAgentSession(client, agentSessionId, { plan: makePlan("repo_resolved") });
@@ -529,6 +543,9 @@ async function handleNewSession(
       title: `${issue.identifier}: ${issue.title}`,
       model,
       reasoningEffort,
+      actorUserId: appUserId,
+      actorDisplayName,
+      actorEmail,
     },
     traceId
   );

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { Env } from "./types";
 import type * as SlackClientModule from "./utils/slack-client";
 
-const { mockVerifySlackSignature, mockPublishView, mockOpenView } = vi.hoisted(() => ({
-  mockVerifySlackSignature: vi.fn(),
-  mockPublishView: vi.fn(),
-  mockOpenView: vi.fn(),
-}));
+const { mockVerifySlackSignature, mockPublishView, mockOpenView, mockGetUserInfo } = vi.hoisted(
+  () => ({
+    mockVerifySlackSignature: vi.fn(),
+    mockPublishView: vi.fn(),
+    mockOpenView: vi.fn(),
+    mockGetUserInfo: vi.fn(),
+  })
+);
 
 vi.mock("./utils/slack-client", async () => {
   const actual = await vi.importActual<typeof SlackClientModule>("./utils/slack-client");
@@ -15,6 +18,7 @@ vi.mock("./utils/slack-client", async () => {
     verifySlackSignature: mockVerifySlackSignature,
     publishView: mockPublishView,
     openView: mockOpenView,
+    getUserInfo: mockGetUserInfo,
   };
 });
 
@@ -123,6 +127,7 @@ describe("POST /interactions", () => {
     clearLocalCache();
     mockVerifySlackSignature.mockResolvedValue(true);
     mockOpenView.mockResolvedValue({ ok: true });
+    mockGetUserInfo.mockResolvedValue({ ok: true, user: undefined });
   });
 
   it.each(["foo..bar", "release/", "-bad", "@", "foo/.bar", "foo.lock"])(
@@ -543,6 +548,121 @@ describe("POST /interactions", () => {
     const init = sessionCall?.[1] as RequestInit;
     const body = JSON.parse(String(init.body)) as { branch?: string };
     expect(body.branch).toBe("repo-branch");
+
+    slackFetch.mockRestore();
+  });
+
+  it("forwards identity fields from getUserInfo to session creation", async () => {
+    const slackFetch = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      return new Response(JSON.stringify({ ok: true, ts: "123.456" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    mockGetUserInfo.mockResolvedValue({
+      ok: true,
+      user: {
+        id: "U123",
+        name: "jdoe",
+        real_name: "Jane Doe",
+        profile: {
+          display_name: "Jane",
+          email: "jane@example.com",
+        },
+      },
+    });
+
+    const payload = {
+      type: "block_actions",
+      user: { id: "U123" },
+      channel: { id: "C123" },
+      message: { ts: "111.222" },
+      actions: [
+        {
+          action_id: "select_repo",
+          selected_option: { value: "acme/app" },
+        },
+      ],
+    };
+
+    const request = new Request("http://localhost/interactions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "x-slack-signature": "v0=test",
+        "x-slack-request-timestamp": `${Math.floor(Date.now() / 1000)}`,
+      },
+      body: new URLSearchParams({ payload: JSON.stringify(payload) }),
+    });
+
+    const env = makeEnv();
+    await (env.SLACK_KV as unknown as { put: (k: string, v: string) => Promise<void> }).put(
+      "pending:C123:111.222",
+      JSON.stringify({
+        message: "Please handle this",
+        userId: "U123",
+      })
+    );
+
+    (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/repos")) {
+          return new Response(
+            JSON.stringify({
+              repos: [
+                {
+                  id: "acme/app",
+                  owner: "acme",
+                  name: "app",
+                  fullName: "acme/app",
+                  defaultBranch: "main",
+                  private: true,
+                },
+              ],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+          );
+        }
+        if (url.endsWith("/sessions")) {
+          return new Response(JSON.stringify({ sessionId: "session-1", status: "running" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        if (url.includes("/prompt")) {
+          return new Response(JSON.stringify({ messageId: "msg-1" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return new Response(JSON.stringify({ enabledModels: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    );
+
+    const ctx = makeCtx();
+    const response = await app.fetch(request, env, ctx);
+    expect(response.status).toBe(200);
+    await flushWaitUntil(ctx);
+
+    const sessionCall = (
+      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls.find(([input]) => {
+      const url = typeof input === "string" ? input : (input as URL).toString();
+      return url.endsWith("/sessions");
+    });
+
+    expect(sessionCall).toBeTruthy();
+    const init = sessionCall?.[1] as RequestInit;
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+    expect(body.actorUserId).toBe("U123");
+    expect(body.actorDisplayName).toBe("Jane");
+    expect(body.actorEmail).toBe("jane@example.com");
+    expect(body.spawnSource).toBe("slack-bot");
 
     slackFetch.mockRestore();
   });

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -667,6 +667,110 @@ describe("POST /interactions", () => {
     slackFetch.mockRestore();
   });
 
+  it("creates session even when getUserInfo throws", async () => {
+    const slackFetch = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      return new Response(JSON.stringify({ ok: true, ts: "123.456" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    mockGetUserInfo.mockRejectedValue(new Error("Slack API down"));
+
+    const payload = {
+      type: "block_actions",
+      user: { id: "U123" },
+      channel: { id: "C123" },
+      message: { ts: "111.222" },
+      actions: [
+        {
+          action_id: "select_repo",
+          selected_option: { value: "acme/app" },
+        },
+      ],
+    };
+
+    const request = new Request("http://localhost/interactions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "x-slack-signature": "v0=test",
+        "x-slack-request-timestamp": `${Math.floor(Date.now() / 1000)}`,
+      },
+      body: new URLSearchParams({ payload: JSON.stringify(payload) }),
+    });
+
+    const env = makeEnv();
+    await (env.SLACK_KV as unknown as { put: (k: string, v: string) => Promise<void> }).put(
+      "pending:C123:111.222",
+      JSON.stringify({
+        message: "Please handle this",
+        userId: "U123",
+      })
+    );
+
+    (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/repos")) {
+          return new Response(
+            JSON.stringify({
+              repos: [
+                {
+                  id: "acme/app",
+                  owner: "acme",
+                  name: "app",
+                  fullName: "acme/app",
+                  defaultBranch: "main",
+                  private: true,
+                },
+              ],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+          );
+        }
+        if (url.endsWith("/sessions")) {
+          return new Response(JSON.stringify({ sessionId: "session-1", status: "running" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        if (url.includes("/prompt")) {
+          return new Response(JSON.stringify({ messageId: "msg-1" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return new Response(JSON.stringify({ enabledModels: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    );
+
+    const ctx = makeCtx();
+    const response = await app.fetch(request, env, ctx);
+    expect(response.status).toBe(200);
+    await flushWaitUntil(ctx);
+
+    const sessionCall = (
+      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls.find(([input]) => {
+      const url = typeof input === "string" ? input : (input as URL).toString();
+      return url.endsWith("/sessions");
+    });
+
+    expect(sessionCall).toBeTruthy();
+    const init = sessionCall?.[1] as RequestInit;
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+    expect(body.actorUserId).toBe("U123");
+    expect(body.actorDisplayName).toBeUndefined();
+    expect(body.actorEmail).toBeUndefined();
+    expect(body.spawnSource).toBe("slack-bot");
+
+    slackFetch.mockRestore();
+  });
+
   it("clears repo-specific branch override from App Home", async () => {
     mockPublishView.mockResolvedValue({ ok: true });
 

--- a/packages/slack-bot/src/index.ts
+++ b/packages/slack-bot/src/index.ts
@@ -22,6 +22,7 @@ import {
   addReaction,
   getChannelInfo,
   getThreadMessages,
+  getUserInfo,
   publishView,
   openView,
 } from "./utils/slack-client";
@@ -84,7 +85,9 @@ async function createSession(
   reasoningEffort: string | undefined,
   branch: string | undefined,
   traceId?: string,
-  slackUserId?: string
+  slackUserId?: string,
+  actorDisplayName?: string,
+  actorEmail?: string
 ): Promise<{ sessionId: string; status: string } | null> {
   const startTime = Date.now();
   const base = {
@@ -109,6 +112,9 @@ async function createSession(
         reasoningEffort,
         branch,
         spawnSource: "slack-bot",
+        actorUserId: slackUserId,
+        actorDisplayName,
+        actorEmail,
       }),
     });
 
@@ -887,6 +893,21 @@ async function startSessionAndSendPrompt(
   const repoBranch = await getUserRepoBranchPreference(env, userId, repo.id);
   const branch = repoBranch ?? globalBranch;
 
+  // Best-effort user info resolution for identity linking
+  let displayName: string | undefined;
+  let email: string | undefined;
+  try {
+    const userInfo = await getUserInfo(env.SLACK_BOT_TOKEN, userId);
+    displayName =
+      userInfo.user?.profile?.display_name ||
+      userInfo.user?.real_name ||
+      userInfo.user?.name ||
+      undefined;
+    email = userInfo.user?.profile?.email || undefined;
+  } catch {
+    // Proceed with no display name / email — control plane handles missing fields
+  }
+
   // Create session via control plane with user's preferred model, reasoning effort, and branch
   const session = await createSession(
     env,
@@ -896,7 +917,9 @@ async function startSessionAndSendPrompt(
     reasoningEffort,
     branch,
     traceId,
-    userId
+    userId,
+    displayName,
+    email
   );
 
   if (!session) {


### PR DESCRIPTION
## Summary

Phase 4 of the unified user model migration (#523). Wires all three bots to send identity fields when creating sessions, enabling the control plane (deployed in Phase 2, PR #550) to resolve canonical user IDs via `resolveOrCreateUser`.

- **GitHub bot**: forwards `scmUserId: String(sender.id)` alongside existing `scmLogin` in all 4 handlers (review requested, PR opened, issue comment, review comment)
- **Slack bot**: calls `getUserInfo` to resolve display name + email, forwards `actorUserId`, `actorDisplayName`, `actorEmail` to session creation
- **Linear bot**: calls `fetchUser` (added in pre-step 7) to resolve display name + email, forwards `actorUserId`, `actorDisplayName`, `actorEmail` to session creation
- **Web route**: already sends `scmUserId: user.id` — no changes needed (Phase 2 wired this)

All identity resolution is best-effort: `getUserInfo`/`fetchUser` failures are swallowed, and the session is created with whatever fields are available. The control plane's `resolveProviderIdentity` handles missing fields by returning `null` (session gets `user_id = NULL`).

## Test plan

- [x] GitHub bot: 100 tests passing — 4 handler tests assert `scmUserId` matches `sender.id`
- [x] Slack bot: 45 tests passing — new test verifies `actorUserId`, `actorDisplayName`, `actorEmail` forwarded from `getUserInfo`
- [x] Linear bot: 96 tests passing — `fetchUser` already tested (4 tests in `linear-client.test.ts`)
- [x] Control plane: 994 unit + 325 integration tests passing (unchanged)
- [x] Web: 185 tests passing (unchanged)
- [x] All packages typecheck and lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session creation now captures and forwards richer user identity details (numeric IDs, display names, emails) from GitHub, Linear, and Slack integrations; session requests include these identity fields.

* **Tests**
  * Added and extended tests to validate identity fields are included in session creation across handlers and bot integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->