### PR TITLE
fix(terraform): plan breaks when cloudflare_custom_domain is unset

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -254,6 +254,7 @@ access.
    Your web app URL depends on `web_platform`:
    - **Vercel**: `https://open-inspect-{deployment_name}.vercel.app`
    - **Cloudflare**: `https://open-inspect-web-{deployment_name}.{your-subdomain}.workers.dev`
+   - **Cloudflare with `cloudflare_custom_domain` set**: `https://{your-custom-domain}`
 
    > **Important**: The callback URL must match your deployed web app URL exactly. The
    > `{deployment_name}` is the unique value you set in `terraform.tfvars` (e.g., your GitHub
@@ -406,6 +407,10 @@ cloudflare_worker_subdomain = "your-subdomain"  # e.g., "twilight-unit-b2cf" (wi
 
 # Web platform: "vercel" (default) or "cloudflare" (OpenNext)
 web_platform                = "vercel"
+
+# Optional custom domain for the web app (only when web_platform = "cloudflare")
+# cloudflare_zone_id       = "your-zone-id"
+# cloudflare_custom_domain = "app.example.com"
 
 # Vercel (only required when web_platform = "vercel")
 # If using Cloudflare, do NOT set these — leave them out so the dummy defaults are used.
@@ -697,6 +702,27 @@ For day-to-day workflows, see [GitHub Integration](./integrations/GITHUB.md).
 Terraform handles the full build and deploy automatically — the web app is built with OpenNext and
 deployed as a Cloudflare Worker during `terraform apply`. No manual step needed.
 
+#### Optional: serve the web app on a custom domain
+
+By default the web app is served from
+`https://open-inspect-web-{deployment_name}.YOUR-SUBDOMAIN.workers.dev`. To use your own hostname,
+set both of these in `terraform.tfvars`:
+
+```hcl
+cloudflare_zone_id       = "your-zone-id"    # zone that owns the hostname
+cloudflare_custom_domain = "app.example.com" # bare hostname, no scheme
+```
+
+Cloudflare provisions the DNS record and edge certificate automatically. Notes:
+
+- The web app URL — including `NEXTAUTH_URL` and the links the bots send — becomes
+  `https://{your-custom-domain}`, and the workers.dev route for the web Worker is disabled so the
+  app has a single canonical origin.
+- Update the GitHub App callback URL (and the Google redirect URI, if Google login is enabled) to
+  the new hostname, or sign-in will fail with a redirect URI mismatch.
+- The Cloudflare API token needs zone-level **Workers Routes: Edit** permission to attach the
+  domain.
+
 ### If using Vercel (`web_platform = "vercel"`)
 
 Terraform creates the Vercel project and configures environment variables, but does **not** deploy
@@ -912,6 +938,7 @@ URL to match your web app URL:
 - **Vercel**: `https://open-inspect-{deployment_name}.vercel.app/api/auth/callback/github`
 - **Cloudflare**:
   `https://open-inspect-web-{deployment_name}.YOUR-SUBDOMAIN.workers.dev/api/auth/callback/github`
+- **Cloudflare with a custom domain**: `https://{your-custom-domain}/api/auth/callback/github`
 
 ### Modal deployment fails
 

--- a/terraform/environments/production/checks.tf
+++ b/terraform/environments/production/checks.tf
@@ -12,6 +12,19 @@ check "vercel_url_matches" {
   }
 }
 
+# Fail the plan when a custom domain is set but cannot take effect — wrong web
+# platform or missing zone ID. Hostname shape is validated on the variable
+# itself; this gate owns the cross-input policy, expressed via the normalized
+# locals so enablement (web_custom_domain_enabled) and enforcement stay in sync.
+resource "terraform_data" "cloudflare_custom_domain_gate" {
+  lifecycle {
+    precondition {
+      condition     = local.web_custom_domain == "" || local.web_custom_domain_enabled
+      error_message = "cloudflare_custom_domain is set but would be silently ignored: it requires web_platform = \"cloudflare\" and a non-empty cloudflare_zone_id."
+    }
+  }
+}
+
 # Fail the plan when no access control is configured. Uses terraform_data with a
 # precondition so this is a hard error, not an advisory check-block warning.
 resource "terraform_data" "access_control_gate" {

--- a/terraform/environments/production/checks.tf
+++ b/terraform/environments/production/checks.tf
@@ -12,19 +12,6 @@ check "vercel_url_matches" {
   }
 }
 
