### PR TITLE
Refactor Slack App Home module

### DIFF
--- a/packages/slack-bot/src/app-home.test.ts
+++ b/packages/slack-bot/src/app-home.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { buildAppHomeIntroText, buildAppHomeView } from "./app-home";
+import type { RepoConfig } from "./types";
+
+describe("buildAppHomeIntroText", () => {
+  it("uses the configured app name", () => {
+    expect(buildAppHomeIntroText("Acme Bot")).toBe("Configure your Acme Bot preferences below.");
+  });
+
+  it("works with the default Open-Inspect name", () => {
+    expect(buildAppHomeIntroText("Open-Inspect")).toBe(
+      "Configure your Open-Inspect preferences below."
+    );
+  });
+});
+
+describe("buildAppHomeView", () => {
+  it("caps the repo-override list under Slack's 100-block limit", () => {
+    const repos: RepoConfig[] = Array.from({ length: 60 }, (_, idx) => {
+      const number = String(idx + 1).padStart(3, "0");
+      return {
+        id: `acme/repo-${number}`,
+        owner: "acme",
+        name: `repo-${number}`,
+        fullName: `acme/repo-${number}`,
+        displayName: `acme/repo-${number}`,
+        description: "",
+        defaultBranch: "main",
+        private: true,
+      };
+    });
+    const repoBranchPreferences = new Map(repos.map((repo) => [repo.id, "staging"]));
+
+    const view = buildAppHomeView({
+      appName: "Open-Inspect",
+      availableModels: [
+        {
+          label: "Claude Haiku",
+          value: "anthropic/claude-haiku-4-5",
+        },
+      ],
+      currentModel: "anthropic/claude-haiku-4-5",
+      currentEffort: "max",
+      currentBranch: undefined,
+      repos,
+      repoBranchPreferences,
+    });
+
+    expect(view.blocks.length).toBeLessThanOrEqual(100);
+
+    const overrideRows = view.blocks.filter(
+      (block) => block.type === "section" && block.text.text.includes("→")
+    );
+    expect(overrideRows.length).toBe(50);
+
+    const hasMoreNote = view.blocks.some(
+      (block) =>
+        block.type === "context" &&
+        block.elements.some((element) => element.text.includes("10 more overrides"))
+    );
+    expect(hasMoreNote).toBe(true);
+  });
+});

