### PR TITLE
fix: enrich bot session participants with linked GitHub identity

### DIFF
--- a/packages/control-plane/src/db/user-scm-tokens.test.ts
+++ b/packages/control-plane/src/db/user-scm-tokens.test.ts
@@ -292,6 +292,25 @@ describe("UserScmTokenStore", () => {
     expect(result).toBeNull();
   });
 
+  it("getEncryptedTokens returns raw ciphertext without decrypting", async () => {
+    const expiresAt = Date.now() + 3600_000;
+    await store.upsertTokens("user-enc", "access-plain", "refresh-plain", expiresAt);
+
+    const encrypted = await store.getEncryptedTokens("user-enc");
+    expect(encrypted).not.toBeNull();
+    expect(encrypted!.expiresAt).toBe(expiresAt);
+    // Values should be ciphertext, not the original plaintext
+    expect(encrypted!.accessTokenEncrypted).toBeTypeOf("string");
+    expect(encrypted!.accessTokenEncrypted).not.toBe("access-plain");
+    expect(encrypted!.refreshTokenEncrypted).toBeTypeOf("string");
+    expect(encrypted!.refreshTokenEncrypted).not.toBe("refresh-plain");
+  });
+
+  it("getEncryptedTokens returns null for unknown user", async () => {
+    const result = await store.getEncryptedTokens("nonexistent");
+    expect(result).toBeNull();
+  });
+
   describe("isTokenFresh", () => {
     it("returns true when token expires well in the future", () => {
       expect(store.isTokenFresh(Date.now() + 120_000)).toBe(true);

--- a/packages/control-plane/src/db/user-scm-tokens.ts
+++ b/packages/control-plane/src/db/user-scm-tokens.ts
@@ -11,6 +11,12 @@ export interface ScmTokenRecord {
   refreshTokenEncrypted: string;
 }
 
+export interface EncryptedScmTokenRecord {
+  accessTokenEncrypted: string;
+  refreshTokenEncrypted: string;
+  expiresAt: number;
+}
+
 export type CasResult = { ok: true } | { ok: false; reason: "cas_conflict" };
 
 export class UserScmTokenStore {
@@ -18,6 +24,27 @@ export class UserScmTokenStore {
     private readonly db: D1Database,
     private readonly encryptionKey: string
   ) {}
+
+  async getEncryptedTokens(providerUserId: string): Promise<EncryptedScmTokenRecord | null> {
+    const row = await this.db
+      .prepare(
+        "SELECT access_token_encrypted, refresh_token_encrypted, token_expires_at FROM user_scm_tokens WHERE provider_user_id = ?"
+      )
+      .bind(providerUserId)
+      .first<{
+        access_token_encrypted: string;
+        refresh_token_encrypted: string;
+        token_expires_at: number;
+      }>();
+
+    if (!row) return null;
+
+    return {
+      accessTokenEncrypted: row.access_token_encrypted,
+      refreshTokenEncrypted: row.refresh_token_encrypted,
+      expiresAt: row.token_expires_at,
+    };
+  }
 
   async getTokens(providerUserId: string): Promise<ScmTokenRecord | null> {
     const row = await this.db

--- a/packages/control-plane/src/router.identity.test.ts
+++ b/packages/control-plane/src/router.identity.test.ts
@@ -41,9 +41,13 @@ describe("parseAuthorId", () => {
 });
 
 describe("deriveUserId", () => {
-  it("returns explicit userId when provided", () => {
+  it("returns explicit userId for non-bot spawnSource", () => {
+    expect(deriveUserId({ userId: "user-abc", spawnSource: "user" })).toBe("user-abc");
+  });
+
+  it("ignores explicit userId for bot spawnSource and derives from identity fields", () => {
     expect(deriveUserId({ userId: "user-abc", spawnSource: "github-bot", scmUserId: "1001" })).toBe(
-      "user-abc"
+      "github:1001"
     );
   });
 

--- a/packages/control-plane/src/router.identity.test.ts
+++ b/packages/control-plane/src/router.identity.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { deriveUserId, parseAuthorId } from "./router";
+
+describe("parseAuthorId", () => {
+  it("parses github authorId", () => {
+    expect(parseAuthorId("github:1001")).toEqual({
+      provider: "github",
+      providerUserId: "1001",
+    });
+  });
+
+  it("parses slack authorId", () => {
+    expect(parseAuthorId("slack:U123ABC")).toEqual({
+      provider: "slack",
+      providerUserId: "U123ABC",
+    });
+  });
+
+  it("parses linear authorId", () => {
+    expect(parseAuthorId("linear:abc-def")).toEqual({
+      provider: "linear",
+      providerUserId: "abc-def",
+    });
+  });
+
+  it("returns null for plain user ID (web client)", () => {
+    expect(parseAuthorId("user-id-123")).toBeNull();
+  });
+
+  it("returns null for 'anonymous'", () => {
+    expect(parseAuthorId("anonymous")).toBeNull();
+  });
+
+  it("returns null for unknown provider prefix", () => {
+    expect(parseAuthorId("unknown:12345")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseAuthorId("")).toBeNull();
+  });
+});
+
+describe("deriveUserId", () => {
+  it("returns explicit userId when provided", () => {
+    expect(deriveUserId({ userId: "user-abc", spawnSource: "github-bot", scmUserId: "1001" })).toBe(
+      "user-abc"
+    );
+  });
+
+  it("derives github-bot userId from scmUserId", () => {
+    expect(deriveUserId({ spawnSource: "github-bot", scmUserId: "1001" })).toBe("github:1001");
+  });
+
+  it("derives slack-bot userId from actorUserId", () => {
+    expect(deriveUserId({ spawnSource: "slack-bot", actorUserId: "U123" })).toBe("slack:U123");
+  });
+
+  it("derives linear-bot userId from actorUserId", () => {
+    expect(deriveUserId({ spawnSource: "linear-bot", actorUserId: "lin-abc" })).toBe(
+      "linear:lin-abc"
+    );
+  });
+
+  it("falls back to anonymous for github-bot without scmUserId", () => {
+    expect(deriveUserId({ spawnSource: "github-bot" })).toBe("anonymous");
+  });
+
+  it("falls back to anonymous for slack-bot without actorUserId", () => {
+    expect(deriveUserId({ spawnSource: "slack-bot" })).toBe("anonymous");
+  });
+
+  it("falls back to anonymous for linear-bot without actorUserId", () => {
+    expect(deriveUserId({ spawnSource: "linear-bot" })).toBe("anonymous");
+  });
+
+  it("falls back to anonymous for unknown spawnSource", () => {
+    expect(deriveUserId({ spawnSource: "user" })).toBe("anonymous");
+  });
+
+  it("falls back to anonymous when no fields provided", () => {
+    expect(deriveUserId({})).toBe("anonymous");
+  });
+});

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -793,8 +793,6 @@ export function deriveUserId(body: {
   scmUserId?: string;
   actorUserId?: string;
 }): string {
-  if (body.userId) return body.userId;
-
   switch (body.spawnSource) {
     case "github-bot":
       return body.scmUserId ? `github:${body.scmUserId}` : "anonymous";
@@ -803,7 +801,7 @@ export function deriveUserId(body: {
     case "linear-bot":
       return body.actorUserId ? `linear:${body.actorUserId}` : "anonymous";
     default:
-      return "anonymous";
+      return body.userId || "anonymous";
   }
 }
 

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -770,6 +770,93 @@ function resolveProviderIdentity(
   }
 }
 
+/**
+ * Parse a bot-format authorId into provider + providerUserId.
+ * Returns null for web client authorIds (plain user IDs without a prefix).
+ */
+export function parseAuthorId(
+  authorId: string
+): { provider: string; providerUserId: string } | null {
+  const match = authorId.match(/^(github|slack|linear):(.+)$/);
+  if (!match) return null;
+  return { provider: match[1], providerUserId: match[2] };
+}
+
+/**
+ * Construct a canonical userId from the bot's identity fields, matching the
+ * format each bot uses for prompt `authorId`. This ensures the owner
+ * participant created at init is findable when the bot later sends a prompt.
+ */
+export function deriveUserId(body: {
+  userId?: string;
+  spawnSource?: SpawnSource;
+  scmUserId?: string;
+  actorUserId?: string;
+}): string {
+  if (body.userId) return body.userId;
+
+  switch (body.spawnSource) {
+    case "github-bot":
+      return body.scmUserId ? `github:${body.scmUserId}` : "anonymous";
+    case "slack-bot":
+      return body.actorUserId ? `slack:${body.actorUserId}` : "anonymous";
+    case "linear-bot":
+      return body.actorUserId ? `linear:${body.actorUserId}` : "anonymous";
+    default:
+      return "anonymous";
+  }
+}
+
+interface GitHubEnrichment {
+  scmUserId: string;
+  scmLogin?: string;
+  displayName?: string;
+  email?: string;
+  accessTokenEncrypted?: string;
+  refreshTokenEncrypted?: string;
+  tokenExpiresAt?: number;
+}
+
+/**
+ * Given a resolved D1 user, find their linked GitHub identity and return
+ * enrichment data (display name, email, OAuth tokens). Returns null if no
+ * GitHub identity is linked. Parallelizes independent D1 lookups.
+ */
+async function resolveGitHubEnrichment(
+  env: Env,
+  userStore: UserStore,
+  userId: string
+): Promise<GitHubEnrichment | null> {
+  const identities = await userStore.getIdentitiesForUser(userId);
+  const githubIdentity = identities.find((i) => i.provider === "github");
+  if (!githubIdentity) return null;
+
+  const [user, tokens] = await Promise.all([
+    userStore.getUserById(userId),
+    env.TOKEN_ENCRYPTION_KEY
+      ? new UserScmTokenStore(env.DB, env.TOKEN_ENCRYPTION_KEY).getEncryptedTokens(
+          githubIdentity.providerUserId
+        )
+      : null,
+  ]);
+
+  const email =
+    githubIdentity.providerEmail ??
+    (githubIdentity.providerLogin
+      ? `${githubIdentity.providerUserId}+${githubIdentity.providerLogin}@users.noreply.github.com`
+      : undefined);
+
+  return {
+    scmUserId: githubIdentity.providerUserId,
+    scmLogin: githubIdentity.providerLogin ?? undefined,
+    displayName: user?.displayName ?? githubIdentity.providerLogin ?? undefined,
+    email,
+    accessTokenEncrypted: tokens?.accessTokenEncrypted,
+    refreshTokenEncrypted: tokens?.refreshTokenEncrypted,
+    tokenExpiresAt: tokens?.expiresAt,
+  };
+}
+
 async function handleCreateSession(
   request: Request,
   env: Env,
@@ -810,15 +897,15 @@ async function handleCreateSession(
 
   const { repoId, defaultBranch } = resolved;
 
-  const userId = body.userId || "anonymous";
+  const userId = deriveUserId(body);
 
   // Resolve canonical user model ID (for D1 session index).
   // Best-effort: if resolution fails, the session is created without a user_id.
+  const userStore = new UserStore(env.DB);
   let resolvedUserId: string | null = null;
   const providerIdentity = resolveProviderIdentity(body.spawnSource ?? "user", body);
   if (providerIdentity) {
     try {
-      const userStore = new UserStore(env.DB);
       const resolvedUser = await userStore.resolveOrCreateUser(providerIdentity);
       resolvedUserId = resolvedUser.id;
     } catch (e) {
@@ -829,13 +916,13 @@ async function handleCreateSession(
     }
   }
 
-  const scmLogin = body.scmLogin;
-  const scmName = body.scmName;
-  const scmEmail = body.scmEmail;
+  let scmLogin = body.scmLogin;
+  let scmName = body.scmName;
+  let scmEmail = body.scmEmail;
   const scmToken = body.scmToken;
   const scmRefreshToken = body.scmRefreshToken;
-  const scmTokenExpiresAt = body.scmTokenExpiresAt;
-  const scmUserId = body.scmUserId;
+  let scmTokenExpiresAt = body.scmTokenExpiresAt;
+  let scmUserId = body.scmUserId;
   let scmTokenEncrypted: string | null = null;
   let scmRefreshTokenEncrypted: string | null = null;
 
@@ -856,6 +943,29 @@ async function handleCreateSession(
       scmRefreshTokenEncrypted = await encryptToken(scmRefreshToken, env.TOKEN_ENCRYPTION_KEY);
     } catch (e) {
       logger.warn("Session created without refresh token — token refresh will be unavailable", {
+        error: e instanceof Error ? e : String(e),
+      });
+    }
+  }
+
+  // Enrich owner participant with linked GitHub identity from D1.
+  // Fills in SCM fields the bot didn't provide (email, display name, OAuth tokens).
+  if (resolvedUserId) {
+    try {
+      const enrichment = await resolveGitHubEnrichment(env, userStore, resolvedUserId);
+      if (enrichment) {
+        scmUserId ??= enrichment.scmUserId;
+        scmLogin ??= enrichment.scmLogin;
+        scmName ??= enrichment.displayName;
+        scmEmail ??= enrichment.email;
+        if (!scmTokenEncrypted) {
+          scmTokenEncrypted = enrichment.accessTokenEncrypted ?? null;
+          scmRefreshTokenEncrypted = enrichment.refreshTokenEncrypted ?? null;
+          scmTokenExpiresAt = enrichment.tokenExpiresAt;
+        }
+      }
+    } catch (e) {
+      logger.warn("Failed to enrich session with GitHub identity", {
         error: e instanceof Error ? e : String(e),
       });
     }
@@ -1031,6 +1141,27 @@ async function handleSessionPrompt(
     return error("content is required");
   }
 
+  const authorId = body.authorId || "anonymous";
+
+  // Enrich bot-originated prompts with linked GitHub identity from D1.
+  // Web client authorIds have no provider prefix — parseAuthorId returns null, skipping this.
+  let enrichment: GitHubEnrichment | undefined;
+  const parsed = parseAuthorId(authorId);
+  if (parsed) {
+    try {
+      const userStore = new UserStore(env.DB);
+      const identity = await userStore.getIdentity(parsed.provider, parsed.providerUserId);
+      if (identity) {
+        enrichment = (await resolveGitHubEnrichment(env, userStore, identity.userId)) ?? undefined;
+      }
+    } catch (e) {
+      logger.warn("Failed to enrich prompt with GitHub identity", {
+        error: e instanceof Error ? e : String(e),
+        authorId,
+      });
+    }
+  }
+
   const doId = env.SESSION.idFromName(sessionId);
   const stub = env.SESSION.get(doId);
 
@@ -1042,12 +1173,19 @@ async function handleSessionPrompt(
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           content: body.content,
-          authorId: body.authorId || "anonymous",
+          authorId,
           source: body.source || "web",
           model: body.model,
           reasoningEffort: body.reasoningEffort,
           attachments: body.attachments,
           callbackContext: body.callbackContext,
+          authorDisplayName: enrichment?.displayName,
+          authorEmail: enrichment?.email,
+          authorLogin: enrichment?.scmLogin,
+          scmUserId: enrichment?.scmUserId,
+          scmAccessTokenEncrypted: enrichment?.accessTokenEncrypted,
+          scmRefreshTokenEncrypted: enrichment?.refreshTokenEncrypted,
+          scmTokenExpiresAt: enrichment?.tokenExpiresAt,
         }),
       },
       ctx

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -258,10 +258,10 @@ describe("SessionMessageQueue", () => {
         content: "Fix bug",
         authorId: "github:1001",
         source: "github-bot",
-        authorDisplayName: "Cole Murray",
+        authorDisplayName: "Octo Cat",
       });
 
-      expect(h.participantService.create).toHaveBeenCalledWith("github:1001", "Cole Murray");
+      expect(h.participantService.create).toHaveBeenCalledWith("github:1001", "Octo Cat");
     });
 
     it("uses authorId as display name when authorDisplayName is missing", async () => {
@@ -284,9 +284,9 @@ describe("SessionMessageQueue", () => {
         content: "Fix bug",
         authorId: "github:1001",
         source: "github-bot",
-        authorDisplayName: "Cole Murray",
-        authorEmail: "1001+cole@users.noreply.github.com",
-        authorLogin: "cole",
+        authorDisplayName: "Octo Cat",
+        authorEmail: "1001+octocat@users.noreply.github.com",
+        authorLogin: "octocat",
         scmUserId: "1001",
         scmAccessTokenEncrypted: "enc-access",
         scmRefreshTokenEncrypted: "enc-refresh",
@@ -294,9 +294,9 @@ describe("SessionMessageQueue", () => {
       });
 
       expect(h.repository.updateParticipantCoalesce).toHaveBeenCalledWith("part-1", {
-        scmName: "Cole Murray",
-        scmEmail: "1001+cole@users.noreply.github.com",
-        scmLogin: "cole",
+        scmName: "Octo Cat",
+        scmEmail: "1001+octocat@users.noreply.github.com",
+        scmLogin: "octocat",
         scmUserId: "1001",
         scmAccessTokenEncrypted: "enc-access",
         scmRefreshTokenEncrypted: "enc-refresh",

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -91,6 +91,7 @@ function buildQueue(options?: { getClientInfo?: (ws: WebSocket) => ClientInfo | 
     getNextPendingMessage: vi.fn(() => null as MessageRow | null),
     updateMessageToProcessing: vi.fn(),
     getParticipantById: vi.fn(() => createParticipant()),
+    updateParticipantCoalesce: vi.fn(),
     updateMessageCompletion: vi.fn(),
     upsertExecutionCompleteEvent: vi.fn(),
   };
@@ -145,6 +146,7 @@ function buildQueue(options?: { getClientInfo?: (ws: WebSocket) => ClientInfo | 
     queue,
     repository,
     wsManager,
+    participantService,
     broadcast,
     spawnSandbox,
     setSessionStatus,
@@ -245,5 +247,74 @@ describe("SessionMessageQueue", () => {
     await h.queue.failStuckProcessingMessage();
 
     expect(h.reconcileSessionStatusAfterExecution).toHaveBeenCalledWith(false);
+  });
+
+  describe("enqueuePromptFromApi", () => {
+    it("creates participant with authorDisplayName when new", async () => {
+      const h = buildQueue();
+      h.participantService.getByUserId.mockReturnValue(null as unknown as ParticipantRow);
+
+      await h.queue.enqueuePromptFromApi({
+        content: "Fix bug",
+        authorId: "github:1001",
+        source: "github-bot",
+        authorDisplayName: "Cole Murray",
+      });
+
+      expect(h.participantService.create).toHaveBeenCalledWith("github:1001", "Cole Murray");
+    });
+
+    it("uses authorId as display name when authorDisplayName is missing", async () => {
+      const h = buildQueue();
+      h.participantService.getByUserId.mockReturnValue(null as unknown as ParticipantRow);
+
+      await h.queue.enqueuePromptFromApi({
+        content: "Fix bug",
+        authorId: "github:1001",
+        source: "github-bot",
+      });
+
+      expect(h.participantService.create).toHaveBeenCalledWith("github:1001", "github:1001");
+    });
+
+    it("runs COALESCE update when enrichment fields are provided", async () => {
+      const h = buildQueue();
+
+      await h.queue.enqueuePromptFromApi({
+        content: "Fix bug",
+        authorId: "github:1001",
+        source: "github-bot",
+        authorDisplayName: "Cole Murray",
+        authorEmail: "1001+cole@users.noreply.github.com",
+        authorLogin: "cole",
+        scmUserId: "1001",
+        scmAccessTokenEncrypted: "enc-access",
+        scmRefreshTokenEncrypted: "enc-refresh",
+        scmTokenExpiresAt: 9999999,
+      });
+
+      expect(h.repository.updateParticipantCoalesce).toHaveBeenCalledWith("part-1", {
+        scmName: "Cole Murray",
+        scmEmail: "1001+cole@users.noreply.github.com",
+        scmLogin: "cole",
+        scmUserId: "1001",
+        scmAccessTokenEncrypted: "enc-access",
+        scmRefreshTokenEncrypted: "enc-refresh",
+        scmTokenExpiresAt: 9999999,
+      });
+      expect(h.repository.getParticipantById).toHaveBeenCalledWith("part-1");
+    });
+
+    it("skips COALESCE when no enrichment fields are provided", async () => {
+      const h = buildQueue();
+
+      await h.queue.enqueuePromptFromApi({
+        content: "Fix bug",
+        authorId: "github:1001",
+        source: "github-bot",
+      });
+
+      expect(h.repository.updateParticipantCoalesce).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -21,6 +21,7 @@ import type { SessionRepository } from "./repository";
 import type { SessionWebSocketManager } from "./websocket-manager";
 import type { ParticipantService } from "./participant-service";
 import type { CallbackNotificationService } from "./callback-notification-service";
+import type { EnqueuePromptRequest } from "./services/message.service";
 import { getAvatarUrl } from "./participant-service";
 
 interface PromptMessageData {
@@ -328,18 +329,29 @@ export class SessionMessageQueue {
     this.deps.broadcast({ type: "sandbox_event", event: userMessageEvent });
   }
 
-  async enqueuePromptFromApi(data: {
-    content: string;
-    authorId: string;
-    source: string;
-    model?: string;
-    reasoningEffort?: string;
-    attachments?: Array<{ type: string; name: string; url?: string }>;
-    callbackContext?: Record<string, unknown>;
-  }): Promise<{ messageId: string; status: "queued" }> {
+  async enqueuePromptFromApi(
+    data: EnqueuePromptRequest
+  ): Promise<{ messageId: string; status: "queued" }> {
     let participant = this.deps.participantService.getByUserId(data.authorId);
     if (!participant) {
-      participant = this.deps.participantService.create(data.authorId, data.authorId);
+      participant = this.deps.participantService.create(
+        data.authorId,
+        data.authorDisplayName || data.authorId
+      );
+    }
+
+    // COALESCE update: populate identity fields on non-owner participants
+    if (data.authorEmail || data.authorLogin || data.scmAccessTokenEncrypted) {
+      this.deps.repository.updateParticipantCoalesce(participant.id, {
+        scmName: data.authorDisplayName ?? null,
+        scmEmail: data.authorEmail ?? null,
+        scmLogin: data.authorLogin ?? null,
+        scmUserId: data.scmUserId ?? null,
+        scmAccessTokenEncrypted: data.scmAccessTokenEncrypted ?? null,
+        scmRefreshTokenEncrypted: data.scmRefreshTokenEncrypted ?? null,
+        scmTokenExpiresAt: data.scmTokenExpiresAt ?? null,
+      });
+      participant = this.deps.repository.getParticipantById(participant.id) ?? participant;
     }
 
     const messageId = generateId();

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -341,7 +341,13 @@ export class SessionMessageQueue {
     }
 
     // COALESCE update: populate identity fields on non-owner participants
-    if (data.authorEmail || data.authorLogin || data.scmAccessTokenEncrypted) {
+    const hasEnrichment =
+      data.authorDisplayName ||
+      data.authorEmail ||
+      data.authorLogin ||
+      data.scmUserId ||
+      data.scmAccessTokenEncrypted;
+    if (hasEnrichment) {
       this.deps.repository.updateParticipantCoalesce(participant.id, {
         scmName: data.authorDisplayName ?? null,
         scmEmail: data.authorEmail ?? null,

--- a/packages/control-plane/src/session/services/message.service.ts
+++ b/packages/control-plane/src/session/services/message.service.ts
@@ -11,6 +11,17 @@ export interface EnqueuePromptRequest {
   reasoningEffort?: string;
   attachments?: Array<{ type: string; name: string; url?: string }>;
   callbackContext?: Record<string, unknown>;
+
+  // Identity enrichment (from router D1 lookup at prompt time)
+  authorDisplayName?: string;
+  authorEmail?: string;
+  authorLogin?: string;
+
+  // SCM token enrichment (from cross-provider identity resolution)
+  scmUserId?: string;
+  scmAccessTokenEncrypted?: string;
+  scmRefreshTokenEncrypted?: string;
+  scmTokenExpiresAt?: number;
 }
 
 export interface ListEventsRequest {


### PR DESCRIPTION
## Summary

Fixes git commit and PR attribution for bot-originated sessions (GitHub, Slack, Linear). This is Steps 2-4 of the attribution fix plan (Step 1 was #577).

**Problem**: Bot sessions created owner participants with `user_id: "anonymous"` (unfindable by later prompts), and resolved D1 identity was discarded — never forwarded to the DO. Commits showed incorrect author identity and PRs always opened as `open-inspect[bot]`.

**Solution**: Enrich participants with linked GitHub identity at two points:

- **Session creation** (owner): `deriveUserId()` constructs canonical userId matching prompt `authorId` format. `resolveGitHubEnrichment()` looks up linked GitHub identity from D1 (display name, email, OAuth tokens) and forwards to DO init.
- **Prompt time** (non-owner): `parseAuthorId()` extracts provider info from bot authorIds, resolves linked GitHub identity, and forwards enrichment fields through `EnqueuePromptRequest` to the DO for COALESCE update.

**Key design decisions**:
- Email resolution: actual GitHub identity email preferred, noreply format as fallback
- D1 queries parallelized where independent (`getUserById` + `getEncryptedTokens`)
- Best-effort enrichment (try/catch) — D1 failures degrade gracefully to existing behavior
- No DO changes needed — existing init/COALESCE/token refresh infrastructure handles enriched data
- Web client path unaffected — `parseAuthorId` returns null for plain user IDs, `deriveUserId` passes through explicit `userId`

### Files changed

| File | Change |
|---|---|
| `router.ts` | `deriveUserId()`, `parseAuthorId()`, `resolveGitHubEnrichment()`, session creation + prompt time enrichment |
| `user-scm-tokens.ts` | `getEncryptedTokens()` — returns raw D1 ciphertext without decrypting |
| `message.service.ts` | Expand `EnqueuePromptRequest` with identity + token fields |
| `message-queue.ts` | Use `EnqueuePromptRequest` type, COALESCE update for non-owner participants |
| `router.identity.test.ts` | 16 tests for `parseAuthorId` and `deriveUserId` |
| `user-scm-tokens.test.ts` | 2 tests for `getEncryptedTokens` |
| `message-queue.test.ts` | 4 tests for `enqueuePromptFromApi` enrichment path |

## Test plan

- [x] `parseAuthorId` — 7 cases (github/slack/linear parse, web client null, anonymous null, unknown prefix null, empty null)
- [x] `deriveUserId` — 9 cases (explicit userId, each bot with/without identity fields, unknown source, empty input)
- [x] `getEncryptedTokens` — round-trip returns ciphertext not plaintext, null for unknown user
- [x] `enqueuePromptFromApi` — COALESCE runs with enrichment fields, skipped without them, `authorDisplayName` used for new participant name, fallback to `authorId`
- [x] Typecheck passes (only pre-existing `CacheStore` errors)
- [x] 1019 control-plane unit tests pass (10 pre-existing failures in `models.test.ts`)
- [x] 93 github-bot tests pass (7 pre-existing failures in `webhook.test.ts`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub identity enrichment during session creation; bot-origin prompts are optionally enriched with author display/email/login and SCM token/identity fields.
  * Canonical user ID derivation for bot authors.
  * Prompt requests now carry enrichment fields; participant creation prefers provided display name and will coalesce SCM identity/token data when present.

* **Tests**
  * Added tests for identity parsing, canonical user ID derivation, encrypted token retrieval, and message-queue participant coalescing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->