### PR TITLE
feat: add configurable setup timeout to sandbox settings

### DIFF
--- a/.claude/skills/onboarding/SKILL.md
+++ b/.claude/skills/onboarding/SKILL.md
@@ -130,10 +130,11 @@ Guide user through creating a GitHub App (handles both OAuth and repo access):
    - **CRITICAL**: Must match deployed Vercel URL exactly!
 6. **Repository permissions**: Contents (Read & Write), Issues (Read & Write), Pull requests (Read &
    Write), Metadata (Read-only)
-7. Create app, note **App ID**
-8. Generate **Client Secret**, note **Client ID** and **Client Secret**
-9. Generate **Private Key** (downloads .pem file)
-10. Install app on account, note **Installation ID** from URL
+7. **Account permissions**: Email addresses (Read-only)
+8. Create app, note **App ID**
+9. Generate **Client Secret**, note **Client ID** and **Client Secret**
+10. Generate **Private Key** (downloads .pem file)
+11. Install app on account, note **Installation ID** from URL
 
 After receiving the .pem path, convert to PKCS#8:
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -216,21 +216,23 @@ access.
    - Issues: **Read & Write** _(required if enabling GitHub bot)_
    - Pull requests: **Read & Write**
    - Metadata: **Read-only**
-6. Click **"Create GitHub App"**
-7. Note the **App ID** and **Client ID** (top of page)
-8. Under **"Client secrets"**, click **"Generate a new client secret"** and note the **Client
+6. Set **Account permissions**:
+   - Email addresses: **Read-only**
+7. Click **"Create GitHub App"**
+8. Note the **App ID** and **Client ID** (top of page)
+9. Under **"Client secrets"**, click **"Generate a new client secret"** and note the **Client
    Secret**
-9. Scroll down to **"Private keys"** and click **"Generate a private key"** (downloads a .pem file)
-10. **Convert the key to PKCS#8 format** (required for Cloudflare Workers):
+10. Scroll down to **"Private keys"** and click **"Generate a private key"** (downloads a .pem file)
+11. **Convert the key to PKCS#8 format** (required for Cloudflare Workers):
     ```bash
     openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt \
       -in ~/Downloads/your-app-name.*.private-key.pem \
       -out private-key-pkcs8.pem
     ```
-11. **Install the app** on your account/organization:
+12. **Install the app** on your account/organization:
     - Click "Install App" in the sidebar
     - Select the repositories you want Open-Inspect to access
