### PR TITLE
Add Z.AI Coding Plan GLM 5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,12 @@ await configureGitIdentity({
 
 Choose the AI model that fits your task, with per-session reasoning effort controls:
 
-| Provider     | Models                                                               |
-| ------------ | -------------------------------------------------------------------- |
-| Anthropic    | Claude Haiku 4.5, Sonnet 4.5/4.6, Opus 4.5/4.6/4.7/4.8, Fable 5      |
-| OpenAI       | GPT 5.2, GPT 5.4, GPT 5.5, GPT 5.2 Codex, 5.3 Codex, 5.3 Codex Spark |
-| OpenCode Zen | Kimi K2.5/K2.6, MiniMax M2.5, Qwen3.7 Max, GLM 5/5.1 (opt-in)        |
+| Provider         | Models                                                               |
+| ---------------- | -------------------------------------------------------------------- |
+| Anthropic        | Claude Haiku 4.5, Sonnet 4.5/4.6, Opus 4.5/4.6/4.7/4.8, Fable 5      |
+| OpenAI           | GPT 5.2, GPT 5.4, GPT 5.5, GPT 5.2 Codex, 5.3 Codex, 5.3 Codex Spark |
+| OpenCode Zen     | Kimi K2.5/K2.6, MiniMax M2.5, Qwen3.7 Max, GLM 5/5.1 (opt-in)        |
+| Z.AI Coding Plan | GLM 5.2 (opt-in)                                                     |
 
 OpenAI models work with your existing ChatGPT subscription via OAuth — no separate API key needed.
 See **[docs/AVAILABLE_MODELS.md](docs/AVAILABLE_MODELS.md)** for the full model list and

--- a/docs/AVAILABLE_MODELS.md
+++ b/docs/AVAILABLE_MODELS.md
@@ -1,9 +1,9 @@
 # Available Models
 
 Open-Inspect exposes these models in the model picker and integration preferences. The default
-enabled set includes Anthropic and OpenAI models; OpenCode Zen models are available but must be
-enabled in **Settings > Models**. DeepSeek models are also opt-in and require `DEEPSEEK_API_KEY` to
-be available in the sandbox environment.
+enabled set includes Anthropic and OpenAI models. OpenCode Zen, Z.AI Coding Plan, and DeepSeek
+models are available but must be enabled in **Settings > Models**. Z.AI Coding Plan requires
+`ZHIPU_API_KEY`; DeepSeek requires `DEEPSEEK_API_KEY`.
 
 ## Anthropic
 
@@ -42,6 +42,14 @@ setup instructions.
 | `opencode/qwen3.7-max`  | Qwen3.7 Max  | Alibaba Cloud | Not supported     | N/A            |
 | `opencode/glm-5`        | GLM 5        | Z.ai 744B MoE | Not supported     | N/A            |
 | `opencode/glm-5.1`      | GLM 5.1      | Z.ai          | Not supported     | N/A            |
+
+## Z.AI Coding Plan
+
+Z.AI Coding Plan models require `ZHIPU_API_KEY` as a global or repository secret.
+
+| Model ID                  | Display name | Description      | Reasoning efforts | Default effort |
+| ------------------------- | ------------ | ---------------- | ----------------- | -------------- |
+| `zai-coding-plan/glm-5.2` | GLM 5.2      | Z.AI Coding Plan | Not supported     | N/A            |
 
 ## DeepSeek
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1020,7 +1020,7 @@ injects keys automatically), these providers require you to add them as global s
 1. Go to **Settings > Secrets** in the web app
 2. Select **All Repositories (Global)** from the scope dropdown
 3. Add the key for your chosen provider (e.g., `ANTHROPIC_API_KEY` for Claude models or
-   `DEEPSEEK_API_KEY` for DeepSeek models)
+   `DEEPSEEK_API_KEY` for DeepSeek models, or `ZHIPU_API_KEY` for Z.AI Coding Plan models)
 4. Click **Save**
 
 See [Secrets Management](SECRETS.md) for more on global and repository secrets.

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -487,7 +487,8 @@ restores still mint a fresh fallback token on restore.
 
 You can configure environment variables (API keys, credentials) at global or per-repository scope:
 
-- **Global secrets** apply to all repositories (e.g., `ANTHROPIC_API_KEY`, `DEEPSEEK_API_KEY`)
+- **Global secrets** apply to all repositories (e.g., `ANTHROPIC_API_KEY`, `DEEPSEEK_API_KEY`,
+  `ZHIPU_API_KEY`)
 - **Repository secrets** apply to a single repo and override global secrets with the same key
 - Stored encrypted (AES-256-GCM) in D1 database
 - Injected into sandboxes at startup
