### PR TITLE
Fail empty OpenCode prompt completions in bridge

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -625,13 +625,26 @@ class AgentBridge:
 
             had_error = False
             error_message = None
+            emitted_output = False
             async for event in self._stream_opencode_response_sse(
                 message_id, content, model, reasoning_effort
             ):
                 if event.get("type") == "error":
                     had_error = True
                     error_message = event.get("error")
+                elif event.get("type") in ("token", "tool_call", "step_finish"):
+                    emitted_output = True
                 await self._send_event(event)
+
+            if not had_error and not emitted_output:
+                had_error = True
+                error_message = "OpenCode completed without emitting assistant output."
+                self.log.error(
+                    "prompt.no_output",
+                    message_id=message_id,
+                    model=model,
+                    reasoning_effort=reasoning_effort,
+                )
 
             if had_error:
                 outcome = "error"
@@ -942,6 +955,7 @@ class AgentBridge:
         cumulative_text: dict[str, str] = {}
         emitted_tool_states: set[str] = set()
         allowed_assistant_msg_ids: set[str] = set()
+        user_message_ids: set[str] = {opencode_message_id}
         pending_parts: dict[str, list[tuple[dict[str, Any], Any]]] = {}
         pending_parts_total = 0
         pending_drop_logged = False
@@ -1114,7 +1128,16 @@ class AgentBridge:
                                         role = info.get("role", "")
                                         finish = info.get("finish", "")
 
-                                        parent_matches = parent_id == opencode_message_id
+                                        if role == "user" and oc_msg_id:
+                                            if oc_msg_id not in user_message_ids:
+                                                self.log.info(
+                                                    "bridge.user_message_id_discovered",
+                                                    expected_id=opencode_message_id,
+                                                    actual_id=oc_msg_id,
+                                                )
+                                            user_message_ids.add(oc_msg_id)
+
+                                        parent_matches = parent_id in user_message_ids
                                         is_compaction_summary = info.get("summary") is True
 
                                         self.log.debug(
@@ -1212,6 +1235,7 @@ class AgentBridge:
                                             opencode_message_id,
                                             cumulative_text,
                                             allowed_assistant_msg_ids,
+                                            user_message_ids=user_message_ids,
                                             compaction_occurred=compaction_occurred,
                                         ):
                                             yield final_event
@@ -1236,6 +1260,7 @@ class AgentBridge:
                                             opencode_message_id,
                                             cumulative_text,
                                             allowed_assistant_msg_ids,
+                                            user_message_ids=user_message_ids,
                                             compaction_occurred=compaction_occurred,
                                         ):
                                             yield final_event
@@ -1294,6 +1319,7 @@ class AgentBridge:
                                 opencode_message_id,
                                 cumulative_text,
                                 allowed_assistant_msg_ids,
+                                user_message_ids=user_message_ids,
                                 compaction_occurred=compaction_occurred,
                             ):
                                 yield final_event
@@ -1317,6 +1343,7 @@ class AgentBridge:
                 opencode_message_id,
                 cumulative_text,
                 allowed_assistant_msg_ids,
+                user_message_ids=user_message_ids,
                 compaction_occurred=compaction_occurred,
             ):
                 yield final_event
@@ -1335,6 +1362,7 @@ class AgentBridge:
         opencode_message_id: str,
         cumulative_text: dict[str, str],
         tracked_msg_ids: set[str] | None = None,
+        user_message_ids: set[str] | None = None,
         compaction_occurred: bool = False,
     ) -> AsyncIterator[dict[str, Any]]:
         """Fetch final message state from API to ensure complete text.
@@ -1383,7 +1411,8 @@ class AgentBridge:
                 if role != "assistant":
                     continue
 
-                parent_matches = parent_id == opencode_message_id
+                valid_parent_ids = user_message_ids or {opencode_message_id}
+                parent_matches = parent_id in valid_parent_ids
                 in_tracked_set = tracked_msg_ids and msg_id in tracked_msg_ids
                 is_compaction_summary = info.get("summary") is True
 

--- a/packages/sandbox-runtime/tests/test_bridge_sse.py
+++ b/packages/sandbox-runtime/tests/test_bridge_sse.py
@@ -311,6 +311,60 @@ class TestSSEStreaming:
         assert token_events[0]["content"] == "Hello"
 
     @pytest.mark.asyncio
+    async def test_tracks_actual_user_message_id_when_opencode_regenerates_it(
+        self, bridge: AgentBridge, opencode_message_id: str
+    ):
+        """Should accept assistant parts parented to OpenCode's actual user message ID."""
+        http_client = bridge.http_client
+        actual_user_message_id = "msg_actual_user"
+
+        http_client.sse_events = [
+            create_sse_event("server.connected", {}),
+            create_sse_event(
+                "message.updated",
+                {
+                    "info": {
+                        "id": actual_user_message_id,
+                        "role": "user",
+                        "sessionID": "oc-session-123",
+                    }
+                },
+            ),
+            create_sse_event(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "oc-msg-1",
+                        "role": "assistant",
+                        "sessionID": "oc-session-123",
+                        "parentID": actual_user_message_id,
+                    }
+                },
+            ),
+            create_sse_event(
+                "message.part.updated",
+                {
+                    "part": {
+                        "type": "text",
+                        "id": "part-1",
+                        "sessionID": "oc-session-123",
+                        "messageID": "oc-msg-1",
+                        "text": "Hello via actual parent",
+                    }
+                },
+            ),
+            create_sse_event("session.idle", {"sessionID": "oc-session-123"}),
+        ]
+
+        events = []
+        async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+            events.append(event)
+
+        token_events = [e for e in events if e["type"] == "token"]
+        assert len(token_events) == 1
+        assert token_events[0]["content"] == "Hello via actual parent"
+
+    @pytest.mark.asyncio
     async def test_tool_events(self, bridge: AgentBridge, opencode_message_id: str):
         """Should emit tool events correctly."""
         http_client = bridge.http_client
