### PR TITLE
refactor(web): handle auth providers explicitly in the sign-in gate

### DIFF
--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -231,6 +231,24 @@ describe("authOptions signIn", () => {
       } as never)
     ).resolves.toBe(false);
   });
+
+  it("denies a sign-in from an unrecognized provider", async () => {
+    const { authOptions } = await importAuthModule({
+      ALLOWED_EMAIL_DOMAINS: "company.com",
+    });
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchImpl);
+
+    await expect(
+      getSignIn(authOptions)({
+        account: { provider: "gitlab", access_token: "glpat-x" },
+        profile: { login: "stranger", email_verified: true },
+        user: { email: "stranger@company.com" },
+      } as never)
+    ).resolves.toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
 });
 
 describe("getVerifiedPrimaryGitHubEmail", () => {
@@ -382,6 +400,22 @@ describe("getStaticSignInReason", () => {
       ).toBe("username_allowlist");
     });
   });
+
+  describe("unrecognized provider", () => {
+    it("denies an unknown provider even when its email matches an allowlist", () => {
+      // Previously a non-google provider fell through to the GitHub branch and
+      // could be admitted by email/domain; an unrecognized provider now fails
+      // closed instead.
+      expect(
+        getStaticSignInReason({
+          provider: "gitlab",
+          profile: { email_verified: true } as unknown as Profile,
+          email: "user@company.com",
+          config: cfg({ allowedDomains: ["company.com"] }),
+        })
+      ).toBeNull();
+    });
+  });
 });
 
 describe("applyJwtClaims", () => {
@@ -476,6 +510,30 @@ describe("applyJwtClaims", () => {
 
     expect(token.provider).toBeUndefined();
     expect(token.providerUserId).toBeUndefined();
+  });
+
+  it("stores no provider and clears GitHub claims for an unrecognized provider", () => {
+    // Defensive: such a session is already denied at signIn, but if a JWT for an
+    // unrecognized provider were ever produced it must carry no SCM/GitHub state.
+    const token = applyJwtClaims(
+      {
+        accessToken: "gho_old",
+        githubUserId: "12345",
+        githubLogin: "octocat",
+      } as JWT,
+      {
+        provider: "gitlab",
+        type: "oauth",
+        providerAccountId: "gl-1",
+        access_token: "glpat-xyz",
+      } as unknown as Account,
+      undefined
+    );
+
+    expect(token.provider).toBeUndefined();
+    expect(token.accessToken).toBeUndefined();
+    expect(token.githubUserId).toBeUndefined();
+    expect(token.githubLogin).toBeUndefined();
   });
 });
 

--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -249,6 +249,25 @@ describe("authOptions signIn", () => {
     ).resolves.toBe(false);
     expect(fetchImpl).not.toHaveBeenCalled();
   });
