### PR TITLE
Fix Modal repo image snapshot timeout cleanup

### DIFF
--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -30,6 +30,7 @@ from ..images.base import base_image
 log = get_logger("manager")
 
 DEFAULT_SANDBOX_TIMEOUT_SECONDS = 7200  # 2 hours
+SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS = 300
 MAX_TUNNEL_PORTS = 10
 
 
@@ -485,7 +486,9 @@ class SandboxManager:
 
         # Use Modal's native snapshot_filesystem() API
         # This returns an Image directly (not async)
-        image = handle.modal_sandbox.snapshot_filesystem()
+        image = handle.modal_sandbox.snapshot_filesystem(
+            timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS
+        )
 
         # The image object_id is the unique identifier for this snapshot
         # Modal automatically stores the image and it persists indefinitely

--- a/packages/modal-infra/src/scheduler/image_builder.py
+++ b/packages/modal-infra/src/scheduler/image_builder.py
@@ -52,6 +52,22 @@ class BuildError(Exception):
     pass
 
 
+async def _terminate_build_sandbox(handle, build_id: str, reason: str) -> bool:
+    """Terminate a build sandbox, logging but not failing the build on cleanup errors."""
+    try:
+        await handle.modal_sandbox.terminate.aio()
+        log.info("build.sandbox_terminated", build_id=build_id, reason=reason)
+        return True
+    except Exception as e:
+        log.warn(
+            "build.sandbox_terminate_failed",
+            build_id=build_id,
+            reason=reason,
+            error=str(e),
+        )
+        return False
+
+
 def _outbound_secret() -> str:
     """Get INTERNAL_CALLBACK_SECRET for authenticating outbound calls to the control plane."""
     secret = os.environ.get("INTERNAL_CALLBACK_SECRET")
