### PR TITLE
feat(opencomputer): add agent-browser, gh, ttyd, bun to template image

### DIFF
--- a/packages/opencomputer-infra/src/build-template.ts
+++ b/packages/opencomputer-infra/src/build-template.ts
@@ -6,11 +6,15 @@ import { Image, Snapshots } from "@opencomputer/sdk/node";
 const OPENCODE_VERSION = "1.14.41";
 const CODE_SERVER_VERSION = "4.109.5";
 const PYTHON_VERSION = "3.12";
+const AGENT_BROWSER_VERSION = "0.21.2";
+const TTYD_VERSION = "1.7.7";
+const TTYD_SHA256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55";
 const SANDBOX_HOME = "/home/sandbox";
 const SANDBOX_APP_DIR = `${SANDBOX_HOME}/app`;
 const NPM_PREFIX = `${SANDBOX_HOME}/.npm-global`;
 const NPM_CACHE = `${SANDBOX_HOME}/.npm-cache`;
 const USER_BIN = `${SANDBOX_HOME}/.local/bin`;
+const BUN_INSTALL_DIR = `${SANDBOX_HOME}/.bun`;
 const PYTHON_VENV = `${SANDBOX_HOME}/.venv`;
 const UV_CACHE = `${SANDBOX_HOME}/.cache/uv`;
 const UV_PYTHON_INSTALL_DIR = `${SANDBOX_HOME}/.local/share/uv/python`;
@@ -148,7 +152,24 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
       `ln -sf ${PYTHON_VENV}/bin/python ${USER_BIN}/python`,
       `HOME=${SANDBOX_HOME} UV_CACHE_DIR=${UV_CACHE} uv pip install --python ${PYTHON_VENV}/bin/python httpx websockets "pydantic>=2.0" "PyJWT[crypto]"`,
       `sudo rm -rf /app && sudo ln -s ${SANDBOX_APP_DIR} /app`,
-      `sudo env npm_config_cache=${NPM_CACHE} npm install -g --prefix ${NPM_PREFIX} pnpm@10 opencode-ai@${OPENCODE_VERSION} @opencode-ai/plugin@${OPENCODE_VERSION} zod@4.4.3`
+      `sudo env npm_config_cache=${NPM_CACHE} npm install -g --prefix ${NPM_PREFIX} pnpm@10 opencode-ai@${OPENCODE_VERSION} @opencode-ai/plugin@${OPENCODE_VERSION} zod@4.4.3 agent-browser@${AGENT_BROWSER_VERSION}`
+    )
+    .runCommands(
+      // GitHub CLI — installed to /usr/bin/gh (the path the runtime's gh wrapper expects).
+      "sudo mkdir -p -m 755 /etc/apt/keyrings",
+      "curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null",
+      "sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg",
+      'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null',
+      "sudo apt-get update && sudo apt-get install -y gh || true",
+      // ttyd (terminal) — pinned binary, checksum-verified (matches the Vercel base image).
+      `curl -fsSL -o /tmp/ttyd https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.x86_64`,
+      `echo "${TTYD_SHA256}  /tmp/ttyd" | sha256sum -c -`,
+      "sudo mv /tmp/ttyd /usr/local/bin/ttyd",
+      "sudo chmod 0755 /usr/local/bin/ttyd",
+      // bun — used by agent-browser and some opencode tooling.
+      `curl -fsSL https://bun.sh/install | sudo env BUN_INSTALL=${BUN_INSTALL_DIR} bash || true`,
+      // agent-browser Chromium download (best-effort; the shared libs are installed via aptInstall above).
+      `sudo env HOME=${SANDBOX_HOME} PATH=${NPM_PREFIX}/bin:${BUN_INSTALL_DIR}/bin:${USER_BIN}:/usr/local/bin:/usr/bin:/bin agent-browser install || true`
     )
     .runCommands(
       `curl -fsSL -o /tmp/code-server.deb https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/code-server_${CODE_SERVER_VERSION}_amd64.deb`,
@@ -169,6 +190,11 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
       "sudo git config --system credential.useHttpPath true",
       `[ -f ${OPENSANDBOX_PROXY_CA} ] && sudo update-ca-certificates || true`,
       `[ -f ${OPENSANDBOX_PROXY_CA} ] && sudo git config --system http.sslCAInfo ${OPENSANDBOX_PROXY_CA} || true`
+    )
+    .runCommands(
+      // The npm/bun/agent-browser steps above run as root (sudo) and write under the sandbox
+      // user's HOME. Re-own HOME so the non-root runtime can read/write those caches.
+      `sudo chown -R sandbox:sandbox ${SANDBOX_HOME} || true`
     );
 
   image = addRuntimeDir(image, runtimeDir);