-# Warn when a custom domain is set without a zone ID. The custom domain is then
-# silently ignored and the app falls back to the workers.dev URL.
-check "cloudflare_custom_domain_config" {
-  assert {
-    condition = (
-      var.web_platform != "cloudflare" ||
-      trimspace(coalesce(var.cloudflare_custom_domain, "")) == "" ||
-      trimspace(coalesce(var.cloudflare_zone_id, "")) != ""
-    )
-    error_message = "cloudflare_custom_domain is set but cloudflare_zone_id is empty — the custom domain is ignored and the app falls back to the workers.dev URL."
-  }
-}
-
 # Fail the plan when no access control is configured. Uses terraform_data with a
 # precondition so this is a hard error, not an advisory check-block warning.
 resource "terraform_data" "access_control_gate" {

--- a/terraform/environments/production/locals.tf
+++ b/terraform/environments/production/locals.tf
@@ -18,17 +18,23 @@ locals {
   # Must match the deployed Worker's `name` and the custom-domain `service` binding.
   web_worker_name = "open-inspect-web-${local.name_suffix}"
 
+  # Custom-domain inputs normalized to "" when unset. coalesce() must not be
+  # used here: it errors when all arguments are null or empty strings, which is
+  # the default for both variables.
+  web_custom_domain         = var.cloudflare_custom_domain == null ? "" : trimspace(var.cloudflare_custom_domain)
+  web_custom_domain_zone_id = var.cloudflare_zone_id == null ? "" : trimspace(var.cloudflare_zone_id)
+
   # Whether a custom domain is configured for the Cloudflare web Worker
   web_custom_domain_enabled = (
     var.web_platform == "cloudflare" &&
-    trimspace(coalesce(var.cloudflare_custom_domain, "")) != "" &&
-    trimspace(coalesce(var.cloudflare_zone_id, "")) != ""
+    local.web_custom_domain != "" &&
+    local.web_custom_domain_zone_id != ""
   )
 
   # Host the Cloudflare web Worker is served from: custom domain when configured,
   # otherwise its default workers.dev hostname.
   web_cloudflare_host = (local.web_custom_domain_enabled
-    ? var.cloudflare_custom_domain
+    ? local.web_custom_domain
     : "${local.web_worker_name}.${var.cloudflare_worker_subdomain}.workers.dev"
   )
 

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -33,7 +33,9 @@ cloudflare_account_id = ""
 # Custom domain (hostname) for the Cloudflare web Worker (optional).
 # Only used when web_platform = "cloudflare". Requires cloudflare_zone_id above
 # and a zone you control. Cloudflare provisions the DNS record + edge cert and
-# the web app URL becomes https://<this-hostname> instead of the workers.dev URL.
+# the web app URL becomes https://<this-hostname> instead of the workers.dev URL
+# (the workers.dev route is disabled). Remember to update the GitHub/Google
+# OAuth callback URLs to the new hostname.
 # cloudflare_custom_domain = "" # e.g., "app.example.com"
 
 # Cloudflare Workers subdomain (found in Workers & Pages -> Overview, bottom-right of panel)

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -23,6 +23,24 @@ variable "cloudflare_custom_domain" {
   description = "Custom domain (hostname) to attach to the Cloudflare web Worker (optional). Requires web_platform = 'cloudflare' and cloudflare_zone_id. e.g. 'app.example.com'"
   type        = string
   default     = null
+
+  validation {
+    condition = (
+      var.cloudflare_custom_domain == null ||
+      trimspace(var.cloudflare_custom_domain) == "" ||
+      can(regex("(?i)^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$", var.cloudflare_custom_domain))
+    )
+    error_message = "cloudflare_custom_domain must be a bare hostname such as 'app.example.com' — no scheme, port, path, trailing dot, or whitespace."
+  }
+
+  validation {
+    condition = (
+      var.cloudflare_custom_domain == null ||
+      trimspace(var.cloudflare_custom_domain) == "" ||
+      (var.web_platform == "cloudflare" && (var.cloudflare_zone_id == null ? "" : trimspace(var.cloudflare_zone_id)) != "")
+    )
+    error_message = "cloudflare_custom_domain is set but would be silently ignored: it requires web_platform = \"cloudflare\" and a non-empty cloudflare_zone_id."
+  }
 }
 
 variable "cloudflare_worker_subdomain" {

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -32,15 +32,6 @@ variable "cloudflare_custom_domain" {
     )
     error_message = "cloudflare_custom_domain must be a bare hostname such as 'app.example.com' — no scheme, port, path, trailing dot, or whitespace."
   }
-
-  validation {
-    condition = (
-      var.cloudflare_custom_domain == null ||
-      trimspace(var.cloudflare_custom_domain) == "" ||
-      (var.web_platform == "cloudflare" && (var.cloudflare_zone_id == null ? "" : trimspace(var.cloudflare_zone_id)) != "")
-    )
-    error_message = "cloudflare_custom_domain is set but would be silently ignored: it requires web_platform = \"cloudflare\" and a non-empty cloudflare_zone_id."
-  }
 }
 
 variable "cloudflare_worker_subdomain" {

--- a/terraform/environments/production/web-cloudflare.tf
+++ b/terraform/environments/production/web-cloudflare.tf
@@ -69,6 +69,10 @@ resource "local_file" "web_app_wrangler_production" {
     compatibility_date = "2025-08-15"
     compatibility_flags = ["nodejs_compat", "global_fetch_strictly_public"]
 
+    # The workers.dev route is disabled when a custom domain is attached, so the
+    # app is only reachable on the origin NEXTAUTH_URL points at.
+    workers_dev = ${local.web_custom_domain_enabled ? "false" : "true"}
+
     [vars]
     GITHUB_CLIENT_ID = "${var.github_client_id}"
     GOOGLE_CLIENT_ID = "${var.google_client_id}"
@@ -127,8 +131,8 @@ resource "cloudflare_workers_custom_domain" "web_app" {
   count = local.web_custom_domain_enabled ? 1 : 0
 
   account_id = var.cloudflare_account_id
-  zone_id    = var.cloudflare_zone_id
-  hostname   = var.cloudflare_custom_domain
+  zone_id    = local.web_custom_domain_zone_id
+  hostname   = local.web_custom_domain
   service    = local.web_worker_name
 
   depends_on = [null_resource.web_app_cloudflare_deploy]


### PR DESCRIPTION
Follow-ups to #747 (custom domain support for the Cloudflare web Worker).

## Bug: `terraform plan` fails for every Cloudflare-platform deployment without a custom domain

Terraform's `coalesce()` errors when **all** arguments are null or empty strings — `coalesce(null, "")` is a hard error, not `""`:

```
Call to function "coalesce" failed: no non-null, non-empty-string arguments.
```

The `web_custom_domain_enabled` local from #747 evaluates `trimspace(coalesce(var.cloudflare_custom_domain, ""))` whenever `web_platform == "cloudflare"` (`&&` short-circuits, so Vercel deployments escape). Both `cloudflare_custom_domain` and `cloudflare_zone_id` default to `null`, so any existing `web_platform = "cloudflare"` deployment that hasn't opted into a custom domain now fails at plan time. Setting `cloudflare_custom_domain = ""` explicitly errors the same way.

This slipped past `terraform validate` because validate treats variables as unknown values — the error only fires on plan/apply with concrete values.

**Fix**: null-safe normalization locals (`var.x == null ? "" : trimspace(var.x)`) consumed by the gate, the host, and the `cloudflare_workers_custom_domain` resource. This also fixes the inconsistency where the gate trimmed the domain but the resource/URL consumed the raw value.

## Hard validation instead of an advisory warning

The `check` block from #747 had the same `coalesce` problem (it would report an evaluation error rather than its intended message), and as a warning it let a misconfigured domain silently fall back to workers.dev — leaving `NEXTAUTH_URL` and OAuth callbacks pointing somewhere the operator didn't intend. Replaced with two hard failures:

- a `validation` block on `cloudflare_custom_domain` for hostname shape: must be a bare hostname — rejects scheme, port, path, trailing dot, whitespace, wildcards
- a `terraform_data.cloudflare_custom_domain_gate` precondition in `checks.tf` for the cross-input policy (same pattern as the existing `access_control_gate`), expressed against the normalized locals as `local.web_custom_domain == "" || local.web_custom_domain_enabled`: a set domain requires `web_platform = "cloudflare"` and a non-empty `cloudflare_zone_id` (also catches the previously-silent domain-set-on-Vercel case)

`null`, `""`, and whitespace-only all still mean "not configured".

## Single canonical origin

Attaching a custom domain doesn't disable the workers.dev route, so the app was reachable on two origins with `NEXTAUTH_URL` pointing at only one. The generated `wrangler.production.toml` now sets `workers_dev = false` when the custom domain is enabled (`true` otherwise — existing behavior, now explicit).

> **Note for deployers already running #747 with a custom domain**: after the next apply, the workers.dev URL for the web app stops serving; the custom domain is the single origin.

## Docs

- `GETTING_STARTED.md`: custom-domain subsection under Step 8 (vars, token permission, OAuth-callback reminder), custom-domain entries in the callback-URL list and redirect-URI troubleshooting, commented vars in the tfvars sample.
- `terraform.tfvars.example`: notes that workers.dev is disabled and GitHub/Google OAuth callback URLs must be updated to the new hostname.

## Verification

`terraform fmt -check` and `terraform validate` pass. Validation and locals exercised end-to-end with `terraform plan` on a minimal harness under Terraform 1.14.6 (the repo's required floor):

| Scenario | Result |
| --- | --- |
| all unset (defaults) | plans cleanly, `enabled = false` — previously the coalesce error |
| domain set, `web_platform = "vercel"` | hard error (precondition gate) |
| domain set, zone id unset | hard error (precondition gate) |
| domain + zone, `web_platform = "cloudflare"` | `enabled = true`, host = custom domain |
| `https://app.example.com` | hard error (bare-hostname rule) |
| domain `""` | plans cleanly, `enabled = false` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for serving the web app on a Cloudflare custom domain (with the default `workers.dev` route disabled when enabled).
  * Expanded setup docs with Cloudflare custom-domain DNS, certificate, and OAuth callback guidance.

* **Bug Fixes**
  * Improved reliability of custom-domain configuration by treating `null`/empty/whitespace as unset and validating against a bare hostname format.
  * Added a stricter preflight check that blocks misconfigured plans when the custom domain requires missing Cloudflare zone settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
