### PR TITLE
refactor: extract session prompt composer

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -20,14 +20,14 @@ import { ScreenshotArtifactCard } from "@/components/screenshot-artifact-card";
 import { MediaLightbox } from "@/components/media-lightbox";
 import { Button } from "@/components/ui/button";
 import { useSidebarContext } from "@/components/sidebar-layout";
+import { SessionPromptComposer } from "@/components/session-prompt-composer";
 import {
   SessionRightSidebar,
   SessionRightSidebarContent,
 } from "@/components/session-right-sidebar";
 import { Group as PanelGroup, Panel, Separator as PanelResizeHandle } from "react-resizable-panels";
 import { TerminalPanel } from "@/components/terminal-panel";
-import { ActionBar } from "@/components/action-bar";
-import { copyToClipboard, formatModelNameLower } from "@/lib/format";
+import { copyToClipboard } from "@/lib/format";
 import { archiveSession } from "@/lib/archive-session";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import {
@@ -39,18 +39,8 @@ import {
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { DEFAULT_MODEL, getDefaultReasoningEffort, type ModelCategory } from "@open-inspect/shared";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
-import { ReasoningEffortPills } from "@/components/reasoning-effort-pills";
 import type { Artifact, SandboxEvent } from "@/types/session";
-import {
-  SidebarIcon,
-  ModelIcon,
-  CheckIcon,
-  SendIcon,
-  StopIcon,
-  CopyIcon,
-  ErrorIcon,
-} from "@/components/ui/icons";
-import { Combobox, type ComboboxGroup } from "@/components/ui/combobox";
+import { SidebarIcon, CheckIcon, CopyIcon, ErrorIcon } from "@/components/ui/icons";
 
 type ToolCallEvent = Extract<SandboxEvent, { type: "tool_call" }>;
 // Event grouping types
@@ -986,111 +976,25 @@ function SessionContent({
         }}
       />
 
-      {/* Input */}
-      <footer className="border-t border-border-muted flex-shrink-0">
-        <form onSubmit={handleSubmit} className="max-w-4xl mx-auto p-4 pb-6">
-          {/* Action bar above input */}
-          <div className="mb-3">
-            <ActionBar
-              sessionId={sessionState?.id || ""}
-              sessionStatus={sessionState?.status || ""}
-              artifacts={artifacts}
-              onArchive={handleArchive}
-              onUnarchive={handleUnarchive}
-            />
-          </div>
-
-          {/* Input container */}
-          <div className="border border-border bg-input">
-            {/* Text input area with floating send button */}
-            <div className="relative">
-              <textarea
-                ref={inputRef}
-                value={prompt}
-                onChange={handleInputChange}
-                onKeyDown={handleKeyDown}
-                placeholder={isProcessing ? "Type your next message..." : "Ask or build anything"}
-                className="w-full resize-none bg-transparent px-4 pt-4 pb-12 focus:outline-none text-foreground placeholder:text-secondary-foreground"
-                rows={3}
-              />
-              {/* Floating action buttons */}
-              <div className="absolute bottom-3 right-3 flex items-center gap-2">
-                {isProcessing && prompt.trim() && (
-                  <span className="text-xs text-warning">Waiting...</span>
-                )}
-                {isProcessing && (
-                  <button
-                    type="button"
-                    onClick={stopExecution}
-                    className="p-2 text-destructive hover:bg-destructive-muted transition"
-                    title="Stop"
-                  >
-                    <StopIcon className="w-5 h-5" />
-                  </button>
-                )}
-                <button
-                  type="submit"
-                  disabled={!prompt.trim() || isProcessing}
-                  className="p-2 text-secondary-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition"
-                  title={
-                    isProcessing && prompt.trim()
-                      ? "Wait for execution to complete"
-                      : `Send (${SHORTCUT_LABELS.SEND_PROMPT})`
-                  }
-                  aria-label={
-                    isProcessing && prompt.trim()
-                      ? "Wait for execution to complete"
-                      : `Send (${SHORTCUT_LABELS.SEND_PROMPT})`
-                  }
-                >
-                  <SendIcon className="w-5 h-5" />
-                </button>
-              </div>
-            </div>
-
-            {/* Footer row with model selector, reasoning pills, and agent label */}
-            <div className="flex flex-col gap-2 px-4 py-2 border-t border-border-muted sm:flex-row sm:items-center sm:justify-between sm:gap-0">
-              {/* Left side - Model selector + Reasoning pills */}
-              <div className="flex flex-wrap items-center gap-2 sm:gap-4 min-w-0">
-                <Combobox
-                  value={selectedModel}
-                  onChange={setSelectedModel}
-                  items={
-                    modelOptions.map((group) => ({
-                      category: group.category,
-                      options: group.models.map((model) => ({
-                        value: model.id,
-                        label: model.name,
-                        description: model.description,
-                      })),
-                    })) as ComboboxGroup[]
-                  }
-                  direction="up"
-                  dropdownWidth="w-56"
-                  disabled={isProcessing}
-                  triggerClassName="flex max-w-full items-center gap-1 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
-                >
-                  <ModelIcon className="w-3.5 h-3.5" />
-                  <span className="truncate max-w-[9rem] sm:max-w-none">
-                    {formatModelNameLower(selectedModel)}
-                  </span>
-                </Combobox>
-
-                {/* Reasoning effort pills */}
-                <ReasoningEffortPills
-                  selectedModel={selectedModel}
-                  reasoningEffort={reasoningEffort}
-                  onSelect={setReasoningEffort}
-                  disabled={isProcessing}
-                />
-              </div>
-
-              {/* Right side - Agent label */}
-              <span className="hidden sm:inline text-sm text-muted-foreground">build agent</span>
-            </div>
-          </div>
-        </form>
-      </footer>
+      <SessionPromptComposer
+        sessionId={sessionState?.id || ""}
+        sessionStatus={sessionState?.status || ""}
+        artifacts={artifacts}
+        prompt={prompt}
+        isProcessing={isProcessing}
+        selectedModel={selectedModel}
+        reasoningEffort={reasoningEffort}
+        inputRef={inputRef}
+        onSubmit={handleSubmit}
+        onInputChange={handleInputChange}
+        onKeyDown={handleKeyDown}
+        onModelChange={setSelectedModel}
+        onReasoningEffortChange={setReasoningEffort}
+        onStopExecution={stopExecution}
+        onArchive={handleArchive}
+        onUnarchive={handleUnarchive}
+        modelOptions={modelOptions}
+      />
     </div>
   );
 }

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -37,10 +37,11 @@ import {
   type SessionListResponse,
 } from "@/lib/session-list";
 import { useMediaQuery } from "@/hooks/use-media-query";
