### PR TITLE
fix: extend Slack thread continuity to 7 days

### DIFF
--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -235,13 +235,13 @@ any pull requests it opened and to the full web session — and the reaction is 
 posts a short failure notice in the thread instead.
 
 Every reply in a thread **continues the same session** — during the run and after it finishes — for
-up to 24 hours after the thread's first trigger, exactly like replying in an `@mention` thread. The
+up to 7 days after the thread's first trigger, exactly like replying in an `@mention` thread. The
 reply is enqueued as a follow-up turn on that session (re-spawning it from a snapshot if it had gone
 idle), and the agent posts its response in-thread when the turn finishes. A follow-up does not need
 to match the trigger condition — conditions gate new runs, not replies that continue an existing
 thread. If a reply races the very first trigger before its session exists, it falls back to an
-ephemeral "a run is already active" notice (reason `concurrent_run_active`); a reply more than 24
-hours after the first trigger starts a fresh run.
+ephemeral "a run is already active" notice (reason `concurrent_run_active`); a reply more than 7
+days after the first trigger starts a fresh run.
 
 ---
 
@@ -357,7 +357,7 @@ Event-driven automations use concurrency keys instead. For inbound webhooks, ret
 `idempotencyKey` are treated as the same event, but separate deliveries without a shared
 `idempotencyKey` can overlap.
 
