### PR TITLE
Add GitHub integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Interact with agents from wherever your team already works:
 - **Slack Bot** — @mention or DM to start a session; replies thread back with results. Per-user
   model and branch preferences via App Home. See [Slack integration](docs/integrations/SLACK.md)
 - **GitHub Bot** — Auto-review on PR open, respond to @mentions in PR comments, or trigger on
-  reviewer assignment. Configurable per-repo
+  reviewer assignment. Configurable per-repo. See [GitHub integration](docs/integrations/GITHUB.md)
 - **Linear Bot** — Assign an issue to the agent and it creates a coding session, posts progress
   activities, and links the resulting PR
 - **Webhooks** — Trigger sessions from any external system via authenticated HTTP POST

--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ Interact with agents from wherever your team already works:
   panel, and multiplayer presence
 - **Slack Bot** — @mention or DM to start a session; replies thread back with results. Per-user
   model and branch preferences via App Home. See [Slack integration](docs/integrations/SLACK.md)
-- **GitHub Bot** — Auto-review on PR open, respond to @mentions in PR comments, or trigger on
-  reviewer assignment. Configurable per-repo. See [GitHub integration](docs/integrations/GITHUB.md)
+- **GitHub Bot** — Auto-review on PR open or respond to @mentions in PR comments. Configurable
+  per-repo. See [GitHub integration](docs/integrations/GITHUB.md)
 - **Linear Bot** — Assign an issue to the agent and it creates a coding session, posts progress
   activities, and links the resulting PR
 - **Webhooks** — Trigger sessions from any external system via authenticated HTTP POST

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -569,7 +569,7 @@ Or construct it from your App's slug: if your app is named `My-Inspect-App`, the
 
 - **Code Review**: Assign the bot as a PR reviewer — it performs an automated review
 - **Comment Actions**: @mention the bot in a PR comment with instructions (e.g.,
-  `@my-app[bot] fix the failing test`)
+  `@my-app[bot] explain why this test is failing`)
 
 For day-to-day workflows, see [GitHub Integration](./integrations/GITHUB.md).
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -571,6 +571,8 @@ Or construct it from your App's slug: if your app is named `My-Inspect-App`, the
 - **Comment Actions**: @mention the bot in a PR comment with instructions (e.g.,
   `@my-app[bot] fix the failing test`)
 
+For day-to-day workflows, see [GitHub Integration](./integrations/GITHUB.md).
+
 ---
 
 ## Step 8: Deploy the Web App

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -567,7 +567,8 @@ Or construct it from your App's slug: if your app is named `My-Inspect-App`, the
 
 ### Usage
 
-- **Code Review**: Assign the bot as a PR reviewer — it performs an automated review
+- **Code Review**: Open a non-draft PR in a repository where auto-review is enabled — it performs an
+  automated review
 - **Comment Actions**: @mention the bot in a PR comment with instructions (e.g.,
   `@my-app[bot] explain why this test is failing`)
 
@@ -835,7 +836,7 @@ If the bot doesn't see the original message when tagged in a thread reply:
 2. Check the webhook secret matches `github_webhook_secret` in terraform.tfvars
 3. Confirm `enable_github_bot = true` in terraform.tfvars and the worker is deployed
 4. Check that `github_bot_username` matches your App's bot login (e.g., `my-app[bot]`)
-5. For PR reviews, ensure the bot is assigned as a reviewer (not just mentioned)
+5. For PR reviews, ensure auto-review is enabled for the repository and the PR is not a draft
 6. For comment actions, ensure the bot is @mentioned in a **PR** comment (not an issue)
 
 ### "Model not found" errors (Daytona provider)

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -162,9 +162,11 @@ can make HTTP requests and maintain WebSocket connections can participate.
 
 - **Web**: Next.js app with real-time streaming, session management, and settings
 - **Slack**: Bot that responds to @mentions and direct messages, classifies repos, and posts results
+- **GitHub**: Bot that reviews PRs and responds to PR `@mentions`
+- **Linear**: Agent workflow that starts sessions from Linear issue activity
 
-All clients see the same session state. Send a prompt from Slack, watch the results on web. This
-works because state lives in the control plane, not the client.
+All clients see the same session state. Send a prompt from Slack or GitHub, watch the results on
+web. This works because state lives in the control plane, not the client.
 
 ---
 

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -232,6 +232,7 @@ Control plane cannot reach Modal (or Modal is not properly configured/deployed).
 
 - Architecture and internals: [docs/HOW_IT_WORKS.md](./HOW_IT_WORKS.md)
 - Full production deployment: [docs/GETTING_STARTED.md](./GETTING_STARTED.md)
