### PR TITLE
Normalize artifact metadata in shared package

### DIFF
--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -1308,7 +1308,8 @@ async function getSessionArtifactFromDo(
 function getMediaMimeType(
   artifact: Pick<ArtifactResponse, "metadata">
 ): "image/png" | "image/jpeg" | "image/webp" | "video/mp4" | null {
-  const mimeType = artifact.metadata?.mimeType;
+  const mimeType =
+    artifact.metadata && "mimeType" in artifact.metadata ? artifact.metadata.mimeType : undefined;
   if (typeof mimeType !== "string") return null;
   if (isSupportedScreenshotMimeType(mimeType) || isSupportedVideoMimeType(mimeType)) {
     return mimeType;

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -10,7 +10,7 @@
 import { DurableObject } from "cloudflare:workers";
 import { initSchema } from "./schema";
 import { buildSessionInternalUrl, SessionInternalPaths } from "./contracts";
-import { resolveAppName, timingSafeEqual } from "@open-inspect/shared";
+import { normalizeArtifactMetadata, resolveAppName, timingSafeEqual } from "@open-inspect/shared";
 import { generateId, hashToken, encryptToken, decryptToken } from "../auth/crypto";
 import { getGitHubAppConfig, getCachedInstallationToken } from "../auth/github-app";
 import { createModalClient } from "../sandbox/client";
@@ -46,6 +46,7 @@ import {
 import { DEFAULT_MODEL, isValidReasoningEffort } from "../utils/models";
 import type {
   Env,
+  ArtifactMetadata,
   ClientInfo,
   ClientMessage,
   ServerMessage,
@@ -1788,14 +1789,14 @@ export class SessionDO extends DurableObject<Env> {
   // HTTP handlers
 
   private parseArtifactMetadata(
-    artifact: Pick<ArtifactRow, "id" | "metadata">
-  ): Record<string, unknown> | null {
+    artifact: Pick<ArtifactRow, "id" | "type" | "metadata">
+  ): ArtifactMetadata | null {
     if (!artifact.metadata) {
       return null;
     }
 
     try {
-      return JSON.parse(artifact.metadata) as Record<string, unknown>;
+      return normalizeArtifactMetadata(artifact.type, JSON.parse(artifact.metadata));
     } catch (error) {
       this.log.warn("Invalid artifact metadata JSON", {
         artifact_id: artifact.id,

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
@@ -1,5 +1,5 @@
 import type { Logger } from "../../../logger";
-import type { SessionArtifact } from "@open-inspect/shared";
+import { normalizeArtifactMetadata, type SessionArtifact } from "@open-inspect/shared";
 import type { ParticipantRole, SandboxEvent, ServerMessage } from "../../../types";
 import type { OpenAITokenRefreshResult } from "../../openai-token-refresh-service";
 import type { SessionRepository } from "../../repository";
@@ -35,7 +35,7 @@ interface CreateMediaArtifactRequest {
   artifactId: string;
   artifactType: string;
   objectKey: string;
-  metadata?: Record<string, unknown>;
+  metadata?: unknown;
 }
 
 export interface SandboxHandler {
@@ -71,13 +71,14 @@ export function createSandboxHandler(deps: SandboxHandlerDeps): SandboxHandler {
       }
 
       const artifactType = assertArtifactType(body.artifactType);
+      const metadata = normalizeArtifactMetadata(artifactType, body.metadata);
       const now = deps.now();
       const timestampSeconds = now / 1000;
       const artifact: SessionArtifact = {
         id: body.artifactId,
         type: artifactType,
         url: body.objectKey,
-        metadata: body.metadata ?? null,
+        metadata,
         createdAt: now,
       };
 
@@ -85,7 +86,7 @@ export function createSandboxHandler(deps: SandboxHandlerDeps): SandboxHandler {
         id: artifact.id,
         type: artifact.type,
         url: artifact.url,
-        metadata: artifact.metadata ? JSON.stringify(artifact.metadata) : null,
+        metadata: metadata ? JSON.stringify(metadata) : null,
         createdAt: now,
       });
 
@@ -94,7 +95,7 @@ export function createSandboxHandler(deps: SandboxHandlerDeps): SandboxHandler {
         artifactType: artifact.type,
         artifactId: artifact.id,
         url: body.objectKey,
-        metadata: artifact.metadata ?? undefined,
+        metadata: metadata ? (metadata as Record<string, unknown>) : undefined,
         messageId: processingMessage.id,
         sandboxId: sandbox.modal_sandbox_id ?? sandbox.id,
         timestamp: timestampSeconds,

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -1,4 +1,4 @@
-import type { SessionArtifact } from "@open-inspect/shared";
+import { normalizeArtifactMetadata, type SessionArtifact } from "@open-inspect/shared";
 import { generateId } from "../auth/crypto";
 import type { Logger } from "../logger";
 import type { GitPushSpec } from "../source-control";
@@ -65,6 +65,7 @@ export class SessionSandboxEventProcessor {
       this.deps.updateLastActivity(now);
 
       const artifactType = assertArtifactType(event.artifactType);
+      const metadata = normalizeArtifactMetadata(artifactType, event.metadata);
       const artifactId =
         typeof event.artifactId === "string" && event.artifactId.length > 0
           ? event.artifactId
@@ -73,13 +74,14 @@ export class SessionSandboxEventProcessor {
         ...event,
         artifactType,
         artifactId,
+        metadata: metadata ? (metadata as Record<string, unknown>) : undefined,
         messageId: messageId ?? undefined,
       };
       const artifact: SessionArtifact = {
         id: artifactId,
         type: artifactType,
         url: event.url,
-        metadata: event.metadata ?? null,
+        metadata,
         createdAt: now,
       };
 
@@ -87,7 +89,7 @@ export class SessionSandboxEventProcessor {
         id: artifact.id,
         type: artifact.type,
         url: artifact.url,
-        metadata: artifact.metadata ? JSON.stringify(artifact.metadata) : null,
+        metadata: metadata ? JSON.stringify(metadata) : null,
         createdAt: now,
       });
       this.deps.repository.createEvent({

--- a/packages/control-plane/src/session/services/message.service.test.ts
+++ b/packages/control-plane/src/session/services/message.service.test.ts
@@ -92,12 +92,12 @@ describe("MessageService", () => {
         id: "a1",
         type: "pr",
         url: "https://example.com/pr/1",
-        metadata: '{"key":"value"}',
+        metadata: '{"number":1}',
         created_at: 1000,
       },
     ];
     vi.mocked(repository.listArtifacts).mockReturnValue(artifacts);
-    vi.mocked(parseArtifactMetadata).mockReturnValue({ key: "value" });
+    vi.mocked(parseArtifactMetadata).mockReturnValue({ number: 1 });
 
     const result = service.listArtifacts();
 
@@ -107,7 +107,7 @@ describe("MessageService", () => {
           id: "a1",
           type: "pr",
           url: "https://example.com/pr/1",
-          metadata: { key: "value" },
+          metadata: { number: 1 },
           createdAt: 1000,
         },
       ],

--- a/packages/control-plane/src/session/services/message.service.ts
+++ b/packages/control-plane/src/session/services/message.service.ts
@@ -1,5 +1,5 @@
 import type { ArtifactRow, EventRow, MessageRow } from "../types";
-import type { ArtifactResponse } from "../../types";
+import type { ArtifactMetadata, ArtifactResponse } from "../../types";
 import type { SessionRepository } from "../repository";
 import type { SessionMessageQueue } from "../message-queue";
 
@@ -42,8 +42,8 @@ interface MessageServiceDeps {
   messageQueue: SessionMessageQueue;
   stopExecution: () => Promise<void>;
   parseArtifactMetadata: (
-    artifact: Pick<ArtifactRow, "id" | "metadata">
-  ) => Record<string, unknown> | null;
+    artifact: Pick<ArtifactRow, "id" | "type" | "metadata">
+  ) => ArtifactMetadata | null;
 }
 
 export class MessageService {
@@ -84,7 +84,7 @@ export class MessageService {
       id: string;
       type: ArtifactRow["type"];
       url: string | null;
-      metadata: Record<string, unknown> | null;
+      metadata: ArtifactMetadata | null;
       createdAt: number;
     }>;
   } {

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -3,7 +3,6 @@
  */
 
 import type {
-  ArtifactType,
   EventType,
   MessageSource,
   MessageStatus,
@@ -12,6 +11,8 @@ import type {
 } from "@open-inspect/shared";
 
 export type {
+  ArtifactMetadata,
+  ArtifactResponse,
   ArtifactType,
   Attachment,
   ClientMessage,
@@ -23,6 +24,7 @@ export type {
   MessageStatus,
   ParticipantRole,
   ParticipantPresence,
+  PullRequestArtifactMetadata,
   SpawnSource,
   SandboxEvent,
   SandboxStatus,
@@ -153,14 +155,6 @@ export interface ListEventsResponse {
   events: EventResponse[];
   cursor?: string;
   hasMore: boolean;
-}
-
-export interface ArtifactResponse {
-  id: string;
-  type: ArtifactType;
-  url: string | null;
-  metadata: Record<string, unknown> | null;
-  createdAt: number;
 }
 
 export interface ParticipantResponse {

--- a/packages/shared/src/artifacts.test.ts
+++ b/packages/shared/src/artifacts.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { normalizeArtifactMetadata } from "./artifacts";
+
+describe("artifact metadata normalization", () => {
+  it("normalizes pull request metadata field by field", () => {
+    expect(
+      normalizeArtifactMetadata("pr", {
+        number: 42,
+        state: "open",
+        head: "feature/video",
+        base: "main",
+        ignored: "value",
+      })
+    ).toEqual({
+      number: 42,
+      state: "open",
+      head: "feature/video",
+      base: "main",
+    });
+  });
+
+  it("normalizes manual pull request branch metadata", () => {
+    expect(
+      normalizeArtifactMetadata("branch", {
+        mode: "manual_pr",
+        head: "feature/video",
+        base: "main",
+        createPrUrl: "https://github.com/acme/app/compare/main...feature/video",
+        provider: "github",
+      })
+    ).toEqual({
+      mode: "manual_pr",
+      head: "feature/video",
+      base: "main",
+      createPrUrl: "https://github.com/acme/app/compare/main...feature/video",
+      provider: "github",
+    });
+  });
+
+  it("normalizes preview status metadata", () => {
+    expect(normalizeArtifactMetadata("preview", { previewStatus: "outdated" })).toEqual({
+      previewStatus: "outdated",
+    });
+  });
+
+  it("normalizes screenshot metadata and drops invalid fields", () => {
+    expect(
+      normalizeArtifactMetadata("screenshot", {
+        objectKey: "sessions/s1/media/a1.png",
+        mimeType: "image/png",
+        sizeBytes: -1,
+        viewport: { width: 1440, height: 900 },
+        sourceUrl: "http://127.0.0.1:3000",
+        fullPage: true,
+        annotated: false,
+        caption: "Dashboard",
+      })
+    ).toEqual({
+      objectKey: "sessions/s1/media/a1.png",
+      mimeType: "image/png",
+      viewport: { width: 1440, height: 900 },
+      sourceUrl: "http://127.0.0.1:3000",
+      fullPage: true,
+      annotated: false,
+      caption: "Dashboard",
+    });
+  });
+
+  it("normalizes video metadata and only preserves hasAudio when false", () => {
+    expect(
+      normalizeArtifactMetadata("video", {
+        objectKey: "sessions/s1/media/a1.mp4",
+        mimeType: "video/mp4",
+        sizeBytes: 4096,
+        caption: "Menu opens",
+        durationMs: 1450,
+        createdAt: 4000,
+        recordingStartedAt: 1000,
+        recordingEndedAt: 2450,
+        dimensions: { width: 1280, height: 720 },
+        truncated: false,
+        hasAudio: true,
+        captureSurface: "browser",
+        source: "agent",
+        sourceUrl: "http://127.0.0.1:3000/start",
+        endUrl: "http://127.0.0.1:3000/end",
+      })
+    ).toEqual({
+      objectKey: "sessions/s1/media/a1.mp4",
+      mimeType: "video/mp4",
+      sizeBytes: 4096,
+      caption: "Menu opens",
+      durationMs: 1450,
+      createdAt: 4000,
+      recordingStartedAt: 1000,
+      recordingEndedAt: 2450,
+      dimensions: { width: 1280, height: 720 },
+      truncated: false,
+      captureSurface: "browser",
+      source: "agent",
+      sourceUrl: "http://127.0.0.1:3000/start",
+      endUrl: "http://127.0.0.1:3000/end",
+    });
+  });
+
+  it("preserves video hasAudio false", () => {
+    expect(normalizeArtifactMetadata("video", { hasAudio: false })).toEqual({ hasAudio: false });
+  });
+
+  it("returns null for missing, non-object, or empty metadata", () => {
+    expect(normalizeArtifactMetadata("screenshot", null)).toBeNull();
+    expect(normalizeArtifactMetadata("screenshot", "not-json")).toBeNull();
+    expect(normalizeArtifactMetadata("screenshot", { sizeBytes: -1 })).toBeNull();
+  });
+});

--- a/packages/shared/src/artifacts.ts
+++ b/packages/shared/src/artifacts.ts
@@ -1,0 +1,155 @@
+import type {
+  ArtifactMetadata,
+  ArtifactType,
+  ManualPullRequestArtifactMetadata,
+  PreviewArtifactMetadata,
+  PullRequestArtifactMetadata,
+  ScreenshotArtifactMetadata,
+  VideoArtifactMetadata,
+} from "./types";
+
+const PR_STATES = new Set(["open", "closed", "merged", "draft"]);
+const PREVIEW_STATUSES = new Set(["active", "outdated", "stopped"]);
+const SCREENSHOT_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/webp"]);
+
+export function normalizeArtifactMetadata(
+  artifactType: ArtifactType,
+  metadata: unknown
+): ArtifactMetadata | null {
+  if (!isRecord(metadata)) return null;
+
+  switch (artifactType) {
+    case "pr":
+      return nonEmpty(normalizePullRequestMetadata(metadata));
+    case "branch":
+      return nonEmpty(normalizeManualPullRequestMetadata(metadata));
+    case "preview":
+      return nonEmpty(normalizePreviewMetadata(metadata));
+    case "screenshot":
+      return nonEmpty(normalizeScreenshotMetadata(metadata));
+    case "video":
+      return nonEmpty(normalizeVideoMetadata(metadata));
+  }
+}
+
+function normalizePullRequestMetadata(
+  metadata: Record<string, unknown>
+): PullRequestArtifactMetadata {
+  return {
+    ...(isPositiveNumber(metadata.number) ? { number: metadata.number } : {}),
+    ...(typeof metadata.state === "string" && PR_STATES.has(metadata.state)
+      ? { state: metadata.state as PullRequestArtifactMetadata["state"] }
+      : {}),
+    ...stringField(metadata, "head"),
+    ...stringField(metadata, "base"),
+  };
+}
+
+function normalizeManualPullRequestMetadata(
+  metadata: Record<string, unknown>
+): ManualPullRequestArtifactMetadata {
+  return {
+    ...(metadata.mode === "manual_pr" ? { mode: "manual_pr" as const } : {}),
+    ...stringField(metadata, "head"),
+    ...stringField(metadata, "base"),
+    ...stringField(metadata, "createPrUrl"),
+    ...stringField(metadata, "provider"),
+  };
+}
+
+function normalizePreviewMetadata(metadata: Record<string, unknown>): PreviewArtifactMetadata {
+  return {
+    ...(typeof metadata.previewStatus === "string" && PREVIEW_STATUSES.has(metadata.previewStatus)
+      ? { previewStatus: metadata.previewStatus as PreviewArtifactMetadata["previewStatus"] }
+      : {}),
+  };
+}
+
+function normalizeScreenshotMetadata(
+  metadata: Record<string, unknown>
+): Partial<ScreenshotArtifactMetadata> {
+  return {
+    ...stringField(metadata, "objectKey"),
+    ...(typeof metadata.mimeType === "string" && SCREENSHOT_MIME_TYPES.has(metadata.mimeType)
+      ? { mimeType: metadata.mimeType as ScreenshotArtifactMetadata["mimeType"] }
+      : {}),
+    ...(isNonNegativeNumber(metadata.sizeBytes) ? { sizeBytes: metadata.sizeBytes } : {}),
+    ...dimensionsField(metadata, "viewport"),
+    ...stringField(metadata, "sourceUrl"),
+    ...booleanField(metadata, "fullPage"),
+    ...booleanField(metadata, "annotated"),
+    ...stringField(metadata, "caption"),
+  };
+}
+
+function normalizeVideoMetadata(metadata: Record<string, unknown>): Partial<VideoArtifactMetadata> {
+  return {
+    ...stringField(metadata, "objectKey"),
+    ...(metadata.mimeType === "video/mp4" ? { mimeType: "video/mp4" as const } : {}),
+    ...(isNonNegativeNumber(metadata.sizeBytes) ? { sizeBytes: metadata.sizeBytes } : {}),
+    ...stringField(metadata, "caption"),
+    ...(isPositiveNumber(metadata.durationMs) ? { durationMs: metadata.durationMs } : {}),
+    ...(isNonNegativeNumber(metadata.createdAt) ? { createdAt: metadata.createdAt } : {}),
+    ...(isPositiveNumber(metadata.recordingStartedAt)
+      ? { recordingStartedAt: metadata.recordingStartedAt }
+      : {}),
+    ...(isPositiveNumber(metadata.recordingEndedAt)
+      ? { recordingEndedAt: metadata.recordingEndedAt }
+      : {}),
+    ...dimensionsField(metadata, "dimensions"),
+    ...booleanField(metadata, "truncated"),
+    ...(metadata.hasAudio === false ? { hasAudio: false as const } : {}),
+    ...(metadata.captureSurface === "browser" ? { captureSurface: "browser" as const } : {}),
+    ...(metadata.source === "agent" ? { source: "agent" as const } : {}),
+    ...stringField(metadata, "sourceUrl"),
+    ...stringField(metadata, "endUrl"),
+  };
+}
+
+function stringField<T extends string>(
+  metadata: Record<string, unknown>,
+  name: T
+): { [K in T]?: string } {
+  const value = metadata[name];
+  return (typeof value === "string" && value.length > 0 ? { [name]: value } : {}) as {
+    [K in T]?: string;
+  };
+}
+
+function booleanField<T extends string>(
+  metadata: Record<string, unknown>,
+  name: T
+): { [K in T]?: boolean } {
+  const value = metadata[name];
+  return (typeof value === "boolean" ? { [name]: value } : {}) as { [K in T]?: boolean };
+}
+
+function dimensionsField<T extends string>(
+  metadata: Record<string, unknown>,
+  name: T
+): { [K in T]?: { width: number; height: number } } {
+  const value = metadata[name];
+  if (!isRecord(value) || !isPositiveNumber(value.width) || !isPositiveNumber(value.height)) {
+    return {};
+  }
+
+  return { [name]: { width: value.width, height: value.height } } as {
+    [K in T]?: { width: number; height: number };
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonNegativeNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function isPositiveNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function nonEmpty<T extends object>(value: T): T | null {
+  return Object.keys(value).length > 0 ? value : null;
+}

--- a/packages/shared/src/completion/extractor.ts
+++ b/packages/shared/src/completion/extractor.ts
@@ -14,6 +14,9 @@ import type {
   ToolCallSummary,
   ArtifactInfo,
   ArtifactType,
+  ArtifactMetadata,
+  ManualPullRequestArtifactMetadata,
+  PullRequestArtifactMetadata,
   Logger,
 } from "../types";
 import { buildInternalAuthHeaders } from "../auth";
@@ -268,14 +271,14 @@ export function getArtifactLabel(data: Record<string, unknown>): string {
  */
 export function getArtifactLabelFromArtifact(
   type: ArtifactType,
-  metadata: Record<string, unknown> | null
+  metadata: ArtifactMetadata | null
 ): string {
   if (type === "pr") {
-    const prNum = metadata?.number;
+    const prNum = (metadata as PullRequestArtifactMetadata | null)?.number;
     return prNum ? `PR #${prNum}` : "Pull Request";
   }
   if (type === "branch") {
-    const branchName = metadata?.head;
+    const branchName = (metadata as ManualPullRequestArtifactMetadata | null)?.head;
     return `Branch: ${branchName ?? "branch"}`;
   }
   return type;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@
  */
 
 export * from "./types";
+export * from "./artifacts";
 export * from "./git";
 export * from "./auth";
 export * from "./models";

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -115,19 +115,40 @@ export interface SessionArtifact {
   id: string;
   type: ArtifactType;
   url: string | null;
-  metadata: Record<string, unknown> | null;
+  metadata: ArtifactMetadata | null;
   createdAt: number;
+}
+
+export type PullRequestArtifactState = "open" | "closed" | "merged" | "draft";
+
+/**
+ * Metadata stored on pull request artifacts.
+ */
+export interface PullRequestArtifactMetadata {
+  number?: number;
+  state?: PullRequestArtifactState;
+  head?: string;
+  base?: string;
 }
 
 /**
  * Metadata stored on branch artifacts when PR creation falls back to manual flow.
  */
 export interface ManualPullRequestArtifactMetadata {
-  mode: "manual_pr";
-  head: string;
-  base: string;
-  createPrUrl: string;
+  mode?: "manual_pr";
+  head?: string;
+  base?: string;
+  createPrUrl?: string;
   provider?: string;
+}
+
+export type PreviewArtifactStatus = "active" | "outdated" | "stopped";
+
+/**
+ * Metadata stored on preview artifacts.
+ */
+export interface PreviewArtifactMetadata {
+  previewStatus?: PreviewArtifactStatus;
 }
 
 /** Metadata stored on screenshot artifacts. */
@@ -183,6 +204,16 @@ export interface VideoArtifactMetadata {
   /** URL when recording stopped */
   endUrl?: string;
 }
+
+export interface ArtifactMetadataByType {
+  pr: PullRequestArtifactMetadata;
+  screenshot: Partial<ScreenshotArtifactMetadata>;
+  video: Partial<VideoArtifactMetadata>;
+  preview: PreviewArtifactMetadata;
+  branch: ManualPullRequestArtifactMetadata;
+}
+
+export type ArtifactMetadata = ArtifactMetadataByType[ArtifactType];
 
 // Pull request info
 export interface PullRequest {
@@ -477,7 +508,7 @@ export interface ArtifactResponse {
   id: string;
   type: ArtifactType;
   url: string | null;
-  metadata: Record<string, unknown> | null;
+  metadata: ArtifactMetadata | null;
   createdAt: number;
 }
 
@@ -494,7 +525,7 @@ export interface ArtifactInfo {
   type: ArtifactType;
   url: string;
   label: string;
-  metadata?: Record<string, unknown> | null;
+  metadata?: ArtifactMetadata | null;
 }
 
 export interface AgentResponse {

--- a/packages/web/src/hooks/use-session-socket.test.tsx
+++ b/packages/web/src/hooks/use-session-socket.test.tsx
@@ -285,7 +285,7 @@ describe("useSessionSocket", () => {
     });
   });
 
-  it("drops wrong-type metadata fields during narrowing", async () => {
+  it("hydrates already-normalized partial screenshot metadata from subscribed artifacts", async () => {
     const { result } = renderHook(() => useSessionSocket("session-1"));
 
     await waitFor(() => {
@@ -307,8 +307,7 @@ describe("useSessionSocket", () => {
             metadata: {
               objectKey: "sessions/session-1/media/artifact-shot-wrong-types.png",
               mimeType: "image/png",
-              sizeBytes: "five",
-              viewport: "not-an-object",
+              caption: "Partial legacy screenshot",
             },
             createdAt: 1234,
           },
@@ -325,8 +324,7 @@ describe("useSessionSocket", () => {
           metadata: expect.objectContaining({
             objectKey: "sessions/session-1/media/artifact-shot-wrong-types.png",
             mimeType: "image/png",
-            sizeBytes: undefined,
-            viewport: undefined,
+            caption: "Partial legacy screenshot",
           }),
           createdAt: 1234,
         },

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -5,13 +5,13 @@ import { mutate } from "swr";
 import { SIDEBAR_SESSIONS_KEY } from "@/lib/session-list";
 import type { Artifact, SandboxEvent } from "@/types/session";
 import type {
+  ArtifactMetadata,
   ParticipantPresence,
+  PullRequestArtifactMetadata,
   SandboxEvent as SharedSandboxEvent,
-  ScreenshotArtifactMetadata,
   ServerMessage,
   SessionArtifact,
   SessionState as SharedSessionState,
-  VideoArtifactMetadata,
 } from "@open-inspect/shared";
 
 // WebSocket URL (should come from env in production)
@@ -113,78 +113,31 @@ function toUiSandboxEvent(event: SharedSandboxEvent): SandboxEvent {
 }
 
 type PrState = NonNullable<NonNullable<Artifact["metadata"]>["prState"]>;
-const PR_STATES = new Set<string>(["open", "merged", "closed", "draft"]);
-type MediaMimeType = ScreenshotArtifactMetadata["mimeType"] | VideoArtifactMetadata["mimeType"];
-const MEDIA_MIME_TYPES = new Set<MediaMimeType>([
-  "image/png",
-  "image/jpeg",
-  "image/webp",
-  "video/mp4",
-]);
 
-function isMediaMimeType(value: string): value is MediaMimeType {
-  return MEDIA_MIME_TYPES.has(value as MediaMimeType);
-}
-
-function narrowDimensions(value: unknown): { width: number; height: number } | undefined {
-  if (
-    value &&
-    typeof value === "object" &&
-    typeof (value as { width?: unknown }).width === "number" &&
-    typeof (value as { height?: unknown }).height === "number"
-  ) {
-    return value as { width: number; height: number };
+function toUiArtifactMetadata(
+  artifactType: SessionArtifact["type"],
+  metadata: ArtifactMetadata
+): Artifact["metadata"] {
+  if (artifactType !== "pr") {
+    return metadata as Artifact["metadata"];
   }
-  return undefined;
+
+  const prMetadata = metadata as PullRequestArtifactMetadata;
+  return {
+    ...(metadata as Artifact["metadata"]),
+    prNumber: prMetadata.number,
+    prState: prMetadata.state as PrState | undefined,
+  };
 }
 
 function toUiArtifact(artifact: SessionArtifact): Artifact {
-  const meta = artifact.metadata as Record<string, unknown> | null;
   return {
     id: artifact.id,
-    type: artifact.type as Artifact["type"],
+    type: artifact.type,
     url: artifact.url,
     createdAt: artifact.createdAt,
-    metadata: meta
-      ? {
-          prNumber: typeof meta.number === "number" ? meta.number : undefined,
-          prState:
-            typeof meta.state === "string" && PR_STATES.has(meta.state)
-              ? (meta.state as PrState)
-              : undefined,
-          mode: meta.mode === "manual_pr" ? "manual_pr" : undefined,
-          createPrUrl: typeof meta.createPrUrl === "string" ? meta.createPrUrl : undefined,
-          head: typeof meta.head === "string" ? meta.head : undefined,
-          base: typeof meta.base === "string" ? meta.base : undefined,
-          provider: typeof meta.provider === "string" ? meta.provider : undefined,
-          filename: typeof meta.filename === "string" ? meta.filename : undefined,
-          objectKey: typeof meta.objectKey === "string" ? meta.objectKey : undefined,
-          mimeType:
-            typeof meta.mimeType === "string" && isMediaMimeType(meta.mimeType)
-              ? meta.mimeType
-              : undefined,
-          sizeBytes: typeof meta.sizeBytes === "number" ? meta.sizeBytes : undefined,
-          viewport: narrowDimensions(meta.viewport),
-          sourceUrl: typeof meta.sourceUrl === "string" ? meta.sourceUrl : undefined,
-          endUrl: typeof meta.endUrl === "string" ? meta.endUrl : undefined,
-          fullPage: typeof meta.fullPage === "boolean" ? meta.fullPage : undefined,
-          annotated: typeof meta.annotated === "boolean" ? meta.annotated : undefined,
-          caption: typeof meta.caption === "string" ? meta.caption : undefined,
-          durationMs: typeof meta.durationMs === "number" ? meta.durationMs : undefined,
-          recordingStartedAt:
-            typeof meta.recordingStartedAt === "number" ? meta.recordingStartedAt : undefined,
-          recordingEndedAt:
-            typeof meta.recordingEndedAt === "number" ? meta.recordingEndedAt : undefined,
-          dimensions: narrowDimensions(meta.dimensions),
-          truncated: typeof meta.truncated === "boolean" ? meta.truncated : undefined,
-          hasAudio: meta.hasAudio === false ? false : undefined,
-          previewStatus:
-            meta.previewStatus === "active" ||
-            meta.previewStatus === "outdated" ||
-            meta.previewStatus === "stopped"
-              ? meta.previewStatus
-              : undefined,
-        }
+    metadata: artifact.metadata
+      ? toUiArtifactMetadata(artifact.type, artifact.metadata)
       : undefined,
   };
 }

--- a/packages/web/src/types/session.ts
+++ b/packages/web/src/types/session.ts
@@ -1,4 +1,8 @@
 import type {
+  ManualPullRequestArtifactMetadata,
+  PreviewArtifactMetadata,
+  PullRequestArtifactMetadata,
+  PullRequestArtifactState,
   SandboxEvent as SharedSandboxEvent,
   ScreenshotArtifactMetadata,
   VideoArtifactMetadata,
@@ -6,21 +10,45 @@ import type {
 
 // Session-related type definitions
 
+type MediaMimeType = ScreenshotArtifactMetadata["mimeType"] | VideoArtifactMetadata["mimeType"];
+
+export type UiArtifactMetadata = {
+  number?: PullRequestArtifactMetadata["number"];
+  state?: PullRequestArtifactState;
+  head?: PullRequestArtifactMetadata["head"] | ManualPullRequestArtifactMetadata["head"];
+  base?: PullRequestArtifactMetadata["base"] | ManualPullRequestArtifactMetadata["base"];
+  mode?: ManualPullRequestArtifactMetadata["mode"];
+  createPrUrl?: ManualPullRequestArtifactMetadata["createPrUrl"];
+  provider?: ManualPullRequestArtifactMetadata["provider"];
+  previewStatus?: PreviewArtifactMetadata["previewStatus"];
+  objectKey?: string;
+  mimeType?: MediaMimeType;
+  sizeBytes?: number;
+  viewport?: ScreenshotArtifactMetadata["viewport"];
+  sourceUrl?: string;
+  endUrl?: string;
+  fullPage?: boolean;
+  annotated?: boolean;
+  caption?: string;
+  durationMs?: number;
+  createdAt?: number;
+  recordingStartedAt?: number;
+  recordingEndedAt?: number;
+  dimensions?: VideoArtifactMetadata["dimensions"];
+  truncated?: boolean;
+  hasAudio?: false;
+  captureSurface?: "browser";
+  source?: "agent";
+  prNumber?: number;
+  prState?: PullRequestArtifactState;
+  filename?: string;
+};
+
 export interface Artifact {
   id: string;
   type: "pr" | "screenshot" | "video" | "preview" | "branch";
   url: string | null;
-  metadata?: (Partial<ScreenshotArtifactMetadata> | Partial<VideoArtifactMetadata>) & {
-    prNumber?: number;
-    prState?: "open" | "merged" | "closed" | "draft";
-    mode?: "manual_pr";
-    createPrUrl?: string;
-    head?: string;
-    base?: string;
-    provider?: string;
-    filename?: string;
-    previewStatus?: "active" | "outdated" | "stopped";
-  };
+  metadata?: UiArtifactMetadata;
   createdAt: number;
 }
 


### PR DESCRIPTION
## Summary

- Add shared artifact metadata types and a shared normalizer for PR, branch/manual PR, preview, screenshot, and video artifacts.
- Normalize artifact metadata in the control plane before storing and broadcasting artifact events, and when hydrating stored artifacts.
- Simplify the web socket artifact mapper so the UI consumes shared-normalized metadata instead of maintaining a second metadata parser.

## Context

This builds on the merged media validator consolidation in main. The upload validators remain responsible for request-level media validation; this change centralizes artifact metadata normalization for stored and streamed session artifacts.

## Validation

- npm run build -w @open-inspect/shared
- npm run test -w @open-inspect/shared -- src/artifacts.test.ts
- npm run typecheck -w @open-inspect/shared
- npm run typecheck -w @open-inspect/control-plane
- npm run typecheck -w @open-inspect/web
- npm run test -w @open-inspect/control-plane -- src/media.test.ts src/session/services/message.service.test.ts src/session/http/handlers/sandbox.handler.test.ts src/session/sandbox-events.test.ts
- npm run test -w @open-inspect/web -- src/hooks/use-session-socket.test.tsx src/components/action-bar.test.tsx src/components/screenshot-media.test.tsx
- npm run test:integration -w @open-inspect/control-plane -- test/integration/media.test.ts
- npx prettier --check ...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced artifact metadata consistency and validation across the platform for screenshots, videos, pull requests, and preview artifacts

* **Tests**
  * Added comprehensive test coverage for artifact metadata normalization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->