### PR TITLE
refactor(shared): consolidate slack-notify contract types

### DIFF
--- a/packages/control-plane/src/db/integration-settings.test.ts
+++ b/packages/control-plane/src/db/integration-settings.test.ts
@@ -3,6 +3,7 @@ import {
   IntegrationSettingsStore,
   IntegrationSettingsValidationError,
   isValidIntegrationId,
+  resolveSlackSettings,
 } from "./integration-settings";
 
 type GlobalRow = {
@@ -899,6 +900,36 @@ describe("IntegrationSettingsStore", () => {
       const config = await store.getResolvedConfig("slack", "acme/widgets");
       expect(config.settings.agentNotificationsEnabled).toBe(true);
       expect(config.settings.mentionsPolicy).toBe("allow");
+    });
+  });
+
+  describe("resolveSlackSettings", () => {
+    it("treats undefined as disabled with default mention policy", () => {
+      expect(resolveSlackSettings(undefined)).toEqual({
+        agentNotificationsEnabled: false,
+        mentionsPolicy: "allow",
+      });
+    });
+
+    it("treats empty object as disabled with default mention policy", () => {
+      expect(resolveSlackSettings({})).toEqual({
+        agentNotificationsEnabled: false,
+        mentionsPolicy: "allow",
+      });
+    });
+
+    it("returns enabled true only when the flag is exactly true", () => {
+      expect(
+        resolveSlackSettings({ agentNotificationsEnabled: true }).agentNotificationsEnabled
+      ).toBe(true);
+      expect(
+        resolveSlackSettings({ agentNotificationsEnabled: false }).agentNotificationsEnabled
+      ).toBe(false);
+    });
+
+    it("preserves a configured mention policy", () => {
+      expect(resolveSlackSettings({ mentionsPolicy: "strip" }).mentionsPolicy).toBe("strip");
+      expect(resolveSlackSettings({ mentionsPolicy: "escape" }).mentionsPolicy).toBe("escape");
     });
   });
 });

