### PR TITLE
fix(auth): check all emails for domain/email access

### DIFF
--- a/.claude/skills/onboarding/SKILL.md
+++ b/.claude/skills/onboarding/SKILL.md
@@ -130,10 +130,11 @@ Guide user through creating a GitHub App (handles both OAuth and repo access):
    - **CRITICAL**: Must match deployed Vercel URL exactly!
 6. **Repository permissions**: Contents (Read & Write), Issues (Read & Write), Pull requests (Read &
    Write), Metadata (Read-only)
-7. Create app, note **App ID**
-8. Generate **Client Secret**, note **Client ID** and **Client Secret**
-9. Generate **Private Key** (downloads .pem file)
-10. Install app on account, note **Installation ID** from URL
+7. **Account permissions**: Email addresses (Read-only)
+8. Create app, note **App ID**
+9. Generate **Client Secret**, note **Client ID** and **Client Secret**
+10. Generate **Private Key** (downloads .pem file)
+11. Install app on account, note **Installation ID** from URL
 
 After receiving the .pem path, convert to PKCS#8:
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -253,21 +253,23 @@ access.
    - Members: **Read-only**
    - For existing GitHub Apps, republish the permission change and request/approve installation
      updates before testing org membership sign-in.
-7. Click **"Create GitHub App"**
-8. Note the **App ID** and **Client ID** (top of page)
-9. Under **"Client secrets"**, click **"Generate a new client secret"** and note the **Client
-   Secret**
-10. Scroll down to **"Private keys"** and click **"Generate a private key"** (downloads a .pem file)
-11. **Convert the key to PKCS#8 format** (required for Cloudflare Workers):
+7. Set **Account permissions**:
+   - Email addresses: **Read-only**
+8. Click **"Create GitHub App"**
+9. Note the **App ID** and **Client ID** (top of page)
+10. Under **"Client secrets"**, click **"Generate a new client secret"** and note the **Client
+    Secret**
+11. Scroll down to **"Private keys"** and click **"Generate a private key"** (downloads a .pem file)
+12. **Convert the key to PKCS#8 format** (required for Cloudflare Workers):
     ```bash
     openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt \
       -in ~/Downloads/your-app-name.*.private-key.pem \
       -out private-key-pkcs8.pem
     ```
-12. **Install the app** on your account/organization:
+13. **Install the app** on your account/organization:
     - Click "Install App" in the sidebar
     - Select the repositories you want Open-Inspect to access
-13. Note the **Installation ID** from the URL after installing:
+14. Note the **Installation ID** from the URL after installing:
     ```
     https://github.com/settings/installations/INSTALLATION_ID
     ```

--- a/packages/web/src/lib/access-control.test.ts
+++ b/packages/web/src/lib/access-control.test.ts
@@ -63,7 +63,7 @@ describe("checkAccessAllowed", () => {
 
       expect(checkAccessAllowed(config, {})).toBe(false);
       expect(checkAccessAllowed(config, { githubUsername: "anyuser" })).toBe(false);
-      expect(checkAccessAllowed(config, { email: "anyone@example.com" })).toBe(false);
+      expect(checkAccessAllowed(config, { emails: ["anyone@example.com"] })).toBe(false);
     });
 
     it("allows all users when unsafeAllowAllUsers is enabled", () => {
@@ -76,7 +76,7 @@ describe("checkAccessAllowed", () => {
 
       expect(checkAccessAllowed(config, {})).toBe(true);
       expect(checkAccessAllowed(config, { githubUsername: "anyuser" })).toBe(true);
-      expect(checkAccessAllowed(config, { email: "anyone@example.com" })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["anyone@example.com"] })).toBe(true);
     });
 
     it("a populated allowedEmails disables the unsafe allow-all gate", () => {
@@ -89,8 +89,8 @@ describe("checkAccessAllowed", () => {
 
       // The gate only fires when ALL three lists are empty; once allowedEmails is
       // set, enforcement applies even with unsafeAllowAllUsers on.
-      expect(checkAccessAllowed(config, { email: "listed@gmail.com" })).toBe(true);
-      expect(checkAccessAllowed(config, { email: "other@gmail.com" })).toBe(false);
+      expect(checkAccessAllowed(config, { emails: ["listed@gmail.com"] })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["other@gmail.com"] })).toBe(false);
       expect(checkAccessAllowed(config, {})).toBe(false);
     });
   });
