### PR TITLE
fix(sandbox-runtime): seed OpenCode global config dir to skip cold-start reify

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -471,20 +471,63 @@ class SandboxSupervisor:
                     continue
                 shutil.copy(tool_file, tool_dest / tool_file.name)
 
-        # Copy pre-built deps (package.json, package-lock.json, node_modules)
-        # from the image staging directory.  This gives OpenCode a lockfile
-        # that matches the declared dependencies so Npm.install() finds
-        # everything in sync and skips arborist reify() entirely.
-        deps_cache = Path("/app/opencode-deps")
+        # Copy pre-built deps (package.json, package-lock.json, node_modules) from the image
+        # staging directory so OpenCode's Npm.install() finds the tree in sync and skips the
+        # arborist reify() that would otherwise block the first request.
+        self._stage_opencode_deps(Path("/app/opencode-deps"), opencode_dir)
+
+    @staticmethod
+    def _stage_opencode_deps(deps_cache: Path, dest_dir: Path) -> None:
+        """Copy the pre-staged OpenCode plugin deps into dest_dir.
+
+        Copies package.json, package-lock.json and node_modules from the image staging
+        directory (base.py's /app/opencode-deps) into dest_dir, per file and only when the
+        destination is absent. This gives OpenCode a lockfile that matches node_modules so
+        Npm.install() finds @opencode-ai/plugin in sync and skips the arborist reify() that
+        would otherwise block the first request.
+        """
         for name in ("package.json", "package-lock.json"):
             src = deps_cache / name
-            dest = opencode_dir / name
+            dest = dest_dir / name
             if src.exists() and not dest.exists():
                 shutil.copy2(src, dest)
         cached_modules = deps_cache / "node_modules"
-        local_modules = opencode_dir / "node_modules"
+        local_modules = dest_dir / "node_modules"
         if cached_modules.is_dir() and not local_modules.exists():
             shutil.copytree(cached_modules, local_modules, symlinks=True)
+
+    @staticmethod
+    def _resolve_opencode_global_config_dir() -> Path:
+        """Resolve OpenCode's global config directory the way OpenCode does.
+
+        OpenCode (via xdg-basedir) uses OPENCODE_CONFIG_DIR when set, otherwise
+        $XDG_CONFIG_HOME/opencode, otherwise ~/.config/opencode.
+        """
+        override = os.environ.get("OPENCODE_CONFIG_DIR")
+        if override:
+            return Path(override)
+        xdg = os.environ.get("XDG_CONFIG_HOME")
+        base = Path(xdg) if xdg else Path.home() / ".config"
+        return base / "opencode"
+
+    def _seed_global_opencode_deps(self) -> None:
+        """Pre-seed OpenCode's global config dir with the staged plugin tree.
+
+        On startup OpenCode bootstraps every directory in its config search path and forks
+        ``npm install @opencode-ai/plugin`` for each. The global config dir is created empty and
+        is never seeded by _install_tools (which only covers the repo's .opencode/), so with a
+        plugin configured the first POST /session blocks on an arborist reify() of that empty
+        directory. Seeding it here makes the reify a no-op for every session.
+        """
+        deps_cache = Path("/app/opencode-deps")
+        if not deps_cache.is_dir():
+            return
+        config_dir = self._resolve_opencode_global_config_dir()
+        if (config_dir / "node_modules").exists():
+            return  # already seeded, or a real global config — never clobber
+        config_dir.mkdir(parents=True, exist_ok=True)
+        self._stage_opencode_deps(deps_cache, config_dir)
+        self.log.info("opencode.global_deps_seeded", config_dir=str(config_dir))
 
     def _install_bin_scripts(self) -> None:
         """Install standalone CLI scripts into /usr/local/bin.
@@ -835,6 +878,13 @@ class SandboxSupervisor:
             workdir = self.repo_path
 
         self._install_tools(workdir)
+        # Seed OpenCode's global config dir too, so its cold-start `npm install` is a no-op and
+        # the first POST /session does not block on an arborist reify(). Best-effort: a failure
+        # here only degrades to the (slower) reify, so it must not crash startup.
+        try:
+            self._seed_global_opencode_deps()
+        except Exception as e:
+            self.log.warn("opencode.global_deps_seed_failed", exc=e)
         self._install_skills(workdir)
         self._install_bin_scripts()
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -523,11 +523,26 @@ class SandboxSupervisor:
         if not deps_cache.is_dir():
             return
         config_dir = self._resolve_opencode_global_config_dir()
-        if (config_dir / "node_modules").exists():
-            return  # already seeded, or a real global config — never clobber
+        # Only seed a pristine dir — never mix our modules into a user's manifest.
+        if (config_dir / "node_modules").exists() or (config_dir / "package.json").exists():
+            self.log.debug("opencode.global_deps_skip", config_dir=str(config_dir))
+            return
         config_dir.mkdir(parents=True, exist_ok=True)
         self._stage_opencode_deps(deps_cache, config_dir)
         self.log.info("opencode.global_deps_seeded", config_dir=str(config_dir))
+
+    def _prepare_opencode_filesystem(self, workdir: Path) -> None:
+        """Stage OpenCode's filesystem assets (tools, deps, skills, bin) before launch.
+
+        The global seed is best-effort (degrades to a slower reify); the rest fail fast.
+        """
+        self._install_tools(workdir)
+        try:
+            self._seed_global_opencode_deps()
+        except Exception as e:
+            self.log.warn("opencode.global_deps_seed_failed", exc=e)
+        self._install_skills(workdir)
+        self._install_bin_scripts()
 
     def _install_bin_scripts(self) -> None:
         """Install standalone CLI scripts into /usr/local/bin.
