### PR TITLE
refactor: remove redundant D1 dual-writes from router

### DIFF
--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -1820,16 +1820,6 @@ async function handleUpdateSessionTitle(
     )
   );
 
-  if (response.ok) {
-    // read the validated title from the DO response
-    const doResult = (await response.clone().json()) as { title: string };
-    const sessionStore = new SessionIndexStore(env.DB);
-    const updated = await sessionStore.updateTitle(sessionId, doResult.title);
-    if (!updated) {
-      logger.warn("Session not found in D1 index during title update", { session_id: sessionId });
-    }
-  }
-
   return response;
 }
 
@@ -1866,15 +1856,6 @@ async function handleArchiveSession(
     )
   );
 
-  if (response.ok) {
-    // Update D1 index
-    const sessionStore = new SessionIndexStore(env.DB);
-    const updated = await sessionStore.updateStatus(sessionId, "archived");
-    if (!updated) {
-      logger.warn("Session not found in D1 index during archive", { session_id: sessionId });
-    }
-  }
-
   return response;
 }
 
@@ -1910,15 +1891,6 @@ async function handleUnarchiveSession(
       ctx
     )
   );
-
-  if (response.ok) {
-    // Update D1 index
-    const sessionStore = new SessionIndexStore(env.DB);
-    const updated = await sessionStore.updateStatus(sessionId, "active");
-    if (!updated) {
-      logger.warn("Session not found in D1 index during unarchive", { session_id: sessionId });
-    }
-  }
 
   return response;
 }
