### PR TITLE
refactor(shared): replace vi.mock with injected dep in resolve-users

### DIFF
--- a/packages/shared/src/slack/resolve-users.test.ts
+++ b/packages/shared/src/slack/resolve-users.test.ts
@@ -1,78 +1,65 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import type * as ClientModule from "./client";
-
-const { mockGetUserInfo } = vi.hoisted(() => ({
-  mockGetUserInfo: vi.fn(),
-}));
-
-vi.mock("./client", async () => {
-  const actual = await vi.importActual<typeof ClientModule>("./client");
-  return {
-    ...actual,
-    getUserInfo: mockGetUserInfo,
-  };
-});
-
+import { describe, expect, it } from "vitest";
+import type { SlackEnvelope, SlackUser } from "./client";
 import { resolveUserNames } from "./resolve-users";
 
+type GetUserInfo = (token: string, userId: string) => Promise<SlackEnvelope<{ user: SlackUser }>>;
+
 describe("resolveUserNames", () => {
-  beforeEach(() => {
-    mockGetUserInfo.mockReset();
-  });
   it("resolves display_name when available", async () => {
-    mockGetUserInfo.mockResolvedValue({
+    const fakeGetUserInfo: GetUserInfo = async (_token, _userId) => ({
       ok: true,
       user: { id: "U1", name: "alice", profile: { display_name: "Alice S" } },
     });
 
-    const result = await resolveUserNames("token", ["U1"]);
+    const result = await resolveUserNames("token", ["U1"], { getUserInfo: fakeGetUserInfo });
     expect(result.get("U1")).toBe("Alice S");
   });
 
   it("falls back to name when display_name is empty", async () => {
-    mockGetUserInfo.mockResolvedValue({
+    const fakeGetUserInfo: GetUserInfo = async (_token, _userId) => ({
       ok: true,
       user: { id: "U2", name: "bob.jones", profile: { display_name: "" } },
     });
 
-    const result = await resolveUserNames("token", ["U2"]);
+    const result = await resolveUserNames("token", ["U2"], { getUserInfo: fakeGetUserInfo });
     expect(result.get("U2")).toBe("bob.jones");
   });
 
   it("falls back to user ID when API fails", async () => {
-    mockGetUserInfo.mockRejectedValue(new Error("network error"));
+    const fakeGetUserInfo: GetUserInfo = async (_token, _userId) => {
+      throw new Error("network error");
+    };
 
-    const result = await resolveUserNames("token", ["U3"]);
+    const result = await resolveUserNames("token", ["U3"], { getUserInfo: fakeGetUserInfo });
     // Promise.allSettled catches the rejection — ID is not in the map
     expect(result.has("U3")).toBe(false);
   });
 
   it("falls back to user ID when user info is missing", async () => {
-    mockGetUserInfo.mockResolvedValue({ ok: false, error: "user_not_found" });
+    const fakeGetUserInfo: GetUserInfo = async (_token, _userId) => ({
+      ok: false,
+      error: "user_not_found",
+    });
 
-    const result = await resolveUserNames("token", ["U4"]);
+    const result = await resolveUserNames("token", ["U4"], { getUserInfo: fakeGetUserInfo });
     expect(result.get("U4")).toBe("U4");
   });
 
   it("resolves multiple users in parallel", async () => {
-    mockGetUserInfo
-      .mockResolvedValueOnce({
-        ok: true,
-        user: { id: "U1", name: "alice", profile: { display_name: "Alice" } },
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        user: { id: "U2", name: "bob", profile: { display_name: "Bob" } },
-      });
+    const responses: Record<string, SlackEnvelope<{ user: SlackUser }>> = {
+      U1: { ok: true, user: { id: "U1", name: "alice", profile: { display_name: "Alice" } } },
+      U2: { ok: true, user: { id: "U2", name: "bob", profile: { display_name: "Bob" } } },
+    };
+    const fakeGetUserInfo: GetUserInfo = async (_token, userId) => responses[userId]!;
 
-    const result = await resolveUserNames("token", ["U1", "U2"]);
+    const result = await resolveUserNames("token", ["U1", "U2"], { getUserInfo: fakeGetUserInfo });
     expect(result.get("U1")).toBe("Alice");
     expect(result.get("U2")).toBe("Bob");
     expect(result.size).toBe(2);
   });
 
   it("does not include real_name in fallback chain", async () => {
-    mockGetUserInfo.mockResolvedValue({
+    const fakeGetUserInfo: GetUserInfo = async (_token, _userId) => ({
       ok: true,
       user: {
         id: "U5",
@@ -82,14 +69,20 @@ describe("resolveUserNames", () => {
       },
     });
 
-    const result = await resolveUserNames("token", ["U5"]);
+    const result = await resolveUserNames("token", ["U5"], { getUserInfo: fakeGetUserInfo });
     // Should use name (jdoe), not real_name (John Doe)
     expect(result.get("U5")).toBe("jdoe");
   });
 
   it("returns empty map for empty input", async () => {
-    const result = await resolveUserNames("token", []);
+    let callCount = 0;
+    const fakeGetUserInfo: GetUserInfo = async (_token, _userId) => {
+      callCount++;
+      return { ok: true, user: { id: "X", name: "x" } };
+    };
+
+    const result = await resolveUserNames("token", [], { getUserInfo: fakeGetUserInfo });
     expect(result.size).toBe(0);
-    expect(mockGetUserInfo).not.toHaveBeenCalled();
+    expect(callCount).toBe(0);
   });
 });

--- a/packages/shared/src/slack/resolve-users.test.ts
+++ b/packages/shared/src/slack/resolve-users.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { SlackEnvelope, SlackUser } from "./client";
-import { resolveUserNames } from "./resolve-users";
-
-type GetUserInfo = (token: string, userId: string) => Promise<SlackEnvelope<{ user: SlackUser }>>;
+import { resolveUserNames, type GetUserInfo } from "./resolve-users";
 
 describe("resolveUserNames", () => {
   it("resolves display_name when available", async () => {
@@ -11,7 +9,7 @@ describe("resolveUserNames", () => {
       user: { id: "U1", name: "alice", profile: { display_name: "Alice S" } },
     });
 
-    const result = await resolveUserNames("token", ["U1"], { getUserInfo: fakeGetUserInfo });
+    const result = await resolveUserNames("token", ["U1"], fakeGetUserInfo);
     expect(result.get("U1")).toBe("Alice S");
   });
 
@@ -21,7 +19,7 @@ describe("resolveUserNames", () => {
       user: { id: "U2", name: "bob.jones", profile: { display_name: "" } },
     });
 
-    const result = await resolveUserNames("token", ["U2"], { getUserInfo: fakeGetUserInfo });
+    const result = await resolveUserNames("token", ["U2"], fakeGetUserInfo);
     expect(result.get("U2")).toBe("bob.jones");
   });
 
@@ -30,7 +28,7 @@ describe("resolveUserNames", () => {
       throw new Error("network error");
     };
 
-    const result = await resolveUserNames("token", ["U3"], { getUserInfo: fakeGetUserInfo });
+    const result = await resolveUserNames("token", ["U3"], fakeGetUserInfo);
     // Promise.allSettled catches the rejection — ID is not in the map
     expect(result.has("U3")).toBe(false);
   });
@@ -41,7 +39,7 @@ describe("resolveUserNames", () => {
       error: "user_not_found",
     });
 
-    const result = await resolveUserNames("token", ["U4"], { getUserInfo: fakeGetUserInfo });
+    const result = await resolveUserNames("token", ["U4"], fakeGetUserInfo);
     expect(result.get("U4")).toBe("U4");
   });
 
@@ -52,7 +50,7 @@ describe("resolveUserNames", () => {
     };
     const fakeGetUserInfo: GetUserInfo = async (_token, userId) => responses[userId]!;
 
-    const result = await resolveUserNames("token", ["U1", "U2"], { getUserInfo: fakeGetUserInfo });
+    const result = await resolveUserNames("token", ["U1", "U2"], fakeGetUserInfo);
     expect(result.get("U1")).toBe("Alice");
     expect(result.get("U2")).toBe("Bob");
     expect(result.size).toBe(2);
@@ -69,7 +67,7 @@ describe("resolveUserNames", () => {
       },
     });
 
-    const result = await resolveUserNames("token", ["U5"], { getUserInfo: fakeGetUserInfo });
+    const result = await resolveUserNames("token", ["U5"], fakeGetUserInfo);
     // Should use name (jdoe), not real_name (John Doe)
     expect(result.get("U5")).toBe("jdoe");
   });
@@ -81,7 +79,7 @@ describe("resolveUserNames", () => {
       return { ok: true, user: { id: "X", name: "x" } };
     };
 
-    const result = await resolveUserNames("token", [], { getUserInfo: fakeGetUserInfo });
+    const result = await resolveUserNames("token", [], fakeGetUserInfo);
     expect(result.size).toBe(0);
     expect(callCount).toBe(0);
   });

--- a/packages/shared/src/slack/resolve-users.ts
+++ b/packages/shared/src/slack/resolve-users.ts
@@ -1,4 +1,6 @@
-import { getUserInfo } from "./client";
+import { getUserInfo as defaultGetUserInfo } from "./client";
+
+type GetUserInfo = (token: string, userId: string) => ReturnType<typeof defaultGetUserInfo>;
 
 /**
  * Resolve Slack user IDs to display names.
@@ -7,11 +9,16 @@ import { getUserInfo } from "./client";
  * error envelope or thrown exception via `Promise.allSettled`), the entry is
  * either populated with the raw user ID (envelope failure) or omitted entirely
  * (thrown exception). Callers should treat a missing entry as "unknown user".
+ *
+ * The optional `deps` parameter allows injecting a custom `getUserInfo`
+ * implementation for testing without module-level mocking.
  */
 export async function resolveUserNames(
   token: string,
-  userIds: string[]
+  userIds: string[],
+  deps: { getUserInfo?: GetUserInfo } = {}
 ): Promise<Map<string, string>> {
+  const getUserInfo = deps.getUserInfo ?? defaultGetUserInfo;
   const names = new Map<string, string>();
   const results = await Promise.allSettled(
     userIds.map(async (id) => {

--- a/packages/shared/src/slack/resolve-users.ts
+++ b/packages/shared/src/slack/resolve-users.ts
@@ -1,6 +1,6 @@
 import { getUserInfo as defaultGetUserInfo } from "./client";
 
-type GetUserInfo = (token: string, userId: string) => ReturnType<typeof defaultGetUserInfo>;
+export type GetUserInfo = (token: string, userId: string) => ReturnType<typeof defaultGetUserInfo>;
 
 /**
  * Resolve Slack user IDs to display names.
@@ -9,16 +9,12 @@ type GetUserInfo = (token: string, userId: string) => ReturnType<typeof defaultG
  * error envelope or thrown exception via `Promise.allSettled`), the entry is
  * either populated with the raw user ID (envelope failure) or omitted entirely
  * (thrown exception). Callers should treat a missing entry as "unknown user".
- *
- * The optional `deps` parameter allows injecting a custom `getUserInfo`
- * implementation for testing without module-level mocking.
  */
 export async function resolveUserNames(
   token: string,
   userIds: string[],
-  deps: { getUserInfo?: GetUserInfo } = {}
+  getUserInfo: GetUserInfo = defaultGetUserInfo
 ): Promise<Map<string, string>> {
-  const getUserInfo = deps.getUserInfo ?? defaultGetUserInfo;
   const names = new Map<string, string>();
   const results = await Promise.allSettled(
     userIds.map(async (id) => {


### PR DESCRIPTION
## What changed and why

`packages/shared/src/slack/resolve-users.test.ts` was using `vi.mock("./client", ...)` with `vi.hoisted` to swap out `getUserInfo` during tests. This violates the project's testing standards, which require real seams (constructor/parameter injection, in-memory adapters) rather than module-level mocking.

## Approach

An optional `deps` parameter was added to `resolveUserNames` with a production default:

```ts
type GetUserInfo = (token: string, userId: string) => ReturnType<typeof defaultGetUserInfo>;

export async function resolveUserNames(
  token: string,
  userIds: string[],
  deps: { getUserInfo?: GetUserInfo } = {}
): Promise<Map<string, string>>
```

- The new parameter is **optional with a default of `{}`**, so all existing callers (e.g. `slack-bot`) continue to work without any changes.
- The production default is the real `getUserInfo` imported from `./client`.

## Test changes

- Removed all `vi.mock`, `vi.hoisted`, `vi.fn`, and `vi.mocked` usage.
- Removed the `vi` import entirely.
- Each test now defines a local inline fake `getUserInfo` function and passes it via `deps`.
- The "empty input" test tracks call count with a closure variable instead of a spy.
- All 6 original test scenarios are preserved with identical assertions.

## Verification

- `npm test -w @open-inspect/shared` — 220 tests pass across 18 files.
- `npx tsc --noEmit` in `packages/shared` — no type errors.


---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/68fba49c178432c3eded91ebd99a0a92)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack user name resolution reliability, including correct fallbacks when display names are unavailable and clearer handling for missing or failed lookups.
  * More robust behavior for rejected requests and non-OK responses, ensuring the result map reflects the expected user identifier when details can’t be retrieved.
* **Tests**
  * Updated tests to use isolated per-case stubs, strengthening coverage for empty input, single-user fallback behavior, and distinct parallel user scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->