### PR TITLE
feat: configurable app name and icon for whitelabel deployments

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -394,9 +394,13 @@ deployment_name = "your-unique-name"  # e.g., "acme", "johndoe", "mycompany"
 project_root    = "../../../"
 
 # Branding (optional — defaults shown)
-# Display name shown in the web UI tab title, sidebar, sign-in page, bot
+# Display name shown in the web UI tab title, sign-in page, landing hero, bot
 # messages (Slack/Linear), PR body footer, and outbound HTTP User-Agent.
 # app_name = "Open-Inspect"
+# Short brand label shown only in the sidebar header (next to the logo).
+# Leave empty to default to "Inspect" (or to follow app_name when app_name
+# is overridden). Set this when app_name is too wide for the sidebar.
+# app_short_name = ""
 # Optional URL (absolute or root-relative) to a custom logo/favicon. When set,
 # replaces the built-in icon in the web sidebar and browser favicon.
 # app_icon_url = ""
@@ -678,6 +682,7 @@ Go to your fork's Settings → Secrets and variables → Actions, and add:
 | `GH_WEBHOOK_SECRET`           | GitHub webhook secret (required if GitHub bot enabled)                        |
 | `GH_BOT_USERNAME`             | GitHub App bot username, e.g., `my-app[bot]` (required if GitHub bot enabled) |
 | `APP_NAME`                    | Optional display name for whitelabeling (default: `Open-Inspect`)             |
+| `APP_SHORT_NAME`              | Optional short label for sidebar header (default: `Inspect`)                  |
 | `APP_ICON_URL`                | Optional URL to a custom logo/favicon (default: built-in icon)                |
 
 **Bulk upload secrets with `gh` CLI:**
@@ -883,19 +888,24 @@ Add these to your `terraform.tfvars`:
 #   - Outbound HTTP User-Agent headers (GitHub, GitLab API)
 app_name = "Acme Bot"
 
+# Optional short label for the sidebar header next to the logo. When empty,
+# falls through to app_name (or "Inspect" if app_name is also unset). Set this
+# when app_name is too wide for the sidebar.
+app_short_name = "Acme"
+
 # Optional URL to a custom logo image (SVG/PNG). When set, replaces the
 # built-in icon in the web sidebar, command menu, and browser favicon.
 # Use an absolute URL or a root-relative path served from packages/web/public/.
 app_icon_url = "/branding/logo.svg"   # or "https://cdn.example.com/logo.svg"
 ```
 
-After changing either value, run `terraform apply` and (for Vercel) redeploy the web app so the new
-build picks up the `NEXT_PUBLIC_APP_NAME` and `NEXT_PUBLIC_APP_ICON_URL` env vars (Cloudflare's web
-deploy is rebuilt automatically by Terraform).
+After changing any of these values, run `terraform apply` and (for Vercel) redeploy the web app so
+the new build picks up the `NEXT_PUBLIC_APP_NAME`, `NEXT_PUBLIC_APP_SHORT_NAME`, and
+`NEXT_PUBLIC_APP_ICON_URL` env vars (Cloudflare's web deploy is rebuilt automatically by Terraform).
 
-> **Note**: `NEXT_PUBLIC_APP_NAME` and `NEXT_PUBLIC_APP_ICON_URL` are inlined into the client bundle
-> at build time, so changes require a fresh web build. The bot/control-plane workers read `APP_NAME`
-> at request time, so they pick up the new value immediately after `terraform apply`.
+> **Note**: `NEXT_PUBLIC_*` vars are inlined into the client bundle at build time, so changes
+> require a fresh web build. The bot/control-plane workers read `APP_NAME` at request time, so they
+> pick up the new value immediately after `terraform apply`.
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -393,6 +393,14 @@ nextauth_secret          = "your-generated-value"
 deployment_name = "your-unique-name"  # e.g., "acme", "johndoe", "mycompany"
 project_root    = "../../../"
 
+# Branding (optional — defaults shown)
+# Display name shown in the web UI tab title, sidebar, sign-in page, bot
+# messages (Slack/Linear), PR body footer, and outbound HTTP User-Agent.
+# app_name = "Open-Inspect"
+# Optional URL (absolute or root-relative) to a custom logo/favicon. When set,
+# replaces the built-in icon in the web sidebar and browser favicon.
+# app_icon_url = ""
+
 # Initial deployment: set both to false (see Step 7)
 enable_durable_object_bindings = false
 enable_service_bindings        = false
@@ -669,6 +677,8 @@ Go to your fork's Settings → Secrets and variables → Actions, and add:
 | `ENABLE_GITHUB_BOT`           | `true` to deploy GitHub bot worker (or empty to skip)                         |
 | `GH_WEBHOOK_SECRET`           | GitHub webhook secret (required if GitHub bot enabled)                        |
 | `GH_BOT_USERNAME`             | GitHub App bot username, e.g., `my-app[bot]` (required if GitHub bot enabled) |
+| `APP_NAME`                    | Optional display name for whitelabeling (default: `Open-Inspect`)             |
+| `APP_ICON_URL`                | Optional URL to a custom logo/favicon (default: built-in icon)                |
 
 **Bulk upload secrets with `gh` CLI:**
 
@@ -854,6 +864,38 @@ This occurs on first deployment. Follow the two-phase deployment process:
 - Rotate secrets periodically using `terraform apply` after updating `terraform.tfvars`
 - Review the [Security Model](../README.md#security-model-single-tenant-only) - this system is
   designed for single-tenant deployment
+
+---
+
+## Customizing the App Name and Icon (Optional)
+
+Open-Inspect can be whitelabeled by overriding the brand name and logo. Both values are optional and
+default to the built-in `Open-Inspect` brand.
+
+Add these to your `terraform.tfvars`:
+
+```hcl
+# Display name shown in:
+#   - Web tab title, sidebar logo, sign-in page, landing hero
+#   - Slack App Home settings page
+#   - Linear OAuth success page and completion comments
+#   - PR body footer ("Created with [<app_name>](<session-url>)")
+#   - Outbound HTTP User-Agent headers (GitHub, GitLab API)
+app_name = "Acme Bot"
+
+# Optional URL to a custom logo image (SVG/PNG). When set, replaces the
+# built-in icon in the web sidebar, command menu, and browser favicon.
+# Use an absolute URL or a root-relative path served from packages/web/public/.
+app_icon_url = "/branding/logo.svg"   # or "https://cdn.example.com/logo.svg"
+```
+
+After changing either value, run `terraform apply` and (for Vercel) redeploy the web app so the new
+build picks up the `NEXT_PUBLIC_APP_NAME` and `NEXT_PUBLIC_APP_ICON_URL` env vars (Cloudflare's web
+deploy is rebuilt automatically by Terraform).
+
+> **Note**: `NEXT_PUBLIC_APP_NAME` and `NEXT_PUBLIC_APP_ICON_URL` are inlined into the client bundle
+> at build time, so changes require a fresh web build. The bot/control-plane workers read `APP_NAME`
+> at request time, so they pick up the new value immediately after `terraform apply`.
 
 ---
 

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -92,6 +92,12 @@ INTERNAL_CALLBACK_SECRET=your_shared_secret
 # Optional access control
 ALLOWED_USERS=
 ALLOWED_EMAIL_DOMAINS=
+
+# Optional whitelabel branding (defaults shown). NEXT_PUBLIC_* vars are
+# inlined into the client bundle at build time — restart `npm run dev`
+# after changing them.
+NEXT_PUBLIC_APP_NAME=Open-Inspect
+NEXT_PUBLIC_APP_ICON_URL=
 ```
 
 Do not commit `packages/web/.env.local`.

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -97,6 +97,10 @@ ALLOWED_EMAIL_DOMAINS=
 # inlined into the client bundle at build time — restart `npm run dev`
 # after changing them.
 NEXT_PUBLIC_APP_NAME=Open-Inspect
+# Short label for the sidebar header (next to the logo). Defaults to
+# "Inspect" when unset; falls through to NEXT_PUBLIC_APP_NAME when only
+# the long name is overridden.
+NEXT_PUBLIC_APP_SHORT_NAME=
 NEXT_PUBLIC_APP_ICON_URL=
 ```
 

--- a/packages/control-plane/src/auth/github-app.ts
+++ b/packages/control-plane/src/auth/github-app.ts
@@ -9,7 +9,11 @@
  * 3. Token valid for 1 hour
  */
 
-import type { CacheStore, InstallationRepository } from "@open-inspect/shared";
+import {
+  DEFAULT_APP_NAME,
+  type CacheStore,
+  type InstallationRepository,
+} from "@open-inspect/shared";
 
 /** Timeout for individual GitHub API requests (ms). */
 export const GITHUB_FETCH_TIMEOUT_MS = 60_000;
@@ -27,6 +31,13 @@ const INSTALLATION_TOKEN_CACHE_KEY_PREFIX = "github:installation-token:v1";
 
 interface InstallationTokenCacheBindings {
   cacheStore?: CacheStore;
+  /** User-Agent header sent on outbound GitHub API requests. */
+  userAgent?: string;
+}
+
+function resolveUserAgent(env: InstallationTokenCacheBindings | undefined): string {
+  const value = env?.userAgent?.trim();
+  return value && value.length > 0 ? value : DEFAULT_APP_NAME;
 }
 
 interface CachedInstallationToken {
@@ -215,7 +226,8 @@ export async function generateAppJwt(appId: string, privateKey: string): Promise
  */
 async function getInstallationTokenWithMetadata(
   jwt: string,
-  installationId: string
+  installationId: string,
+  userAgent: string
 ): Promise<InstallationTokenResponse> {
   const url = `https://api.github.com/app/installations/${installationId}/access_tokens`;
 
