### PR TITLE
feat(slack-bot): repo quick-picks in clarification picker (follow-up to #702)

### DIFF
--- a/packages/slack-bot/src/app-home/interactions.ts
+++ b/packages/slack-bot/src/app-home/interactions.ts
@@ -11,7 +11,7 @@ import {
   isBranchModalCallbackId,
   saveUserRepoBranchPreference,
 } from "../branch-preferences";
-import { getAvailableRepos } from "../classifier/repos";
+import { filterReposByQuery, getAvailableRepos } from "../classifier/repos";
 import { createLogger } from "../logger";
 import type { Env, SlackInteractionPayload } from "../types";
 import {
@@ -78,11 +78,7 @@ export async function getRepoBranchSuggestionOptions(
     getAvailableRepos(env, traceId),
     getUserRepoBranchPreferences(env, userId),
   ]);
-  const normalizedQuery = query?.trim().toLowerCase();
-
-  const filteredRepos = normalizedQuery
-    ? repos.filter((repo) => repo.fullName.toLowerCase().includes(normalizedQuery))
-    : repos;
+  const filteredRepos = filterReposByQuery(repos, query);
 
   return buildRepoBranchSelectOptions(filteredRepos, repoBranchPreferences).slice(
     0,
@@ -119,9 +115,18 @@ export async function handleAppHomeInteractionRoute(
       return null;
     }
 
-    const options = payload.user?.id
-      ? await getRepoBranchSuggestionOptions(env, payload.user.id, payload.value, traceId)
-      : [];
+    let options: SlackSelectOption[] = [];
+    try {
+      options = payload.user?.id
+        ? await getRepoBranchSuggestionOptions(env, payload.user.id, payload.value, traceId)
+        : [];
+    } catch (e) {
+      // A repo-lookup failure must not surface as a 500 on /interactions.
+      log.error("slack.repo_branch_suggestion_options", {
+        trace_id: traceId,
+        error: e instanceof Error ? e : new Error(String(e)),
+      });
+    }
 
     return {
       body: { options },

--- a/packages/slack-bot/src/app-home/slack-types.ts
+++ b/packages/slack-bot/src/app-home/slack-types.ts
@@ -5,7 +5,11 @@ export interface ModelOption {
   value: string;
 }
 
-export type SlackSelectOption = { text: SlackPlainText; value: string };
+export type SlackSelectOption = {
+  text: SlackPlainText;
+  description?: SlackPlainText;
+  value: string;
+};
 export type SlackPlainText = { type: "plain_text"; text: string };
 export type SlackMrkdwnText = { type: "mrkdwn"; text: string };
 export type SlackText = SlackPlainText | SlackMrkdwnText;

--- a/packages/slack-bot/src/app-home/slack-types.ts
+++ b/packages/slack-bot/src/app-home/slack-types.ts
@@ -60,7 +60,9 @@ export type SlackHeaderBlock = { type: "header"; text: SlackPlainText };
 export type SlackSectionBlock = {
   type: "section";
   text: SlackText;
-  accessory?: SlackButtonElement;
+  // A section accessory may be a button or a select (the repo clarification
+  // picker uses an external_select), not only a button.
+  accessory?: SlackBlockElement;
 };
 export type SlackActionsBlock = {
   type: "actions";

--- a/packages/slack-bot/src/app-home/view.ts
+++ b/packages/slack-bot/src/app-home/view.ts
@@ -9,6 +9,7 @@ import {
   SELECT_REASONING_EFFORT_ACTION_ID,
 } from "./constants";
 import type { AppHomeBlock, AppHomeView, ModelOption, SlackSelectOption } from "./slack-types";
+import { plainTextOption } from "../slack-options";
 
 export interface AppHomeViewState {
   appName: string;
@@ -25,16 +26,6 @@ type ConfiguredRepoOverride = {
   branch: string;
 };
 
-const SELECT_OPTION_TEXT_LIMIT = 75;
-
-function truncateSelectOptionText(text: string): string {
-  if (text.length <= SELECT_OPTION_TEXT_LIMIT) {
-    return text;
-  }
-
-  return `${text.slice(0, SELECT_OPTION_TEXT_LIMIT - 1)}…`;
-}
-
 export function buildAppHomeIntroText(appName: string): string {
   return `Configure your ${appName} preferences below.`;
 }
@@ -47,10 +38,7 @@ export function buildRepoBranchSelectOptions(
     const repoBranch = repoBranchPreferences.get(repo.id);
     const label = repoBranch ? `${repo.fullName} → ${repoBranch}` : repo.fullName;
     return {
-      text: {
-        type: "plain_text" as const,
-        text: truncateSelectOptionText(label),
-      },
+      text: plainTextOption(label),
       value: repo.id,
     };
   });
@@ -58,7 +46,7 @@ export function buildRepoBranchSelectOptions(
 
 function toSelectOption(model: ModelOption): SlackSelectOption {
   return {
-    text: { type: "plain_text", text: truncateSelectOptionText(model.label) },
+    text: plainTextOption(model.label),
     value: model.value,
   };
 }

--- a/packages/slack-bot/src/classifier/repos.ts
+++ b/packages/slack-bot/src/classifier/repos.ts
@@ -179,6 +179,19 @@ async function getFromCacheOrFallback(env: Env): Promise<RepoConfig[]> {
 }
 
 /**
+ * Filter repos by a free-text query against their full name (case-insensitive).
+ * Returns all repos when the query is empty — the canonical filter shared by the
+ * clarification picker and the App Home branch picker.
+ */
+export function filterReposByQuery(repos: RepoConfig[], query: string | undefined): RepoConfig[] {
+  const normalizedQuery = query?.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return repos;
+  }
+  return repos.filter((repo) => repo.fullName.toLowerCase().includes(normalizedQuery));
+}
+
+/**
  * Find a repository by owner and name.
  */
 export async function getRepoByFullName(

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -109,6 +109,41 @@ function makeCtx() {
   } as any;
 }
 
+/** Build N numbered repos (acme/repo-001 …) for picker/suggestion tests. */
+function buildNumberedRepos(count: number) {
+  return Array.from({ length: count }, (_, idx) => {
+    const number = String(idx + 1).padStart(3, "0");
+    return {
+      id: `acme/repo-${number}`,
+      owner: "acme",
+      name: `repo-${number}`,
+      fullName: `acme/repo-${number}`,
+      defaultBranch: "main",
+      private: true,
+    };
+  });
+}
+
+/** Point CONTROL_PLANE.fetch at a fixed repo list (other routes return enabledModels). */
+function mockReposFetch(env: Env, repos: unknown[]) {
+  (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+    async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("/repos")) {
+        return new Response(JSON.stringify({ repos }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+  );
+}
+
 function createDeferred<T>() {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((resolver) => {
@@ -1461,34 +1496,8 @@ describe("POST /interactions", () => {
     });
 
     const env = makeEnv();
-    const repos = Array.from({ length: 150 }, (_, idx) => {
-      const number = String(idx + 1).padStart(3, "0");
-      return {
-        id: `acme/repo-${number}`,
-        owner: "acme",
-        name: `repo-${number}`,
-        fullName: `acme/repo-${number}`,
-        defaultBranch: "main",
-        private: true,
-      };
-    });
-
-    (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-      async (input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url.includes("/repos")) {
-          return new Response(JSON.stringify({ repos }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-
-        return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
-      }
-    );
+    const repos = buildNumberedRepos(150);
+    mockReposFetch(env, repos);
 
     const ctx = makeCtx();
     const response = await app.fetch(request, env, ctx);
@@ -1505,6 +1514,48 @@ describe("POST /interactions", () => {
         value: "acme/repo-150",
       },
     ]);
+  });
+
+  it("routes a quick-pick button click through repo selection", async () => {
+    const slackFetch = mockSlackFetch([]);
+    const env = makeEnv();
+    // No pending message stored, so repo selection reports it can't find the request —
+    // which proves the quick-pick button routed into the same handler as the picker.
+
+    const payload = {
+      type: "block_actions",
+      user: { id: "U123" },
+      channel: { id: "C123" },
+      message: { ts: "111.222" },
+      actions: [
+        {
+          action_id: "select_repo_quick_pick",
+          value: "acme/app",
+        },
+      ],
+    };
+    const request = new Request("http://localhost/interactions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "x-slack-signature": "v0=test",
+        "x-slack-request-timestamp": `${Math.floor(Date.now() / 1000)}`,
+      },
+      body: new URLSearchParams({ payload: JSON.stringify(payload) }),
+    });
+    const ctx = makeCtx();
+
+    const response = await app.fetch(request, env, ctx);
+    expect(response.status).toBe(200);
+
+    await flushWaitUntil(ctx);
+
+    const postBodies = slackApiBodies(slackFetch, "chat.postMessage");
+    expect(
+      postBodies.some((body) => String(body.text).includes("couldn't find your original request"))
+    ).toBe(true);
+
+    slackFetch.mockRestore();
   });
 
   it("returns all repos (beyond the old 5-item limit) for the repo clarification picker", async () => {
@@ -1526,34 +1577,8 @@ describe("POST /interactions", () => {
     });
 
     const env = makeEnv();
-    const repos = Array.from({ length: 150 }, (_, idx) => {
-      const number = String(idx + 1).padStart(3, "0");
-      return {
-        id: `acme/repo-${number}`,
-        owner: "acme",
-        name: `repo-${number}`,
-        fullName: `acme/repo-${number}`,
-        defaultBranch: "main",
-        private: true,
-      };
-    });
-
-    (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-      async (input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url.includes("/repos")) {
-          return new Response(JSON.stringify({ repos }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-
-        return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
-      }
-    );
+    const repos = buildNumberedRepos(150);
+    mockReposFetch(env, repos);
 
     const ctx = makeCtx();
     const response = await app.fetch(request, env, ctx);
@@ -1593,34 +1618,8 @@ describe("POST /interactions", () => {
     });
 
     const env = makeEnv();
-    const repos = Array.from({ length: 150 }, (_, idx) => {
-      const number = String(idx + 1).padStart(3, "0");
-      return {
-        id: `acme/repo-${number}`,
-        owner: "acme",
-        name: `repo-${number}`,
-        fullName: `acme/repo-${number}`,
-        defaultBranch: "main",
-        private: true,
-      };
-    });
-
-    (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-      async (input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url.includes("/repos")) {
-          return new Response(JSON.stringify({ repos }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-
-        return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
-      }
-    );
+    const repos = buildNumberedRepos(150);
+    mockReposFetch(env, repos);
 
     const ctx = makeCtx();
     const response = await app.fetch(request, env, ctx);

--- a/packages/slack-bot/src/index.ts
+++ b/packages/slack-bot/src/index.ts
@@ -33,41 +33,17 @@ import { createKvCacheStore } from "@open-inspect/shared";
 import { getUserRepoBranchPreference } from "./branch-preferences";
 import { setAssistantThreadStatusBestEffort } from "./activity-status";
 import { handleAppHomeInteractionRoute, publishAppHome } from "./app-home";
-import { MAX_REPO_SUGGESTION_OPTIONS } from "./app-home/constants";
+import {
+  SELECT_REPO_ACTION_ID,
+  SELECT_REPO_QUICK_PICK_ACTION_ID,
+  getRepoClarificationOptions,
+  buildRepoClarificationBlocks,
+} from "./repo-clarification";
 import { getResolvedUserPreferences } from "./user-preferences";
 
 const log = createLogger("handler");
 
 type BackgroundTaskScheduler = (promise: Promise<void>) => void;
-
-/**
- * Action ID for the repository picker shown when the classifier can't decide
- * which repo a message refers to. The picker is an external_select, so the same
- * ID is matched both for option suggestions (block_suggestion) and selection
- * (block_actions).
- */
-const SELECT_REPO_ACTION_ID = "select_repo";
-
-/**
- * Repo options for the clarification picker's external_select. Slack queries
- * this endpoint as the user types; we filter on the repo's full name and cap
- * the count at Slack's per-response limit. With min_query_length 0 the
- * unfiltered list shows as soon as the menu opens, and typing surfaces any of
- * the remaining repos — so users are no longer limited to a fixed handful.
- */
-async function getRepoClarificationOptions(env: Env, query: string | undefined, traceId?: string) {
-  const repos = await getAvailableRepos(env, traceId);
-  const normalizedQuery = query?.trim().toLowerCase();
-  const filtered = normalizedQuery
-    ? repos.filter((repo) => repo.fullName.toLowerCase().includes(normalizedQuery))
-    : repos;
-
-  return filtered.slice(0, MAX_REPO_SUGGESTION_OPTIONS).map((repo) => ({
-    text: { type: "plain_text" as const, text: repo.displayName },
-    description: { type: "plain_text" as const, text: repo.description.slice(0, 75) },
-    value: repo.id,
-  }));
-}
 
 /**
  * Build authenticated headers for control plane requests.
@@ -636,33 +612,31 @@ app.post("/interactions", async (c) => {
   }
 
   if (payload.type === "block_suggestion") {
-    if (payload.action_id === SELECT_REPO_ACTION_ID) {
-      let options: Awaited<ReturnType<typeof getRepoClarificationOptions>> = [];
-      try {
-        options = await getRepoClarificationOptions(c.env, payload.value, traceId);
-      } catch (e) {
-        // Don't let a lookup failure surface as a 500 on /interactions — return
-        // an empty suggestions payload so Slack just shows no matches.
-        log.error("slack.repo_clarification_options", {
-          trace_id: traceId,
-          query: payload.value,
-          error: e instanceof Error ? e : new Error(String(e)),
-          duration_ms: Date.now() - startTime,
-        });
-      }
-      log.info("http.request", {
-        trace_id: traceId,
-        http_method: "POST",
-        http_path: "/interactions",
-        http_status: 200,
-        interaction_type: payload.type,
-        action_id: payload.action_id,
-        option_count: options.length,
-        duration_ms: Date.now() - startTime,
-      });
-      return c.json({ options });
-    }
-    return c.json({ options: [] });
+    const options =
+      payload.action_id === SELECT_REPO_ACTION_ID
+        ? await getRepoClarificationOptions(c.env, payload.value, traceId).catch((e) => {
+            // A repo-lookup failure must not surface as a 500 on /interactions —
+            // return no matches instead.
+            log.error("slack.repo_clarification_options", {
+              trace_id: traceId,
+              query: payload.value,
+              error: e instanceof Error ? e : new Error(String(e)),
+              duration_ms: Date.now() - startTime,
+            });
+            return [];
+          })
+        : [];
+    log.info("http.request", {
+      trace_id: traceId,
+      http_method: "POST",
+      http_path: "/interactions",
+      http_status: 200,
+      interaction_type: payload.type,
+      action_id: payload.action_id,
+      option_count: options.length,
+      duration_ms: Date.now() - startTime,
+    });
+    return c.json({ options });
   }
 
   const actionId = payload.actions?.[0]?.action_id ?? payload.action_id;
@@ -937,32 +911,7 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
       `I couldn't determine which repository you're referring to. ${result.reasoning}`,
       {
         thread_ts: threadTs || ts,
-        blocks: [
-          {
-            type: "section",
-            text: {
-              type: "mrkdwn",
-              text: `I couldn't determine which repository you're referring to.\n\n_${result.reasoning}_`,
-            },
-          },
-          {
-            type: "section",
-            text: {
-              type: "mrkdwn",
-              text: "Which repository should I work with?",
-            },
-            accessory: {
-              type: "external_select",
-              placeholder: {
-                type: "plain_text",
-                text: "Select a repository",
-              },
-              // 0 so the list appears on open; typing filters across all repos.
-              min_query_length: 0,
-              action_id: SELECT_REPO_ACTION_ID,
-            },
-          },
-        ],
+        blocks: buildRepoClarificationBlocks(result.reasoning, result.alternatives),
       }
     );
     return;
@@ -1233,9 +1182,11 @@ async function handleSlackInteraction(
   const threadTs = payload.message?.thread_ts;
 
   switch (action.action_id) {
-    case SELECT_REPO_ACTION_ID: {
+    case SELECT_REPO_ACTION_ID:
+    case SELECT_REPO_QUICK_PICK_ACTION_ID: {
       if (!channel || !messageTs) return;
-      const repoId = action.selected_option?.value;
+      // external_select selection carries selected_option; quick-pick buttons carry value.
+      const repoId = action.selected_option?.value ?? action.value;
       if (repoId) {
         await handleRepoSelection(
           repoId,

--- a/packages/slack-bot/src/repo-clarification.test.ts
+++ b/packages/slack-bot/src/repo-clarification.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import type { RepoConfig } from "./types";
+import { filterReposByQuery } from "./classifier/repos";
+import {
+  MAX_REPO_QUICK_PICKS,
+  SELECT_REPO_QUICK_PICK_ACTION_ID,
+  buildRepoClarificationBlocks,
+  buildRepoQuickPickButtons,
+} from "./repo-clarification";
+
+function repo(fullName: string, displayName?: string): RepoConfig {
+  const [owner, name] = fullName.split("/");
+  return {
+    id: fullName,
+    owner: owner ?? "acme",
+    name: name ?? fullName,
+    fullName,
+    displayName: displayName ?? name ?? fullName,
+    description: fullName,
+    defaultBranch: "main",
+    private: true,
+  };
+}
+
+describe("filterReposByQuery", () => {
+  const repos = [repo("acme/web"), repo("acme/api"), repo("other/web-utils")];
+
+  it("returns all repos for an empty, undefined, or whitespace query", () => {
+    expect(filterReposByQuery(repos, undefined)).toHaveLength(3);
+    expect(filterReposByQuery(repos, "")).toHaveLength(3);
+    expect(filterReposByQuery(repos, "   ")).toHaveLength(3);
+  });
+
+  it("filters by case-insensitive substring of the full name", () => {
+    expect(filterReposByQuery(repos, "WEB").map((r) => r.id)).toEqual([
+      "acme/web",
+      "other/web-utils",
+    ]);
+    expect(filterReposByQuery(repos, "acme/").map((r) => r.id)).toEqual(["acme/web", "acme/api"]);
+  });
+
+  it("returns no repos when nothing matches", () => {
+    expect(filterReposByQuery(repos, "nope")).toEqual([]);
+  });
+});
+
+describe("buildRepoQuickPickButtons", () => {
+  it("maps alternatives to quick-pick buttons carrying the repo id", () => {
+    expect(buildRepoQuickPickButtons([repo("acme/web"), repo("acme/api")])).toEqual([
+      {
+        type: "button",
+        action_id: SELECT_REPO_QUICK_PICK_ACTION_ID,
+        text: { type: "plain_text", text: "web" },
+        value: "acme/web",
+      },
+      {
+        type: "button",
+        action_id: SELECT_REPO_QUICK_PICK_ACTION_ID,
+        text: { type: "plain_text", text: "api" },
+        value: "acme/api",
+      },
+    ]);
+  });
+
+  it("caps the number of buttons at MAX_REPO_QUICK_PICKS", () => {
+    const alternatives = Array.from({ length: MAX_REPO_QUICK_PICKS + 3 }, (_, idx) =>
+      repo(`acme/repo-${idx}`)
+    );
+    expect(buildRepoQuickPickButtons(alternatives)).toHaveLength(MAX_REPO_QUICK_PICKS);
+  });
+
+  it("truncates long button labels to Slack's 75-character limit", () => {
+    const [button] = buildRepoQuickPickButtons([repo("acme/long", "x".repeat(100))]);
+    expect(button.text.text).toHaveLength(75);
+    expect(button.text.text.endsWith("…")).toBe(true);
+  });
+});
+
+describe("buildRepoClarificationBlocks", () => {
+  it("renders only the searchable picker when there are no alternatives", () => {
+    const blocks = buildRepoClarificationBlocks("could not tell which repo", undefined);
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks.some((block) => block.type === "actions")).toBe(false);
+    expect(blocks).toMatchObject([
+      { type: "section", text: { text: expect.stringContaining("could not tell which repo") } },
+      {
+        type: "section",
+        text: { text: "Which repository should I work with?" },
+        accessory: { type: "external_select", action_id: "select_repo", min_query_length: 0 },
+      },
+    ]);
+  });
+
+  it("renders ranked quick-pick buttons above the picker when alternatives exist", () => {
+    const blocks = buildRepoClarificationBlocks("maybe one of these", [
+      repo("acme/web"),
+      repo("acme/api"),
+    ]);
+
+    expect(blocks).toHaveLength(3);
+    expect(blocks).toMatchObject([
+      { type: "section" },
+      {
+        type: "actions",
+        block_id: "repo_quick_picks",
+        elements: [
+          { type: "button", action_id: SELECT_REPO_QUICK_PICK_ACTION_ID, value: "acme/web" },
+          { type: "button", action_id: SELECT_REPO_QUICK_PICK_ACTION_ID, value: "acme/api" },
+        ],
+      },
+      {
+        type: "section",
+        text: { text: "Or search for another repository:" },
+        accessory: { type: "external_select", action_id: "select_repo" },
+      },
+    ]);
+  });
+});

--- a/packages/slack-bot/src/repo-clarification.test.ts
+++ b/packages/slack-bot/src/repo-clarification.test.ts
@@ -3,6 +3,7 @@ import type { RepoConfig } from "./types";
 import { filterReposByQuery } from "./classifier/repos";
 import {
   MAX_REPO_QUICK_PICKS,
+  SELECT_REPO_ACTION_ID,
   SELECT_REPO_QUICK_PICK_ACTION_ID,
   buildRepoClarificationBlocks,
   buildRepoQuickPickButtons,
@@ -74,6 +75,16 @@ describe("buildRepoQuickPickButtons", () => {
     expect(button.text.text).toHaveLength(75);
     expect(button.text.text.endsWith("…")).toBe(true);
   });
+
+  it("falls back to fullName for picks that share a display name", () => {
+    const buttons = buildRepoQuickPickButtons([
+      repo("acme/web", "web"),
+      repo("other/web", "web"),
+      repo("acme/api", "api"),
+    ]);
+
+    expect(buttons.map((button) => button.text.text)).toEqual(["acme/web", "other/web", "api"]);
+  });
 });
 
 describe("buildRepoClarificationBlocks", () => {
@@ -87,7 +98,11 @@ describe("buildRepoClarificationBlocks", () => {
       {
         type: "section",
         text: { text: "Which repository should I work with?" },
-        accessory: { type: "external_select", action_id: "select_repo", min_query_length: 0 },
+        accessory: {
+          type: "external_select",
+          action_id: SELECT_REPO_ACTION_ID,
+          min_query_length: 0,
+        },
       },
     ]);
   });
@@ -112,7 +127,7 @@ describe("buildRepoClarificationBlocks", () => {
       {
         type: "section",
         text: { text: "Or search for another repository:" },
-        accessory: { type: "external_select", action_id: "select_repo" },
+        accessory: { type: "external_select", action_id: SELECT_REPO_ACTION_ID },
       },
     ]);
   });

--- a/packages/slack-bot/src/repo-clarification.ts
+++ b/packages/slack-bot/src/repo-clarification.ts
@@ -11,7 +11,12 @@
 import { getAvailableRepos, filterReposByQuery } from "./classifier/repos";
 import { MAX_REPO_SUGGESTION_OPTIONS } from "./app-home/constants";
 import { plainTextOption } from "./slack-options";
-import type { SlackButtonElement, SlackSelectOption } from "./app-home/slack-types";
+import type {
+  SlackActionsBlock,
+  SlackButtonElement,
+  SlackSectionBlock,
+  SlackSelectOption,
+} from "./app-home/slack-types";
 import type { Env, RepoConfig } from "./types";
 
 /**
@@ -64,12 +69,30 @@ export async function getRepoClarificationOptions(
  * selection handler as the picker.
  */
 export function buildRepoQuickPickButtons(alternatives: RepoConfig[]): SlackButtonElement[] {
-  return alternatives.slice(0, MAX_REPO_QUICK_PICKS).map((repo) => ({
+  const picks = alternatives.slice(0, MAX_REPO_QUICK_PICKS);
+  const ambiguousNames = duplicateDisplayNames(picks);
+
+  return picks.map((repo) => ({
     type: "button",
     action_id: SELECT_REPO_QUICK_PICK_ACTION_ID,
-    text: plainTextOption(repo.displayName),
+    // Two repos can share a displayName (e.g. the same repo name under different
+    // owners); fall back to the unambiguous fullName for the colliding picks.
+    text: plainTextOption(ambiguousNames.has(repo.displayName) ? repo.fullName : repo.displayName),
     value: repo.id,
   }));
+}
+
+/** Display names that appear more than once across the given repos. */
+function duplicateDisplayNames(repos: RepoConfig[]): Set<string> {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const repo of repos) {
+    if (seen.has(repo.displayName)) {
+      duplicates.add(repo.displayName);
+    }
+    seen.add(repo.displayName);
+  }
+  return duplicates;
 }
 
 /**
@@ -80,10 +103,10 @@ export function buildRepoQuickPickButtons(alternatives: RepoConfig[]): SlackButt
 export function buildRepoClarificationBlocks(
   reasoning: string,
   alternatives: RepoConfig[] | undefined
-) {
+): Array<SlackSectionBlock | SlackActionsBlock> {
   const quickPicks = alternatives?.length ? buildRepoQuickPickButtons(alternatives) : [];
 
-  return [
+  const blocks: Array<SlackSectionBlock | SlackActionsBlock> = [
     {
       type: "section",
       text: {
@@ -91,25 +114,29 @@ export function buildRepoClarificationBlocks(
         text: `I couldn't determine which repository you're referring to.\n\n_${reasoning}_`,
       },
     },
-    ...(quickPicks.length > 0
-      ? [{ type: "actions", block_id: "repo_quick_picks", elements: quickPicks }]
-      : []),
-    {
-      type: "section",
-      text: {
-        type: "mrkdwn",
-        text:
-          quickPicks.length > 0
-            ? "Or search for another repository:"
-            : "Which repository should I work with?",
-      },
-      accessory: {
-        type: "external_select",
-        placeholder: { type: "plain_text", text: "Select a repository" },
-        // 0 so the list appears on open; typing filters across all repos.
-        min_query_length: 0,
-        action_id: SELECT_REPO_ACTION_ID,
-      },
-    },
   ];
+
+  if (quickPicks.length > 0) {
+    blocks.push({ type: "actions", block_id: "repo_quick_picks", elements: quickPicks });
+  }
+
+  blocks.push({
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text:
+        quickPicks.length > 0
+          ? "Or search for another repository:"
+          : "Which repository should I work with?",
+    },
+    accessory: {
+      type: "external_select",
+      placeholder: { type: "plain_text", text: "Select a repository" },
+      // 0 so the list appears on open; typing filters across all repos.
+      min_query_length: 0,
+      action_id: SELECT_REPO_ACTION_ID,
+    },
+  });
+
+  return blocks;
 }

--- a/packages/slack-bot/src/repo-clarification.ts
+++ b/packages/slack-bot/src/repo-clarification.ts
@@ -1,0 +1,115 @@
+/**
+ * Repo clarification picker UI.
+ *
+ * When the classifier can't decide which repository a Slack message refers to,
+ * the bot posts a clarification message: the classifier's ranked guesses as
+ * one-click quick-pick buttons, plus a searchable external_select over every
+ * repo. This module owns that UI — the options Slack queries as the user types,
+ * the quick-pick buttons, and the message blocks themselves.
+ */
+
+import { getAvailableRepos, filterReposByQuery } from "./classifier/repos";
+import { MAX_REPO_SUGGESTION_OPTIONS } from "./app-home/constants";
+import { plainTextOption } from "./slack-options";
+import type { SlackButtonElement, SlackSelectOption } from "./app-home/slack-types";
+import type { Env, RepoConfig } from "./types";
+
+/**
+ * Action ID for the repository picker shown when the classifier can't decide
+ * which repo a message refers to. The picker is an external_select, so the same
+ * ID is matched both for option suggestions (block_suggestion) and selection
+ * (block_actions).
+ */
+export const SELECT_REPO_ACTION_ID = "select_repo";
+
+/**
+ * Action ID for the one-click quick-pick buttons that surface the classifier's
+ * ranked alternatives. Routed through the same selection path as the picker.
+ */
+export const SELECT_REPO_QUICK_PICK_ACTION_ID = "select_repo_quick_pick";
+
+/**
+ * Cap on quick-pick buttons in the clarification message. The classifier rarely
+ * returns more, and the actions block shouldn't become a wall of buttons — the
+ * searchable picker covers everything beyond the top guesses.
+ */
+export const MAX_REPO_QUICK_PICKS = 5;
+
+function toRepoSelectOption(repo: RepoConfig): SlackSelectOption {
+  return {
+    text: plainTextOption(repo.displayName),
+    description: plainTextOption(repo.description),
+    value: repo.id,
+  };
+}
+
+/**
+ * Options for the clarification picker's external_select. Slack queries this as
+ * the user types; we filter on the repo's full name and cap at Slack's
+ * per-response limit. With min_query_length 0 the unfiltered list shows as soon
+ * as the menu opens, and typing surfaces any of the remaining repos.
+ */
+export async function getRepoClarificationOptions(
+  env: Env,
+  query: string | undefined,
+  traceId?: string
+): Promise<SlackSelectOption[]> {
+  const repos = filterReposByQuery(await getAvailableRepos(env, traceId), query);
+  return repos.slice(0, MAX_REPO_SUGGESTION_OPTIONS).map(toRepoSelectOption);
+}
+
+/**
+ * One-click buttons for the classifier's ranked alternatives, capped at
+ * MAX_REPO_QUICK_PICKS. Each carries the repo id and routes through the same
+ * selection handler as the picker.
+ */
+export function buildRepoQuickPickButtons(alternatives: RepoConfig[]): SlackButtonElement[] {
+  return alternatives.slice(0, MAX_REPO_QUICK_PICKS).map((repo) => ({
+    type: "button",
+    action_id: SELECT_REPO_QUICK_PICK_ACTION_ID,
+    text: plainTextOption(repo.displayName),
+    value: repo.id,
+  }));
+}
+
+/**
+ * Blocks for the clarification message: the classifier's reasoning, its ranked
+ * alternatives as quick-pick buttons (when any), and a searchable picker over
+ * every repo as the fallback.
+ */
+export function buildRepoClarificationBlocks(
+  reasoning: string,
+  alternatives: RepoConfig[] | undefined
+) {
+  const quickPicks = alternatives?.length ? buildRepoQuickPickButtons(alternatives) : [];
+
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `I couldn't determine which repository you're referring to.\n\n_${reasoning}_`,
+      },
+    },
+    ...(quickPicks.length > 0
+      ? [{ type: "actions", block_id: "repo_quick_picks", elements: quickPicks }]
+      : []),
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text:
+          quickPicks.length > 0
+            ? "Or search for another repository:"
+            : "Which repository should I work with?",
+      },
+      accessory: {
+        type: "external_select",
+        placeholder: { type: "plain_text", text: "Select a repository" },
+        // 0 so the list appears on open; typing filters across all repos.
+        min_query_length: 0,
+        action_id: SELECT_REPO_ACTION_ID,
+      },
+    },
+  ];
+}

--- a/packages/slack-bot/src/slack-options.ts
+++ b/packages/slack-bot/src/slack-options.ts
@@ -1,0 +1,18 @@
+import type { SlackPlainText } from "./app-home/slack-types";
+
+/** Slack caps a select option's plain_text label/description at 75 characters. */
+export const SELECT_OPTION_TEXT_LIMIT = 75;
+
+/** Truncate option text to Slack's per-option limit, with an ellipsis when cut. */
+export function truncateSelectOptionText(text: string): string {
+  if (text.length <= SELECT_OPTION_TEXT_LIMIT) {
+    return text;
+  }
+
+  return `${text.slice(0, SELECT_OPTION_TEXT_LIMIT - 1)}…`;
+}
+
+/** Build a plain_text object for a select option, truncated to Slack's limit. */
+export function plainTextOption(text: string): SlackPlainText {
+  return { type: "plain_text", text: truncateSelectOptionText(text) };
+}


### PR DESCRIPTION
## Summary

Follow-up to #702 (the searchable repo clarification picker). Two things, in one PR:

1. **The discussed system-level change** — surface the classifier's ranked guesses as one-click quick-pick buttons, so the picker stops discarding a signal the system already computes.
2. **The code-quality feedback** left on #702 — extract the shared filter, name the option shape, share the truncation helper, fold the duplicated log path, guard the App Home picker, and dedupe the tests.

## 1. Quick-picks: stop throwing away the classifier's ranking

#702 fixed a real bug (repos beyond the first 5 were unreachable) but, in doing so, made every clarification show a flat, unranked list — even when the classifier returned `medium` confidence with a ranked shortlist. That shortlist (`ClassificationResult.alternatives`) was still computed on every call and then **discarded**: nothing read it after #702 removed the `result.alternatives || repos.slice(0,5)` consumer.

This PR feeds it back into the UI. The clarification message now renders:

- the classifier's reasoning,
- its ranked alternatives as **quick-pick buttons** (capped at `MAX_REPO_QUICK_PICKS`, when any), and
- the searchable `external_select` over every repo as the fallback ("Or search for another repository:").

Common case → one click. Long tail → search. The buttons route through the **same** selection path as the picker (`handleRepoSelection`), so nothing downstream changes. When the classifier has no basis for a guess (the error/low-confidence path), no buttons render and you get the searchable picker exactly as today.

## 2. Review feedback from #702

- **Extracted `filterReposByQuery`** into `classifier/repos.ts` (canonical repo layer) and reused it in both the clarification picker and the App Home branch picker — the normalize+filter block was duplicated verbatim.
- **Named the option shape**: added optional `description` to `SlackSelectOption` and returned `SlackSelectOption[]` explicitly, dropping the `Awaited<ReturnType<typeof …>>` smell.
- **Shared the option-text truncation**: new `slack-options.ts` (`truncateSelectOptionText` / `plainTextOption`) replaces the magic `75` + raw `.slice(0,75)`; the button/option `text` is now length-guarded too (it wasn't before).
- **Folded the `block_suggestion` handler** to a single central `http.request` log path (removing the inline-duplicated log and closing the gap where the fallback wasn't logged).
- **Guarded the App Home picker** against 500s — it had the same unguarded lookup the #702 guard only protected on the clarification side.
- **Deduped the suggestion tests**: `buildNumberedRepos()` + `mockReposFetch()` replace the 150-repo scaffolding that was copy-pasted across three tests.

## Module layout

New feature/UI logic lives in a focused `repo-clarification.ts` (options endpoint, quick-pick buttons, message blocks) instead of growing the 1.2k-line `index.ts` — which actually **shrank by ~50 lines**. `slack-options.ts` holds the generic select-option text helpers shared by both pickers.

## Testing

- `npm run typecheck` ✅ (full workspace)
- `npm test -w @open-inspect/slack-bot` ✅ (102 tests, +9: pure-function units for the new builders/filter, plus a quick-pick routing test)
- `npm run lint` / prettier ✅




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added quick-pick buttons to speed up repository selection when multiple matches are found.
  * Introduced improved repository clarification UI and shared Slack option formatting.
* **Bug Fixes**
  * Improved robustness for repository suggestion generation: failures are handled gracefully and fall back to no options rather than returning an error.
* **Tests**
  * Expanded coverage for repo query filtering, option/blocks rendering, and interaction routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->