### PR TITLE
fix: restore manual theme selection

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -24,7 +24,8 @@ pre code.hljs {
  * To change the color palette, update only these variables.
  */
 
-:root {
+:root,
+:root.light {
   /* Core backgrounds */
   --background: #f8f8f6;
   --foreground: #1a1a1a;

--- a/packages/web/src/components/settings/appearance-settings.tsx
+++ b/packages/web/src/components/settings/appearance-settings.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTheme } from "next-themes";
 import {
   useSyntaxHighlightPreferences,
   LIGHT_THEMES,
@@ -53,6 +54,8 @@ function ThemeRow({
 export function AppearanceSettings() {
   const { colorSchemeMode, preferredLightTheme, preferredDarkTheme, update } =
     useSyntaxHighlightPreferences();
+  const { theme, setTheme } = useTheme();
+  const selectedColorScheme = (theme ?? colorSchemeMode) as ColorSchemeMode;
 
   return (
     <div>
@@ -81,9 +84,12 @@ export function AppearanceSettings() {
               type="single"
               variant="outline"
               size="sm"
-              value={colorSchemeMode}
+              value={selectedColorScheme}
               onValueChange={(value) => {
-                if (value) update({ colorSchemeMode: value as ColorSchemeMode });
+                if (!value) return;
+                const nextMode = value as ColorSchemeMode;
+                setTheme(nextMode);
+                update({ colorSchemeMode: nextMode });
               }}
             >
               {COLOR_SCHEME_OPTIONS.map((opt) => {


### PR DESCRIPTION
## Summary
- Wire the Appearance color scheme toggle to `next-themes` so Light, Dark, and System update the application theme.
- Keep syntax highlighting color-scheme preferences in sync with the selected app theme.
- Add explicit `:root.light` color tokens so manual Light mode overrides the system dark media-query fallback.

## Root Cause
The UI toggle only updated syntax-highlight preferences and never called `setTheme`, so the app stayed on the system-resolved theme. Additionally, when the OS preferred dark mode, the `@media (prefers-color-scheme: dark)` `:root` variables overrode the default light tokens because there was no explicit light class override.

## Validation
- `npm run typecheck -w @open-inspect/web`
- `npm test -w @open-inspect/web`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/016a15c3d4b727d85b5f997134fd3cf4)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Appearance settings now keep the selected color scheme in sync with the app’s theme system, so changing the toggle updates the interface more reliably.

* **Bug Fixes**
  * Light mode styling now applies correctly when the app is using a light theme class, improving consistency in the default appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->