### PR TITLE
Refactor repo resolvers to raise HttpError

### DIFF
--- a/packages/control-plane/src/router.create-session.test.ts
+++ b/packages/control-plane/src/router.create-session.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { generateInternalToken } from "./auth/internal";
 import { SessionIndexStore } from "./db/session-index";
 import { handleRequest } from "./router";
-import { resolveRepoOrError } from "./routes/shared";
+import { HttpError, resolveRepoOrError } from "./routes/shared";
 import { SessionInternalPaths } from "./session/contracts";
 
 vi.mock("./db/session-index", () => ({
@@ -192,6 +192,24 @@ describe("handleCreateSession D1 ordering", () => {
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({ error: "Invalid session request body" });
     expect(resolveRepoOrError).not.toHaveBeenCalled();
+  });
+
+  it("maps route HttpError failures through the central dispatch catch", async () => {
+    vi.mocked(resolveRepoOrError).mockRejectedValue(
+      new HttpError("Repository is not installed for the GitHub App", 404)
+    );
+
+    const initFetch = vi.fn(async () => Response.json({ status: "created" }));
+    const response = await createSessionRequest(createEnv(initFetch));
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: "Repository is not installed for the GitHub App",
+    });
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("x-request-id")).toBeTruthy();
+    expect(response.headers.get("x-trace-id")).toBeTruthy();
+    expect(initFetch).not.toHaveBeenCalled();
   });
 
   it("creates the D1 session index before initializing the SessionDO", async () => {

--- a/packages/control-plane/src/router.create-session.test.ts
+++ b/packages/control-plane/src/router.create-session.test.ts
@@ -106,6 +106,9 @@ describe("handleCreateSession D1 ordering", () => {
     const response = await createSessionRequest(createEnv(initFetch));
 
     expect(response.status).toBe(500);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("x-request-id")).toBeTruthy();
+    expect(response.headers.get("x-trace-id")).toBeTruthy();
     expect(create).toHaveBeenCalledOnce();
     expect(initFetch).not.toHaveBeenCalled();
   });

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -437,7 +437,7 @@ export async function handleRequest(
             error: e instanceof Error ? e : String(e),
             ...ctx.metrics.summarize(),
           });
-          return error("Internal server error", 500);
+          return withCorsAndTraceHeaders(error("Internal server error", 500), ctx);
         }
       }
 

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -14,7 +14,14 @@ import { createSessionRuntimeClient } from "./session/runtime-client";
 
 import { createRequestMetrics, instrumentD1 } from "./db/instrumented-d1";
 import { createLogger } from "./logger";
-import { type Route, type RequestContext, parsePattern, json, error } from "./routes/shared";
+import {
+  type Route,
+  type RequestContext,
+  parsePattern,
+  json,
+  error,
+  HttpError,
+} from "./routes/shared";
 import { integrationSettingsRoutes } from "./routes/integration-settings";
 import { modelPreferencesRoutes } from "./routes/model-preferences";
 import { reposRoutes } from "./routes/repos";
@@ -413,20 +420,25 @@ export async function handleRequest(
         response = await route.handler(request, instrumentedEnv, match, ctx);
         outcome = response.status >= 500 ? "error" : "success";
       } catch (e) {
-        const durationMs = Date.now() - startTime;
-        logger.error("http.request", {
-          event: "http.request",
-          request_id: ctx.request_id,
-          trace_id: ctx.trace_id,
-          http_method: method,
-          http_path: path,
-          http_status: 500,
-          duration_ms: durationMs,
-          outcome: "error",
-          error: e instanceof Error ? e : String(e),
-          ...ctx.metrics.summarize(),
-        });
-        return error("Internal server error", 500);
+        if (e instanceof HttpError) {
+          response = error(e.message, e.status);
+          outcome = e.status >= 500 ? "error" : "success";
+        } else {
+          const durationMs = Date.now() - startTime;
+          logger.error("http.request", {
+            event: "http.request",
+            request_id: ctx.request_id,
+            trace_id: ctx.trace_id,
+            http_method: method,
+            http_path: path,
+            http_status: 500,
+            duration_ms: durationMs,
+            outcome: "error",
+            error: e instanceof Error ? e : String(e),
+            ...ctx.metrics.summarize(),
+          });
+          return error("Internal server error", 500);
+        }
       }
 
       const durationMs = Date.now() - startTime;

