### PR TITLE
fix: add session recency index

### DIFF
--- a/terraform/d1/migrations/0020_add_sessions_updated_at_index.sql
+++ b/terraform/d1/migrations/0020_add_sessions_updated_at_index.sql
@@ -1,0 +1,3 @@
+-- Supports default session listing ordered by recency when filtering with status != 'archived'.
+CREATE INDEX IF NOT EXISTS idx_sessions_updated_at
+  ON sessions(updated_at DESC);


### PR DESCRIPTION
## Summary
- Add a D1 index on `sessions(updated_at DESC)` to support recency-ordered session listing.
- Improves the default `status != archived ORDER BY updated_at DESC LIMIT/OFFSET` path by allowing D1 to scan in update order instead of doing broader table work.

## Validation
- `npm test -w @open-inspect/control-plane -- session-index`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/a2d4cabd0c3a95738f185ec5a03b6d2b)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database performance for session listings to improve load times when viewing sessions sorted by most recent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->