### PR TITLE
Fix OpenComputer repo image secret-store retention

### DIFF
--- a/packages/control-plane/src/repo-images/opencomputer-adapter.test.ts
+++ b/packages/control-plane/src/repo-images/opencomputer-adapter.test.ts
@@ -100,7 +100,9 @@ describe("OpenComputerRepoImageBuildAdapter", () => {
       correlation,
     });
 
-    expect(provider.deleteSandbox).toHaveBeenCalledWith("oc-session-1");
+    expect(provider.deleteSandbox).toHaveBeenCalledWith("oc-session-1", {
+      deleteSecretStore: true,
+    });
     expect(provider.deleteProviderImage).toHaveBeenCalledWith("oc-checkpoint-1", "oc-session-1");
   });
 });

--- a/packages/control-plane/src/repo-images/opencomputer-adapter.ts
+++ b/packages/control-plane/src/repo-images/opencomputer-adapter.ts
@@ -94,7 +94,7 @@ export class OpenComputerRepoImageBuildAdapter implements RepoImageBuildAdapter<
   ): Promise<void> {
     if (!providerSessionId) return;
     try {
-      await this.provider.deleteSandbox(providerSessionId);
+      await this.provider.deleteSandbox(providerSessionId, { deleteSecretStore: true });
     } catch (error) {
       logger.warn("repo_image.opencomputer_build_cleanup_failed", {
         build_id: buildId,

--- a/packages/control-plane/src/sandbox/index.ts
+++ b/packages/control-plane/src/sandbox/index.ts
@@ -85,6 +85,7 @@ export {
   type OpenComputerRestConfig,
   type OpenComputerSandboxResponse,
   type OpenComputerCreateSandboxParams,
+  type OpenComputerDeleteSandboxOptions,
 } from "./opencomputer-rest-client";
 export {
   resolveSandboxBackendName,

--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
@@ -345,8 +345,10 @@ export class OpenComputerRestClient {
     });
   }
 
-  async deleteSandbox(id: string, options: OpenComputerDeleteSandboxOptions = {}): Promise<void> {
-    const query = options.deleteSecretStore ? "?deleteSecretStore=true" : "";
+  async deleteSandbox(id: string, options?: OpenComputerDeleteSandboxOptions): Promise<void> {
+    const params = new URLSearchParams();
+    if (options?.deleteSecretStore) params.set("deleteSecretStore", "true");
+    const query = params.toString() ? `?${params.toString()}` : "";
     await this.request<void>(
       "DELETE",
       `${this.expandPath(this.paths.sandbox, { id })}${query}`,

--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
@@ -93,6 +93,10 @@ export interface OpenComputerCreateCheckpointOptions {
   retentionPolicy?: OpenComputerCheckpointRetentionPolicy;
 }
 
+export interface OpenComputerDeleteSandboxOptions {
+  deleteSecretStore?: boolean;
+}
+
 export interface OpenComputerExecResult {
   exitCode: number;
   stdout: string;
@@ -341,8 +345,13 @@ export class OpenComputerRestClient {
     });
   }
 
-  async deleteSandbox(id: string): Promise<void> {
-    await this.request<void>("DELETE", this.expandPath(this.paths.sandbox, { id }), TIMEOUT_GET_MS);
+  async deleteSandbox(id: string, options: OpenComputerDeleteSandboxOptions = {}): Promise<void> {
+    const query = options.deleteSecretStore ? "?deleteSecretStore=true" : "";
+    await this.request<void>(
+      "DELETE",
+      `${this.expandPath(this.paths.sandbox, { id })}${query}`,
+      TIMEOUT_GET_MS
+    );
   }
 
   async startRuntime(id: string, extraEnv: Record<string, string> = {}): Promise<void> {

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -301,6 +301,20 @@ describe("OpenComputerSandboxProvider", () => {
     await expect(provider.deleteSandbox("oc-build-2")).resolves.toBeUndefined();
   });
 
+  it("can request attached secret-store cleanup when deleting a sandbox", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await provider.deleteSandbox("oc-build-1", { deleteSecretStore: true });
+
+    expect(client.deleteSandbox).toHaveBeenCalledWith("oc-build-1", {
+      deleteSecretStore: true,
+    });
+  });
+
   it("derives a unique secret-store name per sandbox", async () => {
     const client = createMockClient();
     const provider = new OpenComputerSandboxProvider(client, {

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -295,7 +295,7 @@ describe("OpenComputerSandboxProvider", () => {
     });
 
     await provider.deleteSandbox("oc-build-1");
-    expect(client.deleteSandbox).toHaveBeenCalledWith("oc-build-1");
+    expect(client.deleteSandbox).toHaveBeenCalledWith("oc-build-1", undefined);
 
     vi.mocked(client.deleteSandbox).mockRejectedValueOnce(new OpenComputerNotFoundError("gone"));
     await expect(provider.deleteSandbox("oc-build-2")).resolves.toBeUndefined();

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -19,6 +19,7 @@ import {
   OPENCOMPUTER_CHECKPOINT_RETENTION_POLICY,
   OpenComputerApiError,
   OpenComputerNotFoundError,
+  type OpenComputerDeleteSandboxOptions,
   type OpenComputerRestClient,
   type OpenComputerSandboxResponse,
   type OpenComputerSecretStoreResponse,
@@ -342,9 +343,16 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
    * single-use build sandbox. Idempotent — a missing sandbox is treated as
    * already deleted.
    */
-  async deleteSandbox(providerObjectId: string): Promise<void> {
+  async deleteSandbox(
+    providerObjectId: string,
+    options?: OpenComputerDeleteSandboxOptions
+  ): Promise<void> {
     try {
-      await this.client.deleteSandbox(providerObjectId);
+      if (options) {
+        await this.client.deleteSandbox(providerObjectId, options);
+      } else {
+        await this.client.deleteSandbox(providerObjectId);
+      }
     } catch (error) {
       if (error instanceof OpenComputerNotFoundError) return;
       throw this.classifyError("Failed to delete OpenComputer sandbox", error);

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -348,11 +348,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     options?: OpenComputerDeleteSandboxOptions
   ): Promise<void> {
     try {
-      if (options) {
-        await this.client.deleteSandbox(providerObjectId, options);
-      } else {
-        await this.client.deleteSandbox(providerObjectId);
-      }
+      await this.client.deleteSandbox(providerObjectId, options);
     } catch (error) {
       if (error instanceof OpenComputerNotFoundError) return;
       throw this.classifyError("Failed to delete OpenComputer sandbox", error);


### PR DESCRIPTION
## Summary
- retain the secret store for the active OpenComputer repo image
- carry provider secret-store ids through repo-image replacement cleanup
- delete OpenComputer secret stores only for failed builds or superseded images

## Verification
- npm test -w @open-inspect/control-plane -- repo-images opencomputer-adapter
- npm run typecheck -w @open-inspect/control-plane

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox cleanup now also removes the associated OpenComputer secret store when a provider session sandbox is deleted.
  * Deleting a sandbox now supports an optional setting to include secret-store removal in the request.
  * Existing behavior for missing or already-deleted sandboxes remains unchanged.
* **Tests**
  * Updated and added unit tests to verify secret-store deletion options are forwarded correctly.
* **Documentation**
  * Public sandbox options type is now re-exported for easier use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->