### PR TITLE
feat(terraform): support custom domains for Cloudflare workers

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -94,6 +94,11 @@ jobs:
         run: terraform validate -no-color
         working-directory: ${{ env.TF_WORKING_DIR }}
 
+      - name: Terraform Test
+        id: test
+        run: terraform test -no-color
+        working-directory: ${{ env.TF_WORKING_DIR }}
+
       - name: Post Validation Results
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v8
@@ -111,6 +116,7 @@ jobs:
             | Format | ${{ steps.fmt.outcome == 'success' && '✅' || '⚠️' }} |
             | Init | ${{ steps.init.outcome == 'success' && '✅' || '❌' }} |
             | Validate | ${{ steps.validate.outcome == 'success' && '✅' || '❌' }} |
+            | Test | ${{ steps.test.outcome == 'success' && '✅' || '❌' }} |
             ${planNote}
 
             *Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -708,7 +708,7 @@ runtime config:
 Before you apply, add a new line to the GitHub App's "Identifying and authorizing users" → Callback
 URL field:
 
-```
+```text
 https://app.example.com/api/auth/callback/github
 ```
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -405,6 +405,12 @@ project_root    = "../../../"
 # replaces the built-in icon in the web sidebar and browser favicon.
 # app_icon_url = ""
 
+# Custom domains (optional, Cloudflare web_platform only — see Step 9b).
+# Hostname only, no scheme. Leave empty to use the default workers.dev URLs.
+# Domains must be bound to the Cloudflare worker before setting these.
+# web_app_domain       = ""
+# control_plane_domain = ""
+
 # Initial deployment: set both to false (see Step 7)
 enable_durable_object_bindings = false
 enable_service_bindings        = false
@@ -637,6 +643,106 @@ curl -I https://open-inspect-web-{deployment_name}.YOUR-SUBDOMAIN.workers.dev
 2. Sign in with GitHub
 3. Create a new session with a repository
 4. Send a prompt and verify the sandbox starts
+
+---
+
+## Step 9b: Custom Domains (Optional, Cloudflare only)
+
+By default, deployments use Cloudflare-assigned `*.workers.dev` URLs. You can put the web app and/or
+control plane behind your own domain (e.g., `app.example.com`) without redeploying any
+infrastructure — only the URL/identity layer changes.
+
+> **Cloudflare web_platform only.** Vercel deployments use Vercel-managed domains (configured in the
+> Vercel dashboard) and ignore these variables.
+
+### 1. Bind the domain to the worker in Cloudflare
+
+You must bind the hostname to the worker **before** setting any tfvars values, or sign-in will break
+(NextAuth will redirect to a URL that doesn't resolve).
+
+Two paths:
+
+**Dashboard (simplest):** Workers & Pages → `open-inspect-web-{deployment_name}` → Settings →
+Triggers → Custom Domains → "Add Custom Domain". Cloudflare auto-creates the DNS record on the zone
+and provisions a TLS certificate (usually under 60 seconds). Repeat for the control plane worker if
+you also want a custom domain there.
+
+**Terraform:** add a `cloudflare_workers_custom_domain` resource to the production environment. This
+requires your `cloudflare_api_token` to have `Workers Routes: Edit` and `DNS: Edit` on the zone, and
+the zone must already be in your Cloudflare account.
+
+Verify the binding before continuing:
+
+```bash
+curl -I https://app.example.com
+```
+
+You should see a response from the worker (200, 302, or 307). If you see SSL errors or a Cloudflare
+error page, the binding isn't fully provisioned — wait and try again.
+
+### 2. Set the variables in `terraform.tfvars`
+
+```hcl
+# Hostname only, no scheme.
+web_app_domain       = "app.example.com"
+control_plane_domain = "api.app.example.com"   # optional — leave empty to keep workers.dev
+```
+
+Setting either variable changes the corresponding URLs that get baked into the worker bundles and
+runtime config:
+
+| Variable               | Drives                                                               |
+| ---------------------- | -------------------------------------------------------------------- |
+| `web_app_domain`       | `NEXTAUTH_URL`                                                       |
+| `control_plane_domain` | `NEXT_PUBLIC_WS_URL`, `CONTROL_PLANE_URL`, Modal's allowed-host list |
+
+### 3. Update the GitHub App callback URL
+
+Before you apply, add a new line to the GitHub App's "Identifying and authorizing users" → Callback
+URL field:
+
+```
+https://app.example.com/api/auth/callback/github
+```
+
+GitHub Apps support multiple callback URLs. **Keep the existing `*.workers.dev` callback during
+cutover** so you can roll back without breaking sign-in. Save.
+
+### 4. Apply
+
+```bash
+cd terraform/environments/production
+terraform apply
+```
+
+Terraform rebuilds the web app worker (the build provisioner re-runs every apply) and regenerates
+`packages/web/wrangler.production.toml` with the new URL values.
+
+### 5. Smoke-test in this order
+
+1. `https://app.example.com` loads the unauthenticated landing page.
+2. Click sign in → consent on GitHub → redirected back to `https://app.example.com` (not the
+   workers.dev URL).
+3. Land on the dashboard, no `?error=Configuration` in the address bar.
+4. Open or create a session and send a prompt. Streaming output proves the WebSocket connection
+   works through the new control plane domain (or workers.dev, if you only set `web_app_domain`).
+
+### 6. Clean up after verification
+
+Once you've used the new domain for a day or two:
+
+- Remove the `*.workers.dev` callback URL from the GitHub App (optional, just tidy).
+- The `*.workers.dev` URLs themselves remain reachable forever — Cloudflare keeps them as fallbacks.
+  No action needed.
+
+### Troubleshooting
+
+| Symptom                                 | Likely cause                                                                                   |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Sign-in shows `?error=Configuration`    | `NEXTAUTH_URL` doesn't match the URL the browser is hitting (check `wrangler.production.toml`) |
+| `redirect_uri is not associated`        | New callback URL isn't saved on the GitHub App, or there's a typo                              |
+| WSS connection fails (sessions hang)    | `control_plane_domain` set but binding not provisioned, or browser CORS blocking the origin    |
+| Cloudflare 522/525 on the custom domain | Binding incomplete — TLS still provisioning, or domain pointing at the wrong worker            |
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -652,8 +652,15 @@ By default, deployments use Cloudflare-assigned `*.workers.dev` URLs. You can pu
 control plane behind your own domain (e.g., `app.example.com`) without redeploying any
 infrastructure — only the URL/identity layer changes.
 
