### PR TITLE
fix(control-plane): dedupe presence list by participantId

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1018,7 +1018,17 @@ export class SessionDO extends DurableObject<Env> {
       } else {
         const client = this.wsManager.removeClient(ws);
         if (client) {
-          this.broadcast({ type: "presence_leave", userId: client.userId });
+          // If the participant still has other authenticated sockets (e.g. another
+          // browser tab), don't send presence_leave — the client filters by userId
+          // and would remove them entirely. Broadcast a refresh instead.
+          const stillPresent = Array.from(this.wsManager.getAuthenticatedClients()).some(
+            (c) => c.participantId === client.participantId
+          );
+          if (stillPresent) {
+            this.presenceService.broadcastPresence();
+          } else {
+            this.broadcast({ type: "presence_leave", userId: client.userId });
+          }
         }
       }
     } finally {

--- a/packages/control-plane/src/session/presence-service.test.ts
+++ b/packages/control-plane/src/session/presence-service.test.ts
@@ -107,6 +107,74 @@ describe("PresenceService", () => {
       const result = harness.service.getPresenceList();
       expect(result).toEqual([]);
     });
+
+    it("dedupes by participantId when the same user is connected on multiple sockets", () => {
+      // Same user connected from two tabs → two ClientInfo entries sharing one participantId.
+      // Presence should report the participant exactly once so the UI doesn't render
+      // duplicate avatars / log a React duplicate-key warning.
+      const tab1 = createMockClient({
+        participantId: "part-1",
+        userId: "user-1",
+        name: "Alice",
+        status: "idle",
+        lastSeen: 1000,
+        clientId: "client-tab-1",
+      });
+      const tab2 = createMockClient({
+        participantId: "part-1",
+        userId: "user-1",
+        name: "Alice",
+        status: "active",
+        lastSeen: 5000,
+        clientId: "client-tab-2",
+      });
+      harness.clients.push(tab1, tab2);
+
+      const result = harness.service.getPresenceList();
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({
+        participantId: "part-1",
+        userId: "user-1",
+        name: "Alice",
+        avatar: "https://example.com/avatar.png",
+        // any socket being active → participant is active
+        status: "active",
+        // most recent socket activity wins
+        lastSeen: 5000,
+      });
+    });
+
+    it("keeps distinct participants distinct while deduping shared ones", () => {
+      const aliceTab1 = createMockClient({
+        participantId: "part-1",
+        userId: "user-1",
+        name: "Alice",
+        status: "idle",
+        lastSeen: 1000,
+      });
+      const aliceTab2 = createMockClient({
+        participantId: "part-1",
+        userId: "user-1",
+        name: "Alice",
+        status: "active",
+        lastSeen: 2000,
+      });
+      const bob = createMockClient({
+        participantId: "part-2",
+        userId: "user-2",
+        name: "Bob",
+        status: "idle",
+        lastSeen: 3000,
+      });
+      harness.clients.push(aliceTab1, aliceTab2, bob);
+
+      const result = harness.service.getPresenceList();
+
+      expect(result).toHaveLength(2);
+      const ids = result.map((p) => p.participantId).sort();
+      expect(ids).toEqual(["part-1", "part-2"]);
+    });
   });
 
   describe("sendPresence", () => {

--- a/packages/control-plane/src/session/presence-service.ts
+++ b/packages/control-plane/src/session/presence-service.ts
@@ -35,16 +35,30 @@ export class PresenceService {
 
   /**
    * Get list of present participants.
+   *
+   * A single participant can hold multiple WebSocket connections (e.g. two
+   * browser tabs), so we dedupe by participantId: any active socket marks the
+   * participant active, and we take the most recent lastSeen across sockets.
    */
   getPresenceList(): ParticipantPresence[] {
-    return Array.from(this.deps.getAuthenticatedClients()).map((c) => ({
-      participantId: c.participantId,
-      userId: c.userId,
-      name: c.name,
-      avatar: c.avatar,
-      status: c.status,
-      lastSeen: c.lastSeen,
-    }));
+    const byId = new Map<string, ParticipantPresence>();
+    for (const c of this.deps.getAuthenticatedClients()) {
+      const existing = byId.get(c.participantId);
+      if (!existing) {
+        byId.set(c.participantId, {
+          participantId: c.participantId,
+          userId: c.userId,
+          name: c.name,
+          avatar: c.avatar,
+          status: c.status,
+          lastSeen: c.lastSeen,
+        });
+        continue;
+      }
+      if (c.status === "active") existing.status = "active";
+      if (c.lastSeen > existing.lastSeen) existing.lastSeen = c.lastSeen;
+    }
+    return Array.from(byId.values());
   }
 
   /**

--- a/packages/control-plane/test/integration/websocket-client.test.ts
+++ b/packages/control-plane/test/integration/websocket-client.test.ts
@@ -263,6 +263,55 @@ describe("Client WebSocket (via SELF.fetch)", () => {
     ws.close();
   });
 
+  it("closing one of multiple sockets for the same participant sends presence_update, not presence_leave", async () => {
+    const name = `ws-client-presence-multi-${Date.now()}`;
+    await initNamedSession(name);
+
+    // Two tabs for the same user → same participantId
+    const tab1 = await openClientWs(name, { subscribe: true, userId: "user-1" });
+    const tab2 = await openClientWs(name, { subscribe: true, userId: "user-1" });
+    expect(tab1.participantId).toBe(tab2.participantId);
+
+    const collector = collectMessages(tab1.ws, {
+      until: (msg) => msg.type === "presence_update" || msg.type === "presence_leave",
+      timeoutMs: 2000,
+    });
+
+    tab2.ws.close();
+
+    const messages = await collector;
+    expect(messages.some((m) => m.type === "presence_leave")).toBe(false);
+    const update = messages.find((m) => m.type === "presence_update") as Record<string, unknown>;
+    expect(update).toBeDefined();
+    const participants = update.participants as Array<{ participantId: string }>;
+    expect(participants.some((p) => p.participantId === tab1.participantId)).toBe(true);
+
+    tab1.ws.close();
+  });
+
+  it("closing the only socket for a participant broadcasts presence_leave", async () => {
+    const name = `ws-client-presence-leave-${Date.now()}`;
+    await initNamedSession(name);
+
+    // Two distinct users so the watcher remains connected after the target leaves
+    const watcher = await openClientWs(name, { subscribe: true, userId: "user-1" });
+    const leaver = await openClientWs(name, { subscribe: true, userId: "user-2" });
+
+    const collector = collectMessages(watcher.ws, {
+      until: (msg) => msg.type === "presence_leave",
+      timeoutMs: 2000,
+    });
+
+    leaver.ws.close();
+
+    const messages = await collector;
+    const leave = messages.find((m) => m.type === "presence_leave") as Record<string, unknown>;
+    expect(leave).toBeDefined();
+    expect(leave.userId).toBe("user-2");
+
+    watcher.ws.close();
+  });
+
   it("sandbox event is broadcast to subscribed client", async () => {
     const name = `ws-client-broadcast-${Date.now()}`;
     const { stub } = await initNamedSession(name);


### PR DESCRIPTION
Fixes a bug where a prompt engineer would show up twice (or more) based upon how many tabs they had open. This change ensures that they only show up once in the list of prompt engineers. 

## Summary
- The presence list returned one entry per WebSocket client, so a single user with multiple connections (e.g. two browser tabs) appeared as multiple participants - rendering duplicate avatars in the UI and producing React duplicate-key warnings.
- Dedupe `getPresenceList()` output by `participantId`: any active socket marks the participant active, and the most recent `lastSeen` across sockets wins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate presence entries for the same participant when connected from multiple tabs/devices; presence now shows a single entry per participant.
  * Presence now uses the most recent activity timestamp and treats any active connection as active for the participant, preventing premature removals.
* **Tests**
  * Added integration and unit tests validating presence deduplication and correct presence_update vs presence_leave behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/622)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->