### PR TITLE
feat: make model api key settings explicit

### DIFF
--- a/packages/web/src/components/settings/model-api-keys-settings.test.tsx
+++ b/packages/web/src/components/settings/model-api-keys-settings.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { SWRConfig, mutate as globalMutate } from "swr";
+import { ModelApiKeysSettings } from "./model-api-keys-settings";
+
+expect.extend(matchers);
+
+const { reposMock, toastMock } = vi.hoisted(() => ({
+  reposMock: {
+    repos: [
+      {
+        id: 1,
+        fullName: "acme/app",
+        owner: "acme",
+        name: "app",
+        description: null,
+        private: true,
+        defaultBranch: "main",
+      },
+    ],
+    loading: false,
+  },
+  toastMock: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@/hooks/use-repos", () => ({
+  useRepos: () => ({ repos: reposMock.repos, loading: reposMock.loading }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: toastMock,
+}));
+
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function renderWithSWR(fallback: Record<string, unknown> = {}) {
+  const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+    if (init?.method === "PUT" || init?.method === "DELETE") {
+      return jsonResponse({ status: "ok" });
+    }
+    throw new Error("unexpected fetch");
+  });
+  vi.stubGlobal("fetch", fetchMock);
+
+  const result = render(
+    <SWRConfig
+      value={{
+        provider: () => new Map(),
+        fallback,
+        dedupingInterval: Infinity,
+        revalidateOnFocus: false,
+        revalidateIfStale: false,
+        revalidateOnReconnect: false,
+      }}
+    >
+      <ModelApiKeysSettings />
+    </SWRConfig>
+  );
+
+  return { ...result, fetchMock };
+}
+
+async function selectRepo() {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: /All Repositories/ }));
+  await user.click(screen.getByRole("option", { name: /app/ }));
+}
+
+afterEach(async () => {
+  cleanup();
+  await globalMutate(() => true, undefined, { revalidate: false });
+  vi.restoreAllMocks();
+  reposMock.loading = false;
+  toastMock.success.mockReset();
+  toastMock.error.mockReset();
+});
+
+describe("ModelApiKeysSettings", () => {
+  it("saves model API keys to global secrets by default", async () => {
+    const user = userEvent.setup();
+    const { fetchMock } = renderWithSWR({
+      "/api/secrets": { secrets: [] },
+    });
+
+    await user.type(screen.getByLabelText("Anthropic API key"), "sk-ant-test");
+    await user.type(screen.getByLabelText("OpenAI API key"), "sk-openai-test");
+    await user.click(screen.getByRole("button", { name: "Save API Keys" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/secrets",
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({
+            secrets: {
+              ANTHROPIC_API_KEY: "sk-ant-test",
+              OPENAI_API_KEY: "sk-openai-test",
+            },
+          }),
+        })
+      );
+    });
+  });
+
+  it("shows repo keys as set and global keys as inherited", async () => {
+    renderWithSWR({
+      "/api/secrets": { secrets: [] },
+      "/api/repos/acme/app/secrets": {
+        secrets: [{ key: "OPENAI_API_KEY" }],
+        globalSecrets: [{ key: "ANTHROPIC_API_KEY" }],
+      },
+    });
+
+    await selectRepo();
+
+    expect(screen.getByText("Inherited")).toBeInTheDocument();
+    expect(screen.getByText("Set")).toBeInTheDocument();
+  });
+
+  it("saves repo overrides to the selected repository secrets endpoint", async () => {
+    const user = userEvent.setup();
+    const { fetchMock } = renderWithSWR({
+      "/api/secrets": { secrets: [] },
+      "/api/repos/acme/app/secrets": {
+        secrets: [],
+        globalSecrets: [{ key: "ANTHROPIC_API_KEY" }],
+      },
+    });
+
+    await selectRepo();
+    await user.type(screen.getByLabelText("Anthropic API key"), "sk-ant-repo");
+    await user.click(screen.getByRole("button", { name: "Save API Keys" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/repos/acme/app/secrets",
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({
+            secrets: {
+              ANTHROPIC_API_KEY: "sk-ant-repo",
+            },
+          }),
+        })
+      );
+    });
+  });
+
+  it("deletes only the direct key for the selected repository", async () => {
+    const user = userEvent.setup();
+    const { fetchMock } = renderWithSWR({
+      "/api/secrets": { secrets: [] },
+      "/api/repos/acme/app/secrets": {
+        secrets: [{ key: "OPENAI_API_KEY" }],
+        globalSecrets: [{ key: "ANTHROPIC_API_KEY" }],
+      },
+    });
+
+    await selectRepo();
+    await user.click(screen.getByRole("button", { name: "Remove OPENAI_API_KEY" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/repos/acme/app/secrets/OPENAI_API_KEY", {
+        method: "DELETE",
+      });
+    });
+  });
+});

