### PR TITLE
refactor: extract session event stream

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -72,6 +72,7 @@ import { DOFetcherAdapter } from "../scheduler/do-fetcher-adapter";
 import { PresenceService } from "./presence-service";
 import { SessionMessageQueue } from "./message-queue";
 import { SessionSandboxEventProcessor } from "./sandbox-events";
+import { SessionEventStream } from "./event-stream";
 import { createSessionInternalRoutes } from "./http/routes";
 import { createMessagesHandler, type MessagesHandler } from "./http/handlers/messages.handler";
 import {
@@ -139,6 +140,7 @@ export class SessionDO extends DurableObject<Env> {
   private _messageQueue: SessionMessageQueue | null = null;
   // Message service (lazily initialized)
   private _messageService: MessageService | null = null;
+  private _eventStream: SessionEventStream | null = null;
   // Messages handler (lazily initialized)
   private _messagesHandler: MessagesHandler | null = null;
   // Child sessions handler (lazily initialized)
@@ -345,6 +347,14 @@ export class SessionDO extends DurableObject<Env> {
     }
 
     return this._messageService;
+  }
+
+  private get eventStream(): SessionEventStream {
+    if (!this._eventStream) {
+      this._eventStream = new SessionEventStream(this.repository);
+    }
+
+    return this._eventStream;
   }
 
   private get messagesHandler(): MessagesHandler {
@@ -1254,7 +1264,7 @@ export class SessionDO extends DurableObject<Env> {
     const sandbox = this.getSandbox();
     const state = await this.getSessionState(sandbox);
     const artifacts = this.messageService.listArtifacts();
-    const replay = this.getReplayData();
+    const replay = this.eventStream.getReplay();
 
     this.safeSend(ws, {
       type: "subscribed",
@@ -1279,33 +1289,6 @@ export class SessionDO extends DurableObject<Env> {
 
     // Notify others
     this.presenceService.broadcastPresence();
-  }
-
-  /**
-   * Collect historical events for replay.
-   * Returns parsed events and pagination metadata for inclusion in the subscribed message.
-   */
-  private getReplayData(): {
-    events: SandboxEvent[];
-    hasMore: boolean;
-    cursor: { timestamp: number; id: string } | null;
-  } {
-    const REPLAY_LIMIT = 500;
-    const rows = this.repository.getEventsForReplay(REPLAY_LIMIT);
-    const hasMore = rows.length >= REPLAY_LIMIT;
-
-    const events: SandboxEvent[] = [];
-    for (const row of rows) {
-      try {
-        events.push(JSON.parse(row.data));
-      } catch {
-        // Skip malformed events
-      }
-    }
-
-    const cursor = rows.length > 0 ? { timestamp: rows[0].created_at, id: rows[0].id } : null;
-
-    return { events, hasMore, cursor };
   }
 
   /**
@@ -1400,30 +1383,16 @@ export class SessionDO extends DurableObject<Env> {
     }
     client.lastFetchHistoryAt = now;
 
-    const rawLimit = typeof data.limit === "number" ? data.limit : 200;
-    const limit = Math.max(1, Math.min(rawLimit, 500));
-    const page = this.repository.getEventTimelinePage({
-      cursor: { kind: "timeline", createdAt: data.cursor.timestamp, id: data.cursor.id },
-      excludeTypes: ["heartbeat"],
-      limit,
+    const page = this.eventStream.getHistoryPage({
+      cursor: data.cursor,
+      limit: data.limit,
     });
-
-    const items: SandboxEvent[] = [];
-    for (const event of page.events) {
-      try {
-        items.push(JSON.parse(event.data));
-      } catch {
-        // Skip malformed events
-      }
-    }
 
     this.safeSend(ws, {
       type: "history_page",
-      items,
+      items: page.items,
       hasMore: page.hasMore,
-      cursor: page.nextCursor
-        ? { timestamp: page.nextCursor.createdAt, id: page.nextCursor.id }
-        : null,
+      cursor: page.cursor,
     } as ServerMessage);
   }
 

--- a/packages/control-plane/src/session/event-stream.test.ts
+++ b/packages/control-plane/src/session/event-stream.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from "vitest";
+import { SessionEventStream, type SessionEventStreamRepository } from "./event-stream";
+import type { EventRow } from "./types";
+
+function createStream() {
+  const repository = {
+    getEventsForReplay: vi.fn(),
+    getEventTimelinePage: vi.fn(),
+    listEventPage: vi.fn(),
+  } as unknown as SessionEventStreamRepository;
+
+  return {
+    stream: new SessionEventStream(repository),
+    repository,
+  };
+}
+
+function eventRow(
+  id: string,
+  type: EventRow["type"],
+  data: Record<string, unknown> | string,
+  createdAt: number
+): EventRow {
+  return {
+    id,
+    type,
+    data: typeof data === "string" ? data : JSON.stringify(data),
+    message_id: null,
+    created_at: createdAt,
+  };
+}
+
+describe("SessionEventStream", () => {
+  describe("getReplay", () => {
+    it("loads replay rows with the default replay limit", () => {
+      const { stream, repository } = createStream();
+      vi.mocked(repository.getEventsForReplay).mockReturnValue([]);
+
+      stream.getReplay();
+
+      expect(repository.getEventsForReplay).toHaveBeenCalledWith(500);
+    });
+
+    it("returns parsed replay events and the oldest cursor from the loaded window", () => {
+      const { stream, repository } = createStream();
+      vi.mocked(repository.getEventsForReplay).mockReturnValue([
+        eventRow("e1", "tool_call", { type: "tool_call", tool: "read_file" }, 1000),
+        eventRow("e2", "tool_result", { type: "tool_result", result: "ok" }, 2000),
+      ]);
+
+      const replay = stream.getReplay();
+
+      expect(replay).toEqual({
+        events: [
+          { type: "tool_call", tool: "read_file" },
+          { type: "tool_result", result: "ok" },
+        ],
+        hasMore: false,
+        cursor: { timestamp: 1000, id: "e1" },
+      });
+    });
+
+    it("marks replay as having more when the loaded window reaches the limit", () => {
+      const { stream, repository } = createStream();
+      vi.mocked(repository.getEventsForReplay).mockReturnValue([
+        eventRow("e1", "token", { type: "token", content: "a" }, 1000),
+        eventRow("e2", "token", { type: "token", content: "b" }, 2000),
+      ]);
+
+      const replay = stream.getReplay(2);
+
+      expect(replay.hasMore).toBe(true);
+    });
+
+    it("skips malformed replay event JSON", () => {
+      const { stream, repository } = createStream();
+      vi.mocked(repository.getEventsForReplay).mockReturnValue([
+        eventRow("bad", "tool_call", "{bad", 1000),
+        eventRow("good", "tool_result", { type: "tool_result", result: "ok" }, 2000),
+      ]);
+
+      const replay = stream.getReplay();
+
+      expect(replay.events).toEqual([{ type: "tool_result", result: "ok" }]);
+      expect(replay.cursor).toEqual({ timestamp: 1000, id: "bad" });
+    });
+  });
+
+  describe("getHistoryPage", () => {
+    it("loads history after a client cursor while excluding heartbeats", () => {
+      const { stream, repository } = createStream();
+      vi.mocked(repository.getEventTimelinePage).mockReturnValue({
+        events: [eventRow("e1", "tool_call", { type: "tool_call", tool: "write_file" }, 1000)],
+        hasMore: false,
+        nextCursor: { kind: "timeline", createdAt: 1000, id: "e1" },
+      });
+
+      const page = stream.getHistoryPage({
+        cursor: { timestamp: 2000, id: "cursor-id" },
+        limit: 100,
+      });
+
+      expect(repository.getEventTimelinePage).toHaveBeenCalledWith({
+        cursor: { kind: "timeline", createdAt: 2000, id: "cursor-id" },
+        excludeTypes: ["heartbeat"],
+        limit: 100,
+      });
+      expect(page).toEqual({
+        items: [{ type: "tool_call", tool: "write_file" }],
+        hasMore: false,
+        cursor: { timestamp: 1000, id: "e1" },
+      });
+    });
+
+    it("clamps history limits to the supported range", () => {
+      const { stream, repository } = createStream();
+      vi.mocked(repository.getEventTimelinePage).mockReturnValue({
+        events: [],
+        hasMore: false,
+        nextCursor: null,
+      });
+
+      stream.getHistoryPage({ cursor: { timestamp: 2000, id: "cursor-id" }, limit: 999 });
+      stream.getHistoryPage({ cursor: { timestamp: 2000, id: "cursor-id" }, limit: 0 });
+      stream.getHistoryPage({ cursor: { timestamp: 2000, id: "cursor-id" } });
+
+      expect(repository.getEventTimelinePage).toHaveBeenNthCalledWith(1, {
+        cursor: { kind: "timeline", createdAt: 2000, id: "cursor-id" },
+        excludeTypes: ["heartbeat"],
+        limit: 500,
+      });
+      expect(repository.getEventTimelinePage).toHaveBeenNthCalledWith(2, {
+        cursor: { kind: "timeline", createdAt: 2000, id: "cursor-id" },
+        excludeTypes: ["heartbeat"],
+        limit: 1,
+      });
+      expect(repository.getEventTimelinePage).toHaveBeenNthCalledWith(3, {
+        cursor: { kind: "timeline", createdAt: 2000, id: "cursor-id" },
+        excludeTypes: ["heartbeat"],
+        limit: 200,
+      });
+    });
+
+    it("skips malformed history event JSON", () => {
+      const { stream, repository } = createStream();
+      vi.mocked(repository.getEventTimelinePage).mockReturnValue({
+        events: [
+          eventRow("bad", "tool_call", "{bad", 1000),
+          eventRow("good", "tool_result", { type: "tool_result", result: "ok" }, 2000),
+        ],
+        hasMore: true,
+        nextCursor: { kind: "timeline", createdAt: 1000, id: "bad" },
+      });
+
+      const page = stream.getHistoryPage({
+        cursor: { timestamp: 3000, id: "cursor-id" },
+        limit: 10,
+      });
+
+      expect(page).toEqual({
+        items: [{ type: "tool_result", result: "ok" }],
+        hasMore: true,
+        cursor: { timestamp: 1000, id: "bad" },
+      });
+    });
+  });
+
+  describe("listEvents", () => {
+    it("projects event rows to the shared HTTP response shape", () => {
+      const { stream, repository } = createStream();
+      vi.mocked(repository.listEventPage).mockReturnValue({
+        events: [eventRow("e1", "token", { type: "token", content: "hello" }, 1000)],
+        hasMore: true,
+        nextCursor: { kind: "timeline", createdAt: 1000, id: "e1" },
+      });
+
+      const page = stream.listEvents({
+        cursor: null,
+        limit: 10,
+        type: "token",
+        messageId: "m1",
+      });
+
+      expect(repository.listEventPage).toHaveBeenCalledWith({
+        cursor: null,
+        limit: 10,
+        type: "token",
+        messageId: "m1",
+      });
+      expect(page).toEqual({
+        events: [
+          {
+            id: "e1",
+            type: "token",
+            data: { type: "token", content: "hello" },
+            messageId: null,
+            createdAt: 1000,
+          },
+        ],
+        cursor: "1000:e1",
+        hasMore: true,
+      });
+    });
+  });
+});

--- a/packages/control-plane/src/session/event-stream.ts
+++ b/packages/control-plane/src/session/event-stream.ts
@@ -1,0 +1,114 @@
+import type {
+  ClientMessage,
+  EventResponse,
+  ListEventsResponse,
+  SandboxEvent,
+  ServerMessage,
+} from "../types";
+import { encodeEventTimelineCursor, type EventListCursor } from "./event-cursor";
+import type { EventRow } from "./types";
+import type { SessionRepository } from "./repository";
+
+const DEFAULT_REPLAY_LIMIT = 500;
+const DEFAULT_HISTORY_LIMIT = 200;
+const MIN_HISTORY_LIMIT = 1;
+const MAX_HISTORY_LIMIT = 500;
+const HISTORY_EXCLUDED_TYPES = ["heartbeat"];
+
+export type EventStreamCursor = Extract<ClientMessage, { type: "fetch_history" }>["cursor"];
+export type SessionReplay = NonNullable<Extract<ServerMessage, { type: "subscribed" }>["replay"]>;
+export type SessionHistoryPage = Omit<Extract<ServerMessage, { type: "history_page" }>, "type">;
+
+export type SessionEventStreamRepository = Pick<
+  SessionRepository,
+  "getEventsForReplay" | "getEventTimelinePage" | "listEventPage"
+>;
+
+export interface SessionEventListRequest {
+  cursor: EventListCursor | null;
+  limit: number;
+  type: string | null;
+  messageId: string | null;
+}
+
+export class SessionEventStream {
+  constructor(private readonly repository: SessionEventStreamRepository) {}
+
+  getReplay(limit = DEFAULT_REPLAY_LIMIT): SessionReplay {
+    const rows = this.repository.getEventsForReplay(limit);
+    const events = parseSandboxEvents(rows);
+    const cursor = rows.length > 0 ? cursorFromRow(rows[0]) : null;
+
+    return {
+      events,
+      hasMore: rows.length >= limit,
+      cursor,
+    };
+  }
+
+  getHistoryPage(input: { cursor: EventStreamCursor; limit?: number }): SessionHistoryPage {
+    const page = this.repository.getEventTimelinePage({
+      cursor: {
+        kind: "timeline",
+        createdAt: input.cursor.timestamp,
+        id: input.cursor.id,
+      },
+      excludeTypes: HISTORY_EXCLUDED_TYPES,
+      limit: clampHistoryLimit(input.limit),
+    });
+
+    return {
+      items: parseSandboxEvents(page.events),
+      hasMore: page.hasMore,
+      cursor: page.nextCursor
+        ? { timestamp: page.nextCursor.createdAt, id: page.nextCursor.id }
+        : null,
+    };
+  }
+
+  listEvents(request: SessionEventListRequest): ListEventsResponse {
+    const page = this.repository.listEventPage({
+      cursor: request.cursor,
+      limit: request.limit,
+      type: request.type,
+      messageId: request.messageId,
+    });
+
+    return {
+      events: page.events.map(toEventResponse),
+      cursor: page.nextCursor ? encodeEventTimelineCursor(page.nextCursor) : undefined,
+      hasMore: page.hasMore,
+    };
+  }
+}
+
+function parseSandboxEvents(rows: EventRow[]): SandboxEvent[] {
+  const events: SandboxEvent[] = [];
+  for (const row of rows) {
+    try {
+      events.push(JSON.parse(row.data) as SandboxEvent);
+    } catch {
+      // Preserve existing replay/history behavior: malformed events are skipped.
+    }
+  }
+  return events;
+}
+
+function cursorFromRow(row: Pick<EventRow, "created_at" | "id">): EventStreamCursor {
+  return { timestamp: row.created_at, id: row.id };
+}
+
+function toEventResponse(event: EventRow): EventResponse {
+  return {
+    id: event.id,
+    type: event.type,
+    data: JSON.parse(event.data) as Record<string, unknown>,
+    messageId: event.message_id,
+    createdAt: event.created_at,
+  };
+}
+
+function clampHistoryLimit(limit: number | undefined): number {
+  const rawLimit = typeof limit === "number" ? limit : DEFAULT_HISTORY_LIMIT;
+  return Math.max(MIN_HISTORY_LIMIT, Math.min(rawLimit, MAX_HISTORY_LIMIT));
+}

--- a/packages/control-plane/src/session/http/handlers/messages.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/messages.handler.test.ts
@@ -96,16 +96,16 @@ describe("createMessagesHandler", () => {
     expect(messageService.listEvents).not.toHaveBeenCalled();
   });
 
-  it("maps listEvents response", async () => {
+  it("returns listEvents response from service", async () => {
     const { handler, messageService } = createHandler();
     vi.mocked(messageService.listEvents).mockReturnValue({
       events: [
         {
           id: "e1",
           type: "token",
-          data: '{"x":1}',
-          message_id: "m1",
-          created_at: 1000,
+          data: { x: 1 },
+          messageId: "m1",
+          createdAt: 1000,
         },
       ],
       cursor: "1000",

--- a/packages/control-plane/src/session/http/handlers/messages.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/messages.handler.ts
@@ -79,17 +79,7 @@ export function createMessagesHandler(deps: MessagesHandlerDeps): MessagesHandle
         messageId,
       });
 
-      return Response.json({
-        events: result.events.map((event) => ({
-          id: event.id,
-          type: event.type,
-          data: JSON.parse(event.data),
-          messageId: event.message_id,
-          createdAt: event.created_at,
-        })),
-        cursor: result.cursor,
-        hasMore: result.hasMore,
-      });
+      return Response.json(result);
     },
 
     listArtifacts(url: URL): Response {

--- a/packages/control-plane/src/session/services/message.service.test.ts
+++ b/packages/control-plane/src/session/services/message.service.test.ts
@@ -81,6 +81,13 @@ describe("MessageService", () => {
     expect(result.hasMore).toBe(true);
     expect(result.cursor).toBe("2000:e2");
     expect(result.events).toHaveLength(2);
+    expect(result.events[0]).toEqual({
+      id: "e3",
+      type: "token",
+      data: {},
+      messageId: "m1",
+      createdAt: 3000,
+    });
     expect(repository.listEventPage).toHaveBeenCalledWith({
       cursor: null,
       limit: 2,

--- a/packages/control-plane/src/session/services/message.service.ts
+++ b/packages/control-plane/src/session/services/message.service.ts
@@ -1,8 +1,8 @@
-import type { ArtifactRow, EventRow, MessageRow } from "../types";
-import type { ArtifactResponse } from "../../types";
+import type { ArtifactRow, MessageRow } from "../types";
+import type { ArtifactResponse, ListEventsResponse } from "../../types";
 import type { SessionRepository } from "../repository";
-import { encodeEventTimelineCursor, type EventListCursor } from "../event-cursor";
 import type { SessionMessageQueue } from "../message-queue";
+import { SessionEventStream, type SessionEventListRequest } from "../event-stream";
 
 export interface EnqueuePromptRequest {
   content: string;
@@ -25,12 +25,7 @@ export interface EnqueuePromptRequest {
   scmTokenExpiresAt?: number;
 }
 
-export interface ListEventsRequest {
-  cursor: EventListCursor | null;
-  limit: number;
-  type: string | null;
-  messageId: string | null;
-}
+export type ListEventsRequest = SessionEventListRequest;
 
 export interface ListMessagesRequest {
   cursor: string | null;
@@ -48,7 +43,11 @@ interface MessageServiceDeps {
 }
 
 export class MessageService {
-  constructor(private readonly deps: MessageServiceDeps) {}
+  private readonly eventStream: SessionEventStream;
+
+  constructor(private readonly deps: MessageServiceDeps) {
+    this.eventStream = new SessionEventStream(deps.repository);
+  }
 
   enqueuePrompt(request: EnqueuePromptRequest): Promise<{ messageId: string; status: "queued" }> {
     return this.deps.messageQueue.enqueuePromptFromApi(request);
@@ -59,22 +58,8 @@ export class MessageService {
     return { status: "stopping" };
   }
 
-  listEvents(request: ListEventsRequest): {
-    events: EventRow[];
-    cursor: string | undefined;
-    hasMore: boolean;
-  } {
-    const page = this.deps.repository.listEventPage({
-      cursor: request.cursor,
-      limit: request.limit,
-      type: request.type,
-      messageId: request.messageId,
-    });
-    return {
-      events: page.events,
-      cursor: page.nextCursor ? encodeEventTimelineCursor(page.nextCursor) : undefined,
-      hasMore: page.hasMore,
-    };
+  listEvents(request: ListEventsRequest): ListEventsResponse {
+    return this.eventStream.listEvents(request);
   }
 
   listArtifacts(): {

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -4,7 +4,6 @@
 
 import type {
   ArtifactType,
-  EventType,
   MessageSource,
   MessageStatus,
   ParticipantRole,
@@ -17,8 +16,10 @@ export type {
   ClientMessage,
   CreateSessionRequest,
   CreateSessionResponse,
+  EventResponse,
   EventType,
   GitSyncStatus,
+  ListEventsResponse,
   MessageSource,
   MessageStatus,
   ParticipantRole,
@@ -149,20 +150,6 @@ export interface MessageResponse {
   createdAt: number;
   startedAt: number | null;
   completedAt: number | null;
-}
-
-export interface EventResponse {
-  id: string;
-  type: EventType;
-  data: Record<string, unknown>;
-  messageId: string | null;
-  createdAt: number;
-}
-
-export interface ListEventsResponse {
-  events: EventResponse[];
-  cursor?: string;
-  hasMore: boolean;
 }
 
 export interface ArtifactResponse {


### PR DESCRIPTION
## Summary

- Extract session replay/history behavior from `SessionDO` into `SessionEventStream`
- Centralize EventRow projection for WebSocket replay/history and HTTP event listing
- Re-export event list response types from shared instead of maintaining local duplicates

## Why

`SessionDO` was carrying Session Event Stream replay and paginated history projection inline. Moving this into a focused class reduces Durable Object surface area and gives the event stream behavior its own testable interface without adding callback-heavy dependencies.

## Validation

- `npm test -w @open-inspect/control-plane -- src/session/event-stream.test.ts src/session/services/message.service.test.ts src/session/http/handlers/messages.handler.test.ts`
- `npm run build -w @open-inspect/shared`
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/websocket-client.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `npx prettier --check packages/control-plane/src/session/durable-object.ts packages/control-plane/src/session/event-stream.ts packages/control-plane/src/session/event-stream.test.ts packages/control-plane/src/session/http/handlers/messages.handler.ts packages/control-plane/src/session/http/handlers/messages.handler.test.ts packages/control-plane/src/session/services/message.service.ts packages/control-plane/src/session/services/message.service.test.ts packages/control-plane/src/types.ts`
- `npx eslint packages/control-plane/src/session/durable-object.ts packages/control-plane/src/session/event-stream.ts packages/control-plane/src/session/event-stream.test.ts packages/control-plane/src/session/http/handlers/messages.handler.ts packages/control-plane/src/session/http/handlers/messages.handler.test.ts packages/control-plane/src/session/services/message.service.ts packages/control-plane/src/session/services/message.service.test.ts packages/control-plane/src/types.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored session event handling and replay data sourcing to improve modularity and code organization.
  * Consolidated event response types to the shared package for better reusability.

* **Tests**
  * Added comprehensive test suite for session event stream functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->