### PR TITLE
test: cover modal clone token resolver

### DIFF
--- a/packages/modal-infra/src/clone_token.py
+++ b/packages/modal-infra/src/clone_token.py
@@ -1,0 +1,36 @@
+"""Resolve VCS clone tokens for Modal sandbox git operations."""
+
+import os
+
+from .log_config import get_logger
+
+log = get_logger("clone_token")
+
+
+def resolve_clone_token() -> str | None:
+    """Return a provider-specific clone token, or None when credentials are unavailable."""
+    from .auth import generate_installation_token
+
+    scm_provider = os.environ.get("SCM_PROVIDER", "github")
+
+    if scm_provider == "gitlab":
+        token = os.environ.get("GITLAB_ACCESS_TOKEN")
+        if not token:
+            log.warn("gitlab.token_missing")
+        return token
+
+    try:
+        app_id = os.environ.get("GITHUB_APP_ID")
+        private_key = os.environ.get("GITHUB_APP_PRIVATE_KEY")
+        installation_id = os.environ.get("GITHUB_APP_INSTALLATION_ID")
+
+        if app_id and private_key and installation_id:
+            return generate_installation_token(
+                app_id=app_id,
+                private_key=private_key,
+                installation_id=installation_id,
+            )
+    except Exception as e:
+        log.warn("github.token_error", exc=e)
+
+    return None

--- a/packages/modal-infra/src/scheduler/image_builder.py
+++ b/packages/modal-infra/src/scheduler/image_builder.py
@@ -38,6 +38,7 @@ from ..app import (
     validate_control_plane_url,
 )
 from ..auth import generate_internal_token
