### PR TITLE
fix(d1): fail fast on duplicate migration version prefixes

### DIFF
--- a/scripts/d1-migrate.sh
+++ b/scripts/d1-migrate.sh
@@ -7,16 +7,34 @@ MIGRATIONS_DIR="${2:-$SCRIPT_DIR/../terraform/d1/migrations}"
 
 WRANGLER="npx wrangler"
 
-# 0. Guard against duplicate version numbers. Migrations are deduped by their
-# numeric prefix (the _schema_migrations version), so two files sharing a
-# prefix mean one is silently skipped forever — e.g. two PRs that each grab the
-# next number and then both merge. Fail fast instead of skipping.
-DUPES=$(
-  for file in "$MIGRATIONS_DIR"/*.sql; do
-    [ -f "$file" ] || continue
-    basename "$file" | grep -oE '^[0-9]+'
-  done | sort | uniq -d
-)
+# 0. Validate filenames and guard against duplicate version numbers. Migrations
+# are deduped by their numeric prefix (the _schema_migrations version), so two
+# files sharing a prefix mean one is silently skipped forever — e.g. two PRs
+# that each grab the next number and then both merge. A file with no numeric
+# prefix can't be tracked at all. Fail fast on either, with a clear message.
+INVALID_FILES=""
+PREFIXES=""
+for file in "$MIGRATIONS_DIR"/*.sql; do
+  [ -f "$file" ] || continue
+  BASE=$(basename "$file")
+  # `|| true` so a prefix-less filename doesn't trip the grep's non-zero exit
+  # under `set -o pipefail` and abort before we can report it below.
+  PREFIX=$(printf '%s' "$BASE" | grep -oE '^[0-9]+' || true)
+  if [ -z "$PREFIX" ]; then
+    INVALID_FILES+="  $BASE"$'\n'
+  else
+    PREFIXES+="$PREFIX"$'\n'
+  fi
+done
+
+if [ -n "$INVALID_FILES" ]; then
+  echo "ERROR: migration files without a leading numeric prefix:" >&2
+  printf '%s' "$INVALID_FILES" >&2
+  echo "Rename them as NNNN_description.sql so they can be tracked." >&2
+  exit 1
+fi
+
+DUPES=$(printf '%s' "$PREFIXES" | sort | uniq -d)
 if [ -n "$DUPES" ]; then
   echo "ERROR: duplicate migration version prefixes detected:" >&2
   echo "$DUPES" | sed 's/^/  /' >&2

--- a/scripts/d1-migrate.sh
+++ b/scripts/d1-migrate.sh
@@ -7,6 +7,23 @@ MIGRATIONS_DIR="${2:-$SCRIPT_DIR/../terraform/d1/migrations}"
 
 WRANGLER="npx wrangler"
 
+# 0. Guard against duplicate version numbers. Migrations are deduped by their
+# numeric prefix (the _schema_migrations version), so two files sharing a
+# prefix mean one is silently skipped forever — e.g. two PRs that each grab the
+# next number and then both merge. Fail fast instead of skipping.
+DUPES=$(
+  for file in "$MIGRATIONS_DIR"/*.sql; do
+    [ -f "$file" ] || continue
+    basename "$file" | grep -oE '^[0-9]+'
+  done | sort | uniq -d
+)
+if [ -n "$DUPES" ]; then
+  echo "ERROR: duplicate migration version prefixes detected:" >&2
+  echo "$DUPES" | sed 's/^/  /' >&2
+  echo "Renumber the colliding files so each prefix is unique before deploying." >&2
+  exit 1
+fi
+
 # 1. Ensure tracking table exists
 $WRANGLER d1 execute "$DATABASE_NAME" --remote \
   --command "CREATE TABLE IF NOT EXISTS _schema_migrations (


### PR DESCRIPTION
## Problem

`scripts/d1-migrate.sh` tracks applied migrations by their **numeric prefix** — `VERSION=$(echo "$FILENAME" | grep -oE '^[0-9]+')`, stored as the `_schema_migrations.version` primary key, and the skip check is `grep -qxF "$VERSION"`.

If two migration files ever share a prefix, only one is recorded and the other is **silently skipped — permanently**. A re-run never recovers it, because the number is already marked applied. The result is schema drift that doesn't surface at migrate time; it shows up later as a confusing runtime error (e.g. `table X has no column named Y`).

This is easy to hit without anyone doing anything wrong: two PRs in flight each grab the next sequential number (`00NN_...`), both pass CI independently, and after both merge the directory has two `00NN_*.sql` files. One migration is then dropped on the next deploy.

## Fix

Detect colliding numeric prefixes at the start of the run and fail with a clear, actionable message instead of silently skipping:

```
ERROR: duplicate migration version prefixes detected:
  0022
Renumber the colliding files so each prefix is unique before deploying.
```

No behavior change when prefixes are unique. One-file change, no new dependencies (`sort | uniq -d` over the basenames' prefixes).

## Why a guard rather than reworking the tracking

Keying on the full filename instead of the prefix would also avoid the silent skip, but it changes the `_schema_migrations` PK semantics and the INSERT path for existing deployments. The guard is the minimal, behavior-preserving fix; it just turns a silent data-loss case into a loud, self-explaining failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a pre-flight validation for migration files to stop the migration process when two SQL files share the same version prefix.
  * Migrations now fail fast with clear error output when duplicate migration numbers are detected (and require filenames with numeric prefixes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->