### PR TITLE
fix(web): accept opencomputer as a sandbox provider

### DIFF
--- a/packages/web/src/app/api/repo-images/[owner]/[name]/toggle/route.ts
+++ b/packages/web/src/app/api/repo-images/[owner]/[name]/toggle/route.ts
@@ -11,7 +11,10 @@ export async function PUT(
 ) {
   if (!supportsRepoImages()) {
     return NextResponse.json(
-      { error: "Repo images are only available when SANDBOX_PROVIDER=modal or vercel" },
+      {
+        error:
+          "Repo images are only available when SANDBOX_PROVIDER=modal, vercel, or opencomputer",
+      },
       { status: 501 }
     );
   }

--- a/packages/web/src/app/api/repo-images/[owner]/[name]/trigger/route.ts
+++ b/packages/web/src/app/api/repo-images/[owner]/[name]/trigger/route.ts
@@ -11,7 +11,10 @@ export async function POST(
 ) {
   if (!supportsRepoImages()) {
     return NextResponse.json(
-      { error: "Repo images are only available when SANDBOX_PROVIDER=modal or vercel" },
+      {
+        error:
+          "Repo images are only available when SANDBOX_PROVIDER=modal, vercel, or opencomputer",
+      },
       { status: 501 }
     );
   }

--- a/packages/web/src/app/api/repo-images/route.ts
+++ b/packages/web/src/app/api/repo-images/route.ts
@@ -7,7 +7,10 @@ import { supportsRepoImages } from "@/lib/sandbox-provider";
 export async function GET() {
   if (!supportsRepoImages()) {
     return NextResponse.json(
-      { error: "Repo images are only available when SANDBOX_PROVIDER=modal or vercel" },
+      {
+        error:
+          "Repo images are only available when SANDBOX_PROVIDER=modal, vercel, or opencomputer",
+      },
       { status: 501 }
     );
   }

--- a/packages/web/src/components/settings/images-settings.tsx
+++ b/packages/web/src/components/settings/images-settings.tsx
@@ -43,8 +43,8 @@ export function ImagesSettings() {
       <div>
         <h2 className="text-xl font-semibold text-foreground mb-1">Pre-Built Images</h2>
         <p className="text-sm text-muted-foreground">
-          Pre-built images are only available when <code>SANDBOX_PROVIDER=modal</code> or{" "}
-          <code>SANDBOX_PROVIDER=vercel</code>.
+          Pre-built images are only available when <code>SANDBOX_PROVIDER=modal</code>,{" "}
+          <code>SANDBOX_PROVIDER=vercel</code>, or <code>SANDBOX_PROVIDER=opencomputer</code>.
         </p>
       </div>
     );

--- a/packages/web/src/lib/sandbox-provider.test.ts
+++ b/packages/web/src/lib/sandbox-provider.test.ts
@@ -53,6 +53,16 @@ describe("sandbox-provider", () => {
     expect(supportsRepoImages()).toBe(false);
   });
 
+  it("supports opencomputer with repo images", async () => {
+    delete process.env.NEXT_PUBLIC_SANDBOX_PROVIDER;
+    process.env.SANDBOX_PROVIDER = "opencomputer";
+
+    const { getPublicSandboxProvider, supportsRepoImages } = await loadProvider();
+
+    expect(getPublicSandboxProvider()).toBe("opencomputer");
+    expect(supportsRepoImages()).toBe(true);
+  });
+
   it("throws for unsupported providers", async () => {
     process.env.NEXT_PUBLIC_SANDBOX_PROVIDER = "fly";
 

--- a/packages/web/src/lib/sandbox-provider.ts
+++ b/packages/web/src/lib/sandbox-provider.ts
@@ -2,7 +2,7 @@
  * Public sandbox backend helpers for the web app.
  */
 
-export type PublicSandboxProvider = "modal" | "daytona" | "vercel";
+export type PublicSandboxProvider = "modal" | "daytona" | "vercel" | "opencomputer";
 
 export function getPublicSandboxProvider(): PublicSandboxProvider {
   const rawValue = process.env.NEXT_PUBLIC_SANDBOX_PROVIDER ?? process.env.SANDBOX_PROVIDER;
@@ -11,7 +11,7 @@ export function getPublicSandboxProvider(): PublicSandboxProvider {
   }
 
   const value = rawValue.trim().toLowerCase();
-  if (value === "modal" || value === "daytona" || value === "vercel") {
+  if (value === "modal" || value === "daytona" || value === "vercel" || value === "opencomputer") {
     return value;
   }
 
@@ -20,5 +20,5 @@ export function getPublicSandboxProvider(): PublicSandboxProvider {
 
 export function supportsRepoImages(): boolean {
   const provider = getPublicSandboxProvider();
-  return provider === "modal" || provider === "vercel";
+  return provider === "modal" || provider === "vercel" || provider === "opencomputer";
 }


### PR DESCRIPTION
## Problem

A deployment with `SANDBOX_PROVIDER=opencomputer` crashes the web client:

```
Uncaught Error: Invalid sandbox provider: opencomputer
```

The web app keeps its **own** sandbox-provider allow-list in `getPublicSandboxProvider()` (`packages/web/src/lib/sandbox-provider.ts`). #818 added the `opencomputer` provider to the control-plane and Terraform but never added it here, so the function falls through to its `else` and throws. It's called — via `supportsRepoImages()` — from the settings page, settings nav, images settings, and the three repo-image API routes; since `NEXT_PUBLIC_SANDBOX_PROVIDER` is inlined into the client bundle at build time, the throw reaches the browser and crashes the page.

## Fix

- Add `"opencomputer"` to the `PublicSandboxProvider` type and the runtime check in `getPublicSandboxProvider()` — stops the crash.
- Add it to `supportsRepoImages()` as well: OpenComputer supports repo-image builds, so the Images UI/API should be enabled for it, not merely un-crashed.
- Update the "modal or vercel" help copy (3 repo-image API routes + the settings UI) to include opencomputer.
- Add test coverage for the opencomputer case.

## Validation

`sandbox-provider` unit test 5/5, prettier + eslint clean, web typecheck clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repo image features now work with the `opencomputer` sandbox provider in supported environments.
* **Bug Fixes**
  * Updated repo image availability messages across the app and API responses to include `opencomputer`.
  * Improved sandbox provider handling so `opencomputer` is recognized as a valid option.
* **Tests**
  * Added coverage for `opencomputer` support and repo image availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->