@@ -709,6 +763,32 @@ class TestSSEStreaming:
         # Event should have control plane's messageId
         assert events[0]["messageId"] == "cp-message-from-control-plane"
         assert events[0]["messageId"] != "oc-internal-msg-id"
+
+    @pytest.mark.asyncio
+    async def test_handle_prompt_fails_when_opencode_emits_no_output(self, bridge: AgentBridge):
+        """Should not report success when OpenCode idles without assistant output."""
+        bridge._configure_git_identity = AsyncMock()
+        bridge._send_event = AsyncMock()
+        http_client = bridge.http_client
+        http_client.sse_events = [
+            create_sse_event("server.connected", {}),
+            create_sse_event("session.idle", {"sessionID": "oc-session-123"}),
+        ]
+
+        await bridge._handle_prompt(
+            {
+                "messageId": "cp-msg-1",
+                "content": "Test prompt",
+                "model": "anthropic/claude-haiku-4-5",
+            }
+        )
+
+        sent_events = [call.args[0] for call in bridge._send_event.await_args_list]
+        complete = sent_events[-1]
+        assert complete["type"] == "execution_complete"
+        assert complete["messageId"] == "cp-msg-1"
+        assert complete["success"] is False
+        assert complete["error"] == "OpenCode completed without emitting assistant output."
 
 
 class TestFetchFinalMessageState:


### PR DESCRIPTION
## Summary

Fixes #718.

This hardens the sandbox bridge against OpenCode prompt completions that produce no assistant output, and against OpenCode regenerating the user message ID instead of preserving the `messageID` supplied to `prompt_async`.

Changes:

- Track actual OpenCode user message IDs from `message.updated` events where `role == "user"`.
- Accept assistant messages whose `parentID` matches either the generated bridge ID or an actual user message ID observed in the stream.
- Treat a prompt stream with no `token`, `tool_call`, or `step_finish` as a failed execution instead of reporting `execution_complete success=true`.
- Add regression coverage for regenerated user message IDs and empty prompt completions.

## Evidence

This was reproduced in a production Vercel-backed Open-Inspect deployment using OpenCode `1.14.41`.

Observed control-plane event sequence for the reproduced session:

```text
ready
user_message
execution_complete success=true
```

No `token` event was emitted, while the web app showed the sandbox as connected/ready and the prompt as complete.

Cloudflare logs showed the control plane dispatched the prompt successfully and the sandbox reported success. Vercel sandbox creation and the sandbox websocket were healthy, so the failure was inside the sandbox runtime/OpenCode bridge path.

Inspecting the saved OpenCode DB from the sandbox snapshot showed:

- OpenCode created a user message with its own generated ID, not the bridge-supplied `messageID`.
- OpenCode created an assistant message with `cost: 0` and all token counts at zero.
- The `part` table had only the user text part; there were no assistant text parts.

That explains why the bridge had nothing to forward, but the current `_handle_prompt` still sent a successful `execution_complete`: it only considered explicit `error` events as failures.

This is the failure mode called out as a follow-up in #630 / #567: silent or empty OpenCode streams should fail loudly rather than become successful no-reply prompts.

## Why this fix works

The bridge needs two independent guards:

1. Correlation should follow the actual OpenCode message graph. If OpenCode emits a user `message.updated` with a generated ID, assistant messages parented to that real user ID belong to the current prompt and should not be filtered out.
2. Completion success should require evidence of prompt output. If the stream reaches idle/return without any assistant token, tool call, or step finish, the UI should receive a failed `execution_complete` with a clear error.

This keeps the existing parent-based filtering for unrelated prompts, while making it robust to OpenCode regenerating the user message ID.

## Test plan

- [x] `python3 -m compileall packages/sandbox-runtime/src/sandbox_runtime/bridge.py`
- [x] `git diff --check`
- [ ] `python3 -m pytest packages/sandbox-runtime/tests/test_bridge_sse.py packages/sandbox-runtime/tests/test_bridge_message_tracking.py` could not be run in my local environment because the available Python is `3.9.6` and `pytest` is not installed. The package requires Python `>=3.12`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for prompts that produce no output—now properly reported as failures.
  * Enhanced message correlation in streaming mode to reliably track and link assistant responses to their source messages, especially when message IDs change during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->