### PR TITLE
feat(web): allow per-repo override of auto-review-on-open in GitHub integration settings

### DIFF
--- a/packages/web/src/components/settings/integrations/github-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/github-integration-settings.tsx
@@ -608,6 +608,12 @@ function RepoOverrideRow({
   const [commentActionInstructions, setCommentActionInstructions] = useState(
     entry.settings.commentActionInstructions ?? ""
   );
+  const [autoReviewMode, setAutoReviewMode] = useState<"global" | "override">(
+    entry.settings.autoReviewOnOpen !== undefined ? "override" : "global"
+  );
+  const [autoReviewOnOpen, setAutoReviewOnOpen] = useState(
+    entry.settings.autoReviewOnOpen ?? false
+  );
   const [newUsername, setNewUsername] = useState("");
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
@@ -634,6 +640,7 @@ function RepoOverrideRow({
     if (codeReviewMode === "override") settings.codeReviewInstructions = codeReviewInstructions;
     if (commentActionMode === "override")
       settings.commentActionInstructions = commentActionInstructions;
+    if (autoReviewMode === "override") settings.autoReviewOnOpen = autoReviewOnOpen;
 
     try {
       const res = await fetch(`/api/integration-settings/github/repos/${owner}/${name}`, {
@@ -739,6 +746,39 @@ function RepoOverrideRow({
         <Button variant="destructive" size="sm" onClick={handleDelete}>
           Remove
         </Button>
+      </div>
+
+      <div>
+        <p className="text-xs font-medium text-muted-foreground mb-1">Auto-review new PRs</p>
+        <div className="flex items-center gap-2 mb-1">
+          <Select
+            value={autoReviewMode}
+            onValueChange={(v: "global" | "override") => {
+              setAutoReviewMode(v);
+              setDirty(true);
+            }}
+          >
+            <SelectTrigger density="compact" className="w-48">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="global">Use global default</SelectItem>
+              <SelectItem value="override">Override for this repo</SelectItem>
+            </SelectContent>
+          </Select>
+          {autoReviewMode === "override" && (
+            <label className="flex items-center gap-2 text-xs text-foreground">
+              <Switch
+                checked={autoReviewOnOpen}
+                onCheckedChange={(checked) => {
+                  setAutoReviewOnOpen(checked);
+                  setDirty(true);
+                }}
+              />
+              <span>{autoReviewOnOpen ? "Enabled" : "Disabled"}</span>
+            </label>
+          )}
+        </div>
       </div>
 
       <div>


### PR DESCRIPTION
## Summary
- Adds an "Auto-review new PRs" control to the per-repo override row in the GitHub integration settings UI.
- Lets users either inherit the global `autoReviewOnOpen` default or override it for a specific repo with an on/off toggle.
- Pure UI change wired through the existing `RepoOverrideRow` save flow.

**Example: Auto review PR's is off globally , but enabled on this repo**
<img width="1392" height="952" alt="CleanShot 2026-05-12 at 11 51 44@2x" src="https://github.com/user-attachments/assets/c3ef5343-5062-4560-8e1f-c62bc7596f60" />


## Test plan
- `npm test -w @open-inspect/web`
- Manual: open Settings → Integrations → GitHub, add a repo override, switch the new control between "Use global default" and "Override for this repo", flip the Switch, save, and confirm the override persists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-repository override capability for "Auto-review new PRs" in GitHub integration settings
  * Users can now choose to override global settings and customize auto-review behavior for individual repositories

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/628)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->