### PR TITLE
Keep sidebar branding compact

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -403,12 +403,10 @@ project_root    = "../../../"
 # Display name shown in the web UI tab title, sign-in page, landing hero, bot
 # messages (Slack/Linear), PR body footer, and outbound HTTP User-Agent.
 # app_name = "Open-Inspect"
-# Short brand label shown only in the sidebar header (next to the logo).
-# Leave empty to default to "Inspect" (or to follow app_name when app_name
-# is overridden). Set this when app_name is too wide for the sidebar.
-# app_short_name = ""
+# Short brand label shown only in the sidebar header.
+# app_short_name = "Inspect"
 # Optional URL (absolute or root-relative) to a custom logo/favicon. When set,
-# replaces the built-in icon in the web sidebar and browser favicon.
+# replaces the built-in icon in the command menu and browser favicon.
 # app_icon_url = ""
 
 # Initial deployment: set both to false (see Step 7)
@@ -887,20 +885,19 @@ Add these to your `terraform.tfvars`:
 
 ```hcl
 # Display name shown in:
-#   - Web tab title, sidebar logo, sign-in page, landing hero
+#   - Web tab title, sign-in page, landing hero
 #   - Slack App Home settings page
 #   - Linear OAuth success page and completion comments
 #   - PR body footer ("Created with [<app_name>](<session-url>)")
 #   - Outbound HTTP User-Agent headers (GitHub, GitLab API)
 app_name = "Acme Bot"
 
-# Optional short label for the sidebar header next to the logo. When empty,
-# falls through to app_name (or "Inspect" if app_name is also unset). Set this
-# when app_name is too wide for the sidebar.
+# Optional short label for the sidebar header. Set this when app_name is too
+# wide for the sidebar.
 app_short_name = "Acme"
 
 # Optional URL to a custom logo image (SVG/PNG). When set, replaces the
-# built-in icon in the web sidebar, command menu, and browser favicon.
+# built-in icon in the command menu and browser favicon.
 # Use an absolute URL or a root-relative path served from packages/web/public/.
 app_icon_url = "/branding/logo.svg"   # or "https://cdn.example.com/logo.svg"
 ```

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -97,10 +97,8 @@ ALLOWED_EMAIL_DOMAINS=
 # inlined into the client bundle at build time — restart `npm run dev`
 # after changing them.
 NEXT_PUBLIC_APP_NAME=Open-Inspect
