### PR TITLE
feat: configurable repo-image build timeout

### DIFF
--- a/packages/control-plane/src/routes/repo-images.trigger.test.ts
+++ b/packages/control-plane/src/routes/repo-images.trigger.test.ts
@@ -9,6 +9,7 @@ import type * as SourceControlModule from "../source-control";
 import type * as SandboxClientModule from "../sandbox/client";
 import type * as VercelProviderModule from "../sandbox/providers/vercel/provider";
 import type * as VercelClientModule from "../sandbox/providers/vercel/client";
+import type * as IntegrationSettingsResolutionModule from "../session/integration-settings-resolution";
 
 // handleTriggerBuild resolves the repo's actual default branch (never assumes
 // "main") and threads it into the build record + the build backend. The #757
@@ -27,6 +28,10 @@ const modalClient = vi.hoisted(() => ({
 
 const vercelProvider = vi.hoisted(() => ({
   triggerRepoImageBuild: vi.fn(),
+}));
+
+const integrationSettings = vi.hoisted(() => ({
+  resolveSandboxSettings: vi.fn(),
 }));
 
 vi.mock("../source-control", async (importOriginal) => {
@@ -58,6 +63,14 @@ vi.mock("../sandbox/providers/vercel/client", async (importOriginal) => {
   return {
     ...actual,
     createVercelSandboxClient: vi.fn(() => ({})),
+  };
+});
+
+vi.mock("../session/integration-settings-resolution", async (importOriginal) => {
+  const actual = await importOriginal<typeof IntegrationSettingsResolutionModule>();
+  return {
+    ...actual,
+    resolveSandboxSettings: integrationSettings.resolveSandboxSettings,
   };
 });
 
@@ -138,6 +151,7 @@ describe("POST /repo-images/trigger/:owner/:name", () => {
     registerBuildSpy.mockResolvedValue(undefined);
     modalClient.buildRepoImage.mockResolvedValue(undefined);
     vercelProvider.triggerRepoImageBuild.mockResolvedValue(undefined);
+    integrationSettings.resolveSandboxSettings.mockResolvedValue({});
     scmProvider.generateCredentialHelperAuth.mockResolvedValue({
       username: "x-access-token",
       password: "clone-token",
@@ -168,6 +182,7 @@ describe("POST /repo-images/trigger/:owner/:name", () => {
         repoOwner: "acme",
         repoName: "repo",
         defaultBranch: "develop",
+        buildTimeoutSeconds: 1800,
       }),
       expect.any(Object)
     );
@@ -212,6 +227,36 @@ describe("POST /repo-images/trigger/:owner/:name", () => {
         provider: "vercel",
         baseBranch: "develop",
       })
+    );
+  });
+
+  it("resolves and clamps the configured build timeout into the Modal backend", async () => {
+    scmProvider.checkRepositoryAccess.mockResolvedValue(RESOLVED_REPO);
+    integrationSettings.resolveSandboxSettings.mockResolvedValue({ buildTimeoutSeconds: 5000 });
+
+    const response = await callTrigger(createModalEnv());
+
+    expect(response.status).toBe(200);
+    expect(integrationSettings.resolveSandboxSettings).toHaveBeenCalledWith(
+      expect.anything(),
+      "acme",
+      "repo"
+    );
+    expect(modalClient.buildRepoImage).toHaveBeenCalledWith(
+      expect.objectContaining({ buildTimeoutSeconds: 3600 }),
+      expect.any(Object)
+    );
+  });
+
+  it("threads the resolved build timeout into the Vercel backend", async () => {
+    scmProvider.checkRepositoryAccess.mockResolvedValue(RESOLVED_REPO);
+    integrationSettings.resolveSandboxSettings.mockResolvedValue({ buildTimeoutSeconds: 2400 });
+
+    const response = await callTrigger(createVercelEnv());
+
+    expect(response.status).toBe(200);
+    expect(vercelProvider.triggerRepoImageBuild).toHaveBeenCalledWith(
+      expect.objectContaining({ buildTimeoutSeconds: 2400 })
     );
   });
 

--- a/packages/control-plane/src/routes/repo-images.ts
+++ b/packages/control-plane/src/routes/repo-images.ts
@@ -8,8 +8,9 @@
  * - Maintenance operations (stale builds, cleanup)
  */
 
-import { computeHmacHex } from "@open-inspect/shared";
+import { computeHmacHex, resolveBuildTimeoutSeconds } from "@open-inspect/shared";
 import { RepoImageStore } from "../db/repo-images";
+import { resolveSandboxSettings } from "../session/integration-settings-resolution";
 import { verifyInternalToken } from "../auth/internal";
 import { RepoMetadataStore } from "../db/repo-metadata";
 import { GlobalSecretsStore } from "../db/global-secrets";
@@ -643,6 +644,9 @@ async function handleTriggerBuild(
     // Construct callback URL
     const callbackUrl = `${env.WORKER_URL}/repo-images/build-complete`;
 
+    const sandboxSettings = await resolveSandboxSettings(env.DB, owner, name);
+    const buildTimeoutSeconds = resolveBuildTimeoutSeconds(sandboxSettings);
+
     // Best-effort: fetch user secrets for the build sandbox
     let userEnvVars: Record<string, string> | undefined;
     if (env.REPO_SECRETS_ENCRYPTION_KEY) {
@@ -704,6 +708,7 @@ async function handleTriggerBuild(
             buildId,
             callbackUrl,
             userEnvVars,
+            buildTimeoutSeconds,
           },
           { trace_id: ctx.trace_id, request_id: ctx.request_id }
         );
@@ -735,6 +740,7 @@ async function handleTriggerBuild(
           callbackToken,
           userEnvVars,
           cloneToken,
+          buildTimeoutSeconds,
           onProviderSessionCreated: async (providerSessionId) => {
             const bound = await store.bindProviderSession(buildId, "vercel", providerSessionId);
             if (!bound) {
@@ -849,7 +855,9 @@ async function handleMarkStale(
     body = {};
   }
 
-  const maxAgeSeconds = body.max_age_seconds ?? 2100; // 35 minutes default
+  // Body-less fallback only; the scheduler always sends max_age_seconds explicitly.
+  // Mirrors STALE_BUILD_THRESHOLD_SECONDS in the Modal scheduler (image_builder.py).
+  const maxAgeSeconds = body.max_age_seconds ?? 4200;
   const maxAgeMs = maxAgeSeconds * 1000;
 
   const store = new RepoImageStore(env.DB);

--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -121,4 +121,51 @@ describe("ModalClient", () => {
       mcp_servers: [{ id: "mcp-1", name: "Tool", type: "local", enabled: true }],
     });
   });
+
+  it("threads the build timeout into the repo image build request body", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ success: true, data: { build_id: "img-1", status: "building" } }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      );
+
+    const client = createModalClient("secret", "acme", "prod-web");
+    await client.buildRepoImage({
+      repoOwner: "acme",
+      repoName: "repo",
+      defaultBranch: "main",
+      buildId: "img-1",
+      callbackUrl: "https://cp.test/repo-images/build-complete",
+      buildTimeoutSeconds: 2400,
+    });
+
+    const body = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string);
+    expect(body.build_timeout_seconds).toBe(2400);
+  });
+
+  it("sends a null build timeout when unset so Modal applies its default", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ success: true, data: { build_id: "img-1", status: "building" } }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      );
+
+    const client = createModalClient("secret", "acme", "prod-web");
+    await client.buildRepoImage({
+      repoOwner: "acme",
+      repoName: "repo",
+      defaultBranch: "main",
+      buildId: "img-1",
+      callbackUrl: "https://cp.test/repo-images/build-complete",
+    });
+
+    const body = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string);
+    expect(body.build_timeout_seconds).toBeNull();
+  });
 });

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -141,6 +141,12 @@ export interface BuildRepoImageRequest {
   buildId: string;
   callbackUrl: string;
   userEnvVars?: Record<string, string>;
+  /**
+   * Build sandbox lifetime, in seconds. Already capped at
+   * MAX_BUILD_TIMEOUT_SECONDS by the trigger.
+   * Omitted → Modal applies DEFAULT_BUILD_TIMEOUT_SECONDS.
+   */
+  buildTimeoutSeconds?: number;
 }
 
 export interface BuildRepoImageResponse {
@@ -554,6 +560,7 @@ export class ModalClient {
           build_id: request.buildId,
           callback_url: request.callbackUrl,
           user_env_vars: request.userEnvVars,
+          build_timeout_seconds: request.buildTimeoutSeconds ?? null,
         }),
       });
 

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
@@ -575,6 +575,42 @@ describe("VercelSandboxProvider", () => {
     expect(result).toEqual({ buildId: "build-123", status: "building" });
   });
 
