### PR TITLE
fix(linear-bot): resolve GitLab nested-group repos in suggestion path

### DIFF
--- a/packages/linear-bot/src/utils/repo.test.ts
+++ b/packages/linear-bot/src/utils/repo.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { splitRepoFullName } from "./repo";
+
+describe("splitRepoFullName", () => {
+  it("splits a GitHub-style org/repo full name", () => {
+    expect(splitRepoFullName("acme/web-app")).toEqual({
+      owner: "acme",
+      name: "web-app",
+    });
+  });
+
+  it("splits a GitLab nested-group path on the last slash", () => {
+    expect(splitRepoFullName("acme/backend/web-app")).toEqual({
+      owner: "acme/backend",
+      name: "web-app",
+    });
+  });
+
+  it("splits deeply nested GitLab subgroup paths", () => {
+    expect(splitRepoFullName("acme/infra/tools/elasticsearch/scripts")).toEqual({
+      owner: "acme/infra/tools/elasticsearch",
+      name: "scripts",
+    });
+  });
+
+  it("returns an empty owner when there is no slash", () => {
+    expect(splitRepoFullName("web-app")).toEqual({
+      owner: "",
+      name: "web-app",
+    });
+  });
+});

--- a/packages/linear-bot/src/utils/repo.ts
+++ b/packages/linear-bot/src/utils/repo.ts
@@ -1,0 +1,18 @@
+/**
+ * Repository identifier helpers.
+ */
+
+/**
+ * Split a repo full name into owner and name.
+ *
+ * Splits on the LAST slash: GitLab projects can live in nested groups
+ * ("group/subgroup/project"), where everything before the final segment is
+ * the owner namespace. GitHub "org/repo" names split identically.
+ */
+export function splitRepoFullName(fullName: string): { owner: string; name: string } {
+  const idx = fullName.lastIndexOf("/");
+  if (idx === -1) {
+    return { owner: "", name: fullName };
+  }
+  return { owner: fullName.slice(0, idx), name: fullName.slice(idx + 1) };
+}

--- a/packages/linear-bot/src/webhook-handler.ts
+++ b/packages/linear-bot/src/webhook-handler.ts
@@ -19,6 +19,7 @@ import {
   getRepoSuggestions,
 } from "./utils/linear-client";
 import { buildInternalAuthHeaders } from "./utils/internal";
+import { splitRepoFullName } from "./utils/repo";
 import { classifyRepo } from "./classifier";
 import { getAvailableRepos } from "./classifier/repos";
 import { getLinearConfig } from "./utils/integration-config";
@@ -400,7 +401,9 @@ async function handleNewSession(
       const suggestions = await getRepoSuggestions(client, issue.id, agentSessionId, candidates);
       const topSuggestion = suggestions.find((s) => s.confidence >= 0.7);
       if (topSuggestion) {
-        const [owner, name] = topSuggestion.repositoryFullName.split("/");
+        // Split on the last slash — GitLab nested-group paths
+        // ("group/subgroup/project") carry slashes in the owner.
+        const { owner, name } = splitRepoFullName(topSuggestion.repositoryFullName);
         repoOwner = owner;
         repoName = name;
         repoFullName = topSuggestion.repositoryFullName;


### PR DESCRIPTION
## Summary

- The Linear repo-suggestions resolution path split `repositoryFullName` on the **first** slash (`const [owner, name] = fullName.split("/")`). GitLab projects can live in nested groups, so `group/subgroup/project` resolved to owner=`group`, name=`subgroup` — session creation then looked up a nonexistent project and failed with `HTTP 404: {"error":"Repository is not installed for the GitHub App"}` posted back to the Linear thread.
- Adds a `splitRepoFullName` helper that splits on the **last** slash and uses it in the suggestion path. GitHub `org/repo` names split identically, so GitHub deployments are unaffected.

Note: `utils/integration-config.ts` has the same first-slash split, but fixing it requires URL-encoding the owner segment through the control-plane route, so it degrades gracefully today (falls back to defaults) and is left for a follow-up.

## Test plan

- [x] New unit tests for `splitRepoFullName` (GitHub-style, single-nested, deeply-nested, no-slash)
- [x] `npm test -w @open-inspect/linear-bot` — 109 tests pass
- [x] `tsc --noEmit` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository path parsing to correctly handle GitLab nested group structures, ensuring accurate owner and repository name extraction regardless of path depth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->