+- GitHub integration usage: [docs/integrations/GITHUB.md](./integrations/GITHUB.md)
 - Debugging and observability: [docs/DEBUGGING_PLAYBOOK.md](./DEBUGGING_PLAYBOOK.md)
 - OpenAI model setup: [docs/OPENAI_MODELS.md](./OPENAI_MODELS.md)
 - Contribution workflow: [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/docs/integrations/GITHUB.md
+++ b/docs/integrations/GITHUB.md
@@ -15,11 +15,11 @@ Settings and safety notes are covered near the end.
 
 1. Make sure the GitHub App is installed on the repository you want Open-Inspect to work in.
 2. To request a review, assign the GitHub App bot as a PR reviewer.
-3. To ask for a change or answer, mention the bot in a PR comment:
+3. To ask for analysis or a reply, mention the bot in a PR comment:
    ```text
-   @my-app[bot] fix the failing checkout test
+   @my-app[bot] can you explain why the checkout test is failing?
    ```
-4. For line-specific work, mention the bot in an inline PR review comment.
+4. For line-specific discussion, mention the bot in an inline PR review comment.
 5. Watch for the eyes reaction, which means the bot accepted the request.
 6. Open the Open-Inspect web app to watch the full session while the agent works.
 
@@ -72,15 +72,19 @@ inline review comments when useful.
 
 ## Comment-Triggered Actions
 
-Mention the GitHub App bot in a PR conversation comment to ask for code changes, analysis, or a
-follow-up answer:
+Mention the GitHub App bot in a PR conversation comment to ask for analysis, a follow-up answer, or
+a GitHub reply:
 
 ```text
-@my-app[bot] can you simplify the retry logic and update the tests?
+@my-app[bot] can you explain why this retry path is failing?
 ```
 
 Open-Inspect strips the bot mention before sending the request to the agent. The rest of the comment
 becomes the prompt.
+
+Comment-triggered sessions currently start from the repository default branch, not the PR head
+branch. Use them for responses and review-thread discussion rather than asking the agent to push
+commits to the existing PR branch.
 
 Comment-triggered actions only run on pull requests. Mentions on ordinary GitHub issues are ignored.
 Comments from the bot itself are also ignored so the bot does not respond to its own output.
@@ -105,7 +109,7 @@ GitHub rejects the reaction, the session can still start.
 For review workflows, the agent posts the review result back to the PR. Depending on what it finds,
 that may be a general review comment, an approval, a request for changes, or inline review comments.
 
-For comment-triggered workflows, the agent posts a PR comment summarizing what it did or answering
+For comment-triggered workflows, the agent posts a PR comment summarizing its response or answering
 the question. If the request came from an inline review thread, the agent may also reply in that
 thread.
 
@@ -124,7 +128,7 @@ Open the web app and go to **Settings > Integrations > GitHub** to configure the
 | Auto-review new PRs         | Whether new non-draft PRs should be reviewed automatically                                      |
 | Repository Scope            | Whether the bot responds in all accessible repositories or only selected repositories           |
 | Allowed Trigger Users       | Who can trigger the bot from GitHub                                                             |
-| Model and reasoning effort  | Per-repository model and reasoning depth for GitHub-started sessions                            |
+| Model and reasoning effort  | Model and reasoning depth for GitHub-started sessions, when configured                          |
 | Code Review Instructions    | Extra guidance appended to PR review prompts                                                    |
 | Comment Action Instructions | Extra guidance appended to `@mention` action prompts                                            |
 | Repository Overrides        | Per-repository overrides for model, reasoning, instructions, trigger users, and review behavior |
@@ -134,12 +138,17 @@ available to the GitHub App are in scope, auto-review is enabled, and users with
 admin access to the repository can trigger the bot.
 
 If repository scope is set to **Selected repositories** and no repositories are selected, the bot
-does not respond to GitHub webhooks. If **Only specific users** is selected and the user list is
-empty, no one can trigger the bot for that scope.
+does not run direct GitHub Bot workflows such as auto-review, reviewer assignment, or `@mention`
+actions. If **Only specific users** is selected and the user list is empty, no one can trigger those
+direct bot workflows for that scope.
 
-Repository overrides take priority over global defaults for the repository they apply to. Model and
-reasoning settings are configured through repository overrides; otherwise, GitHub-started sessions
-use the deployment default model.
+These GitHub Bot settings do not gate GitHub event automations. Automations are matched separately
+by their repository, event type, enabled state, and trigger conditions.
+
+Repository overrides take priority over global defaults for the repository they apply to. The web UI
+currently exposes model and reasoning settings on repository overrides. If global model or reasoning
+defaults exist in integration settings, GitHub-started sessions honor them. If neither a repository
+override nor global default sets a model, sessions use the deployment default model.
 
 ---
 
@@ -158,10 +167,14 @@ should be available.
 - By default, trigger access is checked against GitHub repository permission and requires write,
   maintain, or admin access. If you configure **Only specific users**, that list becomes the trigger
   gate for the configured scope.
-- The bot ignores draft PRs, bot-authored PRs, bot-authored comments, ordinary issue comments, and
-  comments that do not mention the bot.
-- GitHub content such as PR titles, descriptions, and comments is treated as untrusted context
-  before it is sent to the agent.
+- Auto-review skips draft PRs and PRs opened by the GitHub App bot. Manual reviewer assignments and
+  `@mention` triggers are still evaluated through the normal repository and user gates.
+- The bot ignores bot-authored comments, ordinary issue comments, and comments that do not mention
+  the bot.
+- Initial prompts mark selected GitHub fields as untrusted. Code-review prompts wrap PR title,
+  author, branches, and description; comment-triggered prompts wrap the triggering comment.
+  Review-thread file and diff context, plus GitHub context later read by the agent, are not
+  separately transformed by the bot.
 - If the bot cannot load its GitHub integration settings, it fails closed and does not start
   sessions.
 
@@ -175,8 +188,9 @@ Check that the GitHub App is installed on the repository and that the GitHub Bot
 Then confirm the webhook URL, webhook secret, subscribed events, and `github_bot_username` in
 [Complete GitHub Bot Setup](../GETTING_STARTED.md#step-7c-complete-github-bot-setup-if-using-github-bot).
 
-Also check **Settings > Integrations > GitHub**. The repository may be outside the selected
-repository scope, or the triggering user may be outside the allowed user list.
+Also check **Settings > Integrations > GitHub**. For direct GitHub Bot workflows, the repository may
+be outside the selected repository scope, or the triggering user may be outside the allowed user
+list.
 
 ### Auto-review did not run
 

--- a/docs/integrations/GITHUB.md
+++ b/docs/integrations/GITHUB.md
@@ -1,0 +1,207 @@
+# GitHub Integration
+
+Open-Inspect's GitHub integration lets your team start agent work from pull requests. The GitHub Bot
+can review PRs, respond to `@mentions` in PR comments, and act on inline review-thread comments.
+
+This guide is for people using the GitHub integration day to day. If you are installing the GitHub
+App or deploying the bot worker, start with
+[Create GitHub App](../GETTING_STARTED.md#step-3-create-github-app) and
+[Complete GitHub Bot Setup](../GETTING_STARTED.md#step-7c-complete-github-bot-setup-if-using-github-bot).
+Settings and safety notes are covered near the end.
+
+---
+
+## Quick Start
+
+1. Make sure the GitHub App is installed on the repository you want Open-Inspect to work in.
+2. To request a review, assign the GitHub App bot as a PR reviewer.
+3. To ask for a change or answer, mention the bot in a PR comment:
+   ```text
+   @my-app[bot] fix the failing checkout test
+   ```
+4. For line-specific work, mention the bot in an inline PR review comment.
+5. Watch for the eyes reaction, which means the bot accepted the request.
+6. Open the Open-Inspect web app to watch the full session while the agent works.
+
+---
+
+## What GitHub Can Do
+
+| Workflow                  | How it works                                                               |
+| ------------------------- | -------------------------------------------------------------------------- |
+| Auto-review new PRs       | Review non-draft PRs when they are opened, if auto-review is enabled       |
+| Review on demand          | Assign the GitHub App bot as a PR reviewer                                 |
+| Respond to PR comments    | Mention the bot in a PR conversation comment                               |
+| Respond to review threads | Mention the bot in an inline review comment                                |
+| Post back to GitHub       | Submit a PR review, reply to a review thread, or post a PR summary comment |
+| Customize behavior        | Set repository scope, trigger users, models, and custom instructions       |
+
+Open-Inspect does not use GitHub slash commands today. In GitHub, requests are ordinary PR comments
+or review-thread comments that mention the bot.
+
+---
+
+## Starting Code Reviews
+
+### Auto-review on PR open
+
+When **Auto-review new PRs** is enabled, Open-Inspect starts a review session for newly opened,
+non-draft PRs in enabled repositories.
+
+Auto-review is skipped when:
+
+- The PR is a draft
+- The PR was opened by the GitHub App bot itself
+- The repository is outside the configured GitHub Bot scope
+- The PR opener is not allowed to trigger the bot
+- Auto-review is disabled globally or for that repository
+
+Converting a draft PR to ready for review does not start the same auto-review path. Assign the bot
+as a reviewer if you want a review after a draft becomes ready.
+
+### Reviewer assignment
+
+Assign the GitHub App bot as a reviewer on a PR to request an on-demand code review. The bot starts
+a new Open-Inspect session, acknowledges the request with an eyes reaction on the PR, and asks the
+agent to inspect the PR diff and submit a GitHub review.
+
+The review can be a general comment, an approval, or a request for changes. The agent may also add
+inline review comments when useful.
+
+---
+
+## Comment-Triggered Actions
+
+Mention the GitHub App bot in a PR conversation comment to ask for code changes, analysis, or a
+follow-up answer:
+
+```text
+@my-app[bot] can you simplify the retry logic and update the tests?
+```
+
+Open-Inspect strips the bot mention before sending the request to the agent. The rest of the comment
+becomes the prompt.
+
+Comment-triggered actions only run on pull requests. Mentions on ordinary GitHub issues are ignored.
+Comments from the bot itself are also ignored so the bot does not respond to its own output.
+
+### Inline review comments
+
+When you mention the bot in a PR review thread, Open-Inspect includes the file path and diff context
+from that thread. The agent can reply directly to the review thread and can also post a summary
+comment on the PR.
+
+Each accepted GitHub webhook starts a new Open-Inspect session. GitHub comments do not continue an
+existing session the way Slack thread replies do. The agent still reads the current PR conversation
+when it needs context.
+
+---
+
+## What Gets Posted Back
+
+When a GitHub request is accepted, the bot adds an eyes reaction. That reaction is best-effort; if
+GitHub rejects the reaction, the session can still start.
+
+For review workflows, the agent posts the review result back to the PR. Depending on what it finds,
+that may be a general review comment, an approval, a request for changes, or inline review comments.
+
+For comment-triggered workflows, the agent posts a PR comment summarizing what it did or answering
+the question. If the request came from an inline review thread, the agent may also reply in that
+thread.
+
+GitHub does not receive the same managed completion message that Slack receives. After the initial
+eyes reaction, GitHub-facing output is written by the agent from inside the session. If you want to
+watch live progress, inspect logs, or see artifacts, open the Open-Inspect web app.
+
+---
+
+## Settings and Repository Scope
+
+Open the web app and go to **Settings > Integrations > GitHub** to configure the GitHub Bot.
+
+| Setting                     | What it controls                                                                                |
+| --------------------------- | ----------------------------------------------------------------------------------------------- |
+| Auto-review new PRs         | Whether new non-draft PRs should be reviewed automatically                                      |
+| Repository Scope            | Whether the bot responds in all accessible repositories or only selected repositories           |
+| Allowed Trigger Users       | Who can trigger the bot from GitHub                                                             |
+| Model and reasoning effort  | Per-repository model and reasoning depth for GitHub-started sessions                            |
+| Code Review Instructions    | Extra guidance appended to PR review prompts                                                    |
+| Comment Action Instructions | Extra guidance appended to `@mention` action prompts                                            |
+| Repository Overrides        | Per-repository overrides for model, reasoning, instructions, trigger users, and review behavior |
+
+If no GitHub Bot settings are configured, Open-Inspect uses permissive defaults: all repositories
+available to the GitHub App are in scope, auto-review is enabled, and users with write, maintain, or
+admin access to the repository can trigger the bot.
+
+If repository scope is set to **Selected repositories** and no repositories are selected, the bot
+does not respond to GitHub webhooks. If **Only specific users** is selected and the user list is
+empty, no one can trigger the bot for that scope.
+
+Repository overrides take priority over global defaults for the repository they apply to. Model and
+reasoning settings are configured through repository overrides; otherwise, GitHub-started sessions
+use the deployment default model.
+
+---
+
+## Admin and Safety Notes
+
+These notes are most useful for repository and deployment admins deciding where the GitHub Bot
+should be available.
+
+- Repository access is deployment-scoped through the configured GitHub App installation. To restrict
+  what Open-Inspect can access, install the GitHub App only on intended repositories and use
+  **Repository Scope** for an additional bot-level filter.
+- The same GitHub App is used for OAuth and repository access. GitHub App credentials and webhook
+  secrets stay server-side.
+- Webhooks are verified before Open-Inspect acts on them. Duplicate webhook deliveries are
+  deduplicated so GitHub retries do not normally create duplicate sessions.
+- By default, trigger access is checked against GitHub repository permission and requires write,
+  maintain, or admin access. If you configure **Only specific users**, that list becomes the trigger
+  gate for the configured scope.
+- The bot ignores draft PRs, bot-authored PRs, bot-authored comments, ordinary issue comments, and
+  comments that do not mention the bot.
+- GitHub content such as PR titles, descriptions, and comments is treated as untrusted context
+  before it is sent to the agent.
+- If the bot cannot load its GitHub integration settings, it fails closed and does not start
+  sessions.
+
+---
+
+## Troubleshooting
+
+### The bot does not respond to a PR
+
+Check that the GitHub App is installed on the repository and that the GitHub Bot worker is enabled.
+Then confirm the webhook URL, webhook secret, subscribed events, and `github_bot_username` in
+[Complete GitHub Bot Setup](../GETTING_STARTED.md#step-7c-complete-github-bot-setup-if-using-github-bot).
+
+Also check **Settings > Integrations > GitHub**. The repository may be outside the selected
+repository scope, or the triggering user may be outside the allowed user list.
+
+### Auto-review did not run
+
+Auto-review only runs for newly opened, non-draft PRs. It is skipped for draft PRs, bot-authored
+PRs, disabled repositories, and users who are not allowed to trigger the bot. If a PR was converted
+from draft to ready for review, assign the bot as a reviewer.
+
+### A mention did not start a session
+
+Mentions must be in a pull request conversation comment or PR review thread. Mentions on ordinary
+GitHub issues are ignored. Use the bot's full GitHub username, including `[bot]`, such as
+`@my-app[bot]`.
+
+### I see an eyes reaction but no follow-up
+
+The eyes reaction means the bot accepted the request. GitHub completion output is posted by the
+agent, not by a managed bot callback. The session may still be running, or the agent may have failed
+after the request was accepted. Open the Open-Inspect web app to inspect the session.
+
+### The wrong model or instructions were used
+
+Check **Settings > Integrations > GitHub**. Repository overrides take priority over global defaults.
+Changes apply to new GitHub-triggered sessions.
+
+### The bot is active in too many repositories
+
+Limit the GitHub App installation to the repositories Open-Inspect should access. You can also set
+**Repository Scope** to **Selected repositories** in the GitHub integration settings.

--- a/docs/integrations/GITHUB.md
+++ b/docs/integrations/GITHUB.md
@@ -1,52 +1,53 @@
 # GitHub Integration
 
 Open-Inspect's GitHub integration lets your team start agent work from pull requests. The GitHub Bot
-can review PRs, respond to `@mentions` in PR comments, and act on inline review-thread comments.
+can automatically review new PRs and respond when you mention it in PR comments or inline review
+threads.
 
 This guide is for people using the GitHub integration day to day. If you are installing the GitHub
 App or deploying the bot worker, start with
 [Create GitHub App](../GETTING_STARTED.md#step-3-create-github-app) and
 [Complete GitHub Bot Setup](../GETTING_STARTED.md#step-7c-complete-github-bot-setup-if-using-github-bot).
-Settings and safety notes are covered near the end.
 
 ---
 
 ## Quick Start
 
-1. Make sure the GitHub App is installed on the repository you want Open-Inspect to work in.
-2. To request a review, assign the GitHub App bot as a PR reviewer.
+1. Make sure the GitHub App is installed on the repository.
+2. To get an automatic review, open a non-draft PR in a repository where auto-review is enabled.
 3. To ask for analysis or a reply, mention the bot in a PR comment:
    ```text
    @my-app[bot] can you explain why the checkout test is failing?
    ```
 4. For line-specific discussion, mention the bot in an inline PR review comment.
 5. Watch for the eyes reaction, which means the bot accepted the request.
-6. Open the Open-Inspect web app to watch the full session while the agent works.
+6. Open the Open-Inspect web app to watch the full session.
 
 ---
 
-## What GitHub Can Do
+## Supported Workflows
 
 | Workflow                  | How it works                                                               |
 | ------------------------- | -------------------------------------------------------------------------- |
 | Auto-review new PRs       | Review non-draft PRs when they are opened, if auto-review is enabled       |
-| Review on demand          | Assign the GitHub App bot as a PR reviewer                                 |
 | Respond to PR comments    | Mention the bot in a PR conversation comment                               |
 | Respond to review threads | Mention the bot in an inline review comment                                |
 | Post back to GitHub       | Submit a PR review, reply to a review thread, or post a PR summary comment |
 | Customize behavior        | Set repository scope, trigger users, models, and custom instructions       |
 
-Open-Inspect does not use GitHub slash commands today. In GitHub, requests are ordinary PR comments
-or review-thread comments that mention the bot.
+Open-Inspect does not use GitHub slash commands today, and it does not support requesting the GitHub
+App bot through the PR reviewer picker. Use auto-review or `@mention` comments instead.
 
 ---
 
-## Starting Code Reviews
+## Automatic PR Reviews
 
-### Auto-review on PR open
+### When It Runs
 
 When **Auto-review new PRs** is enabled, Open-Inspect starts a review session for newly opened,
-non-draft PRs in enabled repositories.
+non-draft PRs in enabled repositories. The agent inspects the PR diff and posts a GitHub review.
+
+### When It Skips
 
 Auto-review is skipped when:
 
@@ -56,21 +57,19 @@ Auto-review is skipped when:
 - The PR opener is not allowed to trigger the bot
 - Auto-review is disabled globally or for that repository
 
-Converting a draft PR to ready for review does not start the same auto-review path. Assign the bot
-as a reviewer if you want a review after a draft becomes ready.
+Converting a draft PR to ready for review does not start the same auto-review path. If you need a
+follow-up after a draft becomes ready, mention the bot in a PR comment.
 
-### Reviewer assignment
+### What It Posts
 
-Assign the GitHub App bot as a reviewer on a PR to request an on-demand code review. The bot starts
-a new Open-Inspect session, acknowledges the request with an eyes reaction on the PR, and asks the
-agent to inspect the PR diff and submit a GitHub review.
-
-The review can be a general comment, an approval, or a request for changes. The agent may also add
-inline review comments when useful.
+The agent can submit a general review comment, approve the PR, request changes, or add inline review
+comments when useful.
 
 ---
 
-## Comment-Triggered Actions
+## `@Mention` Actions
+
+### PR Conversation Comments
 
 Mention the GitHub App bot in a PR conversation comment to ask for analysis, a follow-up answer, or
 a GitHub reply:
@@ -82,68 +81,80 @@ a GitHub reply:
 Open-Inspect strips the bot mention before sending the request to the agent. The rest of the comment
 becomes the prompt.
 
-Comment-triggered sessions currently start from the repository default branch, not the PR head
-branch. Use them for responses and review-thread discussion rather than asking the agent to push
-commits to the existing PR branch.
-
-Comment-triggered actions only run on pull requests. Mentions on ordinary GitHub issues are ignored.
-Comments from the bot itself are also ignored so the bot does not respond to its own output.
-
-### Inline review comments
+### Inline Review Threads
 
 When you mention the bot in a PR review thread, Open-Inspect includes the file path and diff context
 from that thread. The agent can reply directly to the review thread and can also post a summary
 comment on the PR.
 
+### Current Branch Behavior
+
+Comment-triggered sessions currently start from the repository default branch, not the PR head
+branch. Use them for responses and review-thread discussion rather than asking the agent to push
+commits to the existing PR branch.
+
 Each accepted GitHub webhook starts a new Open-Inspect session. GitHub comments do not continue an
 existing session the way Slack thread replies do. The agent still reads the current PR conversation
 when it needs context.
 
+Comment-triggered actions only run on pull requests. Mentions on ordinary GitHub issues are ignored.
+Comments from the bot itself are also ignored so the bot does not respond to its own output.
+
 ---
 
-## What Gets Posted Back
+## What You See
+
+### Acknowledgment
 
 When a GitHub request is accepted, the bot adds an eyes reaction. That reaction is best-effort; if
 GitHub rejects the reaction, the session can still start.
 
-For review workflows, the agent posts the review result back to the PR. Depending on what it finds,
-that may be a general review comment, an approval, a request for changes, or inline review comments.
+### GitHub Output
 
-For comment-triggered workflows, the agent posts a PR comment summarizing its response or answering
-the question. If the request came from an inline review thread, the agent may also reply in that
-thread.
+For auto-review workflows, the agent posts the review result back to the PR. Depending on what it
+finds, that may be a general review comment, an approval, a request for changes, or inline review
+comments.
+
+For `@mention` workflows, the agent posts a PR comment summarizing its response or answering the
+question. If the request came from an inline review thread, the agent may also reply in that thread.
 
 GitHub does not receive the same managed completion message that Slack receives. After the initial
-eyes reaction, GitHub-facing output is written by the agent from inside the session. If you want to
-watch live progress, inspect logs, or see artifacts, open the Open-Inspect web app.
+eyes reaction, GitHub-facing output is written by the agent from inside the session. Use the
+Open-Inspect web app to watch live progress, inspect logs, or see artifacts.
 
 ---
 
-## Settings and Repository Scope
+## Settings
 
 Open the web app and go to **Settings > Integrations > GitHub** to configure the GitHub Bot.
 
-| Setting                     | What it controls                                                                                |
-| --------------------------- | ----------------------------------------------------------------------------------------------- |
-| Auto-review new PRs         | Whether new non-draft PRs should be reviewed automatically                                      |
-| Repository Scope            | Whether the bot responds in all accessible repositories or only selected repositories           |
-| Allowed Trigger Users       | Who can trigger the bot from GitHub                                                             |
-| Model and reasoning effort  | Model and reasoning depth for GitHub-started sessions, when configured                          |
-| Code Review Instructions    | Extra guidance appended to PR review prompts                                                    |
-| Comment Action Instructions | Extra guidance appended to `@mention` action prompts                                            |
-| Repository Overrides        | Per-repository overrides for model, reasoning, instructions, trigger users, and review behavior |
+### Defaults and Scope
+
+| Setting               | What it controls                                                                      |
+| --------------------- | ------------------------------------------------------------------------------------- |
+| Auto-review new PRs   | Whether new non-draft PRs should be reviewed automatically                            |
+| Repository Scope      | Whether the bot responds in all accessible repositories or only selected repositories |
+| Allowed Trigger Users | Who can trigger the bot from GitHub                                                   |
 
 If no GitHub Bot settings are configured, Open-Inspect uses permissive defaults: all repositories
 available to the GitHub App are in scope, auto-review is enabled, and users with write, maintain, or
 admin access to the repository can trigger the bot.
 
-If repository scope is set to **Selected repositories** and no repositories are selected, the bot
-does not run direct GitHub Bot workflows such as auto-review, reviewer assignment, or `@mention`
-actions. If **Only specific users** is selected and the user list is empty, no one can trigger those
-direct bot workflows for that scope.
+If repository scope is set to **Selected repositories** and no repositories are selected, direct
+GitHub Bot workflows are disabled. If **Only specific users** is selected and the user list is
+empty, no one can trigger direct bot workflows for that scope.
 
-These GitHub Bot settings do not gate GitHub event automations. Automations are matched separately
-by their repository, event type, enabled state, and trigger conditions.
+These settings do not gate GitHub event automations. Automations are matched separately by their
+repository, event type, enabled state, and trigger conditions.
+
+### Models and Instructions
+
+| Setting                     | What it controls                                                          |
+| --------------------------- | ------------------------------------------------------------------------- |
+| Model and reasoning effort  | Model and reasoning depth for GitHub-started sessions, when configured    |
+| Code Review Instructions    | Extra guidance appended to PR review prompts                              |
+| Comment Action Instructions | Extra guidance appended to `@mention` action prompts                      |
+| Repository Overrides        | Per-repository overrides for model, reasoning, instructions, and behavior |
 
 Repository overrides take priority over global defaults for the repository they apply to. The web UI
 currently exposes model and reasoning settings on repository overrides. If global model or reasoning
@@ -154,29 +165,34 @@ override nor global default sets a model, sessions use the deployment default mo
 
 ## Admin and Safety Notes
 
-These notes are most useful for repository and deployment admins deciding where the GitHub Bot
-should be available.
+### Access Boundaries
 
 - Repository access is deployment-scoped through the configured GitHub App installation. To restrict
   what Open-Inspect can access, install the GitHub App only on intended repositories and use
   **Repository Scope** for an additional bot-level filter.
 - The same GitHub App is used for OAuth and repository access. GitHub App credentials and webhook
   secrets stay server-side.
-- Webhooks are verified before Open-Inspect acts on them. Duplicate webhook deliveries are
-  deduplicated so GitHub retries do not normally create duplicate sessions.
 - By default, trigger access is checked against GitHub repository permission and requires write,
   maintain, or admin access. If you configure **Only specific users**, that list becomes the trigger
   gate for the configured scope.
-- Auto-review skips draft PRs and PRs opened by the GitHub App bot. Manual reviewer assignments and
-  `@mention` triggers are still evaluated through the normal repository and user gates.
+
+### Bot Behavior
+
+- Auto-review skips draft PRs and PRs opened by the GitHub App bot. Manual `@mention` triggers are
+  still evaluated through the normal repository and user gates.
 - The bot ignores bot-authored comments, ordinary issue comments, and comments that do not mention
   the bot.
+- If the bot cannot load its GitHub integration settings, it fails closed and does not start direct
+  bot sessions.
+
+### Prompt Safety
+
 - Initial prompts mark selected GitHub fields as untrusted. Code-review prompts wrap PR title,
   author, branches, and description; comment-triggered prompts wrap the triggering comment.
-  Review-thread file and diff context, plus GitHub context later read by the agent, are not
+- Review-thread file and diff context, plus GitHub context later read by the agent, are not
   separately transformed by the bot.
-- If the bot cannot load its GitHub integration settings, it fails closed and does not start
-  sessions.
+- Webhooks are verified before Open-Inspect acts on them. Duplicate webhook deliveries are
+  deduplicated so GitHub retries do not normally create duplicate direct bot sessions.
 
 ---
 
@@ -195,8 +211,9 @@ list.
 ### Auto-review did not run
 
 Auto-review only runs for newly opened, non-draft PRs. It is skipped for draft PRs, bot-authored
-PRs, disabled repositories, and users who are not allowed to trigger the bot. If a PR was converted
-from draft to ready for review, assign the bot as a reviewer.
+PRs, disabled repositories, and users who are not allowed to trigger the bot.
+
+If a PR was converted from draft to ready for review, mention the bot in a PR comment instead.
 
 ### A mention did not start a session
 

--- a/packages/github-bot/README.md
+++ b/packages/github-bot/README.md
@@ -3,13 +3,13 @@
 A stateless Cloudflare Worker that translates GitHub webhook events into Open-Inspect coding agent
 sessions. It provides two capabilities:
 
-For day-to-day usage, see the user-facing
-[GitHub integration guide](../../docs/integrations/GITHUB.md).
-
-1. **Code Review** — Assign the bot as a PR reviewer; it performs an automated code review and
-   submits structured feedback.
+1. **Code Review** — Review newly opened PRs when auto-review is enabled and submit structured
+   feedback.
 2. **Comment-Triggered Actions** — @mention the bot in a PR comment; it reads the PR context and
    responds with analysis, a summary comment, or a review-thread reply.
+
+For day-to-day usage, see the user-facing
+[GitHub integration guide](../../docs/integrations/GITHUB.md).
 
 The bot is a **webhook-to-session translator** — it verifies webhooks, posts an acknowledgment
 reaction, creates a session via the control plane, and sends a prompt. The agent in the sandbox
@@ -104,7 +104,7 @@ For the agent to interact with GitHub from the sandbox, two prerequisites must b
 | Event                         | Action             | Trigger                     | Handler                   |
 | ----------------------------- | ------------------ | --------------------------- | ------------------------- |
 | `pull_request`                | `opened`           | Non-draft PR opened         | `handlePullRequestOpened` |
-| `pull_request`                | `review_requested` | Bot assigned as reviewer    | `handleReviewRequested`   |
+| `pull_request`                | `review_requested` | Compatibility event path    | `handleReviewRequested`   |
 | `issue_comment`               | `created`          | @mention in a PR comment    | `handleIssueComment`      |
 | `pull_request_review_comment` | `created`          | @mention in a review thread | `handleReviewComment`     |
 
@@ -121,7 +121,10 @@ All events are processed asynchronously via `executionCtx.waitUntil()`. The webh
 4. Create session via control plane
 5. Send code review prompt (includes PR metadata + `gh` CLI instructions)
 
-**Review Requested:**
+**Review Requested (compatibility path):**
+
+This handler is retained for webhook compatibility. The user-facing GitHub workflow does not ask
+people to request the GitHub App bot through the PR reviewer picker.
 
 1. Check `requested_reviewer.login` matches `GITHUB_BOT_USERNAME` — return early if not
 2. Post eyes reaction on the PR (fire-and-forget)

--- a/packages/github-bot/README.md
+++ b/packages/github-bot/README.md
@@ -9,7 +9,7 @@ For day-to-day usage, see the user-facing
 1. **Code Review** — Assign the bot as a PR reviewer; it performs an automated code review and
    submits structured feedback.
 2. **Comment-Triggered Actions** — @mention the bot in a PR comment; it reads the PR context and
-   executes the requested action (typically making code changes and pushing commits).
+   responds with analysis, a summary comment, or a review-thread reply.
 
 The bot is a **webhook-to-session translator** — it verifies webhooks, posts an acknowledgment
 reaction, creates a session via the control plane, and sends a prompt. The agent in the sandbox
@@ -49,9 +49,8 @@ Key design decisions:
 - **Unidirectional service binding**: The bot calls the control plane to create sessions and send
   prompts. There is no reverse binding — the agent posts results to GitHub directly from the
   sandbox.
-- **No session reuse**: Every non-duplicate webhook delivery creates a fresh session. Git provides
-  continuity (the agent clones the latest branch state). Delivery dedupe is handled separately in KV
-  using `X-GitHub-Delivery`.
+- **No session reuse**: Every non-duplicate webhook delivery creates a fresh session. Delivery
+  dedupe is handled separately in KV using `X-GitHub-Delivery`.
 - **No PR context fetching**: The bot only uses metadata already in the webhook payload. The agent
   gathers additional context (diffs, prior comments, file contents) itself using `gh` CLI.
 

--- a/packages/github-bot/README.md
+++ b/packages/github-bot/README.md
@@ -3,6 +3,9 @@
 A stateless Cloudflare Worker that translates GitHub webhook events into Open-Inspect coding agent
 sessions. It provides two capabilities:
 
+For day-to-day usage, see the user-facing
+[GitHub integration guide](../../docs/integrations/GITHUB.md).
+
 1. **Code Review** — Assign the bot as a PR reviewer; it performs an automated code review and
    submits structured feedback.
 2. **Comment-Triggered Actions** — @mention the bot in a PR comment; it reads the PR context and


### PR DESCRIPTION
## Summary
- Add a user-facing GitHub integration guide covering PR reviews, @mention workflows, settings, and troubleshooting
- Link the guide from README, Getting Started, Setup Guide, GitHub bot README, and the architecture client list

## Validation
- npx prettier --check docs/integrations/GITHUB.md README.md docs/GETTING_STARTED.md docs/SETUP_GUIDE.md packages/github-bot/README.md docs/HOW_IT_WORKS.md
- git diff --check origin/main..HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive GitHub integration guide covering setup, configuration, usage patterns, session behavior, UI feedback, and troubleshooting.
  * Updated README, getting-started, and setup docs to point to the new GitHub guide and day-to-day usage notes.
  * Clarified bot triggers and comment-driven responses: auto-review for newly opened non-draft PRs and actions on mentions; removed reviewer-assignment trigger.
  * Listed GitHub and Linear as supported client platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/640)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->