### PR TITLE
feat: server-trusted filter by current user for session list

### DIFF
--- a/packages/control-plane/src/db/session-index.test.ts
+++ b/packages/control-plane/src/db/session-index.test.ts
@@ -311,6 +311,11 @@ class FakeD1Database {
         const nameVal = args[argIdx++] as string;
         rows = rows.filter((r) => r.repo_name === nameVal);
       }
+
+      if (conditions.includes("user_id = ?")) {
+        const userIdVal = args[argIdx++] as string;
+        rows = rows.filter((r) => r.user_id === userIdVal);
+      }
     }
 
     return rows;
@@ -540,6 +545,61 @@ describe("SessionIndexStore", () => {
       const row = result.sessions.find((s) => s.id === "s-orphan");
       expect(row?.creatorDisplayName).toBeNull();
       expect(row?.creatorAvatarUrl).toBeNull();
+    });
+
+    it("filters by userId when set, returning only sessions whose user_id matches", async () => {
+      await store.create(makeSession({ id: "s-alice-1", userId: "u-alice", updatedAt: 3000 }));
+      await store.create(makeSession({ id: "s-alice-2", userId: "u-alice", updatedAt: 2000 }));
+      await store.create(makeSession({ id: "s-bob-1", userId: "u-bob", updatedAt: 1000 }));
+      await store.create(makeSession({ id: "s-orphan", updatedAt: 500 }));
+
+      const result = await store.list({ userId: "u-alice" });
+      expect(result.sessions.map((s) => s.id)).toEqual(["s-alice-1", "s-alice-2"]);
+      expect(result.total).toBe(2);
+    });
+
+    it("excludes user_id IS NULL sessions when userId filter is applied (spec AC 9)", async () => {
+      // Pre-migration session: scmLogin matches but user_id is null
+      await store.create(
+        makeSession({ id: "s-pre-migration", scmLogin: "alice", updatedAt: 2000 })
+      );
+      // Linked session
+      await store.create(
+        makeSession({ id: "s-linked", userId: "u-alice", scmLogin: "alice", updatedAt: 1000 })
+      );
+
+      const result = await store.list({ userId: "u-alice" });
+      expect(result.sessions.map((s) => s.id)).toEqual(["s-linked"]);
+      expect(result.total).toBe(1);
+    });
+
+    it("combines userId with excludeStatus", async () => {
+      await store.create(
+        makeSession({ id: "active", userId: "u-1", status: "active", updatedAt: 3000 })
+      );
+      await store.create(
+        makeSession({ id: "archived", userId: "u-1", status: "archived", updatedAt: 2000 })
+      );
+      await store.create(
+        makeSession({ id: "other-user-active", userId: "u-2", status: "active", updatedAt: 1000 })
+      );
+
+      const result = await store.list({ userId: "u-1", excludeStatus: "archived" });
+      expect(result.sessions.map((s) => s.id)).toEqual(["active"]);
+      expect(result.total).toBe(1);
+    });
+
+    it("paginates within the user-scoped result set", async () => {
+      for (let i = 0; i < 5; i++) {
+        await store.create(makeSession({ id: `s${i}`, userId: "u-1", updatedAt: i * 1000 }));
+      }
+      // Other users' sessions should not affect pagination of u-1's slice
+      await store.create(makeSession({ id: "other-1", userId: "u-other", updatedAt: 99999 }));
+
+      const page = await store.list({ userId: "u-1", limit: 2, offset: 1 });
+      expect(page.sessions).toHaveLength(2);
+      expect(page.total).toBe(5);
+      expect(page.hasMore).toBe(true);
     });
   });
 

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -60,6 +60,8 @@ export interface ListSessionsOptions {
   excludeStatus?: SessionStatus;
   repoOwner?: string;
   repoName?: string;
+  /** Filter to sessions whose canonical creator (sessions.user_id) matches. */
+  userId?: string;
   limit?: number;
   offset?: number;
 }