@@ -199,7 +215,7 @@ async def build_repo_image(
         build_id: Build identifier from the control plane
         user_env_vars: User-defined environment variables (repo secrets) injected into the build sandbox
     """
-    from ..sandbox.manager import SandboxManager
+    from ..sandbox.manager import SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS, SandboxManager
 
     # Validate callback URL against allowed hosts to prevent SSRF
     if callback_url and not validate_control_plane_url(callback_url):
@@ -208,6 +224,8 @@ async def build_repo_image(
 
     start_time = time.time()
     manager = SandboxManager()
+    handle = None
+    sandbox_terminated = False
 
     try:
         clone_token = _generate_clone_token()
@@ -236,11 +254,13 @@ async def build_repo_image(
             raise BuildError(f"Build sandbox exited without completing (exit_code={exit_code})")
 
         # 4. Snapshot the running sandbox's filesystem
-        image = await handle.modal_sandbox.snapshot_filesystem.aio()
+        image = await handle.modal_sandbox.snapshot_filesystem.aio(
+            timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS
+        )
         provider_image_id = image.object_id
 
         # 5. Terminate the sandbox (no longer needed after snapshot)
-        await handle.modal_sandbox.terminate.aio()
+        sandbox_terminated = await _terminate_build_sandbox(handle, build_id, "snapshot_complete")
 
         build_duration = time.time() - start_time
 
@@ -266,6 +286,9 @@ async def build_repo_image(
 
     except Exception as e:
         build_duration = time.time() - start_time
+        if handle is not None and not sandbox_terminated:
+            sandbox_terminated = await _terminate_build_sandbox(handle, build_id, "build_failed")
+
         log.error(
             "build.failed",
             build_id=build_id,
@@ -284,6 +307,9 @@ async def build_repo_image(
                     "error": str(e),
                 },
             )
+    finally:
+        if handle is not None and not sandbox_terminated:
+            await _terminate_build_sandbox(handle, build_id, "cleanup")
 
 
 # ---------------------------------------------------------------------------

--- a/packages/modal-infra/tests/test_image_builder_v2.py
+++ b/packages/modal-infra/tests/test_image_builder_v2.py
@@ -2,18 +2,21 @@
 
 import json
 import time
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
 from sandbox_runtime.auth.internal import generate_internal_token, verify_internal_token
+from src.sandbox.manager import SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS
 from src.scheduler.image_builder import (
     CALLBACK_BACKOFF_BASE,
     CALLBACK_MAX_RETRIES,
     BuildError,
     _callback_with_retry,
     _stream_build_logs,
+    build_repo_image,
 )
 
 
@@ -233,7 +236,7 @@ class TestStreamBuildLogs:
 
         async def _raise():
             raise Exception("stream error")
-            yield  # noqa: unreachable — makes this an async generator
+            yield  # pragma: no cover - makes this an async generator
 
         mock_sandbox = MagicMock()
         mock_sandbox.stdout = _raise()
@@ -265,3 +268,101 @@ class TestBuildError:
         err = BuildError("sandbox exited with code 1")
         assert isinstance(err, Exception)
         assert str(err) == "sandbox exited with code 1"
+
+
+class TestBuildRepoImage:
+    """Test the async repo image build worker."""
+
+    @staticmethod
+    def _async_stdout(lines):
+        async def _aiter():
+            for line in lines:
+                yield line
+
+        return _aiter()
+
+    def _build_handle(self, *, snapshot_side_effect=None):
+        snapshot_aio = AsyncMock(
+            side_effect=snapshot_side_effect,
+            return_value=SimpleNamespace(object_id="im-test"),
+        )
+        snapshot_filesystem = MagicMock()
+        snapshot_filesystem.aio = snapshot_aio
+        terminate_aio = AsyncMock()
+        terminate = SimpleNamespace(aio=terminate_aio)
+        sandbox = SimpleNamespace(
+            stdout=self._async_stdout(
+                [
+                    json.dumps({"event": "git.sync_complete", "head_sha": "abc123"}),
+                    json.dumps({"event": "image_build.complete", "duration_ms": 5000}),
+                ]
+            ),
+            snapshot_filesystem=snapshot_filesystem,
+            terminate=terminate,
+            returncode=0,
+        )
+        return SimpleNamespace(modal_sandbox=sandbox), snapshot_aio, terminate_aio
+
+    @pytest.mark.asyncio
+    async def test_uses_snapshot_timeout_and_terminates_on_success(self):
+        handle, snapshot_aio, terminate_aio = self._build_handle()
+        manager = SimpleNamespace(create_build_sandbox=AsyncMock(return_value=handle))
+
+        with (
+            patch("src.scheduler.image_builder.validate_control_plane_url", return_value=True),
+            patch("src.scheduler.image_builder._generate_clone_token", return_value="gh-token"),
+            patch("src.sandbox.manager.SandboxManager", return_value=manager),
+            patch(
+                "src.scheduler.image_builder._callback_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as callback,
+        ):
+            await build_repo_image.local(
+                repo_owner="acme",
+                repo_name="repo",
+                callback_url="https://cp.test/repo-images/build-complete",
+                build_id="img-1",
+            )
+
+        snapshot_aio.assert_awaited_once_with(timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS)
+        terminate_aio.assert_awaited_once()
+        callback.assert_awaited_once()
+        callback_payload = callback.await_args.args[1]
+        assert callback_payload["build_id"] == "img-1"
+        assert callback_payload["provider_image_id"] == "im-test"
+        assert callback_payload["base_sha"] == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_terminates_and_reports_failure_when_snapshot_times_out(self):
+        handle, snapshot_aio, terminate_aio = self._build_handle(
+            snapshot_side_effect=TimeoutError("Timed out waiting for image to be created")
+        )
+        manager = SimpleNamespace(create_build_sandbox=AsyncMock(return_value=handle))
+
+        with (
+            patch("src.scheduler.image_builder.validate_control_plane_url", return_value=True),
+            patch("src.scheduler.image_builder._generate_clone_token", return_value="gh-token"),
+            patch("src.sandbox.manager.SandboxManager", return_value=manager),
+            patch(
+                "src.scheduler.image_builder._callback_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as callback,
+        ):
+            await build_repo_image.local(
+                repo_owner="acme",
+                repo_name="repo",
+                callback_url="https://cp.test/repo-images/build-complete",
+                build_id="img-1",
+            )
+
+        snapshot_aio.assert_awaited_once_with(timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS)
+        terminate_aio.assert_awaited_once()
+        callback.assert_awaited_once()
+        failure_url, failure_payload = callback.await_args.args
+        assert failure_url == "https://cp.test/repo-images/build-failed"
+        assert failure_payload == {
+            "build_id": "img-1",
+            "error": "Timed out waiting for image to be created",
+        }

--- a/packages/modal-infra/tests/test_snapshot_timeout.py
+++ b/packages/modal-infra/tests/test_snapshot_timeout.py
@@ -1,0 +1,28 @@
+"""Tests for Modal filesystem snapshot timeout configuration."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sandbox_runtime.types import SandboxStatus
+from src.sandbox.manager import (
+    SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS,
+    SandboxHandle,
+    SandboxManager,
+)
+
+
+def test_take_snapshot_passes_explicit_timeout():
+    """Session snapshots should not rely on Modal's short default timeout."""
+    image = SimpleNamespace(object_id="im-session")
+    snapshot_filesystem = MagicMock(return_value=image)
+    handle = SandboxHandle(
+        sandbox_id="sandbox-1",
+        modal_sandbox=SimpleNamespace(snapshot_filesystem=snapshot_filesystem),
+        status=SandboxStatus.READY,
+        created_at=0,
+    )
+
+    image_id = SandboxManager().take_snapshot(handle)
+
+    assert image_id == "im-session"
+    snapshot_filesystem.assert_called_once_with(timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS)


### PR DESCRIPTION
## Summary

- Add a shared explicit timeout for Modal `snapshot_filesystem()` calls so repo image builds and session snapshots do not rely on Modal's short default.
- Terminate image build sandboxes on both successful snapshots and snapshot/build failures.
- Add focused tests for snapshot timeout propagation and build sandbox cleanup on snapshot timeout.

## Root Cause

`Sandbox.snapshot_filesystem()` defaults to a 55 second timeout in the installed Modal SDK. Large repos can finish `setup.sh` successfully, then exceed that snapshot timeout and report `Timed out waiting for image to be created`. The previous failure path also reported the build failure without terminating the build sandbox.

## Validation

- `cd packages/modal-infra && ruff check src/scheduler/image_builder.py src/sandbox/manager.py tests/test_image_builder_v2.py tests/test_snapshot_timeout.py`
- `cd packages/modal-infra && pytest tests/ -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox cleanup during image builds with safer error handling and enhanced logging when cleanup encounters issues.
  * Enhanced filesystem snapshot timeout configuration for more reliable and robust snapshot operations.

* **Tests**
  * Added comprehensive test coverage validating image build operations and snapshot timeout behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/636)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->