@@ -110,7 +110,7 @@ describe("checkAccessAllowed", () => {
     it("denies synchronously — membership is checked asynchronously elsewhere", () => {
       expect(checkAccessAllowed(config, {})).toBe(false);
       expect(checkAccessAllowed(config, { githubUsername: "anyuser" })).toBe(false);
-      expect(checkAccessAllowed(config, { email: "anyone@example.com" })).toBe(false);
+      expect(checkAccessAllowed(config, { emails: ["anyone@example.com"] })).toBe(false);
     });
 
     it("keeps the unsafe allow-all gate closed because an allowlist is configured", () => {
@@ -141,7 +141,7 @@ describe("checkAccessAllowed", () => {
 
     it("denies when no username provided", () => {
       expect(checkAccessAllowed(config, {})).toBe(false);
-      expect(checkAccessAllowed(config, { email: "user@example.com" })).toBe(false);
+      expect(checkAccessAllowed(config, { emails: ["user@example.com"] })).toBe(false);
     });
   });
 
@@ -154,18 +154,18 @@ describe("checkAccessAllowed", () => {
     };
 
     it("allows an exact listed email — even on a shared domain like gmail.com", () => {
-      expect(checkAccessAllowed(config, { email: "pm@gmail.com" })).toBe(true);
-      expect(checkAccessAllowed(config, { email: "support@gmail.com" })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["pm@gmail.com"] })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["support@gmail.com"] })).toBe(true);
     });
 
     it("matches case-insensitively", () => {
-      expect(checkAccessAllowed(config, { email: "PM@Gmail.com" })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["PM@Gmail.com"] })).toBe(true);
     });
 
     it("does NOT admit other addresses on the same shared domain", () => {
       // The whole point of the exact-email list: a gmail.com address is admitted
       // without admitting every gmail.com account.
-      expect(checkAccessAllowed(config, { email: "stranger@gmail.com" })).toBe(false);
+      expect(checkAccessAllowed(config, { emails: ["stranger@gmail.com"] })).toBe(false);
     });
 
     it("denies when no email provided", () => {
@@ -183,15 +183,15 @@ describe("checkAccessAllowed", () => {
     };
 
     it("allows users with matching email domain", () => {
-      expect(checkAccessAllowed(config, { email: "user@company.com" })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["user@company.com"] })).toBe(true);
     });
 
     it("allows users with different case email", () => {
-      expect(checkAccessAllowed(config, { email: "User@COMPANY.COM" })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["User@COMPANY.COM"] })).toBe(true);
     });
 
     it("denies users with non-matching email domain", () => {
-      expect(checkAccessAllowed(config, { email: "user@other.com" })).toBe(false);
+      expect(checkAccessAllowed(config, { emails: ["user@other.com"] })).toBe(false);
     });
 
     it("denies when no email provided", () => {
@@ -200,7 +200,43 @@ describe("checkAccessAllowed", () => {
     });
   });
 
