### PR TITLE
fix: add error toasts and failure test for sidebar archive

### DIFF
--- a/packages/web/src/components/archive-session-dialog.tsx
+++ b/packages/web/src/components/archive-session-dialog.tsx
@@ -14,7 +14,7 @@ import {
 interface ArchiveSessionDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onConfirm: () => void | Promise<void>;
+  onConfirm: () => void;
 }
 
 export function ArchiveSessionDialog({ open, onOpenChange, onConfirm }: ArchiveSessionDialogProps) {

--- a/packages/web/src/components/session-sidebar.test.tsx
+++ b/packages/web/src/components/session-sidebar.test.tsx
@@ -256,4 +256,47 @@ describe("SessionSidebar", () => {
       expect(fetchMock).toHaveBeenCalledWith("/api/sessions/session-1/archive", { method: "POST" });
     });
   });
+
+  it("keeps the session in the sidebar when archiving fails", async () => {
+    mockUseIsMobile.mockReturnValue(true);
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === "/api/sessions/session-1/archive" && init?.method === "POST") {
+        return new Response(null, { status: 500 });
+      }
+
+      throw new Error(`Unexpected fetch for ${String(input)}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <SWRConfig
+        value={{
+          fallback: { [SIDEBAR_SESSIONS_KEY]: { sessions: [createSession(1)], hasMore: false } },
+          dedupingInterval: 0,
+          revalidateOnFocus: false,
+        }}
+      >
+        <SessionSidebar />
+      </SWRConfig>
+    );
+
+    const link = await screen.findByRole("link", { name: /session 1/i });
+    vi.useFakeTimers();
+    fireEvent.touchStart(link, { touches: [{ clientX: 20, clientY: 20 }] });
+    act(() => {
+      vi.advanceTimersByTime(MOBILE_LONG_PRESS_MS);
+    });
+    vi.useRealTimers();
+
+    fireEvent.click(screen.getByText("Archive"));
+    fireEvent.click(await screen.findByRole("button", { name: "Archive" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/sessions/session-1/archive", { method: "POST" });
+    });
+
+    expect(screen.getByRole("link", { name: /session 1/i })).toBeInTheDocument();
+  });
 });

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -222,6 +222,8 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
 
   const handleSessionArchived = useCallback(
     async (sessionId: string) => {
+      // First-page sessions are removed from the SWR cache by archiveSession() itself.
+      // Extra sessions (loaded via pagination) are managed in local state.
       setExtraSessions((prev) => prev.filter((session) => session.id !== sessionId));
 
       if (currentSessionId === sessionId) {

--- a/packages/web/src/lib/archive-session.ts
+++ b/packages/web/src/lib/archive-session.ts
@@ -1,4 +1,5 @@
 import { mutate } from "swr";
+import { toast } from "sonner";
 import {
   removeSessionFromList,
   SIDEBAR_SESSIONS_KEY,
@@ -34,14 +35,14 @@ export async function archiveSession(sessionId: string): Promise<boolean> {
   try {
     const response = await fetch(`/api/sessions/${sessionId}/archive`, { method: "POST" });
     if (!response.ok) {
-      console.error("Failed to archive session");
+      toast.error("Failed to archive session");
       return false;
     }
 
     await removeSessionFromSidebarCache(sessionId);
     return true;
-  } catch (error) {
-    console.error("Failed to archive session:", { sessionId, error });
+  } catch {
+    toast.error("Failed to archive session");
     return false;
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #570. Addresses review feedback:

- **Error toasts**: Replace silent `console.error` calls in `archiveSession()` with `toast.error()` so users see feedback when archiving fails
- **Failure-path test**: Add test that verifies the session stays in the sidebar when the archive API returns 500
- **Clarifying comment**: Document the split cache responsibility in `handleSessionArchived` (SWR cache vs local `extraSessions` state)
- **Type narrowing**: Change `ArchiveSessionDialog.onConfirm` from `() => void | Promise<void>` to `() => void` since the dialog never awaits it

## Test plan

- [x] `npm test -w @open-inspect/web` — 192 tests pass (including new failure-path test)
- [x] `npm run typecheck -w @open-inspect/web` — clean
- [x] `npm run lint -w @open-inspect/web` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error notifications when session archiving fails, now displaying user-friendly messages instead of silent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->