### PR TITLE
Remove repo-image fallback tokens

### DIFF
--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -464,13 +464,13 @@ was built for internal use where all employees have access to company repositori
 | Sandbox Auth Token | Authenticate sandbox → control plane calls | Single session                   |
 | WebSocket Token    | Authenticate client connections            | Single session                   |
 
-Fresh sandboxes fetch git credentials on demand through the control plane instead of relying on a
-token embedded in the environment or remote URL. Older snapshots and repo images may still receive
-env-token fallbacks so they can boot through the credential-helper migration. The helper authorizes
-HTTPS requests for the configured SCM host, preserving existing setup/start hooks that clone other
-private repositories available to the installation. This primarily protects continuously running
-sessions and Daytona persistent resumes from expired embedded credentials; Modal snapshot restores
-already mint a fresh fallback token on restore.
+Fresh and repo-image sandboxes fetch git credentials on demand through the control plane instead of
+relying on a token embedded in the environment or remote URL. Snapshot restores may still receive
+env-token fallbacks so legacy snapshots can boot through the credential-helper migration. The helper
+authorizes HTTPS requests for the configured SCM host, preserving existing setup/start hooks that
+clone other private repositories available to the installation. This primarily protects continuously
+running sessions and Daytona persistent resumes from expired embedded credentials; Modal snapshot
+restores still mint a fresh fallback token on restore.
 
 ### Secrets
 

--- a/packages/control-plane/README.md
+++ b/packages/control-plane/README.md
@@ -218,15 +218,14 @@ The system uses two types of GitHub tokens:
 | GitHub App Token | Clone, fetch, push | Brokered to credential helper | All repos where App is installed |
 | User OAuth Token | Create PRs         | Server-only                   | User's accessible repos          |
 
-Fresh sandboxes do not receive a long-lived `GITHUB_TOKEN`, `GITHUB_APP_TOKEN`, or `VCS_CLONE_TOKEN`
-for normal git operations. Git invokes the sandbox credential helper, which calls
+Fresh and repo-image sandboxes do not receive a long-lived `GITHUB_TOKEN`, `GITHUB_APP_TOKEN`, or
+`VCS_CLONE_TOKEN` for normal git operations. Git invokes the sandbox credential helper, which calls
 `/sessions/:id/scm-credentials` with the sandbox auth token and receives short-lived credentials on
-demand. Legacy snapshots, repo images, and one-shot image builds may still receive env-token
-fallbacks for compatibility. The helper preserves the existing installation-wide model by serving
-credentials for HTTPS git requests to the configured SCM host, including setup/start hooks that
-clone auxiliary private repos. This avoids stale embedded credentials in long-running sessions and
-Daytona persistent resumes; Modal snapshot restores still mint a fresh fallback token during
-restore.
+demand. Legacy snapshots and one-shot image builds may still receive env-token fallbacks for
+compatibility. The helper preserves the existing installation-wide model by serving credentials for
+HTTPS git requests to the configured SCM host, including setup/start hooks that clone auxiliary
+private repos. This avoids stale embedded credentials in long-running sessions and Daytona
+persistent resumes; Modal snapshot restores still mint a fresh fallback token during restore.
 
 If a `create-pr` request is triggered by a participant without a user OAuth token (for example,
 Slack-created sessions), the sandbox can still push the branch with brokered GitHub App credentials

--- a/packages/github-bot/README.md
+++ b/packages/github-bot/README.md
@@ -99,9 +99,9 @@ For the agent to interact with GitHub from the sandbox, these prerequisites must
 2. **Git credential helper** configured in the sandbox image/runtime so git operations can request
    short-lived SCM credentials from the control plane
 
