### PR TITLE
fix: fail sandbox spawn when secrets cannot be loaded

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -679,6 +679,33 @@ describe("SandboxLifecycleManager", () => {
       expect(storage.calls).toContain("updateSandboxStatus:failed");
     });
 
+    it("fails spawn when getUserEnvVars rejects", async () => {
+      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      storage.getUserEnvVars = vi.fn(async () => {
+        throw new Error("D1 decryption failure");
+      });
+      const broadcaster = createMockBroadcaster();
+      const wsManager = createMockWebSocketManager(false);
+      const provider = createMockProvider();
+
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        broadcaster,
+        wsManager,
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      expect(provider.createSandbox).not.toHaveBeenCalled();
+      expect(storage.calls).toContain("updateSandboxStatus:failed");
+      expect(manager.isSpawning()).toBe(false);
+    });
+
     it("skips spawn when already spawning", async () => {
       const sandbox = createMockSandbox({ status: "spawning" });
       const storage = createMockStorage(createMockSession(), sandbox);

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1686,30 +1686,14 @@ export class SessionDO extends DurableObject<Env> {
       return undefined;
     }
 
-    // Fetch global secrets
-    let globalSecrets: Record<string, string> = {};
-    try {
-      const globalStore = new GlobalSecretsStore(this.env.DB, this.env.REPO_SECRETS_ENCRYPTION_KEY);
-      globalSecrets = await globalStore.getDecryptedSecrets();
-    } catch (e) {
-      this.log.error("Failed to load global secrets, proceeding without", {
-        error: e instanceof Error ? e.message : String(e),
-      });
-    }
+    // Fetch global secrets (fail hard — secrets are required for sandbox operation)
+    const globalStore = new GlobalSecretsStore(this.env.DB, this.env.REPO_SECRETS_ENCRYPTION_KEY);
+    const globalSecrets = await globalStore.getDecryptedSecrets();
 
     // Fetch repo secrets
-    let repoSecrets: Record<string, string> = {};
-    try {
-      const repoId = await this.ensureRepoId(session);
-      const repoStore = new RepoSecretsStore(this.env.DB, this.env.REPO_SECRETS_ENCRYPTION_KEY);
-      repoSecrets = await repoStore.getDecryptedSecrets(repoId);
-    } catch (e) {
-      this.log.warn("Failed to load repo secrets, proceeding without", {
-        repo_owner: session.repo_owner,
-        repo_name: session.repo_name,
-        error: e instanceof Error ? e.message : String(e),
-      });
-    }
+    const repoId = await this.ensureRepoId(session);
+    const repoStore = new RepoSecretsStore(this.env.DB, this.env.REPO_SECRETS_ENCRYPTION_KEY);
+    const repoSecrets = await repoStore.getDecryptedSecrets(repoId);
 
     // Merge: repo overrides global
     const { merged, totalBytes, exceedsLimit } = mergeSecrets(globalSecrets, repoSecrets);

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1686,11 +1686,10 @@ export class SessionDO extends DurableObject<Env> {
       return undefined;
     }
 
-    // Fetch global secrets (fail hard — secrets are required for sandbox operation)
+    // Fail hard on secret loading — sandboxes must not silently lose secrets
     const globalStore = new GlobalSecretsStore(this.env.DB, this.env.REPO_SECRETS_ENCRYPTION_KEY);
     const globalSecrets = await globalStore.getDecryptedSecrets();
 
-    // Fetch repo secrets
     const repoId = await this.ensureRepoId(session);
     const repoStore = new RepoSecretsStore(this.env.DB, this.env.REPO_SECRETS_ENCRYPTION_KEY);
     const repoSecrets = await repoStore.getDecryptedSecrets(repoId);


### PR DESCRIPTION
## Summary

- Remove try/catch wrappers around global and repo secret loading in `getUserEnvVars()` so failures propagate as errors instead of being silently swallowed
- Previously, a failure to load secrets would log a warning and proceed without them — spawning a sandbox missing user-configured secrets (e.g. `OPENAI_API_KEY`)
- Now, if secret loading fails, the error bubbles up to the lifecycle manager which already handles spawn/restore failures with proper status updates and client notifications

## Context

The original fallback behavior was added when D1 secrets were first introduced, as a safety net during rollout. Now that secrets are a core part of sandbox operation, silently dropping them can cause confusing downstream failures (agent can't authenticate to APIs, etc.). Failing fast gives clear signal.

## Test plan

- [x] Typecheck passes
- [x] All 1003 unit tests pass
- [x] All 327 integration tests pass
- [ ] Verify in staging that a sandbox spawns correctly when secrets load successfully
- [ ] Verify that a D1/encryption failure surfaces as a spawn error to the user (not a silent degradation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Secrets loading now fails explicitly when credentials cannot be retrieved, preventing operations with incomplete configuration.

* **Tests**
  * Added coverage for failure during secret retrieval: ensure sandbox creation aborts, a failed status is recorded, and internal spawn state is reset after the error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->