### PR TITLE
ci: wire APP_NAME, APP_SHORT_NAME, APP_ICON_URL to Terraform

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -208,6 +208,9 @@ jobs:
           TF_VAR_enable_github_bot: "${{ secrets.ENABLE_GITHUB_BOT || 'false' }}"
           TF_VAR_github_webhook_secret: ${{ secrets.GH_WEBHOOK_SECRET }}
           TF_VAR_github_bot_username: ${{ secrets.GH_BOT_USERNAME }}
+          TF_VAR_app_name: "${{ secrets.APP_NAME || 'Open-Inspect' }}"
+          TF_VAR_app_short_name: ${{ secrets.APP_SHORT_NAME }}
+          TF_VAR_app_icon_url: ${{ secrets.APP_ICON_URL }}
           TF_VAR_enable_linear_bot: "${{ secrets.ENABLE_LINEAR_BOT || 'false' }}"
           TF_VAR_linear_client_id: ${{ secrets.LINEAR_CLIENT_ID }}
           TF_VAR_linear_client_secret: ${{ secrets.LINEAR_CLIENT_SECRET }}
@@ -336,6 +339,9 @@ jobs:
           TF_VAR_enable_github_bot: "${{ secrets.ENABLE_GITHUB_BOT || 'false' }}"
           TF_VAR_github_webhook_secret: ${{ secrets.GH_WEBHOOK_SECRET }}
           TF_VAR_github_bot_username: ${{ secrets.GH_BOT_USERNAME }}
+          TF_VAR_app_name: "${{ secrets.APP_NAME || 'Open-Inspect' }}"
+          TF_VAR_app_short_name: ${{ secrets.APP_SHORT_NAME }}
+          TF_VAR_app_icon_url: ${{ secrets.APP_ICON_URL }}
           TF_VAR_enable_linear_bot: "${{ secrets.ENABLE_LINEAR_BOT || 'false' }}"
           TF_VAR_linear_client_id: ${{ secrets.LINEAR_CLIENT_ID }}
           TF_VAR_linear_client_secret: ${{ secrets.LINEAR_CLIENT_SECRET }}


### PR DESCRIPTION
## Summary

Follow-up to #594. The whitelabel branding secrets are documented in `docs/GETTING_STARTED.md` (CI secrets table) but the Terraform workflow doesn't actually read them, so setting `APP_NAME` / `APP_SHORT_NAME` / `APP_ICON_URL` in GitHub Actions secrets currently has no effect on a deployment.

This adds the three missing `TF_VAR_` entries to both the **plan** and **apply** jobs in `.github/workflows/terraform.yml`, ordered to match the docs table (right after `GH_BOT_USERNAME`).

## Backwards compatibility

- `APP_NAME` uses an `|| 'Open-Inspect'` fallback so the Terraform default (`"Open-Inspect"`) is preserved when the secret isn't set. Without the fallback, GitHub Actions would pass an empty string, which would override the Terraform default.
- `APP_SHORT_NAME` and `APP_ICON_URL` are passed bare — their Terraform defaults are already `""`, so an empty string from the unset secret matches the existing default.
- Even if an empty string did slip through, the runtime resolvers (`resolveAppName(env)` in workers, `site-config.ts` in the web bundle) already handle empty strings by falling back to `DEFAULT_APP_NAME`.

Net effect: no behavior change for users who don't set the new secrets; users who do set them now actually see them flow through to their deployment.

## Test plan

- [ ] Open this PR and confirm the **Plan** job runs with the new env vars (visible in the workflow logs)
- [ ] After merge, set `APP_NAME` repo secret to a test value and confirm it appears in the next `terraform apply` plan as `var.app_name`
- [ ] Confirm a deployment without any of the new secrets still resolves to the `Open-Inspect` defaults end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to properly supply environment variables during infrastructure provisioning and deployment steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->