### PR TITLE
feat: wire user_id through automations, scheduler, and token store

### DIFF
--- a/packages/control-plane/src/db/automation-store.test.ts
+++ b/packages/control-plane/src/db/automation-store.test.ts
@@ -94,6 +94,7 @@ const sampleRow: AutomationRow = {
   next_run_at: now + 86400000,
   consecutive_failures: 0,
   created_by: "user-1",
+  user_id: null,
   created_at: now,
   updated_at: now,
   deleted_at: null,

--- a/packages/control-plane/src/db/automation-store.ts
+++ b/packages/control-plane/src/db/automation-store.ts
@@ -26,6 +26,7 @@ export interface AutomationRow {
   next_run_at: number | null;
   consecutive_failures: number;
   created_by: string;
+  user_id: string | null;
   created_at: number;
   updated_at: number;
   deleted_at: number | null;
@@ -114,9 +115,9 @@ export class AutomationStore {
         `INSERT INTO automations
          (id, name, repo_owner, repo_name, base_branch, repo_id, instructions,
           trigger_type, schedule_cron, schedule_tz, model, reasoning_effort, enabled, next_run_at,
-          consecutive_failures, created_by, created_at, updated_at, deleted_at,
+          consecutive_failures, created_by, user_id, created_at, updated_at, deleted_at,
           event_type, trigger_config, trigger_auth_data)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .bind(
         row.id,
@@ -135,6 +136,7 @@ export class AutomationStore {
         row.next_run_at,
         row.consecutive_failures,
         row.created_by,
+        row.user_id,
         row.created_at,
         row.updated_at,
         row.deleted_at,

--- a/packages/control-plane/src/db/user-scm-tokens.test.ts
+++ b/packages/control-plane/src/db/user-scm-tokens.test.ts
@@ -81,7 +81,7 @@ class FakeD1Database {
         access_token_encrypted: accessEnc,
         refresh_token_encrypted: refreshEnc,
         token_expires_at: expiresAt,
-        user_id: existing ? existing.user_id : userId,
+        user_id: existing ? (existing.user_id ?? userId) : userId,
         created_at: existing ? existing.created_at : createdAt,
         updated_at: updatedAt,
       });
@@ -272,6 +272,19 @@ describe("UserScmTokenStore", () => {
 
     const row = db.getRow("user-789");
     expect(row!.user_id).toBe("canonical-user-1");
+  });
+
+  it("upsertTokens backfills null user_id on conflict update", async () => {
+    const expiresAt1 = Date.now() + 3600_000;
+    const expiresAt2 = Date.now() + 7200_000;
+
+    await store.upsertTokens("user-legacy", "access-1", "refresh-1", expiresAt1);
+    expect(db.getRow("user-legacy")!.user_id).toBeNull();
+
+    await store.upsertTokens("user-legacy", "access-2", "refresh-2", expiresAt2, "resolved-user");
+
+    const row = db.getRow("user-legacy");
+    expect(row!.user_id).toBe("resolved-user");
   });
 
   it("getTokens returns null for unknown user", async () => {

--- a/packages/control-plane/src/db/user-scm-tokens.test.ts
+++ b/packages/control-plane/src/db/user-scm-tokens.test.ts
@@ -23,6 +23,7 @@ type ScmTokenRow = {
   access_token_encrypted: string;
   refresh_token_encrypted: string;
   token_expires_at: number;
+  user_id: string | null;
   created_at: number;
   updated_at: number;
 };
@@ -66,14 +67,8 @@ class FakeD1Database {
     const normalized = normalizeQuery(query);
 
     if (QUERY_PATTERNS.UPSERT_TOKENS.test(normalized)) {
-      const [providerUserId, accessEnc, refreshEnc, expiresAt, createdAt, updatedAt] = args as [
-        string,
-        string,
-        string,
-        number,
-        number,
-        number,
-      ];
+      const [providerUserId, accessEnc, refreshEnc, expiresAt, userId, createdAt, updatedAt] =
+        args as [string, string, string, number, string | null, number, number];
       const existing = this.rows.get(providerUserId);
 
       // Freshness guard: ON CONFLICT ... WHERE excluded.token_expires_at > user_scm_tokens.token_expires_at
@@ -86,6 +81,7 @@ class FakeD1Database {
         access_token_encrypted: accessEnc,
         refresh_token_encrypted: refreshEnc,
         token_expires_at: expiresAt,
+        user_id: existing ? existing.user_id : userId,
         created_at: existing ? existing.created_at : createdAt,
         updated_at: updatedAt,
       });
@@ -241,6 +237,41 @@ describe("UserScmTokenStore", () => {
     // Original values unchanged
     const unchanged = await store.getTokens("user-123");
     expect(unchanged!.accessToken).toBe("access-old");
+  });
+
+  it("upsertTokens stores user_id when provided", async () => {
+    const expiresAt = Date.now() + 3600_000;
+    await store.upsertTokens(
+      "user-123",
+      "access-abc",
+      "refresh-xyz",
+      expiresAt,
+      "canonical-user-1"
+    );
+
+    const row = db.getRow("user-123");
+    expect(row).toBeDefined();
+    expect(row!.user_id).toBe("canonical-user-1");
+  });
+
+  it("upsertTokens stores null user_id when omitted", async () => {
+    const expiresAt = Date.now() + 3600_000;
+    await store.upsertTokens("user-456", "access-abc", "refresh-xyz", expiresAt);
+
+    const row = db.getRow("user-456");
+    expect(row).toBeDefined();
+    expect(row!.user_id).toBeNull();
+  });
+
+  it("upsertTokens preserves existing user_id on conflict update", async () => {
+    const expiresAt1 = Date.now() + 3600_000;
+    const expiresAt2 = Date.now() + 7200_000;
+
+    await store.upsertTokens("user-789", "access-1", "refresh-1", expiresAt1, "canonical-user-1");
+    await store.upsertTokens("user-789", "access-2", "refresh-2", expiresAt2, "different-user");
+
+    const row = db.getRow("user-789");
+    expect(row!.user_id).toBe("canonical-user-1");
   });
 
   it("getTokens returns null for unknown user", async () => {

--- a/packages/control-plane/src/db/user-scm-tokens.ts
+++ b/packages/control-plane/src/db/user-scm-tokens.ts
@@ -50,7 +50,8 @@ export class UserScmTokenStore {
     providerUserId: string,
     accessToken: string,
     refreshToken: string,
-    expiresAt: number
+    expiresAt: number,
+    userId?: string | null
   ): Promise<void> {
     const now = Date.now();
     const [accessTokenEncrypted, refreshTokenEncrypted] = await Promise.all([
@@ -61,8 +62,8 @@ export class UserScmTokenStore {
     await this.db
       .prepare(
         `INSERT INTO user_scm_tokens
-         (provider_user_id, access_token_encrypted, refresh_token_encrypted, token_expires_at, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?)
+         (provider_user_id, access_token_encrypted, refresh_token_encrypted, token_expires_at, user_id, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(provider_user_id) DO UPDATE SET
            access_token_encrypted = excluded.access_token_encrypted,
            refresh_token_encrypted = excluded.refresh_token_encrypted,
@@ -70,7 +71,15 @@ export class UserScmTokenStore {
            updated_at = excluded.updated_at
          WHERE excluded.token_expires_at > user_scm_tokens.token_expires_at`
       )
-      .bind(providerUserId, accessTokenEncrypted, refreshTokenEncrypted, expiresAt, now, now)
+      .bind(
+        providerUserId,
+        accessTokenEncrypted,
+        refreshTokenEncrypted,
+        expiresAt,
+        userId ?? null,
+        now,
+        now
+      )
       .run();
   }
 

--- a/packages/control-plane/src/db/user-scm-tokens.ts
+++ b/packages/control-plane/src/db/user-scm-tokens.ts
@@ -68,6 +68,7 @@ export class UserScmTokenStore {
            access_token_encrypted = excluded.access_token_encrypted,
            refresh_token_encrypted = excluded.refresh_token_encrypted,
            token_expires_at = excluded.token_expires_at,
+           user_id = COALESCE(user_scm_tokens.user_id, excluded.user_id),
            updated_at = excluded.updated_at
          WHERE excluded.token_expires_at > user_scm_tokens.token_expires_at`
       )

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -925,7 +925,8 @@ async function handleCreateSession(
           scmUserId,
           scmToken,
           scmRefreshToken,
-          scmTokenExpiresAt ?? Date.now() + DEFAULT_TOKEN_LIFETIME_MS
+          scmTokenExpiresAt ?? Date.now() + DEFAULT_TOKEN_LIFETIME_MS,
+          resolvedUserId
         )
         .catch((e) =>
           logger.error("Failed to write tokens to D1", {

--- a/packages/control-plane/src/routes/automations.test.ts
+++ b/packages/control-plane/src/routes/automations.test.ts
@@ -32,6 +32,13 @@ vi.mock("../db/automation-store", () => ({
   toAutomationRun: vi.fn((row: unknown) => row),
 }));
 
+const mockUserStore = {
+  resolveOrCreateUser: vi.fn().mockResolvedValue({ id: "resolved-user-1", isNew: false }),
+};
+vi.mock("../db/user-store", () => ({
+  UserStore: vi.fn().mockImplementation(() => mockUserStore),
+}));
+
 vi.mock("../auth/crypto", () => ({
   generateId: vi.fn(() => "generated-id"),
 }));
@@ -189,6 +196,38 @@ describe("automation route handlers", () => {
       const res = await callRoute("POST", "/automations", { body: validBody });
       expect(res.status).toBe(201);
       expect(mockStore.create).toHaveBeenCalledTimes(1);
+    });
+
+    it("resolves user_id when scmUserId is provided", async () => {
+      mockStore.create.mockResolvedValue(undefined);
+      mockStore.getById.mockResolvedValue(sampleRow);
+
+      const res = await callRoute("POST", "/automations", {
+        body: { ...validBody, scmUserId: "12345", scmLogin: "alice" },
+      });
+
+      expect(res.status).toBe(201);
+      expect(mockUserStore.resolveOrCreateUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: "github",
+          providerUserId: "12345",
+          providerLogin: "alice",
+        })
+      );
+      expect(mockStore.create).toHaveBeenCalledWith(
+        expect.objectContaining({ user_id: "resolved-user-1" })
+      );
+    });
+
+    it("creates automation with null user_id when scmUserId is missing", async () => {
+      mockStore.create.mockResolvedValue(undefined);
+      mockStore.getById.mockResolvedValue(sampleRow);
+
+      const res = await callRoute("POST", "/automations", { body: validBody });
+
+      expect(res.status).toBe(201);
+      expect(mockUserStore.resolveOrCreateUser).not.toHaveBeenCalled();
+      expect(mockStore.create).toHaveBeenCalledWith(expect.objectContaining({ user_id: null }));
     });
 
     it("stores reasoning effort when valid for the selected model", async () => {

--- a/packages/control-plane/src/routes/automations.ts
+++ b/packages/control-plane/src/routes/automations.ts
@@ -17,6 +17,7 @@ import {
   type AutomationTriggerType,
 } from "@open-inspect/shared";
 import { AutomationStore, toAutomation, toAutomationRun } from "../db/automation-store";
+import { UserStore } from "../db/user-store";
 import { generateId } from "../auth/crypto";
 import { generateWebhookApiKey, hashApiKey, encryptSentrySecret } from "../auth/webhook-key";
 import { createLogger } from "../logger";
@@ -92,7 +93,15 @@ async function handleCreateAutomation(
   _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const body = await parseJsonBody<CreateAutomationRequest & { userId?: string }>(request);
+  const body = await parseJsonBody<
+    CreateAutomationRequest & {
+      userId?: string;
+      scmUserId?: string;
+      scmLogin?: string;
+      scmName?: string;
+      scmEmail?: string;
+    }
+  >(request);
   if (body instanceof Response) return body;
 
   // Validate required fields
@@ -215,6 +224,26 @@ async function handleCreateAutomation(
     triggerAuthData = await encryptSentrySecret(sentrySecret, env.REPO_SECRETS_ENCRYPTION_KEY);
   }
 
+  // Resolve canonical user model ID (best-effort, same pattern as handleCreateSession)
+  let resolvedUserId: string | null = null;
+  if (body.scmUserId) {
+    try {
+      const userStore = new UserStore(env.DB);
+      const resolvedUser = await userStore.resolveOrCreateUser({
+        provider: "github",
+        providerUserId: body.scmUserId,
+        providerLogin: body.scmLogin,
+        providerEmail: body.scmEmail,
+        displayName: body.scmName || body.scmLogin,
+      });
+      resolvedUserId = resolvedUser.id;
+    } catch (e) {
+      logger.warn("Failed to resolve user identity for automation", {
+        error: e instanceof Error ? e : String(e),
+      });
+    }
+  }
+
   const store = new AutomationStore(env.DB);
   await store.create({
     id,
@@ -233,6 +262,7 @@ async function handleCreateAutomation(
     next_run_at: nextRunAt,
     consecutive_failures: 0,
     created_by: body.userId || "anonymous",
+    user_id: resolvedUserId,
     created_at: now,
     updated_at: now,
     deleted_at: null,

--- a/packages/control-plane/src/routes/automations.ts
+++ b/packages/control-plane/src/routes/automations.ts
@@ -240,6 +240,7 @@ async function handleCreateAutomation(
     } catch (e) {
       logger.warn("Failed to resolve user identity for automation", {
         error: e instanceof Error ? e : String(e),
+        scmUserId: body.scmUserId,
       });
     }
   }

--- a/packages/control-plane/src/scheduler/durable-object.test.ts
+++ b/packages/control-plane/src/scheduler/durable-object.test.ts
@@ -52,9 +52,17 @@ vi.mock("../db/automation-store", () => ({
   toAutomationRun: vi.fn((row: unknown) => row),
 }));
 
+const mockSessionStoreCreate = vi.fn().mockResolvedValue(undefined);
 vi.mock("../db/session-index", () => ({
   SessionIndexStore: vi.fn().mockImplementation(() => ({
-    create: vi.fn().mockResolvedValue(undefined),
+    create: mockSessionStoreCreate,
+  })),
+}));
+
+const mockUserStoreGetIdentity = vi.fn().mockResolvedValue(null);
+vi.mock("../db/user-store", () => ({
+  UserStore: vi.fn().mockImplementation(() => ({
+    getIdentity: mockUserStoreGetIdentity,
   })),
 }));
 
@@ -115,6 +123,7 @@ const sampleAutomation = {
   next_run_at: now - 60000,
   consecutive_failures: 0,
   created_by: "user-1",
+  user_id: null as string | null,
   created_at: now - 86400000,
   updated_at: now - 86400000,
   deleted_at: null,
@@ -312,6 +321,43 @@ describe("SchedulerDO", () => {
         completed_at: expect.any(Number),
       });
       expect(mockStore.incrementConsecutiveFailures).toHaveBeenCalledWith("auto-1");
+    });
+
+    it("passes automation user_id to session index", async () => {
+      const automation = { ...sampleAutomation, user_id: "canonical-user-1" };
+      mockStore.getOverdueAutomations.mockResolvedValue([automation]);
+
+      const scheduler = createSchedulerDO();
+      await scheduler.fetch(new Request("http://internal/internal/tick", { method: "POST" }));
+
+      expect(mockSessionStoreCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: "canonical-user-1" })
+      );
+    });
+
+    it("falls back to identity lookup for legacy automations without user_id", async () => {
+      mockStore.getOverdueAutomations.mockResolvedValue([sampleAutomation]);
+      mockUserStoreGetIdentity.mockResolvedValue({ userId: "looked-up-user" });
+
+      const scheduler = createSchedulerDO();
+      await scheduler.fetch(new Request("http://internal/internal/tick", { method: "POST" }));
+
+      expect(mockUserStoreGetIdentity).toHaveBeenCalledWith("github", "user-1");
+      expect(mockSessionStoreCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: "looked-up-user" })
+      );
+    });
+
+    it("creates session with null userId when identity lookup finds nothing", async () => {
+      mockStore.getOverdueAutomations.mockResolvedValue([sampleAutomation]);
+      mockUserStoreGetIdentity.mockResolvedValue(null);
+
+      const scheduler = createSchedulerDO();
+      await scheduler.fetch(new Request("http://internal/internal/tick", { method: "POST" }));
+
+      expect(mockSessionStoreCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: null })
+      );
     });
 
     it("recovers timed-out running runs", async () => {

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -19,6 +19,7 @@ import {
 } from "@open-inspect/shared";
 import { AutomationStore, toAutomationRun, type AutomationRow } from "../db/automation-store";
 import { SessionIndexStore } from "../db/session-index";
+import { UserStore } from "../db/user-store";
 import { generateId } from "../auth/crypto";
 import { createLogger, parseLogLevel } from "../logger";
 import type { Logger } from "../logger";
@@ -566,6 +567,23 @@ export class SchedulerDO extends DurableObject<Env> {
       throw new Error(`Session init failed with status ${initResponse.status}`);
     }
 
+    // Resolve the canonical user_id for the session index.
+    // New automations have user_id populated at creation time.
+    // Legacy automations (pre-Phase 5) store the GitHub numeric user ID in created_by
+    // (set from NextAuth session.user.id). Fall back to looking it up via user_identities.
+    let userId = automation.user_id;
+    if (!userId && automation.created_by && automation.created_by !== "anonymous") {
+      try {
+        const userStore = new UserStore(this.env.DB);
+        const identity = await userStore.getIdentity("github", automation.created_by);
+        if (identity) {
+          userId = identity.userId;
+        }
+      } catch {
+        // Best-effort — proceed without user_id
+      }
+    }
+
     // Index the session in D1
     const now = Date.now();
     const sessionStore = new SessionIndexStore(this.env.DB);
@@ -582,6 +600,7 @@ export class SchedulerDO extends DurableObject<Env> {
       spawnDepth: 0,
       automationId: automation.id,
       automationRunId: runId,
+      userId,
       createdAt: now,
       updatedAt: now,
     });

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -568,9 +568,12 @@ export class SchedulerDO extends DurableObject<Env> {
     }
 
     // Resolve the canonical user_id for the session index.
-    // New automations have user_id populated at creation time.
-    // Legacy automations (pre-Phase 5) store the GitHub numeric user ID in created_by
-    // (set from NextAuth session.user.id). Fall back to looking it up via user_identities.
+    // New automations (post-Phase 5) have user_id populated at creation time, so this
+    // lookup is skipped. Legacy automations have user_id = NULL but store the GitHub
+    // numeric user ID in created_by (set from NextAuth session.user.id in the web UI,
+    // which is the only automation creation path). We look up that GitHub ID in
+    // user_identities to find the canonical user. This fallback becomes dead code once
+    // the Phase 6 backfill populates user_id on all existing automation rows.
     let userId = automation.user_id;
     if (!userId && automation.created_by && automation.created_by !== "anonymous") {
       try {

--- a/packages/control-plane/test/integration/automation-store.test.ts
+++ b/packages/control-plane/test/integration/automation-store.test.ts
@@ -29,6 +29,7 @@ function makeAutomation(overrides?: Partial<AutomationRow>): AutomationRow {
     next_run_at: now + 86400000,
     consecutive_failures: 0,
     created_by: "user-1",
+    user_id: null,
     created_at: now,
     updated_at: now,
     deleted_at: null,
@@ -80,6 +81,24 @@ describe("AutomationStore (D1 integration)", () => {
       expect(result!.schedule_cron).toBe("0 9 * * *");
       expect(result!.enabled).toBe(1);
       expect(result!.consecutive_failures).toBe(0);
+    });
+
+    it("stores and retrieves user_id", async () => {
+      const store = new AutomationStore(env.DB);
+      await store.create(makeAutomation({ id: "auto-uid", user_id: "canonical-user-1" }));
+
+      const result = await store.getById("auto-uid");
+      expect(result).not.toBeNull();
+      expect(result!.user_id).toBe("canonical-user-1");
+    });
+
+    it("defaults user_id to null when omitted", async () => {
+      const store = new AutomationStore(env.DB);
+      await store.create(makeAutomation({ id: "auto-uid-null" }));
+
+      const result = await store.getById("auto-uid-null");
+      expect(result).not.toBeNull();
+      expect(result!.user_id).toBeNull();
     });
 
     it("returns null for nonexistent automation", async () => {

--- a/packages/control-plane/test/integration/scheduler-events.test.ts
+++ b/packages/control-plane/test/integration/scheduler-events.test.ts
@@ -32,6 +32,7 @@ function makeAutomation(overrides?: Partial<AutomationRow>): AutomationRow {
     next_run_at: now + 86400000,
     consecutive_failures: 0,
     created_by: "user-1",
+    user_id: null,
     created_at: now,
     updated_at: now,
     deleted_at: null,

--- a/packages/control-plane/test/integration/scheduler.test.ts
+++ b/packages/control-plane/test/integration/scheduler.test.ts
@@ -31,6 +31,7 @@ function makeAutomation(overrides?: Partial<AutomationRow>): AutomationRow {
     next_run_at: now + 86400000,
     consecutive_failures: 0,
     created_by: "user-1",
+    user_id: null,
     created_at: now,
     updated_at: now,
     deleted_at: null,

--- a/packages/control-plane/test/integration/webhooks.test.ts
+++ b/packages/control-plane/test/integration/webhooks.test.ts
@@ -39,6 +39,7 @@ function makeAutomation(overrides: Partial<AutomationRow> = {}): AutomationRow {
     next_run_at: null,
     consecutive_failures: 0,
     created_by: "test-user",
+    user_id: null,
     created_at: Date.now(),
     updated_at: Date.now(),
     deleted_at: null,

--- a/packages/web/src/app/api/automations/route.ts
+++ b/packages/web/src/app/api/automations/route.ts
@@ -36,7 +36,14 @@ export async function POST(request: NextRequest) {
 
     const response = await controlPlaneFetch("/automations", {
       method: "POST",
-      body: JSON.stringify({ ...body, userId }),
+      body: JSON.stringify({
+        ...body,
+        userId,
+        scmUserId: user.id,
+        scmLogin: user.login,
+        scmName: user.name,
+        scmEmail: user.email,
+      }),
     });
     const data = await response.json();
     return NextResponse.json(data, { status: response.status });


### PR DESCRIPTION
## Summary

Phase 5 of the unified user model migration (#523). Wires canonical `user_id` through three components that were previously unlinked:

- **Automation creation** — `handleCreateAutomation` now calls `UserStore.resolveOrCreateUser` with SCM identity fields forwarded from the web UI, writing the resolved `user_id` to the automation row
- **Scheduler session creation** — `createSessionForAutomation` reads `automation.user_id` and passes it to `sessionStore.create()`, with a legacy fallback that looks up `created_by` via `user_identities` for pre-Phase 5 automations
- **Token store** — `UserScmTokenStore.upsertTokens` accepts an optional `userId` param, included on INSERT (preserved on conflict update)

### Files changed

| File | Change |
|---|---|
| `automation-store.ts` | Add `user_id` to `AutomationRow` and `create()` SQL |
| `routes/automations.ts` | Import `UserStore`, accept `scm*` fields, resolve user, pass `user_id` |
| `scheduler/durable-object.ts` | Import `UserStore`, resolve `user_id` with legacy fallback, pass to session index |
| `user-scm-tokens.ts` | Add optional `userId` param to `upsertTokens()` |
| `router.ts` | Pass `resolvedUserId` to `upsertTokens` in `handleCreateSession` |
| `web/automations/route.ts` | Forward `scmUserId`, `scmLogin`, `scmName`, `scmEmail` from NextAuth session |

### What does NOT change
- No new D1 migration — `automations.user_id` column already exists from migration 0019
- No shared types changes
- The DO init body — `userId` in the DO remains the provider-specific value

## Test plan

- [x] `npm run typecheck -w @open-inspect/control-plane` — clean
- [x] `npm run typecheck -w @open-inspect/web` — clean
- [x] `npm test -w @open-inspect/control-plane` — 1002 passed (8 new)
- [x] `npm run test:integration -w @open-inspect/control-plane` — 327 passed (2 new)
- [x] `npm test -w @open-inspect/web` — 185 passed
- [x] `npm run lint -w @open-inspect/control-plane` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automations can be associated with resolved GitHub users; creation now includes SCM identity fields so user association is persisted and used for session creation.
  * Token persistence now stores an optional canonical user identifier and preserves existing non-null associations during updates.

* **Tests**
  * Added coverage for user resolution, token upsert semantics (including null/backfill behavior), persistence of user associations, and scheduler/session handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->