### PR TITLE
fix(control-plane): correct View Session URL in Slack notification

### DIFF
--- a/packages/control-plane/src/routes/slack-notify.ts
+++ b/packages/control-plane/src/routes/slack-notify.ts
@@ -285,7 +285,7 @@ function buildBlocks(opts: {
         {
           type: "button",
           text: { type: "plain_text", text: "View Session" },
-          url: `${opts.webAppUrl.replace(/\/$/, "")}/sessions/${opts.sessionId}`,
+          url: `${opts.webAppUrl.replace(/\/$/, "")}/session/${opts.sessionId}`,
         },
       ],
     });


### PR DESCRIPTION
## Summary
- The `View Session` button in the agent slack-notify message was linking to `/sessions/<id>` (plural), but the web app route is `/session/<id>` (singular), so the link 404'd.
- One-character fix in `packages/control-plane/src/routes/slack-notify.ts`.

## Test plan
- [ ] Trigger a slack-notify from a sandbox agent and confirm the `View Session` button opens the correct session page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "View Session" link in Slack notifications to direct to the correct URL path.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/612)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->