### PR TITLE
feat: configurable code-server and terminal ports

### DIFF
--- a/packages/control-plane/src/sandbox/providers/daytona-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/daytona-provider.ts
@@ -5,7 +5,8 @@
  * code-server password derivation that previously lived in the Python shim.
  */
 
-import { computeHmacHex, MAX_TUNNEL_PORTS, type SandboxSettings } from "@open-inspect/shared";
+import { computeHmacHex, type SandboxSettings } from "@open-inspect/shared";
+import { resolveServicePorts, resolveTunnelPorts } from "./port-resolution";
 import { createLogger } from "../../logger";
 import type { SourceControlProviderName } from "../../source-control";
 import type { DaytonaRestClient, DaytonaCreateSandboxParams } from "../daytona-rest-client";
@@ -29,7 +30,6 @@ const log = createLogger("daytona-provider");
 // Constants (ported from packages/daytona-infra/src/config.py)
 // ---------------------------------------------------------------------------
 
-const CODE_SERVER_PORT = 8080;
 const DEFAULT_PREVIEW_EXPIRY_SECONDS = 3900;
 
 // ---------------------------------------------------------------------------
@@ -209,6 +209,7 @@ export class DaytonaSandboxProvider implements SandboxProvider {
 
     if (config.codeServerEnabled) {
       envVars.CODE_SERVER_PASSWORD = await this.deriveCodeServerPassword(config.sandboxId);
+      envVars.CODE_SERVER_PORT = String(resolveServicePorts(config.sandboxSettings).codeServerPort);
     }
 
     if (config.agentSlackNotifyEnabled) {
@@ -261,6 +262,7 @@ export class DaytonaSandboxProvider implements SandboxProvider {
     tunnelUrls?: Record<string, string>;
   }> {
     const expirySeconds = resolvePreviewExpirySeconds(timeoutSeconds);
+    const { codeServerPort } = resolveServicePorts(sandboxSettings);
     let tunnelPorts = resolveTunnelPorts(sandboxSettings?.tunnelPorts);
     let codeServerUrl: string | undefined;
     let codeServerPassword: string | undefined;
@@ -268,12 +270,12 @@ export class DaytonaSandboxProvider implements SandboxProvider {
     if (codeServerEnabled) {
       const preview = await this.client.getSignedPreviewUrl(
         daytonaSandboxId,
-        CODE_SERVER_PORT,
+        codeServerPort,
         expirySeconds
       );
       codeServerUrl = preview.url;
       codeServerPassword = await this.deriveCodeServerPassword(logicalSandboxId);
-      tunnelPorts = tunnelPorts.filter((p) => p !== CODE_SERVER_PORT);
+      tunnelPorts = tunnelPorts.filter((p) => p !== codeServerPort);
     }
 
     let tunnelUrls: Record<string, string> | undefined;
@@ -329,18 +331,6 @@ export class DaytonaSandboxProvider implements SandboxProvider {
 function resolvePreviewExpirySeconds(timeoutSeconds: number | undefined): number {
   if (!timeoutSeconds) return DEFAULT_PREVIEW_EXPIRY_SECONDS;
   return Math.min(86400, Math.max(900, timeoutSeconds + 300));
-}
-
-function resolveTunnelPorts(rawPorts: number[] | undefined): number[] {
-  if (!rawPorts) return [];
-  const ports: number[] = [];
-  for (const value of rawPorts) {
-    if (Number.isInteger(value) && value >= 1 && value <= 65535) {
-      ports.push(value);
-    }
-    if (ports.length >= MAX_TUNNEL_PORTS) break;
-  }
-  return ports;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/control-plane/src/sandbox/providers/port-resolution.ts
+++ b/packages/control-plane/src/sandbox/providers/port-resolution.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared port resolution for sandbox providers. Applies the shared defaults to
+ * the configurable service ports and validates/caps user-supplied tunnel ports,
+ * so every provider shares one defaulting/validation rule instead of carrying a
+ * near-duplicate copy.
+ */
+
+import {
+  DEFAULT_CODE_SERVER_PORT,
+  DEFAULT_TERMINAL_PORT,
+  MAX_TUNNEL_PORTS,
+  type SandboxSettings,
+} from "@open-inspect/shared";
+
+/** Effective code-server / terminal ports from settings, with shared defaults. */
+export function resolveServicePorts(sandboxSettings: SandboxSettings | undefined): {
+  codeServerPort: number;
+  terminalPort: number;
+} {
+  return {
+    codeServerPort: sandboxSettings?.codeServerPort ?? DEFAULT_CODE_SERVER_PORT,
+    terminalPort: sandboxSettings?.terminalPort ?? DEFAULT_TERMINAL_PORT,
+  };
+}
+
+/** Validated, capped list of user-configured tunnel ports (invalid entries dropped). */
+export function resolveTunnelPorts(rawPorts: number[] | undefined): number[] {
+  if (!rawPorts) return [];
+  const ports: number[] = [];
+  for (const value of rawPorts) {
+    if (Number.isInteger(value) && value >= 1 && value <= 65535) {
+      ports.push(value);
+    }
+    if (ports.length >= MAX_TUNNEL_PORTS) break;
+  }
+  return ports;
+}

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
@@ -366,6 +366,33 @@ describe("VercelSandboxProvider", () => {
     });
   });
 
+  it("uses configured code-server / terminal ports for exposure and env", async () => {
+    const client = createMockClient();
+    const provider = new VercelSandboxProvider(client, providerConfig);
+
+    await provider.createSandbox({
+      ...baseCreateConfig,
+      codeServerEnabled: true,
+      sandboxSettings: {
+        terminalEnabled: true,
+        codeServerPort: 8081,
+        terminalPort: 7000,
+        tunnelPorts: [8080],
+      },
+    });
+
+    const createCall = vi.mocked(client.createSandbox).mock.calls[0][0];
+    // code-server on 8081, terminal on 7000, and the user's 8080 is now a free tunnel.
+    expect(createCall.ports).toEqual([8081, 7000, 8080]);
+    expect(createCall.env).toEqual(
+      expect.objectContaining({
+        CODE_SERVER_PORT: "8081",
+        TTYD_PROXY_PORT: "7000",
+        EXPECTED_TUNNEL_PORTS: "8080",
+      })
+    );
+  });
+
   it("requires a base snapshot when no repo image snapshot is available", async () => {
     const client = createMockClient();
     const provider = new VercelSandboxProvider(client, {

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.ts
@@ -2,7 +2,8 @@
  * Vercel Sandbox provider implementation.
  */
 
-import { computeHmacHex, MAX_TUNNEL_PORTS, type SandboxSettings } from "@open-inspect/shared";
+import { computeHmacHex, type SandboxSettings } from "@open-inspect/shared";
+import { resolveServicePorts, resolveTunnelPorts } from "../port-resolution";
 import { createLogger } from "../../../logger";
 import type { CorrelationContext } from "../../../logger";
 import type { SourceControlProviderName } from "../../../source-control";
@@ -33,8 +34,6 @@ import { DEFAULT_VERCEL_RUNTIME, VERCEL_PYTHON_BIN } from "./bootstrap";
 
 const log = createLogger("vercel-provider");
 
-const CODE_SERVER_PORT = 8080;
-const TTYD_PROXY_PORT = 7680;
 const TUNNEL_ENV_FILE_PATH = "/workspace/.tunnels.env";
 const EXPECTED_TUNNEL_PORTS_ENV_VAR = "EXPECTED_TUNNEL_PORTS";
 const DEFAULT_SNAPSHOT_EXPIRATION_MS = 0;
@@ -345,11 +344,14 @@ export class VercelSandboxProvider implements SandboxProvider {
       envVars.FROM_REPO_IMAGE = "true";
       envVars.REPO_IMAGE_SHA = mode.repoImageSha ?? "";
     }
+    const { codeServerPort, terminalPort } = resolveServicePorts(config.sandboxSettings);
     if (config.codeServerEnabled) {
       envVars.CODE_SERVER_PASSWORD = await this.deriveCodeServerPassword(config.sandboxId);
+      envVars.CODE_SERVER_PORT = String(codeServerPort);
     }
     if (config.sandboxSettings?.terminalEnabled) {
       envVars.TERMINAL_ENABLED = "true";
+      envVars.TTYD_PROXY_PORT = String(terminalPort);
     }
     if (config.agentSlackNotifyEnabled) {
       envVars.AGENT_SLACK_NOTIFY_ENABLED = "true";
@@ -443,11 +445,12 @@ export class VercelSandboxProvider implements SandboxProvider {
       await this.writeTunnelEnvFile(created.session.id, tunnelUrls, correlation);
     }
 
+    const { codeServerPort, terminalPort } = resolveServicePorts(sandboxSettings);
     const codeServerUrl = codeServerEnabled
-      ? routeToUrl(routeByPort.get(CODE_SERVER_PORT))
+      ? routeToUrl(routeByPort.get(codeServerPort))
       : undefined;
     const ttydUrl = sandboxSettings?.terminalEnabled
-      ? routeToUrl(routeByPort.get(TTYD_PROXY_PORT))
+      ? routeToUrl(routeByPort.get(terminalPort))
       : undefined;
 
     return {
@@ -592,16 +595,17 @@ function collectExposedPorts(
   codeServerEnabled: boolean | undefined,
   sandboxSettings: SandboxSettings | undefined
 ): { allExposedPorts: number[]; extraTunnelPorts: number[] } {
+  const { codeServerPort, terminalPort } = resolveServicePorts(sandboxSettings);
   const reserved = new Set<number>();
   const exposed: number[] = [];
 
   if (codeServerEnabled) {
-    exposed.push(CODE_SERVER_PORT);
-    reserved.add(CODE_SERVER_PORT);
+    exposed.push(codeServerPort);
+    reserved.add(codeServerPort);
   }
   if (sandboxSettings?.terminalEnabled) {
-    exposed.push(TTYD_PROXY_PORT);
-    reserved.add(TTYD_PROXY_PORT);
+    exposed.push(terminalPort);
+    reserved.add(terminalPort);
   }
 
   const extraTunnelPorts = resolveTunnelPorts(sandboxSettings?.tunnelPorts).filter(
@@ -610,18 +614,6 @@ function collectExposedPorts(
   exposed.push(...extraTunnelPorts);
 
   return { allExposedPorts: exposed, extraTunnelPorts };
-}
-
-function resolveTunnelPorts(rawPorts: number[] | undefined): number[] {
-  if (!rawPorts) return [];
-  const ports: number[] = [];
-  for (const value of rawPorts) {
-    if (Number.isInteger(value) && value >= 1 && value <= 65535) {
-      ports.push(value);
-    }
-    if (ports.length >= MAX_TUNNEL_PORTS) break;
-  }
-  return ports;
 }
 
 function resolveVercelResources(

--- a/packages/control-plane/src/sandbox/settings.test.ts
+++ b/packages/control-plane/src/sandbox/settings.test.ts
@@ -91,4 +91,27 @@ describe("normalizeSandboxSettings", () => {
       tunnelPorts: [8080],
     });
   });
+
+  it("drops colliding ports in omit mode so the merged config stays conflict-free", () => {
+    // Mirrors getResolvedConfig: a global service port and a repo tunnel port can
+    // merge into a collision that must not survive omit-mode normalization (or it
+    // would be silently dropped again at sandbox spawn).
+    expect(
+      normalizeSandboxSettings(
+        { codeServerPort: 9000, tunnelPorts: [9000, 3000] },
+        { invalid: "omit" }
+      )
+    ).toEqual({
+      codeServerPort: 9000,
+      tunnelPorts: [3000],
+    });
+  });
+
+  it("drops the reserved internal terminal port from tunnels in omit mode", () => {
+    expect(
+      normalizeSandboxSettings({ tunnelPorts: [INTERNAL_TTYD_PORT, 3000] }, { invalid: "omit" })
+    ).toEqual({
+      tunnelPorts: [3000],
+    });
+  });
 });

--- a/packages/control-plane/src/sandbox/settings.test.ts
+++ b/packages/control-plane/src/sandbox/settings.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { INTERNAL_TTYD_PORT } from "@open-inspect/shared";
 import { normalizeSandboxSettings, SandboxSettingsValidationError } from "./settings";
 
 class CustomSettingsValidationError extends Error {}
@@ -47,6 +48,47 @@ describe("normalizeSandboxSettings", () => {
       terminalEnabled: true,
       maxTotalChildSessions: 5,
       memoryMib: 2048,
+    });
+  });
+
+  it("accepts valid codeServerPort and terminalPort", () => {
+    expect(normalizeSandboxSettings({ codeServerPort: 8081, terminalPort: 7000 })).toEqual({
+      codeServerPort: 8081,
+      terminalPort: 7000,
+    });
+  });
+
+  it("throws for out-of-range service ports", () => {
+    expect(() => normalizeSandboxSettings({ codeServerPort: 0 })).toThrow(
+      SandboxSettingsValidationError
+    );
+    expect(() => normalizeSandboxSettings({ terminalPort: 70000 })).toThrow(
+      SandboxSettingsValidationError
+    );
+  });
+
+  it("rejects the reserved internal terminal port", () => {
+    expect(() => normalizeSandboxSettings({ codeServerPort: INTERNAL_TTYD_PORT })).toThrow(
+      SandboxSettingsValidationError
+    );
+    expect(() => normalizeSandboxSettings({ tunnelPorts: [INTERNAL_TTYD_PORT] })).toThrow(
+      SandboxSettingsValidationError
+    );
+  });
+
+  it("rejects duplicate ports across code-server, terminal, and tunnels", () => {
+    expect(() => normalizeSandboxSettings({ codeServerPort: 3000, tunnelPorts: [3000] })).toThrow(
+      SandboxSettingsValidationError
+    );
+    expect(() => normalizeSandboxSettings({ codeServerPort: 9000, terminalPort: 9000 })).toThrow(
+      SandboxSettingsValidationError
+    );
+  });
+
+  it("frees the default port for a tunnel when code-server is moved", () => {
+    expect(normalizeSandboxSettings({ codeServerPort: 8081, tunnelPorts: [8080] })).toEqual({
+      codeServerPort: 8081,
+      tunnelPorts: [8080],
     });
   });
 });

--- a/packages/control-plane/src/sandbox/settings.ts
+++ b/packages/control-plane/src/sandbox/settings.ts
@@ -149,29 +149,50 @@ function normalizePort(
  * tunnel ports. Enablement-independent: every configured port must be unique so a
  * port is never silently dropped at sandbox spawn. The conflict rule itself lives
  * in `findSandboxPortConflict` (shared with the web settings UI).
+ *
+ * In `invalid: "omit"` mode `reject` returns instead of throwing, so we actively
+ * drop the offending port and re-check until the result is collision-free. This
+ * matters at the merged global+repo boundary (`getResolvedConfig`), which
+ * normalizes in omit mode — a surviving collision would otherwise reach providers
+ * and be silently dropped again at spawn.
  */
 function checkPortCollisions(result: SandboxSettings, reject: (message: string) => false): void {
-  const ports: ConfiguredSandboxPort[] = [];
-  if (result.codeServerPort !== undefined) {
-    ports.push({ port: result.codeServerPort, label: "codeServerPort" });
-  }
-  if (result.terminalPort !== undefined) {
-    ports.push({ port: result.terminalPort, label: "terminalPort" });
-  }
-  for (const port of result.tunnelPorts ?? []) {
-    ports.push({ port, label: "tunnelPorts" });
-  }
+  for (;;) {
+    const ports: ConfiguredSandboxPort[] = [];
+    if (result.codeServerPort !== undefined) {
+      ports.push({ port: result.codeServerPort, label: "codeServerPort" });
+    }
+    if (result.terminalPort !== undefined) {
+      ports.push({ port: result.terminalPort, label: "terminalPort" });
+    }
+    for (const port of result.tunnelPorts ?? []) {
+      ports.push({ port, label: "tunnelPorts" });
+    }
 
-  const conflict = findSandboxPortConflict(ports);
-  if (!conflict) return;
-  if (conflict.kind === "reserved") {
+    const conflict = findSandboxPortConflict(ports);
+    if (!conflict) return;
+
     reject(
-      `Port ${conflict.port} is reserved for the internal terminal (used by ${conflict.label})`
+      conflict.kind === "reserved"
+        ? `Port ${conflict.port} is reserved for the internal terminal (used by ${conflict.label})`
+        : `Port ${conflict.port} is used more than once across code-server, terminal, and tunnel ports`
     );
-  } else {
-    reject(
-      `Port ${conflict.port} is used more than once across code-server, terminal, and tunnel ports`
-    );
+
+    // Reached only in omit mode (throw mode already threw). Drop the offending
+    // port and re-check; removing a port never creates a new conflict, so this
+    // terminates. Service ports listed first win; conflicting tunnels are dropped.
+    if (conflict.label === "codeServerPort") {
+      delete result.codeServerPort;
+    } else if (conflict.label === "terminalPort") {
+      delete result.terminalPort;
+    } else {
+      const remaining = (result.tunnelPorts ?? []).filter((p) => p !== conflict.port);
+      if (remaining.length > 0) {
+        result.tunnelPorts = remaining;
+      } else {
+        delete result.tunnelPorts;
+      }
+    }
   }
 }
 

--- a/packages/control-plane/src/sandbox/settings.ts
+++ b/packages/control-plane/src/sandbox/settings.ts
@@ -1,4 +1,9 @@
-import { MAX_TUNNEL_PORTS, type SandboxSettings } from "@open-inspect/shared";
+import {
+  findSandboxPortConflict,
+  MAX_TUNNEL_PORTS,
+  type ConfiguredSandboxPort,
+  type SandboxSettings,
+} from "@open-inspect/shared";
 
 export type InvalidSandboxSettingsBehavior = "throw" | "omit";
 
@@ -56,6 +61,12 @@ export function normalizeSandboxSettings(
     normalizeTunnelPorts(settings.tunnelPorts, reject, result);
   }
 
+  const codeServerPort = normalizePort(settings.codeServerPort, "codeServerPort", reject);
+  if (codeServerPort !== undefined) result.codeServerPort = codeServerPort;
+
+  const terminalPort = normalizePort(settings.terminalPort, "terminalPort", reject);
+  if (terminalPort !== undefined) result.terminalPort = terminalPort;
+
   let maxConcurrentChildSessions = normalizePositiveIntegerSetting(
     settings.maxConcurrentChildSessions,
     "maxConcurrentChildSessions",
@@ -111,7 +122,57 @@ export function normalizeSandboxSettings(
     }
   }
 
+  checkPortCollisions(result, reject);
+
   return result;
+}
+
+function isValidPort(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 65535;
+}
+
+function normalizePort(
+  value: unknown,
+  name: string,
+  reject: (message: string) => false
+): number | undefined {
+  if (value === undefined) return undefined;
+  if (!isValidPort(value)) {
+    reject(`${name} must be an integer between 1 and 65535`);
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * Reject reserved-port use and any port shared across code-server, terminal, and
+ * tunnel ports. Enablement-independent: every configured port must be unique so a
+ * port is never silently dropped at sandbox spawn. The conflict rule itself lives
+ * in `findSandboxPortConflict` (shared with the web settings UI).
+ */
+function checkPortCollisions(result: SandboxSettings, reject: (message: string) => false): void {
+  const ports: ConfiguredSandboxPort[] = [];
+  if (result.codeServerPort !== undefined) {
+    ports.push({ port: result.codeServerPort, label: "codeServerPort" });
+  }
+  if (result.terminalPort !== undefined) {
+    ports.push({ port: result.terminalPort, label: "terminalPort" });
+  }
+  for (const port of result.tunnelPorts ?? []) {
+    ports.push({ port, label: "tunnelPorts" });
+  }
+
+  const conflict = findSandboxPortConflict(ports);
+  if (!conflict) return;
+  if (conflict.kind === "reserved") {
+    reject(
+      `Port ${conflict.port} is reserved for the internal terminal (used by ${conflict.label})`
+    );
+  } else {
+    reject(
+      `Port ${conflict.port} is used more than once across code-server, terminal, and tunnel ports`
+    );
+  }
 }
 
 function normalizeTunnelPorts(
@@ -126,7 +187,7 @@ function normalizeTunnelPorts(
 
   const ports: number[] = [];
   for (const port of value) {
-    if (typeof port !== "number" || !Number.isInteger(port) || port < 1 || port > 65535) {
+    if (!isValidPort(port)) {
       reject(`Invalid port number: ${port}. Must be an integer between 1 and 65535`);
       continue;
     }

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -22,8 +22,10 @@ import modal
 
 from sandbox_runtime.constants import (
     CODE_SERVER_PORT,
+    CODE_SERVER_PORT_ENV_VAR,
     EXPECTED_TUNNEL_PORTS_ENV_VAR,
     TTYD_PROXY_PORT,
+    TTYD_PROXY_PORT_ENV_VAR,
     TUNNEL_ENV_FILE_PATH,
 )
 from sandbox_runtime.log_config import get_logger
@@ -184,20 +186,41 @@ class SandboxManager:
         return ports
 
     @staticmethod
+    def _resolve_service_ports(settings: dict[str, Any] | None) -> tuple[int, int]:
+        """Return effective (code_server_port, ttyd_proxy_port) from settings.
+
+        Falls back to the CODE_SERVER_PORT / TTYD_PROXY_PORT defaults when unset
+        or invalid. The control plane validates these before they reach here.
+        """
+        s = settings or {}
+
+        def coerce(value: Any, default: int) -> int:
+            if isinstance(value, int) and not isinstance(value, bool) and 1 <= value <= 65535:
+                return value
+            return default
+
+        return (
+            coerce(s.get("codeServerPort"), CODE_SERVER_PORT),
+            coerce(s.get("terminalPort"), TTYD_PROXY_PORT),
+        )
+
+    @staticmethod
     def _collect_exposed_ports(
         code_server_enabled: bool,
         terminal_enabled: bool,
         settings: dict[str, Any] | None,
+        code_server_port: int,
+        ttyd_proxy_port: int,
     ) -> tuple[list[int], list[int]]:
         """Return (all_exposed_ports, extra_tunnel_ports) from settings and feature flags."""
         reserved: set[int] = set()
         exposed: list[int] = []
         if code_server_enabled:
-            exposed.append(CODE_SERVER_PORT)
-            reserved.add(CODE_SERVER_PORT)
+            exposed.append(code_server_port)
+            reserved.add(code_server_port)
         if terminal_enabled:
-            exposed.append(TTYD_PROXY_PORT)
-            reserved.add(TTYD_PROXY_PORT)
+            exposed.append(ttyd_proxy_port)
+            reserved.add(ttyd_proxy_port)
 
         raw_ports = (settings or {}).get("tunnelPorts", [])
         tunnel_ports = SandboxManager._validate_ports(raw_ports) if raw_ports else []
@@ -213,13 +236,15 @@ class SandboxManager:
         code_server_enabled: bool,
         terminal_enabled: bool,
         extra_ports: list[int],
+        code_server_port: int,
+        ttyd_proxy_port: int,
     ) -> tuple[str | None, str | None, dict[int, str] | None]:
         """Resolve all tunnels in a single pass. Returns (code_server_url, ttyd_url, extra_urls)."""
         all_ports: list[int] = []
         if code_server_enabled:
-            all_ports.append(CODE_SERVER_PORT)
+            all_ports.append(code_server_port)
         if terminal_enabled:
-            all_ports.append(TTYD_PROXY_PORT)
+            all_ports.append(ttyd_proxy_port)
         all_ports.extend(extra_ports)
 
         if not all_ports:
@@ -227,8 +252,11 @@ class SandboxManager:
 
         resolved = await SandboxManager._resolve_tunnels(sandbox, sandbox_id, all_ports)
 
-        code_server_url = resolved.pop(CODE_SERVER_PORT, None)
-        ttyd_url = resolved.pop(TTYD_PROXY_PORT, None)
+        # Only pull a service port out of the resolved map when that service owns
+        # it. Otherwise a user's own port (e.g. 8080 with code-server disabled)
+        # would be misrouted to code_server_url and dropped from the tunnel map.
+        code_server_url = resolved.pop(code_server_port, None) if code_server_enabled else None
+        ttyd_url = resolved.pop(ttyd_proxy_port, None) if terminal_enabled else None
         extra_urls = resolved if resolved else None
 
         if extra_urls:
@@ -400,8 +428,18 @@ class SandboxManager:
         else:
             image = base_image
 
+        code_server_port, ttyd_proxy_port = self._resolve_service_ports(config.settings)
+        if config.code_server_enabled:
+            env_vars[CODE_SERVER_PORT_ENV_VAR] = str(code_server_port)
+        if terminal_enabled:
+            env_vars[TTYD_PROXY_PORT_ENV_VAR] = str(ttyd_proxy_port)
+
         exposed_ports, tunnel_ports = self._collect_exposed_ports(
-            config.code_server_enabled, terminal_enabled, config.settings
+            config.code_server_enabled,
+            terminal_enabled,
+            config.settings,
+            code_server_port,
+            ttyd_proxy_port,
         )
         if tunnel_ports:
             env_vars[EXPECTED_TUNNEL_PORTS_ENV_VAR] = ",".join(str(p) for p in tunnel_ports)
@@ -427,7 +465,13 @@ class SandboxManager:
 
         modal_object_id = sandbox.object_id
         code_server_url, ttyd_url, extra_tunnel_urls = await self._resolve_and_setup_tunnels(
-            sandbox, sandbox_id, config.code_server_enabled, terminal_enabled, tunnel_ports
+            sandbox,
+            sandbox_id,
+            config.code_server_enabled,
+            terminal_enabled,
+            tunnel_ports,
+            code_server_port,
+            ttyd_proxy_port,
         )
 
         duration_ms = int((time.time() - start_time) * 1000)
@@ -730,8 +774,18 @@ class SandboxManager:
         if agent_slack_notify_enabled:
             env_vars["AGENT_SLACK_NOTIFY_ENABLED"] = "true"
 
+        code_server_port, ttyd_proxy_port = self._resolve_service_ports(settings)
+        if code_server_enabled:
+            env_vars[CODE_SERVER_PORT_ENV_VAR] = str(code_server_port)
+        if terminal_enabled:
+            env_vars[TTYD_PROXY_PORT_ENV_VAR] = str(ttyd_proxy_port)
+
         exposed_ports, tunnel_ports = self._collect_exposed_ports(
-            code_server_enabled, terminal_enabled, settings
+            code_server_enabled,
+            terminal_enabled,
+            settings,
+            code_server_port,
+            ttyd_proxy_port,
         )
         if tunnel_ports:
             env_vars[EXPECTED_TUNNEL_PORTS_ENV_VAR] = ",".join(str(p) for p in tunnel_ports)
@@ -757,7 +811,13 @@ class SandboxManager:
 
         modal_object_id = sandbox.object_id
         code_server_url, ttyd_url, extra_tunnel_urls = await self._resolve_and_setup_tunnels(
-            sandbox, sandbox_id, code_server_enabled, terminal_enabled, tunnel_ports
+            sandbox,
+            sandbox_id,
+            code_server_enabled,
+            terminal_enabled,
+            tunnel_ports,
+            code_server_port,
+            ttyd_proxy_port,
         )
 
         duration_ms = int((time.time() - start_time) * 1000)

--- a/packages/modal-infra/tests/test_ttyd.py
+++ b/packages/modal-infra/tests/test_ttyd.py
@@ -18,7 +18,11 @@ class TestCollectExposedPortsTerminal:
 
     def test_terminal_enabled_includes_proxy_port(self):
         exposed, _extra = SandboxManager._collect_exposed_ports(
-            code_server_enabled=False, terminal_enabled=True, settings=None
+            code_server_enabled=False,
+            terminal_enabled=True,
+            settings=None,
+            code_server_port=CODE_SERVER_PORT,
+            ttyd_proxy_port=TTYD_PROXY_PORT,
         )
         assert TTYD_PROXY_PORT in exposed
         # ttyd raw port should NOT be exposed (only the proxy port)
@@ -26,13 +30,21 @@ class TestCollectExposedPortsTerminal:
 
     def test_terminal_disabled_excludes_proxy_port(self):
         exposed, _extra = SandboxManager._collect_exposed_ports(
-            code_server_enabled=False, terminal_enabled=False, settings=None
+            code_server_enabled=False,
+            terminal_enabled=False,
+            settings=None,
+            code_server_port=CODE_SERVER_PORT,
+            ttyd_proxy_port=TTYD_PROXY_PORT,
         )
         assert TTYD_PROXY_PORT not in exposed
 
     def test_terminal_and_code_server_both_enabled(self):
         exposed, _extra = SandboxManager._collect_exposed_ports(
-            code_server_enabled=True, terminal_enabled=True, settings=None
+            code_server_enabled=True,
+            terminal_enabled=True,
+            settings=None,
+            code_server_port=CODE_SERVER_PORT,
+            ttyd_proxy_port=TTYD_PROXY_PORT,
         )
         assert CODE_SERVER_PORT in exposed
         assert TTYD_PROXY_PORT in exposed
@@ -41,7 +53,11 @@ class TestCollectExposedPortsTerminal:
         """If user explicitly lists TTYD_PROXY_PORT in tunnelPorts, it should not duplicate."""
         settings = {"tunnelPorts": [TTYD_PROXY_PORT, 3000]}
         exposed, extra = SandboxManager._collect_exposed_ports(
-            code_server_enabled=False, terminal_enabled=True, settings=settings
+            code_server_enabled=False,
+            terminal_enabled=True,
+            settings=settings,
+            code_server_port=CODE_SERVER_PORT,
+            ttyd_proxy_port=TTYD_PROXY_PORT,
         )
         assert exposed.count(TTYD_PROXY_PORT) == 1
         assert 3000 in exposed
@@ -62,7 +78,13 @@ class TestResolveTunnelsTerminal:
         sandbox.tunnels.return_value = {TTYD_PROXY_PORT: tunnel}
 
         cs_url, ttyd_url, extra = await SandboxManager._resolve_and_setup_tunnels(
-            sandbox, "sb-123", code_server_enabled=False, terminal_enabled=True, extra_ports=[]
+            sandbox,
+            "sb-123",
+            code_server_enabled=False,
+            terminal_enabled=True,
+            extra_ports=[],
+            code_server_port=CODE_SERVER_PORT,
+            ttyd_proxy_port=TTYD_PROXY_PORT,
         )
         assert cs_url is None
         assert ttyd_url == "https://ttyd.example.com"
@@ -72,7 +94,13 @@ class TestResolveTunnelsTerminal:
     async def test_returns_none_when_terminal_disabled(self):
         sandbox = MagicMock()
         cs_url, ttyd_url, extra = await SandboxManager._resolve_and_setup_tunnels(
-            sandbox, "sb-123", code_server_enabled=False, terminal_enabled=False, extra_ports=[]
+            sandbox,
+            "sb-123",
+            code_server_enabled=False,
+            terminal_enabled=False,
+            extra_ports=[],
+            code_server_port=CODE_SERVER_PORT,
+            ttyd_proxy_port=TTYD_PROXY_PORT,
         )
         assert cs_url is None
         assert ttyd_url is None
@@ -97,6 +125,8 @@ class TestResolveTunnelsTerminal:
             code_server_enabled=True,
             terminal_enabled=True,
             extra_ports=[],
+            code_server_port=CODE_SERVER_PORT,
+            ttyd_proxy_port=TTYD_PROXY_PORT,
         )
         assert cs_url == "https://cs.example.com"
         assert ttyd_url == "https://ttyd.example.com"

--- a/packages/modal-infra/tests/test_tunnel_ports.py
+++ b/packages/modal-infra/tests/test_tunnel_ports.py
@@ -5,8 +5,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from sandbox_runtime.constants import (
+    CODE_SERVER_PORT_ENV_VAR,
     EXPECTED_TUNNEL_PORTS_ENV_VAR,
     TTYD_PROXY_PORT,
+    TTYD_PROXY_PORT_ENV_VAR,
     TUNNEL_ENV_FILE_PATH,
 )
 from src.sandbox.manager import CODE_SERVER_PORT, SandboxConfig, SandboxManager
@@ -96,7 +98,13 @@ class TestResolveAndSetupTunnels:
     async def test_returns_none_none_none_for_no_ports(self):
         sandbox = MagicMock()
         cs_url, ttyd_url, extra = await SandboxManager._resolve_and_setup_tunnels(
-            sandbox, "sb-1", False, False, []
+            sandbox,
+            "sb-1",
+            False,
+            False,
+            [],
+            code_server_port=CODE_SERVER_PORT,
+            ttyd_proxy_port=TTYD_PROXY_PORT,
         )
         assert cs_url is None
         assert ttyd_url is None
@@ -114,7 +122,13 @@ class TestResolveAndSetupTunnels:
             return_value=tunnel_urls,
         ):
             cs_url, ttyd_url, extra = await SandboxManager._resolve_and_setup_tunnels(
-                sandbox, "sb-1", False, False, [3000]
+                sandbox,
+                "sb-1",
+                False,
+                False,
+                [3000],
+                code_server_port=CODE_SERVER_PORT,
+                ttyd_proxy_port=TTYD_PROXY_PORT,
             )
 
         assert cs_url is None
@@ -137,12 +151,72 @@ class TestResolveAndSetupTunnels:
             return_value=resolved,
         ):
             cs_url, ttyd_url, extra = await SandboxManager._resolve_and_setup_tunnels(
-                sandbox, "sb-1", True, False, [3000]
+                sandbox,
+                "sb-1",
+                True,
+                False,
+                [3000],
+                code_server_port=CODE_SERVER_PORT,
+                ttyd_proxy_port=TTYD_PROXY_PORT,
             )
 
         assert cs_url == "https://cs.example.com"
         assert ttyd_url is None
         assert extra == {3000: "https://tunnel-3000.example.com"}
+
+    @pytest.mark.asyncio
+    async def test_keeps_code_server_port_tunnel_when_code_server_disabled(self):
+        """Regression: a user's own 8080 tunnel is kept, not misrouted to code_server_url."""
+        resolved = {CODE_SERVER_PORT: "https://my-app.example.com"}
+        sandbox, _f = _mock_sandbox_with_open()
+
+        with patch.object(
+            SandboxManager,
+            "_resolve_tunnels",
+            new_callable=AsyncMock,
+            return_value=resolved,
+        ):
+            cs_url, ttyd_url, extra = await SandboxManager._resolve_and_setup_tunnels(
+                sandbox,
+                "sb-1",
+                False,
+                False,
+                [CODE_SERVER_PORT],
+                code_server_port=CODE_SERVER_PORT,
+                ttyd_proxy_port=TTYD_PROXY_PORT,
+            )
+
+        assert cs_url is None
+        assert ttyd_url is None
+        assert extra == {CODE_SERVER_PORT: "https://my-app.example.com"}
+
+    @pytest.mark.asyncio
+    async def test_splits_custom_code_server_port_from_user_tunnel(self):
+        """code-server on 8081 → its URL is the code_server_url; user's 8080 is a tunnel."""
+        resolved = {
+            8081: "https://cs.example.com",
+            CODE_SERVER_PORT: "https://my-app.example.com",
+        }
+        sandbox, _f = _mock_sandbox_with_open()
+
+        with patch.object(
+            SandboxManager,
+            "_resolve_tunnels",
+            new_callable=AsyncMock,
+            return_value=resolved,
+        ):
+            cs_url, _ttyd_url, extra = await SandboxManager._resolve_and_setup_tunnels(
+                sandbox,
+                "sb-1",
+                True,
+                False,
+                [CODE_SERVER_PORT],
+                code_server_port=8081,
+                ttyd_proxy_port=TTYD_PROXY_PORT,
+            )
+
+        assert cs_url == "https://cs.example.com"
+        assert extra == {CODE_SERVER_PORT: "https://my-app.example.com"}
 
 
 class TestWriteTunnelEnvFile:
@@ -214,7 +288,15 @@ class TestResolveAndSetupTunnelsWritesFile:
             new_callable=AsyncMock,
             return_value=tunnel_urls,
         ):
-            await SandboxManager._resolve_and_setup_tunnels(sandbox, "sb-1", False, False, [3000])
+            await SandboxManager._resolve_and_setup_tunnels(
+                sandbox,
+                "sb-1",
+                False,
+                False,
+                [3000],
+                code_server_port=CODE_SERVER_PORT,
+                ttyd_proxy_port=TTYD_PROXY_PORT,
+            )
 
         sandbox.open.aio.assert_awaited_once_with(TUNNEL_ENV_FILE_PATH, "w")
         written = f.write.aio.call_args[0][0]
@@ -231,7 +313,13 @@ class TestResolveAndSetupTunnelsWritesFile:
             return_value={},
         ):
             _cs, _ttyd, extra = await SandboxManager._resolve_and_setup_tunnels(
-                sandbox, "sb-1", False, False, [3000]
+                sandbox,
+                "sb-1",
+                False,
+                False,
+                [3000],
+                code_server_port=CODE_SERVER_PORT,
+                ttyd_proxy_port=TTYD_PROXY_PORT,
             )
 
         assert extra is None
@@ -248,7 +336,15 @@ class TestResolveAndSetupTunnelsWritesFile:
             new_callable=AsyncMock,
             return_value={CODE_SERVER_PORT: "https://cs.example.com"},
         ):
-            await SandboxManager._resolve_and_setup_tunnels(sandbox, "sb-1", True, False, [])
+            await SandboxManager._resolve_and_setup_tunnels(
+                sandbox,
+                "sb-1",
+                True,
+                False,
+                [],
+                code_server_port=CODE_SERVER_PORT,
+                ttyd_proxy_port=TTYD_PROXY_PORT,
+            )
 
         sandbox.open.aio.assert_not_called()
 
@@ -268,7 +364,13 @@ class TestResolveAndSetupTunnelsWritesFile:
             patch("src.sandbox.manager.log"),
         ):
             _cs, _ttyd, extra = await SandboxManager._resolve_and_setup_tunnels(
-                sandbox, "sb-1", False, False, [3000]
+                sandbox,
+                "sb-1",
+                False,
+                False,
+                [3000],
+                code_server_port=CODE_SERVER_PORT,
+                ttyd_proxy_port=TTYD_PROXY_PORT,
             )
 
         assert extra == {3000: "https://tunnel-3000.example.com"}
@@ -378,47 +480,72 @@ class TestCollectExposedPorts:
     """SandboxManager._collect_exposed_ports tests."""
 
     def test_no_ports_when_no_settings(self):
-        exposed, tunnel = SandboxManager._collect_exposed_ports(False, False, None)
+        exposed, tunnel = SandboxManager._collect_exposed_ports(
+            False, False, None, CODE_SERVER_PORT, TTYD_PROXY_PORT
+        )
         assert exposed == []
         assert tunnel == []
 
     def test_code_server_only(self):
-        exposed, tunnel = SandboxManager._collect_exposed_ports(True, False, None)
+        exposed, tunnel = SandboxManager._collect_exposed_ports(
+            True, False, None, CODE_SERVER_PORT, TTYD_PROXY_PORT
+        )
         assert exposed == [CODE_SERVER_PORT]
         assert tunnel == []
 
     def test_tunnel_ports_only(self):
         exposed, tunnel = SandboxManager._collect_exposed_ports(
-            False, False, {"tunnelPorts": [3000, 5173]}
+            False, False, {"tunnelPorts": [3000, 5173]}, CODE_SERVER_PORT, TTYD_PROXY_PORT
         )
         assert exposed == [3000, 5173]
         assert tunnel == [3000, 5173]
 
     def test_combined_code_server_and_tunnels(self):
         exposed, tunnel = SandboxManager._collect_exposed_ports(
-            True, False, {"tunnelPorts": [3000]}
+            True, False, {"tunnelPorts": [3000]}, CODE_SERVER_PORT, TTYD_PROXY_PORT
         )
         assert exposed == [CODE_SERVER_PORT, 3000]
         assert tunnel == [3000]
 
     def test_terminal_only(self):
-        exposed, tunnel = SandboxManager._collect_exposed_ports(False, True, None)
+        exposed, tunnel = SandboxManager._collect_exposed_ports(
+            False, True, None, CODE_SERVER_PORT, TTYD_PROXY_PORT
+        )
         assert exposed == [TTYD_PROXY_PORT]
         assert tunnel == []
 
     def test_deduplicates_ttyd_port_from_tunnels(self):
         exposed, tunnel = SandboxManager._collect_exposed_ports(
-            False, True, {"tunnelPorts": [TTYD_PROXY_PORT, 3000]}
+            False, True, {"tunnelPorts": [TTYD_PROXY_PORT, 3000]}, CODE_SERVER_PORT, TTYD_PROXY_PORT
         )
         assert exposed == [TTYD_PROXY_PORT, 3000]
         assert tunnel == [3000]
 
     def test_deduplicates_code_server_port_from_tunnels(self):
         exposed, tunnel = SandboxManager._collect_exposed_ports(
-            True, False, {"tunnelPorts": [CODE_SERVER_PORT, 3000]}
+            True,
+            False,
+            {"tunnelPorts": [CODE_SERVER_PORT, 3000]},
+            CODE_SERVER_PORT,
+            TTYD_PROXY_PORT,
         )
         assert exposed == [CODE_SERVER_PORT, 3000]
         assert tunnel == [3000]
+
+    def test_custom_code_server_port_frees_default_for_tunnel(self):
+        # code-server moved to 8081 → the default 8080 is free as a user tunnel.
+        exposed, tunnel = SandboxManager._collect_exposed_ports(
+            True, False, {"tunnelPorts": [CODE_SERVER_PORT]}, 8081, TTYD_PROXY_PORT
+        )
+        assert exposed == [8081, CODE_SERVER_PORT]
+        assert tunnel == [CODE_SERVER_PORT]
+
+    def test_custom_terminal_port_frees_default_for_tunnel(self):
+        exposed, tunnel = SandboxManager._collect_exposed_ports(
+            False, True, {"tunnelPorts": [TTYD_PROXY_PORT, 3000]}, CODE_SERVER_PORT, 7000
+        )
+        assert exposed == [7000, TTYD_PROXY_PORT, 3000]
+        assert tunnel == [TTYD_PROXY_PORT, 3000]
 
 
 class TestValidatePorts:
@@ -439,3 +566,100 @@ class TestValidatePorts:
 
     def test_empty_list(self):
         assert SandboxManager._validate_ports([]) == []
+
+
+def _patch_sandbox_create(monkeypatch, captured: dict) -> None:
+    """Stub modal.Sandbox.create + tunnel resolution; capture the env passed to create."""
+
+    async def fake_create_aio(*args, **kwargs):
+        captured["env"] = kwargs.get("env") or {}
+
+        class FakeSandbox:
+            object_id = "obj-1"
+            stdout = None
+
+        return FakeSandbox()
+
+    fake_create_aio.aio = fake_create_aio
+    monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", fake_create_aio)
+    monkeypatch.setattr(
+        SandboxManager,
+        "_resolve_and_setup_tunnels",
+        AsyncMock(return_value=(None, None, None)),
+    )
+
+
+class TestResolveServicePorts:
+    """SandboxManager._resolve_service_ports tests."""
+
+    def test_defaults_when_unset(self):
+        assert SandboxManager._resolve_service_ports(None) == (CODE_SERVER_PORT, TTYD_PROXY_PORT)
+        assert SandboxManager._resolve_service_ports({}) == (CODE_SERVER_PORT, TTYD_PROXY_PORT)
+
+    def test_uses_configured_ports(self):
+        assert SandboxManager._resolve_service_ports(
+            {"codeServerPort": 9000, "terminalPort": 9001}
+        ) == (9000, 9001)
+
+    def test_falls_back_on_invalid(self):
+        assert SandboxManager._resolve_service_ports(
+            {"codeServerPort": 0, "terminalPort": 99999}
+        ) == (CODE_SERVER_PORT, TTYD_PROXY_PORT)
+        # strings and bools are not valid in-range ints
+        assert SandboxManager._resolve_service_ports(
+            {"codeServerPort": "8081", "terminalPort": True}
+        ) == (CODE_SERVER_PORT, TTYD_PROXY_PORT)
+
+
+class TestServicePortEnvVars:
+    """create_sandbox sets CODE_SERVER_PORT / TTYD_PROXY_PORT env when features are enabled."""
+
+    @pytest.mark.asyncio
+    async def test_sets_code_server_port_env_when_enabled(self, monkeypatch):
+        captured: dict[str, dict[str, str]] = {}
+        _patch_sandbox_create(monkeypatch, captured)
+
+        manager = SandboxManager()
+        await manager.create_sandbox(
+            SandboxConfig(
+                repo_owner="acme",
+                repo_name="repo",
+                code_server_enabled=True,
+                settings={"codeServerPort": 8081},
+            )
+        )
+
+        assert captured["env"][CODE_SERVER_PORT_ENV_VAR] == "8081"
+
+    @pytest.mark.asyncio
+    async def test_omits_code_server_port_env_when_disabled(self, monkeypatch):
+        captured: dict[str, dict[str, str]] = {}
+        _patch_sandbox_create(monkeypatch, captured)
+
+        manager = SandboxManager()
+        await manager.create_sandbox(
+            SandboxConfig(
+                repo_owner="acme",
+                repo_name="repo",
+                code_server_enabled=False,
+                settings={"codeServerPort": 8081},
+            )
+        )
+
+        assert CODE_SERVER_PORT_ENV_VAR not in captured["env"]
+
+    @pytest.mark.asyncio
+    async def test_sets_terminal_port_env_when_terminal_enabled(self, monkeypatch):
+        captured: dict[str, dict[str, str]] = {}
+        _patch_sandbox_create(monkeypatch, captured)
+
+        manager = SandboxManager()
+        await manager.create_sandbox(
+            SandboxConfig(
+                repo_owner="acme",
+                repo_name="repo",
+                settings={"terminalEnabled": True, "terminalPort": 7000},
+            )
+        )
+
+        assert captured["env"][TTYD_PROXY_PORT_ENV_VAR] == "7000"

--- a/packages/sandbox-runtime/src/sandbox_runtime/constants.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/constants.py
@@ -1,8 +1,17 @@
 """Shared constants for sandbox modules."""
 
+# Default service ports. The control plane may override the externally-exposed
+# ones per session via the *_ENV_VAR env vars below; the entrypoint and ttyd
+# proxy fall back to these defaults. TTYD_PORT is localhost-only and fixed — it
+# is never exposed and has no env override (7681 is reserved so nothing collides).
 CODE_SERVER_PORT = 8080
 TTYD_PORT = 7681
 TTYD_PROXY_PORT = 7680
+
+# Env vars carrying per-session port overrides for the in-sandbox runtime, set by
+# the control plane when the respective feature is enabled.
+CODE_SERVER_PORT_ENV_VAR = "CODE_SERVER_PORT"
+TTYD_PROXY_PORT_ENV_VAR = "TTYD_PROXY_PORT"
 
 # Dotenv file containing `TUNNEL_<port>=<url>` per line, consumed by local
 # services via `--env-file` or direct read.

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -24,15 +24,29 @@ import httpx
 
 from .constants import (
     CODE_SERVER_PORT,
+    CODE_SERVER_PORT_ENV_VAR,
     EXPECTED_TUNNEL_PORTS_ENV_VAR,
     TTYD_PORT,
     TTYD_PROXY_PORT,
+    TTYD_PROXY_PORT_ENV_VAR,
     TUNNEL_ENV_FILE_PATH,
 )
 from .log_config import configure_logging, get_logger
 from .repo_image_callback import RepoImageBuildCallback
 
 configure_logging()
+
+
+def _port_from_env(env_var: str, default: int) -> int:
+    """Read an integer port from the environment, falling back to ``default``."""
+    raw = os.environ.get(env_var)
+    if raw is None:
+        return default
+    try:
+        port = int(raw)
+    except ValueError:
+        return default
+    return port if 1 <= port <= 65535 else default
 
 
 AGENT_TOOLS_GATED_ON_ENV: dict[str, str] = {
@@ -567,10 +581,11 @@ class SandboxSupervisor:
         if self.repo_path.exists() and (self.repo_path / ".git").exists():
             workdir = self.repo_path
 
+        code_server_port = _port_from_env(CODE_SERVER_PORT_ENV_VAR, CODE_SERVER_PORT)
         self.code_server_process = await asyncio.create_subprocess_exec(
             "code-server",
             "--bind-addr",
-            f"0.0.0.0:{CODE_SERVER_PORT}",
+            f"0.0.0.0:{code_server_port}",
             "--auth",
             "password",
             "--disable-telemetry",
@@ -582,7 +597,7 @@ class SandboxSupervisor:
         )
 
         asyncio.create_task(self._forward_code_server_logs())
-        self.log.info("code_server.started", port=CODE_SERVER_PORT)
+        self.log.info("code_server.started", port=code_server_port)
 
     async def _forward_code_server_logs(self) -> None:
         """Forward code-server stdout to supervisor stdout."""
@@ -712,7 +727,7 @@ class SandboxSupervisor:
         cmd = [
             "ttyd",
             "--port",
-            str(TTYD_PORT),
+            str(TTYD_PORT),  # localhost-only internal port; fixed (never exposed)
             "--interface",
             "127.0.0.1",  # localhost only — proxy is the only external gateway
             "--writable",
@@ -739,7 +754,10 @@ class SandboxSupervisor:
 
         cmd = ["bun", "run", "/app/sandbox_runtime/ttyd_proxy/server.ts"]
 
-        self.log.info("ttyd_proxy.starting", port=TTYD_PROXY_PORT)
+        self.log.info(
+            "ttyd_proxy.starting",
+            port=_port_from_env(TTYD_PROXY_PORT_ENV_VAR, TTYD_PROXY_PORT),
+        )
 
         self.ttyd_proxy_process = await asyncio.create_subprocess_exec(
             *cmd,
@@ -1471,7 +1489,8 @@ class SandboxSupervisor:
 
             if self.ttyd_process is not None:
                 ttyd_ready = await self._wait_for_port(
-                    TTYD_PORT, timeout_seconds=self.SIDECAR_TIMEOUT_SECONDS
+                    TTYD_PORT,
+                    timeout_seconds=self.SIDECAR_TIMEOUT_SECONDS,
                 )
                 if ttyd_ready:
                     try:

--- a/packages/sandbox-runtime/src/sandbox_runtime/ttyd_proxy/server.ts
+++ b/packages/sandbox-runtime/src/sandbox_runtime/ttyd_proxy/server.ts
@@ -7,8 +7,19 @@
  * Usage: bun run /app/sandbox_runtime/ttyd_proxy/server.ts
  */
 
+// PROXY_PORT (the externally-exposed, tunneled bind port) may be overridden by
+// the control plane via the TTYD_PROXY_PORT env var; its default mirrors
+// TTYD_PROXY_PORT in ../constants.py. TTYD_PORT is the fixed localhost-only
+// upstream (mirrors TTYD_PORT in ../constants.py) — no env override.
+function portFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535 ? parsed : fallback;
+}
+
 const TTYD_PORT = 7681;
-const PROXY_PORT = 7680;
+const PROXY_PORT = portFromEnv("TTYD_PROXY_PORT", 7680);
 const SECRET = process.env.SANDBOX_AUTH_TOKEN;
 
 if (!SECRET) {

--- a/packages/sandbox-runtime/tests/test_service_ports.py
+++ b/packages/sandbox-runtime/tests/test_service_ports.py
@@ -1,0 +1,126 @@
+"""Tests for configurable code-server / ttyd ports in the sandbox runtime."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sandbox_runtime.constants import CODE_SERVER_PORT, TTYD_PORT
+from sandbox_runtime.entrypoint import SandboxSupervisor, _port_from_env
+
+
+class TestPortFromEnv:
+    def test_returns_default_when_unset(self):
+        with patch.dict("os.environ", {}, clear=True):
+            assert _port_from_env("X_TEST_PORT", 1234) == 1234
+
+    def test_reads_override(self):
+        with patch.dict("os.environ", {"X_TEST_PORT": "4321"}, clear=True):
+            assert _port_from_env("X_TEST_PORT", 1234) == 4321
+
+    def test_falls_back_on_non_numeric(self):
+        with patch.dict("os.environ", {"X_TEST_PORT": "abc"}, clear=True):
+            assert _port_from_env("X_TEST_PORT", 1234) == 1234
+
+    def test_falls_back_on_out_of_range(self):
+        with patch.dict("os.environ", {"X_TEST_PORT": "99999"}, clear=True):
+            assert _port_from_env("X_TEST_PORT", 1234) == 1234
+
+
+def _make_supervisor() -> SandboxSupervisor:
+    with patch.dict(
+        "os.environ",
+        {
+            "SANDBOX_ID": "test-sandbox",
+            "CONTROL_PLANE_URL": "https://cp.example.com",
+            "SANDBOX_AUTH_TOKEN": "tok",
+            "REPO_OWNER": "acme",
+            "REPO_NAME": "app",
+        },
+    ):
+        return SandboxSupervisor()
+
+
+class TestStartCodeServerPort:
+    @pytest.mark.asyncio
+    async def test_binds_to_env_port(self):
+        sup = _make_supervisor()
+        sup._forward_code_server_logs = AsyncMock()
+        proc = MagicMock()
+        proc.stdout = None
+        with (
+            patch.dict(
+                "os.environ",
+                {"CODE_SERVER_PASSWORD": "pw", "CODE_SERVER_PORT": "9999"},
+                clear=True,
+            ),
+            patch(
+                "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+                return_value=proc,
+            ) as mock_exec,
+        ):
+            await sup.start_code_server()
+
+        assert "0.0.0.0:9999" in mock_exec.call_args[0]
+
+    @pytest.mark.asyncio
+    async def test_binds_to_default_when_unset(self):
+        sup = _make_supervisor()
+        sup._forward_code_server_logs = AsyncMock()
+        proc = MagicMock()
+        proc.stdout = None
+        with (
+            patch.dict("os.environ", {"CODE_SERVER_PASSWORD": "pw"}, clear=True),
+            patch(
+                "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+                return_value=proc,
+            ) as mock_exec,
+        ):
+            await sup.start_code_server()
+
+        assert f"0.0.0.0:{CODE_SERVER_PORT}" in mock_exec.call_args[0]
+
+
+class TestStartTtydPort:
+    @pytest.mark.asyncio
+    async def test_binds_internal_ttyd_to_default(self):
+        sup = _make_supervisor()
+        sup._forward_ttyd_logs = AsyncMock()
+        proc = MagicMock()
+        proc.stdout = None
+        with (
+            patch.dict("os.environ", {"TERMINAL_ENABLED": "true"}, clear=True),
+            patch(
+                "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+                return_value=proc,
+            ) as mock_exec,
+        ):
+            await sup.start_ttyd()
+
+        assert str(TTYD_PORT) in mock_exec.call_args[0]
+
+    @pytest.mark.asyncio
+    async def test_ignores_ttyd_port_env_override(self):
+        """The internal ttyd port is fixed — a TTYD_PORT env var must not move it."""
+        sup = _make_supervisor()
+        sup._forward_ttyd_logs = AsyncMock()
+        proc = MagicMock()
+        proc.stdout = None
+        with (
+            patch.dict(
+                "os.environ",
+                {"TERMINAL_ENABLED": "true", "TTYD_PORT": "9999"},
+                clear=True,
+            ),
+            patch(
+                "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
+                new_callable=AsyncMock,
+                return_value=proc,
+            ) as mock_exec,
+        ):
+            await sup.start_ttyd()
+
+        assert str(TTYD_PORT) in mock_exec.call_args[0]
+        assert "9999" not in mock_exec.call_args[0]

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -42,6 +42,59 @@ export interface CodeServerSettings {
 /** Maximum number of tunnel ports a user can configure per sandbox. */
 export const MAX_TUNNEL_PORTS = 10;
 
+/**
+ * Default port code-server binds to inside the sandbox. Mirrors
+ * `CODE_SERVER_PORT` in `packages/sandbox-runtime/src/sandbox_runtime/constants.py`.
+ */
+export const DEFAULT_CODE_SERVER_PORT = 8080;
+
+/**
+ * Default port the web terminal (ttyd) proxy is exposed on. Mirrors
+ * `TTYD_PROXY_PORT` in `packages/sandbox-runtime/src/sandbox_runtime/constants.py`.
+ */
+export const DEFAULT_TERMINAL_PORT = 7680;
+
+/**
+ * Internal ttyd port (localhost-only, behind the proxy). Reserved: it is never
+ * exposed and cannot be chosen as a code-server, terminal, or tunnel port.
+ * Mirrors `TTYD_PORT` in `packages/sandbox-runtime/src/sandbox_runtime/constants.py`.
+ */
+export const INTERNAL_TTYD_PORT = 7681;
+
+/** A configured sandbox port plus where it came from, for conflict diagnostics. */
+export interface ConfiguredSandboxPort {
+  port: number;
+  /** Human-readable source, e.g. "codeServerPort" or "terminal port". */
+  label: string;
+}
+
+/** A port conflict: either the reserved internal port, or a duplicate. */
+export type SandboxPortConflict =
+  | { kind: "reserved"; port: number; label: string }
+  | { kind: "duplicate"; port: number; label: string };
+
+/**
+ * Find the first conflict across configured sandbox ports (code-server,
+ * terminal, and tunnel ports): a port equal to the reserved internal ttyd port
+ * ({@link INTERNAL_TTYD_PORT}), or a port used more than once. Returns null when
+ * every port is usable.
+ *
+ * Enablement-independent — every configured port must be unique so none is
+ * silently dropped at sandbox spawn. Shared by control-plane validation and the
+ * web settings UI so the rule lives in exactly one place.
+ */
+export function findSandboxPortConflict(
+  ports: ConfiguredSandboxPort[]
+): SandboxPortConflict | null {
+  const seen = new Set<number>();
+  for (const { port, label } of ports) {
+    if (port === INTERNAL_TTYD_PORT) return { kind: "reserved", port, label };
+    if (seen.has(port)) return { kind: "duplicate", port, label };
+    seen.add(port);
+  }
+  return null;
+}
+
 /** Default maximum active agent-spawned child sessions per parent session. */
 export const DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS = 5;
 
@@ -62,6 +115,18 @@ export interface SandboxSettings {
   tunnelPorts?: number[];
   /** Enable a browser-based terminal (ttyd) in sandbox sessions. */
   terminalEnabled?: boolean;
+  /**
+   * Port code-server binds to inside the sandbox (only used when code-server is
+   * enabled). Unset → DEFAULT_CODE_SERVER_PORT. Set this to free the default
+   * port for your own service on a tunnel.
+   */
+  codeServerPort?: number;
+  /**
+   * Port the web terminal (ttyd) proxy is exposed on (only used when
+   * `terminalEnabled`). Unset → DEFAULT_TERMINAL_PORT. Ignored by providers
+   * without terminal support.
+   */
+  terminalPort?: number;
   /** Maximum active agent-spawned child sessions per parent session. */
   maxConcurrentChildSessions?: number;
   /** Maximum total agent-spawned child sessions per parent session. */

--- a/packages/web/src/components/settings/sandbox-settings.test.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.test.tsx
@@ -205,6 +205,88 @@ describe("SandboxSettingsPage — tunnel ports editor", () => {
     });
   });
 
+  it("includes configured code-server and terminal ports in the save payload", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "PUT") {
+        return new Response(JSON.stringify({}), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${String(input)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <SWRConfig
+        value={{
+          provider: () => new Map(),
+          fallback: { [SETTINGS_KEY]: globalSettings([], ["acme/app"]) },
+          dedupingInterval: Infinity,
+          revalidateOnFocus: false,
+          revalidateIfStale: false,
+          revalidateOnReconnect: false,
+        }}
+      >
+        <SandboxSettingsPage />
+      </SWRConfig>
+    );
+
+    await user.type(screen.getByPlaceholderText("8080"), "8081");
+    await user.type(screen.getByPlaceholderText("7680"), "7000");
+    await user.click(screen.getByText("Save Settings"));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        SETTINGS_KEY,
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({
+            settings: {
+              defaults: {
+                tunnelPorts: [],
+                terminalEnabled: false,
+                codeServerPort: 8081,
+                terminalPort: 7000,
+                maxConcurrentChildSessions: DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS,
+                maxTotalChildSessions: DEFAULT_MAX_TOTAL_CHILD_SESSIONS,
+              },
+              enabledRepos: ["acme/app"],
+            },
+          }),
+        })
+      );
+    });
+  });
+
+  it("rejects a service port that duplicates a tunnel port", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({}), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <SWRConfig
+        value={{
+          provider: () => new Map(),
+          fallback: { [SETTINGS_KEY]: globalSettings([], ["acme/app"]) },
+          dedupingInterval: Infinity,
+          revalidateOnFocus: false,
+          revalidateIfStale: false,
+          revalidateOnReconnect: false,
+        }}
+      >
+        <SandboxSettingsPage />
+      </SWRConfig>
+    );
+
+    await user.click(screen.getByText("Add port"));
+    await user.type(screen.getByPlaceholderText("e.g. 3000"), "3000");
+    await user.type(screen.getByPlaceholderText("8080"), "3000");
+    await user.click(screen.getByText("Save Settings"));
+
+    expect(screen.getByText(/must all be different/)).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      SETTINGS_KEY,
+      expect.objectContaining({ method: "PUT" })
+    );
+  });
+
   it("renders child session limits from settings", () => {
     renderWithSWR(
       globalSettings([], undefined, {

--- a/packages/web/src/components/settings/sandbox-settings.test.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.test.tsx
@@ -181,7 +181,7 @@ describe("SandboxSettingsPage — tunnel ports editor", () => {
     );
 
     await user.click(screen.getByText("Add port"));
-    await user.type(screen.getByPlaceholderText("e.g. 3000"), "8080");
+    await user.type(screen.getByPlaceholderText("e.g. 3000"), "3000");
     await user.click(screen.getByText("Save Settings"));
 
     await waitFor(() => {
@@ -192,7 +192,7 @@ describe("SandboxSettingsPage — tunnel ports editor", () => {
           body: JSON.stringify({
             settings: {
               defaults: {
-                tunnelPorts: [8080],
+                tunnelPorts: [3000],
                 terminalEnabled: false,
                 maxConcurrentChildSessions: DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS,
                 maxTotalChildSessions: DEFAULT_MAX_TOTAL_CHILD_SESSIONS,
@@ -285,6 +285,89 @@ describe("SandboxSettingsPage — tunnel ports editor", () => {
       SETTINGS_KEY,
       expect.objectContaining({ method: "PUT" })
     );
+  });
+
+  it("rejects a tunnel port that collides with a blank service port's default", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({}), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <SWRConfig
+        value={{
+          provider: () => new Map(),
+          fallback: { [SETTINGS_KEY]: globalSettings([], ["acme/app"]) },
+          dedupingInterval: Infinity,
+          revalidateOnFocus: false,
+          revalidateIfStale: false,
+          revalidateOnReconnect: false,
+        }}
+      >
+        <SandboxSettingsPage />
+      </SWRConfig>
+    );
+
+    // Code-server port left blank → effective default 8080, so tunneling 8080 collides.
+    await user.click(screen.getByText("Add port"));
+    await user.type(screen.getByPlaceholderText("e.g. 3000"), "8080");
+    await user.click(screen.getByText("Save Settings"));
+
+    expect(screen.getByText(/must all be different/)).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      SETTINGS_KEY,
+      expect.objectContaining({ method: "PUT" })
+    );
+  });
+
+  it("allows tunneling a default port once its service port is moved", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "PUT") {
+        return new Response(JSON.stringify({}), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${String(input)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <SWRConfig
+        value={{
+          provider: () => new Map(),
+          fallback: { [SETTINGS_KEY]: globalSettings([], ["acme/app"]) },
+          dedupingInterval: Infinity,
+          revalidateOnFocus: false,
+          revalidateIfStale: false,
+          revalidateOnReconnect: false,
+        }}
+      >
+        <SandboxSettingsPage />
+      </SWRConfig>
+    );
+
+    // Move code-server off 8080, then 8080 is free to tunnel.
+    await user.type(screen.getByPlaceholderText("8080"), "8081");
+    await user.click(screen.getByText("Add port"));
+    await user.type(screen.getByPlaceholderText("e.g. 3000"), "8080");
+    await user.click(screen.getByText("Save Settings"));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        SETTINGS_KEY,
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({
+            settings: {
+              defaults: {
+                tunnelPorts: [8080],
+                terminalEnabled: false,
+                codeServerPort: 8081,
+                maxConcurrentChildSessions: DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS,
+                maxTotalChildSessions: DEFAULT_MAX_TOTAL_CHILD_SESSIONS,
+              },
+              enabledRepos: ["acme/app"],
+            },
+          }),
+        })
+      );
+    });
   });
 
   it("renders child session limits from settings", () => {

--- a/packages/web/src/components/settings/sandbox-settings.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.tsx
@@ -7,10 +7,13 @@ import { ChevronDownIcon, CheckIcon, PlusIcon } from "@/components/ui/icons";
 import { Combobox } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import useSWR from "swr";
-import type { SandboxSettings } from "@open-inspect/shared";
+import type { ConfiguredSandboxPort, SandboxSettings } from "@open-inspect/shared";
 import {
+  DEFAULT_CODE_SERVER_PORT,
   DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS,
   DEFAULT_MAX_TOTAL_CHILD_SESSIONS,
+  DEFAULT_TERMINAL_PORT,
+  findSandboxPortConflict,
   MAX_TUNNEL_PORTS,
 } from "@open-inspect/shared";
 
@@ -120,6 +123,14 @@ function SandboxSettingsEditor({
     ? ((data as GlobalSettingsResponse)?.settings?.defaults?.terminalEnabled ?? false)
     : ((data as RepoSettingsResponse)?.settings?.terminalEnabled ?? false);
 
+  const currentCodeServerPort: number | undefined = isGlobal
+    ? (data as GlobalSettingsResponse)?.settings?.defaults?.codeServerPort
+    : (data as RepoSettingsResponse)?.settings?.codeServerPort;
+
+  const currentTerminalPort: number | undefined = isGlobal
+    ? (data as GlobalSettingsResponse)?.settings?.defaults?.terminalPort
+    : (data as RepoSettingsResponse)?.settings?.terminalPort;
+
   const currentMaxConcurrentChildSessions: number = isGlobal
     ? (globalDefaults?.maxConcurrentChildSessions ?? DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS)
     : (repoSettings?.maxConcurrentChildSessions ??
@@ -142,6 +153,8 @@ function SandboxSettingsEditor({
 
   const [portRows, setPortRows] = useState<string[] | null>(null);
   const [terminalEnabled, setTerminalEnabled] = useState<boolean | null>(null);
+  const [codeServerPort, setCodeServerPort] = useState<string | null>(null);
+  const [terminalPort, setTerminalPort] = useState<string | null>(null);
   const [maxConcurrentChildSessions, setMaxConcurrentChildSessions] = useState<string | null>(null);
   const [maxTotalChildSessions, setMaxTotalChildSessions] = useState<string | null>(null);
   const [cpuCores, setCpuCores] = useState<string | null>(null);
@@ -163,6 +176,10 @@ function SandboxSettingsEditor({
     cpuCores ?? (currentCpuCores !== undefined ? String(currentCpuCores) : "");
   const resolvedMemoryMib =
     memoryMib ?? (currentMemoryMib !== undefined ? String(currentMemoryMib) : "");
+  const resolvedCodeServerPort =
+    codeServerPort ?? (currentCodeServerPort !== undefined ? String(currentCodeServerPort) : "");
+  const resolvedTerminalPort =
+    terminalPort ?? (currentTerminalPort !== undefined ? String(currentTerminalPort) : "");
 
   const handleAddRow = () => {
     if (rows.length >= MAX_TUNNEL_PORTS) return;
@@ -220,6 +237,38 @@ function SandboxSettingsEditor({
       return;
     }
 
+    const trimmedCodeServerPort = resolvedCodeServerPort.trim();
+    if (trimmedCodeServerPort !== "" && !isValidPort(trimmedCodeServerPort)) {
+      setError("Code server port must be a whole number between 1 and 65535.");
+      return;
+    }
+
+    const trimmedTerminalPort = resolvedTerminalPort.trim();
+    if (trimmedTerminalPort !== "" && !isValidPort(trimmedTerminalPort)) {
+      setError("Terminal port must be a whole number between 1 and 65535.");
+      return;
+    }
+
+    const configuredPorts: ConfiguredSandboxPort[] = ports.map((port) => ({
+      port,
+      label: "tunnel port",
+    }));
+    if (trimmedCodeServerPort !== "") {
+      configuredPorts.push({ port: Number(trimmedCodeServerPort), label: "code server port" });
+    }
+    if (trimmedTerminalPort !== "") {
+      configuredPorts.push({ port: Number(trimmedTerminalPort), label: "terminal port" });
+    }
+    const portConflict = findSandboxPortConflict(configuredPorts);
+    if (portConflict) {
+      setError(
+        portConflict.kind === "reserved"
+          ? `Port ${portConflict.port} is reserved for the internal terminal and cannot be used.`
+          : "Code server, terminal, and tunnel ports must all be different."
+      );
+      return;
+    }
+
     setSaving(true);
     try {
       const existingEnabledRepos = isGlobal
@@ -229,6 +278,12 @@ function SandboxSettingsEditor({
         tunnelPorts: ports,
         terminalEnabled: resolvedTerminalEnabled,
       };
+      if (trimmedCodeServerPort !== "") {
+        settingsPayload.codeServerPort = Number(trimmedCodeServerPort);
+      }
+      if (trimmedTerminalPort !== "") {
+        settingsPayload.terminalPort = Number(trimmedTerminalPort);
+      }
       if (
         isGlobal ||
         maxConcurrentChildSessions !== null ||
@@ -274,6 +329,8 @@ function SandboxSettingsEditor({
       setMaxTotalChildSessions(null);
       setCpuCores(null);
       setMemoryMib(null);
+      setCodeServerPort(null);
+      setTerminalPort(null);
       setSuccess(true);
       setTimeout(() => setSuccess(false), 2000);
     } catch (e) {
@@ -292,6 +349,8 @@ function SandboxSettingsEditor({
     resolvedMaxTotalChildSessions,
     resolvedCpuCores,
     resolvedMemoryMib,
+    resolvedCodeServerPort,
+    resolvedTerminalPort,
     cpuCores,
     memoryMib,
     maxConcurrentChildSessions,
@@ -316,13 +375,23 @@ function SandboxSettingsEditor({
   const currentMemoryMibString = currentMemoryMib !== undefined ? String(currentMemoryMib) : "";
   const hasCpuChange = cpuCores !== null && cpuCores.trim() !== currentCpuCoresString;
   const hasMemoryChange = memoryMib !== null && memoryMib.trim() !== currentMemoryMibString;
+  const currentCodeServerPortString =
+    currentCodeServerPort !== undefined ? String(currentCodeServerPort) : "";
+  const currentTerminalPortString =
+    currentTerminalPort !== undefined ? String(currentTerminalPort) : "";
+  const hasCodeServerPortChange =
+    codeServerPort !== null && codeServerPort.trim() !== currentCodeServerPortString;
+  const hasTerminalPortChange =
+    terminalPort !== null && terminalPort.trim() !== currentTerminalPortString;
   const hasChanges =
     hasPortChanges ||
     hasTerminalChange ||
     hasConcurrentLimitChange ||
     hasTotalLimitChange ||
     hasCpuChange ||
-    hasMemoryChange;
+    hasMemoryChange ||
+    hasCodeServerPortChange ||
+    hasTerminalPortChange;
 
   if (isLoading || isLoadingGlobal) {
     return <p className="text-sm text-muted-foreground">Loading...</p>;
@@ -354,6 +423,49 @@ function SandboxSettingsEditor({
               }`}
             />
           </button>
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-foreground mb-1.5">Service Ports</label>
+        <p className="text-xs text-muted-foreground mb-2">
+          Ports code-server and the web terminal bind to. Leave blank for the defaults (
+          {DEFAULT_CODE_SERVER_PORT} and {DEFAULT_TERMINAL_PORT}). Change a port to free the default
+          for your own service on a tunnel. Code-server is enabled in its own settings.
+        </p>
+        <div className="grid gap-3 max-w-sm sm:grid-cols-2">
+          <div>
+            <label
+              htmlFor="code-server-port"
+              className="block text-xs font-medium text-muted-foreground mb-1"
+            >
+              Code server port
+            </label>
+            <Input
+              id="code-server-port"
+              type="text"
+              inputMode="numeric"
+              value={resolvedCodeServerPort}
+              onChange={(e) => setCodeServerPort(e.target.value)}
+              placeholder={String(DEFAULT_CODE_SERVER_PORT)}
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="terminal-port"
+              className="block text-xs font-medium text-muted-foreground mb-1"
+            >
+              Terminal port
+            </label>
+            <Input
+              id="terminal-port"
+              type="text"
+              inputMode="numeric"
+              value={resolvedTerminalPort}
+              onChange={(e) => setTerminalPort(e.target.value)}
+              placeholder={String(DEFAULT_TERMINAL_PORT)}
+            />
+          </div>
         </div>
       </div>
 

--- a/packages/web/src/components/settings/sandbox-settings.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.tsx
@@ -249,16 +249,27 @@ function SandboxSettingsEditor({
       return;
     }
 
-    const configuredPorts: ConfiguredSandboxPort[] = ports.map((port) => ({
-      port,
-      label: "tunnel port",
-    }));
-    if (trimmedCodeServerPort !== "") {
-      configuredPorts.push({ port: Number(trimmedCodeServerPort), label: "code server port" });
-    }
-    if (trimmedTerminalPort !== "") {
-      configuredPorts.push({ port: Number(trimmedTerminalPort), label: "terminal port" });
-    }
+    // Validate against the EFFECTIVE service ports the runtime will bind: an
+    // explicit value, else (at repo scope) the inherited global default, else the
+    // shared default. A blank field still occupies its default port, so a tunnel
+    // on 8080/7680 must be caught here just like an explicit collision.
+    const effectiveCodeServerPort =
+      trimmedCodeServerPort !== ""
+        ? Number(trimmedCodeServerPort)
+        : isGlobal
+          ? DEFAULT_CODE_SERVER_PORT
+          : (globalDefaults?.codeServerPort ?? DEFAULT_CODE_SERVER_PORT);
+    const effectiveTerminalPort =
+      trimmedTerminalPort !== ""
+        ? Number(trimmedTerminalPort)
+        : isGlobal
+          ? DEFAULT_TERMINAL_PORT
+          : (globalDefaults?.terminalPort ?? DEFAULT_TERMINAL_PORT);
+    const configuredPorts: ConfiguredSandboxPort[] = [
+      ...ports.map((port) => ({ port, label: "tunnel port" })),
+      { port: effectiveCodeServerPort, label: "code server port" },
+      { port: effectiveTerminalPort, label: "terminal port" },
+    ];
     const portConflict = findSandboxPortConflict(configuredPorts);
     if (portConflict) {
       setError(
@@ -359,6 +370,8 @@ function SandboxSettingsEditor({
     repoSettings?.maxTotalChildSessions,
     repoSettings?.cpuCores,
     repoSettings?.memoryMib,
+    globalDefaults?.codeServerPort,
+    globalDefaults?.terminalPort,
   ]);
 
   const hasPortChanges =


### PR DESCRIPTION
## Summary

Makes the **code-server** and **web terminal (ttyd proxy)** ports user-configurable from sandbox settings, across all three providers (Modal, Vercel, Daytona). This also fixes a bug where a user's own service running on a default port (e.g. `8080`) was **silently dropped** from the tunnel URL list.

### The original bug

When code-server was disabled but a user exposed their own service on `8080` (or `7680`) via `tunnelPorts`, the Modal manager unconditionally `pop()`-ed those ports out of the resolved tunnel map — so the URL never reached the UI. The pop is now **enablement-aware**: a service port is only pulled out of the tunnel map when that service actually owns it.

## What changed

- **`SandboxSettings.codeServerPort` / `SandboxSettings.terminalPort`** (new, optional). Unset → shared defaults (`8080` / `7680`). Set one to free its default port for your own service on a tunnel.
- **Control plane** validates the ports (range, reserved, and cross-port uniqueness) and passes the effective values to providers, which expose/tunnel them and inject `CODE_SERVER_PORT` / `TTYD_PROXY_PORT` env vars when the relevant feature is enabled.
- **In-sandbox runtime** (`sandbox_runtime` entrypoint + ttyd proxy) reads those env vars with the constants as fallback, so the bind logic changed once and is read by every provider.
- **Web settings** gains a "Service Ports" section with client-side validation mirroring the server rules.

### Provider coverage
- **Modal** — code-server + terminal ports configurable.
- **Vercel** — code-server + terminal ports configurable.
- **Daytona** — code-server port configurable (Daytona has no terminal support; `terminalPort` is ignored there, consistent with `terminalEnabled`).

## Design decisions

- **`codeServerPort` lives in `SandboxSettings`** (alongside `terminalPort` and `tunnelPorts`), even though code-server's *enable* flag lives in the separate code-server integration. This keeps all four port concepts in one object so the cross-port collision check is a single-object validation, and avoids new plumbing through the code-server integration's resolution path. The UI help text notes code-server is enabled in its own settings.
- **Port `7681` is reserved and fixed** — it's the localhost-only internal ttyd port behind the proxy. It can't be chosen for any service/tunnel port, and is intentionally **not** env-configurable.

## Code quality

The conflict rule and the port defaulting each live in exactly one place rather than being duplicated:
- `findSandboxPortConflict()` in `@open-inspect/shared` — the reserved-port + no-duplicates rule, shared by control-plane validation and the web UI.
- `sandbox/providers/port-resolution.ts` — `resolveServicePorts` + `resolveTunnelPorts`, shared by the Vercel and Daytona providers (replaced four near-duplicate copies).

## Testing

| Suite | Result |
|---|---|
| `shared` build, typecheck (control-plane, web) | OK |
| control-plane unit | 1346 passed |
| web | 342 passed |
| sandbox-runtime pytest | 353 passed |
| modal-infra pytest | 145 passed |
| prettier / eslint / ruff | clean |

New coverage includes the enablement-aware-pop regression, custom-port exposure/env wiring per provider, the shared validation rules, and a regression test asserting the internal ttyd port ignores a `TTYD_PORT` env override.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable service ports for code-server and the web terminal in sandbox settings.
  * Updated sandbox runtime to allow per-session overrides of code-server and TTYD proxy ports via environment variables.
* **Bug Fixes**
  * Improved tunnel port handling to avoid collisions with effective service ports and reserved internal ports.
* **Tests**
  * Added/expanded unit and integration tests covering service-port resolution, environment variable behavior, and tunnel splitting rules.
* **Documentation**
  * Added inline guidance for default service port behavior and override semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->