### PR TITLE
fix(slack-bot): inline small repo clarification pickers

### DIFF
--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -468,6 +468,91 @@ describe("POST /events", () => {
     slackFetch.mockRestore();
   });
 
+  it("embeds repo options in clarification messages when the repo list fits inline", async () => {
+    const slackFetch = mockSlackFetch([]);
+    const env = makeEnv();
+    (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/repos")) {
+          return new Response(
+            JSON.stringify({
+              repos: [
+                { owner: "acme", name: "web", defaultBranch: "main", private: true },
+                { owner: "acme", name: "api", defaultBranch: "main", private: true },
+                { owner: "acme", name: "docs", defaultBranch: "main", private: true },
+              ],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+          );
+        }
+
+        if (url.includes("/integration-settings/slack")) {
+          return new Response(
+            JSON.stringify({
+              settings: {
+                defaults: {
+                  routingRules: [
+                    { keyword: "frontend", target: "acme/web" },
+                    { keyword: "backend", target: "acme/api" },
+                  ],
+                },
+              },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+          );
+        }
+
+        return new Response(JSON.stringify({ enabledModels: ["anthropic/claude-haiku-4-5"] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    );
+
+    const ctx = makeCtx();
+    const response = await app.fetch(
+      slackEventRequest({
+        type: "app_mention",
+        text: "<@B123> frontend backend help",
+        user: "U123",
+        channel: "C123",
+        ts: "111.222",
+      }),
+      env,
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    await flushWaitUntil(ctx);
+
+    const postBodies = slackApiBodies(slackFetch, "chat.postMessage");
+    const clarification = postBodies.find((body) =>
+      String(body.text).includes("I couldn't determine which repository")
+    );
+
+    expect(clarification).toEqual(
+      expect.objectContaining({
+        blocks: expect.arrayContaining([
+          expect.objectContaining({
+            type: "section",
+            accessory: expect.objectContaining({
+              type: "static_select",
+              action_id: "select_repo",
+              options: expect.arrayContaining([
+                expect.objectContaining({ value: "acme/web" }),
+                expect.objectContaining({ value: "acme/api" }),
+                expect.objectContaining({ value: "acme/docs" }),
+              ]),
+            }),
+          }),
+        ]),
+      })
+    );
+
+    slackFetch.mockRestore();
+  });
+
   it("sets Starting status for a direct message", async () => {
     const order: string[] = [];
     const slackFetch = mockSlackFetch(order);

--- a/packages/slack-bot/src/index.ts
+++ b/packages/slack-bot/src/index.ts
@@ -932,7 +932,7 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
       `I couldn't determine which repository you're referring to. ${result.reasoning}`,
       {
         thread_ts: threadTs || ts,
-        blocks: buildRepoClarificationBlocks(result.reasoning, result.alternatives),
+        blocks: buildRepoClarificationBlocks(result.reasoning, result.alternatives, repos),
       }
     );
     return;

--- a/packages/slack-bot/src/repo-clarification.test.ts
+++ b/packages/slack-bot/src/repo-clarification.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { RepoConfig } from "./types";
+import { MAX_REPO_SUGGESTION_OPTIONS } from "./app-home/constants";
 import { filterReposByQuery } from "./classifier/repos";
 import {
   MAX_REPO_QUICK_PICKS,
@@ -113,8 +114,9 @@ describe("baseActionId", () => {
 });
 
 describe("buildRepoClarificationBlocks", () => {
-  it("renders only the searchable picker when there are no alternatives", () => {
-    const blocks = buildRepoClarificationBlocks("could not tell which repo", undefined);
+  it("renders an inline picker when the repo list fits in Slack's static option limit", () => {
+    const repos = [repo("acme/web"), repo("acme/api")];
+    const blocks = buildRepoClarificationBlocks("could not tell which repo", undefined, repos);
 
     expect(blocks).toHaveLength(2);
     expect(blocks.some((block) => block.type === "actions")).toBe(false);
@@ -124,19 +126,20 @@ describe("buildRepoClarificationBlocks", () => {
         type: "section",
         text: { text: "Which repository should I work with?" },
         accessory: {
-          type: "external_select",
+          type: "static_select",
           action_id: SELECT_REPO_ACTION_ID,
-          min_query_length: 0,
+          options: [
+            { text: { type: "plain_text", text: "web" }, value: "acme/web" },
+            { text: { type: "plain_text", text: "api" }, value: "acme/api" },
+          ],
         },
       },
     ]);
   });
 
   it("renders ranked quick-pick buttons above the picker when alternatives exist", () => {
-    const blocks = buildRepoClarificationBlocks("maybe one of these", [
-      repo("acme/web"),
-      repo("acme/api"),
-    ]);
+    const repos = [repo("acme/web"), repo("acme/api"), repo("acme/docs")];
+    const blocks = buildRepoClarificationBlocks("maybe one of these", repos.slice(0, 2), repos);
 
     expect(blocks).toHaveLength(3);
     expect(blocks).toMatchObject([
@@ -151,8 +154,28 @@ describe("buildRepoClarificationBlocks", () => {
       },
       {
         type: "section",
-        text: { text: "Or search for another repository:" },
-        accessory: { type: "external_select", action_id: SELECT_REPO_ACTION_ID },
+        text: { text: "Or choose another repository:" },
+        accessory: { type: "static_select", action_id: SELECT_REPO_ACTION_ID },
+      },
+    ]);
+  });
+
+  it("uses the searchable external picker when the repo list exceeds Slack's static option limit", () => {
+    const repos = Array.from({ length: MAX_REPO_SUGGESTION_OPTIONS + 1 }, (_, idx) =>
+      repo(`acme/repo-${idx}`)
+    );
+    const blocks = buildRepoClarificationBlocks("too many to inline", undefined, repos);
+
+    expect(blocks).toMatchObject([
+      { type: "section" },
+      {
+        type: "section",
+        text: { text: "Which repository should I work with?" },
+        accessory: {
+          type: "external_select",
+          action_id: SELECT_REPO_ACTION_ID,
+          min_query_length: 0,
+        },
       },
     ]);
   });

--- a/packages/slack-bot/src/repo-clarification.ts
+++ b/packages/slack-bot/src/repo-clarification.ts
@@ -3,9 +3,9 @@
  *
  * When the classifier can't decide which repository a Slack message refers to,
  * the bot posts a clarification message: the classifier's ranked guesses as
- * one-click quick-pick buttons, plus a searchable external_select over every
- * repo. This module owns that UI — the options Slack queries as the user types,
- * the quick-pick buttons, and the message blocks themselves.
+ * one-click quick-pick buttons, plus a repository picker. This module owns that
+ * UI — the options Slack queries as the user types, the quick-pick buttons, and
+ * the message blocks themselves.
  */
 
 import { getAvailableRepos, filterReposByQuery } from "./classifier/repos";
@@ -14,8 +14,10 @@ import { plainTextOption } from "./slack-options";
 import type {
   SlackActionsBlock,
   SlackButtonElement,
+  SlackExternalSelectElement,
   SlackSectionBlock,
   SlackSelectOption,
+  SlackStaticSelectElement,
 } from "./slack-blocks";
 import type { Env, RepoConfig } from "./types";
 
@@ -79,6 +81,27 @@ export async function getRepoClarificationOptions(
   return repos.slice(0, MAX_REPO_SUGGESTION_OPTIONS).map(toRepoSelectOption);
 }
 
+function buildRepoPickerAccessory(
+  repos: RepoConfig[]
+): SlackStaticSelectElement | SlackExternalSelectElement {
+  if (repos.length > 0 && repos.length <= MAX_REPO_SUGGESTION_OPTIONS) {
+    return {
+      type: "static_select",
+      placeholder: { type: "plain_text", text: "Select a repository" },
+      options: repos.map(toRepoSelectOption),
+      action_id: SELECT_REPO_ACTION_ID,
+    };
+  }
+
+  return {
+    type: "external_select",
+    placeholder: { type: "plain_text", text: "Select a repository" },
+    // 0 so the list appears on open; typing filters across all repos.
+    min_query_length: 0,
+    action_id: SELECT_REPO_ACTION_ID,
+  };
+}
+
 /**
  * One-click buttons for the classifier's ranked alternatives, capped at
  * MAX_REPO_QUICK_PICKS. Each carries the repo id and routes through the same
@@ -118,9 +141,11 @@ function duplicateDisplayNames(repos: RepoConfig[]): Set<string> {
  */
 export function buildRepoClarificationBlocks(
   reasoning: string,
-  alternatives: RepoConfig[] | undefined
+  alternatives: RepoConfig[] | undefined,
+  repos: RepoConfig[]
 ): Array<SlackSectionBlock | SlackActionsBlock> {
   const quickPicks = alternatives?.length ? buildRepoQuickPickButtons(alternatives) : [];
+  const usesInlinePicker = repos.length > 0 && repos.length <= MAX_REPO_SUGGESTION_OPTIONS;
 
   const blocks: Array<SlackSectionBlock | SlackActionsBlock> = [
     {
@@ -142,16 +167,12 @@ export function buildRepoClarificationBlocks(
       type: "mrkdwn",
       text:
         quickPicks.length > 0
-          ? "Or search for another repository:"
+          ? usesInlinePicker
+            ? "Or choose another repository:"
+            : "Or search for another repository:"
           : "Which repository should I work with?",
     },
-    accessory: {
-      type: "external_select",
-      placeholder: { type: "plain_text", text: "Select a repository" },
-      // 0 so the list appears on open; typing filters across all repos.
-      min_query_length: 0,
-      action_id: SELECT_REPO_ACTION_ID,
-    },
+    accessory: buildRepoPickerAccessory(repos),
   });
 
   return blocks;


### PR DESCRIPTION
## Summary
- Render repo clarification pickers as inline `static_select` menus when the full repo list fits Slack's 100-option limit
- Keep `external_select` for larger repo lists that need dynamic option loading
- Pass the already-fetched repo list into the clarification block builder and cover both picker paths in tests

## Why
The repo clarification dropdown became dependent on Slack's Select Menus Options Load URL after moving to `external_select`. If that URL is not configured, Slack shows `no result` and the worker never receives a `/interactions` request, so it cannot show a better runtime error. Small installs can avoid that dependency by embedding the repo options directly in the message.

## Validation
- `npm test -w @open-inspect/slack-bot`
- `npm run typecheck -w @open-inspect/slack-bot`
- `npm run lint -w @open-inspect/slack-bot`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a smarter repository chooser in Slack clarification messages.
  * When the repository list is small enough, users now see inline selectable repo options; larger lists switch to search-based selection.
  * Updated the prompt text to match whether users should choose or search for another repository.

* **Tests**
  * Expanded coverage for the new repo selection behavior, including inline selection and search-based fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->