-import { DEFAULT_MODEL, getDefaultReasoningEffort, type ModelCategory } from "@open-inspect/shared";
+import { DEFAULT_MODEL, getDefaultReasoningEffort } from "@open-inspect/shared";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
 import type { Artifact, SandboxEvent } from "@/types/session";
 import { SidebarIcon, CheckIcon, CopyIcon, ErrorIcon } from "@/components/ui/icons";
+import type { ComboboxGroup } from "@/components/ui/combobox";
 
 type ToolCallEvent = Extract<SandboxEvent, { type: "tool_call" }>;
 // Event grouping types
@@ -298,6 +299,18 @@ function SessionPageContent() {
   const typingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const { enabledModels, enabledModelOptions } = useEnabledModels();
+  const modelItems = useMemo<ComboboxGroup[]>(
+    () =>
+      enabledModelOptions.map((group) => ({
+        category: group.category,
+        options: group.models.map((model) => ({
+          value: model.id,
+          label: model.name,
+          description: model.description,
+        })),
+      })),
+    [enabledModelOptions]
+  );
 
   const handleModelChange = useCallback((model: string) => {
     setSelectedModel(model);
@@ -384,7 +397,7 @@ function SessionPageContent() {
       renameSession={renameSession}
       loadingHistory={loadingHistory}
       loadOlderEvents={loadOlderEvents}
-      modelOptions={enabledModelOptions}
+      modelItems={modelItems}
       fallbackSessionInfo={fallbackSessionInfo}
       sessionId={sessionId}
       selectedMediaArtifactId={selectedMediaArtifactId}
@@ -422,7 +435,7 @@ function SessionContent({
   renameSession,
   loadingHistory,
   loadOlderEvents,
-  modelOptions,
+  modelItems,
   fallbackSessionInfo,
   sessionId,
   selectedMediaArtifactId,
@@ -456,7 +469,7 @@ function SessionContent({
   renameSession: (title: string) => Promise<boolean | undefined>;
   loadingHistory: boolean;
   loadOlderEvents: () => void;
-  modelOptions: ModelCategory[];
+  modelItems: ComboboxGroup[];
   fallbackSessionInfo: FallbackSessionInfo;
   sessionId: string;
   selectedMediaArtifactId: string | null;
@@ -977,23 +990,29 @@ function SessionContent({
       />
 
       <SessionPromptComposer
-        sessionId={sessionState?.id || ""}
-        sessionStatus={sessionState?.status || ""}
-        artifacts={artifacts}
-        prompt={prompt}
-        isProcessing={isProcessing}
-        selectedModel={selectedModel}
-        reasoningEffort={reasoningEffort}
-        inputRef={inputRef}
-        onSubmit={handleSubmit}
-        onInputChange={handleInputChange}
-        onKeyDown={handleKeyDown}
-        onModelChange={setSelectedModel}
-        onReasoningEffortChange={setReasoningEffort}
-        onStopExecution={stopExecution}
-        onArchive={handleArchive}
-        onUnarchive={handleUnarchive}
-        modelOptions={modelOptions}
+        session={{
+          id: sessionId,
+          status: sessionState?.status || "",
+          artifacts,
+          onArchive: handleArchive,
+          onUnarchive: handleUnarchive,
+        }}
+        prompt={{
+          value: prompt,
+          isProcessing,
+          inputRef,
+          onSubmit: handleSubmit,
+          onChange: handleInputChange,
+          onKeyDown: handleKeyDown,
+          onStopExecution: stopExecution,
+        }}
+        model={{
+          selectedModel,
+          reasoningEffort,
+          items: modelItems,
+          onModelChange: setSelectedModel,
+          onReasoningEffortChange: setReasoningEffort,
+        }}
       />
     </div>
   );

--- a/packages/web/src/components/session-prompt-composer.tsx
+++ b/packages/web/src/components/session-prompt-composer.tsx
@@ -7,58 +7,45 @@ import { ModelIcon, SendIcon, StopIcon } from "@/components/ui/icons";
 import { formatModelNameLower } from "@/lib/format";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import type { Artifact } from "@/types/session";
-import type { ModelCategory } from "@open-inspect/shared";
 
 type SessionPromptComposerProps = {
-  sessionId: string;
-  sessionStatus: string;
-  artifacts: Artifact[];
-  prompt: string;
-  isProcessing: boolean;
-  selectedModel: string;
-  reasoningEffort: string | undefined;
-  inputRef: React.RefObject<HTMLTextAreaElement | null>;
-  onSubmit: (e: React.FormEvent) => void;
-  onInputChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
-  onKeyDown: (e: React.KeyboardEvent) => void;
-  onModelChange: (model: string) => void;
-  onReasoningEffortChange: (value: string | undefined) => void;
-  onStopExecution: () => void;
-  onArchive: () => void | Promise<void>;
-  onUnarchive: () => void | Promise<void>;
-  modelOptions: ModelCategory[];
+  session: {
+    id: string;
+    status: string;
+    artifacts: Artifact[];
+    onArchive: () => void | Promise<void>;
+    onUnarchive: () => void | Promise<void>;
+  };
+  prompt: {
+    value: string;
+    isProcessing: boolean;
+    inputRef: React.RefObject<HTMLTextAreaElement | null>;
+    onSubmit: (e: React.FormEvent) => void;
+    onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+    onKeyDown: (e: React.KeyboardEvent) => void;
+    onStopExecution: () => void;
+  };
+  model: {
+    selectedModel: string;
+    reasoningEffort: string | undefined;
+    items: ComboboxGroup[];
+    onModelChange: (model: string) => void;
+    onReasoningEffortChange: (value: string | undefined) => void;
+  };
 };
 
-export function SessionPromptComposer({
-  sessionId,
-  sessionStatus,
-  artifacts,
-  prompt,
-  isProcessing,
-  selectedModel,
-  reasoningEffort,
-  inputRef,
-  onSubmit,
-  onInputChange,
-  onKeyDown,
-  onModelChange,
-  onReasoningEffortChange,
-  onStopExecution,
-  onArchive,
-  onUnarchive,
-  modelOptions,
-}: SessionPromptComposerProps) {
+export function SessionPromptComposer({ session, prompt, model }: SessionPromptComposerProps) {
   return (
     <footer className="border-t border-border-muted flex-shrink-0">
-      <form onSubmit={onSubmit} className="max-w-4xl mx-auto p-4 pb-6">
+      <form onSubmit={prompt.onSubmit} className="max-w-4xl mx-auto p-4 pb-6">
         {/* Action bar above input */}
         <div className="mb-3">
           <ActionBar
-            sessionId={sessionId}
-            sessionStatus={sessionStatus}
-            artifacts={artifacts}
-            onArchive={onArchive}
-            onUnarchive={onUnarchive}
+            sessionId={session.id}
+            sessionStatus={session.status}
+            artifacts={session.artifacts}
+            onArchive={session.onArchive}
+            onUnarchive={session.onUnarchive}
           />
         </div>
 
@@ -67,23 +54,25 @@ export function SessionPromptComposer({
           {/* Text input area with floating send button */}
           <div className="relative">
             <textarea
-              ref={inputRef}
-              value={prompt}
-              onChange={onInputChange}
-              onKeyDown={onKeyDown}
-              placeholder={isProcessing ? "Type your next message..." : "Ask or build anything"}
+              ref={prompt.inputRef}
+              value={prompt.value}
+              onChange={prompt.onChange}
+              onKeyDown={prompt.onKeyDown}
+              placeholder={
+                prompt.isProcessing ? "Type your next message..." : "Ask or build anything"
+              }
               className="w-full resize-none bg-transparent px-4 pt-4 pb-12 focus:outline-none text-foreground placeholder:text-secondary-foreground"
               rows={3}
             />
             {/* Floating action buttons */}
             <div className="absolute bottom-3 right-3 flex items-center gap-2">
-              {isProcessing && prompt.trim() && (
+              {prompt.isProcessing && prompt.value.trim() && (
                 <span className="text-xs text-warning">Waiting...</span>
               )}
-              {isProcessing && (
+              {prompt.isProcessing && (
                 <button
                   type="button"
-                  onClick={onStopExecution}
+                  onClick={prompt.onStopExecution}
                   className="p-2 text-destructive hover:bg-destructive-muted transition"
                   title="Stop"
                 >
@@ -92,15 +81,15 @@ export function SessionPromptComposer({
               )}
               <button
                 type="submit"
-                disabled={!prompt.trim() || isProcessing}
+                disabled={!prompt.value.trim() || prompt.isProcessing}
                 className="p-2 text-secondary-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition"
                 title={
-                  isProcessing && prompt.trim()
+                  prompt.isProcessing && prompt.value.trim()
                     ? "Wait for execution to complete"
                     : `Send (${SHORTCUT_LABELS.SEND_PROMPT})`
                 }
                 aria-label={
-                  isProcessing && prompt.trim()
+                  prompt.isProcessing && prompt.value.trim()
                     ? "Wait for execution to complete"
                     : `Send (${SHORTCUT_LABELS.SEND_PROMPT})`
                 }
@@ -115,35 +104,26 @@ export function SessionPromptComposer({
             {/* Left side - Model selector + Reasoning pills */}
             <div className="flex flex-wrap items-center gap-2 sm:gap-4 min-w-0">
               <Combobox
-                value={selectedModel}
-                onChange={onModelChange}
-                items={
-                  modelOptions.map((group) => ({
-                    category: group.category,
-                    options: group.models.map((model) => ({
-                      value: model.id,
-                      label: model.name,
-                      description: model.description,
-                    })),
-                  })) as ComboboxGroup[]
-                }
+                value={model.selectedModel}
+                onChange={model.onModelChange}
+                items={model.items}
                 direction="up"
                 dropdownWidth="w-56"
-                disabled={isProcessing}
+                disabled={prompt.isProcessing}
                 triggerClassName="flex max-w-full items-center gap-1 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
               >
                 <ModelIcon className="w-3.5 h-3.5" />
                 <span className="truncate max-w-[9rem] sm:max-w-none">
-                  {formatModelNameLower(selectedModel)}
+                  {formatModelNameLower(model.selectedModel)}
                 </span>
               </Combobox>
 
               {/* Reasoning effort pills */}
               <ReasoningEffortPills
-                selectedModel={selectedModel}
-                reasoningEffort={reasoningEffort}
-                onSelect={onReasoningEffortChange}
-                disabled={isProcessing}
+                selectedModel={model.selectedModel}
+                reasoningEffort={model.reasoningEffort}
+                onSelect={model.onReasoningEffortChange}
+                disabled={prompt.isProcessing}
               />
             </div>
 

--- a/packages/web/src/components/session-prompt-composer.tsx
+++ b/packages/web/src/components/session-prompt-composer.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { ActionBar } from "@/components/action-bar";
+import { ReasoningEffortPills } from "@/components/reasoning-effort-pills";
+import { Combobox, type ComboboxGroup } from "@/components/ui/combobox";
+import { ModelIcon, SendIcon, StopIcon } from "@/components/ui/icons";
+import { formatModelNameLower } from "@/lib/format";
+import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
+import type { Artifact } from "@/types/session";
+import type { ModelCategory } from "@open-inspect/shared";
+
+type SessionPromptComposerProps = {
+  sessionId: string;
+  sessionStatus: string;
+  artifacts: Artifact[];
+  prompt: string;
+  isProcessing: boolean;
+  selectedModel: string;
+  reasoningEffort: string | undefined;
+  inputRef: React.RefObject<HTMLTextAreaElement | null>;
+  onSubmit: (e: React.FormEvent) => void;
+  onInputChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onKeyDown: (e: React.KeyboardEvent) => void;
+  onModelChange: (model: string) => void;
+  onReasoningEffortChange: (value: string | undefined) => void;
+  onStopExecution: () => void;
+  onArchive: () => void | Promise<void>;
+  onUnarchive: () => void | Promise<void>;
+  modelOptions: ModelCategory[];
+};
+
+export function SessionPromptComposer({
+  sessionId,
+  sessionStatus,
+  artifacts,
+  prompt,
+  isProcessing,
+  selectedModel,
+  reasoningEffort,
+  inputRef,
+  onSubmit,
+  onInputChange,
+  onKeyDown,
+  onModelChange,
+  onReasoningEffortChange,
+  onStopExecution,
+  onArchive,
+  onUnarchive,
+  modelOptions,
+}: SessionPromptComposerProps) {
+  return (
+    <footer className="border-t border-border-muted flex-shrink-0">
+      <form onSubmit={onSubmit} className="max-w-4xl mx-auto p-4 pb-6">
+        {/* Action bar above input */}
+        <div className="mb-3">
+          <ActionBar
+            sessionId={sessionId}
+            sessionStatus={sessionStatus}
+            artifacts={artifacts}
+            onArchive={onArchive}
+            onUnarchive={onUnarchive}
+          />
+        </div>
+
+        {/* Input container */}
+        <div className="border border-border bg-input">
+          {/* Text input area with floating send button */}
+          <div className="relative">
+            <textarea
+              ref={inputRef}
+              value={prompt}
+              onChange={onInputChange}
+              onKeyDown={onKeyDown}
+              placeholder={isProcessing ? "Type your next message..." : "Ask or build anything"}
+              className="w-full resize-none bg-transparent px-4 pt-4 pb-12 focus:outline-none text-foreground placeholder:text-secondary-foreground"
+              rows={3}
+            />
+            {/* Floating action buttons */}
+            <div className="absolute bottom-3 right-3 flex items-center gap-2">
+              {isProcessing && prompt.trim() && (
+                <span className="text-xs text-warning">Waiting...</span>
+              )}
+              {isProcessing && (
+                <button
+                  type="button"
+                  onClick={onStopExecution}
+                  className="p-2 text-destructive hover:bg-destructive-muted transition"
+                  title="Stop"
+                >
+                  <StopIcon className="w-5 h-5" />
+                </button>
+              )}
+              <button
+                type="submit"
+                disabled={!prompt.trim() || isProcessing}
+                className="p-2 text-secondary-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition"
+                title={
+                  isProcessing && prompt.trim()
+                    ? "Wait for execution to complete"
+                    : `Send (${SHORTCUT_LABELS.SEND_PROMPT})`
+                }
+                aria-label={
+                  isProcessing && prompt.trim()
+                    ? "Wait for execution to complete"
+                    : `Send (${SHORTCUT_LABELS.SEND_PROMPT})`
+                }
+              >
+                <SendIcon className="w-5 h-5" />
+              </button>
+            </div>
+          </div>
+
+          {/* Footer row with model selector, reasoning pills, and agent label */}
+          <div className="flex flex-col gap-2 px-4 py-2 border-t border-border-muted sm:flex-row sm:items-center sm:justify-between sm:gap-0">
+            {/* Left side - Model selector + Reasoning pills */}
+            <div className="flex flex-wrap items-center gap-2 sm:gap-4 min-w-0">
+              <Combobox
+                value={selectedModel}
+                onChange={onModelChange}
+                items={
+                  modelOptions.map((group) => ({
+                    category: group.category,
+                    options: group.models.map((model) => ({
+                      value: model.id,
+                      label: model.name,
+                      description: model.description,
+                    })),
+                  })) as ComboboxGroup[]
+                }
+                direction="up"
+                dropdownWidth="w-56"
+                disabled={isProcessing}
+                triggerClassName="flex max-w-full items-center gap-1 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
+              >
+                <ModelIcon className="w-3.5 h-3.5" />
+                <span className="truncate max-w-[9rem] sm:max-w-none">
+                  {formatModelNameLower(selectedModel)}
+                </span>
+              </Combobox>
+
+              {/* Reasoning effort pills */}
+              <ReasoningEffortPills
+                selectedModel={selectedModel}
+                reasoningEffort={reasoningEffort}
+                onSelect={onReasoningEffortChange}
+                disabled={isProcessing}
+              />
+            </div>
+
+            {/* Right side - Agent label */}
+            <span className="hidden sm:inline text-sm text-muted-foreground">build agent</span>
+          </div>
+        </div>
+      </form>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract the session footer prompt composer into `SessionPromptComposer` under `packages/web/src/components`.
- Keep prompt state, submit/key/change handlers, model selection, reasoning effort, stop/archive behavior, and labels wired through props from the session page.

## Checks
- `npm run typecheck -w @open-inspect/web`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/84e7cda5162806ca91cfe6d1e59e7495)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the session chat footer with a modular composer: controlled textarea, send/stop buttons with proper enable/disable and "Waiting..." indicator, model selector, and reasoning-effort pills.
  * Footer includes archive/unarchive controls and a small-screen "build agent" label.

* **Refactor**
  * Reorganized session chat interface into a reusable composer for improved modularity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->