-12. Note the **Installation ID** from the URL after installing:
+13. Note the **Installation ID** from the URL after installing:
     ```
     https://github.com/settings/installations/INSTALLATION_ID
     ```

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -150,7 +150,8 @@ Create an R2 API Token:
 1. Go to [Modal Settings](https://modal.com/settings)
 2. **Create a new API token**: Settings -> API Tokens -> New Token
 3. Note the **Token ID** and **Token Secret**
-4. Note your **Workspace name** (visible in your Modal dashboard URL)
+4. Note your **Workspace** and **Environment names** (visible in your Modal dashboard URL,
+   https://modal.com/apps/<modal_workspace>/<modal_environment>)
 
 ### Daytona
 
@@ -355,6 +356,7 @@ vercel_team_id              = "team_xxxxx"       # Your Vercel ID (even personal
 modal_token_id              = "your-modal-token-id"
 modal_token_secret          = "your-modal-token-secret"
 modal_workspace             = "your-modal-workspace"
+modal_environment           = "your-modal-environment"
 
 # Daytona (only required when sandbox_provider = "daytona")
 # daytona_api_url           = "https://app.daytona.io/api"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "globals": "^15.14.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.7",
+        "node-addon-api": "^8.7.0",
+        "node-gyp": "^12.2.0",
         "prettier": "^3.4.2",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.21.0",
@@ -833,9 +835,9 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.1.tgz",
-      "integrity": "sha512-gy/gffKz0zaHDaqRiLCdIvgHmaAL/HXuAtMcBP7euYSFx4BsbsdlfmUBJag+Gqe62z6/XuloKyQyaiH+kS3Vrg==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.2.tgz",
+      "integrity": "sha512-oav5AOAz+1XkwUfp6SrEm42UPDpUP5D4jNYXkDwFR1VfWqYX62+jpytdfzURmJ9McSoJIQwi0OJlC4oCi6t0VQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -872,13 +874,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.27.tgz",
-      "integrity": "sha512-xfUt2CUZDC+Tf16A6roD1b4pk/nrXdkoLY3TEhv198AXDtBo5xUJP1zd0e8SmuKLN4PpIBX96OizZbmMlcI6oQ==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.28.tgz",
+      "integrity": "sha512-87GdRJ2OR0qR4VkMjXN/SZi66DZsunW2qQCbtw9rKw3Y7JurFi6tQWYKOSLY/gOADrU6OxGqFmdw3hKzZqDZOQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/core": "^3.974.2",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/types": "^4.14.1",
@@ -889,13 +891,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.29",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.29.tgz",
-      "integrity": "sha512-hjNeYb6oLyHgMihra83ie0J/T2y9om3cy1qC90h9DRgvYXEoN4BCFf8bHguZjKhXunnv7YkmZRuYL5Mkk77eCA==",
+      "version": "3.972.30",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.30.tgz",
+      "integrity": "sha512-6quozmW2PKwBJTUQLb+lk1q8w5Pm45qaqhx4Tld9EIqYYQOVGj+MT0a8NRVS7QgWJj7rzGlB7rQu3KYBFHemJw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/core": "^3.974.2",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/fetch-http-handler": "^5.3.17",
         "@smithy/node-http-handler": "^4.5.3",
@@ -911,20 +913,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.31.tgz",
-      "integrity": "sha512-PuQ7e8WYzAPpzvFcajxf8c0LqSzakVHVlKw8M0oubk8Kf347YOCCqT1seQrHs5AdZuIh2RD9LX4O+Xa5ImEBfQ==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.32.tgz",
+      "integrity": "sha512-Nkr+UKtczZlocUjc6g96WzQadZSIZO/HVXPki4qbfaVOZYSbfLQKWKfADtJ0kGYsCvSYOZrO66tSc9dkboUt/w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
-        "@aws-sdk/credential-provider-env": "^3.972.27",
-        "@aws-sdk/credential-provider-http": "^3.972.29",
-        "@aws-sdk/credential-provider-login": "^3.972.31",
-        "@aws-sdk/credential-provider-process": "^3.972.27",
-        "@aws-sdk/credential-provider-sso": "^3.972.31",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.31",
-        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/credential-provider-env": "^3.972.28",
+        "@aws-sdk/credential-provider-http": "^3.972.30",
+        "@aws-sdk/credential-provider-login": "^3.972.32",
+        "@aws-sdk/credential-provider-process": "^3.972.28",
+        "@aws-sdk/credential-provider-sso": "^3.972.32",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.32",
+        "@aws-sdk/nested-clients": "^3.997.0",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -937,14 +939,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.31.tgz",
-      "integrity": "sha512-bBmWDmtSpmLOZR6a0kmowBcVL1hiL8Vlap/RXeMpFd7JbWl87YcwqL6T9LH/0oBVEZXu1dUZAtojgSuZgMO5xw==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.32.tgz",
+      "integrity": "sha512-UxgwT1HmZz1QPXuBy5ZUPJNFXOSlhwdQL61eGhWRthF0xRrT02BCOVJ1p5Ejg5AXfnESTWoKPJ7v/sCkNUtB9g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
-        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/nested-clients": "^3.997.0",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
@@ -957,18 +959,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.32.tgz",
-      "integrity": "sha512-9aj0x9hGYUondBZSD0XkksAdHhOKttFw4BWpLCeggeg40qSJxGrAP++g0GCm0VqWc1WtC/NRFiAVzPCy56vmog==",
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.33.tgz",
+      "integrity": "sha512-6pGQnEdSeRvBViTQh/FwaRKB38a3Th+W2mVxuvqAd2Z1Ayo3e6eJ5QqJoZwEMwR6xoxkl3wz3qAfiB1xRhMC+w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.27",
-        "@aws-sdk/credential-provider-http": "^3.972.29",
-        "@aws-sdk/credential-provider-ini": "^3.972.31",
-        "@aws-sdk/credential-provider-process": "^3.972.27",
-        "@aws-sdk/credential-provider-sso": "^3.972.31",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.31",
+        "@aws-sdk/credential-provider-env": "^3.972.28",
+        "@aws-sdk/credential-provider-http": "^3.972.30",
+        "@aws-sdk/credential-provider-ini": "^3.972.32",
+        "@aws-sdk/credential-provider-process": "^3.972.28",
+        "@aws-sdk/credential-provider-sso": "^3.972.32",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.32",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/property-provider": "^4.2.14",
@@ -981,13 +983,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.27.tgz",
-      "integrity": "sha512-1CZvfb1WzudWWIFAVQkd1OI/T1RxPcSvNWzNsb2BMBVsBJzBtB8dV5f2nymHVU4UqwxipdVt/DAbgdDRf33JDg==",
+      "version": "3.972.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.28.tgz",
+      "integrity": "sha512-CRAlD8u6oNBhjnX/3ekVGocarD+lFmEn/qeDzytgIdmwrmwMJGFPqS9lGwEfhOTihZKrQ0xSp3z6paX+iXJJhA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/core": "^3.974.2",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -999,15 +1001,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.31.tgz",
-      "integrity": "sha512-x8Mx18S48XMl9bEEpYwmXDTvjWGPIfDadReN37Lc099/DUrlL4Zs9T9rwwggo6DkKS1aev6v+MTUx7JTa87TZQ==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.32.tgz",
+      "integrity": "sha512-whhmQghRYOt9mJxFyVMhX7eB8n0oA25OCvqoR7dzFAZjmioCkf7WVB22Bc6llM5cFpBXFX7s4Jv+xVq32VPGWg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
-        "@aws-sdk/nested-clients": "^3.996.21",
-        "@aws-sdk/token-providers": "3.1032.0",
+        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/nested-clients": "^3.997.0",
+        "@aws-sdk/token-providers": "3.1033.0",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -1019,14 +1021,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.31.tgz",
-      "integrity": "sha512-zfuNMIkGfjYsHis9qytYf74Bcmq6Ji9Xwf4w53baRCI/b2otTwZv3SW1uRiJ5Di7999QzRGhHZ96+eUeo3gSOA==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.32.tgz",
+      "integrity": "sha512-Z0Y0LDaqyQDznlmr9gv6n4+eWKKWNgmi9j5L6RENr6wyOCguhO8FRPmqDbVLSw0DPdMqICKnA3PurJiS8bD6Cw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
-        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/nested-clients": "^3.997.0",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -1038,13 +1040,13 @@
       }
     },
     "node_modules/@aws-sdk/dynamodb-codec": {
-      "version": "3.973.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.1.tgz",
-      "integrity": "sha512-BuxJyHW+fnuGLFZ84z5txzlfKXLVbf3hmWH4wQ9q5a/P6O5slNg6j2eUE2kQMYWt3A3PheUR4tgRBUC7j9i/nQ==",
+      "version": "3.973.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.2.tgz",
+      "integrity": "sha512-CEinPow54jr1y4bvhdyRDR0uM+t8J+27U1jh5lOm2shXVBrx9W1SHVCklxZ0oaWXiSJcYil1G8RTBYj4OGHn8A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/core": "^3.974.2",
         "@smithy/core": "^3.23.15",
         "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
@@ -1122,16 +1124,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.974.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.9.tgz",
-      "integrity": "sha512-ye6xVuMEQ5NCT+yQOryGYsuCXnOwu7iGFGzV+qpXZOWtqXIAAaFostapxj6RCubw36rekVwmdB2lcspFuyNfYQ==",
+      "version": "3.974.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.10.tgz",
+      "integrity": "sha512-R9oqyD1hR7aF2UQaYBo90/ILNn8Sq7gl/2Y4WkDDvsaqklqPomso++sFbgYgNmN/Kfx6gqvJwcjSkxJHEBK1tQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/core": "^3.974.2",
         "@aws-sdk/crc64-nvme": "^3.972.7",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/is-array-buffer": "^4.2.2",
@@ -1211,13 +1213,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.30.tgz",
-      "integrity": "sha512-hoQRxjJu4tt3gEOQin21rJKotClJC+x7AmCh9ylRct1DJeaNI/BRlFxMbuhJe54bG6xANPagSs0my8K30QyV9g==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.31.tgz",
+      "integrity": "sha512-5hS08Fp0Rm+59uGCmkWhZmveXiA7OUV7Wa+IARejdzf9JTZ1qAVeIOE9JoBpsLPvUgEjmsGNHBuFbtGmYyqiqQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/core": "^3.974.2",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-arn-parser": "^3.972.3",
         "@smithy/core": "^3.23.15",
@@ -1270,13 +1272,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.31",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.31.tgz",
-      "integrity": "sha512-L+hXN2HDomlIsWSHW5DVD7ppccCeRnlHXZ5uHG34ePTjF5bm0I1fmrJLbUGiW97xRXWryit5cjdP4Sx2FwiGog==",
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.32.tgz",
+      "integrity": "sha512-HQ0x9DDKqLZOGhDiL2eicYXXkYT5dogE4mw0lAfHCpJ6t7MM0PNIsJl2TZzWKU9SpBzOMXHRa7K6ZLKUJu1y0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/core": "^3.974.2",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.7",
         "@smithy/core": "^3.23.15",
@@ -1307,24 +1309,25 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.21",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.21.tgz",
-      "integrity": "sha512-Me3d/ua2lb2G0bQfFmvCeQQp3+nN6GSPqMxDmi/IQlQ8CrlpQ5C0JJHpz2AnOUkEFI0lBNrAL3Vnt29l44ndkA==",
+      "version": "3.997.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.0.tgz",
+      "integrity": "sha512-4bI5GHjUiY5R8N6PtchpG6tW2Dl8I2IcZNg3JwqwxHRXjfvQlPoo4VMknG4qkd5W0t3Y20rQ6C7pSR561YG5JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.1",
+        "@aws-sdk/core": "^3.974.2",
         "@aws-sdk/middleware-host-header": "^3.972.10",
         "@aws-sdk/middleware-logger": "^3.972.10",
         "@aws-sdk/middleware-recursion-detection": "^3.972.11",
-        "@aws-sdk/middleware-user-agent": "^3.972.31",
+        "@aws-sdk/middleware-user-agent": "^3.972.32",
         "@aws-sdk/region-config-resolver": "^3.972.12",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.19",
         "@aws-sdk/types": "^3.973.8",
         "@aws-sdk/util-endpoints": "^3.996.7",
         "@aws-sdk/util-user-agent-browser": "^3.972.10",
-        "@aws-sdk/util-user-agent-node": "^3.973.17",
+        "@aws-sdk/util-user-agent-node": "^3.973.18",
         "@smithy/config-resolver": "^4.4.16",
         "@smithy/core": "^3.23.15",
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -1350,6 +1353,24 @@
         "@smithy/util-middleware": "^4.2.14",
         "@smithy/util-retry": "^4.3.2",
         "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.19.tgz",
+      "integrity": "sha512-7Sy8+GhfwUi06NQNLplxuJuXMKJURDsNQfK8yTW6E9wN2J1B+8S5dWZG7vg3InvPPhaXqkcYTr8pzeE+dLjMbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.31",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1409,14 +1430,14 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1032.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1032.0.tgz",
-      "integrity": "sha512-n+PU8Z+gll7p3wDrH+Wo6fkt8sPrVnq30YYM6Ryga95oJlEneNMEbDHj0iqjMX3V7gaGdJo/hJWyPo4lscP+mA==",
+      "version": "3.1033.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1033.0.tgz",
+      "integrity": "sha512-/TsXhqjyRAFb0xVgmbFAha3cJfZdWjnyn6ohJ3AB4E3peLgxNcmKfYr45hruHymyJAydiHoXC3N1a8qgl41cog==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.974.1",
-        "@aws-sdk/nested-clients": "^3.996.21",
+        "@aws-sdk/core": "^3.974.2",
+        "@aws-sdk/nested-clients": "^3.997.0",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/property-provider": "^4.2.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
@@ -1498,13 +1519,13 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.17",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.17.tgz",
-      "integrity": "sha512-utF5qjjbuJQuU9VdCkWl7L87sr93cApsrD+uxGfUnlafX8iyEzJrb7EZnufjThURZVTOtelRMXrblWxpefElUg==",
+      "version": "3.973.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.18.tgz",
+      "integrity": "sha512-Nh4YvAL0Mzv5jBvzXLFL0tLf7WPrRMnYZQ5jlFuyS0xiVJQsObMUKAkbYjmt/e04wpQqUaa+Is7k+mBr89A9yA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.31",
+        "@aws-sdk/middleware-user-agent": "^3.972.32",
         "@aws-sdk/types": "^3.973.8",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/types": "^4.14.1",
@@ -3341,6 +3362,16 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
+    "node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
+      "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -3933,6 +3964,19 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -4316,6 +4360,69 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@npmcli/agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-4.0.0.tgz",
+      "integrity": "sha512-kAQTcEN9E8ERLVg5AsGwLNoFb+oEG6engbqAU2P43gD4JEIkNGMHdVQ096FsOAAYpZPB0RSt0zgInKIAS1l5QA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^11.2.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
+      "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/fs/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@npmcli/redact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+      "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@octokit/webhooks-types": {
@@ -6629,16 +6736,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.16",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.16.tgz",
-      "integrity": "sha512-GFlGPNLZKrGfqWpqVb31z7hvYCA9ZscfX1buYnvvMGcRYsQQnhH+4uN6mWWflcD5jB4OXP/LBrdpukEdjl41tg==",
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/types": "^4.14.1",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-endpoints": "^3.4.1",
+        "@smithy/util-endpoints": "^3.4.2",
         "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
@@ -6647,9 +6754,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.23.15",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.15.tgz",
-      "integrity": "sha512-E7GVCgsQttzfujEZb6Qep005wWf4xiL4x06apFEtzQMWYBPggZh/0cnOxPficw5cuK/YjjkehKoIN4YUaSh0UQ==",
+      "version": "3.23.16",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.16.tgz",
+      "integrity": "sha512-JStomOrINQA1VqNEopLsgcdgwd42au7mykKqVr30XFw89wLt9sDxJDi4djVPRwQmmzyTGy/uOvTc2ultMpFi1w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6659,7 +6766,7 @@
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-stream": "^4.5.23",
+        "@smithy/util-stream": "^4.5.24",
         "@smithy/util-utf8": "^4.2.2",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
@@ -6882,14 +6989,14 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.30",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.30.tgz",
-      "integrity": "sha512-qS2XqhKeXmdZ4nEQ4cOxIczSP/Y91wPAHYuRwmWDCh975B7/57uxsm5d6sisnUThn2u2FwzMdJNM7AbO1YPsPg==",
+      "version": "4.4.31",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.31.tgz",
+      "integrity": "sha512-KJPdCIN2kOE2aGmqZd7eUTr4WQwOGgtLWgUkswGJggs7rBcQYQjcZMEDa3C0DwbOiXS9L8/wDoQHkfxBYLfiLw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.15",
-        "@smithy/middleware-serde": "^4.2.18",
+        "@smithy/core": "^3.23.16",
+        "@smithy/middleware-serde": "^4.2.19",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/shared-ini-file-loader": "^4.4.9",
         "@smithy/types": "^4.14.1",
@@ -6902,20 +7009,20 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.3.tgz",
-      "integrity": "sha512-TE8dJNi6JuxzGSxMCVd3i9IEWDndCl3bmluLsBNDWok8olgj65OfkndMhl9SZ7m14c+C5SQn/PcUmrDl57rSFw==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.4.tgz",
+      "integrity": "sha512-/z7nIFK+ZRW3Ie/l3NEVGdy34LvmEOzBrtBAvgWZ/4PrKX0xP3kWm8pkfcwUk523SqxZhdbQP9JSXgjF77Uhpw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.15",
+        "@smithy/core": "^3.23.16",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/protocol-http": "^5.3.14",
-        "@smithy/service-error-classification": "^4.2.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/service-error-classification": "^4.3.0",
+        "@smithy/smithy-client": "^4.12.12",
         "@smithy/types": "^4.14.1",
         "@smithy/util-middleware": "^4.2.14",
-        "@smithy/util-retry": "^4.3.2",
+        "@smithy/util-retry": "^4.3.3",
         "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
@@ -6924,13 +7031,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.18",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.18.tgz",
-      "integrity": "sha512-M6CSgnp3v4tYz9ynj2JHbA60woBZcGqEwNjTKjBsNHPV26R1ZX52+0wW8WsZU18q45jD0tw2wL22S17Ze9LpEw==",
+      "version": "4.2.19",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.19.tgz",
+      "integrity": "sha512-Q6y+W9h3iYVMCKWDoVge+OC1LKFqbEKaq8SIWG2X2bWJRpd/6dDLyICcNLT6PbjH3Rr6bmg/SeDB25XFOFfeEw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.15",
+        "@smithy/core": "^3.23.16",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
@@ -6970,9 +7077,9 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.3.tgz",
-      "integrity": "sha512-lc5jFL++x17sPhIwMWJ3YOnqmSjw/2Po6VLDlUIXvxVWRuJwRXnJ4jOBBLB0cfI5BB5ehIl02Fxr1PDvk/kxDw==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.0.tgz",
+      "integrity": "sha512-P734cAoTFtuGfWa/R3jgBnGlURt2w9bYEBwQNMKf58sRM9RShirB2mKwLsVP+jlG/wxpCu8abv8NxdUts8tdLA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7043,9 +7150,9 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.14.tgz",
-      "integrity": "sha512-vVimoUnGxlx4eLLQbZImdOZFOe+Zh+5ACntv8VxZuGP72LdWu5GV3oEmCahSEReBgRJoWjypFkrehSj7BWx1HQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.0.tgz",
+      "integrity": "sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7090,18 +7197,18 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.12.11",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.11.tgz",
-      "integrity": "sha512-wzz/Wa1CH/Tlhxh0s4DQPEcXSxSVfJ59AZcUh9Gu0c6JTlKuwGf4o/3P2TExv0VbtPFt8odIBG+eQGK2+vTECg==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.12.tgz",
+      "integrity": "sha512-daO7SJn4eM6ArbmrEs+/BTbH7af8AEbSL3OMQdcRvvn8tuUcR5rU2n6DgxIV53aXMS42uwK8NgKKCh5XgqYOPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.23.15",
-        "@smithy/middleware-endpoint": "^4.4.30",
+        "@smithy/core": "^3.23.16",
+        "@smithy/middleware-endpoint": "^4.4.31",
         "@smithy/middleware-stack": "^4.2.14",
         "@smithy/protocol-http": "^5.3.14",
         "@smithy/types": "^4.14.1",
-        "@smithy/util-stream": "^4.5.23",
+        "@smithy/util-stream": "^4.5.24",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -7205,14 +7312,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.47",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.47.tgz",
-      "integrity": "sha512-zlIuXai3/SHjQUQ8y3g/woLvrH573SK2wNjcDaHu5e9VOcC0JwM1MI0Sq0GZJyN3BwSUneIhpjZ18nsiz5AtQw==",
+      "version": "4.3.48",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.48.tgz",
+      "integrity": "sha512-hxVRVPYaRDWa6YQdse1aWX1qrksmLsvNyGBKdc32q4jFzSjxYVNWfstknAfR228TnzS4tzgswXRuYIbhXBuXFQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.12",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -7221,17 +7328,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.52",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.52.tgz",
-      "integrity": "sha512-cQBz8g68Vnw1W2meXlkb3D/hXJU+Taiyj9P8qLJtjREEV9/Td65xi4A/H1sRQ8EIgX5qbZbvdYPKygKLholZ3w==",
+      "version": "4.2.53",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.53.tgz",
+      "integrity": "sha512-ybgCk+9JdBq8pYC8Y6U5fjyS8e4sboyAShetxPNL0rRBtaVl56GSFAxsolVBIea1tXR4LPIzL8i6xqmcf0+DCQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.16",
+        "@smithy/config-resolver": "^4.4.17",
         "@smithy/credential-provider-imds": "^4.2.14",
         "@smithy/node-config-provider": "^4.3.14",
         "@smithy/property-provider": "^4.2.14",
-        "@smithy/smithy-client": "^4.12.11",
+        "@smithy/smithy-client": "^4.12.12",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -7240,9 +7347,9 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.1.tgz",
-      "integrity": "sha512-wMxNDZJrgS5mQV9oxCs4TWl5767VMgOfqfZ3JHyCkMtGC2ykW9iPqMvFur695Otcc5yxLG8OKO/80tsQBxrhXg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7282,13 +7389,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.2.tgz",
-      "integrity": "sha512-2+KTsJEwTi63NUv4uR9IQ+IFT1yu6Rf6JuoBK2WKaaJ/TRvOiOVGcXAsEqX/TQN2thR9yII21kPUJq1UV/WI2A==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.3.tgz",
+      "integrity": "sha512-idjUvd4M9Jj6rXkhqw4H4reHoweuK4ZxYWyOrEp4N2rOF5VtaOlQGLDQJva/8WanNXk9ScQtsAb7o5UHGvFm4A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.14",
+        "@smithy/service-error-classification": "^4.3.0",
         "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
@@ -7297,14 +7404,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.23",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.23.tgz",
-      "integrity": "sha512-N6on1+ngJ3RznZOnDWNveIwnTSlqxNnXuNAh7ez889ZZaRdXoNRTXKgmYOLe6dB0gCmAVtuRScE1hymQFl4hpg==",
+      "version": "4.5.24",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.24.tgz",
+      "integrity": "sha512-na5vv2mBSDzXewLEEoWGI7LQQkfpmFEomBsmOpzLFjqGctm0iMwXY5lAwesY9pIaErkccW0qzEOUcYP+WKneXg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.3.17",
-        "@smithy/node-http-handler": "^4.5.3",
+        "@smithy/node-http-handler": "^4.6.0",
         "@smithy/types": "^4.14.1",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-buffer-from": "^4.2.2",
@@ -8160,6 +8267,16 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -8825,6 +8942,73 @@
         "node": ">=8"
       }
     },
