### PR TITLE
fix: batch recovery sweep updates and add LIMIT to sweep queries

### DIFF
--- a/packages/control-plane/src/db/automation-store.test.ts
+++ b/packages/control-plane/src/db/automation-store.test.ts
@@ -354,7 +354,7 @@ describe("AutomationStore", () => {
         allResults: [sampleRunRow],
       });
       const store = new AutomationStore(db);
-      const result = await store.getOrphanedStartingRuns(5 * 60 * 1000);
+      const result = await store.getOrphanedStartingRuns(5 * 60 * 1000, 50);
       expect(result).toHaveLength(1);
       expect(statements[0].sql).toContain("status = 'starting'");
     });
@@ -366,7 +366,7 @@ describe("AutomationStore", () => {
         allResults: [{ ...sampleRunRow, status: "running", started_at: now }],
       });
       const store = new AutomationStore(db);
-      const result = await store.getTimedOutRunningRuns(90 * 60 * 1000);
+      const result = await store.getTimedOutRunningRuns(90 * 60 * 1000, 50);
       expect(result).toHaveLength(1);
       expect(statements[0].sql).toContain("status = 'running'");
     });

--- a/packages/control-plane/src/db/automation-store.ts
+++ b/packages/control-plane/src/db/automation-store.ts
@@ -389,7 +389,10 @@ export class AutomationStore {
 
     const placeholders = automationIds.map(() => "?").join(", ");
     const result = await this.db
-      .prepare(`SELECT id, consecutive_failures FROM automations WHERE id IN (${placeholders})`)
+      .prepare(
+        `SELECT id, consecutive_failures FROM automations
+         WHERE id IN (${placeholders}) AND deleted_at IS NULL`
+      )
       .bind(...automationIds)
       .all<{ id: string; consecutive_failures: number }>();
 
@@ -502,7 +505,7 @@ export class AutomationStore {
   async getOrphanedStartingRuns(thresholdMs: number, limit: number): Promise<AutomationRunRow[]> {
     const cutoff = Date.now() - thresholdMs;
     const result = await this.db
-      .prepare(`${AutomationStore.ORPHANED_STARTING_RUNS_SQL} LIMIT ?`)
+      .prepare(`${AutomationStore.ORPHANED_STARTING_RUNS_SQL} ORDER BY created_at ASC LIMIT ?`)
       .bind(cutoff, limit)
       .all<AutomationRunRow>();
     return result.results || [];
@@ -514,7 +517,7 @@ export class AutomationStore {
   ): Promise<AutomationRunRow[]> {
     const cutoff = Date.now() - executionTimeoutMs;
     const result = await this.db
-      .prepare(`${AutomationStore.TIMED_OUT_RUNNING_RUNS_SQL} LIMIT ?`)
+      .prepare(`${AutomationStore.TIMED_OUT_RUNNING_RUNS_SQL} ORDER BY started_at ASC LIMIT ?`)
       .bind(cutoff, limit)
       .all<AutomationRunRow>();
     return result.results || [];

--- a/packages/control-plane/src/db/automation-store.ts
+++ b/packages/control-plane/src/db/automation-store.ts
@@ -355,6 +355,51 @@ export class AutomationStore {
       .run();
   }
 
+  async bulkFailRuns(runIds: string[], reason: string, completedAt: number): Promise<void> {
+    if (runIds.length === 0) return;
+    const placeholders = runIds.map(() => "?").join(", ");
+    await this.db
+      .prepare(
+        `UPDATE automation_runs
+         SET status = 'failed', failure_reason = ?, completed_at = ?
+         WHERE id IN (${placeholders})`
+      )
+      .bind(reason, completedAt, ...runIds)
+      .run();
+  }
+
+  async bulkIncrementFailures(
+    automationIdCounts: Map<string, number>
+  ): Promise<Map<string, number>> {
+    if (automationIdCounts.size === 0) return new Map();
+
+    const now = Date.now();
+    const automationIds = [...automationIdCounts.keys()];
+
+    const statements = automationIds.map((automationId) =>
+      this.db
+        .prepare(
+          `UPDATE automations
+           SET consecutive_failures = consecutive_failures + ?, updated_at = ?
+           WHERE id = ? AND deleted_at IS NULL`
+        )
+        .bind(automationIdCounts.get(automationId)!, now, automationId)
+    );
+    await this.db.batch(statements);
+
+    const placeholders = automationIds.map(() => "?").join(", ");
+    const result = await this.db
+      .prepare(`SELECT id, consecutive_failures FROM automations WHERE id IN (${placeholders})`)
+      .bind(...automationIds)
+      .all<{ id: string; consecutive_failures: number }>();
+
+    const counts = new Map<string, number>();
+    for (const row of result.results ?? []) {
+      counts.set(row.id, row.consecutive_failures);
+    }
+    return counts;
+  }
+
   async getActiveRunForAutomation(automationId: string): Promise<AutomationRunRow | null> {
     return this.db
       .prepare(
@@ -454,20 +499,23 @@ export class AutomationStore {
   static readonly TIMED_OUT_RUNNING_RUNS_SQL =
     "SELECT * FROM automation_runs WHERE status = 'running' AND started_at IS NOT NULL AND started_at < ?";
 
-  async getOrphanedStartingRuns(thresholdMs: number): Promise<AutomationRunRow[]> {
+  async getOrphanedStartingRuns(thresholdMs: number, limit: number): Promise<AutomationRunRow[]> {
     const cutoff = Date.now() - thresholdMs;
     const result = await this.db
-      .prepare(AutomationStore.ORPHANED_STARTING_RUNS_SQL)
-      .bind(cutoff)
+      .prepare(`${AutomationStore.ORPHANED_STARTING_RUNS_SQL} LIMIT ?`)
+      .bind(cutoff, limit)
       .all<AutomationRunRow>();
     return result.results || [];
   }
 
-  async getTimedOutRunningRuns(executionTimeoutMs: number): Promise<AutomationRunRow[]> {
+  async getTimedOutRunningRuns(
+    executionTimeoutMs: number,
+    limit: number
+  ): Promise<AutomationRunRow[]> {
     const cutoff = Date.now() - executionTimeoutMs;
     const result = await this.db
-      .prepare(AutomationStore.TIMED_OUT_RUNNING_RUNS_SQL)
-      .bind(cutoff)
+      .prepare(`${AutomationStore.TIMED_OUT_RUNNING_RUNS_SQL} LIMIT ?`)
+      .bind(cutoff, limit)
       .all<AutomationRunRow>();
     return result.results || [];
   }

--- a/packages/control-plane/src/scheduler/durable-object.test.ts
+++ b/packages/control-plane/src/scheduler/durable-object.test.ts
@@ -462,6 +462,46 @@ describe("SchedulerDO", () => {
       );
     });
 
+    it("recovers one category when the other recovery query fails", async () => {
+      const timedOutRun = {
+        id: "timeout-1",
+        automation_id: "auto-1",
+        status: "running",
+        started_at: now - 2 * 60 * 60 * 1000,
+      };
+      mockStore.getOrphanedStartingRuns.mockRejectedValue(new Error("D1 orphan query timeout"));
+      mockStore.getTimedOutRunningRuns.mockResolvedValue([timedOutRun]);
+      mockStore.bulkIncrementFailures.mockResolvedValue(new Map([["auto-1", 1]]));
+
+      const scheduler = createSchedulerDO();
+      const errorSpy = vi
+        .spyOn((scheduler as unknown as { log: Logger }).log, "error")
+        .mockImplementation(() => {});
+
+      const res = await scheduler.fetch(
+        new Request("http://internal/internal/tick", { method: "POST" })
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockStore.bulkFailRuns).toHaveBeenCalledWith(
+        ["timeout-1"],
+        "execution_timeout",
+        expect.any(Number)
+      );
+      expect(mockStore.bulkIncrementFailures).toHaveBeenCalledWith(new Map([["auto-1", 1]]));
+
+      const queryErrorCall = errorSpy.mock.calls.find(
+        ([, data]) =>
+          (data as Record<string, unknown> | undefined)?.event === "scheduler.recovery.query_error"
+      );
+      expect(queryErrorCall).toBeDefined();
+      expect(queryErrorCall![1]).toMatchObject({
+        event: "scheduler.recovery.query_error",
+        category: "orphaned",
+        error: "D1 orphan query timeout",
+      });
+    });
+
     it("batches multiple orphaned runs into a single bulkFailRuns call", async () => {
       const orphanedRuns = [
         { id: "orphan-a", automation_id: "auto-1", status: "starting", created_at: now - 1 },
@@ -511,6 +551,71 @@ describe("SchedulerDO", () => {
         automation_id: "auto-1",
         consecutive_failures: 3,
       });
+    });
+
+    it("continues auto-pausing later automations when one auto-pause fails", async () => {
+      const orphanedRuns = [
+        {
+          id: "orphan-1",
+          automation_id: "auto-1",
+          status: "starting",
+          created_at: now - 10 * 60 * 1000,
+        },
+        {
+          id: "orphan-2",
+          automation_id: "auto-2",
+          status: "starting",
+          created_at: now - 10 * 60 * 1000,
+        },
+      ];
+      mockStore.getOrphanedStartingRuns.mockResolvedValue(orphanedRuns);
+      mockStore.bulkIncrementFailures.mockResolvedValue(
+        new Map([
+          ["auto-1", 3],
+          ["auto-2", 3],
+        ])
+      );
+      mockStore.autoPause.mockImplementation(async (automationId: string) => {
+        if (automationId === "auto-1") {
+          throw new Error("D1 auto-pause timeout");
+        }
+      });
+
+      const scheduler = createSchedulerDO();
+      const errorSpy = vi
+        .spyOn((scheduler as unknown as { log: Logger }).log, "error")
+        .mockImplementation(() => {});
+      const warnSpy = vi
+        .spyOn((scheduler as unknown as { log: Logger }).log, "warn")
+        .mockImplementation(() => {});
+
+      const res = await scheduler.fetch(
+        new Request("http://internal/internal/tick", { method: "POST" })
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockStore.autoPause).toHaveBeenCalledWith("auto-1");
+      expect(mockStore.autoPause).toHaveBeenCalledWith("auto-2");
+
+      const autoPauseErrorCall = errorSpy.mock.calls.find(
+        ([, data]) =>
+          (data as Record<string, unknown> | undefined)?.event ===
+          "scheduler.recovery.auto_pause_error"
+      );
+      expect(autoPauseErrorCall).toBeDefined();
+      expect(autoPauseErrorCall![1]).toMatchObject({
+        event: "scheduler.recovery.auto_pause_error",
+        automation_id: "auto-1",
+        consecutive_failures: 3,
+        error: "D1 auto-pause timeout",
+      });
+
+      const autoPauseSuccessCall = warnSpy.mock.calls.find(
+        ([, data]) =>
+          (data as Record<string, unknown> | undefined)?.event === "scheduler.auto_pause" &&
+          (data as Record<string, unknown> | undefined)?.automation_id === "auto-2"
+      );
+      expect(autoPauseSuccessCall).toBeDefined();
     });
 
     it("swallows bulkFailRuns errors and logs scheduler.recovery.bulk_fail_error", async () => {

--- a/packages/control-plane/src/scheduler/durable-object.test.ts
+++ b/packages/control-plane/src/scheduler/durable-object.test.ts
@@ -43,6 +43,8 @@ function createMockStore() {
     resetConsecutiveFailures: vi.fn().mockResolvedValue(undefined),
     autoPause: vi.fn().mockResolvedValue(undefined),
     update: vi.fn().mockResolvedValue(undefined),
+    bulkFailRuns: vi.fn().mockResolvedValue(undefined),
+    bulkIncrementFailures: vi.fn().mockResolvedValue(new Map()),
   };
 }
 
@@ -390,16 +392,17 @@ describe("SchedulerDO", () => {
         created_at: now - 10 * 60 * 1000,
       };
       mockStore.getOrphanedStartingRuns.mockResolvedValue([orphanedRun]);
+      mockStore.bulkIncrementFailures.mockResolvedValue(new Map([["auto-1", 1]]));
 
       const scheduler = createSchedulerDO();
       await scheduler.fetch(new Request("http://internal/internal/tick", { method: "POST" }));
 
-      expect(mockStore.updateRun).toHaveBeenCalledWith("orphan-1", {
-        status: "failed",
-        failure_reason: "session_creation_timeout",
-        completed_at: expect.any(Number),
-      });
-      expect(mockStore.incrementConsecutiveFailures).toHaveBeenCalledWith("auto-1");
+      expect(mockStore.bulkFailRuns).toHaveBeenCalledWith(
+        ["orphan-1"],
+        "session_creation_timeout",
+        expect.any(Number)
+      );
+      expect(mockStore.bulkIncrementFailures).toHaveBeenCalledWith(new Map([["auto-1", 1]]));
     });
 
     it("passes automation user_id to session index", async () => {
@@ -447,14 +450,138 @@ describe("SchedulerDO", () => {
         started_at: now - 2 * 60 * 60 * 1000,
       };
       mockStore.getTimedOutRunningRuns.mockResolvedValue([timedOutRun]);
+      mockStore.bulkIncrementFailures.mockResolvedValue(new Map([["auto-1", 1]]));
 
       const scheduler = createSchedulerDO();
       await scheduler.fetch(new Request("http://internal/internal/tick", { method: "POST" }));
 
-      expect(mockStore.updateRun).toHaveBeenCalledWith("timeout-1", {
-        status: "failed",
-        failure_reason: "execution_timeout",
-        completed_at: expect.any(Number),
+      expect(mockStore.bulkFailRuns).toHaveBeenCalledWith(
+        ["timeout-1"],
+        "execution_timeout",
+        expect.any(Number)
+      );
+    });
+
+    it("batches multiple orphaned runs into a single bulkFailRuns call", async () => {
+      const orphanedRuns = [
+        { id: "orphan-a", automation_id: "auto-1", status: "starting", created_at: now - 1 },
+        { id: "orphan-b", automation_id: "auto-1", status: "starting", created_at: now - 2 },
+        { id: "orphan-c", automation_id: "auto-1", status: "starting", created_at: now - 3 },
+      ];
+      mockStore.getOrphanedStartingRuns.mockResolvedValue(orphanedRuns);
+      mockStore.bulkIncrementFailures.mockResolvedValue(new Map([["auto-1", 3]]));
+
+      const scheduler = createSchedulerDO();
+      await scheduler.fetch(new Request("http://internal/internal/tick", { method: "POST" }));
+
+      expect(mockStore.bulkFailRuns).toHaveBeenCalledTimes(1);
+      expect(mockStore.bulkFailRuns).toHaveBeenCalledWith(
+        ["orphan-a", "orphan-b", "orphan-c"],
+        "session_creation_timeout",
+        expect.any(Number)
+      );
+      expect(mockStore.bulkIncrementFailures).toHaveBeenCalledWith(new Map([["auto-1", 3]]));
+    });
+
+    it("auto-pauses automation when bulk increment reaches threshold", async () => {
+      const orphanedRun = {
+        id: "orphan-1",
+        automation_id: "auto-1",
+        status: "starting",
+        created_at: now - 10 * 60 * 1000,
+      };
+      mockStore.getOrphanedStartingRuns.mockResolvedValue([orphanedRun]);
+      mockStore.bulkIncrementFailures.mockResolvedValue(new Map([["auto-1", 3]]));
+
+      const scheduler = createSchedulerDO();
+      const warnSpy = vi
+        .spyOn((scheduler as unknown as { log: Logger }).log, "warn")
+        .mockImplementation(() => {});
+
+      await scheduler.fetch(new Request("http://internal/internal/tick", { method: "POST" }));
+
+      expect(mockStore.autoPause).toHaveBeenCalledWith("auto-1");
+      const autoPauseCall = warnSpy.mock.calls.find(
+        ([, data]) =>
+          (data as Record<string, unknown> | undefined)?.event === "scheduler.auto_pause"
+      );
+      expect(autoPauseCall).toBeDefined();
+      expect(autoPauseCall![1]).toMatchObject({
+        event: "scheduler.auto_pause",
+        automation_id: "auto-1",
+        consecutive_failures: 3,
+      });
+    });
+
+    it("swallows bulkFailRuns errors and logs scheduler.recovery.bulk_fail_error", async () => {
+      const orphanedRun = {
+        id: "orphan-1",
+        automation_id: "auto-1",
+        status: "starting",
+        created_at: now - 10 * 60 * 1000,
+      };
+      mockStore.getOrphanedStartingRuns.mockResolvedValue([orphanedRun]);
+      mockStore.bulkFailRuns.mockRejectedValue(new Error("D1 timeout"));
+
+      const scheduler = createSchedulerDO();
+      const errorSpy = vi
+        .spyOn((scheduler as unknown as { log: Logger }).log, "error")
+        .mockImplementation(() => {});
+
+      const res = await scheduler.fetch(
+        new Request("http://internal/internal/tick", { method: "POST" })
+      );
+
+      expect(res.status).toBe(200);
+      const bulkFailErrorCall = errorSpy.mock.calls.find(
+        ([, data]) =>
+          (data as Record<string, unknown> | undefined)?.event ===
+          "scheduler.recovery.bulk_fail_error"
+      );
+      expect(bulkFailErrorCall).toBeDefined();
+      expect(bulkFailErrorCall![1]).toMatchObject({
+        event: "scheduler.recovery.bulk_fail_error",
+        orphaned_count: 1,
+        timed_out_count: 0,
+        error: "D1 timeout",
+      });
+      expect(mockStore.bulkIncrementFailures).not.toHaveBeenCalled();
+    });
+
+    it("swallows bulkIncrementFailures errors and logs scheduler.recovery.bulk_track_error", async () => {
+      const orphanedRun = {
+        id: "orphan-1",
+        automation_id: "auto-1",
+        status: "starting",
+        created_at: now - 10 * 60 * 1000,
+      };
+      mockStore.getOrphanedStartingRuns.mockResolvedValue([orphanedRun]);
+      mockStore.bulkIncrementFailures.mockRejectedValue(new Error("D1 timeout"));
+
+      const scheduler = createSchedulerDO();
+      const errorSpy = vi
+        .spyOn((scheduler as unknown as { log: Logger }).log, "error")
+        .mockImplementation(() => {});
+
+      const res = await scheduler.fetch(
+        new Request("http://internal/internal/tick", { method: "POST" })
+      );
+
+      expect(res.status).toBe(200);
+      expect(mockStore.bulkFailRuns).toHaveBeenCalledWith(
+        ["orphan-1"],
+        "session_creation_timeout",
+        expect.any(Number)
+      );
+      const bulkTrackErrorCall = errorSpy.mock.calls.find(
+        ([, data]) =>
+          (data as Record<string, unknown> | undefined)?.event ===
+          "scheduler.recovery.bulk_track_error"
+      );
+      expect(bulkTrackErrorCall).toBeDefined();
+      expect(bulkTrackErrorCall![1]).toMatchObject({
+        event: "scheduler.recovery.bulk_track_error",
+        error: "D1 timeout",
       });
     });
 

--- a/packages/control-plane/src/scheduler/durable-object.test.ts
+++ b/packages/control-plane/src/scheduler/durable-object.test.ts
@@ -541,11 +541,71 @@ describe("SchedulerDO", () => {
       expect(bulkFailErrorCall).toBeDefined();
       expect(bulkFailErrorCall![1]).toMatchObject({
         event: "scheduler.recovery.bulk_fail_error",
-        orphaned_count: 1,
-        timed_out_count: 0,
+        category: "orphaned",
+        count: 1,
         error: "D1 timeout",
       });
       expect(mockStore.bulkIncrementFailures).not.toHaveBeenCalled();
+    });
+
+    it("increments failures for runs marked failed when the other category throws", async () => {
+      const orphanedRun = {
+        id: "orphan-1",
+        automation_id: "auto-1",
+        status: "starting",
+        created_at: now - 10 * 60 * 1000,
+      };
+      const timedOutRun = {
+        id: "timeout-1",
+        automation_id: "auto-2",
+        status: "running",
+        started_at: now - 2 * 60 * 60 * 1000,
+      };
+      mockStore.getOrphanedStartingRuns.mockResolvedValue([orphanedRun]);
+      mockStore.getTimedOutRunningRuns.mockResolvedValue([timedOutRun]);
+      mockStore.bulkFailRuns.mockImplementation(async (runIds: string[]) => {
+        if (runIds.includes("timeout-1")) {
+          throw new Error("D1 timeout");
+        }
+      });
+      mockStore.bulkIncrementFailures.mockResolvedValue(new Map([["auto-1", 1]]));
+
+      const scheduler = createSchedulerDO();
+      const errorSpy = vi
+        .spyOn((scheduler as unknown as { log: Logger }).log, "error")
+        .mockImplementation(() => {});
+
+      const res = await scheduler.fetch(
+        new Request("http://internal/internal/tick", { method: "POST" })
+      );
+
+      expect(res.status).toBe(200);
+
+      expect(mockStore.bulkFailRuns).toHaveBeenCalledWith(
+        ["orphan-1"],
+        "session_creation_timeout",
+        expect.any(Number)
+      );
+      expect(mockStore.bulkFailRuns).toHaveBeenCalledWith(
+        ["timeout-1"],
+        "execution_timeout",
+        expect.any(Number)
+      );
+
+      expect(mockStore.bulkIncrementFailures).toHaveBeenCalledWith(new Map([["auto-1", 1]]));
+
+      const bulkFailErrorCall = errorSpy.mock.calls.find(
+        ([, data]) =>
+          (data as Record<string, unknown> | undefined)?.event ===
+          "scheduler.recovery.bulk_fail_error"
+      );
+      expect(bulkFailErrorCall).toBeDefined();
+      expect(bulkFailErrorCall![1]).toMatchObject({
+        event: "scheduler.recovery.bulk_fail_error",
+        category: "timed_out",
+        count: 1,
+        error: "D1 timeout",
+      });
     });
 
     it("swallows bulkIncrementFailures errors and logs scheduler.recovery.bulk_track_error", async () => {

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -256,10 +256,35 @@ export class SchedulerDO extends DurableObject<Env> {
       10
     );
 
-    const [orphaned, timedOut] = await Promise.all([
+    const [orphanedResult, timedOutResult] = await Promise.allSettled([
       store.getOrphanedStartingRuns(ORPHAN_THRESHOLD_MS, RECOVERY_SWEEP_LIMIT),
       store.getTimedOutRunningRuns(executionTimeoutMs, RECOVERY_SWEEP_LIMIT),
     ]);
+
+    const orphaned = orphanedResult.status === "fulfilled" ? orphanedResult.value : [];
+    const timedOut = timedOutResult.status === "fulfilled" ? timedOutResult.value : [];
+
+    if (orphanedResult.status === "rejected") {
+      this.log.error("Recovery sweep failed to query orphaned runs", {
+        event: "scheduler.recovery.query_error",
+        category: "orphaned",
+        error:
+          orphanedResult.reason instanceof Error
+            ? orphanedResult.reason.message
+            : String(orphanedResult.reason),
+      });
+    }
+
+    if (timedOutResult.status === "rejected") {
+      this.log.error("Recovery sweep failed to query timed-out runs", {
+        event: "scheduler.recovery.query_error",
+        category: "timed_out",
+        error:
+          timedOutResult.reason instanceof Error
+            ? timedOutResult.reason.message
+            : String(timedOutResult.reason),
+      });
+    }
 
     if (orphaned.length === 0 && timedOut.length === 0) return;
 
@@ -319,28 +344,40 @@ export class SchedulerDO extends DurableObject<Env> {
 
     if (recoveredRuns.length === 0) return;
 
-    try {
-      const automationCounts = new Map<string, number>();
-      for (const run of recoveredRuns) {
-        automationCounts.set(run.automation_id, (automationCounts.get(run.automation_id) ?? 0) + 1);
-      }
+    const automationCounts = new Map<string, number>();
+    for (const run of recoveredRuns) {
+      automationCounts.set(run.automation_id, (automationCounts.get(run.automation_id) ?? 0) + 1);
+    }
 
-      const newCounts = await store.bulkIncrementFailures(automationCounts);
-      for (const [automationId, count] of newCounts) {
-        if (count >= AUTO_PAUSE_THRESHOLD) {
-          await store.autoPause(automationId);
-          this.log.warn("Automation auto-paused due to consecutive failures", {
-            event: "scheduler.auto_pause",
-            automation_id: automationId,
-            consecutive_failures: count,
-          });
-        }
-      }
+    let newCounts: Map<string, number>;
+    try {
+      newCounts = await store.bulkIncrementFailures(automationCounts);
     } catch (e) {
       this.log.error("Recovery sweep failed to track failures", {
         event: "scheduler.recovery.bulk_track_error",
         error: e instanceof Error ? e.message : String(e),
       });
+      return;
+    }
+
+    for (const [automationId, count] of newCounts) {
+      if (count < AUTO_PAUSE_THRESHOLD) continue;
+
+      try {
+        await store.autoPause(automationId);
+        this.log.warn("Automation auto-paused due to consecutive failures", {
+          event: "scheduler.auto_pause",
+          automation_id: automationId,
+          consecutive_failures: count,
+        });
+      } catch (e) {
+        this.log.error("Recovery sweep failed to auto-pause automation", {
+          event: "scheduler.recovery.auto_pause_error",
+          automation_id: automationId,
+          consecutive_failures: count,
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
     }
   }
 

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -17,7 +17,12 @@ import {
   type AutomationEvent,
   type TriggerConfig,
 } from "@open-inspect/shared";
-import { AutomationStore, toAutomationRun, type AutomationRow } from "../db/automation-store";
+import {
+  AutomationStore,
+  toAutomationRun,
+  type AutomationRow,
+  type AutomationRunRow,
+} from "../db/automation-store";
 import { UserStore } from "../db/user-store";
 import { createRequestMetrics } from "../db/instrumented-d1";
 import { generateId } from "../auth/crypto";

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -42,6 +42,9 @@ const DEFAULT_EXECUTION_TIMEOUT_MS = 90 * 60 * 1000;
 /** Consecutive failure threshold for auto-pause. */
 const AUTO_PAUSE_THRESHOLD = 3;
 
+/** Max runs to recover per sweep type per tick (backpressure). */
+const RECOVERY_SWEEP_LIMIT = 50;
+
 export class SchedulerDO extends DurableObject<Env> {
   private readonly log: Logger;
 
@@ -243,32 +246,82 @@ export class SchedulerDO extends DurableObject<Env> {
   // ─── Recovery sweep ──────────────────────────────────────────────────────
 
   private async recoverySweep(store: AutomationStore): Promise<void> {
-    // Orphaned starting runs (session creation never completed)
-    const orphaned = await store.getOrphanedStartingRuns(ORPHAN_THRESHOLD_MS);
+    const executionTimeoutMs = parseInt(
+      this.env.EXECUTION_TIMEOUT_MS || String(DEFAULT_EXECUTION_TIMEOUT_MS),
+      10
+    );
+
+    const [orphaned, timedOut] = await Promise.all([
+      store.getOrphanedStartingRuns(ORPHAN_THRESHOLD_MS, RECOVERY_SWEEP_LIMIT),
+      store.getTimedOutRunningRuns(executionTimeoutMs, RECOVERY_SWEEP_LIMIT),
+    ]);
+
+    if (orphaned.length === 0 && timedOut.length === 0) return;
+
     for (const run of orphaned) {
       this.log.warn("Recovering orphaned starting run", {
         event: "scheduler.recovery.orphaned",
         run_id: run.id,
         automation_id: run.automation_id,
       });
-
-      await this.failRunAndTrack(store, run.id, run.automation_id, "session_creation_timeout");
     }
-
-    // Timed-out running runs
-    const executionTimeoutMs = parseInt(
-      this.env.EXECUTION_TIMEOUT_MS || String(DEFAULT_EXECUTION_TIMEOUT_MS),
-      10
-    );
-    const timedOut = await store.getTimedOutRunningRuns(executionTimeoutMs);
     for (const run of timedOut) {
       this.log.warn("Recovering timed-out running run", {
         event: "scheduler.recovery.timed_out",
         run_id: run.id,
         automation_id: run.automation_id,
       });
+    }
 
-      await this.failRunAndTrack(store, run.id, run.automation_id, "execution_timeout");
+    const now = Date.now();
+
+    try {
+      if (orphaned.length > 0) {
+        await store.bulkFailRuns(
+          orphaned.map((r) => r.id),
+          "session_creation_timeout",
+          now
+        );
+      }
+      if (timedOut.length > 0) {
+        await store.bulkFailRuns(
+          timedOut.map((r) => r.id),
+          "execution_timeout",
+          now
+        );
+      }
+    } catch (e) {
+      this.log.error("Recovery sweep failed to mark runs as failed", {
+        event: "scheduler.recovery.bulk_fail_error",
+        orphaned_count: orphaned.length,
+        timed_out_count: timedOut.length,
+        error: e instanceof Error ? e.message : String(e),
+      });
+      return;
+    }
+
+    try {
+      const automationCounts = new Map<string, number>();
+      for (const run of [...orphaned, ...timedOut]) {
+        automationCounts.set(run.automation_id, (automationCounts.get(run.automation_id) ?? 0) + 1);
+      }
+
+      const newCounts = await store.bulkIncrementFailures(automationCounts);
+      for (const [automationId, count] of newCounts) {
+        if (count >= AUTO_PAUSE_THRESHOLD) {
+          await store.autoPause(automationId);
+          this.log.warn("Automation auto-paused due to consecutive failures", {
+            event: "scheduler.auto_pause",
+            automation_id: automationId,
+            consecutive_failures: count,
+          });
+        }
+      }
+    } catch (e) {
+      this.log.error("Recovery sweep failed to track failures", {
+        event: "scheduler.recovery.bulk_track_error",
+        error: e instanceof Error ? e.message : String(e),
+      });
     }
   }
 

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -274,35 +274,49 @@ export class SchedulerDO extends DurableObject<Env> {
     }
 
     const now = Date.now();
+    const recoveredRuns: AutomationRunRow[] = [];
 
-    try {
-      if (orphaned.length > 0) {
+    if (orphaned.length > 0) {
+      try {
         await store.bulkFailRuns(
           orphaned.map((r) => r.id),
           "session_creation_timeout",
           now
         );
+        recoveredRuns.push(...orphaned);
+      } catch (e) {
+        this.log.error("Recovery sweep failed to mark orphaned runs as failed", {
+          event: "scheduler.recovery.bulk_fail_error",
+          category: "orphaned",
+          count: orphaned.length,
+          error: e instanceof Error ? e.message : String(e),
+        });
       }
-      if (timedOut.length > 0) {
+    }
+
+    if (timedOut.length > 0) {
+      try {
         await store.bulkFailRuns(
           timedOut.map((r) => r.id),
           "execution_timeout",
           now
         );
+        recoveredRuns.push(...timedOut);
+      } catch (e) {
+        this.log.error("Recovery sweep failed to mark timed-out runs as failed", {
+          event: "scheduler.recovery.bulk_fail_error",
+          category: "timed_out",
+          count: timedOut.length,
+          error: e instanceof Error ? e.message : String(e),
+        });
       }
-    } catch (e) {
-      this.log.error("Recovery sweep failed to mark runs as failed", {
-        event: "scheduler.recovery.bulk_fail_error",
-        orphaned_count: orphaned.length,
-        timed_out_count: timedOut.length,
-        error: e instanceof Error ? e.message : String(e),
-      });
-      return;
     }
+
+    if (recoveredRuns.length === 0) return;
 
     try {
       const automationCounts = new Map<string, number>();
-      for (const run of [...orphaned, ...timedOut]) {
+      for (const run of recoveredRuns) {
         automationCounts.set(run.automation_id, (automationCounts.get(run.automation_id) ?? 0) + 1);
       }
 

--- a/packages/control-plane/test/integration/automation-store.test.ts
+++ b/packages/control-plane/test/integration/automation-store.test.ts
@@ -547,6 +547,52 @@ describe("AutomationStore (D1 integration)", () => {
       expect(timedOut).toHaveLength(0);
     });
 
+    it("drains oldest orphaned runs first when LIMIT is hit", async () => {
+      const store = new AutomationStore(env.DB);
+      const now = Date.now();
+      await store.create(makeAutomation({ id: "auto-order1" }));
+
+      const base = now - 60 * 60 * 1000;
+      for (let i = 0; i < 5; i++) {
+        await store.insertRun(
+          makeRun("auto-order1", {
+            id: `run-order-${i}`,
+            status: "starting",
+            scheduled_at: base + i * 1000,
+            created_at: base + i * 1000,
+          })
+        );
+      }
+
+      const orphaned = await store.getOrphanedStartingRuns(5 * 60 * 1000, 3);
+      expect(orphaned).toHaveLength(3);
+      expect(orphaned.map((r) => r.id)).toEqual(["run-order-0", "run-order-1", "run-order-2"]);
+    });
+
+    it("drains oldest timed-out runs first when LIMIT is hit", async () => {
+      const store = new AutomationStore(env.DB);
+      const now = Date.now();
+      await store.create(makeAutomation({ id: "auto-order2" }));
+
+      const base = now - 3 * 60 * 60 * 1000;
+      for (let i = 0; i < 5; i++) {
+        await store.insertRun(
+          makeRun("auto-order2", {
+            id: `run-to-${i}`,
+            status: "running",
+            session_id: `sess-${i}`,
+            scheduled_at: base + i * 1000,
+            started_at: base + i * 1000,
+            created_at: base + i * 1000,
+          })
+        );
+      }
+
+      const timedOut = await store.getTimedOutRunningRuns(90 * 60 * 1000, 3);
+      expect(timedOut).toHaveLength(3);
+      expect(timedOut.map((r) => r.id)).toEqual(["run-to-0", "run-to-1", "run-to-2"]);
+    });
+
     // The behavioural tests above pass with or without the index (a scan returns
     // the same rows); these EXPLAIN the real production SQL to assert the partial
     // index is actually used.

--- a/packages/control-plane/test/integration/automation-store.test.ts
+++ b/packages/control-plane/test/integration/automation-store.test.ts
@@ -489,7 +489,7 @@ describe("AutomationStore (D1 integration)", () => {
         })
       );
 
-      const orphaned = await store.getOrphanedStartingRuns(5 * 60 * 1000);
+      const orphaned = await store.getOrphanedStartingRuns(5 * 60 * 1000, 50);
       expect(orphaned).toHaveLength(1);
       expect(orphaned[0].id).toBe("run-orphan-1");
     });
@@ -503,7 +503,7 @@ describe("AutomationStore (D1 integration)", () => {
         makeRun("auto-rec2", { id: "run-recent-1", status: "starting", created_at: now })
       );
 
-      const orphaned = await store.getOrphanedStartingRuns(5 * 60 * 1000);
+      const orphaned = await store.getOrphanedStartingRuns(5 * 60 * 1000, 50);
       expect(orphaned).toHaveLength(0);
     });
 
@@ -524,7 +524,7 @@ describe("AutomationStore (D1 integration)", () => {
         })
       );
 
-      const timedOut = await store.getTimedOutRunningRuns(90 * 60 * 1000);
+      const timedOut = await store.getTimedOutRunningRuns(90 * 60 * 1000, 50);
       expect(timedOut).toHaveLength(1);
       expect(timedOut[0].id).toBe("run-timeout-1");
     });
@@ -543,7 +543,7 @@ describe("AutomationStore (D1 integration)", () => {
         })
       );
 
-      const timedOut = await store.getTimedOutRunningRuns(90 * 60 * 1000);
+      const timedOut = await store.getTimedOutRunningRuns(90 * 60 * 1000, 50);
       expect(timedOut).toHaveLength(0);
     });
 

--- a/packages/control-plane/test/integration/scheduler.test.ts
+++ b/packages/control-plane/test/integration/scheduler.test.ts
@@ -420,6 +420,40 @@ describe("SchedulerDO (integration)", () => {
       expect(automation!.enabled).toBe(0);
       expect(automation!.next_run_at).toBeNull();
     });
+
+    it("bulk recovery handles multiple orphaned runs for the same automation", async () => {
+      const store = new AutomationStore(env.DB);
+      const now = Date.now();
+      await store.create(
+        makeAutomation({ id: "auto-t6", next_run_at: now + 86400000, enabled: 1 })
+      );
+
+      const tenMinutesAgo = now - 10 * 60 * 1000;
+      const runIds = ["run-bulk-1", "run-bulk-2", "run-bulk-3"];
+      for (let i = 0; i < runIds.length; i++) {
+        await store.insertRun(
+          makeRun("auto-t6", {
+            id: runIds[i],
+            status: "starting",
+            scheduled_at: tenMinutesAgo - i,
+            created_at: tenMinutesAgo - i,
+          })
+        );
+      }
+
+      const stub = getSchedulerStub();
+      const res = await stub.fetch("http://internal/internal/tick", { method: "POST" });
+      expect(res.status).toBe(200);
+
+      for (const runId of runIds) {
+        const run = await store.getRunById("auto-t6", runId);
+        expect(run!.status).toBe("failed");
+        expect(run!.failure_reason).toBe("session_creation_timeout");
+      }
+
+      const automation = await store.getById("auto-t6");
+      expect(automation!.consecutive_failures).toBe(3);
+    });
   });
 
   // ─── Trigger handler ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Addresses fix 2 from the D1 timeout debugging analysis: the recovery sweep ran unbounded queries and issued N×3 sequential D1 writes per tick, creating a feedback loop under load (timeouts → orphans → recovery write load → more timeouts).

### LIMIT on recovery sweep queries

`getOrphanedStartingRuns` and `getTimedOutRunningRuns` now accept a `limit` parameter (defaulting to `RECOVERY_SWEEP_LIMIT = 50` per sweep type). The SQL constants (`ORPHANED_STARTING_RUNS_SQL`, `TIMED_OUT_RUNNING_RUNS_SQL`) are unchanged so EXPLAIN QUERY PLAN integration tests continue to pass — `LIMIT ?` is appended in the method body.

### Bulk operations replace per-run loop

The `recoverySweep()` method was refactored:

- **Before:** N runs × 2-3 sequential D1 queries each (`updateRun` → `incrementConsecutiveFailures` (UPDATE+SELECT) → optional `autoPause`)
- **After:** 2 `bulkFailRuns` calls (one per sweep type) + 1 `bulkIncrementFailures` call = 3 D1 round-trips total, regardless of N

New `AutomationStore` methods:
- `bulkFailRuns(runIds, reason, completedAt)` — single `UPDATE ... WHERE id IN (...)` marking all recovered runs as failed in one query
- `bulkIncrementFailures(automationIdCounts)` — batch UPDATE via `db.batch()` (one transaction for all automations), then a single SELECT to read back updated counts for auto-pause threshold checks. Replaces N×(UPDATE+SELECT) with 2 round-trips

Additional improvements:
- Both sweep queries now run in parallel via `Promise.all` (they're independent)
- `executionTimeoutMs` computation moved before the queries (was between them)
- Error handling: `bulkFailRuns` failure returns early (runs stay in starting/running state, retried next tick); `bulkIncrementFailures` failure is best-effort (runs already marked failed, counts may be under-counted — logged and swallowed, consistent with the `failRunAndTrackBestEffort` pattern from fix 1)
- `failRunAndTrack` / `failRunAndTrackBestEffort` left intact for their other call sites (tick inner catch, event catch, trigger catch, run-complete)

### Files changed
- `packages/control-plane/src/db/automation-store.ts` — `limit` param on sweep queries + new `bulkFailRuns` / `bulkIncrementFailures` methods
- `packages/control-plane/src/scheduler/durable-object.ts` — `RECOVERY_SWEEP_LIMIT` constant + refactored `recoverySweep()`
- `packages/control-plane/src/scheduler/durable-object.test.ts` — updated 2 existing recovery tests + 4 new unit tests (batching, auto-pause via bulk increment, bulk_fail_error swallow, bulk_track_error swallow)
- `packages/control-plane/test/integration/automation-store.test.ts` — updated direct calls to pass `limit` param
- `packages/control-plane/test/integration/scheduler.test.ts` — new integration test: bulk recovery of multiple orphaned runs for the same automation (verifies all runs fail + `consecutive_failures` increments by 3)

### Verification
- `npm run typecheck` — all packages pass
- `npm test -w @open-inspect/control-plane` — 1329 unit tests pass (30 scheduler tests, was 25)
- `npm run test:integration -w @open-inspect/control-plane` — 371 pass, 2-3 pre-existing flaky failures (session-lifecycle, websocket-client, websocket-sandbox) confirmed unrelated to scheduler/D1 changes — all scheduler and automation-store integration tests pass including the new bulk recovery test
- ESLint + Prettier clean


---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/cfa8d301244ced8cc84fda8995357b1c)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduler recovery sweeps now process orphaned and timed-out runs in bounded, oldest-first batches per tick.
  * Bulk recovery updates multiple runs together, ensuring consistent consecutive-failure counting and auto-pausing once the configured threshold is reached.
* **Bug Fixes**
  * Recovery now caps how many runs are selected each tick, preventing unexpected over-processing.
  * Failure tracking and auto-pausing are more resilient: errors are logged per recovery category and won’t block other recovery paths.
* **Tests**
  * Added/updated coverage for limit-and-order selection and bulk recovery behavior (including multi-run and error scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->