### PR TITLE
feat(slack): keyword-based repository routing rules

### DIFF
--- a/docs/integrations/SLACK.md
+++ b/docs/integrations/SLACK.md
@@ -54,11 +54,13 @@ repository name when the request could apply to more than one repo:
 @Open-Inspect update the billing docs in acme/api
 ```
 
-Open-Inspect chooses from repositories available to this Open-Inspect deployment. It uses the
-message, Slack channel context, and recent thread context to pick a repository. If only one
-repository is available, it uses that repository automatically. If an administrator has associated
-the Slack channel with exactly one repository, that repository is used. When the match is unclear,
-Open-Inspect asks you to choose from candidate repositories in the Slack thread.
+Open-Inspect chooses from repositories available to this Open-Inspect deployment, using the message,
+Slack channel context, and recent thread context. It picks a repository in this order: if only one
+repository is available, it uses that one; if your message contains a configured
+[routing-rule keyword](#routing-rules), it routes to that keyword's repository; if an administrator
+has associated the Slack channel with exactly one repository, that repository is used; otherwise it
+infers the repository from your message. When the match is unclear, Open-Inspect asks you to choose
+from candidate repositories in the Slack thread.
 
 ### From a DM
 
@@ -83,6 +85,32 @@ request and thread context.
 
 In shared channels, the original requester should choose the repository. If the dropdown has
 expired, send the request again and include the repository name, such as `owner/repo`.
+
+### Routing rules
+
+Administrators can map keywords to repositories so common requests route instantly, without
+Open-Inspect having to guess. Configure them in the web app under **Settings → Integrations → Slack
+→ Routing rules**: each rule pairs a keyword with a target repository.
+
+For example, with `frontend → acme/web-app` and `api → acme/backend`:
+
+- `@Open-Inspect fix the frontend nav bug` → routes to `acme/web-app`
+- `@Open-Inspect add the new api endpoint` → routes to `acme/backend`
+
+How matching works:
+
+- **Whole words, case-insensitive.** `api` matches "the api is down" but not "rapidly".
+- **Channels and DMs.** Rules apply everywhere, which makes them especially useful in DMs where
+  there is no channel association.
+- **Rules beat channel association.** An explicit keyword always wins over the channel's default
+  repository.
+- **Ambiguity asks, never guesses.** If one message matches keywords for two different repositories,
+  Open-Inspect shows the repository picker seeded with those candidates.
+- **Stale targets are ignored.** A rule whose repository is later removed from the deployment
+  becomes inert until access is restored, rather than routing somewhere unexpected.
+
+Routing rules do not override an active thread: a keyword in a thread reply does not move that
+conversation to a different repository.
 
 ---
 

--- a/packages/control-plane/src/db/integration-settings.test.ts
+++ b/packages/control-plane/src/db/integration-settings.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { MAX_SLACK_ROUTING_KEYWORD_LENGTH, MAX_SLACK_ROUTING_RULES } from "@open-inspect/shared";
 import {
   IntegrationSettingsStore,
   IntegrationSettingsValidationError,
@@ -993,6 +994,77 @@ describe("IntegrationSettingsStore", () => {
       const config = await store.getResolvedConfig("slack", "acme/widgets");
       expect(config.settings.agentNotificationsEnabled).toBe(true);
       expect(config.settings.mentionsPolicy).toBe("allow");
+    });
+
+    it("round-trips and normalizes routingRules at global level", async () => {
+      await store.setGlobal("slack", {
+        defaults: {
+          routingRules: [
+            { keyword: "  FrontEnd ", target: "Acme/Web-App" },
+            { keyword: "api", target: "acme/api" },
+          ],
+        },
+      });
+
+      const result = await store.getGlobal("slack");
+      expect(result?.defaults?.routingRules).toEqual([
+        { keyword: "frontend", target: "acme/web-app" },
+        { keyword: "api", target: "acme/api" },
+      ]);
+    });
+
+    it("rejects routingRules at per-repo level (global-only field)", async () => {
+      await expect(
+        store.setRepoSettings("slack", "acme/widgets", {
+          routingRules: [{ keyword: "frontend", target: "acme/web" }],
+        } as unknown as { agentNotificationsEnabled?: boolean })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
+
+    it("rejects non-array routingRules", async () => {
+      await expect(
+        store.setGlobal("slack", {
+          defaults: { routingRules: "frontend" as unknown as [] },
+        })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
+
+    it("rejects a routing rule with an empty keyword", async () => {
+      await expect(
+        store.setGlobal("slack", {
+          defaults: { routingRules: [{ keyword: "   ", target: "acme/web" }] },
+        })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
+
+    it("rejects a routing rule whose target is not in owner/name form", async () => {
+      await expect(
+        store.setGlobal("slack", {
+          defaults: { routingRules: [{ keyword: "frontend", target: "not-a-repo" }] },
+        })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
+
+    it("rejects a routing rule keyword longer than the maximum", async () => {
+      await expect(
+        store.setGlobal("slack", {
+          defaults: {
+            routingRules: [
+              { keyword: "x".repeat(MAX_SLACK_ROUTING_KEYWORD_LENGTH + 1), target: "acme/web" },
+            ],
+          },
+        })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
+
+    it("rejects more than the maximum number of routing rules", async () => {
+      const tooMany = Array.from({ length: MAX_SLACK_ROUTING_RULES + 1 }, (_, i) => ({
+        keyword: `kw${i}`,
+        target: `acme/repo${i}`,
+      }));
+      await expect(
+        store.setGlobal("slack", { defaults: { routingRules: tooMany } })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
     });
   });
 

--- a/packages/control-plane/src/db/integration-settings.ts
+++ b/packages/control-plane/src/db/integration-settings.ts
@@ -3,6 +3,9 @@ import {
   isValidReasoningEffort,
   INTEGRATION_DEFINITIONS,
   DEFAULT_MENTIONS_POLICY,
+  MAX_SLACK_ROUTING_RULES,
+  MAX_SLACK_ROUTING_KEYWORD_LENGTH,
+  normalizeRoutingRules,
   type IntegrationId,
   type IntegrationSettingsMap,
   type GitHubBotSettings,
@@ -10,6 +13,7 @@ import {
   type CodeServerSettings,
   type SlackGlobalSettings,
   type SlackMentionsPolicy,
+  type SlackRoutingRule,
 } from "@open-inspect/shared";
 import { normalizeSandboxSettings } from "../sandbox/settings";
 
@@ -347,7 +351,7 @@ export class IntegrationSettingsStore {
   ): SlackGlobalSettings {
     const allowedKeys =
       level === "global"
-        ? new Set(["agentNotificationsEnabled", "mentionsPolicy"])
+        ? new Set(["agentNotificationsEnabled", "mentionsPolicy", "routingRules"])
         : new Set(["agentNotificationsEnabled"]);
 
     for (const key of Object.keys(settings)) {
@@ -372,7 +376,48 @@ export class IntegrationSettingsStore {
       );
     }
 
+    // Routing rules are workspace-wide (the allowedKeys gate above already
+    // rejects them at the per-repo level). Validate structure here; normalize
+    // for storage. Target existence is not checked (the repo list isn't
+    // available at this layer) — the bot skips stale targets at match time.
+    if (settings.routingRules !== undefined) {
+      return { ...settings, routingRules: this.validateRoutingRules(settings.routingRules) };
+    }
+
     return settings;
+  }
+
+  private validateRoutingRules(rules: unknown): SlackRoutingRule[] {
+    if (!Array.isArray(rules)) {
+      throw new IntegrationSettingsValidationError("routingRules must be an array");
+    }
+    if (rules.length > MAX_SLACK_ROUTING_RULES) {
+      throw new IntegrationSettingsValidationError(
+        `routingRules cannot exceed ${MAX_SLACK_ROUTING_RULES} entries`
+      );
+    }
+    for (const rule of rules) {
+      if (typeof rule !== "object" || rule === null) {
+        throw new IntegrationSettingsValidationError("each routing rule must be an object");
+      }
+      const { keyword, target } = rule as { keyword?: unknown; target?: unknown };
+      if (typeof keyword !== "string" || keyword.trim() === "") {
+        throw new IntegrationSettingsValidationError(
+          "routing rule keyword must be a non-empty string"
+        );
+      }
+      if (keyword.trim().length > MAX_SLACK_ROUTING_KEYWORD_LENGTH) {
+        throw new IntegrationSettingsValidationError(
+          `routing rule keyword must be ${MAX_SLACK_ROUTING_KEYWORD_LENGTH} characters or fewer`
+        );
+      }
+      if (typeof target !== "string" || !/^[^/\s]+\/[^/\s]+$/.test(target.trim())) {
+        throw new IntegrationSettingsValidationError(
+          "routing rule target must be a repository in owner/name form"
+        );
+      }
+    }
+    return normalizeRoutingRules(rules as SlackRoutingRule[]);
   }
 }
 

--- a/packages/github-bot/src/handlers.ts
+++ b/packages/github-bot/src/handlers.ts
@@ -1,4 +1,4 @@
-import { buildInternalAuthHeaders, resolveAppName } from "@open-inspect/shared";
+import { buildInternalAuthHeaders, escapeRegExp, resolveAppName } from "@open-inspect/shared";
 import type {
   Env,
   PullRequestOpenedPayload,
@@ -82,8 +82,7 @@ async function sendPrompt(
 }
 
 function stripMention(body: string, botUsername: string): string {
-  const escaped = botUsername.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return body.replace(new RegExp(`@${escaped}`, "gi"), "").trim();
+  return body.replace(new RegExp(`@${escapeRegExp(botUsername)}`, "gi"), "").trim();
 }
 
 function fireAndForgetReaction(

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,6 +4,7 @@
 
 export * from "./types";
 export * from "./git";
+export * from "./regex";
 export * from "./auth";
 export * from "./models";
 export * from "./cron";

--- a/packages/shared/src/regex.ts
+++ b/packages/shared/src/regex.ts
@@ -1,0 +1,7 @@
+/**
+ * Escape a string so it can be embedded literally inside a `RegExp`. Every
+ * regex-special character is backslash-escaped so the value matches itself.
+ */
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/shared/src/triggers/glob.ts
+++ b/packages/shared/src/triggers/glob.ts
@@ -7,6 +7,8 @@
  * - Literal characters match exactly (case-sensitive)
  */
 
+import { escapeRegExp } from "../regex";
+
 export function matchGlob(pattern: string, input: string): boolean {
   return globToRegex(pattern).test(input);
 }
@@ -23,14 +25,10 @@ function globToRegex(pattern: string): RegExp {
       regex += "[^/]*";
       i++;
     } else {
-      regex += escapeRegex(pattern[i]);
+      regex += escapeRegExp(pattern[i]);
       i++;
     }
   }
   regex += "$";
   return new RegExp(regex);
-}
-
-function escapeRegex(char: string): string {
-  return char.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/packages/shared/src/types/integrations.test.ts
+++ b/packages/shared/src/types/integrations.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_BUILD_TIMEOUT_SECONDS,
   MAX_BUILD_TIMEOUT_SECONDS,
+  MAX_SLACK_ROUTING_RULES,
+  matchRoutingRules,
+  normalizeRoutingRules,
   resolveBuildTimeoutSeconds,
+  type SlackRoutingRule,
 } from "./integrations";
 
 describe("resolveBuildTimeoutSeconds", () => {
@@ -37,5 +41,118 @@ describe("resolveBuildTimeoutSeconds", () => {
 
   it("keeps the default below the maximum", () => {
     expect(DEFAULT_BUILD_TIMEOUT_SECONDS).toBeLessThan(MAX_BUILD_TIMEOUT_SECONDS);
+  });
+});
+
+describe("normalizeRoutingRules", () => {
+  it("returns an empty array for undefined or empty input", () => {
+    expect(normalizeRoutingRules(undefined)).toEqual([]);
+    expect(normalizeRoutingRules([])).toEqual([]);
+  });
+
+  it("trims and lowercases keyword and target", () => {
+    expect(normalizeRoutingRules([{ keyword: "  FrontEnd ", target: "Acme/Web-App " }])).toEqual([
+      { keyword: "frontend", target: "acme/web-app" },
+    ]);
+  });
+
+  it("drops rules whose keyword or target is empty after trimming", () => {
+    expect(
+      normalizeRoutingRules([
+        { keyword: "   ", target: "acme/web" },
+        { keyword: "frontend", target: "  " },
+        { keyword: "api", target: "acme/api" },
+      ])
+    ).toEqual([{ keyword: "api", target: "acme/api" }]);
+  });
+
+  it("de-dupes identical (keyword, target) pairs case-insensitively", () => {
+    expect(
+      normalizeRoutingRules([
+        { keyword: "frontend", target: "acme/web" },
+        { keyword: "Frontend", target: "Acme/Web" },
+      ])
+    ).toEqual([{ keyword: "frontend", target: "acme/web" }]);
+  });
+
+  it("keeps the same keyword pointing at different targets (a conflict, surfaced later)", () => {
+    expect(
+      normalizeRoutingRules([
+        { keyword: "frontend", target: "acme/web" },
+        { keyword: "frontend", target: "acme/admin" },
+      ])
+    ).toEqual([
+      { keyword: "frontend", target: "acme/web" },
+      { keyword: "frontend", target: "acme/admin" },
+    ]);
+  });
+
+  it("caps the number of rules at MAX_SLACK_ROUTING_RULES", () => {
+    const many: SlackRoutingRule[] = Array.from(
+      { length: MAX_SLACK_ROUTING_RULES + 25 },
+      (_, i) => ({
+        keyword: `kw${i}`,
+        target: `acme/repo${i}`,
+      })
+    );
+    expect(normalizeRoutingRules(many)).toHaveLength(MAX_SLACK_ROUTING_RULES);
+  });
+});
+
+describe("matchRoutingRules", () => {
+  const rules: SlackRoutingRule[] = [
+    { keyword: "frontend", target: "acme/web" },
+    { keyword: "api", target: "acme/api" },
+    { keyword: "user service", target: "acme/users" },
+    { keyword: "node.js", target: "acme/runtime" },
+  ];
+
+  it("returns an empty array when there are no rules", () => {
+    expect(matchRoutingRules("fix the frontend", [])).toEqual([]);
+  });
+
+  it("matches a whole-word keyword present in the message, case-insensitively", () => {
+    expect(matchRoutingRules("Fix the FRONTEND nav bug", rules)).toEqual([
+      { keyword: "frontend", target: "acme/web" },
+    ]);
+  });
+
+  it("does not match a keyword that only appears as a substring of another word", () => {
+    // "api" must not match inside "rapidly"
+    expect(matchRoutingRules("ship this rapidly please", rules)).toEqual([]);
+  });
+
+  it("matches a keyword at the very start and very end of the message", () => {
+    expect(matchRoutingRules("frontend", rules)).toEqual([
+      { keyword: "frontend", target: "acme/web" },
+    ]);
+    expect(matchRoutingRules("please fix the api", rules)).toEqual([
+      { keyword: "api", target: "acme/api" },
+    ]);
+  });
+
+  it("matches a multi-word phrase keyword", () => {
+    expect(matchRoutingRules("the user service is down", rules)).toEqual([
+      { keyword: "user service", target: "acme/users" },
+    ]);
+  });
+
+  it("treats regex-special characters in the keyword literally", () => {
+    expect(matchRoutingRules("upgrade node.js today", rules)).toEqual([
+      { keyword: "node.js", target: "acme/runtime" },
+    ]);
+    // The "." must be literal, so it should not match an arbitrary character.
+    expect(matchRoutingRules("upgrade nodexjs today", rules)).toEqual([]);
+  });
+
+  it("returns every matching rule, preserving rule order", () => {
+    expect(matchRoutingRules("the api and the frontend both broke", rules)).toEqual([
+      { keyword: "frontend", target: "acme/web" },
+      { keyword: "api", target: "acme/api" },
+    ]);
+  });
+
+  it("returns an empty array when no keyword is present", () => {
+    expect(matchRoutingRules("just a normal message", rules)).toEqual([]);
   });
 });

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -1,5 +1,7 @@
 // Integration settings types
 
+import { escapeRegExp } from "../regex";
+
 export type IntegrationId = "github" | "linear" | "code-server" | "sandbox" | "slack";
 
 /** Enforces the common shape for all integration configurations. */
@@ -183,6 +185,25 @@ export function resolveBuildTimeoutSeconds(settings: SandboxSettings | undefined
 
 export type SlackMentionsPolicy = "allow" | "escape" | "strip";
 
+/**
+ * A workspace-wide keyword→repository routing rule for Slack. When a Slack
+ * message contains the keyword, the bot routes the agent to the target
+ * repository deterministically, before falling back to LLM classification.
+ */
+export interface SlackRoutingRule {
+  /** Case-insensitive keyword or phrase. Matched as a whole token in the message. */
+  keyword: string;
+  /** Canonical "owner/name" (lowercase) of the target repository. */
+  target: string;
+  // Future (deferred): targetType?: "repository" | "environment" — defaults to "repository".
+}
+
+/** Maximum number of routing rules a workspace can configure (bounds the settings blob). */
+export const MAX_SLACK_ROUTING_RULES = 100;
+
+/** Maximum length of a single routing-rule keyword. */
+export const MAX_SLACK_ROUTING_KEYWORD_LENGTH = 100;
+
 /** Per-repo Slack overrides. Mentions policy is workspace-wide and cannot be overridden per repo. */
 export interface SlackRepoSettings {
   agentNotificationsEnabled?: boolean;
@@ -191,6 +212,55 @@ export interface SlackRepoSettings {
 /** Global Slack defaults: per-repo fields plus workspace-wide policy controls. */
 export interface SlackGlobalSettings extends SlackRepoSettings {
   mentionsPolicy?: SlackMentionsPolicy;
+  /** Workspace-wide keyword→repository routing rules (global-only, like mentionsPolicy). */
+  routingRules?: SlackRoutingRule[];
+}
+
+/**
+ * Clean up raw routing rules for storage or use: trim and lowercase keyword and
+ * target, drop entries that are empty after trimming, de-dupe identical
+ * (keyword, target) pairs, and cap the count at {@link MAX_SLACK_ROUTING_RULES}.
+ *
+ * Lenient by design — it never throws — so it is safe on the bot's read path as
+ * well as the control plane's write path. Shape/length enforcement (with errors)
+ * lives in the control plane validator. A keyword pointing at two different
+ * targets is intentionally preserved; that conflict surfaces at match time.
+ */
+export function normalizeRoutingRules(rules: SlackRoutingRule[] | undefined): SlackRoutingRule[] {
+  if (!rules || rules.length === 0) return [];
+  const seen = new Set<string>();
+  const normalized: SlackRoutingRule[] = [];
+  for (const rule of rules) {
+    const keyword = typeof rule?.keyword === "string" ? rule.keyword.trim().toLowerCase() : "";
+    const target = typeof rule?.target === "string" ? rule.target.trim().toLowerCase() : "";
+    if (!keyword || !target) continue;
+    const dedupeKey = `${keyword} ${target}`;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    normalized.push({ keyword, target });
+    if (normalized.length >= MAX_SLACK_ROUTING_RULES) break;
+  }
+  return normalized;
+}
+
+/**
+ * Return the rules whose keyword appears in `message` as a whole token
+ * (case-insensitive, word-boundary match so "api" does not match "rapidly";
+ * multi-word keywords match as a phrase). Rule order is preserved. Keywords are
+ * matched literally, so regex-special characters carry no special meaning.
+ *
+ * Boundaries use `\W` (ASCII word characters), which is the right granularity
+ * for the alphanumeric technical keywords this is designed for; matching against
+ * non-ASCII keywords is intentionally looser.
+ */
+export function matchRoutingRules(message: string, rules: SlackRoutingRule[]): SlackRoutingRule[] {
+  if (!message || rules.length === 0) return [];
+  const haystack = message.toLowerCase();
+  return rules.filter((rule) => {
+    const keyword = typeof rule?.keyword === "string" ? rule.keyword.trim().toLowerCase() : "";
+    if (!keyword) return false;
+    return new RegExp(`(?:^|\\W)${escapeRegExp(keyword)}(?:\\W|$)`).test(haystack);
+  });
 }
 
 /** Maps each integration ID to its global and per-repo settings types. */

--- a/packages/slack-bot/src/classifier/index.test.ts
+++ b/packages/slack-bot/src/classifier/index.test.ts
@@ -6,11 +6,13 @@ const {
   mockGetAvailableRepos,
   mockBuildRepoDescriptions,
   mockGetReposByChannel,
+  mockGetRoutingRules,
 } = vi.hoisted(() => ({
   mockMessagesCreate: vi.fn(),
   mockGetAvailableRepos: vi.fn(),
   mockBuildRepoDescriptions: vi.fn(),
   mockGetReposByChannel: vi.fn(),
+  mockGetRoutingRules: vi.fn(),
 }));
 
 vi.mock("@anthropic-ai/sdk", () => ({
@@ -29,6 +31,7 @@ vi.mock("./repos", () => ({
   getAvailableRepos: mockGetAvailableRepos,
   buildRepoDescriptions: mockBuildRepoDescriptions,
   getReposByChannel: mockGetReposByChannel,
+  getRoutingRules: mockGetRoutingRules,
 }));
 
 import { RepoClassifier } from "./index";
@@ -70,6 +73,7 @@ describe("RepoClassifier", () => {
     vi.clearAllMocks();
     mockGetAvailableRepos.mockResolvedValue(TEST_REPOS);
     mockGetReposByChannel.mockResolvedValue([]);
+    mockGetRoutingRules.mockResolvedValue([]);
     mockBuildRepoDescriptions.mockResolvedValue("- acme/prod\n- acme/web");
   });
 
@@ -153,5 +157,111 @@ describe("RepoClassifier", () => {
     expect(result.needsClarification).toBe(true);
     expect(result.reasoning).toContain("structured model output");
     expect(result.alternatives).toBeUndefined();
+  });
+
+  describe("routing rules", () => {
+    it("routes deterministically when a keyword matches, without calling the LLM", async () => {
+      mockGetRoutingRules.mockResolvedValue([{ keyword: "frontend", target: "acme/web" }]);
+
+      const classifier = new RepoClassifier(TEST_ENV);
+      const result = await classifier.classify("please fix the frontend nav bug", undefined, "t");
+
+      expect(result.repo?.fullName).toBe("acme/web");
+      expect(result.confidence).toBe("high");
+      expect(result.needsClarification).toBe(false);
+      expect(result.reasoning).toContain("routing rule");
+      expect(mockMessagesCreate).not.toHaveBeenCalled();
+    });
+
+    it("asks for clarification when rules point at multiple distinct repos", async () => {
+      mockGetRoutingRules.mockResolvedValue([
+        { keyword: "frontend", target: "acme/web" },
+        { keyword: "prod", target: "acme/prod" },
+      ]);
+
+      const classifier = new RepoClassifier(TEST_ENV);
+      const result = await classifier.classify("fix the frontend on prod");
+
+      expect(result.repo).toBeNull();
+      expect(result.needsClarification).toBe(true);
+      expect(result.alternatives?.map((r) => r.fullName).sort()).toEqual(["acme/prod", "acme/web"]);
+      expect(mockMessagesCreate).not.toHaveBeenCalled();
+    });
+
+    it("routes once when multiple keywords map to the same repo", async () => {
+      mockGetRoutingRules.mockResolvedValue([
+        { keyword: "frontend", target: "acme/web" },
+        { keyword: "ui", target: "acme/web" },
+      ]);
+
+      const classifier = new RepoClassifier(TEST_ENV);
+      const result = await classifier.classify("frontend ui cleanup");
+
+      expect(result.repo?.fullName).toBe("acme/web");
+      expect(result.needsClarification).toBe(false);
+      expect(mockMessagesCreate).not.toHaveBeenCalled();
+    });
+
+    it("skips a rule whose target is not accessible and falls through to the LLM", async () => {
+      mockGetRoutingRules.mockResolvedValue([{ keyword: "frontend", target: "acme/ghost" }]);
+      mockMessagesCreate.mockResolvedValue({
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_x",
+            name: "classify_repository",
+            input: {
+              repoId: "acme/web",
+              confidence: "high",
+              reasoning: "Mentions frontend.",
+              alternatives: [],
+            },
+          },
+        ],
+      });
+
+      const classifier = new RepoClassifier(TEST_ENV);
+      const result = await classifier.classify("frontend issue");
+
+      expect(result.repo?.fullName).toBe("acme/web");
+      expect(mockMessagesCreate).toHaveBeenCalledOnce();
+    });
+
+    it("falls through to the LLM when no rule keyword is present", async () => {
+      mockGetRoutingRules.mockResolvedValue([{ keyword: "frontend", target: "acme/web" }]);
+      mockMessagesCreate.mockResolvedValue({
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_y",
+            name: "classify_repository",
+            input: {
+              repoId: "acme/prod",
+              confidence: "high",
+              reasoning: "Mentions prod.",
+              alternatives: [],
+            },
+          },
+        ],
+      });
+
+      const classifier = new RepoClassifier(TEST_ENV);
+      const result = await classifier.classify("update the deployment config");
+
+      expect(result.repo?.fullName).toBe("acme/prod");
+      expect(mockMessagesCreate).toHaveBeenCalledOnce();
+    });
+
+    it("takes precedence over a channel association", async () => {
+      // Channel maps to acme/prod, but an explicit keyword maps to acme/web.
+      mockGetReposByChannel.mockResolvedValue([TEST_REPOS[0]]); // acme/prod
+      mockGetRoutingRules.mockResolvedValue([{ keyword: "frontend", target: "acme/web" }]);
+
+      const classifier = new RepoClassifier(TEST_ENV);
+      const result = await classifier.classify("frontend tweak", { channelId: "C123" });
+
+      expect(result.repo?.fullName).toBe("acme/web");
+      expect(mockMessagesCreate).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/slack-bot/src/classifier/index.ts
+++ b/packages/slack-bot/src/classifier/index.ts
@@ -7,8 +7,13 @@
 
 import Anthropic from "@anthropic-ai/sdk";
 import type { Env, RepoConfig, ThreadContext, ClassificationResult } from "../types";
-import type { ConfidenceLevel } from "@open-inspect/shared";
-import { getAvailableRepos, buildRepoDescriptions, getReposByChannel } from "./repos";
+import {
+  getAvailableRepos,
+  buildRepoDescriptions,
+  getReposByChannel,
+  getRoutingRules,
+} from "./repos";
+import { matchRoutingRules, type ConfidenceLevel } from "@open-inspect/shared";
 import { createLogger } from "../logger";
 
 const log = createLogger("classifier");
@@ -186,6 +191,58 @@ export class RepoClassifier {
   }
 
   /**
+   * Match the message against the workspace's Slack routing rules.
+   *
+   * Returns a high-confidence result when exactly one accessible target matches,
+   * a clarification result when several distinct targets match (so the user
+   * picks rather than the bot guessing), or `null` when no rule applies — in
+   * which case the caller falls through to channel association and the LLM.
+   *
+   * Rules whose target is not in the accessible repo list are skipped, so a
+   * stale rule never routes to an inaccessible repository.
+   */
+  private async classifyByRoutingRules(
+    message: string,
+    repos: RepoConfig[],
+    traceId?: string
+  ): Promise<ClassificationResult | null> {
+    const matched = matchRoutingRules(message, await getRoutingRules(this.env, traceId));
+    if (matched.length === 0) return null;
+
+    const targets = new Map<string, { repo: RepoConfig; keyword: string }>();
+    for (const rule of matched) {
+      const repo = repos.find(
+        (r) => r.fullName.toLowerCase() === rule.target || r.id.toLowerCase() === rule.target
+      );
+      if (repo && !targets.has(repo.id)) {
+        targets.set(repo.id, { repo, keyword: rule.keyword });
+      }
+    }
+
+    const resolved = [...targets.values()];
+    if (resolved.length === 0) return null;
+
+    if (resolved.length === 1) {
+      const { repo, keyword } = resolved[0];
+      log.info("classifier.routing_rule_match", { trace_id: traceId, repo_id: repo.id, keyword });
+      return {
+        repo,
+        confidence: "high",
+        reasoning: `Matched routing rule "${keyword}" → ${repo.fullName}`,
+        needsClarification: false,
+      };
+    }
+
+    return {
+      repo: null,
+      confidence: "medium",
+      reasoning: "Multiple routing rules matched; asking which repository to use.",
+      alternatives: resolved.map((t) => t.repo),
+      needsClarification: true,
+    };
+  }
+
+  /**
    * Classify which repository a message refers to.
    */
   async classify(
@@ -214,6 +271,14 @@ export class RepoClassifier {
         reasoning: "Only one repository is available.",
         needsClarification: false,
       };
+    }
+
+    // Deterministic routing rules (explicit keyword → repo) take precedence over
+    // channel association and LLM inference, but never override an active thread
+    // (handled before classify is called).
+    const routed = await this.classifyByRoutingRules(message, repos, traceId);
+    if (routed) {
+      return routed;
     }
 
     // Check for channel-specific repos first

--- a/packages/slack-bot/src/classifier/repos.test.ts
+++ b/packages/slack-bot/src/classifier/repos.test.ts
@@ -74,4 +74,20 @@ describe("getRoutingRules", () => {
     const env = makeEnv(new Error("control plane unreachable"));
     expect(await getRoutingRules(env)).toEqual([]);
   });
+
+  it("normalizes rules read from the KV cache on the fail-open path", async () => {
+    const env = {
+      SLACK_KV: {
+        get: vi.fn().mockResolvedValue([{ keyword: " FrontEnd ", target: "Acme/Web" }]),
+        put: vi.fn().mockResolvedValue(undefined),
+      },
+      CONTROL_PLANE: {
+        fetch: vi.fn().mockResolvedValue(new Response("error", { status: 500 })),
+      },
+    } as unknown as Env;
+
+    expect(await getRoutingRules(env, "trace")).toEqual([
+      { keyword: "frontend", target: "acme/web" },
+    ]);
+  });
 });

--- a/packages/slack-bot/src/classifier/repos.test.ts
+++ b/packages/slack-bot/src/classifier/repos.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "../types";
+import { clearLocalCache, getRoutingRules } from "./repos";
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** Minimal Env whose control plane returns `response` and whose KV is empty. */
+function makeEnv(fetchResult: Response | Error): Env {
+  const fetch =
+    fetchResult instanceof Error
+      ? vi.fn().mockRejectedValue(fetchResult)
+      : vi.fn().mockResolvedValue(fetchResult);
+  return {
+    SLACK_KV: {
+      get: vi.fn().mockResolvedValue(null),
+      put: vi.fn().mockResolvedValue(undefined),
+    },
+    CONTROL_PLANE: { fetch },
+  } as unknown as Env;
+}
+
+describe("getRoutingRules", () => {
+  beforeEach(() => {
+    clearLocalCache();
+    vi.clearAllMocks();
+  });
+
+  it("parses routing rules from the control-plane settings response", async () => {
+    const env = makeEnv(
+      jsonResponse({
+        integrationId: "slack",
+        settings: { defaults: { routingRules: [{ keyword: "frontend", target: "acme/web" }] } },
+      })
+    );
+
+    expect(await getRoutingRules(env, "trace")).toEqual([
+      { keyword: "frontend", target: "acme/web" },
+    ]);
+  });
+
+  it("returns an empty list when slack settings are unset", async () => {
+    const env = makeEnv(jsonResponse({ integrationId: "slack", settings: null }));
+    expect(await getRoutingRules(env)).toEqual([]);
+  });
+
+  it("normalizes rules on read (trim, lowercase, de-dupe)", async () => {
+    const env = makeEnv(
+      jsonResponse({
+        settings: {
+          defaults: {
+            routingRules: [
+              { keyword: " FrontEnd ", target: "Acme/Web" },
+              { keyword: "frontend", target: "acme/web" },
+            ],
+          },
+        },
+      })
+    );
+
+    expect(await getRoutingRules(env)).toEqual([{ keyword: "frontend", target: "acme/web" }]);
+  });
+
+  it("fails open to an empty list on a non-OK response", async () => {
+    const env = makeEnv(new Response("error", { status: 500 }));
+    expect(await getRoutingRules(env)).toEqual([]);
+  });
+
+  it("fails open to an empty list when the fetch throws", async () => {
+    const env = makeEnv(new Error("control plane unreachable"));
+    expect(await getRoutingRules(env)).toEqual([]);
+  });
+});

--- a/packages/slack-bot/src/classifier/repos.ts
+++ b/packages/slack-bot/src/classifier/repos.ts
@@ -8,7 +8,13 @@
 
 import type { Env, RepoConfig, ControlPlaneRepo, ControlPlaneReposResponse } from "../types";
 import { normalizeRepoId } from "../utils/repo";
-import { buildInternalAuthHeaders, createKvCacheStore } from "@open-inspect/shared";
+import {
+  buildInternalAuthHeaders,
+  createKvCacheStore,
+  normalizeRoutingRules,
+  type SlackGlobalConfig,
+  type SlackRoutingRule,
+} from "@open-inspect/shared";
 import { createLogger } from "../logger";
 
 const log = createLogger("repos");
@@ -35,6 +41,17 @@ let localCache: {
 } | null = null;
 
 /**
+ * Local in-memory cache for Slack routing rules. Same TTL as the repos cache;
+ * the bot tolerates rules being up to a few minutes stale.
+ */
+let routingRulesLocalCache: {
+  rules: SlackRoutingRule[];
+  timestamp: number;
+} | null = null;
+
+const ROUTING_RULES_CACHE_KEY = "slack:routing-rules";
+
+/**
  * Convert a control plane repo to a RepoConfig.
  * Normalizes identifiers to lowercase for consistent comparison.
  */
@@ -58,6 +75,23 @@ function toRepoConfig(repo: ControlPlaneRepo): RepoConfig {
 }
 
 /**
+ * Issue an authenticated GET to the control plane, preferring the service
+ * binding and falling back to URL-based fetch. Centralizes the internal-auth
+ * headers and binding-vs-URL switch shared by every control-plane read.
+ */
+async function controlPlaneFetch(env: Env, path: string, traceId?: string): Promise<Response> {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    ...(await buildInternalAuthHeaders(env.INTERNAL_CALLBACK_SECRET, traceId)),
+  };
+  return env.CONTROL_PLANE
+    ? env.CONTROL_PLANE.fetch(`https://internal${path}`, { headers })
+    : fetch(`${env.CONTROL_PLANE_URL}${path}`, {
+        headers: { ...headers, "User-Agent": "open-inspect-slack-bot" },
+      });
+}
+
+/**
  * Fetch available repositories from the control plane.
  *
  * This function:
@@ -76,28 +110,7 @@ export async function getAvailableRepos(env: Env, traceId?: string): Promise<Rep
 
   const startTime = Date.now();
   try {
-    // Use service binding if available, otherwise fall back to HTTP fetch
-    let response: Response;
-
-    // Build headers with auth token if secret is configured
-    const headers: Record<string, string> = {
-      Accept: "application/json",
-      ...(await buildInternalAuthHeaders(env.INTERNAL_CALLBACK_SECRET, traceId)),
-    };
-
-    if (env.CONTROL_PLANE) {
-      response = await env.CONTROL_PLANE.fetch("https://internal/repos", {
-        headers,
-      });
-    } else {
-      const url = `${env.CONTROL_PLANE_URL}/repos`;
-      response = await fetch(url, {
-        headers: {
-          ...headers,
-          "User-Agent": "open-inspect-slack-bot",
-        },
-      });
-    }
+    const response = await controlPlaneFetch(env, "/repos", traceId);
 
     if (!response.ok) {
       log.error("control_plane.fetch_repos", {
@@ -179,6 +192,84 @@ async function getFromCacheOrFallback(env: Env): Promise<RepoConfig[]> {
 }
 
 /**
+ * Fetch workspace-wide Slack routing rules (keyword → repository) from the
+ * control plane's GET /integration-settings/slack endpoint.
+ *
+ * Mirrors {@link getAvailableRepos}: in-memory cache → control plane → KV cache,
+ * and **fails open to an empty list** so a settings-fetch problem never blocks
+ * classification — the bot simply behaves as if no rules were configured.
+ */
+export async function getRoutingRules(env: Env, traceId?: string): Promise<SlackRoutingRule[]> {
+  if (
+    routingRulesLocalCache &&
+    Date.now() - routingRulesLocalCache.timestamp < LOCAL_CACHE_TTL_MS
+  ) {
+    return routingRulesLocalCache.rules;
+  }
+
+  const startTime = Date.now();
+  try {
+    const response = await controlPlaneFetch(env, "/integration-settings/slack", traceId);
+
+    if (!response.ok) {
+      log.warn("control_plane.fetch_routing_rules", {
+        trace_id: traceId,
+        outcome: "error",
+        http_status: response.status,
+        duration_ms: Date.now() - startTime,
+      });
+      return getRoutingRulesFromCache(env);
+    }
+
+    const data = (await response.json()) as { settings?: SlackGlobalConfig | null };
+    const rules = normalizeRoutingRules(data.settings?.defaults?.routingRules);
+
+    routingRulesLocalCache = { rules, timestamp: Date.now() };
+
+    try {
+      await createKvCacheStore(env.SLACK_KV).put(ROUTING_RULES_CACHE_KEY, JSON.stringify(rules), {
+        expirationTtl: 300, // 5 minutes
+      });
+    } catch (e) {
+      log.warn("kv.put", {
+        trace_id: traceId,
+        key_prefix: "routing_rules_cache",
+        error: e instanceof Error ? e : new Error(String(e)),
+      });
+    }
+
+    return rules;
+  } catch (e) {
+    log.warn("control_plane.fetch_routing_rules", {
+      trace_id: traceId,
+      outcome: "error",
+      error: e instanceof Error ? e : new Error(String(e)),
+      duration_ms: Date.now() - startTime,
+    });
+    return getRoutingRulesFromCache(env);
+  }
+}
+
+/**
+ * Read routing rules from the KV cache, returning an empty list on miss/error.
+ * Fail open: no rules means no deterministic routing, the safe default.
+ */
+async function getRoutingRulesFromCache(env: Env): Promise<SlackRoutingRule[]> {
+  try {
+    const cached = await createKvCacheStore(env.SLACK_KV).get(ROUTING_RULES_CACHE_KEY, "json");
+    if (cached && Array.isArray(cached)) {
+      return cached as SlackRoutingRule[];
+    }
+  } catch (e) {
+    log.warn("kv.get", {
+      key_prefix: "routing_rules_cache",
+      error: e instanceof Error ? e : new Error(String(e)),
+    });
+  }
+  return [];
+}
+
+/**
  * Filter repos by a free-text query against their full name (case-insensitive).
  * Returns all repos when the query is empty — the canonical filter shared by the
  * clarification picker and the App Home branch picker.
@@ -252,8 +343,9 @@ export async function buildRepoDescriptions(env: Env, traceId?: string): Promise
 }
 
 /**
- * Clear local cache (for testing or forced refresh).
+ * Clear local caches (for testing or forced refresh).
  */
 export function clearLocalCache(): void {
   localCache = null;
+  routingRulesLocalCache = null;
 }

