### PR TITLE
refactor(control-plane): extract shared tunnel_urls parser

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -57,6 +57,7 @@ import type {
 } from "../types";
 import type { SessionRow, ArtifactRow, SandboxRow } from "./types";
 import { SessionRepository } from "./repository";
+import { parseTunnelUrls } from "./tunnel-urls";
 import { SessionWebSocketManagerImpl, type SessionWebSocketManager } from "./websocket-manager";
 import { SessionPullRequestService } from "./pull-request-service";
 import { RepoSecretsStore } from "../db/repo-secrets";
@@ -1771,12 +1772,11 @@ export class SessionDO extends DurableObject<Env> {
   }
 
   private safeParseTunnelUrls(raw: string): Record<string, string> | null {
-    try {
-      return JSON.parse(raw) as Record<string, string>;
-    } catch {
+    const urls = parseTunnelUrls(raw);
+    if (!urls) {
       this.log.warn("Invalid sandbox tunnel_urls JSON");
-      return null;
     }
+    return urls;
   }
 
   // Database helpers

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
@@ -503,4 +503,17 @@ describe("createSandboxHandler", () => {
     expect(await response.json()).toEqual({ error: "Invalid stored tunnel URLs" });
     expect(log.warn).toHaveBeenCalled();
   });
+
+  it("returns 500 when a stored tunnel URL value is not a string", async () => {
+    const { handler, getSandbox, log } = createHandler();
+    getSandbox.mockReturnValue({
+      tunnel_urls: JSON.stringify({ "3000": "https://a.example", "5000": 5000 }),
+    } as unknown as SandboxRow);
+
+    const response = await handler.tunnelUrls();
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({ error: "Invalid stored tunnel URLs" });
+    expect(log.warn).toHaveBeenCalled();
+  });
 });

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
@@ -6,6 +6,7 @@ import type { ScmCredentialsResult } from "../../scm-credentials-service";
 import type { SessionRepository } from "../../repository";
 import type { SandboxRow, SessionRow } from "../../types";
 import { assertArtifactType } from "../../artifacts";