@@ -877,16 +892,7 @@ class SandboxSupervisor:
         if self.repo_path.exists() and (self.repo_path / ".git").exists():
             workdir = self.repo_path
 
-        self._install_tools(workdir)
-        # Seed OpenCode's global config dir too, so its cold-start `npm install` is a no-op and
-        # the first POST /session does not block on an arborist reify(). Best-effort: a failure
-        # here only degrades to the (slower) reify, so it must not crash startup.
-        try:
-            self._seed_global_opencode_deps()
-        except Exception as e:
-            self.log.warn("opencode.global_deps_seed_failed", exc=e)
-        self._install_skills(workdir)
-        self._install_bin_scripts()
+        self._prepare_opencode_filesystem(workdir)
 
         # Deploy codex auth proxy plugin if OpenAI OAuth is configured
         opencode_dir = workdir / ".opencode"

--- a/packages/sandbox-runtime/tests/test_tool_installation.py
+++ b/packages/sandbox-runtime/tests/test_tool_installation.py
@@ -385,3 +385,100 @@ class TestInstallSkills:
             sup._install_skills(workdir)
 
         assert not (workdir / ".opencode" / "skills").exists()
+
+
+def _make_opencode_deps_staging(tmp_path: Path) -> Path:
+    """Build a fake /app/opencode-deps staging tree (plugin-only, in sync)."""
+    deps_cache = tmp_path / "opencode-deps"
+    deps_cache.mkdir()
+    (deps_cache / "package.json").write_text('{"dependencies": {"@opencode-ai/plugin": "1.14.41"}}')
+    (deps_cache / "package-lock.json").write_text('{"lockfileVersion": 3}')
+    plugin = deps_cache / "node_modules" / "@opencode-ai" / "plugin"
+    plugin.mkdir(parents=True)
+    (plugin / "index.js").write_text("module.exports = {}")
+    return deps_cache
+
+
+class TestResolveGlobalConfigDir:
+    """Cases for _resolve_opencode_global_config_dir() — OpenCode's xdg-basedir resolution."""
+
+    def test_uses_opencode_config_dir_override(self, tmp_path, monkeypatch):
+        """OPENCODE_CONFIG_DIR wins over XDG_CONFIG_HOME and is used verbatim."""
+        monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(tmp_path / "custom"))
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+        assert SandboxSupervisor._resolve_opencode_global_config_dir() == tmp_path / "custom"
+
+    def test_uses_xdg_config_home(self, tmp_path, monkeypatch):
+        """Without the override, $XDG_CONFIG_HOME/opencode is used."""
+        monkeypatch.delenv("OPENCODE_CONFIG_DIR", raising=False)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+        assert (
+            SandboxSupervisor._resolve_opencode_global_config_dir() == tmp_path / "xdg" / "opencode"
+        )
+
+    def test_falls_back_to_home_config(self, tmp_path, monkeypatch):
+        """With neither set, ~/.config/opencode is used."""
+        monkeypatch.delenv("OPENCODE_CONFIG_DIR", raising=False)
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        assert (
+            SandboxSupervisor._resolve_opencode_global_config_dir()
+            == tmp_path / "home" / ".config" / "opencode"
+        )
+
+
+class TestSeedGlobalOpencodeDeps:
+    """Cases for _seed_global_opencode_deps() — seeding OpenCode's global config dir."""
+
+    def test_seeds_empty_global_config_dir(self, tmp_path, monkeypatch):
+        """The staged plugin tree is copied into $XDG_CONFIG_HOME/opencode when it is empty."""
+        sup = _make_supervisor()
+        deps_cache = _make_opencode_deps_staging(tmp_path)
+        cfg = tmp_path / "xdg"
+        monkeypatch.delenv("OPENCODE_CONFIG_DIR", raising=False)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(cfg))
+
+        with _patch_paths(
+            legacy=tmp_path / "no-legacy", tools=tmp_path / "no-tools", deps_cache=deps_cache
+        ):
+            sup._seed_global_opencode_deps()
+
+        seeded = cfg / "opencode"
+        assert (seeded / "package.json").exists()
+        assert (seeded / "package-lock.json").exists()
+        assert (seeded / "node_modules" / "@opencode-ai" / "plugin").is_dir()
+
+    def test_does_not_clobber_populated_global_dir(self, tmp_path, monkeypatch):
+        """An existing global config dir that already has node_modules is left untouched."""
+        sup = _make_supervisor()
+        deps_cache = _make_opencode_deps_staging(tmp_path)
+        cfg = tmp_path / "xdg"
+        seeded = cfg / "opencode"
+        (seeded / "node_modules").mkdir(parents=True)
+        existing_pkg = seeded / "package.json"
+        existing_pkg.write_text('{"name": "existing"}')
+        monkeypatch.delenv("OPENCODE_CONFIG_DIR", raising=False)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(cfg))
+
+        with _patch_paths(
+            legacy=tmp_path / "no-legacy", tools=tmp_path / "no-tools", deps_cache=deps_cache
+        ):
+            sup._seed_global_opencode_deps()
+
+        assert existing_pkg.read_text() == '{"name": "existing"}'
+
+    def test_noop_when_staging_absent(self, tmp_path, monkeypatch):
+        """No global dir is created when the /app/opencode-deps staging is missing."""
+        sup = _make_supervisor()
+        cfg = tmp_path / "xdg"
+        monkeypatch.delenv("OPENCODE_CONFIG_DIR", raising=False)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(cfg))
+
+        with _patch_paths(
+            legacy=tmp_path / "no-legacy",
+            tools=tmp_path / "no-tools",
+            deps_cache=tmp_path / "missing",
+        ):
+            sup._seed_global_opencode_deps()
+
+        assert not (cfg / "opencode").exists()

