### PR TITLE
perf(modal-infra): bake OpenCode global deps to skip boot-time seed

### DIFF
--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -47,7 +47,7 @@ TTYD_SHA256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55"
 
 # Cache buster - change this to force Modal image rebuild
 # v51: SCM credential helper backed by control plane; remove embedded VCS tokens
-CACHE_BUSTER = "v51-scm-credential-helper"
+CACHE_BUSTER = "v52-bake-opencode-global-deps"
 
 # Base image with all development tools
 base_image = (
@@ -132,6 +132,13 @@ base_image = (
     # OpenCode's Npm.install() finds package-lock.json in sync and skips
     # the slow arborist reify() call (2-22s) that would otherwise block
     # the first prompt and exceed the bridge's HTTP timeout.
+    #
+    # Also bake the same tree into OpenCode's GLOBAL config dir. OpenCode installs
+    # @opencode-ai/plugin into every config directory it discovers — including the
+    # global one (HOME=/root, so ~/.config/opencode), which it creates empty on
+    # startup — so without this the runtime _seed_global_opencode_deps() pays a
+    # multi-second node_modules copy on every boot. Baking it makes that seed a
+    # no-op (it skips when node_modules already exists). See #767 / #790.
     .run_commands(
         "mkdir -p /app/opencode-deps",
         # Pin staged plugin to OPENCODE_VERSION so the pre-staged tree copied
@@ -140,6 +147,9 @@ base_image = (
         f'"dependencies":{{"@opencode-ai/plugin":"{OPENCODE_VERSION}"}}}}\''
         " > /app/opencode-deps/package.json",
         "cd /app/opencode-deps && npm install --ignore-scripts --no-audit --no-fund",
+        # Bake the in-sync tree into the global config dir so the runtime seed is a no-op.
+        "mkdir -p /root/.config/opencode",
+        "cp -a /app/opencode-deps/. /root/.config/opencode/",
     )
     # Install code-server for browser-based VS Code editing (direct .deb from GitHub releases)
     .run_commands(

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -474,7 +474,13 @@ class SandboxSupervisor:
         # Copy pre-built deps (package.json, package-lock.json, node_modules) from the image
         # staging directory so OpenCode's Npm.install() finds the tree in sync and skips the
         # arborist reify() that would otherwise block the first request.
+        staged_at = time.monotonic()
         self._stage_opencode_deps(Path("/app/opencode-deps"), opencode_dir)
+        self.log.info(
+            "opencode.repo_deps_staged",
+            dir=str(opencode_dir),
+            duration_ms=round((time.monotonic() - staged_at) * 1000),
+        )
 
     @staticmethod
     def _stage_opencode_deps(deps_cache: Path, dest_dir: Path) -> None:
@@ -511,25 +517,39 @@ class SandboxSupervisor:
         return base / "opencode"
 
     def _seed_global_opencode_deps(self) -> None:
-        """Pre-seed OpenCode's global config dir with the staged plugin tree.
+        """Fallback seed of OpenCode's global config dir with the staged plugin tree.
 
-        On startup OpenCode bootstraps every directory in its config search path and forks
+        OpenCode bootstraps every directory in its config search path and forks
         ``npm install @opencode-ai/plugin`` for each. The global config dir is created empty and
         is never seeded by _install_tools (which only covers the repo's .opencode/), so with a
-        plugin configured the first POST /session blocks on an arborist reify() of that empty
-        directory. Seeding it here makes the reify a no-op for every session.
+        plugin configured the first POST /session would block on an arborist reify() of it.
+
+        The image bakes this tree into the global dir at build time (base.py), so this is
+        normally a no-op (we skip when node_modules already exists); it stays as a fallback for
+        environments where the baked dir is absent (e.g. a different HOME).
         """
         deps_cache = Path("/app/opencode-deps")
         if not deps_cache.is_dir():
             return
         config_dir = self._resolve_opencode_global_config_dir()
-        # Only seed a pristine dir — never mix our modules into a user's manifest.
-        if (config_dir / "node_modules").exists() or (config_dir / "package.json").exists():
-            self.log.debug("opencode.global_deps_skip", config_dir=str(config_dir))
+        # Only seed a pristine dir — never mix our modules into a user's manifest. The image
+        # bakes this tree in (base.py), so node_modules is normally already present and we skip.
+        nm_exists = (config_dir / "node_modules").exists()
+        if nm_exists or (config_dir / "package.json").exists():
+            self.log.info(
+                "opencode.global_deps_skip",
+                config_dir=str(config_dir),
+                reason="already_present" if nm_exists else "foreign_manifest",
+            )
             return
+        seeded_at = time.monotonic()
         config_dir.mkdir(parents=True, exist_ok=True)
         self._stage_opencode_deps(deps_cache, config_dir)
-        self.log.info("opencode.global_deps_seeded", config_dir=str(config_dir))
+        self.log.info(
+            "opencode.global_deps_seeded",
+            config_dir=str(config_dir),
+            duration_ms=round((time.monotonic() - seeded_at) * 1000),
+        )
 
     def _prepare_opencode_filesystem(self, workdir: Path) -> None:
         """Stage OpenCode's filesystem assets (tools, deps, skills, bin) before launch.


### PR DESCRIPTION
## Summary

Follow-up to #790. That PR fixed the user-visible cold-start `ReadTimeout` (#767) by seeding OpenCode's **global** config dir (`~/.config/opencode`) so the first `POST /session` no longer reifies it — but it did the seeding by **copying `node_modules` at boot**, which is a multi-second cost on every sandbox start (observed as ~9–19s in the `opencode.start → opencode.global_deps_seeded` window).

This moves that work to **image-build time**: bake the staged plugin tree into the global config dir once, so the runtime seed becomes a no-op.

## Change

**`base.py`** — after staging `/app/opencode-deps`, also copy it into the global config dir at build time (the image fixes `HOME=/root`, so the dir is always `/root/.config/opencode`):

```dockerfile
mkdir -p /root/.config/opencode
cp -a /app/opencode-deps/. /root/.config/opencode/
```

`CACHE_BUSTER` is bumped `v51 → v52-bake-opencode-global-deps` to rebuild the base image and stamp a distinct `SANDBOX_VERSION` (so we can confirm from telemetry which sandboxes run the baked image; per `manager.py:416`, repo-images/snapshots don't auto-rebuild on a bump and pick it up as they refresh).

**`entrypoint.py`** — `_seed_global_opencode_deps()` is now a documented **fallback**: it skips when `node_modules` is already present (which it now is, thanks to the bake). `OpenCode`'s startup `mkdir(recursive)` won't clear a populated dir, so the baked tree survives and still avoids the reify. The seed stays for environments where the baked dir isn't present (e.g. a different `HOME`).

Added timing/visibility so the boot cost is measurable (this was the other half of the ask):

- `opencode.repo_deps_staged` `duration_ms` — the pre-existing copy of the same tree into the **repo's** `.opencode/` (the remaining boot cost after this change).
- `opencode.global_deps_seeded` `duration_ms` — the fallback seed, when it actually runs.
- `opencode.global_deps_skip` `reason=already_present|foreign_manifest` — promoted to `info` so the baked steady-state is visible each boot.

## Effect

- **Fresh base-image boots:** the global seed is a no-op (`global_deps_skip reason=already_present`) → that ~9s+ copy is gone from boot.
- **Repo-images / snapshots:** pick up the baked dir as they rebuild/refresh; until then the runtime fallback keeps them correct.
- No runtime `CACHE_BUSTER` dependency — the bake is build-time content; nothing per-session changes.

## Testing

- `ruff check` / `ruff format --check` — clean (sandbox-runtime + `base.py`).
- `pytest tests/` — 360 passed.
- `mypy src/` — no new errors (mypy-neutral vs `main`: 12 ↔ 12).
- `python -m py_compile base.py` — valid.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced logging and performance metrics for dependency operations with duration tracking
  * Improved observability of dependency staging and global configuration seeding processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->