-  describe("when allowedUsers, allowedEmails and allowedDomains are set (OR logic)", () => {
+  describe("when user has multiple emails", () => {
+    const config = {
+      allowedDomains: ["company.com"],
+      allowedUsers: [],
+      allowedEmails: [],
+      unsafeAllowAllUsers: false,
+    };
+
+    it("allows access when any email exactly matches the email allowlist", () => {
+      expect(
+        checkAccessAllowed(
+          { ...config, allowedDomains: [], allowedEmails: ["user@company.com"] },
+          {
+            emails: ["user@personal.com", "user@company.com"],
+          }
+        )
+      ).toBe(true);
+    });
+
+    it("allows access when any email matches the domain", () => {
+      expect(
+        checkAccessAllowed(config, {
+          emails: ["user@personal.com", "user@company.com"],
+        })
+      ).toBe(true);
+    });
+
+    it("denies access when no email matches the domain", () => {
+      expect(
+        checkAccessAllowed(config, {
+          emails: ["user@personal.com", "user@gmail.com"],
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe("when both allowedUsers, allowedEmails, and allowedDomains are set (OR logic)", () => {
     const config = {
       allowedDomains: ["company.com"],
       allowedUsers: ["specialuser"],
@@ -213,25 +249,25 @@ describe("checkAccessAllowed", () => {
     });
 
     it("allows users matching exact email", () => {
-      expect(checkAccessAllowed(config, { email: "contractor@gmail.com" })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["contractor@gmail.com"] })).toBe(true);
     });
 
     it("allows users matching email domain", () => {
-      expect(checkAccessAllowed(config, { email: "someone@company.com" })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["someone@company.com"] })).toBe(true);
     });
 
     it("allows users matching any condition", () => {
       expect(
         checkAccessAllowed(config, {
           githubUsername: "specialuser",
-          email: "user@other.com",
+          emails: ["user@other.com"],
         })
       ).toBe(true);
 
       expect(
         checkAccessAllowed(config, {
           githubUsername: "otheruser",
-          email: "user@company.com",
+          emails: ["user@company.com"],
         })
       ).toBe(true);
     });
@@ -240,7 +276,7 @@ describe("checkAccessAllowed", () => {
       expect(
         checkAccessAllowed(config, {
           githubUsername: "randomuser",
-          email: "user@other.com",
+          emails: ["user@other.com"],
         })
       ).toBe(false);
     });
@@ -257,14 +293,14 @@ describe("checkAccessAllowed", () => {
 
     it("allows users matching a synchronous list (username or domain)", () => {
       expect(checkAccessAllowed(config, { githubUsername: "specialuser" })).toBe(true);
-      expect(checkAccessAllowed(config, { email: "user@company.com" })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["user@company.com"] })).toBe(true);
     });
 
     it("denies users matching none of the synchronous lists (org checked elsewhere)", () => {
       expect(
         checkAccessAllowed(config, {
           githubUsername: "randomuser",
-          email: "user@other.com",
+          emails: ["user@other.com"],
         })
       ).toBe(false);
     });
@@ -280,12 +316,12 @@ describe("checkAccessAllowed", () => {
 
     it("still enforces the allowlist for matching users", () => {
       expect(checkAccessAllowed(config, { githubUsername: "specialuser" })).toBe(true);
-      expect(checkAccessAllowed(config, { email: "user@company.com" })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["user@company.com"] })).toBe(true);
     });
 
     it("denies users not in the allowlist", () => {
       expect(checkAccessAllowed(config, { githubUsername: "randomuser" })).toBe(false);
-      expect(checkAccessAllowed(config, { email: "user@other.com" })).toBe(false);
+      expect(checkAccessAllowed(config, { emails: ["user@other.com"] })).toBe(false);
     });
 
     it("does not bypass a populated organization allowlist", () => {
@@ -318,8 +354,8 @@ describe("checkAccessAllowed", () => {
     });
 
     it("allows any domain from the list", () => {
-      expect(checkAccessAllowed(config, { email: "user@company.com" })).toBe(true);
-      expect(checkAccessAllowed(config, { email: "user@partner.org" })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["user@company.com"] })).toBe(true);
+      expect(checkAccessAllowed(config, { emails: ["user@partner.org"] })).toBe(true);
     });
   });
 });
@@ -346,7 +382,7 @@ describe("getAccessAllowReason", () => {
           allowedEmails: ["pm@gmail.com"],
           unsafeAllowAllUsers: false,
         },
-        { email: "PM@gmail.com" }
+        { emails: ["PM@gmail.com"] }
       )
     ).toBe("email_allowlist");
 
@@ -358,7 +394,7 @@ describe("getAccessAllowReason", () => {
           allowedEmails: [],
           unsafeAllowAllUsers: false,
         },
-        { email: "user@company.com" }
+        { emails: ["user@company.com"] }
       )
     ).toBe("email_domain_allowlist");
   });