@@ -184,7 +210,7 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
       UV_PYTHON_INSTALL_DIR,
       VIRTUAL_ENV: PYTHON_VENV,
       PNPM_HOME: `${SANDBOX_HOME}/.local/share/pnpm`,
-      PATH: `${PYTHON_VENV}/bin:${NPM_PREFIX}/bin:${USER_BIN}:${SANDBOX_HOME}/.local/share/pnpm:/usr/local/bin:/usr/bin:/bin`,
+      PATH: `${PYTHON_VENV}/bin:${NPM_PREFIX}/bin:${USER_BIN}:${BUN_INSTALL_DIR}/bin:${SANDBOX_HOME}/.local/share/pnpm:/usr/local/bin:/usr/bin:/bin`,
       PYTHONPATH: "/app",
       NODE_PATH: `${NPM_PREFIX}/lib/node_modules:/usr/lib/node_modules`,
       SSL_CERT_FILE: SYSTEM_CA_BUNDLE,
@@ -196,7 +222,7 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
       OPENINSPECT_BIN_INSTALL_DIR: USER_BIN,
       NO_PROXY: LOCAL_NO_PROXY,
       no_proxy: LOCAL_NO_PROXY,
-      SANDBOX_VERSION: "opencomputer-v1",
+      SANDBOX_VERSION: "opencomputer-v2",
     })
     .workdir(`${SANDBOX_HOME}/workspace`)
     .builderMemory(options.builderMemoryMb);

--- a/packages/opencomputer-infra/src/build-template.ts
+++ b/packages/opencomputer-infra/src/build-template.ts
@@ -156,11 +156,15 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
     )
     .runCommands(
       // GitHub CLI — installed to /usr/bin/gh (the path the runtime's gh wrapper expects).
-      "sudo mkdir -p -m 755 /etc/apt/keyrings",
-      "curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null",
-      "sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg",
-      'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null',
-      "sudo apt-get update && sudo apt-get install -y gh || true",
+      // Best-effort end-to-end (keyring + apt source + install) so a cli.github.com hiccup
+      // can't fail the build, matching how vercel/bootstrap.ts best-efforts its whole gh block.
+      "if ! command -v gh >/dev/null 2>&1; then " +
+        "sudo mkdir -p -m 755 /etc/apt/keyrings && " +
+        "curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null && " +
+        "sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && " +
+        'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null && ' +
+        "sudo apt-get update && sudo apt-get install -y gh; " +
+        "fi || true",
       // ttyd (terminal) — pinned binary, checksum-verified (matches the Vercel base image).
       `curl -fsSL -o /tmp/ttyd https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.x86_64`,
       `echo "${TTYD_SHA256}  /tmp/ttyd" | sha256sum -c -`,
@@ -190,14 +194,14 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
       "sudo git config --system credential.useHttpPath true",
       `[ -f ${OPENSANDBOX_PROXY_CA} ] && sudo update-ca-certificates || true`,
       `[ -f ${OPENSANDBOX_PROXY_CA} ] && sudo git config --system http.sslCAInfo ${OPENSANDBOX_PROXY_CA} || true`
-    )
-    .runCommands(
-      // The npm/bun/agent-browser steps above run as root (sudo) and write under the sandbox
-      // user's HOME. Re-own HOME so the non-root runtime can read/write those caches.
-      `sudo chown -R sandbox:sandbox ${SANDBOX_HOME} || true`
     );
 
   image = addRuntimeDir(image, runtimeDir);
