### PR TITLE
fix(sandbox): copy complete bundled skill directories

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -376,8 +376,14 @@ class SandboxSupervisor:
                 continue
 
             dest_dir = skills_dest / skill_dir.name
-            dest_dir.mkdir(parents=True, exist_ok=True)
-            shutil.copy(skill_file, dest_dir / "SKILL.md")
+            # Preserve symlinks rather than dereferencing paths outside the bundled skill.
+            shutil.copytree(
+                skill_dir,
+                dest_dir,
+                dirs_exist_ok=True,
+                ignore=shutil.ignore_patterns("__pycache__", "*.pyc", ".DS_Store"),
+                symlinks=True,
+            )
             installed_any = True
 
         if installed_any:

--- a/packages/sandbox-runtime/tests/test_tool_installation.py
+++ b/packages/sandbox-runtime/tests/test_tool_installation.py
@@ -315,16 +315,38 @@ class TestInstallBinScripts:
 class TestInstallSkills:
     """Cases for _install_skills() bundled Skill installation."""
 
-    def test_skills_dir_files_copied(self, tmp_path):
-        """Bundled Skills should be copied into .opencode/skills."""
+    def test_complete_skill_directories_are_copied(self, tmp_path):
+        """Bundled Skills should include companion files and directories."""
         sup = _make_supervisor()
         workdir = tmp_path / "workspace"
         workdir.mkdir()
 
         skills_dir = tmp_path / "app" / "sandbox" / "skills"
         agent_browser_dir = skills_dir / "agent-browser"
-        agent_browser_dir.mkdir(parents=True)
+        scripts_dir = agent_browser_dir / "scripts"
+        references_dir = agent_browser_dir / "references"
+        scripts_dir.mkdir(parents=True)
+        references_dir.mkdir()
         (agent_browser_dir / "SKILL.md").write_text("# agent-browser")
+        (scripts_dir / "helper.py").write_text("print('helper')")
+        (references_dir / "notes.md").write_text("Use this reference")
+        pycache_dir = scripts_dir / "__pycache__"
+        pycache_dir.mkdir()
+        (pycache_dir / "helper.cpython-314.pyc").write_bytes(b"compiled")
+
+        record_video_dir = skills_dir / "record-video"
+        record_video_dir.mkdir()
+        (record_video_dir / "SKILL.md").write_text("# record-video")
+        (record_video_dir / "helper.txt").write_text("fresh install")
+
+        (skills_dir / "README.md").write_text("not a skill")
+        no_skill_dir = skills_dir / "not-a-skill"
+        no_skill_dir.mkdir()
+        (no_skill_dir / "notes.md").write_text("missing SKILL.md")
+
+        existing_file = workdir / ".opencode" / "skills" / "agent-browser" / "local.txt"
+        existing_file.parent.mkdir(parents=True)
+        existing_file.write_text("keep me")
 
         with _patch_paths(
             legacy=tmp_path / "no-legacy",
@@ -333,9 +355,17 @@ class TestInstallSkills:
         ):
             sup._install_skills(workdir)
 
-        skill_dest = workdir / ".opencode" / "skills" / "agent-browser" / "SKILL.md"
-        assert skill_dest.exists()
-        assert skill_dest.read_text() == "# agent-browser"
+        skill_dest = workdir / ".opencode" / "skills" / "agent-browser"
+        assert (skill_dest / "SKILL.md").read_text() == "# agent-browser"
+        assert (skill_dest / "scripts" / "helper.py").read_text() == "print('helper')"
+        assert (skill_dest / "references" / "notes.md").read_text() == "Use this reference"
+        assert not (skill_dest / "scripts" / "__pycache__").exists()
+        assert existing_file.read_text() == "keep me"
+        fresh_skill_dest = workdir / ".opencode" / "skills" / "record-video"
+        assert (fresh_skill_dest / "SKILL.md").read_text() == "# record-video"
+        assert (fresh_skill_dest / "helper.txt").read_text() == "fresh install"
+        assert not (workdir / ".opencode" / "skills" / "README.md").exists()
+        assert not (workdir / ".opencode" / "skills" / "not-a-skill").exists()
 
     def test_skills_dir_non_directory_is_ignored(self, tmp_path):
         """A non-directory skills path should not raise or copy files."""


### PR DESCRIPTION
## Summary

- copy each valid bundled skill directory into `.opencode/skills`, instead of copying only its `SKILL.md`
- keep the existing rule that only directories containing `SKILL.md` are installed
- skip generated local artifacts such as `__pycache__`, `*.pyc`, and `.DS_Store`
- expand the installer test to cover companion files, fresh installs, merge behavior, and ignored non-skill entries

## Why this is useful

Bundled skills are a platform extension point, but the current installer only copies the top-level `SKILL.md`. That means any skill which needs companion files, such as helper scripts, references, templates, or assets, is silently incomplete inside the sandbox even though those files are present in the runtime image.

Copying the full validated skill directory makes bundled skills self-contained and lets future skills grow beyond a single markdown file without each one needing custom installer logic. The change keeps the existing safety boundary: loose files in the skills root and directories without `SKILL.md` are still ignored.

## Prior upstream work checked

- Refreshed `upstream/main` before creating this branch.
- Checked `upstream/main` for `_install_skills`, `.opencode/skills`, `shutil.copy(skill_file`, and `copytree(skill_dir`.
- Reviewed related upstream PRs found by searching for `_install_skills`, `.opencode/skills`, bundled skills, and `copytree`. The matching PRs added or documented skills, but did not change the installer to copy complete skill directories.

## Test plan

- `cd packages/sandbox-runtime && ./.venv/bin/ruff check .`
- `cd packages/sandbox-runtime && ./.venv/bin/ruff format --check .`
- `cd packages/sandbox-runtime && ./.venv/bin/pytest tests/test_tool_installation.py -q`
- `cd packages/sandbox-runtime && ./.venv/bin/pytest tests/ -q`
- `git diff --check upstream/main...HEAD`

The full sandbox-runtime test suite passes with the existing RuntimeWarnings in `tests/test_bridge_git_identity.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced skills installation to copy complete skill directories with improved file handling, properly excluding cache and system files while preserving symlinks for more reliable installations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->