### PR TITLE
Remove session list count query

### DIFF
--- a/packages/control-plane/src/db/session-index.test.ts
+++ b/packages/control-plane/src/db/session-index.test.ts
@@ -50,8 +50,10 @@ function normalizeQuery(query: string): string {
 
 class FakeD1Database {
   private rows = new Map<string, SessionRow>();
+  readonly preparedQueries: string[] = [];
 
   prepare(query: string) {
+    this.preparedQueries.push(normalizeQuery(query));
     return new FakePreparedStatement(this, query);
   }
 
@@ -474,7 +476,6 @@ describe("SessionIndexStore", () => {
 
       const result = await store.list();
       expect(result.sessions.map((s) => s.id)).toEqual(["new", "mid", "old"]);
-      expect(result.total).toBe(3);
       expect(result.hasMore).toBe(false);
     });
 
@@ -485,7 +486,6 @@ describe("SessionIndexStore", () => {
       const result = await store.list({ status: "active" });
       expect(result.sessions).toHaveLength(1);
       expect(result.sessions[0].id).toBe("a");
-      expect(result.total).toBe(1);
     });
 
     it("filters by excludeStatus", async () => {
@@ -496,7 +496,6 @@ describe("SessionIndexStore", () => {
       const result = await store.list({ excludeStatus: "archived" });
       expect(result.sessions).toHaveLength(2);
       expect(result.sessions.map((s) => s.id)).toEqual(["c", "a"]);
-      expect(result.total).toBe(2);
     });
 
     it("filters by creator user ids", async () => {
@@ -508,7 +507,6 @@ describe("SessionIndexStore", () => {
       const result = await store.list({ createdByUserIds: ["alice"] });
 
       expect(result.sessions.map((s) => s.id)).toEqual(["alice-new", "alice-old"]);
-      expect(result.total).toBe(2);
       expect(result.hasMore).toBe(false);
     });
 
@@ -520,7 +518,6 @@ describe("SessionIndexStore", () => {
 
       expect(result.sessions).toHaveLength(1);
       expect(result.sessions[0].id).toBe("match");
-      expect(result.total).toBe(1);
     });
 
     it("supports multiple creator user ids", async () => {
@@ -531,7 +528,6 @@ describe("SessionIndexStore", () => {
       const result = await store.list({ createdByUserIds: ["alice", "bob"] });
 
       expect(result.sessions.map((s) => s.id)).toEqual(["bob", "alice"]);
-      expect(result.total).toBe(2);
     });
 
     it("supports pagination with limit and offset", async () => {
@@ -541,7 +537,6 @@ describe("SessionIndexStore", () => {
 
       const page1 = await store.list({ limit: 2, offset: 0 });
       expect(page1.sessions).toHaveLength(2);
-      expect(page1.total).toBe(5);
       expect(page1.hasMore).toBe(true);
 
       const page2 = await store.list({ limit: 2, offset: 2 });
@@ -551,6 +546,21 @@ describe("SessionIndexStore", () => {
       const page3 = await store.list({ limit: 2, offset: 4 });
       expect(page3.sessions).toHaveLength(1);
       expect(page3.hasMore).toBe(false);
+    });
+
+    it("derives hasMore without counting", async () => {
+      for (let i = 0; i < 3; i++) {
+        await store.create(makeSession({ id: `s${i}`, updatedAt: i * 1000 }));
+      }
+      db.preparedQueries.length = 0;
+
+      const result = await store.list({ limit: 2 });
+
+      expect(result.sessions.map((s) => s.id)).toEqual(["s2", "s1"]);
+      expect(result.hasMore).toBe(true);
+      expect(db.preparedQueries.some((query) => QUERY_PATTERNS.SELECT_COUNT.test(query))).toBe(
+        false
+      );
     });
   });
 

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -60,7 +60,6 @@ export interface ListSessionsOptions {
 
 export interface ListSessionsResult {
   sessions: SessionEntry[];
-  total: number;
   hasMore: boolean;
 }
 
@@ -199,26 +198,18 @@ export class SessionIndexStore {
 
     const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
-    // Get total count
-    const countResult = await this.db
-      .prepare(`SELECT COUNT(*) as count FROM sessions ${where}`)
-      .bind(...params)
-      .first<{ count: number }>();
-
-    const total = countResult?.count ?? 0;
-
     // Get paginated results
     const result = await this.db
       .prepare(`SELECT * FROM sessions ${where} ORDER BY updated_at DESC LIMIT ? OFFSET ?`)
-      .bind(...params, limit, offset)
+      .bind(...params, limit + 1, offset)
       .all<SessionRow>();
 
-    const sessions = (result.results || []).map(toEntry);
+    const rows = result.results || [];
+    const sessions = rows.slice(0, limit).map(toEntry);
 
     return {
       sessions,
-      total,
-      hasMore: offset + sessions.length < total,
+      hasMore: rows.length > limit,
     };
   }
 

--- a/packages/control-plane/src/routes/session-index.test.ts
+++ b/packages/control-plane/src/routes/session-index.test.ts
@@ -57,7 +57,6 @@ describe("session index routes", () => {
     vi.clearAllMocks();
     mockSessionIndexStore.list.mockResolvedValue({
       sessions: [],
-      total: 0,
       hasMore: false,
     });
   });

--- a/packages/control-plane/src/routes/session-index.ts
+++ b/packages/control-plane/src/routes/session-index.ts
@@ -80,7 +80,6 @@ async function handleListSessions(
 
   return json({
     sessions: result.sessions,
-    total: result.total,
     hasMore: result.hasMore,
   });
 }

--- a/packages/control-plane/test/integration/auth.test.ts
+++ b/packages/control-plane/test/integration/auth.test.ts
@@ -49,9 +49,8 @@ describe("HMAC authentication", () => {
       headers: { Authorization: `Bearer ${token}` },
     });
     expect(response.status).toBe(200);
-    const body = await response.json<{ sessions: unknown[]; total: number; hasMore: boolean }>();
+    const body = await response.json<{ sessions: unknown[]; hasMore: boolean }>();
     expect(body.sessions).toEqual([]);
-    expect(body.total).toBe(0);
     expect(body.hasMore).toBe(false);
   });
 
@@ -107,9 +106,9 @@ describe("HMAC authentication", () => {
     });
 
     expect(response.status).toBe(200);
-    const body = await response.json<{ sessions: Array<{ id: string }>; total: number }>();
+    const body = await response.json<{ sessions: Array<{ id: string }>; hasMore: boolean }>();
     expect(body.sessions.map((session) => session.id)).toEqual(["alice-session"]);
-    expect(body.total).toBe(1);
+    expect(body.hasMore).toBe(false);
   });
 
   it("rejects invalid creator user id filters", async () => {

--- a/packages/control-plane/test/integration/d1-session-index.test.ts
+++ b/packages/control-plane/test/integration/d1-session-index.test.ts
@@ -68,7 +68,7 @@ describe("D1 SessionIndexStore", () => {
     expect(activeResult.sessions[0].id).toBe("session-active-1");
 
     const allResult = await store.list({});
-    expect(allResult.total).toBe(2);
+    expect(allResult.sessions.length).toBe(2);
   });
 
   it("stores and returns reasoning effort", async () => {

--- a/packages/web/src/components/settings/data-controls-settings.tsx
+++ b/packages/web/src/components/settings/data-controls-settings.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { buildSessionHref, type SessionItem } from "@/components/session-sidebar";
 import { formatRepoLabel } from "@/lib/repo-label";
 import {
+  buildSessionsPageKey,
   isUnarchivedSessionListKey,
   removeSessionFromList,
   type SessionListResponse,
@@ -15,7 +16,11 @@ import {
 import { formatRelativeTime } from "@/lib/time";
 
 const PAGE_SIZE = 20;
-const ARCHIVED_SESSIONS_KEY = `/api/sessions?status=archived&limit=${PAGE_SIZE}&offset=0`;
+const ARCHIVED_SESSIONS_KEY = buildSessionsPageKey({
+  status: "archived",
+  limit: PAGE_SIZE,
+  offset: 0,
+});
 
 export function DataControlsSettings() {
   const [extraSessions, setExtraSessions] = useState<SessionItem[]>([]);
@@ -26,7 +31,7 @@ export function DataControlsSettings() {
   const { data, isLoading: loading } = useSWR<SessionListResponse>(ARCHIVED_SESSIONS_KEY, {
     onSuccess: (data) => {
       const fetched = data.sessions || [];
-      setHasMore(fetched.length === PAGE_SIZE);
+      setHasMore(data.hasMore);
       setOffset(fetched.length);
       setExtraSessions([]);
     },
@@ -38,12 +43,18 @@ export function DataControlsSettings() {
   const handleLoadMore = useCallback(async () => {
     setLoadingMore(true);
     try {
-      const res = await fetch(`/api/sessions?status=archived&limit=${PAGE_SIZE}&offset=${offset}`);
+      const res = await fetch(
+        buildSessionsPageKey({
+          status: "archived",
+          limit: PAGE_SIZE,
+          offset,
+        })
+      );
       if (res.ok) {
-        const resData = await res.json();
+        const resData: SessionListResponse = await res.json();
         const fetched: SessionItem[] = resData.sessions || [];
         setExtraSessions((prev) => [...prev, ...fetched]);
-        setHasMore(fetched.length === PAGE_SIZE);
+        setHasMore(resData.hasMore);
         setOffset((prev) => prev + fetched.length);
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- remove the exact `total` count from the sessions list API
- derive `hasMore` by fetching one extra session row
- update archived-session pagination to use the returned `hasMore` flag

## Why
The frontend only consumes `sessions` and `hasMore`, so the D1 `COUNT(*)` query was doing unnecessary work on a hot session-list path. Removing it avoids the growing table scan for `status != archived` requests.

## Validation
- `npm test -w @open-inspect/control-plane -- session-index`
- `npm test -w @open-inspect/web -- session-list control-plane-query data-controls-settings session-sidebar`
- `npm run test:integration -w @open-inspect/control-plane -- d1-session-index auth`
- `npm run typecheck`
- `npm run lint -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/web`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session lists now use server-provided pagination info, making “Load more” behavior more reliable.
  * Archived sessions now load more accurately without relying on page size checks.

* **Improvements**
  * Session list responses no longer include a total count and now return a clearer `hasMore` indicator.
  * Pagination handling was updated across the app to match the new session list response format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->