+
+  // The npm/bun/agent-browser installs above run as root (sudo) and write under the sandbox
+  // user's HOME, and addRuntimeDir copies the runtime in as root too. Re-own HOME last so the
+  // non-root runtime can read/write its own code and the install caches.
+  image = image.runCommands(`sudo chown -R sandbox:sandbox ${SANDBOX_HOME} || true`);
 
   return image
     .env({


### PR DESCRIPTION
## What

Adds the four runtime tools that the **Vercel** base image installs but the OpenComputer template (#818) dropped during its `dnf`→`apt` port:

| Tool | Lands at | Why |
|---|---|---|
| **agent-browser** `0.21.2` | `${NPM_PREFIX}/bin` + Chromium cache | The image already apt-installs the full headless-Chromium shared-lib set (`libnss3`, `libgbm1`, …) + `ffmpeg` — but never installed the tool that uses them. They were dead weight. |
| **gh** (GitHub CLI) | `/usr/bin/gh` | The runtime's gh wrapper (`entrypoint.py:62,280`) targets `/usr/bin/gh` and silently no-ops without it. Installed via the official apt repo so it lands exactly where the wrapper expects. |
| **ttyd** `1.7.7` | `/usr/local/bin/ttyd` | Terminal support (checksum-verified binary, same pin as the Vercel image). |
| **bun** | `${SANDBOX_HOME}/.bun` | Used by agent-browser and some opencode tooling. |

## Why

Code review of #818 found the OpenComputer build was modeled on `vercel/bootstrap.ts` but is an **incomplete port**: its apt package list is a 1:1 `dnf`→`apt` translation of Vercel's browser libs, and its `npm install -g` line is Vercel's **minus exactly the `agent-browser` token**. The result shipped Chromium's worth of shared libs + ffmpeg with no consumer, and no `gh`. This brings the image to parity for basic testing.

## Notes

- **Ownership fix:** the `npm`/`bun`/`agent-browser` installs run as root (`sudo`) but write under the non-root sandbox user's HOME. Added a `chown -R sandbox:sandbox ${SANDBOX_HOME}` so the runtime can actually read/write those caches (otherwise agent-browser's Chromium cache is root-owned and unusable). This also addresses review finding **B3**.
- Network-dependent steps (`gh` apt install, `bun`, `agent-browser install`) are best-effort (`|| true`), matching Vercel's robustness choices; `ttyd` is checksum-verified (strict).
- Bumped `SANDBOX_VERSION` `opencomputer-v1`→`v2` (the real rebuild trigger is the content-hashed `image.cacheKey()`, which changes automatically with the new `runCommands`).

## ⚠️ Validation pending

I could **not** run `build:opencomputer-template` locally (needs the OpenComputer SDK + API). Before merge, please run a real template build and confirm in the built image:
- `gh --version`, `agent-browser --version`, `ttyd --version`, `bun --version`
- the `sandbox:sandbox` user/group assumption in the `chown` is correct for the OpenComputer base image (it's `|| true`, so a wrong name is a no-op, not a build break — but then B3 isn't fixed).

## Base

#818 is now merged to `main`, so this targets `main` directly with a clean deps-only diff. (Supersedes #837, which auto-closed during a base-branch retarget.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/installed additional sandbox runtime tools, including GitHub CLI, ttyd, Bun, and agent-browser (with pinned versions).
  * Updated the runtime environment so Bun is available via the command path.

* **Bug Fixes**
  * Improved post-build permissions to ensure sandbox files and caches remain accessible at runtime.

* **Changes**
  * Updated the sandbox version identifier to the latest release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->