-Fresh sandboxes get GitHub CLI credentials through the helper rather than spawn-time token
-injection. `GITHUB_TOKEN` and `GITHUB_APP_TOKEN` env fallbacks are only used for legacy snapshots
-and repo images when the user has not provided an explicit GitHub CLI token. One-shot image-build
+Fresh and repo-image sandboxes get GitHub CLI credentials through the helper rather than spawn-time
+token injection. `GITHUB_TOKEN` and `GITHUB_APP_TOKEN` env fallbacks are only used for legacy
+snapshots when the user has not provided an explicit GitHub CLI token. One-shot image-build
 sandboxes use only the narrower `VCS_CLONE_TOKEN` fallback because they cannot call the
 control-plane credential broker. For git operations, the helper keeps the existing installation-wide
 access model and can authenticate auxiliary private repos on the configured SCM host.

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -74,7 +74,7 @@ class SandboxConfig:
     control_plane_url: str = ""
     sandbox_auth_token: str = ""
     timeout_seconds: int = DEFAULT_SANDBOX_TIMEOUT_SECONDS
-    clone_token: str | None = None  # VCS clone token for git operations
+    fallback_clone_token: str | None = None  # VCS token for legacy snapshot fallback paths
     user_env_vars: dict[str, str] | None = None  # User-provided env vars (repo secrets)
     repo_image_id: str | None = None  # Pre-built repo image ID from provider
     repo_image_sha: str | None = None  # Git SHA the repo image was built from
@@ -359,14 +359,10 @@ class SandboxManager:
             }
         )
 
-        # Session snapshot boots still receive the restore fallback token for
-        # legacy entrypoints. Fresh and repo-image boots rely on the in-sandbox
-        # credential helper and must not receive SCM tokens in env.
-        boots_from_snapshot = bool(config.snapshot_id)
         self._inject_vcs_env_vars(
             env_vars,
-            clone_token=config.clone_token if boots_from_snapshot else None,
-            include_github_cli_aliases=boots_from_snapshot,
+            clone_token=config.fallback_clone_token,
+            include_github_cli_aliases=bool(config.fallback_clone_token),
         )
 
         code_server_password: str | None = None

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -289,7 +289,7 @@ class SandboxManager:
         token when ``CONTROL_PLANE_URL`` / ``SANDBOX_AUTH_TOKEN`` are unset.
 
         ``include_github_cli_aliases`` adds fallback ``GITHUB_TOKEN`` /
-        ``GITHUB_APP_TOKEN`` for legacy snapshots/repo images that predate the
+        ``GITHUB_APP_TOKEN`` for legacy snapshots that predate the
         gh wrapper. These aliases are only injected when the user has not
         provided a GitHub CLI token. Fallback injection is marked with
         ``OI_GITHUB_TOKEN_IS_FALLBACK=1`` so helper-capable boots refresh past
@@ -359,20 +359,14 @@ class SandboxManager:
             }
         )
 
