### PR TITLE
fix(opencomputer): delete build sandboxes, unique secret-store names

### DIFF
--- a/packages/control-plane/src/routes/repo-images.ts
+++ b/packages/control-plane/src/routes/repo-images.ts
@@ -691,30 +691,15 @@ async function completeOpenComputerBuildFromSession(
   } finally {
     if (openComputerProvider) {
       try {
-        const stopResult = await openComputerProvider.stopSandbox({
-          providerObjectId: params.providerSessionId,
-          sessionId: params.buildId,
-          reason: "repo_image_build_complete",
-          correlation: {
-            request_id: params.requestId,
-            trace_id: params.traceId,
-            sandbox_id: params.providerSessionId,
-          },
-        });
-        if (!stopResult.success) {
-          logger.warn("repo_image.opencomputer_build_stop_failed", {
-            build_id: params.buildId,
-            provider_session_id: params.providerSessionId,
-            error: stopResult.error,
-            request_id: params.requestId,
-            trace_id: params.traceId,
-          });
-        }
-      } catch (stopError) {
-        logger.warn("repo_image.opencomputer_build_stop_failed", {
+        // The repo-image build sandbox is single-use — its checkpoint is the
+        // image. Delete it rather than hibernating (stopSandbox), which would
+        // leave it running/leaked after the build.
+        await openComputerProvider.deleteSandbox(params.providerSessionId);
+      } catch (cleanupError) {
+        logger.warn("repo_image.opencomputer_build_cleanup_failed", {
           build_id: params.buildId,
           provider_session_id: params.providerSessionId,
-          error: stopError instanceof Error ? stopError.message : String(stopError),
+          error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
           request_id: params.requestId,
           trace_id: params.traceId,
         });
@@ -790,21 +775,14 @@ async function handleBuildFailed(
     if (backend === "opencomputer" && body.provider_session_id) {
       const cleanupPromise = (async () => {
         try {
-          await createConfiguredOpenComputerProvider(env).stopSandbox({
-            providerObjectId: body.provider_session_id!,
-            sessionId: buildId,
-            reason: "repo_image_build_failed",
-            correlation: {
-              request_id: ctx.request_id,
-              trace_id: ctx.trace_id,
-              sandbox_id: body.provider_session_id!,
-            },
-          });
-        } catch (stopError) {
-          logger.warn("repo_image.opencomputer_build_stop_failed", {
+          // Single-use build sandbox: delete it rather than hibernating so a
+          // failed build doesn't leave the sandbox running/leaked.
+          await createConfiguredOpenComputerProvider(env).deleteSandbox(body.provider_session_id!);
+        } catch (cleanupError) {
+          logger.warn("repo_image.opencomputer_build_cleanup_failed", {
             build_id: buildId,
             provider_session_id: body.provider_session_id,
-            error: stopError instanceof Error ? stopError.message : String(stopError),
+            error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
             request_id: ctx.request_id,
             trace_id: ctx.trace_id,
           });

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -9,6 +9,7 @@ import type {
 import {
   OPENCOMPUTER_CHECKPOINT_KIND,
   OPENCOMPUTER_CHECKPOINT_RETENTION_POLICY,
+  OpenComputerNotFoundError,
 } from "../opencomputer-rest-client";
 import type { CreateSandboxConfig } from "../provider";
 
@@ -146,7 +147,7 @@ describe("OpenComputerSandboxProvider", () => {
     expect(client.startRuntime).toHaveBeenCalledWith("oc-sandbox-1");
     expect(createCall.env).toHaveProperty("ANTHROPIC_API_KEY", "sk-test");
     expect(client.createSecretStore).toHaveBeenCalledWith({
-      name: "openinspect-session-1",
+      name: expect.stringMatching(/^openinspect-session-1-[0-9a-f]{8}$/),
       egressAllowlist: ["*"],
     });
     expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-sandbox-1", 600);
@@ -222,6 +223,39 @@ describe("OpenComputerSandboxProvider", () => {
 
     expect(client.deleteSandbox).toHaveBeenCalledWith("oc-sandbox-1");
     expect(client.deleteSecretStore).toHaveBeenCalledWith("secret-store-1");
+  });
+
+  it("deletes a build sandbox, ignoring a missing sandbox", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await provider.deleteSandbox("oc-build-1");
+    expect(client.deleteSandbox).toHaveBeenCalledWith("oc-build-1");
+
+    vi.mocked(client.deleteSandbox).mockRejectedValueOnce(new OpenComputerNotFoundError("gone"));
+    await expect(provider.deleteSandbox("oc-build-2")).resolves.toBeUndefined();
+  });
+
+  it("derives a unique secret-store name per sandbox", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await provider.createSandbox({ ...baseConfig, userEnvVars: { ANTHROPIC_API_KEY: "sk-test" } });
+    await provider.createSandbox({ ...baseConfig, userEnvVars: { ANTHROPIC_API_KEY: "sk-test" } });
+
+    const names = vi.mocked(client.createSecretStore).mock.calls.map((call) => call[0].name);
+    expect(names).toHaveLength(2);
+    expect(names[0]).toMatch(/^openinspect-/);
+    expect(names[1]).toMatch(/^openinspect-/);
+    // Names must be unique so concurrent or sequential same-repo builds never
+    // collide on create (which would otherwise risk reaping a live store).
+    expect(names[0]).not.toBe(names[1]);
   });
 
   it("forks from a repo image checkpoint when provided", async () => {

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -324,6 +324,22 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     }
   }
 
+  /**
+   * Permanently delete a sandbox. Used to tear down ephemeral repo-image build
+   * sandboxes once their checkpoint has been taken: stopSandbox only hibernates
+   * (pause-for-resume), which is correct for idle sessions but would leak the
+   * single-use build sandbox. Idempotent — a missing sandbox is treated as
+   * already deleted.
+   */
+  async deleteSandbox(providerObjectId: string): Promise<void> {
+    try {
+      await this.client.deleteSandbox(providerObjectId);
+    } catch (error) {
+      if (error instanceof OpenComputerNotFoundError) return;
+      throw this.classifyError("Failed to delete OpenComputer sandbox", error);
+    }
+  }
+
   async triggerRepoImageBuild(
     config: TriggerOpenComputerRepoImageBuildConfig
   ): Promise<TriggerOpenComputerRepoImageBuildResult> {
@@ -519,8 +535,19 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     }
   }
 
-  private buildSecretStoreName(sessionId: string): string {
-    return `openinspect-${sessionId.slice(0, 32)}`;
+  /**
+   * Build a unique secret-store name for a sandbox. The store is linked to its
+   * sandbox by the name returned at creation and is never looked up by a
+   * re-derived name, so the name only needs to be unique, not deterministic.
+   *
+   * Build ids are `img-<owner>-<repo>-<ts>`; a plain `id.slice(0, 32)` dropped
+   * the unique timestamp, collapsing every build for a repo to one name — so
+   * concurrent or sequential same-repo builds (and session re-spawns) collided
+   * on create. Appending a random suffix keeps names unique, within the same
+   * length budget, so no two stores ever share a name.
+   */
+  private buildSecretStoreName(id: string): string {
+    return `openinspect-${id.slice(0, 23)}-${crypto.randomUUID().slice(0, 8)}`;
   }
 
   private buildCheckpointName(sessionId: string, reason: string): string {


### PR DESCRIPTION
## Problem

Two resource leaks surfaced while exercising the OpenComputer prod flip after a repo-image pre-build:

1. **Build sandboxes were never reaped.** After a repo-image build's checkpoint was taken, the single-use build sandbox was *hibernated* (`stopSandbox`) rather than deleted — leaving it running and counting against OpenComputer's concurrent-sandbox limit. Repeated builds steadily filled the slots.

2. **Repeat builds for a repo failed with `"a store with that name already exists"`.** Build secret stores were named `openinspect-${buildId.slice(0, 32)}`. The build id is `img-<owner>-<repo>-<ts>`, whose first 32 chars drop the timestamp — so every build for a given repo derived the **same** store name, and a leaked store from a prior build wedged the next build's create.

## Fix

1. Add `provider.deleteSandbox()` (idempotent — a missing sandbox is treated as already deleted) and call it from the build-complete and build-failed cleanup paths instead of `stopSandbox`.

2. **Give each secret store a unique name** (`openinspect-${id.slice(0, 23)}-${random8}`). The store is linked to its sandbox by the name returned at creation and is never looked up by a re-derived name, so the name only needs to be unique, not deterministic. This fixes the original trigger failure non-destructively, and concurrent or sequential same-repo builds (and session re-spawns) never collide on create.

> **Note on the approach:** an earlier revision made the create *tolerant* — on a name conflict it reaped the existing store and retried. Per CodeRabbit's review, that's unsafe: the trigger path doesn't serialize same-repo builds and the sandbox links the store by name, so deleting by name could reap a **concurrent build's live store**. Unique names eliminate the collision at the source, so no reap (and no list/delete race) is needed.

Adds unit coverage for both.

## Scope / follow-up

Leaked-store accumulation and the standing pool of already-leaked `stopped` sandboxes are tracked separately — the provider should move to delete-on-terminate, and OpenComputer's per-account concurrent-sandbox cap needs raising.

---

Part 2 of 2 from an OpenComputer repo-image debugging session; the boot-mode correctness fix landed in #845.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for permanently deleting OpenComputer sandboxes during build cleanup and failure handling.
  * Improved sandbox naming so each build gets a unique secret store name.

* **Bug Fixes**
  * Deleting a sandbox now succeeds even if the sandbox is already missing.
  * Reduced the chance of name collisions by using randomized secret store suffixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
