### PR TITLE
fix(web): prevent Radix focus steal on sidebar rename

### DIFF
--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -501,6 +501,7 @@ function SessionListItem({
   const [showArchiveDialog, setShowArchiveDialog] = useState(false);
   const [title, setTitle] = useState(displayTitle);
   const isStartingRenameRef = useRef(false);
+  const renameInputRef = useRef<HTMLInputElement>(null);
   const longPressTimerRef = useRef<number | null>(null);
   const longPressTriggeredRef = useRef(false);
   const touchStartRef = useRef<{ x: number; y: number } | null>(null);
@@ -517,6 +518,15 @@ function SessionListItem({
     setTitle(displayTitle);
     setIsRenaming(true);
   };
+
+  useEffect(() => {
+    if (!isRenaming) return;
+    const id = window.setTimeout(() => {
+      renameInputRef.current?.focus();
+      renameInputRef.current?.select();
+    }, 0);
+    return () => window.clearTimeout(id);
+  }, [isRenaming]);
 
   const handleCancelRename = () => {
     setTitle(displayTitle);
@@ -653,7 +663,7 @@ function SessionListItem({
         {isRenaming ? (
           <>
             <input
-              autoFocus
+              ref={renameInputRef}
               value={title}
               onChange={(e) => setTitle(e.target.value)}
               onFocus={(e) => e.currentTarget.select()}

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -500,6 +500,7 @@ function SessionListItem({
   const [isArchiving, setIsArchiving] = useState(false);
   const [showArchiveDialog, setShowArchiveDialog] = useState(false);
   const [title, setTitle] = useState(displayTitle);
+  const isStartingRenameRef = useRef(false);
   const longPressTimerRef = useRef<number | null>(null);
   const longPressTriggeredRef = useRef(false);
   const touchStartRef = useRef<{ x: number; y: number } | null>(null);
@@ -511,6 +512,7 @@ function SessionListItem({
   }, [displayTitle, isRenaming]);
 
   const handleStartRename = () => {
+    isStartingRenameRef.current = true;
     setIsActionsOpen(false);
     setTitle(displayTitle);
     setIsRenaming(true);
@@ -737,8 +739,16 @@ function SessionListItem({
                 <MoreIcon className="w-4 h-4" />
               </button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={handleStartRename}>Rename</DropdownMenuItem>
+            <DropdownMenuContent
+              align="end"
+              onCloseAutoFocus={(event) => {
+                if (isStartingRenameRef.current) {
+                  event.preventDefault();
+                  isStartingRenameRef.current = false;
+                }
+              }}
+            >
+              <DropdownMenuItem onSelect={handleStartRename}>Rename</DropdownMenuItem>
               <DropdownMenuItem onClick={handleStartArchive} disabled={isArchiving}>
                 <ArchiveIcon className="w-4 h-4" />
                 Archive


### PR DESCRIPTION
## Summary

Clicking **Rename** in the session sidebar dropdown opened the input briefly before Radix's `onCloseAutoFocus` restored focus to the trigger button, blurring the input and immediately submitting an unchanged title — effectively making rename unusable.

**Root cause:** Radix `DropdownMenu` fires `onCloseAutoFocus` after the menu closes, which moves focus back to the trigger. Since the rename `<input>` mounts with `autoFocus` in the same render, it gets focus first, then immediately loses it.

**Fix:** Prevent the focus restore by setting a ref flag in `handleStartRename` and calling `event.preventDefault()` in `onCloseAutoFocus` when that flag is set. Also switches the Rename menu item from `onClick` to `onSelect` for proper Radix menu lifecycle sequencing.

Relates to #580 — this is a minimal alternative to the focus-fix portion of that PR.

## Test plan
- [ ] Click "..." → Rename on a sidebar session — input should appear and stay focused
- [ ] Type a new name, press Enter — title updates
- [ ] Press Escape during rename — reverts to original title
- [ ] Open "..." menu and close without selecting — focus returns to trigger (not broken by the fix)
- [ ] Existing tests pass (`npm test -w @open-inspect/web` — 192/192)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rename flow in the sidebar: starting a rename now reliably focuses and selects the session name input so you can type immediately.
  * Prevented the dropdown from stealing focus after opening, avoiding interruptions to the rename interaction.
  * Ensured the Rename menu item triggers the rename action consistently when selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->