@@ -496,8 +497,8 @@ You can configure environment variables (API keys, credentials) at global or per
 > **Daytona and Vercel users**: LLM API keys (e.g., `ANTHROPIC_API_KEY` for Claude models) must be
 > added as global secrets. Modal injects these automatically via its own secrets mechanism.
 >
-> **DeepSeek (all providers)**: DeepSeek models require `DEEPSEEK_API_KEY` as a global secret with
-> any sandbox provider — unlike `ANTHROPIC_API_KEY`, Modal does not inject it automatically.
+> **Opt-in model providers**: DeepSeek models require `DEEPSEEK_API_KEY`, and Z.AI Coding Plan
+> models require `ZHIPU_API_KEY`, as a global secret with any sandbox provider.
 
 See [Secrets Management](./SECRETS.md) for setup instructions.
 

--- a/docs/OPENCOMPUTER_PROVIDER.md
+++ b/docs/OPENCOMPUTER_PROVIDER.md
@@ -110,7 +110,8 @@ Terraform passes these provider-level values to the control plane:
 
 The runtime also receives repository credentials from Open-Inspect for Git operations. If you use
 additional model providers or custom agent tools, add those keys through Open-Inspect's secrets
-settings. See [SECRETS.md](./SECRETS.md).
+settings. For example, Z.AI Coding Plan GLM models require `ZHIPU_API_KEY`. See
+[SECRETS.md](./SECRETS.md).
 
 ## Verify
 
@@ -162,5 +163,5 @@ debugging OpenComputer.
 ### LLM/API Key Problems
 
 The control plane passes `ANTHROPIC_API_KEY` for the default Claude models. If OpenCode reports a
-model or provider error, confirm that the key is present in Terraform and that the selected model is
-available for that account.
+model or provider error, confirm that the required provider key is available through Terraform or
+Open-Inspect secrets and that the selected model is available for that account.

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -20,10 +20,10 @@ That's it — the next sandbox you launch will have the secret available as an e
 
 ## Global vs. Repository Secrets
 
-| Scope          | Applies to        | Use case                                                              |
-| -------------- | ----------------- | --------------------------------------------------------------------- |
-| **Global**     | All repositories  | API keys shared across projects (`ANTHROPIC_API_KEY`, `DATABASE_URL`) |
-| **Repository** | One specific repo | Repo-specific credentials (`STRIPE_SECRET_KEY`, `AWS_ACCESS_KEY_ID`)  |
+| Scope          | Applies to        | Use case                                                               |
+| -------------- | ----------------- | ---------------------------------------------------------------------- |
+| **Global**     | All repositories  | API keys shared across projects (`ANTHROPIC_API_KEY`, `ZHIPU_API_KEY`) |
+| **Repository** | One specific repo | Repo-specific credentials (`STRIPE_SECRET_KEY`, `AWS_ACCESS_KEY_ID`)   |
 
 **Precedence**: Repository secrets override global secrets with the same key. When viewing a
 repository's secrets, inherited global keys are shown in a read-only section with a "Global" badge.
