### PR TITLE
perf(scheduler): parallelize automation child fan-out

### DIFF
--- a/packages/control-plane/src/scheduler/durable-object.test.ts
+++ b/packages/control-plane/src/scheduler/durable-object.test.ts
@@ -238,6 +238,14 @@ function promptCallCount(fetchMock: ReturnType<typeof vi.fn>): number {
   }).length;
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 function createEnv(overrides?: Partial<Env>): Env {
   const sessionStub = createMockSessionStub();
   return {
@@ -491,6 +499,65 @@ describe("SchedulerDO", () => {
       // Both children share the invocation id.
       expect(children[0].invocation_id).toBe(children[1].invocation_id);
       // Both launched.
+      expect(mockStore.updateRun).toHaveBeenCalledTimes(2);
+    });
+
+    it("starts later child launches before earlier child sessions finish initializing", async () => {
+      mockStore.getOverdueAutomations.mockResolvedValue([sampleAutomation]);
+      selectRepositories("auto-1", [
+        repositoryRow("auto-1", { repo_name: "web-app" }),
+        repositoryRow("auto-1", { repo_name: "api", base_branch: null }),
+      ]);
+
+      const firstInit = deferred<Response>();
+      const firstInitStarted = deferred<void>();
+      const secondInitStarted = deferred<void>();
+      let initCalls = 0;
+      const fetchMock = vi.fn(async (input: RequestInfo, _init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.url;
+        const path = new URL(url).pathname;
+
+        if (path === "/internal/init") {
+          initCalls++;
+          if (initCalls === 1) {
+            firstInitStarted.resolve();
+            return firstInit.promise;
+          }
+          if (initCalls === 2) {
+            secondInitStarted.resolve();
+          }
+          return Response.json({ status: "ok" });
+        }
+
+        if (path === "/internal/prompt") {
+          return Response.json({ messageId: "msg-1", status: "queued" });
+        }
+
+        return new Response("Not Found", { status: 404 });
+      });
+
+      const env = createEnv();
+      vi.mocked(env.SESSION.get).mockReturnValue({ fetch: fetchMock } as never);
+
+      const scheduler = createSchedulerDO(env);
+      const tickPromise = scheduler.fetch(
+        new Request("http://internal/internal/tick", { method: "POST" })
+      );
+
+      await firstInitStarted.promise;
+      const overlapped = await Promise.race([
+        secondInitStarted.promise.then(() => true),
+        new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 50)),
+      ]);
+
+      try {
+        expect(overlapped).toBe(true);
+      } finally {
+        firstInit.resolve(Response.json({ status: "ok" }));
+        await tickPromise;
+      }
+
+      expect(initCalls).toBe(2);
       expect(mockStore.updateRun).toHaveBeenCalledTimes(2);
     });
 

