### PR TITLE
fix: persist removing all conditionals from automation

### DIFF
--- a/packages/web/src/components/automations/automation-form.test.tsx
+++ b/packages/web/src/components/automations/automation-form.test.tsx
@@ -123,6 +123,35 @@ describe("automation cron submission", () => {
     expect(screen.getByText("Event type is required.")).toBeInTheDocument();
     expect(onSubmit).not.toHaveBeenCalled();
   });
+
+  it("submits triggerConfig with empty conditions for non-schedule automations", () => {
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <AutomationForm
+        mode="edit"
+        submitting={false}
+        onSubmit={onSubmit}
+        initialValues={{
+          name: "Review PRs",
+          repoOwner: "open-inspect",
+          repoName: "background-agents",
+          baseBranch: "main",
+          model: "openai/gpt-5.4",
+          instructions: "Review incoming PRs.",
+          triggerType: "github_event",
+          eventType: "pull_request.opened",
+          triggerConfig: { conditions: [] },
+        }}
+      />
+    );
+
+    fireEvent.submit(container.querySelector("form")!);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({
+      triggerConfig: { conditions: [] },
+    });
+  });
 });
 
 describe("instructions character counter", () => {

--- a/packages/web/src/components/automations/automation-form.tsx
+++ b/packages/web/src/components/automations/automation-form.tsx
@@ -182,7 +182,9 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
       delete (values as Partial<AutomationFormValues>).scheduleTz;
 
       if (eventType) values.eventType = eventType;
-      if (conditions.length > 0) values.triggerConfig = { conditions };
+      // Always send triggerConfig so clearing all conditions persists (PUT skips
+      // trigger_config when triggerConfig is omitted).
+      values.triggerConfig = { conditions };
       if (triggerType === "sentry" && mode === "create" && sentryClientSecret.trim()) {
         values.sentryClientSecret = sentryClientSecret.trim();
       }


### PR DESCRIPTION
## Description

### 1. The `automation-form.tsx` form omitted `triggerConfig` when there were no conditions
In handleSubmit, for non-schedule triggers, `triggerConfig` was only attached when conditions.length > 0. If the user removed every condition (including the only one), the PUT body had no `triggerConfig` field.

### 2. The control plane only updates `trigger_config` when the body includes `triggerConfig`
The update handler builds `updateFields` from the request body. `trigger_config` was only touched when `body.triggerConfig !== undefined`.

### Fix
`triggerConfig` is always present on the PUT request body whenever the user changed conditions and we need the server to persist an empty list.

**Important**: If the user updates fields other than the `conditions` one, the "unchanged" conditions should be kept (no modification).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with form submission where trigger configuration was being omitted when no conditions were configured. The form now always includes the complete trigger configuration payload with the conditions array, even when that array is empty.

* **Tests**
  * Added test coverage to validate that trigger configuration is correctly submitted with empty conditions when editing non-schedule automations in the form.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/662?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->