### PR TITLE
fix(modal): support non-main Modal environments

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -188,6 +188,7 @@ jobs:
           TF_VAR_modal_token_id: ${{ secrets.MODAL_TOKEN_ID }}
           TF_VAR_modal_token_secret: ${{ secrets.MODAL_TOKEN_SECRET }}
           TF_VAR_modal_workspace: ${{ secrets.MODAL_WORKSPACE }}
+          TF_VAR_modal_environment: "${{ secrets.MODAL_ENVIRONMENT || 'main' }}"
           TF_VAR_github_client_id: ${{ secrets.GH_OAUTH_CLIENT_ID }}
           TF_VAR_github_client_secret: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
           TF_VAR_github_app_id: ${{ secrets.GH_APP_ID }}
@@ -319,6 +320,7 @@ jobs:
           TF_VAR_modal_token_id: ${{ secrets.MODAL_TOKEN_ID }}
           TF_VAR_modal_token_secret: ${{ secrets.MODAL_TOKEN_SECRET }}
           TF_VAR_modal_workspace: ${{ secrets.MODAL_WORKSPACE }}
+          TF_VAR_modal_environment: "${{ secrets.MODAL_ENVIRONMENT || 'main' }}"
           TF_VAR_github_client_id: ${{ secrets.GH_OAUTH_CLIENT_ID }}
           TF_VAR_github_client_secret: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
           TF_VAR_github_app_id: ${{ secrets.GH_APP_ID }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -189,6 +189,7 @@ jobs:
           TF_VAR_modal_token_secret: ${{ secrets.MODAL_TOKEN_SECRET }}
           TF_VAR_modal_workspace: ${{ secrets.MODAL_WORKSPACE }}
           TF_VAR_modal_environment: "${{ secrets.MODAL_ENVIRONMENT || 'main' }}"
+          TF_VAR_modal_environment_web_suffix: ${{ secrets.MODAL_ENVIRONMENT_WEB_SUFFIX }}
           TF_VAR_github_client_id: ${{ secrets.GH_OAUTH_CLIENT_ID }}
           TF_VAR_github_client_secret: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
           TF_VAR_github_app_id: ${{ secrets.GH_APP_ID }}
@@ -321,6 +322,7 @@ jobs:
           TF_VAR_modal_token_secret: ${{ secrets.MODAL_TOKEN_SECRET }}
           TF_VAR_modal_workspace: ${{ secrets.MODAL_WORKSPACE }}
           TF_VAR_modal_environment: "${{ secrets.MODAL_ENVIRONMENT || 'main' }}"
+          TF_VAR_modal_environment_web_suffix: ${{ secrets.MODAL_ENVIRONMENT_WEB_SUFFIX }}
           TF_VAR_github_client_id: ${{ secrets.GH_OAUTH_CLIENT_ID }}
           TF_VAR_github_client_secret: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
           TF_VAR_github_app_id: ${{ secrets.GH_APP_ID }}

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -152,8 +152,9 @@ Create an R2 API Token:
 3. Note the **Token ID** and **Token Secret**
 4. Note your **Workspace** and **Environment name** (visible in your Modal dashboard URL,
    https://modal.com/apps/<modal_workspace>/<modal_environment>)
-5. Note the environment's **Web suffix** from Modal's environment settings. Leave it empty for the
-   environment whose endpoints use `https://<workspace>--...modal.run`.
+5. Note the environment's **Web suffix** from Modal's environment settings. Use the normalized
+   lowercase suffix made of letters, digits, and dashes. Leave it empty for the environment whose
+   endpoints use `https://<workspace>--...modal.run`.
 
 ### Daytona
 
@@ -359,7 +360,7 @@ modal_token_id              = "your-modal-token-id"
 modal_token_secret          = "your-modal-token-secret"
 modal_workspace             = "your-modal-workspace"
 modal_environment           = "your-modal-environment"
-modal_environment_web_suffix = "your-modal-web-suffix" # Empty for https://workspace--... endpoints
+modal_environment_web_suffix = "your-modal-web-suffix" # Lowercase letters, digits, dashes; empty for https://workspace--... endpoints
 
 # Daytona (only required when sandbox_provider = "daytona")
 # daytona_api_url           = "https://app.daytona.io/api"
@@ -633,8 +634,11 @@ Or manually:
 # 1. Control Plane health check (replace {deployment_name} and YOUR-SUBDOMAIN)
 curl https://open-inspect-control-plane-{deployment_name}.YOUR-SUBDOMAIN.workers.dev/health
 
-# 2. Modal health check (replace YOUR-WORKSPACE)
-curl https://YOUR-WORKSPACE--open-inspect-api-health.modal.run
+# 2. Modal health check
+# Prefer the exact URL from terraform output verification_commands.
+# Manual form: https://<workspace>[-<modal_environment_web_suffix>]--open-inspect-api-health.modal.run
+MODAL_WORKSPACE_SLUG="YOUR-WORKSPACE" # or "YOUR-WORKSPACE-YOUR-MODAL-WEB-SUFFIX"
+curl https://${MODAL_WORKSPACE_SLUG}--open-inspect-api-health.modal.run
 
 # 3. Web app (should return 200)
 # Vercel:
@@ -658,46 +662,46 @@ Enable automatic deployments when you push to main by adding GitHub Secrets.
 
 Go to your fork's Settings → Secrets and variables → Actions, and add:
 
-| Secret Name                    | Value                                                                         |
-| ------------------------------ | ----------------------------------------------------------------------------- |
-| `CLOUDFLARE_API_TOKEN`         | Your Cloudflare API token                                                     |
-| `CLOUDFLARE_ACCOUNT_ID`        | Your Cloudflare account ID                                                    |
-| `CLOUDFLARE_WORKER_SUBDOMAIN`  | Your workers.dev subdomain                                                    |
-| `DEPLOYMENT_NAME`              | Your deployment name                                                          |
-| `R2_ACCESS_KEY_ID`             | R2 access key ID                                                              |
-| `R2_SECRET_ACCESS_KEY`         | R2 secret access key                                                          |
-| `WEB_PLATFORM`                 | `vercel` or `cloudflare`                                                      |
-| `VERCEL_API_TOKEN`             | Vercel API token _(only if `web_platform = "vercel"`)_                        |
-| `VERCEL_TEAM_ID`               | Vercel team/account ID _(only if `web_platform = "vercel"`)_                  |
-| `VERCEL_PROJECT_ID`            | Vercel project ID _(only if `web_platform = "vercel"`)_                       |
-| `NEXTAUTH_URL`                 | Your web app URL                                                              |
-| `MODAL_TOKEN_ID`               | Modal token ID                                                                |
-| `MODAL_TOKEN_SECRET`           | Modal token secret                                                            |
-| `MODAL_WORKSPACE`              | Modal workspace name                                                          |
-| `MODAL_ENVIRONMENT`            | Modal environment name (defaults to `main`)                                   |
-| `MODAL_ENVIRONMENT_WEB_SUFFIX` | Modal environment web suffix for endpoint URLs                                |
-| `GH_OAUTH_CLIENT_ID`           | GitHub App OAuth client ID                                                    |
-| `GH_OAUTH_CLIENT_SECRET`       | GitHub App OAuth client secret                                                |
-| `GH_APP_ID`                    | GitHub App ID                                                                 |
-| `GH_APP_PRIVATE_KEY`           | GitHub App private key (PKCS#8 format)                                        |
-| `GH_APP_INSTALLATION_ID`       | GitHub App installation ID                                                    |
-| `ENABLE_SLACK_BOT`             | `true` to deploy Slack bot, `false` to skip (default: `true`)                 |
-| `SLACK_BOT_TOKEN`              | Slack bot token (required if enabled)                                         |
-| `SLACK_SIGNING_SECRET`         | Slack signing secret (required if enabled)                                    |
-| `ANTHROPIC_API_KEY`            | Anthropic API key                                                             |
-| `TOKEN_ENCRYPTION_KEY`         | Generated encryption key (OAuth tokens)                                       |
-| `REPO_SECRETS_ENCRYPTION_KEY`  | Generated encryption key (repo secrets)                                       |
-| `INTERNAL_CALLBACK_SECRET`     | Generated callback secret                                                     |
-| `MODAL_API_SECRET`             | Generated Modal API secret                                                    |
-| `NEXTAUTH_SECRET`              | Generated NextAuth secret                                                     |
-| `ALLOWED_USERS`                | Comma-separated GitHub usernames (or empty for all users)                     |
-| `ALLOWED_EMAIL_DOMAINS`        | Comma-separated email domains (or empty for all domains)                      |
-| `ENABLE_GITHUB_BOT`            | `true` to deploy GitHub bot worker (or empty to skip)                         |
-| `GH_WEBHOOK_SECRET`            | GitHub webhook secret (required if GitHub bot enabled)                        |
-| `GH_BOT_USERNAME`              | GitHub App bot username, e.g., `my-app[bot]` (required if GitHub bot enabled) |
-| `APP_NAME`                     | Optional display name for whitelabeling (default: `Open-Inspect`)             |
-| `APP_SHORT_NAME`               | Optional short label for sidebar header (default: `Inspect`)                  |
-| `APP_ICON_URL`                 | Optional URL to a custom logo/favicon (default: built-in icon)                |
+| Secret Name                    | Value                                                                                       |
+| ------------------------------ | ------------------------------------------------------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`         | Your Cloudflare API token                                                                   |
+| `CLOUDFLARE_ACCOUNT_ID`        | Your Cloudflare account ID                                                                  |
+| `CLOUDFLARE_WORKER_SUBDOMAIN`  | Your workers.dev subdomain                                                                  |
+| `DEPLOYMENT_NAME`              | Your deployment name                                                                        |
+| `R2_ACCESS_KEY_ID`             | R2 access key ID                                                                            |
+| `R2_SECRET_ACCESS_KEY`         | R2 secret access key                                                                        |
+| `WEB_PLATFORM`                 | `vercel` or `cloudflare`                                                                    |
+| `VERCEL_API_TOKEN`             | Vercel API token _(only if `web_platform = "vercel"`)_                                      |
+| `VERCEL_TEAM_ID`               | Vercel team/account ID _(only if `web_platform = "vercel"`)_                                |
+| `VERCEL_PROJECT_ID`            | Vercel project ID _(only if `web_platform = "vercel"`)_                                     |
+| `NEXTAUTH_URL`                 | Your web app URL                                                                            |
+| `MODAL_TOKEN_ID`               | Modal token ID                                                                              |
+| `MODAL_TOKEN_SECRET`           | Modal token secret                                                                          |
+| `MODAL_WORKSPACE`              | Modal workspace name                                                                        |
+| `MODAL_ENVIRONMENT`            | Modal environment name (defaults to `main`)                                                 |
+| `MODAL_ENVIRONMENT_WEB_SUFFIX` | Modal environment web suffix for endpoint URLs; lowercase letters, digits, dashes, or empty |
+| `GH_OAUTH_CLIENT_ID`           | GitHub App OAuth client ID                                                                  |
+| `GH_OAUTH_CLIENT_SECRET`       | GitHub App OAuth client secret                                                              |
+| `GH_APP_ID`                    | GitHub App ID                                                                               |
+| `GH_APP_PRIVATE_KEY`           | GitHub App private key (PKCS#8 format)                                                      |
+| `GH_APP_INSTALLATION_ID`       | GitHub App installation ID                                                                  |
+| `ENABLE_SLACK_BOT`             | `true` to deploy Slack bot, `false` to skip (default: `true`)                               |
+| `SLACK_BOT_TOKEN`              | Slack bot token (required if enabled)                                                       |
+| `SLACK_SIGNING_SECRET`         | Slack signing secret (required if enabled)                                                  |
+| `ANTHROPIC_API_KEY`            | Anthropic API key                                                                           |
+| `TOKEN_ENCRYPTION_KEY`         | Generated encryption key (OAuth tokens)                                                     |
+| `REPO_SECRETS_ENCRYPTION_KEY`  | Generated encryption key (repo secrets)                                                     |
+| `INTERNAL_CALLBACK_SECRET`     | Generated callback secret                                                                   |
+| `MODAL_API_SECRET`             | Generated Modal API secret                                                                  |
+| `NEXTAUTH_SECRET`              | Generated NextAuth secret                                                                   |
+| `ALLOWED_USERS`                | Comma-separated GitHub usernames (or empty for all users)                                   |
+| `ALLOWED_EMAIL_DOMAINS`        | Comma-separated email domains (or empty for all domains)                                    |
+| `ENABLE_GITHUB_BOT`            | `true` to deploy GitHub bot worker (or empty to skip)                                       |
+| `GH_WEBHOOK_SECRET`            | GitHub webhook secret (required if GitHub bot enabled)                                      |
+| `GH_BOT_USERNAME`              | GitHub App bot username, e.g., `my-app[bot]` (required if GitHub bot enabled)               |
+| `APP_NAME`                     | Optional display name for whitelabeling (default: `Open-Inspect`)                           |
+| `APP_SHORT_NAME`               | Optional short label for sidebar header (default: `Inspect`)                                |
+| `APP_ICON_URL`                 | Optional URL to a custom logo/favicon (default: built-in icon)                              |
 
 **Bulk upload secrets with `gh` CLI:**
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -150,8 +150,10 @@ Create an R2 API Token:
 1. Go to [Modal Settings](https://modal.com/settings)
 2. **Create a new API token**: Settings -> API Tokens -> New Token
 3. Note the **Token ID** and **Token Secret**
-4. Note your **Workspace** and **Environment names** (visible in your Modal dashboard URL,
+4. Note your **Workspace** and **Environment name** (visible in your Modal dashboard URL,
    https://modal.com/apps/<modal_workspace>/<modal_environment>)
+5. Note the environment's **Web suffix** from Modal's environment settings. Leave it empty for the
+   environment whose endpoints use `https://<workspace>--...modal.run`.
 
 ### Daytona
 
@@ -357,6 +359,7 @@ modal_token_id              = "your-modal-token-id"
 modal_token_secret          = "your-modal-token-secret"
 modal_workspace             = "your-modal-workspace"
 modal_environment           = "your-modal-environment"
+modal_environment_web_suffix = "your-modal-web-suffix" # Empty for https://workspace--... endpoints
 
 # Daytona (only required when sandbox_provider = "daytona")
 # daytona_api_url           = "https://app.daytona.io/api"
@@ -655,45 +658,46 @@ Enable automatic deployments when you push to main by adding GitHub Secrets.
 
 Go to your fork's Settings → Secrets and variables → Actions, and add:
 
-| Secret Name                   | Value                                                                         |
-| ----------------------------- | ----------------------------------------------------------------------------- |
-| `CLOUDFLARE_API_TOKEN`        | Your Cloudflare API token                                                     |
-| `CLOUDFLARE_ACCOUNT_ID`       | Your Cloudflare account ID                                                    |
-| `CLOUDFLARE_WORKER_SUBDOMAIN` | Your workers.dev subdomain                                                    |
-| `DEPLOYMENT_NAME`             | Your deployment name                                                          |
-| `R2_ACCESS_KEY_ID`            | R2 access key ID                                                              |
-| `R2_SECRET_ACCESS_KEY`        | R2 secret access key                                                          |
-| `WEB_PLATFORM`                | `vercel` or `cloudflare`                                                      |
-| `VERCEL_API_TOKEN`            | Vercel API token _(only if `web_platform = "vercel"`)_                        |
-| `VERCEL_TEAM_ID`              | Vercel team/account ID _(only if `web_platform = "vercel"`)_                  |
-| `VERCEL_PROJECT_ID`           | Vercel project ID _(only if `web_platform = "vercel"`)_                       |
-| `NEXTAUTH_URL`                | Your web app URL                                                              |
-| `MODAL_TOKEN_ID`              | Modal token ID                                                                |
-| `MODAL_TOKEN_SECRET`          | Modal token secret                                                            |
-| `MODAL_WORKSPACE`             | Modal workspace name                                                          |
-| `MODAL_ENVIRONMENT`           | Modal environment name (defaults to `main`)                                   |
-| `GH_OAUTH_CLIENT_ID`          | GitHub App OAuth client ID                                                    |
-| `GH_OAUTH_CLIENT_SECRET`      | GitHub App OAuth client secret                                                |
-| `GH_APP_ID`                   | GitHub App ID                                                                 |
-| `GH_APP_PRIVATE_KEY`          | GitHub App private key (PKCS#8 format)                                        |
-| `GH_APP_INSTALLATION_ID`      | GitHub App installation ID                                                    |
-| `ENABLE_SLACK_BOT`            | `true` to deploy Slack bot, `false` to skip (default: `true`)                 |
-| `SLACK_BOT_TOKEN`             | Slack bot token (required if enabled)                                         |
-| `SLACK_SIGNING_SECRET`        | Slack signing secret (required if enabled)                                    |
-| `ANTHROPIC_API_KEY`           | Anthropic API key                                                             |
-| `TOKEN_ENCRYPTION_KEY`        | Generated encryption key (OAuth tokens)                                       |
-| `REPO_SECRETS_ENCRYPTION_KEY` | Generated encryption key (repo secrets)                                       |
-| `INTERNAL_CALLBACK_SECRET`    | Generated callback secret                                                     |
-| `MODAL_API_SECRET`            | Generated Modal API secret                                                    |
-| `NEXTAUTH_SECRET`             | Generated NextAuth secret                                                     |
-| `ALLOWED_USERS`               | Comma-separated GitHub usernames (or empty for all users)                     |
-| `ALLOWED_EMAIL_DOMAINS`       | Comma-separated email domains (or empty for all domains)                      |
-| `ENABLE_GITHUB_BOT`           | `true` to deploy GitHub bot worker (or empty to skip)                         |
-| `GH_WEBHOOK_SECRET`           | GitHub webhook secret (required if GitHub bot enabled)                        |
-| `GH_BOT_USERNAME`             | GitHub App bot username, e.g., `my-app[bot]` (required if GitHub bot enabled) |
-| `APP_NAME`                    | Optional display name for whitelabeling (default: `Open-Inspect`)             |
-| `APP_SHORT_NAME`              | Optional short label for sidebar header (default: `Inspect`)                  |
-| `APP_ICON_URL`                | Optional URL to a custom logo/favicon (default: built-in icon)                |
+| Secret Name                    | Value                                                                         |
+| ------------------------------ | ----------------------------------------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`         | Your Cloudflare API token                                                     |
+| `CLOUDFLARE_ACCOUNT_ID`        | Your Cloudflare account ID                                                    |
+| `CLOUDFLARE_WORKER_SUBDOMAIN`  | Your workers.dev subdomain                                                    |
+| `DEPLOYMENT_NAME`              | Your deployment name                                                          |
+| `R2_ACCESS_KEY_ID`             | R2 access key ID                                                              |
+| `R2_SECRET_ACCESS_KEY`         | R2 secret access key                                                          |
+| `WEB_PLATFORM`                 | `vercel` or `cloudflare`                                                      |
+| `VERCEL_API_TOKEN`             | Vercel API token _(only if `web_platform = "vercel"`)_                        |
+| `VERCEL_TEAM_ID`               | Vercel team/account ID _(only if `web_platform = "vercel"`)_                  |
+| `VERCEL_PROJECT_ID`            | Vercel project ID _(only if `web_platform = "vercel"`)_                       |
+| `NEXTAUTH_URL`                 | Your web app URL                                                              |
+| `MODAL_TOKEN_ID`               | Modal token ID                                                                |
+| `MODAL_TOKEN_SECRET`           | Modal token secret                                                            |
+| `MODAL_WORKSPACE`              | Modal workspace name                                                          |
+| `MODAL_ENVIRONMENT`            | Modal environment name (defaults to `main`)                                   |
+| `MODAL_ENVIRONMENT_WEB_SUFFIX` | Modal environment web suffix for endpoint URLs                                |
+| `GH_OAUTH_CLIENT_ID`           | GitHub App OAuth client ID                                                    |
+| `GH_OAUTH_CLIENT_SECRET`       | GitHub App OAuth client secret                                                |
+| `GH_APP_ID`                    | GitHub App ID                                                                 |
+| `GH_APP_PRIVATE_KEY`           | GitHub App private key (PKCS#8 format)                                        |
+| `GH_APP_INSTALLATION_ID`       | GitHub App installation ID                                                    |
+| `ENABLE_SLACK_BOT`             | `true` to deploy Slack bot, `false` to skip (default: `true`)                 |
+| `SLACK_BOT_TOKEN`              | Slack bot token (required if enabled)                                         |
+| `SLACK_SIGNING_SECRET`         | Slack signing secret (required if enabled)                                    |
+| `ANTHROPIC_API_KEY`            | Anthropic API key                                                             |
+| `TOKEN_ENCRYPTION_KEY`         | Generated encryption key (OAuth tokens)                                       |
+| `REPO_SECRETS_ENCRYPTION_KEY`  | Generated encryption key (repo secrets)                                       |
+| `INTERNAL_CALLBACK_SECRET`     | Generated callback secret                                                     |
+| `MODAL_API_SECRET`             | Generated Modal API secret                                                    |
+| `NEXTAUTH_SECRET`              | Generated NextAuth secret                                                     |
+| `ALLOWED_USERS`                | Comma-separated GitHub usernames (or empty for all users)                     |
+| `ALLOWED_EMAIL_DOMAINS`        | Comma-separated email domains (or empty for all domains)                      |
+| `ENABLE_GITHUB_BOT`            | `true` to deploy GitHub bot worker (or empty to skip)                         |
+| `GH_WEBHOOK_SECRET`            | GitHub webhook secret (required if GitHub bot enabled)                        |
+| `GH_BOT_USERNAME`              | GitHub App bot username, e.g., `my-app[bot]` (required if GitHub bot enabled) |
+| `APP_NAME`                     | Optional display name for whitelabeling (default: `Open-Inspect`)             |
+| `APP_SHORT_NAME`               | Optional short label for sidebar header (default: `Inspect`)                  |
+| `APP_ICON_URL`                 | Optional URL to a custom logo/favicon (default: built-in icon)                |
 
 **Bulk upload secrets with `gh` CLI:**
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -671,6 +671,7 @@ Go to your fork's Settings → Secrets and variables → Actions, and add:
 | `MODAL_TOKEN_ID`              | Modal token ID                                                                |
 | `MODAL_TOKEN_SECRET`          | Modal token secret                                                            |
 | `MODAL_WORKSPACE`             | Modal workspace name                                                          |
+| `MODAL_ENVIRONMENT`           | Modal environment name (defaults to `main`)                                   |
 | `GH_OAUTH_CLIENT_ID`          | GitHub App OAuth client ID                                                    |
 | `GH_OAUTH_CLIENT_SECRET`      | GitHub App OAuth client secret                                                |
 | `GH_APP_ID`                   | GitHub App ID                                                                 |

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -150,7 +150,8 @@ Create an R2 API Token:
 1. Go to [Modal Settings](https://modal.com/settings)
 2. **Create a new API token**: Settings -> API Tokens -> New Token
 3. Note the **Token ID** and **Token Secret**
-4. Note your **Workspace name** (visible in your Modal dashboard URL)
+4. Note your **Workspace** and **Environment names** (visible in your Modal dashboard URL,
+   https://modal.com/apps/<modal_workspace>/<modal_environment>)
 
 ### Daytona
 
@@ -355,6 +356,7 @@ vercel_team_id              = "team_xxxxx"       # Your Vercel ID (even personal
 modal_token_id              = "your-modal-token-id"
 modal_token_secret          = "your-modal-token-secret"
 modal_workspace             = "your-modal-workspace"
+modal_environment           = "your-modal-environment"
 
 # Daytona (only required when sandbox_provider = "daytona")
 # daytona_api_url           = "https://app.daytona.io/api"

--- a/packages/control-plane/src/routes/repo-images.ts
+++ b/packages/control-plane/src/routes/repo-images.ts
@@ -97,7 +97,11 @@ async function handleBuildComplete(
       ctx.executionCtx?.waitUntil(
         (async () => {
           try {
-            const client = createModalClient(env.MODAL_API_SECRET!, env.MODAL_WORKSPACE!);
+            const client = createModalClient(
+              env.MODAL_API_SECRET!,
+              env.MODAL_WORKSPACE!,
+              env.MODAL_ENVIRONMENT
+            );
             await client.deleteProviderImage({ providerImageId: result.replacedImageId! });
           } catch (e) {
             logger.warn("repo_image.delete_old_failed", {
@@ -261,7 +265,11 @@ async function handleTriggerBuild(
     }
 
     // Trigger build on Modal
-    const client = createModalClient(env.MODAL_API_SECRET, env.MODAL_WORKSPACE);
+    const client = createModalClient(
+      env.MODAL_API_SECRET,
+      env.MODAL_WORKSPACE,
+      env.MODAL_ENVIRONMENT
+    );
     await client.buildRepoImage(
       {
         repoOwner: owner,

--- a/packages/control-plane/src/routes/repo-images.ts
+++ b/packages/control-plane/src/routes/repo-images.ts
@@ -100,7 +100,7 @@ async function handleBuildComplete(
             const client = createModalClient(
               env.MODAL_API_SECRET!,
               env.MODAL_WORKSPACE!,
-              env.MODAL_ENVIRONMENT
+              env.MODAL_ENVIRONMENT_WEB_SUFFIX
             );
             await client.deleteProviderImage({ providerImageId: result.replacedImageId! });
           } catch (e) {
@@ -268,7 +268,7 @@ async function handleTriggerBuild(
     const client = createModalClient(
       env.MODAL_API_SECRET,
       env.MODAL_WORKSPACE,
-      env.MODAL_ENVIRONMENT
+      env.MODAL_ENVIRONMENT_WEB_SUFFIX
     );
     await client.buildRepoImage(
       {

--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -1,5 +1,21 @@
-import { describe, expect, it } from "vitest";
-import { buildModalSandboxDashboardUrl } from "./client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildModalSandboxDashboardUrl,
+  buildModalWorkspaceSlug,
+  createModalClient,
+} from "./client";
+
+describe("buildModalWorkspaceSlug", () => {
+  it("uses the raw workspace for the default Modal environment", () => {
+    expect(buildModalWorkspaceSlug("acme")).toBe("acme");
+    expect(buildModalWorkspaceSlug("acme", "")).toBe("acme");
+    expect(buildModalWorkspaceSlug("acme", "main")).toBe("acme");
+  });
+
+  it("appends non-main Modal environments for endpoint URLs", () => {
+    expect(buildModalWorkspaceSlug("acme", "production")).toBe("acme-production");
+  });
+});
 
 describe("buildModalSandboxDashboardUrl", () => {
   it("builds a Modal dashboard URL for a sandbox object", () => {
@@ -50,5 +66,27 @@ describe("buildModalSandboxDashboardUrl", () => {
         providerObjectId: null,
       })
     ).toBeNull();
+  });
+});
+
+describe("ModalClient", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses the Modal environment in endpoint URLs", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: { status: "ok", service: "modal" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const client = createModalClient("secret", "acme", "production");
+    await client.health();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://acme-production--open-inspect-api-health.modal.run"
+    );
   });
 });

--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -6,14 +6,13 @@ import {
 } from "./client";
 
 describe("buildModalWorkspaceSlug", () => {
-  it("uses the raw workspace for the default Modal environment", () => {
+  it("uses the raw workspace when the Modal environment has no web suffix", () => {
     expect(buildModalWorkspaceSlug("acme")).toBe("acme");
     expect(buildModalWorkspaceSlug("acme", "")).toBe("acme");
-    expect(buildModalWorkspaceSlug("acme", "main")).toBe("acme");
   });
 
-  it("appends non-main Modal environments for endpoint URLs", () => {
-    expect(buildModalWorkspaceSlug("acme", "production")).toBe("acme-production");
+  it("appends the Modal environment web suffix for endpoint URLs", () => {
+    expect(buildModalWorkspaceSlug("acme", "prod-web")).toBe("acme-prod-web");
   });
 });
 
@@ -74,7 +73,7 @@ describe("ModalClient", () => {
     vi.restoreAllMocks();
   });
 
-  it("uses the Modal environment in endpoint URLs", async () => {
+  it("uses the Modal environment web suffix in endpoint URLs", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ success: true, data: { status: "ok", service: "modal" } }), {
         status: 200,
@@ -82,11 +81,11 @@ describe("ModalClient", () => {
       })
     );
 
-    const client = createModalClient("secret", "acme", "production");
+    const client = createModalClient("secret", "acme", "prod-web");
     await client.health();
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://acme-production--open-inspect-api-health.modal.run"
+      "https://acme-prod-web--open-inspect-api-health.modal.run"
     );
   });
 });

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -16,14 +16,24 @@ const log = createLogger("modal-client");
 const MODAL_APP_NAME = "open-inspect";
 
 // Modal's default environment name; unrelated to the git branch named "main".
-const DEFAULT_MODAL_DASHBOARD_ENVIRONMENT = "main";
+const DEFAULT_MODAL_ENVIRONMENT = "main";
+
+export function buildModalWorkspaceSlug(
+  workspace: string,
+  environment = DEFAULT_MODAL_ENVIRONMENT
+): string {
+  const modalEnvironment = environment || DEFAULT_MODAL_ENVIRONMENT;
+  return modalEnvironment === DEFAULT_MODAL_ENVIRONMENT
+    ? workspace
+    : `${workspace}-${modalEnvironment}`;
+}
 
 /**
- * Construct the Modal base URL from workspace name.
- * Modal endpoint URLs follow the pattern: https://{workspace}--{app-name}
+ * Construct the Modal base URL from workspace and environment.
+ * Non-main Modal environments use https://{workspace}-{environment}--{app-name}.
  */
-function getModalBaseUrl(workspace: string): string {
-  return `https://${workspace}--${MODAL_APP_NAME}`;
+function getModalBaseUrl(workspace: string, environment?: string): string {
+  return `https://${buildModalWorkspaceSlug(workspace, environment)}--${MODAL_APP_NAME}`;
 }
 
 export function buildModalSandboxDashboardUrl(params: {
@@ -33,7 +43,7 @@ export function buildModalSandboxDashboardUrl(params: {
 }): string | null {
   if (!params.workspace || !params.providerObjectId) return null;
   const workspace = encodeURIComponent(params.workspace);
-  const environment = encodeURIComponent(params.environment || DEFAULT_MODAL_DASHBOARD_ENVIRONMENT);
+  const environment = encodeURIComponent(params.environment || DEFAULT_MODAL_ENVIRONMENT);
   const providerObjectId = encodeURIComponent(params.providerObjectId);
   return `https://modal.com/apps/${workspace}/${environment}/deployed/${MODAL_APP_NAME}?activeTab=sandboxes&sandboxId=${providerObjectId}`;
 }
@@ -182,7 +192,7 @@ export class ModalClient {
   private deleteProviderImageUrl: string;
   private secret: string;
 
-  constructor(secret: string, workspace: string) {
+  constructor(secret: string, workspace: string, environment?: string) {
     if (!secret) {
       throw new Error("ModalClient requires MODAL_API_SECRET for authentication");
     }
@@ -190,7 +200,7 @@ export class ModalClient {
       throw new Error("ModalClient requires MODAL_WORKSPACE for URL construction");
     }
     this.secret = secret;
-    const baseUrl = getModalBaseUrl(workspace);
+    const baseUrl = getModalBaseUrl(workspace, environment);
     this.createSandboxUrl = `${baseUrl}-api-create-sandbox.modal.run`;
     this.warmSandboxUrl = `${baseUrl}-api-warm-sandbox.modal.run`;
     this.healthUrl = `${baseUrl}-api-health.modal.run`;
@@ -657,16 +667,21 @@ export class ModalClient {
  * The caller is responsible for managing the client lifecycle.
  *
  * @param secret - The MODAL_API_SECRET for authentication
- * @param workspace - The Modal workspace name (used in endpoint URLs)
+ * @param workspace - The Modal workspace name
+ * @param environment - The Modal environment name
  * @returns A new ModalClient instance
  * @throws Error if secret or workspace is not provided
  */
-export function createModalClient(secret: string, workspace: string): ModalClient {
+export function createModalClient(
+  secret: string,
+  workspace: string,
+  environment?: string
+): ModalClient {
   if (!secret) {
     throw new Error("MODAL_API_SECRET is required to create ModalClient");
   }
   if (!workspace) {
     throw new Error("MODAL_WORKSPACE is required to create ModalClient");
   }
-  return new ModalClient(secret, workspace);
+  return new ModalClient(secret, workspace, environment);
 }

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -18,24 +18,23 @@ const MODAL_APP_NAME = "open-inspect";
 // Modal's default environment name; unrelated to the git branch named "main".
 const DEFAULT_MODAL_ENVIRONMENT = "main";
 
-export function buildModalWorkspaceSlug(
-  workspace: string,
-  environment = DEFAULT_MODAL_ENVIRONMENT
-): string {
-  const modalEnvironment = environment || DEFAULT_MODAL_ENVIRONMENT;
-  return modalEnvironment === DEFAULT_MODAL_ENVIRONMENT
-    ? workspace
-    : `${workspace}-${modalEnvironment}`;
+/**
+ * Build the Modal endpoint workspace slug from the raw workspace and environment web suffix.
+ */
+export function buildModalWorkspaceSlug(workspace: string, environmentWebSuffix = ""): string {
+  return environmentWebSuffix === "" ? workspace : `${workspace}-${environmentWebSuffix}`;
 }
 
 /**
- * Construct the Modal base URL from workspace and environment.
- * Non-main Modal environments use https://{workspace}-{environment}--{app-name}.
+ * Construct the Modal base URL from workspace and environment web suffix.
  */
-function getModalBaseUrl(workspace: string, environment?: string): string {
-  return `https://${buildModalWorkspaceSlug(workspace, environment)}--${MODAL_APP_NAME}`;
+function getModalBaseUrl(workspace: string, environmentWebSuffix?: string): string {
+  return `https://${buildModalWorkspaceSlug(workspace, environmentWebSuffix)}--${MODAL_APP_NAME}`;
 }
 
+/**
+ * Build a Modal dashboard link for a sandbox object.
+ */
 export function buildModalSandboxDashboardUrl(params: {
   workspace: string | undefined;
   environment?: string | undefined;
@@ -192,7 +191,7 @@ export class ModalClient {
   private deleteProviderImageUrl: string;
   private secret: string;
 
-  constructor(secret: string, workspace: string, environment?: string) {
+  constructor(secret: string, workspace: string, environmentWebSuffix?: string) {
     if (!secret) {
       throw new Error("ModalClient requires MODAL_API_SECRET for authentication");
     }
@@ -200,7 +199,7 @@ export class ModalClient {
       throw new Error("ModalClient requires MODAL_WORKSPACE for URL construction");
     }
     this.secret = secret;
-    const baseUrl = getModalBaseUrl(workspace, environment);
+    const baseUrl = getModalBaseUrl(workspace, environmentWebSuffix);
     this.createSandboxUrl = `${baseUrl}-api-create-sandbox.modal.run`;
     this.warmSandboxUrl = `${baseUrl}-api-warm-sandbox.modal.run`;
     this.healthUrl = `${baseUrl}-api-health.modal.run`;
@@ -668,14 +667,14 @@ export class ModalClient {
  *
  * @param secret - The MODAL_API_SECRET for authentication
  * @param workspace - The Modal workspace name
- * @param environment - The Modal environment name
+ * @param environmentWebSuffix - The Modal environment web suffix used in endpoint URLs
  * @returns A new ModalClient instance
  * @throws Error if secret or workspace is not provided
  */
 export function createModalClient(
   secret: string,
   workspace: string,
-  environment?: string
+  environmentWebSuffix?: string
 ): ModalClient {
   if (!secret) {
     throw new Error("MODAL_API_SECRET is required to create ModalClient");
@@ -683,5 +682,5 @@ export function createModalClient(
   if (!workspace) {
     throw new Error("MODAL_WORKSPACE is required to create ModalClient");
   }
-  return new ModalClient(secret, workspace, environment);
+  return new ModalClient(secret, workspace, environmentWebSuffix);
 }

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -28,7 +28,7 @@ import {
  *
  * @example
  * ```typescript
- * const client = createModalClient(secret, workspace);
+ * const client = createModalClient(secret, workspace, environment);
  * const provider = new ModalSandboxProvider(client);
  *
  * try {

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -28,7 +28,7 @@ import {
  *
  * @example
  * ```typescript
- * const client = createModalClient(secret, workspace, environment);
+ * const client = createModalClient(secret, workspace, environmentWebSuffix);
  * const provider = new ModalSandboxProvider(client);
  *
  * try {

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -596,7 +596,8 @@ export class SessionDO extends DurableObject<Env> {
 
             const modalClient = createModalClient(
               this.env.MODAL_API_SECRET,
-              this.env.MODAL_WORKSPACE
+              this.env.MODAL_WORKSPACE,
+              this.env.MODAL_ENVIRONMENT
             );
             return createModalProvider(modalClient);
           })();
@@ -1723,6 +1724,7 @@ export class SessionDO extends DurableObject<Env> {
     if (resolveSandboxBackendName(this.env.SANDBOX_PROVIDER) !== "modal") return null;
     return buildModalSandboxDashboardUrl({
       workspace: this.env.MODAL_WORKSPACE,
+      environment: this.env.MODAL_ENVIRONMENT,
       providerObjectId,
     });
   }

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -597,7 +597,7 @@ export class SessionDO extends DurableObject<Env> {
             const modalClient = createModalClient(
               this.env.MODAL_API_SECRET,
               this.env.MODAL_WORKSPACE,
-              this.env.MODAL_ENVIRONMENT
+              this.env.MODAL_ENVIRONMENT_WEB_SUFFIX
             );
             return createModalProvider(modalClient);
           })();

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -81,7 +81,8 @@ export interface Env {
   WEB_APP_URL?: string; // Base URL for the web app (for PR links)
   CF_ACCOUNT_ID?: string; // Cloudflare account ID
   SANDBOX_PROVIDER?: string; // "modal" (default) or "daytona"
-  MODAL_WORKSPACE?: string; // Modal workspace name (used in Modal endpoint URLs)
+  MODAL_WORKSPACE?: string; // Modal workspace name
+  MODAL_ENVIRONMENT?: string; // Modal environment name for endpoint and dashboard URLs
   DAYTONA_API_URL?: string; // Daytona REST API base URL
   DAYTONA_BASE_SNAPSHOT?: string; // Named Daytona snapshot used for fresh sandbox creation
   DAYTONA_AUTO_STOP_INTERVAL_MINUTES?: string; // Daytona idle stop interval in minutes

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -82,7 +82,8 @@ export interface Env {
   CF_ACCOUNT_ID?: string; // Cloudflare account ID
   SANDBOX_PROVIDER?: string; // "modal" (default) or "daytona"
   MODAL_WORKSPACE?: string; // Modal workspace name
-  MODAL_ENVIRONMENT?: string; // Modal environment name for endpoint and dashboard URLs
+  MODAL_ENVIRONMENT?: string; // Modal environment name for dashboard URLs
+  MODAL_ENVIRONMENT_WEB_SUFFIX?: string; // Modal environment web suffix for endpoint URLs
   DAYTONA_API_URL?: string; // Daytona REST API base URL
   DAYTONA_BASE_SNAPSHOT?: string; // Named Daytona snapshot used for fresh sandbox creation
   DAYTONA_AUTO_STOP_INTERVAL_MINUTES?: string; // Daytona idle stop interval in minutes

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -179,7 +179,7 @@ MODAL_TOKEN_ID
 MODAL_TOKEN_SECRET
 MODAL_WORKSPACE
 MODAL_ENVIRONMENT # Optional; defaults to main
-MODAL_ENVIRONMENT_WEB_SUFFIX # Optional; empty for workspace--... endpoints
+MODAL_ENVIRONMENT_WEB_SUFFIX # Optional; lowercase letters, digits, dashes; empty for workspace--... endpoints
 
 # GitHub OAuth App
 GH_OAUTH_CLIENT_ID
@@ -372,8 +372,11 @@ terraform output verification_commands
 # 1. Health check control plane
 curl https://open-inspect-control-plane-prod.<subdomain>.workers.dev/health
 
-# 2. Health check Modal (replace <workspace> with your Modal workspace)
-curl https://<workspace>--open-inspect-api-health.modal.run
+# 2. Health check Modal
+# Prefer the exact URL from terraform output verification_commands.
+# Manual form: https://<workspace>[-<modal_environment_web_suffix>]--open-inspect-api-health.modal.run
+MODAL_WORKSPACE_SLUG="<workspace>" # or "<workspace>-<modal_environment_web_suffix>"
+curl https://${MODAL_WORKSPACE_SLUG}--open-inspect-api-health.modal.run
 
 # 3. Verify Vercel deployment (replace with your Vercel app URL)
 curl https://<your-vercel-app>.vercel.app

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -177,6 +177,8 @@ VERCEL_TEAM_ID
 # Modal
 MODAL_TOKEN_ID
 MODAL_TOKEN_SECRET
+MODAL_WORKSPACE
+MODAL_ENVIRONMENT # Optional; defaults to main
 
 # GitHub OAuth App
 GH_OAUTH_CLIENT_ID
@@ -301,9 +303,11 @@ module "modal" {
   modal_token_id     = var.modal_token_id
   modal_token_secret = var.modal_token_secret
 
-  app_name      = "my-app"
-  deploy_path   = "${path.root}/../../../packages/modal-infra"
-  deploy_module = "deploy"
+  app_name          = "my-app"
+  workspace         = "my-workspace"
+  modal_environment = "main"
+  deploy_path       = "${path.root}/../../../packages/modal-infra"
+  deploy_module     = "deploy"
 
   secrets = [
     {

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -179,6 +179,7 @@ MODAL_TOKEN_ID
 MODAL_TOKEN_SECRET
 MODAL_WORKSPACE
 MODAL_ENVIRONMENT # Optional; defaults to main
+MODAL_ENVIRONMENT_WEB_SUFFIX # Optional; empty for workspace--... endpoints
 
 # GitHub OAuth App
 GH_OAUTH_CLIENT_ID
@@ -303,11 +304,12 @@ module "modal" {
   modal_token_id     = var.modal_token_id
   modal_token_secret = var.modal_token_secret
 
-  app_name          = "my-app"
-  workspace         = "my-workspace"
-  modal_environment = "main"
-  deploy_path       = "${path.root}/../../../packages/modal-infra"
-  deploy_module     = "deploy"
+  app_name                     = "my-app"
+  workspace                    = "my-workspace"
+  modal_environment            = "main"
+  modal_environment_web_suffix = ""
+  deploy_path                  = "${path.root}/../../../packages/modal-infra"
+  deploy_module                = "deploy"
 
   secrets = [
     {

--- a/terraform/environments/production/locals.tf
+++ b/terraform/environments/production/locals.tf
@@ -2,6 +2,10 @@ locals {
   name_suffix         = var.deployment_name
   use_modal_backend   = var.sandbox_provider == "modal"
   use_daytona_backend = var.sandbox_provider == "daytona"
+  # Modal omits the environment segment for the default "main" environment.
+  # Non-main environments: "{workspace}-{env}--{app}.modal.run"
+  # Default (main) environment:  "{workspace}--{app}.modal.run"
+  modal_workspace_slug = var.modal_environment == "main" ? var.modal_workspace : "${var.modal_workspace}-${var.modal_environment}"
 
   # URLs for cross-service configuration
   control_plane_host = "open-inspect-control-plane-${local.name_suffix}.${var.cloudflare_worker_subdomain}.workers.dev"

--- a/terraform/environments/production/locals.tf
+++ b/terraform/environments/production/locals.tf
@@ -2,10 +2,6 @@ locals {
   name_suffix         = var.deployment_name
   use_modal_backend   = var.sandbox_provider == "modal"
   use_daytona_backend = var.sandbox_provider == "daytona"
-  # Modal omits the environment segment for the default "main" environment.
-  # Non-main environments: "{workspace}-{env}--{app}.modal.run"
-  # Default (main) environment:  "{workspace}--{app}.modal.run"
-  modal_workspace_slug = var.modal_environment == "main" ? var.modal_workspace : "${var.modal_workspace}-${var.modal_environment}"
 
   # URLs for cross-service configuration
   control_plane_host = "open-inspect-control-plane-${local.name_suffix}.${var.cloudflare_worker_subdomain}.workers.dev"

--- a/terraform/environments/production/modal.tf
+++ b/terraform/environments/production/modal.tf
@@ -28,7 +28,7 @@ module "modal_app" {
   modal_token_secret = var.modal_token_secret
 
   app_name      = "open-inspect"
-  workspace     = var.modal_workspace
+  workspace     = local.modal_workspace_slug
   deploy_path   = "${var.project_root}/packages/modal-infra"
   deploy_module = "deploy"
   source_hash   = data.external.modal_source_hash[0].result.hash

--- a/terraform/environments/production/modal.tf
+++ b/terraform/environments/production/modal.tf
@@ -27,11 +27,12 @@ module "modal_app" {
   modal_token_id     = var.modal_token_id
   modal_token_secret = var.modal_token_secret
 
-  app_name      = "open-inspect"
-  workspace     = local.modal_workspace_slug
-  deploy_path   = "${var.project_root}/packages/modal-infra"
-  deploy_module = "deploy"
-  source_hash   = data.external.modal_source_hash[0].result.hash
+  app_name          = "open-inspect"
+  workspace         = local.modal_workspace_slug
+  modal_environment = var.modal_environment
+  deploy_path       = "${var.project_root}/packages/modal-infra"
+  deploy_module     = "deploy"
+  source_hash       = data.external.modal_source_hash[0].result.hash
 
   secrets = [
     {

--- a/terraform/environments/production/modal.tf
+++ b/terraform/environments/production/modal.tf
@@ -27,12 +27,13 @@ module "modal_app" {
   modal_token_id     = var.modal_token_id
   modal_token_secret = var.modal_token_secret
 
-  app_name          = "open-inspect"
-  workspace         = local.modal_workspace_slug
-  modal_environment = var.modal_environment
-  deploy_path       = "${var.project_root}/packages/modal-infra"
-  deploy_module     = "deploy"
-  source_hash       = data.external.modal_source_hash[0].result.hash
+  app_name                     = "open-inspect"
+  workspace                    = var.modal_workspace
+  modal_environment            = var.modal_environment
+  modal_environment_web_suffix = var.modal_environment_web_suffix
+  deploy_path                  = "${var.project_root}/packages/modal-infra"
+  deploy_module                = "deploy"
+  source_hash                  = data.external.modal_source_hash[0].result.hash
 
   secrets = [
     {

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -51,10 +51,14 @@ cloudflare_worker_subdomain = ""
 modal_token_id = ""
 modal_token_secret = ""
 
-# Modal workspace name (used in endpoint URLs)
+# Modal workspace name and environment (used in endpoint URLs)
 # Only required when sandbox_provider = "modal"
-# This is your Modal username/workspace (e.g., "myworkspace" in "https://myworkspace--app.modal.run")
-modal_workspace = ""
+# workspace: your Modal username (e.g., "myworkspace")
+# environment: Modal environment name. Use "main" for the default environment:
+#   main env:     https://myworkspace--app.modal.run
+#   non-main env: https://myworkspace-production--app.modal.run
+modal_workspace   = ""
+modal_environment = "main"
 
 # Daytona REST API
 # Only required when sandbox_provider = "daytona"

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -51,14 +51,16 @@ cloudflare_worker_subdomain = ""
 modal_token_id = ""
 modal_token_secret = ""
 
-# Modal workspace name and environment (used in endpoint URLs)
+# Modal workspace, environment, and endpoint web suffix
 # Only required when sandbox_provider = "modal"
 # workspace: your Modal username (e.g., "myworkspace")
-# environment: Modal environment name. Use "main" for the default environment:
-#   main env:     https://myworkspace--app.modal.run
-#   non-main env: https://myworkspace-production--app.modal.run
-modal_workspace   = ""
-modal_environment = "main"
+# environment: Modal environment name used by the CLI
+# environment_web_suffix: Modal web suffix used in endpoint URLs:
+#   empty suffix:      https://myworkspace--app.modal.run
+#   "production":      https://myworkspace-production--app.modal.run
+modal_workspace               = ""
+modal_environment             = "main"
+modal_environment_web_suffix  = ""
 
 # Daytona REST API
 # Only required when sandbox_provider = "daytona"

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -72,6 +72,17 @@ variable "modal_workspace" {
   }
 }
 
+variable "modal_environment" {
+  description = "Modal environment name. Use 'main' for the default environment (omitted from endpoint URLs). Non-main envs (e.g., 'production', 'dev') are included in the URL slug."
+  type        = string
+  default     = "main"
+
+  validation {
+    condition     = var.sandbox_provider != "modal" || length(var.modal_environment) > 0
+    error_message = "modal_environment must be set when sandbox_provider = 'modal'."
+  }
+}
+
 # =============================================================================
 # GitHub OAuth App Credentials
 # =============================================================================

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -78,8 +78,8 @@ variable "modal_environment" {
   default     = "main"
 
   validation {
-    condition     = var.sandbox_provider != "modal" || length(var.modal_environment) > 0
-    error_message = "modal_environment must be set when sandbox_provider = 'modal'."
+    condition     = var.sandbox_provider != "modal" || (length(var.modal_environment) > 0 && can(regex("^[^:/]+$", var.modal_environment)))
+    error_message = "modal_environment must be set and must not contain colons or slashes when sandbox_provider = 'modal'."
   }
 }
 

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -62,7 +62,7 @@ variable "modal_token_secret" {
 }
 
 variable "modal_workspace" {
-  description = "Modal workspace name (used in endpoint URLs)"
+  description = "Modal workspace name"
   type        = string
   default     = ""
 
@@ -73,13 +73,24 @@ variable "modal_workspace" {
 }
 
 variable "modal_environment" {
-  description = "Modal environment name. Use 'main' for the default environment (omitted from endpoint URLs). Non-main envs (e.g., 'production', 'dev') are included in the URL slug."
+  description = "Modal environment name used by the Modal CLI"
   type        = string
   default     = "main"
 
   validation {
-    condition     = var.sandbox_provider != "modal" || (length(var.modal_environment) > 0 && can(regex("^[^:/]+$", var.modal_environment)))
-    error_message = "modal_environment must be set and must not contain colons or slashes when sandbox_provider = 'modal'."
+    condition     = var.sandbox_provider != "modal" || (length(trimspace(var.modal_environment)) > 0 && can(regex("^[^:/\\\\]+$", var.modal_environment)))
+    error_message = "modal_environment must be set and must not contain colons, slashes, or backslashes when sandbox_provider = 'modal'."
+  }
+}
+
+variable "modal_environment_web_suffix" {
+  description = "Modal environment web suffix used in endpoint URLs. Leave empty for the environment with no web suffix."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.sandbox_provider != "modal" || var.modal_environment_web_suffix == "" || (length(trimspace(var.modal_environment_web_suffix)) > 0 && can(regex("^[^:/\\\\]+$", var.modal_environment_web_suffix)))
+    error_message = "modal_environment_web_suffix must not contain colons, slashes, or backslashes when sandbox_provider = 'modal'."
   }
 }
 

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -89,7 +89,7 @@ variable "modal_environment_web_suffix" {
   default     = ""
 
   validation {
-    condition     = var.sandbox_provider != "modal" || var.modal_environment_web_suffix == "" || (length(trimspace(var.modal_environment_web_suffix)) > 0 && can(regex("^[^:/\\\\]+$", var.modal_environment_web_suffix)))
+    condition     = var.sandbox_provider != "modal" || var.modal_environment_web_suffix == "" || can(regex("^[^[:space:]:/\\\\]+$", var.modal_environment_web_suffix))
     error_message = "modal_environment_web_suffix must not contain colons, slashes, or backslashes when sandbox_provider = 'modal'."
   }
 }

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -84,13 +84,13 @@ variable "modal_environment" {
 }
 
 variable "modal_environment_web_suffix" {
-  description = "Modal environment web suffix used in endpoint URLs. Leave empty for the environment with no web suffix."
+  description = "Modal environment web suffix used in endpoint URLs. Use lowercase letters, digits, and dashes, or leave empty for the environment with no web suffix."
   type        = string
   default     = ""
 
   validation {
-    condition     = var.sandbox_provider != "modal" || var.modal_environment_web_suffix == "" || can(regex("^[^[:space:]:/\\\\]+$", var.modal_environment_web_suffix))
-    error_message = "modal_environment_web_suffix must not contain colons, slashes, or backslashes when sandbox_provider = 'modal'."
+    condition     = var.sandbox_provider != "modal" || can(regex("^$|^[a-z0-9-]+$", var.modal_environment_web_suffix))
+    error_message = "modal_environment_web_suffix must be empty or contain only lowercase letters, digits, and dashes when sandbox_provider = 'modal'."
   }
 }
 

--- a/terraform/environments/production/workers-control-plane.tf
+++ b/terraform/environments/production/workers-control-plane.tf
@@ -70,7 +70,10 @@ module "control_plane_worker" {
       { name = "APP_NAME", value = var.app_name },
       { name = "SANDBOX_PROVIDER", value = var.sandbox_provider },
     ],
-    local.use_modal_backend ? [{ name = "MODAL_WORKSPACE", value = local.modal_workspace_slug }] : [],
+    local.use_modal_backend ? [
+      { name = "MODAL_WORKSPACE", value = var.modal_workspace },
+      { name = "MODAL_ENVIRONMENT", value = var.modal_environment },
+    ] : [],
     local.use_daytona_backend ? [
       { name = "DAYTONA_API_URL", value = var.daytona_api_url },
       { name = "DAYTONA_BASE_SNAPSHOT", value = var.daytona_base_snapshot },

--- a/terraform/environments/production/workers-control-plane.tf
+++ b/terraform/environments/production/workers-control-plane.tf
@@ -73,6 +73,7 @@ module "control_plane_worker" {
     local.use_modal_backend ? [
       { name = "MODAL_WORKSPACE", value = var.modal_workspace },
       { name = "MODAL_ENVIRONMENT", value = var.modal_environment },
+      { name = "MODAL_ENVIRONMENT_WEB_SUFFIX", value = var.modal_environment_web_suffix },
     ] : [],
     local.use_daytona_backend ? [
       { name = "DAYTONA_API_URL", value = var.daytona_api_url },

--- a/terraform/environments/production/workers-control-plane.tf
+++ b/terraform/environments/production/workers-control-plane.tf
@@ -70,7 +70,7 @@ module "control_plane_worker" {
       { name = "APP_NAME", value = var.app_name },
       { name = "SANDBOX_PROVIDER", value = var.sandbox_provider },
     ],
-    local.use_modal_backend ? [{ name = "MODAL_WORKSPACE", value = var.modal_workspace }] : [],
+    local.use_modal_backend ? [{ name = "MODAL_WORKSPACE", value = local.modal_workspace_slug }] : [],
     local.use_daytona_backend ? [
       { name = "DAYTONA_API_URL", value = var.daytona_api_url },
       { name = "DAYTONA_BASE_SNAPSHOT", value = var.daytona_base_snapshot },

--- a/terraform/modules/modal-app/main.tf
+++ b/terraform/modules/modal-app/main.tf
@@ -13,7 +13,8 @@ resource "null_resource" "modal_secrets" {
 
   triggers = {
     # Re-run when secrets configuration changes
-    secrets_hash = sha256(local.secrets_json)
+    secrets_hash      = sha256(local.secrets_json)
+    modal_environment = var.modal_environment
   }
 
   provisioner "local-exec" {
@@ -23,6 +24,7 @@ resource "null_resource" "modal_secrets" {
     environment = {
       MODAL_TOKEN_ID     = var.modal_token_id
       MODAL_TOKEN_SECRET = var.modal_token_secret
+      MODAL_ENVIRONMENT  = var.modal_environment
       DEPLOY_PATH        = var.deploy_path
       SECRETS_JSON       = local.secrets_json
     }
@@ -36,6 +38,8 @@ resource "null_resource" "modal_deploy" {
     source_hash = var.source_hash
     # Re-deploy when app name changes
     app_name = var.app_name
+    # Re-deploy when Modal environment changes
+    modal_environment = var.modal_environment
     # Ensure secrets are created first
     secrets_created = length(var.secrets) > 0 ? null_resource.modal_secrets[0].id : "no-secrets"
   }
@@ -47,6 +51,7 @@ resource "null_resource" "modal_deploy" {
     environment = {
       MODAL_TOKEN_ID     = var.modal_token_id
       MODAL_TOKEN_SECRET = var.modal_token_secret
+      MODAL_ENVIRONMENT  = var.modal_environment
       APP_NAME           = var.app_name
       DEPLOY_PATH        = var.deploy_path
       DEPLOY_MODULE      = var.deploy_module

--- a/terraform/modules/modal-app/main.tf
+++ b/terraform/modules/modal-app/main.tf
@@ -4,7 +4,8 @@
 
 locals {
   # Combine all secrets for the create-secrets script
-  secrets_json = jsonencode(var.secrets)
+  secrets_json         = jsonencode(var.secrets)
+  modal_workspace_slug = var.modal_environment_web_suffix == "" ? var.workspace : "${var.workspace}-${var.modal_environment_web_suffix}"
 }
 
 # Create Modal secrets

--- a/terraform/modules/modal-app/outputs.tf
+++ b/terraform/modules/modal-app/outputs.tf
@@ -10,10 +10,10 @@ output "deploy_id" {
 
 output "api_health_url" {
   description = "URL of the health check endpoint"
-  value       = "https://${var.workspace}--${var.app_name}-api-health.modal.run"
+  value       = "https://${local.modal_workspace_slug}--${var.app_name}-api-health.modal.run"
 }
 
 output "api_create_sandbox_url" {
   description = "URL of the create sandbox endpoint"
-  value       = "https://${var.workspace}--${var.app_name}-api-create-sandbox.modal.run"
+  value       = "https://${local.modal_workspace_slug}--${var.app_name}-api-create-sandbox.modal.run"
 }

--- a/terraform/modules/modal-app/scripts/create-secrets.sh
+++ b/terraform/modules/modal-app/scripts/create-secrets.sh
@@ -3,13 +3,19 @@
 # Required environment variables:
 #   MODAL_TOKEN_ID - Modal API token ID
 #   MODAL_TOKEN_SECRET - Modal API token secret
+#   MODAL_ENVIRONMENT - Modal environment to create secrets in
 #   DEPLOY_PATH - Path to the Modal app source (for uv project resolution)
 #   SECRETS_JSON - JSON array of secrets with format:
 #     [{"name": "secret-name", "values": {"KEY1": "value1", "KEY2": "value2"}}]
 
 set -euo pipefail
 
-echo "Creating/updating Modal secrets..."
+if [[ -z "${MODAL_ENVIRONMENT:-}" ]]; then
+    echo "Error: MODAL_ENVIRONMENT environment variable is not set"
+    exit 1
+fi
+
+echo "Creating/updating Modal secrets in environment: ${MODAL_ENVIRONMENT}"
 
 # Validate SECRETS_JSON is valid JSON
 if ! echo "${SECRETS_JSON}" | jq empty 2>/dev/null; then

--- a/terraform/modules/modal-app/scripts/deploy.sh
+++ b/terraform/modules/modal-app/scripts/deploy.sh
@@ -3,15 +3,12 @@
 # Required environment variables:
 #   MODAL_TOKEN_ID - Modal API token ID
 #   MODAL_TOKEN_SECRET - Modal API token secret
+#   MODAL_ENVIRONMENT - Modal environment to deploy into
 #   APP_NAME - Name of the app (for logging)
 #   DEPLOY_PATH - Path to the Modal app source
 #   DEPLOY_MODULE - Module to deploy (e.g., 'deploy' or 'src')
 
 set -euo pipefail
-
-echo "Deploying Modal app: ${APP_NAME}"
-echo "Deploy path: ${DEPLOY_PATH}"
-echo "Deploy module: ${DEPLOY_MODULE}"
 
 # Verify required environment variables
 if [[ -z "${MODAL_TOKEN_ID:-}" ]]; then
@@ -23,6 +20,16 @@ if [[ -z "${MODAL_TOKEN_SECRET:-}" ]]; then
     echo "Error: MODAL_TOKEN_SECRET environment variable is not set"
     exit 1
 fi
+
+if [[ -z "${MODAL_ENVIRONMENT:-}" ]]; then
+    echo "Error: MODAL_ENVIRONMENT environment variable is not set"
+    exit 1
+fi
+
+echo "Deploying Modal app: ${APP_NAME}"
+echo "Modal environment: ${MODAL_ENVIRONMENT}"
+echo "Deploy path: ${DEPLOY_PATH}"
+echo "Deploy module: ${DEPLOY_MODULE}"
 
 # Change to the deployment directory
 cd "${DEPLOY_PATH}" || {

--- a/terraform/modules/modal-app/scripts/deploy.sh
+++ b/terraform/modules/modal-app/scripts/deploy.sh
@@ -26,6 +26,21 @@ if [[ -z "${MODAL_ENVIRONMENT:-}" ]]; then
     exit 1
 fi
 
+if [[ -z "${APP_NAME:-}" ]]; then
+    echo "Error: APP_NAME environment variable is not set"
+    exit 1
+fi
+
+if [[ -z "${DEPLOY_PATH:-}" ]]; then
+    echo "Error: DEPLOY_PATH environment variable is not set"
+    exit 1
+fi
+
+if [[ -z "${DEPLOY_MODULE:-}" ]]; then
+    echo "Error: DEPLOY_MODULE environment variable is not set"
+    exit 1
+fi
+
 echo "Deploying Modal app: ${APP_NAME}"
 echo "Modal environment: ${MODAL_ENVIRONMENT}"
 echo "Deploy path: ${DEPLOY_PATH}"

--- a/terraform/modules/modal-app/variables.tf
+++ b/terraform/modules/modal-app/variables.tf
@@ -32,13 +32,13 @@ variable "modal_environment" {
 }
 
 variable "modal_environment_web_suffix" {
-  description = "Modal environment web suffix used in endpoint URLs. Leave empty for the environment with no web suffix."
+  description = "Modal environment web suffix used in endpoint URLs. Use lowercase letters, digits, and dashes, or leave empty for the environment with no web suffix."
   type        = string
   default     = ""
 
   validation {
-    condition     = var.modal_environment_web_suffix == "" || can(regex("^[^[:space:]:/\\\\]+$", var.modal_environment_web_suffix))
-    error_message = "modal_environment_web_suffix must not contain colons, slashes, or backslashes."
+    condition     = can(regex("^$|^[a-z0-9-]+$", var.modal_environment_web_suffix))
+    error_message = "modal_environment_web_suffix must be empty or contain only lowercase letters, digits, and dashes."
   }
 }
 

--- a/terraform/modules/modal-app/variables.tf
+++ b/terraform/modules/modal-app/variables.tf
@@ -16,7 +16,7 @@ variable "app_name" {
 }
 
 variable "workspace" {
-  description = "Modal workspace slug used in endpoint URLs"
+  description = "Modal workspace name"
   type        = string
 }
 
@@ -24,6 +24,22 @@ variable "modal_environment" {
   description = "Modal environment name used by the Modal CLI"
   type        = string
   default     = "main"
+
+  validation {
+    condition     = length(trimspace(var.modal_environment)) > 0 && can(regex("^[^:/\\\\]+$", var.modal_environment))
+    error_message = "modal_environment must be non-empty and must not contain colons, slashes, or backslashes."
+  }
+}
+
+variable "modal_environment_web_suffix" {
+  description = "Modal environment web suffix used in endpoint URLs. Leave empty for the environment with no web suffix."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.modal_environment_web_suffix == "" || (length(trimspace(var.modal_environment_web_suffix)) > 0 && can(regex("^[^:/\\\\]+$", var.modal_environment_web_suffix)))
+    error_message = "modal_environment_web_suffix must not contain colons, slashes, or backslashes."
+  }
 }
 
 variable "deploy_path" {

--- a/terraform/modules/modal-app/variables.tf
+++ b/terraform/modules/modal-app/variables.tf
@@ -37,7 +37,7 @@ variable "modal_environment_web_suffix" {
   default     = ""
 
   validation {
-    condition     = var.modal_environment_web_suffix == "" || (length(trimspace(var.modal_environment_web_suffix)) > 0 && can(regex("^[^:/\\\\]+$", var.modal_environment_web_suffix)))
+    condition     = var.modal_environment_web_suffix == "" || can(regex("^[^[:space:]:/\\\\]+$", var.modal_environment_web_suffix))
     error_message = "modal_environment_web_suffix must not contain colons, slashes, or backslashes."
   }
 }

--- a/terraform/modules/modal-app/variables.tf
+++ b/terraform/modules/modal-app/variables.tf
@@ -16,8 +16,14 @@ variable "app_name" {
 }
 
 variable "workspace" {
-  description = "Modal workspace name (used in endpoint URLs)"
+  description = "Modal workspace slug used in endpoint URLs"
   type        = string
+}
+
+variable "modal_environment" {
+  description = "Modal environment name used by the Modal CLI"
+  type        = string
+  default     = "main"
 }
 
 variable "deploy_path" {


### PR DESCRIPTION
## Summary
- Takes over #629 on a new branch because the original PR head is company-owned.
- Adds `modal_environment` through the Modal Terraform module so secrets and deploy commands run in the selected Modal environment.
- Adds `modal_environment_web_suffix` / `MODAL_ENVIRONMENT_WEB_SUFFIX` for Modal endpoint URL hosts, keeping it separate from the CLI environment name.
- Keeps `MODAL_WORKSPACE` as the raw workspace, passes `MODAL_ENVIRONMENT` for dashboard links, and uses the web suffix for Modal API endpoint slugs.
- Documents the new Modal environment settings and wires them into Terraform GitHub Actions.

## Addresses Review Feedback
- Owner thread on `terraform/environments/production/modal.tf`: Modal CLI now receives `MODAL_ENVIRONMENT` for both secret creation and deploys.
- Owner thread on `packages/control-plane/src/sandbox/client.ts`: endpoint hosts now use explicit Modal web suffix instead of deriving from environment name.
- CodeRabbit validation note on `modal_environment`: rejects empty values, colons, slashes, and backslashes for Modal deployments, including at the module boundary.
- CodeRabbit deploy script note: validates all required env vars before first use under `set -u`.

## Validation
- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/control-plane -- --run src/sandbox/client.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`
- `terraform fmt -recursive -check terraform`
- `terraform -chdir=terraform/environments/production init -backend=false`
- `terraform -chdir=terraform/environments/production validate`
- `bash -n terraform/modules/modal-app/scripts/deploy.sh`
- `bash -n terraform/modules/modal-app/scripts/create-secrets.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add selectable Modal deployment environments and pass environment to Modal clients and deploy tooling
  * Configurable environment-to-endpoint web-suffix for Modal URLs and health checks

* **Documentation**
  * Updated setup, CI, and Terraform docs to document workspace, environment, and web-suffix and new secrets/vars

* **Tests**
  * Added tests for workspace-slug generation and environment-specific client health endpoints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/687?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->