### PR TITLE
fix: switch sessions chart from stacked to independent areas

### DIFF
--- a/packages/web/src/components/analytics/timeseries-chart.tsx
+++ b/packages/web/src/components/analytics/timeseries-chart.tsx
@@ -70,7 +70,7 @@ export function AnalyticsTimeseriesChart({ series, loading }: TimeseriesChartPro
       <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <h2 className="text-lg font-semibold text-foreground">Sessions Over Time</h2>
-          <p className="text-sm text-muted-foreground">Daily session counts stacked by user.</p>
+          <p className="text-sm text-muted-foreground">Daily session counts by user.</p>
         </div>
         <div className="flex flex-wrap gap-2 pt-2 sm:justify-end">
           {previewGroups.map((groupKey) => (
@@ -92,8 +92,8 @@ export function AnalyticsTimeseriesChart({ series, loading }: TimeseriesChartPro
                   const gradientId = getGradientId(groupKey, index);
                   return (
                     <linearGradient key={groupKey} id={gradientId} x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%" stopColor={color} stopOpacity={0.32} />
-                      <stop offset="95%" stopColor={color} stopOpacity={0.06} />
+                      <stop offset="5%" stopColor={color} stopOpacity={0.18} />
+                      <stop offset="95%" stopColor={color} stopOpacity={0.03} />
                     </linearGradient>
                   );
                 })}
@@ -136,7 +136,6 @@ export function AnalyticsTimeseriesChart({ series, loading }: TimeseriesChartPro
                     key={groupKey}
                     type="monotone"
                     dataKey={groupKey}
-                    stackId="sessions"
                     stroke={color}
                     fill={`url(#${gradientId})`}
                     strokeWidth={2}
@@ -150,7 +149,7 @@ export function AnalyticsTimeseriesChart({ series, loading }: TimeseriesChartPro
         </div>
       </div>
       <div className="mt-3 text-xs text-muted-foreground">
-        Hover the chart to inspect stacked daily counts for each user.
+        Hover the chart to inspect daily counts for each user.
       </div>
     </div>
   );

--- a/packages/web/src/lib/analytics.ts
+++ b/packages/web/src/lib/analytics.ts
@@ -100,6 +100,7 @@ export function buildTimeseriesChartData(series: AnalyticsTimeseriesResponse["se
   }
 
   const groupKeys = Array.from(totals.entries())
+    .filter(([, total]) => total > 0)
     .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
     .map(([groupKey]) => groupKey);
 


### PR DESCRIPTION
## Summary

- Removed `stackId="sessions"` from the timeseries `<Area>` components so each user gets an independent line from y=0 instead of stacking on top of each other
- Filtered out groups with 0 total sessions from `buildTimeseriesChartData` to prevent phantom legend entries
- Reduced area fill opacity (0.32→0.18 / 0.06→0.03) so overlapping areas remain legible

**Problem**: The stacked area chart caused misleading visuals. On any day where a user had 0 sessions, their stroke still rendered on top of the previous user's data at the cumulative height — making it look like they were the dominant contributor (e.g., "Unknown user" appearing as the highest green line despite having 0 sessions).

**Fix**: Independent (non-stacked) areas. Each user's line directly represents their session count. No stacking confusion, and the chart reads correctly for the typical 1-3 user single-tenant deployment.

## Test plan

- [x] `analytics.test.ts` passes (8 tests)
- [ ] Verify chart renders correctly on analytics dashboard with real data
- [ ] Confirm overlapping areas are distinguishable with reduced opacity
- [ ] Check tooltip still shows correct per-user counts on hover

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics chart now excludes data series with zero or negative totals

* **Style**
  * Adjusted area chart gradient transparency for improved visibility
  * Removed stacking behavior from area series
  * Updated descriptive labels in analytics interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->