### PR TITLE
fix(modal): pin snapshot TTL and fall back on image-restore failure

### DIFF
--- a/packages/control-plane/src/db/repo-images.test.ts
+++ b/packages/control-plane/src/db/repo-images.test.ts
@@ -44,6 +44,8 @@ const QUERY_PATTERNS = {
   DELETE_SUPERSEDED: /^DELETE FROM repo_images WHERE id = \? AND status = 'superseded'$/,
   UPDATE_FAILED:
     /^UPDATE repo_images SET status = 'failed', error_message = \? WHERE id = \? AND provider = \? AND status = 'building'$/,
+  UPDATE_RESTORE_FAILED:
+    /^UPDATE repo_images SET status = 'failed', error_message = \? WHERE id = \? AND status = 'ready'$/,
   SELECT_LATEST_READY:
     /^SELECT ri\.\* FROM repo_images ri INNER JOIN repo_metadata rm ON ri\.repo_owner = rm\.repo_owner AND ri\.repo_name = rm\.repo_name WHERE ri\.repo_owner = \? AND ri\.repo_name = \?.*ORDER BY ri\.created_at DESC LIMIT 1$/,
   SELECT_STATUS:
@@ -446,6 +448,17 @@ class FakeD1Database {
       const [error, id, provider] = args as [string, string, string];
       const row = this.rows.get(id);
       if (row && row.provider === provider && row.status === "building") {
+        row.status = "failed";
+        row.error_message = error;
+        return { meta: { changes: 1 } };
+      }
+      return { meta: { changes: 0 } };
+    }
+
+    if (QUERY_PATTERNS.UPDATE_RESTORE_FAILED.test(normalized)) {
+      const [error, id] = args as [string, string];
+      const row = this.rows.get(id);
+      if (row && row.status === "ready") {
         row.status = "failed";
         row.error_message = error;
         return { meta: { changes: 1 } };
@@ -1076,6 +1089,58 @@ describe("RepoImageStore", () => {
       const status = await store.getStatus("acme", "repo");
       expect(status[0].status).toBe("failed");
       expect(status[0].error_message).toBe("setup failed");
+    });
+  });
+
+  describe("markRestoreFailed", () => {
+    const readyRow = (overrides: Partial<RepoImageRow> = {}): RepoImageRow => ({
+      id: "img-1",
+      repo_owner: "acme",
+      repo_name: "repo",
+      provider: "modal",
+      provider_session_id: null,
+      base_branch: "main",
+      provider_image_id: "im-modal-1",
+      status: "ready",
+      base_sha: "abc123",
+      build_duration_seconds: 10,
+      error_message: null,
+      callback_token_hash: null,
+      callback_token_expires_at: null,
+      callback_token_used_at: null,
+      created_at: 1000,
+      ...overrides,
+    });
+
+    it("flips a ready image to failed by id, removing it from selection", async () => {
+      db.setImageBuildEnabled("acme", "repo", true);
+      db.seedRow(readyRow());
+
+      await expect(store.getLatestReady("acme", "repo", "modal")).resolves.toMatchObject({
+        id: "img-1",
+      });
+
+      await expect(store.markRestoreFailed("img-1", "restore failed at spawn")).resolves.toBe(true);
+
+      await expect(store.getLatestReady("acme", "repo", "modal")).resolves.toBeNull();
+      const status = await store.getStatus("acme", "repo");
+      expect(status[0].status).toBe("failed");
+      expect(status[0].error_message).toBe("restore failed at spawn");
+    });
+
+    it("is a no-op for non-ready rows — building stays markBuildFailed's job", async () => {
+      db.seedRow(readyRow({ status: "building" }));
+
+      await expect(store.markRestoreFailed("img-1", "boom")).resolves.toBe(false);
+      const status = await store.getStatus("acme", "repo");
+      expect(status[0].status).toBe("building");
+    });
+
+    it("is idempotent under concurrent spawn failures", async () => {
+      db.seedRow(readyRow());
+
+      await expect(store.markRestoreFailed("img-1", "boom")).resolves.toBe(true);
+      await expect(store.markRestoreFailed("img-1", "boom")).resolves.toBe(false);
     });
   });
 

--- a/packages/control-plane/src/db/repo-images.ts
+++ b/packages/control-plane/src/db/repo-images.ts
@@ -485,6 +485,24 @@ export class RepoImageStore {
     return (result.meta?.changes ?? 0) > 0;
   }
 
+  /**
+   * Mark a ready image failed after the provider could not restore it at
+   * spawn time (e.g. the underlying snapshot expired provider-side). Guarded
+   * on status = 'ready': in-flight builds stay markBuildFailed's job, and
+   * concurrent spawn failures against the same image are idempotent. With the
+   * row failed, the cron's no-ready-image trigger rebuilds it.
+   */
+  async markRestoreFailed(imageId: string, error: string): Promise<boolean> {
+    const result = await this.db
+      .prepare(
+        "UPDATE repo_images SET status = 'failed', error_message = ? WHERE id = ? AND status = 'ready'"
+      )
+      .bind(error, imageId)
+      .run();
+
+    return (result.meta?.changes ?? 0) > 0;
+  }
+
   async getLatestReady(
     repoOwner: string,
     repoName: string,

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -79,7 +79,19 @@ export interface CreateSandboxResponse {
   codeServerPassword?: string;
   ttydUrl?: string;
   tunnelUrls?: Record<string, string>;
+  /**
+   * True when the requested repo image failed to restore (e.g. expired
+   * provider-side) and the sandbox booted from the base image instead.
+   */
+  imageRestoreFailed?: boolean;
 }
+
+/**
+ * Structured error code returned by the Modal restore endpoint when the
+ * snapshot image expired or was deleted provider-side. Mirrors the mapping of
+ * SnapshotRestoreError in modal-infra's web_api.py — keep the strings in sync.
+ */
+export const SNAPSHOT_RESTORE_FAILED_ERROR_CODE = "SNAPSHOT_RESTORE_FAILED";
 
 export interface RestoreSandboxRequest {
   snapshotImageId: string;
@@ -105,6 +117,8 @@ export interface RestoreSandboxResponse {
   sandboxId?: string;
   modalObjectId?: string;
   error?: string;
+  /** Structured failure code, e.g. SNAPSHOT_RESTORE_FAILED_ERROR_CODE. */
+  errorCode?: string;
   codeServerUrl?: string;
   codeServerPassword?: string;
   ttydUrl?: string;
@@ -167,6 +181,8 @@ interface ModalApiResponse<T> {
   success: boolean;
   data?: T;
   error?: string;
+  /** Structured failure code on error responses (e.g. SNAPSHOT_RESTORE_FAILED). */
+  error_code?: string;
 }
 
 /**
@@ -288,6 +304,7 @@ export class ModalClient {
         code_server_password?: string;
         ttyd_url?: string;
         tunnel_urls?: Record<string, string>;
+        image_restore_failed?: boolean;
       }>;
 
       if (!result.success || !result.data) {
@@ -304,6 +321,7 @@ export class ModalClient {
         codeServerPassword: result.data.code_server_password,
         ttydUrl: result.data.ttyd_url,
         tunnelUrls: result.data.tunnel_urls,
+        imageRestoreFailed: result.data.image_restore_failed ?? false,
       };
     } finally {
       log.info("modal.request", {
@@ -368,7 +386,11 @@ export class ModalClient {
       }>;
 
       if (!result.success) {
-        return { success: false, error: result.error || "Unknown restore error" };
+        return {
+          success: false,
+          error: result.error || "Unknown restore error",
+          errorCode: result.error_code,
+        };
       }
 
       outcome = "success";

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -477,9 +477,11 @@ describe("SandboxLifecycleManager", () => {
       };
       const repoImageLookup: RepoImageLookup = {
         getLatestReady: vi.fn(async () => ({
+          id: "row-1",
           provider_image_id: "repo-image-1",
           base_sha: "abc123",
         })),
+        markRestoreFailed: vi.fn(async () => true),
       };
 
       const manager = new SandboxLifecycleManager(
@@ -599,6 +601,76 @@ describe("SandboxLifecycleManager", () => {
 
       expect(provider.restoreFromSnapshot).toHaveBeenCalled();
       expect(provider.createSandbox).not.toHaveBeenCalled();
+    });
+
+    it("surfaces a user-legible error when the snapshot has expired", async () => {
+      const sandbox = createMockSandbox({
+        status: "stopped",
+        snapshot_image_id: "img-abc123",
+      });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const broadcaster = createMockBroadcaster();
+      const provider = createMockProvider({
+        restoreFromSnapshot: vi.fn(async () => ({
+          success: false,
+          error: "Snapshot image img-abc123 is no longer available",
+          errorCode: "SNAPSHOT_RESTORE_FAILED",
+        })),
+      });
+
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        broadcaster,
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      const errorMessage = broadcaster.messages.find(
+        (m) => (m as { type: string }).type === "sandbox_error"
+      ) as { error: string } | undefined;
+      expect(errorMessage?.error).toContain("expired");
+      expect(
+        storage.calls.some(
+          (c) => c.startsWith("setLastSpawnError:") && c.includes("expired") && !c.includes("null")
+        )
+      ).toBe(true);
+    });
+
+    it("keeps the provider error message for non-expiry restore failures", async () => {
+      const sandbox = createMockSandbox({
+        status: "stopped",
+        snapshot_image_id: "img-abc123",
+      });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const broadcaster = createMockBroadcaster();
+      const provider = createMockProvider({
+        restoreFromSnapshot: vi.fn(async () => ({
+          success: false,
+          error: "Modal API error: 500",
+        })),
+      });
+
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        broadcaster,
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      const errorMessage = broadcaster.messages.find(
+        (m) => (m as { type: string }).type === "sandbox_error"
+      ) as { error: string } | undefined;
+      expect(errorMessage?.error).toBe("Modal API error: 500");
     });
 
     it("schedules connecting timeout alarm after restore", async () => {
@@ -1693,9 +1765,11 @@ describe("SandboxLifecycleManager", () => {
 
       const repoImageLookup: RepoImageLookup = {
         getLatestReady: vi.fn(async () => ({
+          id: "row-abc123",
           provider_image_id: "img-abc123",
           base_sha: "sha-def456",
         })),
+        markRestoreFailed: vi.fn(async () => true),
       };
 
       const manager = new SandboxLifecycleManager(
@@ -1718,6 +1792,124 @@ describe("SandboxLifecycleManager", () => {
           repoImageSha: "sha-def456",
         })
       );
+      expect(repoImageLookup.markRestoreFailed).not.toHaveBeenCalled();
+    });
+
+    it("marks the ready row failed when the provider reports a restore failure", async () => {
+      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const provider = createMockProvider({
+        createSandbox: vi.fn(async (config: CreateSandboxConfig) => ({
+          sandboxId: config.sandboxId,
+          providerObjectId: "provider-obj-123",
+          status: "connecting",
+          createdAt: Date.now(),
+          imageRestoreFailed: true,
+        })),
+      });
+      const repoImageLookup: RepoImageLookup = {
+        getLatestReady: vi.fn(async () => ({
+          id: "row-abc123",
+          provider_image_id: "img-abc123",
+          base_sha: "sha-def456",
+        })),
+        markRestoreFailed: vi.fn(async () => true),
+      };
+
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig(),
+        {},
+        repoImageLookup
+      );
+
+      await manager.spawnSandbox();
+
+      expect(repoImageLookup.markRestoreFailed).toHaveBeenCalledWith(
+        "row-abc123",
+        expect.any(String)
+      );
+      // The spawn itself succeeded — the sandbox booted from base.
+      expect(storage.calls).toContain("updateSandboxStatus:connecting");
+    });
+
+    it("does not mark anything when the flag is set but no image was requested", async () => {
+      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const provider = createMockProvider({
+        createSandbox: vi.fn(async (config: CreateSandboxConfig) => ({
+          sandboxId: config.sandboxId,
+          providerObjectId: "provider-obj-123",
+          status: "connecting",
+          createdAt: Date.now(),
+          imageRestoreFailed: true,
+        })),
+      });
+      const repoImageLookup: RepoImageLookup = {
+        getLatestReady: vi.fn(async () => null),
+        markRestoreFailed: vi.fn(async () => true),
+      };
+
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig(),
+        {},
+        repoImageLookup
+      );
+
+      await manager.spawnSandbox();
+
+      expect(repoImageLookup.markRestoreFailed).not.toHaveBeenCalled();
+    });
+
+    it("continues the spawn when marking the restore failure throws", async () => {
+      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const provider = createMockProvider({
+        createSandbox: vi.fn(async (config: CreateSandboxConfig) => ({
+          sandboxId: config.sandboxId,
+          providerObjectId: "provider-obj-123",
+          status: "connecting",
+          createdAt: Date.now(),
+          imageRestoreFailed: true,
+        })),
+      });
+      const repoImageLookup: RepoImageLookup = {
+        getLatestReady: vi.fn(async () => ({
+          id: "row-abc123",
+          provider_image_id: "img-abc123",
+          base_sha: "sha-def456",
+        })),
+        markRestoreFailed: vi.fn(async () => {
+          throw new Error("D1 unavailable");
+        }),
+      };
+
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig(),
+        {},
+        repoImageLookup
+      );
+
+      await manager.spawnSandbox();
+
+      expect(storage.calls).toContain("updateSandboxStatus:connecting");
     });
 
     it("passes null repoImageId when no ready image exists", async () => {
@@ -1728,6 +1920,7 @@ describe("SandboxLifecycleManager", () => {
 
       const repoImageLookup: RepoImageLookup = {
         getLatestReady: vi.fn(async () => null),
+        markRestoreFailed: vi.fn(async () => true),
       };
 
       const manager = new SandboxLifecycleManager(
@@ -1762,6 +1955,7 @@ describe("SandboxLifecycleManager", () => {
         getLatestReady: vi.fn(async () => {
           throw new Error("D1 unavailable");
         }),
+        markRestoreFailed: vi.fn(async () => true),
       };
 
       const manager = new SandboxLifecycleManager(
@@ -1795,6 +1989,7 @@ describe("SandboxLifecycleManager", () => {
 
       const repoImageLookup: RepoImageLookup = {
         getLatestReady: vi.fn(async () => null),
+        markRestoreFailed: vi.fn(async () => true),
       };
 
       const manager = new SandboxLifecycleManager(

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -18,6 +18,7 @@ import {
 import type { SandboxStatus } from "../../types";
 import { sessionHasRepository, type SandboxRow, type SessionRow } from "../../session/types";
 import { SandboxProviderError, type SandboxProvider, type CreateSandboxConfig } from "../provider";
+import { SNAPSHOT_RESTORE_FAILED_ERROR_CODE } from "../client";
 import {
   evaluateCircuitBreaker,
   evaluateSpawnDecision,
@@ -218,7 +219,12 @@ export interface RepoImageLookup {
     repoOwner: string,
     repoName: string,
     baseBranch?: string
-  ): Promise<{ provider_image_id: string; base_sha: string } | null>;
+  ): Promise<{ id: string; provider_image_id: string; base_sha: string } | null>;
+  /**
+   * Mark a ready image failed after the provider could not restore it at
+   * spawn time, so the rebuild cron picks it up. Keyed by the D1 row id.
+   */
+  markRestoreFailed(imageId: string, error: string): Promise<boolean>;
 }
 
 // ==================== Slack Agent-Notify Lookup ====================
@@ -411,6 +417,7 @@ export class SandboxLifecycleManager {
       // Look up pre-built repo image (graceful fallback on failure)
       let repoImageId: string | null = null;
       let repoImageSha: string | null = null;
+      let repoImageRowId: string | null = null;
       if (hasRepository && this.repoImageLookup) {
         try {
           const repoImage = await this.repoImageLookup.getLatestReady(
@@ -421,6 +428,7 @@ export class SandboxLifecycleManager {
           if (repoImage) {
             repoImageId = repoImage.provider_image_id;
             repoImageSha = repoImage.base_sha;
+            repoImageRowId = repoImage.id;
             this.log.info("Using pre-built repo image", {
               provider_image_id: repoImageId,
               base_sha: repoImageSha,
@@ -469,6 +477,28 @@ export class SandboxLifecycleManager {
         sandbox_id: result.sandboxId,
         provider_object_id: result.providerObjectId,
       });
+
+      // The provider fell back to the base image because the repo image could
+      // not be restored (e.g. expired snapshot). The session boots fine, just
+      // slower; fail the D1 row so the rebuild cron replaces it.
+      if (result.imageRestoreFailed && repoImageRowId && this.repoImageLookup) {
+        this.log.warn("Repo image failed to restore at spawn; booted from base image", {
+          event: "sandbox.repo_image_restore_failed",
+          repo_image_row_id: repoImageRowId,
+          provider_image_id: repoImageId,
+        });
+        try {
+          await this.repoImageLookup.markRestoreFailed(
+            repoImageRowId,
+            "Provider could not restore the image at spawn (expired or deleted)"
+          );
+        } catch (e) {
+          this.log.warn("Failed to mark repo image restore failure", {
+            repo_image_row_id: repoImageRowId,
+            error: e instanceof Error ? e.message : String(e),
+          });
+        }
+      }
 
       if (result.providerObjectId) {
         this.storeAndBroadcastProviderObjectId(result.providerObjectId);
@@ -681,16 +711,20 @@ export class SandboxLifecycleManager {
       } else {
         this.log.error("Snapshot restore failed", {
           error: result.error,
+          error_code: result.errorCode,
           snapshot_image_id: snapshotImageId,
         });
-        this.storage.setLastSpawnError(
-          result.error || "Failed to restore from snapshot",
-          Date.now()
-        );
+        // An expired snapshot is unrecoverable (the filesystem state is gone) —
+        // tell the user that, not a generic spawn failure.
+        const restoreError =
+          result.errorCode === SNAPSHOT_RESTORE_FAILED_ERROR_CODE
+            ? "The saved session snapshot has expired and can no longer be restored. Start a new session to continue this work."
+            : result.error || "Failed to restore from snapshot";
+        this.storage.setLastSpawnError(restoreError, Date.now());
         this.storage.updateSandboxStatus("failed");
         this.broadcaster.broadcast({
           type: "sandbox_error",
-          error: result.error || "Failed to restore from snapshot",
+          error: restoreError,
         });
       }
     } catch (error) {

--- a/packages/control-plane/src/sandbox/provider.ts
+++ b/packages/control-plane/src/sandbox/provider.ts
@@ -97,6 +97,12 @@ export interface CreateSandboxResult {
   ttydUrl?: string;
   /** Tunnel URLs for extra ports (port -> URL mapping) */
   tunnelUrls?: Record<string, string>;
+  /**
+   * True when the requested repo image failed to restore (e.g. expired
+   * provider-side) and the sandbox booted from the base image instead. The
+   * lifecycle manager marks the image row failed so the cron rebuilds it.
+   */
+  imageRestoreFailed?: boolean;
 }
 
 /**
@@ -151,6 +157,8 @@ export interface RestoreResult {
   providerObjectId?: string;
   /** Error message if failed */
   error?: string;
+  /** Structured failure code (e.g. SNAPSHOT_RESTORE_FAILED_ERROR_CODE). */
+  errorCode?: string;
   /** Code-server tunnel URL (if available) */
   codeServerUrl?: string;
   /** Code-server password (if available) */

--- a/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
@@ -97,6 +97,48 @@ describe("ModalSandboxProvider", () => {
     });
   });
 
+  describe("restore-failure signal mapping", () => {
+    it("maps imageRestoreFailed through the createSandbox result", async () => {
+      const client = createMockModalClient({
+        createSandbox: vi.fn(
+          async (): Promise<CreateSandboxResponse> => ({
+            sandboxId: "sandbox-123",
+            modalObjectId: "modal-obj-123",
+            status: "created",
+            createdAt: Date.now(),
+            imageRestoreFailed: true,
+          })
+        ),
+      });
+      const provider = new ModalSandboxProvider(client);
+
+      const result = await provider.createSandbox(testConfig);
+
+      expect(result.imageRestoreFailed).toBe(true);
+    });
+
+    it("maps errorCode through the restoreFromSnapshot failure result", async () => {
+      const client = createMockModalClient({
+        restoreSandbox: vi.fn(
+          async (): Promise<RestoreSandboxResponse> => ({
+            success: false,
+            error: "Snapshot image im-1 is no longer available",
+            errorCode: "SNAPSHOT_RESTORE_FAILED",
+          })
+        ),
+      });
+      const provider = new ModalSandboxProvider(client);
+
+      const result = await provider.restoreFromSnapshot({
+        ...testConfig,
+        snapshotImageId: "im-1",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe("SNAPSHOT_RESTORE_FAILED");
+    });
+  });
+
   describe("error classification", () => {
     describe("transient errors", () => {
       it("classifies 'fetch failed' as transient", async () => {

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -121,6 +121,7 @@ export class ModalSandboxProvider implements SandboxProvider, ModalRepoImageBuil
         codeServerPassword: result.codeServerPassword,
         ttydUrl: result.ttydUrl,
         tunnelUrls: result.tunnelUrls,
+        imageRestoreFailed: result.imageRestoreFailed,
       };
     } catch (error) {
       throw this.classifyError("Failed to create sandbox", error);
@@ -169,6 +170,7 @@ export class ModalSandboxProvider implements SandboxProvider, ModalRepoImageBuil
       return {
         success: false,
         error: result.error || "Unknown restore error",
+        errorCode: result.errorCode,
       };
     } catch (error) {
       if (error instanceof ModalApiError) {

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -711,6 +711,7 @@ export class SessionDO extends DurableObject<Env> {
       repoImageLookup = {
         getLatestReady: (repoOwner, repoName, baseBranch) =>
           repoImageStore.getLatestReady(repoOwner, repoName, repoImageProvider, baseBranch),
+        markRestoreFailed: (imageId, error) => repoImageStore.markRestoreFailed(imageId, error),
       };
     }
 

--- a/packages/modal-infra/pyproject.toml
+++ b/packages/modal-infra/pyproject.toml
@@ -5,7 +5,7 @@ description = "Modal sandbox infrastructure for Open-Inspect coding agent"
 requires-python = ">=3.12"
 dependencies = [
     "open-inspect-sandbox-runtime",  # sibling package, resolved via [tool.uv.sources]
-    "modal>=1.4.3",  # Function.with_options() (per-call timeout override) requires >=1.4.3
+    "modal>=1.5.1",  # snapshot_filesystem(ttl=...) requires >=1.5; Function.with_options() >=1.4.3
     "httpx>=0.27.0",
     "websockets>=13.0",
     "pydantic>=2.0",

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -46,6 +46,22 @@ BUILD_FUNCTION_TIMEOUT_MARGIN_SECONDS = 300
 MAX_TUNNEL_PORTS = 10
 
 
+class SnapshotRestoreError(Exception):
+    """A session-snapshot image could not be restored (expired or deleted).
+
+    Unlike repo images, a session snapshot cannot fall back to the base image —
+    the workspace state it holds is unrecoverable — so this is surfaced as a
+    structured error (web_api maps it to error_code SNAPSHOT_RESTORE_FAILED).
+    """
+
+    def __init__(self, snapshot_id: str, cause: str = ""):
+        self.snapshot_id = snapshot_id
+        message = f"Snapshot image {snapshot_id} is no longer available"
+        if cause:
+            message = f"{message}: {cause}"
+        super().__init__(message)
+
+
 def build_function_timeout_seconds(build_timeout_seconds: int) -> int:
     """Modal function timeout for the build worker (build_repo_image).
 
@@ -130,6 +146,9 @@ class SandboxHandle:
     code_server_password: str | None = None
     ttyd_url: str | None = None  # proxy tunnel URL (not ttyd directly)
     tunnel_urls: dict[int, str] | None = None  # port -> tunnel URL mapping for extra ports
+    # True when a requested repo image could not be restored and the sandbox
+    # booted from the base image instead (control plane marks the row failed).
+    image_restore_failed: bool = False
 
     def get_logs(self) -> str:
         """Get sandbox logs."""
@@ -162,6 +181,25 @@ class SandboxManager:
     def _generate_code_server_password() -> str:
         """Generate a random code-server password."""
         return secrets.token_urlsafe(16)
+
+    @staticmethod
+    async def _hydrate_repo_image(repo_image_id: str) -> tuple[modal.Image, bool]:
+        """Resolve a repo image, falling back to the base image on failure.
+
+        Returns (image, restore_failed). Hydration is forced eagerly so an
+        expired/deleted image is detected here instead of failing the spawn.
+        """
+        try:
+            image = modal.Image.from_id(repo_image_id)
+            await image.hydrate.aio()
+            return image, False
+        except Exception as e:
+            log.warn(
+                "sandbox.repo_image_restore_failed",
+                repo_image_id=repo_image_id,
+                exc=e,
+            )
+            return base_image, True
 
     @staticmethod
     async def _resolve_tunnels(
@@ -444,12 +482,17 @@ class SandboxManager:
             env_vars["SESSION_CONFIG"] = config.session_config.model_dump_json()
 
         # Determine image to use (priority: session snapshot > repo image > base image)
+        # Repo images are probed eagerly (hydrate): Modal snapshots can expire
+        # provider-side while D1 still lists the image as ready, and an expired
+        # image must degrade to a slow base-image boot, not a spawn failure.
+        image_restore_failed = False
         if config.snapshot_id:
             image = modal.Image.from_registry(f"open-inspect-snapshot:{config.snapshot_id}")
         elif config.repo_image_id:
-            image = modal.Image.from_id(config.repo_image_id)
-            env_vars["FROM_REPO_IMAGE"] = "true"
-            env_vars["REPO_IMAGE_SHA"] = config.repo_image_sha or ""
+            image, image_restore_failed = await self._hydrate_repo_image(config.repo_image_id)
+            if not image_restore_failed:
+                env_vars["FROM_REPO_IMAGE"] = "true"
+                env_vars["REPO_IMAGE_SHA"] = config.repo_image_sha or ""
         else:
             image = base_image
 
@@ -481,12 +524,33 @@ class SandboxManager:
         if exposed_ports:
             create_kwargs["encrypted_ports"] = exposed_ports
 
-        sandbox = await modal.Sandbox.create.aio(
-            "python",
-            "-m",
-            "sandbox_runtime.entrypoint",  # Run the supervisor entrypoint
-            **create_kwargs,
-        )
+        try:
+            sandbox = await modal.Sandbox.create.aio(
+                "python",
+                "-m",
+                "sandbox_runtime.entrypoint",  # Run the supervisor entrypoint
+                **create_kwargs,
+            )
+        except Exception as e:
+            if env_vars.get("FROM_REPO_IMAGE") != "true":
+                raise
+            # Image expiry can surface at creation even when the hydrate probe
+            # passed; retry once on the base image rather than failing the spawn.
+            log.warn(
+                "sandbox.repo_image_create_failed",
+                repo_image_id=config.repo_image_id,
+                exc=e,
+            )
+            image_restore_failed = True
+            env_vars.pop("FROM_REPO_IMAGE", None)
+            env_vars.pop("REPO_IMAGE_SHA", None)
+            create_kwargs["image"] = base_image
+            sandbox = await modal.Sandbox.create.aio(
+                "python",
+                "-m",
+                "sandbox_runtime.entrypoint",
+                **create_kwargs,
+            )
 
         modal_object_id = sandbox.object_id
         code_server_url, ttyd_url, extra_tunnel_urls = await self._resolve_and_setup_tunnels(
@@ -521,6 +585,7 @@ class SandboxManager:
             code_server_password=code_server_password,
             ttyd_url=ttyd_url,
             tunnel_urls=extra_tunnel_urls,
+            image_restore_failed=image_restore_failed,
         )
 
     async def create_build_sandbox(
@@ -663,12 +728,13 @@ class SandboxManager:
 
         # Use Modal's native snapshot_filesystem() API
         # This returns an Image directly (not async)
+        # ttl=None opts out of Modal 1.5's 30-day default TTL: a session
+        # snapshot must not expire while the session row still references it.
         image = handle.modal_sandbox.snapshot_filesystem(
-            timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS
+            timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS, ttl=None
         )
 
         # The image object_id is the unique identifier for this snapshot
-        # Modal automatically stores the image and it persists indefinitely
         image_id = image.object_id
 
         duration_ms = int((time.time() - start_time) * 1000)
@@ -756,8 +822,14 @@ class SandboxManager:
             sandbox_name = f"{repo_owner}-{repo_name}" if has_repository else "no-repository"
             sandbox_id = f"sandbox-{sandbox_name}-{int(time.time() * 1000)}"
 
-        # Lookup the image by ID
-        image = modal.Image.from_id(snapshot_image_id)
+        # Lookup the image by ID, probing eagerly: snapshots taken before we
+        # pinned ttl=None can be expired provider-side, and that must surface
+        # as a structured error, not a generic sandbox-creation failure.
+        try:
+            image = modal.Image.from_id(snapshot_image_id)
+            await image.hydrate.aio()
+        except Exception as e:
+            raise SnapshotRestoreError(snapshot_image_id, str(e)) from e
 
         # Prepare environment variables (user vars first, system vars override)
         env_vars: dict[str, str] = {}
@@ -831,12 +903,16 @@ class SandboxManager:
         if exposed_ports:
             create_kwargs["encrypted_ports"] = exposed_ports
 
-        sandbox = await modal.Sandbox.create.aio(
-            "python",
-            "-m",
-            "sandbox_runtime.entrypoint",
-            **create_kwargs,
-        )
+        try:
+            sandbox = await modal.Sandbox.create.aio(
+                "python",
+                "-m",
+                "sandbox_runtime.entrypoint",
+                **create_kwargs,
+            )
+        except modal.exception.NotFoundError as e:
+            # Expiry the hydrate probe missed; classify it the same way.
+            raise SnapshotRestoreError(snapshot_image_id, str(e)) from e
 
         modal_object_id = sandbox.object_id
         code_server_url, ttyd_url, extra_tunnel_urls = await self._resolve_and_setup_tunnels(

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -193,7 +193,7 @@ class SandboxManager:
             image = modal.Image.from_id(repo_image_id)
             await image.hydrate.aio()
             return image, False
-        except Exception as e:
+        except modal.exception.NotFoundError as e:
             log.warn(
                 "sandbox.repo_image_restore_failed",
                 repo_image_id=repo_image_id,
@@ -531,7 +531,7 @@ class SandboxManager:
                 "sandbox_runtime.entrypoint",  # Run the supervisor entrypoint
                 **create_kwargs,
             )
-        except Exception as e:
+        except modal.exception.NotFoundError as e:
             if env_vars.get("FROM_REPO_IMAGE") != "true":
                 raise
             # Image expiry can surface at creation even when the hydrate probe
@@ -828,7 +828,7 @@ class SandboxManager:
         try:
             image = modal.Image.from_id(snapshot_image_id)
             await image.hydrate.aio()
-        except Exception as e:
+        except modal.exception.NotFoundError as e:
             raise SnapshotRestoreError(snapshot_image_id, str(e)) from e
 
         # Prepare environment variables (user vars first, system vars override)

--- a/packages/modal-infra/src/scheduler/image_builder.py
+++ b/packages/modal-infra/src/scheduler/image_builder.py
@@ -300,8 +300,10 @@ async def build_repo_image(
             raise BuildError(f"Build sandbox exited without completing (exit_code={exit_code})")
 
         # 4. Snapshot the running sandbox's filesystem
+        # ttl=None opts out of Modal 1.5's 30-day default TTL: a ready repo
+        # image for an idle repo must not expire out from under D1.
         image = await handle.modal_sandbox.snapshot_filesystem.aio(
-            timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS
+            timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS, ttl=None
         )
         provider_image_id = image.object_id
 

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -185,6 +185,9 @@ async def api_create_sandbox(
                 "code_server_password": handle.code_server_password,
                 "ttyd_url": handle.ttyd_url,
                 "tunnel_urls": handle.tunnel_urls,
+                # True when a requested repo image failed to restore and the
+                # sandbox booted from base — the control plane marks the row.
+                "image_restore_failed": bool(getattr(handle, "image_restore_failed", False)),
             },
         }
     except HTTPException as e:
@@ -447,9 +450,14 @@ async def api_restore_sandbox(
     if not snapshot_image_id:
         raise HTTPException(status_code=400, detail="snapshot_image_id is required")
 
-    try:
-        from .sandbox.manager import DEFAULT_SANDBOX_TIMEOUT_SECONDS, SandboxManager
+    # Imported before the try block so the except clause can name the error type.
+    from .sandbox.manager import (
+        DEFAULT_SANDBOX_TIMEOUT_SECONDS,
+        SandboxManager,
+        SnapshotRestoreError,
+    )
 
+    try:
         session_config = request.get("session_config", {})
         sandbox_id = request.get("sandbox_id")
         sandbox_auth_token = request.get("sandbox_auth_token", "")
@@ -498,6 +506,19 @@ async def api_restore_sandbox(
         outcome = "error"
         http_status = e.status_code
         raise
+    except SnapshotRestoreError as e:
+        # Snapshot expired or was deleted provider-side. Unlike repo images
+        # there is no fallback — surface a structured code so the control
+        # plane can fail the resume with a user-legible error.
+        outcome = "error"
+        http_status = 500
+        log.error("api.snapshot_restore_failed", exc=e, endpoint_name="api_restore_sandbox")
+        return {
+            "success": False,
+            "error": str(e),
+            "error_code": "SNAPSHOT_RESTORE_FAILED",
+            "snapshot_id": e.snapshot_id,
+        }
     except Exception as e:
         outcome = "error"
         http_status = 500

--- a/packages/modal-infra/tests/test_agent_slack_notify_env.py
+++ b/packages/modal-infra/tests/test_agent_slack_notify_env.py
@@ -96,6 +96,11 @@ class TestRestoreFromSnapshotAgentSlackNotify:
         class FakeImage:
             object_id = "img-123"
 
+            class hydrate:
+                @staticmethod
+                async def aio() -> None:
+                    return None
+
         monkeypatch.setattr("src.sandbox.manager.modal.Image.from_id", lambda *a, **k: FakeImage())
         _patch_create(monkeypatch, captured)
 
@@ -117,6 +122,11 @@ class TestRestoreFromSnapshotAgentSlackNotify:
 
         class FakeImage:
             object_id = "img-123"
+
+            class hydrate:
+                @staticmethod
+                async def aio() -> None:
+                    return None
 
         monkeypatch.setattr("src.sandbox.manager.modal.Image.from_id", lambda *a, **k: FakeImage())
         _patch_create(monkeypatch, captured)

--- a/packages/modal-infra/tests/test_code_server.py
+++ b/packages/modal-infra/tests/test_code_server.py
@@ -172,6 +172,11 @@ class TestRestoreSandboxCodeServer:
         class FakeImage:
             object_id = "img-123"
 
+            class hydrate:
+                @staticmethod
+                async def aio() -> None:
+                    return None
+
         def fake_from_id(*args, **kwargs):
             return FakeImage()
 
@@ -222,6 +227,11 @@ class TestRestoreSandboxCodeServer:
 
         class FakeImage:
             object_id = "img-123"
+
+            class hydrate:
+                @staticmethod
+                async def aio() -> None:
+                    return None
 
         def fake_from_id(*args, **kwargs):
             return FakeImage()

--- a/packages/modal-infra/tests/test_image_builder_v2.py
+++ b/packages/modal-infra/tests/test_image_builder_v2.py
@@ -399,7 +399,7 @@ class TestBuildRepoImage:
                 build_id="img-1",
             )
 
-        snapshot_aio.assert_awaited_once_with(timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS)
+        snapshot_aio.assert_awaited_once_with(timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS, ttl=None)
         terminate_aio.assert_awaited_once()
         callback.assert_awaited_once()
         callback_payload = callback.await_args.args[1]
@@ -490,7 +490,7 @@ class TestBuildRepoImage:
                 build_id="img-1",
             )
 
-        snapshot_aio.assert_awaited_once_with(timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS)
+        snapshot_aio.assert_awaited_once_with(timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS, ttl=None)
         terminate_aio.assert_awaited_once()
         callback.assert_awaited_once()
         failure_url, failure_payload = callback.await_args.args

--- a/packages/modal-infra/tests/test_image_restore_fallback.py
+++ b/packages/modal-infra/tests/test_image_restore_fallback.py
@@ -96,6 +96,16 @@ class TestRepoImageRestoreFallback:
         assert "REPO_IMAGE_SHA" not in captured[0]["env"]
 
     @pytest.mark.asyncio
+    async def test_generic_hydrate_failure_propagates(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.sandbox.manager.modal.Image.from_id",
+            lambda *_a, **_k: _fake_image(RuntimeError("modal unavailable")),
+        )
+
+        with pytest.raises(RuntimeError, match="modal unavailable"):
+            await SandboxManager().create_sandbox(_repo_image_config())
+
+    @pytest.mark.asyncio
     async def test_create_failure_on_repo_image_retries_with_base_image(self, monkeypatch):
         """Expiry can also surface at Sandbox.create — retry once on base."""
         captured: list = []
@@ -113,6 +123,20 @@ class TestRepoImageRestoreFallback:
         assert captured[1]["image"] is manager_module.base_image
         assert "FROM_REPO_IMAGE" not in captured[1]["env"]
         assert "REPO_IMAGE_SHA" not in captured[1]["env"]
+
+    @pytest.mark.asyncio
+    async def test_generic_create_failure_on_repo_image_propagates(self, monkeypatch):
+        captured: list = []
+        _patch_create(monkeypatch, captured, side_effects=[RuntimeError("quota exceeded")])
+        monkeypatch.setattr(
+            "src.sandbox.manager.modal.Image.from_id", lambda *_a, **_k: _fake_image()
+        )
+
+        with pytest.raises(RuntimeError, match="quota exceeded"):
+            await SandboxManager().create_sandbox(_repo_image_config())
+
+        assert len(captured) == 1
+        assert captured[0]["env"]["FROM_REPO_IMAGE"] == "true"
 
     @pytest.mark.asyncio
     async def test_create_failure_without_repo_image_propagates(self, monkeypatch):
@@ -147,6 +171,19 @@ class TestSnapshotRestoreFailure:
             )
 
         assert exc_info.value.snapshot_id == "im-snap-1"
+
+    @pytest.mark.asyncio
+    async def test_generic_hydrate_failure_propagates(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.sandbox.manager.modal.Image.from_id",
+            lambda *_a, **_k: _fake_image(RuntimeError("modal unavailable")),
+        )
+
+        with pytest.raises(RuntimeError, match="modal unavailable"):
+            await SandboxManager().restore_from_snapshot(
+                snapshot_image_id="im-snap-1",
+                session_config={"session_id": "s1", "repo_owner": "acme", "repo_name": "repo"},
+            )
 
     @pytest.mark.asyncio
     async def test_not_found_at_create_raises_structured_error(self, monkeypatch):

--- a/packages/modal-infra/tests/test_image_restore_fallback.py
+++ b/packages/modal-infra/tests/test_image_restore_fallback.py
@@ -1,0 +1,182 @@
+"""Tests for provider-image restore failure handling in SandboxManager.
+
+Modal filesystem snapshots carry a provider-side TTL (a 30-day default before
+we pinned ttl=None), so an image that D1 still considers `ready` can be gone at
+spawn time. Repo-image boots must degrade to the base image and flag the
+failure so the control plane can mark the row failed; session-snapshot restores
+cannot fall back silently (the filesystem state is unrecoverable) and must
+raise a structured error instead.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import modal
+import pytest
+
+from src.sandbox import manager as manager_module
+from src.sandbox.manager import SandboxConfig, SandboxManager, SnapshotRestoreError
+
+
+def _fake_image(hydrate_error: Exception | None = None) -> SimpleNamespace:
+    hydrate = MagicMock()
+    hydrate.aio = AsyncMock(side_effect=hydrate_error)
+    return SimpleNamespace(hydrate=hydrate)
+
+
+def _patch_create(monkeypatch, captured: list, side_effects: list | None = None) -> None:
+    """Patch modal.Sandbox.create to capture kwargs, optionally failing per call."""
+
+    call_index = {"n": 0}
+
+    async def fake_create_aio(*args, **kwargs):
+        captured.append(kwargs)
+        if side_effects and call_index["n"] < len(side_effects):
+            effect = side_effects[call_index["n"]]
+            call_index["n"] += 1
+            if isinstance(effect, Exception):
+                raise effect
+
+        class FakeSandbox:
+            object_id = "obj-123"
+            stdout = None
+
+        return FakeSandbox()
+
+    fake_create = MagicMock()
+    fake_create.aio = fake_create_aio
+    monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", fake_create)
+    monkeypatch.setattr(
+        SandboxManager,
+        "_resolve_and_setup_tunnels",
+        AsyncMock(return_value=(None, None, None)),
+    )
+
+
+def _repo_image_config() -> SandboxConfig:
+    return SandboxConfig(
+        repo_owner="acme",
+        repo_name="repo",
+        control_plane_url="https://cp.example.com",
+        sandbox_auth_token="token-123",
+        repo_image_id="im-ready-1",
+        repo_image_sha="abc123",
+    )
+
+
+class TestRepoImageRestoreFallback:
+    @pytest.mark.asyncio
+    async def test_healthy_repo_image_boots_with_flag_unset(self, monkeypatch):
+        captured: list = []
+        _patch_create(monkeypatch, captured)
+        image = _fake_image()
+        monkeypatch.setattr("src.sandbox.manager.modal.Image.from_id", lambda *_a, **_k: image)
+
+        handle = await SandboxManager().create_sandbox(_repo_image_config())
+
+        assert handle.image_restore_failed is False
+        assert captured[0]["env"]["FROM_REPO_IMAGE"] == "true"
+        assert captured[0]["env"]["REPO_IMAGE_SHA"] == "abc123"
+        assert captured[0]["image"] is image
+
+    @pytest.mark.asyncio
+    async def test_hydrate_failure_falls_back_to_base_image(self, monkeypatch):
+        captured: list = []
+        _patch_create(monkeypatch, captured)
+        monkeypatch.setattr(
+            "src.sandbox.manager.modal.Image.from_id",
+            lambda *_a, **_k: _fake_image(modal.exception.NotFoundError("image expired")),
+        )
+
+        handle = await SandboxManager().create_sandbox(_repo_image_config())
+
+        assert handle.image_restore_failed is True
+        assert captured[0]["image"] is manager_module.base_image
+        assert "FROM_REPO_IMAGE" not in captured[0]["env"]
+        assert "REPO_IMAGE_SHA" not in captured[0]["env"]
+
+    @pytest.mark.asyncio
+    async def test_create_failure_on_repo_image_retries_with_base_image(self, monkeypatch):
+        """Expiry can also surface at Sandbox.create — retry once on base."""
+        captured: list = []
+        _patch_create(
+            monkeypatch, captured, side_effects=[modal.exception.NotFoundError("image gone")]
+        )
+        image = _fake_image()
+        monkeypatch.setattr("src.sandbox.manager.modal.Image.from_id", lambda *_a, **_k: image)
+
+        handle = await SandboxManager().create_sandbox(_repo_image_config())
+
+        assert handle.image_restore_failed is True
+        assert len(captured) == 2
+        assert captured[0]["image"] is image
+        assert captured[1]["image"] is manager_module.base_image
+        assert "FROM_REPO_IMAGE" not in captured[1]["env"]
+        assert "REPO_IMAGE_SHA" not in captured[1]["env"]
+
+    @pytest.mark.asyncio
+    async def test_create_failure_without_repo_image_propagates(self, monkeypatch):
+        """The base-image retry is repo-image-only; other failures still raise."""
+        captured: list = []
+        _patch_create(monkeypatch, captured, side_effects=[RuntimeError("quota exceeded")])
+
+        with pytest.raises(RuntimeError):
+            await SandboxManager().create_sandbox(
+                SandboxConfig(
+                    repo_owner="acme",
+                    repo_name="repo",
+                    control_plane_url="https://cp.example.com",
+                    sandbox_auth_token="token-123",
+                )
+            )
+        assert len(captured) == 1
+
+
+class TestSnapshotRestoreFailure:
+    @pytest.mark.asyncio
+    async def test_hydrate_failure_raises_structured_error(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.sandbox.manager.modal.Image.from_id",
+            lambda *_a, **_k: _fake_image(modal.exception.NotFoundError("image expired")),
+        )
+
+        with pytest.raises(SnapshotRestoreError) as exc_info:
+            await SandboxManager().restore_from_snapshot(
+                snapshot_image_id="im-snap-1",
+                session_config={"session_id": "s1", "repo_owner": "acme", "repo_name": "repo"},
+            )
+
+        assert exc_info.value.snapshot_id == "im-snap-1"
+
+    @pytest.mark.asyncio
+    async def test_not_found_at_create_raises_structured_error(self, monkeypatch):
+        captured: list = []
+        _patch_create(
+            monkeypatch, captured, side_effects=[modal.exception.NotFoundError("image gone")]
+        )
+        monkeypatch.setattr(
+            "src.sandbox.manager.modal.Image.from_id", lambda *_a, **_k: _fake_image()
+        )
+
+        with pytest.raises(SnapshotRestoreError) as exc_info:
+            await SandboxManager().restore_from_snapshot(
+                snapshot_image_id="im-snap-1",
+                session_config={"session_id": "s1", "repo_owner": "acme", "repo_name": "repo"},
+            )
+
+        assert exc_info.value.snapshot_id == "im-snap-1"
+
+    @pytest.mark.asyncio
+    async def test_generic_create_failure_propagates_unchanged(self, monkeypatch):
+        """Only image-lookup failures classify as snapshot-restore errors."""
+        captured: list = []
+        _patch_create(monkeypatch, captured, side_effects=[RuntimeError("quota exceeded")])
+        monkeypatch.setattr(
+            "src.sandbox.manager.modal.Image.from_id", lambda *_a, **_k: _fake_image()
+        )
+
+        with pytest.raises(RuntimeError):
+            await SandboxManager().restore_from_snapshot(
+                snapshot_image_id="im-snap-1",
+                session_config={"session_id": "s1", "repo_owner": "acme", "repo_name": "repo"},
+            )

--- a/packages/modal-infra/tests/test_sandbox_env_vars.py
+++ b/packages/modal-infra/tests/test_sandbox_env_vars.py
@@ -109,6 +109,11 @@ async def test_restore_user_env_vars_override_order(monkeypatch):
     class FakeImage:
         object_id = "img-123"
 
+        class hydrate:
+            @staticmethod
+            async def aio() -> None:
+                return None
+
     def fake_from_id(*args, **kwargs):
         return FakeImage()
 
@@ -160,6 +165,11 @@ async def test_restore_uses_default_timeout(monkeypatch):
     class FakeImage:
         object_id = "img-123"
 
+        class hydrate:
+            @staticmethod
+            async def aio() -> None:
+                return None
+
     def fake_from_id(*args, **kwargs):
         return FakeImage()
 
@@ -198,6 +208,11 @@ async def test_restore_uses_custom_timeout(monkeypatch):
 
     class FakeImage:
         object_id = "img-123"
+
+        class hydrate:
+            @staticmethod
+            async def aio() -> None:
+                return None
 
     def fake_from_id(*args, **kwargs):
         return FakeImage()
@@ -239,6 +254,11 @@ async def test_create_and_restore_timeout_consistency(monkeypatch):
 
     class FakeImage:
         object_id = "img-123"
+
+        class hydrate:
+            @staticmethod
+            async def aio() -> None:
+                return None
 
     def fake_from_id(*args, **kwargs):
         return FakeImage()
@@ -298,6 +318,11 @@ def _fake_restore_setup(monkeypatch):
 
     class FakeImage:
         object_id = "img-123"
+
+        class hydrate:
+            @staticmethod
+            async def aio() -> None:
+                return None
 
     monkeypatch.setattr("src.sandbox.manager.modal.Image.from_id", lambda *a, **kw: FakeImage())
     monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", _fake_sandbox_create(captured))
@@ -464,6 +489,11 @@ async def test_repo_image_boot_omits_fallback_tokens(monkeypatch):
     class FakeImage:
         object_id = "repo-img-1"
 
+        class hydrate:
+            @staticmethod
+            async def aio() -> None:
+                return None
+
     monkeypatch.setattr("src.sandbox.manager.modal.Image.from_id", lambda *a, **kw: FakeImage())
     monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", _fake_sandbox_create(captured))
     monkeypatch.delenv("SCM_PROVIDER", raising=False)
@@ -492,6 +522,11 @@ async def test_repo_image_boot_preserves_user_github_cli_token(monkeypatch, toke
 
     class FakeImage:
         object_id = "repo-img-1"
+
+        class hydrate:
+            @staticmethod
+            async def aio() -> None:
+                return None
 
     monkeypatch.setattr("src.sandbox.manager.modal.Image.from_id", lambda *a, **kw: FakeImage())
     monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", _fake_sandbox_create(captured))
@@ -596,6 +631,11 @@ async def test_restore_no_repo_gets_host_scoping_without_tokens(monkeypatch):
     class FakeImage:
         object_id = "img-123"
 
+        class hydrate:
+            @staticmethod
+            async def aio() -> None:
+                return None
+
     monkeypatch.setattr("src.sandbox.manager.modal.Image.from_id", lambda *a, **kw: FakeImage())
     monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", _fake_sandbox_create(captured))
     monkeypatch.setenv("SCM_PROVIDER", "bitbucket")
@@ -634,6 +674,11 @@ async def test_restore_preserves_vcs_clone_token_for_legacy_snapshots(monkeypatc
     class FakeImage:
         object_id = "img-123"
 
+        class hydrate:
+            @staticmethod
+            async def aio() -> None:
+                return None
+
     monkeypatch.setattr("src.sandbox.manager.modal.Image.from_id", lambda *a, **kw: FakeImage())
     monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", _fake_sandbox_create(captured))
     monkeypatch.setenv("SCM_PROVIDER", "bitbucket")
@@ -670,6 +715,11 @@ async def test_restore_github_includes_gh_cli_aliases(monkeypatch):
     class FakeImage:
         object_id = "img-123"
 
+        class hydrate:
+            @staticmethod
+            async def aio() -> None:
+                return None
+
     monkeypatch.setattr("src.sandbox.manager.modal.Image.from_id", lambda *a, **kw: FakeImage())
     monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", _fake_sandbox_create(captured))
     monkeypatch.delenv("SCM_PROVIDER", raising=False)
@@ -704,6 +754,11 @@ async def test_no_repo_restore_omits_clone_token(monkeypatch):
 
     class FakeImage:
         object_id = "img-123"
+
+        class hydrate:
+            @staticmethod
+            async def aio() -> None:
+                return None
 
     monkeypatch.setattr("src.sandbox.manager.modal.Image.from_id", lambda *a, **kw: FakeImage())
     monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", _fake_sandbox_create(captured))

--- a/packages/modal-infra/tests/test_sandbox_resources.py
+++ b/packages/modal-infra/tests/test_sandbox_resources.py
@@ -94,6 +94,11 @@ class TestCreateSandboxResources:
         class FakeImage:
             object_id = "img-1"
 
+            class hydrate:
+                @staticmethod
+                async def aio() -> None:
+                    return None
+
         monkeypatch.setattr(
             "src.sandbox.manager.modal.Image.from_id", lambda *_a, **_kw: FakeImage()
         )

--- a/packages/modal-infra/tests/test_snapshot_timeout.py
+++ b/packages/modal-infra/tests/test_snapshot_timeout.py
@@ -11,8 +11,10 @@ from src.sandbox.manager import (
 )
 
 
-def test_take_snapshot_passes_explicit_timeout():
-    """Session snapshots should not rely on Modal's short default timeout."""
+def test_take_snapshot_passes_explicit_timeout_and_no_ttl():
+    """Session snapshots must not rely on Modal's short default timeout, and
+    must pin ttl=None: Modal 1.5 gave snapshots a 30-day default TTL with GC,
+    which would silently expire snapshots of long-idle sessions."""
     image = SimpleNamespace(object_id="im-session")
     snapshot_filesystem = MagicMock(return_value=image)
     handle = SandboxHandle(
@@ -25,4 +27,6 @@ def test_take_snapshot_passes_explicit_timeout():
     image_id = SandboxManager().take_snapshot(handle)
 
     assert image_id == "im-session"
-    snapshot_filesystem.assert_called_once_with(timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS)
+    snapshot_filesystem.assert_called_once_with(
+        timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS, ttl=None
+    )

--- a/packages/modal-infra/tests/test_ttyd.py
+++ b/packages/modal-infra/tests/test_ttyd.py
@@ -223,6 +223,11 @@ class TestRestoreSandboxTerminal:
         class FakeImage:
             object_id = "img-123"
 
+            class hydrate:
+                @staticmethod
+                async def aio() -> None:
+                    return None
+
         def fake_from_id(*args, **kwargs):
             return FakeImage()
 
@@ -272,6 +277,11 @@ class TestRestoreSandboxTerminal:
 
         class FakeImage:
             object_id = "img-123"
+
+            class hydrate:
+                @staticmethod
+                async def aio() -> None:
+                    return None
 
         def fake_from_id(*args, **kwargs):
             return FakeImage()

--- a/packages/modal-infra/tests/test_tunnel_ports.py
+++ b/packages/modal-infra/tests/test_tunnel_ports.py
@@ -446,6 +446,11 @@ class TestExpectedTunnelPortsEnvVar:
         class FakeImage:
             object_id = "img-1"
 
+            class hydrate:
+                @staticmethod
+                async def aio() -> None:
+                    return None
+
         async def fake_create_aio(*args, **kwargs):
             captured["env"] = kwargs.get("env") or {}
 

--- a/packages/modal-infra/tests/test_web_api_create_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_create_sandbox.py
@@ -292,3 +292,86 @@ async def test_restore_sandbox_rejects_partial_repo_context(monkeypatch, session
 
     assert getattr(exc_info.value, "status_code", None) == 400
     assert "repo_owner and repo_name must be provided together" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_reports_image_restore_failure(monkeypatch):
+    """The create response surfaces the repo-image fallback so the control
+    plane can mark the D1 row failed and the cron can rebuild."""
+    _patch_auth(monkeypatch)
+
+    class FakeManager:
+        async def create_sandbox(self, config):
+            return SimpleNamespace(
+                sandbox_id="sandbox-123",
+                modal_object_id="obj-123",
+                status=SandboxStatus.WARMING,
+                created_at=123.0,
+                code_server_url=None,
+                code_server_password=None,
+                ttyd_url=None,
+                tunnel_urls=None,
+                image_restore_failed=True,
+            )
+
+    monkeypatch.setattr(manager_module, "SandboxManager", FakeManager)
+
+    result = await _call_create_sandbox(
+        {
+            "session_id": "sess-1",
+            "repo_owner": "acme",
+            "repo_name": "repo",
+            "repo_image_id": "im-ready-1",
+            "control_plane_url": "https://control-plane.example",
+            "sandbox_auth_token": "sandbox-token",
+        }
+    )
+
+    assert result["success"] is True
+    assert result["data"]["image_restore_failed"] is True
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_image_restore_flag_defaults_false(monkeypatch):
+    captured = {}
+    _patch_auth(monkeypatch)
+    _patch_manager(monkeypatch, captured)
+
+    result = await _call_create_sandbox(
+        {
+            "session_id": "sess-1",
+            "repo_owner": "acme",
+            "repo_name": "repo",
+            "control_plane_url": "https://control-plane.example",
+            "sandbox_auth_token": "sandbox-token",
+        }
+    )
+
+    assert result["success"] is True
+    assert result["data"]["image_restore_failed"] is False
+
+
+@pytest.mark.asyncio
+async def test_restore_sandbox_reports_expired_snapshot(monkeypatch):
+    """An expired/deleted snapshot returns a structured error code — the
+    control plane must distinguish it from generic restore failures."""
+    _patch_auth(monkeypatch)
+
+    class FakeManager:
+        async def restore_from_snapshot(self, **kwargs):
+            raise manager_module.SnapshotRestoreError("im-snap-1", "image expired")
+
+    monkeypatch.setattr(manager_module, "SandboxManager", FakeManager)
+
+    result = await _call_restore_sandbox(
+        {
+            "snapshot_image_id": "im-snap-1",
+            "session_config": {"session_id": "s1", "repo_owner": "acme", "repo_name": "repo"},
+            "control_plane_url": "https://control-plane.example",
+            "sandbox_auth_token": "sandbox-token",
+        }
+    )
+
+    assert result["success"] is False
+    assert result["error_code"] == "SNAPSHOT_RESTORE_FAILED"
+    assert result["snapshot_id"] == "im-snap-1"

--- a/packages/modal-infra/uv.lock
+++ b/packages/modal-infra/uv.lock
@@ -617,7 +617,7 @@ wheels = [
 
 [[package]]
 name = "modal"
-version = "1.4.3"
+version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -634,9 +634,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/7d/4126d0fe879ef3e86002ca821a34cb68a2588ea2e8ccb2bfe421d0f42ffe/modal-1.4.3.tar.gz", hash = "sha256:35b2fc840f759b512e12527afb538e1ea4cc232b84cfbfcef3f5d96d5a66abaa", size = 720488, upload-time = "2026-05-18T22:34:45.842Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/56/a8d1a1dd705044e0c3534642361e8586db98908b683f8231b9fd39a86209/modal-1.5.1.tar.gz", hash = "sha256:f8fb7f4d3ccc5b774370704b1aabb79e629ea7e6681a7f9671af5cf77161be12", size = 801962, upload-time = "2026-06-23T15:44:18.853Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/54/400262056c144ceee5edab40efa2541ae8928ae5f244fd9025f3ad26c909/modal-1.4.3-py3-none-any.whl", hash = "sha256:802917181f576458a0cb833322157dab09c4f367326426c5a732661a0c519577", size = 826232, upload-time = "2026-05-18T22:34:43.335Z" },
+    { url = "https://files.pythonhosted.org/packages/85/67/c91cb2ee6cbae523ae051f5ecfebd9fc24518fb84b9e92859d32fbbe3a71/modal-1.5.1-py3-none-any.whl", hash = "sha256:49aeda1a4fafc71994c3aa63d3e2321419b586de0303113fa5bfc68f31ad5c95", size = 915761, upload-time = "2026-06-23T15:44:16.48Z" },
 ]
 
 [[package]]
@@ -806,7 +806,7 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.110.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "modal", specifier = ">=1.4.3" },
+    { name = "modal", specifier = ">=1.5.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14.0" },
     { name = "open-inspect-sandbox-runtime", editable = "../sandbox-runtime" },
     { name = "pydantic", specifier = ">=2.0" },


### PR DESCRIPTION
## Summary

Modal 1.5 (2026-06-09) gave `snapshot_filesystem()` a **30-day default TTL with automatic garbage collection** (`ttl: int | None = 2592000`). Neither of our snapshot call sites passes `ttl`, so once we run a ≥1.5 client, repo images of idle repos and session-snapshot resumes past 30 idle days silently expire — and an expired-but-`ready`-in-D1 image hard-fails sandbox creation instead of falling back. This is Phase 0 of the multi-repo sessions plan (`docs/multi-repo-sessions-implementation-plan.md`, PR-0) and is design-independent.

### Changes

**modal-infra** (bumps `modal>=1.5.1` — required for the `ttl=` parameter; `uv.lock` updated)
- `sandbox/manager.py` `take_snapshot` and `scheduler/image_builder.py` snapshot call now pass `ttl=None` — session snapshots and repo images must not expire while D1 references them.
- **Repo-image boots degrade instead of failing:** `create_sandbox` eagerly hydrates the repo image; on failure it boots the base image (no `FROM_REPO_IMAGE`) and reports `image_restore_failed: true` + the create-time `Sandbox.create` exception path retries once on base for repo-image boots.
- **Session-snapshot restores fail with a structured error** (no silent fallback — the filesystem state is unrecoverable): new `SnapshotRestoreError` maps to `{"error_code": "SNAPSHOT_RESTORE_FAILED", "snapshot_id": ...}` in `api_restore_sandbox`.

**control-plane**
- New `RepoImageStore.markRestoreFailed(imageId, error)` — flips a **ready** row to failed by id (guarded on `status = 'ready'`, idempotent under concurrent spawn failures). Note `markBuildFailed` only updates `status = 'building'` rows, so it is a silent no-op for this case — without the new method the expired image keeps being selected while suppressing rebuilds.
- Lifecycle manager threads `imageRestoreFailed` from the provider result and marks the selected row failed (spawn continues; the cron's no-ready-image trigger rebuilds).
- Restore path surfaces `SNAPSHOT_RESTORE_FAILED` as a user-legible "snapshot has expired" error instead of a generic spawn failure.

### Tests
- pytest (189 passed): `ttl=None` at both call sites; hydrate-failure fallback; create-time retry; base-path failures still propagate; `SnapshotRestoreError` classification; web_api response contracts.
- vitest (1530 passed): `markRestoreFailed` semantics (ready→failed, building untouched, idempotent); doSpawn marks the row on the flag (and survives a marking failure); restore error-code message mapping; modal-provider signal mapping.
- `npm run typecheck` + `npm run lint` clean.

### Deploy note
Ships alone. Existing ready images minted before the TTL took effect may already be past expiry — after deploy, run a one-off sweep: list enabled repos from `GET /repo-images/status` and `POST /repo-images/trigger/...` for any whose latest ready image predates the TTL window. (The runtime fallback also self-heals these on first spawn.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox creation now reports when a repo-image restore fallback occurred (sandbox boots from the base image).
  * Snapshot restore failures now return a structured error code for easier client handling.

* **Bug Fixes**
  * Snapshot restore errors now show a clearer “expired/unavailable” message when applicable, and preserve the original provider error otherwise.
  * Repo image restore failures are recorded reliably when a restore-spawn failure occurs, without blocking sandbox creation.
  * Snapshot-related images no longer expire unexpectedly due to default TTL behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->