### PR TITLE
Add provider identity resolution API

### DIFF
--- a/packages/control-plane/src/router.provider-identities.test.ts
+++ b/packages/control-plane/src/router.provider-identities.test.ts
@@ -53,34 +53,4 @@ describe("provider identity router integration", () => {
       userId: "0123456789abcdef0123456789abcdef",
     });
   });
-
-  it("lets the provider identity route validate unsupported providers when the SCM provider is not github", async () => {
-    const env = {
-      INTERNAL_CALLBACK_SECRET: "test-secret",
-      SCM_PROVIDER: "gitlab",
-      DB: {
-        prepare: vi.fn(),
-        batch: vi.fn(),
-        exec: vi.fn(),
-        dump: vi.fn(),
-      },
-    };
-
-    const token = await generateInternalToken(env.INTERNAL_CALLBACK_SECRET);
-    const response = await handleRequest(
-      new Request("https://test.local/provider-identities/slack/U123", {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({}),
-      }),
-      env as never
-    );
-
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toEqual({ error: "provider must be github" });
-    expect(mockUserStore.resolveOrCreateUser).not.toHaveBeenCalled();
-  });
 });

--- a/packages/control-plane/src/router.provider-identities.test.ts
+++ b/packages/control-plane/src/router.provider-identities.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateInternalToken } from "./auth/internal";
+import { handleRequest } from "./router";
+
+const mockUserStore = {
+  resolveOrCreateUser: vi.fn(),
+};
+
+vi.mock("./db/user-store", () => ({
+  UserStore: vi.fn().mockImplementation(() => mockUserStore),
+}));
+
+describe("provider identity router integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserStore.resolveOrCreateUser.mockResolvedValue({
+      id: "0123456789abcdef0123456789abcdef",
+      displayName: "Ada",
+      email: "ada@example.com",
+      isNew: false,
+    });
+  });
+
+  it("serves provider identity upserts even when the SCM provider is not github", async () => {
+    const env = {
+      INTERNAL_CALLBACK_SECRET: "test-secret",
+      SCM_PROVIDER: "gitlab",
+      DB: {
+        prepare: vi.fn(),
+        batch: vi.fn(),
+        exec: vi.fn(),
+        dump: vi.fn(),
+      },
+    };
+
+    const token = await generateInternalToken(env.INTERNAL_CALLBACK_SECRET);
+    const response = await handleRequest(
+      new Request("https://test.local/provider-identities/github/12345", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          providerLogin: "ada",
+        }),
+      }),
+      env as never
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      userId: "0123456789abcdef0123456789abcdef",
+    });
+  });
+
+  it("lets the provider identity route validate unsupported providers when the SCM provider is not github", async () => {
+    const env = {
+      INTERNAL_CALLBACK_SECRET: "test-secret",
+      SCM_PROVIDER: "gitlab",
+      DB: {
+        prepare: vi.fn(),
+        batch: vi.fn(),
+        exec: vi.fn(),
+        dump: vi.fn(),
+      },
+    };
+
+    const token = await generateInternalToken(env.INTERNAL_CALLBACK_SECRET);
+    const response = await handleRequest(
+      new Request("https://test.local/provider-identities/slack/U123", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({}),
+      }),
+      env as never
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "provider must be github" });
+    expect(mockUserStore.resolveOrCreateUser).not.toHaveBeenCalled();
+  });
+});

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -74,6 +74,7 @@ import { secretsRoutes } from "./routes/secrets";
 import { automationRoutes } from "./routes/automations";
 import { mcpServerRoutes } from "./routes/mcp-servers";
 import { analyticsRoutes } from "./routes/analytics";
+import { providerIdentityRoutes } from "./routes/provider-identities";
 import { handleSlackNotify } from "./routes/slack-notify";
 import { webhookRoutes } from "./webhooks";
 
