### PR TITLE
fix: update hono security dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1986,6 +1986,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
       "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2716,6 +2717,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2738,6 +2740,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2760,6 +2763,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2776,6 +2780,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2792,6 +2797,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2808,6 +2814,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2824,6 +2831,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2840,6 +2848,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2856,6 +2865,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2872,6 +2882,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2888,6 +2899,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2904,6 +2916,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2920,6 +2933,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2942,6 +2956,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2964,6 +2979,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2986,6 +3002,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3008,6 +3025,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3030,6 +3048,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3052,6 +3071,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3074,6 +3094,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3096,6 +3117,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -3115,6 +3137,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3134,6 +3157,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3153,6 +3177,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -10368,15 +10393,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.9.0"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -18477,7 +18493,7 @@
       "dependencies": {
         "@cloudflare/workers-types": "^4.20241230.0",
         "@open-inspect/shared": "file:../shared",
-        "hono": "^4.12.18"
+        "hono": "^4.12.26"
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.0",
@@ -19104,6 +19120,15 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "packages/github-bot/node_modules/hono": {
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "packages/github-bot/node_modules/std-env": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
@@ -19254,7 +19279,7 @@
       "dependencies": {
         "@cloudflare/workers-types": "^4.20241230.0",
         "@open-inspect/shared": "file:../shared",
-        "hono": "^4.12.18"
+        "hono": "^4.12.26"
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.0",
@@ -19882,6 +19907,15 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "packages/linear-bot/node_modules/hono": {
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "packages/linear-bot/node_modules/std-env": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
@@ -20302,7 +20336,7 @@
         "@anthropic-ai/sdk": "^0.39.0",
         "@cloudflare/workers-types": "^4.20241230.0",
         "@open-inspect/shared": "file:../shared",
-        "hono": "^4.12.18"
+        "hono": "^4.12.26"
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^4.1.0",
@@ -20928,6 +20962,15 @@
         "@esbuild/win32-arm64": "0.28.1",
         "@esbuild/win32-ia32": "0.28.1",
         "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "packages/slack-bot/node_modules/hono": {
+      "version": "4.12.26",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "packages/slack-bot/node_modules/std-env": {

--- a/packages/github-bot/package.json
+++ b/packages/github-bot/package.json
@@ -14,12 +14,12 @@
   "dependencies": {
     "@cloudflare/workers-types": "^4.20241230.0",
     "@open-inspect/shared": "file:../shared",
-    "hono": "^4.12.18"
+    "hono": "^4.12.26"
   },
   "devDependencies": {
+    "@vitest/coverage-v8": "^4.1.0",
     "esbuild": "^0.28.1",
     "typescript": "^5.7.2",
-    "@vitest/coverage-v8": "^4.1.0",
     "vitest": "^4.1.0"
   }
 }

--- a/packages/linear-bot/package.json
+++ b/packages/linear-bot/package.json
@@ -15,12 +15,12 @@
   "dependencies": {
     "@cloudflare/workers-types": "^4.20241230.0",
     "@open-inspect/shared": "file:../shared",
-    "hono": "^4.12.18"
+    "hono": "^4.12.26"
   },
   "devDependencies": {
+    "@vitest/coverage-v8": "^4.1.0",
     "esbuild": "^0.28.1",
     "typescript": "^5.7.2",
-    "@vitest/coverage-v8": "^4.1.0",
     "vitest": "^4.1.0",
     "wrangler": "^4.0.0"
   }

--- a/packages/slack-bot/package.json
+++ b/packages/slack-bot/package.json
@@ -16,12 +16,12 @@
     "@anthropic-ai/sdk": "^0.39.0",
     "@cloudflare/workers-types": "^4.20241230.0",
     "@open-inspect/shared": "file:../shared",
-    "hono": "^4.12.18"
+    "hono": "^4.12.26"
   },
   "devDependencies": {
+    "@vitest/coverage-v8": "^4.1.0",
     "esbuild": "^0.28.1",
     "typescript": "^5.7.2",
-    "@vitest/coverage-v8": "^4.1.0",
     "vitest": "^4.1.0",
     "wrangler": "^4.0.0"
   }


### PR DESCRIPTION
## Summary
- Update Hono in the GitHub, Slack, and Linear bot workspaces to `^4.12.26` to resolve the Dependabot security advisory affecting versions below `4.12.25`.
- Regenerate the npm lockfile for the workspace dependency changes.

## Verification
- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/github-bot`
- `npm run typecheck -w @open-inspect/slack-bot`
- `npm run typecheck -w @open-inspect/linear-bot`
- `npm test -w @open-inspect/github-bot`
- `npm test -w @open-inspect/slack-bot`
- `npm test -w @open-inspect/linear-bot`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/deb6256afd8f17000a2a2be35841b743)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `hono` dependency to version `4.12.26` across the github-bot, linear-bot, and slack-bot packages
  * Reorganized development dependency ordering for improved consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->