### PR TITLE
refactor: extract session details overlay

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -20,10 +20,8 @@ import { ScreenshotArtifactCard } from "@/components/screenshot-artifact-card";
 import { MediaLightbox } from "@/components/media-lightbox";
 import { Button } from "@/components/ui/button";
 import { useSidebarContext } from "@/components/sidebar-layout";
-import {
-  SessionRightSidebar,
-  SessionRightSidebarContent,
-} from "@/components/session-right-sidebar";
+import { SessionRightSidebar } from "@/components/session-right-sidebar";
+import { SessionDetailsOverlay } from "@/components/session-details-overlay";
 import { Group as PanelGroup, Panel, Separator as PanelResizeHandle } from "react-resizable-panels";
 import { TerminalPanel } from "@/components/terminal-panel";
 import { ActionBar } from "@/components/action-bar";
@@ -885,94 +883,23 @@ function SessionContent({
       </main>
 
       {isBelowLg && (
-        <div
-          className={`fixed inset-0 z-50 lg:hidden ${isDetailsOpen ? "" : "pointer-events-none"}`}
-        >
-          <div
-            className={`absolute inset-0 bg-overlay transition-opacity duration-200 ${
-              isDetailsOpen ? "opacity-100" : "opacity-0"
-            }`}
-            onClick={closeDetails}
-          />
-
-          {isPhone ? (
-            <div
-              id="session-details-dialog"
-              role="dialog"
-              aria-modal="true"
-              aria-label="Session details"
-              className="absolute inset-x-0 bottom-0 max-h-[85vh] bg-background border-t border-border-muted shadow-xl flex flex-col"
-              style={{
-                transform: isDetailsOpen ? `translateY(${sheetDragY}px)` : "translateY(100%)",
-                transition: sheetDragY > 0 ? "none" : "transform 200ms ease-in-out",
-              }}
-            >
-              <div
-                className="px-4 pt-3 pb-2 border-b border-border-muted"
-                onTouchStart={handleSheetTouchStart}
-                onTouchMove={handleSheetTouchMove}
-                onTouchEnd={handleSheetTouchEnd}
-                onTouchCancel={handleSheetTouchEnd}
-              >
-                <div className="mx-auto mb-2 h-1.5 w-12 rounded-full bg-muted" />
-                <div className="flex items-center justify-between">
-                  <h2 className="text-sm font-medium text-foreground">Session details</h2>
-                  <button
-                    type="button"
-                    onClick={closeDetails}
-                    className="text-sm text-muted-foreground hover:text-foreground transition"
-                  >
-                    Close
-                  </button>
-                </div>
-              </div>
-              <div className="overflow-y-auto">
-                <SessionRightSidebarContent
-                  sessionId={sessionId}
-                  sessionState={sessionState}
-                  participants={participants}
-                  events={events}
-                  artifacts={artifacts}
-                  terminalOpen={terminalOpen}
-                  onToggleTerminal={toggleTerminal}
-                  onOpenMedia={setSelectedMediaArtifactId}
-                />
-              </div>
-            </div>
-          ) : (
-            <div
-              id="session-details-dialog"
-              role="dialog"
-              aria-modal="true"
-              aria-label="Session details"
-              className="absolute inset-y-0 right-0 w-80 max-w-[85vw] bg-background border-l border-border-muted shadow-xl flex flex-col transition-transform duration-200 ease-in-out"
-              style={{ transform: isDetailsOpen ? "translateX(0)" : "translateX(100%)" }}
-            >
-              <div className="px-4 py-3 border-b border-border-muted flex items-center justify-between">
-                <h2 className="text-sm font-medium text-foreground">Session details</h2>
-                <button
-                  type="button"
-                  onClick={closeDetails}
-                  className="text-sm text-muted-foreground hover:text-foreground transition"
-                >
-                  Close
-                </button>
-              </div>
-              <div className="flex-1 overflow-y-auto">
-                <SessionRightSidebarContent
-                  sessionId={sessionId}
-                  sessionState={sessionState}
-                  participants={participants}
-                  events={events}
-                  artifacts={artifacts}
-                  terminalOpen={terminalOpen}
-                  onToggleTerminal={toggleTerminal}
-                  onOpenMedia={setSelectedMediaArtifactId}
-                />
-              </div>
-            </div>
-          )}
-        </div>
+        <SessionDetailsOverlay
+          isOpen={isDetailsOpen}
+          isPhone={isPhone}
+          sheetDragY={sheetDragY}
+          onClose={closeDetails}
+          onSheetTouchStart={handleSheetTouchStart}
+          onSheetTouchMove={handleSheetTouchMove}
+          onSheetTouchEnd={handleSheetTouchEnd}
+          sessionId={sessionId}
+          sessionState={sessionState}
+          participants={participants}
+          events={events}
+          artifacts={artifacts}
+          terminalOpen={terminalOpen}
+          onToggleTerminal={toggleTerminal}
+          onOpenMedia={setSelectedMediaArtifactId}
+        />
       )}
 
       <MediaLightbox

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -485,10 +485,7 @@ function SessionContent({
   const [isRenaming, setIsRenaming] = useState(false);
   const [title, setTitle] = useState(baseResolvedTitle);
   const [optimisticTitle, setOptimisticTitle] = useState<string | null>(null);
-  const [sheetDragY, setSheetDragY] = useState(0);
-  const sheetDragYRef = useRef(0);
   const detailsButtonRef = useRef<HTMLButtonElement>(null);
-  const sheetTouchStartYRef = useRef<number | null>(null);
 
   // Terminal panel state
   const [terminalOpen, setTerminalOpen] = useState(() => {
@@ -518,26 +515,9 @@ function SessionContent({
   const prevScrollHeightRef = useRef(0);
   const isNearBottomRef = useRef(true);
 
-  const resetSheetDragState = useCallback(() => {
-    setSheetDragY(0);
-    sheetDragYRef.current = 0;
-  }, []);
-
-  const closeDetails = useCallback(() => {
-    setIsDetailsOpen(false);
-    resetSheetDragState();
-    detailsButtonRef.current?.focus();
-  }, [resetSheetDragState]);
-
   const toggleDetails = useCallback(() => {
-    setIsDetailsOpen((prev) => {
-      const next = !prev;
-      if (!next) {
-        resetSheetDragState();
-      }
-      return next;
-    });
-  }, [resetSheetDragState]);
+    setIsDetailsOpen((prev) => !prev);
+  }, []);
 
   const handleStartRename = () => {
     setTitle(resolvedTitle);
@@ -579,40 +559,6 @@ function SessionContent({
     }
   }, [optimisticTitle, sessionState?.title]);
 
-  const handleSheetTouchStart = useCallback((event: React.TouchEvent<HTMLDivElement>) => {
-    const startY = event.touches[0]?.clientY;
-    sheetTouchStartYRef.current = startY ?? null;
-  }, []);
-
-  const handleSheetTouchMove = useCallback((event: React.TouchEvent<HTMLDivElement>) => {
-    const startY = sheetTouchStartYRef.current;
-    const currentY = event.touches[0]?.clientY;
-
-    if (startY === null || currentY === undefined) return;
-
-    const delta = currentY - startY;
-    if (delta > 0) {
-      const nextDragY = Math.min(delta, 180);
-      sheetDragYRef.current = nextDragY;
-      setSheetDragY(nextDragY);
-    } else {
-      sheetDragYRef.current = 0;
-      setSheetDragY(0);
-    }
-  }, []);
-
-  const handleSheetTouchEnd = useCallback(() => {
-    if (sheetDragYRef.current > 100) {
-      closeDetails();
-      sheetTouchStartYRef.current = null;
-      return;
-    }
-
-    sheetDragYRef.current = 0;
-    setSheetDragY(0);
-    sheetTouchStartYRef.current = null;
-  }, [closeDetails]);
-
   useEffect(() => {
     if (!isRenaming) setTitle(sessionState?.title ?? "");
   }, [sessionState?.title, isRenaming]);
@@ -620,32 +566,7 @@ function SessionContent({
   useEffect(() => {
     if (isBelowLg) return;
     setIsDetailsOpen(false);
-    resetSheetDragState();
-  }, [isBelowLg, resetSheetDragState]);
-
-  useEffect(() => {
-    if (!isDetailsOpen) return;
-
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        closeDetails();
-      }
-    };
-
-    window.addEventListener("keydown", handleEscape);
-    return () => window.removeEventListener("keydown", handleEscape);
-  }, [closeDetails, isDetailsOpen]);
-
-  useEffect(() => {
-    if (!isDetailsOpen) return;
-
-    const originalOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-
-    return () => {
-      document.body.style.overflow = originalOverflow;
-    };
-  }, [isDetailsOpen]);
+  }, [isBelowLg]);
 
   // Track user scroll
   const handleScroll = useCallback(() => {
@@ -884,13 +805,10 @@ function SessionContent({
 
       {isBelowLg && (
         <SessionDetailsOverlay
-          isOpen={isDetailsOpen}
+          open={isDetailsOpen}
+          onOpenChange={setIsDetailsOpen}
           isPhone={isPhone}
-          sheetDragY={sheetDragY}
-          onClose={closeDetails}
-          onSheetTouchStart={handleSheetTouchStart}
-          onSheetTouchMove={handleSheetTouchMove}
-          onSheetTouchEnd={handleSheetTouchEnd}
+          returnFocusRef={detailsButtonRef}
           sessionId={sessionId}
           sessionState={sessionState}
           participants={participants}

--- a/packages/web/src/components/session-details-overlay.tsx
+++ b/packages/web/src/components/session-details-overlay.tsx
@@ -1,26 +1,40 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type RefObject,
+  type TouchEvent,
+} from "react";
 import {
   SessionRightSidebarContent,
   type SessionRightSidebarContentProps,
 } from "./session-right-sidebar";
 
 interface SessionDetailsOverlayProps extends SessionRightSidebarContentProps {
-  isOpen: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   isPhone: boolean;
-  sheetDragY: number;
-  onClose: () => void;
-  onSheetTouchStart: React.TouchEventHandler<HTMLDivElement>;
-  onSheetTouchMove: React.TouchEventHandler<HTMLDivElement>;
-  onSheetTouchEnd: React.TouchEventHandler<HTMLDivElement>;
+  returnFocusRef?: RefObject<HTMLElement | null>;
 }
 
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
 export function SessionDetailsOverlay({
-  isOpen,
+  open,
+  onOpenChange,
   isPhone,
-  sheetDragY,
-  onClose,
-  onSheetTouchStart,
-  onSheetTouchMove,
-  onSheetTouchEnd,
+  returnFocusRef,
   sessionId,
   sessionState,
   participants,
@@ -30,6 +44,118 @@ export function SessionDetailsOverlay({
   onToggleTerminal,
   onOpenMedia,
 }: SessionDetailsOverlayProps) {
+  const [sheetDragY, setSheetDragY] = useState(0);
+  const sheetDragYRef = useRef(0);
+  const sheetTouchStartYRef = useRef<number | null>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  const resetSheetDragState = useCallback(() => {
+    setSheetDragY(0);
+    sheetDragYRef.current = 0;
+  }, []);
+
+  const closeOverlay = useCallback(() => {
+    onOpenChange(false);
+    resetSheetDragState();
+    returnFocusRef?.current?.focus();
+  }, [onOpenChange, resetSheetDragState, returnFocusRef]);
+
+  const handleSheetTouchStart = useCallback((event: TouchEvent<HTMLDivElement>) => {
+    const startY = event.touches[0]?.clientY;
+    sheetTouchStartYRef.current = startY ?? null;
+  }, []);
+
+  const handleSheetTouchMove = useCallback((event: TouchEvent<HTMLDivElement>) => {
+    const startY = sheetTouchStartYRef.current;
+    const currentY = event.touches[0]?.clientY;
+
+    if (startY === null || currentY === undefined) return;
+
+    const delta = currentY - startY;
+    if (delta > 0) {
+      const nextDragY = Math.min(delta, 180);
+      sheetDragYRef.current = nextDragY;
+      setSheetDragY(nextDragY);
+    } else {
+      sheetDragYRef.current = 0;
+      setSheetDragY(0);
+    }
+  }, []);
+
+  const handleSheetTouchEnd = useCallback(() => {
+    if (sheetDragYRef.current > 100) {
+      closeOverlay();
+      sheetTouchStartYRef.current = null;
+      return;
+    }
+
+    resetSheetDragState();
+    sheetTouchStartYRef.current = null;
+  }, [closeOverlay, resetSheetDragState]);
+
+  const handleDialogKeyDown = useCallback((event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Tab") return;
+
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    const focusableElements = Array.from(
+      dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+    ).filter((element) => element.offsetParent !== null || element === document.activeElement);
+
+    if (focusableElements.length === 0) {
+      event.preventDefault();
+      dialog.focus();
+      return;
+    }
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (event.shiftKey && document.activeElement === firstElement) {
+      event.preventDefault();
+      lastElement.focus();
+    } else if (!event.shiftKey && document.activeElement === lastElement) {
+      event.preventDefault();
+      firstElement.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) return;
+    resetSheetDragState();
+  }, [open, resetSheetDragState]);
+
+  useEffect(() => {
+    if (!open) return;
+    closeButtonRef.current?.focus();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closeOverlay();
+      }
+    };
+
+    window.addEventListener("keydown", handleEscape);
+    return () => window.removeEventListener("keydown", handleEscape);
+  }, [closeOverlay, open]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [open]);
+
   const sidebarContent = (
     <SessionRightSidebarContent
       sessionId={sessionId}
@@ -44,39 +170,43 @@ export function SessionDetailsOverlay({
   );
 
   return (
-    <div className={`fixed inset-0 z-50 lg:hidden ${isOpen ? "" : "pointer-events-none"}`}>
+    <div className={`fixed inset-0 z-50 lg:hidden ${open ? "" : "pointer-events-none"}`}>
       <div
         className={`absolute inset-0 bg-overlay transition-opacity duration-200 ${
-          isOpen ? "opacity-100" : "opacity-0"
+          open ? "opacity-100" : "opacity-0"
         }`}
-        onClick={onClose}
+        onClick={closeOverlay}
       />
 
       {isPhone ? (
         <div
+          ref={dialogRef}
           id="session-details-dialog"
           role="dialog"
           aria-modal="true"
           aria-label="Session details"
+          tabIndex={-1}
           className="absolute inset-x-0 bottom-0 max-h-[85vh] bg-background border-t border-border-muted shadow-xl flex flex-col"
+          onKeyDown={handleDialogKeyDown}
           style={{
-            transform: isOpen ? `translateY(${sheetDragY}px)` : "translateY(100%)",
+            transform: open ? `translateY(${sheetDragY}px)` : "translateY(100%)",
             transition: sheetDragY > 0 ? "none" : "transform 200ms ease-in-out",
           }}
         >
           <div
             className="px-4 pt-3 pb-2 border-b border-border-muted"
-            onTouchStart={onSheetTouchStart}
-            onTouchMove={onSheetTouchMove}
-            onTouchEnd={onSheetTouchEnd}
-            onTouchCancel={onSheetTouchEnd}
+            onTouchStart={handleSheetTouchStart}
+            onTouchMove={handleSheetTouchMove}
+            onTouchEnd={handleSheetTouchEnd}
+            onTouchCancel={handleSheetTouchEnd}
           >
             <div className="mx-auto mb-2 h-1.5 w-12 rounded-full bg-muted" />
             <div className="flex items-center justify-between">
               <h2 className="text-sm font-medium text-foreground">Session details</h2>
               <button
+                ref={closeButtonRef}
                 type="button"
-                onClick={onClose}
+                onClick={closeOverlay}
                 className="text-sm text-muted-foreground hover:text-foreground transition"
               >
                 Close
@@ -87,18 +217,22 @@ export function SessionDetailsOverlay({
         </div>
       ) : (
         <div
+          ref={dialogRef}
           id="session-details-dialog"
           role="dialog"
           aria-modal="true"
           aria-label="Session details"
+          tabIndex={-1}
           className="absolute inset-y-0 right-0 w-80 max-w-[85vw] bg-background border-l border-border-muted shadow-xl flex flex-col transition-transform duration-200 ease-in-out"
-          style={{ transform: isOpen ? "translateX(0)" : "translateX(100%)" }}
+          onKeyDown={handleDialogKeyDown}
+          style={{ transform: open ? "translateX(0)" : "translateX(100%)" }}
         >
           <div className="px-4 py-3 border-b border-border-muted flex items-center justify-between">
             <h2 className="text-sm font-medium text-foreground">Session details</h2>
             <button
+              ref={closeButtonRef}
               type="button"
-              onClick={onClose}
+              onClick={closeOverlay}
               className="text-sm text-muted-foreground hover:text-foreground transition"
             >
               Close

--- a/packages/web/src/components/session-details-overlay.tsx
+++ b/packages/web/src/components/session-details-overlay.tsx
@@ -1,0 +1,112 @@
+import {
+  SessionRightSidebarContent,
+  type SessionRightSidebarContentProps,
+} from "./session-right-sidebar";
+
+interface SessionDetailsOverlayProps extends SessionRightSidebarContentProps {
+  isOpen: boolean;
+  isPhone: boolean;
+  sheetDragY: number;
+  onClose: () => void;
+  onSheetTouchStart: React.TouchEventHandler<HTMLDivElement>;
+  onSheetTouchMove: React.TouchEventHandler<HTMLDivElement>;
+  onSheetTouchEnd: React.TouchEventHandler<HTMLDivElement>;
+}
+
+export function SessionDetailsOverlay({
+  isOpen,
+  isPhone,
+  sheetDragY,
+  onClose,
+  onSheetTouchStart,
+  onSheetTouchMove,
+  onSheetTouchEnd,
+  sessionId,
+  sessionState,
+  participants,
+  events,
+  artifacts,
+  terminalOpen,
+  onToggleTerminal,
+  onOpenMedia,
+}: SessionDetailsOverlayProps) {
+  const sidebarContent = (
+    <SessionRightSidebarContent
+      sessionId={sessionId}
+      sessionState={sessionState}
+      participants={participants}
+      events={events}
+      artifacts={artifacts}
+      terminalOpen={terminalOpen}
+      onToggleTerminal={onToggleTerminal}
+      onOpenMedia={onOpenMedia}
+    />
+  );
+
+  return (
+    <div className={`fixed inset-0 z-50 lg:hidden ${isOpen ? "" : "pointer-events-none"}`}>
+      <div
+        className={`absolute inset-0 bg-overlay transition-opacity duration-200 ${
+          isOpen ? "opacity-100" : "opacity-0"
+        }`}
+        onClick={onClose}
+      />
+
+      {isPhone ? (
+        <div
+          id="session-details-dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Session details"
+          className="absolute inset-x-0 bottom-0 max-h-[85vh] bg-background border-t border-border-muted shadow-xl flex flex-col"
+          style={{
+            transform: isOpen ? `translateY(${sheetDragY}px)` : "translateY(100%)",
+            transition: sheetDragY > 0 ? "none" : "transform 200ms ease-in-out",
+          }}
+        >
+          <div
+            className="px-4 pt-3 pb-2 border-b border-border-muted"
+            onTouchStart={onSheetTouchStart}
+            onTouchMove={onSheetTouchMove}
+            onTouchEnd={onSheetTouchEnd}
+            onTouchCancel={onSheetTouchEnd}
+          >
+            <div className="mx-auto mb-2 h-1.5 w-12 rounded-full bg-muted" />
+            <div className="flex items-center justify-between">
+              <h2 className="text-sm font-medium text-foreground">Session details</h2>
+              <button
+                type="button"
+                onClick={onClose}
+                className="text-sm text-muted-foreground hover:text-foreground transition"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+          <div className="overflow-y-auto">{sidebarContent}</div>
+        </div>
+      ) : (
+        <div
+          id="session-details-dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Session details"
+          className="absolute inset-y-0 right-0 w-80 max-w-[85vw] bg-background border-l border-border-muted shadow-xl flex flex-col transition-transform duration-200 ease-in-out"
+          style={{ transform: isOpen ? "translateX(0)" : "translateX(100%)" }}
+        >
+          <div className="px-4 py-3 border-b border-border-muted flex items-center justify-between">
+            <h2 className="text-sm font-medium text-foreground">Session details</h2>
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-sm text-muted-foreground hover:text-foreground transition"
+            >
+              Close
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto">{sidebarContent}</div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract the responsive mobile/tablet session details overlay from the session page into `SessionDetailsOverlay`.
- Preserve the existing dialog attributes, close behavior, drag handlers, transitions, terminal toggle, and media open plumbing.

## Checks
- `npm run typecheck -w @open-inspect/web`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/e7533f132139f48c31e02115efd35471)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved session details interface with optimized responsive layouts. Mobile users now see a bottom sheet overlay with touch and drag gesture support, while desktop users benefit from an enhanced side panel. Both layouts include a clear header and close button for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->