@@ -139,7 +141,7 @@ export class SessionIndexStore {
   }
 
   async list(options: ListSessionsOptions = {}): Promise<ListSessionsResult> {
-    const { status, excludeStatus, repoOwner, repoName, limit = 50, offset = 0 } = options;
+    const { status, excludeStatus, repoOwner, repoName, userId, limit = 50, offset = 0 } = options;
 
     const conditions: string[] = [];
     const params: unknown[] = [];
@@ -162,6 +164,11 @@ export class SessionIndexStore {
     if (repoName) {
       conditions.push("repo_name = ?");
       params.push(repoName.toLowerCase());
+    }
+
+    if (userId) {
+      conditions.push("user_id = ?");
+      params.push(userId);
     }
 
     const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -675,6 +675,14 @@ export async function handleRequest(
 
 // Session handlers
 
+/** Provider values accepted by the `mineProvider` query parameter on GET /sessions. */
+const SUPPORTED_MINE_PROVIDERS = ["github", "slack", "linear"] as const;
+type SupportedMineProvider = (typeof SUPPORTED_MINE_PROVIDERS)[number];
+
+function isSupportedMineProvider(value: string): value is SupportedMineProvider {
+  return (SUPPORTED_MINE_PROVIDERS as readonly string[]).includes(value);
+}
+
 async function handleListSessions(
   request: Request,
   env: Env,
@@ -697,8 +705,36 @@ async function handleListSessions(
     return error("Invalid excludeStatus", 400);
   }
 
+  // "Filter to the authenticated user" — server-trusted: the BFF derives identity
+  // from the NextAuth session and forwards mineScmUserId+mineProvider. The browser
+  // never sets these directly (they're not on the BFF's allowlist).
+  const mineScmUserId = url.searchParams.get("mineScmUserId");
+  const mineProvider = url.searchParams.get("mineProvider");
+
+  if (mineScmUserId !== null && !mineProvider) {
+    return error("mineProvider is required when mineScmUserId is set", 400);
+  }
+  if (mineProvider !== null && !mineScmUserId) {
+    return error("mineScmUserId is required when mineProvider is set", 400);
+  }
+  if (mineProvider && !isSupportedMineProvider(mineProvider)) {
+    return error("Unsupported mineProvider", 400);
+  }
+
+  let userId: string | undefined;
+  if (mineScmUserId && mineProvider) {
+    // Read-only resolve — must NOT auto-create users from a list query.
+    const userStore = new UserStore(env.DB);
+    const identity = await userStore.getIdentity(mineProvider, mineScmUserId);
+    if (!identity) {
+      // Identity not yet canonicalized → empty page (spec E2).
+      return json({ sessions: [], total: 0, hasMore: false });
+    }
+    userId = identity.userId;
+  }
+
   const store = new SessionIndexStore(env.DB);
-  const result = await store.list({ status, excludeStatus, limit, offset });
+  const result = await store.list({ status, excludeStatus, userId, limit, offset });
 
   return json({
     sessions: result.sessions,

--- a/packages/control-plane/test/integration/sessions-list.test.ts
+++ b/packages/control-plane/test/integration/sessions-list.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { SELF, env } from "cloudflare:test";
+import { generateInternalToken } from "../../src/auth/internal";
+import { SessionIndexStore } from "../../src/db/session-index";
+import { UserStore } from "../../src/db/user-store";
+import { cleanD1Tables } from "./cleanup";
+
+async function authHeaders(): Promise<Record<string, string>> {
+  const token = await generateInternalToken(env.INTERNAL_CALLBACK_SECRET!);
+  return { Authorization: `Bearer ${token}` };
+}
+
+interface ListSessionsBody {
+  sessions: Array<{ id: string; userId?: string | null; scmLogin?: string | null }>;
+  total: number;
+  hasMore: boolean;
+}
+
+describe("GET /sessions filter by current user", () => {
+  beforeEach(cleanD1Tables);
+
+  async function seedSession(
+    store: SessionIndexStore,
+    input: {
+      id: string;
+      userId?: string | null;
+      scmLogin?: string | null;
+      status?: "created" | "active" | "completed" | "archived";
+      updatedAt?: number;
+    }
+  ): Promise<void> {
+    const now = input.updatedAt ?? Date.now();
+    await store.create({
+      id: input.id,
+      title: input.id,
+      repoOwner: "acme",
+      repoName: "web-app",
+      model: "anthropic/claude-haiku-4-5",
+      reasoningEffort: null,
+      baseBranch: null,
+      status: input.status ?? "active",
+      userId: input.userId ?? null,
+      scmLogin: input.scmLogin ?? null,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  it("filters by mineScmUserId+mineProvider, returning only that user's sessions", async () => {
+    const store = new SessionIndexStore(env.DB);
+    const userStore = new UserStore(env.DB);
+
+    const alice = await userStore.resolveOrCreateUser({
+      provider: "github",
+      providerUserId: "12345",
+      providerLogin: "alice",
+      displayName: "Alice",
+      avatarUrl: "https://example.com/alice.png",
+    });
+    const bob = await userStore.resolveOrCreateUser({
+      provider: "github",
+      providerUserId: "67890",
+      providerLogin: "bob",
+    });
+
+    await seedSession(store, { id: "alice-1", userId: alice.id, updatedAt: 3000 });
+    await seedSession(store, { id: "alice-2", userId: alice.id, updatedAt: 2000 });
+    await seedSession(store, { id: "bob-1", userId: bob.id, updatedAt: 1000 });
+    // Pre-migration session: scmLogin matches but user_id is null — must NOT appear
+    await seedSession(store, { id: "pre-mig", scmLogin: "alice", updatedAt: 500 });
+
+    const response = await SELF.fetch(
+      "https://test.local/sessions?mineScmUserId=12345&mineProvider=github",
+      { headers: await authHeaders() }
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json<ListSessionsBody>();
+    expect(body.sessions.map((s) => s.id)).toEqual(["alice-1", "alice-2"]);
+    expect(body.total).toBe(2);
+    expect(body.hasMore).toBe(false);
+  });
+
+  it("returns empty page when the provider identity is not yet canonicalized (spec E2)", async () => {
+    const store = new SessionIndexStore(env.DB);
+    await seedSession(store, { id: "any-1", userId: "u-someone", updatedAt: 1000 });
+
+    const response = await SELF.fetch(
+      "https://test.local/sessions?mineScmUserId=99999&mineProvider=github",
+      { headers: await authHeaders() }
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json<ListSessionsBody>();
+    expect(body.sessions).toEqual([]);
+    expect(body.total).toBe(0);
+    expect(body.hasMore).toBe(false);
+  });
+
+  it("returns all sessions when no mineScmUserId is supplied (no regression)", async () => {
+    const store = new SessionIndexStore(env.DB);
+    await seedSession(store, { id: "s1", updatedAt: 2000 });
+    await seedSession(store, { id: "s2", userId: "u-1", updatedAt: 1000 });
+
+    const response = await SELF.fetch("https://test.local/sessions", {
+      headers: await authHeaders(),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json<ListSessionsBody>();
+    expect(body.sessions.map((s) => s.id).sort()).toEqual(["s1", "s2"]);
+    expect(body.total).toBe(2);
+  });
+
+  it("rejects unsupported mineProvider values", async () => {
+    const response = await SELF.fetch(
+      "https://test.local/sessions?mineScmUserId=12345&mineProvider=facebook",
+      { headers: await authHeaders() }
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects mineProvider without mineScmUserId", async () => {
+    const response = await SELF.fetch("https://test.local/sessions?mineProvider=github", {
+      headers: await authHeaders(),
+    });
+    expect(response.status).toBe(400);
+  });
+
+  it("combines mine filter with excludeStatus", async () => {
+    const store = new SessionIndexStore(env.DB);
+    const userStore = new UserStore(env.DB);
+
+    const alice = await userStore.resolveOrCreateUser({
+      provider: "github",
+      providerUserId: "12345",
+      providerLogin: "alice",
+    });
+
+    await seedSession(store, {
+      id: "alice-active",
+      userId: alice.id,
+      status: "active",
+      updatedAt: 3000,
+    });
+    await seedSession(store, {
+      id: "alice-archived",
+      userId: alice.id,
+      status: "archived",
+      updatedAt: 2000,
+    });
+
+    const response = await SELF.fetch(
+      "https://test.local/sessions?mineScmUserId=12345&mineProvider=github&excludeStatus=archived",
+      { headers: await authHeaders() }
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json<ListSessionsBody>();
+    expect(body.sessions.map((s) => s.id)).toEqual(["alice-active"]);
+    expect(body.total).toBe(1);
+  });
+
+  it("preserves sort order (updated_at DESC) and pagination shape under mine filter", async () => {
+    const store = new SessionIndexStore(env.DB);
+    const userStore = new UserStore(env.DB);
+
+    const alice = await userStore.resolveOrCreateUser({
+      provider: "github",
+      providerUserId: "12345",
+      providerLogin: "alice",
+    });
+    for (let i = 0; i < 5; i++) {
+      await seedSession(store, {
+        id: `alice-${i}`,
+        userId: alice.id,
+        updatedAt: i * 1000,
+      });
+    }
+
+    const response = await SELF.fetch(
+      "https://test.local/sessions?mineScmUserId=12345&mineProvider=github&limit=2&offset=1",
+      { headers: await authHeaders() }
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json<ListSessionsBody>();
+    expect(body.sessions.map((s) => s.id)).toEqual(["alice-3", "alice-2"]);
+    expect(body.total).toBe(5);
+    expect(body.hasMore).toBe(true);
+  });
+});

--- a/packages/web/src/app/api/sessions/route.test.ts
+++ b/packages/web/src/app/api/sessions/route.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  authOptions: {},
+}));
+
+vi.mock("@/lib/control-plane", () => ({
+  controlPlaneFetch: vi.fn(),
+}));
+
+vi.mock("next-auth/jwt", () => ({
+  getToken: vi.fn(),
+}));
+
+import { getServerSession } from "next-auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+import { GET } from "./route";
+
+function makeNextRequest(url: string): Parameters<typeof GET>[0] {
+  // The BFF route uses `request.nextUrl.searchParams`. Provide a minimal
+  // structural object that matches the parts the handler reads.
+  const u = new URL(url);
+  return {
+    nextUrl: u,
+    url,
+  } as unknown as Parameters<typeof GET>[0];
+}
+
+describe("sessions API GET route", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns 401 when the user session is missing", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+
+    const response = await GET(makeNextRequest("http://localhost/api/sessions"));
+
+    expect(response.status).toBe(401);
+    expect(controlPlaneFetch).not.toHaveBeenCalled();
+  });
+
+  it("forwards plain list call with no mine flag", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "12345", login: "alice" },
+    } as never);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(
+      Response.json({ sessions: [], total: 0, hasMore: false })
+    );
+
+    const response = await GET(
+      makeNextRequest("http://localhost/api/sessions?excludeStatus=archived&limit=50")
+    );
+
+    expect(controlPlaneFetch).toHaveBeenCalledTimes(1);
+    const path = vi.mocked(controlPlaneFetch).mock.calls[0][0];
+    expect(path).toBe("/sessions?limit=50&excludeStatus=archived");
+    expect(response.status).toBe(200);
+  });
+
+  it("translates ?mine=true into server-derived mineScmUserId+mineProvider", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "12345", login: "alice" },
+    } as never);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(
+      Response.json({ sessions: [], total: 0, hasMore: false })
+    );
+
+    await GET(makeNextRequest("http://localhost/api/sessions?mine=true&excludeStatus=archived"));
+
+    expect(controlPlaneFetch).toHaveBeenCalledTimes(1);
+    const path = vi.mocked(controlPlaneFetch).mock.calls[0][0];
+    expect(path).toContain("mineScmUserId=12345");
+    expect(path).toContain("mineProvider=github");
+    expect(path).toContain("excludeStatus=archived");
+  });
+
+  it("does NOT forward client-supplied mineScmUserId (spoof-resistance, spec AC 10)", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "12345", login: "alice" },
+    } as never);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(
+      Response.json({ sessions: [], total: 0, hasMore: false })
+    );
+
+    await GET(
+      makeNextRequest(
+        "http://localhost/api/sessions?mine=true&mineScmUserId=99999&mineProvider=facebook"
+      )
+    );
+
+    const path = vi.mocked(controlPlaneFetch).mock.calls[0][0];
+    expect(path).toContain("mineScmUserId=12345");
+    expect(path).not.toContain("mineScmUserId=99999");
+    expect(path).toContain("mineProvider=github");
+    expect(path).not.toContain("mineProvider=facebook");
+  });
+
+  it("does NOT add mineScmUserId when mine is absent or false", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "12345", login: "alice" },
+    } as never);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(
+      Response.json({ sessions: [], total: 0, hasMore: false })
+    );
+
+    await GET(makeNextRequest("http://localhost/api/sessions?mine=false"));
+    const path1 = vi.mocked(controlPlaneFetch).mock.calls[0][0];
+    expect(path1).not.toContain("mineScmUserId");
+    expect(path1).not.toContain("mineProvider");
+
+    vi.mocked(controlPlaneFetch).mockClear();
+    await GET(makeNextRequest("http://localhost/api/sessions"));
+    const path2 = vi.mocked(controlPlaneFetch).mock.calls[0][0];
+    expect(path2).not.toContain("mineScmUserId");
+    expect(path2).not.toContain("mineProvider");
+  });
+
+  it("strips client-supplied identity even when mine flag is absent", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "12345", login: "alice" },
+    } as never);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(
+      Response.json({ sessions: [], total: 0, hasMore: false })
+    );
+
+    await GET(
+      makeNextRequest(
+        "http://localhost/api/sessions?mineScmUserId=99999&mineProvider=github&excludeStatus=archived"
+      )
+    );
+
+    const path = vi.mocked(controlPlaneFetch).mock.calls[0][0];
+    expect(path).not.toContain("mineScmUserId");
+    expect(path).not.toContain("mineProvider");
+    expect(path).toContain("excludeStatus=archived");
+  });
+});

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -25,9 +25,17 @@ export async function GET(request: NextRequest) {
     SESSION_CONTROL_PLANE_QUERY_PARAMS
   );
 