@@ -38,6 +38,7 @@ The most common example:
 | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ANTHROPIC_API_KEY` | Required for Claude models when using the **Daytona** or **Vercel** sandbox provider (Modal injects this automatically via its own secrets mechanism) |
 | `DEEPSEEK_API_KEY`  | Required for DeepSeek models with any sandbox provider                                                                                                |
+| `ZHIPU_API_KEY`     | Required for Z.AI Coding Plan GLM models with any sandbox provider                                                                                    |
 
 > **Daytona and Vercel sandbox users**: If you plan to use Claude models, you must add
 > `ANTHROPIC_API_KEY` as a global secret after deploying. Without it, Claude sessions will fail with
@@ -115,6 +116,7 @@ If you try to save a reserved key, the UI will show a validation error.
 | ---------------------------- | ------ | ------------------------------------------------------------ |
 | `ANTHROPIC_API_KEY`          | Global | Claude API access (required for Daytona or Vercel sandboxes) |
 | `DEEPSEEK_API_KEY`           | Global | DeepSeek API access                                          |
+| `ZHIPU_API_KEY`              | Global | Z.AI Coding Plan GLM access                                  |
 | `OPENAI_OAUTH_REFRESH_TOKEN` | Repo   | OpenAI Codex access ([setup guide](OPENAI_MODELS.md))        |
 | `OPENAI_OAUTH_ACCOUNT_ID`    | Repo   | OpenAI Codex access ([setup guide](OPENAI_MODELS.md))        |
 | `DATABASE_URL`               | Repo   | Database connection string                                   |
@@ -129,7 +131,7 @@ If you try to save a reserved key, the UI will show a validation error.
 
 If you see "Model not found" errors, add the API key for your selected model provider as a global
 secret in Settings. For Claude on Daytona or Vercel, add `ANTHROPIC_API_KEY`. For DeepSeek, add
-`DEEPSEEK_API_KEY`.
+`DEEPSEEK_API_KEY`. For Z.AI Coding Plan, add `ZHIPU_API_KEY`.
 
 ### Secret not appearing in sandbox
 

--- a/packages/shared/src/models.test.ts
+++ b/packages/shared/src/models.test.ts
@@ -43,6 +43,7 @@ const ZEN_MODELS = [
 ] as const;
 
 const DEEPSEEK_MODELS = ["deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro"] as const;
+const ZAI_CODING_PLAN_MODELS = ["zai-coding-plan/glm-5.2"] as const;
 
 describe("model utilities", () => {
   it("keeps DEFAULT_MODEL valid", () => {
@@ -54,6 +55,7 @@ describe("model utilities", () => {
       ...ANTHROPIC_MODELS,
       ...OPENAI_MODELS,
       ...ZEN_MODELS,
+      ...ZAI_CODING_PLAN_MODELS,
       ...DEEPSEEK_MODELS,
     ]) {
       expect(isValidModel(model)).toBe(true);
@@ -174,11 +176,14 @@ describe("model utilities", () => {
       MODEL_OPTIONS.find((group) => group.category === "OpenCode Zen")?.models.map((m) => m.id)
     ).toEqual(ZEN_MODELS);
     expect(
+      MODEL_OPTIONS.find((group) => group.category === "Z.AI Coding Plan")?.models.map((m) => m.id)
+    ).toEqual(ZAI_CODING_PLAN_MODELS);
+    expect(
       MODEL_OPTIONS.find((group) => group.category === "DeepSeek")?.models.map((m) => m.id)
     ).toEqual(DEEPSEEK_MODELS);
 
     expect(DEFAULT_ENABLED_MODELS).toEqual([...ANTHROPIC_MODELS, ...OPENAI_MODELS]);
-    for (const optInModel of [...ZEN_MODELS, ...DEEPSEEK_MODELS]) {
+    for (const optInModel of [...ZEN_MODELS, ...ZAI_CODING_PLAN_MODELS, ...DEEPSEEK_MODELS]) {
       expect(DEFAULT_ENABLED_MODELS).not.toContain(optInModel);
     }
   });

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -30,6 +30,7 @@ export const VALID_MODELS = [
   "opencode/qwen3.7-max",
   "opencode/glm-5",
   "opencode/glm-5.1",
+  "zai-coding-plan/glm-5.2",
   "deepseek/deepseek-v4-flash",
   "deepseek/deepseek-v4-pro",
 ] as const;
@@ -172,6 +173,10 @@ export const MODEL_OPTIONS: ModelCategory[] = [
     ],
   },
   {
+    category: "Z.AI Coding Plan",
+    models: [{ id: "zai-coding-plan/glm-5.2", name: "GLM 5.2", description: "Z.AI Coding Plan" }],
+  },
+  {
     category: "DeepSeek",
     models: [
       { id: "deepseek/deepseek-v4-flash", name: "DeepSeek V4 Flash", description: "Fast model" },
@@ -182,7 +187,7 @@ export const MODEL_OPTIONS: ModelCategory[] = [
 
 /**
  * Models enabled by default when no preferences are stored.
- * Excludes zen models which must be opted into via settings.
+ * Excludes opt-in providers which must be enabled via settings.
  */
 export const DEFAULT_ENABLED_MODELS: ValidModel[] = [
   "anthropic/claude-haiku-4-5",


### PR DESCRIPTION
## Summary
- add `zai-coding-plan/glm-5.2` as an opt-in model category
- document `ZHIPU_API_KEY` setup through Open-Inspect web app secrets
- update model utility tests for the new provider group

## Notes
- no Terraform, Modal secret, or control-plane provider-key plumbing was added; customers configure `ZHIPU_API_KEY` via Settings > Secrets
- verified the OpenCode catalog exposes provider `zai-coding-plan` with model `glm-5.2` and env key `ZHIPU_API_KEY`

## Tests
- `npm test -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/shared`
- `npm run lint -w @open-inspect/shared`
- `npx prettier --check README.md docs/AVAILABLE_MODELS.md docs/GETTING_STARTED.md docs/HOW_IT_WORKS.md docs/OPENCOMPUTER_PROVIDER.md docs/SECRETS.md packages/shared/src/models.ts packages/shared/src/models.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the **Z.AI Coding Plan** model in model selection and validation.
  * The new provider appears in the available models list and related model groupings.

* **Documentation**
  * Updated setup and troubleshooting docs to explain when provider-specific secrets are needed.
  * Added guidance for enabling Z.AI Coding Plan and its required API key.
  * Refreshed model availability tables and secret examples across the docs.

* **Tests**
  * Expanded model coverage to include the new provider and its default-enable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->