### PR TITLE
fix(slack-bot): show all repos in clarification picker via search

### DIFF
--- a/packages/slack-bot/src/classifier/index.test.ts
+++ b/packages/slack-bot/src/classifier/index.test.ts
@@ -128,7 +128,7 @@ describe("RepoClassifier", () => {
     expect(result.confidence).toBe("low");
     expect(result.needsClarification).toBe(true);
     expect(result.reasoning).toContain("structured model output");
-    expect(result.alternatives).toHaveLength(2);
+    expect(result.alternatives).toBeUndefined();
   });
 
   it("asks for clarification when tool output is missing", async () => {
@@ -148,6 +148,6 @@ describe("RepoClassifier", () => {
     expect(result.confidence).toBe("low");
     expect(result.needsClarification).toBe(true);
     expect(result.reasoning).toContain("structured model output");
-    expect(result.alternatives).toHaveLength(2);
+    expect(result.alternatives).toBeUndefined();
   });
 });

--- a/packages/slack-bot/src/classifier/index.ts
+++ b/packages/slack-bot/src/classifier/index.ts
@@ -301,7 +301,9 @@ export class RepoClassifier {
         confidence: "low",
         reasoning:
           "Could not classify repository from structured model output. Please select a repository.",
-        alternatives: repos.slice(0, 5),
+        // No basis to suggest specific repos on a classification failure; the
+        // picker lets the user search the full list.
+        alternatives: undefined,
         needsClarification: true,
       };
     }

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -1506,4 +1506,136 @@ describe("POST /interactions", () => {
       },
     ]);
   });
+
+  it("returns all repos (beyond the old 5-item limit) for the repo clarification picker", async () => {
+    const payload = {
+      type: "block_suggestion",
+      action_id: "select_repo",
+      user: { id: "U123" },
+      value: "",
+    };
+
+    const request = new Request("http://localhost/interactions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "x-slack-signature": "v0=test",
+        "x-slack-request-timestamp": `${Math.floor(Date.now() / 1000)}`,
+      },
+      body: new URLSearchParams({ payload: JSON.stringify(payload) }),
+    });
+
+    const env = makeEnv();
+    const repos = Array.from({ length: 150 }, (_, idx) => {
+      const number = String(idx + 1).padStart(3, "0");
+      return {
+        id: `acme/repo-${number}`,
+        owner: "acme",
+        name: `repo-${number}`,
+        fullName: `acme/repo-${number}`,
+        defaultBranch: "main",
+        private: true,
+      };
+    });
+
+    (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/repos")) {
+          return new Response(JSON.stringify({ repos }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    );
+
+    const ctx = makeCtx();
+    const response = await app.fetch(request, env, ctx);
+
+    expect(response.status).toBe(200);
+    expect(ctx.waitUntil).not.toHaveBeenCalled();
+
+    const body = (await response.json()) as {
+      options: Array<{ text: { type: string; text: string }; value: string }>;
+    };
+    // Old behavior capped this at 5; new behavior shows the full list up to
+    // Slack's per-response ceiling.
+    expect(body.options).toHaveLength(100);
+    expect(body.options[0]).toEqual({
+      text: { type: "plain_text", text: "repo-001" },
+      description: { type: "plain_text", text: "repo-001" },
+      value: "acme/repo-001",
+    });
+  });
+
+  it("filters repo clarification suggestions by the typed query", async () => {
+    const payload = {
+      type: "block_suggestion",
+      action_id: "select_repo",
+      user: { id: "U123" },
+      value: "repo-150",
+    };
+
+    const request = new Request("http://localhost/interactions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "x-slack-signature": "v0=test",
+        "x-slack-request-timestamp": `${Math.floor(Date.now() / 1000)}`,
+      },
+      body: new URLSearchParams({ payload: JSON.stringify(payload) }),
+    });
+
+    const env = makeEnv();
+    const repos = Array.from({ length: 150 }, (_, idx) => {
+      const number = String(idx + 1).padStart(3, "0");
+      return {
+        id: `acme/repo-${number}`,
+        owner: "acme",
+        name: `repo-${number}`,
+        fullName: `acme/repo-${number}`,
+        defaultBranch: "main",
+        private: true,
+      };
+    });
+
+    (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/repos")) {
+          return new Response(JSON.stringify({ repos }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    );
+
+    const ctx = makeCtx();
+    const response = await app.fetch(request, env, ctx);
+
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      options: Array<{ text: { type: string; text: string }; value: string }>;
+    };
+    expect(body.options).toEqual([
+      {
+        text: { type: "plain_text", text: "repo-150" },
+        description: { type: "plain_text", text: "repo-150" },
+        value: "acme/repo-150",
+      },
+    ]);
+  });
 });

