### PR TITLE
fix(slack-bot): cap App Home repo-override list under Slack's block limit

### DIFF
--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -1394,6 +1394,96 @@ describe("POST /interactions", () => {
     expect(mockPublishView).toHaveBeenCalled();
   });
 
+  it("caps the App Home repo-override list under Slack's 100-block limit", async () => {
+    mockVerifySlackSignature.mockResolvedValue(true);
+    mockPublishView.mockResolvedValue({ ok: true });
+
+    const env = makeEnv();
+
+    // 60 available repos, each with a repo-specific branch override.
+    const repos = Array.from({ length: 60 }, (_, idx) => {
+      const number = String(idx + 1).padStart(3, "0");
+      return {
+        id: `acme/repo-${number}`,
+        owner: "acme",
+        name: `repo-${number}`,
+        fullName: `acme/repo-${number}`,
+        defaultBranch: "main",
+        private: true,
+      };
+    });
+
+    for (const repo of repos) {
+      await (env.SLACK_KV as unknown as { put: (k: string, v: string) => Promise<void> }).put(
+        `user_repo_branch:U123:${repo.id}`,
+        "staging"
+      );
+    }
+
+    (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/repos")) {
+          return new Response(JSON.stringify({ repos }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    );
+
+    const payload = {
+      type: "event_callback",
+      event_id: "Ev-override-cap",
+      event: { type: "app_home_opened", tab: "home", user: "U123" },
+    };
+
+    const request = new Request("http://localhost/events", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-slack-signature": "v0=test",
+        "x-slack-request-timestamp": `${Math.floor(Date.now() / 1000)}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const ctx = makeCtx();
+    const response = await app.fetch(request, env, ctx);
+    expect(response.status).toBe(200);
+    await flushWaitUntil(ctx);
+
+    expect(mockPublishView).toHaveBeenCalled();
+    const publishedView = mockPublishView.mock.calls.at(-1)?.[2] as {
+      blocks: Array<{
+        type: string;
+        text?: { text?: string };
+        elements?: Array<{ text?: string }>;
+      }>;
+    };
+
+    // Stays under Slack's hard 100-block ceiling for views.publish.
+    expect(publishedView.blocks.length).toBeLessThanOrEqual(100);
+
+    // Exactly the cap is rendered (one section per override) ...
+    const overrideRows = publishedView.blocks.filter(
+      (b) => b.type === "section" && (b.text?.text ?? "").includes("→")
+    );
+    expect(overrideRows.length).toBe(50);
+
+    // ... and the remainder is surfaced as a summary instead of dropped silently.
+    const hasMoreNote = publishedView.blocks.some(
+      (b) =>
+        b.type === "context" &&
+        (b.elements ?? []).some((e) => (e.text ?? "").includes("10 more overrides"))
+    );
+    expect(hasMoreNote).toBe(true);
+  });
+
   it("returns repo suggestions beyond 100 repos via search", async () => {
     const payload = {
       type: "block_suggestion",

--- a/packages/slack-bot/src/index.ts
+++ b/packages/slack-bot/src/index.ts
@@ -66,6 +66,11 @@ import { setAssistantThreadStatusBestEffort } from "./activity-status";
 const log = createLogger("handler");
 
 const MAX_REPO_SUGGESTION_OPTIONS = 100;
+
+// Max repo-specific branch overrides rendered in the App Home tab. Each renders
+// one block and Slack's views.publish rejects views over 100 blocks, so this
+// bounds the list well under the limit (the base App Home uses ~15 blocks).
+const MAX_RENDERED_REPO_OVERRIDES = 50;
 type BackgroundTaskScheduler = (promise: Promise<void>) => void;
 
 export function buildAppHomeIntroText(appName: string): string {
@@ -646,7 +651,13 @@ async function publishAppHome(env: Env, userId: string): Promise<void> {
         },
       });
 
-      for (const { repo, branch } of configuredRepoOverrides) {
+      // Slack's views.publish rejects Home tabs over 100 blocks. Each override
+      // renders one block, so cap the list to stay well under the limit. Hidden
+      // overrides are still fully manageable via the "Search repository"
+      // selector above, which opens a modal that can clear any repo's override.
+      const renderedOverrides = configuredRepoOverrides.slice(0, MAX_RENDERED_REPO_OVERRIDES);
+
+      for (const { repo, branch } of renderedOverrides) {
         blocks.push({
           type: "section",
           text: {
@@ -669,6 +680,19 @@ async function publishAppHome(env: Env, userId: string): Promise<void> {
               deny: { type: "plain_text", text: "Cancel" },
             },
           },
+        });
+      }
+
+      const hiddenOverrideCount = configuredRepoOverrides.length - renderedOverrides.length;
+      if (hiddenOverrideCount > 0) {
+        blocks.push({
+          type: "context",
+          elements: [
+            {
+              type: "mrkdwn",
+              text: `…and ${hiddenOverrideCount} more override${hiddenOverrideCount === 1 ? "" : "s"}. Use *Search repository* above to view or clear any repo's override.`,
+            },
+          ],
         });
       }
     }


### PR DESCRIPTION
## Problem

The App Home tab renders **one block per repo-specific branch override** with no upper bound (`slack-bot/src/index.ts`). Slack's `views.publish` rejects any view over **100 blocks**, so once a user configures ~85+ repo overrides the entire Home tab fails to publish — including the UI needed to manage those overrides, leaving the user stuck.

## Fix

- Cap rendered overrides at **50** (`MAX_RENDERED_REPO_OVERRIDES`), well under the 100-block ceiling (~15 base blocks).
- Surface the remainder as a `…and N more` summary instead of dropping it silently.
- Hidden overrides stay **fully manageable** via the existing "Search repository" selector → modal, which clears any repo's override on empty submit — so the cap strands nothing.

## Test

Adds a regression test that drives the real `app_home_opened` → `views.publish` path with 60 overrides and asserts the published view stays ≤ 100 blocks, renders exactly 50 rows, and includes the "10 more overrides" note. Full slack-bot suite (87 tests) + typecheck pass.

Found while syncing this change into a downstream fork. Happy to adjust the cap value or copy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large numbers of repository overrides in the Slack App Home interface. The interface now displays up to 50 overrides with a summary note indicating additional hidden overrides, ensuring functionality within Slack's technical constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ColeMurray/background-agents/pull/689?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->