### PR TITLE
fix(slack-bot): give each repo quick-pick button a unique action_id

### DIFF
--- a/packages/slack-bot/src/index.ts
+++ b/packages/slack-bot/src/index.ts
@@ -37,6 +37,7 @@ import { handleAppHomeInteractionRoute, publishAppHome } from "./app-home";
 import {
   SELECT_REPO_ACTION_ID,
   SELECT_REPO_QUICK_PICK_ACTION_ID,
+  baseActionId,
   getRepoClarificationOptions,
   buildRepoClarificationBlocks,
 } from "./repo-clarification";
@@ -1201,7 +1202,8 @@ async function handleSlackInteraction(
   const messageTs = payload.message?.ts;
   const threadTs = payload.message?.thread_ts;
 
-  switch (action.action_id) {
+  // Collapse a quick-pick's per-button action_id back to the bare constant before matching.
+  switch (baseActionId(action.action_id)) {
     case SELECT_REPO_ACTION_ID:
     case SELECT_REPO_QUICK_PICK_ACTION_ID: {
       if (!channel || !messageTs) return;

--- a/packages/slack-bot/src/repo-clarification.test.ts
+++ b/packages/slack-bot/src/repo-clarification.test.ts
@@ -7,6 +7,8 @@ import {
   SELECT_REPO_QUICK_PICK_ACTION_ID,
   buildRepoClarificationBlocks,
   buildRepoQuickPickButtons,
+  baseActionId,
+  quickPickActionId,
 } from "./repo-clarification";
 
 function repo(fullName: string, displayName?: string): RepoConfig {
@@ -50,17 +52,29 @@ describe("buildRepoQuickPickButtons", () => {
     expect(buildRepoQuickPickButtons([repo("acme/web"), repo("acme/api")])).toEqual([
       {
         type: "button",
-        action_id: SELECT_REPO_QUICK_PICK_ACTION_ID,
+        action_id: quickPickActionId(0),
         text: { type: "plain_text", text: "web" },
         value: "acme/web",
       },
       {
         type: "button",
-        action_id: SELECT_REPO_QUICK_PICK_ACTION_ID,
+        action_id: quickPickActionId(1),
         text: { type: "plain_text", text: "api" },
         value: "acme/api",
       },
     ]);
+  });
+
+  it("gives each button a unique action_id so Slack accepts the block", () => {
+    // Slack requires action_id to be unique within an actions block.
+    const buttons = buildRepoQuickPickButtons(
+      Array.from({ length: MAX_REPO_QUICK_PICKS }, (_, idx) => repo(`acme/repo-${idx}`))
+    );
+    const actionIds = buttons.map((button) => button.action_id);
+    expect(new Set(actionIds).size).toBe(actionIds.length);
+    expect(actionIds.every((id) => baseActionId(id) === SELECT_REPO_QUICK_PICK_ACTION_ID)).toBe(
+      true
+    );
   });
 
   it("caps the number of buttons at MAX_REPO_QUICK_PICKS", () => {
@@ -84,6 +98,17 @@ describe("buildRepoQuickPickButtons", () => {
     ]);
 
     expect(buttons.map((button) => button.text.text)).toEqual(["acme/web", "other/web", "api"]);
+  });
+});
+
+describe("baseActionId", () => {
+  it("collapses indexed quick-pick ids to the bare constant, passing others through", () => {
+    expect(baseActionId(quickPickActionId(0))).toBe(SELECT_REPO_QUICK_PICK_ACTION_ID);
+    expect(baseActionId(quickPickActionId(4))).toBe(SELECT_REPO_QUICK_PICK_ACTION_ID);
+    // Messages posted before the per-button suffix existed stay clickable.
+    expect(baseActionId(SELECT_REPO_QUICK_PICK_ACTION_ID)).toBe(SELECT_REPO_QUICK_PICK_ACTION_ID);
+    expect(baseActionId(SELECT_REPO_ACTION_ID)).toBe(SELECT_REPO_ACTION_ID);
+    expect(baseActionId("view_session")).toBe("view_session");
   });
 });
 
@@ -120,8 +145,8 @@ describe("buildRepoClarificationBlocks", () => {
         type: "actions",
         block_id: "repo_quick_picks",
         elements: [
-          { type: "button", action_id: SELECT_REPO_QUICK_PICK_ACTION_ID, value: "acme/web" },
-          { type: "button", action_id: SELECT_REPO_QUICK_PICK_ACTION_ID, value: "acme/api" },
+          { type: "button", action_id: quickPickActionId(0), value: "acme/web" },
+          { type: "button", action_id: quickPickActionId(1), value: "acme/api" },
         ],
       },
       {

--- a/packages/slack-bot/src/repo-clarification.ts
+++ b/packages/slack-bot/src/repo-clarification.ts
@@ -28,10 +28,26 @@ import type { Env, RepoConfig } from "./types";
 export const SELECT_REPO_ACTION_ID = "select_repo";
 
 /**
- * Action ID for the one-click quick-pick buttons that surface the classifier's
- * ranked alternatives. Routed through the same selection path as the picker.
+ * Action ID prefix for the one-click quick-pick buttons that surface the
+ * classifier's ranked alternatives. Routed through the same selection path as
+ * the picker; each button gets a unique suffix via {@link quickPickActionId}.
  */
 export const SELECT_REPO_QUICK_PICK_ACTION_ID = "select_repo_quick_pick";
+
+/** Unique per-button action_id; Slack requires action_id uniqueness within an actions block. */
+export function quickPickActionId(index: number): string {
+  return `${SELECT_REPO_QUICK_PICK_ACTION_ID}:${index}`;
+}
+
+/**
+ * Collapse a quick-pick's per-button action_id back to the bare constant so the
+ * interactions handler can match it; other action_ids pass through unchanged.
+ */
+export function baseActionId(actionId: string): string {
+  return actionId.startsWith(`${SELECT_REPO_QUICK_PICK_ACTION_ID}:`)
+    ? SELECT_REPO_QUICK_PICK_ACTION_ID
+    : actionId;
+}
 
 /**
  * Cap on quick-pick buttons in the clarification message. The classifier rarely
@@ -72,9 +88,9 @@ export function buildRepoQuickPickButtons(alternatives: RepoConfig[]): SlackButt
   const picks = alternatives.slice(0, MAX_REPO_QUICK_PICKS);
   const ambiguousNames = duplicateDisplayNames(picks);
 
-  return picks.map((repo) => ({
+  return picks.map((repo, index) => ({
     type: "button",
-    action_id: SELECT_REPO_QUICK_PICK_ACTION_ID,
+    action_id: quickPickActionId(index),
     // Two repos can share a displayName (e.g. the same repo name under different
     // owners); fall back to the unambiguous fullName for the colliding picks.
     text: plainTextOption(ambiguousNames.has(repo.displayName) ? repo.fullName : repo.displayName),


### PR DESCRIPTION
Slack requires action_id to be unique within an actions block and rejects the message with invalid_blocks otherwise. When the repo-clarification picker offers two or more quick-picks, it doesn't post and the user gets no response.

    `action_id` "select_repo_quick_pick" already exists
    [json-pointer:/blocks/0/elements/1/action_id]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repo selection handling in Slack so quick-pick buttons route correctly.
  * Each quick-pick button now uses a unique interaction ID, reducing collisions and making button clicks more reliable.
  * Repo selection options continue to behave the same for users, but interactions are now handled more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->