### PR TITLE
feat: add Google login as a second auth provider

### DIFF
--- a/.claude/skills/onboarding/SKILL.md
+++ b/.claude/skills/onboarding/SKILL.md
@@ -20,7 +20,7 @@ Use TodoWrite to create a checklist tracking these phases:
 1. Initial setup questions
 2. Repository setup
 3. Credential collection (Cloudflare, Vercel, Modal, Anthropic)
-4. GitHub App creation
+4. GitHub App creation (+ Google OAuth if enabled)
 5. Slack App creation (if enabled)
 6. Security secrets generation
 7. Terraform configuration
@@ -141,6 +141,34 @@ After receiving the .pem path, convert to PKCS#8:
 openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in {pem_path} -out /tmp/github-app-key-pkcs8.pem
 cat /tmp/github-app-key-pkcs8.pem
 ```
+
+## Phase 4b: Google OAuth Setup (If Enabled)
+
+Only if the user wants Google login for non-developer users (PMs, support agents). Skip for
+GitHub-only deployments — leave `google_client_id` and `google_client_secret` empty.
+
+Guide user:
+
+1. https://console.cloud.google.com/apis/credentials → "Create Credentials" → "OAuth client ID"
+2. **Application type**: Web application
+3. **Authorized redirect URI**:
+   `https://open-inspect-{deployment_name}.vercel.app/api/auth/callback/google` (or your
+   `*.workers.dev` web URL if `web_platform = "cloudflare"`)
+   - **CRITICAL**: Must match deployed web URL exactly!
+4. OAuth consent screen: request only `openid`, `email`, `profile` scopes (non-sensitive — no Google
+   verification review required)
+5. Note **Client ID** and **Client Secret**
+
+Then in `terraform.tfvars`:
+
+- Set `google_client_id` and `google_client_secret` (both required together; leave both empty to
+  disable)
+- Add at least one entry to `allowed_emails` (exact addresses, e.g. `pm@gmail.com`) or
+  `allowed_email_domains`. Prefer `allowed_emails` for shared domains like gmail.com.
+
+Terraform derives `NEXT_PUBLIC_GOOGLE_ENABLED` automatically when both Google credentials are set,
+which reveals the "Sign in with Google" button. Google users get the same flat access; their PRs
+fall back to the App bot unless the same verified email is also a linked GitHub identity.
 
 ## Phase 5: Slack App Setup (If Enabled)
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -192,6 +192,8 @@ jobs:
           TF_VAR_modal_environment_web_suffix: ${{ secrets.MODAL_ENVIRONMENT_WEB_SUFFIX }}
           TF_VAR_github_client_id: ${{ secrets.GH_OAUTH_CLIENT_ID }}
           TF_VAR_github_client_secret: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
+          TF_VAR_google_client_id: ${{ secrets.GOOGLE_CLIENT_ID }}
+          TF_VAR_google_client_secret: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           TF_VAR_github_app_id: ${{ secrets.GH_APP_ID }}
           TF_VAR_github_app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           TF_VAR_github_app_installation_id: ${{ secrets.GH_APP_INSTALLATION_ID }}
@@ -206,6 +208,7 @@ jobs:
           TF_VAR_modal_api_secret: ${{ secrets.MODAL_API_SECRET }}
           TF_VAR_allowed_users: ${{ secrets.ALLOWED_USERS }}
           TF_VAR_allowed_email_domains: ${{ secrets.ALLOWED_EMAIL_DOMAINS }}
+          TF_VAR_allowed_emails: ${{ secrets.ALLOWED_EMAILS }}
           TF_VAR_deployment_name: ${{ secrets.DEPLOYMENT_NAME }}
           TF_VAR_enable_github_bot: "${{ secrets.ENABLE_GITHUB_BOT || 'false' }}"
           TF_VAR_github_webhook_secret: ${{ secrets.GH_WEBHOOK_SECRET }}
@@ -332,6 +335,8 @@ jobs:
           TF_VAR_modal_environment_web_suffix: ${{ secrets.MODAL_ENVIRONMENT_WEB_SUFFIX }}
           TF_VAR_github_client_id: ${{ secrets.GH_OAUTH_CLIENT_ID }}
           TF_VAR_github_client_secret: ${{ secrets.GH_OAUTH_CLIENT_SECRET }}
+          TF_VAR_google_client_id: ${{ secrets.GOOGLE_CLIENT_ID }}
+          TF_VAR_google_client_secret: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           TF_VAR_github_app_id: ${{ secrets.GH_APP_ID }}
           TF_VAR_github_app_private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           TF_VAR_github_app_installation_id: ${{ secrets.GH_APP_INSTALLATION_ID }}
@@ -346,6 +351,7 @@ jobs:
           TF_VAR_modal_api_secret: ${{ secrets.MODAL_API_SECRET }}
           TF_VAR_allowed_users: ${{ secrets.ALLOWED_USERS }}
           TF_VAR_allowed_email_domains: ${{ secrets.ALLOWED_EMAIL_DOMAINS }}
+          TF_VAR_allowed_emails: ${{ secrets.ALLOWED_EMAILS }}
           TF_VAR_deployment_name: ${{ secrets.DEPLOYMENT_NAME }}
           TF_VAR_enable_github_bot: "${{ secrets.ENABLE_GITHUB_BOT || 'false' }}"
           TF_VAR_github_webhook_secret: ${{ secrets.GH_WEBHOOK_SECRET }}

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ through the git credential helper on demand. This means:
   organization's repositories, and any user of the system can access any repo the App has access to
 - **No per-user repository access validation** - The system does not verify that a user has
   permission to access a specific repository before creating a session
-- **User OAuth tokens are used for PR creation** - PRs are created using the user's GitHub OAuth
-  token, ensuring proper attribution and that users can only create PRs on repos they have write
-  access to
+- **GitHub users' OAuth tokens are used for PR creation** - For GitHub logins, PRs are created using
+  the user's GitHub OAuth token, ensuring proper attribution and that they can only create PRs on
+  repos they have write access to. Users who sign in another way (e.g. Google) carry no SCM token,
+  so their PRs fall back to the shared GitHub App bot
 
 ### Token Architecture
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -420,6 +420,13 @@ github_app_private_key     = <<-EOF
 -----END PRIVATE KEY-----
 EOF
 
+# Google OAuth (optional — enables "Sign in with Google" for non-developer
+# users). Create a Web OAuth client at https://console.cloud.google.com/apis/credentials
+# with redirect URI {your-web-app-url}/api/auth/callback/google. Set BOTH to
+# enable, or leave BOTH empty for GitHub-only. See "Enable Google Login" below.
+google_client_id     = ""
+google_client_secret = ""
+
 # Slack (set enable_slack_bot = false to disable Slack integration)
 enable_slack_bot     = false
 slack_bot_token      = ""
@@ -460,18 +467,44 @@ project_root    = "../../../"
 enable_durable_object_bindings = false
 enable_service_bindings        = false
 
-# Access Control (set at least one allowlist for production)
+# Access Control (set at least one allowlist for production). A user is admitted
+# if they match ANY allowlist below.
 allowed_users         = "your-github-username"  # Comma-separated GitHub usernames, or empty
 allowed_email_domains = ""                      # Comma-separated domains (e.g., "example.com,corp.io")
+allowed_emails        = ""                      # Exact addresses (e.g., "pm@gmail.com") — for users on shared domains
 
-# Explicitly opt into open access only if you want any authenticated GitHub user
-# to be able to sign in when both allowlists are empty.
+# Explicitly opt into open access only if you want any authenticated user to be
+# able to sign in when all allowlists are empty.
 unsafe_allow_all_users = false
 ```
 
-> **Note**: Review `allowed_users` and `allowed_email_domains` carefully - these control who can
-> sign in. Terraform now fails if both are empty unless you explicitly set
-> `unsafe_allow_all_users = true`.
+> **Note**: Review `allowed_users`, `allowed_email_domains`, and `allowed_emails` carefully — these
+> control who can sign in. Terraform fails if all three are empty unless you explicitly set
+> `unsafe_allow_all_users = true`. Use `allowed_emails` for individual users on shared domains (e.g.
+> a specific `person@gmail.com`) where `allowed_email_domains` would admit too many.
+
+### Enable Google Login (Optional)
+
+Google login lets non-developer users (PMs, support agents) sign in without a GitHub account. They
+get the same flat access as everyone else; git operations still use the shared GitHub App, and their
+PRs fall back to the App bot (no personal GitHub attribution unless the same verified email is also
+a linked GitHub identity).
+
+1. In the [Google Cloud Console](https://console.cloud.google.com/apis/credentials), create an
+   **OAuth client ID** of type **Web application**.
+2. Add the authorized redirect URI `{your-web-app-url}/api/auth/callback/google` (e.g.
+   `https://open-inspect-yourname.vercel.app/api/auth/callback/google`). It must match the deployed
+   URL exactly.
+3. On the OAuth consent screen, request only the `openid`, `email`, and `profile` scopes — these are
+   non-sensitive, so Google requires no app-verification review.
+4. Set `google_client_id` and `google_client_secret` (both required together), and add at least one
+   allowed user to `allowed_emails` (exact addresses) or `allowed_email_domains`. Terraform derives
+   `NEXT_PUBLIC_GOOGLE_ENABLED` automatically when both credentials are present, which reveals the
+   "Sign in with Google" button.
+
+> **Security note**: Google sign-in is admitted only for **verified** emails that match an
+> allowlist. Because addresses on shared domains like `gmail.com` are generic, prefer
+> `allowed_emails` (exact match) over `allowed_email_domains` for those users.
 
 ---
 
@@ -736,6 +769,8 @@ Go to your fork's Settings → Secrets and variables → Actions, and add:
 | `VERCEL_SANDBOX_API_BASE_URL`    | Optional advanced Vercel Sandbox API base URL override                                      |
 | `GH_OAUTH_CLIENT_ID`             | GitHub App OAuth client ID                                                                  |
 | `GH_OAUTH_CLIENT_SECRET`         | GitHub App OAuth client secret                                                              |
+| `GOOGLE_CLIENT_ID`               | Google OAuth client ID (only if Google login enabled; pair with `GOOGLE_CLIENT_SECRET`)     |
+| `GOOGLE_CLIENT_SECRET`           | Google OAuth client secret (only if Google login enabled)                                   |
 | `GH_APP_ID`                      | GitHub App ID                                                                               |
 | `GH_APP_PRIVATE_KEY`             | GitHub App private key (PKCS#8 format)                                                      |
 | `GH_APP_INSTALLATION_ID`         | GitHub App installation ID                                                                  |
@@ -755,6 +790,7 @@ Go to your fork's Settings → Secrets and variables → Actions, and add:
 | `NEXTAUTH_SECRET`                | Generated NextAuth secret                                                                   |
 | `ALLOWED_USERS`                  | Comma-separated GitHub usernames (or empty for all users)                                   |
 | `ALLOWED_EMAIL_DOMAINS`          | Comma-separated email domains (or empty for all domains)                                    |
+| `ALLOWED_EMAILS`                 | Comma-separated exact email addresses (for individual users on shared domains)              |
 | `ENABLE_DURABLE_OBJECT_BINDINGS` | Optional Terraform CI flag for Durable Object phase 1 (defaults to `true`)                  |
 | `ENABLE_GITHUB_BOT`              | `true` to deploy GitHub bot worker (or empty to skip)                                       |
 | `GH_WEBHOOK_SECRET`              | GitHub webhook secret (required if GitHub bot enabled)                                      |

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -357,8 +357,12 @@ When you ask the agent to create a PR:
 
 1. Agent pushes the branch using brokered SCM credentials from the sandbox credential helper
 2. Control plane receives the branch name
-3. Control plane creates the PR using _your_ GitHub OAuth token
+3. Control plane creates the PR using _your_ GitHub OAuth token (GitHub logins)
 4. PR appears as created by you, not a bot
+
+If you signed in another way (e.g. Google) you have no GitHub OAuth token, so the control plane
+pushes the branch with the shared GitHub App credentials and returns a manual `pull/new` URL — the
+PR is attributed to the App bot rather than to you.
 
 This maintains proper code review workflows—you can't approve your own PRs.
 

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -78,6 +78,14 @@ Edit `packages/web/.env.local`:
 GITHUB_CLIENT_ID=your_github_app_client_id
 GITHUB_CLIENT_SECRET=your_github_app_client_secret
 
+# Google OAuth (optional — enables "Sign in with Google"). Create a Web OAuth
+# client at https://console.cloud.google.com/apis/credentials with redirect URI
+# http://localhost:3000/api/auth/callback/google. Set NEXT_PUBLIC_GOOGLE_ENABLED=true
+# to reveal the button (inlined at build time — restart the dev server after changing).
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+NEXT_PUBLIC_GOOGLE_ENABLED=
+
 # NextAuth
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=your_generated_secret
@@ -89,9 +97,11 @@ NEXT_PUBLIC_WS_URL=wss://open-inspect-control-plane-<name>.<subdomain>.workers.d
 # Must match control-plane INTERNAL_CALLBACK_SECRET
 INTERNAL_CALLBACK_SECRET=your_shared_secret
 
-# Optional access control
+# Optional access control (a user is admitted if they match ANY allowlist)
 ALLOWED_USERS=
 ALLOWED_EMAIL_DOMAINS=
+# Exact emails (any provider's verified email) — for users on shared domains
+ALLOWED_EMAILS=
 
 # Optional whitelabel branding (defaults shown). NEXT_PUBLIC_* vars are
 # inlined into the client bundle at build time — restart `npm run dev`
@@ -120,6 +130,10 @@ In GitHub App settings, include:
 `http://localhost:3000/api/auth/callback/github`
 
 If this does not match exactly, sign-in will fail.
+
+If you enabled Google login, also add this redirect URI to your Google OAuth client:
+
+`http://localhost:3000/api/auth/callback/google`
 
 ### 4. Run the app
 

--- a/packages/control-plane/README.md
+++ b/packages/control-plane/README.md
@@ -229,8 +229,9 @@ Daytona persistent resumes; Modal snapshot restores still mint a fresh fallback 
 restore.
 
 If a `create-pr` request is triggered by a participant without a user OAuth token (for example,
-Slack-created sessions), the sandbox can still push the branch with brokered GitHub App credentials
-and the control plane returns a manual GitHub `pull/new` URL instead of failing the request.
+Slack-created or Google-login sessions), the sandbox can still push the branch with brokered GitHub
+App credentials and the control plane returns a manual GitHub `pull/new` URL instead of failing the
+request.
 
 ### Why This Matters
 

--- a/packages/control-plane/src/db/user-store.ts
+++ b/packages/control-plane/src/db/user-store.ts
@@ -3,7 +3,7 @@ import { generateId } from "../auth/crypto";
 // ── Public types ────────────────────────────────────────────────────
 
 export interface ProviderIdentity {
-  provider: "github" | "slack" | "linear";
+  provider: "github" | "slack" | "linear" | "google";
   providerUserId: string;
   providerLogin?: string;
   providerEmail?: string;
@@ -150,8 +150,12 @@ export class UserStore {
   }
 
   async getIdentitiesForUser(userId: string): Promise<UserIdentity[]> {
+    // ORDER BY created_at gives a deterministic order so callers that pick a
+    // single identity (e.g. resolveGitHubEnrichment) get a stable result.
+    // Google's email-based cross-provider linking makes multi-identity users
+    // more common, so the previously-unordered query could otherwise vary.
     const result = await this.db
-      .prepare("SELECT * FROM user_identities WHERE user_id = ?")
+      .prepare("SELECT * FROM user_identities WHERE user_id = ? ORDER BY created_at ASC")
       .bind(userId)
       .all<UserIdentityRow>();
     return (result.results ?? []).map(toUserIdentity);

--- a/packages/control-plane/src/router.provider-identities.test.ts
+++ b/packages/control-plane/src/router.provider-identities.test.ts
@@ -56,6 +56,44 @@ describe("provider identity router integration", () => {
     });
   });
 
