### PR TITLE
fix: index scheduler recovery sweeps to avoid D1 timeouts

### DIFF
--- a/packages/control-plane/src/db/automation-store.ts
+++ b/packages/control-plane/src/db/automation-store.ts
@@ -447,6 +447,13 @@ export class AutomationStore {
   }
 
   // --- Recovery sweep queries ---
+  //
+  // These filter by a single status across all automations and are backed by the
+  // per-status partial indexes idx_runs_orphan_sweep / idx_runs_timeout_sweep
+  // (migration 0024). Keep `status` a string literal in the SQL: partial-index
+  // matching happens at plan time and is syntactic, so `status = ?` (a bound
+  // parameter) would not match the index predicate and would silently fall back
+  // to a full table scan of the append-only automation_runs table.
 
   async getOrphanedStartingRuns(thresholdMs: number): Promise<AutomationRunRow[]> {
     const cutoff = Date.now() - thresholdMs;

--- a/packages/control-plane/src/db/automation-store.ts
+++ b/packages/control-plane/src/db/automation-store.ts
@@ -447,17 +447,8 @@ export class AutomationStore {
   }
 
   // --- Recovery sweep queries ---
-  //
-  // These filter by a single status across all automations and are backed by the
-  // per-status partial indexes idx_runs_orphan_sweep / idx_runs_timeout_sweep
-  // (migration 0024). Keep `status` a string literal in the SQL: partial-index
-  // matching happens at plan time and is syntactic, so `status = ?` (a bound
-  // parameter) would not match the index predicate and would silently fall back
-  // to a full table scan of the append-only automation_runs table.
-  //
-  // The SQL is held in constants so the EXPLAIN-based planner regression tests
-  // assert against the exact production query text — there is no separate copy
-  // to drift out of sync.
+  // Backed by partial indexes (migration 0024); `status` must stay a literal, not
+  // a bound param, or the planner skips the index and full-scans automation_runs.
   static readonly ORPHANED_STARTING_RUNS_SQL =
     "SELECT * FROM automation_runs WHERE status = 'starting' AND created_at < ?";
   static readonly TIMED_OUT_RUNNING_RUNS_SQL =

--- a/packages/control-plane/src/db/automation-store.ts
+++ b/packages/control-plane/src/db/automation-store.ts
@@ -454,14 +454,19 @@ export class AutomationStore {
   // matching happens at plan time and is syntactic, so `status = ?` (a bound
   // parameter) would not match the index predicate and would silently fall back
   // to a full table scan of the append-only automation_runs table.
+  //
+  // The SQL is held in constants so the EXPLAIN-based planner regression tests
+  // assert against the exact production query text — there is no separate copy
+  // to drift out of sync.
+  static readonly ORPHANED_STARTING_RUNS_SQL =
+    "SELECT * FROM automation_runs WHERE status = 'starting' AND created_at < ?";
+  static readonly TIMED_OUT_RUNNING_RUNS_SQL =
+    "SELECT * FROM automation_runs WHERE status = 'running' AND started_at IS NOT NULL AND started_at < ?";
 
   async getOrphanedStartingRuns(thresholdMs: number): Promise<AutomationRunRow[]> {
     const cutoff = Date.now() - thresholdMs;
     const result = await this.db
-      .prepare(
-        `SELECT * FROM automation_runs
-         WHERE status = 'starting' AND created_at < ?`
-      )
+      .prepare(AutomationStore.ORPHANED_STARTING_RUNS_SQL)
       .bind(cutoff)
       .all<AutomationRunRow>();
     return result.results || [];
@@ -470,10 +475,7 @@ export class AutomationStore {
   async getTimedOutRunningRuns(executionTimeoutMs: number): Promise<AutomationRunRow[]> {
     const cutoff = Date.now() - executionTimeoutMs;
     const result = await this.db
-      .prepare(
-        `SELECT * FROM automation_runs
-         WHERE status = 'running' AND started_at IS NOT NULL AND started_at < ?`
-      )
+      .prepare(AutomationStore.TIMED_OUT_RUNNING_RUNS_SQL)
       .bind(cutoff)
       .all<AutomationRunRow>();
     return result.results || [];

--- a/packages/control-plane/test/integration/automation-store.test.ts
+++ b/packages/control-plane/test/integration/automation-store.test.ts
@@ -547,13 +547,9 @@ describe("AutomationStore (D1 integration)", () => {
       expect(timedOut).toHaveLength(0);
     });
 
-    // Regression guard for the D1 recovery-sweep timeout: these sweeps must be
-    // served by their per-status partial indexes (migration 0024), never a full
-    // SCAN of the append-only automation_runs table. A full scan would pass the
-    // behavioural tests above but time out once history grows. We EXPLAIN the
-    // exact production SQL (AutomationStore.*_SQL) so the guard tracks the real
-    // query shape: parameterizing `status`, dropping the index, or otherwise
-    // breaking partial-index matching flips the plan to a SCAN and fails here.
+    // The behavioural tests above pass with or without the index (a scan returns
+    // the same rows); these EXPLAIN the real production SQL to assert the partial
+    // index is actually used.
     it("orphan sweep is served by idx_runs_orphan_sweep, not a full scan", async () => {
       const plan = await env.DB.prepare(
         `EXPLAIN QUERY PLAN ${AutomationStore.ORPHANED_STARTING_RUNS_SQL}`

--- a/packages/control-plane/test/integration/automation-store.test.ts
+++ b/packages/control-plane/test/integration/automation-store.test.ts
@@ -546,6 +546,33 @@ describe("AutomationStore (D1 integration)", () => {
       const timedOut = await store.getTimedOutRunningRuns(90 * 60 * 1000);
       expect(timedOut).toHaveLength(0);
     });
+
+    // Regression guard for the D1 recovery-sweep timeout: these sweeps must be
+    // served by their per-status partial indexes (migration 0024), never a full
+    // SCAN of the append-only automation_runs table. A full scan would pass the
+    // behavioural tests above but time out once history grows. The WHERE clauses
+    // mirror getOrphanedStartingRuns / getTimedOutRunningRuns verbatim — keep
+    // them in sync (in particular, status must stay a literal, not a bound param,
+    // or the planner will not match the partial index).
+    it("orphan sweep is served by idx_runs_orphan_sweep, not a full scan", async () => {
+      const plan = await env.DB.prepare(
+        "EXPLAIN QUERY PLAN SELECT * FROM automation_runs WHERE status = 'starting' AND created_at < ?"
+      )
+        .bind(Date.now())
+        .all<{ detail: string }>();
+      const detail = plan.results.map((r) => r.detail).join("\n");
+      expect(detail).toContain("USING INDEX idx_runs_orphan_sweep");
+    });
+
+    it("timeout sweep is served by idx_runs_timeout_sweep, not a full scan", async () => {
+      const plan = await env.DB.prepare(
+        "EXPLAIN QUERY PLAN SELECT * FROM automation_runs WHERE status = 'running' AND started_at IS NOT NULL AND started_at < ?"
+      )
+        .bind(Date.now())
+        .all<{ detail: string }>();
+      const detail = plan.results.map((r) => r.detail).join("\n");
+      expect(detail).toContain("USING INDEX idx_runs_timeout_sweep");
+    });
   });
 
   // ─── Failure tracking ──────────────────────────────────────────────────────

--- a/packages/control-plane/test/integration/automation-store.test.ts
+++ b/packages/control-plane/test/integration/automation-store.test.ts
@@ -550,13 +550,13 @@ describe("AutomationStore (D1 integration)", () => {
     // Regression guard for the D1 recovery-sweep timeout: these sweeps must be
     // served by their per-status partial indexes (migration 0024), never a full
     // SCAN of the append-only automation_runs table. A full scan would pass the
-    // behavioural tests above but time out once history grows. The WHERE clauses
-    // mirror getOrphanedStartingRuns / getTimedOutRunningRuns verbatim — keep
-    // them in sync (in particular, status must stay a literal, not a bound param,
-    // or the planner will not match the partial index).
+    // behavioural tests above but time out once history grows. We EXPLAIN the
+    // exact production SQL (AutomationStore.*_SQL) so the guard tracks the real
+    // query shape: parameterizing `status`, dropping the index, or otherwise
+    // breaking partial-index matching flips the plan to a SCAN and fails here.
     it("orphan sweep is served by idx_runs_orphan_sweep, not a full scan", async () => {
       const plan = await env.DB.prepare(
-        "EXPLAIN QUERY PLAN SELECT * FROM automation_runs WHERE status = 'starting' AND created_at < ?"
+        `EXPLAIN QUERY PLAN ${AutomationStore.ORPHANED_STARTING_RUNS_SQL}`
       )
         .bind(Date.now())
         .all<{ detail: string }>();
@@ -566,7 +566,7 @@ describe("AutomationStore (D1 integration)", () => {
 
     it("timeout sweep is served by idx_runs_timeout_sweep, not a full scan", async () => {
       const plan = await env.DB.prepare(
-        "EXPLAIN QUERY PLAN SELECT * FROM automation_runs WHERE status = 'running' AND started_at IS NOT NULL AND started_at < ?"
+        `EXPLAIN QUERY PLAN ${AutomationStore.TIMED_OUT_RUNNING_RUNS_SQL}`
       )
         .bind(Date.now())
         .all<{ detail: string }>();

--- a/terraform/d1/migrations/0024_fix_recovery_sweep_indexes.sql
+++ b/terraform/d1/migrations/0024_fix_recovery_sweep_indexes.sql
@@ -1,0 +1,28 @@
+-- Fix the scheduler recovery-sweep indexes.
+--
+-- The recovery sweeps query a single status with a literal predicate:
+--   getOrphanedStartingRuns: WHERE status = 'starting' AND created_at < ?
+--   getTimedOutRunningRuns:  WHERE status = 'running'  AND started_at < ?
+--
+-- The previous index, idx_runs_active_status (status, created_at)
+-- WHERE status IN ('starting','running'), was NEVER used by those queries:
+-- SQLite (and therefore D1) cannot prove that `status = 'starting'` implies the
+-- index's `status IN ('starting','running')` predicate, so each sweep fell back
+-- to a full table SCAN of automation_runs. automation_runs is append-only, so as
+-- run history grew the scan eventually exceeded D1's query time limit -> the
+-- recovery sweep (and thus the whole scheduler tick) started timing out.
+--
+-- Bare-equality partial predicates match each query verbatim, so the planner
+-- uses them. Because they are partial, each index only ever holds the small
+-- active subset (rows in a terminal state are excluded), so they stay tiny and
+-- fast regardless of how large the history grows.
+
+DROP INDEX IF EXISTS idx_runs_active_status;
+
+CREATE INDEX IF NOT EXISTS idx_runs_orphan_sweep
+  ON automation_runs (created_at)
+  WHERE status = 'starting';
+
+CREATE INDEX IF NOT EXISTS idx_runs_timeout_sweep
+  ON automation_runs (started_at)
+  WHERE status = 'running';

--- a/terraform/d1/migrations/0024_fix_recovery_sweep_indexes.sql
+++ b/terraform/d1/migrations/0024_fix_recovery_sweep_indexes.sql
@@ -1,21 +1,8 @@
--- Fix the scheduler recovery-sweep indexes.
---
--- The recovery sweeps query a single status with a literal predicate:
---   getOrphanedStartingRuns: WHERE status = 'starting' AND created_at < ?
---   getTimedOutRunningRuns:  WHERE status = 'running'  AND started_at < ?
---
--- The previous index, idx_runs_active_status (status, created_at)
--- WHERE status IN ('starting','running'), was NEVER used by those queries:
--- SQLite (and therefore D1) cannot prove that `status = 'starting'` implies the
--- index's `status IN ('starting','running')` predicate, so each sweep fell back
--- to a full table SCAN of automation_runs. automation_runs is append-only, so as
--- run history grew the scan eventually exceeded D1's query time limit -> the
--- recovery sweep (and thus the whole scheduler tick) started timing out.
---
--- Bare-equality partial predicates match each query verbatim, so the planner
--- uses them. Because they are partial, each index only ever holds the small
--- active subset (rows in a terminal state are excluded), so they stay tiny and
--- fast regardless of how large the history grows.
+-- Replace idx_runs_active_status with per-status partial indexes for the recovery
+-- sweeps. Its `status IN ('starting','running')` predicate is never matched by the
+-- sweeps' `status = '...'` queries, so they full-scanned the append-only
+-- automation_runs table and timed out as history grew. Bare-equality partials
+-- match the queries and stay scoped to the small active subset.
 
 DROP INDEX IF EXISTS idx_runs_active_status;
 


### PR DESCRIPTION
## Problem

The scheduler's recovery sweep was timing out against D1, which takes the whole tick down with it:

```
D1DatabaseSessionAlwaysPrimary._sendOrThrow (cloudflare-internal:d1-api)
AutomationStore.getOrphanedStartingRuns
SchedulerDO.recoverySweep
SchedulerDO.handleTick
```

`recoverySweep()` runs at the top of every tick, before any overdue automations are processed, and is not wrapped in try/catch — so when its first query times out the entire tick aborts and **no scheduled automations run at all**.

## Root cause

Both recovery-sweep queries filter `automation_runs` by a single literal status:

- `getOrphanedStartingRuns`: `WHERE status = 'starting' AND created_at < ?`
- `getTimedOutRunningRuns`: `WHERE status = 'running' AND started_at IS NOT NULL AND started_at < ?`

The only candidate index was:

```sql
CREATE INDEX idx_runs_active_status ON automation_runs (status, created_at)
  WHERE status IN ('starting', 'running');
```

SQLite (and therefore D1) only uses a partial index when it can prove the query's `WHERE` implies the index predicate, and it "does not do algebra" — it cannot prove `status = 'starting'` implies `status IN ('starting','running')` (`IN` is represented as its own node type, not OR-connected terms). So the index was **never used** and both sweeps fell back to a full table `SCAN`.

`automation_runs` is append-only (no retention), so scan cost grows with total history until it exceeds D1's query time limit — the classic "worked for months, then started timing out as data grew."

`EXPLAIN QUERY PLAN` on the exact production query confirms the scan:

```
SELECT * FROM automation_runs WHERE status = 'starting' AND created_at < ?;
`--SCAN automation_runs          -- idx_runs_active_status not used
```

## Fix

Replace the unused index with bare-equality **per-status partial indexes** that the planner matches verbatim (migration `0024`):

```sql
DROP INDEX IF EXISTS idx_runs_active_status;
CREATE INDEX idx_runs_orphan_sweep  ON automation_runs (created_at) WHERE status = 'starting';
CREATE INDEX idx_runs_timeout_sweep ON automation_runs (started_at) WHERE status = 'running';
```

After the migration:

```
SELECT * FROM automation_runs WHERE status = 'starting' AND created_at < ?;
`--SEARCH automation_runs USING INDEX idx_runs_orphan_sweep (created_at<?)
```

Because the indexes are partial, they only ever contain the small *active* subset (terminal rows are excluded), so they stay tiny and fast regardless of how large the history grows — index size tracks the live working set, not total history. (On a 200k-row sample, the partial indexes measured ~4 KB each vs ~4.6 MB for a full `(status, created_at)` index, and the gap widens without bound.)

`idx_runs_active_status` had no other readers — every other status-filtered query is also scoped by `automation_id` and uses `idx_runs_automation_status` / `idx_runs_concurrency` — so dropping it is safe.

The queries are unchanged. A guard comment on the recovery-sweep section documents that `status` must stay a string literal: partial-index matching is syntactic and happens at plan time, so `status = ?` (a bound parameter) would silently revert to a full scan.

## Why not a full `(status, created_at)` index?

A full index would also work, but it reintroduces the unbounded-growth coupling that caused the bug — its size grows with the entire append-only table forever. Partial indexes decouple index size from history size, which is the canonical "index the active subset" idiom (cf. Postgres' unbilled-orders example; good_job / graphile-worker / Oban Pro all index the active subset).

## Tests

- Existing behavioural recovery-sweep tests still pass.
- Added two `EXPLAIN QUERY PLAN` regression guards (integration, against real D1) asserting each sweep is served by its partial index — these catch a migration revert, predicate drift, or the literal→bound-param mistake.
- Full suite green: **1365 unit + 370 integration**.

## Follow-up (not in this PR)

`automation_runs` still grows without bound. This change makes the *sweeps* immune to table size, but the table itself and per-automation history queries (`listRunsForAutomation`'s `COUNT(*)`) keep growing. A retention/pruning job for old terminal runs is worth a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage to ensure recovery-sweep queries use the expected database indexes and don’t fall back to full scans.

* **Chores**
  * Improved recovery-sweep database indexing by replacing the previous combined partial index with per-status partial indexes optimized for “starting” and “running” runs.
  * Refined the recovery-sweep queries to consistently leverage these indexes for better performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->