### PR TITLE
fix: respect Slack default model settings

### DIFF
--- a/packages/control-plane/src/db/integration-settings.test.ts
+++ b/packages/control-plane/src/db/integration-settings.test.ts
@@ -890,6 +890,23 @@ describe("IntegrationSettingsStore", () => {
       });
     });
 
+    it("round-trips a global slack default model", async () => {
+      await store.setGlobal("slack", {
+        defaults: { model: "anthropic/claude-sonnet-4-6" },
+      });
+
+      const result = await store.getGlobal("slack");
+      expect(result?.defaults?.model).toBe("anthropic/claude-sonnet-4-6");
+    });
+
+    it("rejects invalid slack default models", async () => {
+      await expect(
+        store.setGlobal("slack", {
+          defaults: { model: "not-a-real-model" },
+        })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
+
     it("accepts every valid mentionsPolicy value at global level", async () => {
       for (const policy of ["allow", "escape", "strip"] as const) {
         await store.setGlobal("slack", { defaults: { mentionsPolicy: policy } });
@@ -935,6 +952,14 @@ describe("IntegrationSettingsStore", () => {
       await expect(
         store.setRepoSettings("slack", "acme/widgets", {
           mentionsPolicy: "escape",
+        } as unknown as { agentNotificationsEnabled?: boolean })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
+
+    it("rejects model at per-repo level (global-only field)", async () => {
+      await expect(
+        store.setRepoSettings("slack", "acme/widgets", {
+          model: "anthropic/claude-sonnet-4-6",
         } as unknown as { agentNotificationsEnabled?: boolean })
       ).rejects.toThrow(IntegrationSettingsValidationError);
     });

--- a/packages/control-plane/src/db/integration-settings.ts
+++ b/packages/control-plane/src/db/integration-settings.ts
@@ -351,7 +351,7 @@ export class IntegrationSettingsStore {
   ): SlackGlobalSettings {
     const allowedKeys =
       level === "global"
-        ? new Set(["agentNotificationsEnabled", "mentionsPolicy", "routingRules"])
+        ? new Set(["agentNotificationsEnabled", "model", "mentionsPolicy", "routingRules"])
         : new Set(["agentNotificationsEnabled"]);
 
     for (const key of Object.keys(settings)) {
@@ -366,6 +366,8 @@ export class IntegrationSettingsStore {
     ) {
       throw new IntegrationSettingsValidationError("agentNotificationsEnabled must be a boolean");
     }
+
+    this.validateModelAndEffort(settings);
 
     if (
       settings.mentionsPolicy !== undefined &&

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -503,8 +503,7 @@ export interface AgentResponse {
 
 export interface UserPreferences {
   userId: string;
-  model: string;
-  appHomeModelOverride?: boolean;
+  model?: string;
   reasoningEffort?: string;
   branch?: string;
   updatedAt: number;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -504,6 +504,7 @@ export interface AgentResponse {
 export interface UserPreferences {
   userId: string;
   model: string;
+  appHomeModelOverride?: boolean;
   reasoningEffort?: string;
   branch?: string;
   updatedAt: number;

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -211,6 +211,7 @@ export interface SlackRepoSettings {
 
 /** Global Slack defaults: per-repo fields plus workspace-wide policy controls. */
 export interface SlackGlobalSettings extends SlackRepoSettings {
+  model?: string;
   mentionsPolicy?: SlackMentionsPolicy;
   /** Workspace-wide keyword→repository routing rules (global-only, like mentionsPolicy). */
   routingRules?: SlackRoutingRule[];

--- a/packages/slack-bot/src/app-home/interactions.ts
+++ b/packages/slack-bot/src/app-home/interactions.ts
@@ -246,7 +246,8 @@ async function handleBranchSubmission(
   const branch = getSubmittedBranch(payload);
 
   if (payload.view?.callback_id === BRANCH_MODAL_CALLBACK_ID) {
-    await updateUserPreferences(env, userId, { branch });
+    const options = await getPreferenceResolutionOptions(env, traceId);
+    await updateUserPreferences(env, userId, { branch }, options);
     await publishAppHome(env, userId);
     return;
   }
@@ -412,12 +413,14 @@ async function handleClearRepoBranch({
 
 async function handleClearBranchPreference({
   env,
+  traceId,
   userId,
 }: AppHomeBlockActionContext): Promise<void> {
   if (!userId) {
     return;
   }
 
-  await updateUserPreferences(env, userId, { branch: undefined });
+  const options = await getPreferenceResolutionOptions(env, traceId);
+  await updateUserPreferences(env, userId, { branch: undefined }, options);
   await publishAppHome(env, userId);
 }

--- a/packages/slack-bot/src/app-home/interactions.ts
+++ b/packages/slack-bot/src/app-home/interactions.ts
@@ -32,7 +32,12 @@ import type {
 } from "./slack-types";
 import type { SlackSelectOption } from "../slack-blocks";
 import { buildRepoBranchSelectOptions } from "./view";
-import { getResolvedUserPreferences, updateUserPreferences } from "../user-preferences";
+import {
+  getResolvedUserPreferences,
+  updateUserPreferences,
+  type UserPreferenceResolutionOptions,
+} from "../user-preferences";
+import { getAvailableModels, getSlackDefaultModel } from "./models";
 
 const log = createLogger("app-home");
 
@@ -98,6 +103,20 @@ function getAppHomeBlockAction(payload: SlackInteractionPayload): AppHomeBlockAc
 
   const handler = APP_HOME_BLOCK_ACTIONS[action.action_id];
   return handler ? { action, handler } : null;
+}
+
+async function getPreferenceResolutionOptions(
+  env: Env,
+  traceId: string | undefined
+): Promise<UserPreferenceResolutionOptions> {
+  const [availableModels, slackDefaultModel] = await Promise.all([
+    getAvailableModels(env, traceId),
+    getSlackDefaultModel(env, traceId),
+  ]);
+  return {
+    defaultModel: slackDefaultModel ?? env.DEFAULT_MODEL,
+    enabledModels: availableModels.map((model) => model.value),
+  };
 }
 
 function isAppHomeViewSubmission(payload: SlackInteractionPayload): boolean {
@@ -300,6 +319,7 @@ async function handleSelectModel({
 async function handleSelectReasoningEffort({
   action,
   env,
+  traceId,
   userId,
 }: AppHomeBlockActionContext): Promise<void> {
   const selectedEffort = action.selected_option?.value;
@@ -307,13 +327,19 @@ async function handleSelectReasoningEffort({
     return;
   }
 
-  const updated = await updateUserPreferences(env, userId, (current) => {
-    if (!isValidReasoningEffort(current.model, selectedEffort)) {
-      return null;
-    }
+  const options = await getPreferenceResolutionOptions(env, traceId);
+  const updated = await updateUserPreferences(
+    env,
+    userId,
+    (current) => {
+      if (!isValidReasoningEffort(current.model, selectedEffort)) {
+        return null;
+      }
 
-    return { reasoningEffort: selectedEffort };
-  });
+      return { reasoningEffort: selectedEffort };
+    },
+    options
+  );
   if (!updated) {
     return;
   }

--- a/packages/slack-bot/src/app-home/models.ts
+++ b/packages/slack-bot/src/app-home/models.ts
@@ -2,6 +2,8 @@ import {
   DEFAULT_ENABLED_MODELS,
   MODEL_OPTIONS,
   buildInternalAuthHeaders,
+  isValidModel,
+  type SlackGlobalConfig,
 } from "@open-inspect/shared";
 import type { Env } from "../types";
 import type { ModelOption } from "./slack-types";
@@ -49,4 +51,27 @@ export async function getAvailableModels(env: Env, traceId?: string): Promise<Mo
   }
 
   return getDefaultModelOptions();
+}
+
+export async function getSlackDefaultModel(
+  env: Env,
+  traceId?: string
+): Promise<string | undefined> {
+  try {
+    const headers = await getAuthHeaders(env, traceId);
+    const response = await env.CONTROL_PLANE.fetch("https://internal/integration-settings/slack", {
+      method: "GET",
+      headers,
+    });
+
+    if (!response.ok) {
+      return undefined;
+    }
+
+    const data = (await response.json()) as { settings: SlackGlobalConfig | null };
+    const model = data.settings?.defaults?.model;
+    return model && isValidModel(model) ? model : undefined;
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/slack-bot/src/app-home/publisher.ts
+++ b/packages/slack-bot/src/app-home/publisher.ts
@@ -4,19 +4,25 @@ import { getAvailableRepos } from "../classifier/repos";
 import { createLogger } from "../logger";
 import type { Env } from "../types";
 import { getUserPreferences, resolveUserPreferences } from "../user-preferences";
-import { getAvailableModels } from "./models";
+import { getAvailableModels, getSlackDefaultModel } from "./models";
 import { buildAppHomeView } from "./view";
 
 const log = createLogger("app-home");
 
 export async function publishAppHome(env: Env, userId: string): Promise<void> {
-  const [prefs, availableModels, repos, repoBranchPreferences] = await Promise.all([
-    getUserPreferences(env, userId),
-    getAvailableModels(env),
-    getAvailableRepos(env),
-    getUserRepoBranchPreferences(env, userId),
-  ]);
-  const current = resolveUserPreferences(prefs, env.DEFAULT_MODEL);
+  const [prefs, availableModels, slackDefaultModel, repos, repoBranchPreferences] =
+    await Promise.all([
+      getUserPreferences(env, userId),
+      getAvailableModels(env),
+      getSlackDefaultModel(env),
+      getAvailableRepos(env),
+      getUserRepoBranchPreferences(env, userId),
+    ]);
+  const current = resolveUserPreferences(
+    prefs,
+    slackDefaultModel ?? env.DEFAULT_MODEL,
+    availableModels.map((model) => model.value)
+  );
   const view = buildAppHomeView({
     appName: resolveAppName(env),
     availableModels,

--- a/packages/slack-bot/src/index.ts
+++ b/packages/slack-bot/src/index.ts
@@ -41,6 +41,7 @@ import {
   buildRepoClarificationBlocks,
 } from "./repo-clarification";
 import { getResolvedUserPreferences } from "./user-preferences";
+import { getAvailableModels, getSlackDefaultModel } from "./app-home/models";
 import { slackInteractionPayloadSchema } from "./interaction-payload";
 
 const log = createLogger("handler");
@@ -368,7 +369,14 @@ async function startSessionAndSendPrompt(
   channelDescription?: string,
   traceId?: string
 ): Promise<{ sessionId: string } | null> {
-  const userPrefs = await getResolvedUserPreferences(env, userId);
+  const [availableModels, slackDefaultModel] = await Promise.all([
+    getAvailableModels(env, traceId),
+    getSlackDefaultModel(env, traceId),
+  ]);
+  const userPrefs = await getResolvedUserPreferences(env, userId, {
+    defaultModel: slackDefaultModel ?? env.DEFAULT_MODEL,
+    enabledModels: availableModels.map((modelOption) => modelOption.value),
+  });
   const model = userPrefs.model;
   const reasoningEffort = userPrefs.reasoningEffort;
   const globalBranch = userPrefs.branch;

--- a/packages/slack-bot/src/user-preferences.test.ts
+++ b/packages/slack-bot/src/user-preferences.test.ts
@@ -103,6 +103,36 @@ describe("resolveUserPreferences", () => {
     expect(resolved.model).toBe("anthropic/claude-sonnet-4-6");
   });
 
+  it("treats legacy preferences without an override flag as inheriting Slack defaults", () => {
+    const resolved = resolveUserPreferences(
+      {
+        userId: "U123",
+        model: "anthropic/claude-haiku-4-5",
+        updatedAt: 1,
+      },
+      "anthropic/claude-sonnet-4-6",
+      ["anthropic/claude-sonnet-4-6"]
+    );
+
+    expect(resolved.model).toBe("anthropic/claude-sonnet-4-6");
+    expect(resolved.appHomeModelOverride).toBe(false);
+  });
+
+  it("uses the Slack default before the shared default for invalid stored models", () => {
+    const resolved = resolveUserPreferences(
+      {
+        userId: "U123",
+        model: "not-a-real-model",
+        appHomeModelOverride: true,
+        updatedAt: 1,
+      },
+      "openai/gpt-5.2",
+      ["anthropic/claude-sonnet-4-6", "openai/gpt-5.2"]
+    );
+
+    expect(resolved.model).toBe("openai/gpt-5.2");
+  });
+
   it("falls back when the App Home model is no longer enabled", () => {
     const resolved = resolveUserPreferences(
       {

--- a/packages/slack-bot/src/user-preferences.test.ts
+++ b/packages/slack-bot/src/user-preferences.test.ts
@@ -49,9 +49,11 @@ describe("updateUserPreferences", () => {
 
     const prefs = await getUserPreferences(env, "U123");
     expect(prefs?.model).toBe("anthropic/claude-haiku-4-5");
-    expect(prefs?.appHomeModelOverride).toBe(true);
-    expect(prefs?.reasoningEffort).toBe(getDefaultReasoningEffort("anthropic/claude-haiku-4-5"));
+    expect(prefs?.reasoningEffort).toBeUndefined();
     expect(prefs?.branch).toBe("staging");
+
+    const resolved = resolveUserPreferences(prefs, env.DEFAULT_MODEL);
+    expect(resolved.reasoningEffort).toBe(getDefaultReasoningEffort("anthropic/claude-haiku-4-5"));
   });
 
   it("distinguishes an omitted branch from an explicit clear", async () => {
@@ -75,25 +77,58 @@ describe("updateUserPreferences", () => {
     expect(prefs?.branch).toBeUndefined();
   });
 
-  it("does not mark the model as overridden when only branch is changed", async () => {
+  it("does not persist a model when only branch is changed", async () => {
     const env = makeEnv();
 
     await updateUserPreferences(env, "U123", { branch: "feature/test" });
 
     const prefs = await getUserPreferences(env, "U123");
-    expect(prefs?.model).toBe("anthropic/claude-haiku-4-5");
-    expect(prefs?.appHomeModelOverride).toBe(false);
+    expect(prefs?.model).toBeUndefined();
     expect(prefs?.branch).toBe("feature/test");
+  });
+
+  it("preserves an existing stored model when only branch is changed", async () => {
+    const env = makeEnv();
+    await env.SLACK_KV.put(
+      "user_prefs:U123",
+      JSON.stringify({
+        userId: "U123",
+        model: "openai/gpt-5.2",
+        updatedAt: 1,
+      })
+    );
+
+    await updateUserPreferences(env, "U123", { branch: "feature/test" });
+
+    const prefs = await getUserPreferences(env, "U123");
+    expect(prefs?.model).toBe("openai/gpt-5.2");
+    expect(prefs?.branch).toBe("feature/test");
+  });
+
+  it("does not persist a model when only reasoning effort is changed", async () => {
+    const env = makeEnv();
+
+    await updateUserPreferences(
+      env,
+      "U123",
+      { reasoningEffort: "none" },
+      {
+        defaultModel: "openai/gpt-5.2",
+        enabledModels: ["openai/gpt-5.2"],
+      }
+    );
+
+    const prefs = await getUserPreferences(env, "U123");
+    expect(prefs?.model).toBeUndefined();
+    expect(prefs?.reasoningEffort).toBe("none");
   });
 });
 
 describe("resolveUserPreferences", () => {
-  it("uses the Slack default model when App Home has not overridden model", () => {
+  it("uses the Slack default model when no model is stored", () => {
     const resolved = resolveUserPreferences(
       {
         userId: "U123",
-        model: "anthropic/claude-haiku-4-5",
-        appHomeModelOverride: false,
         updatedAt: 1,
       },
       "anthropic/claude-sonnet-4-6",
@@ -103,7 +138,7 @@ describe("resolveUserPreferences", () => {
     expect(resolved.model).toBe("anthropic/claude-sonnet-4-6");
   });
 
-  it("treats legacy preferences without an override flag as inheriting Slack defaults", () => {
+  it("uses a stored model before the Slack default", () => {
     const resolved = resolveUserPreferences(
       {
         userId: "U123",
@@ -111,11 +146,10 @@ describe("resolveUserPreferences", () => {
         updatedAt: 1,
       },
       "anthropic/claude-sonnet-4-6",
-      ["anthropic/claude-sonnet-4-6"]
+      ["anthropic/claude-haiku-4-5", "anthropic/claude-sonnet-4-6"]
     );
 
-    expect(resolved.model).toBe("anthropic/claude-sonnet-4-6");
-    expect(resolved.appHomeModelOverride).toBe(false);
+    expect(resolved.model).toBe("anthropic/claude-haiku-4-5");
   });
 
   it("uses the Slack default before the shared default for invalid stored models", () => {
@@ -123,7 +157,6 @@ describe("resolveUserPreferences", () => {
       {
         userId: "U123",
         model: "not-a-real-model",
-        appHomeModelOverride: true,
         updatedAt: 1,
       },
       "openai/gpt-5.2",
@@ -138,7 +171,6 @@ describe("resolveUserPreferences", () => {
       {
         userId: "U123",
         model: "anthropic/claude-haiku-4-5",
-        appHomeModelOverride: true,
         updatedAt: 1,
       },
       "anthropic/claude-sonnet-4-6",
@@ -153,7 +185,6 @@ describe("resolveUserPreferences", () => {
       {
         userId: "U123",
         model: "anthropic/claude-haiku-4-5",
-        appHomeModelOverride: true,
         updatedAt: 1,
       },
       "anthropic/claude-sonnet-4-6",
@@ -161,5 +192,20 @@ describe("resolveUserPreferences", () => {
     );
 
     expect(resolved.model).toBe("openai/gpt-5.2");
+  });
+
+  it("validates stored reasoning effort against the resolved Slack default model", () => {
+    const resolved = resolveUserPreferences(
+      {
+        userId: "U123",
+        reasoningEffort: "none",
+        updatedAt: 1,
+      },
+      "openai/gpt-5.2",
+      ["openai/gpt-5.2"]
+    );
+
+    expect(resolved.model).toBe("openai/gpt-5.2");
+    expect(resolved.reasoningEffort).toBe("none");
   });
 });

--- a/packages/slack-bot/src/user-preferences.test.ts
+++ b/packages/slack-bot/src/user-preferences.test.ts
@@ -105,6 +105,33 @@ describe("updateUserPreferences", () => {
     expect(prefs?.branch).toBe("feature/test");
   });
 
+  it("preserves reasoning effort on branch updates using the Slack default model context", async () => {
+    const env = makeEnv();
+    await env.SLACK_KV.put(
+      "user_prefs:U123",
+      JSON.stringify({
+        userId: "U123",
+        reasoningEffort: "none",
+        updatedAt: 1,
+      })
+    );
+
+    await updateUserPreferences(
+      env,
+      "U123",
+      { branch: "feature/test" },
+      {
+        defaultModel: "openai/gpt-5.2",
+        enabledModels: ["openai/gpt-5.2"],
+      }
+    );
+
+    const prefs = await getUserPreferences(env, "U123");
+    expect(prefs?.model).toBeUndefined();
+    expect(prefs?.reasoningEffort).toBe("none");
+    expect(prefs?.branch).toBe("feature/test");
+  });
+
   it("does not persist a model when only reasoning effort is changed", async () => {
     const env = makeEnv();
 

--- a/packages/slack-bot/src/user-preferences.test.ts
+++ b/packages/slack-bot/src/user-preferences.test.ts
@@ -1,7 +1,11 @@
 import { getDefaultReasoningEffort } from "@open-inspect/shared";
 import { describe, expect, it, vi } from "vitest";
 import type { Env } from "./types";
-import { getUserPreferences, updateUserPreferences } from "./user-preferences";
+import {
+  getUserPreferences,
+  resolveUserPreferences,
+  updateUserPreferences,
+} from "./user-preferences";
 
 function createMockKV() {
   const store = new Map<string, string>();
@@ -45,6 +49,7 @@ describe("updateUserPreferences", () => {
 
     const prefs = await getUserPreferences(env, "U123");
     expect(prefs?.model).toBe("anthropic/claude-haiku-4-5");
+    expect(prefs?.appHomeModelOverride).toBe(true);
     expect(prefs?.reasoningEffort).toBe(getDefaultReasoningEffort("anthropic/claude-haiku-4-5"));
     expect(prefs?.branch).toBe("staging");
   });
@@ -68,5 +73,63 @@ describe("updateUserPreferences", () => {
     expect(prefs?.model).toBe("anthropic/claude-haiku-4-5");
     expect(prefs?.reasoningEffort).toBe("max");
     expect(prefs?.branch).toBeUndefined();
+  });
+
+  it("does not mark the model as overridden when only branch is changed", async () => {
+    const env = makeEnv();
+
+    await updateUserPreferences(env, "U123", { branch: "feature/test" });
+
+    const prefs = await getUserPreferences(env, "U123");
+    expect(prefs?.model).toBe("anthropic/claude-haiku-4-5");
+    expect(prefs?.appHomeModelOverride).toBe(false);
+    expect(prefs?.branch).toBe("feature/test");
+  });
+});
+
+describe("resolveUserPreferences", () => {
+  it("uses the Slack default model when App Home has not overridden model", () => {
+    const resolved = resolveUserPreferences(
+      {
+        userId: "U123",
+        model: "anthropic/claude-haiku-4-5",
+        appHomeModelOverride: false,
+        updatedAt: 1,
+      },
+      "anthropic/claude-sonnet-4-6",
+      ["anthropic/claude-sonnet-4-6"]
+    );
+
+    expect(resolved.model).toBe("anthropic/claude-sonnet-4-6");
+  });
+
+  it("falls back when the App Home model is no longer enabled", () => {
+    const resolved = resolveUserPreferences(
+      {
+        userId: "U123",
+        model: "anthropic/claude-haiku-4-5",
+        appHomeModelOverride: true,
+        updatedAt: 1,
+      },
+      "anthropic/claude-sonnet-4-6",
+      ["openai/gpt-5.2", "anthropic/claude-sonnet-4-6"]
+    );
+
+    expect(resolved.model).toBe("anthropic/claude-sonnet-4-6");
+  });
+
+  it("uses the first enabled model when neither preferred nor default is enabled", () => {
+    const resolved = resolveUserPreferences(
+      {
+        userId: "U123",
+        model: "anthropic/claude-haiku-4-5",
+        appHomeModelOverride: true,
+        updatedAt: 1,
+      },
+      "anthropic/claude-sonnet-4-6",
+      ["openai/gpt-5.2"]
+    );
+
+    expect(resolved.model).toBe("openai/gpt-5.2");
   });
 });

--- a/packages/slack-bot/src/user-preferences.ts
+++ b/packages/slack-bot/src/user-preferences.ts
@@ -3,7 +3,9 @@ import {
   createKvCacheStore,
   getDefaultReasoningEffort,
   getValidModelOrDefault,
+  isValidModel,
   isValidReasoningEffort,
+  normalizeModelId,
 } from "@open-inspect/shared";
 import type { Env, UserPreferences } from "./types";
 import {
@@ -57,8 +59,19 @@ function normalizeResolvedPreferences(
     model,
     reasoningEffort,
     branch,
-    appHomeModelOverride: preferences.appHomeModelOverride,
+    appHomeModelOverride: preferences.appHomeModelOverride === true,
   };
+}
+
+function getValidModelOrFallback(
+  model: string | undefined | null,
+  fallback: string | undefined
+): string {
+  if (model && isValidModel(model)) {
+    return normalizeModelId(model);
+  }
+
+  return getValidModelOrDefault(fallback ?? DEFAULT_MODEL);
 }
 
 function resolveEnabledModel(
@@ -66,8 +79,8 @@ function resolveEnabledModel(
   defaultModel: string | undefined,
   enabledModels: string[] | undefined
 ): string {
-  const desired = getValidModelOrDefault(model ?? defaultModel ?? DEFAULT_MODEL);
   const fallback = getValidModelOrDefault(defaultModel ?? DEFAULT_MODEL);
+  const desired = getValidModelOrFallback(model, fallback);
   if (!enabledModels || enabledModels.length === 0) {
     return desired;
   }
@@ -125,7 +138,7 @@ export function resolveUserPreferences(
   defaultModel: string | undefined,
   enabledModels?: string[]
 ): ResolvedUserPreferences {
-  const appHomeModelOverride = prefs ? prefs.appHomeModelOverride !== false : false;
+  const appHomeModelOverride = prefs?.appHomeModelOverride === true;
   return normalizeResolvedPreferences(
     {
       model: appHomeModelOverride && prefs ? prefs.model : (defaultModel ?? DEFAULT_MODEL),

--- a/packages/slack-bot/src/user-preferences.ts
+++ b/packages/slack-bot/src/user-preferences.ts
@@ -21,7 +21,6 @@ export interface ResolvedUserPreferences {
   model: string;
   reasoningEffort: string | undefined;
   branch: string | undefined;
-  appHomeModelOverride: boolean;
 }
 
 type UserPreferencesPatch = Partial<ResolvedUserPreferences>;
@@ -41,7 +40,11 @@ function hasPreferenceField<K extends keyof UserPreferencesPatch>(
 }
 
 function normalizeResolvedPreferences(
-  preferences: ResolvedUserPreferences,
+  preferences: {
+    model: string | undefined | null;
+    reasoningEffort?: string;
+    branch?: string;
+  },
   defaultModel: string | undefined,
   options: { validateBranch?: boolean; enabledModels?: string[] } = {}
 ): ResolvedUserPreferences {
@@ -59,19 +62,15 @@ function normalizeResolvedPreferences(
     model,
     reasoningEffort,
     branch,
-    appHomeModelOverride: preferences.appHomeModelOverride === true,
   };
 }
 
-function getValidModelOrFallback(
-  model: string | undefined | null,
-  fallback: string | undefined
-): string {
+function getNormalizedValidModel(model: string | undefined | null): string | undefined {
   if (model && isValidModel(model)) {
     return normalizeModelId(model);
   }
 
-  return getValidModelOrDefault(fallback ?? DEFAULT_MODEL);
+  return undefined;
 }
 
 function resolveEnabledModel(
@@ -80,7 +79,7 @@ function resolveEnabledModel(
   enabledModels: string[] | undefined
 ): string {
   const fallback = getValidModelOrDefault(defaultModel ?? DEFAULT_MODEL);
-  const desired = getValidModelOrFallback(model, fallback);
+  const desired = getNormalizedValidModel(model) ?? fallback;
   if (!enabledModels || enabledModels.length === 0) {
     return desired;
   }
@@ -92,28 +91,45 @@ function resolveEnabledModel(
 }
 
 function mergeUserPreferencesPatch(
-  current: ResolvedUserPreferences,
+  userId: string,
+  current: UserPreferences | null,
   patch: UserPreferencesPatch,
-  defaultModel: string | undefined
-): ResolvedUserPreferences {
-  const model = hasPreferenceField(patch, "model") ? (patch.model ?? current.model) : current.model;
-  const reasoningEffort = hasPreferenceField(patch, "reasoningEffort")
+  options: UserPreferenceResolutionOptions
+): UserPreferences | null {
+  const model = hasPreferenceField(patch, "model")
+    ? getNormalizedValidModel(patch.model)
+    : getNormalizedValidModel(current?.model);
+  let reasoningEffort = hasPreferenceField(patch, "reasoningEffort")
     ? patch.reasoningEffort
     : hasPreferenceField(patch, "model")
       ? undefined
-      : current.reasoningEffort;
-  const branch = hasPreferenceField(patch, "branch") ? patch.branch : current.branch;
-  const appHomeModelOverride = hasPreferenceField(patch, "model")
-    ? true
-    : current.appHomeModelOverride;
+      : current?.reasoningEffort;
+  const branch = hasPreferenceField(patch, "branch")
+    ? normalizeBranchPreference(patch.branch)
+    : normalizeBranchPreference(current?.branch);
 
-  return normalizeResolvedPreferences(
-    { model, reasoningEffort, branch, appHomeModelOverride },
-    defaultModel,
-    {
-      validateBranch: false,
-    }
+  if (branch && !isValidBranchName(branch)) {
+    log.warn("slack.branch_pref.invalid", {
+      user_id: userId,
+      branch,
+    });
+    return null;
+  }
+
+  const resolvedModel = resolveEnabledModel(
+    model,
+    options.defaultModel ?? DEFAULT_MODEL,
+    options.enabledModels
   );
+  if (reasoningEffort && !isValidReasoningEffort(resolvedModel, reasoningEffort)) {
+    reasoningEffort = undefined;
+  }
+
+  const prefs: UserPreferences = { userId, updatedAt: Date.now() };
+  if (model) prefs.model = model;
+  if (reasoningEffort) prefs.reasoningEffort = reasoningEffort;
+  if (branch) prefs.branch = branch;
+  return prefs;
 }
 
 function isValidUserPreferences(data: unknown): data is UserPreferences {
@@ -122,13 +138,16 @@ function isValidUserPreferences(data: unknown): data is UserPreferences {
   }
 
   const obj = data as Record<string, unknown>;
+  const modelValid = obj.model === undefined || typeof obj.model === "string";
+  const reasoningEffortValid =
+    obj.reasoningEffort === undefined || typeof obj.reasoningEffort === "string";
   const branchValid = obj.branch === undefined || typeof obj.branch === "string";
 
   return (
     typeof obj.userId === "string" &&
-    typeof obj.model === "string" &&
+    modelValid &&
+    reasoningEffortValid &&
     typeof obj.updatedAt === "number" &&
-    (obj.appHomeModelOverride === undefined || typeof obj.appHomeModelOverride === "boolean") &&
     branchValid
   );
 }
@@ -138,13 +157,11 @@ export function resolveUserPreferences(
   defaultModel: string | undefined,
   enabledModels?: string[]
 ): ResolvedUserPreferences {
-  const appHomeModelOverride = prefs?.appHomeModelOverride === true;
   return normalizeResolvedPreferences(
     {
-      model: appHomeModelOverride && prefs ? prefs.model : (defaultModel ?? DEFAULT_MODEL),
+      model: prefs?.model ?? defaultModel ?? DEFAULT_MODEL,
       reasoningEffort: prefs?.reasoningEffort,
       branch: prefs?.branch,
-      appHomeModelOverride,
     },
     defaultModel,
     { enabledModels }
@@ -190,29 +207,33 @@ export async function getResolvedUserPreferences(
 export async function saveUserPreferences(
   env: Env,
   userId: string,
-  preferences: ResolvedUserPreferences
+  preferences: UserPreferences,
+  options: UserPreferenceResolutionOptions = {}
 ): Promise<boolean> {
   try {
-    const normalizedPreferences = normalizeResolvedPreferences(preferences, env.DEFAULT_MODEL, {
-      validateBranch: false,
-    });
-    const normalizedBranch = normalizeBranchPreference(normalizedPreferences.branch);
-    if (normalizedBranch && !isValidBranchName(normalizedBranch)) {
+    const model = getNormalizedValidModel(preferences.model);
+    let reasoningEffort = preferences.reasoningEffort;
+    const branch = normalizeBranchPreference(preferences.branch);
+    if (branch && !isValidBranchName(branch)) {
       log.warn("slack.branch_pref.invalid", {
         user_id: userId,
-        branch: normalizedBranch,
+        branch,
       });
       return false;
     }
+    const resolvedModel = resolveEnabledModel(
+      model,
+      options.defaultModel ?? env.DEFAULT_MODEL,
+      options.enabledModels
+    );
+    if (reasoningEffort && !isValidReasoningEffort(resolvedModel, reasoningEffort)) {
+      reasoningEffort = undefined;
+    }
 
-    const prefs: UserPreferences = {
-      userId,
-      model: normalizedPreferences.model,
-      appHomeModelOverride: normalizedPreferences.appHomeModelOverride,
-      reasoningEffort: normalizedPreferences.reasoningEffort,
-      branch: normalizedBranch,
-      updatedAt: Date.now(),
-    };
+    const prefs: UserPreferences = { userId, updatedAt: Date.now() };
+    if (model) prefs.model = model;
+    if (reasoningEffort) prefs.reasoningEffort = reasoningEffort;
+    if (branch) prefs.branch = branch;
 
     await createKvCacheStore(env.SLACK_KV).put(
       getUserPreferencesKey(userId),
@@ -232,17 +253,24 @@ export async function saveUserPreferences(
 export async function updateUserPreferences(
   env: Env,
   userId: string,
-  patchOrUpdater: UserPreferencesPatch | UserPreferencesUpdater
+  patchOrUpdater: UserPreferencesPatch | UserPreferencesUpdater,
+  options: UserPreferenceResolutionOptions = {}
 ): Promise<boolean> {
-  const current = await getResolvedUserPreferences(env, userId);
-  const patch = typeof patchOrUpdater === "function" ? patchOrUpdater(current) : patchOrUpdater;
+  const current = await getUserPreferences(env, userId);
+  const resolvedCurrent = resolveUserPreferences(
+    current,
+    options.defaultModel ?? env.DEFAULT_MODEL,
+    options.enabledModels
+  );
+  const patch =
+    typeof patchOrUpdater === "function" ? patchOrUpdater(resolvedCurrent) : patchOrUpdater;
   if (!patch) {
     return false;
   }
 
-  return saveUserPreferences(
-    env,
-    userId,
-    mergeUserPreferencesPatch(current, patch, env.DEFAULT_MODEL)
-  );
+  const merged = mergeUserPreferencesPatch(userId, current, patch, {
+    defaultModel: options.defaultModel ?? env.DEFAULT_MODEL,
+    enabledModels: options.enabledModels,
+  });
+  return merged ? saveUserPreferences(env, userId, merged, options) : false;
 }

--- a/packages/slack-bot/src/user-preferences.ts
+++ b/packages/slack-bot/src/user-preferences.ts
@@ -19,6 +19,7 @@ export interface ResolvedUserPreferences {
   model: string;
   reasoningEffort: string | undefined;
   branch: string | undefined;
+  appHomeModelOverride: boolean;
 }
 
 type UserPreferencesPatch = Partial<ResolvedUserPreferences>;
@@ -40,9 +41,9 @@ function hasPreferenceField<K extends keyof UserPreferencesPatch>(
 function normalizeResolvedPreferences(
   preferences: ResolvedUserPreferences,
   defaultModel: string | undefined,
-  options: { validateBranch?: boolean } = {}
+  options: { validateBranch?: boolean; enabledModels?: string[] } = {}
 ): ResolvedUserPreferences {
-  const model = getValidModelOrDefault(preferences.model ?? defaultModel ?? DEFAULT_MODEL);
+  const model = resolveEnabledModel(preferences.model, defaultModel, options.enabledModels);
   const reasoningEffort =
     preferences.reasoningEffort && isValidReasoningEffort(model, preferences.reasoningEffort)
       ? preferences.reasoningEffort
@@ -56,7 +57,25 @@ function normalizeResolvedPreferences(
     model,
     reasoningEffort,
     branch,
+    appHomeModelOverride: preferences.appHomeModelOverride,
   };
+}
+
+function resolveEnabledModel(
+  model: string | undefined | null,
+  defaultModel: string | undefined,
+  enabledModels: string[] | undefined
+): string {
+  const desired = getValidModelOrDefault(model ?? defaultModel ?? DEFAULT_MODEL);
+  const fallback = getValidModelOrDefault(defaultModel ?? DEFAULT_MODEL);
+  if (!enabledModels || enabledModels.length === 0) {
+    return desired;
+  }
+
+  const enabled = new Set(enabledModels);
+  if (enabled.has(desired)) return desired;
+  if (enabled.has(fallback)) return fallback;
+  return enabledModels[0] ?? fallback;
 }
 
 function mergeUserPreferencesPatch(
@@ -71,10 +90,17 @@ function mergeUserPreferencesPatch(
       ? undefined
       : current.reasoningEffort;
   const branch = hasPreferenceField(patch, "branch") ? patch.branch : current.branch;
+  const appHomeModelOverride = hasPreferenceField(patch, "model")
+    ? true
+    : current.appHomeModelOverride;
 
-  return normalizeResolvedPreferences({ model, reasoningEffort, branch }, defaultModel, {
-    validateBranch: false,
-  });
+  return normalizeResolvedPreferences(
+    { model, reasoningEffort, branch, appHomeModelOverride },
+    defaultModel,
+    {
+      validateBranch: false,
+    }
+  );
 }
 
 function isValidUserPreferences(data: unknown): data is UserPreferences {
@@ -89,22 +115,32 @@ function isValidUserPreferences(data: unknown): data is UserPreferences {
     typeof obj.userId === "string" &&
     typeof obj.model === "string" &&
     typeof obj.updatedAt === "number" &&
+    (obj.appHomeModelOverride === undefined || typeof obj.appHomeModelOverride === "boolean") &&
     branchValid
   );
 }
 
 export function resolveUserPreferences(
   prefs: UserPreferences | null | undefined,
-  defaultModel: string | undefined
+  defaultModel: string | undefined,
+  enabledModels?: string[]
 ): ResolvedUserPreferences {
+  const appHomeModelOverride = prefs ? prefs.appHomeModelOverride !== false : false;
   return normalizeResolvedPreferences(
     {
-      model: prefs?.model ?? defaultModel ?? DEFAULT_MODEL,
+      model: appHomeModelOverride && prefs ? prefs.model : (defaultModel ?? DEFAULT_MODEL),
       reasoningEffort: prefs?.reasoningEffort,
       branch: prefs?.branch,
+      appHomeModelOverride,
     },
-    defaultModel
+    defaultModel,
+    { enabledModels }
   );
+}
+
+export interface UserPreferenceResolutionOptions {
+  defaultModel?: string;
+  enabledModels?: string[];
 }
 
 export async function getUserPreferences(
@@ -127,10 +163,15 @@ export async function getUserPreferences(
 
 export async function getResolvedUserPreferences(
   env: Env,
-  userId: string
+  userId: string,
+  options: UserPreferenceResolutionOptions = {}
 ): Promise<ResolvedUserPreferences> {
   const prefs = await getUserPreferences(env, userId);
-  return resolveUserPreferences(prefs, env.DEFAULT_MODEL);
+  return resolveUserPreferences(
+    prefs,
+    options.defaultModel ?? env.DEFAULT_MODEL,
+    options.enabledModels
+  );
 }
 
 export async function saveUserPreferences(
@@ -154,6 +195,7 @@ export async function saveUserPreferences(
     const prefs: UserPreferences = {
       userId,
       model: normalizedPreferences.model,
+      appHomeModelOverride: normalizedPreferences.appHomeModelOverride,
       reasoningEffort: normalizedPreferences.reasoningEffort,
       branch: normalizedBranch,
       updatedAt: Date.now(),

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
@@ -180,6 +180,52 @@ describe("SlackIntegrationSettings", () => {
     expect(body.settings.defaults?.mentionsPolicy).toBe("escape");
   });
 
+  it("saving a selected default model includes the model in global defaults", async () => {
+    const user = userEvent.setup();
+    setupSWR({ global: null });
+    fetchMock.mockResolvedValue(okJson({}));
+
+    render(<SlackIntegrationSettings />);
+
+    const modelSection = screen.getByText("Default model").closest("div")!;
+    await user.click(within(modelSection).getByRole("combobox"));
+    await user.click(await screen.findByRole("option", { name: "GPT 5.2" }));
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body as string) as { settings: SlackGlobalConfig };
+    expect(body.settings.defaults?.model).toBe("openai/gpt-5.2");
+  });
+
+  it("clearing the selected default model omits model while preserving other defaults", async () => {
+    const user = userEvent.setup();
+    setupSWR({
+      global: {
+        defaults: {
+          agentNotificationsEnabled: true,
+          model: "openai/gpt-5.2",
+          mentionsPolicy: "strip",
+          routingRules: [{ keyword: "frontend", target: "acme/web" }],
+        },
+      },
+      availableRepos: [repo("acme/web")],
+    });
+    fetchMock.mockResolvedValue(okJson({}));
+
+    render(<SlackIntegrationSettings />);
+
+    await user.click(screen.getByRole("button", { name: /use system default/i }));
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body as string) as { settings: SlackGlobalConfig };
+    expect(body.settings.defaults).toEqual({
+      agentNotificationsEnabled: true,
+      mentionsPolicy: "strip",
+      routingRules: [{ keyword: "frontend", target: "acme/web" }],
+    });
+  });
+
   it("renders populated settings with master switch on and policy 'strip'", () => {
     setupSWR({
       global: {

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
@@ -287,6 +287,19 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
             )}
           </SelectContent>
         </Select>
+        {model && (
+          <Button
+            type="button"
+            variant="ghost"
+            className="mt-2 h-auto px-0 text-xs"
+            onClick={() => {
+              setModel("");
+              setDirty(true);
+            }}
+          >
+            Use system default
+          </Button>
+        )}
         {!selectedModelEnabled && selectedModelLabel && (
           <p className="text-xs text-destructive mt-2">
             {selectedModelLabel} is disabled in model settings. Slack will use the first enabled
@@ -336,9 +349,9 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
           <AlertDialogHeader>
             <AlertDialogTitle>Reset to defaults</AlertDialogTitle>
             <AlertDialogDescription>
-              Reset Slack defaults? The master switch will turn off and mentions policy will return
-              to <strong>allow</strong>. Per-repository overrides and routing rules are not
-              affected.
+              Reset Slack defaults? The master switch will turn off, the default model will use the
+              system default, and mentions policy will return to <strong>allow</strong>.
+              Per-repository overrides and routing rules are not affected.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import {
   DEFAULT_MENTIONS_POLICY,
   MAX_SLACK_ROUTING_RULES,
+  MODEL_OPTIONS,
   type EnrichedRepository,
   type SlackGlobalConfig,
   type SlackGlobalSettings,
@@ -13,6 +14,7 @@ import {
   type SlackRepoSettings,
   type SlackRoutingRule,
 } from "@open-inspect/shared";
+import { useEnabledModels } from "@/hooks/use-enabled-models";
 import { IntegrationSettingsSkeleton } from "./integration-settings-skeleton";
 import { Button } from "@/components/ui/button";
 import { APP_NAME } from "@/lib/site-config";
@@ -145,9 +147,11 @@ export function SlackIntegrationSettings() {
 }
 
 function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | null | undefined }) {
+  const { enabledModels, enabledModelOptions, loading: modelsLoading } = useEnabledModels();
   const [agentNotificationsEnabled, setAgentNotificationsEnabled] = useState(
     settings?.defaults?.agentNotificationsEnabled ?? false
   );
+  const [model, setModel] = useState(settings?.defaults?.model ?? "");
   const [mentionsPolicy, setMentionsPolicy] = useState<SlackMentionsPolicy>(
     settings?.defaults?.mentionsPolicy ?? DEFAULT_MENTIONS_POLICY
   );
@@ -158,8 +162,14 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
   useEffect(() => {
     if (settings === undefined || dirty || saving) return;
     setAgentNotificationsEnabled(settings?.defaults?.agentNotificationsEnabled ?? false);
+    setModel(settings?.defaults?.model ?? "");
     setMentionsPolicy(settings?.defaults?.mentionsPolicy ?? DEFAULT_MENTIONS_POLICY);
   }, [settings, dirty, saving]);
+
+  const selectedModelEnabled = model ? enabledModels.includes(model) : true;
+  const selectedModelLabel = model
+    ? MODEL_OPTIONS.flatMap((group) => group.models).find((option) => option.id === model)?.name
+    : undefined;
 
   const isConfigured = settings !== null && settings !== undefined;
 
@@ -180,6 +190,7 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
       if (res.ok) {
         mutate(GLOBAL_SETTINGS_KEY);
         setAgentNotificationsEnabled(false);
+        setModel("");
         setMentionsPolicy(DEFAULT_MENTIONS_POLICY);
         setDirty(false);
         toast.success("Settings reset to defaults.");
@@ -197,7 +208,11 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
   const handleSave = async () => {
     setSaving(true);
     const body: SlackGlobalConfig = {
-      defaults: mergedGlobalDefaults(settings, { agentNotificationsEnabled, mentionsPolicy }),
+      defaults: mergedGlobalDefaults(settings, {
+        agentNotificationsEnabled,
+        model: model || undefined,
+        mentionsPolicy,
+      }),
     };
 
     try {
@@ -245,6 +260,40 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
           }}
         />
       </label>
+
+      <div className="mb-4">
+        <p className="text-sm font-medium text-foreground mb-2">Default model</p>
+        <p className="text-xs text-muted-foreground mb-2">
+          Used for Slack-created sessions until a user chooses their own model in Slack App Home.
+        </p>
+        <Select
+          value={model}
+          onValueChange={(value) => {
+            setModel(value);
+            setDirty(true);
+          }}
+          disabled={modelsLoading}
+        >
+          <SelectTrigger className="w-full sm:w-96">
+            <SelectValue placeholder="Use system default" />
+          </SelectTrigger>
+          <SelectContent>
+            {enabledModelOptions.map((group) =>
+              group.models.map((option) => (
+                <SelectItem key={option.id} value={option.id}>
+                  {option.name}
+                </SelectItem>
+              ))
+            )}
+          </SelectContent>
+        </Select>
+        {!selectedModelEnabled && selectedModelLabel && (
+          <p className="text-xs text-destructive mt-2">
+            {selectedModelLabel} is disabled in model settings. Slack will use the first enabled
+            model until you save a different default.
+          </p>
+        )}
+      </div>
 
       <div className="mb-4">
         <p className="text-sm font-medium text-foreground mb-2">Mentions policy</p>


### PR DESCRIPTION
## Summary
- Add a workspace-level Slack default model setting in the web UI, including a non-destructive “Use system default” clear action.
- Resolve Slack App Home and Slack-created sessions from explicit user preference → Slack workspace default → system default, constrained to the globally enabled model list.
- Store Slack user models only when a user explicitly selects one in App Home; branch and reasoning updates preserve existing model choices without saving resolved defaults.
- Validate Slack default model settings in the control plane and keep per-repo Slack overrides limited to supported fields.
- Ensure App Home reasoning-effort updates validate against the same model context used to render App Home.

## Verification
- npm run build -w @open-inspect/shared
- npm test -w @open-inspect/slack-bot -- user-preferences.test.ts
- npm test -w @open-inspect/control-plane -- integration-settings.test.ts
- npm test -w @open-inspect/web -- slack-integration-settings.test.tsx
- npm run typecheck -w @open-inspect/slack-bot
- npm run typecheck -w @open-inspect/control-plane
- npm run typecheck -w @open-inspect/web

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a workspace default model setting for Slack, with support for selecting an enabled model or using the system default.
  * Model selection now takes available models into account across Slack app home, session start, and preference updates.

* **Bug Fixes**
  * Improved validation so model and reasoning settings are checked when provided.
  * Preference handling now better preserves or clears model and reasoning choices depending on what changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->