### PR TITLE
fix: include pyproject.toml + uv.lock in modal deploy source_hash

### DIFF
--- a/terraform/environments/production/modal.tf
+++ b/terraform/environments/production/modal.tf
@@ -4,16 +4,17 @@
 
 # Calculate hash of Modal source files for change detection
 # Uses sha256sum (Linux) or shasum (macOS) for cross-platform compatibility
-# Includes .py, .js, and .ts files (sandbox plugins and tools)
+# Includes .py/.js/.ts under src/ AND modal-infra's pyproject.toml + uv.lock, so
+# dependency-only changes (e.g. a modal version bump) also trigger a redeploy.
 data "external" "modal_source_hash" {
   count = local.use_modal_backend ? 1 : 0
 
   program = ["bash", "-c", <<-EOF
     cd ${var.project_root}
     if command -v sha256sum &> /dev/null; then
-      hash=$(find packages/modal-infra/src packages/sandbox-runtime/src -type f \( -name "*.py" -o -name "*.js" -o -name "*.ts" \) -exec sha256sum {} \; | sha256sum | cut -d' ' -f1)
+      hash=$( ( find packages/modal-infra/src packages/sandbox-runtime/src -type f \( -name "*.py" -o -name "*.js" -o -name "*.ts" \) -exec sha256sum {} \; ; sha256sum packages/modal-infra/pyproject.toml packages/modal-infra/uv.lock ) | sha256sum | cut -d' ' -f1)
     else
-      hash=$(find packages/modal-infra/src packages/sandbox-runtime/src -type f \( -name "*.py" -o -name "*.js" -o -name "*.ts" \) -exec shasum -a 256 {} \; | shasum -a 256 | cut -d' ' -f1)
+      hash=$( ( find packages/modal-infra/src packages/sandbox-runtime/src -type f \( -name "*.py" -o -name "*.js" -o -name "*.ts" \) -exec shasum -a 256 {} \; ; shasum -a 256 packages/modal-infra/pyproject.toml packages/modal-infra/uv.lock ) | shasum -a 256 | cut -d' ' -f1)
     fi
     echo "{\"hash\": \"$hash\"}"
   EOF


### PR DESCRIPTION
## Summary

The Terraform Modal deploy only redeploys when its `source_hash` changes, but that hash was computed from **only `*.py/*.js/*.ts` under `packages/{modal-infra,sandbox-runtime}/src`** — it excluded `packages/modal-infra/pyproject.toml` and `uv.lock`.

The data plane deploys via `uv sync --frozen` (installs exactly the lockfile), so the lockfile *is* a deploy input. Excluding it means a **dependency-only change silently does not redeploy Modal**: `null_resource.modal_deploy` (`terraform/modules/modal-app/main.tf`) sees no trigger change and is a no-op. This is what swallowed #791's `modal>=1.4.3` bump — the lockfile changed, but `modal deploy` never ran, so the running container kept the old client.

## Fix

Include `pyproject.toml` + `uv.lock` in `modal_source_hash` (both the Linux `sha256sum` and macOS `shasum` branches), so dependency-only changes trigger a redeploy.

## Verification

- `terraform fmt -check` clean; `terraform validate` → "Success! The configuration is valid."
- Confirmed the digest changes when only `uv.lock`/`pyproject.toml` change (and stays a valid 64-char hash).
