### PR TITLE
Allow Slack sessions to use OpenCode titles

### DIFF
--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -289,6 +289,15 @@ function promptFetchBodies(fetchMock: { mock: { calls: readonly (readonly unknow
     .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as Record<string, unknown>);
 }
 
+function sessionFetchBodies(fetchMock: { mock: { calls: readonly (readonly unknown[])[] } }) {
+  return fetchMock.mock.calls
+    .filter(([input]) => {
+      const url = typeof input === "string" ? input : String(input);
+      return url.endsWith("/sessions");
+    })
+    .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as Record<string, unknown>);
+}
+
 function slackEventRequest(event: Record<string, unknown>, eventId = crypto.randomUUID()): Request {
   return new Request("http://localhost/events", {
     method: "POST",
@@ -352,6 +361,11 @@ describe("POST /events", () => {
 
     const postBodies = slackApiBodies(slackFetch, "chat.postMessage");
     expect(postBodies.some((body) => String(body.text).includes("Session started!"))).toBe(false);
+
+    const sessionBodies = sessionFetchBodies(
+      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: readonly (readonly unknown[])[] } }
+    );
+    expect(sessionBodies[0]).not.toHaveProperty("title");
 
     const updateBodies = slackApiBodies(slackFetch, "chat.update");
     expect(updateBodies).toEqual(

--- a/packages/slack-bot/src/index.ts
+++ b/packages/slack-bot/src/index.ts
@@ -88,7 +88,6 @@ async function getAuthHeaders(env: Env, traceId?: string): Promise<Record<string
 async function createSession(
   env: Env,
   repo: RepoConfig,
-  title: string | undefined,
   model: string,
   reasoningEffort: string | undefined,
   branch: string | undefined,
@@ -115,7 +114,6 @@ async function createSession(
       body: JSON.stringify({
         repoOwner: repo.owner,
         repoName: repo.name,
-        title: title || `Slack: ${repo.name}`,
         model,
         reasoningEffort,
         branch,
@@ -973,7 +971,6 @@ async function startSessionAndSendPrompt(
   const session = await createSession(
     env,
     repo,
-    messageText.slice(0, 100),
     model,
     reasoningEffort,
     branch,


### PR DESCRIPTION
## Summary
- Stop pre-filling Slack-created session titles from the Slack message or repo fallback
- Leave Slack session titles unset so OpenCode-generated title events can populate them
- Add a regression assertion for the Slack session creation payload

## Validation
- npm run build -w @open-inspect/shared
- npm test -w @open-inspect/slack-bot
- npm run typecheck -w @open-inspect/slack-bot
- npm run lint -w @open-inspect/slack-bot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed title field from session creation requests to the control plane.

* **Tests**
  * Updated tests to verify title field is not included in session creation requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->