--- a/packages/slack-bot/src/app-home.test.ts
+++ b/packages/slack-bot/src/app-home.test.ts
@@ -15,6 +15,44 @@ describe("buildAppHomeIntroText", () => {
 });
 
 describe("buildAppHomeView", () => {
+  it("caps model select option labels at Slack's 75-character limit", () => {
+    const longLabel = "Long model label ".repeat(8);
+
+    const view = buildAppHomeView({
+      appName: "Open-Inspect",
+      availableModels: [
+        {
+          label: longLabel,
+          value: "anthropic/claude-haiku-4-5",
+        },
+      ],
+      currentModel: "anthropic/claude-haiku-4-5",
+      currentEffort: "max",
+      currentBranch: undefined,
+      repos: [],
+      repoBranchPreferences: new Map(),
+    });
+
+    const modelActionsBlock = view.blocks.find(
+      (block) => block.type === "actions" && block.block_id === "model_selection"
+    );
+    expect(modelActionsBlock?.type).toBe("actions");
+    if (modelActionsBlock?.type !== "actions") {
+      throw new Error("Missing model actions block");
+    }
+
+    const modelSelect = modelActionsBlock.elements[0];
+    expect(modelSelect.type).toBe("static_select");
+    if (modelSelect.type !== "static_select") {
+      throw new Error("Missing model static select");
+    }
+
+    expect(modelSelect.options[0].text.text).toHaveLength(75);
+    expect(modelSelect.options[0].text.text).toMatch(/…$/);
+    expect(modelSelect.initial_option?.text.text).toHaveLength(75);
+    expect(modelSelect.initial_option?.text.text).toMatch(/…$/);
+  });
+
   it("caps the repo-override list under Slack's 100-block limit", () => {
     const repos: RepoConfig[] = Array.from({ length: 60 }, (_, idx) => {
       const number = String(idx + 1).padStart(3, "0");

--- a/packages/slack-bot/src/app-home/constants.ts
+++ b/packages/slack-bot/src/app-home/constants.ts
@@ -1,0 +1,11 @@
+export const MAX_REPO_SUGGESTION_OPTIONS = 100;
+
+// Max repo-specific branch overrides rendered in the App Home tab. Each renders
+// one block and Slack's views.publish rejects views over 100 blocks, so this
+// bounds the list well under the limit (the base App Home uses ~15 blocks).
+export const MAX_RENDERED_REPO_OVERRIDES = 50;
+
+export const SELECT_MODEL_ACTION_ID = "select_model";
+export const SELECT_REASONING_EFFORT_ACTION_ID = "select_reasoning_effort";
+export const OPEN_BRANCH_MODAL_ACTION_ID = "open_branch_modal";
+export const CLEAR_BRANCH_PREFERENCE_ACTION_ID = "clear_branch_preference";

--- a/packages/slack-bot/src/app-home/index.ts
+++ b/packages/slack-bot/src/app-home/index.ts
@@ -1,0 +1,4 @@
+export { getRepoBranchSuggestionOptions, handleAppHomeInteractionRoute } from "./interactions";
+export { publishAppHome } from "./publisher";
+export { buildAppHomeIntroText, buildAppHomeView } from "./view";
+export type { AppHomeViewState } from "./view";

--- a/packages/slack-bot/src/app-home/interactions.ts
+++ b/packages/slack-bot/src/app-home/interactions.ts
@@ -1,0 +1,402 @@
+import {
+  getDefaultReasoningEffort,
+  isValidModel,
+  isValidReasoningEffort,
+} from "@open-inspect/shared";
+import {
+  BRANCH_INPUT_BLOCK_ID,
+  BRANCH_MODAL_CALLBACK_ID,
+  CLEAR_REPO_BRANCH_ACTION_ID,
+  REPO_BRANCH_SELECTOR_ACTION_ID,
+  getBranchSubmissionValidationError,
+  getSubmittedBranch,
+  getUserRepoBranchPreference,
+  getUserRepoBranchPreferences,
+  isBranchModalCallbackId,
+  saveUserRepoBranchPreference,
+} from "../branch-preferences";
+import { getAvailableRepos } from "../classifier/repos";
+import { createLogger } from "../logger";
+import type { Env, SlackInteractionPayload } from "../types";
+import {
+  CLEAR_BRANCH_PREFERENCE_ACTION_ID,
+  MAX_REPO_SUGGESTION_OPTIONS,
+  OPEN_BRANCH_MODAL_ACTION_ID,
+  SELECT_MODEL_ACTION_ID,
+  SELECT_REASONING_EFFORT_ACTION_ID,
+} from "./constants";
+import { decodeRepoBranchModalMetadata } from "./metadata";
+import { openBranchPreferenceModal, openRepoBranchPreferenceModal } from "./modals";
+import { publishAppHome } from "./publisher";
+import type {
+  AppHomeInteractionLogContext,
+  AppHomeInteractionResponseBody,
+  BackgroundTaskScheduler,
+  SlackBlockAction,
+  SlackSelectOption,
+} from "./slack-types";
+import { buildRepoBranchSelectOptions } from "./view";
+import { getResolvedUserPreferences, saveUserPreferences } from "../user-preferences";
+
+const log = createLogger("app-home");
+
+type AppHomeBlockActionContext = {
+  action: SlackBlockAction;
+  payload: SlackInteractionPayload;
+  env: Env;
+  traceId: string | undefined;
+  userId: string | undefined;
+};
+
+type AppHomeBlockActionHandler = {
+  runInline?: boolean;
+  handle: (context: AppHomeBlockActionContext) => Promise<void>;
+};
+
+type AppHomeBlockActionMatch = {
+  action: SlackBlockAction;
+  handler: AppHomeBlockActionHandler;
+};
+
+export interface AppHomeInteractionRouteResult {
+  body: AppHomeInteractionResponseBody;
+  logContext: AppHomeInteractionLogContext;
+}
+
+const APP_HOME_BLOCK_ACTIONS: Record<string, AppHomeBlockActionHandler> = {
+  [SELECT_MODEL_ACTION_ID]: { handle: handleSelectModel },
+  [SELECT_REASONING_EFFORT_ACTION_ID]: { handle: handleSelectReasoningEffort },
+  [OPEN_BRANCH_MODAL_ACTION_ID]: { runInline: true, handle: handleOpenBranchModal },
+  [REPO_BRANCH_SELECTOR_ACTION_ID]: { runInline: true, handle: handleRepoBranchSelection },
+  [CLEAR_REPO_BRANCH_ACTION_ID]: { handle: handleClearRepoBranch },
+  [CLEAR_BRANCH_PREFERENCE_ACTION_ID]: { handle: handleClearBranchPreference },
+};
+
+export async function getRepoBranchSuggestionOptions(
+  env: Env,
+  userId: string,
+  query: string | undefined,
+  traceId?: string
+): Promise<SlackSelectOption[]> {
+  const [repos, repoBranchPreferences] = await Promise.all([
+    getAvailableRepos(env, traceId),
+    getUserRepoBranchPreferences(env, userId),
+  ]);
+  const normalizedQuery = query?.trim().toLowerCase();
+
+  const filteredRepos = normalizedQuery
+    ? repos.filter((repo) => repo.fullName.toLowerCase().includes(normalizedQuery))
+    : repos;
+
+  return buildRepoBranchSelectOptions(filteredRepos, repoBranchPreferences).slice(
+    0,
+    MAX_REPO_SUGGESTION_OPTIONS
+  );
+}
+
+function getAppHomeBlockAction(payload: SlackInteractionPayload): AppHomeBlockActionMatch | null {
+  if (payload.type !== "block_actions") {
+    return null;
+  }
+
+  const action = payload.actions?.[0];
+  if (!action) {
+    return null;
+  }
+
+  const handler = APP_HOME_BLOCK_ACTIONS[action.action_id];
+  return handler ? { action, handler } : null;
+}
+
+function isAppHomeViewSubmission(payload: SlackInteractionPayload): boolean {
+  return payload.type === "view_submission" && isBranchModalCallbackId(payload.view?.callback_id);
+}
+
+export async function handleAppHomeInteractionRoute(
+  payload: SlackInteractionPayload,
+  env: Env,
+  traceId: string | undefined,
+  scheduleBackground: BackgroundTaskScheduler
+): Promise<AppHomeInteractionRouteResult | null> {
+  if (payload.type === "block_suggestion") {
+    if (payload.action_id !== REPO_BRANCH_SELECTOR_ACTION_ID) {
+      return null;
+    }
+
+    const options = payload.user?.id
+      ? await getRepoBranchSuggestionOptions(env, payload.user.id, payload.value, traceId)
+      : [];
+
+    return {
+      body: { options },
+      logContext: {
+        interaction_type: payload.type,
+        action_id: payload.action_id,
+        option_count: options.length,
+      },
+    };
+  }
+
+  const branchValidationError = getBranchSubmissionValidationError(payload);
+  if (branchValidationError) {
+    const submittedBranch = getSubmittedBranch(payload);
+    log.warn("slack.branch_pref.invalid", {
+      trace_id: traceId,
+      user_id: payload.user?.id,
+      branch: submittedBranch ?? "",
+    });
+
+    return {
+      body: {
+        response_action: "errors",
+        errors: {
+          [BRANCH_INPUT_BLOCK_ID]: branchValidationError,
+        },
+      },
+      logContext: {
+        interaction_type: payload.type,
+        callback_id: payload.view?.callback_id,
+        outcome: "validation_error",
+      },
+    };
+  }
+
+  const blockAction = getAppHomeBlockAction(payload);
+  if (!isAppHomeViewSubmission(payload) && !blockAction) {
+    return null;
+  }
+
+  const actionId = blockAction?.action.action_id ?? payload.action_id;
+  const interactionTask = Promise.resolve().then(() =>
+    handleAppHomeInteraction(payload, env, traceId)
+  );
+
+  if (blockAction?.handler.runInline) {
+    await interactionTask;
+  } else {
+    scheduleBackground(interactionTask);
+  }
+
+  return {
+    body: isAppHomeViewSubmission(payload) ? { response_action: "clear" } : { ok: true },
+    logContext: {
+      interaction_type: payload.type,
+      action_id: actionId,
+      callback_id: payload.view?.callback_id,
+    },
+  };
+}
+
+async function handleAppHomeInteraction(
+  payload: SlackInteractionPayload,
+  env: Env,
+  traceId: string | undefined
+): Promise<void> {
+  const userId = payload.user?.id;
+
+  if (payload.type === "view_submission") {
+    await handleBranchSubmission(payload, env, traceId, userId);
+    return;
+  }
+
+  const blockAction = getAppHomeBlockAction(payload);
+  if (!blockAction) {
+    return;
+  }
+
+  await blockAction.handler.handle({
+    action: blockAction.action,
+    payload,
+    env,
+    traceId,
+    userId,
+  });
+}
+
+async function handleBranchSubmission(
+  payload: SlackInteractionPayload,
+  env: Env,
+  traceId: string | undefined,
+  userId: string | undefined
+): Promise<void> {
+  if (!isBranchModalCallbackId(payload.view?.callback_id) || !userId) {
+    return;
+  }
+
+  const branch = getSubmittedBranch(payload);
+
+  if (payload.view?.callback_id === BRANCH_MODAL_CALLBACK_ID) {
+    const current = await getResolvedUserPreferences(env, userId);
+    await saveUserPreferences(env, userId, { ...current, branch });
+    await publishAppHome(env, userId);
+    return;
+  }
+
+  const repoId = getRepoIdFromSubmission(payload, traceId, userId);
+  if (!repoId) {
+    log.warn("slack.repo_branch_pref.missing_repo", { trace_id: traceId, user_id: userId });
+    await publishAppHome(env, userId);
+    return;
+  }
+
+  const availableRepos = await getAvailableRepos(env, traceId);
+  if (!availableRepos.some((repo) => repo.id === repoId)) {
+    log.warn("slack.repo_branch_pref.unknown_repo", {
+      trace_id: traceId,
+      user_id: userId,
+      repo_id: repoId,
+    });
+    await publishAppHome(env, userId);
+    return;
+  }
+
+  await saveUserRepoBranchPreference(env, userId, repoId, branch);
+  await publishAppHome(env, userId);
+}
+
+function getRepoIdFromSubmission(
+  payload: SlackInteractionPayload,
+  traceId: string | undefined,
+  userId: string
+): string | undefined {
+  const decoded = decodeRepoBranchModalMetadata(payload.view?.private_metadata);
+  if (!decoded.ok) {
+    if (decoded.reason !== "missing") {
+      log.warn("slack.repo_branch_pref.bad_metadata", {
+        trace_id: traceId,
+        user_id: userId,
+        reason: decoded.reason,
+        ...(decoded.errorMessage ? { error: decoded.errorMessage } : {}),
+      });
+    }
+    return undefined;
+  }
+
+  if (decoded.metadata.userId !== userId) {
+    log.warn("slack.repo_branch_pref.user_mismatch", {
+      trace_id: traceId,
+      user_id: userId,
+      metadata_user_id: decoded.metadata.userId,
+    });
+  }
+
+  return decoded.metadata.repoId;
+}
+
+async function handleSelectModel({
+  action,
+  env,
+  userId,
+}: AppHomeBlockActionContext): Promise<void> {
+  const selectedModel = action.selected_option?.value;
+  if (!selectedModel || !userId || !isValidModel(selectedModel)) {
+    return;
+  }
+
+  const current = await getResolvedUserPreferences(env, userId);
+  const newDefault = getDefaultReasoningEffort(selectedModel);
+  await saveUserPreferences(env, userId, {
+    model: selectedModel,
+    reasoningEffort: newDefault,
+    branch: current.branch,
+  });
+  await publishAppHome(env, userId);
+}
+
+async function handleSelectReasoningEffort({
+  action,
+  env,
+  userId,
+}: AppHomeBlockActionContext): Promise<void> {
+  const selectedEffort = action.selected_option?.value;
+  if (!selectedEffort || !userId) {
+    return;
+  }
+
+  const current = await getResolvedUserPreferences(env, userId);
+  if (!isValidReasoningEffort(current.model, selectedEffort)) {
+    return;
+  }
+
+  await saveUserPreferences(env, userId, {
+    ...current,
+    reasoningEffort: selectedEffort,
+  });
+  await publishAppHome(env, userId);
+}
+
+async function handleOpenBranchModal({
+  payload,
+  env,
+  userId,
+}: AppHomeBlockActionContext): Promise<void> {
+  if (!userId || !payload.trigger_id) {
+    return;
+  }
+
+  const current = await getResolvedUserPreferences(env, userId);
+  await openBranchPreferenceModal(env, userId, payload.trigger_id, current.branch);
+}
+
+async function handleRepoBranchSelection({
+  action,
+  payload,
+  env,
+  traceId,
+  userId,
+}: AppHomeBlockActionContext): Promise<void> {
+  if (!userId || !payload.trigger_id) {
+    return;
+  }
+
+  const repoId = action.selected_option?.value;
+  if (!repoId) {
+    return;
+  }
+
+  const repos = await getAvailableRepos(env, traceId);
+  const repo = repos.find((item) => item.id === repoId);
+  if (!repo) {
+    log.warn("slack.repo_branch_pref.repo_not_found", {
+      trace_id: traceId,
+      user_id: userId,
+      repo_id: repoId,
+    });
+    await publishAppHome(env, userId);
+    return;
+  }
+
+  const currentRepoBranch = await getUserRepoBranchPreference(env, userId, repo.id);
+  await openRepoBranchPreferenceModal(env, userId, payload.trigger_id, repo, currentRepoBranch);
+}
+
+async function handleClearRepoBranch({
+  action,
+  env,
+  userId,
+}: AppHomeBlockActionContext): Promise<void> {
+  if (!userId) {
+    return;
+  }
+
+  const repoId = action.value ?? action.selected_option?.value;
+  if (!repoId) {
+    return;
+  }
+
+  await saveUserRepoBranchPreference(env, userId, repoId, undefined);
+  await publishAppHome(env, userId);
+}
+
+async function handleClearBranchPreference({
+  env,
+  userId,
+}: AppHomeBlockActionContext): Promise<void> {
+  if (!userId) {
+    return;
+  }
+
+  const current = await getResolvedUserPreferences(env, userId);
+  await saveUserPreferences(env, userId, { ...current, branch: undefined });
+  await publishAppHome(env, userId);
+}

--- a/packages/slack-bot/src/app-home/interactions.ts
+++ b/packages/slack-bot/src/app-home/interactions.ts
@@ -1,8 +1,4 @@
-import {
-  getDefaultReasoningEffort,
-  isValidModel,
-  isValidReasoningEffort,
-} from "@open-inspect/shared";
+import { isValidModel, isValidReasoningEffort } from "@open-inspect/shared";
 import {
   BRANCH_INPUT_BLOCK_ID,
   BRANCH_MODAL_CALLBACK_ID,
@@ -36,7 +32,7 @@ import type {
   SlackSelectOption,
 } from "./slack-types";
 import { buildRepoBranchSelectOptions } from "./view";
-import { getResolvedUserPreferences, saveUserPreferences } from "../user-preferences";
+import { getResolvedUserPreferences, updateUserPreferences } from "../user-preferences";
 
 const log = createLogger("app-home");
 
@@ -226,8 +222,7 @@ async function handleBranchSubmission(
   const branch = getSubmittedBranch(payload);
 
   if (payload.view?.callback_id === BRANCH_MODAL_CALLBACK_ID) {
-    const current = await getResolvedUserPreferences(env, userId);
-    await saveUserPreferences(env, userId, { ...current, branch });
+    await updateUserPreferences(env, userId, { branch });
     await publishAppHome(env, userId);
     return;
   }
@@ -293,13 +288,7 @@ async function handleSelectModel({
     return;
   }
 
-  const current = await getResolvedUserPreferences(env, userId);
-  const newDefault = getDefaultReasoningEffort(selectedModel);
-  await saveUserPreferences(env, userId, {
-    model: selectedModel,
-    reasoningEffort: newDefault,
-    branch: current.branch,
-  });
+  await updateUserPreferences(env, userId, { model: selectedModel });
   await publishAppHome(env, userId);
 }
 
@@ -313,15 +302,17 @@ async function handleSelectReasoningEffort({
     return;
   }
 
-  const current = await getResolvedUserPreferences(env, userId);
-  if (!isValidReasoningEffort(current.model, selectedEffort)) {
+  const updated = await updateUserPreferences(env, userId, (current) => {
+    if (!isValidReasoningEffort(current.model, selectedEffort)) {
+      return null;
+    }
+
+    return { reasoningEffort: selectedEffort };
+  });
+  if (!updated) {
     return;
   }
 
-  await saveUserPreferences(env, userId, {
-    ...current,
-    reasoningEffort: selectedEffort,
-  });
   await publishAppHome(env, userId);
 }
 
@@ -396,7 +387,6 @@ async function handleClearBranchPreference({
     return;
   }
 
-  const current = await getResolvedUserPreferences(env, userId);
-  await saveUserPreferences(env, userId, { ...current, branch: undefined });
+  await updateUserPreferences(env, userId, { branch: undefined });
   await publishAppHome(env, userId);
 }

--- a/packages/slack-bot/src/app-home/metadata.ts
+++ b/packages/slack-bot/src/app-home/metadata.ts
@@ -1,0 +1,50 @@
+export type BranchModalMetadata = {
+  userId: string;
+};
+
+export type RepoBranchModalMetadata = BranchModalMetadata & {
+  repoId: string;
+};
+
+export type RepoBranchModalMetadataDecodeResult =
+  | { ok: true; metadata: RepoBranchModalMetadata }
+  | { ok: false; reason: "missing" | "invalid_json" | "invalid_shape"; errorMessage?: string };
+
+export function encodeBranchModalMetadata(metadata: BranchModalMetadata): string {
+  return JSON.stringify(metadata);
+}
+
+export function encodeRepoBranchModalMetadata(metadata: RepoBranchModalMetadata): string {
+  return JSON.stringify(metadata);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function isRepoBranchModalMetadata(value: unknown): value is RepoBranchModalMetadata {
+  return isRecord(value) && typeof value.userId === "string" && typeof value.repoId === "string";
+}
+
+export function decodeRepoBranchModalMetadata(
+  metadataRaw: string | undefined
+): RepoBranchModalMetadataDecodeResult {
+  if (!metadataRaw) {
+    return { ok: false, reason: "missing" };
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(metadataRaw);
+    if (!isRepoBranchModalMetadata(parsed)) {
+      return { ok: false, reason: "invalid_shape" };
+    }
+
+    return { ok: true, metadata: parsed };
+  } catch (error) {
+    return {
+      ok: false,
+      reason: "invalid_json",
+      errorMessage: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/packages/slack-bot/src/app-home/modals.ts
+++ b/packages/slack-bot/src/app-home/modals.ts
@@ -1,0 +1,141 @@
+import { openView } from "@open-inspect/shared";
+import {
+  BRANCH_INPUT_ACTION_ID,
+  BRANCH_INPUT_BLOCK_ID,
+  BRANCH_MODAL_CALLBACK_ID,
+  REPO_BRANCH_MODAL_CALLBACK_ID,
+} from "../branch-preferences";
+import { createLogger } from "../logger";
+import type { Env, RepoConfig } from "../types";
+import { encodeBranchModalMetadata, encodeRepoBranchModalMetadata } from "./metadata";
+import type { AppHomeModalBlock, SlackInputBlock } from "./slack-types";
+
+const log = createLogger("app-home");
+
+type BranchInputBlockOptions = {
+  label: string;
+  hint: string;
+  currentBranch: string | undefined;
+};
+
+function buildBranchInputBlock({
+  label,
+  hint,
+  currentBranch,
+}: BranchInputBlockOptions): SlackInputBlock {
+  return {
+    type: "input",
+    block_id: BRANCH_INPUT_BLOCK_ID,
+    optional: true,
+    label: {
+      type: "plain_text",
+      text: label,
+    },
+    element: {
+      type: "plain_text_input",
+      action_id: BRANCH_INPUT_ACTION_ID,
+      initial_value: currentBranch || "",
+      placeholder: {
+        type: "plain_text",
+        text: "e.g. main, staging, release/2026-03",
+      },
+    },
+    hint: {
+      type: "plain_text",
+      text: hint,
+    },
+  };
+}
+
+export async function openBranchPreferenceModal(
+  env: Env,
+  userId: string,
+  triggerId: string,
+  currentBranch?: string
+): Promise<void> {
+  const blocks: AppHomeModalBlock[] = [
+    buildBranchInputBlock({
+      label: "Default branch for new Slack sessions",
+      hint: "Leave empty to use each repository's default branch.",
+      currentBranch,
+    }),
+  ];
+
+  const result = await openView(env.SLACK_BOT_TOKEN, triggerId, {
+    type: "modal",
+    callback_id: BRANCH_MODAL_CALLBACK_ID,
+    title: {
+      type: "plain_text",
+      text: "Branch Preference",
+    },
+    submit: {
+      type: "plain_text",
+      text: "Save",
+    },
+    close: {
+      type: "plain_text",
+      text: "Cancel",
+    },
+    private_metadata: encodeBranchModalMetadata({ userId }),
+    blocks,
+  });
+
+  if (!result.ok) {
+    log.error("slack.open_branch_modal", {
+      user_id: userId,
+      outcome: "error",
+      slack_error: result.error,
+    });
+  }
+}
+
+export async function openRepoBranchPreferenceModal(
+  env: Env,
+  userId: string,
+  triggerId: string,
+  repo: RepoConfig,
+  currentBranch?: string
+): Promise<void> {
+  const blocks: AppHomeModalBlock[] = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `Repository: *${repo.fullName}*`,
+      },
+    },
+    buildBranchInputBlock({
+      label: "Branch override",
+      hint: "Leave empty to clear this repository override.",
+      currentBranch,
+    }),
+  ];
+
+  const result = await openView(env.SLACK_BOT_TOKEN, triggerId, {
+    type: "modal",
+    callback_id: REPO_BRANCH_MODAL_CALLBACK_ID,
+    title: {
+      type: "plain_text",
+      text: "Repo Branch",
+    },
+    submit: {
+      type: "plain_text",
+      text: "Save",
+    },
+    close: {
+      type: "plain_text",
+      text: "Cancel",
+    },
+    private_metadata: encodeRepoBranchModalMetadata({ userId, repoId: repo.id }),
+    blocks,
+  });
+
+  if (!result.ok) {
+    log.error("slack.open_repo_branch_modal", {
+      user_id: userId,
+      repo_id: repo.id,
+      outcome: "error",
+      slack_error: result.error,
+    });
+  }
+}

--- a/packages/slack-bot/src/app-home/models.ts
+++ b/packages/slack-bot/src/app-home/models.ts
@@ -1,0 +1,52 @@
+import {
+  DEFAULT_ENABLED_MODELS,
+  MODEL_OPTIONS,
+  buildInternalAuthHeaders,
+} from "@open-inspect/shared";
+import type { Env } from "../types";
+import type { ModelOption } from "./slack-types";
+
+const ALL_MODELS = MODEL_OPTIONS.flatMap((group) =>
+  group.models.map((model) => ({
+    label: `${model.name} (${model.description})`,
+    value: model.id,
+  }))
+);
+
+function getDefaultModelOptions(): ModelOption[] {
+  const defaultSet = new Set<string>(DEFAULT_ENABLED_MODELS);
+  const defaultOptions = ALL_MODELS.filter((model) => defaultSet.has(model.value));
+  return defaultOptions.length > 0 ? defaultOptions : ALL_MODELS;
+}
+
+async function getAuthHeaders(env: Env, traceId?: string): Promise<Record<string, string>> {
+  return {
+    "Content-Type": "application/json",
+    ...(await buildInternalAuthHeaders(env.INTERNAL_CALLBACK_SECRET, traceId)),
+  };
+}
+
+export async function getAvailableModels(env: Env, traceId?: string): Promise<ModelOption[]> {
+  try {
+    const headers = await getAuthHeaders(env, traceId);
+    const response = await env.CONTROL_PLANE.fetch("https://internal/model-preferences", {
+      method: "GET",
+      headers,
+    });
+
+    if (response.ok) {
+      const data = (await response.json()) as { enabledModels: string[] };
+      if (data.enabledModels.length > 0) {
+        const enabledSet = new Set(data.enabledModels);
+        const enabledModels = ALL_MODELS.filter((model) => enabledSet.has(model.value));
+        if (enabledModels.length > 0) {
+          return enabledModels;
+        }
+      }
+    }
+  } catch {
+    // Fall through to defaults
+  }
+
+  return getDefaultModelOptions();
+}

--- a/packages/slack-bot/src/app-home/publisher.ts
+++ b/packages/slack-bot/src/app-home/publisher.ts
@@ -1,0 +1,38 @@
+import { publishView, resolveAppName } from "@open-inspect/shared";
+import { getUserRepoBranchPreferences } from "../branch-preferences";
+import { getAvailableRepos } from "../classifier/repos";
+import { createLogger } from "../logger";
+import type { Env } from "../types";
+import { getUserPreferences, resolveUserPreferences } from "../user-preferences";
+import { getAvailableModels } from "./models";
+import { buildAppHomeView } from "./view";
+
+const log = createLogger("app-home");
+
+export async function publishAppHome(env: Env, userId: string): Promise<void> {
+  const [prefs, availableModels, repos, repoBranchPreferences] = await Promise.all([
+    getUserPreferences(env, userId),
+    getAvailableModels(env),
+    getAvailableRepos(env),
+    getUserRepoBranchPreferences(env, userId),
+  ]);
+  const current = resolveUserPreferences(prefs, env.DEFAULT_MODEL);
+  const view = buildAppHomeView({
+    appName: resolveAppName(env),
+    availableModels,
+    currentModel: current.model,
+    currentEffort: current.reasoningEffort,
+    currentBranch: current.branch,
+    repos,
+    repoBranchPreferences,
+  });
+
+  const result = await publishView(env.SLACK_BOT_TOKEN, userId, {
+    type: view.type,
+    blocks: view.blocks,
+  });
+
+  if (!result.ok) {
+    log.error("slack.app_home", { user_id: userId, outcome: "error", slack_error: result.error });
+  }
+}

--- a/packages/slack-bot/src/app-home/slack-types.ts
+++ b/packages/slack-bot/src/app-home/slack-types.ts
@@ -1,0 +1,101 @@
+import type { SlackInteractionPayload } from "../types";
+
+export interface ModelOption {
+  label: string;
+  value: string;
+}
+
+export type SlackSelectOption = { text: SlackPlainText; value: string };
+export type SlackPlainText = { type: "plain_text"; text: string };
+export type SlackMrkdwnText = { type: "mrkdwn"; text: string };
+export type SlackText = SlackPlainText | SlackMrkdwnText;
+
+export type SlackConfirmation = {
+  title: SlackPlainText;
+  text: SlackText;
+  confirm: SlackPlainText;
+  deny: SlackPlainText;
+};
+
+export type SlackButtonElement = {
+  type: "button";
+  action_id: string;
+  text: SlackPlainText;
+  value?: string;
+  style?: "danger";
+  confirm?: SlackConfirmation;
+};
+
+export type SlackStaticSelectElement = {
+  type: "static_select";
+  action_id: string;
+  initial_option?: SlackSelectOption;
+  placeholder?: SlackPlainText;
+  options: SlackSelectOption[];
+};
+
+export type SlackExternalSelectElement = {
+  type: "external_select";
+  action_id: string;
+  placeholder: SlackPlainText;
+  min_query_length: number;
+};
+
+export type SlackPlainTextInputElement = {
+  type: "plain_text_input";
+  action_id: string;
+  initial_value: string;
+  placeholder: SlackPlainText;
+};
+
+export type SlackBlockElement =
+  | SlackButtonElement
+  | SlackStaticSelectElement
+  | SlackExternalSelectElement;
+export type SlackHeaderBlock = { type: "header"; text: SlackPlainText };
+export type SlackSectionBlock = {
+  type: "section";
+  text: SlackText;
+  accessory?: SlackButtonElement;
+};
+export type SlackActionsBlock = {
+  type: "actions";
+  block_id?: string;
+  elements: SlackBlockElement[];
+};
+export type SlackContextBlock = { type: "context"; elements: SlackText[] };
+export type SlackInputBlock = {
+  type: "input";
+  block_id: string;
+  optional?: boolean;
+  label: SlackPlainText;
+  element: SlackPlainTextInputElement;
+  hint?: SlackPlainText;
+};
+export type SlackDividerBlock = { type: "divider" };
+
+export type AppHomeBlock =
+  | SlackHeaderBlock
+  | SlackSectionBlock
+  | SlackActionsBlock
+  | SlackContextBlock
+  | SlackDividerBlock;
+export type AppHomeModalBlock = SlackSectionBlock | SlackInputBlock;
+export type AppHomeView = { type: "home"; blocks: AppHomeBlock[] };
+
+export type SlackBlockAction = NonNullable<SlackInteractionPayload["actions"]>[number];
+export type BackgroundTaskScheduler = (promise: Promise<void>) => void;
+
+export type AppHomeInteractionResponseBody =
+  | { options: SlackSelectOption[] }
+  | { response_action: "errors"; errors: Record<string, string> }
+  | { response_action: "clear" }
+  | { ok: true };
+
+export type AppHomeInteractionLogContext = {
+  interaction_type: string;
+  action_id?: string;
+  callback_id?: string;
+  option_count?: number;
+  outcome?: string;
+};

--- a/packages/slack-bot/src/app-home/view.ts
+++ b/packages/slack-bot/src/app-home/view.ts
@@ -1,0 +1,338 @@
+import { getDefaultReasoningEffort, getReasoningConfig } from "@open-inspect/shared";
+import { CLEAR_REPO_BRANCH_ACTION_ID, REPO_BRANCH_SELECTOR_ACTION_ID } from "../branch-preferences";
+import type { RepoConfig } from "../types";
+import {
+  CLEAR_BRANCH_PREFERENCE_ACTION_ID,
+  MAX_RENDERED_REPO_OVERRIDES,
+  OPEN_BRANCH_MODAL_ACTION_ID,
+  SELECT_MODEL_ACTION_ID,
+  SELECT_REASONING_EFFORT_ACTION_ID,
+} from "./constants";
+import type { AppHomeBlock, AppHomeView, ModelOption, SlackSelectOption } from "./slack-types";
+
+export interface AppHomeViewState {
+  appName: string;
+  availableModels: ModelOption[];
+  currentModel: string;
+  currentEffort: string | undefined;
+  currentBranch: string | undefined;
+  repos: RepoConfig[];
+  repoBranchPreferences: Map<string, string>;
+}
+
+type ConfiguredRepoOverride = {
+  repo: RepoConfig;
+  branch: string;
+};
+
+export function buildAppHomeIntroText(appName: string): string {
+  return `Configure your ${appName} preferences below.`;
+}
+
+export function buildRepoBranchSelectOptions(
+  repos: RepoConfig[],
+  repoBranchPreferences: Map<string, string>
+): SlackSelectOption[] {
+  return repos.map((repo) => {
+    const repoBranch = repoBranchPreferences.get(repo.id);
+    const label = repoBranch ? `${repo.fullName} → ${repoBranch}` : repo.fullName;
+    return {
+      text: {
+        type: "plain_text" as const,
+        text: label.slice(0, 75),
+      },
+      value: repo.id,
+    };
+  });
+}
+
+function toSelectOption(model: ModelOption): SlackSelectOption {
+  return {
+    text: { type: "plain_text", text: model.label },
+    value: model.value,
+  };
+}
+
+function buildModelBlocks(
+  currentModelInfo: ModelOption,
+  modelOptions: ModelOption[]
+): AppHomeBlock[] {
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "*Model*\nSelect the model for your coding sessions:",
+      },
+    },
+    {
+      type: "actions",
+      block_id: "model_selection",
+      elements: [
+        {
+          type: "static_select",
+          action_id: SELECT_MODEL_ACTION_ID,
+          initial_option: toSelectOption(currentModelInfo),
+          options: modelOptions.map(toSelectOption),
+        },
+      ],
+    },
+  ];
+}
+
+function buildReasoningBlocks(
+  currentModel: string,
+  effectiveEffort: string | undefined
+): AppHomeBlock[] {
+  const reasoningConfig = getReasoningConfig(currentModel);
+  if (!reasoningConfig) {
+    return [];
+  }
+
+  const reasoningOptions = reasoningConfig.efforts.map((effort) => ({
+    text: { type: "plain_text" as const, text: effort },
+    value: effort,
+  }));
+  const currentEffortOption = reasoningOptions.find((option) => option.value === effectiveEffort);
+
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "*Reasoning Effort*\nControl the depth of reasoning for your sessions:",
+      },
+    },
+    {
+      type: "actions",
+      block_id: "reasoning_selection",
+      elements: [
+        {
+          type: "static_select",
+          action_id: SELECT_REASONING_EFFORT_ACTION_ID,
+          ...(currentEffortOption ? { initial_option: currentEffortOption } : {}),
+          placeholder: { type: "plain_text" as const, text: "Select effort" },
+          options: reasoningOptions,
+        },
+      ],
+    },
+  ];
+}
+
+function buildGlobalBranchBlocks(currentBranch: string | undefined): AppHomeBlock[] {
+  return [
+    {
+      type: "divider",
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "*Branch (optional)*\nSet a default branch for new Slack sessions. Leave empty to use each repository default branch.",
+      },
+      accessory: {
+        type: "button",
+        action_id: OPEN_BRANCH_MODAL_ACTION_ID,
+        text: { type: "plain_text", text: currentBranch ? "Edit branch" : "Set branch" },
+        value: OPEN_BRANCH_MODAL_ACTION_ID,
+      },
+    },
+    {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: currentBranch
+            ? `Branch override: *${currentBranch}*`
+            : "Branch override: *(repo default)*",
+        },
+      ],
+    },
+    ...(currentBranch
+      ? [
+          {
+            type: "actions" as const,
+            elements: [
+              {
+                type: "button" as const,
+                action_id: CLEAR_BRANCH_PREFERENCE_ACTION_ID,
+                text: { type: "plain_text" as const, text: "Clear branch override" },
+                style: "danger" as const,
+                value: CLEAR_BRANCH_PREFERENCE_ACTION_ID,
+              },
+            ],
+          },
+        ]
+      : []),
+  ];
+}
+
+function getConfiguredRepoOverrides(
+  repos: RepoConfig[],
+  repoBranchPreferences: Map<string, string>
+): ConfiguredRepoOverride[] {
+  return repos
+    .map((repo) => ({ repo, branch: repoBranchPreferences.get(repo.id) }))
+    .filter((entry): entry is ConfiguredRepoOverride => Boolean(entry.branch));
+}
+
+function buildRepoOverrideRow({ repo, branch }: ConfiguredRepoOverride): AppHomeBlock {
+  return {
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: `\`${repo.fullName}\` → *${branch}*`,
+    },
+    accessory: {
+      type: "button",
+      action_id: CLEAR_REPO_BRANCH_ACTION_ID,
+      text: { type: "plain_text", text: "Delete" },
+      style: "danger",
+      value: repo.id,
+      confirm: {
+        title: { type: "plain_text", text: "Delete override?" },
+        text: {
+          type: "mrkdwn",
+          text: `Remove branch override for *${repo.fullName}*?`,
+        },
+        confirm: { type: "plain_text", text: "Delete" },
+        deny: { type: "plain_text", text: "Cancel" },
+      },
+    },
+  };
+}
+
+function buildConfiguredRepoOverrideBlocks(
+  configuredRepoOverrides: ConfiguredRepoOverride[]
+): AppHomeBlock[] {
+  if (configuredRepoOverrides.length === 0) {
+    return [];
+  }
+
+  const renderedOverrides = configuredRepoOverrides.slice(0, MAX_RENDERED_REPO_OVERRIDES);
+  const hiddenOverrideCount = configuredRepoOverrides.length - renderedOverrides.length;
+
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "*Configured repo overrides*",
+      },
+    },
+    ...renderedOverrides.map(buildRepoOverrideRow),
+    ...(hiddenOverrideCount > 0
+      ? [
+          {
+            type: "context" as const,
+            elements: [
+              {
+                type: "mrkdwn" as const,
+                text: `…and ${hiddenOverrideCount} more override${hiddenOverrideCount === 1 ? "" : "s"}. Use *Search repository* above to view or clear any repo's override.`,
+              },
+            ],
+          },
+        ]
+      : []),
+  ];
+}
+
+function buildRepoBranchBlocks(
+  repos: RepoConfig[],
+  repoBranchPreferences: Map<string, string>
+): AppHomeBlock[] {
+  if (repos.length === 0) {
+    return [];
+  }
+
+  const configuredRepoOverrides = getConfiguredRepoOverrides(repos, repoBranchPreferences);
+
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "*Branch by repository*\nChoose a repository to set a repo-specific branch override.",
+      },
+    },
+    {
+      type: "actions",
+      block_id: "repo_branch_selection",
+      elements: [
+        {
+          type: "external_select",
+          action_id: REPO_BRANCH_SELECTOR_ACTION_ID,
+          placeholder: { type: "plain_text", text: "Search repository" },
+          min_query_length: 0,
+        },
+      ],
+    },
+    {
+      type: "context",
+      elements: [
+        {
+          type: "mrkdwn",
+          text: "Priority: repo-specific override → global override → repository default branch.",
+        },
+      ],
+    },
+    ...buildConfiguredRepoOverrideBlocks(configuredRepoOverrides),
+  ];
+}
+
+function buildSummaryBlock(
+  currentModelInfo: ModelOption,
+  effectiveEffort: string | undefined,
+  currentBranch: string | undefined
+): AppHomeBlock {
+  return {
+    type: "context",
+    elements: [
+      {
+        type: "mrkdwn",
+        text: `Currently using: *${currentModelInfo.label}*${effectiveEffort ? ` · ${effectiveEffort}` : ""}${currentBranch ? ` · branch:${currentBranch}` : ""}`,
+      },
+    ],
+  };
+}
+
+export function buildAppHomeView({
+  appName,
+  availableModels,
+  currentModel,
+  currentEffort,
+  currentBranch,
+  repos,
+  repoBranchPreferences,
+}: AppHomeViewState): AppHomeView {
+  const currentModelInfo = availableModels.find((model) => model.value === currentModel) ??
+    availableModels[0] ?? {
+      label: currentModel,
+      value: currentModel,
+    };
+  const modelOptions = availableModels.length > 0 ? availableModels : [currentModelInfo];
+  const effectiveEffort = currentEffort ?? getDefaultReasoningEffort(currentModel);
+
+  return {
+    type: "home",
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: "Settings" },
+      },
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: buildAppHomeIntroText(appName),
+        },
+      },
+      { type: "divider" },
+      ...buildModelBlocks(currentModelInfo, modelOptions),
+      ...buildReasoningBlocks(currentModel, effectiveEffort),
+      ...buildGlobalBranchBlocks(currentBranch),
+      ...buildRepoBranchBlocks(repos, repoBranchPreferences),
+      buildSummaryBlock(currentModelInfo, effectiveEffort, currentBranch),
+    ],
+  };
+}

