### PR TITLE
fix: clean up Vercel SCM build env

### DIFF
--- a/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
@@ -467,11 +467,11 @@ describe("VercelSandboxProvider", () => {
         IMAGE_BUILD_MODE: "true",
         SESSION_CONFIG: JSON.stringify({ branch: "main" }),
         VCS_CLONE_TOKEN: "clone-token",
-        GITHUB_TOKEN: "clone-token",
-        GITHUB_APP_TOKEN: "clone-token",
-        OI_GITHUB_TOKEN_IS_FALLBACK: "1",
       })
     );
+    expect(createCall.env).not.toHaveProperty("GITHUB_TOKEN");
+    expect(createCall.env).not.toHaveProperty("GITHUB_APP_TOKEN");
+    expect(createCall.env).not.toHaveProperty("OI_GITHUB_TOKEN_IS_FALLBACK");
     expect(createCall.env).not.toHaveProperty("OI_INTERNAL_CALLBACK_SECRET");
     expect(createCall.env).not.toHaveProperty("OI_VERCEL_TOKEN");
     expect(createCall.env).not.toHaveProperty("OI_VERCEL_CALLBACK_URL");

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.ts
@@ -400,16 +400,6 @@ export class VercelSandboxProvider implements SandboxProvider {
 
     if (cloneToken) {
       envVars.VCS_CLONE_TOKEN = cloneToken;
-      if (this.providerConfig.scmProvider === "github") {
-        const hasUserGithubCliToken = Boolean(
-          envVars.GH_TOKEN || envVars.GITHUB_TOKEN || envVars.GITHUB_APP_TOKEN
-        );
-        if (!hasUserGithubCliToken) {
-          envVars.GITHUB_TOKEN = cloneToken;
-          envVars.GITHUB_APP_TOKEN = cloneToken;
-          envVars.OI_GITHUB_TOKEN_IS_FALLBACK = "1";
-        }
-      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Preserve `VCS_CLONE_TOKEN` for Vercel repo-image build authentication.
- Stop exposing clone tokens through legacy GitHub CLI fallback aliases in Vercel build envs.
- Update the Vercel provider test to assert the fallback aliases are absent.

## Tests
- `npm test -w @open-inspect/control-plane -- src/sandbox/providers/vercel/provider.test.ts`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/9905058ed12578364c7e56d67dd04f07)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined Vercel sandbox repository authentication by removing redundant GitHub-specific token fallback environment variables. The provider now uses a single clone token variable when credentials are provided, simplifying the authentication mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->