### PR TITLE
refactor(shared): SlackEnvelope discriminated union + slack-bot/github-bot polish

### DIFF
--- a/packages/control-plane/src/routes/slack-notify.ts
+++ b/packages/control-plane/src/routes/slack-notify.ts
@@ -125,13 +125,10 @@ export async function handleSlackNotify(
     return failureResponse(reasonCode, post.error, post.retryAfter);
   }
 
-  const channelId = post.channel ?? parsed.channel;
-  const messageTs = post.ts ?? "";
-  const permalinkResp = await getPermalink(token, channelId, messageTs).catch(() => ({
-    ok: false as const,
-    permalink: undefined as string | undefined,
-  }));
-  const permalink = permalinkResp.ok && permalinkResp.permalink ? permalinkResp.permalink : "";
+  const channelId = post.channel;
+  const messageTs = post.ts;
+  const permalinkResp = await getPermalink(token, channelId, messageTs);
+  const permalink = permalinkResp.ok ? permalinkResp.permalink : "";
 
   const result: SlackNotifySuccessOutput = {
     ok: true,

--- a/packages/github-bot/src/handlers.ts
+++ b/packages/github-bot/src/handlers.ts
@@ -1,4 +1,4 @@
-import { resolveAppName } from "@open-inspect/shared";
+import { buildInternalAuthHeaders, resolveAppName } from "@open-inspect/shared";
 import type {
   Env,
   PullRequestOpenedPayload,
@@ -9,7 +9,6 @@ import type {
 import type { Logger } from "./logger";
 import { generateInstallationToken, postReaction, checkSenderPermission } from "./github-auth";
 import { buildCodeReviewPrompt, buildCommentActionPrompt } from "./prompts";
-import { buildInternalAuthHeaders } from "./utils/internal";
 import { getGitHubConfig, type ResolvedGitHubConfig } from "./utils/integration-config";
 
 export type HandlerResult =

--- a/packages/github-bot/src/utils/integration-config.ts
+++ b/packages/github-bot/src/utils/integration-config.ts
@@ -1,6 +1,6 @@
 import type { Env } from "../types";
 import type { Logger } from "../logger";
-import { buildInternalAuthHeaders } from "./internal";
+import { buildInternalAuthHeaders } from "@open-inspect/shared";
 
 export interface ResolvedGitHubConfig {
   model: string;

--- a/packages/github-bot/src/utils/internal.ts
+++ b/packages/github-bot/src/utils/internal.ts
@@ -1,7 +1,0 @@
-/**
- * Internal API authentication for service-to-service calls.
- *
- * Re-exports from @open-inspect/shared for consistency across packages.
- */
-
-export { generateInternalToken, buildInternalAuthHeaders } from "@open-inspect/shared";

--- a/packages/shared/src/slack/client.test.ts
+++ b/packages/shared/src/slack/client.test.ts
@@ -1,6 +1,17 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { getChannelInfo, postMessage } from "./client";
+import {
+  addReaction,
+  getChannelInfo,
+  getPermalink,
+  getThreadMessages,
+  getUserInfo,
+  openView,
+  postMessage,
+  publishView,
+  removeReaction,
+  updateMessage,
+} from "./client";
 
 function jsonResponse(
   body: unknown,
@@ -162,5 +173,308 @@ describe("getChannelInfo", () => {
     const result = await getChannelInfo("xoxb-token", "C123");
     expect(result.ok).toBe(false);
     expect(result.error).toBe("http_500");
+  });
+});
+
+describe("getPermalink", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches a permalink via GET with channel + message_ts query", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({
+        ok: true,
+        channel: "C123",
+        permalink: "https://slack.com/archives/C123/p1700000000000100",
+      })
+    );
+
+    const result = await getPermalink("xoxb-token", "C123", "1700000000.000100");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.permalink).toContain("/archives/C123/p");
+    }
+    const [url] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe(
+      "https://slack.com/api/chat.getPermalink?channel=C123&message_ts=1700000000.000100"
+    );
+  });
+
+  it("returns Slack's error envelope when the message is missing", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ ok: false, error: "message_not_found" })
+    );
+
+    const result = await getPermalink("xoxb-token", "C123", "1.0");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("message_not_found");
+    }
+  });
+});
+
+describe("updateMessage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("posts channel/ts/text (and optional blocks) to chat.update", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    const result = await updateMessage("xoxb-token", "C123", "1700000000.000100", "edited", {
+      blocks: [{ type: "section", text: { type: "mrkdwn", text: "edited" } }],
+    });
+
+    expect(result.ok).toBe(true);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("https://slack.com/api/chat.update");
+    expect(init?.method).toBe("POST");
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body.channel).toBe("C123");
+    expect(body.ts).toBe("1700000000.000100");
+    expect(body.text).toBe("edited");
+    expect(Array.isArray(body.blocks)).toBe(true);
+  });
+
+  it("returns Slack's error envelope on edit failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ ok: false, error: "message_not_found" })
+    );
+
+    const result = await updateMessage("xoxb-token", "C123", "1.0", "x");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("message_not_found");
+    }
+  });
+});
+
+describe("addReaction", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("posts channel/timestamp/name to reactions.add", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    const result = await addReaction("xoxb-token", "C123", "1700000000.000100", "eyes");
+
+    expect(result.ok).toBe(true);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("https://slack.com/api/reactions.add");
+    expect(init?.method).toBe("POST");
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body.channel).toBe("C123");
+    expect(body.timestamp).toBe("1700000000.000100");
+    expect(body.name).toBe("eyes");
+  });
+
+  it("returns the already_reacted envelope verbatim", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ ok: false, error: "already_reacted" })
+    );
+
+    const result = await addReaction("xoxb-token", "C123", "1.0", "eyes");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("already_reacted");
+    }
+  });
+});
+
+describe("removeReaction", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("posts channel/timestamp/name to reactions.remove", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    await removeReaction("xoxb-token", "C123", "1700000000.000100", "eyes");
+
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("https://slack.com/api/reactions.remove");
+    expect(init?.method).toBe("POST");
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body.channel).toBe("C123");
+    expect(body.timestamp).toBe("1700000000.000100");
+    expect(body.name).toBe("eyes");
+  });
+
+  it("returns Slack's error envelope on no_reaction", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ ok: false, error: "no_reaction" })
+    );
+
+    const result = await removeReaction("xoxb-token", "C123", "1.0", "eyes");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("no_reaction");
+    }
+  });
+});
+
+describe("getThreadMessages", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches replies via GET with channel/ts/limit", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({
+        ok: true,
+        messages: [
+          { ts: "1.1", text: "first", user: "U1" },
+          { ts: "1.2", text: "second", user: "U2" },
+        ],
+      })
+    );
+
+    const result = await getThreadMessages("xoxb-token", "C123", "1.0", 5);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages[0]!.text).toBe("first");
+    }
+    const [url] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("https://slack.com/api/conversations.replies?channel=C123&ts=1.0&limit=5");
+  });
+
+  it("defaults limit to 10 when not provided", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ ok: true, messages: [] }));
+
+    await getThreadMessages("xoxb-token", "C123", "1.0");
+
+    const [url] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toContain("limit=10");
+  });
+
+  it("returns Slack's error envelope on lookup failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ ok: false, error: "thread_not_found" })
+    );
+
+    const result = await getThreadMessages("xoxb-token", "C123", "1.0");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("thread_not_found");
+    }
+  });
+});
+
+describe("getUserInfo", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches user info via GET with user query", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({
+        ok: true,
+        user: { id: "U1", name: "alice", profile: { display_name: "Alice S" } },
+      })
+    );
+
+    const result = await getUserInfo("xoxb-token", "U1");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.user.id).toBe("U1");
+      expect(result.user.profile?.display_name).toBe("Alice S");
+    }
+    const [url] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("https://slack.com/api/users.info?user=U1");
+  });
+
+  it("returns Slack's error envelope on user_not_found", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ ok: false, error: "user_not_found" })
+    );
+
+    const result = await getUserInfo("xoxb-token", "U404");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("user_not_found");
+    }
+  });
+});
+
+describe("publishView", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("posts user_id and view to views.publish", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    const view = { type: "home", blocks: [] };
+    const result = await publishView("xoxb-token", "U1", view);
+
+    expect(result.ok).toBe(true);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("https://slack.com/api/views.publish");
+    expect(init?.method).toBe("POST");
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body.user_id).toBe("U1");
+    expect(body.view).toEqual(view);
+  });
+
+  it("returns Slack's error envelope on hash_conflict", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ ok: false, error: "hash_conflict" })
+    );
+
+    const result = await publishView("xoxb-token", "U1", { type: "home" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("hash_conflict");
+    }
+  });
+});
+
+describe("openView", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("posts trigger_id and view to views.open", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+    const view = { type: "modal", title: { type: "plain_text", text: "T" } };
+    await openView("xoxb-token", "trig.1", view);
+
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("https://slack.com/api/views.open");
+    expect(init?.method).toBe("POST");
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body.trigger_id).toBe("trig.1");
+    expect(body.view).toEqual(view);
+  });
+
+  it("returns Slack's error envelope on expired trigger", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ ok: false, error: "expired_trigger_id" })
+    );
+
+    const result = await openView("xoxb-token", "trig.1", { type: "modal" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("expired_trigger_id");
+    }
   });
 });

