### PR TITLE
chore: update setup-uv action for Node 24

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -297,7 +297,7 @@ jobs:
           npm run build -w @open-inspect/linear-bot
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.2.0
 
       - name: Install Modal and Python dependencies
         run: uv sync --frozen


### PR DESCRIPTION
## Summary
- Updates `astral-sh/setup-uv` from `v6` to `v8.2.0` in the Terraform apply workflow.
- Resolves the GitHub Actions warning for JavaScript actions running on deprecated Node.js 20.

## Testing
- Not run; workflow action version-only change.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/79f95b18210c9f3d91153ae004182c63)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow tooling dependencies to newer versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->