--- a/packages/slack-bot/src/app-home/view.ts
+++ b/packages/slack-bot/src/app-home/view.ts
@@ -25,6 +25,16 @@ type ConfiguredRepoOverride = {
   branch: string;
 };
 
+const SELECT_OPTION_TEXT_LIMIT = 75;
+
+function truncateSelectOptionText(text: string): string {
+  if (text.length <= SELECT_OPTION_TEXT_LIMIT) {
+    return text;
+  }
+
+  return `${text.slice(0, SELECT_OPTION_TEXT_LIMIT - 1)}…`;
+}
+
 export function buildAppHomeIntroText(appName: string): string {
   return `Configure your ${appName} preferences below.`;
 }
@@ -39,7 +49,7 @@ export function buildRepoBranchSelectOptions(
     return {
       text: {
         type: "plain_text" as const,
-        text: label.slice(0, 75),
+        text: truncateSelectOptionText(label),
       },
       value: repo.id,
     };
@@ -48,7 +58,7 @@ export function buildRepoBranchSelectOptions(
 
 function toSelectOption(model: ModelOption): SlackSelectOption {
   return {
-    text: { type: "plain_text", text: model.label },
+    text: { type: "plain_text", text: truncateSelectOptionText(model.label) },
     value: model.value,
   };
 }

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -22,20 +22,8 @@ vi.mock("@open-inspect/shared", async () => {
   };
 });
 
-import app, { buildAppHomeIntroText } from "./index";
+import app from "./index";
 import { clearLocalCache } from "./classifier/repos";
-
-describe("buildAppHomeIntroText", () => {
-  it("uses the configured app name", () => {
-    expect(buildAppHomeIntroText("Acme Bot")).toBe("Configure your Acme Bot preferences below.");
-  });
-
-  it("works with the default Open-Inspect name", () => {
-    expect(buildAppHomeIntroText("Open-Inspect")).toBe(
-      "Configure your Open-Inspect preferences below."
-    );
-  });
-});
 
 function createMockKV() {
   const store = new Map<string, string>();
@@ -1406,96 +1394,6 @@ describe("POST /interactions", () => {
     const kvDelete = (env.SLACK_KV as unknown as { delete: ReturnType<typeof vi.fn> }).delete;
     expect(kvDelete).toHaveBeenCalledWith("user_repo_branch:U123:acme/app");
     expect(mockPublishView).toHaveBeenCalled();
-  });
-
-  it("caps the App Home repo-override list under Slack's 100-block limit", async () => {
-    mockVerifySlackSignature.mockResolvedValue(true);
-    mockPublishView.mockResolvedValue({ ok: true });
-
-    const env = makeEnv();
-
-    // 60 available repos, each with a repo-specific branch override.
-    const repos = Array.from({ length: 60 }, (_, idx) => {
-      const number = String(idx + 1).padStart(3, "0");
-      return {
-        id: `acme/repo-${number}`,
-        owner: "acme",
-        name: `repo-${number}`,
-        fullName: `acme/repo-${number}`,
-        defaultBranch: "main",
-        private: true,
-      };
-    });
-
-    for (const repo of repos) {
-      await (env.SLACK_KV as unknown as { put: (k: string, v: string) => Promise<void> }).put(
-        `user_repo_branch:U123:${repo.id}`,
-        "staging"
-      );
-    }
-
-    (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-      async (input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url.includes("/repos")) {
-          return new Response(JSON.stringify({ repos }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-        return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
-      }
-    );
-
-    const payload = {
-      type: "event_callback",
-      event_id: "Ev-override-cap",
-      event: { type: "app_home_opened", tab: "home", user: "U123" },
-    };
-
-    const request = new Request("http://localhost/events", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "x-slack-signature": "v0=test",
-        "x-slack-request-timestamp": `${Math.floor(Date.now() / 1000)}`,
-      },
-      body: JSON.stringify(payload),
-    });
-
-    const ctx = makeCtx();
-    const response = await app.fetch(request, env, ctx);
-    expect(response.status).toBe(200);
-    await flushWaitUntil(ctx);
-
-    expect(mockPublishView).toHaveBeenCalled();
-    const publishedView = mockPublishView.mock.calls.at(-1)?.[2] as {
-      blocks: Array<{
-        type: string;
-        text?: { text?: string };
-        elements?: Array<{ text?: string }>;
-      }>;
-    };
-
-    // Stays under Slack's hard 100-block ceiling for views.publish.
-    expect(publishedView.blocks.length).toBeLessThanOrEqual(100);
-
-    // Exactly the cap is rendered (one section per override) ...
-    const overrideRows = publishedView.blocks.filter(
-      (b) => b.type === "section" && (b.text?.text ?? "").includes("→")
-    );
-    expect(overrideRows.length).toBe(50);
-
-    // ... and the remainder is surfaced as a summary instead of dropped silently.
-    const hasMoreNote = publishedView.blocks.some(
-      (b) =>
-        b.type === "context" &&
-        (b.elements ?? []).some((e) => (e.text ?? "").includes("10 more overrides"))
-    );
-    expect(hasMoreNote).toBe(true);
   });
 
   it("returns repo suggestions beyond 100 repos via search", async () => {

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -312,6 +312,52 @@ describe("POST /events", () => {
     mockGetUserInfo.mockResolvedValue({ ok: true, user: undefined });
   });
 
+  it("publishes App Home when the home tab is opened", async () => {
+    mockPublishView.mockResolvedValue({ ok: true });
+    const env = makeEnv();
+    const ctx = makeCtx();
+
+    const response = await app.fetch(
+      slackEventRequest({
+        type: "app_home_opened",
+        tab: "home",
+        user: "U123",
+      }),
+      env,
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(ctx.waitUntil).toHaveBeenCalledOnce();
+
+    await flushWaitUntil(ctx);
+
+    expect(mockPublishView).toHaveBeenCalledOnce();
+    const [token, userId, view] = mockPublishView.mock.calls[0];
+    expect(token).toBe("xoxb-test");
+    expect(userId).toBe("U123");
+    expect(view).toEqual(
+      expect.objectContaining({
+        type: "home",
+        blocks: expect.arrayContaining([
+          expect.objectContaining({
+            type: "section",
+            text: expect.objectContaining({
+              text: "Configure your Open-Inspect preferences below.",
+            }),
+          }),
+          expect.objectContaining({
+            type: "section",
+            text: expect.objectContaining({
+              text: expect.stringContaining("*Branch by repository*"),
+            }),
+          }),
+        ]),
+      })
+    );
+  });
+
   it("sets Starting status for a new app mention before session creation", async () => {
     const order: string[] = [];
     const slackFetch = mockSlackFetch(order);

--- a/packages/slack-bot/src/index.ts
+++ b/packages/slack-bot/src/index.ts
@@ -6,13 +6,11 @@
  */
 
 import { Hono } from "hono";
-import { resolveAppName } from "@open-inspect/shared";
 import type {
   Env,
   RepoConfig,
   CallbackContext,
   ThreadSession,
-  UserPreferences,
   SlackInteractionPayload,
 } from "./types";
 import { stripMentions, isDmDispatchable } from "./dm-utils";
@@ -24,8 +22,6 @@ import {
   getChannelInfo,
   getThreadMessages,
   getUserInfo,
-  publishView,
-  openView,
 } from "@open-inspect/shared";
 import { resolveUserNames } from "@open-inspect/shared";
 import { createClassifier } from "./classifier";
@@ -34,48 +30,14 @@ import { callbacksRouter } from "./callbacks";
 import { buildInternalAuthHeaders } from "@open-inspect/shared";
 import { createLogger } from "./logger";
 import { createKvCacheStore } from "@open-inspect/shared";
-import {
-  BRANCH_MODAL_CALLBACK_ID,
-  REPO_BRANCH_MODAL_CALLBACK_ID,
-  BRANCH_INPUT_BLOCK_ID,
-  BRANCH_INPUT_ACTION_ID,
-  REPO_BRANCH_SELECTOR_ACTION_ID,
-  CLEAR_REPO_BRANCH_ACTION_ID,
-  getUserRepoBranchPreference,
-  getUserRepoBranchPreferences,
-  saveUserRepoBranchPreference,
-  normalizeBranchPreference,
-  isValidBranchName,
-  getValidatedBranch,
-  isBranchModalCallbackId,
-  getSubmittedBranch,
-  getBranchSubmissionValidationError,
-} from "./branch-preferences";
-import {
-  MODEL_OPTIONS,
-  DEFAULT_MODEL,
-  DEFAULT_ENABLED_MODELS,
-  isValidModel,
-  getValidModelOrDefault,
-  getReasoningConfig,
-  getDefaultReasoningEffort,
-  isValidReasoningEffort,
-} from "@open-inspect/shared";
+import { getUserRepoBranchPreference } from "./branch-preferences";
 import { setAssistantThreadStatusBestEffort } from "./activity-status";
+import { handleAppHomeInteractionRoute, publishAppHome } from "./app-home";
+import { getResolvedUserPreferences } from "./user-preferences";
 
 const log = createLogger("handler");
 
-const MAX_REPO_SUGGESTION_OPTIONS = 100;
-
-// Max repo-specific branch overrides rendered in the App Home tab. Each renders
-// one block and Slack's views.publish rejects views over 100 blocks, so this
-// bounds the list well under the limit (the base App Home uses ~15 blocks).
-const MAX_RENDERED_REPO_OVERRIDES = 50;
 type BackgroundTaskScheduler = (promise: Promise<void>) => void;
-
-export function buildAppHomeIntroText(appName: string): string {
-  return `Configure your ${appName} preferences below.`;
-}
 
 /**
  * Build authenticated headers for control plane requests.
@@ -295,560 +257,6 @@ async function clearThreadSession(env: Env, channel: string, threadTs: string): 
 }
 
 /**
- * Derive flat model options from shared MODEL_OPTIONS for Slack dropdowns.
- */
-const ALL_MODELS = MODEL_OPTIONS.flatMap((group) =>
-  group.models.map((m) => ({
-    label: `${m.name} (${m.description})`,
-    value: m.id,
-  }))
-);
-
-/**
- * Fetch enabled models from the control plane, falling back to defaults.
- */
-async function getAvailableModels(
-  env: Env,
-  traceId?: string
-): Promise<{ label: string; value: string }[]> {
-  try {
-    const headers = await getAuthHeaders(env, traceId);
-    const response = await env.CONTROL_PLANE.fetch("https://internal/model-preferences", {
-      method: "GET",
-      headers,
-    });
-
-    if (response.ok) {
-      const data = (await response.json()) as { enabledModels: string[] };
-      if (data.enabledModels.length > 0) {
-        const enabledSet = new Set(data.enabledModels);
-        return ALL_MODELS.filter((m) => enabledSet.has(m.value));
-      }
-    }
-  } catch {
-    // Fall through to defaults
-  }
-
-  const defaultSet = new Set<string>(DEFAULT_ENABLED_MODELS);
-  return ALL_MODELS.filter((m) => defaultSet.has(m.value));
-}
-
-/**
- * Generate a consistent KV key for user preferences.
- */
-function getUserPreferencesKey(userId: string): string {
-  return `user_prefs:${userId}`;
-}
-
-/**
- * Type guard to validate UserPreferences shape from KV.
- */
-function isValidUserPreferences(data: unknown): data is UserPreferences {
-  if (!data || typeof data !== "object" || Array.isArray(data)) {
-    return false;
-  }
-  const obj = data as Record<string, unknown>;
-  const branchValid = obj.branch === undefined || typeof obj.branch === "string";
-  return (
-    typeof obj.userId === "string" &&
-    typeof obj.model === "string" &&
-    typeof obj.updatedAt === "number" &&
-    branchValid
-  );
-}
-
-/**
- * Look up user preferences from KV.
- */
-async function getUserPreferences(env: Env, userId: string): Promise<UserPreferences | null> {
-  try {
-    const key = getUserPreferencesKey(userId);
-    const data = await createKvCacheStore(env.SLACK_KV).get(key, "json");
-    if (isValidUserPreferences(data)) {
-      return data;
-    }
-    return null;
-  } catch (e) {
-    log.error("kv.get", {
-      key_prefix: "user_prefs",
-      user_id: userId,
-      error: e instanceof Error ? e : new Error(String(e)),
-    });
-    return null;
-  }
-}
-
-/**
- * Save user preferences to KV.
- * @returns true if saved successfully, false otherwise
- */
-async function saveUserPreferences(
-  env: Env,
-  userId: string,
-  model: string,
-  reasoningEffort?: string,
-  branch?: string
-): Promise<boolean> {
-  try {
-    const key = getUserPreferencesKey(userId);
-    const normalizedBranch = normalizeBranchPreference(branch);
-    if (normalizedBranch && !isValidBranchName(normalizedBranch)) {
-      log.warn("slack.branch_pref.invalid", {
-        user_id: userId,
-        branch: normalizedBranch,
-      });
-      return false;
-    }
-    const prefs: UserPreferences = {
-      userId,
-      model,
-      reasoningEffort,
-      branch: normalizedBranch,
-      updatedAt: Date.now(),
-    };
-    // No TTL - preferences persist indefinitely
-    await createKvCacheStore(env.SLACK_KV).put(key, JSON.stringify(prefs));
-    return true;
-  } catch (e) {
-    log.error("kv.put", {
-      key_prefix: "user_prefs",
-      user_id: userId,
-      error: e instanceof Error ? e : new Error(String(e)),
-    });
-    return false;
-  }
-}
-
-/**
- * Build Slack select options for repositories with optional branch labels.
- */
-function buildRepoBranchSelectOptions(
-  repos: RepoConfig[],
-  repoBranchPreferences: Map<string, string>
-): Array<{ text: { type: "plain_text"; text: string }; value: string }> {
-  return repos.map((repo) => {
-    const repoBranch = repoBranchPreferences.get(repo.id);
-    const label = repoBranch ? `${repo.fullName} → ${repoBranch}` : repo.fullName;
-    return {
-      text: {
-        type: "plain_text" as const,
-        text: label.slice(0, 75),
-      },
-      value: repo.id,
-    };
-  });
-}
-
-/**
- * Build searchable repository options for Slack external_select.
- */
-async function getRepoBranchSuggestionOptions(
-  env: Env,
-  userId: string,
-  query: string | undefined,
-  traceId?: string
-): Promise<Array<{ text: { type: "plain_text"; text: string }; value: string }>> {
-  const repos = await getAvailableRepos(env, traceId);
-  const repoBranchPreferences = await getUserRepoBranchPreferences(env, userId);
-  const normalizedQuery = query?.trim().toLowerCase();
-
-  const filteredRepos = normalizedQuery
-    ? repos.filter((repo) => repo.fullName.toLowerCase().includes(normalizedQuery))
-    : repos;
-
-  return buildRepoBranchSelectOptions(filteredRepos, repoBranchPreferences).slice(
-    0,
-    MAX_REPO_SUGGESTION_OPTIONS
-  );
-}
-
-/**
- * Publish the App Home view for a user.
- */
-async function publishAppHome(env: Env, userId: string): Promise<void> {
-  const prefs = await getUserPreferences(env, userId);
-  const fallback = env.DEFAULT_MODEL || DEFAULT_MODEL;
-  // Normalize model to ensure it's valid - UI and behavior will be consistent
-  const currentModel = getValidModelOrDefault(prefs?.model ?? fallback);
-  const availableModels = await getAvailableModels(env);
-  const currentModelInfo =
-    availableModels.find((m) => m.value === currentModel) || availableModels[0];
-
-  // Determine reasoning effort options for the current model
-  const reasoningConfig = getReasoningConfig(currentModel);
-  const currentEffort =
-    prefs?.reasoningEffort && isValidReasoningEffort(currentModel, prefs.reasoningEffort)
-      ? prefs.reasoningEffort
-      : getDefaultReasoningEffort(currentModel);
-  const currentBranch = getValidatedBranch(prefs?.branch);
-
-  const repos = await getAvailableRepos(env);
-  const repoBranchPreferences = await getUserRepoBranchPreferences(env, userId);
-
-  const reasoningOptions = reasoningConfig
-    ? reasoningConfig.efforts.map((effort) => ({
-        text: { type: "plain_text" as const, text: effort },
-        value: effort,
-      }))
-    : [];
-
-  const blocks: Array<Record<string, unknown>> = [
-    {
-      type: "header",
-      text: { type: "plain_text", text: "Settings" },
-    },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: buildAppHomeIntroText(resolveAppName(env)),
-      },
-    },
-    { type: "divider" },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "*Model*\nSelect the model for your coding sessions:",
-      },
-    },
-    {
-      type: "actions",
-      block_id: "model_selection",
-      elements: [
-        {
-          type: "static_select",
-          action_id: "select_model",
-          initial_option: {
-            text: { type: "plain_text", text: currentModelInfo.label },
-            value: currentModelInfo.value,
-          },
-          options: availableModels.map((m) => ({
-            text: { type: "plain_text", text: m.label },
-            value: m.value,
-          })),
-        },
-      ],
-    },
-  ];
-
-  // Add reasoning effort dropdown if the model supports it
-  if (reasoningConfig) {
-    const currentEffortOption = reasoningOptions.find((o) => o.value === currentEffort);
-    blocks.push(
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: "*Reasoning Effort*\nControl the depth of reasoning for your sessions:",
-        },
-      },
-      {
-        type: "actions",
-        block_id: "reasoning_selection",
-        elements: [
-          {
-            type: "static_select",
-            action_id: "select_reasoning_effort",
-            ...(currentEffortOption ? { initial_option: currentEffortOption } : {}),
-            placeholder: { type: "plain_text" as const, text: "Select effort" },
-            options: reasoningOptions,
-          },
-        ],
-      }
-    );
-  }
-
-  blocks.push(
-    {
-      type: "divider",
-    },
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text: "*Branch (optional)*\nSet a default branch for new Slack sessions. Leave empty to use each repository default branch.",
-      },
-      accessory: {
-        type: "button",
-        action_id: "open_branch_modal",
-        text: { type: "plain_text", text: currentBranch ? "Edit branch" : "Set branch" },
-        value: "open_branch_modal",
-      },
-    },
-    {
-      type: "context",
-      elements: [
-        {
-          type: "mrkdwn",
-          text: currentBranch
-            ? `Branch override: *${currentBranch}*`
-            : "Branch override: *(repo default)*",
-        },
-      ],
-    }
-  );
-
-  if (currentBranch) {
-    blocks.push({
-      type: "actions",
-      elements: [
-        {
-          type: "button",
-          action_id: "clear_branch_preference",
-          text: { type: "plain_text", text: "Clear branch override" },
-          style: "danger",
-          value: "clear_branch_preference",
-        },
-      ],
-    });
-  }
-
-  if (repos.length > 0) {
-    const configuredRepoOverrides = repos
-      .map((repo) => ({ repo, branch: repoBranchPreferences.get(repo.id) }))
-      .filter((entry): entry is { repo: RepoConfig; branch: string } => Boolean(entry.branch));
-
-    blocks.push(
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: "*Branch by repository*\nChoose a repository to set a repo-specific branch override.",
-        },
-      },
-      {
-        type: "actions",
-        block_id: "repo_branch_selection",
-        elements: [
-          {
-            type: "external_select",
-            action_id: REPO_BRANCH_SELECTOR_ACTION_ID,
-            placeholder: { type: "plain_text", text: "Search repository" },
-            min_query_length: 0,
-          },
-        ],
-      },
-      {
-        type: "context",
-        elements: [
-          {
-            type: "mrkdwn",
-            text: "Priority: repo-specific override → global override → repository default branch.",
-          },
-        ],
-      }
-    );
-
-    if (configuredRepoOverrides.length > 0) {
-      blocks.push({
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: "*Configured repo overrides*",
-        },
-      });
-
-      // Slack's views.publish rejects Home tabs over 100 blocks. Each override
-      // renders one block, so cap the list to stay well under the limit. Hidden
-      // overrides are still fully manageable via the "Search repository"
-      // selector above, which opens a modal that can clear any repo's override.
-      const renderedOverrides = configuredRepoOverrides.slice(0, MAX_RENDERED_REPO_OVERRIDES);
-
-      for (const { repo, branch } of renderedOverrides) {
-        blocks.push({
-          type: "section",
-          text: {
-            type: "mrkdwn",
-            text: `\`${repo.fullName}\` → *${branch}*`,
-          },
-          accessory: {
-            type: "button",
-            action_id: CLEAR_REPO_BRANCH_ACTION_ID,
-            text: { type: "plain_text", text: "Delete" },
-            style: "danger",
-            value: repo.id,
-            confirm: {
-              title: { type: "plain_text", text: "Delete override?" },
-              text: {
-                type: "mrkdwn",
-                text: `Remove branch override for *${repo.fullName}*?`,
-              },
-              confirm: { type: "plain_text", text: "Delete" },
-              deny: { type: "plain_text", text: "Cancel" },
-            },
-          },
-        });
-      }
-
-      const hiddenOverrideCount = configuredRepoOverrides.length - renderedOverrides.length;
-      if (hiddenOverrideCount > 0) {
-        blocks.push({
-          type: "context",
-          elements: [
-            {
-              type: "mrkdwn",
-              text: `…and ${hiddenOverrideCount} more override${hiddenOverrideCount === 1 ? "" : "s"}. Use *Search repository* above to view or clear any repo's override.`,
-            },
-          ],
-        });
-      }
-    }
-  }
-
-  blocks.push({
-    type: "context",
-    elements: [
-      {
-        type: "mrkdwn",
-        text: `Currently using: *${currentModelInfo.label}*${currentEffort ? ` · ${currentEffort}` : ""}${currentBranch ? ` · branch:${currentBranch}` : ""}`,
-      },
-    ],
-  });
-
-  const view = {
-    type: "home",
-    blocks,
-  };
-
-  const result = await publishView(env.SLACK_BOT_TOKEN, userId, view);
-  if (!result.ok) {
-    log.error("slack.app_home", { user_id: userId, outcome: "error", slack_error: result.error });
-  }
-}
-
-/**
- * Open a modal to set or clear a user's branch preference.
- */
-async function openBranchPreferenceModal(
-  env: Env,
-  userId: string,
-  triggerId: string,
-  currentBranch?: string
-): Promise<void> {
-  const view = {
-    type: "modal",
-    callback_id: BRANCH_MODAL_CALLBACK_ID,
-    title: {
-      type: "plain_text",
-      text: "Branch Preference",
-    },
-    submit: {
-      type: "plain_text",
-      text: "Save",
-    },
-    close: {
-      type: "plain_text",
-      text: "Cancel",
-    },
-    private_metadata: JSON.stringify({ userId }),
-    blocks: [
-      {
-        type: "input",
-        block_id: BRANCH_INPUT_BLOCK_ID,
-        optional: true,
-        label: {
-          type: "plain_text",
-          text: "Default branch for new Slack sessions",
-        },
-        element: {
-          type: "plain_text_input",
-          action_id: BRANCH_INPUT_ACTION_ID,
-          initial_value: currentBranch || "",
-          placeholder: {
-            type: "plain_text",
-            text: "e.g. main, staging, release/2026-03",
-          },
-        },
-        hint: {
-          type: "plain_text",
-          text: "Leave empty to use each repository's default branch.",
-        },
-      },
-    ],
-  };
-
-  const result = await openView(env.SLACK_BOT_TOKEN, triggerId, view);
-  if (!result.ok) {
-    log.error("slack.open_branch_modal", {
-      user_id: userId,
-      outcome: "error",
-      slack_error: result.error,
-    });
-  }
-}
-
-/**
- * Open a modal to set or clear a user's branch preference for a specific repository.
- */
-async function openRepoBranchPreferenceModal(
-  env: Env,
-  userId: string,
-  triggerId: string,
-  repo: RepoConfig,
-  currentBranch?: string
-): Promise<void> {
-  const view = {
-    type: "modal",
-    callback_id: REPO_BRANCH_MODAL_CALLBACK_ID,
-    title: {
-      type: "plain_text",
-      text: "Repo Branch",
-    },
-    submit: {
-      type: "plain_text",
-      text: "Save",
-    },
-    close: {
-      type: "plain_text",
-      text: "Cancel",
-    },
-    private_metadata: JSON.stringify({ userId, repoId: repo.id }),
-    blocks: [
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: `Repository: *${repo.fullName}*`,
-        },
-      },
-      {
-        type: "input",
-        block_id: BRANCH_INPUT_BLOCK_ID,
-        optional: true,
-        label: {
-          type: "plain_text",
-          text: "Branch override",
-        },
-        element: {
-          type: "plain_text_input",
-          action_id: BRANCH_INPUT_ACTION_ID,
-          initial_value: currentBranch || "",
-          placeholder: {
-            type: "plain_text",
-            text: "e.g. main, staging, release/2026-03",
-          },
-        },
-        hint: {
-          type: "plain_text",
-          text: "Leave empty to clear this repository override.",
-        },
-      },
-    ],
-  };
-
-  const result = await openView(env.SLACK_BOT_TOKEN, triggerId, view);
-  if (!result.ok) {
-    log.error("slack.open_repo_branch_modal", {
-      user_id: userId,
-      repo_id: repo.id,
-      outcome: "error",
-      slack_error: result.error,
-    });
-  }
-}
-
-/**
  * Build a ThreadSession object for storage.
  */
 function buildThreadSession(
@@ -962,15 +370,10 @@ async function startSessionAndSendPrompt(
   channelDescription?: string,
   traceId?: string
 ): Promise<{ sessionId: string } | null> {
-  // Fetch user's preferred model and reasoning effort
-  const userPrefs = await getUserPreferences(env, userId);
-  const fallback = env.DEFAULT_MODEL || DEFAULT_MODEL;
-  const model = getValidModelOrDefault(userPrefs?.model ?? fallback);
-  const reasoningEffort =
-    userPrefs?.reasoningEffort && isValidReasoningEffort(model, userPrefs.reasoningEffort)
-      ? userPrefs.reasoningEffort
-      : getDefaultReasoningEffort(model);
-  const globalBranch = getValidatedBranch(userPrefs?.branch);
+  const userPrefs = await getResolvedUserPreferences(env, userId);
+  const model = userPrefs.model;
+  const reasoningEffort = userPrefs.reasoningEffort;
+  const globalBranch = userPrefs.branch;
   const repoBranch = await getUserRepoBranchPreference(env, userId, repo.id);
   const branch = repoBranch ?? globalBranch;
 
@@ -1182,78 +585,35 @@ app.post("/interactions", async (c) => {
 
   const payloadStr = new URLSearchParams(body).get("payload") || "{}";
   const payload = JSON.parse(payloadStr) as SlackInteractionPayload;
+  const scheduleBackground = (promise: Promise<void>) => c.executionCtx.waitUntil(promise);
 
-  if (payload.type === "block_suggestion") {
-    const suggestionActionId = payload.action_id;
-    const suggestionUserId = payload.user?.id;
-
-    if (suggestionActionId === REPO_BRANCH_SELECTOR_ACTION_ID && suggestionUserId) {
-      const options = await getRepoBranchSuggestionOptions(
-        c.env,
-        suggestionUserId,
-        payload.value,
-        traceId
-      );
-
-      log.info("http.request", {
-        trace_id: traceId,
-        http_method: "POST",
-        http_path: "/interactions",
-        http_status: 200,
-        interaction_type: payload.type,
-        action_id: suggestionActionId,
-        option_count: options.length,
-        duration_ms: Date.now() - startTime,
-      });
-
-      return c.json({ options });
-    }
-
-    return c.json({ options: [] });
-  }
-
-  const submittedBranch = getSubmittedBranch(payload);
-  const branchValidationError = getBranchSubmissionValidationError(payload);
-
-  if (branchValidationError) {
-    log.warn("slack.branch_pref.invalid", {
-      trace_id: traceId,
-      user_id: payload.user?.id,
-      branch: submittedBranch ?? "",
-    });
+  const appHomeResponse = await handleAppHomeInteractionRoute(
+    payload,
+    c.env,
+    traceId,
+    scheduleBackground
+  );
+  if (appHomeResponse) {
     log.info("http.request", {
       trace_id: traceId,
       http_method: "POST",
       http_path: "/interactions",
       http_status: 200,
-      interaction_type: payload.type,
-      callback_id: payload.view?.callback_id,
-      outcome: "validation_error",
+      ...appHomeResponse.logContext,
       duration_ms: Date.now() - startTime,
     });
-    return c.json({
-      response_action: "errors",
-      errors: {
-        [BRANCH_INPUT_BLOCK_ID]: branchValidationError,
-      },
-    });
+    return c.json(appHomeResponse.body);
+  }
+
+  if (payload.type === "block_suggestion") {
+    return c.json({ options: [] });
   }
 
   const actionId = payload.actions?.[0]?.action_id ?? payload.action_id;
-  const isViewSubmission = payload.type === "view_submission";
-  const shouldOpenModalInline =
-    actionId === "open_branch_modal" || actionId === REPO_BRANCH_SELECTOR_ACTION_ID;
-
-  const scheduleBackground = (promise: Promise<void>) => c.executionCtx.waitUntil(promise);
-
-  if (shouldOpenModalInline) {
-    await handleSlackInteraction(payload, c.env, traceId, scheduleBackground);
-  } else {
-    const interactionTask = Promise.resolve().then(() =>
-      handleSlackInteraction(payload, c.env, traceId, scheduleBackground)
-    );
-    c.executionCtx.waitUntil(interactionTask);
-  }
+  const interactionTask = Promise.resolve().then(() =>
+    handleSlackInteraction(payload, c.env, traceId, scheduleBackground)
+  );
+  c.executionCtx.waitUntil(interactionTask);
 
   log.info("http.request", {
     trace_id: traceId,
@@ -1265,10 +625,6 @@ app.post("/interactions", async (c) => {
     callback_id: payload.view?.callback_id,
     duration_ms: Date.now() - startTime,
   });
-
-  if (isViewSubmission && isBranchModalCallbackId(payload.view?.callback_id)) {
-    return c.json({ response_action: "clear" });
-  }
 
   return c.json({ ok: true });
 });
@@ -1823,86 +1179,6 @@ async function handleSlackInteraction(
   traceId: string | undefined,
   scheduleBackground: BackgroundTaskScheduler
 ): Promise<void> {
-  const userId = payload.user?.id;
-
-  if (payload.type === "view_submission") {
-    if (!isBranchModalCallbackId(payload.view?.callback_id) || !userId) {
-      return;
-    }
-
-    const branchRaw =
-      payload.view?.state?.values?.[BRANCH_INPUT_BLOCK_ID]?.[BRANCH_INPUT_ACTION_ID]?.value;
-    const branch = normalizeBranchPreference(branchRaw);
-
-    if (branch && !isValidBranchName(branch)) {
-      log.warn("slack.branch_pref.invalid", {
-        trace_id: traceId,
-        user_id: userId,
-        branch,
-      });
-      return;
-    }
-
-    if (payload.view?.callback_id === BRANCH_MODAL_CALLBACK_ID) {
-      const currentPrefs = await getUserPreferences(env, userId);
-      const model = getValidModelOrDefault(
-        currentPrefs?.model ?? env.DEFAULT_MODEL ?? DEFAULT_MODEL
-      );
-      const reasoningEffort =
-        currentPrefs?.reasoningEffort && isValidReasoningEffort(model, currentPrefs.reasoningEffort)
-          ? currentPrefs.reasoningEffort
-          : getDefaultReasoningEffort(model);
-
-      await saveUserPreferences(env, userId, model, reasoningEffort, branch);
-      await publishAppHome(env, userId);
-      return;
-    }
-
-    const metadataRaw = payload.view?.private_metadata;
-    let repoId: string | undefined;
-
-    if (metadataRaw) {
-      try {
-        const metadata = JSON.parse(metadataRaw) as { repoId?: string; userId?: string };
-        if (metadata.userId && metadata.userId !== userId) {
-          log.warn("slack.repo_branch_pref.user_mismatch", {
-            trace_id: traceId,
-            user_id: userId,
-            metadata_user_id: metadata.userId,
-          });
-        }
-        repoId = metadata.repoId;
-      } catch (error) {
-        log.warn("slack.repo_branch_pref.bad_metadata", {
-          trace_id: traceId,
-          user_id: userId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    }
-
-    if (!repoId) {
-      log.warn("slack.repo_branch_pref.missing_repo", { trace_id: traceId, user_id: userId });
-      await publishAppHome(env, userId);
-      return;
-    }
-
-    const availableRepos = await getAvailableRepos(env, traceId);
-    if (!availableRepos.some((repo) => repo.id === repoId)) {
-      log.warn("slack.repo_branch_pref.unknown_repo", {
-        trace_id: traceId,
-        user_id: userId,
-        repo_id: repoId,
-      });
-      await publishAppHome(env, userId);
-      return;
-    }
-
-    await saveUserRepoBranchPreference(env, userId, repoId, branch);
-    await publishAppHome(env, userId);
-    return;
-  }
-
   if (payload.type !== "block_actions" || !payload.actions?.length) {
     return;
   }
@@ -1913,93 +1189,6 @@ async function handleSlackInteraction(
   const threadTs = payload.message?.thread_ts;
 
   switch (action.action_id) {
-    case "select_model": {
-      // Handle model selection from App Home
-      const selectedModel = action.selected_option?.value;
-      // Validate the selected model before saving
-      if (selectedModel && userId && isValidModel(selectedModel)) {
-        const currentPrefs = await getUserPreferences(env, userId);
-        const preservedBranch = getValidatedBranch(currentPrefs?.branch);
-        // Reset reasoning effort to new model's default when model changes
-        const newDefault = getDefaultReasoningEffort(selectedModel);
-        await saveUserPreferences(env, userId, selectedModel, newDefault, preservedBranch);
-        await publishAppHome(env, userId);
-      }
-      break;
-    }
-
-    case "select_reasoning_effort": {
-      // Handle reasoning effort selection from App Home
-      const selectedEffort = action.selected_option?.value;
-      if (selectedEffort && userId) {
-        const currentPrefs = await getUserPreferences(env, userId);
-        const currentModel = getValidModelOrDefault(
-          currentPrefs?.model ?? env.DEFAULT_MODEL ?? DEFAULT_MODEL
-        );
-        const preservedBranch = getValidatedBranch(currentPrefs?.branch);
-        if (isValidReasoningEffort(currentModel, selectedEffort)) {
-          await saveUserPreferences(env, userId, currentModel, selectedEffort, preservedBranch);
-          await publishAppHome(env, userId);
-        }
-      }
-      break;
-    }
-
-    case "open_branch_modal": {
-      if (!userId || !payload.trigger_id) return;
-      const currentPrefs = await getUserPreferences(env, userId);
-      const currentBranch = getValidatedBranch(currentPrefs?.branch);
-      await openBranchPreferenceModal(env, userId, payload.trigger_id, currentBranch);
-      break;
-    }
-
-    case REPO_BRANCH_SELECTOR_ACTION_ID: {
-      if (!userId || !payload.trigger_id) return;
-      const repoId = action.selected_option?.value;
-      if (!repoId) return;
-
-      const repos = await getAvailableRepos(env, traceId);
-      const repo = repos.find((item) => item.id === repoId);
-      if (!repo) {
-        log.warn("slack.repo_branch_pref.repo_not_found", {
-          trace_id: traceId,
-          user_id: userId,
-          repo_id: repoId,
-        });
-        await publishAppHome(env, userId);
-        return;
-      }
-
-      const currentRepoBranch = await getUserRepoBranchPreference(env, userId, repo.id);
-      await openRepoBranchPreferenceModal(env, userId, payload.trigger_id, repo, currentRepoBranch);
-      break;
-    }
-
-    case CLEAR_REPO_BRANCH_ACTION_ID: {
-      if (!userId) return;
-      const repoId = action.value ?? action.selected_option?.value;
-      if (!repoId) return;
-
-      await saveUserRepoBranchPreference(env, userId, repoId, undefined);
-      await publishAppHome(env, userId);
-      break;
-    }
-
-    case "clear_branch_preference": {
-      if (!userId) return;
-      const currentPrefs = await getUserPreferences(env, userId);
-      const model = getValidModelOrDefault(
-        currentPrefs?.model ?? env.DEFAULT_MODEL ?? DEFAULT_MODEL
-      );
-      const reasoningEffort =
-        currentPrefs?.reasoningEffort && isValidReasoningEffort(model, currentPrefs.reasoningEffort)
-          ? currentPrefs.reasoningEffort
-          : getDefaultReasoningEffort(model);
-      await saveUserPreferences(env, userId, model, reasoningEffort, undefined);
-      await publishAppHome(env, userId);
-      break;
-    }
-
     case "select_repo": {
       if (!channel || !messageTs) return;
       const repoId = action.selected_option?.value;

--- a/packages/slack-bot/src/user-preferences.test.ts
+++ b/packages/slack-bot/src/user-preferences.test.ts
@@ -1,0 +1,72 @@
+import { getDefaultReasoningEffort } from "@open-inspect/shared";
+import { describe, expect, it, vi } from "vitest";
+import type { Env } from "./types";
+import { getUserPreferences, updateUserPreferences } from "./user-preferences";
+
+function createMockKV() {
+  const store = new Map<string, string>();
+
+  return {
+    get: vi.fn(async (key: string, type?: string) => {
+      const value = store.get(key);
+      if (!value) {
+        return null;
+      }
+      return type === "json" ? JSON.parse(value) : value;
+    }),
+    put: vi.fn(async (key: string, value: string) => {
+      store.set(key, value);
+    }),
+  };
+}
+
+function makeEnv(): Env {
+  return {
+    SLACK_KV: createMockKV() as unknown as KVNamespace,
+    DEFAULT_MODEL: "anthropic/claude-haiku-4-5",
+  } as Env;
+}
+
+describe("updateUserPreferences", () => {
+  it("preserves unspecified fields and resets reasoning when the model changes", async () => {
+    const env = makeEnv();
+    await env.SLACK_KV.put(
+      "user_prefs:U123",
+      JSON.stringify({
+        userId: "U123",
+        model: "anthropic/claude-haiku-4-5",
+        reasoningEffort: "medium",
+        branch: "staging",
+        updatedAt: 1,
+      })
+    );
+
+    await updateUserPreferences(env, "U123", { model: "anthropic/claude-haiku-4-5" });
+
+    const prefs = await getUserPreferences(env, "U123");
+    expect(prefs?.model).toBe("anthropic/claude-haiku-4-5");
+    expect(prefs?.reasoningEffort).toBe(getDefaultReasoningEffort("anthropic/claude-haiku-4-5"));
+    expect(prefs?.branch).toBe("staging");
+  });
+
+  it("distinguishes an omitted branch from an explicit clear", async () => {
+    const env = makeEnv();
+    await env.SLACK_KV.put(
+      "user_prefs:U123",
+      JSON.stringify({
+        userId: "U123",
+        model: "anthropic/claude-haiku-4-5",
+        reasoningEffort: "max",
+        branch: "staging",
+        updatedAt: 1,
+      })
+    );
+
+    await updateUserPreferences(env, "U123", { branch: undefined });
+
+    const prefs = await getUserPreferences(env, "U123");
+    expect(prefs?.model).toBe("anthropic/claude-haiku-4-5");
+    expect(prefs?.reasoningEffort).toBe("max");
+    expect(prefs?.branch).toBeUndefined();
+  });
+});

--- a/packages/slack-bot/src/user-preferences.ts
+++ b/packages/slack-bot/src/user-preferences.ts
@@ -21,8 +21,60 @@ export interface ResolvedUserPreferences {
   branch: string | undefined;
 }
 
+type UserPreferencesPatch = Partial<ResolvedUserPreferences>;
+type UserPreferencesUpdater = (
+  current: ResolvedUserPreferences
+) => UserPreferencesPatch | null | undefined;
+
 function getUserPreferencesKey(userId: string): string {
   return `user_prefs:${userId}`;
+}
+
+function hasPreferenceField<K extends keyof UserPreferencesPatch>(
+  patch: UserPreferencesPatch,
+  field: K
+): patch is UserPreferencesPatch & Required<Pick<UserPreferencesPatch, K>> {
+  return Object.prototype.hasOwnProperty.call(patch, field);
+}
+
+function normalizeResolvedPreferences(
+  preferences: ResolvedUserPreferences,
+  defaultModel: string | undefined,
+  options: { validateBranch?: boolean } = {}
+): ResolvedUserPreferences {
+  const model = getValidModelOrDefault(preferences.model ?? defaultModel ?? DEFAULT_MODEL);
+  const reasoningEffort =
+    preferences.reasoningEffort && isValidReasoningEffort(model, preferences.reasoningEffort)
+      ? preferences.reasoningEffort
+      : getDefaultReasoningEffort(model);
+  const branch =
+    options.validateBranch === false
+      ? normalizeBranchPreference(preferences.branch)
+      : getValidatedBranch(preferences.branch);
+
+  return {
+    model,
+    reasoningEffort,
+    branch,
+  };
+}
+
+function mergeUserPreferencesPatch(
+  current: ResolvedUserPreferences,
+  patch: UserPreferencesPatch,
+  defaultModel: string | undefined
+): ResolvedUserPreferences {
+  const model = hasPreferenceField(patch, "model") ? (patch.model ?? current.model) : current.model;
+  const reasoningEffort = hasPreferenceField(patch, "reasoningEffort")
+    ? patch.reasoningEffort
+    : hasPreferenceField(patch, "model")
+      ? undefined
+      : current.reasoningEffort;
+  const branch = hasPreferenceField(patch, "branch") ? patch.branch : current.branch;
+
+  return normalizeResolvedPreferences({ model, reasoningEffort, branch }, defaultModel, {
+    validateBranch: false,
+  });
 }
 
 function isValidUserPreferences(data: unknown): data is UserPreferences {
@@ -45,17 +97,14 @@ export function resolveUserPreferences(
   prefs: UserPreferences | null | undefined,
   defaultModel: string | undefined
 ): ResolvedUserPreferences {
-  const model = getValidModelOrDefault(prefs?.model ?? defaultModel ?? DEFAULT_MODEL);
-  const reasoningEffort =
-    prefs?.reasoningEffort && isValidReasoningEffort(model, prefs.reasoningEffort)
-      ? prefs.reasoningEffort
-      : getDefaultReasoningEffort(model);
-
-  return {
-    model,
-    reasoningEffort,
-    branch: getValidatedBranch(prefs?.branch),
-  };
+  return normalizeResolvedPreferences(
+    {
+      model: prefs?.model ?? defaultModel ?? DEFAULT_MODEL,
+      reasoningEffort: prefs?.reasoningEffort,
+      branch: prefs?.branch,
+    },
+    defaultModel
+  );
 }
 
 export async function getUserPreferences(
@@ -90,7 +139,10 @@ export async function saveUserPreferences(
   preferences: ResolvedUserPreferences
 ): Promise<boolean> {
   try {
-    const normalizedBranch = normalizeBranchPreference(preferences.branch);
+    const normalizedPreferences = normalizeResolvedPreferences(preferences, env.DEFAULT_MODEL, {
+      validateBranch: false,
+    });
+    const normalizedBranch = normalizeBranchPreference(normalizedPreferences.branch);
     if (normalizedBranch && !isValidBranchName(normalizedBranch)) {
       log.warn("slack.branch_pref.invalid", {
         user_id: userId,
@@ -101,8 +153,8 @@ export async function saveUserPreferences(
 
     const prefs: UserPreferences = {
       userId,
-      model: preferences.model,
-      reasoningEffort: preferences.reasoningEffort,
+      model: normalizedPreferences.model,
+      reasoningEffort: normalizedPreferences.reasoningEffort,
       branch: normalizedBranch,
       updatedAt: Date.now(),
     };
@@ -120,4 +172,22 @@ export async function saveUserPreferences(
     });
     return false;
   }
+}
+
+export async function updateUserPreferences(
+  env: Env,
+  userId: string,
+  patchOrUpdater: UserPreferencesPatch | UserPreferencesUpdater
+): Promise<boolean> {
+  const current = await getResolvedUserPreferences(env, userId);
+  const patch = typeof patchOrUpdater === "function" ? patchOrUpdater(current) : patchOrUpdater;
+  if (!patch) {
+    return false;
+  }
+
+  return saveUserPreferences(
+    env,
+    userId,
+    mergeUserPreferencesPatch(current, patch, env.DEFAULT_MODEL)
+  );
 }

--- a/packages/slack-bot/src/user-preferences.ts
+++ b/packages/slack-bot/src/user-preferences.ts
@@ -1,0 +1,123 @@
+import {
+  DEFAULT_MODEL,
+  createKvCacheStore,
+  getDefaultReasoningEffort,
+  getValidModelOrDefault,
+  isValidReasoningEffort,
+} from "@open-inspect/shared";
+import type { Env, UserPreferences } from "./types";
+import {
+  getValidatedBranch,
+  isValidBranchName,
+  normalizeBranchPreference,
+} from "./branch-preferences";
+import { createLogger } from "./logger";
+
+const log = createLogger("user-preferences");
+
+export interface ResolvedUserPreferences {
+  model: string;
+  reasoningEffort: string | undefined;
+  branch: string | undefined;
+}
+
+function getUserPreferencesKey(userId: string): string {
+  return `user_prefs:${userId}`;
+}
+
+function isValidUserPreferences(data: unknown): data is UserPreferences {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    return false;
+  }
+
+  const obj = data as Record<string, unknown>;
+  const branchValid = obj.branch === undefined || typeof obj.branch === "string";
+
+  return (
+    typeof obj.userId === "string" &&
+    typeof obj.model === "string" &&
+    typeof obj.updatedAt === "number" &&
+    branchValid
+  );
+}
+
+export function resolveUserPreferences(
+  prefs: UserPreferences | null | undefined,
+  defaultModel: string | undefined
+): ResolvedUserPreferences {
+  const model = getValidModelOrDefault(prefs?.model ?? defaultModel ?? DEFAULT_MODEL);
+  const reasoningEffort =
+    prefs?.reasoningEffort && isValidReasoningEffort(model, prefs.reasoningEffort)
+      ? prefs.reasoningEffort
+      : getDefaultReasoningEffort(model);
+
+  return {
+    model,
+    reasoningEffort,
+    branch: getValidatedBranch(prefs?.branch),
+  };
+}
+
+export async function getUserPreferences(
+  env: Env,
+  userId: string
+): Promise<UserPreferences | null> {
+  try {
+    const key = getUserPreferencesKey(userId);
+    const data = await createKvCacheStore(env.SLACK_KV).get(key, "json");
+    return isValidUserPreferences(data) ? data : null;
+  } catch (e) {
+    log.error("kv.get", {
+      key_prefix: "user_prefs",
+      user_id: userId,
+      error: e instanceof Error ? e : new Error(String(e)),
+    });
+    return null;
+  }
+}
+
+export async function getResolvedUserPreferences(
+  env: Env,
+  userId: string
+): Promise<ResolvedUserPreferences> {
+  const prefs = await getUserPreferences(env, userId);
+  return resolveUserPreferences(prefs, env.DEFAULT_MODEL);
+}
+
+export async function saveUserPreferences(
+  env: Env,
+  userId: string,
+  preferences: ResolvedUserPreferences
+): Promise<boolean> {
+  try {
+    const normalizedBranch = normalizeBranchPreference(preferences.branch);
+    if (normalizedBranch && !isValidBranchName(normalizedBranch)) {
+      log.warn("slack.branch_pref.invalid", {
+        user_id: userId,
+        branch: normalizedBranch,
+      });
+      return false;
+    }
+
+    const prefs: UserPreferences = {
+      userId,
+      model: preferences.model,
+      reasoningEffort: preferences.reasoningEffort,
+      branch: normalizedBranch,
+      updatedAt: Date.now(),
+    };
+
+    await createKvCacheStore(env.SLACK_KV).put(
+      getUserPreferencesKey(userId),
+      JSON.stringify(prefs)
+    );
+    return true;
+  } catch (e) {
+    log.error("kv.put", {
+      key_prefix: "user_prefs",
+      user_id: userId,
+      error: e instanceof Error ? e : new Error(String(e)),
+    });
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- move Slack App Home publishing, interaction handling, view construction, modals, metadata, model lookup, and local Slack view types into focused `app-home/` modules
- extract user preference persistence/resolution into `user-preferences.ts`
- keep the `/interactions` route delegating App Home-specific payloads while leaving generic Slack interaction handling in `index.ts`
- move App Home view unit coverage into `app-home.test.ts`

## Validation
- `npm run typecheck -w @open-inspect/slack-bot`
- `npm run lint -w @open-inspect/slack-bot`
- `npx prettier --check packages/slack-bot/src/app-home packages/slack-bot/src/app-home.test.ts packages/slack-bot/src/user-preferences.ts`
- `git diff --check`
- `npm test -w @open-inspect/slack-bot`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App Home settings: model selection, reasoning-effort choice, global and per-repo branch overrides with modals.
  * Repo search suggestions and truncated option labels to fit Slack limits; long override lists show a “more” summary.

* **Refactor**
  * Centralized App Home interaction routing and unified preference resolution.
  * App Home publishing made asynchronous and robust.

* **Tests**
  * Expanded coverage for App Home view, suggestions, truncation, and preference updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->