-Slack Message triggers key concurrency by thread. Replies in a thread are not skipped — for 24 hours
+Slack Message triggers key concurrency by thread. Replies in a thread are not skipped — for 7 days
 after the thread's first trigger they continue the same session (during the run and after it
 finishes), routed to that session as follow-up prompts (see the **Run feedback** note under
 [Slack Message Triggers](#slack-message-triggers)).

--- a/docs/integrations/SLACK.md
+++ b/docs/integrations/SLACK.md
@@ -124,7 +124,7 @@ A top-level Slack request starts a new Slack thread. Reply in that thread to sen
 to the same Open-Inspect session. This applies in both channels and DMs: in a direct message, the
 follow-up still needs to be a thread reply, not a fresh top-level DM.
 
-Open-Inspect keeps the Slack thread connected to the session for about 24 hours. If you reply after
+Open-Inspect keeps the Slack thread connected to the session for about 7 days. If you reply after
 that mapping expires, or if you reply outside the thread, the bot may start repository selection
 again and create a new session.
 
@@ -258,11 +258,11 @@ condition to filter by content. See
   (with links to any pull requests and the full session), and the reaction is cleared. A failed run
   posts a short failure notice instead.
 - Every reply in a thread continues the same session — during the run and after it finishes — for up
-  to 24 hours after the thread's first trigger, like replying in an `@mention` thread. The reply is
+  to 7 days after the thread's first trigger, like replying in an `@mention` thread. The reply is
   routed to that session as a follow-up prompt (re-spawned from a snapshot if it had gone idle),
   gets its own 👀 reaction and in-thread response, and does **not** need to match the trigger's text
-  condition — conditions gate new runs, not replies that continue a thread. A reply more than 24
-  hours after the first trigger starts a fresh run.
+  condition — conditions gate new runs, not replies that continue a thread. A reply more than 7 days
+  after the first trigger starts a fresh run.
 
 ### Threat model
 
@@ -326,8 +326,8 @@ dropdown expires after one hour.
 
 ### A follow-up started a new session
 
-Reply inside the same Slack thread as the original request. Thread-to-session mappings last about 24
-hours, so older threads may need a fresh request.
+Reply inside the same Slack thread as the original request. Thread-to-session mappings last about 7
+days, so older threads may need a fresh request.
 
 ### The wrong model or branch was used
 

--- a/packages/control-plane/src/scheduler/durable-object.test.ts
+++ b/packages/control-plane/src/scheduler/durable-object.test.ts
@@ -1148,13 +1148,17 @@ describe("SchedulerDO", () => {
       const body = await res.json<{ triggered: number; skipped: number; steered: number }>();
       expect(body).toEqual({ triggered: 0, skipped: 0, steered: 1 });
 
-      // The continuity lookup is scoped to the thread's concurrency key and a time
-      // window measured from now (24h back).
+      // The continuity lookup is scoped to the thread's concurrency key and a
+      // 7-day window measured from now.
       expect(mockStore.getLatestSteerableRunForThread).toHaveBeenCalledWith(
         "auto-slack",
         "slack:C1:thread-root",
         expect.any(Number)
       );
+      const sinceMs = mockStore.getLatestSteerableRunForThread.mock.calls[0]?.[2] as number;
+      const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+      expect(sinceMs).toBeGreaterThanOrEqual(Date.now() - sevenDaysMs - 1000);
+      expect(sinceMs).toBeLessThanOrEqual(Date.now() - sevenDaysMs + 1000);
 
       // The follow-up was enqueued onto the existing session as a slack-sourced
       // turn, so its reply posts back in-thread via /callbacks/complete.

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -64,11 +64,11 @@ const RECOVERY_SWEEP_LIMIT = 50;
 
 /**
  * How long after a slack run's first trigger that thread replies keep continuing
- * the same session (matches the interactive thread→session KV TTL of 24h). Steering
+ * the same session (matches the interactive thread→session KV TTL of 7 days). Steering
  * does not create new runs, so this is measured from the root run's `created_at` and
  * does not slide — a reply after the window forks a fresh run.
  */
-const SLACK_THREAD_CONTINUITY_WINDOW_MS = 24 * 60 * 60 * 1000;
+const SLACK_THREAD_CONTINUITY_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 
 export class SchedulerDO extends DurableObject<Env> {
   private readonly log: Logger;

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -435,6 +435,11 @@ describe("POST /events", () => {
       env.CONTROL_PLANE.fetch as unknown as { mock: { calls: readonly (readonly unknown[])[] } }
     );
     expect(sessionBodies[0]).not.toHaveProperty("title");
+    expect((env.SLACK_KV as unknown as { put: ReturnType<typeof vi.fn> }).put).toHaveBeenCalledWith(
+      "thread:C123:111.222",
+      expect.any(String),
+      { expirationTtl: 7 * 24 * 60 * 60 }
+    );
 
     const updateBodies = slackApiBodies(slackFetch, "chat.update");
     expect(updateBodies).toEqual(

--- a/packages/slack-bot/src/index.ts
+++ b/packages/slack-bot/src/index.ts
@@ -45,6 +45,7 @@ import { getAvailableModels, getSlackDefaultModel } from "./app-home/models";
 import { slackInteractionPayloadSchema } from "./interaction-payload";
 
 const log = createLogger("handler");
+const THREAD_SESSION_TTL_SECONDS = 7 * 24 * 60 * 60;
 
 type BackgroundTaskScheduler = (promise: Promise<void>) => void;
 
@@ -215,7 +216,7 @@ async function lookupThreadSession(
 
 /**
  * Store a session mapping for a thread.
- * TTL is 24 hours by default.
+ * TTL is THREAD_SESSION_TTL_SECONDS by default.
  */
 async function storeThreadSession(
   env: Env,
@@ -226,7 +227,7 @@ async function storeThreadSession(
   try {
     const key = getThreadSessionKey(channel, threadTs);
     await createKvCacheStore(env.SLACK_KV).put(key, JSON.stringify(session), {
-      expirationTtl: 86400, // 24 hours
+      expirationTtl: THREAD_SESSION_TTL_SECONDS,
     });
   } catch (e) {
     log.error("kv.put", {


### PR DESCRIPTION
## Summary
- Extend interactive Slack thread-to-session KV mappings from 24 hours to 7 days.
- Extend Slack Message automation thread continuity to the same 7-day window.
- Update Slack integration and automation docs, and add assertions for the new continuity window.

Closes #855.

## Tests
- `npm test -w @open-inspect/slack-bot -- --run`
- `npm test -w @open-inspect/control-plane -- --run src/scheduler/durable-object.test.ts`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/c8344026e924768d8206a738c84ffad3)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Slack thread replies now keep the same session for up to 7 days instead of 24 hours.
  * Late replies now follow the updated fallback behavior, starting a new session when the window has expired.
  * Concurrent run handling now uses the same 7-day thread-based window.
  
* **Documentation**
  * Updated Slack and automation docs to match the longer thread continuity window and related troubleshooting guidance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->