### PR TITLE
fix(web): make inactive session checks deterministic

### DIFF
--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -246,10 +246,11 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
 
     const active: SessionItem[] = [];
     const inactive: SessionItem[] = [];
+    const now = Date.now();
 
     for (const session of topLevel) {
       const timestamp = session.updatedAt || session.createdAt;
-      if (isInactiveSession(timestamp)) {
+      if (isInactiveSession(timestamp, now)) {
         inactive.push(session);
       } else {
         active.push(session);

--- a/packages/web/src/lib/time.ts
+++ b/packages/web/src/lib/time.ts
@@ -43,7 +43,7 @@ export function formatRelativeTime(timestamp: number): string {
  * Group sessions by activity status.
  * Sessions older than 7 days are considered "inactive".
  */
-export function isInactiveSession(updatedAt: number): boolean {
-  const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+export function isInactiveSession(updatedAt: number, now: number): boolean {
+  const sevenDaysAgo = now - 7 * 24 * 60 * 60 * 1000;
   return updatedAt < sevenDaysAgo;
 }


### PR DESCRIPTION
## Summary
- Pass a captured `now` timestamp into `isInactiveSession` instead of reading ambient time inside the helper.
- Capture `Date.now()` once when partitioning sidebar sessions so active/inactive grouping is deterministic within the calculation.

## Verification
- `npm test -w @open-inspect/web -- session-sidebar.test.tsx`
- `npm run build -w @open-inspect/shared && npm run typecheck -w @open-inspect/web`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/c4a0ce9a276f1663a40014d0fdf5e261)*