### PR TITLE
fix(deps): bump hono to 4.12.23 (4 security advisories)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11404,9 +11404,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary

Bumps **hono** `4.12.18 → 4.12.23` (lockfile-only) to patch 4 Dependabot security advisories. hono is a direct dependency of `slack-bot`, `github-bot`, and `linear-bot`, all hoisted to a single `node_modules/hono` entry.

The declared ranges (`^4.12.18`) already permit `4.12.23`, so **only `package-lock.json` changes** — no manifest edits, no transitive churn. This mirrors how Dependabot performs a range-satisfiable security update. hono is zero-dependency, so no sub-tree changes are required.

## Advisories resolved

| Alert | Severity | GHSA | Issue |
|---|---|---|---|
| #118 | medium | GHSA-2gcr-mfcq-wcc3 | `app.mount()` strips mount prefix using undecoded path → wrong routing for percent-encoded paths |
| #117 | medium | GHSA-xrhx-7g5j-rcj5 | IP Restriction bypasses static deny rules for non-canonical IPv6 |
| #116 | medium | GHSA-3hrh-pfw6-9m5x | Cookie helper does not sanitize `sameSite`/`priority` → Set-Cookie injection |
| #115 | medium | GHSA-f577-qrjj-4474 | JWT middleware accepts any Authorization scheme, not only Bearer |

First patched version: `4.12.21`. Resolved to latest `4.x` (`4.12.23`).

## Verification

- `package-lock.json` remains valid JSON; diff is exactly the 3 hono fields (version/resolved/integrity).
- Integrity hash taken directly from the npm registry for `4.12.23`.
- CI (`npm ci` + typecheck + test + build across all packages) validates the bump end-to-end.

## Scope

One advisory-group per PR, as requested. Other open alerts (vitest critical = separate PR; uuid/postcss/Pygments = transitive, skipped) are tracked separately.