### PR TITLE
Document OpenComputer provider setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,17 +113,18 @@ built for internal use where all employees are trusted and have access to compan
 
 ## Packages
 
-| Package                                     | Description                                 |
-| ------------------------------------------- | ------------------------------------------- |
-| [control-plane](packages/control-plane)     | Cloudflare Workers + Durable Objects        |
-| [web](packages/web)                         | Next.js web client                          |
-| [sandbox-runtime](packages/sandbox-runtime) | Shared in-sandbox agent runtime             |
-| [modal-infra](packages/modal-infra)         | Modal sandbox infrastructure                |
-| [daytona-infra](packages/daytona-infra)     | Daytona snapshot infrastructure             |
-| [slack-bot](packages/slack-bot)             | Slack integration (sessions from messages)  |
-| [github-bot](packages/github-bot)           | GitHub integration (auto-review, @mention)  |
-| [linear-bot](packages/linear-bot)           | Linear integration (issue → coding session) |
-| [shared](packages/shared)                   | Shared types and utilities                  |
+| Package                                           | Description                                 |
+| ------------------------------------------------- | ------------------------------------------- |
+| [control-plane](packages/control-plane)           | Cloudflare Workers + Durable Objects        |
+| [web](packages/web)                               | Next.js web client                          |
+| [sandbox-runtime](packages/sandbox-runtime)       | Shared in-sandbox agent runtime             |
+| [modal-infra](packages/modal-infra)               | Modal sandbox infrastructure                |
+| [daytona-infra](packages/daytona-infra)           | Daytona snapshot infrastructure             |
+| [opencomputer-infra](packages/opencomputer-infra) | OpenComputer template infrastructure        |
+| [slack-bot](packages/slack-bot)                   | Slack integration (sessions from messages)  |
+| [github-bot](packages/github-bot)                 | GitHub integration (auto-review, @mention)  |
+| [linear-bot](packages/linear-bot)                 | Linear integration (issue → coding session) |
+| [shared](packages/shared)                         | Shared types and utilities                  |
 
 ## Getting Started
 
