### PR TITLE
chore: lint sandbox-runtime python in pre-commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
     "packages/modal-infra/**/*.py": [
       "ruff check --fix",
       "ruff format"
+    ],
+    "packages/sandbox-runtime/**/*.py": [
+      "ruff check --fix",
+      "ruff format"
     ]
   }
 }


### PR DESCRIPTION
## Summary
Adds `packages/sandbox-runtime/**/*.py` to the root `lint-staged` config so its Python is ruff-checked/formatted on pre-commit, mirroring the existing `packages/modal-infra/**/*.py` entry.

## Why
`sandbox-runtime` is already linted in CI (`ruff check src/ tests/`), but — unlike `modal-infra` — its Python wasn't covered by the pre-commit hook, so ruff issues only surfaced in CI rather than locally on commit. This makes pre-commit coverage consistent across both Python packages.

## Notes
- No functional change; `sandbox-runtime` is already ruff-clean.
- Verified locally: `prettier --check package.json` clean; `ruff check` / `ruff format --check` clean on `packages/sandbox-runtime`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality tooling configuration to cover additional Python modules during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->