### PR TITLE
feat(web): support custom domain

### DIFF
--- a/terraform/environments/production/checks.tf
+++ b/terraform/environments/production/checks.tf
@@ -12,6 +12,19 @@ check "vercel_url_matches" {
   }
 }
 
+# Warn when a custom domain is set without a zone ID. The custom domain is then
+# silently ignored and the app falls back to the workers.dev URL.
+check "cloudflare_custom_domain_config" {
+  assert {
+    condition = (
+      var.web_platform != "cloudflare" ||
+      trimspace(coalesce(var.cloudflare_custom_domain, "")) == "" ||
+      trimspace(coalesce(var.cloudflare_zone_id, "")) != ""
+    )
+    error_message = "cloudflare_custom_domain is set but cloudflare_zone_id is empty — the custom domain is ignored and the app falls back to the workers.dev URL."
+  }
+}
+
 # Fail the plan when no access control is configured. Uses terraform_data with a
 # precondition so this is a hard error, not an advisory check-block warning.
 resource "terraform_data" "access_control_gate" {

--- a/terraform/environments/production/locals.tf
+++ b/terraform/environments/production/locals.tf
@@ -14,8 +14,13 @@ locals {
   control_plane_url  = "https://${local.control_plane_host}"
   ws_url             = "wss://${local.control_plane_host}"
 
+  # Whether a custom domain is configured for the Cloudflare web Worker
+  web_custom_domain_enabled = var.web_platform == "cloudflare" && var.cloudflare_custom_domain != null && var.cloudflare_custom_domain != "" && var.cloudflare_zone_id != null && var.cloudflare_zone_id != ""
+
   # Web app URL depends on deployment platform
-  web_app_url = var.web_platform == "cloudflare" ? (
+  web_app_url = local.web_custom_domain_enabled ? (
+    "https://${var.cloudflare_custom_domain}"
+    ) : var.web_platform == "cloudflare" ? (
     "https://open-inspect-web-${local.name_suffix}.${var.cloudflare_worker_subdomain}.workers.dev"
     ) : (
     "https://open-inspect-${local.name_suffix}.vercel.app"

--- a/terraform/environments/production/locals.tf
+++ b/terraform/environments/production/locals.tf
@@ -14,16 +14,27 @@ locals {
   control_plane_url  = "https://${local.control_plane_host}"
   ws_url             = "wss://${local.control_plane_host}"
 
+  # Must match the deployed Worker's `name` and the custom-domain `service` binding.
+  web_worker_name = "open-inspect-web-${local.name_suffix}"
+
   # Whether a custom domain is configured for the Cloudflare web Worker
-  web_custom_domain_enabled = var.web_platform == "cloudflare" && var.cloudflare_custom_domain != null && var.cloudflare_custom_domain != "" && var.cloudflare_zone_id != null && var.cloudflare_zone_id != ""
+  web_custom_domain_enabled = (
+    var.web_platform == "cloudflare" &&
+    trimspace(coalesce(var.cloudflare_custom_domain, "")) != "" &&
+    trimspace(coalesce(var.cloudflare_zone_id, "")) != ""
+  )
+
+  # Host the Cloudflare web Worker is served from: custom domain when configured,
+  # otherwise its default workers.dev hostname.
+  web_cloudflare_host = (local.web_custom_domain_enabled
+    ? var.cloudflare_custom_domain
+    : "${local.web_worker_name}.${var.cloudflare_worker_subdomain}.workers.dev"
+  )
 
   # Web app URL depends on deployment platform
-  web_app_url = local.web_custom_domain_enabled ? (
-    "https://${var.cloudflare_custom_domain}"
-    ) : var.web_platform == "cloudflare" ? (
-    "https://open-inspect-web-${local.name_suffix}.${var.cloudflare_worker_subdomain}.workers.dev"
-    ) : (
-    "https://open-inspect-${local.name_suffix}.vercel.app"
+  web_app_url = (var.web_platform == "cloudflare"
+    ? "https://${local.web_cloudflare_host}"
+    : "https://open-inspect-${local.name_suffix}.vercel.app"
   )
 
   # Worker script paths (deterministic output locations)

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -27,7 +27,7 @@ cloudflare_api_token = ""
 cloudflare_account_id = ""
 
 # Cloudflare zone ID (optional, only needed for custom domains)
-# From domains overview list, select the "copy zone id"
+# In the Cloudflare dashboard, open the domain's Overview and use "Copy zone ID".
 # cloudflare_zone_id = ""
 
 # Custom domain (hostname) for the Cloudflare web Worker (optional).

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -27,7 +27,14 @@ cloudflare_api_token = ""
 cloudflare_account_id = ""
 
 # Cloudflare zone ID (optional, only needed for custom domains)
+# From domains overview list, select the "copy zone id"
 # cloudflare_zone_id = ""
+
+# Custom domain (hostname) for the Cloudflare web Worker (optional).
+# Only used when web_platform = "cloudflare". Requires cloudflare_zone_id above
+# and a zone you control. Cloudflare provisions the DNS record + edge cert and
+# the web app URL becomes https://<this-hostname> instead of the workers.dev URL.
+# cloudflare_custom_domain = "" # e.g., "app.example.com"
 
 # Cloudflare Workers subdomain (found in Workers & Pages -> Overview, bottom-right of panel)
 # This is the subdomain used for workers.dev URLs (e.g., "myaccount" in "worker.myaccount.workers.dev")

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -19,6 +19,12 @@ variable "cloudflare_zone_id" {
   default     = null
 }
 
+variable "cloudflare_custom_domain" {
+  description = "Custom domain (hostname) to attach to the Cloudflare web Worker (optional). Requires web_platform = 'cloudflare' and cloudflare_zone_id. e.g. 'app.example.com'"
+  type        = string
+  default     = null
+}
+
 variable "cloudflare_worker_subdomain" {
   description = "Cloudflare Workers account subdomain (e.g. 'myaccount' — .workers.dev is appended automatically)"
   type        = string

--- a/terraform/environments/production/web-cloudflare.tf
+++ b/terraform/environments/production/web-cloudflare.tf
@@ -120,3 +120,16 @@ resource "null_resource" "web_app_cloudflare_deploy" {
     local_file.web_app_wrangler_production,
   ]
 }
+
+# Attach a custom domain to the web Worker (when configured).
+# Cloudflare provisions and manages the DNS record + edge cert for the hostname.
+resource "cloudflare_workers_custom_domain" "web_app" {
+  count = local.web_custom_domain_enabled ? 1 : 0
+
+  account_id = var.cloudflare_account_id
+  zone_id    = var.cloudflare_zone_id
+  hostname   = var.cloudflare_custom_domain
+  service    = "open-inspect-web-${local.name_suffix}"
+
+  depends_on = [null_resource.web_app_cloudflare_deploy]
+}

--- a/terraform/environments/production/web-cloudflare.tf
+++ b/terraform/environments/production/web-cloudflare.tf
@@ -47,7 +47,7 @@ resource "null_resource" "web_app_cloudflare_secrets" {
     environment = {
       CLOUDFLARE_API_TOKEN     = var.cloudflare_api_token
       CLOUDFLARE_ACCOUNT_ID    = var.cloudflare_account_id
-      WORKER_NAME              = "open-inspect-web-${local.name_suffix}"
+      WORKER_NAME              = local.web_worker_name
       GITHUB_CLIENT_SECRET     = var.github_client_secret
       GOOGLE_CLIENT_SECRET     = var.google_client_secret
       NEXTAUTH_SECRET          = var.nextauth_secret
@@ -64,7 +64,7 @@ resource "local_file" "web_app_wrangler_production" {
   count    = var.web_platform == "cloudflare" ? 1 : 0
   filename = "${var.project_root}/packages/web/wrangler.production.toml"
   content  = <<-TOML
-    name = "open-inspect-web-${local.name_suffix}"
+    name = "${local.web_worker_name}"
     main = ".open-next/worker.js"
     compatibility_date = "2025-08-15"
     compatibility_flags = ["nodejs_compat", "global_fetch_strictly_public"]
@@ -129,7 +129,7 @@ resource "cloudflare_workers_custom_domain" "web_app" {
   account_id = var.cloudflare_account_id
   zone_id    = var.cloudflare_zone_id
   hostname   = var.cloudflare_custom_domain
-  service    = "open-inspect-web-${local.name_suffix}"
+  service    = local.web_worker_name
 
   depends_on = [null_resource.web_app_cloudflare_deploy]
 }


### PR DESCRIPTION
## Support a custom domain for the Cloudflare web Worker

Adds the ability to serve the web app on a custom domain (e.g. `app.example.com`)
instead of the default `*.workers.dev` URL when `web_platform = "cloudflare"`.

There was an existing `cloudflare_zone_id` terraform variable, but it was unused.

### Changes

- **`variables.tf`** — new optional `cloudflare_custom_domain` variable (the hostname to attach), alongside the existing `cloudflare_zone_id`. Defaults to `null`.
- **`web-cloudflare.tf`** — new `cloudflare_workers_custom_domain.web_app` resource that attaches the hostname to the web Worker. Cloudflare provisions the DNS record and edge certificate. Gated on `local.web_custom_domain_enabled` and depends on the Worker deploy.
- **`locals.tf`** — added `web_custom_domain_enabled` flag and a third case to `web_app_url`. When a custom domain is set, the app URL (used for `NEXTAUTH_URL` and cross-service config) becomes `https://<custom-domain>` instead of the `workers.dev` URL.
- **`terraform.tfvars.example`** — documented the new `cloudflare_custom_domain` input under the Cloudflare zone section.

### Behavior

The custom domain only activates when **all** of the following are true:

- `web_platform = "cloudflare"`
- `cloudflare_zone_id` is set
- `cloudflare_custom_domain` is non-empty

Otherwise the deployment falls back to the existing `workers.dev` URL — no change for existing deployments.

### Notes

- Requires a Cloudflare zone you control (set `cloudflare_zone_id`).
- The Cloudflare API token needs **Workers Routes: Edit** to manage the custom domain.
- `terraform validate` passes cleanly (dropped the deprecated `environment` attribute on the resource).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Cloudflare custom-domain support for production web workers, including automatic URL switching to the custom hostname when configured.
* **Safety Checks**
  * Added validation to prevent misconfigured custom-domain/zone settings; falls back to the default workers subdomain when required inputs are missing.
* **Documentation**
  * Expanded production Cloudflare setup guidance and examples for the custom-domain option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->