### PR TITLE
fix(web): show char counter on automation instructions, raise cap to 15k

### DIFF
--- a/packages/control-plane/src/routes/automations.test.ts
+++ b/packages/control-plane/src/routes/automations.test.ts
@@ -279,13 +279,13 @@ describe("automation route handlers", () => {
       expect(res.status).toBe(400);
     });
 
-    it("returns 400 when instructions exceeds 10K chars", async () => {
+    it("returns 400 when instructions exceeds the maximum length", async () => {
       const res = await callRoute("POST", "/automations", {
-        body: { ...validBody, instructions: "x".repeat(10_001) },
+        body: { ...validBody, instructions: "x".repeat(15_001) },
       });
       expect(res.status).toBe(400);
       const body = await res.json<{ error: string }>();
-      expect(body.error).toContain("10000");
+      expect(body.error).toContain("15000");
     });
 
     it("returns 400 when repoOwner is missing", async () => {

--- a/packages/control-plane/src/routes/automations.ts
+++ b/packages/control-plane/src/routes/automations.ts
@@ -40,8 +40,8 @@ const MIN_CRON_INTERVAL_MINUTES = 15;
 /** Maximum name length. */
 const MAX_NAME_LENGTH = 200;
 
-/** Maximum instructions length. */
-const MAX_INSTRUCTIONS_LENGTH = 10_000;
+/** Maximum instructions length. Keep in sync with INSTRUCTIONS_MAX_LENGTH in packages/web/src/components/automations/automation-form.tsx. */
+const MAX_INSTRUCTIONS_LENGTH = 15_000;
 
 /** Warn if next run is more than 31 days away. */
 const FAR_FUTURE_THRESHOLD_MS = 31 * 24 * 60 * 60 * 1000;

--- a/packages/web/src/components/automations/automation-form.test.tsx
+++ b/packages/web/src/components/automations/automation-form.test.tsx
@@ -124,3 +124,52 @@ describe("automation cron submission", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 });
+
+describe("instructions character counter", () => {
+  const baseInitialValues = {
+    name: "Daily review",
+    repoOwner: "open-inspect",
+    repoName: "background-agents",
+    baseBranch: "main",
+    model: "openai/gpt-5.4",
+    scheduleCron: "0 9 * * *",
+    scheduleTz: "UTC",
+  };
+
+  const renderForm = (instructions: string) =>
+    render(
+      <AutomationForm
+        mode="edit"
+        submitting={false}
+        onSubmit={vi.fn()}
+        initialValues={{ ...baseInitialValues, instructions }}
+      />
+    );
+
+  it("shows current length and the 15,000 cap", () => {
+    renderForm("hello");
+    expect(screen.getByText("5 / 15,000")).toBeInTheDocument();
+  });
+
+  it("uses muted color well below the warning threshold", () => {
+    renderForm("hello");
+    const counter = screen.getByText("5 / 15,000");
+    expect(counter).toHaveClass("text-muted-foreground");
+    expect(counter).not.toHaveClass("text-warning");
+    expect(counter).not.toHaveClass("text-destructive");
+  });
+
+  it("switches to warning color at 90% of the cap", () => {
+    renderForm("a".repeat(13500));
+    const counter = screen.getByText("13,500 / 15,000");
+    expect(counter).toHaveClass("text-warning");
+    expect(counter).not.toHaveClass("text-destructive");
+  });
+
+  it("switches to destructive color and shows a notice at the cap", () => {
+    renderForm("a".repeat(15000));
+    const counter = screen.getByText(/15,000 \/ 15,000/);
+    expect(counter).toHaveClass("text-destructive");
+    expect(counter).toHaveTextContent("Maximum length reached.");
+  });
+});

--- a/packages/web/src/components/automations/automation-form.tsx
+++ b/packages/web/src/components/automations/automation-form.tsx
@@ -50,6 +50,11 @@ const COMMON_SET = new Set(COMMON_TIMEZONES);
 const ALL_TIMEZONES = Intl.supportedValuesOf("timeZone");
 const DEFAULT_REASONING_VALUE = "__default__";
 
+// Keep in sync with MAX_INSTRUCTIONS_LENGTH in
+// packages/control-plane/src/routes/automations.ts.
+const INSTRUCTIONS_MAX_LENGTH = 15000;
+const INSTRUCTIONS_WARNING_THRESHOLD = Math.floor(INSTRUCTIONS_MAX_LENGTH * 0.9);
+
 const toOption = (tz: string) => ({ value: tz, label: tz.replace(/_/g, " ") });
 
 const TIMEZONE_GROUPS: ComboboxGroup[] = [
@@ -452,11 +457,28 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
                   ? "Review this pull request and provide feedback. Check for code quality issues, potential bugs, and suggest improvements."
                   : "Process this webhook payload and take the appropriate action."
           }
-          maxLength={10000}
+          maxLength={INSTRUCTIONS_MAX_LENGTH}
           required
           rows={6}
+          aria-describedby="instructions-counter"
           className="resize-y"
         />
+        <div
+          id="instructions-counter"
+          aria-live="polite"
+          className={`mt-1 text-xs text-right ${
+            instructions.length >= INSTRUCTIONS_MAX_LENGTH
+              ? "text-destructive"
+              : instructions.length >= INSTRUCTIONS_WARNING_THRESHOLD
+                ? "text-warning"
+                : "text-muted-foreground"
+          }`}
+        >
+          {instructions.length >= INSTRUCTIONS_MAX_LENGTH ? (
+            <span>Maximum length reached. </span>
+          ) : null}
+          {instructions.length.toLocaleString()} / {INSTRUCTIONS_MAX_LENGTH.toLocaleString()}
+        </div>
       </div>
 
       {/* Submit */}


### PR DESCRIPTION
## Summary

- Users editing an automation whose `instructions` already sat at the previous 10,000-char cap could not insert characters. The browser silently rejected plain typing because `maxLength` was already met. Replacing a selection worked because length did not increase — exactly matching the reported "I can only type after I highlight a word" symptom.
- Bumps the cap to 15,000 in both the form (`maxLength`) and the control-plane validator so the two stay in sync.
- Adds a live character counter under the textarea: muted under 90%, warning color at 90%+, destructive at the cap with a "Maximum length reached." prefix so the limit is visible before users hit it.

## Files changed

- `packages/web/src/components/automations/automation-form.tsx` — counter + raised cap + `aria-describedby`/`aria-live` for screen readers.
- `packages/control-plane/src/routes/automations.ts` — `MAX_INSTRUCTIONS_LENGTH` raised to 15,000 with a comment pointing at the matching front-end constant.
- Tests updated/added for both packages.

## Test plan

- [x] `npm run test -w @open-inspect/web -- --run src/components/automations/automation-form.test.tsx` (7/7 pass, including 4 new counter cases)
- [x] `npm test -w @open-inspect/control-plane -- --run automations` (41/41 pass, updated boundary test)
- [x] `npm run lint -w @open-inspect/web`
- [x] `npm run typecheck -w @open-inspect/web`
- [ ] Manual: load an automation with ~14,500 chars of instructions and confirm the counter turns amber; pad to 15,000 and confirm it turns red and shows "Maximum length reached."
- [ ] Manual: edit a normal-length automation and confirm plain typing inserts characters (the originally reported bug).

## Notes

The two constants live in separate packages because that mirrors the existing pattern for `MAX_NAME_LENGTH`. Comments in both files point at the counterpart so they don't drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased automation instructions field maximum length to 15,000 characters.
  * Added a character counter to the instructions field displaying current character count against the limit.
  * Visual indicators appear at 90% capacity (warning styling) and maximum length (destructive styling with "Maximum length reached" message).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/625)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->