### PR TITLE
Clean up Slack startup status messages

### DIFF
--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -257,6 +257,17 @@ function statusFetchBodies(fetchMock: { mock: { calls: readonly (readonly unknow
     .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as Record<string, unknown>);
 }
 
+function startingStatusBodies(fetchMock: { mock: { calls: readonly (readonly unknown[])[] } }) {
+  return statusFetchBodies(fetchMock).filter((body) => {
+    const loadingMessages = body.loading_messages;
+    return (
+      body.status === "Starting..." &&
+      Array.isArray(loadingMessages) &&
+      loadingMessages[0] === "Starting..."
+    );
+  });
+}
+
 function slackApiBodies(
   fetchMock: { mock: { calls: readonly (readonly unknown[])[] } },
   method: string
@@ -327,7 +338,7 @@ describe("POST /events", () => {
 
     await flushWaitUntil(ctx);
     await flushWaitUntil(ctx, 1);
-    expect(ctx.waitUntil).toHaveBeenCalledTimes(2);
+    expect(ctx.waitUntil).toHaveBeenCalledTimes(4);
 
     expect(statusFetchBodies(slackFetch)).toContainEqual({
       channel_id: "C123",
@@ -335,6 +346,7 @@ describe("POST /events", () => {
       status: "Starting...",
       loading_messages: ["Starting..."],
     });
+    expect(startingStatusBodies(slackFetch)).toHaveLength(3);
     expect(order.indexOf("status")).toBeLessThan(order.indexOf("channelInfo"));
     expect(order.indexOf("status")).toBeLessThan(order.indexOf("session"));
 
@@ -396,6 +408,7 @@ describe("POST /events", () => {
       status: "Starting...",
       loading_messages: ["Starting..."],
     });
+    expect(startingStatusBodies(slackFetch)).toHaveLength(3);
     expect(order.indexOf("status")).toBeLessThan(order.indexOf("session"));
 
     slackFetch.mockRestore();
@@ -521,7 +534,7 @@ describe("POST /events", () => {
     expect(backgroundOutcome).toBe("complete");
     expect(order).toContain("session");
     expect(order).toContain("prompt");
-    expect(ctx.waitUntil).toHaveBeenCalledTimes(2);
+    expect(ctx.waitUntil).toHaveBeenCalledTimes(4);
 
     const statusPromise = ctx.waitUntil.mock.calls[1]?.[0] as Promise<void>;
     const statusOutcome = await Promise.race([
@@ -593,7 +606,7 @@ describe("POST /interactions", () => {
 
     await flushWaitUntil(ctx);
     await flushWaitUntil(ctx, 1);
-    expect(ctx.waitUntil).toHaveBeenCalledTimes(2);
+    expect(ctx.waitUntil).toHaveBeenCalledTimes(4);
 
     expect(statusFetchBodies(slackFetch)).toContainEqual({
       channel_id: "C123",
@@ -601,6 +614,7 @@ describe("POST /interactions", () => {
       status: "Starting...",
       loading_messages: ["Starting..."],
     });
+    expect(startingStatusBodies(slackFetch)).toHaveLength(3);
     expect(order.indexOf("repos")).toBeLessThan(order.indexOf("status"));
     expect(order.indexOf("status")).toBeLessThan(order.indexOf("session"));
 
@@ -1100,7 +1114,7 @@ describe("POST /interactions", () => {
 
     await flushWaitUntil(ctx);
     await flushWaitUntil(ctx, 1);
-    expect(ctx.waitUntil).toHaveBeenCalledTimes(2);
+    expect(ctx.waitUntil).toHaveBeenCalledTimes(4);
 
     const sessionCall = (
       env.CONTROL_PLANE.fetch as unknown as { mock: { calls: unknown[][] } }

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -257,6 +257,18 @@ function statusFetchBodies(fetchMock: { mock: { calls: readonly (readonly unknow
     .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as Record<string, unknown>);
 }
 
+function slackApiBodies(
+  fetchMock: { mock: { calls: readonly (readonly unknown[])[] } },
+  method: string
+) {
+  return fetchMock.mock.calls
+    .filter(([input]) => {
+      const url = typeof input === "string" ? input : String(input);
+      return url.includes(method);
+    })
+    .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as Record<string, unknown>);
+}
+
 function promptFetchBodies(fetchMock: { mock: { calls: readonly (readonly unknown[])[] } }) {
   return fetchMock.mock.calls
     .filter(([input]) => {
@@ -325,6 +337,33 @@ describe("POST /events", () => {
     });
     expect(order.indexOf("status")).toBeLessThan(order.indexOf("channelInfo"));
     expect(order.indexOf("status")).toBeLessThan(order.indexOf("session"));
+
+    const postBodies = slackApiBodies(slackFetch, "chat.postMessage");
+    expect(postBodies.some((body) => String(body.text).includes("Session started!"))).toBe(false);
+
+    const updateBodies = slackApiBodies(slackFetch, "chat.update");
+    expect(updateBodies).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          channel: "C123",
+          ts: "222.333",
+          text: "Working on *acme/app*...",
+          blocks: expect.arrayContaining([
+            expect.objectContaining({
+              type: "actions",
+              elements: expect.arrayContaining([
+                expect.objectContaining({
+                  type: "button",
+                  text: { type: "plain_text", text: "View Session" },
+                  url: "https://app.test/session/session-1",
+                  action_id: "view_session",
+                }),
+              ]),
+            }),
+          ]),
+        }),
+      ])
+    );
 
     slackFetch.mockRestore();
   });
@@ -564,6 +603,31 @@ describe("POST /interactions", () => {
     });
     expect(order.indexOf("repos")).toBeLessThan(order.indexOf("status"));
     expect(order.indexOf("status")).toBeLessThan(order.indexOf("session"));
+
+    const postBodies = slackApiBodies(slackFetch, "chat.postMessage");
+    expect(postBodies.some((body) => String(body.text).includes("Session started!"))).toBe(false);
+
+    const updateBodies = slackApiBodies(slackFetch, "chat.update");
+    expect(updateBodies).toEqual([
+      expect.objectContaining({
+        channel: "C123",
+        ts: "222.333",
+        text: "Working on *acme/app*...",
+        blocks: expect.arrayContaining([
+          expect.objectContaining({
+            type: "actions",
+            elements: expect.arrayContaining([
+              expect.objectContaining({
+                type: "button",
+                text: { type: "plain_text", text: "View Session" },
+                url: "https://app.test/session/session-1",
+                action_id: "view_session",
+              }),
+            ]),
+          }),
+        ]),
+      }),
+    ]);
 
     slackFetch.mockRestore();
   });

--- a/packages/slack-bot/src/index.ts
+++ b/packages/slack-bot/src/index.ts
@@ -1341,6 +1341,7 @@ interface IncomingMessageParams {
   channelDescription?: string;
   env: Env;
   traceId?: string;
+  scheduleBackground: BackgroundTaskScheduler;
 }
 
 /**
@@ -1364,6 +1365,7 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
     channelDescription,
     env,
     traceId,
+    scheduleBackground,
   } = params;
 
   if (!messageText) {
@@ -1561,6 +1563,7 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
   );
 
   const ackTs = ackResult.ok ? ackResult.ts : undefined;
+  scheduleStartingStatus(scheduleBackground, env, channel, threadKey, traceId);
 
   // Create session and send prompt using shared logic
   const sessionResult = await startSessionAndSendPrompt(
@@ -1589,6 +1592,7 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
         webAppUrl: env.WEB_APP_URL,
       }),
     });
+    scheduleStartingStatus(scheduleBackground, env, channel, threadKey, traceId);
   }
 }
 
@@ -1642,6 +1646,7 @@ async function handleAppMention(
     channelDescription,
     env,
     traceId,
+    scheduleBackground,
   });
 }
 
@@ -1681,6 +1686,7 @@ async function handleDirectMessage(
     threadTs: event.thread_ts,
     env,
     traceId,
+    scheduleBackground,
   });
 }
 
@@ -1753,6 +1759,7 @@ async function handleRepoSelection(
     }
   );
   const ackTs = ackResult.ok ? ackResult.ts : undefined;
+  scheduleStartingStatus(scheduleBackground, env, channel, threadKey, traceId);
 
   // Create session and send prompt using shared logic
   const sessionResult = await startSessionAndSendPrompt(
@@ -1782,6 +1789,7 @@ async function handleRepoSelection(
         webAppUrl: env.WEB_APP_URL,
       }),
     });
+    scheduleStartingStatus(scheduleBackground, env, channel, threadKey, traceId);
   }
 }
 

--- a/packages/slack-bot/src/index.ts
+++ b/packages/slack-bot/src/index.ts
@@ -886,6 +886,42 @@ function scheduleStartingStatus(
   );
 }
 
+function buildWorkingMessageBlocks(
+  repoFullName: string,
+  options: { reasoning?: string; sessionId?: string; webAppUrl?: string } = {}
+): Array<Record<string, unknown>> {
+  const blocks: Array<Record<string, unknown>> = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: options.reasoning
+          ? `Working on *${repoFullName}*...\n_${options.reasoning}_`
+          : `Working on *${repoFullName}*...`,
+      },
+    },
+  ];
+
+  if (options.sessionId && options.webAppUrl) {
+    blocks.push({
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: "View Session",
+          },
+          url: `${options.webAppUrl}/session/${options.sessionId}`,
+          action_id: "view_session",
+        },
+      ],
+    });
+  }
+
+  return blocks;
+}
+
 /**
  * Create a session and send the initial prompt.
  * Shared logic between handleAppMention and handleRepoSelection.
@@ -1000,23 +1036,6 @@ async function startSessionAndSendPrompt(
   }
 
   return { sessionId: session.sessionId };
-}
-
-/**
- * Post the "session started" notification to Slack.
- */
-async function postSessionStartedMessage(
-  env: Env,
-  channel: string,
-  threadTs: string,
-  sessionId: string
-): Promise<void> {
-  await postMessage(
-    env.SLACK_BOT_TOKEN,
-    channel,
-    `Session started! The agent is now working on your request.\n\nView progress: ${env.WEB_APP_URL}/session/${sessionId}`,
-    { thread_ts: threadTs }
-  );
 }
 
 const app = new Hono<{ Bindings: Env }>();
@@ -1333,7 +1352,6 @@ interface IncomingMessageParams {
  * - Repo classification
  * - Clarification / repo selection UI
  * - Ack message + session creation
- * - Session started message
  */
 async function handleIncomingMessage(params: IncomingMessageParams): Promise<void> {
   const {
@@ -1538,15 +1556,7 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
     `Working on *${repo.fullName}*...`,
     {
       thread_ts: threadKey,
-      blocks: [
-        {
-          type: "section",
-          text: {
-            type: "mrkdwn",
-            text: `Working on *${repo.fullName}*...\n_${result.reasoning}_`,
-          },
-        },
-      ],
+      blocks: buildWorkingMessageBlocks(repo.fullName, { reasoning: result.reasoning }),
     }
   );
 
@@ -1573,34 +1583,13 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
   // Update the acknowledgment message with session link button
   if (ackTs) {
     await updateMessage(env.SLACK_BOT_TOKEN, channel, ackTs, `Working on *${repo.fullName}*...`, {
-      blocks: [
-        {
-          type: "section",
-          text: {
-            type: "mrkdwn",
-            text: `Working on *${repo.fullName}*...\n_${result.reasoning}_`,
-          },
-        },
-        {
-          type: "actions",
-          elements: [
-            {
-              type: "button",
-              text: {
-                type: "plain_text",
-                text: "View Session",
-              },
-              url: `${env.WEB_APP_URL}/session/${sessionResult.sessionId}`,
-              action_id: "view_session",
-            },
-          ],
-        },
-      ],
+      blocks: buildWorkingMessageBlocks(repo.fullName, {
+        reasoning: result.reasoning,
+        sessionId: sessionResult.sessionId,
+        webAppUrl: env.WEB_APP_URL,
+      }),
     });
   }
-
-  // Post that the agent is working
-  await postSessionStartedMessage(env, channel, threadKey, sessionResult.sessionId);
 }
 
 /**
@@ -1754,9 +1743,16 @@ async function handleRepoSelection(
   scheduleStartingStatus(scheduleBackground, env, channel, threadKey, traceId);
 
   // Post acknowledgment
-  await postMessage(env.SLACK_BOT_TOKEN, channel, `Working on *${repo.fullName}*...`, {
-    thread_ts: threadKey,
-  });
+  const ackResult = await postMessage(
+    env.SLACK_BOT_TOKEN,
+    channel,
+    `Working on *${repo.fullName}*...`,
+    {
+      thread_ts: threadKey,
+      blocks: buildWorkingMessageBlocks(repo.fullName),
+    }
+  );
+  const ackTs = ackResult.ok ? ackResult.ts : undefined;
 
   // Create session and send prompt using shared logic
   const sessionResult = await startSessionAndSendPrompt(
@@ -1779,8 +1775,14 @@ async function handleRepoSelection(
   // Clean up pending message
   await createKvCacheStore(env.SLACK_KV).delete(pendingKey);
 
-  // Post that the agent is working
-  await postSessionStartedMessage(env, channel, threadKey, sessionResult.sessionId);
+  if (ackTs) {
+    await updateMessage(env.SLACK_BOT_TOKEN, channel, ackTs, `Working on *${repo.fullName}*...`, {
+      blocks: buildWorkingMessageBlocks(repo.fullName, {
+        sessionId: sessionResult.sessionId,
+        webAppUrl: env.WEB_APP_URL,
+      }),
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Removes the extra `Session started!` Slack reply and keeps the run-start experience centered on the existing `Working on ...` message.
- Adds the `View Session` button to that working message once session creation succeeds, including repo-selection starts.
- Re-sends `Starting...` after Slack message posts/updates so the assistant loading surface stays visible while the sandbox boots, until tool-call callbacks take over.

## Validation

- `npm ci`
- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/slack-bot`
- `npm run typecheck -w @open-inspect/slack-bot`
- `npm run lint -w @open-inspect/slack-bot`
- `npm run build -w @open-inspect/slack-bot`
- `git diff --check public/main...HEAD`

## Notes

This was tested first in the downstream production deployment before opening the public PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "View Session" button directly in working messages for quick access to session details.

* **Improvements**
  * Enhanced status visibility with more reliable "Starting..." updates during message processing.
  * Streamlined notification flow by consolidating session messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->