--- a/packages/web/src/lib/access-control.ts
+++ b/packages/web/src/lib/access-control.ts
@@ -8,7 +8,7 @@ export interface AccessControlConfig {
 
 export interface AccessCheckParams {
   githubUsername?: string;
-  email?: string;
+  emails?: string[];
 }
 
 export type AccessAllowReason =
@@ -30,6 +30,11 @@ export function parseAllowlist(value: string | undefined): string[] {
 
 export function parseBooleanEnv(value: string | undefined): boolean {
   return value?.trim().toLowerCase() === "true";
+}
+
+function parseDomain(email: string): string | null {
+  const parts = email.split("@");
+  return parts.length === 2 ? parts[1].toLowerCase() : null;
 }
 
 /**
@@ -60,7 +65,7 @@ export function getAccessAllowReason(
 ): AccessAllowReason | null {
   const { allowedDomains, allowedUsers, allowedEmails, unsafeAllowAllUsers } = config;
   const allowedOrganizations = config.allowedOrganizations ?? [];
-  const { githubUsername, email } = params;
+  const { githubUsername, emails } = params;
 
   // Empty allowlists only permit sign-in when explicitly enabled.
   if (
@@ -80,16 +85,18 @@ export function getAccessAllowReason(
   // Check exact email allowlist. Provider-agnostic, and the only way to admit a
   // specific address on a shared domain (e.g. one gmail.com user) without
   // domain-allowing every gmail.com account.
-  if (email && allowedEmails.includes(email.toLowerCase())) {
+  if (emails?.some((email) => allowedEmails.includes(email.toLowerCase()))) {
     return "email_allowlist";
   }
 
-  // Check email domain allowlist
-  if (email) {
-    const domain = email.toLowerCase().split("@")[1];
-    if (domain && allowedDomains.includes(domain)) {
-      return "email_domain_allowlist";
-    }
+  // Check email domain allowlist.
+  if (
+    emails
+      ?.map((email) => parseDomain(email))
+      ?.filter((domain) => domain !== null)
+      ?.some((domain) => allowedDomains.includes(domain))
+  ) {
+    return "email_domain_allowlist";
   }
 
   return null;

--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -6,7 +6,7 @@ import {
   applyJwtClaims,
   applySessionUser,
   getStaticSignInReason,
-  getVerifiedPrimaryGitHubEmail,
+  getVerifiedGitHubEmails,
 } from "./auth";
 
 vi.mock("@open-inspect/shared", () => ({
@@ -270,8 +270,8 @@ describe("authOptions signIn", () => {
   });
 });
 
-describe("getVerifiedPrimaryGitHubEmail", () => {
-  it("returns the verified primary GitHub email", async () => {
+describe("getVerifiedGitHubEmails", () => {
+  it("returns all verified emails", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
         JSON.stringify([
@@ -281,10 +281,13 @@ describe("getVerifiedPrimaryGitHubEmail", () => {
       )
     );
 
-    await expect(getVerifiedPrimaryGitHubEmail("token")).resolves.toBe("user@company.com");
+    await expect(getVerifiedGitHubEmails({ accessToken: "token" })).resolves.toEqual([
+      { email: "other@example.com", primary: false, verified: true, visibility: "private" },
+      { email: "user@company.com", primary: true, verified: true, visibility: "private" },
+    ]);
   });
 
-  it("rejects an unverified primary GitHub email", async () => {
+  it("excludes unverified emails", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
         JSON.stringify([
@@ -293,13 +296,13 @@ describe("getVerifiedPrimaryGitHubEmail", () => {
       )
     );
 
-    await expect(getVerifiedPrimaryGitHubEmail("token")).resolves.toBeNull();
+    await expect(getVerifiedGitHubEmails({ accessToken: "token" })).resolves.toEqual([]);
   });
 
-  it("returns null when GitHub email lookup fails", async () => {
+  it("returns empty array when GitHub email lookup fails", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 403 }));
 
-    await expect(getVerifiedPrimaryGitHubEmail("token")).resolves.toBeNull();
+    await expect(getVerifiedGitHubEmails({ accessToken: "token" })).resolves.toEqual([]);
   });
 });
 
@@ -312,7 +315,7 @@ describe("getStaticSignInReason", () => {
         getStaticSignInReason({
           provider: "google",
           profile: { email_verified: false } as unknown as Profile,
-          email: "pm@gmail.com",
+          emails: ["pm@gmail.com"],
           config,
         })
       ).toBeNull();
@@ -323,7 +326,7 @@ describe("getStaticSignInReason", () => {
         getStaticSignInReason({
           provider: "google",
           profile: { email_verified: "false" } as unknown as Profile,
-          email: "pm@gmail.com",
+          emails: ["pm@gmail.com"],
           config,
         })
       ).toBeNull();
@@ -334,7 +337,7 @@ describe("getStaticSignInReason", () => {
         getStaticSignInReason({
           provider: "google",
           profile: {} as Profile,
-          email: "pm@gmail.com",
+          emails: ["pm@gmail.com"],
           config,
         })
       ).toBeNull();
@@ -345,7 +348,7 @@ describe("getStaticSignInReason", () => {
         getStaticSignInReason({
           provider: "google",
           profile: { email_verified: true } as unknown as Profile,
-          email: "pm@gmail.com",
+          emails: ["pm@gmail.com"],
           config,
         })
       ).toBe("email_allowlist");
@@ -356,7 +359,7 @@ describe("getStaticSignInReason", () => {
         getStaticSignInReason({
           provider: "google",
           profile: { email_verified: "true" } as unknown as Profile,
-          email: "pm@gmail.com",
+          emails: ["pm@gmail.com"],
           config,
         })
       ).toBe("email_allowlist");
@@ -367,7 +370,7 @@ describe("getStaticSignInReason", () => {
         getStaticSignInReason({
           provider: "google",
           profile: { email_verified: "True" } as unknown as Profile,
-          email: "pm@gmail.com",
+          emails: ["pm@gmail.com"],
           config,
         })
       ).toBe("email_allowlist");
@@ -378,7 +381,7 @@ describe("getStaticSignInReason", () => {
         getStaticSignInReason({
           provider: "google",
           profile: { email_verified: true } as unknown as Profile,
-          email: "stranger@gmail.com",
+          emails: ["stranger@gmail.com"],
           config,
         })
       ).toBeNull();
@@ -391,7 +394,7 @@ describe("getStaticSignInReason", () => {
         getStaticSignInReason({
           provider: "github",
           profile: { login: "octocat" } as unknown as Profile,
-          email: "octo@company.com",
+          emails: ["octo@company.com"],
           config: cfg({ allowedUsers: ["octocat"] }),
         })
       ).toBe("username_allowlist");
@@ -402,7 +405,7 @@ describe("getStaticSignInReason", () => {
         getStaticSignInReason({
           provider: "github",
           profile: { login: "stranger" } as unknown as Profile,
-          email: "stranger@other.com",
+          emails: ["stranger@other.com"],
           config: cfg({ allowedDomains: ["company.com"], allowedUsers: ["octocat"] }),
         })
       ).toBeNull();
@@ -413,7 +416,7 @@ describe("getStaticSignInReason", () => {
         getStaticSignInReason({
           provider: undefined,
           profile: { login: "octocat" } as unknown as Profile,
-          email: "octo@company.com",
+          emails: ["octo@company.com"],
           config: cfg({ allowedUsers: ["octocat"] }),
         })
       ).toBe("username_allowlist");
@@ -429,7 +432,7 @@ describe("getStaticSignInReason", () => {
         getStaticSignInReason({
           provider: "gitlab",
           profile: { email_verified: true } as unknown as Profile,
-          email: "user@company.com",
+          emails: ["user@company.com"],
           config: cfg({ allowedDomains: ["company.com"] }),
         })
       ).toBeNull();

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -17,22 +17,60 @@ import {
 } from "./github-org-membership";
 import { type AuthProvider, isAuthProvider } from "./build-auth-identity";
 
-export async function getVerifiedPrimaryGitHubEmail(
-  accessToken: string | undefined
-): Promise<string | null> {
-  if (!accessToken) return null;
+const GITHUB_EMAIL_FETCH_TIMEOUT_MS = 5_000;
 
-  const response = await fetch("https://api.github.com/user/emails", {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      Accept: "application/vnd.github+json",
-    },
-  });
+interface GitHubEmailFetchParams {
+  accessToken: string | undefined;
+  fetchImpl?: typeof fetch;
+  userAgent?: string;
+  timeoutMs?: number;
+}
 
-  if (!response.ok) return null;
+type GitHubProfileWithEmails = GithubProfile & { verifiedEmails?: GithubEmail[] };
 
-  const emails = (await response.json()) as GithubEmail[];
-  return emails.find((email) => email.primary && email.verified)?.email ?? null;
+/**
+ * Fetch verified email addresses from GitHub's API.
+ *
+ * Returns all verified emails for the authenticated user. If the access token
+ * is missing or the request fails, returns an empty array (fails closed).
+ * Requests are aborted after the timeout to prevent hanging.
+ */
+export async function getVerifiedGitHubEmails({
+  accessToken,
+  fetchImpl = fetch,
+  userAgent = "Open-Inspect",
+  timeoutMs = GITHUB_EMAIL_FETCH_TIMEOUT_MS,
+}: GitHubEmailFetchParams): Promise<GithubEmail[]> {
+  if (!accessToken) return [];
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  const startedAt = performance.now();
+
+  try {
+    const response = await fetchImpl("https://api.github.com/user/emails", {
+      headers: { Authorization: `Bearer ${accessToken}`, "User-Agent": userAgent },
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      console.warn("[github-email-fetch] request failed", {
+        status: response.status,
+        elapsedMs: Math.round(performance.now() - startedAt),
+      });
+      return [];
+    }
+    const emails = (await response.json()) as GithubEmail[];
+    return emails.filter((e) => e.verified);
+  } catch (error) {
+    console.warn("[github-email-fetch] request error", {
+      error: error instanceof Error ? error.name : "unknown",
+      message: error instanceof Error ? error.message : String(error),
+      elapsedMs: Math.round(performance.now() - startedAt),
+    });
+    return [];
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 // Extend NextAuth types to include provider-agnostic identity plus the
@@ -107,10 +145,10 @@ function isVerifiedGoogleEmail(profile: Profile | undefined): boolean {
 export function getStaticSignInReason(args: {
   provider: string | undefined;
   profile: Profile | undefined;
-  email: string | null | undefined;
+  emails: string[] | undefined;
   config: AccessControlConfig;
 }): AccessAllowReason | null {
-  const { provider, profile, email, config } = args;
+  const { provider, profile, emails, config } = args;
 
   switch (provider) {
     case "google": {
@@ -118,7 +156,7 @@ export function getStaticSignInReason(args: {
       if (!isVerifiedGoogleEmail(profile)) {
         return null;
       }
-      return getAccessAllowReason(config, { email: email ?? undefined });
+      return getAccessAllowReason(config, { emails });
     }
     case "github":
     case undefined: {
@@ -129,7 +167,7 @@ export function getStaticSignInReason(args: {
       const githubProfile = profile as { login?: string } | undefined;
       return getAccessAllowReason(config, {
         githubUsername: githubProfile?.login,
-        email: email ?? undefined,
+        emails,
       });
     }
     default:
@@ -260,8 +298,10 @@ const providers: NextAuthOptions["providers"] = [
     userinfo: {
       url: "https://api.github.com/user",
       async request({ client, tokens }) {
-        const profile = (await client.userinfo(tokens.access_token!)) as GithubProfile;
-        profile.email = await getVerifiedPrimaryGitHubEmail(tokens.access_token);
+        const profile = (await client.userinfo(tokens.access_token!)) as GitHubProfileWithEmails;
+        const verifiedEmails = await getVerifiedGitHubEmails({ accessToken: tokens.access_token! });
+        profile.email = verifiedEmails.find((e) => e.primary)?.email ?? null;
+        profile.verifiedEmails = verifiedEmails;
         return profile as unknown as Profile;
       },
     },
@@ -302,13 +342,23 @@ export const authOptions: NextAuthOptions = {
 
       const provider = account?.provider;
       const githubProfile = profile as { login?: string } | undefined;
+      const isGitHubProvider = provider === "github" || provider === undefined;
+      const hasAllowLists = config.allowedDomains.length > 0 || config.allowedEmails.length > 0;
+
+      let emails: string[] | undefined = undefined;
+      if (isGitHubProvider && hasAllowLists) {
+        const verifiedEmails = (profile as GitHubProfileWithEmails | undefined)?.verifiedEmails;
+        emails = verifiedEmails?.map((e) => e.email);
+      } else {
+        emails = user.email ? [user.email] : undefined;
+      }
 
       // Static, synchronous allowlist gate. Provider-aware: Google requires a
       // verified email before any email-based match (see getStaticSignInReason).
       const staticReason = getStaticSignInReason({
         provider,
         profile,
-        email: user.email,
+        emails,
         config,
       });
       if (staticReason) {
@@ -323,7 +373,6 @@ export const authOptions: NextAuthOptions = {
       // Google or unrecognized — fails closed here without contacting GitHub, so
       // a non-GitHub OAuth token is never sent to GitHub's API.
       const allowedOrganizations = config.allowedOrganizations ?? [];
-      const isGitHubProvider = provider === "github" || provider === undefined;
       if (!isGitHubProvider || allowedOrganizations.length === 0) {
         logSignInDecision(githubProfile?.login, "deny", "no_matching_policy");
         return false;


### PR DESCRIPTION
## Description

GitHub OAuth only exposes the primary email in the NextAuth user object. Users with multiple email addressses were silently denied even with a valid domain in `ALLOWED_EMAIL_DOMAINS`. Use cases:

- Consultants with company/client emails
- Anyone who uses GitHub's [private emails](https://docs.github.com/en/account-and-profile/reference/email-addresses-reference#your-noreply-email-address)
- Anyone who prefers a personal email over their work email for their primary

Now the signIn callback fetches all verified emails from `/user/emails` (already authorized by the `user:email` scope) and passes the full list to `getAccessAllowReason`, which checks each one against the domain/email allowlists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sign-in and access checks now support multiple email addresses, improving allowlist matching for users with more than one verified email.
  * GitHub sign-in handling now evaluates email- and domain-based access rules using all verified GitHub emails (not just the primary).
  * Access decisions fail more consistently when provider/email verification details don’t match expected access rules.
* **Documentation**
  * Updated setup guides with a new GitHub App **Account permissions** step (**Email addresses: Read-only**) before creating the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->