+import { parseTunnelUrls } from "../../tunnel-urls";
 
 interface AddParticipantRequest {
   userId: string;
@@ -206,10 +207,11 @@ export function createSandboxHandler(deps: SandboxHandlerDeps): SandboxHandler {
      *
      * Responses:
      * - `404` when no sandbox exists for the session.
-     * - `500` when the stored value is malformed JSON or not a JSON object, so
-     *   corrupted data is distinguishable from "no tunnels resolved yet" (an
-     *   empty map would let the in-sandbox setup silently write an empty
-     *   `.tunnels.env`).
+     * - `500` when the stored value is malformed — invalid JSON, not a plain
+     *   object, or holding a non-string value — so the in-sandbox setup hard-
+     *   fails on corrupt data instead of writing a garbage `.tunnels.env`. Note
+     *   a not-yet-resolved sandbox still returns `200` with an empty map, so the
+     *   client must tolerate an empty result and retry until ports appear.
      * - `200` with `{ tunnelUrls }` otherwise (empty map when none are stored).
      */
     async tunnelUrls(): Promise<Response> {
@@ -220,20 +222,12 @@ export function createSandboxHandler(deps: SandboxHandlerDeps): SandboxHandler {
 
       let urls: Record<string, string> = {};
       if (sandbox.tunnel_urls) {
-        let parsed: unknown;
-        try {
-          parsed = JSON.parse(sandbox.tunnel_urls);
-        } catch (err) {
-          deps.getLog().warn("Failed to parse stored tunnel_urls JSON", {
-            error: err instanceof Error ? err.message : String(err),
-          });
+        const parsed = parseTunnelUrls(sandbox.tunnel_urls);
+        if (!parsed) {
+          deps.getLog().warn("Invalid stored tunnel_urls");
           return Response.json({ error: "Invalid stored tunnel URLs" }, { status: 500 });
         }
-        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-          deps.getLog().warn("Stored tunnel_urls is not a JSON object");
-          return Response.json({ error: "Invalid stored tunnel URLs" }, { status: 500 });
-        }
-        urls = parsed as Record<string, string>;
+        urls = parsed;
       }
 
       return Response.json(

--- a/packages/control-plane/src/session/tunnel-urls.test.ts
+++ b/packages/control-plane/src/session/tunnel-urls.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { parseTunnelUrls } from "./tunnel-urls";
+
+describe("parseTunnelUrls", () => {
+  it("parses a port -> url map", () => {
+    const raw = JSON.stringify({ "3000": "https://a.example", "5000": "https://b.example" });
+    expect(parseTunnelUrls(raw)).toEqual({
+      "3000": "https://a.example",
+      "5000": "https://b.example",
+    });
+  });
+
+  it("returns an empty map for an empty object", () => {
+    expect(parseTunnelUrls("{}")).toEqual({});
+  });
+
+  it("returns null for invalid JSON", () => {
+    expect(parseTunnelUrls("{not json")).toBeNull();
+  });
+
+  it("returns null when the value is not an object", () => {
+    expect(parseTunnelUrls(JSON.stringify(["3000", "5000"]))).toBeNull();
+    expect(parseTunnelUrls(JSON.stringify("3000"))).toBeNull();
+    expect(parseTunnelUrls(JSON.stringify(42))).toBeNull();
+    expect(parseTunnelUrls(JSON.stringify(null))).toBeNull();
+  });
+
+  it("returns null when any value is not a string", () => {
+    expect(parseTunnelUrls(JSON.stringify({ "3000": 5000 }))).toBeNull();
+    expect(
+      parseTunnelUrls(JSON.stringify({ "3000": "https://a.example", "5000": null }))
+    ).toBeNull();
+    expect(parseTunnelUrls(JSON.stringify({ "3000": { nested: true } }))).toBeNull();
+  });
+});

--- a/packages/control-plane/src/session/tunnel-urls.ts
+++ b/packages/control-plane/src/session/tunnel-urls.ts
@@ -1,0 +1,29 @@
+/**
+ * Parse a stored `sandbox.tunnel_urls` blob into a `{ [port]: url }` map.
+ *
+ * `tunnel_urls` is a JSON-encoded `Record<string, string>` written by
+ * `SandboxLifecycleManager#storeAndBroadcastTunnelUrls`. Returns `null` when the
+ * stored value is malformed — not valid JSON, not a plain JSON object, or holds
+ * a non-string value — so callers can tell corrupt data apart from an empty map
+ * and decide how to react (the DO state path falls open to `null`; the
+ * sandbox-auth endpoint hard-fails with a 500). Logging is left to the caller so
+ * this stays a pure, independently testable function.
+ */
+export function parseTunnelUrls(raw: string): Record<string, string> | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+
+  if (!Object.values(parsed).every((value) => typeof value === "string")) {
+    return null;
+  }
+
+  return parsed as Record<string, string>;
+}


### PR DESCRIPTION
## Summary

Follow-up to #691 (already merged). That PR added the sandbox-auth
`GET /sessions/:id/tunnel-urls` endpoint with an **inline** JSON parser for
`sandbox.tunnel_urls`, duplicating the `safeParseTunnelUrls` logic already
living in `SessionDO`. The two had quietly diverged:

| | `safeParseTunnelUrls` (DO state path) | inline parser (new endpoint) |
|---|---|---|
| invalid JSON | `null` | `500` |
| not a plain object / is array | **not checked** (blind cast) | `500` |
| value not a string | not checked | not checked |

Two parsers for one column, neither aware of the other — drift bait the next
time the stored format changes.

## What changed

Extract one pure helper, `parseTunnelUrls(raw)`, in
`packages/control-plane/src/session/tunnel-urls.ts`, and route both call sites
through it:

- **handler `tunnelUrls()`** drops its inline `try/catch` + shape check
  (~15 lines → 4).
- **`SessionDO#safeParseTunnelUrls`** delegates to the helper, keeping its
  contextual `warn` log, and now gains the object + string-value validation it
  previously lacked.

The helper validates JSON, plain-object shape, and that **every value is a
string**, returning `null` on any failure. Logging stays in the callers, so the
helper is pure and unit-testable; each caller maps `null` as it sees fit (the DO
state path falls open to `null` for the UI; the endpoint returns `500` so the
in-sandbox `setup.sh` hard-fails instead of writing a garbage `.tunnels.env`).

Also tightened the endpoint doc comment: it implied the `500` path fully guards
against an empty `.tunnels.env`, but a *not-yet-resolved* sandbox still returns
`200 {}` — so the client must tolerate an empty result and retry. The comment
now says so.

## Behavior

Unchanged for valid data. The only differences are **stricter rejection of
corrupt stored data**: the DO state path now treats a non-object/non-string
blob as `null` (was a blind cast), and the endpoint now `500`s on non-string
values (was silently returned).

## Tests

- New `tunnel-urls.test.ts` unit-tests the parser directly (valid, empty,
  invalid JSON, non-object, non-string values).
- Added a handler case: non-string value → `500`.
- `npm run typecheck -w @open-inspect/control-plane` — clean.
- `npm test -w @open-inspect/control-plane` for `tunnel-urls`, `sandbox.handler`,
  `routes`, and `router.scm-credentials` — 32 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tunnel URL validation with clearer error responses when misconfigured tunnel data is detected, returning HTTP 500 with a descriptive error message instead of generic failures.

* **Tests**
  * Added comprehensive test coverage for tunnel URL parsing, including handling of invalid JSON, malformed data structures, and non-string values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->