### PR TITLE
fix(types): validate webhook normalizer payloads

### DIFF
--- a/packages/shared/src/triggers/github/normalizer.test.ts
+++ b/packages/shared/src/triggers/github/normalizer.test.ts
@@ -340,6 +340,17 @@ describe("normalizeGitHubEvent", () => {
       expect(normalizeGitHubEvent("pull_request", payload)).toBeNull();
     });
 
+    it("returns null for pull_request with malformed labels", () => {
+      const payload = {
+        action: "opened",
+        repository: repo,
+        sender,
+        pull_request: { ...basePR, labels: "bug" },
+      };
+
+      expect(normalizeGitHubEvent("pull_request", payload)).toBeNull();
+    });
+
     it("returns null for issue_comment without a numeric comment id", () => {
       const payload = {
         action: "created",
@@ -374,6 +385,23 @@ describe("normalizeGitHubEvent", () => {
           pull_requests: [],
         },
       };
+      expect(normalizeGitHubEvent("check_suite", payload)).toBeNull();
+    });
+
+    it("returns null for check_suite with malformed pull request references", () => {
+      const payload = {
+        action: "completed",
+        repository: repo,
+        sender,
+        check_suite: {
+          id: 77777,
+          head_branch: "main",
+          head_sha: "abc123",
+          conclusion: "success",
+          pull_requests: [{ number: "42" }],
+        },
+      };
+
       expect(normalizeGitHubEvent("check_suite", payload)).toBeNull();
     });
 

--- a/packages/shared/src/triggers/github/normalizer.ts
+++ b/packages/shared/src/triggers/github/normalizer.ts
@@ -88,65 +88,174 @@ export function normalizeGitHubEvent(
   const supportedActions = SUPPORTED_EVENTS[githubEventHeader];
   if (!supportedActions) return null;
   if (typeof action !== "string" || !supportedActions.has(action)) return null;
-
-  const typedPayload = payload as unknown as SupportedGitHubPayload;
-
   const eventType = `${githubEventHeader}.${action}`;
-  const repoOwner = getRepoOwner(typedPayload);
-  const repoName = getRepoName(typedPayload);
-  const actor = getActor(typedPayload);
 
   switch (githubEventHeader) {
     case "pull_request":
+      if (!isPullRequestPayload(payload)) return null;
       return normalizePullRequest(
         eventType,
         action,
-        typedPayload as PullRequestPayload,
-        repoOwner,
-        repoName,
-        actor
+        payload,
+        getRepoOwner(payload),
+        getRepoName(payload),
+        getActor(payload)
       );
 
     case "issue_comment":
+      if (!isIssueCommentPayload(payload)) return null;
       return normalizeIssueComment(
         eventType,
-        typedPayload as IssueCommentPayload,
-        repoOwner,
-        repoName,
-        actor
+        payload,
+        getRepoOwner(payload),
+        getRepoName(payload),
+        getActor(payload)
       );
 
     case "pull_request_review_comment":
+      if (!isReviewCommentPayload(payload)) return null;
       return normalizeReviewComment(
         eventType,
-        typedPayload as PullRequestReviewCommentPayload,
-        repoOwner,
-        repoName,
-        actor
+        payload,
+        getRepoOwner(payload),
+        getRepoName(payload),
+        getActor(payload)
       );
 
     case "check_suite":
+      if (!isCheckSuitePayload(payload)) return null;
       return normalizeCheckSuite(
         eventType,
-        typedPayload as CheckSuitePayload,
-        repoOwner,
-        repoName,
-        actor
+        payload,
+        getRepoOwner(payload),
+        getRepoName(payload),
+        getActor(payload)
       );
 
     case "issues":
+      if (!isIssuesPayload(payload)) return null;
       return normalizeIssue(
         eventType,
         action,
-        typedPayload as IssuesPayload,
-        repoOwner,
-        repoName,
-        actor
+        payload,
+        getRepoOwner(payload),
+        getRepoName(payload),
+        getActor(payload)
       );
 
     default:
       return null;
   }
+}
+
+function isPullRequestPayload(payload: unknown): payload is PullRequestPayload {
+  if (!isRecord(payload)) return false;
+  if (!hasValidRepository(payload) || !hasValidSender(payload)) return false;
+  if (!isRecord(payload.pull_request)) return false;
+  return hasValidPullRequest(payload.pull_request);
+}
+
+function isIssueCommentPayload(payload: unknown): payload is IssueCommentPayload {
+  if (!isRecord(payload)) return false;
+  if (!hasValidRepository(payload) || !hasValidSender(payload)) return false;
+  if (!isRecord(payload.issue) || !isRecord(payload.comment)) return false;
+  return hasFiniteNumber(payload.issue.number) && hasFiniteNumber(payload.comment.id);
+}
+
+function isReviewCommentPayload(payload: unknown): payload is PullRequestReviewCommentPayload {
+  if (!isRecord(payload)) return false;
+  if (!hasValidRepository(payload) || !hasValidSender(payload)) return false;
+  if (!isRecord(payload.pull_request) || !isRecord(payload.comment)) return false;
+  if (!hasFiniteNumber(payload.comment.id)) return false;
+  if (!isOptionalString(payload.comment.body)) return false;
+  if (!isOptionalString(payload.comment.path)) return false;
+  if (!isOptionalString(payload.comment.diff_hunk)) return false;
+  return hasValidPullRequest(payload.pull_request);
+}
+
+function isCheckSuitePayload(payload: unknown): payload is CheckSuitePayload {
+  if (!isRecord(payload)) return false;
+  if (!hasValidRepository(payload) || !hasValidSender(payload)) return false;
+  if (!isRecord(payload.check_suite)) return false;
+  if (!hasFiniteNumber(payload.check_suite.id)) return false;
+  if (!isOptionalString(payload.check_suite.conclusion)) return false;
+  if (!isOptionalString(payload.check_suite.head_branch)) return false;
+  if (!isOptionalString(payload.check_suite.head_sha)) return false;
+  const pullRequests = payload.check_suite.pull_requests;
+  return (
+    pullRequests === undefined ||
+    (Array.isArray(pullRequests) &&
+      pullRequests.every(
+        (pullRequest) => isRecord(pullRequest) && hasFiniteNumber(pullRequest.number)
+      ))
+  );
+}
+
+function isIssuesPayload(payload: unknown): payload is IssuesPayload {
+  if (!isRecord(payload)) return false;
+  if (!hasValidRepository(payload) || !hasValidSender(payload)) return false;
+  if (!isRecord(payload.issue)) return false;
+  if (!hasFiniteNumber(payload.issue.number)) return false;
+  if (!isOptionalString(payload.issue.title)) return false;
+  if (!isOptionalString(payload.issue.body)) return false;
+  return hasValidLabels(payload.issue.labels);
+}
+
+function hasValidPullRequest(pr: Record<string, unknown>): boolean {
+  if (!hasFiniteNumber(pr.number)) return false;
+  if (!isOptionalString(pr.title)) return false;
+  if (!isOptionalString(pr.body)) return false;
+  if (!isOptionalBoolean(pr.merged)) return false;
+  if (!hasValidLabels(pr.labels)) return false;
+  if (
+    pr.head !== undefined &&
+    (!isRecord(pr.head) || !isOptionalString(pr.head.ref) || !isOptionalString(pr.head.sha))
+  ) {
+    return false;
+  }
+  if (pr.base !== undefined && (!isRecord(pr.base) || !isOptionalString(pr.base.ref))) {
+    return false;
+  }
+  return true;
+}
+
+function hasValidRepository(payload: Record<string, unknown>): boolean {
+  if (payload.repository === undefined) return true;
+  if (!isRecord(payload.repository)) return false;
+  if (!isOptionalString(payload.repository.name)) return false;
+  if (payload.repository.owner === undefined) return true;
+  return isRecord(payload.repository.owner) && isOptionalString(payload.repository.owner.login);
+}
+
+function hasValidSender(payload: Record<string, unknown>): boolean {
+  if (payload.sender === undefined) return true;
+  return isRecord(payload.sender) && isOptionalString(payload.sender.login);
+}
+
+function hasValidLabels(labels: unknown): boolean {
+  return (
+    labels === undefined ||
+    (Array.isArray(labels) &&
+      labels.every(
+        (label) => isRecord(label) && (label.name === undefined || typeof label.name === "string")
+      ))
+  );
+}
+
+function hasFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === "string";
+}
+
+function isOptionalBoolean(value: unknown): value is boolean | undefined {
+  return value === undefined || typeof value === "boolean";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object";
 }
 
 // ─── Per-event normalizers ────────────────────────────────────────────────────

