### PR TITLE
fix(web): keep archived list pagination on unarchive

### DIFF
--- a/packages/web/src/components/settings/data-controls-settings.test.tsx
+++ b/packages/web/src/components/settings/data-controls-settings.test.tsx
@@ -61,12 +61,17 @@ function jsonResponse(body: unknown, status = 200) {
 }
 
 type FetchHandlers = {
-  archivedPages?: ArchivedSession[][];
+  // Flat backing store of archived sessions. GETs slice it by offset/limit;
+  // successful POST /unarchive removes the session from it so subsequent
+  // pages shift the way they would server-side.
+  archivedSessions?: ArchivedSession[];
   onUnarchive?: (sessionId: string) => Response | Promise<Response>;
   onListSidebar?: () => Response | Promise<Response>;
 };
 
 function installFetch(handlers: FetchHandlers) {
+  const archived = [...(handlers.archivedSessions ?? [])];
+
   const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
     const method = init?.method ?? "GET";
@@ -74,21 +79,26 @@ function installFetch(handlers: FetchHandlers) {
     const unarchiveMatch = url.match(/^\/api\/sessions\/([^/]+)\/unarchive$/);
     if (unarchiveMatch && method === "POST") {
       if (!handlers.onUnarchive) throw new Error(`No POST handler for ${url}`);
-      return handlers.onUnarchive(unarchiveMatch[1]);
+      const sessionId = unarchiveMatch[1];
+      const res = await handlers.onUnarchive(sessionId);
+      if (res.ok) {
+        const idx = archived.findIndex((s) => s.id === sessionId);
+        if (idx >= 0) archived.splice(idx, 1);
+      }
+      return res;
     }
 
     if (method === "GET" && url.startsWith("/api/sessions?")) {
       const params = new URL(url, "http://localhost").searchParams;
-      const offset = Number(params.get("offset") || 0);
-      const limit = Number(params.get("limit") || 20);
       if (params.get("status") === "archived") {
-        const page = (handlers.archivedPages ?? []).find((_, i) => offset === i * limit);
-        const sessions = page ?? [];
-        const nextOffset = offset + sessions.length;
-        const hasMore = (handlers.archivedPages ?? []).some(
-          (p, i) => i * limit === nextOffset && p.length > 0
-        );
-        return jsonResponse({ sessions, hasMore, total: sessions.length });
+        const offset = Number(params.get("offset") || 0);
+        const limit = Number(params.get("limit") || 20);
+        const sessions = archived.slice(offset, offset + limit);
+        return jsonResponse({
+          sessions,
+          hasMore: offset + sessions.length < archived.length,
+          total: archived.length,
+        });
       }
       if (params.get("excludeStatus") === "archived") {
         return handlers.onListSidebar
@@ -103,7 +113,7 @@ function installFetch(handlers: FetchHandlers) {
   return fetchMock;
 }
 
-function renderComponent() {
+function renderComponent(additionalChildren?: React.ReactNode) {
   return render(
     <SWRConfig
       value={{
@@ -119,6 +129,7 @@ function renderComponent() {
       }}
     >
       <DataControlsSettings />
+      {additionalChildren}
     </SWRConfig>
   );
 }
@@ -135,7 +146,7 @@ afterEach(async () => {
 describe("DataControlsSettings — unarchive flow", () => {
   it("removes the row when the unarchive request succeeds", async () => {
     installFetch({
-      archivedPages: [[createArchivedSession(1)]],
+      archivedSessions: [createArchivedSession(1)],
       onUnarchive: () => jsonResponse({ status: "active" }),
     });
 
@@ -156,11 +167,10 @@ describe("DataControlsSettings — unarchive flow", () => {
   });
 
   it("preserves Load-more pagination when a page-1 session is unarchived", async () => {
-    const page1 = Array.from({ length: 20 }, (_, i) => createArchivedSession(i + 1));
-    const page2 = Array.from({ length: 3 }, (_, i) => createArchivedSession(i + 21));
+    const sessions = Array.from({ length: 23 }, (_, i) => createArchivedSession(i + 1));
 
     installFetch({
-      archivedPages: [page1, page2],
+      archivedSessions: sessions,
       onUnarchive: () => jsonResponse({ status: "active" }),
     });
 
@@ -192,11 +202,10 @@ describe("DataControlsSettings — unarchive flow", () => {
   });
 
   it("removes a page-2 session from the list when it is unarchived", async () => {
-    const page1 = Array.from({ length: 20 }, (_, i) => createArchivedSession(i + 1));
-    const page2 = Array.from({ length: 3 }, (_, i) => createArchivedSession(i + 21));
+    const sessions = Array.from({ length: 23 }, (_, i) => createArchivedSession(i + 1));
 
     installFetch({
-      archivedPages: [page1, page2],
+      archivedSessions: sessions,
       onUnarchive: () => jsonResponse({ status: "active" }),
     });
 
@@ -227,9 +236,45 @@ describe("DataControlsSettings — unarchive flow", () => {
     expect(screen.getByText("Session 1")).toBeInTheDocument();
   });
 
+  it("does not skip an archived session when Load more runs after an unarchive", async () => {
+    // 23 archived sessions: page 1 holds 1..20, page 2 would hold 21..23.
+    // After unarchiving session 1 (without loading page 2), the server-side
+    // list shifts down so the next session at offset 19 is session 21. If we
+    // forget to decrement the local offset, Load more would request offset 20
+    // and skip session 21.
+    const sessions = Array.from({ length: 23 }, (_, i) => createArchivedSession(i + 1));
+
+    installFetch({
+      archivedSessions: sessions,
+      onUnarchive: () => jsonResponse({ status: "active" }),
+    });
+
+    renderComponent();
+
+    expect(await screen.findByText("Session 1")).toBeInTheDocument();
+    expect(screen.queryByText("Session 21")).not.toBeInTheDocument();
+
+    const user = userEvent.setup();
+    const rowOne = screen.getByText("Session 1").closest("div.group") as HTMLElement;
+    await user.click(rowOne.querySelector("button") as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(toastMock.success).toHaveBeenCalledWith("Session unarchived");
+    });
+    await waitFor(() => {
+      expect(screen.queryByText("Session 1")).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Load more" }));
+
+    expect(await screen.findByText("Session 21")).toBeInTheDocument();
+    expect(screen.getByText("Session 22")).toBeInTheDocument();
+    expect(screen.getByText("Session 23")).toBeInTheDocument();
+  });
+
   it("keeps the row visible when the unarchive request returns 500", async () => {
     installFetch({
-      archivedPages: [[createArchivedSession(1)]],
+      archivedSessions: [createArchivedSession(1)],
       onUnarchive: () => jsonResponse({ error: "boom" }, 500),
     });
 
@@ -260,29 +305,12 @@ describe("DataControlsSettings — sidebar invalidation", () => {
   it("refetches the sidebar session list after a successful unarchive", async () => {
     const sidebarHandler = vi.fn(() => jsonResponse({ sessions: [], hasMore: false }));
     const fetchMock = installFetch({
-      archivedPages: [[createArchivedSession(1)]],
+      archivedSessions: [createArchivedSession(1)],
       onUnarchive: () => jsonResponse({ status: "active" }),
       onListSidebar: sidebarHandler,
     });
 
-    render(
-      <SWRConfig
-        value={{
-          dedupingInterval: 0,
-          revalidateOnFocus: false,
-          revalidateIfStale: false,
-          revalidateOnReconnect: false,
-          fetcher: async (url: string) => {
-            const response = await fetch(url);
-            if (!response.ok) throw new Error(`HTTP ${response.status}`);
-            return response.json();
-          },
-        }}
-      >
-        <DataControlsSettings />
-        <SidebarProbe />
-      </SWRConfig>
-    );
+    renderComponent(<SidebarProbe />);
 
     expect(await screen.findByText("Session 1")).toBeInTheDocument();
     // Sidebar probe should have done its initial fetch.

--- a/packages/web/src/components/settings/data-controls-settings.test.tsx
+++ b/packages/web/src/components/settings/data-controls-settings.test.tsx
@@ -1,0 +1,306 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import useSWR, { SWRConfig, mutate as globalMutate } from "swr";
+import { DataControlsSettings } from "./data-controls-settings";
+import { SIDEBAR_SESSIONS_KEY } from "@/lib/session-list";
+
+expect.extend(matchers);
+
+const { toastMock } = vi.hoisted(() => ({
+  toastMock: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: toastMock,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: React.ComponentProps<"a">) => (
+    <a href={typeof href === "string" ? href : "#"} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+type ArchivedSession = ReturnType<typeof createArchivedSession>;
+
+function createArchivedSession(index: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id: `session-${index}`,
+    title: `Session ${index}`,
+    repoOwner: "open-inspect",
+    repoName: "background-agents",
+    baseBranch: "main",
+    branchName: null,
+    baseSha: null,
+    currentSha: null,
+    opencodeSessionId: null,
+    parentSessionId: null,
+    spawnSource: "user",
+    spawnDepth: 0,
+    status: "archived",
+    createdAt: 1000 + index,
+    updatedAt: 2000 + index,
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+type FetchHandlers = {
+  archivedPages?: ArchivedSession[][];
+  onUnarchive?: (sessionId: string) => Response | Promise<Response>;
+  onListSidebar?: () => Response | Promise<Response>;
+};
+
+function installFetch(handlers: FetchHandlers) {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+
+    const unarchiveMatch = url.match(/^\/api\/sessions\/([^/]+)\/unarchive$/);
+    if (unarchiveMatch && method === "POST") {
+      if (!handlers.onUnarchive) throw new Error(`No POST handler for ${url}`);
+      return handlers.onUnarchive(unarchiveMatch[1]);
+    }
+
+    if (method === "GET" && url.startsWith("/api/sessions?")) {
+      const params = new URL(url, "http://localhost").searchParams;
+      const offset = Number(params.get("offset") || 0);
+      const limit = Number(params.get("limit") || 20);
+      if (params.get("status") === "archived") {
+        const page = (handlers.archivedPages ?? []).find((_, i) => offset === i * limit);
+        const sessions = page ?? [];
+        const nextOffset = offset + sessions.length;
+        const hasMore = (handlers.archivedPages ?? []).some(
+          (p, i) => i * limit === nextOffset && p.length > 0
+        );
+        return jsonResponse({ sessions, hasMore, total: sessions.length });
+      }
+      if (params.get("excludeStatus") === "archived") {
+        return handlers.onListSidebar
+          ? handlers.onListSidebar()
+          : jsonResponse({ sessions: [], hasMore: false });
+      }
+    }
+
+    throw new Error(`Unexpected fetch: ${method} ${url}`);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function renderComponent() {
+  return render(
+    <SWRConfig
+      value={{
+        dedupingInterval: 0,
+        revalidateOnFocus: false,
+        revalidateIfStale: false,
+        revalidateOnReconnect: false,
+        fetcher: async (url: string) => {
+          const response = await fetch(url);
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
+          return response.json();
+        },
+      }}
+    >
+      <DataControlsSettings />
+    </SWRConfig>
+  );
+}
+
+afterEach(async () => {
+  cleanup();
+  // Clear SWR's global cache between tests so cache state doesn't leak.
+  await globalMutate(() => true, undefined, { revalidate: false });
+  vi.restoreAllMocks();
+  toastMock.success.mockReset();
+  toastMock.error.mockReset();
+});
+
+describe("DataControlsSettings — unarchive flow", () => {
+  it("removes the row when the unarchive request succeeds", async () => {
+    installFetch({
+      archivedPages: [[createArchivedSession(1)]],
+      onUnarchive: () => jsonResponse({ status: "active" }),
+    });
+
+    renderComponent();
+
+    expect(await screen.findByText("Session 1")).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Unarchive" }));
+
+    await waitFor(() => {
+      expect(toastMock.success).toHaveBeenCalledWith("Session unarchived");
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Session 1")).not.toBeInTheDocument();
+    });
+  });
+
+  it("preserves Load-more pagination when a page-1 session is unarchived", async () => {
+    const page1 = Array.from({ length: 20 }, (_, i) => createArchivedSession(i + 1));
+    const page2 = Array.from({ length: 3 }, (_, i) => createArchivedSession(i + 21));
+
+    installFetch({
+      archivedPages: [page1, page2],
+      onUnarchive: () => jsonResponse({ status: "active" }),
+    });
+
+    renderComponent();
+
+    expect(await screen.findByText("Session 1")).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Load more" }));
+
+    expect(await screen.findByText("Session 23")).toBeInTheDocument();
+
+    // Unarchive a page-1 session.
+    const rowOne = screen.getByText("Session 1").closest("div.group") as HTMLElement;
+    const unarchiveButton = rowOne.querySelector("button") as HTMLButtonElement;
+    await user.click(unarchiveButton);
+
+    await waitFor(() => {
+      expect(toastMock.success).toHaveBeenCalledWith("Session unarchived");
+    });
+
+    // Session 1 should be gone; page-2 sessions must remain visible.
+    await waitFor(() => {
+      expect(screen.queryByText("Session 1")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("Session 21")).toBeInTheDocument();
+    expect(screen.getByText("Session 22")).toBeInTheDocument();
+    expect(screen.getByText("Session 23")).toBeInTheDocument();
+  });
+
+  it("removes a page-2 session from the list when it is unarchived", async () => {
+    const page1 = Array.from({ length: 20 }, (_, i) => createArchivedSession(i + 1));
+    const page2 = Array.from({ length: 3 }, (_, i) => createArchivedSession(i + 21));
+
+    installFetch({
+      archivedPages: [page1, page2],
+      onUnarchive: () => jsonResponse({ status: "active" }),
+    });
+
+    renderComponent();
+
+    expect(await screen.findByText("Session 1")).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Load more" }));
+    expect(await screen.findByText("Session 22")).toBeInTheDocument();
+
+    // Unarchive Session 22 (from page 2).
+    const row = screen.getByText("Session 22").closest("div.group") as HTMLElement;
+    const unarchiveButton = row.querySelector("button") as HTMLButtonElement;
+    await user.click(unarchiveButton);
+
+    await waitFor(() => {
+      expect(toastMock.success).toHaveBeenCalledWith("Session unarchived");
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Session 22")).not.toBeInTheDocument();
+    });
+    // Siblings in page 2 must remain.
+    expect(screen.getByText("Session 21")).toBeInTheDocument();
+    expect(screen.getByText("Session 23")).toBeInTheDocument();
+    // Page 1 anchor still there.
+    expect(screen.getByText("Session 1")).toBeInTheDocument();
+  });
+
+  it("keeps the row visible when the unarchive request returns 500", async () => {
+    installFetch({
+      archivedPages: [[createArchivedSession(1)]],
+      onUnarchive: () => jsonResponse({ error: "boom" }, 500),
+    });
+
+    renderComponent();
+
+    expect(await screen.findByText("Session 1")).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Unarchive" }));
+
+    await waitFor(() => {
+      expect(toastMock.error).toHaveBeenCalledWith("Failed to unarchive session");
+    });
+
+    expect(screen.getByText("Session 1")).toBeInTheDocument();
+    expect(toastMock.success).not.toHaveBeenCalled();
+  });
+});
+
+function SidebarProbe() {
+  // Mounting this subscribes to SIDEBAR_SESSIONS_KEY so that mutate(key)
+  // from the component-under-test triggers a real refetch we can observe.
+  useSWR<{ sessions: unknown[]; hasMore: boolean }>(SIDEBAR_SESSIONS_KEY);
+  return null;
+}
+
+describe("DataControlsSettings — sidebar invalidation", () => {
+  it("refetches the sidebar session list after a successful unarchive", async () => {
+    const sidebarHandler = vi.fn(() => jsonResponse({ sessions: [], hasMore: false }));
+    const fetchMock = installFetch({
+      archivedPages: [[createArchivedSession(1)]],
+      onUnarchive: () => jsonResponse({ status: "active" }),
+      onListSidebar: sidebarHandler,
+    });
+
+    render(
+      <SWRConfig
+        value={{
+          dedupingInterval: 0,
+          revalidateOnFocus: false,
+          revalidateIfStale: false,
+          revalidateOnReconnect: false,
+          fetcher: async (url: string) => {
+            const response = await fetch(url);
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            return response.json();
+          },
+        }}
+      >
+        <DataControlsSettings />
+        <SidebarProbe />
+      </SWRConfig>
+    );
+
+    expect(await screen.findByText("Session 1")).toBeInTheDocument();
+    // Sidebar probe should have done its initial fetch.
+    await waitFor(() => {
+      expect(sidebarHandler).toHaveBeenCalledTimes(1);
+    });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "Unarchive" }));
+
+    await waitFor(() => {
+      expect(toastMock.success).toHaveBeenCalledWith("Session unarchived");
+    });
+
+    // After unarchive, the sidebar key should have been revalidated.
+    await waitFor(() => {
+      expect(sidebarHandler).toHaveBeenCalledTimes(2);
+    });
+    expect(fetchMock).toHaveBeenCalledWith(SIDEBAR_SESSIONS_KEY);
+  });
+});

--- a/packages/web/src/components/settings/data-controls-settings.tsx
+++ b/packages/web/src/components/settings/data-controls-settings.tsx
@@ -69,6 +69,10 @@ export function DataControlsSettings() {
         { revalidate: false, populateCache: true }
       );
       setExtraSessions((prev) => prev.filter((s) => s.id !== sessionId));
+      // Server-side list shifts down by one, so the next Load more must
+      // start one offset earlier to avoid skipping the session that took
+      // this row's slot.
+      setOffset((prev) => prev - 1);
       mutate(SIDEBAR_SESSIONS_KEY);
     } catch {
       toast.error("Failed to unarchive session");

--- a/packages/web/src/components/settings/data-controls-settings.tsx
+++ b/packages/web/src/components/settings/data-controls-settings.tsx
@@ -6,7 +6,11 @@ import useSWR, { mutate } from "swr";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { buildSessionHref, type SessionItem } from "@/components/session-sidebar";
-import { SIDEBAR_SESSIONS_KEY } from "@/lib/session-list";
+import {
+  SIDEBAR_SESSIONS_KEY,
+  removeSessionFromList,
+  type SessionListResponse,
+} from "@/lib/session-list";
 import { formatRelativeTime } from "@/lib/time";
 
 const PAGE_SIZE = 20;
@@ -14,23 +18,21 @@ const ARCHIVED_SESSIONS_KEY = `/api/sessions?status=archived&limit=${PAGE_SIZE}&
 
 export function DataControlsSettings() {
   const [extraSessions, setExtraSessions] = useState<SessionItem[]>([]);
-  const [hiddenIds, setHiddenIds] = useState<Set<string>>(new Set());
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(false);
   const [offset, setOffset] = useState(0);
 
-  const { data, isLoading: loading } = useSWR<{ sessions: SessionItem[] }>(ARCHIVED_SESSIONS_KEY, {
+  const { data, isLoading: loading } = useSWR<SessionListResponse>(ARCHIVED_SESSIONS_KEY, {
     onSuccess: (data) => {
       const fetched = data.sessions || [];
       setHasMore(fetched.length === PAGE_SIZE);
       setOffset(fetched.length);
       setExtraSessions([]);
-      setHiddenIds(new Set());
     },
   });
 
   const firstPageSessions = data?.sessions ?? [];
-  const sessions = [...firstPageSessions, ...extraSessions].filter((s) => !hiddenIds.has(s.id));
+  const sessions = [...firstPageSessions, ...extraSessions];
 
   const handleLoadMore = useCallback(async () => {
     setLoadingMore(true);
@@ -51,21 +53,25 @@ export function DataControlsSettings() {
   }, [offset]);
 
   const handleUnarchive = async (sessionId: string) => {
-    // Optimistically hide from both first-page and extra sessions
-    setHiddenIds((prev) => new Set(prev).add(sessionId));
     try {
       const res = await fetch(`/api/sessions/${sessionId}/unarchive`, { method: "POST" });
-      if (res.ok) {
-        toast.success("Session unarchived");
-        mutate(SIDEBAR_SESSIONS_KEY);
-        mutate(ARCHIVED_SESSIONS_KEY);
-      } else {
+      if (!res.ok) {
         toast.error("Failed to unarchive session");
-        mutate(ARCHIVED_SESSIONS_KEY);
+        return;
       }
+      toast.success("Session unarchived");
+      await mutate<SessionListResponse>(
+        ARCHIVED_SESSIONS_KEY,
+        (current) =>
+          current
+            ? { ...current, sessions: removeSessionFromList(current.sessions, sessionId) }
+            : current,
+        { revalidate: false, populateCache: true }
+      );
+      setExtraSessions((prev) => prev.filter((s) => s.id !== sessionId));
+      mutate(SIDEBAR_SESSIONS_KEY);
     } catch {
       toast.error("Failed to unarchive session");
-      mutate(ARCHIVED_SESSIONS_KEY);
     }
   };
 


### PR DESCRIPTION
## Summary

- The Data Controls archive list optimistically hid rows on Unarchive but never rolled back `hiddenIds` on failure, and on success the `mutate(ARCHIVED_SESSIONS_KEY)` revalidation collapsed any "Load more" pagination via the SWR `onSuccess` callback.
- Switched to the request-first + scoped cache-update pattern already used by `session-sidebar.tsx` (`handleSessionArchived`): on success, remove the row from the first-page SWR cache with `revalidate: false` and filter it from `extraSessions`; on failure, leave state alone so the row stays visible.
- Adds a Vitest + RTL test file covering the affected behavior.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Unarchive succeeds | Row hidden optimistically, then revalidation collapses page-2 of "Load more" | Row removed from page-1 cache + extras filter; pagination preserved |
| Unarchive returns 500 | Row hidden, sometimes flickers back on revalidation, stays hidden if GET also fails | Row stays visible; `toast.error` shown |
| Unarchive succeeds on a page-2 session | Row reappears after revalidation collapse + onSuccess wipe | Row removed cleanly from `extraSessions` |
| Sidebar refresh on success | `mutate(SIDEBAR_SESSIONS_KEY)` (kept) | Same — newly active session reappears in sidebar |

## Out of scope (flagged for follow-up)

- The `onSuccess` callback on the archived-sessions `useSWR` still resets `extraSessions` on unrelated revalidations (focus/reconnect). The sidebar handles the same issue with a `prevDataRef` synchronous-render pattern (`session-sidebar.tsx:96-101`); worth porting in a separate PR.
- No tests added for the `/api/sessions/[id]/unarchive` route handler — would match the `route.test.ts` pattern from existing API route tests.

## Test plan

- [x] `npx vitest run` in `packages/web` — 30 files, 242 tests pass (5 new in `data-controls-settings.test.tsx`)
- [x] `npx tsc --noEmit` in `packages/web` — clean
- [x] `npx eslint src/` in `packages/web` — clean
- [ ] Manual: Settings > Data Controls — unarchive a session, confirm row disappears and reappears in sidebar
- [ ] Manual: Settings > Data Controls — force POST `/api/sessions/<id>/unarchive` to 500 via devtools, confirm row stays visible and an error toast appears
- [ ] Manual: Settings > Data Controls — with `>20` archived sessions, click "Load more", then unarchive a session from page 1; confirm page-2 rows remain visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session unarchive now shows clear success and error notifications and preserves pagination visibility when unarchiving across pages.
  * Sidebar reliably refreshes to reflect session unarchives.

* **Tests**
  * Added test coverage for unarchive success/failure, pagination edge cases, UI row visibility, and sidebar refresh behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/635)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->