### PR TITLE
fix(sandbox): pin opencode-ai to 1.14.41 to restore SSE event publishing

### DIFF
--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -19,8 +19,20 @@ import sandbox_runtime
 # Get the path to the sandbox runtime code (provider-agnostic)
 SANDBOX_RUNTIME_DIR = Path(sandbox_runtime.__file__).parent
 
-# OpenCode version to install
-OPENCODE_VERSION = "latest"
+# OpenCode version to install.
+#
+# Pinned to 1.14.41 — the last release before opencode's Hono → Effect Schema
+# migration (landed across v1.14.42+, released 2026-05-09 onward) broke event
+# publishing on the legacy `/event` SSE endpoint. With newer versions the
+# bridge connects, posts the prompt, opencode processes it and records the
+# assistant response in the session store, but no `message.updated` /
+# `message.part.updated` / `session.idle` events are streamed back — so the
+# session shows execution_complete with no reply.
+#
+# Symptom in bridge logs: `prompt.run outcome=success duration_ms=35-367`,
+# which means `_stream_opencode_response_sse` returned with zero yielded
+# events. Tracked in #567.
+OPENCODE_VERSION = "1.14.41"
 
 # code-server version to install (pinned for reproducible images)
 CODE_SERVER_VERSION = "4.109.5"
@@ -33,8 +45,8 @@ TTYD_VERSION = "1.7.7"
 TTYD_SHA256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55"
 
 # Cache buster - change this to force Modal image rebuild
-# v48: refresh sandbox image for Claude Opus 4.7 support
-CACHE_BUSTER = "v48-opus-4-7"
+# v49: pin opencode-ai to 1.14.41 (newer versions break SSE event publishing)
+CACHE_BUSTER = "v49-pin-opencode-1-14-41"
 
 # Base image with all development tools
 base_image = (
@@ -107,11 +119,11 @@ base_image = (
     # CACHE_BUSTER is embedded in a no-op echo so Modal invalidates this layer on bump.
     .run_commands(
         f"echo 'cache: {CACHE_BUSTER}' > /dev/null",
-        "npm install -g opencode-ai@latest",
+        f"npm install -g opencode-ai@{OPENCODE_VERSION}",
         "opencode --version || echo 'OpenCode installed'",
         # Install @opencode-ai/plugin globally for custom tools
         # This ensures tools can import the plugin without needing to run bun add
-        "npm install -g @opencode-ai/plugin@latest zod",
+        f"npm install -g @opencode-ai/plugin@{OPENCODE_VERSION} zod",
     )
     # Pre-build OpenCode plugin deps into a staging directory.
     # At boot, _install_tools() copies these into .opencode/ so that


### PR DESCRIPTION
Fixes #567.

## Summary

`opencode-ai@latest` (currently 1.14.48) broke the legacy `/event` SSE endpoint that the sandbox bridge depends on. Subscribers connect successfully, receive the initial `server.connected` event, but no subsequent `message.updated` / `message.part.updated` / `session.idle` events are streamed back — even though opencode does process the prompt and records the assistant response in the session store.

In the bridge this surfaces as `prompt.run outcome=success duration_ms=35-367` in modal app logs: `_stream_opencode_response_sse` returns with zero yielded events, the bridge sends `execution_complete success=true` to the control plane, and the session shows "completed" with no model reply. This matches the symptoms in #567 exactly — including the "204 No Content" log line one user spotted.

## Reproduction

Exec'd into a live sandbox running 1.14.48 via `modal container exec`:

```bash
SID=$(curl -s -X POST http://localhost:4096/session -d '{}' | jq -r .id)
MSG_ID=msg_<bridge-format-ascending-id>

# subscribe to SSE
curl -s -N -H "Accept: text/event-stream" http://localhost:4096/event > sse.log &

# post a prompt exactly as the bridge does
curl -X POST http://localhost:4096/session/$SID/prompt_async \
  -d '{"messageID":"'$MSG_ID'","parts":[{"type":"text","text":"reply just OK"}],
       "model":{"providerID":"anthropic","modelID":"claude-haiku-4-5"}}'
# → 204 No Content

# wait 25s — sse.log contains only `server.connected`, nothing else.
curl -s http://localhost:4096/api/session/$SID/message | jq
# → confirms user message + assistant reply were recorded.
```

The response is plain `text/event-stream`, `Transfer-Encoding: chunked`, no `Content-Encoding` — so this isn't a compression issue. The legacy event publishing pipeline simply isn't wired up for prompt-driven events anymore.

Root cause is likely opencode's Hono → Effect Schema migration that landed across 1.14.42+. See commits in `sst/opencode` like ["Clean up post-Hono references"](https://github.com/sst/opencode/commit/6f2f759), "Drop unused opencode Zod statics", "Generate config schema from Effect Schema" — all merged 2026-05-11.

## Why this surfaced now

The bug only shows up when the Modal base image is freshly built. Existing deployments with a cached image from before 2026-05-09 keep working because their image baked in 1.14.41 (or earlier). Anyone bumping `CACHE_BUSTER` or building in a fresh Modal workspace after 2026-05-09 will hit it on the first session attempt.

## Changes

- Pin `OPENCODE_VERSION = "1.14.41"` (last release before the broken migration, published 2026-05-07).
- Thread `OPENCODE_VERSION` through both the `opencode-ai` and `@opencode-ai/plugin` installs so they stay in sync.
- Bump `CACHE_BUSTER` from `v48-opus-4-7` to `v49-pin-opencode-1-14-41` to force the rebuild.

## Test plan

- [ ] Rebuild image, spawn a fresh session, see streamed assistant tokens in the UI.
- [ ] `prompt.run` log shows `duration_ms` consistent with actual model latency (seconds, not 35ms).
- [ ] Existing snapshots from before 2026-05-09 keep working (they already used 1.14.41).

## Follow-ups (out of scope here)

- Track when opencode upstream fixes the regression so we can unpin.
- Consider tightening the bridge to fail-loud on a silent SSE: e.g. assert at least one non-`server.connected` event arrives within a few seconds, otherwise mark the prompt errored instead of reporting success.

---

Tested locally; happy to iterate on the comment wording or version choice (any of 1.14.34–1.14.41 should work).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Open-Inspect base image build to pin runtime to a specific version for improved stability and consistency.
  * Updated build cache settings to ensure proper image rebuilding with the latest configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/630)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->