### PR TITLE
Add child session result introspection

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -177,7 +177,7 @@ export class SessionDO extends DurableObject<Env> {
     openaiTokenRefresh: () => this.sandboxHandler.openaiTokenRefresh(),
     scmCredentials: () => this.sandboxHandler.scmCredentials(),
     spawnContext: () => this.childSessionsHandler.getSpawnContext(),
-    childSummary: () => this.childSessionsHandler.getChildSummary(),
+    childSummary: (_request, url) => this.childSessionsHandler.getChildSummary(url),
     cancel: () => this.sessionLifecycleHandler.cancel(),
     childSessionUpdate: (request) => this.childSessionsHandler.childSessionUpdate(request),
   });
@@ -361,6 +361,7 @@ export class SessionDO extends DurableObject<Env> {
         getSession: () => this.getSession(),
         getSandbox: () => this.getSandbox(),
         getPublicSessionId: (session) => this.getPublicSessionId(session),
+        parseArtifactMetadata: (artifact) => this.parseArtifactMetadata(artifact),
         broadcast: (message) => this.broadcast(message),
       });
     }
@@ -1370,7 +1371,11 @@ export class SessionDO extends DurableObject<Env> {
 
     const rawLimit = typeof data.limit === "number" ? data.limit : 200;
     const limit = Math.max(1, Math.min(rawLimit, 500));
-    const page = this.repository.getEventsHistoryPage(data.cursor.timestamp, data.cursor.id, limit);
+    const page = this.repository.getEventTimelinePage({
+      cursor: { kind: "timeline", createdAt: data.cursor.timestamp, id: data.cursor.id },
+      excludeTypes: ["heartbeat"],
+      limit,
+    });
 
     const items: SandboxEvent[] = [];
     for (const event of page.events) {
@@ -1381,14 +1386,13 @@ export class SessionDO extends DurableObject<Env> {
       }
     }
 
-    // Compute new cursor from oldest item in the page
-    const oldestEvent = page.events.length > 0 ? page.events[0] : null;
-
     this.safeSend(ws, {
       type: "history_page",
       items,
       hasMore: page.hasMore,
-      cursor: oldestEvent ? { timestamp: oldestEvent.created_at, id: oldestEvent.id } : null,
+      cursor: page.nextCursor
+        ? { timestamp: page.nextCursor.createdAt, id: page.nextCursor.id }
+        : null,
     } as ServerMessage);
   }
 

--- a/packages/control-plane/src/session/event-cursor.test.ts
+++ b/packages/control-plane/src/session/event-cursor.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  encodeEventTimelineCursor,
+  parseEventListCursor,
+  parseEventTimelineCursor,
+} from "./event-cursor";
+
+describe("event cursor helpers", () => {
+  it("encodes and parses composite timeline cursors", () => {
+    const encoded = encodeEventTimelineCursor({
+      kind: "timeline",
+      createdAt: 5000,
+      id: "token:msg-1",
+    });
+
+    expect(encoded).toBe("5000:token%3Amsg-1");
+    expect(parseEventTimelineCursor(encoded)).toEqual({
+      ok: true,
+      cursor: { kind: "timeline", createdAt: 5000, id: "token:msg-1" },
+    });
+  });
+
+  it("allows legacy timestamp cursors only on event lists", () => {
+    expect(parseEventListCursor("5000")).toEqual({
+      ok: true,
+      cursor: { kind: "legacy", createdAt: 5000 },
+    });
+    expect(parseEventTimelineCursor("5000")).toEqual({
+      ok: false,
+      error: "Invalid cursor",
+    });
+  });
+
+  it("rejects malformed cursors", () => {
+    expect(parseEventListCursor("bad")).toEqual({ ok: false, error: "Invalid cursor" });
+    expect(parseEventTimelineCursor("5000:")).toEqual({
+      ok: false,
+      error: "Invalid cursor",
+    });
+  });
+});

