### PR TITLE
fix: await installed repo resolution

### DIFF
--- a/packages/control-plane/src/routes/shared.ts
+++ b/packages/control-plane/src/routes/shared.ts
@@ -74,7 +74,8 @@ export async function resolveInstalledRepo(
   repoOwner: string,
   repoName: string
 ): Promise<RepositoryAccessResult | null> {
-  return provider.checkRepositoryAccess({ owner: repoOwner, name: repoName });
+  const result = await provider.checkRepositoryAccess({ owner: repoOwner, name: repoName });
+  return result;
 }
 
 /**

--- a/packages/control-plane/test/integration/resolve-installed-repo.test.ts
+++ b/packages/control-plane/test/integration/resolve-installed-repo.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { env } from "cloudflare:test";
+import { createRouteSourceControlProvider, resolveInstalledRepo } from "../../src/routes/shared";
+
+describe("resolveInstalledRepo", () => {
+  it("handles a missing GitHub App configuration without leaking an unhandled rejection", async () => {
+    const provider = createRouteSourceControlProvider(env);
+
+    await expect(resolveInstalledRepo(provider, "acme", "web")).rejects.toThrow(
+      "GitHub App not configured"
+    );
+  });
+});

--- a/packages/control-plane/test/integration/resolve-installed-repo.test.ts
+++ b/packages/control-plane/test/integration/resolve-installed-repo.test.ts
@@ -5,9 +5,23 @@ import { createRouteSourceControlProvider, resolveInstalledRepo } from "../../sr
 describe("resolveInstalledRepo", () => {
   it("handles a missing GitHub App configuration without leaking an unhandled rejection", async () => {
     const provider = createRouteSourceControlProvider(env);
+    const unhandled: unknown[] = [];
+    const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+      unhandled.push(event.reason);
+      event.preventDefault();
+    };
 
-    await expect(resolveInstalledRepo(provider, "acme", "web")).rejects.toThrow(
-      "GitHub App not configured"
-    );
+    addEventListener("unhandledrejection", onUnhandledRejection);
+    try {
+      await expect(resolveInstalledRepo(provider, "acme", "web")).rejects.toThrow(
+        "GitHub App not configured"
+      );
+
+      await scheduler.wait(0);
+
+      expect(unhandled).toEqual([]);
+    } finally {
+      removeEventListener("unhandledrejection", onUnhandledRejection);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Await `checkRepositoryAccess` inside `resolveInstalledRepo` so synchronously rejected provider promises are handled immediately.
- Add a workers integration regression test for the missing GitHub App configuration path.

## Verification
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/resolve-installed-repo.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/eb33037b275a5187001c7ca0d7e644f2)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated repository access resolution to use a clearer async flow while preserving existing behavior.

* **Tests**
  * Added an integration test covering missing GitHub App configuration, confirming the expected failure message is returned and that no unhandled promise rejection occurs during resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->