@@ -274,6 +275,7 @@ built with:
 - [Modal](https://modal.com) - Cloud sandbox infrastructure
 - [Daytona](https://www.daytona.io) - Cloud development sandboxes
 - [Vercel Sandbox](https://vercel.com/docs/vercel-sandbox) - Cloud sandbox infrastructure
+- [OpenComputer](https://www.opencomputer.dev) - Cloud sandbox infrastructure
 - [Cloudflare Workers](https://workers.cloudflare.com) - Edge computing
 - [OpenCode](https://opencode.ai) - Coding agent runtime
 - [Next.js](https://nextjs.org) - Web framework

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -15,11 +15,11 @@ This guide walks you through deploying your own instance of Open-Inspect using T
 
 Open-Inspect uses Terraform to automate deployment across multiple cloud providers:
 
-| Provider                                          | Purpose                          | What Terraform Creates                                                   |
-| ------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------ |
-| **Cloudflare**                                    | Control plane, session state     | Workers, KV namespaces, Durable Objects, D1 Database                     |
-| **Vercel** _or_ **Cloudflare Workers**            | Web application                  | Project + env vars (Vercel) _or_ Worker via OpenNext (Cloudflare)        |
-| **Modal**, **Daytona**, _or_ **Vercel Sandboxes** | Sandbox execution infrastructure | Modal app deployment, Daytona API config, _or_ Vercel Sandbox API config |
+| Provider                                                            | Purpose                          | What Terraform Creates                                                                                     |
+| ------------------------------------------------------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **Cloudflare**                                                      | Control plane, session state     | Workers, KV namespaces, Durable Objects, D1 Database                                                       |
+| **Vercel** _or_ **Cloudflare Workers**                              | Web application                  | Project + env vars (Vercel) _or_ Worker via OpenNext (Cloudflare)                                          |
+| **Modal**, **Daytona**, **Vercel Sandboxes**, _or_ **OpenComputer** | Sandbox execution infrastructure | Modal app deployment, Daytona API config, Vercel Sandbox API config, _or_ OpenComputer template/API config |
 
 > **Web platform choice**: Set `web_platform` in your `terraform.tfvars` to `"vercel"` (default) or
 > `"cloudflare"`. The Cloudflare option deploys the Next.js app as a Cloudflare Worker using
@@ -36,17 +36,18 @@ Open-Inspect uses Terraform to automate deployment across multiple cloud provide
 
 Create accounts on these services before continuing:
 
-| Service                                             | Purpose                                                        |
-| --------------------------------------------------- | -------------------------------------------------------------- |
-| [Cloudflare](https://dash.cloudflare.com)           | Control plane hosting (+ web app if using Cloudflare platform) |
-| [Vercel](https://vercel.com) _(optional)_           | Web application hosting (only if `web_platform = "vercel"`)    |
-| [Modal](https://modal.com) _(optional)_             | Sandbox infrastructure when `sandbox_provider = "modal"`       |
-| [Daytona](https://app.daytona.io) _(optional)_      | Sandbox infrastructure when `sandbox_provider = "daytona"`     |
-| [Vercel Sandboxes](https://vercel.com) _(optional)_ | Sandbox infrastructure when `sandbox_provider = "vercel"`      |
-| [GitHub](https://github.com/settings/developers)    | OAuth + repository access                                      |
-| [Anthropic](https://console.anthropic.com)          | Claude API                                                     |
-| [Slack](https://api.slack.com/apps) _(optional)_    | Slack bot integration                                          |
-| GitHub App Webhooks _(optional)_                    | GitHub bot (PR reviews)                                        |
+| Service                                                   | Purpose                                                         |
+| --------------------------------------------------------- | --------------------------------------------------------------- |
+| [Cloudflare](https://dash.cloudflare.com)                 | Control plane hosting (+ web app if using Cloudflare platform)  |
+| [Vercel](https://vercel.com) _(optional)_                 | Web application hosting (only if `web_platform = "vercel"`)     |
+| [Modal](https://modal.com) _(optional)_                   | Sandbox infrastructure when `sandbox_provider = "modal"`        |
+| [Daytona](https://app.daytona.io) _(optional)_            | Sandbox infrastructure when `sandbox_provider = "daytona"`      |
+| [Vercel Sandboxes](https://vercel.com) _(optional)_       | Sandbox infrastructure when `sandbox_provider = "vercel"`       |
+| [OpenComputer](https://app.opencomputer.dev) _(optional)_ | Sandbox infrastructure when `sandbox_provider = "opencomputer"` |
+| [GitHub](https://github.com/settings/developers)          | OAuth + repository access                                       |
+| [Anthropic](https://console.anthropic.com)                | Claude API                                                      |
+| [Slack](https://api.slack.com/apps) _(optional)_          | Slack bot integration                                           |
+| GitHub App Webhooks _(optional)_                          | GitHub bot (PR reviews)                                         |
 
 ### Required Tools
 
@@ -210,6 +211,20 @@ for the full runtime, snapshot, and resource configuration model.
 > **Important**: Unlike Modal, the Vercel provider does not automatically inject LLM API keys into
 > sandboxes. If you plan to use Claude models, add `ANTHROPIC_API_KEY` as a **global secret** in
 > Settings > Secrets after deploying. See [Secrets Management](SECRETS.md) for details.
+
+### OpenComputer
+
+> Only required when `sandbox_provider = "opencomputer"`.
+
+1. Create an OpenComputer API key.
+2. Set `sandbox_provider = "opencomputer"` in `terraform.tfvars`.
+3. Set `opencomputer_api_url` and `opencomputer_api_key`.
+4. Leave `opencomputer_template = ""` to let Terraform build the OpenInspect runtime template, or
+   set it to an existing OpenComputer template name.
+5. Run `terraform apply`.
+
+For the full template build and runtime details, see
+[OpenComputer Sandbox Provider](OPENCOMPUTER_PROVIDER.md).
 
 ### Anthropic
 

--- a/docs/OPENCOMPUTER_PROVIDER.md
+++ b/docs/OPENCOMPUTER_PROVIDER.md
@@ -1,0 +1,166 @@
+# OpenComputer Sandbox Provider
+
+Open-Inspect can use OpenComputer as the sandbox provider for coding sessions. The control plane
+talks directly to the OpenComputer REST API from Cloudflare Workers; there is no Modal-style shim
+service to deploy.
+
+Use `sandbox_provider = "opencomputer"` when you want sessions to run in OpenComputer sandboxes
+while keeping the same Open-Inspect control plane, web app, GitHub OAuth, and Slack/GitHub
+integrations.
+
+## Configuration
+
+Set these values in `terraform/environments/production/terraform.tfvars`:
+
+```hcl
+sandbox_provider = "opencomputer"
+
+opencomputer_api_url = "https://app.opencomputer.dev/api"
+opencomputer_api_key = "osb_..."
+
+# Optional: use an existing OpenComputer template by name.
+# Leave empty to let Terraform build and manage the OpenInspect runtime template.
+opencomputer_template = ""
+```
+
+The OpenComputer provider also needs the normal Open-Inspect values such as Cloudflare, GitHub App,
+Anthropic, and web app configuration. See [GETTING_STARTED.md](./GETTING_STARTED.md) for the full
+deployment flow.
+
+## Template Build
+
+OpenComputer sandboxes boot from a declarative template that contains:
+
+- the OpenInspect sandbox runtime
+- OpenCode and the OpenCode plugin dependencies
+- Python 3.12 runtime dependencies
+- GitHub CLI and Git credential helpers
+- browser/terminal support tools used by the agent runtime
+- certificate and localhost bootstrap commands needed by the sandbox environment
+
+There are two supported ways to provide this template.
+
+### Terraform-Managed Template
+
+This is the recommended path for a normal deployment.
+
+Leave `opencomputer_template = ""`. When `sandbox_provider = "opencomputer"`, Terraform computes a
+hash of the sandbox runtime and OpenComputer template builder source, builds a deterministic
+template named like:
+
+```text
+openinspect-runtime-<source-hash-prefix>
+```
+
+and passes that template name to the deployed control plane as `OPENCOMPUTER_TEMPLATE`.
+
+Run the deployment from the production Terraform directory:
+
+```bash
+cd terraform/environments/production
+terraform init
+terraform apply
+```
+
+Terraform rebuilds the managed template when relevant runtime or builder files change.
+
+### Manual Template
+
+Use this path when you want to build or test a template before wiring it into Terraform.
+
+```bash
+OPENCOMPUTER_API_URL="https://app.opencomputer.dev/api" \
+OPENCOMPUTER_API_KEY="osb_..." \
+OPENCOMPUTER_TEMPLATE="openinspect-runtime" \
+npm run build:opencomputer-template
+```
+
+Then set the same template name in Terraform:
+
+```hcl
+sandbox_provider      = "opencomputer"
+opencomputer_template = "openinspect-runtime"
+```
+
+When `opencomputer_template` is non-empty, Terraform skips the managed template build and uses that
+exact template name.
+
+## Runtime Behavior
+
+The OpenComputer provider creates fresh sandboxes from the configured template. The sandbox starts
+the OpenInspect runtime, which:
+
+1. clones or syncs the selected GitHub repository
+2. prepares repo-local OpenCode tools and skills
+3. starts OpenCode inside the sandbox
+4. starts the OpenInspect bridge process
+5. streams agent events back through the control plane
+
+OpenComputer owns sandbox hibernation and wake-up. Open-Inspect should not need to manually stop
+OpenComputer sandboxes during normal operation.
+
+## Required Secrets
+
+Terraform passes these provider-level values to the control plane:
+
+- `OPENCOMPUTER_API_URL`
+- `OPENCOMPUTER_API_KEY`
+- `OPENCOMPUTER_TEMPLATE`
+- `ANTHROPIC_API_KEY`
+
+The runtime also receives repository credentials from Open-Inspect for Git operations. If you use
+additional model providers or custom agent tools, add those keys through Open-Inspect's secrets
+settings. See [SECRETS.md](./SECRETS.md).
+
+## Verify
+
+After `terraform apply`, verify:
+
+1. The control plane is healthy:
+
+   ```bash
+   curl https://open-inspect-control-plane-<deployment_name>.<workers-subdomain>.workers.dev/health
+   ```
+
+2. The OpenComputer dashboard shows the OpenInspect template as ready.
+
+3. Starting a session in the web app creates an OpenComputer sandbox and reaches `Connected`.
+
+4. Inside the session, ask a simple repo question such as:
+
+   ```text
+   tell me about this repository
+   ```
+
+If a session starts but never produces agent output, check the control-plane Worker logs and the
+OpenComputer sandbox logs for runtime startup, bridge connection, and OpenCode health events.
+
+## Common Issues
+
+### Template Was Not Built
+
+If `opencomputer_template` is empty, Terraform should build the managed template during
+`terraform apply`. If you set `opencomputer_template`, make sure that exact template name already
+exists in OpenComputer and is ready.
+
+### Wrong API URL
+
+Use the API base URL, normally:
+
+```text
+https://app.opencomputer.dev/api
+```
+
+The builder normalizes a missing `/api` suffix, but the Terraform value should still be explicit.
+
+### Missing Repository Access
+
+Repository access still comes from the configured GitHub App installation. If the dashboard shows no
+repositories or a sandbox cannot clone a repo, check the GitHub App installation permissions before
+debugging OpenComputer.
+
+### LLM/API Key Problems
+
+The control plane passes `ANTHROPIC_API_KEY` for the default Claude models. If OpenCode reports a
+model or provider error, confirm that the key is present in Terraform and that the selected model is
+available for that account.

--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
@@ -24,10 +24,6 @@ export interface OpenComputerRestConfig {
   apiKey: string;
   /** Declarative template identifier containing the OpenInspect runtime */
   template: string;
-  /** Optional project/workspace/tenant scope */
-  projectId?: string;
-  /** Optional target/region/cell */
-  target?: string;
   /** Header used for API key authentication. Defaults to X-API-Key. */
   authHeaderName?: string;
   /** Optional prefix for the API key header value, e.g. "Bearer ". */
@@ -69,8 +65,6 @@ export interface OpenComputerCreateSandboxParams {
   labels?: Record<string, string>;
   timeoutSeconds?: number;
   secretStore?: string;
-  projectId?: string;
-  target?: string;
 }
 
 export interface OpenComputerForkCheckpointParams {
@@ -226,16 +220,11 @@ export class OpenComputerRestClient {
     params: OpenComputerCreateSandboxParams
   ): Promise<OpenComputerSandboxResponse> {
     const startMs = Date.now();
-    const metadata = {
-      ...(params.labels ?? {}),
-      ...(params.projectId ? { opencomputer_project_id: params.projectId } : {}),
-      ...(params.target ? { opencomputer_target: params.target } : {}),
-    };
     const body: Record<string, unknown> = {
       templateID: "base",
       snapshot: params.template,
       envs: params.env,
-      metadata,
+      metadata: params.labels,
     };
     if (params.timeoutSeconds !== undefined) {
       body.timeout = params.timeoutSeconds;

--- a/packages/control-plane/src/sandbox/provider-factory.ts
+++ b/packages/control-plane/src/sandbox/provider-factory.ts
@@ -70,8 +70,6 @@ function createOpenComputerProviderFromEnv(env: Env): OpenComputerSandboxProvide
     apiUrl: env.OPENCOMPUTER_API_URL,
     apiKey: env.OPENCOMPUTER_API_KEY,
     template: env.OPENCOMPUTER_TEMPLATE,
-    projectId: env.OPENCOMPUTER_PROJECT_ID,
-    target: env.OPENCOMPUTER_TARGET,
   });
 
   return createOpenComputerProvider(client, {

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -150,7 +150,8 @@ describe("OpenComputerSandboxProvider", () => {
       name: expect.stringMatching(/^openinspect-session-1-[0-9a-f]{8}$/),
       egressAllowlist: ["*"],
     });
-    expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-sandbox-1", 600);
+    expect(createCall).not.toHaveProperty("timeoutSeconds");
+    expect(client.setSandboxTimeout).not.toHaveBeenCalled();
     expect(client.setSecret).toHaveBeenCalledWith({
       storeId: "secret-store-1",
       name: "ANTHROPIC_API_KEY",
@@ -165,6 +166,23 @@ describe("OpenComputerSandboxProvider", () => {
       model: "claude-sonnet-4-6",
       branch: "main",
     });
+  });
+
+  it("applies an explicit timeout when creating a sandbox", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await provider.createSandbox({
+      ...baseConfig,
+      timeoutSeconds: 120,
+    });
+
+    const createCall = vi.mocked(client.createSandbox).mock.calls[0][0];
+    expect(createCall.timeoutSeconds).toBe(120);
+    expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-sandbox-1", 120);
   });
 
   it("serializes repo-less sandboxes without nullable repo env or labels", async () => {
@@ -318,7 +336,9 @@ describe("OpenComputerSandboxProvider", () => {
         }),
       })
     );
-    expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-fork-1", 600);
+    const forkCall = vi.mocked(client.forkFromCheckpoint).mock.calls[0][0];
+    expect(forkCall).not.toHaveProperty("timeoutSeconds");
+    expect(client.setSandboxTimeout).not.toHaveBeenCalled();
     expect(client.startRuntime).toHaveBeenCalledWith("oc-fork-1");
   });
 
@@ -344,8 +364,28 @@ describe("OpenComputerSandboxProvider", () => {
         }),
       })
     );
-    expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-fork-1", 600);
+    const forkCall = vi.mocked(client.forkFromCheckpoint).mock.calls[0][0];
+    expect(forkCall).not.toHaveProperty("timeoutSeconds");
+    expect(client.setSandboxTimeout).not.toHaveBeenCalled();
     expect(client.startRuntime).toHaveBeenCalledWith("oc-fork-1");
+  });
+
+  it("applies an explicit timeout when restoring from a snapshot", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await provider.restoreFromSnapshot({
+      ...baseConfig,
+      snapshotImageId: "checkpoint-session-1",
+      timeoutSeconds: 120,
+    });
+
+    const forkCall = vi.mocked(client.forkFromCheckpoint).mock.calls[0][0];
+    expect(forkCall.timeoutSeconds).toBe(120);
+    expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-fork-1", 120);
   });
 
   it("serializes repo-less snapshot restores without nullable repo env or labels", async () => {
@@ -502,7 +542,27 @@ describe("OpenComputerSandboxProvider", () => {
     expect(result).toMatchObject({ success: true, providerObjectId: "oc-sandbox-1" });
     expect(client.getSandbox).toHaveBeenCalledWith("oc-sandbox-1");
     expect(client.wakeSandbox).toHaveBeenCalledWith("oc-sandbox-1");
-    expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-sandbox-1", 600);
+    expect(client.setSandboxTimeout).not.toHaveBeenCalled();
+    expect(client.startRuntime).toHaveBeenCalledWith("oc-sandbox-1");
+  });
+
+  it("applies an explicit timeout when waking a hibernated sandbox", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await provider.resumeSandbox({
+      providerObjectId: "oc-sandbox-1",
+      sessionId: "session-1",
+      sandboxId: "sandbox-acme-repo-1",
+      codeServerEnabled: false,
+      timeoutSeconds: 120,
+    });
+
+    expect(client.wakeSandbox).toHaveBeenCalledWith("oc-sandbox-1");
+    expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-sandbox-1", 120);
     expect(client.startRuntime).toHaveBeenCalledWith("oc-sandbox-1");
   });
 

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -42,7 +42,6 @@ import {
 
 const log = createLogger("opencomputer-provider");
 const OPENCOMPUTER_SECRET_STORE_EGRESS_ALLOWLIST = ["*"];
-const OPENCOMPUTER_PROVIDER_TIMEOUT_FALLBACK_SECONDS = 10 * 60;
 const REPO_IMAGE_CALLBACK_ENV_KEYS = [
   "OI_REPO_IMAGE_PROVIDER_SESSION_ID",
   "OI_REPO_IMAGE_BUILD_ID",
@@ -108,7 +107,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
             name: config.sandboxId,
             env: envVars,
             labels,
-            timeoutSeconds,
+            ...(timeoutSeconds !== undefined ? { timeoutSeconds } : {}),
             secretStore: secretStore?.name,
           })
         : await this.client.createSandbox({
@@ -116,13 +115,15 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
             template: this.client.config.template,
             env: envVars,
             labels,
-            timeoutSeconds,
+            ...(timeoutSeconds !== undefined ? { timeoutSeconds } : {}),
             secretStore: secretStore?.name,
             projectId: this.client.config.projectId,
             target: this.client.config.target,
           });
       providerObjectId = sandbox.id;
-      await this.client.setSandboxTimeout(providerObjectId, timeoutSeconds);
+      if (timeoutSeconds !== undefined) {
+        await this.client.setSandboxTimeout(providerObjectId, timeoutSeconds);
+      }
       await this.client.startRuntime(providerObjectId);
       const tunnels = await this.buildTunnelUrls(
         providerObjectId,
@@ -166,19 +167,19 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     try {
       const envVars = await this.buildRuntimeEnvVars(config, { restoredFromSnapshot: true });
       secretStore = await this.createSecretStoreFor(config.sessionId, config.userEnvVars);
+      const timeoutSeconds = resolveOpenComputerTimeoutSeconds(config.timeoutSeconds);
       const sandbox = await this.client.forkFromCheckpoint({
         checkpointId: config.snapshotImageId,
         name: config.sandboxId,
         env: envVars,
         labels: this.buildLabels(config),
-        timeoutSeconds: resolveOpenComputerTimeoutSeconds(config.timeoutSeconds),
+        ...(timeoutSeconds !== undefined ? { timeoutSeconds } : {}),
         secretStore: secretStore?.name,
       });
       providerObjectId = sandbox.id;
-      await this.client.setSandboxTimeout(
-        providerObjectId,
-        resolveOpenComputerTimeoutSeconds(config.timeoutSeconds)
-      );
+      if (timeoutSeconds !== undefined) {
+        await this.client.setSandboxTimeout(providerObjectId, timeoutSeconds);
+      }
       await this.client.startRuntime(providerObjectId);
       const tunnels = await this.buildTunnelUrls(
         providerObjectId,
@@ -268,10 +269,10 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
       }
 
       if (wokeSandbox) {
-        await this.client.setSandboxTimeout(
-          config.providerObjectId,
-          resolveOpenComputerTimeoutSeconds(config.timeoutSeconds)
-        );
+        const timeoutSeconds = resolveOpenComputerTimeoutSeconds(config.timeoutSeconds);
+        if (timeoutSeconds !== undefined) {
+          await this.client.setSandboxTimeout(config.providerObjectId, timeoutSeconds);
+        }
         await this.client.startRuntime(config.providerObjectId);
       }
 
@@ -686,8 +687,8 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
   }
 }
 
-function resolveOpenComputerTimeoutSeconds(timeoutSeconds: number | undefined): number {
-  return timeoutSeconds ?? OPENCOMPUTER_PROVIDER_TIMEOUT_FALLBACK_SECONDS;
+function resolveOpenComputerTimeoutSeconds(timeoutSeconds: number | undefined): number | undefined {
+  return timeoutSeconds;
 }
 
 export function createOpenComputerProvider(

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -117,8 +117,6 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
             labels,
             ...(timeoutSeconds !== undefined ? { timeoutSeconds } : {}),
             secretStore: secretStore?.name,
-            projectId: this.client.config.projectId,
-            target: this.client.config.target,
           });
       providerObjectId = sandbox.id;
       if (timeoutSeconds !== undefined) {
@@ -362,8 +360,6 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
         },
         timeoutSeconds: config.buildTimeoutSeconds ?? DEFAULT_BUILD_TIMEOUT_SECONDS,
         secretStore: secretStore?.name,
-        projectId: this.client.config.projectId,
-        target: this.client.config.target,
       });
 
       if (config.onProviderSessionCreated) {

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -95,8 +95,6 @@ export interface Env {
   DAYTONA_TARGET?: string; // Optional Daytona target name
   OPENCOMPUTER_API_URL?: string; // OpenComputer REST API base URL
   OPENCOMPUTER_TEMPLATE?: string; // Declarative template containing sandbox runtime
-  OPENCOMPUTER_PROJECT_ID?: string; // Optional OpenComputer project/workspace scope
-  OPENCOMPUTER_TARGET?: string; // Optional OpenComputer target/region/cell
   VERCEL_PROJECT_ID?: string; // Vercel project ID used for Sandbox API scope
   VERCEL_TEAM_ID?: string; // Optional Vercel team ID used for Sandbox API scope
   VERCEL_BASE_SNAPSHOT_ID?: string; // Optional prebuilt base snapshot with sandbox runtime

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -89,8 +89,6 @@ vercel_sandbox_project_id = "" # e.g., "prj_xxxxxxxxxxxxxxxxxxxx"
 opencomputer_api_url = "https://app.opencomputer.dev/api"
 opencomputer_api_key = ""
 opencomputer_template = ""
-# opencomputer_project_id = "" # Optional project/workspace scope
-# opencomputer_target     = "" # Optional target/region/cell
 
 # =============================================================================
 # GitHub App Credentials

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -378,18 +378,6 @@ variable "opencomputer_template" {
   default     = ""
 }
 
-variable "opencomputer_project_id" {
-  description = "Optional OpenComputer project/workspace scope"
-  type        = string
-  default     = ""
-}
-
-variable "opencomputer_target" {
-  description = "Optional OpenComputer target, region, or cell"
-  type        = string
-  default     = ""
-}
-
 variable "vercel_sandbox_token" {
   description = "Vercel API token for the Vercel Sandbox API"
   type        = string

--- a/terraform/environments/production/workers-control-plane.tf
+++ b/terraform/environments/production/workers-control-plane.tf
@@ -92,12 +92,6 @@ module "control_plane_worker" {
         value = var.opencomputer_template != "" ? var.opencomputer_template : module.opencomputer_infra[0].snapshot_name,
       },
     ] : [],
-    local.use_opencomputer_backend && var.opencomputer_project_id != "" ? [
-      { name = "OPENCOMPUTER_PROJECT_ID", value = var.opencomputer_project_id },
-    ] : [],
-    local.use_opencomputer_backend && var.opencomputer_target != "" ? [
-      { name = "OPENCOMPUTER_TARGET", value = var.opencomputer_target },
-    ] : [],
     local.use_vercel_backend ? [
       { name = "VERCEL_PROJECT_ID", value = var.vercel_sandbox_project_id },
       { name = "VERCEL_RUNTIME", value = var.vercel_sandbox_runtime },


### PR DESCRIPTION
These documentation guides were missing in the opencomputer provider support. I have instructed an agent to generate them and verified correctness manually

Also bundled in this change: I removed the arguments opencomputer_project_id abd opencomputer_target which are hullociations from the agent (they don't really exist)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support and setup guidance for using OpenComputer as a sandbox provider.
  * Expanded the getting-started docs with updated provider and prerequisites information.

* **Bug Fixes**
  * Improved sandbox timeout handling so timeouts are only applied when explicitly provided.
  * Simplified OpenComputer setup by removing unnecessary scoping settings from configuration and deployment examples.

* **Documentation**
  * Updated the README credits and package table formatting.
  * Added a new OpenComputer provider guide and refreshed production setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->