### PR TITLE
[codex] Fix session creation D1 failure ordering

### DIFF
--- a/packages/control-plane/src/router.create-session.test.ts
+++ b/packages/control-plane/src/router.create-session.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateInternalToken } from "./auth/internal";
+import { SessionIndexStore } from "./db/session-index";
+import { handleRequest } from "./router";
+import { resolveRepoOrError } from "./routes/shared";
+import { SessionInternalPaths } from "./session/contracts";
+
+vi.mock("./db/session-index", () => ({
+  SessionIndexStore: vi.fn(),
+}));
+
+vi.mock("./routes/shared", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    resolveRepoOrError: vi.fn(),
+  };
+});
+
+describe("handleCreateSession D1 ordering", () => {
+  const secret = "test-internal-secret";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(resolveRepoOrError).mockResolvedValue({
+      repoId: 12345,
+      defaultBranch: "main",
+    } as never);
+  });
+
+  async function createSessionRequest(env: Record<string, unknown>): Promise<Response> {
+    const token = await generateInternalToken(secret);
+
+    return handleRequest(
+      new Request("https://test.local/sessions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          repoOwner: "Acme",
+          repoName: "Web-App",
+          title: "Test session",
+          model: "anthropic/claude-haiku-4-5",
+        }),
+      }),
+      env as never
+    );
+  }
+
+  function createEnv(initFetch: ReturnType<typeof vi.fn>): Record<string, unknown> {
+    const statement = {
+      bind: vi.fn(() => statement),
+      first: vi.fn(async () => null),
+      all: vi.fn(async () => ({ results: [] })),
+      run: vi.fn(async () => ({ meta: { changes: 0 } })),
+    };
+
+    return {
+      INTERNAL_CALLBACK_SECRET: secret,
+      SCM_PROVIDER: "github",
+      DB: {
+        prepare: vi.fn(() => statement),
+        batch: vi.fn(),
+        exec: vi.fn(),
+        dump: vi.fn(),
+      },
+      SESSION: {
+        idFromName: (name: string) => name,
+        get: () => ({ fetch: initFetch }),
+      },
+    };
+  }
+
+  it("does not initialize the SessionDO when D1 session index creation fails", async () => {
+    const create = vi.fn().mockRejectedValue(new Error("D1 unavailable"));
+    vi.mocked(SessionIndexStore).mockImplementation(() => ({ create }) as never);
+
+    const initFetch = vi.fn(async () => Response.json({ status: "created" }));
+    const response = await createSessionRequest(createEnv(initFetch));
+
+    expect(response.status).toBe(500);
+    expect(create).toHaveBeenCalledOnce();
+    expect(initFetch).not.toHaveBeenCalled();
+  });
+
+  it("creates the D1 session index before initializing the SessionDO", async () => {
+    const create = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(SessionIndexStore).mockImplementation(() => ({ create }) as never);
+
+    const initFetch = vi.fn(async (request: Request) => {
+      expect(new URL(request.url).pathname).toBe(SessionInternalPaths.init);
+      return Response.json({ status: "created" });
+    });
+
+    const response = await createSessionRequest(createEnv(initFetch));
+
+    expect(response.status).toBe(201);
+    expect(create).toHaveBeenCalledOnce();
+    expect(initFetch).toHaveBeenCalledOnce();
+    expect(create.mock.invocationCallOrder[0]).toBeLessThan(initFetch.mock.invocationCallOrder[0]);
+  });
+});

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -881,6 +881,26 @@ async function handleCreateSession(
     resolveSandboxSettings(env.DB, repoOwner, repoName),
   ]);
 
+  // Store session in D1 before initializing the SessionDO. SessionDO init starts
+  // sandbox warming, so D1 failures must fail before any sandbox can be spawned.
+  const now = Date.now();
+  const sessionStore = new SessionIndexStore(env.DB);
+  await sessionStore.create({
+    id: sessionId,
+    title: body.title || null,
+    repoOwner,
+    repoName,
+    model,
+    reasoningEffort,
+    baseBranch: body.branch || defaultBranch || "main",
+    status: "created",
+    spawnSource: body.spawnSource,
+    scmLogin: scmLogin || null,
+    userId: resolvedUserId,
+    createdAt: now,
+    updatedAt: now,
+  });
+
   // Initialize session with user info and optional encrypted token
   const initResponse = await stub.fetch(
     internalRequest(
@@ -937,25 +957,6 @@ async function handleCreateSession(
         )
     );
   }
-
-  // Store session in D1 index for listing
-  const now = Date.now();
-  const sessionStore = new SessionIndexStore(env.DB);
-  await sessionStore.create({
-    id: sessionId,
-    title: body.title || null,
-    repoOwner,
-    repoName,
-    model,
-    reasoningEffort,
-    baseBranch: body.branch || defaultBranch || "main",
-    status: "created",
-    spawnSource: body.spawnSource,
-    scmLogin: scmLogin || null,
-    userId: resolvedUserId,
-    createdAt: now,
-    updatedAt: now,
-  });
 
   const result: CreateSessionResponse = {
     sessionId,


### PR DESCRIPTION
## Summary

Moves the `POST /sessions` D1 session-index write before SessionDO initialization. SessionDO init starts sandbox warming, so this makes D1 failures fail before any sandbox can be spawned.

Adds a focused router regression test proving that a D1 session-index failure does not call `/internal/init`, and that successful creates write D1 before initializing the SessionDO.

## Why

During D1 stalls, the previous order could initialize a SessionDO and start sandbox warming before the caller received a `sessionId`. Bot flows send prompts in a second request after `POST /sessions` returns, so if the D1 write stalled or failed after DO init, a sandbox could boot without ever receiving the prompt.

## Validation

- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/control-plane -- router.create-session.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite for session creation flow, verifying correct error handling and request sequencing.

* **Bug Fixes**
  * Updated session creation to validate database persistence before initializing the session backend, ensuring database failures are caught earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->