### PR TITLE
feat(opencomputer): add agent-browser, gh, ttyd, bun to template image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1817,7 +1817,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2573,7 +2572,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2596,7 +2594,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2619,7 +2616,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2636,7 +2632,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2653,7 +2648,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2670,7 +2664,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2687,7 +2680,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2704,7 +2696,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2721,7 +2712,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2738,7 +2728,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2755,7 +2744,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2772,7 +2760,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2789,7 +2776,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2812,7 +2798,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2835,7 +2820,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2858,7 +2842,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2881,7 +2864,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2904,7 +2886,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2927,7 +2908,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2950,7 +2930,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2973,7 +2952,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -2993,7 +2971,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3013,7 +2990,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3033,7 +3009,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3491,6 +3466,10 @@
       "resolved": "packages/linear-bot",
       "link": true
     },
+    "node_modules/@open-inspect/opencomputer-infra": {
+      "resolved": "packages/opencomputer-infra",
+      "link": true
+    },
     "node_modules/@open-inspect/shared": {
       "resolved": "packages/shared",
       "link": true
@@ -3502,6 +3481,16 @@
     "node_modules/@open-inspect/web": {
       "resolved": "packages/web",
       "link": true
+    },
+    "node_modules/@opencomputer/sdk": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@opencomputer/sdk/-/sdk-0.9.1.tgz",
+      "integrity": "sha512-FOYPqSARppZgg0Ai8m3yfxOyXxx36zJg+Y70QglPg5AL+B/F2aIJgx6yJewlA2cz3kBeKBPib80joA8loyY38w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@oxc-project/types": {
       "version": "0.133.0",
@@ -16006,6 +15995,15 @@
         "typescript": "^5.7.2",
         "vitest": "^4.1.0",
         "wrangler": "^4.103.0"
+      }
+    },
+    "packages/opencomputer-infra": {
+      "name": "@open-inspect/opencomputer-infra",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@opencomputer/sdk": "^0.9.1",
+        "esbuild": "^0.28.1",
+        "typescript": "^5.7.2"
       }
     },
     "packages/shared": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:integration": "npm run test:integration --workspaces --if-present",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "build": "npm run build --workspaces --if-present",
