### PR TITLE
fix: harden OpenComputer provider review gaps

### DIFF
--- a/packages/control-plane/src/repo-images/opencomputer-adapter.test.ts
+++ b/packages/control-plane/src/repo-images/opencomputer-adapter.test.ts
@@ -22,6 +22,7 @@ function createPlan(): OpenComputerRepoImageBuildPlan {
     baseBranch: "develop",
     callbackUrl: "https://worker.test/repo-images/build-complete",
     callbackToken: "callback-token",
+    cloneAuth: { type: "credential_helper", token: "clone-token" },
     buildTimeoutMs: 1_800_001,
     userEnvVars: { FOO: "bar" },
     correlation: {
@@ -46,6 +47,7 @@ describe("OpenComputerRepoImageBuildAdapter", () => {
       defaultBranch: "develop",
       callbackUrl: "https://worker.test/repo-images/build-complete",
       callbackToken: "callback-token",
+      cloneToken: "clone-token",
       buildTimeoutSeconds: 1801,
       userEnvVars: { FOO: "bar" },
       onProviderSessionCreated: bindProviderSession,

--- a/packages/control-plane/src/repo-images/opencomputer-adapter.ts
+++ b/packages/control-plane/src/repo-images/opencomputer-adapter.ts
@@ -35,6 +35,10 @@ export class OpenComputerRepoImageBuildAdapter implements RepoImageBuildAdapter<
       callbackUrl: openComputerPlan.callbackUrl,
       callbackToken: openComputerPlan.callbackToken,
       userEnvVars: openComputerPlan.userEnvVars,
+      cloneToken:
+        openComputerPlan.cloneAuth.type === "credential_helper"
+          ? openComputerPlan.cloneAuth.token
+          : undefined,
       buildTimeoutSeconds: Math.ceil(openComputerPlan.buildTimeoutMs / MS_PER_SECOND),
       onProviderSessionCreated: callbacks.bindProviderSession,
     });

--- a/packages/control-plane/src/repo-images/planner.ts
+++ b/packages/control-plane/src/repo-images/planner.ts
@@ -18,7 +18,7 @@ import {
 import { RepoImagePlanningError, RepoImageRepositoryNotInstalledError } from "./errors";
 import type { RepoImageProvider } from "./model";
 import { getRepoImageCallbackMode } from "./provider-policy";
-import type { PlannedRepoImageBuild, VercelCloneAuth } from "./types";
+import type { PlannedRepoImageBuild, RepoImageCloneAuth } from "./types";
 
 const logger = createLogger("repo-images:planner");
 const MS_PER_SECOND = 1000;
@@ -74,7 +74,7 @@ export class RepoImageBuildPlanner {
         repoName: params.repoName,
         repoId: resolved.repoId,
       }),
-      this.resolveVercelCloneAuth({
+      this.resolveProviderSessionCloneAuth({
         repoOwner: params.repoOwner,
         repoName: params.repoName,
       }),
@@ -144,7 +144,7 @@ export class RepoImageBuildPlanner {
   private createPlannedBuildForProvider(
     basePlan: BaseRepoImageBuildPlanInput,
     callbackAuth: PlannedCallbackAuth,
-    cloneAuth: VercelCloneAuth
+    cloneAuth: RepoImageCloneAuth
   ): PlannedRepoImageBuild {
     switch (this.provider) {
       case "modal":
@@ -181,6 +181,7 @@ export class RepoImageBuildPlanner {
             provider: "opencomputer",
             callbackMode: "provider_session",
             callbackToken: bearerAuth.token,
+            cloneAuth,
           },
           callbackAuth: {
             type: "bearer_token",
@@ -244,11 +245,13 @@ export class RepoImageBuildPlanner {
     return merged;
   }
 
-  private async resolveVercelCloneAuth(params: {
+  private async resolveProviderSessionCloneAuth(params: {
     repoOwner: string;
     repoName: string;
-  }): Promise<VercelCloneAuth> {
-    if (this.provider !== "vercel") return { type: "unavailable" };
+  }): Promise<RepoImageCloneAuth> {
+    if (getRepoImageCallbackMode(this.provider) !== "provider_session") {
+      return { type: "unavailable" };
+    }
 
     try {
       const provider = createSourceControlProviderFromEnv(this.env);

--- a/packages/control-plane/src/repo-images/planner.ts
+++ b/packages/control-plane/src/repo-images/planner.ts
@@ -17,7 +17,7 @@ import {
 } from "./auth";
 import { RepoImagePlanningError, RepoImageRepositoryNotInstalledError } from "./errors";
 import type { RepoImageProvider } from "./model";
-import { getRepoImageCallbackMode } from "./provider-policy";
+import { getRepoImageCallbackMode, getRepoImageCloneAuthMode } from "./provider-policy";
 import type { PlannedRepoImageBuild, RepoImageCloneAuth } from "./types";
 
 const logger = createLogger("repo-images:planner");
@@ -74,7 +74,7 @@ export class RepoImageBuildPlanner {
         repoName: params.repoName,
         repoId: resolved.repoId,
       }),
-      this.resolveProviderSessionCloneAuth({
+      this.resolveCloneAuth({
         repoOwner: params.repoOwner,
         repoName: params.repoName,
       }),
@@ -245,11 +245,11 @@ export class RepoImageBuildPlanner {
     return merged;
   }
 
-  private async resolveProviderSessionCloneAuth(params: {
+  private async resolveCloneAuth(params: {
     repoOwner: string;
     repoName: string;
   }): Promise<RepoImageCloneAuth> {
-    if (getRepoImageCallbackMode(this.provider) !== "provider_session") {
+    if (getRepoImageCloneAuthMode(this.provider) !== "credential_helper") {
       return { type: "unavailable" };
     }
 

--- a/packages/control-plane/src/repo-images/provider-policy.ts
+++ b/packages/control-plane/src/repo-images/provider-policy.ts
@@ -1,7 +1,7 @@
 import { resolveSandboxBackendName, type SandboxBackendName } from "../sandbox/provider-name";
 import type { Env } from "../types";
 import type { RepoImageProvider } from "./model";
-import type { RepoImageCallbackMode } from "./types";
+import type { RepoImageCallbackMode, RepoImageCloneAuthMode } from "./types";
 
 /**
  * Central provider policy for repo image support.
@@ -14,6 +14,12 @@ const REPO_IMAGE_CALLBACK_MODES = {
   vercel: "provider_session",
   opencomputer: "provider_session",
 } satisfies Record<RepoImageProvider, RepoImageCallbackMode>;
+
+const REPO_IMAGE_CLONE_AUTH_MODES = {
+  modal: "none",
+  vercel: "credential_helper",
+  opencomputer: "credential_helper",
+} satisfies Record<RepoImageProvider, RepoImageCloneAuthMode>;
 
 export function getRepoImagesUnsupportedMessage(env: Env): string | null {
   if (resolveRepoImageProvider(env.SANDBOX_PROVIDER)) {
@@ -38,6 +44,10 @@ export function getRepoImageProvider(env: Env): RepoImageProvider {
 
 export function getRepoImageCallbackMode(provider: RepoImageProvider): RepoImageCallbackMode {
   return REPO_IMAGE_CALLBACK_MODES[provider];
+}
+
+export function getRepoImageCloneAuthMode(provider: RepoImageProvider): RepoImageCloneAuthMode {
+  return REPO_IMAGE_CLONE_AUTH_MODES[provider];
 }
 
 function isRepoImageProvider(provider: SandboxBackendName): provider is RepoImageProvider {

--- a/packages/control-plane/src/repo-images/types.ts
+++ b/packages/control-plane/src/repo-images/types.ts
@@ -41,16 +41,18 @@ export interface ModalRepoImageBuildPlan extends BaseRepoImageBuildPlan {
   callbackMode: "provider_image";
 }
 
-export type VercelCloneAuth =
+export type RepoImageCloneAuth =
   | { type: "credential_helper"; token: string }
   | { type: "unavailable" };
+
+export type VercelCloneAuth = RepoImageCloneAuth;
 
 /** Vercel builds inside a sandbox; the control plane snapshots it after callback success. */
 export interface VercelRepoImageBuildPlan extends BaseRepoImageBuildPlan {
   provider: "vercel";
   callbackMode: "provider_session";
   callbackToken: string;
-  cloneAuth: VercelCloneAuth;
+  cloneAuth: RepoImageCloneAuth;
 }
 
 /** OpenComputer builds inside a sandbox; the control plane checkpoints it after callback success. */
@@ -58,6 +60,7 @@ export interface OpenComputerRepoImageBuildPlan extends BaseRepoImageBuildPlan {
   provider: "opencomputer";
   callbackMode: "provider_session";
   callbackToken: string;
+  cloneAuth: RepoImageCloneAuth;
 }
 
 export type ProviderSessionRepoImageBuildPlan =

--- a/packages/control-plane/src/repo-images/types.ts
+++ b/packages/control-plane/src/repo-images/types.ts
@@ -45,6 +45,8 @@ export type RepoImageCloneAuth =
   | { type: "credential_helper"; token: string }
   | { type: "unavailable" };
 
+export type RepoImageCloneAuthMode = "credential_helper" | "none";
+
 export type VercelCloneAuth = RepoImageCloneAuth;
 
 /** Vercel builds inside a sandbox; the control plane snapshots it after callback success. */

--- a/packages/control-plane/src/routes/repo-images.trigger.test.ts
+++ b/packages/control-plane/src/routes/repo-images.trigger.test.ts
@@ -9,6 +9,8 @@ import type * as SourceControlModule from "../source-control";
 import type * as SandboxClientModule from "../sandbox/client";
 import type * as VercelProviderModule from "../sandbox/providers/vercel/provider";
 import type * as VercelClientModule from "../sandbox/providers/vercel/client";
+import type * as OpenComputerProviderModule from "../sandbox/providers/opencomputer-provider";
+import type * as OpenComputerClientModule from "../sandbox/opencomputer-rest-client";
 import type * as IntegrationSettingsResolutionModule from "../session/integration-settings-resolution";
 
 // handleTriggerBuild resolves the repo's actual default branch (never assumes
@@ -27,6 +29,10 @@ const modalClient = vi.hoisted(() => ({
 }));
 
 const vercelProvider = vi.hoisted(() => ({
+  triggerRepoImageBuild: vi.fn(),
+}));
+
+const openComputerProvider = vi.hoisted(() => ({
   triggerRepoImageBuild: vi.fn(),
 }));
 
@@ -63,6 +69,22 @@ vi.mock("../sandbox/providers/vercel/client", async (importOriginal) => {
   return {
     ...actual,
     createVercelSandboxClient: vi.fn(() => ({})),
+  };
+});
+
+vi.mock("../sandbox/providers/opencomputer-provider", async (importOriginal) => {
+  const actual = await importOriginal<typeof OpenComputerProviderModule>();
+  return {
+    ...actual,
+    createOpenComputerProvider: vi.fn(() => openComputerProvider),
+  };
+});
+
+vi.mock("../sandbox/opencomputer-rest-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof OpenComputerClientModule>();
+  return {
+    ...actual,
+    createOpenComputerRestClient: vi.fn(() => ({})),
   };
 });
 
@@ -125,6 +147,19 @@ function createVercelEnv(): Env {
   } as Env;
 }
 
+function createOpenComputerEnv(): Env {
+  return {
+    DB: {} as unknown as D1Database,
+    SANDBOX_PROVIDER: "opencomputer",
+    SCM_PROVIDER: "github",
+    WORKER_URL: "https://cp.test",
+    INTERNAL_CALLBACK_SECRET: "callback-secret",
+    OPENCOMPUTER_API_URL: "https://opencomputer.test",
+    OPENCOMPUTER_API_KEY: "oc-token",
+    OPENCOMPUTER_TEMPLATE: "openinspect-runtime",
+  } as Env;
+}
+
 async function callTrigger(env: Env): Promise<Response> {
   return triggerRoute().handler(
     new Request(`https://test.local${TRIGGER_PATH}`, { method: "POST" }),
@@ -151,6 +186,7 @@ describe("POST /repo-images/trigger/:owner/:name", () => {
     registerBuildSpy.mockResolvedValue(undefined);
     modalClient.buildRepoImage.mockResolvedValue({ buildId: "build-1", status: "building" });
     vercelProvider.triggerRepoImageBuild.mockResolvedValue(undefined);
+    openComputerProvider.triggerRepoImageBuild.mockResolvedValue(undefined);
     integrationSettings.resolveSandboxSettings.mockResolvedValue({});
     scmProvider.generateCredentialHelperAuth.mockResolvedValue({
       username: "x-access-token",
@@ -216,6 +252,7 @@ describe("POST /repo-images/trigger/:owner/:name", () => {
         repoOwner: "acme",
         repoName: "repo",
         defaultBranch: "develop",
+        cloneToken: "clone-token",
       })
     );
 
@@ -225,6 +262,34 @@ describe("POST /repo-images/trigger/:owner/:name", () => {
         repoOwner: "acme",
         repoName: "repo",
         provider: "vercel",
+        baseBranch: "develop",
+      })
+    );
+  });
+
+  it("threads the clone token into the OpenComputer build backend", async () => {
+    scmProvider.checkRepositoryAccess.mockResolvedValue(RESOLVED_REPO);
+
+    const response = await callTrigger(createOpenComputerEnv());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      buildId: expect.stringContaining("img-acme-repo-"),
+      status: "building",
+    });
+    expect(scmProvider.generateCredentialHelperAuth).toHaveBeenCalled();
+    expect(openComputerProvider.triggerRepoImageBuild).toHaveBeenCalledTimes(1);
+    expect(openComputerProvider.triggerRepoImageBuild).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoOwner: "acme",
+        repoName: "repo",
+        defaultBranch: "develop",
+        cloneToken: "clone-token",
+      })
+    );
+    expect(registerBuildSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "opencomputer",
         baseBranch: "develop",
       })
     );

--- a/packages/control-plane/src/routes/repo-images.trigger.test.ts
+++ b/packages/control-plane/src/routes/repo-images.trigger.test.ts
@@ -222,6 +222,7 @@ describe("POST /repo-images/trigger/:owner/:name", () => {
       }),
       expect.any(Object)
     );
+    expect(scmProvider.generateCredentialHelperAuth).not.toHaveBeenCalled();
 
     // ...and is persisted as the build's base branch.
     expect(registerBuildSpy).toHaveBeenCalledWith(

--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
@@ -395,6 +395,14 @@ export class OpenComputerRestClient {
     );
   }
 
+  async getCheckpoint(id: string, checkpointId: string): Promise<OpenComputerCheckpointResponse> {
+    return await this.request<OpenComputerCheckpointResponse>(
+      "GET",
+      this.expandPath(this.paths.checkpoint, { id, checkpointId }),
+      TIMEOUT_GET_MS
+    );
+  }
+
   async deleteCheckpoint(id: string, checkpointId: string): Promise<void> {
     await this.request<void>(
       "DELETE",

--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
@@ -395,14 +395,6 @@ export class OpenComputerRestClient {
     );
   }
 
-  async getCheckpoint(id: string, checkpointId: string): Promise<OpenComputerCheckpointResponse> {
-    return await this.request<OpenComputerCheckpointResponse>(
-      "GET",
-      this.expandPath(this.paths.checkpoint, { id, checkpointId }),
-      TIMEOUT_GET_MS
-    );
-  }
-
   async deleteCheckpoint(id: string, checkpointId: string): Promise<void> {
     await this.request<void>(
       "DELETE",

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -37,7 +37,12 @@ function createMockClient(overrides: Partial<OpenComputerRestClient> = {}): Open
     createCheckpoint: vi.fn(async () => ({
       id: "checkpoint-1",
       sandboxId: "oc-sandbox-1",
-      status: "processing",
+      status: "ready",
+    })),
+    getCheckpoint: vi.fn(async () => ({
+      id: "checkpoint-1",
+      sandboxId: "oc-sandbox-1",
+      status: "ready",
     })),
     deleteSandbox: vi.fn(async (): Promise<void> => undefined),
     deleteCheckpoint: vi.fn(async (): Promise<void> => undefined),
@@ -226,6 +231,23 @@ describe("OpenComputerSandboxProvider", () => {
     expect(createCall.env).toHaveProperty("ANTHROPIC_API_KEY", "sk-provider");
   });
 
+  it("keeps repo LLM credentials ahead of provider defaults", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+      llmEnvVars: { ANTHROPIC_API_KEY: "sk-provider" },
+    });
+
+    await provider.createSandbox({
+      ...baseConfig,
+      userEnvVars: { ANTHROPIC_API_KEY: "sk-repo" },
+    });
+
+    const createCall = vi.mocked(client.createSandbox).mock.calls[0][0];
+    expect(createCall.env).toHaveProperty("ANTHROPIC_API_KEY", "sk-repo");
+  });
+
   it("scopes clone secrets to GitLab hosts for GitLab sessions", async () => {
     const client = createMockClient();
     const provider = new OpenComputerSandboxProvider(client, {
@@ -370,6 +392,28 @@ describe("OpenComputerSandboxProvider", () => {
     expect(client.startRuntime).toHaveBeenCalledWith("oc-fork-1");
   });
 
+  it("cleans up a restored sandbox when runtime startup fails", async () => {
+    const client = createMockClient({
+      startRuntime: vi.fn(async () => {
+        throw new Error("runtime failed");
+      }),
+    });
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await expect(
+      provider.restoreFromSnapshot({
+        ...baseConfig,
+        snapshotImageId: "checkpoint-session-1",
+      })
+    ).rejects.toThrow("Failed to restore OpenComputer sandbox from checkpoint");
+
+    expect(client.deleteSandbox).toHaveBeenCalledWith("oc-fork-1");
+    expect(client.deleteSecretStore).toHaveBeenCalledWith("secret-store-1");
+  });
+
   it("applies an explicit timeout when restoring from a snapshot", async () => {
     const client = createMockClient();
     const provider = new OpenComputerSandboxProvider(client, {
@@ -460,6 +504,40 @@ describe("OpenComputerSandboxProvider", () => {
     );
   });
 
+  it("waits for processing checkpoints before returning a snapshot image", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = createMockClient({
+        createCheckpoint: vi.fn(async () => ({
+          id: "checkpoint-1",
+          sandboxId: "oc-sandbox-1",
+          status: "processing",
+        })),
+        getCheckpoint: vi.fn(async () => ({
+          id: "checkpoint-1",
+          sandboxId: "oc-sandbox-1",
+          status: "ready",
+        })),
+      });
+      const provider = new OpenComputerSandboxProvider(client, {
+        scmProvider: "github",
+        codeServerPasswordSecret: "secret",
+      });
+
+      const snapshot = provider.takeSnapshot({
+        providerObjectId: "oc-sandbox-1",
+        sessionId: "session-1",
+        reason: "user_stop",
+      });
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      await expect(snapshot).resolves.toEqual({ success: true, imageId: "checkpoint-1" });
+      expect(client.getCheckpoint).toHaveBeenCalledWith("oc-sandbox-1", "checkpoint-1");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("creates checkpoints for execution-complete snapshots", async () => {
     const client = createMockClient();
     const provider = new OpenComputerSandboxProvider(client, {
@@ -501,6 +579,13 @@ describe("OpenComputerSandboxProvider", () => {
       defaultBranch: "main",
       callbackUrl: "https://control.example/repo-images/build-complete",
       callbackToken: "callback-token",
+      cloneToken: "clone-token",
+      userEnvVars: {
+        ANTHROPIC_API_KEY: "sk-repo",
+        OI_REPO_IMAGE_PROVIDER_SESSION_ID: "user-controlled",
+        OI_REPO_IMAGE_CALLBACK_TOKEN: "user-controlled",
+        OI_REPO_IMAGE_CALLBACK_SECRET: "legacy-user-controlled",
+      },
       onProviderSessionCreated,
     });
 
@@ -511,7 +596,8 @@ describe("OpenComputerSandboxProvider", () => {
           OI_REPO_IMAGE_BUILD_ID: "build-1",
           OI_REPO_IMAGE_CALLBACK_URL: "https://control.example/repo-images/build-complete",
           OI_REPO_IMAGE_CALLBACK_TOKEN: "callback-token",
-          ANTHROPIC_API_KEY: "sk-provider",
+          VCS_CLONE_TOKEN: "clone-token",
+          ANTHROPIC_API_KEY: "sk-repo",
         }),
         labels: expect.objectContaining({
           openinspect_kind: "repo-image-build",
@@ -519,10 +605,51 @@ describe("OpenComputerSandboxProvider", () => {
         }),
       })
     );
+    const createCall = vi.mocked(client.createSandbox).mock.calls[0][0];
+    expect(createCall.env).not.toHaveProperty("OI_REPO_IMAGE_PROVIDER_SESSION_ID");
+    expect(createCall.env).not.toHaveProperty("OI_REPO_IMAGE_CALLBACK_SECRET");
+    expect(client.setSecret).toHaveBeenCalledWith({
+      storeId: "secret-store-1",
+      name: "ANTHROPIC_API_KEY",
+      value: "sk-repo",
+      allowedHosts: ["api.anthropic.com"],
+    });
+    expect(client.setSecret).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: "OI_REPO_IMAGE_CALLBACK_TOKEN" })
+    );
+    expect(client.setSecret).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: "OI_REPO_IMAGE_CALLBACK_SECRET" })
+    );
     expect(onProviderSessionCreated).toHaveBeenCalledWith("oc-sandbox-1");
     expect(client.startRuntime).toHaveBeenCalledWith("oc-sandbox-1", {
       OI_REPO_IMAGE_PROVIDER_SESSION_ID: "oc-sandbox-1",
     });
+  });
+
+  it("cleans up a repo image build sandbox when runtime startup fails", async () => {
+    const client = createMockClient({
+      startRuntime: vi.fn(async () => {
+        throw new Error("runtime failed");
+      }),
+    });
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await expect(
+      provider.triggerRepoImageBuild({
+        buildId: "build-1",
+        repoOwner: "acme",
+        repoName: "repo",
+        defaultBranch: "main",
+        callbackUrl: "https://control.example/repo-images/build-complete",
+        callbackToken: "callback-token",
+      })
+    ).rejects.toThrow("Failed to trigger OpenComputer repo image build");
+
+    expect(client.deleteSandbox).toHaveBeenCalledWith("oc-sandbox-1");
+    expect(client.deleteSecretStore).toHaveBeenCalledWith("secret-store-1");
   });
 
   it("wakes hibernated sandboxes on resume", async () => {

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -350,6 +350,7 @@ describe("OpenComputerSandboxProvider", () => {
           OI_REPO_IMAGE_BUILD_ID: "",
           OI_REPO_IMAGE_CALLBACK_URL: "",
           OI_REPO_IMAGE_CALLBACK_TOKEN: "",
+          VCS_CLONE_TOKEN: "",
         }),
       })
     );
@@ -357,6 +358,29 @@ describe("OpenComputerSandboxProvider", () => {
     expect(forkCall).not.toHaveProperty("timeoutSeconds");
     expect(client.setSandboxTimeout).not.toHaveBeenCalled();
     expect(client.startRuntime).toHaveBeenCalledWith("oc-fork-1");
+  });
+
+  it("keeps explicit session clone tokens when forking from a repo image", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await provider.createSandbox({
+      ...baseConfig,
+      repoImageId: "checkpoint-repo-1",
+      userEnvVars: { VCS_CLONE_TOKEN: "session-token" },
+    });
+
+    expect(client.forkFromCheckpoint).toHaveBeenCalledWith(
+      expect.objectContaining({
+        checkpointId: "checkpoint-repo-1",
+        env: expect.objectContaining({
+          VCS_CLONE_TOKEN: "session-token",
+        }),
+      })
+    );
   });
 
   it("restores session snapshots by forking from the checkpoint", async () => {

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -37,12 +37,7 @@ function createMockClient(overrides: Partial<OpenComputerRestClient> = {}): Open
     createCheckpoint: vi.fn(async () => ({
       id: "checkpoint-1",
       sandboxId: "oc-sandbox-1",
-      status: "ready",
-    })),
-    getCheckpoint: vi.fn(async () => ({
-      id: "checkpoint-1",
-      sandboxId: "oc-sandbox-1",
-      status: "ready",
+      status: "processing",
     })),
     deleteSandbox: vi.fn(async (): Promise<void> => undefined),
     deleteCheckpoint: vi.fn(async (): Promise<void> => undefined),
@@ -502,40 +497,6 @@ describe("OpenComputerSandboxProvider", () => {
         retentionPolicy: OPENCOMPUTER_CHECKPOINT_RETENTION_POLICY,
       }
     );
-  });
-
-  it("waits for processing checkpoints before returning a snapshot image", async () => {
-    vi.useFakeTimers();
-    try {
-      const client = createMockClient({
-        createCheckpoint: vi.fn(async () => ({
-          id: "checkpoint-1",
-          sandboxId: "oc-sandbox-1",
-          status: "processing",
-        })),
-        getCheckpoint: vi.fn(async () => ({
-          id: "checkpoint-1",
-          sandboxId: "oc-sandbox-1",
-          status: "ready",
-        })),
-      });
-      const provider = new OpenComputerSandboxProvider(client, {
-        scmProvider: "github",
-        codeServerPasswordSecret: "secret",
-      });
-
-      const snapshot = provider.takeSnapshot({
-        providerObjectId: "oc-sandbox-1",
-        sessionId: "session-1",
-        reason: "user_stop",
-      });
-      await vi.advanceTimersByTimeAsync(2_000);
-
-      await expect(snapshot).resolves.toEqual({ success: true, imageId: "checkpoint-1" });
-      expect(client.getCheckpoint).toHaveBeenCalledWith("oc-sandbox-1", "checkpoint-1");
-    } finally {
-      vi.useRealTimers();
-    }
   });
 
   it("creates checkpoints for execution-complete snapshots", async () => {

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -81,6 +81,11 @@ export interface OpenComputerProviderConfig {
   llmEnvVars?: Record<string, string | undefined>;
 }
 
+interface PreparedOpenComputerEnvironment {
+  envVars: Record<string, string>;
+  secretEnvVars?: Record<string, string>;
+}
+
 export class OpenComputerSandboxProvider implements SandboxProvider {
   readonly name = "opencomputer";
 
@@ -101,18 +106,18 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     let secretStore: OpenComputerSecretStoreResponse | undefined;
     let providerObjectId: string | undefined;
     try {
-      const envVars = await this.buildRuntimeEnvVars(config, {
+      const environment = await this.buildRuntimeEnvironment(config, {
         fromRepoImage: !!config.repoImageId,
         repoImageSha: config.repoImageSha ?? undefined,
       });
-      secretStore = await this.createSecretStoreFor(config.sessionId, config.userEnvVars);
+      secretStore = await this.createSecretStoreFor(config.sessionId, environment.secretEnvVars);
       const labels = this.buildLabels(config);
       const timeoutSeconds = resolveOpenComputerTimeoutSeconds(config.timeoutSeconds);
       const sandbox = config.repoImageId
         ? await this.client.forkFromCheckpoint({
             checkpointId: config.repoImageId,
             name: config.sandboxId,
-            env: envVars,
+            env: environment.envVars,
             labels,
             ...(timeoutSeconds !== undefined ? { timeoutSeconds } : {}),
             secretStore: secretStore?.name,
@@ -120,7 +125,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
         : await this.client.createSandbox({
             name: config.sandboxId,
             template: this.client.config.template,
-            env: envVars,
+            env: environment.envVars,
             labels,
             ...(timeoutSeconds !== undefined ? { timeoutSeconds } : {}),
             secretStore: secretStore?.name,
@@ -170,13 +175,15 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     let secretStore: OpenComputerSecretStoreResponse | undefined;
     let providerObjectId: string | undefined;
     try {
-      const envVars = await this.buildRuntimeEnvVars(config, { restoredFromSnapshot: true });
-      secretStore = await this.createSecretStoreFor(config.sessionId, config.userEnvVars);
+      const environment = await this.buildRuntimeEnvironment(config, {
+        restoredFromSnapshot: true,
+      });
+      secretStore = await this.createSecretStoreFor(config.sessionId, environment.secretEnvVars);
       const timeoutSeconds = resolveOpenComputerTimeoutSeconds(config.timeoutSeconds);
       const sandbox = await this.client.forkFromCheckpoint({
         checkpointId: config.snapshotImageId,
         name: config.sandboxId,
-        env: envVars,
+        env: environment.envVars,
         labels: this.buildLabels(config),
         ...(timeoutSeconds !== undefined ? { timeoutSeconds } : {}),
         secretStore: secretStore?.name,
@@ -344,13 +351,12 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     let providerObjectId: string | undefined;
     try {
       const sandboxName = `build-${config.repoOwner}-${config.repoName}-${Date.now()}`;
-      const userEnvVars = withoutReservedRepoImageEnvVars(config.userEnvVars);
-      const envVars = await this.buildBuildEnvVars({ ...config, userEnvVars });
-      secretStore = await this.createSecretStoreFor(config.buildId, userEnvVars);
+      const environment = await this.buildBuildEnvironment(config);
+      secretStore = await this.createSecretStoreFor(config.buildId, environment.secretEnvVars);
       const sandbox = await this.client.createSandbox({
         name: sandboxName,
         template: this.client.config.template,
-        env: envVars,
+        env: environment.envVars,
         labels: {
           openinspect_framework: "open-inspect",
           openinspect_provider: "opencomputer",
@@ -411,23 +417,17 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     }
   }
 
-  private async buildRuntimeEnvVars(
+  private async buildRuntimeEnvironment(
     config: CreateSandboxConfig | RestoreConfig,
     mode: {
       restoredFromSnapshot?: boolean;
       fromRepoImage?: boolean;
       repoImageSha?: string;
     } = {}
-  ): Promise<Record<string, string>> {
-    const envVars: Record<string, string> = {};
+  ): Promise<PreparedOpenComputerEnvironment> {
+    const environment = this.prepareEnvironment(config.userEnvVars);
+    const { envVars } = environment;
     const sessionConfig = buildSessionConfig(config);
-
-    for (const [name, value] of Object.entries(this.providerConfig.llmEnvVars ?? {})) {
-      if (value) envVars[name] = value;
-    }
-    for (const [name, value] of Object.entries(config.userEnvVars ?? {})) {
-      if (value) envVars[name] = value;
-    }
 
     Object.assign(envVars, {
       PYTHONUNBUFFERED: "1",
@@ -473,23 +473,16 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
       envVars.VCS_CLONE_USERNAME = "x-access-token";
     }
 
-    return envVars;
+    return environment;
   }
 
-  private async buildBuildEnvVars(
+  private async buildBuildEnvironment(
     config: TriggerOpenComputerRepoImageBuildConfig
-  ): Promise<Record<string, string>> {
-    const envVars: Record<string, string> = {};
-
-    for (const [name, value] of Object.entries(this.providerConfig.llmEnvVars ?? {})) {
-      if (value) envVars[name] = value;
-    }
-    for (const [name, value] of Object.entries(config.userEnvVars ?? {})) {
-      if (value) envVars[name] = value;
-    }
-    for (const key of RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS) {
-      delete envVars[key];
-    }
+  ): Promise<PreparedOpenComputerEnvironment> {
+    const environment = this.prepareEnvironment(config.userEnvVars, {
+      scrubReservedRepoImageEnv: true,
+    });
+    const { envVars } = environment;
 
     Object.assign(envVars, {
       PYTHONUNBUFFERED: "1",
@@ -514,7 +507,26 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
       envVars.VCS_CLONE_TOKEN = config.cloneToken;
     }
 
-    return envVars;
+    return environment;
+  }
+
+  private prepareEnvironment(
+    userEnvVars: Record<string, string> | undefined,
+    options: { scrubReservedRepoImageEnv?: boolean } = {}
+  ): PreparedOpenComputerEnvironment {
+    const envVars: Record<string, string> = {};
+    copyDefinedEnvVars(envVars, this.providerConfig.llmEnvVars);
+    copyDefinedEnvVars(envVars, userEnvVars);
+
+    const secretEnvVars = copyDefinedEnvVars({}, userEnvVars);
+    if (options.scrubReservedRepoImageEnv) {
+      for (const key of RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS) {
+        delete envVars[key];
+        delete secretEnvVars[key];
+      }
+    }
+
+    return { envVars, secretEnvVars };
   }
 
   private async createSecretStoreFor(
@@ -728,15 +740,14 @@ function sleepMs(durationMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, durationMs));
 }
 
-function withoutReservedRepoImageEnvVars(
-  envVars: Record<string, string> | undefined
-): Record<string, string> | undefined {
-  if (!envVars) return undefined;
-  const filtered = { ...envVars };
-  for (const key of RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS) {
-    delete filtered[key];
+function copyDefinedEnvVars(
+  target: Record<string, string>,
+  source: Record<string, string | undefined> | undefined
+): Record<string, string> {
+  for (const [name, value] of Object.entries(source ?? {})) {
+    if (value) target[name] = value;
   }
-  return filtered;
+  return target;
 }
 
 export function createOpenComputerProvider(

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -458,17 +458,20 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     if (mode.fromRepoImage) {
       envVars.FROM_REPO_IMAGE = "true";
       envVars.REPO_IMAGE_SHA = mode.repoImageSha ?? "";
+      if (!envVars.VCS_CLONE_TOKEN) {
+        envVars.VCS_CLONE_TOKEN = "";
+      }
     }
 
     // OpenComputer forks (repo-image create + snapshot restore) inherit the
     // source sandbox's persisted env. Repo-image checkpoints are taken from a
     // build sandbox, so its build-mode markers — IMAGE_BUILD_MODE plus the
-    // repo-image build-callback vars — leak into the forked session unless we
-    // override them here, making the supervisor re-enter image-build mode
-    // (booting "build" instead of "repo_image", then failing the already-
-    // completed build-complete callback). A runtime session is never an image
-    // build, so force the markers off. IMAGE_BUILD_MODE is checked as
-    // === "true" in entrypoint.py, so "false" disables it.
+    // repo-image build-callback vars — and one-shot clone token leak into the
+    // forked session unless we override them here, making the supervisor
+    // re-enter image-build mode (booting "build" instead of "repo_image", then
+    // failing the already-completed build-complete callback). A runtime session
+    // is never an image build, so force the markers off. IMAGE_BUILD_MODE is
+    // checked as === "true" in entrypoint.py, so "false" disables it.
     envVars.IMAGE_BUILD_MODE = "false";
     for (const key of RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS) envVars[key] = "";
 

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -42,8 +42,6 @@ import {
 
 const log = createLogger("opencomputer-provider");
 const OPENCOMPUTER_SECRET_STORE_EGRESS_ALLOWLIST = ["*"];
-const CHECKPOINT_READY_TIMEOUT_MS = 5 * 60_000;
-const CHECKPOINT_READY_POLL_INTERVAL_MS = 2_000;
 const REPO_IMAGE_CALLBACK_ENV_KEYS = [
   "OI_REPO_IMAGE_PROVIDER_SESSION_ID",
   "OI_REPO_IMAGE_BUILD_ID",
@@ -240,7 +238,16 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
         }
       );
 
-      return await this.waitForCheckpointReady(config.providerObjectId, checkpoint);
+      if (
+        checkpoint.status &&
+        checkpoint.status !== "ready" &&
+        checkpoint.status !== "created" &&
+        checkpoint.status !== "processing"
+      ) {
+        return { success: false, error: `Checkpoint status was ${checkpoint.status}` };
+      }
+
+      return { success: true, imageId: checkpoint.id };
     } catch (error) {
       if (error instanceof SandboxProviderError) throw error;
       throw this.classifyError("Failed to checkpoint OpenComputer sandbox", error);
@@ -693,33 +700,6 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     return digest.slice(0, 32);
   }
 
-  private async waitForCheckpointReady(
-    providerObjectId: string,
-    initialCheckpoint: { id: string; status?: string }
-  ): Promise<SnapshotResult> {
-    let checkpoint = initialCheckpoint;
-    const deadlineMs = Date.now() + CHECKPOINT_READY_TIMEOUT_MS;
-
-    while (true) {
-      const status = checkpoint.status?.toLowerCase();
-      if (!status || status === "ready") {
-        return { success: true, imageId: checkpoint.id };
-      }
-      if (status !== "created" && status !== "processing") {
-        return { success: false, error: `Checkpoint status was ${checkpoint.status}` };
-      }
-      if (Date.now() >= deadlineMs) {
-        return {
-          success: false,
-          error: `Checkpoint ${checkpoint.id} was not ready before timeout`,
-        };
-      }
-
-      await sleepMs(CHECKPOINT_READY_POLL_INTERVAL_MS);
-      checkpoint = await this.client.getCheckpoint(providerObjectId, checkpoint.id);
-    }
-  }
-
   private classifyError(message: string, error: unknown): SandboxProviderError {
     if (error instanceof OpenComputerApiError) {
       return SandboxProviderError.fromFetchError(
@@ -734,10 +714,6 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
 
 function resolveOpenComputerTimeoutSeconds(timeoutSeconds: number | undefined): number | undefined {
   return timeoutSeconds;
-}
-
-function sleepMs(durationMs: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, durationMs));
 }
 
 function copyDefinedEnvVars(

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -42,11 +42,17 @@ import {
 
 const log = createLogger("opencomputer-provider");
 const OPENCOMPUTER_SECRET_STORE_EGRESS_ALLOWLIST = ["*"];
+const CHECKPOINT_READY_TIMEOUT_MS = 5 * 60_000;
+const CHECKPOINT_READY_POLL_INTERVAL_MS = 2_000;
 const REPO_IMAGE_CALLBACK_ENV_KEYS = [
   "OI_REPO_IMAGE_PROVIDER_SESSION_ID",
   "OI_REPO_IMAGE_BUILD_ID",
   "OI_REPO_IMAGE_CALLBACK_URL",
   "OI_REPO_IMAGE_CALLBACK_TOKEN",
+] as const;
+const RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS = [
+  ...REPO_IMAGE_CALLBACK_ENV_KEYS,
+  "OI_REPO_IMAGE_CALLBACK_SECRET",
 ] as const;
 
 export interface TriggerOpenComputerRepoImageBuildConfig {
@@ -57,6 +63,7 @@ export interface TriggerOpenComputerRepoImageBuildConfig {
   callbackUrl: string;
   callbackToken: string;
   userEnvVars?: Record<string, string>;
+  cloneToken?: string;
   buildTimeoutSeconds?: number;
   onProviderSessionCreated?: (providerSessionId: string) => Promise<void>;
 }
@@ -226,16 +233,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
         }
       );
 
-      if (
-        checkpoint.status &&
-        checkpoint.status !== "ready" &&
-        checkpoint.status !== "created" &&
-        checkpoint.status !== "processing"
-      ) {
-        return { success: false, error: `Checkpoint status was ${checkpoint.status}` };
-      }
-
-      return { success: true, imageId: checkpoint.id };
+      return await this.waitForCheckpointReady(config.providerObjectId, checkpoint);
     } catch (error) {
       if (error instanceof SandboxProviderError) throw error;
       throw this.classifyError("Failed to checkpoint OpenComputer sandbox", error);
@@ -343,10 +341,12 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     config: TriggerOpenComputerRepoImageBuildConfig
   ): Promise<TriggerOpenComputerRepoImageBuildResult> {
     let secretStore: OpenComputerSecretStoreResponse | undefined;
+    let providerObjectId: string | undefined;
     try {
       const sandboxName = `build-${config.repoOwner}-${config.repoName}-${Date.now()}`;
-      const envVars = await this.buildBuildEnvVars(config);
-      secretStore = await this.createSecretStoreFor(config.buildId, config.userEnvVars);
+      const userEnvVars = withoutReservedRepoImageEnvVars(config.userEnvVars);
+      const envVars = await this.buildBuildEnvVars({ ...config, userEnvVars });
+      secretStore = await this.createSecretStoreFor(config.buildId, userEnvVars);
       const sandbox = await this.client.createSandbox({
         name: sandboxName,
         template: this.client.config.template,
@@ -361,6 +361,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
         timeoutSeconds: config.buildTimeoutSeconds ?? DEFAULT_BUILD_TIMEOUT_SECONDS,
         secretStore: secretStore?.name,
       });
+      providerObjectId = sandbox.id;
 
       if (config.onProviderSessionCreated) {
         await config.onProviderSessionCreated(sandbox.id);
@@ -378,6 +379,9 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
 
       return { buildId: config.buildId, status: "building" };
     } catch (error) {
+      if (providerObjectId) {
+        await this.cleanupSandboxAfterFailedCreate(providerObjectId, config.buildId);
+      }
       if (secretStore) {
         try {
           await this.client.deleteSecretStore(secretStore.id);
@@ -418,10 +422,10 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     const envVars: Record<string, string> = {};
     const sessionConfig = buildSessionConfig(config);
 
-    for (const [name, value] of Object.entries(config.userEnvVars ?? {})) {
+    for (const [name, value] of Object.entries(this.providerConfig.llmEnvVars ?? {})) {
       if (value) envVars[name] = value;
     }
-    for (const [name, value] of Object.entries(this.providerConfig.llmEnvVars ?? {})) {
+    for (const [name, value] of Object.entries(config.userEnvVars ?? {})) {
       if (value) envVars[name] = value;
     }
 
@@ -459,7 +463,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     // build, so force the markers off. IMAGE_BUILD_MODE is checked as
     // === "true" in entrypoint.py, so "false" disables it.
     envVars.IMAGE_BUILD_MODE = "false";
-    for (const key of REPO_IMAGE_CALLBACK_ENV_KEYS) envVars[key] = "";
+    for (const key of RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS) envVars[key] = "";
 
     if (this.providerConfig.scmProvider === "gitlab") {
       envVars.VCS_HOST = "gitlab.com";
@@ -477,11 +481,14 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
   ): Promise<Record<string, string>> {
     const envVars: Record<string, string> = {};
 
+    for (const [name, value] of Object.entries(this.providerConfig.llmEnvVars ?? {})) {
+      if (value) envVars[name] = value;
+    }
     for (const [name, value] of Object.entries(config.userEnvVars ?? {})) {
       if (value) envVars[name] = value;
     }
-    for (const [name, value] of Object.entries(this.providerConfig.llmEnvVars ?? {})) {
-      if (value) envVars[name] = value;
+    for (const key of RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS) {
+      delete envVars[key];
     }
 
     Object.assign(envVars, {
@@ -502,6 +509,9 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     } else {
       envVars.VCS_HOST = "github.com";
       envVars.VCS_CLONE_USERNAME = "x-access-token";
+    }
+    if (config.cloneToken) {
+      envVars.VCS_CLONE_TOKEN = config.cloneToken;
     }
 
     return envVars;
@@ -671,6 +681,33 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     return digest.slice(0, 32);
   }
 
+  private async waitForCheckpointReady(
+    providerObjectId: string,
+    initialCheckpoint: { id: string; status?: string }
+  ): Promise<SnapshotResult> {
+    let checkpoint = initialCheckpoint;
+    const deadlineMs = Date.now() + CHECKPOINT_READY_TIMEOUT_MS;
+
+    while (true) {
+      const status = checkpoint.status?.toLowerCase();
+      if (!status || status === "ready") {
+        return { success: true, imageId: checkpoint.id };
+      }
+      if (status !== "created" && status !== "processing") {
+        return { success: false, error: `Checkpoint status was ${checkpoint.status}` };
+      }
+      if (Date.now() >= deadlineMs) {
+        return {
+          success: false,
+          error: `Checkpoint ${checkpoint.id} was not ready before timeout`,
+        };
+      }
+
+      await sleepMs(CHECKPOINT_READY_POLL_INTERVAL_MS);
+      checkpoint = await this.client.getCheckpoint(providerObjectId, checkpoint.id);
+    }
+  }
+
   private classifyError(message: string, error: unknown): SandboxProviderError {
     if (error instanceof OpenComputerApiError) {
       return SandboxProviderError.fromFetchError(
@@ -685,6 +722,21 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
 
 function resolveOpenComputerTimeoutSeconds(timeoutSeconds: number | undefined): number | undefined {
   return timeoutSeconds;
+}
+
+function sleepMs(durationMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, durationMs));
+}
+
+function withoutReservedRepoImageEnvVars(
+  envVars: Record<string, string> | undefined
+): Record<string, string> | undefined {
+  if (!envVars) return undefined;
+  const filtered = { ...envVars };
+  for (const key of RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS) {
+    delete filtered[key];
+  }
+  return filtered;
 }
 
 export function createOpenComputerProvider(


### PR DESCRIPTION
## Summary
- Pass credential-helper clone auth through OpenComputer repo-image builds, matching the Vercel provider-session path while leaving normal sessions broker-based.
- Preserve repo/user LLM secret precedence over provider defaults and scrub reserved repo-image callback env keys from OpenComputer build env/secrets.
- Clear inherited repo-image build clone tokens from runtime forks unless the session explicitly supplies one.
- Clean up allocated OpenComputer sandboxes on startup/bind failures.

## Tests
- npm run typecheck -w @open-inspect/control-plane
- npm test -w @open-inspect/control-plane

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenComputer builds now support repository clone authentication, improving private repo setup.
  * Repo-image workflows now handle provider-specific clone auth more consistently across supported providers.

* **Bug Fixes**
  * Fixed environment handling so user-provided secrets and callback values are preserved or cleared appropriately.
  * Improved cleanup when sandbox startup fails, preventing leftover resources.
  * Added safer behavior for repo-image forks, including clearer handling of clone tokens and build-mode markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->