--- a/packages/sandbox-runtime/tests/test_tool_installation.py
+++ b/packages/sandbox-runtime/tests/test_tool_installation.py
@@ -467,6 +467,27 @@ class TestSeedGlobalOpencodeDeps:
 
         assert existing_pkg.read_text() == '{"name": "existing"}'
 
+    def test_skips_when_manifest_present_without_node_modules(self, tmp_path, monkeypatch):
+        """A global dir with a user package.json but no node_modules is left untouched —
+        seeding our node_modules against a foreign manifest would be an out-of-sync tree."""
+        sup = _make_supervisor()
+        deps_cache = _make_opencode_deps_staging(tmp_path)
+        cfg = tmp_path / "xdg"
+        seeded = cfg / "opencode"
+        seeded.mkdir(parents=True)
+        existing_pkg = seeded / "package.json"
+        existing_pkg.write_text('{"name": "user-global"}')
+        monkeypatch.delenv("OPENCODE_CONFIG_DIR", raising=False)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(cfg))
+
+        with _patch_paths(
+            legacy=tmp_path / "no-legacy", tools=tmp_path / "no-tools", deps_cache=deps_cache
+        ):
+            sup._seed_global_opencode_deps()
+
+        assert existing_pkg.read_text() == '{"name": "user-global"}'
+        assert not (seeded / "node_modules").exists()
+
     def test_noop_when_staging_absent(self, tmp_path, monkeypatch):
         """No global dir is created when the /app/opencode-deps staging is missing."""
         sup = _make_supervisor()


### PR DESCRIPTION
## Summary

