### PR TITLE
feat: surface creator identity in session listings

### DIFF
--- a/packages/control-plane/src/db/session-index.test.ts
+++ b/packages/control-plane/src/db/session-index.test.ts
@@ -24,13 +24,23 @@ type SessionRow = {
   pr_count: number;
   created_at: number;
   updated_at: number;
+  creator_display_name?: string | null;
+  creator_avatar_url?: string | null;
+};
+
+type UserRow = {
+  id: string;
+  display_name: string | null;
+  avatar_url: string | null;
 };
 
 const QUERY_PATTERNS = {
   INSERT_SESSION: /^INSERT OR IGNORE INTO sessions/,
   SELECT_BY_ID: /^SELECT \* FROM sessions WHERE id = \?$/,
   SELECT_COUNT: /^SELECT COUNT\(\*\) as count FROM sessions\b/,
-  SELECT_LIST: /^SELECT \* FROM sessions\b.*ORDER BY updated_at DESC LIMIT/,
+  // List query LEFT JOINs users to surface creator display_name / avatar_url.
+  SELECT_LIST:
+    /^SELECT sessions\.\*, u\.display_name AS creator_display_name, u\.avatar_url AS creator_avatar_url\s+FROM sessions\s+LEFT JOIN users u ON sessions\.user_id = u\.id\b.*ORDER BY sessions\.updated_at DESC LIMIT/,
   UPDATE_STATUS: /^UPDATE sessions SET status = \?/,
   UPDATE_UPDATED_AT: /^UPDATE sessions SET updated_at = \?/,
   UPDATE_TITLE: /^UPDATE sessions SET title = \?/,
@@ -48,6 +58,12 @@ function normalizeQuery(query: string): string {
 
 class FakeD1Database {
   private rows = new Map<string, SessionRow>();
+  private users = new Map<string, UserRow>();
+
+  /** Test helper: seed a users row so list() can join against it. */
+  seedUser(user: UserRow): void {
+    this.users.set(user.id, user);
+  }
 
   prepare(query: string) {
     return new FakePreparedStatement(this, query);
@@ -102,7 +118,7 @@ class FakeD1Database {
       const filtered = this.applyWhereConditions(normalized, whereArgs);
       const sorted = filtered.sort((a, b) => b.updated_at - a.updated_at);
       const paged = sorted.slice(offset, offset + limit);
-      return paged;
+      return paged.map((row) => this.joinUser(row));
     }
 
     if (QUERY_PATTERNS.SELECT_BY_PARENT.test(normalized)) {
@@ -114,6 +130,16 @@ class FakeD1Database {
     }
 
     throw new Error(`Unexpected all() query: ${query}`);
+  }
+
+  /** Simulate the LEFT JOIN to users in the list() query. */
+  private joinUser(row: SessionRow): SessionRow {
+    const user = row.user_id ? this.users.get(row.user_id) : undefined;
+    return {
+      ...row,
+      creator_display_name: user?.display_name ?? null,
+      creator_avatar_url: user?.avatar_url ?? null,
+    };
   }
 
   run(query: string, args: unknown[]) {
@@ -358,6 +384,9 @@ describe("SessionIndexStore", () => {
         automationRunId: null,
         scmLogin: null,
         userId: null,
+        // get() does not LEFT JOIN users; toEntry coerces missing columns to null.
+        creatorDisplayName: null,
+        creatorAvatarUrl: null,
         totalCost: 0,
         activeDurationMs: 0,
         messageCount: 0,
@@ -479,6 +508,38 @@ describe("SessionIndexStore", () => {
       const page3 = await store.list({ limit: 2, offset: 4 });
       expect(page3.sessions).toHaveLength(1);
       expect(page3.hasMore).toBe(false);
+    });
+
+    it("populates creatorDisplayName and creatorAvatarUrl from joined users row", async () => {
+      db.seedUser({
+        id: "u-1",
+        display_name: "Alice",
+        avatar_url: "https://example.com/alice.png",
+      });
+      await store.create(makeSession({ id: "s-with-user", userId: "u-1" }));
+
+      const result = await store.list();
+      const row = result.sessions.find((s) => s.id === "s-with-user");
+      expect(row?.creatorDisplayName).toBe("Alice");
+      expect(row?.creatorAvatarUrl).toBe("https://example.com/alice.png");
+    });
+
+    it("returns null creator fields when userId is null", async () => {
+      await store.create(makeSession({ id: "s-no-user" }));
+
+      const result = await store.list();
+      const row = result.sessions.find((s) => s.id === "s-no-user");
+      expect(row?.creatorDisplayName).toBeNull();
+      expect(row?.creatorAvatarUrl).toBeNull();
+    });
+
+    it("returns null creator fields when userId has no matching users row", async () => {
+      await store.create(makeSession({ id: "s-orphan", userId: "u-missing" }));
+
+      const result = await store.list();
+      const row = result.sessions.find((s) => s.id === "s-orphan");
+      expect(row?.creatorDisplayName).toBeNull();
+      expect(row?.creatorAvatarUrl).toBeNull();
     });
   });
 

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -16,6 +16,10 @@ export interface SessionEntry {
   automationRunId?: string | null;
   scmLogin?: string | null;
   userId?: string | null;
+  /** Display name from the linked users row (null when user_id is null or unlinked). Populated by list(). */
+  creatorDisplayName?: string | null;
+  /** Avatar URL from the linked users row (null when user_id is null or unlinked). Populated by list(). */
+  creatorAvatarUrl?: string | null;
   totalCost?: number;
   activeDurationMs?: number;
   messageCount?: number;
@@ -46,6 +50,9 @@ interface SessionRow {
   pr_count: number;
   created_at: number;
   updated_at: number;
+  // Populated only when the query includes a LEFT JOIN to users.
+  creator_display_name?: string | null;
+  creator_avatar_url?: string | null;
 }
 
 export interface ListSessionsOptions {
@@ -80,6 +87,8 @@ function toEntry(row: SessionRow): SessionEntry {
     automationRunId: row.automation_run_id,
     scmLogin: row.scm_login,
     userId: row.user_id,
+    creatorDisplayName: row.creator_display_name ?? null,
+    creatorAvatarUrl: row.creator_avatar_url ?? null,
     totalCost: row.total_cost,
     activeDurationMs: row.active_duration_ms,
     messageCount: row.message_count,
@@ -165,9 +174,17 @@ export class SessionIndexStore {
 
     const total = countResult?.count ?? 0;
 
-    // Get paginated results
+    // Get paginated results, enriched with creator display_name / avatar_url from
+    // the unified users table. LEFT JOIN keeps rows with NULL or orphan user_id.
     const result = await this.db
-      .prepare(`SELECT * FROM sessions ${where} ORDER BY updated_at DESC LIMIT ? OFFSET ?`)
+      .prepare(
+        `SELECT sessions.*, u.display_name AS creator_display_name, u.avatar_url AS creator_avatar_url
+         FROM sessions
+         LEFT JOIN users u ON sessions.user_id = u.id
+         ${where}
+         ORDER BY sessions.updated_at DESC
+         LIMIT ? OFFSET ?`
+      )
       .bind(...params, limit, offset)
       .all<SessionRow>();
 

--- a/packages/control-plane/test/integration/d1-session-index.test.ts
+++ b/packages/control-plane/test/integration/d1-session-index.test.ts
@@ -489,4 +489,181 @@ describe("D1 SessionIndexStore", () => {
       expect(session!.userId).toBeNull();
     });
   });
+
+  describe("creator identity (LEFT JOIN users)", () => {
+    async function seedUser(
+      id: string,
+      displayName: string | null,
+      avatarUrl: string | null
+    ): Promise<void> {
+      const now = Date.now();
+      await env.DB.prepare(
+        "INSERT INTO users (id, display_name, email, avatar_url, created_at, updated_at) VALUES (?, ?, NULL, ?, ?, ?)"
+      )
+        .bind(id, displayName, avatarUrl, now, now)
+        .run();
+    }
+
+    it("list() populates creatorDisplayName from users.display_name", async () => {
+      const store = new SessionIndexStore(env.DB);
+      const now = Date.now();
+
+      await seedUser("u-alice", "Alice", null);
+      await store.create({
+        id: "s-alice",
+        title: null,
+        repoOwner: "acme",
+        repoName: "web-app",
+        model: "anthropic/claude-haiku-4-5",
+        reasoningEffort: null,
+        baseBranch: null,
+        status: "created",
+        userId: "u-alice",
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const result = await store.list({});
+      const row = result.sessions.find((s) => s.id === "s-alice");
+      expect(row).toBeDefined();
+      expect(row!.creatorDisplayName).toBe("Alice");
+    });
+
+    it("list() populates creatorAvatarUrl from users.avatar_url", async () => {
+      const store = new SessionIndexStore(env.DB);
+      const now = Date.now();
+
+      await seedUser("u-bob", "Bob", "https://example.com/bob.png");
+      await store.create({
+        id: "s-bob",
+        title: null,
+        repoOwner: "acme",
+        repoName: "web-app",
+        model: "anthropic/claude-haiku-4-5",
+        reasoningEffort: null,
+        baseBranch: null,
+        status: "created",
+        userId: "u-bob",
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const result = await store.list({});
+      const row = result.sessions.find((s) => s.id === "s-bob");
+      expect(row).toBeDefined();
+      expect(row!.creatorAvatarUrl).toBe("https://example.com/bob.png");
+    });
+
+    it("list() returns null creator fields when user_id is NULL", async () => {
+      const store = new SessionIndexStore(env.DB);
+      const now = Date.now();
+
+      await store.create({
+        id: "s-orphan",
+        title: null,
+        repoOwner: "acme",
+        repoName: "web-app",
+        model: "anthropic/claude-haiku-4-5",
+        reasoningEffort: null,
+        baseBranch: null,
+        status: "created",
+        // No userId — pre-migration row
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const result = await store.list({});
+      const row = result.sessions.find((s) => s.id === "s-orphan");
+      expect(row).toBeDefined();
+      expect(row!.creatorDisplayName).toBeNull();
+      expect(row!.creatorAvatarUrl).toBeNull();
+    });
+
+    it("list() returns null creator fields when user_id has no matching users row", async () => {
+      const store = new SessionIndexStore(env.DB);
+      const now = Date.now();
+
+      // No users row seeded for "u-missing"
+      await store.create({
+        id: "s-orphan-fk",
+        title: null,
+        repoOwner: "acme",
+        repoName: "web-app",
+        model: "anthropic/claude-haiku-4-5",
+        reasoningEffort: null,
+        baseBranch: null,
+        status: "created",
+        userId: "u-missing",
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const result = await store.list({});
+      const row = result.sessions.find((s) => s.id === "s-orphan-fk");
+      expect(row).toBeDefined();
+      expect(row!.creatorDisplayName).toBeNull();
+      expect(row!.creatorAvatarUrl).toBeNull();
+    });
+
+    it("list() returns null creator fields when users.display_name and avatar_url are NULL", async () => {
+      const store = new SessionIndexStore(env.DB);
+      const now = Date.now();
+
+      await seedUser("u-bare", null, null);
+      await store.create({
+        id: "s-bare",
+        title: null,
+        repoOwner: "acme",
+        repoName: "web-app",
+        model: "anthropic/claude-haiku-4-5",
+        reasoningEffort: null,
+        baseBranch: null,
+        status: "created",
+        userId: "u-bare",
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const result = await store.list({});
+      const row = result.sessions.find((s) => s.id === "s-bare");
+      expect(row).toBeDefined();
+      expect(row!.creatorDisplayName).toBeNull();
+      expect(row!.creatorAvatarUrl).toBeNull();
+    });
+
+    it("list() preserves existing fields alongside the new creator fields", async () => {
+      const store = new SessionIndexStore(env.DB);
+      const now = Date.now();
+
+      await seedUser("u-carol", "Carol", "https://example.com/carol.png");
+      await store.create({
+        id: "s-carol",
+        title: "Carol's session",
+        repoOwner: "acme",
+        repoName: "api",
+        model: "anthropic/claude-sonnet-4-6",
+        reasoningEffort: "high",
+        baseBranch: "main",
+        status: "active",
+        userId: "u-carol",
+        scmLogin: "carol",
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const result = await store.list({});
+      const row = result.sessions.find((s) => s.id === "s-carol");
+      expect(row).toMatchObject({
+        id: "s-carol",
+        title: "Carol's session",
+        repoOwner: "acme",
+        repoName: "api",
+        status: "active",
+        userId: "u-carol",
+        scmLogin: "carol",
+        creatorDisplayName: "Carol",
+        creatorAvatarUrl: "https://example.com/carol.png",
+      });
+    });
+  });
 });

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -77,6 +77,14 @@ export interface Session {
   spawnDepth: number;
   createdAt: number;
   updatedAt: number;
+  /** Canonical creator (users.id). Populated on session list responses. */
+  userId?: string | null;
+  /** Provider login of the creator (e.g. GitHub username). */
+  scmLogin?: string | null;
+  /** Display name of the creator (joined from users table). Populated on list responses. */
+  creatorDisplayName?: string | null;
+  /** Avatar URL of the creator (joined from users table). Populated on list responses. */
+  creatorAvatarUrl?: string | null;
 }
 
 // Message in a session


### PR DESCRIPTION
## Summary
- LEFT JOIN `sessions` to `users` in `SessionIndexStore.list` to expose `creatorDisplayName` and `creatorAvatarUrl` per row.
- Extend the shared `Session` type so the wire format declares creator fields.
- Backwards compatible: existing clients ignore the new optional fields.

## Why
First of five stacked PRs implementing #557 (Session filters by user). This PR is the data foundation — surfacing creator identity per row — so subsequent PRs can wire up the per-row creator avatar in the sidebar's "all" view without further schema work. No UX change here.

Spec / design docs live in `docs/internal/2026-05-06-session-filters-by-user-{research,design-decisions,spec,implementation-plan}.md`.

## Test plan
- [x] Unit tests: `SessionIndexStore.list` populates creator fields from joined users row, falls through to nulls when `user_id IS NULL` or unlinked
- [x] Integration tests (real D1): same coverage end-to-end against the actual migrations
- [x] All existing `SessionIndexStore` tests continue to pass (35 unit + 30 integration)
- [x] Workspace `typecheck` clean

## Notes
- `get()` does not JOIN — only `list()` enriches. Consumers that need creator info on a single row should switch to `list()` or fetch the user via `UserStore.getUserById`.
- One extra column in the SELECT projection, indexed JOIN on `users.id` PK. No measurable perf impact at D1 scale.
- Rollback: revert. No schema change, no migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now display creator identity information, including display name and avatar URL. Creator details are populated from linked user profiles and appear as null when no user is associated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->