+  // Server-trusted "filter to current user": when the client opts in via
+  // `?mine=true`, derive identity from the NextAuth session and append the
+  // canonical-resolution params for the control plane. The buildControlPlanePath
+  // allowlist already strips any client-supplied mineScmUserId/mineProvider —
+  // identity is *only* what the server derives here.
+  const mineFlag = request.nextUrl.searchParams.get("mine") === "true";
+  const finalPath = mineFlag && session.user?.id ? appendMineParams(path, session.user.id) : path;
+
   try {
     const fetchStart = Date.now();
-    const response = await controlPlaneFetch(path);
+    const response = await controlPlaneFetch(finalPath);
     const fetchMs = Date.now() - fetchStart;
     const data = await response.json();
     const totalMs = Date.now() - routeStart;
@@ -41,6 +49,13 @@ export async function GET(request: NextRequest) {
     console.error("Failed to fetch sessions:", error);
     return NextResponse.json({ error: "Failed to fetch sessions" }, { status: 500 });
   }
+}
+
+function appendMineParams(path: string, scmUserId: string): string {
+  const sep = path.includes("?") ? "&" : "?";
+  // session.user.id is the GitHub numeric ID for web NextAuth sessions; the
+  // control plane resolves (provider, providerUserId) via UserStore.getIdentity.
+  return `${path}${sep}mineScmUserId=${encodeURIComponent(scmUserId)}&mineProvider=github`;
 }
 
 export async function POST(request: NextRequest) {

--- a/packages/web/src/lib/control-plane-query.test.ts
+++ b/packages/web/src/lib/control-plane-query.test.ts
@@ -39,4 +39,24 @@ describe("buildControlPlanePath", () => {
       buildControlPlanePath("/sessions", searchParams, SESSION_CONTROL_PLANE_QUERY_PARAMS)
     ).toBe("/sessions?status=running&excludeStatus=archived");
   });
