### PR TITLE
fix(terraform): run the OpenComputer snapshot builder from the repo root

### DIFF
--- a/terraform/modules/opencomputer-infra/scripts/build-base-snapshot.sh
+++ b/terraform/modules/opencomputer-infra/scripts/build-base-snapshot.sh
@@ -29,9 +29,15 @@ cd "${PROJECT_ROOT}" || {
     exit 1
 }
 
-# build-template.ts reads OPENCOMPUTER_API_URL / OPENCOMPUTER_API_KEY / OPENCOMPUTER_TEMPLATE
-# from the environment and creates the snapshot under that exact name. The image is
-# content-addressed (image.cacheKey()), so an unchanged source rebuild is a cheap no-op.
-OPENINSPECT_REPO_ROOT="${PROJECT_ROOT}" npm run build:opencomputer-template
+# Build the bundle, then run it directly from the repo root (mirrors the sibling Vercel builder,
+# terraform/modules/vercel-sandbox-infra). We've cd'd into the repo, so cwd is the repo root;
+# running `node <dist>` from here keeps cwd at the root, which is how build-template.ts resolves
+# the sandbox-runtime source.
+# (Running the builder via `npm -w` instead would move cwd into packages/opencomputer-infra and
+# mis-resolve the runtime dir.) build-template.ts reads OPENCOMPUTER_API_URL /
+# OPENCOMPUTER_API_KEY / OPENCOMPUTER_TEMPLATE from the env and creates the snapshot under that
+# exact name; the image is content-addressed (image.cacheKey()) so an unchanged rebuild is cheap.
+npm run build -w @open-inspect/opencomputer-infra
+node packages/opencomputer-infra/dist/build-template.js
 
 echo "Built OpenComputer base snapshot ${OPENCOMPUTER_TEMPLATE}"


### PR DESCRIPTION
## Summary

Fixes the Terraform-managed OpenComputer snapshot build (added in #840). A real `terraform apply` with `SANDBOX_PROVIDER=opencomputer` fails immediately with:

```
Missing sandbox runtime directory: ../../../packages/sandbox-runtime/src/sandbox_runtime
```

## Root cause

The script ran the builder through `npm run build:opencomputer-template`, which uses `npm -w @open-inspect/opencomputer-infra` and **moves cwd into the workspace** (`packages/opencomputer-infra`). `build-template.ts` resolves the `sandbox-runtime` source relative to that cwd, so it looked for the runtime dir under the workspace instead of the repo root.

## Fix

Mirror the **sibling Vercel builder** (`terraform/modules/vercel-sandbox-infra/scripts/build-base-snapshot.sh`), which splits build from run and invokes the builder directly from the repo root:

```sh
cd "${PROJECT_ROOT}"
npm run build -w @open-inspect/opencomputer-infra        # build the bundle (cwd irrelevant)
node packages/opencomputer-infra/dist/build-template.js  # run from repo root -> cwd = repo root
```

The script already `cd`s into the repo, so running `node` from there keeps cwd at the repo root and the runtime dir resolves — with **no `OPENINSPECT_REPO_ROOT` env override and no git dependency**. This keeps repo-root resolution consistent with how the other providers' Terraform builders work.

## Validation

Ran the new invocation with `--print-manifest` (which builds the image and returns *before* the snapshot API call) from the repo root:

- exit 0, no "Missing sandbox runtime directory"
- **26** `sandbox_runtime/*` files resolved, including the 4 `skills/*/SKILL.md` prompts
- cacheKey computed

The original `$(pwd)` approach was also proven end-to-end against a real OpenComputer build (image built all 36 steps); this revision keeps that working while removing the env contract per review.

Pure shell change — `bash -n` clean, file mode (`100755`) preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed snapshot build path resolution issues caused by changing directories during the build process, improving reliability across runs.
  * Improved build logic to ensure the correct runtime and template resources are located consistently, even when invoked from the repository root.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->