### PR TITLE
fix(sandbox): pin opencode-ai to 1.14.41 in Daytona toolchain

### DIFF
--- a/packages/daytona-infra/src/toolchain.py
+++ b/packages/daytona-infra/src/toolchain.py
@@ -6,7 +6,20 @@ from pathlib import Path
 
 from daytona import CreateSnapshotParams, Daytona, Image
 
-OPENCODE_VERSION = "latest"
+# OpenCode version to install.
+#
+# Pinned to 1.14.41 — the last release before opencode's Hono → Effect Schema
+# migration (landed across v1.14.42+, released 2026-05-09 onward) broke event
+# publishing on the legacy `/event` SSE endpoint. With newer versions the
+# bridge connects, posts the prompt, opencode processes it and records the
+# assistant response in the session store, but no `message.updated` /
+# `message.part.updated` / `session.idle` events are streamed back — so the
+# session shows execution_complete with no reply.
+#
+# Symptom in bridge logs: `prompt.run outcome=success duration_ms=35-367`,
+# which means `_stream_opencode_response_sse` returned with zero yielded
+# events. Tracked in #567.
+OPENCODE_VERSION = "1.14.41"
 CODE_SERVER_VERSION = "4.109.5"
 AGENT_BROWSER_VERSION = "0.21.2"
 SANDBOX_VERSION = "daytona-v1"
@@ -46,7 +59,7 @@ def build_base_image(repo_root: Path) -> Image:
         )
         .run_commands(
             f"npm install -g opencode-ai@{OPENCODE_VERSION}",
-            "npm install -g @opencode-ai/plugin@latest zod",
+            f"npm install -g @opencode-ai/plugin@{OPENCODE_VERSION} zod",
             f"curl -fsSL -o /tmp/code-server.deb "
             f"https://github.com/coder/code-server/releases/download/v{CODE_SERVER_VERSION}/"
             f"code-server_{CODE_SERVER_VERSION}_amd64.deb",


### PR DESCRIPTION
Follow-up to #630 for the Daytona sandbox provider. Refs #567.

## Summary

#630 pinned `opencode-ai` to `1.14.41` in `packages/modal-infra/src/images/base.py` to work around the broken `/event` SSE endpoint in 1.14.42+. It missed `packages/daytona-infra/src/toolchain.py`, which has its own `OPENCODE_VERSION` and was still installing `opencode-ai@latest` plus `@opencode-ai/plugin@latest`. Anyone running the Daytona backend hits the exact symptom described in #567 — the bridge connects to `/event`, receives `server.connected`, posts the prompt, opencode records the assistant response in the session store, but no further events are streamed back, so the session shows `execution_complete` with no reply.

See #630 for the full reproduction, root-cause analysis (Hono → Effect Schema migration in opencode 1.14.42+), and reasoning behind the 1.14.41 pin — not repeating it here.

## Changes

- Pin `OPENCODE_VERSION = "1.14.41"` in `packages/daytona-infra/src/toolchain.py` with the same comment block as #630.
- Thread `OPENCODE_VERSION` through `@opencode-ai/plugin` so both installs stay in sync (matches what #630 did for `base.py`).

## Test plan

- [ ] Re-run `terraform apply` in an environment with `sandbox_provider = "daytona"`; confirm the snapshot is rebuilt.
- [ ] Spawn a fresh Daytona session, send a prompt, see streamed assistant tokens in the UI.
- [ ] `prompt.run` log shows `duration_ms` consistent with actual model latency (seconds, not 35ms).

## Notes

- **No `SANDBOX_VERSION` bump.** I checked: in `terraform/environments/production/daytona.tf`, `data "external" "daytona_source_hash"` already hashes every `.py` file under `packages/daytona-infra/src` and `packages/sandbox-runtime/src`. Editing `toolchain.py` invalidates that hash, which retriggers `null_resource.daytona_snapshot` and rebuilds via `bootstrap.py --force`. `SANDBOX_VERSION` is only surfaced as an env var inside the running sandbox (informational); it doesn't drive cache invalidation, so I left it as `daytona-v1`.
- For deployments not driven by Terraform (manual `python -m src.bootstrap --force` runs), the snapshot must be rebuilt manually after this change lands.

## Follow-ups (out of scope)

- Same as #630: track when opencode upstream restores SSE event publishing so we can unpin.
- Consider extracting `OPENCODE_VERSION` to a shared location so Modal and Daytona can't drift again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pinned OpenCode package version for improved stability and reliability in base image builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/632)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->