### PR TITLE
fix(auth): diagnose missing GitHub email permission + cover multi-email sign-in

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -254,7 +254,11 @@ access.
    - For existing GitHub Apps, republish the permission change and request/approve installation
      updates before testing org membership sign-in.
 7. Set **Account permissions**:
-   - Email addresses: **Read-only**
+   - Email addresses: **Read-only** _(required for `ALLOWED_EMAILS`/`ALLOWED_EMAIL_DOMAINS`; without
+     it the app cannot read verified emails and those allowlists silently deny every GitHub
+     sign-in)_
+   - For existing GitHub Apps, republish the permission change and request/approve installation
+     updates, otherwise the added permission does not apply to current installs.
 8. Click **"Create GitHub App"**
 9. Note the **App ID** and **Client ID** (top of page)
 10. Under **"Client secrets"**, click **"Generate a new client secret"** and note the **Client

--- a/packages/web/src/lib/auth.test.ts
+++ b/packages/web/src/lib/auth.test.ts
@@ -268,6 +268,95 @@ describe("authOptions signIn", () => {
     // The org fallback is GitHub-only, so a non-GitHub token never reaches GitHub.
     expect(fetchImpl).not.toHaveBeenCalled();
   });
+
+  it("admits a GitHub user whose non-primary verified email matches the domain allowlist", async () => {
+    // The core behavior of PR #829: the gate considers ALL verified emails, not
+    // just the primary. Here the primary (personal.com) does not match but a
+    // non-primary verified company.com email does. Before the fix this user was
+    // silently denied because only user.email (the primary) was checked.
+    const { authOptions } = await importAuthModule({
+      ALLOWED_EMAIL_DOMAINS: "company.com",
+    });
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    await expect(
+      getSignIn(authOptions)({
+        account: { provider: "github", access_token: "gho_token" },
+        profile: {
+          login: "octocat",
+          verifiedEmails: [
+            { email: "octo@personal.com", primary: true, verified: true, visibility: "private" },
+            { email: "octo@company.com", primary: false, verified: true, visibility: null },
+          ],
+        },
+        user: { email: "octo@personal.com" },
+      } as never)
+    ).resolves.toBe(true);
+
+    expect(info).toHaveBeenCalledWith("[auth] sign-in decision", {
+      login: "octocat",
+      decision: "allow",
+      reason: "email_domain_allowlist",
+    });
+  });
+
+  it("denies a GitHub user when none of the verified emails match the allowlists", async () => {
+    const { authOptions } = await importAuthModule({
+      ALLOWED_EMAIL_DOMAINS: "company.com",
+      ALLOWED_EMAILS: "exact@gmail.com",
+    });
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    await expect(
+      getSignIn(authOptions)({
+        account: { provider: "github", access_token: "gho_token" },
+        profile: {
+          login: "stranger",
+          verifiedEmails: [
+            {
+              email: "stranger@personal.com",
+              primary: true,
+              verified: true,
+              visibility: "private",
+            },
+            { email: "stranger@other.com", primary: false, verified: true, visibility: null },
+          ],
+        },
+        user: { email: "stranger@personal.com" },
+      } as never)
+    ).resolves.toBe(false);
+
+    expect(info).toHaveBeenCalledWith("[auth] sign-in decision", {
+      login: "stranger",
+      decision: "deny",
+      reason: "no_matching_policy",
+    });
+  });
+
+  it("does not trust user.email for the GitHub email/domain gate when verified emails are unavailable", async () => {
+    // Fail-closed guard: if the verified-email fetch came back empty (e.g.
+    // /user/emails 403'd for lack of the Email-addresses permission), the gate
+    // must NOT fall back to user.email — that value is not independently verified
+    // here. A user.email on an allowed domain must still be denied.
+    const { authOptions } = await importAuthModule({
+      ALLOWED_EMAIL_DOMAINS: "company.com",
+    });
+    const info = vi.spyOn(console, "info").mockImplementation(() => {});
+
+    await expect(
+      getSignIn(authOptions)({
+        account: { provider: "github", access_token: "gho_token" },
+        profile: { login: "octocat", verifiedEmails: [] },
+        user: { email: "octo@company.com" },
+      } as never)
+    ).resolves.toBe(false);
+
+    expect(info).toHaveBeenCalledWith("[auth] sign-in decision", {
+      login: "octocat",
+      decision: "deny",
+      reason: "no_matching_policy",
+    });
+  });
 });
 
 describe("getVerifiedGitHubEmails", () => {
@@ -303,6 +392,33 @@ describe("getVerifiedGitHubEmails", () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 403 }));
 
     await expect(getVerifiedGitHubEmails({ accessToken: "token" })).resolves.toEqual([]);
