### PR TITLE
fix: enforce Slack notification repo scope

### DIFF
--- a/packages/control-plane/src/routes/slack-notify.ts
+++ b/packages/control-plane/src/routes/slack-notify.ts
@@ -82,7 +82,15 @@ export async function handleSlackNotify(
   }
 
   const settingsStore = new IntegrationSettingsStore(env.DB);
-  const { settings } = await settingsStore.getResolvedConfig("slack", repo);
+  const { enabledRepos, settings } = await settingsStore.getResolvedConfig("slack", repo);
+  if (enabledRepos !== null && !enabledRepos.includes(repo.toLowerCase())) {
+    await emitDenial(env, sessionId, ctx, parsed, attribution, "feature_disabled");
+    return failureResponse(
+      "feature_disabled",
+      "Slack agent notifications are disabled for this repository."
+    );
+  }
+
   const { agentNotificationsEnabled, mentionsPolicy } = resolveSlackSettings(
     settings as Partial<SlackGlobalSettings>
   );

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -719,10 +719,9 @@ export class SessionDO extends DurableObject<Env> {
       slackAgentNotifyLookup = {
         isEnabledForRepo: async (repoOwner, repoName) => {
           if (!tokenPresent) return false;
-          const { settings } = await settingsStore.getResolvedConfig(
-            "slack",
-            `${repoOwner}/${repoName}`
-          );
+          const repo = `${repoOwner}/${repoName}`;
+          const { enabledRepos, settings } = await settingsStore.getResolvedConfig("slack", repo);
+          if (enabledRepos !== null && !enabledRepos.includes(repo.toLowerCase())) return false;
           return resolveSlackSettings(settings).agentNotificationsEnabled;
         },
       };

--- a/packages/control-plane/test/integration/slack-notify.test.ts
+++ b/packages/control-plane/test/integration/slack-notify.test.ts
@@ -7,6 +7,7 @@ import { initNamedSession, queryDO, seedSandboxAuth } from "./helpers";
 
 async function setupSession(opts?: {
   agentNotificationsEnabled?: boolean;
+  enabledRepos?: string[];
   mentionsPolicy?: "allow" | "escape" | "strip";
   parentSessionId?: string | null;
   spawnSource?: "user" | "agent";
@@ -47,6 +48,7 @@ async function setupSession(opts?: {
   if (opts?.agentNotificationsEnabled !== undefined || opts?.mentionsPolicy !== undefined) {
     const store = new IntegrationSettingsStore(env.DB);
     await store.setGlobal("slack", {
+      ...(opts.enabledRepos !== undefined ? { enabledRepos: opts.enabledRepos } : {}),
       defaults: {
         agentNotificationsEnabled: opts?.agentNotificationsEnabled ?? false,
         mentionsPolicy: opts?.mentionsPolicy ?? "allow",
@@ -119,6 +121,30 @@ describe("POST /sessions/:id/slack-notify", () => {
     expect(res.status).toBe(403);
     const body = await res.json<{ error: string }>();
     expect(body.error).toBe("feature_disabled");
+  });
+
+  it("returns 403 feature_disabled when the repo is outside the Slack enabledRepos allowlist", async () => {
+    const { sessionName, sandboxToken } = await setupSession({
+      agentNotificationsEnabled: true,
+      enabledRepos: ["other/repo"],
+    });
+
+    const slackFetch = buildSlackFetchMock({});
+    vi.stubGlobal("fetch", slackFetch);
+
+    const res = await SELF.fetch(`https://test.local/sessions/${sessionName}/slack-notify`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${sandboxToken}`,
+      },
+      body: JSON.stringify({ channel: "#ops", text: "hi" }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toBe("feature_disabled");
+    expect(slackFetch).not.toHaveBeenCalled();
   });
 
   it("returns 200 and emits tool_call + tool_result events on Slack success", async () => {

--- a/packages/control-plane/test/integration/slack-tool-gate.test.ts
+++ b/packages/control-plane/test/integration/slack-tool-gate.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { env, runInDurableObject } from "cloudflare:test";
+import type { SessionDO } from "../../src/session/durable-object";
+import { IntegrationSettingsStore } from "../../src/db/integration-settings";
+import { cleanD1Tables } from "./cleanup";
+import { initNamedSession } from "./helpers";
+
+describe("spawn-time slack-notify tool gate", () => {
+  beforeEach(cleanD1Tables);
+
+  it("does not install slack-notify when the repo is outside the Slack enabledRepos allowlist", async () => {
+    const { stub } = await initNamedSession(`gate-${Date.now()}`, {
+      repoOwner: "acme",
+      repoName: "web-app",
+    });
+
+    const store = new IntegrationSettingsStore(env.DB);
+    await store.setGlobal("slack", {
+      enabledRepos: ["other/repo"],
+      defaults: {
+        agentNotificationsEnabled: true,
+        mentionsPolicy: "allow",
+      },
+    });
+
+    let createSandboxBody: Record<string, unknown> | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        createSandboxBody = init?.body ? JSON.parse(init.body as string) : undefined;
+        return new Response(
+          JSON.stringify({
+            success: true,
+            data: {
+              sandbox_id: "sandbox-acme-web-app-test",
+              modal_object_id: "modal-1",
+              status: "warming",
+              created_at: Date.now(),
+            },
+          }),
+          { status: 200 }
+        );
+      })
+    );
+
+    await runInDurableObject(stub, async (instance: SessionDO) => {
+      await (
+        instance as unknown as { lifecycleManager: { spawnSandbox(): Promise<void> } }
+      ).lifecycleManager.spawnSandbox();
+    });
+
+    expect(createSandboxBody?.agent_slack_notify_enabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Enforce Slack `enabledRepos` scope before allowing agent-initiated Slack notifications.
- Apply the same repo scope check to the spawn-time `slack-notify` tool gate.
- Add integration coverage for excluded repos on both the endpoint and sandbox tool installation path.

## Tests
- `npm run test:integration -w @open-inspect/control-plane -- slack-notify.test.ts`
- `npm run test:integration -w @open-inspect/control-plane -- slack-tool-gate.test.ts`
- `npm run test:integration -w @open-inspect/control-plane -- slack-notify.test.ts slack-tool-gate.test.ts`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/f9c68bcd4bd222f84c9881aba08e3ca9)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack agent notifications now support per-repository configuration through an allowlist. Repositories not included in the allowlist will have the feature disabled.

* **Tests**
  * Added integration tests to verify Slack notification allowlisting behavior and tool-gating enforcement.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/617)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->