### PR TITLE
feat(terraform): allow overriding R2 media bucket name

### DIFF
--- a/terraform/environments/production/r2.tf
+++ b/terraform/environments/production/r2.tf
@@ -4,6 +4,6 @@
 
 resource "cloudflare_r2_bucket" "media" {
   account_id = var.cloudflare_account_id
-  name       = "open-inspect-media-${local.name_suffix}"
+  name       = var.r2_media_bucket_name != "" ? var.r2_media_bucket_name : "open-inspect-media-${local.name_suffix}"
   location   = var.r2_media_location
 }

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -174,6 +174,36 @@ deployment_name = ""
 # Path to project root (relative to this directory)
 project_root = "../../../"
 
+# Override the R2 media bucket name (optional)
+# Defaults to "open-inspect-media-<deployment_name>" when left empty.
+# Set this when the bucket must be pre-created out-of-band — for example, when
+# the Cloudflare API token used by Terraform doesn't have permission to create
+# R2 buckets and an admin had to provision one with a specific name.
+#
+# Manual setup requirements (when an admin pre-creates the bucket):
+#   - Must live in the same Cloudflare account as the Workers (cloudflare_account_id).
+#   - Private bucket — do NOT enable public access. The control-plane Worker
+#     reads/writes objects through its binding; clients never hit R2 directly.
+#   - No CORS rules or lifecycle policies are required.
+#   - Location should match r2_media_location (default ENAM).
+#
+# Create with wrangler (equivalent to what Terraform would do):
+#   wrangler r2 bucket create <bucket-name> --location ENAM
+# Or create via the Cloudflare dashboard: R2 -> Create bucket (Standard storage class).
+#
+# After manual creation, import the bucket so Terraform manages the binding without
+# trying to recreate it:
+#   terraform import cloudflare_r2_bucket.media <cloudflare_account_id>/<bucket-name>
+#
+# Worker runtime needs (granted automatically through the binding, listed for reference):
+#   - R2 object-level: Read, Write, Delete on this bucket only.
+# The Terraform/Cloudflare API token does NOT need object-level R2 permissions —
+# it only manages the bucket resource and the Worker binding. Required token scopes:
+#   - Workers R2 Storage: Edit (only needed when Terraform creates/manages the bucket;
+#     if the bucket is pre-created and imported, drop to Read or omit)
+#   - Workers Scripts: Edit (to attach the MEDIA_BUCKET binding to the Worker)
+# r2_media_bucket_name = ""
+
 # =============================================================================
 # Initial Deployment Flags
 # =============================================================================

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -235,7 +235,7 @@ project_root = "../../../"
 #
 # After manual creation, import the bucket so Terraform manages the binding without
 # trying to recreate it:
-#   terraform import cloudflare_r2_bucket.media <cloudflare_account_id>/<bucket-name>
+#   terraform import cloudflare_r2_bucket.media <cloudflare_account_id>/<bucket-name>/default
 #
 # Worker runtime needs (granted automatically through the binding, listed for reference):
 #   - R2 object-level: Read, Write, Delete on this bucket only.

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -237,6 +237,13 @@ project_root = "../../../"
 # trying to recreate it:
 #   terraform import cloudflare_r2_bucket.media <cloudflare_account_id>/<bucket-name>/default
 #
+# WARNING — renaming an existing Terraform-managed bucket:
+# If you previously deployed without this variable (Terraform owns the default-named
+# bucket) and now set r2_media_bucket_name to a different name WITHOUT first running
+# `terraform import` on the new name, Terraform will destroy the existing bucket and
+# create a new one — permanently deleting all stored objects. Migrate objects first
+# (e.g. with rclone) and import the new bucket before applying.
+#
 # Worker runtime needs (granted automatically through the binding, listed for reference):
 #   - R2 object-level: Read, Write, Delete on this bucket only.
 # The Terraform/Cloudflare API token does NOT need object-level R2 permissions —

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -377,6 +377,12 @@ variable "r2_media_location" {
   default     = "ENAM"
 }
 
+variable "r2_media_bucket_name" {
+  description = "Override the R2 media bucket name. Leave empty to use the default 'open-inspect-media-<deployment_name>'. Set this when the bucket must be pre-created out-of-band (e.g. when the Terraform credentials cannot create R2 buckets)."
+  type        = string
+  default     = ""
+}
+
 # =============================================================================
 # Access Control
 # =============================================================================


### PR DESCRIPTION
Add an optional r2_media_bucket_name variable so the bucket can be pre-created out-of-band and the deployment can point at it instead of having Terraform create one. This unblocks environments where the Cloudflare API token used by Terraform/CI does not have R2 bucket- creation rights and an admin must provision the bucket manually.

When the override is empty, behavior is unchanged: the bucket is created as open-inspect-media-<deployment_name>. When set, that exact name is used and operators are expected to terraform import the existing bucket so applies do not try to recreate it.

The example tfvars documents manual-setup requirements (same account, private, no CORS/lifecycle, matching location) and clarifies that the Terraform token only needs Workers R2 Storage Read plus Workers Scripts Edit once the bucket exists — object-level R2 permissions are never required because runtime access flows through the in-account MEDIA_BUCKET Worker binding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow specifying a custom R2 media bucket name for production deployments; leaving it empty keeps the automatic default naming.

* **Documentation**
  * Added guidance for overriding the bucket name and for manually pre-creating/importing a bucket, including privacy, location, and import cautions to avoid destructive changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->