### PR TITLE
docs: update supported model list

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,11 +166,11 @@ await configureGitIdentity({
 
 Choose the AI model that fits your task, with per-session reasoning effort controls:
 
-| Provider     | Models                                                      |
-| ------------ | ----------------------------------------------------------- |
-| Anthropic    | Claude Haiku 4.5, Sonnet 4.5/4.6, Opus 4.5/4.6              |
-| OpenAI       | GPT 5.2, GPT 5.4, GPT 5.2 Codex, 5.3 Codex, 5.3 Codex Spark |
-| OpenCode Zen | Kimi K2.5, MiniMax M2.5, GLM 5 (opt-in)                     |
+| Provider     | Models                                                               |
+| ------------ | -------------------------------------------------------------------- |
+| Anthropic    | Claude Haiku 4.5, Sonnet 4.5/4.6, Opus 4.5/4.6/4.7                   |
+| OpenAI       | GPT 5.2, GPT 5.4, GPT 5.5, GPT 5.2 Codex, 5.3 Codex, 5.3 Codex Spark |
+| OpenCode Zen | Kimi K2.5, MiniMax M2.5, GLM 5 (opt-in)                              |
 
 OpenAI models work with your existing ChatGPT subscription via OAuth — no separate API key needed.
 See **[docs/OPENAI_MODELS.md](docs/OPENAI_MODELS.md)** for setup instructions.


### PR DESCRIPTION
## Summary
- Add GPT 5.5 to the OpenAI supported models list in the main README.
- Add Opus 4.7 to the Anthropic supported models list.

## Testing
- `npx prettier --check README.md` before formatting showed README formatting drift.
- `npx prettier --write README.md` applied formatting via the same formatter used by the commit hook.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/a534cbb42b653000f58a5e420d7c04da)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Multi-Provider Model Support table with expanded model offerings from Anthropic and OpenAI, including new Opus and GPT variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/641)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->