### PR TITLE
feat(web): add external-link glyph to sandbox dashboard link

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -1150,6 +1150,9 @@ function SandboxStatus({
         className={`${className} hover:underline`}
       >
         {label}
+        <span aria-hidden="true" className="ml-0.5">
+          ↗
+        </span>
       </a>
     );
   }


### PR DESCRIPTION
## Summary

- The sandbox dashboard link (added in #654) rendered as the plain `Sandbox: <status>` text in the session header with only a `hover:underline`, so users couldn't tell it was clickable.
- Append a decorative trailing `↗` glyph so the link affordance is visible at rest: `Sandbox: ready ↗`.

The arrow is `aria-hidden` (the existing `title="Open sandbox in provider dashboard"` already covers screen readers) and only renders when a `dashboardUrl` is present. The non-link branch and the desktop-only (`md:`) gating are unchanged.

## Test plan

- [x] `npm run build -w @open-inspect/shared && npm run typecheck -w @open-inspect/web`
- [x] `npx prettier --check` + `npx eslint` on the changed file
- [ ] Visually confirm on a desktop-width session view that `Sandbox: <status> ↗` shows the arrow at rest and opens the Modal dashboard in a new tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * External links now display a visual right-arrow indicator to clearly show they navigate outside the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/682?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->