+    "node_modules/cacache": {
+      "version": "20.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+      "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^5.0.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^13.0.0",
+        "lru-cache": "^11.1.0",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^7.0.2",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/cacache/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cacache/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/cacache/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -9041,6 +9225,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/cjs-module-lexer": {
@@ -9961,6 +10155,16 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/environment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -10578,6 +10782,13 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
@@ -10956,6 +11167,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -11203,6 +11427,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/gzip-size": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
@@ -11442,6 +11673,13 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -11635,6 +11873,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -12678,6 +12926,30 @@
         "node": ">=10"
       }
     },
+    "node_modules/make-fetch-happen": {
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
+      "integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
+        "cacache": "^20.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^1.0.0",
+        "proc-log": "^6.0.0",
+        "ssri": "^13.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
@@ -13714,6 +13986,115 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minipass-collect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-5.0.2.tgz",
+      "integrity": "sha512-2d0q2a8eCi2IRg/IGubCNRJoYbA1+YPXAzQVRFmB45gdGZafyivnZ5YSEfo3JikbjGxOdntGFvBQGqaSMXlAFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^2.0.0",
+        "minizlib": "^3.0.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      },
+      "optionalDependencies": {
+        "iconv-lite": "^0.7.2"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-2.0.0.tgz",
+      "integrity": "sha512-zSsHhto5BcUVM2m1LurnXY6M//cGhVaegT71OfOXoprxT6o780GZd792ea6FfrQkuU4usHZIUczAQMRUE2plzA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -13925,6 +14306,16 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
+      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -13965,12 +14356,92 @@
         }
       }
     },
