### PR TITLE
fix(web): respect NEXT_PUBLIC_APP_NAME in Slack settings copy

### DIFF
--- a/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
@@ -13,6 +13,7 @@ import {
 } from "@open-inspect/shared";
 import { IntegrationSettingsSkeleton } from "./integration-settings-skeleton";
 import { Button } from "@/components/ui/button";
+import { APP_NAME } from "@/lib/site-config";
 import { RadioCard } from "@/components/ui/form-controls";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -100,10 +101,10 @@ export function SlackIntegrationSettings() {
 
       <Section
         title="Channel access"
-        description="Open-Inspect does not maintain its own channel allowlist."
+        description={`${APP_NAME} does not maintain its own channel allowlist.`}
       >
         <p className="text-sm text-muted-foreground">
-          To make a channel available to agents, invite the Open-Inspect Slack bot to a channel in
+          To make a channel available to agents, invite the {APP_NAME} Slack bot to a channel in
           Slack. The bot can post only to channels it&apos;s a member of; remove access by kicking
           the bot from the channel.
         </p>

--- a/packages/web/src/components/slack-notify-event.tsx
+++ b/packages/web/src/components/slack-notify-event.tsx
@@ -9,6 +9,7 @@ import {
 import type { SandboxEvent } from "@/types/session";
 import { formatSessionEventTime } from "@/lib/time";
 import { getSafeExternalUrl } from "@/lib/urls";
+import { APP_NAME } from "@/lib/site-config";
 import { ChevronRightIcon, ErrorIcon, LinkIcon, SlackIcon } from "@/components/ui/icons";
 
 type ToolCallEvent = Extract<SandboxEvent, { type: "tool_call" }>;
@@ -26,7 +27,7 @@ const DENIAL_COPY: Record<SlackDenialReason, { headline: string; hint?: string }
   },
   channel_not_found_or_forbidden: {
     headline: "Channel not found or bot is not in the channel.",
-    hint: "Invite the Open-Inspect bot to the channel and try again.",
+    hint: `Invite the ${APP_NAME} bot to the channel and try again.`,
   },
   rate_limited: {
     headline: "Slack rate-limited the request.",


### PR DESCRIPTION
## Summary

The Slack integration settings page and the slack-notify denial hint hardcoded `"Open-Inspect"` instead of using the configurable `APP_NAME`. This defeated the `NEXT_PUBLIC_APP_NAME` whitelabel variable for those strings — white-labeled deployments still showed "Open-Inspect" in:

- the **Channel access** section description,
- the bot-invite instructions, and
- the `channel_not_found_or_forbidden` error hint.

This wires all three strings to `APP_NAME` from `site-config`, matching how the page title, sidebar, and welcome screen already resolve the app name.

## Test plan

- [ ] With `NEXT_PUBLIC_APP_NAME` unset, Slack settings still read "Open-Inspect" (default fallback preserved).
- [ ] With `NEXT_PUBLIC_APP_NAME=Acme`, the Channel access copy, bot-invite text, and channel-not-found hint all read "Acme".
- [ ] `tsc` and `eslint` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Slack integration and notification settings to dynamically reference the correct app name in channel access descriptions and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->