### PR TITLE
feat: add OpenCode Zen GLM 5.1 model

### DIFF
--- a/packages/control-plane/src/utils/models.test.ts
+++ b/packages/control-plane/src/utils/models.test.ts
@@ -51,6 +51,13 @@ describe("model utilities", () => {
       expect(isValidModel("deepseek/deepseek-v4-pro")).toBe(true);
     });
 
+    it("returns true for OpenCode Zen models", () => {
+      expect(isValidModel("opencode/kimi-k2.5")).toBe(true);
+      expect(isValidModel("opencode/minimax-m2.5")).toBe(true);
+      expect(isValidModel("opencode/glm-5")).toBe(true);
+      expect(isValidModel("opencode/glm-5.1")).toBe(true);
+    });
+
     it("accepts bare GPT model names via normalization", () => {
       expect(isValidModel("gpt-5.4")).toBe(true);
       expect(isValidModel("gpt-5.5")).toBe(true);
@@ -568,6 +575,18 @@ describe("model utilities", () => {
   });
 
   describe("MODEL_OPTIONS", () => {
+    it("includes OpenCode Zen models in an opt-in category", () => {
+      const openCodeZenCategory = MODEL_OPTIONS.find((group) => group.category === "OpenCode Zen");
+
+      expect(openCodeZenCategory?.models.map((model) => model.id)).toEqual([
+        "opencode/kimi-k2.5",
+        "opencode/minimax-m2.5",
+        "opencode/glm-5",
+        "opencode/glm-5.1",
+      ]);
+      expect(DEFAULT_ENABLED_MODELS).not.toContain("opencode/glm-5.1");
+    });
+
     it("includes DeepSeek models in an opt-in category", () => {
       const deepseekCategory = MODEL_OPTIONS.find((group) => group.category === "DeepSeek");
 

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -27,6 +27,7 @@ export const VALID_MODELS = [
   "opencode/kimi-k2.5",
   "opencode/minimax-m2.5",
   "opencode/glm-5",
+  "opencode/glm-5.1",
   "deepseek/deepseek-v4-flash",
   "deepseek/deepseek-v4-pro",
 ] as const;
@@ -163,6 +164,7 @@ export const MODEL_OPTIONS: ModelCategory[] = [
       { id: "opencode/kimi-k2.5", name: "Kimi K2.5", description: "Moonshot AI" },
       { id: "opencode/minimax-m2.5", name: "MiniMax M2.5", description: "MiniMax" },
       { id: "opencode/glm-5", name: "GLM 5", description: "Z.ai 744B MoE" },
+      { id: "opencode/glm-5.1", name: "GLM 5.1", description: "Z.ai" },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Add `opencode/glm-5.1` to the shared valid model registry and OpenCode Zen model options.
- Cover OpenCode Zen validation and opt-in category behavior in model utility tests.

## Tests
- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/control-plane -- src/utils/models.test.ts`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/83c36fc8b5ba885b03c3e5b42aa4df2a)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenCode Zen's GLM-5.1 model is now available as an opt-in selection in the model dropdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->