### PR TITLE
feat(modal): expose tunnel URLs in sandbox via /workspace/.tunnels.env

### DIFF
--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -221,11 +221,8 @@ class SandboxManager:
     ) -> None:
         """Write tunnel URLs to TUNNEL_ENV_FILE_PATH as a dotenv file.
 
-        Local services started by the agent inside the sandbox can consume the
-        URLs via `--env-file=.tunnels.env` or by reading the file directly.
-
-        Failures are logged but do not block sandbox creation — the URLs are
-        also returned to the control plane via the SandboxHandle.
+        Failures are logged but do not block sandbox creation; URLs are also
+        returned to the control plane via the SandboxHandle.
         """
         lines = [f"TUNNEL_{port}={url}" for port, url in sorted(tunnel_urls.items())]
         content = "\n".join(lines) + "\n"
@@ -338,8 +335,12 @@ class SandboxManager:
         else:
             image = base_image
 
-        # Create the sandbox
-        # The entrypoint command is passed as positional args
+        exposed_ports, tunnel_ports = self._collect_exposed_ports(
+            config.code_server_enabled, terminal_enabled, config.settings
+        )
+        if tunnel_ports:
+            env_vars[EXPECTED_TUNNEL_PORTS_ENV_VAR] = ",".join(str(p) for p in tunnel_ports)
+
         create_kwargs: dict = {
             "image": image,
             "app": app,
@@ -348,15 +349,8 @@ class SandboxManager:
             "workdir": "/workspace",
             "env": env_vars,
         }
-        exposed_ports, tunnel_ports = self._collect_exposed_ports(
-            config.code_server_enabled, terminal_enabled, config.settings
-        )
         if exposed_ports:
             create_kwargs["encrypted_ports"] = exposed_ports
