### PR TITLE
test: re-enable integration file parallelism (per-file D1 isolation)

### DIFF
--- a/packages/control-plane/vitest.integration.config.ts
+++ b/packages/control-plane/vitest.integration.config.ts
@@ -26,10 +26,10 @@ function generateTestEncryptionKey(): string {
 // `defineWorkersConfig` + `test.poolOptions.workers` setup with the
 // `cloudflareTest()` Vite plugin, configured via `defineConfig` from
 // "vitest/config". The old `singleWorker`/`isolatedStorage` poolOptions are not
-// configured here; integration tests share one D1 instance and rely on explicit
-// `cleanD1Tables()` cleanup (see test/integration/cleanup.ts) for isolation.
-// That cleanup-based isolation only holds when files run one at a time — see
-// `fileParallelism: false` below.
+// configured here; pool-workers isolates D1 storage per test FILE, so files run
+// in parallel without cross-file interference. Within a file, tests share one D1
+// instance and rely on explicit `cleanD1Tables()` cleanup (see
+// test/integration/cleanup.ts) for isolation.
 export default defineConfig({
   resolve: {
     alias: {
@@ -64,13 +64,5 @@ export default defineConfig({
   test: {
     include: ["test/integration/**/*.test.ts"],
     setupFiles: ["test/integration/apply-migrations.ts"],
-    // Run integration files serially. They share a single D1 instance, so
-    // running them in parallel lets one file's beforeEach `cleanD1Tables()`
-    // DELETE rows another file just seeded. The scheduler tick scans automations
-    // globally (getOverdueAutomations + an unconditional DELETE in cleanup), so
-    // concurrent files made its tick tests flaky (an overdue automation could
-    // vanish mid-tick). Serial execution is what makes cleanup-based isolation
-    // actually hold.
-    fileParallelism: false,
   },
 });


### PR DESCRIPTION
## Summary

Removes the `fileParallelism: false` serialization added in #765. Its stated rationale turned out to be false, so it was slowing the integration job (~2x) for no correctness benefit.

## Why #765's premise was wrong

#765 serialized the integration suite on the theory that, since files share one D1 and isolate via `cleanD1Tables()` in `beforeEach`, running them concurrently lets one file's cleanup `DELETE` rows another file just seeded — making the scheduler tick tests flaky.

That premise doesn't hold: **`@cloudflare/vitest-pool-workers` 0.16.13 isolates D1 storage per test _file_.** I verified with a two-file probe where each file inserts a marker row and polls 3s for the other's:

- Both files ran **concurrently** (identical ~3063ms durations — sequential would be ~6s total).
- **Neither saw the other's row.**

So within a file tests share storage (hence `cleanD1Tables` is still needed), but **cross-file contamination cannot happen**, and file parallelism is safe.

The integration failures on #748 were never this — they were vite 8's luxon CJS interop, fixed in **#784** (that luxon alias is **kept** here).

## What changed

- Remove `fileParallelism: false` from `vitest.integration.config.ts`.
- Correct the now-inaccurate "integration tests share one D1 instance" comment to describe per-file isolation (so the serialization isn't reintroduced).
- **Kept:** #765's `scheduler.test.ts` assertion improvements (scoped to the seeded automation, schedule-advancement checks) — good test design and parallel-safe.

## Verification

Real `npm ci` on main's lockfile (**vite 8.0.16**), full integration suite in parallel with the luxon alias:

- **6/6 runs green** (372/372 tests each).
- `typecheck`, `prettier`, `eslint`: clean.

Cross-file isolation was confirmed by the concurrent probe above; the earlier "parallel flakes" I saw locally were pure resource exhaustion on an overloaded laptop (`setup 250s`), not contamination — they don't reproduce on a normal machine, and `main` CI was historically green under parallel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized test infrastructure configuration to improve integration test execution efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->