### PR TITLE
docs: list Opus 4.8 in supported Anthropic models table

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Choose the AI model that fits your task, with per-session reasoning effort contr
 
 | Provider     | Models                                                               |
 | ------------ | -------------------------------------------------------------------- |
-| Anthropic    | Claude Haiku 4.5, Sonnet 4.5/4.6, Opus 4.5/4.6/4.7                   |
+| Anthropic    | Claude Haiku 4.5, Sonnet 4.5/4.6, Opus 4.5/4.6/4.7/4.8               |
 | OpenAI       | GPT 5.2, GPT 5.4, GPT 5.5, GPT 5.2 Codex, 5.3 Codex, 5.3 Codex Spark |
 | OpenCode Zen | Kimi K2.5, MiniMax M2.5, GLM 5 (opt-in)                              |
 


### PR DESCRIPTION
## Summary

Follow-up to #706 (which added Claude Opus 4.8 to the model list and enabled xhigh effort for Opus 4.7/4.8). That PR updated the code but left the README's "Multi-Provider Model Support" table still listing Anthropic models only through Opus 4.7.

This updates the table so the documented model list matches what's actually supported:

- `Opus 4.5/4.6/4.7` → `Opus 4.5/4.6/4.7/4.8`

## Test plan

- [x] Table column alignment preserved (all rows remain equal width)
- [x] No code changes — docs only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Multi-Provider Model Support table to expand the range of supported Anthropic Opus model variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->