### PR TITLE
docs: add Slack options load URL setup

### DIFF
--- a/.claude/skills/onboarding/SKILL.md
+++ b/.claude/skills/onboarding/SKILL.md
@@ -266,10 +266,13 @@ The App Home provides a settings interface where users can configure their prefe
 
 4. Interactivity → Enable → Request URL:
    `https://open-inspect-slack-bot-{deployment_name}.{subdomain}.workers.dev/interactions`
+5. Select Menus → Options Load URL:
+   `https://open-inspect-slack-bot-{deployment_name}.{subdomain}.workers.dev/interactions` Required
+   for searchable Slack repository pickers that use external data sources.
 
 ### Invite Bot to Channels
 
-5. Invite bot to channels: `/invite @BotName`
+6. Invite bot to channels: `/invite @BotName`
 
 ## Phase 10: Complete GitHub Bot Setup (If Enabled)
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -628,7 +628,12 @@ The App Home provides a settings interface where users can configure their prefe
    ```
    https://open-inspect-slack-bot-{deployment_name}.YOUR-SUBDOMAIN.workers.dev/interactions
    ```
-4. Click **Save Changes**
+4. Under **Select Menus**, enter **Options Load URL** using the same endpoint:
+   ```
+   https://open-inspect-slack-bot-{deployment_name}.YOUR-SUBDOMAIN.workers.dev/interactions
+   ```
+   This is required for searchable Slack repository pickers that use external data sources.
+5. Click **Save Changes**
 
 ### Invite the Bot to Channels
 


### PR DESCRIPTION
## Summary
- Document Slack's separate Select Menus Options Load URL for external select menus
- Point the Options Load URL at the existing `/interactions` endpoint
- Clarify that searchable repository pickers require this configuration

## Why
Slack quick-pick buttons are rendered inline, but the searchable repo dropdown uses an `external_select`. Slack only requests those dynamic options when the app has a Select Menus Options Load URL configured, so the dropdown can show `no result` even though repos are available.

## Validation
- `npx prettier --check docs/GETTING_STARTED.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Slack setup guide to add a required **Select Menus → Options Load URL** configuration for searchable repository pickers.
  * Clarified that the Options Load URL should match the same `/interactions` endpoint used for the Request URL.
  * Renumbered/reformatted the subsequent setup steps to reflect the added configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->