### PR TITLE
Require verified GitHub email for domain allowlist

### DIFF
--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getVerifiedPrimaryGitHubEmail } from "./auth";
+
+describe("getVerifiedPrimaryGitHubEmail", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the verified primary GitHub email", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          { email: "other@example.com", primary: false, verified: true, visibility: "private" },
+          { email: "user@company.com", primary: true, verified: true, visibility: "private" },
+        ])
+      )
+    );
+
+    await expect(getVerifiedPrimaryGitHubEmail("token")).resolves.toBe("user@company.com");
+  });
+
+  it("rejects an unverified primary GitHub email", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          { email: "user@company.com", primary: true, verified: false, visibility: "private" },
+        ])
+      )
+    );
+
+    await expect(getVerifiedPrimaryGitHubEmail("token")).resolves.toBeNull();
+  });
+
+  it("returns null when GitHub email lookup fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 403 }));
+
+    await expect(getVerifiedPrimaryGitHubEmail("token")).resolves.toBeNull();
+  });
+});

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -1,6 +1,25 @@
-import type { NextAuthOptions } from "next-auth";
+import type { NextAuthOptions, Profile } from "next-auth";
 import GitHubProvider from "next-auth/providers/github";
+import type { GithubEmail, GithubProfile } from "next-auth/providers/github";
 import { checkAccessAllowed, parseAllowlist, parseBooleanEnv } from "./access-control";
+
+export async function getVerifiedPrimaryGitHubEmail(
+  accessToken: string | undefined
+): Promise<string | null> {
+  if (!accessToken) return null;
+
+  const response = await fetch("https://api.github.com/user/emails", {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: "application/vnd.github+json",
+    },
+  });
+
+  if (!response.ok) return null;
+
+  const emails = (await response.json()) as GithubEmail[];
+  return emails.find((email) => email.primary && email.verified)?.email ?? null;
+}
 
 // Extend NextAuth types to include GitHub-specific user info
 declare module "next-auth" {
@@ -28,12 +47,20 @@ declare module "next-auth/jwt" {
 export const authOptions: NextAuthOptions = {
   debug: process.env.NODE_ENV === "development" || process.env.NEXTAUTH_DEBUG === "true",
   providers: [
-    GitHubProvider({
+    GitHubProvider<GithubProfile>({
       clientId: process.env.GITHUB_CLIENT_ID!,
       clientSecret: process.env.GITHUB_CLIENT_SECRET!,
       authorization: {
         params: {
           scope: "read:user user:email repo",
+        },
+      },
+      userinfo: {
+        url: "https://api.github.com/user",
+        async request({ client, tokens }) {
+          const profile = (await client.userinfo(tokens.access_token!)) as GithubProfile;
+          profile.email = await getVerifiedPrimaryGitHubEmail(tokens.access_token);
+          return profile as unknown as Profile;
         },
       },
     }),


### PR DESCRIPTION
## Summary
- Use GitHub's email API to select the verified primary email for NextAuth profile email values.
- Add focused tests covering verified primary email selection and fallback behavior.

## Verification
- `npm test -w @open-inspect/web -- src/lib/auth.test.ts src/lib/access-control.test.ts`
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/dab18490e20502144e02589cb9fa578d)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced GitHub authentication to automatically retrieve and use verified primary email addresses from GitHub user accounts during the login process, improving account setup.

* **Tests**
  * Added comprehensive test suite for email verification logic, covering scenarios where verified emails exist, when unverified emails are present, and when GitHub API lookups fail or return errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/669?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->