### PR TITLE
fix: hide sandbox from integrations list

### DIFF
--- a/packages/web/src/app/(app)/settings/integrations/[id]/page.tsx
+++ b/packages/web/src/app/(app)/settings/integrations/[id]/page.tsx
@@ -2,26 +2,15 @@
 
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { INTEGRATION_DEFINITIONS, type IntegrationId } from "@open-inspect/shared";
+import { INTEGRATION_DEFINITIONS } from "@open-inspect/shared";
 import { useSidebarContext } from "@/components/sidebar-layout";
 import { SidebarIcon, BackIcon } from "@/components/ui/icons";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import { useIsMobile } from "@/hooks/use-media-query";
-import { CodeServerIntegrationSettings } from "@/components/settings/integrations/code-server-integration-settings";
-import { GitHubIntegrationSettings } from "@/components/settings/integrations/github-integration-settings";
-import { LinearIntegrationSettings } from "@/components/settings/integrations/linear-integration-settings";
-import { SlackIntegrationSettings } from "@/components/settings/integrations/slack-integration-settings";
+import { integrationSettingsComponents } from "@/components/settings/integrations/integration-settings-registry";
 
 function getIntegration(id: string) {
   return INTEGRATION_DEFINITIONS.find((d) => d.id === id);
-}
-
-function IntegrationDetail({ integrationId }: { integrationId: IntegrationId }) {
-  if (integrationId === "github") return <GitHubIntegrationSettings />;
-  if (integrationId === "linear") return <LinearIntegrationSettings />;
-  if (integrationId === "code-server") return <CodeServerIntegrationSettings />;
-  if (integrationId === "slack") return <SlackIntegrationSettings />;
-  return null;
 }
 
 export default function IntegrationDetailPage() {
@@ -30,6 +19,7 @@ export default function IntegrationDetailPage() {
   const isMobile = useIsMobile();
 
   const integration = getIntegration(params.id);
+  const IntegrationDetail = integration ? integrationSettingsComponents[integration.id] : undefined;
 
   if (!integration) {
     return (
@@ -65,9 +55,7 @@ export default function IntegrationDetailPage() {
       </header>
 
       <div className="flex-1 overflow-y-auto p-4 md:p-8">
-        <div className="max-w-2xl">
-          <IntegrationDetail integrationId={integration.id} />
-        </div>
+        <div className="max-w-2xl">{IntegrationDetail ? <IntegrationDetail /> : null}</div>
       </div>
     </div>
   );

--- a/packages/web/src/components/settings/integrations-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations-settings.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { IntegrationsSettings } from "./integrations-settings";
+
+expect.extend(matchers);
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("IntegrationsSettings", () => {
+  it("does not list sandbox settings as a dedicated integration", () => {
+    const { container } = render(<IntegrationsSettings />);
+
+    expect(container.querySelector('a[href="/settings/integrations/sandbox"]')).toBeNull();
+    expect(screen.getByRole("link", { name: /github bot/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /linear agent/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /code server/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /slack/i })).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/settings/integrations-settings.tsx
+++ b/packages/web/src/components/settings/integrations-settings.tsx
@@ -1,8 +1,19 @@
 "use client";
 
 import Link from "next/link";
-import { INTEGRATION_DEFINITIONS } from "@open-inspect/shared";
+import { INTEGRATION_DEFINITIONS, type IntegrationId } from "@open-inspect/shared";
 import { ChevronRightIcon } from "@/components/ui/icons";
+
+const DEDICATED_INTEGRATION_SETTINGS = new Set<IntegrationId>([
+  "github",
+  "linear",
+  "code-server",
+  "slack",
+]);
+
+const visibleIntegrations = INTEGRATION_DEFINITIONS.filter((integration) =>
+  DEDICATED_INTEGRATION_SETTINGS.has(integration.id)
+);
 
 export function IntegrationsSettings() {
   return (
@@ -14,7 +25,7 @@ export function IntegrationsSettings() {
 
       <div className="border border-border-muted rounded-md bg-background">
         <ul className="divide-y divide-border-muted">
-          {INTEGRATION_DEFINITIONS.map((integration) => (
+          {visibleIntegrations.map((integration) => (
             <li key={integration.id}>
               <Link
                 href={`/settings/integrations/${integration.id}`}

--- a/packages/web/src/components/settings/integrations-settings.tsx
+++ b/packages/web/src/components/settings/integrations-settings.tsx
@@ -1,19 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { INTEGRATION_DEFINITIONS, type IntegrationId } from "@open-inspect/shared";
 import { ChevronRightIcon } from "@/components/ui/icons";
-
-const DEDICATED_INTEGRATION_SETTINGS = new Set<IntegrationId>([
-  "github",
-  "linear",
-  "code-server",
-  "slack",
-]);
-
-const visibleIntegrations = INTEGRATION_DEFINITIONS.filter((integration) =>
-  DEDICATED_INTEGRATION_SETTINGS.has(integration.id)
-);
+import { visibleIntegrationDefinitions } from "./integrations/integration-settings-registry";
 
 export function IntegrationsSettings() {
   return (
@@ -25,7 +14,7 @@ export function IntegrationsSettings() {
 
       <div className="border border-border-muted rounded-md bg-background">
         <ul className="divide-y divide-border-muted">
-          {visibleIntegrations.map((integration) => (
+          {visibleIntegrationDefinitions.map((integration) => (
             <li key={integration.id}>
               <Link
                 href={`/settings/integrations/${integration.id}`}

--- a/packages/web/src/components/settings/integrations/integration-settings-registry.tsx
+++ b/packages/web/src/components/settings/integrations/integration-settings-registry.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import type { ComponentType } from "react";
+import { INTEGRATION_DEFINITIONS, type IntegrationId } from "@open-inspect/shared";
+import { CodeServerIntegrationSettings } from "./code-server-integration-settings";
+import { GitHubIntegrationSettings } from "./github-integration-settings";
+import { LinearIntegrationSettings } from "./linear-integration-settings";
+import { SlackIntegrationSettings } from "./slack-integration-settings";
+
+export const integrationSettingsComponents: Partial<Record<IntegrationId, ComponentType>> = {
+  github: GitHubIntegrationSettings,
+  linear: LinearIntegrationSettings,
+  "code-server": CodeServerIntegrationSettings,
+  slack: SlackIntegrationSettings,
+};
+
+export const visibleIntegrationDefinitions = INTEGRATION_DEFINITIONS.filter(
+  ({ id }) => id in integrationSettingsComponents
+);


### PR DESCRIPTION
## Summary
- Hide Sandbox from the Integrations settings list because its settings already live in the top-level Sandbox tab.
- Add a regression test that ensures the stale Sandbox integration link is not rendered.

## Verification
- `npm test -w @open-inspect/web -- src/components/settings/integrations-settings.test.tsx`
- `npm run lint -w @open-inspect/web`
- `npm run typecheck -w @open-inspect/web`

## Visual Verification
- Recorded video artifact: `da0014843ce48470ee4b9acd872e1e31`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/e2be56f9801f83c0e93087cd53a4b29c)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the integrations settings UI to only display intended integrations, preventing unrelated entries (such as “sandbox”) from appearing as separate links.
  * Ensured key integrations—including GitHub, Linear, Code Server, and Slack—are still shown in the list.
* **Tests**
  * Added a React Testing Library/Vitest test suite to verify the correct integration links render in the integrations settings page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->