### PR TITLE
fix(control-plane): use full GitLab namespace paths

### DIFF
--- a/packages/control-plane/src/source-control/providers/gitlab-provider.test.ts
+++ b/packages/control-plane/src/source-control/providers/gitlab-provider.test.ts
@@ -37,7 +37,7 @@ describe("GitLabSourceControlProvider", () => {
           name: "My Web App", // display name — should NOT be used
           path: "web", // URL slug — should be used as name
           path_with_namespace: "acme/web",
-          namespace: { path: "acme" },
+          namespace: { path: "acme", full_path: "acme" },
           default_branch: "main",
           visibility: "private",
         })
@@ -59,6 +59,29 @@ describe("GitLabSourceControlProvider", () => {
       });
     });
 
+    it("returns the full namespace path as owner for nested-group projects", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({
+          id: 43,
+          name: "Web App",
+          path: "web",
+          path_with_namespace: "acme/backend/web",
+          namespace: { path: "backend", full_path: "acme/backend" },
+          default_branch: "main",
+          visibility: "private",
+        })
+      );
+
+      const provider = new GitLabSourceControlProvider(fakeConfig);
+      const repo = await provider.getRepository(
+        { authType: "pat", token: "user-token" },
+        { owner: "acme/backend", name: "web" }
+      );
+
+      expect(repo.owner).toBe("acme/backend");
+      expect(repo.fullName).toBe("acme/backend/web");
+    });
+
     it("marks public repos as not private", async () => {
       mockFetch.mockResolvedValueOnce(
         makeResponse({
@@ -66,7 +89,7 @@ describe("GitLabSourceControlProvider", () => {
           name: "OSS Project",
           path: "oss",
           path_with_namespace: "acme/oss",
-          namespace: { path: "acme" },
+          namespace: { path: "acme", full_path: "acme" },
           default_branch: "main",
           visibility: "public",
         })
@@ -342,7 +365,7 @@ describe("GitLabSourceControlProvider", () => {
       mockFetch.mockResolvedValueOnce(
         makeResponse({
           id: 99,
-          namespace: { path: "acme" },
+          namespace: { path: "acme", full_path: "acme" },
           path: "web",
           default_branch: "main",
         })
@@ -357,6 +380,23 @@ describe("GitLabSourceControlProvider", () => {
         repoName: "web",
         defaultBranch: "main",
       });
+    });
+
+    it("returns the full namespace path as repoOwner for nested-group projects", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeResponse({
+          id: 100,
+          namespace: { path: "backend", full_path: "acme/backend" },
+          path: "web",
+          default_branch: "main",
+        })
+      );
+
+      const provider = new GitLabSourceControlProvider(fakeConfig);
+      const result = await provider.checkRepositoryAccess({ owner: "acme/backend", name: "web" });
+
+      expect(result?.repoOwner).toBe("acme/backend");
+      expect(result?.repoName).toBe("web");
     });
 
     it("returns null for 404", async () => {
@@ -401,7 +441,7 @@ describe("GitLabSourceControlProvider", () => {
       mockFetch.mockResolvedValueOnce(
         makeResponse({
           id: 1,
-          namespace: { path: "ACME" },
+          namespace: { path: "ACME", full_path: "ACME" },
           path: "WEB",
           default_branch: "main",
         })
@@ -424,7 +464,7 @@ describe("GitLabSourceControlProvider", () => {
             name: "My Web App", // display name — should NOT be used
             path: "web", // URL slug — should be used as name
             path_with_namespace: "acme/web",
-            namespace: { path: "acme" },
+            namespace: { path: "acme", full_path: "acme" },
             description: "The web app",
             visibility: "private",
             default_branch: "main",
@@ -465,7 +505,7 @@ describe("GitLabSourceControlProvider", () => {
             name: "Active App",
             path: "active",
             path_with_namespace: "acme/active",
-            namespace: { path: "acme" },
+            namespace: { path: "acme", full_path: "acme" },
             description: null,
             visibility: "private",
             default_branch: "main",
@@ -476,7 +516,7 @@ describe("GitLabSourceControlProvider", () => {
             name: "Archived App",
             path: "archived",
             path_with_namespace: "acme/archived",
-            namespace: { path: "acme" },
+            namespace: { path: "acme", full_path: "acme" },
             description: null,
             visibility: "private",
             default_branch: "main",
@@ -489,6 +529,30 @@ describe("GitLabSourceControlProvider", () => {
       const repos = await provider.listRepositories();
 
       expect(repos.map((repo) => repo.fullName)).toEqual(["acme/active"]);
+    });
+
+    it("returns the full namespace path as owner for nested-group projects", async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeResponse([
+          {
+            id: 2,
+            name: "Web App",
+            path: "web",
+            path_with_namespace: "acme/backend/web",
+            namespace: { path: "backend", full_path: "acme/backend" },
+            description: null,
+            visibility: "private",
+            default_branch: "main",
+            archived: false,
+          },
+        ])
+      );
+
+      const provider = new GitLabSourceControlProvider(fakeConfig);
+      const repos = await provider.listRepositories();
+
+      expect(repos[0].owner).toBe("acme/backend");
+      expect(repos[0].fullName).toBe("acme/backend/web");
     });
 
     it("fetches from group endpoint when namespace is configured", async () => {
@@ -592,6 +656,19 @@ describe("GitLabSourceControlProvider", () => {
       expect(url).toContain("acme%20org");
       expect(url).toContain("web%2Fapp");
       expect(url).toContain("feature%2Ftest%20branch");
+    });
+
+    it("preserves nested group separators in the project path", () => {
+      const provider = new GitLabSourceControlProvider(fakeConfig);
+      const url = provider.buildManualPullRequestUrl({
+        owner: "acme/backend",
+        name: "web",
+        sourceBranch: "feature/add-thing",
+        targetBranch: "main",
+      });
+
+      expect(url).toContain("/acme/backend/web/-/merge_requests/new");
+      expect(url).not.toContain("acme%2Fbackend");
     });
   });
 

--- a/packages/control-plane/src/source-control/providers/gitlab-provider.ts
+++ b/packages/control-plane/src/source-control/providers/gitlab-provider.ts
@@ -47,6 +47,12 @@ function encodeProjectPath(owner: string, name: string): string {
   return encodeURIComponent(`${owner}/${name}`);
 }
 
+/** URL-encode a project web path while preserving nested group separators. */
+function encodeProjectWebPath(owner: string, name: string): string {
+  const encodedOwner = owner.split("/").map(encodeURIComponent).join("/");
+  return `${encodedOwner}/${encodeURIComponent(name)}`;
+}
+
 /**
  * GitLab implementation of SourceControlProvider.
  *
@@ -104,13 +110,15 @@ export class GitLabSourceControlProvider implements SourceControlProvider {
       name: string;
       path: string;
       path_with_namespace: string;
-      namespace: { path: string };
+      namespace: { full_path: string };
       default_branch: string;
       visibility: string;
     };
 
+    // full_path, not path: nested groups ("group/subgroup") need the
+    // entire namespace so owner/name lookups reconstruct the project path.
     return {
-      owner: data.namespace.path,
+      owner: data.namespace.full_path,
       name: data.path,
       fullName: data.path_with_namespace,
       defaultBranch: data.default_branch,
@@ -229,7 +237,7 @@ export class GitLabSourceControlProvider implements SourceControlProvider {
 
       const data = (await response.json()) as {
         id: number;
-        namespace: { path: string };
+        namespace: { full_path: string };
         path: string;
         default_branch: string;
         archived: boolean;
@@ -241,7 +249,7 @@ export class GitLabSourceControlProvider implements SourceControlProvider {
 
       return {
         repoId: data.id,
-        repoOwner: data.namespace.path.toLowerCase(),
+        repoOwner: data.namespace.full_path.toLowerCase(),
         repoName: data.path.toLowerCase(),
         defaultBranch: data.default_branch,
       };
@@ -286,7 +294,7 @@ export class GitLabSourceControlProvider implements SourceControlProvider {
         name: string;
         path: string;
         path_with_namespace: string;
-        namespace: { path: string };
+        namespace: { full_path: string };
         description: string | null;
         visibility: string;
         default_branch: string;
@@ -297,7 +305,7 @@ export class GitLabSourceControlProvider implements SourceControlProvider {
         .filter((project) => !project.archived)
         .map((project) => ({
           id: project.id,
-          owner: project.namespace.path,
+          owner: project.namespace.full_path,
           name: project.path,
           fullName: project.path_with_namespace,
           description: project.description,
@@ -369,12 +377,11 @@ export class GitLabSourceControlProvider implements SourceControlProvider {
   }
 
   buildManualPullRequestUrl(config: BuildManualPullRequestUrlConfig): string {
-    const encodedOwner = encodeURIComponent(config.owner);
-    const encodedName = encodeURIComponent(config.name);
+    const encodedProjectPath = encodeProjectWebPath(config.owner, config.name);
     const encodedSource = encodeURIComponent(config.sourceBranch);
     const encodedTarget = encodeURIComponent(config.targetBranch);
     return (
-      `https://gitlab.com/${encodedOwner}/${encodedName}/-/merge_requests/new` +
+      `https://gitlab.com/${encodedProjectPath}/-/merge_requests/new` +
       `?merge_request[source_branch]=${encodedSource}` +
       `&merge_request[target_branch]=${encodedTarget}`
     );


### PR DESCRIPTION
## Summary
- Take over #734 and resolve conflicts with current `main`, preserving archived-project filtering.
- Use GitLab `namespace.full_path` for repository owner mapping so nested groups round-trip correctly.
- Preserve nested group separators in manual MR URLs while still encoding individual path segments.

## Test plan
- `npm test -w @open-inspect/control-plane -- gitlab-provider.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/8b33d071aa6249421aeed1640d5ca6f7)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repository ownership and listing for projects inside nested GitLab groups.
  * Improved manually generated merge request links so nested group paths open correctly.
  * Preserved archived repository filtering while updating project path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->