-> **Cloudflare web_platform only.** Vercel deployments use Vercel-managed domains (configured in the
-> Vercel dashboard) and ignore these variables.
+> **Cloudflare web_platform only.** `web_app_domain` is rejected at plan time when
+> `web_platform = "vercel"` — Vercel deployments use Vercel-managed domains (configured in the
+> Vercel dashboard). `control_plane_domain` always applies regardless of web platform, since the
+> control plane is a Cloudflare Worker either way.
+>
+> **Sandbox backend interaction.** When `sandbox_provider = "modal"`, setting `control_plane_domain`
+> automatically updates Modal's `ALLOWED_CONTROL_PLANE_HOSTS` so sandbox callbacks reach the new
+> hostname. Daytona deployments need no extra wiring — the control plane calls Daytona's REST API,
+> not the reverse, so there's no host allowlist to maintain.
 
 ### 1. Bind the domain to the worker in Cloudflare
 
@@ -691,10 +698,10 @@ control_plane_domain = "api.app.example.com"   # optional — leave empty to kee
 Setting either variable changes the corresponding URLs that get baked into the worker bundles and
 runtime config:
 
-| Variable               | Drives                                                               |
-| ---------------------- | -------------------------------------------------------------------- |
-| `web_app_domain`       | `NEXTAUTH_URL`                                                       |
-| `control_plane_domain` | `NEXT_PUBLIC_WS_URL`, `CONTROL_PLANE_URL`, Modal's allowed-host list |
+| Variable               | Drives                                                                                                                   |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `web_app_domain`       | `NEXTAUTH_URL` (Cloudflare web_platform only)                                                                            |
+| `control_plane_domain` | `NEXT_PUBLIC_WS_URL`, `CONTROL_PLANE_URL`, and Modal's `ALLOWED_CONTROL_PLANE_HOSTS` (when `sandbox_provider = "modal"`) |
 
 ### 3. Update the GitHub App callback URL
 

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -206,6 +206,21 @@ Critical notes before deploy:
 - Use two-phase Terraform deploy for DO/service bindings.
 - Deploy Modal with `modal deploy deploy.py` (not `src/app.py`).
 