@@ -225,7 +237,7 @@ async function getInstallationTokenWithMetadata(
       Authorization: `Bearer ${jwt}`,
       Accept: "application/vnd.github+json",
       "X-GitHub-Api-Version": "2022-11-28",
-      "User-Agent": "Open-Inspect",
+      "User-Agent": userAgent,
     },
   });
 
@@ -318,7 +330,11 @@ async function refreshInstallationToken(
 ): Promise<CachedInstallationToken> {
   const nowEpochMs = Date.now();
   const jwt = await generateAppJwt(config.appId, config.privateKey);
-  const tokenData = await getInstallationTokenWithMetadata(jwt, config.installationId);
+  const tokenData = await getInstallationTokenWithMetadata(
+    jwt,
+    config.installationId,
+    resolveUserAgent(env)
+  );
   const parsedExpiresAtEpochMs = Date.parse(tokenData.expires_at);
   const cached: CachedInstallationToken = {
     token: tokenData.token,
@@ -418,7 +434,7 @@ export async function listInstallationRepositories(
     Authorization: `Bearer ${token}`,
     Accept: "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
-    "User-Agent": "Open-Inspect",
+    "User-Agent": resolveUserAgent(env),
   };
 
   const fetchPage = async (
@@ -522,7 +538,7 @@ export async function getInstallationRepository(
         Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
-        "User-Agent": "Open-Inspect",
+        "User-Agent": resolveUserAgent(env),
       },
     });
 
@@ -586,7 +602,7 @@ export async function listRepositoryBranches(
           Authorization: `Bearer ${token}`,
           Accept: "application/vnd.github+json",
           "X-GitHub-Api-Version": "2022-11-28",
-          "User-Agent": "Open-Inspect",
+          "User-Agent": resolveUserAgent(env),
         },
       }
     );

--- a/packages/control-plane/src/auth/github.ts
+++ b/packages/control-plane/src/auth/github.ts
@@ -2,6 +2,7 @@
  * GitHub authentication utilities.
  */
 
+import { DEFAULT_APP_NAME } from "@open-inspect/shared";
 import { decryptToken, encryptToken } from "./crypto";
 import type { GitHubUser, GitHubTokenResponse } from "../types";
 