+  it("honors an explicit build timeout below the Vercel limit for repo image builds", async () => {
+    const client = createMockClient();
+    const provider = new VercelSandboxProvider(client, providerConfig);
+
+    await provider.triggerRepoImageBuild({
+      buildId: "build-123",
+      repoOwner: "testowner",
+      repoName: "testrepo",
+      defaultBranch: "main",
+      callbackUrl: "https://control-plane.test/repo-images/build-complete",
+      callbackToken: "callback-token",
+      buildTimeoutSeconds: 30 * 60,
+    });
+
+    expect(vi.mocked(client.createSandbox).mock.calls[0][0].timeoutMs).toBe(30 * 60 * 1000);
+  });
+
+  it("caps an over-limit build timeout at Vercel's 45 minute limit", async () => {
+    const client = createMockClient();
+    const provider = new VercelSandboxProvider(client, providerConfig);
+
+    await provider.triggerRepoImageBuild({
+      buildId: "build-123",
+      repoOwner: "testowner",
+      repoName: "testrepo",
+      defaultBranch: "main",
+      callbackUrl: "https://control-plane.test/repo-images/build-complete",
+      callbackToken: "callback-token",
+      buildTimeoutSeconds: 60 * 60,
+    });
+
+    expect(vi.mocked(client.createSandbox).mock.calls[0][0].timeoutMs).toBe(
+      VERCEL_MAX_SANDBOX_TIMEOUT_MS
+    );
+  });
+
   it("fails sandbox launch when tunnel env writing exits non-zero", async () => {
     const client = createMockClient({
       runCommandAndWait: vi.fn(async () => ({ commandId: "cmd-1", exitCode: 1 })),

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.ts
@@ -2,7 +2,11 @@
  * Vercel Sandbox provider implementation.
  */
 
-import { computeHmacHex, type SandboxSettings } from "@open-inspect/shared";
+import {
+  computeHmacHex,
+  DEFAULT_BUILD_TIMEOUT_SECONDS,
+  type SandboxSettings,
+} from "@open-inspect/shared";
 import { resolveServicePorts, resolveTunnelPorts } from "../port-resolution";
 import { createLogger } from "../../../logger";
 import type { CorrelationContext } from "../../../logger";
@@ -37,7 +41,6 @@ const log = createLogger("vercel-provider");
 const TUNNEL_ENV_FILE_PATH = "/workspace/.tunnels.env";
 const EXPECTED_TUNNEL_PORTS_ENV_VAR = "EXPECTED_TUNNEL_PORTS";
 const DEFAULT_SNAPSHOT_EXPIRATION_MS = 0;
-const BUILD_TIMEOUT_SECONDS = 1800;
 const VERCEL_MAX_SANDBOX_TIMEOUT_MS = 45 * 60 * 1000;
 const VERCEL_MEMORY_MIB_PER_VCPU = 2048;
 const VERCEL_SUPPORTED_VCPUS: readonly VercelVcpus[] = [1, 2, 4, 8];
@@ -80,6 +83,12 @@ export interface TriggerVercelRepoImageBuildConfig {
   callbackToken: string;
   userEnvVars?: Record<string, string>;
   cloneToken?: string;
+  /**
+   * Build sandbox lifetime, in seconds (already capped at
+   * MAX_BUILD_TIMEOUT_SECONDS by the trigger). Further capped to Vercel's own
+   * limit. Omitted → DEFAULT_BUILD_TIMEOUT_SECONDS.
+   */
+  buildTimeoutSeconds?: number;
   onProviderSessionCreated?: (providerSessionId: string) => Promise<void>;
   correlation?: CorrelationContext;
 }
@@ -264,7 +273,9 @@ export class VercelSandboxProvider implements SandboxProvider {
         {
           name: sandboxName,
           runtime: this.providerConfig.runtime || DEFAULT_VERCEL_RUNTIME,
-          timeoutMs: BUILD_TIMEOUT_SECONDS * 1000,
+          timeoutMs: resolveVercelTimeoutMs(
+            config.buildTimeoutSeconds ?? DEFAULT_BUILD_TIMEOUT_SECONDS
+          ),
           env,
           tags: {
             openinspect_framework: "open-inspect",

--- a/packages/control-plane/src/sandbox/settings.test.ts
+++ b/packages/control-plane/src/sandbox/settings.test.ts
@@ -51,6 +51,30 @@ describe("normalizeSandboxSettings", () => {
     });
   });
 
+  it("accepts a valid buildTimeoutSeconds", () => {
+    expect(normalizeSandboxSettings({ buildTimeoutSeconds: 2400 })).toEqual({
+      buildTimeoutSeconds: 2400,
+    });
+  });
+
+  it("throws for a non-positive or non-integer buildTimeoutSeconds", () => {
+    expect(() => normalizeSandboxSettings({ buildTimeoutSeconds: 0 })).toThrow(
+      SandboxSettingsValidationError
+    );
+    expect(() => normalizeSandboxSettings({ buildTimeoutSeconds: 12.5 })).toThrow(
+      SandboxSettingsValidationError
+    );
+  });
+
+  it("omits an invalid buildTimeoutSeconds in omit mode while keeping valid fields", () => {
+    expect(
+      normalizeSandboxSettings(
+        { buildTimeoutSeconds: -5, terminalEnabled: true },
+        { invalid: "omit" }
+      )
+    ).toEqual({ terminalEnabled: true });
+  });
+
   it("accepts valid codeServerPort and terminalPort", () => {
     expect(normalizeSandboxSettings({ codeServerPort: 8081, terminalPort: 7000 })).toEqual({
       codeServerPort: 8081,

--- a/packages/control-plane/src/sandbox/settings.ts
+++ b/packages/control-plane/src/sandbox/settings.ts
@@ -122,6 +122,16 @@ export function normalizeSandboxSettings(
     }
   }
 
+  const buildTimeoutSeconds = normalizePositiveIntegerSetting(
+    settings.buildTimeoutSeconds,
+    "buildTimeoutSeconds",
+    reject
+  );
+  if (buildTimeoutSeconds !== undefined) {
+    // Stored as-is; the build trigger caps it at MAX via resolveBuildTimeoutSeconds.
+    result.buildTimeoutSeconds = buildTimeoutSeconds;
+  }
+
   checkPortCollisions(result, reject);
 
   return result;

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -38,7 +38,26 @@ log = get_logger("manager")
 
 DEFAULT_SANDBOX_TIMEOUT_SECONDS = 7200  # 2 hours
 SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS = 300
+# Mirrors DEFAULT_BUILD_TIMEOUT_SECONDS in shared (packages/shared/src/types/integrations.ts).
+DEFAULT_BUILD_TIMEOUT_SECONDS = 1800
+# Mirrors MAX_BUILD_TIMEOUT_SECONDS in shared.
+MAX_BUILD_TIMEOUT_SECONDS = 3600
+BUILD_FUNCTION_TIMEOUT_MARGIN_SECONDS = 300
 MAX_TUNNEL_PORTS = 10
+
+
+def build_function_timeout_seconds(build_timeout_seconds: int) -> int:
+    """Modal function timeout for the build worker (build_repo_image).
+
+    The worker idles until the build sandbox finishes, then snapshots it
+    (SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS) and reports back, so its timeout must
+    exceed the sandbox lifetime plus the snapshot budget plus a margin.
+    """
+    return (
+        build_timeout_seconds
+        + SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS
+        + BUILD_FUNCTION_TIMEOUT_MARGIN_SECONDS
+    )
 
 
 def _resource_kwargs(settings: dict[str, Any] | None) -> dict:
@@ -505,6 +524,7 @@ class SandboxManager:
         default_branch: str = "main",
         clone_token: str = "",
         user_env_vars: dict[str, str] | None = None,
+        timeout_seconds: int = DEFAULT_BUILD_TIMEOUT_SECONDS,
     ) -> SandboxHandle:
         """
         Create a sandbox specifically for image building.
@@ -512,14 +532,13 @@ class SandboxManager:
         Like create_sandbox() but:
         - Sets IMAGE_BUILD_MODE=true (exits after setup, no OpenCode/bridge)
         - No SANDBOX_AUTH_TOKEN, CONTROL_PLANE_URL, or LLM secrets
-        - Shorter timeout (30 min vs 2 hours)
+        - Configurable, shorter lifetime (defaults to DEFAULT_BUILD_TIMEOUT_SECONDS
+          vs the 2-hour session default)
         - Always uses base_image (builds start from the universal base)
 
         Note: MCP servers are not available during image builds (no session config).
         MCP packages are installed at first use via npx instead.
         """
-        BUILD_TIMEOUT_SECONDS = 1800
-
         start_time = time.time()
         sandbox_id = f"build-{repo_owner}-{repo_name}-{int(time.time() * 1000)}"
 
@@ -549,7 +568,7 @@ class SandboxManager:
             image=base_image,
             app=app,
             secrets=[],
-            timeout=BUILD_TIMEOUT_SECONDS,
+            timeout=timeout_seconds,
             workdir="/workspace",
             env=env_vars,
         )

--- a/packages/modal-infra/src/scheduler/image_builder.py
+++ b/packages/modal-infra/src/scheduler/image_builder.py
@@ -39,6 +39,11 @@ from ..app import (
 )
 from ..auth import generate_internal_token
 from ..log_config import get_logger
+from ..sandbox.manager import (
+    DEFAULT_BUILD_TIMEOUT_SECONDS,
+    MAX_BUILD_TIMEOUT_SECONDS,
+    build_function_timeout_seconds,
+)
 
 log = get_logger("image_builder")
 
@@ -238,7 +243,7 @@ async def _stream_build_logs(
 @app.function(
     image=function_image,
     secrets=[internal_api_secret, github_app_secrets],
-    timeout=1800,  # 30 minutes
+    timeout=build_function_timeout_seconds(DEFAULT_BUILD_TIMEOUT_SECONDS),
 )
 async def build_repo_image(
     repo_owner: str,
@@ -247,6 +252,7 @@ async def build_repo_image(
     callback_url: str = "",
     build_id: str = "",
     user_env_vars: dict[str, str] | None = None,
+    build_timeout_seconds: int | None = None,
 ) -> None:
     """
     Async worker: create build sandbox, await exit, snapshot, callback.
@@ -261,8 +267,13 @@ async def build_repo_image(
         callback_url: URL to POST success result to
         build_id: Build identifier from the control plane
         user_env_vars: User-defined environment variables (repo secrets) injected into the build sandbox
+        build_timeout_seconds: Build sandbox lifetime (already clamped by the control
+            plane). None → DEFAULT_BUILD_TIMEOUT_SECONDS. The caller sizes this
+            function's own timeout above it via build_function_timeout_seconds().
     """
     from ..sandbox.manager import SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS, SandboxManager
+
+    sandbox_timeout_seconds = build_timeout_seconds or DEFAULT_BUILD_TIMEOUT_SECONDS
 
     # Validate callback URL against allowed hosts to prevent SSRF
     if callback_url and not validate_control_plane_url(callback_url):
@@ -292,6 +303,7 @@ async def build_repo_image(
             default_branch=default_branch,
             clone_token=clone_token,
             user_env_vars=user_env_vars,
+            timeout_seconds=sandbox_timeout_seconds,
         )
 
         # 3. Stream stdout until build completes (sandbox stays alive for snapshotting)
@@ -369,8 +381,8 @@ async def build_repo_image(
 # Scheduler: cron-based rebuild logic
 # ---------------------------------------------------------------------------
 
-# Stale build threshold: builds older than this are marked failed
-STALE_BUILD_THRESHOLD_SECONDS = 2100  # 35 minutes
+# Sized at the longest possible build's worker timeout so a long-but-live build isn't reaped.
+STALE_BUILD_THRESHOLD_SECONDS = build_function_timeout_seconds(MAX_BUILD_TIMEOUT_SECONDS)
 
 # Cleanup threshold: failed builds older than this are deleted
 FAILED_BUILD_CLEANUP_SECONDS = 86400  # 24 hours

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -552,7 +552,8 @@ async def api_build_repo_image(
         "repo_name": "...",
         "default_branch": "main",
         "build_id": "...",
-        "callback_url": "..."
+        "callback_url": "...",
+        "build_timeout_seconds": 1800  // optional
     }
     """
     start_time = time.time()
@@ -562,6 +563,10 @@ async def api_build_repo_image(
     require_auth(authorization)
 
     try:
+        from .sandbox.manager import (
+            DEFAULT_BUILD_TIMEOUT_SECONDS,
+            build_function_timeout_seconds,
+        )
         from .scheduler.image_builder import build_repo_image
 
         repo_owner = request.get("repo_owner")
@@ -570,6 +575,10 @@ async def api_build_repo_image(
         build_id = request.get("build_id", "")
         callback_url = request.get("callback_url", "")
         user_env_vars = request.get("user_env_vars") or None
+        # Already capped by the control plane; default when absent/null.
+        build_timeout_seconds = int(
+            request.get("build_timeout_seconds") or DEFAULT_BUILD_TIMEOUT_SECONDS
+        )
 
         if not repo_owner or not repo_name:
             raise HTTPException(status_code=400, detail="repo_owner and repo_name are required")
@@ -580,14 +589,17 @@ async def api_build_repo_image(
         if not default_branch:
             raise HTTPException(status_code=400, detail="default_branch is required")
 
+        function_timeout = build_function_timeout_seconds(build_timeout_seconds)
+
         # Spawn the async builder — returns immediately
-        await build_repo_image.spawn.aio(
+        await build_repo_image.with_options(timeout=function_timeout).spawn.aio(
             repo_owner=repo_owner,
             repo_name=repo_name,
             default_branch=default_branch,
             callback_url=callback_url,
             build_id=build_id,
             user_env_vars=user_env_vars,
+            build_timeout_seconds=build_timeout_seconds,
         )
 
         return {

--- a/packages/modal-infra/tests/test_build_sandbox.py
+++ b/packages/modal-infra/tests/test_build_sandbox.py
@@ -99,8 +99,8 @@ async def test_no_control_plane_or_auth_vars(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_timeout_is_1800(monkeypatch):
-    """Build sandbox should use 30-minute (1800s) timeout."""
+async def test_timeout_defaults_to_1800(monkeypatch):
+    """Build sandbox should default to the 30-minute (1800s) timeout."""
     captured = {}
     monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", _fake_sandbox_create(captured))
 
@@ -111,6 +111,36 @@ async def test_timeout_is_1800(monkeypatch):
     )
 
     assert captured["timeout"] == 1800
+
+
+@pytest.mark.asyncio
+async def test_honors_explicit_timeout_seconds(monkeypatch):
+    """An explicit timeout_seconds should drive the build sandbox lifetime."""
+    captured = {}
+    monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", _fake_sandbox_create(captured))
+
+    manager = SandboxManager()
+    await manager.create_build_sandbox(
+        repo_owner="acme",
+        repo_name="my-repo",
+        timeout_seconds=2400,
+    )
+
+    assert captured["timeout"] == 2400
+
+
+def test_build_function_timeout_exceeds_sandbox_plus_snapshot():
+    """The build worker's function timeout must outlive sandbox + snapshot."""
+    from src.sandbox.manager import (
+        SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS,
+        build_function_timeout_seconds,
+    )
+
+    for sandbox_timeout in (1800, 3600):
+        assert (
+            build_function_timeout_seconds(sandbox_timeout)
+            > sandbox_timeout + SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS
+        )
 
 
 @pytest.mark.asyncio

--- a/packages/modal-infra/tests/test_image_builder_v2.py
+++ b/packages/modal-infra/tests/test_image_builder_v2.py
@@ -408,6 +408,64 @@ class TestBuildRepoImage:
         assert callback_payload["base_sha"] == "abc123"
 
     @pytest.mark.asyncio
+    async def test_forwards_build_timeout_to_create_build_sandbox(self):
+        handle, _snapshot_aio, _terminate_aio = self._build_handle()
+        create_build_sandbox = AsyncMock(return_value=handle)
+        manager = SimpleNamespace(create_build_sandbox=create_build_sandbox)
+
+        with (
+            patch("src.scheduler.image_builder.validate_control_plane_url", return_value=True),
+            patch("src.scheduler.image_builder._generate_clone_token", return_value="gh-token"),
+            patch("src.sandbox.manager.SandboxManager", return_value=manager),
+            patch(
+                "src.scheduler.image_builder._callback_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            await build_repo_image.local(
+                repo_owner="acme",
+                repo_name="repo",
+                default_branch="main",
+                callback_url="https://cp.test/repo-images/build-complete",
+                build_id="img-1",
+                build_timeout_seconds=2400,
+            )
+
+        assert create_build_sandbox.await_args.kwargs["timeout_seconds"] == 2400
+
+    @pytest.mark.asyncio
+    async def test_defaults_build_timeout_when_unset(self):
+        from src.sandbox.manager import DEFAULT_BUILD_TIMEOUT_SECONDS
+
+        handle, _snapshot_aio, _terminate_aio = self._build_handle()
+        create_build_sandbox = AsyncMock(return_value=handle)
+        manager = SimpleNamespace(create_build_sandbox=create_build_sandbox)
+
+        with (
+            patch("src.scheduler.image_builder.validate_control_plane_url", return_value=True),
+            patch("src.scheduler.image_builder._generate_clone_token", return_value="gh-token"),
+            patch("src.sandbox.manager.SandboxManager", return_value=manager),
+            patch(
+                "src.scheduler.image_builder._callback_with_retry",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            await build_repo_image.local(
+                repo_owner="acme",
+                repo_name="repo",
+                default_branch="main",
+                callback_url="https://cp.test/repo-images/build-complete",
+                build_id="img-1",
+            )
+
+        assert (
+            create_build_sandbox.await_args.kwargs["timeout_seconds"]
+            == DEFAULT_BUILD_TIMEOUT_SECONDS
+        )
+
+    @pytest.mark.asyncio
     async def test_terminates_and_reports_failure_when_snapshot_times_out(self):
         handle, snapshot_aio, terminate_aio = self._build_handle(
             snapshot_side_effect=TimeoutError("Timed out waiting for image to be created")

--- a/packages/modal-infra/tests/test_web_api_build_repo_image.py
+++ b/packages/modal-infra/tests/test_web_api_build_repo_image.py
@@ -1,0 +1,109 @@
+"""Tests for Modal build-repo-image API request assembly (timeout wiring)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from src import web_api
+from src.sandbox.manager import (
+    DEFAULT_BUILD_TIMEOUT_SECONDS,
+    build_function_timeout_seconds,
+)
+
+
+def _patch_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(web_api, "require_auth", lambda _authorization: None)
+
+
+def _patch_build_repo_image(monkeypatch: pytest.MonkeyPatch, captured: dict) -> None:
+    """Stub build_repo_image so we can capture .with_options(timeout=).spawn.aio(**)."""
+
+    async def fake_aio(**kwargs):
+        captured["spawn_kwargs"] = kwargs
+        return SimpleNamespace(object_id="fc-1")
+
+    def with_options(**kwargs):
+        captured["with_options"] = kwargs
+        return SimpleNamespace(spawn=SimpleNamespace(aio=fake_aio))
+
+    monkeypatch.setattr(
+        "src.scheduler.image_builder.build_repo_image",
+        SimpleNamespace(with_options=with_options),
+    )
+
+
+async def _call_build(request: dict) -> dict:
+    return await web_api.api_build_repo_image.get_raw_f()(
+        request,
+        authorization="Bearer test",
+        x_trace_id=None,
+        x_request_id=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_uses_requested_timeout_for_sandbox_and_function(monkeypatch):
+    """The requested build timeout drives the sandbox lifetime and the worker timeout."""
+    captured = {}
+    _patch_auth(monkeypatch)
+    _patch_build_repo_image(monkeypatch, captured)
+
+    result = await _call_build(
+        {
+            "repo_owner": "acme",
+            "repo_name": "repo",
+            "default_branch": "main",
+            "build_id": "img-1",
+            "callback_url": "https://cp.test/repo-images/build-complete",
+            "build_timeout_seconds": 2400,
+        }
+    )
+
+    assert result["success"] is True
+    assert captured["spawn_kwargs"]["build_timeout_seconds"] == 2400
+    assert captured["with_options"]["timeout"] == build_function_timeout_seconds(2400)
+
+
+@pytest.mark.asyncio
+async def test_build_defaults_timeout_when_absent(monkeypatch):
+    """A missing build_timeout_seconds falls back to the default everywhere."""
+    captured = {}
+    _patch_auth(monkeypatch)
+    _patch_build_repo_image(monkeypatch, captured)
+
+    result = await _call_build(
+        {
+            "repo_owner": "acme",
+            "repo_name": "repo",
+            "default_branch": "main",
+            "build_id": "img-1",
+            "callback_url": "https://cp.test/repo-images/build-complete",
+        }
+    )
+
+    assert result["success"] is True
+    assert captured["spawn_kwargs"]["build_timeout_seconds"] == DEFAULT_BUILD_TIMEOUT_SECONDS
+    assert captured["with_options"]["timeout"] == build_function_timeout_seconds(
+        DEFAULT_BUILD_TIMEOUT_SECONDS
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_requires_core_fields(monkeypatch):
+    """Validation still rejects missing identifiers before spawning."""
+    captured = {}
+    _patch_auth(monkeypatch)
+    _patch_build_repo_image(monkeypatch, captured)
+
+    with pytest.raises(web_api.HTTPException) as exc_info:
+        await _call_build(
+            {
+                "repo_name": "repo",
+                "default_branch": "main",
+                "build_id": "img-1",
+                "callback_url": "https://cp.test/repo-images/build-complete",
+            }
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "spawn_kwargs" not in captured

--- a/packages/shared/src/types/integrations.test.ts
+++ b/packages/shared/src/types/integrations.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_BUILD_TIMEOUT_SECONDS,
+  MAX_BUILD_TIMEOUT_SECONDS,
+  resolveBuildTimeoutSeconds,
+} from "./integrations";
+
+describe("resolveBuildTimeoutSeconds", () => {
+  it("defaults when no setting is present", () => {
+    expect(resolveBuildTimeoutSeconds(undefined)).toBe(DEFAULT_BUILD_TIMEOUT_SECONDS);
+    expect(resolveBuildTimeoutSeconds({})).toBe(DEFAULT_BUILD_TIMEOUT_SECONDS);
+  });
+
+  it("passes through values at or below the maximum, including short ones", () => {
+    expect(resolveBuildTimeoutSeconds({ buildTimeoutSeconds: 2400 })).toBe(2400);
+    expect(resolveBuildTimeoutSeconds({ buildTimeoutSeconds: 60 })).toBe(60);
+  });
+
+  it("caps above the maximum", () => {
+    expect(resolveBuildTimeoutSeconds({ buildTimeoutSeconds: 99999 })).toBe(
+      MAX_BUILD_TIMEOUT_SECONDS
+    );
+    expect(resolveBuildTimeoutSeconds({ buildTimeoutSeconds: MAX_BUILD_TIMEOUT_SECONDS })).toBe(
+      MAX_BUILD_TIMEOUT_SECONDS
+    );
+  });
+
+  it("falls back to the default for non-finite values", () => {
+    expect(resolveBuildTimeoutSeconds({ buildTimeoutSeconds: NaN })).toBe(
+      DEFAULT_BUILD_TIMEOUT_SECONDS
+    );
+  });
+
+  it("rounds fractional values before capping", () => {
+    expect(resolveBuildTimeoutSeconds({ buildTimeoutSeconds: 2400.4 })).toBe(2400);
+  });
+
+  it("keeps the default below the maximum", () => {
+    expect(DEFAULT_BUILD_TIMEOUT_SECONDS).toBeLessThan(MAX_BUILD_TIMEOUT_SECONDS);
+  });
+});

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -102,6 +102,20 @@ export const DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS = 5;
 export const DEFAULT_MAX_TOTAL_CHILD_SESSIONS = 15;
 
 /**
+ * Default repo-image build timeout (the build sandbox lifetime), in seconds.
+ * Mirrors `DEFAULT_BUILD_TIMEOUT_SECONDS` in the Modal data plane
+ * (`packages/modal-infra/src/sandbox/manager.py`).
+ */
+export const DEFAULT_BUILD_TIMEOUT_SECONDS = 1800;
+
+/**
+ * Maximum configurable repo-image build timeout, in seconds. The Modal
+ * stale-build sweep (`STALE_BUILD_THRESHOLD_SECONDS`) is sized above this, so
+ * raising it requires raising that threshold in lockstep.
+ */
+export const MAX_BUILD_TIMEOUT_SECONDS = 3600;
+
+/**
  * Sandbox environment settings. Provider-agnostic: describes what the user
  * wants, not how it's done. Resource fields (`cpuCores`, `memoryMib`) are
  * advisory and provider-dependent — Modal maps them directly, Vercel maps
@@ -143,6 +157,28 @@ export interface SandboxSettings {
    * default.
    */
   memoryMib?: number | null;
+  /**
+   * Repo-image build timeout (the build sandbox lifetime), in seconds.
+   * Build-only — sessions are unaffected. Unset → DEFAULT_BUILD_TIMEOUT_SECONDS.
+   * The trigger caps the effective value at MAX_BUILD_TIMEOUT_SECONDS via
+   * {@link resolveBuildTimeoutSeconds}.
+   */
+  buildTimeoutSeconds?: number;
+}
+
+/**
+ * Resolve the effective repo-image build timeout (seconds) from sandbox
+ * settings: the default when unset, otherwise capped at
+ * MAX_BUILD_TIMEOUT_SECONDS. Capping here keeps the Modal function-timeout and
+ * stale-sweep invariants intact regardless of how the stored value got there
+ * (old rows, direct API writes). A non-finite value falls back to the default.
+ */
+export function resolveBuildTimeoutSeconds(settings: SandboxSettings | undefined): number {
+  const requested = settings?.buildTimeoutSeconds;
+  if (typeof requested !== "number" || !Number.isFinite(requested)) {
+    return DEFAULT_BUILD_TIMEOUT_SECONDS;
+  }
+  return Math.min(MAX_BUILD_TIMEOUT_SECONDS, Math.max(1, Math.round(requested)));
 }
 
 export type SlackMentionsPolicy = "allow" | "escape" | "strip";

--- a/packages/web/src/components/settings/sandbox-settings.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.tsx
@@ -9,11 +9,13 @@ import { Input } from "@/components/ui/input";
 import useSWR from "swr";
 import type { ConfiguredSandboxPort, SandboxSettings } from "@open-inspect/shared";
 import {
+  DEFAULT_BUILD_TIMEOUT_SECONDS,
   DEFAULT_CODE_SERVER_PORT,
   DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS,
   DEFAULT_MAX_TOTAL_CHILD_SESSIONS,
   DEFAULT_TERMINAL_PORT,
   findSandboxPortConflict,
+  MAX_BUILD_TIMEOUT_SECONDS,
   MAX_TUNNEL_PORTS,
 } from "@open-inspect/shared";
 
@@ -50,6 +52,12 @@ function isValidCpuCores(value: string): boolean {
 function isValidMemoryMib(value: string): boolean {
   if (!/^\d+$/.test(value)) return false;
   return Number(value) >= 1;
+}
+
+function isValidBuildTimeout(value: string): boolean {
+  if (!/^\d+$/.test(value)) return false;
+  const n = Number(value);
+  return n >= 1 && n <= MAX_BUILD_TIMEOUT_SECONDS;
 }
 
 const numOrUndef = (v: number | null | undefined): number | undefined =>
@@ -131,6 +139,10 @@ function SandboxSettingsEditor({
     ? (data as GlobalSettingsResponse)?.settings?.defaults?.terminalPort
     : (data as RepoSettingsResponse)?.settings?.terminalPort;
 
+  const currentBuildTimeoutSeconds: number | undefined = isGlobal
+    ? (data as GlobalSettingsResponse)?.settings?.defaults?.buildTimeoutSeconds
+    : (data as RepoSettingsResponse)?.settings?.buildTimeoutSeconds;
+
   const currentMaxConcurrentChildSessions: number = isGlobal
     ? (globalDefaults?.maxConcurrentChildSessions ?? DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS)
     : (repoSettings?.maxConcurrentChildSessions ??
@@ -155,6 +167,7 @@ function SandboxSettingsEditor({
   const [terminalEnabled, setTerminalEnabled] = useState<boolean | null>(null);
   const [codeServerPort, setCodeServerPort] = useState<string | null>(null);
   const [terminalPort, setTerminalPort] = useState<string | null>(null);
+  const [buildTimeoutSeconds, setBuildTimeoutSeconds] = useState<string | null>(null);
   const [maxConcurrentChildSessions, setMaxConcurrentChildSessions] = useState<string | null>(null);
   const [maxTotalChildSessions, setMaxTotalChildSessions] = useState<string | null>(null);
   const [cpuCores, setCpuCores] = useState<string | null>(null);
@@ -180,6 +193,9 @@ function SandboxSettingsEditor({
     codeServerPort ?? (currentCodeServerPort !== undefined ? String(currentCodeServerPort) : "");
   const resolvedTerminalPort =
     terminalPort ?? (currentTerminalPort !== undefined ? String(currentTerminalPort) : "");
+  const resolvedBuildTimeoutSeconds =
+    buildTimeoutSeconds ??
+    (currentBuildTimeoutSeconds !== undefined ? String(currentBuildTimeoutSeconds) : "");
 
   const handleAddRow = () => {
     if (rows.length >= MAX_TUNNEL_PORTS) return;
@@ -249,6 +265,14 @@ function SandboxSettingsEditor({
       return;
     }
 
+    const trimmedBuildTimeout = resolvedBuildTimeoutSeconds.trim();
+    if (trimmedBuildTimeout !== "" && !isValidBuildTimeout(trimmedBuildTimeout)) {
+      setError(
+        `Build timeout must be a whole number of seconds, at most ${MAX_BUILD_TIMEOUT_SECONDS}.`
+      );
+      return;
+    }
+
     // Validate against the EFFECTIVE service ports the runtime will bind: an
     // explicit value, else (at repo scope) the inherited global default, else the
     // shared default. A blank field still occupies its default port, so a tunnel
@@ -294,6 +318,9 @@ function SandboxSettingsEditor({
       }
       if (trimmedTerminalPort !== "") {
         settingsPayload.terminalPort = Number(trimmedTerminalPort);
+      }
+      if (trimmedBuildTimeout !== "") {
+        settingsPayload.buildTimeoutSeconds = Number(trimmedBuildTimeout);
       }
       if (
         isGlobal ||
@@ -342,6 +369,7 @@ function SandboxSettingsEditor({
       setMemoryMib(null);
       setCodeServerPort(null);
       setTerminalPort(null);
+      setBuildTimeoutSeconds(null);
       setSuccess(true);
       setTimeout(() => setSuccess(false), 2000);
     } catch (e) {
@@ -362,6 +390,7 @@ function SandboxSettingsEditor({
     resolvedMemoryMib,
     resolvedCodeServerPort,
     resolvedTerminalPort,
+    resolvedBuildTimeoutSeconds,
     cpuCores,
     memoryMib,
     maxConcurrentChildSessions,
@@ -396,6 +425,10 @@ function SandboxSettingsEditor({
     codeServerPort !== null && codeServerPort.trim() !== currentCodeServerPortString;
   const hasTerminalPortChange =
     terminalPort !== null && terminalPort.trim() !== currentTerminalPortString;
+  const currentBuildTimeoutSecondsString =
+    currentBuildTimeoutSeconds !== undefined ? String(currentBuildTimeoutSeconds) : "";
+  const hasBuildTimeoutChange =
+    buildTimeoutSeconds !== null && buildTimeoutSeconds.trim() !== currentBuildTimeoutSecondsString;
   const hasChanges =
     hasPortChanges ||
     hasTerminalChange ||
@@ -404,7 +437,8 @@ function SandboxSettingsEditor({
     hasCpuChange ||
     hasMemoryChange ||
     hasCodeServerPortChange ||
-    hasTerminalPortChange;
+    hasTerminalPortChange ||
+    hasBuildTimeoutChange;
 
   if (isLoading || isLoadingGlobal) {
     return <p className="text-sm text-muted-foreground">Loading...</p>;
@@ -609,6 +643,35 @@ function SandboxSettingsEditor({
               placeholder="provider default"
             />
           </div>
+        </div>
+      </div>
+
+      <div>
+        <label
+          htmlFor="sandbox-build-timeout"
+          className="block text-sm font-medium text-foreground mb-1.5"
+        >
+          Repo Image Build Timeout
+        </label>
+        <p className="text-xs text-muted-foreground mb-2">
+          How long a pre-built repo image may take to build (clone + setup), in seconds. Raise it
+          for large repos with slow setup. Leave blank for the default (
+          {DEFAULT_BUILD_TIMEOUT_SECONDS}s). Builds only — sessions are unaffected.
+        </p>
+        <div className="max-w-sm">
+          <Input
+            id="sandbox-build-timeout"
+            type="number"
+            min={1}
+            max={MAX_BUILD_TIMEOUT_SECONDS}
+            inputMode="numeric"
+            value={resolvedBuildTimeoutSeconds}
+            onChange={(e) => setBuildTimeoutSeconds(e.target.value)}
+            placeholder={String(DEFAULT_BUILD_TIMEOUT_SECONDS)}
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            Maximum: {MAX_BUILD_TIMEOUT_SECONDS} seconds.
+          </p>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

The repo-image build ceiling was a hardcoded `1800s` in several places. This makes it a configurable per-repo setting (`SandboxSettings.buildTimeoutSeconds`) so repositories with longer build/setup steps can raise it without code changes, while keeping the coupled function/sandbox/stale-sweep timeouts consistent.

Backward compatible: the default stays `1800s`, so repos that don't set the field behave exactly as before.

## What changed

**shared**
- Add `buildTimeoutSeconds?: number` to `SandboxSettings`.
- Add `resolveBuildTimeoutSeconds()` — a pure resolver that defaults to `1800` and caps at `MAX_BUILD_TIMEOUT_SECONDS` (`3600`). Single source of truth for the cap + default.

**control-plane**
- Validate `buildTimeoutSeconds` in `normalizeSandboxSettings` (positive integer).
- Resolve + cap the value once at build-trigger time and thread it to both backends.
- Modal: send `build_timeout_seconds` on the build request.
- Vercel: pass the timeout through and reuse the canonical `resolveVercelTimeoutMs`.

**modal-infra**
- Thread the timeout into the build sandbox lifetime.
- Derive the build-function timeout (`sandbox + snapshot + margin`) and the stale-build sweep threshold from a single `build_function_timeout_seconds()` helper, so the three coupled timeouts can't drift apart.
- `web_api` overrides the spawned function's timeout per request via `with_options(timeout=...)`.

**web**
- Add a "Repo Image Build Timeout" numeric field to sandbox settings, surfacing the max/default as hints.

## Design notes

- **Cap at the trigger, validate at the edge.** `normalizeSandboxSettings` only enforces "positive integer"; the cap + default live in `resolveBuildTimeoutSeconds`, so the policy has one home.
- **No configured minimum.** The `MAX` cap (a resource/cost bound that the stale-sweep is sized against) and the positive-integer check are the load-bearing guards. A too-short value isn't a system risk — the build just fails fast and frees its sandbox — so configured values pass through up to the cap (with a floor of 1s).
- **Coupled timeouts derived, not duplicated.** The function timeout and stale threshold are computed from the build timeout via one helper rather than hardcoded literals, so raising the cap automatically keeps the sweep threshold ahead of it.
- The shared TS constants and the Python constants are mirrored (with comments) across the language boundary.

## Testing

- shared: unit tests for `resolveBuildTimeoutSeconds` (default, passthrough including short values, cap above max, boundary, NaN, rounding).
- control-plane: settings validation, client request shape, trigger resolution for both backends, Vercel timeout cap.
- modal-infra: build-sandbox timeout forwarding + the function-timeout-exceeds-sandbox-plus-snapshot invariant; `web_api` request plumbing.
- All suites green locally (shared 181, control-plane 1357, web 344, modal 152); typecheck, prettier, eslint, ruff clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Build timeout is now configurable for repository image builds in sandbox settings with automatic enforcement of maximum limits to prevent resource exhaustion.
  * Users can specify custom build timeout values through the settings interface with input validation, sensible defaults, and helpful guidance on configuration behavior and system fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->