### PR TITLE
Refactor session timeline rendering

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -3,15 +3,7 @@
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { mutate } from "swr";
 import useSWRMutation from "swr/mutation";
-import {
-  Suspense,
-  useState,
-  useRef,
-  useEffect,
-  useLayoutEffect,
-  useCallback,
-  useMemo,
-} from "react";
+import { Suspense, useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { useSessionSocket } from "@/hooks/use-session-socket";
 import { SessionTimeline } from "@/components/session-timeline";
 import { MediaLightbox } from "@/components/media-lightbox";
@@ -202,7 +194,6 @@ function SessionPageContent() {
   const [reasoningEffort, setReasoningEffort] = useState<string | undefined>(
     getDefaultReasoningEffort(DEFAULT_MODEL)
   );
-  const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const typingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -276,7 +267,6 @@ function SessionPageContent() {
       events={events}
       artifacts={artifacts}
       currentParticipantId={currentParticipantId}
-      messagesEndRef={messagesEndRef}
       prompt={prompt}
       isProcessing={isProcessing}
       selectedModel={selectedModel}
@@ -314,7 +304,6 @@ function SessionContent({
   events,
   artifacts,
   currentParticipantId,
-  messagesEndRef,
   prompt,
   isProcessing,
   selectedModel,
@@ -348,7 +337,6 @@ function SessionContent({
   events: ReturnType<typeof useSessionSocket>["events"];
   artifacts: ReturnType<typeof useSessionSocket>["artifacts"];
   currentParticipantId: string | null;
-  messagesEndRef: React.RefObject<HTMLDivElement | null>;
   prompt: string;
   isProcessing: boolean;
   selectedModel: string;
@@ -410,14 +398,6 @@ function SessionContent({
   const ttydUrl = sessionState?.ttydUrl;
   const ttydToken = sessionState?.ttydToken;
   const showTerminal = !!(ttydUrl && ttydToken && terminalOpen && !isBelowLg);
-
-  // Scroll pagination refs
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const topSentinelRef = useRef<HTMLDivElement>(null);
-  const hasScrolledRef = useRef(false);
-  const isPrependingRef = useRef(false);
-  const prevScrollHeightRef = useRef(0);
-  const isNearBottomRef = useRef(true);
 
   const resetSheetDragState = useCallback(() => {
     setSheetDragY(0);
@@ -547,55 +527,6 @@ function SessionContent({
       document.body.style.overflow = originalOverflow;
     };
   }, [isDetailsOpen]);
-
-  // Track user scroll
-  const handleScroll = useCallback(() => {
-    hasScrolledRef.current = true;
-    const el = scrollContainerRef.current;
-    if (el) {
-      isNearBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
-    }
-  }, []);
-
-  // IntersectionObserver to trigger loading older events
-  useEffect(() => {
-    const sentinel = topSentinelRef.current;
-    const container = scrollContainerRef.current;
-    if (!sentinel || !container) return;
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (
-          entry.isIntersecting &&
-          hasScrolledRef.current &&
-          container.scrollHeight > container.clientHeight
-        ) {
-          // Capture scroll height BEFORE triggering load
-          prevScrollHeightRef.current = container.scrollHeight;
-          isPrependingRef.current = true;
-          loadOlderEvents();
-        }
-      },
-      { root: container, threshold: 0.1 }
-    );
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [loadOlderEvents]);
-
-  // Maintain scroll position when older events are prepended
-  useLayoutEffect(() => {
-    if (isPrependingRef.current && scrollContainerRef.current) {
-      const el = scrollContainerRef.current;
-      el.scrollTop += el.scrollHeight - prevScrollHeightRef.current;
-      isPrependingRef.current = false;
-    }
-  }, [events]);
-
-  // Auto-scroll to bottom only when near bottom (not when prepending older history)
-  useEffect(() => {
-    if (isNearBottomRef.current && !isPrependingRef.current) {
-      messagesEndRef.current?.scrollIntoView({ behavior: "auto" });
-    }
-  }, [events, messagesEndRef]);
 
   const mediaArtifacts = useMemo(
     () =>
@@ -728,10 +659,7 @@ function SessionContent({
                 isProcessing={isProcessing}
                 loadingHistory={loadingHistory}
                 showSkeleton={showTimelineSkeleton}
-                scrollContainerRef={scrollContainerRef}
-                topSentinelRef={topSentinelRef}
-                messagesEndRef={messagesEndRef}
-                onScroll={handleScroll}
+                onLoadOlder={loadOlderEvents}
                 onOpenMedia={setSelectedMediaArtifactId}
               />
             </Panel>

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -5,7 +5,6 @@ import { mutate } from "swr";
 import useSWRMutation from "swr/mutation";
 import {
   Suspense,
-  memo,
   useState,
   useRef,
   useEffect,
@@ -14,9 +13,7 @@ import {
   useMemo,
 } from "react";
 import { useSessionSocket } from "@/hooks/use-session-socket";
-import { SafeMarkdown } from "@/components/safe-markdown";
-import { ToolCallGroup } from "@/components/tool-call-group";
-import { ScreenshotArtifactCard } from "@/components/screenshot-artifact-card";
+import { SessionTimeline } from "@/components/session-timeline";
 import { MediaLightbox } from "@/components/media-lightbox";
 import { Button } from "@/components/ui/button";
 import { useSidebarContext } from "@/components/sidebar-layout";
@@ -27,7 +24,7 @@ import {
 import { Group as PanelGroup, Panel, Separator as PanelResizeHandle } from "react-resizable-panels";
 import { TerminalPanel } from "@/components/terminal-panel";
 import { ActionBar } from "@/components/action-bar";
-import { copyToClipboard, formatModelNameLower } from "@/lib/format";
+import { formatModelNameLower } from "@/lib/format";
 import { archiveSession } from "@/lib/archive-session";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import {
@@ -40,23 +37,8 @@ import { useMediaQuery } from "@/hooks/use-media-query";
 import { DEFAULT_MODEL, getDefaultReasoningEffort, type ModelCategory } from "@open-inspect/shared";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
 import { ReasoningEffortPills } from "@/components/reasoning-effort-pills";
-import type { Artifact, SandboxEvent } from "@/types/session";
-import {
-  SidebarIcon,
-  ModelIcon,
-  CheckIcon,
-  SendIcon,
-  StopIcon,
-  CopyIcon,
-  ErrorIcon,
-} from "@/components/ui/icons";
+import { SidebarIcon, ModelIcon, SendIcon, StopIcon } from "@/components/ui/icons";
 import { Combobox, type ComboboxGroup } from "@/components/ui/combobox";
-
-type ToolCallEvent = Extract<SandboxEvent, { type: "tool_call" }>;
-// Event grouping types
-type EventGroup =
-  | { type: "tool_group"; events: ToolCallEvent[]; id: string }
-  | { type: "single"; event: SandboxEvent; id: string };
 
 type SessionState = ReturnType<typeof useSessionSocket>["sessionState"];
 
@@ -65,89 +47,6 @@ type FallbackSessionInfo = {
   repoName: string | null;
   title: string | null;
 };
-
-// Group consecutive tool calls of the same type
-function groupEvents(events: SandboxEvent[]): EventGroup[] {
-  const groups: EventGroup[] = [];
-  let currentToolGroup: ToolCallEvent[] = [];
-  let groupIndex = 0;
-
-  const flushToolGroup = () => {
-    if (currentToolGroup.length > 0) {
-      groups.push({
-        type: "tool_group",
-        events: [...currentToolGroup],
-        id: `tool-group-${groupIndex++}`,
-      });
-      currentToolGroup = [];
-    }
-  };
-
-  for (const event of events) {
-    if (event.type === "tool_call") {
-      // Check if same tool as current group
-      if (currentToolGroup.length > 0 && currentToolGroup[0].tool === event.tool) {
-        currentToolGroup.push(event);
-      } else {
-        // Flush previous group and start new one
-        flushToolGroup();
-        currentToolGroup = [event];
-      }
-    } else {
-      // Flush any tool group before non-tool event
-      flushToolGroup();
-      groups.push({
-        type: "single",
-        event,
-        id: `single-${event.type}-${("messageId" in event ? event.messageId : undefined) || event.timestamp}-${groupIndex++}`,
-      });
-    }
-  }
-
-  // Flush final group
-  flushToolGroup();
-
-  return groups;
-}
-
-function dedupeAndGroupEvents(events: SandboxEvent[]): EventGroup[] {
-  const filteredEvents: Array<SandboxEvent | null> = [];
-  const seenToolCalls = new Map<string, number>();
-  const seenCompletions = new Set<string>();
-  const seenTokens = new Map<string, number>();
-
-  for (const event of events) {
-    if (event.type === "tool_call" && event.callId) {
-      // Deduplicate tool_call events by callId - keep the latest (most complete) one
-      const existingIdx = seenToolCalls.get(event.callId);
-      if (existingIdx !== undefined) {
-        filteredEvents[existingIdx] = event;
-      } else {
-        seenToolCalls.set(event.callId, filteredEvents.length);
-        filteredEvents.push(event);
-      }
-    } else if (event.type === "execution_complete" && event.messageId) {
-      // Skip duplicate execution_complete for the same message
-      if (!seenCompletions.has(event.messageId)) {
-        seenCompletions.add(event.messageId);
-        filteredEvents.push(event);
-      }
-    } else if (event.type === "token" && event.messageId) {
-      // Deduplicate tokens by messageId - keep latest at its chronological position
-      const existingIdx = seenTokens.get(event.messageId);
-      if (existingIdx !== undefined) {
-        filteredEvents[existingIdx] = null;
-      }
-      seenTokens.set(event.messageId, filteredEvents.length);
-      filteredEvents.push(event);
-    } else {
-      // All other events (user_message, git_sync, etc.) - add as-is
-      filteredEvents.push(event);
-    }
-  }
-
-  return groupEvents(filteredEvents.filter((event): event is SandboxEvent => event !== null));
-}
 
 function resolveSessionDisplayInfo(
   sessionState: SessionState,
@@ -698,8 +597,6 @@ function SessionContent({
     }
   }, [events, messagesEndRef]);
 
-  // Deduplicate and group events for rendering
-  const groupedEvents = useMemo(() => dedupeAndGroupEvents(events), [events]);
   const mediaArtifacts = useMemo(
     () =>
       artifacts.filter((artifact) => artifact.type === "screenshot" || artifact.type === "video"),
@@ -824,39 +721,19 @@ function SessionContent({
           <PanelGroup orientation="vertical" id="session-terminal">
             {/* Chat / Event Timeline */}
             <Panel defaultSize={showTerminal ? "70%" : "100%"} minSize="30%">
-              <div
-                ref={scrollContainerRef}
+              <SessionTimeline
+                events={events}
+                sessionId={sessionId}
+                currentParticipantId={currentParticipantId}
+                isProcessing={isProcessing}
+                loadingHistory={loadingHistory}
+                showSkeleton={showTimelineSkeleton}
+                scrollContainerRef={scrollContainerRef}
+                topSentinelRef={topSentinelRef}
+                messagesEndRef={messagesEndRef}
                 onScroll={handleScroll}
-                className="h-full overflow-y-auto overflow-x-hidden p-4"
-              >
-                <div className="max-w-3xl mx-auto space-y-2">
-                  {/* Scroll sentinel for loading older history */}
-                  <div ref={topSentinelRef} className="h-1" />
-                  {loadingHistory && (
-                    <div className="text-center text-muted-foreground text-sm py-2">Loading...</div>
-                  )}
-                  {showTimelineSkeleton ? (
-                    <TimelineSkeleton />
-                  ) : (
-                    groupedEvents.map((group) =>
-                      group.type === "tool_group" ? (
-                        <ToolCallGroup key={group.id} events={group.events} groupId={group.id} />
-                      ) : (
-                        <EventItem
-                          key={group.id}
-                          event={group.event}
-                          sessionId={sessionId}
-                          currentParticipantId={currentParticipantId}
-                          onOpenMedia={setSelectedMediaArtifactId}
-                        />
-                      )
-                    )
-                  )}
-                  {isProcessing && <ThinkingIndicator />}
-
-                  <div ref={messagesEndRef} />
-                </div>
-              </div>
+                onOpenMedia={setSelectedMediaArtifactId}
+              />
             </Panel>
 
             {/* Terminal panel — only rendered when URL + token available and open */}
@@ -1202,35 +1079,6 @@ function CombinedStatusDot({
   );
 }
 
-function ThinkingIndicator() {
-  return (
-    <div className="bg-card p-4 flex items-center gap-2">
-      <span className="inline-block w-2 h-2 bg-accent rounded-full animate-pulse" />
-      <span className="text-sm text-muted-foreground">Thinking...</span>
-    </div>
-  );
-}
-
-function TimelineSkeleton() {
-  return (
-    <div className="space-y-3 py-2 animate-pulse">
-      <div className="bg-card p-4 space-y-2">
-        <div className="h-3 w-24 bg-muted rounded" />
-        <div className="h-3 w-full bg-muted rounded" />
-        <div className="h-3 w-5/6 bg-muted rounded" />
-      </div>
-      <div className="bg-accent-muted p-4 ml-8 space-y-2">
-        <div className="h-3 w-20 bg-muted rounded" />
-        <div className="h-3 w-4/5 bg-muted rounded" />
-      </div>
-      <div className="bg-card p-4 space-y-2">
-        <div className="h-3 w-32 bg-muted rounded" />
-        <div className="h-3 w-3/4 bg-muted rounded" />
-      </div>
-    </div>
-  );
-}
-
 function ParticipantsList({
   participants,
 }: {
@@ -1260,198 +1108,3 @@ function ParticipantsList({
     </div>
   );
 }
-
-const EventItem = memo(function EventItem({
-  event,
-  sessionId,
-  currentParticipantId,
-  onOpenMedia,
-}: {
-  event: SandboxEvent;
-  sessionId: string;
-  currentParticipantId: string | null;
-  onOpenMedia: (artifactId: string) => void;
-}) {
-  const [copied, setCopied] = useState(false);
-  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const time = new Date(event.timestamp * 1000).toLocaleTimeString();
-
-  useEffect(() => {
-    return () => {
-      if (copyTimeoutRef.current) {
-        clearTimeout(copyTimeoutRef.current);
-      }
-    };
-  }, []);
-
-  const handleCopyContent = useCallback(async (content: string) => {
-    const success = await copyToClipboard(content);
-    if (!success) return;
-
-    setCopied(true);
-    if (copyTimeoutRef.current) {
-      clearTimeout(copyTimeoutRef.current);
-    }
-    copyTimeoutRef.current = setTimeout(() => {
-      setCopied(false);
-      copyTimeoutRef.current = null;
-    }, 1500);
-  }, []);
-
-  switch (event.type) {
-    case "user_message": {
-      // Display user's prompt with correct author attribution
-      if (!event.content) return null;
-      const messageContent = event.content;
-
-      // Determine if this message is from the current user
-      const isCurrentUser =
-        event.author?.participantId && currentParticipantId
-          ? event.author.participantId === currentParticipantId
-          : !event.author; // Messages without author are assumed to be from current user (local)
-
-      const authorName = isCurrentUser ? "You" : event.author?.name || "Unknown User";
-
-      return (
-        <div className="group bg-accent-muted p-4 ml-8">
-          <div className="flex items-center justify-between mb-2">
-            <div className="flex items-center gap-2">
-              {!isCurrentUser && event.author?.avatar && (
-                <img src={event.author.avatar} alt={authorName} className="w-5 h-5 rounded-full" />
-              )}
-              <span className="text-xs text-accent">{authorName}</span>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <button
-                type="button"
-                onClick={() => handleCopyContent(messageContent)}
-                className="p-1 text-secondary-foreground hover:text-foreground hover:bg-muted/60 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto transition-colors"
-                title={copied ? "Copied" : "Copy markdown"}
-                aria-label={copied ? "Copied" : "Copy markdown"}
-              >
-                {copied ? (
-                  <CheckIcon className="w-3.5 h-3.5" />
-                ) : (
-                  <CopyIcon className="w-3.5 h-3.5" />
-                )}
-              </button>
-              <span className="text-xs text-secondary-foreground">{time}</span>
-            </div>
-          </div>
-          <pre className="whitespace-pre-wrap text-sm text-foreground">{messageContent}</pre>
-        </div>
-      );
-    }
-
-    case "token": {
-      // Display the model's text response with safe markdown rendering
-      if (!event.content) return null;
-      const messageContent = event.content;
-      return (
-        <div className="group bg-card p-4">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-xs text-muted-foreground">Assistant</span>
-            <div className="flex items-center gap-1.5">
-              <button
-                type="button"
-                onClick={() => handleCopyContent(messageContent)}
-                className="p-1 text-secondary-foreground hover:text-foreground hover:bg-muted opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto transition-colors"
-                title={copied ? "Copied" : "Copy markdown"}
-                aria-label={copied ? "Copied" : "Copy markdown"}
-              >
-                {copied ? (
-                  <CheckIcon className="w-3.5 h-3.5" />
-                ) : (
-                  <CopyIcon className="w-3.5 h-3.5" />
-                )}
-              </button>
-              <span className="text-xs text-secondary-foreground">{time}</span>
-            </div>
-          </div>
-          <SafeMarkdown content={messageContent} className="text-sm" />
-        </div>
-      );
-    }
-
-    case "tool_call":
-      // Tool calls are handled by ToolCallGroup component
-      return null;
-
-    case "tool_result":
-      // Tool results are now shown inline with tool calls
-      // Only show standalone results if they're errors
-      if (!event.error) return null;
-      return (
-        <div className="flex items-center gap-2 text-sm text-destructive py-1">
-          <ErrorIcon className="w-4 h-4" />
-          <span className="truncate">{event.error}</span>
-          <span className="text-xs text-secondary-foreground ml-auto">{time}</span>
-        </div>
-      );
-
-    case "git_sync":
-      return (
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <span className="w-2 h-2 rounded-full bg-accent" />
-          Git sync: {event.status}
-          <span className="text-xs">{time}</span>
-        </div>
-      );
-
-    case "artifact":
-      if (
-        (event.artifactType !== "screenshot" && event.artifactType !== "video") ||
-        !event.artifactId
-      ) {
-        return null;
-      }
-
-      return (
-        <div className="space-y-2 border border-border-muted bg-card p-4">
-          <div className="flex items-center justify-between">
-            <span className="text-xs text-muted-foreground">
-              {event.artifactType === "video" ? "Video" : "Screenshot"}
-            </span>
-            <span className="text-xs text-secondary-foreground">{time}</span>
-          </div>
-          <ScreenshotArtifactCard
-            sessionId={sessionId}
-            artifactId={event.artifactId}
-            artifactType={event.artifactType}
-            metadata={event.metadata as Artifact["metadata"] | undefined}
-            onOpen={onOpenMedia}
-          />
-        </div>
-      );
-
-    case "error":
-      return (
-        <div className="flex items-center gap-2 text-sm text-destructive">
-          <span className="w-2 h-2 rounded-full bg-destructive" />
-          Error{event.error ? `: ${event.error}` : ""}
-          <span className="text-xs text-secondary-foreground">{time}</span>
-        </div>
-      );
-
-    case "execution_complete":
-      if (event.success === false) {
-        return (
-          <div className="flex items-center gap-2 text-sm text-destructive">
-            <span className="w-2 h-2 rounded-full bg-destructive" />
-            Execution failed{event.error ? `: ${event.error}` : ""}
-            <span className="text-xs text-secondary-foreground">{time}</span>
-          </div>
-        );
-      }
-      return (
-        <div className="flex items-center gap-2 text-sm text-success">
-          <span className="w-2 h-2 rounded-full bg-success" />
-          Execution complete
-          <span className="text-xs text-secondary-foreground">{time}</span>
-        </div>
-      );
-
-    default:
-      return null;
-  }
-});

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { SafeMarkdown } from "@/components/safe-markdown";
+import { ScreenshotArtifactCard } from "@/components/screenshot-artifact-card";
+import { ToolCallGroup } from "@/components/tool-call-group";
+import { copyToClipboard } from "@/lib/format";
+import type { Artifact, SandboxEvent } from "@/types/session";
+import { CheckIcon, CopyIcon, ErrorIcon } from "@/components/ui/icons";
+
+type ToolCallEvent = Extract<SandboxEvent, { type: "tool_call" }>;
+
+export type EventGroup =
+  | { type: "tool_group"; events: ToolCallEvent[]; id: string }
+  | { type: "single"; event: SandboxEvent; id: string };
+
+function groupEvents(events: SandboxEvent[]): EventGroup[] {
+  const groups: EventGroup[] = [];
+  let currentToolGroup: ToolCallEvent[] = [];
+  let groupIndex = 0;
+
+  const flushToolGroup = () => {
+    if (currentToolGroup.length > 0) {
+      groups.push({
+        type: "tool_group",
+        events: [...currentToolGroup],
+        id: `tool-group-${groupIndex++}`,
+      });
+      currentToolGroup = [];
+    }
+  };
+
+  for (const event of events) {
+    if (event.type === "tool_call") {
+      if (currentToolGroup.length > 0 && currentToolGroup[0].tool === event.tool) {
+        currentToolGroup.push(event);
+      } else {
+        flushToolGroup();
+        currentToolGroup = [event];
+      }
+    } else {
+      flushToolGroup();
+      groups.push({
+        type: "single",
+        event,
+        id: `single-${event.type}-${("messageId" in event ? event.messageId : undefined) || event.timestamp}-${groupIndex++}`,
+      });
+    }
+  }
+
+  flushToolGroup();
+
+  return groups;
+}
+
+export function dedupeAndGroupEvents(events: SandboxEvent[]): EventGroup[] {
+  const filteredEvents: Array<SandboxEvent | null> = [];
+  const seenToolCalls = new Map<string, number>();
+  const seenCompletions = new Set<string>();
+  const seenTokens = new Map<string, number>();
+
+  for (const event of events) {
+    if (event.type === "tool_call" && event.callId) {
+      const existingIdx = seenToolCalls.get(event.callId);
+      if (existingIdx !== undefined) {
+        filteredEvents[existingIdx] = event;
+      } else {
+        seenToolCalls.set(event.callId, filteredEvents.length);
+        filteredEvents.push(event);
+      }
+    } else if (event.type === "execution_complete" && event.messageId) {
+      if (!seenCompletions.has(event.messageId)) {
+        seenCompletions.add(event.messageId);
+        filteredEvents.push(event);
+      }
+    } else if (event.type === "token" && event.messageId) {
+      const existingIdx = seenTokens.get(event.messageId);
+      if (existingIdx !== undefined) {
+        filteredEvents[existingIdx] = null;
+      }
+      seenTokens.set(event.messageId, filteredEvents.length);
+      filteredEvents.push(event);
+    } else {
+      filteredEvents.push(event);
+    }
+  }
+
+  return groupEvents(filteredEvents.filter((event): event is SandboxEvent => event !== null));
+}
+
+export function SessionTimeline({
+  events,
+  sessionId,
+  currentParticipantId,
+  isProcessing,
+  loadingHistory,
+  showSkeleton,
+  scrollContainerRef,
+  topSentinelRef,
+  messagesEndRef,
+  onScroll,
+  onOpenMedia,
+}: {
+  events: SandboxEvent[];
+  sessionId: string;
+  currentParticipantId: string | null;
+  isProcessing: boolean;
+  loadingHistory: boolean;
+  showSkeleton: boolean;
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+  topSentinelRef: React.RefObject<HTMLDivElement | null>;
+  messagesEndRef: React.RefObject<HTMLDivElement | null>;
+  onScroll: () => void;
+  onOpenMedia: (artifactId: string) => void;
+}) {
+  const groupedEvents = useMemo(() => dedupeAndGroupEvents(events), [events]);
+
+  return (
+    <div
+      ref={scrollContainerRef}
+      onScroll={onScroll}
+      className="h-full overflow-y-auto overflow-x-hidden p-4"
+    >
+      <div className="max-w-3xl mx-auto space-y-2">
+        <div ref={topSentinelRef} className="h-1" />
+        {loadingHistory && (
+          <div className="text-center text-muted-foreground text-sm py-2">Loading...</div>
+        )}
+        {showSkeleton ? (
+          <TimelineSkeleton />
+        ) : (
+          groupedEvents.map((group) =>
+            group.type === "tool_group" ? (
+              <ToolCallGroup key={group.id} events={group.events} groupId={group.id} />
+            ) : (
+              <EventItem
+                key={group.id}
+                event={group.event}
+                sessionId={sessionId}
+                currentParticipantId={currentParticipantId}
+                onOpenMedia={onOpenMedia}
+              />
+            )
+          )
+        )}
+        {isProcessing && <ThinkingIndicator />}
+
+        <div ref={messagesEndRef} />
+      </div>
+    </div>
+  );
+}
+
+export function ThinkingIndicator() {
+  return (
+    <div className="bg-card p-4 flex items-center gap-2">
+      <span className="inline-block w-2 h-2 bg-accent rounded-full animate-pulse" />
+      <span className="text-sm text-muted-foreground">Thinking...</span>
+    </div>
+  );
+}
+
+export function TimelineSkeleton() {
+  return (
+    <div className="space-y-3 py-2 animate-pulse">
+      <div className="bg-card p-4 space-y-2">
+        <div className="h-3 w-24 bg-muted rounded" />
+        <div className="h-3 w-full bg-muted rounded" />
+        <div className="h-3 w-5/6 bg-muted rounded" />
+      </div>
+      <div className="bg-accent-muted p-4 ml-8 space-y-2">
+        <div className="h-3 w-20 bg-muted rounded" />
+        <div className="h-3 w-4/5 bg-muted rounded" />
+      </div>
+      <div className="bg-card p-4 space-y-2">
+        <div className="h-3 w-32 bg-muted rounded" />
+        <div className="h-3 w-3/4 bg-muted rounded" />
+      </div>
+    </div>
+  );
+}
+
+export const EventItem = memo(function EventItem({
+  event,
+  sessionId,
+  currentParticipantId,
+  onOpenMedia,
+}: {
+  event: SandboxEvent;
+  sessionId: string;
+  currentParticipantId: string | null;
+  onOpenMedia: (artifactId: string) => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const time = new Date(event.timestamp * 1000).toLocaleTimeString();
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) {
+        clearTimeout(copyTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopyContent = useCallback(async (content: string) => {
+    const success = await copyToClipboard(content);
+    if (!success) return;
+
+    setCopied(true);
+    if (copyTimeoutRef.current) {
+      clearTimeout(copyTimeoutRef.current);
+    }
+    copyTimeoutRef.current = setTimeout(() => {
+      setCopied(false);
+      copyTimeoutRef.current = null;
+    }, 1500);
+  }, []);
+
+  switch (event.type) {
+    case "user_message": {
+      if (!event.content) return null;
+      const messageContent = event.content;
+      const isCurrentUser =
+        event.author?.participantId && currentParticipantId
+          ? event.author.participantId === currentParticipantId
+          : !event.author;
+      const authorName = isCurrentUser ? "You" : event.author?.name || "Unknown User";
+
+      return (
+        <div className="group bg-accent-muted p-4 ml-8">
+          <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center gap-2">
+              {!isCurrentUser && event.author?.avatar && (
+                <img src={event.author.avatar} alt={authorName} className="w-5 h-5 rounded-full" />
+              )}
+              <span className="text-xs text-accent">{authorName}</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <button
+                type="button"
+                onClick={() => handleCopyContent(messageContent)}
+                className="p-1 text-secondary-foreground hover:text-foreground hover:bg-muted/60 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto transition-colors"
+                title={copied ? "Copied" : "Copy markdown"}
+                aria-label={copied ? "Copied" : "Copy markdown"}
+              >
+                {copied ? (
+                  <CheckIcon className="w-3.5 h-3.5" />
+                ) : (
+                  <CopyIcon className="w-3.5 h-3.5" />
+                )}
+              </button>
+              <span className="text-xs text-secondary-foreground">{time}</span>
+            </div>
+          </div>
+          <pre className="whitespace-pre-wrap text-sm text-foreground">{messageContent}</pre>
+        </div>
+      );
+    }
+
+    case "token": {
+      if (!event.content) return null;
+      const messageContent = event.content;
+      return (
+        <div className="group bg-card p-4">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs text-muted-foreground">Assistant</span>
+            <div className="flex items-center gap-1.5">
+              <button
+                type="button"
+                onClick={() => handleCopyContent(messageContent)}
+                className="p-1 text-secondary-foreground hover:text-foreground hover:bg-muted opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto transition-colors"
+                title={copied ? "Copied" : "Copy markdown"}
+                aria-label={copied ? "Copied" : "Copy markdown"}
+              >
+                {copied ? (
+                  <CheckIcon className="w-3.5 h-3.5" />
+                ) : (
+                  <CopyIcon className="w-3.5 h-3.5" />
+                )}
+              </button>
+              <span className="text-xs text-secondary-foreground">{time}</span>
+            </div>
+          </div>
+          <SafeMarkdown content={messageContent} className="text-sm" />
+        </div>
+      );
+    }
+
+    case "tool_call":
+      return null;
+
+    case "tool_result":
+      if (!event.error) return null;
+      return (
+        <div className="flex items-center gap-2 text-sm text-destructive py-1">
+          <ErrorIcon className="w-4 h-4" />
+          <span className="truncate">{event.error}</span>
+          <span className="text-xs text-secondary-foreground ml-auto">{time}</span>
+        </div>
+      );
+
+    case "git_sync":
+      return (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <span className="w-2 h-2 rounded-full bg-accent" />
+          Git sync: {event.status}
+          <span className="text-xs">{time}</span>
+        </div>
+      );
+
+    case "artifact":
+      if (
+        (event.artifactType !== "screenshot" && event.artifactType !== "video") ||
+        !event.artifactId
+      ) {
+        return null;
+      }
+
+      return (
+        <div className="space-y-2 border border-border-muted bg-card p-4">
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">
+              {event.artifactType === "video" ? "Video" : "Screenshot"}
+            </span>
+            <span className="text-xs text-secondary-foreground">{time}</span>
+          </div>
+          <ScreenshotArtifactCard
+            sessionId={sessionId}
+            artifactId={event.artifactId}
+            artifactType={event.artifactType}
+            metadata={event.metadata as Artifact["metadata"] | undefined}
+            onOpen={onOpenMedia}
+          />
+        </div>
+      );
+
+    case "error":
+      return (
+        <div className="flex items-center gap-2 text-sm text-destructive">
+          <span className="w-2 h-2 rounded-full bg-destructive" />
+          Error{event.error ? `: ${event.error}` : ""}
+          <span className="text-xs text-secondary-foreground">{time}</span>
+        </div>
+      );
+
+    case "execution_complete":
+      if (event.success === false) {
+        return (
+          <div className="flex items-center gap-2 text-sm text-destructive">
+            <span className="w-2 h-2 rounded-full bg-destructive" />
+            Execution failed{event.error ? `: ${event.error}` : ""}
+            <span className="text-xs text-secondary-foreground">{time}</span>
+          </div>
+        );
+      }
+      return (
+        <div className="flex items-center gap-2 text-sm text-success">
+          <span className="w-2 h-2 rounded-full bg-success" />
+          Execution complete
+          <span className="text-xs text-secondary-foreground">{time}</span>
+        </div>
+      );
+
+    default:
+      return null;
+  }
+});

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { SafeMarkdown } from "@/components/safe-markdown";
 import { ScreenshotArtifactCard } from "@/components/screenshot-artifact-card";
 import { ToolCallGroup } from "@/components/tool-call-group";
@@ -95,10 +104,7 @@ export function SessionTimeline({
   isProcessing,
   loadingHistory,
   showSkeleton,
-  scrollContainerRef,
-  topSentinelRef,
-  messagesEndRef,
-  onScroll,
+  onLoadOlder,
   onOpenMedia,
 }: {
   events: SandboxEvent[];
@@ -107,18 +113,68 @@ export function SessionTimeline({
   isProcessing: boolean;
   loadingHistory: boolean;
   showSkeleton: boolean;
-  scrollContainerRef: React.RefObject<HTMLDivElement | null>;
-  topSentinelRef: React.RefObject<HTMLDivElement | null>;
-  messagesEndRef: React.RefObject<HTMLDivElement | null>;
-  onScroll: () => void;
+  onLoadOlder: () => void;
   onOpenMedia: (artifactId: string) => void;
 }) {
   const groupedEvents = useMemo(() => dedupeAndGroupEvents(events), [events]);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const topSentinelRef = useRef<HTMLDivElement>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const hasScrolledRef = useRef(false);
+  const isPrependingRef = useRef(false);
+  const prevScrollHeightRef = useRef(0);
+  const isNearBottomRef = useRef(true);
+
+  const handleScroll = useCallback(() => {
+    hasScrolledRef.current = true;
+    const el = scrollContainerRef.current;
+    if (el) {
+      isNearBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 100;
+    }
+  }, []);
+
+  useEffect(() => {
+    const sentinel = topSentinelRef.current;
+    const container = scrollContainerRef.current;
+    if (!sentinel || !container) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (
+          entry.isIntersecting &&
+          hasScrolledRef.current &&
+          container.scrollHeight > container.clientHeight
+        ) {
+          prevScrollHeightRef.current = container.scrollHeight;
+          isPrependingRef.current = true;
+          onLoadOlder();
+        }
+      },
+      { root: container, threshold: 0.1 }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [onLoadOlder]);
+
+  useLayoutEffect(() => {
+    if (isPrependingRef.current && scrollContainerRef.current) {
+      const el = scrollContainerRef.current;
+      el.scrollTop += el.scrollHeight - prevScrollHeightRef.current;
+      isPrependingRef.current = false;
+    }
+  }, [events]);
+
+  useEffect(() => {
+    if (isNearBottomRef.current && !isPrependingRef.current) {
+      messagesEndRef.current?.scrollIntoView({ behavior: "auto" });
+    }
+  }, [events]);
 
   return (
     <div
       ref={scrollContainerRef}
-      onScroll={onScroll}
+      onScroll={handleScroll}
       className="h-full overflow-y-auto overflow-x-hidden p-4"
     >
       <div className="max-w-3xl mx-auto space-y-2">
@@ -180,6 +236,251 @@ export function TimelineSkeleton() {
   );
 }
 
+type EventRendererProps = {
+  event: SandboxEvent;
+  sessionId: string;
+  currentParticipantId: string | null;
+  copied: boolean;
+  onCopyContent: (content: string) => void;
+  onOpenMedia: (artifactId: string) => void;
+};
+
+type MessageFrameProps = {
+  label: ReactNode;
+  time: string;
+  copied: boolean;
+  content: string;
+  className: string;
+  copyButtonClassName: string;
+  onCopyContent: (content: string) => void;
+  children: ReactNode;
+};
+
+function CopyButton({
+  copied,
+  className,
+  onClick,
+}: {
+  copied: boolean;
+  className: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={className}
+      title={copied ? "Copied" : "Copy markdown"}
+      aria-label={copied ? "Copied" : "Copy markdown"}
+    >
+      {copied ? <CheckIcon className="w-3.5 h-3.5" /> : <CopyIcon className="w-3.5 h-3.5" />}
+    </button>
+  );
+}
+
+function MessageFrame({
+  label,
+  time,
+  copied,
+  content,
+  className,
+  copyButtonClassName,
+  onCopyContent,
+  children,
+}: MessageFrameProps) {
+  return (
+    <div className={className}>
+      <div className="flex items-center justify-between mb-2">
+        {label}
+        <div className="flex items-center gap-1.5">
+          <CopyButton
+            copied={copied}
+            className={copyButtonClassName}
+            onClick={() => onCopyContent(content)}
+          />
+          <span className="text-xs text-secondary-foreground">{time}</span>
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function StatusRow({
+  tone,
+  time,
+  children,
+}: {
+  tone: "muted" | "success" | "destructive";
+  time: string;
+  children: ReactNode;
+}) {
+  const dotClassName =
+    tone === "success" ? "bg-success" : tone === "destructive" ? "bg-destructive" : "bg-accent";
+  const textClassName =
+    tone === "success"
+      ? "text-success"
+      : tone === "destructive"
+        ? "text-destructive"
+        : "text-muted-foreground";
+
+  return (
+    <div className={`flex items-center gap-2 text-sm ${textClassName}`}>
+      <span className={`w-2 h-2 rounded-full ${dotClassName}`} />
+      {children}
+      <span className="text-xs text-secondary-foreground">{time}</span>
+    </div>
+  );
+}
+
+function UserMessageEvent({
+  event,
+  currentParticipantId,
+  copied,
+  onCopyContent,
+}: EventRendererProps) {
+  if (event.type !== "user_message" || !event.content) return null;
+
+  const isCurrentUser =
+    event.author?.participantId && currentParticipantId
+      ? event.author.participantId === currentParticipantId
+      : !event.author;
+  const authorName = isCurrentUser ? "You" : event.author?.name || "Unknown User";
+
+  return (
+    <MessageFrame
+      label={
+        <div className="flex items-center gap-2">
+          {!isCurrentUser && event.author?.avatar && (
+            <img src={event.author.avatar} alt={authorName} className="w-5 h-5 rounded-full" />
+          )}
+          <span className="text-xs text-accent">{authorName}</span>
+        </div>
+      }
+      time={formatEventTime(event)}
+      copied={copied}
+      content={event.content}
+      className="group bg-accent-muted p-4 ml-8"
+      copyButtonClassName="p-1 text-secondary-foreground hover:text-foreground hover:bg-muted/60 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto transition-colors"
+      onCopyContent={onCopyContent}
+    >
+      <pre className="whitespace-pre-wrap text-sm text-foreground">{event.content}</pre>
+    </MessageFrame>
+  );
+}
+
+function AssistantMessageEvent({ event, copied, onCopyContent }: EventRendererProps) {
+  if (event.type !== "token" || !event.content) return null;
+
+  return (
+    <MessageFrame
+      label={<span className="text-xs text-muted-foreground">Assistant</span>}
+      time={formatEventTime(event)}
+      copied={copied}
+      content={event.content}
+      className="group bg-card p-4"
+      copyButtonClassName="p-1 text-secondary-foreground hover:text-foreground hover:bg-muted opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto transition-colors"
+      onCopyContent={onCopyContent}
+    >
+      <SafeMarkdown content={event.content} className="text-sm" />
+    </MessageFrame>
+  );
+}
+
+function ToolResultEvent({ event }: EventRendererProps) {
+  if (event.type !== "tool_result" || !event.error) return null;
+
+  return (
+    <div className="flex items-center gap-2 text-sm text-destructive py-1">
+      <ErrorIcon className="w-4 h-4" />
+      <span className="truncate">{event.error}</span>
+      <span className="text-xs text-secondary-foreground ml-auto">{formatEventTime(event)}</span>
+    </div>
+  );
+}
+
+function GitSyncEvent({ event }: EventRendererProps) {
+  if (event.type !== "git_sync") return null;
+
+  return (
+    <StatusRow tone="muted" time={formatEventTime(event)}>
+      Git sync: {event.status}
+    </StatusRow>
+  );
+}
+
+function ArtifactEvent({ event, sessionId, onOpenMedia }: EventRendererProps) {
+  if (
+    event.type !== "artifact" ||
+    (event.artifactType !== "screenshot" && event.artifactType !== "video") ||
+    !event.artifactId
+  ) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2 border border-border-muted bg-card p-4">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-muted-foreground">
+          {event.artifactType === "video" ? "Video" : "Screenshot"}
+        </span>
+        <span className="text-xs text-secondary-foreground">{formatEventTime(event)}</span>
+      </div>
+      <ScreenshotArtifactCard
+        sessionId={sessionId}
+        artifactId={event.artifactId}
+        artifactType={event.artifactType}
+        metadata={event.metadata as Artifact["metadata"] | undefined}
+        onOpen={onOpenMedia}
+      />
+    </div>
+  );
+}
+
+function ErrorEvent({ event }: EventRendererProps) {
+  if (event.type !== "error") return null;
+
+  return (
+    <StatusRow tone="destructive" time={formatEventTime(event)}>
+      Error{event.error ? `: ${event.error}` : ""}
+    </StatusRow>
+  );
+}
+
+function ExecutionCompleteEvent({ event }: EventRendererProps) {
+  if (event.type !== "execution_complete") return null;
+
+  if (event.success === false) {
+    return (
+      <StatusRow tone="destructive" time={formatEventTime(event)}>
+        Execution failed{event.error ? `: ${event.error}` : ""}
+      </StatusRow>
+    );
+  }
+
+  return (
+    <StatusRow tone="success" time={formatEventTime(event)}>
+      Execution complete
+    </StatusRow>
+  );
+}
+
+function formatEventTime(event: SandboxEvent): string {
+  return new Date(event.timestamp * 1000).toLocaleTimeString();
+}
+
+const eventRenderers: Partial<
+  Record<SandboxEvent["type"], (props: EventRendererProps) => ReactNode>
+> = {
+  user_message: UserMessageEvent,
+  token: AssistantMessageEvent,
+  tool_result: ToolResultEvent,
+  git_sync: GitSyncEvent,
+  artifact: ArtifactEvent,
+  error: ErrorEvent,
+  execution_complete: ExecutionCompleteEvent,
+};
+
 export const EventItem = memo(function EventItem({
   event,
   sessionId,
@@ -193,7 +494,6 @@ export const EventItem = memo(function EventItem({
 }) {
   const [copied, setCopied] = useState(false);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const time = new Date(event.timestamp * 1000).toLocaleTimeString();
 
   useEffect(() => {
     return () => {
@@ -217,152 +517,15 @@ export const EventItem = memo(function EventItem({
     }, 1500);
   }, []);
 
-  switch (event.type) {
-    case "user_message": {
-      if (!event.content) return null;
-      const messageContent = event.content;
-      const isCurrentUser =
-        event.author?.participantId && currentParticipantId
-          ? event.author.participantId === currentParticipantId
-          : !event.author;
-      const authorName = isCurrentUser ? "You" : event.author?.name || "Unknown User";
+  const render = eventRenderers[event.type];
+  if (!render) return null;
 
-      return (
-        <div className="group bg-accent-muted p-4 ml-8">
-          <div className="flex items-center justify-between mb-2">
-            <div className="flex items-center gap-2">
-              {!isCurrentUser && event.author?.avatar && (
-                <img src={event.author.avatar} alt={authorName} className="w-5 h-5 rounded-full" />
-              )}
-              <span className="text-xs text-accent">{authorName}</span>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <button
-                type="button"
-                onClick={() => handleCopyContent(messageContent)}
-                className="p-1 text-secondary-foreground hover:text-foreground hover:bg-muted/60 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto transition-colors"
-                title={copied ? "Copied" : "Copy markdown"}
-                aria-label={copied ? "Copied" : "Copy markdown"}
-              >
-                {copied ? (
-                  <CheckIcon className="w-3.5 h-3.5" />
-                ) : (
-                  <CopyIcon className="w-3.5 h-3.5" />
-                )}
-              </button>
-              <span className="text-xs text-secondary-foreground">{time}</span>
-            </div>
-          </div>
-          <pre className="whitespace-pre-wrap text-sm text-foreground">{messageContent}</pre>
-        </div>
-      );
-    }
-
-    case "token": {
-      if (!event.content) return null;
-      const messageContent = event.content;
-      return (
-        <div className="group bg-card p-4">
-          <div className="flex items-center justify-between mb-2">
-            <span className="text-xs text-muted-foreground">Assistant</span>
-            <div className="flex items-center gap-1.5">
-              <button
-                type="button"
-                onClick={() => handleCopyContent(messageContent)}
-                className="p-1 text-secondary-foreground hover:text-foreground hover:bg-muted opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto focus-visible:opacity-100 focus-visible:pointer-events-auto transition-colors"
-                title={copied ? "Copied" : "Copy markdown"}
-                aria-label={copied ? "Copied" : "Copy markdown"}
-              >
-                {copied ? (
-                  <CheckIcon className="w-3.5 h-3.5" />
-                ) : (
-                  <CopyIcon className="w-3.5 h-3.5" />
-                )}
-              </button>
-              <span className="text-xs text-secondary-foreground">{time}</span>
-            </div>
-          </div>
-          <SafeMarkdown content={messageContent} className="text-sm" />
-        </div>
-      );
-    }
-
-    case "tool_call":
-      return null;
-
-    case "tool_result":
-      if (!event.error) return null;
-      return (
-        <div className="flex items-center gap-2 text-sm text-destructive py-1">
-          <ErrorIcon className="w-4 h-4" />
-          <span className="truncate">{event.error}</span>
-          <span className="text-xs text-secondary-foreground ml-auto">{time}</span>
-        </div>
-      );
-
-    case "git_sync":
-      return (
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <span className="w-2 h-2 rounded-full bg-accent" />
-          Git sync: {event.status}
-          <span className="text-xs">{time}</span>
-        </div>
-      );
-
-    case "artifact":
-      if (
-        (event.artifactType !== "screenshot" && event.artifactType !== "video") ||
-        !event.artifactId
-      ) {
-        return null;
-      }
-
-      return (
-        <div className="space-y-2 border border-border-muted bg-card p-4">
-          <div className="flex items-center justify-between">
-            <span className="text-xs text-muted-foreground">
-              {event.artifactType === "video" ? "Video" : "Screenshot"}
-            </span>
-            <span className="text-xs text-secondary-foreground">{time}</span>
-          </div>
-          <ScreenshotArtifactCard
-            sessionId={sessionId}
-            artifactId={event.artifactId}
-            artifactType={event.artifactType}
-            metadata={event.metadata as Artifact["metadata"] | undefined}
-            onOpen={onOpenMedia}
-          />
-        </div>
-      );
-
-    case "error":
-      return (
-        <div className="flex items-center gap-2 text-sm text-destructive">
-          <span className="w-2 h-2 rounded-full bg-destructive" />
-          Error{event.error ? `: ${event.error}` : ""}
-          <span className="text-xs text-secondary-foreground">{time}</span>
-        </div>
-      );
-
-    case "execution_complete":
-      if (event.success === false) {
-        return (
-          <div className="flex items-center gap-2 text-sm text-destructive">
-            <span className="w-2 h-2 rounded-full bg-destructive" />
-            Execution failed{event.error ? `: ${event.error}` : ""}
-            <span className="text-xs text-secondary-foreground">{time}</span>
-          </div>
-        );
-      }
-      return (
-        <div className="flex items-center gap-2 text-sm text-success">
-          <span className="w-2 h-2 rounded-full bg-success" />
-          Execution complete
-          <span className="text-xs text-secondary-foreground">{time}</span>
-        </div>
-      );
-
-    default:
-      return null;
-  }
+  return render({
+    event,
+    sessionId,
+    currentParticipantId,
+    copied,
+    onCopyContent: handleCopyContent,
+    onOpenMedia,
+  });
 });


### PR DESCRIPTION
## Summary
- Extract session timeline rendering into a reusable `SessionTimeline` component.
- Move event grouping/deduping, `EventItem`, `ThinkingIndicator`, and `TimelineSkeleton` out of the session page.
- Keep page-owned scroll pagination/lightbox state wired through existing refs and callbacks.

## Checks
- `npm run typecheck -w @open-inspect/web`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/2aadb09b01a6e1ef8edccdb02fb2d425)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized session timeline components for improved code modularity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->