### PR TITLE
fix(sandbox): recover sessions stuck in spawning/connecting

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/decisions.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.test.ts
@@ -133,6 +133,7 @@ describe("evaluateSpawnDecision", () => {
   const config: SpawnConfig = {
     cooldownMs: 30000,
     readyWaitMs: 60000,
+    spawningTimeoutMs: 120000,
   };
 
   it('returns "restore" when snapshot exists and sandbox is stopped', () => {
@@ -207,6 +208,48 @@ describe("evaluateSpawnDecision", () => {
     };
 
     const decision = evaluateSpawnDecision(state, config, now, false);
+
+    expect(decision.action).toBe("skip");
+  });
+
+  it('returns "spawn" when stuck in "spawning" past the spawning timeout (recovers interrupted spawn)', () => {
+    const now = Date.now();
+    const state: SandboxState = {
+      status: "spawning",
+      createdAt: now - (config.spawningTimeoutMs + 1000),
+      snapshotImageId: null,
+      hasActiveWebSocket: false,
+    };
+
+    const decision = evaluateSpawnDecision(state, config, now, false);
+
+    expect(decision.action).toBe("spawn");
+  });
+
+  it('returns "spawn" when stuck in "connecting" past the spawning timeout', () => {
+    const now = Date.now();
+    const state: SandboxState = {
+      status: "connecting",
+      createdAt: now - (config.spawningTimeoutMs + 1000),
+      snapshotImageId: null,
+      hasActiveWebSocket: false,
+    };
+
+    const decision = evaluateSpawnDecision(state, config, now, false);
+
+    expect(decision.action).toBe("spawn");
+  });
+
+  it('still skips a stale "spawning" when a spawn is in progress in-memory', () => {
+    const now = Date.now();
+    const state: SandboxState = {
+      status: "spawning",
+      createdAt: now - (config.spawningTimeoutMs + 1000),
+      snapshotImageId: null,
+      hasActiveWebSocket: false,
+    };
+
+    const decision = evaluateSpawnDecision(state, config, now, true);
 
     expect(decision.action).toBe("skip");
   });
@@ -722,19 +765,28 @@ describe("evaluateConnectingTimeout", () => {
     expect(result.elapsedMs).toBe(config.timeoutMs);
   });
 
-  it("ignores all non-connecting statuses", () => {
+  it("returns timed out when stuck in spawning past timeout (interrupted spawn)", () => {
+    const now = Date.now();
+    const createdAt = now - 130_000; // 130s ago, past 120s timeout
+
+    const result = evaluateConnectingTimeout("spawning", createdAt, config, now);
+
+    expect(result.isTimedOut).toBe(true);
+    expect(result.elapsedMs).toBe(130_000);
+  });
+
+  it("returns not timed out for spawning within timeout window", () => {
+    const now = Date.now();
+    const result = evaluateConnectingTimeout("spawning", now - 60_000, config, now);
+
+    expect(result.isTimedOut).toBe(false);
+  });
+
+  it("ignores all non-spawning/connecting statuses", () => {
     const now = Date.now();
     const old = now - 999_999;
 
-    for (const status of [
-      "pending",
-      "spawning",
-      "ready",
-      "running",
-      "stopped",
-      "failed",
-      "stale",
-    ] as const) {
+    for (const status of ["pending", "ready", "running", "stopped", "failed", "stale"] as const) {
       const result = evaluateConnectingTimeout(status, old, config, now);
       expect(result.isTimedOut).toBe(false);
     }

--- a/packages/control-plane/src/sandbox/lifecycle/decisions.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.ts
@@ -133,6 +133,17 @@ export interface SpawnConfig {
   cooldownMs: number;
   /** Time to wait for WebSocket after spawn (default: 60s) */
   readyWaitMs: number;
+  /**
+   * Max time a sandbox may remain in "spawning"/"connecting" before it is
+   * treated as dead and a fresh spawn is allowed (default: 120s).
+   *
+   * Guards against spawns interrupted before the sandbox connects (provider
+   * crash, redeploy, cancelled provider call). Such a spawn can leave the
+   * persisted status pinned at "spawning"/"connecting" indefinitely — the
+   * connecting-timeout alarm may never have been scheduled — which otherwise
+   * makes every later spawn attempt skip with "already spawning" forever.
+   */
+  spawningTimeoutMs: number;
 }
 
 /**
@@ -141,6 +152,7 @@ export interface SpawnConfig {
 export const DEFAULT_SPAWN_CONFIG: SpawnConfig = {
   cooldownMs: 30000, // 30 seconds
   readyWaitMs: 60000, // 60 seconds
+  spawningTimeoutMs: 120000, // 2 minutes — matches the connecting-timeout watchdog
 };
 
 /**
@@ -210,8 +222,16 @@ export function evaluateSpawnDecision(
     return { action: "restore", snapshotImageId: state.snapshotImageId };
   }
 
-  // Don't spawn if already spawning or connecting (persisted status)
-  if (state.status === "spawning" || state.status === "connecting") {
+  // Don't spawn if a spawn/connect is genuinely in progress (persisted status).
+  // But a spawn interrupted before the sandbox connects (provider crash,
+  // redeploy, cancelled provider call) can pin the status at "spawning"/
+  // "connecting" forever — the connecting-timeout alarm may never have been
+  // scheduled. Treat a stale spawn/connect as dead so a fresh spawn can recover
+  // the session, instead of skipping indefinitely.
+  if (
+    (state.status === "spawning" || state.status === "connecting") &&
+    timeSinceLastSpawn < config.spawningTimeoutMs
+  ) {
     return { action: "skip", reason: `already ${state.status}` };
   }
 
@@ -474,14 +494,18 @@ export interface ConnectingTimeoutResult {
  * (crash, network failure, etc.), this function detects the timeout so the
  * alarm handler can fail the sandbox.
  *
+ * Covers both "connecting" and "spawning": a spawn that is interrupted before
+ * the provider call returns leaves the status at "spawning" (the transition to
+ * "connecting" never happens), so the timeout must apply there too.
+ *
  * Pure function: no side effects. Safe to call for any status — returns
- * `isTimedOut: false` for non-connecting sandboxes.
+ * `isTimedOut: false` for sandboxes that are not spawning/connecting.
  *
  * @param status - Current sandbox status
  * @param createdAt - Timestamp (ms) when the sandbox was spawned
  * @param config - Connecting timeout configuration
  * @param now - Current timestamp (ms)
- * @returns Whether the sandbox has timed out and how long it's been connecting
+ * @returns Whether the sandbox has timed out and how long it's been spawning/connecting
  */
 export function evaluateConnectingTimeout(
   status: SandboxStatus,
@@ -489,7 +513,7 @@ export function evaluateConnectingTimeout(
   config: ConnectingTimeoutConfig,
   now: number
 ): ConnectingTimeoutResult {
-  if (status !== "connecting") {
+  if (status !== "connecting" && status !== "spawning") {
     return { isTimedOut: false, elapsedMs: 0 };
   }
 


### PR DESCRIPTION
## Summary

A sandbox spawn that is interrupted **before the sandbox connects** — provider crash, redeploy draining in-flight tasks, or a cancelled provider `createSandbox()` call — can leave the persisted sandbox status pinned at `spawning` (or `connecting`) **indefinitely**, permanently wedging the session:

- The connecting-timeout watchdog alarm is only scheduled **after** `createSandbox()` returns, so for an interrupted spawn it is never scheduled and never fires.
- Even if an alarm did fire, `evaluateConnectingTimeout` only times out `connecting`, not `spawning`.
- `evaluateSpawnDecision` then skips every subsequent attempt with `already spawning`/`already connecting`.

Net effect: prompts queue but never dispatch (`no_sandbox`), and re-triggering the session keeps skipping forever. We hit this in production when a deploy redeployed the sandbox provider mid-spawn.

This closes the two gaps so the session self-heals:

- **`evaluateSpawnDecision`**: only skip a `spawning`/`connecting` sandbox while it is *recent* (`< spawningTimeoutMs`). A stale spawn/connect is treated as dead and a fresh spawn is allowed — so the session recovers on the next prompt. The in-memory same-request guard is still honoured.
- **`evaluateConnectingTimeout`**: also time out `spawning`, not just `connecting`, so the watchdog alarm recovers a stuck spawn when it does fire.
- Adds `SpawnConfig.spawningTimeoutMs` (default `120000`, matching the connecting timeout).

Both are pure functions; no behavioural change for healthy spawns (a spawn within the window still skips as before).

## Test plan

- [x] `vitest run decisions.test.ts` — added regression tests: stale `spawning`/`connecting` → `spawn`; stale `spawning` with in-memory spawn in progress → still `skip`; `evaluateConnectingTimeout` times out `spawning` past the window and ignores it within the window.
- [x] `vitest run manager.test.ts` — existing lifecycle tests pass (uses `DEFAULT_SPAWN_CONFIG`).
- [x] `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced spawning timeout configuration to sandbox lifecycle management with a 2-minute default threshold.

* **Bug Fixes**
  * Enhanced timeout logic to properly handle sandboxes stuck in spawning or connecting states, enabling recovery attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->