### PR TITLE
fix: avoid default OpenComputer sandbox timeout

### DIFF
--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -150,7 +150,8 @@ describe("OpenComputerSandboxProvider", () => {
       name: expect.stringMatching(/^openinspect-session-1-[0-9a-f]{8}$/),
       egressAllowlist: ["*"],
     });
-    expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-sandbox-1", 600);
+    expect(createCall).not.toHaveProperty("timeoutSeconds");
+    expect(client.setSandboxTimeout).not.toHaveBeenCalled();
     expect(client.setSecret).toHaveBeenCalledWith({
       storeId: "secret-store-1",
       name: "ANTHROPIC_API_KEY",
@@ -165,6 +166,23 @@ describe("OpenComputerSandboxProvider", () => {
       model: "claude-sonnet-4-6",
       branch: "main",
     });
+  });
+
+  it("applies an explicit timeout when creating a sandbox", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await provider.createSandbox({
+      ...baseConfig,
+      timeoutSeconds: 120,
+    });
+
+    const createCall = vi.mocked(client.createSandbox).mock.calls[0][0];
+    expect(createCall.timeoutSeconds).toBe(120);
+    expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-sandbox-1", 120);
   });
 
   it("serializes repo-less sandboxes without nullable repo env or labels", async () => {
@@ -318,7 +336,9 @@ describe("OpenComputerSandboxProvider", () => {
         }),
       })
     );
-    expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-fork-1", 600);
+    const forkCall = vi.mocked(client.forkFromCheckpoint).mock.calls[0][0];
+    expect(forkCall).not.toHaveProperty("timeoutSeconds");
+    expect(client.setSandboxTimeout).not.toHaveBeenCalled();
     expect(client.startRuntime).toHaveBeenCalledWith("oc-fork-1");
   });
 
@@ -344,8 +364,28 @@ describe("OpenComputerSandboxProvider", () => {
         }),
       })
     );
-    expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-fork-1", 600);
+    const forkCall = vi.mocked(client.forkFromCheckpoint).mock.calls[0][0];
+    expect(forkCall).not.toHaveProperty("timeoutSeconds");
+    expect(client.setSandboxTimeout).not.toHaveBeenCalled();
     expect(client.startRuntime).toHaveBeenCalledWith("oc-fork-1");
