### PR TITLE
Add Linear integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,8 @@ Interact with agents from wherever your team already works:
   model and branch preferences via App Home. See [Slack integration](docs/integrations/SLACK.md)
 - **GitHub Bot** — Auto-review on PR open or respond to @mentions in PR comments. Configurable
   per-repo. See [GitHub integration](docs/integrations/GITHUB.md)
-- **Linear Bot** — Assign an issue to the agent and it creates a coding session, posts progress
-  activities, and links the resulting PR
+- **Linear Bot** — Mention or assign the agent on an issue to start a coding session, post progress
+  activities, and link the resulting PR. See [Linear integration](docs/integrations/LINEAR.md)
 - **Webhooks** — Trigger sessions from any external system via authenticated HTTP POST
 
 ### Automations

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -231,6 +231,7 @@ Control plane cannot reach Modal (or Modal is not properly configured/deployed).
 - Architecture and internals: [docs/HOW_IT_WORKS.md](./HOW_IT_WORKS.md)
 - Full production deployment: [docs/GETTING_STARTED.md](./GETTING_STARTED.md)
 - GitHub integration usage: [docs/integrations/GITHUB.md](./integrations/GITHUB.md)
+- Linear integration usage: [docs/integrations/LINEAR.md](./integrations/LINEAR.md)
 - Debugging and observability: [docs/DEBUGGING_PLAYBOOK.md](./DEBUGGING_PLAYBOOK.md)
 - OpenAI model setup: [docs/OPENAI_MODELS.md](./OPENAI_MODELS.md)
 - Contribution workflow: [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/docs/integrations/LINEAR.md
+++ b/docs/integrations/LINEAR.md
@@ -1,0 +1,253 @@
+# Linear Integration
+
+Open-Inspect's Linear integration lets your team start coding sessions from Linear issues. The
+Linear Agent can be mentioned or assigned on an issue, posts progress and results back to Linear,
+and can continue active issue work with follow-up prompts.
+
+This guide is for people using the Linear integration day to day. If you are installing the Linear
+OAuth app or deploying the worker, start with the
+[Linear Bot setup guide](../../packages/linear-bot/README.md#setup).
+
+---
+
+## Quick Start
+
+1. Make sure the Linear Agent is installed in your workspace.
+2. Open the Linear issue you want Open-Inspect to work on.
+3. Mention the agent in a comment:
+   ```text
+   @OpenInspect please implement this issue and open a pull request
+   ```
+4. Or assign the issue to the Linear Agent.
+5. If Open-Inspect asks which repository to use, include the repository name in your reply, such as
+   `owner/repo`.
+6. Use **View Session** to watch the full Open-Inspect session while the agent works.
+7. Send follow-up prompts from the same issue's active Linear Agent session.
+
+---
+
+## Supported Workflows
+
+| Workflow                    | How it works                                                                  |
+| --------------------------- | ----------------------------------------------------------------------------- |
+| Start from an issue mention | Mention the Linear Agent on an issue                                          |
+| Start from assignment       | Assign the issue to the Linear Agent                                          |
+| Continue active work        | Send a follow-up prompt on the same issue while the session is still mapped   |
+| Stop or cancel work         | Stop or cancel the Linear Agent session to stop the Open-Inspect session      |
+| Resolve the repository      | Let Open-Inspect infer the repo, or include `owner/repo` when asked           |
+| Follow progress             | Watch Linear activities or open the full session with **View Session**        |
+| Customize behavior          | Set repository scope, model defaults, model overrides, and issue instructions |
+
+Linear currently responds to Linear Agent session events. Ordinary Linear issue or comment webhook
+events do not start Open-Inspect sessions by themselves.
+
+---
+
+## Starting Sessions
+
+### From an `@mention`
+
+Mention the Linear Agent on an issue when you want Open-Inspect to start work from that issue:
+
+```text
+@OpenInspect can you fix the failing invite flow described above?
+```
+
+Open-Inspect uses the issue title, description, labels, project, assignee, priority, recent
+comments, and triggering comment as context. The triggering comment becomes the agent instruction,
+so include the concrete work you want done.
+
+### From Assignment
+
+Assign the issue to the Linear Agent to ask Open-Inspect to pick it up. This is useful when the
+issue already has enough title and description detail for the agent to understand the requested
+work.
+
+If the issue could apply to several repositories, include the repository name in the issue or a
+comment. Open-Inspect may ask for clarification before starting.
+
+### Follow-Up Messages
+
+When a Linear issue already has an active Open-Inspect session, follow-up prompts on that issue are
+sent to the existing session instead of creating a new one. The follow-up includes the new prompt
+and a short summary of recent agent output when available.
+
+Issue-to-session mappings are kept for several days. If the mapping has expired, or if the previous
+session was stopped or cancelled, a new Linear Agent request may start a new Open-Inspect session.
+
+### Stop or Cancel
+
+Stopping or cancelling the Linear Agent session stops the associated Open-Inspect sandbox session
+and clears the issue's session mapping.
+
+---
+
+## What You See
+
+### Linear Activities
+
+The Linear Agent posts progress through Linear's agent activity surface:
+
+| Activity            | What it means                                                              |
+| ------------------- | -------------------------------------------------------------------------- |
+| Thinking            | Open-Inspect is analyzing the issue, resolving the repo, or creating work  |
+| Working             | A session has started and the agent is working in the sandbox              |
+| Tool progress       | Optional updates such as reading files, editing files, or running commands |
+| Clarification       | Open-Inspect needs more information, usually the target repository         |
+| Completion or error | The session finished, failed, or could not continue                        |
+
+Tool progress is best-effort and may be disabled by an admin. The Open-Inspect web session remains
+the best place to watch live output, inspect files, view logs, or take over.
+
+### Session and Pull Request Links
+
+When a session starts, Linear receives a **View Session** link. Follow-up acknowledgments include
+the same session link.
+
+When the agent finishes, Linear receives the final agent response. If the agent created a pull
+request, Linear also gets a **Pull Request** link.
+
+### Linear Issue Fields
+
+Open-Inspect does not currently update Linear issue status, labels, assignee, priority, or project.
+It posts Linear Agent activity and session links, while code changes and pull requests happen in the
+connected repository.
+
+---
+
+## Repository Resolution
+
+Open-Inspect needs to choose a repository before it can start a coding session. It usually resolves
+the repository from the Linear project, team, labels, issue content, recent comments, and available
+repository metadata.
+
+If the issue could match more than one repository, include the intended repository name in the issue
+or trigger comment:
+
+```text
+Please handle this in acme/billing-api.
+```
+
+If Open-Inspect is not confident, it asks a clarification question in Linear. Include the repository
+name in `owner/repo` format in your reply. That follow-up gives Open-Inspect more context for the
+next resolution attempt.
+
+Admins can configure project-to-repository and team-to-repository mappings through the Linear Bot
+setup/API flow. See
+[Configure Repo Mapping](../../packages/linear-bot/README.md#4-configure-repo-mapping-optional) for
+details.
+
+After the repo is resolved, Open-Inspect checks whether the Linear integration is enabled for that
+repository. If repository scope is set to **Selected repositories** and the repo is not selected,
+Linear shows an error activity and the session does not start.
+
+---
+
+## Settings
+
+Open the web app and go to **Settings > Integrations > Linear** to configure the Linear Agent.
+
+### Defaults and Scope
+
+| Setting                    | What it controls                                                             |
+| -------------------------- | ---------------------------------------------------------------------------- |
+| Default model              | Model used for Linear-started sessions when no higher-priority override wins |
+| Default reasoning effort   | Reasoning depth for models that support reasoning effort controls            |
+| Repository Scope           | Whether Linear can run against all accessible repos or only selected repos   |
+| Issue Session Instructions | Extra guidance appended to Linear issue prompts                              |
+
+If no Linear settings are configured, Open-Inspect uses permissive defaults: all accessible
+repositories are in scope, user model preferences are allowed, model labels are allowed, and tool
+progress activities are enabled.
+
+If repository scope is set to **Selected repositories** and no repositories are selected, Linear
+shows an error activity after repository resolution and the session does not start.
+
+### Model Overrides
+
+| Setting                        | What it controls                                                  |
+| ------------------------------ | ----------------------------------------------------------------- |
+| Allow user model preferences   | Whether admin-managed user preferences can override the model     |
+| Allow model labels (`model:*`) | Whether Linear issue labels can choose the model                  |
+| Repository Overrides           | Per-repository defaults for model, reasoning, and Linear behavior |
+
+The settings page controls whether user preferences and labels are allowed, but Linear user
+preferences are currently managed through admin/API configuration rather than a self-service Linear
+screen.
+
+Model selection uses this priority, highest to lowest:
+
+1. `model:*` issue label, when allowed.
+2. Linear user preference, when allowed.
+3. Repository override or global Linear default.
+4. Worker default model.
+
+Label overrides win over user preferences. Supported label names include `model:haiku`,
+`model:sonnet`, `model:opus`, `model:opus-4-6`, `model:opus-4-7`, `model:gpt-5.2`, `model:gpt-5.4`,
+`model:gpt-5.5`, `model:gpt-5.2-codex`, and `model:gpt-5.3-codex`.
+
+### Progress Updates
+
+**Emit tool progress activities** controls whether Linear receives ephemeral activity updates for
+file edits, file reads, and commands. Turning it off keeps completion responses and session links,
+but hides intermediate tool activity in Linear.
+
+---
+
+## Admin and Safety Notes
+
+- Linear webhooks are verified before Open-Inspect acts on them.
+- Linear OAuth tokens, webhook secrets, and callback secrets stay server-side.
+- Linear does not provide Git credentials. Repository access still comes from the deployment's
+  configured source-control integration, such as the GitHub App installation.
+- Repository scope in Linear settings controls which resolved repositories can receive
+  Linear-started sessions.
+- Linear issue text, comments, and prompt context are treated as untrusted content before being sent
+  to the agent.
+- The Linear Agent ignores ordinary non-agent webhook events today.
+
+---
+
+## Troubleshooting
+
+### The agent does not appear in Linear
+
+Confirm the Linear OAuth app is installed in the workspace and that the app was installed with the
+agent scopes required for mentions and assignment. Setup details live in the
+[Linear Bot setup guide](../../packages/linear-bot/README.md#setup).
+
+### Mentioning the agent does not start a session
+
+Make sure the mention is creating a Linear Agent session on an issue. Ordinary Linear comment
+webhooks do not start Open-Inspect sessions unless they are part of the Linear Agent workflow.
+
+### Assignment does not start a session
+
+Check that the Linear Agent is assignable in the workspace and that the issue belongs to a repo
+Open-Inspect can resolve and access.
+
+### Open-Inspect asks which repository to use
+
+Include the repository name in `owner/repo` format in your Linear reply. To avoid repeated
+clarification, include the repository name in future issues or ask an admin to configure project or
+team mappings through the Linear Bot setup/API flow.
+
+### I see progress in Linear but need full logs
+
+Open **View Session**. Linear shows status and completion activity, while detailed logs,
+transcripts, artifacts, and file changes live in the Open-Inspect web session.
+
+### The wrong model was used
+
+Check **Settings > Integrations > Linear**. Repository overrides, user preferences, and `model:*`
+labels can all affect model selection. Changes apply to new Linear-started sessions.
+
+### The wrong repository was used
+
+Check project and team repo mappings, issue labels, repository metadata, and the selected repository
+scope. If an issue is ambiguous, include the intended `owner/repo` in the issue or trigger comment.
+
+### The agent is active in too many repositories
+
+Limit the source-control installation to intended repositories, or set **Repository Scope** to
+**Selected repositories** in the Linear integration settings.

--- a/docs/integrations/LINEAR.md
+++ b/docs/integrations/LINEAR.md
@@ -1,8 +1,7 @@
 # Linear Integration
 
-Open-Inspect's Linear integration lets your team start coding sessions from Linear issues. The
-Linear Agent can be mentioned or assigned on an issue, posts progress and results back to Linear,
-and can continue active issue work with follow-up prompts.
+Open-Inspect's Linear integration starts coding sessions from Linear issues. Mention or assign the
+Linear Agent to start work, then use Linear for progress, results, and follow-ups.
 
 This guide is for people using the Linear integration day to day. If you are installing the Linear
 OAuth app or deploying the worker, start with the
@@ -12,38 +11,35 @@ OAuth app or deploying the worker, start with the
 
 ## Quick Start
 
-1. Make sure the Linear Agent is installed in your workspace.
-2. Open the Linear issue you want Open-Inspect to work on.
-3. Mention the agent in a comment:
+1. Open the Linear issue you want Open-Inspect to work on.
+2. Mention the agent in a comment:
    ```text
    @OpenInspect please implement this issue and open a pull request
    ```
-4. Or assign the issue to the Linear Agent.
-5. If Open-Inspect asks which repository to use, include the repository name in your reply, such as
-   `owner/repo`.
-6. Use **View Session** to watch the full Open-Inspect session while the agent works.
-7. Send follow-up prompts from the same issue's active Linear Agent session.
+3. Or assign the issue to the Linear Agent when the issue already explains the work.
+4. Include `owner/repo` if the issue could match more than one repository.
+5. Use **View Session** to watch the full session.
+6. Send follow-ups through the same active Linear Agent session.
 
 ---
 
-## Supported Workflows
+## What Linear Can Do
 
-| Workflow                    | How it works                                                                  |
-| --------------------------- | ----------------------------------------------------------------------------- |
-| Start from an issue mention | Mention the Linear Agent on an issue                                          |
-| Start from assignment       | Assign the issue to the Linear Agent                                          |
-| Continue active work        | Send a follow-up prompt on the same issue while the session is still mapped   |
-| Stop or cancel work         | Stop or cancel the Linear Agent session to stop the Open-Inspect session      |
-| Resolve the repository      | Let Open-Inspect infer the repo, or include `owner/repo` when asked           |
-| Follow progress             | Watch Linear activities or open the full session with **View Session**        |
-| Customize behavior          | Set repository scope, model defaults, model overrides, and issue instructions |
+| Workflow                    | How it works                                                             |
+| --------------------------- | ------------------------------------------------------------------------ |
+| Start from an issue mention | Mention the Linear Agent on an issue                                     |
+| Start from assignment       | Assign the issue to the Linear Agent                                     |
+| Continue active work        | Send a follow-up through the same active Linear Agent session            |
+| Stop or cancel work         | Stop or cancel the Linear Agent session to stop the Open-Inspect session |
+| Resolve the repository      | Let Open-Inspect infer the repo, or include `owner/repo` when asked      |
+| Follow progress             | Watch Linear activities or open the full session with **View Session**   |
 
-Linear currently responds to Linear Agent session events. Ordinary Linear issue or comment webhook
-events do not start Open-Inspect sessions by themselves.
+Start work by mentioning or assigning the Linear Agent. Regular issue comments only continue work
+when they are part of an active Linear Agent session.
 
 ---
 
-## Starting Sessions
+## Start, Continue, or Stop Work
 
 ### From an `@mention`
 
@@ -53,24 +49,24 @@ Mention the Linear Agent on an issue when you want Open-Inspect to start work fr
 @OpenInspect can you fix the failing invite flow described above?
 ```
 
-Open-Inspect uses the issue title, description, labels, project, assignee, priority, recent
-comments, and triggering comment as context. The triggering comment becomes the agent instruction,
-so include the concrete work you want done.
+Open-Inspect uses the issue and recent comments as context. The triggering comment becomes the agent
+instruction, so include the concrete work you want done.
 
 ### From Assignment
 
-Assign the issue to the Linear Agent to ask Open-Inspect to pick it up. This is useful when the
-issue already has enough title and description detail for the agent to understand the requested
-work.
+Assign the issue to the Linear Agent when the title and description already describe the work.
 
-If the issue could apply to several repositories, include the repository name in the issue or a
-comment. Open-Inspect may ask for clarification before starting.
+Assignment works best when the issue includes:
+
+- A clear title and description
+- Acceptance criteria or expected result
+- The target repository, if it is ambiguous
+- Whether the agent should open a pull request
 
 ### Follow-Up Messages
 
-When a Linear issue already has an active Open-Inspect session, follow-up prompts on that issue are
-sent to the existing session instead of creating a new one. The follow-up includes the new prompt
-and a short summary of recent agent output when available.
+Follow-up prompts on an issue with an active Open-Inspect session go to that session. When
+available, Open-Inspect adds recent agent output as context.
 
 Issue-to-session mappings are kept for several days. If the mapping has expired, or if the previous
 session was stopped or cancelled, a new Linear Agent request may start a new Open-Inspect session.
@@ -82,44 +78,10 @@ and clears the issue's session mapping.
 
 ---
 
-## What You See
+## Repository Selection
 
-### Linear Activities
-
-The Linear Agent posts progress through Linear's agent activity surface:
-
-| Activity            | What it means                                                              |
-| ------------------- | -------------------------------------------------------------------------- |
-| Thinking            | Open-Inspect is analyzing the issue, resolving the repo, or creating work  |
-| Working             | A session has started and the agent is working in the sandbox              |
-| Tool progress       | Optional updates such as reading files, editing files, or running commands |
-| Clarification       | Open-Inspect needs more information, usually the target repository         |
-| Completion or error | The session finished, failed, or could not continue                        |
-
-Tool progress is best-effort and may be disabled by an admin. The Open-Inspect web session remains
-the best place to watch live output, inspect files, view logs, or take over.
-
-### Session and Pull Request Links
-
-When a session starts, Linear receives a **View Session** link. Follow-up acknowledgments include
-the same session link.
-
-When the agent finishes, Linear receives the final agent response. If the agent created a pull
-request, Linear also gets a **Pull Request** link.
-
-### Linear Issue Fields
-
-Open-Inspect does not currently update Linear issue status, labels, assignee, priority, or project.
-It posts Linear Agent activity and session links, while code changes and pull requests happen in the
-connected repository.
-
----
-
-## Repository Resolution
-
-Open-Inspect needs to choose a repository before it can start a coding session. It usually resolves
-the repository from the Linear project, team, labels, issue content, recent comments, and available
-repository metadata.
+Before starting work, Open-Inspect chooses a repo from the Linear project, team, labels, issue text,
+comments, and repo metadata.
 
 If the issue could match more than one repository, include the intended repository name in the issue
 or trigger comment:
@@ -128,18 +90,33 @@ or trigger comment:
 Please handle this in acme/billing-api.
 ```
 
-If Open-Inspect is not confident, it asks a clarification question in Linear. Include the repository
-name in `owner/repo` format in your reply. That follow-up gives Open-Inspect more context for the
-next resolution attempt.
+If Open-Inspect asks for clarification, reply with `owner/repo`. That answer is used on the next
+resolution attempt.
 
-Admins can configure project-to-repository and team-to-repository mappings through the Linear Bot
-setup/API flow. See
+Admins can map Linear projects or teams to repositories. See
 [Configure Repo Mapping](../../packages/linear-bot/README.md#4-configure-repo-mapping-optional) for
 details.
 
-After the repo is resolved, Open-Inspect checks whether the Linear integration is enabled for that
-repository. If repository scope is set to **Selected repositories** and the repo is not selected,
-Linear shows an error activity and the session does not start.
+If the resolved repo is outside the selected Linear scope, Linear shows an error and no session
+starts.
+
+---
+
+## What Linear Shows
+
+| Activity            | What it means                                              |
+| ------------------- | ---------------------------------------------------------- |
+| Thinking            | Open-Inspect is analyzing the issue or choosing a repo     |
+| Working             | A session has started                                      |
+| Tool progress       | Optional updates for file reads, edits, and commands       |
+| Clarification       | Open-Inspect needs more information, usually the repo name |
+| Completion or error | The session finished, failed, or could not continue        |
+
+When a session starts, Linear receives a **View Session** link. If the agent opens a pull request,
+Linear receives a **Pull Request** link when the session finishes.
+
+Open the web session for live output, logs, artifacts, and file changes. Linear does not currently
+update issue status, labels, assignee, priority, or project.
 
 ---
 
@@ -147,50 +124,27 @@ Linear shows an error activity and the session does not start.
 
 Open the web app and go to **Settings > Integrations > Linear** to configure the Linear Agent.
 
-### Defaults and Scope
-
-| Setting                    | What it controls                                                             |
-| -------------------------- | ---------------------------------------------------------------------------- |
-| Default model              | Model used for Linear-started sessions when no higher-priority override wins |
-| Default reasoning effort   | Reasoning depth for models that support reasoning effort controls            |
-| Repository Scope           | Whether Linear can run against all accessible repos or only selected repos   |
-| Issue Session Instructions | Extra guidance appended to Linear issue prompts                              |
-
-If no Linear settings are configured, Open-Inspect uses permissive defaults: all accessible
-repositories are in scope, user model preferences are allowed, model labels are allowed, and tool
-progress activities are enabled.
-
-If repository scope is set to **Selected repositories** and no repositories are selected, Linear
-shows an error activity after repository resolution and the session does not start.
-
-### Model Overrides
-
 | Setting                        | What it controls                                                  |
 | ------------------------------ | ----------------------------------------------------------------- |
+| Default model and effort       | Model and reasoning depth for Linear-started sessions             |
+| Repository Scope               | Whether Linear can run in all accessible repos or selected repos  |
+| Issue Session Instructions     | Extra guidance appended to Linear issue prompts                   |
 | Allow user model preferences   | Whether admin-managed user preferences can override the model     |
 | Allow model labels (`model:*`) | Whether Linear issue labels can choose the model                  |
+| Tool progress activities       | Whether Linear shows intermediate file and command activity       |
 | Repository Overrides           | Per-repository defaults for model, reasoning, and Linear behavior |
 
-The settings page controls whether user preferences and labels are allowed, but Linear user
-preferences are currently managed through admin/API configuration rather than a self-service Linear
-screen.
+If no Linear settings are configured, all accessible repositories are in scope, user preferences and
+model labels are allowed, and tool progress is enabled.
 
 Model selection uses this priority, highest to lowest:
 
 1. `model:*` issue label, when allowed.
 2. Linear user preference, when allowed.
 3. Repository override or global Linear default.
-4. Worker default model.
+4. Deployment default model.
 
-Label overrides win over user preferences. Supported label names include `model:haiku`,
-`model:sonnet`, `model:opus`, `model:opus-4-6`, `model:opus-4-7`, `model:gpt-5.2`, `model:gpt-5.4`,
-`model:gpt-5.5`, `model:gpt-5.2-codex`, and `model:gpt-5.3-codex`.
-
-### Progress Updates
-
-**Emit tool progress activities** controls whether Linear receives ephemeral activity updates for
-file edits, file reads, and commands. Turning it off keeps completion responses and session links,
-but hides intermediate tool activity in Linear.
+Linear user preferences are currently admin/API-managed, not set from a self-service Linear screen.
 
 ---
 
@@ -202,9 +156,8 @@ but hides intermediate tool activity in Linear.
   configured source-control integration, such as the GitHub App installation.
 - Repository scope in Linear settings controls which resolved repositories can receive
   Linear-started sessions.
-- Linear issue text, comments, and prompt context are treated as untrusted content before being sent
-  to the agent.
-- The Linear Agent ignores ordinary non-agent webhook events today.
+- Linear issue titles, descriptions, comments, and agent prompts may be sent to the coding agent. Do
+  not include secrets.
 
 ---
 
@@ -216,21 +169,15 @@ Confirm the Linear OAuth app is installed in the workspace and that the app was 
 agent scopes required for mentions and assignment. Setup details live in the
 [Linear Bot setup guide](../../packages/linear-bot/README.md#setup).
 
-### Mentioning the agent does not start a session
+### A request does not start
 
-Make sure the mention is creating a Linear Agent session on an issue. Ordinary Linear comment
-webhooks do not start Open-Inspect sessions unless they are part of the Linear Agent workflow.
-
-### Assignment does not start a session
-
-Check that the Linear Agent is assignable in the workspace and that the issue belongs to a repo
-Open-Inspect can resolve and access.
+Make sure the request mentions or assigns the Linear Agent on an issue. Also check that the issue
+belongs to a repo Open-Inspect can resolve and access.
 
 ### Open-Inspect asks which repository to use
 
-Include the repository name in `owner/repo` format in your Linear reply. To avoid repeated
-clarification, include the repository name in future issues or ask an admin to configure project or
-team mappings through the Linear Bot setup/API flow.
+Reply with `owner/repo`. To avoid future prompts, add the repo to the issue or ask an admin to map
+the Linear project or team.
 
 ### I see progress in Linear but need full logs
 
@@ -240,7 +187,7 @@ transcripts, artifacts, and file changes live in the Open-Inspect web session.
 ### The wrong model was used
 
 Check **Settings > Integrations > Linear**. Repository overrides, user preferences, and `model:*`
-labels can all affect model selection. Changes apply to new Linear-started sessions.
+labels can affect model selection. Changes apply to new Linear-started sessions.
 
 ### The wrong repository was used
 

--- a/packages/linear-bot/README.md
+++ b/packages/linear-bot/README.md
@@ -4,6 +4,9 @@ Cloudflare Worker that integrates [Linear](https://linear.app) with Open-Inspect
 **Linear Agent**. Users can `@mention` or assign the agent on issues to trigger background coding
 sessions.
 
+For day-to-day usage, see the user-facing
+[Linear integration guide](../../docs/integrations/LINEAR.md).
+
 ## How It Works
 
 ```


### PR DESCRIPTION
## Summary

- Add a user-facing Linear integration guide covering quick start, supported workflows, session follow-ups, repository resolution, Linear-visible progress, settings, admin notes, and troubleshooting
- Link the new guide from the main README, setup guide, and Linear bot README

## Validation

- `npx prettier --check docs/integrations/LINEAR.md README.md docs/SETUP_GUIDE.md packages/linear-bot/README.md`
- `git diff --check`
- `git diff --check HEAD~1 HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the Linear Bot can be triggered by mentioning or assigning the agent
  * Added a comprehensive Linear integration guide covering usage, workflows, settings, admin/safety notes, and troubleshooting
  * Updated references to point to the new integration documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->