### PR TITLE
fix: forward avatar URL to user model

### DIFF
--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -723,6 +723,7 @@ function resolveProviderIdentity(
     scmLogin?: string;
     scmName?: string;
     scmEmail?: string;
+    scmAvatarUrl?: string;
     actorUserId?: string;
     actorDisplayName?: string;
     actorEmail?: string;
@@ -739,6 +740,7 @@ function resolveProviderIdentity(
             providerLogin: body.scmLogin,
             providerEmail: body.scmEmail,
             displayName: body.scmName || body.scmLogin,
+            avatarUrl: body.scmAvatarUrl,
           }
         : null;
 

--- a/packages/control-plane/src/routes/automations.ts
+++ b/packages/control-plane/src/routes/automations.ts
@@ -100,6 +100,7 @@ async function handleCreateAutomation(
       scmLogin?: string;
       scmName?: string;
       scmEmail?: string;
+      scmAvatarUrl?: string;
     }
   >(request);
   if (body instanceof Response) return body;
@@ -235,6 +236,7 @@ async function handleCreateAutomation(
         providerLogin: body.scmLogin,
         providerEmail: body.scmEmail,
         displayName: body.scmName || body.scmLogin,
+        avatarUrl: body.scmAvatarUrl,
       });
       resolvedUserId = resolvedUser.id;
     } catch (e) {

--- a/packages/github-bot/src/handlers.ts
+++ b/packages/github-bot/src/handlers.ts
@@ -33,6 +33,7 @@ async function createSession(
     reasoningEffort?: string | null;
     scmLogin: string;
     scmUserId: string;
+    scmAvatarUrl: string;
   }
 ): Promise<string> {
   const body: Record<string, unknown> = {
@@ -42,6 +43,7 @@ async function createSession(
     model: params.model,
     scmLogin: params.scmLogin,
     scmUserId: params.scmUserId,
+    scmAvatarUrl: params.scmAvatarUrl,
     spawnSource: "github-bot",
   };
   if (params.reasoningEffort) {
@@ -211,6 +213,7 @@ export async function handleReviewRequested(
     reasoningEffort: config.reasoningEffort,
     scmLogin: sender.login,
     scmUserId: String(sender.id),
+    scmAvatarUrl: sender.avatar_url,
   });
   log.info("session.created", { ...meta, session_id: sessionId, action: "review" });
 
@@ -309,6 +312,7 @@ export async function handlePullRequestOpened(
     reasoningEffort: config.reasoningEffort,
     scmLogin: sender.login,
     scmUserId: String(sender.id),
+    scmAvatarUrl: sender.avatar_url,
   });
   log.info("session.created", { ...meta, session_id: sessionId, action: "auto_review" });
 
@@ -413,6 +417,7 @@ export async function handleIssueComment(
     reasoningEffort: config.reasoningEffort,
     scmLogin: sender.login,
     scmUserId: String(sender.id),
+    scmAvatarUrl: sender.avatar_url,
   });
   log.info("session.created", { ...meta, session_id: sessionId, action: "comment" });
 
@@ -510,6 +515,7 @@ export async function handleReviewComment(
     reasoningEffort: config.reasoningEffort,
     scmLogin: sender.login,
     scmUserId: String(sender.id),
+    scmAvatarUrl: sender.avatar_url,
   });
   log.info("session.created", { ...meta, session_id: sessionId, action: "review_comment" });
 

--- a/packages/github-bot/src/types.ts
+++ b/packages/github-bot/src/types.ts
@@ -53,7 +53,7 @@ export interface PullRequestOpenedPayload {
     draft: boolean;
   };
   repository: { owner: { login: string }; name: string; private: boolean };
-  sender: { login: string; id: number };
+  sender: { login: string; id: number; avatar_url: string };
 }
 
 export interface ReviewRequestedPayload {
@@ -68,7 +68,7 @@ export interface ReviewRequestedPayload {
   };
   requested_reviewer?: { login: string };
   repository: { owner: { login: string }; name: string; private: boolean };
-  sender: { login: string; id: number };
+  sender: { login: string; id: number; avatar_url: string };
 }
 
 export interface IssueCommentPayload {
@@ -84,7 +84,7 @@ export interface IssueCommentPayload {
     user: { login: string };
   };
   repository: { owner: { login: string }; name: string; private: boolean };
-  sender: { login: string; id: number };
+  sender: { login: string; id: number; avatar_url: string };
 }
 
 export interface ReviewCommentPayload {
@@ -104,5 +104,5 @@ export interface ReviewCommentPayload {
     user: { login: string };
   };
   repository: { owner: { login: string }; name: string; private: boolean };
-  sender: { login: string; id: number };
+  sender: { login: string; id: number; avatar_url: string };
 }

--- a/packages/github-bot/test/handlers.test.ts
+++ b/packages/github-bot/test/handlers.test.ts
@@ -109,7 +109,7 @@ const pullRequestOpenedPayload: PullRequestOpenedPayload = {
     draft: false,
   },
   repository: { owner: { login: "acme" }, name: "widgets", private: false },
