### PR TITLE
test: serialize integration suite to fix flaky scheduler tick tests

### DIFF
--- a/packages/control-plane/test/integration/scheduler.test.ts
+++ b/packages/control-plane/test/integration/scheduler.test.ts
@@ -345,11 +345,18 @@ describe("SchedulerDO (integration)", () => {
       const body = await res.json<{ processed: number; skipped: number; failed: number }>();
       expect(body.skipped).toBeGreaterThanOrEqual(1);
 
-      // Verify a skipped run was created
+      // Assert on the automation this test owns rather than only the tick's
+      // global counters: auto-t3 must get exactly one skipped run with the
+      // concurrency reason, and its schedule must advance into the future so it
+      // isn't re-skipped on every later tick.
       const runs = await store.listRunsForAutomation("auto-t3", { limit: 10, offset: 0 });
-      const skippedRun = runs.runs.find((r) => r.status === "skipped");
-      expect(skippedRun).toBeDefined();
-      expect(skippedRun!.skip_reason).toBe("concurrent_run_active");
+      const skippedRuns = runs.runs.filter((r) => r.status === "skipped");
+      expect(skippedRuns).toHaveLength(1);
+      expect(skippedRuns[0]!.skip_reason).toBe("concurrent_run_active");
+
+      const advanced = await store.getById("auto-t3");
+      expect(advanced!.next_run_at).not.toBeNull();
+      expect(advanced!.next_run_at!).toBeGreaterThan(now);
     });
 
     it("processes overdue automations (creates run, advances schedule)", async () => {
@@ -369,19 +376,18 @@ describe("SchedulerDO (integration)", () => {
       expect(res.status).toBe(200);
 
       const body = await res.json<{ processed: number; skipped: number; failed: number }>();
-      // The automation will be picked up. Session creation in test env may succeed
-      // or fail — either way a run is created and schedule is advanced.
-      const totalHandled = body.processed + body.failed;
-      expect(totalHandled).toBeGreaterThanOrEqual(1);
+      expect(body.processed + body.failed).toBeGreaterThanOrEqual(1);
 
-      // Verify schedule was advanced (next_run_at should be in the future)
+      // Assert on auto-t4 specifically rather than the tick's global counters.
+      // Session creation may succeed or fail in the test env; either way the
+      // automation must get exactly one run and its schedule must advance into
+      // the future so it isn't reprocessed on the next tick.
+      const runs = await store.listRunsForAutomation("auto-t4", { limit: 10, offset: 0 });
+      expect(runs.runs).toHaveLength(1);
+
       const automation = await store.getById("auto-t4");
       expect(automation!.next_run_at).not.toBeNull();
       expect(automation!.next_run_at!).toBeGreaterThan(now);
-
-      // Verify a run was created
-      const runs = await store.listRunsForAutomation("auto-t4", { limit: 10, offset: 0 });
-      expect(runs.total).toBeGreaterThanOrEqual(1);
     });
 
     it("auto-pauses after recovery sweep detects 3rd consecutive failure", async () => {

--- a/packages/control-plane/vitest.integration.config.ts
+++ b/packages/control-plane/vitest.integration.config.ts
@@ -17,6 +17,8 @@ function generateTestEncryptionKey(): string {
 // "vitest/config". The old `singleWorker`/`isolatedStorage` poolOptions are not
 // configured here; integration tests share one D1 instance and rely on explicit
 // `cleanD1Tables()` cleanup (see test/integration/cleanup.ts) for isolation.
+// That cleanup-based isolation only holds when files run one at a time — see
+// `fileParallelism: false` below.
 export default defineConfig({
   plugins: [
     cloudflareTest(async () => {
@@ -46,5 +48,13 @@ export default defineConfig({
   test: {
     include: ["test/integration/**/*.test.ts"],
     setupFiles: ["test/integration/apply-migrations.ts"],
+    // Run integration files serially. They share a single D1 instance, so
+    // running them in parallel lets one file's beforeEach `cleanD1Tables()`
+    // DELETE rows another file just seeded. The scheduler tick scans automations
+    // globally (getOverdueAutomations + an unconditional DELETE in cleanup), so
+    // concurrent files made its tick tests flaky (an overdue automation could
+    // vanish mid-tick). Serial execution is what makes cleanup-based isolation
+    // actually hold.
+    fileParallelism: false,
   },
 });


### PR DESCRIPTION
## Problem

The `Test (control-plane integration)` job intermittently fails on two scheduler tick tests in `test/integration/scheduler.test.ts`:

- `skips overdue automations with active runs (concurrency guard)` → `expect(body.skipped).toBeGreaterThanOrEqual(1)` gets `0`
- `processes overdue automations (creates run, advances schedule)` → `expect(automation!.next_run_at!).toBeGreaterThan(now)` gets `now - 60000` (the seeded value, **unadvanced**)

Both symptoms mean the overdue automation the test seeded was never processed by `/internal/tick`.

This most recently surfaced on dependabot **#748** (a lockfile-only bump of `form-data` / `js-yaml` / `vite`). Those deps don't touch the scheduler/D1/time path at all — the failure is a pre-existing flake, not a regression from the bump.

## Root cause

Integration files share **one** D1 instance and rely on `cleanD1Tables()` in `beforeEach` for isolation (see the comment in `vitest.integration.config.ts`). But the suite ran files **in parallel** — `setup 54.77s` of CPU against `7.84s` wall-clock at ~292% CPU = ~3 workerd workers concurrently.

Four files write to the shared `automations` table (`scheduler`, `scheduler-events`, `webhooks`, `automation-store`). So while `scheduler.test.ts` seeds an overdue automation and ticks:

- another file's `beforeEach(cleanD1Tables)` can `DELETE FROM automations` mid-flight, and
- the scheduler's `getOverdueAutomations()` scans **globally**, so the tick also sees/handles foreign rows.

Cleanup-in-`beforeEach` only isolates tests if files run **one at a time** — which the config assumed but never enforced.

## Fix

1. **`vitest.integration.config.ts` — `fileParallelism: false`** (the root fix). Makes the cleanup-based isolation the suite already documents actually hold. Cost: integration suite wall-clock ~8s → ~19s (setup CPU drops 54.77s → 8.49s); correctness over speed for integration tests.
2. **`scheduler.test.ts` — scope assertions to the seeded automation.** Assert on the specific automation's run(s) and advanced schedule rather than the tick's global `body.skipped` / `body.processed+failed` counters, and additionally verify the concurrency-skip path advances `next_run_at` (previously unchecked). Defense-in-depth even if parallelism is ever re-enabled.

## Verification

- Full integration suite: **31 files / 370 tests pass**, now serial.
- `scheduler.test.ts` run 6× back-to-back: stable.
- `typecheck`, `prettier --check`, `eslint`: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test assertions for scheduler behavior to verify automation-scoped run tracking and state advancement.

* **Chores**
  * Updated integration test configuration to enforce serial execution for reliable database cleanup isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->