### PR TITLE
feat(control-plane): auto-rename sessions on first prompt via Haiku titler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17911,6 +17911,7 @@
       "name": "@open-inspect/control-plane",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.39.0",
         "@cloudflare/workers-types": "^4.20241230.0",
         "@open-inspect/shared": "file:../shared"
       },

--- a/packages/control-plane/package.json
+++ b/packages/control-plane/package.json
@@ -13,6 +13,7 @@
     "lint:fix": "eslint src/ --fix"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.39.0",
     "@cloudflare/workers-types": "^4.20241230.0",
     "@open-inspect/shared": "file:../shared"
   },

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -54,6 +54,8 @@ function createMockSession(overrides: Partial<SessionRow> = {}): SessionRow {
     code_server_enabled: 0,
     total_cost: 0,
     sandbox_settings: null,
+    title_manually_set: 0,
+    title_auto_rename_attempted_at: null,
     created_at: Date.now() - 60000,
     updated_at: Date.now(),
     ...overrides,

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -92,6 +92,8 @@ import {
 } from "./http/handlers/participants.handler";
 import { MessageService } from "./services/message.service";
 import { createAlarmHandler, type AlarmHandler } from "./alarm/handler";
+import Anthropic from "@anthropic-ai/sdk";
+import { generateTitle, runAutoRename, type TitlerClient } from "./services/session-titler";
 
 /**
  * Timeout for WebSocket authentication (in milliseconds).
@@ -150,6 +152,12 @@ export class SessionDO extends DurableObject<Env> {
   private _alarmHandler: AlarmHandler | null = null;
   // Sandbox event processor (lazily initialized)
   private _sandboxEventProcessor: SessionSandboxEventProcessor | null = null;
+  // Titler client for session auto-rename. Tri-state lazy:
+  //   undefined → not yet computed
+  //   null      → computed, no ANTHROPIC_API_KEY configured (fallback path only)
+  //   instance  → ready
+  // The getter caches null so the cold-start warning fires exactly once per DO.
+  private _titlerClient: TitlerClient | null | undefined;
 
   // Internal HTTP route table (transport wiring only; handlers remain on SessionDO).
   private readonly routes = createSessionInternalRoutes({
@@ -319,6 +327,7 @@ export class SessionDO extends DurableObject<Env> {
             await this.ctx.storage.setAlarm(deadline);
           }
         },
+        triggerAutoRename: (prompt: string) => this.runAutoRenameForFirstPrompt(prompt),
       });
     }
 
@@ -336,6 +345,25 @@ export class SessionDO extends DurableObject<Env> {
     }
 
     return this._messageService;
+  }
+
+  /**
+   * Returns the Anthropic SDK client used for session auto-rename, or null
+   * if ANTHROPIC_API_KEY is not configured. Lazily instantiated, cached for
+   * the DO lifetime.
+   */
+  private get titlerClient(): TitlerClient | null {
+    if (this._titlerClient === undefined) {
+      this._titlerClient = this.env.ANTHROPIC_API_KEY
+        ? new Anthropic({ apiKey: this.env.ANTHROPIC_API_KEY })
+        : null;
+      if (!this._titlerClient) {
+        this.log.warn("auto_rename.no_api_key", {
+          message: "ANTHROPIC_API_KEY not configured; auto-rename will use deterministic fallback",
+        });
+      }
+    }
+    return this._titlerClient;
   }
 
   private get messagesHandler(): MessagesHandler {
@@ -1426,6 +1454,32 @@ export class SessionDO extends DurableObject<Env> {
    */
   private async processMessageQueue(): Promise<void> {
     await this.messageQueue.processMessageQueue();
+  }
+
+  /**
+   * Build deps and run the auto-rename orchestrator.
+   * Called from the message queue via ctx.waitUntil on the first eligible prompt.
+   */
+  private async runAutoRenameForFirstPrompt(prompt: string): Promise<void> {
+    await runAutoRename({
+      deps: {
+        repository: {
+          getSession: () => this.repository.getSession(),
+          updateSessionTitle: (sessionId, title, updatedAt) =>
+            this.repository.updateSessionTitle(sessionId, title, updatedAt),
+          markTitleAutoRenameAttempted: (sessionId, attemptedAt) =>
+            this.repository.markTitleAutoRenameAttempted(sessionId, attemptedAt),
+        },
+        titler: ({ prompt, spawnSource }) =>
+          generateTitle({ client: this.titlerClient, prompt, spawnSource }),
+        syncSessionIndexTitle: (sessionId, title) => this.syncSessionIndexTitle(sessionId, title),
+        broadcast: (message) => this.broadcast(message),
+        getPublicSessionId: (session) => this.getPublicSessionId(session),
+        log: this.log,
+        now: () => Date.now(),
+      },
+      prompt,
+    });
   }
 
   /**

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1250,6 +1250,17 @@ export class SessionDO extends DurableObject<Env> {
     // Fetch sandbox once and thread it through to avoid a redundant SQLite read.
     const sandbox = this.getSandbox();
     const state = await this.getSessionState(sandbox);
+    // Close a race with concurrent ctx.waitUntil background tasks (e.g. the
+    // auto-rename titler) that may commit a new title between getSessionState's
+    // snapshot read and this point — the titler's Haiku call can resolve
+    // anywhere in this window, and its post-call tail (updateSessionTitle +
+    // broadcast) runs synchronously. Without this refresh, the broadcast they
+    // emit would arrive on the wire *before* "subscribed", and the client's
+    // session_title handler drops updates when sessionState is still null.
+    const latestTitle = this.getSession()?.title ?? null;
+    if (latestTitle !== state.title) {
+      state.title = latestTitle;
+    }
     const artifacts = this.messageService.listArtifacts();
     const replay = this.getReplayData();
 

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
@@ -24,6 +24,8 @@ function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
     code_server_enabled: 0,
     total_cost: 0,
     sandbox_settings: null,
+    title_manually_set: 0,
+    title_auto_rename_attempted_at: null,
     created_at: 1000,
     updated_at: 2000,
     ...overrides,

--- a/packages/control-plane/src/session/http/handlers/pull-request.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/pull-request.handler.test.ts
@@ -24,6 +24,8 @@ function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
     code_server_enabled: 0,
     total_cost: 0,
     sandbox_settings: null,
+    title_manually_set: 0,
+    title_auto_rename_attempted_at: null,
     created_at: 1000,
     updated_at: 2000,
     ...overrides,

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
@@ -25,6 +25,8 @@ function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
     code_server_enabled: 0,
     total_cost: 0,
     sandbox_settings: null,
+    title_manually_set: 0,
+    title_auto_rename_attempted_at: null,
     created_at: 1000,
     updated_at: 2000,
     ...overrides,
@@ -81,6 +83,7 @@ function createHandler() {
     createSandbox: vi.fn(),
     createParticipant: vi.fn(),
     updateSessionTitle: vi.fn(),
+    markTitleManuallySet: vi.fn(),
   };
   const getDurableObjectId = vi.fn(() => "session-do-id");
   const encryptToken = vi.fn();
@@ -458,6 +461,7 @@ describe("createSessionLifecycleHandler", () => {
     expect(repository.updateSessionTitle).toHaveBeenCalledWith("session-1", "New Title", 1234);
     expect(syncSessionIndexTitle).toHaveBeenCalledWith("public-session-1", "New Title");
     expect(broadcast).toHaveBeenCalledWith({ type: "session_title", title: "New Title" });
+    expect(repository.markTitleManuallySet).toHaveBeenCalledWith("session-1", 1234);
   });
 
   it("returns 400 for invalid archive body", async () => {

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
@@ -41,7 +41,11 @@ interface InitRequest {
 export interface SessionLifecycleHandlerDeps {
   repository: Pick<
     SessionRepository,
-    "upsertSession" | "createSandbox" | "createParticipant" | "updateSessionTitle"
+    | "upsertSession"
+    | "createSandbox"
+    | "createParticipant"
+    | "updateSessionTitle"
+    | "markTitleManuallySet"
   >;
   getDurableObjectId: () => string;
   tokenEncryptionKey?: string;
@@ -228,7 +232,11 @@ export function createSessionLifecycleHandler(
         );
       }
 
-      deps.repository.updateSessionTitle(session.id, body.title, deps.now());
+      const now = deps.now();
+      deps.repository.updateSessionTitle(session.id, body.title, now);
+      // Flag the row so the background auto-rename in session-titler never
+      // overwrites a participant's explicit choice.
+      deps.repository.markTitleManuallySet(session.id, now);
 
       const publicSessionId = deps.getPublicSessionId(session);
       deps.syncSessionIndexTitle(publicSessionId, body.title);

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -44,6 +44,8 @@ function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
     code_server_enabled: 0,
     total_cost: 0,
     sandbox_settings: null,
+    title_manually_set: 0,
+    title_auto_rename_attempted_at: null,
     created_at: 1000,
     updated_at: 1000,
     ...overrides,
@@ -82,7 +84,11 @@ function createClientInfo(overrides: Partial<ClientInfo> = {}): ClientInfo {
   };
 }
 
-function buildQueue(options?: { getClientInfo?: (ws: WebSocket) => ClientInfo | null }) {
+function buildQueue(options?: {
+  getClientInfo?: (ws: WebSocket) => ClientInfo | null;
+  session?: SessionRow | null;
+  triggerAutoRename?: (prompt: string) => Promise<void>;
+}) {
   const repository = {
     createMessage: vi.fn(),
     createEvent: vi.fn(),
@@ -117,6 +123,8 @@ function buildQueue(options?: { getClientInfo?: (ws: WebSocket) => ClientInfo | 
   const updateLastActivity = vi.fn();
   const waitUntil = vi.fn();
 
+  const session = options?.session === undefined ? createSession() : options.session;
+
   const queue = new SessionMessageQueue({
     env: {} as Env,
     ctx: { waitUntil } as unknown as DurableObjectState,
@@ -134,12 +142,13 @@ function buildQueue(options?: { getClientInfo?: (ws: WebSocket) => ClientInfo | 
     scmProvider: "github",
     getClientInfo: options?.getClientInfo ?? (() => createClientInfo()),
     validateReasoningEffort: vi.fn(() => null),
-    getSession: vi.fn(() => createSession()),
+    getSession: vi.fn(() => session),
     updateLastActivity,
     spawnSandbox,
     broadcast,
     setSessionStatus,
     reconcileSessionStatusAfterExecution,
+    triggerAutoRename: options?.triggerAutoRename,
   });
 
   return {
@@ -316,5 +325,69 @@ describe("SessionMessageQueue", () => {
 
       expect(h.repository.updateParticipantCoalesce).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("SessionMessageQueue auto-rename trigger", () => {
+  it("triggers auto-rename via waitUntil on first bot prompt", async () => {
+    const triggerAutoRename = vi.fn(async (_prompt: string) => {});
+    const h = buildQueue({
+      session: createSession({
+        title: null,
+        title_manually_set: 0,
+        title_auto_rename_attempted_at: null,
+      }),
+      triggerAutoRename,
+    });
+
+    await h.queue.enqueuePromptFromApi({
+      content: "Fix the login bug",
+      authorId: "github:1001",
+      source: "github-bot",
+    });
+
+    expect(h.waitUntil).toHaveBeenCalledTimes(1);
+    expect(triggerAutoRename).toHaveBeenCalledTimes(1);
+    expect(triggerAutoRename).toHaveBeenCalledWith("Fix the login bug");
+  });
+
+  it("does NOT trigger when title was manually set", async () => {
+    const triggerAutoRename = vi.fn(async (_prompt: string) => {});
+    const h = buildQueue({
+      session: createSession({
+        title: "Manually chosen",
+        title_manually_set: 1,
+        title_auto_rename_attempted_at: null,
+      }),
+      triggerAutoRename,
+    });
+
+    await h.queue.enqueuePromptFromApi({
+      content: "Fix the login bug",
+      authorId: "github:1001",
+      source: "github-bot",
+    });
+
+    expect(triggerAutoRename).not.toHaveBeenCalled();
+  });
+
+  it("does NOT trigger when auto-rename was already attempted", async () => {
+    const triggerAutoRename = vi.fn(async (_prompt: string) => {});
+    const h = buildQueue({
+      session: createSession({
+        title: "Some title",
+        title_manually_set: 0,
+        title_auto_rename_attempted_at: 1234567890,
+      }),
+      triggerAutoRename,
+    });
+
+    await h.queue.enqueuePromptFromApi({
+      content: "Fix the login bug",
+      authorId: "github:1001",
+      source: "github-bot",
+    });
+
+    expect(triggerAutoRename).not.toHaveBeenCalled();
   });
 });

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -49,6 +49,12 @@ interface MessageQueueDeps {
   setSessionStatus: (status: SessionStatus) => Promise<void>;
   reconcileSessionStatusAfterExecution: (success: boolean) => Promise<void>;
   scheduleExecutionTimeout?: (startedAtMs: number) => Promise<void>;
+  /**
+   * Background task to auto-generate a session title from the first prompt.
+   * Called via ctx.waitUntil after the message is persisted. Receives the raw
+   * prompt content. Wired by SessionDO; absent in tests that don't exercise it.
+   */
+  triggerAutoRename?: (prompt: string) => Promise<void>;
 }
 
 interface StopExecutionOptions {
@@ -103,6 +109,8 @@ export class SessionMessageQueue {
       status: "pending",
       createdAt: now,
     });
+
+    this.maybeScheduleAutoRename(data.content);
 
     await this.deps.setSessionStatus("active");
 
@@ -329,6 +337,27 @@ export class SessionMessageQueue {
     this.deps.broadcast({ type: "sandbox_event", event: userMessageEvent });
   }
 
+  /**
+   * Schedule background auto-rename on the FIRST eligible prompt for a session.
+   * Skips if title was manually set or auto-rename was already attempted.
+   */
+  private maybeScheduleAutoRename(prompt: string): void {
+    if (!this.deps.triggerAutoRename) return;
+    const session = this.deps.getSession();
+    if (!session) return;
+    if (session.title_manually_set === 1) return;
+    if (session.title_auto_rename_attempted_at !== null) return;
+    const trigger = this.deps.triggerAutoRename;
+    this.deps.ctx.waitUntil(
+      trigger(prompt).catch((error) => {
+        this.deps.log.error("auto_rename.background_error", {
+          session_id: session.id,
+          error,
+        });
+      })
+    );
+  }
+
   async enqueuePromptFromApi(
     data: EnqueuePromptRequest
   ): Promise<{ messageId: string; status: "queued" }> {
@@ -390,6 +419,8 @@ export class SessionMessageQueue {
       status: "pending",
       createdAt: now,
     });
+
+    this.maybeScheduleAutoRename(data.content);
 
     await this.deps.setSessionStatus("active");
 

--- a/packages/control-plane/src/session/openai-token-refresh-service.test.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.test.ts
@@ -90,6 +90,8 @@ function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
     code_server_enabled: 0,
     total_cost: 0,
     sandbox_settings: null,
+    title_manually_set: 0,
+    title_auto_rename_attempted_at: null,
     created_at: 1,
     updated_at: 1,
     ...overrides,

--- a/packages/control-plane/src/session/pull-request-service.test.ts
+++ b/packages/control-plane/src/session/pull-request-service.test.ts
@@ -42,6 +42,8 @@ function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
     code_server_enabled: 0,
     total_cost: 0,
     sandbox_settings: null,
+    title_manually_set: 0,
+    title_auto_rename_attempted_at: null,
     created_at: 1,
     updated_at: 1,
     ...overrides,

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -283,6 +283,25 @@ export class SessionRepository {
     );
   }
 
+  markTitleManuallySet(sessionId: string, updatedAt: number): void {
+    this.sql.exec(
+      `UPDATE session SET title_manually_set = 1, updated_at = ? WHERE id = ?`,
+      updatedAt,
+      sessionId
+    );
+  }
+
+  // Intentionally does NOT touch updated_at — this marker is an internal
+  // one-shot guard for auto-rename, not a participant-visible session update,
+  // so it must not bump the row's activity timestamp.
+  markTitleAutoRenameAttempted(sessionId: string, attemptedAt: number): void {
+    this.sql.exec(
+      `UPDATE session SET title_auto_rename_attempted_at = ? WHERE id = ?`,
+      attemptedAt,
+      sessionId
+    );
+  }
+
   updateSessionStatus(sessionId: string, status: SessionStatus, updatedAt: number): void {
     this.sql.exec(
       `UPDATE session SET status = ?, updated_at = ? WHERE id = ?`,

--- a/packages/control-plane/src/session/schema.ts
+++ b/packages/control-plane/src/session/schema.ts
@@ -28,6 +28,8 @@ CREATE TABLE IF NOT EXISTS session (
   code_server_enabled INTEGER NOT NULL DEFAULT 0,   -- 0 = disabled, 1 = enabled (opt-in)
   total_cost REAL NOT NULL DEFAULT 0,              -- Running session cost from step_finish events
   sandbox_settings TEXT DEFAULT NULL,               -- JSON blob of SandboxSettings (resolved at session creation)
+  title_manually_set INTEGER NOT NULL DEFAULT 0, -- 1 once a participant has explicitly renamed via PATCH
+  title_auto_rename_attempted_at INTEGER,        -- Unix ms when auto-rename began (one-shot guard)
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL
 );
@@ -382,6 +384,16 @@ export const MIGRATIONS: readonly SchemaMigration[] = [
     id: 30,
     description: "Add total_cost to session",
     run: `ALTER TABLE session ADD COLUMN total_cost REAL NOT NULL DEFAULT 0`,
+  },
+  {
+    id: 31,
+    description: "Add title_manually_set to session",
+    run: `ALTER TABLE session ADD COLUMN title_manually_set INTEGER NOT NULL DEFAULT 0`,
+  },
+  {
+    id: 32,
+    description: "Add title_auto_rename_attempted_at to session",
+    run: `ALTER TABLE session ADD COLUMN title_auto_rename_attempted_at INTEGER`,
   },
 ];
 

--- a/packages/control-plane/src/session/services/session-titler.test.ts
+++ b/packages/control-plane/src/session/services/session-titler.test.ts
@@ -1,0 +1,422 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  derivePromptTitle,
+  generateTitle,
+  runAutoRename,
+  type AutoRenameDeps,
+  type TitlerClient,
+} from "./session-titler";
+import type { SessionRow } from "../types";
+
+describe("derivePromptTitle", () => {
+  it("uses first non-empty line of plain prompt with no prefix for user spawnSource", () => {
+    const out = derivePromptTitle("Fix the login bug\nRest of context here", "user");
+    expect(out).toBe("Fix the login bug");
+  });
+
+  it("prefixes GitHub: for github-bot spawn", () => {
+    const out = derivePromptTitle("Review PR #42 carefully", "github-bot");
+    expect(out).toBe("GitHub: Review PR #42 carefully");
+  });
+
+  it("prefixes Slack: for slack-bot spawn", () => {
+    const out = derivePromptTitle("Fix the deploy script", "slack-bot");
+    expect(out).toBe("Slack: Fix the deploy script");
+  });
+
+  it("prefixes Linear: for linear-bot spawn", () => {
+    const out = derivePromptTitle("Refactor session sidebar", "linear-bot");
+    expect(out).toBe("Linear: Refactor session sidebar");
+  });
+
+  it("strips markdown formatting characters", () => {
+    const out = derivePromptTitle("**Important**: fix `auth.ts` _now_", "user");
+    expect(out).toBe("Important: fix auth.ts now");
+  });
+
+  it("strips code fences", () => {
+    const out = derivePromptTitle("```\ncode here\n```\nFix the parser", "user");
+    expect(out).toBe("Fix the parser");
+  });
+
+  it("strips URLs", () => {
+    const out = derivePromptTitle("See https://example.com/foo for context, fix the bug", "user");
+    expect(out).toContain("fix the bug");
+    expect(out).not.toContain("https://");
+  });
+
+  it("collapses whitespace", () => {
+    const out = derivePromptTitle("Fix     the      bug", "user");
+    expect(out).toBe("Fix the bug");
+  });
+
+  it("truncates to <= 60 chars at word boundary with ellipsis when over 55", () => {
+    const long =
+      "This is a very long prompt that should definitely be truncated because it goes way over the limit";
+    const out = derivePromptTitle(long, "user");
+    expect(out.length).toBeLessThanOrEqual(60);
+    expect(out.endsWith("…")).toBe(true);
+    expect(out.slice(0, -1)).not.toMatch(/[a-z]$/i);
+  });
+
+  it("returns 'Untitled session' when prompt is entirely whitespace", () => {
+    expect(derivePromptTitle("   \n\t  ", "user")).toBe("Untitled session");
+  });
+
+  it("returns 'Untitled session' when prompt is only URLs", () => {
+    expect(derivePromptTitle("https://a.com https://b.com", "user")).toBe("Untitled session");
+  });
+
+  it("returns 'Untitled session' when prompt is only a code fence", () => {
+    expect(derivePromptTitle("```\njust code\n```", "user")).toBe("Untitled session");
+  });
+
+  it("does not exceed 60 chars even with a long github-bot prefix", () => {
+    const long = "a".repeat(200);
+    const out = derivePromptTitle(long, "github-bot");
+    expect(out.length).toBeLessThanOrEqual(60);
+    expect(out.startsWith("GitHub: ")).toBe(true);
+  });
+
+  it("returns 'Untitled session' literal even when spawnSource has a prefix and prompt is empty", () => {
+    expect(derivePromptTitle("   ", "github-bot")).toBe("Untitled session");
+  });
+
+  it("preserves > characters that are not at line start (comparisons, redirects)", () => {
+    expect(derivePromptTitle("Fix x > y comparison", "user")).toBe("Fix x > y comparison");
+    expect(derivePromptTitle("Use cmd > out.txt", "user")).toBe("Use cmd > out.txt");
+  });
+
+  it("preserves underscores in identifiers (snake_case)", () => {
+    expect(derivePromptTitle("Fix the my_var_name handling", "user")).toBe(
+      "Fix the my_var_name handling"
+    );
+  });
+
+  it("strips leading blockquote markers", () => {
+    expect(derivePromptTitle("> quote line\nFix the bug", "user")).toBe("quote line");
+  });
+});
+
+function makeMockClient(toolInput: unknown, content?: unknown): TitlerClient {
+  return {
+    messages: {
+      create: vi.fn().mockResolvedValue({
+        content: content ?? [{ type: "tool_use", name: "set_session_title", input: toolInput }],
+      }),
+    },
+  } as unknown as TitlerClient;
+}
+
+describe("generateTitle", () => {
+  it("returns the title from a well-formed tool_use block", async () => {
+    const client = makeMockClient({ title: "GitHub: Fix flaky tests" });
+    const out = await generateTitle({
+      client,
+      prompt: "Please fix the flaky tests",
+      spawnSource: "github-bot",
+    });
+    expect(out).toBe("GitHub: Fix flaky tests");
+  });
+
+  it("returns null when there is no tool_use block", async () => {
+    const client = makeMockClient(undefined, [{ type: "text", text: "I refuse" }]);
+    const out = await generateTitle({
+      client,
+      prompt: "Anything",
+      spawnSource: "user",
+    });
+    expect(out).toBeNull();
+  });
+
+  it("returns null when tool input is missing the title field", async () => {
+    const client = makeMockClient({});
+    const out = await generateTitle({
+      client,
+      prompt: "Anything",
+      spawnSource: "user",
+    });
+    expect(out).toBeNull();
+  });
+
+  it("returns null when title is empty/whitespace", async () => {
+    const client = makeMockClient({ title: "   " });
+    const out = await generateTitle({
+      client,
+      prompt: "Anything",
+      spawnSource: "user",
+    });
+    expect(out).toBeNull();
+  });
+
+  it("trims, collapses whitespace, and hard-truncates titles over 60 chars", async () => {
+    const client = makeMockClient({
+      title:
+        "  GitHub:    Fix  the  very    long  title that exceeds the maximum allowed length easily  ",
+    });
+    const out = await generateTitle({
+      client,
+      prompt: "Anything",
+      spawnSource: "github-bot",
+    });
+    expect(out).not.toBeNull();
+    expect(out!.length).toBeLessThanOrEqual(60);
+    expect(out!).toMatch(/^GitHub:/);
+  });
+
+  it("returns null when the underlying client throws (network error)", async () => {
+    const client = {
+      messages: {
+        create: vi.fn().mockRejectedValue(new Error("network")),
+      },
+    } as unknown as TitlerClient;
+    const out = await generateTitle({
+      client,
+      prompt: "Anything",
+      spawnSource: "user",
+    });
+    expect(out).toBeNull();
+  });
+
+  it("returns null when client is null (no API key configured)", async () => {
+    const out = await generateTitle({
+      client: null,
+      prompt: "Anything",
+      spawnSource: "user",
+    });
+    expect(out).toBeNull();
+  });
+});
+
+function baseSession(overrides: Partial<SessionRow> = {}): SessionRow {
+  return {
+    id: "session-1",
+    session_name: "session-public-1",
+    title: null,
+    repo_owner: "acme",
+    repo_name: "web",
+    repo_id: 1,
+    base_branch: "main",
+    branch_name: null,
+    base_sha: null,
+    current_sha: null,
+    opencode_session_id: null,
+    model: "anthropic/claude-haiku-4-5",
+    reasoning_effort: null,
+    status: "active",
+    parent_session_id: null,
+    spawn_source: "user",
+    spawn_depth: 0,
+    code_server_enabled: 0,
+    total_cost: 0,
+    sandbox_settings: null,
+    title_manually_set: 0,
+    title_auto_rename_attempted_at: null,
+    created_at: 1,
+    updated_at: 1,
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides: Partial<AutoRenameDeps> = {}): AutoRenameDeps {
+  return {
+    repository: {
+      getSession: vi.fn().mockReturnValue(baseSession()),
+      updateSessionTitle: vi.fn(),
+      markTitleAutoRenameAttempted: vi.fn(),
+    },
+    titler: vi.fn().mockResolvedValue("GitHub: Fix flaky tests"),
+    syncSessionIndexTitle: vi.fn(),
+    broadcast: vi.fn(),
+    getPublicSessionId: vi.fn().mockReturnValue("session-public-1"),
+    log: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(),
+    },
+    now: () => 12345,
+    ...overrides,
+  };
+}
+
+describe("runAutoRename", () => {
+  it("marks attempted before calling titler (so a crash mid-call doesn't retry)", async () => {
+    const calls: string[] = [];
+    const deps = makeDeps({
+      titler: vi.fn().mockImplementation(async () => {
+        calls.push("titler");
+        return "Some title";
+      }),
+      repository: {
+        getSession: vi.fn().mockReturnValue(baseSession()),
+        updateSessionTitle: vi.fn(),
+        markTitleAutoRenameAttempted: vi.fn().mockImplementation(() => calls.push("mark")),
+      },
+    });
+    await runAutoRename({ deps, prompt: "p" });
+    expect(calls.indexOf("mark")).toBeLessThan(calls.indexOf("titler"));
+  });
+
+  it("does nothing when title_manually_set is 1", async () => {
+    const deps = makeDeps({
+      repository: {
+        getSession: vi.fn().mockReturnValue(baseSession({ title_manually_set: 1 })),
+        updateSessionTitle: vi.fn(),
+        markTitleAutoRenameAttempted: vi.fn(),
+      },
+    });
+    await runAutoRename({ deps, prompt: "p" });
+    expect(deps.titler).not.toHaveBeenCalled();
+    expect(deps.repository.updateSessionTitle).not.toHaveBeenCalled();
+    expect(deps.repository.markTitleAutoRenameAttempted).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when title_auto_rename_attempted_at is set", async () => {
+    const deps = makeDeps({
+      repository: {
+        getSession: vi.fn().mockReturnValue(baseSession({ title_auto_rename_attempted_at: 1 })),
+        updateSessionTitle: vi.fn(),
+        markTitleAutoRenameAttempted: vi.fn(),
+      },
+    });
+    await runAutoRename({ deps, prompt: "p" });
+    expect(deps.titler).not.toHaveBeenCalled();
+    expect(deps.repository.updateSessionTitle).not.toHaveBeenCalled();
+  });
+
+  it("writes Haiku title when titler returns and existing title is null", async () => {
+    const deps = makeDeps({
+      titler: vi.fn().mockResolvedValue("GitHub: Fix flaky tests"),
+      repository: {
+        getSession: vi
+          .fn()
+          .mockReturnValueOnce(baseSession({ title: null }))
+          .mockReturnValueOnce(baseSession({ title: null })),
+        updateSessionTitle: vi.fn(),
+        markTitleAutoRenameAttempted: vi.fn(),
+      },
+    });
+    await runAutoRename({ deps, prompt: "fix the bug" });
+    expect(deps.repository.updateSessionTitle).toHaveBeenCalledWith(
+      "session-1",
+      "GitHub: Fix flaky tests",
+      12345
+    );
+    expect(deps.syncSessionIndexTitle).toHaveBeenCalledWith(
+      "session-public-1",
+      "GitHub: Fix flaky tests"
+    );
+    expect(deps.broadcast).toHaveBeenCalledWith({
+      type: "session_title",
+      title: "GitHub: Fix flaky tests",
+    });
+  });
+
+  it("writes Haiku title and overwrites a non-empty existing bot default", async () => {
+    const deps = makeDeps({
+      titler: vi.fn().mockResolvedValue("GitHub: Fix flaky tests"),
+      repository: {
+        getSession: vi
+          .fn()
+          .mockReturnValueOnce(baseSession({ title: "GitHub: Review PR #8" }))
+          .mockReturnValueOnce(baseSession({ title: "GitHub: Review PR #8" })),
+        updateSessionTitle: vi.fn(),
+        markTitleAutoRenameAttempted: vi.fn(),
+      },
+    });
+    await runAutoRename({ deps, prompt: "fix the bug" });
+    expect(deps.repository.updateSessionTitle).toHaveBeenCalledWith(
+      "session-1",
+      "GitHub: Fix flaky tests",
+      12345
+    );
+  });
+
+  it("falls back to derivePromptTitle when titler returns null AND existing title is null", async () => {
+    const deps = makeDeps({
+      titler: vi.fn().mockResolvedValue(null),
+      repository: {
+        getSession: vi
+          .fn()
+          .mockReturnValueOnce(baseSession({ title: null }))
+          .mockReturnValueOnce(baseSession({ title: null })),
+        updateSessionTitle: vi.fn(),
+        markTitleAutoRenameAttempted: vi.fn(),
+      },
+    });
+    await runAutoRename({ deps, prompt: "Add tests for the parser" });
+    const writtenTitle = (deps.repository.updateSessionTitle as ReturnType<typeof vi.fn>).mock
+      .calls[0][1];
+    expect(writtenTitle).toBe("Add tests for the parser");
+  });
+
+  it("preserves existing non-empty title when titler returns null (no downgrade)", async () => {
+    const deps = makeDeps({
+      titler: vi.fn().mockResolvedValue(null),
+      repository: {
+        getSession: vi
+          .fn()
+          .mockReturnValueOnce(baseSession({ title: "GitHub: Review PR #8" }))
+          .mockReturnValueOnce(baseSession({ title: "GitHub: Review PR #8" })),
+        updateSessionTitle: vi.fn(),
+        markTitleAutoRenameAttempted: vi.fn(),
+      },
+    });
+    await runAutoRename({ deps, prompt: "anything" });
+    expect(deps.repository.updateSessionTitle).not.toHaveBeenCalled();
+    expect(deps.broadcast).not.toHaveBeenCalled();
+  });
+
+  it("writes 'Untitled session' when titler null AND prompt is whitespace AND title null (the load-bearing invariant)", async () => {
+    const deps = makeDeps({
+      titler: vi.fn().mockResolvedValue(null),
+      repository: {
+        getSession: vi
+          .fn()
+          .mockReturnValueOnce(baseSession({ title: null }))
+          .mockReturnValueOnce(baseSession({ title: null })),
+        updateSessionTitle: vi.fn(),
+        markTitleAutoRenameAttempted: vi.fn(),
+      },
+    });
+    await runAutoRename({ deps, prompt: "   \n\t  " });
+    expect(deps.repository.updateSessionTitle).toHaveBeenCalledWith(
+      "session-1",
+      "Untitled session",
+      12345
+    );
+  });
+
+  it("re-checks title_manually_set after the Haiku call returns and skips the write if true", async () => {
+    let callCount = 0;
+    const deps = makeDeps({
+      titler: vi.fn().mockResolvedValue("Haiku title"),
+      repository: {
+        getSession: vi.fn().mockImplementation(() => {
+          callCount += 1;
+          if (callCount === 1) return baseSession({ title: null, title_manually_set: 0 });
+          return baseSession({ title: "User chose this", title_manually_set: 1 });
+        }),
+        updateSessionTitle: vi.fn(),
+        markTitleAutoRenameAttempted: vi.fn(),
+      },
+    });
+    await runAutoRename({ deps, prompt: "p" });
+    expect(deps.repository.updateSessionTitle).not.toHaveBeenCalled();
+  });
+
+  it("returns silently if session is missing on the pre-call read", async () => {
+    const deps = makeDeps({
+      repository: {
+        getSession: vi.fn().mockReturnValue(null),
+        updateSessionTitle: vi.fn(),
+        markTitleAutoRenameAttempted: vi.fn(),
+      },
+    });
+    await runAutoRename({ deps, prompt: "p" });
+    expect(deps.titler).not.toHaveBeenCalled();
+    expect(deps.repository.updateSessionTitle).not.toHaveBeenCalled();
+  });
+});

--- a/packages/control-plane/src/session/services/session-titler.ts
+++ b/packages/control-plane/src/session/services/session-titler.ts
@@ -1,0 +1,294 @@
+import type Anthropic from "@anthropic-ai/sdk";
+
+import type { Logger } from "../../logger";
+import type { SpawnSource } from "../../types";
+import type { SessionRow } from "../types";
+import type { ServerMessage } from "../../types";
+
+const MAX_TITLE_LENGTH = 60;
+const TARGET_TITLE_LENGTH = 55;
+const UNTITLED = "Untitled session";
+
+interface PrefixSpec {
+  prefix: string;
+}
+
+function getPrefixSpec(spawnSource: SpawnSource | string | null | undefined): PrefixSpec {
+  switch (spawnSource) {
+    case "github-bot":
+      return { prefix: "GitHub: " };
+    case "slack-bot":
+      return { prefix: "Slack: " };
+    case "linear-bot":
+      return { prefix: "Linear: " };
+    default:
+      return { prefix: "" };
+  }
+}
+
+function sanitizePromptForTitle(prompt: string): string {
+  let cleaned = prompt.replace(/```[\s\S]*?```/g, " ");
+  cleaned = cleaned.replace(/https?:\/\/\S+/gi, " ");
+  // Strip paired bold/italic asterisks: **bold**, *italic*
+  cleaned = cleaned.replace(/\*+([^*\n]+)\*+/g, "$1");
+  // Strip paired inline code: `code`
+  cleaned = cleaned.replace(/`+([^`\n]+)`+/g, "$1");
+  // Strip paired underscore emphasis only when bounded by non-identifier chars
+  // (preserves snake_case identifiers like my_var_name)
+  cleaned = cleaned.replace(/(^|\W)_+([^_\n]+?)_+(?=\W|$)/g, "$1$2");
+  // Strip blockquote markers ONLY at line start (preserves x > y, cmd > file)
+  cleaned = cleaned.replace(/^\s*>+\s?/gm, "");
+  const firstLine = cleaned
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  if (!firstLine) return "";
+  return firstLine.replace(/\s+/g, " ").trim();
+}
+
+function truncateAtWordBoundary(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  const slice = text.slice(0, maxLength);
+  const lastSpace = slice.lastIndexOf(" ");
+  if (lastSpace > maxLength * 0.5) {
+    // Cut at the word boundary and keep the trailing space so the ellipsis
+    // visibly follows a non-letter (signals the cut to the reader).
+    return slice.slice(0, lastSpace) + " …";
+  }
+  return slice.slice(0, maxLength) + "…";
+}
+
+/**
+ * Minimal interface describing what we use from the Anthropic SDK client.
+ * Modeled this way so tests can inject a mock without instantiating the real client.
+ */
+export interface TitlerClient {
+  messages: {
+    create: (
+      params: Anthropic.Messages.MessageCreateParamsNonStreaming
+    ) => Promise<Anthropic.Messages.Message>;
+  };
+}
+
+const SET_TITLE_TOOL_NAME = "set_session_title";
+const TITLER_MODEL = "claude-haiku-4-5";
+const TITLER_MAX_OUTPUT_TOKENS = 50;
+
+const SET_TITLE_TOOL: Anthropic.Messages.Tool = {
+  name: SET_TITLE_TOOL_NAME,
+  description:
+    "Set the display title for a coding-agent session, shown in the left sidebar. Title must be short and human-readable.",
+  input_schema: {
+    type: "object",
+    properties: {
+      title: {
+        type: "string",
+        description: `A 3-6 word topic summary. Total length must be at most ${TARGET_TITLE_LENGTH} characters. No trailing punctuation, no quotes, no emoji.`,
+      },
+    },
+    required: ["title"],
+    additionalProperties: false,
+  },
+};
+
+function buildPrefixInstruction(spawnSource: SpawnSource | string | null | undefined): string {
+  switch (spawnSource) {
+    case "github-bot":
+      return 'Output format: "GitHub: <topic>". Replace any "PR #N" placeholder with a real topic. Comments become "GitHub: <ask>".';
+    case "slack-bot":
+      return 'Output format: "Slack: <topic>".';
+    case "linear-bot":
+      return 'Output format: "Linear: <ticket-id> – <topic>" if a ticket ID like "ABC-123" is present in the prompt; otherwise "Linear: <topic>".';
+    default:
+      return "Output format: just the topic, no prefix.";
+  }
+}
+
+const SYSTEM_MESSAGE = `You are naming a coding-agent session for display in a left-hand sidebar.
+The user prompt is the first message they sent in this session.
+Pick a short topic that summarizes what the session is about — what the user wants to do, or what they want changed.
+Constraints:
+- Total length must be at most ${TARGET_TITLE_LENGTH} characters (hard ceiling ${MAX_TITLE_LENGTH}).
+- 3 to 6 words for the topic itself.
+- Sentence case is fine.
+- No trailing punctuation. No quotes. No emoji.
+- Do not include the user's name or repository name unless the user mentioned it explicitly in the prompt.
+You must respond by calling the ${SET_TITLE_TOOL_NAME} tool.`;
+
+interface GenerateTitleArgs {
+  client: TitlerClient | null;
+  prompt: string;
+  spawnSource: SpawnSource | string | null | undefined;
+}
+
+function sanitizeModelTitle(raw: string): string {
+  const collapsed = raw.replace(/\s+/g, " ").trim();
+  if (collapsed.length === 0) return "";
+  if (collapsed.length <= MAX_TITLE_LENGTH) return collapsed;
+  return collapsed.slice(0, MAX_TITLE_LENGTH);
+}
+
+/**
+ * Call Haiku to produce a session title. Returns null on any failure path
+ * (network error, no client, malformed tool result, empty title, etc).
+ */
+export async function generateTitle(args: GenerateTitleArgs): Promise<string | null> {
+  if (!args.client) return null;
+
+  const userMessage = `${buildPrefixInstruction(args.spawnSource)}
+
+User prompt:
+${args.prompt}`;
+
+  try {
+    const response = await args.client.messages.create({
+      model: TITLER_MODEL,
+      max_tokens: TITLER_MAX_OUTPUT_TOKENS,
+      temperature: 0,
+      system: SYSTEM_MESSAGE,
+      tools: [SET_TITLE_TOOL],
+      tool_choice: {
+        type: "tool",
+        name: SET_TITLE_TOOL_NAME,
+        disable_parallel_tool_use: true,
+      },
+      messages: [{ role: "user", content: userMessage }],
+    });
+
+    const toolBlock = response.content.find(
+      (block): block is Anthropic.Messages.ToolUseBlock =>
+        block.type === "tool_use" && block.name === SET_TITLE_TOOL_NAME
+    );
+    if (!toolBlock) return null;
+
+    const input = toolBlock.input as { title?: unknown } | undefined;
+    if (!input || typeof input.title !== "string") return null;
+
+    const sanitized = sanitizeModelTitle(input.title);
+    return sanitized.length > 0 ? sanitized : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a deterministic, non-empty title from a prompt.
+ * Guarantees: returns a non-empty string of at most MAX_TITLE_LENGTH characters,
+ * with the appropriate source prefix for the spawnSource. If sanitization yields
+ * nothing, returns the literal "Untitled session".
+ */
+export function derivePromptTitle(
+  prompt: string,
+  spawnSource: SpawnSource | string | null | undefined
+): string {
+  const sanitized = sanitizePromptForTitle(prompt);
+  const { prefix } = getPrefixSpec(spawnSource);
+
+  if (sanitized.length === 0) {
+    return UNTITLED;
+  }
+
+  const budget = TARGET_TITLE_LENGTH - prefix.length;
+  if (budget <= 0) {
+    return UNTITLED;
+  }
+
+  const truncated = truncateAtWordBoundary(sanitized, budget);
+  const candidate = prefix + truncated;
+
+  if (candidate.length > MAX_TITLE_LENGTH) {
+    return candidate.slice(0, MAX_TITLE_LENGTH - 1) + "…";
+  }
+
+  return candidate;
+}
+
+export interface AutoRenameDeps {
+  repository: {
+    getSession: () => SessionRow | null;
+    updateSessionTitle: (sessionId: string, title: string, updatedAt: number) => void;
+    markTitleAutoRenameAttempted: (sessionId: string, attemptedAt: number) => void;
+  };
+  /** Returns a non-empty title, or null on any failure (network, malformed, empty). */
+  titler: (args: {
+    prompt: string;
+    spawnSource: SpawnSource | string | null | undefined;
+  }) => Promise<string | null>;
+  syncSessionIndexTitle: (publicSessionId: string, title: string) => void;
+  broadcast: (message: ServerMessage) => void;
+  getPublicSessionId: (session: SessionRow) => string;
+  log: Logger;
+  now: () => number;
+}
+
+interface RunAutoRenameArgs {
+  deps: AutoRenameDeps;
+  prompt: string;
+}
+
+/**
+ * Background task that produces and applies an auto-generated session title.
+ *
+ * Invariants:
+ * - title_manually_set wins. If a participant has explicitly renamed the session,
+ *   no auto-rename ever overwrites them.
+ * - One-shot. The marker `title_auto_rename_attempted_at` is set BEFORE the LLM
+ *   call so a worker crash mid-call does not cause a second attempt on the next
+ *   prompt.
+ * - No nameless session. If the titler returns null AND the existing title is
+ *   null/empty, we fall back to a deterministic prompt-derived title; if that
+ *   also yields nothing, we write the literal "Untitled session".
+ */
+export async function runAutoRename({ deps, prompt }: RunAutoRenameArgs): Promise<void> {
+  const session = deps.repository.getSession();
+  if (!session) return;
+
+  if (session.title_manually_set === 1) {
+    deps.log.debug("auto_rename.skip", { reason: "title_manually_set", session_id: session.id });
+    return;
+  }
+  if (session.title_auto_rename_attempted_at !== null) {
+    deps.log.debug("auto_rename.skip", { reason: "already_attempted", session_id: session.id });
+    return;
+  }
+
+  deps.repository.markTitleAutoRenameAttempted(session.id, deps.now());
+
+  const haikuTitle = await deps.titler({ prompt, spawnSource: session.spawn_source });
+
+  const fresh = deps.repository.getSession();
+  if (!fresh) return;
+  if (fresh.title_manually_set === 1) {
+    deps.log.info("auto_rename.skip_post_call", {
+      reason: "title_manually_set_during_call",
+      session_id: fresh.id,
+    });
+    return;
+  }
+
+  const existing = fresh.title?.trim() ?? "";
+  const existingIsEmpty = existing.length === 0;
+
+  let finalTitle: string;
+  if (haikuTitle && haikuTitle.trim().length > 0) {
+    finalTitle = haikuTitle;
+  } else if (existingIsEmpty) {
+    finalTitle = derivePromptTitle(prompt, fresh.spawn_source);
+  } else {
+    deps.log.info("auto_rename.preserve_existing", {
+      session_id: fresh.id,
+      existing_title: existing,
+    });
+    return;
+  }
+
+  deps.repository.updateSessionTitle(fresh.id, finalTitle, deps.now());
+  deps.syncSessionIndexTitle(deps.getPublicSessionId(fresh), finalTitle);
+  deps.broadcast({ type: "session_title", title: finalTitle });
+
+  deps.log.info("auto_rename.applied", {
+    session_id: fresh.id,
+    used_haiku: haikuTitle !== null,
+    final_title: finalTitle,
+  });
+}

--- a/packages/control-plane/src/session/types.ts
+++ b/packages/control-plane/src/session/types.ts
@@ -39,6 +39,8 @@ export interface SessionRow {
   code_server_enabled: number; // 0 = disabled (default), 1 = enabled
   total_cost: number; // Running aggregate of step_finish event costs
   sandbox_settings: string | null; // JSON blob of SandboxSettings
+  title_manually_set: number; // 0 or 1
+  title_auto_rename_attempted_at: number | null;
   created_at: number;
   updated_at: number;
 }

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -62,6 +62,7 @@ export interface Env {
   MODAL_API_SECRET?: string; // Shared secret for authenticating with Modal endpoints
   DAYTONA_API_KEY?: string; // Daytona REST API key (Bearer auth + HMAC derivation)
   INTERNAL_CALLBACK_SECRET?: string; // For signing callbacks to slack-bot
+  ANTHROPIC_API_KEY?: string; // For session auto-rename via Claude Haiku
   SLACK_BOT_TOKEN?: string; // Slack bot token for agent-initiated chat.postMessage calls
 
   // GitHub App secrets (for git operations)

--- a/packages/control-plane/test/integration/session-auto-rename.test.ts
+++ b/packages/control-plane/test/integration/session-auto-rename.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import { env, runInDurableObject } from "cloudflare:test";
+import { initSession, initNamedSession, openClientWs, collectMessages, queryDO } from "./helpers";
+import type { SessionDO } from "../../src/session/durable-object";
+
+async function waitForAutoRename(stub: DurableObjectStub, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const rows = await queryDO<{
+      title_auto_rename_attempted_at: number | null;
+      title: string | null;
+    }>(stub, `SELECT title, title_auto_rename_attempted_at FROM session LIMIT 1`);
+    if (rows[0]?.title_auto_rename_attempted_at !== null) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error("Auto-rename did not run within timeout");
+}
+
+describe("session auto-rename (integration)", () => {
+  it("requires ANTHROPIC_API_KEY to be unset for this suite", () => {
+    expect(env.ANTHROPIC_API_KEY).toBeFalsy();
+  });
+
+  it("writes a non-empty title for a web-initiated session via deterministic fallback (no API key)", async () => {
+    // env.ANTHROPIC_API_KEY is unset in the integration env, so the titler
+    // returns null and we exercise the derivePromptTitle path.
+    const { stub } = await initSession();
+
+    // Clear any default title that initSession might have set so we exercise
+    // the "existing title null" branch explicitly.
+    await runInDurableObject(stub, (instance: SessionDO) => {
+      instance.ctx.storage.sql.exec(
+        `UPDATE session SET title = NULL WHERE id = (SELECT id FROM session LIMIT 1)`
+      );
+    });
+
+    const res = await stub.fetch("http://internal/internal/prompt", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        content: "Refactor the session sidebar layout",
+        authorId: "user-1",
+        source: "web",
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    await waitForAutoRename(stub);
+
+    const rows = await queryDO<{
+      title: string | null;
+      title_auto_rename_attempted_at: number | null;
+    }>(stub, `SELECT title, title_auto_rename_attempted_at FROM session LIMIT 1`);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].title_auto_rename_attempted_at).not.toBeNull();
+    expect(rows[0].title).not.toBeNull();
+    expect(rows[0].title!.length).toBeGreaterThan(0);
+    // "user" spawnSource → no prefix
+    expect(rows[0].title).toBe("Refactor the session sidebar layout");
+  });
+
+  it("does not auto-rename when title_manually_set is 1", async () => {
+    const { stub } = await initSession({ title: "User Chose This" });
+
+    // Simulate the user's manual rename PATCH having already happened.
+    await runInDurableObject(stub, (instance: SessionDO) => {
+      instance.ctx.storage.sql.exec(
+        `UPDATE session SET title_manually_set = 1, title = ? WHERE id = (SELECT id FROM session LIMIT 1)`,
+        "User Chose This"
+      );
+    });
+
+    await stub.fetch("http://internal/internal/prompt", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "Anything", authorId: "user-1", source: "web" }),
+    });
+
+    // Give the would-be-background-task time to NOT run.
+    await new Promise((r) => setTimeout(r, 200));
+
+    const rows = await queryDO<{
+      title: string | null;
+      title_auto_rename_attempted_at: number | null;
+    }>(stub, `SELECT title, title_auto_rename_attempted_at FROM session LIMIT 1`);
+    expect(rows[0].title).toBe("User Chose This");
+    expect(rows[0].title_auto_rename_attempted_at).toBeNull();
+  });
+
+  it("falls back to 'Untitled session' when prompt is whitespace AND existing title is empty", async () => {
+    const { stub } = await initSession();
+    await runInDurableObject(stub, (instance: SessionDO) => {
+      instance.ctx.storage.sql.exec(
+        `UPDATE session SET title = NULL WHERE id = (SELECT id FROM session LIMIT 1)`
+      );
+    });
+
+    await stub.fetch("http://internal/internal/prompt", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: "   \n\t  ", authorId: "user-1", source: "web" }),
+    });
+
+    await waitForAutoRename(stub);
+
+    const rows = await queryDO<{ title: string | null }>(stub, `SELECT title FROM session LIMIT 1`);
+    expect(rows[0].title).toBe("Untitled session");
+  });
+
+  it("only triggers once even if multiple prompts arrive quickly", async () => {
+    const { stub } = await initSession();
+    await runInDurableObject(stub, (instance: SessionDO) => {
+      instance.ctx.storage.sql.exec(
+        `UPDATE session SET title = NULL WHERE id = (SELECT id FROM session LIMIT 1)`
+      );
+    });
+
+    await Promise.all([
+      stub.fetch("http://internal/internal/prompt", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: "First prompt", authorId: "user-1", source: "web" }),
+      }),
+      stub.fetch("http://internal/internal/prompt", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: "Second prompt", authorId: "user-1", source: "web" }),
+      }),
+    ]);
+
+    await waitForAutoRename(stub);
+
+    // Either the first or the second won the race, but the title should be set
+    // and the attempted marker should be set.
+    const rows = await queryDO<{
+      title: string | null;
+      title_auto_rename_attempted_at: number | null;
+    }>(stub, `SELECT title, title_auto_rename_attempted_at FROM session LIMIT 1`);
+    expect(rows[0].title_auto_rename_attempted_at).not.toBeNull();
+    expect(rows[0].title).toMatch(/(First prompt|Second prompt)/);
+  });
+
+  it("broadcasts session_title to subscribed clients after auto-rename completes", async () => {
+    const sessionName = `auto-rename-broadcast-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const { stub } = await initNamedSession(sessionName);
+    // Ensure existing title is null so the fallback path writes a title.
+    await runInDurableObject(stub, (instance: SessionDO) => {
+      instance.ctx.storage.sql.exec(
+        `UPDATE session SET title = NULL WHERE id = (SELECT id FROM session LIMIT 1)`
+      );
+    });
+
+    // Subscribe a client BEFORE enqueueing the prompt so we capture the broadcast.
+    const { ws } = await openClientWs(sessionName, { subscribe: true, userId: "user-1" });
+
+    // Start collecting AFTER subscribe completes — wait specifically for session_title.
+    const collector = collectMessages(ws, {
+      until: (msg) => msg.type === "session_title",
+      timeoutMs: 3000,
+    });
+
+    const res = await stub.fetch("http://internal/internal/prompt", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        content: "Refactor the session sidebar layout",
+        authorId: "user-1",
+        source: "web",
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    const messages = await collector;
+    const titleMessage = messages.find((m) => m.type === "session_title");
+    expect(titleMessage).toBeDefined();
+    expect(titleMessage!.title).toBe("Refactor the session sidebar layout");
+  });
+});