+  });
+
+  it("applies an explicit timeout when restoring from a snapshot", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await provider.restoreFromSnapshot({
+      ...baseConfig,
+      snapshotImageId: "checkpoint-session-1",
+      timeoutSeconds: 120,
+    });
+
+    const forkCall = vi.mocked(client.forkFromCheckpoint).mock.calls[0][0];
+    expect(forkCall.timeoutSeconds).toBe(120);
+    expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-fork-1", 120);
   });
 
   it("serializes repo-less snapshot restores without nullable repo env or labels", async () => {
@@ -502,7 +542,27 @@ describe("OpenComputerSandboxProvider", () => {
     expect(result).toMatchObject({ success: true, providerObjectId: "oc-sandbox-1" });
     expect(client.getSandbox).toHaveBeenCalledWith("oc-sandbox-1");
     expect(client.wakeSandbox).toHaveBeenCalledWith("oc-sandbox-1");
-    expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-sandbox-1", 600);
+    expect(client.setSandboxTimeout).not.toHaveBeenCalled();
+    expect(client.startRuntime).toHaveBeenCalledWith("oc-sandbox-1");
+  });
+
+  it("applies an explicit timeout when waking a hibernated sandbox", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await provider.resumeSandbox({
+      providerObjectId: "oc-sandbox-1",
+      sessionId: "session-1",
+      sandboxId: "sandbox-acme-repo-1",
+      codeServerEnabled: false,
+      timeoutSeconds: 120,
+    });
+
+    expect(client.wakeSandbox).toHaveBeenCalledWith("oc-sandbox-1");
+    expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-sandbox-1", 120);
     expect(client.startRuntime).toHaveBeenCalledWith("oc-sandbox-1");
   });
 

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -42,7 +42,6 @@ import {
 
 const log = createLogger("opencomputer-provider");
 const OPENCOMPUTER_SECRET_STORE_EGRESS_ALLOWLIST = ["*"];
-const OPENCOMPUTER_PROVIDER_TIMEOUT_FALLBACK_SECONDS = 10 * 60;
 const REPO_IMAGE_CALLBACK_ENV_KEYS = [
   "OI_REPO_IMAGE_PROVIDER_SESSION_ID",
   "OI_REPO_IMAGE_BUILD_ID",
@@ -108,7 +107,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
             name: config.sandboxId,
             env: envVars,
             labels,
-            timeoutSeconds,
+            ...(timeoutSeconds !== undefined ? { timeoutSeconds } : {}),
             secretStore: secretStore?.name,
           })
         : await this.client.createSandbox({
@@ -116,13 +115,15 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
             template: this.client.config.template,
             env: envVars,
             labels,
-            timeoutSeconds,
+            ...(timeoutSeconds !== undefined ? { timeoutSeconds } : {}),
             secretStore: secretStore?.name,
             projectId: this.client.config.projectId,
             target: this.client.config.target,
           });
       providerObjectId = sandbox.id;
-      await this.client.setSandboxTimeout(providerObjectId, timeoutSeconds);
+      if (timeoutSeconds !== undefined) {
+        await this.client.setSandboxTimeout(providerObjectId, timeoutSeconds);
+      }
       await this.client.startRuntime(providerObjectId);
       const tunnels = await this.buildTunnelUrls(
         providerObjectId,
@@ -166,19 +167,19 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     try {
       const envVars = await this.buildRuntimeEnvVars(config, { restoredFromSnapshot: true });
       secretStore = await this.createSecretStoreFor(config.sessionId, config.userEnvVars);
+      const timeoutSeconds = resolveOpenComputerTimeoutSeconds(config.timeoutSeconds);
       const sandbox = await this.client.forkFromCheckpoint({
         checkpointId: config.snapshotImageId,
         name: config.sandboxId,
         env: envVars,
         labels: this.buildLabels(config),
-        timeoutSeconds: resolveOpenComputerTimeoutSeconds(config.timeoutSeconds),
+        ...(timeoutSeconds !== undefined ? { timeoutSeconds } : {}),
         secretStore: secretStore?.name,
       });
       providerObjectId = sandbox.id;
-      await this.client.setSandboxTimeout(
-        providerObjectId,
-        resolveOpenComputerTimeoutSeconds(config.timeoutSeconds)
-      );
+      if (timeoutSeconds !== undefined) {
+        await this.client.setSandboxTimeout(providerObjectId, timeoutSeconds);
+      }
       await this.client.startRuntime(providerObjectId);
       const tunnels = await this.buildTunnelUrls(
         providerObjectId,
@@ -268,10 +269,10 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
       }
 
       if (wokeSandbox) {
-        await this.client.setSandboxTimeout(
-          config.providerObjectId,
-          resolveOpenComputerTimeoutSeconds(config.timeoutSeconds)
-        );
+        const timeoutSeconds = resolveOpenComputerTimeoutSeconds(config.timeoutSeconds);
+        if (timeoutSeconds !== undefined) {
+          await this.client.setSandboxTimeout(config.providerObjectId, timeoutSeconds);
+        }
         await this.client.startRuntime(config.providerObjectId);
       }
 
@@ -686,8 +687,8 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
   }
 }
 
-function resolveOpenComputerTimeoutSeconds(timeoutSeconds: number | undefined): number {
-  return timeoutSeconds ?? OPENCOMPUTER_PROVIDER_TIMEOUT_FALLBACK_SECONDS;
+function resolveOpenComputerTimeoutSeconds(timeoutSeconds: number | undefined): number | undefined {
+  return timeoutSeconds;
 }
 
 export function createOpenComputerProvider(


### PR DESCRIPTION
I noticed a strange behaviour when testing the opencomputer provider with openinspect - the sandboxes would hibernate (automatically) after a few mins of inactive. After 10 minutes it seems that they get killed by openinspect, seems to be detecting that box as stale. Subsequent messages lead to a failed start

Upon digging i noticed that openinspect attempts to checkpoint the (automatically) hibernated sandbox and that attempt fails, which leads to subsequent reconnects failing. 

In order to keep things simpler, in this change we don't set an automatic timeout when the sandbox starts instead we delegate explicit hibernation to the durable object session to perform the hibernation and waking up. On this test it seems more stable. 

This change removes the implicit OpenComputer timeout for normal runtime sessions. We now only pass/set a timeout when one is explicitly supplied, while leaving repo-image build timeouts unchanged. The intent is to let the Durable Object own normal session hibernation and wake behavior, which has been more stable in testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox actions now only apply a timeout when one is explicitly provided.
  * Default sandbox creation, restore, and resume flows no longer force a timeout.
  * Explicit timeout values are still honored when set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->