### PR TITLE
Clean up child task status includes

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/cancel-task.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/cancel-task.js
@@ -14,7 +14,8 @@ export default tool({
   },
   async execute(args) {
     try {
-      const response = await bridgeFetch(`/children/${args.taskId}/cancel`, {
+      const encodedTaskId = encodeURIComponent(args.taskId);
+      const response = await bridgeFetch(`/children/${encodedTaskId}/cancel`, {
         method: "POST",
       });
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/get-task-status-format.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/get-task-status-format.js
@@ -50,13 +50,9 @@ export function summarizeEvent(event) {
   return "";
 }
 
-export function shouldIncludeResponse(options = {}) {
-  return Boolean(options.includeResponse || options.includeTrajectory);
-}
-
 export function buildChildDetailQuery(options = {}) {
   const include = [];
-  if (shouldIncludeResponse(options)) {
+  if (options.includeResponse) {
     include.push("result");
   }
   if (options.includeTrajectory) {
@@ -172,7 +168,7 @@ export function formatChildDetail(detail, taskId, options = {}) {
   }
 
   lines.push(...formatArtifacts(detail.artifacts));
-  lines.push(...formatFinalResponse(detail.finalResponse, shouldIncludeResponse(options)));
+  lines.push(...formatFinalResponse(detail.finalResponse, Boolean(options.includeResponse)));
   lines.push(...formatTrajectory(detail.trajectory, options));
   lines.push(...formatRecentEvents(detail.recentEvents));
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/get-task-status.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/get-task-status.js
@@ -82,7 +82,7 @@ export default tool({
       .boolean()
       .optional()
       .describe(
-        "Include a persisted child event trajectory page. This also includes the final response when available."
+        "Include a persisted child event trajectory page. Use includeResponse separately to include the final response."
       ),
     trajectoryLimit: z
       .number()

--- a/packages/sandbox-runtime/tests/get-task-status-format.test.mjs
+++ b/packages/sandbox-runtime/tests/get-task-status-format.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   buildChildDetailQuery,
+  formatChildDetail,
   formatFinalResponse,
   formatRecentEvents,
   formatTrajectory,
@@ -19,7 +20,17 @@ test("buildChildDetailQuery includes trajectory pagination parameters", () => {
       trajectoryLimit: 25,
       trajectoryCursor: "10:event:1",
     }),
-    "?include=result%2Ctrajectory&trajectoryLimit=25&trajectoryCursor=10%3Aevent%3A1"
+    "?include=trajectory&trajectoryLimit=25&trajectoryCursor=10%3Aevent%3A1"
+  );
+});
+
+test("buildChildDetailQuery keeps response and trajectory includes separate", () => {
+  assert.equal(
+    buildChildDetailQuery({
+      includeResponse: true,
+      includeTrajectory: true,
+    }),
+    "?include=result%2Ctrajectory"
   );
 });
 
@@ -58,6 +69,27 @@ test("formatTrajectory shows event summaries and pagination cursor", () => {
   assert.match(output, /Bash: npm test/);
   assert.match(output, /More events available/);
   assert.match(output, /trajectoryCursor="30:event-1"/);
+});
+
+test("formatChildDetail does not show final response placeholder for trajectory-only requests", () => {
+  const output = formatChildDetail(
+    {
+      session: {
+        id: "task-1",
+        title: "Trajectory only",
+        status: "completed",
+      },
+      trajectory: {
+        hasMore: false,
+        events: [{ type: "execution_complete", createdAt: 1000, data: { success: true } }],
+      },
+    },
+    "task-1",
+    { includeTrajectory: true }
+  );
+
+  assert.doesNotMatch(output, /Final response/);
+  assert.match(output, /Trajectory/);
 });
 
 test("formatRecentEvents summarizes message-like payloads", () => {


### PR DESCRIPTION
## Summary
- keep `get-task-status` response and trajectory includes orthogonal in the sandbox client
- remove the now-trivial response include helper
- URL-encode `cancel-task` child IDs before using them as path segments

## Validation
- `node --check packages/sandbox-runtime/src/sandbox_runtime/tools/get-task-status.js`
- `node --check packages/sandbox-runtime/src/sandbox_runtime/tools/get-task-status-format.js`
- `node --check packages/sandbox-runtime/src/sandbox_runtime/tools/cancel-task.js`
- `node --test packages/sandbox-runtime/tests/get-task-status-format.test.mjs`
- `npx prettier --check packages/sandbox-runtime/src/sandbox_runtime/tools/get-task-status-format.js packages/sandbox-runtime/src/sandbox_runtime/tools/get-task-status.js packages/sandbox-runtime/src/sandbox_runtime/tools/cancel-task.js packages/sandbox-runtime/tests/get-task-status-format.test.mjs`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced task cancellation request handling for special characters in task IDs
  * Fixed task status display logic—final response now displays only when explicitly requested, independently from trajectory information

* **Documentation**
  * Clarified task status option descriptions to reflect that trajectory and response are independent settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->