--- a/packages/control-plane/test/integration/session-auto-rename.test.ts
+++ b/packages/control-plane/test/integration/session-auto-rename.test.ts
@@ -138,10 +138,15 @@ describe("session auto-rename (integration)", () => {
       );
     });
 
-    // Subscribe BEFORE both prompts. Collect for a bounded window so we can verify
-    // exactly one session_title broadcast fires (no early-exit via `until`).
+    // Two-phase wait: (a) wait up to AUTO_RENAME_TIMEOUT_MS for the FIRST session_title
+    // broadcast so we never time out before the (background) rename fires; (b) then collect
+    // for a short tail window to assert no SECOND broadcast — that's what proves
+    // "only triggers once."
     const { ws } = await openClientWs(sessionName, { subscribe: true, userId: "user-1" });
-    const collector = collectMessages(ws, { timeoutMs: NO_BROADCAST_WAIT_MS });
+    const firstCollector = collectMessages(ws, {
+      until: (msg) => msg.type === "session_title",
+      timeoutMs: AUTO_RENAME_TIMEOUT_MS,
+    });
 
     await Promise.all([
       stub.fetch("http://internal/internal/prompt", {
@@ -156,10 +161,14 @@ describe("session auto-rename (integration)", () => {
       }),
     ]);
 
-    const messages = await collector;
-    const titleMessages = messages.filter((m) => m.type === "session_title");
-    expect(titleMessages).toHaveLength(1);
-    expect(titleMessages[0].title).toMatch(/(First prompt|Second prompt)/);
+    const firstMessages = await firstCollector;
+    const firstTitleMessages = firstMessages.filter((m) => m.type === "session_title");
+    expect(firstTitleMessages).toHaveLength(1);
+    expect(firstTitleMessages[0].title).toMatch(/(First prompt|Second prompt)/);
+
+    // Tail: no second broadcast should follow.
+    const tailMessages = await collectMessages(ws, { timeoutMs: NO_BROADCAST_WAIT_MS });
+    expect(tailMessages.some((m) => m.type === "session_title")).toBe(false);
 
     const rows = await queryDO<{
       title: string | null;

--- a/packages/control-plane/test/integration/session-auto-rename.test.ts
+++ b/packages/control-plane/test/integration/session-auto-rename.test.ts
@@ -140,6 +140,36 @@ describe("session auto-rename (integration)", () => {
     expect(rows[0].title).toMatch(/(First prompt|Second prompt)/);
   });
 
+  it("subscribed state reflects a title committed during the subscribe handshake", async () => {
+    // Regression: the auto-rename runs in ctx.waitUntil and, after the Haiku
+    // network call returns, commits a new title and broadcasts session_title.
+    // If that commit lands after `getSessionState` captures its title snapshot
+    // but before `subscribed` is sent, the subscribed payload would ship with
+    // a stale (null) title and the client had nothing to fall back to. The fix
+    // re-reads the latest title from SQLite right before sending. We simulate
+    // the committed-mid-handshake state by writing the title directly via
+    // runInDurableObject (the same synchronous SQLite write the auto-rename
+    // tail performs) and then subscribing.
+    const sessionName = `auto-rename-handshake-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const { stub } = await initNamedSession(sessionName);
+
+    await runInDurableObject(stub, (instance: SessionDO) => {
+      instance.ctx.storage.sql.exec(
+        `UPDATE session SET title = ? WHERE id = (SELECT id FROM session LIMIT 1)`,
+        "Late-committed title"
+      );
+    });
+
+    const { messages } = await openClientWs(sessionName, {
+      subscribe: true,
+      userId: "user-1",
+    });
+    const subscribed = messages.find((m) => m.type === "subscribed") as
+      | { state?: { title?: string | null } }
+      | undefined;
+    expect(subscribed?.state?.title).toBe("Late-committed title");
+  });
+
   it("broadcasts session_title to subscribed clients after auto-rename completes", async () => {
     const sessionName = `auto-rename-broadcast-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const { stub } = await initNamedSession(sessionName);

--- a/packages/control-plane/test/integration/session-auto-rename.test.ts
+++ b/packages/control-plane/test/integration/session-auto-rename.test.ts
@@ -3,15 +3,31 @@ import { env, runInDurableObject } from "cloudflare:test";
 import { initSession, initNamedSession, openClientWs, collectMessages, queryDO } from "./helpers";
 import type { SessionDO } from "../../src/session/durable-object";
 
-async function waitForAutoRename(stub: DurableObjectStub, timeoutMs = 3000): Promise<void> {
+const AUTO_RENAME_TIMEOUT_MS = 3000;
+const AUTO_RENAME_POLL_INTERVAL_MS = 25;
+// runAutoRename writes title_auto_rename_attempted_at BEFORE awaiting the titler call and
+// writing the final title — wait for both so downstream title assertions don't race.
+const BACKGROUND_SETTLE_WAIT_MS = 200;
+
+async function waitForAutoRename(
+  stub: DurableObjectStub,
+  timeoutMs = AUTO_RENAME_TIMEOUT_MS
+): Promise<void> {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     const rows = await queryDO<{
       title_auto_rename_attempted_at: number | null;
       title: string | null;
     }>(stub, `SELECT title, title_auto_rename_attempted_at FROM session LIMIT 1`);
-    if (rows[0]?.title_auto_rename_attempted_at !== null) return;
-    await new Promise((r) => setTimeout(r, 25));
+    const row = rows[0];
+    if (
+      row?.title_auto_rename_attempted_at !== null &&
+      typeof row?.title === "string" &&
+      row.title.trim().length > 0
+    ) {
+      return;
+    }
+    await new Promise((r) => setTimeout(r, AUTO_RENAME_POLL_INTERVAL_MS));
   }
   throw new Error("Auto-rename did not run within timeout");
 }
@@ -77,7 +93,7 @@ describe("session auto-rename (integration)", () => {
     });
 
     // Give the would-be-background-task time to NOT run.
-    await new Promise((r) => setTimeout(r, 200));
+    await new Promise((r) => setTimeout(r, BACKGROUND_SETTLE_WAIT_MS));
 
     const rows = await queryDO<{
       title: string | null;
@@ -186,7 +202,7 @@ describe("session auto-rename (integration)", () => {
     // Start collecting AFTER subscribe completes — wait specifically for session_title.
     const collector = collectMessages(ws, {
       until: (msg) => msg.type === "session_title",
-      timeoutMs: 3000,
+      timeoutMs: AUTO_RENAME_TIMEOUT_MS,
     });
 
     const res = await stub.fetch("http://internal/internal/prompt", {

--- a/packages/control-plane/test/integration/session-auto-rename.test.ts
+++ b/packages/control-plane/test/integration/session-auto-rename.test.ts
@@ -1,35 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { env, runInDurableObject } from "cloudflare:test";
-import { initSession, initNamedSession, openClientWs, collectMessages, queryDO } from "./helpers";
+import { initNamedSession, openClientWs, collectMessages, queryDO } from "./helpers";
 import type { SessionDO } from "../../src/session/durable-object";
 
 const AUTO_RENAME_TIMEOUT_MS = 3000;
-const AUTO_RENAME_POLL_INTERVAL_MS = 25;
-// runAutoRename writes title_auto_rename_attempted_at BEFORE awaiting the titler call and
-// writing the final title — wait for both so downstream title assertions don't race.
-const BACKGROUND_SETTLE_WAIT_MS = 200;
+// Bounded wait for the negative case to assert no background auto-rename fired.
+// Not polling — a single setTimeout sufficient to surface an erroneously-scheduled write.
+const NO_BROADCAST_WAIT_MS = 200;
 
-async function waitForAutoRename(
-  stub: DurableObjectStub,
-  timeoutMs = AUTO_RENAME_TIMEOUT_MS
-): Promise<void> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    const rows = await queryDO<{
-      title_auto_rename_attempted_at: number | null;
-      title: string | null;
-    }>(stub, `SELECT title, title_auto_rename_attempted_at FROM session LIMIT 1`);
-    const row = rows[0];
-    if (
-      row?.title_auto_rename_attempted_at !== null &&
-      typeof row?.title === "string" &&
-      row.title.trim().length > 0
-    ) {
-      return;
-    }
-    await new Promise((r) => setTimeout(r, AUTO_RENAME_POLL_INTERVAL_MS));
-  }
-  throw new Error("Auto-rename did not run within timeout");
+function uniqueSessionName(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
 describe("session auto-rename (integration)", () => {
@@ -40,14 +20,23 @@ describe("session auto-rename (integration)", () => {
   it("writes a non-empty title for a web-initiated session via deterministic fallback (no API key)", async () => {
     // env.ANTHROPIC_API_KEY is unset in the integration env, so the titler
     // returns null and we exercise the derivePromptTitle path.
-    const { stub } = await initSession();
+    const sessionName = uniqueSessionName("auto-rename-fallback");
+    const { stub } = await initNamedSession(sessionName);
 
-    // Clear any default title that initSession might have set so we exercise
-    // the "existing title null" branch explicitly.
+    // Clear any default title so we exercise the "existing title null" branch explicitly.
     await runInDurableObject(stub, (instance: SessionDO) => {
       instance.ctx.storage.sql.exec(
         `UPDATE session SET title = NULL WHERE id = (SELECT id FROM session LIMIT 1)`
       );
+    });
+
+    // Subscribe BEFORE sending the prompt so we capture the session_title broadcast.
+    // runAutoRename broadcasts session_title AFTER persisting the title, so receiving
+    // the broadcast is a deterministic signal that the title write is complete — no polling.
+    const { ws } = await openClientWs(sessionName, { subscribe: true, userId: "user-1" });
+    const collector = collectMessages(ws, {
+      until: (msg) => msg.type === "session_title",
+      timeoutMs: AUTO_RENAME_TIMEOUT_MS,
     });
 
     const res = await stub.fetch("http://internal/internal/prompt", {
@@ -61,7 +50,11 @@ describe("session auto-rename (integration)", () => {
     });
     expect(res.status).toBe(200);
 
-    await waitForAutoRename(stub);
+    const messages = await collector;
+    const titleMessage = messages.find((m) => m.type === "session_title");
+    expect(titleMessage).toBeDefined();
+    // "user" spawnSource → no prefix
+    expect(titleMessage!.title).toBe("Refactor the session sidebar layout");
 
     const rows = await queryDO<{
       title: string | null;
@@ -69,14 +62,12 @@ describe("session auto-rename (integration)", () => {
     }>(stub, `SELECT title, title_auto_rename_attempted_at FROM session LIMIT 1`);
     expect(rows).toHaveLength(1);
     expect(rows[0].title_auto_rename_attempted_at).not.toBeNull();
-    expect(rows[0].title).not.toBeNull();
-    expect(rows[0].title!.length).toBeGreaterThan(0);
-    // "user" spawnSource → no prefix
     expect(rows[0].title).toBe("Refactor the session sidebar layout");
   });
 
   it("does not auto-rename when title_manually_set is 1", async () => {
-    const { stub } = await initSession({ title: "User Chose This" });
+    const sessionName = uniqueSessionName("auto-rename-manual");
+    const { stub } = await initNamedSession(sessionName, { title: "User Chose This" });
 
     // Simulate the user's manual rename PATCH having already happened.
     await runInDurableObject(stub, (instance: SessionDO) => {
@@ -86,14 +77,20 @@ describe("session auto-rename (integration)", () => {
       );
     });
 
+    // Subscribe and collect for a bounded window — assert no session_title broadcast
+    // arrives. maybeScheduleAutoRename returns synchronously without ctx.waitUntil when
+    // title_manually_set is 1, but we collect over a window to surface any regression.
+    const { ws } = await openClientWs(sessionName, { subscribe: true, userId: "user-1" });
+    const collector = collectMessages(ws, { timeoutMs: NO_BROADCAST_WAIT_MS });
+
     await stub.fetch("http://internal/internal/prompt", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ content: "Anything", authorId: "user-1", source: "web" }),
     });
 
-    // Give the would-be-background-task time to NOT run.
-    await new Promise((r) => setTimeout(r, BACKGROUND_SETTLE_WAIT_MS));
+    const messages = await collector;
+    expect(messages.some((m) => m.type === "session_title")).toBe(false);
 
     const rows = await queryDO<{
       title: string | null;
@@ -104,11 +101,18 @@ describe("session auto-rename (integration)", () => {
   });
 
   it("falls back to 'Untitled session' when prompt is whitespace AND existing title is empty", async () => {
-    const { stub } = await initSession();
+    const sessionName = uniqueSessionName("auto-rename-whitespace");
+    const { stub } = await initNamedSession(sessionName);
     await runInDurableObject(stub, (instance: SessionDO) => {
       instance.ctx.storage.sql.exec(
         `UPDATE session SET title = NULL WHERE id = (SELECT id FROM session LIMIT 1)`
       );
+    });
+
+    const { ws } = await openClientWs(sessionName, { subscribe: true, userId: "user-1" });
+    const collector = collectMessages(ws, {
+      until: (msg) => msg.type === "session_title",
+      timeoutMs: AUTO_RENAME_TIMEOUT_MS,
     });
 
     await stub.fetch("http://internal/internal/prompt", {
@@ -117,19 +121,27 @@ describe("session auto-rename (integration)", () => {
       body: JSON.stringify({ content: "   \n\t  ", authorId: "user-1", source: "web" }),
     });
 
-    await waitForAutoRename(stub);
+    const messages = await collector;
+    const titleMessage = messages.find((m) => m.type === "session_title");
+    expect(titleMessage?.title).toBe("Untitled session");
 
     const rows = await queryDO<{ title: string | null }>(stub, `SELECT title FROM session LIMIT 1`);
     expect(rows[0].title).toBe("Untitled session");
   });
 
   it("only triggers once even if multiple prompts arrive quickly", async () => {
-    const { stub } = await initSession();
+    const sessionName = uniqueSessionName("auto-rename-once");
+    const { stub } = await initNamedSession(sessionName);
     await runInDurableObject(stub, (instance: SessionDO) => {
       instance.ctx.storage.sql.exec(
         `UPDATE session SET title = NULL WHERE id = (SELECT id FROM session LIMIT 1)`
       );
     });
+
+    // Subscribe BEFORE both prompts. Collect for a bounded window so we can verify
+    // exactly one session_title broadcast fires (no early-exit via `until`).
+    const { ws } = await openClientWs(sessionName, { subscribe: true, userId: "user-1" });
+    const collector = collectMessages(ws, { timeoutMs: NO_BROADCAST_WAIT_MS });
 
     await Promise.all([
       stub.fetch("http://internal/internal/prompt", {
@@ -144,10 +156,11 @@ describe("session auto-rename (integration)", () => {
       }),
     ]);
 
-    await waitForAutoRename(stub);
+    const messages = await collector;
+    const titleMessages = messages.filter((m) => m.type === "session_title");
+    expect(titleMessages).toHaveLength(1);
+    expect(titleMessages[0].title).toMatch(/(First prompt|Second prompt)/);
 
-    // Either the first or the second won the race, but the title should be set
-    // and the attempted marker should be set.
     const rows = await queryDO<{
       title: string | null;
       title_auto_rename_attempted_at: number | null;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -41,6 +41,17 @@ export type EventType =
   | "push_error"
   | "user_message";
 export type ParticipantRole = "owner" | "member";
+/**
+ * Origin of a session. Drives the auto-rename sidebar prefix in the
+ * control-plane session-titler.
+ *
+ * When adding a new bot integration (e.g. `"jira-bot"`, `"clickup-bot"`), also
+ * update both prefix maps in
+ * `packages/control-plane/src/session/services/session-titler.ts`:
+ *   - `getPrefixSpec`         — deterministic fallback prefix (e.g. `"Jira: "`)
+ *   - `buildPrefixInstruction` — Haiku prompt instruction for the same prefix
+ * Otherwise sessions from the new integration end up with no prefix.
+ */
 export type SpawnSource =
   | "user"
   | "agent"

--- a/packages/web/src/hooks/use-session-socket.test.tsx
+++ b/packages/web/src/hooks/use-session-socket.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ServerMessage, SessionArtifact, SessionState } from "@open-inspect/shared";
 import type * as SwrModule from "swr";
+import { SIDEBAR_SESSIONS_KEY, type SessionListResponse } from "@/lib/session-list";
 import { useSessionSocket } from "./use-session-socket";
 
 const { mutateMock } = vi.hoisted(() => ({
@@ -497,6 +498,8 @@ describe("useSessionSocket", () => {
       expect(result.current.sessionState?.title).toBe("Session 1");
     });
 
+    mutateMock.mockClear();
+
     act(() => {
       socket.receive({ type: "session_title", title: "Refreshed title" });
     });
@@ -504,5 +507,74 @@ describe("useSessionSocket", () => {
     await waitFor(() => {
       expect(result.current.sessionState?.title).toBe("Refreshed title");
     });
+
+    // Regression: the auto-rename title must also flow into the sidebar SWR
+    // cache so the session list updates in lockstep with the detail header.
+    // Without this, the sidebar stayed stale until an unrelated event
+    // (e.g. session_status) happened to revalidate the list.
+    const titleCalls = mutateMock.mock.calls.filter(([key]) => key === SIDEBAR_SESSIONS_KEY);
+    expect(titleCalls).toHaveLength(1);
+    const [, updater, options] = titleCalls[0];
+    expect(options).toMatchObject({ revalidate: false });
+    const updated = (updater as (data: SessionListResponse | undefined) => SessionListResponse)({
+      sessions: [
+        {
+          id: "session-1",
+          title: "Session 1",
+          repoOwner: "acme",
+          repoName: "web-app",
+          createdAt: 1,
+          updatedAt: 1,
+        } as SessionListResponse["sessions"][number],
+      ],
+      hasMore: false,
+    });
+    expect(updated.sessions[0].title).toBe("Refreshed title");
+  });
+
+  it("mutates the sidebar cache when a buffered session_title is applied via subscribe", async () => {
+    const { result } = renderHook(() => useSessionSocket("session-1"));
+
+    await waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
+
+    const socket = FakeWebSocket.instances[0];
+    act(() => {
+      socket.open();
+      socket.receive({ type: "session_title", title: "Auto-named topic" });
+    });
+
+    expect(mutateMock.mock.calls.filter(([key]) => key === SIDEBAR_SESSIONS_KEY)).toHaveLength(0);
+
+    act(() => {
+      socket.receive(createSubscribedMessage());
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionState?.title).toBe("Auto-named topic");
+    });
+
+    // The buffered title must also be mirrored to the sidebar cache when it
+    // is finally applied on subscribe — same reasoning as the post-subscribed
+    // case above.
+    const titleCalls = mutateMock.mock.calls.filter(([key]) => key === SIDEBAR_SESSIONS_KEY);
+    expect(titleCalls).toHaveLength(1);
+    const [, updater, options] = titleCalls[0];
+    expect(options).toMatchObject({ revalidate: false });
+    const updated = (updater as (data: SessionListResponse | undefined) => SessionListResponse)({
+      sessions: [
+        {
+          id: "session-1",
+          title: "Session 1",
+          repoOwner: "acme",
+          repoName: "web-app",
+          createdAt: 1,
+          updatedAt: 1,
+        } as SessionListResponse["sessions"][number],
+      ],
+      hasMore: false,
+    });
+    expect(updated.sessions[0].title).toBe("Auto-named topic");
   });
 });

--- a/packages/web/src/hooks/use-session-socket.test.tsx
+++ b/packages/web/src/hooks/use-session-socket.test.tsx
@@ -41,9 +41,9 @@ class FakeWebSocket {
     this.sentMessages.push(JSON.parse(data) as Record<string, unknown>);
   }
 
-  close(code = 1000, reason = "") {
+  close(code = 1000, reason = "", wasClean = true) {
     this.readyState = FakeWebSocket.CLOSED;
-    this.onclose?.({ code, reason, wasClean: true } as CloseEvent);
+    this.onclose?.({ code, reason, wasClean } as CloseEvent);
   }
 
   open() {
@@ -407,6 +407,102 @@ describe("useSessionSocket", () => {
           createdAt: 300,
         },
       ]);
+    });
+  });
+
+  // Regression: when the auto-rename titler commits during the WS subscribe
+  // handshake, the server can send `session_title` on the wire BEFORE
+  // `subscribed`. Without buffering, the title was silently dropped because
+  // the handler ignored updates while sessionState was still null.
+  it("buffers a session_title that arrives before subscribed and applies it on subscribe", async () => {
+    const { result } = renderHook(() => useSessionSocket("session-1"));
+
+    await waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
+
+    const socket = FakeWebSocket.instances[0];
+    act(() => {
+      socket.open();
+    });
+
+    act(() => {
+      socket.receive({ type: "session_title", title: "Auto-named topic" });
+    });
+
+    // Title arrived before subscribed — sessionState is still null and the
+    // title must NOT be visible yet (nothing to merge into).
+    expect(result.current.sessionState).toBeNull();
+
+    act(() => {
+      socket.receive(createSubscribedMessage());
+    });
+
+    // Subscribed snapshot had the stale title ("Session 1"), but the buffered
+    // session_title takes precedence.
+    await waitFor(() => {
+      expect(result.current.sessionState?.title).toBe("Auto-named topic");
+    });
+  });
+
+  it("drops a buffered session_title when the WebSocket closes before subscribed lands", async () => {
+    const { result } = renderHook(() => useSessionSocket("session-1"));
+
+    await waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
+
+    const socket = FakeWebSocket.instances[0];
+    act(() => {
+      socket.open();
+      socket.receive({ type: "session_title", title: "Stale from old socket" });
+      // Drop unclean before subscribed lands so the hook auto-reconnects.
+      socket.close(1006, "abnormal", false);
+    });
+
+    // After reconnect, a fresh subscribed must NOT be overridden by the stale
+    // buffered title from the previous socket.
+    await waitFor(
+      () => {
+        expect(FakeWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+      },
+      { timeout: 3000 }
+    );
+
+    const reconnected = FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+    act(() => {
+      reconnected.open();
+      reconnected.receive(createSubscribedMessage());
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionState?.title).toBe("Session 1");
+    });
+  });
+
+  it("applies session_title normally when it arrives after subscribed", async () => {
+    const { result } = renderHook(() => useSessionSocket("session-1"));
+
+    await waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
+
+    const socket = FakeWebSocket.instances[0];
+    act(() => {
+      socket.open();
+      socket.receive(createSubscribedMessage());
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionState?.title).toBe("Session 1");
+    });
+
+    act(() => {
+      socket.receive({ type: "session_title", title: "Refreshed title" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionState?.title).toBe("Refreshed title");
     });
   });
 });

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -203,6 +203,10 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
   const [authError, setAuthError] = useState<string | null>(null);
   const [connectionError, setConnectionError] = useState<string | null>(null);
   const [sessionState, setSessionState] = useState<SessionState | null>(null);
+  // Holds a session_title broadcast that arrived before "subscribed" so it
+  // can be applied once the initial state lands. Without this, the title is
+  // silently dropped (see use-session-socket.test.ts).
+  const pendingTitleRef = useRef<string | null>(null);
   const [messages, _setMessages] = useState<Message[]>([]);
   const [events, setEvents] = useState<SandboxEvent[]>([]);
   const [participants, setParticipants] = useState<Participant[]>([]);
@@ -284,11 +288,15 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
           setArtifacts(data.artifacts.map(toUiArtifact));
           pendingTextRef.current = null;
           if (data.state) {
+            const bufferedTitle = pendingTitleRef.current;
+            pendingTitleRef.current = null;
             setSessionState({
               ...data.state,
               // Backward-compatible default for older sessions that may omit this.
               isProcessing: data.state.isProcessing ?? false,
               totalCost: data.state.totalCost ?? 0,
+              // Apply any session_title that arrived before "subscribed".
+              ...(bufferedTitle ? { title: bufferedTitle } : {}),
             });
           }
           // Store the current user's participant ID and info for author attribution
@@ -443,7 +451,14 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
 
         case "session_title":
           if (data.title) {
-            setSessionState((prev) => (prev ? { ...prev, title: data.title! } : null));
+            const incomingTitle = data.title;
+            if (subscribedRef.current) {
+              setSessionState((prev) => (prev ? { ...prev, title: incomingTitle } : null));
+            } else {
+              // Subscribed hasn't landed yet — buffer so the "subscribed"
+              // handler can apply the title once state is initialized.
+              pendingTitleRef.current = incomingTitle;
+            }
           }
           break;
 
@@ -586,6 +601,9 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
       });
       connectingRef.current = false;
       subscribedRef.current = false;
+      // Drop any buffered session_title so a stale value from this socket
+      // can't override the freshly-fetched title in the next "subscribed".
+      pendingTitleRef.current = null;
       setConnected(false);
       setConnecting(false);
       setReplaying(false);

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -2,7 +2,11 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import { mutate } from "swr";
-import { SIDEBAR_SESSIONS_KEY } from "@/lib/session-list";
+import {
+  applyTitleUpdate,
+  SIDEBAR_SESSIONS_KEY,
+  type SessionListResponse,
+} from "@/lib/session-list";
 import type { Artifact, SandboxEvent } from "@/types/session";
 import type {
   ParticipantPresence,
@@ -298,6 +302,15 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
               // Apply any session_title that arrived before "subscribed".
               ...(bufferedTitle ? { title: bufferedTitle } : {}),
             });
+            if (bufferedTitle) {
+              // Buffered title is being applied to the header now; mirror it
+              // into the sidebar cache so the list updates at the same time.
+              void mutate<SessionListResponse>(
+                SIDEBAR_SESSIONS_KEY,
+                (current) => applyTitleUpdate(current, sessionId, bufferedTitle, Date.now()),
+                { revalidate: false }
+              );
+            }
           }
           // Store the current user's participant ID and info for author attribution
           if (data.participantId) {
@@ -454,6 +467,15 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
             const incomingTitle = data.title;
             if (subscribedRef.current) {
               setSessionState((prev) => (prev ? { ...prev, title: incomingTitle } : null));
+              // Mirror the title into the sidebar SWR cache so the list
+              // updates in lockstep with the detail header. Without this, the
+              // sidebar stayed stale until an unrelated event (e.g.
+              // session_status) happened to revalidate the list.
+              void mutate<SessionListResponse>(
+                SIDEBAR_SESSIONS_KEY,
+                (current) => applyTitleUpdate(current, sessionId, incomingTitle, Date.now()),
+                { revalidate: false }
+              );
             } else {
               // Subscribed hasn't landed yet — buffer so the "subscribed"
               // handler can apply the title once state is initialized.

--- a/terraform/environments/production/workers-control-plane.tf
+++ b/terraform/environments/production/workers-control-plane.tf
@@ -90,6 +90,7 @@ module "control_plane_worker" {
       { name = "GITHUB_APP_ID", value = var.github_app_id },
       { name = "GITHUB_APP_PRIVATE_KEY", value = var.github_app_private_key },
       { name = "GITHUB_APP_INSTALLATION_ID", value = var.github_app_installation_id },
+      { name = "ANTHROPIC_API_KEY", value = var.anthropic_api_key },
     ],
     local.use_modal_backend ? [
       { name = "MODAL_TOKEN_ID", value = var.modal_token_id },


### PR DESCRIPTION
Adds an auto-session titler to the system. 

User types a prompt, or a bot starts a session, the prompt gets analyzed and then the session title gets renamed to match what the session is about, just like Conductor does. 

## Summary
- Adds a session-titler service that generates a concise human-readable title for a session from its first user prompt using Claude Haiku (`@anthropic-ai/sdk`), and persists it so the dashboard shows meaningful names instead of placeholder IDs.
- Bot-source-aware prefixes ("GitHub: ", "Slack: ", "Linear: ") driven by the existing `SpawnSource` value, with a deterministic prompt-derived fallback when the Haiku call fails or no API key is configured.
- Wires the titler into the session durable object so generation runs in the background and does not block streaming the first response.
- Extends the session schema, repository, and shared types to carry the generated title.
- Adds a new required worker secret `ANTHROPIC_API_KEY`, wired through Terraform as `var.anthropic_api_key`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic session renaming from the first eligible prompt with AI-generated titles; manual titles now block automated overwrites.
  * Web client buffers title updates received before subscription and applies them when subscribing.

* **Bug Fixes**
  * Reduced race conditions so late-renamed titles reliably appear to connected clients.

* **Tests**
  * Expanded unit and integration tests covering auto-rename, title derivation, buffering, and WebSocket scenarios.

* **Chores**
  * DB schema/migrations and optional Anthropic API key/client support for titling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/620)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->