### PR TITLE
fix(opencomputer): clear inherited build-mode env on forked sessions

### DIFF
--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -248,6 +248,12 @@ describe("OpenComputerSandboxProvider", () => {
         env: expect.objectContaining({
           FROM_REPO_IMAGE: "true",
           REPO_IMAGE_SHA: "abc123",
+          // Build-mode markers inherited from the build sandbox's checkpoint
+          // must be neutralized so the fork boots as a session, not a build.
+          IMAGE_BUILD_MODE: "false",
+          OI_REPO_IMAGE_BUILD_ID: "",
+          OI_REPO_IMAGE_CALLBACK_URL: "",
+          OI_REPO_IMAGE_CALLBACK_TOKEN: "",
         }),
       })
     );
@@ -271,11 +277,33 @@ describe("OpenComputerSandboxProvider", () => {
     expect(client.forkFromCheckpoint).toHaveBeenCalledWith(
       expect.objectContaining({
         checkpointId: "checkpoint-session-1",
-        env: expect.objectContaining({ RESTORED_FROM_SNAPSHOT: "true" }),
+        env: expect.objectContaining({
+          RESTORED_FROM_SNAPSHOT: "true",
+          IMAGE_BUILD_MODE: "false",
+        }),
       })
     );
     expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-fork-1", 600);
     expect(client.startRuntime).toHaveBeenCalledWith("oc-fork-1");
+  });
+
+  it("never marks a runtime session as an image build", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await provider.createSandbox(baseConfig);
+
+    const createCall = vi.mocked(client.createSandbox).mock.calls[0][0];
+    expect(createCall.env).toMatchObject({
+      IMAGE_BUILD_MODE: "false",
+      OI_REPO_IMAGE_PROVIDER_SESSION_ID: "",
+      OI_REPO_IMAGE_BUILD_ID: "",
+      OI_REPO_IMAGE_CALLBACK_URL: "",
+      OI_REPO_IMAGE_CALLBACK_TOKEN: "",
+    });
   });
 
   it("creates checkpoints for snapshots", async () => {

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -436,6 +436,18 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
       envVars.REPO_IMAGE_SHA = mode.repoImageSha ?? "";
     }
 
+    // OpenComputer forks (repo-image create + snapshot restore) inherit the
+    // source sandbox's persisted env. Repo-image checkpoints are taken from a
+    // build sandbox, so its build-mode markers — IMAGE_BUILD_MODE plus the
+    // repo-image build-callback vars — leak into the forked session unless we
+    // override them here, making the supervisor re-enter image-build mode
+    // (booting "build" instead of "repo_image", then failing the already-
+    // completed build-complete callback). A runtime session is never an image
+    // build, so force the markers off. IMAGE_BUILD_MODE is checked as
+    // === "true" in entrypoint.py, so "false" disables it.
+    envVars.IMAGE_BUILD_MODE = "false";
+    for (const key of REPO_IMAGE_CALLBACK_ENV_KEYS) envVars[key] = "";
+
     if (this.providerConfig.scmProvider === "gitlab") {
       envVars.VCS_HOST = "gitlab.com";
       envVars.VCS_CLONE_USERNAME = "oauth2";


### PR DESCRIPTION
## Problem

After flipping a deployment to `SANDBOX_PROVIDER=opencomputer` and running a repo-image pre-build, **every session forked from the repo-image checkpoint booted in image-build mode** instead of as a runtime session. The supervisor logged `boot_mode "build"`, re-POSTed the already-completed build-complete callback (HTTP 400), and shut down — so the session never connected.

## Root cause

OpenComputer's `forkFromCheckpoint` **merges the new `envs` over the source sandbox's persisted env**: keys present in the new env win, but keys *absent* from the new env survive from the checkpoint. Repo-image checkpoints are taken from the **build sandbox**, whose env contains `IMAGE_BUILD_MODE=true` and the `OI_REPO_IMAGE_*` build-callback vars.

`buildRuntimeEnvVars` never set those keys, so they survived the merge into every forked runtime session. `entrypoint.py` checks `IMAGE_BUILD_MODE == "true"` first (ahead of the repo-image / snapshot / fresh branches), so the supervisor re-entered build mode.

## Fix

`buildRuntimeEnvVars` now explicitly forces `IMAGE_BUILD_MODE="false"` and clears the repo-image callback vars, so a runtime fork is never mistaken for an image build. (`entrypoint.py` gates on `=== "true"`, so `"false"` disables it.)

Adds unit coverage: the repo-image fork and snapshot-restore paths assert the build markers are neutralized, plus a regression test that a plain session create never marks itself an image build.

## Validation

Deployed as a prod hotfix and confirmed live — sessions now boot and connect from a repo-image checkpoint.

---

Part 1 of 2 from an OpenComputer repo-image debugging session; the lifecycle/cleanup fixes are in a sibling PR. The two merge cleanly in either order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime sandbox sessions now consistently show image-build mode as disabled.
  * Session forks no longer inherit build-only markers or callback-related values from image-build checkpoints.
  * Snapshot restores now include the correct runtime environment flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->