--- a/packages/shared/src/triggers/sentry/normalizer.test.ts
+++ b/packages/shared/src/triggers/sentry/normalizer.test.ts
@@ -77,6 +77,21 @@ describe("normalizeSentryEvent", () => {
     expect(event!.contextBlock).toContain("acme-backend");
   });
 
+  it("returns null for issue alerts missing consumed issue fields", () => {
+    const malformedPayload = {
+      ...issueAlertPayload,
+      data: {
+        ...issueAlertPayload.data,
+        issue: {
+          ...issueAlertPayload.data.issue,
+          project: { id: 1, name: "Acme Backend" },
+        },
+      },
+    };
+
+    expect(normalizeSentryEvent(malformedPayload)).toBeNull();
+  });
+
   it("normalizes a regression payload", () => {
     const regressionPayload = {
       ...issueAlertPayload,
@@ -109,6 +124,26 @@ describe("normalizeSentryEvent", () => {
     expect(event!.eventType).toBe("metric_alert.critical");
     expect(event!.triggerKey).toBe("sentry_metric:789:2026-03-23T14:30:00Z");
     expect(event!.concurrencyKey).toBe("sentry_metric:789");
+  });
+
+  it("returns null for metric alerts missing trigger key fields", () => {
+    const malformedPayload = {
+      action: "critical",
+      data: {
+        metric_alert: {
+          id: 456,
+          title: "Error rate > 5%",
+          alert_rule: { name: "High error rate" },
+          date_started: "2026-03-23T14:30:00Z",
+          current_trigger: { label: "critical" },
+        },
+        description_text: "Error rate exceeded 5%",
+        description_title: "Metric Alert",
+        web_url: "https://sentry.io/alerts/456/",
+      },
+    };
+
+    expect(normalizeSentryEvent(malformedPayload)).toBeNull();
   });
 
   it("returns null for non-critical metric alerts", () => {

--- a/packages/shared/src/triggers/sentry/normalizer.ts
+++ b/packages/shared/src/triggers/sentry/normalizer.ts
@@ -78,7 +78,7 @@ export function normalizeSentryEvent(
 ): SentryAutomationEvent | null {
   // Issue alert (event_alert action or issue action)
   if (isIssueAlertPayload(payload)) {
-    const p = payload as unknown as SentryIssueAlertPayload;
+    const p = payload;
     const issue = p.data.issue;
     const isRegression = p.action === "regression" || issue.status === "regressed";
     const eventType = isRegression ? "issue.regression" : "issue.created";
@@ -96,7 +96,7 @@ export function normalizeSentryEvent(
       sentryProject: issue.project.slug,
       sentryLevel: issue.level,
       culpritFile: p.data.event.metadata.filename,
-      contextBlock: buildSentryContextBlock(p as unknown as Record<string, unknown>),
+      contextBlock: buildSentryContextBlock(payload),
       meta: {
         issueId: issue.id,
         shortId: issue.shortId,
@@ -107,7 +107,7 @@ export function normalizeSentryEvent(
 
   // Metric alert
   if (isMetricAlertPayload(payload)) {
-    const p = payload as unknown as SentryMetricAlertPayload;
+    const p = payload;
     if (p.action !== "critical") return null;
 
     const alert = p.data.metric_alert;
@@ -133,14 +133,67 @@ export function normalizeSentryEvent(
   return null;
 }
 
-function isIssueAlertPayload(payload: Record<string, unknown>): boolean {
-  const data = payload.data as Record<string, unknown> | undefined;
-  return !!data && "issue" in data && "event" in data;
+function isIssueAlertPayload(payload: unknown): payload is SentryIssueAlertPayload {
+  if (!isRecord(payload)) return false;
+  if (typeof payload.action !== "string") return false;
+  if (!isRecord(payload.data)) return false;
+
+  const { event, issue, triggered_rule: triggeredRule } = payload.data;
+  if (!isRecord(event) || !isRecord(issue) || typeof triggeredRule !== "string") return false;
+  if (!isRecord(event.metadata)) return false;
+
+  const metadata = event.metadata;
+  if (!isOptionalString(metadata.type)) return false;
+  if (!isOptionalString(metadata.value)) return false;
+  if (!isOptionalString(metadata.filename)) return false;
+  if (!isOptionalString(metadata.function)) return false;
+
+  if (typeof issue.id !== "string") return false;
+  if (typeof issue.shortId !== "string") return false;
+  if (typeof issue.title !== "string") return false;
+  if (typeof issue.culprit !== "string") return false;
+  if (typeof issue.level !== "string") return false;
+  if (typeof issue.count !== "string") return false;
+  if (typeof issue.firstSeen !== "string") return false;
+  if (typeof issue.lastSeen !== "string") return false;
+  if (typeof issue.status !== "string") return false;
+  if (!isRecord(issue.project) || typeof issue.project.slug !== "string") return false;
+
+  return true;
 }
 
-function isMetricAlertPayload(payload: Record<string, unknown>): boolean {
-  const data = payload.data as Record<string, unknown> | undefined;
-  return !!data && "metric_alert" in data;
+function isMetricAlertPayload(payload: unknown): payload is SentryMetricAlertPayload {
+  if (!isRecord(payload)) return false;
+  if (typeof payload.action !== "string") return false;
+  if (!isRecord(payload.data)) return false;
+
+  const data = payload.data;
+  if (!isRecord(data.metric_alert)) return false;
+  if (typeof data.description_text !== "string") return false;
+  if (typeof data.description_title !== "string") return false;
+  if (typeof data.web_url !== "string") return false;
+
+  const alert = data.metric_alert;
+  if (typeof alert.id !== "number" || !Number.isFinite(alert.id)) return false;
+  if (typeof alert.title !== "string") return false;
+  if (typeof alert.date_started !== "string") return false;
+  if (!isRecord(alert.alert_rule)) return false;
+  if (typeof alert.alert_rule.id !== "number" || !Number.isFinite(alert.alert_rule.id)) {
+    return false;
+  }
+  if (typeof alert.alert_rule.name !== "string") return false;
+  if (!isRecord(alert.current_trigger)) return false;
+  if (typeof alert.current_trigger.label !== "string") return false;
+
+  return true;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object";
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || typeof value === "string";
 }
 
 function buildSentryMetricContextBlock(p: SentryMetricAlertPayload): string {


### PR DESCRIPTION
This is an automated nightly unsafe-cast remediation sweep. It replaces high-risk webhook boundary double-casts with local hand-written guards so malformed payloads are rejected through the existing `null` normalizer contract instead of being asserted into domain payloads.

## Findings Fixed
| file:line | risk | cast removed | how it was fixed |
| --- | --- | --- | --- |
| `packages/shared/src/triggers/github/normalizer.ts:92` | HIGH | `payload as unknown as SupportedGitHubPayload` for raw GitHub webhook payloads feeding trigger/session metadata | Added per-event payload guards before normalizing supported GitHub events. |
| `packages/shared/src/triggers/sentry/normalizer.ts:81` | HIGH | `payload as unknown as SentryIssueAlertPayload` for raw Sentry issue alerts feeding trigger/concurrency keys | Strengthened `isIssueAlertPayload` into a narrowing guard for consumed issue/event fields. |
| `packages/shared/src/triggers/sentry/normalizer.ts:110` | HIGH | `payload as unknown as SentryMetricAlertPayload` for raw Sentry metric alerts feeding trigger/concurrency keys | Strengthened `isMetricAlertPayload` into a narrowing guard for consumed metric alert fields. |

## Verification
| command | result |
| --- | --- |
| `npm test -w @open-inspect/shared` | passed, 16 files / 199 tests |
| `npm run build -w @open-inspect/shared` | passed |
| `npm run typecheck` | passed |
| `npm run format` | passed |
| `npx eslint packages/shared/src/triggers/github/normalizer.ts packages/shared/src/triggers/github/normalizer.test.ts packages/shared/src/triggers/sentry/normalizer.ts packages/shared/src/triggers/sentry/normalizer.test.ts` | passed |
| `npx eslint . --ignore-pattern .opencode/` | passed |
| `npm run lint` | blocked by pre-existing untracked `.opencode/` tooling files in this workspace; tracked repo source passes lint as above |

Reference: TypeScript Coding Standards unsafe-cast / parse-don't-validate guidance.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/e6b657c9ff06672203f90e99e6bd9131)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for incoming event payloads to properly handle malformed or incomplete event data from GitHub and Sentry sources.

* **Tests**
  * Added test coverage for edge cases with malformed event structures and missing required fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->