### PR TITLE
fix(terraform): pin cloudflare provider below 5.20.0

### DIFF
--- a/terraform/environments/production/.terraform.lock.hcl
+++ b/terraform/environments/production/.terraform.lock.hcl
@@ -3,8 +3,9 @@
 
 provider "registry.terraform.io/cloudflare/cloudflare" {
   version     = "5.19.1"
-  constraints = ">= 5.0.0, ~> 5.16"
+  constraints = ">= 5.0.0, >= 5.16.0, < 5.20.0"
   hashes = [
+    "h1:HkKPMZ/n+QiExkRUSLjGMTGnuIaph+k932LiTp7CKZM=",
     "h1:mopYISyLkUVUwMjJbuPenxIUVDrna1/7ACB1hfMfciU=",
     "zh:0651618000db705564dab5a25322b9d76ea54b7dd78931ed3565497b559babeb",
     "zh:1a7847e9479fb6d21a65ef933ffae1416b1e4b44ca940c0d6c50fc4248cc4a0d",

--- a/terraform/environments/production/versions.tf
+++ b/terraform/environments/production/versions.tf
@@ -3,8 +3,13 @@ terraform {
 
   required_providers {
     cloudflare = {
-      source  = "cloudflare/cloudflare"
-      version = "~> 5.16"
+      source = "cloudflare/cloudflare"
+      # Pin below 5.20.0: that release regressed cloudflare_worker observability
+      # to emit observability.traces.propagation_policy, which fails with
+      # "propagation_policy requires the trace propagation feature to be enabled"
+      # (403, code 100342) on accounts without that feature.
+      # See cloudflare/terraform-provider-cloudflare#7177.
+      version = ">= 5.16, < 5.20.0"
     }
     vercel = {
       source  = "vercel/vercel"


### PR DESCRIPTION
## Problem

Following the Terraform getting-started instructions fails at `terraform apply` with a 403 from the Cloudflare API:

```
POST ".../workers/workers": 403 Forbidden {
  "code": 100342,
  "message": "propagation_policy requires the trace propagation feature to be enabled."
}
```

Fixes #750.

## Root cause

Cloudflare Terraform provider **v5.20.0** regressed `cloudflare_worker` observability: the worker-metadata model gained a `traces.propagation_policy` field that the provider now always emits, but accounts without the trace-propagation feature reject it with `403 / code 100342`. The bug is tracked upstream in [cloudflare/terraform-provider-cloudflare#7177](https://github.com/cloudflare/terraform-provider-cloudflare/issues/7177) and is **not yet fixed** in any released version. The last known-good release is **5.19.1**.

Our root constraint was `~> 5.16` (i.e. `>= 5.16, < 6.0`), so a fresh `terraform init` (or `terraform init -upgrade`) is free to select the broken 5.20.x line.

## Fix

Cap the constraint below the regression so provider resolution stays on the known-good line:

```hcl
version = ">= 5.16, < 5.20.0"
```

The committed lock file already pinned `5.19.1`; this change keeps it there and updates the recorded `constraints` metadata to match (plus an additive cross-platform hash). When the upstream fix ships we can lift the cap.

## Verification

- `terraform init -backend=false` resolves cloudflare to **v5.19.1** (5.20.x excluded) ✅
- `terraform fmt -check` passes ✅

## Credit

Diagnosis and workaround by @tvi in #750. 🙏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cloudflare Terraform provider version constraints to `>= 5.16, < 5.20.0` in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->