+
+  it("does not run the GitHub org fallback for an unrecognized provider", async () => {
+    const { authOptions } = await importAuthModule({
+      ALLOWED_GITHUB_ORGS: "acme",
+    });
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchImpl);
+
+    await expect(
+      getSignIn(authOptions)({
+        account: { provider: "gitlab", access_token: "glpat-x" },
+        profile: { login: "stranger" },
+        user: { email: "stranger@example.com" },
+      } as never)
+    ).resolves.toBe(false);
+    // The org fallback is GitHub-only, so a non-GitHub token never reaches GitHub.
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
 });
 
 describe("getVerifiedPrimaryGitHubEmail", () => {
@@ -531,6 +550,7 @@ describe("applyJwtClaims", () => {
     );
 
     expect(token.provider).toBeUndefined();
+    expect(token.providerUserId).toBeUndefined();
     expect(token.accessToken).toBeUndefined();
     expect(token.githubUserId).toBeUndefined();
     expect(token.githubLogin).toBeUndefined();

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -161,12 +161,13 @@ export function applyJwtClaims(
   profile: Profile | undefined
 ): JWT {
   if (account) {
-    // Validate the provider against the supported set instead of casting: an
-    // unrecognized provider stores `undefined` and falls to the SCM-clearing
-    // branch below rather than retaining an untyped value.
+    // Validate the provider against the supported set instead of casting. Only a
+    // validated provider contributes an identity: an unrecognized provider stores
+    // no provider/providerUserId and falls to the claim-clearing branch below, so
+    // it can't surface as a legacy GitHub session via resolveAuthProvider.
     const provider = isAuthProvider(account.provider) ? account.provider : undefined;
     token.provider = provider;
-    token.providerUserId = account.providerAccountId;
+    token.providerUserId = provider ? account.providerAccountId : undefined;
 
     if (provider === "github") {
       token.accessToken = account.access_token;
@@ -317,10 +318,13 @@ export const authOptions: NextAuthOptions = {
 
       // GitHub organization membership fallback. Org membership is a GitHub
       // concept and the async check calls GitHub's API with the OAuth token, so
-      // it never runs for Google sign-ins or when no orgs are configured (fail
-      // closed).
+      // it runs only for GitHub sign-ins (including legacy sessions with no
+      // provider) when at least one org is configured. Any other provider —
+      // Google or unrecognized — fails closed here without contacting GitHub, so
+      // a non-GitHub OAuth token is never sent to GitHub's API.
       const allowedOrganizations = config.allowedOrganizations ?? [];
-      if (provider === "google" || allowedOrganizations.length === 0) {
+      const isGitHubProvider = provider === "github" || provider === undefined;
+      if (!isGitHubProvider || allowedOrganizations.length === 0) {
         logSignInDecision(githubProfile?.login, "deny", "no_matching_policy");
         return false;
       }

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -15,6 +15,7 @@ import {
   checkGitHubOrganizationAccess,
   type GitHubOrganizationAccessResult,
 } from "./github-org-membership";
+import { type AuthProvider, isAuthProvider } from "./build-auth-identity";
 
 export async function getVerifiedPrimaryGitHubEmail(
   accessToken: string | undefined
@@ -41,7 +42,7 @@ declare module "next-auth" {
     user: {
       id?: string; // Canonical provider user id: GitHub numeric id or Google sub
       login?: string; // GitHub username (GitHub-only)
-      provider?: "github" | "google"; // Which provider authenticated this session
+      provider?: AuthProvider; // Which provider authenticated this session
       name?: string | null;
       email?: string | null;
       image?: string | null;
@@ -56,7 +57,7 @@ declare module "next-auth/jwt" {
     accessTokenExpiresAt?: number; // Unix timestamp in milliseconds
     githubUserId?: string;
     githubLogin?: string;
-    provider?: "github" | "google";
+    provider?: AuthProvider;
     providerUserId?: string; // GitHub numeric id or Google sub
   }
 }
@@ -72,18 +73,32 @@ export function buildGitHubOAuthScope(
 }
 
 /**
+ * Normalize Google's `email_verified` claim. Google has returned it as boolean
+ * `true` or the string "true" (case-insensitive) depending on the flow; anything
+ * else is treated as unverified and fails closed.
+ */
+function isVerifiedGoogleEmail(profile: Profile | undefined): boolean {
+  const googleProfile = profile as { email_verified?: boolean | string } | undefined;
+  return (
+    googleProfile?.email_verified === true ||
+    String(googleProfile?.email_verified).toLowerCase() === "true"
+  );
+}
+
+/**
  * Resolve the static (synchronous) allow reason for a sign-in attempt, or null
  * when the static allowlists don't admit it. Pure and exported so the policy is
  * unit-testable — NextAuth's inline signIn callback otherwise can't be reached.
  *
+ * Providers are handled explicitly; an unrecognized provider is denied
+ * (default-closed) rather than treated as GitHub.
+ *
  * - GitHub: the email was already resolved to the verified primary in the
  *   provider's userinfo override, so only the allowlist gate applies.
- * - Google: the email MUST be verified before any allowlist match. All
- *   email-based admission (the email allowlist here, and cross-provider account
- *   linking downstream) trusts this flag, so it is the single most
- *   security-sensitive check in the sign-in path. `email_verified` is normalized
- *   defensively — boolean `true` or a case-insensitive "true" string — because
- *   Google has returned the string form in some flows. Anything else fails closed.
+ * - Google: the email MUST be verified (see isVerifiedGoogleEmail) before any
+ *   allowlist match. All email-based admission (the email allowlist here, and
+ *   cross-provider account linking downstream) trusts this, so it is the single
+ *   most security-sensitive check in the sign-in path.
  *
  * GitHub organization membership is intentionally NOT resolved here: it needs an
  * async call to GitHub's API, so the signIn callback applies it as a fallback
@@ -97,23 +112,32 @@ export function getStaticSignInReason(args: {
 }): AccessAllowReason | null {
   const { provider, profile, email, config } = args;
 
-  if (provider === "google") {
-    const googleProfile = profile as { email_verified?: boolean | string } | undefined;
-    const emailVerified =
-      googleProfile?.email_verified === true ||
-      String(googleProfile?.email_verified).toLowerCase() === "true";
-    if (!emailVerified) {
-      return null;
+  switch (provider) {
+    case "google": {
+      // The email must be verified before any email-based allowlist match.
+      if (!isVerifiedGoogleEmail(profile)) {
+        return null;
+      }
+      return getAccessAllowReason(config, { email: email ?? undefined });
     }
-    return getAccessAllowReason(config, { email: email ?? undefined });
+    case "github":
+    case undefined: {
+      // GitHub, including legacy sessions minted before the provider field
+      // existed (treated as GitHub, matching resolveAuthProvider). The email was
+      // already resolved to the verified primary in the provider's userinfo
+      // override, so only the allowlist gate applies.
+      const githubProfile = profile as { login?: string } | undefined;
+      return getAccessAllowReason(config, {
+        githubUsername: githubProfile?.login,
+        email: email ?? undefined,
+      });
+    }
+    default:
+      // Any other provider is denied rather than treated as GitHub, so admitting
+      // a new provider is a deliberate case here and never relies on an email
+      // this app has not verified for that provider.
+      return null;
   }
-
-  // GitHub (default).
-  const githubProfile = profile as { login?: string } | undefined;
-  return getAccessAllowReason(config, {
-    githubUsername: githubProfile?.login,
-    email: email ?? undefined,
-  });
 }
 
 /**
@@ -137,13 +161,14 @@ export function applyJwtClaims(
   profile: Profile | undefined
 ): JWT {
   if (account) {
-    // The cast is not validated: it relies on only "github" and "google" being
-    // registered providers below. A new provider must widen this union (and the
-    // SCM gate) rather than silently storing an untyped value.
-    token.provider = account.provider as "github" | "google";
+    // Validate the provider against the supported set instead of casting: an
+    // unrecognized provider stores `undefined` and falls to the SCM-clearing
+    // branch below rather than retaining an untyped value.
+    const provider = isAuthProvider(account.provider) ? account.provider : undefined;
+    token.provider = provider;
     token.providerUserId = account.providerAccountId;
 
-    if (account.provider === "github") {
+    if (provider === "github") {
       token.accessToken = account.access_token;
       token.refreshToken = account.refresh_token as string | undefined;
       // expires_at is in seconds, convert to milliseconds (only set if provided)

--- a/packages/web/src/lib/build-auth-identity.test.ts
+++ b/packages/web/src/lib/build-auth-identity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildAuthIdentity,
   buildScmCredentials,
+  isAuthProvider,
   resolveAuthProvider,
   type AuthIdentityUser,
 } from "./build-auth-identity";
@@ -39,6 +40,20 @@ describe("resolveAuthProvider", () => {
     expect(resolveAuthProvider({ id: "12345" })).toBe("github");
     expect(resolveAuthProvider(null)).toBe("github");
     expect(resolveAuthProvider(undefined)).toBe("github");
+  });
+});
+
+describe("isAuthProvider", () => {
+  it("accepts supported providers", () => {
+    expect(isAuthProvider("github")).toBe(true);
+    expect(isAuthProvider("google")).toBe(true);
+  });
+
+  it("rejects unknown or missing providers", () => {
+    expect(isAuthProvider("gitlab")).toBe(false);
+    expect(isAuthProvider("")).toBe(false);
+    expect(isAuthProvider(undefined)).toBe(false);
+    expect(isAuthProvider(null)).toBe(false);
   });
 });
 

--- a/packages/web/src/lib/build-auth-identity.ts
+++ b/packages/web/src/lib/build-auth-identity.ts
@@ -17,6 +17,15 @@
 
 export type AuthProvider = "github" | "google";
 
+/**
+ * Validated narrowing for the auth-provider discriminator. Returns true only for
+ * a provider this app explicitly supports, so an unrecognized value fails closed
+ * at the boundary instead of being cast onto the union.
+ */
+export function isAuthProvider(value: string | null | undefined): value is AuthProvider {
+  return value === "github" || value === "google";
+}
+
 export interface AuthIdentityUser {
   id?: string | null;
   login?: string | null;


### PR DESCRIPTION
## What

Branch on the auth provider explicitly in the web sign-in path instead of treating "not Google" as GitHub.

- `getStaticSignInReason` now uses a `switch` on the provider:
  - `google` → verified-email check, then the email allowlist
  - `github` / `undefined` → the GitHub path (`undefined` keeps the legacy back-compat default that `resolveAuthProvider` already uses)
  - anything else → `null` (denied), instead of falling through to the GitHub branch
- Extracted the Google `email_verified` normalization into an `isVerifiedGoogleEmail` helper (no behavior change).
- Added `isAuthProvider` to `build-auth-identity.ts` and used it in `applyJwtClaims` to validate `account.provider` rather than the `as "github" | "google"` cast. An unrecognized provider stores `undefined` and falls through to the existing SCM-clearing branch.
- Reused the existing `AuthProvider` type for the `provider` field on the NextAuth `Session`/`JWT` module augmentations.

## Why

The provider was handled with an implicit `else = GitHub` plus an unchecked cast. With only GitHub and Google registered, behavior is identical — but a provider added to the `providers` array later would route through the GitHub branch and skip the Google verified-email check by default. Handling providers explicitly and defaulting to deny makes adding one a deliberate change. This also lines the web sign-in path up with the control plane, which already allowlists the provider in `resolveProviderIdentity`.

## Behavior

- GitHub and Google sign-ins: unchanged.
- Legacy GitHub sessions without a `provider`: unchanged (still treated as GitHub).
- An unrecognized provider: denied at sign-in, and its JWT carries no SCM/identity claims.

## Tests

- `getStaticSignInReason` denies an unrecognized provider even when its email matches an allowlist.
- The signIn callback denies an unrecognized provider.
- `applyJwtClaims` stores no provider and clears GitHub claims for an unrecognized provider.
- Added `isAuthProvider` unit tests.
- Existing web auth/identity tests pass unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved authentication security by denying sign-in for unrecognized or invalid providers.
  * Added stricter Google handling: only verified emails are eligible for allowlist checks.
  * Prevented unsupported providers from persisting provider-specific identity/token claims.

* **Tests**
  * Added coverage to ensure unrecognized providers fail closed across sign-in decisions and JWT claim handling.
  * Added validation tests for provider recognition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->