+from ..clone_token import resolve_clone_token
 from ..log_config import get_logger
 from ..sandbox.manager import (
     DEFAULT_BUILD_TIMEOUT_SECONDS,
@@ -173,26 +174,6 @@ async def _callback_with_retry(
     return False
 
 
-def _generate_clone_token() -> str:
-    """Generate a GitHub App install token for git operations. Returns empty string on failure."""
-    from ..auth import generate_installation_token
-
-    try:
-        app_id = os.environ.get("GITHUB_APP_ID")
-        private_key = os.environ.get("GITHUB_APP_PRIVATE_KEY")
-        installation_id = os.environ.get("GITHUB_APP_INSTALLATION_ID")
-
-        if app_id and private_key and installation_id:
-            return generate_installation_token(
-                app_id=app_id,
-                private_key=private_key,
-                installation_id=installation_id,
-            )
-    except Exception as e:
-        log.warn("github.token_error", error=str(e))
-    return ""
-
-
 async def _stream_build_logs(
     sandbox, redact_values: Iterable[str] = ()
 ) -> tuple[str, bool, str | None]:
@@ -286,7 +267,7 @@ async def build_repo_image(
     sandbox_terminated = False
 
     try:
-        clone_token = _generate_clone_token()
+        clone_token = resolve_clone_token() or ""
 
         # Create build sandbox
         log.info(
@@ -579,7 +560,7 @@ async def rebuild_repo_images():
         all_images: list[dict] = status_data.get("images", [])
 
         # 3. Generate GitHub App token for ls-remote
-        clone_token = _generate_clone_token()
+        clone_token = resolve_clone_token() or ""
 
         # 4. Check each enabled repo
         for repo in enabled_repos:

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -11,7 +11,6 @@ SECURITY: All sensitive endpoints require authentication via HMAC-signed tokens.
 The control plane must include an Authorization header with a valid token.
 """
 
-import os
 import time
 
 from fastapi import Header, HTTPException
@@ -25,6 +24,7 @@ from .app import (
     validate_control_plane_url,
 )
 from .auth import AuthConfigurationError, verify_internal_token
+from .clone_token import resolve_clone_token
 from .log_config import configure_logging, get_logger
 
 configure_logging()
@@ -53,41 +53,6 @@ def require_auth(authorization: str | None) -> None:
             status_code=503,
             detail=f"Service unavailable: Authentication not configured. {e}",
         )
-
-
-def _resolve_clone_token() -> str | None:
-    """Resolve a VCS clone token based on SCM_PROVIDER.
-
-    - "gitlab": reads GITLAB_ACCESS_TOKEN from the environment.
-    - "github" (default): generates a short-lived GitHub App installation token.
-
-    Returns None if credentials are missing or token generation fails.
-    """
-    from .auth import generate_installation_token
-
-    scm_provider = os.environ.get("SCM_PROVIDER", "github")
-
-    if scm_provider == "gitlab":
-        token = os.environ.get("GITLAB_ACCESS_TOKEN")
-        if not token:
-            log.warn("gitlab.token_missing")
-        return token
-
-    try:
-        app_id = os.environ.get("GITHUB_APP_ID")
-        private_key = os.environ.get("GITHUB_APP_PRIVATE_KEY")
-        installation_id = os.environ.get("GITHUB_APP_INSTALLATION_ID")
-
-        if app_id and private_key and installation_id:
-            return generate_installation_token(
-                app_id=app_id,
-                private_key=private_key,
-                installation_id=installation_id,
-            )
-    except Exception as e:
-        log.warn("github.token_error", exc=e)
-
-    return None
 
 
 def require_valid_control_plane_url(url: str | None) -> None:
@@ -156,7 +121,7 @@ async def api_create_sandbox(
 
         snapshot_id = request.get("snapshot_id")
         repo_image_id = request.get("repo_image_id") or None
-        fallback_clone_token = _resolve_clone_token() if snapshot_id else None
+        fallback_clone_token = resolve_clone_token() if snapshot_id else None
 
         session_config = SessionConfig(
             session_id=request.get("session_id"),
@@ -467,7 +432,7 @@ async def api_restore_sandbox(
         timeout_seconds = int(request.get("timeout_seconds", DEFAULT_SANDBOX_TIMEOUT_SECONDS))
 
         manager = SandboxManager()
-        clone_token = _resolve_clone_token()
+        clone_token = resolve_clone_token()
 
         code_server_enabled = bool(request.get("code_server_enabled", False))
         agent_slack_notify_enabled = bool(request.get("agent_slack_notify_enabled", False))

--- a/packages/modal-infra/tests/test_clone_token.py
+++ b/packages/modal-infra/tests/test_clone_token.py
@@ -1,0 +1,75 @@
+"""Tests for VCS clone token resolution."""
+
+import pytest
+
+from src.clone_token import resolve_clone_token
+
+
+@pytest.fixture(autouse=True)
+def clear_clone_token_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in [
+        "SCM_PROVIDER",
+        "GITLAB_ACCESS_TOKEN",
+        "GITHUB_APP_ID",
+        "GITHUB_APP_PRIVATE_KEY",
+        "GITHUB_APP_INSTALLATION_ID",
+    ]:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_resolve_clone_token_uses_gitlab_access_token(monkeypatch):
+    monkeypatch.setenv("SCM_PROVIDER", "gitlab")
+    monkeypatch.setenv("GITLAB_ACCESS_TOKEN", "glpat-token")
+
+    assert resolve_clone_token() == "glpat-token"
+
+
+def test_resolve_clone_token_returns_none_for_missing_gitlab_token(monkeypatch):
+    monkeypatch.setenv("SCM_PROVIDER", "gitlab")
+
+    assert resolve_clone_token() is None
+
+
+def test_resolve_clone_token_generates_github_installation_token(monkeypatch):
+    monkeypatch.setenv("GITHUB_APP_ID", "123")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", "private-key")
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "456")
+    captured = {}
+
+    def fake_generate_installation_token(**kwargs):
+        captured.update(kwargs)
+        return "ghs-token"
+
+    monkeypatch.setattr("src.auth.generate_installation_token", fake_generate_installation_token)
+
+    assert resolve_clone_token() == "ghs-token"
+    assert captured == {
+        "app_id": "123",
+        "private_key": "private-key",
+        "installation_id": "456",
+    }
+
+
+def test_resolve_clone_token_returns_none_when_github_credentials_incomplete(monkeypatch):
+    monkeypatch.setenv("GITHUB_APP_ID", "123")
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "456")
+
+    def fail_if_called(**_kwargs):
+        raise AssertionError("generate_installation_token should not be called")
+
+    monkeypatch.setattr("src.auth.generate_installation_token", fail_if_called)
+
+    assert resolve_clone_token() is None
+
+
+def test_resolve_clone_token_returns_none_when_github_generation_fails(monkeypatch):
+    monkeypatch.setenv("GITHUB_APP_ID", "123")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", "private-key")
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "456")
+
+    def raise_from_generate(**_kwargs):
+        raise RuntimeError("token generation failed")
+
+    monkeypatch.setattr("src.auth.generate_installation_token", raise_from_generate)
+
+    assert resolve_clone_token() is None

--- a/packages/modal-infra/tests/test_image_builder_v2.py
+++ b/packages/modal-infra/tests/test_image_builder_v2.py
@@ -383,7 +383,7 @@ class TestBuildRepoImage:
 
         with (
             patch("src.scheduler.image_builder.validate_control_plane_url", return_value=True),
-            patch("src.scheduler.image_builder._generate_clone_token", return_value="gh-token"),
+            patch("src.scheduler.image_builder.resolve_clone_token", return_value="gh-token"),
             patch("src.sandbox.manager.SandboxManager", return_value=manager),
             patch(
                 "src.scheduler.image_builder._callback_with_retry",
@@ -415,7 +415,7 @@ class TestBuildRepoImage:
 
         with (
             patch("src.scheduler.image_builder.validate_control_plane_url", return_value=True),
-            patch("src.scheduler.image_builder._generate_clone_token", return_value="gh-token"),
+            patch("src.scheduler.image_builder.resolve_clone_token", return_value="gh-token"),
             patch("src.sandbox.manager.SandboxManager", return_value=manager),
             patch(
                 "src.scheduler.image_builder._callback_with_retry",
@@ -444,7 +444,7 @@ class TestBuildRepoImage:
 
         with (
             patch("src.scheduler.image_builder.validate_control_plane_url", return_value=True),
-            patch("src.scheduler.image_builder._generate_clone_token", return_value="gh-token"),
+            patch("src.scheduler.image_builder.resolve_clone_token", return_value="gh-token"),
             patch("src.sandbox.manager.SandboxManager", return_value=manager),
             patch(
                 "src.scheduler.image_builder._callback_with_retry",
@@ -474,7 +474,7 @@ class TestBuildRepoImage:
 
         with (
             patch("src.scheduler.image_builder.validate_control_plane_url", return_value=True),
-            patch("src.scheduler.image_builder._generate_clone_token", return_value="gh-token"),
+            patch("src.scheduler.image_builder.resolve_clone_token", return_value="gh-token"),
             patch("src.sandbox.manager.SandboxManager", return_value=manager),
             patch(
                 "src.scheduler.image_builder._callback_with_retry",
@@ -524,7 +524,7 @@ class TestBuildRepoImage:
 
         with (
             patch("src.scheduler.image_builder.validate_control_plane_url", return_value=True),
-            patch("src.scheduler.image_builder._generate_clone_token", return_value="gh-token"),
+            patch("src.scheduler.image_builder.resolve_clone_token", return_value="gh-token"),
             patch("src.sandbox.manager.SandboxManager", return_value=manager),
             patch(
                 "src.scheduler.image_builder._callback_with_retry",

--- a/packages/modal-infra/tests/test_web_api_create_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_create_sandbox.py
@@ -32,17 +32,6 @@ def _patch_manager(monkeypatch: pytest.MonkeyPatch, captured: dict) -> None:
     monkeypatch.setattr(manager_module, "SandboxManager", FakeManager)
 
 
-def _clear_clone_token_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    for name in [
-        "SCM_PROVIDER",
-        "GITLAB_ACCESS_TOKEN",
-        "GITHUB_APP_ID",
-        "GITHUB_APP_PRIVATE_KEY",
-        "GITHUB_APP_INSTALLATION_ID",
-    ]:
-        monkeypatch.delenv(name, raising=False)
-
-
 async def _call_create_sandbox(request: dict) -> dict:
     return await web_api.api_create_sandbox.get_raw_f()(
         request,
@@ -54,69 +43,6 @@ async def _call_create_sandbox(request: dict) -> dict:
     )
 
 
-def test_resolve_clone_token_uses_gitlab_access_token(monkeypatch):
-    _clear_clone_token_env(monkeypatch)
-    monkeypatch.setenv("SCM_PROVIDER", "gitlab")
-    monkeypatch.setenv("GITLAB_ACCESS_TOKEN", "glpat-token")
-
-    assert web_api._resolve_clone_token() == "glpat-token"
-
-
-def test_resolve_clone_token_returns_none_for_missing_gitlab_token(monkeypatch):
-    _clear_clone_token_env(monkeypatch)
-    monkeypatch.setenv("SCM_PROVIDER", "gitlab")
-
-    assert web_api._resolve_clone_token() is None
-
-
-def test_resolve_clone_token_generates_github_installation_token(monkeypatch):
-    _clear_clone_token_env(monkeypatch)
-    monkeypatch.setenv("GITHUB_APP_ID", "123")
-    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", "private-key")
-    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "456")
-    captured = {}
-
-    def fake_generate_installation_token(**kwargs):
-        captured.update(kwargs)
-        return "ghs-token"
-
-    monkeypatch.setattr("src.auth.generate_installation_token", fake_generate_installation_token)
-
-    assert web_api._resolve_clone_token() == "ghs-token"
-    assert captured == {
-        "app_id": "123",
-        "private_key": "private-key",
-        "installation_id": "456",
-    }
-
-
-def test_resolve_clone_token_returns_none_when_github_credentials_incomplete(monkeypatch):
-    _clear_clone_token_env(monkeypatch)
-    monkeypatch.setenv("GITHUB_APP_ID", "123")
-    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "456")
-
-    def fail_if_called(**_kwargs):
-        raise AssertionError("generate_installation_token should not be called")
-
-    monkeypatch.setattr("src.auth.generate_installation_token", fail_if_called)
-
-    assert web_api._resolve_clone_token() is None
-
-
-def test_resolve_clone_token_returns_none_when_github_generation_fails(monkeypatch):
-    _clear_clone_token_env(monkeypatch)
-    monkeypatch.setenv("GITHUB_APP_ID", "123")
-    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", "private-key")
-    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "456")
-
-    def raise_from_generate(**_kwargs):
-        raise RuntimeError("token generation failed")
-
-    monkeypatch.setattr("src.auth.generate_installation_token", raise_from_generate)
-
-    assert web_api._resolve_clone_token() is None
-
-
 @pytest.mark.asyncio
 async def test_create_sandbox_does_not_resolve_clone_token_for_fresh_boot(monkeypatch):
     """Fresh base-image boots authenticate via the credential helper only."""
@@ -125,7 +51,7 @@ async def test_create_sandbox_does_not_resolve_clone_token_for_fresh_boot(monkey
 
     _patch_auth(monkeypatch)
     _patch_manager(monkeypatch, captured)
-    monkeypatch.setattr(web_api, "_resolve_clone_token", lambda: calls.append(True) or "ghs_token")
+    monkeypatch.setattr(web_api, "resolve_clone_token", lambda: calls.append(True) or "ghs_token")
 
     result = await _call_create_sandbox(
         {
@@ -155,7 +81,7 @@ async def test_create_sandbox_does_not_resolve_clone_token_for_repo_image_boot(m
         calls.append(True)
         return "ghs_prebuilt"
 
-    monkeypatch.setattr(web_api, "_resolve_clone_token", resolve_clone_token)
+    monkeypatch.setattr(web_api, "resolve_clone_token", resolve_clone_token)
 
     result = await _call_create_sandbox(
         {
@@ -186,7 +112,7 @@ async def test_create_sandbox_resolves_clone_token_for_snapshot_boot(monkeypatch
         calls.append(True)
         return "ghs_snapshot"
 
-    monkeypatch.setattr(web_api, "_resolve_clone_token", resolve_clone_token)
+    monkeypatch.setattr(web_api, "resolve_clone_token", resolve_clone_token)
 
     result = await _call_create_sandbox(
         {

--- a/packages/modal-infra/tests/test_web_api_create_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_create_sandbox.py
@@ -32,6 +32,17 @@ def _patch_manager(monkeypatch: pytest.MonkeyPatch, captured: dict) -> None:
     monkeypatch.setattr(manager_module, "SandboxManager", FakeManager)
 
 
+def _clear_clone_token_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in [
+        "SCM_PROVIDER",
+        "GITLAB_ACCESS_TOKEN",
+        "GITHUB_APP_ID",
+        "GITHUB_APP_PRIVATE_KEY",
+        "GITHUB_APP_INSTALLATION_ID",
+    ]:
+        monkeypatch.delenv(name, raising=False)
+
+
 async def _call_create_sandbox(request: dict) -> dict:
     return await web_api.api_create_sandbox.get_raw_f()(
         request,
@@ -41,6 +52,69 @@ async def _call_create_sandbox(request: dict) -> dict:
         x_session_id=None,
         x_sandbox_id=None,
     )
+
+
+def test_resolve_clone_token_uses_gitlab_access_token(monkeypatch):
+    _clear_clone_token_env(monkeypatch)
+    monkeypatch.setenv("SCM_PROVIDER", "gitlab")
+    monkeypatch.setenv("GITLAB_ACCESS_TOKEN", "glpat-token")
+
+    assert web_api._resolve_clone_token() == "glpat-token"
+
+
+def test_resolve_clone_token_returns_none_for_missing_gitlab_token(monkeypatch):
+    _clear_clone_token_env(monkeypatch)
+    monkeypatch.setenv("SCM_PROVIDER", "gitlab")
+
+    assert web_api._resolve_clone_token() is None
+
+
+def test_resolve_clone_token_generates_github_installation_token(monkeypatch):
+    _clear_clone_token_env(monkeypatch)
+    monkeypatch.setenv("GITHUB_APP_ID", "123")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", "private-key")
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "456")
+    captured = {}
+
+    def fake_generate_installation_token(**kwargs):
+        captured.update(kwargs)
+        return "ghs-token"
+
+    monkeypatch.setattr("src.auth.generate_installation_token", fake_generate_installation_token)
+
+    assert web_api._resolve_clone_token() == "ghs-token"
+    assert captured == {
+        "app_id": "123",
+        "private_key": "private-key",
+        "installation_id": "456",
+    }
+
+
+def test_resolve_clone_token_returns_none_when_github_credentials_incomplete(monkeypatch):
+    _clear_clone_token_env(monkeypatch)
+    monkeypatch.setenv("GITHUB_APP_ID", "123")
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "456")
+
+    def fail_if_called(**_kwargs):
+        raise AssertionError("generate_installation_token should not be called")
+
+    monkeypatch.setattr("src.auth.generate_installation_token", fail_if_called)
+
+    assert web_api._resolve_clone_token() is None
+
+
+def test_resolve_clone_token_returns_none_when_github_generation_fails(monkeypatch):
+    _clear_clone_token_env(monkeypatch)
+    monkeypatch.setenv("GITHUB_APP_ID", "123")
+    monkeypatch.setenv("GITHUB_APP_PRIVATE_KEY", "private-key")
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "456")
+
+    def raise_from_generate(**_kwargs):
+        raise RuntimeError("token generation failed")
+
+    monkeypatch.setattr("src.auth.generate_installation_token", raise_from_generate)
+
+    assert web_api._resolve_clone_token() is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Centralizes Modal VCS clone token resolution in `src.clone_token.resolve_clone_token` so web API snapshot restore/create flows and repo image builds share one credential path.
- Adds focused credential-matrix tests for GitLab and GitHub token resolution on the canonical helper.
- Keeps create-sandbox tests focused on request assembly by only asserting when snapshot boots request a fallback token.

## Verification
- `./.venv/bin/pytest tests/test_clone_token.py tests/test_web_api_create_sandbox.py tests/test_image_builder_v2.py -v`
- `./.venv/bin/ruff check src/clone_token.py src/web_api.py src/scheduler/image_builder.py tests/test_clone_token.py tests/test_web_api_create_sandbox.py tests/test_image_builder_v2.py && ./.venv/bin/ruff format --check src/clone_token.py src/web_api.py src/scheduler/image_builder.py tests/test_clone_token.py tests/test_web_api_create_sandbox.py tests/test_image_builder_v2.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for clone-token resolution across GitLab and GitHub, including scenarios where credentials are missing or token generation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->