### PR TITLE
refactor(web): centralize model normalization in AutomationForm

### DIFF
--- a/packages/web/src/app/(app)/automations/new/page.tsx
+++ b/packages/web/src/app/(app)/automations/new/page.tsx
@@ -8,8 +8,7 @@ import {
   type AutomationFormValues,
 } from "@/components/automations/automation-form";
 import { WebhookConfig } from "@/components/automations/webhook-config";
-import { useEnabledModels } from "@/hooks/use-enabled-models";
-import { getTemplateById, resolveTemplateInitialValues } from "@/lib/automation-templates";
+import { getTemplateById } from "@/lib/automation-templates";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { SidebarIcon, BackIcon } from "@/components/ui/icons";
@@ -20,7 +19,6 @@ function NewAutomationContent() {
   const { isOpen, toggle } = useSidebarContext();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { enabledModels, loading: loadingModels } = useEnabledModels();
 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
@@ -32,16 +30,10 @@ function NewAutomationContent() {
   } | null>(null);
 
   // A template id (from the gallery) pre-fills the form. Repository is never
-  // pre-filled, so the repo-required-at-creation invariant is untouched.
+  // pre-filled, so the repo-required-at-creation invariant is untouched. The
+  // form coerces a template's suggested model against the user's enabled set.
   const template = getTemplateById(searchParams.get("template") ?? "");
-
-  // The model selector has no built-in fallback, so a suggested model must be
-  // resolved against the user's enabled set before the form mounts (it reads
-  // initialValues once). Only block on the enabled list when one is suggested.
-  const needsModelResolution = Boolean(template?.prefill.model);
-  const initialValues: Partial<AutomationFormValues> | undefined = template
-    ? resolveTemplateInitialValues(template.prefill, enabledModels)
-    : undefined;
+  const initialValues: Partial<AutomationFormValues> | undefined = template?.prefill;
 
   const handleSubmit = async (values: AutomationFormValues) => {
     setSubmitting(true);
@@ -178,18 +170,12 @@ function NewAutomationContent() {
             </div>
           )}
 
-          {needsModelResolution && loadingModels ? (
-            <div className="flex justify-center py-12">
-              <div className="animate-spin rounded-full h-6 w-6 border-2 border-current border-t-transparent text-muted-foreground" />
-            </div>
-          ) : (
-            <AutomationForm
-              mode="create"
-              initialValues={initialValues}
-              onSubmit={handleSubmit}
-              submitting={submitting}
-            />
-          )}
+          <AutomationForm
+            mode="create"
+            initialValues={initialValues}
+            onSubmit={handleSubmit}
+            submitting={submitting}
+          />
         </div>
       </div>
     </div>

--- a/packages/web/src/components/automations/automation-form.test.tsx
+++ b/packages/web/src/components/automations/automation-form.test.tsx
@@ -15,8 +15,10 @@ afterEach(cleanup);
 
 // Mutable per-test enabled set; the hoisted use-enabled-models mock closes over it.
 let enabledModelsValue: string[] = ["openai/gpt-5.4"];
+let loadingModelsValue = false;
 beforeEach(() => {
   enabledModelsValue = ["openai/gpt-5.4"];
+  loadingModelsValue = false;
 });
 
 vi.mock("@/hooks/use-repos", () => ({
@@ -52,7 +54,7 @@ vi.mock("@/hooks/use-enabled-models", () => ({
         models: [{ id: "openai/gpt-5.4", name: "GPT-5.4", description: "Test model" }],
       },
     ],
-    loading: false,
+    loading: loadingModelsValue,
   }),
 }));
 
@@ -266,5 +268,24 @@ describe("model normalization", () => {
     const onSubmit = submitForm({ model: "anthropic/claude-opus-4-8", reasoningEffort: "high" });
     expect(onSubmit.mock.calls[0][0].model).toBe("openai/gpt-5.4");
     expect(onSubmit.mock.calls[0][0].reasoningEffort).toBe("high");
+  });
+
+  it("does not submit while enabled models are still loading", () => {
+    loadingModelsValue = true;
+    const onSubmit = submitForm({ model: "anthropic/claude-opus-4-8" });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("disables the submit button while enabled models are still loading", () => {
+    loadingModelsValue = true;
+    render(
+      <AutomationForm
+        mode="edit"
+        submitting={false}
+        onSubmit={vi.fn()}
+        initialValues={{ ...baseInitialValues, model: "anthropic/claude-opus-4-8" }}
+      />
+    );
+    expect(screen.getByRole("button", { name: "Save Changes" })).toBeDisabled();
   });
 });