--- a/packages/control-plane/src/routes/automations.ts
+++ b/packages/control-plane/src/routes/automations.ts
@@ -32,7 +32,6 @@ import { generateId } from "../auth/crypto";
 import { generateWebhookApiKey, hashApiKey, encryptSentrySecret } from "../auth/webhook-key";
 import { createLogger } from "../logger";
 import { automationRepositoriesInputSchema } from "@open-inspect/shared";
-import type { RepositoryAccessResult } from "../source-control";
 import {
   type Route,
   type RequestContext,
@@ -134,13 +133,13 @@ async function resolveRepositorySelection(
       resolveRepoOrError(env, repository.repoOwner, repository.repoName, ctx, logger)
     )
   );
-  const firstRejected = settled.find((result) => result.status === "rejected");
-  if (firstRejected?.status === "rejected") {
-    throw firstRejected.reason;
-  }
+  const resolved = settled.map((result) => {
+    if (result.status === "rejected") throw result.reason;
+    return result.value;
+  });
 
   return repositories.map((repository, index) => {
-    const access = (settled[index] as PromiseFulfilledResult<RepositoryAccessResult>).value;
+    const access = resolved[index];
     return {
       repo_owner: repository.repoOwner,
       repo_name: repository.repoName,

--- a/packages/control-plane/src/routes/automations.ts
+++ b/packages/control-plane/src/routes/automations.ts
@@ -128,17 +128,19 @@ async function resolveRepositorySelection(
   env: Env,
   repositories: NormalizedRepositoryInput[],
   ctx: RequestContext
-): Promise<AutomationRepositoryInsert[] | Response> {
-  const resolved = await Promise.all(
+): Promise<AutomationRepositoryInsert[]> {
+  const settled = await Promise.allSettled(
     repositories.map((repository) =>
       resolveRepoOrError(env, repository.repoOwner, repository.repoName, ctx, logger)
     )
   );
-  for (const result of resolved) {
-    if (result instanceof Response) return result;
+  const firstRejected = settled.find((result) => result.status === "rejected");
+  if (firstRejected?.status === "rejected") {
+    throw firstRejected.reason;
   }
+
   return repositories.map((repository, index) => {
-    const access = resolved[index] as RepositoryAccessResult;
+    const access = (settled[index] as PromiseFulfilledResult<RepositoryAccessResult>).value;
     return {
       repo_owner: repository.repoOwner,
       repo_name: repository.repoName,
@@ -332,7 +334,6 @@ async function handleCreateAutomation(
   }
 
   const newRepositories = await resolveRepositorySelection(env, requestedRepositories, ctx);
-  if (newRepositories instanceof Response) return newRepositories;
 
   // Compute next run (only for schedule triggers)
   const nextRunAt = isSchedule
@@ -582,7 +583,6 @@ async function handleUpdateAutomation(
       throw e;
     }
     const resolved = await resolveRepositorySelection(env, selection.repositories, ctx);
-    if (resolved instanceof Response) return resolved;
     replacementRepositories = resolved;
   }
 

--- a/packages/control-plane/src/routes/secrets.ts
+++ b/packages/control-plane/src/routes/secrets.ts
@@ -41,7 +41,6 @@ async function handleSetRepoSecrets(
   const { owner, name } = params;
 
   const resolved = await resolveRepoOrError(env, owner, name, ctx, logger);
-  if (resolved instanceof Response) return resolved;
 
   const body = await parseJsonBody<{ secrets?: Record<string, string> }>(request);
   if (body instanceof Response) return body;
@@ -116,7 +115,6 @@ async function handleListRepoSecrets(
   const { owner, name } = params;
 
   const resolved = await resolveRepoOrError(env, owner, name, ctx, logger);
-  if (resolved instanceof Response) return resolved;
 
   const store = new RepoSecretsStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
   const globalStore = new GlobalSecretsStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
@@ -187,7 +185,6 @@ async function handleDeleteRepoSecret(
   }
 
   const resolved = await resolveRepoOrError(env, owner, name, ctx, logger);
-  if (resolved instanceof Response) return resolved;
 
   const store = new RepoSecretsStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
 

--- a/packages/control-plane/src/routes/session-create.ts
+++ b/packages/control-plane/src/routes/session-create.ts
@@ -65,7 +65,6 @@ async function handleCreateSession(
     repoOwner = repositoryContext.repoOwner;
     repoName = repositoryContext.repoName;
     const resolved = await resolveRepoOrError(env, repoOwner, repoName, ctx, logger);
-    if (resolved instanceof Response) return resolved;
 
     repoId = resolved.repoId;
     defaultBranch = resolved.defaultBranch;

--- a/packages/control-plane/src/routes/shared.ts
+++ b/packages/control-plane/src/routes/shared.ts
@@ -62,6 +62,21 @@ export function error(message: string, status = 400): Response {
 }
 
 /**
+ * Raise from a route handler or helper to return an error response with a
+ * specific status. Mapped centrally in router.ts's dispatch catch to
+ * error(message, status), avoiding `| Response` plumbing in callers.
+ */
+export class HttpError extends Error {
+  constructor(
+    message: string,
+    readonly status: number
+  ) {
+    super(message);
+    this.name = "HttpError";
+  }
+}
+
+/**
  * Create a SourceControlProvider for use in Worker-level route handlers.
  * Cheap to construct (no I/O), so creating per-request is fine.
  */
@@ -112,7 +127,7 @@ export function extractRepoParams(
 
 /**
  * Resolve a repository via the SCM provider, returning the full
- * {@link RepositoryAccessResult} or an error Response.
+ * {@link RepositoryAccessResult} or raising an HttpError.
  *
  * Handles:
  * - Provider construction
@@ -126,14 +141,11 @@ export async function resolveRepoOrError(
   name: string,
   ctx: RequestContext,
   logger: Logger
-): Promise<RepositoryAccessResult | Response> {
+): Promise<RepositoryAccessResult> {
+  let resolved: RepositoryAccessResult | null = null;
   try {
     const provider = createRouteSourceControlProvider(env);
-    const resolved = await resolveInstalledRepo(provider, owner, name);
-    if (!resolved) {
-      return error("Repository is not installed for the GitHub App", 404);
-    }
-    return resolved;
+    resolved = await resolveInstalledRepo(provider, owner, name);
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
     logger.error("Failed to resolve repository", {
@@ -145,6 +157,10 @@ export async function resolveRepoOrError(
     });
     const isConfigError =
       e instanceof SourceControlProviderError && e.errorType === "permanent" && !e.httpStatus;
-    return error(isConfigError ? message : "Failed to resolve repository", 500);
+    throw new HttpError(isConfigError ? message : "Failed to resolve repository", 500);
   }
+  if (!resolved) {
+    throw new HttpError("Repository is not installed for the GitHub App", 404);
+  }
+  return resolved;
 }


### PR DESCRIPTION
## Summary
- Add `HttpError` and map it once in the central router dispatch catch while preserving fall-through logging and headers.
- Convert repo resolution helpers to return success types and throw on failures, including ordered `Promise.allSettled` handling for automation repository selection.
- Remove the seven direct resolver `instanceof Response` checks and add router coverage for 404 body plus CORS/trace headers.

## Validation
- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm test -w @open-inspect/control-plane`
- `npm run lint:fix -w @open-inspect/control-plane`
- `npm run lint:fix` fails because root ESLint descends into `worktrees/multi-repo-automations/` and reports 139 unrelated pre-existing errors there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repository resolution failures now map to the correct HTTP status and JSON error message (including not-found), with CORS and tracing/request-id headers preserved.
  * Session, automation, and secret endpoints no longer stop prematurely on repository lookup results and now handle failures consistently.
  * Automation repository selection now runs lookups concurrently while keeping input-order behavior for determining failures.
* **Tests**
  * Added coverage for error mapping behavior, ensuring expected status, message, and headers are returned and that downstream fetch is not called.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->