### PR TITLE
fix(modal): Support non-main envs in Modal

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -150,7 +150,8 @@ Create an R2 API Token:
 1. Go to [Modal Settings](https://modal.com/settings)
 2. **Create a new API token**: Settings -> API Tokens -> New Token
 3. Note the **Token ID** and **Token Secret**
-4. Note your **Workspace name** (visible in your Modal dashboard URL)
+4. Note your **Workspace** and **Environment names** (visible in your Modal dashboard URL,
+   https://modal.com/apps/<modal_workspace>/<modal_environment>)
 
 ### Daytona
 
@@ -355,6 +356,7 @@ vercel_team_id              = "team_xxxxx"       # Your Vercel ID (even personal
 modal_token_id              = "your-modal-token-id"
 modal_token_secret          = "your-modal-token-secret"
 modal_workspace             = "your-modal-workspace"
+modal_environment           = "your-modal-environment"
 
 # Daytona (only required when sandbox_provider = "daytona")
 # daytona_api_url           = "https://app.daytona.io/api"

--- a/terraform/environments/production/locals.tf
+++ b/terraform/environments/production/locals.tf
@@ -2,6 +2,10 @@ locals {
   name_suffix         = var.deployment_name
   use_modal_backend   = var.sandbox_provider == "modal"
   use_daytona_backend = var.sandbox_provider == "daytona"
+  # Modal omits the environment segment for the default "main" environment.
+  # Non-main environments: "{workspace}-{env}--{app}.modal.run"
+  # Default (main) environment:  "{workspace}--{app}.modal.run"
+  modal_workspace_slug = var.modal_environment == "main" ? var.modal_workspace : "${var.modal_workspace}-${var.modal_environment}"
 
   # URLs for cross-service configuration
   control_plane_host = "open-inspect-control-plane-${local.name_suffix}.${var.cloudflare_worker_subdomain}.workers.dev"

--- a/terraform/environments/production/modal.tf
+++ b/terraform/environments/production/modal.tf
@@ -28,7 +28,7 @@ module "modal_app" {
   modal_token_secret = var.modal_token_secret
 
   app_name      = "open-inspect"
-  workspace     = var.modal_workspace
+  workspace     = local.modal_workspace_slug
   deploy_path   = "${var.project_root}/packages/modal-infra"
   deploy_module = "deploy"
   source_hash   = data.external.modal_source_hash[0].result.hash

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -51,10 +51,14 @@ cloudflare_worker_subdomain = ""
 modal_token_id = ""
 modal_token_secret = ""
 
-# Modal workspace name (used in endpoint URLs)
+# Modal workspace name and environment (used in endpoint URLs)
 # Only required when sandbox_provider = "modal"
-# This is your Modal username/workspace (e.g., "myworkspace" in "https://myworkspace--app.modal.run")
-modal_workspace = ""
+# workspace: your Modal username (e.g., "myworkspace")
+# environment: Modal environment name. Use "main" for the default environment:
+#   main env:     https://myworkspace--app.modal.run
+#   non-main env: https://myworkspace-production--app.modal.run
+modal_workspace   = ""
+modal_environment = "main"
 
 # Daytona REST API
 # Only required when sandbox_provider = "daytona"

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -72,6 +72,17 @@ variable "modal_workspace" {
   }
 }
 
+variable "modal_environment" {
+  description = "Modal environment name. Use 'main' for the default environment (omitted from endpoint URLs). Non-main envs (e.g., 'production', 'dev') are included in the URL slug."
+  type        = string
+  default     = "main"
+
+  validation {
+    condition     = var.sandbox_provider != "modal" || length(var.modal_environment) > 0
+    error_message = "modal_environment must be set when sandbox_provider = 'modal'."
+  }
+}
+
 # =============================================================================
 # GitHub OAuth App Credentials
 # =============================================================================

--- a/terraform/environments/production/workers-control-plane.tf
+++ b/terraform/environments/production/workers-control-plane.tf
@@ -70,7 +70,7 @@ module "control_plane_worker" {
       { name = "APP_NAME", value = var.app_name },
       { name = "SANDBOX_PROVIDER", value = var.sandbox_provider },
     ],
-    local.use_modal_backend ? [{ name = "MODAL_WORKSPACE", value = var.modal_workspace }] : [],
+    local.use_modal_backend ? [{ name = "MODAL_WORKSPACE", value = local.modal_workspace_slug }] : [],
     local.use_daytona_backend ? [
       { name = "DAYTONA_API_URL", value = var.daytona_api_url },
       { name = "DAYTONA_BASE_SNAPSHOT", value = var.daytona_base_snapshot },


### PR DESCRIPTION
## Summary

Modal has a hierarchy of workspaces -> environments. The default environment is `main`. If you stick with that, the environment doesn't have any impact on Modal's URLs; however, if you use a non-default environment, e.g., `prod`, that environment name is added into the URL. These changes support generating Modal's URL slug properly to support both `main` and non-default environments.

## Backwards compatibility

- The new `modal_environment` Terraform variable defaults to `main` so projects that don't set it will not be impacted.

## Docs updated

- `docs/GETTING_STARTED.md` — updated `terraform.tfvars` block
- `terraform/environments/production/terraform.tfvars.example` — updated example to include the new variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated getting started guide with expanded Modal prerequisites, now requiring both Workspace and Environment names with guidance on locating them.

* **New Features**
  * Terraform configuration now includes environment variable support for Modal, enabling flexible workspace configuration across different deployment environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/629)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->