--- a/packages/web/src/components/automations/automation-form.test.tsx
+++ b/packages/web/src/components/automations/automation-form.test.tsx
@@ -1,16 +1,23 @@
 // @vitest-environment jsdom
 /// <reference types="@testing-library/jest-dom" />
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import type { ReactNode } from "react";
-import { AutomationForm } from "./automation-form";
+import { DEFAULT_MODEL } from "@open-inspect/shared";
+import { AutomationForm, type AutomationFormValues } from "./automation-form";
 import { CronPicker } from "./cron-picker";
 
 expect.extend(matchers);
 
 afterEach(cleanup);
+
+// Mutable per-test enabled set; the hoisted use-enabled-models mock closes over it.
+let enabledModelsValue: string[] = ["openai/gpt-5.4"];
+beforeEach(() => {
+  enabledModelsValue = ["openai/gpt-5.4"];
+});
 
 vi.mock("@/hooks/use-repos", () => ({
   useRepos: () => ({
@@ -38,12 +45,14 @@ vi.mock("@/hooks/use-branches", () => ({
 
 vi.mock("@/hooks/use-enabled-models", () => ({
   useEnabledModels: () => ({
+    enabledModels: enabledModelsValue,
     enabledModelOptions: [
       {
         category: "OpenAI",
         models: [{ id: "openai/gpt-5.4", name: "GPT-5.4", description: "Test model" }],
       },
     ],
+    loading: false,
   }),
 }));
 
@@ -200,5 +209,62 @@ describe("instructions character counter", () => {
     const counter = screen.getByText(/15,000 \/ 15,000/);
     expect(counter).toHaveClass("text-destructive");
     expect(counter).toHaveTextContent("Maximum length reached.");
+  });
+});
+
+describe("model normalization", () => {
+  const baseInitialValues = {
+    name: "Daily review",
+    repoOwner: "open-inspect",
+    repoName: "background-agents",
+    baseBranch: "main",
+    scheduleCron: "0 9 * * *",
+    scheduleTz: "UTC",
+    instructions: "Review the repo.",
+    triggerType: "schedule" as const,
+  };
+
+  const submitForm = (initialValues: Partial<AutomationFormValues>) => {
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <AutomationForm
+        mode="edit"
+        submitting={false}
+        onSubmit={onSubmit}
+        initialValues={{ ...baseInitialValues, ...initialValues }}
+      />
+    );
+    fireEvent.submit(container.querySelector("form")!);
+    return onSubmit;
+  };
+
+  it("coerces a disabled initial model to an enabled one before submit", () => {
+    const onSubmit = submitForm({ model: "anthropic/claude-opus-4-8" });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0].model).toBe("openai/gpt-5.4");
+  });
+
+  it("leaves an enabled initial model untouched", () => {
+    const onSubmit = submitForm({ model: "openai/gpt-5.4" });
+    expect(onSubmit.mock.calls[0][0].model).toBe("openai/gpt-5.4");
+  });
+
+  it("prefers the enabled default when the initial model is disabled", () => {
+    enabledModelsValue = [DEFAULT_MODEL, "openai/gpt-5.4"];
+    const onSubmit = submitForm({ model: "anthropic/claude-opus-4-8" });
+    expect(onSubmit.mock.calls[0][0].model).toBe(DEFAULT_MODEL);
+  });
+
+  it("drops a reasoning effort the coerced model does not support", () => {
+    // gpt-5.4 supports none/low/medium/high/xhigh but not "max".
+    const onSubmit = submitForm({ model: "anthropic/claude-opus-4-8", reasoningEffort: "max" });
+    expect(onSubmit.mock.calls[0][0].model).toBe("openai/gpt-5.4");
+    expect(onSubmit.mock.calls[0][0].reasoningEffort).toBeNull();
+  });
+
+  it("keeps a reasoning effort the coerced model supports", () => {
+    const onSubmit = submitForm({ model: "anthropic/claude-opus-4-8", reasoningEffort: "high" });
+    expect(onSubmit.mock.calls[0][0].model).toBe("openai/gpt-5.4");
+    expect(onSubmit.mock.calls[0][0].reasoningEffort).toBe("high");
   });
 });

--- a/packages/web/src/components/automations/automation-form.tsx
+++ b/packages/web/src/components/automations/automation-form.tsx
@@ -16,6 +16,7 @@ import { useRepos } from "@/hooks/use-repos";
 import { useBranches } from "@/hooks/use-branches";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
 import { formatModelNameLower } from "@/lib/format";
+import { resolveEnabledModel } from "@/lib/model-selection";
 import { Combobox, type ComboboxGroup } from "@/components/ui/combobox";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -103,7 +104,7 @@ interface AutomationFormProps {
 
 export function AutomationForm({ mode, initialValues, onSubmit, submitting }: AutomationFormProps) {
   const { repos, loading: loadingRepos } = useRepos();
-  const { enabledModelOptions } = useEnabledModels();
+  const { enabledModels, enabledModelOptions, loading: loadingModels } = useEnabledModels();
 
   const [name, setName] = useState(initialValues?.name ?? "");
   const [selectedRepo, setSelectedRepo] = useState(
@@ -157,6 +158,21 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
       setEventTypeError("");
     }
   }, [showEventTypeSelector, eventType]);
+
+  // Once the user's enabled models load, coerce the selected model to one they
+  // can actually pick. The selector only lists enabled models, so a disabled
+  // default (blank create), a disabled saved model (edit), or a disabled
+  // template suggestion would otherwise show an unselected control and submit
+  // verbatim. Mirrors the reasoning reset the selector's onChange performs.
+  useEffect(() => {
+    if (loadingModels) return;
+    const resolved = resolveEnabledModel(model, enabledModels);
+    if (resolved === model) return;
+    setModel(resolved);
+    setReasoningEffort((current) =>
+      current && !isValidReasoningEffort(resolved, current) ? "" : current
+    );
+  }, [loadingModels, enabledModels, model]);
 
   const handleRepoChange = useCallback(
     (repoFullName: string) => {

--- a/packages/web/src/components/automations/automation-form.tsx
+++ b/packages/web/src/components/automations/automation-form.tsx
@@ -136,6 +136,17 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
   const isSchedule = triggerType === "schedule";
   const isScheduleValid = !isSchedule || isValidCron(scheduleCron);
 
+  // The model we display and submit. The selector only lists enabled models, so
+  // a disabled default (blank create), a disabled saved model (edit), or a
+  // disabled template suggestion is coerced to an enabled one. Until preferences
+  // load we can't know the enabled set, so the raw selection stands and submit
+  // is blocked — keeping display, reasoning, and the payload in agreement
+  // without relying on a post-load effect.
+  const resolvedModel = useMemo(
+    () => (loadingModels ? model : resolveEnabledModel(model, enabledModels)),
+    [loadingModels, model, enabledModels]
+  );
+
   const triggerMetadata = useMemo(
     () => triggerSources.find((sourceDef) => sourceDef.triggerType === triggerType),
     [triggerType]
@@ -159,21 +170,6 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
     }
   }, [showEventTypeSelector, eventType]);
 
-  // Once the user's enabled models load, coerce the selected model to one they
-  // can actually pick. The selector only lists enabled models, so a disabled
-  // default (blank create), a disabled saved model (edit), or a disabled
-  // template suggestion would otherwise show an unselected control and submit
-  // verbatim. Mirrors the reasoning reset the selector's onChange performs.
-  useEffect(() => {
-    if (loadingModels) return;
-    const resolved = resolveEnabledModel(model, enabledModels);
-    if (resolved === model) return;
-    setModel(resolved);
-    setReasoningEffort((current) =>
-      current && !isValidReasoningEffort(resolved, current) ? "" : current
-    );
-  }, [loadingModels, enabledModels, model]);
-
   const handleRepoChange = useCallback(
     (repoFullName: string) => {
       setSelectedRepo(repoFullName);
@@ -185,6 +181,9 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    // Block until enabled models load: resolvedModel can't coerce against an
+    // unknown set, so submitting now could persist a disabled model.
+    if (loadingModels) return;
     if (!name.trim() || !selectedRepo || !instructions.trim() || !isScheduleValid) return;
     if (triggerType === "sentry" && mode === "create" && !sentryClientSecret.trim()) return;
     if (showEventTypeSelector && !eventType) {
@@ -197,8 +196,11 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
       repoOwner,
       repoName,
       baseBranch,
-      model,
-      reasoningEffort: reasoningEffort || null,
+      model: resolvedModel,
+      reasoningEffort:
+        reasoningEffort && isValidReasoningEffort(resolvedModel, reasoningEffort)
+          ? reasoningEffort
+          : null,
       scheduleCron,
       scheduleTz,
       instructions: instructions.trim(),
@@ -232,7 +234,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
   const displayRepoName = selectedRepoObj
     ? selectedRepoObj.name
     : selectedRepo || "Select repository";
-  const reasoningConfig = getReasoningConfig(model);
+  const reasoningConfig = getReasoningConfig(resolvedModel);
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
@@ -347,7 +349,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
       <div>
         <label className="block text-sm font-medium text-foreground mb-1.5">Model</label>
         <Combobox
-          value={model}
+          value={resolvedModel}
           onChange={(nextModel) => {
             setModel(nextModel);
             if (reasoningEffort && !isValidReasoningEffort(nextModel, reasoningEffort)) {
@@ -368,7 +370,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
           triggerClassName="flex w-full items-center gap-1.5 px-3 py-2 text-sm border border-border bg-input text-foreground hover:border-foreground/20 transition"
         >
           <ModelIcon className="w-3.5 h-3.5 text-muted-foreground" />
-          <span className="truncate flex-1 text-left">{formatModelNameLower(model)}</span>
+          <span className="truncate flex-1 text-left">{formatModelNameLower(resolvedModel)}</span>
           <ChevronDownIcon className="w-3 h-3 text-muted-foreground" />
         </Combobox>
         <FieldDescription>
@@ -561,6 +563,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
           type="submit"
           disabled={
             submitting ||
+            loadingModels ||
             !name.trim() ||
             !selectedRepo ||
             !instructions.trim() ||

--- a/packages/web/src/lib/automation-templates.test.ts
+++ b/packages/web/src/lib/automation-templates.test.ts
@@ -8,7 +8,6 @@ import {
   validateConditions,
   conditionRegistry,
   TRIGGER_TYPE_TO_SOURCE,
-  DEFAULT_ENABLED_MODELS,
   DEFAULT_MODEL,
   type AutomationTriggerType,
 } from "@open-inspect/shared";
@@ -18,7 +17,6 @@ import {
   getTemplateById,
   getTemplatesForCategory,
   getVisibleCategories,
-  resolveTemplateInitialValues,
 } from "./automation-templates";
 
 // Keep in sync with INSTRUCTIONS_MAX_LENGTH in automation-form.tsx /
@@ -174,73 +172,5 @@ describe("getVisibleCategories", () => {
 
   it("starts with Popular", () => {
     expect(getVisibleCategories()[0].id).toBe("popular");
-  });
-});
-
-describe("resolveTemplateInitialValues", () => {
-  it("keeps a suggested model that is enabled", () => {
-    const result = resolveTemplateInitialValues({ model: "anthropic/claude-opus-4-8" }, [
-      "anthropic/claude-opus-4-8",
-      DEFAULT_MODEL,
-    ]);
-    expect(result.model).toBe("anthropic/claude-opus-4-8");
-  });
-
-  it("coerces an unenabled suggested model to the default when the default is enabled", () => {
-    const result = resolveTemplateInitialValues({ model: "anthropic/claude-opus-4-8" }, [
-      DEFAULT_MODEL,
-    ]);
-    expect(result.model).toBe(DEFAULT_MODEL);
-  });
-
-  it("coerces to the first enabled model when neither suggestion nor default is enabled", () => {
-    const result = resolveTemplateInitialValues({ model: "anthropic/claude-opus-4-8" }, [
-      "openai/gpt-5.5",
-    ]);
-    expect(result.model).toBe("openai/gpt-5.5");
-  });
-
-  it("omits the model when the template does not suggest one", () => {
-    const result = resolveTemplateInitialValues({ name: "X" }, DEFAULT_ENABLED_MODELS as string[]);
-    expect(result.model).toBeUndefined();
-    expect(result.name).toBe("X");
-  });
-
-  it("drops a reasoning effort the resolved model does not support", () => {
-    const result = resolveTemplateInitialValues(
-      { model: "anthropic/claude-opus-4-8", reasoningEffort: "max" },
-      ["openai/gpt-5.5"]
-    );
-    expect(result.model).toBe("openai/gpt-5.5");
-    expect(result.reasoningEffort).toBeUndefined();
-  });
-
-  it("keeps a reasoning effort valid for the resolved model", () => {
-    const result = resolveTemplateInitialValues(
-      { model: "anthropic/claude-opus-4-8", reasoningEffort: "high" },
-      ["anthropic/claude-opus-4-8"]
-    );
-    expect(result.reasoningEffort).toBe("high");
-  });
-
-  it("passes non-model fields through untouched", () => {
-    const result = resolveTemplateInitialValues(
-      { name: "Find bugs", triggerType: "schedule", scheduleCron: "0 9 * * *" },
-      DEFAULT_ENABLED_MODELS as string[]
-    );
-    expect(result).toMatchObject({
-      name: "Find bugs",
-      triggerType: "schedule",
-      scheduleCron: "0 9 * * *",
-    });
-  });
-
-  it("resolves every catalog template to an enabled model", () => {
-    for (const t of automationTemplates) {
-      const result = resolveTemplateInitialValues(t.prefill, DEFAULT_ENABLED_MODELS as string[]);
-      if (result.model !== undefined) {
-        expect((DEFAULT_ENABLED_MODELS as readonly string[]).includes(result.model)).toBe(true);
-      }
-    }
   });
 });

--- a/packages/web/src/lib/automation-templates.ts
+++ b/packages/web/src/lib/automation-templates.ts
@@ -6,12 +6,7 @@
  * repo-required-at-creation invariant is untouched.
  */
 
-import {
-  DEFAULT_MODEL,
-  getValidModelOrDefault,
-  isValidReasoningEffort,
-  type AutomationTriggerType,
-} from "@open-inspect/shared";
+import type { AutomationTriggerType } from "@open-inspect/shared";
 import type { AutomationFormValues } from "@/components/automations/automation-form";
 
 export type TemplateCategory =
@@ -271,47 +266,4 @@ export function getTemplatesForCategory(category: TemplateCategory): AutomationT
 
 export function getVisibleCategories(): Array<{ id: TemplateCategory; label: string }> {
   return TEMPLATE_CATEGORIES.filter((c) => getTemplatesForCategory(c.id).length > 0);
-}
-
-/**
- * Build the `initialValues` passed to the create form from a template's
- * pre-fill, resolving the suggested model against the user's enabled models.
- *
- * The model selector has no built-in fallback, so an unenabled suggested model
- * would render a broken/unselected control and be submitted verbatim. This
- * coerces the model to one that is actually enabled (preferring the suggestion,
- * then the system default, then the first enabled model) and drops a suggested
- * reasoning effort that the resolved model does not support.
- */
-export function resolveTemplateInitialValues(
-  prefill: Partial<AutomationFormValues>,
-  enabledModels: string[]
-): Partial<AutomationFormValues> {
-  const { model, reasoningEffort, ...rest } = prefill;
-  const result: Partial<AutomationFormValues> = { ...rest };
-
-  // The model the form will actually use. When no model is suggested, the form
-  // falls back to DEFAULT_MODEL, so reasoning is validated against that.
-  let effectiveModel: string = DEFAULT_MODEL;
-
-  if (model) {
-    const enabled = new Set(enabledModels);
-    // getValidModelOrDefault already guarantees a valid model id; the branches
-    // below only resolve the *enabled* dimension (prefer the suggestion, then
-    // the system default, then the first enabled model).
-    const coerced = getValidModelOrDefault(model);
-    const chosen = enabled.has(coerced)
-      ? coerced
-      : enabled.has(DEFAULT_MODEL)
-        ? DEFAULT_MODEL
-        : (enabledModels[0] ?? DEFAULT_MODEL);
-    result.model = chosen;
-    effectiveModel = chosen;
-  }
-
-  if (reasoningEffort && isValidReasoningEffort(effectiveModel, reasoningEffort)) {
-    result.reasoningEffort = reasoningEffort;
-  }
-
-  return result;
 }

--- a/packages/web/src/lib/model-selection.test.ts
+++ b/packages/web/src/lib/model-selection.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { DEFAULT_MODEL } from "@open-inspect/shared";
+import { resolveEnabledModel } from "./model-selection";
+
+describe("resolveEnabledModel", () => {
+  it("keeps the desired model when it is enabled", () => {
+    expect(
+      resolveEnabledModel("anthropic/claude-opus-4-8", ["anthropic/claude-opus-4-8", DEFAULT_MODEL])
+    ).toBe("anthropic/claude-opus-4-8");
+  });
+
+  it("normalizes a bare model id before checking the enabled set", () => {
+    expect(resolveEnabledModel("claude-opus-4-8", ["anthropic/claude-opus-4-8"])).toBe(
+      "anthropic/claude-opus-4-8"
+    );
+  });
+
+  it("falls back to the default when the desired model is not enabled", () => {
+    expect(resolveEnabledModel("anthropic/claude-opus-4-8", [DEFAULT_MODEL])).toBe(DEFAULT_MODEL);
+  });
+
+  it("falls back to the first enabled model when neither desired nor default is enabled", () => {
+    expect(resolveEnabledModel("anthropic/claude-opus-4-8", ["openai/gpt-5.5"])).toBe(
+      "openai/gpt-5.5"
+    );
+  });
+
+  it("coerces an unknown model id to the enabled default", () => {
+    expect(resolveEnabledModel("not-a-real-model", [DEFAULT_MODEL, "openai/gpt-5.5"])).toBe(
+      DEFAULT_MODEL
+    );
+  });
+
+  it("falls back to the default when no models are enabled", () => {
+    expect(resolveEnabledModel("anthropic/claude-opus-4-8", [])).toBe(DEFAULT_MODEL);
+  });
+});

--- a/packages/web/src/lib/model-selection.ts
+++ b/packages/web/src/lib/model-selection.ts
@@ -1,0 +1,20 @@
+import { DEFAULT_MODEL, getValidModelOrDefault } from "@open-inspect/shared";
+
+/**
+ * Pick the model the automation form should actually use, given a desired model
+ * (a blank-create default, a saved automation's model, or a template
+ * suggestion) and the user's currently enabled models.
+ *
+ * The form's model selector only lists enabled models, so a model the user has
+ * not enabled would render an unselected control and be submitted verbatim. This
+ * coerces to a model that is actually enabled, preferring the desired model,
+ * then the system default, then the first enabled model. `getValidModelOrDefault`
+ * also normalizes legacy/bare ids and falls back for unknown ones.
+ */
+export function resolveEnabledModel(model: string, enabledModels: string[]): string {
+  const desired = getValidModelOrDefault(model);
+  const enabled = new Set(enabledModels);
+  if (enabled.has(desired)) return desired;
+  if (enabled.has(DEFAULT_MODEL)) return DEFAULT_MODEL;
+  return enabledModels[0] ?? DEFAULT_MODEL;
+}


### PR DESCRIPTION
Closes #799.

## Problem

`AutomationForm` initialized its model selector to `initialValues?.model ?? DEFAULT_MODEL` with no fallback to the user's *enabled* models, and read `initialValues` only on mount. Only the template-prefill flow resolved a possibly-unenabled model, and it did so at the call site (`new/page.tsx`), gating render on the enabled-models load. The blank-create and edit flows could still show/submit a disabled model — e.g. the system default, or a saved model the user later disabled — since the selector only lists enabled models.

## Change

Move the coercion into the form so every create/edit/template path is consistent:

- New pure helper `resolveEnabledModel(model, enabledModels)` (extracted from the old template resolver): prefer the desired model, then the system default, then the first enabled model; normalizes legacy/unknown ids.
- `AutomationForm` coerces the selected model once enabled models load, and re-validates reasoning effort against the resolved model (mirroring the selector's existing `onChange`). Implemented as an effect, consistent with the form's existing event-type correction effects.
- `new/page.tsx` now passes `template.prefill` straight through — no call-site resolver, no loading gate.
- Removed `resolveTemplateInitialValues`.

## Tests

- `model-selection.test.ts` — helper units (enabled / normalize / default / first-enabled / unknown / empty).
- `automation-form.test.tsx` — coercion + reasoning drop/keep through the form on submit (blank-default, edit, and template cases).
- Existing `new/page.test.tsx` end-to-end coercion test passes unchanged.

typecheck ✓ · eslint ✓ · prettier ✓ · 429 web tests ✓ · `next build` ✓ (`/automations/new` + `/automations/templates` still static)

Frontend-only; `@open-inspect/shared` untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Automation creation form now renders sooner by removing the wait for enabled model resolution before showing the form.

* **Bug Fixes**
  * If the chosen automation model isn’t available, the form now automatically switches to a valid enabled alternative.
  * Reasoning effort is now cleared when the selected model doesn’t support it, preventing invalid combinations.
  * Submission is disabled while enabled models are still loading to avoid incorrect payloads.

* **Tests**
  * Updated automation and template-related test coverage to reflect the new model/initial-value behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->