### PR TITLE
test(control-plane): stabilize cancel integration test

### DIFF
--- a/packages/control-plane/test/integration/do-internal-routes.test.ts
+++ b/packages/control-plane/test/integration/do-internal-routes.test.ts
@@ -1,9 +1,60 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { env } from "cloudflare:test";
 import { initSession, queryDO, seedEvents } from "./helpers";
 import type { SpawnContext, ChildSessionDetail } from "@open-inspect/shared";
 
+const originalFetch = globalThis.fetch;
+
+function installModalFetchMock(): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+
+      if (!url.includes(".modal.run")) {
+        return originalFetch(input, init);
+      }
+
+      const body = JSON.parse(String(init?.body ?? "{}")) as { sandbox_id?: string };
+      const sandboxId = body.sandbox_id ?? "sandbox-test";
+
+      return Response.json({
+        success: true,
+        data: {
+          sandbox_id: sandboxId,
+          modal_object_id: `modal-${sandboxId}`,
+          status: "running",
+          created_at: Date.now(),
+        },
+      });
+    })
+  );
+}
+
+async function waitForSandboxSpawn(stub: DurableObjectStub): Promise<void> {
+  const deadline = Date.now() + 1000;
+
+  while (Date.now() < deadline) {
+    const rows = await queryDO<{ status: string }>(stub, "SELECT status FROM sandbox LIMIT 1");
+    if (rows[0]?.status === "connecting") {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  throw new Error("Timed out waiting for sandbox spawn");
+}
+
 describe("DO internal sub-session routes", () => {
+  beforeEach(() => {
+    installModalFetchMock();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   describe("GET /internal/spawn-context", () => {
     it("returns SpawnContext with session and owner info", async () => {
       const { stub } = await initSession({
@@ -189,6 +240,8 @@ describe("DO internal sub-session routes", () => {
         repoName: "web-app",
         userId: "user-1",
       });
+
+      await waitForSandboxSpawn(stub);
 
       // Set session to active to simulate a running session
       await queryDO(stub, "UPDATE session SET status = 'active'");


### PR DESCRIPTION
## Summary

The control-plane integration test in `packages/control-plane/test/integration/do-internal-routes.test.ts` has been flaky. The cancel-then-assert-status test occasionally fails because the sandbox row reaches `failed` before the assertion runs, rather than `stopped` as expected.

This PR stabilizes the suite with two changes, both confined to that one test file:

- **Mock outbound Modal HTTP calls at the `fetch` layer.** A `beforeEach`/`afterEach` pair installs/removes a `vi.stubGlobal("fetch", ...)` mock that intercepts requests to `*.modal.run` and returns a synthetic `running` sandbox response. Non-Modal `fetch` calls pass through to the real `fetch`.
- **Add a `waitForSandboxSpawn` helper.** Polls the DO's `sandbox` table until the row reaches `connecting` (1s timeout, 10ms interval), so the test waits for the async spawn to land before driving subsequent state transitions.

## Why this matters

The integration suite has been making real outbound Modal HTTP calls in CI. Modal returns `404 modal-http: invalid function call` (most likely because `MODAL_WORKSPACE` is the dummy test workspace), so no real sandboxes are being created — but the `fetch` calls themselves are leaving the workerd runtime.

Recent successful upstream `control-plane` integration jobs each contained 132 `modal-client` request log lines:

- run 25871996174 / job 76029563892
- run 25846191019 / job 75941960701
- run 25844133580 / job 75935538363
- run 25873416058 / job 76034453557

Each shows the same pattern:

```
"component":"modal-client","msg":"modal.request","endpoint":"createSandbox","http_status":404,"outcome":"error"
"msg":"Sandbox spawn failed"
"Failed to create sandbox: Modal API error: 404 modal-http: invalid function call"
```

These `createSandbox` requests originate from the background `ctx.waitUntil()` callback that session init kicks off. Most tests do not assert on the final sandbox status, so the background 404 has just been noise. The cancel test was one of the few that did assert on status after cancel, which made it race-prone:

- Sometimes the cancel path wrote `stopped` and the assertion ran before the background Modal failure wrote `failed`.
- Sometimes the Modal failure won the race and the assertion observed `failed`.

By mocking Modal at the `fetch` boundary, the test no longer depends on `MODAL_WORKSPACE` being unset or on Modal's response timing, and the deterministic `connecting → running` path lets `waitForSandboxSpawn` synchronize the assertion against the spawn write.

## Test plan

- [ ] `npm run test:integration -w @open-inspect/control-plane` passes locally and in CI.
- [ ] CI logs for this test file show zero outbound `*.modal.run` requests after the change.
- [ ] No other integration tests regress; the mock is scoped to `do-internal-routes.test.ts` only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Tests**
* Enhanced internal test suite for DO routes with improved sandbox spawning verification and deterministic request handling.

---

*Note: This release contains no user-facing changes. Updates are limited to internal testing infrastructure improvements.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/643)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->