### PR TITLE
fix: align sandbox base tool staging

### DIFF
--- a/packages/control-plane/src/sandbox/providers/vercel/bootstrap.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/bootstrap.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { buildVercelBootstrapScript } from "./bootstrap";
+
+describe("buildVercelBootstrapScript", () => {
+  it("installs shared sandbox helpers and stages OpenCode deps", () => {
+    const script = buildVercelBootstrapScript();
+
+    expect(script).toContain("install_git_credential_helper() {");
+    expect(script).toContain(
+      "printf '%s\\n' '#!/bin/sh' 'exec /usr/bin/python3.12 -m sandbox_runtime.credentials.git_credential_helper \"$@\"'"
+    );
+    expect(script).toContain("sudo git config --system credential.useHttpPath true || true");
+    expect(script).toContain("stage_opencode_deps() {");
+    expect(script).toContain("sudo npm install --ignore-scripts --no-audit --no-fund");
+    expect(script).toContain("sudo cp -a /app/opencode-deps/. /root/.config/opencode/");
+    expect(script).toContain("install_git_credential_helper\nstage_opencode_deps");
+  });
+});

--- a/packages/control-plane/src/sandbox/providers/vercel/bootstrap.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/bootstrap.test.ts
@@ -2,17 +2,31 @@ import { describe, expect, it } from "vitest";
 import { buildVercelBootstrapScript } from "./bootstrap";
 
 describe("buildVercelBootstrapScript", () => {
-  it("installs shared sandbox helpers and stages OpenCode deps", () => {
+  it("installs the sandbox toolchain contract", () => {
     const script = buildVercelBootstrapScript();
 
-    expect(script).toContain("install_git_credential_helper() {");
     expect(script).toContain(
       "printf '%s\\n' '#!/bin/sh' 'exec /usr/bin/python3.12 -m sandbox_runtime.credentials.git_credential_helper \"$@\"'"
     );
+    expect(script).toContain("sudo tee /usr/local/bin/oi-git-credentials >/dev/null");
+    expect(script).toContain(
+      "sudo git config --system credential.helper /usr/local/bin/oi-git-credentials || true"
+    );
     expect(script).toContain("sudo git config --system credential.useHttpPath true || true");
-    expect(script).toContain("stage_opencode_deps() {");
+
+    expect(script).toContain(
+      '{"name":"opencode-tools","type":"module","dependencies":{"@opencode-ai/plugin":"$OPENCODE_VERSION"}}'
+    );
+    expect(script).toContain(
+      "sudo mv /tmp/opencode-deps-package.json /app/opencode-deps/package.json"
+    );
+    expect(script).toContain("cd /app/opencode-deps");
     expect(script).toContain("sudo npm install --ignore-scripts --no-audit --no-fund");
+    expect(script).toContain("sudo mkdir -p /root/.config/opencode");
     expect(script).toContain("sudo cp -a /app/opencode-deps/. /root/.config/opencode/");
-    expect(script).toContain("install_git_credential_helper\nstage_opencode_deps");
+
+    expect(script).toContain(
+      "sudo /usr/bin/python3.12 -m pip install --break-system-packages -e packages/sandbox-runtime"
+    );
   });
 });

--- a/packages/control-plane/src/sandbox/providers/vercel/bootstrap.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/bootstrap.ts
@@ -10,7 +10,6 @@ export const VERCEL_RUNTIME_WORKDIR = "/tmp/open-inspect-runtime";
 export const VERCEL_LOCAL_RUNTIME_EXTRACT_DIR = `${VERCEL_RUNTIME_WORKDIR}/packages`;
 
 export function buildVercelBootstrapScript(params: { runtimeExtractDir?: string } = {}): string {
-  const gitCredentialHelperCommand = `exec ${VERCEL_PYTHON_BIN} -m sandbox_runtime.credentials.git_credential_helper "$@"`;
   const runtimeExtractDir = params.runtimeExtractDir || VERCEL_LOCAL_RUNTIME_EXTRACT_DIR;
   return `
 set -euo pipefail
@@ -21,7 +20,25 @@ AGENT_BROWSER_VERSION="0.21.2"
 TTYD_VERSION="1.7.7"
 TTYD_SHA256="8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55"
 
-sudo mkdir -p /workspace /app /app/plugins /app/opencode-deps /tmp/opencode /root
+install_git_credential_helper() {
+  printf '%s\\n' '#!/bin/sh' 'exec ${VERCEL_PYTHON_BIN} -m sandbox_runtime.credentials.git_credential_helper "$@"' | sudo tee /usr/local/bin/oi-git-credentials >/dev/null
+  sudo chmod 0755 /usr/local/bin/oi-git-credentials
+  sudo git config --system credential.helper /usr/local/bin/oi-git-credentials || true
+  sudo git config --system credential.useHttpPath true || true
+}
+
+stage_opencode_deps() {
+  cat > /tmp/opencode-deps-package.json <<EOF
+{"name":"opencode-tools","type":"module","dependencies":{"@opencode-ai/plugin":"$OPENCODE_VERSION"}}
+EOF
+  sudo mv /tmp/opencode-deps-package.json /app/opencode-deps/package.json
+  cd /app/opencode-deps
+  sudo npm install --ignore-scripts --no-audit --no-fund
+  sudo mkdir -p /root/.config/opencode
+  sudo cp -a /app/opencode-deps/. /root/.config/opencode/
+}
+
+sudo mkdir -p /workspace /app /app/plugins /app/opencode-deps /tmp/opencode /root/.config/opencode
 
 sudo dnf install -y dnf-plugins-core git gcc gcc-c++ make ca-certificates openssh-clients jq unzip tar gzip python3.12 python3.12-pip python3.12-devel
 sudo dnf install -y libX11 libXcomposite libXdamage libXext libXfixes libXrandr libxcb libxkbcommon libdrm mesa-libgbm alsa-lib atk at-spi2-atk cups-libs pango cairo nspr nss || true
@@ -64,17 +81,8 @@ sudo cp -a packages/sandbox-runtime/src/sandbox_runtime /app/sandbox_runtime
 sudo chmod -R a+rX /app/sandbox_runtime
 sudo ${VERCEL_PYTHON_BIN} -m pip install --break-system-packages -e packages/sandbox-runtime || sudo ${VERCEL_PYTHON_BIN} -m pip install -e packages/sandbox-runtime
 
-printf '%s\\n' '#!/bin/sh' ${shellQuote(gitCredentialHelperCommand)} | sudo tee /usr/local/bin/oi-git-credentials >/dev/null
-sudo chmod 0755 /usr/local/bin/oi-git-credentials
-sudo git config --system credential.helper /usr/local/bin/oi-git-credentials || true
-sudo git config --system credential.useHttpPath true || true
-
-cat > /tmp/opencode-deps-package.json <<EOF
-{"name":"opencode-tools","type":"module","dependencies":{"@opencode-ai/plugin":"$OPENCODE_VERSION"}}
-EOF
-sudo mv /tmp/opencode-deps-package.json /app/opencode-deps/package.json
-cd /app/opencode-deps
-sudo npm install --ignore-scripts --no-audit --no-fund
+install_git_credential_helper
+stage_opencode_deps
 `;
 }
 

--- a/packages/daytona-infra/src/toolchain.py
+++ b/packages/daytona-infra/src/toolchain.py
@@ -22,10 +22,48 @@ from daytona import CreateSnapshotParams, Daytona, Image
 OPENCODE_VERSION = "1.14.41"
 CODE_SERVER_VERSION = "4.109.5"
 AGENT_BROWSER_VERSION = "0.21.2"
+TTYD_VERSION = "1.7.7"
+TTYD_SHA256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55"
 # Bump when changing image contents to invalidate the Daytona snapshot.
-# daytona-v2: install the SCM credential-helper shim and configure
-# git system-wide so per-request token brokerage matches the Modal base image.
-SANDBOX_VERSION = "daytona-v2-credential-helper"
+# daytona-v3: align ttyd and OpenCode dependency staging with Modal/Vercel.
+SANDBOX_VERSION = "daytona-v3-opencode-deps-ttyd"
+
+
+def opencode_deps_staging_commands() -> tuple[str, ...]:
+    """Commands that pre-stage OpenCode plugin deps and global config."""
+    return (
+        "mkdir -p /app/opencode-deps",
+        f'echo \'{{"name":"opencode-tools","type":"module",'
+        f'"dependencies":{{"@opencode-ai/plugin":"{OPENCODE_VERSION}"}}}}\''
+        " > /app/opencode-deps/package.json",
+        "cd /app/opencode-deps && npm install --ignore-scripts --no-audit --no-fund",
+        "mkdir -p /root/.config/opencode",
+        "cp -a /app/opencode-deps/. /root/.config/opencode/",
+    )
+
+
+def ttyd_install_commands() -> tuple[str, ...]:
+    """Commands that install pinned ttyd from the upstream release binary."""
+    return (
+        f"curl -fsSL -o /usr/local/bin/ttyd "
+        f"https://github.com/tsl0922/ttyd/releases/download/{TTYD_VERSION}/ttyd.x86_64",
+        f'echo "{TTYD_SHA256}  /usr/local/bin/ttyd" | sha256sum -c -',
+        "chmod +x /usr/local/bin/ttyd",
+        "ttyd --version",
+    )
+
+
+def git_credential_helper_commands() -> tuple[str, ...]:
+    """Commands that install and configure the Open-Inspect git credential helper."""
+    return (
+        "printf '%s\\n'"
+        " '#!/bin/sh'"
+        ' \'exec python3 -m sandbox_runtime.credentials.git_credential_helper "$@"\''
+        " > /usr/local/bin/oi-git-credentials",
+        "chmod 0755 /usr/local/bin/oi-git-credentials",
+        "git config --system credential.helper /usr/local/bin/oi-git-credentials",
+        "git config --system credential.useHttpPath true",
+    )
 
 
 def build_base_image(repo_root: Path) -> Image:
@@ -65,27 +103,21 @@ def build_base_image(repo_root: Path) -> Image:
         .run_commands(
             f"npm install -g opencode-ai@{OPENCODE_VERSION}",
             f"npm install -g @opencode-ai/plugin@{OPENCODE_VERSION} zod",
+            *opencode_deps_staging_commands(),
             f"curl -fsSL -o /tmp/code-server.deb "
             f"https://github.com/coder/code-server/releases/download/v{CODE_SERVER_VERSION}/"
             f"code-server_{CODE_SERVER_VERSION}_amd64.deb",
             "dpkg -i /tmp/code-server.deb",
             "rm /tmp/code-server.deb",
+            *ttyd_install_commands(),
             f"npm install -g agent-browser@{AGENT_BROWSER_VERSION}",
             "agent-browser install",
-            "mkdir -p /workspace /app /tmp/opencode",
+            "mkdir -p /workspace /app/plugins /tmp/opencode",
             # Install the SCM credential-helper shim and configure git
             # system-wide. The shim delegates to the Python helper module
             # under sandbox_runtime, baked in at build time via add_local_dir
             # below. Mirror packages/modal-infra/src/images/base.py.
-            "printf '%s\\n'"
-            " '#!/bin/sh'"
-            ' \'exec python3 -m sandbox_runtime.credentials.git_credential_helper "$@"\''
-            " > /usr/local/bin/oi-git-credentials",
-            "chmod 0755 /usr/local/bin/oi-git-credentials",
-            "git config --system credential.helper /usr/local/bin/oi-git-credentials",
-            # Pass the repo path to the helper so it can scope credentials to
-            # the session repo, not just the host.
-            "git config --system credential.useHttpPath true",
+            *git_credential_helper_commands(),
         )
         .env(
             {

--- a/packages/daytona-infra/src/toolchain.py
+++ b/packages/daytona-infra/src/toolchain.py
@@ -2,72 +2,38 @@
 
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
+from types import ModuleType
 
 from daytona import CreateSnapshotParams, Daytona, Image
 
-# OpenCode version to install.
-#
-# Pinned to 1.14.41 — the last release before opencode's Hono → Effect Schema
-# migration (landed across v1.14.42+, released 2026-05-09 onward) broke event
-# publishing on the legacy `/event` SSE endpoint. With newer versions the
-# bridge connects, posts the prompt, opencode processes it and records the
-# assistant response in the session store, but no `message.updated` /
-# `message.part.updated` / `session.idle` events are streamed back — so the
-# session shows execution_complete with no reply.
-#
-# Symptom in bridge logs: `prompt.run outcome=success duration_ms=35-367`,
-# which means `_stream_opencode_response_sse` returned with zero yielded
-# events. Tracked in #567.
-OPENCODE_VERSION = "1.14.41"
-CODE_SERVER_VERSION = "4.109.5"
-AGENT_BROWSER_VERSION = "0.21.2"
-TTYD_VERSION = "1.7.7"
-TTYD_SHA256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55"
 # Bump when changing image contents to invalidate the Daytona snapshot.
 # daytona-v3: align ttyd and OpenCode dependency staging with Modal/Vercel.
 SANDBOX_VERSION = "daytona-v3-opencode-deps-ttyd"
 
 
-def opencode_deps_staging_commands() -> tuple[str, ...]:
-    """Commands that pre-stage OpenCode plugin deps and global config."""
-    return (
-        "mkdir -p /app/opencode-deps",
-        f'echo \'{{"name":"opencode-tools","type":"module",'
-        f'"dependencies":{{"@opencode-ai/plugin":"{OPENCODE_VERSION}"}}}}\''
-        " > /app/opencode-deps/package.json",
-        "cd /app/opencode-deps && npm install --ignore-scripts --no-audit --no-fund",
-        "mkdir -p /root/.config/opencode",
-        "cp -a /app/opencode-deps/. /root/.config/opencode/",
+def load_toolchain_contract(repo_root: Path) -> ModuleType:
+    """Load the canonical sandbox-runtime toolchain contract from this checkout."""
+    toolchain_path = (
+        repo_root
+        / "packages"
+        / "sandbox-runtime"
+        / "src"
+        / "sandbox_runtime"
+        / "toolchain.py"
     )
-
-
-def ttyd_install_commands() -> tuple[str, ...]:
-    """Commands that install pinned ttyd from the upstream release binary."""
-    return (
-        f"curl -fsSL -o /usr/local/bin/ttyd "
-        f"https://github.com/tsl0922/ttyd/releases/download/{TTYD_VERSION}/ttyd.x86_64",
-        f'echo "{TTYD_SHA256}  /usr/local/bin/ttyd" | sha256sum -c -',
-        "chmod +x /usr/local/bin/ttyd",
-        "ttyd --version",
-    )
-
-
-def git_credential_helper_commands() -> tuple[str, ...]:
-    """Commands that install and configure the Open-Inspect git credential helper."""
-    return (
-        "printf '%s\\n'"
-        " '#!/bin/sh'"
-        ' \'exec python3 -m sandbox_runtime.credentials.git_credential_helper "$@"\''
-        " > /usr/local/bin/oi-git-credentials",
-        "chmod 0755 /usr/local/bin/oi-git-credentials",
-        "git config --system credential.helper /usr/local/bin/oi-git-credentials",
-        "git config --system credential.useHttpPath true",
-    )
+    spec = importlib.util.spec_from_file_location("sandbox_runtime.toolchain", toolchain_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load sandbox toolchain contract from {toolchain_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def build_base_image(repo_root: Path) -> Image:
     """Build the Open-Inspect Daytona base image."""
+    toolchain = load_toolchain_contract(repo_root)
     sandbox_runtime_dir = (
         repo_root / "packages" / "sandbox-runtime" / "src" / "sandbox_runtime"
     )
@@ -101,23 +67,23 @@ def build_base_image(repo_root: Path) -> Image:
             "PyJWT[crypto]",
         )
         .run_commands(
-            f"npm install -g opencode-ai@{OPENCODE_VERSION}",
-            f"npm install -g @opencode-ai/plugin@{OPENCODE_VERSION} zod",
-            *opencode_deps_staging_commands(),
+            f"npm install -g opencode-ai@{toolchain.OPENCODE_VERSION}",
+            f"npm install -g @opencode-ai/plugin@{toolchain.OPENCODE_VERSION} zod",
+            *toolchain.opencode_deps_staging_commands(),
             f"curl -fsSL -o /tmp/code-server.deb "
-            f"https://github.com/coder/code-server/releases/download/v{CODE_SERVER_VERSION}/"
-            f"code-server_{CODE_SERVER_VERSION}_amd64.deb",
+            f"https://github.com/coder/code-server/releases/download/v{toolchain.CODE_SERVER_VERSION}/"
+            f"code-server_{toolchain.CODE_SERVER_VERSION}_amd64.deb",
             "dpkg -i /tmp/code-server.deb",
             "rm /tmp/code-server.deb",
-            *ttyd_install_commands(),
-            f"npm install -g agent-browser@{AGENT_BROWSER_VERSION}",
+            *toolchain.ttyd_install_commands(),
+            f"npm install -g agent-browser@{toolchain.AGENT_BROWSER_VERSION}",
             "agent-browser install",
             "mkdir -p /workspace /app/plugins /tmp/opencode",
             # Install the SCM credential-helper shim and configure git
             # system-wide. The shim delegates to the Python helper module
             # under sandbox_runtime, baked in at build time via add_local_dir
             # below. Mirror packages/modal-infra/src/images/base.py.
-            *git_credential_helper_commands(),
+            *toolchain.git_credential_helper_commands(),
         )
         .env(
             {

--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -49,6 +49,38 @@ TTYD_SHA256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55"
 # v51: SCM credential helper backed by control plane; remove embedded VCS tokens
 CACHE_BUSTER = "v52-bake-opencode-global-deps"
 
+
+def opencode_deps_staging_commands() -> tuple[str, ...]:
+    """Commands that pre-stage OpenCode plugin deps and global config."""
+    return (
+        "mkdir -p /app/opencode-deps",
+        # Pin staged plugin to OPENCODE_VERSION so the pre-staged tree copied
+        # into .opencode/ at boot matches the globally installed plugin (#567).
+        f'echo \'{{"name":"opencode-tools","type":"module",'
+        f'"dependencies":{{"@opencode-ai/plugin":"{OPENCODE_VERSION}"}}}}\''
+        " > /app/opencode-deps/package.json",
+        "cd /app/opencode-deps && npm install --ignore-scripts --no-audit --no-fund",
+        # Bake the in-sync tree into the global config dir so the runtime seed is a no-op.
+        "mkdir -p /root/.config/opencode",
+        "cp -a /app/opencode-deps/. /root/.config/opencode/",
+    )
+
+
+def git_credential_helper_commands() -> tuple[str, ...]:
+    """Commands that install and configure the Open-Inspect git credential helper."""
+    return (
+        "printf '%s\\n'"
+        " '#!/bin/sh'"
+        " 'exec python3 -m sandbox_runtime.credentials.git_credential_helper \"$@\"'"
+        " > /usr/local/bin/oi-git-credentials",
+        "chmod 0755 /usr/local/bin/oi-git-credentials",
+        "git config --system credential.helper /usr/local/bin/oi-git-credentials",
+        # Pass the repo path to the helper so it can scope credentials to the
+        # session repo, not just the host.
+        "git config --system credential.useHttpPath true",
+    )
+
+
 # Base image with all development tools
 base_image = (
     modal.Image.debian_slim(python_version="3.12")
@@ -140,16 +172,7 @@ base_image = (
     # multi-second node_modules copy on every boot. Baking it makes that seed a
     # no-op (it skips when node_modules already exists). See #767 / #790.
     .run_commands(
-        "mkdir -p /app/opencode-deps",
-        # Pin staged plugin to OPENCODE_VERSION so the pre-staged tree copied
-        # into .opencode/ at boot matches the globally installed plugin (#567).
-        f'echo \'{{"name":"opencode-tools","type":"module",'
-        f'"dependencies":{{"@opencode-ai/plugin":"{OPENCODE_VERSION}"}}}}\''
-        " > /app/opencode-deps/package.json",
-        "cd /app/opencode-deps && npm install --ignore-scripts --no-audit --no-fund",
-        # Bake the in-sync tree into the global config dir so the runtime seed is a no-op.
-        "mkdir -p /root/.config/opencode",
-        "cp -a /app/opencode-deps/. /root/.config/opencode/",
+        *opencode_deps_staging_commands(),
     )
     # Install code-server for browser-based VS Code editing (direct .deb from GitHub releases)
     .run_commands(
@@ -191,15 +214,7 @@ base_image = (
     # system level so it applies before entrypoint.py has a chance to run
     # (e.g. when restoring a snapshot whose first action is a `git fetch`).
     .run_commands(
-        "printf '%s\\n'"
-        " '#!/bin/sh'"
-        " 'exec python3 -m sandbox_runtime.credentials.git_credential_helper \"$@\"'"
-        " > /usr/local/bin/oi-git-credentials",
-        "chmod 0755 /usr/local/bin/oi-git-credentials",
-        "git config --system credential.helper /usr/local/bin/oi-git-credentials",
-        # Pass the repo path to the helper so it can scope credentials to the
-        # session repo, not just the host.
-        "git config --system credential.useHttpPath true",
+        *git_credential_helper_commands(),
     )
     # Set environment variables (including cache buster to force rebuild)
     .env(

--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -16,69 +16,21 @@ from pathlib import Path
 import modal
 
 import sandbox_runtime
+from sandbox_runtime.toolchain import (
+    AGENT_BROWSER_VERSION,
+    CODE_SERVER_VERSION,
+    OPENCODE_VERSION,
+    git_credential_helper_commands,
+    opencode_deps_staging_commands,
+    ttyd_install_commands,
+)
 
 # Get the path to the sandbox runtime code (provider-agnostic)
 SANDBOX_RUNTIME_DIR = Path(sandbox_runtime.__file__).parent
 
-# OpenCode version to install.
-#
-# Pinned to 1.14.41 — the last release before opencode's Hono → Effect Schema
-# migration (landed across v1.14.42+, released 2026-05-09 onward) broke event
-# publishing on the legacy `/event` SSE endpoint. With newer versions the
-# bridge connects, posts the prompt, opencode processes it and records the
-# assistant response in the session store, but no `message.updated` /
-# `message.part.updated` / `session.idle` events are streamed back — so the
-# session shows execution_complete with no reply.
-#
-# Symptom in bridge logs: `prompt.run outcome=success duration_ms=35-367`,
-# which means `_stream_opencode_response_sse` returned with zero yielded
-# events. Tracked in #567.
-OPENCODE_VERSION = "1.14.41"
-
-# code-server version to install (pinned for reproducible images)
-CODE_SERVER_VERSION = "4.109.5"
-
-# agent-browser version to install (pinned for reproducible images)
-AGENT_BROWSER_VERSION = "0.21.2"
-
-# ttyd version to install (pinned for reproducible images)
-TTYD_VERSION = "1.7.7"
-TTYD_SHA256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55"
-
 # Cache buster - change this to force Modal image rebuild
 # v51: SCM credential helper backed by control plane; remove embedded VCS tokens
 CACHE_BUSTER = "v52-bake-opencode-global-deps"
-
-
-def opencode_deps_staging_commands() -> tuple[str, ...]:
-    """Commands that pre-stage OpenCode plugin deps and global config."""
-    return (
-        "mkdir -p /app/opencode-deps",
-        # Pin staged plugin to OPENCODE_VERSION so the pre-staged tree copied
-        # into .opencode/ at boot matches the globally installed plugin (#567).
-        f'echo \'{{"name":"opencode-tools","type":"module",'
-        f'"dependencies":{{"@opencode-ai/plugin":"{OPENCODE_VERSION}"}}}}\''
-        " > /app/opencode-deps/package.json",
-        "cd /app/opencode-deps && npm install --ignore-scripts --no-audit --no-fund",
-        # Bake the in-sync tree into the global config dir so the runtime seed is a no-op.
-        "mkdir -p /root/.config/opencode",
-        "cp -a /app/opencode-deps/. /root/.config/opencode/",
-    )
-
-
-def git_credential_helper_commands() -> tuple[str, ...]:
-    """Commands that install and configure the Open-Inspect git credential helper."""
-    return (
-        "printf '%s\\n'"
-        " '#!/bin/sh'"
-        " 'exec python3 -m sandbox_runtime.credentials.git_credential_helper \"$@\"'"
-        " > /usr/local/bin/oi-git-credentials",
-        "chmod 0755 /usr/local/bin/oi-git-credentials",
-        "git config --system credential.helper /usr/local/bin/oi-git-credentials",
-        # Pass the repo path to the helper so it can scope credentials to the
-        # session repo, not just the host.
-        "git config --system credential.useHttpPath true",
-    )
 
 
 # Base image with all development tools
@@ -185,12 +137,7 @@ base_image = (
     )
     # Install ttyd web terminal (direct binary from GitHub releases)
     .run_commands(
-        f"curl -fsSL -o /usr/local/bin/ttyd"
-        f" https://github.com/tsl0922/ttyd/releases/download/{TTYD_VERSION}"
-        f"/ttyd.x86_64",
-        f'echo "{TTYD_SHA256}  /usr/local/bin/ttyd" | sha256sum -c -',
-        "chmod +x /usr/local/bin/ttyd",
-        "ttyd --version",
+        *ttyd_install_commands(),
     )
     # Install agent-browser CLI and download Chromium
     .run_commands(

--- a/packages/sandbox-runtime/src/sandbox_runtime/toolchain.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/toolchain.py
@@ -1,0 +1,57 @@
+"""Canonical sandbox toolchain install contract shared by Python providers."""
+
+# OpenCode version to install.
+#
+# Pinned to 1.14.41 — the last release before opencode's Hono → Effect Schema
+# migration (landed across v1.14.42+, released 2026-05-09 onward) broke event
+# publishing on the legacy `/event` SSE endpoint. With newer versions the
+# bridge connects, posts the prompt, opencode processes it and records the
+# assistant response in the session store, but no `message.updated` /
+# `message.part.updated` / `session.idle` events are streamed back — so the
+# session shows execution_complete with no reply.
+#
+# Symptom in bridge logs: `prompt.run outcome=success duration_ms=35-367`,
+# which means `_stream_opencode_response_sse` returned with zero yielded
+# events. Tracked in #567.
+OPENCODE_VERSION = "1.14.41"
+CODE_SERVER_VERSION = "4.109.5"
+AGENT_BROWSER_VERSION = "0.21.2"
+TTYD_VERSION = "1.7.7"
+TTYD_SHA256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55"
+
+
+def opencode_deps_staging_commands() -> tuple[str, ...]:
+    """Commands that pre-stage OpenCode plugin deps and global config."""
+    return (
+        "mkdir -p /app/opencode-deps",
+        f'echo \'{{"name":"opencode-tools","type":"module",'
+        f'"dependencies":{{"@opencode-ai/plugin":"{OPENCODE_VERSION}"}}}}\''
+        " > /app/opencode-deps/package.json",
+        "cd /app/opencode-deps && npm install --ignore-scripts --no-audit --no-fund",
+        "mkdir -p /root/.config/opencode",
+        "cp -a /app/opencode-deps/. /root/.config/opencode/",
+    )
+
+
+def ttyd_install_commands() -> tuple[str, ...]:
+    """Commands that install pinned ttyd from the upstream release binary."""
+    return (
+        f"curl -fsSL -o /usr/local/bin/ttyd "
+        f"https://github.com/tsl0922/ttyd/releases/download/{TTYD_VERSION}/ttyd.x86_64",
+        f'echo "{TTYD_SHA256}  /usr/local/bin/ttyd" | sha256sum -c -',
+        "chmod +x /usr/local/bin/ttyd",
+        "ttyd --version",
+    )
+
+
+def git_credential_helper_commands() -> tuple[str, ...]:
+    """Commands that install and configure the Open-Inspect git credential helper."""
+    return (
+        "printf '%s\\n'"
+        " '#!/bin/sh'"
+        " 'exec python3 -m sandbox_runtime.credentials.git_credential_helper \"$@\"'"
+        " > /usr/local/bin/oi-git-credentials",
+        "chmod 0755 /usr/local/bin/oi-git-credentials",
+        "git config --system credential.helper /usr/local/bin/oi-git-credentials",
+        "git config --system credential.useHttpPath true",
+    )

--- a/packages/sandbox-runtime/tests/test_toolchain_contract.py
+++ b/packages/sandbox-runtime/tests/test_toolchain_contract.py
@@ -1,0 +1,30 @@
+"""Tests for the shared sandbox toolchain install contract."""
+
+from sandbox_runtime import toolchain
+
+
+def test_opencode_deps_staging_contract() -> None:
+    commands = "\n".join(toolchain.opencode_deps_staging_commands())
+
+    assert "mkdir -p /app/opencode-deps" in commands
+    assert f'"@opencode-ai/plugin":"{toolchain.OPENCODE_VERSION}"' in commands
+    assert "npm install --ignore-scripts --no-audit --no-fund" in commands
+    assert "mkdir -p /root/.config/opencode" in commands
+    assert "cp -a /app/opencode-deps/. /root/.config/opencode/" in commands
+
+
+def test_git_credential_helper_contract() -> None:
+    commands = "\n".join(toolchain.git_credential_helper_commands())
+
+    assert "python3 -m sandbox_runtime.credentials.git_credential_helper" in commands
+    assert "> /usr/local/bin/oi-git-credentials" in commands
+    assert "git config --system credential.helper /usr/local/bin/oi-git-credentials" in commands
+    assert "git config --system credential.useHttpPath true" in commands
+
+
+def test_ttyd_install_contract() -> None:
+    commands = "\n".join(toolchain.ttyd_install_commands())
+
+    assert f"/releases/download/{toolchain.TTYD_VERSION}/ttyd.x86_64" in commands
+    assert toolchain.TTYD_SHA256 in commands
+    assert "chmod +x /usr/local/bin/ttyd" in commands


### PR DESCRIPTION
## Summary
- Factor repeated Modal image install snippets into provider-local helpers for OpenCode dependency staging and git credential helper setup.
- Normalize Daytona base snapshot tooling with pinned ttyd installation, /app/opencode-deps staging, and /root/.config/opencode seeding.
- Update Vercel bootstrap to use shell helper functions and seed global OpenCode deps, with focused coverage for the generated script.

## Verification
- `npm test -w @open-inspect/control-plane -- src/sandbox/providers/vercel/bootstrap.test.ts src/sandbox/providers/vercel/base-snapshot.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `python -m py_compile packages/modal-infra/src/images/base.py packages/daytona-infra/src/toolchain.py`
- `npx prettier --check packages/control-plane/src/sandbox/providers/vercel/bootstrap.ts packages/control-plane/src/sandbox/providers/vercel/bootstrap.test.ts`

## Notes
- `pytest`/`python -m pytest` and `python -m ruff` were unavailable in the shell environment before commit; the commit hook did run `ruff check --fix` and `ruff format` for the staged Modal Python file.
- Daytona normalization assumes its Debian-based image accepts the same direct upstream ttyd binary install used by Modal.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/9bccd115ad6b6a2cfbef8c12a1653065)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added contract-style tests to ensure sandbox bootstrap and image build command generation includes the expected setup steps for OpenCode deps, git credential helper configuration, and ttyd installation.

* **Refactor**
  * Unified sandbox runtime toolchain setup so dependency staging, credential helper configuration, and ttyd installation are generated consistently across sandbox providers.
  * Restructured Vercel bootstrap script generation to use clearer, reusable command blocks.

* **Chores**
  * Pinned specific sandbox component versions (including ttyd) to ensure consistent runtime provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->