--- a/packages/slack-bot/src/classifier/repos.ts
+++ b/packages/slack-bot/src/classifier/repos.ts
@@ -33,6 +33,12 @@ const FALLBACK_REPOS: RepoConfig[] = [];
 const LOCAL_CACHE_TTL_MS = 60 * 1000;
 
 /**
+ * Expiration for the shared KV caches (repos + routing rules), in seconds —
+ * the unit Cloudflare KV's `expirationTtl` expects.
+ */
+const KV_CACHE_TTL_SECONDS = 300;
+
+/**
  * Local in-memory cache for repos.
  */
 let localCache: {
@@ -134,7 +140,7 @@ export async function getAvailableRepos(env: Env, traceId?: string): Promise<Rep
     // Also store in KV for persistence across worker restarts
     try {
       await createKvCacheStore(env.SLACK_KV).put("repos:cache", JSON.stringify(repos), {
-        expirationTtl: 300, // 5 minutes
+        expirationTtl: KV_CACHE_TTL_SECONDS,
       });
     } catch (e) {
       log.warn("kv.put", {
@@ -228,7 +234,7 @@ export async function getRoutingRules(env: Env, traceId?: string): Promise<Slack
 
     try {
       await createKvCacheStore(env.SLACK_KV).put(ROUTING_RULES_CACHE_KEY, JSON.stringify(rules), {
-        expirationTtl: 300, // 5 minutes
+        expirationTtl: KV_CACHE_TTL_SECONDS,
       });
     } catch (e) {
       log.warn("kv.put", {
@@ -258,7 +264,9 @@ async function getRoutingRulesFromCache(env: Env): Promise<SlackRoutingRule[]> {
   try {
     const cached = await createKvCacheStore(env.SLACK_KV).get(ROUTING_RULES_CACHE_KEY, "json");
     if (cached && Array.isArray(cached)) {
-      return cached as SlackRoutingRule[];
+      // Normalize on read so the KV-fallback path returns the same canonical
+      // shape as the fresh control-plane path (one uniform contract).
+      return normalizeRoutingRules(cached as SlackRoutingRule[]);
     }
   } catch (e) {
     log.warn("kv.get", {

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
@@ -355,4 +355,169 @@ describe("SlackIntegrationSettings", () => {
     expect(screen.queryByRole("option", { name: "acme/web" })).toBeNull();
     expect(await screen.findByRole("option", { name: "acme/api" })).toBeInTheDocument();
   });
+
+  describe("routing rules", () => {
+    function routingSection() {
+      return screen.getByRole("heading", { name: /routing rules/i }).closest("section")!;
+    }
+
+    it("renders existing routing rules from settings", () => {
+      setupSWR({
+        global: {
+          defaults: {
+            agentNotificationsEnabled: false,
+            mentionsPolicy: "allow",
+            routingRules: [{ keyword: "frontend", target: "acme/web" }],
+          },
+        },
+        availableRepos: [repo("acme/web")],
+      });
+      render(<SlackIntegrationSettings />);
+
+      const section = routingSection();
+      expect(within(section).getByDisplayValue("frontend")).toBeInTheDocument();
+      expect(within(section).getByText("acme/web")).toBeInTheDocument();
+    });
+
+    it("adds a routing rule and saves it merged into the defaults", async () => {
+      const user = userEvent.setup();
+      setupSWR({
+        global: { defaults: { agentNotificationsEnabled: true, mentionsPolicy: "allow" } },
+        availableRepos: [repo("acme/web")],
+      });
+      fetchMock.mockResolvedValue(okJson({}));
+      render(<SlackIntegrationSettings />);
+
+      const section = routingSection();
+      await user.click(within(section).getByRole("button", { name: /add rule/i }));
+      await user.type(within(section).getByRole("textbox", { name: /keyword/i }), "Frontend");
+      await user.click(within(section).getByRole("combobox", { name: /target repository/i }));
+      await user.click(await screen.findByRole("option", { name: "acme/web" }));
+      await user.click(within(section).getByRole("button", { name: /save routing rules/i }));
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/integration-settings/slack",
+        expect.objectContaining({ method: "PUT" })
+      );
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body as string) as {
+        settings: SlackGlobalConfig;
+      };
+      expect(body.settings.defaults).toEqual({
+        agentNotificationsEnabled: true,
+        mentionsPolicy: "allow",
+        routingRules: [{ keyword: "frontend", target: "acme/web" }],
+      });
+    });
+
+    it("preserves existing routing rules when the Defaults section is saved", async () => {
+      const user = userEvent.setup();
+      setupSWR({
+        global: {
+          defaults: {
+            agentNotificationsEnabled: false,
+            mentionsPolicy: "allow",
+            routingRules: [{ keyword: "frontend", target: "acme/web" }],
+          },
+        },
+        availableRepos: [repo("acme/web")],
+      });
+      fetchMock.mockResolvedValue(okJson({}));
+      render(<SlackIntegrationSettings />);
+
+      await user.click(screen.getByRole("switch", { name: /enable agent notifications/i }));
+      await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body as string) as {
+        settings: SlackGlobalConfig;
+      };
+      expect(body.settings.defaults).toEqual({
+        agentNotificationsEnabled: true,
+        mentionsPolicy: "allow",
+        routingRules: [{ keyword: "frontend", target: "acme/web" }],
+      });
+    });
+
+    it("omits routingRules on save after the last rule is removed", async () => {
+      const user = userEvent.setup();
+      setupSWR({
+        global: {
+          defaults: {
+            agentNotificationsEnabled: true,
+            mentionsPolicy: "allow",
+            routingRules: [{ keyword: "frontend", target: "acme/web" }],
+          },
+        },
+        availableRepos: [repo("acme/web")],
+      });
+      fetchMock.mockResolvedValue(okJson({}));
+      render(<SlackIntegrationSettings />);
+
+      const section = routingSection();
+      await user.click(within(section).getByRole("button", { name: /remove/i }));
+      await user.click(within(section).getByRole("button", { name: /save routing rules/i }));
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body as string) as {
+        settings: SlackGlobalConfig;
+      };
+      expect(body.settings.defaults).toEqual({
+        agentNotificationsEnabled: true,
+        mentionsPolicy: "allow",
+      });
+    });
+
+    it("blocks save and shows an error when a rule has no target", async () => {
+      const user = userEvent.setup();
+      setupSWR({
+        global: { defaults: { agentNotificationsEnabled: true, mentionsPolicy: "allow" } },
+        availableRepos: [repo("acme/web")],
+      });
+      render(<SlackIntegrationSettings />);
+
+      const section = routingSection();
+      await user.click(within(section).getByRole("button", { name: /add rule/i }));
+      await user.type(within(section).getByRole("textbox", { name: /keyword/i }), "frontend");
+      await user.click(within(section).getByRole("button", { name: /save routing rules/i }));
+
+      expect(toastError).toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("warns when a rule targets a repository that is not accessible", () => {
+      setupSWR({
+        global: {
+          defaults: {
+            agentNotificationsEnabled: true,
+            mentionsPolicy: "allow",
+            routingRules: [{ keyword: "frontend", target: "acme/ghost" }],
+          },
+        },
+        availableRepos: [repo("acme/web")],
+      });
+      render(<SlackIntegrationSettings />);
+
+      const section = routingSection();
+      expect(within(section).getByText(/not in your accessible repositories/i)).toBeInTheDocument();
+    });
+
+    it("warns when the same keyword is used by more than one rule", () => {
+      setupSWR({
+        global: {
+          defaults: {
+            agentNotificationsEnabled: true,
+            mentionsPolicy: "allow",
+            routingRules: [
+              { keyword: "frontend", target: "acme/web" },
+              { keyword: "frontend", target: "acme/api" },
+            ],
+          },
+        },
+        availableRepos: [repo("acme/web"), repo("acme/api")],
+      });
+      render(<SlackIntegrationSettings />);
+
+      const section = routingSection();
+      // Both conflicting rows are flagged.
+      expect(within(section).getAllByText(/used by more than one rule/i)).toHaveLength(2);
+    });
+  });
 });

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { act, cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as matchers from "@testing-library/jest-dom/matchers";
+import { MAX_SLACK_ROUTING_RULES } from "@open-inspect/shared";
 import type {
   SlackGlobalConfig,
   SlackRepoSettings,
@@ -479,6 +480,39 @@ describe("SlackIntegrationSettings", () => {
       await user.click(within(section).getByRole("button", { name: /save routing rules/i }));
 
       expect(toastError).toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("blocks save and shows an error when more than the maximum rules are defined", async () => {
+      const user = userEvent.setup();
+      const tooMany = Array.from({ length: MAX_SLACK_ROUTING_RULES + 1 }, (_, i) => ({
+        keyword: `rule-${i}`,
+        target: "acme/web",
+      }));
+      setupSWR({
+        global: {
+          defaults: {
+            agentNotificationsEnabled: true,
+            mentionsPolicy: "allow",
+            routingRules: tooMany,
+          },
+        },
+        availableRepos: [repo("acme/web")],
+      });
+      render(<SlackIntegrationSettings />);
+
+      const section = routingSection();
+      // Save is disabled until the form is dirty; edit a keyword (keeping it
+      // valid) so the only remaining problem is the over-limit count.
+      await user.type(
+        within(section).getAllByRole("textbox", { name: /routing keyword/i })[0],
+        "x"
+      );
+      await user.click(within(section).getByRole("button", { name: /save routing rules/i }));
+
+      expect(toastError).toHaveBeenCalledWith(
+        expect.stringContaining(String(MAX_SLACK_ROUTING_RULES))
+      );
       expect(fetchMock).not.toHaveBeenCalled();
     });
 

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
@@ -5,11 +5,13 @@ import useSWR, { mutate } from "swr";
 import { toast } from "sonner";
 import {
   DEFAULT_MENTIONS_POLICY,
+  normalizeRoutingRules,
   type EnrichedRepository,
   type SlackGlobalConfig,
   type SlackGlobalSettings,
   type SlackMentionsPolicy,
   type SlackRepoSettings,
+  type SlackRoutingRule,
 } from "@open-inspect/shared";
 import { IntegrationSettingsSkeleton } from "./integration-settings-skeleton";
 import { Button } from "@/components/ui/button";
@@ -76,6 +78,24 @@ interface ReposResponse {
   repos: EnrichedRepository[];
 }
 
+/**
+ * Merge a patch onto the current global defaults, dropping keys cleared to
+ * `undefined`. The control plane replaces the whole settings blob on save, so
+ * every section that writes it must preserve the others' fields; centralizing
+ * the merge makes that a property of the data flow rather than per-section
+ * discipline.
+ */
+function mergedGlobalDefaults(
+  current: SlackGlobalConfig | null | undefined,
+  patch: Partial<SlackGlobalSettings>
+): SlackGlobalSettings {
+  const defaults: SlackGlobalSettings = { ...current?.defaults, ...patch };
+  for (const key of Object.keys(defaults) as (keyof SlackGlobalSettings)[]) {
+    if (defaults[key] === undefined) delete defaults[key];
+  }
+  return defaults;
+}
+
 export function SlackIntegrationSettings() {
   const { data: globalData, isLoading: globalLoading } =
     useSWR<GlobalResponse>(GLOBAL_SETTINGS_KEY);
@@ -112,6 +132,8 @@ export function SlackIntegrationSettings() {
 
       <GlobalSettingsSection settings={settings} />
 
+      <RoutingRulesSection settings={settings} availableRepos={availableRepos} />
+
       <Section
         title="Repository overrides"
         description="Override the master switch for specific repositories. Mentions policy is workspace-wide and is not overridable per repo."
@@ -144,7 +166,17 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
   const handleConfirmReset = async () => {
     setSaving(true);
     try {
-      const res = await fetch(GLOBAL_SETTINGS_KEY, { method: "DELETE" });
+      // Reset only the notification/mention defaults. If routing rules exist,
+      // preserve them by writing a blob that keeps just the rules (rather than
+      // deleting the whole row); otherwise clear the row entirely.
+      const existingRules = settings?.defaults?.routingRules;
+      const res = existingRules?.length
+        ? await fetch(GLOBAL_SETTINGS_KEY, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ settings: { defaults: { routingRules: existingRules } } }),
+          })
+        : await fetch(GLOBAL_SETTINGS_KEY, { method: "DELETE" });
       if (res.ok) {
         mutate(GLOBAL_SETTINGS_KEY);
         setAgentNotificationsEnabled(false);
@@ -164,11 +196,9 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
 
   const handleSave = async () => {
     setSaving(true);
-    const defaults: SlackGlobalSettings = {
-      agentNotificationsEnabled,
-      mentionsPolicy,
+    const body: SlackGlobalConfig = {
+      defaults: mergedGlobalDefaults(settings, { agentNotificationsEnabled, mentionsPolicy }),
     };
-    const body: SlackGlobalConfig = { defaults };
 
     try {
       const res = await fetch(GLOBAL_SETTINGS_KEY, {
@@ -258,7 +288,8 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
             <AlertDialogTitle>Reset to defaults</AlertDialogTitle>
             <AlertDialogDescription>
               Reset Slack defaults? The master switch will turn off and mentions policy will return
-              to <strong>allow</strong>. Per-repository overrides are not affected.
+              to <strong>allow</strong>. Per-repository overrides and routing rules are not
+              affected.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -437,6 +468,195 @@ function RepoOverrideRow({ entry }: { entry: RepoSettingsEntry }) {
         </Button>
       </div>
     </div>
+  );
+}
+
+interface DraftRoutingRule {
+  /** Stable key for list rendering; not persisted. */
+  id: number;
+  keyword: string;
+  target: string;
+}
+
+// Monotonic source of stable React keys for draft rows.
+let draftRoutingRuleIdCounter = 0;
+
+function toDraftRoutingRules(rules: SlackRoutingRule[] | undefined): DraftRoutingRule[] {
+  return (rules ?? []).map((rule) => ({
+    id: draftRoutingRuleIdCounter++,
+    keyword: rule.keyword,
+    target: rule.target,
+  }));
+}
+
+function RoutingRulesSection({
+  settings,
+  availableRepos,
+}: {
+  settings: SlackGlobalConfig | null | undefined;
+  availableRepos: EnrichedRepository[];
+}) {
+  const [rules, setRules] = useState<DraftRoutingRule[]>(() =>
+    toDraftRoutingRules(settings?.defaults?.routingRules)
+  );
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState(false);
+
+  useEffect(() => {
+    if (settings === undefined || dirty || saving) return;
+    setRules(toDraftRoutingRules(settings?.defaults?.routingRules));
+  }, [settings, dirty, saving]);
+
+  const accessibleRepos = new Set(availableRepos.map((r) => r.fullName.toLowerCase()));
+  const keywordCounts = new Map<string, number>();
+  for (const rule of rules) {
+    const key = rule.keyword.trim().toLowerCase();
+    if (key) keywordCounts.set(key, (keywordCounts.get(key) ?? 0) + 1);
+  }
+
+  const updateRule = (id: number, patch: Partial<DraftRoutingRule>) => {
+    setRules((prev) => prev.map((r) => (r.id === id ? { ...r, ...patch } : r)));
+    setDirty(true);
+  };
+
+  const addRule = () => {
+    setRules((prev) => [...prev, { id: draftRoutingRuleIdCounter++, keyword: "", target: "" }]);
+    setDirty(true);
+  };
+
+  const removeRule = (id: number) => {
+    setRules((prev) => prev.filter((r) => r.id !== id));
+    setDirty(true);
+  };
+
+  const handleSave = async () => {
+    const trimmed = rules.map((r) => ({ keyword: r.keyword.trim(), target: r.target.trim() }));
+    if (trimmed.some((r) => !r.keyword || !r.target)) {
+      toast.error("Every routing rule needs a keyword and a target repository.");
+      return;
+    }
+
+    setSaving(true);
+    // normalizeRoutingRules lowercases, de-dupes, and caps — the same shape the
+    // control plane stores, so the UI and storage stay in sync.
+    const normalized = normalizeRoutingRules(trimmed);
+    const body: SlackGlobalConfig = {
+      defaults: mergedGlobalDefaults(settings, {
+        routingRules: normalized.length > 0 ? normalized : undefined,
+      }),
+    };
+
+    try {
+      const res = await fetch(GLOBAL_SETTINGS_KEY, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ settings: body }),
+      });
+      if (res.ok) {
+        mutate(GLOBAL_SETTINGS_KEY);
+        toast.success("Routing rules saved.");
+        setDirty(false);
+      } else {
+        const data = await res.json();
+        toast.error(data.error || "Failed to save routing rules");
+      }
+    } catch {
+      toast.error("Failed to save routing rules");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Section
+      title="Routing rules"
+      description="Map keywords to repositories. When a Slack message contains a keyword, the agent is routed to that repository before falling back to channel association or automatic detection."
+    >
+      {rules.length > 0 ? (
+        <div className="space-y-3 mb-4">
+          {rules.map((rule) => {
+            const target = rule.target.trim().toLowerCase();
+            const staleTarget = target !== "" && !accessibleRepos.has(target);
+            const duplicateKeyword =
+              rule.keyword.trim() !== "" &&
+              (keywordCounts.get(rule.keyword.trim().toLowerCase()) ?? 0) > 1;
+
+            // A target that is no longer accessible must still render so the user
+            // can see and re-point it (Radix Select needs a matching item).
+            const targetOptions = staleTarget
+              ? [...availableRepos.map((r) => r.fullName), rule.target]
+              : availableRepos.map((r) => r.fullName);
+
+            return (
+              <div key={rule.id}>
+                <div className="flex items-center gap-2">
+                  <input
+                    aria-label="Routing keyword"
+                    value={rule.keyword}
+                    onChange={(e) => updateRule(rule.id, { keyword: e.target.value })}
+                    placeholder="keyword"
+                    className="w-48 px-3 py-2 text-sm bg-input border border-border rounded-sm focus:outline-none focus:ring-2 focus:ring-ring text-foreground placeholder:text-secondary-foreground"
+                  />
+                  <span className="text-muted-foreground" aria-hidden="true">
+                    &rarr;
+                  </span>
+                  <Select value={target} onValueChange={(v) => updateRule(rule.id, { target: v })}>
+                    <SelectTrigger className="flex-1" aria-label="Routing target repository">
+                      <SelectValue placeholder="Select a repository..." />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {targetOptions.map((fullName) => (
+                        <SelectItem key={fullName} value={fullName.toLowerCase()}>
+                          {fullName}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Button variant="destructive" size="sm" onClick={() => removeRule(rule.id)}>
+                    Remove
+                  </Button>
+                </div>
+                {(staleTarget || duplicateKeyword) && (
+                  <div className="mt-1 ml-1 space-y-0.5">
+                    {staleTarget && (
+                      <p className="text-xs text-warning">
+                        <code>{rule.target}</code> is not in your accessible repositories — this
+                        rule is ignored until access is restored.
+                      </p>
+                    )}
+                    {duplicateKeyword && (
+                      <p className="text-xs text-warning">
+                        This keyword is used by more than one rule — matching messages will ask
+                        which repository to use.
+                      </p>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground mb-4">
+          No routing rules yet. Add one to route messages containing a keyword to a specific
+          repository.
+        </p>
+      )}
+
+      <div className="flex items-center gap-2">
+        <Button variant="outline" onClick={addRule}>
+          Add rule
+        </Button>
+        <Button onClick={handleSave} disabled={saving || !dirty}>
+          {saving ? "Saving..." : "Save routing rules"}
+        </Button>
+      </div>
+
+      <p className="mt-3 text-xs text-muted-foreground">
+        Keywords match whole words, case-insensitively. Point each keyword at one repository; the
+        same keyword on two repositories will prompt for a choice instead of guessing.
+      </p>
+    </Section>
   );
 }
 

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
@@ -5,6 +5,7 @@ import useSWR, { mutate } from "swr";
 import { toast } from "sonner";
 import {
   DEFAULT_MENTIONS_POLICY,
+  MAX_SLACK_ROUTING_RULES,
   normalizeRoutingRules,
   type EnrichedRepository,
   type SlackGlobalConfig,
@@ -535,10 +536,17 @@ function RoutingRulesSection({
       toast.error("Every routing rule needs a keyword and a target repository.");
       return;
     }
+    if (trimmed.length > MAX_SLACK_ROUTING_RULES) {
+      toast.error(
+        `You can define at most ${MAX_SLACK_ROUTING_RULES} routing rules (you have ${trimmed.length}). Remove ${trimmed.length - MAX_SLACK_ROUTING_RULES} to save.`
+      );
+      return;
+    }
 
     setSaving(true);
-    // normalizeRoutingRules lowercases, de-dupes, and caps — the same shape the
-    // control plane stores, so the UI and storage stay in sync.
+    // normalizeRoutingRules lowercases and de-dupes to match the stored shape;
+    // its cap is a no-op here since over-limit drafts are rejected above, and
+    // the control plane remains the canonical validator.
     const normalized = normalizeRoutingRules(trimmed);
     const body: SlackGlobalConfig = {
       defaults: mergedGlobalDefaults(settings, {


### PR DESCRIPTION
## Summary

Adds **routing rules** to the Slack integration — keyword→repository mappings that an admin configures in the web settings. When a Slack message contains a configured keyword, the agent is routed to that repository **deterministically**, before the LLM classifier ever runs. With no rules configured, behavior is identical to today.

This is a deliberately minimal-change feature: it reuses the existing `integration_settings` pipeline (**no D1 migration, no new routes**) and adds a single deterministic tier to the existing `RepoClassifier`.

## How routing works

`RepoClassifier.classify()` resolves a message to a repo through ordered tiers. Routing rules slot in as a new deterministic tier:

1. Active thread / existing session (handled before `classify`)
2. Only one repository available → use it
3. **Routing rules (new)** — whole-word, case-insensitive keyword match
4. Channel ↔ repository association
5. LLM classifier (`claude-haiku-4-5`)

Within the routing tier:

- **Exactly one** accessible target matches → route with `high` confidence (`Matched routing rule "api" → acme/backend`).
- **Two or more distinct** targets match → ask the user to clarify among them (no guess, no LLM).
- Target not accessible / no keyword match → fall through to the existing tiers.

Matching is whole-word (`(?:^|\W)keyword(?:\W|$)`, lowercased) so `api` does not match `capybara`. The bot reads rules via the existing internal `GET /integration-settings/slack` (HMAC), KV-cached ~5 min, and **fails open to `[]`** so a settings outage can never block classification.

## Storage & UI

- Stored in the existing `integration_settings` **global** blob at `defaults.routingRules` (mirrors `mentionsPolicy`) — **no migration, no new routes**. Reuses `GET/PUT /integration-settings/slack` and the existing web proxy.
- New **Routing rules** section in the Slack integration settings: a keyword input + repository picker per rule, Add / Remove, and a single "Save routing rules". Inline warnings for **duplicate keywords** and **stale targets** (a rule pointing at a repo that is no longer accessible).
- Routing rules are kept **separate** from the existing per-repo `keywords`/`aliases`. Those remain fuzzy hints for the LLM; routing rules are the deterministic pre-LLM layer. Unifying them would change existing behavior and needs product sign-off.

## What changed (by layer)

- **shared** — `SlackRoutingRule` type, `normalizeRoutingRules` / `matchRoutingRules` helpers, and caps (`MAX_SLACK_ROUTING_RULES = 100`, `MAX_SLACK_ROUTING_KEYWORD_LENGTH = 100`). Also extracted a canonical `escapeRegExp` into `shared/src/regex.ts`, removing three duplicate copies (`triggers/glob.ts`, `github-bot/handlers.ts`, and the new matcher).
- **control-plane** — `validateSlackSettings` accepts and validates `routingRules` (rejects non-array, over-count, non-object rule, empty/over-long keyword, and malformed `owner/name` target).
- **slack-bot** — `getRoutingRules` (fetch + cache, fail-open) and the new `classifyByRoutingRules` tier. A small `controlPlaneFetch` transport helper now backs both `getAvailableRepos` and `getRoutingRules`.
- **web** — Routing rules section, plus a `mergedGlobalDefaults` helper so the two writers to the global blob (Defaults and Routing rules) merge-preserve each other's fields instead of clobbering on save/reset.
- **docs** — `docs/integrations/SLACK.md` precedence prose + a new Routing rules subsection.

## Design decisions

- **Repos only, no environments** — environments don't exist anywhere in the codebase; a `targetType` field is reserved for the future.
- **Rules beat channel association** — safe because the tier only fires on an explicit keyword match.
- **Multi-match → clarify**, never guess.
- **Caps enforced by throwing** in the validator (not silent truncation), and surfaced in the UI.
- Backward compatible: absent rules == today's behavior.

## Testing

- `npm run typecheck` ✅ (full workspace) · `npm run lint` / prettier ✅
- shared ✅ · control-plane ✅ (unit + integration) · slack-bot ✅ · github-bot ✅ · web ✅
- New coverage: shared helper units (`normalizeRoutingRules`, `matchRoutingRules`), control-plane validation, slack-bot `getRoutingRules` contract + routing-tier classification, and web component tests (render / add / remove / save-merge / duplicate + stale-target warnings).

A short screen recording of the settings UI (add, remove, duplicate-keyword warning, stale-target warning, save) was captured during development to validate the UX.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Slack routing rules (keyword → repository) for deterministic message routing, including clarification when multiple repositories match.
  * Enhanced the Slack integration settings UI to add/manage routing rules with validation (limits, duplicates, missing/unauthorized targets) and to preserve existing routing rules when editing/resetting other defaults.
* **Documentation**
  * Expanded Slack integration documentation with routing-rule configuration, keyword matching semantics, precedence/interaction with other routing methods, and handling of ambiguous or stale targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->