+  });
+
+  it("hints at the missing Email-addresses permission on a 403", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 403 }));
+
+    await expect(getVerifiedGitHubEmails({ accessToken: "token" })).resolves.toEqual([]);
+
+    expect(warn).toHaveBeenCalledWith(
+      "[github-email-fetch] request failed",
+      expect.objectContaining({
+        status: 403,
+        hint: expect.stringContaining("Email addresses"),
+      })
+    );
+  });
+
+  it("does not attach the permission hint on non-403 failures", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 500 }));
+
+    await expect(getVerifiedGitHubEmails({ accessToken: "token" })).resolves.toEqual([]);
+
+    expect(warn).toHaveBeenCalledWith(
+      "[github-email-fetch] request failed",
+      expect.not.objectContaining({ hint: expect.anything() })
+    );
   });
 });
 

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -49,13 +49,27 @@ export async function getVerifiedGitHubEmails({
 
   try {
     const response = await fetchImpl("https://api.github.com/user/emails", {
-      headers: { Authorization: `Bearer ${accessToken}`, "User-Agent": userAgent },
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": userAgent,
+      },
       signal: controller.signal,
     });
     if (!response.ok) {
       console.warn("[github-email-fetch] request failed", {
         status: response.status,
         elapsedMs: Math.round(performance.now() - startedAt),
+        // A 403 here almost always means the GitHub App is missing the "Email
+        // addresses" account permission (read-only), so /user/emails is forbidden
+        // even with a valid token. Without it, ALLOWED_EMAILS /
+        // ALLOWED_EMAIL_DOMAINS can never match a GitHub sign-in, which otherwise
+        // looks like an unexplained "no_matching_policy" denial. Surface a fix.
+        // (OAuth App deployments authorize this via the user:email scope instead.)
+        ...(response.status === 403 && {
+          hint: "GitHub App is likely missing the 'Email addresses: Read-only' account permission; grant it and re-approve the installation, or ALLOWED_EMAILS/ALLOWED_EMAIL_DOMAINS will not match GitHub sign-ins.",
+        }),
       });
       return [];
     }


### PR DESCRIPTION
## Description

Follow-ups to #829 (which expanded the GitHub sign-in gate from the primary email to **all verified** emails), addressing findings from a post-merge security review. No behavior change to the allow/deny decision — this adds test coverage, diagnostics, and docs around the existing logic.

### Changes

**1. Test coverage for the `signIn` multi-email wiring (the main gap)**
The multi-email logic was well covered at the pure-function layer (`getAccessAllowReason` / `getStaticSignInReason`), but the `signIn` callback's wiring — pulling `verifiedEmails` off the profile and choosing it over `user.email` — had **no** direct test. `verifiedEmails` appeared zero times in `auth.test.ts`. A refactor could silently re-break the feature while every pure-function test still passed. Added three callback-level tests:
- a non-primary verified email admits via the domain allowlist (the exact scenario #829 fixes);
- non-matching verified emails are denied;
- **fail-closed guard:** an empty verified-email list must **not** fall back to `user.email`, even when that address is on an allowed domain.

**2. Actionable diagnostics for a missing GitHub App permission**
When a GitHub App lacks the **Email addresses: Read-only** account permission, `GET /user/emails` returns `403` → no verified emails → email/domain allowlists silently deny every GitHub sign-in, surfacing only as a generic `no_matching_policy`. `getVerifiedGitHubEmails` now attaches an actionable `hint` to the `403` warn log pointing at the permission + re-approval. No security/behavior change — it just makes a silent lockout self-diagnosing.

**3. Header consistency / API pinning**
The email fetch now sends `Accept: application/vnd.github+json` and `X-GitHub-Api-Version: 2022-11-28`, matching the sibling org-membership fetch and pinning the response shape.

**4. Docs**
`GETTING_STARTED.md` now states the Email-addresses permission is **required** for `ALLOWED_EMAILS` / `ALLOWED_EMAIL_DOMAINS`, and that existing GitHub Apps must re-approve the installation for an added permission to take effect (parity with the existing org-membership note).

### Not a regression

Holding App permissions constant, #829 is identical-or-more-permissive: the old primary-email path hit the **same** `/user/emails` endpoint, so any install where email/domain allowlists worked already has the permission. The docs/diagnostics target installs newly *enabling* email/domain allowlists. A companion `[Breaking Change]` issue documents the operational fix for self-hosters.

### Testing
- `vitest run src/lib/auth.test.ts src/lib/access-control.test.ts` → **86 passed** (5 new).
- `tsc --noEmit` clean on all changed files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved GitHub sign-in support for email allowlists, including matching against verified emails.
  * Added clearer warning messages when GitHub email access is unavailable, with guidance for fixing app permissions.

* **Bug Fixes**
  * Sign-in now fails closed when verified email data is missing, preventing unintended access.
  * Allowlist checks no longer rely on fallback email values when verified emails can’t be read.

* **Documentation**
  * Expanded setup instructions for GitHub App email permissions and re-enabling changes on existing installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->