A user's **first prompt on a freshly-spawned sandbox can hard-fail with "Execution failed"** when
the bridge's `POST /session` to the in-sandbox OpenCode server times out (30 s `httpx.ReadTimeout`).
This seeds OpenCode's **global** config dir (`~/.config/opencode`) with the plugin dependency tree
we already stage, so OpenCode's cold-start `npm install` is a no-op and the first request no longer
blocks on it.

## Root cause (confirmed on a live sandbox)

`POST /session` runs OpenCode's per-directory bootstrap. When a plugin is configured (an OpenAI-OAuth
session deploys `codex-auth-plugin.js`, and the repo may ship its own `.opencode/plugins/*.ts`),
`plugin.init()` calls `config.waitForDependencies()`, which makes the request **block** on a forked
`npm install @opencode-ai/plugin` for **every** directory in OpenCode's config search path.

That search path includes **`Global.Path.config` = `~/.config/opencode`**, which OpenCode `mkdir`s
empty on every startup. We pre-stage `/app/opencode-deps` and copy it into the **repo's** `.opencode/`
(`_install_tools`), but we **never** seed the global dir — so it has no `node_modules`, OpenCode's
`checkNodeModules` reifies it (a real `arborist.reify()` npm install, no internal timeout), and on a
slow/cold install that exceeds the bridge's 30 s budget the prompt fails.

Verified on a running sandbox — `~/.config/opencode/` contains:

```json
{ "dependencies": { "@opencode-ai/plugin": "1.14.41" } }
```

plus `node_modules/` and a 14K `package-lock.json`. That `package.json` has **no `name`/`type`** — it
is arborist's synthesized manifest, **not** our staged file (`{"name":"opencode-tools","type":"module",…}`),
proving OpenCode reified this directory itself. (Global `npm install -g` lands in `/usr/lib/node_modules`;
`_install_tools` targets the repo's `.opencode/` — neither writes here.)

This is **not** the previously-suspected `_install_tools` mixed-tree bug: the incident repo committed
only `.opencode/plugins/skill-audit.ts` (no `.opencode/package.json`), so its repo `.opencode/` is
seeded consistently and does not reify — the unseeded **global** dir is the culprit.

## Fix

`entrypoint.py`:
- Extract the existing deps-copy into a shared `_stage_opencode_deps(deps_cache, dest_dir)`.
- Add `_seed_global_opencode_deps()` — resolves OpenCode's global config dir the way OpenCode does
  (`OPENCODE_CONFIG_DIR` → `$XDG_CONFIG_HOME/opencode` → `~/.config/opencode`) and copies the staged
  tree there **only if it has no `node_modules`** (never clobbers a real/existing config).
- Call it from `start_opencode` right after `_install_tools`, **best-effort** (a failure only degrades
  to the slower reify, so it must not crash startup).

It's a plain file copy, runs on every serving boot (fresh / repo-image / snapshot, and Daytona since
the entrypoint is shared), and is robust to `HOME`/`XDG_CONFIG_HOME` changes.

## Why this approach

It removes the **specific directory that actually reified**, for every session, at zero per-session
cost. For the reported incident it is complete on its own (the repo's `.opencode/` was already
consistent). Considered, deliberately **not** in this PR (tracked as follow-ups):
- A bridge-side dedicated `POST /session` timeout + retry (defense in depth) — recommended next.
- A general "warm the bootstrap before `ready`" step that pays *any* reify off the prompt path —
  useful for repos that ship their own `.opencode/` npm deps.

## Testing

- New unit tests in `test_tool_installation.py`:
  - `TestResolveGlobalConfigDir` — `OPENCODE_CONFIG_DIR` override, `XDG_CONFIG_HOME`, and `~/.config`
    fallback.
  - `TestSeedGlobalOpencodeDeps` — seeds an empty global dir; no-ops when `node_modules` already
    present (never clobbers); no-ops when the staging is absent.
- `pytest tests/` — 359 passed.
- `ruff check` / `ruff format --check` — clean.
- `mypy src/` — no new errors (mypy-neutral vs `main`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced OpenCode dependency staging by reusing cached `package*.json` and `node_modules` when absent, and optionally seeding them into the standard global configuration directory when empty.
* **Bug Fixes**
  * Improved startup resilience by running global seeding in best-effort mode and continuing even if seeding fails.
* **Tests**
  * Added coverage for global config directory resolution (environment/XDG/home fallback) and seeding behavior under empty, partially populated, and missing staging-cache scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->