+  it("serves Google provider identity upserts even when the SCM provider is not github", async () => {
+    // Guards the widened isScmAgnosticRoute regex: a typo dropping `google`
+    // would make this 501 (SCM not implemented) instead of reaching the handler.
+    const env = {
+      INTERNAL_CALLBACK_SECRET: "test-secret",
+      SCM_PROVIDER: "gitlab",
+      DB: {
+        prepare: vi.fn(),
+        batch: vi.fn(),
+        exec: vi.fn(),
+        dump: vi.fn(),
+      },
+    };
+
+    const token = await generateInternalToken(env.INTERNAL_CALLBACK_SECRET);
+    const response = await handleRequest(
+      new Request("https://test.local/provider-identities/google/google-sub-1", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          providerEmail: "pm@corp.com",
+        }),
+      }),
+      env as never
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      userId: "0123456789abcdef0123456789abcdef",
+    });
+    expect(mockUserStore.resolveOrCreateUser).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "google", providerUserId: "google-sub-1" })
+    );
+  });
+
   it("rejects non-GitHub provider identity paths when the SCM provider is not github", async () => {
     const env = {
       INTERNAL_CALLBACK_SECRET: "test-secret",

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -127,7 +127,9 @@ function isSandboxAuthRoute(path: string): boolean {
 function isScmAgnosticRoute(path: string): boolean {
   return (
     /^\/analytics\/(summary|timeseries|breakdown)$/.test(path) ||
-    /^\/provider-identities\/github\/[^/]+$/.test(path) ||
+    // Identity upserts are independent of the SCM provider. Only the known auth
+    // providers are agnostic; an unimplemented SCM (e.g. gitlab) still 501s.
+    /^\/provider-identities\/(github|slack|linear|google)\/[^/]+$/.test(path) ||
     /^\/sessions\/[^/]+\/tunnel-urls$/.test(path)
   );
 }

--- a/packages/control-plane/src/routes/automations.test.ts
+++ b/packages/control-plane/src/routes/automations.test.ts
@@ -234,6 +234,33 @@ describe("automation route handlers", () => {
       expect(mockStore.create).toHaveBeenCalledWith(expect.objectContaining({ user_id: null }));
     });
 
+    it("resolves user_id for a Google automation (auth* fields, no scmUserId)", async () => {
+      mockStore.create.mockResolvedValue(undefined);
+      mockStore.getById.mockResolvedValue(sampleRow);
+
+      const res = await callRoute("POST", "/automations", {
+        body: {
+          ...validBody,
+          authProvider: "google",
+          authUserId: "google-sub-1",
+          authEmail: "pm@corp.com",
+          authName: "PM Person",
+        },
+      });
+
+      expect(res.status).toBe(201);
+      expect(mockUserStore.resolveOrCreateUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: "google",
+          providerUserId: "google-sub-1",
+          providerEmail: "pm@corp.com",
+        })
+      );
+      expect(mockStore.create).toHaveBeenCalledWith(
+        expect.objectContaining({ user_id: "resolved-user-1" })
+      );
+    });
+
     it("stores reasoning effort when valid for the selected model", async () => {
       mockStore.create.mockResolvedValue(undefined);
       mockStore.getById.mockResolvedValue({ ...sampleRow, reasoning_effort: "high" });

--- a/packages/control-plane/src/routes/automations.ts
+++ b/packages/control-plane/src/routes/automations.ts
@@ -18,6 +18,7 @@ import {
 } from "@open-inspect/shared";
 import { AutomationStore, toAutomation, toAutomationRun } from "../db/automation-store";
 import { UserStore } from "../db/user-store";
+import { resolveProviderIdentity, type SessionIdentityFields } from "../session/identity";
 import { generateId } from "../auth/crypto";
 import { generateWebhookApiKey, hashApiKey, encryptSentrySecret } from "../auth/webhook-key";
 import { createLogger } from "../logger";
@@ -93,16 +94,7 @@ async function handleCreateAutomation(
   _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const body = await parseJsonBody<
-    CreateAutomationRequest & {
-      userId?: string;
-      scmUserId?: string;
-      scmLogin?: string;
-      scmName?: string;
-      scmEmail?: string;
-      scmAvatarUrl?: string;
-    }
-  >(request);
+  const body = await parseJsonBody<CreateAutomationRequest & SessionIdentityFields>(request);
   if (body instanceof Response) return body;
 
   // Validate required fields
@@ -225,24 +217,24 @@ async function handleCreateAutomation(
     triggerAuthData = await encryptSentrySecret(sentrySecret, env.REPO_SECRETS_ENCRYPTION_KEY);
   }
 
-  // Resolve canonical user model ID (best-effort, same pattern as handleCreateSession)
+  // Resolve canonical user model ID (best-effort, same pattern as handleCreateSession).
+  // Automations are created by web users, so resolve through the provider-agnostic
+  // "user" path: this populates user_id for both GitHub (scm*) and Google (auth*)
+  // users at creation time. Without it a Google automation would store user_id = NULL,
+  // and the github-only scheduler fallback (createSessionForAutomation) could never
+  // recover the canonical user — losing attribution, enrichment, and tokens at fire time.
   let resolvedUserId: string | null = null;
-  if (body.scmUserId) {
+  const providerIdentity = resolveProviderIdentity("user", body);
+  if (providerIdentity) {
     try {
       const userStore = new UserStore(env.DB);
-      const resolvedUser = await userStore.resolveOrCreateUser({
-        provider: "github",
-        providerUserId: body.scmUserId,
-        providerLogin: body.scmLogin,
-        providerEmail: body.scmEmail,
-        displayName: body.scmName || body.scmLogin,
-        avatarUrl: body.scmAvatarUrl,
-      });
+      const resolvedUser = await userStore.resolveOrCreateUser(providerIdentity);
       resolvedUserId = resolvedUser.id;
     } catch (e) {
       logger.warn("Failed to resolve user identity for automation", {
         error: e instanceof Error ? e : String(e),
-        scmUserId: body.scmUserId,
+        provider: providerIdentity.provider,
+        providerUserId: providerIdentity.providerUserId,
       });
     }
   }

--- a/packages/control-plane/src/routes/provider-identities.test.ts
+++ b/packages/control-plane/src/routes/provider-identities.test.ts
@@ -73,7 +73,7 @@ describe("provider identity routes", () => {
     });
   });
 
-  describe("PUT /provider-identities/github/:providerUserId", () => {
+  describe("PUT /provider-identities/:provider/:providerUserId", () => {
     it("upserts a GitHub identity and returns its canonical user ID", async () => {
       const response = await callProviderIdentityRoute("/provider-identities/github/12345", {
         providerLogin: "ada",
@@ -96,11 +96,46 @@ describe("provider identity routes", () => {
       });
     });
 
-    it("does not match non-GitHub provider identity paths", () => {
+    it("matches every supported provider identity path and captures the provider", () => {
       const route = providerIdentityRoutes.find((candidate) => candidate.method === "PUT")!;
 
-      expect("/provider-identities/slack/U123".match(route.pattern)).toBeNull();
-      expect("/provider-identities/linear/abc".match(route.pattern)).toBeNull();
+      for (const [path, provider, providerUserId] of [
+        ["/provider-identities/github/12345", "github", "12345"],
+        ["/provider-identities/slack/U123", "slack", "U123"],
+        ["/provider-identities/linear/abc", "linear", "abc"],
+        ["/provider-identities/google/google-sub-1", "google", "google-sub-1"],
+      ] as const) {
+        const match = path.match(route.pattern);
+        expect(match?.groups).toMatchObject({ provider, providerUserId });
+      }
+    });
+
+    it("upserts a non-GitHub (Google) identity using the provider from the path", async () => {
+      const response = await callProviderIdentityRoute("/provider-identities/google/google-sub-1", {
+        providerEmail: "pm@corp.com",
+        displayName: "PM Person",
+        avatarUrl: "https://lh3.googleusercontent.com/pic",
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockUserStore.resolveOrCreateUser).toHaveBeenCalledWith({
+        provider: "google",
+        providerUserId: "google-sub-1",
+        providerLogin: undefined,
+        providerEmail: "pm@corp.com",
+        displayName: "PM Person",
+        avatarUrl: "https://lh3.googleusercontent.com/pic",
+      });
+    });
+
+    it("rejects unsupported providers with 400 without resolving a user", async () => {
+      const response = await callProviderIdentityRoute("/provider-identities/gitlab/U123", {});
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: "provider must be one of: github, slack, linear, google",
+      });
+      expect(mockUserStore.resolveOrCreateUser).not.toHaveBeenCalled();
     });
 
     it("rejects requests with no request body", async () => {

--- a/packages/control-plane/src/routes/provider-identities.ts
+++ b/packages/control-plane/src/routes/provider-identities.ts
@@ -17,6 +17,14 @@ type UpsertProviderIdentityRequest = {
   avatarUrl?: unknown;
 };
 
+/** Providers that may be upserted through this internal route. */
+const ALLOWED_PROVIDERS = ["github", "slack", "linear", "google"] as const;
+type AllowedProvider = (typeof ALLOWED_PROVIDERS)[number];
+
+function isAllowedProvider(value: string | undefined): value is AllowedProvider {
+  return value !== undefined && (ALLOWED_PROVIDERS as readonly string[]).includes(value);
+}
+
 function optionalString(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
@@ -48,13 +56,18 @@ export async function handleUpsertProviderIdentity(
     return error("Request body must be an object", 400);
   }
 
+  const provider = match.groups?.provider;
+  if (!isAllowedProvider(provider)) {
+    return error(`provider must be one of: ${ALLOWED_PROVIDERS.join(", ")}`, 400);
+  }
+
   const providerUserId = pathSegment(match.groups?.providerUserId);
   if (!providerUserId) {
     return error("providerUserId is required", 400);
   }
 
   const identity: ProviderIdentity = {
-    provider: "github",
+    provider,
     providerUserId,
     providerLogin: optionalString(body.providerLogin),
     providerEmail: optionalString(body.providerEmail),
@@ -73,7 +86,7 @@ export async function handleUpsertProviderIdentity(
 export const providerIdentityRoutes: Route[] = [
   {
     method: "PUT",
-    pattern: parsePattern("/provider-identities/github/:providerUserId"),
+    pattern: parsePattern("/provider-identities/:provider/:providerUserId"),
     handler: handleUpsertProviderIdentity,
   },
 ];

--- a/packages/control-plane/src/routes/session-create.ts
+++ b/packages/control-plane/src/routes/session-create.ts
@@ -97,8 +97,17 @@ async function handleCreateSession(
     }
   }
 
-  // Enrich owner participant with linked GitHub identity from D1.
-  // Fills in SCM fields the bot didn't provide (email, display name, OAuth tokens).
+  // Enrich the owner with their linked GitHub identity from D1: fill in SCM
+  // fields the caller didn't provide (email, display name, OAuth token).
+  //
+  // This intentionally applies even when the session was authenticated via a
+  // non-GitHub provider (e.g. Google): if the canonical user has ALSO linked a
+  // verified-email GitHub identity, enrichment surfaces THAT identity's token so
+  // the same human keeps GitHub-attributed commits/PRs. resolveGitHubEnrichment
+  // keys off the linked `provider === "github"` identity, never the Google
+  // credential; a user with no linked GitHub identity gets null here and falls
+  // back to the App bot. The invariant is "a Google credential is never used as
+  // an SCM credential", not "a Google-authenticated session carries no SCM state".
   if (resolvedUserId) {
     try {
       const enrichment = await resolveGitHubEnrichment(env, userStore, resolvedUserId);

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -549,12 +549,12 @@ export class SchedulerDO extends DurableObject<Env> {
     const sessionId = generateId();
 
     // Resolve the canonical user_id for the session index.
-    // New automations (post-Phase 5) have user_id populated at creation time, so this
-    // lookup is skipped. Legacy automations have user_id = NULL but store the GitHub
-    // numeric user ID in created_by (set from NextAuth session.user.id in the web UI,
-    // which is the only automation creation path). We look up that GitHub ID in
-    // user_identities to find the canonical user. This fallback becomes dead code once
-    // the Phase 6 backfill populates user_id on all existing automation rows.
+    // Automations created through the web UI populate user_id at creation time
+    // (handleCreateAutomation resolves it for both GitHub and Google users), so this
+    // lookup is skipped for them. The fallback below only covers legacy rows with
+    // user_id = NULL: those predate Google login and store the GitHub numeric user ID
+    // in created_by (from NextAuth session.user.id), so a github-only identity lookup
+    // recovers the canonical user. It becomes dead code once legacy rows are backfilled.
     let userId = automation.user_id;
     if (!userId && automation.created_by && automation.created_by !== "anonymous") {
       try {

--- a/packages/control-plane/src/session/identity.test.ts
+++ b/packages/control-plane/src/session/identity.test.ts
@@ -289,6 +289,38 @@ describe("resolveProviderIdentity", () => {
         resolveProviderIdentity("user", { spawnSource: "user", authProvider: "google" })
       ).toBeNull();
     });
+
+    it("fails closed on an unsupported authProvider rather than persisting it raw", () => {
+      expect(
+        resolveProviderIdentity("user", {
+          spawnSource: "user",
+          // Deliberately invalid discriminator from a malformed/crafted body.
+          authProvider: "evil" as unknown as "github" | "google",
+          authUserId: "x-1",
+          scmUserId: "1001",
+        })
+      ).toBeNull();
+    });
+
+    it("never pairs authProvider with a scm* fallback id (no mixed-source identity)", () => {
+      // authUserId absent: identity comes entirely from scm* (always github),
+      // never provider=authProvider paired with providerUserId=scmUserId.
+      expect(
+        resolveProviderIdentity("user", {
+          spawnSource: "user",
+          authProvider: "google",
+          scmUserId: "1001",
+          scmLogin: "ada",
+        })
+      ).toEqual({
+        provider: "github",
+        providerUserId: "1001",
+        providerLogin: "ada",
+        providerEmail: undefined,
+        displayName: "ada",
+        avatarUrl: undefined,
+      });
+    });
   });
 });
 

--- a/packages/control-plane/src/session/identity.test.ts
+++ b/packages/control-plane/src/session/identity.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { deriveParticipantUserId, parseAuthorId } from "./identity";
+import type { UserStore } from "../db/user-store";
+import type { Env } from "../types";
+import {
+  deriveParticipantUserId,
+  parseAuthorId,
+  resolveGitHubEnrichment,
+  resolveProviderIdentity,
+} from "./identity";
 
 describe("parseAuthorId", () => {
   it("parses github authorId", () => {
@@ -91,5 +98,251 @@ describe("deriveParticipantUserId", () => {
 
   it("falls back to anonymous when no fields provided", () => {
     expect(deriveParticipantUserId({})).toBe("anonymous");
+  });
+});
+
+describe("resolveProviderIdentity", () => {
+  // Characterization tests: lock in the current output for every branch before
+  // the user/github-bot case is split and the auth* block is introduced.
+  describe("current behavior", () => {
+    it("maps a web user (spawnSource 'user') to a github identity from scm* fields", () => {
+      expect(
+        resolveProviderIdentity("user", {
+          spawnSource: "user",
+          scmUserId: "1001",
+          scmLogin: "ada",
+          scmName: "Ada Lovelace",
+          scmEmail: "ada@example.com",
+          scmAvatarUrl: "https://avatars.githubusercontent.com/u/1001",
+        })
+      ).toEqual({
+        provider: "github",
+        providerUserId: "1001",
+        providerLogin: "ada",
+        providerEmail: "ada@example.com",
+        displayName: "Ada Lovelace",
+        avatarUrl: "https://avatars.githubusercontent.com/u/1001",
+      });
+    });
+
+    it("falls back to scmLogin for displayName when scmName is absent (user)", () => {
+      expect(
+        resolveProviderIdentity("user", { spawnSource: "user", scmUserId: "1001", scmLogin: "ada" })
+      ).toEqual({
+        provider: "github",
+        providerUserId: "1001",
+        providerLogin: "ada",
+        providerEmail: undefined,
+        displayName: "ada",
+        avatarUrl: undefined,
+      });
+    });
+
+    it("returns null for a web user without scmUserId", () => {
+      expect(resolveProviderIdentity("user", { spawnSource: "user" })).toBeNull();
+    });
+
+    it("maps github-bot to a github identity from scm* fields", () => {
+      expect(
+        resolveProviderIdentity("github-bot", {
+          spawnSource: "github-bot",
+          scmUserId: "2002",
+          scmLogin: "octocat",
+          scmName: "Octo Cat",
+          scmEmail: "octo@example.com",
+          scmAvatarUrl: "https://avatars.githubusercontent.com/u/2002",
+        })
+      ).toEqual({
+        provider: "github",
+        providerUserId: "2002",
+        providerLogin: "octocat",
+        providerEmail: "octo@example.com",
+        displayName: "Octo Cat",
+        avatarUrl: "https://avatars.githubusercontent.com/u/2002",
+      });
+    });
+
+    it("returns null for github-bot without scmUserId", () => {
+      expect(resolveProviderIdentity("github-bot", { spawnSource: "github-bot" })).toBeNull();
+    });
+
+    it("maps slack-bot to a slack identity from actor* fields", () => {
+      expect(
+        resolveProviderIdentity("slack-bot", {
+          spawnSource: "slack-bot",
+          actorUserId: "U123",
+          actorEmail: "slacker@example.com",
+          actorDisplayName: "Slacker",
+          actorAvatarUrl: "https://slack.example/avatar",
+        })
+      ).toEqual({
+        provider: "slack",
+        providerUserId: "U123",
+        providerEmail: "slacker@example.com",
+        displayName: "Slacker",
+        avatarUrl: "https://slack.example/avatar",
+      });
+    });
+
+    it("returns null for slack-bot without actorUserId", () => {
+      expect(resolveProviderIdentity("slack-bot", { spawnSource: "slack-bot" })).toBeNull();
+    });
+
+    it("maps linear-bot to a linear identity from actor* fields (no avatar)", () => {
+      expect(
+        resolveProviderIdentity("linear-bot", {
+          spawnSource: "linear-bot",
+          actorUserId: "lin-1",
+          actorEmail: "lin@example.com",
+          actorDisplayName: "Lin",
+        })
+      ).toEqual({
+        provider: "linear",
+        providerUserId: "lin-1",
+        providerEmail: "lin@example.com",
+        displayName: "Lin",
+      });
+    });
+
+    it("returns null for linear-bot without actorUserId", () => {
+      expect(resolveProviderIdentity("linear-bot", { spawnSource: "linear-bot" })).toBeNull();
+    });
+
+    it("returns null for an unknown spawnSource", () => {
+      expect(
+        resolveProviderIdentity("automation", { spawnSource: "automation", scmUserId: "9" })
+      ).toBeNull();
+    });
+  });
+
+  describe("google + back-compat (post-split)", () => {
+    it("maps a Google web user to a google identity from auth* fields (no scm*)", () => {
+      expect(
+        resolveProviderIdentity("user", {
+          spawnSource: "user",
+          authProvider: "google",
+          authUserId: "google-sub-123",
+          authEmail: "pm@corp.com",
+          authName: "PM Person",
+          authAvatarUrl: "https://lh3.googleusercontent.com/pic",
+        })
+      ).toEqual({
+        provider: "google",
+        providerUserId: "google-sub-123",
+        providerLogin: undefined,
+        providerEmail: "pm@corp.com",
+        displayName: "PM Person",
+        avatarUrl: "https://lh3.googleusercontent.com/pic",
+      });
+    });
+
+    it("still resolves an old-web scm-only payload (no auth*) to a github identity (M2/R1 back-compat)", () => {
+      // During the staggered web/control-plane rollout, old web keeps sending
+      // scm* with no auth*. Without the fallback this would resolve to NULL and
+      // every in-flight GitHub user's session would lose its user_id.
+      expect(
+        resolveProviderIdentity("user", {
+          spawnSource: "user",
+          scmUserId: "1001",
+          scmLogin: "ada",
+          scmName: "Ada Lovelace",
+          scmEmail: "ada@example.com",
+          scmAvatarUrl: "https://avatars.githubusercontent.com/u/1001",
+        })
+      ).toEqual({
+        provider: "github",
+        providerUserId: "1001",
+        providerLogin: "ada",
+        providerEmail: "ada@example.com",
+        displayName: "Ada Lovelace",
+        avatarUrl: "https://avatars.githubusercontent.com/u/1001",
+      });
+    });
+
+    it("prefers auth* over scm* when the GitHub web path sends both (providerLogin stays scm-sourced)", () => {
+      expect(
+        resolveProviderIdentity("user", {
+          spawnSource: "user",
+          authProvider: "github",
+          authUserId: "1001",
+          authEmail: "ada@auth.example.com",
+          authName: "Ada (auth)",
+          authAvatarUrl: "https://auth.example/pic",
+          scmUserId: "1001",
+          scmLogin: "ada",
+          scmName: "Ada (scm)",
+          scmEmail: "ada@scm.example.com",
+          scmAvatarUrl: "https://scm.example/pic",
+        })
+      ).toEqual({
+        provider: "github",
+        providerUserId: "1001",
+        providerLogin: "ada",
+        providerEmail: "ada@auth.example.com",
+        displayName: "Ada (auth)",
+        avatarUrl: "https://auth.example/pic",
+      });
+    });
+
+    it("returns null for a Google web user missing authUserId (and no scm fallback)", () => {
+      expect(
+        resolveProviderIdentity("user", { spawnSource: "user", authProvider: "google" })
+      ).toBeNull();
+    });
+  });
+});
+
+describe("resolveGitHubEnrichment", () => {
+  // This is the fire-time F1/F2 gate: a resolved user with no linked GitHub
+  // identity must yield null so no SCM token is attached (bot-attributed
+  // fallback). With no TOKEN_ENCRYPTION_KEY the token-store branch is skipped,
+  // so these unit tests need no D1 — they pin the identity-selection boundary.
+  const env = { DB: {}, TOKEN_ENCRYPTION_KEY: "" } as unknown as Env;
+
+  function fakeStore(
+    identities: Array<{
+      provider: string;
+      providerUserId: string;
+      providerEmail?: string | null;
+      providerLogin?: string | null;
+    }>,
+    user?: { id: string; displayName?: string | null; email?: string | null }
+  ): UserStore {
+    return {
+      getIdentitiesForUser: async () => identities,
+      getUserById: async () => user ?? null,
+    } as unknown as UserStore;
+  }
+
+  it("returns null for a pure-Google user — no linked GitHub identity means no SCM token", async () => {
+    const store = fakeStore([
+      { provider: "google", providerUserId: "google-sub-1", providerEmail: "pm@gmail.com" },
+    ]);
+
+    await expect(resolveGitHubEnrichment(env, store, "user-1")).resolves.toBeNull();
+  });
+
+  it("enriches from the linked GitHub identity, never the Google one", async () => {
+    const store = fakeStore(
+      [
+        { provider: "google", providerUserId: "google-sub-1", providerEmail: "pm@gmail.com" },
+        {
+          provider: "github",
+          providerUserId: "gh-42",
+          providerLogin: "pm-dev",
+          providerEmail: "pm@users.noreply.github.com",
+        },
+      ],
+      { id: "user-1", displayName: "PM Person", email: "pm@gmail.com" }
+    );
+
+    const enrichment = await resolveGitHubEnrichment(env, store, "user-1");
+
+    expect(enrichment).not.toBeNull();
+    // The SCM identifier is the GitHub provider id — never the Google sub.
+    expect(enrichment!.scmUserId).toBe("gh-42");
+    expect(enrichment!.scmLogin).toBe("pm-dev");
+    // No token-encryption key configured → no token material leaks in.
+    expect(enrichment!.accessTokenEncrypted).toBeUndefined();
   });
 });

--- a/packages/control-plane/src/session/identity.ts
+++ b/packages/control-plane/src/session/identity.ts
@@ -61,18 +61,31 @@ export function resolveProviderIdentity(
 ): ProviderIdentity | null {
   switch (spawnSource) {
     case "user": {
-      // Web users (GitHub or Google). Identity comes from the auth* block,
-      // falling back to scm* for back-compat with old-web payloads that predate
-      // auth*. Returns null only when neither identifier is present.
-      const providerUserId = body.authUserId ?? body.scmUserId;
-      if (!providerUserId) return null;
+      // Web users (GitHub or Google). Identity comes from the auth* block; we
+      // fall back to scm* only for old-web payloads that predate auth* (always
+      // GitHub). provider and providerUserId are taken from the SAME source so a
+      // malformed payload can't pair a Google id with provider "github", and the
+      // discriminator is allowlisted (fail closed) rather than persisted raw —
+      // mirroring the /provider-identities/:provider route guard.
+      if (body.authUserId) {
+        if (body.authProvider !== "github" && body.authProvider !== "google") return null;
+        return {
+          provider: body.authProvider,
+          providerUserId: body.authUserId,
+          providerLogin: body.scmLogin,
+          providerEmail: body.authEmail ?? body.scmEmail,
+          displayName: body.authName ?? (body.scmName || body.scmLogin),
+          avatarUrl: body.authAvatarUrl ?? body.scmAvatarUrl,
+        };
+      }
+      if (!body.scmUserId) return null;
       return {
-        provider: body.authProvider ?? "github",
-        providerUserId,
+        provider: "github",
+        providerUserId: body.scmUserId,
         providerLogin: body.scmLogin,
-        providerEmail: body.authEmail ?? body.scmEmail,
-        displayName: body.authName ?? (body.scmName || body.scmLogin),
-        avatarUrl: body.authAvatarUrl ?? body.scmAvatarUrl,
+        providerEmail: body.scmEmail,
+        displayName: body.scmName || body.scmLogin,
+        avatarUrl: body.scmAvatarUrl,
       };
     }
 

--- a/packages/control-plane/src/session/identity.ts
+++ b/packages/control-plane/src/session/identity.ts
@@ -16,11 +16,25 @@ export interface GitHubEnrichment {
 export interface SessionIdentityFields {
   userId?: string;
   spawnSource?: SpawnSource;
+
+  // Provider-agnostic authentication identity — "who logged in". The web client
+  // populates this for every auth provider (GitHub or Google); it resolves the
+  // canonical D1 user. Kept separate from scm* (GitHub-only SCM credentials and
+  // git-commit attribution) so a pure-Google session carries auth* and no scm*.
+  authProvider?: "github" | "google";
+  authUserId?: string;
+  authEmail?: string;
+  authName?: string;
+  authAvatarUrl?: string;
+
+  // GitHub SCM credentials + git-commit attribution (GitHub-only, optional).
   scmUserId?: string;
   scmLogin?: string;
   scmName?: string;
   scmEmail?: string;
   scmAvatarUrl?: string;
+
+  // Slack / Linear bot actor identity.
   actorUserId?: string;
   actorDisplayName?: string;
   actorEmail?: string;
@@ -29,20 +43,39 @@ export interface SessionIdentityFields {
 
 /**
  * Derives a ProviderIdentity from spawnSource and the request body.
- * For GitHub-based callers (web + github-bot), reuses existing scm* fields.
- * For Slack/Linear bots, uses the actor* fields.
  *
- * Returns null when the caller hasn't supplied the required provider-specific
- * ID (scmUserId for GitHub, actorUserId for Slack/Linear). This is expected
- * during the phased rollout: Phase 2 wires this plumbing, Phase 4 updates
- * each bot to send identity fields. Until then, bot sessions get user_id = NULL.
+ * - Web users (spawnSource "user"): the provider-agnostic auth* block identifies
+ *   who logged in (GitHub or Google). Falls back to scm* so that in-flight
+ *   old-web payloads — which send only scm* and no auth* during the rollout
+ *   window — still resolve to a user_id.
+ * - github-bot: GitHub identity from scm* fields.
+ * - Slack / Linear bots: actor* fields.
+ *
+ * Returns null when the caller hasn't supplied the required provider-specific ID
+ * (authUserId/scmUserId for web users, scmUserId for github-bot, actorUserId for
+ * Slack/Linear). Such sessions get user_id = NULL.
  */
 export function resolveProviderIdentity(
   spawnSource: SpawnSource,
   body: SessionIdentityFields
 ): ProviderIdentity | null {
   switch (spawnSource) {
-    case "user":
+    case "user": {
+      // Web users (GitHub or Google). Identity comes from the auth* block,
+      // falling back to scm* for back-compat with old-web payloads that predate
+      // auth*. Returns null only when neither identifier is present.
+      const providerUserId = body.authUserId ?? body.scmUserId;
+      if (!providerUserId) return null;
+      return {
+        provider: body.authProvider ?? "github",
+        providerUserId,
+        providerLogin: body.scmLogin,
+        providerEmail: body.authEmail ?? body.scmEmail,
+        displayName: body.authName ?? (body.scmName || body.scmLogin),
+        avatarUrl: body.authAvatarUrl ?? body.scmAvatarUrl,
+      };
+    }
+
     case "github-bot":
       return body.scmUserId
         ? {

--- a/packages/control-plane/test/integration/user-store.test.ts
+++ b/packages/control-plane/test/integration/user-store.test.ts
@@ -96,6 +96,37 @@ describe("UserStore", () => {
       expect(identities.map((i) => i.provider).sort()).toEqual(["github", "slack"]);
     });
 
+    it("links a Google identity to an existing GitHub user by matching verified email (F1/F2 link surface)", async () => {
+      const github = await store.resolveOrCreateUser({
+        provider: "github",
+        providerUserId: "gh-900",
+        displayName: "Cole",
+        providerEmail: "cole@example.com",
+      });
+
+      const google = await store.resolveOrCreateUser({
+        provider: "google",
+        providerUserId: "google-sub-900",
+        displayName: "Cole (Google)",
+        providerEmail: "cole@example.com",
+      });
+
+      expect(google.id).toBe(github.id);
+      expect(google.isNew).toBe(false);
+
+      const identities = await store.getIdentitiesForUser(github.id);
+      expect(identities).toHaveLength(2);
+      expect(identities.map((i) => i.provider).sort()).toEqual(["github", "google"]);
+
+      // The Google login must not overwrite or masquerade as the GitHub identity:
+      // each provider keeps its own provider_user_id (a Google sub never lands
+      // under provider='github').
+      const githubIdentity = identities.find((i) => i.provider === "github");
+      const googleIdentity = identities.find((i) => i.provider === "google");
+      expect(githubIdentity!.providerUserId).toBe("gh-900");
+      expect(googleIdentity!.providerUserId).toBe("google-sub-900");
+    });
+
     it("backfills email on existing user when email becomes available", async () => {
       // Create user without email (e.g. Slack bot before users:read.email scope)
       const first = await store.resolveOrCreateUser({

--- a/packages/web/.env.example
+++ b/packages/web/.env.example
@@ -2,6 +2,18 @@
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 
+# Google OAuth (optional — enables "Sign in with Google").
+# Create an OAuth 2.0 Web Client at https://console.cloud.google.com/apis/credentials
+# Authorized redirect URI: http://localhost:3000/api/auth/callback/google
+# Set both to enable Google login; leave both empty for GitHub-only.
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+# Build-time flag that reveals the "Sign in with Google" button. Set to "true"
+# when Google is configured. NEXT_PUBLIC_* vars are inlined at build time —
+# restart `npm run dev` after changing. (For local dev only: deployed
+# environments derive this automatically from local.google_enabled in Terraform.)
+NEXT_PUBLIC_GOOGLE_ENABLED=
+
 # NextAuth (generate with: openssl rand -base64 32)
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=
@@ -14,6 +26,11 @@ NEXT_PUBLIC_WS_URL=wss://open-inspect-control-plane.YOUR-ACCOUNT.workers.dev
 # Generate with: openssl rand -base64 32
 INTERNAL_CALLBACK_SECRET=
 
-# Access Control (comma-separated, leave empty to allow all GitHub users)
+# Access Control (comma-separated, leave empty to allow all users).
+# A user is admitted if they match ANY allowlist below.
 ALLOWED_EMAIL_DOMAINS=
 ALLOWED_USERS=
+# Exact email addresses (matched against any provider's verified email) — for
+# individual users on shared domains like gmail.com where a domain allowlist
+# would be too broad.
+ALLOWED_EMAILS=

--- a/packages/web/src/app/api/automations/route.test.ts
+++ b/packages/web/src/app/api/automations/route.test.ts
@@ -1,0 +1,145 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("next-auth/jwt", () => ({
+  getToken: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  authOptions: {},
+}));
+
+vi.mock("@/lib/control-plane", () => ({
+  controlPlaneFetch: vi.fn(),
+}));
+
+// NOTE: @/lib/build-auth-identity is intentionally NOT mocked — these tests
+// exercise the real chokepoint to prove the route's outgoing body is correct.
+import { getServerSession } from "next-auth";
+import { getToken } from "next-auth/jwt";
+import { controlPlaneFetch } from "@/lib/control-plane";
+import { POST } from "./route";
+
+function postRequest(body: unknown) {
+  return {
+    json: async () => body,
+  } as unknown as NextRequest;
+}
+
+function controlPlaneBody(callIndex = 0): Record<string, unknown> {
+  const options = vi.mocked(controlPlaneFetch).mock.calls[callIndex]?.[1];
+  return JSON.parse(String(options?.body)) as Record<string, unknown>;
+}
+
+const validBody = {
+  name: "Daily sync",
+  repoOwner: "o",
+  repoName: "r",
+  scheduleCron: "0 9 * * *",
+  scheduleTz: "UTC",
+  instructions: "Run tests",
+};
+
+describe("automations API route (POST)", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns 401 when the user session is missing", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+
+    const response = await POST(postRequest(validBody));
+
+    expect(response.status).toBe(401);
+    expect(controlPlaneFetch).not.toHaveBeenCalled();
+  });
+
+  it("sends auth* and scm* for a GitHub user", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: {
+        id: "12345",
+        login: "ada",
+        name: "Ada Lovelace",
+        email: "ada@example.com",
+        image: "https://avatars.githubusercontent.com/u/12345",
+        provider: "github",
+      },
+    } as never);
+    vi.mocked(getToken).mockResolvedValue({
+      accessToken: "gho_abc",
+      refreshToken: "ghr_def",
+      accessTokenExpiresAt: 1_700_000_000_000,
+    } as never);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(
+      Response.json({ automation: { id: "auto1" } }, { status: 201 })
+    );
+
+    const response = await POST(postRequest(validBody));
+
+    expect(response.status).toBe(201);
+    expect(controlPlaneFetch).toHaveBeenCalledWith(
+      "/automations",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(controlPlaneBody()).toMatchObject({
+      name: "Daily sync",
+      repoOwner: "o",
+      repoName: "r",
+      userId: "12345",
+      authProvider: "github",
+      authUserId: "12345",
+      authEmail: "ada@example.com",
+      authName: "Ada Lovelace",
+      authAvatarUrl: "https://avatars.githubusercontent.com/u/12345",
+      scmUserId: "12345",
+      scmLogin: "ada",
+      scmName: "Ada Lovelace",
+      scmEmail: "ada@example.com",
+      scmAvatarUrl: "https://avatars.githubusercontent.com/u/12345",
+      scmToken: "gho_abc",
+      scmRefreshToken: "ghr_def",
+      scmTokenExpiresAt: 1_700_000_000_000,
+    });
+  });
+
+  it("sends auth* but no scm* for a Google user (F1/F2: a Google sub must never become a GitHub identity)", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: {
+        id: "google-sub-1",
+        name: "Pat PM",
+        email: "pm@gmail.com",
+        image: "https://lh3.googleusercontent.com/a/pat",
+        provider: "google",
+      },
+    } as never);
+    // A token on the JWT must not bleed into scm* for a Google session.
+    vi.mocked(getToken).mockResolvedValue({ accessToken: "ya29.google" } as never);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(
+      Response.json({ automation: { id: "auto2" } }, { status: 201 })
+    );
+
+    const response = await POST(postRequest(validBody));
+
+    expect(response.status).toBe(201);
+    const sent = controlPlaneBody();
+    expect(sent).toMatchObject({
+      authProvider: "google",
+      authUserId: "google-sub-1",
+      authEmail: "pm@gmail.com",
+      userId: "google-sub-1",
+    });
+    // Regression guard: the bug sent scmUserId = user.id = the Google sub, which
+    // the control plane then stored under provider='github'. After the fix there
+    // is no scm* block at all for a Google user.
+    expect(sent.scmUserId).toBeUndefined();
+    expect(sent.scmToken).toBeUndefined();
+    expect(sent.scmLogin).toBeUndefined();
+    expect(sent.scmName).toBeUndefined();
+    expect(sent.scmEmail).toBeUndefined();
+    expect(sent.scmAvatarUrl).toBeUndefined();
+  });
+});

--- a/packages/web/src/app/api/automations/route.ts
+++ b/packages/web/src/app/api/automations/route.ts
@@ -1,7 +1,9 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
+import { getToken } from "next-auth/jwt";
 import { authOptions } from "@/lib/auth";
+import { buildAuthIdentity, buildScmCredentials } from "@/lib/build-auth-identity";
 import { controlPlaneFetch } from "@/lib/control-plane";
 import { buildControlPlanePath } from "@/lib/control-plane-query";
 
@@ -31,6 +33,14 @@ export async function POST(request: NextRequest) {
 
   try {
     const body = await request.json();
+
+    const jwt = await getToken({ req: request });
+
+    // Derive identity from the server-side NextAuth session, routed through the
+    // shared chokepoint (same as the sessions/ws-token routes): provider-agnostic
+    // auth* resolves the canonical user for BOTH GitHub and Google, while the
+    // GitHub-only scm* block is empty for Google — so a Google sub never reaches
+    // the SCM path (F1/F2).
     const user = session.user;
     const userId = user.id || user.email || "anonymous";
 
@@ -39,11 +49,8 @@ export async function POST(request: NextRequest) {
       body: JSON.stringify({
         ...body,
         userId,
-        scmUserId: user.id,
-        scmLogin: user.login,
-        scmName: user.name,
-        scmEmail: user.email,
-        scmAvatarUrl: user.image,
+        ...buildAuthIdentity(user),
+        ...buildScmCredentials(user, jwt),
       }),
     });
     const data = await response.json();

--- a/packages/web/src/app/api/sessions/[id]/ws-token/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/ws-token/route.test.ts
@@ -1,0 +1,113 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("next-auth/jwt", () => ({
+  getToken: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  authOptions: {},
+}));
+
+vi.mock("@/lib/control-plane", () => ({
+  controlPlaneFetch: vi.fn(),
+}));
+
+import { getServerSession } from "next-auth";
+import { getToken } from "next-auth/jwt";
+import { controlPlaneFetch } from "@/lib/control-plane";
+import { POST } from "./route";
+
+function request() {
+  return {} as NextRequest;
+}
+
+function params(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function sentBody(): Record<string, unknown> {
+  const options = vi.mocked(controlPlaneFetch).mock.calls[0]?.[1];
+  return JSON.parse(String(options?.body)) as Record<string, unknown>;
+}
+
+describe("ws-token API route", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns 401 when the session is missing", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+
+    const response = await POST(request(), params("sess1"));
+
+    expect(response.status).toBe(401);
+    expect(controlPlaneFetch).not.toHaveBeenCalled();
+  });
+
+  it("sends scm* credentials for a GitHub user", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: {
+        id: "12345",
+        login: "ada",
+        name: "Ada Lovelace",
+        email: "ada@example.com",
+        image: "https://avatars.githubusercontent.com/u/12345",
+        provider: "github",
+      },
+    } as never);
+    vi.mocked(getToken).mockResolvedValue({
+      accessToken: "gho_abc",
+      refreshToken: "ghr_def",
+      accessTokenExpiresAt: 1_700_000_000_000,
+    } as never);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(
+      Response.json({ token: "ws-tok" }, { status: 200 })
+    );
+
+    const response = await POST(request(), params("sess1"));
+
+    expect(response.status).toBe(200);
+    expect(controlPlaneFetch).toHaveBeenCalledWith(
+      "/sessions/sess1/ws-token",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(sentBody()).toEqual({
+      userId: "12345",
+      scmUserId: "12345",
+      scmLogin: "ada",
+      scmName: "Ada Lovelace",
+      scmEmail: "ada@example.com",
+      scmAvatarUrl: "https://avatars.githubusercontent.com/u/12345",
+      scmToken: "gho_abc",
+      scmRefreshToken: "ghr_def",
+      scmTokenExpiresAt: 1_700_000_000_000,
+    });
+  });
+
+  it("omits scm* entirely for a Google user — identity survives via userId, no token leak", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: {
+        id: "google-sub-1",
+        name: "Pat PM",
+        email: "pm@gmail.com",
+        image: "https://lh3.googleusercontent.com/a/pat",
+        provider: "google",
+      },
+    } as never);
+    // Even if the JWT carried a token, a Google session must send no scm*.
+    vi.mocked(getToken).mockResolvedValue({ accessToken: "ya29.google" } as never);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(
+      Response.json({ token: "ws-tok" }, { status: 200 })
+    );
+
+    const response = await POST(request(), params("sess2"));
+
+    expect(response.status).toBe(200);
+    expect(sentBody()).toEqual({ userId: "google-sub-1" });
+  });
+});

--- a/packages/web/src/app/api/sessions/[id]/ws-token/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/ws-token/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { getToken } from "next-auth/jwt";
 import { authOptions } from "@/lib/auth";
+import { buildScmCredentials } from "@/lib/build-auth-identity";
 import { controlPlaneFetch } from "@/lib/control-plane";
 
 /**
@@ -40,13 +41,9 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       method: "POST",
       body: JSON.stringify({
         userId,
-        scmUserId: user.id,
-        scmLogin: user.login,
-        scmName: user.name,
-        scmEmail: user.email,
-        scmToken: jwt?.accessToken as string | undefined,
-        scmTokenExpiresAt: jwt?.accessTokenExpiresAt as number | undefined,
-        scmRefreshToken: jwt?.refreshToken as string | undefined,
+        // GitHub-only SCM credentials + attribution; empty for Google, which
+        // keeps participant identity via userId and writes no SCM token.
+        ...buildScmCredentials(user, jwt),
       }),
     });
     const fetchMs = Date.now() - fetchStart;

--- a/packages/web/src/app/api/sessions/route.test.ts
+++ b/packages/web/src/app/api/sessions/route.test.ts
@@ -18,14 +18,26 @@ vi.mock("@/lib/control-plane", () => ({
 }));
 
 import { getServerSession } from "next-auth";
+import { getToken } from "next-auth/jwt";
 import { controlPlaneFetch } from "@/lib/control-plane";
 import { clearCurrentUserIdCacheForTests } from "@/lib/current-user";
-import { GET } from "./route";
+import { GET, POST } from "./route";
 
 function request(path: string) {
   return {
     nextUrl: new URL(`http://localhost${path}`),
   } as NextRequest;
+}
+
+function postRequest(body: unknown) {
+  return {
+    json: async () => body,
+  } as unknown as NextRequest;
+}
+
+function controlPlaneBody(callIndex = 0): Record<string, unknown> {
+  const options = vi.mocked(controlPlaneFetch).mock.calls[callIndex]?.[1];
+  return JSON.parse(String(options?.body)) as Record<string, unknown>;
 }
 
 describe("sessions API route", () => {
@@ -97,14 +109,50 @@ describe("sessions API route", () => {
     expect(response.status).toBe(200);
   });
 
-  it("returns 409 when createdBy=me cannot resolve a GitHub user ID", async () => {
+  it("returns 409 when createdBy=me cannot resolve a user id", async () => {
     vi.mocked(getServerSession).mockResolvedValue({ user: { email: "ada@example.com" } } as never);
 
     const response = await GET(request("/api/sessions?createdBy=me"));
 
     expect(response.status).toBe(409);
-    await expect(response.json()).resolves.toEqual({ error: "GitHub user ID is unavailable" });
+    await expect(response.json()).resolves.toEqual({ error: "User id unavailable" });
     expect(controlPlaneFetch).not.toHaveBeenCalled();
+  });
+
+  it("resolves createdBy=me for a Google user via the google provider route", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: {
+        id: "google-sub-1",
+        name: "Pat PM",
+        email: "pm@gmail.com",
+        image: "https://lh3.googleusercontent.com/a/pat",
+        provider: "google",
+      },
+    } as never);
+    vi.mocked(controlPlaneFetch)
+      .mockResolvedValueOnce(Response.json({ userId: "0123456789abcdef0123456789abcdef" }))
+      .mockResolvedValueOnce(Response.json({ sessions: [], hasMore: false }, { status: 200 }));
+
+    const response = await GET(request("/api/sessions?limit=50&createdBy=me"));
+
+    expect(controlPlaneFetch).toHaveBeenNthCalledWith(
+      1,
+      "/provider-identities/google/google-sub-1",
+      {
+        method: "PUT",
+        body: JSON.stringify({
+          providerLogin: undefined,
+          providerEmail: "pm@gmail.com",
+          displayName: "Pat PM",
+          avatarUrl: "https://lh3.googleusercontent.com/a/pat",
+        }),
+      }
+    );
+    expect(controlPlaneFetch).toHaveBeenNthCalledWith(
+      2,
+      "/sessions?limit=50&createdBy=0123456789abcdef0123456789abcdef"
+    );
+    expect(response.status).toBe(200);
   });
 
   it("resolves createdBy=me alongside explicit creator filters", async () => {
@@ -177,5 +225,97 @@ describe("sessions API route", () => {
       3,
       "/sessions?limit=50&offset=50&excludeStatus=archived&createdBy=0123456789abcdef0123456789abcdef"
     );
+  });
+});
+
+describe("sessions API route (POST)", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns 401 when the user session is missing", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+
+    const response = await POST(postRequest({ repoOwner: "o", repoName: "r" }));
+
+    expect(response.status).toBe(401);
+    expect(controlPlaneFetch).not.toHaveBeenCalled();
+  });
+
+  it("sends auth* and scm* for a GitHub session", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: {
+        id: "12345",
+        login: "ada",
+        name: "Ada Lovelace",
+        email: "ada@example.com",
+        image: "https://avatars.githubusercontent.com/u/12345",
+        provider: "github",
+      },
+    } as never);
+    vi.mocked(getToken).mockResolvedValue({
+      accessToken: "gho_abc",
+      refreshToken: "ghr_def",
+      accessTokenExpiresAt: 1_700_000_000_000,
+    } as never);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(Response.json({ id: "sess1" }, { status: 201 }));
+
+    const response = await POST(postRequest({ repoOwner: "o", repoName: "r", model: "m" }));
+
+    expect(response.status).toBe(201);
+    expect(controlPlaneFetch).toHaveBeenCalledWith(
+      "/sessions",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(controlPlaneBody()).toMatchObject({
+      repoOwner: "o",
+      repoName: "r",
+      model: "m",
+      spawnSource: "user",
+      userId: "12345",
+      authProvider: "github",
+      authUserId: "12345",
+      authEmail: "ada@example.com",
+      authName: "Ada Lovelace",
+      authAvatarUrl: "https://avatars.githubusercontent.com/u/12345",
+      scmUserId: "12345",
+      scmLogin: "ada",
+      scmName: "Ada Lovelace",
+      scmEmail: "ada@example.com",
+      scmAvatarUrl: "https://avatars.githubusercontent.com/u/12345",
+      scmToken: "gho_abc",
+      scmRefreshToken: "ghr_def",
+      scmTokenExpiresAt: 1_700_000_000_000,
+    });
+  });
+
+  it("sends auth* but no scm* for a Google session (no token leak)", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: {
+        id: "google-sub-1",
+        name: "Pat PM",
+        email: "pm@gmail.com",
+        image: "https://lh3.googleusercontent.com/a/pat",
+        provider: "google",
+      },
+    } as never);
+    // A token on the JWT must not bleed into scm* for a Google session.
+    vi.mocked(getToken).mockResolvedValue({ accessToken: "ya29.google" } as never);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(Response.json({ id: "sess2" }, { status: 201 }));
+
+    const response = await POST(postRequest({ repoOwner: "o", repoName: "r", model: "m" }));
+
+    expect(response.status).toBe(201);
+    const sent = controlPlaneBody();
+    expect(sent).toMatchObject({
+      authProvider: "google",
+      authUserId: "google-sub-1",
+      authEmail: "pm@gmail.com",
+      userId: "google-sub-1",
+    });
+    expect(sent.scmUserId).toBeUndefined();
+    expect(sent.scmToken).toBeUndefined();
+    expect(sent.scmLogin).toBeUndefined();
+    expect(sent.scmEmail).toBeUndefined();
   });
 });

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { getToken } from "next-auth/jwt";
 import { authOptions } from "@/lib/auth";
+import { buildAuthIdentity, buildScmCredentials } from "@/lib/build-auth-identity";
 import { controlPlaneFetch } from "@/lib/control-plane";
 import {
   buildControlPlanePath,
@@ -73,7 +74,6 @@ export async function POST(request: NextRequest) {
     const body = await request.json();
 
     const jwt = await getToken({ req: request });
-    const accessToken = jwt?.accessToken as string | undefined;
 
     // Explicitly pick allowed fields from client body and derive identity
     // from the server-side NextAuth session (not client-supplied data)
@@ -88,15 +88,12 @@ export async function POST(request: NextRequest) {
       branch: body.branch,
       title: body.title,
       spawnSource: "user" as const,
-      scmToken: accessToken,
-      scmRefreshToken: jwt?.refreshToken as string | undefined,
-      scmTokenExpiresAt: jwt?.accessTokenExpiresAt as number | undefined,
-      scmUserId: user.id,
       userId,
-      scmLogin: user.login,
-      scmName: user.name,
-      scmEmail: user.email,
-      scmAvatarUrl: user.image,
+      // Provider-agnostic auth identity (GitHub or Google) resolves the
+      // canonical user; GitHub-only scm* carries SCM credentials + attribution
+      // and is empty for Google.
+      ...buildAuthIdentity(user),
+      ...buildScmCredentials(user, jwt),
     };
 
     const response = await controlPlaneFetch("/sessions", {

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -11,8 +11,8 @@ import { useIsMobile } from "@/hooks/use-media-query";
 import { useGlobalShortcuts } from "@/hooks/use-global-shortcuts";
 import { SIDEBAR_SESSIONS_KEY, type SessionListResponse } from "@/lib/session-list";
 import { Button } from "@/components/ui/button";
-import { GitHubIcon } from "@/components/ui/icons";
-import { APP_NAME } from "@/lib/site-config";
+import { GitHubIcon, GoogleIcon } from "@/components/ui/icons";
+import { APP_NAME, GOOGLE_LOGIN_ENABLED } from "@/lib/site-config";
 
 interface SidebarContextValue {
   isOpen: boolean;
@@ -94,10 +94,18 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
         <p className="text-muted-foreground max-w-md text-center">
           Background coding agent for your team. Ship faster with AI-powered code changes.
         </p>
-        <Button onClick={() => signIn("github")} className="gap-2 px-6 py-3">
-          <GitHubIcon className="w-5 h-5" />
-          Sign in with GitHub
-        </Button>
+        <div className="flex flex-col items-stretch gap-3">
+          <Button onClick={() => signIn("github")} className="gap-2 px-6 py-3">
+            <GitHubIcon className="w-5 h-5" />
+            Sign in with GitHub
+          </Button>
+          {GOOGLE_LOGIN_ENABLED && (
+            <Button onClick={() => signIn("google")} variant="outline" className="gap-2 px-6 py-3">
+              <GoogleIcon className="w-5 h-5" />
+              Sign in with Google
+            </Button>
+          )}
+        </div>
       </div>
     );
   }

--- a/packages/web/src/components/ui/icons.tsx
+++ b/packages/web/src/components/ui/icons.tsx
@@ -268,6 +268,28 @@ export function GitHubIcon({ className }: IconProps) {
   );
 }
 
+// Official Google "G" brand mark — intentionally multicolor (does not inherit
+// theme color), per Google's sign-in branding guidelines.
+export function GoogleIcon({ className }: IconProps) {
+  return (
+    <svg className={className} data-testid="google-icon" viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        fill="#4285F4"
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+      />
+      <path
+        fill="#34A853"
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84A11 11 0 0012 23z"
+      />
+      <path fill="#FBBC05" d="M5.84 14.1a6.6 6.6 0 010-4.2V7.06H2.18a11 11 0 000 9.88l3.66-2.84z" />
+      <path
+        fill="#EA4335"
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1A11 11 0 002.18 7.06l3.66 2.84C6.71 7.31 9.14 5.38 12 5.38z"
+      />
+    </svg>
+  );
+}
+
 export function GitPrIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/packages/web/src/lib/access-control.test.ts
+++ b/packages/web/src/lib/access-control.test.ts
@@ -47,9 +47,14 @@ describe("parseBooleanEnv", () => {
 });
 
 describe("checkAccessAllowed", () => {
-  describe("when both allowlists are empty", () => {
+  describe("when all allowlists are empty", () => {
     it("denies all users by default", () => {
-      const config = { allowedDomains: [], allowedUsers: [], unsafeAllowAllUsers: false };
+      const config = {
+        allowedDomains: [],
+        allowedUsers: [],
+        allowedEmails: [],
+        unsafeAllowAllUsers: false,
+      };
 
       expect(checkAccessAllowed(config, {})).toBe(false);
       expect(checkAccessAllowed(config, { githubUsername: "anyuser" })).toBe(false);
@@ -57,11 +62,31 @@ describe("checkAccessAllowed", () => {
     });
 
     it("allows all users when unsafeAllowAllUsers is enabled", () => {
-      const config = { allowedDomains: [], allowedUsers: [], unsafeAllowAllUsers: true };
+      const config = {
+        allowedDomains: [],
+        allowedUsers: [],
+        allowedEmails: [],
+        unsafeAllowAllUsers: true,
+      };
 
       expect(checkAccessAllowed(config, {})).toBe(true);
       expect(checkAccessAllowed(config, { githubUsername: "anyuser" })).toBe(true);
       expect(checkAccessAllowed(config, { email: "anyone@example.com" })).toBe(true);
+    });
+
+    it("a populated allowedEmails disables the unsafe allow-all gate", () => {
+      const config = {
+        allowedDomains: [],
+        allowedUsers: [],
+        allowedEmails: ["listed@gmail.com"],
+        unsafeAllowAllUsers: true,
+      };
+
+      // The gate only fires when ALL three lists are empty; once allowedEmails is
+      // set, enforcement applies even with unsafeAllowAllUsers on.
+      expect(checkAccessAllowed(config, { email: "listed@gmail.com" })).toBe(true);
+      expect(checkAccessAllowed(config, { email: "other@gmail.com" })).toBe(false);
+      expect(checkAccessAllowed(config, {})).toBe(false);
     });
   });
 
@@ -69,6 +94,7 @@ describe("checkAccessAllowed", () => {
     const config = {
       allowedDomains: [],
       allowedUsers: ["alloweduser"],
+      allowedEmails: [],
       unsafeAllowAllUsers: false,
     };
 
@@ -91,10 +117,40 @@ describe("checkAccessAllowed", () => {
     });
   });
 
+  describe("when allowedEmails is set", () => {
+    const config = {
+      allowedDomains: [],
+      allowedUsers: [],
+      allowedEmails: ["pm@gmail.com", "support@gmail.com"],
+      unsafeAllowAllUsers: false,
+    };
+
+    it("allows an exact listed email — even on a shared domain like gmail.com", () => {
+      expect(checkAccessAllowed(config, { email: "pm@gmail.com" })).toBe(true);
+      expect(checkAccessAllowed(config, { email: "support@gmail.com" })).toBe(true);
+    });
+
+    it("matches case-insensitively", () => {
+      expect(checkAccessAllowed(config, { email: "PM@Gmail.com" })).toBe(true);
+    });
+
+    it("does NOT admit other addresses on the same shared domain", () => {
+      // The whole point of the exact-email list: a gmail.com address is admitted
+      // without admitting every gmail.com account.
+      expect(checkAccessAllowed(config, { email: "stranger@gmail.com" })).toBe(false);
+    });
+
+    it("denies when no email provided", () => {
+      expect(checkAccessAllowed(config, {})).toBe(false);
+      expect(checkAccessAllowed(config, { githubUsername: "pm" })).toBe(false);
+    });
+  });
+
   describe("when allowedDomains is set", () => {
     const config = {
       allowedDomains: ["company.com"],
       allowedUsers: [],
+      allowedEmails: [],
       unsafeAllowAllUsers: false,
     };
 
@@ -116,10 +172,11 @@ describe("checkAccessAllowed", () => {
     });
   });
 
-  describe("when both allowedUsers and allowedDomains are set (OR logic)", () => {
+  describe("when allowedUsers, allowedEmails and allowedDomains are set (OR logic)", () => {
     const config = {
       allowedDomains: ["company.com"],
       allowedUsers: ["specialuser"],
+      allowedEmails: ["contractor@gmail.com"],
       unsafeAllowAllUsers: false,
     };
 
@@ -127,11 +184,15 @@ describe("checkAccessAllowed", () => {
       expect(checkAccessAllowed(config, { githubUsername: "specialuser" })).toBe(true);
     });
 
+    it("allows users matching exact email", () => {
+      expect(checkAccessAllowed(config, { email: "contractor@gmail.com" })).toBe(true);
+    });
+
     it("allows users matching email domain", () => {
       expect(checkAccessAllowed(config, { email: "someone@company.com" })).toBe(true);
     });
 
-    it("allows users matching either condition", () => {
+    it("allows users matching any condition", () => {
       expect(
         checkAccessAllowed(config, {
           githubUsername: "specialuser",
@@ -147,7 +208,7 @@ describe("checkAccessAllowed", () => {
       ).toBe(true);
     });
 
-    it("denies users matching neither condition", () => {
+    it("denies users matching no condition", () => {
       expect(
         checkAccessAllowed(config, {
           githubUsername: "randomuser",
@@ -161,6 +222,7 @@ describe("checkAccessAllowed", () => {
     const config = {
       allowedDomains: ["company.com"],
       allowedUsers: ["specialuser"],
+      allowedEmails: [],
       unsafeAllowAllUsers: true,
     };
 
@@ -179,6 +241,7 @@ describe("checkAccessAllowed", () => {
     const config = {
       allowedDomains: ["company.com", "partner.org"],
       allowedUsers: ["admin", "developer"],
+      allowedEmails: [],
       unsafeAllowAllUsers: false,
     };
 

--- a/packages/web/src/lib/access-control.ts
+++ b/packages/web/src/lib/access-control.ts
@@ -1,6 +1,7 @@
 export interface AccessControlConfig {
   allowedDomains: string[];
   allowedUsers: string[];
+  allowedEmails: string[];
   unsafeAllowAllUsers: boolean;
 }
 
@@ -28,26 +29,34 @@ export function parseBooleanEnv(value: string | undefined): boolean {
  * Check if a user is allowed to sign in based on access control configuration.
  *
  * Returns true if:
- * - Both allowlists are empty and unsafeAllowAllUsers is true
+ * - All allowlists are empty and unsafeAllowAllUsers is true
  * - User's GitHub username is in allowedUsers
+ * - User's exact email is in allowedEmails
  * - User's email domain is in allowedDomains
  *
- * Logic is OR-based: matching either list grants access.
+ * Logic is OR-based: matching any list grants access.
  */
 export function checkAccessAllowed(
   config: AccessControlConfig,
   params: AccessCheckParams
 ): boolean {
-  const { allowedDomains, allowedUsers, unsafeAllowAllUsers } = config;
+  const { allowedDomains, allowedUsers, allowedEmails, unsafeAllowAllUsers } = config;
   const { githubUsername, email } = params;
 
   // Empty allowlists only permit sign-in when explicitly enabled.
-  if (allowedDomains.length === 0 && allowedUsers.length === 0) {
+  if (allowedDomains.length === 0 && allowedUsers.length === 0 && allowedEmails.length === 0) {
     return unsafeAllowAllUsers;
   }
 
   // Check explicit user allowlist (GitHub username)
   if (githubUsername && allowedUsers.includes(githubUsername.toLowerCase())) {
+    return true;
+  }
+
+  // Check exact email allowlist. Provider-agnostic, and the only way to admit a
+  // specific address on a shared domain (e.g. one gmail.com user) without
+  // domain-allowing every gmail.com account.
+  if (email && allowedEmails.includes(email.toLowerCase())) {
     return true;
   }
 

--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -221,6 +221,37 @@ describe("applyJwtClaims", () => {
     expect(token.githubLogin).toBeUndefined();
   });
 
+  it("clears stale GitHub claims when a prior GitHub JWT is reused for a Google sign-in", () => {
+    const token = applyJwtClaims(
+      {
+        provider: "github",
+        providerUserId: "12345",
+        githubUserId: "12345",
+        githubLogin: "octocat",
+        accessToken: "gho_abc",
+        refreshToken: "ghr_def",
+        accessTokenExpiresAt: 1_700_000_000 * 1000,
+      } as JWT,
+      {
+        provider: "google",
+        type: "oauth",
+        providerAccountId: "google-sub-1",
+        access_token: "ya29.google-token",
+        refresh_token: "1//google-refresh",
+        expires_at: 1_700_000_000,
+      } as Account,
+      { sub: "google-sub-1", email: "pm@gmail.com", email_verified: true } as unknown as Profile
+    );
+
+    expect(token.provider).toBe("google");
+    expect(token.providerUserId).toBe("google-sub-1");
+    expect(token.accessToken).toBeUndefined();
+    expect(token.refreshToken).toBeUndefined();
+    expect(token.accessTokenExpiresAt).toBeUndefined();
+    expect(token.githubUserId).toBeUndefined();
+    expect(token.githubLogin).toBeUndefined();
+  });
+
   it("backfills provider/providerUserId for a legacy GitHub JWT with no account on the request", () => {
     const token = applyJwtClaims({ githubUserId: "999" } as JWT, null, undefined);
 

--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -1,5 +1,23 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getVerifiedPrimaryGitHubEmail } from "./auth";
+import type { Account, Profile, Session } from "next-auth";
+import type { JWT } from "next-auth/jwt";
+import type { AccessControlConfig } from "./access-control";
+import {
+  applyJwtClaims,
+  applySessionUser,
+  buildSignInDecision,
+  getVerifiedPrimaryGitHubEmail,
+} from "./auth";
+
+function cfg(overrides: Partial<AccessControlConfig> = {}): AccessControlConfig {
+  return {
+    allowedDomains: [],
+    allowedUsers: [],
+    allowedEmails: [],
+    unsafeAllowAllUsers: false,
+    ...overrides,
+  };
+}
 
 describe("getVerifiedPrimaryGitHubEmail", () => {
   afterEach(() => {
@@ -35,5 +53,223 @@ describe("getVerifiedPrimaryGitHubEmail", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 403 }));
 
     await expect(getVerifiedPrimaryGitHubEmail("token")).resolves.toBeNull();
+  });
+});
+
+describe("buildSignInDecision", () => {
+  describe("Google", () => {
+    const config = cfg({ allowedEmails: ["pm@gmail.com"] });
+
+    it("denies an unverified email (boolean false) before any allowlist match", () => {
+      expect(
+        buildSignInDecision({
+          provider: "google",
+          profile: { email_verified: false } as unknown as Profile,
+          email: "pm@gmail.com",
+          config,
+        })
+      ).toBe(false);
+    });
+
+    it('denies an unverified email when email_verified is the string "false"', () => {
+      expect(
+        buildSignInDecision({
+          provider: "google",
+          profile: { email_verified: "false" } as unknown as Profile,
+          email: "pm@gmail.com",
+          config,
+        })
+      ).toBe(false);
+    });
+
+    it("denies when email_verified is absent", () => {
+      expect(
+        buildSignInDecision({
+          provider: "google",
+          profile: {} as Profile,
+          email: "pm@gmail.com",
+          config,
+        })
+      ).toBe(false);
+    });
+
+    it("allows a verified (boolean true) allowlisted email", () => {
+      expect(
+        buildSignInDecision({
+          provider: "google",
+          profile: { email_verified: true } as unknown as Profile,
+          email: "pm@gmail.com",
+          config,
+        })
+      ).toBe(true);
+    });
+
+    it('allows a verified email when email_verified is the string "true"', () => {
+      expect(
+        buildSignInDecision({
+          provider: "google",
+          profile: { email_verified: "true" } as unknown as Profile,
+          email: "pm@gmail.com",
+          config,
+        })
+      ).toBe(true);
+    });
+
+    it('accepts a mixed-case "True" string (case-insensitive normalization)', () => {
+      expect(
+        buildSignInDecision({
+          provider: "google",
+          profile: { email_verified: "True" } as unknown as Profile,
+          email: "pm@gmail.com",
+          config,
+        })
+      ).toBe(true);
+    });
+
+    it("denies a verified email that is not on any allowlist", () => {
+      expect(
+        buildSignInDecision({
+          provider: "google",
+          profile: { email_verified: true } as unknown as Profile,
+          email: "stranger@gmail.com",
+          config,
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("GitHub", () => {
+    it("admits an allowlisted GitHub username without an email_verified check", () => {
+      expect(
+        buildSignInDecision({
+          provider: "github",
+          profile: { login: "octocat" } as unknown as Profile,
+          email: "octo@company.com",
+          config: cfg({ allowedUsers: ["octocat"] }),
+        })
+      ).toBe(true);
+    });
+
+    it("denies a non-allowlisted GitHub user", () => {
+      expect(
+        buildSignInDecision({
+          provider: "github",
+          profile: { login: "stranger" } as unknown as Profile,
+          email: "stranger@other.com",
+          config: cfg({ allowedDomains: ["company.com"], allowedUsers: ["octocat"] }),
+        })
+      ).toBe(false);
+    });
+
+    it("treats an undefined provider as the GitHub path", () => {
+      expect(
+        buildSignInDecision({
+          provider: undefined,
+          profile: { login: "octocat" } as unknown as Profile,
+          email: "octo@company.com",
+          config: cfg({ allowedUsers: ["octocat"] }),
+        })
+      ).toBe(true);
+    });
+  });
+});
+
+describe("applyJwtClaims", () => {
+  it("captures SCM credentials and identity for a GitHub sign-in", () => {
+    const token = applyJwtClaims(
+      {},
+      {
+        provider: "github",
+        type: "oauth",
+        providerAccountId: "12345",
+        access_token: "gho_abc",
+        refresh_token: "ghr_def",
+        expires_at: 1_700_000_000,
+      } as Account,
+      { id: 12345, login: "octocat" } as unknown as Profile
+    );
+
+    expect(token.provider).toBe("github");
+    expect(token.providerUserId).toBe("12345");
+    expect(token.githubUserId).toBe("12345");
+    expect(token.githubLogin).toBe("octocat");
+    expect(token.accessToken).toBe("gho_abc");
+    expect(token.refreshToken).toBe("ghr_def");
+    expect(token.accessTokenExpiresAt).toBe(1_700_000_000 * 1000);
+  });
+
+  it("does NOT capture an access token for a Google sign-in (F1 credential-leak gate)", () => {
+    const token = applyJwtClaims(
+      {},
+      {
+        provider: "google",
+        type: "oauth",
+        providerAccountId: "google-sub-1",
+        access_token: "ya29.google-token",
+        refresh_token: "1//google-refresh",
+        expires_at: 1_700_000_000,
+      } as Account,
+      { sub: "google-sub-1", email: "pm@gmail.com", email_verified: true } as unknown as Profile
+    );
+
+    expect(token.accessToken).toBeUndefined();
+    expect(token.refreshToken).toBeUndefined();
+    expect(token.accessTokenExpiresAt).toBeUndefined();
+    expect(token.provider).toBe("google");
+    expect(token.providerUserId).toBe("google-sub-1");
+    expect(token.githubUserId).toBeUndefined();
+    expect(token.githubLogin).toBeUndefined();
+  });
+
+  it("backfills provider/providerUserId for a legacy GitHub JWT with no account on the request", () => {
+    const token = applyJwtClaims({ githubUserId: "999" } as JWT, null, undefined);
+
+    expect(token.provider).toBe("github");
+    expect(token.providerUserId).toBe("999");
+    // No account on the request, so no fresh credentials are captured.
+    expect(token.accessToken).toBeUndefined();
+  });
+
+  it("leaves an anonymous token untouched", () => {
+    const token = applyJwtClaims({}, null, undefined);
+
+    expect(token.provider).toBeUndefined();
+    expect(token.providerUserId).toBeUndefined();
+  });
+});
+
+describe("applySessionUser", () => {
+  function emptySession(): Session {
+    return { user: {}, expires: "" };
+  }
+
+  it("maps a GitHub token onto the session user", () => {
+    const session = applySessionUser(emptySession(), {
+      provider: "github",
+      providerUserId: "12345",
+      githubUserId: "12345",
+      githubLogin: "octocat",
+    } as JWT);
+
+    expect(session.user.id).toBe("12345");
+    expect(session.user.provider).toBe("github");
+    expect(session.user.login).toBe("octocat");
+  });
+
+  it("maps a Google token onto the session user with no login", () => {
+    const session = applySessionUser(emptySession(), {
+      provider: "google",
+      providerUserId: "google-sub-1",
+    } as JWT);
+
+    expect(session.user.id).toBe("google-sub-1");
+    expect(session.user.provider).toBe("google");
+    expect(session.user.login).toBeUndefined();
+  });
+
+  it("falls back to githubUserId for a legacy token without providerUserId", () => {
+    const session = applySessionUser(emptySession(), { githubUserId: "999" } as JWT);
+
+    expect(session.user.id).toBe("999");
   });
 });

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -103,6 +103,12 @@ export function buildSignInDecision(args: {
  * the session-create and ws-token routes forward `token.accessToken` as
  * `scmToken`, after which the control plane would use a Google token against
  * GitHub's API and refresh it at GitHub's OAuth endpoint (credential leak).
+ *
+ * On a non-GitHub sign-in we also CLEAR any GitHub SCM/identity claims carried
+ * over from a prior GitHub session on the same JWT (NextAuth passes the previous
+ * token into this callback), so a Google token can never hold stale GitHub
+ * credentials. Cross-provider GitHub attribution for a linked user is resolved
+ * server-side from D1, not from these cookie claims.
  */
 export function applyJwtClaims(
   token: JWT,
@@ -121,6 +127,14 @@ export function applyJwtClaims(
       token.refreshToken = account.refresh_token as string | undefined;
       // expires_at is in seconds, convert to milliseconds (only set if provided)
       token.accessTokenExpiresAt = account.expires_at ? account.expires_at * 1000 : undefined;
+    } else {
+      // Non-GitHub sign-in: drop any GitHub SCM/identity claims left on a token
+      // reused from a prior GitHub session, so a Google JWT carries no SCM state.
+      token.accessToken = undefined;
+      token.refreshToken = undefined;
+      token.accessTokenExpiresAt = undefined;
+      token.githubUserId = undefined;
+      token.githubLogin = undefined;
     }
   }
 

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -1,7 +1,14 @@
-import type { NextAuthOptions, Profile } from "next-auth";
+import type { Account, NextAuthOptions, Profile, Session } from "next-auth";
+import type { JWT } from "next-auth/jwt";
 import GitHubProvider from "next-auth/providers/github";
 import type { GithubEmail, GithubProfile } from "next-auth/providers/github";
-import { checkAccessAllowed, parseAllowlist, parseBooleanEnv } from "./access-control";
+import GoogleProvider from "next-auth/providers/google";
+import {
+  type AccessControlConfig,
+  checkAccessAllowed,
+  parseAllowlist,
+  parseBooleanEnv,
+} from "./access-control";
 
 export async function getVerifiedPrimaryGitHubEmail(
   accessToken: string | undefined
@@ -21,12 +28,14 @@ export async function getVerifiedPrimaryGitHubEmail(
   return emails.find((email) => email.primary && email.verified)?.email ?? null;
 }
 
-// Extend NextAuth types to include GitHub-specific user info
+// Extend NextAuth types to include provider-agnostic identity plus the
+// GitHub-only SCM fields.
 declare module "next-auth" {
   interface Session {
     user: {
-      id?: string; // GitHub user ID
-      login?: string; // GitHub username
+      id?: string; // Canonical provider user id: GitHub numeric id or Google sub
+      login?: string; // GitHub username (GitHub-only)
+      provider?: "github" | "google"; // Which provider authenticated this session
       name?: string | null;
       email?: string | null;
       image?: string | null;
@@ -41,74 +50,184 @@ declare module "next-auth/jwt" {
     accessTokenExpiresAt?: number; // Unix timestamp in milliseconds
     githubUserId?: string;
     githubLogin?: string;
+    provider?: "github" | "google";
+    providerUserId?: string; // GitHub numeric id or Google sub
   }
+}
+
+/**
+ * Decide whether a sign-in attempt is allowed. Pure and exported so the policy
+ * is unit-testable — NextAuth's inline signIn callback otherwise can't be reached.
+ *
+ * - GitHub: the email was already resolved to the verified primary in the
+ *   provider's userinfo override, so only the allowlist gate applies.
+ * - Google: the email MUST be verified before any allowlist match. All
+ *   email-based admission (the email allowlist here, and cross-provider account
+ *   linking downstream) trusts this flag, so it is the single most
+ *   security-sensitive check in the sign-in path. `email_verified` is normalized
+ *   defensively — boolean `true` or a case-insensitive "true" string — because
+ *   Google has returned the string form in some flows. Anything else fails closed.
+ */
+export function buildSignInDecision(args: {
+  provider: string | undefined;
+  profile: Profile | undefined;
+  email: string | null | undefined;
+  config: AccessControlConfig;
+}): boolean {
+  const { provider, profile, email, config } = args;
+
+  if (provider === "google") {
+    const googleProfile = profile as { email_verified?: boolean | string } | undefined;
+    const emailVerified =
+      googleProfile?.email_verified === true ||
+      String(googleProfile?.email_verified).toLowerCase() === "true";
+    if (!emailVerified) {
+      return false;
+    }
+    return checkAccessAllowed(config, { email: email ?? undefined });
+  }
+
+  // GitHub (default).
+  const githubProfile = profile as { login?: string } | undefined;
+  return checkAccessAllowed(config, {
+    githubUsername: githubProfile?.login,
+    email: email ?? undefined,
+  });
+}
+
+/**
+ * Apply provider claims to the JWT. Pure and exported for testing.
+ *
+ * SCM credentials (accessToken/refreshToken/expiry) are captured ONLY for
+ * GitHub. A Google `access_token` must never populate `token.accessToken`: both
+ * the session-create and ws-token routes forward `token.accessToken` as
+ * `scmToken`, after which the control plane would use a Google token against
+ * GitHub's API and refresh it at GitHub's OAuth endpoint (credential leak).
+ */
+export function applyJwtClaims(
+  token: JWT,
+  account: Account | null | undefined,
+  profile: Profile | undefined
+): JWT {
+  if (account) {
+    // The cast is not validated: it relies on only "github" and "google" being
+    // registered providers below. A new provider must widen this union (and the
+    // SCM gate) rather than silently storing an untyped value.
+    token.provider = account.provider as "github" | "google";
+    token.providerUserId = account.providerAccountId;
+
+    if (account.provider === "github") {
+      token.accessToken = account.access_token;
+      token.refreshToken = account.refresh_token as string | undefined;
+      // expires_at is in seconds, convert to milliseconds (only set if provided)
+      token.accessTokenExpiresAt = account.expires_at ? account.expires_at * 1000 : undefined;
+    }
+  }
+
+  if (profile) {
+    // GitHub profile carries id (numeric) and login (username); Google profiles
+    // carry neither, so these stay unset for Google sessions.
+    const githubProfile = profile as { id?: number; login?: string };
+    if (githubProfile.id) {
+      token.githubUserId = githubProfile.id.toString();
+    }
+    if (githubProfile.login) {
+      token.githubLogin = githubProfile.login;
+    }
+  }
+
+  // Back-compat for the staggered deploy: GitHub JWTs minted before
+  // provider/providerUserId existed carry githubUserId but no provider. Backfill
+  // from githubUserId so session.user.id/provider stay correct without forcing a
+  // re-login. Never fires for Google (no githubUserId) or fresh logins
+  // (providerUserId is already set from the account above).
+  if (!token.providerUserId && token.githubUserId) {
+    token.provider = "github";
+    token.providerUserId = token.githubUserId;
+  }
+
+  return token;
+}
+
+/**
+ * Map JWT claims onto the session user. Pure and exported for testing.
+ */
+export function applySessionUser(session: Session, token: JWT): Session {
+  if (session.user) {
+    // Canonical provider user id, falling back to githubUserId so legacy GitHub
+    // JWTs (minted before providerUserId existed) keep a stable session.user.id
+    // across the deploy.
+    session.user.id = token.providerUserId ?? token.githubUserId;
+    session.user.provider = token.provider;
+    // login is GitHub-only; undefined for Google sessions.
+    session.user.login = token.githubLogin;
+  }
+  return session;
+}
+
+const providers: NextAuthOptions["providers"] = [
+  GitHubProvider<GithubProfile>({
+    clientId: process.env.GITHUB_CLIENT_ID!,
+    clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+    authorization: {
+      params: {
+        scope: "read:user user:email repo",
+      },
+    },
+    userinfo: {
+      url: "https://api.github.com/user",
+      async request({ client, tokens }) {
+        const profile = (await client.userinfo(tokens.access_token!)) as GithubProfile;
+        profile.email = await getVerifiedPrimaryGitHubEmail(tokens.access_token);
+        return profile as unknown as Profile;
+      },
+    },
+  }),
+];
+
+// Google is opt-in: enabled only when both credentials are configured, so
+// GitHub-only deployments are byte-unchanged. Scopes stay within the
+// non-sensitive openid/email/profile set (no SCM access, no Google review).
+const googleClientId = process.env.GOOGLE_CLIENT_ID;
+const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET;
+if (googleClientId && googleClientSecret) {
+  providers.push(
+    GoogleProvider({
+      clientId: googleClientId,
+      clientSecret: googleClientSecret,
+      authorization: {
+        params: {
+          scope: "openid email profile",
+        },
+      },
+    })
+  );
 }
 
 export const authOptions: NextAuthOptions = {
   debug: process.env.NODE_ENV === "development" || process.env.NEXTAUTH_DEBUG === "true",
-  providers: [
-    GitHubProvider<GithubProfile>({
-      clientId: process.env.GITHUB_CLIENT_ID!,
-      clientSecret: process.env.GITHUB_CLIENT_SECRET!,
-      authorization: {
-        params: {
-          scope: "read:user user:email repo",
-        },
-      },
-      userinfo: {
-        url: "https://api.github.com/user",
-        async request({ client, tokens }) {
-          const profile = (await client.userinfo(tokens.access_token!)) as GithubProfile;
-          profile.email = await getVerifiedPrimaryGitHubEmail(tokens.access_token);
-          return profile as unknown as Profile;
-        },
-      },
-    }),
-  ],
+  providers,
   callbacks: {
-    async signIn({ profile, user }) {
-      const config = {
+    async signIn({ account, profile, user }) {
+      const config: AccessControlConfig = {
         allowedDomains: parseAllowlist(process.env.ALLOWED_EMAIL_DOMAINS),
         allowedUsers: parseAllowlist(process.env.ALLOWED_USERS),
+        allowedEmails: parseAllowlist(process.env.ALLOWED_EMAILS),
         unsafeAllowAllUsers: parseBooleanEnv(process.env.UNSAFE_ALLOW_ALL_USERS),
       };
 
-      const githubProfile = profile as { login?: string };
-      const isAllowed = checkAccessAllowed(config, {
-        githubUsername: githubProfile.login,
-        email: user.email ?? undefined,
+      return buildSignInDecision({
+        provider: account?.provider,
+        profile,
+        email: user.email,
+        config,
       });
-
-      if (!isAllowed) {
-        return false;
-      }
-      return true;
     },
     async jwt({ token, account, profile }) {
-      if (account) {
-        token.accessToken = account.access_token;
-        token.refreshToken = account.refresh_token as string | undefined;
-        // expires_at is in seconds, convert to milliseconds (only set if provided)
-        token.accessTokenExpiresAt = account.expires_at ? account.expires_at * 1000 : undefined;
-      }
-      if (profile) {
-        // GitHub profile includes id (numeric) and login (username)
-        const githubProfile = profile as { id?: number; login?: string };
-        if (githubProfile.id) {
-          token.githubUserId = githubProfile.id.toString();
-        }
-        if (githubProfile.login) {
-          token.githubLogin = githubProfile.login;
-        }
-      }
-      return token;
+      return applyJwtClaims(token, account, profile);
     },
     async session({ session, token }) {
-      if (session.user) {
-        session.user.id = token.githubUserId;
-        session.user.login = token.githubLogin;
-      }
-      return session;
+      return applySessionUser(session, token);
     },
   },
   pages: {

--- a/packages/web/src/lib/build-auth-identity.test.ts
+++ b/packages/web/src/lib/build-auth-identity.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAuthIdentity,
+  buildScmCredentials,
+  resolveAuthProvider,
+  type AuthIdentityUser,
+} from "./build-auth-identity";
+
+const githubUser: AuthIdentityUser = {
+  id: "12345",
+  login: "ada",
+  name: "Ada Lovelace",
+  email: "ada@example.com",
+  image: "https://avatars.githubusercontent.com/u/12345",
+  provider: "github",
+};
+
+const googleUser: AuthIdentityUser = {
+  id: "google-sub-1",
+  name: "Pat PM",
+  email: "pm@gmail.com",
+  image: "https://lh3.googleusercontent.com/a/pat",
+  provider: "google",
+};
+
+const tokens = {
+  accessToken: "gho_abc",
+  refreshToken: "ghr_def",
+  accessTokenExpiresAt: 1_700_000_000_000,
+};
+
+describe("resolveAuthProvider", () => {
+  it("returns the explicit provider", () => {
+    expect(resolveAuthProvider(githubUser)).toBe("github");
+    expect(resolveAuthProvider(googleUser)).toBe("google");
+  });
+
+  it("defaults a missing provider to github (legacy session back-compat)", () => {
+    expect(resolveAuthProvider({ id: "12345" })).toBe("github");
+    expect(resolveAuthProvider(null)).toBe("github");
+    expect(resolveAuthProvider(undefined)).toBe("github");
+  });
+});
+
+describe("buildAuthIdentity", () => {
+  it("maps a GitHub user to the auth* block", () => {
+    expect(buildAuthIdentity(githubUser)).toEqual({
+      authProvider: "github",
+      authUserId: "12345",
+      authEmail: "ada@example.com",
+      authName: "Ada Lovelace",
+      authAvatarUrl: "https://avatars.githubusercontent.com/u/12345",
+    });
+  });
+
+  it("maps a Google user to the auth* block", () => {
+    expect(buildAuthIdentity(googleUser)).toEqual({
+      authProvider: "google",
+      authUserId: "google-sub-1",
+      authEmail: "pm@gmail.com",
+      authName: "Pat PM",
+      authAvatarUrl: "https://lh3.googleusercontent.com/a/pat",
+    });
+  });
+
+  it("normalizes null fields to undefined and defaults the provider", () => {
+    expect(buildAuthIdentity({ id: "12345", name: null, email: null, image: null })).toEqual({
+      authProvider: "github",
+      authUserId: "12345",
+      authEmail: undefined,
+      authName: undefined,
+      authAvatarUrl: undefined,
+    });
+  });
+});
+
+describe("buildScmCredentials", () => {
+  it("returns the full GitHub SCM block including the OAuth token", () => {
+    expect(buildScmCredentials(githubUser, tokens)).toEqual({
+      scmUserId: "12345",
+      scmLogin: "ada",
+      scmName: "Ada Lovelace",
+      scmEmail: "ada@example.com",
+      scmAvatarUrl: "https://avatars.githubusercontent.com/u/12345",
+      scmToken: "gho_abc",
+      scmRefreshToken: "ghr_def",
+      scmTokenExpiresAt: 1_700_000_000_000,
+    });
+  });
+
+  it("returns an empty object for Google — no scm* fields, and no token leak even if one is passed", () => {
+    // The credential-leak gate (F1/F2): a Google session must never carry an
+    // SCM token, regardless of what the JWT holds.
+    expect(buildScmCredentials(googleUser, { accessToken: "ya29.google-token" })).toEqual({});
+  });
+
+  it("treats a missing provider as GitHub (legacy session back-compat)", () => {
+    expect(buildScmCredentials({ id: "12345", login: "ada" }, tokens)).toMatchObject({
+      scmUserId: "12345",
+      scmLogin: "ada",
+      scmToken: "gho_abc",
+    });
+  });
+
+  it("tolerates absent tokens", () => {
+    expect(buildScmCredentials(githubUser, null)).toMatchObject({
+      scmUserId: "12345",
+      scmToken: undefined,
+      scmRefreshToken: undefined,
+      scmTokenExpiresAt: undefined,
+    });
+  });
+});

--- a/packages/web/src/lib/build-auth-identity.ts
+++ b/packages/web/src/lib/build-auth-identity.ts
@@ -1,0 +1,102 @@
+/**
+ * Single chokepoint for the auth-provider discriminator on the web side.
+ *
+ * Every request body we send to the control plane separates two concerns:
+ *
+ * - `auth*` — provider-agnostic authentication identity ("who logged in").
+ *   Populated for BOTH GitHub and Google; resolves the canonical D1 user.
+ * - `scm*` — GitHub-only SCM credentials + git-commit attribution. Populated
+ *   ONLY for GitHub; a Google session carries no `scm*` at all.
+ *
+ * Keeping the `provider === "github"` decision in this one module is the whole
+ * point of the 4B split — otherwise the branch sprawls across every route and
+ * a Google token can leak into the SCM path. Both `sessions` and `ws-token`
+ * routes build their bodies from these helpers and never branch on provider
+ * themselves.
+ */
+
+export type AuthProvider = "github" | "google";
+
+export interface AuthIdentityUser {
+  id?: string | null;
+  login?: string | null;
+  name?: string | null;
+  email?: string | null;
+  image?: string | null;
+  provider?: AuthProvider;
+}
+
+export interface AuthIdentity {
+  authProvider: AuthProvider;
+  authUserId?: string;
+  authEmail?: string;
+  authName?: string;
+  authAvatarUrl?: string;
+}
+
+export interface ScmTokenSource {
+  accessToken?: string;
+  refreshToken?: string;
+  accessTokenExpiresAt?: number;
+}
+
+export interface ScmCredentials {
+  scmUserId?: string;
+  scmLogin?: string;
+  scmName?: string;
+  scmEmail?: string;
+  scmAvatarUrl?: string;
+  scmToken?: string;
+  scmRefreshToken?: string;
+  scmTokenExpiresAt?: number;
+}
+
+/**
+ * Resolve the authentication provider for a session user. Legacy GitHub
+ * sessions were minted before `provider` existed, so a missing provider is
+ * treated as GitHub — the same back-compat default the control plane applies
+ * (`authProvider ?? "github"`).
+ */
+export function resolveAuthProvider(user: AuthIdentityUser | null | undefined): AuthProvider {
+  return user?.provider ?? "github";
+}
+
+/**
+ * Provider-agnostic identity block. Sent for every provider so the control
+ * plane can resolve the canonical user via `/provider-identities/:provider/:id`.
+ */
+export function buildAuthIdentity(user: AuthIdentityUser | null | undefined): AuthIdentity {
+  return {
+    authProvider: resolveAuthProvider(user),
+    authUserId: user?.id ?? undefined,
+    authEmail: user?.email ?? undefined,
+    authName: user?.name ?? undefined,
+    authAvatarUrl: user?.image ?? undefined,
+  };
+}
+
+/**
+ * GitHub SCM credentials + git-commit attribution. Returns an empty object for
+ * non-GitHub providers (e.g. Google) so their request bodies carry no `scm*`
+ * fields and no OAuth token — the credential-leak gate the F1/F2 findings call
+ * for, enforced here at the single source rather than at each call site.
+ */
+export function buildScmCredentials(
+  user: AuthIdentityUser | null | undefined,
+  tokens: ScmTokenSource | null | undefined
+): ScmCredentials {
+  if (resolveAuthProvider(user) !== "github") {
+    return {};
+  }
+
+  return {
+    scmUserId: user?.id ?? undefined,
+    scmLogin: user?.login ?? undefined,
+    scmName: user?.name ?? undefined,
+    scmEmail: user?.email ?? undefined,
+    scmAvatarUrl: user?.image ?? undefined,
+    scmToken: tokens?.accessToken,
+    scmRefreshToken: tokens?.refreshToken,
+    scmTokenExpiresAt: tokens?.accessTokenExpiresAt,
+  };
+}

--- a/packages/web/src/lib/current-user.test.ts
+++ b/packages/web/src/lib/current-user.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/control-plane", () => ({
+  controlPlaneFetch: vi.fn(),
+}));
+
+import { controlPlaneFetch } from "@/lib/control-plane";
+import { clearCurrentUserIdCacheForTests, resolveCurrentUserId } from "./current-user";
+
+describe("resolveCurrentUserId — provider-scoped cache", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    clearCurrentUserIdCacheForTests();
+  });
+
+  it("does not alias a GitHub id and a numerically identical Google sub", async () => {
+    const githubUserId = "0123456789abcdef0123456789abcdef";
+    const googleUserId = "fedcba9876543210fedcba9876543210";
+    vi.mocked(controlPlaneFetch)
+      .mockResolvedValueOnce(Response.json({ userId: githubUserId }))
+      .mockResolvedValueOnce(Response.json({ userId: googleUserId }));
+
+    // Same numeric id ("123") under two providers must resolve independently.
+    const gh = await resolveCurrentUserId({ id: "123", provider: "github", login: "ada" });
+    const google = await resolveCurrentUserId({
+      id: "123",
+      provider: "google",
+      email: "pm@gmail.com",
+    });
+
+    expect(gh).toEqual({ ok: true, userId: githubUserId });
+    expect(google).toEqual({ ok: true, userId: googleUserId });
+    expect(controlPlaneFetch).toHaveBeenNthCalledWith(
+      1,
+      "/provider-identities/github/123",
+      expect.anything()
+    );
+    expect(controlPlaneFetch).toHaveBeenNthCalledWith(
+      2,
+      "/provider-identities/google/123",
+      expect.anything()
+    );
+
+    // A second GitHub resolution must come from the GitHub-scoped cache entry,
+    // not the Google one, and without a third control-plane call.
+    const githubAgain = await resolveCurrentUserId({ id: "123", provider: "github", login: "ada" });
+    expect(githubAgain).toEqual({ ok: true, userId: githubUserId });
+    expect(controlPlaneFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/web/src/lib/current-user.ts
+++ b/packages/web/src/lib/current-user.ts
@@ -1,13 +1,12 @@
 import { isCanonicalUserId } from "@open-inspect/shared";
+import {
+  buildAuthIdentity,
+  type AuthIdentity,
+  type AuthIdentityUser,
+} from "@/lib/build-auth-identity";
 import { controlPlaneFetch } from "@/lib/control-plane";
 
-export type CurrentUserIdentityInput = {
-  id?: string | null;
-  login?: string | null;
-  name?: string | null;
-  email?: string | null;
-  image?: string | null;
-};
+export type CurrentUserIdentityInput = AuthIdentityUser;
 
 type CurrentUserResponse = {
   userId?: unknown;
@@ -36,15 +35,19 @@ export function clearCurrentUserIdCacheForTests() {
 export async function resolveCurrentUserId(
   user: CurrentUserIdentityInput | null | undefined
 ): Promise<ResolveCurrentUserResult> {
-  if (!user?.id) {
+  const identity = buildAuthIdentity(user);
+  const authUserId = identity.authUserId;
+  if (!authUserId) {
     return {
       ok: false,
       status: 409,
-      body: { error: "GitHub user ID is unavailable" },
+      body: { error: "User id unavailable" },
     };
   }
 
-  const cacheKey = user.id;
+  // Resolution is provider-scoped (the route path carries the provider), so the
+  // cache must be too — the same id under two providers must never alias.
+  const cacheKey = `${identity.authProvider}:${authUserId}`;
   const cached = currentUserIdCache.get(cacheKey);
   if (cached && cached.expiresAt > Date.now()) {
     return {
@@ -58,25 +61,30 @@ export async function resolveCurrentUserId(
     return pending;
   }
 
-  const resolution = resolveCurrentUserIdUncached({ ...user, id: cacheKey }).finally(() => {
-    pendingCurrentUserIdResolutions.delete(cacheKey);
-  });
+  const resolution = resolveCurrentUserIdUncached(identity, authUserId, user, cacheKey).finally(
+    () => {
+      pendingCurrentUserIdResolutions.delete(cacheKey);
+    }
+  );
   pendingCurrentUserIdResolutions.set(cacheKey, resolution);
   return resolution;
 }
 
 async function resolveCurrentUserIdUncached(
-  user: CurrentUserIdentityInput & { id: string }
+  identity: AuthIdentity,
+  authUserId: string,
+  user: CurrentUserIdentityInput | null | undefined,
+  cacheKey: string
 ): Promise<ResolveCurrentUserResult> {
   const response = await controlPlaneFetch(
-    `/provider-identities/github/${encodeURIComponent(user.id)}`,
+    `/provider-identities/${identity.authProvider}/${encodeURIComponent(authUserId)}`,
     {
       method: "PUT",
       body: JSON.stringify({
-        providerLogin: user.login,
-        providerEmail: user.email,
-        displayName: user.name || user.login,
-        avatarUrl: user.image,
+        providerLogin: user?.login ?? undefined,
+        providerEmail: identity.authEmail,
+        displayName: identity.authName || user?.login || undefined,
+        avatarUrl: identity.authAvatarUrl,
       }),
     }
   );
@@ -98,7 +106,7 @@ async function resolveCurrentUserIdUncached(
     };
   }
 
-  currentUserIdCache.set(user.id, {
+  currentUserIdCache.set(cacheKey, {
     userId: data.userId,
     expiresAt: Date.now() + CURRENT_USER_ID_CACHE_TTL_MS,
   });

--- a/packages/web/src/lib/site-config.ts
+++ b/packages/web/src/lib/site-config.ts
@@ -16,3 +16,12 @@ export const APP_SHORT_NAME =
 
 export const APP_ICON_URL = process.env.NEXT_PUBLIC_APP_ICON_URL?.trim() || "";
 export const APP_FAVICON_URL = APP_ICON_URL || DEFAULT_FAVICON_URL;
+
+/**
+ * Whether to show the "Sign in with Google" button. Build-time flag mirroring
+ * the server-side conditional GoogleProvider (enabled only when both
+ * GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET are set). The provider set is static
+ * per deployment, so a build-time flag avoids an async getProviders() round-trip
+ * in the sign-in client component.
+ */
+export const GOOGLE_LOGIN_ENABLED = process.env.NEXT_PUBLIC_GOOGLE_ENABLED?.trim() === "true";

--- a/scripts/wrangler-secrets.sh
+++ b/scripts/wrangler-secrets.sh
@@ -7,11 +7,20 @@ set -euo pipefail
 #   GITHUB_CLIENT_SECRET     - GitHub OAuth client secret
 #   NEXTAUTH_SECRET          - NextAuth.js signing secret
 #   INTERNAL_CALLBACK_SECRET - service-to-service auth secret
+# Optional environment variables:
+#   GOOGLE_CLIENT_SECRET     - Google OAuth client secret (uploaded only when set;
+#                              empty for GitHub-only deployments)
 
 echo "Uploading secrets to worker: ${WORKER_NAME}"
 
 echo "${GITHUB_CLIENT_SECRET}" | npx wrangler secret put GITHUB_CLIENT_SECRET --name "${WORKER_NAME}"
 echo "${NEXTAUTH_SECRET}" | npx wrangler secret put NEXTAUTH_SECRET --name "${WORKER_NAME}"
 echo "${INTERNAL_CALLBACK_SECRET}" | npx wrangler secret put INTERNAL_CALLBACK_SECRET --name "${WORKER_NAME}"
+
+# Google login is opt-in: only upload the secret when configured. (Disabling
+# Google after enabling leaves the old secret in place; delete it manually if needed.)
+if [ -n "${GOOGLE_CLIENT_SECRET:-}" ]; then
+  echo "${GOOGLE_CLIENT_SECRET}" | npx wrangler secret put GOOGLE_CLIENT_SECRET --name "${WORKER_NAME}"
+fi
 
 echo "Secrets uploaded successfully"

--- a/terraform/d1/migrations/0019_create_users.sql
+++ b/terraform/d1/migrations/0019_create_users.sql
@@ -17,7 +17,9 @@ CREATE TABLE IF NOT EXISTS users (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email
   ON users(email COLLATE NOCASE) WHERE email IS NOT NULL;
 
--- Links provider identities (GitHub, Slack, Linear) to canonical users
+-- Links provider identities (GitHub, Slack, Linear, Google) to canonical users.
+-- `provider` is intentionally free-form (no CHECK constraint) so new auth/SCM
+-- providers can be added without a migration.
 CREATE TABLE IF NOT EXISTS user_identities (
   id               TEXT PRIMARY KEY,
   user_id          TEXT NOT NULL,

--- a/terraform/environments/production/checks.tf
+++ b/terraform/environments/production/checks.tf
@@ -20,9 +20,10 @@ resource "terraform_data" "access_control_gate" {
       condition = (
         var.unsafe_allow_all_users ||
         length([for item in split(",", var.allowed_users) : trimspace(item) if trimspace(item) != ""]) > 0 ||
-        length([for item in split(",", var.allowed_email_domains) : trimspace(item) if trimspace(item) != ""]) > 0
+        length([for item in split(",", var.allowed_email_domains) : trimspace(item) if trimspace(item) != ""]) > 0 ||
+        length([for item in split(",", var.allowed_emails) : trimspace(item) if trimspace(item) != ""]) > 0
       )
-      error_message = "At least one access control allowlist must be configured. Set allowed_users or allowed_email_domains, or set unsafe_allow_all_users = true to explicitly allow all authenticated GitHub users."
+      error_message = "At least one access control allowlist must be configured. Set allowed_users, allowed_email_domains, or allowed_emails, or set unsafe_allow_all_users = true to explicitly allow all authenticated users."
     }
   }
 }

--- a/terraform/environments/production/locals.tf
+++ b/terraform/environments/production/locals.tf
@@ -4,6 +4,11 @@ locals {
   use_daytona_backend = var.sandbox_provider == "daytona"
   use_vercel_backend  = var.sandbox_provider == "vercel"
 
+  # Google login is enabled only when both OAuth credentials are configured.
+  # Drives the build-time NEXT_PUBLIC_GOOGLE_ENABLED flag (sign-in button) and
+  # mirrors the server-side conditional GoogleProvider in packages/web/src/lib/auth.ts.
+  google_enabled = var.google_client_id != "" && var.google_client_secret != ""
+
   # URLs for cross-service configuration
   control_plane_host = "open-inspect-control-plane-${local.name_suffix}.${var.cloudflare_worker_subdomain}.workers.dev"
   control_plane_url  = "https://${local.control_plane_host}"

--- a/terraform/environments/production/locals.tf
+++ b/terraform/environments/production/locals.tf
@@ -7,7 +7,7 @@ locals {
   # Google login is enabled only when both OAuth credentials are configured.
   # Drives the build-time NEXT_PUBLIC_GOOGLE_ENABLED flag (sign-in button) and
   # mirrors the server-side conditional GoogleProvider in packages/web/src/lib/auth.ts.
-  google_enabled = var.google_client_id != "" && var.google_client_secret != ""
+  google_enabled = trimspace(var.google_client_id) != "" && trimspace(var.google_client_secret) != ""
 
   # URLs for cross-service configuration
   control_plane_host = "open-inspect-control-plane-${local.name_suffix}.${var.cloudflare_worker_subdomain}.workers.dev"

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -136,6 +136,19 @@ github_webhook_secret = ""
 github_bot_username = ""
 
 # =============================================================================
+# Google OAuth Credentials (Optional)
+# =============================================================================
+# Enables "Sign in with Google" for non-developer users (PMs, support agents).
+# Create an OAuth 2.0 Client ID at: https://console.cloud.google.com/apis/credentials
+#   - Application type: Web application
+#   - Authorized redirect URI: {your-web-app-url}/api/auth/callback/google
+#   - Consent screen scopes: openid, email, profile (non-sensitive — no Google review)
+# Set BOTH values to enable Google login, or leave BOTH empty for GitHub-only.
+# Pair with allowed_emails / allowed_email_domains below to control who may sign in.
+google_client_id = ""
+google_client_secret = ""
+
+# =============================================================================
 # Slack App Credentials (Optional)
 # =============================================================================
 # From Slack App dashboard: https://api.slack.com/apps
@@ -290,15 +303,22 @@ enable_service_bindings = false
 # =============================================================================
 # Access Control
 # =============================================================================
+# Three provider-agnostic allowlists; a user is admitted if they match ANY of
+# them. Set at least one unless you intentionally opt into open access with
+# unsafe_allow_all_users = true.
+
 # Comma-separated list of GitHub usernames allowed to sign in
-# Set at least one access-control allowlist unless you intentionally opt into
-# open access with unsafe_allow_all_users = true.
 allowed_users = ""
 
-# Comma-separated list of email domains allowed to sign in
-# Example: "example.com,corp.io"
+# Comma-separated list of email domains allowed to sign in (matches any
+# provider's verified email). Example: "example.com,corp.io"
 allowed_email_domains = ""
 
+# Comma-separated list of exact email addresses allowed to sign in. Use this for
+# individual users on shared domains (e.g. one person@gmail.com) where a domain
+# allowlist would admit too many. Example: "pm@gmail.com,agent@gmail.com"
+allowed_emails = ""
+
 # Explicitly bypass the Terraform access-control safety check and allow any
-# authenticated GitHub user to sign in when both allowlists are empty.
+# authenticated user to sign in when all allowlists are empty.
 unsafe_allow_all_users = false

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -110,6 +110,33 @@ variable "github_client_secret" {
 }
 
 # =============================================================================
+# Google OAuth Credentials (Optional — enables "Sign in with Google")
+# =============================================================================
+# Set both google_client_id and google_client_secret to enable Google login for
+# non-developer users (PMs, support agents). Leave both empty for GitHub-only
+# deployments, which stay byte-unchanged. A Google session authenticates the user
+# but carries no SCM credentials; git operations continue to use the shared
+# GitHub App installation, and PRs fall back to the App bot.
+
+variable "google_client_id" {
+  description = "Google OAuth 2.0 client ID. Set together with google_client_secret to enable Google login; leave both empty to keep the deployment GitHub-only."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = (var.google_client_id == "") == (var.google_client_secret == "")
+    error_message = "google_client_id and google_client_secret must be set together (both non-empty) or both left empty. Setting only one silently disables Google login."
+  }
+}
+
+variable "google_client_secret" {
+  description = "Google OAuth 2.0 client secret. Required together with google_client_id."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+# =============================================================================
 # GitHub App Credentials (for Modal sandbox)
 # =============================================================================
 
@@ -479,21 +506,30 @@ variable "r2_media_bucket_name" {
 # =============================================================================
 # Access Control
 # =============================================================================
+# Three provider-agnostic allowlists gate sign-in; a user is admitted if they
+# match ANY configured allowlist. Leave all three empty only with
+# unsafe_allow_all_users = true.
 
 variable "allowed_users" {
-  description = "Comma-separated list of GitHub usernames allowed to sign in. Leave empty only when allowed_email_domains is set or unsafe_allow_all_users is true."
+  description = "Comma-separated list of GitHub usernames allowed to sign in. Leave empty only when another allowlist (allowed_email_domains, allowed_emails) is set or unsafe_allow_all_users is true."
   type        = string
   default     = ""
 }
 
 variable "allowed_email_domains" {
-  description = "Comma-separated list of email domains allowed to sign in (e.g., 'example.com,corp.io'). Leave empty only when allowed_users is set or unsafe_allow_all_users is true."
+  description = "Comma-separated list of email domains allowed to sign in (e.g., 'example.com,corp.io'). Matches any provider's verified email. Leave empty only when another allowlist (allowed_users, allowed_emails) is set or unsafe_allow_all_users is true."
+  type        = string
+  default     = ""
+}
+
+variable "allowed_emails" {
+  description = "Comma-separated list of exact email addresses allowed to sign in, matched case-insensitively against any provider's verified email. Use this for individual users on shared domains (e.g. one person@gmail.com) where allowed_email_domains would be too broad. Leave empty only when another allowlist is set or unsafe_allow_all_users is true."
   type        = string
   default     = ""
 }
 
 variable "unsafe_allow_all_users" {
-  description = "Bypass Terraform's access-control safety check and allow any authenticated GitHub user to sign in when both allowlists are empty. Set to true only for intentionally open deployments."
+  description = "Bypass Terraform's access-control safety check and allow any authenticated user to sign in when all allowlists are empty. Set to true only for intentionally open deployments."
   type        = bool
   default     = false
 }

--- a/terraform/environments/production/web-cloudflare.tf
+++ b/terraform/environments/production/web-cloudflare.tf
@@ -21,6 +21,7 @@ resource "null_resource" "web_app_cloudflare_build" {
       NEXT_PUBLIC_APP_NAME         = var.app_name
       NEXT_PUBLIC_APP_SHORT_NAME   = var.app_short_name
       NEXT_PUBLIC_APP_ICON_URL     = var.app_icon_url
+      NEXT_PUBLIC_GOOGLE_ENABLED   = tostring(local.google_enabled)
     }
   }
 }
@@ -33,6 +34,7 @@ resource "null_resource" "web_app_cloudflare_secrets" {
   triggers = {
     secrets_hash = sha256(join(",", [
       var.github_client_secret,
+      var.google_client_secret,
       var.nextauth_secret,
       var.internal_callback_secret,
     ]))
@@ -47,6 +49,7 @@ resource "null_resource" "web_app_cloudflare_secrets" {
       CLOUDFLARE_ACCOUNT_ID    = var.cloudflare_account_id
       WORKER_NAME              = "open-inspect-web-${local.name_suffix}"
       GITHUB_CLIENT_SECRET     = var.github_client_secret
+      GOOGLE_CLIENT_SECRET     = var.google_client_secret
       NEXTAUTH_SECRET          = var.nextauth_secret
       INTERNAL_CALLBACK_SECRET = var.internal_callback_secret
     }
@@ -68,6 +71,7 @@ resource "local_file" "web_app_wrangler_production" {
 
     [vars]
     GITHUB_CLIENT_ID = "${var.github_client_id}"
+    GOOGLE_CLIENT_ID = "${var.google_client_id}"
     NEXTAUTH_URL = "${local.web_app_url}"
     CONTROL_PLANE_URL = "${local.control_plane_url}"
     NEXT_PUBLIC_WS_URL = "${local.ws_url}"
@@ -75,8 +79,10 @@ resource "local_file" "web_app_wrangler_production" {
     NEXT_PUBLIC_APP_NAME = "${var.app_name}"
     NEXT_PUBLIC_APP_SHORT_NAME = "${var.app_short_name}"
     NEXT_PUBLIC_APP_ICON_URL = "${var.app_icon_url}"
+    NEXT_PUBLIC_GOOGLE_ENABLED = "${tostring(local.google_enabled)}"
     ALLOWED_USERS = "${var.allowed_users}"
     ALLOWED_EMAIL_DOMAINS = "${var.allowed_email_domains}"
+    ALLOWED_EMAILS = "${var.allowed_emails}"
     UNSAFE_ALLOW_ALL_USERS = "${tostring(var.unsafe_allow_all_users)}"
 
     [assets]

--- a/terraform/environments/production/web-vercel.tf
+++ b/terraform/environments/production/web-vercel.tf
@@ -105,5 +105,38 @@ module "web_app" {
       targets   = ["production", "preview"]
       sensitive = false
     },
+    # New env vars MUST be appended here. The module's env-var resource is
+    # count-indexed by list position (modules/vercel-project/main.tf uses count,
+    # because Vercel values are sensitive and can't be for_each keys), so
+    # inserting mid-list renumbers every downstream var and forces Vercel to
+    # destroy/recreate them — which races into ENV_CONFLICT. Appending keeps
+    # existing indices stable.
+    # Google OAuth (optional; both empty for GitHub-only deployments)
+    {
+      key       = "GOOGLE_CLIENT_ID"
+      value     = var.google_client_id
+      targets   = ["production", "preview"]
+      sensitive = false
+    },
+    {
+      key       = "GOOGLE_CLIENT_SECRET"
+      value     = var.google_client_secret
+      targets   = ["production", "preview"]
+      sensitive = true
+    },
+    # Build-time flag that reveals the "Sign in with Google" button. Inlined into
+    # the client bundle, so it must be present at build time (not just runtime).
+    {
+      key       = "NEXT_PUBLIC_GOOGLE_ENABLED"
+      value     = tostring(local.google_enabled)
+      targets   = ["production", "preview"]
+      sensitive = false
+    },
+    {
+      key       = "ALLOWED_EMAILS"
+      value     = var.allowed_emails
+      targets   = ["production", "preview"]
+      sensitive = false
+    },
   ]
 }


### PR DESCRIPTION
## Summary

Adds **Google login** (NextAuth `GoogleProvider`) as an optional second sign-in provider alongside GitHub, so people who orchestrate the agent without a GitHub account (PMs, support, etc.) can sign in. GitHub login is unchanged, and **Google is off by default** — it activates only when credentials are configured.

## How it works

**Authentication identity is decoupled from source-control credentials.** Two concerns travel separately on every web → control-plane request:

- **`auth*` — provider-agnostic identity** (provider, id/sub, email). Populated for both GitHub and Google; resolves the canonical user via the existing `users` / `user_identities` model, with email-based cross-provider linking.
- **`scm*` — GitHub-only SCM credentials** (the OAuth token used for clone/push and commit/PR attribution). Built **only** for GitHub sessions — a Google *credential* is never used as an SCM credential. A Google sign-in with no linked GitHub identity carries no SCM token and its commits/PRs fall back to the shared GitHub App bot. If the canonical user has **also** linked a verified-email GitHub identity (i.e. the same person previously signed in with GitHub), the session is enriched server-side with *that GitHub identity's* token, so they keep GitHub-attributed commits/PRs.

Both are produced by one chokepoint (`buildAuthIdentity` / `buildScmCredentials`) that every route uses, so a Google credential can't reach the SCM path. The control plane resolves identity provider-agnostically (`/provider-identities/:provider/:id`), and the user cache is keyed per provider so a GitHub id and a numerically identical Google sub never alias.

## Access control

Adds an **exact-email allowlist** (`ALLOWED_EMAILS`) alongside the existing domain and username lists. This admits specific individuals on shared domains (e.g. `gmail.com`) without opening the entire domain. Google sign-ins additionally require a **verified** email. A user is admitted if they match any configured allowlist.

## Enabling it

Google registers only when **both** `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` are set; the "Sign in with Google" button is gated on a build-time flag (`NEXT_PUBLIC_GOOGLE_ENABLED`) derived from that config. Terraform variables, CI, and the setup docs (GETTING_STARTED / SETUP_GUIDE / onboarding) are updated for the new optional inputs, including the Google OAuth redirect URI (`/api/auth/callback/google`). Leaving the variables empty keeps the deployment GitHub-only and byte-unchanged.

## Tests

Adds unit + integration coverage for:

- provider-agnostic identity resolution and the GitHub / Google / back-compat branches,
- the credential-isolation boundary (a Google session sends no `scm*` / token; GitHub enrichment returns null for a non-GitHub user),
- the exact-email allowlist and verified-email gate,
- the provider-scoped user cache (no GitHub-id / Google-sub aliasing),
- cross-provider account linking by verified email.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional “Sign in with Google” (including OAuth setup guidance and configuration flags)
  * Added `allowed_emails` allowlist support for precise access control

* **Bug Fixes**
  * Improved provider-agnostic identity handling for automations, sessions, and PR creation (including correct attribution when using non-GitHub sign-in)
  * Prevented SCM/token data leakage for non-GitHub sessions

* **Documentation**
  * Updated setup/onboarding and guides to cover Google OAuth and the new allowlist behavior

* **Chores**
  * Updated Terraform workflow and variables to pass Google auth settings and allowed emails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->