--- a/packages/control-plane/src/scheduler/durable-object.test.ts
+++ b/packages/control-plane/src/scheduler/durable-object.test.ts
@@ -511,7 +511,6 @@ describe("SchedulerDO", () => {
 
       const firstInit = deferred<Response>();
       const firstInitStarted = deferred<void>();
-      const secondInitStarted = deferred<void>();
       let initCalls = 0;
       const fetchMock = vi.fn(async (input: RequestInfo, _init?: RequestInit) => {
         const url = typeof input === "string" ? input : input.url;
@@ -522,9 +521,6 @@ describe("SchedulerDO", () => {
           if (initCalls === 1) {
             firstInitStarted.resolve();
             return firstInit.promise;
-          }
-          if (initCalls === 2) {
-            secondInitStarted.resolve();
           }
           return Response.json({ status: "ok" });
         }
@@ -545,13 +541,11 @@ describe("SchedulerDO", () => {
       );
 
       await firstInitStarted.promise;
-      const overlapped = await Promise.race([
-        secondInitStarted.promise.then(() => true),
-        new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 50)),
-      ]);
 
       try {
-        expect(overlapped).toBe(true);
+        await vi.waitFor(() => {
+          expect(initCalls).toBe(2);
+        });
       } finally {
         firstInit.resolve(Response.json({ status: "ok" }));
         await tickPromise;

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -64,6 +64,12 @@ const MAX_PER_TICK = 25;
  */
 const TICK_CHILD_LAUNCH_BUDGET = 50;
 
+/**
+ * Smooths Modal cold-start / warm-pool pressure for multi-repo fan-out. The
+ * maximum fan-out is 10 repositories, so this only caps the per-invocation spike.
+ */
+const AUTOMATION_LAUNCH_CONCURRENCY = 4;
+
 /** Threshold for detecting orphaned "starting" runs (5 minutes). */
 const ORPHAN_THRESHOLD_MS = 5 * 60 * 1000;
 
@@ -120,6 +126,26 @@ function badJsonRequest(message: string): Response {
     status: 400,
     headers: { "Content-Type": "application/json" },
   });
+}
+
+async function runWithBoundedConcurrency<T>(
+  items: T[],
+  concurrency: number,
+  run: (item: T) => Promise<void>
+): Promise<void> {
+  if (items.length === 0) return;
+
+  let cursor = 0;
+  const workerCount = Math.min(Math.max(concurrency, 1), items.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    for (;;) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      await run(items[index]);
+    }
+  });
+
+  await Promise.all(workers);
 }
 
 interface StartInvocationParams {
@@ -332,9 +358,7 @@ export class SchedulerDO extends DurableObject<Env> {
       return this.recordOverlapSkip(store, params, { advanceSchedule: false });
     }
 
-    let launched = 0;
-    for (const child of children) {
-      if (child.status !== "starting") continue;
+    const launchChild = async (child: AutomationRunRow): Promise<void> => {
       try {
         const { sessionId } = await this.createSessionForAutomationRun(automation, child);
         await this.sendPromptToSession(
@@ -350,7 +374,6 @@ export class SchedulerDO extends DurableObject<Env> {
         });
         child.status = "running";
         child.session_id = sessionId;
-        launched++;
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e);
         this.log.error("Failed to launch automation run", {
@@ -378,7 +401,11 @@ export class SchedulerDO extends DurableObject<Env> {
         child.status = "failed";
         child.failure_reason = message;
       }
-    }
+    };
+
+    const launchCandidates = children.filter((child) => child.status === "starting");
+    await runWithBoundedConcurrency(launchCandidates, AUTOMATION_LAUNCH_CONCURRENCY, launchChild);
+    const launched = launchCandidates.filter((child) => child.status === "running").length;
 
     // Pre-failed and launch-failed children have no callback coming — apply
     // the failure strike now (CAS-deduped). This is also the born-terminal

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -128,26 +128,6 @@ function badJsonRequest(message: string): Response {
   });
 }
 
-async function runWithBoundedConcurrency<T>(
-  items: T[],
-  concurrency: number,
-  run: (item: T) => Promise<void>
-): Promise<void> {
-  if (items.length === 0) return;
-
-  let cursor = 0;
-  const workerCount = Math.min(Math.max(concurrency, 1), items.length);
-  const workers = Array.from({ length: workerCount }, async () => {
-    for (;;) {
-      const index = cursor++;
-      if (index >= items.length) return;
-      await run(items[index]);
-    }
-  });
-
-  await Promise.all(workers);
-}
-
 interface StartInvocationParams {
   automation: AutomationRow;
   source: AutomationInvocationSource;
@@ -404,7 +384,17 @@ export class SchedulerDO extends DurableObject<Env> {
     };
 
     const launchCandidates = children.filter((child) => child.status === "starting");
-    await runWithBoundedConcurrency(launchCandidates, AUTOMATION_LAUNCH_CONCURRENCY, launchChild);
+    let nextLaunchIndex = 0;
+    const launchWorkerCount = Math.min(AUTOMATION_LAUNCH_CONCURRENCY, launchCandidates.length);
+    await Promise.all(
+      Array.from({ length: launchWorkerCount }, async () => {
+        for (;;) {
+          const child = launchCandidates[nextLaunchIndex++];
+          if (!child) return;
+          await launchChild(child);
+        }
+      })
+    );
     const launched = launchCandidates.filter((child) => child.status === "running").length;
 
     // Pre-failed and launch-failed children have no callback coming — apply


### PR DESCRIPTION
## Summary
- Adds a bounded local worker pool for automation child-session launches with concurrency 4.
- Keeps per-child failure handling inside each launch task and counts launched children from final running statuses.
- Adds a regression test proving a later child init begins while an earlier child is still pending.

## Concurrency Notes
- `createSessionForAutomationRun` is per-child: each call generates its own `sessionId`, uses the run repo snapshot, and initializes its own session.
- `sendPromptToSession` enqueues work per session, so prompt delivery remains isolated.
- `AutomationStore.updateRun` prepares SQL and params per call; concurrent updates target distinct run ids and do not reuse a shared mutable statement buffer.
- Each child object is only mutated by its own launch task; the pool only shares a cursor.

## Verification
- `npm test -w @open-inspect/control-plane`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint:fix`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bounded concurrency for child automation run launches (capped at 4 per start invocation) to smooth multi-repo fan-out spikes.

* **Bug Fixes**
  * Updated scheduler orchestration so later child sessions begin initialization while earlier ones are still blocked, improving parallel startup behavior and reliability.

* **Tests**
  * Added a unit test covering scheduler launch concurrency and confirmed both init requests and run updates occur as expected under blocked initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->