### PR TITLE
fix: wait for Daytona snapshot deletion before recreate

### DIFF
--- a/packages/daytona-infra/src/bootstrap.py
+++ b/packages/daytona-infra/src/bootstrap.py
@@ -3,11 +3,36 @@
 from __future__ import annotations
 
 import argparse
+import time
 
 from daytona import Daytona, DaytonaConfig, DaytonaNotFoundError
 
 from .config import load_config
 from .toolchain import create_base_snapshot
+
+# Daytona's snapshot.delete() returns before the backend has finished removing
+# the snapshot. Recreating with the same name inside that window fails with
+# "Snapshot already exists", so we poll until the delete is fully visible
+# before rebuilding.
+_SNAPSHOT_DELETE_TIMEOUT_SECONDS = 300
+_SNAPSHOT_DELETE_POLL_SECONDS = 5
+
+
+def _wait_for_snapshot_deletion(client: Daytona, name: str) -> None:
+    """Block until the named snapshot is no longer returned by the API."""
+    deadline = time.monotonic() + _SNAPSHOT_DELETE_TIMEOUT_SECONDS
+    while True:
+        try:
+            client.snapshot.get(name)
+        except DaytonaNotFoundError:
+            return
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"Daytona snapshot {name!r} still present "
+                f"{_SNAPSHOT_DELETE_TIMEOUT_SECONDS}s after delete()"
+            )
+        print(f"Waiting for snapshot {name!r} deletion to complete...")
+        time.sleep(_SNAPSHOT_DELETE_POLL_SECONDS)
 
 
 def main() -> None:
@@ -37,6 +62,7 @@ def main() -> None:
 
         if existing is not None:
             client.snapshot.delete(existing)
+            _wait_for_snapshot_deletion(client, config.base_snapshot)
 
     create_base_snapshot(client, config.repo_root, config.base_snapshot)
 


### PR DESCRIPTION
## Problem

`packages/daytona-infra/src/bootstrap.py --force` deletes the existing base snapshot and then immediately recreates it with the same name:

```python
client.snapshot.delete(existing)
create_base_snapshot(...)   # races
```

Daytona's `snapshot.delete()` is **asynchronous** — it returns before the backend has finished removing the snapshot. The immediate `create()` then collides with the still-present snapshot and fails:

```
DaytonaError: Failed to create snapshot: Snapshot with name "<name>" already exists for this organization
```

The delete itself succeeds (no exception); it just hasn't taken effect yet when `create()` runs. This makes `--force` rebuilds (e.g. a Terraform-driven snapshot refresh) fail intermittently/deterministically depending on timing.

## Fix

After `delete()`, poll `snapshot.get()` until it reports the snapshot is gone (`DaytonaNotFoundError`) before recreating, with a 300s timeout. This makes the `--force` rebuild path deterministic.

## Risk

Low. No behavior change when the snapshot doesn't already exist (the new wait only runs after a delete). The snapshot is only consumed by sandboxes once it's rebuilt, so the delete/recreate window has no readers.

## Validation

- `ruff check` / `ruff format --check`: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of snapshot recreation when using the `--force` option by properly waiting for backend deletion operations to complete before proceeding with snapshot creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->