-        if tunnel_ports:
-            # Signals the entrypoint to (a) clear any stale tunnel env file
-            # from a snapshot and (b) wait for fresh URLs before start.sh.
-            env_vars[EXPECTED_TUNNEL_PORTS_ENV_VAR] = ",".join(str(p) for p in tunnel_ports)
 
         sandbox = await modal.Sandbox.create.aio(
             "python",
@@ -661,24 +655,22 @@ class SandboxManager:
         if agent_slack_notify_enabled:
             env_vars["AGENT_SLACK_NOTIFY_ENABLED"] = "true"
 
-        # Create the sandbox from the snapshot image
+        exposed_ports, tunnel_ports = self._collect_exposed_ports(
+            code_server_enabled, terminal_enabled, settings
+        )
+        if tunnel_ports:
+            env_vars[EXPECTED_TUNNEL_PORTS_ENV_VAR] = ",".join(str(p) for p in tunnel_ports)
+
         create_kwargs: dict = {
-            "image": image,  # Use the snapshot image directly
+            "image": image,
             "app": app,
             "secrets": [llm_secrets],
             "timeout": timeout_seconds,
             "workdir": "/workspace",
             "env": env_vars,
         }
-        exposed_ports, tunnel_ports = self._collect_exposed_ports(
-            code_server_enabled, terminal_enabled, settings
-        )
         if exposed_ports:
             create_kwargs["encrypted_ports"] = exposed_ports
-        if tunnel_ports:
-            # Signals the entrypoint to (a) clear any stale tunnel env file
-            # from the snapshot and (b) wait for fresh URLs before start.sh.
-            env_vars[EXPECTED_TUNNEL_PORTS_ENV_VAR] = ",".join(str(p) for p in tunnel_ports)
 
         sandbox = await modal.Sandbox.create.aio(
             "python",

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -20,7 +20,12 @@ from typing import Any
 
 import modal
 
-from sandbox_runtime.constants import CODE_SERVER_PORT, TTYD_PROXY_PORT
+from sandbox_runtime.constants import (
+    CODE_SERVER_PORT,
+    EXPECTED_TUNNEL_PORTS_ENV_VAR,
+    TTYD_PROXY_PORT,
+    TUNNEL_ENV_FILE_PATH,
+)
 from sandbox_runtime.log_config import get_logger
 from sandbox_runtime.types import SandboxStatus, SessionConfig
 
@@ -32,11 +37,6 @@ log = get_logger("manager")
 DEFAULT_SANDBOX_TIMEOUT_SECONDS = 7200  # 2 hours
 SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS = 300
 MAX_TUNNEL_PORTS = 10
-
-# Path inside the sandbox where extra tunnel URLs are exposed in dotenv format.
-# Local services can consume via `--env-file=.tunnels.env` (Node, Bun, Vite,
-# docker compose) or read directly. Format is `TUNNEL_<port>=<url>` per line.
-TUNNEL_ENV_FILE_PATH = "/workspace/.tunnels.env"
 
 
 @dataclass
@@ -353,6 +353,10 @@ class SandboxManager:
         )
         if exposed_ports:
             create_kwargs["encrypted_ports"] = exposed_ports
+        if tunnel_ports:
+            # Signals the entrypoint to (a) clear any stale tunnel env file
+            # from a snapshot and (b) wait for fresh URLs before start.sh.
+            env_vars[EXPECTED_TUNNEL_PORTS_ENV_VAR] = ",".join(str(p) for p in tunnel_ports)
 
         sandbox = await modal.Sandbox.create.aio(
             "python",
@@ -671,6 +675,10 @@ class SandboxManager:
         )
         if exposed_ports:
             create_kwargs["encrypted_ports"] = exposed_ports
+        if tunnel_ports:
+            # Signals the entrypoint to (a) clear any stale tunnel env file
+            # from the snapshot and (b) wait for fresh URLs before start.sh.
+            env_vars[EXPECTED_TUNNEL_PORTS_ENV_VAR] = ",".join(str(p) for p in tunnel_ports)
 
         sandbox = await modal.Sandbox.create.aio(
             "python",

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -33,6 +33,11 @@ DEFAULT_SANDBOX_TIMEOUT_SECONDS = 7200  # 2 hours
 SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS = 300
 MAX_TUNNEL_PORTS = 10
 
+# Path inside the sandbox where extra tunnel URLs are exposed in dotenv format.
+# Local services can consume via `--env-file=.tunnels.env` (Node, Bun, Vite,
+# docker compose) or read directly. Format is `TUNNEL_<port>=<url>` per line.
+TUNNEL_ENV_FILE_PATH = "/workspace/.tunnels.env"
+
 
 @dataclass
 class SandboxConfig:
@@ -203,7 +208,46 @@ class SandboxManager:
         ttyd_url = resolved.pop(TTYD_PROXY_PORT, None)
         extra_urls = resolved if resolved else None
 
+        if extra_urls:
+            await SandboxManager._write_tunnel_env_file(sandbox, sandbox_id, extra_urls)
+
         return code_server_url, ttyd_url, extra_urls
+
+    @staticmethod
+    async def _write_tunnel_env_file(
+        sandbox: modal.Sandbox,
+        sandbox_id: str,
+        tunnel_urls: dict[int, str],
+    ) -> None:
+        """Write tunnel URLs to TUNNEL_ENV_FILE_PATH as a dotenv file.
+
+        Local services started by the agent inside the sandbox can consume the
+        URLs via `--env-file=.tunnels.env` or by reading the file directly.
+
+        Failures are logged but do not block sandbox creation — the URLs are
+        also returned to the control plane via the SandboxHandle.
+        """
+        lines = [f"TUNNEL_{port}={url}" for port, url in sorted(tunnel_urls.items())]
+        content = "\n".join(lines) + "\n"
+        try:
+            f = await sandbox.open.aio(TUNNEL_ENV_FILE_PATH, "w")
+            try:
+                await f.write.aio(content)
+            finally:
+                await f.close.aio()
+            log.info(
+                "tunnel.urls_written",
+                sandbox_id=sandbox_id,
+                path=TUNNEL_ENV_FILE_PATH,
+                ports=list(tunnel_urls.keys()),
+            )
+        except Exception as e:
+            log.warn(
+                "tunnel.urls_write_failed",
+                sandbox_id=sandbox_id,
+                path=TUNNEL_ENV_FILE_PATH,
+                exc=e,
+            )
 
     @staticmethod
     def _inject_vcs_env_vars(env_vars: dict[str, str], clone_token: str | None) -> None:

--- a/packages/modal-infra/tests/test_tunnel_ports.py
+++ b/packages/modal-infra/tests/test_tunnel_ports.py
@@ -4,8 +4,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from sandbox_runtime.constants import TTYD_PROXY_PORT
-from src.sandbox.manager import CODE_SERVER_PORT, TUNNEL_ENV_FILE_PATH, SandboxManager
+from sandbox_runtime.constants import (
+    EXPECTED_TUNNEL_PORTS_ENV_VAR,
+    TTYD_PROXY_PORT,
+    TUNNEL_ENV_FILE_PATH,
+)
+from src.sandbox.manager import CODE_SERVER_PORT, SandboxConfig, SandboxManager
 
 
 def _mock_sandbox_with_open() -> tuple[MagicMock, AsyncMock]:
@@ -268,6 +272,106 @@ class TestResolveAndSetupTunnelsWritesFile:
             )
 
         assert extra == {3000: "https://tunnel-3000.example.com"}
+
+
+class TestExpectedTunnelPortsEnvVar:
+    """create_sandbox / restore_from_snapshot set EXPECTED_TUNNEL_PORTS env var."""
+
+    @pytest.mark.asyncio
+    async def test_create_sandbox_sets_env_var_when_tunnel_ports_configured(self, monkeypatch):
+        captured: dict[str, dict[str, str]] = {}
+
+        async def fake_create_aio(*args, **kwargs):
+            captured["env"] = kwargs.get("env") or {}
+
+            class FakeSandbox:
+                object_id = "obj-1"
+                stdout = None
+
+            return FakeSandbox()
+
+        fake_create_aio.aio = fake_create_aio
+        monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", fake_create_aio)
+        monkeypatch.setattr(
+            SandboxManager,
+            "_resolve_and_setup_tunnels",
+            AsyncMock(return_value=(None, None, None)),
+        )
+
+        manager = SandboxManager()
+        await manager.create_sandbox(
+            SandboxConfig(
+                repo_owner="acme",
+                repo_name="repo",
+                settings={"tunnelPorts": [3000, 5173]},
+            )
+        )
+
+        assert captured["env"][EXPECTED_TUNNEL_PORTS_ENV_VAR] == "3000,5173"
+
+    @pytest.mark.asyncio
+    async def test_create_sandbox_omits_env_var_when_no_tunnel_ports(self, monkeypatch):
+        captured: dict[str, dict[str, str]] = {}
+
+        async def fake_create_aio(*args, **kwargs):
+            captured["env"] = kwargs.get("env") or {}
+
+            class FakeSandbox:
+                object_id = "obj-1"
+                stdout = None
+
+            return FakeSandbox()
+
+        fake_create_aio.aio = fake_create_aio
+        monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", fake_create_aio)
+        monkeypatch.setattr(
+            SandboxManager,
+            "_resolve_and_setup_tunnels",
+            AsyncMock(return_value=(None, None, None)),
+        )
+
+        manager = SandboxManager()
+        await manager.create_sandbox(SandboxConfig(repo_owner="acme", repo_name="repo"))
+
+        assert EXPECTED_TUNNEL_PORTS_ENV_VAR not in captured["env"]
+
+    @pytest.mark.asyncio
+    async def test_restore_from_snapshot_sets_env_var_when_tunnel_ports_configured(
+        self, monkeypatch
+    ):
+        captured: dict[str, dict[str, str]] = {}
+
+        class FakeImage:
+            object_id = "img-1"
+
+        async def fake_create_aio(*args, **kwargs):
+            captured["env"] = kwargs.get("env") or {}
+
+            class FakeSandbox:
+                object_id = "obj-1"
+                stdout = None
+
+            return FakeSandbox()
+
+        fake_create_aio.aio = fake_create_aio
+        monkeypatch.setattr(
+            "src.sandbox.manager.modal.Image.from_id", lambda *_a, **_kw: FakeImage()
+        )
+        monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", fake_create_aio)
+        monkeypatch.setattr(
+            SandboxManager,
+            "_resolve_and_setup_tunnels",
+            AsyncMock(return_value=(None, None, None)),
+        )
+
+        manager = SandboxManager()
+        await manager.restore_from_snapshot(
+            snapshot_image_id="img-abc",
+            session_config={"repo_owner": "acme", "repo_name": "repo"},
+            settings={"tunnelPorts": [3000]},
+        )
+
+        assert captured["env"][EXPECTED_TUNNEL_PORTS_ENV_VAR] == "3000"
 
 
 class TestCollectExposedPorts:

--- a/packages/modal-infra/tests/test_tunnel_ports.py
+++ b/packages/modal-infra/tests/test_tunnel_ports.py
@@ -5,7 +5,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from sandbox_runtime.constants import TTYD_PROXY_PORT
-from src.sandbox.manager import CODE_SERVER_PORT, SandboxManager
+from src.sandbox.manager import CODE_SERVER_PORT, TUNNEL_ENV_FILE_PATH, SandboxManager
+
+
+def _mock_sandbox_with_open() -> tuple[MagicMock, AsyncMock]:
+    """Return (sandbox, file_handle) with sandbox.open.aio returning the handle."""
+    f = AsyncMock()
+    sandbox = MagicMock()
+    sandbox.open = MagicMock()
+    sandbox.open.aio = AsyncMock(return_value=f)
+    return sandbox, f
 
 
 class TestResolveTunnels:
@@ -93,7 +102,7 @@ class TestResolveAndSetupTunnels:
     async def test_resolves_extra_ports(self):
         tunnel_urls = {3000: "https://tunnel-3000.example.com"}
 
-        sandbox = MagicMock()
+        sandbox, _f = _mock_sandbox_with_open()
         with patch.object(
             SandboxManager,
             "_resolve_tunnels",
@@ -115,7 +124,7 @@ class TestResolveAndSetupTunnels:
             3000: "https://tunnel-3000.example.com",
         }
 
-        sandbox = MagicMock()
+        sandbox, _f = _mock_sandbox_with_open()
 
         with patch.object(
             SandboxManager,
@@ -129,6 +138,135 @@ class TestResolveAndSetupTunnels:
 
         assert cs_url == "https://cs.example.com"
         assert ttyd_url is None
+        assert extra == {3000: "https://tunnel-3000.example.com"}
+
+
+class TestWriteTunnelEnvFile:
+    """SandboxManager._write_tunnel_env_file tests."""
+
+    @pytest.mark.asyncio
+    async def test_writes_dotenv_format_to_expected_path(self):
+        sandbox, f = _mock_sandbox_with_open()
+
+        await SandboxManager._write_tunnel_env_file(
+            sandbox,
+            "sb-1",
+            {
+                3001: "https://tunnel-3001.example.com",
+                3000: "https://tunnel-3000.example.com",
+            },
+        )
+
+        sandbox.open.aio.assert_awaited_once_with(TUNNEL_ENV_FILE_PATH, "w")
+        f.write.aio.assert_awaited_once()
+        written = f.write.aio.call_args[0][0]
+        # Sorted by port, dotenv format, trailing newline.
+        assert written == (
+            "TUNNEL_3000=https://tunnel-3000.example.com\n"
+            "TUNNEL_3001=https://tunnel-3001.example.com\n"
+        )
+        f.close.aio.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_closes_file_when_write_raises(self):
+        sandbox, f = _mock_sandbox_with_open()
+        f.write.aio = AsyncMock(side_effect=Exception("write failed"))
+
+        with patch("src.sandbox.manager.log") as mock_log:
+            await SandboxManager._write_tunnel_env_file(
+                sandbox, "sb-1", {3000: "https://tunnel-3000.example.com"}
+            )
+
+        f.close.aio.assert_awaited_once()
+        mock_log.warn.assert_called_once()
+        assert mock_log.warn.call_args[0][0] == "tunnel.urls_write_failed"
+
+    @pytest.mark.asyncio
+    async def test_open_failure_does_not_raise(self):
+        sandbox = MagicMock()
+        sandbox.open = MagicMock()
+        sandbox.open.aio = AsyncMock(side_effect=Exception("open failed"))
+
+        with patch("src.sandbox.manager.log") as mock_log:
+            await SandboxManager._write_tunnel_env_file(
+                sandbox, "sb-1", {3000: "https://tunnel-3000.example.com"}
+            )
+
+        mock_log.warn.assert_called_once()
+        assert mock_log.warn.call_args[0][0] == "tunnel.urls_write_failed"
+
+
+class TestResolveAndSetupTunnelsWritesFile:
+    """Integration of _resolve_and_setup_tunnels with the env-file write."""
+
+    @pytest.mark.asyncio
+    async def test_writes_file_when_extra_urls_present(self):
+        sandbox, f = _mock_sandbox_with_open()
+        tunnel_urls = {3000: "https://tunnel-3000.example.com"}
+
+        with patch.object(
+            SandboxManager,
+            "_resolve_tunnels",
+            new_callable=AsyncMock,
+            return_value=tunnel_urls,
+        ):
+            await SandboxManager._resolve_and_setup_tunnels(sandbox, "sb-1", False, False, [3000])
+
+        sandbox.open.aio.assert_awaited_once_with(TUNNEL_ENV_FILE_PATH, "w")
+        written = f.write.aio.call_args[0][0]
+        assert "TUNNEL_3000=https://tunnel-3000.example.com" in written
+
+    @pytest.mark.asyncio
+    async def test_does_not_write_file_when_no_extra_urls(self):
+        sandbox, _f = _mock_sandbox_with_open()
+
+        with patch.object(
+            SandboxManager,
+            "_resolve_tunnels",
+            new_callable=AsyncMock,
+            return_value={},
+        ):
+            _cs, _ttyd, extra = await SandboxManager._resolve_and_setup_tunnels(
+                sandbox, "sb-1", False, False, [3000]
+            )
+
+        assert extra is None
+        sandbox.open.aio.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_does_not_write_file_for_only_reserved_ports(self):
+        """code-server / ttyd URLs aren't extras; no file is written when those are the only ones."""
+        sandbox, _f = _mock_sandbox_with_open()
+
+        with patch.object(
+            SandboxManager,
+            "_resolve_tunnels",
+            new_callable=AsyncMock,
+            return_value={CODE_SERVER_PORT: "https://cs.example.com"},
+        ):
+            await SandboxManager._resolve_and_setup_tunnels(sandbox, "sb-1", True, False, [])
+
+        sandbox.open.aio.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_write_failure_does_not_block_return(self):
+        sandbox = MagicMock()
+        sandbox.open = MagicMock()
+        sandbox.open.aio = AsyncMock(side_effect=Exception("boom"))
+
+        with (
+            patch.object(
+                SandboxManager,
+                "_resolve_tunnels",
+                new_callable=AsyncMock,
+                return_value={3000: "https://tunnel-3000.example.com"},
+            ),
+            patch("src.sandbox.manager.log"),
+        ):
+            _cs, _ttyd, extra = await SandboxManager._resolve_and_setup_tunnels(
+                sandbox, "sb-1", False, False, [3000]
+            )
+
         assert extra == {3000: "https://tunnel-3000.example.com"}
 
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/constants.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/constants.py
@@ -4,13 +4,10 @@ CODE_SERVER_PORT = 8080
 TTYD_PORT = 7681
 TTYD_PROXY_PORT = 7680
 
-# Path inside the sandbox where extra tunnel URLs are exposed in dotenv format.
-# Local services consume via `--env-file=.tunnels.env` (Node, Bun, Vite, docker
-# compose) or read directly. Format is `TUNNEL_<port>=<url>` per line.
+# Dotenv file containing `TUNNEL_<port>=<url>` per line, consumed by local
+# services via `--env-file` or direct read.
 TUNNEL_ENV_FILE_PATH = "/workspace/.tunnels.env"
 
-# Env var carrying the comma-separated list of tunnel ports the manager will
-# resolve and write into TUNNEL_ENV_FILE_PATH. Used by the entrypoint to (a)
-# clear any stale file at boot and (b) wait for fresh URLs before running
-# repo start hooks that may depend on them.
+# Comma-separated tunnel ports the manager will resolve. Read by the entrypoint
+# to gate stale-file cleanup and the wait-for-fresh-URLs before start.sh.
 EXPECTED_TUNNEL_PORTS_ENV_VAR = "EXPECTED_TUNNEL_PORTS"

--- a/packages/sandbox-runtime/src/sandbox_runtime/constants.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/constants.py
@@ -3,3 +3,14 @@
 CODE_SERVER_PORT = 8080
 TTYD_PORT = 7681
 TTYD_PROXY_PORT = 7680
+
+# Path inside the sandbox where extra tunnel URLs are exposed in dotenv format.
+# Local services consume via `--env-file=.tunnels.env` (Node, Bun, Vite, docker
+# compose) or read directly. Format is `TUNNEL_<port>=<url>` per line.
+TUNNEL_ENV_FILE_PATH = "/workspace/.tunnels.env"
+
+# Env var carrying the comma-separated list of tunnel ports the manager will
+# resolve and write into TUNNEL_ENV_FILE_PATH. Used by the entrypoint to (a)
+# clear any stale file at boot and (b) wait for fresh URLs before running
+# repo start hooks that may depend on them.
+EXPECTED_TUNNEL_PORTS_ENV_VAR = "EXPECTED_TUNNEL_PORTS"

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -1171,13 +1171,7 @@ class SandboxSupervisor:
         return ports
 
     def _clear_stale_tunnel_env_file(self) -> None:
-        """Remove any pre-existing tunnel env file before the manager writes fresh URLs.
-
-        On snapshot restore the file is carried over from the previous session and
-        contains URLs bound to a sandbox that no longer exists. Clearing it here
-        eliminates the window where start.sh could read dead URLs before the
-        manager's overwrite arrives.
-        """
+        """Remove any pre-existing tunnel env file inherited from a snapshot."""
         path = Path(TUNNEL_ENV_FILE_PATH)
         try:
             path.unlink(missing_ok=True)
@@ -1188,28 +1182,26 @@ class SandboxSupervisor:
     async def _wait_for_tunnel_env_file(self, expected_ports: list[int]) -> bool:
         """Block until TUNNEL_ENV_FILE_PATH contains entries for all expected ports.
 
-        Bounded by DEFAULT_TUNNEL_WAIT_TIMEOUT_SECONDS (override via
-        TUNNEL_WAIT_TIMEOUT_SECONDS env var). On timeout, log and return False so
-        start.sh proceeds anyway — a Modal-side outage should degrade rather than
-        block the session forever.
-
-        Returns True if the file became ready within the timeout, False otherwise.
+        On timeout, log and return False so start.sh proceeds with degraded data
+        rather than hanging on a Modal-side outage.
         """
         if not expected_ports:
             return True
 
-        timeout_raw = os.environ.get("TUNNEL_WAIT_TIMEOUT_SECONDS")
+        timeout_seconds_raw = os.environ.get("TUNNEL_WAIT_TIMEOUT_SECONDS")
         try:
-            timeout = (
-                float(timeout_raw) if timeout_raw else self.DEFAULT_TUNNEL_WAIT_TIMEOUT_SECONDS
+            timeout_seconds = (
+                float(timeout_seconds_raw)
+                if timeout_seconds_raw
+                else self.DEFAULT_TUNNEL_WAIT_TIMEOUT_SECONDS
             )
         except ValueError:
-            timeout = self.DEFAULT_TUNNEL_WAIT_TIMEOUT_SECONDS
+            timeout_seconds = self.DEFAULT_TUNNEL_WAIT_TIMEOUT_SECONDS
 
         path = Path(TUNNEL_ENV_FILE_PATH)
         expected_prefixes = [f"TUNNEL_{p}=" for p in expected_ports]
         start_time = time.time()
-        deadline = start_time + timeout
+        deadline = start_time + timeout_seconds
 
         while time.time() < deadline:
             if path.exists():
@@ -1231,7 +1223,7 @@ class SandboxSupervisor:
             "tunnel.env_file_wait_timeout",
             path=str(path),
             ports=expected_ports,
-            timeout_seconds=timeout,
+            timeout_seconds=timeout_seconds,
         )
         return False
 
@@ -1270,12 +1262,11 @@ class SandboxSupervisor:
             repo_image_sha = os.environ.get("REPO_IMAGE_SHA", "unknown")
             self.log.info("supervisor.from_repo_image", build_sha=repo_image_sha)
 
-        # If tunnels are expected this boot, clear any stale env file before
-        # repo hooks (setup/start) can observe it. The manager will write
-        # fresh URLs after Sandbox.create() returns; we block on that file
-        # below in Phase 3 right before start.sh runs.
+        # Clear stale tunnel file on every restore: a snapshot taken with
+        # tunnels configured retains the previous session's URLs even if this
+        # session has no tunnel ports.
         expected_tunnel_ports = self._expected_tunnel_ports()
-        if expected_tunnel_ports:
+        if restored_from_snapshot or expected_tunnel_ports:
             self._clear_stale_tunnel_env_file()
 
         # Set up signal handlers
@@ -1307,9 +1298,8 @@ class SandboxSupervisor:
                 if image_build_mode and not setup_success:
                     raise RuntimeError("setup hook failed in build mode")
 
-            # Phase 3: Run runtime start hook for all non-build boots.
-            # Block on the tunnel env file first so dev servers booted by
-            # start.sh observe fresh URLs rather than absent/stale ones.
+            # Phase 3: Run runtime start hook for all non-build boots. Wait for
+            # tunnel URLs first so dev servers booted by start.sh see fresh data.
             start_success: bool | None = None
             if self.boot_mode != "build":
                 await self._wait_for_tunnel_env_file(expected_tunnel_ports)

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -22,7 +22,13 @@ from pathlib import Path
 
 import httpx
 
-from .constants import CODE_SERVER_PORT, TTYD_PORT, TTYD_PROXY_PORT
+from .constants import (
+    CODE_SERVER_PORT,
+    EXPECTED_TUNNEL_PORTS_ENV_VAR,
+    TTYD_PORT,
+    TTYD_PROXY_PORT,
+    TUNNEL_ENV_FILE_PATH,
+)
 from .log_config import configure_logging, get_logger
 
 configure_logging()
@@ -54,6 +60,8 @@ class SandboxSupervisor:
     START_SCRIPT_PATH = ".openinspect/start.sh"
     DEFAULT_SETUP_TIMEOUT_SECONDS = 300
     DEFAULT_START_TIMEOUT_SECONDS = 120
+    DEFAULT_TUNNEL_WAIT_TIMEOUT_SECONDS = 30
+    TUNNEL_WAIT_POLL_INTERVAL_SECONDS = 0.2
     CLONE_DEPTH_COMMITS = 100
     SIDECAR_TIMEOUT_SECONDS = 5
     MCP_PACKAGE_INSTALL_TIMEOUT_SECONDS = 180
@@ -1146,6 +1154,87 @@ class SandboxSupervisor:
             default_timeout_seconds=self.DEFAULT_START_TIMEOUT_SECONDS,
         )
 
+    def _expected_tunnel_ports(self) -> list[int]:
+        """Parse EXPECTED_TUNNEL_PORTS env var into a list of port ints."""
+        raw = os.environ.get(EXPECTED_TUNNEL_PORTS_ENV_VAR, "")
+        if not raw:
+            return []
+        ports: list[int] = []
+        for piece in raw.split(","):
+            piece = piece.strip()
+            if not piece:
+                continue
+            try:
+                ports.append(int(piece))
+            except ValueError:
+                self.log.warn("tunnel.expected_ports_parse_failed", value=piece, raw=raw)
+        return ports
+
+    def _clear_stale_tunnel_env_file(self) -> None:
+        """Remove any pre-existing tunnel env file before the manager writes fresh URLs.
+
+        On snapshot restore the file is carried over from the previous session and
+        contains URLs bound to a sandbox that no longer exists. Clearing it here
+        eliminates the window where start.sh could read dead URLs before the
+        manager's overwrite arrives.
+        """
+        path = Path(TUNNEL_ENV_FILE_PATH)
+        try:
+            path.unlink(missing_ok=True)
+            self.log.info("tunnel.stale_file_cleared", path=str(path))
+        except Exception as e:
+            self.log.warn("tunnel.stale_file_clear_failed", path=str(path), exc=e)
+
+    async def _wait_for_tunnel_env_file(self, expected_ports: list[int]) -> bool:
+        """Block until TUNNEL_ENV_FILE_PATH contains entries for all expected ports.
+
+        Bounded by DEFAULT_TUNNEL_WAIT_TIMEOUT_SECONDS (override via
+        TUNNEL_WAIT_TIMEOUT_SECONDS env var). On timeout, log and return False so
+        start.sh proceeds anyway — a Modal-side outage should degrade rather than
+        block the session forever.
+
+        Returns True if the file became ready within the timeout, False otherwise.
+        """
+        if not expected_ports:
+            return True
+
+        timeout_raw = os.environ.get("TUNNEL_WAIT_TIMEOUT_SECONDS")
+        try:
+            timeout = (
+                float(timeout_raw) if timeout_raw else self.DEFAULT_TUNNEL_WAIT_TIMEOUT_SECONDS
+            )
+        except ValueError:
+            timeout = self.DEFAULT_TUNNEL_WAIT_TIMEOUT_SECONDS
+
+        path = Path(TUNNEL_ENV_FILE_PATH)
+        expected_prefixes = [f"TUNNEL_{p}=" for p in expected_ports]
+        start_time = time.time()
+        deadline = start_time + timeout
+
+        while time.time() < deadline:
+            if path.exists():
+                try:
+                    lines = path.read_text().splitlines()
+                    if all(any(ln.startswith(pfx) for ln in lines) for pfx in expected_prefixes):
+                        self.log.info(
+                            "tunnel.env_file_ready",
+                            path=str(path),
+                            ports=expected_ports,
+                            wait_ms=int((time.time() - start_time) * 1000),
+                        )
+                        return True
+                except Exception as e:
+                    self.log.warn("tunnel.env_file_read_failed", path=str(path), exc=e)
+            await asyncio.sleep(self.TUNNEL_WAIT_POLL_INTERVAL_SECONDS)
+
+        self.log.warn(
+            "tunnel.env_file_wait_timeout",
+            path=str(path),
+            ports=expected_ports,
+            timeout_seconds=timeout,
+        )
+        return False
+
     async def run(self) -> None:
         """Main supervisor loop."""
         startup_start = time.time()
@@ -1181,6 +1270,14 @@ class SandboxSupervisor:
             repo_image_sha = os.environ.get("REPO_IMAGE_SHA", "unknown")
             self.log.info("supervisor.from_repo_image", build_sha=repo_image_sha)
 
+        # If tunnels are expected this boot, clear any stale env file before
+        # repo hooks (setup/start) can observe it. The manager will write
+        # fresh URLs after Sandbox.create() returns; we block on that file
+        # below in Phase 3 right before start.sh runs.
+        expected_tunnel_ports = self._expected_tunnel_ports()
+        if expected_tunnel_ports:
+            self._clear_stale_tunnel_env_file()
+
         # Set up signal handlers
         loop = asyncio.get_event_loop()
         for sig in (signal.SIGTERM, signal.SIGINT):
@@ -1211,8 +1308,11 @@ class SandboxSupervisor:
                     raise RuntimeError("setup hook failed in build mode")
 
             # Phase 3: Run runtime start hook for all non-build boots.
+            # Block on the tunnel env file first so dev servers booted by
+            # start.sh observe fresh URLs rather than absent/stale ones.
             start_success: bool | None = None
             if self.boot_mode != "build":
+                await self._wait_for_tunnel_env_file(expected_tunnel_ports)
                 start_success = await self.run_start_script()
                 if not start_success:
                     raise RuntimeError("start hook failed")

--- a/packages/sandbox-runtime/tests/test_entrypoint_tunnel_urls.py
+++ b/packages/sandbox-runtime/tests/test_entrypoint_tunnel_urls.py
@@ -1,0 +1,160 @@
+"""Tests for SandboxSupervisor tunnel-env-file handling.
+
+The supervisor owns the tunnel env file lifecycle from inside the sandbox:
+- clears any stale file at boot when tunnels are expected this session
+- blocks `start.sh` until the manager has written fresh URLs (bounded)
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from sandbox_runtime.constants import (
+    EXPECTED_TUNNEL_PORTS_ENV_VAR,
+    TUNNEL_ENV_FILE_PATH,
+)
+from sandbox_runtime.entrypoint import SandboxSupervisor
+
+
+def _make_supervisor() -> SandboxSupervisor:
+    """Create a SandboxSupervisor with minimal stable env.
+
+    Env vars read live (like EXPECTED_TUNNEL_PORTS) must be patched in the test
+    body, not here — this helper only stabilizes the constructor.
+    """
+    base_env = {
+        "SANDBOX_ID": "test-sandbox",
+        "CONTROL_PLANE_URL": "https://cp.example.com",
+        "SANDBOX_AUTH_TOKEN": "tok",
+        "REPO_OWNER": "acme",
+        "REPO_NAME": "app",
+    }
+    with patch.dict("os.environ", base_env, clear=True):
+        return SandboxSupervisor()
+
+
+class TestExpectedTunnelPorts:
+    def test_returns_empty_list_when_env_var_unset(self, monkeypatch):
+        monkeypatch.delenv(EXPECTED_TUNNEL_PORTS_ENV_VAR, raising=False)
+        sup = _make_supervisor()
+        assert sup._expected_tunnel_ports() == []
+
+    def test_parses_single_port(self, monkeypatch):
+        monkeypatch.setenv(EXPECTED_TUNNEL_PORTS_ENV_VAR, "3000")
+        sup = _make_supervisor()
+        assert sup._expected_tunnel_ports() == [3000]
+
+    def test_parses_multiple_ports(self, monkeypatch):
+        monkeypatch.setenv(EXPECTED_TUNNEL_PORTS_ENV_VAR, "3000,5173,8080")
+        sup = _make_supervisor()
+        assert sup._expected_tunnel_ports() == [3000, 5173, 8080]
+
+    def test_tolerates_whitespace(self, monkeypatch):
+        monkeypatch.setenv(EXPECTED_TUNNEL_PORTS_ENV_VAR, " 3000 , 5173 ")
+        sup = _make_supervisor()
+        assert sup._expected_tunnel_ports() == [3000, 5173]
+
+    def test_skips_unparseable_entries(self, monkeypatch):
+        monkeypatch.setenv(EXPECTED_TUNNEL_PORTS_ENV_VAR, "3000,not-a-port,5173")
+        sup = _make_supervisor()
+        assert sup._expected_tunnel_ports() == [3000, 5173]
+
+    def test_empty_string_returns_empty(self, monkeypatch):
+        monkeypatch.setenv(EXPECTED_TUNNEL_PORTS_ENV_VAR, "")
+        sup = _make_supervisor()
+        assert sup._expected_tunnel_ports() == []
+
+
+class TestClearStaleTunnelEnvFile:
+    def test_removes_existing_file(self, tmp_path, monkeypatch):
+        stub_path = tmp_path / "tunnels.env"
+        stub_path.write_text("TUNNEL_3000=https://stale.example.com\n")
+        monkeypatch.setattr("sandbox_runtime.entrypoint.TUNNEL_ENV_FILE_PATH", str(stub_path))
+
+        sup = _make_supervisor()
+        sup._clear_stale_tunnel_env_file()
+
+        assert not stub_path.exists()
+
+    def test_no_op_when_file_missing(self, tmp_path, monkeypatch):
+        stub_path = tmp_path / "tunnels.env"
+        monkeypatch.setattr("sandbox_runtime.entrypoint.TUNNEL_ENV_FILE_PATH", str(stub_path))
+
+        sup = _make_supervisor()
+        sup._clear_stale_tunnel_env_file()  # must not raise
+
+
+class TestWaitForTunnelEnvFile:
+    @pytest.mark.asyncio
+    async def test_returns_true_immediately_when_no_ports_expected(self):
+        sup = _make_supervisor()
+        assert await sup._wait_for_tunnel_env_file([]) is True
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_file_already_present(self, tmp_path, monkeypatch):
+        stub_path = tmp_path / "tunnels.env"
+        stub_path.write_text("TUNNEL_3000=https://fresh.example.com\n")
+        monkeypatch.setattr("sandbox_runtime.entrypoint.TUNNEL_ENV_FILE_PATH", str(stub_path))
+
+        sup = _make_supervisor()
+        assert await sup._wait_for_tunnel_env_file([3000]) is True
+
+    @pytest.mark.asyncio
+    async def test_returns_true_for_all_expected_ports(self, tmp_path, monkeypatch):
+        stub_path = tmp_path / "tunnels.env"
+        stub_path.write_text(
+            "TUNNEL_3000=https://a.example.com\nTUNNEL_5173=https://b.example.com\n"
+        )
+        monkeypatch.setattr("sandbox_runtime.entrypoint.TUNNEL_ENV_FILE_PATH", str(stub_path))
+
+        sup = _make_supervisor()
+        assert await sup._wait_for_tunnel_env_file([3000, 5173]) is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_timeout_when_file_missing(self, tmp_path, monkeypatch):
+        stub_path = tmp_path / "tunnels.env"
+        monkeypatch.setattr("sandbox_runtime.entrypoint.TUNNEL_ENV_FILE_PATH", str(stub_path))
+        monkeypatch.setenv("TUNNEL_WAIT_TIMEOUT_SECONDS", "0.05")
+
+        sup = _make_supervisor()
+        sup.TUNNEL_WAIT_POLL_INTERVAL_SECONDS = 0.01
+        assert await sup._wait_for_tunnel_env_file([3000]) is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_only_partial_ports_resolve(self, tmp_path, monkeypatch):
+        """If Modal only resolves a subset of ports, we time out and degrade."""
+        stub_path = tmp_path / "tunnels.env"
+        stub_path.write_text("TUNNEL_3000=https://a.example.com\n")
+        monkeypatch.setattr("sandbox_runtime.entrypoint.TUNNEL_ENV_FILE_PATH", str(stub_path))
+        monkeypatch.setenv("TUNNEL_WAIT_TIMEOUT_SECONDS", "0.05")
+
+        sup = _make_supervisor()
+        sup.TUNNEL_WAIT_POLL_INTERVAL_SECONDS = 0.01
+        assert await sup._wait_for_tunnel_env_file([3000, 5173]) is False
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_file_appears_during_wait(self, tmp_path, monkeypatch):
+        stub_path = tmp_path / "tunnels.env"
+        monkeypatch.setattr("sandbox_runtime.entrypoint.TUNNEL_ENV_FILE_PATH", str(stub_path))
+        monkeypatch.setenv("TUNNEL_WAIT_TIMEOUT_SECONDS", "1.0")
+
+        sup = _make_supervisor()
+        sup.TUNNEL_WAIT_POLL_INTERVAL_SECONDS = 0.02
+
+        async def write_after_delay() -> None:
+            await asyncio.sleep(0.05)
+            stub_path.write_text("TUNNEL_3000=https://late.example.com\n")
+
+        writer = asyncio.create_task(write_after_delay())
+        try:
+            assert await sup._wait_for_tunnel_env_file([3000]) is True
+        finally:
+            await writer
+
+
+class TestConstantValue:
+    """Sanity: the shared constant is the path we expect the manager to write."""
+
+    def test_default_path(self):
+        assert TUNNEL_ENV_FILE_PATH == "/workspace/.tunnels.env"


### PR DESCRIPTION
## Summary

When extra tunnel ports are configured in Sandbox Settings (e.g. dev server
ports 3000, 5173), Modal allocates tunnel URLs that the control plane and web
UI display. However, processes running **inside** the sandbox — including
dev/backend servers booted by `.openinspect/start.sh` — only see `localhost`.
They have no way to discover their own public URL for use in configuration
(CORS allowlists, `BASE_URL`, OAuth callbacks, etc.).

This makes URLs available via `/workspace/.tunnels.env` in dotenv format, and
coordinates the manager / entrypoint so `start.sh` observes **fresh** URLs —
never absent, never stale from a previous session.

## How it works

Two coordinated changes:

### 1. Manager writes the file, signals the entrypoint

In `_resolve_and_setup_tunnels`:

- Resolve URLs via `sandbox.tunnels()` (existing).
- Write `/workspace/.tunnels.env` via Modal's `sandbox.open()` filesystem API
  (no shell, no quoting hazard, no subprocess spawn).

In `create_sandbox` and `restore_from_snapshot`:

- Set `EXPECTED_TUNNEL_PORTS=3000,5173` in the sandbox env when extra ports
  are configured. This is the signal the entrypoint uses to wait for fresh
  URLs before `start.sh`.

### 2. Entrypoint owns the file lifecycle from inside the sandbox

In `SandboxSupervisor.run()`:

- Early in boot, unlink any pre-existing `/workspace/.tunnels.env` whenever
  `RESTORED_FROM_SNAPSHOT=true` **or** `EXPECTED_TUNNEL_PORTS` is set. On
  snapshot restore the file is carried over with URLs bound to a sandbox
  that no longer exists — clearing it eliminates the stale-URLs-visible
  window, including the "user removed tunnel ports between snapshot and
  restore" case.

- Before `run_start_script()`, wait for the file to contain a
  `TUNNEL_<port>=` line for every expected port. Bounded by
  `TUNNEL_WAIT_TIMEOUT_SECONDS` (default 30s). On timeout, log a warning
  and proceed so a Modal-side outage degrades rather than blocks the
  session forever.

Shared constants (`TUNNEL_ENV_FILE_PATH`, `EXPECTED_TUNNEL_PORTS_ENV_VAR`)
live in `sandbox_runtime.constants` so both packages reference one source
of truth.

## Why dotenv format

```
TUNNEL_3000=https://abc.modal.run
TUNNEL_5173=https://def.modal.run
```

Directly consumable by `node --env-file=/workspace/.tunnels.env`,
`bun --env-file=...`, Vite, docker compose, every dotenv loader, and shell
`source` from inside `start.sh`. Zero new parsing code on the consumer side.

## Path coverage

| Scenario | Before start.sh runs |
|---|---|
| Fresh create, no tunnels | No env var → no wait → no file (unchanged) |
| Fresh create with tunnels | Wait until manager writes file → start.sh sees fresh URLs |
| Restore, no tunnels | Stale file unlinked on `RESTORED_FROM_SNAPSHOT` → no wait → no file |
| Restore with tunnels | Stale file cleared → wait → manager writes fresh file → start.sh sees fresh URLs |
| Build mode | Never invokes the wait, never sets the env var, start.sh doesn't run |
| Warm pool sandbox | No tunnels configured at warm time → unchanged |

## Alternatives considered

- **Env vars on OpenCode**: Modal has no post-create env mutation; URLs aren't
  knowable until after `Sandbox.create()` returns. The file + entrypoint wait
  is the cleanest available primitive.
- **`/etc/profile.d`**: only reaches login shells. OpenCode (Node) and Python
  subprocesses don't see it.
- **`BASH_ENV`**: only fires for non-interactive `bash` specifically — not
  direct `execve`, not dash, not Node.
- **WebSocket bridge from control plane**: cleanest architecturally but
  changes three packages. Deferred until a second use case for "control
  plane pushes dynamic state to the runtime" appears.
- **`sandbox.exec` with bash heredoc** (a previous prototype): replaced with
  `sandbox.open()` to avoid the shell, quoting hazards, and subprocess spawn.

## Test plan

### Automated (~18 new tests, all passing)

**modal-infra** (`test_tunnel_ports.py`):

- [x] `_resolve_and_setup_tunnels` writes dotenv-formatted file via `sandbox.open()`
- [x] File closed even when write raises (try/finally)
- [x] `sandbox.open()` failure logs warning and doesn't block return
- [x] Integration: file written when extra URLs present, not when empty
- [x] code-server / ttyd alone don't trigger a file write
- [x] `EXPECTED_TUNNEL_PORTS` env var set on `create_sandbox` when ports configured
- [x] `EXPECTED_TUNNEL_PORTS` env var omitted when no ports
- [x] `EXPECTED_TUNNEL_PORTS` env var set on `restore_from_snapshot` when ports configured

**sandbox-runtime** (`test_entrypoint_tunnel_urls.py`):

- [x] `_expected_tunnel_ports()` parses single / multi / whitespace / garbage / empty
- [x] `_clear_stale_tunnel_env_file()` removes existing file, no-ops when missing
- [x] `_wait_for_tunnel_env_file()` returns True immediately for no expected ports
- [x] Returns True when file already present with all ports
- [x] Returns False on timeout when file missing
- [x] Returns False on timeout when only partial ports resolve
- [x] Returns True when file appears mid-wait

Total: 115 modal-infra + 287 sandbox-runtime, ruff clean.

### Manual

- [ ] Configure tunnel ports (e.g. 3000, 5173) in Sandbox Settings for a repo
- [ ] Start a fresh session — confirm `start.sh` sees `TUNNEL_3000` etc.
- [ ] Snapshot mid-session, modify start.sh to log `TUNNEL_3000`, restore — confirm logged value matches the **new** sandbox's URL, not the snapshot's
- [ ] Restore with tunnel ports removed from settings — confirm `/workspace/.tunnels.env` is absent (not stale)
- [ ] Verify `node --env-file=/workspace/.tunnels.env -e "console.log(process.env.TUNNEL_3000)"` prints the URL
- [ ] Verify a session without tunnel ports configured boots normally (no wait, no file)
