### PR TITLE
test: pin luxon to CJS build so integration tests survive vite 8

### DIFF
--- a/packages/control-plane/vitest.integration.config.ts
+++ b/packages/control-plane/vitest.integration.config.ts
@@ -2,8 +2,19 @@ import { cloudflareTest, readD1Migrations } from "@cloudflare/vitest-pool-worker
 import { defineConfig } from "vitest/config";
 import path from "path";
 import { webcrypto } from "node:crypto";
+import { createRequire } from "node:module";
 
 const migrationsPath = path.resolve(__dirname, "../../terraform/d1/migrations");
+
+// Pin luxon to its CommonJS build. vite 8 resolves luxon via the "import"
+// condition to its ESM build, but cron-parser (a CJS transitive dep of
+// @open-inspect/shared, used by the scheduler's nextCronOccurrence) reads it as
+// `require("luxon").DateTime`. Under @cloudflare/vitest-pool-workers that
+// CJS->ESM interop yields `undefined`, so the scheduler tick throws "Cannot read
+// properties of undefined (reading 'DateTime')" and silently skips every overdue
+// automation (see scheduler.test.ts /internal/tick). vite 7 used the CJS build,
+// which interops correctly. Test-only — production bundles via esbuild/wrangler.
+const luxonCjsEntry = createRequire(__filename).resolve("luxon");
 
 /** Generate a random base64-encoded 32-byte AES key for tests. */
 function generateTestEncryptionKey(): string {
@@ -20,6 +31,11 @@ function generateTestEncryptionKey(): string {
 // That cleanup-based isolation only holds when files run one at a time — see
 // `fileParallelism: false` below.
 export default defineConfig({
+  resolve: {
+    alias: {
+      luxon: luxonCjsEntry,
+    },
+  },
   plugins: [
     cloudflareTest(async () => {
       const migrations = await readD1Migrations(migrationsPath);


### PR DESCRIPTION
## The actual issue behind the #748 integration failures

Dependabot #748 (group bump of `form-data` / `js-yaml` / `vite`) fails `Test (control-plane integration)` on two scheduler tick tests — deterministically, even with the serialization fix from #765 merged in. This is **not** flaky and **not** coincidental: the **vite 7 → 8** part of the bump is the cause.

### Root cause

`scheduler`'s `nextCronOccurrence` → `cron-parser` (CJS) → `luxon`. cron-parser's `CronDate.js` reads luxon as:

```js
const luxon_1 = require("luxon");
luxon_1.DateTime.fromJSDate(...);
```

luxon ships both builds via conditional exports:

```jsonc
"." : { "import": "./build/es6/luxon.mjs", "require": "./build/node/luxon.js" }
```

- **vite 7** resolved luxon to its **CJS** build → `require("luxon").DateTime` works.
- **vite 8** resolves luxon via the **`import`** condition to the **ESM** build, and under `@cloudflare/vitest-pool-workers` that CJS→ESM interop makes `luxon_1.DateTime` **`undefined`**.

So in the workers test runtime the scheduler tick throws `Cannot read properties of undefined (reading 'DateTime')`, the tick's `try/catch` swallows it, and **every overdue automation is silently skipped** — surfacing as `body.skipped = 0` and no run created (`scheduler.test.ts:346` / `:386`).

This is **test-only**: production bundles the control plane via esbuild/wrangler (not vite), so the runtime is unaffected. vite is a dev-only dependency.

### Fix

Alias `luxon` to its CJS entry (`require.resolve("luxon")`) in `vitest.integration.config.ts`, restoring the vite 7 resolution for the workers pool. The standard vite dep knobs (`optimizeDeps.include`, `ssr.noExternal`, `server.deps.inline`) don't apply here — pool-workers does its own module bundling — so a `resolve.alias` is the lever that works.

### Verification

Reproduced locally with the #748 lockfile (real `npm ci`, vite **8.0.16**):

| | scheduler.test.ts | full integration suite |
|---|---|---|
| vite 8, **before** | ❌ 2 failed (`DateTime` undefined) | ❌ 2 failed |
| vite 8, **after** | ✅ 17/17 | ✅ 31 files / 370 tests |
| vite 7.3.2, **after** | ✅ 17/17 | ✅ (no-op; harmless) |

`typecheck`, `prettier`, `eslint`: clean.

### After this merges

#748 just needs to merge `main` again (or `@dependabot rebase`) to pick up the fix, and the integration job should pass. Alternative if you'd rather not adopt vite 8 yet: have dependabot hold `vite` at `^7` in the group — but this fix lets the bump land safely.

Builds on #765 (which serialized the suite — a real flake fix, but a different problem from this deterministic one).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration test environment configuration and dependency resolution settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->