### PR TITLE
refactor: clean up web session display constants

### DIFF
--- a/packages/web/src/components/slack-notify-event.tsx
+++ b/packages/web/src/components/slack-notify-event.tsx
@@ -7,6 +7,7 @@ import {
   type SlackNotifyToolEnvelope,
 } from "@open-inspect/shared";
 import type { SandboxEvent } from "@/types/session";
+import { formatSessionEventTime } from "@/lib/time";
 import { getSafeExternalUrl } from "@/lib/urls";
 import { ChevronRightIcon, ErrorIcon, LinkIcon, SlackIcon } from "@/components/ui/icons";
 
@@ -96,10 +97,7 @@ export function SlackNotifyEvent({
   const argsChannel = event.args?.channel;
   const channelInput =
     success?.channelInput ?? (typeof argsChannel === "string" ? argsChannel : undefined);
-  const time = new Date(event.timestamp * 1000).toLocaleTimeString([], {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  const time = formatSessionEventTime(event.timestamp);
 
   let summaryLine: string;
   if (success) {

--- a/packages/web/src/components/tool-call-group.tsx
+++ b/packages/web/src/components/tool-call-group.tsx
@@ -2,6 +2,7 @@
 
 import { memo, useState } from "react";
 import type { SandboxEvent } from "@/types/session";
+import { formatSessionEventTime } from "@/lib/time";
 import { formatToolGroup } from "@/lib/tool-formatters";
 import { ToolCallItem } from "./tool-call-item";
 import {
@@ -42,10 +43,7 @@ export const ToolCallGroup = memo(
 
     const formatted = formatToolGroup(events);
     const firstEvent = events[0];
-    const time = new Date(firstEvent.timestamp * 1000).toLocaleTimeString([], {
-      hour: "2-digit",
-      minute: "2-digit",
-    });
+    const time = formatSessionEventTime(firstEvent.timestamp);
 
     const toggleItem = (itemId: string) => {
       setExpandedItems((prev) => {

--- a/packages/web/src/components/tool-call-item.tsx
+++ b/packages/web/src/components/tool-call-item.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { SandboxEvent } from "@/types/session";
+import { formatSessionEventTime } from "@/lib/time";
 import { formatToolCall } from "@/lib/tool-formatters";
 import { SlackNotifyEvent } from "./slack-notify-event";
 import {
@@ -63,10 +64,7 @@ export function ToolCallItem({ event, isExpanded, onToggle, showTime = true }: T
 
   const formatted = formatToolCall(event);
   const isApplyPatch = event.tool?.toLowerCase() === "apply_patch";
-  const time = new Date(event.timestamp * 1000).toLocaleTimeString([], {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+  const time = formatSessionEventTime(event.timestamp);
 
   const { args, output } = formatted.getDetails();
   const patchText = isApplyPatch && typeof args?.patchText === "string" ? args.patchText : null;

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -21,6 +21,13 @@ const WS_URL = process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:8787";
 const WS_CLOSE_AUTH_REQUIRED = 4001;
 const WS_CLOSE_SESSION_EXPIRED = 4002;
 
+const MAX_RECONNECT_ATTEMPTS = 5;
+const RECONNECT_BASE_DELAY_MS = 1000;
+const MAX_RECONNECT_DELAY_MS = 30000;
+const PROMPT_SUBSCRIPTION_RETRY_DELAY_MS = 500;
+const HISTORY_PAGE_SIZE = 200;
+const PING_INTERVAL_MS = 30000;
+
 interface Message {
   id: string;
   authorId: string;
@@ -614,8 +621,11 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
 
       // Only reconnect if mounted and not a clean close
       if (mountedRef.current && !event.wasClean) {
-        if (reconnectAttempts.current < 5) {
-          const delay = Math.min(1000 * Math.pow(2, reconnectAttempts.current), 30000);
+        if (reconnectAttempts.current < MAX_RECONNECT_ATTEMPTS) {
+          const delay = Math.min(
+            RECONNECT_BASE_DELAY_MS * Math.pow(2, reconnectAttempts.current),
+            MAX_RECONNECT_DELAY_MS
+          );
           reconnectAttempts.current++;
           console.log(`Reconnecting in ${delay}ms (attempt ${reconnectAttempts.current})`);
 
@@ -626,7 +636,7 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
           }, delay);
         } else {
           // Exhausted reconnection attempts
-          console.error("WebSocket reconnection failed after 5 attempts");
+          console.error(`WebSocket reconnection failed after ${MAX_RECONNECT_ATTEMPTS} attempts`);
           setConnectionError("Connection lost. Please check your network and try reconnecting.");
         }
       }
@@ -646,7 +656,10 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
     if (!subscribedRef.current) {
       console.error("Not subscribed yet, waiting...");
       // Retry after a short delay
-      setTimeout(() => sendPrompt(content, model, reasoningEffort), 500);
+      setTimeout(
+        () => sendPrompt(content, model, reasoningEffort),
+        PROMPT_SUBSCRIPTION_RETRY_DELAY_MS
+      );
       return;
     }
 
@@ -711,7 +724,7 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
       JSON.stringify({
         type: "fetch_history",
         cursor: cursorRef.current,
-        limit: 200,
+        limit: HISTORY_PAGE_SIZE,
       })
     );
   }, [hasMoreHistory, loadingHistory]);
@@ -747,13 +760,13 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
     };
   }, [connect]);
 
-  // Ping every 30 seconds to keep connection alive
+  // Ping periodically to keep connection alive.
   useEffect(() => {
     const pingInterval = setInterval(() => {
       if (wsRef.current?.readyState === WebSocket.OPEN) {
         wsRef.current.send(JSON.stringify({ type: "ping" }));
       }
-    }, 30000);
+    }, PING_INTERVAL_MS);
 
     return () => clearInterval(pingInterval);
   }, []);

--- a/packages/web/src/lib/time.ts
+++ b/packages/web/src/lib/time.ts
@@ -2,6 +2,18 @@
  * Time formatting utilities for displaying relative timestamps.
  */
 
+const SESSION_EVENT_TIME_FORMAT: Intl.DateTimeFormatOptions = {
+  hour: "2-digit",
+  minute: "2-digit",
+};
+
+/**
+ * Format a session event timestamp, stored in seconds, as a compact local time.
+ */
+export function formatSessionEventTime(timestampSeconds: number): string {
+  return new Date(timestampSeconds * 1000).toLocaleTimeString([], SESSION_EVENT_TIME_FORMAT);
+}
+
 /**
  * Format a timestamp as a relative time string (e.g., "2d", "3h", "5m").
  * Returns "just now" for very recent timestamps.


### PR DESCRIPTION
## Summary
- Centralize session event time formatting in `formatSessionEventTime`
- Replace inline WebSocket retry, history, and ping values with named constants

## Verification
- `npm run lint -w @open-inspect/web`
- `npm test -w @open-inspect/web`
- `npm run typecheck -w @open-inspect/web`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/49dd345f26374c6bc6c76ab237603180)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified time formatting across all session event displays to ensure consistent timestamp representation throughout the application interface.

* **Improvements**
  * Improved WebSocket connection reliability with enhanced reconnection handling, configurable retry limits, and optimized backoff timing for failed connection attempts.
  * Enhanced application performance through refined communication settings, including optimized ping intervals and history data pagination configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/668?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->