### PR TITLE
refactor(slack): make control plane the sole routing-rule normalizer

### DIFF
--- a/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
@@ -403,10 +403,12 @@ describe("SlackIntegrationSettings", () => {
       const body = JSON.parse(fetchMock.mock.calls[0][1].body as string) as {
         settings: SlackGlobalConfig;
       };
+      // The UI sends the keyword as-typed (trimmed); the control plane is the
+      // sole normalizer that lowercases on write.
       expect(body.settings.defaults).toEqual({
         agentNotificationsEnabled: true,
         mentionsPolicy: "allow",
-        routingRules: [{ keyword: "frontend", target: "acme/web" }],
+        routingRules: [{ keyword: "Frontend", target: "acme/web" }],
       });
     });
 

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
@@ -6,7 +6,6 @@ import { toast } from "sonner";
 import {
   DEFAULT_MENTIONS_POLICY,
   MAX_SLACK_ROUTING_RULES,
-  normalizeRoutingRules,
   type EnrichedRepository,
   type SlackGlobalConfig,
   type SlackGlobalSettings,
@@ -544,13 +543,12 @@ function RoutingRulesSection({
     }
 
     setSaving(true);
-    // normalizeRoutingRules lowercases and de-dupes to match the stored shape;
-    // its cap is a no-op here since over-limit drafts are rejected above, and
-    // the control plane remains the canonical validator.
-    const normalized = normalizeRoutingRules(trimmed);
+    // Send the validated draft as-is and let the control-plane validator be the
+    // single canonical normalizer (lowercase/de-dupe) on write. The UI's job is
+    // to validate and present, not to own the stored shape.
     const body: SlackGlobalConfig = {
       defaults: mergedGlobalDefaults(settings, {
-        routingRules: normalized.length > 0 ? normalized : undefined,
+        routingRules: trimmed.length > 0 ? trimmed : undefined,
       }),
     };
 


### PR DESCRIPTION
## Summary

Small follow-up to the deep-review boundary feedback on #797. The Slack routing-rules UI no longer reuses the storage normalizer (`normalizeRoutingRules`) on the save path.

Before, `handleSave` both validated the draft **and** lowercased/de-duped it client-side before the PUT — duplicating the control plane's normalization across the UI/storage boundary. Now the UI's job is purely **validate + present**, and the control-plane validator is the **single canonical normalizer** that lowercases and de-dupes on write.

## What changed

- `handleSave` sends the validated draft (`trimmed`, with the existing empty-field and over-limit guards) directly, instead of `normalizeRoutingRules(trimmed)`.
- Dropped the web component's dependency on the `normalizeRoutingRules` import.
- Updated the one test that asserted UI-side lowercasing to expect the keyword as-typed; the control plane lowercases on write (already covered by its own validation tests).

No change to stored data — keywords are still lowercased and de-duped, just canonically in one place. The only visible difference: a freshly-typed mixed-case keyword shows as-typed until the post-save SWR revalidation re-seeds it from the normalized stored value.

## Testing

- `npm run typecheck -w @open-inspect/web` ✅
- `npm test -w @open-inspect/web` ✅ (434 tests)
- `npm run lint` / prettier ✅

## Note on the other deep-review suggestion

The companion suggestion — extract `normalizeRoutingRules`/`matchRoutingRules` out of `types/integrations.ts` into a dedicated module — was intentionally **not** taken. That file already co-locates shared pure helpers with the settings types/constants they operate on by design (`findSandboxPortConflict`, `resolveBuildTimeoutSeconds`, each documented as living "in exactly one place" for control-plane + web reuse), so the routing helpers follow the established pattern rather than becoming the odd one out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Slack routing rule keyword normalization has been moved from the frontend to the backend. Keywords are now validated and sent to the backend as-typed (with whitespace trimmed), where normalization occurs server-side.

* **Tests**
  * Updated routing rules test to verify keywords are sent as-typed rather than pre-normalized on the frontend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->