### PR TITLE
Refactor repo image build workflow boundaries

### DIFF
--- a/packages/control-plane/src/db/repo-images.test.ts
+++ b/packages/control-plane/src/db/repo-images.test.ts
@@ -22,17 +22,17 @@ type RepoImageRow = {
 const QUERY_PATTERNS = {
   INSERT_BUILD: /^INSERT INTO repo_images/,
   SELECT_BY_ID:
-    /^SELECT repo_owner, repo_name, provider, base_branch FROM repo_images WHERE id = \? AND provider = \? AND status = 'building'$/,
+    /^SELECT repo_owner, repo_name, provider, base_branch, created_at FROM repo_images WHERE id = \? AND provider = \? AND status = 'building'$/,
   UPDATE_PROVIDER_SESSION:
     /^UPDATE repo_images SET provider_session_id = \? WHERE id = \? AND provider = \? AND status = 'building'$/,
   SELECT_CALLBACK_BUILD:
     /^SELECT id, provider, provider_session_id, status, callback_token_hash, callback_token_expires_at, callback_token_used_at FROM repo_images WHERE id = \? AND provider = \?$/,
   UPDATE_CALLBACK_USED:
-    /^UPDATE repo_images SET callback_token_used_at = \? WHERE id = \? AND provider = \? AND status = 'building' AND callback_token_hash = \? AND callback_token_used_at IS NULL$/,
+    /^UPDATE repo_images SET callback_token_used_at = \? WHERE id = \? AND provider = \? AND provider_session_id = \? AND status = 'building' AND callback_token_hash = \? AND callback_token_expires_at >= \? AND callback_token_used_at IS NULL$/,
   SELECT_READY_FOR_REPO:
-    /^SELECT id, provider_image_id, provider_session_id FROM repo_images WHERE repo_owner = \? AND repo_name = \? AND provider = \? AND base_branch = \? AND status = 'ready'$/,
+    /^SELECT id, provider_image_id, provider_session_id FROM repo_images WHERE repo_owner = \? AND repo_name = \? AND provider = \? AND base_branch = \? AND status = 'ready' AND id <> \? AND \( created_at < \? OR \(created_at = \? AND id < \?\) \) ORDER BY created_at DESC, id DESC$/,
   UPDATE_READY:
-    /^UPDATE repo_images SET status = 'ready', provider_image_id = \?, base_sha = \?, build_duration_seconds = \? WHERE id = \? AND provider = \? AND status = 'building'$/,
+    /^UPDATE repo_images SET status = 'ready', provider_image_id = \?, base_sha = \?, build_duration_seconds = \? WHERE id = \? AND provider = \? AND status = 'building' AND NOT EXISTS \( SELECT 1 FROM repo_images newer WHERE newer\.repo_owner = \? AND newer\.repo_name = \? AND newer\.provider = \? AND newer\.base_branch = \? AND newer\.status = 'ready' AND \( newer\.created_at > \? OR \(newer\.created_at = \? AND newer\.id > \?\) \) \)$/,
   DELETE_BY_ID: /^DELETE FROM repo_images WHERE id = \?$/,
   UPDATE_FAILED:
     /^UPDATE repo_images SET status = 'failed', error_message = \? WHERE id = \? AND provider = \? AND status = 'building'$/,
@@ -81,6 +81,7 @@ class FakeD1Database {
             repo_name: row.repo_name,
             provider: row.provider,
             base_branch: row.base_branch,
+            created_at: row.created_at,
           }
         : null;
     }
@@ -99,26 +100,6 @@ class FakeD1Database {
             callback_token_used_at: row.callback_token_used_at,
           }
         : null;
-    }
-
-    if (QUERY_PATTERNS.SELECT_READY_FOR_REPO.test(normalized)) {
-      const [owner, name, provider, branch] = args as [string, string, string, string];
-      for (const row of this.rows.values()) {
-        if (
-          row.repo_owner === owner &&
-          row.repo_name === name &&
-          row.provider === provider &&
-          row.base_branch === branch &&
-          row.status === "ready"
-        ) {
-          return {
-            id: row.id,
-            provider_image_id: row.provider_image_id,
-            provider_session_id: row.provider_session_id,
-          };
-        }
-      }
-      return null;
     }
 
     if (QUERY_PATTERNS.SELECT_LATEST_READY.test(normalized)) {
@@ -154,6 +135,33 @@ class FakeD1Database {
 
   all(query: string, args: unknown[]): Partial<RepoImageRow>[] {
     const normalized = normalizeQuery(query);
+
+    if (QUERY_PATTERNS.SELECT_READY_FOR_REPO.test(normalized)) {
+      const [owner, name, provider, branch, currentId, currentCreatedAt, sameCreatedAt, tieId] =
+        args as [string, string, string, string, string, number, number, string];
+      const results: RepoImageRow[] = [];
+      for (const row of this.rows.values()) {
+        if (
+          row.repo_owner === owner &&
+          row.repo_name === name &&
+          row.provider === provider &&
+          row.base_branch === branch &&
+          row.status === "ready" &&
+          row.id !== currentId &&
+          (row.created_at < currentCreatedAt ||
+            (row.created_at === sameCreatedAt && row.id < tieId))
+        ) {
+          results.push({ ...row });
+        }
+      }
+      return results
+        .sort((a, b) => b.created_at - a.created_at || b.id.localeCompare(a.id))
+        .map((row) => ({
+          id: row.id,
+          provider_image_id: row.provider_image_id,
+          provider_session_id: row.provider_session_id,
+        }));
+    }
 
     if (QUERY_PATTERNS.SELECT_STATUS.test(normalized)) {
       const [owner, name] = args as [string, string];
@@ -222,13 +230,23 @@ class FakeD1Database {
     }
 
     if (QUERY_PATTERNS.UPDATE_CALLBACK_USED.test(normalized)) {
-      const [usedAt, id, provider, tokenHash] = args as [number, string, string, string];
+      const [usedAt, id, provider, providerSessionId, tokenHash, now] = args as [
+        number,
+        string,
+        string,
+        string,
+        string,
+        number,
+      ];
       const row = this.rows.get(id);
       if (
         row &&
         row.provider === provider &&
+        row.provider_session_id === providerSessionId &&
         row.status === "building" &&
         row.callback_token_hash === tokenHash &&
+        row.callback_token_expires_at !== null &&
+        row.callback_token_expires_at >= now &&
         row.callback_token_used_at === null
       ) {
         row.callback_token_used_at = usedAt;
@@ -238,15 +256,45 @@ class FakeD1Database {
     }
 
     if (QUERY_PATTERNS.UPDATE_READY.test(normalized)) {
-      const [providerImageId, baseSha, buildDuration, id, provider] = args as [
+      const [
+        providerImageId,
+        baseSha,
+        buildDuration,
+        id,
+        provider,
+        owner,
+        name,
+        readyProvider,
+        branch,
+        currentCreatedAt,
+        sameCreatedAt,
+        tieId,
+      ] = args as [
         string,
         string,
         number,
         string,
         string,
+        string,
+        string,
+        string,
+        string,
+        number,
+        number,
+        string,
       ];
       const row = this.rows.get(id);
-      if (row && row.provider === provider && row.status === "building") {
+      const hasNewerReady = Array.from(this.rows.values()).some(
+        (candidate) =>
+          candidate.repo_owner === owner &&
+          candidate.repo_name === name &&
+          candidate.provider === readyProvider &&
+          candidate.base_branch === branch &&
+          candidate.status === "ready" &&
+          (candidate.created_at > currentCreatedAt ||
+            (candidate.created_at === sameCreatedAt && candidate.id > tieId))
+      );
+      if (row && row.provider === provider && row.status === "building" && !hasNewerReady) {
         row.status = "ready";
         row.provider_image_id = providerImageId;
         row.base_sha = baseSha;
@@ -479,9 +527,36 @@ describe("RepoImageStore", () => {
         })
       ).resolves.toBeNull();
     });
+
+    it("rejects expired callback tokens without marking them used", async () => {
+      const now = Date.now();
+      await store.registerBuild({
+        id: "img-vercel",
+        repoOwner: "acme",
+        repoName: "repo",
+        provider: "vercel",
+        baseBranch: "main",
+        callbackTokenHash: "token-hash",
+        callbackTokenExpiresAt: now - 1,
+      });
+      await store.bindProviderSession("img-vercel", "vercel", "vercel-session-1");
+
+      await expect(
+        store.consumeCallbackToken({
+          buildId: "img-vercel",
+          provider: "vercel",
+          providerSessionId: "vercel-session-1",
+          tokenHash: "token-hash",
+          now,
+        })
+      ).resolves.toBeNull();
+
+      const status = await store.getStatus("acme", "repo");
+      expect(status[0].callback_token_used_at).toBeNull();
+    });
   });
 
-  describe("markReady", () => {
+  describe("markBuildReady", () => {
     it("updates build to ready with provider image details", async () => {
       db.setImageBuildEnabled("acme", "repo", true);
       await store.registerBuild({
@@ -492,7 +567,7 @@ describe("RepoImageStore", () => {
         baseBranch: "main",
       });
 
-      const result = await store.markReady("img-1", "modal", "modal-img-abc", "sha123", 45.2);
+      const result = await store.markBuildReady("img-1", "modal", "modal-img-abc", "sha123", 45.2);
 
       expect(result.replacedImageId).toBeNull();
 
@@ -516,7 +591,7 @@ describe("RepoImageStore", () => {
       await expect(
         store.bindProviderSession("img-old", "modal", "modal-build-session-old")
       ).resolves.toBe(true);
-      await store.markReady("img-old", "modal", "modal-img-old", "sha-old", 30);
+      await store.markBuildReady("img-old", "modal", "modal-img-old", "sha-old", 30);
 
       vi.advanceTimersByTime(60000);
 
@@ -527,7 +602,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      const result = await store.markReady("img-new", "modal", "modal-img-new", "sha-new", 40);
+      const result = await store.markBuildReady("img-new", "modal", "modal-img-new", "sha-new", 40);
 
       expect(result.replacedImageId).toBe("modal-img-old");
       expect(result.replacedProviderSessionId).toBe("modal-build-session-old");
@@ -547,12 +622,12 @@ describe("RepoImageStore", () => {
         baseBranch: "main",
       });
 
-      const result = await store.markReady("img-1", "modal", "modal-img-1", "sha1", 20);
+      const result = await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 20);
       expect(result.replacedImageId).toBeNull();
     });
 
     it("returns null for unknown buildId", async () => {
-      const result = await store.markReady("nonexistent", "modal", "img", "sha", 10);
+      const result = await store.markBuildReady("nonexistent", "modal", "img", "sha", 10);
       expect(result.replacedImageId).toBeNull();
     });
 
@@ -565,7 +640,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markReady("img-modal", "modal", "modal-img", "sha-modal", 30);
+      await store.markBuildReady("img-modal", "modal", "modal-img", "sha-modal", 30);
 
       vi.advanceTimersByTime(1000);
 
@@ -576,7 +651,7 @@ describe("RepoImageStore", () => {
         provider: "vercel",
         baseBranch: "main",
       });
-      const result = await store.markReady(
+      const result = await store.markBuildReady(
         "img-vercel",
         "vercel",
         "vercel-snapshot",
@@ -591,9 +666,26 @@ describe("RepoImageStore", () => {
       expect(modalReady!.provider_image_id).toBe("modal-img");
       expect(vercelReady!.provider_image_id).toBe("vercel-snapshot");
     });
+
+    it("exposes markBuildReady as the workflow ready transition", async () => {
+      db.setImageBuildEnabled("acme", "repo", true);
+      await store.registerBuild({
+        id: "img-1",
+        repoOwner: "acme",
+        repoName: "repo",
+        provider: "modal",
+        baseBranch: "main",
+      });
+
+      const result = await store.markBuildReady("img-1", "modal", "modal-img-abc", "sha123", 45.2);
+
+      expect(result.updated).toBe(true);
+      const ready = await store.getLatestReady("acme", "repo", "modal");
+      expect(ready!.provider_image_id).toBe("modal-img-abc");
+    });
   });
 
-  describe("markFailed", () => {
+  describe("markBuildFailed", () => {
     it("sets error message and failed status", async () => {
       await store.registerBuild({
         id: "img-1",
@@ -603,11 +695,27 @@ describe("RepoImageStore", () => {
         baseBranch: "main",
       });
 
-      await store.markFailed("img-1", "modal", "npm install failed");
+      await store.markBuildFailed("img-1", "modal", "npm install failed");
 
       const status = await store.getStatus("acme", "repo");
       expect(status[0].status).toBe("failed");
       expect(status[0].error_message).toBe("npm install failed");
+    });
+
+    it("exposes markBuildFailed as the workflow failure transition", async () => {
+      await store.registerBuild({
+        id: "img-1",
+        repoOwner: "acme",
+        repoName: "repo",
+        provider: "modal",
+        baseBranch: "main",
+      });
+
+      await expect(store.markBuildFailed("img-1", "modal", "setup failed")).resolves.toBe(true);
+
+      const status = await store.getStatus("acme", "repo");
+      expect(status[0].status).toBe("failed");
+      expect(status[0].error_message).toBe("setup failed");
     });
   });
 
@@ -641,7 +749,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markReady("img-1", "modal", "modal-img-1", "sha1", 30);
+      await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30);
 
       const result = await store.getLatestReady("acme", "repo", "modal");
       expect(result).not.toBeNull();
@@ -658,7 +766,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markReady("img-1", "modal", "modal-img-1", "sha1", 30);
+      await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30);
 
       const result = await store.getLatestReady("acme", "repo", "modal");
       expect(result).toBeNull();
@@ -673,7 +781,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markReady("img-1", "modal", "modal-img-1", "sha1", 30);
+      await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30);
 
       const result = await store.getLatestReady("acme", "repo", "modal");
       expect(result).toBeNull();
@@ -688,7 +796,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markReady("img-1", "modal", "modal-img-1", "sha1", 30);
+      await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30);
 
       const result = await store.getLatestReady("ACME", "REPO", "modal");
       expect(result).not.toBeNull();
@@ -703,7 +811,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markReady("img-main", "modal", "modal-img-main", "sha-main", 30);
+      await store.markBuildReady("img-main", "modal", "modal-img-main", "sha-main", 30);
 
       vi.advanceTimersByTime(1000);
 
@@ -714,7 +822,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "develop",
       });
-      await store.markReady("img-dev", "modal", "modal-img-dev", "sha-dev", 25);
+      await store.markBuildReady("img-dev", "modal", "modal-img-dev", "sha-dev", 25);
 
       // Without branch filter: returns most recent (develop)
       const anyBranch = await store.getLatestReady("acme", "repo", "modal");
@@ -745,7 +853,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markReady("img-modal", "modal", "modal-img", "sha-modal", 30);
+      await store.markBuildReady("img-modal", "modal", "modal-img", "sha-modal", 30);
 
       vi.advanceTimersByTime(1000);
 
@@ -756,7 +864,7 @@ describe("RepoImageStore", () => {
         provider: "vercel",
         baseBranch: "main",
       });
-      await store.markReady("img-vercel", "vercel", "vercel-snapshot", "sha-vercel", 40);
+      await store.markBuildReady("img-vercel", "vercel", "vercel-snapshot", "sha-vercel", 40);
 
       const modalImage = await store.getLatestReady("acme", "repo", "modal");
       const vercelImage = await store.getLatestReady("acme", "repo", "vercel");
@@ -773,7 +881,7 @@ describe("RepoImageStore", () => {
         provider: "vercel",
         baseBranch: "main",
       });
-      await store.markReady("img-vercel", "vercel", "vercel-snapshot", "sha-vercel", 40);
+      await store.markBuildReady("img-vercel", "vercel", "vercel-snapshot", "sha-vercel", 40);
 
       vi.advanceTimersByTime(1000);
 
@@ -784,7 +892,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markReady("img-modal", "modal", "modal-img", "sha-modal", 30);
+      await store.markBuildReady("img-modal", "modal", "modal-img", "sha-modal", 30);
 
       const vercelImage = await store.getLatestReady("acme", "repo", "vercel");
       expect(vercelImage!.provider_image_id).toBe("vercel-snapshot");
@@ -801,7 +909,7 @@ describe("RepoImageStore", () => {
         provider: "vercel",
         baseBranch: "main",
       });
-      await store.markReady("img-vercel", "vercel", "vercel-snapshot", "sha-vercel", 40);
+      await store.markBuildReady("img-vercel", "vercel", "vercel-snapshot", "sha-vercel", 40);
 
       vi.advanceTimersByTime(1000);
 
@@ -812,7 +920,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markReady("img-modal", "modal", "modal-img", "sha-modal", 30);
+      await store.markBuildReady("img-modal", "modal", "modal-img", "sha-modal", 30);
 
       const latest = await store.getLatestReadyForAnyProvider("acme", "repo");
       expect(latest!.provider_image_id).toBe("modal-img");
@@ -820,7 +928,7 @@ describe("RepoImageStore", () => {
     });
   });
 
-  describe("markReady branch isolation", () => {
+  describe("markBuildReady branch isolation", () => {
     it("only replaces the previous ready image on the same branch", async () => {
       db.setImageBuildEnabled("acme", "repo", true);
       // Build and mark ready on main
@@ -831,7 +939,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markReady("img-main", "modal", "modal-img-main", "sha-main", 30);
+      await store.markBuildReady("img-main", "modal", "modal-img-main", "sha-main", 30);
 
       vi.advanceTimersByTime(1000);
 
@@ -843,7 +951,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "develop",
       });
-      const result = await store.markReady("img-dev", "modal", "modal-img-dev", "sha-dev", 25);
+      const result = await store.markBuildReady("img-dev", "modal", "modal-img-dev", "sha-dev", 25);
 
       // No replacement since no previous ready image on "develop"
       expect(result.replacedImageId).toBeNull();
@@ -955,7 +1063,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markReady("img-ready", "modal", "modal-img", "sha1", 30);
+      await store.markBuildReady("img-ready", "modal", "modal-img", "sha1", 30);
 
       vi.advanceTimersByTime(3600000);
 
@@ -973,7 +1081,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markFailed("img-1", "modal", "error");
+      await store.markBuildFailed("img-1", "modal", "error");
 
       vi.advanceTimersByTime(86400001); // just over 24 hours
 
@@ -992,7 +1100,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markFailed("img-1", "modal", "error");
+      await store.markBuildFailed("img-1", "modal", "error");
 
       vi.advanceTimersByTime(60000); // 1 minute
 

--- a/packages/control-plane/src/db/repo-images.test.ts
+++ b/packages/control-plane/src/db/repo-images.test.ts
@@ -33,14 +33,17 @@ const QUERY_PATTERNS = {
     /^SELECT id, provider_image_id, provider_session_id FROM repo_images WHERE repo_owner = \? AND repo_name = \? AND provider = \? AND base_branch = \? AND status = 'ready' AND id <> \? AND \( created_at < \? OR \(created_at = \? AND id < \?\) \) ORDER BY created_at DESC, id DESC$/,
   UPDATE_READY:
     /^UPDATE repo_images SET status = 'ready', provider_image_id = \?, base_sha = \?, build_duration_seconds = \? WHERE id = \? AND provider = \? AND status = 'building' AND NOT EXISTS \( SELECT 1 FROM repo_images newer WHERE newer\.repo_owner = \? AND newer\.repo_name = \? AND newer\.provider = \? AND newer\.base_branch = \? AND newer\.status = 'ready' AND \( newer\.created_at > \? OR \(newer\.created_at = \? AND newer\.id > \?\) \) \)$/,
-  DELETE_BY_ID: /^DELETE FROM repo_images WHERE id = \?$/,
+  UPDATE_SUPERSEDED:
+    /^UPDATE repo_images SET status = 'superseded' WHERE id = \? AND status = 'ready'$/,
+  DELETE_SUPERSEDED: /^DELETE FROM repo_images WHERE id = \? AND status = 'superseded'$/,
   UPDATE_FAILED:
     /^UPDATE repo_images SET status = 'failed', error_message = \? WHERE id = \? AND provider = \? AND status = 'building'$/,
   SELECT_LATEST_READY:
     /^SELECT ri\.\* FROM repo_images ri INNER JOIN repo_metadata rm ON ri\.repo_owner = rm\.repo_owner AND ri\.repo_name = rm\.repo_name WHERE ri\.repo_owner = \? AND ri\.repo_name = \?.*ORDER BY ri\.created_at DESC LIMIT 1$/,
   SELECT_STATUS:
-    /^SELECT \* FROM repo_images WHERE repo_owner = \? AND repo_name = \? ORDER BY created_at DESC LIMIT 10$/,
-  SELECT_ALL_STATUS: /^SELECT \* FROM repo_images ORDER BY created_at DESC LIMIT 100$/,
+    /^SELECT \* FROM repo_images WHERE repo_owner = \? AND repo_name = \? AND status <> 'superseded' ORDER BY created_at DESC LIMIT 10$/,
+  SELECT_ALL_STATUS:
+    /^SELECT \* FROM repo_images WHERE status <> 'superseded' ORDER BY created_at DESC LIMIT 100$/,
   UPDATE_STALE:
     /^UPDATE repo_images SET status = 'failed', error_message = \? WHERE status = 'building' AND created_at < \?$/,
   DELETE_OLD_FAILED: /^DELETE FROM repo_images WHERE status = 'failed' AND created_at < \?$/,
@@ -155,7 +158,11 @@ class FakeD1Database {
         }
       }
       return results
-        .sort((a, b) => b.created_at - a.created_at || b.id.localeCompare(a.id))
+        .sort((a, b) => {
+          if (b.created_at !== a.created_at) return b.created_at - a.created_at;
+          if (a.id === b.id) return 0;
+          return a.id < b.id ? 1 : -1;
+        })
         .map((row) => ({
           id: row.id,
           provider_image_id: row.provider_image_id,
@@ -167,7 +174,7 @@ class FakeD1Database {
       const [owner, name] = args as [string, string];
       const results: RepoImageRow[] = [];
       for (const row of this.rows.values()) {
-        if (row.repo_owner === owner && row.repo_name === name) {
+        if (row.repo_owner === owner && row.repo_name === name && row.status !== "superseded") {
           results.push({ ...row });
         }
       }
@@ -177,7 +184,9 @@ class FakeD1Database {
     if (QUERY_PATTERNS.SELECT_ALL_STATUS.test(normalized)) {
       const results: RepoImageRow[] = [];
       for (const row of this.rows.values()) {
-        results.push({ ...row });
+        if (row.status !== "superseded") {
+          results.push({ ...row });
+        }
       }
       return results.sort((a, b) => b.created_at - a.created_at).slice(0, 100);
     }
@@ -259,7 +268,7 @@ class FakeD1Database {
       const [
         providerImageId,
         baseSha,
-        buildDuration,
+        buildDurationSeconds,
         id,
         provider,
         owner,
@@ -298,16 +307,30 @@ class FakeD1Database {
         row.status = "ready";
         row.provider_image_id = providerImageId;
         row.base_sha = baseSha;
-        row.build_duration_seconds = buildDuration;
+        row.build_duration_seconds = buildDurationSeconds;
         return { meta: { changes: 1 } };
       }
       return { meta: { changes: 0 } };
     }
 
-    if (QUERY_PATTERNS.DELETE_BY_ID.test(normalized)) {
+    if (QUERY_PATTERNS.UPDATE_SUPERSEDED.test(normalized)) {
       const [id] = args as [string];
-      const deleted = this.rows.delete(id);
-      return { meta: { changes: deleted ? 1 : 0 } };
+      const row = this.rows.get(id);
+      if (row && row.status === "ready") {
+        row.status = "superseded";
+        return { meta: { changes: 1 } };
+      }
+      return { meta: { changes: 0 } };
+    }
+
+    if (QUERY_PATTERNS.DELETE_SUPERSEDED.test(normalized)) {
+      const [id] = args as [string];
+      const row = this.rows.get(id);
+      if (row?.status === "superseded") {
+        this.rows.delete(id);
+        return { meta: { changes: 1 } };
+      }
+      return { meta: { changes: 0 } };
     }
 
     if (QUERY_PATTERNS.UPDATE_FAILED.test(normalized)) {
@@ -567,7 +590,13 @@ describe("RepoImageStore", () => {
         baseBranch: "main",
       });
 
-      const result = await store.markBuildReady("img-1", "modal", "modal-img-abc", "sha123", 45.2);
+      const result = await store.markBuildReady(
+        "img-1",
+        "modal",
+        "modal-img-abc",
+        "sha123",
+        45_200
+      );
 
       expect(result.replacedImageId).toBeNull();
 
@@ -591,7 +620,7 @@ describe("RepoImageStore", () => {
       await expect(
         store.bindProviderSession("img-old", "modal", "modal-build-session-old")
       ).resolves.toBe(true);
-      await store.markBuildReady("img-old", "modal", "modal-img-old", "sha-old", 30);
+      await store.markBuildReady("img-old", "modal", "modal-img-old", "sha-old", 30_000);
 
       vi.advanceTimersByTime(60000);
 
@@ -602,7 +631,13 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      const result = await store.markBuildReady("img-new", "modal", "modal-img-new", "sha-new", 40);
+      const result = await store.markBuildReady(
+        "img-new",
+        "modal",
+        "modal-img-new",
+        "sha-new",
+        40_000
+      );
 
       expect(result.replacedImageId).toBe("modal-img-old");
       expect(result.replacedProviderSessionId).toBe("modal-build-session-old");
@@ -611,6 +646,12 @@ describe("RepoImageStore", () => {
       expect(ready).not.toBeNull();
       expect(ready!.id).toBe("img-new");
       expect(ready!.provider_image_id).toBe("modal-img-new");
+
+      const status = await store.getStatus("acme", "repo");
+      expect(status.map((image) => image.id)).not.toContain("img-old");
+
+      await expect(store.deleteSupersededImage("img-old")).resolves.toBe(true);
+      await expect(store.deleteSupersededImage("img-old")).resolves.toBe(false);
     });
 
     it("returns null replacedImageId when no previous ready image", async () => {
@@ -622,12 +663,12 @@ describe("RepoImageStore", () => {
         baseBranch: "main",
       });
 
-      const result = await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 20);
+      const result = await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 20_000);
       expect(result.replacedImageId).toBeNull();
     });
 
     it("returns null for unknown buildId", async () => {
-      const result = await store.markBuildReady("nonexistent", "modal", "img", "sha", 10);
+      const result = await store.markBuildReady("nonexistent", "modal", "img", "sha", 10_000);
       expect(result.replacedImageId).toBeNull();
     });
 
@@ -640,7 +681,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markBuildReady("img-modal", "modal", "modal-img", "sha-modal", 30);
+      await store.markBuildReady("img-modal", "modal", "modal-img", "sha-modal", 30_000);
 
       vi.advanceTimersByTime(1000);
 
@@ -656,7 +697,7 @@ describe("RepoImageStore", () => {
         "vercel",
         "vercel-snapshot",
         "sha-vercel",
-        40
+        40_000
       );
 
       expect(result.replacedImageId).toBeNull();
@@ -677,7 +718,13 @@ describe("RepoImageStore", () => {
         baseBranch: "main",
       });
 
-      const result = await store.markBuildReady("img-1", "modal", "modal-img-abc", "sha123", 45.2);
+      const result = await store.markBuildReady(
+        "img-1",
+        "modal",
+        "modal-img-abc",
+        "sha123",
+        45_200
+      );
 
       expect(result.updated).toBe(true);
       const ready = await store.getLatestReady("acme", "repo", "modal");
@@ -749,7 +796,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30);
+      await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30_000);
 
       const result = await store.getLatestReady("acme", "repo", "modal");
       expect(result).not.toBeNull();
@@ -766,7 +813,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30);
+      await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30_000);
 
       const result = await store.getLatestReady("acme", "repo", "modal");
       expect(result).toBeNull();
@@ -781,7 +828,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30);
+      await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30_000);
 
       const result = await store.getLatestReady("acme", "repo", "modal");
       expect(result).toBeNull();
@@ -796,7 +843,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30);
+      await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30_000);
 
       const result = await store.getLatestReady("ACME", "REPO", "modal");
       expect(result).not.toBeNull();
@@ -811,7 +858,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markBuildReady("img-main", "modal", "modal-img-main", "sha-main", 30);
+      await store.markBuildReady("img-main", "modal", "modal-img-main", "sha-main", 30_000);
 
       vi.advanceTimersByTime(1000);
 
@@ -822,7 +869,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "develop",
       });
-      await store.markBuildReady("img-dev", "modal", "modal-img-dev", "sha-dev", 25);
+      await store.markBuildReady("img-dev", "modal", "modal-img-dev", "sha-dev", 25_000);
 
       // Without branch filter: returns most recent (develop)
       const anyBranch = await store.getLatestReady("acme", "repo", "modal");
@@ -853,7 +900,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markBuildReady("img-modal", "modal", "modal-img", "sha-modal", 30);
+      await store.markBuildReady("img-modal", "modal", "modal-img", "sha-modal", 30_000);
 
       vi.advanceTimersByTime(1000);
 
@@ -864,7 +911,7 @@ describe("RepoImageStore", () => {
         provider: "vercel",
         baseBranch: "main",
       });
-      await store.markBuildReady("img-vercel", "vercel", "vercel-snapshot", "sha-vercel", 40);
+      await store.markBuildReady("img-vercel", "vercel", "vercel-snapshot", "sha-vercel", 40_000);
 
       const modalImage = await store.getLatestReady("acme", "repo", "modal");
       const vercelImage = await store.getLatestReady("acme", "repo", "vercel");
@@ -881,7 +928,7 @@ describe("RepoImageStore", () => {
         provider: "vercel",
         baseBranch: "main",
       });
-      await store.markBuildReady("img-vercel", "vercel", "vercel-snapshot", "sha-vercel", 40);
+      await store.markBuildReady("img-vercel", "vercel", "vercel-snapshot", "sha-vercel", 40_000);
 
       vi.advanceTimersByTime(1000);
 
@@ -892,7 +939,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markBuildReady("img-modal", "modal", "modal-img", "sha-modal", 30);
+      await store.markBuildReady("img-modal", "modal", "modal-img", "sha-modal", 30_000);
 
       const vercelImage = await store.getLatestReady("acme", "repo", "vercel");
       expect(vercelImage!.provider_image_id).toBe("vercel-snapshot");
@@ -909,7 +956,7 @@ describe("RepoImageStore", () => {
         provider: "vercel",
         baseBranch: "main",
       });
-      await store.markBuildReady("img-vercel", "vercel", "vercel-snapshot", "sha-vercel", 40);
+      await store.markBuildReady("img-vercel", "vercel", "vercel-snapshot", "sha-vercel", 40_000);
 
       vi.advanceTimersByTime(1000);
 
@@ -920,7 +967,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markBuildReady("img-modal", "modal", "modal-img", "sha-modal", 30);
+      await store.markBuildReady("img-modal", "modal", "modal-img", "sha-modal", 30_000);
 
       const latest = await store.getLatestReadyForAnyProvider("acme", "repo");
       expect(latest!.provider_image_id).toBe("modal-img");
@@ -939,7 +986,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markBuildReady("img-main", "modal", "modal-img-main", "sha-main", 30);
+      await store.markBuildReady("img-main", "modal", "modal-img-main", "sha-main", 30_000);
 
       vi.advanceTimersByTime(1000);
 
@@ -951,7 +998,13 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "develop",
       });
-      const result = await store.markBuildReady("img-dev", "modal", "modal-img-dev", "sha-dev", 25);
+      const result = await store.markBuildReady(
+        "img-dev",
+        "modal",
+        "modal-img-dev",
+        "sha-dev",
+        25_000
+      );
 
       // No replacement since no previous ready image on "develop"
       expect(result.replacedImageId).toBeNull();
@@ -1063,7 +1116,7 @@ describe("RepoImageStore", () => {
         provider: "modal",
         baseBranch: "main",
       });
-      await store.markBuildReady("img-ready", "modal", "modal-img", "sha1", 30);
+      await store.markBuildReady("img-ready", "modal", "modal-img", "sha1", 30_000);
 
       vi.advanceTimersByTime(3600000);
 

--- a/packages/control-plane/src/db/repo-images.ts
+++ b/packages/control-plane/src/db/repo-images.ts
@@ -36,6 +36,11 @@ export interface RepoImageCallbackBuild {
   provider_session_id: string | null;
 }
 
+export interface ReplacedRepoImage {
+  providerImageId: string;
+  providerSessionId: string | null;
+}
+
 export class RepoImageStore {
   constructor(private readonly db: D1Database) {}
 
@@ -90,7 +95,7 @@ export class RepoImageStore {
     buildId: string;
     provider: RepoImageProvider;
     tokenHash: string;
-    providerSessionId?: string;
+    providerSessionId: string;
     now: number;
   }): Promise<RepoImageCallbackBuild | null> {
     const build = await this.db
@@ -114,16 +119,26 @@ export class RepoImageStore {
     if (build.callback_token_used_at !== null) return null;
     if (build.callback_token_expires_at < params.now) return null;
     if (!timingSafeEqual(build.callback_token_hash, params.tokenHash)) return null;
-    if (params.providerSessionId && build.provider_session_id !== params.providerSessionId) {
+    if (build.provider_session_id !== params.providerSessionId) {
       return null;
     }
 
     const result = await this.db
       .prepare(
         `UPDATE repo_images SET callback_token_used_at = ?
-         WHERE id = ? AND provider = ? AND status = 'building' AND callback_token_hash = ? AND callback_token_used_at IS NULL`
+         WHERE id = ? AND provider = ? AND provider_session_id = ? AND status = 'building'
+           AND callback_token_hash = ?
+           AND callback_token_expires_at >= ?
+           AND callback_token_used_at IS NULL`
       )
-      .bind(params.now, params.buildId, params.provider, params.tokenHash)
+      .bind(
+        params.now,
+        params.buildId,
+        params.provider,
+        params.providerSessionId,
+        params.tokenHash,
+        params.now
+      )
       .run();
 
     if ((result.meta?.changes ?? 0) === 0) return null;
@@ -135,7 +150,7 @@ export class RepoImageStore {
     };
   }
 
-  async markReady(
+  async markBuildReady(
     buildId: string,
     provider: RepoImageProvider,
     providerImageId: string,
@@ -145,10 +160,11 @@ export class RepoImageStore {
     updated: boolean;
     replacedImageId: string | null;
     replacedProviderSessionId: string | null;
+    replacedImages: ReplacedRepoImage[];
   }> {
     const build = await this.db
       .prepare(
-        "SELECT repo_owner, repo_name, provider, base_branch FROM repo_images WHERE id = ? AND provider = ? AND status = 'building'"
+        "SELECT repo_owner, repo_name, provider, base_branch, created_at FROM repo_images WHERE id = ? AND provider = ? AND status = 'building'"
       )
       .bind(buildId, provider)
       .first<{
@@ -156,42 +172,114 @@ export class RepoImageStore {
         repo_name: string;
         provider: RepoImageProvider;
         base_branch: string;
+        created_at: number;
       }>();
 
     if (!build) {
-      return { updated: false, replacedImageId: null, replacedProviderSessionId: null };
+      return {
+        updated: false,
+        replacedImageId: null,
+        replacedProviderSessionId: null,
+        replacedImages: [],
+      };
     }
-
-    const oldReady = await this.db
-      .prepare(
-        "SELECT id, provider_image_id, provider_session_id FROM repo_images WHERE repo_owner = ? AND repo_name = ? AND provider = ? AND base_branch = ? AND status = 'ready'"
-      )
-      .bind(build.repo_owner, build.repo_name, build.provider, build.base_branch)
-      .first<{ id: string; provider_image_id: string; provider_session_id: string | null }>();
 
     const updateResult = await this.db
       .prepare(
-        "UPDATE repo_images SET status = 'ready', provider_image_id = ?, base_sha = ?, build_duration_seconds = ? WHERE id = ? AND provider = ? AND status = 'building'"
+        `UPDATE repo_images
+         SET status = 'ready', provider_image_id = ?, base_sha = ?, build_duration_seconds = ?
+         WHERE id = ? AND provider = ? AND status = 'building'
+           AND NOT EXISTS (
+             SELECT 1 FROM repo_images newer
+             WHERE newer.repo_owner = ?
+               AND newer.repo_name = ?
+               AND newer.provider = ?
+               AND newer.base_branch = ?
+               AND newer.status = 'ready'
+               AND (
+                 newer.created_at > ?
+                 OR (newer.created_at = ? AND newer.id > ?)
+               )
+           )`
       )
-      .bind(providerImageId, baseSha, buildDurationSeconds, buildId, provider)
+      .bind(
+        providerImageId,
+        baseSha,
+        buildDurationSeconds,
+        buildId,
+        provider,
+        build.repo_owner,
+        build.repo_name,
+        build.provider,
+        build.base_branch,
+        build.created_at,
+        build.created_at,
+        buildId
+      )
       .run();
 
     if ((updateResult.meta?.changes ?? 0) === 0) {
-      return { updated: false, replacedImageId: null, replacedProviderSessionId: null };
+      return {
+        updated: false,
+        replacedImageId: null,
+        replacedProviderSessionId: null,
+        replacedImages: [],
+      };
     }
 
-    if (oldReady) {
-      await this.db.prepare("DELETE FROM repo_images WHERE id = ?").bind(oldReady.id).run();
+    const superseded = await this.db
+      .prepare(
+        `SELECT id, provider_image_id, provider_session_id FROM repo_images
+         WHERE repo_owner = ?
+           AND repo_name = ?
+           AND provider = ?
+           AND base_branch = ?
+           AND status = 'ready'
+           AND id <> ?
+           AND (
+             created_at < ?
+             OR (created_at = ? AND id < ?)
+           )
+         ORDER BY created_at DESC, id DESC`
+      )
+      .bind(
+        build.repo_owner,
+        build.repo_name,
+        build.provider,
+        build.base_branch,
+        buildId,
+        build.created_at,
+        build.created_at,
+        buildId
+      )
+      .all<{ id: string; provider_image_id: string; provider_session_id: string | null }>();
+
+    const replacedImages = (superseded.results || []).map((image) => ({
+      providerImageId: image.provider_image_id,
+      providerSessionId: image.provider_session_id,
+    }));
+
+    if (superseded.results?.length) {
+      await this.db.batch(
+        superseded.results.map((image) =>
+          this.db.prepare("DELETE FROM repo_images WHERE id = ?").bind(image.id)
+        )
+      );
     }
 
     return {
       updated: true,
-      replacedImageId: oldReady?.provider_image_id ?? null,
-      replacedProviderSessionId: oldReady?.provider_session_id ?? null,
+      replacedImageId: replacedImages[0]?.providerImageId ?? null,
+      replacedProviderSessionId: replacedImages[0]?.providerSessionId ?? null,
+      replacedImages,
     };
   }
 
-  async markFailed(buildId: string, provider: RepoImageProvider, error: string): Promise<boolean> {
+  async markBuildFailed(
+    buildId: string,
+    provider: RepoImageProvider,
+    error: string
+  ): Promise<boolean> {
     const result = await this.db
       .prepare(
         "UPDATE repo_images SET status = 'failed', error_message = ? WHERE id = ? AND provider = ? AND status = 'building'"

--- a/packages/control-plane/src/db/repo-images.ts
+++ b/packages/control-plane/src/db/repo-images.ts
@@ -1,6 +1,8 @@
 import { timingSafeEqual } from "@open-inspect/shared";
+import type { ReplacedRepoImage } from "../repo-images/types";
 
 export type RepoImageProvider = "modal" | "vercel" | "opencomputer";
+const MS_PER_SECOND = 1000;
 
 export interface RepoImageBuild {
   id: string;
@@ -21,7 +23,7 @@ export interface RepoImage {
   provider_image_id: string;
   base_sha: string;
   base_branch: string;
-  status: "building" | "ready" | "failed";
+  status: "building" | "ready" | "failed" | "superseded";
   build_duration_seconds: number | null;
   error_message: string | null;
   callback_token_hash: string | null;
@@ -34,11 +36,6 @@ export interface RepoImageCallbackBuild {
   id: string;
   provider: RepoImageProvider;
   provider_session_id: string | null;
-}
-
-export interface ReplacedRepoImage {
-  providerImageId: string;
-  providerSessionId: string | null;
 }
 
 export class RepoImageStore {
@@ -155,7 +152,7 @@ export class RepoImageStore {
     provider: RepoImageProvider,
     providerImageId: string,
     baseSha: string,
-    buildDurationSeconds: number
+    buildDurationMs: number
   ): Promise<{
     updated: boolean;
     replacedImageId: string | null;
@@ -205,7 +202,7 @@ export class RepoImageStore {
       .bind(
         providerImageId,
         baseSha,
-        buildDurationSeconds,
+        buildDurationMs / MS_PER_SECOND,
         buildId,
         provider,
         build.repo_owner,
@@ -255,6 +252,7 @@ export class RepoImageStore {
       .all<{ id: string; provider_image_id: string; provider_session_id: string | null }>();
 
     const replacedImages = (superseded.results || []).map((image) => ({
+      repoImageId: image.id,
       providerImageId: image.provider_image_id,
       providerSessionId: image.provider_session_id,
     }));
@@ -262,7 +260,11 @@ export class RepoImageStore {
     if (superseded.results?.length) {
       await this.db.batch(
         superseded.results.map((image) =>
-          this.db.prepare("DELETE FROM repo_images WHERE id = ?").bind(image.id)
+          this.db
+            .prepare(
+              "UPDATE repo_images SET status = 'superseded' WHERE id = ? AND status = 'ready'"
+            )
+            .bind(image.id)
         )
       );
     }
@@ -273,6 +275,15 @@ export class RepoImageStore {
       replacedProviderSessionId: replacedImages[0]?.providerSessionId ?? null,
       replacedImages,
     };
+  }
+
+  async deleteSupersededImage(repoImageId: string): Promise<boolean> {
+    const result = await this.db
+      .prepare("DELETE FROM repo_images WHERE id = ? AND status = 'superseded'")
+      .bind(repoImageId)
+      .run();
+
+    return (result.meta?.changes ?? 0) > 0;
   }
 
   async markBuildFailed(
@@ -346,7 +357,7 @@ export class RepoImageStore {
   async getStatus(repoOwner: string, repoName: string): Promise<RepoImage[]> {
     const result = await this.db
       .prepare(
-        "SELECT * FROM repo_images WHERE repo_owner = ? AND repo_name = ? ORDER BY created_at DESC LIMIT 10"
+        "SELECT * FROM repo_images WHERE repo_owner = ? AND repo_name = ? AND status <> 'superseded' ORDER BY created_at DESC LIMIT 10"
       )
       .bind(repoOwner.toLowerCase(), repoName.toLowerCase())
       .all<RepoImage>();
@@ -356,7 +367,9 @@ export class RepoImageStore {
 
   async getAllStatus(): Promise<RepoImage[]> {
     const result = await this.db
-      .prepare("SELECT * FROM repo_images ORDER BY created_at DESC LIMIT 100")
+      .prepare(
+        "SELECT * FROM repo_images WHERE status <> 'superseded' ORDER BY created_at DESC LIMIT 100"
+      )
       .all<RepoImage>();
 
     return result.results || [];

--- a/packages/control-plane/src/repo-images/auth.ts
+++ b/packages/control-plane/src/repo-images/auth.ts
@@ -1,0 +1,20 @@
+import { computeHmacHex } from "@open-inspect/shared";
+import type { Env } from "../types";
+
+export const REPO_IMAGE_CALLBACK_TOKEN_TTL_MS = 2 * 60 * 60 * 1000;
+export const REPO_IMAGE_CALLBACK_TOKEN_PATTERN = /^[a-f0-9]{64}$/;
+
+export function generateRepoImageCallbackToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+export async function hashRepoImageCallbackToken(token: string, env: Env): Promise<string> {
+  if (!env.INTERNAL_CALLBACK_SECRET) {
+    throw new Error("INTERNAL_CALLBACK_SECRET is required for repo image callback hashing");
+  }
+  return computeHmacHex(`repo-image-callback:${token}`, env.INTERNAL_CALLBACK_SECRET);
+}

--- a/packages/control-plane/src/repo-images/backend-policy.ts
+++ b/packages/control-plane/src/repo-images/backend-policy.ts
@@ -1,0 +1,29 @@
+import type { RepoImageProvider } from "../db/repo-images";
+import { resolveSandboxBackendName, supportsRepoImageBackend } from "../sandbox/provider-name";
+import type { Env } from "../types";
+import type { RepoImageCallbackMode } from "./types";
+
+export function getRepoImagesUnsupportedMessage(env: Env): string | null {
+  if (supportsRepoImageBackend(env.SANDBOX_PROVIDER)) {
+    return null;
+  }
+
+  return "Repo images are only available when SANDBOX_PROVIDER=modal, vercel, or opencomputer";
+}
+
+export function resolveRepoImageBackend(value: string | undefined): RepoImageProvider | null {
+  const backend = resolveSandboxBackendName(value);
+  return backend === "modal" || backend === "vercel" || backend === "opencomputer" ? backend : null;
+}
+
+export function getRepoImageBackend(env: Env): RepoImageProvider {
+  const backend = resolveRepoImageBackend(env.SANDBOX_PROVIDER);
+  if (!backend) {
+    throw new Error(`Repo images are not supported for SANDBOX_PROVIDER=${env.SANDBOX_PROVIDER}`);
+  }
+  return backend;
+}
+
+export function getRepoImageCallbackMode(backend: RepoImageProvider): RepoImageCallbackMode {
+  return backend === "modal" ? "provider_image" : "provider_session";
+}

--- a/packages/control-plane/src/repo-images/backend-policy.ts
+++ b/packages/control-plane/src/repo-images/backend-policy.ts
@@ -1,10 +1,16 @@
 import type { RepoImageProvider } from "../db/repo-images";
-import { resolveSandboxBackendName, supportsRepoImageBackend } from "../sandbox/provider-name";
+import { resolveSandboxBackendName, type SandboxBackendName } from "../sandbox/provider-name";
 import type { Env } from "../types";
 import type { RepoImageCallbackMode } from "./types";
 
+const REPO_IMAGE_CALLBACK_MODES = {
+  modal: "provider_image",
+  vercel: "provider_session",
+  opencomputer: "provider_session",
+} satisfies Record<RepoImageProvider, RepoImageCallbackMode>;
+
 export function getRepoImagesUnsupportedMessage(env: Env): string | null {
-  if (supportsRepoImageBackend(env.SANDBOX_PROVIDER)) {
+  if (resolveRepoImageBackend(env.SANDBOX_PROVIDER)) {
     return null;
   }
 
@@ -13,7 +19,7 @@ export function getRepoImagesUnsupportedMessage(env: Env): string | null {
 
 export function resolveRepoImageBackend(value: string | undefined): RepoImageProvider | null {
   const backend = resolveSandboxBackendName(value);
-  return backend === "modal" || backend === "vercel" || backend === "opencomputer" ? backend : null;
+  return isRepoImageBackend(backend) ? backend : null;
 }
 
 export function getRepoImageBackend(env: Env): RepoImageProvider {
@@ -25,5 +31,9 @@ export function getRepoImageBackend(env: Env): RepoImageProvider {
 }
 
 export function getRepoImageCallbackMode(backend: RepoImageProvider): RepoImageCallbackMode {
-  return backend === "modal" ? "provider_image" : "provider_session";
+  return REPO_IMAGE_CALLBACK_MODES[backend];
+}
+
+function isRepoImageBackend(backend: SandboxBackendName): backend is RepoImageProvider {
+  return backend in REPO_IMAGE_CALLBACK_MODES;
 }

--- a/packages/control-plane/src/repo-images/modal-adapter.test.ts
+++ b/packages/control-plane/src/repo-images/modal-adapter.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { ModalRepoImageBuildProvider } from "../sandbox/providers/modal-provider";
 import { ModalRepoImageBuildAdapter } from "./modal-adapter";
-import type { RepoImageBuildPlan } from "./types";
+import type { ModalRepoImageBuildPlan } from "./types";
 
 function createProvider(): ModalRepoImageBuildProvider {
   return {
@@ -10,7 +10,7 @@ function createProvider(): ModalRepoImageBuildProvider {
   };
 }
 
-function createPlan(): RepoImageBuildPlan {
+function createPlan(): ModalRepoImageBuildPlan {
   return {
     provider: "modal",
     callbackMode: "provider_image",
@@ -19,7 +19,7 @@ function createPlan(): RepoImageBuildPlan {
     repoName: "repo",
     baseBranch: "develop",
     callbackUrl: "https://worker.test/repo-images/build-complete",
-    buildTimeoutSeconds: 1800,
+    buildTimeoutMs: 1_800_000,
     userEnvVars: { FOO: "bar" },
     correlation: {
       request_id: "request-1",
@@ -42,7 +42,7 @@ describe("ModalRepoImageBuildAdapter", () => {
       repoName: "repo",
       defaultBranch: "develop",
       callbackUrl: "https://worker.test/repo-images/build-complete",
-      buildTimeoutSeconds: 1800,
+      buildTimeoutMs: 1_800_000,
       userEnvVars: { FOO: "bar" },
       correlation: {
         request_id: "request-1",

--- a/packages/control-plane/src/repo-images/modal-adapter.test.ts
+++ b/packages/control-plane/src/repo-images/modal-adapter.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ModalRepoImageBuildProvider } from "../sandbox/providers/modal-provider";
+import { ModalRepoImageBuildAdapter } from "./modal-adapter";
+import type { RepoImageBuildPlan } from "./types";
+
+function createProvider(): ModalRepoImageBuildProvider {
+  return {
+    triggerRepoImageBuild: vi.fn(async () => ({ buildId: "build-1", status: "building" })),
+    deleteProviderImage: vi.fn(async () => undefined),
+  };
+}
+
+function createPlan(): RepoImageBuildPlan {
+  return {
+    provider: "modal",
+    callbackMode: "provider_image",
+    buildId: "build-1",
+    repoOwner: "acme",
+    repoName: "repo",
+    baseBranch: "develop",
+    callbackUrl: "https://worker.test/repo-images/build-complete",
+    buildTimeoutSeconds: 1800,
+    userEnvVars: { FOO: "bar" },
+    correlation: {
+      request_id: "request-1",
+      trace_id: "trace-1",
+    },
+  };
+}
+
+describe("ModalRepoImageBuildAdapter", () => {
+  it("starts builds through the Modal provider capability", async () => {
+    const provider = createProvider();
+    const adapter = new ModalRepoImageBuildAdapter(provider);
+    const plan = createPlan();
+
+    await adapter.startBuild(plan, { bindProviderSession: vi.fn() });
+
+    expect(provider.triggerRepoImageBuild).toHaveBeenCalledWith({
+      buildId: "build-1",
+      repoOwner: "acme",
+      repoName: "repo",
+      defaultBranch: "develop",
+      callbackUrl: "https://worker.test/repo-images/build-complete",
+      buildTimeoutSeconds: 1800,
+      userEnvVars: { FOO: "bar" },
+      correlation: {
+        request_id: "request-1",
+        trace_id: "trace-1",
+      },
+    });
+  });
+
+  it("deletes provider images through the Modal provider capability", async () => {
+    const provider = createProvider();
+    const adapter = new ModalRepoImageBuildAdapter(provider);
+    const correlation = { request_id: "request-1", trace_id: "trace-1" };
+
+    await adapter.deleteImage({
+      providerImageId: "modal-image-1",
+      correlation,
+    });
+
+    expect(provider.deleteProviderImage).toHaveBeenCalledWith("modal-image-1", correlation);
+  });
+});

--- a/packages/control-plane/src/repo-images/modal-adapter.ts
+++ b/packages/control-plane/src/repo-images/modal-adapter.ts
@@ -5,18 +5,16 @@ import type {
   FinalizeRepoImageBuildResult,
   ModalRepoImageBuildPlan,
   RepoImageBuildAdapter,
-  RepoImageBuildPlan,
   RepoImageBuildStartCallbacks,
 } from "./types";
 
-export class ModalRepoImageBuildAdapter implements RepoImageBuildAdapter {
+export class ModalRepoImageBuildAdapter implements RepoImageBuildAdapter<ModalRepoImageBuildPlan> {
   constructor(private readonly provider: ModalRepoImageBuildProvider) {}
 
   async startBuild(
-    plan: RepoImageBuildPlan,
+    modalPlan: ModalRepoImageBuildPlan,
     _callbacks: RepoImageBuildStartCallbacks
   ): Promise<void> {
-    const modalPlan = requireModalPlan(plan);
     await this.provider.triggerRepoImageBuild({
       repoOwner: modalPlan.repoOwner,
       repoName: modalPlan.repoName,
@@ -24,7 +22,7 @@ export class ModalRepoImageBuildAdapter implements RepoImageBuildAdapter {
       buildId: modalPlan.buildId,
       callbackUrl: modalPlan.callbackUrl,
       userEnvVars: modalPlan.userEnvVars,
-      buildTimeoutSeconds: modalPlan.buildTimeoutSeconds,
+      buildTimeoutMs: modalPlan.buildTimeoutMs,
       correlation: modalPlan.correlation,
     });
   }
@@ -41,11 +39,4 @@ export class ModalRepoImageBuildAdapter implements RepoImageBuildAdapter {
   async deleteImage(input: DeleteRepoImageInput): Promise<void> {
     await this.provider.deleteProviderImage(input.providerImageId, input.correlation);
   }
-}
-
-function requireModalPlan(plan: RepoImageBuildPlan): ModalRepoImageBuildPlan {
-  if (plan.provider !== "modal") {
-    throw new Error(`Modal adapter received ${plan.provider} repo image build plan`);
-  }
-  return plan;
 }

--- a/packages/control-plane/src/repo-images/modal-adapter.ts
+++ b/packages/control-plane/src/repo-images/modal-adapter.ts
@@ -1,0 +1,51 @@
+import type { ModalRepoImageBuildProvider } from "../sandbox/providers/modal-provider";
+import type {
+  DeleteRepoImageInput,
+  FinalizeRepoImageBuildInput,
+  FinalizeRepoImageBuildResult,
+  ModalRepoImageBuildPlan,
+  RepoImageBuildAdapter,
+  RepoImageBuildPlan,
+  RepoImageBuildStartCallbacks,
+} from "./types";
+
+export class ModalRepoImageBuildAdapter implements RepoImageBuildAdapter {
+  constructor(private readonly provider: ModalRepoImageBuildProvider) {}
+
+  async startBuild(
+    plan: RepoImageBuildPlan,
+    _callbacks: RepoImageBuildStartCallbacks
+  ): Promise<void> {
+    const modalPlan = requireModalPlan(plan);
+    await this.provider.triggerRepoImageBuild({
+      repoOwner: modalPlan.repoOwner,
+      repoName: modalPlan.repoName,
+      defaultBranch: modalPlan.baseBranch,
+      buildId: modalPlan.buildId,
+      callbackUrl: modalPlan.callbackUrl,
+      userEnvVars: modalPlan.userEnvVars,
+      buildTimeoutSeconds: modalPlan.buildTimeoutSeconds,
+      correlation: modalPlan.correlation,
+    });
+  }
+
+  async finalizeSuccessfulBuild(
+    input: FinalizeRepoImageBuildInput
+  ): Promise<FinalizeRepoImageBuildResult> {
+    if (input.kind !== "provider_image") {
+      throw new Error("provider_image_id is required for Modal repo image completion");
+    }
+    return { providerImageId: input.providerImageId };
+  }
+
+  async deleteImage(input: DeleteRepoImageInput): Promise<void> {
+    await this.provider.deleteProviderImage(input.providerImageId, input.correlation);
+  }
+}
+
+function requireModalPlan(plan: RepoImageBuildPlan): ModalRepoImageBuildPlan {
+  if (plan.provider !== "modal") {
+    throw new Error(`Modal adapter received ${plan.provider} repo image build plan`);
+  }
+  return plan;
+}

--- a/packages/control-plane/src/repo-images/opencomputer-adapter.ts
+++ b/packages/control-plane/src/repo-images/opencomputer-adapter.ts
@@ -1,0 +1,103 @@
+import { createLogger } from "../logger";
+import type { OpenComputerSandboxProvider } from "../sandbox/providers/opencomputer-provider";
+import type {
+  DeleteRepoImageInput,
+  FailedRepoImageBuildInput,
+  FinalizeRepoImageBuildInput,
+  FinalizeRepoImageBuildResult,
+  OpenComputerRepoImageBuildPlan,
+  RepoImageBuildAdapter,
+  RepoImageBuildPlan,
+  RepoImageBuildStartCallbacks,
+} from "./types";
+
+const logger = createLogger("repo-images:opencomputer-adapter");
+
+export class OpenComputerRepoImageBuildAdapter implements RepoImageBuildAdapter {
+  constructor(private readonly provider: OpenComputerSandboxProvider) {}
+
+  async startBuild(
+    plan: RepoImageBuildPlan,
+    callbacks: RepoImageBuildStartCallbacks
+  ): Promise<void> {
+    const openComputerPlan = requireOpenComputerPlan(plan);
+
+    await this.provider.triggerRepoImageBuild({
+      repoOwner: openComputerPlan.repoOwner,
+      repoName: openComputerPlan.repoName,
+      defaultBranch: openComputerPlan.baseBranch,
+      buildId: openComputerPlan.buildId,
+      callbackUrl: openComputerPlan.callbackUrl,
+      callbackToken: openComputerPlan.callbackToken,
+      userEnvVars: openComputerPlan.userEnvVars,
+      buildTimeoutSeconds: openComputerPlan.buildTimeoutSeconds,
+      onProviderSessionCreated: callbacks.bindProviderSession,
+    });
+  }
+
+  async finalizeSuccessfulBuild(
+    input: FinalizeRepoImageBuildInput
+  ): Promise<FinalizeRepoImageBuildResult> {
+    if (input.kind !== "provider_session") {
+      throw new Error("provider_session_id is required for OpenComputer repo image completion");
+    }
+
+    try {
+      const snapshot = await this.provider.takeSnapshot({
+        providerObjectId: input.providerSessionId,
+        sessionId: input.buildId,
+        reason: "repo_image_build",
+        correlation: {
+          ...input.correlation,
+          sandbox_id: input.providerSessionId,
+        },
+      });
+
+      if (!snapshot.success || !snapshot.imageId) {
+        throw new Error(snapshot.error || "OpenComputer checkpoint did not return an image id");
+      }
+
+      return {
+        providerImageId: snapshot.imageId,
+        providerSessionId: input.providerSessionId,
+      };
+    } finally {
+      await this.deleteBuildSandbox(input.buildId, input.providerSessionId, input.correlation);
+    }
+  }
+
+  async cleanupFailedBuild(input: FailedRepoImageBuildInput): Promise<void> {
+    if (input.kind !== "provider_session") return;
+    await this.deleteBuildSandbox(input.buildId, input.providerSessionId, input.correlation);
+  }
+
+  async deleteImage(input: DeleteRepoImageInput): Promise<void> {
+    await this.provider.deleteProviderImage(input.providerImageId, input.providerSessionId);
+  }
+
+  private async deleteBuildSandbox(
+    buildId: string,
+    providerSessionId: string | null | undefined,
+    correlation: FinalizeRepoImageBuildInput["correlation"]
+  ): Promise<void> {
+    if (!providerSessionId) return;
+    try {
+      await this.provider.deleteSandbox(providerSessionId);
+    } catch (error) {
+      logger.warn("repo_image.opencomputer_build_cleanup_failed", {
+        build_id: buildId,
+        provider_session_id: providerSessionId,
+        error: error instanceof Error ? error.message : String(error),
+        request_id: correlation.request_id,
+        trace_id: correlation.trace_id,
+      });
+    }
+  }
+}
+
+function requireOpenComputerPlan(plan: RepoImageBuildPlan): OpenComputerRepoImageBuildPlan {
+  if (plan.provider !== "opencomputer") {
+    throw new Error(`OpenComputer adapter received ${plan.provider} repo image build plan`);
+  }
+  return plan;
+}

--- a/packages/control-plane/src/repo-images/opencomputer-adapter.ts
+++ b/packages/control-plane/src/repo-images/opencomputer-adapter.ts
@@ -1,27 +1,26 @@
 import { createLogger } from "../logger";
 import type { OpenComputerSandboxProvider } from "../sandbox/providers/opencomputer-provider";
 import type {
+  CleanupCompletedProviderSessionBuildInput,
   DeleteRepoImageInput,
   FailedRepoImageBuildInput,
   FinalizeRepoImageBuildInput,
   FinalizeRepoImageBuildResult,
   OpenComputerRepoImageBuildPlan,
   RepoImageBuildAdapter,
-  RepoImageBuildPlan,
   RepoImageBuildStartCallbacks,
 } from "./types";
 
 const logger = createLogger("repo-images:opencomputer-adapter");
+const MS_PER_SECOND = 1000;
 
-export class OpenComputerRepoImageBuildAdapter implements RepoImageBuildAdapter {
+export class OpenComputerRepoImageBuildAdapter implements RepoImageBuildAdapter<OpenComputerRepoImageBuildPlan> {
   constructor(private readonly provider: OpenComputerSandboxProvider) {}
 
   async startBuild(
-    plan: RepoImageBuildPlan,
+    openComputerPlan: OpenComputerRepoImageBuildPlan,
     callbacks: RepoImageBuildStartCallbacks
   ): Promise<void> {
-    const openComputerPlan = requireOpenComputerPlan(plan);
-
     await this.provider.triggerRepoImageBuild({
       repoOwner: openComputerPlan.repoOwner,
       repoName: openComputerPlan.repoName,
@@ -30,7 +29,7 @@ export class OpenComputerRepoImageBuildAdapter implements RepoImageBuildAdapter 
       callbackUrl: openComputerPlan.callbackUrl,
       callbackToken: openComputerPlan.callbackToken,
       userEnvVars: openComputerPlan.userEnvVars,
-      buildTimeoutSeconds: openComputerPlan.buildTimeoutSeconds,
+      buildTimeoutSeconds: Math.ceil(openComputerPlan.buildTimeoutMs / MS_PER_SECOND),
       onProviderSessionCreated: callbacks.bindProviderSession,
     });
   }
@@ -42,28 +41,28 @@ export class OpenComputerRepoImageBuildAdapter implements RepoImageBuildAdapter 
       throw new Error("provider_session_id is required for OpenComputer repo image completion");
     }
 
-    try {
-      const snapshot = await this.provider.takeSnapshot({
-        providerObjectId: input.providerSessionId,
-        sessionId: input.buildId,
-        reason: "repo_image_build",
-        correlation: {
-          ...input.correlation,
-          sandbox_id: input.providerSessionId,
-        },
-      });
+    const snapshot = await this.provider.takeSnapshot({
+      providerObjectId: input.providerSessionId,
+      sessionId: input.buildId,
+      reason: "repo_image_build",
+      correlation: {
+        ...input.correlation,
+        sandbox_id: input.providerSessionId,
+      },
+    });
 
-      if (!snapshot.success || !snapshot.imageId) {
-        throw new Error(snapshot.error || "OpenComputer checkpoint did not return an image id");
-      }
-
-      return {
-        providerImageId: snapshot.imageId,
-        providerSessionId: input.providerSessionId,
-      };
-    } finally {
-      await this.deleteBuildSandbox(input.buildId, input.providerSessionId, input.correlation);
+    if (!snapshot.success || !snapshot.imageId) {
+      throw new Error(snapshot.error || "OpenComputer checkpoint did not return an image id");
     }
+
+    return {
+      providerImageId: snapshot.imageId,
+      providerSessionId: input.providerSessionId,
+    };
+  }
+
+  async cleanupCompletedBuild(input: CleanupCompletedProviderSessionBuildInput): Promise<void> {
+    await this.deleteBuildSandbox(input.buildId, input.providerSessionId, input.correlation);
   }
 
   async cleanupFailedBuild(input: FailedRepoImageBuildInput): Promise<void> {
@@ -93,11 +92,4 @@ export class OpenComputerRepoImageBuildAdapter implements RepoImageBuildAdapter 
       });
     }
   }
-}
-
-function requireOpenComputerPlan(plan: RepoImageBuildPlan): OpenComputerRepoImageBuildPlan {
-  if (plan.provider !== "opencomputer") {
-    throw new Error(`OpenComputer adapter received ${plan.provider} repo image build plan`);
-  }
-  return plan;
 }

--- a/packages/control-plane/src/repo-images/planner.ts
+++ b/packages/control-plane/src/repo-images/planner.ts
@@ -13,23 +13,30 @@ import {
   REPO_IMAGE_CALLBACK_TOKEN_TTL_MS,
 } from "./auth";
 import { getRepoImageCallbackMode } from "./backend-policy";
-import type { RepoImageBuildPlan, VercelCloneAuth } from "./types";
+import type { PlannedRepoImageBuild, VercelCloneAuth } from "./types";
 
 const logger = createLogger("repo-images:planner");
+const MS_PER_SECOND = 1000;
 
 type PlannedCallbackAuth =
   | { kind: "none" }
   | { kind: "bearer_token"; token: string; tokenHash: string; expiresAt: number };
 
+interface BaseRepoImageBuildPlanInput {
+  buildId: string;
+  repoOwner: string;
+  repoName: string;
+  baseBranch: string;
+  callbackUrl: string;
+  buildTimeoutMs: number;
+  userEnvVars?: Record<string, string>;
+  correlation: CorrelationContext;
+}
+
 export type RepoImageBuildPlanningResult =
   | {
       type: "ok";
-      plan: RepoImageBuildPlan;
-      registration: {
-        baseBranch: string;
-        callbackTokenHash?: string;
-        callbackTokenExpiresAt?: number;
-      };
+      build: PlannedRepoImageBuild;
     }
   | { type: "repo_not_installed"; message: string }
   | { type: "failed"; message: string };
@@ -71,28 +78,17 @@ export class RepoImageBuildPlanner {
       repoName: params.repoName,
       baseBranch: resolved.defaultBranch,
       callbackUrl: params.callbackUrl,
-      buildTimeoutSeconds: resolveBuildTimeoutSeconds(sandboxSettings),
+      buildTimeoutMs: resolveBuildTimeoutSeconds(sandboxSettings) * MS_PER_SECOND,
       userEnvVars,
       correlation: {
         trace_id: params.correlation.trace_id,
         request_id: params.correlation.request_id,
       },
     };
-    const plan = this.createPlanForBackend(basePlan, callbackAuth, cloneAuth);
 
     return {
       type: "ok",
-      plan,
-      registration:
-        callbackAuth.kind === "bearer_token"
-          ? {
-              baseBranch: resolved.defaultBranch,
-              callbackTokenHash: callbackAuth.tokenHash,
-              callbackTokenExpiresAt: callbackAuth.expiresAt,
-            }
-          : {
-              baseBranch: resolved.defaultBranch,
-            },
+      build: this.createPlannedBuildForBackend(basePlan, callbackAuth, cloneAuth),
     };
   }
 
@@ -147,16 +143,19 @@ export class RepoImageBuildPlanner {
     };
   }
 
-  private createPlanForBackend(
-    basePlan: Omit<RepoImageBuildPlan, "provider" | "callbackMode" | "callbackToken" | "cloneAuth">,
+  private createPlannedBuildForBackend(
+    basePlan: BaseRepoImageBuildPlanInput,
     callbackAuth: PlannedCallbackAuth,
     cloneAuth: VercelCloneAuth
-  ): RepoImageBuildPlan {
+  ): PlannedRepoImageBuild {
     if (this.backend === "modal") {
       return {
-        ...basePlan,
-        provider: "modal",
-        callbackMode: "provider_image",
+        plan: {
+          ...basePlan,
+          provider: "modal",
+          callbackMode: "provider_image",
+        },
+        callbackAuth: { type: "none" },
       };
     }
 
@@ -166,19 +165,33 @@ export class RepoImageBuildPlanner {
 
     if (this.backend === "vercel") {
       return {
-        ...basePlan,
-        provider: "vercel",
-        callbackMode: "provider_session",
-        callbackToken: callbackAuth.token,
-        cloneAuth,
+        plan: {
+          ...basePlan,
+          provider: "vercel",
+          callbackMode: "provider_session",
+          callbackToken: callbackAuth.token,
+          cloneAuth,
+        },
+        callbackAuth: {
+          type: "bearer_token",
+          tokenHash: callbackAuth.tokenHash,
+          expiresAt: callbackAuth.expiresAt,
+        },
       };
     }
 
     return {
-      ...basePlan,
-      provider: "opencomputer",
-      callbackMode: "provider_session",
-      callbackToken: callbackAuth.token,
+      plan: {
+        ...basePlan,
+        provider: "opencomputer",
+        callbackMode: "provider_session",
+        callbackToken: callbackAuth.token,
+      },
+      callbackAuth: {
+        type: "bearer_token",
+        tokenHash: callbackAuth.tokenHash,
+        expiresAt: callbackAuth.expiresAt,
+      },
     };
   }
 

--- a/packages/control-plane/src/repo-images/planner.ts
+++ b/packages/control-plane/src/repo-images/planner.ts
@@ -1,0 +1,256 @@
+import { resolveBuildTimeoutSeconds } from "@open-inspect/shared";
+import { GlobalSecretsStore } from "../db/global-secrets";
+import type { RepoImageProvider } from "../db/repo-images";
+import { RepoSecretsStore } from "../db/repo-secrets";
+import { mergeSecrets } from "../db/secrets-validation";
+import { createLogger, type CorrelationContext } from "../logger";
+import { resolveSandboxSettings } from "../session/integration-settings-resolution";
+import { createSourceControlProviderFromEnv, SourceControlProviderError } from "../source-control";
+import type { Env } from "../types";
+import {
+  generateRepoImageCallbackToken,
+  hashRepoImageCallbackToken,
+  REPO_IMAGE_CALLBACK_TOKEN_TTL_MS,
+} from "./auth";
+import { getRepoImageCallbackMode } from "./backend-policy";
+import type { RepoImageBuildPlan, VercelCloneAuth } from "./types";
+
+const logger = createLogger("repo-images:planner");
+
+type PlannedCallbackAuth =
+  | { kind: "none" }
+  | { kind: "bearer_token"; token: string; tokenHash: string; expiresAt: number };
+
+export type RepoImageBuildPlanningResult =
+  | {
+      type: "ok";
+      plan: RepoImageBuildPlan;
+      registration: {
+        baseBranch: string;
+        callbackTokenHash?: string;
+        callbackTokenExpiresAt?: number;
+      };
+    }
+  | { type: "repo_not_installed"; message: string }
+  | { type: "failed"; message: string };
+
+export class RepoImageBuildPlanner {
+  constructor(
+    private readonly env: Env,
+    private readonly backend: RepoImageProvider
+  ) {}
+
+  async planBuild(params: {
+    buildId: string;
+    repoOwner: string;
+    repoName: string;
+    now: number;
+    callbackUrl: string;
+    correlation: CorrelationContext;
+  }): Promise<RepoImageBuildPlanningResult> {
+    const resolved = await this.resolveRepo(params.repoOwner, params.repoName, params.correlation);
+    if (resolved.type !== "ok") return resolved;
+
+    const [callbackAuth, sandboxSettings, userEnvVars, cloneAuth] = await Promise.all([
+      this.createCallbackAuth(params.now),
+      resolveSandboxSettings(this.env.DB, params.repoOwner, params.repoName),
+      this.loadUserEnvVars({
+        repoOwner: params.repoOwner,
+        repoName: params.repoName,
+        repoId: resolved.repoId,
+      }),
+      this.resolveVercelCloneAuth({
+        repoOwner: params.repoOwner,
+        repoName: params.repoName,
+      }),
+    ]);
+
+    const basePlan = {
+      buildId: params.buildId,
+      repoOwner: params.repoOwner,
+      repoName: params.repoName,
+      baseBranch: resolved.defaultBranch,
+      callbackUrl: params.callbackUrl,
+      buildTimeoutSeconds: resolveBuildTimeoutSeconds(sandboxSettings),
+      userEnvVars,
+      correlation: {
+        trace_id: params.correlation.trace_id,
+        request_id: params.correlation.request_id,
+      },
+    };
+    const plan = this.createPlanForBackend(basePlan, callbackAuth, cloneAuth);
+
+    return {
+      type: "ok",
+      plan,
+      registration:
+        callbackAuth.kind === "bearer_token"
+          ? {
+              baseBranch: resolved.defaultBranch,
+              callbackTokenHash: callbackAuth.tokenHash,
+              callbackTokenExpiresAt: callbackAuth.expiresAt,
+            }
+          : {
+              baseBranch: resolved.defaultBranch,
+            },
+    };
+  }
+
+  private async resolveRepo(
+    owner: string,
+    name: string,
+    correlation: CorrelationContext
+  ): Promise<
+    | { type: "ok"; repoId: number; defaultBranch: string }
+    | { type: "repo_not_installed"; message: string }
+    | { type: "failed"; message: string }
+  > {
+    try {
+      const provider = createSourceControlProviderFromEnv(this.env);
+      const resolved = await provider.checkRepositoryAccess({ owner, name });
+      if (!resolved) {
+        return {
+          type: "repo_not_installed",
+          message: "Repository is not installed for the GitHub App",
+        };
+      }
+      return { type: "ok", repoId: resolved.repoId, defaultBranch: resolved.defaultBranch };
+    } catch (e) {
+      const message = errorMessage(e);
+      logger.error("Failed to resolve repository", {
+        error: message,
+        repo_owner: owner,
+        repo_name: name,
+        request_id: correlation.request_id,
+        trace_id: correlation.trace_id,
+      });
+      const isConfigError =
+        e instanceof SourceControlProviderError && e.errorType === "permanent" && !e.httpStatus;
+      return {
+        type: "failed",
+        message: isConfigError ? message : "Failed to resolve repository",
+      };
+    }
+  }
+
+  private async createCallbackAuth(now: number): Promise<PlannedCallbackAuth> {
+    if (getRepoImageCallbackMode(this.backend) !== "provider_session") {
+      return { kind: "none" };
+    }
+
+    const token = generateRepoImageCallbackToken();
+    return {
+      kind: "bearer_token",
+      token,
+      tokenHash: await hashRepoImageCallbackToken(token, this.env),
+      expiresAt: now + REPO_IMAGE_CALLBACK_TOKEN_TTL_MS,
+    };
+  }
+
+  private createPlanForBackend(
+    basePlan: Omit<RepoImageBuildPlan, "provider" | "callbackMode" | "callbackToken" | "cloneAuth">,
+    callbackAuth: PlannedCallbackAuth,
+    cloneAuth: VercelCloneAuth
+  ): RepoImageBuildPlan {
+    if (this.backend === "modal") {
+      return {
+        ...basePlan,
+        provider: "modal",
+        callbackMode: "provider_image",
+      };
+    }
+
+    if (callbackAuth.kind !== "bearer_token") {
+      throw new Error(`${this.backend} repo image builds require callback token auth`);
+    }
+
+    if (this.backend === "vercel") {
+      return {
+        ...basePlan,
+        provider: "vercel",
+        callbackMode: "provider_session",
+        callbackToken: callbackAuth.token,
+        cloneAuth,
+      };
+    }
+
+    return {
+      ...basePlan,
+      provider: "opencomputer",
+      callbackMode: "provider_session",
+      callbackToken: callbackAuth.token,
+    };
+  }
+
+  private async loadUserEnvVars(params: {
+    repoOwner: string;
+    repoName: string;
+    repoId: number;
+  }): Promise<Record<string, string> | undefined> {
+    if (!this.env.REPO_SECRETS_ENCRYPTION_KEY) return undefined;
+
+    let globalSecrets: Record<string, string> = {};
+    try {
+      const globalStore = new GlobalSecretsStore(this.env.DB, this.env.REPO_SECRETS_ENCRYPTION_KEY);
+      globalSecrets = await globalStore.getDecryptedSecrets();
+    } catch (e) {
+      logger.warn("repo_image.global_secrets_failed", {
+        error: errorMessage(e),
+        repo_owner: params.repoOwner,
+        repo_name: params.repoName,
+      });
+    }
+
+    let repoSecrets: Record<string, string> = {};
+    try {
+      const repoStore = new RepoSecretsStore(this.env.DB, this.env.REPO_SECRETS_ENCRYPTION_KEY);
+      repoSecrets = await repoStore.getDecryptedSecrets(params.repoId);
+    } catch (e) {
+      logger.warn("repo_image.repo_secrets_failed", {
+        error: errorMessage(e),
+        repo_owner: params.repoOwner,
+        repo_name: params.repoName,
+      });
+    }
+
+    const { merged, totalBytes, exceedsLimit } = mergeSecrets(globalSecrets, repoSecrets);
+    if (Object.keys(merged).length === 0) return undefined;
+
+    const logLevel = exceedsLimit ? "warn" : "info";
+    logger[logLevel]("repo_image.secrets_loaded", {
+      global_count: Object.keys(globalSecrets).length,
+      repo_count: Object.keys(repoSecrets).length,
+      merged_count: Object.keys(merged).length,
+      payload_bytes: totalBytes,
+      exceeds_limit: exceedsLimit,
+      repo_owner: params.repoOwner,
+      repo_name: params.repoName,
+    });
+
+    return merged;
+  }
+
+  private async resolveVercelCloneAuth(params: {
+    repoOwner: string;
+    repoName: string;
+  }): Promise<VercelCloneAuth> {
+    if (this.backend !== "vercel") return { type: "unavailable" };
+
+    try {
+      const provider = createSourceControlProviderFromEnv(this.env);
+      const auth = await provider.generateCredentialHelperAuth();
+      return { type: "credential_helper", token: auth.password };
+    } catch (e) {
+      logger.warn("repo_image.clone_token_failed", {
+        error: errorMessage(e),
+        repo_owner: params.repoOwner,
+        repo_name: params.repoName,
+      });
+      return { type: "unavailable" };
+    }
+  }
+}
+
+function errorMessage(errorValue: unknown): string {
+  return errorValue instanceof Error ? errorValue.message : String(errorValue);
+}

--- a/packages/control-plane/src/repo-images/provider-factory.ts
+++ b/packages/control-plane/src/repo-images/provider-factory.ts
@@ -1,9 +1,11 @@
 import { createSandboxProviderFromEnv } from "../sandbox/provider-factory";
+import type { RepoImageProvider } from "../db/repo-images";
 import type { Env } from "../types";
 import { ModalRepoImageBuildAdapter } from "./modal-adapter";
 import { OpenComputerRepoImageBuildAdapter } from "./opencomputer-adapter";
 import { VercelRepoImageBuildAdapter } from "./vercel-adapter";
 import type {
+  AnyRepoImageBuildAdapter,
   ModalRepoImageBuildPlan,
   OpenComputerRepoImageBuildPlan,
   RepoImageBuildAdapter,
@@ -11,17 +13,32 @@ import type {
 } from "./types";
 
 export interface RepoImageBuildAdapterFactory {
-  createModal(): RepoImageBuildAdapter<ModalRepoImageBuildPlan>;
-  createVercel(): RepoImageBuildAdapter<VercelRepoImageBuildPlan>;
-  createOpenComputer(): RepoImageBuildAdapter<OpenComputerRepoImageBuildPlan>;
+  create(provider: "modal"): RepoImageBuildAdapter<ModalRepoImageBuildPlan>;
+  create(provider: "vercel"): RepoImageBuildAdapter<VercelRepoImageBuildPlan>;
+  create(provider: "opencomputer"): RepoImageBuildAdapter<OpenComputerRepoImageBuildPlan>;
+  create(provider: RepoImageProvider): AnyRepoImageBuildAdapter;
 }
 
 export function createRepoImageBuildAdapterFactory(env: Env): RepoImageBuildAdapterFactory {
-  return {
-    createModal: () => new ModalRepoImageBuildAdapter(createSandboxProviderFromEnv(env, "modal")),
-    createVercel: () =>
-      new VercelRepoImageBuildAdapter(createSandboxProviderFromEnv(env, "vercel")),
-    createOpenComputer: () =>
-      new OpenComputerRepoImageBuildAdapter(createSandboxProviderFromEnv(env, "opencomputer")),
-  };
+  return new EnvRepoImageBuildAdapterFactory(env);
+}
+
+class EnvRepoImageBuildAdapterFactory implements RepoImageBuildAdapterFactory {
+  constructor(private readonly env: Env) {}
+
+  create(provider: "modal"): RepoImageBuildAdapter<ModalRepoImageBuildPlan>;
+  create(provider: "vercel"): RepoImageBuildAdapter<VercelRepoImageBuildPlan>;
+  create(provider: "opencomputer"): RepoImageBuildAdapter<OpenComputerRepoImageBuildPlan>;
+  create(provider: RepoImageProvider): AnyRepoImageBuildAdapter {
+    switch (provider) {
+      case "modal":
+        return new ModalRepoImageBuildAdapter(createSandboxProviderFromEnv(this.env, "modal"));
+      case "vercel":
+        return new VercelRepoImageBuildAdapter(createSandboxProviderFromEnv(this.env, "vercel"));
+      case "opencomputer":
+        return new OpenComputerRepoImageBuildAdapter(
+          createSandboxProviderFromEnv(this.env, "opencomputer")
+        );
+    }
+  }
 }

--- a/packages/control-plane/src/repo-images/provider-factory.ts
+++ b/packages/control-plane/src/repo-images/provider-factory.ts
@@ -1,0 +1,25 @@
+import { createSandboxProviderFromEnv } from "../sandbox/provider-factory";
+import type { Env } from "../types";
+import { getRepoImageBackend } from "./backend-policy";
+import { ModalRepoImageBuildAdapter } from "./modal-adapter";
+import { OpenComputerRepoImageBuildAdapter } from "./opencomputer-adapter";
+import { VercelRepoImageBuildAdapter } from "./vercel-adapter";
+import type { RepoImageBuildAdapter } from "./types";
+
+export function createRepoImageBuildAdapter(env: Env): RepoImageBuildAdapter {
+  const backend = getRepoImageBackend(env);
+  switch (backend) {
+    case "modal":
+      return new ModalRepoImageBuildAdapter(createSandboxProviderFromEnv(env, "modal"));
+    case "vercel":
+      return new VercelRepoImageBuildAdapter(createSandboxProviderFromEnv(env, "vercel"));
+    case "opencomputer":
+      return new OpenComputerRepoImageBuildAdapter(
+        createSandboxProviderFromEnv(env, "opencomputer")
+      );
+    default: {
+      const unsupportedBackend: never = backend;
+      throw new Error(`Repo image builds are not supported for provider ${unsupportedBackend}`);
+    }
+  }
+}

--- a/packages/control-plane/src/repo-images/provider-factory.ts
+++ b/packages/control-plane/src/repo-images/provider-factory.ts
@@ -1,25 +1,27 @@
 import { createSandboxProviderFromEnv } from "../sandbox/provider-factory";
 import type { Env } from "../types";
-import { getRepoImageBackend } from "./backend-policy";
 import { ModalRepoImageBuildAdapter } from "./modal-adapter";
 import { OpenComputerRepoImageBuildAdapter } from "./opencomputer-adapter";
 import { VercelRepoImageBuildAdapter } from "./vercel-adapter";
-import type { RepoImageBuildAdapter } from "./types";
+import type {
+  ModalRepoImageBuildPlan,
+  OpenComputerRepoImageBuildPlan,
+  RepoImageBuildAdapter,
+  VercelRepoImageBuildPlan,
+} from "./types";
 
-export function createRepoImageBuildAdapter(env: Env): RepoImageBuildAdapter {
-  const backend = getRepoImageBackend(env);
-  switch (backend) {
-    case "modal":
-      return new ModalRepoImageBuildAdapter(createSandboxProviderFromEnv(env, "modal"));
-    case "vercel":
-      return new VercelRepoImageBuildAdapter(createSandboxProviderFromEnv(env, "vercel"));
-    case "opencomputer":
-      return new OpenComputerRepoImageBuildAdapter(
-        createSandboxProviderFromEnv(env, "opencomputer")
-      );
-    default: {
-      const unsupportedBackend: never = backend;
-      throw new Error(`Repo image builds are not supported for provider ${unsupportedBackend}`);
-    }
-  }
+export interface RepoImageBuildAdapterFactory {
+  createModal(): RepoImageBuildAdapter<ModalRepoImageBuildPlan>;
+  createVercel(): RepoImageBuildAdapter<VercelRepoImageBuildPlan>;
+  createOpenComputer(): RepoImageBuildAdapter<OpenComputerRepoImageBuildPlan>;
+}
+
+export function createRepoImageBuildAdapterFactory(env: Env): RepoImageBuildAdapterFactory {
+  return {
+    createModal: () => new ModalRepoImageBuildAdapter(createSandboxProviderFromEnv(env, "modal")),
+    createVercel: () =>
+      new VercelRepoImageBuildAdapter(createSandboxProviderFromEnv(env, "vercel")),
+    createOpenComputer: () =>
+      new OpenComputerRepoImageBuildAdapter(createSandboxProviderFromEnv(env, "opencomputer")),
+  };
 }

--- a/packages/control-plane/src/repo-images/types.ts
+++ b/packages/control-plane/src/repo-images/types.ts
@@ -4,6 +4,7 @@ export type RepoImageCallbackMode = "provider_image" | "provider_session";
 export type RepoImageWorkflowContext = CorrelationContext;
 
 export interface ReplacedRepoImage {
+  repoImageId: string;
   providerImageId: string;
   providerSessionId: string | null;
 }
@@ -32,7 +33,7 @@ interface BaseRepoImageBuildPlan {
   repoName: string;
   baseBranch: string;
   callbackUrl: string;
-  buildTimeoutSeconds: number;
+  buildTimeoutMs: number;
   userEnvVars?: Record<string, string>;
   correlation: CorrelationContext;
 }
@@ -68,6 +69,21 @@ export type RepoImageBuildPlan =
   | VercelRepoImageBuildPlan
   | OpenComputerRepoImageBuildPlan;
 
+export type RepoImageCallbackAuth =
+  | { type: "none" }
+  | { type: "bearer_token"; tokenHash: string; expiresAt: number };
+
+export type PlannedRepoImageBuild =
+  | { plan: ModalRepoImageBuildPlan; callbackAuth: { type: "none" } }
+  | {
+      plan: VercelRepoImageBuildPlan;
+      callbackAuth: Extract<RepoImageCallbackAuth, { type: "bearer_token" }>;
+    }
+  | {
+      plan: OpenComputerRepoImageBuildPlan;
+      callbackAuth: Extract<RepoImageCallbackAuth, { type: "bearer_token" }>;
+    };
+
 export interface RepoImageBuildStartCallbacks {
   bindProviderSession(providerSessionId: string): Promise<void>;
 }
@@ -77,7 +93,7 @@ export interface CompleteProviderImageBuild {
   buildId: string;
   providerImageId: string;
   baseSha: string;
-  buildDurationSeconds: number;
+  buildDurationMs: number;
 }
 
 export interface CompleteProviderSessionBuild {
@@ -85,7 +101,7 @@ export interface CompleteProviderSessionBuild {
   buildId: string;
   providerSessionId: string;
   baseSha: string;
-  buildDurationSeconds: number;
+  buildDurationMs: number;
 }
 
 export type CompleteRepoImageBuild = CompleteProviderImageBuild | CompleteProviderSessionBuild;
@@ -118,20 +134,38 @@ export type FailedRepoImageBuildInput = FailRepoImageBuild & {
   correlation: CorrelationContext;
 };
 
+export interface CleanupCompletedProviderSessionBuildInput {
+  kind: "provider_session";
+  buildId: string;
+  providerSessionId: string;
+  correlation: CorrelationContext;
+}
+
 export interface DeleteRepoImageInput {
   providerImageId: string;
   providerSessionId?: string | null;
   correlation?: CorrelationContext;
 }
 
-export interface RepoImageBuildAdapter {
-  startBuild(plan: RepoImageBuildPlan, callbacks: RepoImageBuildStartCallbacks): Promise<void>;
-
+export interface RepoImageBuildFinalizer {
   finalizeSuccessfulBuild(
     input: FinalizeRepoImageBuildInput
   ): Promise<FinalizeRepoImageBuildResult>;
 
   cleanupFailedBuild?(input: FailedRepoImageBuildInput): Promise<void>;
 
+  cleanupCompletedBuild?(input: CleanupCompletedProviderSessionBuildInput): Promise<void>;
+
   deleteImage(input: DeleteRepoImageInput): Promise<void>;
 }
+
+export interface RepoImageBuildAdapter<
+  Plan extends RepoImageBuildPlan,
+> extends RepoImageBuildFinalizer {
+  startBuild(plan: Plan, callbacks: RepoImageBuildStartCallbacks): Promise<void>;
+}
+
+export type AnyRepoImageBuildAdapter =
+  | RepoImageBuildAdapter<ModalRepoImageBuildPlan>
+  | RepoImageBuildAdapter<VercelRepoImageBuildPlan>
+  | RepoImageBuildAdapter<OpenComputerRepoImageBuildPlan>;

--- a/packages/control-plane/src/repo-images/types.ts
+++ b/packages/control-plane/src/repo-images/types.ts
@@ -1,0 +1,137 @@
+import type { CorrelationContext } from "../logger";
+
+export type RepoImageCallbackMode = "provider_image" | "provider_session";
+export type RepoImageWorkflowContext = CorrelationContext;
+
+export interface ReplacedRepoImage {
+  providerImageId: string;
+  providerSessionId: string | null;
+}
+
+export type RepoImageWorkflowResult =
+  | { type: "build_triggered"; buildId: string }
+  | { type: "completion_accepted"; finalization: Promise<void> }
+  | { type: "build_ready"; replacedImages: ReplacedRepoImage[]; cleanup?: Promise<void> }
+  | { type: "build_failed"; cleanup?: Promise<void> }
+  | { type: "callback_auth_rejected"; message: string }
+  | { type: "callback_auth_unavailable"; message: string }
+  | { type: "repository_not_installed"; message: string }
+  | { type: "repo_image_workflow_unavailable"; message: string }
+  | { type: "repo_image_provider_unconfigured"; message: string }
+  | { type: "completion_not_accepted"; message: string }
+  | { type: "failure_not_accepted"; message: string }
+  | {
+      type: "workflow_failed";
+      operation: "trigger_build" | "build_complete" | "build_failed";
+      message: string;
+    };
+
+interface BaseRepoImageBuildPlan {
+  buildId: string;
+  repoOwner: string;
+  repoName: string;
+  baseBranch: string;
+  callbackUrl: string;
+  buildTimeoutSeconds: number;
+  userEnvVars?: Record<string, string>;
+  correlation: CorrelationContext;
+}
+
+export interface ModalRepoImageBuildPlan extends BaseRepoImageBuildPlan {
+  provider: "modal";
+  callbackMode: "provider_image";
+}
+
+export type VercelCloneAuth =
+  | { type: "credential_helper"; token: string }
+  | { type: "unavailable" };
+
+export interface VercelRepoImageBuildPlan extends BaseRepoImageBuildPlan {
+  provider: "vercel";
+  callbackMode: "provider_session";
+  callbackToken: string;
+  cloneAuth: VercelCloneAuth;
+}
+
+export interface OpenComputerRepoImageBuildPlan extends BaseRepoImageBuildPlan {
+  provider: "opencomputer";
+  callbackMode: "provider_session";
+  callbackToken: string;
+}
+
+export type ProviderSessionRepoImageBuildPlan =
+  | VercelRepoImageBuildPlan
+  | OpenComputerRepoImageBuildPlan;
+
+export type RepoImageBuildPlan =
+  | ModalRepoImageBuildPlan
+  | VercelRepoImageBuildPlan
+  | OpenComputerRepoImageBuildPlan;
+
+export interface RepoImageBuildStartCallbacks {
+  bindProviderSession(providerSessionId: string): Promise<void>;
+}
+
+export interface CompleteProviderImageBuild {
+  kind: "provider_image";
+  buildId: string;
+  providerImageId: string;
+  baseSha: string;
+  buildDurationSeconds: number;
+}
+
+export interface CompleteProviderSessionBuild {
+  kind: "provider_session";
+  buildId: string;
+  providerSessionId: string;
+  baseSha: string;
+  buildDurationSeconds: number;
+}
+
+export type CompleteRepoImageBuild = CompleteProviderImageBuild | CompleteProviderSessionBuild;
+
+export type FinalizeRepoImageBuildInput = CompleteRepoImageBuild & {
+  correlation: CorrelationContext;
+};
+
+export interface FinalizeRepoImageBuildResult {
+  providerImageId: string;
+  providerSessionId?: string;
+}
+
+export interface FailProviderImageBuild {
+  kind: "provider_image";
+  buildId: string;
+  errorMessage: string;
+}
+
+export interface FailProviderSessionBuild {
+  kind: "provider_session";
+  buildId: string;
+  providerSessionId: string;
+  errorMessage: string;
+}
+
+export type FailRepoImageBuild = FailProviderImageBuild | FailProviderSessionBuild;
+
+export type FailedRepoImageBuildInput = FailRepoImageBuild & {
+  correlation: CorrelationContext;
+};
+
+export interface DeleteRepoImageInput {
+  providerImageId: string;
+  providerSessionId?: string | null;
+  correlation?: CorrelationContext;
+}
+
+export interface RepoImageBuildAdapter {
+  startBuild(plan: RepoImageBuildPlan, callbacks: RepoImageBuildStartCallbacks): Promise<void>;
+
+  finalizeSuccessfulBuild(
+    input: FinalizeRepoImageBuildInput
+  ): Promise<FinalizeRepoImageBuildResult>;
+
+  cleanupFailedBuild?(input: FailedRepoImageBuildInput): Promise<void>;
+
+  deleteImage(input: DeleteRepoImageInput): Promise<void>;
+}

--- a/packages/control-plane/src/repo-images/vercel-adapter.ts
+++ b/packages/control-plane/src/repo-images/vercel-adapter.ts
@@ -6,22 +6,20 @@ import type {
   FinalizeRepoImageBuildInput,
   FinalizeRepoImageBuildResult,
   RepoImageBuildAdapter,
-  RepoImageBuildPlan,
   RepoImageBuildStartCallbacks,
   VercelRepoImageBuildPlan,
 } from "./types";
 
 const logger = createLogger("repo-images:vercel-adapter");
+const MS_PER_SECOND = 1000;
 
-export class VercelRepoImageBuildAdapter implements RepoImageBuildAdapter {
+export class VercelRepoImageBuildAdapter implements RepoImageBuildAdapter<VercelRepoImageBuildPlan> {
   constructor(private readonly provider: VercelSandboxProvider) {}
 
   async startBuild(
-    plan: RepoImageBuildPlan,
+    vercelPlan: VercelRepoImageBuildPlan,
     callbacks: RepoImageBuildStartCallbacks
   ): Promise<void> {
-    const vercelPlan = requireVercelPlan(plan);
-
     await this.provider.triggerRepoImageBuild({
       repoOwner: vercelPlan.repoOwner,
       repoName: vercelPlan.repoName,
@@ -32,7 +30,7 @@ export class VercelRepoImageBuildAdapter implements RepoImageBuildAdapter {
       userEnvVars: vercelPlan.userEnvVars,
       cloneToken:
         vercelPlan.cloneAuth.type === "credential_helper" ? vercelPlan.cloneAuth.token : undefined,
-      buildTimeoutSeconds: vercelPlan.buildTimeoutSeconds,
+      buildTimeoutSeconds: Math.ceil(vercelPlan.buildTimeoutMs / MS_PER_SECOND),
       onProviderSessionCreated: callbacks.bindProviderSession,
       correlation: vercelPlan.correlation,
     });
@@ -81,11 +79,21 @@ export class VercelRepoImageBuildAdapter implements RepoImageBuildAdapter {
 
   async cleanupFailedBuild(input: FailedRepoImageBuildInput): Promise<void> {
     if (input.kind !== "provider_session") return;
-    await this.stopBuildSandbox({
-      buildId: input.buildId,
-      providerSessionId: input.providerSessionId,
-      correlation: input.correlation,
-    });
+    try {
+      await this.stopBuildSandbox({
+        buildId: input.buildId,
+        providerSessionId: input.providerSessionId,
+        correlation: input.correlation,
+      });
+    } catch (error) {
+      logger.warn("repo_image.vercel_build_stop_failed", {
+        build_id: input.buildId,
+        provider_session_id: input.providerSessionId,
+        error: error instanceof Error ? error.message : String(error),
+        request_id: input.correlation.request_id,
+        trace_id: input.correlation.trace_id,
+      });
+    }
   }
 
   async deleteImage(input: DeleteRepoImageInput): Promise<void> {
@@ -113,11 +121,4 @@ export class VercelRepoImageBuildAdapter implements RepoImageBuildAdapter {
       throw new Error(stopResult.error || "Failed to stop Vercel build sandbox");
     }
   }
-}
-
-function requireVercelPlan(plan: RepoImageBuildPlan): VercelRepoImageBuildPlan {
-  if (plan.provider !== "vercel") {
-    throw new Error(`Vercel adapter received ${plan.provider} repo image build plan`);
-  }
-  return plan;
 }

--- a/packages/control-plane/src/repo-images/vercel-adapter.ts
+++ b/packages/control-plane/src/repo-images/vercel-adapter.ts
@@ -1,0 +1,123 @@
+import { createLogger } from "../logger";
+import type { VercelSandboxProvider } from "../sandbox/providers/vercel/provider";
+import type {
+  DeleteRepoImageInput,
+  FailedRepoImageBuildInput,
+  FinalizeRepoImageBuildInput,
+  FinalizeRepoImageBuildResult,
+  RepoImageBuildAdapter,
+  RepoImageBuildPlan,
+  RepoImageBuildStartCallbacks,
+  VercelRepoImageBuildPlan,
+} from "./types";
+
+const logger = createLogger("repo-images:vercel-adapter");
+
+export class VercelRepoImageBuildAdapter implements RepoImageBuildAdapter {
+  constructor(private readonly provider: VercelSandboxProvider) {}
+
+  async startBuild(
+    plan: RepoImageBuildPlan,
+    callbacks: RepoImageBuildStartCallbacks
+  ): Promise<void> {
+    const vercelPlan = requireVercelPlan(plan);
+
+    await this.provider.triggerRepoImageBuild({
+      repoOwner: vercelPlan.repoOwner,
+      repoName: vercelPlan.repoName,
+      defaultBranch: vercelPlan.baseBranch,
+      buildId: vercelPlan.buildId,
+      callbackUrl: vercelPlan.callbackUrl,
+      callbackToken: vercelPlan.callbackToken,
+      userEnvVars: vercelPlan.userEnvVars,
+      cloneToken:
+        vercelPlan.cloneAuth.type === "credential_helper" ? vercelPlan.cloneAuth.token : undefined,
+      buildTimeoutSeconds: vercelPlan.buildTimeoutSeconds,
+      onProviderSessionCreated: callbacks.bindProviderSession,
+      correlation: vercelPlan.correlation,
+    });
+  }
+
+  async finalizeSuccessfulBuild(
+    input: FinalizeRepoImageBuildInput
+  ): Promise<FinalizeRepoImageBuildResult> {
+    if (input.kind !== "provider_session") {
+      throw new Error("provider_session_id is required for Vercel repo image completion");
+    }
+
+    try {
+      const snapshot = await this.provider.takeSnapshot({
+        providerObjectId: input.providerSessionId,
+        sessionId: input.buildId,
+        reason: "repo_image_build",
+        correlation: {
+          ...input.correlation,
+          sandbox_id: input.providerSessionId,
+        },
+      });
+
+      if (!snapshot.success || !snapshot.imageId) {
+        throw new Error(snapshot.error || "Vercel snapshot did not return an image id");
+      }
+
+      return {
+        providerImageId: snapshot.imageId,
+        providerSessionId: input.providerSessionId,
+      };
+    } finally {
+      try {
+        await this.stopBuildSandbox(input);
+      } catch (error) {
+        logger.warn("repo_image.vercel_build_stop_failed", {
+          build_id: input.buildId,
+          provider_session_id: input.providerSessionId,
+          error: error instanceof Error ? error.message : String(error),
+          request_id: input.correlation.request_id,
+          trace_id: input.correlation.trace_id,
+        });
+      }
+    }
+  }
+
+  async cleanupFailedBuild(input: FailedRepoImageBuildInput): Promise<void> {
+    if (input.kind !== "provider_session") return;
+    await this.stopBuildSandbox({
+      buildId: input.buildId,
+      providerSessionId: input.providerSessionId,
+      correlation: input.correlation,
+    });
+  }
+
+  async deleteImage(input: DeleteRepoImageInput): Promise<void> {
+    await this.provider.deleteProviderImage(input.providerImageId);
+  }
+
+  private async stopBuildSandbox(input: {
+    buildId: string;
+    providerSessionId?: string;
+    correlation: FinalizeRepoImageBuildInput["correlation"];
+  }): Promise<void> {
+    if (!input.providerSessionId) return;
+
+    const stopResult = await this.provider.stopSandbox({
+      providerObjectId: input.providerSessionId,
+      sessionId: input.buildId,
+      reason: "repo_image_build_complete",
+      correlation: {
+        ...input.correlation,
+        sandbox_id: input.providerSessionId,
+      },
+    });
+
+    if (!stopResult.success) {
+      throw new Error(stopResult.error || "Failed to stop Vercel build sandbox");
+    }
+  }
+}
+
+function requireVercelPlan(plan: RepoImageBuildPlan): VercelRepoImageBuildPlan {
+  if (plan.provider !== "vercel") {
+    throw new Error(`Vercel adapter received ${plan.provider} repo image build plan`);
+  }
+  return plan;
+}

--- a/packages/control-plane/src/repo-images/workflow.test.ts
+++ b/packages/control-plane/src/repo-images/workflow.test.ts
@@ -1,0 +1,567 @@
+import { computeHmacHex } from "@open-inspect/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RepoImageStore } from "../db/repo-images";
+import type { Env } from "../types";
+import type {
+  RepoImageBuildAdapter,
+  RepoImageWorkflowContext,
+  RepoImageWorkflowResult,
+} from "./types";
+import { RepoImageBuildWorkflow } from "./workflow";
+
+const CALLBACK_TOKEN = "b".repeat(64);
+
+function createContext(): RepoImageWorkflowContext {
+  return {
+    request_id: "request-1",
+    trace_id: "trace-1",
+  };
+}
+
+function createStore(overrides: Partial<RepoImageStore> = {}): RepoImageStore {
+  return {
+    consumeCallbackToken: vi.fn(async () => ({
+      id: "build-1",
+      provider: "vercel",
+      provider_session_id: "provider-session-1",
+    })),
+    markBuildReady: vi.fn(async () => ({
+      updated: true,
+      replacedImageId: null,
+      replacedProviderSessionId: null,
+      replacedImages: [],
+    })),
+    markBuildFailed: vi.fn(async () => true),
+    registerBuild: vi.fn(),
+    bindProviderSession: vi.fn(),
+    getLatestReady: vi.fn(),
+    getLatestReadyForAnyProvider: vi.fn(),
+    getStatus: vi.fn(),
+    getAllStatus: vi.fn(),
+    markStaleBuildsAsFailed: vi.fn(),
+    deleteOldFailedBuilds: vi.fn(),
+    ...overrides,
+  } as unknown as RepoImageStore;
+}
+
+function createAdapter(overrides: Partial<RepoImageBuildAdapter> = {}): RepoImageBuildAdapter {
+  return {
+    startBuild: vi.fn(),
+    finalizeSuccessfulBuild: vi.fn(async () => ({
+      providerImageId: "provider-image-1",
+      providerSessionId: "provider-session-1",
+    })),
+    cleanupFailedBuild: vi.fn(async () => undefined),
+    deleteImage: vi.fn(),
+    ...overrides,
+  } as RepoImageBuildAdapter;
+}
+
+async function tokenHash(): Promise<string> {
+  return computeHmacHex(`repo-image-callback:${CALLBACK_TOKEN}`, "callback-secret");
+}
+
+function expectCompletionAccepted(result: RepoImageWorkflowResult): Promise<void> {
+  expect(result).toMatchObject({ type: "completion_accepted" });
+  if (result.type !== "completion_accepted") {
+    throw new Error(`Expected completion_accepted, got ${result.type}`);
+  }
+  return result.finalization;
+}
+
+function expectBuildFailed(result: RepoImageWorkflowResult): Promise<void> | undefined {
+  expect(result).toMatchObject({ type: "build_failed" });
+  if (result.type !== "build_failed") {
+    throw new Error(`Expected build_failed, got ${result.type}`);
+  }
+  return result.cleanup;
+}
+
+describe("RepoImageBuildWorkflow", () => {
+  let env: Env;
+
+  beforeEach(() => {
+    env = {
+      INTERNAL_CALLBACK_SECRET: "callback-secret",
+    } as Env;
+  });
+
+  it("triggers a build from the planner-owned plan and binds provider sessions", async () => {
+    const store = createStore({
+      registerBuild: vi.fn(async () => undefined),
+      bindProviderSession: vi.fn(async () => true),
+    });
+    const adapter = createAdapter({
+      startBuild: vi.fn(async (_plan, callbacks) => {
+        await callbacks.bindProviderSession("provider-session-1");
+      }),
+    });
+    const planner = {
+      planBuild: vi.fn(
+        async (params: {
+          buildId: string;
+          repoOwner: string;
+          repoName: string;
+          now: number;
+          callbackUrl: string;
+          correlation: { request_id: string; trace_id: string };
+        }) => ({
+          type: "ok" as const,
+          plan: {
+            provider: "vercel" as const,
+            callbackMode: "provider_session" as const,
+            buildId: params.buildId,
+            repoOwner: "acme",
+            repoName: "repo",
+            baseBranch: "develop",
+            callbackUrl: "https://worker.test/repo-images/build-complete",
+            callbackToken: CALLBACK_TOKEN,
+            cloneAuth: { type: "unavailable" as const },
+            buildTimeoutSeconds: 1800,
+            correlation: { request_id: "request-1", trace_id: "trace-1" },
+          },
+          registration: {
+            baseBranch: "develop",
+            callbackTokenHash: "token-hash",
+            callbackTokenExpiresAt: 456,
+          },
+        })
+      ),
+    };
+    const workflow = new RepoImageBuildWorkflow(
+      { ...env, WORKER_URL: "https://worker.test" } as Env,
+      store,
+      () => adapter,
+      "vercel",
+      planner
+    );
+
+    const result = await workflow.triggerBuild("acme", "repo", createContext());
+
+    expect(result).toEqual({ type: "build_triggered", buildId: expect.stringContaining("img-") });
+    expect(planner.planBuild).toHaveBeenCalledWith({
+      buildId: expect.stringContaining("img-acme-repo-"),
+      repoOwner: "acme",
+      repoName: "repo",
+      now: expect.any(Number),
+      callbackUrl: "https://worker.test/repo-images/build-complete",
+      correlation: { request_id: "request-1", trace_id: "trace-1" },
+    });
+    expect(store.registerBuild).toHaveBeenCalledWith({
+      id: expect.stringContaining("img-acme-repo-"),
+      repoOwner: "acme",
+      repoName: "repo",
+      provider: "vercel",
+      baseBranch: "develop",
+      callbackTokenHash: "token-hash",
+      callbackTokenExpiresAt: 456,
+    });
+    expect(adapter.startBuild).toHaveBeenCalledWith(
+      expect.objectContaining({ baseBranch: "develop", callbackUrl: expect.any(String) }),
+      expect.objectContaining({ bindProviderSession: expect.any(Function) })
+    );
+    expect(store.bindProviderSession).toHaveBeenCalledWith(
+      expect.stringContaining("img-acme-repo-"),
+      "vercel",
+      "provider-session-1"
+    );
+  });
+
+  it("maps a planner repo access miss without creating a build", async () => {
+    const store = createStore();
+    const adapter = createAdapter();
+    const planner = {
+      planBuild: vi.fn(async () => ({
+        type: "repo_not_installed" as const,
+        message: "Repository is not installed for the GitHub App",
+      })),
+    };
+    const workflow = new RepoImageBuildWorkflow(
+      { ...env, WORKER_URL: "https://worker.test" } as Env,
+      store,
+      () => adapter,
+      "modal",
+      planner
+    );
+
+    const result = await workflow.triggerBuild("acme", "repo", createContext());
+
+    expect(result).toEqual({
+      type: "repository_not_installed",
+      message: "Repository is not installed for the GitHub App",
+    });
+    expect(store.registerBuild).not.toHaveBeenCalled();
+    expect(adapter.startBuild).not.toHaveBeenCalled();
+  });
+
+  it("marks Modal provider-image completions ready without callback-token auth", async () => {
+    const store = createStore();
+    const adapter = createAdapter({
+      finalizeSuccessfulBuild: vi.fn(async (input) => {
+        if (input.kind !== "provider_image") {
+          throw new Error("expected provider image completion");
+        }
+        return { providerImageId: input.providerImageId };
+      }),
+    });
+    const workflow = new RepoImageBuildWorkflow(env, store, () => adapter, "modal");
+
+    const result = await workflow.acceptBuildComplete({
+      completion: {
+        kind: "provider_image",
+        buildId: "build-1",
+        providerImageId: "modal-image-1",
+        baseSha: "abc123",
+        buildDurationSeconds: 4.5,
+      },
+      context: createContext(),
+    });
+
+    expect(result).toEqual({ type: "build_ready", replacedImages: [] });
+    expect(store.consumeCallbackToken).not.toHaveBeenCalled();
+    expect(adapter.finalizeSuccessfulBuild).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "provider_image",
+        buildId: "build-1",
+        providerImageId: "modal-image-1",
+        correlation: { request_id: "request-1", trace_id: "trace-1" },
+      })
+    );
+    expect(store.markBuildReady).toHaveBeenCalledWith(
+      "build-1",
+      "modal",
+      "modal-image-1",
+      "abc123",
+      4.5
+    );
+  });
+
+  it("returns a cleanup task for superseded provider-image completions", async () => {
+    const store = createStore({
+      markBuildReady: vi.fn(async () => ({
+        updated: true,
+        replacedImageId: "old-modal-image",
+        replacedProviderSessionId: null,
+        replacedImages: [{ providerImageId: "old-modal-image", providerSessionId: null }],
+      })),
+    });
+    const adapter = createAdapter({
+      finalizeSuccessfulBuild: vi.fn(async (input) => {
+        if (input.kind !== "provider_image") {
+          throw new Error("expected provider image completion");
+        }
+        return { providerImageId: input.providerImageId };
+      }),
+    });
+    const workflow = new RepoImageBuildWorkflow(env, store, () => adapter, "modal");
+
+    const result = await workflow.acceptBuildComplete({
+      completion: {
+        kind: "provider_image",
+        buildId: "build-1",
+        providerImageId: "modal-image-1",
+        baseSha: "abc123",
+        buildDurationSeconds: 4.5,
+      },
+      context: createContext(),
+    });
+
+    expect(result).toMatchObject({
+      type: "build_ready",
+      replacedImages: [{ providerImageId: "old-modal-image", providerSessionId: null }],
+    });
+    if (result.type !== "build_ready") {
+      throw new Error(`Expected build_ready, got ${result.type}`);
+    }
+
+    await result.cleanup;
+    expect(adapter.deleteImage).toHaveBeenCalledWith({
+      providerImageId: "old-modal-image",
+      providerSessionId: null,
+      correlation: { request_id: "request-1", trace_id: "trace-1" },
+    });
+  });
+
+  it("deletes a newly finalized provider image when Modal completion is rejected", async () => {
+    const store = createStore({
+      markBuildReady: vi.fn(async () => ({
+        updated: false,
+        replacedImageId: null,
+        replacedProviderSessionId: null,
+        replacedImages: [],
+      })),
+    });
+    const adapter = createAdapter({
+      finalizeSuccessfulBuild: vi.fn(async (input) => {
+        if (input.kind !== "provider_image") {
+          throw new Error("expected provider image completion");
+        }
+        return { providerImageId: input.providerImageId };
+      }),
+    });
+    const workflow = new RepoImageBuildWorkflow(env, store, () => adapter, "modal");
+
+    const result = await workflow.acceptBuildComplete({
+      completion: {
+        kind: "provider_image",
+        buildId: "build-1",
+        providerImageId: "modal-image-1",
+        baseSha: "abc123",
+        buildDurationSeconds: 4.5,
+      },
+      context: createContext(),
+    });
+
+    expect(result).toEqual({
+      type: "completion_not_accepted",
+      message: "Build is not accepting completion",
+    });
+    expect(adapter.deleteImage).toHaveBeenCalledWith({
+      providerImageId: "modal-image-1",
+      providerSessionId: undefined,
+      correlation: { request_id: "request-1", trace_id: "trace-1" },
+    });
+  });
+
+  it("finalizes a provider-session callback, commits ready, and deletes a superseded image", async () => {
+    const store = createStore({
+      markBuildReady: vi.fn(async () => ({
+        updated: true,
+        replacedImageId: "old-image-1",
+        replacedProviderSessionId: "old-session-1",
+        replacedImages: [{ providerImageId: "old-image-1", providerSessionId: "old-session-1" }],
+      })),
+    });
+    const adapter = createAdapter();
+    const workflow = new RepoImageBuildWorkflow(env, store, () => adapter, "vercel");
+
+    const result = await workflow.acceptBuildComplete({
+      callbackToken: CALLBACK_TOKEN,
+      completion: {
+        kind: "provider_session",
+        buildId: "build-1",
+        providerSessionId: "provider-session-1",
+        baseSha: "abc123",
+        buildDurationSeconds: 12.5,
+      },
+      context: createContext(),
+    });
+
+    await expectCompletionAccepted(result);
+
+    expect(store.consumeCallbackToken).toHaveBeenCalledWith({
+      buildId: "build-1",
+      provider: "vercel",
+      providerSessionId: "provider-session-1",
+      tokenHash: await tokenHash(),
+      now: expect.any(Number),
+    });
+    expect(adapter.finalizeSuccessfulBuild).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buildId: "build-1",
+        providerSessionId: "provider-session-1",
+        baseSha: "abc123",
+        buildDurationSeconds: 12.5,
+      })
+    );
+    expect(store.markBuildReady).toHaveBeenCalledWith(
+      "build-1",
+      "vercel",
+      "provider-image-1",
+      "abc123",
+      12.5
+    );
+    expect(adapter.deleteImage).toHaveBeenCalledWith({
+      providerImageId: "old-image-1",
+      providerSessionId: "old-session-1",
+      correlation: { request_id: "request-1", trace_id: "trace-1" },
+    });
+  });
+
+  it("deletes a newly finalized orphan image when the build no longer accepts completion", async () => {
+    const store = createStore({
+      markBuildReady: vi.fn(async () => ({
+        updated: false,
+        replacedImageId: null,
+        replacedProviderSessionId: null,
+        replacedImages: [],
+      })),
+    });
+    const adapter = createAdapter();
+    const workflow = new RepoImageBuildWorkflow(env, store, () => adapter, "vercel");
+
+    const result = await workflow.acceptBuildComplete({
+      callbackToken: CALLBACK_TOKEN,
+      completion: {
+        kind: "provider_session",
+        buildId: "build-1",
+        providerSessionId: "provider-session-1",
+        baseSha: "",
+        buildDurationSeconds: 0,
+      },
+      context: createContext(),
+    });
+
+    await expectCompletionAccepted(result);
+
+    expect(adapter.deleteImage).toHaveBeenCalledWith({
+      providerImageId: "provider-image-1",
+      providerSessionId: "provider-session-1",
+      correlation: { request_id: "request-1", trace_id: "trace-1" },
+    });
+  });
+
+  it("marks the build failed when provider finalization fails after token acceptance", async () => {
+    const store = createStore();
+    const adapter = createAdapter({
+      finalizeSuccessfulBuild: vi.fn(async () => {
+        throw new Error("snapshot failed");
+      }),
+    });
+    const workflow = new RepoImageBuildWorkflow(env, store, () => adapter, "vercel");
+
+    const result = await workflow.acceptBuildComplete({
+      callbackToken: CALLBACK_TOKEN,
+      completion: {
+        kind: "provider_session",
+        buildId: "build-1",
+        providerSessionId: "provider-session-1",
+        baseSha: "",
+        buildDurationSeconds: 0,
+      },
+      context: createContext(),
+    });
+
+    await expectCompletionAccepted(result);
+
+    expect(store.markBuildFailed).toHaveBeenCalledWith("build-1", "vercel", "snapshot failed");
+  });
+
+  it("rejects replayed or mismatched callback tokens without finalizing", async () => {
+    const store = createStore({
+      consumeCallbackToken: vi.fn(async () => null),
+    });
+    const adapter = createAdapter();
+    const workflow = new RepoImageBuildWorkflow(env, store, () => adapter, "vercel");
+
+    const result = await workflow.acceptBuildComplete({
+      callbackToken: CALLBACK_TOKEN,
+      completion: {
+        kind: "provider_session",
+        buildId: "build-1",
+        providerSessionId: "provider-session-1",
+        baseSha: "",
+        buildDurationSeconds: 0,
+      },
+      context: createContext(),
+    });
+
+    expect(result).toEqual({ type: "callback_auth_rejected", message: "Unauthorized" });
+    expect(adapter.finalizeSuccessfulBuild).not.toHaveBeenCalled();
+  });
+
+  it("rejects completion tokens before creating provider adapters", async () => {
+    const store = createStore({
+      consumeCallbackToken: vi.fn(async () => null),
+    });
+    const createAdapter = vi.fn(() => {
+      throw new Error("Vercel configuration not available");
+    });
+    const workflow = new RepoImageBuildWorkflow(env, store, createAdapter, "vercel");
+
+    const result = await workflow.acceptBuildComplete({
+      callbackToken: CALLBACK_TOKEN,
+      completion: {
+        kind: "provider_session",
+        buildId: "build-1",
+        providerSessionId: "provider-session-1",
+        baseSha: "",
+        buildDurationSeconds: 0,
+      },
+      context: createContext(),
+    });
+
+    expect(result).toEqual({ type: "callback_auth_rejected", message: "Unauthorized" });
+    expect(createAdapter).not.toHaveBeenCalled();
+  });
+
+  it("marks valid completions failed when provider configuration is unavailable", async () => {
+    const store = createStore();
+    const createAdapter = vi.fn(() => {
+      throw new Error("Vercel configuration not available");
+    });
+    const workflow = new RepoImageBuildWorkflow(env, store, createAdapter, "vercel");
+
+    const result = await workflow.acceptBuildComplete({
+      callbackToken: CALLBACK_TOKEN,
+      completion: {
+        kind: "provider_session",
+        buildId: "build-1",
+        providerSessionId: "provider-session-1",
+        baseSha: "",
+        buildDurationSeconds: 0,
+      },
+      context: createContext(),
+    });
+
+    await expectCompletionAccepted(result);
+
+    expect(createAdapter).toHaveBeenCalledOnce();
+    expect(store.markBuildFailed).toHaveBeenCalledWith(
+      "build-1",
+      "vercel",
+      "Vercel configuration not available"
+    );
+  });
+
+  it("marks failed callbacks and asks the adapter to clean up provider-session sandboxes", async () => {
+    const store = createStore();
+    const adapter = createAdapter();
+    const workflow = new RepoImageBuildWorkflow(env, store, () => adapter, "vercel");
+
+    const result = await workflow.acceptBuildFailed({
+      callbackToken: CALLBACK_TOKEN,
+      failure: {
+        kind: "provider_session",
+        buildId: "build-1",
+        providerSessionId: "provider-session-1",
+        errorMessage: "setup failed",
+      },
+      context: createContext(),
+    });
+
+    await expectBuildFailed(result);
+
+    expect(store.markBuildFailed).toHaveBeenCalledWith("build-1", "vercel", "setup failed");
+    expect(adapter.cleanupFailedBuild).toHaveBeenCalledWith({
+      buildId: "build-1",
+      kind: "provider_session",
+      providerSessionId: "provider-session-1",
+      errorMessage: "setup failed",
+      correlation: { request_id: "request-1", trace_id: "trace-1" },
+    });
+  });
+
+  it("does not require provider cleanup configuration to accept failed callbacks", async () => {
+    const store = createStore();
+    const createAdapter = vi.fn(() => {
+      throw new Error("Vercel configuration not available");
+    });
+    const workflow = new RepoImageBuildWorkflow(env, store, createAdapter, "vercel");
+
+    const result = await workflow.acceptBuildFailed({
+      callbackToken: CALLBACK_TOKEN,
+      failure: {
+        kind: "provider_session",
+        buildId: "build-1",
+        providerSessionId: "provider-session-1",
+        errorMessage: "setup failed",
+      },
+      context: createContext(),
+    });
+
+    expect(result).toEqual({ type: "build_failed" });
+    expect(store.markBuildFailed).toHaveBeenCalledWith("build-1", "vercel", "setup failed");
+    expect(createAdapter).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/control-plane/src/repo-images/workflow.test.ts
+++ b/packages/control-plane/src/repo-images/workflow.test.ts
@@ -2,8 +2,9 @@ import { computeHmacHex } from "@open-inspect/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RepoImageStore } from "../db/repo-images";
 import type { Env } from "../types";
+import type { RepoImageBuildAdapterFactory } from "./provider-factory";
 import type {
-  RepoImageBuildAdapter,
+  AnyRepoImageBuildAdapter,
   RepoImageWorkflowContext,
   RepoImageWorkflowResult,
 } from "./types";
@@ -40,11 +41,14 @@ function createStore(overrides: Partial<RepoImageStore> = {}): RepoImageStore {
     getAllStatus: vi.fn(),
     markStaleBuildsAsFailed: vi.fn(),
     deleteOldFailedBuilds: vi.fn(),
+    deleteSupersededImage: vi.fn(async () => true),
     ...overrides,
   } as unknown as RepoImageStore;
 }
 
-function createAdapter(overrides: Partial<RepoImageBuildAdapter> = {}): RepoImageBuildAdapter {
+function createAdapter(
+  overrides: Partial<AnyRepoImageBuildAdapter> = {}
+): AnyRepoImageBuildAdapter {
   return {
     startBuild: vi.fn(),
     finalizeSuccessfulBuild: vi.fn(async () => ({
@@ -54,7 +58,45 @@ function createAdapter(overrides: Partial<RepoImageBuildAdapter> = {}): RepoImag
     cleanupFailedBuild: vi.fn(async () => undefined),
     deleteImage: vi.fn(),
     ...overrides,
-  } as RepoImageBuildAdapter;
+  } as AnyRepoImageBuildAdapter;
+}
+
+function createAdapterFactory(adapter: AnyRepoImageBuildAdapter): RepoImageBuildAdapterFactory & {
+  createModal: ReturnType<typeof vi.fn>;
+  createVercel: ReturnType<typeof vi.fn>;
+  createOpenComputer: ReturnType<typeof vi.fn>;
+} {
+  return {
+    createModal: vi.fn(() => adapter),
+    createVercel: vi.fn(() => adapter),
+    createOpenComputer: vi.fn(() => adapter),
+  } as unknown as RepoImageBuildAdapterFactory & {
+    createModal: ReturnType<typeof vi.fn>;
+    createVercel: ReturnType<typeof vi.fn>;
+    createOpenComputer: ReturnType<typeof vi.fn>;
+  };
+}
+
+function createThrowingAdapterFactory(error: Error): RepoImageBuildAdapterFactory & {
+  createModal: ReturnType<typeof vi.fn>;
+  createVercel: ReturnType<typeof vi.fn>;
+  createOpenComputer: ReturnType<typeof vi.fn>;
+} {
+  return {
+    createModal: vi.fn(() => {
+      throw error;
+    }),
+    createVercel: vi.fn(() => {
+      throw error;
+    }),
+    createOpenComputer: vi.fn(() => {
+      throw error;
+    }),
+  } as unknown as RepoImageBuildAdapterFactory & {
+    createModal: ReturnType<typeof vi.fn>;
+    createVercel: ReturnType<typeof vi.fn>;
+    createOpenComputer: ReturnType<typeof vi.fn>;
+  };
 }
 
 async function tokenHash(): Promise<string> {
@@ -107,23 +149,25 @@ describe("RepoImageBuildWorkflow", () => {
           correlation: { request_id: string; trace_id: string };
         }) => ({
           type: "ok" as const,
-          plan: {
-            provider: "vercel" as const,
-            callbackMode: "provider_session" as const,
-            buildId: params.buildId,
-            repoOwner: "acme",
-            repoName: "repo",
-            baseBranch: "develop",
-            callbackUrl: "https://worker.test/repo-images/build-complete",
-            callbackToken: CALLBACK_TOKEN,
-            cloneAuth: { type: "unavailable" as const },
-            buildTimeoutSeconds: 1800,
-            correlation: { request_id: "request-1", trace_id: "trace-1" },
-          },
-          registration: {
-            baseBranch: "develop",
-            callbackTokenHash: "token-hash",
-            callbackTokenExpiresAt: 456,
+          build: {
+            plan: {
+              provider: "vercel" as const,
+              callbackMode: "provider_session" as const,
+              buildId: params.buildId,
+              repoOwner: "acme",
+              repoName: "repo",
+              baseBranch: "develop",
+              callbackUrl: "https://worker.test/repo-images/build-complete",
+              callbackToken: CALLBACK_TOKEN,
+              cloneAuth: { type: "unavailable" as const },
+              buildTimeoutMs: 1_800_000,
+              correlation: { request_id: "request-1", trace_id: "trace-1" },
+            },
+            callbackAuth: {
+              type: "bearer_token" as const,
+              tokenHash: "token-hash",
+              expiresAt: 456,
+            },
           },
         })
       ),
@@ -131,7 +175,7 @@ describe("RepoImageBuildWorkflow", () => {
     const workflow = new RepoImageBuildWorkflow(
       { ...env, WORKER_URL: "https://worker.test" } as Env,
       store,
-      () => adapter,
+      createAdapterFactory(adapter),
       "vercel",
       planner
     );
@@ -167,6 +211,65 @@ describe("RepoImageBuildWorkflow", () => {
     );
   });
 
+  it("cleans up provider-session builds when trigger binding fails after provider start", async () => {
+    const store = createStore({
+      registerBuild: vi.fn(async () => undefined),
+      bindProviderSession: vi.fn(async () => false),
+    });
+    const adapter = createAdapter({
+      startBuild: vi.fn(async (_plan, callbacks) => {
+        await callbacks.bindProviderSession("provider-session-1");
+      }),
+    });
+    const planner = {
+      planBuild: vi.fn(async (params: { buildId: string }) => ({
+        type: "ok" as const,
+        build: {
+          plan: {
+            provider: "vercel" as const,
+            callbackMode: "provider_session" as const,
+            buildId: params.buildId,
+            repoOwner: "acme",
+            repoName: "repo",
+            baseBranch: "develop",
+            callbackUrl: "https://worker.test/repo-images/build-complete",
+            callbackToken: CALLBACK_TOKEN,
+            cloneAuth: { type: "unavailable" as const },
+            buildTimeoutMs: 1_800_000,
+            correlation: { request_id: "request-1", trace_id: "trace-1" },
+          },
+          callbackAuth: {
+            type: "bearer_token" as const,
+            tokenHash: "token-hash",
+            expiresAt: 456,
+          },
+        },
+      })),
+    };
+    const workflow = new RepoImageBuildWorkflow(
+      { ...env, WORKER_URL: "https://worker.test" } as Env,
+      store,
+      createAdapterFactory(adapter),
+      "vercel",
+      planner
+    );
+
+    const result = await workflow.triggerBuild("acme", "repo", createContext());
+
+    expect(result).toEqual({
+      type: "workflow_failed",
+      operation: "trigger_build",
+      message: "Failed to trigger build",
+    });
+    expect(adapter.cleanupFailedBuild).toHaveBeenCalledWith({
+      kind: "provider_session",
+      buildId: expect.stringContaining("img-acme-repo-"),
+      providerSessionId: "provider-session-1",
+      errorMessage: "Failed to bind vercel build session",
+      correlation: { request_id: "request-1", trace_id: "trace-1" },
+    });
+  });
+
   it("maps a planner repo access miss without creating a build", async () => {
     const store = createStore();
     const adapter = createAdapter();
@@ -179,7 +282,7 @@ describe("RepoImageBuildWorkflow", () => {
     const workflow = new RepoImageBuildWorkflow(
       { ...env, WORKER_URL: "https://worker.test" } as Env,
       store,
-      () => adapter,
+      createAdapterFactory(adapter),
       "modal",
       planner
     );
@@ -204,7 +307,7 @@ describe("RepoImageBuildWorkflow", () => {
         return { providerImageId: input.providerImageId };
       }),
     });
-    const workflow = new RepoImageBuildWorkflow(env, store, () => adapter, "modal");
+    const workflow = new RepoImageBuildWorkflow(env, store, createAdapterFactory(adapter), "modal");
 
     const result = await workflow.acceptBuildComplete({
       completion: {
@@ -212,7 +315,7 @@ describe("RepoImageBuildWorkflow", () => {
         buildId: "build-1",
         providerImageId: "modal-image-1",
         baseSha: "abc123",
-        buildDurationSeconds: 4.5,
+        buildDurationMs: 4_500,
       },
       context: createContext(),
     });
@@ -232,7 +335,7 @@ describe("RepoImageBuildWorkflow", () => {
       "modal",
       "modal-image-1",
       "abc123",
-      4.5
+      4_500
     );
   });
 
@@ -242,7 +345,9 @@ describe("RepoImageBuildWorkflow", () => {
         updated: true,
         replacedImageId: "old-modal-image",
         replacedProviderSessionId: null,
-        replacedImages: [{ providerImageId: "old-modal-image", providerSessionId: null }],
+        replacedImages: [
+          { repoImageId: "old-row-1", providerImageId: "old-modal-image", providerSessionId: null },
+        ],
       })),
     });
     const adapter = createAdapter({
@@ -253,7 +358,7 @@ describe("RepoImageBuildWorkflow", () => {
         return { providerImageId: input.providerImageId };
       }),
     });
-    const workflow = new RepoImageBuildWorkflow(env, store, () => adapter, "modal");
+    const workflow = new RepoImageBuildWorkflow(env, store, createAdapterFactory(adapter), "modal");
 
     const result = await workflow.acceptBuildComplete({
       completion: {
@@ -261,14 +366,16 @@ describe("RepoImageBuildWorkflow", () => {
         buildId: "build-1",
         providerImageId: "modal-image-1",
         baseSha: "abc123",
-        buildDurationSeconds: 4.5,
+        buildDurationMs: 4_500,
       },
       context: createContext(),
     });
 
     expect(result).toMatchObject({
       type: "build_ready",
-      replacedImages: [{ providerImageId: "old-modal-image", providerSessionId: null }],
+      replacedImages: [
+        { repoImageId: "old-row-1", providerImageId: "old-modal-image", providerSessionId: null },
+      ],
     });
     if (result.type !== "build_ready") {
       throw new Error(`Expected build_ready, got ${result.type}`);
@@ -280,6 +387,7 @@ describe("RepoImageBuildWorkflow", () => {
       providerSessionId: null,
       correlation: { request_id: "request-1", trace_id: "trace-1" },
     });
+    expect(store.deleteSupersededImage).toHaveBeenCalledWith("old-row-1");
   });
 
   it("deletes a newly finalized provider image when Modal completion is rejected", async () => {
@@ -299,7 +407,7 @@ describe("RepoImageBuildWorkflow", () => {
         return { providerImageId: input.providerImageId };
       }),
     });
-    const workflow = new RepoImageBuildWorkflow(env, store, () => adapter, "modal");
+    const workflow = new RepoImageBuildWorkflow(env, store, createAdapterFactory(adapter), "modal");
 
     const result = await workflow.acceptBuildComplete({
       completion: {
@@ -307,7 +415,7 @@ describe("RepoImageBuildWorkflow", () => {
         buildId: "build-1",
         providerImageId: "modal-image-1",
         baseSha: "abc123",
-        buildDurationSeconds: 4.5,
+        buildDurationMs: 4_500,
       },
       context: createContext(),
     });
@@ -323,17 +431,67 @@ describe("RepoImageBuildWorkflow", () => {
     });
   });
 
+  it("deletes a newly finalized provider image when the ready commit throws", async () => {
+    const store = createStore({
+      markBuildReady: vi.fn(async () => {
+        throw new Error("D1 write failed");
+      }),
+    });
+    const adapter = createAdapter({
+      finalizeSuccessfulBuild: vi.fn(async (input) => {
+        if (input.kind !== "provider_image") {
+          throw new Error("expected provider image completion");
+        }
+        return { providerImageId: input.providerImageId };
+      }),
+    });
+    const workflow = new RepoImageBuildWorkflow(env, store, createAdapterFactory(adapter), "modal");
+
+    const result = await workflow.acceptBuildComplete({
+      completion: {
+        kind: "provider_image",
+        buildId: "build-1",
+        providerImageId: "modal-image-1",
+        baseSha: "abc123",
+        buildDurationMs: 4_500,
+      },
+      context: createContext(),
+    });
+
+    expect(result).toEqual({
+      type: "workflow_failed",
+      operation: "build_complete",
+      message: "Failed to mark build as ready",
+    });
+    expect(adapter.deleteImage).toHaveBeenCalledWith({
+      providerImageId: "modal-image-1",
+      providerSessionId: undefined,
+      correlation: { request_id: "request-1", trace_id: "trace-1" },
+    });
+  });
+
   it("finalizes a provider-session callback, commits ready, and deletes a superseded image", async () => {
     const store = createStore({
       markBuildReady: vi.fn(async () => ({
         updated: true,
         replacedImageId: "old-image-1",
         replacedProviderSessionId: "old-session-1",
-        replacedImages: [{ providerImageId: "old-image-1", providerSessionId: "old-session-1" }],
+        replacedImages: [
+          {
+            repoImageId: "old-row-1",
+            providerImageId: "old-image-1",
+            providerSessionId: "old-session-1",
+          },
+        ],
       })),
     });
     const adapter = createAdapter();
-    const workflow = new RepoImageBuildWorkflow(env, store, () => adapter, "vercel");
+    const workflow = new RepoImageBuildWorkflow(
+      env,
+      store,
+      createAdapterFactory(adapter),
+      "vercel"
+    );
 
     const result = await workflow.acceptBuildComplete({
       callbackToken: CALLBACK_TOKEN,
@@ -342,7 +500,7 @@ describe("RepoImageBuildWorkflow", () => {
         buildId: "build-1",
         providerSessionId: "provider-session-1",
         baseSha: "abc123",
-        buildDurationSeconds: 12.5,
+        buildDurationMs: 12_500,
       },
       context: createContext(),
     });
@@ -361,7 +519,7 @@ describe("RepoImageBuildWorkflow", () => {
         buildId: "build-1",
         providerSessionId: "provider-session-1",
         baseSha: "abc123",
-        buildDurationSeconds: 12.5,
+        buildDurationMs: 12_500,
       })
     );
     expect(store.markBuildReady).toHaveBeenCalledWith(
@@ -369,13 +527,63 @@ describe("RepoImageBuildWorkflow", () => {
       "vercel",
       "provider-image-1",
       "abc123",
-      12.5
+      12_500
     );
     expect(adapter.deleteImage).toHaveBeenCalledWith({
       providerImageId: "old-image-1",
       providerSessionId: "old-session-1",
       correlation: { request_id: "request-1", trace_id: "trace-1" },
     });
+    expect(store.deleteSupersededImage).toHaveBeenCalledWith("old-row-1");
+  });
+
+  it("does not fail a ready provider-session build when superseded row cleanup fails", async () => {
+    const store = createStore({
+      markBuildReady: vi.fn(async () => ({
+        updated: true,
+        replacedImageId: "old-image-1",
+        replacedProviderSessionId: "old-session-1",
+        replacedImages: [
+          {
+            repoImageId: "old-row-1",
+            providerImageId: "old-image-1",
+            providerSessionId: "old-session-1",
+          },
+        ],
+      })),
+      deleteSupersededImage: vi.fn(async () => {
+        throw new Error("D1 delete failed");
+      }),
+    });
+    const adapter = createAdapter();
+    const workflow = new RepoImageBuildWorkflow(
+      env,
+      store,
+      createAdapterFactory(adapter),
+      "vercel"
+    );
+
+    const result = await workflow.acceptBuildComplete({
+      callbackToken: CALLBACK_TOKEN,
+      completion: {
+        kind: "provider_session",
+        buildId: "build-1",
+        providerSessionId: "provider-session-1",
+        baseSha: "abc123",
+        buildDurationMs: 12_500,
+      },
+      context: createContext(),
+    });
+
+    await expectCompletionAccepted(result);
+
+    expect(adapter.deleteImage).toHaveBeenCalledWith({
+      providerImageId: "old-image-1",
+      providerSessionId: "old-session-1",
+      correlation: { request_id: "request-1", trace_id: "trace-1" },
+    });
+    expect(store.deleteSupersededImage).toHaveBeenCalledWith("old-row-1");
+    expect(store.markBuildFailed).not.toHaveBeenCalled();
   });
 
   it("deletes a newly finalized orphan image when the build no longer accepts completion", async () => {
@@ -388,7 +596,12 @@ describe("RepoImageBuildWorkflow", () => {
       })),
     });
     const adapter = createAdapter();
-    const workflow = new RepoImageBuildWorkflow(env, store, () => adapter, "vercel");
+    const workflow = new RepoImageBuildWorkflow(
+      env,
+      store,
+      createAdapterFactory(adapter),
+      "vercel"
+    );
 
     const result = await workflow.acceptBuildComplete({
       callbackToken: CALLBACK_TOKEN,
@@ -397,7 +610,7 @@ describe("RepoImageBuildWorkflow", () => {
         buildId: "build-1",
         providerSessionId: "provider-session-1",
         baseSha: "",
-        buildDurationSeconds: 0,
+        buildDurationMs: 0,
       },
       context: createContext(),
     });
@@ -411,6 +624,55 @@ describe("RepoImageBuildWorkflow", () => {
     });
   });
 
+  it("runs completed provider-session cleanup after rejected image cleanup", async () => {
+    const store = createStore({
+      markBuildReady: vi.fn(async () => ({
+        updated: false,
+        replacedImageId: null,
+        replacedProviderSessionId: null,
+        replacedImages: [],
+      })),
+    });
+    const deleteImage = vi.fn(async () => undefined);
+    const cleanupCompletedBuild = vi.fn(async () => undefined);
+    const adapter = createAdapter({ deleteImage, cleanupCompletedBuild });
+    const workflow = new RepoImageBuildWorkflow(
+      env,
+      store,
+      createAdapterFactory(adapter),
+      "opencomputer"
+    );
+
+    const result = await workflow.acceptBuildComplete({
+      callbackToken: CALLBACK_TOKEN,
+      completion: {
+        kind: "provider_session",
+        buildId: "build-1",
+        providerSessionId: "provider-session-1",
+        baseSha: "abc123",
+        buildDurationMs: 12_500,
+      },
+      context: createContext(),
+    });
+
+    await expectCompletionAccepted(result);
+
+    expect(deleteImage).toHaveBeenCalledWith({
+      providerImageId: "provider-image-1",
+      providerSessionId: "provider-session-1",
+      correlation: { request_id: "request-1", trace_id: "trace-1" },
+    });
+    expect(cleanupCompletedBuild).toHaveBeenCalledWith({
+      kind: "provider_session",
+      buildId: "build-1",
+      providerSessionId: "provider-session-1",
+      correlation: { request_id: "request-1", trace_id: "trace-1" },
+    });
+    expect(deleteImage.mock.invocationCallOrder[0]).toBeLessThan(
+      cleanupCompletedBuild.mock.invocationCallOrder[0]
+    );
+  });
+
   it("marks the build failed when provider finalization fails after token acceptance", async () => {
     const store = createStore();
     const adapter = createAdapter({
@@ -418,7 +680,12 @@ describe("RepoImageBuildWorkflow", () => {
         throw new Error("snapshot failed");
       }),
     });
-    const workflow = new RepoImageBuildWorkflow(env, store, () => adapter, "vercel");
+    const workflow = new RepoImageBuildWorkflow(
+      env,
+      store,
+      createAdapterFactory(adapter),
+      "vercel"
+    );
 
     const result = await workflow.acceptBuildComplete({
       callbackToken: CALLBACK_TOKEN,
@@ -427,7 +694,7 @@ describe("RepoImageBuildWorkflow", () => {
         buildId: "build-1",
         providerSessionId: "provider-session-1",
         baseSha: "",
-        buildDurationSeconds: 0,
+        buildDurationMs: 0,
       },
       context: createContext(),
     });
@@ -442,7 +709,12 @@ describe("RepoImageBuildWorkflow", () => {
       consumeCallbackToken: vi.fn(async () => null),
     });
     const adapter = createAdapter();
-    const workflow = new RepoImageBuildWorkflow(env, store, () => adapter, "vercel");
+    const workflow = new RepoImageBuildWorkflow(
+      env,
+      store,
+      createAdapterFactory(adapter),
+      "vercel"
+    );
 
     const result = await workflow.acceptBuildComplete({
       callbackToken: CALLBACK_TOKEN,
@@ -451,7 +723,7 @@ describe("RepoImageBuildWorkflow", () => {
         buildId: "build-1",
         providerSessionId: "provider-session-1",
         baseSha: "",
-        buildDurationSeconds: 0,
+        buildDurationMs: 0,
       },
       context: createContext(),
     });
@@ -464,10 +736,10 @@ describe("RepoImageBuildWorkflow", () => {
     const store = createStore({
       consumeCallbackToken: vi.fn(async () => null),
     });
-    const createAdapter = vi.fn(() => {
-      throw new Error("Vercel configuration not available");
-    });
-    const workflow = new RepoImageBuildWorkflow(env, store, createAdapter, "vercel");
+    const adapterFactory = createThrowingAdapterFactory(
+      new Error("Vercel configuration not available")
+    );
+    const workflow = new RepoImageBuildWorkflow(env, store, adapterFactory, "vercel");
 
     const result = await workflow.acceptBuildComplete({
       callbackToken: CALLBACK_TOKEN,
@@ -476,21 +748,21 @@ describe("RepoImageBuildWorkflow", () => {
         buildId: "build-1",
         providerSessionId: "provider-session-1",
         baseSha: "",
-        buildDurationSeconds: 0,
+        buildDurationMs: 0,
       },
       context: createContext(),
     });
 
     expect(result).toEqual({ type: "callback_auth_rejected", message: "Unauthorized" });
-    expect(createAdapter).not.toHaveBeenCalled();
+    expect(adapterFactory.createVercel).not.toHaveBeenCalled();
   });
 
   it("marks valid completions failed when provider configuration is unavailable", async () => {
     const store = createStore();
-    const createAdapter = vi.fn(() => {
-      throw new Error("Vercel configuration not available");
-    });
-    const workflow = new RepoImageBuildWorkflow(env, store, createAdapter, "vercel");
+    const adapterFactory = createThrowingAdapterFactory(
+      new Error("Vercel configuration not available")
+    );
+    const workflow = new RepoImageBuildWorkflow(env, store, adapterFactory, "vercel");
 
     const result = await workflow.acceptBuildComplete({
       callbackToken: CALLBACK_TOKEN,
@@ -499,25 +771,30 @@ describe("RepoImageBuildWorkflow", () => {
         buildId: "build-1",
         providerSessionId: "provider-session-1",
         baseSha: "",
-        buildDurationSeconds: 0,
+        buildDurationMs: 0,
       },
       context: createContext(),
     });
 
     await expectCompletionAccepted(result);
 
-    expect(createAdapter).toHaveBeenCalledOnce();
+    expect(adapterFactory.createVercel).toHaveBeenCalledOnce();
     expect(store.markBuildFailed).toHaveBeenCalledWith(
       "build-1",
       "vercel",
-      "Vercel configuration not available"
+      "Repo image provider is not configured"
     );
   });
 
   it("marks failed callbacks and asks the adapter to clean up provider-session sandboxes", async () => {
     const store = createStore();
     const adapter = createAdapter();
-    const workflow = new RepoImageBuildWorkflow(env, store, () => adapter, "vercel");
+    const workflow = new RepoImageBuildWorkflow(
+      env,
+      store,
+      createAdapterFactory(adapter),
+      "vercel"
+    );
 
     const result = await workflow.acceptBuildFailed({
       callbackToken: CALLBACK_TOKEN,
@@ -544,10 +821,10 @@ describe("RepoImageBuildWorkflow", () => {
 
   it("does not require provider cleanup configuration to accept failed callbacks", async () => {
     const store = createStore();
-    const createAdapter = vi.fn(() => {
-      throw new Error("Vercel configuration not available");
-    });
-    const workflow = new RepoImageBuildWorkflow(env, store, createAdapter, "vercel");
+    const adapterFactory = createThrowingAdapterFactory(
+      new Error("Vercel configuration not available")
+    );
+    const workflow = new RepoImageBuildWorkflow(env, store, adapterFactory, "vercel");
 
     const result = await workflow.acceptBuildFailed({
       callbackToken: CALLBACK_TOKEN,
@@ -562,6 +839,6 @@ describe("RepoImageBuildWorkflow", () => {
 
     expect(result).toEqual({ type: "build_failed" });
     expect(store.markBuildFailed).toHaveBeenCalledWith("build-1", "vercel", "setup failed");
-    expect(createAdapter).toHaveBeenCalledOnce();
+    expect(adapterFactory.createVercel).toHaveBeenCalledOnce();
   });
 });

--- a/packages/control-plane/src/repo-images/workflow.test.ts
+++ b/packages/control-plane/src/repo-images/workflow.test.ts
@@ -62,40 +62,24 @@ function createAdapter(
 }
 
 function createAdapterFactory(adapter: AnyRepoImageBuildAdapter): RepoImageBuildAdapterFactory & {
-  createModal: ReturnType<typeof vi.fn>;
-  createVercel: ReturnType<typeof vi.fn>;
-  createOpenComputer: ReturnType<typeof vi.fn>;
+  create: ReturnType<typeof vi.fn>;
 } {
   return {
-    createModal: vi.fn(() => adapter),
-    createVercel: vi.fn(() => adapter),
-    createOpenComputer: vi.fn(() => adapter),
+    create: vi.fn(() => adapter),
   } as unknown as RepoImageBuildAdapterFactory & {
-    createModal: ReturnType<typeof vi.fn>;
-    createVercel: ReturnType<typeof vi.fn>;
-    createOpenComputer: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
   };
 }
 
 function createThrowingAdapterFactory(error: Error): RepoImageBuildAdapterFactory & {
-  createModal: ReturnType<typeof vi.fn>;
-  createVercel: ReturnType<typeof vi.fn>;
-  createOpenComputer: ReturnType<typeof vi.fn>;
+  create: ReturnType<typeof vi.fn>;
 } {
   return {
-    createModal: vi.fn(() => {
-      throw error;
-    }),
-    createVercel: vi.fn(() => {
-      throw error;
-    }),
-    createOpenComputer: vi.fn(() => {
+    create: vi.fn(() => {
       throw error;
     }),
   } as unknown as RepoImageBuildAdapterFactory & {
-    createModal: ReturnType<typeof vi.fn>;
-    createVercel: ReturnType<typeof vi.fn>;
-    createOpenComputer: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -754,7 +738,7 @@ describe("RepoImageBuildWorkflow", () => {
     });
 
     expect(result).toEqual({ type: "callback_auth_rejected", message: "Unauthorized" });
-    expect(adapterFactory.createVercel).not.toHaveBeenCalled();
+    expect(adapterFactory.create).not.toHaveBeenCalled();
   });
 
   it("marks valid completions failed when provider configuration is unavailable", async () => {
@@ -778,7 +762,7 @@ describe("RepoImageBuildWorkflow", () => {
 
     await expectCompletionAccepted(result);
 
-    expect(adapterFactory.createVercel).toHaveBeenCalledOnce();
+    expect(adapterFactory.create).toHaveBeenCalledWith("vercel");
     expect(store.markBuildFailed).toHaveBeenCalledWith(
       "build-1",
       "vercel",
@@ -839,6 +823,6 @@ describe("RepoImageBuildWorkflow", () => {
 
     expect(result).toEqual({ type: "build_failed" });
     expect(store.markBuildFailed).toHaveBeenCalledWith("build-1", "vercel", "setup failed");
-    expect(adapterFactory.createVercel).toHaveBeenCalledOnce();
+    expect(adapterFactory.create).toHaveBeenCalledWith("vercel");
   });
 });

--- a/packages/control-plane/src/repo-images/workflow.ts
+++ b/packages/control-plane/src/repo-images/workflow.ts
@@ -1,17 +1,23 @@
+import { generateId } from "../auth/crypto";
 import { RepoImageStore } from "../db/repo-images";
-import type { RepoImageProvider } from "../db/repo-images";
+import type { RepoImageBuild, RepoImageProvider } from "../db/repo-images";
 import { createLogger, type CorrelationContext } from "../logger";
 import type { Env } from "../types";
 import { hashRepoImageCallbackToken } from "./auth";
 import { getRepoImageBackend } from "./backend-policy";
 import { RepoImageBuildPlanner } from "./planner";
-import { createRepoImageBuildAdapter } from "./provider-factory";
+import {
+  createRepoImageBuildAdapterFactory,
+  type RepoImageBuildAdapterFactory,
+} from "./provider-factory";
 import type {
+  AnyRepoImageBuildAdapter,
   CompleteProviderSessionBuild,
   CompleteRepoImageBuild,
   FailRepoImageBuild,
   FinalizeRepoImageBuildResult,
-  RepoImageBuildAdapter,
+  PlannedRepoImageBuild,
+  RepoImageBuildFinalizer,
   RepoImageWorkflowContext,
   RepoImageWorkflowResult,
   ReplacedRepoImage,
@@ -19,14 +25,22 @@ import type {
 
 const logger = createLogger("repo-images:workflow");
 
-type RepoImageBuildAdapterFactory = () => RepoImageBuildAdapter;
 type PlanBuildInput = Parameters<RepoImageBuildPlanner["planBuild"]>[0];
-type AdapterResolution =
-  | { type: "ok"; adapter: RepoImageBuildAdapter }
+type AdapterResolution<TAdapter extends RepoImageBuildFinalizer> =
+  | { type: "ok"; adapter: TAdapter }
   | {
       type: "unconfigured";
       result: Extract<RepoImageWorkflowResult, { type: "repo_image_provider_unconfigured" }>;
     };
+type PlannedBuildStart =
+  | {
+      type: "ok";
+      adapter: AnyRepoImageBuildAdapter;
+      start(callbacks: {
+        bindProviderSession(providerSessionId: string): Promise<void>;
+      }): Promise<void>;
+    }
+  | Extract<AdapterResolution<AnyRepoImageBuildAdapter>, { type: "unconfigured" }>;
 
 interface RepoImageBuildPlannerLike {
   planBuild(params: PlanBuildInput): ReturnType<RepoImageBuildPlanner["planBuild"]>;
@@ -37,7 +51,7 @@ interface ReadyBuildCompletion {
   buildId: string;
   providerSessionId?: string;
   baseSha: string;
-  buildDurationSeconds: number;
+  buildDurationMs: number;
 }
 
 export interface AcceptBuildCompleteCommand {
@@ -56,7 +70,7 @@ export class RepoImageBuildWorkflow {
   constructor(
     private readonly env: Env,
     private readonly store: RepoImageStore,
-    private readonly createAdapter: RepoImageBuildAdapterFactory,
+    private readonly adapterFactory: RepoImageBuildAdapterFactory,
     private readonly backend: RepoImageProvider,
     private readonly planner: RepoImageBuildPlannerLike = new RepoImageBuildPlanner(env, backend)
   ) {}
@@ -71,7 +85,9 @@ export class RepoImageBuildWorkflow {
     }
 
     const now = Date.now();
-    const buildId = `img-${owner}-${name}-${now}`;
+    const buildId = createBuildId(owner, name, now);
+    let providerSessionIdForCleanup: string | null = null;
+    let adapterForCleanup: AnyRepoImageBuildAdapter | null = null;
 
     try {
       const planned = await this.planner.planBuild({
@@ -93,22 +109,23 @@ export class RepoImageBuildWorkflow {
         };
       }
 
-      const adapterResolution = this.createAdapterForOperation("trigger_build", ctx, buildId);
-      if (adapterResolution.type === "unconfigured") return adapterResolution.result;
-      const { adapter } = adapterResolution;
+      const build = planned.build;
+      const start = this.preparePlannedBuildStart(build, ctx);
+      if (start.type === "unconfigured") return start.result;
+      adapterForCleanup = start.adapter;
 
       await this.store.registerBuild({
         id: buildId,
         repoOwner: owner,
         repoName: name,
         provider: this.backend,
-        baseBranch: planned.registration.baseBranch,
-        callbackTokenHash: planned.registration.callbackTokenHash,
-        callbackTokenExpiresAt: planned.registration.callbackTokenExpiresAt,
+        baseBranch: build.plan.baseBranch,
+        ...callbackAuthRegistration(build),
       });
 
-      await adapter.startBuild(planned.plan, {
+      await start.start({
         bindProviderSession: async (providerSessionId) => {
+          providerSessionIdForCleanup = providerSessionId;
           const bound = await this.store.bindProviderSession(
             buildId,
             this.backend,
@@ -130,6 +147,26 @@ export class RepoImageBuildWorkflow {
 
       return { type: "build_triggered", buildId };
     } catch (e) {
+      if (providerSessionIdForCleanup && adapterForCleanup?.cleanupFailedBuild) {
+        await adapterForCleanup
+          .cleanupFailedBuild({
+            kind: "provider_session",
+            buildId,
+            providerSessionId: providerSessionIdForCleanup,
+            errorMessage: errorMessage(e),
+            correlation: ctx,
+          })
+          .catch((cleanupError) => {
+            logger.warn(`repo_image.${this.backend}_trigger_cleanup_failed`, {
+              build_id: buildId,
+              provider_session_id: providerSessionIdForCleanup,
+              error: errorMessage(cleanupError),
+              request_id: ctx.request_id,
+              trace_id: ctx.trace_id,
+            });
+          });
+      }
+
       try {
         await this.store.markBuildFailed(buildId, this.backend, errorMessage(e));
       } catch (markFailedError) {
@@ -194,8 +231,9 @@ export class RepoImageBuildWorkflow {
     if (adapterResolution.type === "unconfigured") return adapterResolution.result;
     const { adapter } = adapterResolution;
 
+    let finalized: FinalizeRepoImageBuildResult | null = null;
     try {
-      const finalized = await adapter.finalizeSuccessfulBuild({
+      finalized = await adapter.finalizeSuccessfulBuild({
         ...completion,
         correlation: ctx,
       });
@@ -214,6 +252,14 @@ export class RepoImageBuildWorkflow {
         ? { type: "build_ready", replacedImages: result.replacedImages, cleanup: result.cleanup }
         : { type: "build_ready", replacedImages: result.replacedImages };
     } catch (e) {
+      if (finalized) {
+        await this.deleteImageBestEffort(
+          finalized.providerImageId,
+          finalized.providerSessionId,
+          ctx,
+          adapter
+        );
+      }
       logger.error("repo_image.build_complete_error", {
         error: errorMessage(e),
         build_id: completion.buildId,
@@ -279,9 +325,35 @@ export class RepoImageBuildWorkflow {
     operation: string,
     ctx: RepoImageWorkflowContext,
     buildId?: string
-  ): AdapterResolution {
+  ): AdapterResolution<AnyRepoImageBuildAdapter> {
+    switch (this.backend) {
+      case "modal":
+        return this.createAdapter(operation, ctx, () => this.adapterFactory.createModal(), buildId);
+      case "vercel":
+        return this.createAdapter(
+          operation,
+          ctx,
+          () => this.adapterFactory.createVercel(),
+          buildId
+        );
+      case "opencomputer":
+        return this.createAdapter(
+          operation,
+          ctx,
+          () => this.adapterFactory.createOpenComputer(),
+          buildId
+        );
+    }
+  }
+
+  private createAdapter<TAdapter extends RepoImageBuildFinalizer>(
+    operation: string,
+    ctx: RepoImageWorkflowContext,
+    create: () => TAdapter,
+    buildId?: string
+  ): AdapterResolution<TAdapter> {
     try {
-      return { type: "ok", adapter: this.createAdapter() };
+      return { type: "ok", adapter: create() };
     } catch (e) {
       logger.error("repo_image.adapter_config_error", {
         operation,
@@ -301,24 +373,64 @@ export class RepoImageBuildWorkflow {
     }
   }
 
+  private preparePlannedBuildStart(
+    build: PlannedRepoImageBuild,
+    ctx: RepoImageWorkflowContext
+  ): PlannedBuildStart {
+    const plan = build.plan;
+    switch (plan.provider) {
+      case "modal": {
+        const adapterResolution = this.createAdapter(
+          "trigger_build",
+          ctx,
+          () => this.adapterFactory.createModal(),
+          plan.buildId
+        );
+        if (adapterResolution.type === "unconfigured") return adapterResolution;
+        return {
+          type: "ok",
+          adapter: adapterResolution.adapter,
+          start: (callbacks) => adapterResolution.adapter.startBuild(plan, callbacks),
+        };
+      }
+      case "vercel": {
+        const adapterResolution = this.createAdapter(
+          "trigger_build",
+          ctx,
+          () => this.adapterFactory.createVercel(),
+          plan.buildId
+        );
+        if (adapterResolution.type === "unconfigured") return adapterResolution;
+        return {
+          type: "ok",
+          adapter: adapterResolution.adapter,
+          start: (callbacks) => adapterResolution.adapter.startBuild(plan, callbacks),
+        };
+      }
+      case "opencomputer": {
+        const adapterResolution = this.createAdapter(
+          "trigger_build",
+          ctx,
+          () => this.adapterFactory.createOpenComputer(),
+          plan.buildId
+        );
+        if (adapterResolution.type === "unconfigured") return adapterResolution;
+        return {
+          type: "ok",
+          adapter: adapterResolution.adapter,
+          start: (callbacks) => adapterResolution.adapter.startBuild(plan, callbacks),
+        };
+      }
+    }
+  }
+
   private createAdapterForBestEffortCleanup(
     buildId: string,
     providerSessionId: string | null | undefined,
     ctx: RepoImageWorkflowContext
-  ): RepoImageBuildAdapter | null {
-    try {
-      return this.createAdapter();
-    } catch (e) {
-      logger.warn("repo_image.cleanup_adapter_unavailable", {
-        build_id: buildId,
-        provider_session_id: providerSessionId,
-        provider: this.backend,
-        error: errorMessage(e),
-        request_id: ctx.request_id,
-        trace_id: ctx.trace_id,
-      });
-      return null;
-    }
+  ): AnyRepoImageBuildAdapter | null {
+    const adapterResolution = this.createAdapterForOperation("cleanup", ctx, buildId);
+    return adapterResolution.type === "ok" ? adapterResolution.adapter : null;
   }
 
   private async requireTokenBuildCallbackAuth(
@@ -379,11 +491,19 @@ export class RepoImageBuildWorkflow {
     ctx: RepoImageWorkflowContext
   ): Promise<void> {
     const startedAt = Date.now();
-    let finalizedProviderImageId: string | null = null;
-    let adapter: RepoImageBuildAdapter | null = null;
+    let finalized: FinalizeRepoImageBuildResult | null = null;
+    let adapter: AnyRepoImageBuildAdapter | null = null;
 
     try {
-      adapter = this.createAdapter();
+      const adapterResolution = this.createAdapterForOperation(
+        "build_complete",
+        ctx,
+        input.buildId
+      );
+      if (adapterResolution.type === "unconfigured") {
+        throw new Error(adapterResolution.result.message);
+      }
+      adapter = adapterResolution.adapter;
       logger.info(`repo_image.${this.backend}_finalize_start`, {
         build_id: input.buildId,
         provider_session_id: input.providerSessionId,
@@ -391,8 +511,7 @@ export class RepoImageBuildWorkflow {
         trace_id: ctx.trace_id,
       });
 
-      const finalized = await adapter.finalizeSuccessfulBuild(input);
-      finalizedProviderImageId = finalized.providerImageId;
+      finalized = await adapter.finalizeSuccessfulBuild(input);
 
       const result = await this.markFinalizedBuildReady({
         adapter,
@@ -403,15 +522,19 @@ export class RepoImageBuildWorkflow {
         deleteFinalizedImageOnReject: true,
       });
       await result.cleanup;
+      await this.cleanupCompletedBuild(adapter, input, ctx);
     } catch (e) {
       const message = errorMessage(e);
-      if (finalizedProviderImageId && adapter) {
+      if (finalized && adapter) {
         await this.deleteImageBestEffort(
-          finalizedProviderImageId,
-          input.providerSessionId,
+          finalized.providerImageId,
+          finalized.providerSessionId,
           ctx,
           adapter
         );
+      }
+      if (adapter) {
+        await this.cleanupCompletedBuild(adapter, input, ctx);
       }
       try {
         await this.store.markBuildFailed(input.buildId, this.backend, message);
@@ -435,21 +558,39 @@ export class RepoImageBuildWorkflow {
   }
 
   private deleteReplacedImages(
-    adapter: RepoImageBuildAdapter,
+    adapter: RepoImageBuildFinalizer,
     replacedImages: ReplacedRepoImage[],
     ctx: RepoImageWorkflowContext
   ): Promise<void> | undefined {
     if (replacedImages.length === 0) return undefined;
 
     return Promise.all(
-      replacedImages.map((image) =>
-        this.deleteImageBestEffort(image.providerImageId, image.providerSessionId, ctx, adapter)
-      )
+      replacedImages.map(async (image) => {
+        const deleted = await this.deleteImageBestEffort(
+          image.providerImageId,
+          image.providerSessionId,
+          ctx,
+          adapter
+        );
+        if (deleted) {
+          try {
+            await this.store.deleteSupersededImage(image.repoImageId);
+          } catch (e) {
+            logger.warn("repo_image.delete_superseded_row_failed", {
+              repo_image_id: image.repoImageId,
+              provider_image_id: image.providerImageId,
+              error: errorMessage(e),
+              request_id: ctx.request_id,
+              trace_id: ctx.trace_id,
+            });
+          }
+        }
+      })
     ).then(() => undefined);
   }
 
   private async markFinalizedBuildReady(params: {
-    adapter: RepoImageBuildAdapter;
+    adapter: RepoImageBuildFinalizer;
     completion: ReadyBuildCompletion;
     finalized: FinalizeRepoImageBuildResult;
     ctx: RepoImageWorkflowContext;
@@ -467,7 +608,7 @@ export class RepoImageBuildWorkflow {
       this.backend,
       params.finalized.providerImageId,
       params.completion.baseSha,
-      params.completion.buildDurationSeconds
+      params.completion.buildDurationMs
     );
 
     if (!result.updated) {
@@ -539,18 +680,45 @@ export class RepoImageBuildWorkflow {
     providerImageId: string,
     providerSessionId: string | null | undefined,
     ctx: RepoImageWorkflowContext,
-    adapter: RepoImageBuildAdapter
-  ): Promise<void> {
+    adapter: RepoImageBuildFinalizer
+  ): Promise<boolean> {
     try {
       await adapter.deleteImage({
         providerImageId,
         providerSessionId,
         correlation: ctx,
       });
+      return true;
     } catch (e) {
       logger.warn("repo_image.delete_old_failed", {
         provider_image_id: providerImageId,
         error: errorMessage(e),
+      });
+      return false;
+    }
+  }
+
+  private async cleanupCompletedBuild(
+    adapter: RepoImageBuildFinalizer,
+    input: CompleteProviderSessionBuild & { correlation: CorrelationContext },
+    ctx: RepoImageWorkflowContext
+  ): Promise<void> {
+    if (!adapter.cleanupCompletedBuild) return;
+
+    try {
+      await adapter.cleanupCompletedBuild({
+        kind: "provider_session",
+        buildId: input.buildId,
+        providerSessionId: input.providerSessionId,
+        correlation: ctx,
+      });
+    } catch (e) {
+      logger.warn(`repo_image.${this.backend}_completed_build_cleanup_failed`, {
+        build_id: input.buildId,
+        provider_session_id: input.providerSessionId,
+        error: errorMessage(e),
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
       });
     }
   }
@@ -560,9 +728,24 @@ export function createRepoImageBuildWorkflowFromEnv(env: Env): RepoImageBuildWor
   return new RepoImageBuildWorkflow(
     env,
     new RepoImageStore(env.DB),
-    () => createRepoImageBuildAdapter(env),
+    createRepoImageBuildAdapterFactory(env),
     getRepoImageBackend(env)
   );
+}
+
+function createBuildId(owner: string, name: string, now: number): string {
+  return `img-${owner}-${name}-${now}-${generateId(4)}`;
+}
+
+function callbackAuthRegistration(
+  build: PlannedRepoImageBuild
+): Partial<Pick<RepoImageBuild, "callbackTokenHash" | "callbackTokenExpiresAt">> {
+  return build.callbackAuth.type === "bearer_token"
+    ? {
+        callbackTokenHash: build.callbackAuth.tokenHash,
+        callbackTokenExpiresAt: build.callbackAuth.expiresAt,
+      }
+    : {};
 }
 
 function errorMessage(errorValue: unknown): string {

--- a/packages/control-plane/src/repo-images/workflow.ts
+++ b/packages/control-plane/src/repo-images/workflow.ts
@@ -1,0 +1,570 @@
+import { RepoImageStore } from "../db/repo-images";
+import type { RepoImageProvider } from "../db/repo-images";
+import { createLogger, type CorrelationContext } from "../logger";
+import type { Env } from "../types";
+import { hashRepoImageCallbackToken } from "./auth";
+import { getRepoImageBackend } from "./backend-policy";
+import { RepoImageBuildPlanner } from "./planner";
+import { createRepoImageBuildAdapter } from "./provider-factory";
+import type {
+  CompleteProviderSessionBuild,
+  CompleteRepoImageBuild,
+  FailRepoImageBuild,
+  FinalizeRepoImageBuildResult,
+  RepoImageBuildAdapter,
+  RepoImageWorkflowContext,
+  RepoImageWorkflowResult,
+  ReplacedRepoImage,
+} from "./types";
+
+const logger = createLogger("repo-images:workflow");
+
+type RepoImageBuildAdapterFactory = () => RepoImageBuildAdapter;
+type PlanBuildInput = Parameters<RepoImageBuildPlanner["planBuild"]>[0];
+type AdapterResolution =
+  | { type: "ok"; adapter: RepoImageBuildAdapter }
+  | {
+      type: "unconfigured";
+      result: Extract<RepoImageWorkflowResult, { type: "repo_image_provider_unconfigured" }>;
+    };
+
+interface RepoImageBuildPlannerLike {
+  planBuild(params: PlanBuildInput): ReturnType<RepoImageBuildPlanner["planBuild"]>;
+}
+
+interface ReadyBuildCompletion {
+  kind: "provider_image" | "provider_session";
+  buildId: string;
+  providerSessionId?: string;
+  baseSha: string;
+  buildDurationSeconds: number;
+}
+
+export interface AcceptBuildCompleteCommand {
+  completion: CompleteRepoImageBuild;
+  callbackToken?: string | null;
+  context: RepoImageWorkflowContext;
+}
+
+export interface AcceptBuildFailedCommand {
+  failure: FailRepoImageBuild;
+  callbackToken?: string | null;
+  context: RepoImageWorkflowContext;
+}
+
+export class RepoImageBuildWorkflow {
+  constructor(
+    private readonly env: Env,
+    private readonly store: RepoImageStore,
+    private readonly createAdapter: RepoImageBuildAdapterFactory,
+    private readonly backend: RepoImageProvider,
+    private readonly planner: RepoImageBuildPlannerLike = new RepoImageBuildPlanner(env, backend)
+  ) {}
+
+  async triggerBuild(
+    owner: string,
+    name: string,
+    ctx: RepoImageWorkflowContext
+  ): Promise<RepoImageWorkflowResult> {
+    if (!this.env.WORKER_URL) {
+      return { type: "repo_image_workflow_unavailable", message: "WORKER_URL not configured" };
+    }
+
+    const now = Date.now();
+    const buildId = `img-${owner}-${name}-${now}`;
+
+    try {
+      const planned = await this.planner.planBuild({
+        buildId,
+        repoOwner: owner,
+        repoName: name,
+        now,
+        callbackUrl: `${this.env.WORKER_URL}/repo-images/build-complete`,
+        correlation: ctx,
+      });
+      if (planned.type === "repo_not_installed") {
+        return { type: "repository_not_installed", message: planned.message };
+      }
+      if (planned.type === "failed") {
+        return {
+          type: "workflow_failed",
+          operation: "trigger_build",
+          message: planned.message,
+        };
+      }
+
+      const adapterResolution = this.createAdapterForOperation("trigger_build", ctx, buildId);
+      if (adapterResolution.type === "unconfigured") return adapterResolution.result;
+      const { adapter } = adapterResolution;
+
+      await this.store.registerBuild({
+        id: buildId,
+        repoOwner: owner,
+        repoName: name,
+        provider: this.backend,
+        baseBranch: planned.registration.baseBranch,
+        callbackTokenHash: planned.registration.callbackTokenHash,
+        callbackTokenExpiresAt: planned.registration.callbackTokenExpiresAt,
+      });
+
+      await adapter.startBuild(planned.plan, {
+        bindProviderSession: async (providerSessionId) => {
+          const bound = await this.store.bindProviderSession(
+            buildId,
+            this.backend,
+            providerSessionId
+          );
+          if (!bound) {
+            throw new Error(`Failed to bind ${this.backend} build session`);
+          }
+        },
+      });
+
+      logger.info("repo_image.build_triggered", {
+        build_id: buildId,
+        repo_owner: owner,
+        repo_name: name,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+
+      return { type: "build_triggered", buildId };
+    } catch (e) {
+      try {
+        await this.store.markBuildFailed(buildId, this.backend, errorMessage(e));
+      } catch (markFailedError) {
+        logger.warn("repo_image.trigger_mark_failed_error", {
+          error: errorMessage(markFailedError),
+          build_id: buildId,
+          request_id: ctx.request_id,
+          trace_id: ctx.trace_id,
+        });
+      }
+
+      logger.error("repo_image.trigger_error", {
+        error: errorMessage(e),
+        repo_owner: owner,
+        repo_name: name,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+      return {
+        type: "workflow_failed",
+        operation: "trigger_build",
+        message: "Failed to trigger build",
+      };
+    }
+  }
+
+  async acceptBuildComplete(command: AcceptBuildCompleteCommand): Promise<RepoImageWorkflowResult> {
+    const { completion, context: ctx } = command;
+
+    if (completion.kind === "provider_session") {
+      const authError = await this.requireTokenBuildCallbackAuth(command.callbackToken, {
+        buildId: completion.buildId,
+        providerSessionId: completion.providerSessionId,
+        ctx,
+      });
+      if (authError) return authError;
+
+      logger.info("repo_image.build_complete_received", {
+        build_id: completion.buildId,
+        provider_session_id: completion.providerSessionId,
+        base_sha: completion.baseSha,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+
+      const finalization = this.finalizeAndCommit(
+        {
+          ...completion,
+          correlation: ctx,
+        },
+        ctx
+      );
+
+      return { type: "completion_accepted", finalization };
+    }
+
+    const adapterResolution = this.createAdapterForOperation(
+      "build_complete",
+      ctx,
+      completion.buildId
+    );
+    if (adapterResolution.type === "unconfigured") return adapterResolution.result;
+    const { adapter } = adapterResolution;
+
+    try {
+      const finalized = await adapter.finalizeSuccessfulBuild({
+        ...completion,
+        correlation: ctx,
+      });
+      const result = await this.markFinalizedBuildReady({
+        adapter,
+        completion,
+        finalized,
+        ctx,
+        startedAt: Date.now(),
+        deleteFinalizedImageOnReject: true,
+      });
+      if (!result.updated) {
+        return { type: "completion_not_accepted", message: "Build is not accepting completion" };
+      }
+      return result.cleanup
+        ? { type: "build_ready", replacedImages: result.replacedImages, cleanup: result.cleanup }
+        : { type: "build_ready", replacedImages: result.replacedImages };
+    } catch (e) {
+      logger.error("repo_image.build_complete_error", {
+        error: errorMessage(e),
+        build_id: completion.buildId,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+      return {
+        type: "workflow_failed",
+        operation: "build_complete",
+        message: "Failed to mark build as ready",
+      };
+    }
+  }
+
+  async acceptBuildFailed(command: AcceptBuildFailedCommand): Promise<RepoImageWorkflowResult> {
+    const { failure, context: ctx } = command;
+
+    if (failure.kind === "provider_session") {
+      const authError = await this.requireTokenBuildCallbackAuth(command.callbackToken, {
+        buildId: failure.buildId,
+        providerSessionId: failure.providerSessionId,
+        ctx,
+      });
+      if (authError) return authError;
+    }
+
+    try {
+      const updated = await this.store.markBuildFailed(
+        failure.buildId,
+        this.backend,
+        failure.errorMessage
+      );
+      if (!updated) {
+        return { type: "failure_not_accepted", message: "Build is not accepting failure" };
+      }
+
+      logger.info("repo_image.build_failed", {
+        build_id: failure.buildId,
+        error_message: failure.errorMessage,
+        provider_session_id: failure.kind === "provider_session" ? failure.providerSessionId : null,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+
+      const cleanup = this.cleanupFailedBuild(failure, ctx);
+      return cleanup ? { type: "build_failed", cleanup } : { type: "build_failed" };
+    } catch (e) {
+      logger.error("repo_image.build_failed_error", {
+        error: errorMessage(e),
+        build_id: failure.buildId,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+      return {
+        type: "workflow_failed",
+        operation: "build_failed",
+        message: "Failed to mark build as failed",
+      };
+    }
+  }
+
+  private createAdapterForOperation(
+    operation: string,
+    ctx: RepoImageWorkflowContext,
+    buildId?: string
+  ): AdapterResolution {
+    try {
+      return { type: "ok", adapter: this.createAdapter() };
+    } catch (e) {
+      logger.error("repo_image.adapter_config_error", {
+        operation,
+        build_id: buildId,
+        provider: this.backend,
+        error: errorMessage(e),
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+      return {
+        type: "unconfigured",
+        result: {
+          type: "repo_image_provider_unconfigured",
+          message: "Repo image provider is not configured",
+        },
+      };
+    }
+  }
+
+  private createAdapterForBestEffortCleanup(
+    buildId: string,
+    providerSessionId: string | null | undefined,
+    ctx: RepoImageWorkflowContext
+  ): RepoImageBuildAdapter | null {
+    try {
+      return this.createAdapter();
+    } catch (e) {
+      logger.warn("repo_image.cleanup_adapter_unavailable", {
+        build_id: buildId,
+        provider_session_id: providerSessionId,
+        provider: this.backend,
+        error: errorMessage(e),
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+      return null;
+    }
+  }
+
+  private async requireTokenBuildCallbackAuth(
+    token: string | null | undefined,
+    params: { buildId: string; providerSessionId: string; ctx: RepoImageWorkflowContext }
+  ): Promise<RepoImageWorkflowResult | null> {
+    if (!token) {
+      logger.warn("repo_image.callback_auth_failed", {
+        build_id: params.buildId,
+        provider_session_id: params.providerSessionId,
+        request_id: params.ctx.request_id,
+        trace_id: params.ctx.trace_id,
+      });
+      return { type: "callback_auth_rejected", message: "Unauthorized" };
+    }
+
+    let tokenHash: string;
+    try {
+      tokenHash = await hashRepoImageCallbackToken(token, this.env);
+    } catch (e) {
+      logger.error("repo_image.callback_auth_misconfigured", {
+        build_id: params.buildId,
+        error: errorMessage(e),
+        request_id: params.ctx.request_id,
+        trace_id: params.ctx.trace_id,
+      });
+      return {
+        type: "callback_auth_unavailable",
+        message: "Internal authentication not configured",
+      };
+    }
+
+    const build = await this.store.consumeCallbackToken({
+      buildId: params.buildId,
+      provider: this.backend,
+      providerSessionId: params.providerSessionId,
+      tokenHash,
+      now: Date.now(),
+    });
+
+    if (!build) {
+      logger.warn("repo_image.callback_auth_failed", {
+        build_id: params.buildId,
+        provider_session_id: params.providerSessionId,
+        request_id: params.ctx.request_id,
+        trace_id: params.ctx.trace_id,
+      });
+      return { type: "callback_auth_rejected", message: "Unauthorized" };
+    }
+
+    return null;
+  }
+
+  private async finalizeAndCommit(
+    input: CompleteProviderSessionBuild & {
+      correlation: CorrelationContext;
+    },
+    ctx: RepoImageWorkflowContext
+  ): Promise<void> {
+    const startedAt = Date.now();
+    let finalizedProviderImageId: string | null = null;
+    let adapter: RepoImageBuildAdapter | null = null;
+
+    try {
+      adapter = this.createAdapter();
+      logger.info(`repo_image.${this.backend}_finalize_start`, {
+        build_id: input.buildId,
+        provider_session_id: input.providerSessionId,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+
+      const finalized = await adapter.finalizeSuccessfulBuild(input);
+      finalizedProviderImageId = finalized.providerImageId;
+
+      const result = await this.markFinalizedBuildReady({
+        adapter,
+        completion: input,
+        finalized,
+        ctx,
+        startedAt,
+        deleteFinalizedImageOnReject: true,
+      });
+      await result.cleanup;
+    } catch (e) {
+      const message = errorMessage(e);
+      if (finalizedProviderImageId && adapter) {
+        await this.deleteImageBestEffort(
+          finalizedProviderImageId,
+          input.providerSessionId,
+          ctx,
+          adapter
+        );
+      }
+      try {
+        await this.store.markBuildFailed(input.buildId, this.backend, message);
+      } catch (markFailedError) {
+        logger.error("repo_image.mark_failed_after_finalize_error", {
+          build_id: input.buildId,
+          error: errorMessage(markFailedError),
+          request_id: ctx.request_id,
+          trace_id: ctx.trace_id,
+        });
+      }
+      logger.error(`repo_image.${this.backend}_finalize_error`, {
+        build_id: input.buildId,
+        provider_session_id: input.providerSessionId,
+        error: message,
+        duration_ms: Date.now() - startedAt,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+    }
+  }
+
+  private deleteReplacedImages(
+    adapter: RepoImageBuildAdapter,
+    replacedImages: ReplacedRepoImage[],
+    ctx: RepoImageWorkflowContext
+  ): Promise<void> | undefined {
+    if (replacedImages.length === 0) return undefined;
+
+    return Promise.all(
+      replacedImages.map((image) =>
+        this.deleteImageBestEffort(image.providerImageId, image.providerSessionId, ctx, adapter)
+      )
+    ).then(() => undefined);
+  }
+
+  private async markFinalizedBuildReady(params: {
+    adapter: RepoImageBuildAdapter;
+    completion: ReadyBuildCompletion;
+    finalized: FinalizeRepoImageBuildResult;
+    ctx: RepoImageWorkflowContext;
+    startedAt: number;
+    deleteFinalizedImageOnReject: boolean;
+  }): Promise<{
+    updated: boolean;
+    replacedImageId: string | null;
+    replacedProviderSessionId: string | null;
+    replacedImages: ReplacedRepoImage[];
+    cleanup?: Promise<void>;
+  }> {
+    const result = await this.store.markBuildReady(
+      params.completion.buildId,
+      this.backend,
+      params.finalized.providerImageId,
+      params.completion.baseSha,
+      params.completion.buildDurationSeconds
+    );
+
+    if (!result.updated) {
+      if (params.deleteFinalizedImageOnReject) {
+        await this.deleteImageBestEffort(
+          params.finalized.providerImageId,
+          params.finalized.providerSessionId,
+          params.ctx,
+          params.adapter
+        );
+      }
+
+      logger.warn(`repo_image.${this.backend}_finalize_not_applied`, {
+        build_id: params.completion.buildId,
+        provider_session_id: params.completion.providerSessionId,
+        provider_image_id: params.finalized.providerImageId,
+        duration_ms: Date.now() - params.startedAt,
+        request_id: params.ctx.request_id,
+        trace_id: params.ctx.trace_id,
+      });
+      return result;
+    }
+
+    logger.info("repo_image.build_complete", {
+      build_id: params.completion.buildId,
+      provider_image_id: params.finalized.providerImageId,
+      provider_session_id: params.completion.providerSessionId,
+      base_sha: params.completion.baseSha,
+      replaced_image_id: result.replacedImageId,
+      snapshot_duration_ms: Date.now() - params.startedAt,
+      request_id: params.ctx.request_id,
+      trace_id: params.ctx.trace_id,
+    });
+
+    const cleanup = this.deleteReplacedImages(params.adapter, result.replacedImages, params.ctx);
+    return cleanup ? { ...result, cleanup } : result;
+  }
+
+  private cleanupFailedBuild(
+    failure: FailRepoImageBuild,
+    ctx: RepoImageWorkflowContext
+  ): Promise<void> | undefined {
+    if (failure.kind !== "provider_session") return undefined;
+
+    const adapter = this.createAdapterForBestEffortCleanup(
+      failure.buildId,
+      failure.providerSessionId,
+      ctx
+    );
+    if (!adapter?.cleanupFailedBuild) return undefined;
+
+    return adapter
+      .cleanupFailedBuild({
+        ...failure,
+        correlation: ctx,
+      })
+      .catch((e) => {
+        logger.warn(`repo_image.${this.backend}_build_cleanup_failed`, {
+          build_id: failure.buildId,
+          provider_session_id: failure.providerSessionId,
+          error: errorMessage(e),
+          request_id: ctx.request_id,
+          trace_id: ctx.trace_id,
+        });
+      });
+  }
+
+  private async deleteImageBestEffort(
+    providerImageId: string,
+    providerSessionId: string | null | undefined,
+    ctx: RepoImageWorkflowContext,
+    adapter: RepoImageBuildAdapter
+  ): Promise<void> {
+    try {
+      await adapter.deleteImage({
+        providerImageId,
+        providerSessionId,
+        correlation: ctx,
+      });
+    } catch (e) {
+      logger.warn("repo_image.delete_old_failed", {
+        provider_image_id: providerImageId,
+        error: errorMessage(e),
+      });
+    }
+  }
+}
+
+export function createRepoImageBuildWorkflowFromEnv(env: Env): RepoImageBuildWorkflow {
+  return new RepoImageBuildWorkflow(
+    env,
+    new RepoImageStore(env.DB),
+    () => createRepoImageBuildAdapter(env),
+    getRepoImageBackend(env)
+  );
+}
+
+function errorMessage(errorValue: unknown): string {
+  return errorValue instanceof Error ? errorValue.message : String(errorValue);
+}

--- a/packages/control-plane/src/repo-images/workflow.ts
+++ b/packages/control-plane/src/repo-images/workflow.ts
@@ -326,24 +326,12 @@ export class RepoImageBuildWorkflow {
     ctx: RepoImageWorkflowContext,
     buildId?: string
   ): AdapterResolution<AnyRepoImageBuildAdapter> {
-    switch (this.backend) {
-      case "modal":
-        return this.createAdapter(operation, ctx, () => this.adapterFactory.createModal(), buildId);
-      case "vercel":
-        return this.createAdapter(
-          operation,
-          ctx,
-          () => this.adapterFactory.createVercel(),
-          buildId
-        );
-      case "opencomputer":
-        return this.createAdapter(
-          operation,
-          ctx,
-          () => this.adapterFactory.createOpenComputer(),
-          buildId
-        );
-    }
+    return this.createAdapter(
+      operation,
+      ctx,
+      () => this.adapterFactory.create(this.backend),
+      buildId
+    );
   }
 
   private createAdapter<TAdapter extends RepoImageBuildFinalizer>(
@@ -383,7 +371,7 @@ export class RepoImageBuildWorkflow {
         const adapterResolution = this.createAdapter(
           "trigger_build",
           ctx,
-          () => this.adapterFactory.createModal(),
+          () => this.adapterFactory.create(plan.provider),
           plan.buildId
         );
         if (adapterResolution.type === "unconfigured") return adapterResolution;
@@ -397,7 +385,7 @@ export class RepoImageBuildWorkflow {
         const adapterResolution = this.createAdapter(
           "trigger_build",
           ctx,
-          () => this.adapterFactory.createVercel(),
+          () => this.adapterFactory.create(plan.provider),
           plan.buildId
         );
         if (adapterResolution.type === "unconfigured") return adapterResolution;
@@ -411,7 +399,7 @@ export class RepoImageBuildWorkflow {
         const adapterResolution = this.createAdapter(
           "trigger_build",
           ctx,
-          () => this.adapterFactory.createOpenComputer(),
+          () => this.adapterFactory.create(plan.provider),
           plan.buildId
         );
         if (adapterResolution.type === "unconfigured") return adapterResolution;

--- a/packages/control-plane/src/routes/repo-image-callback-auth.ts
+++ b/packages/control-plane/src/routes/repo-image-callback-auth.ts
@@ -1,0 +1,83 @@
+import { verifyInternalToken } from "../auth/internal";
+import type { RepoImageProvider } from "../db/repo-images";
+import type { Logger } from "../logger";
+import { REPO_IMAGE_CALLBACK_TOKEN_PATTERN } from "../repo-images/auth";
+import type { Env } from "../types";
+import { error, type RequestContext } from "./shared";
+
+function getBearerToken(request: Request): string | null {
+  const authHeader = request.headers.get("Authorization");
+  if (!authHeader?.startsWith("Bearer ")) return null;
+  const token = authHeader.slice(7).trim();
+  return token || null;
+}
+
+export function getRepoImageCallbackBearerToken(request: Request): string | null {
+  const token = getBearerToken(request);
+  if (!token || !REPO_IMAGE_CALLBACK_TOKEN_PATTERN.test(token)) return null;
+  return token;
+}
+
+export async function requireBuildCallbackAuth(
+  request: Request,
+  env: Env,
+  ctx: RequestContext,
+  logger: Logger
+): Promise<Response | null> {
+  if (!env.INTERNAL_CALLBACK_SECRET) {
+    logger.error("repo_image.callback_auth_misconfigured", {
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return error("Internal authentication not configured", 500);
+  }
+
+  const authorized = await verifyInternalToken(
+    request.headers.get("Authorization"),
+    env.INTERNAL_CALLBACK_SECRET
+  );
+
+  if (!authorized) {
+    logger.warn("repo_image.callback_auth_failed", {
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return error("Unauthorized", 401);
+  }
+
+  return null;
+}
+
+function requireRepoImageCallbackBearerFormat(
+  request: Request,
+  ctx: RequestContext,
+  logger: Logger
+): Response | null {
+  if (getRepoImageCallbackBearerToken(request)) return null;
+
+  logger.warn("repo_image.callback_auth_failed", {
+    request_id: ctx.request_id,
+    trace_id: ctx.trace_id,
+  });
+  return error("Unauthorized", 401);
+}
+
+/**
+ * Authenticates Modal callbacks before parsing the body. Provider-session
+ * backends only get a bearer-token format gate here; single-use token
+ * authorization is completed by RepoImageBuildWorkflow after parsing the
+ * provider session id from the callback body.
+ */
+export async function requireCallbackPreParseGate(
+  request: Request,
+  env: Env,
+  backend: RepoImageProvider,
+  ctx: RequestContext,
+  logger: Logger
+): Promise<Response | null> {
+  if (backend === "modal") {
+    return requireBuildCallbackAuth(request, env, ctx, logger);
+  }
+
+  return requireRepoImageCallbackBearerFormat(request, ctx, logger);
+}

--- a/packages/control-plane/src/routes/repo-images.test.ts
+++ b/packages/control-plane/src/routes/repo-images.test.ts
@@ -65,18 +65,22 @@ function createRepoImageDb(row: RepoImageRow): D1Database {
                 repo_name: row.repo_name,
                 provider: row.provider,
                 base_branch: row.base_branch,
+                created_at: row.created_at,
               }
             : null;
         }
-        if (sql.includes("SELECT id, provider_image_id")) {
-          return null;
-        }
         return null;
+      },
+      all: async () => {
+        if (sql.includes("SELECT id, provider_image_id")) {
+          return { results: [] };
+        }
+        return { results: [] };
       },
       run: async () => {
         if (sql.includes("UPDATE repo_images SET callback_token_used_at")) {
           row.callback_token_used_at = Number(args[0]);
-        } else if (sql.includes("UPDATE repo_images SET status = 'ready'")) {
+        } else if (sql.includes("SET status = 'ready'")) {
           row.status = "ready";
           row.provider_image_id = String(args[0]);
           row.base_sha = String(args[1]);

--- a/packages/control-plane/src/routes/repo-images.test.ts
+++ b/packages/control-plane/src/routes/repo-images.test.ts
@@ -31,7 +31,7 @@ interface RepoImageRow {
   provider_session_id: string | null;
   base_branch: string;
   provider_image_id: string;
-  status: "building" | "ready" | "failed";
+  status: "building" | "ready" | "failed" | "superseded";
   base_sha: string;
   build_duration_seconds: number | null;
   error_message: string | null;

--- a/packages/control-plane/src/routes/repo-images.trigger.test.ts
+++ b/packages/control-plane/src/routes/repo-images.trigger.test.ts
@@ -149,7 +149,7 @@ describe("POST /repo-images/trigger/:owner/:name", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     registerBuildSpy.mockResolvedValue(undefined);
-    modalClient.buildRepoImage.mockResolvedValue(undefined);
+    modalClient.buildRepoImage.mockResolvedValue({ buildId: "build-1", status: "building" });
     vercelProvider.triggerRepoImageBuild.mockResolvedValue(undefined);
     integrationSettings.resolveSandboxSettings.mockResolvedValue({});
     scmProvider.generateCredentialHelperAuth.mockResolvedValue({

--- a/packages/control-plane/src/routes/repo-images.ts
+++ b/packages/control-plane/src/routes/repo-images.ts
@@ -39,6 +39,9 @@ import {
 } from "./repo-image-callback-auth";
 
 const logger = createLogger("router:repo-images");
+const MS_PER_SECOND = 1000;
+const DEFAULT_STALE_BUILD_MAX_AGE_MS = 4200 * MS_PER_SECOND;
+const DEFAULT_FAILED_BUILD_CLEANUP_MAX_AGE_MS = 86400 * MS_PER_SECOND;
 
 interface RepoImageBuildCompleteBody {
   build_id?: unknown;
@@ -147,6 +150,7 @@ function buildCompleteCommand(
     "build_duration_seconds"
   );
   if (buildDurationSeconds instanceof Response) return buildDurationSeconds;
+  const buildDurationMs = buildDurationSeconds * MS_PER_SECOND;
 
   if (getRepoImageCallbackMode(backend) === "provider_session") {
     const providerSessionId = requireStringField(body.provider_session_id, "provider_session_id");
@@ -156,7 +160,7 @@ function buildCompleteCommand(
       buildId,
       providerSessionId,
       baseSha,
-      buildDurationSeconds,
+      buildDurationMs,
     };
   }
 
@@ -167,7 +171,7 @@ function buildCompleteCommand(
     buildId,
     providerImageId,
     baseSha,
-    buildDurationSeconds,
+    buildDurationMs,
   };
 }
 
@@ -361,10 +365,11 @@ async function handleMarkStale(
     body = {};
   }
 
-  // Body-less fallback only; the scheduler always sends max_age_seconds explicitly.
-  // Mirrors STALE_BUILD_THRESHOLD_SECONDS in the Modal scheduler (image_builder.py).
-  const maxAgeSeconds = body.max_age_seconds ?? 4200;
-  const maxAgeMs = maxAgeSeconds * 1000;
+  const maxAgeMs =
+    body.max_age_seconds === undefined
+      ? DEFAULT_STALE_BUILD_MAX_AGE_MS
+      : body.max_age_seconds * MS_PER_SECOND;
+  const maxAgeSeconds = maxAgeMs / MS_PER_SECOND;
 
   const store = new RepoImageStore(env.DB);
 
@@ -413,8 +418,11 @@ async function handleCleanup(
     body = {};
   }
 
-  const maxAgeSeconds = body.max_age_seconds ?? 86400;
-  const maxAgeMs = maxAgeSeconds * 1000;
+  const maxAgeMs =
+    body.max_age_seconds === undefined
+      ? DEFAULT_FAILED_BUILD_CLEANUP_MAX_AGE_MS
+      : body.max_age_seconds * MS_PER_SECOND;
+  const maxAgeSeconds = maxAgeMs / MS_PER_SECOND;
 
   const store = new RepoImageStore(env.DB);
 

--- a/packages/control-plane/src/routes/repo-images.ts
+++ b/packages/control-plane/src/routes/repo-images.ts
@@ -8,238 +8,194 @@
  * - Maintenance operations (stale builds, cleanup)
  */
 
-import { computeHmacHex, resolveBuildTimeoutSeconds } from "@open-inspect/shared";
-import { RepoImageStore } from "../db/repo-images";
-import { resolveSandboxSettings } from "../session/integration-settings-resolution";
-import { verifyInternalToken } from "../auth/internal";
+import { RepoImageStore, type RepoImageProvider } from "../db/repo-images";
 import { RepoMetadataStore } from "../db/repo-metadata";
-import { GlobalSecretsStore } from "../db/global-secrets";
-import { RepoSecretsStore } from "../db/repo-secrets";
-import { mergeSecrets } from "../db/secrets-validation";
-import { createModalClient } from "../sandbox/client";
-import { createVercelSandboxClient } from "../sandbox/providers/vercel/client";
-import { createVercelProvider } from "../sandbox/providers/vercel/provider";
-import { createOpenComputerRestClient } from "../sandbox/opencomputer-rest-client";
-import { createOpenComputerProvider } from "../sandbox/providers/opencomputer-provider";
-import { resolveSandboxBackendName, supportsRepoImageBackend } from "../sandbox/provider-name";
-import { resolveScmProviderFromEnv } from "../source-control";
 import { createLogger } from "../logger";
+import {
+  getRepoImageBackend,
+  getRepoImageCallbackMode,
+  getRepoImagesUnsupportedMessage,
+} from "../repo-images/backend-policy";
+import { createRepoImageBuildWorkflowFromEnv } from "../repo-images/workflow";
+import type {
+  CompleteRepoImageBuild,
+  FailRepoImageBuild,
+  RepoImageWorkflowContext,
+  RepoImageWorkflowResult,
+} from "../repo-images/types";
 import type { Env } from "../types";
 import {
-  type Route,
   type RequestContext,
-  parsePattern,
-  json,
+  type Route,
   error,
-  parseJsonBody,
   extractRepoParams,
-  createRouteSourceControlProvider,
-  resolveRepoOrError,
+  json,
+  parseJsonBody,
+  parsePattern,
 } from "./shared";
+import {
+  getRepoImageCallbackBearerToken,
+  requireCallbackPreParseGate,
+} from "./repo-image-callback-auth";
 
 const logger = createLogger("router:repo-images");
-const REPO_IMAGE_CALLBACK_TOKEN_TTL_MS = 2 * 60 * 60 * 1000;
-const REPO_IMAGE_CALLBACK_TOKEN_PATTERN = /^[a-f0-9]{64}$/;
+
+interface RepoImageBuildCompleteBody {
+  build_id?: unknown;
+  provider_image_id?: unknown;
+  provider_session_id?: unknown;
+  base_sha?: unknown;
+  build_duration_seconds?: unknown;
+}
+
+interface RepoImageBuildFailedBody {
+  build_id?: unknown;
+  provider_session_id?: unknown;
+  error?: unknown;
+}
 
 function requireRepoImages(env: Env): Response | null {
-  if (supportsRepoImageBackend(env.SANDBOX_PROVIDER)) {
-    return null;
-  }
-
-  return error(
-    "Repo images are only available when SANDBOX_PROVIDER=modal, vercel, or opencomputer",
-    501
-  );
+  const message = getRepoImagesUnsupportedMessage(env);
+  return message ? error(message, 501) : null;
 }
 
-function getRepoImageBackend(env: Env): "modal" | "vercel" | "opencomputer" {
-  const backend = resolveSandboxBackendName(env.SANDBOX_PROVIDER);
-  if (backend !== "modal" && backend !== "vercel" && backend !== "opencomputer") {
-    throw new Error(`Repo images are not supported for SANDBOX_PROVIDER=${backend}`);
-  }
-  return backend;
-}
-
-async function requireBuildCallbackAuth(
-  request: Request,
-  env: Env,
-  ctx: RequestContext
-): Promise<Response | null> {
-  if (!env.INTERNAL_CALLBACK_SECRET) {
-    logger.error("repo_image.callback_auth_misconfigured", {
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-    return error("Internal authentication not configured", 500);
-  }
-
-  const authorized = await verifyInternalToken(
-    request.headers.get("Authorization"),
-    env.INTERNAL_CALLBACK_SECRET
-  );
-
-  if (!authorized) {
-    logger.warn("repo_image.callback_auth_failed", {
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-    return error("Unauthorized", 401);
-  }
-
-  return null;
-}
-
-function createConfiguredVercelProvider(env: Env) {
-  if (!env.VERCEL_TOKEN || !env.VERCEL_PROJECT_ID) {
-    throw new Error("Vercel configuration not available");
-  }
-
-  const client = createVercelSandboxClient({
-    token: env.VERCEL_TOKEN,
-    projectId: env.VERCEL_PROJECT_ID,
-    teamId: env.VERCEL_TEAM_ID,
-    apiBaseUrl: env.VERCEL_SANDBOX_API_BASE_URL,
-  });
-
-  return createVercelProvider(client, {
-    scmProvider: resolveScmProviderFromEnv(env.SCM_PROVIDER),
-    token: env.VERCEL_TOKEN,
-    teamId: env.VERCEL_TEAM_ID,
-    apiBaseUrl: env.VERCEL_SANDBOX_API_BASE_URL,
-    baseSnapshotId: env.VERCEL_BASE_SNAPSHOT_ID,
-    baseSnapshotName: env.VERCEL_BASE_SNAPSHOT_NAME,
-    runtime: env.VERCEL_RUNTIME,
-    snapshotExpirationMs: parseInt(env.VERCEL_SNAPSHOT_EXPIRATION_MS || "0", 10),
-    codeServerPasswordSecret: env.VERCEL_TOKEN,
-  });
-}
-
-function createConfiguredOpenComputerProvider(env: Env) {
-  if (!env.OPENCOMPUTER_API_URL || !env.OPENCOMPUTER_API_KEY || !env.OPENCOMPUTER_TEMPLATE) {
-    throw new Error("OpenComputer configuration not available");
-  }
-
-  const client = createOpenComputerRestClient({
-    apiUrl: env.OPENCOMPUTER_API_URL,
-    apiKey: env.OPENCOMPUTER_API_KEY,
-    template: env.OPENCOMPUTER_TEMPLATE,
-    projectId: env.OPENCOMPUTER_PROJECT_ID,
-    target: env.OPENCOMPUTER_TARGET,
-  });
-
-  return createOpenComputerProvider(client, {
-    scmProvider: resolveScmProviderFromEnv(env.SCM_PROVIDER),
-    codeServerPasswordSecret: env.OPENCOMPUTER_API_KEY,
-    llmEnvVars: {
-      ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY,
-    },
-  });
-}
-
-function generateRepoImageCallbackToken(): string {
-  const bytes = new Uint8Array(32);
-  crypto.getRandomValues(bytes);
-  return Array.from(bytes)
-    .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("");
-}
-
-async function hashRepoImageCallbackToken(token: string, env: Env): Promise<string> {
-  if (!env.INTERNAL_CALLBACK_SECRET) {
-    throw new Error("INTERNAL_CALLBACK_SECRET is required for repo image callback hashing");
-  }
-  return computeHmacHex(`repo-image-callback:${token}`, env.INTERNAL_CALLBACK_SECRET);
-}
-
-function getBearerToken(request: Request): string | null {
-  const authHeader = request.headers.get("Authorization");
-  if (!authHeader?.startsWith("Bearer ")) return null;
-  const token = authHeader.slice(7).trim();
-  return token || null;
-}
-
-function getRepoImageCallbackBearerToken(request: Request): string | null {
-  const token = getBearerToken(request);
-  if (!token || !REPO_IMAGE_CALLBACK_TOKEN_PATTERN.test(token)) return null;
-  return token;
-}
-
-function requireRepoImageCallbackBearerAuth(
-  request: Request,
-  ctx: RequestContext
-): Response | null {
-  if (getRepoImageCallbackBearerToken(request)) return null;
-
-  logger.warn("repo_image.callback_auth_failed", {
+function workflowContext(ctx: RequestContext): RepoImageWorkflowContext {
+  return {
     request_id: ctx.request_id,
     trace_id: ctx.trace_id,
-  });
-  return error("Unauthorized", 401);
+  };
 }
 
-async function requireCallbackPreParseAuth(
-  request: Request,
-  env: Env,
-  backend: "modal" | "vercel" | "opencomputer",
+async function workflowResultToResponse(
+  result: RepoImageWorkflowResult,
   ctx: RequestContext
-): Promise<Response | null> {
-  if (backend === "modal") {
-    return requireBuildCallbackAuth(request, env, ctx);
+): Promise<Response> {
+  if (result.type === "completion_accepted") {
+    await scheduleWorkflowTask(result.finalization, ctx);
+  } else if ((result.type === "build_ready" || result.type === "build_failed") && result.cleanup) {
+    await scheduleWorkflowTask(result.cleanup, ctx);
   }
 
-  return requireRepoImageCallbackBearerAuth(request, ctx);
+  switch (result.type) {
+    case "build_triggered":
+      return json({ buildId: result.buildId, status: "building" });
+    case "completion_accepted":
+      return json({ ok: true, snapshotPending: true });
+    case "build_ready":
+      return json({
+        ok: true,
+        replacedImageId: result.replacedImages[0]?.providerImageId ?? null,
+      });
+    case "build_failed":
+      return json({ ok: true });
+    case "callback_auth_rejected":
+      return error(result.message, 401);
+    case "callback_auth_unavailable":
+      return error(result.message, 500);
+    case "repository_not_installed":
+      return error(result.message, 404);
+    case "repo_image_workflow_unavailable":
+    case "repo_image_provider_unconfigured":
+      return error(result.message, 503);
+    case "completion_not_accepted":
+    case "failure_not_accepted":
+      return error(result.message, 409);
+    case "workflow_failed":
+      return error(result.message, 500);
+    default: {
+      const exhaustive: never = result;
+      return error(`Unhandled workflow result: ${String(exhaustive)}`, 500);
+    }
+  }
 }
 
-async function requireTokenBuildCallbackAuth(
-  request: Request,
-  env: Env,
-  store: RepoImageStore,
-  params: { buildId: string; provider: "vercel" | "opencomputer"; providerSessionId: string },
-  ctx: RequestContext
-): Promise<Response | null> {
-  const token = getRepoImageCallbackBearerToken(request);
-  if (!token) {
-    logger.warn("repo_image.callback_auth_failed", {
-      build_id: params.buildId,
-      provider_session_id: params.providerSessionId,
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-    return error("Unauthorized", 401);
+async function scheduleWorkflowTask(task: Promise<void>, ctx: RequestContext): Promise<void> {
+  if (ctx.executionCtx) {
+    ctx.executionCtx.waitUntil(task);
+    return;
   }
 
-  let tokenHash: string;
-  try {
-    tokenHash = await hashRepoImageCallbackToken(token, env);
-  } catch (e) {
-    logger.error("repo_image.callback_auth_misconfigured", {
-      build_id: params.buildId,
-      error: e instanceof Error ? e.message : String(e),
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-    return error("Internal authentication not configured", 500);
+  await task;
+}
+
+function requireStringField(value: unknown, field: string): string | Response {
+  return typeof value === "string" && value.length > 0 ? value : error(`${field} is required`, 400);
+}
+
+function requireNumberField(value: unknown, field: string): number | Response {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : error(`${field} is required`, 400);
+}
+
+function optionalStringField(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+function buildCompleteCommand(
+  body: RepoImageBuildCompleteBody,
+  backend: RepoImageProvider
+): CompleteRepoImageBuild | Response {
+  const buildId = requireStringField(body.build_id, "build_id");
+  if (buildId instanceof Response) return buildId;
+
+  const baseSha = requireStringField(body.base_sha, "base_sha");
+  if (baseSha instanceof Response) return baseSha;
+
+  const buildDurationSeconds = requireNumberField(
+    body.build_duration_seconds,
+    "build_duration_seconds"
+  );
+  if (buildDurationSeconds instanceof Response) return buildDurationSeconds;
+
+  if (getRepoImageCallbackMode(backend) === "provider_session") {
+    const providerSessionId = requireStringField(body.provider_session_id, "provider_session_id");
+    if (providerSessionId instanceof Response) return providerSessionId;
+    return {
+      kind: "provider_session",
+      buildId,
+      providerSessionId,
+      baseSha,
+      buildDurationSeconds,
+    };
   }
 
-  const build = await store.consumeCallbackToken({
-    buildId: params.buildId,
-    provider: params.provider,
-    providerSessionId: params.providerSessionId,
-    tokenHash,
-    now: Date.now(),
-  });
+  const providerImageId = requireStringField(body.provider_image_id, "provider_image_id");
+  if (providerImageId instanceof Response) return providerImageId;
+  return {
+    kind: "provider_image",
+    buildId,
+    providerImageId,
+    baseSha,
+    buildDurationSeconds,
+  };
+}
 
-  if (!build) {
-    logger.warn("repo_image.callback_auth_failed", {
-      build_id: params.buildId,
-      provider_session_id: params.providerSessionId,
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-    return error("Unauthorized", 401);
+function buildFailedCommand(
+  body: RepoImageBuildFailedBody,
+  backend: RepoImageProvider
+): FailRepoImageBuild | Response {
+  const buildId = requireStringField(body.build_id, "build_id");
+  if (buildId instanceof Response) return buildId;
+
+  const errorMessage = optionalStringField(body.error, "Unknown error");
+
+  if (getRepoImageCallbackMode(backend) === "provider_session") {
+    const providerSessionId = requireStringField(body.provider_session_id, "provider_session_id");
+    if (providerSessionId instanceof Response) return providerSessionId;
+    return {
+      kind: "provider_session",
+      buildId,
+      providerSessionId,
+      errorMessage,
+    };
   }
 
-  return null;
+  return {
+    kind: "provider_image",
+    buildId,
+    errorMessage,
+  };
 }
 
 /**
@@ -260,452 +216,21 @@ async function handleBuildComplete(
   }
 
   const backend = getRepoImageBackend(env);
-  const preParseAuthError = await requireCallbackPreParseAuth(request, env, backend, ctx);
+  const preParseAuthError = await requireCallbackPreParseGate(request, env, backend, ctx, logger);
   if (preParseAuthError) return preParseAuthError;
 
-  const body = await parseJsonBody<{
-    build_id?: string;
-    provider_image_id?: string;
-    provider_session_id?: string;
-    base_sha?: string;
-    build_duration_seconds?: number;
-  }>(request);
+  const body = await parseJsonBody<RepoImageBuildCompleteBody>(request);
   if (body instanceof Response) return body;
 
-  const buildId = body.build_id;
-  const providerImageId = body.provider_image_id;
-  const providerSessionId = body.provider_session_id;
-  const baseSha = body.base_sha;
-  const buildDurationSeconds = body.build_duration_seconds;
+  const completion = buildCompleteCommand(body, backend);
+  if (completion instanceof Response) return completion;
 
-  if (!buildId) {
-    return error("build_id is required", 400);
-  }
-
-  const store = new RepoImageStore(env.DB);
-
-  if (backend === "vercel" || backend === "opencomputer") {
-    if (!providerSessionId) {
-      return error("provider_session_id is required", 400);
-    }
-
-    const authError = await requireTokenBuildCallbackAuth(
-      request,
-      env,
-      store,
-      { buildId, provider: backend, providerSessionId },
-      ctx
-    );
-    if (authError) return authError;
-
-    logger.info("repo_image.build_complete_received", {
-      build_id: buildId,
-      provider_session_id: providerSessionId,
-      base_sha: baseSha,
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-
-    const completion =
-      backend === "vercel"
-        ? completeVercelBuildFromSession(env, {
-            buildId,
-            providerSessionId,
-            baseSha: baseSha || "",
-            buildDurationSeconds: buildDurationSeconds ?? 0,
-            requestId: ctx.request_id,
-            traceId: ctx.trace_id,
-          })
-        : completeOpenComputerBuildFromSession(env, {
-            buildId,
-            providerSessionId,
-            baseSha: baseSha || "",
-            buildDurationSeconds: buildDurationSeconds ?? 0,
-            requestId: ctx.request_id,
-            traceId: ctx.trace_id,
-          });
-
-    if (ctx.executionCtx) {
-      ctx.executionCtx.waitUntil(completion);
-    } else {
-      await completion;
-    }
-
-    return json({ ok: true, snapshotPending: true });
-  }
-
-  if (!providerImageId) {
-    return error("provider_image_id is required", 400);
-  }
-
-  try {
-    const result = await store.markReady(
-      buildId,
-      backend,
-      providerImageId,
-      baseSha || "",
-      buildDurationSeconds ?? 0
-    );
-    if (!result.updated) {
-      return error("Build is not accepting completion", 409);
-    }
-
-    logger.info("repo_image.build_complete", {
-      build_id: buildId,
-      provider_image_id: providerImageId,
-      base_sha: baseSha,
-      replaced_image_id: result.replacedImageId,
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-
-    // Fire-and-forget: delete the replaced provider image if one was replaced.
-    if (result.replacedImageId) {
-      ctx.executionCtx?.waitUntil(
-        (async () => {
-          try {
-            if (getRepoImageBackend(env) === "vercel") {
-              await createConfiguredVercelProvider(env).deleteProviderImage(
-                result.replacedImageId!
-              );
-            } else if (env.MODAL_API_SECRET && env.MODAL_WORKSPACE) {
-              const client = createModalClient(
-                env.MODAL_API_SECRET,
-                env.MODAL_WORKSPACE,
-                env.MODAL_ENVIRONMENT_WEB_SUFFIX
-              );
-              await client.deleteProviderImage({ providerImageId: result.replacedImageId! });
-            }
-          } catch (e) {
-            logger.warn("repo_image.delete_old_failed", {
-              provider_image_id: result.replacedImageId,
-              error: e instanceof Error ? e.message : String(e),
-            });
-          }
-        })()
-      );
-    }
-
-    return json({ ok: true, replacedImageId: result.replacedImageId });
-  } catch (e) {
-    logger.error("repo_image.build_complete_error", {
-      error: e instanceof Error ? e.message : String(e),
-      build_id: buildId,
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-    return error("Failed to mark build as ready", 500);
-  }
-}
-
-async function completeVercelBuildFromSession(
-  env: Env,
-  params: {
-    buildId: string;
-    providerSessionId: string;
-    baseSha: string;
-    buildDurationSeconds: number;
-    requestId: string;
-    traceId: string;
-  }
-): Promise<void> {
-  if (!env.DB) {
-    logger.error("repo_image.vercel_snapshot_error", {
-      build_id: params.buildId,
-      provider_session_id: params.providerSessionId,
-      error: "Database not configured",
-      request_id: params.requestId,
-      trace_id: params.traceId,
-    });
-    return;
-  }
-
-  const snapshotStart = Date.now();
-  const store = new RepoImageStore(env.DB);
-  let vercelProvider: ReturnType<typeof createConfiguredVercelProvider> | null = null;
-
-  try {
-    logger.info("repo_image.vercel_snapshot_start", {
-      build_id: params.buildId,
-      provider_session_id: params.providerSessionId,
-      request_id: params.requestId,
-      trace_id: params.traceId,
-    });
-
-    vercelProvider = createConfiguredVercelProvider(env);
-    const snapshot = await vercelProvider.takeSnapshot({
-      providerObjectId: params.providerSessionId,
-      sessionId: params.buildId,
-      reason: "repo_image_build",
-      correlation: {
-        request_id: params.requestId,
-        trace_id: params.traceId,
-        sandbox_id: params.providerSessionId,
-      },
-    });
-
-    if (!snapshot.success || !snapshot.imageId) {
-      const message = snapshot.error || "Vercel snapshot did not return an image id";
-      await store.markFailed(params.buildId, "vercel", message);
-      logger.error("repo_image.vercel_snapshot_failed", {
-        build_id: params.buildId,
-        provider_session_id: params.providerSessionId,
-        error: message,
-        duration_ms: Date.now() - snapshotStart,
-        request_id: params.requestId,
-        trace_id: params.traceId,
-      });
-      return;
-    }
-
-    const result = await store.markReady(
-      params.buildId,
-      "vercel",
-      snapshot.imageId,
-      params.baseSha,
-      params.buildDurationSeconds
-    );
-    if (!result.updated) {
-      logger.warn("repo_image.vercel_snapshot_not_applied", {
-        build_id: params.buildId,
-        provider_session_id: params.providerSessionId,
-        provider_image_id: snapshot.imageId,
-        duration_ms: Date.now() - snapshotStart,
-        request_id: params.requestId,
-        trace_id: params.traceId,
-      });
-      return;
-    }
-
-    logger.info("repo_image.build_complete", {
-      build_id: params.buildId,
-      provider_image_id: snapshot.imageId,
-      provider_session_id: params.providerSessionId,
-      base_sha: params.baseSha,
-      replaced_image_id: result.replacedImageId,
-      snapshot_duration_ms: Date.now() - snapshotStart,
-      request_id: params.requestId,
-      trace_id: params.traceId,
-    });
-
-    if (result.replacedImageId) {
-      try {
-        await vercelProvider.deleteProviderImage(result.replacedImageId);
-      } catch (e) {
-        logger.warn("repo_image.delete_old_failed", {
-          provider_image_id: result.replacedImageId,
-          error: e instanceof Error ? e.message : String(e),
-        });
-      }
-    }
-  } catch (e) {
-    const message = e instanceof Error ? e.message : String(e);
-    try {
-      await store.markFailed(params.buildId, "vercel", message);
-    } catch (markFailedError) {
-      logger.error("repo_image.mark_failed_after_snapshot_error", {
-        build_id: params.buildId,
-        error: markFailedError instanceof Error ? markFailedError.message : String(markFailedError),
-        request_id: params.requestId,
-        trace_id: params.traceId,
-      });
-    }
-    logger.error("repo_image.vercel_snapshot_error", {
-      build_id: params.buildId,
-      provider_session_id: params.providerSessionId,
-      error: message,
-      duration_ms: Date.now() - snapshotStart,
-      request_id: params.requestId,
-      trace_id: params.traceId,
-    });
-  } finally {
-    if (vercelProvider) {
-      try {
-        const stopResult = await vercelProvider.stopSandbox({
-          providerObjectId: params.providerSessionId,
-          sessionId: params.buildId,
-          reason: "repo_image_build_complete",
-          correlation: {
-            request_id: params.requestId,
-            trace_id: params.traceId,
-            sandbox_id: params.providerSessionId,
-          },
-        });
-        if (!stopResult.success) {
-          logger.warn("repo_image.vercel_build_stop_failed", {
-            build_id: params.buildId,
-            provider_session_id: params.providerSessionId,
-            error: stopResult.error,
-            request_id: params.requestId,
-            trace_id: params.traceId,
-          });
-        }
-      } catch (stopError) {
-        logger.warn("repo_image.vercel_build_stop_failed", {
-          build_id: params.buildId,
-          provider_session_id: params.providerSessionId,
-          error: stopError instanceof Error ? stopError.message : String(stopError),
-          request_id: params.requestId,
-          trace_id: params.traceId,
-        });
-      }
-    }
-  }
-}
-
-async function completeOpenComputerBuildFromSession(
-  env: Env,
-  params: {
-    buildId: string;
-    providerSessionId: string;
-    baseSha: string;
-    buildDurationSeconds: number;
-    requestId: string;
-    traceId: string;
-  }
-): Promise<void> {
-  if (!env.DB) {
-    logger.error("repo_image.opencomputer_checkpoint_error", {
-      build_id: params.buildId,
-      provider_session_id: params.providerSessionId,
-      error: "Database not configured",
-      request_id: params.requestId,
-      trace_id: params.traceId,
-    });
-    return;
-  }
-
-  const checkpointStart = Date.now();
-  const store = new RepoImageStore(env.DB);
-  let openComputerProvider: ReturnType<typeof createConfiguredOpenComputerProvider> | null = null;
-
-  try {
-    logger.info("repo_image.opencomputer_checkpoint_start", {
-      build_id: params.buildId,
-      provider_session_id: params.providerSessionId,
-      request_id: params.requestId,
-      trace_id: params.traceId,
-    });
-
-    openComputerProvider = createConfiguredOpenComputerProvider(env);
-    const snapshot = await openComputerProvider.takeSnapshot({
-      providerObjectId: params.providerSessionId,
-      sessionId: params.buildId,
-      reason: "repo_image_build",
-      correlation: {
-        request_id: params.requestId,
-        trace_id: params.traceId,
-        sandbox_id: params.providerSessionId,
-      },
-    });
-
-    if (!snapshot.success || !snapshot.imageId) {
-      const message = snapshot.error || "OpenComputer checkpoint did not return an image id";
-      await store.markFailed(params.buildId, "opencomputer", message);
-      logger.error("repo_image.opencomputer_checkpoint_failed", {
-        build_id: params.buildId,
-        provider_session_id: params.providerSessionId,
-        error: message,
-        duration_ms: Date.now() - checkpointStart,
-        request_id: params.requestId,
-        trace_id: params.traceId,
-      });
-      return;
-    }
-
-    const result = await store.markReady(
-      params.buildId,
-      "opencomputer",
-      snapshot.imageId,
-      params.baseSha,
-      params.buildDurationSeconds
-    );
-    if (!result.updated) {
-      try {
-        await openComputerProvider.deleteProviderImage(snapshot.imageId, params.providerSessionId);
-      } catch (cleanupError) {
-        logger.warn("repo_image.opencomputer_checkpoint_cleanup_failed", {
-          build_id: params.buildId,
-          provider_session_id: params.providerSessionId,
-          provider_image_id: snapshot.imageId,
-          error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
-          request_id: params.requestId,
-          trace_id: params.traceId,
-        });
-      }
-      logger.warn("repo_image.opencomputer_checkpoint_not_applied", {
-        build_id: params.buildId,
-        provider_session_id: params.providerSessionId,
-        provider_image_id: snapshot.imageId,
-        duration_ms: Date.now() - checkpointStart,
-        request_id: params.requestId,
-        trace_id: params.traceId,
-      });
-      return;
-    }
-
-    logger.info("repo_image.build_complete", {
-      build_id: params.buildId,
-      provider_image_id: snapshot.imageId,
-      provider_session_id: params.providerSessionId,
-      base_sha: params.baseSha,
-      replaced_image_id: result.replacedImageId,
-      snapshot_duration_ms: Date.now() - checkpointStart,
-      request_id: params.requestId,
-      trace_id: params.traceId,
-    });
-
-    if (result.replacedImageId) {
-      try {
-        await openComputerProvider.deleteProviderImage(
-          result.replacedImageId,
-          result.replacedProviderSessionId
-        );
-      } catch (e) {
-        logger.warn("repo_image.delete_old_failed", {
-          provider_image_id: result.replacedImageId,
-          error: e instanceof Error ? e.message : String(e),
-        });
-      }
-    }
-  } catch (e) {
-    const message = e instanceof Error ? e.message : String(e);
-    try {
-      await store.markFailed(params.buildId, "opencomputer", message);
-    } catch (markFailedError) {
-      logger.error("repo_image.mark_failed_after_checkpoint_error", {
-        build_id: params.buildId,
-        error: markFailedError instanceof Error ? markFailedError.message : String(markFailedError),
-        request_id: params.requestId,
-        trace_id: params.traceId,
-      });
-    }
-    logger.error("repo_image.opencomputer_checkpoint_error", {
-      build_id: params.buildId,
-      provider_session_id: params.providerSessionId,
-      error: message,
-      duration_ms: Date.now() - checkpointStart,
-      request_id: params.requestId,
-      trace_id: params.traceId,
-    });
-  } finally {
-    if (openComputerProvider) {
-      try {
-        // The repo-image build sandbox is single-use — its checkpoint is the
-        // image. Delete it rather than hibernating (stopSandbox), which would
-        // leave it running/leaked after the build.
-        await openComputerProvider.deleteSandbox(params.providerSessionId);
-      } catch (cleanupError) {
-        logger.warn("repo_image.opencomputer_build_cleanup_failed", {
-          build_id: params.buildId,
-          provider_session_id: params.providerSessionId,
-          error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
-          request_id: params.requestId,
-          trace_id: params.traceId,
-        });
-      }
-    }
-  }
+  const result = await createRepoImageBuildWorkflowFromEnv(env).acceptBuildComplete({
+    completion,
+    callbackToken: getRepoImageCallbackBearerToken(request),
+    context: workflowContext(ctx),
+  });
+  return workflowResultToResponse(result, ctx);
 }
 
 /**
@@ -726,85 +251,21 @@ async function handleBuildFailed(
   }
 
   const backend = getRepoImageBackend(env);
-  const preParseAuthError = await requireCallbackPreParseAuth(request, env, backend, ctx);
+  const preParseAuthError = await requireCallbackPreParseGate(request, env, backend, ctx, logger);
   if (preParseAuthError) return preParseAuthError;
 
-  const body = await parseJsonBody<{
-    build_id?: string;
-    provider_session_id?: string;
-    error?: string;
-  }>(request);
+  const body = await parseJsonBody<RepoImageBuildFailedBody>(request);
   if (body instanceof Response) return body;
 
-  const buildId = body.build_id;
-  if (!buildId) {
-    return error("build_id is required", 400);
-  }
+  const failure = buildFailedCommand(body, backend);
+  if (failure instanceof Response) return failure;
 
-  const store = new RepoImageStore(env.DB);
-
-  if (backend === "vercel" || backend === "opencomputer") {
-    if (!body.provider_session_id) {
-      return error("provider_session_id is required", 400);
-    }
-
-    const authError = await requireTokenBuildCallbackAuth(
-      request,
-      env,
-      store,
-      { buildId, provider: backend, providerSessionId: body.provider_session_id },
-      ctx
-    );
-    if (authError) return authError;
-  }
-
-  try {
-    const updated = await store.markFailed(buildId, backend, body.error || "Unknown error");
-    if (!updated) {
-      return error("Build is not accepting failure", 409);
-    }
-
-    logger.info("repo_image.build_failed", {
-      build_id: buildId,
-      error_message: body.error,
-      provider_session_id: body.provider_session_id,
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-
-    if (backend === "opencomputer" && body.provider_session_id) {
-      const cleanupPromise = (async () => {
-        try {
-          // Single-use build sandbox: delete it rather than hibernating so a
-          // failed build doesn't leave the sandbox running/leaked.
-          await createConfiguredOpenComputerProvider(env).deleteSandbox(body.provider_session_id!);
-        } catch (cleanupError) {
-          logger.warn("repo_image.opencomputer_build_cleanup_failed", {
-            build_id: buildId,
-            provider_session_id: body.provider_session_id,
-            error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
-            request_id: ctx.request_id,
-            trace_id: ctx.trace_id,
-          });
-        }
-      })();
-      if (ctx.executionCtx) {
-        ctx.executionCtx.waitUntil(cleanupPromise);
-      } else {
-        await cleanupPromise;
-      }
-    }
-
-    return json({ ok: true });
-  } catch (e) {
-    logger.error("repo_image.build_failed_error", {
-      error: e instanceof Error ? e.message : String(e),
-      build_id: buildId,
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-    return error("Failed to mark build as failed", 500);
-  }
+  const result = await createRepoImageBuildWorkflowFromEnv(env).acceptBuildFailed({
+    failure,
+    callbackToken: getRepoImageCallbackBearerToken(request),
+    context: workflowContext(ctx),
+  });
+  return workflowResultToResponse(result, ctx);
 }
 
 /**
@@ -823,218 +284,16 @@ async function handleTriggerBuild(
   if (!env.DB) {
     return error("Database not configured", 503);
   }
-  if (!env.WORKER_URL) {
-    return error("WORKER_URL not configured", 503);
-  }
 
   const params = extractRepoParams(match);
   if (params instanceof Response) return params;
-  const { owner, name } = params;
 
-  // Resolve the repo to get its actual default branch — never assume "main".
-  // The same resolution yields repoId, reused below for repo-scoped secrets.
-  const resolved = await resolveRepoOrError(env, owner, name, ctx, logger);
-  if (resolved instanceof Response) return resolved;
-  const { repoId, defaultBranch } = resolved;
-
-  const store = new RepoImageStore(env.DB);
-  const backend = getRepoImageBackend(env);
-  const now = Date.now();
-  const buildId = `img-${owner}-${name}-${now}`;
-
-  try {
-    const callbackToken =
-      backend === "vercel" || backend === "opencomputer"
-        ? generateRepoImageCallbackToken()
-        : undefined;
-    const callbackTokenHash = callbackToken
-      ? await hashRepoImageCallbackToken(callbackToken, env)
-      : undefined;
-
-    // Register the build in D1
-    await store.registerBuild({
-      id: buildId,
-      repoOwner: owner,
-      repoName: name,
-      provider: backend,
-      baseBranch: defaultBranch,
-      callbackTokenHash,
-      callbackTokenExpiresAt: callbackToken ? now + REPO_IMAGE_CALLBACK_TOKEN_TTL_MS : undefined,
-    });
-
-    // Construct callback URL
-    const callbackUrl = `${env.WORKER_URL}/repo-images/build-complete`;
-
-    const sandboxSettings = await resolveSandboxSettings(env.DB, owner, name);
-    const buildTimeoutSeconds = resolveBuildTimeoutSeconds(sandboxSettings);
-
-    // Best-effort: fetch user secrets for the build sandbox
-    let userEnvVars: Record<string, string> | undefined;
-    if (env.REPO_SECRETS_ENCRYPTION_KEY) {
-      let globalSecrets: Record<string, string> = {};
-      try {
-        const globalStore = new GlobalSecretsStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
-        globalSecrets = await globalStore.getDecryptedSecrets();
-      } catch (e) {
-        logger.warn("repo_image.global_secrets_failed", {
-          error: e instanceof Error ? e.message : String(e),
-          repo_owner: owner,
-          repo_name: name,
-        });
-      }
-
-      let repoSecrets: Record<string, string> = {};
-      try {
-        const repoStore = new RepoSecretsStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
-        repoSecrets = await repoStore.getDecryptedSecrets(repoId);
-      } catch (e) {
-        logger.warn("repo_image.repo_secrets_failed", {
-          error: e instanceof Error ? e.message : String(e),
-          repo_owner: owner,
-          repo_name: name,
-        });
-      }
-
-      const { merged, totalBytes, exceedsLimit } = mergeSecrets(globalSecrets, repoSecrets);
-      if (Object.keys(merged).length > 0) {
-        userEnvVars = merged;
-        const logLevel = exceedsLimit ? "warn" : "info";
-        logger[logLevel]("repo_image.secrets_loaded", {
-          global_count: Object.keys(globalSecrets).length,
-          repo_count: Object.keys(repoSecrets).length,
-          merged_count: Object.keys(merged).length,
-          payload_bytes: totalBytes,
-          exceeds_limit: exceedsLimit,
-          repo_owner: owner,
-          repo_name: name,
-        });
-      }
-    }
-
-    switch (backend) {
-      case "modal": {
-        if (!env.MODAL_API_SECRET || !env.MODAL_WORKSPACE) {
-          return error("Modal configuration not available", 503);
-        }
-        const client = createModalClient(
-          env.MODAL_API_SECRET,
-          env.MODAL_WORKSPACE,
-          env.MODAL_ENVIRONMENT_WEB_SUFFIX
-        );
-        await client.buildRepoImage(
-          {
-            repoOwner: owner,
-            repoName: name,
-            defaultBranch,
-            buildId,
-            callbackUrl,
-            userEnvVars,
-            buildTimeoutSeconds,
-          },
-          { trace_id: ctx.trace_id, request_id: ctx.request_id }
-        );
-        break;
-      }
-      case "vercel": {
-        if (!callbackToken) {
-          throw new Error("Vercel callback token was not generated");
-        }
-
-        let cloneToken: string | undefined;
-        try {
-          const provider = createRouteSourceControlProvider(env);
-          const auth = await provider.generateCredentialHelperAuth();
-          cloneToken = auth.password;
-        } catch (e) {
-          logger.warn("repo_image.clone_token_failed", {
-            error: e instanceof Error ? e.message : String(e),
-            repo_owner: owner,
-            repo_name: name,
-          });
-        }
-        await createConfiguredVercelProvider(env).triggerRepoImageBuild({
-          repoOwner: owner,
-          repoName: name,
-          defaultBranch,
-          buildId,
-          callbackUrl,
-          callbackToken,
-          userEnvVars,
-          cloneToken,
-          buildTimeoutSeconds,
-          onProviderSessionCreated: async (providerSessionId) => {
-            const bound = await store.bindProviderSession(buildId, "vercel", providerSessionId);
-            if (!bound) {
-              throw new Error("Failed to bind Vercel build session");
-            }
-          },
-          correlation: { trace_id: ctx.trace_id, request_id: ctx.request_id },
-        });
-        break;
-      }
-      case "opencomputer": {
-        if (!callbackToken) {
-          throw new Error("OpenComputer callback token was not generated");
-        }
-
-        await createConfiguredOpenComputerProvider(env).triggerRepoImageBuild({
-          repoOwner: owner,
-          repoName: name,
-          defaultBranch,
-          buildId,
-          callbackUrl,
-          callbackToken,
-          userEnvVars,
-          buildTimeoutSeconds,
-          onProviderSessionCreated: async (providerSessionId) => {
-            const bound = await store.bindProviderSession(
-              buildId,
-              "opencomputer",
-              providerSessionId
-            );
-            if (!bound) {
-              throw new Error("Failed to bind OpenComputer build session");
-            }
-          },
-        });
-        break;
-      }
-      default: {
-        const unsupportedBackend: never = backend;
-        return error(`Repo image builds are not supported for provider ${unsupportedBackend}`, 501);
-      }
-    }
-
-    logger.info("repo_image.build_triggered", {
-      build_id: buildId,
-      repo_owner: owner,
-      repo_name: name,
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-
-    return json({ buildId, status: "building" });
-  } catch (e) {
-    try {
-      await store.markFailed(buildId, backend, e instanceof Error ? e.message : String(e));
-    } catch (markFailedError) {
-      logger.warn("repo_image.trigger_mark_failed_error", {
-        error: markFailedError instanceof Error ? markFailedError.message : String(markFailedError),
-        build_id: buildId,
-        request_id: ctx.request_id,
-        trace_id: ctx.trace_id,
-      });
-    }
-
-    logger.error("repo_image.trigger_error", {
-      error: e instanceof Error ? e.message : String(e),
-      repo_owner: owner,
-      repo_name: name,
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-    return error("Failed to trigger build", 500);
-  }
+  const result = await createRepoImageBuildWorkflowFromEnv(env).triggerBuild(
+    params.owner,
+    params.name,
+    workflowContext(ctx)
+  );
+  return workflowResultToResponse(result, ctx);
 }
 
 /**
@@ -1066,7 +325,6 @@ async function handleGetStatus(
       return json({ images });
     }
 
-    // Return all status (for scheduler use)
     const images = await store.getAllStatus();
     return json({ images });
   } catch (e) {
@@ -1155,7 +413,7 @@ async function handleCleanup(
     body = {};
   }
 
-  const maxAgeSeconds = body.max_age_seconds ?? 86400; // 24 hours default
+  const maxAgeSeconds = body.max_age_seconds ?? 86400;
   const maxAgeMs = maxAgeSeconds * 1000;
 
   const store = new RepoImageStore(env.DB);

--- a/packages/control-plane/src/sandbox/provider-factory.test.ts
+++ b/packages/control-plane/src/sandbox/provider-factory.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { Env } from "../types";
+import { createSandboxProviderFromEnv } from "./provider-factory";
+
+function createEnv(overrides: Partial<Env>): Env {
+  return {
+    DB: {} as D1Database,
+    SESSION: {} as DurableObjectNamespace,
+    MEDIA_BUCKET: {} as R2Bucket,
+    TOKEN_ENCRYPTION_KEY: "test-token-key",
+    DEPLOYMENT_NAME: "test",
+    ...overrides,
+  } as Env;
+}
+
+describe("createSandboxProviderFromEnv", () => {
+  it("rejects malformed Vercel numeric configuration", () => {
+    const env = createEnv({
+      VERCEL_TOKEN: "vercel-token",
+      VERCEL_PROJECT_ID: "project-id",
+      VERCEL_SNAPSHOT_EXPIRATION_MS: "10m",
+    });
+
+    expect(() => createSandboxProviderFromEnv(env, "vercel")).toThrow(
+      "VERCEL_SNAPSHOT_EXPIRATION_MS must be a valid number"
+    );
+  });
+
+  it("rejects malformed Daytona auto-stop configuration", () => {
+    const env = createEnv({
+      DAYTONA_API_URL: "https://daytona.test",
+      DAYTONA_API_KEY: "daytona-key",
+      DAYTONA_BASE_SNAPSHOT: "base",
+      DAYTONA_AUTO_STOP_INTERVAL_MINUTES: "abc",
+    });
+
+    expect(() => createSandboxProviderFromEnv(env, "daytona")).toThrow(
+      "DAYTONA_AUTO_STOP_INTERVAL_MINUTES must be a valid number"
+    );
+  });
+
+  it("rejects malformed Daytona auto-archive configuration", () => {
+    const env = createEnv({
+      DAYTONA_API_URL: "https://daytona.test",
+      DAYTONA_API_KEY: "daytona-key",
+      DAYTONA_BASE_SNAPSHOT: "base",
+      DAYTONA_AUTO_STOP_INTERVAL_MINUTES: "30",
+      DAYTONA_AUTO_ARCHIVE_INTERVAL_MINUTES: "abc",
+    });
+
+    expect(() => createSandboxProviderFromEnv(env, "daytona")).toThrow(
+      "DAYTONA_AUTO_ARCHIVE_INTERVAL_MINUTES must be a valid number"
+    );
+  });
+});

--- a/packages/control-plane/src/sandbox/provider-factory.ts
+++ b/packages/control-plane/src/sandbox/provider-factory.ts
@@ -50,7 +50,11 @@ function createVercelProviderFromEnv(env: Env): VercelSandboxProvider {
     baseSnapshotId: env.VERCEL_BASE_SNAPSHOT_ID,
     baseSnapshotName: env.VERCEL_BASE_SNAPSHOT_NAME,
     runtime: env.VERCEL_RUNTIME,
-    snapshotExpirationMs: parseInt(env.VERCEL_SNAPSHOT_EXPIRATION_MS || "0", 10),
+    snapshotExpirationMs: parseNumericEnv(
+      "VERCEL_SNAPSHOT_EXPIRATION_MS",
+      env.VERCEL_SNAPSHOT_EXPIRATION_MS,
+      0
+    ),
     codeServerPasswordSecret: env.VERCEL_TOKEN,
   });
 }
@@ -91,8 +95,16 @@ function createDaytonaProviderFromEnv(env: Env): DaytonaSandboxProvider {
     apiKey: env.DAYTONA_API_KEY,
     target: env.DAYTONA_TARGET,
     baseSnapshot: env.DAYTONA_BASE_SNAPSHOT,
-    autoStopIntervalMinutes: parseInt(env.DAYTONA_AUTO_STOP_INTERVAL_MINUTES || "120", 10),
-    autoArchiveIntervalMinutes: parseInt(env.DAYTONA_AUTO_ARCHIVE_INTERVAL_MINUTES || "10080", 10),
+    autoStopIntervalMinutes: parseNumericEnv(
+      "DAYTONA_AUTO_STOP_INTERVAL_MINUTES",
+      env.DAYTONA_AUTO_STOP_INTERVAL_MINUTES,
+      120
+    ),
+    autoArchiveIntervalMinutes: parseNumericEnv(
+      "DAYTONA_AUTO_ARCHIVE_INTERVAL_MINUTES",
+      env.DAYTONA_AUTO_ARCHIVE_INTERVAL_MINUTES,
+      10080
+    ),
   });
 
   return createDaytonaProvider(client, {
@@ -127,4 +139,15 @@ export function createSandboxProviderFromEnv(
     case "modal":
       return createModalProviderFromEnv(env);
   }
+}
+
+function parseNumericEnv(name: string, value: string | undefined, defaultValue: number): number {
+  const raw = value?.trim();
+  if (!raw) return defaultValue;
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${name} must be a valid number`);
+  }
+  return parsed;
 }

--- a/packages/control-plane/src/sandbox/provider-factory.ts
+++ b/packages/control-plane/src/sandbox/provider-factory.ts
@@ -1,0 +1,130 @@
+import { createModalClient } from "./client";
+import { createDaytonaRestClient } from "./daytona-rest-client";
+import { createOpenComputerRestClient } from "./opencomputer-rest-client";
+import { resolveSandboxBackendName, type SandboxBackendName } from "./provider-name";
+import type { SandboxProvider } from "./provider";
+import { createDaytonaProvider, type DaytonaSandboxProvider } from "./providers/daytona-provider";
+import { createModalProvider, type ModalSandboxProvider } from "./providers/modal-provider";
+import {
+  createOpenComputerProvider,
+  type OpenComputerSandboxProvider,
+} from "./providers/opencomputer-provider";
+import { createVercelSandboxClient } from "./providers/vercel/client";
+import { createVercelProvider, type VercelSandboxProvider } from "./providers/vercel/provider";
+import { resolveScmProviderFromEnv } from "../source-control";
+import type { Env } from "../types";
+
+function createModalProviderFromEnv(env: Env): ModalSandboxProvider {
+  if (!env.MODAL_API_SECRET || !env.MODAL_WORKSPACE) {
+    throw new Error(
+      "MODAL_API_SECRET and MODAL_WORKSPACE are required when SANDBOX_PROVIDER=modal"
+    );
+  }
+
+  const client = createModalClient(
+    env.MODAL_API_SECRET,
+    env.MODAL_WORKSPACE,
+    env.MODAL_ENVIRONMENT_WEB_SUFFIX
+  );
+
+  return createModalProvider(client);
+}
+
+function createVercelProviderFromEnv(env: Env): VercelSandboxProvider {
+  if (!env.VERCEL_TOKEN || !env.VERCEL_PROJECT_ID) {
+    throw new Error("VERCEL_TOKEN and VERCEL_PROJECT_ID are required when SANDBOX_PROVIDER=vercel");
+  }
+
+  const client = createVercelSandboxClient({
+    token: env.VERCEL_TOKEN,
+    projectId: env.VERCEL_PROJECT_ID,
+    teamId: env.VERCEL_TEAM_ID,
+    apiBaseUrl: env.VERCEL_SANDBOX_API_BASE_URL,
+  });
+
+  return createVercelProvider(client, {
+    scmProvider: resolveScmProviderFromEnv(env.SCM_PROVIDER),
+    token: env.VERCEL_TOKEN,
+    teamId: env.VERCEL_TEAM_ID,
+    apiBaseUrl: env.VERCEL_SANDBOX_API_BASE_URL,
+    baseSnapshotId: env.VERCEL_BASE_SNAPSHOT_ID,
+    baseSnapshotName: env.VERCEL_BASE_SNAPSHOT_NAME,
+    runtime: env.VERCEL_RUNTIME,
+    snapshotExpirationMs: parseInt(env.VERCEL_SNAPSHOT_EXPIRATION_MS || "0", 10),
+    codeServerPasswordSecret: env.VERCEL_TOKEN,
+  });
+}
+
+function createOpenComputerProviderFromEnv(env: Env): OpenComputerSandboxProvider {
+  if (!env.OPENCOMPUTER_API_URL || !env.OPENCOMPUTER_API_KEY || !env.OPENCOMPUTER_TEMPLATE) {
+    throw new Error(
+      "OPENCOMPUTER_API_URL, OPENCOMPUTER_API_KEY, and OPENCOMPUTER_TEMPLATE are required when SANDBOX_PROVIDER=opencomputer"
+    );
+  }
+
+  const client = createOpenComputerRestClient({
+    apiUrl: env.OPENCOMPUTER_API_URL,
+    apiKey: env.OPENCOMPUTER_API_KEY,
+    template: env.OPENCOMPUTER_TEMPLATE,
+    projectId: env.OPENCOMPUTER_PROJECT_ID,
+    target: env.OPENCOMPUTER_TARGET,
+  });
+
+  return createOpenComputerProvider(client, {
+    scmProvider: resolveScmProviderFromEnv(env.SCM_PROVIDER),
+    codeServerPasswordSecret: env.OPENCOMPUTER_API_KEY,
+    llmEnvVars: {
+      ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY,
+    },
+  });
+}
+
+function createDaytonaProviderFromEnv(env: Env): DaytonaSandboxProvider {
+  if (!env.DAYTONA_API_URL || !env.DAYTONA_API_KEY || !env.DAYTONA_BASE_SNAPSHOT) {
+    throw new Error(
+      "DAYTONA_API_URL, DAYTONA_API_KEY, and DAYTONA_BASE_SNAPSHOT are required when SANDBOX_PROVIDER=daytona"
+    );
+  }
+
+  const client = createDaytonaRestClient({
+    apiUrl: env.DAYTONA_API_URL,
+    apiKey: env.DAYTONA_API_KEY,
+    target: env.DAYTONA_TARGET,
+    baseSnapshot: env.DAYTONA_BASE_SNAPSHOT,
+    autoStopIntervalMinutes: parseInt(env.DAYTONA_AUTO_STOP_INTERVAL_MINUTES || "120", 10),
+    autoArchiveIntervalMinutes: parseInt(env.DAYTONA_AUTO_ARCHIVE_INTERVAL_MINUTES || "10080", 10),
+  });
+
+  return createDaytonaProvider(client, {
+    scmProvider: resolveScmProviderFromEnv(env.SCM_PROVIDER),
+    gitlabAccessToken: env.GITLAB_ACCESS_TOKEN,
+    codeServerPasswordSecret: env.DAYTONA_API_KEY,
+  });
+}
+
+export function createSandboxProviderFromEnv(env: Env, backend: "daytona"): DaytonaSandboxProvider;
+export function createSandboxProviderFromEnv(env: Env, backend: "modal"): ModalSandboxProvider;
+export function createSandboxProviderFromEnv(env: Env, backend: "vercel"): VercelSandboxProvider;
+export function createSandboxProviderFromEnv(
+  env: Env,
+  backend: "opencomputer"
+): OpenComputerSandboxProvider;
+export function createSandboxProviderFromEnv(
+  env: Env,
+  backend?: SandboxBackendName
+): SandboxProvider;
+export function createSandboxProviderFromEnv(
+  env: Env,
+  backend: SandboxBackendName = resolveSandboxBackendName(env.SANDBOX_PROVIDER)
+): SandboxProvider {
+  switch (backend) {
+    case "daytona":
+      return createDaytonaProviderFromEnv(env);
+    case "vercel":
+      return createVercelProviderFromEnv(env);
+    case "opencomputer":
+      return createOpenComputerProviderFromEnv(env);
+    case "modal":
+      return createModalProviderFromEnv(env);
+  }
+}

--- a/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
@@ -497,7 +497,7 @@ describe("ModalSandboxProvider", () => {
         defaultBranch: "develop",
         callbackUrl: "https://worker.test/repo-images/build-complete",
         userEnvVars: { FOO: "bar" },
-        buildTimeoutSeconds: 1800,
+        buildTimeoutMs: 1_800_000,
         correlation,
       });
 

--- a/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
@@ -16,6 +16,10 @@ import type {
   RestoreSandboxResponse,
   SnapshotSandboxRequest,
   SnapshotSandboxResponse,
+  BuildRepoImageRequest,
+  BuildRepoImageResponse,
+  DeleteProviderImageRequest,
+  DeleteProviderImageResponse,
 } from "../client";
 
 // ==================== Mock Factories ====================
@@ -25,6 +29,8 @@ function createMockModalClient(
     createSandbox: (req: CreateSandboxRequest) => Promise<CreateSandboxResponse>;
     restoreSandbox: (req: RestoreSandboxRequest) => Promise<RestoreSandboxResponse>;
     snapshotSandbox: (req: SnapshotSandboxRequest) => Promise<SnapshotSandboxResponse>;
+    buildRepoImage: (req: BuildRepoImageRequest) => Promise<BuildRepoImageResponse>;
+    deleteProviderImage: (req: DeleteProviderImageRequest) => Promise<DeleteProviderImageResponse>;
   }> = {}
 ): ModalClient {
   return {
@@ -47,6 +53,18 @@ function createMockModalClient(
       async (): Promise<SnapshotSandboxResponse> => ({
         success: true,
         imageId: "image-123",
+      })
+    ),
+    buildRepoImage: vi.fn(
+      async (): Promise<BuildRepoImageResponse> => ({
+        buildId: "build-123",
+        status: "building",
+      })
+    ),
+    deleteProviderImage: vi.fn(
+      async (req: DeleteProviderImageRequest): Promise<DeleteProviderImageResponse> => ({
+        providerImageId: req.providerImageId,
+        deleted: true,
       })
     ),
     ...overrides,
@@ -463,6 +481,52 @@ describe("ModalSandboxProvider", () => {
       expect(result.providerObjectId).toBe("modal-obj-xyz");
       expect(result.status).toBe("created");
       expect(result.createdAt).toBe(1234567890);
+    });
+  });
+
+  describe("repo image builds", () => {
+    it("triggers repo image builds through the Modal client", async () => {
+      const client = createMockModalClient();
+      const provider = new ModalSandboxProvider(client);
+      const correlation = { request_id: "request-1", trace_id: "trace-1" };
+
+      const result = await provider.triggerRepoImageBuild({
+        buildId: "build-123",
+        repoOwner: "acme",
+        repoName: "repo",
+        defaultBranch: "develop",
+        callbackUrl: "https://worker.test/repo-images/build-complete",
+        userEnvVars: { FOO: "bar" },
+        buildTimeoutSeconds: 1800,
+        correlation,
+      });
+
+      expect(result).toEqual({ buildId: "build-123", status: "building" });
+      expect(client.buildRepoImage).toHaveBeenCalledWith(
+        {
+          repoOwner: "acme",
+          repoName: "repo",
+          defaultBranch: "develop",
+          buildId: "build-123",
+          callbackUrl: "https://worker.test/repo-images/build-complete",
+          userEnvVars: { FOO: "bar" },
+          buildTimeoutSeconds: 1800,
+        },
+        correlation
+      );
+    });
+
+    it("deletes provider images through the Modal client", async () => {
+      const client = createMockModalClient();
+      const provider = new ModalSandboxProvider(client);
+      const correlation = { request_id: "request-1", trace_id: "trace-1" };
+
+      await provider.deleteProviderImage("modal-image-1", correlation);
+
+      expect(client.deleteProviderImage).toHaveBeenCalledWith(
+        { providerImageId: "modal-image-1" },
+        correlation
+      );
     });
   });
 

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -21,6 +21,8 @@ import {
   type SnapshotResult,
 } from "../provider";
 
+const MS_PER_SECOND = 1000;
+
 export interface TriggerModalRepoImageBuildConfig {
   buildId: string;
   repoOwner: string;
@@ -29,11 +31,10 @@ export interface TriggerModalRepoImageBuildConfig {
   callbackUrl: string;
   userEnvVars?: Record<string, string>;
   /**
-   * Build sandbox lifetime, in seconds. Already capped at
-   * MAX_BUILD_TIMEOUT_SECONDS by the trigger. Omitted -> Modal applies
-   * DEFAULT_BUILD_TIMEOUT_SECONDS.
+   * Build sandbox lifetime, in milliseconds. Already capped by the trigger.
+   * Omitted -> Modal applies DEFAULT_BUILD_TIMEOUT_SECONDS.
    */
-  buildTimeoutSeconds?: number;
+  buildTimeoutMs?: number;
   correlation?: CorrelationContext;
 }
 
@@ -237,7 +238,10 @@ export class ModalSandboxProvider implements SandboxProvider, ModalRepoImageBuil
           buildId: config.buildId,
           callbackUrl: config.callbackUrl,
           userEnvVars: config.userEnvVars,
-          buildTimeoutSeconds: config.buildTimeoutSeconds,
+          buildTimeoutSeconds:
+            config.buildTimeoutMs === undefined
+              ? undefined
+              : Math.ceil(config.buildTimeoutMs / MS_PER_SECOND),
         },
         config.correlation
       );

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -7,6 +7,7 @@
 
 import { ModalApiError } from "../client";
 import type { ModalClient } from "../client";
+import type { CorrelationContext } from "../../logger";
 import {
   DEFAULT_SANDBOX_TIMEOUT_SECONDS,
   SandboxProviderError,
@@ -19,6 +20,34 @@ import {
   type SnapshotConfig,
   type SnapshotResult,
 } from "../provider";
+
+export interface TriggerModalRepoImageBuildConfig {
+  buildId: string;
+  repoOwner: string;
+  repoName: string;
+  defaultBranch: string;
+  callbackUrl: string;
+  userEnvVars?: Record<string, string>;
+  /**
+   * Build sandbox lifetime, in seconds. Already capped at
+   * MAX_BUILD_TIMEOUT_SECONDS by the trigger. Omitted -> Modal applies
+   * DEFAULT_BUILD_TIMEOUT_SECONDS.
+   */
+  buildTimeoutSeconds?: number;
+  correlation?: CorrelationContext;
+}
+
+export interface TriggerModalRepoImageBuildResult {
+  buildId: string;
+  status: string;
+}
+
+export interface ModalRepoImageBuildProvider {
+  triggerRepoImageBuild(
+    config: TriggerModalRepoImageBuildConfig
+  ): Promise<TriggerModalRepoImageBuildResult>;
+  deleteProviderImage(providerImageId: string, correlation?: CorrelationContext): Promise<void>;
+}
 
 /**
  * Modal sandbox provider.
@@ -40,7 +69,7 @@ import {
  * }
  * ```
  */
-export class ModalSandboxProvider implements SandboxProvider {
+export class ModalSandboxProvider implements SandboxProvider, ModalRepoImageBuildProvider {
   readonly name = "modal";
 
   readonly capabilities: SandboxProviderCapabilities = {
@@ -194,17 +223,84 @@ export class ModalSandboxProvider implements SandboxProvider {
   }
 
   /**
+   * Trigger a Modal repo-image build.
+   */
+  async triggerRepoImageBuild(
+    config: TriggerModalRepoImageBuildConfig
+  ): Promise<TriggerModalRepoImageBuildResult> {
+    try {
+      const result = await this.client.buildRepoImage(
+        {
+          repoOwner: config.repoOwner,
+          repoName: config.repoName,
+          defaultBranch: config.defaultBranch,
+          buildId: config.buildId,
+          callbackUrl: config.callbackUrl,
+          userEnvVars: config.userEnvVars,
+          buildTimeoutSeconds: config.buildTimeoutSeconds,
+        },
+        config.correlation
+      );
+
+      return {
+        buildId: result.buildId,
+        status: result.status,
+      };
+    } catch (error) {
+      if (error instanceof ModalApiError) {
+        throw this.classifyErrorWithStatus(
+          `Repo image build failed with HTTP ${error.status}: ${error.message}`,
+          error.status,
+          error
+        );
+      }
+      if (error instanceof SandboxProviderError) {
+        throw error;
+      }
+      throw this.classifyError("Failed to trigger Modal repo image build", error);
+    }
+  }
+
+  /**
+   * Delete a Modal provider image.
+   */
+  async deleteProviderImage(
+    providerImageId: string,
+    correlation?: CorrelationContext
+  ): Promise<void> {
+    try {
+      await this.client.deleteProviderImage({ providerImageId }, correlation);
+    } catch (error) {
+      if (error instanceof ModalApiError) {
+        throw this.classifyErrorWithStatus(
+          `Provider image deletion failed with HTTP ${error.status}: ${error.message}`,
+          error.status,
+          error
+        );
+      }
+      if (error instanceof SandboxProviderError) {
+        throw error;
+      }
+      throw this.classifyError("Failed to delete Modal provider image", error);
+    }
+  }
+
+  /**
    * Classify an error based on HTTP status code.
    * Uses status code directly for accurate transient/permanent classification.
    */
-  private classifyErrorWithStatus(message: string, status: number): SandboxProviderError {
+  private classifyErrorWithStatus(
+    message: string,
+    status: number,
+    cause?: Error
+  ): SandboxProviderError {
     // Transient: 502, 503, 504 (gateway/availability issues)
     if (status === 502 || status === 503 || status === 504) {
-      return new SandboxProviderError(message, "transient");
+      return new SandboxProviderError(message, "transient", cause);
     }
 
     // Permanent: 4xx (client errors) and other 5xx (server errors)
-    return new SandboxProviderError(message, "permanent");
+    return new SandboxProviderError(message, "permanent", cause);
   }
 
   /**

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -19,15 +19,10 @@ import {
   timingSafeEqual,
 } from "@open-inspect/shared";
 import { generateId, hashToken, encryptToken, decryptToken } from "../auth/crypto";
-import { buildModalSandboxDashboardUrl, createModalClient } from "../sandbox/client";
-import { createDaytonaRestClient } from "../sandbox/daytona-rest-client";
-import { createOpenComputerRestClient } from "../sandbox/opencomputer-rest-client";
-import { createVercelSandboxClient } from "../sandbox/providers/vercel/client";
-import { createModalProvider } from "../sandbox/providers/modal-provider";
-import { createDaytonaProvider } from "../sandbox/providers/daytona-provider";
-import { createOpenComputerProvider } from "../sandbox/providers/opencomputer-provider";
-import { createVercelProvider } from "../sandbox/providers/vercel/provider";
-import { resolveSandboxBackendName, supportsRepoImageBackend } from "../sandbox/provider-name";
+import { buildModalSandboxDashboardUrl } from "../sandbox/client";
+import { resolveSandboxBackendName } from "../sandbox/provider-name";
+import { createSandboxProviderFromEnv } from "../sandbox/provider-factory";
+import { resolveRepoImageBackend } from "../repo-images/backend-policy";
 import { createLogger, parseLogLevel } from "../logger";
 import type { Logger } from "../logger";
 import {
@@ -47,7 +42,6 @@ import { McpServerStore } from "../db/mcp-servers";
 import { IntegrationSettingsStore, resolveSlackSettings } from "../db/integration-settings";
 import { SessionIndexStore } from "../db/session-index";
 import { DEFAULT_EXECUTION_TIMEOUT_MS } from "../sandbox/lifecycle/decisions";
-import type { RepoImageProvider } from "../db/repo-images";
 import {
   createSourceControlProviderFromEnv,
   resolveScmProviderFromEnv,
@@ -578,112 +572,7 @@ export class SessionDO extends DurableObject<Env> {
   private createLifecycleManager(): SandboxLifecycleManager {
     const sandboxBackend = resolveSandboxBackendName(this.env.SANDBOX_PROVIDER);
 
-    const provider = (() => {
-      if (sandboxBackend === "daytona") {
-        if (
-          !this.env.DAYTONA_API_URL ||
-          !this.env.DAYTONA_API_KEY ||
-          !this.env.DAYTONA_BASE_SNAPSHOT
-        ) {
-          throw new Error(
-            "DAYTONA_API_URL, DAYTONA_API_KEY, and DAYTONA_BASE_SNAPSHOT are required when SANDBOX_PROVIDER=daytona"
-          );
-        }
-
-        const daytonaClient = createDaytonaRestClient({
-          apiUrl: this.env.DAYTONA_API_URL,
-          apiKey: this.env.DAYTONA_API_KEY,
-          target: this.env.DAYTONA_TARGET,
-          baseSnapshot: this.env.DAYTONA_BASE_SNAPSHOT,
-          autoStopIntervalMinutes: parseInt(
-            this.env.DAYTONA_AUTO_STOP_INTERVAL_MINUTES || "120",
-            10
-          ),
-          autoArchiveIntervalMinutes: parseInt(
-            this.env.DAYTONA_AUTO_ARCHIVE_INTERVAL_MINUTES || "10080",
-            10
-          ),
-        });
-
-        const scmProvider = resolveScmProviderFromEnv(this.env.SCM_PROVIDER);
-
-        return createDaytonaProvider(daytonaClient, {
-          scmProvider,
-          gitlabAccessToken: this.env.GITLAB_ACCESS_TOKEN,
-          // Reuses API key as HMAC secret for code-server password derivation
-          // (distinct message prefix prevents collision with auth use)
-          codeServerPasswordSecret: this.env.DAYTONA_API_KEY,
-        });
-      }
-
-      if (sandboxBackend === "vercel") {
-        if (!this.env.VERCEL_TOKEN || !this.env.VERCEL_PROJECT_ID) {
-          throw new Error(
-            "VERCEL_TOKEN and VERCEL_PROJECT_ID are required when SANDBOX_PROVIDER=vercel"
-          );
-        }
-
-        const vercelClient = createVercelSandboxClient({
-          token: this.env.VERCEL_TOKEN,
-          projectId: this.env.VERCEL_PROJECT_ID,
-          teamId: this.env.VERCEL_TEAM_ID,
-          apiBaseUrl: this.env.VERCEL_SANDBOX_API_BASE_URL,
-        });
-
-        return createVercelProvider(vercelClient, {
-          scmProvider: resolveScmProviderFromEnv(this.env.SCM_PROVIDER),
-          token: this.env.VERCEL_TOKEN,
-          teamId: this.env.VERCEL_TEAM_ID,
-          apiBaseUrl: this.env.VERCEL_SANDBOX_API_BASE_URL,
-          baseSnapshotId: this.env.VERCEL_BASE_SNAPSHOT_ID,
-          baseSnapshotName: this.env.VERCEL_BASE_SNAPSHOT_NAME,
-          runtime: this.env.VERCEL_RUNTIME,
-          snapshotExpirationMs: parseInt(this.env.VERCEL_SNAPSHOT_EXPIRATION_MS || "0", 10),
-          codeServerPasswordSecret: this.env.VERCEL_TOKEN,
-        });
-      }
-
-      if (sandboxBackend === "opencomputer") {
-        if (
-          !this.env.OPENCOMPUTER_API_URL ||
-          !this.env.OPENCOMPUTER_API_KEY ||
-          !this.env.OPENCOMPUTER_TEMPLATE
-        ) {
-          throw new Error(
-            "OPENCOMPUTER_API_URL, OPENCOMPUTER_API_KEY, and OPENCOMPUTER_TEMPLATE are required when SANDBOX_PROVIDER=opencomputer"
-          );
-        }
-
-        const openComputerClient = createOpenComputerRestClient({
-          apiUrl: this.env.OPENCOMPUTER_API_URL,
-          apiKey: this.env.OPENCOMPUTER_API_KEY,
-          template: this.env.OPENCOMPUTER_TEMPLATE,
-          projectId: this.env.OPENCOMPUTER_PROJECT_ID,
-          target: this.env.OPENCOMPUTER_TARGET,
-        });
-
-        return createOpenComputerProvider(openComputerClient, {
-          scmProvider: resolveScmProviderFromEnv(this.env.SCM_PROVIDER),
-          codeServerPasswordSecret: this.env.OPENCOMPUTER_API_KEY,
-          llmEnvVars: {
-            ANTHROPIC_API_KEY: this.env.ANTHROPIC_API_KEY,
-          },
-        });
-      }
-
-      if (!this.env.MODAL_API_SECRET || !this.env.MODAL_WORKSPACE) {
-        throw new Error(
-          "MODAL_API_SECRET and MODAL_WORKSPACE are required when SANDBOX_PROVIDER=modal"
-        );
-      }
-
-      const modalClient = createModalClient(
-        this.env.MODAL_API_SECRET,
-        this.env.MODAL_WORKSPACE,
-        this.env.MODAL_ENVIRONMENT_WEB_SUFFIX
-      );
-      return createModalProvider(modalClient);
-    })();
+    const provider = createSandboxProviderFromEnv(this.env, sandboxBackend);
 
     // Storage adapter
     const storage: SandboxStorage = {
@@ -815,9 +704,9 @@ export class SessionDO extends DurableObject<Env> {
 
     // Create repo image lookup if D1 is available and the provider supports repo images.
     let repoImageLookup: RepoImageLookup | undefined;
-    if (this.env.DB && supportsRepoImageBackend(sandboxBackend)) {
+    const repoImageProvider = resolveRepoImageBackend(sandboxBackend);
+    if (this.env.DB && repoImageProvider) {
       const repoImageStore = new RepoImageStore(this.env.DB);
-      const repoImageProvider = sandboxBackend as RepoImageProvider;
       repoImageLookup = {
         getLatestReady: (repoOwner, repoName, baseBranch) =>
           repoImageStore.getLatestReady(repoOwner, repoName, repoImageProvider, baseBranch),

--- a/packages/control-plane/test/integration/repo-images.test.ts
+++ b/packages/control-plane/test/integration/repo-images.test.ts
@@ -52,7 +52,7 @@ describe("D1 RepoImageStore", () => {
       baseBranch: "main",
     });
 
-    const result = await store.markBuildReady("img-1", "modal", "modal-img-abc", "abc123", 42.5);
+    const result = await store.markBuildReady("img-1", "modal", "modal-img-abc", "abc123", 42_500);
     expect(result.replacedImageId).toBeNull();
 
     const ready = await store.getLatestReady("acme", "repo", "modal");
@@ -72,7 +72,7 @@ describe("D1 RepoImageStore", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    await store.markBuildReady("img-old", "modal", "modal-img-old", "sha-old", 30);
+    await store.markBuildReady("img-old", "modal", "modal-img-old", "sha-old", 30_000);
 
     await store.registerBuild({
       id: "img-new",
@@ -81,17 +81,26 @@ describe("D1 RepoImageStore", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    const result = await store.markBuildReady("img-new", "modal", "modal-img-new", "sha-new", 40);
+    const result = await store.markBuildReady(
+      "img-new",
+      "modal",
+      "modal-img-new",
+      "sha-new",
+      40_000
+    );
 
     expect(result.replacedImageId).toBe("modal-img-old");
 
     const ready = await store.getLatestReady("acme", "repo", "modal");
     expect(ready!.id).toBe("img-new");
 
-    // Old image row should be deleted
+    // Old image row is hidden from normal status while retained for cleanup retry.
     const status = await store.getStatus("acme", "repo");
     const ids = status.map((r) => r.id);
     expect(ids).not.toContain("img-old");
+
+    await expect(store.deleteSupersededImage("img-old")).resolves.toBe(true);
+    await expect(store.deleteSupersededImage("img-old")).resolves.toBe(false);
   });
 
   it("markBuildFailed sets error message", async () => {
@@ -146,7 +155,7 @@ describe("D1 RepoImageStore", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30);
+    await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30_000);
 
     const result = await store.getLatestReady("ACME", "REPO", "modal");
     expect(result).not.toBeNull();
@@ -162,7 +171,7 @@ describe("D1 RepoImageStore", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30);
+    await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30_000);
 
     const result = await store.getLatestReady("acme", "repo", "modal");
     expect(result).toBeNull();
@@ -177,7 +186,7 @@ describe("D1 RepoImageStore", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30);
+    await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30_000);
 
     // Disable — image should not be returned
     await metadataStore.setImageBuildEnabled("acme", "repo", false);
@@ -272,7 +281,7 @@ describe("D1 RepoImageStore", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    await store.markBuildReady("img-a", "modal", "modal-a", "sha-a", 30);
+    await store.markBuildReady("img-a", "modal", "modal-a", "sha-a", 30_000);
 
     await store.registerBuild({
       id: "img-b",
@@ -281,7 +290,7 @@ describe("D1 RepoImageStore", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    await store.markBuildReady("img-b", "modal", "modal-b", "sha-b", 40);
+    await store.markBuildReady("img-b", "modal", "modal-b", "sha-b", 40_000);
 
     const readyA = await store.getLatestReady("acme", "repo-a", "modal");
     const readyB = await store.getLatestReady("acme", "repo-b", "modal");
@@ -299,7 +308,7 @@ describe("D1 RepoImageStore", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    await store.markBuildReady("img-modal", "modal", "modal-img", "sha-modal", 30);
+    await store.markBuildReady("img-modal", "modal", "modal-img", "sha-modal", 30_000);
 
     await store.registerBuild({
       id: "img-vercel",
@@ -308,7 +317,7 @@ describe("D1 RepoImageStore", () => {
       provider: "vercel",
       baseBranch: "main",
     });
-    await store.markBuildReady("img-vercel", "vercel", "vercel-snapshot", "sha-vercel", 40);
+    await store.markBuildReady("img-vercel", "vercel", "vercel-snapshot", "sha-vercel", 40_000);
 
     const modalImage = await store.getLatestReady("acme", "repo", "modal", "main");
     const vercelImage = await store.getLatestReady("acme", "repo", "vercel", "main");
@@ -636,7 +645,7 @@ describe("Repo image HTTP routes", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    await store.markBuildReady("img-s1", "modal", "modal-img-1", "sha1", 30);
+    await store.markBuildReady("img-s1", "modal", "modal-img-1", "sha1", 30_000);
 
     const headers = await authHeaders();
     delete (headers as Record<string, string | undefined>)["Content-Type"];

--- a/packages/control-plane/test/integration/repo-images.test.ts
+++ b/packages/control-plane/test/integration/repo-images.test.ts
@@ -42,7 +42,7 @@ describe("D1 RepoImageStore", () => {
     expect(status[0].created_at).toBeGreaterThan(0);
   });
 
-  it("markReady updates build with provider image details", async () => {
+  it("markBuildReady updates build with provider image details", async () => {
     await metadataStore.setImageBuildEnabled("acme", "repo", true);
     await store.registerBuild({
       id: "img-1",
@@ -52,7 +52,7 @@ describe("D1 RepoImageStore", () => {
       baseBranch: "main",
     });
 
-    const result = await store.markReady("img-1", "modal", "modal-img-abc", "abc123", 42.5);
+    const result = await store.markBuildReady("img-1", "modal", "modal-img-abc", "abc123", 42.5);
     expect(result.replacedImageId).toBeNull();
 
     const ready = await store.getLatestReady("acme", "repo", "modal");
@@ -63,7 +63,7 @@ describe("D1 RepoImageStore", () => {
     expect(ready!.status).toBe("ready");
   });
 
-  it("markReady replaces previous ready image", async () => {
+  it("markBuildReady replaces previous ready image", async () => {
     await metadataStore.setImageBuildEnabled("acme", "repo", true);
     await store.registerBuild({
       id: "img-old",
@@ -72,7 +72,7 @@ describe("D1 RepoImageStore", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    await store.markReady("img-old", "modal", "modal-img-old", "sha-old", 30);
+    await store.markBuildReady("img-old", "modal", "modal-img-old", "sha-old", 30);
 
     await store.registerBuild({
       id: "img-new",
@@ -81,7 +81,7 @@ describe("D1 RepoImageStore", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    const result = await store.markReady("img-new", "modal", "modal-img-new", "sha-new", 40);
+    const result = await store.markBuildReady("img-new", "modal", "modal-img-new", "sha-new", 40);
 
     expect(result.replacedImageId).toBe("modal-img-old");
 
@@ -94,7 +94,7 @@ describe("D1 RepoImageStore", () => {
     expect(ids).not.toContain("img-old");
   });
 
-  it("markFailed sets error message", async () => {
+  it("markBuildFailed sets error message", async () => {
     await store.registerBuild({
       id: "img-1",
       repoOwner: "acme",
@@ -102,7 +102,7 @@ describe("D1 RepoImageStore", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    await store.markFailed("img-1", "modal", "npm install failed");
+    await store.markBuildFailed("img-1", "modal", "npm install failed");
 
     const status = await store.getStatus("acme", "repo");
     expect(status[0].status).toBe("failed");
@@ -131,7 +131,7 @@ describe("D1 RepoImageStore", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    await store.markFailed("img-failed", "modal", "error");
+    await store.markBuildFailed("img-failed", "modal", "error");
 
     const result = await store.getLatestReady("acme", "repo", "modal");
     expect(result).toBeNull();
@@ -146,7 +146,7 @@ describe("D1 RepoImageStore", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    await store.markReady("img-1", "modal", "modal-img-1", "sha1", 30);
+    await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30);
 
     const result = await store.getLatestReady("ACME", "REPO", "modal");
     expect(result).not.toBeNull();
@@ -162,7 +162,7 @@ describe("D1 RepoImageStore", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    await store.markReady("img-1", "modal", "modal-img-1", "sha1", 30);
+    await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30);
 
     const result = await store.getLatestReady("acme", "repo", "modal");
     expect(result).toBeNull();
@@ -177,7 +177,7 @@ describe("D1 RepoImageStore", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    await store.markReady("img-1", "modal", "modal-img-1", "sha1", 30);
+    await store.markBuildReady("img-1", "modal", "modal-img-1", "sha1", 30);
 
     // Disable — image should not be returned
     await metadataStore.setImageBuildEnabled("acme", "repo", false);
@@ -272,7 +272,7 @@ describe("D1 RepoImageStore", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    await store.markReady("img-a", "modal", "modal-a", "sha-a", 30);
+    await store.markBuildReady("img-a", "modal", "modal-a", "sha-a", 30);
 
     await store.registerBuild({
       id: "img-b",
@@ -281,7 +281,7 @@ describe("D1 RepoImageStore", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    await store.markReady("img-b", "modal", "modal-b", "sha-b", 40);
+    await store.markBuildReady("img-b", "modal", "modal-b", "sha-b", 40);
 
     const readyA = await store.getLatestReady("acme", "repo-a", "modal");
     const readyB = await store.getLatestReady("acme", "repo-b", "modal");
@@ -299,7 +299,7 @@ describe("D1 RepoImageStore", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    await store.markReady("img-modal", "modal", "modal-img", "sha-modal", 30);
+    await store.markBuildReady("img-modal", "modal", "modal-img", "sha-modal", 30);
 
     await store.registerBuild({
       id: "img-vercel",
@@ -308,7 +308,7 @@ describe("D1 RepoImageStore", () => {
       provider: "vercel",
       baseBranch: "main",
     });
-    await store.markReady("img-vercel", "vercel", "vercel-snapshot", "sha-vercel", 40);
+    await store.markBuildReady("img-vercel", "vercel", "vercel-snapshot", "sha-vercel", 40);
 
     const modalImage = await store.getLatestReady("acme", "repo", "modal", "main");
     const vercelImage = await store.getLatestReady("acme", "repo", "vercel", "main");
@@ -395,6 +395,32 @@ describe("Repo image HTTP routes", () => {
     });
 
     expect(response.status).toBe(401);
+    const status = await store.getStatus("acme", "repo");
+    expect(status[0].status).toBe("building");
+  });
+
+  it("POST /repo-images/build-complete rejects missing completion metadata", async () => {
+    await store.registerBuild({
+      id: "img-missing-metadata",
+      repoOwner: "acme",
+      repoName: "repo",
+      provider: "modal",
+      baseBranch: "main",
+    });
+
+    const response = await SELF.fetch("https://test.local/repo-images/build-complete", {
+      method: "POST",
+      headers: await authHeaders(),
+      body: JSON.stringify({
+        build_id: "img-missing-metadata",
+        provider_image_id: "modal-img-missing-metadata",
+      }),
+    });
+
+    expect(response.status).toBe(400);
+    const body = await response.json<{ error: string }>();
+    expect(body.error).toBe("base_sha is required");
+
     const status = await store.getStatus("acme", "repo");
     expect(status[0].status).toBe("building");
   });
@@ -610,7 +636,7 @@ describe("Repo image HTTP routes", () => {
       provider: "modal",
       baseBranch: "main",
     });
-    await store.markReady("img-s1", "modal", "modal-img-1", "sha1", 30);
+    await store.markBuildReady("img-s1", "modal", "modal-img-1", "sha1", 30);
 
     const headers = await authHeaders();
     delete (headers as Record<string, string | undefined>)["Content-Type"];


### PR DESCRIPTION
## Summary

- extract repo image build planning, provider adapters, backend policy, callback auth, and workflow orchestration out of the route/session boundary
- replace the loose repo image build plan bag with provider-specific discriminated interfaces and explicit callback/clone auth modes
- harden build-ready finalization so stale completions cannot replace newer ready images and superseded images are cleaned up deterministically
- tighten build-complete callback validation for required completion metadata

## Validation

- npm run typecheck -w @open-inspect/control-plane
- npm run lint -w @open-inspect/control-plane
- npm test -w @open-inspect/control-plane
- npm run build -w @open-inspect/control-plane
- npm run test:integration -w @open-inspect/control-plane
- git diff --check

Note: the integration suite completed successfully while still printing the existing Cloudflare/Vitest teardown/span warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end repo image build workflow that coordinates triggering, callback authorization, completion/failure handling, and final status updates across multiple backends (modal, vercel, opencomputer).

* **Bug Fixes**
  * Strengthened callback token security by enforcing provider-session matching and rejecting expired/replayed tokens.
  * Improved “ready” image replacement to keep newer builds and mark/delete superseded images safely.
  * Hardened completion/failure flows with best-effort cleanup when errors occur.

* **Documentation/Tests**
  * Updated and expanded workflow/status test coverage, including stricter request validation (e.g., missing `base_sha` now returns 400).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->