### PR TITLE
Clarify repo image source architecture

### DIFF
--- a/packages/control-plane/src/db/repo-images.ts
+++ b/packages/control-plane/src/db/repo-images.ts
@@ -38,6 +38,14 @@ export interface RepoImage {
   created_at: number;
 }
 
+/**
+ * D1-backed repo image registry and state machine.
+ *
+ * The store is the concurrency boundary for build acceptance. Methods only move
+ * rows from building to terminal states when predicates still hold, which lets
+ * the workflow handle duplicate callbacks, provider-session token replay, and
+ * newer builds racing older builds without provider-specific branching.
+ */
 export class RepoImageStore {
   constructor(private readonly db: D1Database) {}
 

--- a/packages/control-plane/src/db/repo-images.ts
+++ b/packages/control-plane/src/db/repo-images.ts
@@ -41,10 +41,9 @@ export interface RepoImage {
 /**
  * D1-backed repo image registry and state machine.
  *
- * The store is the concurrency boundary for build acceptance. Methods only move
- * rows from building to terminal states when predicates still hold, which lets
- * the workflow handle duplicate callbacks, provider-session token replay, and
- * newer builds racing older builds without provider-specific branching.
+ * Completion and failure transitions use conditional updates so the workflow
+ * can handle duplicate callbacks, provider-session token replay, and newer
+ * builds racing older builds without provider-specific branching.
  */
 export class RepoImageStore {
   constructor(private readonly db: D1Database) {}

--- a/packages/control-plane/src/repo-images/modal-adapter.ts
+++ b/packages/control-plane/src/repo-images/modal-adapter.ts
@@ -8,6 +8,12 @@ import type {
   RepoImageBuildStartCallbacks,
 } from "./types";
 
+/**
+ * Modal adapter for direct provider-image callbacks.
+ *
+ * Modal's repo image builder returns the final provider image id in the callback,
+ * so finalization only validates and normalizes that artifact reference.
+ */
 export class ModalRepoImageBuildAdapter implements RepoImageBuildAdapter<ModalRepoImageBuildPlan> {
   constructor(private readonly provider: ModalRepoImageBuildProvider) {}
 

--- a/packages/control-plane/src/repo-images/modal-adapter.ts
+++ b/packages/control-plane/src/repo-images/modal-adapter.ts
@@ -12,7 +12,7 @@ import type {
  * Modal adapter for direct provider-image callbacks.
  *
  * Modal's repo image builder returns the final provider image id in the callback,
- * so finalization only validates and normalizes that artifact reference.
+ * so finalization passes that artifact id through after kind validation.
  */
 export class ModalRepoImageBuildAdapter implements RepoImageBuildAdapter<ModalRepoImageBuildPlan> {
   constructor(private readonly provider: ModalRepoImageBuildProvider) {}

--- a/packages/control-plane/src/repo-images/model.ts
+++ b/packages/control-plane/src/repo-images/model.ts
@@ -1,6 +1,14 @@
+/**
+ * Domain terms shared across repo image planning, storage, and session startup.
+ *
+ * A repo image is a provider-opaque prebuilt environment artifact: Modal stores
+ * an image id, Vercel stores a snapshot id, and OpenComputer stores a checkpoint
+ * id. Code outside provider adapters should treat those ids as opaque.
+ */
 export type RepoImageProvider = "modal" | "vercel" | "opencomputer";
 export type RepoImageBuildStatus = "building" | "ready" | "failed" | "superseded";
 
+/** Opaque provider artifact reference, optionally tied to the build sandbox that produced it. */
 export interface RepoImageProviderImageRef {
   providerImageId: string;
   providerSessionId?: string | null;
@@ -16,6 +24,7 @@ export type MarkRepoImageReadyResult =
   | { type: "superseded_by_newer_ready"; supersededImage: SupersededRepoImage }
   | { type: "not_accepting_completion" };
 
+/** Minimal build row shape needed before accepting a callback. */
 export interface RepoImageCallbackBuild {
   id: string;
   provider: RepoImageProvider;

--- a/packages/control-plane/src/repo-images/opencomputer-adapter.ts
+++ b/packages/control-plane/src/repo-images/opencomputer-adapter.ts
@@ -14,6 +14,12 @@ import type {
 const logger = createLogger("repo-images:opencomputer-adapter");
 const MS_PER_SECOND = 1000;
 
+/**
+ * OpenComputer adapter for provider-session repo image builds.
+ *
+ * Builds run in a temporary OpenComputer sandbox. On success, the adapter
+ * checkpoints that sandbox into the repo image artifact and deletes the build sandbox.
+ */
 export class OpenComputerRepoImageBuildAdapter implements RepoImageBuildAdapter<OpenComputerRepoImageBuildPlan> {
   constructor(private readonly provider: OpenComputerSandboxProvider) {}
 

--- a/packages/control-plane/src/repo-images/opencomputer-adapter.ts
+++ b/packages/control-plane/src/repo-images/opencomputer-adapter.ts
@@ -17,8 +17,8 @@ const MS_PER_SECOND = 1000;
 /**
  * OpenComputer adapter for provider-session repo image builds.
  *
- * Builds run in a temporary OpenComputer sandbox. On success, the adapter
- * checkpoints that sandbox into the repo image artifact and deletes the build sandbox.
+ * Builds run in a temporary OpenComputer sandbox. On success, the adapter turns
+ * that sandbox into the repo image artifact; cleanup hooks handle teardown.
  */
 export class OpenComputerRepoImageBuildAdapter implements RepoImageBuildAdapter<OpenComputerRepoImageBuildPlan> {
   constructor(private readonly provider: OpenComputerSandboxProvider) {}

--- a/packages/control-plane/src/repo-images/planner.ts
+++ b/packages/control-plane/src/repo-images/planner.ts
@@ -43,6 +43,13 @@ interface ResolvedRepoImageRepository {
   defaultBranch: string;
 }
 
+/**
+ * Resolves a trigger request into a concrete provider build plan.
+ *
+ * The planner is the only repo-image layer that talks to source-control and
+ * settings/secrets stores. It produces a typed plan that the workflow can run
+ * without passing request objects or environment lookup concerns into adapters.
+ */
 export class RepoImageBuildPlanner {
   constructor(
     private readonly env: Env,

--- a/packages/control-plane/src/repo-images/provider-factory.ts
+++ b/packages/control-plane/src/repo-images/provider-factory.ts
@@ -12,6 +12,13 @@ import type {
   VercelRepoImageBuildPlan,
 } from "./types";
 
+/**
+ * Composition boundary for repo image provider adapters.
+ *
+ * Callers choose by provider name; overloads preserve the relationship between
+ * provider and plan type so the workflow does not need unsafe casts or
+ * provider-specific construction details.
+ */
 export interface RepoImageBuildAdapterFactory {
   create(provider: "modal"): RepoImageBuildAdapter<ModalRepoImageBuildPlan>;
   create(provider: "vercel"): RepoImageBuildAdapter<VercelRepoImageBuildPlan>;

--- a/packages/control-plane/src/repo-images/provider-policy.ts
+++ b/packages/control-plane/src/repo-images/provider-policy.ts
@@ -3,6 +3,12 @@ import type { Env } from "../types";
 import type { RepoImageProvider } from "./model";
 import type { RepoImageCallbackMode } from "./types";
 
+/**
+ * Central provider policy for repo image support.
+ *
+ * Keep capability and callback-mode decisions here so routes/workflows can work
+ * from provider-neutral lifecycle terms instead of open-coded provider checks.
+ */
 const REPO_IMAGE_CALLBACK_MODES = {
   modal: "provider_image",
   vercel: "provider_session",

--- a/packages/control-plane/src/repo-images/types.ts
+++ b/packages/control-plane/src/repo-images/types.ts
@@ -1,6 +1,13 @@
 import type { CorrelationContext } from "../logger";
 import type { RepoImageProviderImageRef, SupersededRepoImage } from "./model";
 
+/**
+ * Callback mode captures the lifecycle shape, not the vendor.
+ *
+ * provider_image: the builder callback includes the ready artifact id.
+ * provider_session: the callback identifies a build sandbox; the control plane
+ * then snapshots/checkpoints that sandbox into the repo image artifact.
+ */
 export type RepoImageCallbackMode = "provider_image" | "provider_session";
 export type RepoImageWorkflowContext = CorrelationContext;
 
@@ -16,6 +23,7 @@ export type RepoImageWorkflowResult =
   | { type: "build_superseded"; cleanup?: Promise<void> }
   | { type: "build_failed"; cleanup?: Promise<void> };
 
+/** Provider-neutral build request fields resolved before adapter-specific execution. */
 interface BaseRepoImageBuildPlan {
   buildId: string;
   repoOwner: string;
@@ -27,6 +35,7 @@ interface BaseRepoImageBuildPlan {
   correlation: CorrelationContext;
 }
 
+/** Modal's data-plane builder returns the provider image id directly in its callback. */
 export interface ModalRepoImageBuildPlan extends BaseRepoImageBuildPlan {
   provider: "modal";
   callbackMode: "provider_image";
@@ -36,6 +45,7 @@ export type VercelCloneAuth =
   | { type: "credential_helper"; token: string }
   | { type: "unavailable" };
 
+/** Vercel builds inside a sandbox; the control plane snapshots it after callback success. */
 export interface VercelRepoImageBuildPlan extends BaseRepoImageBuildPlan {
   provider: "vercel";
   callbackMode: "provider_session";
@@ -43,6 +53,7 @@ export interface VercelRepoImageBuildPlan extends BaseRepoImageBuildPlan {
   cloneAuth: VercelCloneAuth;
 }
 
+/** OpenComputer builds inside a sandbox; the control plane checkpoints it after callback success. */
 export interface OpenComputerRepoImageBuildPlan extends BaseRepoImageBuildPlan {
   provider: "opencomputer";
   callbackMode: "provider_session";
@@ -62,6 +73,10 @@ export type RepoImageCallbackAuth =
   | { type: "none" }
   | { type: "bearer_token"; tokenHash: string; expiresAt: number };
 
+/**
+ * Planner output keeps the provider-specific plan and its persisted callback auth together.
+ * This is the handoff from environment/repository resolution to workflow execution.
+ */
 export type PlannedRepoImageBuild =
   | { plan: ModalRepoImageBuildPlan; callbackAuth: { type: "none" } }
   | {
@@ -73,6 +88,7 @@ export type PlannedRepoImageBuild =
       callbackAuth: Extract<RepoImageCallbackAuth, { type: "bearer_token" }>;
     };
 
+/** Lets provider-session adapters bind the provider sandbox id before the runtime launches. */
 export interface RepoImageBuildStartCallbacks {
   bindProviderSession(providerSessionId: string): Promise<void>;
 }
@@ -134,6 +150,7 @@ export type FailedRepoImageBuildInput = FailRepoImageBuild & {
   correlation: CorrelationContext;
 };
 
+/** Cleanup hook for providers whose completed build sandbox outlives finalization. */
 export interface CleanupCompletedProviderSessionBuildInput {
   kind: "provider_session";
   buildId: string;
@@ -146,6 +163,12 @@ export interface DeleteRepoImageInput {
   correlation?: CorrelationContext;
 }
 
+/**
+ * Provider-facing operations needed after a build has started.
+ *
+ * The workflow owns state transitions; adapters own translating lifecycle steps
+ * into provider API calls such as snapshot/checkpoint, stop/delete, and artifact deletion.
+ */
 export interface RepoImageBuildFinalizer {
   finalizeSuccessfulBuild(
     input: FinalizeRepoImageBuildInput
@@ -158,6 +181,7 @@ export interface RepoImageBuildFinalizer {
   deleteImage(input: DeleteRepoImageInput): Promise<void>;
 }
 
+/** Full provider adapter contract for starting and finalizing one typed repo image plan. */
 export type RepoImageBuildAdapter<Plan extends RepoImageBuildPlan> = RepoImageBuildFinalizer & {
   startBuild(plan: Plan, callbacks: RepoImageBuildStartCallbacks): Promise<void>;
 };

--- a/packages/control-plane/src/repo-images/types.ts
+++ b/packages/control-plane/src/repo-images/types.ts
@@ -181,7 +181,6 @@ export interface RepoImageBuildFinalizer {
   deleteImage(input: DeleteRepoImageInput): Promise<void>;
 }
 
-/** Full provider adapter contract for starting and finalizing one typed repo image plan. */
 export type RepoImageBuildAdapter<Plan extends RepoImageBuildPlan> = RepoImageBuildFinalizer & {
   startBuild(plan: Plan, callbacks: RepoImageBuildStartCallbacks): Promise<void>;
 };

--- a/packages/control-plane/src/repo-images/vercel-adapter.ts
+++ b/packages/control-plane/src/repo-images/vercel-adapter.ts
@@ -13,6 +13,12 @@ import type {
 const logger = createLogger("repo-images:vercel-adapter");
 const MS_PER_SECOND = 1000;
 
+/**
+ * Vercel adapter for provider-session repo image builds.
+ *
+ * Builds run in a temporary Vercel sandbox. On success, the adapter snapshots
+ * that sandbox into the durable repo image artifact and stops the build sandbox.
+ */
 export class VercelRepoImageBuildAdapter implements RepoImageBuildAdapter<VercelRepoImageBuildPlan> {
   constructor(private readonly provider: VercelSandboxProvider) {}
 

--- a/packages/control-plane/src/repo-images/vercel-adapter.ts
+++ b/packages/control-plane/src/repo-images/vercel-adapter.ts
@@ -16,8 +16,8 @@ const MS_PER_SECOND = 1000;
 /**
  * Vercel adapter for provider-session repo image builds.
  *
- * Builds run in a temporary Vercel sandbox. On success, the adapter snapshots
- * that sandbox into the durable repo image artifact and stops the build sandbox.
+ * Builds run in a temporary Vercel sandbox. On success, the adapter turns that
+ * sandbox into the durable repo image artifact; cleanup hooks handle teardown.
  */
 export class VercelRepoImageBuildAdapter implements RepoImageBuildAdapter<VercelRepoImageBuildPlan> {
   constructor(private readonly provider: VercelSandboxProvider) {}

--- a/packages/control-plane/src/repo-images/workflow.ts
+++ b/packages/control-plane/src/repo-images/workflow.ts
@@ -92,8 +92,17 @@ export interface AcceptBuildFailedCommand {
   context: RepoImageWorkflowContext;
 }
 
-// Workflow methods return successful domain outcomes and throw RepoImageError subclasses for
-// route-level error mapping.
+/**
+ * Application service for the repo image build lifecycle.
+ *
+ * The workflow sequences planning, provider adapter calls, callback authorization,
+ * store state transitions, and best-effort cleanup. It deliberately keeps HTTP
+ * parsing in routes, environment/repository resolution in the planner, and
+ * provider API details in adapters.
+ *
+ * Public methods return successful domain outcomes and throw RepoImageError
+ * subclasses for route-level error mapping.
+ */
 export class RepoImageBuildWorkflow {
   private readonly planner: RepoImageBuildPlannerLike | null;
 


### PR DESCRIPTION
## Summary

- Add source-level architecture comments for the repo image domain model, typed build plans, workflow, planner, store, provider policy/factory, and provider adapters.
- Clarify the difference between provider-image callbacks and provider-session callbacks without changing runtime behavior.
- Document that repo image artifact IDs are provider-opaque and should stay interpreted inside provider adapters.

## Validation

- `git diff --check`
- `npm run lint -w @open-inspect/control-plane`
- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run build -w @open-inspect/control-plane`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded developer-facing JSDoc documentation across repo image build planning, provider policy, adapter-provider boundaries, and callback-mode semantics.
  * Clarified build lifecycle behavior, including temporary sandbox usage, checkpointing/snapshotting artifacts on success, and best-effort cleanup.
  * Added clearer explanations of workflow sequencing and repo image store transitions, including safe handling of duplicate callbacks and racing builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->