### PR TITLE
docs: fix contributing clone URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ contributing to the project.
 ## Getting Started
 
 1. Fork the repository
-2. Clone your fork: `git clone https://github.com/YOUR-USERNAME/open-inspect.git`
+2. Clone your fork: `git clone https://github.com/YOUR-USERNAME/background-agents.git`
 3. Run the setup script: `bash .openinspect/setup.sh`
 4. Create a branch for your changes: `git checkout -b feature/your-feature-name`
 


### PR DESCRIPTION
## Summary
- Updates the fork clone command in `CONTRIBUTING.md` to use `background-agents.git`.
- Fixes the broken `open-inspect.git` repository path reported in #890.

## Testing
- Not run; documentation-only change.

Closes #890

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/c0fe2862611b9d09cf3331cfec519eb6)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the getting started instructions to use the current repository URL for cloning the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->