### PR TITLE
feat(web): add Slack integration settings UI

### DIFF
--- a/packages/web/src/app/(app)/settings/integrations/[id]/page.tsx
+++ b/packages/web/src/app/(app)/settings/integrations/[id]/page.tsx
@@ -10,6 +10,7 @@ import { useIsMobile } from "@/hooks/use-media-query";
 import { CodeServerIntegrationSettings } from "@/components/settings/integrations/code-server-integration-settings";
 import { GitHubIntegrationSettings } from "@/components/settings/integrations/github-integration-settings";
 import { LinearIntegrationSettings } from "@/components/settings/integrations/linear-integration-settings";
+import { SlackIntegrationSettings } from "@/components/settings/integrations/slack-integration-settings";
 
 function getIntegration(id: string) {
   return INTEGRATION_DEFINITIONS.find((d) => d.id === id);
@@ -19,6 +20,7 @@ function IntegrationDetail({ integrationId }: { integrationId: IntegrationId }) 
   if (integrationId === "github") return <GitHubIntegrationSettings />;
   if (integrationId === "linear") return <LinearIntegrationSettings />;
   if (integrationId === "code-server") return <CodeServerIntegrationSettings />;
+  if (integrationId === "slack") return <SlackIntegrationSettings />;
   return null;
 }
 

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
@@ -2,7 +2,7 @@
 /// <reference types="@testing-library/jest-dom" />
 
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, within } from "@testing-library/react";
+import { act, cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import type {
@@ -265,5 +265,94 @@ describe("SlackIntegrationSettings", () => {
       "/api/integration-settings/slack/repos/acme/web",
       expect.objectContaining({ method: "DELETE" })
     );
+  });
+
+  // Regression: form must resync when SWR revalidates after the first render.
+  it("global form resyncs when settings change from null to populated (not dirty)", () => {
+    setupSWR({ global: null });
+    const { rerender } = render(<SlackIntegrationSettings />);
+
+    expect(screen.getByRole("switch", { name: /enable agent notifications/i })).toHaveAttribute(
+      "aria-checked",
+      "false"
+    );
+
+    act(() => {
+      setupSWR({
+        global: { defaults: { agentNotificationsEnabled: true, mentionsPolicy: "strip" } },
+      });
+    });
+    rerender(<SlackIntegrationSettings />);
+
+    expect(screen.getByRole("switch", { name: /enable agent notifications/i })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+    expect((screen.getByRole("radio", { name: /strip/i }) as HTMLInputElement).checked).toBe(true);
+  });
+
+  // Regression: dirty edits must not be clobbered by SWR revalidation.
+  it("global form preserves dirty local edits when settings revalidate", async () => {
+    const user = userEvent.setup();
+    setupSWR({ global: null });
+    const { rerender } = render(<SlackIntegrationSettings />);
+
+    await user.click(screen.getByRole("switch", { name: /enable agent notifications/i }));
+    expect(screen.getByRole("switch", { name: /enable agent notifications/i })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+
+    act(() => {
+      setupSWR({
+        global: { defaults: { agentNotificationsEnabled: false, mentionsPolicy: "strip" } },
+      });
+    });
+    rerender(<SlackIntegrationSettings />);
+
+    expect(screen.getByRole("switch", { name: /enable agent notifications/i })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+    expect((screen.getByRole("radio", { name: /allow/i }) as HTMLInputElement).checked).toBe(true);
+  });
+
+  // Regression: per-repo row must resync when entry.settings changes from SWR.
+  it("repo override row resyncs mode when entry.settings updates", () => {
+    setupSWR({
+      global: { defaults: { agentNotificationsEnabled: true, mentionsPolicy: "allow" } },
+      repos: [{ repo: "acme/web", settings: {} }],
+      availableRepos: [repo("acme/web")],
+    });
+    const { rerender } = render(<SlackIntegrationSettings />);
+
+    expect(screen.getByText("Inherit global setting")).toBeInTheDocument();
+
+    act(() => {
+      setupSWR({
+        global: { defaults: { agentNotificationsEnabled: true, mentionsPolicy: "allow" } },
+        repos: [{ repo: "acme/web", settings: { agentNotificationsEnabled: false } }],
+        availableRepos: [repo("acme/web")],
+      });
+    });
+    rerender(<SlackIntegrationSettings />);
+
+    expect(screen.getByText("Override: notifications off")).toBeInTheDocument();
+  });
+
+  // Regression: mixed-case override keys still dedupe against the available-repos picker.
+  it("dedupes available repos against mixed-case override keys", async () => {
+    const user = userEvent.setup();
+    setupSWR({
+      global: { defaults: { agentNotificationsEnabled: true, mentionsPolicy: "allow" } },
+      repos: [{ repo: "ACME/Web", settings: {} }],
+      availableRepos: [repo("acme/web"), repo("acme/api")],
+    });
+
+    render(<SlackIntegrationSettings />);
+
+    await user.click(screen.getByRole("combobox", { name: /select a repository/i }));
+    expect(screen.queryByRole("option", { name: "acme/web" })).toBeNull();
+    expect(await screen.findByRole("option", { name: "acme/api" })).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
@@ -1,0 +1,269 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import type {
+  SlackGlobalConfig,
+  SlackRepoSettings,
+  EnrichedRepository,
+} from "@open-inspect/shared";
+import { SlackIntegrationSettings } from "./slack-integration-settings";
+
+expect.extend(matchers);
+
+interface RepoSettingsEntry {
+  repo: string;
+  settings: SlackRepoSettings;
+}
+
+const { useSWRMock, mutateMock } = vi.hoisted(() => ({
+  useSWRMock: vi.fn(),
+  mutateMock: vi.fn(),
+}));
+
+vi.mock("swr", () => ({
+  default: useSWRMock,
+  mutate: mutateMock,
+}));
+
+const { toastSuccess, toastError } = vi.hoisted(() => ({
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: toastSuccess, error: toastError },
+}));
+
+const fetchMock = vi.fn();
+
+function setupSWR(opts: {
+  global?: SlackGlobalConfig | null;
+  repos?: RepoSettingsEntry[];
+  availableRepos?: EnrichedRepository[];
+  globalLoading?: boolean;
+  reposLoading?: boolean;
+}) {
+  useSWRMock.mockImplementation((key: string) => {
+    if (key === "/api/integration-settings/slack") {
+      return {
+        data: opts.global === undefined ? undefined : { settings: opts.global },
+        isLoading: opts.globalLoading ?? false,
+      };
+    }
+    if (key === "/api/integration-settings/slack/repos") {
+      return {
+        data: { repos: opts.repos ?? [] },
+        isLoading: opts.reposLoading ?? false,
+      };
+    }
+    if (key === "/api/repos") {
+      return {
+        data: { repos: opts.availableRepos ?? [] },
+        isLoading: false,
+      };
+    }
+    return { data: undefined, isLoading: false };
+  });
+}
+
+function repo(fullName: string): EnrichedRepository {
+  return {
+    fullName,
+    private: false,
+    description: null,
+    htmlUrl: `https://github.com/${fullName}`,
+    defaultBranch: "main",
+  } as unknown as EnrichedRepository;
+}
+
+// Radix Select uses pointer-capture APIs that jsdom doesn't implement.
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+});
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  toastSuccess.mockReset();
+  toastError.mockReset();
+  mutateMock.mockReset();
+  useSWRMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function okJson(body: unknown) {
+  return {
+    ok: true,
+    json: async () => body,
+  } as Response;
+}
+
+describe("SlackIntegrationSettings", () => {
+  it("shows skeleton while loading global settings", () => {
+    setupSWR({ globalLoading: true });
+    const { container } = render(<SlackIntegrationSettings />);
+    expect(container.querySelector(".animate-pulse")).not.toBeNull();
+  });
+
+  it("renders empty state with master switch off and mentions policy 'allow'", () => {
+    setupSWR({ global: null });
+    render(<SlackIntegrationSettings />);
+
+    expect(screen.getByRole("heading", { name: "Slack" })).toBeInTheDocument();
+
+    const masterSwitch = screen.getByRole("switch", { name: /enable agent notifications/i });
+    expect(masterSwitch).toHaveAttribute("aria-checked", "false");
+
+    const allowRadio = screen.getByRole("radio", { name: /allow/i }) as HTMLInputElement;
+    expect(allowRadio.checked).toBe(true);
+  });
+
+  it("describes channel access via Slack bot membership in help copy", () => {
+    setupSWR({ global: null });
+    render(<SlackIntegrationSettings />);
+
+    expect(
+      screen.getByText(/invite the .*slack.* bot to a channel/i, { selector: "p" })
+    ).toBeInTheDocument();
+  });
+
+  it("toggling master switch on and saving sends agentNotificationsEnabled: true", async () => {
+    const user = userEvent.setup();
+    setupSWR({ global: null });
+    fetchMock.mockResolvedValue(okJson({}));
+
+    render(<SlackIntegrationSettings />);
+
+    await user.click(screen.getByRole("switch", { name: /enable agent notifications/i }));
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/integration-settings/slack");
+    expect(init.method).toBe("PUT");
+    const body = JSON.parse(init.body as string) as { settings: SlackGlobalConfig };
+    expect(body.settings.defaults).toEqual({
+      agentNotificationsEnabled: true,
+      mentionsPolicy: "allow",
+    });
+  });
+
+  it("changing mentions policy radio sends the new value on save", async () => {
+    const user = userEvent.setup();
+    setupSWR({ global: null });
+    fetchMock.mockResolvedValue(okJson({}));
+
+    render(<SlackIntegrationSettings />);
+
+    await user.click(screen.getByRole("radio", { name: /escape/i }));
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body as string) as { settings: SlackGlobalConfig };
+    expect(body.settings.defaults?.mentionsPolicy).toBe("escape");
+  });
+
+  it("renders populated settings with master switch on and policy 'strip'", () => {
+    setupSWR({
+      global: {
+        defaults: {
+          agentNotificationsEnabled: true,
+          mentionsPolicy: "strip",
+        },
+      },
+    });
+    render(<SlackIntegrationSettings />);
+
+    expect(screen.getByRole("switch", { name: /enable agent notifications/i })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+    expect((screen.getByRole("radio", { name: /strip/i }) as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("adding a per-repo override posts an empty settings body", async () => {
+    const user = userEvent.setup();
+    setupSWR({
+      global: { defaults: { agentNotificationsEnabled: true, mentionsPolicy: "allow" } },
+      repos: [],
+      availableRepos: [repo("acme/web")],
+    });
+    fetchMock.mockResolvedValue(okJson({}));
+
+    render(<SlackIntegrationSettings />);
+
+    await user.click(screen.getByRole("combobox", { name: /select a repository/i }));
+    await user.click(await screen.findByRole("option", { name: "acme/web" }));
+    await user.click(screen.getByRole("button", { name: /add override/i }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/integration-settings/slack/repos/acme/web",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ settings: {} }),
+      })
+    );
+  });
+
+  it("repo override row toggling enabled flag and saving sends override value", async () => {
+    const user = userEvent.setup();
+    setupSWR({
+      global: { defaults: { agentNotificationsEnabled: true, mentionsPolicy: "allow" } },
+      repos: [{ repo: "acme/web", settings: {} }],
+      availableRepos: [repo("acme/web")],
+    });
+    fetchMock.mockResolvedValue(okJson({}));
+
+    render(<SlackIntegrationSettings />);
+
+    const row = screen.getByText("acme/web").closest("div")!.parentElement!;
+    const overrideToggle = within(row).getByRole("combobox");
+    await user.click(overrideToggle);
+    await user.click(await screen.findByRole("option", { name: /override.*off/i }));
+    await user.click(within(row).getByRole("button", { name: /^save$/i }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/integration-settings/slack/repos/acme/web",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({ settings: { agentNotificationsEnabled: false } }),
+      })
+    );
+  });
+
+  it("removing a per-repo override sends DELETE", async () => {
+    const user = userEvent.setup();
+    setupSWR({
+      global: { defaults: { agentNotificationsEnabled: true, mentionsPolicy: "allow" } },
+      repos: [{ repo: "acme/web", settings: { agentNotificationsEnabled: false } }],
+      availableRepos: [repo("acme/web")],
+    });
+    fetchMock.mockResolvedValue(okJson({}));
+
+    render(<SlackIntegrationSettings />);
+
+    const row = screen.getByText("acme/web").closest("div")!.parentElement!;
+    await user.click(within(row).getByRole("button", { name: /remove/i }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/integration-settings/slack/repos/acme/web",
+      expect.objectContaining({ method: "DELETE" })
+    );
+  });
+});

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
@@ -1,0 +1,461 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import useSWR, { mutate } from "swr";
+import { toast } from "sonner";
+import {
+  type EnrichedRepository,
+  type SlackGlobalConfig,
+  type SlackGlobalSettings,
+  type SlackMentionsPolicy,
+  type SlackRepoSettings,
+} from "@open-inspect/shared";
+import { IntegrationSettingsSkeleton } from "./integration-settings-skeleton";
+import { Button } from "@/components/ui/button";
+import { RadioCard } from "@/components/ui/form-controls";
+import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+const GLOBAL_SETTINGS_KEY = "/api/integration-settings/slack";
+const REPO_SETTINGS_KEY = "/api/integration-settings/slack/repos";
+
+const MENTIONS_POLICY_OPTIONS: {
+  value: SlackMentionsPolicy;
+  label: string;
+  description: string;
+}[] = [
+  {
+    value: "allow",
+    label: "Allow",
+    description: "Direct user mentions like <@U123> are passed through to Slack.",
+  },
+  {
+    value: "escape",
+    label: "Escape",
+    description: "Mentions are rendered as plain text — Slack will not notify the user.",
+  },
+  {
+    value: "strip",
+    label: "Strip",
+    description: "Mentions are removed entirely from the message body.",
+  },
+];
+
+const DEFAULT_MENTIONS_POLICY: SlackMentionsPolicy = "allow";
+
+interface GlobalResponse {
+  settings: SlackGlobalConfig | null;
+}
+
+interface RepoSettingsEntry {
+  repo: string;
+  settings: SlackRepoSettings;
+}
+
+interface RepoListResponse {
+  repos: RepoSettingsEntry[];
+}
+
+interface ReposResponse {
+  repos: EnrichedRepository[];
+}
+
+export function SlackIntegrationSettings() {
+  const { data: globalData, isLoading: globalLoading } =
+    useSWR<GlobalResponse>(GLOBAL_SETTINGS_KEY);
+  const { data: repoSettingsData, isLoading: repoSettingsLoading } =
+    useSWR<RepoListResponse>(REPO_SETTINGS_KEY);
+  const { data: reposData } = useSWR<ReposResponse>("/api/repos");
+
+  if (globalLoading || repoSettingsLoading) {
+    return <IntegrationSettingsSkeleton />;
+  }
+
+  const settings = globalData?.settings;
+  const repoOverrides = repoSettingsData?.repos ?? [];
+  const availableRepos = reposData?.repos ?? [];
+
+  return (
+    <div>
+      <h3 className="text-lg font-semibold text-foreground mb-1">Slack</h3>
+      <p className="text-sm text-muted-foreground mb-6">
+        Let agents post Slack notifications when the user explicitly asks for them. Posts go through
+        the control plane — the Slack token never enters the sandbox.
+      </p>
+
+      <Section
+        title="Channel access"
+        description="Open-Inspect does not maintain its own channel allowlist."
+      >
+        <p className="text-sm text-muted-foreground">
+          To make a channel available to agents, invite the Open-Inspect Slack bot to a channel in
+          Slack. The bot can post only to channels it&apos;s a member of; remove access by kicking
+          the bot from the channel.
+        </p>
+      </Section>
+
+      <GlobalSettingsSection settings={settings} />
+
+      <Section
+        title="Repository overrides"
+        description="Override the master switch for specific repositories. Mentions policy is workspace-wide and is not overridable per repo."
+      >
+        <RepoOverridesSection overrides={repoOverrides} availableRepos={availableRepos} />
+      </Section>
+    </div>
+  );
+}
+
+function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | null | undefined }) {
+  const [agentNotificationsEnabled, setAgentNotificationsEnabled] = useState(
+    settings?.defaults?.agentNotificationsEnabled ?? false
+  );
+  const [mentionsPolicy, setMentionsPolicy] = useState<SlackMentionsPolicy>(
+    settings?.defaults?.mentionsPolicy ?? DEFAULT_MENTIONS_POLICY
+  );
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+  const [initialized, setInitialized] = useState(false);
+  const [showResetDialog, setShowResetDialog] = useState(false);
+
+  useEffect(() => {
+    if (settings !== undefined && !initialized) {
+      if (settings) {
+        setAgentNotificationsEnabled(settings.defaults?.agentNotificationsEnabled ?? false);
+        setMentionsPolicy(settings.defaults?.mentionsPolicy ?? DEFAULT_MENTIONS_POLICY);
+      }
+      setInitialized(true);
+    }
+  }, [settings, initialized]);
+
+  const isConfigured = settings !== null && settings !== undefined;
+
+  const handleConfirmReset = async () => {
+    setSaving(true);
+    try {
+      const res = await fetch(GLOBAL_SETTINGS_KEY, { method: "DELETE" });
+      if (res.ok) {
+        mutate(GLOBAL_SETTINGS_KEY);
+        setAgentNotificationsEnabled(false);
+        setMentionsPolicy(DEFAULT_MENTIONS_POLICY);
+        setDirty(false);
+        toast.success("Settings reset to defaults.");
+      } else {
+        const data = await res.json();
+        toast.error(data.error || "Failed to reset settings");
+      }
+    } catch {
+      toast.error("Failed to reset settings");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    const defaults: SlackGlobalSettings = {
+      agentNotificationsEnabled,
+      mentionsPolicy,
+    };
+    const body: SlackGlobalConfig = { defaults };
+
+    try {
+      const res = await fetch(GLOBAL_SETTINGS_KEY, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ settings: body }),
+      });
+      if (res.ok) {
+        mutate(GLOBAL_SETTINGS_KEY);
+        toast.success("Settings saved.");
+        setDirty(false);
+      } else {
+        const data = await res.json();
+        toast.error(data.error || "Failed to save settings");
+      }
+    } catch {
+      toast.error("Failed to save settings");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Section
+      title="Defaults"
+      description="Workspace-wide settings for agent-initiated Slack posts."
+    >
+      <label
+        htmlFor="slack-master-switch"
+        className="flex items-center justify-between px-4 py-3 border border-border hover:bg-muted/50 transition cursor-pointer mb-4 rounded-sm"
+      >
+        <div>
+          <span className="text-sm font-medium text-foreground">Enable agent notifications</span>
+          <span className="text-sm text-muted-foreground ml-2">
+            Master switch for the slack-notify tool. Off by default.
+          </span>
+        </div>
+        <Switch
+          id="slack-master-switch"
+          checked={agentNotificationsEnabled}
+          onCheckedChange={(checked) => {
+            setAgentNotificationsEnabled(checked);
+            setDirty(true);
+          }}
+        />
+      </label>
+
+      <div className="mb-4">
+        <p className="text-sm font-medium text-foreground mb-2">Mentions policy</p>
+        <p className="text-xs text-muted-foreground mb-2">
+          How direct user mentions (<code>{"<@U…>"}</code>) are handled in agent messages. Broadcast
+          mentions (<code>@channel</code>, <code>@here</code>, <code>@subteam</code>) are always
+          stripped regardless of this setting.
+        </p>
+        <div className="grid sm:grid-cols-3 gap-2">
+          {MENTIONS_POLICY_OPTIONS.map((opt) => (
+            <RadioCard
+              key={opt.value}
+              name="slack-mentions-policy"
+              checked={mentionsPolicy === opt.value}
+              onChange={() => {
+                setMentionsPolicy(opt.value);
+                setDirty(true);
+              }}
+              label={opt.label}
+              description={opt.description}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button onClick={handleSave} disabled={saving || !dirty}>
+          {saving ? "Saving..." : "Save"}
+        </Button>
+
+        {isConfigured && (
+          <Button variant="destructive" onClick={() => setShowResetDialog(true)} disabled={saving}>
+            Reset to defaults
+          </Button>
+        )}
+      </div>
+
+      <AlertDialog open={showResetDialog} onOpenChange={setShowResetDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Reset to defaults</AlertDialogTitle>
+            <AlertDialogDescription>
+              Reset Slack defaults? The master switch will turn off and mentions policy will return
+              to <strong>allow</strong>. Per-repository overrides are not affected.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmReset}>Reset</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Section>
+  );
+}
+
+function RepoOverridesSection({
+  overrides,
+  availableRepos,
+}: {
+  overrides: RepoSettingsEntry[];
+  availableRepos: EnrichedRepository[];
+}) {
+  const [addingRepo, setAddingRepo] = useState("");
+
+  const overriddenRepos = new Set(overrides.map((o) => o.repo));
+  const availableForOverride = availableRepos.filter(
+    (r) => !overriddenRepos.has(r.fullName.toLowerCase())
+  );
+
+  const handleAdd = async () => {
+    if (!addingRepo) return;
+    const [owner, name] = addingRepo.split("/");
+
+    try {
+      const res = await fetch(`/api/integration-settings/slack/repos/${owner}/${name}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ settings: {} }),
+      });
+      if (res.ok) {
+        mutate(REPO_SETTINGS_KEY);
+        setAddingRepo("");
+        toast.success("Override added.");
+      } else {
+        const data = await res.json();
+        toast.error(data.error || "Failed to add override");
+      }
+    } catch {
+      toast.error("Failed to add override");
+    }
+  };
+
+  return (
+    <div>
+      {overrides.length > 0 ? (
+        <div className="space-y-2 mb-4">
+          {overrides.map((entry) => (
+            <RepoOverrideRow key={entry.repo} entry={entry} />
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground mb-4">
+          No repository overrides yet. Add one to override the master switch for a specific repo.
+        </p>
+      )}
+
+      <div className="flex items-center gap-2">
+        <Select value={addingRepo} onValueChange={setAddingRepo}>
+          <SelectTrigger className="flex-1" aria-label="Select a repository">
+            <SelectValue placeholder="Select a repository..." />
+          </SelectTrigger>
+          <SelectContent>
+            {availableForOverride.map((repo) => (
+              <SelectItem key={repo.fullName} value={repo.fullName.toLowerCase()}>
+                {repo.fullName}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button onClick={handleAdd} disabled={!addingRepo}>
+          Add Override
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+type OverrideMode = "inherit" | "on" | "off";
+
+function deriveOverrideMode(settings: SlackRepoSettings): OverrideMode {
+  if (settings.agentNotificationsEnabled === undefined) return "inherit";
+  return settings.agentNotificationsEnabled ? "on" : "off";
+}
+
+function RepoOverrideRow({ entry }: { entry: RepoSettingsEntry }) {
+  const [mode, setMode] = useState<OverrideMode>(deriveOverrideMode(entry.settings));
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+
+  const handleSave = async () => {
+    setSaving(true);
+    const [owner, name] = entry.repo.split("/");
+    const settings: SlackRepoSettings = {};
+    if (mode === "on") settings.agentNotificationsEnabled = true;
+    if (mode === "off") settings.agentNotificationsEnabled = false;
+
+    try {
+      const res = await fetch(`/api/integration-settings/slack/repos/${owner}/${name}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ settings }),
+      });
+      if (res.ok) {
+        mutate(REPO_SETTINGS_KEY);
+        setDirty(false);
+        toast.success(`Override for ${entry.repo} saved.`);
+      } else {
+        const data = await res.json();
+        toast.error(data.error || "Failed to save override");
+      }
+    } catch {
+      toast.error("Failed to save override");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    const [owner, name] = entry.repo.split("/");
+    try {
+      const res = await fetch(`/api/integration-settings/slack/repos/${owner}/${name}`, {
+        method: "DELETE",
+      });
+      if (res.ok) {
+        mutate(REPO_SETTINGS_KEY);
+        toast.success(`Override for ${entry.repo} removed.`);
+      } else {
+        const data = await res.json();
+        toast.error(data.error || "Failed to delete override");
+      }
+    } catch {
+      toast.error("Failed to delete override");
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-2 px-4 py-3 border border-border rounded-sm">
+      <div className="flex items-center gap-3 flex-1 min-w-0">
+        <span className="text-sm font-medium text-foreground truncate">{entry.repo}</span>
+        <Select
+          value={mode}
+          onValueChange={(v: OverrideMode) => {
+            setMode(v);
+            setDirty(true);
+          }}
+        >
+          <SelectTrigger density="compact" className="w-56">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="inherit">Inherit global setting</SelectItem>
+            <SelectItem value="on">Override: notifications on</SelectItem>
+            <SelectItem value="off">Override: notifications off</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button size="sm" onClick={handleSave} disabled={saving || !dirty}>
+          {saving ? "..." : "Save"}
+        </Button>
+        <Button variant="destructive" size="sm" onClick={handleDelete}>
+          Remove
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="border border-border-muted rounded-md p-5 mb-5">
+      <h4 className="text-sm font-semibold uppercase tracking-wider text-foreground mb-1">
+        {title}
+      </h4>
+      <p className="text-sm text-muted-foreground mb-4">{description}</p>
+      {children}
+    </section>
+  );
+}

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
@@ -131,18 +131,13 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
   );
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
-  const [initialized, setInitialized] = useState(false);
   const [showResetDialog, setShowResetDialog] = useState(false);
 
   useEffect(() => {
-    if (settings !== undefined && !initialized) {
-      if (settings) {
-        setAgentNotificationsEnabled(settings.defaults?.agentNotificationsEnabled ?? false);
-        setMentionsPolicy(settings.defaults?.mentionsPolicy ?? DEFAULT_MENTIONS_POLICY);
-      }
-      setInitialized(true);
-    }
-  }, [settings, initialized]);
+    if (settings === undefined || dirty || saving) return;
+    setAgentNotificationsEnabled(settings?.defaults?.agentNotificationsEnabled ?? false);
+    setMentionsPolicy(settings?.defaults?.mentionsPolicy ?? DEFAULT_MENTIONS_POLICY);
+  }, [settings, dirty, saving]);
 
   const isConfigured = settings !== null && settings !== undefined;
 
@@ -285,7 +280,7 @@ function RepoOverridesSection({
 }) {
   const [addingRepo, setAddingRepo] = useState("");
 
-  const overriddenRepos = new Set(overrides.map((o) => o.repo));
+  const overriddenRepos = new Set(overrides.map((o) => o.repo.toLowerCase()));
   const availableForOverride = availableRepos.filter(
     (r) => !overriddenRepos.has(r.fullName.toLowerCase())
   );
@@ -359,6 +354,11 @@ function RepoOverrideRow({ entry }: { entry: RepoSettingsEntry }) {
   const [mode, setMode] = useState<OverrideMode>(deriveOverrideMode(entry.settings));
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
+
+  useEffect(() => {
+    if (dirty || saving) return;
+    setMode(deriveOverrideMode(entry.settings));
+  }, [entry.settings, dirty, saving]);
 
   const handleSave = async () => {
     setSaving(true);


### PR DESCRIPTION
## Summary

PR 3 of the agent-slack-notification feature ([implementation plan](docs/agent-slack-notification-tool-implementation-plan.md)). Operator-facing surface for the Slack integration shipped in #607.

Three controls, mirroring the pattern of `github-integration-settings.tsx`:
- **Master switch** (global): `agentNotificationsEnabled`, off by default.
- **Mentions policy** (global, radio: allow / escape / strip). Workspace-wide; not overridable per repo (per spec §9.1).
- **Per-repo override** (`inherit` / `on` / `off`): forces the master switch for a specific repo.

Help copy explains that channel access is delegated to Slack bot membership rather than an Open-Inspect-side allowlist (per the v3 plan's allowlist-removal decision). The existing `[id]` API proxy already passes `slack` through to the control plane, so no new web-side API routes are needed.

## What this does NOT do

- No control-plane endpoint or sandbox tool yet — those land in PRs 4 and 5. Until then, the UI writes settings the control plane will read once PR 4 wires the feature flag.
- No event-list rendering for `slack-notify` tool calls — that's PR 6.

## Test plan

- [x] `npm test -w @open-inspect/web` — 217/217 (9 new component tests for `<SlackIntegrationSettings />`)
- [x] `npm run typecheck -w @open-inspect/web`
- [x] `npm run lint -w @open-inspect/web`
- [ ] Manual browser smoke: navigate to Settings → Integrations → Slack, configure settings, save, reload, confirm settings persisted (will verify after this and #607 are deployed together)

## Rollback

Revert. Operators can still hit the API directly with curl if needed; PR 4 still works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Slack integration settings UI with workspace defaults and per-repository overrides; configure agent notifications and mentions policy; add/remove repo overrides and reset to defaults with confirmation.
* **Improvements**
  * Loading skeleton, help text, and clearer save/reset feedback; repository picker dedupes mixed-case entries.
* **Tests**
  * Expanded test coverage for loading, save/reset flows, per-repo overrides, and server-sync/resync behaviors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/608)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->