### PR TITLE
feat: add target branch condition for GitHub Event Automations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2680,6 +2680,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3410,6 +3411,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3432,6 +3434,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3454,6 +3457,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3470,6 +3474,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3486,6 +3491,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3502,6 +3508,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3518,6 +3525,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3534,6 +3542,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3550,6 +3559,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3566,6 +3576,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3582,6 +3593,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3598,6 +3610,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3614,6 +3627,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3636,6 +3650,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3658,6 +3673,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3680,6 +3696,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3702,6 +3719,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3724,6 +3742,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3746,6 +3765,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3768,6 +3788,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3790,6 +3811,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -3809,6 +3831,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3828,6 +3851,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3847,6 +3871,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [

--- a/packages/shared/src/triggers/conditions.test.ts
+++ b/packages/shared/src/triggers/conditions.test.ts
@@ -103,6 +103,32 @@ describe("matchesConditions", () => {
       ];
       expect(matchesConditions(conditions, event, conditionRegistry)).toBe(false);
     });
+
+    it("matches with the exact operator", () => {
+      const event = buildMockEvent("github", {
+        branch: "feature/x",
+        targetBranch: "release/v1",
+      });
+      const conditions = [
+        {
+          type: "target_branch" as const,
+          operator: "exact" as const,
+          value: ["release/v1", "main"],
+        },
+      ];
+      expect(matchesConditions(conditions, event, conditionRegistry)).toBe(true);
+    });
+
+    it("does not match with the exact operator when no value equals the target", () => {
+      const event = buildMockEvent("github", {
+        branch: "feature/x",
+        targetBranch: "release/v1",
+      });
+      const conditions = [
+        { type: "target_branch" as const, operator: "exact" as const, value: ["release"] },
+      ];
+      expect(matchesConditions(conditions, event, conditionRegistry)).toBe(false);
+    });
   });
 });
 

--- a/packages/shared/src/triggers/conditions.test.ts
+++ b/packages/shared/src/triggers/conditions.test.ts
@@ -72,6 +72,38 @@ describe("matchesConditions", () => {
       expect(matchesConditions(conditions, event, conditionRegistry)).toBe(false);
     });
   });
+
+  describe("GitHub target_branch (merge base)", () => {
+    it("matches when merge base ref matches a pattern", () => {
+      const event = buildMockEvent("github", {
+        branch: "feature/x",
+        targetBranch: "stable",
+      });
+      const conditions = [
+        { type: "target_branch" as const, operator: "glob_match" as const, value: ["stable"] },
+      ];
+      expect(matchesConditions(conditions, event, conditionRegistry)).toBe(true);
+    });
+
+    it("does not match when merge base differs", () => {
+      const event = buildMockEvent("github", {
+        branch: "feature/x",
+        targetBranch: "main",
+      });
+      const conditions = [
+        { type: "target_branch" as const, operator: "glob_match" as const, value: ["stable"] },
+      ];
+      expect(matchesConditions(conditions, event, conditionRegistry)).toBe(false);
+    });
+
+    it("does not match when the event has no merge base ref", () => {
+      const event = buildMockEvent("github", { branch: "main" });
+      const conditions = [
+        { type: "target_branch" as const, operator: "glob_match" as const, value: ["main"] },
+      ];
+      expect(matchesConditions(conditions, event, conditionRegistry)).toBe(false);
+    });
+  });
 });
 
 describe("validateConditions", () => {
@@ -102,5 +134,24 @@ describe("validateConditions", () => {
     );
     expect(errors).toHaveLength(1);
     expect(errors[0]).toContain("does not apply to webhook triggers");
+  });
+
+  it("returns error for empty target_branch patterns on github", () => {
+    const errors = validateConditions(
+      [{ type: "target_branch", operator: "glob_match", value: [] }],
+      "github",
+      conditionRegistry
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("target branch");
+  });
+
+  it("accepts target_branch for github triggers", () => {
+    const errors = validateConditions(
+      [{ type: "target_branch", operator: "glob_match", value: ["stable", "main"] }],
+      "github",
+      conditionRegistry
+    );
+    expect(errors).toHaveLength(0);
   });
 });

