### PR TITLE
fix(linear-bot): keep sessions open and emit proper action activities

### DIFF
--- a/packages/control-plane/src/session/callback-notification-service.test.ts
+++ b/packages/control-plane/src/session/callback-notification-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Logger } from "../logger";
 import {
   CallbackNotificationService,
@@ -291,6 +291,153 @@ describe("CallbackNotificationService", () => {
 
       const fetchMock = (h.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch;
       expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    describe("dedup by callId", () => {
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it("fires once per callId even when events arrive past the throttle window", async () => {
+        // Anthropic emits running+completed for the same tool. OpenAI's
+        // Responses API may report only completed. Either way, one activity.
+        vi.useFakeTimers();
+        const start = 1_700_000_000_000;
+        vi.setSystemTime(start);
+
+        vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+          callback_context: JSON.stringify({ channel: "C123" }),
+          source: "slack",
+        });
+        const fetchMock = vi.mocked(
+          (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
+        );
+        fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
+
+        await harness.service.notifyToolCall("msg-1", {
+          type: "tool_call",
+          tool: "bash",
+          callId: "call-abc",
+          status: "running",
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        // Advance well past the 3s throttle so the second call is throttle-eligible
+        vi.setSystemTime(start + 5_000);
+
+        await harness.service.notifyToolCall("msg-1", {
+          type: "tool_call",
+          tool: "bash",
+          callId: "call-abc",
+          status: "completed",
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      });
+
+      it("fires once per distinct callId across many tool calls", async () => {
+        vi.useFakeTimers();
+        let now = 1_700_000_000_000;
+        vi.setSystemTime(now);
+
+        vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+          callback_context: JSON.stringify({ channel: "C123" }),
+          source: "slack",
+        });
+        const fetchMock = vi.mocked(
+          (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
+        );
+        fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
+
+        for (let i = 0; i < 3; i++) {
+          // Each tool emits running then completed; only running should fire
+          await harness.service.notifyToolCall("msg-1", {
+            type: "tool_call",
+            tool: "bash",
+            callId: `call-${i}`,
+            status: "running",
+          });
+          await harness.service.notifyToolCall("msg-1", {
+            type: "tool_call",
+            tool: "bash",
+            callId: `call-${i}`,
+            status: "completed",
+          });
+          now += 3_001;
+          vi.setSystemTime(now);
+        }
+
+        expect(fetchMock).toHaveBeenCalledTimes(3);
+      });
+
+      it("evicts the oldest callId (FIFO) once the cap is exceeded", async () => {
+        vi.useFakeTimers();
+        let now = 1_700_000_000_000;
+        vi.setSystemTime(now);
+
+        vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+          callback_context: JSON.stringify({ channel: "C123" }),
+          source: "slack",
+        });
+        const fetchMock = vi.mocked(
+          (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
+        );
+        fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
+
+        // Cap is 500. Fire 501 distinct callIds; the first one ("call-0")
+        // should be evicted when "call-500" is admitted.
+        for (let i = 0; i <= 500; i++) {
+          await harness.service.notifyToolCall("msg-1", {
+            type: "tool_call",
+            tool: "bash",
+            callId: `call-${i}`,
+            status: "running",
+          });
+          now += 3_001;
+          vi.setSystemTime(now);
+        }
+        expect(fetchMock).toHaveBeenCalledTimes(501);
+
+        // call-0 was evicted, so a re-fire is treated as a fresh tool call
+        await harness.service.notifyToolCall("msg-1", {
+          type: "tool_call",
+          tool: "bash",
+          callId: "call-0",
+          status: "running",
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(502);
+
+        // call-1 is still in the set (it became the new oldest), so it dedupes
+        await harness.service.notifyToolCall("msg-1", {
+          type: "tool_call",
+          tool: "bash",
+          callId: "call-1",
+          status: "running",
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(502);
+      });
+
+      it("falls back to throttle-only behavior when callId is missing", async () => {
+        vi.useFakeTimers();
+        const start = 1_700_000_000_000;
+        vi.setSystemTime(start);
+
+        vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+          callback_context: JSON.stringify({ channel: "C123" }),
+          source: "slack",
+        });
+        const fetchMock = vi.mocked(
+          (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
+        );
+        fetchMock.mockResolvedValue(new Response("ok", { status: 200 }));
+
+        await harness.service.notifyToolCall("msg-1", { type: "tool_call", tool: "bash" });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        // No callId on either event — second event past throttle should fire
+        vi.setSystemTime(start + 5_000);
+        await harness.service.notifyToolCall("msg-1", { type: "tool_call", tool: "read" });
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      });
     });
   });
 

--- a/packages/control-plane/src/session/callback-notification-service.test.ts
+++ b/packages/control-plane/src/session/callback-notification-service.test.ts
@@ -438,6 +438,55 @@ describe("CallbackNotificationService", () => {
         await harness.service.notifyToolCall("msg-1", { type: "tool_call", tool: "read" });
         expect(fetchMock).toHaveBeenCalledTimes(2);
       });
+
+      it("retries on a later event when the first delivery for a callId fails", async () => {
+        // markCallIdNotified runs only on response.ok, so a transient failure
+        // (e.g. network error or non-2xx) on Anthropic's "running" event must
+        // not prevent the subsequent "completed" event from re-delivering.
+        vi.useFakeTimers();
+        const start = 1_700_000_000_000;
+        vi.setSystemTime(start);
+
+        vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+          callback_context: JSON.stringify({ channel: "C123" }),
+          source: "slack",
+        });
+        const fetchMock = vi.mocked(
+          (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
+        );
+        fetchMock
+          .mockRejectedValueOnce(new Error("network"))
+          .mockResolvedValue(new Response("ok", { status: 200 }));
+
+        await harness.service.notifyToolCall("msg-1", {
+          type: "tool_call",
+          tool: "bash",
+          callId: "call-retry",
+          status: "running",
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        // Advance past the throttle window so the retry is eligible.
+        vi.setSystemTime(start + 5_000);
+
+        await harness.service.notifyToolCall("msg-1", {
+          type: "tool_call",
+          tool: "bash",
+          callId: "call-retry",
+          status: "completed",
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+
+        // Third event for the same callId after a successful delivery should dedupe.
+        vi.setSystemTime(start + 10_000);
+        await harness.service.notifyToolCall("msg-1", {
+          type: "tool_call",
+          tool: "bash",
+          callId: "call-retry",
+          status: "completed",
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      });
     });
   });
 

--- a/packages/control-plane/src/session/callback-notification-service.ts
+++ b/packages/control-plane/src/session/callback-notification-service.ts
@@ -275,15 +275,15 @@ export class CallbackNotificationService {
 
     // Dedup before throttle so a skipped duplicate doesn't burn the rate-limit
     // window. Anthropic emits running+completed for the same callId; OpenAI's
-    // Responses API may emit only completed. Fire once per callId either way.
+    // Responses API may emit only completed. Fire once per successfully
+    // delivered callId either way — failed deliveries do not mark the set, so
+    // a later event for the same callId can retry.
     if (callId && this.notifiedCallIds.has(callId)) return;
 
     // Throttle: max 1 per 3 seconds
     const now = Date.now();
     if (now - this._lastToolCallCallbackTs < 3000) return;
     this._lastToolCallCallbackTs = now;
-
-    if (callId) this.markCallIdNotified(callId);
 
     const tool = event.tool ?? "unknown";
 
@@ -344,6 +344,10 @@ export class CallbackNotificationService {
       });
 
       if (response.ok) {
+        // Mark only on success so a transient failure doesn't dedupe the next
+        // event for this callId (Anthropic's running and completed may be
+        // seconds apart for long-running tools — the second event should retry).
+        if (callId) this.markCallIdNotified(callId);
         this.log.info("callback.tool_call", {
           message_id: messageId,
           session_id: sessionId,

--- a/packages/control-plane/src/session/callback-notification-service.ts
+++ b/packages/control-plane/src/session/callback-notification-service.ts
@@ -41,18 +41,35 @@ export interface CallbackServiceDeps {
   getSessionId: () => string;
 }
 
+/**
+ * Per-session cap on remembered tool callIds. Used to dedupe notifications
+ * across provider lifecycles (Anthropic emits running+completed, OpenAI may
+ * emit only completed). FIFO eviction; the failure mode on overflow is a
+ * single duplicate Linear/Slack activity, not data loss.
+ */
+const NOTIFIED_CALL_IDS_CAP = 500;
+
 export class CallbackNotificationService {
   private readonly repository: CallbackRepository;
   private readonly env: CallbackServiceEnv;
   private readonly log: Logger;
   private readonly getSessionId: () => string;
   private _lastToolCallCallbackTs = 0;
+  private readonly notifiedCallIds = new Set<string>();
 
   constructor(deps: CallbackServiceDeps) {
     this.repository = deps.repository;
     this.env = deps.env;
     this.log = deps.log;
     this.getSessionId = deps.getSessionId;
+  }
+
+  private markCallIdNotified(callId: string): void {
+    this.notifiedCallIds.add(callId);
+    if (this.notifiedCallIds.size > NOTIFIED_CALL_IDS_CAP) {
+      const oldest = this.notifiedCallIds.values().next().value;
+      if (oldest !== undefined) this.notifiedCallIds.delete(oldest);
+    }
   }
 
   /**
@@ -254,10 +271,19 @@ export class CallbackNotificationService {
       status?: string;
     }
   ): Promise<void> {
+    const callId = event.callId ?? event.call_id ?? "";
+
+    // Dedup before throttle so a skipped duplicate doesn't burn the rate-limit
+    // window. Anthropic emits running+completed for the same callId; OpenAI's
+    // Responses API may emit only completed. Fire once per callId either way.
+    if (callId && this.notifiedCallIds.has(callId)) return;
+
     // Throttle: max 1 per 3 seconds
     const now = Date.now();
     if (now - this._lastToolCallCallbackTs < 3000) return;
     this._lastToolCallCallbackTs = now;
+
+    if (callId) this.markCallIdNotified(callId);
 
     const tool = event.tool ?? "unknown";
 
@@ -296,7 +322,6 @@ export class CallbackNotificationService {
 
     const sessionId = this.getSessionId();
     const context = JSON.parse(message.callback_context);
-    const callId = event.callId ?? event.call_id ?? "";
 
     const payloadData = {
       sessionId,

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -312,6 +312,30 @@ describe("SessionSandboxEventProcessor", () => {
       expect(h.updateLastActivity).toHaveBeenCalledWith(expect.any(Number));
     });
 
+    it("notifies tool_call regardless of status (provider-agnostic)", async () => {
+      // Anthropic lifecycle uses status="running"; OpenAI's Responses API may
+      // only emit status="completed". Both should reach notifyToolCall so the
+      // service-level dedup decides whether to fire.
+      for (const status of ["running", "completed", "in_progress"]) {
+        const h = createProcessor();
+        await h.processor.processSandboxEvent({
+          type: "tool_call",
+          tool: "bash",
+          args: { command: "ls" },
+          callId: `call-${status}`,
+          status,
+          messageId: "msg-1",
+          sandboxId: "sb-1",
+          timestamp: 1000,
+        });
+
+        expect(h.callbackService.notifyToolCall).toHaveBeenCalledWith(
+          "msg-1",
+          expect.objectContaining({ type: "tool_call", status, callId: `call-${status}` })
+        );
+      }
+    });
+
     it("resets activity timer on step_start", async () => {
       const h = createProcessor();
       await h.processor.processSandboxEvent({

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -138,7 +138,7 @@ export class SessionSandboxEventProcessor {
       }
       this.deps.broadcast({ type: "sandbox_event", event });
 
-      if (messageId && event.status === "running") {
+      if (messageId) {
         this.deps.ctx.waitUntil(
           this.deps.callbackService.notifyToolCall(messageId, event).catch((error) => {
             this.deps.log.error("callback.tool_call.background_error", {

--- a/packages/linear-bot/src/callbacks.helpers.test.ts
+++ b/packages/linear-bot/src/callbacks.helpers.test.ts
@@ -5,60 +5,96 @@ import { formatCompletionComment, formatToolAction, isValidToolCallPayload } fro
 
 describe("formatToolAction", () => {
   it("edit_file with filepath", () => {
-    expect(formatToolAction("edit_file", { filepath: "src/main.ts" })).toBe(
-      "Editing `src/main.ts`"
-    );
+    expect(formatToolAction("edit_file", { filepath: "src/main.ts" })).toEqual({
+      action: "Edit",
+      parameter: "src/main.ts",
+    });
   });
 
   it("write_file with path", () => {
-    expect(formatToolAction("write_file", { path: "out/bundle.js" })).toBe(
-      "Editing `out/bundle.js`"
-    );
+    expect(formatToolAction("write_file", { path: "out/bundle.js" })).toEqual({
+      action: "Edit",
+      parameter: "out/bundle.js",
+    });
   });
 
   it("edit_file falls back to 'file' when no filepath or path", () => {
-    expect(formatToolAction("edit_file", {})).toBe("Editing `file`");
+    expect(formatToolAction("edit_file", {})).toEqual({ action: "Edit", parameter: "file" });
   });
 
   it("read_file with filepath", () => {
-    expect(formatToolAction("read_file", { filepath: "README.md" })).toBe("Reading `README.md`");
+    expect(formatToolAction("read_file", { filepath: "README.md" })).toEqual({
+      action: "Read",
+      parameter: "README.md",
+    });
   });
 
   it("read_file with path", () => {
-    expect(formatToolAction("read_file", { path: "docs/guide.md" })).toBe(
-      "Reading `docs/guide.md`"
-    );
+    expect(formatToolAction("read_file", { path: "docs/guide.md" })).toEqual({
+      action: "Read",
+      parameter: "docs/guide.md",
+    });
   });
 
   it("read_file falls back to 'file' when no filepath or path", () => {
-    expect(formatToolAction("read_file", {})).toBe("Reading `file`");
+    expect(formatToolAction("read_file", {})).toEqual({ action: "Read", parameter: "file" });
   });
 
   it("bash with command", () => {
-    expect(formatToolAction("bash", { command: "npm test" })).toBe("Running `npm test`");
+    expect(formatToolAction("bash", { command: "npm test" })).toEqual({
+      action: "Run",
+      parameter: "npm test",
+    });
   });
 
   it("execute_command with cmd", () => {
-    expect(formatToolAction("execute_command", { cmd: "ls -la" })).toBe("Running `ls -la`");
+    expect(formatToolAction("execute_command", { cmd: "ls -la" })).toEqual({
+      action: "Run",
+      parameter: "ls -la",
+    });
   });
 
   it("bash with command >80 chars truncates to 77 + ...", () => {
     const longCmd = "a".repeat(100);
-    const result = formatToolAction("bash", { command: longCmd });
-    expect(result).toBe(`Running \`${"a".repeat(77)}...\``);
+    expect(formatToolAction("bash", { command: longCmd })).toEqual({
+      action: "Run",
+      parameter: `${"a".repeat(77)}...`,
+    });
   });
 
   it("bash with command exactly 80 chars is not truncated", () => {
     const cmd = "a".repeat(80);
-    expect(formatToolAction("bash", { command: cmd })).toBe(`Running \`${cmd}\``);
+    expect(formatToolAction("bash", { command: cmd })).toEqual({
+      action: "Run",
+      parameter: cmd,
+    });
   });
 
-  it("bash with no command renders empty", () => {
-    expect(formatToolAction("bash", {})).toBe("Running ``");
+  it("bash with no command falls back to a placeholder so parameter is never empty", () => {
+    // Linear's API rejects action activities with empty `parameter` fields.
+    expect(formatToolAction("bash", {})).toEqual({ action: "Run", parameter: "(no command)" });
   });
 
-  it("unknown tool → 'Using tool: {name}'", () => {
-    expect(formatToolAction("search_files", { query: "foo" })).toBe("Using tool: search_files");
+  it("unknown tool uses the tool name as action and a string arg as parameter", () => {
+    expect(formatToolAction("search_files", { query: "foo" })).toEqual({
+      action: "search_files",
+      parameter: "foo",
+    });
+  });
+
+  it("unknown tool with no string args falls back to a placeholder parameter", () => {
+    expect(formatToolAction("noop", { count: 3 })).toEqual({
+      action: "noop",
+      parameter: "(no args)",
+    });
+  });
+
+  it("unknown tool truncates very long string args to 200 chars", () => {
+    const long = "x".repeat(500);
+    const result = formatToolAction("fetch_url", { url: long });
+    expect(result.action).toBe("fetch_url");
+    expect(result.parameter).toHaveLength(200);
+    expect(result.parameter).toBe("x".repeat(200));
   });
 });
 

--- a/packages/linear-bot/src/callbacks.ts
+++ b/packages/linear-bot/src/callbacks.ts
@@ -130,7 +130,9 @@ export function formatToolAction(
     default: {
       const firstStringArg = Object.values(args).find((v) => typeof v === "string");
       return {
-        action: tool,
+        // Linear rejects activities with an empty `action`; the upstream
+        // validator allows tool === "" so guard here.
+        action: tool || "Tool",
         parameter: firstStringArg ? String(firstStringArg).slice(0, 200) : "(no args)",
       };
     }

--- a/packages/linear-bot/src/callbacks.ts
+++ b/packages/linear-bot/src/callbacks.ts
@@ -104,20 +104,36 @@ callbacksRouter.post("/complete", async (c) => {
 
 // ─── Tool Call Callback ──────────────────────────────────────────────────────
 
-export function formatToolAction(tool: string, args: Record<string, unknown>): string {
+/**
+ * Linear's Agent API requires `action`-typed activities to carry `action` and
+ * `parameter` fields (not `body`). The `action` is the verb shown in the UI,
+ * the `parameter` is the operand. Both fields must be present and non-empty.
+ */
+export function formatToolAction(
+  tool: string,
+  args: Record<string, unknown>
+): { action: string; parameter: string } {
   switch (tool) {
     case "edit_file":
     case "write_file":
-      return `Editing \`${args.filepath || args.path || "file"}\``;
+      return { action: "Edit", parameter: String(args.filepath || args.path || "file") };
     case "read_file":
-      return `Reading \`${args.filepath || args.path || "file"}\``;
+      return { action: "Read", parameter: String(args.filepath || args.path || "file") };
     case "bash":
     case "execute_command": {
       const cmd = String(args.command || args.cmd || "");
-      return `Running \`${cmd.length > 80 ? cmd.slice(0, 77) + "..." : cmd}\``;
+      return {
+        action: "Run",
+        parameter: cmd.length > 80 ? cmd.slice(0, 77) + "..." : cmd || "(no command)",
+      };
     }
-    default:
-      return `Using tool: ${tool}`;
+    default: {
+      const firstStringArg = Object.values(args).find((v) => typeof v === "string");
+      return {
+        action: tool,
+        parameter: firstStringArg ? String(firstStringArg).slice(0, 200) : "(no args)",
+      };
+    }
   }
 }
 
@@ -224,11 +240,11 @@ callbacksRouter.post("/tool_call", async (c) => {
       }
 
       try {
-        const description = formatToolAction(payload.tool, payload.args);
+        const { action, parameter } = formatToolAction(payload.tool, payload.args);
         await emitAgentActivity(
           client,
           context.agentSessionId,
-          { type: "action", body: description },
+          { type: "action", action, parameter },
           true
         );
         log.info("callback.tool_call", {

--- a/packages/linear-bot/src/utils/linear-client.ts
+++ b/packages/linear-bot/src/utils/linear-client.ts
@@ -93,7 +93,8 @@ export async function getOAuthToken(env: Env, orgId: string): Promise<string | n
     });
 
     if (!res.ok) {
-      log.error("oauth.refresh_failed", { org_id: orgId, status: res.status });
+      const errBody = await res.text();
+      log.error("oauth.refresh_failed", { org_id: orgId, status: res.status, body: errBody });
       return null;
     }
 

--- a/packages/linear-bot/src/utils/linear-client.ts
+++ b/packages/linear-bot/src/utils/linear-client.ts
@@ -93,8 +93,29 @@ export async function getOAuthToken(env: Env, orgId: string): Promise<string | n
     });
 
     if (!res.ok) {
-      const errBody = await res.text();
-      log.error("oauth.refresh_failed", { org_id: orgId, status: res.status, body: errBody });
+      // RFC 6749 OAuth error responses carry `error` and `error_description` fields.
+      // Extract those so we can distinguish invalid_grant from invalid_client without
+      // logging the raw body (which contained client_secret and refresh_token in the
+      // request — and could be reflected by a misconfigured upstream).
+      const rawBody = await res.text();
+      let oauthError: string | undefined;
+      let oauthErrorDescription: string | undefined;
+      try {
+        const parsed = JSON.parse(rawBody) as { error?: unknown; error_description?: unknown };
+        if (typeof parsed.error === "string") oauthError = parsed.error;
+        if (typeof parsed.error_description === "string") {
+          oauthErrorDescription = parsed.error_description;
+        }
+      } catch {
+        // Non-JSON body — fall back to a bounded truncation below.
+      }
+      log.error("oauth.refresh_failed", {
+        org_id: orgId,
+        status: res.status,
+        oauth_error: oauthError,
+        oauth_error_description: oauthErrorDescription,
+        body_snippet: oauthError ? undefined : rawBody.slice(0, 500),
+      });
       return null;
     }
 

--- a/packages/linear-bot/src/webhook-handler.ts
+++ b/packages/linear-bot/src/webhook-handler.ts
@@ -297,7 +297,7 @@ async function handleFollowUp(
 
   if (promptRes.ok) {
     await emitAgentActivity(client, agentSessionId, {
-      type: "response",
+      type: "thought",
       body: `Follow-up sent to existing session.\n\n[View session](${env.WEB_APP_URL}/session/${existingSession.sessionId})`,
     });
   } else {
@@ -644,7 +644,7 @@ async function handleNewSession(
   }
 
   await emitAgentActivity(client, agentSessionId, {
-    type: "response",
+    type: "thought",
     body: `Working on \`${repoFullName}\` with **${model}**.\n\n${classificationReasoning ? `*${classificationReasoning}*\n\n` : ""}[View session](${env.WEB_APP_URL}/session/${session.sessionId})`,
   });
 


### PR DESCRIPTION
## Summary

Three related fixes for the Linear integration so OpenAI-backed sessions work end-to-end and intermediate status updates don't terminate the agent session early. Ported from the prod repo (commits e8db818, 82a69b4, 623a218) as a single squashed commit.

- **Keep agent sessions open during in-progress updates** — `webhook-handler.ts` was sending the initial "Working on `<repo>`" message and the "Follow-up sent" message as `type: "response"`, which Linear's Agent API treats as terminal. Both now use `type: "thought"`. The terminal response is still sent from `callbacks/complete` when the sandbox emits `execution_complete`. Also include the OAuth token endpoint response body in `oauth.refresh_failed` logs so we can distinguish `invalid_grant` from `invalid_client`.

- **Dedupe tool_call notifications by callId** — the gate in `sandbox-events.ts` only fired when `event.status === "running"`. Anthropic's lifecycle passes through `running`, but OpenAI's Responses API (used by gpt-5.x codex models) may skip directly to `completed` — so no Linear "action" activities were ever emitted for those sessions. Drop the status filter and dedupe by `callId` inside `CallbackNotificationService`. The `notifiedCallIds` set is bounded at 500 entries with FIFO eviction.

- **Emit action activities with `action`+`parameter` fields** — Linear's Agent API rejects `activityCreate` calls where `type: "action"` carries only a `body` field; it requires distinct `action` (verb) and `parameter` (operand) fields. `formatToolAction` now returns an `{ action, parameter }` pair, and the `tool_call` callback spreads them into `agentActivity` content. Placeholders (`"(no command)"`, `"(no args)"`) cover the rare cases where args are missing so neither field is ever empty. This bug only surfaced after the dedup fix above — before that, no action activities were ever sent for OpenAI sessions, so the shape mismatch went unnoticed.

## Test plan

- [x] `npm run typecheck -w @open-inspect/linear-bot` — passes
- [x] `npm run test -w @open-inspect/linear-bot` — 105 tests pass (includes new dedup/format tests)
- [x] `npm run test -w @open-inspect/control-plane` — 1124 tests pass (includes new callId dedup, FIFO eviction, and provider-agnostic firing tests)
- [x] ESLint clean on all 8 changed files
- [ ] Verify in Linear that a long-running OpenAI session no longer closes early after the initial "Working on…" message
- [ ] Verify that tool activities appear in Linear's UI with `Run`/`Edit`/`Read` verbs and the command/path as the parameter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool-call notifications now deduplicate by call identifier, avoiding duplicate callbacks
  * OAuth token refresh failures now log response body details for clearer diagnostics

* **New Features**
  * Tool action payloads now use structured {action, parameter} fields
  * Tool-call callbacks are emitted for multiple event statuses (not just one)

* **Other**
  * Agent activity type for follow-up/session notices changed from "response" to "thought"

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->