### PR TITLE
feat(web): add automation templates gallery

### DIFF
--- a/packages/web/src/app/(app)/automations/new/page.test.tsx
+++ b/packages/web/src/app/(app)/automations/new/page.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import type { ReactNode } from "react";
+import { DEFAULT_MODEL } from "@open-inspect/shared";
+import NewAutomationPage from "./page";
+
+expect.extend(matchers);
+afterEach(cleanup);
+
+// Mutable per-test inputs (vi.mock factories are hoisted, so they close over these).
+let search = "";
+let enabledModelsValue: string[] = [DEFAULT_MODEL, "anthropic/claude-opus-4-8", "openai/gpt-5.5"];
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(search),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/components/sidebar-layout", () => ({
+  useSidebarContext: () => ({ isOpen: true, toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-repos", () => ({
+  useRepos: () => ({ repos: [], loading: false }),
+}));
+
+vi.mock("@/hooks/use-branches", () => ({
+  useBranches: () => ({ branches: [], loading: false }),
+}));
+
+vi.mock("@/hooks/use-enabled-models", () => ({
+  useEnabledModels: () => ({
+    enabledModels: enabledModelsValue,
+    enabledModelOptions: [
+      {
+        category: "Anthropic",
+        models: [{ id: DEFAULT_MODEL, name: "Claude Sonnet 4.6", description: "" }],
+      },
+    ],
+    loading: false,
+  }),
+}));
+
+// Mirror the form's own test: render the combobox trigger contents so we can
+// read the displayed repository / model without driving the dropdown.
+vi.mock("@/components/ui/combobox", () => ({
+  Combobox: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+beforeEach(() => {
+  search = "";
+  enabledModelsValue = [DEFAULT_MODEL, "anthropic/claude-opus-4-8", "openai/gpt-5.5"];
+});
+
+describe("NewAutomationPage template pre-fill", () => {
+  it("pre-fills the form from a known template and leaves the repository empty", () => {
+    search = "template=find-bugs";
+    render(<NewAutomationPage />);
+
+    expect(screen.getByDisplayValue("Find bugs")).toBeInTheDocument();
+    expect(screen.getByDisplayValue(/Review the most recent commits/)).toBeInTheDocument();
+    // Repository is intentionally not pre-filled.
+    expect(screen.getByText("Select repository")).toBeInTheDocument();
+    // A hint tells the user the form was prefilled from a template.
+    expect(screen.getByText(/prefilled from/i)).toBeInTheDocument();
+  });
+
+  it("renders the blank create form for an unknown template id", () => {
+    search = "template=does-not-exist";
+    render(<NewAutomationPage />);
+
+    const nameInput = screen.getByPlaceholderText("Daily code review") as HTMLInputElement;
+    expect(nameInput.value).toBe("");
+    expect(screen.queryByDisplayValue("Find bugs")).not.toBeInTheDocument();
+    expect(screen.queryByText(/prefilled from/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the blank create form when no template param is present", () => {
+    search = "";
+    render(<NewAutomationPage />);
+
+    const nameInput = screen.getByPlaceholderText("Daily code review") as HTMLInputElement;
+    expect(nameInput.value).toBe("");
+  });
+
+  it("coerces an unenabled suggested model to an enabled one", () => {
+    // scan-vulnerabilities suggests anthropic/claude-opus-4-8; exclude it.
+    enabledModelsValue = [DEFAULT_MODEL];
+    search = "template=scan-vulnerabilities";
+    render(<NewAutomationPage />);
+
+    expect(screen.getByDisplayValue("Scan codebase for vulnerabilities")).toBeInTheDocument();
+    // Falls back to the enabled default model rather than the unenabled suggestion.
+    expect(screen.getByText("claude sonnet 4.6")).toBeInTheDocument();
+    expect(screen.queryByText("claude opus 4.8")).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/app/(app)/automations/new/page.tsx
+++ b/packages/web/src/app/(app)/automations/new/page.tsx
@@ -1,22 +1,27 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useSidebarContext } from "@/components/sidebar-layout";
 import {
   AutomationForm,
   type AutomationFormValues,
 } from "@/components/automations/automation-form";
 import { WebhookConfig } from "@/components/automations/webhook-config";
+import { useEnabledModels } from "@/hooks/use-enabled-models";
+import { getTemplateById, resolveTemplateInitialValues } from "@/lib/automation-templates";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { SidebarIcon, BackIcon } from "@/components/ui/icons";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import Link from "next/link";
 
-export default function NewAutomationPage() {
+function NewAutomationContent() {
   const { isOpen, toggle } = useSidebarContext();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const { enabledModels, loading: loadingModels } = useEnabledModels();
+
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [webhookResult, setWebhookResult] = useState<{
@@ -25,6 +30,18 @@ export default function NewAutomationPage() {
     webhookUrl?: string;
     sentryWebhookUrl?: string;
   } | null>(null);
+
+  // A template id (from the gallery) pre-fills the form. Repository is never
+  // pre-filled, so the repo-required-at-creation invariant is untouched.
+  const template = getTemplateById(searchParams.get("template") ?? "");
+
+  // The model selector has no built-in fallback, so a suggested model must be
+  // resolved against the user's enabled set before the form mounts (it reads
+  // initialValues once). Only block on the enabled list when one is suggested.
+  const needsModelResolution = Boolean(template?.prefill.model);
+  const initialValues: Partial<AutomationFormValues> | undefined = template
+    ? resolveTemplateInitialValues(template.prefill, enabledModels)
+    : undefined;
 
   const handleSubmit = async (values: AutomationFormValues) => {
     setSubmitting(true);
@@ -153,9 +170,42 @@ export default function NewAutomationPage() {
             </ErrorBanner>
           )}
 
-          <AutomationForm mode="create" onSubmit={handleSubmit} submitting={submitting} />
+          {template && (
+            <div className="mb-4 rounded-md border border-border-muted bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+              Prefilled from the{" "}
+              <span className="font-medium text-foreground">{template.title}</span> template. Review
+              the details and choose a repository to create it.
+            </div>
+          )}
+
+          {needsModelResolution && loadingModels ? (
+            <div className="flex justify-center py-12">
+              <div className="animate-spin rounded-full h-6 w-6 border-2 border-current border-t-transparent text-muted-foreground" />
+            </div>
+          ) : (
+            <AutomationForm
+              mode="create"
+              initialValues={initialValues}
+              onSubmit={handleSubmit}
+              submitting={submitting}
+            />
+          )}
         </div>
       </div>
     </div>
+  );
+}
+
+export default function NewAutomationPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="h-full flex items-center justify-center">
+          <div className="animate-spin rounded-full h-6 w-6 border-2 border-current border-t-transparent text-muted-foreground" />
+        </div>
+      }
+    >
+      <NewAutomationContent />
+    </Suspense>
   );
 }

--- a/packages/web/src/app/(app)/automations/page.tsx
+++ b/packages/web/src/app/(app)/automations/page.tsx
@@ -57,14 +57,17 @@ export default function AutomationsPage() {
         <div className="max-w-3xl mx-auto">
           <div className="flex items-center justify-between mb-6">
             <h1 className="text-3xl font-semibold text-foreground">Automations</h1>
-            <Link href="/automations/new">
-              <Button size="sm">
-                <span className="flex items-center gap-1.5">
+            <div className="flex items-center gap-2">
+              <Button variant="outline" size="sm" asChild>
+                <Link href="/automations/templates">Browse templates</Link>
+              </Button>
+              <Button size="sm" asChild>
+                <Link href="/automations/new" className="flex items-center gap-1.5">
                   <PlusIcon className="w-4 h-4" />
                   Create Automation
-                </span>
+                </Link>
               </Button>
-            </Link>
+            </div>
           </div>
 
           {actionError && (

--- a/packages/web/src/app/(app)/automations/templates/page.tsx
+++ b/packages/web/src/app/(app)/automations/templates/page.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import Link from "next/link";
+import { useSidebarContext } from "@/components/sidebar-layout";
+import { TemplateGallery } from "@/components/automations/template-gallery";
+import { SidebarIcon, BackIcon } from "@/components/ui/icons";
+import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
+
+export default function AutomationTemplatesPage() {
+  const { isOpen, toggle } = useSidebarContext();
+
+  return (
+    <div className="h-full flex flex-col">
+      {!isOpen && (
+        <header className="border-b border-border-muted flex-shrink-0">
+          <div className="px-4 py-3 flex items-center gap-2">
+            <button
+              onClick={toggle}
+              className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition"
+              title={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
+              aria-label={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
+            >
+              <SidebarIcon className="w-4 h-4" />
+            </button>
+            <Link
+              href="/automations"
+              className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition"
+              aria-label="Back to automations"
+            >
+              <BackIcon className="w-4 h-4" />
+            </Link>
+          </div>
+        </header>
+      )}
+
+      <div className="flex-1 overflow-y-auto p-8">
+        <div className="max-w-3xl mx-auto">
+          <div className="mb-6">
+            <h1 className="text-3xl font-semibold text-foreground">Automation templates</h1>
+            <p className="mt-1.5 text-sm text-muted-foreground">
+              Start from a pre-built idea instead of a blank form. Pick a template, choose a
+              repository, and create.
+            </p>
+          </div>
+
+          <TemplateGallery />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/automations/automations-list.test.tsx
+++ b/packages/web/src/components/automations/automations-list.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import type { ComponentProps } from "react";
+import { AutomationsList } from "./automations-list";
+
+expect.extend(matchers);
+afterEach(cleanup);
+
+vi.mock("next/link", () => ({
+  default: ({ children, ...props }: ComponentProps<"a">) => <a {...props}>{children}</a>,
+}));
+
+const noop = () => {};
+
+describe("AutomationsList empty state", () => {
+  it("offers a template path and a from-scratch path when there are no automations", () => {
+    render(
+      <AutomationsList
+        automations={[]}
+        onPause={noop}
+        onResume={noop}
+        onTrigger={noop}
+        onDelete={noop}
+      />
+    );
+
+    expect(screen.getByRole("link", { name: /start from a template/i })).toHaveAttribute(
+      "href",
+      "/automations/templates"
+    );
+    expect(screen.getByRole("link", { name: /create automation/i })).toHaveAttribute(
+      "href",
+      "/automations/new"
+    );
+  });
+});

--- a/packages/web/src/components/automations/automations-list.tsx
+++ b/packages/web/src/components/automations/automations-list.tsx
@@ -67,8 +67,16 @@ export function AutomationsList({
       <div className="border border-border-muted rounded-md bg-card p-8 text-center">
         <p className="text-muted-foreground">No automations yet.</p>
         <p className="text-sm text-muted-foreground mt-1">
-          Create one to run tasks on a schedule or in response to events.
+          Start from a template, or create one to run tasks on a schedule or in response to events.
         </p>
+        <div className="mt-4 flex flex-wrap items-center justify-center gap-2">
+          <Button size="sm" asChild>
+            <Link href="/automations/templates">Start from a template</Link>
+          </Button>
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/automations/new">Create Automation</Link>
+          </Button>
+        </div>
       </div>
     );
   }

--- a/packages/web/src/components/automations/template-gallery.test.tsx
+++ b/packages/web/src/components/automations/template-gallery.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import type { ComponentProps } from "react";
+import { TemplateGallery } from "./template-gallery";
+import { getTemplatesForCategory, getVisibleCategories } from "@/lib/automation-templates";
+
+expect.extend(matchers);
+afterEach(cleanup);
+
+vi.mock("next/link", () => ({
+  default: ({ children, ...props }: ComponentProps<"a">) => <a {...props}>{children}</a>,
+}));
+
+describe("TemplateGallery", () => {
+  it("defaults to the Popular category and lists its templates", () => {
+    render(<TemplateGallery />);
+    for (const t of getTemplatesForCategory("popular")) {
+      expect(screen.getByRole("heading", { name: t.title })).toBeInTheDocument();
+    }
+  });
+
+  it("only renders categories that contain templates", () => {
+    render(<TemplateGallery />);
+    expect(screen.getAllByTestId(/^category-/)).toHaveLength(getVisibleCategories().length);
+  });
+
+  it("filters the grid when another category is selected (without navigation)", () => {
+    render(<TemplateGallery />);
+    // "Generate docs" is code-review only, so it is hidden under Popular.
+    expect(screen.queryByRole("heading", { name: "Generate docs" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("category-code-review"));
+
+    expect(screen.getByRole("heading", { name: "Generate docs" })).toBeInTheDocument();
+    // A popular-only / non-code-review template is now hidden.
+    expect(
+      screen.queryByRole("heading", { name: "Weekly dependency digest" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("links each template's Add button to the prefilled create page", () => {
+    render(<TemplateGallery />);
+    const card = screen.getByRole("heading", { name: "Find bugs" }).closest("[data-template-id]");
+    expect(card).not.toBeNull();
+    expect(within(card as HTMLElement).getByRole("link", { name: /add/i })).toHaveAttribute(
+      "href",
+      "/automations/new?template=find-bugs"
+    );
+  });
+
+  it("gives each Add control a distinguishing accessible name", () => {
+    render(<TemplateGallery />);
+    expect(screen.getByRole("link", { name: "Add Find bugs" })).toHaveAttribute(
+      "href",
+      "/automations/new?template=find-bugs"
+    );
+  });
+
+  it("shows a setup note for templates that need extra setup", () => {
+    render(<TemplateGallery />);
+    fireEvent.click(screen.getByTestId("category-security"));
+    const card = screen
+      .getByRole("heading", { name: "Scan codebase for vulnerabilities" })
+      .closest("[data-template-id]");
+    expect(within(card as HTMLElement).getByText(/requires slack/i)).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/automations/template-gallery.tsx
+++ b/packages/web/src/components/automations/template-gallery.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import type { AutomationTriggerType } from "@open-inspect/shared";
+import {
+  automationTemplates,
+  getVisibleCategories,
+  type AutomationTemplate,
+  type TemplateCategory,
+} from "@/lib/automation-templates";
+import { Button } from "@/components/ui/button";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import {
+  ClockIcon,
+  GitHubIcon,
+  GitPrIcon,
+  GlobeIcon,
+  SentryIcon,
+  SlackIcon,
+} from "@/components/ui/icons";
+
+const ICON_CLASS = "w-4 h-4 flex-shrink-0";
+
+const TRIGGER_LABELS: Record<string, string> = {
+  schedule: "Schedule",
+  github_event: "GitHub event",
+  sentry: "Sentry",
+  webhook: "Webhook",
+  linear_event: "Linear",
+};
+
+const OUTPUT_LABELS: Record<AutomationTemplate["primaryOutput"], string> = {
+  pr: "Pull request",
+  slack: "Slack",
+};
+
+function TriggerIcon({ type }: { type?: AutomationTriggerType }) {
+  switch (type) {
+    case "github_event":
+      return <GitHubIcon className={ICON_CLASS} />;
+    case "sentry":
+      return <SentryIcon className={ICON_CLASS} />;
+    case "webhook":
+      return <GlobeIcon className={ICON_CLASS} />;
+    case "schedule":
+    default:
+      return <ClockIcon className={ICON_CLASS} />;
+  }
+}
+
+function OutputIcon({ output }: { output: AutomationTemplate["primaryOutput"] }) {
+  return output === "slack" ? (
+    <SlackIcon className={ICON_CLASS} />
+  ) : (
+    <GitPrIcon className={ICON_CLASS} />
+  );
+}
+
+function TemplateCard({ template }: { template: AutomationTemplate }) {
+  const triggerLabel = TRIGGER_LABELS[template.prefill.triggerType ?? "schedule"] ?? "Schedule";
+  const outputLabel = OUTPUT_LABELS[template.primaryOutput];
+
+  return (
+    <div
+      data-template-id={template.id}
+      className="flex flex-col rounded-md border border-border-muted bg-card p-4"
+    >
+      <div className="flex items-center text-muted-foreground">
+        <span
+          className="flex items-center gap-1.5"
+          aria-hidden="true"
+          title={`${triggerLabel} → ${outputLabel}`}
+        >
+          <TriggerIcon type={template.prefill.triggerType} />
+          <span className="text-xs">—</span>
+          <OutputIcon output={template.primaryOutput} />
+        </span>
+        <span className="sr-only">
+          Trigger: {triggerLabel}. Output: {outputLabel}.
+        </span>
+      </div>
+
+      <h3 className="mt-3 font-medium text-foreground">{template.title}</h3>
+      <p className="mt-1 flex-1 text-sm text-muted-foreground leading-normal">
+        {template.description}
+      </p>
+
+      {template.setupNote && (
+        <p className="mt-2 text-xs text-muted-foreground/80 leading-normal">{template.setupNote}</p>
+      )}
+
+      <div className="mt-3">
+        <Button variant="outline" size="sm" asChild>
+          <Link
+            href={`/automations/new?template=${template.id}`}
+            aria-label={`Add ${template.title}`}
+          >
+            Add
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function TemplateGallery() {
+  const categories = getVisibleCategories();
+  const [category, setCategory] = useState<TemplateCategory>(categories[0]?.id ?? "popular");
+
+  const activeLabel = categories.find((c) => c.id === category)?.label ?? "";
+  const templates = automationTemplates.filter((t) => t.categories.includes(category));
+
+  return (
+    <div>
+      <ToggleGroup
+        type="single"
+        value={category}
+        onValueChange={(value) => {
+          // Radix emits "" when the active item is re-clicked; keep the selection.
+          if (value) setCategory(value as TemplateCategory);
+        }}
+        variant="outline"
+        size="sm"
+        aria-label="Filter templates by category"
+        className="flex flex-wrap justify-start gap-1 rounded-md bg-card p-1"
+      >
+        {categories.map((c) => (
+          <ToggleGroupItem key={c.id} value={c.id} data-testid={`category-${c.id}`}>
+            {c.label}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+
+      {/* Visually-hidden heading fills the h1 → h3 gap for assistive tech. */}
+      <h2 className="sr-only">{activeLabel} templates</h2>
+
+      <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {templates.map((template) => (
+          <TemplateCard key={template.id} template={template} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/automations/template-gallery.tsx
+++ b/packages/web/src/components/automations/template-gallery.tsx
@@ -27,7 +27,6 @@ const TRIGGER_LABELS: Record<string, string> = {
   github_event: "GitHub event",
   sentry: "Sentry",
   webhook: "Webhook",
-  linear_event: "Linear",
 };
 
 const OUTPUT_LABELS: Record<AutomationTemplate["primaryOutput"], string> = {
@@ -35,7 +34,7 @@ const OUTPUT_LABELS: Record<AutomationTemplate["primaryOutput"], string> = {
   slack: "Slack",
 };
 
-function TriggerIcon({ type }: { type?: AutomationTriggerType }) {
+function TriggerIcon({ type }: { type: AutomationTriggerType }) {
   switch (type) {
     case "github_event":
       return <GitHubIcon className={ICON_CLASS} />;
@@ -58,7 +57,7 @@ function OutputIcon({ output }: { output: AutomationTemplate["primaryOutput"] })
 }
 
 function TemplateCard({ template }: { template: AutomationTemplate }) {
-  const triggerLabel = TRIGGER_LABELS[template.prefill.triggerType ?? "schedule"] ?? "Schedule";
+  const triggerLabel = TRIGGER_LABELS[template.prefill.triggerType] ?? "Schedule";
   const outputLabel = OUTPUT_LABELS[template.primaryOutput];
 
   return (

--- a/packages/web/src/components/ui/icons.tsx
+++ b/packages/web/src/components/ui/icons.tsx
@@ -180,6 +180,26 @@ export function SlackIcon({ className }: IconProps) {
   );
 }
 
+export function SentryIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      data-testid="sentry-icon"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12 4.5 4.6 17.4a1.4 1.4 0 0 0 1.2 2.1H9" />
+      <path d="M12 4.5 19.4 17.4a1.4 1.4 0 0 1-1.2 2.1h-3.6" />
+      <path d="M8.8 19.5a5.5 5.5 0 0 0-2.6-4.6" />
+      <path d="M14.6 19.5A10.5 10.5 0 0 0 9.2 10.3" />
+    </svg>
+  );
+}
+
 export function ArchiveIcon({ className }: IconProps) {
   return (
     <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/packages/web/src/lib/automation-templates.test.ts
+++ b/packages/web/src/lib/automation-templates.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect } from "vitest";
+import {
+  triggerSources,
+  isValidCron,
+  cronIntervalMinutes,
+  isValidModel,
+  isValidReasoningEffort,
+  validateConditions,
+  conditionRegistry,
+  TRIGGER_TYPE_TO_SOURCE,
+  DEFAULT_ENABLED_MODELS,
+  DEFAULT_MODEL,
+  type AutomationTriggerType,
+} from "@open-inspect/shared";
+import {
+  automationTemplates,
+  TEMPLATE_CATEGORIES,
+  getTemplateById,
+  getTemplatesForCategory,
+  getVisibleCategories,
+  resolveTemplateInitialValues,
+} from "./automation-templates";
+
+// Keep in sync with INSTRUCTIONS_MAX_LENGTH in automation-form.tsx /
+// MAX_INSTRUCTIONS_LENGTH in control-plane routes/automations.ts.
+const INSTRUCTIONS_MAX_LENGTH = 15000;
+// Schedules must be at least this far apart (control-plane create validation).
+const MIN_INTERVAL_MINUTES = 15;
+
+const CATEGORY_IDS = new Set(TEMPLATE_CATEGORIES.map((c) => c.id));
+const REPO_FIELDS = ["repoOwner", "repoName", "baseBranch"] as const;
+
+// Maps each trigger type to the set of event types its source actually supports.
+const eventTypesByTrigger = new Map<string, Set<string>>(
+  triggerSources.map((s) => [s.triggerType, new Set(s.eventTypes.map((e) => e.eventType))])
+);
+
+describe("automation templates catalog", () => {
+  it("has at least one template", () => {
+    expect(automationTemplates.length).toBeGreaterThan(0);
+  });
+
+  it("has unique ids", () => {
+    const ids = automationTemplates.map((t) => t.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("has at least one Popular template", () => {
+    expect(automationTemplates.some((t) => t.categories.includes("popular"))).toBe(true);
+  });
+
+  describe.each(automationTemplates.map((t) => [t.id, t] as const))("template %s", (_id, t) => {
+    it("never prefills repository fields (AC-4)", () => {
+      for (const field of REPO_FIELDS) {
+        expect(t.prefill[field]).toBeUndefined();
+      }
+    });
+
+    it("omits scheduleTz so the user's timezone default applies", () => {
+      expect(t.prefill.scheduleTz).toBeUndefined();
+    });
+
+    it("has non-empty title, description, and instructions", () => {
+      expect(t.title.trim().length).toBeGreaterThan(0);
+      expect(t.description.trim().length).toBeGreaterThan(0);
+      expect((t.prefill.instructions ?? "").trim().length).toBeGreaterThan(0);
+    });
+
+    it("keeps instructions within the 15,000 character cap", () => {
+      expect((t.prefill.instructions ?? "").length).toBeLessThanOrEqual(INSTRUCTIONS_MAX_LENGTH);
+    });
+
+    it("declares only known categories", () => {
+      expect(t.categories.length).toBeGreaterThan(0);
+      for (const category of t.categories) {
+        expect(CATEGORY_IDS.has(category)).toBe(true);
+      }
+    });
+
+    it("declares a supported primary output", () => {
+      expect(["pr", "slack"]).toContain(t.primaryOutput);
+    });
+
+    const triggerType = t.prefill.triggerType;
+
+    it("has a trigger type", () => {
+      expect(triggerType).toBeDefined();
+    });
+
+    if (triggerType === "schedule") {
+      it("schedule template has a valid cron of at least 15 minutes and no event type", () => {
+        expect(t.prefill.scheduleCron).toBeDefined();
+        expect(isValidCron(t.prefill.scheduleCron as string)).toBe(true);
+        // All starter cadences are constant-interval (daily/weekly), so the
+        // interval is computable and must clear the 15-minute floor.
+        const interval = cronIntervalMinutes(t.prefill.scheduleCron as string);
+        expect(interval).not.toBeNull();
+        expect(interval as number).toBeGreaterThanOrEqual(MIN_INTERVAL_MINUTES);
+        expect(t.prefill.eventType).toBeUndefined();
+      });
+    } else {
+      it("event template has an event type in its source's catalog", () => {
+        const allowed = eventTypesByTrigger.get(triggerType as string);
+        expect(allowed).toBeDefined();
+        expect(t.prefill.eventType).toBeDefined();
+        expect(allowed?.has(t.prefill.eventType as string)).toBe(true);
+      });
+    }
+
+    if (t.prefill.model) {
+      it("suggests a valid model id", () => {
+        expect(isValidModel(t.prefill.model as string)).toBe(true);
+      });
+    }
+
+    if (t.prefill.reasoningEffort) {
+      it("suggests a reasoning effort valid for the suggested/default model", () => {
+        const model = (t.prefill.model as string) ?? DEFAULT_MODEL;
+        expect(isValidReasoningEffort(model, t.prefill.reasoningEffort as string)).toBe(true);
+      });
+    }
+
+    if (t.primaryOutput === "slack") {
+      it("names a Slack channel in its instructions and carries a setup note", () => {
+        expect(t.prefill.instructions ?? "").toMatch(/#[a-z0-9-]+/i);
+        expect(t.setupNote).toBeTruthy();
+      });
+    }
+
+    if (t.prefill.triggerConfig?.conditions?.length) {
+      const conditions = t.prefill.triggerConfig.conditions;
+      it("has trigger conditions valid for its source", () => {
+        const source = TRIGGER_TYPE_TO_SOURCE[triggerType as AutomationTriggerType];
+        expect(source).toBeDefined();
+        const errors = validateConditions(
+          conditions,
+          source as NonNullable<typeof source>,
+          conditionRegistry
+        );
+        expect(errors).toEqual([]);
+      });
+    }
+  });
+});
+
+describe("getTemplateById", () => {
+  it("finds a template by id", () => {
+    const first = automationTemplates[0];
+    expect(getTemplateById(first.id)).toBe(first);
+  });
+
+  it("returns undefined for an unknown id", () => {
+    expect(getTemplateById("does-not-exist")).toBeUndefined();
+  });
+});
+
+describe("getTemplatesForCategory", () => {
+  it("returns only templates in that category, preserving catalog order", () => {
+    const popular = getTemplatesForCategory("popular");
+    expect(popular.length).toBeGreaterThan(0);
+    expect(popular.every((t) => t.categories.includes("popular"))).toBe(true);
+    const catalogIndices = popular.map((t) => automationTemplates.indexOf(t));
+    expect(catalogIndices).toEqual([...catalogIndices].sort((a, b) => a - b));
+  });
+});
+
+describe("getVisibleCategories", () => {
+  it("includes only categories that have at least one template", () => {
+    const visible = getVisibleCategories();
+    expect(visible.length).toBeGreaterThan(0);
+    for (const category of visible) {
+      expect(getTemplatesForCategory(category.id).length).toBeGreaterThan(0);
+    }
+  });
+
+  it("preserves the curated category order (a subsequence of TEMPLATE_CATEGORIES)", () => {
+    const curated = TEMPLATE_CATEGORIES.map((c) => c.id);
+    const visible = getVisibleCategories().map((c) => c.id);
+    let cursor = 0;
+    for (const id of curated) {
+      if (visible[cursor] === id) cursor++;
+    }
+    expect(cursor).toBe(visible.length);
+  });
+
+  it("starts with Popular", () => {
+    expect(getVisibleCategories()[0].id).toBe("popular");
+  });
+});
+
+describe("resolveTemplateInitialValues", () => {
+  it("keeps a suggested model that is enabled", () => {
+    const result = resolveTemplateInitialValues({ model: "anthropic/claude-opus-4-8" }, [
+      "anthropic/claude-opus-4-8",
+      DEFAULT_MODEL,
+    ]);
+    expect(result.model).toBe("anthropic/claude-opus-4-8");
+  });
+
+  it("coerces an unenabled suggested model to the default when the default is enabled", () => {
+    const result = resolveTemplateInitialValues({ model: "anthropic/claude-opus-4-8" }, [
+      DEFAULT_MODEL,
+    ]);
+    expect(result.model).toBe(DEFAULT_MODEL);
+  });
+
+  it("coerces to the first enabled model when neither suggestion nor default is enabled", () => {
+    const result = resolveTemplateInitialValues({ model: "anthropic/claude-opus-4-8" }, [
+      "openai/gpt-5.5",
+    ]);
+    expect(result.model).toBe("openai/gpt-5.5");
+  });
+
+  it("omits the model when the template does not suggest one", () => {
+    const result = resolveTemplateInitialValues({ name: "X" }, DEFAULT_ENABLED_MODELS as string[]);
+    expect(result.model).toBeUndefined();
+    expect(result.name).toBe("X");
+  });
+
+  it("drops a reasoning effort the resolved model does not support", () => {
+    const result = resolveTemplateInitialValues(
+      { model: "anthropic/claude-opus-4-8", reasoningEffort: "max" },
+      ["openai/gpt-5.5"]
+    );
+    expect(result.model).toBe("openai/gpt-5.5");
+    expect(result.reasoningEffort).toBeUndefined();
+  });
+
+  it("keeps a reasoning effort valid for the resolved model", () => {
+    const result = resolveTemplateInitialValues(
+      { model: "anthropic/claude-opus-4-8", reasoningEffort: "high" },
+      ["anthropic/claude-opus-4-8"]
+    );
+    expect(result.reasoningEffort).toBe("high");
+  });
+
+  it("passes non-model fields through untouched", () => {
+    const result = resolveTemplateInitialValues(
+      { name: "Find bugs", triggerType: "schedule", scheduleCron: "0 9 * * *" },
+      DEFAULT_ENABLED_MODELS as string[]
+    );
+    expect(result).toMatchObject({
+      name: "Find bugs",
+      triggerType: "schedule",
+      scheduleCron: "0 9 * * *",
+    });
+  });
+
+  it("resolves every catalog template to an enabled model", () => {
+    for (const t of automationTemplates) {
+      const result = resolveTemplateInitialValues(t.prefill, DEFAULT_ENABLED_MODELS as string[]);
+      if (result.model !== undefined) {
+        expect((DEFAULT_ENABLED_MODELS as readonly string[]).includes(result.model)).toBe(true);
+      }
+    }
+  });
+});

--- a/packages/web/src/lib/automation-templates.test.ts
+++ b/packages/web/src/lib/automation-templates.test.ts
@@ -28,7 +28,6 @@ const INSTRUCTIONS_MAX_LENGTH = 15000;
 const MIN_INTERVAL_MINUTES = 15;
 
 const CATEGORY_IDS = new Set(TEMPLATE_CATEGORIES.map((c) => c.id));
-const REPO_FIELDS = ["repoOwner", "repoName", "baseBranch"] as const;
 
 // Maps each trigger type to the set of event types its source actually supports.
 const eventTypesByTrigger = new Map<string, Set<string>>(
@@ -50,24 +49,14 @@ describe("automation templates catalog", () => {
   });
 
   describe.each(automationTemplates.map((t) => [t.id, t] as const))("template %s", (_id, t) => {
-    it("never prefills repository fields (AC-4)", () => {
-      for (const field of REPO_FIELDS) {
-        expect(t.prefill[field]).toBeUndefined();
-      }
-    });
-
-    it("omits scheduleTz so the user's timezone default applies", () => {
-      expect(t.prefill.scheduleTz).toBeUndefined();
-    });
-
     it("has non-empty title, description, and instructions", () => {
       expect(t.title.trim().length).toBeGreaterThan(0);
       expect(t.description.trim().length).toBeGreaterThan(0);
-      expect((t.prefill.instructions ?? "").trim().length).toBeGreaterThan(0);
+      expect(t.prefill.instructions.trim().length).toBeGreaterThan(0);
     });
 
     it("keeps instructions within the 15,000 character cap", () => {
-      expect((t.prefill.instructions ?? "").length).toBeLessThanOrEqual(INSTRUCTIONS_MAX_LENGTH);
+      expect(t.prefill.instructions.length).toBeLessThanOrEqual(INSTRUCTIONS_MAX_LENGTH);
     });
 
     it("declares only known categories", () => {
@@ -122,7 +111,7 @@ describe("automation templates catalog", () => {
 
     if (t.primaryOutput === "slack") {
       it("names a Slack channel in its instructions and carries a setup note", () => {
-        expect(t.prefill.instructions ?? "").toMatch(/#[a-z0-9-]+/i);
+        expect(t.prefill.instructions).toMatch(/#[a-z0-9-]+/i);
         expect(t.setupNote).toBeTruthy();
       });
     }

--- a/packages/web/src/lib/automation-templates.ts
+++ b/packages/web/src/lib/automation-templates.ts
@@ -1,0 +1,305 @@
+/**
+ * Static, code-defined catalog of automation "ideas" shown in the templates
+ * gallery. Adding a template pre-fills the existing Create Automation form
+ * (`/automations/new?template=<id>`); it never creates or runs anything on its
+ * own. Repository is intentionally never pre-filled so the existing
+ * repo-required-at-creation invariant is untouched.
+ */
+
+import {
+  DEFAULT_MODEL,
+  getValidModelOrDefault,
+  isValidReasoningEffort,
+} from "@open-inspect/shared";
+import type { AutomationFormValues } from "@/components/automations/automation-form";
+
+export type TemplateCategory =
+  | "popular"
+  | "code-review"
+  | "security"
+  | "incidents"
+  | "data-research";
+
+export interface AutomationTemplate {
+  /** Stable slug used in `?template=<id>`. */
+  id: string;
+  title: string;
+  description: string;
+  categories: TemplateCategory[];
+  primaryOutput: "pr" | "slack";
+  /**
+   * Static "needs setup" copy surfaced on the card. Present when the template
+   * requires configuration beyond picking a repository (Slack, Sentry secret,
+   * GitHub event delivery). Informational only — the gallery performs no checks.
+   */
+  setupNote?: string;
+  /**
+   * Values pre-filled into the create form. Never includes
+   * `repoOwner`/`repoName`/`baseBranch` (repo is always chosen by the user) and
+   * omits `scheduleTz` so the form's default (the user's timezone) applies.
+   */
+  prefill: Partial<AutomationFormValues>;
+}
+
+/** Curated category order. */
+export const TEMPLATE_CATEGORIES: ReadonlyArray<{ id: TemplateCategory; label: string }> = [
+  { id: "popular", label: "Popular" },
+  { id: "code-review", label: "Code Review" },
+  { id: "security", label: "Security" },
+  { id: "incidents", label: "Incidents" },
+  { id: "data-research", label: "Data & Research" },
+];
+
+// Conservative cadences to limit recurring cost. Both are ≥ the 15-minute floor.
+const DAILY_9AM = "0 9 * * *";
+const WEEKLY_MON_9AM = "0 9 * * 1";
+
+/**
+ * The starter catalog. Array order is curated and is the order templates appear
+ * within each category (no sort applied) — the Popular ordering relies on it.
+ */
+export const automationTemplates: AutomationTemplate[] = [
+  {
+    id: "find-bugs",
+    title: "Find bugs",
+    description:
+      "Analyze recent commits for high-severity correctness bugs and open a PR with safe fixes.",
+    categories: ["popular", "code-review"],
+    primaryOutput: "pr",
+    prefill: {
+      name: "Find bugs",
+      triggerType: "schedule",
+      scheduleCron: DAILY_9AM,
+      instructions:
+        "Review the most recent commits on this repository for high-severity correctness bugs — " +
+        "logic errors, off-by-one mistakes, unhandled error cases, race conditions, and incorrect " +
+        "edge-case handling — focusing on changes from roughly the last day.\n\n" +
+        "For each issue you are confident about, implement a minimal, well-scoped fix. Open a single " +
+        "pull request containing the fixes, with a clear description of each bug and why the change " +
+        "is correct. Do not make unrelated refactors. If you find no high-confidence bugs, do not " +
+        "open a pull request.",
+    },
+  },
+  {
+    id: "scan-vulnerabilities",
+    title: "Scan codebase for vulnerabilities",
+    description:
+      "Run a scheduled application-security review and post validated high-impact findings to Slack.",
+    categories: ["popular", "security"],
+    primaryOutput: "slack",
+    setupNote:
+      "Posts to Slack — requires Slack agent notifications enabled and the bot invited to the channel.",
+    prefill: {
+      name: "Scan codebase for vulnerabilities",
+      triggerType: "schedule",
+      scheduleCron: WEEKLY_MON_9AM,
+      // Security review benefits from a stronger model; coerced if the user hasn't enabled it.
+      model: "anthropic/claude-opus-4-8",
+      reasoningEffort: "high",
+      instructions:
+        "Perform an application-security review of this repository. Look for validated, exploitable " +
+        "vulnerabilities with a realistic attack path — for example injection (SQL/command/template), " +
+        "authentication or authorization flaws, insecure deserialization, SSRF, secrets committed to " +
+        "the repository, and unsafe handling of untrusted input.\n\n" +
+        "Only report issues you can substantiate with a concrete code path; avoid generic or " +
+        "theoretical findings. When finished, post a concise summary of the medium/high/critical " +
+        "findings (with file references and recommended fixes) to the #security Slack channel using " +
+        "the slack-notify tool. If you find nothing credible, post a short “no new findings” note.",
+    },
+  },
+  {
+    id: "add-test-coverage",
+    title: "Add test coverage",
+    description: "Find high-risk, under-tested logic in recent changes, add tests, and open a PR.",
+    categories: ["popular", "code-review"],
+    primaryOutput: "pr",
+    prefill: {
+      name: "Add test coverage",
+      triggerType: "schedule",
+      scheduleCron: WEEKLY_MON_9AM,
+      instructions:
+        "Identify high-risk application logic in this repository that lacks adequate automated test " +
+        "coverage, prioritizing recently changed files and core business logic.\n\n" +
+        "Add focused unit or integration tests that capture the important behaviors and edge cases, " +
+        "following the project's existing test conventions and framework, and make sure the new tests " +
+        "pass. Open a pull request with the added tests and a short summary of what they cover and why. " +
+        "Do not modify production code except where a trivial, clearly-correct change is required to " +
+        "make code testable.",
+    },
+  },
+  {
+    id: "review-new-prs",
+    title: "Review new PRs",
+    description:
+      "When a pull request is opened, review the diff and leave actionable review comments.",
+    categories: ["popular", "code-review"],
+    primaryOutput: "pr",
+    setupNote:
+      "Runs only when GitHub events reach this repo (GitHub App installed and the repo enabled for events).",
+    prefill: {
+      name: "Review new PRs",
+      triggerType: "github_event",
+      eventType: "pull_request.opened",
+      instructions:
+        "A pull request was opened; its number and details are shown above. Review it using the " +
+        "GitHub CLI, which is already authenticated in this environment.\n\n" +
+        "1. Read the changes with `gh pr diff <number>`.\n" +
+        "2. Assess them for correctness bugs, security issues, missing tests, and deviations from the " +
+        "project's conventions.\n" +
+        "3. Post your feedback as a review on the existing PR with " +
+        '`gh pr review <number> --comment --body "..."`. Lead with a short overall summary, then the ' +
+        "most important issues with file/line references. For line-anchored comments you may use " +
+        "`gh api repos/{owner}/{repo}/pulls/<number>/comments`.\n\n" +
+        "Be concise and prioritize high-impact issues; do not nitpick formatting that automated tooling " +
+        "already handles. Do not open a new pull request — comment on the existing one.",
+    },
+  },
+  {
+    id: "generate-docs",
+    title: "Generate docs",
+    description:
+      "Create or update developer docs for recently changed or under-documented code, via a PR.",
+    categories: ["code-review"],
+    primaryOutput: "pr",
+    prefill: {
+      name: "Generate docs",
+      triggerType: "schedule",
+      scheduleCron: WEEKLY_MON_9AM,
+      instructions:
+        "Improve developer documentation for this repository. Find recently changed or " +
+        "under-documented modules, public functions, and APIs, and create or update their " +
+        "documentation (docstrings, README sections, or docs/ pages) to match the project's existing " +
+        "style.\n\n" +
+        "Keep documentation accurate to the current code. Open a pull request with the documentation " +
+        "updates and a summary of what changed. Do not alter application behavior.",
+    },
+  },
+  {
+    id: "investigate-sentry",
+    title: "Investigate Sentry issues",
+    description: "When Sentry reports a new error, find the root cause and open a fix PR.",
+    categories: ["security", "incidents"],
+    primaryOutput: "pr",
+    setupNote:
+      "Requires a Sentry client secret at creation and completing the Sentry webhook setup shown afterward.",
+    prefill: {
+      name: "Investigate Sentry issues",
+      triggerType: "sentry",
+      eventType: "issue.created",
+      instructions:
+        "A Sentry error was reported (details are included above). Investigate the root cause in this " +
+        "codebase: trace the stack trace to the responsible code, determine why the error occurs, and " +
+        "identify the correct fix.\n\n" +
+        "Implement a minimal fix and open a pull request that explains the root cause and the change. " +
+        "If the issue cannot be safely fixed automatically, open a pull request with a clear write-up " +
+        "of the root cause and a proposed approach instead.",
+    },
+  },
+  {
+    id: "triage-ci-failures",
+    title: "Triage failed CI",
+    description:
+      "When a CI check suite fails, reproduce the failure locally, diagnose it, and report to Slack.",
+    categories: ["incidents"],
+    primaryOutput: "slack",
+    setupNote:
+      "Requires GitHub events for this repo and Slack agent notifications enabled with the bot in the channel.",
+    prefill: {
+      name: "Triage failed CI",
+      triggerType: "github_event",
+      eventType: "check_suite.completed",
+      // Only fire on failed suites — avoids spawning a run on every green build.
+      triggerConfig: {
+        conditions: [{ type: "check_conclusion", operator: "eq", value: "failure" }],
+      },
+      instructions:
+        "A CI check suite failed on this repository; the failing branch and commit are shown above.\n\n" +
+        "Diagnose it from the codebase (this environment cannot read GitHub Actions logs):\n" +
+        "1. Check out the failing commit/branch and run the project's build and test commands to " +
+        "reproduce the failure locally.\n" +
+        "2. Read the failing output and the related code to determine the most likely cause — a failing " +
+        "test, a flaky test, a build/config error, or a real regression.\n\n" +
+        "Post a concise summary — what failed, the most probable cause with file references, and a " +
+        "recommended next step — to the #ci-alerts Slack channel using the slack-notify tool. Do not " +
+        "open a pull request.",
+    },
+  },
+  {
+    id: "dependency-digest",
+    title: "Weekly dependency digest",
+    description:
+      "Summarize dependency updates, changelogs, and advisories and post the digest to Slack.",
+    categories: ["data-research"],
+    primaryOutput: "slack",
+    setupNote:
+      "Posts to Slack — requires Slack agent notifications enabled and the bot invited to the channel.",
+    prefill: {
+      name: "Weekly dependency digest",
+      triggerType: "schedule",
+      scheduleCron: WEEKLY_MON_9AM,
+      instructions:
+        "Produce a weekly dependency digest for this repository. Use the project's package manager to " +
+        "inspect dependencies — check for outdated packages and known security advisories (for example " +
+        "`npm outdated` and `npm audit`, or the equivalent for this stack) — and review notable " +
+        "changelog entries and deprecations for the versions in use.\n\n" +
+        "Summarize the most important items and any recommended upgrades (call out breaking changes), " +
+        "and post the digest to the #dependencies Slack channel using the slack-notify tool. Do not " +
+        "modify dependencies or open a pull request — this is a read-only report.",
+    },
+  },
+];
+
+export function getTemplateById(id: string): AutomationTemplate | undefined {
+  return automationTemplates.find((t) => t.id === id);
+}
+
+export function getTemplatesForCategory(category: TemplateCategory): AutomationTemplate[] {
+  return automationTemplates.filter((t) => t.categories.includes(category));
+}
+
+export function getVisibleCategories(): Array<{ id: TemplateCategory; label: string }> {
+  return TEMPLATE_CATEGORIES.filter((c) => getTemplatesForCategory(c.id).length > 0);
+}
+
+/**
+ * Build the `initialValues` passed to the create form from a template's
+ * pre-fill, resolving the suggested model against the user's enabled models.
+ *
+ * The model selector has no built-in fallback, so an unenabled suggested model
+ * would render a broken/unselected control and be submitted verbatim. This
+ * coerces the model to one that is actually enabled (preferring the suggestion,
+ * then the system default, then the first enabled model) and drops a suggested
+ * reasoning effort that the resolved model does not support.
+ */
+export function resolveTemplateInitialValues(
+  prefill: Partial<AutomationFormValues>,
+  enabledModels: string[]
+): Partial<AutomationFormValues> {
+  const { model, reasoningEffort, ...rest } = prefill;
+  const result: Partial<AutomationFormValues> = { ...rest };
+
+  // The model the form will actually use. When no model is suggested, the form
+  // falls back to DEFAULT_MODEL, so reasoning is validated against that.
+  let effectiveModel: string = DEFAULT_MODEL;
+
+  if (model) {
+    const enabled = new Set(enabledModels);
+    // getValidModelOrDefault already guarantees a valid model id; the branches
+    // below only resolve the *enabled* dimension (prefer the suggestion, then
+    // the system default, then the first enabled model).
+    const coerced = getValidModelOrDefault(model);
+    const chosen = enabled.has(coerced)
+      ? coerced
+      : enabled.has(DEFAULT_MODEL)
+        ? DEFAULT_MODEL
+        : (enabledModels[0] ?? DEFAULT_MODEL);
+    result.model = chosen;
+    effectiveModel = chosen;
+  }
+
+  if (reasoningEffort && isValidReasoningEffort(effectiveModel, reasoningEffort)) {
+    result.reasoningEffort = reasoningEffort;
+  }
+
+  return result;
+}

--- a/packages/web/src/lib/automation-templates.ts
+++ b/packages/web/src/lib/automation-templates.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_MODEL,
   getValidModelOrDefault,
   isValidReasoningEffort,
+  type AutomationTriggerType,
 } from "@open-inspect/shared";
 import type { AutomationFormValues } from "@/components/automations/automation-form";
 
@@ -19,6 +20,22 @@ export type TemplateCategory =
   | "security"
   | "incidents"
   | "data-research";
+
+/**
+ * The create-form fields a template pre-fills. Repository fields and
+ * `scheduleTz` are statically excluded (repo is always the user's choice; the
+ * form's timezone default applies), and `name`/`triggerType`/`instructions` are
+ * required so every template is complete by construction — making these
+ * invariants compile-time rather than test-only.
+ */
+export type AutomationTemplatePrefill = Omit<
+  Partial<AutomationFormValues>,
+  "repoOwner" | "repoName" | "baseBranch" | "scheduleTz"
+> & {
+  name: string;
+  triggerType: AutomationTriggerType;
+  instructions: string;
+};
 
 export interface AutomationTemplate {
   /** Stable slug used in `?template=<id>`. */
@@ -33,12 +50,7 @@ export interface AutomationTemplate {
    * GitHub event delivery). Informational only — the gallery performs no checks.
    */
   setupNote?: string;
-  /**
-   * Values pre-filled into the create form. Never includes
-   * `repoOwner`/`repoName`/`baseBranch` (repo is always chosen by the user) and
-   * omits `scheduleTz` so the form's default (the user's timezone) applies.
-   */
-  prefill: Partial<AutomationFormValues>;
+  prefill: AutomationTemplatePrefill;
 }
 
 /** Curated category order. */


### PR DESCRIPTION
## Summary

Adds a **template gallery** to Automations so users can start from a pre-built "idea" instead of a blank form. Clicking **Add** opens the existing Create Automation form pre-filled with a template's trigger, schedule/event, instructions, and model — the user just picks a repository and creates.

**Frontend-only and minimal:** a static, code-defined catalog drives everything through the existing create flow. No control-plane, D1, scheduler, or `AutomationForm` changes; no new automation fields, columns, or migrations.

## What's included

- **Gallery** at `/automations/templates` — categorized card grid (Popular by default), each card showing a trigger → output icon pair, description, optional setup note, and an **Add** button. Empty categories are hidden; switching categories re-filters without navigation.
- **Pre-fill flow** — `Add` → `/automations/new?template=<id>`. The create page is split behind `<Suspense>` (required for `useSearchParams` in Next 16), looks the template up in the static catalog, **coerces the suggested model against the user's enabled set**, and shows a "Prefilled from &lt;template&gt;" hint. **Repository is intentionally never pre-filled**, preserving the repo-required-at-creation invariant.
- **Entry points** — a "Browse templates" action on the list page plus net-new empty-state CTAs.
- **Starter catalog** — 8 templates across Popular / Code Review / Security / Incidents / Data & Research:
  - **Find bugs**, **Add test coverage**, **Generate docs** — Schedule → PR
  - **Review new PRs** — PR opened → review via `gh`
  - **Investigate Sentry issues** — Sentry error → fix PR
  - **Scan codebase for vulnerabilities**, **Weekly dependency digest** — Schedule → Slack
  - **Triage failed CI** — failed check suite → Slack
- A new `SentryIcon`.

## Design notes

- **Slack** templates use the existing `slack-notify` tool by naming the channel in the instructions — no Tools section, channel picker, or `conversations.list`.
- The template prompts were **audited against actual automation-agent runtime capabilities**:
  - PR-review and CI-triage templates use `gh` (authenticated via the GitHub App installation token) where there's no dedicated tool.
  - `triage-ci-failures` **reproduces the failure locally** rather than reading Actions logs (the App lacks `Actions: read`), and is gated with a `check_conclusion = failure` condition so it only fires on red builds, not every green one.

## Testing

- **442 web tests pass** (96 new): catalog invariants (no repo fields, valid trigger/event/cron ≥15 min, model coercion, condition validation), gallery rendering/filtering, create-page pre-fill + model coercion, and empty-state CTAs.
- `typecheck`, `eslint`, and `prettier` are clean; production build succeeds (`/automations/templates` and `/automations/new` prerender statically).

## Notes for reviewers

- Several templates need setup before they run (Slack enablement, a Sentry secret, GitHub event delivery). This is surfaced as static setup-note copy on the cards — the gallery performs no connection checks and introduces no new failure modes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Automation templates page with a searchable/browseable gallery of pre-configured templates.
  * “Browse templates” is now available from the Automations page.
  * Starting from a template now pre-fills the automation creation form and shows a “Prefilled from the … template” notice.
* **Bug Fixes**
  * Ensures template-suggested models are coerced to an enabled model (avoids showing unsupported options), with loading feedback while model resolution completes.
* **Tests**
  * Added/expanded UI and catalog tests for templates, gallery filtering, and template-driven form prefilling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->