--- a/packages/shared/src/slack/client.ts
+++ b/packages/shared/src/slack/client.ts
@@ -12,23 +12,23 @@ import { computeHmacHex, timingSafeEqual } from "../auth";
 
 const SLACK_API_BASE = "https://slack.com/api";
 
-interface SlackResponseBase {
-  ok: boolean;
-  error?: string;
-  retryAfter?: number;
-}
+/**
+ * Discriminated success/failure envelope returned by every Slack API method.
+ *
+ * The success arm is `{ ok: true } & T`; the failure arm carries an `error`
+ * string (Slack's `error` field, or one of the synthesized values
+ * `network_error` / `invalid_response` / `http_<status>` / `ratelimited`).
+ */
+export type SlackEnvelope<T = Record<string, never>> =
+  | ({ ok: true } & T)
+  | { ok: false; error: string; retryAfter?: number };
 
-interface SlackFetchInit {
-  method?: "GET" | "POST";
-  query?: Record<string, string>;
-  body?: Record<string, unknown>;
-}
-
-async function slackFetch<T extends SlackResponseBase>(
+async function slackFetch<T>(
   token: string,
   endpoint: string,
-  init?: SlackFetchInit
-): Promise<T> {
+  method: "GET" | "POST",
+  init?: { query?: Record<string, string>; body?: Record<string, unknown> }
+): Promise<SlackEnvelope<T>> {
   const url = init?.query
     ? `${SLACK_API_BASE}/${endpoint}?${new URLSearchParams(init.query).toString()}`
     : `${SLACK_API_BASE}/${endpoint}`;
@@ -44,13 +44,9 @@ async function slackFetch<T extends SlackResponseBase>(
 
   let response: Response;
   try {
-    response = await fetch(url, {
-      method: init?.method ?? "GET",
-      headers,
-      body,
-    });
+    response = await fetch(url, { method, headers, body });
   } catch {
-    return { ok: false, error: "network_error" } as T;
+    return { ok: false, error: "network_error" };
   }
 
   if (response.status === 429) {
@@ -60,18 +56,34 @@ async function slackFetch<T extends SlackResponseBase>(
       ok: false,
       error: "ratelimited",
       ...(Number.isFinite(parsed) ? { retryAfter: parsed } : {}),
-    } as T;
+    };
   }
 
   if (!response.ok) {
-    return { ok: false, error: `http_${response.status}` } as T;
+    return { ok: false, error: `http_${response.status}` };
   }
 
   try {
-    return (await response.json()) as T;
+    return (await response.json()) as SlackEnvelope<T>;
   } catch {
-    return { ok: false, error: "invalid_response" } as T;
+    return { ok: false, error: "invalid_response" };
   }
+}
+
+function slackGet<T>(
+  token: string,
+  endpoint: string,
+  query?: Record<string, string>
+): Promise<SlackEnvelope<T>> {
+  return slackFetch<T>(token, endpoint, "GET", query ? { query } : undefined);
+}
+
+function slackPost<T>(
+  token: string,
+  endpoint: string,
+  body?: Record<string, unknown>
+): Promise<SlackEnvelope<T>> {
+  return slackFetch<T>(token, endpoint, "POST", body ? { body } : undefined);
 }
 
 /**
@@ -101,7 +113,7 @@ export async function verifySlackSignature(
   return timingSafeEqual(signature, expectedSignature);
 }
 
-export async function postMessage(
+export function postMessage(
   token: string,
   channel: string,
   text: string,
@@ -110,166 +122,121 @@ export async function postMessage(
     blocks?: unknown[];
     reply_broadcast?: boolean;
   }
-): Promise<{
-  ok: boolean;
-  channel?: string;
-  ts?: string;
-  error?: string;
-  retryAfter?: number;
-}> {
-  return slackFetch(token, "chat.postMessage", {
-    method: "POST",
-    body: {
-      channel,
-      text,
-      thread_ts: options?.thread_ts,
-      blocks: options?.blocks,
-      reply_broadcast: options?.reply_broadcast,
-    },
+): Promise<SlackEnvelope<{ channel: string; ts: string }>> {
+  return slackPost(token, "chat.postMessage", {
+    channel,
+    text,
+    thread_ts: options?.thread_ts,
+    blocks: options?.blocks,
+    reply_broadcast: options?.reply_broadcast,
   });
 }
 
-export async function getPermalink(
+export function getPermalink(
   token: string,
   channel: string,
   messageTs: string
-): Promise<{
-  ok: boolean;
-  permalink?: string;
-  channel?: string;
-  error?: string;
-  retryAfter?: number;
-}> {
-  return slackFetch(token, "chat.getPermalink", {
-    query: { channel, message_ts: messageTs },
-  });
+): Promise<SlackEnvelope<{ permalink: string; channel: string }>> {
+  return slackGet(token, "chat.getPermalink", { channel, message_ts: messageTs });
 }
 
-export async function updateMessage(
+export function updateMessage(
   token: string,
   channel: string,
   ts: string,
   text: string,
-  options?: {
-    blocks?: unknown[];
-  }
-): Promise<{ ok: boolean; error?: string; retryAfter?: number }> {
-  return slackFetch(token, "chat.update", {
-    method: "POST",
-    body: {
-      channel,
-      ts,
-      text,
-      blocks: options?.blocks,
-    },
+  options?: { blocks?: unknown[] }
+): Promise<SlackEnvelope> {
+  return slackPost(token, "chat.update", {
+    channel,
+    ts,
+    text,
+    blocks: options?.blocks,
   });
 }
 
-export async function addReaction(
+export function addReaction(
   token: string,
   channel: string,
   messageTs: string,
   name: string
-): Promise<{ ok: boolean; error?: string; retryAfter?: number }> {
-  return slackFetch(token, "reactions.add", {
-    method: "POST",
-    body: { channel, timestamp: messageTs, name },
-  });
+): Promise<SlackEnvelope> {
+  return slackPost(token, "reactions.add", { channel, timestamp: messageTs, name });
 }
 
-export async function removeReaction(
+export function removeReaction(
   token: string,
   channel: string,
   messageTs: string,
   name: string
-): Promise<{ ok: boolean; error?: string; retryAfter?: number }> {
-  return slackFetch(token, "reactions.remove", {
-    method: "POST",
-    body: { channel, timestamp: messageTs, name },
-  });
+): Promise<SlackEnvelope> {
+  return slackPost(token, "reactions.remove", { channel, timestamp: messageTs, name });
 }
 
-export async function getChannelInfo(
+export interface SlackChannelInfo {
+  id: string;
+  name: string;
+  topic?: { value: string };
+  purpose?: { value: string };
+}
+
+export function getChannelInfo(
   token: string,
   channelId: string
-): Promise<{
-  ok: boolean;
-  channel?: {
-    id: string;
-    name: string;
-    topic?: { value: string };
-    purpose?: { value: string };
-  };
-  error?: string;
-  retryAfter?: number;
-}> {
-  return slackFetch(token, "conversations.info", {
-    query: { channel: channelId },
-  });
+): Promise<SlackEnvelope<{ channel: SlackChannelInfo }>> {
+  return slackGet(token, "conversations.info", { channel: channelId });
 }
 
-export async function getThreadMessages(
+export interface SlackThreadMessage {
+  ts: string;
+  text: string;
+  user?: string;
+  bot_id?: string;
+}
+
+export function getThreadMessages(
   token: string,
   channelId: string,
   threadTs: string,
   limit = 10
-): Promise<{
-  ok: boolean;
-  messages?: Array<{
-    ts: string;
-    text: string;
-    user?: string;
-    bot_id?: string;
-  }>;
-  error?: string;
-  retryAfter?: number;
-}> {
-  return slackFetch(token, "conversations.replies", {
-    query: { channel: channelId, ts: threadTs, limit: String(limit) },
+): Promise<SlackEnvelope<{ messages: SlackThreadMessage[] }>> {
+  return slackGet(token, "conversations.replies", {
+    channel: channelId,
+    ts: threadTs,
+    limit: String(limit),
   });
 }
 
-export async function getUserInfo(
+export interface SlackUser {
+  id: string;
+  name: string;
+  real_name?: string;
+  profile?: {
+    display_name?: string;
+    real_name?: string;
+    email?: string;
+  };
+}
+
+export function getUserInfo(
   token: string,
   userId: string
-): Promise<{
-  ok: boolean;
-  user?: {
-    id: string;
-    name: string;
-    real_name?: string;
-    profile?: {
-      display_name?: string;
-      real_name?: string;
-      email?: string;
-    };
-  };
-  error?: string;
-  retryAfter?: number;
-}> {
-  return slackFetch(token, "users.info", {
-    query: { user: userId },
-  });
+): Promise<SlackEnvelope<{ user: SlackUser }>> {
+  return slackGet(token, "users.info", { user: userId });
 }
 
-export async function publishView(
+export function publishView(
   token: string,
   userId: string,
   view: Record<string, unknown>
-): Promise<{ ok: boolean; error?: string; retryAfter?: number }> {
-  return slackFetch(token, "views.publish", {
-    method: "POST",
-    body: { user_id: userId, view },
-  });
+): Promise<SlackEnvelope> {
+  return slackPost(token, "views.publish", { user_id: userId, view });
 }
 
-export async function openView(
+export function openView(
   token: string,
   triggerId: string,
   view: Record<string, unknown>
-): Promise<{ ok: boolean; error?: string; retryAfter?: number }> {
-  return slackFetch(token, "views.open", {
-    method: "POST",
-    body: { trigger_id: triggerId, view },
-  });
+): Promise<SlackEnvelope> {
+  return slackPost(token, "views.open", { trigger_id: triggerId, view });
 }

--- a/packages/shared/src/slack/index.ts
+++ b/packages/shared/src/slack/index.ts
@@ -11,6 +11,7 @@ export {
   updateMessage,
   verifySlackSignature,
 } from "./client";
+export type { SlackChannelInfo, SlackEnvelope, SlackThreadMessage, SlackUser } from "./client";
 export {
   applyMentionPolicy,
   sanitizeAgentText,
@@ -19,5 +20,6 @@ export {
   truncateForSlack,
 } from "./mrkdwn";
 export type { MentionPolicy, SanitizeOptions, SanitizeResult } from "./mrkdwn";
+export { resolveUserNames } from "./resolve-users";
 export { SLACK_DENIAL_REASONS, SLACK_DENIAL_STATUS, DEFAULT_MENTIONS_POLICY } from "./types";
 export type { SlackDenialReason, SlackNotifySuccessOutput, SlackNotifyFailureBody } from "./types";

--- a/packages/shared/src/slack/resolve-users.test.ts
+++ b/packages/shared/src/slack/resolve-users.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type * as SharedModule from "@open-inspect/shared";
+import type * as ClientModule from "./client";
 
 const { mockGetUserInfo } = vi.hoisted(() => ({
   mockGetUserInfo: vi.fn(),
 }));
 
-vi.mock("@open-inspect/shared", async () => {
-  const actual = await vi.importActual<typeof SharedModule>("@open-inspect/shared");
+vi.mock("./client", async () => {
+  const actual = await vi.importActual<typeof ClientModule>("./client");
   return {
     ...actual,
     getUserInfo: mockGetUserInfo,

--- a/packages/shared/src/slack/resolve-users.ts
+++ b/packages/shared/src/slack/resolve-users.ts
@@ -1,8 +1,12 @@
-import { getUserInfo } from "@open-inspect/shared";
+import { getUserInfo } from "./client";
 
 /**
  * Resolve Slack user IDs to display names.
- * Returns a map of userId → displayName. Falls back to userId on failure.
+ *
+ * Returns a map of `userId → displayName`. When `getUserInfo` fails (Slack
+ * error envelope or thrown exception via `Promise.allSettled`), the entry is
+ * either populated with the raw user ID (envelope failure) or omitted entirely
+ * (thrown exception). Callers should treat a missing entry as "unknown user".
  */
 export async function resolveUserNames(
   token: string,
@@ -12,7 +16,8 @@ export async function resolveUserNames(
   const results = await Promise.allSettled(
     userIds.map(async (id) => {
       const info = await getUserInfo(token, id);
-      const displayName = info.user?.profile?.display_name || info.user?.name || id;
+      if (!info.ok) return { id, displayName: id };
+      const displayName = info.user.profile?.display_name || info.user.name || id;
       return { id, displayName };
     })
   );

--- a/packages/slack-bot/src/classifier/repos.ts
+++ b/packages/slack-bot/src/classifier/repos.ts
@@ -8,9 +8,8 @@
 
 import type { Env, RepoConfig, ControlPlaneRepo, ControlPlaneReposResponse } from "../types";
 import { normalizeRepoId } from "../utils/repo";
-import { buildInternalAuthHeaders } from "../utils/internal";
+import { buildInternalAuthHeaders, createKvCacheStore } from "@open-inspect/shared";
 import { createLogger } from "../logger";
-import { createKvCacheStore } from "@open-inspect/shared";
 
 const log = createLogger("repos");
 

--- a/packages/slack-bot/src/index.ts
+++ b/packages/slack-bot/src/index.ts
@@ -27,11 +27,11 @@ import {
   publishView,
   openView,
 } from "@open-inspect/shared";
-import { resolveUserNames } from "./utils/resolve-users";
+import { resolveUserNames } from "@open-inspect/shared";
 import { createClassifier } from "./classifier";
 import { getAvailableRepos } from "./classifier/repos";
 import { callbacksRouter } from "./callbacks";
-import { buildInternalAuthHeaders } from "./utils/internal";
+import { buildInternalAuthHeaders } from "@open-inspect/shared";
 import { createLogger } from "./logger";
 import { createKvCacheStore } from "@open-inspect/shared";
 import {
@@ -904,12 +904,14 @@ async function startSessionAndSendPrompt(
   let email: string | undefined;
   try {
     const userInfo = await getUserInfo(env.SLACK_BOT_TOKEN, userId);
-    displayName =
-      userInfo.user?.profile?.display_name ||
-      userInfo.user?.real_name ||
-      userInfo.user?.name ||
-      undefined;
-    email = userInfo.user?.profile?.email || undefined;
+    if (userInfo.ok) {
+      displayName =
+        userInfo.user.profile?.display_name ||
+        userInfo.user.real_name ||
+        userInfo.user.name ||
+        undefined;
+      email = userInfo.user.profile?.email || undefined;
+    }
   } catch {
     // Proceed with no display name / email — control plane handles missing fields
   }
@@ -1519,7 +1521,7 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
     }
   );
 
-  const ackTs = ackResult.ts;
+  const ackTs = ackResult.ok ? ackResult.ts : undefined;
 
   // Create session and send prompt using shared logic
   const sessionResult = await startSessionAndSendPrompt(

--- a/packages/slack-bot/src/utils/internal.ts
+++ b/packages/slack-bot/src/utils/internal.ts
@@ -1,7 +1,0 @@
-/**
- * Internal API authentication for service-to-service calls.
- *
- * Re-exports from @open-inspect/shared for consistency across packages.
- */
-
-export { generateInternalToken, buildInternalAuthHeaders } from "@open-inspect/shared";


### PR DESCRIPTION
## Summary

- Tightens the shared Slack client return types into a discriminated `SlackEnvelope<T>` union so callers narrow once on `.ok` and the success arm carries required fields (channel, ts, user, messages, etc.) instead of optional ones. Removes a class of defensive `?? fallback` and `&& result.x` patterns from callers.
- Factors `slackFetch` into typed `slackPost`/`slackGet` helpers; the per-method bodies are now one line each.
- Promotes `resolveUserNames` from `slack-bot/utils/` to `@open-inspect/shared/slack/` alongside the rest of the slack client (its only dependency was already `getUserInfo`).
- Deletes `slack-bot/utils/internal.ts` and `github-bot/utils/internal.ts` re-export shims; 4 import sites now reach `@open-inspect/shared` directly.
- Adds happy-path + error-envelope tests for the 8 previously untested client methods (`getPermalink`, `updateMessage`, `addReaction`, `removeReaction`, `getThreadMessages`, `getUserInfo`, `publishView`, `openView`). Shared package goes from ~138 → 160 unit tests.

## Notes

- A few slack-bot call sites needed `.ok` narrowing under the stricter union (`getUserInfo` profile lookup at `index.ts:906`; `ackResult.ts` read at `index.ts:1522`). `slack-notify.ts` no longer needs its `.catch(...)` envelope synthesizer — the client already maps thrown errors to `{ ok: false, error: 'network_error' }`.
- No public API removals or behavior changes — same wire interactions, stricter types, fewer lines.

## Test plan

- [x] `npm run typecheck` clean across all 6 TS packages
- [x] `npm test -w @open-inspect/shared` (160 tests, includes 16 new client tests + 7 moved resolve-users tests)
- [x] `npm test -w @open-inspect/slack-bot` (41)
- [x] `npm test -w @open-inspect/control-plane` (1095)
- [x] `npm run test:integration -w @open-inspect/control-plane` (332/332 — including slack-notify integration coverage)
- [x] `npm test -w @open-inspect/github-bot` (103)
- [x] `npm test -w @open-inspect/web` (230)
- [x] `npm test -w @open-inspect/linear-bot` (103)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Slack API error handling with improved consistency and resilience across messaging, reactions, and user resolution flows.
  * Strengthened error recovery in authentication and integration handlers to prevent cascading failures.

* **Tests**
  * Expanded test coverage for Slack client functionality including error scenarios and edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/614)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->