### PR TITLE
refactor: consolidate media upload validators

### DIFF
--- a/packages/control-plane/src/media.test.ts
+++ b/packages/control-plane/src/media.test.ts
@@ -5,8 +5,8 @@ import {
   detectVideoFileType,
   isSupportedScreenshotMimeType,
   isSupportedVideoMimeType,
+  parseDimensions,
   parseOptionalBoolean,
-  parseOptionalViewport,
   parseVideoUploadMetadata,
 } from "./media";
 
@@ -14,6 +14,9 @@ const MP4_SIGNATURE = Uint8Array.from([
   0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00,
   0x69, 0x73, 0x6f, 0x6d, 0x69, 0x73, 0x6f, 0x32,
 ]);
+
+const VIEWPORT_OPTS = { name: "viewport", required: false, mode: "round" } as const;
+const DIMENSIONS_OPTS = { name: "dimensions", required: true, mode: "integer" } as const;
 
 describe("media helpers", () => {
   it("builds session-scoped media object keys", () => {
@@ -71,7 +74,7 @@ describe("media helpers", () => {
 
   it.each([
     ["missing caption", { caption: "" }, "caption is required"],
-    ["non-positive duration", { durationMs: "0" }, "durationMs must be a positive number"],
+    ["non-positive duration", { durationMs: "0" }, "durationMs must be a positive integer"],
     ["decimal duration", { durationMs: "2500.5" }, "durationMs must be a positive integer"],
     ["exponent duration", { durationMs: "1e3" }, "durationMs must be a positive integer"],
     [
@@ -165,18 +168,41 @@ describe("media helpers", () => {
   });
 
   it("parses optional viewport JSON and rounds dimensions", () => {
-    expect(parseOptionalViewport('{"width":1279.6,"height":719.2}')).toEqual({
+    expect(parseDimensions('{"width":1279.6,"height":719.2}', VIEWPORT_OPTS)).toEqual({
       width: 1280,
       height: 719,
     });
-    expect(parseOptionalViewport(null)).toBeUndefined();
+    expect(parseDimensions(null, VIEWPORT_OPTS)).toBeUndefined();
   });
 
   it("rejects invalid viewport payloads", () => {
-    expect(() => parseOptionalViewport("not-json")).toThrow("viewport must be valid JSON");
-    expect(() => parseOptionalViewport("123")).toThrow("viewport must be an object");
-    expect(() => parseOptionalViewport('{"width":0,"height":100}')).toThrow(
+    expect(() => parseDimensions("not-json", VIEWPORT_OPTS)).toThrow("viewport must be valid JSON");
+    expect(() => parseDimensions("123", VIEWPORT_OPTS)).toThrow("viewport must be an object");
+    expect(() => parseDimensions('{"width":0,"height":100}', VIEWPORT_OPTS)).toThrow(
       "viewport must include positive width and height"
+    );
+  });
+
+  it("rejects round-mode values that round to zero", () => {
+    expect(() => parseDimensions('{"width":0.4,"height":720}', VIEWPORT_OPTS)).toThrow(
+      "viewport must include positive width and height"
+    );
+  });
+
+  it("parses required integer dimensions", () => {
+    expect(parseDimensions('{"width":1280,"height":720}', DIMENSIONS_OPTS)).toEqual({
+      width: 1280,
+      height: 720,
+    });
+  });
+
+  it("rejects missing or non-integer dimensions", () => {
+    expect(() => parseDimensions(null, DIMENSIONS_OPTS)).toThrow("dimensions is required");
+    expect(() => parseDimensions('{"width":1280.5,"height":720}', DIMENSIONS_OPTS)).toThrow(
+      "dimensions must include positive integer width and height"
+    );
+    expect(() => parseDimensions('{"width":-1,"height":720}', DIMENSIONS_OPTS)).toThrow(
+      "dimensions must include positive integer width and height"
     );
   });
 });

--- a/packages/control-plane/src/media.ts
+++ b/packages/control-plane/src/media.ts
@@ -115,41 +115,58 @@ export function parseOptionalBoolean(value: MultipartFieldValue | null): boolean
   throw new Error("Boolean fields must be 'true' or 'false'");
 }
 
-export function parseOptionalViewport(
-  value: MultipartFieldValue | null
-): { width: number; height: number } | undefined {
-  if (value === null) return undefined;
+type Dimensions = { width: number; height: number };
+type DimensionsMode = "integer" | "round";
+
+export function parseDimensions(
+  value: MultipartFieldValue | null,
+  opts: { name: string; required: true; mode: DimensionsMode }
+): Dimensions;
+export function parseDimensions(
+  value: MultipartFieldValue | null,
+  opts: { name: string; required: false; mode: DimensionsMode }
+): Dimensions | undefined;
+export function parseDimensions(
+  value: MultipartFieldValue | null,
+  opts: { name: string; required: boolean; mode: DimensionsMode }
+): Dimensions | undefined {
+  if (value === null) {
+    if (opts.required) throw new Error(`${opts.name} is required`);
+    return undefined;
+  }
   if (typeof value !== "string") {
-    throw new Error("viewport must be a JSON string");
+    throw new Error(`${opts.name} must be a JSON string`);
   }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(value);
   } catch {
-    throw new Error("viewport must be valid JSON");
+    throw new Error(`${opts.name} must be valid JSON`);
   }
 
   if (!parsed || typeof parsed !== "object") {
-    throw new Error("viewport must be an object");
+    throw new Error(`${opts.name} must be an object`);
   }
 
   const candidate = parsed as { width?: unknown; height?: unknown };
-  if (
-    typeof candidate.width !== "number" ||
-    !Number.isFinite(candidate.width) ||
-    candidate.width <= 0 ||
-    typeof candidate.height !== "number" ||
-    !Number.isFinite(candidate.height) ||
-    candidate.height <= 0
-  ) {
-    throw new Error("viewport must include positive width and height");
+  const width = coerceDimension(candidate.width, opts.mode);
+  const height = coerceDimension(candidate.height, opts.mode);
+  if (width === null || height === null) {
+    const detail =
+      opts.mode === "integer" ? "positive integer width and height" : "positive width and height";
+    throw new Error(`${opts.name} must include ${detail}`);
   }
 
-  return {
-    width: Math.round(candidate.width),
-    height: Math.round(candidate.height),
-  };
+  return { width, height };
+}
+
+function coerceDimension(value: unknown, mode: DimensionsMode): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return null;
+  if (mode === "integer") return Number.isInteger(value) ? value : null;
+  // Reject values that round to 0 — Math.round(0.4) === 0 would silently produce a zero dimension.
+  const rounded = Math.round(value);
+  return rounded > 0 ? rounded : null;
 }
 
 export function parseVideoUploadMetadata(
@@ -157,19 +174,16 @@ export function parseVideoUploadMetadata(
   createdAt = Date.now()
 ): VideoUploadMetadata {
   const caption = parseRequiredString(fields.get("caption"), "caption");
-  const durationMs = parseRequiredPositiveInteger(fields.get("durationMs"), "durationMs");
-  if (durationMs > VIDEO_MAX_DURATION_MS) {
-    throw new Error(`durationMs must be ${VIDEO_MAX_DURATION_MS} or less`);
-  }
-
-  const recordingStartedAt = parseRequiredPositiveInteger(
-    fields.get("recordingStartedAt"),
-    "recordingStartedAt"
-  );
-  const recordingEndedAt = parseRequiredPositiveInteger(
-    fields.get("recordingEndedAt"),
-    "recordingEndedAt"
-  );
+  const durationMs = parsePositiveInteger(fields.get("durationMs"), {
+    name: "durationMs",
+    max: VIDEO_MAX_DURATION_MS,
+  });
+  const recordingStartedAt = parsePositiveInteger(fields.get("recordingStartedAt"), {
+    name: "recordingStartedAt",
+  });
+  const recordingEndedAt = parsePositiveInteger(fields.get("recordingEndedAt"), {
+    name: "recordingEndedAt",
+  });
   if (recordingEndedAt < recordingStartedAt) {
     throw new Error("recordingEndedAt must be greater than or equal to recordingStartedAt");
   }
@@ -181,7 +195,11 @@ export function parseVideoUploadMetadata(
     throw new Error("durationMs must not exceed the recording timestamp span");
   }
 
-  const dimensions = parseRequiredDimensions(fields.get("dimensions"));
+  const dimensions = parseDimensions(fields.get("dimensions"), {
+    name: "dimensions",
+    required: true,
+    mode: "integer",
+  });
   const truncated = parseRequiredBoolean(fields.get("truncated"), "truncated");
   const sourceUrl = parseOptionalUrl(fields.get("sourceUrl"), "sourceUrl");
   const endUrl = parseOptionalUrl(fields.get("endUrl"), "endUrl");
@@ -231,72 +249,31 @@ function parseRequiredString(value: MultipartFieldValue | null, name: string): s
   return value.trim();
 }
 
-function parseRequiredPositiveInteger(value: MultipartFieldValue | null, name: string): number {
-  const stringValue = parseRequiredString(value, name);
-  if (stringValue === "0") {
-    throw new Error(`${name} must be a positive number`);
+// Strict integer-only parsing — rejects decimals, exponents, and unsafe sizes.
+function parsePositiveInteger(
+  value: MultipartFieldValue | null,
+  opts: { name: string; max?: number }
+): number {
+  const text = parseRequiredString(value, opts.name);
+  if (!/^[1-9]\d*$/.test(text)) {
+    throw new Error(`${opts.name} must be a positive integer`);
   }
-  if (!/^[1-9]\d*$/.test(stringValue)) {
-    throw new Error(`${name} must be a positive integer`);
-  }
-
-  const parsed = Number(stringValue);
+  const parsed = Number(text);
   if (!Number.isSafeInteger(parsed)) {
-    throw new Error(`${name} must be a safe integer`);
+    throw new Error(`${opts.name} must be a safe integer`);
   }
-
+  if (opts.max !== undefined && parsed > opts.max) {
+    throw new Error(`${opts.name} must be ${opts.max} or less`);
+  }
   return parsed;
 }
 
 function parseRequiredBoolean(value: MultipartFieldValue | null, name: string): boolean {
-  if (value === null) {
+  const parsed = parseOptionalBoolean(value);
+  if (parsed === undefined) {
     throw new Error(`${name} is required`);
   }
-
-  return parseOptionalBoolean(value) ?? false;
-}
-
-function parseRequiredDimensions(value: MultipartFieldValue | null): {
-  width: number;
-  height: number;
-} {
-  if (value === null) {
-    throw new Error("dimensions is required");
-  }
-
-  if (typeof value !== "string") {
-    throw new Error("dimensions must be a JSON string");
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(value);
-  } catch {
-    throw new Error("dimensions must be valid JSON");
-  }
-
-  if (!parsed || typeof parsed !== "object") {
-    throw new Error("dimensions must be an object");
-  }
-
-  const candidate = parsed as { width?: unknown; height?: unknown };
-  if (
-    typeof candidate.width !== "number" ||
-    !Number.isFinite(candidate.width) ||
-    !Number.isInteger(candidate.width) ||
-    candidate.width <= 0 ||
-    typeof candidate.height !== "number" ||
-    !Number.isFinite(candidate.height) ||
-    !Number.isInteger(candidate.height) ||
-    candidate.height <= 0
-  ) {
-    throw new Error("dimensions must include positive integer width and height");
-  }
-
-  return {
-    width: candidate.width,
-    height: candidate.height,
-  };
+  return parsed;
 }
 
 function parseOptionalUrl(value: MultipartFieldValue | null, name: string): string | undefined {

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -19,8 +19,8 @@ import {
   isSupportedScreenshotMimeType,
   isSupportedVideoMimeType,
   type MultipartFieldValue,
+  parseDimensions,
   parseOptionalBoolean,
-  parseOptionalViewport,
   parseVideoUploadMetadata,
   SCREENSHOT_MAX_BYTES,
   SCREENSHOT_UPLOAD_LIMIT_PER_SESSION,
@@ -1380,7 +1380,11 @@ async function handleMediaUpload(
   try {
     fullPage = parseOptionalBoolean(formData.get("fullPage"));
     annotated = parseOptionalBoolean(formData.get("annotated"));
-    viewport = parseOptionalViewport(formData.get("viewport"));
+    viewport = parseDimensions(formData.get("viewport"), {
+      name: "viewport",
+      required: false,
+      mode: "round",
+    });
   } catch (fieldError) {
     return error(
       fieldError instanceof Error ? fieldError.message : "Invalid screenshot metadata",

--- a/packages/web/src/hooks/use-session-socket.test.tsx
+++ b/packages/web/src/hooks/use-session-socket.test.tsx
@@ -285,7 +285,7 @@ describe("useSessionSocket", () => {
     });
   });
 
-  it("drops invalid numeric screenshot metadata from subscribed artifacts", async () => {
+  it("drops wrong-type metadata fields during narrowing", async () => {
     const { result } = renderHook(() => useSessionSocket("session-1"));
 
     await waitFor(() => {
@@ -301,14 +301,14 @@ describe("useSessionSocket", () => {
       socket.receive(
         createSubscribedMessage([
           {
-            id: "artifact-shot-invalid",
+            id: "artifact-shot-wrong-types",
             type: "screenshot",
-            url: "sessions/session-1/media/artifact-shot-invalid.png",
+            url: "sessions/session-1/media/artifact-shot-wrong-types.png",
             metadata: {
-              objectKey: "sessions/session-1/media/artifact-shot-invalid.png",
+              objectKey: "sessions/session-1/media/artifact-shot-wrong-types.png",
               mimeType: "image/png",
-              sizeBytes: -1,
-              viewport: { width: 0, height: -100 },
+              sizeBytes: "five",
+              viewport: "not-an-object",
             },
             createdAt: 1234,
           },
@@ -319,11 +319,11 @@ describe("useSessionSocket", () => {
     await waitFor(() => {
       expect(result.current.artifacts).toEqual([
         {
-          id: "artifact-shot-invalid",
+          id: "artifact-shot-wrong-types",
           type: "screenshot",
-          url: "sessions/session-1/media/artifact-shot-invalid.png",
+          url: "sessions/session-1/media/artifact-shot-wrong-types.png",
           metadata: expect.objectContaining({
-            objectKey: "sessions/session-1/media/artifact-shot-invalid.png",
+            objectKey: "sessions/session-1/media/artifact-shot-wrong-types.png",
             mimeType: "image/png",
             sizeBytes: undefined,
             viewport: undefined,

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -114,44 +114,26 @@ function toUiSandboxEvent(event: SharedSandboxEvent): SandboxEvent {
 
 type PrState = NonNullable<NonNullable<Artifact["metadata"]>["prState"]>;
 const PR_STATES = new Set<string>(["open", "merged", "closed", "draft"]);
-const SCREENSHOT_MIME_TYPES = new Set<ScreenshotArtifactMetadata["mimeType"]>([
+type MediaMimeType = ScreenshotArtifactMetadata["mimeType"] | VideoArtifactMetadata["mimeType"];
+const MEDIA_MIME_TYPES = new Set<MediaMimeType>([
   "image/png",
   "image/jpeg",
   "image/webp",
+  "video/mp4",
 ]);
-const VIDEO_MIME_TYPES = new Set<VideoArtifactMetadata["mimeType"]>(["video/mp4"]);
 
-function isScreenshotMimeType(value: string): value is ScreenshotArtifactMetadata["mimeType"] {
-  return SCREENSHOT_MIME_TYPES.has(value as ScreenshotArtifactMetadata["mimeType"]);
+function isMediaMimeType(value: string): value is MediaMimeType {
+  return MEDIA_MIME_TYPES.has(value as MediaMimeType);
 }
 
-function isVideoMimeType(value: string): value is VideoArtifactMetadata["mimeType"] {
-  return VIDEO_MIME_TYPES.has(value as VideoArtifactMetadata["mimeType"]);
-}
-
-function toNonNegativeNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
-}
-
-function toPositiveNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
-}
-
-function toDimensions(value: unknown): { width: number; height: number } | undefined {
+function narrowDimensions(value: unknown): { width: number; height: number } | undefined {
   if (
     value &&
     typeof value === "object" &&
     typeof (value as { width?: unknown }).width === "number" &&
-    Number.isFinite((value as { width: number }).width) &&
-    (value as { width: number }).width > 0 &&
-    typeof (value as { height?: unknown }).height === "number" &&
-    Number.isFinite((value as { height: number }).height) &&
-    (value as { height: number }).height > 0
+    typeof (value as { height?: unknown }).height === "number"
   ) {
-    return {
-      width: (value as { width: number }).width,
-      height: (value as { height: number }).height,
-    };
+    return value as { width: number; height: number };
   }
   return undefined;
 }
@@ -178,21 +160,22 @@ function toUiArtifact(artifact: SessionArtifact): Artifact {
           filename: typeof meta.filename === "string" ? meta.filename : undefined,
           objectKey: typeof meta.objectKey === "string" ? meta.objectKey : undefined,
           mimeType:
-            typeof meta.mimeType === "string" &&
-            (isScreenshotMimeType(meta.mimeType) || isVideoMimeType(meta.mimeType))
+            typeof meta.mimeType === "string" && isMediaMimeType(meta.mimeType)
               ? meta.mimeType
               : undefined,
-          sizeBytes: toNonNegativeNumber(meta.sizeBytes),
-          viewport: toDimensions(meta.viewport),
+          sizeBytes: typeof meta.sizeBytes === "number" ? meta.sizeBytes : undefined,
+          viewport: narrowDimensions(meta.viewport),
           sourceUrl: typeof meta.sourceUrl === "string" ? meta.sourceUrl : undefined,
           endUrl: typeof meta.endUrl === "string" ? meta.endUrl : undefined,
           fullPage: typeof meta.fullPage === "boolean" ? meta.fullPage : undefined,
           annotated: typeof meta.annotated === "boolean" ? meta.annotated : undefined,
           caption: typeof meta.caption === "string" ? meta.caption : undefined,
-          durationMs: toPositiveNumber(meta.durationMs),
-          recordingStartedAt: toPositiveNumber(meta.recordingStartedAt),
-          recordingEndedAt: toPositiveNumber(meta.recordingEndedAt),
-          dimensions: toDimensions(meta.dimensions),
+          durationMs: typeof meta.durationMs === "number" ? meta.durationMs : undefined,
+          recordingStartedAt:
+            typeof meta.recordingStartedAt === "number" ? meta.recordingStartedAt : undefined,
+          recordingEndedAt:
+            typeof meta.recordingEndedAt === "number" ? meta.recordingEndedAt : undefined,
+          dimensions: narrowDimensions(meta.dimensions),
           truncated: typeof meta.truncated === "boolean" ? meta.truncated : undefined,
           hasAudio: meta.hasAudio === false ? false : undefined,
           previewStatus:


### PR DESCRIPTION
## Summary

Follow-on to #648. Consolidates the duplicated number and dimension parsers introduced alongside the video upload path, and aligns the web client to trust server-side validation.

### Control plane (`packages/control-plane/src/media.ts`)

- `parseDimensions(value, { name, required, mode })` replaces `parseRequiredDimensions` and `parseOptionalViewport`. Overloads narrow the return type by `required`.
- `parsePositiveInteger(value, { name, max? })` replaces `parseRequiredPositiveInteger`. The duration bound check now lives in the parser; the unreachable `"0"` branch is gone.
- Round mode now rejects values that round to 0 (e.g. `{ "width": 0.4 }` no longer silently coerces to `{ "width": 0 }`).
- `parseRequiredBoolean` drops its unreachable `?? false` fallback.
- `type Dimensions` is internal (was needlessly exported).

### Web (`packages/web/src/hooks/use-session-socket.ts`)

- Trust the boundary: removed `toNonNegativeNumber`, `toPositiveNumber`, `toDimensions`. Server validation already guarantees valid ranges; the client now only narrows types.
- Merged `SCREENSHOT_MIME_TYPES` + `VIDEO_MIME_TYPES` into a single `MEDIA_MIME_TYPES` set and one `isMediaMimeType` guard — the screenshot/video distinction was never consumed.

### Behavior changes (visible at the HTTP boundary)

- Error message for `durationMs=0` changes from `"must be a positive number"` to `"must be a positive integer"`. Other 400 messages unchanged.
- Round-mode dimensions with `0 < value < 0.5` now return 400 instead of silently coercing to 0.

Net **+133 / -143** across 5 files.

## Test plan

- [x] `npm run typecheck` — clean for `@open-inspect/shared`, `@open-inspect/control-plane`, `@open-inspect/web`
- [x] `npm run lint -w @open-inspect/control-plane` and `-w @open-inspect/web` — clean
- [x] `npm test -w @open-inspect/control-plane` — 1112 unit tests pass; `media.test.ts` grew 26 → 29 (added direct `parseDimensions` tests + round-to-zero rejection)
- [x] `npm run test:integration -w @open-inspect/control-plane -- test/integration/media.test.ts` — 11 tests pass
- [x] `npm test -w @open-inspect/web` — 251 tests pass (replaced the range-validation test in `use-session-socket.test.tsx` with a wrong-type narrowing test)
- [x] `npm test -w @open-inspect/shared` — 162 tests pass
- [ ] CI green
- [ ] Manual smoke: screenshot upload still validates viewport JSON via `POST /sessions/<id>/media`
- [ ] Manual smoke: video upload still validates all required metadata fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened validation of media metadata during uploads to enforce stricter dimension parsing and require specified fields to be properly formatted.
  * Enhanced error detection for invalid metadata values and malformed dimension data in video and image uploads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/649?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->