### PR TITLE
Cap Vercel sandbox timeout

### DIFF
--- a/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
@@ -207,6 +207,42 @@ describe("VercelSandboxProvider", () => {
     );
   });
 
+  it("caps the default sandbox timeout at Vercel's 45 minute limit", async () => {
+    const client = createMockClient();
+    const provider = new VercelSandboxProvider(client, providerConfig);
+
+    await provider.createSandbox(baseCreateConfig);
+
+    expect(vi.mocked(client.createSandbox).mock.calls[0][0].timeoutMs).toBe(45 * 60 * 1000);
+  });
+
+  it("keeps explicit Vercel sandbox timeouts below the provider limit", async () => {
+    const client = createMockClient();
+    const provider = new VercelSandboxProvider(client, providerConfig);
+
+    await provider.createSandbox({ ...baseCreateConfig, timeoutSeconds: 30 * 60 });
+
+    expect(vi.mocked(client.createSandbox).mock.calls[0][0].timeoutMs).toBe(30 * 60 * 1000);
+  });
+
+  it("caps explicit Vercel sandbox timeouts above the provider limit", async () => {
+    const client = createMockClient();
+    const provider = new VercelSandboxProvider(client, providerConfig);
+
+    await provider.createSandbox({ ...baseCreateConfig, timeoutSeconds: 60 * 60 });
+
+    expect(vi.mocked(client.createSandbox).mock.calls[0][0].timeoutMs).toBe(45 * 60 * 1000);
+  });
+
+  it("caps restore timeouts at Vercel's 45 minute limit", async () => {
+    const client = createMockClient();
+    const provider = new VercelSandboxProvider(client, providerConfig);
+
+    await provider.restoreFromSnapshot(baseRestoreConfig);
+
+    expect(vi.mocked(client.createSandbox).mock.calls[0][0].timeoutMs).toBe(45 * 60 * 1000);
+  });
+
   it("resolves a configured base snapshot name before creating a fresh sandbox", async () => {
     const client = createMockClient();
     const provider = new VercelSandboxProvider(client, {

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
@@ -116,6 +116,9 @@ const baseRestoreConfig: RestoreConfig = {
   model: "anthropic/claude-sonnet-4-5",
 };
 
+// Mirrors VERCEL_MAX_SANDBOX_TIMEOUT_MS in provider.ts — Vercel rejects timeouts above 45 minutes.
+const VERCEL_MAX_SANDBOX_TIMEOUT_MS = 45 * 60 * 1000;
+
 describe("VercelSandboxProvider", () => {
   it("reports Vercel capabilities", () => {
     const provider = new VercelSandboxProvider(createMockClient(), providerConfig);
@@ -213,7 +216,9 @@ describe("VercelSandboxProvider", () => {
 
     await provider.createSandbox(baseCreateConfig);
 
-    expect(vi.mocked(client.createSandbox).mock.calls[0][0].timeoutMs).toBe(45 * 60 * 1000);
+    expect(vi.mocked(client.createSandbox).mock.calls[0][0].timeoutMs).toBe(
+      VERCEL_MAX_SANDBOX_TIMEOUT_MS
+    );
   });
 
   it("keeps explicit Vercel sandbox timeouts below the provider limit", async () => {
@@ -231,7 +236,9 @@ describe("VercelSandboxProvider", () => {
 
     await provider.createSandbox({ ...baseCreateConfig, timeoutSeconds: 60 * 60 });
 
-    expect(vi.mocked(client.createSandbox).mock.calls[0][0].timeoutMs).toBe(45 * 60 * 1000);
+    expect(vi.mocked(client.createSandbox).mock.calls[0][0].timeoutMs).toBe(
+      VERCEL_MAX_SANDBOX_TIMEOUT_MS
+    );
   });
 
   it("caps restore timeouts at Vercel's 45 minute limit", async () => {
@@ -240,7 +247,9 @@ describe("VercelSandboxProvider", () => {
 
     await provider.restoreFromSnapshot(baseRestoreConfig);
 
-    expect(vi.mocked(client.createSandbox).mock.calls[0][0].timeoutMs).toBe(45 * 60 * 1000);
+    expect(vi.mocked(client.createSandbox).mock.calls[0][0].timeoutMs).toBe(
+      VERCEL_MAX_SANDBOX_TIMEOUT_MS
+    );
   });
 
   it("resolves a configured base snapshot name before creating a fresh sandbox", async () => {

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.ts
@@ -38,6 +38,7 @@ const TUNNEL_ENV_FILE_PATH = "/workspace/.tunnels.env";
 const EXPECTED_TUNNEL_PORTS_ENV_VAR = "EXPECTED_TUNNEL_PORTS";
 const DEFAULT_SNAPSHOT_EXPIRATION_MS = 0;
 const BUILD_TIMEOUT_SECONDS = 1800;
+const VERCEL_MAX_SANDBOX_TIMEOUT_MS = 45 * 60 * 1000;
 const VERCEL_TUNNEL_ENV_WRITE_TIMEOUT_MS = 30_000;
 const REPO_IMAGE_CALLBACK_ENV_KEYS = [
   "OI_REPO_IMAGE_PROVIDER_SESSION_ID",
@@ -49,6 +50,11 @@ const RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS = [
   ...REPO_IMAGE_CALLBACK_ENV_KEYS,
   "OI_REPO_IMAGE_CALLBACK_SECRET",
 ] as const;
+
+function resolveVercelTimeoutMs(timeoutSeconds?: number): number {
+  const requestedMs = (timeoutSeconds ?? DEFAULT_SANDBOX_TIMEOUT_SECONDS) * 1000;
+  return Math.min(requestedMs, VERCEL_MAX_SANDBOX_TIMEOUT_MS);
+}
 
 export interface VercelProviderConfig {
   scmProvider: SourceControlProviderName;
@@ -119,7 +125,7 @@ export class VercelSandboxProvider implements SandboxProvider {
         {
           name: config.sandboxId,
           runtime: this.providerConfig.runtime || DEFAULT_VERCEL_RUNTIME,
-          timeoutMs: (config.timeoutSeconds ?? DEFAULT_SANDBOX_TIMEOUT_SECONDS) * 1000,
+          timeoutMs: resolveVercelTimeoutMs(config.timeoutSeconds),
           ports,
           env,
           tags: this.buildTags(config),
@@ -165,7 +171,7 @@ export class VercelSandboxProvider implements SandboxProvider {
         {
           name: config.sandboxId,
           runtime: this.providerConfig.runtime || DEFAULT_VERCEL_RUNTIME,
-          timeoutMs: (config.timeoutSeconds ?? DEFAULT_SANDBOX_TIMEOUT_SECONDS) * 1000,
+          timeoutMs: resolveVercelTimeoutMs(config.timeoutSeconds),
           ports,
           env,
           tags: this.buildTags(config),


### PR DESCRIPTION
Hi

I was setting up open inspect with a Vercel sandbox. I found that during a brand new project setup the default timeout was 2 hours but Vercel's spec requires a timeout of less than or equal to 45 minutes. My sandboxes would fail to initialize as a result. I observed an error from my cloudflare worker's observability web app. Attached the error at the footer.

This change adds a custom cap to vercel so the max is 45 minutes rather than all other sandbox providers standard 2 hours.

This project is really cool. Thank you, Cole!

```
SandboxProviderError: Failed to create Vercel sandbox: Vercel Sandbox API error: 400 {"error":{"code":"bad_request","message":"`timeout` should be <= 45m"}}
    at _SandboxProviderError.fromFetchError (index.js:13763:14)
    at VercelSandboxProvider.classifyError (index.js:14191:35)
    at VercelSandboxProvider.createSandbox (index.js:13860:18)
    at async SandboxLifecycleManager.doSpawn (index.js:20913:22)
    at async SandboxLifecycleManager.spawnSandbox (index.js:20830:9)
    at async SandboxLifecycleManager.warmSandbox (index.js:21491:5)
    at async SessionDO.warmSandbox (index.js:26318:5)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox operations on Vercel now enforce a 45‑minute maximum timeout for create and restore actions. Explicit timeouts above the cap are reduced to the maximum; defaults are also bounded.

* **Tests**
  * Added unit tests validating default timeout capping, preserving lower explicit timeouts, capping higher explicit timeouts, and capping timeouts during restore-from-snapshot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->