### PR TITLE
refactor(web): introduce tool renderer registry

### DIFF
--- a/packages/web/src/components/tool-call-item.tsx
+++ b/packages/web/src/components/tool-call-item.tsx
@@ -23,6 +23,11 @@ interface ToolCallItemProps {
   showTime?: boolean;
 }
 
+//Registry
+const TOOL_RENDERERS: Record<string, React.ComponentType<ToolCallItemProps>> = {
+  "slack-notify": SlackNotifyEvent,
+};
+
 function ToolIcon({ name }: { name: string | null }) {
   if (!name) return null;
 
@@ -51,14 +56,11 @@ function ToolIcon({ name }: { name: string | null }) {
 }
 
 export function ToolCallItem({ event, isExpanded, onToggle, showTime = true }: ToolCallItemProps) {
-  if (event.tool === "slack-notify") {
+  const Renderer = TOOL_RENDERERS[event.tool];
+
+  if (Renderer) {
     return (
-      <SlackNotifyEvent
-        event={event}
-        isExpanded={isExpanded}
-        onToggle={onToggle}
-        showTime={showTime}
-      />
+      <Renderer event={event} isExpanded={isExpanded} onToggle={onToggle} showTime={showTime} />
     );
   }
 


### PR DESCRIPTION
## Summary

Introduce a simple tool renderer registry and migrate the existing `slack-notify` custom renderer to use it.

## Changes

* Added a `TOOL_RENDERERS` registry mapping tool names to custom renderer components.
* Replaced the hardcoded `slack-notify` conditional in `ToolCallItem` with a registry lookup.
* Preserved the existing generic rendering path for tools without a registered custom renderer.
* Typed the registry using `React.ComponentType<ToolCallItemProps>` to support future custom renderers.

## Motivation

This is a first step toward supporting additional custom tool renderers without adding more tool-specific conditionals inside `ToolCallItem`.

With this structure in place, future renderers (such as `get-task-status`) can be added by registering a component rather than modifying the core rendering logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated tool rendering logic to streamline how different tool types are handled within the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->