--- a/packages/control-plane/src/db/integration-settings.ts
+++ b/packages/control-plane/src/db/integration-settings.ts
@@ -2,6 +2,7 @@ import {
   isValidModel,
   isValidReasoningEffort,
   INTEGRATION_DEFINITIONS,
+  DEFAULT_MENTIONS_POLICY,
   type IntegrationId,
   type IntegrationSettingsMap,
   type GitHubBotSettings,
@@ -9,6 +10,7 @@ import {
   type CodeServerSettings,
   type SandboxSettings,
   type SlackGlobalSettings,
+  type SlackMentionsPolicy,
   MAX_TUNNEL_PORTS,
 } from "@open-inspect/shared";
 
@@ -372,4 +374,23 @@ export class IntegrationSettingsStore {
 export interface ResolvedIntegrationConfig<TRepo extends object = Record<string, unknown>> {
   enabledRepos: string[] | null;
   settings: TRepo;
+}
+
+/**
+ * Apply runtime defaults to raw Slack settings.
+ *
+ * Reads the partially-typed shape returned by `getResolvedConfig("slack", ...)`
+ * and produces the canonical view used by the route handler and the DO
+ * lifecycle factory: a definite boolean for the master gate, and a definite
+ * mention policy. Avoids re-applying `=== true` and `?? "allow"` at every
+ * call site.
+ */
+export function resolveSlackSettings(raw: Partial<SlackGlobalSettings> | undefined): {
+  agentNotificationsEnabled: boolean;
+  mentionsPolicy: SlackMentionsPolicy;
+} {
+  return {
+    agentNotificationsEnabled: raw?.agentNotificationsEnabled === true,
+    mentionsPolicy: raw?.mentionsPolicy ?? DEFAULT_MENTIONS_POLICY,
+  };
 }

--- a/packages/control-plane/src/routes/slack-notify.ts
+++ b/packages/control-plane/src/routes/slack-notify.ts
@@ -11,11 +11,13 @@ import {
   getPermalink,
   postMessage,
   sanitizeAgentText,
-  type MentionPolicy,
+  SLACK_DENIAL_STATUS,
+  type SlackDenialReason,
   type SlackGlobalSettings,
+  type SlackNotifySuccessOutput,
 } from "@open-inspect/shared";
 import { generateId } from "../auth/crypto";
-import { IntegrationSettingsStore } from "../db/integration-settings";
+import { IntegrationSettingsStore, resolveSlackSettings } from "../db/integration-settings";
 import { SessionIndexStore } from "../db/session-index";
 import { createLogger } from "../logger";
 import { buildSessionInternalUrl, SessionInternalPaths } from "../session/contracts";
@@ -32,27 +34,7 @@ const RAW_TEXT_INPUT_MAX_LENGTH = 12_000;
 const CHANNEL_INPUT_MAX_LENGTH = 80;
 /** Reason field cap; recorded for audit only. */
 const REASON_MAX_LENGTH = 500;
-const DEFAULT_MENTIONS_POLICY: MentionPolicy = "allow";
 const SYNTHETIC_SANDBOX_ID = "control-plane";
-
-type DenialReason =
-  | "feature_unavailable"
-  | "feature_disabled"
-  | "empty_message_after_sanitization"
-  | "channel_not_found_or_forbidden"
-  | "rate_limited"
-  | "slack_api_error"
-  | "invalid_input";
-
-const STATUS_FOR_REASON: Record<DenialReason, number> = {
-  feature_unavailable: 503,
-  feature_disabled: 403,
-  empty_message_after_sanitization: 422,
-  channel_not_found_or_forbidden: 404,
-  rate_limited: 429,
-  slack_api_error: 502,
-  invalid_input: 400,
-};
 
 interface ParsedBody {
   channel: string;
@@ -66,17 +48,6 @@ interface Attribution {
   triggerSource: string | null;
   parentSessionId: string | null;
   repo: string;
-}
-
-interface SuccessOutput {
-  ok: true;
-  channelInput: string;
-  channelId: string;
-  messageTs: string;
-  permalink: string;
-  truncated: boolean;
-  strippedBroadcasts: boolean;
-  mentionsModified: boolean;
 }
 
 export async function handleSlackNotify(
@@ -112,8 +83,10 @@ export async function handleSlackNotify(
 
   const settingsStore = new IntegrationSettingsStore(env.DB);
   const { settings } = await settingsStore.getResolvedConfig("slack", repo);
-  const slackSettings = settings as Partial<SlackGlobalSettings>;
-  if (slackSettings.agentNotificationsEnabled !== true) {
+  const { agentNotificationsEnabled, mentionsPolicy } = resolveSlackSettings(
+    settings as Partial<SlackGlobalSettings>
+  );
+  if (!agentNotificationsEnabled) {
     await emitDenial(env, sessionId, ctx, parsed, attribution, "feature_disabled");
     return failureResponse(
       "feature_disabled",
@@ -121,7 +94,6 @@ export async function handleSlackNotify(
     );
   }
 
-  const mentionsPolicy = (slackSettings.mentionsPolicy ?? DEFAULT_MENTIONS_POLICY) as MentionPolicy;
   const sanitized = sanitizeAgentText(parsed.text, {
     mentionsPolicy,
     maxLength: SLACK_TEXT_MAX_LENGTH,
@@ -161,7 +133,7 @@ export async function handleSlackNotify(
   }));
   const permalink = permalinkResp.ok && permalinkResp.permalink ? permalinkResp.permalink : "";
 
-  const result: SuccessOutput = {
+  const result: SlackNotifySuccessOutput = {
     ok: true,
     channelInput: parsed.channel,
     channelId,
@@ -294,7 +266,7 @@ function buildBlocks(opts: {
   return blocks;
 }
 
-function mapSlackError(slackError: string | undefined): DenialReason {
+function mapSlackError(slackError: string | undefined): SlackDenialReason {
   if (!slackError) return "slack_api_error";
   if (
     slackError === "channel_not_found" ||
@@ -308,14 +280,14 @@ function mapSlackError(slackError: string | undefined): DenialReason {
 }
 
 function failureResponse(
-  reason: DenialReason,
+  reason: SlackDenialReason,
   message: string | undefined,
   retryAfter?: number
 ): Response {
   const body: Record<string, unknown> = { error: reason };
   if (message) body.message = message;
   if (typeof retryAfter === "number") body.retryAfter = retryAfter;
-  return json(body, STATUS_FOR_REASON[reason]);
+  return json(body, SLACK_DENIAL_STATUS[reason]);
 }
 
 async function emitDenial(
@@ -324,7 +296,7 @@ async function emitDenial(
   ctx: RequestContext,
   parsed: ParsedBody,
   attribution: Attribution,
-  reason: DenialReason,
+  reason: SlackDenialReason,
   retryAfter?: number
 ): Promise<void> {
   await emitToolEvent(env, sessionId, ctx, {

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -34,7 +34,7 @@ import {
 } from "../sandbox/lifecycle/manager";
 import { RepoImageStore } from "../db/repo-images";
 import { McpServerStore } from "../db/mcp-servers";
-import { IntegrationSettingsStore } from "../db/integration-settings";
+import { IntegrationSettingsStore, resolveSlackSettings } from "../db/integration-settings";
 import { SessionIndexStore } from "../db/session-index";
 import { DEFAULT_EXECUTION_TIMEOUT_MS } from "../sandbox/lifecycle/decisions";
 import {
@@ -701,7 +701,6 @@ export class SessionDO extends DurableObject<Env> {
     const sessionId = session?.session_name || session?.id || this.ctx.id.toString();
 
     // Create D1-backed lookups if database is available
-    // Create D1-backed lookups if database is available
     let mcpServerLookup: McpServerLookup | undefined;
     if (this.env.DB) {
       const mcpStore = new McpServerStore(this.env.DB, this.env.REPO_SECRETS_ENCRYPTION_KEY);
@@ -724,7 +723,7 @@ export class SessionDO extends DurableObject<Env> {
             "slack",
             `${repoOwner}/${repoName}`
           );
-          return settings.agentNotificationsEnabled === true;
+          return resolveSlackSettings(settings).agentNotificationsEnabled;
         },
       };
     }

--- a/packages/shared/src/slack/index.ts
+++ b/packages/shared/src/slack/index.ts
@@ -19,3 +19,5 @@ export {
   truncateForSlack,
 } from "./mrkdwn";
 export type { MentionPolicy, SanitizeOptions, SanitizeResult } from "./mrkdwn";
+export { SLACK_DENIAL_REASONS, SLACK_DENIAL_STATUS, DEFAULT_MENTIONS_POLICY } from "./types";
+export type { SlackDenialReason, SlackNotifySuccessOutput, SlackNotifyFailureBody } from "./types";

--- a/packages/shared/src/slack/types.ts
+++ b/packages/shared/src/slack/types.ts
@@ -1,0 +1,61 @@
+/**
+ * Wire-contract types for the agent slack-notify endpoint and its renderers.
+ *
+ * Consumed by:
+ * - control-plane (routes/slack-notify.ts) — produces these envelopes
+ * - web (components/slack-notify-event.tsx) — parses tool_call output
+ * - web settings UI — uses DEFAULT_MENTIONS_POLICY for form defaults
+ *
+ * The sandbox-side JS tool (packages/sandbox-runtime/.../tools/slack-notify.js)
+ * cannot import from this package at runtime — it ships verbatim into the
+ * sandbox image. Its REASON_GUIDANCE keys must stay symmetric with
+ * SLACK_DENIAL_REASONS by hand.
+ */
+
+import type { SlackMentionsPolicy } from "../types/integrations";
+
+/** Reasons the control plane can return for a denied or failed slack-notify request. */
+export const SLACK_DENIAL_REASONS = [
+  "feature_unavailable",
+  "feature_disabled",
+  "empty_message_after_sanitization",
+  "channel_not_found_or_forbidden",
+  "rate_limited",
+  "slack_api_error",
+  "invalid_input",
+] as const;
+
+export type SlackDenialReason = (typeof SLACK_DENIAL_REASONS)[number];
+
+/** HTTP status codes the control plane emits for each denial reason. */
+export const SLACK_DENIAL_STATUS: Record<SlackDenialReason, number> = {
+  feature_unavailable: 503,
+  feature_disabled: 403,
+  empty_message_after_sanitization: 422,
+  channel_not_found_or_forbidden: 404,
+  rate_limited: 429,
+  slack_api_error: 502,
+  invalid_input: 400,
+};
+
+/** Successful tool_call output produced by the slack-notify route. */
+export interface SlackNotifySuccessOutput {
+  ok: true;
+  channelInput: string;
+  channelId: string;
+  messageTs: string;
+  permalink: string;
+  truncated: boolean;
+  strippedBroadcasts: boolean;
+  mentionsModified: boolean;
+}
+
+/** HTTP failure body returned by the slack-notify endpoint to the sandbox. */
+export interface SlackNotifyFailureBody {
+  error: SlackDenialReason;
+  message?: string;
+  retryAfter?: number;
+}
+
+/** Default mention policy when no per-repo or global override is set. */
+export const DEFAULT_MENTIONS_POLICY: SlackMentionsPolicy = "allow";

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, type ReactNode } from "react";
 import useSWR, { mutate } from "swr";
 import { toast } from "sonner";
 import {
+  DEFAULT_MENTIONS_POLICY,
   type EnrichedRepository,
   type SlackGlobalConfig,
   type SlackGlobalSettings,
@@ -56,8 +57,6 @@ const MENTIONS_POLICY_OPTIONS: {
     description: "Mentions are removed entirely from the message body.",
   },
 ];
-
-const DEFAULT_MENTIONS_POLICY: SlackMentionsPolicy = "allow";
 
 interface GlobalResponse {
   settings: SlackGlobalConfig | null;

--- a/packages/web/src/components/slack-notify-event.tsx
+++ b/packages/web/src/components/slack-notify-event.tsx
@@ -1,34 +1,21 @@
 "use client";
 
+import {
+  SLACK_DENIAL_REASONS,
+  type SlackDenialReason,
+  type SlackNotifySuccessOutput,
+} from "@open-inspect/shared";
 import type { SandboxEvent } from "@/types/session";
 import { getSafeExternalUrl } from "@/lib/urls";
 import { ChevronRightIcon, ErrorIcon, LinkIcon, SlackIcon } from "@/components/ui/icons";
 
 type ToolCallEvent = Extract<SandboxEvent, { type: "tool_call" }>;
 
-interface SlackNotifySuccessOutput {
-  ok: true;
-  channelInput: string;
-  channelId?: string;
-  messageTs?: string;
-  permalink?: string;
-  truncated?: boolean;
-  strippedBroadcasts?: boolean;
-  mentionsModified?: boolean;
-}
+/** Defensive wire-shape: tolerates older events that omit non-essential fields. */
+type ParsedSuccess = Pick<SlackNotifySuccessOutput, "ok" | "channelInput"> &
+  Partial<Omit<SlackNotifySuccessOutput, "ok" | "channelInput">>;
 
-const DENIAL_REASONS = [
-  "feature_unavailable",
-  "feature_disabled",
-  "empty_message_after_sanitization",
-  "channel_not_found_or_forbidden",
-  "rate_limited",
-  "slack_api_error",
-  "invalid_input",
-] as const;
-type DenialReason = (typeof DENIAL_REASONS)[number];
-
-const DENIAL_COPY: Record<DenialReason, { headline: string; hint?: string }> = {
+const DENIAL_COPY: Record<SlackDenialReason, { headline: string; hint?: string }> = {
   feature_unavailable: {
     headline: "Slack notifications are not configured for this deployment.",
   },
@@ -54,7 +41,7 @@ const DENIAL_COPY: Record<DenialReason, { headline: string; hint?: string }> = {
   },
 };
 
-function parseSuccess(output: string | undefined): SlackNotifySuccessOutput | null {
+function parseSuccess(output: string | undefined): ParsedSuccess | null {
   if (!output) return null;
   try {
     const parsed: unknown = JSON.parse(output);
@@ -64,7 +51,7 @@ function parseSuccess(output: string | undefined): SlackNotifySuccessOutput | nu
       (parsed as { ok?: unknown }).ok === true &&
       typeof (parsed as { channelInput?: unknown }).channelInput === "string"
     ) {
-      return parsed as SlackNotifySuccessOutput;
+      return parsed as ParsedSuccess;
     }
   } catch {
     return null;
@@ -72,11 +59,11 @@ function parseSuccess(output: string | undefined): SlackNotifySuccessOutput | nu
   return null;
 }
 
-function getDenialReason(event: ToolCallEvent): DenialReason | null {
+function getDenialReason(event: ToolCallEvent): SlackDenialReason | null {
   if (event.status !== "error") return null;
   if (typeof event.output !== "string") return null;
-  return (DENIAL_REASONS as readonly string[]).includes(event.output)
-    ? (event.output as DenialReason)
+  return (SLACK_DENIAL_REASONS as readonly string[]).includes(event.output)
+    ? (event.output as SlackDenialReason)
     : null;
 }
 
@@ -152,7 +139,7 @@ export function SlackNotifyEvent({
   );
 }
 
-function SlackNotifySuccessBody({ success }: { success: SlackNotifySuccessOutput }) {
+function SlackNotifySuccessBody({ success }: { success: ParsedSuccess }) {
   const notes: string[] = [];
   if (success.truncated) notes.push("Message was truncated to fit Slack length limits.");
   if (success.strippedBroadcasts) notes.push("Broadcast mentions (@channel/@here) were stripped.");
@@ -195,7 +182,7 @@ function SlackNotifyDenialBody({
   reason,
   channelInput,
 }: {
-  reason: DenialReason;
+  reason: SlackDenialReason;
   channelInput: string | undefined;
 }) {
   const { headline, hint } = DENIAL_COPY[reason];


### PR DESCRIPTION
## Summary

- Moves the slack-notify wire-contract types and `DEFAULT_MENTIONS_POLICY` into `@open-inspect/shared/slack/types`. The control-plane route, web event renderer, and Slack settings UI now share one source of truth instead of redeclaring the denial-reason union, success envelope, and default policy in three places.
- Adds `resolveSlackSettings(raw)` next to `getResolvedConfig` in the integration-settings DB module, used by both the slack-notify route handler and the Session DO's spawn-time gate closure to replace the ad-hoc `agentNotificationsEnabled === true` and `mentionsPolicy ?? "allow"` checks.
- The sandbox JS tool (`packages/sandbox-runtime/.../tools/slack-notify.js`) keeps its own `REASON_GUIDANCE` map: it ships verbatim into the sandbox image, has no access to `@open-inspect/shared` at runtime, and there's no codegen precedent in the repo. Drift mitigation for it is left for a follow-up (e.g. a small symmetry test).

## What moved to `@open-inspect/shared/slack/types`

- `SLACK_DENIAL_REASONS` (const tuple) + `SlackDenialReason` type — was a 7-value union in `routes/slack-notify.ts` and a separate 7-value `DENIAL_REASONS` array in `slack-notify-event.tsx`
- `SLACK_DENIAL_STATUS` (denial-reason → HTTP status map) — was `STATUS_FOR_REASON` in `routes/slack-notify.ts`
- `SlackNotifySuccessOutput` interface — was `SuccessOutput` in the route and `SlackNotifySuccessOutput` in the web component
- `SlackNotifyFailureBody` interface — declared but not yet imported anywhere; documents the HTTP wire shape so future callers don't need to reinvent it
- `DEFAULT_MENTIONS_POLICY = "allow"` — was a duplicated constant in the route and the settings UI

## What stayed local

- `mapSlackError` in `routes/slack-notify.ts` — single TS caller, no dedup benefit yet
- `buildBlocks` in `routes/slack-notify.ts` — single TS caller
- `DENIAL_COPY` (UI strings) in `slack-notify-event.tsx` — UI-specific copy, not a contract
- `SlackAgentNotifyLookup` interface in `sandbox/lifecycle/manager.ts` — single-package consumer
- `REASON_GUIDANCE` and `STATUS_FALLBACK_REASON` in the sandbox JS tool — JS runtime can't import from `@open-inspect/shared`

## Drive-by

- Removed a duplicated `// Create D1-backed lookups if database is available` comment in `durable-object.ts:703-704`.

## Test plan

- [x] `npm run build -w @open-inspect/shared` (rebuilds with the new exports)
- [x] `npm run typecheck` — passes across all 6 TS packages
- [x] `npm test -w @open-inspect/shared` — 136/136
- [x] `npm test -w @open-inspect/control-plane` — 1095/1095 (+4 new `resolveSlackSettings` unit tests)
- [x] `npm run test:integration -w @open-inspect/control-plane` — 332/332
- [x] `npm test -w @open-inspect/web` — 230/230
- [x] `npm test -w @open-inspect/slack-bot` — 48/48 (transitively imports from `@open-inspect/shared`)
- [x] ESLint clean on all modified files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced Slack integration settings handling with improved default values for missing configurations
  * Standardized Slack notification error responses with proper HTTP status codes
  * More consistent behavior for Slack mentions policies across the application

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/613)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->