--- a/packages/shared/src/triggers/conditions.ts
+++ b/packages/shared/src/triggers/conditions.ts
@@ -11,6 +11,7 @@ import type { AutomationEvent, AutomationEventSource } from "./types";
 
 export interface ConditionConfigMap {
   branch: { operator: "glob_match" | "exact"; value: string[] };
+  target_branch: { operator: "glob_match" | "exact"; value: string[] };
   label: { operator: "any_of" | "none_of"; value: string[] };
   path_glob: { operator: "any_match"; value: string[] };
   actor: { operator: "include" | "exclude"; value: string[] };

--- a/packages/shared/src/triggers/github/index.ts
+++ b/packages/shared/src/triggers/github/index.ts
@@ -22,5 +22,12 @@ export const githubSource: TriggerSourceDefinition = {
     displayName,
     description,
   })),
-  supportedConditions: ["branch", "label", "path_glob", "actor", "check_conclusion"],
+  supportedConditions: [
+    "branch",
+    "target_branch",
+    "label",
+    "path_glob",
+    "actor",
+    "check_conclusion",
+  ],
 };

--- a/packages/shared/src/triggers/github/normalizer.test.ts
+++ b/packages/shared/src/triggers/github/normalizer.test.ts
@@ -146,7 +146,12 @@ describe("normalizeGitHubEvent", () => {
       expect(event!.contextBlock).toContain("pull_request.opened");
       expect(event!.contextBlock).toContain("acme-org/my-app");
       expect(event!.contextBlock).toContain("PR #42");
-      expect(event!.meta).toMatchObject({ prNumber: 42, sha: "abc1234def5678", action: "opened" });
+      expect(event!.meta).toMatchObject({
+        prNumber: 42,
+        sha: "abc1234def5678",
+        action: "opened",
+        targetBranch: "main",
+      });
     });
   });
 
@@ -232,7 +237,11 @@ describe("normalizeGitHubEvent", () => {
       expect(event!.targetBranch).toBe("main");
       expect(event!.actor).toBe("dev-user");
       expect(event!.contextBlock).toContain("pull_request_review_comment.created");
-      expect(event!.meta).toMatchObject({ commentId: 5555, prNumber: 42 });
+      expect(event!.meta).toMatchObject({
+        commentId: 5555,
+        prNumber: 42,
+        targetBranch: "main",
+      });
     });
   });
 