+
+  it("does NOT forward mineScmUserId or mineProvider from clients (server-trusted only)", () => {
+    // mineScmUserId / mineProvider are inserted by the BFF after server-side
+    // identity derivation. Anything supplied by the client must be stripped.
+    const searchParams = new URLSearchParams(
+      "mineScmUserId=99999&mineProvider=facebook&excludeStatus=archived"
+    );
+
+    expect(
+      buildControlPlanePath("/sessions", searchParams, SESSION_CONTROL_PLANE_QUERY_PARAMS)
+    ).toBe("/sessions?excludeStatus=archived");
+  });
+
+  it("does NOT forward the browser-facing mine flag (BFF translates it)", () => {
+    const searchParams = new URLSearchParams("mine=true&limit=50");
+
+    expect(
+      buildControlPlanePath("/sessions", searchParams, SESSION_CONTROL_PLANE_QUERY_PARAMS)
+    ).toBe("/sessions?limit=50");
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a `userId` option to `SessionIndexStore.list` (`WHERE user_id = ?`, hits `idx_sessions_user_id`).
- `GET /sessions` accepts `mineScmUserId` + `mineProvider`; control plane resolves via `UserStore.getIdentity` (read-only) and applies the filter. Unresolved identity → empty page (spec E2).
- Next.js BFF accepts `?mine=true` from the browser, derives the GitHub numeric ID from the NextAuth session, and forwards `?mineScmUserId=<id>&mineProvider=github`.
- `buildControlPlanePath` allowlist already strips client-supplied `mineScmUserId`/`mineProvider` — tests pin the spoof-resistance contract (spec AC 10).
- No UX yet — the toggle that drives `?mine=true` lands in the next PR.

## Why
Second of five stacked PRs implementing #557. This PR delivers the API capability that the upcoming sidebar toggle will consume. Verifiable in isolation via curl + auth cookie.

## Stacked on
**[#599](https://github.com/ColeMurray/background-agents/pull/599)** (creator identity in listings). This PR's base is `feat/session-list-creator-identity`.

## Test plan
- [x] Unit tests: `SessionIndexStore.list({ userId })` filters correctly, excludes NULL `user_id`, paginates within slice, combines with `excludeStatus` (spec AC 9, 12)
- [x] Integration tests: `GET /sessions?mineScmUserId=…&mineProvider=github` resolves real identities, returns empty when unresolved, rejects asymmetric/unsupported provider (spec AC 12, 13)
- [x] BFF route tests: `?mine=true` translation, spoof-resistance, no-flag passthrough (spec AC 10)
- [x] All existing control-plane (1057) + web (216) unit tests pass
- [x] Workspace `typecheck` clean
- [x] All 340 control-plane integration tests pass

## Acceptance criteria covered
- 9: NULL `user_id` sessions excluded from "mine"
- 10: Spoof-resistance (BFF strips client-supplied identity)
- 12: Sort/pagination preserved under filter
- 13: Indexed lookup (`idx_sessions_user_id`)
- 7, 8: Verify-only — child / automation inheritance already correct via `parentSession.userId` and `automation.user_id` propagation

## Notes
- Not added to `SESSION_CONTROL_PLANE_QUERY_PARAMS`: `mine`, `mineScmUserId`, `mineProvider`. The browser-facing `mine` flag is BFF-private; identity is server-derived only.
- Rollback: revert. No schema change.