### PR TITLE
Allow repo-less sessions from web composer

### DIFF
--- a/packages/web/src/app/(app)/page.test.tsx
+++ b/packages/web/src/app/(app)/page.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { DEFAULT_MODEL } from "@open-inspect/shared";
+import Home from "./page";
+
+expect.extend(matchers);
+
+const mocks = vi.hoisted(() => ({
+  routerPush: vi.fn(),
+  mutateMock: vi.fn(),
+  reposValue: [] as Array<{
+    id: number;
+    fullName: string;
+    owner: string;
+    name: string;
+    description: string | null;
+    private: boolean;
+    defaultBranch: string;
+  }>,
+  loadingReposValue: false,
+}));
+
+const repo = {
+  id: 1,
+  fullName: "open-inspect/background-agents",
+  owner: "open-inspect",
+  name: "background-agents",
+  description: null,
+  private: true,
+  defaultBranch: "main",
+};
+
+vi.mock("next-auth/react", () => ({
+  useSession: () => ({ data: { user: { id: "user-1" } }, status: "authenticated" }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.routerPush }),
+}));
+
+vi.mock("swr", () => ({
+  mutate: mocks.mutateMock,
+}));
+
+vi.mock("@/components/sidebar-layout", () => ({
+  useSidebarContext: () => ({ isOpen: true, toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-repos", () => ({
+  useRepos: () => ({ repos: mocks.reposValue, loading: mocks.loadingReposValue }),
+}));
+
+vi.mock("@/hooks/use-branches", () => ({
+  useBranches: () => ({ branches: [{ name: "main" }], loading: false }),
+}));
+
+vi.mock("@/hooks/use-enabled-models", () => ({
+  useEnabledModels: () => ({
+    enabledModels: [DEFAULT_MODEL],
+    enabledModelOptions: [
+      {
+        category: "Anthropic",
+        models: [{ id: DEFAULT_MODEL, name: "Claude Sonnet 4.6", description: "" }],
+      },
+    ],
+    loading: false,
+  }),
+}));
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+beforeEach(() => {
+  mocks.reposValue = [repo];
+  mocks.loadingReposValue = false;
+  mocks.routerPush.mockReset();
+  mocks.mutateMock.mockReset();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/sessions") {
+        return Response.json({ sessionId: "session-1" });
+      }
+      if (url === "/api/sessions/session-1/prompt") {
+        return Response.json({ ok: true });
+      }
+      return Response.json({ error: "unexpected request" }, { status: 500 });
+    })
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+function sessionCreateBody(): Record<string, unknown> {
+  const calls = vi.mocked(fetch).mock.calls;
+  const createCall = calls.find(([input]) => String(input) === "/api/sessions");
+  expect(createCall).toBeDefined();
+  return JSON.parse(String(createCall?.[1]?.body)) as Record<string, unknown>;
+}
+
+describe("Home", () => {
+  it("can start a new session without a repository from the primary selector", async () => {
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await screen.findByRole("button", { name: /background-agents/i });
+    await user.click(screen.getByRole("button", { name: /background-agents/i }));
+    const listbox = screen.getByRole("listbox");
+    await user.click(within(listbox).getByRole("option", { name: /no repository/i }));
+
+    await user.type(screen.getByPlaceholderText("What do you want to build?"), "Investigate logs");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+
+    await waitFor(() => expect(mocks.routerPush).toHaveBeenCalledWith("/session/session-1"));
+    expect(sessionCreateBody()).toMatchObject({
+      repoOwner: null,
+      repoName: null,
+      model: DEFAULT_MODEL,
+    });
+    expect(sessionCreateBody()).not.toHaveProperty("branch");
+  });
+
+  it("defaults to a no-repository session target when no repositories are available", async () => {
+    mocks.reposValue = [];
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await screen.findByRole("button", { name: /no repository/i });
+    await user.type(screen.getByPlaceholderText("What do you want to build?"), "Draft a plan");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+
+    await waitFor(() => expect(mocks.routerPush).toHaveBeenCalledWith("/session/session-1"));
+    expect(sessionCreateBody()).toMatchObject({
+      repoOwner: null,
+      repoName: null,
+      model: DEFAULT_MODEL,
+    });
+    expect(screen.getByText(/you can start without a repository/i)).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -36,23 +36,31 @@ import { Combobox, type ComboboxGroup } from "@/components/ui/combobox";
 const LAST_SELECTED_REPO_STORAGE_KEY = "open-inspect-last-selected-repo";
 const LAST_SELECTED_MODEL_STORAGE_KEY = "open-inspect-last-selected-model";
 const LAST_SELECTED_REASONING_EFFORT_STORAGE_KEY = "open-inspect-last-selected-reasoning-effort";
-const NO_REPOSITORY_VALUE = "__no_repository__";
+const NO_REPOSITORY_OPTION_VALUE = "__no_repository__";
 
-function isNoRepositoryTarget(value: string): boolean {
-  return value === NO_REPOSITORY_VALUE;
+type SessionTarget = { kind: "none" } | { kind: "repo"; repoFullName: string };
+
+function parseRepoFullName(repoFullName: string): { owner: string; name: string } | null {
+  const [owner, name] = repoFullName.split("/");
+  return owner && name ? { owner, name } : null;
 }
 
-function parseSelectedRepository(value: string): { owner: string; name: string } | null {
-  if (!value || isNoRepositoryTarget(value)) return null;
-  const [owner, name] = value.split("/");
-  return owner && name ? { owner, name } : null;
+function getTargetSelectValue(target: SessionTarget | null): string {
+  if (!target) return "";
+  return target.kind === "none" ? NO_REPOSITORY_OPTION_VALUE : target.repoFullName;
+}
+
+function parseTargetSelectValue(value: string): SessionTarget {
+  return value === NO_REPOSITORY_OPTION_VALUE
+    ? { kind: "none" }
+    : { kind: "repo", repoFullName: value };
 }
 
 export default function Home() {
   const { data: session } = useSession();
   const router = useRouter();
   const { repos, loading: loadingRepos } = useRepos();
-  const [selectedRepo, setSelectedRepo] = useState<string>("");
+  const [sessionTarget, setSessionTarget] = useState<SessionTarget | null>(null);
   const [selectedModel, setSelectedModel] = useState<string>(DEFAULT_MODEL);
   const [reasoningEffort, setReasoningEffort] = useState<string | undefined>(
     getDefaultReasoningEffort(DEFAULT_MODEL)
@@ -65,38 +73,40 @@ export default function Home() {
   const [isCreatingSession, setIsCreatingSession] = useState(false);
   const sessionCreationPromise = useRef<Promise<string | null> | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
-  const pendingConfigRef = useRef<{ repo: string; model: string; branch: string } | null>(null);
+  const pendingConfigRef = useRef<{ target: string; model: string; branch: string } | null>(null);
   const [hasHydratedModelPreferences, setHasHydratedModelPreferences] = useState(false);
   const { enabledModels, enabledModelOptions } = useEnabledModels();
-  const selectedRepository = parseSelectedRepository(selectedRepo);
+  const targetSelectValue = getTargetSelectValue(sessionTarget);
+  const selectedRepository =
+    sessionTarget?.kind === "repo" ? parseRepoFullName(sessionTarget.repoFullName) : null;
   const selectedRepoOwner = selectedRepository?.owner ?? "";
   const selectedRepoName = selectedRepository?.name ?? "";
   const { branches, loading: loadingBranches } = useBranches(selectedRepoOwner, selectedRepoName);
 
   // Auto-select repo when repos load
   useEffect(() => {
-    if (selectedRepo) return;
+    if (sessionTarget) return;
 
     if (repos.length > 0) {
       const lastSelectedRepo = localStorage.getItem(LAST_SELECTED_REPO_STORAGE_KEY);
       const hasLastSelectedRepo = repos.some((repo) => repo.fullName === lastSelectedRepo);
       const defaultRepo =
         (hasLastSelectedRepo ? lastSelectedRepo : repos[0].fullName) ?? repos[0].fullName;
-      setSelectedRepo(defaultRepo);
+      setSessionTarget({ kind: "repo", repoFullName: defaultRepo });
       const repo = repos.find((r) => r.fullName === defaultRepo);
       if (repo) setSelectedBranch(repo.defaultBranch);
       return;
     }
 
     if (!loadingRepos) {
-      setSelectedRepo(NO_REPOSITORY_VALUE);
+      setSessionTarget({ kind: "none" });
     }
-  }, [loadingRepos, repos, selectedRepo]);
+  }, [loadingRepos, repos, sessionTarget]);
 
   useEffect(() => {
-    if (!selectedRepo || isNoRepositoryTarget(selectedRepo)) return;
-    localStorage.setItem(LAST_SELECTED_REPO_STORAGE_KEY, selectedRepo);
-  }, [selectedRepo]);
+    if (sessionTarget?.kind !== "repo") return;
+    localStorage.setItem(LAST_SELECTED_REPO_STORAGE_KEY, sessionTarget.repoFullName);
+  }, [sessionTarget]);
 
   useEffect(() => {
     if (enabledModels.length === 0 || hasHydratedModelPreferences) return;
@@ -140,19 +150,20 @@ export default function Home() {
     setIsCreatingSession(false);
     sessionCreationPromise.current = null;
     pendingConfigRef.current = null;
-  }, [selectedRepo, selectedModel, selectedBranch]);
+  }, [sessionTarget, selectedModel, selectedBranch]);
 
   const createSessionForWarming = useCallback(async () => {
     if (pendingSessionId) return pendingSessionId;
     if (sessionCreationPromise.current) return sessionCreationPromise.current;
-    if (!selectedRepo) return null;
+    if (!sessionTarget) return null;
 
     setIsCreatingSession(true);
-    const repository = parseSelectedRepository(selectedRepo);
+    const repository =
+      sessionTarget.kind === "repo" ? parseRepoFullName(sessionTarget.repoFullName) : null;
     const currentConfig = {
-      repo: selectedRepo,
+      target: getTargetSelectValue(sessionTarget),
       model: selectedModel,
-      branch: repository ? selectedBranch : "",
+      branch: sessionTarget.kind === "repo" ? selectedBranch : "",
     };
     pendingConfigRef.current = currentConfig;
 
@@ -177,7 +188,7 @@ export default function Home() {
         if (res.ok) {
           const data = await res.json();
           if (
-            pendingConfigRef.current?.repo === currentConfig.repo &&
+            pendingConfigRef.current?.target === currentConfig.target &&
             pendingConfigRef.current?.model === currentConfig.model &&
             pendingConfigRef.current?.branch === currentConfig.branch
           ) {
@@ -204,7 +215,7 @@ export default function Home() {
 
     sessionCreationPromise.current = promise;
     return promise;
-  }, [selectedRepo, selectedModel, reasoningEffort, selectedBranch, pendingSessionId]);
+  }, [sessionTarget, selectedModel, reasoningEffort, selectedBranch, pendingSessionId]);
 
   // Reset selections when model preferences change (only after hydration)
   useEffect(() => {
@@ -222,14 +233,15 @@ export default function Home() {
     }
   }, [hasHydratedModelPreferences, enabledModels, selectedModel, reasoningEffort]);
 
-  const handleRepoChange = useCallback(
-    (repoFullName: string) => {
-      setSelectedRepo(repoFullName);
-      if (isNoRepositoryTarget(repoFullName)) {
+  const handleSessionTargetChange = useCallback(
+    (value: string) => {
+      const nextTarget = parseTargetSelectValue(value);
+      setSessionTarget(nextTarget);
+      if (nextTarget.kind === "none") {
         setSelectedBranch("");
         return;
       }
-      const repo = repos.find((r) => r.fullName === repoFullName);
+      const repo = repos.find((r) => r.fullName === nextTarget.repoFullName);
       if (repo) setSelectedBranch(repo.defaultBranch);
     },
     [repos]
@@ -243,7 +255,7 @@ export default function Home() {
   const handlePromptChange = (value: string) => {
     const wasEmpty = prompt.length === 0;
     setPrompt(value);
-    if (wasEmpty && value.length > 0 && !pendingSessionId && !isCreatingSession && selectedRepo) {
+    if (wasEmpty && value.length > 0 && !pendingSessionId && !isCreatingSession && sessionTarget) {
       createSessionForWarming();
     }
   };
@@ -251,7 +263,7 @@ export default function Home() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!prompt.trim()) return;
-    if (!selectedRepo) {
+    if (!sessionTarget) {
       setError("Please select a repository");
       return;
     }
@@ -300,8 +312,9 @@ export default function Home() {
       isAuthenticated={!!session}
       repos={repos}
       loadingRepos={loadingRepos}
-      selectedRepo={selectedRepo}
-      setSelectedRepo={handleRepoChange}
+      sessionTarget={sessionTarget}
+      targetSelectValue={targetSelectValue}
+      setSessionTargetSelectValue={handleSessionTargetChange}
       selectedBranch={selectedBranch}
       setSelectedBranch={setSelectedBranch}
       branches={branches}
@@ -325,8 +338,9 @@ function HomeContent({
   isAuthenticated,
   repos,
   loadingRepos,
-  selectedRepo,
-  setSelectedRepo,
+  sessionTarget,
+  targetSelectValue,
+  setSessionTargetSelectValue,
   selectedBranch,
   setSelectedBranch,
   branches,
@@ -346,8 +360,9 @@ function HomeContent({
   isAuthenticated: boolean;
   repos: Repo[];
   loadingRepos: boolean;
-  selectedRepo: string;
-  setSelectedRepo: (value: string) => void;
+  sessionTarget: SessionTarget | null;
+  targetSelectValue: string;
+  setSessionTargetSelectValue: (value: string) => void;
   selectedBranch: string;
   setSelectedBranch: (value: string) => void;
   branches: { name: string }[];
@@ -376,15 +391,19 @@ function HomeContent({
     }
   };
 
-  const selectedRepoObj = repos.find((r) => r.fullName === selectedRepo);
-  const displayRepoName = isNoRepositoryTarget(selectedRepo)
-    ? NO_REPOSITORY_LABEL
-    : selectedRepoObj
-      ? selectedRepoObj.name
-      : "Select repo";
+  const selectedRepoObj =
+    sessionTarget?.kind === "repo"
+      ? repos.find((r) => r.fullName === sessionTarget.repoFullName)
+      : undefined;
+  const displayRepoName =
+    sessionTarget?.kind === "none"
+      ? NO_REPOSITORY_LABEL
+      : sessionTarget?.kind === "repo"
+        ? (selectedRepoObj?.name ?? sessionTarget.repoFullName)
+        : "Select repo";
   const repositoryOptions = [
     {
-      value: NO_REPOSITORY_VALUE,
+      value: NO_REPOSITORY_OPTION_VALUE,
       label: NO_REPOSITORY_LABEL,
       description: "Start without cloning a repository",
     },
@@ -453,7 +472,7 @@ function HomeContent({
                     )}
                     <button
                       type="submit"
-                      disabled={!prompt.trim() || creating || !selectedRepo}
+                      disabled={!prompt.trim() || creating || !sessionTarget}
                       className="p-2 text-secondary-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition"
                       title={`Send (${SHORTCUT_LABELS.SEND_PROMPT})`}
                       aria-label={`Send (${SHORTCUT_LABELS.SEND_PROMPT})`}
@@ -473,8 +492,8 @@ function HomeContent({
                   <div className="flex flex-wrap items-center gap-2 sm:gap-4 min-w-0">
                     {/* Repo selector */}
                     <Combobox
-                      value={selectedRepo}
-                      onChange={(value) => setSelectedRepo(value)}
+                      value={targetSelectValue}
+                      onChange={(value) => setSessionTargetSelectValue(value)}
                       items={repositoryOptions}
                       searchable
                       searchPlaceholder="Search repositories..."
@@ -496,7 +515,7 @@ function HomeContent({
                     </Combobox>
 
                     {/* Branch selector */}
-                    {selectedRepoObj && (
+                    {sessionTarget?.kind === "repo" && (
                       <Combobox
                         value={selectedBranch}
                         onChange={(value) => setSelectedBranch(value)}

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { formatModelNameLower } from "@/lib/format";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
+import { NO_REPOSITORY_LABEL } from "@/lib/repo-label";
 import { isUnarchivedSessionListKey } from "@/lib/session-list";
 import { APP_NAME } from "@/lib/site-config";
 import {
@@ -35,6 +36,17 @@ import { Combobox, type ComboboxGroup } from "@/components/ui/combobox";
 const LAST_SELECTED_REPO_STORAGE_KEY = "open-inspect-last-selected-repo";
 const LAST_SELECTED_MODEL_STORAGE_KEY = "open-inspect-last-selected-model";
 const LAST_SELECTED_REASONING_EFFORT_STORAGE_KEY = "open-inspect-last-selected-reasoning-effort";
+const NO_REPOSITORY_VALUE = "__no_repository__";
+
+function isNoRepositoryTarget(value: string): boolean {
+  return value === NO_REPOSITORY_VALUE;
+}
+
+function parseSelectedRepository(value: string): { owner: string; name: string } | null {
+  if (!value || isNoRepositoryTarget(value)) return null;
+  const [owner, name] = value.split("/");
+  return owner && name ? { owner, name } : null;
+}
 
 export default function Home() {
   const { data: session } = useSession();
@@ -56,13 +68,16 @@ export default function Home() {
   const pendingConfigRef = useRef<{ repo: string; model: string; branch: string } | null>(null);
   const [hasHydratedModelPreferences, setHasHydratedModelPreferences] = useState(false);
   const { enabledModels, enabledModelOptions } = useEnabledModels();
-  const selectedRepoOwner = selectedRepo.split("/")[0] ?? "";
-  const selectedRepoName = selectedRepo.split("/")[1] ?? "";
+  const selectedRepository = parseSelectedRepository(selectedRepo);
+  const selectedRepoOwner = selectedRepository?.owner ?? "";
+  const selectedRepoName = selectedRepository?.name ?? "";
   const { branches, loading: loadingBranches } = useBranches(selectedRepoOwner, selectedRepoName);
 
   // Auto-select repo when repos load
   useEffect(() => {
-    if (repos.length > 0 && !selectedRepo) {
+    if (selectedRepo) return;
+
+    if (repos.length > 0) {
       const lastSelectedRepo = localStorage.getItem(LAST_SELECTED_REPO_STORAGE_KEY);
       const hasLastSelectedRepo = repos.some((repo) => repo.fullName === lastSelectedRepo);
       const defaultRepo =
@@ -70,11 +85,16 @@ export default function Home() {
       setSelectedRepo(defaultRepo);
       const repo = repos.find((r) => r.fullName === defaultRepo);
       if (repo) setSelectedBranch(repo.defaultBranch);
+      return;
     }
-  }, [repos, selectedRepo]);
+
+    if (!loadingRepos) {
+      setSelectedRepo(NO_REPOSITORY_VALUE);
+    }
+  }, [loadingRepos, repos, selectedRepo]);
 
   useEffect(() => {
-    if (!selectedRepo) return;
+    if (!selectedRepo || isNoRepositoryTarget(selectedRepo)) return;
     localStorage.setItem(LAST_SELECTED_REPO_STORAGE_KEY, selectedRepo);
   }, [selectedRepo]);
 
@@ -128,8 +148,12 @@ export default function Home() {
     if (!selectedRepo) return null;
 
     setIsCreatingSession(true);
-    const [owner, name] = selectedRepo.split("/");
-    const currentConfig = { repo: selectedRepo, model: selectedModel, branch: selectedBranch };
+    const repository = parseSelectedRepository(selectedRepo);
+    const currentConfig = {
+      repo: selectedRepo,
+      model: selectedModel,
+      branch: repository ? selectedBranch : "",
+    };
     pendingConfigRef.current = currentConfig;
 
     const abortController = new AbortController();
@@ -141,11 +165,11 @@ export default function Home() {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            repoOwner: owner,
-            repoName: name,
+            repoOwner: repository?.owner ?? null,
+            repoName: repository?.name ?? null,
             model: selectedModel,
             reasoningEffort,
-            branch: selectedBranch || undefined,
+            ...(repository ? { branch: selectedBranch || undefined } : {}),
           }),
           signal: abortController.signal,
         });
@@ -201,6 +225,10 @@ export default function Home() {
   const handleRepoChange = useCallback(
     (repoFullName: string) => {
       setSelectedRepo(repoFullName);
+      if (isNoRepositoryTarget(repoFullName)) {
+        setSelectedBranch("");
+        return;
+      }
       const repo = repos.find((r) => r.fullName === repoFullName);
       if (repo) setSelectedBranch(repo.defaultBranch);
     },
@@ -349,7 +377,23 @@ function HomeContent({
   };
 
   const selectedRepoObj = repos.find((r) => r.fullName === selectedRepo);
-  const displayRepoName = selectedRepoObj ? selectedRepoObj.name : "Select repo";
+  const displayRepoName = isNoRepositoryTarget(selectedRepo)
+    ? NO_REPOSITORY_LABEL
+    : selectedRepoObj
+      ? selectedRepoObj.name
+      : "Select repo";
+  const repositoryOptions = [
+    {
+      value: NO_REPOSITORY_VALUE,
+      label: NO_REPOSITORY_LABEL,
+      description: "Start without cloning a repository",
+    },
+    ...repos.map((repo) => ({
+      value: repo.fullName,
+      label: repo.name,
+      description: `${repo.owner}${repo.private ? " \u2022 private" : ""}`,
+    })),
+  ];
 
   return (
     <div className="h-full flex flex-col">
@@ -431,11 +475,7 @@ function HomeContent({
                     <Combobox
                       value={selectedRepo}
                       onChange={(value) => setSelectedRepo(value)}
-                      items={repos.map((repo) => ({
-                        value: repo.fullName,
-                        label: repo.name,
-                        description: `${repo.owner}${repo.private ? " \u2022 private" : ""}`,
-                      }))}
+                      items={repositoryOptions}
                       searchable
                       searchPlaceholder="Search repositories..."
                       filterFn={(option, query) =>
@@ -456,27 +496,29 @@ function HomeContent({
                     </Combobox>
 
                     {/* Branch selector */}
-                    <Combobox
-                      value={selectedBranch}
-                      onChange={(value) => setSelectedBranch(value)}
-                      items={branches.map((b) => ({
-                        value: b.name,
-                        label: b.name,
-                      }))}
-                      searchable
-                      searchPlaceholder="Search branches..."
-                      filterFn={(option, query) => option.label.toLowerCase().includes(query)}
-                      direction="up"
-                      dropdownWidth="w-56"
-                      disabled={creating || !selectedRepo || loadingBranches}
-                      triggerClassName="flex max-w-full items-center gap-1 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
-                    >
-                      <BranchIcon className="w-3.5 h-3.5" />
-                      <span className="truncate max-w-[9rem] sm:max-w-none">
-                        {loadingBranches ? "Loading..." : selectedBranch || "branch"}
-                      </span>
-                      <ChevronDownIcon className="w-3 h-3" />
-                    </Combobox>
+                    {selectedRepoObj && (
+                      <Combobox
+                        value={selectedBranch}
+                        onChange={(value) => setSelectedBranch(value)}
+                        items={branches.map((b) => ({
+                          value: b.name,
+                          label: b.name,
+                        }))}
+                        searchable
+                        searchPlaceholder="Search branches..."
+                        filterFn={(option, query) => option.label.toLowerCase().includes(query)}
+                        direction="up"
+                        dropdownWidth="w-56"
+                        disabled={creating || loadingBranches}
+                        triggerClassName="flex max-w-full items-center gap-1 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
+                      >
+                        <BranchIcon className="w-3.5 h-3.5" />
+                        <span className="truncate max-w-[9rem] sm:max-w-none">
+                          {loadingBranches ? "Loading..." : selectedBranch || "branch"}
+                        </span>
+                        <ChevronDownIcon className="w-3 h-3" />
+                      </Combobox>
+                    )}
 
                     {/* Model selector */}
                     <Combobox
@@ -532,7 +574,8 @@ function HomeContent({
 
               {repos.length === 0 && !loadingRepos && (
                 <p className="mt-3 text-sm text-muted-foreground text-center">
-                  No repositories found. Make sure you have granted access to your repositories.
+                  No repositories found. You can start without a repository or grant repository
+                  access in settings.
                 </p>
               )}
             </form>


### PR DESCRIPTION
## Summary
- Add an explicit `No repository` option to the homepage session target selector.
- Create repo-less sessions from the web composer with `repoOwner: null` and `repoName: null`.
- Hide branch selection and omit branch context for repo-less sessions.
- Default to `No repository` when the user has no accessible repositories.

## Testing
- `npm test -w @open-inspect/web -- src/app/(app)/page.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web`
- `npm test -w @open-inspect/web`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit “start without a repository” option for session creation.
  * Updated the repository picker to reflect this choice and only show branch selection when a repository is selected.
* **Bug Fixes**
  * Improved session startup when no repositories are available, including clearer guidance in the empty state.
* **Tests**
  * Added UI flow coverage to ensure sessions can start with a “no repository” target and send the expected session creation payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->