### PR TITLE
fix: include mcp_servers in Daytona SESSION_CONFIG

### DIFF
--- a/packages/control-plane/src/sandbox/providers/daytona-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/daytona-provider.test.ts
@@ -200,6 +200,22 @@ describe("DaytonaSandboxProvider", () => {
       expect(sessionConfig.branch).toBe("feature/test");
     });
 
+    it("includes mcp_servers in SESSION_CONFIG when provided", async () => {
+      const client = createMockClient();
+      const provider = new DaytonaSandboxProvider(client, defaultProviderConfig);
+
+      await provider.createSandbox({
+        ...baseCreateConfig,
+        mcpServers: [{ id: "mcp-1", name: "Tool", type: "local", enabled: true }],
+      });
+
+      const envVars = (client.createSandbox as ReturnType<typeof vi.fn>).mock.calls[0][0].env;
+      const sessionConfig = JSON.parse(envVars.SESSION_CONFIG);
+      expect(sessionConfig.mcp_servers).toEqual([
+        { id: "mcp-1", name: "Tool", type: "local", enabled: true },
+      ]);
+    });
+
     it("includes user env vars (repo secrets) with system vars taking precedence", async () => {
       const client = createMockClient();
       const provider = new DaytonaSandboxProvider(client, defaultProviderConfig);

--- a/packages/control-plane/src/sandbox/providers/daytona-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/daytona-provider.ts
@@ -194,12 +194,13 @@ export class DaytonaSandboxProvider implements SandboxProvider {
     // Start with user env vars (repo secrets), then overlay system vars
     const envVars: Record<string, string> = { ...(config.userEnvVars ?? {}) };
 
-    const sessionConfig: Record<string, string> = {
+    const sessionConfig: Record<string, unknown> = {
       session_id: config.sessionId,
       repo_owner: config.repoOwner,
       repo_name: config.repoName,
       provider: config.provider,
       model: config.model,
+      mcp_servers: config.mcpServers,
     };
     if (config.branch) {
       sessionConfig.branch = config.branch;


### PR DESCRIPTION
## Summary

Fixes a latent correctness bug where **MCP servers never reached Daytona sandboxes**. This was identified as finding **V4** in `docs/internal/2026-06-07-vercel-sandbox-provider-post-merge-review.md` (the Vercel provider post-merge review).

## Root cause

The shared sandbox runtime reads MCP config from `SESSION_CONFIG.mcp_servers` (`packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py` — `self.session_config.get("mcp_servers") or []`). Every provider hand-rolls its own `SESSION_CONFIG`, and the Daytona provider's `buildEnvVars` typed `sessionConfig` as `Record<string, string>` and never wrote `config.mcpServers`:

- The `Record<string, string>` type **structurally prevented** adding the `McpServerConfig[]` value (an object array, not a string), so the omission couldn't even be fixed in place.
- The data was fully available — it flows D1 → `McpServerStore.getDecryptedForSession()` → `lifecycle/manager.ts` `loadMcpServers()` → `CreateSandboxConfig.mcpServers` — and was then silently dropped.
- Downstream the absence is **silent**: missing key → `[]` → the `if mcp_servers:` block in `start_opencode()` is skipped → OpenCode starts with no MCP tools. No error, no warning, no log.

Vercel (`vercel-provider.ts`, `Record<string, unknown>` + `mcp_servers: config.mcpServers`) and Modal (Pydantic `SessionConfig` model) already include it correctly — Daytona was the only provider dropping it.

## Fix

In `daytona-provider.ts` `buildEnvVars`, widen the `sessionConfig` type to `Record<string, unknown>` and add `mcp_servers: config.mcpServers`, mirroring the Vercel provider. When no MCP servers are configured, `config.mcpServers` is `undefined` and `JSON.stringify` omits the key — so the serialized output is unchanged for the no-MCP case.

Scope is intentionally minimal: `buildEnvVars` is called only by `createSandbox`; `resumeSandbox` reuses the already-running persistent sandbox (`supportsRestore: false`), so this is the single fix point.

## Testing (TDD)

- **RED:** Added `includes mcp_servers in SESSION_CONFIG when provided` to `daytona-provider.test.ts` (mirroring the existing Vercel assertion). Confirmed it failed against the unpatched provider (`sessionConfig.mcp_servers` was `undefined`).
- **GREEN:** Applied the fix; the new test passes and the full Daytona suite stays green (28/28). The existing `SESSION_CONFIG` `toEqual` baseline test still passes (undefined `mcpServers` is omitted by `JSON.stringify`).
- Full monorepo unit suite (2018 tests), `tsc --noEmit`, ESLint, and Prettier all pass.

## Notes

This ships as the standalone bug-fix recommended by the review's suggested sequencing (step 1), independent of the larger V1/V2 refactors. The deeper remedy — a shared `sandbox/sandbox-env.ts` `buildSessionConfig()` so providers stop hand-rolling `SESSION_CONFIG` (which is what allowed this drift) — is tracked separately in the review (V4/V6) and intentionally out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring MCP (Model Context Protocol) servers within sandbox environments, enabling integration of external tools and services.

* **Tests**
  * Added test coverage to ensure MCP server configuration is properly applied during sandbox initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->