### PR TITLE
fix(opencomputer): bake gh auth wrapper into image at build time

### DIFF
--- a/packages/opencomputer-infra/src/build-template.ts
+++ b/packages/opencomputer-infra/src/build-template.ts
@@ -192,6 +192,17 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
       "sudo chmod 0755 /usr/local/bin/oi-git-credentials",
       "sudo git config --system credential.helper /usr/local/bin/oi-git-credentials",
       "sudo git config --system credential.useHttpPath true",
+      // gh CLI auth wrapper — baked here as root, at build time, rather than
+      // left to the runtime's _install_gh_wrapper(). That runtime install
+      // writes /usr/local/bin/gh as the non-root `sandbox` user, but the dir is
+      // root-owned, so the write fails with a swallowed PermissionError and gh
+      // is left unauthenticated — agents then can't post PR comments. (It works
+      // on Modal only because that runtime is root and can self-install.) Keep
+      // this body byte-identical to GH_WRAPPER_BODY in
+      // sandbox-runtime/src/sandbox_runtime/entrypoint.py so the runtime install
+      // sees a matching file and no-ops instead of failing to overwrite it.
+      "printf '%s\\n' '#!/bin/sh' 'REAL_GH=\"/usr/bin/gh\"' 'token=$(python3 -m sandbox_runtime.credentials.git_credential_helper gh-token || true)' 'if [ -n \"$token\" ]; then' '  export GH_TOKEN=\"$token\"' 'fi' 'exec \"$REAL_GH\" \"$@\"' | sudo tee /usr/local/bin/gh >/dev/null",
+      "sudo chmod 0755 /usr/local/bin/gh",
       `[ -f ${OPENSANDBOX_PROXY_CA} ] && sudo update-ca-certificates || true`,
       `[ -f ${OPENSANDBOX_PROXY_CA} ] && sudo git config --system http.sslCAInfo ${OPENSANDBOX_PROXY_CA} || true`
     );


### PR DESCRIPTION
## Problem

In OpenComputer sandboxes the `gh` CLI is unauthenticated and there is no `GH_TOKEN`/`GITHUB_TOKEN` in the environment, so in-sandbox agents can't post PR review comments:

> Found 1 maintainability issue, but could not post inline because gh is unauthenticated and no GH_TOKEN/GITHUB_TOKEN is available.

This works on Modal.

## Root cause

`gh` is authenticated by a thin wrapper at `/usr/local/bin/gh` (ahead of the real `/usr/bin/gh` on `PATH`) that mints a fresh token from the control plane via the credential helper's `gh-token` action and exports it as `GH_TOKEN`. That wrapper is installed **at runtime** by `SandboxSupervisor._install_gh_wrapper()` (`packages/sandbox-runtime/.../entrypoint.py`), which does a plain `Path("/usr/local/bin/gh").write_text(...)`.

- On **Modal**, the runtime is **root**, so the write succeeds and the wrapper installs.
- On **OpenComputer**, the runtime is the **non-root `sandbox` user** and `/usr/local/bin` is root-owned, so the write raises `PermissionError`, which `_install_gh_wrapper()` swallows as `OSError` and logs at `debug`. The wrapper is silently **never installed**, and `gh` resolves to the bare, unauthenticated `/usr/bin/gh`.

`git` works on OpenComputer because its credential-helper shim is **baked into the image at build time** (with `sudo`) — the `gh` wrapper had no equivalent bake, only the root-only runtime install.

## Fix

Bake the `gh` wrapper into the image at build time with `sudo`, immediately after the git credential-helper shim it mirrors. The body is **byte-identical** to `GH_WRAPPER_BODY` in `entrypoint.py`, so the runtime `_install_gh_wrapper()` sees a matching file and no-ops instead of failing to overwrite it.

## Validation

- Baked wrapper output verified **byte-identical** to `GH_WRAPPER_BODY`.
- prettier + eslint clean. (The two local `tsc` errors on this file — `@opencomputer/sdk/node` resolution and a pre-existing implicit-any at line 68 — are pre-existing and unrelated to this change.)

## Deploy note

Takes effect on the next OpenComputer base-snapshot rebuild; existing sessions are unaffected. The snapshot source-hash already includes `build-template.ts`, so a Terraform-managed OC backend rebuilds automatically.

## Follow-ups (not in this PR)

- Raise the non-root `/usr/local/bin` write behavior with the OpenComputer team.
- Optionally harden the shared `_install_gh_wrapper()` to be non-root-aware (fall back to a user-writable dir on `PATH`) and bump the silent `debug` to `warn`. Deferred for now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic GitHub CLI authentication in built images, so `gh` can use available credentials without extra setup.
  - The CLI now runs through a wrapper that sets the login token when available and then launches the standard GitHub CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->