### PR TITLE
fix: include sandbox id in session logs

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -232,7 +232,7 @@ export class SandboxLifecycleManager {
   private isSpawningSandbox = false;
 
   /** Session-scoped logger. Falls back to module-level logger if no sessionId configured. */
-  private readonly log: Logger;
+  private log: Logger;
 
   constructor(
     private readonly provider: SandboxProvider,
@@ -246,6 +246,10 @@ export class SandboxLifecycleManager {
     private readonly repoImageLookup?: RepoImageLookup
   ) {
     this.log = config.sessionId ? log.child({ session_id: config.sessionId }) : log;
+  }
+
+  setLog(log: Logger): void {
+    this.log = log;
   }
 
   /**

--- a/packages/control-plane/src/session/callback-notification-service.ts
+++ b/packages/control-plane/src/session/callback-notification-service.ts
@@ -44,7 +44,7 @@ export interface CallbackServiceDeps {
 export class CallbackNotificationService {
   private readonly repository: CallbackRepository;
   private readonly env: CallbackServiceEnv;
-  private readonly log: Logger;
+  private log: Logger;
   private readonly getSessionId: () => string;
   private _lastToolCallCallbackTs = 0;
 
@@ -53,6 +53,10 @@ export class CallbackNotificationService {
     this.env = deps.env;
     this.log = deps.log;
     this.getSessionId = deps.getSessionId;
+  }
+
+  setLog(log: Logger): void {
+    this.log = log;
   }
 
   /**

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -114,6 +114,7 @@ export class SessionDO extends DurableObject<Env> {
   private repository: SessionRepository;
   private initialized = false;
   private log: Logger;
+  private loggerSandboxId: string | null = null;
   // WebSocket manager (lazily initialized like lifecycleManager)
   private _wsManager: SessionWebSocketManager | null = null;
   // Lifecycle manager (lazily initialized)
@@ -759,12 +760,22 @@ export class SessionDO extends DurableObject<Env> {
     this.initialized = true;
     const session = this.repository.getSession();
     const sessionId = session?.session_name || session?.id || this.ctx.id.toString();
-    this.log = createLogger(
-      "session-do",
-      { session_id: sessionId },
-      parseLogLevel(this.env.LOG_LEVEL)
-    );
+    const sandboxId = this.repository.getSandbox()?.modal_sandbox_id ?? null;
+    const logContext: Record<string, unknown> = { session_id: sessionId };
+    if (sandboxId) {
+      logContext.sandbox_id = sandboxId;
+      this.loggerSandboxId = sandboxId;
+    }
+    this.log = createLogger("session-do", logContext, parseLogLevel(this.env.LOG_LEVEL));
     this.wsManager.enableAutoPingPong();
+  }
+
+  private refreshLoggerSandboxId(): void {
+    const sandboxId = this.repository.getSandbox()?.modal_sandbox_id ?? null;
+    if (!sandboxId || sandboxId === this.loggerSandboxId) return;
+
+    this.log = this.log.child({ sandbox_id: sandboxId });
+    this.loggerSandboxId = sandboxId;
   }
 
   /**
@@ -777,6 +788,7 @@ export class SessionDO extends DurableObject<Env> {
     const initMs = performance.now() - fetchStart;
 
     const originalLogger = this.log;
+    const originalLoggerSandboxId = this.loggerSandboxId;
 
     // Extract correlation headers and create a request-scoped logger
     const traceId = request.headers.get("x-trace-id");
@@ -831,7 +843,10 @@ export class SessionDO extends DurableObject<Env> {
 
       return new Response("Not Found", { status: 404 });
     } finally {
-      this.log = originalLogger;
+      this.log =
+        this.loggerSandboxId && this.loggerSandboxId !== originalLoggerSandboxId
+          ? originalLogger.child({ sandbox_id: this.loggerSandboxId })
+          : originalLogger;
     }
   }
 
@@ -914,6 +929,7 @@ export class SessionDO extends DurableObject<Env> {
         // Notify manager that sandbox connected so it can reset the spawning flag
         this.lifecycleManager.onSandboxConnected();
         this.updateSandboxStatus("ready");
+        this.refreshLoggerSandboxId();
         this.broadcast({ type: "sandbox_status", status: "ready" });
 
         // Set initial activity timestamp and schedule inactivity check
@@ -1411,6 +1427,7 @@ export class SessionDO extends DurableObject<Env> {
    */
   private async spawnSandbox(): Promise<void> {
     await this.lifecycleManager.spawnSandbox();
+    this.refreshLoggerSandboxId();
   }
 
   /**

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -729,7 +729,7 @@ export class SessionDO extends DurableObject<Env> {
       };
     }
 
-    return new SandboxLifecycleManager(
+    const manager = new SandboxLifecycleManager(
       provider,
       storage,
       broadcaster,
@@ -742,6 +742,8 @@ export class SessionDO extends DurableObject<Env> {
       },
       repoImageLookup
     );
+    manager.setLog(this.log);
+    return manager;
   }
 
   /**
@@ -776,6 +778,16 @@ export class SessionDO extends DurableObject<Env> {
 
     this.log = this.log.child({ sandbox_id: sandboxId });
     this.loggerSandboxId = sandboxId;
+    this.rebindLoggerConsumers();
+  }
+
+  private rebindLoggerConsumers(): void {
+    this._wsManager?.setLog(this.log);
+    this._lifecycleManager?.setLog(this.log);
+    this._participantService?.setLog(this.log);
+    this._callbackService?.setLog(this.log);
+    this._messageQueue?.setLog(this.log);
+    this._sandboxEventProcessor?.setLog(this.log);
   }
 
   /**
@@ -843,10 +855,14 @@ export class SessionDO extends DurableObject<Env> {
 
       return new Response("Not Found", { status: 404 });
     } finally {
-      this.log =
+      const restoredLogger =
         this.loggerSandboxId && this.loggerSandboxId !== originalLoggerSandboxId
           ? originalLogger.child({ sandbox_id: this.loggerSandboxId })
           : originalLogger;
+      this.log = restoredLogger;
+      if (traceId || requestId || this.loggerSandboxId !== originalLoggerSandboxId) {
+        this.rebindLoggerConsumers();
+      }
     }
   }
 

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -57,6 +57,10 @@ interface StopExecutionOptions {
 export class SessionMessageQueue {
   constructor(private readonly deps: MessageQueueDeps) {}
 
+  setLog(log: Logger): void {
+    this.deps.log = log;
+  }
+
   async handlePromptMessage(ws: WebSocket, data: PromptMessageData): Promise<void> {
     const client = this.deps.getClientInfo(ws);
     if (!client) {

--- a/packages/control-plane/src/session/participant-service.ts
+++ b/packages/control-plane/src/session/participant-service.ts
@@ -69,7 +69,7 @@ export function getAvatarUrl(
 export class ParticipantService {
   private readonly repository: ParticipantRepository;
   private readonly env: ParticipantServiceEnv;
-  private readonly log: Logger;
+  private log: Logger;
   private readonly generateId: () => string;
   private readonly userScmTokenStore: UserScmTokenStore | null;
 
@@ -79,6 +79,10 @@ export class ParticipantService {
     this.log = deps.log;
     this.generateId = deps.generateId;
     this.userScmTokenStore = deps.userScmTokenStore ?? null;
+  }
+
+  setLog(log: Logger): void {
+    this.log = log;
   }
 
   /**

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -42,10 +42,12 @@ export class SessionSandboxEventProcessor {
   constructor(private readonly deps: SessionSandboxEventProcessorDeps) {}
 
   async processSandboxEvent(event: SandboxEventWithAck): Promise<void> {
+    const sandboxId = "sandboxId" in event ? event.sandboxId : undefined;
+
     if (event.type === "heartbeat" || event.type === "token") {
-      this.deps.log.debug("Sandbox event", { event_type: event.type });
+      this.deps.log.debug("Sandbox event", { event_type: event.type, sandbox_id: sandboxId });
     } else if (event.type !== "execution_complete") {
-      this.deps.log.info("Sandbox event", { event_type: event.type });
+      this.deps.log.info("Sandbox event", { event_type: event.type, sandbox_id: sandboxId });
     }
     const now = Date.now();
 
@@ -143,6 +145,7 @@ export class SessionSandboxEventProcessor {
           this.deps.callbackService.notifyToolCall(messageId, event).catch((error) => {
             this.deps.log.error("callback.tool_call.background_error", {
               message_id: messageId,
+              sandbox_id: sandboxId,
               error,
             });
           })
@@ -188,6 +191,7 @@ export class SessionSandboxEventProcessor {
         this.deps.log.info("prompt.complete", {
           event: "prompt.complete",
           message_id: completionMessageId,
+          sandbox_id: sandboxId,
           outcome: event.success ? "success" : "failure",
           message_status: status,
           total_duration_ms: totalDurationMs,
@@ -209,6 +213,7 @@ export class SessionSandboxEventProcessor {
         this.deps.log.info("prompt.complete", {
           event: "prompt.complete",
           message_id: completionMessageId,
+          sandbox_id: sandboxId,
           outcome: "already_stopped",
         });
       }

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -41,6 +41,10 @@ export class SessionSandboxEventProcessor {
 
   constructor(private readonly deps: SessionSandboxEventProcessorDeps) {}
 
+  setLog(log: Logger): void {
+    this.deps.log = log;
+  }
+
   async processSandboxEvent(event: SandboxEventWithAck): Promise<void> {
     const sandboxId = "sandboxId" in event ? event.sandboxId : undefined;
 

--- a/packages/control-plane/src/session/websocket-manager.ts
+++ b/packages/control-plane/src/session/websocket-manager.ts
@@ -32,6 +32,9 @@ export interface WebSocketManagerConfig {
 // ---------------------------------------------------------------------------
 
 export interface SessionWebSocketManager {
+  /** Replace the logger used by this long-lived manager. */
+  setLog(log: Logger): void;
+
   /** Accept a client WebSocket with a wsId tag for hibernation recovery. */
   acceptClientSocket(ws: WebSocket, wsId: string): void;
 
@@ -94,9 +97,13 @@ export class SessionWebSocketManagerImpl implements SessionWebSocketManager {
   constructor(
     private readonly ctx: DurableObjectState,
     private readonly repository: SessionRepository,
-    private readonly log: Logger,
+    private log: Logger,
     private readonly config: WebSocketManagerConfig
   ) {}
+
+  setLog(log: Logger): void {
+    this.log = log;
+  }
 
   // -------------------------------------------------------------------------
   // Accept


### PR DESCRIPTION
## Summary
- Add `sandbox_id` to the session Durable Object logger context when an existing sandbox row is available during initialization.
- Refresh the DO logger context after sandbox spawn and sandbox WebSocket connect so subsequent logs include the Modal sandbox ID.
- Include `sandbox_id` directly on sandbox event, prompt completion, and callback background error logs.

## Tests
- `npm test -w @open-inspect/control-plane -- sandbox-events`
- `npm run typecheck -w @open-inspect/control-plane`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/847e398a5368f30c3d4e0fa32da0ad51)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced logging so sandbox identifiers are consistently attached to session requests and sandbox events for improved correlation and observability.
  * Logging can now be updated at runtime across session components, ensuring logs reflect current sandbox context throughout request handling and event processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->