### PR TITLE
test: cover Linear webhook delivery dedupe

### DIFF
--- a/packages/linear-bot/src/index.test.ts
+++ b/packages/linear-bot/src/index.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import type { Env } from "./types";
 import type * as WebhookHandler from "./webhook-handler";
+import {
+  createFakeKV,
+  makeExecutionContext,
+  makeLinearBotEnv,
+  signLinearWebhookRequest,
+} from "./test-helpers";
 
 const mocks = vi.hoisted(() => ({
   handleAgentSessionEvent: vi.fn(async () => undefined),
@@ -15,76 +20,6 @@ vi.mock("./webhook-handler", async (importOriginal) => {
 });
 
 const { default: app } = await import("./index");
-
-const SECRET = "test-linear-webhook-secret";
-
-interface PutCall {
-  key: string;
-  value: string;
-  options?: { expirationTtl?: number };
-}
-
-async function sign(body: string): Promise<string> {
-  const encoder = new TextEncoder();
-  const key = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(SECRET),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"]
-  );
-  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(body));
-  return Array.from(new Uint8Array(signature))
-    .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("");
-}
-
-function createFakeKV(initial: Record<string, string> = {}) {
-  const store = new Map(Object.entries(initial));
-  const putCalls: PutCall[] = [];
-
-  const kv = {
-    get: vi.fn(async (key: string, type?: string) => {
-      const value = store.get(key) ?? null;
-      if (value === null) return null;
-      if (type === "json") return JSON.parse(value) as unknown;
-      return value;
-    }),
-    put: vi.fn(async (key: string, value: string, options?: { expirationTtl?: number }) => {
-      store.set(key, value);
-      putCalls.push({ key, value, options });
-    }),
-    delete: vi.fn(async (key: string) => {
-      store.delete(key);
-    }),
-  };
-
-  return { kv: kv as unknown as KVNamespace, store, putCalls };
-}
-
-function makeEnv(kv: KVNamespace): Env {
-  return {
-    LINEAR_KV: kv,
-    LINEAR_WEBHOOK_SECRET: SECRET,
-    DEFAULT_MODEL: "anthropic/claude-haiku-4-5",
-    DEPLOYMENT_NAME: "test",
-    CONTROL_PLANE_URL: "https://control-plane.example.test",
-    WEB_APP_URL: "https://web.example.test",
-    LINEAR_CLIENT_ID: "linear-client-id",
-    LINEAR_CLIENT_SECRET: "linear-client-secret",
-    WORKER_URL: "https://linear-bot.example.test",
-    ANTHROPIC_API_KEY: "anthropic-key",
-    CONTROL_PLANE: { fetch: vi.fn() } as unknown as Fetcher,
-  };
-}
-
-function makeCtx() {
-  return {
-    props: {},
-    waitUntil: vi.fn(),
-    passThroughOnException: vi.fn(),
-  } as unknown as ExecutionContext & { waitUntil: ReturnType<typeof vi.fn> };
-}
 
 function makeAgentSessionPayload(webhookId = "webhook-config-1") {
   return {
@@ -103,7 +38,7 @@ async function makeWebhookRequest(payload: unknown, deliveryId?: string): Promis
   const body = JSON.stringify(payload);
   const headers: Record<string, string> = {
     "content-type": "application/json",
-    "linear-signature": await sign(body),
+    "linear-signature": await signLinearWebhookRequest(body),
   };
   if (deliveryId) headers["linear-delivery"] = deliveryId;
 
@@ -121,11 +56,11 @@ describe("POST /webhook", () => {
 
   it("rejects AgentSessionEvent payloads without Linear-Delivery before dedupe or enqueue", async () => {
     const { kv } = createFakeKV();
-    const ctx = makeCtx();
+    const ctx = makeExecutionContext();
 
     const res = await app.fetch(
       await makeWebhookRequest(makeAgentSessionPayload()),
-      makeEnv(kv),
+      makeLinearBotEnv(kv),
       ctx
     );
 
@@ -139,8 +74,8 @@ describe("POST /webhook", () => {
 
   it("deduplicates AgentSessionEvent deliveries by Linear-Delivery header", async () => {
     const { kv, putCalls } = createFakeKV();
-    const env = makeEnv(kv);
-    const ctx = makeCtx();
+    const env = makeLinearBotEnv(kv);
+    const ctx = makeExecutionContext();
     const payload = makeAgentSessionPayload();
 
     const firstRes = await app.fetch(await makeWebhookRequest(payload, "delivery-1"), env, ctx);
@@ -159,8 +94,8 @@ describe("POST /webhook", () => {
 
   it("does not treat distinct Linear-Delivery headers with the same webhookId as duplicates", async () => {
     const { kv, putCalls } = createFakeKV();
-    const env = makeEnv(kv);
-    const ctx = makeCtx();
+    const env = makeLinearBotEnv(kv);
+    const ctx = makeExecutionContext();
     const payload = makeAgentSessionPayload("stable-webhook-config-id");
 
     const firstRes = await app.fetch(await makeWebhookRequest(payload, "delivery-1"), env, ctx);
@@ -177,7 +112,7 @@ describe("POST /webhook", () => {
 
   it("rejects malformed AgentSessionEvent payloads before dedupe", async () => {
     const { kv } = createFakeKV();
-    const ctx = makeCtx();
+    const ctx = makeExecutionContext();
     const payload = {
       type: "AgentSessionEvent",
       action: "created",
@@ -186,12 +121,17 @@ describe("POST /webhook", () => {
       agentSession: {},
     };
 
-    const res = await app.fetch(await makeWebhookRequest(payload, "delivery-1"), makeEnv(kv), ctx);
+    const res = await app.fetch(
+      await makeWebhookRequest(payload, "delivery-1"),
+      makeLinearBotEnv(kv),
+      ctx
+    );
 
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: "Invalid payload" });
     expect(kv.get).not.toHaveBeenCalled();
     expect(kv.put).not.toHaveBeenCalled();
     expect(ctx.waitUntil).not.toHaveBeenCalled();
+    expect(mocks.handleAgentSessionEvent).not.toHaveBeenCalled();
   });
 });

--- a/packages/linear-bot/src/index.test.ts
+++ b/packages/linear-bot/src/index.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { Env } from "./types";
+import type * as WebhookHandler from "./webhook-handler";
+
+const mocks = vi.hoisted(() => ({
+  handleAgentSessionEvent: vi.fn(async () => undefined),
+}));
+
+vi.mock("./webhook-handler", async (importOriginal) => {
+  const actual = await importOriginal<typeof WebhookHandler>();
+  return {
+    ...actual,
+    handleAgentSessionEvent: mocks.handleAgentSessionEvent,
+  };
+});
+
+const { default: app } = await import("./index");
+
+const SECRET = "test-linear-webhook-secret";
+
+interface PutCall {
+  key: string;
+  value: string;
+  options?: { expirationTtl?: number };
+}
+
+async function sign(body: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(SECRET),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(body));
+  return Array.from(new Uint8Array(signature))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function createFakeKV(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial));
+  const putCalls: PutCall[] = [];
+
+  const kv = {
+    get: vi.fn(async (key: string, type?: string) => {
+      const value = store.get(key) ?? null;
+      if (value === null) return null;
+      if (type === "json") return JSON.parse(value) as unknown;
+      return value;
+    }),
+    put: vi.fn(async (key: string, value: string, options?: { expirationTtl?: number }) => {
+      store.set(key, value);
+      putCalls.push({ key, value, options });
+    }),
+    delete: vi.fn(async (key: string) => {
+      store.delete(key);
+    }),
+  };
+
+  return { kv: kv as unknown as KVNamespace, store, putCalls };
+}
+
+function makeEnv(kv: KVNamespace): Env {
+  return {
+    LINEAR_KV: kv,
+    LINEAR_WEBHOOK_SECRET: SECRET,
+    DEFAULT_MODEL: "anthropic/claude-haiku-4-5",
+    DEPLOYMENT_NAME: "test",
+    CONTROL_PLANE_URL: "https://control-plane.example.test",
+    WEB_APP_URL: "https://web.example.test",
+    LINEAR_CLIENT_ID: "linear-client-id",
+    LINEAR_CLIENT_SECRET: "linear-client-secret",
+    WORKER_URL: "https://linear-bot.example.test",
+    ANTHROPIC_API_KEY: "anthropic-key",
+    CONTROL_PLANE: { fetch: vi.fn() } as unknown as Fetcher,
+  };
+}
+
+function makeCtx() {
+  return {
+    props: {},
+    waitUntil: vi.fn(),
+    passThroughOnException: vi.fn(),
+  } as unknown as ExecutionContext & { waitUntil: ReturnType<typeof vi.fn> };
+}
+
+function makeAgentSessionPayload(webhookId = "webhook-config-1") {
+  return {
+    type: "AgentSessionEvent",
+    action: "created",
+    organizationId: "org-1",
+    webhookId,
+    agentSession: {
+      id: "agent-session-1",
+      promptContext: "Implement the Linear issue.",
+    },
+  };
+}
+
+async function makeWebhookRequest(payload: unknown, deliveryId?: string): Promise<Request> {
+  const body = JSON.stringify(payload);
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "linear-signature": await sign(body),
+  };
+  if (deliveryId) headers["linear-delivery"] = deliveryId;
+
+  return new Request("http://localhost/webhook", {
+    method: "POST",
+    headers,
+    body,
+  });
+}
+
+describe("POST /webhook", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects AgentSessionEvent payloads without Linear-Delivery before dedupe or enqueue", async () => {
+    const { kv } = createFakeKV();
+    const ctx = makeCtx();
+
+    const res = await app.fetch(
+      await makeWebhookRequest(makeAgentSessionPayload()),
+      makeEnv(kv),
+      ctx
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Missing Linear-Delivery header" });
+    expect(kv.get).not.toHaveBeenCalled();
+    expect(kv.put).not.toHaveBeenCalled();
+    expect(ctx.waitUntil).not.toHaveBeenCalled();
+    expect(mocks.handleAgentSessionEvent).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates AgentSessionEvent deliveries by Linear-Delivery header", async () => {
+    const { kv, putCalls } = createFakeKV();
+    const env = makeEnv(kv);
+    const ctx = makeCtx();
+    const payload = makeAgentSessionPayload();
+
+    const firstRes = await app.fetch(await makeWebhookRequest(payload, "delivery-1"), env, ctx);
+    const duplicateRes = await app.fetch(await makeWebhookRequest(payload, "delivery-1"), env, ctx);
+
+    expect(firstRes.status).toBe(200);
+    expect(await firstRes.json()).toEqual({ ok: true });
+    expect(duplicateRes.status).toBe(200);
+    expect(await duplicateRes.json()).toEqual({ ok: true, skipped: true, reason: "duplicate" });
+    expect(ctx.waitUntil).toHaveBeenCalledOnce();
+    expect(mocks.handleAgentSessionEvent).toHaveBeenCalledOnce();
+    expect(putCalls).toEqual([
+      { key: "event:delivery-1", value: "1", options: { expirationTtl: 3600 } },
+    ]);
+  });
+
+  it("does not treat distinct Linear-Delivery headers with the same webhookId as duplicates", async () => {
+    const { kv, putCalls } = createFakeKV();
+    const env = makeEnv(kv);
+    const ctx = makeCtx();
+    const payload = makeAgentSessionPayload("stable-webhook-config-id");
+
+    const firstRes = await app.fetch(await makeWebhookRequest(payload, "delivery-1"), env, ctx);
+    const secondRes = await app.fetch(await makeWebhookRequest(payload, "delivery-2"), env, ctx);
+
+    expect(firstRes.status).toBe(200);
+    expect(await firstRes.json()).toEqual({ ok: true });
+    expect(secondRes.status).toBe(200);
+    expect(await secondRes.json()).toEqual({ ok: true });
+    expect(ctx.waitUntil).toHaveBeenCalledTimes(2);
+    expect(mocks.handleAgentSessionEvent).toHaveBeenCalledTimes(2);
+    expect(putCalls.map((call) => call.key)).toEqual(["event:delivery-1", "event:delivery-2"]);
+  });
+
+  it("rejects malformed AgentSessionEvent payloads before dedupe", async () => {
+    const { kv } = createFakeKV();
+    const ctx = makeCtx();
+    const payload = {
+      type: "AgentSessionEvent",
+      action: "created",
+      organizationId: "org-1",
+      webhookId: "webhook-config-1",
+      agentSession: {},
+    };
+
+    const res = await app.fetch(await makeWebhookRequest(payload, "delivery-1"), makeEnv(kv), ctx);
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid payload" });
+    expect(kv.get).not.toHaveBeenCalled();
+    expect(kv.put).not.toHaveBeenCalled();
+    expect(ctx.waitUntil).not.toHaveBeenCalled();
+  });
+});

--- a/packages/linear-bot/src/kv-store.test.ts
+++ b/packages/linear-bot/src/kv-store.test.ts
@@ -9,38 +9,7 @@ import {
   isDuplicateEvent,
   DEFAULT_TRIGGER_CONFIG,
 } from "./kv-store";
-import type { Env } from "./types";
-
-// ─── Fake KVNamespace ────────────────────────────────────────────────────────
-
-interface PutCall {
-  key: string;
-  value: string;
-  options?: { expirationTtl?: number };
-}
-
-function createFakeKV(initial: Record<string, string> = {}) {
-  const store = new Map(Object.entries(initial));
-  const putCalls: PutCall[] = [];
-
-  const kv = {
-    async get(key: string, type?: string) {
-      const val = store.get(key) ?? null;
-      if (val === null) return null;
-      if (type === "json") return JSON.parse(val);
-      return val;
-    },
-    async put(key: string, value: string, options?: { expirationTtl?: number }) {
-      store.set(key, value);
-      putCalls.push({ key, value, options });
-    },
-    async delete(key: string) {
-      store.delete(key);
-    },
-  };
-
-  return { kv: kv as unknown as KVNamespace, store, putCalls };
-}
+import { createFakeKV, makeLinearBotEnv } from "./test-helpers";
 
 const errorKv = {
   async get() {
@@ -48,26 +17,22 @@ const errorKv = {
   },
 } as unknown as KVNamespace;
 
-function makeEnv(kv: KVNamespace): Env {
-  return { LINEAR_KV: kv } as unknown as Env;
-}
-
 // ─── getTeamRepoMapping ──────────────────────────────────────────────────────
 
 describe("getTeamRepoMapping", () => {
   it("returns {} when KV has no data", async () => {
     const { kv } = createFakeKV();
-    expect(await getTeamRepoMapping(makeEnv(kv))).toEqual({});
+    expect(await getTeamRepoMapping(makeLinearBotEnv(kv))).toEqual({});
   });
 
   it("returns parsed mapping from KV", async () => {
     const mapping = { "team-1": [{ owner: "org", name: "repo" }] };
     const { kv } = createFakeKV({ "config:team-repos": JSON.stringify(mapping) });
-    expect(await getTeamRepoMapping(makeEnv(kv))).toEqual(mapping);
+    expect(await getTeamRepoMapping(makeLinearBotEnv(kv))).toEqual(mapping);
   });
 
   it("returns {} when KV throws", async () => {
-    expect(await getTeamRepoMapping(makeEnv(errorKv))).toEqual({});
+    expect(await getTeamRepoMapping(makeLinearBotEnv(errorKv))).toEqual({});
   });
 });
 
@@ -76,17 +41,17 @@ describe("getTeamRepoMapping", () => {
 describe("getProjectRepoMapping", () => {
   it("returns {} when KV has no data", async () => {
     const { kv } = createFakeKV();
-    expect(await getProjectRepoMapping(makeEnv(kv))).toEqual({});
+    expect(await getProjectRepoMapping(makeLinearBotEnv(kv))).toEqual({});
   });
 
   it("returns parsed mapping from KV", async () => {
     const mapping = { "proj-1": { owner: "org", name: "repo" } };
     const { kv } = createFakeKV({ "config:project-repos": JSON.stringify(mapping) });
-    expect(await getProjectRepoMapping(makeEnv(kv))).toEqual(mapping);
+    expect(await getProjectRepoMapping(makeLinearBotEnv(kv))).toEqual(mapping);
   });
 
   it("returns {} when KV throws", async () => {
-    expect(await getProjectRepoMapping(makeEnv(errorKv))).toEqual({});
+    expect(await getProjectRepoMapping(makeLinearBotEnv(errorKv))).toEqual({});
   });
 });
 
@@ -95,13 +60,13 @@ describe("getProjectRepoMapping", () => {
 describe("getTriggerConfig", () => {
   it("returns defaults when KV has no data", async () => {
     const { kv } = createFakeKV();
-    expect(await getTriggerConfig(makeEnv(kv))).toEqual(DEFAULT_TRIGGER_CONFIG);
+    expect(await getTriggerConfig(makeLinearBotEnv(kv))).toEqual(DEFAULT_TRIGGER_CONFIG);
   });
 
   it("merges partial config with defaults", async () => {
     const partial = { autoTriggerOnCreate: true };
     const { kv } = createFakeKV({ "config:triggers": JSON.stringify(partial) });
-    expect(await getTriggerConfig(makeEnv(kv))).toEqual({
+    expect(await getTriggerConfig(makeLinearBotEnv(kv))).toEqual({
       ...DEFAULT_TRIGGER_CONFIG,
       autoTriggerOnCreate: true,
     });
@@ -114,11 +79,11 @@ describe("getTriggerConfig", () => {
       triggerCommand: "@bot",
     };
     const { kv } = createFakeKV({ "config:triggers": JSON.stringify(full) });
-    expect(await getTriggerConfig(makeEnv(kv))).toEqual(full);
+    expect(await getTriggerConfig(makeLinearBotEnv(kv))).toEqual(full);
   });
 
   it("returns defaults when KV throws", async () => {
-    expect(await getTriggerConfig(makeEnv(errorKv))).toEqual(DEFAULT_TRIGGER_CONFIG);
+    expect(await getTriggerConfig(makeLinearBotEnv(errorKv))).toEqual(DEFAULT_TRIGGER_CONFIG);
   });
 });
 
@@ -127,17 +92,17 @@ describe("getTriggerConfig", () => {
 describe("getUserPreferences", () => {
   it("returns null when KV has no data", async () => {
     const { kv } = createFakeKV();
-    expect(await getUserPreferences(makeEnv(kv), "user-1")).toBeNull();
+    expect(await getUserPreferences(makeLinearBotEnv(kv), "user-1")).toBeNull();
   });
 
   it("returns parsed preferences", async () => {
     const prefs = { userId: "user-1", model: "claude-opus-4-5", updatedAt: 123 };
     const { kv } = createFakeKV({ "user_prefs:user-1": JSON.stringify(prefs) });
-    expect(await getUserPreferences(makeEnv(kv), "user-1")).toEqual(prefs);
+    expect(await getUserPreferences(makeLinearBotEnv(kv), "user-1")).toEqual(prefs);
   });
 
   it("returns null when KV throws", async () => {
-    expect(await getUserPreferences(makeEnv(errorKv), "user-1")).toBeNull();
+    expect(await getUserPreferences(makeLinearBotEnv(errorKv), "user-1")).toBeNull();
   });
 });
 
@@ -146,7 +111,7 @@ describe("getUserPreferences", () => {
 describe("lookupIssueSession", () => {
   it("returns null when KV has no data", async () => {
     const { kv } = createFakeKV();
-    expect(await lookupIssueSession(makeEnv(kv), "issue-1")).toBeNull();
+    expect(await lookupIssueSession(makeLinearBotEnv(kv), "issue-1")).toBeNull();
   });
 
   it("returns session stored at issue:{id}", async () => {
@@ -160,11 +125,11 @@ describe("lookupIssueSession", () => {
       createdAt: 123,
     };
     const { kv } = createFakeKV({ "issue:issue-1": JSON.stringify(session) });
-    expect(await lookupIssueSession(makeEnv(kv), "issue-1")).toEqual(session);
+    expect(await lookupIssueSession(makeLinearBotEnv(kv), "issue-1")).toEqual(session);
   });
 
   it("returns null when KV throws", async () => {
-    expect(await lookupIssueSession(makeEnv(errorKv), "issue-1")).toBeNull();
+    expect(await lookupIssueSession(makeLinearBotEnv(errorKv), "issue-1")).toBeNull();
   });
 });
 
@@ -183,7 +148,7 @@ describe("storeIssueSession", () => {
 
   it("stores session at correct key", async () => {
     const { kv, putCalls } = createFakeKV();
-    await storeIssueSession(makeEnv(kv), "issue-1", session);
+    await storeIssueSession(makeLinearBotEnv(kv), "issue-1", session);
     expect(putCalls).toHaveLength(1);
     expect(putCalls[0].key).toBe("issue:issue-1");
     expect(JSON.parse(putCalls[0].value)).toEqual(session);
@@ -191,7 +156,7 @@ describe("storeIssueSession", () => {
 
   it("uses 7-day TTL (604800s)", async () => {
     const { kv, putCalls } = createFakeKV();
-    await storeIssueSession(makeEnv(kv), "issue-1", session);
+    await storeIssueSession(makeLinearBotEnv(kv), "issue-1", session);
     expect(putCalls[0].options).toEqual({ expirationTtl: 86400 * 7 });
   });
 });
@@ -201,26 +166,26 @@ describe("storeIssueSession", () => {
 describe("isDuplicateEvent", () => {
   it("returns false on first call for a key", async () => {
     const { kv } = createFakeKV();
-    expect(await isDuplicateEvent(makeEnv(kv), "evt-1")).toBe(false);
+    expect(await isDuplicateEvent(makeLinearBotEnv(kv), "evt-1")).toBe(false);
   });
 
   it("returns true on second call for the same key", async () => {
     const { kv } = createFakeKV();
-    const env = makeEnv(kv);
+    const env = makeLinearBotEnv(kv);
     await isDuplicateEvent(env, "evt-1");
     expect(await isDuplicateEvent(env, "evt-1")).toBe(true);
   });
 
   it("returns false for a different key", async () => {
     const { kv } = createFakeKV();
-    const env = makeEnv(kv);
+    const env = makeLinearBotEnv(kv);
     await isDuplicateEvent(env, "evt-1");
     expect(await isDuplicateEvent(env, "evt-2")).toBe(false);
   });
 
   it("stores with 1-hour TTL at event:{key}", async () => {
     const { kv, putCalls } = createFakeKV();
-    await isDuplicateEvent(makeEnv(kv), "evt-1");
+    await isDuplicateEvent(makeLinearBotEnv(kv), "evt-1");
     expect(putCalls).toHaveLength(1);
     expect(putCalls[0].key).toBe("event:evt-1");
     expect(putCalls[0].options).toEqual({ expirationTtl: 3600 });

--- a/packages/linear-bot/src/test-helpers.ts
+++ b/packages/linear-bot/src/test-helpers.ts
@@ -1,0 +1,73 @@
+import { vi } from "vitest";
+import type { Env } from "./types";
+
+export const LINEAR_WEBHOOK_TEST_SECRET = "test-linear-webhook-secret";
+
+export interface PutCall {
+  key: string;
+  value: string;
+  options?: { expirationTtl?: number };
+}
+
+export function createFakeKV(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial));
+  const putCalls: PutCall[] = [];
+
+  const kv = {
+    get: vi.fn(async (key: string, type?: string) => {
+      const value = store.get(key) ?? null;
+      if (value === null) return null;
+      if (type === "json") return JSON.parse(value) as unknown;
+      return value;
+    }),
+    put: vi.fn(async (key: string, value: string, options?: { expirationTtl?: number }) => {
+      store.set(key, value);
+      putCalls.push({ key, value, options });
+    }),
+    delete: vi.fn(async (key: string) => {
+      store.delete(key);
+    }),
+  };
+
+  return { kv: kv as unknown as KVNamespace, store, putCalls };
+}
+
+export function makeLinearBotEnv(kv: KVNamespace, overrides: Partial<Env> = {}): Env {
+  return {
+    LINEAR_KV: kv,
+    LINEAR_WEBHOOK_SECRET: LINEAR_WEBHOOK_TEST_SECRET,
+    DEFAULT_MODEL: "anthropic/claude-haiku-4-5",
+    DEPLOYMENT_NAME: "test",
+    CONTROL_PLANE_URL: "https://control-plane.example.test",
+    WEB_APP_URL: "https://web.example.test",
+    LINEAR_CLIENT_ID: "linear-client-id",
+    LINEAR_CLIENT_SECRET: "linear-client-secret",
+    WORKER_URL: "https://linear-bot.example.test",
+    ANTHROPIC_API_KEY: "anthropic-key",
+    CONTROL_PLANE: { fetch: vi.fn() } as unknown as Fetcher,
+    ...overrides,
+  };
+}
+
+export function makeExecutionContext() {
+  return {
+    props: {},
+    waitUntil: vi.fn(),
+    passThroughOnException: vi.fn(),
+  } as unknown as ExecutionContext & { waitUntil: ReturnType<typeof vi.fn> };
+}
+
+export async function signLinearWebhookRequest(body: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(LINEAR_WEBHOOK_TEST_SECRET),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(body));
+  return Array.from(new Uint8Array(signature))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}


### PR DESCRIPTION
## Summary
- Add route-level Linear webhook tests for the recently changed `Linear-Delivery` dedupe contract.
- Cover missing delivery header rejection, duplicate delivery suppression, distinct deliveries sharing the same `webhookId`, and malformed AgentSession payload rejection.

## Why
These paths decide whether external Linear webhook deliveries enqueue agent work, so regressions can silently drop or duplicate sessions.

## Testing
- `npm test -w @open-inspect/linear-bot`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/35e4cdf0db27155230de53a3881b2214)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded webhook endpoint test coverage for request validation, duplicate delivery handling, distinct delivery IDs, and malformed payloads.
  * Refactored Linear bot tests to use shared test utilities (fake KV, execution context, request signing) to improve consistency and reduce duplicated setup logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->