### PR TITLE
Fix replayed assistant token ordering

### DIFF
--- a/packages/web/src/hooks/use-session-socket.test.tsx
+++ b/packages/web/src/hooks/use-session-socket.test.tsx
@@ -8,6 +8,8 @@ import type * as SwrModule from "swr";
 import { isUnarchivedSessionListKey } from "@/lib/session-list";
 import { useSessionSocket } from "./use-session-socket";
 
+type SubscribedMessage = Extract<ServerMessage, { type: "subscribed" }>;
+
 const { mutateMock } = vi.hoisted(() => ({
   mutateMock: vi.fn(),
 }));
@@ -75,7 +77,7 @@ function createSessionState(overrides: Partial<SessionState> = {}): SessionState
   };
 }
 
-function createSubscribedMessage(artifacts: SessionArtifact[] = []): ServerMessage {
+function createSubscribedMessage(artifacts: SessionArtifact[] = []): SubscribedMessage {
   return {
     type: "subscribed",
     sessionId: "session-1",
@@ -252,6 +254,57 @@ describe("useSessionSocket", () => {
     });
 
     expect(mutateMock).toHaveBeenCalledWith(isUnarchivedSessionListKey);
+  });
+
+  it("hydrates replayed assistant text before completion when storage ordering is tied", async () => {
+    const { result } = renderHook(() => useSessionSocket("session-1"));
+
+    await waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
+
+    const socket = FakeWebSocket.instances[0];
+    const subscribed = createSubscribedMessage();
+    subscribed.replay = {
+      events: [
+        {
+          type: "execution_complete",
+          messageId: "msg-1",
+          success: true,
+          sandboxId: "sb-1",
+          timestamp: 2,
+        },
+        {
+          type: "token",
+          content: "Final response",
+          messageId: "msg-1",
+          sandboxId: "sb-1",
+          timestamp: 1,
+        },
+      ],
+      hasMore: false,
+      cursor: null,
+    };
+
+    act(() => {
+      socket.open();
+      socket.receive(subscribed);
+    });
+
+    await waitFor(() => {
+      expect(result.current.events).toEqual([
+        expect.objectContaining({
+          type: "token",
+          content: "Final response",
+          messageId: "msg-1",
+        }),
+        expect.objectContaining({
+          type: "execution_complete",
+          messageId: "msg-1",
+          success: true,
+        }),
+      ]);
+    });
   });
 
   it("hydrates video metadata from subscribed artifacts", async () => {

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { type MutableRefObject, useCallback, useEffect, useRef, useState } from "react";
 import { mutate } from "swr";
 import { isUnarchivedSessionListKey } from "@/lib/session-list";
 import type { Artifact, SandboxEvent } from "@/types/session";
@@ -40,6 +40,11 @@ interface Message {
 type SessionState = SharedSessionState;
 type Participant = ParticipantPresence;
 type WsMessage = ServerMessage;
+type AssistantTokenEvent = Extract<SandboxEvent, { type: "token" }>;
+type PendingAssistantText = Pick<
+  AssistantTokenEvent,
+  "content" | "messageId" | "sandboxId" | "timestamp"
+>;
 
 const CLEARED_SANDBOX_ACCESS_STATE = {
   codeServerUrl: undefined,
@@ -72,46 +77,62 @@ interface UseSessionSocketReturn {
 }
 
 /**
- * Collapse a batch of events by folding streaming token events into their
- * final form (only the last accumulated token before execution_complete is kept).
- * Mutates pendingTextRef to track in-flight tokens across calls.
+ * Token events contain cumulative text. Replay should show one final token per
+ * message, independent of tied storage ordering between token and completion.
  */
-function collapseTokenEvents(
-  events: SandboxEvent[],
-  pendingTextRef: React.MutableRefObject<{
-    content: string;
-    messageId: string;
-    sandboxId: string;
-    timestamp: number;
-  } | null>
-): SandboxEvent[] {
-  const result: SandboxEvent[] = [];
-  for (const evt of events) {
-    if (evt.type === "token" && evt.content && evt.messageId) {
-      pendingTextRef.current = {
-        content: evt.content,
-        messageId: evt.messageId,
-        sandboxId: evt.sandboxId,
-        timestamp: evt.timestamp,
-      };
-    } else if (evt.type === "execution_complete") {
-      if (pendingTextRef.current) {
-        const pending = pendingTextRef.current;
-        pendingTextRef.current = null;
-        result.push({
-          type: "token",
-          content: pending.content,
-          messageId: pending.messageId,
-          sandboxId: pending.sandboxId,
-          timestamp: pending.timestamp,
-        });
-      }
-      result.push(evt);
-    } else {
-      result.push(evt);
+function collapseReplayTokenEvents(events: SandboxEvent[]): SandboxEvent[] {
+  const tokenByMessageId = new Map<string, AssistantTokenEvent>();
+
+  for (const event of events) {
+    if (isRenderableTokenEvent(event)) {
+      tokenByMessageId.set(event.messageId, event);
     }
   }
+
+  if (tokenByMessageId.size === 0) {
+    return events;
+  }
+
+  const result: SandboxEvent[] = [];
+  const emittedTokenMessageIds = new Set<string>();
+
+  for (const evt of events) {
+    if (isRenderableTokenEvent(evt)) {
+      continue;
+    }
+
+    if (evt.type === "execution_complete") {
+      const token = tokenByMessageId.get(evt.messageId);
+      if (token && !emittedTokenMessageIds.has(evt.messageId)) {
+        result.push(token);
+        emittedTokenMessageIds.add(evt.messageId);
+      }
+    }
+
+    result.push(evt);
+  }
+
+  for (const [messageId, token] of tokenByMessageId) {
+    if (!emittedTokenMessageIds.has(messageId)) {
+      result.push(token);
+    }
+  }
+
   return result;
+}
+
+function isRenderableTokenEvent(event: SandboxEvent): event is AssistantTokenEvent {
+  return event.type === "token" && Boolean(event.content) && Boolean(event.messageId);
+}
+
+function takePendingTokenEvent(
+  pendingTextRef: MutableRefObject<PendingAssistantText | null>
+): AssistantTokenEvent | null {
+  const pending = pendingTextRef.current;
+  if (!pending) return null;
+
+  pendingTextRef.current = null;
+  return { type: "token", ...pending };
 }
 
 function parseWsMessage(raw: unknown): WsMessage | null {
@@ -212,12 +233,7 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
   const wsTokenRef = useRef<string | null>(null);
   // Accumulates text during streaming, displayed only on completion to avoid duplicate display.
   // Stores only the latest token since token events contain the full accumulated text (not incremental).
-  const pendingTextRef = useRef<{
-    content: string;
-    messageId: string;
-    sandboxId: string;
-    timestamp: number;
-  } | null>(null);
+  const pendingTextRef = useRef<PendingAssistantText | null>(null);
   const [connected, setConnected] = useState(false);
   const [connecting, setConnecting] = useState(false);
   const [replaying, setReplaying] = useState(true);
@@ -256,21 +272,8 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
       };
     } else if (event.type === "execution_complete") {
       // On completion: Add final text to events using the token's original timestamp
-      if (pendingTextRef.current) {
-        const pending = pendingTextRef.current;
-        pendingTextRef.current = null;
-        setEvents((prev) => [
-          ...prev,
-          {
-            type: "token",
-            content: pending.content,
-            messageId: pending.messageId,
-            sandboxId: pending.sandboxId,
-            timestamp: pending.timestamp,
-          },
-        ]);
-      }
-      setEvents((prev) => [...prev, event]);
+      const pending = takePendingTokenEvent(pendingTextRef);
+      setEvents((prev) => (pending ? [...prev, pending, event] : [...prev, event]));
     } else {
       // Other events (tool_call, user_message, git_sync, etc.) - add normally
       setEvents((prev) => [...prev, event]);
@@ -323,9 +326,7 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
 
           // Process batched replay events in a single state update
           setEvents(
-            data.replay
-              ? collapseTokenEvents(data.replay.events.map(toUiSandboxEvent), pendingTextRef)
-              : []
+            data.replay ? collapseReplayTokenEvents(data.replay.events.map(toUiSandboxEvent)) : []
           );
           setHasMoreHistory(data.replay?.hasMore ?? false);
           cursorRef.current = data.replay?.cursor ?? null;
@@ -708,19 +709,9 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
       return;
     }
     // Preserve partial content when stopping
-    if (pendingTextRef.current) {
-      const pending = pendingTextRef.current;
-      pendingTextRef.current = null;
-      setEvents((prev) => [
-        ...prev,
-        {
-          type: "token",
-          content: pending.content,
-          messageId: pending.messageId,
-          sandboxId: pending.sandboxId,
-          timestamp: pending.timestamp,
-        },
-      ]);
+    const pending = takePendingTokenEvent(pendingTextRef);
+    if (pending) {
+      setEvents((prev) => [...prev, pending]);
     }
     wsRef.current.send(JSON.stringify({ type: "stop" }));
   }, []);


### PR DESCRIPTION
## Summary
- normalize replayed token events without reusing the live streaming pending-text ref
- render the final replayed assistant token before `execution_complete`, even when storage timestamp ties put completion first
- add a hook regression test for the tied-order replay case

## Root Cause
Durable Object replay can return `execution_complete:<messageId>` before `token:<messageId>` when the two rows share `created_at`, because replay uses the event id as the tie-breaker. The previous UI replay reducer only flushed a pending token when it later saw `execution_complete`, so a token at the end of the replay batch was silently dropped.

## Validation
- `npm test -w @open-inspect/web`
- `npm exec -w @open-inspect/web -- eslint src/hooks/use-session-socket.ts src/hooks/use-session-socket.test.tsx`
- `git diff --check`
- `npm run typecheck -w @open-inspect/web` currently fails on pre-existing `SandboxSettings` `cpuCores` / `memoryMib` type errors outside this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for session socket event hydration with improved verification of event ordering and token replay scenarios.

* **Bug Fixes**  
  * Improved reliability of streamed token event handling during socket subscription with refined collapse and replay logic to ensure consistent event ordering and complete token delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->