-# Short label for the sidebar header (next to the logo). Defaults to
-# "Inspect" when unset; falls through to NEXT_PUBLIC_APP_NAME when only
-# the long name is overridden.
-NEXT_PUBLIC_APP_SHORT_NAME=
+# Short label for the sidebar header.
+NEXT_PUBLIC_APP_SHORT_NAME=Inspect
 NEXT_PUBLIC_APP_ICON_URL=
 ```
 

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -36,7 +36,6 @@ import {
   BranchIcon,
   DataControlsIcon,
 } from "@/components/ui/icons";
-import { AppIcon } from "@/components/ui/app-icon";
 import { APP_SHORT_NAME } from "@/lib/site-config";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -270,7 +269,7 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
     <aside className="w-72 h-dvh flex flex-col border-r border-border-muted bg-background">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-border-muted">
-        <div className="flex items-center gap-2">
+        <div className="flex min-w-0 items-center gap-2">
           <Button
             variant="ghost"
             size="icon"
@@ -280,12 +279,11 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
           >
             <SidebarIcon className="w-4 h-4" />
           </Button>
-          <Link href="/" onClick={handleNavigationSelect} className="flex items-center gap-2">
-            <AppIcon className="w-5 h-5" />
-            <span className="font-semibold text-foreground">{APP_SHORT_NAME}</span>
+          <Link href="/" onClick={handleNavigationSelect} className="min-w-0">
+            <span className="block truncate font-semibold text-foreground">{APP_SHORT_NAME}</span>
           </Link>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           <Button
             variant="ghost"
             size="icon"

--- a/packages/web/src/lib/site-config.test.ts
+++ b/packages/web/src/lib/site-config.test.ts
@@ -58,7 +58,14 @@ describe("site-config", () => {
     expect(APP_SHORT_NAME).toBe("Inspect");
   });
 
-  it("APP_SHORT_NAME falls through to APP_NAME when only NEXT_PUBLIC_APP_NAME is set", async () => {
+  it("APP_SHORT_NAME defaults to 'Inspect' when NEXT_PUBLIC_APP_NAME is the built-in default", async () => {
+    process.env.NEXT_PUBLIC_APP_NAME = "Open-Inspect";
+    delete process.env.NEXT_PUBLIC_APP_SHORT_NAME;
+    const { APP_SHORT_NAME } = await import("./site-config");
+    expect(APP_SHORT_NAME).toBe("Inspect");
+  });
+
+  it("APP_SHORT_NAME falls through to custom APP_NAME when only NEXT_PUBLIC_APP_NAME is set", async () => {
     process.env.NEXT_PUBLIC_APP_NAME = "Acme Bot";
     delete process.env.NEXT_PUBLIC_APP_SHORT_NAME;
     const { APP_SHORT_NAME } = await import("./site-config");

--- a/packages/web/src/lib/site-config.ts
+++ b/packages/web/src/lib/site-config.ts
@@ -2,14 +2,15 @@ import { DEFAULT_APP_NAME } from "@open-inspect/shared";
 
 export const APP_NAME = process.env.NEXT_PUBLIC_APP_NAME?.trim() || DEFAULT_APP_NAME;
 
+export const DEFAULT_APP_SHORT_NAME = "Inspect";
+
 /**
- * Short brand label shown in the sidebar header next to the logo.
- * Defaults to "Inspect" (the historical short brand). Set
- * NEXT_PUBLIC_APP_SHORT_NAME to override (defaults to APP_NAME when neither
- * is set explicitly, but stays "Inspect" for the built-in brand).
+ * Short brand label shown in the sidebar header.
+ * Defaults to "Inspect" for the built-in brand. Set NEXT_PUBLIC_APP_SHORT_NAME
+ * to override, or customize NEXT_PUBLIC_APP_NAME to use that as the fallback.
  */
 export const APP_SHORT_NAME =
   process.env.NEXT_PUBLIC_APP_SHORT_NAME?.trim() ||
-  (process.env.NEXT_PUBLIC_APP_NAME?.trim() ? APP_NAME : "Inspect");
+  (APP_NAME === DEFAULT_APP_NAME ? DEFAULT_APP_SHORT_NAME : APP_NAME);
 
 export const APP_ICON_URL = process.env.NEXT_PUBLIC_APP_ICON_URL?.trim() || "";

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -204,14 +204,13 @@ project_root = "../../../"
 # Also used as the outbound HTTP User-Agent header. Defaults to "Open-Inspect".
 # app_name = "Open-Inspect"
 
-# Short brand label shown only in the sidebar header (next to the logo).
-# Leave empty to default to "Inspect" when app_name is unset, or to fall through
-# to app_name when app_name is overridden. Set this when app_name is too wide
-# for the sidebar (e.g. app_name = "Acme Coding Agent", app_short_name = "Acme").
-# app_short_name = ""
+# Short brand label shown only in the sidebar header.
+# Defaults to "Inspect". Set this when app_name is too wide for the sidebar
+# (e.g. app_name = "Acme Coding Agent", app_short_name = "Acme").
+# app_short_name = "Inspect"
 
 # Optional URL (absolute or root-relative path) to a custom logo image for the
-# web sidebar and browser favicon. Leave empty to use the built-in icon.
+# command menu and browser favicon. Leave empty to use the built-in icon.
 # Example: "/branding/logo.svg" (file under packages/web/public/) or
 #          "https://cdn.example.com/logo.svg".
 # app_icon_url = ""

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -332,19 +332,19 @@ variable "deployment_name" {
 }
 
 variable "app_name" {
-  description = "Display name shown in the web UI tab title, sidebar logo, sign-in page, bot messages (Slack, Linear), PR body footer, and outbound HTTP User-Agent headers."
+  description = "Display name shown in the web UI tab title, sign-in page, bot messages (Slack, Linear), PR body footer, and outbound HTTP User-Agent headers."
   type        = string
   default     = "Open-Inspect"
 }
 
 variable "app_short_name" {
-  description = "Short brand label shown only in the web sidebar header next to the logo. Defaults to 'Inspect' to keep the sidebar visually compact. When empty, falls through to app_name when app_name is overridden, otherwise renders as 'Inspect'."
+  description = "Short brand label shown only in the web sidebar header. Defaults to 'Inspect' to keep the sidebar visually compact."
   type        = string
-  default     = ""
+  default     = "Inspect"
 }
 
 variable "app_icon_url" {
-  description = "Optional URL (absolute or root-relative) to a custom logo image for the web sidebar and browser favicon. Leave empty to use the built-in icon."
+  description = "Optional URL (absolute or root-relative) to a custom logo image for the command menu and browser favicon. Leave empty to use the built-in icon."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Summary
- Default the sidebar-specific app short name to `Inspect` in Terraform and the frontend fallback.
- Keep `Open-Inspect` as the full app name while avoiding it in the compact sidebar header.
- Remove the app/document icon from the sidebar header and update branding docs to match.

## Validation
- `npm ci`
- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/web -- site-config`
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web`
- `npx prettier --check docs/GETTING_STARTED.md docs/SETUP_GUIDE.md packages/web/src/components/session-sidebar.tsx packages/web/src/lib/site-config.ts packages/web/src/lib/site-config.test.ts`
- `terraform fmt -check terraform/environments/production/variables.tf`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified branding customization guides and Terraform examples; explicit default short name set to "Inspect" and icon guidance focused on command menu/browser favicon.

* **Chores**
  * Simplified sidebar header to a text-only short-name with improved truncation.
  * Standardized fallback behavior for the short app name to ensure consistent display across default and custom configurations.

* **Tests**
  * Adjusted tests to cover the updated short-name fallback scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/639)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->