### PR TITLE
fix(terraform): align Vercel token fallback with default

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -183,7 +183,7 @@ jobs:
           TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           TF_VAR_cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           TF_VAR_cloudflare_worker_subdomain: ${{ secrets.CLOUDFLARE_WORKER_SUBDOMAIN }}
-          TF_VAR_vercel_api_token: "${{ secrets.VERCEL_API_TOKEN || 'unused' }}"
+          TF_VAR_vercel_api_token: "${{ secrets.VERCEL_API_TOKEN || '000000000000000000000000' }}"
           TF_VAR_vercel_team_id: "${{ secrets.VERCEL_TEAM_ID || 'unused' }}"
           TF_VAR_modal_token_id: ${{ secrets.MODAL_TOKEN_ID }}
           TF_VAR_modal_token_secret: ${{ secrets.MODAL_TOKEN_SECRET }}
@@ -314,7 +314,7 @@ jobs:
           TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           TF_VAR_cloudflare_account_id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           TF_VAR_cloudflare_worker_subdomain: ${{ secrets.CLOUDFLARE_WORKER_SUBDOMAIN }}
-          TF_VAR_vercel_api_token: "${{ secrets.VERCEL_API_TOKEN || 'unused' }}"
+          TF_VAR_vercel_api_token: "${{ secrets.VERCEL_API_TOKEN || '000000000000000000000000' }}"
           TF_VAR_vercel_team_id: "${{ secrets.VERCEL_TEAM_ID || 'unused' }}"
           TF_VAR_modal_token_id: ${{ secrets.MODAL_TOKEN_ID }}
           TF_VAR_modal_token_secret: ${{ secrets.MODAL_TOKEN_SECRET }}


### PR DESCRIPTION
## Summary

- Updates both Terraform workflow `VERCEL_API_TOKEN` fallbacks from `unused` to the same 24-character dummy token used by the Terraform variable default.

## Why

PR #508 updated the Terraform variable default to a 24-character dummy token, but `.github/workflows/terraform.yml` still overrides that default with `unused`. Since the Vercel provider validates `api_token` during provider init, Cloudflare-only deployments can still fail in CI even though no Vercel resources are created.

This keeps the workflow fallback aligned with the existing Terraform default without changing provider constraints, lockfiles, or deployment behavior for real Vercel tokens.

## Prior Upstream Work Checked

- #465 documented the Vercel provider limitation and introduced the workflow fallback to avoid empty-string overrides.
- #508 fixed the Terraform variable default to a valid dummy token shape.
- `upstream/main` still had `TF_VAR_vercel_api_token: "${{ secrets.VERCEL_API_TOKEN || 'unused' }}"` in both the plan and apply jobs before this change.

## Testing

- `git diff --check`
- `terraform fmt -check -recursive terraform`
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails on existing `packages/control-plane/src/utils/models.test.ts` GPT 5.5 reasoning default expectations: 2 failed, 1117 passed)*
- `terraform -chdir=terraform/environments/production init -backend=false -lockfile=readonly` *(initializes successfully, with the existing readonly-lockfile warning)*
- `terraform -chdir=terraform/environments/production validate -no-color` *(blocked locally by the existing `cloudflare/cloudflare` 5.19.1 checksum mismatch in `.terraform.lock.hcl` on `darwin_arm64`; this PR intentionally does not update the lockfile)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to use a fixed fallback token value for the API token environment variable, reducing failures when the secret is absent and improving workflow stability during infrastructure deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->