### PR TITLE
fix(web): render nested child sessions in sidebar

### DIFF
--- a/packages/web/src/components/session-sidebar.test.tsx
+++ b/packages/web/src/components/session-sidebar.test.tsx
@@ -55,15 +55,19 @@ afterEach(() => {
   mockPush.mockReset();
 });
 
-function createSession(index: number) {
+function createSession(index: number, overrides: Record<string, unknown> = {}) {
   return {
     id: `session-${index}`,
     title: `Session ${index}`,
     repoOwner: "open-inspect",
     repoName: "background-agents",
+    parentSessionId: null,
+    spawnSource: "user",
+    spawnDepth: 0,
     status: "active",
     createdAt: 1000 + index,
     updatedAt: 2000 + index,
+    ...overrides,
   };
 }
 
@@ -75,6 +79,45 @@ function jsonResponse(body: unknown) {
 }
 
 describe("SessionSidebar", () => {
+  it("renders nested child sessions under their immediate parent", async () => {
+    const parent = createSession(1, { updatedAt: 4000 });
+    const child = createSession(2, {
+      title: "Child session",
+      parentSessionId: parent.id,
+      spawnSource: "agent",
+      spawnDepth: 1,
+      updatedAt: 3000,
+    });
+    const grandchild = createSession(3, {
+      title: "Grandchild session",
+      parentSessionId: child.id,
+      spawnSource: "agent",
+      spawnDepth: 2,
+      updatedAt: 2000,
+    });
+
+    render(
+      <SWRConfig
+        value={{
+          fallback: {
+            [SIDEBAR_SESSIONS_KEY]: {
+              sessions: [parent, child, grandchild],
+              hasMore: false,
+            },
+          },
+          dedupingInterval: 0,
+          revalidateOnFocus: false,
+        }}
+      >
+        <SessionSidebar />
+      </SWRConfig>
+    );
+
+    expect(await screen.findByText("Session 1")).toBeInTheDocument();
+    expect(screen.getByText("Child session")).toBeInTheDocument();
+    expect(screen.getByText("Grandchild session")).toBeInTheDocument();
+  });
+
   it("loads the next page when scrolled near the bottom", async () => {
     const firstPage = Array.from({ length: 50 }, (_, index) => createSession(index + 1));
     const secondPage = Array.from({ length: 5 }, (_, index) => createSession(index + 51));

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -2,7 +2,15 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useState, useMemo, useCallback, useEffect, useRef, type TouchEvent } from "react";
+import {
+  Fragment,
+  useState,
+  useMemo,
+  useCallback,
+  useEffect,
+  useRef,
+  type TouchEvent,
+} from "react";
 import { useSession, signOut } from "next-auth/react";
 import useSWR, { mutate } from "swr";
 import { ArchiveSessionDialog } from "@/components/archive-session-dialog";
@@ -359,7 +367,7 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
               <SessionWithChildren
                 key={session.id}
                 session={session}
-                childSessions={childrenMap.get(session.id)}
+                childrenMap={childrenMap}
                 currentSessionId={currentSessionId}
                 isMobile={isMobile}
                 onArchive={handleSessionArchived}
@@ -380,7 +388,7 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
                   <SessionWithChildren
                     key={session.id}
                     session={session}
-                    childSessions={childrenMap.get(session.id)}
+                    childrenMap={childrenMap}
                     currentSessionId={currentSessionId}
                     isMobile={isMobile}
                     onArchive={handleSessionArchived}
@@ -453,7 +461,7 @@ function UserMenu({ user }: { user?: { name?: string | null; image?: string | nu
 
 function SessionWithChildren({
   session,
-  childSessions,
+  childrenMap,
   currentSessionId,
   isMobile,
   onArchive,
@@ -461,7 +469,7 @@ function SessionWithChildren({
   onSessionRenamed,
 }: {
   session: SessionItem;
-  childSessions?: SessionItem[];
+  childrenMap: Map<string, SessionItem[]>;
   currentSessionId: string | null;
   isMobile: boolean;
   onArchive: (sessionId: string) => Promise<void>;
@@ -478,18 +486,65 @@ function SessionWithChildren({
         onSessionSelect={onSessionSelect}
         onSessionRenamed={onSessionRenamed}
       />
-      {childSessions &&
-        childSessions.map((child) => (
-          <ChildSessionListItem
-            key={child.id}
-            session={child}
-            isActive={child.id === currentSessionId}
-            isMobile={isMobile}
-            onSessionSelect={onSessionSelect}
-          />
-        ))}
+      <ChildSessionTree
+        parentId={session.id}
+        childrenMap={childrenMap}
+        currentSessionId={currentSessionId}
+        isMobile={isMobile}
+        onSessionSelect={onSessionSelect}
+        visitedIds={new Set([session.id])}
+      />
     </>
   );
+}
+
+function ChildSessionTree({
+  parentId,
+  childrenMap,
+  currentSessionId,
+  isMobile,
+  onSessionSelect,
+  visitedIds,
+  depth = 1,
+}: {
+  parentId: string;
+  childrenMap: Map<string, SessionItem[]>;
+  currentSessionId: string | null;
+  isMobile: boolean;
+  onSessionSelect?: () => void;
+  visitedIds: Set<string>;
+  depth?: number;
+}) {
+  const childSessions = childrenMap.get(parentId);
+  if (!childSessions?.length) return null;
+
+  return childSessions.map((child) => {
+    if (visitedIds.has(child.id)) return null;
+
+    const nextVisitedIds = new Set(visitedIds);
+    nextVisitedIds.add(child.id);
+
+    return (
+      <Fragment key={child.id}>
+        <ChildSessionListItem
+          session={child}
+          isActive={child.id === currentSessionId}
+          isMobile={isMobile}
+          onSessionSelect={onSessionSelect}
+          depth={depth}
+        />
+        <ChildSessionTree
+          parentId={child.id}
+          childrenMap={childrenMap}
+          currentSessionId={currentSessionId}
+          isMobile={isMobile}
+          onSessionSelect={onSessionSelect}
+          visitedIds={nextVisitedIds}
+          depth={depth + 1}
+        />
+      </Fragment>
+    );
+  });
 }
 
 function SessionListItem({
@@ -780,15 +835,18 @@ function ChildSessionListItem({
   isActive,
   isMobile,
   onSessionSelect,
+  depth,
 }: {
   session: SessionItem;
   isActive: boolean;
   isMobile: boolean;
   onSessionSelect?: () => void;
+  depth: number;
 }) {
   const timestamp = session.updatedAt || session.createdAt;
   const relativeTime = formatRelativeTime(timestamp);
   const displayTitle = session.title || "Sub-task";
+  const paddingLeftRem = 1.75 + Math.max(depth - 1, 0) * 1;
   return (
     <Link
       href={buildSessionHref(session)}
@@ -797,9 +855,10 @@ function ChildSessionListItem({
           onSessionSelect?.();
         }
       }}
-      className={`block pl-7 pr-4 py-1.5 border-l-2 transition ${
+      className={`block pr-4 py-1.5 border-l-2 transition ${
         isActive ? "border-l-accent bg-accent-muted" : "border-l-transparent hover:bg-muted"
       }`}
+      style={{ paddingLeft: `${paddingLeftRem}rem` }}
     >
       <div className="flex items-center gap-1.5 text-xs">
         <span className="shrink-0 text-muted-foreground">{relativeTime}</span>


### PR DESCRIPTION
## Summary
- Render child sessions recursively in the left session sidebar so grandchildren appear under their immediate parent.
- Preserve nested indentation and add cycle protection for malformed parent relationships.
- Add a regression test covering parent, child, and grandchild session rendering.

## Tests
- `npm test -w @open-inspect/web -- session-sidebar.test.tsx`
- `npx eslint packages/web/src/components/session-sidebar.tsx packages/web/src/components/session-sidebar.test.tsx`
- `npm run typecheck -w @open-inspect/web`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/c583d2936f4678bd48052e5fd6552c8d)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session sidebar to properly display nested child sessions directly under their parent session.

* **Improvements**
  * Session sidebar now renders with dynamic indentation levels to clearly show the hierarchical relationship between parent and child sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->