--- a/packages/web/src/components/settings/model-api-keys-settings.test.tsx
+++ b/packages/web/src/components/settings/model-api-keys-settings.test.tsx
@@ -10,6 +10,8 @@ import { ModelApiKeysSettings } from "./model-api-keys-settings";
 
 expect.extend(matchers);
 
+const DEDUPING_INTERVAL_MS = Number.POSITIVE_INFINITY;
+
 const { reposMock, toastMock } = vi.hoisted(() => ({
   reposMock: {
     repos: [
@@ -64,7 +66,7 @@ function renderWithSWR(fallback: Record<string, unknown> = {}) {
       value={{
         provider: () => new Map(),
         fallback,
-        dedupingInterval: Infinity,
+        dedupingInterval: DEDUPING_INTERVAL_MS,
         revalidateOnFocus: false,
         revalidateIfStale: false,
         revalidateOnReconnect: false,
@@ -130,8 +132,8 @@ describe("ModelApiKeysSettings", () => {
 
     await selectRepo();
 
-    expect(screen.getByText("Inherited")).toBeInTheDocument();
-    expect(screen.getByText("Set")).toBeInTheDocument();
+    expect(await screen.findByText("Inherited")).toBeInTheDocument();
+    expect(await screen.findByText("Set")).toBeInTheDocument();
   });
 
   it("saves repo overrides to the selected repository secrets endpoint", async () => {

--- a/packages/web/src/components/settings/model-api-keys-settings.tsx
+++ b/packages/web/src/components/settings/model-api-keys-settings.tsx
@@ -306,7 +306,7 @@ export function ModelApiKeysSettings() {
                           size="sm"
                           aria-label={`Remove ${item.key}`}
                           onClick={() => handleDelete(item.key)}
-                          disabled={!hasDirectKey || deletingKey === item.key}
+                          disabled={saving || !hasDirectKey || deletingKey === item.key}
                         >
                           {deletingKey === item.key ? "Removing..." : "Remove"}
                         </Button>

--- a/packages/web/src/components/settings/model-api-keys-settings.tsx
+++ b/packages/web/src/components/settings/model-api-keys-settings.tsx
@@ -1,0 +1,338 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import useSWR, { mutate } from "swr";
+import { toast } from "sonner";
+import { CheckIcon, ChevronDownIcon } from "@/components/ui/icons";
+import { Button } from "@/components/ui/button";
+import { Combobox } from "@/components/ui/combobox";
+import { Input } from "@/components/ui/input";
+import { useRepos } from "@/hooks/use-repos";
+
+const GLOBAL_SCOPE = "__global__";
+const MAX_VALUE_SIZE = 16384;
+const MAX_TOTAL_VALUE_SIZE = 65536;
+
+const MODEL_API_KEYS = [
+  {
+    key: "ANTHROPIC_API_KEY",
+    provider: "Anthropic",
+    description: "Claude models in Anthropic provider sessions",
+    placeholder: "sk-ant-...",
+  },
+  {
+    key: "OPENAI_API_KEY",
+    provider: "OpenAI",
+    description: "GPT and Codex models in OpenAI provider sessions",
+    placeholder: "sk-...",
+  },
+  {
+    key: "OPENCODE_API_KEY",
+    provider: "OpenCode Zen",
+    description: "Zen-routed OpenCode models",
+    placeholder: "opencode_...",
+  },
+] as const;
+
+type ModelApiKeyName = (typeof MODEL_API_KEYS)[number]["key"];
+
+type SecretMeta = {
+  key: string;
+  createdAt?: number;
+  updatedAt?: number;
+};
+
+interface SecretsResponse {
+  secrets: SecretMeta[];
+  globalSecrets?: SecretMeta[];
+}
+
+function createEmptyValues(): Record<ModelApiKeyName, string> {
+  return MODEL_API_KEYS.reduce(
+    (acc, item) => {
+      acc[item.key] = "";
+      return acc;
+    },
+    {} as Record<ModelApiKeyName, string>
+  );
+}
+
+function getUtf8Size(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
+async function readJson(response: Response): Promise<Record<string, unknown>> {
+  try {
+    return (await response.json()) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+export function ModelApiKeysSettings() {
+  const { repos, loading: loadingRepos } = useRepos();
+  const [selectedRepo, setSelectedRepo] = useState(GLOBAL_SCOPE);
+  const [values, setValues] = useState<Record<ModelApiKeyName, string>>(createEmptyValues);
+  const [saving, setSaving] = useState(false);
+  const [deletingKey, setDeletingKey] = useState<ModelApiKeyName | null>(null);
+  const [error, setError] = useState("");
+
+  const selectedRepoObj = repos.find((repo) => repo.fullName === selectedRepo);
+  const isGlobal = selectedRepo === GLOBAL_SCOPE;
+  const ready = isGlobal || Boolean(selectedRepoObj);
+  const apiBase = isGlobal
+    ? "/api/secrets"
+    : selectedRepoObj
+      ? `/api/repos/${selectedRepoObj.owner}/${selectedRepoObj.name}/secrets`
+      : null;
+
+  const {
+    data,
+    isLoading,
+    error: fetchError,
+  } = useSWR<SecretsResponse>(ready && apiBase ? apiBase : null);
+
+  useEffect(() => {
+    setValues(createEmptyValues());
+    setError("");
+  }, [apiBase]);
+
+  const directKeys = useMemo(
+    () => new Set((data?.secrets ?? []).map((secret) => secret.key.toUpperCase())),
+    [data?.secrets]
+  );
+  const inheritedKeys = useMemo(
+    () => new Set((data?.globalSecrets ?? []).map((secret) => secret.key.toUpperCase())),
+    [data?.globalSecrets]
+  );
+
+  const changedKeys = MODEL_API_KEYS.filter((item) => values[item.key].trim().length > 0);
+  const hasChanges = changedKeys.length > 0;
+
+  const selectedRepoLabel = isGlobal
+    ? "All Repositories (Global)"
+    : selectedRepoObj
+      ? selectedRepoObj.fullName
+      : loadingRepos
+        ? "Loading..."
+        : "Select a repository";
+
+  async function handleSave() {
+    if (!apiBase || changedKeys.length === 0) return;
+
+    setError("");
+
+    let totalSize = 0;
+    for (const item of changedKeys) {
+      const value = values[item.key].trim();
+      const valueSize = getUtf8Size(value);
+      if (valueSize > MAX_VALUE_SIZE) {
+        setError(`${item.key} exceeds ${MAX_VALUE_SIZE} bytes`);
+        return;
+      }
+      totalSize += valueSize;
+    }
+
+    if (totalSize > MAX_TOTAL_VALUE_SIZE) {
+      setError(`Model API key values exceed ${MAX_TOTAL_VALUE_SIZE} bytes total`);
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const payload: Partial<Record<ModelApiKeyName, string>> = {};
+      for (const item of changedKeys) {
+        payload[item.key] = values[item.key].trim();
+      }
+
+      const response = await fetch(apiBase, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ secrets: payload }),
+      });
+      const body = await readJson(response);
+
+      if (!response.ok) {
+        toast.error(String(body.error || "Failed to save model API keys"));
+        return;
+      }
+
+      setValues(createEmptyValues());
+      mutate(apiBase);
+      toast.success("Model API keys saved");
+    } catch {
+      toast.error("Failed to save model API keys");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(key: ModelApiKeyName) {
+    if (!apiBase) return;
+
+    setDeletingKey(key);
+    try {
+      const response = await fetch(`${apiBase}/${key}`, { method: "DELETE" });
+      const body = await readJson(response);
+
+      if (!response.ok) {
+        toast.error(String(body.error || `Failed to remove ${key}`));
+        return;
+      }
+
+      setValues((current) => ({ ...current, [key]: "" }));
+      mutate(apiBase);
+      toast.success(`${key} removed`);
+    } catch {
+      toast.error(`Failed to remove ${key}`);
+    } finally {
+      setDeletingKey(null);
+    }
+  }
+
+  return (
+    <section className="mt-10 border-t border-border-muted pt-8" aria-labelledby="model-api-keys">
+      <h2 id="model-api-keys" className="text-xl font-semibold text-foreground mb-1">
+        Model API Keys
+      </h2>
+      <p className="text-sm text-muted-foreground mb-6">
+        Store provider credentials as encrypted secrets for model execution. Repository keys
+        override global keys.
+      </p>
+
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-foreground mb-1.5">Repository</label>
+        <Combobox
+          value={selectedRepo}
+          onChange={setSelectedRepo}
+          items={repos.map((repo) => ({
+            value: repo.fullName,
+            label: repo.name,
+            description: `${repo.owner}${repo.private ? " \u2022 private" : ""}`,
+          }))}
+          searchable
+          searchPlaceholder="Search repositories..."
+          filterFn={(option, query) =>
+            option.label.toLowerCase().includes(query) ||
+            (option.description?.toLowerCase().includes(query) ?? false) ||
+            String(option.value).toLowerCase().includes(query)
+          }
+          direction="down"
+          dropdownWidth="w-full max-w-sm"
+          maxDisplayed={100}
+          disabled={loadingRepos}
+          triggerClassName="w-full max-w-sm flex items-center justify-between px-3 py-2 text-sm border border-border bg-input text-foreground hover:border-foreground/30 disabled:opacity-50 disabled:cursor-not-allowed transition"
+          prependContent={({ select }) => (
+            <>
+              <button
+                type="button"
+                onClick={() => select(GLOBAL_SCOPE)}
+                className={`w-full flex items-center justify-between px-3 py-2 text-sm hover:bg-muted transition ${
+                  isGlobal ? "text-foreground" : "text-muted-foreground"
+                }`}
+              >
+                <div className="flex flex-col items-start text-left">
+                  <span className="font-medium">All Repositories (Global)</span>
+                  <span className="text-xs text-secondary-foreground">
+                    Shared across all repositories
+                  </span>
+                </div>
+                {isGlobal && <CheckIcon className="w-4 h-4 text-accent" />}
+              </button>
+              {repos.length > 0 && <div className="border-t border-border my-1" />}
+            </>
+          )}
+        >
+          <span className="truncate">{selectedRepoLabel}</span>
+          <ChevronDownIcon className="w-3 h-3 flex-shrink-0" />
+        </Combobox>
+      </div>
+
+      {!ready && (
+        <p className="text-sm text-muted-foreground">Select a repository to manage model keys.</p>
+      )}
+
+      {ready && (
+        <>
+          {isLoading && <p className="text-sm text-muted-foreground">Loading model keys...</p>}
+          {fetchError && <p className="text-sm text-destructive">Failed to load model keys.</p>}
+
+          {!isLoading && !fetchError && (
+            <div className="space-y-3">
+              {MODEL_API_KEYS.map((item) => {
+                const hasDirectKey = directKeys.has(item.key);
+                const hasInheritedKey = !isGlobal && inheritedKeys.has(item.key);
+                const status = hasDirectKey ? "Set" : hasInheritedKey ? "Inherited" : "Not set";
+
+                return (
+                  <div key={item.key} className="border border-border bg-background px-4 py-3">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+                      <div className="min-w-0 sm:w-56">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <h3 className="text-sm font-medium text-foreground">{item.provider}</h3>
+                          <span className="rounded-sm border border-border-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                            {status}
+                          </span>
+                        </div>
+                        <p className="mt-1 text-xs text-muted-foreground">{item.description}</p>
+                        <p className="mt-1 font-mono text-xs text-secondary-foreground">
+                          {item.key}
+                        </p>
+                      </div>
+
+                      <div className="flex min-w-0 flex-1 flex-col gap-2 sm:flex-row">
+                        <Input
+                          type="password"
+                          value={values[item.key]}
+                          aria-label={`${item.provider} API key`}
+                          onChange={(event) =>
+                            setValues((current) => ({
+                              ...current,
+                              [item.key]: event.target.value,
+                            }))
+                          }
+                          placeholder={
+                            hasDirectKey
+                              ? "Enter a new value to update"
+                              : hasInheritedKey
+                                ? "Enter a repo override"
+                                : item.placeholder
+                          }
+                          className="min-w-0 flex-1"
+                        />
+                        <Button
+                          type="button"
+                          variant="destructive"
+                          size="sm"
+                          aria-label={`Remove ${item.key}`}
+                          onClick={() => handleDelete(item.key)}
+                          disabled={!hasDirectKey || deletingKey === item.key}
+                        >
+                          {deletingKey === item.key ? "Removing..." : "Remove"}
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {error && <p className="mt-4 text-sm text-destructive">{error}</p>}
+
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <Button
+              onClick={handleSave}
+              disabled={!hasChanges || saving || isLoading || Boolean(fetchError)}
+            >
+              {saving ? "Saving..." : "Save API Keys"}
+            </Button>
+            <p className="text-xs text-muted-foreground">
+              Saved values are never displayed again. Leave a field empty to keep its current value.
+            </p>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/packages/web/src/components/settings/models-settings.tsx
+++ b/packages/web/src/components/settings/models-settings.tsx
@@ -7,6 +7,7 @@ import { MODEL_OPTIONS, DEFAULT_ENABLED_MODELS } from "@open-inspect/shared";
 import { MODEL_PREFERENCES_KEY } from "@/hooks/use-enabled-models";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
+import { ModelApiKeysSettings } from "./model-api-keys-settings";
 
 export function ModelsSettings() {
   const { data, isLoading: loading } = useSWR<{ enabledModels: string[] }>(MODEL_PREFERENCES_KEY);
@@ -76,15 +77,6 @@ export function ModelsSettings() {
     }
   };
 
-  if (loading) {
-    return (
-      <div className="flex items-center gap-2 text-muted-foreground">
-        <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
-        Loading model preferences...
-      </div>
-    );
-  }
-
   return (
     <div>
       <h2 className="text-xl font-semibold text-foreground mb-1">Enabled Models</h2>
@@ -92,60 +84,73 @@ export function ModelsSettings() {
         Choose which models appear in the model selector across the web UI and Slack bot.
       </p>
 
-      <div className="space-y-6">
-        {MODEL_OPTIONS.map((group) => {
-          const allEnabled = group.models.every((m) => enabledModels.has(m.id));
+      {loading ? (
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
+          Loading model preferences...
+        </div>
+      ) : (
+        <>
+          <div className="space-y-6">
+            {MODEL_OPTIONS.map((group) => {
+              const allEnabled = group.models.every((m) => enabledModels.has(m.id));
 
-          return (
-            <div key={group.category}>
-              <div className="flex items-center justify-between mb-3">
-                <h3 className="text-sm font-medium text-foreground uppercase tracking-wider">
-                  {group.category}
-                </h3>
-                <Button
-                  type="button"
-                  variant="subtle"
-                  size="xs"
-                  onClick={() => toggleCategory(group, !allEnabled)}
-                  className="text-accent hover:text-accent/80"
-                >
-                  {allEnabled ? "Disable all" : "Enable all"}
-                </Button>
-              </div>
-              <div className="space-y-2">
-                {group.models.map((model) => {
-                  const isEnabled = enabledModels.has(model.id);
-                  return (
-                    <label
-                      key={model.id}
-                      htmlFor={`model-toggle-${model.id}`}
-                      className="flex items-center justify-between px-4 py-3 border border-border hover:bg-muted/50 transition cursor-pointer"
+              return (
+                <div key={group.category}>
+                  <div className="flex items-center justify-between mb-3">
+                    <h3 className="text-sm font-medium text-foreground uppercase tracking-wider">
+                      {group.category}
+                    </h3>
+                    <Button
+                      type="button"
+                      variant="subtle"
+                      size="xs"
+                      onClick={() => toggleCategory(group, !allEnabled)}
+                      className="text-accent hover:text-accent/80"
                     >
-                      <div>
-                        <span className="text-sm font-medium text-foreground">{model.name}</span>
-                        <span className="text-sm text-muted-foreground ml-2">
-                          {model.description}
-                        </span>
-                      </div>
-                      <Switch
-                        id={`model-toggle-${model.id}`}
-                        checked={isEnabled}
-                        onCheckedChange={() => toggleModel(model.id)}
-                      />
-                    </label>
-                  );
-                })}
-              </div>
-            </div>
-          );
-        })}
-      </div>
+                      {allEnabled ? "Disable all" : "Enable all"}
+                    </Button>
+                  </div>
+                  <div className="space-y-2">
+                    {group.models.map((model) => {
+                      const isEnabled = enabledModels.has(model.id);
+                      return (
+                        <label
+                          key={model.id}
+                          htmlFor={`model-toggle-${model.id}`}
+                          className="flex items-center justify-between px-4 py-3 border border-border hover:bg-muted/50 transition cursor-pointer"
+                        >
+                          <div>
+                            <span className="text-sm font-medium text-foreground">
+                              {model.name}
+                            </span>
+                            <span className="text-sm text-muted-foreground ml-2">
+                              {model.description}
+                            </span>
+                          </div>
+                          <Switch
+                            id={`model-toggle-${model.id}`}
+                            checked={isEnabled}
+                            onCheckedChange={() => toggleModel(model.id)}
+                          />
+                        </label>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
 
-      <div className="mt-6">
-        <Button onClick={handleSave} disabled={saving || !dirty}>
-          {saving ? "Saving..." : "Save"}
-        </Button>
-      </div>
+          <div className="mt-6">
+            <Button onClick={handleSave} disabled={saving || !dirty}>
+              {saving ? "Saving..." : "Save"}
+            </Button>
+          </div>
+        </>
+      )}
+
+      <ModelApiKeysSettings />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Makes the API key settings for models explicit (similar to how it's setup in Cursor), to make it easier to configure them.

## Changes

- Adds fixed inputs for:
    - ANTHROPIC_API_KEY
    - OPENAI_API_KEY
    - OPENCODE_API_KEY

- Supports both global and per-repo scopes using the same encrypted secrets APIs as the existing Secrets settings.
- Shows whether each key is Set, Inherited, or Not set.
- Allows repo-specific keys to override global keys.
- Adds save/remove actions for direct keys.
- Adds focused tests for global save, repo override save, inherited status, and repo key deletion.

## Testing

- npm test -w @open-inspect/web -- model-api-keys-settings.test.tsx
- npm run typecheck -w @open-inspect/web
- npm run lint -w @open-inspect/web

## Screenshot

<img width="632" height="540" alt="Screenshot 2026-06-13 at 1 44 34 PM" src="https://github.com/user-attachments/assets/31fb9195-fe32-43b7-bdbb-1f7b19943a3d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Model API Keys settings UI to manage provider keys (OpenAI, Anthropic, OpenCode Zen) with global and repository-scoped modes, clear status labels, per-key remove, validation, and save notifications.
  * Integrated the API keys UI into the Models settings page; loading state now preserves page context while keys load.

* **Tests**
  * Added a comprehensive test suite covering save, remove, repo/global behavior, and UI states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->