+    "node_modules/node-gyp": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.2.0.tgz",
+      "integrity": "sha512-q23WdzrQv48KozXlr0U1v9dwO/k59NHeSzn6loGcasyf0UnSrtzs8kRxM+mfwJSf0DkX0s43hcqgnSO4/VNthQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^15.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.5.4",
+        "tinyglobby": "^0.2.12",
+        "which": "^6.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -14270,6 +14741,19 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -14734,6 +15218,16 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
       "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
       "license": "MIT"
+    },
+    "node_modules/proc-log": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -15834,6 +16328,47 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/sonner": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -15882,6 +16417,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ssri": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
+      "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/stackback": {
@@ -16430,6 +16978,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/terser": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "globals": "^15.14.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
+    "node-addon-api": "^8.7.0",
+    "node-gyp": "^12.2.0",
     "prettier": "^3.4.2",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.21.0",

--- a/packages/control-plane/src/db/integration-settings.test.ts
+++ b/packages/control-plane/src/db/integration-settings.test.ts
@@ -710,6 +710,33 @@ describe("IntegrationSettingsStore", () => {
         })
       ).rejects.toThrow(IntegrationSettingsValidationError);
     });
+
+    it("round-trips setupTimeoutSeconds", async () => {
+      await store.setGlobal("sandbox", { defaults: { setupTimeoutSeconds: 600 } });
+
+      const result = await store.getGlobal("sandbox");
+      expect(result).toEqual({ defaults: { setupTimeoutSeconds: 600 } });
+    });
+
+    it("rejects setupTimeoutSeconds below minimum", async () => {
+      await expect(
+        store.setGlobal("sandbox", { defaults: { setupTimeoutSeconds: 59 } })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
+
+    it("rejects setupTimeoutSeconds above maximum", async () => {
+      await expect(
+        store.setGlobal("sandbox", { defaults: { setupTimeoutSeconds: 1801 } })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
+
+    it("rejects non-integer setupTimeoutSeconds", async () => {
+      await expect(
+        store.setGlobal("sandbox", {
+          defaults: { setupTimeoutSeconds: 1.5 as unknown as number },
+        })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
   });
 
   describe("linear settings", () => {

--- a/packages/control-plane/src/db/integration-settings.ts
+++ b/packages/control-plane/src/db/integration-settings.ts
@@ -12,6 +12,8 @@ import {
   type SlackGlobalSettings,
   type SlackMentionsPolicy,
   MAX_TUNNEL_PORTS,
+  MIN_SETUP_TIMEOUT_SECONDS,
+  MAX_SETUP_TIMEOUT_SECONDS,
 } from "@open-inspect/shared";
 
 type SettingsLevel = "global" | "repo";
@@ -332,6 +334,18 @@ export class IntegrationSettingsStore {
         }
       }
       return { ...settings, tunnelPorts: dedupedPorts };
+    }
+    if (settings.setupTimeoutSeconds !== undefined) {
+      if (
+        typeof settings.setupTimeoutSeconds !== "number" ||
+        !Number.isInteger(settings.setupTimeoutSeconds) ||
+        settings.setupTimeoutSeconds < MIN_SETUP_TIMEOUT_SECONDS ||
+        settings.setupTimeoutSeconds > MAX_SETUP_TIMEOUT_SECONDS
+      ) {
+        throw new IntegrationSettingsValidationError(
+          `setupTimeoutSeconds must be an integer between ${MIN_SETUP_TIMEOUT_SECONDS} and ${MAX_SETUP_TIMEOUT_SECONDS}`
+        );
+      }
     }
     return settings;
   }

--- a/packages/control-plane/src/routes/repo-images.ts
+++ b/packages/control-plane/src/routes/repo-images.ts
@@ -197,6 +197,14 @@ async function handleTriggerBuild(
   if (params instanceof Response) return params;
   const { owner, name } = params;
 
+  // Resolve the repo to get its actual default branch — never assume "main".
+  const provider = createRouteSourceControlProvider(env);
+  const resolved = await resolveInstalledRepo(provider, owner, name);
+  if (!resolved) {
+    return error("Repository not found or not installed", 404);
+  }
+  const { defaultBranch } = resolved;
+
   const store = new RepoImageStore(env.DB);
   const now = Date.now();
   const buildId = `img-${owner}-${name}-${now}`;
@@ -207,7 +215,7 @@ async function handleTriggerBuild(
       id: buildId,
       repoOwner: owner,
       repoName: name,
-      baseBranch: "main",
+      baseBranch: defaultBranch,
     });
 
     // Construct callback URL
@@ -230,12 +238,8 @@ async function handleTriggerBuild(
 
       let repoSecrets: Record<string, string> = {};
       try {
-        const provider = createRouteSourceControlProvider(env);
-        const resolved = await resolveInstalledRepo(provider, owner, name);
-        if (resolved) {
-          const repoStore = new RepoSecretsStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
-          repoSecrets = await repoStore.getDecryptedSecrets(resolved.repoId);
-        }
+        const repoStore = new RepoSecretsStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
+        repoSecrets = await repoStore.getDecryptedSecrets(resolved.repoId);
       } catch (e) {
         logger.warn("repo_image.repo_secrets_failed", {
           error: e instanceof Error ? e.message : String(e),
@@ -266,7 +270,7 @@ async function handleTriggerBuild(
       {
         repoOwner: owner,
         repoName: name,
-        defaultBranch: "main",
+        defaultBranch,
         buildId,
         callbackUrl,
         userEnvVars,
@@ -512,7 +516,23 @@ async function handleGetEnabledRepos(
 
   try {
     const repos = await metadataStore.getImageBuildEnabledRepos();
-    return json({ repos });
+
+    // Resolve each repo's actual default branch so the scheduler can poll
+    // the right ref. Failures are silenced per-repo — a resolution error
+    // means the scheduler will skip that repo this tick, not crash.
+    const provider = createRouteSourceControlProvider(env);
+    const reposWithBranch = await Promise.all(
+      repos.map(async (repo) => {
+        try {
+          const resolved = await resolveInstalledRepo(provider, repo.repoOwner, repo.repoName);
+          return { ...repo, defaultBranch: resolved?.defaultBranch ?? "" };
+        } catch {
+          return { ...repo, defaultBranch: "" };
+        }
+      })
+    );
+
+    return json({ repos: reposWithBranch });
   } catch (e) {
     logger.error("repo_image.enabled_repos_error", {
       error: e instanceof Error ? e.message : String(e),

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -112,7 +112,7 @@ export interface WarmSandboxResponse {
 export interface BuildRepoImageRequest {
   repoOwner: string;
   repoName: string;
-  defaultBranch?: string;
+  defaultBranch: string;
   buildId: string;
   callbackUrl: string;
   userEnvVars?: Record<string, string>;
@@ -533,7 +533,7 @@ export class ModalClient {
         body: JSON.stringify({
           repo_owner: request.repoOwner,
           repo_name: request.repoName,
-          default_branch: request.defaultBranch || "main",
+          default_branch: request.defaultBranch,
           build_id: request.buildId,
           callback_url: request.callbackUrl,
           user_env_vars: request.userEnvVars,

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -1676,6 +1676,60 @@ describe("SandboxLifecycleManager", () => {
         )
       ).toBe(true);
     });
+
+    it("doSpawn() passes setupTimeoutSeconds from session settings", async () => {
+      const session = createMockSession({
+        sandbox_settings: '{"setupTimeoutSeconds":600}',
+      });
+      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const storage = createMockStorage(session, sandbox);
+      const provider = createMockProvider();
+
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      expect(provider.createSandbox).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sandboxSettings: { setupTimeoutSeconds: 600 },
+        })
+      );
+    });
+
+    it("doSpawn() drops setupTimeoutSeconds outside valid range from stored settings", async () => {
+      const session = createMockSession({
+        sandbox_settings: '{"setupTimeoutSeconds":9999}',
+      });
+      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const storage = createMockStorage(session, sandbox);
+      const provider = createMockProvider();
+
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      expect(provider.createSandbox).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sandboxSettings: {},
+        })
+      );
+    });
   });
 
   describe("agent slack-notify gate", () => {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -10,7 +10,12 @@
  * spawn attempts within the same request.
  */
 
-import { MAX_TUNNEL_PORTS, type SandboxSettings } from "@open-inspect/shared";
+import {
+  MAX_TUNNEL_PORTS,
+  MIN_SETUP_TIMEOUT_SECONDS,
+  MAX_SETUP_TIMEOUT_SECONDS,
+  type SandboxSettings,
+} from "@open-inspect/shared";
 import type { SandboxStatus } from "../../types";
 import type { SandboxRow, SessionRow } from "../../session/types";
 import type { McpServerConfig } from "@open-inspect/shared";
@@ -1183,6 +1188,15 @@ export class SandboxLifecycleManager {
 
       if (typeof settings.terminalEnabled === "boolean") {
         result.terminalEnabled = settings.terminalEnabled;
+      }
+
+      if (
+        typeof settings.setupTimeoutSeconds === "number" &&
+        Number.isInteger(settings.setupTimeoutSeconds) &&
+        settings.setupTimeoutSeconds >= MIN_SETUP_TIMEOUT_SECONDS &&
+        settings.setupTimeoutSeconds <= MAX_SETUP_TIMEOUT_SECONDS
+      ) {
+        result.setupTimeoutSeconds = settings.setupTimeoutSeconds;
       }
 
       return result;

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -278,6 +278,10 @@ class SandboxManager:
         if terminal_enabled:
             env_vars["TERMINAL_ENABLED"] = "true"
 
+        setup_timeout_seconds = (config.settings or {}).get("setupTimeoutSeconds")
+        if setup_timeout_seconds is not None:
+            env_vars["SETUP_TIMEOUT_SECONDS"] = str(setup_timeout_seconds)
+
         if config.agent_slack_notify_enabled:
             env_vars["AGENT_SLACK_NOTIFY_ENABLED"] = "true"
 

--- a/packages/modal-infra/src/scheduler/image_builder.py
+++ b/packages/modal-infra/src/scheduler/image_builder.py
@@ -517,11 +517,17 @@ async def rebuild_repo_images():
         for repo in enabled_repos:
             repo_owner = repo.get("repoOwner", "")
             repo_name = repo.get("repoName", "")
+            default_branch = repo.get("defaultBranch", "")
 
-            if not repo_owner or not repo_name:
+            if not repo_owner or not repo_name or not default_branch:
+                log.warn(
+                    "scheduler.missing_default_branch",
+                    repo_owner=repo_owner,
+                    repo_name=repo_name,
+                )
                 continue
 
-            remote_sha = _git_ls_remote_sha(repo_owner, repo_name, "main", clone_token)
+            remote_sha = _git_ls_remote_sha(repo_owner, repo_name, default_branch, clone_token)
             if not remote_sha:
                 continue
 

--- a/packages/modal-infra/tests/test_scheduler.py
+++ b/packages/modal-infra/tests/test_scheduler.py
@@ -206,7 +206,9 @@ class TestRebuildRepoImages:
             "MODAL_API_SECRET": "test-secret",
         }
 
-        mock_enabled = {"repos": [{"repoOwner": "acme", "repoName": "repo"}]}
+        mock_enabled = {
+            "repos": [{"repoOwner": "acme", "repoName": "repo", "defaultBranch": "master"}]
+        }
         mock_status = {
             "images": [
                 {
@@ -236,6 +238,8 @@ class TestRebuildRepoImages:
                 return mock_cleanup
             return {}
 
+        mock_ls_remote = MagicMock(return_value="new-sha")
+
         with (
             patch.dict("os.environ", env, clear=False),
             patch(
@@ -250,7 +254,7 @@ class TestRebuildRepoImages:
             ) as mock_post,
             patch(
                 "src.scheduler.image_builder._git_ls_remote_sha",
-                return_value="new-sha",
+                side_effect=mock_ls_remote,
             ),
             patch(
                 "sandbox_runtime.auth.github_app.generate_installation_token",
@@ -266,6 +270,9 @@ class TestRebuildRepoImages:
         assert len(trigger_calls) == 1
         assert "acme/repo" in str(trigger_calls[0])
 
+        # Verify ls-remote was called with the real branch, not "main"
+        mock_ls_remote.assert_called_once_with("acme", "repo", "master", mock_ls_remote.call_args[0][3])
+
     @pytest.mark.asyncio
     async def test_skips_build_when_sha_matches(self):
         """Should not trigger a build when SHAs match."""
@@ -274,7 +281,9 @@ class TestRebuildRepoImages:
             "MODAL_API_SECRET": "test-secret",
         }
 
-        mock_enabled = {"repos": [{"repoOwner": "acme", "repoName": "repo"}]}
+        mock_enabled = {
+            "repos": [{"repoOwner": "acme", "repoName": "repo", "defaultBranch": "main"}]
+        }
         mock_status = {
             "images": [
                 {
@@ -335,7 +344,11 @@ class TestRebuildRepoImages:
 
         async def mock_get_side_effect(url, **kwargs):
             if "enabled-repos" in url:
-                return {"repos": [{"repoOwner": "acme", "repoName": "repo"}]}
+                return {
+                    "repos": [
+                        {"repoOwner": "acme", "repoName": "repo", "defaultBranch": "main"}
+                    ]
+                }
             if "status" in url:
                 return {"images": []}
             return {}
@@ -380,3 +393,55 @@ class TestRebuildRepoImages:
 
         cleanup_calls = [c for c in mock_post.call_args_list if "cleanup" in str(c)]
         assert len(cleanup_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_repo_without_default_branch(self):
+        """Should skip repos that are missing defaultBranch in the enabled-repos response."""
+        env = {
+            "CONTROL_PLANE_URL": "https://cp.test",
+            "MODAL_API_SECRET": "test-secret",
+        }
+
+        # Repo returned without defaultBranch (e.g. control plane couldn't resolve it)
+        mock_enabled = {"repos": [{"repoOwner": "acme", "repoName": "repo"}]}
+
+        async def mock_get_side_effect(url, **kwargs):
+            if "enabled-repos" in url:
+                return mock_enabled
+            if "status" in url:
+                return {"images": []}
+            return {}
+
+        mock_ls_remote = MagicMock(return_value="abc123")
+
+        with (
+            patch.dict("os.environ", env, clear=False),
+            patch(
+                "src.scheduler.image_builder._api_get",
+                new_callable=AsyncMock,
+                side_effect=mock_get_side_effect,
+            ),
+            patch(
+                "src.scheduler.image_builder._api_post",
+                new_callable=AsyncMock,
+                return_value={"ok": True, "markedFailed": 0, "deleted": 0},
+            ) as mock_post,
+            patch(
+                "src.scheduler.image_builder._git_ls_remote_sha",
+                side_effect=mock_ls_remote,
+            ),
+            patch(
+                "sandbox_runtime.auth.github_app.generate_installation_token",
+                return_value="gh-token",
+            ),
+        ):
+            from src.scheduler.image_builder import rebuild_repo_images
+
+            await rebuild_repo_images.local()
+
+        # No trigger — repo was skipped
+        trigger_calls = [c for c in mock_post.call_args_list if "trigger" in str(c)]
+        assert len(trigger_calls) == 0
+
+        # ls-remote was never called — skipped before SHA check
+        mock_ls_remote.assert_not_called()

--- a/packages/modal-infra/tests/test_ttyd.py
+++ b/packages/modal-infra/tests/test_ttyd.py
@@ -281,3 +281,76 @@ class TestRestoreSandboxTerminal:
         assert handle.ttyd_url is None
         assert "TERMINAL_ENABLED" not in captured["env"]
         assert captured["encrypted_ports"] is None
+
+
+class TestSetupTimeoutEnvVar:
+    """setup_timeout_seconds setting is injected as SETUP_TIMEOUT_SECONDS env var."""
+
+    @pytest.mark.asyncio
+    async def test_injects_setup_timeout_when_set(self, monkeypatch):
+        captured = {}
+
+        async def fake_create_aio(*args, **kwargs):
+            captured["env"] = kwargs.get("env")
+
+            class FakeSandbox:
+                object_id = "obj-123"
+                stdout = None
+
+            return FakeSandbox()
+
+        fake_create = MagicMock()
+        fake_create.aio = fake_create_aio
+        monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", fake_create)
+        monkeypatch.setattr(
+            SandboxManager,
+            "_resolve_and_setup_tunnels",
+            AsyncMock(return_value=(None, None, None)),
+        )
+
+        manager = SandboxManager()
+        config = SandboxConfig(
+            repo_owner="acme",
+            repo_name="repo",
+            control_plane_url="https://cp.example.com",
+            sandbox_auth_token="token-123",
+            settings={"setupTimeoutSeconds": 600},
+        )
+
+        await manager.create_sandbox(config)
+
+        assert captured["env"]["SETUP_TIMEOUT_SECONDS"] == "600"
+
+    @pytest.mark.asyncio
+    async def test_omits_setup_timeout_when_not_set(self, monkeypatch):
+        captured = {}
+
+        async def fake_create_aio(*args, **kwargs):
+            captured["env"] = kwargs.get("env")
+
+            class FakeSandbox:
+                object_id = "obj-123"
+                stdout = None
+
+            return FakeSandbox()
+
+        fake_create = MagicMock()
+        fake_create.aio = fake_create_aio
+        monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", fake_create)
+        monkeypatch.setattr(
+            SandboxManager,
+            "_resolve_and_setup_tunnels",
+            AsyncMock(return_value=(None, None, None)),
+        )
+
+        manager = SandboxManager()
+        config = SandboxConfig(
+            repo_owner="acme",
+            repo_name="repo",
+            control_plane_url="https://cp.example.com",
+            sandbox_auth_token="token-123",
+        )
+
+        await manager.create_sandbox(config)
+
+        assert "SETUP_TIMEOUT_SECONDS" not in captured["env"]

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -665,6 +665,7 @@ class SandboxSupervisor:
         opencode_config: dict = {
             "model": f"{provider}/{model}",
             "permission": {"*": {"*": "allow"}},
+            "plugin": ["superpowers@git+https://github.com/obra/superpowers.git"],
         }
 
         # Inject MCP servers

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -985,7 +985,7 @@ class SandboxSupervisor:
 
     async def _report_fatal_error(self, message: str) -> None:
         """Report a fatal error to the control plane."""
-        self.log.error("supervisor.fatal", message=message)
+        self.log.error("supervisor.fatal", detail=message)
 
         if not self.control_plane_url:
             return

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -42,12 +42,20 @@ export interface CodeServerSettings {
 /** Maximum number of tunnel ports a user can configure per sandbox. */
 export const MAX_TUNNEL_PORTS = 10;
 
+/** Maximum setup hook timeout (seconds) a user can configure. */
+export const MAX_SETUP_TIMEOUT_SECONDS = 1800;
+
+/** Minimum setup hook timeout (seconds) a user can configure. */
+export const MIN_SETUP_TIMEOUT_SECONDS = 60;
+
 /** Sandbox environment settings. Provider-agnostic: describes what the user wants, not how it's done. */
 export interface SandboxSettings {
   /** Extra ports to expose via tunnels (e.g., dev server ports 3000, 5173). */
   tunnelPorts?: number[];
   /** Enable a browser-based terminal (ttyd) in sandbox sessions. */
   terminalEnabled?: boolean;
+  /** Override the entrypoint's DEFAULT_SETUP_TIMEOUT_SECONDS for .openinspect/setup.sh. */
+  setupTimeoutSeconds?: number;
 }
 
 export type SlackMentionsPolicy = "allow" | "escape" | "strip";

--- a/packages/web/src/components/settings/sandbox-settings.test.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.test.tsx
@@ -6,7 +6,11 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { SWRConfig } from "swr";
-import { MAX_TUNNEL_PORTS } from "@open-inspect/shared";
+import {
+  MAX_TUNNEL_PORTS,
+  MIN_SETUP_TIMEOUT_SECONDS,
+  MAX_SETUP_TIMEOUT_SECONDS,
+} from "@open-inspect/shared";
 import { SandboxSettingsPage } from "./sandbox-settings";
 
 expect.extend(matchers);
@@ -17,10 +21,14 @@ vi.mock("@/hooks/use-repos", () => ({
 
 const SETTINGS_KEY = "/api/integration-settings/sandbox";
 
-function globalSettings(tunnelPorts: number[], enabledRepos?: string[]) {
+function globalSettings(
+  tunnelPorts: number[],
+  enabledRepos?: string[],
+  extra?: { setupTimeoutSeconds?: number; terminalEnabled?: boolean }
+) {
   return {
     integrationId: "sandbox",
-    settings: { defaults: { tunnelPorts }, enabledRepos },
+    settings: { defaults: { tunnelPorts, ...extra }, enabledRepos },
   };
 }
 
@@ -236,5 +244,128 @@ describe("SandboxSettingsPage — tunnel ports editor", () => {
     await user.type(inputs[1], "3000");
 
     expect(screen.getByText("Save Settings").closest("button")).toBeDisabled();
+  });
+});
+
+describe("SandboxSettingsPage — setup timeout", () => {
+  const user = userEvent.setup();
+
+  it("renders setup timeout input with placeholder when no value configured", () => {
+    renderWithSWR({ integrationId: "sandbox", settings: null });
+    expect(screen.getByPlaceholderText("300 (default)")).toBeInTheDocument();
+  });
+
+  it("renders existing setupTimeoutSeconds as input value", () => {
+    renderWithSWR(globalSettings([], undefined, { setupTimeoutSeconds: 600 }));
+    expect(screen.getByPlaceholderText("300 (default)")).toHaveValue(600);
+  });
+
+  it("enables Save when setupTimeoutSeconds is changed", async () => {
+    renderWithSWR({ integrationId: "sandbox", settings: null });
+    const input = screen.getByPlaceholderText("300 (default)");
+    await user.type(input, "600");
+    expect(screen.getByText("Save Settings").closest("button")).not.toBeDisabled();
+  });
+
+  it("shows validation error when timeout is below minimum", async () => {
+    const { fetchMock } = renderWithSWR({ integrationId: "sandbox", settings: null });
+    const input = screen.getByPlaceholderText("300 (default)");
+    await user.type(input, "30");
+    await user.click(screen.getByText("Save Settings"));
+    expect(
+      screen.getByText(
+        new RegExp(
+          `setupTimeoutSeconds must be between ${MIN_SETUP_TIMEOUT_SECONDS} and ${MAX_SETUP_TIMEOUT_SECONDS}`
+        )
+      )
+    ).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      SETTINGS_KEY,
+      expect.objectContaining({ method: "PUT" })
+    );
+  });
+
+  it("includes setupTimeoutSeconds in save payload when set", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "PUT") {
+        return new Response(JSON.stringify({}), { status: 200 });
+      }
+      throw new Error("unexpected fetch");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <SWRConfig
+        value={{
+          provider: () => new Map(),
+          fallback: { [SETTINGS_KEY]: { integrationId: "sandbox", settings: null } },
+          dedupingInterval: Infinity,
+          revalidateOnFocus: false,
+          revalidateIfStale: false,
+          revalidateOnReconnect: false,
+        }}
+      >
+        <SandboxSettingsPage />
+      </SWRConfig>
+    );
+
+    const input = screen.getByPlaceholderText("300 (default)");
+    await user.type(input, "600");
+    await user.click(screen.getByText("Save Settings"));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        SETTINGS_KEY,
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({
+            settings: {
+              defaults: {
+                tunnelPorts: [],
+                terminalEnabled: false,
+                setupTimeoutSeconds: 600,
+              },
+            },
+          }),
+        })
+      );
+    });
+  });
+
+  it("omits setupTimeoutSeconds from payload when input is cleared", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "PUT") {
+        return new Response(JSON.stringify({}), { status: 200 });
+      }
+      throw new Error("unexpected fetch");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <SWRConfig
+        value={{
+          provider: () => new Map(),
+          fallback: {
+            [SETTINGS_KEY]: globalSettings([], undefined, { setupTimeoutSeconds: 600 }),
+          },
+          dedupingInterval: Infinity,
+          revalidateOnFocus: false,
+          revalidateIfStale: false,
+          revalidateOnReconnect: false,
+        }}
+      >
+        <SandboxSettingsPage />
+      </SWRConfig>
+    );
+
+    const input = screen.getByPlaceholderText("300 (default)");
+    await user.clear(input);
+    await user.click(screen.getByText("Save Settings"));
+
+    await waitFor(() => {
+      const call = fetchMock.mock.calls.find(([, init]) => (init as RequestInit)?.method === "PUT");
+      const body = JSON.parse((call?.[1] as RequestInit)?.body as string);
+      expect(body.settings.defaults.setupTimeoutSeconds).toBeUndefined();
+    });
   });
 });

--- a/packages/web/src/components/settings/sandbox-settings.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.tsx
@@ -8,7 +8,11 @@ import { Combobox } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import useSWR from "swr";
 import type { SandboxSettings } from "@open-inspect/shared";
-import { MAX_TUNNEL_PORTS } from "@open-inspect/shared";
+import {
+  MAX_TUNNEL_PORTS,
+  MIN_SETUP_TIMEOUT_SECONDS,
+  MAX_SETUP_TIMEOUT_SECONDS,
+} from "@open-inspect/shared";
 
 const GLOBAL_SCOPE = "__global__";
 
@@ -56,14 +60,26 @@ function SandboxSettingsEditor({
     ? ((data as GlobalSettingsResponse)?.settings?.defaults?.terminalEnabled ?? false)
     : ((data as RepoSettingsResponse)?.settings?.terminalEnabled ?? false);
 
+  const currentSetupTimeoutSeconds: number | undefined = isGlobal
+    ? (data as GlobalSettingsResponse)?.settings?.defaults?.setupTimeoutSeconds
+    : (data as RepoSettingsResponse)?.settings?.setupTimeoutSeconds;
+
   const [portRows, setPortRows] = useState<string[] | null>(null);
   const [terminalEnabled, setTerminalEnabled] = useState<boolean | null>(null);
+  const [setupTimeoutSeconds, setSetupTimeoutSeconds] = useState<number | null | undefined>(
+    undefined
+  );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
 
   // Resolve terminal toggle: local edit or server state
   const resolvedTerminalEnabled = terminalEnabled ?? currentTerminalEnabled;
+
+  const resolvedSetupTimeoutSeconds =
+    setupTimeoutSeconds === undefined
+      ? currentSetupTimeoutSeconds
+      : (setupTimeoutSeconds ?? undefined);
 
   // Use server state unless user is editing
   const rows = portRows ?? currentPorts.map(String);
@@ -104,12 +120,31 @@ function SandboxSettingsEditor({
       return;
     }
 
+    if (
+      resolvedSetupTimeoutSeconds !== undefined &&
+      resolvedSetupTimeoutSeconds !== null &&
+      (!Number.isInteger(resolvedSetupTimeoutSeconds) ||
+        resolvedSetupTimeoutSeconds < MIN_SETUP_TIMEOUT_SECONDS ||
+        resolvedSetupTimeoutSeconds > MAX_SETUP_TIMEOUT_SECONDS)
+    ) {
+      setError(
+        `setupTimeoutSeconds must be between ${MIN_SETUP_TIMEOUT_SECONDS} and ${MAX_SETUP_TIMEOUT_SECONDS}`
+      );
+      return;
+    }
+
     setSaving(true);
     try {
       const existingEnabledRepos = isGlobal
         ? (data as GlobalSettingsResponse)?.settings?.enabledRepos
         : undefined;
-      const settingsPayload = { tunnelPorts: ports, terminalEnabled: resolvedTerminalEnabled };
+      const settingsPayload: SandboxSettings = {
+        tunnelPorts: ports,
+        terminalEnabled: resolvedTerminalEnabled,
+        ...(resolvedSetupTimeoutSeconds != null
+          ? { setupTimeoutSeconds: resolvedSetupTimeoutSeconds }
+          : {}),
+      };
       const body = isGlobal
         ? { settings: { defaults: settingsPayload, enabledRepos: existingEnabledRepos } }
         : { settings: settingsPayload };
@@ -128,6 +163,7 @@ function SandboxSettingsEditor({
       await mutate();
       setPortRows(null);
       setTerminalEnabled(null);
+      setSetupTimeoutSeconds(undefined);
       setSuccess(true);
       setTimeout(() => setSuccess(false), 2000);
     } catch (e) {
@@ -135,13 +171,15 @@ function SandboxSettingsEditor({
     } finally {
       setSaving(false);
     }
-  }, [rows, isGlobal, apiUrl, mutate, data, resolvedTerminalEnabled]);
+  }, [rows, isGlobal, apiUrl, mutate, data, resolvedTerminalEnabled, resolvedSetupTimeoutSeconds]);
 
   const hasPortChanges =
     portRows !== null &&
     JSON.stringify(normalizePorts(portRows).ports) !== JSON.stringify(currentPorts);
   const hasTerminalChange = terminalEnabled !== null && terminalEnabled !== currentTerminalEnabled;
-  const hasChanges = hasPortChanges || hasTerminalChange;
+  const hasTimeoutChange =
+    setupTimeoutSeconds !== undefined && setupTimeoutSeconds !== currentSetupTimeoutSeconds;
+  const hasChanges = hasPortChanges || hasTerminalChange || hasTimeoutChange;
 
   if (isLoading) {
     return <p className="text-sm text-muted-foreground">Loading...</p>;
@@ -174,6 +212,27 @@ function SandboxSettingsEditor({
             />
           </button>
         </div>
+      </div>
+
+      {/* Setup Timeout */}
+      <div className="max-w-sm">
+        <label className="block text-sm font-medium text-foreground mb-1">Setup Timeout</label>
+        <p className="text-xs text-muted-foreground mb-2">
+          Maximum seconds allowed for <code>.openinspect/setup.sh</code> to complete.
+        </p>
+        <Input
+          type="number"
+          inputMode="numeric"
+          min={MIN_SETUP_TIMEOUT_SECONDS}
+          max={MAX_SETUP_TIMEOUT_SECONDS}
+          value={resolvedSetupTimeoutSeconds ?? ""}
+          placeholder="300 (default)"
+          onChange={(e) => {
+            const raw = e.target.value;
+            setSetupTimeoutSeconds(raw === "" ? null : Number(raw));
+          }}
+          className="w-full"
+        />
       </div>
 
       <div>

--- a/packages/web/src/lib/access-control.test.ts
+++ b/packages/web/src/lib/access-control.test.ts
@@ -53,7 +53,7 @@ describe("checkAccessAllowed", () => {
 
       expect(checkAccessAllowed(config, {})).toBe(false);
       expect(checkAccessAllowed(config, { githubUsername: "anyuser" })).toBe(false);
-      expect(checkAccessAllowed(config, { email: "anyone@example.com" })).toBe(false);
+      expect(checkAccessAllowed(config, { emails: ["anyone@example.com"] })).toBe(false);
     });
 
     it("allows all users when unsafeAllowAllUsers is enabled", () => {
@@ -61,7 +61,7 @@ describe("checkAccessAllowed", () => {
 
       expect(checkAccessAllowed(config, {})).toBe(true);
       expect(checkAccessAllowed(config, { githubUsername: "anyuser" })).toBe(true);
-      expect(checkAccessAllowed(config, { email: "anyone@example.com" })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["anyone@example.com"] })).toBe(true);
     });
   });
 
@@ -87,7 +87,7 @@ describe("checkAccessAllowed", () => {
 
     it("denies when no username provided", () => {
       expect(checkAccessAllowed(config, {})).toBe(false);
-      expect(checkAccessAllowed(config, { email: "user@example.com" })).toBe(false);
+      expect(checkAccessAllowed(config, { emails: ["user@example.com"] })).toBe(false);
     });
   });
 
@@ -99,20 +99,44 @@ describe("checkAccessAllowed", () => {
     };
 
     it("allows users with matching email domain", () => {
-      expect(checkAccessAllowed(config, { email: "user@company.com" })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["user@company.com"] })).toBe(true);
     });
 
     it("allows users with different case email", () => {
-      expect(checkAccessAllowed(config, { email: "User@COMPANY.COM" })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["User@COMPANY.COM"] })).toBe(true);
     });
 
     it("denies users with non-matching email domain", () => {
-      expect(checkAccessAllowed(config, { email: "user@other.com" })).toBe(false);
+      expect(checkAccessAllowed(config, { emails: ["user@other.com"] })).toBe(false);
     });
 
     it("denies when no email provided", () => {
       expect(checkAccessAllowed(config, {})).toBe(false);
       expect(checkAccessAllowed(config, { githubUsername: "someuser" })).toBe(false);
+    });
+  });
+
+  describe("when user has multiple emails", () => {
+    const config = {
+      allowedDomains: ["company.com"],
+      allowedUsers: [],
+      unsafeAllowAllUsers: false,
+    };
+
+    it("allows access when any email matches the domain", () => {
+      expect(
+        checkAccessAllowed(config, {
+          emails: ["user@personal.com", "user@company.com"],
+        })
+      ).toBe(true);
+    });
+
+    it("denies access when no email matches the domain", () => {
+      expect(
+        checkAccessAllowed(config, {
+          emails: ["user@personal.com", "user@gmail.com"],
+        })
+      ).toBe(false);
     });
   });
 
@@ -128,21 +152,21 @@ describe("checkAccessAllowed", () => {
     });
 
     it("allows users matching email domain", () => {
-      expect(checkAccessAllowed(config, { email: "someone@company.com" })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["someone@company.com"] })).toBe(true);
     });
 
     it("allows users matching either condition", () => {
       expect(
         checkAccessAllowed(config, {
           githubUsername: "specialuser",
-          email: "user@other.com",
+          emails: ["user@other.com"],
         })
       ).toBe(true);
 
       expect(
         checkAccessAllowed(config, {
           githubUsername: "otheruser",
-          email: "user@company.com",
+          emails: ["user@company.com"],
         })
       ).toBe(true);
     });
@@ -151,7 +175,7 @@ describe("checkAccessAllowed", () => {
       expect(
         checkAccessAllowed(config, {
           githubUsername: "randomuser",
-          email: "user@other.com",
+          emails: ["user@other.com"],
         })
       ).toBe(false);
     });
@@ -166,12 +190,12 @@ describe("checkAccessAllowed", () => {
 
     it("still enforces the allowlist for matching users", () => {
       expect(checkAccessAllowed(config, { githubUsername: "specialuser" })).toBe(true);
-      expect(checkAccessAllowed(config, { email: "user@company.com" })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["user@company.com"] })).toBe(true);
     });
 
     it("denies users not in the allowlist", () => {
       expect(checkAccessAllowed(config, { githubUsername: "randomuser" })).toBe(false);
-      expect(checkAccessAllowed(config, { email: "user@other.com" })).toBe(false);
+      expect(checkAccessAllowed(config, { emails: ["user@other.com"] })).toBe(false);
     });
   });
 
@@ -188,8 +212,8 @@ describe("checkAccessAllowed", () => {
     });
 
     it("allows any domain from the list", () => {
-      expect(checkAccessAllowed(config, { email: "user@company.com" })).toBe(true);
-      expect(checkAccessAllowed(config, { email: "user@partner.org" })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["user@company.com"] })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["user@partner.org"] })).toBe(true);
     });
   });
 });