+### Custom Domains (Cloudflare only)
+
+If you want to put the web app or control plane behind your own domain (e.g., `app.example.com`)
+instead of the default `*.workers.dev` URL, set `web_app_domain` and/or `control_plane_domain` in
+`terraform.tfvars`.
+
+The domain must be **bound to the Cloudflare worker first** (dashboard or
+`cloudflare_workers_custom_domain`) — these tfvars only control the URL/identity layer that gets
+baked into the worker bundle (`NEXTAUTH_URL`, `NEXT_PUBLIC_WS_URL`, `CONTROL_PLANE_URL`, Modal
+allowed hosts).
+
+After setting the vars and applying, also add the new URL to the GitHub App's callback URL list.
+Full walkthrough in
+[GETTING_STARTED.md → Step 9b](./GETTING_STARTED.md#step-9b-custom-domains-optional-cloudflare-only).
+
 ## Common Issues and Fixes
 
 ### OAuth error: `redirect_uri is not associated with this application`

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -214,8 +214,10 @@ instead of the default `*.workers.dev` URL, set `web_app_domain` and/or `control
 
 The domain must be **bound to the Cloudflare worker first** (dashboard or
 `cloudflare_workers_custom_domain`) — these tfvars only control the URL/identity layer that gets
-baked into the worker bundle (`NEXTAUTH_URL`, `NEXT_PUBLIC_WS_URL`, `CONTROL_PLANE_URL`, Modal
-allowed hosts).
+baked into the worker bundle (`NEXTAUTH_URL`, `NEXT_PUBLIC_WS_URL`, `CONTROL_PLANE_URL`, and Modal's
+`ALLOWED_CONTROL_PLANE_HOSTS` when `sandbox_provider = "modal"`). `web_app_domain` is rejected at
+plan time when `web_platform = "vercel"`; `control_plane_domain` always applies. Daytona deployments
+need no extra wiring — see Step 9b for details.
 
 After setting the vars and applying, also add the new URL to the GitHub App's callback URL list.
 Full walkthrough in

--- a/terraform/environments/production/locals.tf
+++ b/terraform/environments/production/locals.tf
@@ -3,14 +3,19 @@ locals {
   use_modal_backend   = var.sandbox_provider == "modal"
   use_daytona_backend = var.sandbox_provider == "daytona"
 
-  # URLs for cross-service configuration
-  control_plane_host = "open-inspect-control-plane-${local.name_suffix}.${var.cloudflare_worker_subdomain}.workers.dev"
+  # Default workers.dev hostnames. They remain reachable even after a custom
+  # domain is bound, so they double as fallbacks.
+  default_control_plane_host = "open-inspect-control-plane-${local.name_suffix}.${var.cloudflare_worker_subdomain}.workers.dev"
+  default_web_app_host       = "open-inspect-web-${local.name_suffix}.${var.cloudflare_worker_subdomain}.workers.dev"
+
+  # Resolved control plane host — custom domain when set, workers.dev otherwise.
+  control_plane_host = var.control_plane_domain != "" ? var.control_plane_domain : local.default_control_plane_host
   control_plane_url  = "https://${local.control_plane_host}"
   ws_url             = "wss://${local.control_plane_host}"
 
-  # Web app URL depends on deployment platform
+  # Web app URL: custom domain on Cloudflare path, or workers.dev / Vercel default
   web_app_url = var.web_platform == "cloudflare" ? (
-    "https://open-inspect-web-${local.name_suffix}.${var.cloudflare_worker_subdomain}.workers.dev"
+    var.web_app_domain != "" ? "https://${var.web_app_domain}" : "https://${local.default_web_app_host}"
     ) : (
     "https://open-inspect-${local.name_suffix}.vercel.app"
   )

--- a/terraform/environments/production/outputs.tf
+++ b/terraform/environments/production/outputs.tf
@@ -26,8 +26,8 @@ output "d1_database_id" {
 
 # Cloudflare Workers
 output "control_plane_url" {
-  description = "Control plane worker URL"
-  value       = module.control_plane_worker.worker_url
+  description = "Control plane worker URL (custom domain when set, else workers.dev)"
+  value       = local.control_plane_url
 }
 
 output "control_plane_worker_name" {
@@ -106,7 +106,7 @@ output "verification_commands" {
   value       = <<-EOF
 
     # 1. Health check control plane
-    curl ${module.control_plane_worker.worker_url}/health
+    curl ${local.control_plane_url}/health
 
     # 2. Health check sandbox backend
     ${local.use_modal_backend ? "curl ${module.modal_app[0].api_health_url}" : "# Daytona sandboxes use the REST API directly — no health endpoint to check"}
@@ -115,7 +115,7 @@ output "verification_commands" {
     curl ${local.web_app_url}
 
     # 4. Test authenticated endpoint (should return 401)
-    curl ${module.control_plane_worker.worker_url}/sessions
+    curl ${local.control_plane_url}/sessions
 
   EOF
 }

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -191,10 +191,25 @@ sandbox_provider = "modal"
 web_platform = "vercel"
 
 # =============================================================================
-# Custom Domains (optional, Cloudflare web_platform only)
+# Custom Domains (Cloudflare workers only)
 # =============================================================================
-# Hostname only, no scheme. Leave empty (or commented) to use the default
-# workers.dev URLs.
+# Optional. Hostname only, no scheme. Leave empty (or commented) to use the
+# default workers.dev URLs.
+#
+# Cloudflare-only feature:
+#   - web_app_domain only takes effect when web_platform = "cloudflare".
+#     Setting it while web_platform = "vercel" fails at plan time — Vercel
+#     manages its own domain bindings in the Vercel dashboard.
+#   - control_plane_domain always applies — the control plane is a Cloudflare
+#     Worker regardless of web platform.
+#
+# Sandbox backend interaction:
+#   - sandbox_provider = "modal": setting control_plane_domain automatically
+#     updates Modal's ALLOWED_CONTROL_PLANE_HOSTS so sandbox callbacks reach
+#     the new hostname.
+#   - sandbox_provider = "daytona": no extra wiring needed. The control
+#     plane calls Daytona's REST API, not the reverse, so there's no host
+#     allowlist to maintain.
 #
 # These variables do NOT bind the domain in Cloudflare. Before setting them:
 #   1. Have the zone admin add the zone to this Cloudflare account.
@@ -206,7 +221,6 @@ web_platform = "vercel"
 # After setting these and running terraform apply:
 #   - NEXTAUTH_URL is rebuilt from web_app_domain.
 #   - NEXT_PUBLIC_WS_URL and CONTROL_PLANE_URL are rebuilt from control_plane_domain.
-#   - Modal's allowed-host list updates automatically.
 #   - Update the GitHub App's OAuth callback URL to:
 #       https://<web_app_domain>/api/auth/callback/github
 #     (GitHub Apps support multiple callback URLs — keep the workers.dev one

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -190,6 +190,34 @@ sandbox_provider = "modal"
 # - "cloudflare": deploy the web app to Cloudflare Workers via OpenNext (no Vercel credentials needed)
 web_platform = "vercel"
 
+# =============================================================================
+# Custom Domains (optional, Cloudflare web_platform only)
+# =============================================================================
+# Hostname only, no scheme. Leave empty (or commented) to use the default
+# workers.dev URLs.
+#
+# These variables do NOT bind the domain in Cloudflare. Before setting them:
+#   1. Have the zone admin add the zone to this Cloudflare account.
+#   2. Bind each hostname to the corresponding worker via a
+#      cloudflare_workers_custom_domain resource (or in the dashboard:
+#      Workers & Pages -> <worker> -> Settings -> Triggers -> Custom Domains).
+#   3. Wait for TLS to provision (usually <60s) and DNS to propagate.
+#
+# After setting these and running terraform apply:
+#   - NEXTAUTH_URL is rebuilt from web_app_domain.
+#   - NEXT_PUBLIC_WS_URL and CONTROL_PLANE_URL are rebuilt from control_plane_domain.
+#   - Modal's allowed-host list updates automatically.
+#   - Update the GitHub App's OAuth callback URL to:
+#       https://<web_app_domain>/api/auth/callback/github
+#     (GitHub Apps support multiple callback URLs — keep the workers.dev one
+#     during cutover, then remove it once the custom domain is verified.)
+#
+# Example layout:
+#   web_app_domain       = "app.example.com"
+#   control_plane_domain = "api.app.example.com"
+# web_app_domain       = ""
+# control_plane_domain = ""
+
 # Unique deployment name (used in resource names and URLs)
 # IMPORTANT: This must be globally unique for Vercel URLs.
 # Use something unique like your GitHub username, company name, or a random suffix.

--- a/terraform/environments/production/tests/custom_domains.tftest.hcl
+++ b/terraform/environments/production/tests/custom_domains.tftest.hcl
@@ -1,0 +1,178 @@
+# =============================================================================
+# Custom domain override tests
+# =============================================================================
+# Verifies that web_app_domain and control_plane_domain correctly override the
+# default workers.dev URLs in cross-service config (and that empty values
+# preserve the existing fallback behavior).
+#
+# These tests run in plan mode with mocked Cloudflare and Vercel providers, so
+# they require no real credentials and create no infrastructure. Run locally
+# from this directory with:
+#
+#   terraform init -backend=false
+#   terraform test
+
+mock_provider "cloudflare" {}
+mock_provider "vercel" {}
+
+# Defaults applied to every run; individual runs can override.
+variables {
+  cloudflare_api_token        = "test-cf-token"
+  cloudflare_account_id       = "test-account-id"
+  cloudflare_worker_subdomain = "test-subdomain"
+
+  modal_token_id     = "test-modal-id"
+  modal_token_secret = "test-modal-secret"
+  modal_workspace    = "test-workspace"
+  modal_api_secret   = "test-modal-api-secret"
+
+  github_client_id           = "test-client-id"
+  github_client_secret       = "test-client-secret"
+  github_app_id              = "1"
+  github_app_installation_id = "1"
+  github_app_private_key     = "test-private-key"
+
+  anthropic_api_key           = "test-anthropic-key"
+  token_encryption_key        = "test-token-key"
+  repo_secrets_encryption_key = "test-repo-key"
+  internal_callback_secret    = "test-internal-secret"
+  nextauth_secret             = "test-nextauth-secret"
+
+  deployment_name = "test"
+  web_platform    = "cloudflare"
+
+  # Disable bot integrations so their validation rules don't require
+  # additional secrets we don't care about for these assertions.
+  enable_slack_bot  = false
+  enable_github_bot = false
+
+  # Skip the access-control safety check.
+  unsafe_allow_all_users = true
+  allowed_users          = ""
+  allowed_email_domains  = ""
+}
+
+run "defaults_use_workers_dev" {
+  command = plan
+
+  variables {
+    web_app_domain       = ""
+    control_plane_domain = ""
+  }
+
+  assert {
+    condition     = local.web_app_url == "https://open-inspect-web-test.test-subdomain.workers.dev"
+    error_message = "Empty web_app_domain must fall back to the workers.dev URL."
+  }
+
+  assert {
+    condition     = local.control_plane_host == "open-inspect-control-plane-test.test-subdomain.workers.dev"
+    error_message = "Empty control_plane_domain must fall back to the workers.dev host."
+  }
+
+  assert {
+    condition     = local.control_plane_url == "https://open-inspect-control-plane-test.test-subdomain.workers.dev"
+    error_message = "control_plane_url must derive https:// from control_plane_host."
+  }
+
+  assert {
+    condition     = local.ws_url == "wss://open-inspect-control-plane-test.test-subdomain.workers.dev"
+    error_message = "ws_url must derive wss:// from control_plane_host."
+  }
+}
+
+run "web_app_domain_overrides_only_web" {
+  command = plan
+
+  variables {
+    web_app_domain       = "app.example.com"
+    control_plane_domain = ""
+  }
+
+  assert {
+    condition     = local.web_app_url == "https://app.example.com"
+    error_message = "web_app_url must use the custom web_app_domain when set."
+  }
+
+  assert {
+    condition     = local.control_plane_host == "open-inspect-control-plane-test.test-subdomain.workers.dev"
+    error_message = "control_plane_host must remain on workers.dev when only web_app_domain is set."
+  }
+
+  assert {
+    condition     = local.ws_url == "wss://open-inspect-control-plane-test.test-subdomain.workers.dev"
+    error_message = "ws_url must remain on workers.dev when only web_app_domain is set."
+  }
+}
+
+run "control_plane_domain_overrides_only_control_plane" {
+  command = plan
+
+  variables {
+    web_app_domain       = ""
+    control_plane_domain = "api.example.com"
+  }
+
+  assert {
+    condition     = local.web_app_url == "https://open-inspect-web-test.test-subdomain.workers.dev"
+    error_message = "web_app_url must remain on workers.dev when only control_plane_domain is set."
+  }
+
+  assert {
+    condition     = local.control_plane_host == "api.example.com"
+    error_message = "control_plane_host must use the custom control_plane_domain when set."
+  }
+
+  assert {
+    condition     = local.control_plane_url == "https://api.example.com"
+    error_message = "control_plane_url must derive https:// from the custom control_plane_domain."
+  }
+
+  assert {
+    condition     = local.ws_url == "wss://api.example.com"
+    error_message = "ws_url must derive wss:// from the custom control_plane_domain."
+  }
+}
+
+run "both_domains_set" {
+  command = plan
+
+  variables {
+    web_app_domain       = "app.example.com"
+    control_plane_domain = "api.example.com"
+  }
+
+  assert {
+    condition     = local.web_app_url == "https://app.example.com"
+    error_message = "web_app_url must use the custom web_app_domain when both are set."
+  }
+
+  assert {
+    condition     = local.control_plane_host == "api.example.com"
+    error_message = "control_plane_host must use the custom control_plane_domain when both are set."
+  }
+
+  assert {
+    condition     = local.control_plane_url == "https://api.example.com"
+    error_message = "control_plane_url must derive https:// from the custom control_plane_domain."
+  }
+
+  assert {
+    condition     = local.ws_url == "wss://api.example.com"
+    error_message = "ws_url must derive wss:// from the custom control_plane_domain."
+  }
+}
+
+run "vercel_platform_ignores_web_app_domain" {
+  command = plan
+
+  variables {
+    web_platform   = "vercel"
+    web_app_domain = "app.example.com"
+  }
+
+  assert {
+    condition     = local.web_app_url == "https://open-inspect-test.vercel.app"
+    error_message = "web_app_domain must be ignored when web_platform = vercel — Vercel manages its own domains."
+  }
+}

--- a/terraform/environments/production/tests/custom_domains.tftest.hcl
+++ b/terraform/environments/production/tests/custom_domains.tftest.hcl
@@ -163,7 +163,7 @@ run "both_domains_set" {
   }
 }
 
-run "vercel_platform_ignores_web_app_domain" {
+run "vercel_platform_rejects_web_app_domain" {
   command = plan
 
   variables {
@@ -171,8 +171,19 @@ run "vercel_platform_ignores_web_app_domain" {
     web_app_domain = "app.example.com"
   }
 
+  expect_failures = [var.web_app_domain]
+}
+
+run "vercel_platform_with_empty_web_app_domain_is_allowed" {
+  command = plan
+
+  variables {
+    web_platform   = "vercel"
+    web_app_domain = ""
+  }
+
   assert {
     condition     = local.web_app_url == "https://open-inspect-test.vercel.app"
-    error_message = "web_app_domain must be ignored when web_platform = vercel — Vercel manages its own domains."
+    error_message = "Empty web_app_domain on Vercel must produce the default vercel.app URL — the validation should only fire when a value is supplied."
   }
 }

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -422,3 +422,28 @@ variable "unsafe_allow_all_users" {
   type        = bool
   default     = false
 }
+
+# =============================================================================
+# Custom Domains (optional)
+# =============================================================================
+# When set, these override the default workers.dev URLs in cross-service
+# config (NEXTAUTH_URL, NEXT_PUBLIC_WS_URL, CONTROL_PLANE_URL, Modal allowed
+# hosts) and in outputs.
+#
+# These variables do NOT create the Cloudflare custom domain bindings — add
+# cloudflare_workers_custom_domain resources separately, or have the zone
+# admin bind the domains in the dashboard.
+#
+# Set the hostname only (no scheme): "app.example.com", not "https://...".
+
+variable "web_app_domain" {
+  description = "Custom hostname for the web app. Overrides the workers.dev URL when set. Drives NEXTAUTH_URL."
+  type        = string
+  default     = ""
+}
+
+variable "control_plane_domain" {
+  description = "Custom hostname for the control plane. Drives CONTROL_PLANE_URL, NEXT_PUBLIC_WS_URL, and Modal's allowed-host list."
+  type        = string
+  default     = ""
+}

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -424,20 +424,30 @@ variable "unsafe_allow_all_users" {
 }
 
 # =============================================================================
-# Custom Domains (optional)
+# Custom Domains (Cloudflare workers only)
 # =============================================================================
-# When set, these override the default workers.dev URLs in cross-service
-# config (NEXTAUTH_URL, NEXT_PUBLIC_WS_URL, CONTROL_PLANE_URL, Modal allowed
-# hosts) and in outputs.
+# Optional. When set, these override the default workers.dev URLs in
+# cross-service config (NEXTAUTH_URL, NEXT_PUBLIC_WS_URL, CONTROL_PLANE_URL)
+# and outputs. When sandbox_provider = "modal", control_plane_domain also
+# flows into Modal's ALLOWED_CONTROL_PLANE_HOSTS so sandbox callbacks
+# reach the new hostname. Daytona doesn't need an equivalent — the
+# control plane calls Daytona's API, not the reverse, so there's no host
+# allowlist to maintain.
 #
-# These variables do NOT create the Cloudflare custom domain bindings — add
-# cloudflare_workers_custom_domain resources separately, or have the zone
-# admin bind the domains in the dashboard.
+# - web_app_domain only takes effect when web_platform = "cloudflare".
+#   Vercel deployments manage their own domains; setting this variable
+#   while web_platform = "vercel" fails at plan time (see validation block).
+# - control_plane_domain always applies — the control plane is a Cloudflare
+#   Worker regardless of web platform.
+#
+# These variables do NOT bind the domain in Cloudflare. Add a
+# cloudflare_workers_custom_domain resource separately, or have the zone
+# admin bind the domain in the dashboard.
 #
 # Set the hostname only (no scheme): "app.example.com", not "https://...".
 
 variable "web_app_domain" {
-  description = "Custom hostname for the web app. Overrides the workers.dev URL when set. Drives NEXTAUTH_URL."
+  description = "Custom hostname for the Cloudflare web Worker. Drives NEXTAUTH_URL. Has no effect when web_platform = \"vercel\" (rejected at plan time when both are set)."
   type        = string
   default     = ""
 
@@ -448,7 +458,7 @@ variable "web_app_domain" {
 }
 
 variable "control_plane_domain" {
-  description = "Custom hostname for the control plane. Drives CONTROL_PLANE_URL, NEXT_PUBLIC_WS_URL, and Modal's allowed-host list."
+  description = "Custom hostname for the Cloudflare control plane Worker. Drives CONTROL_PLANE_URL, NEXT_PUBLIC_WS_URL, and (when sandbox_provider = \"modal\") Modal's ALLOWED_CONTROL_PLANE_HOSTS. No-op for Daytona's REST-pull model."
   type        = string
   default     = ""
 }

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -440,6 +440,11 @@ variable "web_app_domain" {
   description = "Custom hostname for the web app. Overrides the workers.dev URL when set. Drives NEXTAUTH_URL."
   type        = string
   default     = ""
+
+  validation {
+    condition     = var.web_app_domain == "" || var.web_platform == "cloudflare"
+    error_message = "web_app_domain only takes effect when web_platform = \"cloudflare\". Vercel deployments use Vercel-managed domains and ignore this variable. Either remove web_app_domain or switch web_platform to \"cloudflare\"."
+  }
 }
 
 variable "control_plane_domain" {


### PR DESCRIPTION
## Summary
  - Adds two optional Terraform variables — `web_app_domain` and `control_plane_domain` — that override the default  `*.workers.dev` URLs in cross-service config (`NEXTAUTH_URL`, `NEXT_PUBLIC_WS_URL`, `CONTROL_PLANE_URL`, Modal allowed hosts) and outputs.
  - **Cloudflare-only feature.** `web_app_domain` takes effect only when `web_platform = "cloudflare"` — Vercel deployments use Vercel-managed domains and ignore the variable. `control_plane_domain` always applies since the control plane is on Cloudflare regardless of web platform.
  - Both default to empty, so existing deployments produce no diff. The variables describe the URL/identity layer only — binding the hostname to the worker (Cloudflare dashboard or `cloudflare_workers_custom_domain`) is out of scope and left to the operator.
  - Documents the full cutover in `docs/GETTING_STARTED.md` Step 9b (binding, GitHub App callback update, apply, smoke-test, troubleshooting table) plus a pointer in `docs/SETUP_GUIDE.md`. Both are flagged "Cloudflare only".
  - Adds `terraform test` coverage with five plan-mode runs (including `vercel_platform_ignores_web_app_domain` to lock the no-op behavior on the Vercel path) and wires `terraform test` into the existing `validate` CI job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom domain support for Cloudflare deployments (web app and control plane hostnames)

* **Tests**
  * Added Terraform plan-mode tests for custom-domain behavior
  * CI now runs Terraform tests during pre-plan validation and reports test results in the PR summary

* **Documentation**
  * Updated setup/getting-started docs with custom-domain setup, examples, callback updates, smoke-test steps, and troubleshooting guidance

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/604)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->