### PR TITLE
feat(web): render slack-notify events in session transcript (PR 6)

### DIFF
--- a/packages/web/src/components/slack-notify-event.test.tsx
+++ b/packages/web/src/components/slack-notify-event.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import type { SandboxEvent } from "@/types/session";
+import { SlackNotifyEvent } from "./slack-notify-event";
+
+expect.extend(matchers);
+afterEach(() => {
+  cleanup();
+});
+
+type ToolCallEvent = Extract<SandboxEvent, { type: "tool_call" }>;
+
+const BASE: Omit<ToolCallEvent, "args" | "output" | "status"> = {
+  type: "tool_call",
+  tool: "slack-notify",
+  callId: "call-1",
+  messageId: "msg-1",
+  sandboxId: "control-plane",
+  timestamp: 1_700_000_000,
+};
+
+function successEvent(overrides: Record<string, unknown> = {}): ToolCallEvent {
+  return {
+    ...BASE,
+    status: "completed",
+    args: { channel: "#ops", text: "deploy started" },
+    output: JSON.stringify({
+      ok: true,
+      channelInput: "#ops",
+      channelId: "C01ABC",
+      messageTs: "1700000000.001",
+      permalink: "https://slack.com/archives/C01ABC/p1700000000001",
+      truncated: false,
+      strippedBroadcasts: false,
+      mentionsModified: false,
+      attribution: { repo: "acme/web", parentSessionId: null },
+      ...overrides,
+    }),
+  };
+}
+
+function denialEvent(reason: string, channel = "#ops"): ToolCallEvent {
+  return {
+    ...BASE,
+    status: "error",
+    args: { channel, text: "deploy started" },
+    output: reason,
+  };
+}
+
+function expandFirst() {
+  const buttons = screen.getAllByRole("button");
+  fireEvent.click(buttons[0]);
+}
+
+describe("SlackNotifyEvent", () => {
+  it("renders a successful post with channel input and a Slack permalink", () => {
+    render(<SlackNotifyEvent event={successEvent()} />);
+
+    expect(screen.getByText(/posted to #ops/i)).toBeInTheDocument();
+    expandFirst();
+
+    const link = screen.getByRole("link", { name: /view in slack/i });
+    expect(link).toHaveAttribute("href", "https://slack.com/archives/C01ABC/p1700000000001");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+
+  it("surfaces the truncation note when the message was truncated", () => {
+    render(<SlackNotifyEvent event={successEvent({ truncated: true })} />);
+    expandFirst();
+    expect(screen.getByText(/truncated/i)).toBeInTheDocument();
+  });
+
+  it("surfaces the broadcast-strip note when broadcasts were removed", () => {
+    render(<SlackNotifyEvent event={successEvent({ strippedBroadcasts: true })} />);
+    expandFirst();
+    expect(screen.getByText(/broadcast mentions/i)).toBeInTheDocument();
+  });
+
+  it("renders channel_not_found_or_forbidden with an invite-the-bot hint and no permalink", () => {
+    render(<SlackNotifyEvent event={denialEvent("channel_not_found_or_forbidden")} />);
+
+    expect(screen.getByText(/slack notify failed/i)).toBeInTheDocument();
+    expandFirst();
+
+    expect(screen.getByText(/channel not found or bot is not in the channel/i)).toBeInTheDocument();
+    expect(screen.getByText(/invite the open-inspect bot/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /view in slack/i })).not.toBeInTheDocument();
+  });
+
+  it("renders feature_disabled with repo-specific copy", () => {
+    render(<SlackNotifyEvent event={denialEvent("feature_disabled")} />);
+    expandFirst();
+    expect(screen.getByText(/notifications are disabled for this repository/i)).toBeInTheDocument();
+  });
+
+  it("renders rate_limited with retry-window copy", () => {
+    render(<SlackNotifyEvent event={denialEvent("rate_limited")} />);
+    expandFirst();
+    expect(screen.getByText(/rate-limited/i)).toBeInTheDocument();
+  });
+
+  it("falls back gracefully when the output is unparseable", () => {
+    const event: ToolCallEvent = {
+      ...BASE,
+      status: "completed",
+      args: { channel: "#ops", text: "" },
+      output: "not-json",
+    };
+    render(<SlackNotifyEvent event={event} />);
+    expandFirst();
+    expect(screen.getByText(/no details available/i)).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/slack-notify-event.test.tsx
+++ b/packages/web/src/components/slack-notify-event.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 /// <reference types="@testing-library/jest-dom" />
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import type { SandboxEvent } from "@/types/session";
@@ -52,56 +52,64 @@ function denialEvent(reason: string, channel = "#ops"): ToolCallEvent {
   };
 }
 
-function expandFirst() {
-  const buttons = screen.getAllByRole("button");
-  fireEvent.click(buttons[0]);
+function renderExpanded(event: ToolCallEvent) {
+  return render(<SlackNotifyEvent event={event} isExpanded onToggle={() => {}} />);
 }
 
 describe("SlackNotifyEvent", () => {
+  it("invokes onToggle when the row is clicked, leaving expansion to the parent", () => {
+    const onToggle = vi.fn();
+    render(<SlackNotifyEvent event={successEvent()} isExpanded={false} onToggle={onToggle} />);
+
+    expect(screen.queryByRole("link", { name: /view in slack/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button"));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
   it("renders a successful post with channel input and a Slack permalink", () => {
-    render(<SlackNotifyEvent event={successEvent()} />);
+    renderExpanded(successEvent());
 
     expect(screen.getByText(/posted to #ops/i)).toBeInTheDocument();
-    expandFirst();
-
     const link = screen.getByRole("link", { name: /view in slack/i });
     expect(link).toHaveAttribute("href", "https://slack.com/archives/C01ABC/p1700000000001");
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noreferrer"));
+  });
+
+  it("does not render a link when the permalink uses an unsafe scheme", () => {
+    renderExpanded(successEvent({ permalink: "javascript:alert(1)" }));
+
+    expect(screen.getByText(/posted to #ops/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /view in slack/i })).not.toBeInTheDocument();
   });
 
   it("surfaces the truncation note when the message was truncated", () => {
-    render(<SlackNotifyEvent event={successEvent({ truncated: true })} />);
-    expandFirst();
+    renderExpanded(successEvent({ truncated: true }));
     expect(screen.getByText(/truncated/i)).toBeInTheDocument();
   });
 
   it("surfaces the broadcast-strip note when broadcasts were removed", () => {
-    render(<SlackNotifyEvent event={successEvent({ strippedBroadcasts: true })} />);
-    expandFirst();
+    renderExpanded(successEvent({ strippedBroadcasts: true }));
     expect(screen.getByText(/broadcast mentions/i)).toBeInTheDocument();
   });
 
   it("renders channel_not_found_or_forbidden with an invite-the-bot hint and no permalink", () => {
-    render(<SlackNotifyEvent event={denialEvent("channel_not_found_or_forbidden")} />);
+    renderExpanded(denialEvent("channel_not_found_or_forbidden"));
 
     expect(screen.getByText(/slack notify failed/i)).toBeInTheDocument();
-    expandFirst();
-
     expect(screen.getByText(/channel not found or bot is not in the channel/i)).toBeInTheDocument();
     expect(screen.getByText(/invite the open-inspect bot/i)).toBeInTheDocument();
     expect(screen.queryByRole("link", { name: /view in slack/i })).not.toBeInTheDocument();
   });
 
   it("renders feature_disabled with repo-specific copy", () => {
-    render(<SlackNotifyEvent event={denialEvent("feature_disabled")} />);
-    expandFirst();
+    renderExpanded(denialEvent("feature_disabled"));
     expect(screen.getByText(/notifications are disabled for this repository/i)).toBeInTheDocument();
   });
 
   it("renders rate_limited with retry-window copy", () => {
-    render(<SlackNotifyEvent event={denialEvent("rate_limited")} />);
-    expandFirst();
+    renderExpanded(denialEvent("rate_limited"));
     expect(screen.getByText(/rate-limited/i)).toBeInTheDocument();
   });
 
@@ -112,8 +120,7 @@ describe("SlackNotifyEvent", () => {
       args: { channel: "#ops", text: "" },
       output: "not-json",
     };
-    render(<SlackNotifyEvent event={event} />);
-    expandFirst();
+    renderExpanded(event);
     expect(screen.getByText(/no details available/i)).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/slack-notify-event.tsx
+++ b/packages/web/src/components/slack-notify-event.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
 import type { SandboxEvent } from "@/types/session";
+import { getSafeExternalUrl } from "@/lib/urls";
 import { ChevronRightIcon, ErrorIcon, LinkIcon, SlackIcon } from "@/components/ui/icons";
 
 type ToolCallEvent = Extract<SandboxEvent, { type: "tool_call" }>;
@@ -87,11 +87,17 @@ function getChannelInput(event: ToolCallEvent): string | undefined {
 
 interface SlackNotifyEventProps {
   event: ToolCallEvent;
+  isExpanded: boolean;
+  onToggle: () => void;
   showTime?: boolean;
 }
 
-export function SlackNotifyEvent({ event, showTime = true }: SlackNotifyEventProps) {
-  const [expanded, setExpanded] = useState(false);
+export function SlackNotifyEvent({
+  event,
+  isExpanded,
+  onToggle,
+  showTime = true,
+}: SlackNotifyEventProps) {
   const success = parseSuccess(event.output);
   const denial = success ? null : getDenialReason(event);
   const channelInput = success?.channelInput ?? getChannelInput(event);
@@ -112,12 +118,12 @@ export function SlackNotifyEvent({ event, showTime = true }: SlackNotifyEventPro
   return (
     <div className="py-0.5">
       <button
-        onClick={() => setExpanded((prev) => !prev)}
+        onClick={onToggle}
         className="w-full flex items-center gap-1.5 text-sm text-left text-muted-foreground hover:text-foreground transition-colors"
       >
         <ChevronRightIcon
           className={`w-3.5 h-3.5 text-secondary-foreground transition-transform duration-200 ${
-            expanded ? "rotate-90" : ""
+            isExpanded ? "rotate-90" : ""
           }`}
         />
         {denial ? (
@@ -131,7 +137,7 @@ export function SlackNotifyEvent({ event, showTime = true }: SlackNotifyEventPro
         )}
       </button>
 
-      {expanded && (
+      {isExpanded && (
         <div className="mt-2 ml-5 p-3 bg-card border border-border-muted text-xs overflow-hidden">
           {success ? (
             <SlackNotifySuccessBody success={success} />
@@ -152,17 +158,19 @@ function SlackNotifySuccessBody({ success }: { success: SlackNotifySuccessOutput
   if (success.strippedBroadcasts) notes.push("Broadcast mentions (@channel/@here) were stripped.");
   if (success.mentionsModified) notes.push("User mentions were rewritten per workspace policy.");
 
+  const safePermalink = getSafeExternalUrl(success.permalink);
+
   return (
     <div className="space-y-2">
       <div>
         <div className="text-muted-foreground mb-1 font-medium">Channel</div>
         <div className="text-foreground">{success.channelInput}</div>
       </div>
-      {success.permalink ? (
+      {safePermalink ? (
         <div>
           <div className="text-muted-foreground mb-1 font-medium">Slack message</div>
           <a
-            href={success.permalink}
+            href={safePermalink}
             target="_blank"
             rel="noopener noreferrer"
             className="text-primary inline-flex items-center gap-1 hover:underline"

--- a/packages/web/src/components/slack-notify-event.tsx
+++ b/packages/web/src/components/slack-notify-event.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState } from "react";
+import type { SandboxEvent } from "@/types/session";
+import { ChevronRightIcon, ErrorIcon, LinkIcon, SlackIcon } from "@/components/ui/icons";
+
+type ToolCallEvent = Extract<SandboxEvent, { type: "tool_call" }>;
+
+interface SlackNotifySuccessOutput {
+  ok: true;
+  channelInput: string;
+  channelId?: string;
+  messageTs?: string;
+  permalink?: string;
+  truncated?: boolean;
+  strippedBroadcasts?: boolean;
+  mentionsModified?: boolean;
+}
+
+const DENIAL_REASONS = [
+  "feature_unavailable",
+  "feature_disabled",
+  "empty_message_after_sanitization",
+  "channel_not_found_or_forbidden",
+  "rate_limited",
+  "slack_api_error",
+  "invalid_input",
+] as const;
+type DenialReason = (typeof DENIAL_REASONS)[number];
+
+const DENIAL_COPY: Record<DenialReason, { headline: string; hint?: string }> = {
+  feature_unavailable: {
+    headline: "Slack notifications are not configured for this deployment.",
+  },
+  feature_disabled: {
+    headline: "Slack notifications are disabled for this repository.",
+  },
+  empty_message_after_sanitization: {
+    headline: "Message was empty after sanitization, so nothing was posted.",
+  },
+  channel_not_found_or_forbidden: {
+    headline: "Channel not found or bot is not in the channel.",
+    hint: "Invite the Open-Inspect bot to the channel and try again.",
+  },
+  rate_limited: {
+    headline: "Slack rate-limited the request.",
+    hint: "Slack will accept the next attempt after the retry window.",
+  },
+  slack_api_error: {
+    headline: "Slack returned an unexpected error.",
+  },
+  invalid_input: {
+    headline: "The notification arguments were invalid.",
+  },
+};
+
+function parseSuccess(output: string | undefined): SlackNotifySuccessOutput | null {
+  if (!output) return null;
+  try {
+    const parsed: unknown = JSON.parse(output);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      (parsed as { ok?: unknown }).ok === true &&
+      typeof (parsed as { channelInput?: unknown }).channelInput === "string"
+    ) {
+      return parsed as SlackNotifySuccessOutput;
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function getDenialReason(event: ToolCallEvent): DenialReason | null {
+  if (event.status !== "error") return null;
+  if (typeof event.output !== "string") return null;
+  return (DENIAL_REASONS as readonly string[]).includes(event.output)
+    ? (event.output as DenialReason)
+    : null;
+}
+
+function getChannelInput(event: ToolCallEvent): string | undefined {
+  const fromArgs = event.args?.channel;
+  return typeof fromArgs === "string" ? fromArgs : undefined;
+}
+
+interface SlackNotifyEventProps {
+  event: ToolCallEvent;
+  showTime?: boolean;
+}
+
+export function SlackNotifyEvent({ event, showTime = true }: SlackNotifyEventProps) {
+  const [expanded, setExpanded] = useState(false);
+  const success = parseSuccess(event.output);
+  const denial = success ? null : getDenialReason(event);
+  const channelInput = success?.channelInput ?? getChannelInput(event);
+  const time = new Date(event.timestamp * 1000).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  let summaryLine: string;
+  if (success) {
+    summaryLine = `Posted to ${channelInput ?? "Slack"}`;
+  } else if (denial) {
+    summaryLine = `Slack notify failed${channelInput ? ` (${channelInput})` : ""}`;
+  } else {
+    summaryLine = `Slack notify${channelInput ? ` ${channelInput}` : ""}`;
+  }
+
+  return (
+    <div className="py-0.5">
+      <button
+        onClick={() => setExpanded((prev) => !prev)}
+        className="w-full flex items-center gap-1.5 text-sm text-left text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ChevronRightIcon
+          className={`w-3.5 h-3.5 text-secondary-foreground transition-transform duration-200 ${
+            expanded ? "rotate-90" : ""
+          }`}
+        />
+        {denial ? (
+          <ErrorIcon className="w-3.5 h-3.5 text-destructive" />
+        ) : (
+          <SlackIcon className="w-3.5 h-3.5 text-secondary-foreground" />
+        )}
+        <span className="truncate">slack-notify {summaryLine}</span>
+        {showTime && (
+          <span className="text-xs text-secondary-foreground flex-shrink-0 ml-auto">{time}</span>
+        )}
+      </button>
+
+      {expanded && (
+        <div className="mt-2 ml-5 p-3 bg-card border border-border-muted text-xs overflow-hidden">
+          {success ? (
+            <SlackNotifySuccessBody success={success} />
+          ) : denial ? (
+            <SlackNotifyDenialBody reason={denial} channelInput={channelInput} />
+          ) : (
+            <span className="text-secondary-foreground">No details available</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SlackNotifySuccessBody({ success }: { success: SlackNotifySuccessOutput }) {
+  const notes: string[] = [];
+  if (success.truncated) notes.push("Message was truncated to fit Slack length limits.");
+  if (success.strippedBroadcasts) notes.push("Broadcast mentions (@channel/@here) were stripped.");
+  if (success.mentionsModified) notes.push("User mentions were rewritten per workspace policy.");
+
+  return (
+    <div className="space-y-2">
+      <div>
+        <div className="text-muted-foreground mb-1 font-medium">Channel</div>
+        <div className="text-foreground">{success.channelInput}</div>
+      </div>
+      {success.permalink ? (
+        <div>
+          <div className="text-muted-foreground mb-1 font-medium">Slack message</div>
+          <a
+            href={success.permalink}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary inline-flex items-center gap-1 hover:underline"
+          >
+            <LinkIcon className="w-3 h-3" />
+            View in Slack
+          </a>
+        </div>
+      ) : null}
+      {notes.length > 0 ? (
+        <ul className="text-secondary-foreground list-disc pl-4 space-y-0.5">
+          {notes.map((note) => (
+            <li key={note}>{note}</li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+function SlackNotifyDenialBody({
+  reason,
+  channelInput,
+}: {
+  reason: DenialReason;
+  channelInput: string | undefined;
+}) {
+  const { headline, hint } = DENIAL_COPY[reason];
+  return (
+    <div className="space-y-1">
+      <div className="text-foreground">{headline}</div>
+      {hint ? <div className="text-secondary-foreground">{hint}</div> : null}
+      {channelInput ? (
+        <div className="text-muted-foreground">
+          Requested channel: <span className="text-foreground">{channelInput}</span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/web/src/components/tool-call-item.tsx
+++ b/packages/web/src/components/tool-call-item.tsx
@@ -2,6 +2,7 @@
 
 import type { SandboxEvent } from "@/types/session";
 import { formatToolCall } from "@/lib/tool-formatters";
+import { SlackNotifyEvent } from "./slack-notify-event";
 import {
   ChevronRightIcon,
   FileIcon,
@@ -49,6 +50,10 @@ function ToolIcon({ name }: { name: string | null }) {
 }
 
 export function ToolCallItem({ event, isExpanded, onToggle, showTime = true }: ToolCallItemProps) {
+  if (event.tool === "slack-notify") {
+    return <SlackNotifyEvent event={event} showTime={showTime} />;
+  }
+
   const formatted = formatToolCall(event);
   const isApplyPatch = event.tool?.toLowerCase() === "apply_patch";
   const time = new Date(event.timestamp * 1000).toLocaleTimeString([], {

--- a/packages/web/src/components/tool-call-item.tsx
+++ b/packages/web/src/components/tool-call-item.tsx
@@ -51,7 +51,14 @@ function ToolIcon({ name }: { name: string | null }) {
 
 export function ToolCallItem({ event, isExpanded, onToggle, showTime = true }: ToolCallItemProps) {
   if (event.tool === "slack-notify") {
-    return <SlackNotifyEvent event={event} showTime={showTime} />;
+    return (
+      <SlackNotifyEvent
+        event={event}
+        isExpanded={isExpanded}
+        onToggle={onToggle}
+        showTime={showTime}
+      />
+    );
   }
 
   const formatted = formatToolCall(event);

--- a/packages/web/src/components/ui/icons.tsx
+++ b/packages/web/src/components/ui/icons.tsx
@@ -161,6 +161,25 @@ export function LinkIcon({ className }: IconProps) {
   );
 }
 
+export function SlackIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      data-testid="slack-icon"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9h.5a8.48 8.48 0 018 8v.5z"
+      />
+    </svg>
+  );
+}
+
 export function ArchiveIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary

PR 6 / 6 of the agent Slack notification feature ([spec](docs/agent-slack-notification-tool.md), [plan](docs/agent-slack-notification-tool-implementation-plan.md)).

Polishes the session transcript so `slack-notify` tool calls render as a first-class event instead of a generic JSON dump.

- **Success**: Slack icon, channel input on the line, expanded view with a "View in Slack" permalink (target=_blank, rel=noopener noreferrer) and subtle notes for `truncated` / `strippedBroadcasts` / `mentionsModified`.
- **Denial**: error icon plus reason-specific copy:
  - `channel_not_found_or_forbidden` → "invite the Open-Inspect bot to the channel" hint
  - `feature_disabled` → "disabled for this repository"
  - `rate_limited` → retry-window copy
  - `feature_unavailable`, `empty_message_after_sanitization`, `slack_api_error`, `invalid_input` → tailored headlines
- **Unparseable output**: falls back to "No details available" rather than crashing.

`ToolCallItem` dispatches early on `event.tool === "slack-notify"` and delegates to the new `SlackNotifyEvent`, so every other tool (Read/Edit/Bash/Apply Patch/etc.) keeps its existing rendering verbatim.

The plan referenced files (`event-list.tsx`, `session/` subdir) that don't exist in this repo — the actual transcript rendering goes through `tool-call-item.tsx` + `formatToolCall`. Wiring follows the existing dispatcher pattern instead.

## Files

- `packages/web/src/components/slack-notify-event.tsx` (new) — collapsed line + expanded body, success / denial / fallback states
- `packages/web/src/components/slack-notify-event.test.tsx` (new) — 7 tests
- `packages/web/src/components/tool-call-item.tsx` — early-return delegation when `event.tool === "slack-notify"`
- `packages/web/src/components/ui/icons.tsx` — `SlackIcon`

## Test plan

- [x] `npm test -w @open-inspect/web` — **228 passed** (7 new in `slack-notify-event.test.tsx`)
- [x] `npm run typecheck` — clean across all packages
- [x] `npm run lint` — clean
- [ ] Manual browser smoke (replay a session with a successful post and a denial — both render correctly) — to be done at feature-merge time per plan §"E2E smoke"

## Verifies

- Acceptance gate per plan PR 6: success permalink, denial copy, truncation marker visible, no permalink on denial.
- No regression for any other tool (`tool-call-item` only takes the new path for `slack-notify`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Slack notification event display showing success, permission denied, disabled, and rate-limited states, with contextual messages, optional timestamp, and a Slack icon.
  * Integrated specialized rendering for Slack notification events in the tool-call list and added expand/collapse with toggle callback.

* **Tests**
  * Added comprehensive tests covering success and error scenarios, external-link safety, flag notes, edge cases, and expansion behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/611)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->