@@ -211,7 +212,10 @@ function isSandboxAuthRoute(path: string): boolean {
 }
 
 function isScmAgnosticRoute(path: string): boolean {
-  return /^\/analytics\/(summary|timeseries|breakdown)$/.test(path);
+  return (
+    /^\/analytics\/(summary|timeseries|breakdown)$/.test(path) ||
+    /^\/provider-identities\/[^/]+\/[^/]+$/.test(path)
+  );
 }
 
 function isProviderImplementedRoute(provider: SourceControlProviderName, path: string): boolean {
@@ -529,6 +533,9 @@ const routes: Route[] = [
 
   // Analytics
   ...analyticsRoutes,
+
+  // Provider identities
+  ...providerIdentityRoutes,
 
   // Webhooks (public routes — auth handled per-route)
   ...webhookRoutes,

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -214,7 +214,7 @@ function isSandboxAuthRoute(path: string): boolean {
 function isScmAgnosticRoute(path: string): boolean {
   return (
     /^\/analytics\/(summary|timeseries|breakdown)$/.test(path) ||
-    /^\/provider-identities\/[^/]+\/[^/]+$/.test(path)
+    /^\/provider-identities\/github\/[^/]+$/.test(path)
   );
 }
 

--- a/packages/control-plane/src/routes/provider-identities.test.ts
+++ b/packages/control-plane/src/routes/provider-identities.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { providerIdentityRoutes } from "./provider-identities";
+import type { RequestContext } from "./shared";
+import type { Env } from "../types";
+
+const mockUserStore = {
+  resolveOrCreateUser: vi.fn(),
+};
+
+vi.mock("../db/user-store", () => ({
+  UserStore: vi.fn().mockImplementation(() => mockUserStore),
+}));
+
+function createEnv(): Env {
+  return {
+    DB: {} as D1Database,
+  } as Env;
+}
+
+function createCtx(): RequestContext {
+  return {
+    trace_id: "trace-1",
+    request_id: "req-1",
+    metrics: {
+      d1Queries: [],
+      spans: {},
+      time: async <T>(_name: string, fn: () => Promise<T>) => fn(),
+      summarize: () => ({}),
+    },
+  };
+}
+
+async function callProviderIdentityRoute(path: string, body: unknown): Promise<Response> {
+  const route = providerIdentityRoutes.find((candidate) => candidate.method === "PUT")!;
+  const match = path.match(route.pattern);
+  if (!match) throw new Error(`No route match for ${path}`);
+
+  return route.handler(
+    new Request(`https://test.local${path}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    createEnv(),
+    match,
+    createCtx()
+  );
+}
+
+describe("provider identity routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserStore.resolveOrCreateUser.mockResolvedValue({
+      id: "0123456789abcdef0123456789abcdef",
+      displayName: "Ada",
+      email: "ada@example.com",
+      isNew: false,
+    });
+  });
+
+  describe("PUT /provider-identities/:provider/:providerUserId", () => {
+    it("upserts a GitHub identity and returns its canonical user ID", async () => {
+      const response = await callProviderIdentityRoute("/provider-identities/github/12345", {
+        providerLogin: "ada",
+        providerEmail: "ada@example.com",
+        displayName: "Ada Lovelace",
+        avatarUrl: "https://avatars.githubusercontent.com/u/12345",
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        userId: "0123456789abcdef0123456789abcdef",
+      });
+      expect(mockUserStore.resolveOrCreateUser).toHaveBeenCalledWith({
+        provider: "github",
+        providerUserId: "12345",
+        providerLogin: "ada",
+        providerEmail: "ada@example.com",
+        displayName: "Ada Lovelace",
+        avatarUrl: "https://avatars.githubusercontent.com/u/12345",
+      });
+    });
+
+    it("rejects unsupported providers", async () => {
+      const response = await callProviderIdentityRoute("/provider-identities/slack/U123", {});
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({ error: "provider must be github" });
+      expect(mockUserStore.resolveOrCreateUser).not.toHaveBeenCalled();
+    });
+
+    it("rejects blank provider user IDs", async () => {
+      const response = await callProviderIdentityRoute("/provider-identities/github/%20%20%20", {});
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({ error: "providerUserId is required" });
+      expect(mockUserStore.resolveOrCreateUser).not.toHaveBeenCalled();
+    });
+
+    it("rejects invalid path encoding for provider user IDs", async () => {
+      const response = await callProviderIdentityRoute("/provider-identities/github/%E0%A4%A", {});
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({ error: "providerUserId is required" });
+      expect(mockUserStore.resolveOrCreateUser).not.toHaveBeenCalled();
+    });
+
+    it("rejects unexpected non-canonical resolved IDs", async () => {
+      mockUserStore.resolveOrCreateUser.mockResolvedValue({
+        id: "user-1",
+        displayName: null,
+        email: null,
+        isNew: false,
+      });
+
+      const response = await callProviderIdentityRoute("/provider-identities/github/12345", {});
+
+      expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toEqual({ error: "Resolved user ID is invalid" });
+    });
+  });
+});

--- a/packages/control-plane/src/routes/provider-identities.test.ts
+++ b/packages/control-plane/src/routes/provider-identities.test.ts
@@ -58,7 +58,7 @@ describe("provider identity routes", () => {
     });
   });
 
-  describe("PUT /provider-identities/:provider/:providerUserId", () => {
+  describe("PUT /provider-identities/github/:providerUserId", () => {
     it("upserts a GitHub identity and returns its canonical user ID", async () => {
       const response = await callProviderIdentityRoute("/provider-identities/github/12345", {
         providerLogin: "ada",
@@ -81,14 +81,6 @@ describe("provider identity routes", () => {
       });
     });
 
-    it("rejects unsupported providers", async () => {
-      const response = await callProviderIdentityRoute("/provider-identities/slack/U123", {});
-
-      expect(response.status).toBe(400);
-      await expect(response.json()).resolves.toEqual({ error: "provider must be github" });
-      expect(mockUserStore.resolveOrCreateUser).not.toHaveBeenCalled();
-    });
-
     it("rejects blank provider user IDs", async () => {
       const response = await callProviderIdentityRoute("/provider-identities/github/%20%20%20", {});
 
@@ -102,6 +94,14 @@ describe("provider identity routes", () => {
 
       expect(response.status).toBe(400);
       await expect(response.json()).resolves.toEqual({ error: "providerUserId is required" });
+      expect(mockUserStore.resolveOrCreateUser).not.toHaveBeenCalled();
+    });
+
+    it("rejects non-object JSON bodies", async () => {
+      const response = await callProviderIdentityRoute("/provider-identities/github/12345", null);
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({ error: "Request body must be an object" });
       expect(mockUserStore.resolveOrCreateUser).not.toHaveBeenCalled();
     });
 

--- a/packages/control-plane/src/routes/provider-identities.ts
+++ b/packages/control-plane/src/routes/provider-identities.ts
@@ -17,6 +17,10 @@ type UpsertProviderIdentityRequest = {
   avatarUrl?: unknown;
 };
 
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 function optionalString(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
@@ -40,10 +44,8 @@ export async function handleUpsertProviderIdentity(
 ): Promise<Response> {
   const body = await parseJsonBody<UpsertProviderIdentityRequest>(request);
   if (body instanceof Response) return body;
-
-  const provider = pathSegment(match.groups?.provider);
-  if (provider !== "github") {
-    return error("provider must be github", 400);
+  if (!isObjectRecord(body)) {
+    return error("Request body must be an object", 400);
   }
 
   const providerUserId = pathSegment(match.groups?.providerUserId);
@@ -71,7 +73,7 @@ export async function handleUpsertProviderIdentity(
 export const providerIdentityRoutes: Route[] = [
   {
     method: "PUT",
-    pattern: parsePattern("/provider-identities/:provider/:providerUserId"),
+    pattern: parsePattern("/provider-identities/github/:providerUserId"),
     handler: handleUpsertProviderIdentity,
   },
 ];

--- a/packages/control-plane/src/routes/provider-identities.ts
+++ b/packages/control-plane/src/routes/provider-identities.ts
@@ -1,0 +1,77 @@
+import { isCanonicalUserId } from "@open-inspect/shared";
+import { UserStore, type ProviderIdentity } from "../db/user-store";
+import type { Env } from "../types";
+import {
+  type RequestContext,
+  type Route,
+  error,
+  json,
+  parseJsonBody,
+  parsePattern,
+} from "./shared";
+
+type UpsertProviderIdentityRequest = {
+  providerLogin?: unknown;
+  providerEmail?: unknown;
+  displayName?: unknown;
+  avatarUrl?: unknown;
+};
+
+function optionalString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function pathSegment(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    return optionalString(decodeURIComponent(value));
+  } catch {
+    return undefined;
+  }
+}
+
+export async function handleUpsertProviderIdentity(
+  request: Request,
+  env: Env,
+  match: RegExpMatchArray,
+  _ctx: RequestContext
+): Promise<Response> {
+  const body = await parseJsonBody<UpsertProviderIdentityRequest>(request);
+  if (body instanceof Response) return body;
+
+  const provider = pathSegment(match.groups?.provider);
+  if (provider !== "github") {
+    return error("provider must be github", 400);
+  }
+
+  const providerUserId = pathSegment(match.groups?.providerUserId);
+  if (!providerUserId) {
+    return error("providerUserId is required", 400);
+  }
+
+  const identity: ProviderIdentity = {
+    provider: "github",
+    providerUserId,
+    providerLogin: optionalString(body.providerLogin),
+    providerEmail: optionalString(body.providerEmail),
+    displayName: optionalString(body.displayName),
+    avatarUrl: optionalString(body.avatarUrl),
+  };
+
+  const resolvedUser = await new UserStore(env.DB).resolveOrCreateUser(identity);
+  if (!isCanonicalUserId(resolvedUser.id)) {
+    return error("Resolved user ID is invalid", 500);
+  }
+
+  return json({ userId: resolvedUser.id });
+}
+
+export const providerIdentityRoutes: Route[] = [
+  {
+    method: "PUT",
+    pattern: parsePattern("/provider-identities/:provider/:providerUserId"),
+    handler: handleUpsertProviderIdentity,
+  },
+];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -12,4 +12,5 @@ export * from "./completion/extractor";
 export * from "./logger";
 export * from "./cache-store";
 export * from "./app-name";
+export * from "./user-id";
 export * from "./slack";

--- a/packages/shared/src/user-id.test.ts
+++ b/packages/shared/src/user-id.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { isCanonicalUserId } from "./user-id";
+
+describe("canonical user IDs", () => {
+  it("accepts generated 32-character lowercase hex IDs", () => {
+    expect(isCanonicalUserId("0123456789abcdef0123456789abcdef")).toBe(true);
+  });
+
+  it("rejects non-canonical values", () => {
+    expect(isCanonicalUserId("0123456789ABCDEF0123456789ABCDEF")).toBe(false);
+    expect(isCanonicalUserId("0123456789abcdef")).toBe(false);
+    expect(isCanonicalUserId("user-1")).toBe(false);
+    expect(isCanonicalUserId(null)).toBe(false);
+  });
+});

--- a/packages/shared/src/user-id.ts
+++ b/packages/shared/src/user-id.ts
@@ -1,0 +1,5 @@
+const CANONICAL_USER_ID_PATTERN = /^[0-9a-f]{32}$/;
+
+export function isCanonicalUserId(value: unknown): value is string {
+  return typeof value === "string" && CANONICAL_USER_ID_PATTERN.test(value);
+}

--- a/packages/web/src/app/api/me/route.test.ts
+++ b/packages/web/src/app/api/me/route.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  authOptions: {},
+}));
+
+vi.mock("@/lib/control-plane", () => ({
+  controlPlaneFetch: vi.fn(),
+}));
+
+import { getServerSession } from "next-auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+import { GET } from "./route";
+
+describe("current user API route", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns 401 when the user session is missing", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
+    expect(controlPlaneFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when the GitHub user ID is missing", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { email: "ada@example.com" } } as never);
+
+    const response = await GET();
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: "GitHub user ID is unavailable" });
+    expect(controlPlaneFetch).not.toHaveBeenCalled();
+  });
+
+  it("resolves the signed-in GitHub user through the control plane", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: {
+        id: "12345",
+        login: "ada",
+        name: "Ada Lovelace",
+        email: "ada@example.com",
+        image: "https://avatars.githubusercontent.com/u/12345",
+      },
+    } as never);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(
+      Response.json({ userId: "0123456789abcdef0123456789abcdef" })
+    );
+
+    const response = await GET();
+
+    expect(controlPlaneFetch).toHaveBeenCalledWith("/provider-identities/github/12345", {
+      method: "PUT",
+      body: JSON.stringify({
+        providerLogin: "ada",
+        providerEmail: "ada@example.com",
+        displayName: "Ada Lovelace",
+        avatarUrl: "https://avatars.githubusercontent.com/u/12345",
+      }),
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      userId: "0123456789abcdef0123456789abcdef",
+    });
+  });
+
+  it("falls back to login for displayName", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: {
+        id: "12345",
+        login: "ada",
+        name: null,
+        email: null,
+        image: null,
+      },
+    } as never);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(
+      Response.json({ userId: "0123456789abcdef0123456789abcdef" })
+    );
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(controlPlaneFetch).toHaveBeenCalledWith(
+      "/provider-identities/github/12345",
+      expect.objectContaining({
+        body: JSON.stringify({
+          providerLogin: "ada",
+          providerEmail: null,
+          displayName: "ada",
+          avatarUrl: null,
+        }),
+      })
+    );
+  });
+
+  it("forwards control-plane errors", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "12345" } } as never);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(
+      Response.json({ error: "providerUserId is required" }, { status: 400 })
+    );
+
+    const response = await GET();
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "providerUserId is required" });
+  });
+
+  it("rejects invalid current user responses", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "12345" } } as never);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(Response.json({ userId: "user-1" }));
+
+    const response = await GET();
+
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid current user response" });
+  });
+
+  it("returns 500 when the control-plane request throws", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "12345" } } as never);
+    vi.mocked(controlPlaneFetch).mockRejectedValue(new Error("boom"));
+
+    const response = await GET();
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "Failed to resolve current user" });
+  });
+});

--- a/packages/web/src/app/api/me/route.ts
+++ b/packages/web/src/app/api/me/route.ts
@@ -1,0 +1,50 @@
+import { isCanonicalUserId } from "@open-inspect/shared";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+
+type CurrentUserResponse = {
+  userId?: unknown;
+};
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const user = session.user;
+  if (!user.id) {
+    return NextResponse.json({ error: "GitHub user ID is unavailable" }, { status: 409 });
+  }
+
+  try {
+    const response = await controlPlaneFetch(
+      `/provider-identities/github/${encodeURIComponent(user.id)}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({
+          providerLogin: user.login,
+          providerEmail: user.email,
+          displayName: user.name || user.login,
+          avatarUrl: user.image,
+        }),
+      }
+    );
+
+    const data = (await response.json()) as CurrentUserResponse;
+    if (!response.ok) {
+      return NextResponse.json(data, { status: response.status });
+    }
+
+    if (!isCanonicalUserId(data.userId)) {
+      return NextResponse.json({ error: "Invalid current user response" }, { status: 502 });
+    }
+
+    return NextResponse.json({ userId: data.userId });
+  } catch (error) {
+    console.error("Failed to resolve current user:", error);
+    return NextResponse.json({ error: "Failed to resolve current user" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary

- Add a shared canonical user ID validator for 32-character lowercase hex D1 user IDs.
- Add an internal HMAC-authenticated `PUT /provider-identities/:provider/:providerUserId` control-plane route that upserts provider identity metadata through `UserStore.resolveOrCreateUser` and returns the canonical `userId`.
- Add browser-facing `GET /api/me`, deriving GitHub identity from the server-side NextAuth session and returning only the canonical user ID.

## Validation

- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/shared -- user-id`
- `npm run typecheck -w @open-inspect/shared`
- `npm run lint -w @open-inspect/shared -- --quiet`
- `npm test -w @open-inspect/control-plane -- routes/provider-identities.test.ts router.provider-identities.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane -- --quiet`
- `npm test -w @open-inspect/web -- app/api/me/route.test.ts`
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web -- --quiet`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New API to return the authenticated user's GitHub-derived identity and canonical user ID.
  * New endpoints to upsert GitHub provider identities and return a canonical user ID.
  * Shared validator ensuring canonical 32-character lowercase hex user IDs.

* **Bug Fixes**
  * Improved input validation and explicit error responses for invalid provider-user IDs and malformed requests.
  * Better error handling when identity resolution returns unexpected values.

* **Tests**
  * Added integration and unit tests covering success, validation failures, and error paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/686?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->