--- a/packages/shared/src/triggers/github/normalizer.test.ts
+++ b/packages/shared/src/triggers/github/normalizer.test.ts
@@ -132,6 +132,7 @@ describe("normalizeGitHubEvent", () => {
       expect(event!.repoOwner).toBe("acme-org");
       expect(event!.repoName).toBe("my-app");
       expect(event!.branch).toBe("feature/my-feature");
+      expect(event!.targetBranch).toBe("main");
       expect(event!.labels).toEqual(["enhancement", "review-needed"]);
       expect(event!.actor).toBe("dev-user");
       expect(event!.triggerKey).toBe("pr:42:opened:abc1234def5678");
@@ -228,6 +229,7 @@ describe("normalizeGitHubEvent", () => {
       expect(event!.triggerKey).toBe("pr_review_comment:5555");
       expect(event!.concurrencyKey).toBe("pr:42");
       expect(event!.branch).toBe("feature/my-feature");
+      expect(event!.targetBranch).toBe("main");
       expect(event!.actor).toBe("dev-user");
       expect(event!.contextBlock).toContain("pull_request_review_comment.created");
       expect(event!.meta).toMatchObject({ commentId: 5555, prNumber: 42 });
@@ -245,6 +247,7 @@ describe("normalizeGitHubEvent", () => {
       expect(event!.triggerKey).toBe("check_suite:77777");
       expect(event!.concurrencyKey).toBe("check_suite:77777");
       expect(event!.branch).toBe("feature/my-feature");
+      expect(event!.targetBranch).toBeUndefined();
       expect(event!.contextBlock).toContain("check_suite.completed");
       expect(event!.contextBlock).toContain("failure");
       expect(event!.meta).toMatchObject({ checkSuiteId: 77777, conclusion: "failure" });

--- a/packages/shared/src/triggers/github/normalizer.ts
+++ b/packages/shared/src/triggers/github/normalizer.ts
@@ -167,6 +167,7 @@ function normalizePullRequest(
 
   const headSha = pr.head?.sha;
   const branch = pr.head?.ref;
+  const targetBranch = pr.base?.ref;
   const labels = getPRLabels(pr);
 
   const triggerKey = `pr:${prNumber}:${action}:${headSha ?? "unknown"}`;
@@ -180,6 +181,7 @@ function normalizePullRequest(
     repoOwner,
     repoName,
     branch,
+    targetBranch,
     labels,
     actor,
     contextBlock: buildGitHubContextBlock(eventType, payload),
@@ -245,6 +247,7 @@ function normalizeReviewComment(
   if (typeof prNumber !== "number" || !Number.isFinite(prNumber)) return null;
 
   const branch = pr.head?.ref;
+  const targetBranch = pr.base?.ref;
   const triggerKey = `pr_review_comment:${commentId}`;
   const concurrencyKey = `pr:${prNumber}`;
 
@@ -256,6 +259,7 @@ function normalizeReviewComment(
     repoOwner,
     repoName,
     branch,
+    targetBranch,
     actor,
     contextBlock: buildGitHubContextBlock(eventType, payload),
     meta: {

--- a/packages/shared/src/triggers/github/normalizer.ts
+++ b/packages/shared/src/triggers/github/normalizer.ts
@@ -189,6 +189,7 @@ function normalizePullRequest(
       prNumber,
       sha: headSha,
       action,
+      targetBranch,
     },
   };
 }
@@ -265,6 +266,7 @@ function normalizeReviewComment(
     meta: {
       commentId,
       prNumber,
+      targetBranch,
     },
   };
 }

--- a/packages/shared/src/triggers/registry.ts
+++ b/packages/shared/src/triggers/registry.ts
@@ -30,6 +30,18 @@ const sharedConditions = {
       return c.value.some((pattern: string) => matchGlob(pattern, event.branch!));
     },
   },
+  target_branch: {
+    appliesTo: ["github"] as const,
+    validate(c: { value: string[] }) {
+      return c.value.length === 0 ? "At least one target branch pattern required" : null;
+    },
+    evaluate(c: { operator: string; value: string[] }, event: AutomationEvent) {
+      if (event.source !== "github") return true;
+      if (!event.targetBranch) return false;
+      if (c.operator === "exact") return c.value.includes(event.targetBranch);
+      return c.value.some((pattern: string) => matchGlob(pattern, event.targetBranch!));
+    },
+  },
   label: {
     appliesTo: ["github", "linear"] as const,
     validate(c: { value: string[] }) {

--- a/packages/shared/src/triggers/types.ts
+++ b/packages/shared/src/triggers/types.ts
@@ -46,7 +46,10 @@ export interface GitHubAutomationEvent extends BaseAutomationEvent {
   source: "github";
   repoOwner: string;
   repoName: string;
+  /** Pull request head ref when the event is tied to a PR (source branch). */
   branch?: string;
+  /** Pull request base ref when the event is tied to a PR (merge target branch). */
+  targetBranch?: string;
   labels?: string[];
   actor?: string;
   changedFiles?: string[];

--- a/packages/web/src/components/automations/automation-form.tsx
+++ b/packages/web/src/components/automations/automation-form.tsx
@@ -31,6 +31,7 @@ import { RepoIcon, BranchIcon, ModelIcon, ChevronDownIcon } from "@/components/u
 import { CronPicker } from "./cron-picker";
 import { TriggerTypeSelector } from "./trigger-type-selector";
 import { ConditionBuilder } from "./condition-builder";
+import { cn } from "@/lib/utils";
 
 const COMMON_TIMEZONES = [
   "UTC",
@@ -64,6 +65,18 @@ const TIMEZONE_GROUPS: ComboboxGroup[] = [
     options: ALL_TIMEZONES.filter((tz) => !COMMON_SET.has(tz)).map(toOption),
   },
 ];
+
+function FieldDescription({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <p className={cn("text-xs text-muted-foreground mt-1 leading-normal", className)}>{children}</p>
+  );
+}
 
 export interface AutomationFormValues {
   name: string;
@@ -209,6 +222,10 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
       {mode === "create" ? (
         <div>
           <label className="block text-sm font-medium text-foreground mb-1.5">Trigger Type</label>
+          <FieldDescription className="my-1">
+            Scheduled automations run on a repeating timer. Other types run when the connected
+            service sends an event (for example a GitHub webhook or Sentry alert).
+          </FieldDescription>
           <TriggerTypeSelector value={triggerType} onChange={setTriggerType} />
         </div>
       ) : (
@@ -224,6 +241,10 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
             }[triggerType] || triggerType}
             <span className="text-xs ml-2">(cannot be changed)</span>
           </div>
+          <FieldDescription>
+            Trigger type is fixed after the automation is created. Create a new automation to use a
+            different trigger.
+          </FieldDescription>
         </div>
       )}
 
@@ -268,6 +289,10 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
           </span>
           <ChevronDownIcon className="w-3 h-3 text-muted-foreground" />
         </Combobox>
+        <FieldDescription>
+          Runs clone and execute against this repository.
+          {mode === "edit" ? " The repository cannot be changed after creation." : ""}
+        </FieldDescription>
       </div>
 
       {/* Branch */}
@@ -293,6 +318,11 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
           </span>
           <ChevronDownIcon className="w-3 h-3 text-muted-foreground" />
         </Combobox>
+        <FieldDescription>
+          Default branch checked out when a session run starts. Selecting a repository resets this
+          to that repo&apos;s default branch. To filter pull requests by merge target, add a Target
+          branch condition below; Head branch matches the PR source branch.
+        </FieldDescription>
       </div>
 
       {/* Model */}
@@ -323,6 +353,9 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
           <span className="truncate flex-1 text-left">{formatModelNameLower(model)}</span>
           <ChevronDownIcon className="w-3 h-3 text-muted-foreground" />
         </Combobox>
+        <FieldDescription>
+          Model used for the agent on each run of this automation.
+        </FieldDescription>
       </div>
 
       <div>
@@ -348,6 +381,10 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
             ))}
           </SelectContent>
         </Select>
+        <FieldDescription>
+          For models that support it, overrides how much chain-of-thought style reasoning is
+          allowed. &quot;Use model default&quot; leaves the choice to the model.
+        </FieldDescription>
       </div>
 
       {/* Schedule fields (only for schedule type) */}
@@ -356,6 +393,10 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
           <div>
             <label className="block text-sm font-medium text-foreground mb-1.5">Schedule</label>
             <CronPicker value={scheduleCron} onChange={setScheduleCron} timezone={scheduleTz} />
+            <FieldDescription>
+              How often this automation runs. Use a preset or a five-field cron expression (minute,
+              hour, day of month, month, day of week).
+            </FieldDescription>
           </div>
           <div>
             <label className="block text-sm font-medium text-foreground mb-1.5">Timezone</label>
@@ -376,6 +417,10 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
               <span className="truncate flex-1 text-left">{scheduleTz.replace(/_/g, " ")}</span>
               <ChevronDownIcon className="w-3 h-3 text-muted-foreground" />
             </Combobox>
+            <FieldDescription>
+              The schedule is evaluated in this time zone (for example, &quot;9:00&quot; is 9:00
+              local time here).
+            </FieldDescription>
           </div>
         </>
       )}
@@ -403,6 +448,9 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
               ))}
             </SelectContent>
           </Select>
+          <FieldDescription>
+            Only events of this type on the selected repository can start a run for this automation.
+          </FieldDescription>
           {eventTypeError && <p className="mt-1 text-xs text-destructive">{eventTypeError}</p>}
         </div>
       )}