@@ -2213,11 +2185,6 @@ async function handleCancelChild(
   const response = await childStub.fetch(
     internalRequest(buildSessionInternalUrl(SessionInternalPaths.cancel), { method: "POST" }, ctx)
   );
-
-  // Update D1 status if cancel succeeded
-  if (response.ok) {
-    await sessionStore.updateStatus(childId, "cancelled");
-  }
 
   return response;
 }

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -425,6 +425,7 @@ export class SessionDO extends DurableObject<Env> {
         getPublicSessionId: (session) => this.getPublicSessionId(session),
         getParticipantByUserId: (userId) => this.participantService.getByUserId(userId),
         transitionSessionStatus: (status) => this.transitionSessionStatus(status),
+        syncSessionIndexTitle: (sessionId, title) => this.syncSessionIndexTitle(sessionId, title),
         stopExecution: (options) => this.stopExecution(options),
         getSandboxSocket: () => this.wsManager.getSandboxSocket(),
         sendToSandbox: (ws, message) => this.wsManager.send(ws, message),
@@ -1464,6 +1465,20 @@ export class SessionDO extends DurableObject<Env> {
           session_id: sessionId,
           status,
           updated_at: updatedAt,
+          error,
+        });
+      })
+    );
+  }
+
+  private syncSessionIndexTitle(sessionId: string, title: string): void {
+    if (!this.env.DB) return;
+    const sessionStore = new SessionIndexStore(this.env.DB);
+    this.ctx.waitUntil(
+      sessionStore.updateTitle(sessionId, title).catch((error) => {
+        this.log.error("session_index.update_title.background_error", {
+          session_id: sessionId,
+          title,
           error,
         });
       })

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
@@ -100,6 +100,7 @@ function createHandler() {
   const getPublicSessionId = vi.fn<(session: SessionRow) => string>();
   const getParticipantByUserId = vi.fn<(userId: string) => ParticipantRow | null>();
   const transitionSessionStatus = vi.fn<(status: SessionRow["status"]) => Promise<boolean>>();
+  const syncSessionIndexTitle = vi.fn();
   const stopExecution = vi.fn();
   const getSandboxSocket = vi.fn<() => WebSocket | null>();
   const sendToSandbox = vi.fn();
@@ -121,6 +122,7 @@ function createHandler() {
     getPublicSessionId,
     getParticipantByUserId,
     transitionSessionStatus,
+    syncSessionIndexTitle,
     stopExecution,
     getSandboxSocket,
     sendToSandbox,
@@ -143,6 +145,7 @@ function createHandler() {
     getPublicSessionId,
     getParticipantByUserId,
     transitionSessionStatus,
+    syncSessionIndexTitle,
     stopExecution,
     getSandboxSocket,
     sendToSandbox,
@@ -428,9 +431,18 @@ describe("createSessionLifecycleHandler", () => {
     expect(response.status).toBe(403);
   });
 
-  it("updates title, broadcasts, and returns new title", async () => {
-    const { handler, getSession, getParticipantByUserId, repository, broadcast } = createHandler();
+  it("updates title, broadcasts, syncs to D1 index, and returns new title", async () => {
+    const {
+      handler,
+      getSession,
+      getPublicSessionId,
+      getParticipantByUserId,
+      repository,
+      syncSessionIndexTitle,
+      broadcast,
+    } = createHandler();
     getSession.mockReturnValue(createSession());
+    getPublicSessionId.mockReturnValue("public-session-1");
     getParticipantByUserId.mockReturnValue(createParticipant());
 
     const response = await handler.updateTitle(
@@ -444,6 +456,7 @@ describe("createSessionLifecycleHandler", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ title: "New Title" });
     expect(repository.updateSessionTitle).toHaveBeenCalledWith("session-1", "New Title", 1234);
+    expect(syncSessionIndexTitle).toHaveBeenCalledWith("public-session-1", "New Title");
     expect(broadcast).toHaveBeenCalledWith({ type: "session_title", title: "New Title" });
   });
 

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
@@ -51,6 +51,7 @@ export interface SessionLifecycleHandlerDeps {
   getPublicSessionId: (session: SessionRow) => string;
   getParticipantByUserId: (userId: string) => ParticipantRow | null;
   transitionSessionStatus: (status: SessionStatus) => Promise<boolean>;
+  syncSessionIndexTitle: (sessionId: string, title: string) => void;
   stopExecution: (options?: { suppressStatusReconcile?: boolean }) => Promise<void>;
   getSandboxSocket: () => WebSocket | null;
   sendToSandbox: (ws: WebSocket, message: string | object) => boolean;
@@ -223,6 +224,9 @@ export function createSessionLifecycleHandler(
       }
 
       deps.repository.updateSessionTitle(session.id, body.title, deps.now());
+
+      const publicSessionId = deps.getPublicSessionId(session);
+      deps.syncSessionIndexTitle(publicSessionId, body.title);
 
       deps.broadcast({
         type: "session_title",


### PR DESCRIPTION
## Summary

- Removes redundant synchronous D1 writes from 4 router handlers (`handleArchiveSession`, `handleUnarchiveSession`, `handleUpdateSessionTitle`, `handleCancelChild`) — the DO already syncs status to D1 via `transitionSessionStatus` → `syncSessionIndexStatus` using `waitUntil`
- Adds `syncSessionIndexTitle` to the DO (matching the existing `syncSessionIndexStatus` pattern) since title was the one case where the DO didn't previously sync to D1
- These handlers are now pure DO proxies — the router no longer participates in D1 status/title coordination

### Why this is safe

The web client doesn't rely on the router's synchronous D1 write for UI feedback:
- Archive/unarchive/cancel use optimistic cache mutations + WebSocket `session_status` broadcasts
- The DO's `waitUntil` D1 write handles eventual consistency for sidebar list queries
- The previous dual-write pattern created a race between the router's synchronous write and the DO's background write to the same D1 row

## Test plan

- [x] Updated lifecycle handler test to verify DO-side `syncSessionIndexTitle` is called with correct session ID and title
- [x] All 1039 existing control-plane tests pass
- [x] Typecheck passes
- [x] Lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved session management architecture by refactoring how session information is synchronized to the database, now using asynchronous background processing for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->