--- a/packages/slack-bot/src/index.ts
+++ b/packages/slack-bot/src/index.ts
@@ -33,11 +33,41 @@ import { createKvCacheStore } from "@open-inspect/shared";
 import { getUserRepoBranchPreference } from "./branch-preferences";
 import { setAssistantThreadStatusBestEffort } from "./activity-status";
 import { handleAppHomeInteractionRoute, publishAppHome } from "./app-home";
+import { MAX_REPO_SUGGESTION_OPTIONS } from "./app-home/constants";
 import { getResolvedUserPreferences } from "./user-preferences";
 
 const log = createLogger("handler");
 
 type BackgroundTaskScheduler = (promise: Promise<void>) => void;
+
+/**
+ * Action ID for the repository picker shown when the classifier can't decide
+ * which repo a message refers to. The picker is an external_select, so the same
+ * ID is matched both for option suggestions (block_suggestion) and selection
+ * (block_actions).
+ */
+const SELECT_REPO_ACTION_ID = "select_repo";
+
+/**
+ * Repo options for the clarification picker's external_select. Slack queries
+ * this endpoint as the user types; we filter on the repo's full name and cap
+ * the count at Slack's per-response limit. With min_query_length 0 the
+ * unfiltered list shows as soon as the menu opens, and typing surfaces any of
+ * the remaining repos — so users are no longer limited to a fixed handful.
+ */
+async function getRepoClarificationOptions(env: Env, query: string | undefined, traceId?: string) {
+  const repos = await getAvailableRepos(env, traceId);
+  const normalizedQuery = query?.trim().toLowerCase();
+  const filtered = normalizedQuery
+    ? repos.filter((repo) => repo.fullName.toLowerCase().includes(normalizedQuery))
+    : repos;
+
+  return filtered.slice(0, MAX_REPO_SUGGESTION_OPTIONS).map((repo) => ({
+    text: { type: "plain_text" as const, text: repo.displayName },
+    description: { type: "plain_text" as const, text: repo.description.slice(0, 75) },
+    value: repo.id,
+  }));
+}
 
 /**
  * Build authenticated headers for control plane requests.
@@ -606,6 +636,20 @@ app.post("/interactions", async (c) => {
   }
 
   if (payload.type === "block_suggestion") {
+    if (payload.action_id === SELECT_REPO_ACTION_ID) {
+      const options = await getRepoClarificationOptions(c.env, payload.value, traceId);
+      log.info("http.request", {
+        trace_id: traceId,
+        http_method: "POST",
+        http_path: "/interactions",
+        http_status: 200,
+        interaction_type: payload.type,
+        action_id: payload.action_id,
+        option_count: options.length,
+        duration_ms: Date.now() - startTime,
+      });
+      return c.json({ options });
+    }
     return c.json({ options: [] });
   }
 
@@ -875,19 +919,6 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
       { expirationTtl: 3600 } // Expire after 1 hour
     );
 
-    // Build repo selection message
-    const repoOptions = (result.alternatives || repos.slice(0, 5)).map((r) => ({
-      text: {
-        type: "plain_text" as const,
-        text: r.displayName,
-      },
-      description: {
-        type: "plain_text" as const,
-        text: r.description.slice(0, 75),
-      },
-      value: r.id,
-    }));
-
     await postMessage(
       env.SLACK_BOT_TOKEN,
       channel,
@@ -909,13 +940,14 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
               text: "Which repository should I work with?",
             },
             accessory: {
-              type: "static_select",
+              type: "external_select",
               placeholder: {
                 type: "plain_text",
                 text: "Select a repository",
               },
-              options: repoOptions,
-              action_id: "select_repo",
+              // 0 so the list appears on open; typing filters across all repos.
+              min_query_length: 0,
+              action_id: SELECT_REPO_ACTION_ID,
             },
           },
         ],
@@ -1189,7 +1221,7 @@ async function handleSlackInteraction(
   const threadTs = payload.message?.thread_ts;
 
   switch (action.action_id) {
-    case "select_repo": {
+    case SELECT_REPO_ACTION_ID: {
       if (!channel || !messageTs) return;
       const repoId = action.selected_option?.value;
       if (repoId) {

--- a/packages/slack-bot/src/index.ts
+++ b/packages/slack-bot/src/index.ts
@@ -637,7 +637,19 @@ app.post("/interactions", async (c) => {
 
   if (payload.type === "block_suggestion") {
     if (payload.action_id === SELECT_REPO_ACTION_ID) {
-      const options = await getRepoClarificationOptions(c.env, payload.value, traceId);
+      let options: Awaited<ReturnType<typeof getRepoClarificationOptions>> = [];
+      try {
+        options = await getRepoClarificationOptions(c.env, payload.value, traceId);
+      } catch (e) {
+        // Don't let a lookup failure surface as a 500 on /interactions — return
+        // an empty suggestions payload so Slack just shows no matches.
+        log.error("slack.repo_clarification_options", {
+          trace_id: traceId,
+          query: payload.value,
+          error: e instanceof Error ? e : new Error(String(e)),
+          duration_ms: Date.now() - startTime,
+        });
+      }
       log.info("http.request", {
         trace_id: traceId,
         http_method: "POST",


### PR DESCRIPTION
## Problem

When the Slack bot can't determine which repository a message refers to, it posts a "Which repository should I work with?" picker. That picker was a `static_select` built from `repos.slice(0, 5)` — capped at **5 repos**. Worse, when the LLM classifier returned `alternatives`, the menu showed **only** those alternatives, so any other repo was unreachable. Users with more than a handful of repos couldn't select the one they wanted.

## Change

Replace the capped `static_select` with a searchable `external_select`, mirroring the existing App Home branch-override picker:

- The full repo list shows as soon as the menu opens (`min_query_length: 0`).
- Typing filters across **every** repo by full name.
- Results are capped at Slack's per-response ceiling (`MAX_REPO_SUGGESTION_OPTIONS = 100`), consistent with the App Home picker — so it scales past 100 repos via search.
- A new `block_suggestion` handler serves the options for the `select_repo` action; selection still flows through the existing `handleRepoSelection`, unchanged.
- Dropped the now-unused `repos.slice(0, 5)` fallback in the classifier's error path (there's no basis to suggest specific repos on a classification failure, and the picker now lets the user search the full list).

The classifier's `reasoning` is still shown in the message, so the bot's intent remains visible.

## Testing

- `npm run typecheck -w @open-inspect/slack-bot` ✅
- `npm test -w @open-inspect/slack-bot` ✅ (93 tests)
- `npm run lint -w @open-inspect/slack-bot` ✅

New tests cover the searchable picker returning the full list (capped at 100, well beyond the old 5) and filtering by the typed query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Searchable repository picker in Slack clarification flows: users can type to filter and select from up to 100 repo options in real time.

* **Bug Fixes**
  * Removed unreliable repo suggestions from error responses when classification fails; clarifications now avoid presenting unsupported recommendations.

* **Tests**
  * Added tests verifying large-option handling and query-based filtering for the Slack repo picker, and updated expectations for failure responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->