--- a/packages/control-plane/src/session/event-cursor.ts
+++ b/packages/control-plane/src/session/event-cursor.ts
@@ -1,0 +1,70 @@
+import type { EventRow } from "./types";
+
+export interface EventTimelineCursor {
+  kind: "timeline";
+  createdAt: number;
+  id: string;
+}
+
+export interface LegacyEventCursor {
+  kind: "legacy";
+  createdAt: number;
+}
+
+export type EventListCursor = EventTimelineCursor | LegacyEventCursor;
+
+export type ParseEventCursorResult<TCursor> =
+  | { ok: true; cursor: TCursor | null }
+  | { ok: false; error: string };
+
+export function eventTimelineCursorFromRow(
+  event: Pick<EventRow, "created_at" | "id">
+): EventTimelineCursor {
+  return { kind: "timeline", createdAt: event.created_at, id: event.id };
+}
+
+export function encodeEventTimelineCursor(cursor: EventTimelineCursor): string {
+  return `${cursor.createdAt}:${encodeURIComponent(cursor.id)}`;
+}
+
+export function parseEventTimelineCursor(
+  raw: string | null | undefined,
+  fieldName = "cursor"
+): ParseEventCursorResult<EventTimelineCursor> {
+  if (!raw) return { ok: true, cursor: null };
+
+  const cursor = decodeCompositeEventCursor(raw);
+  return cursor ? { ok: true, cursor } : { ok: false, error: `Invalid ${fieldName}` };
+}
+
+export function parseEventListCursor(
+  raw: string | null | undefined,
+  fieldName = "cursor"
+): ParseEventCursorResult<EventListCursor> {
+  if (!raw) return { ok: true, cursor: null };
+
+  const compositeCursor = decodeCompositeEventCursor(raw);
+  if (compositeCursor) return { ok: true, cursor: compositeCursor };
+
+  const legacyCreatedAt = Number(raw);
+  if (Number.isSafeInteger(legacyCreatedAt) && legacyCreatedAt >= 0) {
+    return { ok: true, cursor: { kind: "legacy", createdAt: legacyCreatedAt } };
+  }
+
+  return { ok: false, error: `Invalid ${fieldName}` };
+}
+
+function decodeCompositeEventCursor(raw: string): EventTimelineCursor | null {
+  const separator = raw.indexOf(":");
+  if (separator <= 0) return null;
+
+  const createdAt = Number(raw.slice(0, separator));
+  if (!Number.isSafeInteger(createdAt) || createdAt < 0) return null;
+
+  try {
+    const id = decodeURIComponent(raw.slice(separator + 1));
+    return id ? { kind: "timeline", createdAt, id } : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/control-plane/src/session/http/handlers/child-session-summary.ts
+++ b/packages/control-plane/src/session/http/handlers/child-session-summary.ts
@@ -87,7 +87,7 @@ export function parseChildSummaryOptions(url?: URL): ChildSummaryOptionsResult {
   }
 
   const includeTrajectory = includeValuesResult.values.has("trajectory");
-  const includeFinalResponse = includeValuesResult.values.has("result") || includeTrajectory;
+  const includeFinalResponse = includeValuesResult.values.has("result");
   const trajectoryLimitResult = includeTrajectory
     ? parseLimit(
         url?.searchParams.get("trajectoryLimit"),
@@ -182,6 +182,7 @@ export function buildChildSessionDetail(input: BuildChildSessionDetailInput): Ch
 
   if (input.finalResponse) {
     const artifactInfos = artifacts
+      .filter(({ row }) => artifactCreatedDuringMessage(row, input.finalResponse?.message ?? null))
       .map(({ row, metadata }) => buildArtifactInfo(row, metadata))
       .filter((artifact): artifact is ArtifactInfo => artifact !== null);
     detail.finalResponse = buildFinalResponse(
@@ -279,6 +280,14 @@ function buildArtifactInfo(
     label: getArtifactLabelFromArtifact(artifact.type, metadata),
     metadata,
   };
+}
+
+function artifactCreatedDuringMessage(artifact: ArtifactRow, message: MessageRow | null): boolean {
+  if (!message) return false;
+
+  const start = message.created_at;
+  const end = message.completed_at ?? Number.MAX_SAFE_INTEGER;
+  return artifact.created_at >= start && artifact.created_at <= end;
 }
 
 function buildFinalResponse(

--- a/packages/control-plane/src/session/http/handlers/child-session-summary.ts
+++ b/packages/control-plane/src/session/http/handlers/child-session-summary.ts
@@ -1,0 +1,314 @@
+import {
+  buildAgentResponseFromEvents,
+  getArtifactLabelFromArtifact,
+  type ArtifactInfo,
+  type ChildSessionDetail,
+  type ChildSessionFinalResponse,
+  type ChildSessionTrajectory,
+  type EventResponse,
+} from "@open-inspect/shared";
+import {
+  encodeEventTimelineCursor,
+  parseEventTimelineCursor,
+  type EventTimelineCursor,
+} from "../../event-cursor";
+import type { ArtifactRow, EventRow, MessageRow, SandboxRow, SessionRow } from "../../types";
+
+const CHILD_SESSION_DETAIL_INCLUDES = ["result", "trajectory"] as const;
+
+export const RECENT_EVENT_FETCH_LIMIT = 50;
+export const FINAL_RESPONSE_EVENT_PAGE_LIMIT = 200;
+export const FINAL_RESPONSE_MAX_EVENTS = 1000;
+
+const RECENT_EVENT_DISPLAY_LIMIT = 5;
+const DEFAULT_TRAJECTORY_EVENT_LIMIT = 200;
+const MAX_TRAJECTORY_EVENT_LIMIT = 1000;
+const NOISY_RECENT_EVENT_TYPES = new Set(["token", "heartbeat", "step_start", "step_finish"]);
+const CHILD_SUMMARY_INCLUDE_VALUES = new Set<string>(CHILD_SESSION_DETAIL_INCLUDES);
+
+export interface ChildSummaryOptions {
+  includeFinalResponse: boolean;
+  includeTrajectory: boolean;
+  trajectoryLimit: number;
+  trajectoryCursor: EventTimelineCursor | null;
+}
+
+export type ChildSummaryOptionsResult =
+  | { ok: true; options: ChildSummaryOptions }
+  | { ok: false; error: string };
+
+export interface ChildSummaryFinalResponseInput {
+  message: MessageRow | null;
+  eventRows: EventRow[];
+  eventLimitReached: boolean;
+}
+
+export interface ChildSummaryTrajectoryInput {
+  eventRows: EventRow[];
+  hasMore: boolean;
+  nextCursor: EventTimelineCursor | null;
+  limit: number;
+}
+
+export interface BuildChildSessionDetailInput {
+  session: SessionRow;
+  sandbox: SandboxRow | null;
+  publicSessionId: string;
+  artifacts: ArtifactRow[];
+  recentEventRows: EventRow[];
+  parseArtifactMetadata: (
+    artifact: Pick<ArtifactRow, "id" | "metadata">
+  ) => Record<string, unknown> | null;
+  finalResponse?: ChildSummaryFinalResponseInput;
+  trajectory?: ChildSummaryTrajectoryInput;
+}
+
+export interface FinalResponseEventPageSource {
+  listEventPage(options: {
+    cursor?: EventTimelineCursor | null;
+    limit: number;
+    messageId: string;
+  }): {
+    events: EventRow[];
+    hasMore: boolean;
+    nextCursor: EventTimelineCursor | null;
+  };
+}
+
+export interface CollectedFinalResponseEvents {
+  eventRows: EventRow[];
+  eventLimitReached: boolean;
+}
+
+export function parseChildSummaryOptions(url?: URL): ChildSummaryOptionsResult {
+  const includeValuesResult = parseIncludeValues(url?.searchParams.getAll("include") ?? []);
+  if (!includeValuesResult.ok) {
+    return { ok: false, error: includeValuesResult.error };
+  }
+
+  const includeTrajectory = includeValuesResult.values.has("trajectory");
+  const includeFinalResponse = includeValuesResult.values.has("result") || includeTrajectory;
+  const trajectoryLimitResult = includeTrajectory
+    ? parseLimit(
+        url?.searchParams.get("trajectoryLimit"),
+        DEFAULT_TRAJECTORY_EVENT_LIMIT,
+        MAX_TRAJECTORY_EVENT_LIMIT,
+        "trajectoryLimit"
+      )
+    : { ok: true as const, value: DEFAULT_TRAJECTORY_EVENT_LIMIT };
+  if (!trajectoryLimitResult.ok) {
+    return { ok: false, error: trajectoryLimitResult.error };
+  }
+  const cursorResult = includeTrajectory
+    ? parseTrajectoryCursor(url?.searchParams.get("trajectoryCursor"))
+    : { ok: true as const, cursor: null };
+  if (!cursorResult.ok) {
+    return { ok: false, error: cursorResult.error };
+  }
+
+  return {
+    ok: true,
+    options: {
+      includeFinalResponse,
+      includeTrajectory,
+      trajectoryLimit: trajectoryLimitResult.value,
+      trajectoryCursor: cursorResult.cursor,
+    },
+  };
+}
+
+export function collectFinalResponseEventRows(
+  source: FinalResponseEventPageSource,
+  messageId: string
+): CollectedFinalResponseEvents {
+  const eventRows: EventRow[] = [];
+  let cursor: EventTimelineCursor | null = null;
+
+  while (eventRows.length < FINAL_RESPONSE_MAX_EVENTS) {
+    const remaining = FINAL_RESPONSE_MAX_EVENTS - eventRows.length;
+    const page = source.listEventPage({
+      limit: Math.min(FINAL_RESPONSE_EVENT_PAGE_LIMIT, remaining),
+      messageId,
+      ...(cursor ? { cursor } : {}),
+    });
+
+    eventRows.push(...page.events);
+    if (!page.hasMore) {
+      return { eventRows, eventLimitReached: false };
+    }
+
+    if (!page.nextCursor) {
+      return { eventRows, eventLimitReached: false };
+    }
+    cursor = page.nextCursor;
+  }
+
+  return { eventRows, eventLimitReached: true };
+}
+
+export function buildChildSessionDetail(input: BuildChildSessionDetailInput): ChildSessionDetail {
+  const artifacts = input.artifacts.map((artifact) => ({
+    row: artifact,
+    metadata: input.parseArtifactMetadata(artifact),
+  }));
+  const recentEvents = input.recentEventRows
+    .filter((event) => !NOISY_RECENT_EVENT_TYPES.has(event.type))
+    .slice(0, RECENT_EVENT_DISPLAY_LIMIT);
+
+  const detail: ChildSessionDetail = {
+    session: {
+      id: input.publicSessionId,
+      title: input.session.title ?? "",
+      status: input.session.status,
+      repoOwner: input.session.repo_owner,
+      repoName: input.session.repo_name,
+      branchName: input.session.branch_name,
+      model: input.session.model,
+      createdAt: input.session.created_at,
+      updatedAt: input.session.updated_at,
+    },
+    sandbox: input.sandbox ? { status: input.sandbox.status } : null,
+    artifacts: artifacts.map(({ row, metadata }) => ({
+      type: row.type,
+      url: row.url ?? "",
+      metadata,
+    })),
+    recentEvents: recentEvents.map((event) => ({
+      type: event.type,
+      data: parseJsonRecord(event.data),
+      createdAt: event.created_at,
+    })),
+  };
+
+  if (input.finalResponse) {
+    const artifactInfos = artifacts
+      .map(({ row, metadata }) => buildArtifactInfo(row, metadata))
+      .filter((artifact): artifact is ArtifactInfo => artifact !== null);
+    detail.finalResponse = buildFinalResponse(
+      input.finalResponse.message,
+      input.finalResponse.eventRows,
+      artifactInfos,
+      input.finalResponse.eventLimitReached
+    );
+  }
+
+  if (input.trajectory) {
+    detail.trajectory = buildTrajectory(input.trajectory);
+  }
+
+  return detail;
+}
+
+function parseIncludeValues(
+  rawValues: string[]
+): { ok: true; values: Set<string> } | { ok: false; error: string } {
+  const values = new Set<string>();
+
+  for (const rawValue of rawValues) {
+    for (const value of rawValue.split(",")) {
+      const trimmed = value.trim();
+      if (!trimmed) continue;
+      if (!CHILD_SUMMARY_INCLUDE_VALUES.has(trimmed)) {
+        return { ok: false, error: `Invalid include: ${trimmed}` };
+      }
+      values.add(trimmed);
+    }
+  }
+
+  return { ok: true, values };
+}
+
+function parseLimit(
+  raw: string | null | undefined,
+  fallback: number,
+  max: number,
+  fieldName: string
+): { ok: true; value: number } | { ok: false; error: string } {
+  if (raw == null || raw === "") {
+    return { ok: true, value: fallback };
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    return { ok: false, error: `Invalid ${fieldName}` };
+  }
+
+  return { ok: true, value: Math.min(parsed, max) };
+}
+
+function parseTrajectoryCursor(
+  raw: string | null | undefined
+): { ok: true; cursor: EventTimelineCursor | null } | { ok: false; error: string } {
+  if (!raw) return { ok: true, cursor: null };
+
+  return parseEventTimelineCursor(raw, "trajectoryCursor");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseJsonRecord(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return isRecord(parsed) ? parsed : { value: parsed };
+  } catch {
+    return { value: raw };
+  }
+}
+
+function toEventResponse(event: EventRow): EventResponse {
+  return {
+    id: event.id,
+    type: event.type,
+    data: parseJsonRecord(event.data),
+    messageId: event.message_id,
+    createdAt: event.created_at,
+  };
+}
+
+function buildArtifactInfo(
+  artifact: ArtifactRow,
+  metadata: Record<string, unknown> | null
+): ArtifactInfo | null {
+  if (artifact.type === "screenshot" || artifact.type === "video") return null;
+
+  return {
+    type: artifact.type,
+    url: artifact.url ?? "",
+    label: getArtifactLabelFromArtifact(artifact.type, metadata),
+    metadata,
+  };
+}
+
+function buildFinalResponse(
+  message: MessageRow | null,
+  eventRows: EventRow[],
+  artifacts: ArtifactInfo[],
+  eventLimitReached: boolean
+): ChildSessionFinalResponse | null {
+  if (!message) return null;
+
+  const events = eventRows.map(toEventResponse);
+  return {
+    ...buildAgentResponseFromEvents(events, artifacts, {
+      defaultSuccess: message.status === "completed",
+    }),
+    messageId: message.id,
+    completedAt: message.completed_at,
+    eventCount: events.length,
+    eventLimitReached,
+  };
+}
+
+function buildTrajectory(input: ChildSummaryTrajectoryInput): ChildSessionTrajectory {
+  const events = input.eventRows.map(toEventResponse);
+
+  return {
+    events,
+    hasMore: input.hasMore,
+    cursor:
+      input.hasMore && input.nextCursor ? encodeEventTimelineCursor(input.nextCursor) : undefined,
+    limit: input.limit,
+  };
+}

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
 import { createChildSessionsHandler } from "./child-sessions.handler";
-import type { ArtifactRow, EventRow, ParticipantRow, SandboxRow, SessionRow } from "../../types";
+import {
+  FINAL_RESPONSE_EVENT_PAGE_LIMIT,
+  FINAL_RESPONSE_MAX_EVENTS,
+  collectFinalResponseEventRows,
+} from "./child-session-summary";
+import type {
+  ArtifactRow,
+  EventRow,
+  MessageRow,
+  ParticipantRow,
+  SandboxRow,
+  SessionRow,
+} from "../../types";
 
 function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
   return {
@@ -96,15 +108,39 @@ function createEvent(overrides: Partial<EventRow> = {}): EventRow {
   };
 }
 
+function createMessage(overrides: Partial<MessageRow> = {}): MessageRow {
+  return {
+    id: "message-1",
+    author_id: "user-1",
+    content: "Do the thing",
+    source: "web",
+    model: null,
+    reasoning_effort: null,
+    attachments: null,
+    callback_context: null,
+    status: "completed",
+    error_message: null,
+    created_at: 1,
+    started_at: 2,
+    completed_at: 3,
+    ...overrides,
+  };
+}
+
 function createHandler() {
   const repository = {
     listParticipants: vi.fn(),
     listArtifacts: vi.fn(),
-    listEvents: vi.fn(),
+    listEventPage: vi.fn(),
+    getLatestTerminalMessage: vi.fn(),
+    getEventTimelinePage: vi.fn(),
   };
   const getSession = vi.fn<() => SessionRow | null>();
   const getSandbox = vi.fn<() => SandboxRow | null>();
   const getPublicSessionId = vi.fn<(session: SessionRow) => string>();
+  const parseArtifactMetadata = vi.fn((artifact: Pick<ArtifactRow, "metadata">) =>
+    artifact.metadata ? (JSON.parse(artifact.metadata) as Record<string, unknown>) : null
+  );
   const broadcast = vi.fn();
 
   const handler = createChildSessionsHandler({
@@ -112,6 +148,7 @@ function createHandler() {
     getSession,
     getSandbox,
     getPublicSessionId,
+    parseArtifactMetadata,
     broadcast,
   });
 
@@ -121,6 +158,7 @@ function createHandler() {
     getSession,
     getSandbox,
     getPublicSessionId,
+    parseArtifactMetadata,
     broadcast,
   };
 }
@@ -207,22 +245,26 @@ describe("createChildSessionsHandler", () => {
       createArtifact({ type: "pr", metadata: '{"number":42}' }),
       createArtifact({ type: "preview", metadata: null }),
     ]);
-    repository.listEvents.mockReturnValue([
-      createEvent({ id: "e1", type: "token", data: '{"token":"x"}', created_at: 9 }),
-      createEvent({ id: "e2", type: "error", data: '{"message":"boom"}', created_at: 8 }),
-      createEvent({ id: "e3", type: "heartbeat", data: '{"ok":true}', created_at: 7 }),
-      createEvent({ id: "e4", type: "git_sync", data: '{"state":"done"}', created_at: 6 }),
-      createEvent({ id: "e5", type: "push_error", data: '{"code":"denied"}', created_at: 5 }),
-      createEvent({ id: "e6", type: "step_start", data: '{"step":1}', created_at: 4 }),
-      createEvent({ id: "e7", type: "user_message", data: '{"text":"hi"}', created_at: 3 }),
-      createEvent({ id: "e8", type: "tool_call", data: '{"name":"ls"}', created_at: 2 }),
-      createEvent({
-        id: "e9",
-        type: "execution_complete",
-        data: '{"status":"success"}',
-        created_at: 1,
-      }),
-    ]);
+    repository.listEventPage.mockReturnValue({
+      hasMore: false,
+      nextCursor: null,
+      events: [
+        createEvent({ id: "e1", type: "token", data: '{"token":"x"}', created_at: 9 }),
+        createEvent({ id: "e2", type: "error", data: '{"message":"boom"}', created_at: 8 }),
+        createEvent({ id: "e3", type: "heartbeat", data: '{"ok":true}', created_at: 7 }),
+        createEvent({ id: "e4", type: "git_sync", data: '{"state":"done"}', created_at: 6 }),
+        createEvent({ id: "e5", type: "push_error", data: '{"code":"denied"}', created_at: 5 }),
+        createEvent({ id: "e6", type: "step_start", data: '{"step":1}', created_at: 4 }),
+        createEvent({ id: "e7", type: "user_message", data: '{"text":"hi"}', created_at: 3 }),
+        createEvent({ id: "e8", type: "tool_call", data: '{"name":"ls"}', created_at: 2 }),
+        createEvent({
+          id: "e9",
+          type: "execution_complete",
+          data: '{"status":"success"}',
+          created_at: 1,
+        }),
+      ],
+    });
 
     const response = handler.getChildSummary();
 
@@ -260,7 +302,307 @@ describe("createChildSessionsHandler", () => {
         { type: "tool_call", data: { name: "ls" }, createdAt: 2 },
       ],
     });
-    expect(repository.listEvents).toHaveBeenCalledWith({ limit: 50 });
+    expect(repository.listEventPage).toHaveBeenCalledWith({ limit: 50 });
+    expect(repository.getLatestTerminalMessage).not.toHaveBeenCalled();
+  });
+
+  it("includes final response when requested", async () => {
+    const { handler, getSession, getSandbox, getPublicSessionId, repository } = createHandler();
+    getSession.mockReturnValue(createSession({ status: "completed" }));
+    getSandbox.mockReturnValue(createSandbox({ status: "stopped" }));
+    getPublicSessionId.mockReturnValue("public-session-1");
+    repository.listArtifacts.mockReturnValue([
+      createArtifact({
+        type: "branch",
+        url: "https://example.com/tree/fix",
+        metadata: '{"head":"fix"}',
+      }),
+    ]);
+    repository.getLatestTerminalMessage.mockReturnValue(createMessage({ id: "msg-final" }));
+    repository.listEventPage
+      .mockReturnValueOnce({ events: [], hasMore: false, nextCursor: null })
+      .mockReturnValueOnce({
+        hasMore: false,
+        nextCursor: null,
+        events: [
+          createEvent({
+            id: "token:msg-final",
+            type: "token",
+            message_id: "msg-final",
+            data: '{"content":"Final answer from child"}',
+            created_at: 10,
+          }),
+          createEvent({
+            id: "exec:msg-final",
+            type: "execution_complete",
+            message_id: "msg-final",
+            data: '{"success":true}',
+            created_at: 11,
+          }),
+          createEvent({
+            id: "tool:msg-final",
+            type: "tool_call",
+            message_id: "msg-final",
+            data: '{"tool":"Bash","args":{"command":"npm test"}}',
+            created_at: 9,
+          }),
+        ],
+      });
+
+    const response = handler.getChildSummary(
+      new URL("http://internal/internal/child-summary?include=result")
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      finalResponse: {
+        messageId: "msg-final",
+        completedAt: 3,
+        eventCount: 3,
+        eventLimitReached: false,
+        textContent: "Final answer from child",
+        success: true,
+        toolCalls: [{ tool: "Bash", summary: "Ran: npm test" }],
+        artifacts: [
+          {
+            type: "branch",
+            url: "https://example.com/tree/fix",
+            label: "Branch: fix",
+            metadata: { head: "fix" },
+          },
+        ],
+      },
+    });
+    expect(repository.listEventPage).toHaveBeenNthCalledWith(1, { limit: 50 });
+    expect(repository.listEventPage).toHaveBeenNthCalledWith(2, {
+      limit: 200,
+      messageId: "msg-final",
+    });
+  });
+
+  it("paginates final response events when requested", async () => {
+    const { handler, getSession, getSandbox, getPublicSessionId, repository } = createHandler();
+    getSession.mockReturnValue(createSession({ status: "completed" }));
+    getSandbox.mockReturnValue(createSandbox({ status: "stopped" }));
+    getPublicSessionId.mockReturnValue("public-session-1");
+    repository.listArtifacts.mockReturnValue([]);
+    repository.getLatestTerminalMessage.mockReturnValue(createMessage({ id: "msg-final" }));
+    repository.listEventPage
+      .mockReturnValueOnce({ events: [], hasMore: false, nextCursor: null })
+      .mockReturnValueOnce({
+        hasMore: true,
+        nextCursor: { kind: "timeline", createdAt: 20, id: "token:new" },
+        events: [
+          createEvent({
+            id: "token:new",
+            type: "token",
+            message_id: "msg-final",
+            data: '{"content":"done"}',
+            created_at: 20,
+          }),
+        ],
+      })
+      .mockReturnValueOnce({
+        hasMore: false,
+        nextCursor: null,
+        events: [
+          createEvent({
+            id: "tool:old",
+            type: "tool_call",
+            message_id: "msg-final",
+            data: '{"tool":"Bash","args":{"command":"npm test"}}',
+            created_at: 10,
+          }),
+        ],
+      });
+
+    const response = handler.getChildSummary(
+      new URL("http://internal/internal/child-summary?include=result")
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      finalResponse: {
+        textContent: "done",
+        eventCount: 2,
+        eventLimitReached: false,
+        toolCalls: [{ tool: "Bash", summary: "Ran: npm test" }],
+      },
+    });
+    expect(repository.listEventPage).toHaveBeenNthCalledWith(2, {
+      limit: FINAL_RESPONSE_EVENT_PAGE_LIMIT,
+      messageId: "msg-final",
+    });
+    expect(repository.listEventPage).toHaveBeenNthCalledWith(3, {
+      limit: FINAL_RESPONSE_EVENT_PAGE_LIMIT,
+      messageId: "msg-final",
+      cursor: { kind: "timeline", createdAt: 20, id: "token:new" },
+    });
+  });
+
+  it("marks final response event collection as limited at the explicit cap", () => {
+    const pageRows = Array.from({ length: FINAL_RESPONSE_EVENT_PAGE_LIMIT }, (_, index) =>
+      createEvent({
+        id: `event-${index}`,
+        message_id: "msg-final",
+        created_at: FINAL_RESPONSE_MAX_EVENTS - index,
+      })
+    );
+    const source = {
+      listEventPage: vi.fn().mockReturnValue({
+        events: pageRows,
+        hasMore: true,
+        nextCursor: { kind: "timeline", createdAt: 801, id: "event-199" },
+      }),
+    };
+
+    const result = collectFinalResponseEventRows(source, "msg-final");
+
+    expect(result.eventRows).toHaveLength(FINAL_RESPONSE_MAX_EVENTS);
+    expect(result.eventLimitReached).toBe(true);
+    expect(source.listEventPage).toHaveBeenCalledTimes(
+      FINAL_RESPONSE_MAX_EVENTS / FINAL_RESPONSE_EVENT_PAGE_LIMIT
+    );
+  });
+
+  it("includes chronological trajectory when requested", async () => {
+    const { handler, getSession, getSandbox, getPublicSessionId, repository } = createHandler();
+    getSession.mockReturnValue(createSession());
+    getSandbox.mockReturnValue(createSandbox());
+    getPublicSessionId.mockReturnValue("public-session-1");
+    repository.listArtifacts.mockReturnValue([]);
+    repository.getLatestTerminalMessage.mockReturnValue(null);
+    repository.listEventPage.mockReturnValueOnce({ events: [], hasMore: false, nextCursor: null });
+    repository.getEventTimelinePage.mockReturnValue({
+      events: [
+        createEvent({ id: "e1", type: "tool_call", data: '{"tool":"Read"}', created_at: 10 }),
+        createEvent({ id: "e2", type: "tool_result", data: '{"result":"ok"}', created_at: 20 }),
+      ],
+      hasMore: false,
+      nextCursor: null,
+    });
+
+    const response = handler.getChildSummary(
+      new URL("http://internal/internal/child-summary?include=trajectory")
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      finalResponse: null,
+      trajectory: {
+        hasMore: false,
+        limit: 200,
+        events: [
+          { id: "e1", type: "tool_call", data: { tool: "Read" }, createdAt: 10 },
+          { id: "e2", type: "tool_result", data: { result: "ok" }, createdAt: 20 },
+        ],
+      },
+    });
+    expect(repository.listEventPage).toHaveBeenNthCalledWith(1, { limit: 50 });
+    expect(repository.getEventTimelinePage).toHaveBeenCalledWith({
+      limit: 200,
+      cursor: undefined,
+    });
+  });
+
+  it("returns 400 for malformed trajectory cursors", async () => {
+    const { handler, getSession, getSandbox, getPublicSessionId, repository } = createHandler();
+    getSession.mockReturnValue(createSession());
+    getSandbox.mockReturnValue(createSandbox());
+    getPublicSessionId.mockReturnValue("public-session-1");
+
+    const response = handler.getChildSummary(
+      new URL("http://internal/internal/child-summary?include=trajectory&trajectoryCursor=bad")
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid trajectoryCursor" });
+    expect(repository.listArtifacts).not.toHaveBeenCalled();
+    expect(repository.getEventTimelinePage).not.toHaveBeenCalled();
+  });
+
+  it.each(["0", "-1", "abc", "1.5"])(
+    "returns 400 for invalid trajectory limits (%s)",
+    async (trajectoryLimit) => {
+      const { handler, getSession, getSandbox, getPublicSessionId, repository } = createHandler();
+      getSession.mockReturnValue(createSession());
+      getSandbox.mockReturnValue(createSandbox());
+      getPublicSessionId.mockReturnValue("public-session-1");
+
+      const response = handler.getChildSummary(
+        new URL(
+          `http://internal/internal/child-summary?include=trajectory&trajectoryLimit=${trajectoryLimit}`
+        )
+      );
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error: "Invalid trajectoryLimit" });
+      expect(repository.listArtifacts).not.toHaveBeenCalled();
+      expect(repository.getEventTimelinePage).not.toHaveBeenCalled();
+    }
+  );
+
+  it("returns 400 for invalid child summary includes", async () => {
+    const { handler, getSession, repository } = createHandler();
+    getSession.mockReturnValue(createSession());
+
+    const response = handler.getChildSummary(
+      new URL("http://internal/internal/child-summary?include=result&include=unknown")
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid include: unknown" });
+    expect(repository.listArtifacts).not.toHaveBeenCalled();
+    expect(repository.listEventPage).not.toHaveBeenCalled();
+  });
+
+  it("paginates trajectory with an explicit limit and cursor", async () => {
+    const { handler, getSession, getSandbox, getPublicSessionId, repository } = createHandler();
+    getSession.mockReturnValue(createSession());
+    getSandbox.mockReturnValue(createSandbox());
+    getPublicSessionId.mockReturnValue("public-session-1");
+    repository.listArtifacts.mockReturnValue([]);
+    repository.getLatestTerminalMessage.mockReturnValue(null);
+    repository.listEventPage.mockReturnValueOnce({ events: [], hasMore: false, nextCursor: null });
+    repository.getEventTimelinePage.mockReturnValue({
+      events: [
+        createEvent({
+          id: "token:msg-final",
+          type: "token",
+          data: '{"content":"new"}',
+          created_at: 30,
+        }),
+      ],
+      hasMore: true,
+      nextCursor: { kind: "timeline", createdAt: 30, id: "token:msg-final" },
+    });
+
+    const response = handler.getChildSummary(
+      new URL(
+        "http://internal/internal/child-summary?include=trajectory&trajectoryLimit=1&trajectoryCursor=40:cursor-id"
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      trajectory: {
+        hasMore: true,
+        cursor: "30:token%3Amsg-final",
+        limit: 1,
+        events: [
+          {
+            id: "token:msg-final",
+            type: "token",
+            data: { content: "new" },
+            createdAt: 30,
+          },
+        ],
+      },
+    });
+    expect(repository.getEventTimelinePage).toHaveBeenCalledWith({
+      limit: 1,
+      cursor: { kind: "timeline", createdAt: 40, id: "cursor-id" },
+    });
   });
 
   it("returns 400 when child session update body is missing required fields", async () => {

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
@@ -380,6 +380,70 @@ describe("createChildSessionsHandler", () => {
     });
   });
 
+  it("scopes final response artifacts to the terminal message window", async () => {
+    const { handler, getSession, getSandbox, getPublicSessionId, repository } = createHandler();
+    getSession.mockReturnValue(createSession({ status: "completed" }));
+    getSandbox.mockReturnValue(createSandbox({ status: "stopped" }));
+    getPublicSessionId.mockReturnValue("public-session-1");
+    repository.listArtifacts.mockReturnValue([
+      createArtifact({
+        id: "artifact-old",
+        type: "branch",
+        url: "https://example.com/tree/old",
+        metadata: '{"head":"old"}',
+        created_at: 10,
+      }),
+      createArtifact({
+        id: "artifact-current",
+        type: "branch",
+        url: "https://example.com/tree/current",
+        metadata: '{"head":"current"}',
+        created_at: 30,
+      }),
+    ]);
+    repository.getLatestTerminalMessage.mockReturnValue(
+      createMessage({
+        id: "msg-current",
+        created_at: 20,
+        started_at: 25,
+        completed_at: 40,
+      })
+    );
+    repository.listEventPage
+      .mockReturnValueOnce({ events: [], hasMore: false, nextCursor: null })
+      .mockReturnValueOnce({
+        hasMore: false,
+        nextCursor: null,
+        events: [
+          createEvent({
+            id: "token:msg-current",
+            type: "token",
+            message_id: "msg-current",
+            data: '{"content":"Current answer"}',
+            created_at: 35,
+          }),
+        ],
+      });
+
+    const response = handler.getChildSummary(
+      new URL("http://internal/internal/child-summary?include=result")
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      finalResponse: {
+        artifacts: [
+          {
+            type: "branch",
+            url: "https://example.com/tree/current",
+            label: "Branch: current",
+            metadata: { head: "current" },
+          },
+        ],
+      },
+    });
+  });
+
   it("paginates final response events when requested", async () => {
     const { handler, getSession, getSandbox, getPublicSessionId, repository } = createHandler();
     getSession.mockReturnValue(createSession({ status: "completed" }));
@@ -487,8 +551,9 @@ describe("createChildSessionsHandler", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toMatchObject({
-      finalResponse: null,
+    const body = await response.json();
+    expect(body).not.toHaveProperty("finalResponse");
+    expect(body).toMatchObject({
       trajectory: {
         hasMore: false,
         limit: 200,
@@ -503,6 +568,7 @@ describe("createChildSessionsHandler", () => {
       limit: 200,
       cursor: undefined,
     });
+    expect(repository.getLatestTerminalMessage).not.toHaveBeenCalled();
   });
 
   it("returns 400 for malformed trajectory cursors", async () => {

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
@@ -1,13 +1,31 @@
 import type { SpawnContext } from "@open-inspect/shared";
 import type { SessionStatus } from "../../../types";
 import type { SessionRepository } from "../../repository";
-import type { SandboxRow, SessionRow } from "../../types";
+import type { ArtifactRow, SandboxRow, SessionRow } from "../../types";
+import {
+  RECENT_EVENT_FETCH_LIMIT,
+  buildChildSessionDetail,
+  collectFinalResponseEventRows,
+  parseChildSummaryOptions,
+  type ChildSummaryFinalResponseInput,
+  type ChildSummaryTrajectoryInput,
+} from "./child-session-summary";
 
 export interface ChildSessionsHandlerDeps {
-  repository: Pick<SessionRepository, "listParticipants" | "listArtifacts" | "listEvents">;
+  repository: Pick<
+    SessionRepository,
+    | "listParticipants"
+    | "listArtifacts"
+    | "listEventPage"
+    | "getLatestTerminalMessage"
+    | "getEventTimelinePage"
+  >;
   getSession: () => SessionRow | null;
   getSandbox: () => SandboxRow | null;
   getPublicSessionId: (session: SessionRow) => string;
+  parseArtifactMetadata: (
+    artifact: Pick<ArtifactRow, "id" | "metadata">
+  ) => Record<string, unknown> | null;
   broadcast: (message: {
     type: "child_session_update";
     childSessionId: string;
@@ -18,7 +36,7 @@ export interface ChildSessionsHandlerDeps {
 
 export interface ChildSessionsHandler {
   getSpawnContext: () => Response;
-  getChildSummary: () => Response;
+  getChildSummary: (url?: URL) => Response;
   childSessionUpdate: (request: Request) => Promise<Response>;
 }
 
@@ -58,44 +76,59 @@ export function createChildSessionsHandler(deps: ChildSessionsHandlerDeps): Chil
       return Response.json(context);
     },
 
-    getChildSummary(): Response {
+    getChildSummary(url?: URL): Response {
       const session = deps.getSession();
       if (!session) {
         return Response.json({ error: "Session not found" }, { status: 404 });
       }
 
+      const parsedOptions = parseChildSummaryOptions(url);
+      if (!parsedOptions.ok) {
+        return Response.json({ error: parsedOptions.error }, { status: 400 });
+      }
+
+      const options = parsedOptions.options;
       const sandbox = deps.getSandbox();
       const artifacts = deps.repository.listArtifacts();
-      const allEvents = deps.repository.listEvents({ limit: 50 });
+      const recentEventRows = deps.repository.listEventPage({
+        limit: RECENT_EVENT_FETCH_LIMIT,
+      }).events;
+      let finalResponse: ChildSummaryFinalResponseInput | undefined;
+      let trajectory: ChildSummaryTrajectoryInput | undefined;
 
-      // Filter out noisy event types and keep the most recent five.
-      const filteredTypes = new Set(["token", "heartbeat", "step_start", "step_finish"]);
-      const recentEvents = allEvents.filter((event) => !filteredTypes.has(event.type)).slice(0, 5);
+      if (options.includeFinalResponse) {
+        const terminalMessage = deps.repository.getLatestTerminalMessage();
+        const collectedEvents = terminalMessage
+          ? collectFinalResponseEventRows(deps.repository, terminalMessage.id)
+          : { eventRows: [], eventLimitReached: false };
+        finalResponse = { message: terminalMessage, ...collectedEvents };
+      }
 
-      return Response.json({
-        session: {
-          id: deps.getPublicSessionId(session),
-          title: session.title ?? "",
-          status: session.status,
-          repoOwner: session.repo_owner,
-          repoName: session.repo_name,
-          branchName: session.branch_name,
-          model: session.model,
-          createdAt: session.created_at,
-          updatedAt: session.updated_at,
-        },
-        sandbox: sandbox ? { status: sandbox.status } : null,
-        artifacts: artifacts.map((artifact) => ({
-          type: artifact.type,
-          url: artifact.url ?? "",
-          metadata: artifact.metadata ? JSON.parse(artifact.metadata) : null,
-        })),
-        recentEvents: recentEvents.map((event) => ({
-          type: event.type,
-          data: JSON.parse(event.data),
-          createdAt: event.created_at,
-        })),
-      });
+      if (options.includeTrajectory) {
+        const page = deps.repository.getEventTimelinePage({
+          limit: options.trajectoryLimit,
+          cursor: options.trajectoryCursor ?? undefined,
+        });
+        trajectory = {
+          eventRows: page.events,
+          hasMore: page.hasMore,
+          nextCursor: page.nextCursor,
+          limit: options.trajectoryLimit,
+        };
+      }
+
+      return Response.json(
+        buildChildSessionDetail({
+          session,
+          sandbox,
+          publicSessionId: deps.getPublicSessionId(session),
+          artifacts,
+          recentEventRows,
+          parseArtifactMetadata: deps.parseArtifactMetadata,
+          finalResponse,
+          trajectory,
+        })
+      );
     },
 
     async childSessionUpdate(request: Request): Promise<Response> {

--- a/packages/control-plane/src/session/http/handlers/messages.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/messages.handler.test.ts
@@ -87,6 +87,15 @@ describe("createMessagesHandler", () => {
     expect(await response.json()).toEqual({ error: "Invalid event type: invalid" });
   });
 
+  it("returns 400 for malformed event cursors", async () => {
+    const { handler, messageService } = createHandler();
+
+    const response = handler.listEvents(new URL("http://internal/internal/events?cursor=bad"));
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "Invalid cursor" });
+    expect(messageService.listEvents).not.toHaveBeenCalled();
+  });
+
   it("maps listEvents response", async () => {
     const { handler, messageService } = createHandler();
     vi.mocked(messageService.listEvents).mockReturnValue({
@@ -109,6 +118,33 @@ describe("createMessagesHandler", () => {
       events: [{ id: "e1", type: "token", data: { x: 1 }, messageId: "m1", createdAt: 1000 }],
       cursor: "1000",
       hasMore: false,
+    });
+    expect(messageService.listEvents).toHaveBeenCalledWith({
+      cursor: null,
+      limit: 10,
+      type: null,
+      messageId: null,
+    });
+  });
+
+  it("parses composite event cursors before delegating to the service", async () => {
+    const { handler, messageService } = createHandler();
+    vi.mocked(messageService.listEvents).mockReturnValue({
+      events: [],
+      cursor: undefined,
+      hasMore: false,
+    });
+
+    const response = handler.listEvents(
+      new URL("http://internal/internal/events?cursor=5000:event-id")
+    );
+
+    expect(response.status).toBe(200);
+    expect(messageService.listEvents).toHaveBeenCalledWith({
+      cursor: { kind: "timeline", createdAt: 5000, id: "event-id" },
+      limit: 50,
+      type: null,
+      messageId: null,
     });
   });
 

--- a/packages/control-plane/src/session/http/handlers/messages.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/messages.handler.ts
@@ -1,5 +1,6 @@
 import type { Logger } from "../../../logger";
 import type { EnqueuePromptRequest, MessageService } from "../../services/message.service";
+import { parseEventListCursor } from "../../event-cursor";
 
 /**
  * Valid event types for filtering.
@@ -58,7 +59,7 @@ export function createMessagesHandler(deps: MessagesHandlerDeps): MessagesHandle
     },
 
     listEvents(url: URL): Response {
-      const cursor = url.searchParams.get("cursor");
+      const cursorResult = parseEventListCursor(url.searchParams.get("cursor"));
       const limit = Math.min(parseInt(url.searchParams.get("limit") ?? "50"), 200);
       const type = url.searchParams.get("type");
       const messageId = url.searchParams.get("message_id");
@@ -67,7 +68,16 @@ export function createMessagesHandler(deps: MessagesHandlerDeps): MessagesHandle
         return Response.json({ error: `Invalid event type: ${type}` }, { status: 400 });
       }
 
-      const result = deps.messageService.listEvents({ cursor, limit, type, messageId });
+      if (!cursorResult.ok) {
+        return Response.json({ error: cursorResult.error }, { status: 400 });
+      }
+
+      const result = deps.messageService.listEvents({
+        cursor: cursorResult.cursor,
+        limit,
+        type,
+        messageId,
+      });
 
       return Response.json({
         events: result.events.map((event) => ({

--- a/packages/control-plane/src/session/repository.test.ts
+++ b/packages/control-plane/src/session/repository.test.ts
@@ -597,6 +597,18 @@ describe("SessionRepository", () => {
     });
   });
 
+  describe("getLatestTerminalMessage", () => {
+    it("selects the newest completed or failed message", () => {
+      repo.getLatestTerminalMessage();
+
+      expect(mock.calls[0].query).toContain("status IN ('completed', 'failed')");
+      expect(mock.calls[0].query).toContain(
+        "ORDER BY COALESCE(completed_at, started_at, created_at) DESC"
+      );
+      expect(mock.calls[0].query).toContain("LIMIT 1");
+    });
+  });
+
   // === EVENTS ===
 
   describe("createEvent", () => {
@@ -723,28 +735,120 @@ describe("SessionRepository", () => {
     });
   });
 
-  describe("listEvents", () => {
-    it("returns in descending order", () => {
-      repo.listEvents({ limit: 50 });
-      expect(mock.calls[0].query).toContain("ORDER BY created_at DESC");
+  describe("listEventPage", () => {
+    it("returns in deterministic descending order", () => {
+      repo.listEventPage({ limit: 50 });
+      expect(mock.calls[0].query).toContain("ORDER BY created_at DESC, id DESC");
     });
 
     it("filters by type", () => {
-      repo.listEvents({ limit: 50, type: "tool_call" });
+      repo.listEventPage({ limit: 50, type: "tool_call" });
       expect(mock.calls[0].query).toContain("type = ?");
       expect(mock.calls[0].params).toContain("tool_call");
     });
 
     it("filters by messageId", () => {
-      repo.listEvents({ limit: 50, messageId: "msg-1" });
+      repo.listEventPage({ limit: 50, messageId: "msg-1" });
       expect(mock.calls[0].query).toContain("message_id = ?");
       expect(mock.calls[0].params).toContain("msg-1");
     });
 
-    it("uses cursor for pagination", () => {
-      repo.listEvents({ limit: 50, cursor: "5000" });
+    it("keeps legacy timestamp cursors for pagination", () => {
+      repo.listEventPage({ limit: 50, cursor: { kind: "legacy", createdAt: 5000 } });
       expect(mock.calls[0].query).toContain("created_at < ?");
       expect(mock.calls[0].params).toContain(5000);
+    });
+
+    it("uses composite cursors for stable pagination across tied timestamps", () => {
+      repo.listEventPage({
+        limit: 50,
+        cursor: { kind: "timeline", createdAt: 5000, id: "cursor-id" },
+      });
+      expect(mock.calls[0].query).toContain("((created_at < ?) OR (created_at = ? AND id < ?))");
+      expect(mock.calls[0].params).toEqual([5000, 5000, "cursor-id", 51]);
+    });
+
+    it("returns hasMore and trims overflow", () => {
+      const query = "SELECT * FROM events ORDER BY created_at DESC, id DESC LIMIT ?";
+      mock.setData(query, [
+        { id: "e3", created_at: 5000, type: "token", data: "{}" },
+        { id: "e2", created_at: 4000, type: "tool_call", data: "{}" },
+        { id: "e1", created_at: 3000, type: "token", data: "{}" },
+      ]);
+
+      const result = repo.listEventPage({ limit: 2 });
+
+      expect(result.hasMore).toBe(true);
+      expect(result.events.map((event) => event.id)).toEqual(["e3", "e2"]);
+      expect(result.nextCursor).toEqual({ kind: "timeline", createdAt: 4000, id: "e2" });
+    });
+  });
+
+  describe("getEventTimelinePage", () => {
+    it("queries the first timeline page with deterministic descending storage order", () => {
+      repo.getEventTimelinePage({ limit: 50 });
+
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0].query).toBe(
+        "SELECT * FROM events ORDER BY created_at DESC, id DESC LIMIT ?"
+      );
+      expect(mock.calls[0].params).toEqual([51]);
+    });
+
+    it("queries timeline pages after a composite cursor", () => {
+      repo.getEventTimelinePage({
+        limit: 50,
+        cursor: { kind: "timeline", createdAt: 5000, id: "cursor-id" },
+      });
+
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0].query).toBe(
+        "SELECT * FROM events WHERE ((created_at < ?) OR (created_at = ? AND id < ?)) ORDER BY created_at DESC, id DESC LIMIT ?"
+      );
+      expect(mock.calls[0].params).toEqual([5000, 5000, "cursor-id", 51]);
+    });
+
+    it("can exclude event types while using the same timeline pager", () => {
+      repo.getEventTimelinePage({
+        limit: 50,
+        cursor: { kind: "timeline", createdAt: 5000, id: "cursor-id" },
+        excludeTypes: ["heartbeat"],
+      });
+
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0].query).toBe(
+        "SELECT * FROM events WHERE type NOT IN (?) AND ((created_at < ?) OR (created_at = ? AND id < ?)) ORDER BY created_at DESC, id DESC LIMIT ?"
+      );
+      expect(mock.calls[0].params).toEqual(["heartbeat", 5000, 5000, "cursor-id", 51]);
+    });
+
+    it("returns hasMore=false when a timeline page fits within the limit", () => {
+      const query = "SELECT * FROM events ORDER BY created_at DESC, id DESC LIMIT ?";
+      mock.setData(query, [
+        { id: "e2", created_at: 4000, type: "token", data: "{}" },
+        { id: "e1", created_at: 3000, type: "tool_call", data: "{}" },
+      ]);
+
+      const result = repo.getEventTimelinePage({ limit: 50 });
+
+      expect(result.hasMore).toBe(false);
+      expect(result.events.map((event) => event.id)).toEqual(["e1", "e2"]);
+      expect(result.nextCursor).toEqual({ kind: "timeline", createdAt: 3000, id: "e1" });
+    });
+
+    it("returns hasMore=true and trims overflow when a timeline page exceeds the limit", () => {
+      const query = "SELECT * FROM events ORDER BY created_at DESC, id DESC LIMIT ?";
+      mock.setData(query, [
+        { id: "e3", created_at: 5000, type: "token", data: "{}" },
+        { id: "e2", created_at: 4000, type: "tool_call", data: "{}" },
+        { id: "e1", created_at: 3000, type: "token", data: "{}" },
+      ]);
+
+      const result = repo.getEventTimelinePage({ limit: 2 });
+
+      expect(result.hasMore).toBe(true);
+      expect(result.events.map((event) => event.id)).toEqual(["e2", "e3"]);
+      expect(result.nextCursor).toEqual({ kind: "timeline", createdAt: 4000, id: "e2" });
     });
   });
 
@@ -758,74 +862,6 @@ describe("SessionRepository", () => {
       // Outer query re-sorts to chronological ASC for replay
       expect(mock.calls[0].query).toContain("ORDER BY created_at ASC, id ASC");
       expect(mock.calls[0].params).toEqual([500]);
-    });
-  });
-
-  describe("getEventsHistoryPage", () => {
-    it("queries events with composite cursor excluding heartbeats", () => {
-      repo.getEventsHistoryPage(5000, "cursor-id", 50);
-
-      expect(mock.calls.length).toBe(1);
-      expect(mock.calls[0].query).toContain("FROM events");
-      expect(mock.calls[0].query).toContain("type != 'heartbeat'");
-      expect(mock.calls[0].query).toContain("created_at < ?1");
-      expect(mock.calls[0].query).toContain("created_at = ?1 AND id < ?2");
-      expect(mock.calls[0].query).toContain("ORDER BY created_at DESC, id DESC");
-      expect(mock.calls[0].params).toEqual([5000, "cursor-id", 51]); // limit + 1
-    });
-
-    it("returns hasMore=false when results fit within limit", () => {
-      const query = `SELECT * FROM events
-         WHERE type != 'heartbeat' AND ((created_at < ?1) OR (created_at = ?1 AND id < ?2))
-         ORDER BY created_at DESC, id DESC LIMIT ?3`;
-
-      mock.setData(query, [
-        { id: "e1", created_at: 4000, type: "token", data: "{}" },
-        { id: "e2", created_at: 3000, type: "tool_call", data: "{}" },
-      ]);
-
-      const result = repo.getEventsHistoryPage(5000, "cursor-id", 50);
-      expect(result.hasMore).toBe(false);
-      expect(result.events.length).toBe(2);
-    });
-
-    it("returns hasMore=true and trims overflow when results exceed limit", () => {
-      const query = `SELECT * FROM events
-         WHERE type != 'heartbeat' AND ((created_at < ?1) OR (created_at = ?1 AND id < ?2))
-         ORDER BY created_at DESC, id DESC LIMIT ?3`;
-
-      // 3 rows returned, limit = 2 → hasMore = true, last row trimmed
-      mock.setData(query, [
-        { id: "e1", created_at: 4000, type: "token", data: "{}" },
-        { id: "e2", created_at: 3000, type: "tool_call", data: "{}" },
-        { id: "e3", created_at: 2000, type: "token", data: "{}" },
-      ]);
-
-      const result = repo.getEventsHistoryPage(5000, "cursor-id", 2);
-      expect(result.hasMore).toBe(true);
-      expect(result.events.length).toBe(2);
-    });
-
-    it("returns events in chronological order (reversed from DESC query)", () => {
-      const query = `SELECT * FROM events
-         WHERE type != 'heartbeat' AND ((created_at < ?1) OR (created_at = ?1 AND id < ?2))
-         ORDER BY created_at DESC, id DESC LIMIT ?3`;
-
-      mock.setData(query, [
-        { id: "e2", created_at: 4000, type: "token", data: "{}" },
-        { id: "e1", created_at: 3000, type: "tool_call", data: "{}" },
-      ]);
-
-      const result = repo.getEventsHistoryPage(5000, "cursor-id", 50);
-      // After reverse(), oldest first
-      expect(result.events[0].id).toBe("e1");
-      expect(result.events[1].id).toBe("e2");
-    });
-
-    it("returns empty results with hasMore=false when no data matches cursor", () => {
-      const result = repo.getEventsHistoryPage(5000, "cursor-id", 50);
-      expect(result.events).toEqual([]);
-      expect(result.hasMore).toBe(false);
     });
   });
 

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -174,7 +174,6 @@ export interface EventPage {
 
 interface QueryEventPageOptions extends ListEventPageOptions {
   excludeTypes?: string[];
-  chronological?: boolean;
 }
 
 /**
@@ -793,7 +792,11 @@ export class SessionRepository {
   }
 
   getEventTimelinePage(options: ListEventTimelinePageOptions): EventPage {
-    return this.queryEventPage({ ...options, chronological: true });
+    const page = this.queryEventPage(options);
+    return {
+      ...page,
+      events: [...page.events].reverse(),
+    };
   }
 
   private queryEventPage(options: QueryEventPageOptions): EventPage {
@@ -838,9 +841,7 @@ export class SessionRepository {
     const pageEvents = hasMore ? rows.slice(0, options.limit) : rows;
     const nextCursor =
       pageEvents.length > 0 ? eventTimelineCursorFromRow(pageEvents[pageEvents.length - 1]) : null;
-    const events = options.chronological ? [...pageEvents].reverse() : pageEvents;
-
-    return { events, hasMore, nextCursor };
+    return { events: pageEvents, hasMore, nextCursor };
   }
 
   getEventsForReplay(limit: number): EventRow[] {

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -24,6 +24,11 @@ import type {
   ArtifactType,
   SandboxEvent,
 } from "../types";
+import {
+  eventTimelineCursorFromRow,
+  type EventListCursor,
+  type EventTimelineCursor,
+} from "./event-cursor";
 
 type TokenEvent = Extract<SandboxEvent, { type: "token" }>;
 type ExecutionCompleteEvent = Extract<SandboxEvent, { type: "execution_complete" }>;
@@ -146,13 +151,30 @@ export interface CreateEventData {
 }
 
 /**
- * Options for listing events.
+ * Options for listing event pages.
  */
-export interface ListEventsOptions {
-  cursor?: string | null;
+export interface ListEventPageOptions {
+  cursor?: EventListCursor | null;
   limit: number;
   type?: string | null;
   messageId?: string | null;
+}
+
+export interface ListEventTimelinePageOptions {
+  cursor?: EventTimelineCursor | null;
+  excludeTypes?: string[];
+  limit: number;
+}
+
+export interface EventPage {
+  events: EventRow[];
+  hasMore: boolean;
+  nextCursor: EventTimelineCursor | null;
+}
+
+interface QueryEventPageOptions extends ListEventPageOptions {
+  excludeTypes?: string[];
+  chronological?: boolean;
 }
 
 /**
@@ -707,6 +729,17 @@ export class SessionRepository {
     return this.rows<MessageRow>(result);
   }
 
+  getLatestTerminalMessage(): MessageRow | null {
+    const result = this.sql.exec(
+      `SELECT * FROM messages
+       WHERE status IN ('completed', 'failed')
+       ORDER BY COALESCE(completed_at, started_at, created_at) DESC, created_at DESC, id DESC
+       LIMIT 1`
+    );
+    const rows = this.rows<MessageRow>(result);
+    return rows[0] ?? null;
+  }
+
   // === EVENTS ===
 
   createEvent(data: CreateEventData): void {
@@ -755,30 +788,59 @@ export class SessionRepository {
     this.upsertEventByMessageId("execution_complete", messageId, event, createdAt);
   }
 
-  listEvents(options: ListEventsOptions): EventRow[] {
-    let query = `SELECT * FROM events WHERE 1=1`;
+  listEventPage(options: ListEventPageOptions): EventPage {
+    return this.queryEventPage(options);
+  }
+
+  getEventTimelinePage(options: ListEventTimelinePageOptions): EventPage {
+    return this.queryEventPage({ ...options, chronological: true });
+  }
+
+  private queryEventPage(options: QueryEventPageOptions): EventPage {
+    let query = `SELECT * FROM events`;
+    const conditions: string[] = [];
     const params: (string | number)[] = [];
 
     if (options.type) {
-      query += ` AND type = ?`;
+      conditions.push(`type = ?`);
       params.push(options.type);
     }
 
     if (options.messageId) {
-      query += ` AND message_id = ?`;
+      conditions.push(`message_id = ?`);
       params.push(options.messageId);
     }
 
-    if (options.cursor) {
-      query += ` AND created_at < ?`;
-      params.push(parseInt(options.cursor));
+    if (options.excludeTypes?.length) {
+      conditions.push(`type NOT IN (${options.excludeTypes.map(() => "?").join(", ")})`);
+      params.push(...options.excludeTypes);
     }
 
-    query += ` ORDER BY created_at DESC LIMIT ?`;
+    const cursor = options.cursor;
+    if (cursor?.kind === "timeline") {
+      conditions.push(`((created_at < ?) OR (created_at = ? AND id < ?))`);
+      params.push(cursor.createdAt, cursor.createdAt, cursor.id);
+    } else if (cursor?.kind === "legacy") {
+      conditions.push(`created_at < ?`);
+      params.push(cursor.createdAt);
+    }
+
+    if (conditions.length > 0) {
+      query += ` WHERE ${conditions.join(" AND ")}`;
+    }
+
+    query += ` ORDER BY created_at DESC, id DESC LIMIT ?`;
     params.push(options.limit + 1);
 
     const result = this.sql.exec(query, ...params);
-    return this.rows<EventRow>(result);
+    const rows = this.rows<EventRow>(result);
+    const hasMore = rows.length > options.limit;
+    const pageEvents = hasMore ? rows.slice(0, options.limit) : rows;
+    const nextCursor =
+      pageEvents.length > 0 ? eventTimelineCursorFromRow(pageEvents[pageEvents.length - 1]) : null;
+    const events = options.chronological ? [...pageEvents].reverse() : pageEvents;
+
+    return { events, hasMore, nextCursor };
   }
 
   getEventsForReplay(limit: number): EventRow[] {
@@ -790,35 +852,6 @@ export class SessionRepository {
       limit
     );
     return this.rows<EventRow>(result);
-  }
-
-  /**
-   * Paginate the events timeline using a composite cursor.
-   * Returns events older than the cursor in chronological order, plus a hasMore flag.
-   */
-  getEventsHistoryPage(
-    cursorTimestamp: number,
-    cursorId: string,
-    limit: number
-  ): {
-    events: EventRow[];
-    hasMore: boolean;
-  } {
-    const result = this.sql.exec(
-      `SELECT * FROM events
-         WHERE type != 'heartbeat' AND ((created_at < ?1) OR (created_at = ?1 AND id < ?2))
-         ORDER BY created_at DESC, id DESC LIMIT ?3`,
-      cursorTimestamp,
-      cursorId,
-      limit + 1
-    );
-    const rows = this.rows<EventRow>(result);
-
-    const hasMore = rows.length > limit;
-    if (hasMore) rows.pop();
-    rows.reverse(); // chronological order
-
-    return { events: rows, hasMore };
   }
 
   // === ARTIFACTS ===

--- a/packages/control-plane/src/session/services/message.service.test.ts
+++ b/packages/control-plane/src/session/services/message.service.test.ts
@@ -6,7 +6,7 @@ import { MessageService } from "./message.service";
 
 function createService() {
   const repository = {
-    listEvents: vi.fn(),
+    listEventPage: vi.fn(),
     listArtifacts: vi.fn(),
     getArtifactById: vi.fn(),
     listMessages: vi.fn(),
@@ -70,14 +70,18 @@ describe("MessageService", () => {
       { id: "e2", type: "token", data: "{}", message_id: "m1", created_at: 2000 },
       { id: "e1", type: "token", data: "{}", message_id: "m1", created_at: 1000 },
     ];
-    vi.mocked(repository.listEvents).mockReturnValue(events);
+    vi.mocked(repository.listEventPage).mockReturnValue({
+      events: events.slice(0, 2),
+      hasMore: true,
+      nextCursor: { kind: "timeline", createdAt: 2000, id: "e2" },
+    });
 
     const result = service.listEvents({ cursor: null, limit: 2, type: "token", messageId: "m1" });
 
     expect(result.hasMore).toBe(true);
-    expect(result.cursor).toBe("2000");
+    expect(result.cursor).toBe("2000:e2");
     expect(result.events).toHaveLength(2);
-    expect(repository.listEvents).toHaveBeenCalledWith({
+    expect(repository.listEventPage).toHaveBeenCalledWith({
       cursor: null,
       limit: 2,
       type: "token",

--- a/packages/control-plane/src/session/services/message.service.ts
+++ b/packages/control-plane/src/session/services/message.service.ts
@@ -1,6 +1,7 @@
 import type { ArtifactRow, EventRow, MessageRow } from "../types";
 import type { ArtifactResponse } from "../../types";
 import type { SessionRepository } from "../repository";
+import { encodeEventTimelineCursor, type EventListCursor } from "../event-cursor";
 import type { SessionMessageQueue } from "../message-queue";
 
 export interface EnqueuePromptRequest {
@@ -25,7 +26,7 @@ export interface EnqueuePromptRequest {
 }
 
 export interface ListEventsRequest {
-  cursor: string | null;
+  cursor: EventListCursor | null;
   limit: number;
   type: string | null;
   messageId: string | null;
@@ -63,19 +64,16 @@ export class MessageService {
     cursor: string | undefined;
     hasMore: boolean;
   } {
-    const events = this.deps.repository.listEvents({
+    const page = this.deps.repository.listEventPage({
       cursor: request.cursor,
       limit: request.limit,
       type: request.type,
       messageId: request.messageId,
     });
-    const hasMore = events.length > request.limit;
-    if (hasMore) events.pop();
-
     return {
-      events,
-      cursor: events.length > 0 ? events[events.length - 1].created_at.toString() : undefined,
-      hasMore,
+      events: page.events,
+      cursor: page.nextCursor ? encodeEventTimelineCursor(page.nextCursor) : undefined,
+      hasMore: page.hasMore,
     };
   }
 

--- a/packages/control-plane/test/integration/child-session-ops.test.ts
+++ b/packages/control-plane/test/integration/child-session-ops.test.ts
@@ -136,6 +136,64 @@ describe("Child session operations (list, get, cancel)", () => {
       expect(toolCall).toBeDefined();
     });
 
+    it("forwards optional result and trajectory parameters to child summary", async () => {
+      const { pName, childName, childStub, sandboxToken } = await setupParentAndChild();
+      const [{ id: participantId }] = await queryDO<{ id: string }>(
+        childStub,
+        "SELECT id FROM participants LIMIT 1"
+      );
+
+      await queryDO(
+        childStub,
+        `INSERT INTO messages (id, author_id, content, source, status, created_at, started_at, completed_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        "msg-child-result",
+        participantId,
+        "Do the child task",
+        "web",
+        "completed",
+        100,
+        110,
+        200
+      );
+      await seedEvents(childStub, [
+        {
+          id: "evt-child-token",
+          type: "token",
+          data: JSON.stringify({ content: "usable child result" }),
+          messageId: "msg-child-result",
+          createdAt: 180,
+        },
+        {
+          id: "evt-child-complete",
+          type: "execution_complete",
+          data: JSON.stringify({ success: true }),
+          messageId: "msg-child-result",
+          createdAt: 200,
+        },
+      ]);
+
+      const res = await SELF.fetch(
+        `https://test.local/sessions/${pName}/children/${childName}?include=result,trajectory`,
+        { headers: { Authorization: `Bearer ${sandboxToken}` } }
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json<{
+        finalResponse: { textContent: string; messageId: string } | null;
+        trajectory: { events: Array<{ id: string }> };
+      }>();
+
+      expect(body.finalResponse).toMatchObject({
+        messageId: "msg-child-result",
+        textContent: "usable child result",
+      });
+      expect(body.trajectory.events.map((event) => event.id)).toEqual([
+        "evt-child-token",
+        "evt-child-complete",
+      ]);
+    });
+
     it("returns 404 for wrong parent", async () => {
       const { childName } = await setupParentAndChild();
 

--- a/packages/control-plane/test/integration/do-internal-routes.test.ts
+++ b/packages/control-plane/test/integration/do-internal-routes.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import { env } from "cloudflare:test";
+import { cleanD1Tables } from "./cleanup";
 import { initSession, queryDO, seedEvents } from "./helpers";
 import type { SpawnContext, ChildSessionDetail } from "@open-inspect/shared";
 
@@ -48,7 +49,8 @@ async function waitForSandboxSpawn(stub: DurableObjectStub): Promise<void> {
 }
 
 describe("DO internal sub-session routes", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await cleanD1Tables();
     installModalFetchMock();
   });
 

--- a/packages/control-plane/test/integration/do-internal-routes.test.ts
+++ b/packages/control-plane/test/integration/do-internal-routes.test.ts
@@ -176,6 +176,133 @@ describe("DO internal sub-session routes", () => {
       expect(eventTypes).not.toContain("heartbeat");
     });
 
+    it("can include final response and trajectory when requested", async () => {
+      const externalSessionId = `child-summary-rich-${Date.now()}`;
+      const { stub } = await initSession({
+        sessionName: externalSessionId,
+        repoOwner: "acme",
+        repoName: "web-app",
+        title: "Child task",
+        userId: "user-1",
+      });
+      const [{ id: participantId }] = await queryDO<{ id: string }>(
+        stub,
+        "SELECT id FROM participants LIMIT 1"
+      );
+
+      await queryDO(
+        stub,
+        `INSERT INTO messages (id, author_id, content, source, status, created_at, started_at, completed_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        "msg-rich-1",
+        participantId,
+        "Do the task",
+        "web",
+        "completed",
+        100,
+        110,
+        200
+      );
+
+      await seedEvents(stub, [
+        {
+          id: "evt-tool-rich",
+          type: "tool_call",
+          data: JSON.stringify({ tool: "Bash", args: { command: "npm test" } }),
+          messageId: "msg-rich-1",
+          createdAt: 120,
+        },
+        {
+          id: "evt-token-rich",
+          type: "token",
+          data: JSON.stringify({ content: "Child final answer" }),
+          messageId: "msg-rich-1",
+          createdAt: 180,
+        },
+        {
+          id: "evt-complete-rich",
+          type: "execution_complete",
+          data: JSON.stringify({ success: true }),
+          messageId: "msg-rich-1",
+          createdAt: 200,
+        },
+      ]);
+
+      const res = await stub.fetch(
+        "http://internal/internal/child-summary?include=result,trajectory"
+      );
+
+      expect(res.status).toBe(200);
+      const detail = await res.json<ChildSessionDetail>();
+
+      expect(detail.finalResponse).toMatchObject({
+        messageId: "msg-rich-1",
+        completedAt: 200,
+        textContent: "Child final answer",
+        success: true,
+        toolCalls: [{ tool: "Bash", summary: "Ran: npm test" }],
+      });
+      expect(detail.trajectory?.hasMore).toBe(false);
+      expect(detail.trajectory?.limit).toBe(200);
+      expect(detail.trajectory?.events.map((event) => event.id)).toEqual([
+        "evt-tool-rich",
+        "evt-token-rich",
+        "evt-complete-rich",
+      ]);
+    });
+
+    it("rejects malformed trajectory cursors", async () => {
+      const externalSessionId = `child-summary-bad-cursor-${Date.now()}`;
+      const { stub } = await initSession({
+        sessionName: externalSessionId,
+        repoOwner: "acme",
+        repoName: "web-app",
+        userId: "user-1",
+      });
+
+      const res = await stub.fetch(
+        "http://internal/internal/child-summary?include=trajectory&trajectoryCursor=bad"
+      );
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({ error: "Invalid trajectoryCursor" });
+    });
+
+    it.each(["0", "-1", "abc", "1.5"])(
+      "rejects invalid trajectory limits (%s)",
+      async (trajectoryLimit) => {
+        const externalSessionId = `child-summary-bad-limit-${Date.now()}`;
+        const { stub } = await initSession({
+          sessionName: externalSessionId,
+          repoOwner: "acme",
+          repoName: "web-app",
+          userId: "user-1",
+        });
+
+        const res = await stub.fetch(
+          `http://internal/internal/child-summary?include=trajectory&trajectoryLimit=${trajectoryLimit}`
+        );
+
+        expect(res.status).toBe(400);
+        await expect(res.json()).resolves.toEqual({ error: "Invalid trajectoryLimit" });
+      }
+    );
+
+    it("rejects invalid child summary include values", async () => {
+      const externalSessionId = `child-summary-bad-include-${Date.now()}`;
+      const { stub } = await initSession({
+        sessionName: externalSessionId,
+        repoOwner: "acme",
+        repoName: "web-app",
+        userId: "user-1",
+      });
+
+      const res = await stub.fetch("http://internal/internal/child-summary?include=result,unknown");
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toEqual({ error: "Invalid include: unknown" });
+    });
+
     it("returns 404 when session is not initialized", async () => {
       const id = env.SESSION.newUniqueId();
       const stub = env.SESSION.get(id);

--- a/packages/control-plane/test/integration/events-messages-list.test.ts
+++ b/packages/control-plane/test/integration/events-messages-list.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { beforeEach, describe, it, expect } from "vitest";
+import { cleanD1Tables } from "./cleanup";
 import { initSession, seedEvents } from "./helpers";
 
 describe("GET /internal/events", () => {
+  beforeEach(cleanD1Tables);
+
   it("lists events with default pagination", async () => {
     const { stub } = await initSession();
     const baseTime = Date.now();
@@ -127,10 +130,23 @@ describe("GET /internal/events", () => {
     );
     const page2 = await res2.json<{
       events: Array<{ id: string }>;
+      cursor: string;
       hasMore: boolean;
     }>();
 
     expect(page2.events.map((event) => event.id)).toEqual(["evt-tie-2", "evt-tie-1"]);
+    expect(page2.hasMore).toBe(true);
+
+    const res3 = await stub.fetch(
+      `http://internal/internal/events?type=error&limit=2&cursor=${encodeURIComponent(page2.cursor)}`
+    );
+    const page3 = await res3.json<{
+      events: Array<{ id: string }>;
+      hasMore: boolean;
+    }>();
+
+    expect(page3.events.map((event) => event.id)).toEqual(["evt-tie-0"]);
+    expect(page3.hasMore).toBe(false);
   });
 
   it("rejects malformed cursors", async () => {

--- a/packages/control-plane/test/integration/events-messages-list.test.ts
+++ b/packages/control-plane/test/integration/events-messages-list.test.ts
@@ -97,6 +97,51 @@ describe("GET /internal/events", () => {
     }
   });
 
+  it("cursor pagination includes events tied on the page boundary timestamp", async () => {
+    const { stub } = await initSession();
+    const createdAt = Date.now();
+
+    await seedEvents(
+      stub,
+      Array.from({ length: 5 }, (_, i) => ({
+        id: `evt-tie-${i}`,
+        type: "error",
+        data: JSON.stringify({ type: "error", message: `error-${i}` }),
+        createdAt,
+      }))
+    );
+
+    const res1 = await stub.fetch("http://internal/internal/events?type=error&limit=2");
+    const page1 = await res1.json<{
+      events: Array<{ id: string }>;
+      cursor: string;
+      hasMore: boolean;
+    }>();
+
+    expect(page1.events.map((event) => event.id)).toEqual(["evt-tie-4", "evt-tie-3"]);
+    expect(page1.hasMore).toBe(true);
+    expect(page1.cursor).toBe(`${createdAt}:evt-tie-3`);
+
+    const res2 = await stub.fetch(
+      `http://internal/internal/events?type=error&limit=2&cursor=${encodeURIComponent(page1.cursor)}`
+    );
+    const page2 = await res2.json<{
+      events: Array<{ id: string }>;
+      hasMore: boolean;
+    }>();
+
+    expect(page2.events.map((event) => event.id)).toEqual(["evt-tie-2", "evt-tie-1"]);
+  });
+
+  it("rejects malformed cursors", async () => {
+    const { stub } = await initSession();
+
+    const res = await stub.fetch("http://internal/internal/events?cursor=bad");
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid cursor" });
+  });
+
   it("filters events by type", async () => {
     const { stub } = await initSession();
     const baseTime = Date.now();

--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/get-task-status-format.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/get-task-status-format.js
@@ -1,0 +1,180 @@
+const STATUS_LABELS = {
+  created: "PENDING",
+  active: "RUNNING",
+  completed: "DONE",
+  failed: "FAILED",
+  cancelled: "CANCELLED",
+  archived: "DONE",
+};
+
+export function formatStatus(status) {
+  return STATUS_LABELS[status] || status.toUpperCase();
+}
+
+export function formatTimestamp(ts) {
+  if (!ts) return "n/a";
+  return new Date(ts).toISOString();
+}
+
+export function indentBlock(text, indent = "    ") {
+  return String(text)
+    .split("\n")
+    .map((line) => `${indent}${line}`)
+    .join("\n");
+}
+
+export function formatEventData(data) {
+  try {
+    return JSON.stringify(data);
+  } catch {
+    return String(data);
+  }
+}
+
+export function summarizeEvent(event) {
+  const data = event?.data || {};
+  const text =
+    data.message ?? data.content ?? data.result ?? data.error ?? data.status ?? data.state ?? null;
+
+  if (event.type === "tool_call") {
+    const tool = data.tool || data.name || "tool";
+    const args = data.args || {};
+    const target = args.command || args.file_path || args.pattern;
+    return target ? `${tool}: ${target}` : String(tool);
+  }
+
+  if (typeof text === "string" && text.length > 0) {
+    return text.length > 160 ? `${text.slice(0, 157)}...` : text;
+  }
+
+  return "";
+}
+
+export function shouldIncludeResponse(options = {}) {
+  return Boolean(options.includeResponse || options.includeTrajectory);
+}
+
+export function buildChildDetailQuery(options = {}) {
+  const include = [];
+  if (shouldIncludeResponse(options)) {
+    include.push("result");
+  }
+  if (options.includeTrajectory) {
+    include.push("trajectory");
+  }
+
+  const params = new URLSearchParams();
+  if (include.length > 0) {
+    params.set("include", include.join(","));
+  }
+  if (options.includeTrajectory && options.trajectoryLimit) {
+    params.set("trajectoryLimit", String(options.trajectoryLimit));
+  }
+  if (options.includeTrajectory && options.trajectoryCursor) {
+    params.set("trajectoryCursor", options.trajectoryCursor);
+  }
+
+  const query = params.toString();
+  return query ? `?${query}` : "";
+}
+
+export function formatArtifacts(artifacts = []) {
+  if (artifacts.length === 0) return [];
+
+  const lines = ["", "  Artifacts:"];
+  for (const a of artifacts) {
+    const label = a.type === "pr" ? `PR: ${a.url}` : `${a.type}: ${a.url}`;
+    lines.push(`    - ${label}`);
+  }
+  return lines;
+}
+
+export function formatFinalResponse(finalResponse, includeResponse) {
+  if (!finalResponse) {
+    return includeResponse ? ["", "  Final response: not available yet"] : [];
+  }
+
+  const lines = ["", "  Final response:"];
+  lines.push(`    Success: ${finalResponse.success ? "yes" : "no"}`);
+  if (finalResponse.error) {
+    lines.push(`    Error: ${finalResponse.error}`);
+  }
+  if (finalResponse.eventLimitReached) {
+    lines.push(`    Events: ${finalResponse.eventCount} (limit reached)`);
+  }
+  lines.push("    Text:");
+  lines.push(indentBlock(finalResponse.textContent || "(empty)", "      "));
+
+  if (finalResponse.toolCalls?.length) {
+    lines.push("", "    Tool summary:");
+    for (const call of finalResponse.toolCalls) {
+      lines.push(`      - ${call.summary || call.tool}`);
+    }
+  }
+
+  return lines;
+}
+
+export function formatTrajectory(trajectory, options = {}) {
+  if (!trajectory) return [];
+
+  const suffix = trajectory.hasMore ? " (more available)" : "";
+  const lines = ["", `  Trajectory${suffix}:`];
+  if (!trajectory.events?.length) {
+    lines.push("    (no events)");
+  } else {
+    for (const e of trajectory.events) {
+      const time = formatTimestamp(e.createdAt);
+      const message = e.messageId ? ` message=${e.messageId}` : "";
+      const summary = summarizeEvent(e);
+      lines.push(`    [${time}] ${e.type}${message}${summary ? `: ${summary}` : ""}`);
+      if (options.includeEventData) {
+        lines.push(`      ${formatEventData(e.data)}`);
+      }
+    }
+  }
+
+  if (trajectory.hasMore && trajectory.cursor) {
+    lines.push(`    More events available. Re-run with trajectoryCursor="${trajectory.cursor}".`);
+  }
+
+  return lines;
+}
+
+export function formatRecentEvents(recentEvents = []) {
+  if (recentEvents.length === 0) return [];
+
+  const lines = ["", "  Recent events:"];
+  for (const e of recentEvents) {
+    const time = formatTimestamp(e.createdAt);
+    const raw = e.data?.message || e.data?.content || e.type;
+    const summary = typeof raw === "string" ? raw : JSON.stringify(raw);
+    lines.push(`    [${time}] ${e.type}: ${summary.slice(0, 120)}`);
+  }
+  return lines;
+}
+
+export function formatChildDetail(detail, taskId, options = {}) {
+  const s = detail.session || {};
+  const lines = [
+    `Task: ${s.id || taskId}`,
+    `  Title:   ${s.title || "(untitled)"}`,
+    `  Status:  ${formatStatus(s.status || "unknown")}`,
+    `  Model:   ${s.model || "default"}`,
+    `  Repo:    ${s.repoOwner || ""}/${s.repoName || ""}`,
+    `  Branch:  ${s.branchName || "(none)"}`,
+    `  Created: ${formatTimestamp(s.createdAt)}`,
+    `  Updated: ${formatTimestamp(s.updatedAt)}`,
+  ];
+
+  if (detail.sandbox) {
+    lines.push(`  Sandbox: ${detail.sandbox.status}`);
+  }
+
+  lines.push(...formatArtifacts(detail.artifacts));
+  lines.push(...formatFinalResponse(detail.finalResponse, shouldIncludeResponse(options)));
+  lines.push(...formatTrajectory(detail.trajectory, options));
+  lines.push(...formatRecentEvents(detail.recentEvents));
+
+  return lines.join("\n");
+}

--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/get-task-status.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/get-task-status.js
@@ -50,7 +50,8 @@ async function listChildren() {
 }
 
 async function getChildDetail(taskId, options = {}) {
-  const response = await bridgeFetch(`/children/${taskId}${buildChildDetailQuery(options)}`);
+  const encodedTaskId = encodeURIComponent(taskId);
+  const response = await bridgeFetch(`/children/${encodedTaskId}${buildChildDetailQuery(options)}`);
 
   if (!response.ok) {
     if (response.status === 404) {
@@ -104,7 +105,7 @@ export default tool({
       if (args.taskId) {
         return await getChildDetail(args.taskId, {
           includeResponse: args.includeResponse,
-          includeTrajectory: args.includeTrajectory,
+          includeTrajectory: args.includeTrajectory || args.includeEventData,
           trajectoryLimit: args.trajectoryLimit,
           trajectoryCursor: args.trajectoryCursor,
           includeEventData: args.includeEventData,

--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/get-task-status.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/get-task-status.js
@@ -6,24 +6,12 @@
 import { tool } from "@opencode-ai/plugin";
 import { z } from "zod";
 import { bridgeFetch, extractError } from "./_bridge-client.js";
-
-const STATUS_LABELS = {
-  created: "PENDING",
-  active: "RUNNING",
-  completed: "DONE",
-  failed: "FAILED",
-  cancelled: "CANCELLED",
-  archived: "DONE",
-};
-
-function formatStatus(status) {
-  return STATUS_LABELS[status] || status.toUpperCase();
-}
-
-function formatTimestamp(ts) {
-  if (!ts) return "n/a";
-  return new Date(ts).toISOString();
-}
+import {
+  buildChildDetailQuery,
+  formatChildDetail,
+  formatStatus,
+  formatTimestamp,
+} from "./get-task-status-format.js";
 
 async function listChildren() {
   const response = await bridgeFetch("/children");
@@ -61,8 +49,8 @@ async function listChildren() {
   return [header, "", ...lines].join("\n");
 }
 
-async function getChildDetail(taskId) {
-  const response = await bridgeFetch(`/children/${taskId}`);
+async function getChildDetail(taskId, options = {}) {
+  const response = await bridgeFetch(`/children/${taskId}${buildChildDetailQuery(options)}`);
 
   if (!response.ok) {
     if (response.status === 404) {
@@ -73,57 +61,54 @@ async function getChildDetail(taskId) {
   }
 
   const detail = await response.json();
-  const s = detail.session || {};
-  const lines = [
-    `Task: ${s.id || taskId}`,
-    `  Title:   ${s.title || "(untitled)"}`,
-    `  Status:  ${formatStatus(s.status || "unknown")}`,
-    `  Model:   ${s.model || "default"}`,
-    `  Repo:    ${s.repoOwner || ""}/${s.repoName || ""}`,
-    `  Branch:  ${s.branchName || "(none)"}`,
-    `  Created: ${formatTimestamp(s.createdAt)}`,
-    `  Updated: ${formatTimestamp(s.updatedAt)}`,
-  ];
-
-  if (detail.sandbox) {
-    lines.push(`  Sandbox: ${detail.sandbox.status}`);
-  }
-
-  if (detail.artifacts && detail.artifacts.length > 0) {
-    lines.push("", "  Artifacts:");
-    for (const a of detail.artifacts) {
-      const label = a.type === "pr" ? `PR: ${a.url}` : `${a.type}: ${a.url}`;
-      lines.push(`    - ${label}`);
-    }
-  }
-
-  if (detail.recentEvents && detail.recentEvents.length > 0) {
-    lines.push("", "  Recent events:");
-    for (const e of detail.recentEvents) {
-      const time = formatTimestamp(e.createdAt);
-      const raw = e.data?.message || e.data?.content || e.type;
-      const summary = typeof raw === "string" ? raw : JSON.stringify(raw);
-      lines.push(`    [${time}] ${e.type}: ${summary.slice(0, 120)}`);
-    }
-  }
-
-  return lines.join("\n");
+  return formatChildDetail(detail, taskId, options);
 }
 
 export default tool({
   name: "get-task-status",
   description:
-    "Check the status of child tasks. Without a taskId, lists all child tasks with summary counts. With a taskId, returns detailed information including sandbox status, artifacts (PRs), and recent events.",
+    "Check child task status. Without a taskId, lists all child tasks with summary counts. With a taskId, returns details. Set includeResponse to retrieve the child's final assistant response when available. Set includeTrajectory for a paginated persisted event trajectory.",
   args: {
     taskId: z
       .string()
       .optional()
       .describe("Specific task ID to get details for. Omit to list all child tasks."),
+    includeResponse: z
+      .boolean()
+      .optional()
+      .describe("Include the child's final assistant response when available."),
+    includeTrajectory: z
+      .boolean()
+      .optional()
+      .describe(
+        "Include a persisted child event trajectory page. This also includes the final response when available."
+      ),
+    trajectoryLimit: z
+      .number()
+      .int()
+      .min(1)
+      .max(1000)
+      .optional()
+      .describe("Maximum trajectory events to retrieve when includeTrajectory is true."),
+    trajectoryCursor: z
+      .string()
+      .optional()
+      .describe("Cursor returned by a previous trajectory page."),
+    includeEventData: z
+      .boolean()
+      .optional()
+      .describe("Include raw JSON payloads for each trajectory event."),
   },
   async execute(args) {
     try {
       if (args.taskId) {
-        return await getChildDetail(args.taskId);
+        return await getChildDetail(args.taskId, {
+          includeResponse: args.includeResponse,
+          includeTrajectory: args.includeTrajectory,
+          trajectoryLimit: args.trajectoryLimit,
+          trajectoryCursor: args.trajectoryCursor,
+          includeEventData: args.includeEventData,
+        });
       }
       return await listChildren();
     } catch (error) {

--- a/packages/sandbox-runtime/tests/get-task-status-format.test.mjs
+++ b/packages/sandbox-runtime/tests/get-task-status-format.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildChildDetailQuery,
+  formatFinalResponse,
+  formatRecentEvents,
+  formatTrajectory,
+  summarizeEvent,
+} from "../src/sandbox_runtime/tools/get-task-status-format.js";
+
+test("buildChildDetailQuery includes only result when response is requested", () => {
+  assert.equal(buildChildDetailQuery({ includeResponse: true }), "?include=result");
+});
+
+test("buildChildDetailQuery includes trajectory pagination parameters", () => {
+  assert.equal(
+    buildChildDetailQuery({
+      includeTrajectory: true,
+      trajectoryLimit: 25,
+      trajectoryCursor: "10:event:1",
+    }),
+    "?include=result%2Ctrajectory&trajectoryLimit=25&trajectoryCursor=10%3Aevent%3A1"
+  );
+});
+
+test("formatFinalResponse shows capped event count and tool summaries", () => {
+  const output = formatFinalResponse(
+    {
+      success: true,
+      textContent: "done",
+      toolCalls: [{ tool: "Bash", summary: "Ran: npm test" }],
+      eventCount: 1000,
+      eventLimitReached: true,
+    },
+    true
+  ).join("\n");
+
+  assert.match(output, /Events: 1000 \(limit reached\)/);
+  assert.match(output, /done/);
+  assert.match(output, /Ran: npm test/);
+});
+
+test("formatTrajectory shows event summaries and pagination cursor", () => {
+  const output = formatTrajectory({
+    hasMore: true,
+    cursor: "30:event-1",
+    events: [
+      {
+        id: "event-1",
+        type: "tool_call",
+        messageId: "message-1",
+        createdAt: 1000,
+        data: { tool: "Bash", args: { command: "npm test" } },
+      },
+    ],
+  }).join("\n");
+
+  assert.match(output, /Bash: npm test/);
+  assert.match(output, /More events available/);
+  assert.match(output, /trajectoryCursor="30:event-1"/);
+});
+
+test("formatRecentEvents summarizes message-like payloads", () => {
+  const output = formatRecentEvents([
+    { type: "error", createdAt: 1000, data: { message: "boom" } },
+  ]).join("\n");
+
+  assert.match(output, /error: boom/);
+});
+
+test("summarizeEvent falls back to common data fields", () => {
+  assert.equal(summarizeEvent({ type: "progress", data: { state: "running" } }), "running");
+});

--- a/packages/shared/src/completion/extractor.test.ts
+++ b/packages/shared/src/completion/extractor.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { buildAgentResponseFromEvents, toArtifactType, toEventArtifactInfo } from "./extractor";
+import {
+  buildAgentResponseFromEvents,
+  extractAgentResponse,
+  toArtifactType,
+  toEventArtifactInfo,
+  type ControlPlaneFetcher,
+} from "./extractor";
 
 describe("completion artifact type narrowing", () => {
   it("recognizes video artifacts", () => {
@@ -106,5 +112,103 @@ describe("buildAgentResponseFromEvents", () => {
         { defaultSuccess: true }
       ).success
     ).toBe(false);
+  });
+
+  it("prefers message-scoped artifact events over supplied session artifacts", () => {
+    const response = buildAgentResponseFromEvents(
+      [
+        {
+          id: "artifact:current",
+          type: "artifact",
+          data: {
+            artifactType: "branch",
+            url: "https://example.com/tree/current",
+            metadata: { name: "current" },
+          },
+          messageId: "msg-1",
+          createdAt: 1,
+        },
+      ],
+      [
+        {
+          type: "branch",
+          url: "https://example.com/tree/old",
+          label: "Branch: old",
+        },
+      ]
+    );
+
+    expect(response.artifacts).toEqual([
+      {
+        type: "branch",
+        url: "https://example.com/tree/current",
+        label: "Branch: current",
+      },
+    ]);
+  });
+});
+
+describe("extractAgentResponse", () => {
+  it("filters fetched session artifacts to the message event window", async () => {
+    const fetcher: ControlPlaneFetcher = {
+      async fetch(input) {
+        const url = String(input);
+        if (url.includes("/events")) {
+          return Response.json({
+            events: [
+              {
+                id: "token:msg-1",
+                type: "token",
+                data: { content: "done" },
+                messageId: "msg-1",
+                createdAt: 100,
+              },
+              {
+                id: "complete:msg-1",
+                type: "execution_complete",
+                data: { success: true },
+                messageId: "msg-1",
+                createdAt: 200,
+              },
+            ],
+            hasMore: false,
+          });
+        }
+
+        if (url.includes("/artifacts")) {
+          return Response.json({
+            artifacts: [
+              {
+                id: "artifact-old",
+                type: "branch",
+                url: "https://example.com/tree/old",
+                metadata: { head: "old" },
+                createdAt: 50,
+              },
+              {
+                id: "artifact-current",
+                type: "branch",
+                url: "https://example.com/tree/current",
+                metadata: { head: "current" },
+                createdAt: 150,
+              },
+            ],
+          });
+        }
+
+        return Response.json({}, { status: 404 });
+      },
+    };
+
+    const response = await extractAgentResponse({ fetcher }, "session-1", "msg-1");
+
+    expect(response.artifacts).toEqual([
+      {
+        type: "branch",
+        url: "https://example.com/tree/current",
+        label: "Branch: current",
+        metadata: { head: "current" },
+      },
+    ]);
   });
 });

--- a/packages/shared/src/completion/extractor.test.ts
+++ b/packages/shared/src/completion/extractor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { toArtifactType, toEventArtifactInfo } from "./extractor";
+import { buildAgentResponseFromEvents, toArtifactType, toEventArtifactInfo } from "./extractor";
 
 describe("completion artifact type narrowing", () => {
   it("recognizes video artifacts", () => {
@@ -10,5 +10,101 @@ describe("completion artifact type narrowing", () => {
     expect(toEventArtifactInfo({ artifactType: "video", url: "sessions/s1/media/a1.mp4" })).toBe(
       null
     );
+  });
+});
+
+describe("buildAgentResponseFromEvents", () => {
+  it("aggregates final text, tool calls, artifacts, and completion status", () => {
+    const response = buildAgentResponseFromEvents(
+      [
+        {
+          id: "complete:old",
+          type: "execution_complete",
+          data: { success: false, error: "old failure" },
+          messageId: "msg-1",
+          createdAt: 5,
+        },
+        {
+          id: "complete:1",
+          type: "execution_complete",
+          data: { success: true },
+          messageId: "msg-1",
+          createdAt: 40,
+        },
+        {
+          id: "token:new",
+          type: "token",
+          data: { content: "done" },
+          messageId: "msg-1",
+          createdAt: 30,
+        },
+        {
+          id: "tool:2",
+          type: "tool_call",
+          data: { tool: "Read", args: { file_path: "README.md" } },
+          messageId: "msg-1",
+          createdAt: 25,
+        },
+        {
+          id: "token:old",
+          type: "token",
+          data: { content: "partial" },
+          messageId: "msg-1",
+          createdAt: 10,
+        },
+        {
+          id: "tool:1",
+          type: "tool_call",
+          data: { tool: "Bash", args: { command: "npm test" } },
+          messageId: "msg-1",
+          createdAt: 20,
+        },
+      ],
+      [
+        {
+          type: "branch",
+          url: "https://example.com/tree/fix",
+          label: "Branch: fix",
+          metadata: { head: "fix" },
+        },
+      ]
+    );
+
+    expect(response).toEqual({
+      textContent: "done",
+      toolCalls: [
+        { tool: "Bash", summary: "Ran: npm test" },
+        { tool: "Read", summary: "Read README.md" },
+      ],
+      artifacts: [
+        {
+          type: "branch",
+          url: "https://example.com/tree/fix",
+          label: "Branch: fix",
+          metadata: { head: "fix" },
+        },
+      ],
+      success: true,
+      error: undefined,
+    });
+  });
+
+  it("uses the explicit default success only when completion success is absent", () => {
+    expect(buildAgentResponseFromEvents([], [], { defaultSuccess: true }).success).toBe(true);
+    expect(
+      buildAgentResponseFromEvents(
+        [
+          {
+            id: "complete:1",
+            type: "execution_complete",
+            data: { success: false },
+            messageId: "msg-1",
+            createdAt: 1,
+          },
+        ],
+        [],
+        { defaultSuccess: true }
+      ).success
+    ).toBe(false);
   });
 });

--- a/packages/shared/src/completion/extractor.ts
+++ b/packages/shared/src/completion/extractor.ts
@@ -26,6 +26,10 @@ export const SUMMARY_TOOL_NAMES = ["Edit", "Write", "Bash", "Grep", "Read"] as c
 /** Server-side limit for the events API. */
 const EVENTS_PAGE_LIMIT = 200;
 
+export interface BuildAgentResponseOptions {
+  defaultSuccess?: boolean;
+}
+
 /**
  * Minimal interface for the control-plane service binding.
  * Compatible with Cloudflare Workers' `Fetcher` type without depending on
@@ -111,58 +115,21 @@ export async function extractAgentResponse(
       cursor = data.hasMore ? data.cursor : undefined;
     } while (cursor);
 
-    // Get the final text from the last token event.
-    // Token events contain cumulative text (not incremental deltas), so only the last one matters.
-    const tokenEvents = allEvents
-      .filter((e): e is EventResponse & { type: "token" } => e.type === "token")
-      .sort((a, b) => {
-        const timeDiff = (a.createdAt as number) - (b.createdAt as number);
-        if (timeDiff !== 0) return timeDiff;
-        return a.id.localeCompare(b.id); // Stable secondary sort
-      });
-    const lastToken = tokenEvents[tokenEvents.length - 1];
-    const textContent = lastToken ? String(lastToken.data.content ?? "") : "";
-
-    // Extract tool calls
-    const toolCalls: ToolCallSummary[] = allEvents
-      .filter((e) => e.type === "tool_call")
-      .map((e) => summarizeToolCall(e.data));
-
-    // Fallback artifact extraction from events (historical behavior)
-    const eventArtifacts: ArtifactInfo[] = allEvents
-      .filter((e) => e.type === "artifact")
-      .map((e) => toEventArtifactInfo(e.data))
-      .filter((artifact: ArtifactInfo | null): artifact is ArtifactInfo => artifact !== null);
-
     const artifacts = await fetchSessionArtifacts(deps, sessionId, headers, base);
-    const finalArtifacts = artifacts.length > 0 ? artifacts : eventArtifacts;
-
-    // Check for completion event to get success status and error message.
-    // The error may be on execution_complete itself, or on a separate "error" event.
-    const completionEvent = allEvents.find((e) => e.type === "execution_complete");
-    const errorEvent = allEvents.find((e) => e.type === "error");
-    const errorMessage =
-      (completionEvent?.data.error != null ? String(completionEvent.data.error) : undefined) ??
-      (errorEvent?.data.error != null ? String(errorEvent.data.error) : undefined);
+    const agentResponse = buildAgentResponseFromEvents(allEvents, artifacts);
 
     log.info("control_plane.fetch_events", {
       ...base,
       outcome: "success",
       event_count: allEvents.length,
-      tool_call_count: toolCalls.length,
-      artifact_count: finalArtifacts.length,
-      has_text: Boolean(textContent),
-      has_error: Boolean(errorMessage),
+      tool_call_count: agentResponse.toolCalls.length,
+      artifact_count: agentResponse.artifacts.length,
+      has_text: Boolean(agentResponse.textContent),
+      has_error: Boolean(agentResponse.error),
       duration_ms: Date.now() - startTime,
     });
 
-    return {
-      textContent,
-      toolCalls,
-      artifacts: finalArtifacts,
-      success: Boolean(completionEvent?.data.success),
-      error: errorMessage,
-    };
+    return agentResponse;
   } catch (error) {
     log.error("control_plane.fetch_events", {
       ...base,
@@ -177,6 +144,70 @@ export async function extractAgentResponse(
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+/**
+ * Aggregate persisted control-plane events into the structured response shape
+ * consumed by callbacks and child-session introspection.
+ */
+export function buildAgentResponseFromEvents(
+  events: EventResponse[],
+  artifacts: ArtifactInfo[] = [],
+  options: BuildAgentResponseOptions = {}
+): AgentResponse {
+  const chronologicalEvents = sortEventsChronologically(events);
+
+  // Token events contain cumulative text, so only the chronologically last one matters.
+  const tokenEvents = chronologicalEvents.filter(
+    (event): event is EventResponse & { type: "token" } => event.type === "token"
+  );
+  const lastToken = tokenEvents[tokenEvents.length - 1];
+  const textContent = lastToken ? String(lastToken.data.content ?? "") : "";
+
+  const toolCalls: ToolCallSummary[] = chronologicalEvents
+    .filter((event) => event.type === "tool_call")
+    .map((event) => summarizeToolCall(event.data));
+
+  const eventArtifacts: ArtifactInfo[] = chronologicalEvents
+    .filter((event) => event.type === "artifact")
+    .map((event) => toEventArtifactInfo(event.data))
+    .filter((artifact: ArtifactInfo | null): artifact is ArtifactInfo => artifact !== null);
+
+  const completionEvent = findLastEvent(chronologicalEvents, "execution_complete");
+  const errorEvent = findLastEvent(chronologicalEvents, "error");
+  const errorMessage =
+    (completionEvent?.data.error != null ? String(completionEvent.data.error) : undefined) ??
+    (errorEvent?.data.error != null ? String(errorEvent.data.error) : undefined);
+
+  const successValue = completionEvent?.data.success;
+  const success =
+    typeof successValue === "boolean" ? successValue : (options.defaultSuccess ?? false);
+
+  return {
+    textContent,
+    toolCalls,
+    artifacts: artifacts.length > 0 ? artifacts : eventArtifacts,
+    success,
+    error: errorMessage,
+  };
+}
+
+function sortEventsChronologically(events: EventResponse[]): EventResponse[] {
+  return [...events].sort((a, b) => {
+    const timeDiff = a.createdAt - b.createdAt;
+    if (timeDiff !== 0) return timeDiff;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+function findLastEvent(
+  events: EventResponse[],
+  type: EventResponse["type"]
+): EventResponse | undefined {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    if (events[index].type === type) return events[index];
+  }
+  return undefined;
+}
 
 /**
  * Fetch artifacts from the control-plane `/artifacts` endpoint.

--- a/packages/shared/src/completion/extractor.ts
+++ b/packages/shared/src/completion/extractor.ts
@@ -115,7 +115,7 @@ export async function extractAgentResponse(
       cursor = data.hasMore ? data.cursor : undefined;
     } while (cursor);
 
-    const artifacts = await fetchSessionArtifacts(deps, sessionId, headers, base);
+    const artifacts = await fetchSessionArtifacts(deps, sessionId, headers, base, allEvents);
     const agentResponse = buildAgentResponseFromEvents(allEvents, artifacts);
 
     log.info("control_plane.fetch_events", {
@@ -185,7 +185,7 @@ export function buildAgentResponseFromEvents(
   return {
     textContent,
     toolCalls,
-    artifacts: artifacts.length > 0 ? artifacts : eventArtifacts,
+    artifacts: eventArtifacts.length > 0 ? eventArtifacts : artifacts,
     success,
     error: errorMessage,
   };
@@ -216,9 +216,11 @@ async function fetchSessionArtifacts(
   deps: ExtractorDeps,
   sessionId: string,
   headers: Record<string, string>,
-  base: Record<string, unknown>
+  base: Record<string, unknown>,
+  events: EventResponse[]
 ): Promise<ArtifactInfo[]> {
   const log = deps.log ?? noopLogger;
+  const eventRange = getEventCreatedAtRange(events);
   try {
     const response = await deps.fetcher.fetch(`https://internal/sessions/${sessionId}/artifacts`, {
       headers,
@@ -236,6 +238,7 @@ async function fetchSessionArtifacts(
     const data = (await response.json()) as ListArtifactsResponse;
     return data.artifacts
       .filter((artifact) => artifact.type !== "screenshot" && artifact.type !== "video")
+      .filter((artifact) => isArtifactInEventRange(artifact.createdAt, eventRange))
       .map((artifact) => ({
         type: artifact.type,
         url: artifact.url ? String(artifact.url) : "",
@@ -250,6 +253,27 @@ async function fetchSessionArtifacts(
     });
     return [];
   }
+}
+
+function getEventCreatedAtRange(events: EventResponse[]): { start: number; end: number } | null {
+  if (events.length === 0) return null;
+
+  let start = Number.POSITIVE_INFINITY;
+  let end = Number.NEGATIVE_INFINITY;
+  for (const event of events) {
+    start = Math.min(start, event.createdAt);
+    end = Math.max(end, event.createdAt);
+  }
+
+  return { start, end };
+}
+
+function isArtifactInEventRange(
+  createdAt: number,
+  range: { start: number; end: number } | null
+): boolean {
+  if (!range) return false;
+  return createdAt >= range.start && createdAt <= range.end;
 }
 
 /**

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -619,6 +619,20 @@ export interface SpawnContext {
 }
 
 /** Returned by child DO's GET /internal/child-summary */
+export interface ChildSessionFinalResponse extends AgentResponse {
+  messageId: string;
+  completedAt: number | null;
+  eventCount: number;
+  eventLimitReached: boolean;
+}
+
+export interface ChildSessionTrajectory {
+  events: EventResponse[];
+  hasMore: boolean;
+  cursor?: string;
+  limit: number;
+}
+
 export interface ChildSessionDetail {
   session: {
     id: string;
@@ -634,6 +648,8 @@ export interface ChildSessionDetail {
   sandbox: { status: SandboxStatus } | null;
   artifacts: Array<{ type: string; url: string; metadata: unknown }>;
   recentEvents: Array<{ type: string; data: unknown; createdAt: number }>;
+  finalResponse?: ChildSessionFinalResponse | null;
+  trajectory?: ChildSessionTrajectory;
 }
 
 // ─── Analytics ───────────────────────────────────────────────────────────────

--- a/packages/slack-bot/src/completion/extractor.test.ts
+++ b/packages/slack-bot/src/completion/extractor.test.ts
@@ -43,14 +43,14 @@ describe("extractAgentResponse", () => {
               type: "pr",
               url: "https://github.com/octocat/repo/pull/42",
               metadata: { number: 42 },
-              createdAt: 1,
+              createdAt: 10,
             },
             {
               id: "a2",
               type: "branch",
               url: "https://github.com/octocat/repo/pull/new/main...open-inspect%2Fsession-123",
               metadata: { head: "open-inspect/session-123", mode: "manual_pr" },
-              createdAt: 2,
+              createdAt: 11,
             },
           ],
         });


### PR DESCRIPTION
## Summary
- Add optional child-session result and trajectory introspection through the parent child-status flow.
- Persist and paginate event timelines with composite cursors so tied timestamps do not skip events.
- Reuse shared final-response extraction for child summaries and expose the result/trajectory in get-task-status.
- Split get-task-status formatting/query construction into tested pure helpers.

## Tests
- node --check packages/sandbox-runtime/src/sandbox_runtime/tools/get-task-status.js
- node --check packages/sandbox-runtime/src/sandbox_runtime/tools/get-task-status-format.js
- node --test packages/sandbox-runtime/tests/get-task-status-format.test.mjs
- npm run typecheck -w @open-inspect/shared
- npm test -w @open-inspect/shared -- extractor.test.ts
- npm run build -w @open-inspect/shared
- npm run typecheck -w @open-inspect/control-plane
- npm run build -w @open-inspect/control-plane
- npm test -w @open-inspect/control-plane -- event-cursor.test.ts repository.test.ts message.service.test.ts messages.handler.test.ts child-sessions.handler.test.ts
- npm run test:integration -w @open-inspect/control-plane -- events-messages-list.test.ts do-internal-routes.test.ts child-session-ops.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Child session detail endpoints support include=result and include=trajectory, returning rich final-response summaries and paginated event trajectories.
  * Task status tool options to request final responses, trajectory limits, and cursor-based paging.

* **Refactor**
  * Event listing switched to stable, cursor-based timeline pagination for deterministic ordering and reliable next-cursors.
  * Final-response composition now aggregates events, tool-call summaries, and scoped artifacts.

* **Bug Fixes**
  * Malformed cursors and invalid trajectory parameters return 400 with explicit errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->