### PR TITLE
Improve formatting for get-task-status tool calls

### DIFF
--- a/packages/web/src/lib/tool-formatters.ts
+++ b/packages/web/src/lib/tool-formatters.ts
@@ -278,6 +278,17 @@ export function formatToolCall(event: ToolCallEvent): FormattedToolCall {
       };
     }
 
+    case "get-task-status": {
+      const taskId = getStringArg(args, "taskId");
+
+      return {
+        toolName: "Task Status",
+        summary: taskId ? truncate(taskId, 20) : "List Tasks",
+        icon: "box",
+        getDetails: () => ({ args, output }),
+      };
+    }
+
     default:
       return {
         toolName: tool || "Unknown",


### PR DESCRIPTION
## Changes

* Add dedicated formatter support for `get-task-status`
* Display a clearer tool name and summary instead of falling back to the generic formatter
* Preserve existing argument and output rendering behavior

## Notes

While investigating this issue, I found that `get-task-status` currently falls through to the default formatter in `tool-formatters.ts`.

This change provides an initial improvement to the tool's presentation by giving it a dedicated formatter and summary.

I'm happy to extend this further with a richer custom UI component if maintainers would prefer a more structured presentation of task metadata and final responses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Task Status operations with improved formatting and display, including automatic task identification and task ID references (truncated to 20 characters) or a default "List Tasks" label when task information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->