### PR TITLE
refactor: simplify sandbox resource-settings helpers (#693 follow-up)

### DIFF
--- a/packages/control-plane/src/db/integration-settings.test.ts
+++ b/packages/control-plane/src/db/integration-settings.test.ts
@@ -754,6 +754,20 @@ describe("IntegrationSettingsStore", () => {
       ).rejects.toThrow(IntegrationSettingsValidationError);
     });
 
+    it("normalizes cross-field violations that only appear after merge", async () => {
+      // Each blob is individually valid — neither write throws — because the
+      // invariant (concurrent <= total) spans two fields set in different scopes.
+      // The violation only materializes in the merged result, so getResolvedConfig's
+      // normalize pass is the only thing that catches it. This pins that pass.
+      await store.setGlobal("sandbox", { defaults: { maxConcurrentChildSessions: 3 } });
+      await store.setRepoSettings("sandbox", "acme/app", { maxTotalChildSessions: 2 });
+
+      const config = await store.getResolvedConfig("sandbox", "acme/app");
+      // Merge would be { maxConcurrentChildSessions: 3, maxTotalChildSessions: 2 };
+      // the resolve-time normalize drops the inverted concurrent limit.
+      expect(config.settings).toEqual({ maxTotalChildSessions: 2 });
+    });
+
     it("round-trips fractional cpuCores and small memoryMib", async () => {
       await store.setRepoSettings("sandbox", "acme/app", { cpuCores: 0.5, memoryMib: 64 });
 

--- a/packages/web/src/components/settings/sandbox-settings.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.tsx
@@ -133,7 +133,12 @@ function SandboxSettingsEditor({
       DEFAULT_MAX_TOTAL_CHILD_SESSIONS);
 
   const currentCpuCores = resourceDisplayValue(isGlobal, globalDefaults, repoSettings, "cpuCores");
-  const currentMemoryMib = resourceDisplayValue(isGlobal, globalDefaults, repoSettings, "memoryMib");
+  const currentMemoryMib = resourceDisplayValue(
+    isGlobal,
+    globalDefaults,
+    repoSettings,
+    "memoryMib"
+  );
 
   const [portRows, setPortRows] = useState<string[] | null>(null);
   const [terminalEnabled, setTerminalEnabled] = useState<boolean | null>(null);
@@ -240,7 +245,12 @@ function SandboxSettingsEditor({
       }
       const cpu = resourcePayloadValue(isGlobal, cpuCores, trimmedCpu, repoSettings?.cpuCores);
       if (cpu !== undefined) settingsPayload.cpuCores = cpu;
-      const memory = resourcePayloadValue(isGlobal, memoryMib, trimmedMemory, repoSettings?.memoryMib);
+      const memory = resourcePayloadValue(
+        isGlobal,
+        memoryMib,
+        trimmedMemory,
+        repoSettings?.memoryMib
+      );
       if (memory !== undefined) settingsPayload.memoryMib = memory;
       const body = isGlobal
         ? { settings: { defaults: settingsPayload, enabledRepos: existingEnabledRepos } }

--- a/packages/web/src/components/settings/sandbox-settings.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.tsx
@@ -49,81 +49,38 @@ function isValidMemoryMib(value: string): boolean {
   return Number(value) >= 1;
 }
 
-function hasOwnResourceSetting(
-  settings: SandboxSettings | null | undefined,
-  field: ResourceField
-): boolean {
-  return !!settings && Object.prototype.hasOwnProperty.call(settings, field);
-}
+const numOrUndef = (v: number | null | undefined): number | undefined =>
+  typeof v === "number" ? v : undefined;
 
-function getResourceSetting(
-  settings: SandboxSettings | null | undefined,
-  field: ResourceField
-): number | null | undefined {
-  const value = settings?.[field];
-  return typeof value === "number" || value === null ? value : undefined;
-}
-
-function resolveResourceSetting(
+/** Value to show in the input: own repo override, else inherited global (display only). */
+function resourceDisplayValue(
   isGlobal: boolean,
   globalDefaults: SandboxSettings | undefined,
   repoSettings: SandboxSettings | null | undefined,
   field: ResourceField
-): {
-  displayValue: number | undefined;
-  repoHasOverride: boolean;
-  repoValue: number | null | undefined;
-} {
-  if (isGlobal) {
-    const globalValue = getResourceSetting(globalDefaults, field);
-    return {
-      displayValue: typeof globalValue === "number" ? globalValue : undefined,
-      repoHasOverride: false,
-      repoValue: undefined,
-    };
+): number | undefined {
+  if (!isGlobal) {
+    const own = repoSettings?.[field];
+    if (own !== undefined) return numOrUndef(own); // own override (null → blank)
   }
-
-  if (hasOwnResourceSetting(repoSettings, field)) {
-    const repoValue = getResourceSetting(repoSettings, field);
-    return {
-      displayValue: typeof repoValue === "number" ? repoValue : undefined,
-      repoHasOverride: true,
-      repoValue,
-    };
-  }
-
-  const inheritedValue = getResourceSetting(globalDefaults, field);
-  return {
-    displayValue: typeof inheritedValue === "number" ? inheritedValue : undefined,
-    repoHasOverride: false,
-    repoValue: undefined,
-  };
+  return numOrUndef(globalDefaults?.[field]);
 }
 
-function applyResourcePayload(
-  payload: SandboxSettings,
-  field: ResourceField,
-  trimmedValue: string,
-  editedValue: string | null,
+/**
+ * The value to persist for a resource field, or `undefined` to omit it from the
+ * payload (`null` means "use the provider default"). A stored JSON value is never
+ * `undefined`, so returning `prior` directly preserves an existing override and
+ * skips an inherited-only field in one move.
+ */
+function resourcePayloadValue(
   isGlobal: boolean,
-  repoHasOverride: boolean,
-  repoValue: number | null | undefined
-): void {
-  if (isGlobal) {
-    if (trimmedValue !== "") {
-      payload[field] = Number(trimmedValue);
-    }
-    return;
-  }
-
-  if (editedValue !== null) {
-    payload[field] = trimmedValue === "" ? null : Number(trimmedValue);
-    return;
-  }
-
-  if (repoHasOverride) {
-    payload[field] = repoValue ?? null;
-  }
+  editState: string | null,
+  trimmed: string,
+  prior: number | null | undefined
+): number | null | undefined {
+  if (isGlobal) return trimmed === "" ? undefined : Number(trimmed);
+  if (editState !== null) return trimmed === "" ? null : Number(trimmed);
+  return prior; // not edited: keep existing override, or undefined → don't pin
 }
 
 function SandboxSettingsEditor({
@@ -175,10 +132,8 @@ function SandboxSettingsEditor({
       globalDefaults?.maxTotalChildSessions ??
       DEFAULT_MAX_TOTAL_CHILD_SESSIONS);
 
-  const cpuSetting = resolveResourceSetting(isGlobal, globalDefaults, repoSettings, "cpuCores");
-  const memorySetting = resolveResourceSetting(isGlobal, globalDefaults, repoSettings, "memoryMib");
-  const currentCpuCores = cpuSetting.displayValue;
-  const currentMemoryMib = memorySetting.displayValue;
+  const currentCpuCores = resourceDisplayValue(isGlobal, globalDefaults, repoSettings, "cpuCores");
+  const currentMemoryMib = resourceDisplayValue(isGlobal, globalDefaults, repoSettings, "memoryMib");
 
   const [portRows, setPortRows] = useState<string[] | null>(null);
   const [terminalEnabled, setTerminalEnabled] = useState<boolean | null>(null);
@@ -283,24 +238,10 @@ function SandboxSettingsEditor({
       ) {
         settingsPayload.maxTotalChildSessions = Number(resolvedMaxTotalChildSessions);
       }
-      applyResourcePayload(
-        settingsPayload,
-        "cpuCores",
-        trimmedCpu,
-        cpuCores,
-        isGlobal,
-        cpuSetting.repoHasOverride,
-        cpuSetting.repoValue
-      );
-      applyResourcePayload(
-        settingsPayload,
-        "memoryMib",
-        trimmedMemory,
-        memoryMib,
-        isGlobal,
-        memorySetting.repoHasOverride,
-        memorySetting.repoValue
-      );
+      const cpu = resourcePayloadValue(isGlobal, cpuCores, trimmedCpu, repoSettings?.cpuCores);
+      if (cpu !== undefined) settingsPayload.cpuCores = cpu;
+      const memory = resourcePayloadValue(isGlobal, memoryMib, trimmedMemory, repoSettings?.memoryMib);
+      if (memory !== undefined) settingsPayload.memoryMib = memory;
       const body = isGlobal
         ? { settings: { defaults: settingsPayload, enabledRepos: existingEnabledRepos } }
         : { settings: settingsPayload };
@@ -347,10 +288,8 @@ function SandboxSettingsEditor({
     maxTotalChildSessions,
     repoSettings?.maxConcurrentChildSessions,
     repoSettings?.maxTotalChildSessions,
-    cpuSetting.repoHasOverride,
-    cpuSetting.repoValue,
-    memorySetting.repoHasOverride,
-    memorySetting.repoValue,
+    repoSettings?.cpuCores,
+    repoSettings?.memoryMib,
   ]);
 
   const hasPortChanges =


### PR DESCRIPTION
## What

Follow-up cleanup to #693 (configurable Modal sandbox CPU/memory). Two behavior-preserving changes:

- **web (`sandbox-settings.tsx`):** the cpu/memory override logic was implemented with a heavier, parallel mechanism than the adjacent child-session-limit fields — four helpers including a 7-argument `applyResourcePayload` and a 3-field intermediate object. Collapsed to two small helpers (`resourceDisplayValue`, `resourcePayloadValue`); the inherit / explicit-override / explicit-`null` (provider-default) tri-state is unchanged.
- **control-plane (`integration-settings.test.ts`):** added a regression test pinning the `getResolvedConfig` merge-time `normalizeSandboxSettings` pass.

## Why

The resource fields and the child-session-limit fields solve the same inheritance-guard problem; #693 introduced a second, heavier pattern for it. This narrows them and removes the bespoke indirection (net **−47 lines**).

The regression test closes a gap: the merge-time normalize in `getResolvedConfig` is the **only** enforcement of `maxConcurrent <= maxTotal` when the global defaults and the repo override are each individually valid but the *merged* result is not. It had no committed test, so a future refactor could silently drop it. The test is mutation-verified (it fails if that normalize pass is removed).

## Behavior

No behavior change. The `prior !== undefined` reasoning relies on stored JSON values never being `undefined`, so an inherited-only field is skipped and an explicit `null` override is preserved — exactly as before. Modal's `_resource_kwargs` mapping and every normalization pass are untouched.

## Testing

- web: 25/25 `sandbox-settings` tests pass unchanged
- control-plane: `integration-settings` unit suite passes, +1 new regression test (mutation-verified)
- typecheck clean (against real shared types), eslint clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a sandbox integration test that verifies config normalization handles cross-field validation after merging defaults and overrides.
  * Ensures invalid inverted concurrent/total limit cases are dropped by the merged configuration.

* **Refactor**
  * Improved resource override/inheritance handling for CPU and memory in sandbox settings.
  * Updated editor logic to correctly display values and persist payloads while preserving prior override semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->