--- a/packages/web/src/lib/access-control.ts
+++ b/packages/web/src/lib/access-control.ts
@@ -6,7 +6,7 @@ export interface AccessControlConfig {
 
 export interface AccessCheckParams {
   githubUsername?: string;
-  email?: string;
+  emails?: string[];
 }
 
 /**
@@ -30,7 +30,7 @@ export function parseBooleanEnv(value: string | undefined): boolean {
  * Returns true if:
  * - Both allowlists are empty and unsafeAllowAllUsers is true
  * - User's GitHub username is in allowedUsers
- * - User's email domain is in allowedDomains
+ * - Any of the user's emails has a domain in allowedDomains
  *
  * Logic is OR-based: matching either list grants access.
  */
@@ -39,7 +39,7 @@ export function checkAccessAllowed(
   params: AccessCheckParams
 ): boolean {
   const { allowedDomains, allowedUsers, unsafeAllowAllUsers } = config;
-  const { githubUsername, email } = params;
+  const { githubUsername, emails } = params;
 
   // Empty allowlists only permit sign-in when explicitly enabled.
   if (allowedDomains.length === 0 && allowedUsers.length === 0) {
@@ -51,13 +51,10 @@ export function checkAccessAllowed(
     return true;
   }
 
-  // Check email domain allowlist
-  if (email) {
-    const domain = email.toLowerCase().split("@")[1];
-    if (domain && allowedDomains.includes(domain)) {
-      return true;
-    }
-  }
-
-  return false;
+  return (
+    emails?.some((email) => {
+      const domain = email.toLowerCase().split("@")[1];
+      return domain !== undefined && allowedDomains.includes(domain);
+    }) ?? false
+  );
 }

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -25,6 +25,17 @@ declare module "next-auth/jwt" {
   }
 }
 
+type GitHubEmail = { email: string; verified: boolean; primary: boolean };
+
+async function fetchGitHubEmails(accessToken: string): Promise<string[]> {
+  const response = await fetch("https://api.github.com/user/emails", {
+    headers: { Authorization: `Bearer ${accessToken}`, "User-Agent": "open-inspect" },
+  });
+  if (!response.ok) return [];
+  const emails = (await response.json()) as GitHubEmail[];
+  return emails.filter((e) => e.verified).map((e) => e.email);
+}
+
 export const authOptions: NextAuthOptions = {
   debug: process.env.NODE_ENV === "development" || process.env.NEXTAUTH_DEBUG === "true",
   providers: [
@@ -39,7 +50,7 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
   callbacks: {
-    async signIn({ profile, user }) {
+    async signIn({ profile, account }) {
       const config = {
         allowedDomains: parseAllowlist(process.env.ALLOWED_EMAIL_DOMAINS),
         allowedUsers: parseAllowlist(process.env.ALLOWED_USERS),
@@ -47,15 +58,20 @@ export const authOptions: NextAuthOptions = {
       };
 
       const githubProfile = profile as { login?: string };
-      const isAllowed = checkAccessAllowed(config, {
-        githubUsername: githubProfile.login,
-        email: user.email ?? undefined,
-      });
 
-      if (!isAllowed) {
-        return false;
+      if (checkAccessAllowed(config, { githubUsername: githubProfile.login })) {
+        return true;
       }
-      return true;
+
+      let emails: string[] = [];
+      if (config.allowedDomains.length > 0 && account?.access_token) {
+        emails = await fetchGitHubEmails(account.access_token);
+      }
+
+      return checkAccessAllowed(config, {
+        githubUsername: githubProfile.login,
+        emails,
+      });
     },
     async jwt({ token, account, profile }) {
       if (account) {

--- a/terraform/environments/production/locals.tf
+++ b/terraform/environments/production/locals.tf
@@ -2,6 +2,10 @@ locals {
   name_suffix         = var.deployment_name
   use_modal_backend   = var.sandbox_provider == "modal"
   use_daytona_backend = var.sandbox_provider == "daytona"
+  # Modal omits the environment segment for the default "main" environment.
+  # Non-main environments: "{workspace}-{env}--{app}.modal.run"
+  # Default (main) environment:  "{workspace}--{app}.modal.run"
+  modal_workspace_slug = var.modal_environment == "main" ? var.modal_workspace : "${var.modal_workspace}-${var.modal_environment}"
 
   # URLs for cross-service configuration
   control_plane_host = "open-inspect-control-plane-${local.name_suffix}.${var.cloudflare_worker_subdomain}.workers.dev"

--- a/terraform/environments/production/modal.tf
+++ b/terraform/environments/production/modal.tf
@@ -28,7 +28,7 @@ module "modal_app" {
   modal_token_secret = var.modal_token_secret
 
   app_name      = "open-inspect"
-  workspace     = var.modal_workspace
+  workspace     = local.modal_workspace_slug
   deploy_path   = "${var.project_root}/packages/modal-infra"
   deploy_module = "deploy"
   source_hash   = data.external.modal_source_hash[0].result.hash

--- a/terraform/environments/production/outputs.tf
+++ b/terraform/environments/production/outputs.tf
@@ -27,7 +27,7 @@ output "d1_database_id" {
 # Cloudflare Workers
 output "control_plane_url" {
   description = "Control plane worker URL"
-  value       = module.control_plane_worker.worker_url
+  value       = local.control_plane_url
 }
 
 output "control_plane_worker_name" {
@@ -106,7 +106,7 @@ output "verification_commands" {
   value       = <<-EOF
 
     # 1. Health check control plane
-    curl ${module.control_plane_worker.worker_url}/health
+    curl ${local.control_plane_url}/health
 
     # 2. Health check sandbox backend
     ${local.use_modal_backend ? "curl ${module.modal_app[0].api_health_url}" : "# Daytona sandboxes use the REST API directly — no health endpoint to check"}
@@ -115,7 +115,7 @@ output "verification_commands" {
     curl ${local.web_app_url}
 
     # 4. Test authenticated endpoint (should return 401)
-    curl ${module.control_plane_worker.worker_url}/sessions
+    curl ${local.control_plane_url}/sessions
 
   EOF
 }

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -51,10 +51,14 @@ cloudflare_worker_subdomain = ""
 modal_token_id = ""
 modal_token_secret = ""
 
-# Modal workspace name (used in endpoint URLs)
+# Modal workspace name and environment (used in endpoint URLs)
 # Only required when sandbox_provider = "modal"
-# This is your Modal username/workspace (e.g., "myworkspace" in "https://myworkspace--app.modal.run")
-modal_workspace = ""
+# workspace: your Modal username (e.g., "myworkspace")
+# environment: Modal environment name. Use "main" for the default environment:
+#   main env:     https://myworkspace--app.modal.run
+#   non-main env: https://myworkspace-production--app.modal.run
+modal_workspace   = ""
+modal_environment = "main"
 
 # Daytona REST API
 # Only required when sandbox_provider = "daytona"

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -72,6 +72,17 @@ variable "modal_workspace" {
   }
 }
 
+variable "modal_environment" {
+  description = "Modal environment name. Use 'main' for the default environment (omitted from endpoint URLs). Non-main envs (e.g., 'production', 'dev') are included in the URL slug."
+  type        = string
+  default     = "main"
+
+  validation {
+    condition     = var.sandbox_provider != "modal" || length(var.modal_environment) > 0
+    error_message = "modal_environment must be set when sandbox_provider = 'modal'."
+  }
+}
+
 # =============================================================================
 # GitHub OAuth App Credentials
 # =============================================================================

--- a/terraform/environments/production/workers-control-plane.tf
+++ b/terraform/environments/production/workers-control-plane.tf
@@ -70,7 +70,7 @@ module "control_plane_worker" {
       { name = "APP_NAME", value = var.app_name },
       { name = "SANDBOX_PROVIDER", value = var.sandbox_provider },
     ],
-    local.use_modal_backend ? [{ name = "MODAL_WORKSPACE", value = var.modal_workspace }] : [],
+    local.use_modal_backend ? [{ name = "MODAL_WORKSPACE", value = local.modal_workspace_slug }] : [],
     local.use_daytona_backend ? [
       { name = "DAYTONA_API_URL", value = var.daytona_api_url },
       { name = "DAYTONA_BASE_SNAPSHOT", value = var.daytona_base_snapshot },


### PR DESCRIPTION
## Summary

- Adds `setupTimeoutSeconds` to `SandboxSettings` (optional, 60–1800s)
- Operators can now set the `.openinspect/setup.sh` timeout per-repo or globally in the Sandbox settings UI, instead of using a repo secret
- Control-plane validates the field (rejects non-integer, <60, >1800) and parses it out of stored session settings
- Modal sandbox manager injects it as `SETUP_TIMEOUT_SECONDS` into the sandbox environment; the entrypoint already reads this var
- Web UI: number input with placeholder "300 (default)" added between the Web Terminal toggle and Tunnel Ports

## Motivation

Setup scripts that install language runtimes (e.g. Ruby via rbenv) routinely exceed the hardcoded 300s default. Surfacing this as a first-class setting removes the need to work around it via repo secrets.

## Test plan

- [ ] Set `setupTimeoutSeconds` in the Sandbox settings UI for a specific repo; confirm it saves and round-trips
- [ ] Trigger a session for that repo; confirm `SETUP_TIMEOUT_SECONDS=<value>` appears in sandbox logs
- [ ] Confirm entering a value below 60 or above 1800 shows a validation error and blocks save
- [ ] Confirm clearing the field removes `setupTimeoutSeconds` from the payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox setup timeouts can now be configured in settings
  * Modal environment configuration added for deployments
  * Repositories now use their actual default branch
  * Access control enhanced with email-based user verification and domain filtering

* **Documentation**
  * GitHub App setup instructions updated with account permission requirements
  * Modal configuration guidance expanded for environment-specific deployments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/644?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->