### PR TITLE
refactor(slack-bot): extract neutral slack-blocks module (follow-up to #766)

### DIFF
--- a/packages/slack-bot/src/app-home/interactions.ts
+++ b/packages/slack-bot/src/app-home/interactions.ts
@@ -29,8 +29,8 @@ import type {
   AppHomeInteractionResponseBody,
   BackgroundTaskScheduler,
   SlackBlockAction,
-  SlackSelectOption,
 } from "./slack-types";
+import type { SlackSelectOption } from "../slack-blocks";
 import { buildRepoBranchSelectOptions } from "./view";
 import { getResolvedUserPreferences, updateUserPreferences } from "../user-preferences";
 

--- a/packages/slack-bot/src/app-home/modals.ts
+++ b/packages/slack-bot/src/app-home/modals.ts
@@ -8,7 +8,8 @@ import {
 import { createLogger } from "../logger";
 import type { Env, RepoConfig } from "../types";
 import { encodeBranchModalMetadata, encodeRepoBranchModalMetadata } from "./metadata";
-import type { AppHomeModalBlock, SlackInputBlock } from "./slack-types";
+import type { AppHomeModalBlock } from "./slack-types";
+import type { SlackInputBlock } from "../slack-blocks";
 
 const log = createLogger("app-home");
 

--- a/packages/slack-bot/src/app-home/slack-types.ts
+++ b/packages/slack-bot/src/app-home/slack-types.ts
@@ -1,84 +1,18 @@
 import type { SlackInteractionPayload } from "../types";
+import type {
+  SlackActionsBlock,
+  SlackContextBlock,
+  SlackDividerBlock,
+  SlackHeaderBlock,
+  SlackInputBlock,
+  SlackSectionBlock,
+  SlackSelectOption,
+} from "../slack-blocks";
 
 export interface ModelOption {
   label: string;
   value: string;
 }
-
-export type SlackSelectOption = {
-  text: SlackPlainText;
-  description?: SlackPlainText;
-  value: string;
-};
-export type SlackPlainText = { type: "plain_text"; text: string };
-export type SlackMrkdwnText = { type: "mrkdwn"; text: string };
-export type SlackText = SlackPlainText | SlackMrkdwnText;
-
-export type SlackConfirmation = {
-  title: SlackPlainText;
-  text: SlackText;
-  confirm: SlackPlainText;
-  deny: SlackPlainText;
-};
-
-export type SlackButtonElement = {
-  type: "button";
-  action_id: string;
-  text: SlackPlainText;
-  value?: string;
-  style?: "danger";
-  confirm?: SlackConfirmation;
-};
-
-export type SlackStaticSelectElement = {
-  type: "static_select";
-  action_id: string;
-  initial_option?: SlackSelectOption;
-  placeholder?: SlackPlainText;
-  options: SlackSelectOption[];
-};
-
-export type SlackExternalSelectElement = {
-  type: "external_select";
-  action_id: string;
-  placeholder: SlackPlainText;
-  min_query_length: number;
-};
-
-export type SlackPlainTextInputElement = {
-  type: "plain_text_input";
-  action_id: string;
-  initial_value: string;
-  placeholder: SlackPlainText;
-};
-
-export type SlackBlockElement =
-  | SlackButtonElement
-  | SlackStaticSelectElement
-  | SlackExternalSelectElement;
-export type SlackHeaderBlock = { type: "header"; text: SlackPlainText };
-export type SlackSectionBlock = {
-  type: "section";
-  text: SlackText;
-  // A section accessory may be a button or a select (the repo clarification
-  // picker uses an external_select), not only a button.
-  accessory?: SlackBlockElement;
-};
-export type SlackActionsBlock = {
-  type: "actions";
-  block_id?: string;
-  elements: SlackBlockElement[];
-};
-export type SlackContextBlock = { type: "context"; elements: SlackText[] };
-export type SlackInputBlock = {
-  type: "input";
-  block_id: string;
-  optional?: boolean;
-  label: SlackPlainText;
-  element: SlackPlainTextInputElement;
-  hint?: SlackPlainText;
-};
-export type SlackDividerBlock = { type: "divider" };
 
 export type AppHomeBlock =
   | SlackHeaderBlock

--- a/packages/slack-bot/src/app-home/view.ts
+++ b/packages/slack-bot/src/app-home/view.ts
@@ -8,7 +8,8 @@ import {
   SELECT_MODEL_ACTION_ID,
   SELECT_REASONING_EFFORT_ACTION_ID,
 } from "./constants";
-import type { AppHomeBlock, AppHomeView, ModelOption, SlackSelectOption } from "./slack-types";
+import type { AppHomeBlock, AppHomeView, ModelOption } from "./slack-types";
+import type { SlackSelectOption } from "../slack-blocks";
 import { plainTextOption } from "../slack-options";
 
 export interface AppHomeViewState {

--- a/packages/slack-bot/src/repo-clarification.ts
+++ b/packages/slack-bot/src/repo-clarification.ts
@@ -16,7 +16,7 @@ import type {
   SlackButtonElement,
   SlackSectionBlock,
   SlackSelectOption,
-} from "./app-home/slack-types";
+} from "./slack-blocks";
 import type { Env, RepoConfig } from "./types";
 
 /**

--- a/packages/slack-bot/src/slack-blocks.ts
+++ b/packages/slack-bot/src/slack-blocks.ts
@@ -1,0 +1,85 @@
+/**
+ * Neutral Slack Block Kit primitives.
+ *
+ * Plain shapes for the subset of Slack's Block Kit the bot emits — text
+ * objects, interactive elements, and layout blocks. Kept free of any
+ * feature-specific (App Home, repo clarification, …) concerns so every Slack
+ * message builder can share them without depending on a feature module.
+ */
+
+export type SlackPlainText = { type: "plain_text"; text: string };
+export type SlackMrkdwnText = { type: "mrkdwn"; text: string };
+export type SlackText = SlackPlainText | SlackMrkdwnText;
+
+export type SlackSelectOption = {
+  text: SlackPlainText;
+  description?: SlackPlainText;
+  value: string;
+};
+
+export type SlackConfirmation = {
+  title: SlackPlainText;
+  text: SlackText;
+  confirm: SlackPlainText;
+  deny: SlackPlainText;
+};
+
+export type SlackButtonElement = {
+  type: "button";
+  action_id: string;
+  text: SlackPlainText;
+  value?: string;
+  style?: "danger";
+  confirm?: SlackConfirmation;
+};
+
+export type SlackStaticSelectElement = {
+  type: "static_select";
+  action_id: string;
+  initial_option?: SlackSelectOption;
+  placeholder?: SlackPlainText;
+  options: SlackSelectOption[];
+};
+
+export type SlackExternalSelectElement = {
+  type: "external_select";
+  action_id: string;
+  placeholder: SlackPlainText;
+  min_query_length: number;
+};
+
+export type SlackPlainTextInputElement = {
+  type: "plain_text_input";
+  action_id: string;
+  initial_value: string;
+  placeholder: SlackPlainText;
+};
+
+export type SlackBlockElement =
+  | SlackButtonElement
+  | SlackStaticSelectElement
+  | SlackExternalSelectElement;
+
+export type SlackHeaderBlock = { type: "header"; text: SlackPlainText };
+export type SlackSectionBlock = {
+  type: "section";
+  text: SlackText;
+  // A section accessory may be a button or a select (the repo clarification
+  // picker uses an external_select), not only a button.
+  accessory?: SlackBlockElement;
+};
+export type SlackActionsBlock = {
+  type: "actions";
+  block_id?: string;
+  elements: SlackBlockElement[];
+};
+export type SlackContextBlock = { type: "context"; elements: SlackText[] };
+export type SlackInputBlock = {
+  type: "input";
+  block_id: string;
+  optional?: boolean;
+  label: SlackPlainText;
+  element: SlackPlainTextInputElement;
+  hint?: SlackPlainText;
+};
+export type SlackDividerBlock = { type: "divider" };

--- a/packages/slack-bot/src/slack-options.ts
+++ b/packages/slack-bot/src/slack-options.ts
@@ -1,4 +1,4 @@
-import type { SlackPlainText } from "./app-home/slack-types";
+import type { SlackPlainText } from "./slack-blocks";
 
 /** Slack caps a select option's plain_text label/description at 75 characters. */
 export const SELECT_OPTION_TEXT_LIMIT = 75;


### PR DESCRIPTION
## Summary

Follow-up to the [type-boundary review comment](https://github.com/ColeMurray/background-agents/pull/766#discussion_r3434002158) on #766 (now merged). Extracts the generic Slack Block Kit primitives into a neutral module so non-App-Home Slack message builders stop depending on `app-home/*` for types they don't own.

## The problem

#766 added `repo-clarification.ts` (a general clarification-message builder) and `slack-options.ts` (generic option-text helpers). Both had to import Slack primitive/block types from `app-home/slack-types.ts` — i.e. non-App-Home code reaching into a feature module for types it doesn't own. As the reviewer put it, this risks `app-home` becoming "the accidental home for all Slack message schemas."

## The change

- **New `src/slack-blocks.ts`** — the neutral home for the Block Kit primitives the bot emits: text objects, interactive elements (button / static_select / external_select / plain_text_input), and layout blocks (header / section / actions / context / input / divider).
- **`app-home/slack-types.ts`** now holds only App-Home view models (`ModelOption`, `AppHomeBlock`, `AppHomeView`, `AppHomeInteraction*`, …) and imports the primitives it composes from `../slack-blocks`. It shrank from 85 → 19 lines.
- **Consumers repointed** — `repo-clarification.ts`, `slack-options.ts`, and the App-Home files (`view.ts`, `modals.ts`, `interactions.ts`) now import the primitives from `slack-blocks`. App-Home files keep importing their own view models from `slack-types`.

Pure type relocation — no runtime/behavior change. (The `SlackSectionBlock.accessory` widening to `SlackBlockElement` already landed in #766; it just moved file here.)

## Testing

- `npm run typecheck -w @open-inspect/slack-bot` ✅
- `npm test -w @open-inspect/slack-bot` ✅ (103 tests, unchanged)
- `npm run lint` / prettier ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal infrastructure reorganization for improved code organization. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->