### PR TITLE
Configure child session sandbox limits

### DIFF
--- a/packages/control-plane/src/db/integration-settings.test.ts
+++ b/packages/control-plane/src/db/integration-settings.test.ts
@@ -660,10 +660,22 @@ describe("IntegrationSettingsStore", () => {
     });
 
     it("round-trips global sandbox settings", async () => {
-      await store.setGlobal("sandbox", { defaults: { tunnelPorts: [3000, 3001] } });
+      await store.setGlobal("sandbox", {
+        defaults: {
+          tunnelPorts: [3000, 3001],
+          maxConcurrentChildSessions: 3,
+          maxTotalChildSessions: 8,
+        },
+      });
 
       const result = await store.getGlobal("sandbox");
-      expect(result).toEqual({ defaults: { tunnelPorts: [3000, 3001] } });
+      expect(result).toEqual({
+        defaults: {
+          tunnelPorts: [3000, 3001],
+          maxConcurrentChildSessions: 3,
+          maxTotalChildSessions: 8,
+        },
+      });
     });
 
     it("round-trips per-repo sandbox settings", async () => {
@@ -689,6 +701,19 @@ describe("IntegrationSettingsStore", () => {
       expect(config.settings.tunnelPorts).toEqual([3000, 3001]);
     });
 
+    it("getResolvedConfig merges child session limit overrides", async () => {
+      await store.setGlobal("sandbox", {
+        defaults: { maxConcurrentChildSessions: 5, maxTotalChildSessions: 15 },
+      });
+      await store.setRepoSettings("sandbox", "acme/app", { maxConcurrentChildSessions: 2 });
+
+      const config = await store.getResolvedConfig("sandbox", "acme/app");
+      expect(config.settings).toEqual({
+        maxConcurrentChildSessions: 2,
+        maxTotalChildSessions: 15,
+      });
+    });
+
     it("rejects non-array tunnelPorts", async () => {
       await expect(
         store.setGlobal("sandbox", {
@@ -708,6 +733,16 @@ describe("IntegrationSettingsStore", () => {
         store.setGlobal("sandbox", {
           defaults: { tunnelPorts: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] },
         })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
+
+    it("rejects invalid child session limits", async () => {
+      await expect(
+        store.setGlobal("sandbox", { defaults: { maxConcurrentChildSessions: 1.5 } })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+
+      await expect(
+        store.setGlobal("sandbox", { defaults: { maxTotalChildSessions: -1 } })
       ).rejects.toThrow(IntegrationSettingsValidationError);
     });
   });

--- a/packages/control-plane/src/db/integration-settings.test.ts
+++ b/packages/control-plane/src/db/integration-settings.test.ts
@@ -745,6 +745,14 @@ describe("IntegrationSettingsStore", () => {
         store.setGlobal("sandbox", { defaults: { maxTotalChildSessions: -1 } })
       ).rejects.toThrow(IntegrationSettingsValidationError);
     });
+
+    it("rejects concurrent child session limits greater than total limits", async () => {
+      await expect(
+        store.setGlobal("sandbox", {
+          defaults: { maxConcurrentChildSessions: 6, maxTotalChildSessions: 5 },
+        })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
   });
 
   describe("linear settings", () => {

--- a/packages/control-plane/src/db/integration-settings.ts
+++ b/packages/control-plane/src/db/integration-settings.ts
@@ -314,6 +314,13 @@ export class IntegrationSettingsStore {
     if (settings.terminalEnabled !== undefined && typeof settings.terminalEnabled !== "boolean") {
       throw new IntegrationSettingsValidationError("terminalEnabled must be a boolean");
     }
+
+    this.validatePositiveIntegerSetting(
+      settings.maxConcurrentChildSessions,
+      "maxConcurrentChildSessions"
+    );
+    this.validatePositiveIntegerSetting(settings.maxTotalChildSessions, "maxTotalChildSessions");
+
     if (settings.tunnelPorts !== undefined) {
       if (!Array.isArray(settings.tunnelPorts)) {
         throw new IntegrationSettingsValidationError("tunnelPorts must be an array of numbers");
@@ -334,6 +341,13 @@ export class IntegrationSettingsStore {
       return { ...settings, tunnelPorts: dedupedPorts };
     }
     return settings;
+  }
+
+  private validatePositiveIntegerSetting(value: unknown, name: string): void {
+    if (value === undefined) return;
+    if (typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+      throw new IntegrationSettingsValidationError(`${name} must be a positive integer`);
+    }
   }
 
   private validateSlackSettings(

--- a/packages/control-plane/src/db/integration-settings.ts
+++ b/packages/control-plane/src/db/integration-settings.ts
@@ -320,6 +320,15 @@ export class IntegrationSettingsStore {
       "maxConcurrentChildSessions"
     );
     this.validatePositiveIntegerSetting(settings.maxTotalChildSessions, "maxTotalChildSessions");
+    if (
+      settings.maxConcurrentChildSessions !== undefined &&
+      settings.maxTotalChildSessions !== undefined &&
+      settings.maxConcurrentChildSessions > settings.maxTotalChildSessions
+    ) {
+      throw new IntegrationSettingsValidationError(
+        "maxConcurrentChildSessions must be less than or equal to maxTotalChildSessions"
+      );
+    }
 
     if (settings.tunnelPorts !== undefined) {
       if (!Array.isArray(settings.tunnelPorts)) {

--- a/packages/control-plane/src/router.spawn-child.test.ts
+++ b/packages/control-plane/src/router.spawn-child.test.ts
@@ -4,9 +4,16 @@ import { generateInternalToken } from "./auth/internal";
 import { SessionIndexStore } from "./db/session-index";
 import { SessionInternalPaths } from "./session/contracts";
 
+const integrationSettingsMocks = vi.hoisted(() => ({
+  resolveCodeServerEnabled: vi.fn().mockResolvedValue(false),
+  resolveSandboxSettings: vi.fn().mockResolvedValue({}),
+}));
+
 vi.mock("./db/session-index", () => ({
   SessionIndexStore: vi.fn(),
 }));
+
+vi.mock("./session/integration-settings-resolution", () => integrationSettingsMocks);
 
 describe("handleSpawnChild prompt enqueue handling", () => {
   const parentId = "parent-session-1";
@@ -29,7 +36,11 @@ describe("handleSpawnChild prompt enqueue handling", () => {
   };
 
   const makeStore = (parentUserId: string | null = null) => ({
-    get: vi.fn().mockResolvedValue({ userId: parentUserId }),
+    get: vi.fn().mockResolvedValue({
+      userId: parentUserId,
+      repoOwner: spawnContext.repoOwner,
+      repoName: spawnContext.repoName,
+    }),
     getSpawnDepth: vi.fn().mockResolvedValue(0),
     countActiveChildren: vi.fn().mockResolvedValue(0),
     countTotalChildren: vi.fn().mockResolvedValue(0),
@@ -39,6 +50,8 @@ describe("handleSpawnChild prompt enqueue handling", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    integrationSettingsMocks.resolveCodeServerEnabled.mockResolvedValue(false);
+    integrationSettingsMocks.resolveSandboxSettings.mockResolvedValue({});
   });
 
   async function makeRequest(env: Record<string, unknown>): Promise<Response> {
@@ -137,6 +150,74 @@ describe("handleSpawnChild prompt enqueue handling", () => {
     const payload = await response.json<{ error: string }>();
     expect(payload.error).toContain('Invalid model "not-a-real-model"');
     expect(payload.error).toContain("Valid models:");
+  });
+
+  it("uses configured concurrent child session limit", async () => {
+    const store = makeStore();
+    store.countActiveChildren.mockResolvedValue(2);
+    vi.mocked(SessionIndexStore).mockImplementation(() => store as never);
+    integrationSettingsMocks.resolveSandboxSettings.mockResolvedValue({
+      maxConcurrentChildSessions: 2,
+      maxTotalChildSessions: 15,
+    });
+
+    const parentStub: DurableObjectStub = {
+      fetch: vi.fn(async () => Response.json(spawnContext)),
+    } as never;
+
+    const env = {
+      INTERNAL_CALLBACK_SECRET: "test-internal-secret",
+      SCM_PROVIDER: "github",
+      DB: {},
+      SESSION: {
+        idFromName: (name: string) => name,
+        get: () => parentStub,
+      },
+    };
+
+    const response = await makeRequest(env);
+
+    expect(response.status).toBe(429);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Maximum concurrent children (2) reached",
+    });
+    expect(integrationSettingsMocks.resolveSandboxSettings).toHaveBeenCalledWith(
+      expect.any(Object),
+      "acme",
+      "web-app"
+    );
+  });
+
+  it("uses configured total child session limit", async () => {
+    const store = makeStore();
+    store.countActiveChildren.mockResolvedValue(0);
+    store.countTotalChildren.mockResolvedValue(4);
+    vi.mocked(SessionIndexStore).mockImplementation(() => store as never);
+    integrationSettingsMocks.resolveSandboxSettings.mockResolvedValue({
+      maxConcurrentChildSessions: 5,
+      maxTotalChildSessions: 4,
+    });
+
+    const parentStub: DurableObjectStub = {
+      fetch: vi.fn(async () => Response.json(spawnContext)),
+    } as never;
+
+    const env = {
+      INTERNAL_CALLBACK_SECRET: "test-internal-secret",
+      SCM_PROVIDER: "github",
+      DB: {},
+      SESSION: {
+        idFromName: (name: string) => name,
+        get: () => parentStub,
+      },
+    };
+
+    const response = await makeRequest(env);
+
+    expect(response.status).toBe(429);
+    await expect(response.json()).resolves.toMatchObject({
+      error: "Maximum total children (4) reached",
+    });
   });
 
   it("returns 400 when child specifies an empty-string model", async () => {

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -47,6 +47,8 @@ import {
   isValidModel,
   isValidReasoningEffort,
   VALID_MODELS,
+  DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS,
+  DEFAULT_MAX_TOTAL_CHILD_SESSIONS,
   type ScreenshotArtifactMetadata,
   type VideoArtifactMetadata,
   type SessionStatus,
@@ -79,8 +81,6 @@ const logger = createLogger("router");
 
 // Guardrail constants for agent-spawned child sessions
 const MAX_SPAWN_DEPTH = 2;
-const MAX_CONCURRENT_CHILDREN = 5;
-const MAX_TOTAL_CHILDREN = 15;
 
 const SESSION_STATUSES: SessionStatus[] = [
   "created",
@@ -2100,6 +2100,18 @@ async function handleSpawnChild(
 
   const sessionStore = new SessionIndexStore(env.DB);
 
+  // Read parent's canonical session row before guardrails so repo-scoped sandbox settings can
+  // configure child-session limits without waiting on the parent Durable Object.
+  const parentSession = await sessionStore.get(parentId);
+  const parentUserId = parentSession?.userId ?? null;
+  const childSandboxSettings = parentSession
+    ? await resolveSandboxSettings(env.DB, parentSession.repoOwner, parentSession.repoName)
+    : {};
+  const maxConcurrentChildren =
+    childSandboxSettings.maxConcurrentChildSessions ?? DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS;
+  const maxTotalChildren =
+    childSandboxSettings.maxTotalChildSessions ?? DEFAULT_MAX_TOTAL_CHILD_SESSIONS;
+
   // Guardrail: depth
   const parentDepth = await sessionStore.getSpawnDepth(parentId);
   if (parentDepth >= MAX_SPAWN_DEPTH) {
@@ -2108,19 +2120,15 @@ async function handleSpawnChild(
 
   // Guardrail: concurrent children
   const activeCount = await sessionStore.countActiveChildren(parentId);
-  if (activeCount >= MAX_CONCURRENT_CHILDREN) {
-    return error(`Maximum concurrent children (${MAX_CONCURRENT_CHILDREN}) reached`, 429);
+  if (activeCount >= maxConcurrentChildren) {
+    return error(`Maximum concurrent children (${maxConcurrentChildren}) reached`, 429);
   }
 
   // Guardrail: total children
   const totalCount = await sessionStore.countTotalChildren(parentId);
-  if (totalCount >= MAX_TOTAL_CHILDREN) {
-    return error(`Maximum total children (${MAX_TOTAL_CHILDREN}) reached`, 429);
+  if (totalCount >= maxTotalChildren) {
+    return error(`Maximum total children (${maxTotalChildren}) reached`, 429);
   }
-
-  // Read parent's canonical user_id from D1 for inheritance
-  const parentSession = await sessionStore.get(parentId);
-  const parentUserId = parentSession?.userId ?? null;
 
   // Get parent context from parent DO
   const parentDoId = env.SESSION.idFromName(parentId);
@@ -2167,11 +2175,12 @@ async function handleSpawnChild(
     model,
   });
 
-  // Resolve code-server integration setting and sandbox settings for child (same repo as parent)
-  const [childCodeServerEnabled, childSandboxSettings] = await Promise.all([
-    resolveCodeServerEnabled(env.DB, spawnContext.repoOwner, spawnContext.repoName),
-    resolveSandboxSettings(env.DB, spawnContext.repoOwner, spawnContext.repoName),
-  ]);
+  // Resolve code-server integration setting for child (same repo as parent)
+  const childCodeServerEnabled = await resolveCodeServerEnabled(
+    env.DB,
+    spawnContext.repoOwner,
+    spawnContext.repoName
+  );
 
   const input: SessionInitInput = {
     sessionId: childId,

--- a/packages/control-plane/src/routes/integration-settings.ts
+++ b/packages/control-plane/src/routes/integration-settings.ts
@@ -3,6 +3,8 @@
  */
 
 import {
+  DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS,
+  DEFAULT_MAX_TOTAL_CHILD_SESSIONS,
   isValidReasoningEffort,
   type CodeServerSettings,
   type GitHubBotSettings,
@@ -360,8 +362,10 @@ async function handleGetResolvedConfig(
       config: {
         tunnelPorts: sandboxSettings.tunnelPorts ?? [],
         terminalEnabled: sandboxSettings.terminalEnabled ?? false,
-        maxConcurrentChildSessions: sandboxSettings.maxConcurrentChildSessions,
-        maxTotalChildSessions: sandboxSettings.maxTotalChildSessions,
+        maxConcurrentChildSessions:
+          sandboxSettings.maxConcurrentChildSessions ?? DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS,
+        maxTotalChildSessions:
+          sandboxSettings.maxTotalChildSessions ?? DEFAULT_MAX_TOTAL_CHILD_SESSIONS,
         enabledRepos,
       },
     });

--- a/packages/control-plane/src/routes/integration-settings.ts
+++ b/packages/control-plane/src/routes/integration-settings.ts
@@ -359,6 +359,9 @@ async function handleGetResolvedConfig(
       repo,
       config: {
         tunnelPorts: sandboxSettings.tunnelPorts ?? [],
+        terminalEnabled: sandboxSettings.terminalEnabled ?? false,
+        maxConcurrentChildSessions: sandboxSettings.maxConcurrentChildSessions,
+        maxTotalChildSessions: sandboxSettings.maxTotalChildSessions,
         enabledRepos,
       },
     });

--- a/packages/control-plane/test/integration/integration-settings.test.ts
+++ b/packages/control-plane/test/integration/integration-settings.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { SELF, env } from "cloudflare:test";
+import {
+  DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS,
+  DEFAULT_MAX_TOTAL_CHILD_SESSIONS,
+} from "@open-inspect/shared";
 import { generateInternalToken } from "../../src/auth/internal";
 import { cleanD1Tables } from "./cleanup";
 
@@ -581,10 +585,14 @@ describe("Integration settings API", () => {
       const body = await res.json<{
         config: {
           tunnelPorts: number[];
+          maxConcurrentChildSessions: number;
+          maxTotalChildSessions: number;
           enabledRepos: string[] | null;
         };
       }>();
       expect(body.config.tunnelPorts).toEqual([]);
+      expect(body.config.maxConcurrentChildSessions).toBe(DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS);
+      expect(body.config.maxTotalChildSessions).toBe(DEFAULT_MAX_TOTAL_CHILD_SESSIONS);
       expect(body.config.enabledRepos).toBeNull();
     });
   });

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -42,12 +42,22 @@ export interface CodeServerSettings {
 /** Maximum number of tunnel ports a user can configure per sandbox. */
 export const MAX_TUNNEL_PORTS = 10;
 
+/** Default maximum active agent-spawned child sessions per parent session. */
+export const DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS = 5;
+
+/** Default maximum agent-spawned child sessions per parent session. */
+export const DEFAULT_MAX_TOTAL_CHILD_SESSIONS = 15;
+
 /** Sandbox environment settings. Provider-agnostic: describes what the user wants, not how it's done. */
 export interface SandboxSettings {
   /** Extra ports to expose via tunnels (e.g., dev server ports 3000, 5173). */
   tunnelPorts?: number[];
   /** Enable a browser-based terminal (ttyd) in sandbox sessions. */
   terminalEnabled?: boolean;
+  /** Maximum active agent-spawned child sessions per parent session. */
+  maxConcurrentChildSessions?: number;
+  /** Maximum total agent-spawned child sessions per parent session. */
+  maxTotalChildSessions?: number;
 }
 
 export type SlackMentionsPolicy = "allow" | "escape" | "strip";

--- a/packages/web/src/components/settings/sandbox-settings.test.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.test.tsx
@@ -6,7 +6,11 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { SWRConfig } from "swr";
-import { MAX_TUNNEL_PORTS } from "@open-inspect/shared";
+import {
+  DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS,
+  DEFAULT_MAX_TOTAL_CHILD_SESSIONS,
+  MAX_TUNNEL_PORTS,
+} from "@open-inspect/shared";
 import { SandboxSettingsPage } from "./sandbox-settings";
 
 expect.extend(matchers);
@@ -17,10 +21,14 @@ vi.mock("@/hooks/use-repos", () => ({
 
 const SETTINGS_KEY = "/api/integration-settings/sandbox";
 
-function globalSettings(tunnelPorts: number[], enabledRepos?: string[]) {
+function globalSettings(
+  tunnelPorts: number[],
+  enabledRepos?: string[],
+  limits?: { maxConcurrentChildSessions?: number; maxTotalChildSessions?: number }
+) {
   return {
     integrationId: "sandbox",
-    settings: { defaults: { tunnelPorts }, enabledRepos },
+    settings: { defaults: { tunnelPorts, ...limits }, enabledRepos },
   };
 }
 
@@ -168,13 +176,97 @@ describe("SandboxSettingsPage — tunnel ports editor", () => {
           method: "PUT",
           body: JSON.stringify({
             settings: {
-              defaults: { tunnelPorts: [8080], terminalEnabled: false },
+              defaults: {
+                tunnelPorts: [8080],
+                terminalEnabled: false,
+                maxConcurrentChildSessions: DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS,
+                maxTotalChildSessions: DEFAULT_MAX_TOTAL_CHILD_SESSIONS,
+              },
               enabledRepos: ["acme/app"],
             },
           }),
         })
       );
     });
+  });
+
+  it("renders child session limits from settings", () => {
+    renderWithSWR(
+      globalSettings([], undefined, {
+        maxConcurrentChildSessions: 3,
+        maxTotalChildSessions: 9,
+      })
+    );
+
+    expect(screen.getByLabelText("Max concurrent child sessions")).toHaveValue(3);
+    expect(screen.getByLabelText("Max total child sessions")).toHaveValue(9);
+  });
+
+  it("sends child session limits in the global payload", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "PUT") {
+        return new Response(JSON.stringify({}), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${String(input)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <SWRConfig
+        value={{
+          provider: () => new Map(),
+          fallback: { [SETTINGS_KEY]: globalSettings([], ["acme/app"]) },
+          dedupingInterval: Infinity,
+          revalidateOnFocus: false,
+          revalidateIfStale: false,
+          revalidateOnReconnect: false,
+        }}
+      >
+        <SandboxSettingsPage />
+      </SWRConfig>
+    );
+
+    await user.clear(screen.getByLabelText("Max concurrent child sessions"));
+    await user.type(screen.getByLabelText("Max concurrent child sessions"), "2");
+    await user.clear(screen.getByLabelText("Max total child sessions"));
+    await user.type(screen.getByLabelText("Max total child sessions"), "7");
+    await user.click(screen.getByText("Save Settings"));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        SETTINGS_KEY,
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({
+            settings: {
+              defaults: {
+                tunnelPorts: [],
+                terminalEnabled: false,
+                maxConcurrentChildSessions: 2,
+                maxTotalChildSessions: 7,
+              },
+              enabledRepos: ["acme/app"],
+            },
+          }),
+        })
+      );
+    });
+  });
+
+  it("blocks invalid child session limits", async () => {
+    const { fetchMock } = renderWithSWR(globalSettings([]));
+
+    await user.clear(screen.getByLabelText("Max concurrent child sessions"));
+    await user.type(screen.getByLabelText("Max concurrent child sessions"), "0");
+    await user.click(screen.getByText("Save Settings"));
+
+    expect(
+      screen.getByText("Child session limits must be positive whole numbers.")
+    ).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      SETTINGS_KEY,
+      expect.objectContaining({ method: "PUT" })
+    );
   });
 
   it("deduplicates ports on save", async () => {
@@ -216,7 +308,14 @@ describe("SandboxSettingsPage — tunnel ports editor", () => {
         SETTINGS_KEY,
         expect.objectContaining({
           body: JSON.stringify({
-            settings: { defaults: { tunnelPorts: [3000], terminalEnabled: false } },
+            settings: {
+              defaults: {
+                tunnelPorts: [3000],
+                terminalEnabled: false,
+                maxConcurrentChildSessions: DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS,
+                maxTotalChildSessions: DEFAULT_MAX_TOTAL_CHILD_SESSIONS,
+              },
+            },
           }),
         })
       );

--- a/packages/web/src/components/settings/sandbox-settings.test.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.test.tsx
@@ -15,8 +15,21 @@ import { SandboxSettingsPage } from "./sandbox-settings";
 
 expect.extend(matchers);
 
+const reposMock = vi.hoisted(() => ({
+  repos: [] as Array<{
+    id: number;
+    fullName: string;
+    owner: string;
+    name: string;
+    description: string | null;
+    private: boolean;
+    defaultBranch: string;
+  }>,
+  loading: false,
+}));
+
 vi.mock("@/hooks/use-repos", () => ({
-  useRepos: () => ({ repos: [], loading: false }),
+  useRepos: () => ({ repos: reposMock.repos, loading: reposMock.loading }),
 }));
 
 const SETTINGS_KEY = "/api/integration-settings/sandbox";
@@ -58,6 +71,8 @@ function renderWithSWR(fallbackData: unknown) {
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  reposMock.repos = [];
+  reposMock.loading = false;
 });
 
 describe("SandboxSettingsPage — tunnel ports editor", () => {
@@ -267,6 +282,72 @@ describe("SandboxSettingsPage — tunnel ports editor", () => {
       SETTINGS_KEY,
       expect.objectContaining({ method: "PUT" })
     );
+  });
+
+  it("shows inherited repo child session limits without saving them as overrides", async () => {
+    Element.prototype.scrollIntoView = vi.fn();
+    reposMock.repos = [
+      {
+        id: 1,
+        fullName: "acme/app",
+        owner: "acme",
+        name: "app",
+        description: null,
+        private: false,
+        defaultBranch: "main",
+      },
+    ];
+    const repoSettingsKey = "/api/integration-settings/sandbox/repos/acme/app";
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "PUT") {
+        return new Response(JSON.stringify({}), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${String(input)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <SWRConfig
+        value={{
+          provider: () => new Map(),
+          fallback: {
+            [SETTINGS_KEY]: globalSettings([], undefined, {
+              maxConcurrentChildSessions: 2,
+              maxTotalChildSessions: 7,
+            }),
+            [repoSettingsKey]: { integrationId: "sandbox", repo: "acme/app", settings: null },
+          },
+          dedupingInterval: Infinity,
+          revalidateOnFocus: false,
+          revalidateIfStale: false,
+          revalidateOnReconnect: false,
+        }}
+      >
+        <SandboxSettingsPage />
+      </SWRConfig>
+    );
+
+    await user.click(screen.getByText("All Repositories (Global)"));
+    await user.click(screen.getByRole("option", { name: /app/ }));
+
+    expect(screen.getByLabelText("Max concurrent child sessions")).toHaveValue(2);
+    expect(screen.getByLabelText("Max total child sessions")).toHaveValue(7);
+
+    await user.click(screen.getByText("Add port"));
+    await user.type(screen.getByPlaceholderText("e.g. 3000"), "3000");
+    await user.click(screen.getByText("Save Settings"));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        repoSettingsKey,
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({
+            settings: { tunnelPorts: [3000], terminalEnabled: false },
+          }),
+        })
+      );
+    });
   });
 
   it("deduplicates ports on save", async () => {

--- a/packages/web/src/components/settings/sandbox-settings.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.tsx
@@ -47,14 +47,24 @@ function SandboxSettingsEditor({
   name?: string;
 }) {
   const isGlobal = scope === "global";
+  const globalApiUrl = "/api/integration-settings/sandbox";
   const apiUrl = isGlobal
-    ? "/api/integration-settings/sandbox"
+    ? globalApiUrl
     : `/api/integration-settings/sandbox/repos/${owner}/${name}`;
 
   const { data, mutate, isLoading } = useSWR<GlobalSettingsResponse | RepoSettingsResponse>(
     apiUrl,
     fetcher
   );
+  const { data: globalData, isLoading: isLoadingGlobal } = useSWR<GlobalSettingsResponse>(
+    isGlobal ? null : globalApiUrl,
+    fetcher
+  );
+
+  const globalDefaults = isGlobal
+    ? (data as GlobalSettingsResponse | undefined)?.settings?.defaults
+    : globalData?.settings?.defaults;
+  const repoSettings = isGlobal ? undefined : (data as RepoSettingsResponse | undefined)?.settings;
 
   const currentPorts: number[] = isGlobal
     ? ((data as GlobalSettingsResponse)?.settings?.defaults?.tunnelPorts ?? [])
@@ -65,15 +75,15 @@ function SandboxSettingsEditor({
     : ((data as RepoSettingsResponse)?.settings?.terminalEnabled ?? false);
 
   const currentMaxConcurrentChildSessions: number = isGlobal
-    ? ((data as GlobalSettingsResponse)?.settings?.defaults?.maxConcurrentChildSessions ??
-      DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS)
-    : ((data as RepoSettingsResponse)?.settings?.maxConcurrentChildSessions ??
+    ? (globalDefaults?.maxConcurrentChildSessions ?? DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS)
+    : (repoSettings?.maxConcurrentChildSessions ??
+      globalDefaults?.maxConcurrentChildSessions ??
       DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS);
 
   const currentMaxTotalChildSessions: number = isGlobal
-    ? ((data as GlobalSettingsResponse)?.settings?.defaults?.maxTotalChildSessions ??
-      DEFAULT_MAX_TOTAL_CHILD_SESSIONS)
-    : ((data as RepoSettingsResponse)?.settings?.maxTotalChildSessions ??
+    ? (globalDefaults?.maxTotalChildSessions ?? DEFAULT_MAX_TOTAL_CHILD_SESSIONS)
+    : (repoSettings?.maxTotalChildSessions ??
+      globalDefaults?.maxTotalChildSessions ??
       DEFAULT_MAX_TOTAL_CHILD_SESSIONS);
 
   const [portRows, setPortRows] = useState<string[] | null>(null);
@@ -143,12 +153,24 @@ function SandboxSettingsEditor({
       const existingEnabledRepos = isGlobal
         ? (data as GlobalSettingsResponse)?.settings?.enabledRepos
         : undefined;
-      const settingsPayload = {
+      const settingsPayload: SandboxSettings = {
         tunnelPorts: ports,
         terminalEnabled: resolvedTerminalEnabled,
-        maxConcurrentChildSessions: Number(resolvedMaxConcurrentChildSessions),
-        maxTotalChildSessions: Number(resolvedMaxTotalChildSessions),
       };
+      if (
+        isGlobal ||
+        maxConcurrentChildSessions !== null ||
+        repoSettings?.maxConcurrentChildSessions !== undefined
+      ) {
+        settingsPayload.maxConcurrentChildSessions = Number(resolvedMaxConcurrentChildSessions);
+      }
+      if (
+        isGlobal ||
+        maxTotalChildSessions !== null ||
+        repoSettings?.maxTotalChildSessions !== undefined
+      ) {
+        settingsPayload.maxTotalChildSessions = Number(resolvedMaxTotalChildSessions);
+      }
       const body = isGlobal
         ? { settings: { defaults: settingsPayload, enabledRepos: existingEnabledRepos } }
         : { settings: settingsPayload };
@@ -185,6 +207,10 @@ function SandboxSettingsEditor({
     resolvedTerminalEnabled,
     resolvedMaxConcurrentChildSessions,
     resolvedMaxTotalChildSessions,
+    maxConcurrentChildSessions,
+    maxTotalChildSessions,
+    repoSettings?.maxConcurrentChildSessions,
+    repoSettings?.maxTotalChildSessions,
   ]);
 
   const hasPortChanges =
@@ -200,7 +226,7 @@ function SandboxSettingsEditor({
   const hasChanges =
     hasPortChanges || hasTerminalChange || hasConcurrentLimitChange || hasTotalLimitChange;
 
-  if (isLoading) {
+  if (isLoading || isLoadingGlobal) {
     return <p className="text-sm text-muted-foreground">Loading...</p>;
   }
 

--- a/packages/web/src/components/settings/sandbox-settings.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.tsx
@@ -8,7 +8,11 @@ import { Combobox } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import useSWR from "swr";
 import type { SandboxSettings } from "@open-inspect/shared";
-import { MAX_TUNNEL_PORTS } from "@open-inspect/shared";
+import {
+  DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS,
+  DEFAULT_MAX_TOTAL_CHILD_SESSIONS,
+  MAX_TUNNEL_PORTS,
+} from "@open-inspect/shared";
 
 const GLOBAL_SCOPE = "__global__";
 
@@ -27,6 +31,10 @@ const fetcher = (url: string) => fetch(url).then((r) => r.json());
 
 function isValidPort(value: string): boolean {
   return /^\d+$/.test(value) && Number(value) >= 1 && Number(value) <= 65535;
+}
+
+function isPositiveInteger(value: string): boolean {
+  return /^\d+$/.test(value) && Number(value) >= 1;
 }
 
 function SandboxSettingsEditor({
@@ -56,8 +64,22 @@ function SandboxSettingsEditor({
     ? ((data as GlobalSettingsResponse)?.settings?.defaults?.terminalEnabled ?? false)
     : ((data as RepoSettingsResponse)?.settings?.terminalEnabled ?? false);
 
+  const currentMaxConcurrentChildSessions: number = isGlobal
+    ? ((data as GlobalSettingsResponse)?.settings?.defaults?.maxConcurrentChildSessions ??
+      DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS)
+    : ((data as RepoSettingsResponse)?.settings?.maxConcurrentChildSessions ??
+      DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS);
+
+  const currentMaxTotalChildSessions: number = isGlobal
+    ? ((data as GlobalSettingsResponse)?.settings?.defaults?.maxTotalChildSessions ??
+      DEFAULT_MAX_TOTAL_CHILD_SESSIONS)
+    : ((data as RepoSettingsResponse)?.settings?.maxTotalChildSessions ??
+      DEFAULT_MAX_TOTAL_CHILD_SESSIONS);
+
   const [portRows, setPortRows] = useState<string[] | null>(null);
   const [terminalEnabled, setTerminalEnabled] = useState<boolean | null>(null);
+  const [maxConcurrentChildSessions, setMaxConcurrentChildSessions] = useState<string | null>(null);
+  const [maxTotalChildSessions, setMaxTotalChildSessions] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
@@ -67,6 +89,10 @@ function SandboxSettingsEditor({
 
   // Use server state unless user is editing
   const rows = portRows ?? currentPorts.map(String);
+  const resolvedMaxConcurrentChildSessions =
+    maxConcurrentChildSessions ?? String(currentMaxConcurrentChildSessions);
+  const resolvedMaxTotalChildSessions =
+    maxTotalChildSessions ?? String(currentMaxTotalChildSessions);
 
   const handleAddRow = () => {
     if (rows.length >= MAX_TUNNEL_PORTS) return;
@@ -104,12 +130,25 @@ function SandboxSettingsEditor({
       return;
     }
 
+    if (
+      !isPositiveInteger(resolvedMaxConcurrentChildSessions) ||
+      !isPositiveInteger(resolvedMaxTotalChildSessions)
+    ) {
+      setError("Child session limits must be positive whole numbers.");
+      return;
+    }
+
     setSaving(true);
     try {
       const existingEnabledRepos = isGlobal
         ? (data as GlobalSettingsResponse)?.settings?.enabledRepos
         : undefined;
-      const settingsPayload = { tunnelPorts: ports, terminalEnabled: resolvedTerminalEnabled };
+      const settingsPayload = {
+        tunnelPorts: ports,
+        terminalEnabled: resolvedTerminalEnabled,
+        maxConcurrentChildSessions: Number(resolvedMaxConcurrentChildSessions),
+        maxTotalChildSessions: Number(resolvedMaxTotalChildSessions),
+      };
       const body = isGlobal
         ? { settings: { defaults: settingsPayload, enabledRepos: existingEnabledRepos } }
         : { settings: settingsPayload };
@@ -128,6 +167,8 @@ function SandboxSettingsEditor({
       await mutate();
       setPortRows(null);
       setTerminalEnabled(null);
+      setMaxConcurrentChildSessions(null);
+      setMaxTotalChildSessions(null);
       setSuccess(true);
       setTimeout(() => setSuccess(false), 2000);
     } catch (e) {
@@ -135,13 +176,29 @@ function SandboxSettingsEditor({
     } finally {
       setSaving(false);
     }
-  }, [rows, isGlobal, apiUrl, mutate, data, resolvedTerminalEnabled]);
+  }, [
+    rows,
+    isGlobal,
+    apiUrl,
+    mutate,
+    data,
+    resolvedTerminalEnabled,
+    resolvedMaxConcurrentChildSessions,
+    resolvedMaxTotalChildSessions,
+  ]);
 
   const hasPortChanges =
     portRows !== null &&
     JSON.stringify(normalizePorts(portRows).ports) !== JSON.stringify(currentPorts);
   const hasTerminalChange = terminalEnabled !== null && terminalEnabled !== currentTerminalEnabled;
-  const hasChanges = hasPortChanges || hasTerminalChange;
+  const hasConcurrentLimitChange =
+    maxConcurrentChildSessions !== null &&
+    maxConcurrentChildSessions !== String(currentMaxConcurrentChildSessions);
+  const hasTotalLimitChange =
+    maxTotalChildSessions !== null &&
+    maxTotalChildSessions !== String(currentMaxTotalChildSessions);
+  const hasChanges =
+    hasPortChanges || hasTerminalChange || hasConcurrentLimitChange || hasTotalLimitChange;
 
   if (isLoading) {
     return <p className="text-sm text-muted-foreground">Loading...</p>;
@@ -219,6 +276,47 @@ function SandboxSettingsEditor({
               </div>
             ))
           )}
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-foreground mb-1.5">Child Sessions</label>
+        <p className="text-xs text-muted-foreground mb-2">
+          Limit agent-spawned child sessions to prevent runaway sandbox usage.
+        </p>
+        <div className="grid gap-3 max-w-sm sm:grid-cols-2">
+          <div>
+            <label
+              htmlFor="max-concurrent-child-sessions"
+              className="block text-xs font-medium text-muted-foreground mb-1"
+            >
+              Max concurrent child sessions
+            </label>
+            <Input
+              id="max-concurrent-child-sessions"
+              type="number"
+              min="1"
+              inputMode="numeric"
+              value={resolvedMaxConcurrentChildSessions}
+              onChange={(e) => setMaxConcurrentChildSessions(e.target.value)}
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="max-total-child-sessions"
+              className="block text-xs font-medium text-muted-foreground mb-1"
+            >
+              Max total child sessions
+            </label>
+            <Input
+              id="max-total-child-sessions"
+              type="number"
+              min="1"
+              inputMode="numeric"
+              value={resolvedMaxTotalChildSessions}
+              onChange={(e) => setMaxTotalChildSessions(e.target.value)}
+            />
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Adds sandbox settings for maximum concurrent and total agent-spawned child sessions, with shared defaults preserving existing behavior.
- Enforces configured limits in the child session spawn route and validates persisted sandbox settings.
- Exposes the limits in the web sandbox settings UI with tests for rendering, validation, and payloads.

## Verification
- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/control-plane -- src/db/integration-settings.test.ts src/router.spawn-child.test.ts`
- `npm test -w @open-inspect/web -- src/components/settings/sandbox-settings.test.tsx`
- `npm run typecheck`
- `npx eslint "packages/shared/src/types/integrations.ts" "packages/control-plane/src/router.ts" "packages/control-plane/src/db/integration-settings.ts" "packages/control-plane/src/db/integration-settings.test.ts" "packages/control-plane/src/router.spawn-child.test.ts" "packages/control-plane/src/routes/integration-settings.ts" "packages/web/src/components/settings/sandbox-settings.tsx" "packages/web/src/components/settings/sandbox-settings.test.tsx"`

Note: full `npm run lint` is currently blocked by untracked `.opencode/` tool files in the workspace, unrelated to this patch.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/d36897adee7f971722efd21f883a53f5)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable sandbox limits for concurrent and total child sessions with sensible defaults
  * UI: new "Child Sessions" settings with editable numeric inputs; saved values included in configuration and cleared after save
  * Spawn logic now enforces repo-scoped limits and returns errors when limits are exceeded

* **Bug Fixes**
  * Prevent saving invalid (non-positive/non-integer or inconsistent) child-session limits

* **Tests**
  * Expanded tests for validation, enforcement, inheritance, and resolved configuration responses

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->