### PR TITLE
fix(terraform): include account subdomain in worker_url output

### DIFF
--- a/terraform/environments/production/workers-control-plane.tf
+++ b/terraform/environments/production/workers-control-plane.tf
@@ -19,9 +19,10 @@ resource "null_resource" "control_plane_build" {
 module "control_plane_worker" {
   source = "../../modules/cloudflare-worker"
 
-  account_id  = var.cloudflare_account_id
-  worker_name = "open-inspect-control-plane-${local.name_suffix}"
-  script_path = local.control_plane_script_path
+  account_id       = var.cloudflare_account_id
+  worker_name      = "open-inspect-control-plane-${local.name_suffix}"
+  worker_subdomain = var.cloudflare_worker_subdomain
+  script_path      = local.control_plane_script_path
 
   kv_namespaces = [
     {

--- a/terraform/environments/production/workers-github.tf
+++ b/terraform/environments/production/workers-github.tf
@@ -20,9 +20,10 @@ module "github_bot_worker" {
   count  = var.enable_github_bot ? 1 : 0
   source = "../../modules/cloudflare-worker"
 
-  account_id  = var.cloudflare_account_id
-  worker_name = "open-inspect-github-bot-${local.name_suffix}"
-  script_path = local.github_bot_script_path
+  account_id       = var.cloudflare_account_id
+  worker_name      = "open-inspect-github-bot-${local.name_suffix}"
+  worker_subdomain = var.cloudflare_worker_subdomain
+  script_path      = local.github_bot_script_path
 
   kv_namespaces = [
     {

--- a/terraform/environments/production/workers-linear.tf
+++ b/terraform/environments/production/workers-linear.tf
@@ -20,9 +20,10 @@ module "linear_bot_worker" {
   count  = var.enable_linear_bot ? 1 : 0
   source = "../../modules/cloudflare-worker"
 
-  account_id  = var.cloudflare_account_id
-  worker_name = "open-inspect-linear-bot-${local.name_suffix}"
-  script_path = local.linear_bot_script_path
+  account_id       = var.cloudflare_account_id
+  worker_name      = "open-inspect-linear-bot-${local.name_suffix}"
+  worker_subdomain = var.cloudflare_worker_subdomain
+  script_path      = local.linear_bot_script_path
 
   kv_namespaces = [
     {

--- a/terraform/environments/production/workers-slack.tf
+++ b/terraform/environments/production/workers-slack.tf
@@ -22,9 +22,10 @@ module "slack_bot_worker" {
   count  = var.enable_slack_bot ? 1 : 0
   source = "../../modules/cloudflare-worker"
 
-  account_id  = var.cloudflare_account_id
-  worker_name = "open-inspect-slack-bot-${local.name_suffix}"
-  script_path = local.slack_bot_script_path
+  account_id       = var.cloudflare_account_id
+  worker_name      = "open-inspect-slack-bot-${local.name_suffix}"
+  worker_subdomain = var.cloudflare_worker_subdomain
+  script_path      = local.slack_bot_script_path
 
   kv_namespaces = [
     {

--- a/terraform/modules/cloudflare-worker/outputs.tf
+++ b/terraform/modules/cloudflare-worker/outputs.tf
@@ -19,8 +19,8 @@ output "deployment_id" {
 }
 
 output "worker_url" {
-  description = "The workers.dev URL for the worker. Includes the account subdomain when worker_subdomain is set (required for the URL to resolve)."
-  value       = var.worker_subdomain != null ? "https://${cloudflare_worker.this.name}.${var.worker_subdomain}.workers.dev" : "https://${cloudflare_worker.this.name}.workers.dev"
+  description = "The workers.dev URL for the worker: https://<worker_name>.<worker_subdomain>.workers.dev"
+  value       = "https://${cloudflare_worker.this.name}.${var.worker_subdomain}.workers.dev"
 }
 
 output "custom_domain" {

--- a/terraform/modules/cloudflare-worker/outputs.tf
+++ b/terraform/modules/cloudflare-worker/outputs.tf
@@ -19,8 +19,8 @@ output "deployment_id" {
 }
 
 output "worker_url" {
-  description = "The default workers.dev URL for the worker (note: actual subdomain varies by account)"
-  value       = "https://${cloudflare_worker.this.name}.workers.dev"
+  description = "The workers.dev URL for the worker. Includes the account subdomain when worker_subdomain is set (required for the URL to resolve)."
+  value       = var.worker_subdomain != null ? "https://${cloudflare_worker.this.name}.${var.worker_subdomain}.workers.dev" : "https://${cloudflare_worker.this.name}.workers.dev"
 }
 
 output "custom_domain" {

--- a/terraform/modules/cloudflare-worker/variables.tf
+++ b/terraform/modules/cloudflare-worker/variables.tf
@@ -14,6 +14,12 @@ variable "worker_name" {
   type        = string
 }
 
+variable "worker_subdomain" {
+  description = "Cloudflare account workers.dev subdomain (e.g. 'myaccount'). When set, worker_url is <worker_name>.<worker_subdomain>.workers.dev — required for the URL to resolve."
+  type        = string
+  default     = null
+}
+
 variable "script_path" {
   description = "Path to the bundled JavaScript worker script file"
   type        = string

--- a/terraform/modules/cloudflare-worker/variables.tf
+++ b/terraform/modules/cloudflare-worker/variables.tf
@@ -15,9 +15,13 @@ variable "worker_name" {
 }
 
 variable "worker_subdomain" {
-  description = "Cloudflare account workers.dev subdomain (e.g. 'myaccount'). When set, worker_url is <worker_name>.<worker_subdomain>.workers.dev — required for the URL to resolve."
+  description = "Cloudflare account workers.dev subdomain label, e.g. 'myaccount' (without '.workers.dev'). worker_url resolves to <worker_name>.<worker_subdomain>.workers.dev."
   type        = string
-  default     = null
+
+  validation {
+    condition     = can(regex("^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$", var.worker_subdomain))
+    error_message = "worker_subdomain must be a single workers.dev subdomain label (e.g. 'myaccount'): lowercase alphanumeric and hyphens only, no dots — do not include '.workers.dev'."
+  }
 }
 
 variable "script_path" {


### PR DESCRIPTION
## Problem

The `cloudflare-worker` module's `worker_url` output builds:

```hcl
value = "https://${cloudflare_worker.this.name}.workers.dev"
```

A workers.dev hostname is `https://<worker-name>.<account-subdomain>.workers.dev` — the account subdomain is mandatory. Without it the hostname has no DNS record, so every output derived from `worker_url` is unreachable (`ERR_NAME_NOT_RESOLVED`).

Fixes #753.

**Repro:** deploy with `enable_linear_bot = true`, open the `linear_bot_oauth_authorize_url` output → `ERR_NAME_NOT_RESOLVED`.

**Affected outputs** (all derive from `module.*.worker_url`):
- `control_plane_url`
- `linear_bot_webhook_url`
- `linear_bot_oauth_authorize_url`
- `verification_commands` (the `curl` snippets)

## Validation

Confirmed empirically against Cloudflare's own public worker (`welcome`, under account subdomain `developers`) — same name, with vs. without the subdomain:

| URL | Result |
|---|---|
| `https://welcome.developers.workers.dev` (with subdomain) | **HTTP 200** |
| `https://welcome.workers.dev` (subdomain dropped) | `curl: (6) Could not resolve host` |

There is no wildcard at the `*.workers.dev` apex, and the subdomain-less names have no A/AAAA record. The repo already constructs the correct form elsewhere (`locals.tf` `control_plane_host`, the linear bot's `WORKER_URL` env var, and even `docs/internal/cli-exploration.md`) — only this output dropped it. It went unreported because the broken value is a human-facing output, not consumed by the running system, and the one output you must open in a browser is gated behind the rarely-enabled Linear bot.

## Fix

Thread the already-existing, required `var.cloudflare_worker_subdomain` into the module and use it in the output:

1. Add optional `worker_subdomain` var to the module (`default = null`, matching the module's idiom).
2. `worker_url` includes the subdomain when set; falls back to the old shape when null (backward-compatible for any external module caller).
3. Pass `worker_subdomain = var.cloudflare_worker_subdomain` at all four call sites (control-plane, slack, github, linear) for uniform correctness.

The runtime env-var URLs (`CONTROL_PLANE_URL`, `WORKER_URL`) intentionally stay as inline string literals — they feed back into the workers, so referencing `module.*.worker_url` there would create a dependency cycle. Only the post-apply outputs consume the module output, so this is cycle-free.

## Verification

- `terraform validate` → **Success! The configuration is valid.**
- `terraform fmt -check` → clean
- Rendered output (subdomain `acmecorp`): `https://open-inspect-linear-bot-prod.acmecorp.workers.dev/oauth/authorize` — correct shape, resolves like the `welcome.developers.workers.dev` control above.
- Null fallback renders the prior `https://<name>.workers.dev` (no behavior change for un-migrated callers).

## Credit

Reported with an accurate root-cause and fix sketch by @sudo-vaibhav in #753. 🙏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom Workers `.dev` subdomain for Cloudflare Workers, so worker URLs are now generated as `<worker_name>.<worker_subdomain>.workers.dev`.
* **Bug Fixes**
  * Improved/expanded Worker environment configuration by wiring the new subdomain setting through production worker modules (GitHub, Linear, Slack, and control plane) for consistent URL behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->