### PR TITLE
feat(sandbox): add provider dashboard links

### DIFF
--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -25,6 +25,18 @@ describe("buildModalSandboxDashboardUrl", () => {
     );
   });
 
+  it("encodes URL components", () => {
+    expect(
+      buildModalSandboxDashboardUrl({
+        workspace: "acme team",
+        environment: "prod/main",
+        providerObjectId: "sb 123/456?x=1",
+      })
+    ).toBe(
+      "https://modal.com/apps/acme%20team/prod%2Fmain/deployed/open-inspect?activeTab=sandboxes&sandboxId=sb%20123%2F456%3Fx%3D1"
+    );
+  });
+
   it("returns null when required inputs are missing", () => {
     expect(
       buildModalSandboxDashboardUrl({

--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { buildModalSandboxDashboardUrl } from "./client";
+
+describe("buildModalSandboxDashboardUrl", () => {
+  it("builds a Modal dashboard URL for a sandbox object", () => {
+    expect(
+      buildModalSandboxDashboardUrl({
+        workspace: "acme",
+        providerObjectId: "sb-123",
+      })
+    ).toBe(
+      "https://modal.com/apps/acme/main/deployed/open-inspect?activeTab=sandboxes&sandboxId=sb-123"
+    );
+  });
+
+  it("supports an explicit Modal environment", () => {
+    expect(
+      buildModalSandboxDashboardUrl({
+        workspace: "acme",
+        environment: "production",
+        providerObjectId: "sb-123",
+      })
+    ).toBe(
+      "https://modal.com/apps/acme/production/deployed/open-inspect?activeTab=sandboxes&sandboxId=sb-123"
+    );
+  });
+
+  it("returns null when required inputs are missing", () => {
+    expect(
+      buildModalSandboxDashboardUrl({
+        workspace: undefined,
+        providerObjectId: "sb-123",
+      })
+    ).toBeNull();
+    expect(
+      buildModalSandboxDashboardUrl({
+        workspace: "acme",
+        providerObjectId: null,
+      })
+    ).toBeNull();
+  });
+});

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -14,6 +14,7 @@ const log = createLogger("modal-client");
 
 // Modal app name
 const MODAL_APP_NAME = "open-inspect";
+const DEFAULT_MODAL_DASHBOARD_ENVIRONMENT = "main";
 
 /**
  * Construct the Modal base URL from workspace name.
@@ -21,6 +22,16 @@ const MODAL_APP_NAME = "open-inspect";
  */
 function getModalBaseUrl(workspace: string): string {
   return `https://${workspace}--${MODAL_APP_NAME}`;
+}
+
+export function buildModalSandboxDashboardUrl(params: {
+  workspace: string | undefined;
+  environment?: string | undefined;
+  providerObjectId: string | null | undefined;
+}): string | null {
+  if (!params.workspace || !params.providerObjectId) return null;
+  const environment = params.environment || DEFAULT_MODAL_DASHBOARD_ENVIRONMENT;
+  return `https://modal.com/apps/${params.workspace}/${environment}/deployed/${MODAL_APP_NAME}?activeTab=sandboxes&sandboxId=${params.providerObjectId}`;
 }
 
 export interface CreateSandboxRequest {

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -14,6 +14,8 @@ const log = createLogger("modal-client");
 
 // Modal app name
 const MODAL_APP_NAME = "open-inspect";
+
+// Modal's default environment name; unrelated to the git branch named "main".
 const DEFAULT_MODAL_DASHBOARD_ENVIRONMENT = "main";
 
 /**
@@ -30,8 +32,10 @@ export function buildModalSandboxDashboardUrl(params: {
   providerObjectId: string | null | undefined;
 }): string | null {
   if (!params.workspace || !params.providerObjectId) return null;
-  const environment = params.environment || DEFAULT_MODAL_DASHBOARD_ENVIRONMENT;
-  return `https://modal.com/apps/${params.workspace}/${environment}/deployed/${MODAL_APP_NAME}?activeTab=sandboxes&sandboxId=${params.providerObjectId}`;
+  const workspace = encodeURIComponent(params.workspace);
+  const environment = encodeURIComponent(params.environment || DEFAULT_MODAL_DASHBOARD_ENVIRONMENT);
+  const providerObjectId = encodeURIComponent(params.providerObjectId);
+  return `https://modal.com/apps/${workspace}/${environment}/deployed/${MODAL_APP_NAME}?activeTab=sandboxes&sandboxId=${providerObjectId}`;
 }
 
 export interface CreateSandboxRequest {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -130,6 +130,7 @@ function createMockStorage(
         sandbox.auth_token_hash = data.authTokenHash;
         sandbox.auth_token = null;
         sandbox.modal_sandbox_id = data.modalSandboxId;
+        sandbox.modal_object_id = null;
       }
     }),
     updateSandboxModalObjectId: vi.fn((id: string) => {
@@ -671,6 +672,50 @@ describe("SandboxLifecycleManager", () => {
         {
           type: "sandbox_dashboard_url",
           url: "https://provider.example/new-provider-obj",
+        },
+      ]);
+    });
+
+    it("broadcasts sandbox_dashboard_url after resume when provider object id is unchanged", async () => {
+      const sandbox = createMockSandbox({
+        status: "stopped",
+        modal_object_id: "same-provider-obj",
+        snapshot_image_id: null,
+      });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const broadcaster = createMockBroadcaster();
+      const provider = createMockProvider({
+        capabilities: { supportsPersistentResume: true },
+        resumeSandbox: vi.fn(async () => ({
+          success: true,
+          providerObjectId: "same-provider-obj",
+        })),
+      });
+      const config = {
+        ...createTestConfig(),
+        sandboxDashboardUrlBuilder: (id: string) => `https://provider.example/${id}`,
+      };
+
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        broadcaster,
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        config
+      );
+
+      await manager.spawnSandbox();
+
+      expect(provider.resumeSandbox).toHaveBeenCalled();
+      expect(storage.calls).not.toContain("updateSandboxModalObjectId:same-provider-obj");
+      expect(
+        broadcaster.messages.filter((m) => (m as { type: string }).type === "sandbox_dashboard_url")
+      ).toEqual([
+        {
+          type: "sandbox_dashboard_url",
+          url: "https://provider.example/same-provider-obj",
         },
       ]);
     });

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -24,6 +24,8 @@ import {
   type CreateSandboxResult,
   type RestoreConfig,
   type RestoreResult,
+  type ResumeConfig,
+  type ResumeResult,
   type SnapshotConfig,
   type SnapshotResult,
 } from "../provider";
@@ -254,15 +256,18 @@ function createMockProvider(
   overrides: Partial<{
     createSandbox: (config: CreateSandboxConfig) => Promise<CreateSandboxResult>;
     restoreFromSnapshot: (config: RestoreConfig) => Promise<RestoreResult>;
+    resumeSandbox: (config: ResumeConfig) => Promise<ResumeResult>;
     takeSnapshot: (config: SnapshotConfig) => Promise<SnapshotResult>;
+    capabilities: Partial<SandboxProvider["capabilities"]>;
   }> = {}
 ): SandboxProvider {
-  return {
+  const provider: SandboxProvider = {
     name: "mock",
     capabilities: {
       supportsSnapshots: true,
       supportsRestore: true,
       supportsWarm: true,
+      ...overrides.capabilities,
     },
     createSandbox:
       overrides.createSandbox ||
@@ -285,6 +290,10 @@ function createMockProvider(
         imageId: "snapshot-img-123",
       })),
   };
+  if (overrides.resumeSandbox) {
+    provider.resumeSandbox = overrides.resumeSandbox;
+  }
+  return provider;
 }
 
 function createTestConfig(): SandboxLifecycleConfig {
@@ -326,6 +335,61 @@ describe("SandboxLifecycleManager", () => {
       expect(
         broadcaster.messages.some((m) => (m as { type: string }).type === "sandbox_status")
       ).toBe(true);
+    });
+
+    it("broadcasts sandbox_dashboard_url after spawn when builder is configured", async () => {
+      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const broadcaster = createMockBroadcaster();
+      const config = {
+        ...createTestConfig(),
+        sandboxDashboardUrlBuilder: (id: string) => `https://provider.example/${id}`,
+      };
+
+      const manager = new SandboxLifecycleManager(
+        createMockProvider(),
+        storage,
+        broadcaster,
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        config
+      );
+
+      await manager.spawnSandbox();
+
+      expect(storage.calls).toContain("updateSandboxModalObjectId:provider-obj-123");
+      expect(
+        broadcaster.messages.filter((m) => (m as { type: string }).type === "sandbox_dashboard_url")
+      ).toEqual([
+        {
+          type: "sandbox_dashboard_url",
+          url: "https://provider.example/provider-obj-123",
+        },
+      ]);
+    });
+
+    it("does not broadcast sandbox_dashboard_url when no builder is configured", async () => {
+      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const broadcaster = createMockBroadcaster();
+
+      const manager = new SandboxLifecycleManager(
+        createMockProvider(),
+        storage,
+        broadcaster,
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      expect(storage.calls).toContain("updateSandboxModalObjectId:provider-obj-123");
+      expect(
+        broadcaster.messages.some((m) => (m as { type: string }).type === "sandbox_dashboard_url")
+      ).toBe(false);
     });
 
     it("schedules connecting timeout alarm after spawn", async () => {
@@ -523,6 +587,92 @@ describe("SandboxLifecycleManager", () => {
 
       // Verify providerObjectId was stored for future snapshots
       expect(storage.calls).toContain("updateSandboxModalObjectId:new-modal-obj-after-restore");
+    });
+
+    it("broadcasts sandbox_dashboard_url after restore when builder is configured", async () => {
+      const sandbox = createMockSandbox({
+        status: "stopped",
+        snapshot_image_id: "img-abc123",
+      });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const broadcaster = createMockBroadcaster();
+      const provider = createMockProvider({
+        restoreFromSnapshot: vi.fn(async (config: RestoreConfig) => ({
+          success: true,
+          sandboxId: config.sandboxId,
+          providerObjectId: "restored-obj-456",
+        })),
+      });
+      const config = {
+        ...createTestConfig(),
+        sandboxDashboardUrlBuilder: (id: string) => `https://provider.example/${id}`,
+      };
+
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        broadcaster,
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        config
+      );
+
+      await manager.spawnSandbox();
+
+      expect(storage.calls).toContain("updateSandboxModalObjectId:restored-obj-456");
+      expect(
+        broadcaster.messages.filter((m) => (m as { type: string }).type === "sandbox_dashboard_url")
+      ).toEqual([
+        {
+          type: "sandbox_dashboard_url",
+          url: "https://provider.example/restored-obj-456",
+        },
+      ]);
+    });
+
+    it("broadcasts sandbox_dashboard_url after resume when provider object id changes", async () => {
+      const sandbox = createMockSandbox({
+        status: "stopped",
+        modal_object_id: "old-provider-obj",
+        snapshot_image_id: null,
+      });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const broadcaster = createMockBroadcaster();
+      const provider = createMockProvider({
+        capabilities: { supportsPersistentResume: true },
+        resumeSandbox: vi.fn(async () => ({
+          success: true,
+          providerObjectId: "new-provider-obj",
+        })),
+      });
+      const config = {
+        ...createTestConfig(),
+        sandboxDashboardUrlBuilder: (id: string) => `https://provider.example/${id}`,
+      };
+
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        broadcaster,
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        config
+      );
+
+      await manager.spawnSandbox();
+
+      expect(provider.resumeSandbox).toHaveBeenCalled();
+      expect(storage.calls).toContain("updateSandboxModalObjectId:new-provider-obj");
+      expect(
+        broadcaster.messages.filter((m) => (m as { type: string }).type === "sandbox_dashboard_url")
+      ).toEqual([
+        {
+          type: "sandbox_dashboard_url",
+          url: "https://provider.example/new-provider-obj",
+        },
+      ]);
     });
 
     it("resets isSpawningSandbox flag after restore throws error", async () => {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -166,6 +166,8 @@ export interface SandboxLifecycleConfig {
   mcpServerLookup?: McpServerLookup;
   /** Resolves the spawn-time agent-slack-notify gate. */
   slackAgentNotifyLookup?: SlackAgentNotifyLookup;
+  /** Builds a provider dashboard URL for a persisted provider object ID. */
+  sandboxDashboardUrlBuilder?: (providerObjectId: string) => string | null;
 }
 
 /**
@@ -454,7 +456,7 @@ export class SandboxLifecycleManager {
       });
 
       if (result.providerObjectId) {
-        this.storage.updateSandboxModalObjectId(result.providerObjectId);
+        this.storeAndBroadcastProviderObjectId(result.providerObjectId);
       }
       if (result.codeServerUrl && result.codeServerPassword) {
         await this.storeAndBroadcastCodeServer(result.codeServerUrl, result.codeServerPassword);
@@ -636,7 +638,7 @@ export class SandboxLifecycleManager {
         });
 
         if (result.providerObjectId) {
-          this.storage.updateSandboxModalObjectId(result.providerObjectId);
+          this.storeAndBroadcastProviderObjectId(result.providerObjectId);
         }
         if (result.codeServerUrl && result.codeServerPassword) {
           await this.storeAndBroadcastCodeServer(result.codeServerUrl, result.codeServerPassword);
@@ -751,7 +753,7 @@ export class SandboxLifecycleManager {
       }
 
       if (result.providerObjectId && result.providerObjectId !== providerObjectId) {
-        this.storage.updateSandboxModalObjectId(result.providerObjectId);
+        this.storeAndBroadcastProviderObjectId(result.providerObjectId);
       }
 
       if (result.codeServerUrl && result.codeServerPassword) {
@@ -1144,6 +1146,14 @@ export class SandboxLifecycleManager {
    */
   private getConnectedClientCount(): number {
     return this.wsManager.getConnectedClientCount();
+  }
+
+  private storeAndBroadcastProviderObjectId(providerObjectId: string): void {
+    this.storage.updateSandboxModalObjectId(providerObjectId);
+    const url = this.config.sandboxDashboardUrlBuilder?.(providerObjectId);
+    if (url) {
+      this.broadcaster.broadcast({ type: "sandbox_dashboard_url", url });
+    }
   }
 
   /**

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -579,9 +579,6 @@ export class SandboxLifecycleManager {
 
       this.storage.setLastSpawnError(null, null);
 
-      this.storage.updateSandboxStatus("spawning");
-      this.broadcaster.broadcast({ type: "sandbox_status", status: "spawning" });
-
       const now = Date.now();
       const sandboxAuthToken = this.idGenerator.generateId();
       const sandboxAuthTokenHash = await hashToken(sandboxAuthToken);
@@ -594,6 +591,7 @@ export class SandboxLifecycleManager {
         authTokenHash: sandboxAuthTokenHash,
         modalSandboxId: expectedSandboxId,
       });
+      this.broadcaster.broadcast({ type: "sandbox_status", status: "spawning" });
 
       this.log.info("Restoring from snapshot", {
         event: "sandbox.restore",
@@ -752,9 +750,11 @@ export class SandboxLifecycleManager {
         throw new Error(result.error || "Failed to resume sandbox");
       }
 
+      const finalProviderObjectId = result.providerObjectId ?? providerObjectId;
       if (result.providerObjectId && result.providerObjectId !== providerObjectId) {
-        this.storeAndBroadcastProviderObjectId(result.providerObjectId);
+        this.storeProviderObjectId(result.providerObjectId);
       }
+      this.broadcastSandboxDashboardUrl(finalProviderObjectId);
 
       if (result.codeServerUrl && result.codeServerPassword) {
         await this.storeAndBroadcastCodeServer(result.codeServerUrl, result.codeServerPassword);
@@ -1149,9 +1149,20 @@ export class SandboxLifecycleManager {
   }
 
   private storeAndBroadcastProviderObjectId(providerObjectId: string): void {
+    this.storeProviderObjectId(providerObjectId);
+    this.broadcastSandboxDashboardUrl(providerObjectId);
+  }
+
+  private storeProviderObjectId(providerObjectId: string): void {
     this.storage.updateSandboxModalObjectId(providerObjectId);
+  }
+
+  private broadcastSandboxDashboardUrl(providerObjectId: string): void {
     const url = this.config.sandboxDashboardUrlBuilder?.(providerObjectId);
     if (url) {
+      this.log.debug("Broadcasting sandbox dashboard URL", {
+        provider_object_id: providerObjectId,
+      });
       this.broadcaster.broadcast({ type: "sandbox_dashboard_url", url });
     }
   }

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -13,7 +13,7 @@ import { buildSessionInternalUrl, SessionInternalPaths } from "./contracts";
 import { resolveAppName, timingSafeEqual } from "@open-inspect/shared";
 import { generateId, hashToken, encryptToken, decryptToken } from "../auth/crypto";
 import { getGitHubAppConfig, getCachedInstallationToken } from "../auth/github-app";
-import { createModalClient } from "../sandbox/client";
+import { buildModalSandboxDashboardUrl, createModalClient } from "../sandbox/client";
 import { createDaytonaRestClient } from "../sandbox/daytona-rest-client";
 import { createModalProvider } from "../sandbox/providers/modal-provider";
 import { createDaytonaProvider } from "../sandbox/providers/daytona-provider";
@@ -110,6 +110,12 @@ const WS_TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 /** Statuses that indicate a session is finished — metrics are synced to D1 on these transitions. */
 const TERMINAL_STATUSES: SessionStatus[] = ["completed", "failed", "cancelled"];
+const SANDBOX_DASHBOARD_URL_BLOCKED_STATUSES = new Set<SandboxStatus>([
+  "spawning",
+  "stale",
+  "stopped",
+  "failed",
+]);
 
 export class SessionDO extends DurableObject<Env> {
   private sql: SqlStorage;
@@ -728,6 +734,11 @@ export class SessionDO extends DurableObject<Env> {
       };
     }
 
+    const sandboxDashboardUrlBuilder =
+      sandboxBackend === "modal"
+        ? (providerObjectId: string) => this.getSandboxDashboardUrl(providerObjectId)
+        : undefined;
+
     const config = {
       ...DEFAULT_LIFECYCLE_CONFIG,
       controlPlaneUrl,
@@ -739,6 +750,7 @@ export class SessionDO extends DurableObject<Env> {
       },
       mcpServerLookup,
       slackAgentNotifyLookup,
+      sandboxDashboardUrlBuilder,
     };
 
     // Create repo image lookup if D1 is available (Modal-only — Daytona doesn't use repo images)
@@ -1676,7 +1688,20 @@ export class SessionDO extends DurableObject<Env> {
       tunnelUrls: sandbox?.tunnel_urls ? this.safeParseTunnelUrls(sandbox.tunnel_urls) : null,
       ttydUrl: sandbox?.ttyd_url ?? null,
       ttydToken,
+      sandboxDashboardUrl: this.getSandboxDashboardUrl(sandbox?.modal_object_id, sandbox?.status),
     };
+  }
+
+  private getSandboxDashboardUrl(
+    providerObjectId: string | null | undefined,
+    sandboxStatus?: SandboxStatus | null
+  ): string | null {
+    if (resolveSandboxBackendName(this.env.SANDBOX_PROVIDER) !== "modal") return null;
+    if (sandboxStatus && SANDBOX_DASHBOARD_URL_BLOCKED_STATUSES.has(sandboxStatus)) return null;
+    return buildModalSandboxDashboardUrl({
+      workspace: this.env.MODAL_WORKSPACE,
+      providerObjectId,
+    });
   }
 
   /**

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -110,12 +110,6 @@ const WS_TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 /** Statuses that indicate a session is finished — metrics are synced to D1 on these transitions. */
 const TERMINAL_STATUSES: SessionStatus[] = ["completed", "failed", "cancelled"];
-const SANDBOX_DASHBOARD_URL_BLOCKED_STATUSES = new Set<SandboxStatus>([
-  "spawning",
-  "stale",
-  "stopped",
-  "failed",
-]);
 
 export class SessionDO extends DurableObject<Env> {
   private sql: SqlStorage;
@@ -1688,16 +1682,12 @@ export class SessionDO extends DurableObject<Env> {
       tunnelUrls: sandbox?.tunnel_urls ? this.safeParseTunnelUrls(sandbox.tunnel_urls) : null,
       ttydUrl: sandbox?.ttyd_url ?? null,
       ttydToken,
-      sandboxDashboardUrl: this.getSandboxDashboardUrl(sandbox?.modal_object_id, sandbox?.status),
+      sandboxDashboardUrl: this.getSandboxDashboardUrl(sandbox?.modal_object_id),
     };
   }
 
-  private getSandboxDashboardUrl(
-    providerObjectId: string | null | undefined,
-    sandboxStatus?: SandboxStatus | null
-  ): string | null {
+  private getSandboxDashboardUrl(providerObjectId: string | null | undefined): string | null {
     if (resolveSandboxBackendName(this.env.SANDBOX_PROVIDER) !== "modal") return null;
-    if (sandboxStatus && SANDBOX_DASHBOARD_URL_BLOCKED_STATUSES.has(sandboxStatus)) return null;
     return buildModalSandboxDashboardUrl({
       workspace: this.env.MODAL_WORKSPACE,
       providerObjectId,

--- a/packages/control-plane/src/session/repository.test.ts
+++ b/packages/control-plane/src/session/repository.test.ts
@@ -218,6 +218,7 @@ describe("SessionRepository", () => {
       expect(mock.calls[0].query).toContain("auth_token_hash");
       expect(mock.calls[0].query).toContain("modal_sandbox_id");
       expect(mock.calls[0].query).toContain("auth_token = NULL");
+      expect(mock.calls[0].query).toContain("modal_object_id = NULL");
       expect(mock.calls[0].params).toEqual(["spawning", 1000, "token-hash-123", "modal-sb-1"]);
     });
   });

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -345,7 +345,8 @@ export class SessionRepository {
          created_at = ?,
          auth_token_hash = ?,
          auth_token = NULL,
-         modal_sandbox_id = ?
+         modal_sandbox_id = ?,
+         modal_object_id = NULL
        WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
       data.status,
       data.createdAt,

--- a/packages/control-plane/test/integration/websocket-client.test.ts
+++ b/packages/control-plane/test/integration/websocket-client.test.ts
@@ -31,6 +31,42 @@ describe("Client WebSocket (via SELF.fetch)", () => {
     ws.close();
   });
 
+  it("subscribe hydrates dashboard URL only for accessible sandbox states", async () => {
+    const cases = [
+      {
+        status: "connecting",
+        expectedDashboardUrl:
+          "https://modal.com/apps/test-workspace/main/deployed/open-inspect?activeTab=sandboxes&sandboxId=provider-obj-123",
+      },
+      { status: "spawning", expectedDashboardUrl: null },
+      { status: "stale", expectedDashboardUrl: null },
+      { status: "stopped", expectedDashboardUrl: null },
+      { status: "failed", expectedDashboardUrl: null },
+    ];
+
+    for (const [index, testCase] of cases.entries()) {
+      const name = `ws-client-dashboard-url-${testCase.status}-${Date.now()}-${index}`;
+      const { stub } = await initNamedSession(name);
+      await queryDO(
+        stub,
+        `UPDATE sandbox
+           SET status = ?, modal_object_id = ?
+         WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
+        testCase.status,
+        "provider-obj-123"
+      );
+
+      const { ws, messages } = await openClientWs(name, { subscribe: true });
+      const subscribed = messages!.find((m) => m.type === "subscribed") as Record<string, unknown>;
+      const state = subscribed.state as Record<string, unknown>;
+
+      expect(state.sandboxStatus).toBe(testCase.status);
+      expect(state.sandboxDashboardUrl).toBe(testCase.expectedDashboardUrl);
+
+      ws.close();
+    }
+  });
+
   it("subscribe with invalid token closes socket 4001", async () => {
     const name = `ws-client-badtoken-${Date.now()}`;
     await initNamedSession(name);

--- a/packages/control-plane/test/integration/websocket-client.test.ts
+++ b/packages/control-plane/test/integration/websocket-client.test.ts
@@ -31,21 +31,36 @@ describe("Client WebSocket (via SELF.fetch)", () => {
     ws.close();
   });
 
-  it("subscribe hydrates dashboard URL only for accessible sandbox states", async () => {
+  it("subscribe hydrates dashboard URL when provider object id exists", async () => {
+    const dashboardUrl =
+      "https://modal.com/apps/test-workspace/main/deployed/open-inspect?activeTab=sandboxes&sandboxId=provider-obj-123";
     const cases = [
       {
         status: "connecting",
-        expectedDashboardUrl:
-          "https://modal.com/apps/test-workspace/main/deployed/open-inspect?activeTab=sandboxes&sandboxId=provider-obj-123",
+        providerObjectId: "provider-obj-123",
+        expectedDashboardUrl: dashboardUrl,
       },
-      { status: "spawning", expectedDashboardUrl: null },
-      { status: "stale", expectedDashboardUrl: null },
-      { status: "stopped", expectedDashboardUrl: null },
-      { status: "failed", expectedDashboardUrl: null },
+      {
+        status: "spawning",
+        providerObjectId: "provider-obj-123",
+        expectedDashboardUrl: dashboardUrl,
+      },
+      { status: "spawning", providerObjectId: null, expectedDashboardUrl: null },
+      { status: "stale", providerObjectId: "provider-obj-123", expectedDashboardUrl: dashboardUrl },
+      {
+        status: "stopped",
+        providerObjectId: "provider-obj-123",
+        expectedDashboardUrl: dashboardUrl,
+      },
+      {
+        status: "failed",
+        providerObjectId: "provider-obj-123",
+        expectedDashboardUrl: dashboardUrl,
+      },
     ];
 
     for (const [index, testCase] of cases.entries()) {
-      const name = `ws-client-dashboard-url-${testCase.status}-${Date.now()}-${index}`;
+      const name = `ws-client-dashboard-url-${testCase.status}-${testCase.providerObjectId ? "with-id" : "without-id"}-${Date.now()}-${index}`;
       const { stub } = await initNamedSession(name);
       await queryDO(
         stub,
@@ -53,7 +68,7 @@ describe("Client WebSocket (via SELF.fetch)", () => {
            SET status = ?, modal_object_id = ?
          WHERE id = (SELECT id FROM sandbox LIMIT 1)`,
         testCase.status,
-        "provider-obj-123"
+        testCase.providerObjectId
       );
 
       const { ws, messages } = await openClientWs(name, { subscribe: true });

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -366,6 +366,7 @@ export type ServerMessage =
   | { type: "code_server_info"; url: string; password: string }
   | { type: "ttyd_info"; url: string; token: string }
   | { type: "tunnel_urls"; urls: Record<string, string> }
+  | { type: "sandbox_dashboard_url"; url: string }
   | { type: "error"; code: string; message: string };
 
 // Session state sent to clients
@@ -390,6 +391,7 @@ export interface SessionState {
   tunnelUrls?: Record<string, string> | null;
   ttydUrl?: string | null;
   ttydToken?: string | null;
+  sandboxDashboardUrl?: string | null;
 }
 
 // Participant presence info

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -791,7 +791,10 @@ function SessionContent({
             {/* Desktop: full status indicators */}
             <div className="hidden md:contents">
               <ConnectionStatus connected={connected} connecting={connecting} />
-              <SandboxStatus status={sessionState?.sandboxStatus} />
+              <SandboxStatus
+                status={sessionState?.sandboxStatus}
+                dashboardUrl={sessionState?.sandboxDashboardUrl}
+              />
               <ParticipantsList participants={participants} />
             </div>
           </div>
@@ -1115,7 +1118,13 @@ function ConnectionStatus({ connected, connecting }: { connected: boolean; conne
   );
 }
 
-function SandboxStatus({ status }: { status?: string }) {
+function SandboxStatus({
+  status,
+  dashboardUrl,
+}: {
+  status?: string;
+  dashboardUrl?: string | null;
+}) {
   if (!status) return null;
 
   const colors: Record<string, string> = {
@@ -1128,7 +1137,24 @@ function SandboxStatus({ status }: { status?: string }) {
     failed: "text-destructive",
   };
 
-  return <span className={`text-xs ${colors[status] || colors.pending}`}>Sandbox: {status}</span>;
+  const className = `text-xs ${colors[status] || colors.pending}`;
+  const label = `Sandbox: ${status}`;
+
+  if (dashboardUrl) {
+    return (
+      <a
+        href={dashboardUrl}
+        target="_blank"
+        rel="noreferrer noopener"
+        title="Open sandbox in provider dashboard"
+        className={`${className} hover:underline`}
+      >
+        {label}
+      </a>
+    );
+  }
+
+  return <span className={className}>{label}</span>;
 }
 
 function CombinedStatusDot({

--- a/packages/web/src/hooks/use-session-socket.test.tsx
+++ b/packages/web/src/hooks/use-session-socket.test.tsx
@@ -94,6 +94,18 @@ function createSubscribedMessage(artifacts: SessionArtifact[] = []): ServerMessa
   };
 }
 
+function sendSandboxAccessMessages(socket: FakeWebSocket, sandboxId: string) {
+  socket.receive({
+    type: "code_server_info",
+    url: `https://code.example/${sandboxId}`,
+    password: "secret",
+  });
+  socket.receive({
+    type: "sandbox_dashboard_url",
+    url: `https://provider.example/${sandboxId}`,
+  });
+}
+
 describe("useSessionSocket", () => {
   beforeEach(() => {
     FakeWebSocket.instances = [];
@@ -391,6 +403,109 @@ describe("useSessionSocket", () => {
       expect(result.current.sessionState?.branchName).toBe("feature/live-update");
     });
     expect(mutateMock).not.toHaveBeenCalled();
+  });
+
+  it("updates sessionState.sandboxDashboardUrl from sandbox_dashboard_url", async () => {
+    const { result } = renderHook(() => useSessionSocket("session-1"));
+
+    await waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
+
+    const socket = FakeWebSocket.instances[0];
+    act(() => {
+      socket.open();
+      socket.receive(createSubscribedMessage());
+    });
+
+    act(() => {
+      socket.receive({
+        type: "sandbox_dashboard_url",
+        url: "https://provider.example/sandbox-123",
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionState?.sandboxDashboardUrl).toBe(
+        "https://provider.example/sandbox-123"
+      );
+    });
+  });
+
+  it("clears stale sandbox access state when a sandbox is replaced or becomes terminal", async () => {
+    const { result } = renderHook(() => useSessionSocket("session-1"));
+
+    await waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
+
+    const socket = FakeWebSocket.instances[0];
+    act(() => {
+      socket.open();
+      socket.receive(createSubscribedMessage());
+      sendSandboxAccessMessages(socket, "old-sandbox");
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionState?.sandboxDashboardUrl).toBe(
+        "https://provider.example/old-sandbox"
+      );
+      expect(result.current.sessionState?.codeServerUrl).toBe("https://code.example/old-sandbox");
+    });
+
+    act(() => {
+      socket.receive({ type: "sandbox_spawning" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionState?.sandboxStatus).toBe("spawning");
+      expect(result.current.sessionState?.sandboxDashboardUrl).toBeUndefined();
+      expect(result.current.sessionState?.codeServerUrl).toBeUndefined();
+    });
+
+    act(() => {
+      sendSandboxAccessMessages(socket, "new-sandbox");
+      socket.receive({ type: "sandbox_status", status: "failed" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionState?.sandboxStatus).toBe("failed");
+      expect(result.current.sessionState?.sandboxDashboardUrl).toBeUndefined();
+      expect(result.current.sessionState?.codeServerUrl).toBeUndefined();
+    });
+  });
+
+  it("clears stale sandbox access state on status spawning and sandbox_error", async () => {
+    const { result } = renderHook(() => useSessionSocket("session-1"));
+
+    await waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
+
+    const socket = FakeWebSocket.instances[0];
+    act(() => {
+      socket.open();
+      socket.receive(createSubscribedMessage());
+      sendSandboxAccessMessages(socket, "old-sandbox");
+      socket.receive({ type: "sandbox_status", status: "spawning" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionState?.sandboxStatus).toBe("spawning");
+      expect(result.current.sessionState?.sandboxDashboardUrl).toBeUndefined();
+      expect(result.current.sessionState?.codeServerUrl).toBeUndefined();
+    });
+
+    act(() => {
+      sendSandboxAccessMessages(socket, "new-sandbox");
+      socket.receive({ type: "sandbox_error", error: "spawn failed" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionState?.sandboxStatus).toBe("failed");
+      expect(result.current.sessionState?.sandboxDashboardUrl).toBeUndefined();
+      expect(result.current.sessionState?.codeServerUrl).toBeUndefined();
+    });
   });
 
   it("prepends new artifacts and replaces duplicates by id", async () => {

--- a/packages/web/src/hooks/use-session-socket.test.tsx
+++ b/packages/web/src/hooks/use-session-socket.test.tsx
@@ -432,7 +432,7 @@ describe("useSessionSocket", () => {
     });
   });
 
-  it("clears stale sandbox access state when a sandbox is replaced or becomes terminal", async () => {
+  it("clears credentials on spawn and terminal statuses without dropping diagnostic links early", async () => {
     const { result } = renderHook(() => useSessionSocket("session-1"));
 
     await waitFor(() => {
@@ -459,34 +459,13 @@ describe("useSessionSocket", () => {
 
     await waitFor(() => {
       expect(result.current.sessionState?.sandboxStatus).toBe("spawning");
-      expect(result.current.sessionState?.sandboxDashboardUrl).toBeUndefined();
+      expect(result.current.sessionState?.sandboxDashboardUrl).toBe(
+        "https://provider.example/old-sandbox"
+      );
       expect(result.current.sessionState?.codeServerUrl).toBeUndefined();
     });
 
     act(() => {
-      sendSandboxAccessMessages(socket, "new-sandbox");
-      socket.receive({ type: "sandbox_status", status: "failed" });
-    });
-
-    await waitFor(() => {
-      expect(result.current.sessionState?.sandboxStatus).toBe("failed");
-      expect(result.current.sessionState?.sandboxDashboardUrl).toBeUndefined();
-      expect(result.current.sessionState?.codeServerUrl).toBeUndefined();
-    });
-  });
-
-  it("clears stale sandbox access state on status spawning and sandbox_error", async () => {
-    const { result } = renderHook(() => useSessionSocket("session-1"));
-
-    await waitFor(() => {
-      expect(FakeWebSocket.instances).toHaveLength(1);
-    });
-
-    const socket = FakeWebSocket.instances[0];
-    act(() => {
-      socket.open();
-      socket.receive(createSubscribedMessage());
-      sendSandboxAccessMessages(socket, "old-sandbox");
       socket.receive({ type: "sandbox_status", status: "spawning" });
     });
 
@@ -498,12 +477,69 @@ describe("useSessionSocket", () => {
 
     act(() => {
       sendSandboxAccessMessages(socket, "new-sandbox");
+      socket.receive({ type: "sandbox_status", status: "failed" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionState?.sandboxStatus).toBe("failed");
+      expect(result.current.sessionState?.sandboxDashboardUrl).toBe(
+        "https://provider.example/new-sandbox"
+      );
+      expect(result.current.sessionState?.codeServerUrl).toBeUndefined();
+    });
+  });
+
+  it("clears dashboard URL only for replacement starts, not sandbox errors", async () => {
+    const { result } = renderHook(() => useSessionSocket("session-1"));
+
+    await waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
+
+    const socket = FakeWebSocket.instances[0];
+    act(() => {
+      socket.open();
+      socket.receive(createSubscribedMessage());
+      sendSandboxAccessMessages(socket, "old-sandbox");
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionState?.sandboxDashboardUrl).toBe(
+        "https://provider.example/old-sandbox"
+      );
+      expect(result.current.sessionState?.codeServerUrl).toBe("https://code.example/old-sandbox");
+    });
+
+    act(() => {
+      socket.receive({ type: "sandbox_status", status: "spawning" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionState?.sandboxStatus).toBe("spawning");
+      expect(result.current.sessionState?.sandboxDashboardUrl).toBeUndefined();
+      expect(result.current.sessionState?.codeServerUrl).toBeUndefined();
+    });
+
+    act(() => {
+      sendSandboxAccessMessages(socket, "new-sandbox");
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionState?.sandboxDashboardUrl).toBe(
+        "https://provider.example/new-sandbox"
+      );
+      expect(result.current.sessionState?.codeServerUrl).toBe("https://code.example/new-sandbox");
+    });
+
+    act(() => {
       socket.receive({ type: "sandbox_error", error: "spawn failed" });
     });
 
     await waitFor(() => {
       expect(result.current.sessionState?.sandboxStatus).toBe("failed");
-      expect(result.current.sessionState?.sandboxDashboardUrl).toBeUndefined();
+      expect(result.current.sessionState?.sandboxDashboardUrl).toBe(
+        "https://provider.example/new-sandbox"
+      );
       expect(result.current.sessionState?.codeServerUrl).toBeUndefined();
     });
   });

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -34,6 +34,15 @@ type SessionState = SharedSessionState;
 type Participant = ParticipantPresence;
 type WsMessage = ServerMessage;
 
+const CLEARED_SANDBOX_ACCESS_STATE = {
+  codeServerUrl: undefined,
+  codeServerPassword: undefined,
+  tunnelUrls: undefined,
+  ttydUrl: undefined,
+  ttydToken: undefined,
+  sandboxDashboardUrl: undefined,
+} satisfies Partial<SessionState>;
+
 interface UseSessionSocketReturn {
   connected: boolean;
   connecting: boolean;
@@ -377,31 +386,24 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
               ? {
                   ...prev,
                   sandboxStatus: "spawning",
-                  codeServerUrl: undefined,
-                  codeServerPassword: undefined,
-                  tunnelUrls: undefined,
-                  ttydUrl: undefined,
-                  ttydToken: undefined,
+                  ...CLEARED_SANDBOX_ACCESS_STATE,
                 }
               : null
           );
           break;
 
         case "sandbox_status": {
-          const isTerminal =
-            data.status === "stale" || data.status === "stopped" || data.status === "failed";
+          const shouldClearAccessState =
+            data.status === "spawning" ||
+            data.status === "stale" ||
+            data.status === "stopped" ||
+            data.status === "failed";
           setSessionState((prev) =>
             prev
               ? {
                   ...prev,
                   sandboxStatus: data.status,
-                  ...(isTerminal && {
-                    codeServerUrl: undefined,
-                    codeServerPassword: undefined,
-                    tunnelUrls: undefined,
-                    ttydUrl: undefined,
-                    ttydToken: undefined,
-                  }),
+                  ...(shouldClearAccessState && CLEARED_SANDBOX_ACCESS_STATE),
                 }
               : null
           );
@@ -422,6 +424,10 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
 
         case "tunnel_urls":
           setSessionState((prev) => (prev ? { ...prev, tunnelUrls: data.urls } : null));
+          break;
+
+        case "sandbox_dashboard_url":
+          setSessionState((prev) => (prev ? { ...prev, sandboxDashboardUrl: data.url } : null));
           break;
 
         case "sandbox_ready":
@@ -471,7 +477,15 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
 
         case "sandbox_error":
           console.error("Sandbox error:", data.error);
-          setSessionState((prev) => (prev ? { ...prev, sandboxStatus: "failed" } : null));
+          setSessionState((prev) =>
+            prev
+              ? {
+                  ...prev,
+                  sandboxStatus: "failed",
+                  ...CLEARED_SANDBOX_ACCESS_STATE,
+                }
+              : null
+          );
           break;
 
         case "pong":

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -40,7 +40,6 @@ const CLEARED_SANDBOX_ACCESS_STATE = {
   tunnelUrls: undefined,
   ttydUrl: undefined,
   ttydToken: undefined,
-  sandboxDashboardUrl: undefined,
 } satisfies Partial<SessionState>;
 
 interface UseSessionSocketReturn {
@@ -393,8 +392,9 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
           break;
 
         case "sandbox_status": {
+          const isReplacementStart = data.status === "spawning";
           const shouldClearAccessState =
-            data.status === "spawning" ||
+            isReplacementStart ||
             data.status === "stale" ||
             data.status === "stopped" ||
             data.status === "failed";
@@ -404,6 +404,7 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
                   ...prev,
                   sandboxStatus: data.status,
                   ...(shouldClearAccessState && CLEARED_SANDBOX_ACCESS_STATE),
+                  ...(isReplacementStart && { sandboxDashboardUrl: undefined }),
                 }
               : null
           );


### PR DESCRIPTION
## Summary

- add a provider-neutral `sandbox_dashboard_url` server message and session state field
- broadcast the dashboard URL after a sandbox provider object ID is persisted on spawn, restore, or persistent resume
- render the desktop sandbox status as an external provider-dashboard link when a URL is available

## Why

Modal exposes useful per-sandbox diagnostics in its dashboard, but the web UI currently has no way to link users from a session to the corresponding provider sandbox. This makes debugging stuck, slow, or failed sandboxes harder than it needs to be.

The implementation keeps the shared protocol provider-neutral and confines Modal URL construction to the control-plane Modal path. Existing connected clients receive the URL as soon as the provider object ID is known, while newly subscribed clients receive it through the hydrated session state.

## Prior upstream work checked

- refreshed `upstream/main` before opening this PR; this branch is one commit ahead and zero commits behind
- checked `upstream/main` for `sandboxDashboardUrl`, `sandbox_dashboard_url`, and `modal_sandbox_url`; no existing implementation was present
- searched existing upstream PRs for sandbox/dashboard/Modal dashboard terms; no matching fix for this URL plumbing was found
- noted open PR #629 for non-main Modal environments; this PR defaults the Modal dashboard environment to `main` and does not add new Terraform/env wiring

## Details

- `buildModalSandboxDashboardUrl` returns `null` unless the required Modal workspace and provider object ID are present.
- `SandboxLifecycleManager` centralizes provider object ID persistence and broadcasts the dashboard URL only when configured.
- `SessionDO` wires the builder only for the Modal backend.
- The web socket hook clears stale dashboard URLs when a replacement sandbox starts or the current sandbox reaches a terminal state.

## Tests

- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/control-plane`
- `npm test -w @open-inspect/web`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run typecheck -w @open-inspect/web`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session header shows a clickable sandbox provider dashboard link when available; session state and server messages now include an optional sandbox dashboard URL.

* **Bug Fixes**
  * Dashboard link visibility and updates are more consistent across spawn, restore, and resume flows; dashboard URL cleared or retained appropriately during lifecycle transitions.

* **Tests**
  * Added tests for URL construction, message delivery, session-state hydration, and sandbox access state transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/654?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->