### PR TITLE
fix(shared): add ready sandbox event, tolerate unknown replay events

### DIFF
--- a/packages/shared/src/types/boundary-schemas.test.ts
+++ b/packages/shared/src/types/boundary-schemas.test.ts
@@ -167,6 +167,17 @@ describe("boundary schemas", () => {
         expect(result.data.tokens).toEqual(tokenUsage);
       }
     });
+
+    it("parses a ready event (emitted on every sandbox connect)", () => {
+      const result = sandboxEventSchema.safeParse({
+        type: "ready",
+        sandboxId: "sandbox-1",
+        opencodeSessionId: null,
+        timestamp: 123,
+      });
+
+      expect(result.success).toBe(true);
+    });
   });
 
   describe("clientMessageSchema", () => {
@@ -254,6 +265,44 @@ describe("boundary schemas", () => {
       });
 
       expect(result.success).toBe(true);
+    });
+
+    it("keeps recognized replay events and drops unknown ones without failing", () => {
+      const result = serverMessageSchema.safeParse({
+        type: "subscribed",
+        sessionId: "session-1",
+        state: {
+          id: "session-1",
+          title: null,
+          repoOwner: null,
+          repoName: null,
+          baseBranch: null,
+          branchName: null,
+          status: "completed",
+          sandboxStatus: "stopped",
+          messageCount: 1,
+          createdAt: 123,
+          parentSessionId: null,
+          tunnelUrls: null,
+        },
+        artifacts: [],
+        participantId: "participant-1",
+        replay: {
+          events: [
+            { type: "ready", sandboxId: "sandbox-1", opencodeSessionId: null, timestamp: 1 },
+            { type: "some_future_event", foo: "bar", timestamp: 2 },
+            { type: "token", content: "hi", messageId: "m1", sandboxId: "sandbox-1", timestamp: 3 },
+          ],
+          hasMore: false,
+          cursor: null,
+        },
+        spawnError: null,
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.replay?.events.map((event) => event.type)).toEqual(["ready", "token"]);
+      }
     });
 
     it("rejects a malformed partial sandbox event message", () => {

--- a/packages/shared/src/types/boundary-schemas.test.ts
+++ b/packages/shared/src/types/boundary-schemas.test.ts
@@ -305,6 +305,23 @@ describe("boundary schemas", () => {
       }
     });
 
+    it("keeps recognized history_page items and drops unknown ones without failing", () => {
+      const result = serverMessageSchema.safeParse({
+        type: "history_page",
+        items: [
+          { type: "some_legacy_event", foo: "bar", timestamp: 1 },
+          { type: "git_sync", status: "completed", sandboxId: "sandbox-1", timestamp: 2 },
+        ],
+        hasMore: false,
+        cursor: null,
+      });
+
+      expect(result.success).toBe(true);
+      if (result.success && result.data.type === "history_page") {
+        expect(result.data.items.map((item) => item.type)).toEqual(["git_sync"]);
+      }
+    });
+
     it("rejects a malformed partial sandbox event message", () => {
       const result = serverMessageSchema.safeParse({
         type: "sandbox_event",

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -33,6 +33,7 @@ export type MessageSource = "web" | "slack" | "linear" | "extension" | "github" 
 export type ArtifactType = "pr" | "screenshot" | "video" | "preview" | "branch";
 export type EventType =
   | "heartbeat"
+  | "ready"
   | "token"
   | "tool_call"
   | "step_start"
@@ -372,12 +373,15 @@ export const sandboxEventSchema = z.discriminatedUnion("type", [
 export type SandboxEvent = z.infer<typeof sandboxEventSchema>;
 
 /**
- * Replay history events, resilient to unknown/legacy shapes. Each event is
- * validated individually and dropped if it doesn't match, instead of failing
- * the whole `subscribed` message — a single unrecognized event must never wedge
- * session hydration (which strands the client on "loading session" forever).
+ * Sandbox event arrays for session hydration — both the initial `subscribed`
+ * replay and paginated `history_page` items, which read from the same event
+ * store. Resilient to unknown/legacy event shapes: each event is validated
+ * individually and dropped if it doesn't match, instead of failing the whole
+ * message. A single unrecognized event (e.g. a legacy type no longer in the
+ * schema) must never wedge session hydration and strand the client on
+ * "loading session" forever.
  */
-const replayEventsSchema = z.array(z.unknown()).transform((events) =>
+const tolerantSandboxEventsSchema = z.array(z.unknown()).transform((events) =>
   events.flatMap((event) => {
     const result = sandboxEventSchema.safeParse(event);
     return result.success ? [result.data] : [];
@@ -472,7 +476,7 @@ export const serverMessageSchema = z.discriminatedUnion("type", [
     participant: participantSummarySchema.optional(),
     replay: z
       .object({
-        events: replayEventsSchema,
+        events: tolerantSandboxEventsSchema,
         hasMore: z.boolean(),
         cursor: historyCursorSchema.nullable(),
       })
@@ -500,7 +504,7 @@ export const serverMessageSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("processing_status"), isProcessing: z.boolean() }),
   z.object({
     type: z.literal("history_page"),
-    items: z.array(sandboxEventSchema),
+    items: tolerantSandboxEventsSchema,
     hasMore: z.boolean(),
     cursor: historyCursorSchema.nullable(),
   }),

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -277,6 +277,12 @@ export const sandboxEventSchema = z.discriminatedUnion("type", [
     type: z.literal("heartbeat"),
     status: z.string(),
   }),
+  sandboxEventBaseSchema.extend({
+    // Emitted once when the sandbox bridge connects and OpenCode is ready.
+    // Present in essentially every session's replay history.
+    type: z.literal("ready"),
+    opencodeSessionId: z.string().nullable().optional(),
+  }),
   messageSandboxEventBaseSchema.extend({
     type: z.literal("token"),
     content: z.string(),
@@ -364,6 +370,19 @@ export const sandboxEventSchema = z.discriminatedUnion("type", [
 ]);
 
 export type SandboxEvent = z.infer<typeof sandboxEventSchema>;
+
+/**
+ * Replay history events, resilient to unknown/legacy shapes. Each event is
+ * validated individually and dropped if it doesn't match, instead of failing
+ * the whole `subscribed` message — a single unrecognized event must never wedge
+ * session hydration (which strands the client on "loading session" forever).
+ */
+const replayEventsSchema = z.array(z.unknown()).transform((events) =>
+  events.flatMap((event) => {
+    const result = sandboxEventSchema.safeParse(event);
+    return result.success ? [result.data] : [];
+  })
+);
 
 // WebSocket message types
 // Session state sent to clients
@@ -453,7 +472,7 @@ export const serverMessageSchema = z.discriminatedUnion("type", [
     participant: participantSummarySchema.optional(),
     replay: z
       .object({
-        events: z.array(sandboxEventSchema),
+        events: replayEventsSchema,
         hasMore: z.boolean(),
         cursor: historyCursorSchema.nullable(),
       })


### PR DESCRIPTION
## Summary

Session detail pages can hang on "loading session" and never render.

## Root cause

`sandboxEventSchema` — the `SandboxEvent` discriminated union in `packages/shared/src/types/index.ts` — does not include the `ready` event type. The sandbox bridge emits a `ready` event on every connect (`packages/sandbox-runtime/src/sandbox_runtime/bridge.py`), so `ready` is present in essentially every session's replay history.

The client validates the `subscribed` hydration message with `serverMessageSchema.safeParse(...)` and silently drops the message when validation fails (`packages/web/src/hooks/use-session-socket.ts`). Because `replay.events` was `z.array(sandboxEventSchema)`, a single unrecognized `ready` event failed the entire message — so the client never received the session state and the page stayed on "loading session." Any session whose history contains a `ready` event is affected.

## Fix (`packages/shared/src/types/index.ts`)

1. Add the `ready` branch to `sandboxEventSchema` (`{ type, sandboxId, timestamp, opencodeSessionId }`).
2. Validate replay events individually and drop unrecognized ones instead of failing the whole `subscribed` message, so a single unknown or legacy event can never wedge session hydration.

## Verification

- Added regression tests: a `ready` event parses; the `subscribed` replay keeps recognized events and drops unknown ones without failing.
- `@open-inspect/shared` test suite passes (304 tests); `typecheck` is clean for `shared`, `web`, and `control-plane`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new `"ready"` sandbox event.
  * Replay and history results now handle mixed event/item data more gracefully.

* **Bug Fixes**
  * Parsing no longer fails when replay or history payloads include unknown entries.
  * Valid events and items are preserved while unsupported ones are skipped automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->