+    "build:opencomputer-template": "npm run build-template -w @open-inspect/opencomputer-infra --",
     "prepare": "node -e \"if (process.env.CI) process.exit(0)\" && husky"
   },
   "devDependencies": {

--- a/packages/control-plane/src/db/repo-images.test.ts
+++ b/packages/control-plane/src/db/repo-images.test.ts
@@ -30,7 +30,7 @@ const QUERY_PATTERNS = {
   UPDATE_CALLBACK_USED:
     /^UPDATE repo_images SET callback_token_used_at = \? WHERE id = \? AND provider = \? AND status = 'building' AND callback_token_hash = \? AND callback_token_used_at IS NULL$/,
   SELECT_READY_FOR_REPO:
-    /^SELECT id, provider_image_id FROM repo_images WHERE repo_owner = \? AND repo_name = \? AND provider = \? AND base_branch = \? AND status = 'ready'$/,
+    /^SELECT id, provider_image_id, provider_session_id FROM repo_images WHERE repo_owner = \? AND repo_name = \? AND provider = \? AND base_branch = \? AND status = 'ready'$/,
   UPDATE_READY:
     /^UPDATE repo_images SET status = 'ready', provider_image_id = \?, base_sha = \?, build_duration_seconds = \? WHERE id = \? AND provider = \? AND status = 'building'$/,
   DELETE_BY_ID: /^DELETE FROM repo_images WHERE id = \?$/,
@@ -111,7 +111,11 @@ class FakeD1Database {
           row.base_branch === branch &&
           row.status === "ready"
         ) {
-          return { id: row.id, provider_image_id: row.provider_image_id };
+          return {
+            id: row.id,
+            provider_image_id: row.provider_image_id,
+            provider_session_id: row.provider_session_id,
+          };
         }
       }
       return null;
@@ -509,6 +513,9 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
+      await expect(
+        store.bindProviderSession("img-old", "modal", "modal-build-session-old")
+      ).resolves.toBe(true);
       await store.markReady("img-old", "modal", "modal-img-old", "sha-old", 30);
 
       vi.advanceTimersByTime(60000);
@@ -523,6 +530,7 @@ describe("RepoImageStore", () => {
       const result = await store.markReady("img-new", "modal", "modal-img-new", "sha-new", 40);
 
       expect(result.replacedImageId).toBe("modal-img-old");
+      expect(result.replacedProviderSessionId).toBe("modal-build-session-old");
 
       const ready = await store.getLatestReady("acme", "repo", "modal");
       expect(ready).not.toBeNull();

--- a/packages/control-plane/src/db/repo-images.ts
+++ b/packages/control-plane/src/db/repo-images.ts
@@ -1,6 +1,6 @@
 import { timingSafeEqual } from "@open-inspect/shared";
 
-export type RepoImageProvider = "modal" | "vercel";
+export type RepoImageProvider = "modal" | "vercel" | "opencomputer";
 
 export interface RepoImageBuild {
   id: string;
@@ -141,7 +141,11 @@ export class RepoImageStore {
     providerImageId: string,
     baseSha: string,
     buildDurationSeconds: number
-  ): Promise<{ updated: boolean; replacedImageId: string | null }> {
+  ): Promise<{
+    updated: boolean;
+    replacedImageId: string | null;
+    replacedProviderSessionId: string | null;
+  }> {
     const build = await this.db
       .prepare(
         "SELECT repo_owner, repo_name, provider, base_branch FROM repo_images WHERE id = ? AND provider = ? AND status = 'building'"
@@ -154,30 +158,37 @@ export class RepoImageStore {
         base_branch: string;
       }>();
 
-    if (!build) return { updated: false, replacedImageId: null };
+    if (!build) {
+      return { updated: false, replacedImageId: null, replacedProviderSessionId: null };
+    }
 
     const oldReady = await this.db
       .prepare(
-        "SELECT id, provider_image_id FROM repo_images WHERE repo_owner = ? AND repo_name = ? AND provider = ? AND base_branch = ? AND status = 'ready'"
+        "SELECT id, provider_image_id, provider_session_id FROM repo_images WHERE repo_owner = ? AND repo_name = ? AND provider = ? AND base_branch = ? AND status = 'ready'"
       )
       .bind(build.repo_owner, build.repo_name, build.provider, build.base_branch)
-      .first<{ id: string; provider_image_id: string }>();
+      .first<{ id: string; provider_image_id: string; provider_session_id: string | null }>();
 
-    const statements: D1PreparedStatement[] = [
-      this.db
-        .prepare(
-          "UPDATE repo_images SET status = 'ready', provider_image_id = ?, base_sha = ?, build_duration_seconds = ? WHERE id = ? AND provider = ? AND status = 'building'"
-        )
-        .bind(providerImageId, baseSha, buildDurationSeconds, buildId, provider),
-    ];
+    const updateResult = await this.db
+      .prepare(
+        "UPDATE repo_images SET status = 'ready', provider_image_id = ?, base_sha = ?, build_duration_seconds = ? WHERE id = ? AND provider = ? AND status = 'building'"
+      )
+      .bind(providerImageId, baseSha, buildDurationSeconds, buildId, provider)
+      .run();
 
-    if (oldReady) {
-      statements.push(this.db.prepare("DELETE FROM repo_images WHERE id = ?").bind(oldReady.id));
+    if ((updateResult.meta?.changes ?? 0) === 0) {
+      return { updated: false, replacedImageId: null, replacedProviderSessionId: null };
     }
 
-    await this.db.batch(statements);
+    if (oldReady) {
+      await this.db.prepare("DELETE FROM repo_images WHERE id = ?").bind(oldReady.id).run();
+    }
 
-    return { updated: true, replacedImageId: oldReady?.provider_image_id ?? null };
+    return {
+      updated: true,
+      replacedImageId: oldReady?.provider_image_id ?? null,
+      replacedProviderSessionId: oldReady?.provider_session_id ?? null,
+    };
   }
 
   async markFailed(buildId: string, provider: RepoImageProvider, error: string): Promise<boolean> {

--- a/packages/control-plane/src/routes/repo-images.ts
+++ b/packages/control-plane/src/routes/repo-images.ts
@@ -19,6 +19,8 @@ import { mergeSecrets } from "../db/secrets-validation";
 import { createModalClient } from "../sandbox/client";
 import { createVercelSandboxClient } from "../sandbox/providers/vercel/client";
 import { createVercelProvider } from "../sandbox/providers/vercel/provider";
+import { createOpenComputerRestClient } from "../sandbox/opencomputer-rest-client";
+import { createOpenComputerProvider } from "../sandbox/providers/opencomputer-provider";
 import { resolveSandboxBackendName, supportsRepoImageBackend } from "../sandbox/provider-name";
 import { resolveScmProviderFromEnv } from "../source-control";
 import { createLogger } from "../logger";
@@ -36,20 +38,23 @@ import {
 } from "./shared";
 
 const logger = createLogger("router:repo-images");
-const VERCEL_CALLBACK_TOKEN_TTL_MS = 2 * 60 * 60 * 1000;
-const VERCEL_CALLBACK_TOKEN_PATTERN = /^[a-f0-9]{64}$/;
+const REPO_IMAGE_CALLBACK_TOKEN_TTL_MS = 2 * 60 * 60 * 1000;
+const REPO_IMAGE_CALLBACK_TOKEN_PATTERN = /^[a-f0-9]{64}$/;
 
 function requireRepoImages(env: Env): Response | null {
   if (supportsRepoImageBackend(env.SANDBOX_PROVIDER)) {
     return null;
   }
 
-  return error("Repo images are only available when SANDBOX_PROVIDER=modal or vercel", 501);
+  return error(
+    "Repo images are only available when SANDBOX_PROVIDER=modal, vercel, or opencomputer",
+    501
+  );
 }
 
-function getRepoImageBackend(env: Env): "modal" | "vercel" {
+function getRepoImageBackend(env: Env): "modal" | "vercel" | "opencomputer" {
   const backend = resolveSandboxBackendName(env.SANDBOX_PROVIDER);
-  if (backend !== "modal" && backend !== "vercel") {
+  if (backend !== "modal" && backend !== "vercel" && backend !== "opencomputer") {
     throw new Error(`Repo images are not supported for SANDBOX_PROVIDER=${backend}`);
   }
   return backend;
@@ -109,6 +114,28 @@ function createConfiguredVercelProvider(env: Env) {
   });
 }
 
+function createConfiguredOpenComputerProvider(env: Env) {
+  if (!env.OPENCOMPUTER_API_URL || !env.OPENCOMPUTER_API_KEY || !env.OPENCOMPUTER_TEMPLATE) {
+    throw new Error("OpenComputer configuration not available");
+  }
+
+  const client = createOpenComputerRestClient({
+    apiUrl: env.OPENCOMPUTER_API_URL,
+    apiKey: env.OPENCOMPUTER_API_KEY,
+    template: env.OPENCOMPUTER_TEMPLATE,
+    projectId: env.OPENCOMPUTER_PROJECT_ID,
+    target: env.OPENCOMPUTER_TARGET,
+  });
+
+  return createOpenComputerProvider(client, {
+    scmProvider: resolveScmProviderFromEnv(env.SCM_PROVIDER),
+    codeServerPasswordSecret: env.OPENCOMPUTER_API_KEY,
+    llmEnvVars: {
+      ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY,
+    },
+  });
+}
+
 function generateRepoImageCallbackToken(): string {
   const bytes = new Uint8Array(32);
   crypto.getRandomValues(bytes);
@@ -131,14 +158,17 @@ function getBearerToken(request: Request): string | null {
   return token || null;
 }
 
-function getVercelCallbackBearerToken(request: Request): string | null {
+function getRepoImageCallbackBearerToken(request: Request): string | null {
   const token = getBearerToken(request);
-  if (!token || !VERCEL_CALLBACK_TOKEN_PATTERN.test(token)) return null;
+  if (!token || !REPO_IMAGE_CALLBACK_TOKEN_PATTERN.test(token)) return null;
   return token;
 }
 
-function requireVercelCallbackBearerAuth(request: Request, ctx: RequestContext): Response | null {
-  if (getVercelCallbackBearerToken(request)) return null;
+function requireRepoImageCallbackBearerAuth(
+  request: Request,
+  ctx: RequestContext
+): Response | null {
+  if (getRepoImageCallbackBearerToken(request)) return null;
 
   logger.warn("repo_image.callback_auth_failed", {
     request_id: ctx.request_id,
@@ -150,24 +180,24 @@ function requireVercelCallbackBearerAuth(request: Request, ctx: RequestContext):
 async function requireCallbackPreParseAuth(
   request: Request,
   env: Env,
-  backend: "modal" | "vercel",
+  backend: "modal" | "vercel" | "opencomputer",
   ctx: RequestContext
 ): Promise<Response | null> {
   if (backend === "modal") {
     return requireBuildCallbackAuth(request, env, ctx);
   }
 
-  return requireVercelCallbackBearerAuth(request, ctx);
+  return requireRepoImageCallbackBearerAuth(request, ctx);
 }
 
-async function requireVercelBuildCallbackAuth(
+async function requireTokenBuildCallbackAuth(
   request: Request,
   env: Env,
   store: RepoImageStore,
-  params: { buildId: string; providerSessionId: string },
+  params: { buildId: string; provider: "vercel" | "opencomputer"; providerSessionId: string },
   ctx: RequestContext
 ): Promise<Response | null> {
-  const token = getVercelCallbackBearerToken(request);
+  const token = getRepoImageCallbackBearerToken(request);
   if (!token) {
     logger.warn("repo_image.callback_auth_failed", {
       build_id: params.buildId,
@@ -193,7 +223,7 @@ async function requireVercelBuildCallbackAuth(
 
   const build = await store.consumeCallbackToken({
     buildId: params.buildId,
-    provider: "vercel",
+    provider: params.provider,
     providerSessionId: params.providerSessionId,
     tokenHash,
     now: Date.now(),
@@ -254,16 +284,16 @@ async function handleBuildComplete(
 
   const store = new RepoImageStore(env.DB);
 
-  if (backend === "vercel") {
+  if (backend === "vercel" || backend === "opencomputer") {
     if (!providerSessionId) {
       return error("provider_session_id is required", 400);
     }
 
-    const authError = await requireVercelBuildCallbackAuth(
+    const authError = await requireTokenBuildCallbackAuth(
       request,
       env,
       store,
-      { buildId, providerSessionId },
+      { buildId, provider: backend, providerSessionId },
       ctx
     );
     if (authError) return authError;
@@ -276,14 +306,24 @@ async function handleBuildComplete(
       trace_id: ctx.trace_id,
     });
 
-    const completion = completeVercelBuildFromSession(env, {
-      buildId,
-      providerSessionId,
-      baseSha: baseSha || "",
-      buildDurationSeconds: buildDurationSeconds ?? 0,
-      requestId: ctx.request_id,
-      traceId: ctx.trace_id,
-    });
+    const completion =
+      backend === "vercel"
+        ? completeVercelBuildFromSession(env, {
+            buildId,
+            providerSessionId,
+            baseSha: baseSha || "",
+            buildDurationSeconds: buildDurationSeconds ?? 0,
+            requestId: ctx.request_id,
+            traceId: ctx.trace_id,
+          })
+        : completeOpenComputerBuildFromSession(env, {
+            buildId,
+            providerSessionId,
+            baseSha: baseSha || "",
+            buildDurationSeconds: buildDurationSeconds ?? 0,
+            requestId: ctx.request_id,
+            traceId: ctx.trace_id,
+          });
 
     if (ctx.executionCtx) {
       ctx.executionCtx.waitUntil(completion);
@@ -513,6 +553,176 @@ async function completeVercelBuildFromSession(
   }
 }
 
+async function completeOpenComputerBuildFromSession(
+  env: Env,
+  params: {
+    buildId: string;
+    providerSessionId: string;
+    baseSha: string;
+    buildDurationSeconds: number;
+    requestId: string;
+    traceId: string;
+  }
+): Promise<void> {
+  if (!env.DB) {
+    logger.error("repo_image.opencomputer_checkpoint_error", {
+      build_id: params.buildId,
+      provider_session_id: params.providerSessionId,
+      error: "Database not configured",
+      request_id: params.requestId,
+      trace_id: params.traceId,
+    });
+    return;
+  }
+
+  const checkpointStart = Date.now();
+  const store = new RepoImageStore(env.DB);
+  let openComputerProvider: ReturnType<typeof createConfiguredOpenComputerProvider> | null = null;
+
+  try {
+    logger.info("repo_image.opencomputer_checkpoint_start", {
+      build_id: params.buildId,
+      provider_session_id: params.providerSessionId,
+      request_id: params.requestId,
+      trace_id: params.traceId,
+    });
+
+    openComputerProvider = createConfiguredOpenComputerProvider(env);
+    const snapshot = await openComputerProvider.takeSnapshot({
+      providerObjectId: params.providerSessionId,
+      sessionId: params.buildId,
+      reason: "repo_image_build",
+      correlation: {
+        request_id: params.requestId,
+        trace_id: params.traceId,
+        sandbox_id: params.providerSessionId,
+      },
+    });
+
+    if (!snapshot.success || !snapshot.imageId) {
+      const message = snapshot.error || "OpenComputer checkpoint did not return an image id";
+      await store.markFailed(params.buildId, "opencomputer", message);
+      logger.error("repo_image.opencomputer_checkpoint_failed", {
+        build_id: params.buildId,
+        provider_session_id: params.providerSessionId,
+        error: message,
+        duration_ms: Date.now() - checkpointStart,
+        request_id: params.requestId,
+        trace_id: params.traceId,
+      });
+      return;
+    }
+
+    const result = await store.markReady(
+      params.buildId,
+      "opencomputer",
+      snapshot.imageId,
+      params.baseSha,
+      params.buildDurationSeconds
+    );
+    if (!result.updated) {
+      try {
+        await openComputerProvider.deleteProviderImage(snapshot.imageId, params.providerSessionId);
+      } catch (cleanupError) {
+        logger.warn("repo_image.opencomputer_checkpoint_cleanup_failed", {
+          build_id: params.buildId,
+          provider_session_id: params.providerSessionId,
+          provider_image_id: snapshot.imageId,
+          error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+          request_id: params.requestId,
+          trace_id: params.traceId,
+        });
+      }
+      logger.warn("repo_image.opencomputer_checkpoint_not_applied", {
+        build_id: params.buildId,
+        provider_session_id: params.providerSessionId,
+        provider_image_id: snapshot.imageId,
+        duration_ms: Date.now() - checkpointStart,
+        request_id: params.requestId,
+        trace_id: params.traceId,
+      });
+      return;
+    }
+
+    logger.info("repo_image.build_complete", {
+      build_id: params.buildId,
+      provider_image_id: snapshot.imageId,
+      provider_session_id: params.providerSessionId,
+      base_sha: params.baseSha,
+      replaced_image_id: result.replacedImageId,
+      snapshot_duration_ms: Date.now() - checkpointStart,
+      request_id: params.requestId,
+      trace_id: params.traceId,
+    });
+
+    if (result.replacedImageId) {
+      try {
+        await openComputerProvider.deleteProviderImage(
+          result.replacedImageId,
+          result.replacedProviderSessionId
+        );
+      } catch (e) {
+        logger.warn("repo_image.delete_old_failed", {
+          provider_image_id: result.replacedImageId,
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+    }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    try {
+      await store.markFailed(params.buildId, "opencomputer", message);
+    } catch (markFailedError) {
+      logger.error("repo_image.mark_failed_after_checkpoint_error", {
+        build_id: params.buildId,
+        error: markFailedError instanceof Error ? markFailedError.message : String(markFailedError),
+        request_id: params.requestId,
+        trace_id: params.traceId,
+      });
+    }
+    logger.error("repo_image.opencomputer_checkpoint_error", {
+      build_id: params.buildId,
+      provider_session_id: params.providerSessionId,
+      error: message,
+      duration_ms: Date.now() - checkpointStart,
+      request_id: params.requestId,
+      trace_id: params.traceId,
+    });
+  } finally {
+    if (openComputerProvider) {
+      try {
+        const stopResult = await openComputerProvider.stopSandbox({
+          providerObjectId: params.providerSessionId,
+          sessionId: params.buildId,
+          reason: "repo_image_build_complete",
+          correlation: {
+            request_id: params.requestId,
+            trace_id: params.traceId,
+            sandbox_id: params.providerSessionId,
+          },
+        });
+        if (!stopResult.success) {
+          logger.warn("repo_image.opencomputer_build_stop_failed", {
+            build_id: params.buildId,
+            provider_session_id: params.providerSessionId,
+            error: stopResult.error,
+            request_id: params.requestId,
+            trace_id: params.traceId,
+          });
+        }
+      } catch (stopError) {
+        logger.warn("repo_image.opencomputer_build_stop_failed", {
+          build_id: params.buildId,
+          provider_session_id: params.providerSessionId,
+          error: stopError instanceof Error ? stopError.message : String(stopError),
+          request_id: params.requestId,
+          trace_id: params.traceId,
+        });
+      }
+    }
+  }
+}
+
 /**
  * POST /repo-images/build-failed
  * Callback from repo image builders on failure.
@@ -548,16 +758,16 @@ async function handleBuildFailed(
 
   const store = new RepoImageStore(env.DB);
 
-  if (backend === "vercel") {
+  if (backend === "vercel" || backend === "opencomputer") {
     if (!body.provider_session_id) {
       return error("provider_session_id is required", 400);
     }
 
-    const authError = await requireVercelBuildCallbackAuth(
+    const authError = await requireTokenBuildCallbackAuth(
       request,
       env,
       store,
-      { buildId, providerSessionId: body.provider_session_id },
+      { buildId, provider: backend, providerSessionId: body.provider_session_id },
       ctx
     );
     if (authError) return authError;
@@ -576,6 +786,36 @@ async function handleBuildFailed(
       request_id: ctx.request_id,
       trace_id: ctx.trace_id,
     });
+
+    if (backend === "opencomputer" && body.provider_session_id) {
+      const cleanupPromise = (async () => {
+        try {
+          await createConfiguredOpenComputerProvider(env).stopSandbox({
+            providerObjectId: body.provider_session_id!,
+            sessionId: buildId,
+            reason: "repo_image_build_failed",
+            correlation: {
+              request_id: ctx.request_id,
+              trace_id: ctx.trace_id,
+              sandbox_id: body.provider_session_id!,
+            },
+          });
+        } catch (stopError) {
+          logger.warn("repo_image.opencomputer_build_stop_failed", {
+            build_id: buildId,
+            provider_session_id: body.provider_session_id,
+            error: stopError instanceof Error ? stopError.message : String(stopError),
+            request_id: ctx.request_id,
+            trace_id: ctx.trace_id,
+          });
+        }
+      })();
+      if (ctx.executionCtx) {
+        ctx.executionCtx.waitUntil(cleanupPromise);
+      } else {
+        await cleanupPromise;
+      }
+    }
 
     return json({ ok: true });
   } catch (e) {
@@ -625,7 +865,10 @@ async function handleTriggerBuild(
   const buildId = `img-${owner}-${name}-${now}`;
 
   try {
-    const callbackToken = backend === "vercel" ? generateRepoImageCallbackToken() : undefined;
+    const callbackToken =
+      backend === "vercel" || backend === "opencomputer"
+        ? generateRepoImageCallbackToken()
+        : undefined;
     const callbackTokenHash = callbackToken
       ? await hashRepoImageCallbackToken(callbackToken, env)
       : undefined;
@@ -638,7 +881,7 @@ async function handleTriggerBuild(
       provider: backend,
       baseBranch: defaultBranch,
       callbackTokenHash,
-      callbackTokenExpiresAt: callbackToken ? now + VERCEL_CALLBACK_TOKEN_TTL_MS : undefined,
+      callbackTokenExpiresAt: callbackToken ? now + REPO_IMAGE_CALLBACK_TOKEN_TTL_MS : undefined,
     });
 
     // Construct callback URL
@@ -748,6 +991,33 @@ async function handleTriggerBuild(
             }
           },
           correlation: { trace_id: ctx.trace_id, request_id: ctx.request_id },
+        });
+        break;
+      }
+      case "opencomputer": {
+        if (!callbackToken) {
+          throw new Error("OpenComputer callback token was not generated");
+        }
+
+        await createConfiguredOpenComputerProvider(env).triggerRepoImageBuild({
+          repoOwner: owner,
+          repoName: name,
+          defaultBranch,
+          buildId,
+          callbackUrl,
+          callbackToken,
+          userEnvVars,
+          buildTimeoutSeconds,
+          onProviderSessionCreated: async (providerSessionId) => {
+            const bound = await store.bindProviderSession(
+              buildId,
+              "opencomputer",
+              providerSessionId
+            );
+            if (!bound) {
+              throw new Error("Failed to bind OpenComputer build session");
+            }
+          },
         });
         break;
       }

--- a/packages/control-plane/src/sandbox/index.ts
+++ b/packages/control-plane/src/sandbox/index.ts
@@ -35,6 +35,11 @@ export {
 export { ModalSandboxProvider, createModalProvider } from "./providers/modal-provider";
 export { DaytonaSandboxProvider, createDaytonaProvider } from "./providers/daytona-provider";
 export {
+  OpenComputerSandboxProvider,
+  createOpenComputerProvider,
+  type OpenComputerProviderConfig,
+} from "./providers/opencomputer-provider";
+export {
   VercelSandboxProvider,
   createVercelProvider,
   type VercelProviderConfig,
@@ -72,6 +77,15 @@ export {
   type DaytonaSandboxResponse,
   type DaytonaCreateSandboxParams,
 } from "./daytona-rest-client";
+export {
+  OpenComputerRestClient,
+  OpenComputerNotFoundError,
+  OpenComputerApiError,
+  createOpenComputerRestClient,
+  type OpenComputerRestConfig,
+  type OpenComputerSandboxResponse,
+  type OpenComputerCreateSandboxParams,
+} from "./opencomputer-rest-client";
 export {
   resolveSandboxBackendName,
   isModalSandboxBackend,

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -1236,6 +1236,43 @@ describe("SandboxLifecycleManager", () => {
       expect(storage.calls).toContain("clearSandboxCodeServer");
     });
 
+    it("does not explicitly stop providers when the capability is disabled", async () => {
+      const now = Date.now();
+      const sandbox = createMockSandbox({
+        status: "ready",
+        last_heartbeat: now - 10000,
+        last_activity: now - 11 * 60 * 1000,
+      });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const wsManager = createMockWebSocketManager(false, 0);
+      const stopSandbox = vi.fn(async () => ({ success: true }));
+      const provider = createMockProvider({
+        capabilities: { supportsExplicitStop: false, supportsPersistentResume: false },
+        stopSandbox,
+      });
+
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        createMockBroadcaster(),
+        wsManager,
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.handleAlarm();
+
+      expect(provider.takeSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerObjectId: "modal-obj-123",
+          reason: "inactivity_timeout",
+        })
+      );
+      expect(stopSandbox).not.toHaveBeenCalled();
+      expect(wsManager.sendToSandbox).toHaveBeenCalledWith({ type: "shutdown" });
+    });
+
     it("stops resumable provider-managed sandboxes without snapshotting", async () => {
       const now = Date.now();
       const sandbox = createMockSandbox({

--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
@@ -1,0 +1,515 @@
+/**
+ * Direct REST client for OpenComputer sandboxes.
+ *
+ * The path names are intentionally configurable because OpenComputer deployments
+ * may expose versioned or compatibility routes. Defaults are the canonical MVP
+ * shape expected by OpenInspect.
+ */
+
+import { createLogger } from "../logger";
+
+const log = createLogger("opencomputer-rest-client");
+
+export const OPENCOMPUTER_CHECKPOINT_KIND = "disk_only" as const;
+
+export const OPENCOMPUTER_CHECKPOINT_RETENTION_POLICY = {
+  mode: "delete_oldest",
+  maxCount: 30,
+} as const;
+
+export interface OpenComputerRestConfig {
+  /** OpenComputer API base URL, e.g. https://api.opencomputer.dev */
+  apiUrl: string;
+  /** OpenComputer API key */
+  apiKey: string;
+  /** Declarative template identifier containing the OpenInspect runtime */
+  template: string;
+  /** Optional project/workspace/tenant scope */
+  projectId?: string;
+  /** Optional target/region/cell */
+  target?: string;
+  /** Header used for API key authentication. Defaults to X-API-Key. */
+  authHeaderName?: string;
+  /** Optional prefix for the API key header value, e.g. "Bearer ". */
+  authHeaderValuePrefix?: string;
+  /** Optional route path overrides */
+  paths?: Partial<OpenComputerApiPaths>;
+}
+
+export interface OpenComputerApiPaths {
+  sandboxes: string;
+  sandboxFromCheckpoint: string;
+  sandbox: string;
+  wake: string;
+  hibernate: string;
+  timeout: string;
+  tunnel: string;
+  exec: string;
+  checkpoints: string;
+  checkpoint: string;
+  secretStores: string;
+  secretStore: string;
+  secret: string;
+}
+
+export interface OpenComputerSandboxResponse {
+  id: string;
+  sandboxID?: string;
+  state?: string;
+  status?: string;
+  sandboxDomain?: string;
+  routes?: Array<{ port: number; url: string }>;
+  tunnelUrls?: Record<string, string>;
+}
+
+export interface OpenComputerCreateSandboxParams {
+  name: string;
+  template: string;
+  env?: Record<string, string>;
+  labels?: Record<string, string>;
+  timeoutSeconds?: number;
+  secretStore?: string;
+  projectId?: string;
+  target?: string;
+}
+
+export interface OpenComputerForkCheckpointParams {
+  checkpointId: string;
+  name: string;
+  env?: Record<string, string>;
+  labels?: Record<string, string>;
+  timeoutSeconds?: number;
+  secretStore?: string;
+}
+
+export interface OpenComputerCheckpointResponse {
+  id: string;
+  sandboxId: string;
+  orgId?: string;
+  name?: string;
+  kind?: "full" | "disk_only";
+  status?: string;
+  createdAt?: string;
+}
+
+export type OpenComputerCheckpointRetentionPolicy = typeof OPENCOMPUTER_CHECKPOINT_RETENTION_POLICY;
+
+export interface OpenComputerCreateCheckpointOptions {
+  kind?: typeof OPENCOMPUTER_CHECKPOINT_KIND;
+  retentionPolicy?: OpenComputerCheckpointRetentionPolicy;
+}
+
+export interface OpenComputerExecResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface OpenComputerSecretStoreResponse {
+  id: string;
+  name: string;
+  egressAllowlist?: string[];
+}
+
+export interface OpenComputerCreateSecretStoreParams {
+  name: string;
+  egressAllowlist?: string[];
+}
+
+export interface OpenComputerSetSecretParams {
+  storeId: string;
+  name: string;
+  value: string;
+  allowedHosts?: string[];
+}
+
+export interface OpenComputerTunnelResponse {
+  url: string;
+  hostname?: string;
+}
+
+export class OpenComputerNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OpenComputerNotFoundError";
+  }
+}
+
+export class OpenComputerApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number
+  ) {
+    super(message);
+    this.name = "OpenComputerApiError";
+  }
+}
+
+const DEFAULT_PATHS: OpenComputerApiPaths = {
+  sandboxes: "/sandboxes",
+  sandboxFromCheckpoint: "/sandboxes/from-checkpoint/:checkpointId",
+  sandbox: "/sandboxes/:id",
+  wake: "/sandboxes/:id/wake",
+  hibernate: "/sandboxes/:id/hibernate",
+  timeout: "/sandboxes/:id/timeout",
+  tunnel: "/sandboxes/:id/preview",
+  exec: "/sandboxes/:id/exec/run",
+  checkpoints: "/sandboxes/:id/checkpoints",
+  checkpoint: "/sandboxes/:id/checkpoints/:checkpointId",
+  secretStores: "/secret-stores",
+  secretStore: "/secret-stores/:id",
+  secret: "/secret-stores/:id/secrets/:name",
+};
+
+const TIMEOUT_CREATE_MS = 90_000;
+const TIMEOUT_WAKE_MS = 60_000;
+const TIMEOUT_HIBERNATE_MS = 30_000;
+const TIMEOUT_GET_MS = 15_000;
+const TIMEOUT_TUNNEL_MS = 15_000;
+const TIMEOUT_EXEC_MS = 15_000;
+const TIMEOUT_BUILD_EXEC_MS = 30 * 60_000;
+const TIMEOUT_CHECKPOINT_MS = 5 * 60_000;
+const TIMEOUT_SECRET_STORE_MS = 30_000;
+const RUNTIME_ENTRYPOINT_EXEC_TIMEOUT_MS = 10_000;
+const SYSTEM_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt";
+const OPENSANDBOX_PROXY_CA = "/usr/local/share/ca-certificates/opensandbox-proxy.crt";
+const PYTHON_VENV = "/home/sandbox/.venv";
+const USER_BIN = "/home/sandbox/.local/bin";
+const RUNTIME_CA_EXPORTS =
+  `SSL_CERT_FILE=${SYSTEM_CA_BUNDLE} ` +
+  `CURL_CA_BUNDLE=${SYSTEM_CA_BUNDLE} ` +
+  `REQUESTS_CA_BUNDLE=${SYSTEM_CA_BUNDLE} ` +
+  `NODE_EXTRA_CA_CERTS=${OPENSANDBOX_PROXY_CA} ` +
+  `NPM_CONFIG_CAFILE=${OPENSANDBOX_PROXY_CA} ` +
+  `GIT_SSL_CAINFO=${OPENSANDBOX_PROXY_CA}`;
+const LOCAL_NO_PROXY = "localhost,127.0.0.1,::1";
+const RUNTIME_HOSTS_BOOTSTRAP =
+  "grep -Eq '^[[:space:]]*127\\.0\\.0\\.1[[:space:]].*\\blocalhost\\b' /etc/hosts || " +
+  "printf '%s\\n' '127.0.0.1 localhost' | sudo tee -a /etc/hosts >/dev/null; " +
+  "grep -Eq '^[[:space:]]*::1[[:space:]].*\\blocalhost\\b' /etc/hosts || " +
+  "printf '%s\\n' '::1 localhost ip6-localhost ip6-loopback' | sudo tee -a /etc/hosts >/dev/null";
+const RUNTIME_ENV_EXPORTS =
+  "export HOME=/home/sandbox " +
+  `VIRTUAL_ENV=${PYTHON_VENV} ` +
+  "XDG_CONFIG_HOME=/home/sandbox/.config " +
+  "PYTHONPATH=/app " +
+  "NODE_PATH=/home/sandbox/.npm-global/lib/node_modules:/usr/lib/node_modules " +
+  `OPENINSPECT_BIN_INSTALL_DIR=${USER_BIN} ` +
+  `NO_PROXY=${LOCAL_NO_PROXY} ` +
+  `no_proxy=${LOCAL_NO_PROXY} ` +
+  `PATH=${PYTHON_VENV}/bin:/home/sandbox/.npm-global/bin:${USER_BIN}:/home/sandbox/.local/share/pnpm:/usr/local/bin:/usr/bin:/bin ` +
+  RUNTIME_CA_EXPORTS;
+const RUNTIME_CA_BOOTSTRAP =
+  `[ -f ${OPENSANDBOX_PROXY_CA} ] && sudo update-ca-certificates >/tmp/openinspect-update-ca.log 2>&1 || true; ` +
+  `[ -f ${OPENSANDBOX_PROXY_CA} ] && sudo git config --system http.sslCAInfo ${OPENSANDBOX_PROXY_CA} || true`;
+const RUNTIME_LOG_PATH = "/var/log/openinspect-runtime.log";
+const LEGACY_RUNTIME_LOG_PATH = "/tmp/openinspect-runtime.log";
+const RUNTIME_LOG_BOOTSTRAP =
+  `sudo touch ${RUNTIME_LOG_PATH}; ` +
+  `sudo chown "$(id -u):$(id -g)" ${RUNTIME_LOG_PATH}; ` +
+  `ln -sf ${RUNTIME_LOG_PATH} ${LEGACY_RUNTIME_LOG_PATH}`;
+
+export class OpenComputerRestClient {
+  private readonly baseUrl: string;
+  private readonly paths: OpenComputerApiPaths;
+
+  constructor(public readonly config: OpenComputerRestConfig) {
+    if (!config.apiUrl) throw new Error("OpenComputerRestClient requires apiUrl");
+    if (!config.apiKey) throw new Error("OpenComputerRestClient requires apiKey");
+    if (!config.template) throw new Error("OpenComputerRestClient requires template");
+
+    this.baseUrl = config.apiUrl.replace(/\/+$/, "");
+    this.paths = { ...DEFAULT_PATHS, ...(config.paths ?? {}) };
+  }
+
+  async createSandbox(
+    params: OpenComputerCreateSandboxParams
+  ): Promise<OpenComputerSandboxResponse> {
+    const startMs = Date.now();
+    const metadata = {
+      ...(params.labels ?? {}),
+      ...(params.projectId ? { opencomputer_project_id: params.projectId } : {}),
+      ...(params.target ? { opencomputer_target: params.target } : {}),
+    };
+    const body: Record<string, unknown> = {
+      templateID: "base",
+      snapshot: params.template,
+      envs: params.env,
+      metadata,
+    };
+    if (params.timeoutSeconds !== undefined) {
+      body.timeout = params.timeoutSeconds;
+    }
+    if (params.secretStore) {
+      body.secretStore = params.secretStore;
+    }
+
+    try {
+      const response = await this.request<OpenComputerSandboxResponse>(
+        "POST",
+        this.paths.sandboxes,
+        TIMEOUT_CREATE_MS,
+        body
+      );
+      return this.normalizeSandbox(response);
+    } finally {
+      log.info("opencomputer.create_sandbox", {
+        duration_ms: Date.now() - startMs,
+        sandbox_name: params.name,
+      });
+    }
+  }
+
+  async forkFromCheckpoint(
+    params: OpenComputerForkCheckpointParams
+  ): Promise<OpenComputerSandboxResponse> {
+    const body: Record<string, unknown> = {
+      envs: params.env,
+      metadata: params.labels,
+    };
+    if (params.timeoutSeconds !== undefined) {
+      body.timeout = params.timeoutSeconds;
+    }
+    if (params.secretStore) {
+      body.secretStore = params.secretStore;
+    }
+
+    const response = await this.request<OpenComputerSandboxResponse>(
+      "POST",
+      this.expandPath(this.paths.sandboxFromCheckpoint, { checkpointId: params.checkpointId }),
+      TIMEOUT_CREATE_MS,
+      body
+    );
+    return this.normalizeSandbox(response);
+  }
+
+  async createSecretStore(
+    params: OpenComputerCreateSecretStoreParams
+  ): Promise<OpenComputerSecretStoreResponse> {
+    return await this.request<OpenComputerSecretStoreResponse>(
+      "POST",
+      this.paths.secretStores,
+      TIMEOUT_SECRET_STORE_MS,
+      {
+        name: params.name,
+        egressAllowlist: params.egressAllowlist,
+      }
+    );
+  }
+
+  async setSecret(params: OpenComputerSetSecretParams): Promise<void> {
+    await this.request<void>(
+      "PUT",
+      this.expandPath(this.paths.secret, {
+        id: params.storeId,
+        name: params.name,
+      }),
+      TIMEOUT_SECRET_STORE_MS,
+      {
+        value: params.value,
+        allowedHosts: params.allowedHosts,
+      }
+    );
+  }
+
+  async deleteSecretStore(id: string): Promise<void> {
+    await this.request<void>(
+      "DELETE",
+      this.expandPath(this.paths.secretStore, { id }),
+      TIMEOUT_SECRET_STORE_MS
+    );
+  }
+
+  async getSandbox(id: string): Promise<OpenComputerSandboxResponse> {
+    const response = await this.request<OpenComputerSandboxResponse>(
+      "GET",
+      this.expandPath(this.paths.sandbox, { id }),
+      TIMEOUT_GET_MS
+    );
+    return this.normalizeSandbox(response);
+  }
+
+  async wakeSandbox(id: string): Promise<OpenComputerSandboxResponse | void> {
+    const response = await this.request<OpenComputerSandboxResponse | void>(
+      "POST",
+      this.expandPath(this.paths.wake, { id }),
+      TIMEOUT_WAKE_MS
+    );
+    return response ? this.normalizeSandbox(response) : response;
+  }
+
+  async hibernateSandbox(id: string): Promise<void> {
+    await this.request<void>(
+      "POST",
+      this.expandPath(this.paths.hibernate, { id }),
+      TIMEOUT_HIBERNATE_MS
+    );
+  }
+
+  async setSandboxTimeout(id: string, timeoutSeconds: number): Promise<void> {
+    await this.request<void>("POST", this.expandPath(this.paths.timeout, { id }), TIMEOUT_GET_MS, {
+      timeout: timeoutSeconds,
+    });
+  }
+
+  async deleteSandbox(id: string): Promise<void> {
+    await this.request<void>("DELETE", this.expandPath(this.paths.sandbox, { id }), TIMEOUT_GET_MS);
+  }
+
+  async startRuntime(id: string, extraEnv: Record<string, string> = {}): Promise<void> {
+    const exports = this.shellExportEnv(extraEnv);
+    await this.request<void>("POST", this.expandPath(this.paths.exec, { id }), TIMEOUT_EXEC_MS, {
+      cmd: "sh",
+      args: [
+        "-c",
+        `${RUNTIME_HOSTS_BOOTSTRAP}; ${RUNTIME_CA_BOOTSTRAP}; ${RUNTIME_LOG_BOOTSTRAP}; ${RUNTIME_ENV_EXPORTS}; ${exports}nohup python3 -m sandbox_runtime.entrypoint >>${RUNTIME_LOG_PATH} 2>&1 & echo $!`,
+      ],
+      timeout: RUNTIME_ENTRYPOINT_EXEC_TIMEOUT_MS / 1000,
+    });
+  }
+
+  async runRuntimeForeground(
+    id: string,
+    timeoutSeconds: number,
+    extraEnv: Record<string, string> = {}
+  ): Promise<OpenComputerExecResult> {
+    const exports = this.shellExportEnv(extraEnv);
+    return await this.request<OpenComputerExecResult>(
+      "POST",
+      this.expandPath(this.paths.exec, { id }),
+      TIMEOUT_BUILD_EXEC_MS,
+      {
+        cmd: "sh",
+        args: [
+          "-c",
+          `${RUNTIME_HOSTS_BOOTSTRAP}; ${RUNTIME_CA_BOOTSTRAP}; ${RUNTIME_LOG_BOOTSTRAP}; ${RUNTIME_ENV_EXPORTS}; ${exports} python3 -m sandbox_runtime.entrypoint >>${RUNTIME_LOG_PATH} 2>&1`,
+        ],
+        timeout: timeoutSeconds,
+      }
+    );
+  }
+
+  async createCheckpoint(
+    id: string,
+    name: string,
+    options: OpenComputerCreateCheckpointOptions = {}
+  ): Promise<OpenComputerCheckpointResponse> {
+    return await this.request<OpenComputerCheckpointResponse>(
+      "POST",
+      this.expandPath(this.paths.checkpoints, { id }),
+      TIMEOUT_CHECKPOINT_MS,
+      {
+        name,
+        kind: options.kind ?? OPENCOMPUTER_CHECKPOINT_KIND,
+        retentionPolicy: options.retentionPolicy ?? OPENCOMPUTER_CHECKPOINT_RETENTION_POLICY,
+      }
+    );
+  }
+
+  async deleteCheckpoint(id: string, checkpointId: string): Promise<void> {
+    await this.request<void>(
+      "DELETE",
+      this.expandPath(this.paths.checkpoint, { id, checkpointId }),
+      TIMEOUT_CHECKPOINT_MS
+    );
+  }
+
+  async getTunnelUrl(id: string, port: number): Promise<OpenComputerTunnelResponse> {
+    const response = await this.request<OpenComputerTunnelResponse>(
+      "POST",
+      this.expandPath(this.paths.tunnel, { id, port: String(port) }),
+      TIMEOUT_TUNNEL_MS,
+      { port }
+    );
+    return {
+      ...response,
+      url: response.url ?? (response.hostname ? `https://${response.hostname}` : ""),
+    };
+  }
+
+  private getHeaders(): Record<string, string> {
+    const authHeaderName = this.config.authHeaderName ?? "X-API-Key";
+    return {
+      "Content-Type": "application/json",
+      [authHeaderName]: `${this.config.authHeaderValuePrefix ?? ""}${this.config.apiKey}`,
+    };
+  }
+
+  private async request<T>(
+    method: "GET" | "POST" | "PUT" | "DELETE",
+    path: string,
+    timeoutMs: number,
+    body?: unknown
+  ): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const init: RequestInit = {
+        method,
+        headers: this.getHeaders(),
+        signal: controller.signal,
+      };
+      if (body !== undefined) init.body = JSON.stringify(body);
+
+      let response: Response;
+      try {
+        response = await fetch(url, init);
+      } catch (error) {
+        if (controller.signal.aborted) {
+          throw new Error(`OpenComputer request timed out after ${timeoutMs}ms`);
+        }
+        throw error;
+      }
+
+      if (response.status === 404) {
+        const text = await response.text();
+        throw new OpenComputerNotFoundError(text || `Not found: ${path}`);
+      }
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new OpenComputerApiError(text || response.statusText, response.status);
+      }
+
+      const contentType = response.headers.get("content-type") ?? "";
+      if (contentType.includes("application/json")) {
+        return (await response.json()) as T;
+      }
+      return undefined as T;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private expandPath(path: string, params: Record<string, string>): string {
+    let expanded = path;
+    for (const [key, value] of Object.entries(params)) {
+      expanded = expanded.replace(`:${key}`, encodeURIComponent(value));
+    }
+    return expanded;
+  }
+
+  private shellExportEnv(env: Record<string, string>): string {
+    const entries = Object.entries(env).filter(([, value]) => value.length > 0);
+    if (entries.length === 0) return "";
+    return `${entries.map(([key, value]) => `${key}=${this.shellQuote(value)}`).join(" ")} `;
+  }
+
+  private shellQuote(value: string): string {
+    return `'${value.replace(/'/g, `'\\''`)}'`;
+  }
+
+  private normalizeSandbox(response: OpenComputerSandboxResponse): OpenComputerSandboxResponse {
+    const id = response.id || response.sandboxID;
+    if (!id) return response;
+    return { ...response, id };
+  }
+}
+
+export function createOpenComputerRestClient(
+  config: OpenComputerRestConfig
+): OpenComputerRestClient {
+  return new OpenComputerRestClient(config);
+}

--- a/packages/control-plane/src/sandbox/provider-name.test.ts
+++ b/packages/control-plane/src/sandbox/provider-name.test.ts
@@ -30,17 +30,23 @@ describe("resolveSandboxBackendName", () => {
     expect(resolveSandboxBackendName("vercel")).toBe("vercel");
   });
 
+  it('returns "opencomputer" for "opencomputer"', () => {
+    expect(resolveSandboxBackendName("opencomputer")).toBe("opencomputer");
+  });
+
   it("is case-insensitive", () => {
     expect(resolveSandboxBackendName("MODAL")).toBe("modal");
     expect(resolveSandboxBackendName("Daytona")).toBe("daytona");
     expect(resolveSandboxBackendName("DAYTONA")).toBe("daytona");
     expect(resolveSandboxBackendName("VERCEL")).toBe("vercel");
+    expect(resolveSandboxBackendName("OPENCOMPUTER")).toBe("opencomputer");
   });
 
   it("trims whitespace", () => {
     expect(resolveSandboxBackendName("  modal  ")).toBe("modal");
     expect(resolveSandboxBackendName("  daytona  ")).toBe("daytona");
     expect(resolveSandboxBackendName("  vercel  ")).toBe("vercel");
+    expect(resolveSandboxBackendName("  opencomputer  ")).toBe("opencomputer");
   });
 
   it("throws for unsupported provider", () => {
@@ -65,12 +71,17 @@ describe("isModalSandboxBackend", () => {
   it("returns false for vercel", () => {
     expect(isModalSandboxBackend("vercel")).toBe(false);
   });
+
+  it("returns false for opencomputer", () => {
+    expect(isModalSandboxBackend("opencomputer")).toBe(false);
+  });
 });
 
 describe("supportsRepoImageBackend", () => {
-  it("returns true for modal and vercel", () => {
+  it("returns true for modal, vercel, and opencomputer", () => {
     expect(supportsRepoImageBackend("modal")).toBe(true);
     expect(supportsRepoImageBackend("vercel")).toBe(true);
+    expect(supportsRepoImageBackend("opencomputer")).toBe(true);
     expect(supportsRepoImageBackend(undefined)).toBe(true);
   });
 

--- a/packages/control-plane/src/sandbox/provider-name.ts
+++ b/packages/control-plane/src/sandbox/provider-name.ts
@@ -2,7 +2,7 @@
  * Sandbox backend selection utilities.
  */
 
-export type SandboxBackendName = "modal" | "daytona" | "vercel";
+export type SandboxBackendName = "modal" | "daytona" | "vercel" | "opencomputer";
 
 /**
  * Resolve the configured sandbox backend.
@@ -24,6 +24,10 @@ export function resolveSandboxBackendName(value: string | undefined): SandboxBac
     return "vercel";
   }
 
+  if (normalized === "opencomputer") {
+    return "opencomputer";
+  }
+
   throw new Error(`Unsupported SANDBOX_PROVIDER: ${value}`);
 }
 
@@ -33,5 +37,5 @@ export function isModalSandboxBackend(value: string | undefined): boolean {
 
 export function supportsRepoImageBackend(value: string | undefined): boolean {
   const backend = resolveSandboxBackendName(value);
-  return backend === "modal" || backend === "vercel";
+  return backend === "modal" || backend === "vercel" || backend === "opencomputer";
 }

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -1,0 +1,409 @@
+import { describe, expect, it, vi } from "vitest";
+import { OpenComputerSandboxProvider } from "./opencomputer-provider";
+import type {
+  OpenComputerCreateSandboxParams,
+  OpenComputerForkCheckpointParams,
+  OpenComputerRestClient,
+  OpenComputerSandboxResponse,
+} from "../opencomputer-rest-client";
+import {
+  OPENCOMPUTER_CHECKPOINT_KIND,
+  OPENCOMPUTER_CHECKPOINT_RETENTION_POLICY,
+} from "../opencomputer-rest-client";
+import type { CreateSandboxConfig } from "../provider";
+
+function createMockClient(overrides: Partial<OpenComputerRestClient> = {}): OpenComputerRestClient {
+  const client = {
+    config: {
+      apiUrl: "https://opencomputer.test",
+      apiKey: "oc-token",
+      template: "openinspect-runtime",
+    },
+    createSandbox: vi.fn(
+      async (params: OpenComputerCreateSandboxParams): Promise<OpenComputerSandboxResponse> => ({
+        id: "oc-sandbox-1",
+        state: "running",
+        routes: [{ port: 3000, url: `https://${params.name}-3000.opencomputer.test` }],
+      })
+    ),
+    forkFromCheckpoint: vi.fn(
+      async (params: OpenComputerForkCheckpointParams): Promise<OpenComputerSandboxResponse> => ({
+        id: "oc-fork-1",
+        state: "running",
+        routes: [{ port: 3000, url: `https://${params.name}-3000.opencomputer.test` }],
+      })
+    ),
+    createCheckpoint: vi.fn(async () => ({
+      id: "checkpoint-1",
+      sandboxId: "oc-sandbox-1",
+      status: "processing",
+    })),
+    deleteSandbox: vi.fn(async (): Promise<void> => undefined),
+    deleteCheckpoint: vi.fn(async (): Promise<void> => undefined),
+    getSandbox: vi.fn(
+      async (): Promise<OpenComputerSandboxResponse> => ({
+        id: "oc-sandbox-1",
+        state: "hibernated",
+      })
+    ),
+    wakeSandbox: vi.fn(
+      async (): Promise<OpenComputerSandboxResponse> => ({
+        id: "oc-sandbox-1",
+        state: "running",
+      })
+    ),
+    hibernateSandbox: vi.fn(async (): Promise<void> => undefined),
+    setSandboxTimeout: vi.fn(async (): Promise<void> => undefined),
+    startRuntime: vi.fn(async (): Promise<void> => undefined),
+    createSecretStore: vi.fn(async () => ({
+      id: "secret-store-1",
+      name: "openinspect-session-1",
+      egressAllowlist: [],
+    })),
+    setSecret: vi.fn(async (): Promise<void> => undefined),
+    deleteSecretStore: vi.fn(async (): Promise<void> => undefined),
+    getTunnelUrl: vi.fn(async (_id: string, port: number) => ({
+      url: `https://oc-sandbox-1-${port}.opencomputer.test`,
+    })),
+    ...overrides,
+  };
+  return client as unknown as OpenComputerRestClient;
+}
+
+const baseConfig: CreateSandboxConfig = {
+  sessionId: "session-1",
+  sandboxId: "sandbox-acme-repo-1",
+  repoOwner: "acme",
+  repoName: "repo",
+  controlPlaneUrl: "https://control.example",
+  sandboxAuthToken: "sandbox-token",
+  provider: "anthropic",
+  model: "claude-sonnet-4-6",
+  branch: "main",
+};
+
+describe("OpenComputerSandboxProvider", () => {
+  it("reports checkpoint/fork capabilities", () => {
+    const provider = new OpenComputerSandboxProvider(createMockClient(), {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    expect(provider.name).toBe("opencomputer");
+    expect(provider.capabilities).toEqual({
+      supportsSnapshots: true,
+      supportsRestore: true,
+      supportsWarm: false,
+      supportsPersistentResume: true,
+      supportsExplicitStop: true,
+    });
+  });
+
+  it("creates a sandbox from the configured template with runtime environment", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    const result = await provider.createSandbox({
+      ...baseConfig,
+      userEnvVars: { ANTHROPIC_API_KEY: "sk-test" },
+      codeServerEnabled: true,
+      sandboxSettings: { codeServerPort: 3000, tunnelPorts: [5173] },
+    });
+
+    expect(result).toMatchObject({
+      sandboxId: "sandbox-acme-repo-1",
+      providerObjectId: "oc-sandbox-1",
+      status: "running",
+      codeServerUrl: "https://sandbox-acme-repo-1-3000.opencomputer.test",
+      tunnelUrls: { "5173": "https://oc-sandbox-1-5173.opencomputer.test" },
+    });
+
+    expect(client.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "sandbox-acme-repo-1",
+        template: "openinspect-runtime",
+        env: expect.objectContaining({
+          SANDBOX_ID: "sandbox-acme-repo-1",
+          CONTROL_PLANE_URL: "https://control.example",
+          SANDBOX_AUTH_TOKEN: "sandbox-token",
+          REPO_OWNER: "acme",
+          REPO_NAME: "repo",
+          VCS_HOST: "github.com",
+          VCS_CLONE_USERNAME: "x-access-token",
+        }),
+        labels: expect.objectContaining({
+          openinspect_provider: "opencomputer",
+          openinspect_session_id: "session-1",
+        }),
+        secretStore: "openinspect-session-1",
+      })
+    );
+
+    const createCall = vi.mocked(client.createSandbox).mock.calls[0][0];
+    expect(client.startRuntime).toHaveBeenCalledWith("oc-sandbox-1");
+    expect(createCall.env).toHaveProperty("ANTHROPIC_API_KEY", "sk-test");
+    expect(client.createSecretStore).toHaveBeenCalledWith({
+      name: "openinspect-session-1",
+      egressAllowlist: ["*"],
+    });
+    expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-sandbox-1", 600);
+    expect(client.setSecret).toHaveBeenCalledWith({
+      storeId: "secret-store-1",
+      name: "ANTHROPIC_API_KEY",
+      value: "sk-test",
+      allowedHosts: ["api.anthropic.com"],
+    });
+    expect(JSON.parse(createCall.env!.SESSION_CONFIG)).toMatchObject({
+      session_id: "session-1",
+      repo_owner: "acme",
+      repo_name: "repo",
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      branch: "main",
+    });
+  });
+
+  it("adds provider-level LLM credentials to the runtime environment", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+      llmEnvVars: { ANTHROPIC_API_KEY: "sk-provider" },
+    });
+
+    await provider.createSandbox(baseConfig);
+
+    const createCall = vi.mocked(client.createSandbox).mock.calls[0][0];
+    expect(createCall.env).toHaveProperty("ANTHROPIC_API_KEY", "sk-provider");
+  });
+
+  it("scopes clone secrets to GitLab hosts for GitLab sessions", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "gitlab",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await provider.createSandbox({
+      ...baseConfig,
+      userEnvVars: { VCS_CLONE_TOKEN: "gl-token" },
+    });
+
+    const createCall = vi.mocked(client.createSandbox).mock.calls[0][0];
+    expect(createCall.env).toMatchObject({
+      VCS_HOST: "gitlab.com",
+      VCS_CLONE_USERNAME: "oauth2",
+    });
+    expect(client.setSecret).toHaveBeenCalledWith({
+      storeId: "secret-store-1",
+      name: "VCS_CLONE_TOKEN",
+      value: "gl-token",
+      allowedHosts: ["gitlab.com", "api.gitlab.com"],
+    });
+  });
+
+  it("cleans up a created sandbox when runtime startup fails", async () => {
+    const client = createMockClient({
+      startRuntime: vi.fn(async () => {
+        throw new Error("runtime failed");
+      }),
+    });
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await expect(provider.createSandbox(baseConfig)).rejects.toThrow(
+      "Failed to create OpenComputer sandbox"
+    );
+
+    expect(client.deleteSandbox).toHaveBeenCalledWith("oc-sandbox-1");
+    expect(client.deleteSecretStore).toHaveBeenCalledWith("secret-store-1");
+  });
+
+  it("forks from a repo image checkpoint when provided", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    const result = await provider.createSandbox({
+      ...baseConfig,
+      repoImageId: "checkpoint-repo-1",
+      repoImageSha: "abc123",
+    });
+
+    expect(result).toMatchObject({
+      providerObjectId: "oc-fork-1",
+      status: "running",
+    });
+    expect(client.createSandbox).not.toHaveBeenCalled();
+    expect(client.forkFromCheckpoint).toHaveBeenCalledWith(
+      expect.objectContaining({
+        checkpointId: "checkpoint-repo-1",
+        env: expect.objectContaining({
+          FROM_REPO_IMAGE: "true",
+          REPO_IMAGE_SHA: "abc123",
+        }),
+      })
+    );
+    expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-fork-1", 600);
+    expect(client.startRuntime).toHaveBeenCalledWith("oc-fork-1");
+  });
+
+  it("restores session snapshots by forking from the checkpoint", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    const result = await provider.restoreFromSnapshot({
+      ...baseConfig,
+      snapshotImageId: "checkpoint-session-1",
+    });
+
+    expect(result).toMatchObject({ success: true, providerObjectId: "oc-fork-1" });
+    expect(client.forkFromCheckpoint).toHaveBeenCalledWith(
+      expect.objectContaining({
+        checkpointId: "checkpoint-session-1",
+        env: expect.objectContaining({ RESTORED_FROM_SNAPSHOT: "true" }),
+      })
+    );
+    expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-fork-1", 600);
+    expect(client.startRuntime).toHaveBeenCalledWith("oc-fork-1");
+  });
+
+  it("creates checkpoints for snapshots", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await expect(
+      provider.takeSnapshot({
+        providerObjectId: "oc-sandbox-1",
+        sessionId: "session-1",
+        reason: "user_stop",
+      })
+    ).resolves.toEqual({ success: true, imageId: "checkpoint-1" });
+
+    expect(client.createCheckpoint).toHaveBeenCalledWith(
+      "oc-sandbox-1",
+      expect.stringContaining("openinspect-session-1-user_stop-"),
+      {
+        kind: OPENCOMPUTER_CHECKPOINT_KIND,
+        retentionPolicy: OPENCOMPUTER_CHECKPOINT_RETENTION_POLICY,
+      }
+    );
+  });
+
+  it("creates checkpoints for execution-complete snapshots", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await expect(
+      provider.takeSnapshot({
+        providerObjectId: "oc-sandbox-1",
+        sessionId: "session-1",
+        reason: "execution_complete",
+      })
+    ).resolves.toEqual({ success: true, imageId: "checkpoint-1" });
+
+    expect(client.createCheckpoint).toHaveBeenCalledWith(
+      "oc-sandbox-1",
+      expect.stringContaining("openinspect-session-1-execution_complete-"),
+      {
+        kind: OPENCOMPUTER_CHECKPOINT_KIND,
+        retentionPolicy: OPENCOMPUTER_CHECKPOINT_RETENTION_POLICY,
+      }
+    );
+  });
+
+  it("starts repo image builds with callback provider session env", async () => {
+    const client = createMockClient();
+    const onProviderSessionCreated = vi.fn(async () => undefined);
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+      llmEnvVars: { ANTHROPIC_API_KEY: "sk-provider" },
+    });
+
+    await provider.triggerRepoImageBuild({
+      buildId: "build-1",
+      repoOwner: "acme",
+      repoName: "repo",
+      defaultBranch: "main",
+      callbackUrl: "https://control.example/repo-images/build-complete",
+      callbackToken: "callback-token",
+      onProviderSessionCreated,
+    });
+
+    expect(client.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: expect.objectContaining({
+          IMAGE_BUILD_MODE: "true",
+          OI_REPO_IMAGE_BUILD_ID: "build-1",
+          OI_REPO_IMAGE_CALLBACK_URL: "https://control.example/repo-images/build-complete",
+          OI_REPO_IMAGE_CALLBACK_TOKEN: "callback-token",
+          ANTHROPIC_API_KEY: "sk-provider",
+        }),
+        labels: expect.objectContaining({
+          openinspect_kind: "repo-image-build",
+          openinspect_build_id: "build-1",
+        }),
+      })
+    );
+    expect(onProviderSessionCreated).toHaveBeenCalledWith("oc-sandbox-1");
+    expect(client.startRuntime).toHaveBeenCalledWith("oc-sandbox-1", {
+      OI_REPO_IMAGE_PROVIDER_SESSION_ID: "oc-sandbox-1",
+    });
+  });
+
+  it("wakes hibernated sandboxes on resume", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    const result = await provider.resumeSandbox({
+      providerObjectId: "oc-sandbox-1",
+      sessionId: "session-1",
+      sandboxId: "sandbox-acme-repo-1",
+      codeServerEnabled: false,
+    });
+
+    expect(result).toMatchObject({ success: true, providerObjectId: "oc-sandbox-1" });
+    expect(client.getSandbox).toHaveBeenCalledWith("oc-sandbox-1");
+    expect(client.wakeSandbox).toHaveBeenCalledWith("oc-sandbox-1");
+    expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-sandbox-1", 600);
+    expect(client.startRuntime).toHaveBeenCalledWith("oc-sandbox-1");
+  });
+
+  it("hibernates sandboxes on stop", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await expect(
+      provider.stopSandbox({
+        providerObjectId: "oc-sandbox-1",
+        sessionId: "session-1",
+        reason: "inactivity_timeout",
+      })
+    ).resolves.toEqual({ success: true });
+
+    expect(client.hibernateSandbox).toHaveBeenCalledWith("oc-sandbox-1");
+  });
+});

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -1,0 +1,657 @@
+/**
+ * OpenComputer sandbox provider.
+ *
+ * Uses an OpenComputer declarative template that already contains the
+ * OpenInspect sandbox runtime. Resume maps to wake; idle hibernation is left
+ * to OpenComputer rather than being driven by OpenInspect's lifecycle manager.
+ */
+
+import {
+  computeHmacHex,
+  DEFAULT_BUILD_TIMEOUT_SECONDS,
+  type SandboxSettings,
+} from "@open-inspect/shared";
+import { resolveServicePorts, resolveTunnelPorts } from "./port-resolution";
+import { createLogger } from "../../logger";
+import type { SourceControlProviderName } from "../../source-control";
+import {
+  OPENCOMPUTER_CHECKPOINT_KIND,
+  OPENCOMPUTER_CHECKPOINT_RETENTION_POLICY,
+  OpenComputerApiError,
+  OpenComputerNotFoundError,
+  type OpenComputerRestClient,
+  type OpenComputerSandboxResponse,
+  type OpenComputerSecretStoreResponse,
+} from "../opencomputer-rest-client";
+import { buildSessionConfig } from "../sandbox-env";
+import {
+  SandboxProviderError,
+  type CreateSandboxConfig,
+  type CreateSandboxResult,
+  type ResumeConfig,
+  type ResumeResult,
+  type RestoreConfig,
+  type RestoreResult,
+  type SandboxProvider,
+  type SandboxProviderCapabilities,
+  type SnapshotConfig,
+  type SnapshotResult,
+  type StopConfig,
+  type StopResult,
+} from "../provider";
+
+const log = createLogger("opencomputer-provider");
+const OPENCOMPUTER_SECRET_STORE_EGRESS_ALLOWLIST = ["*"];
+const OPENCOMPUTER_PROVIDER_TIMEOUT_FALLBACK_SECONDS = 10 * 60;
+const REPO_IMAGE_CALLBACK_ENV_KEYS = [
+  "OI_REPO_IMAGE_PROVIDER_SESSION_ID",
+  "OI_REPO_IMAGE_BUILD_ID",
+  "OI_REPO_IMAGE_CALLBACK_URL",
+  "OI_REPO_IMAGE_CALLBACK_TOKEN",
+] as const;
+
+export interface TriggerOpenComputerRepoImageBuildConfig {
+  buildId: string;
+  repoOwner: string;
+  repoName: string;
+  defaultBranch: string;
+  callbackUrl: string;
+  callbackToken: string;
+  userEnvVars?: Record<string, string>;
+  buildTimeoutSeconds?: number;
+  onProviderSessionCreated?: (providerSessionId: string) => Promise<void>;
+}
+
+export interface TriggerOpenComputerRepoImageBuildResult {
+  buildId: string;
+  status: string;
+}
+
+export interface OpenComputerProviderConfig {
+  scmProvider: SourceControlProviderName;
+  /** Secret used for deterministic code-server password derivation */
+  codeServerPasswordSecret: string;
+  /** Provider-level LLM credentials to expose to the sandbox runtime. */
+  llmEnvVars?: Record<string, string | undefined>;
+}
+
+export class OpenComputerSandboxProvider implements SandboxProvider {
+  readonly name = "opencomputer";
+
+  readonly capabilities: SandboxProviderCapabilities = {
+    supportsSnapshots: true,
+    supportsRestore: true,
+    supportsWarm: false,
+    supportsPersistentResume: true,
+    supportsExplicitStop: true,
+  };
+
+  constructor(
+    private readonly client: OpenComputerRestClient,
+    private readonly providerConfig: OpenComputerProviderConfig
+  ) {}
+
+  async createSandbox(config: CreateSandboxConfig): Promise<CreateSandboxResult> {
+    let secretStore: OpenComputerSecretStoreResponse | undefined;
+    let providerObjectId: string | undefined;
+    try {
+      const envVars = await this.buildRuntimeEnvVars(config, {
+        fromRepoImage: !!config.repoImageId,
+        repoImageSha: config.repoImageSha ?? undefined,
+      });
+      secretStore = await this.createSecretStoreFor(config.sessionId, config.userEnvVars);
+      const labels = this.buildLabels(config);
+      const timeoutSeconds = resolveOpenComputerTimeoutSeconds(config.timeoutSeconds);
+      const sandbox = config.repoImageId
+        ? await this.client.forkFromCheckpoint({
+            checkpointId: config.repoImageId,
+            name: config.sandboxId,
+            env: envVars,
+            labels,
+            timeoutSeconds,
+            secretStore: secretStore?.name,
+          })
+        : await this.client.createSandbox({
+            name: config.sandboxId,
+            template: this.client.config.template,
+            env: envVars,
+            labels,
+            timeoutSeconds,
+            secretStore: secretStore?.name,
+            projectId: this.client.config.projectId,
+            target: this.client.config.target,
+          });
+      providerObjectId = sandbox.id;
+      await this.client.setSandboxTimeout(providerObjectId, timeoutSeconds);
+      await this.client.startRuntime(providerObjectId);
+      const tunnels = await this.buildTunnelUrls(
+        providerObjectId,
+        config.sandboxId,
+        config.codeServerEnabled,
+        config.sandboxSettings,
+        sandbox
+      );
+
+      return {
+        sandboxId: config.sandboxId,
+        providerObjectId,
+        status: sandbox.state ?? sandbox.status ?? "created",
+        createdAt: Date.now(),
+        codeServerUrl: tunnels.codeServerUrl,
+        codeServerPassword: tunnels.codeServerPassword,
+        tunnelUrls: tunnels.tunnelUrls,
+      };
+    } catch (error) {
+      if (providerObjectId) {
+        await this.cleanupSandboxAfterFailedCreate(providerObjectId, config.sessionId);
+      }
+      if (secretStore) {
+        try {
+          await this.client.deleteSecretStore(secretStore.id);
+        } catch (cleanupError) {
+          log.warn("opencomputer.secret_store_cleanup_failed", {
+            session_id: config.sessionId,
+            secret_store_id: secretStore.id,
+            error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+          });
+        }
+      }
+      throw this.classifyError("Failed to create OpenComputer sandbox", error);
+    }
+  }
+
+  async restoreFromSnapshot(config: RestoreConfig): Promise<RestoreResult> {
+    let secretStore: OpenComputerSecretStoreResponse | undefined;
+    let providerObjectId: string | undefined;
+    try {
+      const envVars = await this.buildRuntimeEnvVars(config, { restoredFromSnapshot: true });
+      secretStore = await this.createSecretStoreFor(config.sessionId, config.userEnvVars);
+      const sandbox = await this.client.forkFromCheckpoint({
+        checkpointId: config.snapshotImageId,
+        name: config.sandboxId,
+        env: envVars,
+        labels: this.buildLabels(config),
+        timeoutSeconds: resolveOpenComputerTimeoutSeconds(config.timeoutSeconds),
+        secretStore: secretStore?.name,
+      });
+      providerObjectId = sandbox.id;
+      await this.client.setSandboxTimeout(
+        providerObjectId,
+        resolveOpenComputerTimeoutSeconds(config.timeoutSeconds)
+      );
+      await this.client.startRuntime(providerObjectId);
+      const tunnels = await this.buildTunnelUrls(
+        providerObjectId,
+        config.sandboxId,
+        config.codeServerEnabled,
+        config.sandboxSettings,
+        sandbox
+      );
+
+      return {
+        success: true,
+        sandboxId: config.sandboxId,
+        providerObjectId,
+        codeServerUrl: tunnels.codeServerUrl,
+        codeServerPassword: tunnels.codeServerPassword,
+        tunnelUrls: tunnels.tunnelUrls,
+      };
+    } catch (error) {
+      if (providerObjectId) {
+        await this.cleanupSandboxAfterFailedCreate(providerObjectId, config.sessionId);
+      }
+      if (secretStore) {
+        try {
+          await this.client.deleteSecretStore(secretStore.id);
+        } catch (cleanupError) {
+          log.warn("opencomputer.secret_store_cleanup_failed", {
+            session_id: config.sessionId,
+            secret_store_id: secretStore.id,
+            error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+          });
+        }
+      }
+      if (error instanceof SandboxProviderError) throw error;
+      throw this.classifyError("Failed to restore OpenComputer sandbox from checkpoint", error);
+    }
+  }
+
+  async takeSnapshot(config: SnapshotConfig): Promise<SnapshotResult> {
+    try {
+      const checkpoint = await this.client.createCheckpoint(
+        config.providerObjectId,
+        this.buildCheckpointName(config.sessionId, config.reason),
+        {
+          kind: OPENCOMPUTER_CHECKPOINT_KIND,
+          retentionPolicy: OPENCOMPUTER_CHECKPOINT_RETENTION_POLICY,
+        }
+      );
+
+      if (
+        checkpoint.status &&
+        checkpoint.status !== "ready" &&
+        checkpoint.status !== "created" &&
+        checkpoint.status !== "processing"
+      ) {
+        return { success: false, error: `Checkpoint status was ${checkpoint.status}` };
+      }
+
+      return { success: true, imageId: checkpoint.id };
+    } catch (error) {
+      if (error instanceof SandboxProviderError) throw error;
+      throw this.classifyError("Failed to checkpoint OpenComputer sandbox", error);
+    }
+  }
+
+  async resumeSandbox(config: ResumeConfig): Promise<ResumeResult> {
+    try {
+      let sandbox: OpenComputerSandboxResponse;
+      try {
+        sandbox = await this.client.getSandbox(config.providerObjectId);
+      } catch (error) {
+        if (error instanceof OpenComputerNotFoundError) {
+          return {
+            success: false,
+            error: "Sandbox no longer exists in OpenComputer",
+            shouldSpawnFresh: true,
+          };
+        }
+        throw error;
+      }
+
+      const state = (sandbox.state ?? sandbox.status ?? "").toLowerCase();
+      let wokeSandbox = false;
+      if (state !== "running" && state !== "started" && state !== "ready") {
+        const wakeResult = await this.client.wakeSandbox(config.providerObjectId);
+        if (wakeResult && typeof wakeResult === "object") sandbox = wakeResult;
+        wokeSandbox = true;
+      }
+
+      if (wokeSandbox) {
+        await this.client.setSandboxTimeout(
+          config.providerObjectId,
+          resolveOpenComputerTimeoutSeconds(config.timeoutSeconds)
+        );
+        await this.client.startRuntime(config.providerObjectId);
+      }
+
+      let codeServerUrl: string | undefined;
+      let codeServerPassword: string | undefined;
+      let tunnelUrls: Record<string, string> | undefined;
+      try {
+        const tunnels = await this.buildTunnelUrls(
+          config.providerObjectId,
+          config.sandboxId,
+          config.codeServerEnabled,
+          config.sandboxSettings,
+          sandbox
+        );
+        codeServerUrl = tunnels.codeServerUrl;
+        codeServerPassword = tunnels.codeServerPassword;
+        tunnelUrls = tunnels.tunnelUrls;
+      } catch (error) {
+        log.warn("opencomputer.resume_tunnel_urls_failed", {
+          sandbox_id: config.sandboxId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+
+      return {
+        success: true,
+        providerObjectId: sandbox.id || config.providerObjectId,
+        codeServerUrl,
+        codeServerPassword,
+        tunnelUrls,
+      };
+    } catch (error) {
+      if (error instanceof SandboxProviderError) throw error;
+      throw this.classifyError("Failed to resume OpenComputer sandbox", error);
+    }
+  }
+
+  async stopSandbox(config: StopConfig): Promise<StopResult> {
+    try {
+      try {
+        await this.client.hibernateSandbox(config.providerObjectId);
+      } catch (error) {
+        if (error instanceof OpenComputerNotFoundError) return { success: true };
+        throw error;
+      }
+      return { success: true };
+    } catch (error) {
+      if (error instanceof SandboxProviderError) throw error;
+      throw this.classifyError("Failed to hibernate OpenComputer sandbox", error);
+    }
+  }
+
+  async triggerRepoImageBuild(
+    config: TriggerOpenComputerRepoImageBuildConfig
+  ): Promise<TriggerOpenComputerRepoImageBuildResult> {
+    let secretStore: OpenComputerSecretStoreResponse | undefined;
+    try {
+      const sandboxName = `build-${config.repoOwner}-${config.repoName}-${Date.now()}`;
+      const envVars = await this.buildBuildEnvVars(config);
+      secretStore = await this.createSecretStoreFor(config.buildId, config.userEnvVars);
+      const sandbox = await this.client.createSandbox({
+        name: sandboxName,
+        template: this.client.config.template,
+        env: envVars,
+        labels: {
+          openinspect_framework: "open-inspect",
+          openinspect_provider: "opencomputer",
+          openinspect_kind: "repo-image-build",
+          openinspect_build_id: config.buildId,
+          openinspect_repo: `${config.repoOwner}/${config.repoName}`,
+        },
+        timeoutSeconds: config.buildTimeoutSeconds ?? DEFAULT_BUILD_TIMEOUT_SECONDS,
+        secretStore: secretStore?.name,
+        projectId: this.client.config.projectId,
+        target: this.client.config.target,
+      });
+
+      if (config.onProviderSessionCreated) {
+        await config.onProviderSessionCreated(sandbox.id);
+      }
+
+      await this.client.startRuntime(sandbox.id, {
+        [REPO_IMAGE_CALLBACK_ENV_KEYS[0]]: sandbox.id,
+      });
+      log.info("opencomputer.repo_image_build_triggered", {
+        build_id: config.buildId,
+        repo_owner: config.repoOwner,
+        repo_name: config.repoName,
+        sandbox_id: sandbox.id,
+      });
+
+      return { buildId: config.buildId, status: "building" };
+    } catch (error) {
+      if (secretStore) {
+        try {
+          await this.client.deleteSecretStore(secretStore.id);
+        } catch (cleanupError) {
+          log.warn("opencomputer.secret_store_cleanup_failed", {
+            build_id: config.buildId,
+            secret_store_id: secretStore.id,
+            error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+          });
+        }
+      }
+      if (error instanceof SandboxProviderError) throw error;
+      throw this.classifyError("Failed to trigger OpenComputer repo image build", error);
+    }
+  }
+
+  async deleteProviderImage(
+    providerImageId: string,
+    providerSessionId?: string | null
+  ): Promise<void> {
+    if (!providerSessionId) return;
+    try {
+      await this.client.deleteCheckpoint(providerSessionId, providerImageId);
+    } catch (error) {
+      if (error instanceof OpenComputerNotFoundError) return;
+      throw this.classifyError("Failed to delete OpenComputer checkpoint", error);
+    }
+  }
+
+  private async buildRuntimeEnvVars(
+    config: CreateSandboxConfig | RestoreConfig,
+    mode: {
+      restoredFromSnapshot?: boolean;
+      fromRepoImage?: boolean;
+      repoImageSha?: string;
+    } = {}
+  ): Promise<Record<string, string>> {
+    const envVars: Record<string, string> = {};
+    const sessionConfig = buildSessionConfig(config);
+
+    for (const [name, value] of Object.entries(config.userEnvVars ?? {})) {
+      if (value) envVars[name] = value;
+    }
+    for (const [name, value] of Object.entries(this.providerConfig.llmEnvVars ?? {})) {
+      if (value) envVars[name] = value;
+    }
+
+    Object.assign(envVars, {
+      PYTHONUNBUFFERED: "1",
+      SANDBOX_ID: config.sandboxId,
+      CONTROL_PLANE_URL: config.controlPlaneUrl,
+      SANDBOX_AUTH_TOKEN: config.sandboxAuthToken,
+      REPO_OWNER: config.repoOwner,
+      REPO_NAME: config.repoName,
+      SESSION_CONFIG: JSON.stringify(sessionConfig),
+    });
+
+    if (config.codeServerEnabled) {
+      envVars.CODE_SERVER_PASSWORD = await this.deriveCodeServerPassword(config.sandboxId);
+      envVars.CODE_SERVER_PORT = String(resolveServicePorts(config.sandboxSettings).codeServerPort);
+    }
+
+    if (config.agentSlackNotifyEnabled) {
+      envVars.AGENT_SLACK_NOTIFY_ENABLED = "true";
+    }
+    if (mode.restoredFromSnapshot) envVars.RESTORED_FROM_SNAPSHOT = "true";
+    if (mode.fromRepoImage) {
+      envVars.FROM_REPO_IMAGE = "true";
+      envVars.REPO_IMAGE_SHA = mode.repoImageSha ?? "";
+    }
+
+    if (this.providerConfig.scmProvider === "gitlab") {
+      envVars.VCS_HOST = "gitlab.com";
+      envVars.VCS_CLONE_USERNAME = "oauth2";
+    } else {
+      envVars.VCS_HOST = "github.com";
+      envVars.VCS_CLONE_USERNAME = "x-access-token";
+    }
+
+    return envVars;
+  }
+
+  private async buildBuildEnvVars(
+    config: TriggerOpenComputerRepoImageBuildConfig
+  ): Promise<Record<string, string>> {
+    const envVars: Record<string, string> = {};
+
+    for (const [name, value] of Object.entries(config.userEnvVars ?? {})) {
+      if (value) envVars[name] = value;
+    }
+    for (const [name, value] of Object.entries(this.providerConfig.llmEnvVars ?? {})) {
+      if (value) envVars[name] = value;
+    }
+
+    Object.assign(envVars, {
+      PYTHONUNBUFFERED: "1",
+      SANDBOX_ID: `build-${config.repoOwner}-${config.repoName}`,
+      REPO_OWNER: config.repoOwner,
+      REPO_NAME: config.repoName,
+      IMAGE_BUILD_MODE: "true",
+      SESSION_CONFIG: JSON.stringify({ branch: config.defaultBranch }),
+      [REPO_IMAGE_CALLBACK_ENV_KEYS[1]]: config.buildId,
+      [REPO_IMAGE_CALLBACK_ENV_KEYS[2]]: config.callbackUrl,
+      [REPO_IMAGE_CALLBACK_ENV_KEYS[3]]: config.callbackToken,
+    });
+
+    if (this.providerConfig.scmProvider === "gitlab") {
+      envVars.VCS_HOST = "gitlab.com";
+      envVars.VCS_CLONE_USERNAME = "oauth2";
+    } else {
+      envVars.VCS_HOST = "github.com";
+      envVars.VCS_CLONE_USERNAME = "x-access-token";
+    }
+
+    return envVars;
+  }
+
+  private async createSecretStoreFor(
+    id: string,
+    userEnvVars: Record<string, string> = {}
+  ): Promise<OpenComputerSecretStoreResponse> {
+    const entries = Object.entries(userEnvVars).filter(([, value]) => value.length > 0);
+
+    const store = await this.client.createSecretStore({
+      name: this.buildSecretStoreName(id),
+      egressAllowlist: OPENCOMPUTER_SECRET_STORE_EGRESS_ALLOWLIST,
+    });
+
+    try {
+      await Promise.all(
+        entries.map(([name, value]) =>
+          this.client.setSecret({
+            storeId: store.id,
+            name,
+            value,
+            allowedHosts: this.allowedHostsForSecret(name),
+          })
+        )
+      );
+      return store;
+    } catch (error) {
+      try {
+        await this.client.deleteSecretStore(store.id);
+      } catch (cleanupError) {
+        log.warn("opencomputer.secret_store_cleanup_failed", {
+          session_id: id,
+          secret_store_id: store.id,
+          error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+        });
+      }
+      throw error;
+    }
+  }
+
+  private buildSecretStoreName(sessionId: string): string {
+    return `openinspect-${sessionId.slice(0, 32)}`;
+  }
+
+  private buildCheckpointName(sessionId: string, reason: string): string {
+    const safeReason = reason.replace(/[^a-zA-Z0-9_-]/g, "-").slice(0, 40) || "snapshot";
+    return `openinspect-${sessionId.slice(0, 32)}-${safeReason}-${Date.now()}`;
+  }
+
+  private allowedHostsForSecret(name: string): string[] | undefined {
+    const normalized = name.toUpperCase();
+    if (normalized.includes("ANTHROPIC")) return ["api.anthropic.com"];
+    if (normalized.includes("OPENAI")) return ["api.openai.com"];
+    if (normalized.includes("GITHUB") || normalized.includes("VCS_CLONE")) {
+      return this.providerConfig.scmProvider === "gitlab"
+        ? ["gitlab.com", "api.gitlab.com"]
+        : ["github.com", "api.github.com"];
+    }
+    return undefined;
+  }
+
+  private async cleanupSandboxAfterFailedCreate(
+    providerObjectId: string,
+    sessionId: string
+  ): Promise<void> {
+    try {
+      await this.client.deleteSandbox(providerObjectId);
+    } catch (cleanupError) {
+      log.warn("opencomputer.sandbox_cleanup_failed", {
+        session_id: sessionId,
+        provider_object_id: providerObjectId,
+        error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+      });
+    }
+  }
+
+  private buildLabels(config: CreateSandboxConfig | RestoreConfig): Record<string, string> {
+    return {
+      openinspect_framework: "open-inspect",
+      openinspect_provider: "opencomputer",
+      openinspect_session_id: config.sessionId,
+      openinspect_repo: `${config.repoOwner}/${config.repoName}`,
+      openinspect_expected_sandbox_id: config.sandboxId,
+    };
+  }
+
+  private async buildTunnelUrls(
+    providerObjectId: string,
+    logicalSandboxId: string,
+    codeServerEnabled: boolean | undefined,
+    sandboxSettings: SandboxSettings | undefined,
+    sandbox?: OpenComputerSandboxResponse
+  ): Promise<{
+    codeServerUrl?: string;
+    codeServerPassword?: string;
+    tunnelUrls?: Record<string, string>;
+  }> {
+    const routeUrls = this.routeUrlsFromSandbox(sandbox);
+    const { codeServerPort } = resolveServicePorts(sandboxSettings);
+    let tunnelPorts = resolveTunnelPorts(sandboxSettings?.tunnelPorts);
+    let codeServerUrl: string | undefined;
+    let codeServerPassword: string | undefined;
+
+    if (codeServerEnabled) {
+      codeServerUrl =
+        routeUrls[String(codeServerPort)] ??
+        (await this.client.getTunnelUrl(providerObjectId, codeServerPort)).url;
+      codeServerPassword = await this.deriveCodeServerPassword(logicalSandboxId);
+      tunnelPorts = tunnelPorts.filter((port) => port !== codeServerPort);
+    }
+
+    let tunnelUrls: Record<string, string> | undefined;
+    if (tunnelPorts.length > 0) {
+      const entries = await Promise.all(
+        tunnelPorts.map(async (port) => {
+          const url =
+            routeUrls[String(port)] ?? (await this.client.getTunnelUrl(providerObjectId, port)).url;
+          return [String(port), url] as const;
+        })
+      );
+      tunnelUrls = Object.fromEntries(entries);
+    }
+
+    return { codeServerUrl, codeServerPassword, tunnelUrls };
+  }
+
+  private routeUrlsFromSandbox(sandbox?: OpenComputerSandboxResponse): Record<string, string> {
+    if (!sandbox) return {};
+    if (sandbox.tunnelUrls) return sandbox.tunnelUrls;
+    if (sandbox.sandboxDomain) {
+      const sandboxId = sandbox.id || sandbox.sandboxID;
+      if (!sandboxId) return {};
+      return new Proxy<Record<string, string>>(
+        {},
+        {
+          get: (_target, property) =>
+            typeof property === "string"
+              ? `https://${sandboxId}-p${property}.${sandbox.sandboxDomain}`
+              : undefined,
+        }
+      );
+    }
+    if (!sandbox.routes) return {};
+    return Object.fromEntries(sandbox.routes.map((route) => [String(route.port), route.url]));
+  }
+
+  private async deriveCodeServerPassword(sandboxId: string): Promise<string> {
+    const digest = await computeHmacHex(
+      `code-server:${sandboxId}`,
+      this.providerConfig.codeServerPasswordSecret
+    );
+    return digest.slice(0, 32);
+  }
+
+  private classifyError(message: string, error: unknown): SandboxProviderError {
+    if (error instanceof OpenComputerApiError) {
+      return SandboxProviderError.fromFetchError(
+        `${message}: ${error.message}`,
+        error,
+        error.status
+      );
+    }
+    return SandboxProviderError.fromFetchError(message, error);
+  }
+}
+
+function resolveOpenComputerTimeoutSeconds(timeoutSeconds: number | undefined): number {
+  return timeoutSeconds ?? OPENCOMPUTER_PROVIDER_TIMEOUT_FALLBACK_SECONDS;
+}
+
+export function createOpenComputerProvider(
+  client: OpenComputerRestClient,
+  providerConfig: OpenComputerProviderConfig
+): OpenComputerSandboxProvider {
+  return new OpenComputerSandboxProvider(client, providerConfig);
+}

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -21,9 +21,11 @@ import {
 import { generateId, hashToken, encryptToken, decryptToken } from "../auth/crypto";
 import { buildModalSandboxDashboardUrl, createModalClient } from "../sandbox/client";
 import { createDaytonaRestClient } from "../sandbox/daytona-rest-client";
+import { createOpenComputerRestClient } from "../sandbox/opencomputer-rest-client";
 import { createVercelSandboxClient } from "../sandbox/providers/vercel/client";
 import { createModalProvider } from "../sandbox/providers/modal-provider";
 import { createDaytonaProvider } from "../sandbox/providers/daytona-provider";
+import { createOpenComputerProvider } from "../sandbox/providers/opencomputer-provider";
 import { createVercelProvider } from "../sandbox/providers/vercel/provider";
 import { resolveSandboxBackendName, supportsRepoImageBackend } from "../sandbox/provider-name";
 import { createLogger, parseLogLevel } from "../logger";
@@ -45,6 +47,7 @@ import { McpServerStore } from "../db/mcp-servers";
 import { IntegrationSettingsStore, resolveSlackSettings } from "../db/integration-settings";
 import { SessionIndexStore } from "../db/session-index";
 import { DEFAULT_EXECUTION_TIMEOUT_MS } from "../sandbox/lifecycle/decisions";
+import type { RepoImageProvider } from "../db/repo-images";
 import {
   createSourceControlProviderFromEnv,
   resolveScmProviderFromEnv,
@@ -640,6 +643,34 @@ export class SessionDO extends DurableObject<Env> {
         });
       }
 
+      if (sandboxBackend === "opencomputer") {
+        if (
+          !this.env.OPENCOMPUTER_API_URL ||
+          !this.env.OPENCOMPUTER_API_KEY ||
+          !this.env.OPENCOMPUTER_TEMPLATE
+        ) {
+          throw new Error(
+            "OPENCOMPUTER_API_URL, OPENCOMPUTER_API_KEY, and OPENCOMPUTER_TEMPLATE are required when SANDBOX_PROVIDER=opencomputer"
+          );
+        }
+
+        const openComputerClient = createOpenComputerRestClient({
+          apiUrl: this.env.OPENCOMPUTER_API_URL,
+          apiKey: this.env.OPENCOMPUTER_API_KEY,
+          template: this.env.OPENCOMPUTER_TEMPLATE,
+          projectId: this.env.OPENCOMPUTER_PROJECT_ID,
+          target: this.env.OPENCOMPUTER_TARGET,
+        });
+
+        return createOpenComputerProvider(openComputerClient, {
+          scmProvider: resolveScmProviderFromEnv(this.env.SCM_PROVIDER),
+          codeServerPasswordSecret: this.env.OPENCOMPUTER_API_KEY,
+          llmEnvVars: {
+            ANTHROPIC_API_KEY: this.env.ANTHROPIC_API_KEY,
+          },
+        });
+      }
+
       if (!this.env.MODAL_API_SECRET || !this.env.MODAL_WORKSPACE) {
         throw new Error(
           "MODAL_API_SECRET and MODAL_WORKSPACE are required when SANDBOX_PROVIDER=modal"
@@ -786,7 +817,7 @@ export class SessionDO extends DurableObject<Env> {
     let repoImageLookup: RepoImageLookup | undefined;
     if (this.env.DB && supportsRepoImageBackend(sandboxBackend)) {
       const repoImageStore = new RepoImageStore(this.env.DB);
-      const repoImageProvider = sandboxBackend === "vercel" ? "vercel" : "modal";
+      const repoImageProvider = sandboxBackend as RepoImageProvider;
       repoImageLookup = {
         getLatestReady: (repoOwner, repoName, baseBranch) =>
           repoImageStore.getLatestReady(repoOwner, repoName, repoImageProvider, baseBranch),

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -61,7 +61,9 @@ export interface Env {
   MODAL_TOKEN_ID?: string;
   MODAL_TOKEN_SECRET?: string;
   MODAL_API_SECRET?: string; // Shared secret for authenticating with Modal endpoints
+  ANTHROPIC_API_KEY?: string; // Anthropic API key for Claude models
   DAYTONA_API_KEY?: string; // Daytona REST API key (Bearer auth + HMAC derivation)
+  OPENCOMPUTER_API_KEY?: string; // OpenComputer REST API key (X-API-Key auth + HMAC derivation)
   VERCEL_TOKEN?: string; // Vercel API access token for Sandbox API
   INTERNAL_CALLBACK_SECRET?: string; // For signing callbacks to slack-bot
   SLACK_BOT_TOKEN?: string; // Slack bot token for agent-initiated chat.postMessage calls
@@ -82,7 +84,7 @@ export interface Env {
   WORKER_URL?: string; // Base URL for the worker (for callbacks)
   WEB_APP_URL?: string; // Base URL for the web app (for PR links)
   CF_ACCOUNT_ID?: string; // Cloudflare account ID
-  SANDBOX_PROVIDER?: string; // "modal" (default), "daytona", or "vercel"
+  SANDBOX_PROVIDER?: string; // "modal" (default), "daytona", "vercel", or "opencomputer"
   MODAL_WORKSPACE?: string; // Modal workspace name
   MODAL_ENVIRONMENT?: string; // Modal environment name for dashboard URLs
   MODAL_ENVIRONMENT_WEB_SUFFIX?: string; // Modal environment web suffix for endpoint URLs
@@ -91,6 +93,10 @@ export interface Env {
   DAYTONA_AUTO_STOP_INTERVAL_MINUTES?: string; // Daytona idle stop interval in minutes
   DAYTONA_AUTO_ARCHIVE_INTERVAL_MINUTES?: string; // Daytona archive interval in minutes
   DAYTONA_TARGET?: string; // Optional Daytona target name
+  OPENCOMPUTER_API_URL?: string; // OpenComputer REST API base URL
+  OPENCOMPUTER_TEMPLATE?: string; // Declarative template containing sandbox runtime
+  OPENCOMPUTER_PROJECT_ID?: string; // Optional OpenComputer project/workspace scope
+  OPENCOMPUTER_TARGET?: string; // Optional OpenComputer target/region/cell
   VERCEL_PROJECT_ID?: string; // Vercel project ID used for Sandbox API scope
   VERCEL_TEAM_ID?: string; // Optional Vercel team ID used for Sandbox API scope
   VERCEL_BASE_SNAPSHOT_ID?: string; // Optional prebuilt base snapshot with sandbox runtime

--- a/packages/opencomputer-infra/package.json
+++ b/packages/opencomputer-infra/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@open-inspect/opencomputer-infra",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "esbuild src/build-template.ts --bundle --format=esm --platform=node --target=node22 --outfile=dist/build-template.js --packages=external",
+    "build-template": "npm run build && npm run build-template:run --",
+    "build-template:run": "node dist/build-template.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@opencomputer/sdk": "^0.9.1",
+    "esbuild": "^0.28.1",
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/opencomputer-infra/src/build-template.ts
+++ b/packages/opencomputer-infra/src/build-template.ts
@@ -6,11 +6,15 @@ import { Image, Snapshots } from "@opencomputer/sdk/node";
 const OPENCODE_VERSION = "1.14.41";
 const CODE_SERVER_VERSION = "4.109.5";
 const PYTHON_VERSION = "3.12";
+const AGENT_BROWSER_VERSION = "0.21.2";
+const TTYD_VERSION = "1.7.7";
+const TTYD_SHA256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55";
 const SANDBOX_HOME = "/home/sandbox";
 const SANDBOX_APP_DIR = `${SANDBOX_HOME}/app`;
 const NPM_PREFIX = `${SANDBOX_HOME}/.npm-global`;
 const NPM_CACHE = `${SANDBOX_HOME}/.npm-cache`;
 const USER_BIN = `${SANDBOX_HOME}/.local/bin`;
+const BUN_INSTALL_DIR = `${SANDBOX_HOME}/.bun`;
 const PYTHON_VENV = `${SANDBOX_HOME}/.venv`;
 const UV_CACHE = `${SANDBOX_HOME}/.cache/uv`;
 const UV_PYTHON_INSTALL_DIR = `${SANDBOX_HOME}/.local/share/uv/python`;
@@ -148,7 +152,24 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
       `ln -sf ${PYTHON_VENV}/bin/python ${USER_BIN}/python`,
       `HOME=${SANDBOX_HOME} UV_CACHE_DIR=${UV_CACHE} uv pip install --python ${PYTHON_VENV}/bin/python httpx websockets "pydantic>=2.0" "PyJWT[crypto]"`,
       `sudo rm -rf /app && sudo ln -s ${SANDBOX_APP_DIR} /app`,
-      `sudo env npm_config_cache=${NPM_CACHE} npm install -g --prefix ${NPM_PREFIX} pnpm@10 opencode-ai@${OPENCODE_VERSION} @opencode-ai/plugin@${OPENCODE_VERSION} zod@4.4.3`
+      `sudo env npm_config_cache=${NPM_CACHE} npm install -g --prefix ${NPM_PREFIX} pnpm@10 opencode-ai@${OPENCODE_VERSION} @opencode-ai/plugin@${OPENCODE_VERSION} zod@4.4.3 agent-browser@${AGENT_BROWSER_VERSION}`
+    )
+    .runCommands(
+      // GitHub CLI — installed to /usr/bin/gh (the path the runtime's gh wrapper expects).
+      "sudo mkdir -p -m 755 /etc/apt/keyrings",
+      "curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null",
+      "sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg",
+      'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null',
+      "sudo apt-get update && sudo apt-get install -y gh || true",
+      // ttyd (terminal) — pinned binary, checksum-verified (matches the Vercel base image).
+      `curl -fsSL -o /tmp/ttyd https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.x86_64`,
+      `echo "${TTYD_SHA256}  /tmp/ttyd" | sha256sum -c -`,
+      "sudo mv /tmp/ttyd /usr/local/bin/ttyd",
+      "sudo chmod 0755 /usr/local/bin/ttyd",
+      // bun — used by agent-browser and some opencode tooling.
+      `curl -fsSL https://bun.sh/install | sudo env BUN_INSTALL=${BUN_INSTALL_DIR} bash || true`,
+      // agent-browser Chromium download (best-effort; the shared libs are installed via aptInstall above).
+      `sudo env HOME=${SANDBOX_HOME} PATH=${NPM_PREFIX}/bin:${BUN_INSTALL_DIR}/bin:${USER_BIN}:/usr/local/bin:/usr/bin:/bin agent-browser install || true`
     )
     .runCommands(
       `curl -fsSL -o /tmp/code-server.deb https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/code-server_${CODE_SERVER_VERSION}_amd64.deb`,
@@ -169,6 +190,11 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
       "sudo git config --system credential.useHttpPath true",
       `[ -f ${OPENSANDBOX_PROXY_CA} ] && sudo update-ca-certificates || true`,
       `[ -f ${OPENSANDBOX_PROXY_CA} ] && sudo git config --system http.sslCAInfo ${OPENSANDBOX_PROXY_CA} || true`
+    )
+    .runCommands(
+      // The npm/bun/agent-browser steps above run as root (sudo) and write under the sandbox
+      // user's HOME. Re-own HOME so the non-root runtime can read/write those caches.
+      `sudo chown -R sandbox:sandbox ${SANDBOX_HOME} || true`
     );
 
   image = addRuntimeDir(image, runtimeDir);
@@ -184,7 +210,7 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
       UV_PYTHON_INSTALL_DIR,
       VIRTUAL_ENV: PYTHON_VENV,
       PNPM_HOME: `${SANDBOX_HOME}/.local/share/pnpm`,
-      PATH: `${PYTHON_VENV}/bin:${NPM_PREFIX}/bin:${USER_BIN}:${SANDBOX_HOME}/.local/share/pnpm:/usr/local/bin:/usr/bin:/bin`,
+      PATH: `${PYTHON_VENV}/bin:${NPM_PREFIX}/bin:${USER_BIN}:${BUN_INSTALL_DIR}/bin:${SANDBOX_HOME}/.local/share/pnpm:/usr/local/bin:/usr/bin:/bin`,
       PYTHONPATH: "/app",
       NODE_PATH: `${NPM_PREFIX}/lib/node_modules:/usr/lib/node_modules`,
       SSL_CERT_FILE: SYSTEM_CA_BUNDLE,
@@ -196,7 +222,7 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
       OPENINSPECT_BIN_INSTALL_DIR: USER_BIN,
       NO_PROXY: LOCAL_NO_PROXY,
       no_proxy: LOCAL_NO_PROXY,
-      SANDBOX_VERSION: "opencomputer-v1",
+      SANDBOX_VERSION: "opencomputer-v2",
     })
     .workdir(`${SANDBOX_HOME}/workspace`)
     .builderMemory(options.builderMemoryMb);

--- a/packages/opencomputer-infra/src/build-template.ts
+++ b/packages/opencomputer-infra/src/build-template.ts
@@ -1,0 +1,232 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { Image, Snapshots } from "@opencomputer/sdk/node";
+
+const OPENCODE_VERSION = "1.14.41";
+const CODE_SERVER_VERSION = "4.109.5";
+const PYTHON_VERSION = "3.12";
+const SANDBOX_HOME = "/home/sandbox";
+const SANDBOX_APP_DIR = `${SANDBOX_HOME}/app`;
+const NPM_PREFIX = `${SANDBOX_HOME}/.npm-global`;
+const NPM_CACHE = `${SANDBOX_HOME}/.npm-cache`;
+const USER_BIN = `${SANDBOX_HOME}/.local/bin`;
+const PYTHON_VENV = `${SANDBOX_HOME}/.venv`;
+const UV_CACHE = `${SANDBOX_HOME}/.cache/uv`;
+const UV_PYTHON_INSTALL_DIR = `${SANDBOX_HOME}/.local/share/uv/python`;
+const SYSTEM_CA_BUNDLE = "/etc/ssl/certs/ca-certificates.crt";
+const OPENSANDBOX_PROXY_CA = "/usr/local/share/ca-certificates/opensandbox-proxy.crt";
+const LOCAL_NO_PROXY = "localhost,127.0.0.1,::1";
+const HOSTS_BOOTSTRAP =
+  "grep -Eq '^[[:space:]]*127\\.0\\.0\\.1[[:space:]].*\\blocalhost\\b' /etc/hosts || " +
+  "printf '%s\\n' '127.0.0.1 localhost' | sudo tee -a /etc/hosts >/dev/null; " +
+  "grep -Eq '^[[:space:]]*::1[[:space:]].*\\blocalhost\\b' /etc/hosts || " +
+  "printf '%s\\n' '::1 localhost ip6-localhost ip6-loopback' | sudo tee -a /etc/hosts >/dev/null";
+const DNS_BOOTSTRAP =
+  "sudo rm -f /etc/resolv.conf; " +
+  "printf '%s\\n' 'nameserver 8.8.8.8' 'nameserver 1.1.1.1' | sudo tee /etc/resolv.conf >/dev/null";
+
+interface BuildOptions {
+  apiUrl: string;
+  apiKey: string;
+  snapshotName: string;
+  repoRoot: string;
+  builderMemoryMb: number;
+  dryRun: boolean;
+}
+
+async function main(): Promise<void> {
+  const options = resolveOptions(process.argv.slice(2));
+  const image = buildImage(options);
+
+  if (options.dryRun) {
+    console.log(JSON.stringify(image.toJSON(), null, 2));
+    console.log(`cacheKey=${image.cacheKey()}`);
+    return;
+  }
+
+  if (!options.apiKey) {
+    throw new Error("OPENCOMPUTER_API_KEY is required to build an OpenComputer snapshot");
+  }
+
+  console.log(`Building OpenComputer snapshot ${options.snapshotName}`);
+  console.log(`API: ${options.apiUrl}`);
+  console.log(`Runtime source: ${join(options.repoRoot, "packages/sandbox-runtime")}`);
+  console.log(`Image cache key: ${image.cacheKey()}`);
+
+  const snapshots = new Snapshots({
+    apiUrl: options.apiUrl,
+    apiKey: options.apiKey,
+  });
+  const result = await snapshots.create({
+    name: options.snapshotName,
+    image,
+    onBuildLogs: (log) => console.log(`build: ${log}`),
+  });
+  console.log(JSON.stringify(result, null, 2));
+}
+
+function resolveOptions(args: string[]): BuildOptions {
+  const flags = new Set(args);
+  const repoRoot = process.env.OPENINSPECT_REPO_ROOT || getRepoRoot();
+  const snapshotName = process.env.OPENCOMPUTER_TEMPLATE || "openinspect-runtime";
+  const builderMemoryMb = parsePositiveInt(process.env.OPENCOMPUTER_BUILDER_MEMORY_MB, 8192);
+
+  return {
+    apiUrl: normalizeApiUrl(process.env.OPENCOMPUTER_API_URL || "https://app.opencomputer.dev/api"),
+    apiKey: process.env.OPENCOMPUTER_API_KEY || "",
+    snapshotName,
+    repoRoot,
+    builderMemoryMb,
+    dryRun: flags.has("--dry-run") || flags.has("--print-manifest"),
+  };
+}
+
+function getRepoRoot(): string {
+  try {
+    return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+function normalizeApiUrl(value: string): string {
+  const base = value.replace(/\/+$/, "");
+  return base.endsWith("/api") ? base : `${base}/api`;
+}
+
+function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">): Image {
+  const runtimeDir = join(options.repoRoot, "packages/sandbox-runtime/src/sandbox_runtime");
+  if (!existsSync(runtimeDir)) {
+    throw new Error(`Missing sandbox runtime directory: ${runtimeDir}`);
+  }
+
+  let image = Image.base()
+    .aptInstall([
+      "bash",
+      "git",
+      "curl",
+      "build-essential",
+      "ca-certificates",
+      "gnupg",
+      "openssh-client",
+      "jq",
+      "unzip",
+      "libnss3",
+      "libnspr4",
+      "libatk1.0-0",
+      "libatk-bridge2.0-0",
+      "libcups2",
+      "libdrm2",
+      "libxkbcommon0",
+      "libxcomposite1",
+      "libxdamage1",
+      "libxfixes3",
+      "libxrandr2",
+      "libgbm1",
+      "libasound2",
+      "libpango-1.0-0",
+      "libcairo2",
+      "ffmpeg",
+      "procps",
+    ])
+    .pipInstall(["uv"])
+    .runCommands(
+      `mkdir -p ${SANDBOX_APP_DIR} ${NPM_PREFIX} ${NPM_CACHE} ${USER_BIN} ${SANDBOX_HOME}/.config ${SANDBOX_HOME}/workspace ${SANDBOX_HOME}/tmp/opencode`,
+      `HOME=${SANDBOX_HOME} UV_CACHE_DIR=${UV_CACHE} UV_PYTHON_INSTALL_DIR=${UV_PYTHON_INSTALL_DIR} uv python install ${PYTHON_VERSION}`,
+      `HOME=${SANDBOX_HOME} UV_CACHE_DIR=${UV_CACHE} UV_PYTHON_INSTALL_DIR=${UV_PYTHON_INSTALL_DIR} uv venv --python ${PYTHON_VERSION} ${PYTHON_VENV}`,
+      `ln -sf ${PYTHON_VENV}/bin/python ${USER_BIN}/python3`,
+      `ln -sf ${PYTHON_VENV}/bin/python ${USER_BIN}/python`,
+      `HOME=${SANDBOX_HOME} UV_CACHE_DIR=${UV_CACHE} uv pip install --python ${PYTHON_VENV}/bin/python httpx websockets "pydantic>=2.0" "PyJWT[crypto]"`,
+      `sudo rm -rf /app && sudo ln -s ${SANDBOX_APP_DIR} /app`,
+      `sudo env npm_config_cache=${NPM_CACHE} npm install -g --prefix ${NPM_PREFIX} pnpm@10 opencode-ai@${OPENCODE_VERSION} @opencode-ai/plugin@${OPENCODE_VERSION} zod@4.4.3`
+    )
+    .runCommands(
+      `curl -fsSL -o /tmp/code-server.deb https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/code-server_${CODE_SERVER_VERSION}_amd64.deb`,
+      "sudo dpkg -i /tmp/code-server.deb || (sudo apt-get update && sudo apt-get install -f -y)",
+      "rm -f /tmp/code-server.deb"
+    )
+    .runCommands(
+      `mkdir -p ${SANDBOX_APP_DIR}/opencode-deps ${SANDBOX_HOME}/workspace ${SANDBOX_HOME}/tmp/opencode`,
+      `printf '%s\\n' '{"name":"opencode-tools","type":"module","dependencies":{"@opencode-ai/plugin":"${OPENCODE_VERSION}"}}' | sudo tee /app/opencode-deps/package.json >/dev/null`,
+      `cd /app/opencode-deps && sudo env npm_config_cache=${NPM_CACHE} npm install --ignore-scripts --no-audit --no-fund`
+    )
+    .runCommands(
+      HOSTS_BOOTSTRAP,
+      DNS_BOOTSTRAP,
+      "printf '%s\\n' '#!/bin/sh' 'exec python3 -m sandbox_runtime.credentials.git_credential_helper \"$@\"' | sudo tee /usr/local/bin/oi-git-credentials >/dev/null",
+      "sudo chmod 0755 /usr/local/bin/oi-git-credentials",
+      "sudo git config --system credential.helper /usr/local/bin/oi-git-credentials",
+      "sudo git config --system credential.useHttpPath true",
+      `[ -f ${OPENSANDBOX_PROXY_CA} ] && sudo update-ca-certificates || true`,
+      `[ -f ${OPENSANDBOX_PROXY_CA} ] && sudo git config --system http.sslCAInfo ${OPENSANDBOX_PROXY_CA} || true`
+    );
+
+  image = addRuntimeDir(image, runtimeDir);
+
+  return image
+    .env({
+      HOME: SANDBOX_HOME,
+      XDG_CONFIG_HOME: `${SANDBOX_HOME}/.config`,
+      NODE_ENV: "development",
+      npm_config_cache: NPM_CACHE,
+      npm_config_prefix: NPM_PREFIX,
+      UV_CACHE_DIR: UV_CACHE,
+      UV_PYTHON_INSTALL_DIR,
+      VIRTUAL_ENV: PYTHON_VENV,
+      PNPM_HOME: `${SANDBOX_HOME}/.local/share/pnpm`,
+      PATH: `${PYTHON_VENV}/bin:${NPM_PREFIX}/bin:${USER_BIN}:${SANDBOX_HOME}/.local/share/pnpm:/usr/local/bin:/usr/bin:/bin`,
+      PYTHONPATH: "/app",
+      NODE_PATH: `${NPM_PREFIX}/lib/node_modules:/usr/lib/node_modules`,
+      SSL_CERT_FILE: SYSTEM_CA_BUNDLE,
+      CURL_CA_BUNDLE: SYSTEM_CA_BUNDLE,
+      REQUESTS_CA_BUNDLE: SYSTEM_CA_BUNDLE,
+      NODE_EXTRA_CA_CERTS: OPENSANDBOX_PROXY_CA,
+      NPM_CONFIG_CAFILE: OPENSANDBOX_PROXY_CA,
+      GIT_SSL_CAINFO: OPENSANDBOX_PROXY_CA,
+      OPENINSPECT_BIN_INSTALL_DIR: USER_BIN,
+      NO_PROXY: LOCAL_NO_PROXY,
+      no_proxy: LOCAL_NO_PROXY,
+      SANDBOX_VERSION: "opencomputer-v1",
+    })
+    .workdir(`${SANDBOX_HOME}/workspace`)
+    .builderMemory(options.builderMemoryMb);
+}
+
+function addRuntimeDir(image: Image, runtimeDir: string): Image {
+  let result = image;
+  for (const file of collectRuntimeFiles(runtimeDir)) {
+    const remotePath = `${SANDBOX_APP_DIR}/sandbox_runtime/${relative(runtimeDir, file)}`;
+    result = result.addLocalFile(file, remotePath);
+  }
+  return result;
+}
+
+function collectRuntimeFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === "__pycache__" || entry === ".pytest_cache" || entry === ".ruff_cache") continue;
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      files.push(...collectRuntimeFiles(fullPath));
+    } else if (stat.isFile() && !entry.endsWith(".pyc") && entry !== ".DS_Store") {
+      files.push(fullPath);
+    }
+  }
+  return files.sort();
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/packages/opencomputer-infra/tsconfig.json
+++ b/packages/opencomputer-infra/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -36,6 +36,8 @@ from .repo_image_callback import RepoImageBuildCallback
 
 configure_logging()
 
+BIN_INSTALL_DIR_ENV_VAR = "OPENINSPECT_BIN_INSTALL_DIR"
+
 
 def _port_from_env(env_var: str, default: int) -> int:
     """Read an integer port from the environment, falling back to ``default``."""
@@ -565,7 +567,7 @@ class SandboxSupervisor:
         self._install_bin_scripts()
 
     def _install_bin_scripts(self) -> None:
-        """Install standalone CLI scripts into /usr/local/bin.
+        """Install standalone CLI scripts into the sandbox bin directory.
 
         Scripts in bin/ are standalone CLIs (not OpenCode tool plugins) and must
         NOT be placed in .opencode/tool/ — OpenCode would import() them during
@@ -577,7 +579,9 @@ class SandboxSupervisor:
 
         for script in bin_dir.iterdir():
             if script.is_file() and script.suffix == ".js":
-                dest = Path("/usr/local/bin") / script.stem
+                install_dir = Path(os.environ.get(BIN_INSTALL_DIR_ENV_VAR, "/usr/local/bin"))
+                install_dir.mkdir(parents=True, exist_ok=True)
+                dest = install_dir / script.stem
                 shutil.copy(script, dest)
                 dest.chmod(0o755)
                 self.log.info("bin.installed", script=script.stem)

--- a/packages/sandbox-runtime/tests/test_tool_installation.py
+++ b/packages/sandbox-runtime/tests/test_tool_installation.py
@@ -42,6 +42,7 @@ def _patch_paths(
             .replace("/app/sandbox_runtime/bin", str(bin_src))
             .replace("/app/opencode-deps", str(deps_cache))
             .replace("/usr/local/bin", str(bin_dest))
+            .replace("/home/sandbox/.local/bin", str(bin_dest))
         )
         yield
 
@@ -254,7 +255,7 @@ class TestInstallBinScripts:
     """Cases for _install_bin_scripts() standalone CLI installation."""
 
     def test_scripts_installed_to_bin(self, tmp_path):
-        """JS scripts in bin/ should be copied to /usr/local/bin/ without .js extension."""
+        """JS scripts in bin/ should be copied to /usr/local/bin without .js extension."""
         sup = _make_supervisor()
 
         src = tmp_path / "app" / "sandbox_runtime" / "bin"
@@ -273,6 +274,32 @@ class TestInstallBinScripts:
         assert installed.exists()
         assert installed.read_text() == "#!/usr/bin/env node\n// upload cli"
         assert installed.stat().st_mode & 0o755
+
+    def test_scripts_installed_to_configured_bin(self, tmp_path, monkeypatch):
+        """OPENINSPECT_BIN_INSTALL_DIR can override the install directory."""
+        sup = _make_supervisor()
+
+        src = tmp_path / "app" / "sandbox_runtime" / "bin"
+        src.mkdir(parents=True)
+        (src / "upload-media.js").write_text("#!/usr/bin/env node\n// upload cli")
+
+        default_dest = tmp_path / "usr-local-bin"
+        default_dest.mkdir()
+        user_dest = tmp_path / "configured-bin"
+        monkeypatch.setenv("OPENINSPECT_BIN_INSTALL_DIR", str(user_dest))
+
+        with _patch_paths(
+            legacy=tmp_path / "no-legacy",
+            tools=tmp_path / "no-tools",
+            bin_src=src,
+            bin_dest=default_dest,
+        ):
+            sup._install_bin_scripts()
+
+        installed = user_dest / "upload-media"
+        assert installed.exists()
+        assert installed.read_text() == "#!/usr/bin/env node\n// upload cli"
+        assert not (default_dest / "upload-media").exists()
 
     def test_non_js_files_skipped(self, tmp_path):
         """Non-.js files in bin/ should not be installed."""

--- a/terraform/environments/production/locals.tf
+++ b/terraform/environments/production/locals.tf
@@ -1,8 +1,9 @@
 locals {
-  name_suffix         = var.deployment_name
-  use_modal_backend   = var.sandbox_provider == "modal"
-  use_daytona_backend = var.sandbox_provider == "daytona"
-  use_vercel_backend  = var.sandbox_provider == "vercel"
+  name_suffix              = var.deployment_name
+  use_modal_backend        = var.sandbox_provider == "modal"
+  use_daytona_backend      = var.sandbox_provider == "daytona"
+  use_vercel_backend       = var.sandbox_provider == "vercel"
+  use_opencomputer_backend = var.sandbox_provider == "opencomputer"
 
   # Google login is enabled only when both OAuth credentials are configured.
   # Drives the build-time NEXT_PUBLIC_GOOGLE_ENABLED flag (sign-in button) and

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -83,6 +83,15 @@ vercel_sandbox_project_id = "" # e.g., "prj_xxxxxxxxxxxxxxxxxxxx"
 # vercel_sandbox_runtime  = "node24"
 # vercel_snapshot_expiration_ms = 0
 
+# OpenComputer REST API
+# Only required when sandbox_provider = "opencomputer"
+# The template must include the OpenInspect sandbox runtime entrypoint.
+opencomputer_api_url = "https://app.opencomputer.dev/api"
+opencomputer_api_key = ""
+opencomputer_template = ""
+# opencomputer_project_id = "" # Optional project/workspace scope
+# opencomputer_target     = "" # Optional target/region/cell
+
 # =============================================================================
 # GitHub App Credentials
 # =============================================================================
@@ -214,6 +223,7 @@ nextauth_secret = ""
 # - "modal": existing Modal-based sandboxes with filesystem snapshot restore
 # - "daytona": direct Daytona REST API integration with stop/start resume
 # - "vercel": Vercel Sandbox API with filesystem snapshot restore
+# - "opencomputer": OpenComputer declarative-template sandboxes with hibernate/resume
 sandbox_provider = "modal"
 
 # Platform for the web app deployment

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -349,6 +349,52 @@ variable "daytona_target" {
   default     = ""
 }
 
+variable "opencomputer_api_url" {
+  description = "Base URL for the OpenComputer REST API (e.g. https://api.opencomputer.dev)"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.sandbox_provider != "opencomputer" || length(trimspace(var.opencomputer_api_url)) > 0
+    error_message = "opencomputer_api_url must be set when sandbox_provider = 'opencomputer'."
+  }
+}
+
+variable "opencomputer_api_key" {
+  description = "API key for OpenComputer REST API (X-API-Key auth)"
+  type        = string
+  sensitive   = true
+  default     = ""
+
+  validation {
+    condition     = var.sandbox_provider != "opencomputer" || length(trimspace(var.opencomputer_api_key)) > 0
+    error_message = "opencomputer_api_key must be set when sandbox_provider = 'opencomputer'."
+  }
+}
+
+variable "opencomputer_template" {
+  description = "OpenComputer declarative template containing the OpenInspect sandbox runtime"
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.sandbox_provider != "opencomputer" || length(trimspace(var.opencomputer_template)) > 0
+    error_message = "opencomputer_template must be set when sandbox_provider = 'opencomputer'."
+  }
+}
+
+variable "opencomputer_project_id" {
+  description = "Optional OpenComputer project/workspace scope"
+  type        = string
+  default     = ""
+}
+
+variable "opencomputer_target" {
+  description = "Optional OpenComputer target, region, or cell"
+  type        = string
+  default     = ""
+}
+
 variable "vercel_sandbox_token" {
   description = "Vercel API token for the Vercel Sandbox API"
   type        = string
@@ -413,14 +459,20 @@ variable "nextauth_secret" {
 # =============================================================================
 
 variable "sandbox_provider" {
-  description = "Sandbox backend for session execution: 'modal', 'daytona', or 'vercel'"
+  description = "Sandbox backend for session execution: 'modal', 'daytona', 'vercel', or 'opencomputer'"
   type        = string
   default     = "modal"
 
   validation {
-    condition     = contains(["modal", "daytona", "vercel"], var.sandbox_provider)
-    error_message = "sandbox_provider must be 'modal', 'daytona', or 'vercel'."
+    condition     = contains(["modal", "daytona", "vercel", "opencomputer"], var.sandbox_provider)
+    error_message = "sandbox_provider must be 'modal', 'daytona', 'vercel', or 'opencomputer'."
   }
+}
+
+variable "sandbox_inactivity_timeout_ms" {
+  description = "Milliseconds of sandbox inactivity before OpenInspect snapshots and stops the sandbox when no clients are connected."
+  type        = number
+  default     = 600000
 }
 
 variable "web_platform" {

--- a/terraform/environments/production/workers-control-plane.tf
+++ b/terraform/environments/production/workers-control-plane.tf
@@ -70,6 +70,7 @@ module "control_plane_worker" {
       { name = "DEPLOYMENT_NAME", value = var.deployment_name },
       { name = "APP_NAME", value = var.app_name },
       { name = "SANDBOX_PROVIDER", value = var.sandbox_provider },
+      { name = "SANDBOX_INACTIVITY_TIMEOUT_MS", value = tostring(var.sandbox_inactivity_timeout_ms) },
     ],
     local.use_modal_backend ? [
       { name = "MODAL_WORKSPACE", value = var.modal_workspace },
@@ -82,6 +83,16 @@ module "control_plane_worker" {
     ] : [],
     local.use_daytona_backend && var.daytona_target != "" ? [
       { name = "DAYTONA_TARGET", value = var.daytona_target },
+    ] : [],
+    local.use_opencomputer_backend ? [
+      { name = "OPENCOMPUTER_API_URL", value = var.opencomputer_api_url },
+      { name = "OPENCOMPUTER_TEMPLATE", value = var.opencomputer_template },
+    ] : [],
+    local.use_opencomputer_backend && var.opencomputer_project_id != "" ? [
+      { name = "OPENCOMPUTER_PROJECT_ID", value = var.opencomputer_project_id },
+    ] : [],
+    local.use_opencomputer_backend && var.opencomputer_target != "" ? [
+      { name = "OPENCOMPUTER_TARGET", value = var.opencomputer_target },
     ] : [],
     local.use_vercel_backend ? [
       { name = "VERCEL_PROJECT_ID", value = var.vercel_sandbox_project_id },
@@ -120,6 +131,10 @@ module "control_plane_worker" {
     ] : [],
     local.use_daytona_backend ? [
       { name = "DAYTONA_API_KEY", value = var.daytona_api_key },
+    ] : [],
+    local.use_opencomputer_backend ? [
+      { name = "OPENCOMPUTER_API_KEY", value = var.opencomputer_api_key },
+      { name = "ANTHROPIC_API_KEY", value = var.anthropic_api_key },
     ] : [],
     local.use_vercel_backend ? [
       { name = "VERCEL_TOKEN", value = var.vercel_sandbox_token },


### PR DESCRIPTION
## What

Adds the four runtime tools that the **Vercel** base image installs but the OpenComputer template (#818) dropped during its `dnf`→`apt` port:

| Tool | Lands at | Why |
|---|---|---|
| **agent-browser** `0.21.2` | `${NPM_PREFIX}/bin` + Chromium cache | The image already apt-installs the full headless-Chromium shared-lib set (`libnss3`, `libgbm1`, …) + `ffmpeg` — but never installed the tool that uses them. They were dead weight. |
| **gh** (GitHub CLI) | `/usr/bin/gh` | The runtime's gh wrapper (`entrypoint.py:62,280`) targets `/usr/bin/gh` and silently no-ops without it. Installed via the official apt repo so it lands exactly where the wrapper expects. |
| **ttyd** `1.7.7` | `/usr/local/bin/ttyd` | Terminal support (checksum-verified binary, same pin as the Vercel image). |
| **bun** | `${SANDBOX_HOME}/.bun` | Used by agent-browser and some opencode tooling. |

## Why

Code review of #818 found the OpenComputer build was modeled on `vercel/bootstrap.ts` but is an **incomplete port**: its apt package list is a 1:1 `dnf`→`apt` translation of Vercel's browser libs, and its `npm install -g` line is Vercel's **minus exactly the `agent-browser` token**. The result shipped Chromium's worth of shared libs + ffmpeg with no consumer, and no `gh`. This brings the image to parity for basic testing.

## Notes

- **Ownership fix:** the `npm`/`bun`/`agent-browser` installs run as root (`sudo`) but write under the non-root sandbox user's HOME. Added a `chown -R sandbox:sandbox ${SANDBOX_HOME}` so the runtime can actually read/write those caches (otherwise agent-browser's Chromium cache is root-owned and unusable). This also addresses review finding **B3**.
- Network-dependent steps (`gh` apt install, `bun`, `agent-browser install`) are best-effort (`|| true`), matching Vercel's robustness choices; `ttyd` is checksum-verified (strict).
- Bumped `SANDBOX_VERSION` `opencomputer-v1`→`v2` (the real rebuild trigger is the content-hashed `image.cacheKey()`, which changes automatically with the new `runCommands`).

## ⚠️ Validation pending

I could **not** run `build:opencomputer-template` locally (needs the OpenComputer SDK + API). Before merge, please run a real template build and confirm in the built image:
- `gh --version`, `agent-browser --version`, `ttyd --version`, `bun --version`
- the `sandbox:sandbox` user/group assumption in the `chown` is correct for the OpenComputer base image (it's `|| true`, so a wrong name is a no-op, not a build break — but then B3 isn't fixed).

## Stacking

Stacked on **#818** — base branch `opencomputer-provider-mvp` mirrors #818's head (`c63df9fd`) so this PR's diff is deps-only. Rebase onto `main` once #818 merges.
