### PR TITLE
docs: document /workspace/.tunnels.env contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ Every session runs in an isolated Modal sandbox with a full development environm
   and UI verification
 - **Code-server:** Optional browser-based VS Code connected to the session workspace
 - **Web terminal:** ttyd-powered terminal accessible from the session UI
-- **Port tunneling:** Expose up to 10 dev server ports via encrypted tunnels
+- **Port tunneling:** Expose up to 10 dev server ports via encrypted tunnels. URLs are available
+  in-sandbox at `/workspace/.tunnels.env` before `.openinspect/start.sh` runs
+  ([details](docs/HOW_IT_WORKS.md#tunnel-urls-inside-the-sandbox))
 - **Repo secrets:** AES-256-GCM encrypted, scoped per-repo or globally, injected as env vars at
   spawn time. Supports bulk `.env` paste import
 

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -240,6 +240,32 @@ To minimize perceived latency, sandboxes warm proactively:
 - By the time you hit enter, the sandbox may already be ready
 - If restore is fast enough, you won't notice any delay
 
+### Tunnel URLs Inside the Sandbox
+
+When a session uses the `tunnelPorts` sandbox setting, the resolved tunnel URLs are written to
+`/workspace/.tunnels.env` so processes started by `.openinspect/start.sh` (or by the agent later)
+can read them locally.
+
+```dotenv
+# /workspace/.tunnels.env
+TUNNEL_3000=https://abc123-3000.modal.host
+TUNNEL_5173=https://abc123-5173.modal.host
+```
+
+This dotenv shape is consumed directly by `node --env-file=...`, `bun --env-file=...`, Vite,
+`docker compose --env-file=...`, and other dotenv loaders — no parsing required.
+
+**Boot ordering.** On every non-build boot, the supervisor:
+
+1. Clears any stale file inherited from a snapshot.
+2. Waits up to `TUNNEL_WAIT_TIMEOUT_SECONDS` (default `30`) for fresh URLs.
+3. Runs `.openinspect/start.sh`.
+
+If the wait times out (e.g. a Modal-side outage), `start.sh` proceeds without fresh local URLs and
+the supervisor logs `tunnel.env_file_wait_timeout`. The control plane still receives and broadcasts
+the URLs to clients on a separate path. The file is not written when `tunnelPorts` is empty or in
+build mode.
+
 ---
 
 ## How Prompts Flow Through the System

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -252,8 +252,9 @@ TUNNEL_3000=https://abc123-3000.modal.host
 TUNNEL_5173=https://abc123-5173.modal.host
 ```
 
-This dotenv shape is consumed directly by `node --env-file=...`, `bun --env-file=...`, Vite,
-`docker compose --env-file=...`, and other dotenv loaders — no parsing required.
+This dotenv shape works directly with tools that accept an env-file path — `node --env-file=...`,
+`bun --env-file=...`, `docker compose --env-file=...`. The format is plain `KEY=value`, so any other
+dotenv consumer can read it without parsing.
 
 **Boot ordering.** On every non-build boot, the supervisor:
 


### PR DESCRIPTION
## Summary

Follow-up documentation for #663. The PR exposed tunnel URLs to in-sandbox processes via `/workspace/.tunnels.env`, but didn't document the file or the `start.sh` ordering guarantee anywhere user-facing.

- **`docs/HOW_IT_WORKS.md`** — new `### Tunnel URLs Inside the Sandbox` subsection under *The Sandbox Lifecycle*. Covers path, dotenv format, the boot-ordering steps (clear-stale → wait-fresh → run `start.sh`), `TUNNEL_WAIT_TIMEOUT_SECONDS` default, and the timeout-fallback behavior.
- **`README.md`** — expanded the existing *Port tunneling* bullet to mention `/workspace/.tunnels.env` and link to the new section so anyone configuring `tunnelPorts` can find the in-sandbox contract.

Intentionally **not** touched:
- `docs/internal/sandbox-settings-design.md` — design history; the "magic env var" note is the resolved approach.
- `packages/modal-infra/README.md` — scope is deployment/infra, not runtime contract.

## Test plan

- [ ] Render `docs/HOW_IT_WORKS.md` on GitHub and confirm the dotenv code block, ordered list, and `[details]` link from README all render correctly
- [ ] Click through from `README.md#port-tunneling` to the new section anchor
- [ ] Prettier passes (`npx prettier --check README.md docs/HOW_IT_WORKS.md`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded sandbox docs with clearer port-tunneling guidance and links to deeper details.
  * Documented that resolved tunnel URLs are emitted into an env file for local processes to consume before startup, plus the startup sequence that waits briefly for URLs then proceeds if none arrive.
  * Clarified conditions when the env file is not written and how URLs are still propagated to external clients.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->