-  sender: { login: "alice", id: 1001 },
+  sender: { login: "alice", id: 1001, avatar_url: "https://avatars.githubusercontent.com/u/1001" },
 };
 
 const reviewRequestedPayload: ReviewRequestedPayload = {
@@ -124,7 +124,7 @@ const reviewRequestedPayload: ReviewRequestedPayload = {
   },
   requested_reviewer: { login: "test-bot[bot]" },
   repository: { owner: { login: "acme" }, name: "widgets", private: false },
-  sender: { login: "alice", id: 1001 },
+  sender: { login: "alice", id: 1001, avatar_url: "https://avatars.githubusercontent.com/u/1001" },
 };
 
 const issueCommentPayload: IssueCommentPayload = {
@@ -140,7 +140,7 @@ const issueCommentPayload: IssueCommentPayload = {
     user: { login: "bob" },
   },
   repository: { owner: { login: "acme" }, name: "widgets", private: false },
-  sender: { login: "bob", id: 1002 },
+  sender: { login: "bob", id: 1002, avatar_url: "https://avatars.githubusercontent.com/u/1002" },
 };
 
 const reviewCommentPayload: ReviewCommentPayload = {
@@ -160,7 +160,7 @@ const reviewCommentPayload: ReviewCommentPayload = {
     user: { login: "carol" },
   },
   repository: { owner: { login: "acme" }, name: "widgets", private: false },
-  sender: { login: "carol", id: 1003 },
+  sender: { login: "carol", id: 1003, avatar_url: "https://avatars.githubusercontent.com/u/1003" },
 };
 
 beforeEach(() => {
@@ -200,6 +200,7 @@ describe("handlePullRequestOpened", () => {
     expect(sessionBody.title).toContain("Review PR #42");
     expect(sessionBody.scmLogin).toBe("alice");
     expect(sessionBody.scmUserId).toBe("1001");
+    expect(sessionBody.scmAvatarUrl).toBe("https://avatars.githubusercontent.com/u/1001");
     expect(sessionBody.spawnSource).toBe("github-bot");
 
     const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
@@ -369,6 +370,7 @@ describe("handleReviewRequested", () => {
     expect(sessionBody.title).toContain("Review PR #42");
     expect(sessionBody.scmLogin).toBe("alice");
     expect(sessionBody.scmUserId).toBe("1001");
+    expect(sessionBody.scmAvatarUrl).toBe("https://avatars.githubusercontent.com/u/1001");
     expect(sessionBody.spawnSource).toBe("github-bot");
 
     // Verify prompt sending
@@ -464,6 +466,7 @@ describe("handleIssueComment", () => {
     const sessionBody = JSON.parse(cpFetch.mock.calls[0][1].body);
     expect(sessionBody.scmLogin).toBe("bob");
     expect(sessionBody.scmUserId).toBe("1002");
+    expect(sessionBody.scmAvatarUrl).toBe("https://avatars.githubusercontent.com/u/1002");
     expect(sessionBody.spawnSource).toBe("github-bot");
 
     const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
@@ -506,7 +509,11 @@ describe("handleIssueComment", () => {
     const log = createMockLogger();
     const payload: IssueCommentPayload = {
       ...issueCommentPayload,
-      sender: { login: "test-bot[bot]", id: 2001 },
+      sender: {
+        login: "test-bot[bot]",
+        id: 2001,
+        avatar_url: "https://avatars.githubusercontent.com/u/2001",
+      },
     };
 
     const result = await handleIssueComment(env, log, payload, "trace-2");
@@ -556,6 +563,7 @@ describe("handleReviewComment", () => {
     const sessionBody = JSON.parse(cpFetch.mock.calls[0][1].body);
     expect(sessionBody.scmLogin).toBe("carol");
     expect(sessionBody.scmUserId).toBe("1003");
+    expect(sessionBody.scmAvatarUrl).toBe("https://avatars.githubusercontent.com/u/1003");
     expect(sessionBody.spawnSource).toBe("github-bot");
 
     const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
@@ -584,7 +592,11 @@ describe("handleReviewComment", () => {
     const log = createMockLogger();
     const payload: ReviewCommentPayload = {
       ...reviewCommentPayload,
-      sender: { login: "test-bot[bot]", id: 2001 },
+      sender: {
+        login: "test-bot[bot]",
+        id: 2001,
+        avatar_url: "https://avatars.githubusercontent.com/u/2001",
+      },
     };
 
     const result = await handleReviewComment(env, log, payload, "trace-3");

--- a/packages/web/src/app/api/automations/route.ts
+++ b/packages/web/src/app/api/automations/route.ts
@@ -43,6 +43,7 @@ export async function POST(request: NextRequest) {
         scmLogin: user.login,
         scmName: user.name,
         scmEmail: user.email,
+        scmAvatarUrl: user.image,
       }),
     });
     const data = await response.json();

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -76,6 +76,7 @@ export async function POST(request: NextRequest) {
       scmLogin: user.login,
       scmName: user.name,
       scmEmail: user.email,
+      scmAvatarUrl: user.image,
     };
 
     const response = await controlPlaneFetch("/sessions", {


### PR DESCRIPTION
## Summary

The `users.avatar_url` column was always NULL because no caller passed `avatarUrl` to `resolveOrCreateUser`. This forwards the avatar URL from all three creation paths:

- **Web routes** (`sessions/route.ts`, `automations/route.ts`): forward `user.image` from NextAuth session as `scmAvatarUrl`
- **GitHub bot** (`handlers.ts`): add `avatar_url` to webhook sender type, forward as `scmAvatarUrl`
- **Control plane** (`router.ts`): `resolveProviderIdentity` now includes `avatarUrl: body.scmAvatarUrl` for the `"user"`/`"github-bot"` cases, matching the existing Slack pattern (`actorAvatarUrl`)
- **Automation route** (`automations.ts`): pass `avatarUrl: body.scmAvatarUrl` to the direct `resolveOrCreateUser` call

## Test plan

- [x] GitHub bot tests pass (100) — updated sender fixtures with `avatar_url`, added `scmAvatarUrl` assertions
- [x] Control-plane unit tests pass (1003)
- [x] TypeScript typecheck clean across web, control-plane, github-bot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub user avatars are now automatically captured from pull request, code review, and issue comment events and integrated into user profiles
  * Avatar information is propagated through automation creation and session management workflows for improved user identification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->