@@ -439,12 +487,20 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
             onChange={setConditions}
             triggerSource={TRIGGER_TYPE_TO_SOURCE[triggerType] as AutomationEventSource}
           />
+          <FieldDescription>
+            Optional filters on incoming events. When you add conditions, every condition must pass
+            before a run starts.
+          </FieldDescription>
         </div>
       )}
 
       {/* Instructions */}
       <div>
         <label className="block text-sm font-medium text-foreground mb-1.5">Instructions</label>
+        <FieldDescription className="mb-1.5">
+          Main prompt for the agent when a run starts. For event-based triggers, a short summary of
+          the event is inserted above this text.
+        </FieldDescription>
         <Textarea
           value={instructions}
           onChange={(e) => setInstructions(e.target.value)}

--- a/packages/web/src/components/automations/condition-builder.tsx
+++ b/packages/web/src/components/automations/condition-builder.tsx
@@ -23,7 +23,8 @@ const CONDITION_LABELS: Record<string, string> = {
   sentry_project: "Sentry Project",
   sentry_level: "Error Level",
   jsonpath: "JSONPath Filter",
-  branch: "Branch",
+  branch: "Head branch",
+  target_branch: "Target branch",
   label: "Label",
   path_glob: "Path Glob",
   actor: "Actor",
@@ -64,6 +65,9 @@ export function ConditionBuilder({ conditions, onChange, triggerSource }: Condit
         break;
       case "branch":
         newCondition = { type: "branch", operator: "glob_match", value: [] };
+        break;
+      case "target_branch":
+        newCondition = { type: "target_branch", operator: "glob_match", value: [] };
         break;
       case "label":
         newCondition = { type: "label", operator: "any_of", value: [] };
@@ -174,7 +178,15 @@ function ConditionEditor({
         <TagInput
           values={condition.value}
           onChange={(value) => onChange({ ...condition, value })}
-          placeholder="Add branch pattern (e.g., main, feature/*)..."
+          placeholder="Head branch pattern (PR source, e.g. main, feature/*)..."
+        />
+      );
+    case "target_branch":
+      return (
+        <TagInput
+          values={condition.value}
+          onChange={(value) => onChange({ ...condition, value })}
+          placeholder="Target branch pattern (merge base, e.g. main, stable)..."
         />
       );
     case "label":

--- a/packages/web/src/components/automations/condition-builder.tsx
+++ b/packages/web/src/components/automations/condition-builder.tsx
@@ -186,7 +186,7 @@ function ConditionEditor({
         <TagInput
           values={condition.value}
           onChange={(value) => onChange({ ...condition, value })}
-          placeholder="Target branch pattern (merge base, e.g. main, stable)..."
+          placeholder="PR merge base pattern (PR events only, e.g. main, release/*)..."
         />
       );
     case "label":


### PR DESCRIPTION
# Description

Before this PR there was no possible way to build an automation that should ONLY run when a PR to be merged with the `<some-defined-branch>` branch is opened.

Added missing conditional for GitHub Automations so that users can indicate that a new session will run only if a PR opened (or closed, et.al) is to be merged with a particular branch.

For example:
A Github automation should run for `this particular branch` when... -you know, the habitual automation config-... **AND** PR's target branch is `<branch-name>`.

👉 This is particularly useful when we want to create automations for release PRs.

## automation-form.tsx improvements

_Create automation_ fields now include a small description to improve UX.

<img width="1448" height="2196" alt="image" src="https://github.com/user-attachments/assets/283a766f-ddf1-4b15-8fee-746f071c4370" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support filtering GitHub automations by target branch (the branch a pull request is being merged into).

* **UI Improvements**
  * Added field descriptions across the automation form (trigger, repo, branch, model, schedule, timezone, event type, conditions, instructions).
  * Condition builder shows clearer labels/placeholders and exposes target-branch filtering.

* **Tests**
  * Added/updated tests covering target-branch matching and validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->