### PR TITLE
fix: accept structured sandbox token usage

### DIFF
--- a/packages/control-plane/test/integration/websocket-sandbox.test.ts
+++ b/packages/control-plane/test/integration/websocket-sandbox.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
+  collectMessages,
   initNamedSession,
+  openClientWs,
   openSandboxWs,
   seedSandboxAuth,
   queryDO,
@@ -141,5 +143,57 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
     expect(matching.length).toBeGreaterThanOrEqual(1);
 
     ws!.close();
+  });
+
+  it("accepts step_finish messages with structured token usage", async () => {
+    const name = `ws-sandbox-step-finish-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    const { ws: clientWs } = await openClientWs(name, { subscribe: true });
+    await seedSandboxAuth(stub, { authToken: SANDBOX_TOKEN, sandboxId: SANDBOX_ID });
+
+    const { ws: sandboxWs } = await openSandboxWs(name, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+    });
+    expect(sandboxWs).not.toBeNull();
+    sandboxWs!.accept();
+
+    const tokenUsage = {
+      total: 223,
+      input: 219,
+      output: 4,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    };
+    const collector = collectMessages(clientWs, {
+      until: (msg) =>
+        msg.type === "sandbox_event" &&
+        (msg.event as Record<string, unknown> | undefined)?.type === "step_finish",
+    });
+
+    sandboxWs!.send(
+      JSON.stringify({
+        type: "step_finish",
+        messageId: "msg-step-finish-1",
+        cost: 0.001,
+        tokens: tokenUsage,
+        reason: "end_turn",
+        sandboxId: SANDBOX_ID,
+        timestamp: Date.now(),
+      })
+    );
+
+    const messages = await collector;
+    const stepFinish = messages.find(
+      (msg) =>
+        msg.type === "sandbox_event" &&
+        (msg.event as Record<string, unknown> | undefined)?.type === "step_finish"
+    );
+
+    expect(stepFinish).toBeDefined();
+    expect((stepFinish!.event as { tokens: unknown }).tokens).toEqual(tokenUsage);
+
+    sandboxWs!.close();
+    clientWs.close();
   });
 });

--- a/packages/shared/src/types/boundary-schemas.test.ts
+++ b/packages/shared/src/types/boundary-schemas.test.ts
@@ -128,6 +128,31 @@ describe("boundary schemas", () => {
         expect(result.data.ackId).toBe("ack-1");
       }
     });
+
+    it("parses step finish events with structured token usage", () => {
+      const tokenUsage = {
+        total: 223,
+        input: 219,
+        output: 4,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      };
+
+      const result = sandboxEventSchema.safeParse({
+        type: "step_finish",
+        messageId: "message-1",
+        cost: 0.001,
+        tokens: tokenUsage,
+        reason: "end_turn",
+        sandboxId: "sandbox-1",
+        timestamp: 123,
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.tokens).toEqual(tokenUsage);
+      }
+    });
   });
 
   describe("clientMessageSchema", () => {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -88,6 +88,32 @@ const spawnSourceSchema = z.enum([
 ]);
 
 const recordSchema = z.record(z.string(), z.unknown());
+const tokenUsageDetailsSchema = z
+  .object({
+    total: z.number().optional(),
+    input: z.number().optional(),
+    output: z.number().optional(),
+    reasoning: z.number().optional(),
+    cache: z
+      .object({
+        read: z.number().optional(),
+        write: z.number().optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough()
+  .refine(
+    (usage) =>
+      typeof usage.total === "number" ||
+      typeof usage.input === "number" ||
+      typeof usage.output === "number" ||
+      typeof usage.reasoning === "number" ||
+      typeof usage.cache?.read === "number" ||
+      typeof usage.cache?.write === "number",
+    { message: "Expected at least one token usage count" }
+  );
+const tokenUsageSchema = z.union([z.number(), tokenUsageDetailsSchema]);
 
 // Participant in a session
 export interface SessionParticipant {
@@ -270,7 +296,7 @@ export const sandboxEventSchema = z.discriminatedUnion("type", [
   messageSandboxEventBaseSchema.extend({
     type: z.literal("step_finish"),
     cost: z.number().optional(),
-    tokens: z.number().optional(),
+    tokens: tokenUsageSchema.optional(),
     reason: z.string().optional(),
     isSubtask: z.boolean().optional(),
   }),


### PR DESCRIPTION
## Summary
- allow sandbox `step_finish.tokens` to be either the legacy numeric count or a structured usage object
- add shared schema coverage for OpenCode-style token usage details
- add a workerd sandbox WebSocket integration test for the invalid-message regression

## Root Cause
The sandbox bridge forwards OpenCode `step-finish` parts verbatim. OpenCode can send `tokens` as an object with usage details such as `total`, `input`, `output`, `reasoning`, and `cache`, but the control-plane boundary schema only accepted a number, so the Durable Object rejected the entire sandbox message.

## Validation
- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/shared`
- `npm test -w @open-inspect/shared -- src/types/boundary-schemas.test.ts`
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/websocket-sandbox.test.ts`
- `npx prettier --check packages/shared/src/types/index.ts packages/shared/src/types/boundary-schemas.test.ts packages/control-plane/test/integration/websocket-sandbox.test.ts`

## Known Existing Issue
- `npm run typecheck -w @open-inspect/control-plane` still fails on an unrelated scheduler webhook typing issue at `src/scheduler/durable-object.ts(522,49)`: webhook automation `body` is optional where `WebhookAutomationEvent` requires it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox step completion events now support richer token usage details, including total, input, output, reasoning, and cache counts.
  * Token usage can still be provided as a simple total value for compatibility.

* **Bug Fixes**
  * Improved validation and handling of sandbox event token data so structured usage is accepted and preserved consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->