-        # A boot from a pre-built image (session snapshot or repo image) may
-        # run an entrypoint built before the credential-helper migration: no
-        # helper, and the old entrypoint expects VCS_CLONE_TOKEN in env to
-        # rewrite origin. Pass the fresh token through for those (with the
-        # gh-CLI aliases + fallback marker, so helper-capable images refresh
-        # past it). Fresh base-image boots rely on the in-sandbox credential
-        # helper and need no token in env. Repo images are selected by SHA and
-        # aren't rebuilt by a CACHE_BUSTER bump, so we can't assume they're
-        # current.
-        boots_from_prebuilt_image = bool(config.snapshot_id or config.repo_image_id)
+        # Session snapshot boots still receive the restore fallback token for
+        # legacy entrypoints. Fresh and repo-image boots rely on the in-sandbox
+        # credential helper and must not receive SCM tokens in env.
+        boots_from_snapshot = bool(config.snapshot_id)
         self._inject_vcs_env_vars(
             env_vars,
-            clone_token=config.clone_token if boots_from_prebuilt_image else None,
-            include_github_cli_aliases=boots_from_prebuilt_image,
+            clone_token=config.clone_token if boots_from_snapshot else None,
+            include_github_cli_aliases=boots_from_snapshot,
         )
 
         code_server_password: str | None = None

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -156,7 +156,7 @@ async def api_create_sandbox(
 
         snapshot_id = request.get("snapshot_id")
         repo_image_id = request.get("repo_image_id") or None
-        clone_token = _resolve_clone_token() if snapshot_id else None
+        fallback_clone_token = _resolve_clone_token() if snapshot_id else None
 
         session_config = SessionConfig(
             session_id=request.get("session_id"),
@@ -177,7 +177,7 @@ async def api_create_sandbox(
             session_config=session_config,
             control_plane_url=control_plane_url,
             sandbox_auth_token=request.get("sandbox_auth_token"),
-            clone_token=clone_token,
+            fallback_clone_token=fallback_clone_token,
             user_env_vars=request.get("user_env_vars") or None,
             repo_image_id=repo_image_id,
             repo_image_sha=request.get("repo_image_sha") or None,

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -156,7 +156,7 @@ async def api_create_sandbox(
 
         snapshot_id = request.get("snapshot_id")
         repo_image_id = request.get("repo_image_id") or None
-        clone_token = _resolve_clone_token() if snapshot_id or repo_image_id else None
+        clone_token = _resolve_clone_token() if snapshot_id else None
 
         session_config = SessionConfig(
             session_id=request.get("session_id"),

--- a/packages/modal-infra/tests/test_sandbox_env_vars.py
+++ b/packages/modal-infra/tests/test_sandbox_env_vars.py
@@ -329,9 +329,8 @@ def _fake_sandbox_create(captured):
 
 
 # Note: fresh and repo-image sandboxes never receive SCM tokens in the
-# environment. Snapshot and image-build paths still receive VCS_CLONE_TOKEN as
-# a fallback because they may run without credential-broker access or legacy
-# snapshot code may require it. These tests pin that split contract.
+# environment. Callers only set fallback_clone_token for snapshot paths that
+# still need VCS_CLONE_TOKEN for legacy entrypoints.
 
 
 @pytest.mark.asyncio
@@ -345,7 +344,6 @@ async def test_vcs_env_vars_default_github(monkeypatch):
     config = SandboxConfig(
         repo_owner="acme",
         repo_name="repo",
-        clone_token="ghp_test123",
     )
     await manager.create_sandbox(config)
 
@@ -368,7 +366,6 @@ async def test_vcs_env_vars_gitlab(monkeypatch):
     config = SandboxConfig(
         repo_owner="acme",
         repo_name="repo",
-        clone_token="glpat_test123",
     )
     await manager.create_sandbox(config)
 
@@ -389,7 +386,6 @@ async def test_vcs_env_vars_bitbucket(monkeypatch):
     config = SandboxConfig(
         repo_owner="acme",
         repo_name="repo",
-        clone_token="bb_token_abc",
     )
     await manager.create_sandbox(config)
 
@@ -415,7 +411,6 @@ async def test_repo_image_boot_omits_fallback_tokens(monkeypatch):
     config = SandboxConfig(
         repo_owner="acme",
         repo_name="repo",
-        clone_token="ghs_repo_image_token",
         repo_image_id="repo-img-1",
     )
     await manager.create_sandbox(config)
@@ -446,7 +441,6 @@ async def test_repo_image_boot_preserves_user_github_cli_token(monkeypatch, toke
         SandboxConfig(
             repo_owner="acme",
             repo_name="repo",
-            clone_token="ghs_repo_image_token",
             repo_image_id="repo-img-1",
             user_env_vars={token_key: "user_token"},
         )
@@ -473,7 +467,7 @@ async def test_session_snapshot_boot_preserves_clone_token(monkeypatch):
     config = SandboxConfig(
         repo_owner="acme",
         repo_name="repo",
-        clone_token="ghs_snapshot_token",
+        fallback_clone_token="ghs_snapshot_token",
         snapshot_id="snap-1",
     )
     await manager.create_sandbox(config)

--- a/packages/modal-infra/tests/test_sandbox_env_vars.py
+++ b/packages/modal-infra/tests/test_sandbox_env_vars.py
@@ -328,10 +328,10 @@ def _fake_sandbox_create(captured):
     return fake_create_aio
 
 
-# Note: fresh sandboxes never receive SCM tokens in the environment. Legacy
-# snapshot/repo-image and image-build paths still receive VCS_CLONE_TOKEN as a
-# fallback because they may run code built before the credential-helper
-# migration. These tests pin that split contract.
+# Note: fresh and repo-image sandboxes never receive SCM tokens in the
+# environment. Snapshot and image-build paths still receive VCS_CLONE_TOKEN as
+# a fallback because they may run without credential-broker access or legacy
+# snapshot code may require it. These tests pin that split contract.
 
 
 @pytest.mark.asyncio
@@ -400,14 +400,8 @@ async def test_vcs_env_vars_bitbucket(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_repo_image_boot_preserves_clone_token(monkeypatch):
-    """A repo-image boot may run a pre-migration entrypoint with no helper.
-
-    Repo images are selected by SHA and aren't rebuilt by a CACHE_BUSTER
-    bump, so the old entrypoint may still be in use — it needs VCS_CLONE_TOKEN
-    in env (plus the gh aliases + fallback marker). A helper-capable repo
-    image ignores the env token and refreshes via the helper / gh wrapper.
-    """
+async def test_repo_image_boot_omits_fallback_tokens(monkeypatch):
+    """Repo-image boots rely on brokered credentials only."""
     captured = {}
 
     class FakeImage:
@@ -428,15 +422,16 @@ async def test_repo_image_boot_preserves_clone_token(monkeypatch):
 
     env = captured["env"]
     assert env["FROM_REPO_IMAGE"] == "true"
-    assert env["VCS_CLONE_TOKEN"] == "ghs_repo_image_token"
-    assert env["GITHUB_TOKEN"] == "ghs_repo_image_token"
-    assert env["OI_GITHUB_TOKEN_IS_FALLBACK"] == "1"
+    assert "VCS_CLONE_TOKEN" not in env
+    assert "GITHUB_TOKEN" not in env
+    assert "GITHUB_APP_TOKEN" not in env
+    assert "OI_GITHUB_TOKEN_IS_FALLBACK" not in env
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("token_key", ["GH_TOKEN", "GITHUB_TOKEN", "GITHUB_APP_TOKEN"])
 async def test_repo_image_boot_preserves_user_github_cli_token(monkeypatch, token_key):
-    """User-provided GitHub CLI tokens must win over fallback restore tokens."""
+    """Repo-image boots do not replace user-provided GitHub CLI tokens."""
     captured = {}
 
     class FakeImage:
@@ -458,8 +453,8 @@ async def test_repo_image_boot_preserves_user_github_cli_token(monkeypatch, toke
     )
 
     env = captured["env"]
-    assert env["VCS_CLONE_TOKEN"] == "ghs_repo_image_token"
     assert env[token_key] == "user_token"
+    assert "VCS_CLONE_TOKEN" not in env
     assert env.get("GITHUB_TOKEN") != "ghs_repo_image_token"
     assert env.get("GITHUB_APP_TOKEN") != "ghs_repo_image_token"
     assert "OI_GITHUB_TOKEN_IS_FALLBACK" not in env
@@ -467,7 +462,7 @@ async def test_repo_image_boot_preserves_user_github_cli_token(monkeypatch, toke
 
 @pytest.mark.asyncio
 async def test_session_snapshot_boot_preserves_clone_token(monkeypatch):
-    """A session-snapshot boot has the same legacy-compat need as repo images."""
+    """A session-snapshot boot keeps the legacy fallback token."""
     captured = {}
 
     monkeypatch.setattr("src.sandbox.manager.modal.Image.from_registry", lambda *a, **kw: object())

--- a/packages/modal-infra/tests/test_web_api_create_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_create_sandbox.py
@@ -65,7 +65,7 @@ async def test_create_sandbox_does_not_resolve_clone_token_for_fresh_boot(monkey
 
     assert result["success"] is True
     assert calls == []
-    assert captured["config"].clone_token is None
+    assert captured["config"].fallback_clone_token is None
 
 
 @pytest.mark.asyncio
@@ -96,7 +96,7 @@ async def test_create_sandbox_does_not_resolve_clone_token_for_repo_image_boot(m
 
     assert result["success"] is True
     assert calls == []
-    assert captured["config"].clone_token is None
+    assert captured["config"].fallback_clone_token is None
 
 
 @pytest.mark.asyncio
@@ -127,4 +127,4 @@ async def test_create_sandbox_resolves_clone_token_for_snapshot_boot(monkeypatch
 
     assert result["success"] is True
     assert calls == [True]
-    assert captured["config"].clone_token == "ghs_snapshot"
+    assert captured["config"].fallback_clone_token == "ghs_snapshot"

--- a/packages/modal-infra/tests/test_web_api_create_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_create_sandbox.py
@@ -69,8 +69,8 @@ async def test_create_sandbox_does_not_resolve_clone_token_for_fresh_boot(monkey
 
 
 @pytest.mark.asyncio
-async def test_create_sandbox_resolves_clone_token_for_prebuilt_boot(monkeypatch):
-    """Repo images may run pre-migration entrypoints, so they still need a fallback token."""
+async def test_create_sandbox_does_not_resolve_clone_token_for_repo_image_boot(monkeypatch):
+    """Repo-image boots authenticate via brokered credentials only."""
     captured = {}
     calls = []
 
@@ -95,5 +95,36 @@ async def test_create_sandbox_resolves_clone_token_for_prebuilt_boot(monkeypatch
     )
 
     assert result["success"] is True
+    assert calls == []
+    assert captured["config"].clone_token is None
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_resolves_clone_token_for_snapshot_boot(monkeypatch):
+    """Session snapshot boots still receive a legacy fallback token."""
+    captured = {}
+    calls = []
+
+    _patch_auth(monkeypatch)
+    _patch_manager(monkeypatch, captured)
+
+    def resolve_clone_token() -> str:
+        calls.append(True)
+        return "ghs_snapshot"
+
+    monkeypatch.setattr(web_api, "_resolve_clone_token", resolve_clone_token)
+
+    result = await _call_create_sandbox(
+        {
+            "session_id": "sess-1",
+            "repo_owner": "acme",
+            "repo_name": "repo",
+            "control_plane_url": "https://control-plane.example",
+            "sandbox_auth_token": "sandbox-token",
+            "snapshot_id": "snap-1",
+        }
+    )
+
+    assert result["success"] is True
     assert calls == [True]
-    assert captured["config"].clone_token == "ghs_prebuilt"
+    assert captured["config"].clone_token == "ghs_snapshot"


### PR DESCRIPTION
## Summary
- Stop resolving clone fallback tokens for Modal repo-image sandbox boots.
- Limit create-sandbox fallback token injection to snapshot boots while preserving image-build fallback behavior.
- Update Modal tests and credential docs to reflect brokered-credentials-only repo-image boots.

## Tests
- `./.venv/bin/pytest tests/test_sandbox_env_vars.py tests/test_web_api_create_sandbox.py -q`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/86f668907971173e8b113209a56115e2)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified credential architecture: fresh and repo-image sandboxes obtain short-lived git credentials on demand via the control plane; legacy snapshots retain env-token fallback behavior.

* **Refactor**
  * Credential injection now relies on on-demand credential helper behavior instead of passing long-lived clone tokens, reducing risk of stale embedded credentials for long-running sessions and resumes.

* **Tests**
  * Updated tests to reflect tightened fresh vs. legacy sandbox token expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->