### PR TITLE
test(control-plane): accept running status in waitForSandboxSpawn

### DIFF
--- a/packages/control-plane/test/integration/do-internal-routes.test.ts
+++ b/packages/control-plane/test/integration/do-internal-routes.test.ts
@@ -37,7 +37,8 @@ async function waitForSandboxSpawn(stub: DurableObjectStub): Promise<void> {
 
   while (Date.now() < deadline) {
     const rows = await queryDO<{ status: string }>(stub, "SELECT status FROM sandbox LIMIT 1");
-    if (rows[0]?.status === "connecting") {
+    const status = rows[0]?.status;
+    if (status === "connecting" || status === "running") {
       return;
     }
     await new Promise((resolve) => setTimeout(resolve, 10));


### PR DESCRIPTION
## Summary

Follow-up to #643. The `waitForSandboxSpawn` helper polls for
`status = 'connecting'` every 10ms (1s deadline), but with the fetch
mock installed in #643 the `createSandbox` response resolves
synchronously — so on a fast runner the `connecting → running`
transition can complete between two polls. The loop would never
observe `connecting`, then throw `"Timed out waiting for sandbox spawn"`.

This was the residual race I flagged at review time. Broadening the
predicate to accept either `connecting` or `running` removes it —
both states indicate the spawn has progressed past init, which is the
actual precondition the cancel test needs before driving
`status = 'active'`.

```diff
-    if (rows[0]?.status === "connecting") {
+    const status = rows[0]?.status;
+    if (status === "connecting" || status === "running") {
       return;
     }
```

## Test plan

- [x] `npm run test:integration -w @open-inspect/control-plane -- test/integration/do-internal-routes.test.ts` passes locally.
- [x] Ran the test file 30 times in a loop — 30/30 green.
- [x] `npm run typecheck -w @open-inspect/control-plane` clean.
- [x] `npm run lint -w @open-inspect/control-plane` clean.
- [x] `npx prettier --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by updating sandbox readiness detection to recognize additional valid states before proceeding with test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/651?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->