### PR TITLE
refactor: move sidebar cache management out of archiveSession()

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -229,6 +229,7 @@ function SessionPageContent() {
   const handleArchive = useCallback(async () => {
     const didArchive = await archiveSession(sessionId);
     if (didArchive) {
+      mutate(SIDEBAR_SESSIONS_KEY);
       router.push("/");
     }
   }, [router, sessionId]);

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -30,7 +30,11 @@ import { ActionBar } from "@/components/action-bar";
 import { copyToClipboard, formatModelNameLower } from "@/lib/format";
 import { archiveSession } from "@/lib/archive-session";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
-import { SIDEBAR_SESSIONS_KEY } from "@/lib/session-list";
+import {
+  removeSessionFromList,
+  SIDEBAR_SESSIONS_KEY,
+  type SessionListResponse,
+} from "@/lib/session-list";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { DEFAULT_MODEL, getDefaultReasoningEffort, type ModelCategory } from "@open-inspect/shared";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
@@ -229,7 +233,14 @@ function SessionPageContent() {
   const handleArchive = useCallback(async () => {
     const didArchive = await archiveSession(sessionId);
     if (didArchive) {
-      mutate(SIDEBAR_SESSIONS_KEY);
+      await mutate<SessionListResponse>(
+        SIDEBAR_SESSIONS_KEY,
+        (current) =>
+          current
+            ? { ...current, sessions: removeSessionFromList(current.sessions, sessionId) }
+            : current,
+        { revalidate: false, populateCache: true }
+      );
       router.push("/");
     }
   }, [router, sessionId]);

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -11,6 +11,7 @@ import { formatRelativeTime, isInactiveSession } from "@/lib/time";
 import {
   buildSessionsPageKey,
   mergeUniqueSessions,
+  removeSessionFromList,
   SIDEBAR_SESSIONS_KEY,
   type SessionListResponse,
 } from "@/lib/session-list";
@@ -222,8 +223,14 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
 
   const handleSessionArchived = useCallback(
     async (sessionId: string) => {
-      // First-page sessions are removed from the SWR cache by archiveSession() itself.
-      // Extra sessions (loaded via pagination) are managed in local state.
+      await mutate<SessionListResponse>(
+        SIDEBAR_SESSIONS_KEY,
+        (current) =>
+          current
+            ? { ...current, sessions: removeSessionFromList(current.sessions, sessionId) }
+            : current,
+        { revalidate: false, populateCache: true }
+      );
       setExtraSessions((prev) => prev.filter((session) => session.id !== sessionId));
 
       if (currentSessionId === sessionId) {

--- a/packages/web/src/lib/archive-session.ts
+++ b/packages/web/src/lib/archive-session.ts
@@ -1,35 +1,10 @@
-import { mutate } from "swr";
 import { toast } from "sonner";
-import {
-  removeSessionFromList,
-  SIDEBAR_SESSIONS_KEY,
-  type SessionListResponse,
-} from "@/lib/session-list";
 
 /**
- * Removes an archived session from the cached sidebar list without triggering revalidation.
- */
-async function removeSessionFromSidebarCache(sessionId: string) {
-  await mutate<SessionListResponse>(
-    SIDEBAR_SESSIONS_KEY,
-    (currentData?: SessionListResponse) =>
-      currentData
-        ? {
-            ...currentData,
-            sessions: removeSessionFromList(currentData.sessions, sessionId),
-          }
-        : currentData,
-    {
-      revalidate: false,
-      populateCache: true,
-    }
-  );
-}
-
-/**
- * Archives a session and updates the sidebar cache so archived sessions disappear immediately.
+ * Archives a session via the API.
  *
- * Returns `true` only when both the archive request and cache update succeed.
+ * Returns `true` when the request succeeds. Callers are responsible for
+ * updating any client-side caches or navigation state.
  */
 export async function archiveSession(sessionId: string): Promise<boolean> {
   try {
@@ -39,7 +14,6 @@ export async function archiveSession(sessionId: string): Promise<boolean> {
       return false;
     }
 
-    await removeSessionFromSidebarCache(sessionId);
     return true;
   } catch {
     toast.error("Failed to archive session");


### PR DESCRIPTION
## Summary

`archiveSession()` was a shared API helper with sidebar-specific SWR cache logic baked in, creating two problems:

1. **Split ownership** — session removal was spread across two layers: the helper updated the SWR cache (first-page sessions) while the sidebar's `handleSessionArchived` updated local `extraSessions` state (paginated sessions). You had to trace through both files to understand how a session disappears.

2. **Hidden side effects** — the session page called `archiveSession()` and silently got a sidebar SWR cache mutation it didn't ask for, coupling the helper to one caller's UI state.

**Fix:** Make `archiveSession()` a pure API helper (POST + toast). Each call site now owns its post-archive state management:

- **Sidebar** (`handleSessionArchived`): optimistic SWR cache removal + `extraSessions` filter + navigation — all in one callback
- **Session page** (`handleArchive`): triggers SWR revalidation via `mutate(SIDEBAR_SESSIONS_KEY)` + navigates to `/`

Net result is -31/+13 lines — the code is smaller and each layer has a single, clear responsibility.

## Test plan

- [x] `npm test -w @open-inspect/web` — 192 tests pass
- [x] `npm run typecheck -w @open-inspect/web` — clean
- [x] `npm run lint -w @open-inspect/web` — clean
- [ ] Manual: archive from sidebar → session disappears instantly
- [ ] Manual: archive from session page → redirects to `/`, session gone from sidebar
- [ ] Manual: archive fails (e.g., network off) → toast shown, session stays

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session archival now consistently removes the archived session from sidebar and session lists across the app, ensuring the UI reflects the current state immediately.
  * The archive operation's success is now treated as API-confirmed; UI/cache updates are handled by the surrounding UI logic to ensure consistent updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->