### PR TITLE
fix: exclude archived repositories

### DIFF
--- a/packages/control-plane/src/auth/github-app.ts
+++ b/packages/control-plane/src/auth/github-app.ts
@@ -430,6 +430,7 @@ interface ListInstallationReposResponse {
     full_name: string;
     description: string | null;
     private: boolean;
+    archived: boolean;
     default_branch: string;
     language: string | null;
     topics?: string[];
@@ -494,6 +495,7 @@ export async function listInstallationRepositories(
       fullName: repo.full_name,
       description: repo.description,
       private: repo.private,
+      archived: repo.archived,
       defaultBranch: repo.default_branch,
       language: repo.language,
       topics: repo.topics,
@@ -592,6 +594,7 @@ export async function getInstallationRepository(
     full_name: string;
     description: string | null;
     private: boolean;
+    archived: boolean;
     default_branch: string;
     owner: { login: string };
   };
@@ -603,6 +606,7 @@ export async function getInstallationRepository(
     fullName: data.full_name,
     description: data.description,
     private: data.private,
+    archived: data.archived,
     defaultBranch: data.default_branch,
   };
 }

--- a/packages/control-plane/src/routes/repos.ts
+++ b/packages/control-plane/src/routes/repos.ts
@@ -24,7 +24,7 @@ import {
 
 const logger = createLogger("router:repos");
 
-const REPOS_CACHE_KEY = "repos:list";
+const REPOS_CACHE_KEY = "repos:list:v2";
 const REPOS_CACHE_FRESH_MS = 5 * 60 * 1000; // Serve without revalidation for 5 minutes
 const REPOS_CACHE_KV_TTL_SECONDS = 3600; // Keep stale data in KV for 1 hour
 

--- a/packages/control-plane/src/source-control/providers/github-provider.test.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GitHubSourceControlProvider } from "./github-provider";
 import { SourceControlProviderError } from "../errors";
 
@@ -28,6 +28,10 @@ const fakeAppConfig = {
 };
 
 describe("GitHubSourceControlProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   describe("checkRepositoryAccess", () => {
     it("throws permanent error with no httpStatus when appConfig is missing", async () => {
       const provider = new GitHubSourceControlProvider();
@@ -81,6 +85,24 @@ describe("GitHubSourceControlProvider", () => {
       expect((err as SourceControlProviderError).errorType).toBe("permanent");
       expect((err as SourceControlProviderError).httpStatus).toBe(401);
     });
+
+    it("returns null for archived repositories", async () => {
+      mockGetInstallationRepository.mockResolvedValueOnce({
+        id: 1,
+        owner: "acme",
+        name: "web",
+        fullName: "acme/web",
+        description: null,
+        private: true,
+        archived: true,
+        defaultBranch: "main",
+      });
+
+      const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+      const result = await provider.checkRepositoryAccess({ owner: "acme", name: "web" });
+
+      expect(result).toBeNull();
+    });
   });
 
   describe("listRepositories", () => {
@@ -127,6 +149,39 @@ describe("GitHubSourceControlProvider", () => {
       expect(err).toBeInstanceOf(SourceControlProviderError);
       expect((err as SourceControlProviderError).errorType).toBe("permanent");
       expect((err as SourceControlProviderError).httpStatus).toBe(401);
+    });
+
+    it("excludes archived repositories", async () => {
+      mockListInstallationRepositories.mockResolvedValueOnce({
+        repos: [
+          {
+            id: 1,
+            owner: "acme",
+            name: "active",
+            fullName: "acme/active",
+            description: null,
+            private: true,
+            archived: false,
+            defaultBranch: "main",
+          },
+          {
+            id: 2,
+            owner: "acme",
+            name: "archived",
+            fullName: "acme/archived",
+            description: null,
+            private: true,
+            archived: true,
+            defaultBranch: "main",
+          },
+        ],
+        timing: { tokenGenerationMs: 0, pages: [], totalPages: 0, totalRepos: 2 },
+      });
+
+      const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+      const repos = await provider.listRepositories();
+
+      expect(repos.map((repo) => repo.fullName)).toEqual(["acme/active"]);
     });
   });
 

--- a/packages/control-plane/src/source-control/providers/github-provider.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.ts
@@ -223,6 +223,9 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
       if (!repo) {
         return null;
       }
+      if (repo.archived) {
+        return null;
+      }
       return {
         repoId: repo.id,
         repoOwner: config.owner.toLowerCase(),
@@ -254,7 +257,7 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
         cacheStore: this.cacheStore,
         userAgent: this.userAgent,
       });
-      return result.repos;
+      return result.repos.filter((repo) => !repo.archived);
     } catch (error) {
       throw SourceControlProviderError.fromFetchError(
         `Failed to list repositories: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/control-plane/src/source-control/providers/gitlab-provider.test.ts
+++ b/packages/control-plane/src/source-control/providers/gitlab-provider.test.ts
@@ -368,6 +368,23 @@ describe("GitLabSourceControlProvider", () => {
       expect(result).toBeNull();
     });
 
+    it("returns null for archived repositories", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({
+          id: 99,
+          namespace: { path: "acme" },
+          path: "web",
+          default_branch: "main",
+          archived: true,
+        })
+      );
+
+      const provider = new GitLabSourceControlProvider(fakeConfig);
+      const result = await provider.checkRepositoryAccess({ owner: "acme", name: "web" });
+
+      expect(result).toBeNull();
+    });
+
     it("throws on non-404 API errors", async () => {
       mockFetch.mockResolvedValueOnce(makeResponse("internal server error", 500));
 
@@ -411,6 +428,7 @@ describe("GitLabSourceControlProvider", () => {
             description: "The web app",
             visibility: "private",
             default_branch: "main",
+            archived: false,
           },
         ])
       );
@@ -430,8 +448,43 @@ describe("GitLabSourceControlProvider", () => {
         fullName: "acme/web",
         description: "The web app",
         private: true,
+        archived: false,
         defaultBranch: "main",
       });
+    });
+
+    it("excludes archived projects", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeResponse([
+          {
+            id: 1,
+            name: "Active App",
+            path: "active",
+            path_with_namespace: "acme/active",
+            namespace: { path: "acme" },
+            description: null,
+            visibility: "private",
+            default_branch: "main",
+            archived: false,
+          },
+          {
+            id: 2,
+            name: "Archived App",
+            path: "archived",
+            path_with_namespace: "acme/archived",
+            namespace: { path: "acme" },
+            description: null,
+            visibility: "private",
+            default_branch: "main",
+            archived: true,
+          },
+        ])
+      );
+
+      const provider = new GitLabSourceControlProvider(fakeConfig);
+      const repos = await provider.listRepositories();
+
+      expect(repos.map((repo) => repo.fullName)).toEqual(["acme/active"]);
     });
 
     it("fetches from group endpoint when namespace is configured", async () => {

--- a/packages/control-plane/src/source-control/providers/gitlab-provider.test.ts
+++ b/packages/control-plane/src/source-control/providers/gitlab-provider.test.ts
@@ -440,6 +440,10 @@ describe("GitLabSourceControlProvider", () => {
         expect.stringContaining("/projects?membership=true"),
         expect.any(Object)
       );
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("archived=false"),
+        expect.any(Object)
+      );
       expect(repos).toHaveLength(1);
       expect(repos[0]).toEqual({
         id: 1,
@@ -498,6 +502,10 @@ describe("GitLabSourceControlProvider", () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining("/groups/my-group/projects"),
+        expect.any(Object)
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("archived=false"),
         expect.any(Object)
       );
     });

--- a/packages/control-plane/src/source-control/providers/gitlab-provider.ts
+++ b/packages/control-plane/src/source-control/providers/gitlab-provider.ts
@@ -265,8 +265,8 @@ export class GitLabSourceControlProvider implements SourceControlProvider {
   async listRepositories(): Promise<InstallationRepository[]> {
     try {
       const url = this.namespace
-        ? `${GITLAB_API_BASE}/groups/${encodeURIComponent(this.namespace)}/projects?per_page=${PER_PAGE}&include_subgroups=true`
-        : `${GITLAB_API_BASE}/projects?membership=true&per_page=${PER_PAGE}`;
+        ? `${GITLAB_API_BASE}/groups/${encodeURIComponent(this.namespace)}/projects?per_page=${PER_PAGE}&include_subgroups=true&archived=false`
+        : `${GITLAB_API_BASE}/projects?membership=true&per_page=${PER_PAGE}&archived=false`;
 
       const response = await fetchWithTimeout(url, {
         headers: this.headers(this.accessToken),

--- a/packages/control-plane/src/source-control/providers/gitlab-provider.ts
+++ b/packages/control-plane/src/source-control/providers/gitlab-provider.ts
@@ -232,7 +232,12 @@ export class GitLabSourceControlProvider implements SourceControlProvider {
         namespace: { path: string };
         path: string;
         default_branch: string;
+        archived: boolean;
       };
+
+      if (data.archived) {
+        return null;
+      }
 
       return {
         repoId: data.id,
@@ -285,17 +290,21 @@ export class GitLabSourceControlProvider implements SourceControlProvider {
         description: string | null;
         visibility: string;
         default_branch: string;
+        archived: boolean;
       }>;
 
-      return data.map((project) => ({
-        id: project.id,
-        owner: project.namespace.path,
-        name: project.path,
-        fullName: project.path_with_namespace,
-        description: project.description,
-        private: project.visibility !== "public",
-        defaultBranch: project.default_branch,
-      }));
+      return data
+        .filter((project) => !project.archived)
+        .map((project) => ({
+          id: project.id,
+          owner: project.namespace.path,
+          name: project.path,
+          fullName: project.path_with_namespace,
+          description: project.description,
+          private: project.visibility !== "public",
+          archived: project.archived,
+          defaultBranch: project.default_branch,
+        }));
     } catch (error) {
       if (error instanceof SourceControlProviderError) {
         throw error;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -419,7 +419,7 @@ export interface InstallationRepository {
   description: string | null;
   private: boolean;
   defaultBranch: string;
-  archived?: boolean;
+  archived: boolean;
   language?: string | null;
   topics?: string[];
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -419,6 +419,7 @@ export interface InstallationRepository {
   description: string | null;
   private: boolean;
   defaultBranch: string;
+  archived?: boolean;
   language?: string | null;
   topics?: string[];
 }


### PR DESCRIPTION
## Summary
- Exclude archived GitHub installation repositories from repository listings and direct app access checks.
- Exclude archived GitLab projects from repository listings and direct PAT access checks.
- Preserve archived metadata in shared repo types and bump the repos cache key so stale cached archived entries are not reused.

## Tests
- `npm test -w @open-inspect/control-plane -- src/source-control/providers/github-provider.test.ts src/source-control/providers/gitlab-provider.test.ts`
- `npm run build -w @open-inspect/shared`
- `npm run build -w @open-inspect/control-plane`
- `npm run typecheck`

Closes #735

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/c7862a4423a45c8f83c09539389b5088)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository listings now exclude archived repositories.
  * Repository metadata now includes archived status information.

* **Bug Fixes**
  * Archived repositories are treated as inaccessible when checking repository access.
  * Archived handling is consistent across supported GitHub and GitLab providers.
  * Updated repository list cache version to ensure fresh enriched results.

* **Tests**
  * Extended provider test coverage for archived access and filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->