@@ -92,12 +93,15 @@ export async function refreshAccessToken(
 /**
  * Get current user info from GitHub.
  */
-export async function getGitHubUser(accessToken: string): Promise<GitHubUser> {
+export async function getGitHubUser(
+  accessToken: string,
+  userAgent: string = DEFAULT_APP_NAME
+): Promise<GitHubUser> {
   const response = await fetch("https://api.github.com/user", {
     headers: {
       Authorization: `Bearer ${accessToken}`,
       Accept: "application/vnd.github.v3+json",
-      "User-Agent": "Open-Inspect",
+      "User-Agent": userAgent,
     },
   });
 
@@ -112,13 +116,14 @@ export async function getGitHubUser(accessToken: string): Promise<GitHubUser> {
  * Get user's email addresses from GitHub.
  */
 export async function getGitHubUserEmails(
-  accessToken: string
+  accessToken: string,
+  userAgent: string = DEFAULT_APP_NAME
 ): Promise<Array<{ email: string; primary: boolean; verified: boolean }>> {
   const response = await fetch("https://api.github.com/user/emails", {
     headers: {
       Authorization: `Bearer ${accessToken}`,
       Accept: "application/vnd.github.v3+json",
-      "User-Agent": "Open-Inspect",
+      "User-Agent": userAgent,
     },
   });
 

--- a/packages/control-plane/src/routes/shared.ts
+++ b/packages/control-plane/src/routes/shared.ts
@@ -5,7 +5,7 @@
 import type { CorrelationContext } from "../logger";
 import type { RequestMetrics } from "../db/instrumented-d1";
 import type { Env } from "../types";
-import { createKvCacheStore } from "@open-inspect/shared";
+import { createKvCacheStore, resolveAppName } from "@open-inspect/shared";
 import { getGitHubAppConfig } from "../auth/github-app";
 import type { Logger } from "../logger";
 import {
@@ -71,16 +71,19 @@ export function error(message: string, status = 400): Response {
 export function createRouteSourceControlProvider(env: Env): SourceControlProvider {
   const appConfig = getGitHubAppConfig(env);
   const provider = resolveScmProviderFromEnv(env.SCM_PROVIDER);
+  const userAgent = resolveAppName(env);
   return createSourceControlProvider({
     provider,
     github: {
       appConfig: appConfig ?? undefined,
       cacheStore: createKvCacheStore(env.REPOS_CACHE),
+      userAgent,
     },
     ...(env.GITLAB_ACCESS_TOKEN && {
       gitlab: {
         accessToken: env.GITLAB_ACCESS_TOKEN,
         namespace: env.GITLAB_NAMESPACE,
+        userAgent,
       },
     }),
   });

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -10,7 +10,7 @@
 import { DurableObject } from "cloudflare:workers";
 import { initSchema } from "./schema";
 import { buildSessionInternalUrl, SessionInternalPaths } from "./contracts";
-import { timingSafeEqual } from "@open-inspect/shared";
+import { resolveAppName, timingSafeEqual } from "@open-inspect/shared";
 import { generateId, hashToken, encryptToken, decryptToken } from "../auth/crypto";
 import { getGitHubAppConfig, getCachedInstallationToken } from "../auth/github-app";
 import { createModalClient } from "../sandbox/client";
@@ -468,6 +468,7 @@ export class SessionDO extends DurableObject<Env> {
                 artifact,
               });
             },
+            appName: resolveAppName(this.env),
           });
 
           return pullRequestService.createPullRequest(input);
@@ -586,6 +587,7 @@ export class SessionDO extends DurableObject<Env> {
                   ? () =>
                       getCachedInstallationToken(appConfig, {
                         cacheStore: createKvCacheStore(this.env.REPOS_CACHE),
+                        userAgent: resolveAppName(this.env),
                       })
                   : () => Promise.resolve(null);
 

--- a/packages/control-plane/src/session/pull-request-service.test.ts
+++ b/packages/control-plane/src/session/pull-request-service.test.ts
@@ -129,6 +129,7 @@ function createTestHarness() {
     pushBranchToRemote: vi.fn(async () => ({ success: true as const })),
     broadcastSessionBranch: vi.fn(),
     broadcastArtifactCreated: vi.fn(),
+    appName: "Open-Inspect",
   };
 
   const service = new SessionPullRequestService(deps);
@@ -287,6 +288,22 @@ describe("SessionPullRequestService", () => {
       },
       createdAt: expect.any(Number),
     });
+  });
+
+  it("uses the configured appName in the PR body footer", async () => {
+    const customDeps = { ...harness.deps, appName: "Acme Bot" };
+    const customService = new SessionPullRequestService(customDeps);
+
+    await customService.createPullRequest(
+      createInput({ promptingAuth: { authType: "oauth", token: "user-token" } })
+    );
+
+    const createPrCall = (harness.provider.createPullRequest as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(createPrCall[1].body).toContain(
+      "*Created with [Acme Bot](https://app.example.com/session/session-name-1)*"
+    );
+    expect(createPrCall[1].body).not.toContain("Open-Inspect");
   });
 
   it("syncs the branch after push and before PR creation", async () => {

--- a/packages/control-plane/src/session/pull-request-service.ts
+++ b/packages/control-plane/src/session/pull-request-service.ts
@@ -61,6 +61,8 @@ export interface PullRequestServiceDeps {
   pushBranchToRemote: (headBranch: string, pushSpec: GitPushSpec) => Promise<PushBranchResult>;
   broadcastSessionBranch: (branchName: string) => void;
   broadcastArtifactCreated: (artifact: SessionArtifact) => void;
+  /** Display name used in the PR body footer (e.g. "Created with [name](url)"). */
+  appName: string;
 }
 
 /**
@@ -183,7 +185,8 @@ export class SessionPullRequestService {
       // (e.g. sessions triggered from Linear or other integrations without user GitHub OAuth)
       const prAuth = input.promptingAuth ?? appAuth;
 
-      const fullBody = input.body + `\n\n---\n*Created with [Open-Inspect](${input.sessionUrl})*`;
+      const fullBody =
+        input.body + `\n\n---\n*Created with [${this.deps.appName}](${input.sessionUrl})*`;
 
       const prResult = await this.deps.sourceControlProvider.createPullRequest(prAuth, {
         repository: repoInfo,

--- a/packages/control-plane/src/source-control/providers/constants.ts
+++ b/packages/control-plane/src/source-control/providers/constants.ts
@@ -2,8 +2,10 @@
  * Provider constants.
  */
 
-/** User-Agent header for API requests. */
-export const USER_AGENT = "Open-Inspect";
+import { DEFAULT_APP_NAME } from "@open-inspect/shared";
+
+/** Default User-Agent header used when a per-deployment app name is not configured. */
+export const USER_AGENT = DEFAULT_APP_NAME;
 
 /** GitHub API base URL. */
 export const GITHUB_API_BASE = "https://api.github.com";

--- a/packages/control-plane/src/source-control/providers/github-provider.test.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.test.ts
@@ -176,4 +176,55 @@ describe("GitHubSourceControlProvider", () => {
 
     expect(spec.force).toBe(false);
   });
+
+  describe("userAgent threading", () => {
+    it("forwards configured userAgent to listInstallationRepositories", async () => {
+      mockListInstallationRepositories.mockResolvedValueOnce({
+        repos: [],
+        timing: { tokenGenerationMs: 0, pages: [], totalPages: 0, totalRepos: 0 },
+      });
+
+      const provider = new GitHubSourceControlProvider({
+        appConfig: fakeAppConfig,
+        userAgent: "Acme Bot",
+      });
+      await provider.listRepositories();
+
+      expect(mockListInstallationRepositories).toHaveBeenCalledWith(
+        fakeAppConfig,
+        expect.objectContaining({ userAgent: "Acme Bot" })
+      );
+    });
+
+    it("forwards configured userAgent to getInstallationRepository", async () => {
+      mockGetInstallationRepository.mockResolvedValueOnce(null);
+
+      const provider = new GitHubSourceControlProvider({
+        appConfig: fakeAppConfig,
+        userAgent: "Acme Bot",
+      });
+      await provider.checkRepositoryAccess({ owner: "acme", name: "web" });
+
+      expect(mockGetInstallationRepository).toHaveBeenCalledWith(
+        fakeAppConfig,
+        "acme",
+        "web",
+        expect.objectContaining({ userAgent: "Acme Bot" })
+      );
+    });
+
+    it("falls back to the default User-Agent when none is configured", async () => {
+      mockGetInstallationRepository.mockResolvedValueOnce(null);
+
+      const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+      await provider.checkRepositoryAccess({ owner: "acme", name: "web" });
+
+      expect(mockGetInstallationRepository).toHaveBeenCalledWith(
+        fakeAppConfig,
+        "acme",
+        "web",
+        expect.objectContaining({ userAgent: "Open-Inspect" })
+      );
+    });
+  });
 });

--- a/packages/control-plane/src/source-control/providers/github-provider.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.ts
@@ -46,10 +46,20 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
 
   private readonly appConfig?: GitHubProviderConfig["appConfig"];
   private readonly cacheStore?: GitHubProviderConfig["cacheStore"];
+  private readonly userAgent: string;
 
   constructor(config: GitHubProviderConfig = {}) {
     this.appConfig = config.appConfig;
     this.cacheStore = config.cacheStore;
+    this.userAgent = config.userAgent || USER_AGENT;
+  }
+
+  /** Bindings passed to github-app helpers so they share cache + User-Agent. */
+  private installationBindings() {
+    return {
+      cacheStore: this.cacheStore,
+      userAgent: this.userAgent,
+    };
   }
 
   /**
@@ -65,7 +75,7 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
         headers: {
           Accept: "application/vnd.github.v3+json",
           Authorization: `Bearer ${auth.token}`,
-          "User-Agent": USER_AGENT,
+          "User-Agent": this.userAgent,
         },
       }
     );
@@ -124,7 +134,7 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
         headers: {
           Accept: "application/vnd.github.v3+json",
           Authorization: `Bearer ${auth.token}`,
-          "User-Agent": USER_AGENT,
+          "User-Agent": this.userAgent,
           "Content-Type": "application/json",
         },
         body: JSON.stringify(requestBody),
@@ -216,7 +226,7 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
         this.appConfig,
         config.owner,
         config.name,
-        this.cacheStore ? { cacheStore: this.cacheStore } : undefined
+        this.installationBindings()
       );
       if (!repo) {
         return null;
@@ -250,7 +260,7 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
     try {
       const result = await listInstallationRepositories(
         this.appConfig,
-        this.cacheStore ? { cacheStore: this.cacheStore } : undefined
+        this.installationBindings()
       );
       return result.repos;
     } catch (error) {
@@ -278,7 +288,7 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
         this.appConfig,
         config.owner,
         config.name,
-        this.cacheStore ? { cacheStore: this.cacheStore } : undefined
+        this.installationBindings()
       );
     } catch (error) {
       throw SourceControlProviderError.fromFetchError(
@@ -301,7 +311,7 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
     }
 
     try {
-      const token = await getCachedInstallationToken(this.appConfig);
+      const token = await getCachedInstallationToken(this.appConfig, this.installationBindings());
       return {
         authType: "app",
         token,
@@ -355,7 +365,7 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
           headers: {
             Accept: "application/vnd.github.v3+json",
             Authorization: `Bearer ${accessToken}`,
-            "User-Agent": USER_AGENT,
+            "User-Agent": this.userAgent,
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ labels }),
@@ -390,7 +400,7 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
           headers: {
             Accept: "application/vnd.github.v3+json",
             Authorization: `Bearer ${accessToken}`,
-            "User-Agent": USER_AGENT,
+            "User-Agent": this.userAgent,
             "Content-Type": "application/json",
           },
           body: JSON.stringify({ reviewers }),

--- a/packages/control-plane/src/source-control/providers/github-provider.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.ts
@@ -54,14 +54,6 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
     this.userAgent = config.userAgent || USER_AGENT;
   }
 
-  /** Bindings passed to github-app helpers so they share cache + User-Agent. */
-  private installationBindings() {
-    return {
-      cacheStore: this.cacheStore,
-      userAgent: this.userAgent,
-    };
-  }
-
   /**
    * Get repository information from GitHub API.
    */
@@ -222,12 +214,10 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
     }
 
     try {
-      const repo = await getInstallationRepository(
-        this.appConfig,
-        config.owner,
-        config.name,
-        this.installationBindings()
-      );
+      const repo = await getInstallationRepository(this.appConfig, config.owner, config.name, {
+        cacheStore: this.cacheStore,
+        userAgent: this.userAgent,
+      });
       if (!repo) {
         return null;
       }
@@ -258,10 +248,10 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
     }
 
     try {
-      const result = await listInstallationRepositories(
-        this.appConfig,
-        this.installationBindings()
-      );
+      const result = await listInstallationRepositories(this.appConfig, {
+        cacheStore: this.cacheStore,
+        userAgent: this.userAgent,
+      });
       return result.repos;
     } catch (error) {
       throw SourceControlProviderError.fromFetchError(
@@ -284,12 +274,10 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
     }
 
     try {
-      return await listRepositoryBranches(
-        this.appConfig,
-        config.owner,
-        config.name,
-        this.installationBindings()
-      );
+      return await listRepositoryBranches(this.appConfig, config.owner, config.name, {
+        cacheStore: this.cacheStore,
+        userAgent: this.userAgent,
+      });
     } catch (error) {
       throw SourceControlProviderError.fromFetchError(
         `Failed to list branches: ${error instanceof Error ? error.message : String(error)}`,
@@ -311,7 +299,10 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
     }
 
     try {
-      const token = await getCachedInstallationToken(this.appConfig, this.installationBindings());
+      const token = await getCachedInstallationToken(this.appConfig, {
+        cacheStore: this.cacheStore,
+        userAgent: this.userAgent,
+      });
       return {
         authType: "app",
         token,

--- a/packages/control-plane/src/source-control/providers/gitlab-provider.ts
+++ b/packages/control-plane/src/source-control/providers/gitlab-provider.ts
@@ -55,16 +55,18 @@ export class GitLabSourceControlProvider implements SourceControlProvider {
 
   private readonly accessToken: string;
   private readonly namespace?: string;
+  private readonly userAgent: string;
 
   constructor(config: GitLabProviderConfig) {
     this.accessToken = config.accessToken;
     this.namespace = config.namespace;
+    this.userAgent = config.userAgent || USER_AGENT;
   }
 
   private headers(token: string): Record<string, string> {
     return {
       Authorization: `Bearer ${token}`,
-      "User-Agent": USER_AGENT,
+      "User-Agent": this.userAgent,
     };
   }
 

--- a/packages/control-plane/src/source-control/providers/types.ts
+++ b/packages/control-plane/src/source-control/providers/types.ts
@@ -13,6 +13,8 @@ export interface GitHubProviderConfig {
   appConfig?: GitHubAppConfig;
   /** Cache store for caching installation tokens */
   cacheStore?: CacheStore;
+  /** User-Agent value sent on outbound GitHub API requests */
+  userAgent?: string;
 }
 
 /**
@@ -23,4 +25,6 @@ export interface GitLabProviderConfig {
   accessToken: string;
   /** GitLab group namespace to scope repository listing (optional) */
   namespace?: string;
+  /** User-Agent value sent on outbound GitLab API requests */
+  userAgent?: string;
 }

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -74,6 +74,7 @@ export interface Env {
 
   // Variables
   DEPLOYMENT_NAME: string;
+  APP_NAME?: string; // Display name for user-visible UI, PR footers, and HTTP User-Agent headers
   SCM_PROVIDER?: string; // Source control provider for this deployment (default: github)
   WORKER_URL?: string; // Base URL for the worker (for callbacks)
   WEB_APP_URL?: string; // Base URL for the web app (for PR links)

--- a/packages/github-bot/src/github-auth.ts
+++ b/packages/github-bot/src/github-auth.ts
@@ -1,7 +1,11 @@
+import { DEFAULT_APP_NAME } from "@open-inspect/shared";
+
 export interface GitHubAppConfig {
   appId: string;
   privateKey: string;
   installationId: string;
+  /** User-Agent header sent on outbound GitHub API requests. */
+  userAgent?: string;
 }
 
 function base64UrlEncode(input: Uint8Array | string): string {
@@ -63,7 +67,11 @@ export async function generateAppJwt(appId: string, privateKey: string): Promise
   return `${signingInput}.${base64UrlEncode(new Uint8Array(signature))}`;
 }
 
-async function getInstallationToken(jwt: string, installationId: string): Promise<string> {
+async function getInstallationToken(
+  jwt: string,
+  installationId: string,
+  userAgent: string
+): Promise<string> {
   const url = `https://api.github.com/app/installations/${installationId}/access_tokens`;
   const response = await fetch(url, {
     method: "POST",
@@ -71,7 +79,7 @@ async function getInstallationToken(jwt: string, installationId: string): Promis
       Authorization: `Bearer ${jwt}`,
       Accept: "application/vnd.github+json",
       "X-GitHub-Api-Version": "2022-11-28",
-      "User-Agent": "Open-Inspect",
+      "User-Agent": userAgent,
     },
   });
 
@@ -86,7 +94,7 @@ async function getInstallationToken(jwt: string, installationId: string): Promis
 
 export async function generateInstallationToken(config: GitHubAppConfig): Promise<string> {
   const jwt = await generateAppJwt(config.appId, config.privateKey);
-  return getInstallationToken(jwt, config.installationId);
+  return getInstallationToken(jwt, config.installationId, config.userAgent || DEFAULT_APP_NAME);
 }
 
 const WRITE_PERMISSIONS = new Set(["write", "maintain", "admin"]);
@@ -100,7 +108,8 @@ export async function checkSenderPermission(
   token: string,
   owner: string,
   repo: string,
-  username: string
+  username: string,
+  userAgent: string = DEFAULT_APP_NAME
 ): Promise<PermissionCheckResult> {
   try {
     const response = await fetch(
@@ -110,7 +119,7 @@ export async function checkSenderPermission(
           Authorization: `Bearer ${token}`,
           Accept: "application/vnd.github+json",
           "X-GitHub-Api-Version": "2022-11-28",
-          "User-Agent": "Open-Inspect",
+          "User-Agent": userAgent,
         },
       }
     );
@@ -122,7 +131,12 @@ export async function checkSenderPermission(
   }
 }
 
-export async function postReaction(token: string, url: string, content: string): Promise<boolean> {
+export async function postReaction(
+  token: string,
+  url: string,
+  content: string,
+  userAgent: string = DEFAULT_APP_NAME
+): Promise<boolean> {
   try {
     const response = await fetch(url, {
       method: "POST",
@@ -130,7 +144,7 @@ export async function postReaction(token: string, url: string, content: string):
         Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
-        "User-Agent": "Open-Inspect",
+        "User-Agent": userAgent,
       },
       body: JSON.stringify({ content }),
     });

--- a/packages/github-bot/src/handlers.ts
+++ b/packages/github-bot/src/handlers.ts
@@ -1,3 +1,4 @@
+import { resolveAppName } from "@open-inspect/shared";
 import type {
   Env,
   PullRequestOpenedPayload,
@@ -90,9 +91,10 @@ function fireAndForgetReaction(
   log: Logger,
   token: string,
   url: string,
+  userAgent: string,
   meta: Record<string, unknown>
 ): void {
-  postReaction(token, url, "eyes").then(
+  postReaction(token, url, "eyes", userAgent).then(
     (ok) => {
       if (ok) log.debug("acknowledgment.posted", meta);
       else log.warn("acknowledgment.failed", meta);
@@ -125,11 +127,13 @@ async function resolveCallerGating(
     }
   }
 
+  const userAgent = resolveAppName(env);
   const [ghToken, headers] = await Promise.all([
     generateInstallationToken({
       appId: env.GITHUB_APP_ID,
       privateKey: env.GITHUB_APP_PRIVATE_KEY,
       installationId: env.GITHUB_APP_INSTALLATION_ID,
+      userAgent,
     }),
     getAuthHeaders(env, traceId),
   ]);
@@ -139,7 +143,8 @@ async function resolveCallerGating(
       ghToken,
       owner,
       repoName,
-      senderLogin
+      senderLogin,
+      userAgent
     );
     if (!hasPermission) {
       const reason = error ? "permission_check_failed" : "sender_insufficient_permission";
@@ -202,6 +207,7 @@ export async function handleReviewRequested(
     log,
     ghToken,
     `https://api.github.com/repos/${owner}/${repoName}/issues/${pr.number}/reactions`,
+    resolveAppName(env),
     meta
   );
 
@@ -301,6 +307,7 @@ export async function handlePullRequestOpened(
     log,
     ghToken,
     `https://api.github.com/repos/${owner}/${repoName}/issues/${pr.number}/reactions`,
+    resolveAppName(env),
     meta
   );
 
@@ -406,6 +413,7 @@ export async function handleIssueComment(
     log,
     ghToken,
     `https://api.github.com/repos/${owner}/${repoName}/issues/comments/${comment.id}/reactions`,
+    resolveAppName(env),
     meta
   );
 
@@ -504,6 +512,7 @@ export async function handleReviewComment(
     log,
     ghToken,
     `https://api.github.com/repos/${owner}/${repoName}/pulls/comments/${comment.id}/reactions`,
+    resolveAppName(env),
     meta
   );
 

--- a/packages/github-bot/src/types.ts
+++ b/packages/github-bot/src/types.ts
@@ -11,6 +11,9 @@ export interface Env {
   /** Deployment name for logging/identification. */
   DEPLOYMENT_NAME: string;
 
+  /** Display name shown in user-visible bot messages and HTTP User-Agent headers. */
+  APP_NAME?: string;
+
   /** Default model ID for new sessions. */
   DEFAULT_MODEL: string;
 

--- a/packages/github-bot/test/github-auth.test.ts
+++ b/packages/github-bot/test/github-auth.test.ts
@@ -105,6 +105,30 @@ describe("postReaction", () => {
     const result = await postReaction("tok", "https://api.github.com/test", "eyes");
     expect(result).toBe(false);
   });
+
+  it("uses the configured User-Agent when one is provided", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(new Response("", { status: 201 }));
+    await postReaction("tok", "https://api.github.com/test", "eyes", "Acme Bot");
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://api.github.com/test",
+      expect.objectContaining({
+        headers: expect.objectContaining({ "User-Agent": "Acme Bot" }),
+      })
+    );
+  });
+
+  it("defaults the User-Agent to Open-Inspect when omitted", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(new Response("", { status: 201 }));
+    await postReaction("tok", "https://api.github.com/test", "eyes");
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://api.github.com/test",
+      expect.objectContaining({
+        headers: expect.objectContaining({ "User-Agent": "Open-Inspect" }),
+      })
+    );
+  });
 });
 
 describe("checkSenderPermission", () => {
@@ -186,6 +210,20 @@ describe("checkSenderPermission", () => {
           "User-Agent": "Open-Inspect",
         },
       }
+    );
+  });
+
+  it("uses the configured User-Agent when one is provided", async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(JSON.stringify({ permission: "write" }), { status: 200 })
+    );
+    await checkSenderPermission("tok", "acme", "widgets", "alice", "Acme Bot");
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({ "User-Agent": "Acme Bot" }),
+      })
     );
   });
 });

--- a/packages/github-bot/test/handlers.test.ts
+++ b/packages/github-bot/test/handlers.test.ts
@@ -188,7 +188,8 @@ describe("handlePullRequestOpened", () => {
     expect(postReaction).toHaveBeenCalledWith(
       "test-installation-token",
       "https://api.github.com/repos/acme/widgets/issues/42/reactions",
-      "eyes"
+      "eyes",
+      "Open-Inspect"
     );
 
     const cpFetch = getControlPlaneFetch(env);
@@ -350,12 +351,14 @@ describe("handleReviewRequested", () => {
       appId: "12345",
       privateKey: "test-key",
       installationId: "67890",
+      userAgent: "Open-Inspect",
     });
 
     expect(postReaction).toHaveBeenCalledWith(
       "test-installation-token",
       "https://api.github.com/repos/acme/widgets/issues/42/reactions",
-      "eyes"
+      "eyes",
+      "Open-Inspect"
     );
 
     const cpFetch = getControlPlaneFetch(env);
@@ -457,7 +460,8 @@ describe("handleIssueComment", () => {
     expect(postReaction).toHaveBeenCalledWith(
       "test-installation-token",
       "https://api.github.com/repos/acme/widgets/issues/comments/100/reactions",
-      "eyes"
+      "eyes",
+      "Open-Inspect"
     );
 
     const cpFetch = getControlPlaneFetch(env);
@@ -555,7 +559,8 @@ describe("handleReviewComment", () => {
     expect(postReaction).toHaveBeenCalledWith(
       "test-installation-token",
       "https://api.github.com/repos/acme/widgets/pulls/comments/200/reactions",
-      "eyes"
+      "eyes",
+      "Open-Inspect"
     );
 
     const cpFetch = getControlPlaneFetch(env);

--- a/packages/linear-bot/src/__tests__/pure-functions.test.ts
+++ b/packages/linear-bot/src/__tests__/pure-functions.test.ts
@@ -5,7 +5,27 @@ import {
   resolveStaticRepo,
 } from "../model-resolution";
 import { isValidPayload, verifyCallbackSignature } from "../callbacks";
+import { buildOAuthSuccessHtml } from "../index";
 import type { CompletionCallback } from "../types";
+
+describe("buildOAuthSuccessHtml", () => {
+  it("renders the configured app name in the heading", () => {
+    const html = buildOAuthSuccessHtml("Acme Bot", "My Workspace");
+    expect(html).toContain("<h1>Acme Bot Agent Installed!</h1>");
+    expect(html).toContain("<strong>My Workspace</strong>");
+  });
+
+  it("escapes the app name to prevent HTML injection", () => {
+    const html = buildOAuthSuccessHtml("<script>alert(1)</script>", "Acme");
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("escapes the workspace name to prevent HTML injection", () => {
+    const html = buildOAuthSuccessHtml("Open-Inspect", "Evil <img src=x>");
+    expect(html).toContain("Evil &lt;img src=x&gt;");
+  });
+});
 
 // ─── extractModelFromLabels ──────────────────────────────────────────────────
 

--- a/packages/linear-bot/src/callbacks.helpers.test.ts
+++ b/packages/linear-bot/src/callbacks.helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatToolAction, isValidToolCallPayload } from "./callbacks";
+import { formatCompletionComment, formatToolAction, isValidToolCallPayload } from "./callbacks";
 
 // ─── formatToolAction ────────────────────────────────────────────────────────
 
@@ -59,6 +59,28 @@ describe("formatToolAction", () => {
 
   it("unknown tool → 'Using tool: {name}'", () => {
     expect(formatToolAction("search_files", { query: "foo" })).toBe("Using tool: search_files");
+  });
+});
+
+// ─── formatCompletionComment ─────────────────────────────────────────────────
+
+describe("formatCompletionComment", () => {
+  it("uses the configured app name on success", () => {
+    expect(formatCompletionComment("Acme Bot", true, "All set.")).toBe(
+      "## 🤖 Acme Bot completed\n\nAll set."
+    );
+  });
+
+  it("uses the configured app name on failure", () => {
+    expect(formatCompletionComment("Acme Bot", false, "Something went wrong.")).toBe(
+      "## ⚠️ Acme Bot encountered an issue\n\nSomething went wrong."
+    );
+  });
+
+  it("works with the default Open-Inspect name", () => {
+    expect(formatCompletionComment("Open-Inspect", true, "ok")).toBe(
+      "## 🤖 Open-Inspect completed\n\nok"
+    );
   });
 });
 

--- a/packages/linear-bot/src/callbacks.ts
+++ b/packages/linear-bot/src/callbacks.ts
@@ -12,7 +12,7 @@ import {
   updateAgentSession,
 } from "./utils/linear-client";
 import { extractAgentResponse, formatAgentResponse } from "./completion/extractor";
-import { timingSafeEqual } from "@open-inspect/shared";
+import { resolveAppName, timingSafeEqual } from "@open-inspect/shared";
 import { computeHmacHex } from "./utils/crypto";
 import { makePlan } from "./plan";
 import { createLogger } from "./logger";
@@ -26,6 +26,16 @@ export async function verifyCallbackSignature<T extends { signature: string }>(
   const { signature, ...data } = payload;
   const expectedHex = await computeHmacHex(JSON.stringify(data), secret);
   return timingSafeEqual(signature, expectedHex);
+}
+
+export function formatCompletionComment(
+  appName: string,
+  success: boolean,
+  message: string
+): string {
+  return success
+    ? `## 🤖 ${appName} completed\n\n${message}`
+    : `## ⚠️ ${appName} encountered an issue\n\n${message}`;
 }
 
 export function isValidPayload(payload: unknown): payload is CompletionCallback {
@@ -333,9 +343,7 @@ async function handleCompletionCallback(
       return;
     }
 
-    const commentBody = payload.success
-      ? `## 🤖 Open-Inspect completed\n\n${message}`
-      : `## ⚠️ Open-Inspect encountered an issue\n\n${message}`;
+    const commentBody = formatCompletionComment(resolveAppName(env), payload.success, message);
 
     const result = await postIssueComment(env.LINEAR_API_KEY, context.issueId, commentBody);
 

--- a/packages/linear-bot/src/index.ts
+++ b/packages/linear-bot/src/index.ts
@@ -14,7 +14,7 @@ import {
 } from "./utils/linear-client";
 import { callbacksRouter } from "./callbacks";
 import { createLogger } from "./logger";
-import { verifyInternalToken } from "@open-inspect/shared";
+import { resolveAppName, verifyInternalToken } from "@open-inspect/shared";
 import { handleAgentSessionEvent, escapeHtml } from "./webhook-handler";
 import {
   getTeamRepoMapping,
@@ -40,6 +40,19 @@ function isObjectRecord(value: unknown): value is Record<string, unknown> {
 function readStringField(record: Record<string, unknown>, key: string): string | null {
   const value = record[key];
   return typeof value === "string" ? value : null;
+}
+
+export function buildOAuthSuccessHtml(appName: string, orgName: string): string {
+  return `
+      <html>
+        <head><title>OAuth Success</title></head>
+        <body>
+          <h1>${escapeHtml(appName)} Agent Installed!</h1>
+          <p>Successfully connected to workspace: <strong>${escapeHtml(orgName)}</strong></p>
+          <p>You can now @mention or assign the agent on Linear issues.</p>
+        </body>
+      </html>
+    `;
 }
 
 function isAgentSessionWebhookPayload(payload: unknown): payload is AgentSessionWebhook {
@@ -81,16 +94,7 @@ app.get("/oauth/callback", async (c) => {
 
   try {
     const { orgName } = await exchangeCodeForToken(c.env, code);
-    return c.html(`
-      <html>
-        <head><title>OAuth Success</title></head>
-        <body>
-          <h1>Open-Inspect Agent Installed!</h1>
-          <p>Successfully connected to workspace: <strong>${escapeHtml(orgName)}</strong></p>
-          <p>You can now @mention or assign the agent on Linear issues.</p>
-        </body>
-      </html>
-    `);
+    return c.html(buildOAuthSuccessHtml(resolveAppName(c.env), orgName));
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     log.error("oauth.callback_error", { error: err instanceof Error ? err : new Error(msg) });

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -17,6 +17,7 @@ export interface Env {
   CONTROL_PLANE_URL: string;
   WEB_APP_URL: string;
   DEFAULT_MODEL: string;
+  APP_NAME?: string;
 
   // OAuth app credentials
   LINEAR_CLIENT_ID: string;

--- a/packages/shared/src/app-name.test.ts
+++ b/packages/shared/src/app-name.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_APP_NAME, resolveAppName } from "./app-name";
+
+describe("resolveAppName", () => {
+  it("returns the default when env is undefined", () => {
+    expect(resolveAppName(undefined)).toBe(DEFAULT_APP_NAME);
+  });
+
+  it("returns the default when env is null", () => {
+    expect(resolveAppName(null)).toBe(DEFAULT_APP_NAME);
+  });
+
+  it("returns the default when APP_NAME is missing", () => {
+    expect(resolveAppName({})).toBe(DEFAULT_APP_NAME);
+  });
+
+  it("returns the default when APP_NAME is empty", () => {
+    expect(resolveAppName({ APP_NAME: "" })).toBe(DEFAULT_APP_NAME);
+  });
+
+  it("returns the default when APP_NAME is only whitespace", () => {
+    expect(resolveAppName({ APP_NAME: "   " })).toBe(DEFAULT_APP_NAME);
+  });
+
+  it("returns a configured value", () => {
+    expect(resolveAppName({ APP_NAME: "Acme Bot" })).toBe("Acme Bot");
+  });
+
+  it("trims surrounding whitespace from a configured value", () => {
+    expect(resolveAppName({ APP_NAME: "  Acme Bot  " })).toBe("Acme Bot");
+  });
+
+  it("DEFAULT_APP_NAME is Open-Inspect", () => {
+    expect(DEFAULT_APP_NAME).toBe("Open-Inspect");
+  });
+});

--- a/packages/shared/src/app-name.ts
+++ b/packages/shared/src/app-name.ts
@@ -1,0 +1,10 @@
+export const DEFAULT_APP_NAME = "Open-Inspect";
+
+export interface AppNameEnv {
+  APP_NAME?: string;
+}
+
+export function resolveAppName(env?: AppNameEnv | null): string {
+  const value = env?.APP_NAME?.trim();
+  return value && value.length > 0 ? value : DEFAULT_APP_NAME;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,3 +11,4 @@ export * from "./triggers";
 export * from "./completion/extractor";
 export * from "./logger";
 export * from "./cache-store";
+export * from "./app-name";

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -22,8 +22,20 @@ vi.mock("./utils/slack-client", async () => {
   };
 });
 
-import app from "./index";
+import app, { buildAppHomeIntroText } from "./index";
 import { clearLocalCache } from "./classifier/repos";
+
+describe("buildAppHomeIntroText", () => {
+  it("uses the configured app name", () => {
+    expect(buildAppHomeIntroText("Acme Bot")).toBe("Configure your Acme Bot preferences below.");
+  });
+
+  it("works with the default Open-Inspect name", () => {
+    expect(buildAppHomeIntroText("Open-Inspect")).toBe(
+      "Configure your Open-Inspect preferences below."
+    );
+  });
+});
 
 function createMockKV() {
   const store = new Map<string, string>();

--- a/packages/slack-bot/src/index.ts
+++ b/packages/slack-bot/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { Hono } from "hono";
+import { resolveAppName } from "@open-inspect/shared";
 import type {
   Env,
   RepoConfig,
@@ -64,6 +65,10 @@ import {
 const log = createLogger("handler");
 
 const MAX_REPO_SUGGESTION_OPTIONS = 100;
+
+export function buildAppHomeIntroText(appName: string): string {
+  return `Configure your ${appName} preferences below.`;
+}
 
 /**
  * Build authenticated headers for control plane requests.
@@ -491,7 +496,7 @@ async function publishAppHome(env: Env, userId: string): Promise<void> {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: "Configure your Open-Inspect preferences below.",
+        text: buildAppHomeIntroText(resolveAppName(env)),
       },
     },
     { type: "divider" },

--- a/packages/slack-bot/src/types/index.ts
+++ b/packages/slack-bot/src/types/index.ts
@@ -18,6 +18,7 @@ export interface Env {
   WEB_APP_URL: string;
   DEFAULT_MODEL: string;
   CLASSIFICATION_MODEL: string;
+  APP_NAME?: string;
 
   // Secrets
   SLACK_BOT_TOKEN: string;

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -11,6 +11,7 @@ import { ErrorBanner } from "@/components/ui/error-banner";
 import { formatModelNameLower } from "@/lib/format";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import { SIDEBAR_SESSIONS_KEY } from "@/lib/session-list";
+import { APP_NAME } from "@/lib/site-config";
 import {
   DEFAULT_MODEL,
   getDefaultReasoningEffort,
@@ -373,7 +374,7 @@ function HomeContent({
         <div className="w-full max-w-2xl">
           {/* Welcome text */}
           <div className="text-center mb-8">
-            <h1 className="text-3xl font-semibold text-foreground mb-2">Welcome to Open-Inspect</h1>
+            <h1 className="text-3xl font-semibold text-foreground mb-2">Welcome to {APP_NAME}</h1>
             {isAuthenticated ? (
               <p className="text-muted-foreground">
                 Ask a question or describe what you want to build

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Providers } from "./providers";
+import { APP_ICON_URL, APP_NAME } from "@/lib/site-config";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -14,8 +15,9 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Open-Inspect",
+  title: APP_NAME,
   description: "Background coding agent for your team",
+  ...(APP_ICON_URL ? { icons: { icon: APP_ICON_URL } } : {}),
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/packages/web/src/components/global-command-menu.tsx
+++ b/packages/web/src/components/global-command-menu.tsx
@@ -4,13 +4,8 @@ import { useMemo } from "react";
 import type { Session } from "@open-inspect/shared";
 import { formatRelativeTime } from "@/lib/time";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
-import {
-  AutomationsIcon,
-  BranchIcon,
-  InspectIcon,
-  PlusIcon,
-  SettingsIcon,
-} from "@/components/ui/icons";
+import { AutomationsIcon, BranchIcon, PlusIcon, SettingsIcon } from "@/components/ui/icons";
+import { AppIcon } from "@/components/ui/app-icon";
 import {
   Command,
   CommandDialog,
@@ -80,7 +75,7 @@ export function GlobalCommandMenu({
               <CommandShortcut>{SHORTCUT_LABELS.NEW_SESSION}</CommandShortcut>
             </CommandItem>
             <CommandItem onSelect={() => handleSelect(() => onNavigate("/"))}>
-              <InspectIcon className="h-4 w-4" />
+              <AppIcon className="h-4 w-4" />
               <span>Home</span>
             </CommandItem>
             <CommandItem onSelect={() => handleSelect(() => onNavigate("/settings"))}>

--- a/packages/web/src/components/session-sidebar.test.tsx
+++ b/packages/web/src/components/session-sidebar.test.tsx
@@ -182,7 +182,7 @@ describe("SessionSidebar", () => {
       </SWRConfig>
     );
 
-    fireEvent.click(screen.getByRole("link", { name: /^inspect$/i }));
+    fireEvent.click(screen.getByRole("link", { name: /^open-inspect$/i }));
     fireEvent.click(screen.getByTitle("Settings"));
     fireEvent.click(screen.getByRole("link", { name: /automations/i }));
     fireEvent.click(screen.getByRole("link", { name: /analytics/i }));

--- a/packages/web/src/components/session-sidebar.test.tsx
+++ b/packages/web/src/components/session-sidebar.test.tsx
@@ -182,7 +182,7 @@ describe("SessionSidebar", () => {
       </SWRConfig>
     );
 
-    fireEvent.click(screen.getByRole("link", { name: /^open-inspect$/i }));
+    fireEvent.click(screen.getByRole("link", { name: /^inspect$/i }));
     fireEvent.click(screen.getByTitle("Settings"));
     fireEvent.click(screen.getByRole("link", { name: /automations/i }));
     fireEvent.click(screen.getByRole("link", { name: /analytics/i }));

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -29,7 +29,7 @@ import {
   DataControlsIcon,
 } from "@/components/ui/icons";
 import { AppIcon } from "@/components/ui/app-icon";
-import { APP_NAME } from "@/lib/site-config";
+import { APP_SHORT_NAME } from "@/lib/site-config";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -274,7 +274,7 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
           </Button>
           <Link href="/" onClick={handleNavigationSelect} className="flex items-center gap-2">
             <AppIcon className="w-5 h-5" />
-            <span className="font-semibold text-foreground">{APP_NAME}</span>
+            <span className="font-semibold text-foreground">{APP_SHORT_NAME}</span>
           </Link>
         </div>
         <div className="flex items-center gap-2">

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -21,7 +21,6 @@ import { useIsMobile } from "@/hooks/use-media-query";
 import {
   MoreIcon,
   SidebarIcon,
-  InspectIcon,
   ArchiveIcon,
   PlusIcon,
   SettingsIcon,
@@ -29,6 +28,8 @@ import {
   BranchIcon,
   DataControlsIcon,
 } from "@/components/ui/icons";
+import { AppIcon } from "@/components/ui/app-icon";
+import { APP_NAME } from "@/lib/site-config";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -272,8 +273,8 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
             <SidebarIcon className="w-4 h-4" />
           </Button>
           <Link href="/" onClick={handleNavigationSelect} className="flex items-center gap-2">
-            <InspectIcon className="w-5 h-5" />
-            <span className="font-semibold text-foreground">Inspect</span>
+            <AppIcon className="w-5 h-5" />
+            <span className="font-semibold text-foreground">{APP_NAME}</span>
           </Link>
         </div>
         <div className="flex items-center gap-2">

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -12,6 +12,7 @@ import { useGlobalShortcuts } from "@/hooks/use-global-shortcuts";
 import { SIDEBAR_SESSIONS_KEY, type SessionListResponse } from "@/lib/session-list";
 import { Button } from "@/components/ui/button";
 import { GitHubIcon } from "@/components/ui/icons";
+import { APP_NAME } from "@/lib/site-config";
 
 interface SidebarContextValue {
   isOpen: boolean;
@@ -89,7 +90,7 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
   if (!session) {
     return (
       <div className="min-h-screen flex flex-col items-center justify-center gap-8">
-        <h1 className="text-4xl font-bold text-foreground">Open-Inspect</h1>
+        <h1 className="text-4xl font-bold text-foreground">{APP_NAME}</h1>
         <p className="text-muted-foreground max-w-md text-center">
           Background coding agent for your team. Ship faster with AI-powered code changes.
         </p>

--- a/packages/web/src/components/ui/app-icon.tsx
+++ b/packages/web/src/components/ui/app-icon.tsx
@@ -1,0 +1,13 @@
+import { APP_ICON_URL, APP_NAME } from "@/lib/site-config";
+import { InspectIcon } from "@/components/ui/icons";
+
+interface AppIconProps {
+  className?: string;
+}
+
+export function AppIcon({ className }: AppIconProps) {
+  if (APP_ICON_URL) {
+    return <img src={APP_ICON_URL} alt={`${APP_NAME} logo`} className={className} />;
+  }
+  return <InspectIcon className={className} />;
+}

--- a/packages/web/src/lib/site-config.test.ts
+++ b/packages/web/src/lib/site-config.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("site-config", () => {
   const originalAppName = process.env.NEXT_PUBLIC_APP_NAME;
+  const originalShortName = process.env.NEXT_PUBLIC_APP_SHORT_NAME;
   const originalIconUrl = process.env.NEXT_PUBLIC_APP_ICON_URL;
 
   beforeEach(() => {
@@ -13,6 +14,11 @@ describe("site-config", () => {
       delete process.env.NEXT_PUBLIC_APP_NAME;
     } else {
       process.env.NEXT_PUBLIC_APP_NAME = originalAppName;
+    }
+    if (originalShortName === undefined) {
+      delete process.env.NEXT_PUBLIC_APP_SHORT_NAME;
+    } else {
+      process.env.NEXT_PUBLIC_APP_SHORT_NAME = originalShortName;
     }
     if (originalIconUrl === undefined) {
       delete process.env.NEXT_PUBLIC_APP_ICON_URL;
@@ -43,6 +49,27 @@ describe("site-config", () => {
     process.env.NEXT_PUBLIC_APP_NAME = "  Acme Bot  ";
     const { APP_NAME } = await import("./site-config");
     expect(APP_NAME).toBe("Acme Bot");
+  });
+
+  it("APP_SHORT_NAME defaults to 'Inspect' when nothing is set", async () => {
+    delete process.env.NEXT_PUBLIC_APP_NAME;
+    delete process.env.NEXT_PUBLIC_APP_SHORT_NAME;
+    const { APP_SHORT_NAME } = await import("./site-config");
+    expect(APP_SHORT_NAME).toBe("Inspect");
+  });
+
+  it("APP_SHORT_NAME falls through to APP_NAME when only NEXT_PUBLIC_APP_NAME is set", async () => {
+    process.env.NEXT_PUBLIC_APP_NAME = "Acme Bot";
+    delete process.env.NEXT_PUBLIC_APP_SHORT_NAME;
+    const { APP_SHORT_NAME } = await import("./site-config");
+    expect(APP_SHORT_NAME).toBe("Acme Bot");
+  });
+
+  it("APP_SHORT_NAME uses NEXT_PUBLIC_APP_SHORT_NAME when set, even alongside APP_NAME", async () => {
+    process.env.NEXT_PUBLIC_APP_NAME = "Acme Bot";
+    process.env.NEXT_PUBLIC_APP_SHORT_NAME = "Acme";
+    const { APP_SHORT_NAME } = await import("./site-config");
+    expect(APP_SHORT_NAME).toBe("Acme");
   });
 
   it("APP_ICON_URL is empty when NEXT_PUBLIC_APP_ICON_URL is unset", async () => {

--- a/packages/web/src/lib/site-config.test.ts
+++ b/packages/web/src/lib/site-config.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("site-config", () => {
+  const originalAppName = process.env.NEXT_PUBLIC_APP_NAME;
+  const originalIconUrl = process.env.NEXT_PUBLIC_APP_ICON_URL;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalAppName === undefined) {
+      delete process.env.NEXT_PUBLIC_APP_NAME;
+    } else {
+      process.env.NEXT_PUBLIC_APP_NAME = originalAppName;
+    }
+    if (originalIconUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_APP_ICON_URL;
+    } else {
+      process.env.NEXT_PUBLIC_APP_ICON_URL = originalIconUrl;
+    }
+  });
+
+  it("falls back to Open-Inspect when NEXT_PUBLIC_APP_NAME is unset", async () => {
+    delete process.env.NEXT_PUBLIC_APP_NAME;
+    const { APP_NAME } = await import("./site-config");
+    expect(APP_NAME).toBe("Open-Inspect");
+  });
+
+  it("falls back to Open-Inspect when NEXT_PUBLIC_APP_NAME is empty", async () => {
+    process.env.NEXT_PUBLIC_APP_NAME = "   ";
+    const { APP_NAME } = await import("./site-config");
+    expect(APP_NAME).toBe("Open-Inspect");
+  });
+
+  it("uses NEXT_PUBLIC_APP_NAME when set", async () => {
+    process.env.NEXT_PUBLIC_APP_NAME = "Acme Bot";
+    const { APP_NAME } = await import("./site-config");
+    expect(APP_NAME).toBe("Acme Bot");
+  });
+
+  it("trims surrounding whitespace from NEXT_PUBLIC_APP_NAME", async () => {
+    process.env.NEXT_PUBLIC_APP_NAME = "  Acme Bot  ";
+    const { APP_NAME } = await import("./site-config");
+    expect(APP_NAME).toBe("Acme Bot");
+  });
+
+  it("APP_ICON_URL is empty when NEXT_PUBLIC_APP_ICON_URL is unset", async () => {
+    delete process.env.NEXT_PUBLIC_APP_ICON_URL;
+    const { APP_ICON_URL } = await import("./site-config");
+    expect(APP_ICON_URL).toBe("");
+  });
+
+  it("APP_ICON_URL reflects NEXT_PUBLIC_APP_ICON_URL", async () => {
+    process.env.NEXT_PUBLIC_APP_ICON_URL = "/branding/logo.svg";
+    const { APP_ICON_URL } = await import("./site-config");
+    expect(APP_ICON_URL).toBe("/branding/logo.svg");
+  });
+});

--- a/packages/web/src/lib/site-config.ts
+++ b/packages/web/src/lib/site-config.ts
@@ -1,0 +1,5 @@
+import { DEFAULT_APP_NAME } from "@open-inspect/shared";
+
+export const APP_NAME = process.env.NEXT_PUBLIC_APP_NAME?.trim() || DEFAULT_APP_NAME;
+
+export const APP_ICON_URL = process.env.NEXT_PUBLIC_APP_ICON_URL?.trim() || "";

--- a/packages/web/src/lib/site-config.ts
+++ b/packages/web/src/lib/site-config.ts
@@ -2,4 +2,14 @@ import { DEFAULT_APP_NAME } from "@open-inspect/shared";
 
 export const APP_NAME = process.env.NEXT_PUBLIC_APP_NAME?.trim() || DEFAULT_APP_NAME;
 
+/**
+ * Short brand label shown in the sidebar header next to the logo.
+ * Defaults to "Inspect" (the historical short brand). Set
+ * NEXT_PUBLIC_APP_SHORT_NAME to override (defaults to APP_NAME when neither
+ * is set explicitly, but stays "Inspect" for the built-in brand).
+ */
+export const APP_SHORT_NAME =
+  process.env.NEXT_PUBLIC_APP_SHORT_NAME?.trim() ||
+  (process.env.NEXT_PUBLIC_APP_NAME?.trim() ? APP_NAME : "Inspect");
+
 export const APP_ICON_URL = process.env.NEXT_PUBLIC_APP_ICON_URL?.trim() || "";

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -178,6 +178,12 @@ project_root = "../../../"
 # Also used as the outbound HTTP User-Agent header. Defaults to "Open-Inspect".
 # app_name = "Open-Inspect"
 
+# Short brand label shown only in the sidebar header (next to the logo).
+# Leave empty to default to "Inspect" when app_name is unset, or to fall through
+# to app_name when app_name is overridden. Set this when app_name is too wide
+# for the sidebar (e.g. app_name = "Acme Coding Agent", app_short_name = "Acme").
+# app_short_name = ""
+
 # Optional URL (absolute or root-relative path) to a custom logo image for the
 # web sidebar and browser favicon. Leave empty to use the built-in icon.
 # Example: "/branding/logo.svg" (file under packages/web/public/) or

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -174,6 +174,16 @@ deployment_name = ""
 # Path to project root (relative to this directory)
 project_root = "../../../"
 
+# Display name shown in the web UI, bot messages (Slack, Linear), and PR body footers.
+# Also used as the outbound HTTP User-Agent header. Defaults to "Open-Inspect".
+# app_name = "Open-Inspect"
+
+# Optional URL (absolute or root-relative path) to a custom logo image for the
+# web sidebar and browser favicon. Leave empty to use the built-in icon.
+# Example: "/branding/logo.svg" (file under packages/web/public/) or
+#          "https://cdn.example.com/logo.svg".
+# app_icon_url = ""
+
 # =============================================================================
 # Initial Deployment Flags
 # =============================================================================

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -331,6 +331,18 @@ variable "deployment_name" {
   type        = string
 }
 
+variable "app_name" {
+  description = "Display name shown in the web UI tab title, sidebar logo, sign-in page, bot messages (Slack, Linear), PR body footer, and outbound HTTP User-Agent headers."
+  type        = string
+  default     = "Open-Inspect"
+}
+
+variable "app_icon_url" {
+  description = "Optional URL (absolute or root-relative) to a custom logo image for the web sidebar and browser favicon. Leave empty to use the built-in icon."
+  type        = string
+  default     = ""
+}
+
 variable "enable_durable_object_bindings" {
   description = "Enable DO bindings. For initial deployment: set to false (applies migrations), then set to true (adds bindings)."
   type        = bool

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -337,6 +337,12 @@ variable "app_name" {
   default     = "Open-Inspect"
 }
 
+variable "app_short_name" {
+  description = "Short brand label shown only in the web sidebar header next to the logo. Defaults to 'Inspect' to keep the sidebar visually compact. When empty, falls through to app_name when app_name is overridden, otherwise renders as 'Inspect'."
+  type        = string
+  default     = ""
+}
+
 variable "app_icon_url" {
   description = "Optional URL (absolute or root-relative) to a custom logo image for the web sidebar and browser favicon. Leave empty to use the built-in icon."
   type        = string

--- a/terraform/environments/production/web-cloudflare.tf
+++ b/terraform/environments/production/web-cloudflare.tf
@@ -19,6 +19,7 @@ resource "null_resource" "web_app_cloudflare_build" {
       NEXT_PUBLIC_WS_URL           = local.ws_url
       NEXT_PUBLIC_SANDBOX_PROVIDER = var.sandbox_provider
       NEXT_PUBLIC_APP_NAME         = var.app_name
+      NEXT_PUBLIC_APP_SHORT_NAME   = var.app_short_name
       NEXT_PUBLIC_APP_ICON_URL     = var.app_icon_url
     }
   }
@@ -72,6 +73,7 @@ resource "local_file" "web_app_wrangler_production" {
     NEXT_PUBLIC_WS_URL = "${local.ws_url}"
     NEXT_PUBLIC_SANDBOX_PROVIDER = "${var.sandbox_provider}"
     NEXT_PUBLIC_APP_NAME = "${var.app_name}"
+    NEXT_PUBLIC_APP_SHORT_NAME = "${var.app_short_name}"
     NEXT_PUBLIC_APP_ICON_URL = "${var.app_icon_url}"
     ALLOWED_USERS = "${var.allowed_users}"
     ALLOWED_EMAIL_DOMAINS = "${var.allowed_email_domains}"

--- a/terraform/environments/production/web-cloudflare.tf
+++ b/terraform/environments/production/web-cloudflare.tf
@@ -18,6 +18,8 @@ resource "null_resource" "web_app_cloudflare_build" {
       # NEXT_PUBLIC_* vars must be set at build time (inlined into client bundle)
       NEXT_PUBLIC_WS_URL           = local.ws_url
       NEXT_PUBLIC_SANDBOX_PROVIDER = var.sandbox_provider
+      NEXT_PUBLIC_APP_NAME         = var.app_name
+      NEXT_PUBLIC_APP_ICON_URL     = var.app_icon_url
     }
   }
 }
@@ -69,6 +71,8 @@ resource "local_file" "web_app_wrangler_production" {
     CONTROL_PLANE_URL = "${local.control_plane_url}"
     NEXT_PUBLIC_WS_URL = "${local.ws_url}"
     NEXT_PUBLIC_SANDBOX_PROVIDER = "${var.sandbox_provider}"
+    NEXT_PUBLIC_APP_NAME = "${var.app_name}"
+    NEXT_PUBLIC_APP_ICON_URL = "${var.app_icon_url}"
     ALLOWED_USERS = "${var.allowed_users}"
     ALLOWED_EMAIL_DOMAINS = "${var.allowed_email_domains}"
     UNSAFE_ALLOW_ALL_USERS = "${tostring(var.unsafe_allow_all_users)}"

--- a/terraform/environments/production/web-vercel.tf
+++ b/terraform/environments/production/web-vercel.tf
@@ -68,6 +68,12 @@ module "web_app" {
       sensitive = false
     },
     {
+      key       = "NEXT_PUBLIC_APP_SHORT_NAME"
+      value     = var.app_short_name
+      targets   = ["production", "preview"]
+      sensitive = false
+    },
+    {
       key       = "NEXT_PUBLIC_APP_ICON_URL"
       value     = var.app_icon_url
       targets   = ["production", "preview"]

--- a/terraform/environments/production/web-vercel.tf
+++ b/terraform/environments/production/web-vercel.tf
@@ -61,6 +61,18 @@ module "web_app" {
       targets   = ["production", "preview"]
       sensitive = false
     },
+    {
+      key       = "NEXT_PUBLIC_APP_NAME"
+      value     = var.app_name
+      targets   = ["production", "preview"]
+      sensitive = false
+    },
+    {
+      key       = "NEXT_PUBLIC_APP_ICON_URL"
+      value     = var.app_icon_url
+      targets   = ["production", "preview"]
+      sensitive = false
+    },
     # Internal
     {
       key       = "INTERNAL_CALLBACK_SECRET"

--- a/terraform/environments/production/workers-control-plane.tf
+++ b/terraform/environments/production/workers-control-plane.tf
@@ -67,6 +67,7 @@ module "control_plane_worker" {
       { name = "WEB_APP_URL", value = local.web_app_url },
       { name = "WORKER_URL", value = local.control_plane_url },
       { name = "DEPLOYMENT_NAME", value = var.deployment_name },
+      { name = "APP_NAME", value = var.app_name },
       { name = "SANDBOX_PROVIDER", value = var.sandbox_provider },
     ],
     local.use_modal_backend ? [{ name = "MODAL_WORKSPACE", value = var.modal_workspace }] : [],

--- a/terraform/environments/production/workers-github.tf
+++ b/terraform/environments/production/workers-github.tf
@@ -42,6 +42,7 @@ module "github_bot_worker" {
 
   plain_text_bindings = [
     { name = "DEPLOYMENT_NAME", value = var.deployment_name },
+    { name = "APP_NAME", value = var.app_name },
     { name = "DEFAULT_MODEL", value = "anthropic/claude-haiku-4-5" },
     { name = "GITHUB_BOT_USERNAME", value = var.github_bot_username },
   ]

--- a/terraform/environments/production/workers-linear.tf
+++ b/terraform/environments/production/workers-linear.tf
@@ -44,6 +44,7 @@ module "linear_bot_worker" {
     { name = "CONTROL_PLANE_URL", value = local.control_plane_url },
     { name = "WEB_APP_URL", value = local.web_app_url },
     { name = "DEPLOYMENT_NAME", value = var.deployment_name },
+    { name = "APP_NAME", value = var.app_name },
     { name = "DEFAULT_MODEL", value = "claude-sonnet-4-6" },
     { name = "LINEAR_CLIENT_ID", value = var.linear_client_id },
     { name = "WORKER_URL", value = "https://open-inspect-linear-bot-${local.name_suffix}.${var.cloudflare_worker_subdomain}.workers.dev" },

--- a/terraform/environments/production/workers-slack.tf
+++ b/terraform/environments/production/workers-slack.tf
@@ -46,6 +46,7 @@ module "slack_bot_worker" {
     { name = "CONTROL_PLANE_URL", value = local.control_plane_url },
     { name = "WEB_APP_URL", value = local.web_app_url },
     { name = "DEPLOYMENT_NAME", value = var.deployment_name },
+    { name = "APP_NAME", value = var.app_name },
     { name = "DEFAULT_MODEL", value = "claude-haiku-4-5" },
     { name = "CLASSIFICATION_MODEL", value = "claude-haiku-4-5" },
   ]


### PR DESCRIPTION
## Summary

- Threads a single Terraform variable `app_name` (default `Open-Inspect`) through the web UI, both bot workers, the control-plane PR footer, and outbound HTTP `User-Agent` headers — forks and whitelabel deployments can now rebrand without patching source.
- Adds optional `app_icon_url` (custom logo + browser favicon) and `NEXT_PUBLIC_APP_SHORT_NAME` (the historical "Inspect" sidebar label, kept as the default).
- New `resolveAppName(env)` helper in `@open-inspect/shared` is the single source of truth — workers resolve at request time, the web bundle inlines `NEXT_PUBLIC_APP_NAME` / `NEXT_PUBLIC_APP_ICON_URL` / `NEXT_PUBLIC_APP_SHORT_NAME` at build time.

## Surfaces wired up

| Surface | Source | Variable |
|---|---|---|
| Web tab title, sign-in heading, landing hero | `metadata`, `sidebar-layout`, `(app)/page` | `NEXT_PUBLIC_APP_NAME` |
| Web sidebar logo label | `session-sidebar` | `NEXT_PUBLIC_APP_SHORT_NAME` (defaults to `Inspect`) |
| Web sidebar logo image + browser favicon | new `<AppIcon>` helper, `metadata.icons` | `NEXT_PUBLIC_APP_ICON_URL` |
| Slack App Home intro text | `slack-bot/src/index.ts` | `APP_NAME` (worker binding) |
| Linear OAuth success page | `linear-bot/src/index.ts` | `APP_NAME` |
| Linear completion comment headers | `linear-bot/src/callbacks.ts` | `APP_NAME` |
| Pull request body footer | `control-plane/src/session/pull-request-service.ts` | `APP_NAME` |
| GitHub + GitLab `User-Agent` headers | provider config + `github-app.ts` + `github-bot/github-auth.ts` | `APP_NAME` |

Defaults preserve all existing behavior — no diff for deployments that don't set the new vars.

## Backwards compatibility

- All new Terraform vars default to current values (`app_name = "Open-Inspect"`, `app_icon_url = ""`).
- Sidebar logo defaults to literal `Inspect` (the historical short label) and only follows `APP_NAME` when explicitly overridden.
- Function-level User-Agent params on `github-bot` helpers default to `Open-Inspect` so any other callers keep working.

## Screenshots with config values as example

**Default**
<img width="1390" height="550" alt="CleanShot 2026-05-04 at 17 26 36@2x" src="https://github.com/user-attachments/assets/58ae96c6-e8a8-4e88-a45d-0880786b66b0" />


**With Custom App Name (no Short Name)**
<img width="1606" height="460" alt="CleanShot 2026-05-04 at 17 25 59@2x" src="https://github.com/user-attachments/assets/aa204fc0-5be2-47c4-872f-74c9a1d05b76" />

**With Custom App Name and Short Name**
<img width="1556" height="496" alt="CleanShot 2026-05-04 at 17 26 14@2x" src="https://github.com/user-attachments/assets/0de8cc8d-6c7d-4813-af8b-906d532a433a" />




## Docs updated

- `docs/GETTING_STARTED.md` — new `terraform.tfvars` block, CI secrets table entries, and a "Customizing the App Name and Icon" section
- `docs/SETUP_GUIDE.md` — adds `NEXT_PUBLIC_APP_NAME` / `NEXT_PUBLIC_APP_ICON_URL` to the local dev `.env.local` template

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional app branding (name, short name, icon) to customize site title, icon, command menu, sidebar label, PR footers, bot messages, and OAuth success pages.
* **Documentation**
  * Setup and getting-started updated with branding vars, CI/CD secret guidance, and notes about build-time inlining and redeploy steps.
* **Tests**
  * Added coverage ensuring branding appears and is safely escaped in UI, comments, and bot outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->