### PR TITLE
feat(shared): slack integration settings types + validation

### DIFF
--- a/packages/control-plane/src/db/integration-settings.test.ts
+++ b/packages/control-plane/src/db/integration-settings.test.ts
@@ -168,11 +168,11 @@ describe("isValidIntegrationId", () => {
   it("accepts known integration IDs", () => {
     expect(isValidIntegrationId("github")).toBe(true);
     expect(isValidIntegrationId("linear")).toBe(true);
+    expect(isValidIntegrationId("slack")).toBe(true);
   });
 
   it("rejects unknown IDs", () => {
     expect(isValidIntegrationId("githb")).toBe(false);
-    expect(isValidIntegrationId("slack")).toBe(false);
     expect(isValidIntegrationId("")).toBe(false);
   });
 });
@@ -780,6 +780,125 @@ describe("IntegrationSettingsStore", () => {
         allowUserPreferenceOverride: false,
         emitToolProgressActivities: false,
       });
+    });
+  });
+
+  describe("slack settings", () => {
+    it("round-trips global slack settings", async () => {
+      await store.setGlobal("slack", {
+        defaults: { agentNotificationsEnabled: true, mentionsPolicy: "escape" },
+      });
+
+      const result = await store.getGlobal("slack");
+      expect(result).toEqual({
+        defaults: { agentNotificationsEnabled: true, mentionsPolicy: "escape" },
+      });
+    });
+
+    it("accepts every valid mentionsPolicy value at global level", async () => {
+      for (const policy of ["allow", "escape", "strip"] as const) {
+        await store.setGlobal("slack", { defaults: { mentionsPolicy: policy } });
+        const result = await store.getGlobal("slack");
+        expect(result?.defaults?.mentionsPolicy).toBe(policy);
+      }
+    });
+
+    it("rejects invalid mentionsPolicy at global level", async () => {
+      await expect(
+        store.setGlobal("slack", {
+          defaults: { mentionsPolicy: "yell" as unknown as "allow" },
+        })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
+
+    it("rejects non-boolean agentNotificationsEnabled at global level", async () => {
+      await expect(
+        store.setGlobal("slack", {
+          defaults: { agentNotificationsEnabled: "yes" as unknown as boolean },
+        })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
+
+    it("rejects unknown field at global level", async () => {
+      await expect(
+        store.setGlobal("slack", {
+          defaults: { foo: "bar" } as unknown as { agentNotificationsEnabled?: boolean },
+        })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
+
+    it("round-trips per-repo slack settings", async () => {
+      await store.setRepoSettings("slack", "acme/widgets", {
+        agentNotificationsEnabled: false,
+      });
+
+      const result = await store.getRepoSettings("slack", "acme/widgets");
+      expect(result).toEqual({ agentNotificationsEnabled: false });
+    });
+
+    it("rejects mentionsPolicy at per-repo level (global-only field)", async () => {
+      await expect(
+        store.setRepoSettings("slack", "acme/widgets", {
+          mentionsPolicy: "escape",
+        } as unknown as { agentNotificationsEnabled?: boolean })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
+
+    it("rejects unknown field at per-repo level", async () => {
+      await expect(
+        store.setRepoSettings("slack", "acme/widgets", {
+          foo: "bar",
+        } as unknown as { agentNotificationsEnabled?: boolean })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
+
+    it("rejects non-boolean agentNotificationsEnabled at per-repo level", async () => {
+      await expect(
+        store.setRepoSettings("slack", "acme/widgets", {
+          agentNotificationsEnabled: 1 as unknown as boolean,
+        })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
+
+    it("getResolvedConfig: repo agentNotificationsEnabled overrides global", async () => {
+      await store.setGlobal("slack", {
+        defaults: { agentNotificationsEnabled: false, mentionsPolicy: "allow" },
+      });
+      await store.setRepoSettings("slack", "acme/widgets", {
+        agentNotificationsEnabled: true,
+      });
+
+      const config = await store.getResolvedConfig("slack", "acme/widgets");
+      expect(config.settings.agentNotificationsEnabled).toBe(true);
+      expect(config.settings.mentionsPolicy).toBe("allow");
+    });
+
+    it("getResolvedConfig: mentionsPolicy comes from global only", async () => {
+      await store.setGlobal("slack", {
+        defaults: { mentionsPolicy: "strip" },
+      });
+      await store.setRepoSettings("slack", "acme/widgets", {
+        agentNotificationsEnabled: true,
+      });
+
+      const config = await store.getResolvedConfig("slack", "acme/widgets");
+      expect(config.settings.mentionsPolicy).toBe("strip");
+      expect(config.settings.agentNotificationsEnabled).toBe(true);
+    });
+
+    it("getResolvedConfig: returns empty settings when nothing configured", async () => {
+      const config = await store.getResolvedConfig("slack", "acme/widgets");
+      expect(config).toEqual({ enabledRepos: null, settings: {} });
+    });
+
+    it("getResolvedConfig: global agentNotificationsEnabled used when no repo override", async () => {
+      await store.setGlobal("slack", {
+        defaults: { agentNotificationsEnabled: true, mentionsPolicy: "allow" },
+      });
+
+      const config = await store.getResolvedConfig("slack", "acme/widgets");
+      expect(config.settings.agentNotificationsEnabled).toBe(true);
+      expect(config.settings.mentionsPolicy).toBe("allow");
     });
   });
 });

--- a/packages/control-plane/src/db/integration-settings.ts
+++ b/packages/control-plane/src/db/integration-settings.ts
@@ -147,7 +147,9 @@ export class IntegrationSettingsStore {
   async getResolvedConfig<K extends IntegrationId>(
     integrationId: K,
     repo: string
-  ): Promise<ResolvedIntegrationConfig<IntegrationSettingsMap[K]["repo"]>> {
+  ): Promise<
+    ResolvedIntegrationConfig<NonNullable<IntegrationSettingsMap[K]["global"]["defaults"]>>
+  > {
     const [globalSettings, repoSettings] = await Promise.all([
       this.getGlobal(integrationId),
       this.getRepoSettings(integrationId, repo),
@@ -169,7 +171,7 @@ export class IntegrationSettingsStore {
     }
 
     return { enabledRepos, settings } as ResolvedIntegrationConfig<
-      IntegrationSettingsMap[K]["repo"]
+      NonNullable<IntegrationSettingsMap[K]["global"]["defaults"]>
     >;
   }
 

--- a/packages/control-plane/src/db/integration-settings.ts
+++ b/packages/control-plane/src/db/integration-settings.ts
@@ -8,8 +8,13 @@ import {
   type LinearBotSettings,
   type CodeServerSettings,
   type SandboxSettings,
+  type SlackGlobalSettings,
   MAX_TUNNEL_PORTS,
 } from "@open-inspect/shared";
+
+type SettingsLevel = "global" | "repo";
+
+const SLACK_MENTIONS_POLICIES = ["allow", "escape", "strip"] as const;
 
 export class IntegrationSettingsValidationError extends Error {
   constructor(message: string) {
@@ -59,7 +64,7 @@ export class IntegrationSettingsStore {
     if (settings.defaults) {
       settings = {
         ...settings,
-        defaults: this.validateAndNormalizeSettings(integrationId, settings.defaults),
+        defaults: this.validateAndNormalizeSettings(integrationId, settings.defaults, "global"),
       };
     }
 
@@ -103,7 +108,7 @@ export class IntegrationSettingsStore {
     repo: string,
     settings: IntegrationSettingsMap[K]["repo"]
   ): Promise<void> {
-    const normalized = this.validateAndNormalizeSettings(integrationId, settings);
+    const normalized = this.validateAndNormalizeSettings(integrationId, settings, "repo");
 
     const now = Date.now();
     await this.db
@@ -170,7 +175,8 @@ export class IntegrationSettingsStore {
 
   private validateAndNormalizeSettings<K extends IntegrationId>(
     integrationId: K,
-    settings: IntegrationSettingsMap[K]["repo"]
+    settings: IntegrationSettingsMap[K]["repo"],
+    level: SettingsLevel
   ): IntegrationSettingsMap[K]["repo"] {
     if (integrationId === "github") {
       return this.validateAndNormalizeGitHubSettings(
@@ -189,6 +195,13 @@ export class IntegrationSettingsStore {
     if (integrationId === "sandbox") {
       return this.validateSandboxSettings(
         settings as SandboxSettings
+      ) as IntegrationSettingsMap[K]["repo"];
+    }
+
+    if (integrationId === "slack") {
+      return this.validateSlackSettings(
+        settings as SlackGlobalSettings,
+        level
       ) as IntegrationSettingsMap[K]["repo"];
     }
 
@@ -316,6 +329,40 @@ export class IntegrationSettingsStore {
       }
       return { ...settings, tunnelPorts: dedupedPorts };
     }
+    return settings;
+  }
+
+  private validateSlackSettings(
+    settings: SlackGlobalSettings,
+    level: SettingsLevel
+  ): SlackGlobalSettings {
+    const allowedKeys =
+      level === "global"
+        ? new Set(["agentNotificationsEnabled", "mentionsPolicy"])
+        : new Set(["agentNotificationsEnabled"]);
+
+    for (const key of Object.keys(settings)) {
+      if (!allowedKeys.has(key)) {
+        throw new IntegrationSettingsValidationError(`Unknown slack setting: ${key}`);
+      }
+    }
+
+    if (
+      settings.agentNotificationsEnabled !== undefined &&
+      typeof settings.agentNotificationsEnabled !== "boolean"
+    ) {
+      throw new IntegrationSettingsValidationError("agentNotificationsEnabled must be a boolean");
+    }
+
+    if (
+      settings.mentionsPolicy !== undefined &&
+      !SLACK_MENTIONS_POLICIES.includes(settings.mentionsPolicy)
+    ) {
+      throw new IntegrationSettingsValidationError(
+        `mentionsPolicy must be one of: ${SLACK_MENTIONS_POLICIES.join(", ")}`
+      );
+    }
+
     return settings;
   }
 }

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -3,10 +3,13 @@
 export type IntegrationId = "github" | "linear" | "code-server" | "sandbox" | "slack";
 
 /** Enforces the common shape for all integration configurations. */
-export interface IntegrationEntry<TRepo extends object = Record<string, unknown>> {
+export interface IntegrationEntry<
+  TRepo extends object = Record<string, unknown>,
+  TGlobalDefaults extends object = TRepo,
+> {
   global: {
     enabledRepos?: string[];
-    defaults?: TRepo;
+    defaults?: TGlobalDefaults;
   };
   repo: TRepo;
 }
@@ -65,7 +68,7 @@ export interface IntegrationSettingsMap {
   linear: IntegrationEntry<LinearBotSettings>;
   "code-server": IntegrationEntry<CodeServerSettings>;
   sandbox: IntegrationEntry<SandboxSettings>;
-  slack: IntegrationEntry<SlackGlobalSettings>;
+  slack: IntegrationEntry<SlackRepoSettings, SlackGlobalSettings>;
 }
 
 /** Derived type for the GitHub bot global config. */

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -1,6 +1,6 @@
 // Integration settings types
 
-export type IntegrationId = "github" | "linear" | "code-server" | "sandbox";
+export type IntegrationId = "github" | "linear" | "code-server" | "sandbox" | "slack";
 
 /** Enforces the common shape for all integration configurations. */
 export interface IntegrationEntry<TRepo extends object = Record<string, unknown>> {
@@ -47,12 +47,25 @@ export interface SandboxSettings {
   terminalEnabled?: boolean;
 }
 
+export type SlackMentionsPolicy = "allow" | "escape" | "strip";
+
+/** Per-repo Slack overrides. Mentions policy is workspace-wide and cannot be overridden per repo. */
+export interface SlackRepoSettings {
+  agentNotificationsEnabled?: boolean;
+}
+
+/** Global Slack defaults: per-repo fields plus workspace-wide policy controls. */
+export interface SlackGlobalSettings extends SlackRepoSettings {
+  mentionsPolicy?: SlackMentionsPolicy;
+}
+
 /** Maps each integration ID to its global and per-repo settings types. */
 export interface IntegrationSettingsMap {
   github: IntegrationEntry<GitHubBotSettings>;
   linear: IntegrationEntry<LinearBotSettings>;
   "code-server": IntegrationEntry<CodeServerSettings>;
   sandbox: IntegrationEntry<SandboxSettings>;
+  slack: IntegrationEntry<SlackGlobalSettings>;
 }
 
 /** Derived type for the GitHub bot global config. */
@@ -60,6 +73,7 @@ export type GitHubGlobalConfig = IntegrationSettingsMap["github"]["global"];
 export type LinearGlobalConfig = IntegrationSettingsMap["linear"]["global"];
 export type CodeServerGlobalConfig = IntegrationSettingsMap["code-server"]["global"];
 export type SandboxGlobalConfig = IntegrationSettingsMap["sandbox"]["global"];
+export type SlackGlobalConfig = IntegrationSettingsMap["slack"]["global"];
 
 /** Full MCP server config with decrypted credentials. Internal use only. */
 export interface McpServerConfig {
@@ -111,5 +125,10 @@ export const INTEGRATION_DEFINITIONS: {
     id: "sandbox",
     name: "Sandbox",
     description: "Sandbox environment settings (tunnel ports, timeouts, etc.)",
+  },
+  {
+    id: "slack",
+    name: "Slack",
+    description: "Agent-driven Slack notifications and mention policy",
   },
 ];


### PR DESCRIPTION
## Summary

PR 2 of the agent-slack-notification feature ([plan](docs/agent-slack-notification-tool-implementation-plan.md)). Defines the typed shape of Slack integration settings and wires it through the `IntegrationSettingsStore` with strict per-level validation. **No behavior change to anything that exists today** — Slack settings are not yet read or used anywhere; that arrives in PRs 3–5.

- Adds `"slack"` to `IntegrationId`, `IntegrationSettingsMap`, and `INTEGRATION_DEFINITIONS`.
- Defines `SlackRepoSettings` (master switch only) and `SlackGlobalSettings` (master switch + workspace mentions policy). The spec calls out mentions policy as **global only — not overridable per repo**, and the validator enforces it.
- Adds a `level: "global" | "repo"` parameter to the existing `IntegrationSettingsStore.validateAndNormalizeSettings` dispatcher and a `validateSlackSettings` private method that:
  - Rejects unknown fields at both levels
  - Rejects `mentionsPolicy` at the per-repo level
  - Rejects non-boolean `agentNotificationsEnabled`
  - Rejects `mentionsPolicy` values outside `{ "allow", "escape", "strip" }`

## Behavior changes

- The integrations list in Settings will now include a "Slack" row. Clicking it routes to a page that currently renders nothing (the `IntegrationDetail` switch in `[id]/page.tsx` falls through to `null`). PR 3 lands the actual UI.
- The `/integration-settings/slack/...` API endpoints are now reachable (they go through the existing generic handlers). Operators _could_ curl them today, but there's no UI yet.

## What's intentionally NOT here

- **No D1 migration.** `integration_settings` and `integration_repo_settings` already store opaque JSON keyed by `integration_id`; nothing schema-shaped needs to change.
- **No web UI.** That's PR 3.
- **No control-plane handler / Slack call path.** That's PR 4.
- **No defaults applied at storage time.** The plan's "default false / default 'allow'" applies at consumer time (PR 4 will resolve effective config); the store stays consistent with how `GitHubBotSettings` etc. handle defaults today (all fields optional, consumers fill in).

## Naming deviation from spec/plan pseudocode

The spec and plan show field names in snake_case (`agent_notifications_enabled`, `mentions_policy`). The codebase universally uses camelCase for settings fields (`autoReviewOnOpen`, `allowedTriggerUsers`, `tunnelPorts`, `terminalEnabled`). I treated the snake_case as pseudocode and used camelCase here to match existing conventions and avoid making this integration the odd one out.

## Type design note

`IntegrationEntry<TRepo>` couples the global `defaults` and per-repo settings to a single `TRepo` type. Since `mentionsPolicy` is global-only but `agentNotificationsEnabled` is shared, I used `IntegrationEntry<SlackGlobalSettings>` (the wider type) and enforce the constraint at validation time via the new `level` parameter. `SlackRepoSettings` is exported as documentation of intent — it's the narrower view of what's allowed at the per-repo level, which the validator enforces.

## Test plan

- [x] `npm test -w @open-inspect/control-plane` — 1063/1063, including 12 new slack-specific cases (round-trip, accept-all-policies, reject invalid mentionsPolicy, reject non-boolean, reject unknown field at both levels, reject mentionsPolicy at per-repo level, getResolvedConfig merge, mentionsPolicy comes from global only)
- [x] `npm test -w @open-inspect/shared` — 135/135
- [x] `npm test -w @open-inspect/slack-bot` — 48/48 (no behavior change)
- [x] `npm test -w @open-inspect/web` — 208/208
- [x] `npm test -w @open-inspect/github-bot` — 103/103
- [x] `npm test -w @open-inspect/linear-bot` — 103/103
- [x] `npm run test:integration -w @open-inspect/control-plane` — 327/327
- [x] `npm run typecheck` — clean across all packages
- [x] `npm run lint` — clean
- [x] `npm run format -- --check` — clean

## Files

- `packages/shared/src/types/integrations.ts` (+21/-3)
- `packages/control-plane/src/db/integration-settings.ts` (+53/-2)
- `packages/control-plane/src/db/integration-settings.test.ts` (+121/-3, including flipping the existing `expect(isValidIntegrationId("slack")).toBe(false)` to `true`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Slack integration with configurable global and per-repository settings; options include mentions policy and agent notifications, with per-repo overriding agent notifications.
* **Validation**
  * Enforces allowed fields for global vs repo settings, restricts mentions policy values, and rejects unknown fields.
* **Tests**
  * Added comprehensive Slack settings tests covering CRUD, validation, and resolved-config merge rules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/607)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->