### PR TITLE
feat(sandbox-runtime): list-native repo sync, hooks, manifest, push targeting

### DIFF
--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -46,8 +46,8 @@ TTYD_VERSION = "1.7.7"
 TTYD_SHA256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55"
 
 # Cache buster - change this to force Modal image rebuild
-# v51: SCM credential helper backed by control plane; remove embedded VCS tokens
-CACHE_BUSTER = "v52-bake-opencode-global-deps"
+# v52: bake opencode global deps
+CACHE_BUSTER = "v53-list-native-runtime"
 
 # Base image with all development tools
 base_image = (

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -22,7 +22,7 @@ import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, NoReturn
 
 import httpx
 import websockets
@@ -31,7 +31,7 @@ from websockets.exceptions import InvalidStatus
 
 from .constants import BOOT_WARNINGS_FILE_PATH, REPO_MANIFEST_FILE_PATH
 from .log_config import configure_logging, get_logger
-from .repo_config import load_repo_manifest
+from .repo_config import find_repo_entry, load_repo_manifest
 from .types import GitUser
 
 configure_logging()
@@ -56,6 +56,19 @@ class PushRequest:
     push_url: str
     redacted_push_url: str
     force: bool
+
+    @property
+    def has_repo_identity(self) -> bool:
+        """True when the spec names its target repository.
+
+        Owner and name always travel together — _validate_push_request
+        rejects partial identity before anything consults this.
+        """
+        return bool(self.repo_owner and self.repo_name)
+
+    @property
+    def repo_full_name(self) -> str:
+        return f"{self.repo_owner}/{self.repo_name}"
 
     def repo_fields(self) -> dict[str, Any]:
         """Repo identity echoed on push events when the spec carried it."""
@@ -1611,76 +1624,82 @@ class AgentBridge:
             force=bool(push_spec.get("force", False)) if push_spec else False,
         )
 
+    def _reject_push(self, *, reason: str, message: str, **log_fields: Any) -> NoReturn:
+        """Log a push rejection and raise it toward _handle_push's emitter."""
+        self.log.warn("git.push_error", reason=reason, **log_fields)
+        raise PushRejected(message)
+
     def _validate_push_request(
         self, push_spec: dict[str, Any] | None, request: PushRequest
     ) -> None:
         """Reject structurally unusable specs before touching the workspace."""
         if push_spec is None:
-            self.log.warn("git.push_error", reason="missing_push_spec")
-            raise PushRejected("Push failed - missing push specification")
-
+            self._reject_push(
+                reason="missing_push_spec",
+                message="Push failed - missing push specification",
+            )
         if bool(request.repo_owner) != bool(request.repo_name):
-            self.log.warn(
-                "git.push_error",
+            self._reject_push(
                 reason="partial_repo_identity",
+                message="Push failed - pushSpec must carry both repoOwner and repoName",
                 repo_owner=request.repo_owner,
                 repo_name=request.repo_name,
             )
-            raise PushRejected("Push failed - pushSpec must carry both repoOwner and repoName")
-
         if not request.branch_name:
-            self.log.warn("git.push_error", reason="missing_target_branch")
-            raise PushRejected("Push failed - missing target branch")
-
+            self._reject_push(
+                reason="missing_target_branch",
+                message="Push failed - missing target branch",
+            )
         if not request.refspec or not request.push_url:
-            self.log.warn("git.push_error", reason="invalid_push_spec")
-            raise PushRejected("Push failed - invalid push specification")
+            self._reject_push(
+                reason="invalid_push_spec",
+                message="Push failed - invalid push specification",
+            )
 
     def _resolve_push_checkout(self, request: PushRequest) -> Path:
-        """Resolve the checkout to push from.
+        """Pick the git checkout the push runs in."""
+        if request.has_repo_identity:
+            return self._member_checkout(request)
+        return self._sole_workspace_checkout()
 
-        A spec carrying repo identity targets that member through the
-        supervisor-written manifest — never by joining spec-supplied names
-        into the filesystem; a spec without one keeps the legacy behavior —
-        the sole cloned repository under /workspace.
+    def _member_checkout(self, request: PushRequest) -> Path:
+        """Checkout of the session member the spec names.
+
+        The identity is matched against the supervisor-written manifest and
+        the matched entry's path is used verbatim — spec-supplied strings
+        never become filesystem paths, so a crafted name cannot select a
+        checkout outside the session.
         """
-        if not request.repo_owner:
-            repo_dirs = list(self.repo_path.glob("*/.git"))
-            if not repo_dirs:
-                self.log.warn("git.push_error", reason="no_repo_configured")
-                raise PushRejected("No repository found")
-            return repo_dirs[0].parent
-
-        member = next(
-            (
-                entry
-                for entry in load_repo_manifest(self.repo_manifest_path)
-                if entry.owner.lower() == request.repo_owner.lower()
-                and entry.name.lower() == request.repo_name.lower()
-            ),
-            None,
+        member = find_repo_entry(
+            load_repo_manifest(self.repo_manifest_path),
+            request.repo_owner,
+            request.repo_name,
         )
         if member is None:
-            self.log.warn(
-                "git.push_error",
+            self._reject_push(
                 reason="repo_not_session_member",
+                message=f"Repository {request.repo_full_name} is not part of this session",
                 repo_owner=request.repo_owner,
                 repo_name=request.repo_name,
-            )
-            raise PushRejected(
-                f"Repository {request.repo_owner}/{request.repo_name} is not part of this session"
             )
         if not (member.path / ".git").exists():
-            self.log.warn(
-                "git.push_error",
+            self._reject_push(
                 reason="repo_not_in_workspace",
+                message=f"Repository {request.repo_full_name} not found in workspace",
                 repo_owner=request.repo_owner,
                 repo_name=request.repo_name,
             )
-            raise PushRejected(
-                f"Repository {request.repo_owner}/{request.repo_name} not found in workspace"
-            )
         return member.path
+
+    def _sole_workspace_checkout(self) -> Path:
+        """Checkout for a spec that names no repository (legacy control
+        planes, single-repo sessions): the one clone directly under
+        /workspace. Sorted only to be deterministic if that invariant is
+        ever violated."""
+        repo_dirs = sorted(self.repo_path.glob("*/.git"))
+        if not repo_dirs:
+            self._reject_push(reason="no_repo_configured", message="No repository found")
+        return repo_dirs[0].parent
 
     async def _run_git_push(self, request: PushRequest, repo_dir: Path) -> None:
         """Run git push in repo_dir; raises PushRejected on failure or timeout."""

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -60,9 +60,10 @@ class PushRequest:
     @classmethod
     def from_push_spec(cls, push_spec: dict[str, Any] | None) -> "PushRequest":
         """Normalize the raw spec; missing fields become ""/False, never errors."""
+        spec = push_spec or {}
 
         def field(key: str) -> str:
-            return str(push_spec.get(key, "")).strip() if push_spec else ""
+            return str(spec.get(key, "")).strip()
 
         return cls(
             branch_name=field("targetBranch"),
@@ -71,7 +72,7 @@ class PushRequest:
             refspec=field("refspec"),
             push_url=field("remoteUrl"),
             redacted_push_url=field("redactedRemoteUrl"),
-            force=bool(push_spec.get("force", False)) if push_spec else False,
+            force=bool(spec.get("force", False)),
         )
 
     @property
@@ -1598,7 +1599,7 @@ class AgentBridge:
         )
 
         try:
-            self._validate_push_request(push_spec, request)
+            self._validate_push_request(request, spec_present=push_spec is not None)
             repo_dir = self._resolve_push_checkout(request)
             await self._run_git_push(request, repo_dir)
         except PushRejected as rejection:
@@ -1629,11 +1630,9 @@ class AgentBridge:
         self.log.warn("git.push_error", reason=reason, **log_fields)
         raise PushRejected(message)
 
-    def _validate_push_request(
-        self, push_spec: dict[str, Any] | None, request: PushRequest
-    ) -> None:
+    def _validate_push_request(self, request: PushRequest, *, spec_present: bool) -> None:
         """Reject structurally unusable specs before touching the workspace."""
-        if push_spec is None:
+        if not spec_present:
             self._reject_push(
                 reason="missing_push_spec",
                 message="Push failed - missing push specification",

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -20,6 +20,7 @@ import subprocess
 import tempfile
 import time
 from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar
 
@@ -38,6 +39,40 @@ configure_logging()
 # Fallback git identity when prompt author has no SCM name/email configured.
 # Matches the co-author trailer used in generateCommitMessage (shared/git.ts).
 FALLBACK_GIT_USER = GitUser(name="OpenInspect", email="open-inspect@noreply.github.com")
+
+
+@dataclass(frozen=True)
+class PushRequest:
+    """The provider-generated push spec, normalized for execution.
+
+    Absent fields normalize to ""/False; _validate_push_request decides
+    which of those are fatal.
+    """
+
+    branch_name: str
+    repo_owner: str
+    repo_name: str
+    refspec: str
+    push_url: str
+    redacted_push_url: str
+    force: bool
+
+    def repo_fields(self) -> dict[str, Any]:
+        """Repo identity echoed on push events when the spec carried it."""
+        fields: dict[str, Any] = {}
+        if self.repo_owner:
+            fields["repoOwner"] = self.repo_owner
+        if self.repo_name:
+            fields["repoName"] = self.repo_name
+        return fields
+
+
+class PushRejected(Exception):
+    """A push that cannot proceed; str(exc) is the user-facing error message.
+
+    Raise sites log their own specific event first — this exception only
+    carries the message to the single push_error emitter in _handle_push.
+    """
 
 
 class OpenCodeIdentifier:
@@ -1515,272 +1550,226 @@ class AgentBridge:
         self.shutdown_event.set()
 
     async def _handle_push(self, cmd: dict[str, Any]) -> None:
-        """Handle push command using provider-generated push spec."""
+        """Handle push command using provider-generated push spec.
+
+        Pipeline: parse → validate → resolve checkout → run git push. Every
+        failure raises PushRejected (logged at the raise site) and lands in
+        the single push_error emitter below.
+        """
         push_spec = cmd.get("pushSpec") if isinstance(cmd.get("pushSpec"), dict) else None
-        branch_name = str(push_spec.get("targetBranch", "")).strip() if push_spec else ""
-        repo_owner = str(push_spec.get("repoOwner", "")).strip() if push_spec else ""
-        repo_name = str(push_spec.get("repoName", "")).strip() if push_spec else ""
+        request = self._parse_push_request(push_spec)
 
         self.log.info(
             "git.push_start",
-            branch_name=branch_name,
-            repo_owner=repo_owner,
-            repo_name=repo_name,
+            branch_name=request.branch_name,
+            repo_owner=request.repo_owner,
+            repo_name=request.repo_name,
             mode="push_spec",
         )
 
-        def _repo_fields() -> dict[str, Any]:
-            """Repo identity echoed on push events when the spec carried it."""
-            fields: dict[str, Any] = {}
-            if repo_owner:
-                fields["repoOwner"] = repo_owner
-            if repo_name:
-                fields["repoName"] = repo_name
-            return fields
+        try:
+            self._validate_push_request(push_spec, request)
+            repo_dir = self._resolve_push_checkout(request)
+            await self._run_git_push(request, repo_dir)
+        except PushRejected as rejection:
+            await self._send_push_error(str(rejection), request)
+            return
+        except Exception as e:
+            self.log.error("git.push_error", exc=e, branch_name=request.branch_name)
+            await self._send_push_error(str(e), request)
+            return
 
-        # Resolve the target checkout. A spec carrying repo identity targets
-        # that member through the supervisor-written manifest — never by
-        # joining spec-supplied names into the filesystem; a spec without one
-        # keeps the legacy behavior — the sole cloned repository under
-        # /workspace.
-        if repo_owner or repo_name:
-            if not (repo_owner and repo_name):
-                self.log.warn(
-                    "git.push_error",
-                    reason="partial_repo_identity",
-                    repo_owner=repo_owner,
-                    repo_name=repo_name,
-                )
-                await self._send_event(
-                    {
-                        "type": "push_error",
-                        "error": "Push failed - pushSpec must carry both repoOwner and repoName",
-                        "branchName": branch_name,
-                        **_repo_fields(),
-                        "timestamp": time.time(),
-                    }
-                )
-                return
-            member = next(
-                (
-                    entry
-                    for entry in load_repo_manifest(self.repo_manifest_path)
-                    if entry.owner.lower() == repo_owner.lower()
-                    and entry.name.lower() == repo_name.lower()
-                ),
-                None,
+        self.log.info(
+            "git.push_complete",
+            branch_name=request.branch_name,
+            repo_owner=request.repo_owner,
+            repo_name=request.repo_name,
+        )
+        await self._send_event(
+            {
+                "type": "push_complete",
+                "branchName": request.branch_name,
+                **request.repo_fields(),
+                "timestamp": time.time(),
+            }
+        )
+
+    @staticmethod
+    def _parse_push_request(push_spec: dict[str, Any] | None) -> PushRequest:
+        """Normalize the raw spec; missing fields become ""/False, never errors."""
+
+        def field(key: str) -> str:
+            return str(push_spec.get(key, "")).strip() if push_spec else ""
+
+        return PushRequest(
+            branch_name=field("targetBranch"),
+            repo_owner=field("repoOwner"),
+            repo_name=field("repoName"),
+            refspec=field("refspec"),
+            push_url=field("remoteUrl"),
+            redacted_push_url=field("redactedRemoteUrl"),
+            force=bool(push_spec.get("force", False)) if push_spec else False,
+        )
+
+    def _validate_push_request(
+        self, push_spec: dict[str, Any] | None, request: PushRequest
+    ) -> None:
+        """Reject structurally unusable specs before touching the workspace."""
+        if push_spec is None:
+            self.log.warn("git.push_error", reason="missing_push_spec")
+            raise PushRejected("Push failed - missing push specification")
+
+        if bool(request.repo_owner) != bool(request.repo_name):
+            self.log.warn(
+                "git.push_error",
+                reason="partial_repo_identity",
+                repo_owner=request.repo_owner,
+                repo_name=request.repo_name,
             )
-            if member is None:
-                self.log.warn(
-                    "git.push_error",
-                    reason="repo_not_session_member",
-                    repo_owner=repo_owner,
-                    repo_name=repo_name,
-                )
-                await self._send_event(
-                    {
-                        "type": "push_error",
-                        "error": (
-                            f"Repository {repo_owner}/{repo_name} is not part of this session"
-                        ),
-                        "branchName": branch_name,
-                        **_repo_fields(),
-                        "timestamp": time.time(),
-                    }
-                )
-                return
-            repo_dir = member.path
-            if not (repo_dir / ".git").exists():
-                self.log.warn(
-                    "git.push_error",
-                    reason="repo_not_in_workspace",
-                    repo_owner=repo_owner,
-                    repo_name=repo_name,
-                )
-                await self._send_event(
-                    {
-                        "type": "push_error",
-                        "error": f"Repository {repo_owner}/{repo_name} not found in workspace",
-                        "branchName": branch_name,
-                        **_repo_fields(),
-                        "timestamp": time.time(),
-                    }
-                )
-                return
-        else:
+            raise PushRejected("Push failed - pushSpec must carry both repoOwner and repoName")
+
+        if not request.branch_name:
+            self.log.warn("git.push_error", reason="missing_target_branch")
+            raise PushRejected("Push failed - missing target branch")
+
+        if not request.refspec or not request.push_url:
+            self.log.warn("git.push_error", reason="invalid_push_spec")
+            raise PushRejected("Push failed - invalid push specification")
+
+    def _resolve_push_checkout(self, request: PushRequest) -> Path:
+        """Resolve the checkout to push from.
+
+        A spec carrying repo identity targets that member through the
+        supervisor-written manifest — never by joining spec-supplied names
+        into the filesystem; a spec without one keeps the legacy behavior —
+        the sole cloned repository under /workspace.
+        """
+        if not request.repo_owner:
             repo_dirs = list(self.repo_path.glob("*/.git"))
             if not repo_dirs:
                 self.log.warn("git.push_error", reason="no_repo_configured")
-                await self._send_event(
-                    {
-                        "type": "push_error",
-                        "error": "No repository found",
-                        # Included (possibly empty) so the control plane can
-                        # resolve its pending push instead of leaking it.
-                        "branchName": branch_name,
-                        "timestamp": time.time(),
-                    }
-                )
-                return
-            repo_dir = repo_dirs[0].parent
+                raise PushRejected("No repository found")
+            return repo_dirs[0].parent
+
+        member = next(
+            (
+                entry
+                for entry in load_repo_manifest(self.repo_manifest_path)
+                if entry.owner.lower() == request.repo_owner.lower()
+                and entry.name.lower() == request.repo_name.lower()
+            ),
+            None,
+        )
+        if member is None:
+            self.log.warn(
+                "git.push_error",
+                reason="repo_not_session_member",
+                repo_owner=request.repo_owner,
+                repo_name=request.repo_name,
+            )
+            raise PushRejected(
+                f"Repository {request.repo_owner}/{request.repo_name} is not part of this session"
+            )
+        if not (member.path / ".git").exists():
+            self.log.warn(
+                "git.push_error",
+                reason="repo_not_in_workspace",
+                repo_owner=request.repo_owner,
+                repo_name=request.repo_name,
+            )
+            raise PushRejected(
+                f"Repository {request.repo_owner}/{request.repo_name} not found in workspace"
+            )
+        return member.path
+
+    async def _run_git_push(self, request: PushRequest, repo_dir: Path) -> None:
+        """Run git push in repo_dir; raises PushRejected on failure or timeout."""
+        self.log.info(
+            "git.push_command",
+            branch_name=request.branch_name,
+            refspec=request.refspec,
+            force=request.force,
+            remote_url=request.redacted_push_url,
+        )
+
+        process = await asyncio.create_subprocess_exec(
+            "git",
+            "push",
+            request.push_url,
+            request.refspec,
+            *(["-f"] if request.force else []),
+            cwd=repo_dir,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
 
         try:
-            if not push_spec:
-                self.log.warn("git.push_error", reason="missing_push_spec")
-                await self._send_event(
-                    {
-                        "type": "push_error",
-                        "error": "Push failed - missing push specification",
-                        "branchName": branch_name,
-                        "timestamp": time.time(),
-                    }
-                )
-                return
+            _stdout, stderr = await asyncio.wait_for(
+                process.communicate(),
+                timeout=self.GIT_PUSH_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            self.log.warn(
+                "git.push_timeout",
+                branch_name=request.branch_name,
+                timeout_ms=int(self.GIT_PUSH_TIMEOUT_SECONDS * 1000),
+            )
+            await self._terminate_push_process(process, request.branch_name)
+            raise PushRejected(
+                f"Push failed - git push timed out after {int(self.GIT_PUSH_TIMEOUT_SECONDS)}s"
+            ) from None
 
-            if not branch_name:
-                self.log.warn("git.push_error", reason="missing_target_branch")
-                await self._send_event(
-                    {
-                        "type": "push_error",
-                        "error": "Push failed - missing target branch",
-                        "branchName": "",
-                        **_repo_fields(),
-                        "timestamp": time.time(),
-                    }
-                )
-                return
+        if process.returncode != 0:
+            stderr_text = stderr.decode("utf-8", errors="replace").strip() if stderr else ""
+            redacted_stderr_text = self._redact_git_stderr(
+                stderr_text,
+                request.push_url,
+                request.redacted_push_url,
+            )
+            self.log.warn(
+                "git.push_failed",
+                branch_name=request.branch_name,
+                stderr=redacted_stderr_text,
+            )
+            raise PushRejected(
+                f"Push failed: {redacted_stderr_text}"
+                if redacted_stderr_text
+                else "Push failed - unknown error"
+            )
 
-            refspec = str(push_spec.get("refspec", "")).strip()
-            push_url = str(push_spec.get("remoteUrl", "")).strip()
-            redacted_push_url = str(push_spec.get("redactedRemoteUrl", "")).strip()
-            force_push = bool(push_spec.get("force", False))
-
-            if not refspec or not push_url:
-                self.log.warn("git.push_error", reason="invalid_push_spec")
-                await self._send_event(
-                    {
-                        "type": "push_error",
-                        "error": "Push failed - invalid push specification",
-                        "branchName": branch_name,
-                        **_repo_fields(),
-                        "timestamp": time.time(),
-                    }
-                )
-                return
-
-            self.log.info(
-                "git.push_command",
+    async def _terminate_push_process(
+        self, process: asyncio.subprocess.Process, branch_name: str
+    ) -> None:
+        """Terminate a hung git push, escalating to kill after a grace period."""
+        with contextlib.suppress(ProcessLookupError):
+            process.terminate()
+        try:
+            await asyncio.wait_for(
+                process.wait(),
+                timeout=self.GIT_PUSH_TERMINATE_GRACE_SECONDS,
+            )
+        except TimeoutError:
+            self.log.warn(
+                "git.push_kill",
                 branch_name=branch_name,
-                refspec=refspec,
-                force=force_push,
-                remote_url=redacted_push_url,
+                timeout_ms=int(self.GIT_PUSH_TERMINATE_GRACE_SECONDS * 1000),
             )
+            with contextlib.suppress(ProcessLookupError):
+                process.kill()
+            await process.wait()
 
-            result = await asyncio.create_subprocess_exec(
-                "git",
-                "push",
-                push_url,
-                refspec,
-                *(["-f"] if force_push else []),
-                cwd=repo_dir,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-
-            try:
-                _stdout, _stderr = await asyncio.wait_for(
-                    result.communicate(),
-                    timeout=self.GIT_PUSH_TIMEOUT_SECONDS,
-                )
-            except TimeoutError:
-                self.log.warn(
-                    "git.push_timeout",
-                    branch_name=branch_name,
-                    timeout_ms=int(self.GIT_PUSH_TIMEOUT_SECONDS * 1000),
-                )
-
-                with contextlib.suppress(ProcessLookupError):
-                    result.terminate()
-
-                try:
-                    await asyncio.wait_for(
-                        result.wait(),
-                        timeout=self.GIT_PUSH_TERMINATE_GRACE_SECONDS,
-                    )
-                except TimeoutError:
-                    self.log.warn(
-                        "git.push_kill",
-                        branch_name=branch_name,
-                        timeout_ms=int(self.GIT_PUSH_TERMINATE_GRACE_SECONDS * 1000),
-                    )
-                    with contextlib.suppress(ProcessLookupError):
-                        result.kill()
-                    await result.wait()
-
-                await self._send_event(
-                    {
-                        "type": "push_error",
-                        "error": (
-                            "Push failed - git push timed out "
-                            f"after {int(self.GIT_PUSH_TIMEOUT_SECONDS)}s"
-                        ),
-                        "branchName": branch_name,
-                        **_repo_fields(),
-                        "timestamp": time.time(),
-                    }
-                )
-                return
-
-            if result.returncode != 0:
-                stderr_text = _stderr.decode("utf-8", errors="replace").strip() if _stderr else ""
-                redacted_stderr_text = self._redact_git_stderr(
-                    stderr_text,
-                    push_url,
-                    redacted_push_url,
-                )
-                self.log.warn(
-                    "git.push_failed",
-                    branch_name=branch_name,
-                    stderr=redacted_stderr_text,
-                )
-                await self._send_event(
-                    {
-                        "type": "push_error",
-                        "error": f"Push failed: {redacted_stderr_text}"
-                        if redacted_stderr_text
-                        else "Push failed - unknown error",
-                        "branchName": branch_name,
-                        **_repo_fields(),
-                        "timestamp": time.time(),
-                    }
-                )
-            else:
-                self.log.info(
-                    "git.push_complete",
-                    branch_name=branch_name,
-                    repo_owner=repo_owner,
-                    repo_name=repo_name,
-                )
-                await self._send_event(
-                    {
-                        "type": "push_complete",
-                        "branchName": branch_name,
-                        **_repo_fields(),
-                        "timestamp": time.time(),
-                    }
-                )
-
-        except Exception as e:
-            self.log.error("git.push_error", exc=e, branch_name=branch_name)
-            await self._send_event(
-                {
-                    "type": "push_error",
-                    "error": str(e),
-                    "branchName": branch_name,
-                    **_repo_fields(),
-                    "timestamp": time.time(),
-                }
-            )
+    async def _send_push_error(self, error: str, request: PushRequest) -> None:
+        """Emit push_error. branchName is included even when empty so the
+        control plane can resolve its pending push instead of leaking it."""
+        await self._send_event(
+            {
+                "type": "push_error",
+                "error": error,
+                "branchName": request.branch_name,
+                **request.repo_fields(),
+                "timestamp": time.time(),
+            }
+        )
 
     async def _configure_git_identity(self, user: GitUser) -> None:
         """Configure git identity for commit attribution in every member checkout."""

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -28,6 +28,7 @@ import websockets
 from websockets import ClientConnection, State
 from websockets.exceptions import InvalidStatus
 
+from .constants import BOOT_WARNINGS_FILE_PATH
 from .log_config import configure_logging, get_logger
 from .types import GitUser
 
@@ -352,6 +353,8 @@ class AgentBridge:
                     }
                 )
 
+                await self._drain_boot_warnings()
+
                 just_flushed = await self._flush_event_buffer()
                 await self._flush_pending_acks(skip_ack_ids=just_flushed)
 
@@ -402,6 +405,35 @@ class AgentBridge:
                         "timestamp": time.time(),
                     }
                 )
+
+    async def _drain_boot_warnings(self) -> None:
+        """Forward supervisor boot warnings queued before the bridge existed.
+
+        The supervisor appends {scope, message, repoOwner?, repoName?} lines
+        (see BOOT_WARNINGS_FILE_PATH); each becomes a `warning` sandbox event.
+        The file is consumed exactly once — reconnects must not replay it.
+        """
+        path = Path(BOOT_WARNINGS_FILE_PATH)
+        if not path.exists():
+            return
+        try:
+            lines = path.read_text().splitlines()
+            path.unlink(missing_ok=True)
+        except Exception as e:
+            self.log.warn("bridge.boot_warnings_read_failed", exc=e)
+            return
+
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(entry, dict) or not entry.get("message"):
+                continue
+            await self._send_event({"type": "warning", **entry})
 
     async def _send_event(self, event: dict[str, Any]) -> None:
         """Send event to control plane, buffering if WS is unavailable."""
@@ -1481,26 +1513,64 @@ class AgentBridge:
         """Handle push command using provider-generated push spec."""
         push_spec = cmd.get("pushSpec") if isinstance(cmd.get("pushSpec"), dict) else None
         branch_name = str(push_spec.get("targetBranch", "")).strip() if push_spec else ""
+        repo_owner = str(push_spec.get("repoOwner", "")).strip() if push_spec else ""
+        repo_name = str(push_spec.get("repoName", "")).strip() if push_spec else ""
 
         self.log.info(
             "git.push_start",
             branch_name=branch_name,
+            repo_owner=repo_owner,
+            repo_name=repo_name,
             mode="push_spec",
         )
 
-        repo_dirs = list(self.repo_path.glob("*/.git"))
-        if not repo_dirs:
-            self.log.warn("git.push_error", reason="no_repo_configured")
-            await self._send_event(
-                {
-                    "type": "push_error",
-                    "error": "No repository found",
-                    "timestamp": time.time(),
-                }
-            )
-            return
+        def _repo_fields() -> dict[str, Any]:
+            """Repo identity echoed on push events when the spec carried it."""
+            fields: dict[str, Any] = {}
+            if repo_owner:
+                fields["repoOwner"] = repo_owner
+            if repo_name:
+                fields["repoName"] = repo_name
+            return fields
 
-        repo_dir = repo_dirs[0].parent
+        # Resolve the target checkout. A spec carrying repo identity targets
+        # that member directly (multi-repo sessions); a spec without one keeps
+        # the legacy behavior — the sole cloned repository under /workspace.
+        if repo_name:
+            repo_dir = self.repo_path / repo_name
+            if not (repo_dir / ".git").exists():
+                self.log.warn(
+                    "git.push_error",
+                    reason="repo_not_in_workspace",
+                    repo_owner=repo_owner,
+                    repo_name=repo_name,
+                )
+                await self._send_event(
+                    {
+                        "type": "push_error",
+                        "error": f"Repository {repo_owner}/{repo_name} not found in workspace",
+                        "branchName": branch_name,
+                        **_repo_fields(),
+                        "timestamp": time.time(),
+                    }
+                )
+                return
+        else:
+            repo_dirs = list(self.repo_path.glob("*/.git"))
+            if not repo_dirs:
+                self.log.warn("git.push_error", reason="no_repo_configured")
+                await self._send_event(
+                    {
+                        "type": "push_error",
+                        "error": "No repository found",
+                        # Included (possibly empty) so the control plane can
+                        # resolve its pending push instead of leaking it.
+                        "branchName": branch_name,
+                        "timestamp": time.time(),
+                    }
+                )
+                return
+            repo_dir = repo_dirs[0].parent
 
         try:
             if not push_spec:
@@ -1522,6 +1592,7 @@ class AgentBridge:
                         "type": "push_error",
                         "error": "Push failed - missing target branch",
                         "branchName": "",
+                        **_repo_fields(),
                         "timestamp": time.time(),
                     }
                 )
@@ -1539,6 +1610,7 @@ class AgentBridge:
                         "type": "push_error",
                         "error": "Push failed - invalid push specification",
                         "branchName": branch_name,
+                        **_repo_fields(),
                         "timestamp": time.time(),
                     }
                 )
@@ -1601,6 +1673,7 @@ class AgentBridge:
                             f"after {int(self.GIT_PUSH_TIMEOUT_SECONDS)}s"
                         ),
                         "branchName": branch_name,
+                        **_repo_fields(),
                         "timestamp": time.time(),
                     }
                 )
@@ -1625,15 +1698,22 @@ class AgentBridge:
                         if redacted_stderr_text
                         else "Push failed - unknown error",
                         "branchName": branch_name,
+                        **_repo_fields(),
                         "timestamp": time.time(),
                     }
                 )
             else:
-                self.log.info("git.push_complete", branch_name=branch_name)
+                self.log.info(
+                    "git.push_complete",
+                    branch_name=branch_name,
+                    repo_owner=repo_owner,
+                    repo_name=repo_name,
+                )
                 await self._send_event(
                     {
                         "type": "push_complete",
                         "branchName": branch_name,
+                        **_repo_fields(),
                         "timestamp": time.time(),
                     }
                 )
@@ -1645,12 +1725,13 @@ class AgentBridge:
                     "type": "push_error",
                     "error": str(e),
                     "branchName": branch_name,
+                    **_repo_fields(),
                     "timestamp": time.time(),
                 }
             )
 
     async def _configure_git_identity(self, user: GitUser) -> None:
-        """Configure git identity for commit attribution."""
+        """Configure git identity for commit attribution in every member checkout."""
         self.log.debug("git.identity_configure", git_name=user.name, git_email=user.email)
 
         repo_dirs = list(self.repo_path.glob("*/.git"))
@@ -1658,9 +1739,7 @@ class AgentBridge:
             self.log.debug("git.identity_skip", reason="no_repo_configured")
             return
 
-        repo_dir = repo_dirs[0].parent
-
-        async def _run_git_config(*args: str) -> None:
+        async def _run_git_config(repo_dir: Path, *args: str) -> None:
             cmd = ["git", "config", "--local", *args]
             process = await asyncio.create_subprocess_exec(
                 *cmd,
@@ -1693,8 +1772,10 @@ class AgentBridge:
                 )
 
         try:
-            await _run_git_config("user.name", user.name)
-            await _run_git_config("user.email", user.email)
+            for git_dir in repo_dirs:
+                repo_dir = git_dir.parent
+                await _run_git_config(repo_dir, "user.name", user.name)
+                await _run_git_config(repo_dir, "user.email", user.email)
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             self.log.error("git.identity_error", exc=e)
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -57,6 +57,23 @@ class PushRequest:
     redacted_push_url: str
     force: bool
 
+    @classmethod
+    def from_push_spec(cls, push_spec: dict[str, Any] | None) -> "PushRequest":
+        """Normalize the raw spec; missing fields become ""/False, never errors."""
+
+        def field(key: str) -> str:
+            return str(push_spec.get(key, "")).strip() if push_spec else ""
+
+        return cls(
+            branch_name=field("targetBranch"),
+            repo_owner=field("repoOwner"),
+            repo_name=field("repoName"),
+            refspec=field("refspec"),
+            push_url=field("remoteUrl"),
+            redacted_push_url=field("redactedRemoteUrl"),
+            force=bool(push_spec.get("force", False)) if push_spec else False,
+        )
+
     @property
     def has_repo_identity(self) -> bool:
         """True when the spec names its target repository.
@@ -1570,7 +1587,7 @@ class AgentBridge:
         the single push_error emitter below.
         """
         push_spec = cmd.get("pushSpec") if isinstance(cmd.get("pushSpec"), dict) else None
-        request = self._parse_push_request(push_spec)
+        request = PushRequest.from_push_spec(push_spec)
 
         self.log.info(
             "git.push_start",
@@ -1605,23 +1622,6 @@ class AgentBridge:
                 **request.repo_fields(),
                 "timestamp": time.time(),
             }
-        )
-
-    @staticmethod
-    def _parse_push_request(push_spec: dict[str, Any] | None) -> PushRequest:
-        """Normalize the raw spec; missing fields become ""/False, never errors."""
-
-        def field(key: str) -> str:
-            return str(push_spec.get(key, "")).strip() if push_spec else ""
-
-        return PushRequest(
-            branch_name=field("targetBranch"),
-            repo_owner=field("repoOwner"),
-            repo_name=field("repoName"),
-            refspec=field("refspec"),
-            push_url=field("remoteUrl"),
-            redacted_push_url=field("redactedRemoteUrl"),
-            force=bool(push_spec.get("force", False)) if push_spec else False,
         )
 
     def _reject_push(self, *, reason: str, message: str, **log_fields: Any) -> NoReturn:

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -28,8 +28,9 @@ import websockets
 from websockets import ClientConnection, State
 from websockets.exceptions import InvalidStatus
 
-from .constants import BOOT_WARNINGS_FILE_PATH
+from .constants import BOOT_WARNINGS_FILE_PATH, REPO_MANIFEST_FILE_PATH
 from .log_config import configure_logging, get_logger
+from .repo_config import load_repo_manifest
 from .types import GitUser
 
 configure_logging()
@@ -192,6 +193,10 @@ class AgentBridge:
         self.opencode_session_id: str | None = None
         self.session_id_file = Path(tempfile.gettempdir()) / "opencode-session-id"
         self.repo_path = Path("/workspace")
+        # Supervisor-written canonical repo manifest; push targeting resolves
+        # member checkout paths through it rather than joining spec-supplied
+        # names into the filesystem.
+        self.repo_manifest_path = Path(REPO_MANIFEST_FILE_PATH)
 
         # HTTP client for OpenCode API
         self.http_client: httpx.AsyncClient | None = None
@@ -1534,10 +1539,57 @@ class AgentBridge:
             return fields
 
         # Resolve the target checkout. A spec carrying repo identity targets
-        # that member directly (multi-repo sessions); a spec without one keeps
-        # the legacy behavior — the sole cloned repository under /workspace.
-        if repo_name:
-            repo_dir = self.repo_path / repo_name
+        # that member through the supervisor-written manifest — never by
+        # joining spec-supplied names into the filesystem; a spec without one
+        # keeps the legacy behavior — the sole cloned repository under
+        # /workspace.
+        if repo_owner or repo_name:
+            if not (repo_owner and repo_name):
+                self.log.warn(
+                    "git.push_error",
+                    reason="partial_repo_identity",
+                    repo_owner=repo_owner,
+                    repo_name=repo_name,
+                )
+                await self._send_event(
+                    {
+                        "type": "push_error",
+                        "error": "Push failed - pushSpec must carry both repoOwner and repoName",
+                        "branchName": branch_name,
+                        **_repo_fields(),
+                        "timestamp": time.time(),
+                    }
+                )
+                return
+            member = next(
+                (
+                    entry
+                    for entry in load_repo_manifest(self.repo_manifest_path)
+                    if entry.owner.lower() == repo_owner.lower()
+                    and entry.name.lower() == repo_name.lower()
+                ),
+                None,
+            )
+            if member is None:
+                self.log.warn(
+                    "git.push_error",
+                    reason="repo_not_session_member",
+                    repo_owner=repo_owner,
+                    repo_name=repo_name,
+                )
+                await self._send_event(
+                    {
+                        "type": "push_error",
+                        "error": (
+                            f"Repository {repo_owner}/{repo_name} is not part of this session"
+                        ),
+                        "branchName": branch_name,
+                        **_repo_fields(),
+                        "timestamp": time.time(),
+                    }
+                )
+                return
+            repo_dir = member.path
             if not (repo_dir / ".git").exists():
                 self.log.warn(
                     "git.push_error",

--- a/packages/sandbox-runtime/src/sandbox_runtime/constants.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/constants.py
@@ -20,3 +20,8 @@ TUNNEL_ENV_FILE_PATH = "/workspace/.tunnels.env"
 # Comma-separated tunnel ports the manager will resolve. Read by the entrypoint
 # to gate stale-file cleanup and the wait-for-fresh-URLs before start.sh.
 EXPECTED_TUNNEL_PORTS_ENV_VAR = "EXPECTED_TUNNEL_PORTS"
+
+# Boot warnings queued by the supervisor (which has no control-plane event
+# channel) and drained by the bridge as `warning` sandbox events after its
+# WebSocket handshake. JSONL: one {scope, message, repoOwner?, repoName?} per line.
+BOOT_WARNINGS_FILE_PATH = "/tmp/oi-boot-warnings.jsonl"

--- a/packages/sandbox-runtime/src/sandbox_runtime/constants.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/constants.py
@@ -25,3 +25,10 @@ EXPECTED_TUNNEL_PORTS_ENV_VAR = "EXPECTED_TUNNEL_PORTS"
 # channel) and drained by the bridge as `warning` sandbox events after its
 # WebSocket handshake. JSONL: one {scope, message, repoOwner?, repoName?} per line.
 BOOT_WARNINGS_FILE_PATH = "/tmp/oi-boot-warnings.jsonl"
+
+# Canonical repository manifest written by the supervisor before any child
+# process starts, rewritten on every boot. Consumed by the bridge (push
+# targeting) and the JS create-pull-request tool so the /workspace checkout
+# layout has a single owner. JSON: {"repositories": [{owner, name, branch,
+# path}]}. Mirrored as a string literal in plugins/inspect-plugin.js.
+REPO_MANIFEST_FILE_PATH = "/tmp/oi-repo-manifest.json"

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -18,7 +18,6 @@ import re
 import shutil
 import signal
 import time
-from dataclasses import dataclass
 from pathlib import Path
 
 import httpx
@@ -28,32 +27,19 @@ from .constants import (
     CODE_SERVER_PORT,
     CODE_SERVER_PORT_ENV_VAR,
     EXPECTED_TUNNEL_PORTS_ENV_VAR,
+    REPO_MANIFEST_FILE_PATH,
     TTYD_PORT,
     TTYD_PROXY_PORT,
     TTYD_PROXY_PORT_ENV_VAR,
     TUNNEL_ENV_FILE_PATH,
 )
 from .log_config import configure_logging, get_logger
+from .repo_config import RepoConfigError, RepoEntry, dump_repo_manifest, parse_repositories
 from .repo_image_callback import RepoImageBuildCallback
 
 configure_logging()
 
 BIN_INSTALL_DIR_ENV_VAR = "OPENINSPECT_BIN_INSTALL_DIR"
-
-
-@dataclass(frozen=True)
-class RepoEntry:
-    """One repository of the session workspace, in position order.
-
-    The first entry is the primary (mirrors REPO_OWNER/REPO_NAME); every
-    downstream code path iterates the list so single- and multi-repo sessions
-    share one shape.
-    """
-
-    owner: str
-    name: str
-    branch: str
-    path: Path
 
 
 def _port_from_env(env_var: str, default: int) -> int:
@@ -161,6 +147,7 @@ class SandboxSupervisor:
         # of truth; absent, a one-entry list is synthesized from the scalar
         # env so every downstream path iterates the same shape. repo_path
         # stays the primary's path (repositories[0] mirrors REPO_OWNER/NAME).
+        self.repo_config_error: str | None = None
         self.repositories = self._parse_repositories()
         self.is_multi_repo = len(self.repositories) > 1
 
@@ -179,38 +166,25 @@ class SandboxSupervisor:
         return self.session_config.get("branch") or "main"
 
     def _parse_repositories(self) -> list[RepoEntry]:
-        """Build the ordered repository list from SESSION_CONFIG or the scalar env."""
-        raw = self.session_config.get("repositories")
-        entries: list[RepoEntry] = []
-        if isinstance(raw, list):
-            for item in raw:
-                if not isinstance(item, dict):
-                    continue
-                owner = str(item.get("repo_owner") or "").strip()
-                name = str(item.get("repo_name") or "").strip()
-                if not owner or not name:
-                    continue
-                branch = str(item.get("branch") or "").strip() or "main"
-                entries.append(
-                    RepoEntry(
-                        owner=owner,
-                        name=name,
-                        branch=branch,
-                        path=self.workspace_path / name,
-                    )
-                )
-        if entries:
-            return entries
-        if self.has_repository:
-            return [
-                RepoEntry(
-                    owner=self.repo_owner,
-                    name=self.repo_name,
-                    branch=self.base_branch,
-                    path=self.repo_path,
-                )
-            ]
-        return []
+        """Build the ordered repository list, deferring config errors to run().
+
+        A RepoConfigError (unsafe or duplicate names — the checkout path
+        would escape /workspace or collide) cannot be reported from
+        __init__, so it is stashed and run() raises it through the normal
+        fatal-error path.
+        """
+        self.repo_config_error = None
+        try:
+            return parse_repositories(
+                self.session_config,
+                workspace_path=self.workspace_path,
+                scalar_owner=self.repo_owner if self.has_repository else "",
+                scalar_name=self.repo_name if self.has_repository else "",
+                scalar_branch=self.base_branch,
+            )
+        except RepoConfigError as e:
+            self.repo_config_error = str(e)
+            return []
 
     def _build_repo_url(self, repo: RepoEntry) -> str:
         """Build the plain HTTPS URL for a repository.
@@ -245,19 +219,25 @@ class SandboxSupervisor:
             repo_name=repo.name,
         )
 
-        result = await asyncio.create_subprocess_exec(
-            "git",
-            "clone",
-            "--depth",
-            str(self.CLONE_DEPTH_COMMITS),
-            "--branch",
-            repo.branch,
-            self._build_repo_url(repo),
-            str(repo.path),
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        _stdout, stderr = await result.communicate()
+        try:
+            result = await asyncio.create_subprocess_exec(
+                "git",
+                "clone",
+                "--depth",
+                str(self.CLONE_DEPTH_COMMITS),
+                "--branch",
+                repo.branch,
+                self._build_repo_url(repo),
+                str(repo.path),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _stdout, stderr = await result.communicate()
+        except Exception as e:
+            # Keep sync_repositories' partial-failure contract: an OSError
+            # here must surface as a failed member, not abort the gather.
+            self.log.error("git.clone_error", exc=e, repo_owner=repo.owner, repo_name=repo.name)
+            return False
 
         if result.returncode != 0:
             self.log.error(
@@ -576,6 +556,12 @@ class SandboxSupervisor:
             return
 
         dest_root = self.workspace_path / ".opencode"
+        # The merged tree is generated state: rebuild it from scratch so
+        # entries removed from a member (or a removed member) don't survive
+        # snapshot/repo-image boots. System tools and staged deps are
+        # re-installed after assembly on every boot.
+        if dest_root.exists():
+            shutil.rmtree(dest_root, ignore_errors=True)
         provenance: dict[str, RepoEntry] = {}
         for repo in self.repositories:
             src_root = repo.path / ".opencode"
@@ -608,6 +594,19 @@ class SandboxSupervisor:
                 file_count=len(provenance),
                 repo_count=len(self.repositories),
             )
+
+    def _write_repo_manifest(self) -> None:
+        """Write the machine-readable repository manifest.
+
+        The bridge (push targeting) and the JS create-pull-request tool
+        resolve checkout paths through this file instead of re-deriving the
+        /workspace layout. Written before any child process starts and
+        rewritten on every boot so a snapshot never carries a stale member set.
+        """
+        try:
+            Path(REPO_MANIFEST_FILE_PATH).write_text(dump_repo_manifest(self.repositories))
+        except Exception as e:
+            self.log.warn("supervisor.repo_manifest_write_failed", exc=e)
 
     def _write_workspace_manifest(self) -> None:
         """Write the generated /workspace/AGENTS.md for multi-repo sessions.
@@ -1731,6 +1730,15 @@ class SandboxSupervisor:
         head_sha = ""
         opencode_ready = False
         try:
+            # Refuse to boot on an untrusted repository config — unsafe or
+            # duplicate names would let checkout paths escape /workspace or
+            # collide. Raised here (not __init__) so the failure reaches the
+            # control plane through the normal fatal-error path.
+            if self.repo_config_error:
+                raise RuntimeError(f"invalid repository config: {self.repo_config_error}")
+
+            self._write_repo_manifest()
+
             # Phase 0: Make sure the git credential helper is configured
             # before any git operation. New images do this in /etc/gitconfig,
             # but snapshots/repo-images built before this migration won't.

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -559,9 +559,19 @@ class SandboxSupervisor:
         # The merged tree is generated state: rebuild it from scratch so
         # entries removed from a member (or a removed member) don't survive
         # snapshot/repo-image boots. System tools and staged deps are
-        # re-installed after assembly on every boot.
-        if dest_root.exists():
-            shutil.rmtree(dest_root, ignore_errors=True)
+        # re-installed after assembly on every boot. node_modules is spared:
+        # assembly never writes into it (member node_modules are skipped), so
+        # it's purely image-managed — deleting it would force
+        # _stage_opencode_deps to re-copy the whole module tree on every
+        # snapshot restore instead of taking its skip-if-present fast path.
+        if dest_root.is_dir():
+            for child in dest_root.iterdir():
+                if child.name == "node_modules":
+                    continue
+                if child.is_dir() and not child.is_symlink():
+                    shutil.rmtree(child, ignore_errors=True)
+                else:
+                    child.unlink(missing_ok=True)
         provenance: dict[str, RepoEntry] = {}
         for repo in self.repositories:
             src_root = repo.path / ".opencode"

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -178,8 +178,8 @@ class SandboxSupervisor:
             return parse_repositories(
                 self.session_config,
                 workspace_path=self.workspace_path,
-                scalar_owner=self.repo_owner if self.has_repository else "",
-                scalar_name=self.repo_name if self.has_repository else "",
+                scalar_owner=self.repo_owner,
+                scalar_name=self.repo_name,
                 scalar_branch=self.base_branch,
             )
         except RepoConfigError as e:

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -18,11 +18,13 @@ import re
 import shutil
 import signal
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 import httpx
 
 from .constants import (
+    BOOT_WARNINGS_FILE_PATH,
     CODE_SERVER_PORT,
     CODE_SERVER_PORT_ENV_VAR,
     EXPECTED_TUNNEL_PORTS_ENV_VAR,
@@ -37,6 +39,21 @@ from .repo_image_callback import RepoImageBuildCallback
 configure_logging()
 
 BIN_INSTALL_DIR_ENV_VAR = "OPENINSPECT_BIN_INSTALL_DIR"
+
+
+@dataclass(frozen=True)
+class RepoEntry:
+    """One repository of the session workspace, in position order.
+
+    The first entry is the primary (mirrors REPO_OWNER/REPO_NAME); every
+    downstream code path iterates the list so single- and multi-repo sessions
+    share one shape.
+    """
+
+    owner: str
+    name: str
+    branch: str
+    path: Path
 
 
 def _port_from_env(env_var: str, default: int) -> int:
@@ -140,6 +157,13 @@ class SandboxSupervisor:
         )
         self.session_id_file = Path("/tmp/opencode-session-id")
 
+        # Ordered repository list. SESSION_CONFIG.repositories is the source
+        # of truth; absent, a one-entry list is synthesized from the scalar
+        # env so every downstream path iterates the same shape. repo_path
+        # stays the primary's path (repositories[0] mirrors REPO_OWNER/NAME).
+        self.repositories = self._parse_repositories()
+        self.is_multi_repo = len(self.repositories) > 1
+
         # Logger
         session_id = self.session_config.get("session_id", "")
         self.log = get_logger(
@@ -154,13 +178,47 @@ class SandboxSupervisor:
         """The branch to clone/fetch — defaults to 'main'."""
         return self.session_config.get("branch") or "main"
 
-    def _build_repo_url(self) -> str:
-        """Build the plain HTTPS URL for the repository.
+    def _parse_repositories(self) -> list[RepoEntry]:
+        """Build the ordered repository list from SESSION_CONFIG or the scalar env."""
+        raw = self.session_config.get("repositories")
+        entries: list[RepoEntry] = []
+        if isinstance(raw, list):
+            for item in raw:
+                if not isinstance(item, dict):
+                    continue
+                owner = str(item.get("repo_owner") or "").strip()
+                name = str(item.get("repo_name") or "").strip()
+                if not owner or not name:
+                    continue
+                branch = str(item.get("branch") or "").strip() or "main"
+                entries.append(
+                    RepoEntry(
+                        owner=owner,
+                        name=name,
+                        branch=branch,
+                        path=self.workspace_path / name,
+                    )
+                )
+        if entries:
+            return entries
+        if self.has_repository:
+            return [
+                RepoEntry(
+                    owner=self.repo_owner,
+                    name=self.repo_name,
+                    branch=self.base_branch,
+                    path=self.repo_path,
+                )
+            ]
+        return []
+
+    def _build_repo_url(self, repo: RepoEntry) -> str:
+        """Build the plain HTTPS URL for a repository.
 
         Authentication is supplied per-request by the system git credential
         helper, so the remote URL itself never carries a secret.
         """
-        return f"https://{self.vcs_host}/{self.repo_owner}/{self.repo_name}.git"
+        return f"https://{self.vcs_host}/{repo.owner}/{repo.name}.git"
 
     def _redact_git_stderr(self, stderr_text: str) -> str:
         """Redact credential-bearing URLs from git stderr.
@@ -175,16 +233,16 @@ class SandboxSupervisor:
     # Git primitives
     # ------------------------------------------------------------------
 
-    async def _clone_repo(self) -> bool:
-        """Shallow-clone the repository.
+    async def _clone_repo(self, repo: RepoEntry) -> bool:
+        """Shallow-clone a repository.
 
         The remote URL is unauthenticated — the system-wide git credential
         helper supplies short-lived credentials per request.
         """
         self.log.info(
             "git.clone_start",
-            repo_owner=self.repo_owner,
-            repo_name=self.repo_name,
+            repo_owner=repo.owner,
+            repo_name=repo.name,
         )
 
         result = await asyncio.create_subprocess_exec(
@@ -193,9 +251,9 @@ class SandboxSupervisor:
             "--depth",
             str(self.CLONE_DEPTH_COMMITS),
             "--branch",
-            self.base_branch,
-            self._build_repo_url(),
-            str(self.repo_path),
+            repo.branch,
+            self._build_repo_url(repo),
+            str(repo.path),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -204,12 +262,14 @@ class SandboxSupervisor:
         if result.returncode != 0:
             self.log.error(
                 "git.clone_error",
+                repo_owner=repo.owner,
+                repo_name=repo.name,
                 stderr=self._redact_git_stderr(stderr.decode()),
                 exit_code=result.returncode,
             )
             return False
 
-        self.log.info("git.clone_complete", repo_path=str(self.repo_path))
+        self.log.info("git.clone_complete", repo_path=str(repo.path))
         return True
 
     async def _ensure_credential_helper_configured(self) -> None:
@@ -296,7 +356,7 @@ class SandboxSupervisor:
         except OSError as e:
             self.log.debug("gh_wrapper.install_failed", error=str(e))
 
-    async def _ensure_plain_origin(self) -> bool:
+    async def _ensure_plain_origin(self, repo: RepoEntry) -> bool:
         """Rewrite the `origin` remote to a credential-free HTTPS URL.
 
         Older workspaces/images (from before the credential-helper migration)
@@ -311,14 +371,14 @@ class SandboxSupervisor:
 
         Idempotent — safe to call on every boot.
         """
-        expected_url = self._build_repo_url()
+        expected_url = self._build_repo_url(repo)
         proc = await asyncio.create_subprocess_exec(
             "git",
             "remote",
             "set-url",
             "origin",
             expected_url,
-            cwd=self.repo_path,
+            cwd=repo.path,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -332,7 +392,7 @@ class SandboxSupervisor:
             return False
         return True
 
-    async def _fetch_branch(self, branch: str) -> bool:
+    async def _fetch_branch(self, repo: RepoEntry, branch: str) -> bool:
         """Fetch a branch with an explicit refspec.
 
         Uses an explicit refspec so that ``refs/remotes/origin/<branch>`` is
@@ -343,7 +403,7 @@ class SandboxSupervisor:
             "fetch",
             "origin",
             f"{branch}:refs/remotes/origin/{branch}",
-            cwd=self.repo_path,
+            cwd=repo.path,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -357,7 +417,7 @@ class SandboxSupervisor:
             return False
         return True
 
-    async def _checkout_branch(self, branch: str) -> bool:
+    async def _checkout_branch(self, repo: RepoEntry, branch: str) -> bool:
         """Create/reset a local branch to match the remote tip."""
         result = await asyncio.create_subprocess_exec(
             "git",
@@ -365,7 +425,7 @@ class SandboxSupervisor:
             "-B",
             branch,
             f"origin/{branch}",
-            cwd=self.repo_path,
+            cwd=repo.path,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -384,40 +444,41 @@ class SandboxSupervisor:
     # Git sync methods (compose the primitives above)
     # ------------------------------------------------------------------
 
-    async def _update_existing_repo(self) -> bool:
+    async def _update_existing_repo(self, repo: RepoEntry) -> bool:
         """Fetch the target branch and check it out in an existing repo.
 
         Used by both snapshot-restore and repo-image boot paths where the
         repository already exists on disk.
         """
-        if not self.has_repository:
-            self.log.info("git.update_skip", reason="no_repo_configured")
-            return True
-        if not self.repo_path.exists():
-            self.log.info("git.update_skip", reason="no_repo_path")
+        if not repo.path.exists():
+            self.log.info(
+                "git.update_skip",
+                reason="no_repo_path",
+                repo_owner=repo.owner,
+                repo_name=repo.name,
+            )
             return False
 
         try:
-            if not await self._ensure_plain_origin():
+            if not await self._ensure_plain_origin(repo):
                 return False
-            branch = self.base_branch
-            if not await self._fetch_branch(branch):
+            if not await self._fetch_branch(repo, repo.branch):
                 return False
-            return await self._checkout_branch(branch)
+            return await self._checkout_branch(repo, repo.branch)
         except Exception as e:
-            self.log.error("git.update_error", exc=e)
+            self.log.error("git.update_error", exc=e, repo_owner=repo.owner, repo_name=repo.name)
             return False
 
-    async def _get_head_sha(self) -> str:
-        """Return the HEAD SHA of the repo, or empty string on failure."""
-        if not self.repo_path.exists():
+    async def _get_head_sha(self, repo: RepoEntry) -> str:
+        """Return the HEAD SHA of a repo, or empty string on failure."""
+        if not repo.path.exists():
             return ""
         try:
             result = await asyncio.create_subprocess_exec(
                 "git",
                 "rev-parse",
                 "HEAD",
-                cwd=self.repo_path,
+                cwd=repo.path,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -428,31 +489,176 @@ class SandboxSupervisor:
             self.log.warn("git.rev_parse_error", error=str(e))
         return ""
 
-    async def perform_git_sync(self) -> bool:
-        """Clone repository if needed, then sync to the target branch.
+    async def _sync_repo(self, repo: RepoEntry) -> bool:
+        """Sync one repository: update in place when present, clone when missing.
 
-        Returns:
-            True if sync completed successfully, False otherwise.
+        The same rule serves every boot mode — a fresh boot clones, an
+        image/snapshot boot finds the path and fetches — so member count and
+        boot mode never multiply into special cases here. Failure policy is
+        the caller's (run()) job.
         """
         self.log.debug(
             "git.sync_start",
-            repo_owner=self.repo_owner,
-            repo_name=self.repo_name,
-            repo_path=str(self.repo_path),
+            repo_owner=repo.owner,
+            repo_name=repo.name,
+            repo_path=str(repo.path),
         )
-
-        if not self.has_repository:
-            self.log.info("git.skip_clone", reason="no_repo_configured")
-            return True
-
-        if not self.repo_path.exists():
-            if not self.repo_owner or not self.repo_name:
-                self.log.info("git.skip_clone", reason="no_repo_configured")
-                return True
-            if not await self._clone_repo():
+        if not repo.path.exists():
+            if not await self._clone_repo(repo):
                 return False
+        return await self._update_existing_repo(repo)
 
-        return await self._update_existing_repo()
+    async def sync_repositories(self) -> list[RepoEntry]:
+        """Sync all repositories concurrently; returns the members that failed."""
+        if not self.repositories:
+            self.log.info("git.skip_clone", reason="no_repo_configured")
+            return []
+
+        results = await asyncio.gather(*(self._sync_repo(repo) for repo in self.repositories))
+        return [repo for repo, ok in zip(self.repositories, results, strict=True) if not ok]
+
+    # ------------------------------------------------------------------
+    # Multi-repo workspace assembly
+    # ------------------------------------------------------------------
+
+    def _record_boot_warning(
+        self, *, scope: str, message: str, repo: RepoEntry | None = None
+    ) -> None:
+        """Queue a `warning` sandbox event for the bridge to forward on connect.
+
+        The supervisor has no control-plane event channel of its own (only the
+        fatal-error endpoint), and every boot warning happens before the
+        bridge exists — so warnings are appended to a file the bridge drains
+        after its WebSocket handshake.
+        """
+        entry: dict = {"scope": scope, "message": message}
+        if repo is not None:
+            entry["repoOwner"] = repo.owner
+            entry["repoName"] = repo.name
+        # `message` is a reserved LogRecord field — don't pass it as a log kwarg.
+        self.log.warn(
+            "supervisor.boot_warning",
+            scope=scope,
+            warning_message=message,
+            repo_owner=repo.owner if repo is not None else None,
+            repo_name=repo.name if repo is not None else None,
+        )
+        try:
+            with open(BOOT_WARNINGS_FILE_PATH, "a") as f:
+                f.write(json.dumps(entry) + "\n")
+        except Exception as e:
+            self.log.warn("supervisor.boot_warning_write_failed", exc=e)
+
+    def _opencode_workdir(self) -> Path:
+        """Root directory for OpenCode and code-server.
+
+        Single-repo sessions keep today's behavior (the repo itself when
+        cloned); multi-repo and repo-less sessions root at /workspace.
+        """
+        if (
+            len(self.repositories) == 1
+            and self.repo_path.exists()
+            and (self.repo_path / ".git").exists()
+        ):
+            return self.repo_path
+        return self.workspace_path
+
+    def _assemble_workspace_opencode(self) -> None:
+        """Merge member repos' .opencode/ into the workspace root (multi-repo only).
+
+        OpenCode discovers config relative to its cwd — /workspace for
+        multi-repo sessions — so per-repo custom tools/skills/commands would
+        never load. Files are copied in position order, last write wins with a
+        warning naming both members; the system tools installed afterwards
+        still override on filename collision (same as single-repo today).
+        """
+        if not self.is_multi_repo:
+            return
+
+        dest_root = self.workspace_path / ".opencode"
+        provenance: dict[str, RepoEntry] = {}
+        for repo in self.repositories:
+            src_root = repo.path / ".opencode"
+            if not src_root.is_dir():
+                continue
+            for src in sorted(src_root.rglob("*")):
+                if not src.is_file():
+                    continue
+                rel = src.relative_to(src_root)
+                if any(part in ("node_modules", "__pycache__") for part in rel.parts):
+                    continue
+                prior = provenance.get(str(rel))
+                if prior is not None:
+                    self._record_boot_warning(
+                        scope="assembly",
+                        repo=repo,
+                        message=(
+                            f".opencode/{rel} from {prior.owner}/{prior.name} is overridden "
+                            f"by {repo.owner}/{repo.name} (later repositories win)"
+                        ),
+                    )
+                dest = dest_root / rel
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dest)
+                provenance[str(rel)] = repo
+
+        if provenance:
+            self.log.info(
+                "opencode.workspace_assembled",
+                file_count=len(provenance),
+                repo_count=len(self.repositories),
+            )
+
+    def _write_workspace_manifest(self) -> None:
+        """Write the generated /workspace/AGENTS.md for multi-repo sessions.
+
+        Regenerated on every boot (restores included) so it always reflects
+        the session's member set; single-repo sessions are untouched.
+        """
+        if not self.is_multi_repo:
+            return
+
+        primary = self.repositories[0]
+        lines = [
+            "<!-- Generated by Open-Inspect on every boot. Do not edit. -->",
+            "",
+            "# Workspace",
+            "",
+            "This session spans multiple repositories, checked out side by side:",
+            "",
+            "| Path | Repository | Base branch |",
+            "| --- | --- | --- |",
+        ]
+        for repo in self.repositories:
+            lines.append(f"| `./{repo.name}/` | {repo.owner}/{repo.name} | `{repo.branch}` |")
+        lines.append("")
+
+        working_branch = str(self.session_config.get("working_branch_name") or "").strip()
+        if working_branch:
+            lines.append(f"All work happens on the branch `{working_branch}` in every repository.")
+            lines.append("")
+
+        member_docs = [repo for repo in self.repositories if (repo.path / "AGENTS.md").exists()]
+        if member_docs:
+            lines.append(
+                "Repository-specific instructions are NOT loaded automatically. "
+                "Read them before working in a repository:"
+            )
+            lines.append("")
+            lines.extend(f"- `./{repo.name}/AGENTS.md`" for repo in member_docs)
+            lines.append("")
+
+        lines.append(
+            "To open a pull request, call the `create-pull-request` tool once per repository "
+            f'with changes, passing its `repo` argument (e.g. `repo: "{primary.owner}/{primary.name}"`).'
+        )
+        lines.append("")
+
+        try:
+            (self.workspace_path / "AGENTS.md").write_text("\n".join(lines))
+            self.log.info("workspace.manifest_written", repo_count=len(self.repositories))
+        except Exception as e:
+            self.log.warn("workspace.manifest_write_failed", exc=e)
 
     def _install_tools(self, workdir: Path) -> None:
         """Copy custom tools into the .opencode/tool directory for OpenCode to discover."""
@@ -572,6 +778,7 @@ class SandboxSupervisor:
 
         The global seed is best-effort (degrades to a slower reify); the rest fail fast.
         """
+        self._assemble_workspace_opencode()
         self._install_tools(workdir)
         try:
             self._seed_global_opencode_deps()
@@ -672,10 +879,7 @@ class SandboxSupervisor:
             self.log.info("code_server.skip", reason="no_password")
             return
 
-        # Use repo path if cloned, otherwise /workspace
-        workdir = self.workspace_path
-        if self.repo_path.exists() and (self.repo_path / ".git").exists():
-            workdir = self.repo_path
+        workdir = self._opencode_workdir()
 
         code_server_port = _port_from_env(CODE_SERVER_PORT_ENV_VAR, CODE_SERVER_PORT)
         self.code_server_process = await asyncio.create_subprocess_exec(
@@ -925,10 +1129,9 @@ class SandboxSupervisor:
                 opencode_config["mcp"] = mcp_config
                 self.log.info("mcp.configured", count=len(mcp_config))
 
-        # Determine working directory - use repo path if cloned, otherwise /workspace
-        workdir = self.workspace_path
-        if self.repo_path.exists() and (self.repo_path / ".git").exists():
-            workdir = self.repo_path
+        # Working directory: the repo for single-repo sessions, /workspace
+        # for multi-repo (every member visible) and repo-less sessions.
+        workdir = self._opencode_workdir()
 
         self._prepare_opencode_filesystem(workdir)
 
@@ -1256,18 +1459,19 @@ class SandboxSupervisor:
     async def _run_hook(
         self,
         *,
+        repo: RepoEntry,
         hook_name: str,
         relative_script_path: str,
         timeout_env_var: str,
         default_timeout_seconds: int,
     ) -> bool:
         """
-        Run a repo hook script if present.
+        Run one repository's hook script if present.
 
         Returns:
             True if script succeeded or was not present, False on failure/timeout.
         """
-        script_path = self.repo_path / relative_script_path
+        script_path = repo.path / relative_script_path
         start_time = time.time()
 
         if not script_path.exists():
@@ -1287,6 +1491,8 @@ class SandboxSupervisor:
         self.log.info(
             f"{hook_name}.start",
             script=str(script_path),
+            repo_owner=repo.owner,
+            repo_name=repo.name,
             timeout_seconds=timeout_seconds,
             boot_mode=self.boot_mode,
         )
@@ -1295,7 +1501,7 @@ class SandboxSupervisor:
             process = await asyncio.create_subprocess_exec(
                 "bash",
                 str(script_path),
-                cwd=self.repo_path,
+                cwd=repo.path,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,
                 env=self._hook_env(),
@@ -1356,31 +1562,36 @@ class SandboxSupervisor:
             )
             return False
 
-    async def run_setup_script(self) -> bool:
+    async def run_setup_script(self, repo: RepoEntry) -> bool:
         """
-        Run .openinspect/setup.sh if it exists in the cloned repo.
+        Run one repository's .openinspect/setup.sh if it exists.
 
-        Fresh-session failures are non-fatal. Build mode callers may treat
-        failures as fatal.
+        Fatality is the caller's (run()) decision: build boots fail on any
+        member, fresh boots warn and continue.
 
         Returns:
             True if script succeeded or was not present, False on failure/timeout.
         """
         return await self._run_hook(
+            repo=repo,
             hook_name="setup",
             relative_script_path=self.SETUP_SCRIPT_PATH,
             timeout_env_var="SETUP_TIMEOUT_SECONDS",
             default_timeout_seconds=self.DEFAULT_SETUP_TIMEOUT_SECONDS,
         )
 
-    async def run_start_script(self) -> bool:
+    async def run_start_script(self, repo: RepoEntry) -> bool:
         """
-        Run .openinspect/start.sh if it exists in the repository.
+        Run one repository's .openinspect/start.sh if it exists.
+
+        Fatality is the caller's (run()) decision: the primary stays fatal,
+        secondaries warn and continue.
 
         Returns:
             True if script succeeded or was not present, False on failure/timeout.
         """
         return await self._run_hook(
+            repo=repo,
             hook_name="start",
             relative_script_path=self.START_SCRIPT_PATH,
             timeout_env_var="START_TIMEOUT_SECONDS",
@@ -1507,6 +1718,10 @@ class SandboxSupervisor:
         if restored_from_snapshot or expected_tunnel_ports:
             self._clear_stale_tunnel_env_file()
 
+        # Boot warnings are per-boot; a snapshot can carry the previous
+        # boot's file, so always start clean.
+        Path(BOOT_WARNINGS_FILE_PATH).unlink(missing_ok=True)
+
         # Set up signal handlers
         loop = asyncio.get_event_loop()
         for sig in (signal.SIGTERM, signal.SIGINT):
@@ -1519,44 +1734,88 @@ class SandboxSupervisor:
             # Phase 0: Make sure the git credential helper is configured
             # before any git operation. New images do this in /etc/gitconfig,
             # but snapshots/repo-images built before this migration won't.
-            if self.has_repository:
+            if self.repositories:
                 await self._ensure_credential_helper_configured()
 
-            # Phase 1: Git sync
-            if restored_from_snapshot:
-                git_sync_success = await self._update_existing_repo()
-                if not git_sync_success:
-                    self.log.warn(
-                        "git.snapshot_resync_failed",
-                        reason="origin rewrite or fetch failed; repo may be stale",
+            # Phase 1: Git sync — one per-repo rule for every boot mode
+            # (existing checkout → fetch/checkout, missing → clone). Only the
+            # failure policy differs: fresh and build boots cannot do useful
+            # work without every repository, so any failure is fatal
+            # (deliberate change — previously a fresh boot limped on
+            # repo-less); image/snapshot boots keep their leniency (a deleted
+            # upstream branch must not brick a resume).
+            failed_repos = await self.sync_repositories()
+            git_sync_success = not failed_repos
+            if failed_repos:
+                if self.boot_mode in ("fresh", "build"):
+                    failed_names = ", ".join(f"{r.owner}/{r.name}" for r in failed_repos)
+                    raise RuntimeError(f"git sync failed for {failed_names}")
+                for repo in failed_repos:
+                    self._record_boot_warning(
+                        scope="sync",
+                        repo=repo,
+                        message=(
+                            f"Could not update {repo.owner}/{repo.name} from origin; "
+                            "the checkout may be stale."
+                        ),
                     )
-            elif from_repo_image:
-                git_sync_success = await self._update_existing_repo()
-            else:
-                git_sync_success = await self.perform_git_sync()
-            if image_build_mode and git_sync_success:
-                head_sha = await self._get_head_sha()
+            if image_build_mode and git_sync_success and self.repositories:
+                head_sha = await self._get_head_sha(self.repositories[0])
                 if head_sha:
                     self.log.info("git.sync_complete", head_sha=head_sha)
             self.git_sync_complete.set()
 
-            # Phase 2: Run setup script only for fresh or build boots.
+            # Phase 2: Setup hooks, members in position order, only for fresh
+            # or build boots (prebuilt/snapshot boots ran them at build time).
+            # Build boots fail on the first failing member; fresh boots warn
+            # and continue.
             setup_success: bool | None = None
-            if self.has_repository and self.boot_mode in ("fresh", "build"):
-                setup_success = await self.run_setup_script()
-                if image_build_mode and not setup_success:
-                    raise RuntimeError("setup hook failed in build mode")
+            if self.repositories and self.boot_mode in ("fresh", "build"):
+                setup_success = True
+                for repo in self.repositories:
+                    if await self.run_setup_script(repo):
+                        continue
+                    setup_success = False
+                    if image_build_mode:
+                        raise RuntimeError(
+                            f"setup hook failed for {repo.owner}/{repo.name} in build mode"
+                        )
+                    self._record_boot_warning(
+                        scope="setup",
+                        repo=repo,
+                        message=(
+                            f"setup.sh failed for {repo.owner}/{repo.name}; "
+                            "the session continues without it."
+                        ),
+                    )
 
-            # Phase 3: Run runtime start hook for all non-build boots. Wait for
-            # tunnel URLs first so dev servers booted by start.sh see fresh data.
+            # Phase 3: Start hooks for all non-build boots, members in
+            # position order. The primary stays fatal (a broken primary dev
+            # server is a broken session); secondary failures warn and
+            # continue. Wait for tunnel URLs first so dev servers booted by
+            # start.sh see fresh data.
             start_success: bool | None = None
-            if self.has_repository and self.boot_mode != "build":
+            if self.repositories and self.boot_mode != "build":
                 await self._wait_for_tunnel_env_file(expected_tunnel_ports)
-                start_success = await self.run_start_script()
-                if not start_success:
-                    raise RuntimeError("start hook failed")
-            else:
-                start_success = None
+                start_success = True
+                for index, repo in enumerate(self.repositories):
+                    if await self.run_start_script(repo):
+                        continue
+                    start_success = False
+                    if index == 0:
+                        raise RuntimeError(f"start hook failed for {repo.owner}/{repo.name}")
+                    self._record_boot_warning(
+                        scope="start",
+                        repo=repo,
+                        message=(
+                            f"start.sh failed for {repo.owner}/{repo.name}; "
+                            "the session continues without it."
+                        ),
+                    )
+
+            # Multi-repo workspaces get a generated manifest at /workspace/
+            # AGENTS.md (regenerated every boot; no-op for single-repo).
+            self._write_workspace_manifest()
 
             # Image build mode: signal completion then keep sandbox alive for
             # snapshot_filesystem(). MCP packages are not pre-installed during

--- a/packages/sandbox-runtime/src/sandbox_runtime/plugins/inspect-plugin.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/plugins/inspect-plugin.js
@@ -45,9 +45,29 @@ function getSessionId() {
   }
 }
 
-async function getCurrentBranch() {
+// Ordered repository list from SESSION_CONFIG (empty for scalar sessions).
+function getRepositories() {
   try {
-    const { stdout } = await execFileAsync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+    const config = JSON.parse(process.env.SESSION_CONFIG || "{}");
+    const repositories = Array.isArray(config.repositories) ? config.repositories : [];
+    return repositories
+      .map((entry) => ({
+        owner: String(entry?.repo_owner || "").trim(),
+        name: String(entry?.repo_name || "").trim(),
+      }))
+      .filter((entry) => entry.owner && entry.name);
+  } catch (e) {
+    console.log("[create-pull-request] Failed to parse SESSION_CONFIG repositories:", e.message);
+    return [];
+  }
+}
+
+async function getCurrentBranch(repoName) {
+  try {
+    const gitArgs = repoName
+      ? ["-C", `/workspace/${repoName}`, "rev-parse", "--abbrev-ref", "HEAD"]
+      : ["rev-parse", "--abbrev-ref", "HEAD"];
+    const { stdout } = await execFileAsync("git", gitArgs, {
       timeout: 5000,
     });
     const branch = stdout.trim();
@@ -81,8 +101,13 @@ export default tool({
     baseBranch: z
       .string()
       .optional()
+      .describe("Target branch to merge into. Defaults to the session's base branch."),
+    repo: z
+      .string()
+      .optional()
       .describe(
-        "Target branch to merge into. Defaults to the repository's default branch (usually 'main')."
+        'Target repository as "owner/name". Required when the session spans multiple ' +
+          "repositories; may be omitted for single-repository sessions."
       ),
   },
   async execute(args, context) {
@@ -90,7 +115,35 @@ export default tool({
     const title = args.title || "Changes from OpenCode session";
     const body = args.body || "Automated PR created via create-pull-request tool";
     const baseBranch = args.baseBranch; // undefined if not provided, server will use default
-    const headBranch = await getCurrentBranch();
+
+    // Resolve the target repository for multi-repo sessions.
+    const repositories = getRepositories();
+    const validValues = repositories.map((r) => `${r.owner}/${r.name}`).join(", ");
+    let repoOwner;
+    let repoName;
+    if (args.repo) {
+      const parts = String(args.repo).trim().split("/");
+      if (parts.length !== 2 || !parts[0] || !parts[1]) {
+        return `Failed to create pull request: repo must be "owner/name"${
+          validValues ? ` (one of: ${validValues})` : ""
+        }.`;
+      }
+      [repoOwner, repoName] = parts;
+      if (
+        repositories.length > 0 &&
+        !repositories.some(
+          (r) =>
+            r.owner.toLowerCase() === repoOwner.toLowerCase() &&
+            r.name.toLowerCase() === repoName.toLowerCase()
+        )
+      ) {
+        return `Failed to create pull request: ${args.repo} is not part of this session. Valid values: ${validValues}.`;
+      }
+    } else if (repositories.length > 1) {
+      return `Failed to create pull request: this session spans multiple repositories — pass repo with one of: ${validValues}.`;
+    }
+
+    const headBranch = await getCurrentBranch(repoName);
 
     try {
       const sessionId = getSessionId();
@@ -118,6 +171,8 @@ export default tool({
           body: body,
           baseBranch: baseBranch,
           headBranch: headBranch,
+          repoOwner: repoOwner,
+          repoName: repoName,
           timestamp: Date.now(),
         }),
       });

--- a/packages/sandbox-runtime/src/sandbox_runtime/plugins/inspect-plugin.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/plugins/inspect-plugin.js
@@ -7,6 +7,7 @@
 import { tool } from "@opencode-ai/plugin";
 import { z } from "zod";
 import { execFile } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
@@ -45,27 +46,34 @@ function getSessionId() {
   }
 }
 
-// Ordered repository list from SESSION_CONFIG (empty for scalar sessions).
+// Canonical repository manifest written by the supervisor — the single owner
+// of the /workspace checkout layout. Mirrors REPO_MANIFEST_FILE_PATH in
+// sandbox_runtime/constants.py.
+const REPO_MANIFEST_PATH = "/tmp/oi-repo-manifest.json";
+
+// Ordered repository list {owner, name, path} from the supervisor's manifest
+// (empty when the manifest is absent, e.g. tool run outside a sandbox boot).
 function getRepositories() {
   try {
-    const config = JSON.parse(process.env.SESSION_CONFIG || "{}");
-    const repositories = Array.isArray(config.repositories) ? config.repositories : [];
+    const manifest = JSON.parse(readFileSync(REPO_MANIFEST_PATH, "utf8"));
+    const repositories = Array.isArray(manifest?.repositories) ? manifest.repositories : [];
     return repositories
       .map((entry) => ({
-        owner: String(entry?.repo_owner || "").trim(),
-        name: String(entry?.repo_name || "").trim(),
+        owner: String(entry?.owner || "").trim(),
+        name: String(entry?.name || "").trim(),
+        path: String(entry?.path || "").trim(),
       }))
-      .filter((entry) => entry.owner && entry.name);
+      .filter((entry) => entry.owner && entry.name && entry.path);
   } catch (e) {
-    console.log("[create-pull-request] Failed to parse SESSION_CONFIG repositories:", e.message);
+    console.log("[create-pull-request] Failed to read repo manifest:", e.message);
     return [];
   }
 }
 
-async function getCurrentBranch(repoName) {
+async function getCurrentBranch(repoPath) {
   try {
-    const gitArgs = repoName
-      ? ["-C", `/workspace/${repoName}`, "rev-parse", "--abbrev-ref", "HEAD"]
+    const gitArgs = repoPath
+      ? ["-C", repoPath, "rev-parse", "--abbrev-ref", "HEAD"]
       : ["rev-parse", "--abbrev-ref", "HEAD"];
     const { stdout } = await execFileAsync("git", gitArgs, {
       timeout: 5000,
@@ -121,6 +129,7 @@ export default tool({
     const validValues = repositories.map((r) => `${r.owner}/${r.name}`).join(", ");
     let repoOwner;
     let repoName;
+    let repoPath;
     if (args.repo) {
       const parts = String(args.repo).trim().split("/");
       if (parts.length !== 2 || !parts[0] || !parts[1]) {
@@ -128,22 +137,26 @@ export default tool({
           validValues ? ` (one of: ${validValues})` : ""
         }.`;
       }
-      [repoOwner, repoName] = parts;
-      if (
-        repositories.length > 0 &&
-        !repositories.some(
-          (r) =>
-            r.owner.toLowerCase() === repoOwner.toLowerCase() &&
-            r.name.toLowerCase() === repoName.toLowerCase()
-        )
-      ) {
+      const [ownerArg, nameArg] = parts;
+      const match = repositories.find(
+        (r) =>
+          r.owner.toLowerCase() === ownerArg.toLowerCase() &&
+          r.name.toLowerCase() === nameArg.toLowerCase()
+      );
+      if (repositories.length > 0 && !match) {
         return `Failed to create pull request: ${args.repo} is not part of this session. Valid values: ${validValues}.`;
       }
+      // Use the manifest's canonical casing and path — checkout directories
+      // and the control plane's member records are case-sensitive even
+      // though the match above is not.
+      repoOwner = match ? match.owner : ownerArg;
+      repoName = match ? match.name : nameArg;
+      repoPath = match ? match.path : undefined;
     } else if (repositories.length > 1) {
       return `Failed to create pull request: this session spans multiple repositories — pass repo with one of: ${validValues}.`;
     }
 
-    const headBranch = await getCurrentBranch(repoName);
+    const headBranch = await getCurrentBranch(repoPath);
 
     try {
       const sessionId = getSessionId();

--- a/packages/sandbox-runtime/src/sandbox_runtime/repo_config.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/repo_config.py
@@ -101,6 +101,21 @@ def parse_repositories(
     return []
 
 
+def find_repo_entry(entries: list[RepoEntry], owner: str, name: str) -> RepoEntry | None:
+    """Find a repository by identity, case-insensitively.
+
+    GitHub owner/name identifiers are case-insensitive, but the returned
+    entry carries the canonical casing (and checkout path) — callers must
+    use the entry's fields, never the lookup arguments.
+    """
+    owner_key = owner.lower()
+    name_key = name.lower()
+    for entry in entries:
+        if entry.owner.lower() == owner_key and entry.name.lower() == name_key:
+            return entry
+    return None
+
+
 def dump_repo_manifest(repositories: list[RepoEntry]) -> str:
     """Serialize entries for REPO_MANIFEST_FILE_PATH."""
     return json.dumps(

--- a/packages/sandbox-runtime/src/sandbox_runtime/repo_config.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/repo_config.py
@@ -1,0 +1,135 @@
+"""Canonical session repository model.
+
+The supervisor derives the repository list once from SESSION_CONFIG
+(validating names as safe path segments and rejecting duplicates), then
+writes it to REPO_MANIFEST_FILE_PATH. Every other consumer — the bridge's
+push targeting and the JS create-pull-request tool — reads that manifest
+instead of re-deriving the ``/workspace/<repo_name>`` convention, so the
+checkout layout has exactly one owner.
+"""
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from .constants import REPO_MANIFEST_FILE_PATH
+
+# GitHub owner/repo identifiers: a single path segment with no separators.
+# Leading dots are legal (a repo can be named ".github"); "." and ".." are
+# rejected separately below.
+_SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+class RepoConfigError(ValueError):
+    """SESSION_CONFIG carries a repository entry that cannot be trusted."""
+
+
+@dataclass(frozen=True)
+class RepoEntry:
+    """One repository of the session workspace, in position order.
+
+    The first entry is the primary (mirrors REPO_OWNER/REPO_NAME); every
+    downstream code path iterates the list so single- and multi-repo sessions
+    share one shape.
+    """
+
+    owner: str
+    name: str
+    branch: str
+    path: Path
+
+
+def is_safe_repo_segment(value: str) -> bool:
+    """True when ``value`` is usable as a single checkout directory segment."""
+    return bool(_SAFE_SEGMENT_RE.match(value)) and value not in (".", "..")
+
+
+def _require_safe(*, owner: str, name: str) -> None:
+    for label, value in (("repo_owner", owner), ("repo_name", name)):
+        if not is_safe_repo_segment(value):
+            raise RepoConfigError(f"unsafe {label} {value!r}: not a single path segment")
+
+
+def parse_repositories(
+    session_config: dict,
+    *,
+    workspace_path: Path,
+    scalar_owner: str = "",
+    scalar_name: str = "",
+    scalar_branch: str = "main",
+) -> list[RepoEntry]:
+    """Build the ordered repository list from SESSION_CONFIG or the scalar env.
+
+    Checkout paths derive from repo_name, so owners/names must be safe single
+    path segments and names must be unique (case-insensitive — checkout paths
+    would collide). The control plane enforces both at create time, so a
+    violation here means a corrupt or tampered config: RepoConfigError, and
+    the boot must not proceed. Entries missing owner or name are skipped.
+    """
+    raw = session_config.get("repositories")
+    entries: list[RepoEntry] = []
+    seen_names: set[str] = set()
+    if isinstance(raw, list):
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            owner = str(item.get("repo_owner") or "").strip()
+            name = str(item.get("repo_name") or "").strip()
+            if not owner or not name:
+                continue
+            _require_safe(owner=owner, name=name)
+            if name.lower() in seen_names:
+                raise RepoConfigError(f"duplicate repo_name {name!r}: checkout paths would collide")
+            seen_names.add(name.lower())
+            branch = str(item.get("branch") or "").strip() or "main"
+            entries.append(
+                RepoEntry(owner=owner, name=name, branch=branch, path=workspace_path / name)
+            )
+    if entries:
+        return entries
+    if scalar_owner and scalar_name:
+        _require_safe(owner=scalar_owner, name=scalar_name)
+        return [
+            RepoEntry(
+                owner=scalar_owner,
+                name=scalar_name,
+                branch=scalar_branch,
+                path=workspace_path / scalar_name,
+            )
+        ]
+    return []
+
+
+def dump_repo_manifest(repositories: list[RepoEntry]) -> str:
+    """Serialize entries for REPO_MANIFEST_FILE_PATH."""
+    return json.dumps(
+        {
+            "repositories": [
+                {"owner": r.owner, "name": r.name, "branch": r.branch, "path": str(r.path)}
+                for r in repositories
+            ]
+        }
+    )
+
+
+def load_repo_manifest(path: str | Path = REPO_MANIFEST_FILE_PATH) -> list[RepoEntry]:
+    """Read the supervisor-written manifest; empty when missing or malformed."""
+    try:
+        data = json.loads(Path(path).read_text())
+    except (OSError, ValueError):
+        return []
+    raw = data.get("repositories") if isinstance(data, dict) else None
+    entries: list[RepoEntry] = []
+    if isinstance(raw, list):
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            owner = str(item.get("owner") or "").strip()
+            name = str(item.get("name") or "").strip()
+            path_value = str(item.get("path") or "").strip()
+            if not owner or not name or not path_value:
+                continue
+            branch = str(item.get("branch") or "").strip() or "main"
+            entries.append(RepoEntry(owner=owner, name=name, branch=branch, path=Path(path_value)))
+    return entries

--- a/packages/sandbox-runtime/src/sandbox_runtime/repo_config.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/repo_config.py
@@ -10,8 +10,10 @@ checkout layout has exactly one owner.
 
 import json
 import re
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from .constants import REPO_MANIFEST_FILE_PATH
 
@@ -51,8 +53,13 @@ def _require_safe(*, owner: str, name: str) -> None:
             raise RepoConfigError(f"unsafe {label} {value!r}: not a single path segment")
 
 
+def _str_field(item: Mapping[str, Any], key: str) -> str:
+    """A JSON field coerced to a stripped string ("" for null/missing)."""
+    return str(item.get(key) or "").strip()
+
+
 def parse_repositories(
-    session_config: dict,
+    session_config: Mapping[str, Any],
     *,
     workspace_path: Path,
     scalar_owner: str = "",
@@ -74,15 +81,16 @@ def parse_repositories(
         for item in raw:
             if not isinstance(item, dict):
                 continue
-            owner = str(item.get("repo_owner") or "").strip()
-            name = str(item.get("repo_name") or "").strip()
+            owner = _str_field(item, "repo_owner")
+            name = _str_field(item, "repo_name")
             if not owner or not name:
                 continue
             _require_safe(owner=owner, name=name)
-            if name.lower() in seen_names:
+            name_key = name.lower()
+            if name_key in seen_names:
                 raise RepoConfigError(f"duplicate repo_name {name!r}: checkout paths would collide")
-            seen_names.add(name.lower())
-            branch = str(item.get("branch") or "").strip() or "main"
+            seen_names.add(name_key)
+            branch = _str_field(item, "branch") or "main"
             entries.append(
                 RepoEntry(owner=owner, name=name, branch=branch, path=workspace_path / name)
             )
@@ -101,7 +109,7 @@ def parse_repositories(
     return []
 
 
-def find_repo_entry(entries: list[RepoEntry], owner: str, name: str) -> RepoEntry | None:
+def find_repo_entry(entries: Iterable[RepoEntry], owner: str, name: str) -> RepoEntry | None:
     """Find a repository by identity, case-insensitively.
 
     GitHub owner/name identifiers are case-insensitive, but the returned
@@ -140,11 +148,11 @@ def load_repo_manifest(path: str | Path = REPO_MANIFEST_FILE_PATH) -> list[RepoE
         for item in raw:
             if not isinstance(item, dict):
                 continue
-            owner = str(item.get("owner") or "").strip()
-            name = str(item.get("name") or "").strip()
-            path_value = str(item.get("path") or "").strip()
+            owner = _str_field(item, "owner")
+            name = _str_field(item, "name")
+            path_value = _str_field(item, "path")
             if not owner or not name or not path_value:
                 continue
-            branch = str(item.get("branch") or "").strip() or "main"
+            branch = _str_field(item, "branch") or "main"
             entries.append(RepoEntry(owner=owner, name=name, branch=branch, path=Path(path_value)))
     return entries

--- a/packages/sandbox-runtime/src/sandbox_runtime/types.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/types.py
@@ -120,8 +120,25 @@ class McpServerConfig(TypedDict, total=False):
     enabled: bool
 
 
+class SessionRepositoryConfig(TypedDict, total=False):
+    """One member of a multi-repo session, in position order (first = primary).
+
+    Mirrors the control plane's per-repo spawn shape (snake_case wire form).
+    """
+
+    repo_owner: str
+    repo_name: str
+    branch: str | None
+
+
 class SessionConfig(BaseModel):
-    """Configuration passed to sandbox for a session."""
+    """Configuration passed to sandbox for a session.
+
+    This model is round-tripped by modal-infra (web_api builds it from the
+    create request, the manager serializes it into the SESSION_CONFIG env
+    var), and pydantic silently drops unknown keys — new wire fields MUST be
+    added here or they never reach the sandbox.
+    """
 
     session_id: str
     repo_owner: str | None = None
@@ -132,3 +149,9 @@ class SessionConfig(BaseModel):
     provider: str = "anthropic"
     model: str = "claude-sonnet-4-6"
     mcp_servers: list[McpServerConfig] | None = None
+    # Ordered member list for multi-repo sessions; absent for scalar sessions
+    # (the runtime synthesizes a one-entry list from repo_owner/repo_name).
+    repositories: list[SessionRepositoryConfig] | None = None
+    # Shared working-branch name, computed control-plane-side
+    # (generateBranchName) — the runtime never derives branch names itself.
+    working_branch_name: str | None = None

--- a/packages/sandbox-runtime/tests/test_bridge_boot_warnings.py
+++ b/packages/sandbox-runtime/tests/test_bridge_boot_warnings.py
@@ -1,0 +1,68 @@
+"""Tests for the bridge's boot-warning drain.
+
+The supervisor queues warnings to a file before the bridge exists; the bridge
+forwards each as a `warning` sandbox event after its WebSocket handshake and
+consumes the file exactly once.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from sandbox_runtime.bridge import AgentBridge
+
+
+def _create_bridge() -> AgentBridge:
+    return AgentBridge(
+        sandbox_id="test-sandbox",
+        session_id="test-session",
+        control_plane_url="http://localhost:8787",
+        auth_token="test-token",
+    )
+
+
+@pytest.mark.asyncio
+async def test_drain_forwards_warnings_and_deletes_file(tmp_path: Path):
+    warnings_file = tmp_path / "warnings.jsonl"
+    warnings_file.write_text(
+        json.dumps(
+            {"scope": "setup", "message": "setup failed", "repoOwner": "acme", "repoName": "api"}
+        )
+        + "\n"
+        + "not json\n"
+        + json.dumps({"scope": "sync", "message": "stale checkout"})
+        + "\n"
+        + json.dumps({"scope": "sync"})  # no message — dropped
+        + "\n"
+    )
+    bridge = _create_bridge()
+    bridge._send_event = AsyncMock()
+
+    with patch("sandbox_runtime.bridge.BOOT_WARNINGS_FILE_PATH", str(warnings_file)):
+        await bridge._drain_boot_warnings()
+
+    events = [c.args[0] for c in bridge._send_event.await_args_list]
+    assert events == [
+        {
+            "type": "warning",
+            "scope": "setup",
+            "message": "setup failed",
+            "repoOwner": "acme",
+            "repoName": "api",
+        },
+        {"type": "warning", "scope": "sync", "message": "stale checkout"},
+    ]
+    assert not warnings_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_drain_is_a_noop_without_file(tmp_path: Path):
+    bridge = _create_bridge()
+    bridge._send_event = AsyncMock()
+
+    with patch("sandbox_runtime.bridge.BOOT_WARNINGS_FILE_PATH", str(tmp_path / "missing.jsonl")):
+        await bridge._drain_boot_warnings()
+
+    bridge._send_event.assert_not_awaited()

--- a/packages/sandbox-runtime/tests/test_bridge_push.py
+++ b/packages/sandbox-runtime/tests/test_bridge_push.py
@@ -1,6 +1,7 @@
 """Tests for bridge git push handling."""
 
 import asyncio
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -17,9 +18,31 @@ def _create_bridge(tmp_path: Path) -> AgentBridge:
         auth_token="test-token",
     )
     bridge.repo_path = tmp_path
+    # Point at a per-test manifest (absent until a test writes one) so the
+    # real /tmp manifest never leaks in.
+    bridge.repo_manifest_path = tmp_path / "manifest.json"
     repo_dir = tmp_path / "repo"
     (repo_dir / ".git").mkdir(parents=True)
     return bridge
+
+
+def _write_manifest(bridge: AgentBridge, tmp_path: Path, members: list[tuple[str, str]]) -> None:
+    """Write the supervisor-style repo manifest for the given (owner, name) members."""
+    bridge.repo_manifest_path.write_text(
+        json.dumps(
+            {
+                "repositories": [
+                    {
+                        "owner": owner,
+                        "name": name,
+                        "branch": "main",
+                        "path": str(tmp_path / name),
+                    }
+                    for owner, name in members
+                ]
+            }
+        )
+    )
 
 
 def _push_command() -> dict:
@@ -172,6 +195,7 @@ def _multi_repo_push_command() -> dict:
 async def test_handle_push_targets_member_from_spec(tmp_path: Path):
     """A spec carrying repo identity pushes from that member's checkout."""
     bridge = _create_bridge(tmp_path)  # creates tmp_path/repo/.git
+    _write_manifest(bridge, tmp_path, [("open-inspect", "frontend"), ("open-inspect", "backend")])
     (tmp_path / "backend" / ".git").mkdir(parents=True)
     bridge._send_event = AsyncMock()
     process = _fake_process(returncode=0)
@@ -193,8 +217,36 @@ async def test_handle_push_targets_member_from_spec(tmp_path: Path):
 
 
 @pytest.mark.asyncio
-async def test_handle_push_unknown_member_errors_without_pushing(tmp_path: Path):
+async def test_handle_push_matches_member_case_insensitively(tmp_path: Path):
+    """Identity matching is case-insensitive but the canonical path is used."""
     bridge = _create_bridge(tmp_path)
+    _write_manifest(bridge, tmp_path, [("open-inspect", "backend")])
+    (tmp_path / "backend" / ".git").mkdir(parents=True)
+    bridge._send_event = AsyncMock()
+    process = _fake_process(returncode=0)
+    captured: dict = {}
+
+    async def fake_exec(*args, **kwargs):
+        captured["cwd"] = kwargs.get("cwd")
+        return process
+
+    cmd = _multi_repo_push_command()
+    cmd["pushSpec"]["repoOwner"] = "Open-Inspect"
+    cmd["pushSpec"]["repoName"] = "Backend"
+
+    with patch("sandbox_runtime.bridge.asyncio.create_subprocess_exec", side_effect=fake_exec):
+        await bridge._handle_push(cmd)
+
+    assert captured["cwd"] == tmp_path / "backend"
+    event = bridge._send_event.await_args.args[0]
+    assert event["type"] == "push_complete"
+
+
+@pytest.mark.asyncio
+async def test_handle_push_non_member_errors_without_pushing(tmp_path: Path):
+    """Identity not in the manifest never touches the filesystem."""
+    bridge = _create_bridge(tmp_path)
+    _write_manifest(bridge, tmp_path, [("open-inspect", "backend")])
     bridge._send_event = AsyncMock()
     cmd = _multi_repo_push_command()
     cmd["pushSpec"]["repoName"] = "missing"
@@ -205,9 +257,66 @@ async def test_handle_push_unknown_member_errors_without_pushing(tmp_path: Path)
     mock_exec.assert_not_called()
     event = bridge._send_event.await_args.args[0]
     assert event["type"] == "push_error"
-    assert "not found in workspace" in event["error"]
+    assert "not part of this session" in event["error"]
     assert event["branchName"] == "feature/test"
     assert event["repoName"] == "missing"
+
+
+@pytest.mark.asyncio
+async def test_handle_push_traversal_repo_name_errors_without_pushing(tmp_path: Path):
+    """A crafted path-segment identity cannot select a checkout outside the manifest."""
+    bridge = _create_bridge(tmp_path)
+    _write_manifest(bridge, tmp_path, [("open-inspect", "backend")])
+    outside = tmp_path / "outside"
+    (outside / ".git").mkdir(parents=True)
+    bridge._send_event = AsyncMock()
+    cmd = _multi_repo_push_command()
+    cmd["pushSpec"]["repoName"] = "../outside"
+
+    with patch("sandbox_runtime.bridge.asyncio.create_subprocess_exec") as mock_exec:
+        await bridge._handle_push(cmd)
+
+    mock_exec.assert_not_called()
+    event = bridge._send_event.await_args.args[0]
+    assert event["type"] == "push_error"
+    assert "not part of this session" in event["error"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("dropped_field", ["repoOwner", "repoName"])
+async def test_handle_push_partial_identity_errors(tmp_path: Path, dropped_field: str):
+    """Owner and name must travel together — no silent fallback for half a spec."""
+    bridge = _create_bridge(tmp_path)
+    _write_manifest(bridge, tmp_path, [("open-inspect", "backend")])
+    bridge._send_event = AsyncMock()
+    cmd = _multi_repo_push_command()
+    del cmd["pushSpec"][dropped_field]
+
+    with patch("sandbox_runtime.bridge.asyncio.create_subprocess_exec") as mock_exec:
+        await bridge._handle_push(cmd)
+
+    mock_exec.assert_not_called()
+    event = bridge._send_event.await_args.args[0]
+    assert event["type"] == "push_error"
+    assert "both repoOwner and repoName" in event["error"]
+    assert event["branchName"] == "feature/test"
+
+
+@pytest.mark.asyncio
+async def test_handle_push_member_without_checkout_errors(tmp_path: Path):
+    """A manifest member whose checkout is missing on disk fails cleanly."""
+    bridge = _create_bridge(tmp_path)
+    _write_manifest(bridge, tmp_path, [("open-inspect", "backend")])
+    bridge._send_event = AsyncMock()
+
+    with patch("sandbox_runtime.bridge.asyncio.create_subprocess_exec") as mock_exec:
+        await bridge._handle_push(_multi_repo_push_command())
+
+    mock_exec.assert_not_called()
+    event = bridge._send_event.await_args.args[0]
+    assert event["type"] == "push_error"
+    assert "not found in workspace" in event["error"]
+    assert event["repoName"] == "backend"
 
 
 @pytest.mark.asyncio

--- a/packages/sandbox-runtime/tests/test_bridge_push.py
+++ b/packages/sandbox-runtime/tests/test_bridge_push.py
@@ -159,3 +159,95 @@ async def test_handle_push_timeout_terminates_process_and_sends_error(tmp_path: 
     assert event["error"] == "Push failed - git push timed out after 42s"
     assert event["branchName"] == "feature/test"
     assert isinstance(event["timestamp"], float)
+
+
+def _multi_repo_push_command() -> dict:
+    cmd = _push_command()
+    cmd["pushSpec"]["repoOwner"] = "open-inspect"
+    cmd["pushSpec"]["repoName"] = "backend"
+    return cmd
+
+
+@pytest.mark.asyncio
+async def test_handle_push_targets_member_from_spec(tmp_path: Path):
+    """A spec carrying repo identity pushes from that member's checkout."""
+    bridge = _create_bridge(tmp_path)  # creates tmp_path/repo/.git
+    (tmp_path / "backend" / ".git").mkdir(parents=True)
+    bridge._send_event = AsyncMock()
+    process = _fake_process(returncode=0)
+    captured: dict = {}
+
+    async def fake_exec(*args, **kwargs):
+        captured["cwd"] = kwargs.get("cwd")
+        return process
+
+    with patch("sandbox_runtime.bridge.asyncio.create_subprocess_exec", side_effect=fake_exec):
+        await bridge._handle_push(_multi_repo_push_command())
+
+    assert captured["cwd"] == tmp_path / "backend"
+    event = bridge._send_event.await_args.args[0]
+    assert event["type"] == "push_complete"
+    assert event["branchName"] == "feature/test"
+    assert event["repoOwner"] == "open-inspect"
+    assert event["repoName"] == "backend"
+
+
+@pytest.mark.asyncio
+async def test_handle_push_unknown_member_errors_without_pushing(tmp_path: Path):
+    bridge = _create_bridge(tmp_path)
+    bridge._send_event = AsyncMock()
+    cmd = _multi_repo_push_command()
+    cmd["pushSpec"]["repoName"] = "missing"
+
+    with patch("sandbox_runtime.bridge.asyncio.create_subprocess_exec") as mock_exec:
+        await bridge._handle_push(cmd)
+
+    mock_exec.assert_not_called()
+    event = bridge._send_event.await_args.args[0]
+    assert event["type"] == "push_error"
+    assert "not found in workspace" in event["error"]
+    assert event["branchName"] == "feature/test"
+    assert event["repoName"] == "missing"
+
+
+@pytest.mark.asyncio
+async def test_handle_push_without_identity_keeps_legacy_behavior(tmp_path: Path):
+    """Specs without repo identity push from the sole clone, no repo fields."""
+    bridge = _create_bridge(tmp_path)
+    bridge._send_event = AsyncMock()
+    process = _fake_process(returncode=0)
+    captured: dict = {}
+
+    async def fake_exec(*args, **kwargs):
+        captured["cwd"] = kwargs.get("cwd")
+        return process
+
+    with patch("sandbox_runtime.bridge.asyncio.create_subprocess_exec", side_effect=fake_exec):
+        await bridge._handle_push(_push_command())
+
+    assert captured["cwd"] == tmp_path / "repo"
+    event = bridge._send_event.await_args.args[0]
+    assert event["type"] == "push_complete"
+    assert "repoOwner" not in event
+    assert "repoName" not in event
+
+
+@pytest.mark.asyncio
+async def test_handle_push_no_repo_error_includes_branch(tmp_path: Path):
+    """The no-repository error must carry branchName so the control plane can
+    resolve its pending push instead of leaking it for 360s."""
+    bridge = AgentBridge(
+        sandbox_id="test-sandbox",
+        session_id="test-session",
+        control_plane_url="http://localhost:8787",
+        auth_token="test-token",
+    )
+    bridge.repo_path = tmp_path  # no clones at all
+    bridge._send_event = AsyncMock()
+
+    await bridge._handle_push(_push_command())
+
+    event = bridge._send_event.await_args.args[0]
+    assert event["type"] == "push_error"
+    assert event["error"] == "No repository found"
+    assert event["branchName"] == "feature/test"

--- a/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
+++ b/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
@@ -1,9 +1,15 @@
 """Tests for entrypoint boot modes and git sync."""
 
 import os
+from dataclasses import replace
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
+
+
+def _repoint_primary(supervisor):
+    """Repoint the parsed primary entry at the test's reassigned repo_path."""
+    supervisor.repositories = [replace(supervisor.repositories[0], path=supervisor.repo_path)]
 
 
 @pytest.fixture
@@ -89,7 +95,7 @@ class TestImageBuildMode:
         supervisor = _make_supervisor(build_env)
         # Point repo_path to a non-existent dir so clone branch is taken
         supervisor.repo_path = tmp_path / "nonexistent"
-        supervisor.repositories = supervisor._parse_repositories()
+        _repoint_primary(supervisor)
         # Pre-set so entrypoint doesn't hang waiting for builder to terminate
         supervisor.shutdown_event.set()
 
@@ -168,7 +174,7 @@ class TestImageBuildMode:
         """Build mode should log git.sync_complete with head_sha for the image builder."""
         supervisor = _make_supervisor(build_env)
         supervisor.repo_path = tmp_path  # Exists, so _get_head_sha proceeds
-        supervisor.repositories = supervisor._parse_repositories()
+        _repoint_primary(supervisor)
 
         supervisor.sync_repositories = AsyncMock(return_value=[])
         supervisor.run_setup_script = AsyncMock(return_value=True)
@@ -205,7 +211,7 @@ class TestImageBuildMode:
         """Build mode should report completion itself when callback metadata is configured."""
         supervisor = _make_supervisor(build_env)
         supervisor.repo_path = tmp_path
-        supervisor.repositories = supervisor._parse_repositories()
+        _repoint_primary(supervisor)
 
         supervisor.sync_repositories = AsyncMock(return_value=[])
         supervisor.run_setup_script = AsyncMock(return_value=True)
@@ -279,7 +285,7 @@ class TestFromRepoImage:
         supervisor = _make_supervisor(repo_image_env)
         supervisor.repo_path = tmp_path / "my-repo"
         supervisor.repo_path.mkdir(parents=True)
-        supervisor.repositories = supervisor._parse_repositories()
+        _repoint_primary(supervisor)
 
         supervisor._clone_repo = AsyncMock(return_value=True)
         supervisor._update_existing_repo = AsyncMock(return_value=True)
@@ -366,7 +372,7 @@ class TestNormalMode:
         """A fresh boot clones (repo missing) then updates — the unified rule."""
         supervisor = _make_supervisor(base_env)
         supervisor.repo_path = tmp_path / "nonexistent"
-        supervisor.repositories = supervisor._parse_repositories()
+        _repoint_primary(supervisor)
 
         async def fake_clone(repo):
             repo.path.mkdir(parents=True, exist_ok=True)
@@ -413,7 +419,7 @@ class TestNormalMode:
         """Normal mode should clone with --depth 100."""
         supervisor = _make_supervisor(base_env)
         supervisor.repo_path = tmp_path / "nonexistent"
-        supervisor.repositories = supervisor._parse_repositories()
+        _repoint_primary(supervisor)
 
         all_calls = []
 
@@ -588,7 +594,7 @@ class TestUpdateExistingRepo:
         """
         supervisor = _make_supervisor(base_env)
         supervisor.repo_path = tmp_path
-        supervisor.repositories = supervisor._parse_repositories()
+        _repoint_primary(supervisor)
 
         call_log = []
 
@@ -621,7 +627,7 @@ class TestUpdateExistingRepo:
         """Should return False when repo directory doesn't exist."""
         supervisor = _make_supervisor(base_env)
         supervisor.repo_path = tmp_path / "nonexistent"
-        supervisor.repositories = supervisor._parse_repositories()
+        _repoint_primary(supervisor)
 
         with patch("sandbox_runtime.entrypoint.asyncio.create_subprocess_exec") as mock_exec:
             result = await supervisor._update_existing_repo(supervisor.repositories[0])
@@ -635,7 +641,7 @@ class TestUpdateExistingRepo:
         env = {**base_env, "SESSION_CONFIG": '{"branch": "feature/xyz"}'}
         supervisor = _make_supervisor(env)
         supervisor.repo_path = tmp_path
-        supervisor.repositories = supervisor._parse_repositories()
+        _repoint_primary(supervisor)
 
         call_log = []
 
@@ -661,7 +667,7 @@ class TestUpdateExistingRepo:
         env = {**base_env, "SESSION_CONFIG": '{"branch": "develop"}'}
         supervisor = _make_supervisor(env)
         supervisor.repo_path = tmp_path
-        supervisor.repositories = supervisor._parse_repositories()
+        _repoint_primary(supervisor)
 
         call_log = []
 
@@ -687,7 +693,7 @@ class TestUpdateExistingRepo:
         """Should return False when fetch fails."""
         supervisor = _make_supervisor(base_env)
         supervisor.repo_path = tmp_path
-        supervisor.repositories = supervisor._parse_repositories()
+        _repoint_primary(supervisor)
 
         async def fake_subprocess(*args, **kwargs):
             mock_proc = MagicMock()
@@ -712,7 +718,7 @@ class TestUpdateExistingRepo:
         """Should return False when checkout fails."""
         supervisor = _make_supervisor(base_env)
         supervisor.repo_path = tmp_path
-        supervisor.repositories = supervisor._parse_repositories()
+        _repoint_primary(supervisor)
 
         async def fake_subprocess(*args, **kwargs):
             mock_proc = MagicMock()
@@ -745,7 +751,7 @@ class TestPerformGitSync:
         }
         supervisor = _make_supervisor(env)
         supervisor.repo_path = tmp_path / "nonexistent"
-        supervisor.repositories = supervisor._parse_repositories()
+        _repoint_primary(supervisor)
 
         call_log = []
 
@@ -779,7 +785,7 @@ class TestPerformGitSync:
         }
         supervisor = _make_supervisor(env)
         supervisor.repo_path = tmp_path  # Exists, so clone is skipped
-        supervisor.repositories = supervisor._parse_repositories()
+        _repoint_primary(supervisor)
 
         call_log = []
 
@@ -811,7 +817,7 @@ class TestPerformGitSync:
         }
         supervisor = _make_supervisor(env)
         supervisor.repo_path = tmp_path  # Exists
-        supervisor.repositories = supervisor._parse_repositories()
+        _repoint_primary(supervisor)
 
         call_log = []
 
@@ -854,7 +860,7 @@ class TestPerformGitSync:
         env = {**base_env, "VCS_HOST": "github.com"}
         supervisor = _make_supervisor(env)
         supervisor.repo_path = tmp_path
-        supervisor.repositories = supervisor._parse_repositories()
+        _repoint_primary(supervisor)
         supervisor.log = MagicMock()
 
         # Simulate a redirect chain that leaks credentials from an upstream proxy.

--- a/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
+++ b/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
@@ -60,7 +60,7 @@ class TestImageBuildMode:
         """Should return from run() after git sync + setup, before OpenCode."""
         supervisor = _make_supervisor(build_env)
 
-        supervisor.perform_git_sync = AsyncMock(return_value=True)
+        supervisor.sync_repositories = AsyncMock(return_value=[])
 
         supervisor.run_setup_script = AsyncMock(return_value=True)
         supervisor.run_start_script = AsyncMock(return_value=True)
@@ -75,7 +75,7 @@ class TestImageBuildMode:
         with patch.dict(os.environ, build_env, clear=False):
             await supervisor.run()
 
-        supervisor.perform_git_sync.assert_called_once()
+        supervisor.sync_repositories.assert_called_once()
         supervisor.run_setup_script.assert_called_once()
         supervisor.run_start_script.assert_not_called()
         # OpenCode and bridge should NOT be started in build mode
@@ -89,6 +89,7 @@ class TestImageBuildMode:
         supervisor = _make_supervisor(build_env)
         # Point repo_path to a non-existent dir so clone branch is taken
         supervisor.repo_path = tmp_path / "nonexistent"
+        supervisor.repositories = supervisor._parse_repositories()
         # Pre-set so entrypoint doesn't hang waiting for builder to terminate
         supervisor.shutdown_event.set()
 
@@ -127,7 +128,7 @@ class TestImageBuildMode:
         """Setup script should run in build mode (it IS the build)."""
         supervisor = _make_supervisor(build_env)
 
-        supervisor.perform_git_sync = AsyncMock(return_value=True)
+        supervisor.sync_repositories = AsyncMock(return_value=[])
 
         supervisor.run_setup_script = AsyncMock(return_value=True)
         supervisor.run_start_script = AsyncMock(return_value=True)
@@ -146,7 +147,7 @@ class TestImageBuildMode:
         """Build mode should fail fast when setup hook fails."""
         supervisor = _make_supervisor(build_env)
 
-        supervisor.perform_git_sync = AsyncMock(return_value=True)
+        supervisor.sync_repositories = AsyncMock(return_value=[])
         supervisor.run_setup_script = AsyncMock(return_value=False)
         supervisor.run_start_script = AsyncMock(return_value=True)
         supervisor.start_opencode = AsyncMock()
@@ -167,8 +168,9 @@ class TestImageBuildMode:
         """Build mode should log git.sync_complete with head_sha for the image builder."""
         supervisor = _make_supervisor(build_env)
         supervisor.repo_path = tmp_path  # Exists, so _get_head_sha proceeds
+        supervisor.repositories = supervisor._parse_repositories()
 
-        supervisor.perform_git_sync = AsyncMock(return_value=True)
+        supervisor.sync_repositories = AsyncMock(return_value=[])
         supervisor.run_setup_script = AsyncMock(return_value=True)
         supervisor.shutdown = AsyncMock()
         supervisor.shutdown_event.set()
@@ -203,8 +205,9 @@ class TestImageBuildMode:
         """Build mode should report completion itself when callback metadata is configured."""
         supervisor = _make_supervisor(build_env)
         supervisor.repo_path = tmp_path
+        supervisor.repositories = supervisor._parse_repositories()
 
-        supervisor.perform_git_sync = AsyncMock(return_value=True)
+        supervisor.sync_repositories = AsyncMock(return_value=[])
         supervisor.run_setup_script = AsyncMock(return_value=True)
         supervisor.shutdown = AsyncMock()
         supervisor.shutdown_event.set()
@@ -243,7 +246,7 @@ class TestImageBuildMode:
         """Build mode should report failures itself when callback metadata is configured."""
         supervisor = _make_supervisor(build_env)
 
-        supervisor.perform_git_sync = AsyncMock(return_value=True)
+        supervisor.sync_repositories = AsyncMock(return_value=[])
         supervisor.run_setup_script = AsyncMock(return_value=False)
         supervisor.shutdown = AsyncMock()
         supervisor._report_fatal_error = AsyncMock()
@@ -262,18 +265,23 @@ class TestImageBuildMode:
             await supervisor.run()
 
         callback.report_success.assert_not_called()
-        callback.report_failure.assert_awaited_once_with("setup hook failed in build mode")
+        callback.report_failure.assert_awaited_once_with(
+            "setup hook failed for acme/my-repo in build mode"
+        )
 
 
 class TestFromRepoImage:
     """FROM_REPO_IMAGE=true: update repo + start hook, skip setup."""
 
     @pytest.mark.asyncio
-    async def test_uses_update_existing_repo(self, repo_image_env):
-        """Should call _update_existing_repo instead of perform_git_sync."""
+    async def test_updates_existing_checkout_without_cloning(self, repo_image_env, tmp_path):
+        """The unified per-repo rule updates the baked checkout in place."""
         supervisor = _make_supervisor(repo_image_env)
+        supervisor.repo_path = tmp_path / "my-repo"
+        supervisor.repo_path.mkdir(parents=True)
+        supervisor.repositories = supervisor._parse_repositories()
 
-        supervisor.perform_git_sync = AsyncMock(return_value=True)
+        supervisor._clone_repo = AsyncMock(return_value=True)
         supervisor._update_existing_repo = AsyncMock(return_value=True)
 
         supervisor.run_setup_script = AsyncMock(return_value=True)
@@ -286,15 +294,15 @@ class TestFromRepoImage:
         with patch.dict(os.environ, repo_image_env, clear=False):
             await supervisor.run()
 
-        supervisor._update_existing_repo.assert_called_once()
-        supervisor.perform_git_sync.assert_not_called()
+        supervisor._update_existing_repo.assert_called_once_with(supervisor.repositories[0])
+        supervisor._clone_repo.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_skips_setup_and_runs_start_script(self, repo_image_env):
         """Setup is skipped for repo images, but start hook still runs."""
         supervisor = _make_supervisor(repo_image_env)
 
-        supervisor._update_existing_repo = AsyncMock(return_value=True)
+        supervisor.sync_repositories = AsyncMock(return_value=[])
 
         supervisor.run_setup_script = AsyncMock(return_value=True)
         supervisor.run_start_script = AsyncMock(return_value=True)
@@ -314,7 +322,7 @@ class TestFromRepoImage:
         """Should still start OpenCode and bridge (unlike build mode)."""
         supervisor = _make_supervisor(repo_image_env)
 
-        supervisor._update_existing_repo = AsyncMock(return_value=True)
+        supervisor.sync_repositories = AsyncMock(return_value=[])
 
         supervisor.run_start_script = AsyncMock(return_value=True)
         supervisor.start_opencode = AsyncMock()
@@ -333,7 +341,7 @@ class TestFromRepoImage:
         """Repo-image boot should fail fast when start hook fails."""
         supervisor = _make_supervisor(repo_image_env)
 
-        supervisor._update_existing_repo = AsyncMock(return_value=True)
+        supervisor.sync_repositories = AsyncMock(return_value=[])
         supervisor.run_setup_script = AsyncMock(return_value=True)
         supervisor.run_start_script = AsyncMock(return_value=False)
         supervisor.start_opencode = AsyncMock()
@@ -354,11 +362,17 @@ class TestNormalMode:
     """No build mode or repo image flags: full clone + setup + start + OpenCode."""
 
     @pytest.mark.asyncio
-    async def test_uses_full_git_sync(self, base_env):
-        """Should use perform_git_sync (full clone)."""
+    async def test_uses_full_git_sync(self, base_env, tmp_path):
+        """A fresh boot clones (repo missing) then updates — the unified rule."""
         supervisor = _make_supervisor(base_env)
+        supervisor.repo_path = tmp_path / "nonexistent"
+        supervisor.repositories = supervisor._parse_repositories()
 
-        supervisor.perform_git_sync = AsyncMock(return_value=True)
+        async def fake_clone(repo):
+            repo.path.mkdir(parents=True, exist_ok=True)
+            return True
+
+        supervisor._clone_repo = AsyncMock(side_effect=fake_clone)
         supervisor._update_existing_repo = AsyncMock(return_value=True)
 
         supervisor.run_setup_script = AsyncMock(return_value=True)
@@ -371,15 +385,15 @@ class TestNormalMode:
         with patch.dict(os.environ, base_env, clear=False):
             await supervisor.run()
 
-        supervisor.perform_git_sync.assert_called_once()
-        supervisor._update_existing_repo.assert_not_called()
+        supervisor._clone_repo.assert_called_once_with(supervisor.repositories[0])
+        supervisor._update_existing_repo.assert_called_once_with(supervisor.repositories[0])
 
     @pytest.mark.asyncio
     async def test_runs_setup_script(self, base_env):
         """Setup script should run in normal mode."""
         supervisor = _make_supervisor(base_env)
 
-        supervisor.perform_git_sync = AsyncMock(return_value=True)
+        supervisor.sync_repositories = AsyncMock(return_value=[])
 
         supervisor.run_setup_script = AsyncMock(return_value=True)
         supervisor.run_start_script = AsyncMock(return_value=True)
@@ -399,6 +413,7 @@ class TestNormalMode:
         """Normal mode should clone with --depth 100."""
         supervisor = _make_supervisor(base_env)
         supervisor.repo_path = tmp_path / "nonexistent"
+        supervisor.repositories = supervisor._parse_repositories()
 
         all_calls = []
 
@@ -440,7 +455,7 @@ class TestSnapshotRestoreMode:
     async def test_skips_setup_and_runs_start(self, base_env):
         supervisor = _make_supervisor({**base_env, "RESTORED_FROM_SNAPSHOT": "true"})
 
-        supervisor._update_existing_repo = AsyncMock(return_value=True)
+        supervisor.sync_repositories = AsyncMock(return_value=[])
         supervisor.run_setup_script = AsyncMock(return_value=True)
         supervisor.run_start_script = AsyncMock(return_value=True)
         supervisor.start_opencode = AsyncMock()
@@ -458,7 +473,7 @@ class TestSnapshotRestoreMode:
     async def test_start_failure_is_fatal(self, base_env):
         supervisor = _make_supervisor({**base_env, "RESTORED_FROM_SNAPSHOT": "true"})
 
-        supervisor._update_existing_repo = AsyncMock(return_value=True)
+        supervisor.sync_repositories = AsyncMock(return_value=[])
         supervisor.run_setup_script = AsyncMock(return_value=True)
         supervisor.run_start_script = AsyncMock(return_value=False)
         supervisor.start_opencode = AsyncMock()
@@ -474,11 +489,11 @@ class TestSnapshotRestoreMode:
         supervisor.start_opencode.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_resync_failure_is_reported_but_not_fatal(self, base_env):
+    async def test_resync_failure_is_reported_but_not_fatal(self, base_env, tmp_path):
         supervisor = _make_supervisor({**base_env, "RESTORED_FROM_SNAPSHOT": "true"})
         supervisor.log = MagicMock()
 
-        supervisor._update_existing_repo = AsyncMock(return_value=False)
+        supervisor.sync_repositories = AsyncMock(return_value=list(supervisor.repositories))
         supervisor.run_setup_script = AsyncMock(return_value=True)
         supervisor.run_start_script = AsyncMock(return_value=True)
         supervisor.start_opencode = AsyncMock()
@@ -486,12 +501,21 @@ class TestSnapshotRestoreMode:
         supervisor.monitor_processes = AsyncMock()
         supervisor.shutdown = AsyncMock()
 
-        with patch.dict(os.environ, {"RESTORED_FROM_SNAPSHOT": "true"}, clear=False):
+        with (
+            patch.dict(os.environ, {"RESTORED_FROM_SNAPSHOT": "true"}, clear=False),
+            patch(
+                "sandbox_runtime.entrypoint.BOOT_WARNINGS_FILE_PATH",
+                str(tmp_path / "warnings.jsonl"),
+            ),
+        ):
             await supervisor.run()
 
         supervisor.log.warn.assert_any_call(
-            "git.snapshot_resync_failed",
-            reason="origin rewrite or fetch failed; repo may be stale",
+            "supervisor.boot_warning",
+            scope="sync",
+            warning_message=ANY,
+            repo_owner="acme",
+            repo_name="my-repo",
         )
         startup_call = next(
             c
@@ -500,20 +524,24 @@ class TestSnapshotRestoreMode:
         )
         assert startup_call.kwargs["git_sync_success"] is False
         supervisor.start_opencode.assert_called_once()
+        # The warning is queued for the bridge to forward as a sandbox event.
+        warning_lines = (tmp_path / "warnings.jsonl").read_text().splitlines()
+        assert len(warning_lines) == 1
+        assert '"scope": "sync"' in warning_lines[0]
 
 
 class TestNoRepository:
     """Missing repo fields: no clone or repo hooks, but OpenCode still starts."""
 
     @pytest.mark.asyncio
-    async def test_perform_git_sync_skips_clone(self, no_repo_env):
+    async def test_sync_skips_clone(self, no_repo_env):
         supervisor = _make_supervisor(no_repo_env)
         supervisor.log = MagicMock()
 
         with patch("sandbox_runtime.entrypoint.asyncio.create_subprocess_exec") as mock_exec:
-            result = await supervisor.perform_git_sync()
+            failed = await supervisor.sync_repositories()
 
-        assert result is True
+        assert failed == []
         mock_exec.assert_not_called()
         supervisor.log.info.assert_any_call("git.skip_clone", reason="no_repo_configured")
 
@@ -523,8 +551,7 @@ class TestNoRepository:
         supervisor.log = MagicMock()
 
         supervisor._ensure_credential_helper_configured = AsyncMock()
-        supervisor.perform_git_sync = AsyncMock(return_value=True)
-        supervisor._update_existing_repo = AsyncMock(return_value=True)
+        supervisor.sync_repositories = AsyncMock(return_value=[])
         supervisor.run_setup_script = AsyncMock(return_value=True)
         supervisor.run_start_script = AsyncMock(return_value=True)
         supervisor.start_code_server = AsyncMock()
@@ -542,8 +569,7 @@ class TestNoRepository:
         assert supervisor.boot_mode == "fresh"
         supervisor.log.info.assert_any_call("supervisor.no_repo_configured")
         supervisor._ensure_credential_helper_configured.assert_not_called()
-        supervisor.perform_git_sync.assert_called_once()
-        supervisor._update_existing_repo.assert_not_called()
+        supervisor.sync_repositories.assert_called_once()
         supervisor.run_setup_script.assert_not_called()
         supervisor.run_start_script.assert_not_called()
         supervisor.start_opencode.assert_called_once()
@@ -562,6 +588,7 @@ class TestUpdateExistingRepo:
         """
         supervisor = _make_supervisor(base_env)
         supervisor.repo_path = tmp_path
+        supervisor.repositories = supervisor._parse_repositories()
 
         call_log = []
 
@@ -576,14 +603,14 @@ class TestUpdateExistingRepo:
             "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
             side_effect=fake_subprocess,
         ):
-            result = await supervisor._update_existing_repo()
+            result = await supervisor._update_existing_repo(supervisor.repositories[0])
 
         assert result is True
         # set-url (scrub stale embedded token), fetch, checkout
         assert len(call_log) == 3
         assert "set-url" in call_log[0]
         # The rewrite must use a token-free URL.
-        assert call_log[0][-1] == supervisor._build_repo_url()
+        assert call_log[0][-1] == supervisor._build_repo_url(supervisor.repositories[0])
         assert "@" not in call_log[0][-1]
         assert "fetch" in call_log[1]
         assert "checkout" in call_log[2]
@@ -594,9 +621,10 @@ class TestUpdateExistingRepo:
         """Should return False when repo directory doesn't exist."""
         supervisor = _make_supervisor(base_env)
         supervisor.repo_path = tmp_path / "nonexistent"
+        supervisor.repositories = supervisor._parse_repositories()
 
         with patch("sandbox_runtime.entrypoint.asyncio.create_subprocess_exec") as mock_exec:
-            result = await supervisor._update_existing_repo()
+            result = await supervisor._update_existing_repo(supervisor.repositories[0])
             mock_exec.assert_not_called()
 
         assert result is False
@@ -607,6 +635,7 @@ class TestUpdateExistingRepo:
         env = {**base_env, "SESSION_CONFIG": '{"branch": "feature/xyz"}'}
         supervisor = _make_supervisor(env)
         supervisor.repo_path = tmp_path
+        supervisor.repositories = supervisor._parse_repositories()
 
         call_log = []
 
@@ -621,7 +650,7 @@ class TestUpdateExistingRepo:
             "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
             side_effect=fake_subprocess,
         ):
-            await supervisor._update_existing_repo()
+            await supervisor._update_existing_repo(supervisor.repositories[0])
 
         fetch_call = next(c for c in call_log if "fetch" in c)
         assert "feature/xyz:refs/remotes/origin/feature/xyz" in fetch_call
@@ -632,6 +661,7 @@ class TestUpdateExistingRepo:
         env = {**base_env, "SESSION_CONFIG": '{"branch": "develop"}'}
         supervisor = _make_supervisor(env)
         supervisor.repo_path = tmp_path
+        supervisor.repositories = supervisor._parse_repositories()
 
         call_log = []
 
@@ -646,7 +676,7 @@ class TestUpdateExistingRepo:
             "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
             side_effect=fake_subprocess,
         ):
-            await supervisor._update_existing_repo()
+            await supervisor._update_existing_repo(supervisor.repositories[0])
 
         checkout_call = next(c for c in call_log if "checkout" in c)
         assert "develop" in checkout_call
@@ -657,6 +687,7 @@ class TestUpdateExistingRepo:
         """Should return False when fetch fails."""
         supervisor = _make_supervisor(base_env)
         supervisor.repo_path = tmp_path
+        supervisor.repositories = supervisor._parse_repositories()
 
         async def fake_subprocess(*args, **kwargs):
             mock_proc = MagicMock()
@@ -672,7 +703,7 @@ class TestUpdateExistingRepo:
             "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
             side_effect=fake_subprocess,
         ):
-            result = await supervisor._update_existing_repo()
+            result = await supervisor._update_existing_repo(supervisor.repositories[0])
 
         assert result is False
 
@@ -681,6 +712,7 @@ class TestUpdateExistingRepo:
         """Should return False when checkout fails."""
         supervisor = _make_supervisor(base_env)
         supervisor.repo_path = tmp_path
+        supervisor.repositories = supervisor._parse_repositories()
 
         async def fake_subprocess(*args, **kwargs):
             mock_proc = MagicMock()
@@ -696,7 +728,7 @@ class TestUpdateExistingRepo:
             "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
             side_effect=fake_subprocess,
         ):
-            result = await supervisor._update_existing_repo()
+            result = await supervisor._update_existing_repo(supervisor.repositories[0])
 
         assert result is False
 
@@ -713,6 +745,7 @@ class TestPerformGitSync:
         }
         supervisor = _make_supervisor(env)
         supervisor.repo_path = tmp_path / "nonexistent"
+        supervisor.repositories = supervisor._parse_repositories()
 
         call_log = []
 
@@ -730,7 +763,7 @@ class TestPerformGitSync:
             "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
             side_effect=fake_subprocess,
         ):
-            result = await supervisor.perform_git_sync()
+            result = await supervisor._sync_repo(supervisor.repositories[0])
 
         assert result is True
 
@@ -746,6 +779,7 @@ class TestPerformGitSync:
         }
         supervisor = _make_supervisor(env)
         supervisor.repo_path = tmp_path  # Exists, so clone is skipped
+        supervisor.repositories = supervisor._parse_repositories()
 
         call_log = []
 
@@ -761,7 +795,7 @@ class TestPerformGitSync:
             "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
             side_effect=fake_subprocess,
         ):
-            result = await supervisor.perform_git_sync()
+            result = await supervisor._sync_repo(supervisor.repositories[0])
 
         assert result is True
 
@@ -777,6 +811,7 @@ class TestPerformGitSync:
         }
         supervisor = _make_supervisor(env)
         supervisor.repo_path = tmp_path  # Exists
+        supervisor.repositories = supervisor._parse_repositories()
 
         call_log = []
 
@@ -792,7 +827,7 @@ class TestPerformGitSync:
             "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
             side_effect=fake_subprocess,
         ):
-            await supervisor.perform_git_sync()
+            await supervisor._sync_repo(supervisor.repositories[0])
 
         checkout_calls = [c for c in call_log if "checkout" in c]
         assert len(checkout_calls) == 1
@@ -819,6 +854,7 @@ class TestPerformGitSync:
         env = {**base_env, "VCS_HOST": "github.com"}
         supervisor = _make_supervisor(env)
         supervisor.repo_path = tmp_path
+        supervisor.repositories = supervisor._parse_repositories()
         supervisor.log = MagicMock()
 
         # Simulate a redirect chain that leaks credentials from an upstream proxy.
@@ -836,7 +872,7 @@ class TestPerformGitSync:
             "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
             side_effect=fake_subprocess,
         ):
-            await getattr(supervisor, method_name)(*args)
+            await getattr(supervisor, method_name)(supervisor.repositories[0], *args)
 
         log_call = getattr(supervisor.log, log_method_name).call_args
         assert log_call.args[0] == event_name

--- a/packages/sandbox-runtime/tests/test_entrypoint_urls.py
+++ b/packages/sandbox-runtime/tests/test_entrypoint_urls.py
@@ -29,15 +29,15 @@ def _make_supervisor(env_overrides: dict[str, str] | None = None) -> SandboxSupe
 class TestBuildRepoUrl:
     def test_github_default(self) -> None:
         sup = _make_supervisor({"VCS_HOST": "github.com"})
-        assert sup._build_repo_url() == "https://github.com/acme/app.git"
+        assert sup._build_repo_url(sup.repositories[0]) == "https://github.com/acme/app.git"
 
     def test_bitbucket(self) -> None:
         sup = _make_supervisor({"VCS_HOST": "bitbucket.org"})
-        assert sup._build_repo_url() == "https://bitbucket.org/acme/app.git"
+        assert sup._build_repo_url(sup.repositories[0]) == "https://bitbucket.org/acme/app.git"
 
     def test_defaults_to_github(self) -> None:
         sup = _make_supervisor()
-        assert sup._build_repo_url() == "https://github.com/acme/app.git"
+        assert sup._build_repo_url(sup.repositories[0]) == "https://github.com/acme/app.git"
 
     def test_token_env_vars_are_ignored(self) -> None:
         """Stale snapshot tokens in env must NOT leak into the remote URL."""
@@ -48,4 +48,4 @@ class TestBuildRepoUrl:
                 "GITHUB_TOKEN": "ghp_legacy_2",
             }
         )
-        assert sup._build_repo_url() == "https://github.com/acme/app.git"
+        assert sup._build_repo_url(sup.repositories[0]) == "https://github.com/acme/app.git"

--- a/packages/sandbox-runtime/tests/test_multi_repo_workspace.py
+++ b/packages/sandbox-runtime/tests/test_multi_repo_workspace.py
@@ -1,0 +1,383 @@
+"""Tests for multi-repo sessions in the supervisor.
+
+Covers the ordered repository list, the unified per-repo sync rule and its
+boot-mode failure policy, hook ordering/fatality, the OpenCode workdir rule,
+the generated workspace manifest, and .opencode assembly.
+"""
+
+import json
+import os
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
+
+import pytest
+
+from sandbox_runtime.entrypoint import SandboxSupervisor
+
+MULTI_SESSION_CONFIG = json.dumps(
+    {
+        "session_id": "sess-1",
+        "repo_owner": "acme",
+        "repo_name": "frontend",
+        "branch": "main",
+        "working_branch_name": "open-inspect/sess-1",
+        "repositories": [
+            {"repo_owner": "acme", "repo_name": "frontend", "branch": "main"},
+            {"repo_owner": "acme", "repo_name": "backend", "branch": "develop"},
+        ],
+    }
+)
+
+
+def _make_supervisor(tmp_path, session_config: str = MULTI_SESSION_CONFIG) -> SandboxSupervisor:
+    with patch.dict(
+        os.environ,
+        {
+            "SANDBOX_ID": "test-sandbox",
+            "CONTROL_PLANE_URL": "https://cp.example.com",
+            "SANDBOX_AUTH_TOKEN": "tok",
+            "REPO_OWNER": "acme",
+            "REPO_NAME": "frontend",
+            "SESSION_CONFIG": session_config,
+        },
+        clear=False,
+    ):
+        sup = SandboxSupervisor()
+    sup.workspace_path = tmp_path
+    sup.repo_path = tmp_path / "frontend"
+    sup.repositories = sup._parse_repositories()
+    return sup
+
+
+def _mock_run_phases(sup: SandboxSupervisor) -> None:
+    """Mock everything run() touches beyond the phase under test."""
+    sup._ensure_credential_helper_configured = AsyncMock()
+    sup.sync_repositories = AsyncMock(return_value=[])
+    sup.run_setup_script = AsyncMock(return_value=True)
+    sup.run_start_script = AsyncMock(return_value=True)
+    sup.start_code_server = AsyncMock()
+    sup.start_ttyd = AsyncMock()
+    sup.start_opencode = AsyncMock()
+    sup.start_bridge = AsyncMock()
+    sup.monitor_processes = AsyncMock()
+    sup.shutdown = AsyncMock()
+    sup._report_fatal_error = AsyncMock()
+
+
+class TestParseRepositories:
+    def test_parses_ordered_list(self, tmp_path):
+        sup = _make_supervisor(tmp_path)
+
+        assert [(r.owner, r.name, r.branch) for r in sup.repositories] == [
+            ("acme", "frontend", "main"),
+            ("acme", "backend", "develop"),
+        ]
+        assert sup.repositories[0].path == tmp_path / "frontend"
+        assert sup.repositories[1].path == tmp_path / "backend"
+        assert sup.is_multi_repo is True
+
+    def test_member_branch_defaults_to_main(self, tmp_path):
+        config = json.dumps(
+            {
+                "session_id": "s",
+                "repositories": [{"repo_owner": "acme", "repo_name": "frontend"}],
+            }
+        )
+        sup = _make_supervisor(tmp_path, session_config=config)
+
+        assert sup.repositories[0].branch == "main"
+
+    def test_synthesizes_single_entry_from_scalar_env(self, tmp_path):
+        config = json.dumps({"session_id": "s", "branch": "develop"})
+        sup = _make_supervisor(tmp_path, session_config=config)
+
+        assert [(r.owner, r.name, r.branch) for r in sup.repositories] == [
+            ("acme", "frontend", "develop")
+        ]
+        assert sup.is_multi_repo is False
+
+
+class TestSyncRepositories:
+    @pytest.mark.asyncio
+    async def test_returns_failed_members_in_order(self, tmp_path):
+        sup = _make_supervisor(tmp_path)
+        sup._sync_repo = AsyncMock(side_effect=[True, False])
+
+        failed = await sup.sync_repositories()
+
+        assert failed == [sup.repositories[1]]
+        assert sup._sync_repo.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_fresh_boot_member_failure_is_fatal(self, tmp_path):
+        """Deliberate change: a fresh boot no longer limps on repo-less."""
+        sup = _make_supervisor(tmp_path)
+        _mock_run_phases(sup)
+        sup.sync_repositories = AsyncMock(return_value=[sup.repositories[1]])
+
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch(
+                "sandbox_runtime.entrypoint.BOOT_WARNINGS_FILE_PATH",
+                str(tmp_path / "warnings.jsonl"),
+            ),
+        ):
+            await sup.run()
+
+        sup._report_fatal_error.assert_called_once()
+        assert "acme/backend" in sup._report_fatal_error.call_args.args[0]
+        sup.start_opencode.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_snapshot_boot_member_failure_warns_and_continues(self, tmp_path):
+        sup = _make_supervisor(tmp_path)
+        _mock_run_phases(sup)
+        sup.sync_repositories = AsyncMock(return_value=[sup.repositories[1]])
+
+        with (
+            patch.dict(os.environ, {"RESTORED_FROM_SNAPSHOT": "true"}, clear=False),
+            patch(
+                "sandbox_runtime.entrypoint.BOOT_WARNINGS_FILE_PATH",
+                str(tmp_path / "warnings.jsonl"),
+            ),
+        ):
+            await sup.run()
+
+        sup._report_fatal_error.assert_not_called()
+        sup.start_opencode.assert_called_once()
+        warning = json.loads((tmp_path / "warnings.jsonl").read_text().splitlines()[0])
+        assert warning["scope"] == "sync"
+        assert warning["repoName"] == "backend"
+
+
+class TestHookOrchestration:
+    @pytest.mark.asyncio
+    async def test_fresh_setup_failure_warns_and_runs_remaining_members(self, tmp_path):
+        sup = _make_supervisor(tmp_path)
+        _mock_run_phases(sup)
+        sup.run_setup_script = AsyncMock(side_effect=[False, True])
+
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch(
+                "sandbox_runtime.entrypoint.BOOT_WARNINGS_FILE_PATH",
+                str(tmp_path / "warnings.jsonl"),
+            ),
+        ):
+            await sup.run()
+
+        assert [c.args[0] for c in sup.run_setup_script.await_args_list] == sup.repositories
+        sup._report_fatal_error.assert_not_called()
+        sup.start_opencode.assert_called_once()
+        warning = json.loads((tmp_path / "warnings.jsonl").read_text().splitlines()[0])
+        assert warning["scope"] == "setup"
+        assert warning["repoName"] == "frontend"
+
+    @pytest.mark.asyncio
+    async def test_build_setup_failure_is_fatal_naming_member(self, tmp_path):
+        sup = _make_supervisor(tmp_path)
+        _mock_run_phases(sup)
+        sup.run_setup_script = AsyncMock(side_effect=[True, False])
+
+        with (
+            patch.dict(os.environ, {"IMAGE_BUILD_MODE": "true"}, clear=False),
+            patch(
+                "sandbox_runtime.entrypoint.BOOT_WARNINGS_FILE_PATH",
+                str(tmp_path / "warnings.jsonl"),
+            ),
+        ):
+            await sup.run()
+
+        sup._report_fatal_error.assert_called_once()
+        assert "acme/backend" in sup._report_fatal_error.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_primary_start_failure_is_fatal(self, tmp_path):
+        sup = _make_supervisor(tmp_path)
+        _mock_run_phases(sup)
+        sup.run_start_script = AsyncMock(side_effect=[False, True])
+
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch(
+                "sandbox_runtime.entrypoint.BOOT_WARNINGS_FILE_PATH",
+                str(tmp_path / "warnings.jsonl"),
+            ),
+        ):
+            await sup.run()
+
+        sup._report_fatal_error.assert_called_once()
+        assert "acme/frontend" in sup._report_fatal_error.call_args.args[0]
+        sup.start_opencode.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_secondary_start_failure_warns_and_continues(self, tmp_path):
+        sup = _make_supervisor(tmp_path)
+        _mock_run_phases(sup)
+        sup.run_start_script = AsyncMock(side_effect=[True, False])
+
+        with (
+            patch.dict(os.environ, {}, clear=False),
+            patch(
+                "sandbox_runtime.entrypoint.BOOT_WARNINGS_FILE_PATH",
+                str(tmp_path / "warnings.jsonl"),
+            ),
+        ):
+            await sup.run()
+
+        sup._report_fatal_error.assert_not_called()
+        sup.start_opencode.assert_called_once()
+        warning = json.loads((tmp_path / "warnings.jsonl").read_text().splitlines()[0])
+        assert warning["scope"] == "start"
+        assert warning["repoName"] == "backend"
+
+
+class TestOpencodeWorkdir:
+    def test_multi_repo_roots_at_workspace(self, tmp_path):
+        sup = _make_supervisor(tmp_path)
+        (tmp_path / "frontend" / ".git").mkdir(parents=True)
+        (tmp_path / "backend" / ".git").mkdir(parents=True)
+
+        assert sup._opencode_workdir() == tmp_path
+
+    def test_single_repo_roots_at_repo(self, tmp_path):
+        config = json.dumps({"session_id": "s", "branch": "main"})
+        sup = _make_supervisor(tmp_path, session_config=config)
+        (tmp_path / "frontend" / ".git").mkdir(parents=True)
+
+        assert sup._opencode_workdir() == tmp_path / "frontend"
+
+    def test_no_repo_roots_at_workspace(self, tmp_path):
+        config = json.dumps({"session_id": "s"})
+        with patch.dict(
+            os.environ,
+            {
+                "SANDBOX_ID": "t",
+                "REPO_OWNER": "",
+                "REPO_NAME": "",
+                "SESSION_CONFIG": config,
+            },
+            clear=False,
+        ):
+            sup = SandboxSupervisor()
+        sup.workspace_path = tmp_path
+        sup.repositories = sup._parse_repositories()
+
+        assert sup.repositories == []
+        assert sup._opencode_workdir() == tmp_path
+
+
+class TestWorkspaceManifest:
+    def test_writes_manifest_with_members_and_working_branch(self, tmp_path):
+        sup = _make_supervisor(tmp_path)
+        (tmp_path / "frontend").mkdir()
+        (tmp_path / "backend").mkdir()
+        (tmp_path / "backend" / "AGENTS.md").write_text("# backend rules")
+
+        sup._write_workspace_manifest()
+
+        manifest = (tmp_path / "AGENTS.md").read_text()
+        assert "Generated by Open-Inspect" in manifest
+        assert "| `./frontend/` | acme/frontend | `main` |" in manifest
+        assert "| `./backend/` | acme/backend | `develop` |" in manifest
+        assert "`open-inspect/sess-1`" in manifest
+        assert "`./backend/AGENTS.md`" in manifest
+        assert "`./frontend/AGENTS.md`" not in manifest
+        assert "create-pull-request" in manifest
+        assert "`repo`" in manifest
+
+    def test_omits_working_branch_line_when_absent(self, tmp_path):
+        config = json.loads(MULTI_SESSION_CONFIG)
+        del config["working_branch_name"]
+        sup = _make_supervisor(tmp_path, session_config=json.dumps(config))
+
+        sup._write_workspace_manifest()
+
+        manifest = (tmp_path / "AGENTS.md").read_text()
+        assert "open-inspect/sess-1" not in manifest
+
+    def test_single_repo_writes_nothing(self, tmp_path):
+        config = json.dumps({"session_id": "s", "branch": "main"})
+        sup = _make_supervisor(tmp_path, session_config=config)
+
+        sup._write_workspace_manifest()
+
+        assert not (tmp_path / "AGENTS.md").exists()
+
+
+class TestOpencodeAssembly:
+    def test_copies_in_position_order_with_collision_warning(self, tmp_path):
+        sup = _make_supervisor(tmp_path)
+        front = tmp_path / "frontend" / ".opencode" / "command"
+        back = tmp_path / "backend" / ".opencode" / "command"
+        front.mkdir(parents=True)
+        back.mkdir(parents=True)
+        (front / "deploy.md").write_text("from-frontend")
+        (back / "deploy.md").write_text("from-backend")
+        (tmp_path / "backend" / ".opencode" / "tool").mkdir()
+        (tmp_path / "backend" / ".opencode" / "tool" / "db.js").write_text("tool")
+
+        with patch(
+            "sandbox_runtime.entrypoint.BOOT_WARNINGS_FILE_PATH",
+            str(tmp_path / "warnings.jsonl"),
+        ):
+            sup._assemble_workspace_opencode()
+
+        merged = tmp_path / ".opencode"
+        assert (merged / "command" / "deploy.md").read_text() == "from-backend"
+        assert (merged / "tool" / "db.js").read_text() == "tool"
+        warning = json.loads((tmp_path / "warnings.jsonl").read_text().splitlines()[0])
+        assert warning["scope"] == "assembly"
+        assert warning["repoName"] == "backend"
+        assert "acme/frontend" in warning["message"]
+
+    def test_skips_node_modules(self, tmp_path):
+        sup = _make_supervisor(tmp_path)
+        nm = tmp_path / "frontend" / ".opencode" / "node_modules" / "pkg"
+        nm.mkdir(parents=True)
+        (nm / "index.js").write_text("x")
+
+        sup._assemble_workspace_opencode()
+
+        assert not (tmp_path / ".opencode" / "node_modules").exists()
+
+    def test_noop_for_single_repo(self, tmp_path):
+        config = json.dumps({"session_id": "s", "branch": "main"})
+        sup = _make_supervisor(tmp_path, session_config=config)
+        src = tmp_path / "frontend" / ".opencode"
+        src.mkdir(parents=True)
+        (src / "a.md").write_text("a")
+
+        sup._assemble_workspace_opencode()
+
+        assert not (tmp_path / ".opencode").exists()
+
+
+class TestBootWarningRecorder:
+    def test_appends_jsonl_entries(self, tmp_path):
+        sup = _make_supervisor(tmp_path)
+        sup.log = MagicMock()
+
+        with patch(
+            "sandbox_runtime.entrypoint.BOOT_WARNINGS_FILE_PATH",
+            str(tmp_path / "warnings.jsonl"),
+        ):
+            sup._record_boot_warning(scope="setup", message="m1", repo=sup.repositories[0])
+            sup._record_boot_warning(scope="sync", message="m2")
+
+        lines = [
+            json.loads(line) for line in (tmp_path / "warnings.jsonl").read_text().splitlines()
+        ]
+        assert lines[0] == {
+            "scope": "setup",
+            "message": "m1",
+            "repoOwner": "acme",
+            "repoName": "frontend",
+        }
+        assert lines[1] == {"scope": "sync", "message": "m2"}
+        sup.log.warn.assert_any_call(
+            "supervisor.boot_warning",
+            scope="setup",
+            warning_message="m1",
+            repo_owner=ANY,
+            repo_name=ANY,
+        )

--- a/packages/sandbox-runtime/tests/test_multi_repo_workspace.py
+++ b/packages/sandbox-runtime/tests/test_multi_repo_workspace.py
@@ -50,6 +50,7 @@ def _make_supervisor(tmp_path, session_config: str = MULTI_SESSION_CONFIG) -> Sa
 
 def _mock_run_phases(sup: SandboxSupervisor) -> None:
     """Mock everything run() touches beyond the phase under test."""
+    sup._write_repo_manifest = MagicMock()
     sup._ensure_credential_helper_configured = AsyncMock()
     sup.sync_repositories = AsyncMock(return_value=[])
     sup.run_setup_script = AsyncMock(return_value=True)
@@ -95,6 +96,54 @@ class TestParseRepositories:
         ]
         assert sup.is_multi_repo is False
 
+    def test_unsafe_repo_name_defers_config_error(self, tmp_path):
+        config = json.dumps(
+            {
+                "session_id": "s",
+                "repositories": [{"repo_owner": "acme", "repo_name": "../../etc"}],
+            }
+        )
+        sup = _make_supervisor(tmp_path, session_config=config)
+
+        assert sup.repositories == []
+        assert "repo_name" in sup.repo_config_error
+
+    def test_duplicate_repo_names_defer_config_error(self, tmp_path):
+        config = json.dumps(
+            {
+                "session_id": "s",
+                "repositories": [
+                    {"repo_owner": "acme", "repo_name": "app"},
+                    {"repo_owner": "globex", "repo_name": "App"},
+                ],
+            }
+        )
+        sup = _make_supervisor(tmp_path, session_config=config)
+
+        assert sup.repositories == []
+        assert "duplicate" in sup.repo_config_error
+
+    @pytest.mark.asyncio
+    async def test_run_fails_fatally_on_config_error(self, tmp_path):
+        config = json.dumps(
+            {
+                "session_id": "s",
+                "repositories": [{"repo_owner": "acme", "repo_name": "a/b"}],
+            }
+        )
+        sup = _make_supervisor(tmp_path, session_config=config)
+        _mock_run_phases(sup)
+
+        with patch(
+            "sandbox_runtime.entrypoint.BOOT_WARNINGS_FILE_PATH",
+            str(tmp_path / "warnings.jsonl"),
+        ):
+            await sup.run()
+
+        sup._report_fatal_error.assert_called_once()
+        assert "invalid repository config" in sup._report_fatal_error.call_args.args[0]
+        sup.start_opencode.assert_not_called()
+
 
 class TestSyncRepositories:
     @pytest.mark.asyncio
@@ -106,6 +155,20 @@ class TestSyncRepositories:
 
         assert failed == [sup.repositories[1]]
         assert sup._sync_repo.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_clone_subprocess_exception_is_a_member_failure(self, tmp_path):
+        """An OSError from the clone subprocess must surface as a failed
+        member, not abort the whole sync gather."""
+        sup = _make_supervisor(tmp_path)
+
+        with patch(
+            "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
+            AsyncMock(side_effect=OSError("no more processes")),
+        ):
+            failed = await sup.sync_repositories()
+
+        assert failed == sup.repositories
 
     @pytest.mark.asyncio
     async def test_fresh_boot_member_failure_is_fatal(self, tmp_path):
@@ -330,6 +393,22 @@ class TestOpencodeAssembly:
         assert warning["repoName"] == "backend"
         assert "acme/frontend" in warning["message"]
 
+    def test_rebuilds_from_clean_tree(self, tmp_path):
+        """Stale generated files (e.g. from a previous boot's member set)
+        must not survive reassembly on snapshot/repo-image boots."""
+        sup = _make_supervisor(tmp_path)
+        stale = tmp_path / ".opencode" / "command" / "removed.md"
+        stale.parent.mkdir(parents=True)
+        stale.write_text("from a member no longer in the session")
+        src = tmp_path / "frontend" / ".opencode" / "command"
+        src.mkdir(parents=True)
+        (src / "deploy.md").write_text("current")
+
+        sup._assemble_workspace_opencode()
+
+        assert not stale.exists()
+        assert (tmp_path / ".opencode" / "command" / "deploy.md").read_text() == "current"
+
     def test_skips_node_modules(self, tmp_path):
         sup = _make_supervisor(tmp_path)
         nm = tmp_path / "frontend" / ".opencode" / "node_modules" / "pkg"
@@ -350,6 +429,34 @@ class TestOpencodeAssembly:
         sup._assemble_workspace_opencode()
 
         assert not (tmp_path / ".opencode").exists()
+
+
+class TestRepoManifestFile:
+    def test_writes_canonical_entries_with_paths(self, tmp_path):
+        sup = _make_supervisor(tmp_path)
+        manifest_path = tmp_path / "repo-manifest.json"
+
+        with patch(
+            "sandbox_runtime.entrypoint.REPO_MANIFEST_FILE_PATH",
+            str(manifest_path),
+        ):
+            sup._write_repo_manifest()
+
+        manifest = json.loads(manifest_path.read_text())
+        assert manifest["repositories"] == [
+            {
+                "owner": "acme",
+                "name": "frontend",
+                "branch": "main",
+                "path": str(tmp_path / "frontend"),
+            },
+            {
+                "owner": "acme",
+                "name": "backend",
+                "branch": "develop",
+                "path": str(tmp_path / "backend"),
+            },
+        ]
 
 
 class TestBootWarningRecorder:

--- a/packages/sandbox-runtime/tests/test_multi_repo_workspace.py
+++ b/packages/sandbox-runtime/tests/test_multi_repo_workspace.py
@@ -400,6 +400,8 @@ class TestOpencodeAssembly:
         stale = tmp_path / ".opencode" / "command" / "removed.md"
         stale.parent.mkdir(parents=True)
         stale.write_text("from a member no longer in the session")
+        stale_manifest = tmp_path / ".opencode" / "package.json"
+        stale_manifest.write_text("{}")
         src = tmp_path / "frontend" / ".opencode" / "command"
         src.mkdir(parents=True)
         (src / "deploy.md").write_text("current")
@@ -407,7 +409,25 @@ class TestOpencodeAssembly:
         sup._assemble_workspace_opencode()
 
         assert not stale.exists()
+        assert not stale_manifest.exists()
         assert (tmp_path / ".opencode" / "command" / "deploy.md").read_text() == "current"
+
+    def test_rebuild_preserves_staged_node_modules(self, tmp_path):
+        """The image-managed module tree survives the clean rebuild so
+        snapshot restores keep _stage_opencode_deps' skip-if-present fast
+        path instead of re-copying it every boot."""
+        sup = _make_supervisor(tmp_path)
+        staged = tmp_path / ".opencode" / "node_modules" / "@opencode-ai" / "plugin"
+        staged.mkdir(parents=True)
+        (staged / "index.js").write_text("plugin")
+        stale = tmp_path / ".opencode" / "tool" / "removed.js"
+        stale.parent.mkdir(parents=True)
+        stale.write_text("stale")
+
+        sup._assemble_workspace_opencode()
+
+        assert (staged / "index.js").read_text() == "plugin"
+        assert not stale.exists()
 
     def test_skips_node_modules(self, tmp_path):
         sup = _make_supervisor(tmp_path)

--- a/packages/sandbox-runtime/tests/test_repo_config.py
+++ b/packages/sandbox-runtime/tests/test_repo_config.py
@@ -1,0 +1,132 @@
+"""Tests for the canonical session repository model."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sandbox_runtime.repo_config import (
+    RepoConfigError,
+    RepoEntry,
+    dump_repo_manifest,
+    is_safe_repo_segment,
+    load_repo_manifest,
+    parse_repositories,
+)
+
+WORKSPACE = Path("/workspace")
+
+
+def _config(*entries: dict) -> dict:
+    return {"repositories": list(entries)}
+
+
+class TestIsSafeRepoSegment:
+    @pytest.mark.parametrize("value", ["repo", "my-repo_1.2", ".github", "a"])
+    def test_accepts_single_segments(self, value):
+        assert is_safe_repo_segment(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        ["", ".", "..", "a/b", "/etc", "a\\b", "../escape", "a b", "a\x00b", "~user"],
+    )
+    def test_rejects_separators_and_traversal(self, value):
+        assert is_safe_repo_segment(value) is False
+
+
+class TestParseRepositories:
+    def test_rejects_traversal_repo_name(self):
+        config = _config({"repo_owner": "acme", "repo_name": "../../etc"})
+
+        with pytest.raises(RepoConfigError, match="repo_name"):
+            parse_repositories(config, workspace_path=WORKSPACE)
+
+    def test_rejects_absolute_repo_name(self):
+        config = _config({"repo_owner": "acme", "repo_name": "/tmp/x"})
+
+        with pytest.raises(RepoConfigError, match="repo_name"):
+            parse_repositories(config, workspace_path=WORKSPACE)
+
+    def test_rejects_unsafe_owner(self):
+        config = _config({"repo_owner": "a/b", "repo_name": "app"})
+
+        with pytest.raises(RepoConfigError, match="repo_owner"):
+            parse_repositories(config, workspace_path=WORKSPACE)
+
+    def test_rejects_duplicate_names_across_owners_case_insensitively(self):
+        config = _config(
+            {"repo_owner": "acme", "repo_name": "App"},
+            {"repo_owner": "globex", "repo_name": "app"},
+        )
+
+        with pytest.raises(RepoConfigError, match="duplicate"):
+            parse_repositories(config, workspace_path=WORKSPACE)
+
+    def test_skips_entries_missing_owner_or_name(self):
+        config = _config(
+            {"repo_owner": "acme", "repo_name": "app"},
+            {"repo_owner": "", "repo_name": "ghost"},
+            {"repo_name": "ghost2"},
+            "not-a-dict",
+        )
+
+        entries = parse_repositories(config, workspace_path=WORKSPACE)
+
+        assert [(e.owner, e.name) for e in entries] == [("acme", "app")]
+
+    def test_validates_scalar_fallback(self):
+        with pytest.raises(RepoConfigError, match="repo_name"):
+            parse_repositories(
+                {},
+                workspace_path=WORKSPACE,
+                scalar_owner="acme",
+                scalar_name="../escape",
+            )
+
+    def test_paths_derive_from_workspace(self):
+        config = _config({"repo_owner": "acme", "repo_name": "app", "branch": "dev"})
+
+        entries = parse_repositories(config, workspace_path=WORKSPACE)
+
+        assert entries == [
+            RepoEntry(owner="acme", name="app", branch="dev", path=WORKSPACE / "app")
+        ]
+
+
+class TestRepoManifest:
+    def test_round_trips_entries(self, tmp_path):
+        entries = [
+            RepoEntry(owner="acme", name="frontend", branch="main", path=WORKSPACE / "frontend"),
+            RepoEntry(owner="acme", name="backend", branch="dev", path=WORKSPACE / "backend"),
+        ]
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(dump_repo_manifest(entries))
+
+        assert load_repo_manifest(manifest) == entries
+
+    def test_missing_file_loads_empty(self, tmp_path):
+        assert load_repo_manifest(tmp_path / "absent.json") == []
+
+    def test_malformed_file_loads_empty(self, tmp_path):
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text("{not json")
+
+        assert load_repo_manifest(manifest) == []
+
+    def test_skips_incomplete_entries(self, tmp_path):
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "repositories": [
+                        {"owner": "acme", "name": "app", "path": "/workspace/app"},
+                        {"owner": "acme", "name": "no-path"},
+                        {"name": "no-owner", "path": "/workspace/x"},
+                    ]
+                }
+            )
+        )
+
+        entries = load_repo_manifest(manifest)
+
+        assert [(e.owner, e.name) for e in entries] == [("acme", "app")]

--- a/packages/sandbox-runtime/tests/test_repo_config.py
+++ b/packages/sandbox-runtime/tests/test_repo_config.py
@@ -9,6 +9,7 @@ from sandbox_runtime.repo_config import (
     RepoConfigError,
     RepoEntry,
     dump_repo_manifest,
+    find_repo_entry,
     is_safe_repo_segment,
     load_repo_manifest,
     parse_repositories,
@@ -91,6 +92,22 @@ class TestParseRepositories:
         assert entries == [
             RepoEntry(owner="acme", name="app", branch="dev", path=WORKSPACE / "app")
         ]
+
+
+FIND_ENTRIES = [
+    RepoEntry(owner="Acme", name="Frontend", branch="main", path=WORKSPACE / "Frontend"),
+    RepoEntry(owner="acme", name="backend", branch="dev", path=WORKSPACE / "backend"),
+]
+
+
+class TestFindRepoEntry:
+    def test_matches_case_insensitively_returning_canonical_entry(self):
+        entry = find_repo_entry(FIND_ENTRIES, "ACME", "frontend")
+
+        assert entry is FIND_ENTRIES[0]
+
+    def test_returns_none_for_non_member(self):
+        assert find_repo_entry(FIND_ENTRIES, "acme", "missing") is None
 
 
 class TestRepoManifest:

--- a/packages/sandbox-runtime/tests/test_setup_script.py
+++ b/packages/sandbox-runtime/tests/test_setup_script.py
@@ -19,6 +19,7 @@ def _make_supervisor(tmp_path) -> SandboxSupervisor:
         },
     ):
         sup = SandboxSupervisor()
+    sup.workspace_path = tmp_path
     sup.repo_path = tmp_path / "app"
     sup.repositories = sup._parse_repositories()
     return sup

--- a/packages/sandbox-runtime/tests/test_setup_script.py
+++ b/packages/sandbox-runtime/tests/test_setup_script.py
@@ -20,6 +20,7 @@ def _make_supervisor(tmp_path) -> SandboxSupervisor:
     ):
         sup = SandboxSupervisor()
     sup.repo_path = tmp_path / "app"
+    sup.repositories = sup._parse_repositories()
     return sup
 
 
@@ -57,7 +58,7 @@ class TestSetupScriptSkip:
         sup.repo_path.mkdir(parents=True, exist_ok=True)
 
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
-            result = await sup.run_setup_script()
+            result = await sup.run_setup_script(sup.repositories[0])
 
         assert result is True
         mock_exec.assert_not_called()
@@ -67,7 +68,7 @@ class TestSetupScriptSkip:
         # repo_path does not exist at all
 
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
-            result = await sup.run_setup_script()
+            result = await sup.run_setup_script(sup.repositories[0])
 
         assert result is True
         mock_exec.assert_not_called()
@@ -89,7 +90,7 @@ class TestSetupScriptSuccess:
         with patch(
             "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
         ):
-            result = await sup.run_setup_script()
+            result = await sup.run_setup_script(sup.repositories[0])
 
         assert result is True
 
@@ -101,7 +102,7 @@ class TestSetupScriptSuccess:
         with patch(
             "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
         ) as mock_exec:
-            await sup.run_setup_script()
+            await sup.run_setup_script(sup.repositories[0])
 
         mock_exec.assert_called_once()
         call_args = mock_exec.call_args
@@ -117,7 +118,7 @@ class TestSetupScriptSuccess:
         with patch(
             "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
         ):
-            result = await sup.run_setup_script()
+            result = await sup.run_setup_script(sup.repositories[0])
 
         assert result is True
 
@@ -132,7 +133,7 @@ class TestSetupScriptSuccess:
                 "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
             ) as mock_exec,
         ):
-            await sup.run_setup_script()
+            await sup.run_setup_script(sup.repositories[0])
 
         env_arg = mock_exec.call_args[1]["env"]
         assert "MY_VAR" in env_arg
@@ -155,7 +156,7 @@ class TestSetupScriptFailure:
         with patch(
             "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
         ):
-            result = await sup.run_setup_script()
+            result = await sup.run_setup_script(sup.repositories[0])
 
         assert result is False
 
@@ -168,7 +169,7 @@ class TestSetupScriptFailure:
             new_callable=AsyncMock,
             side_effect=OSError("exec failed"),
         ):
-            result = await sup.run_setup_script()
+            result = await sup.run_setup_script(sup.repositories[0])
 
         assert result is False
 
@@ -192,7 +193,7 @@ class TestSetupScriptTimeout:
         with patch(
             "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
         ):
-            result = await sup.run_setup_script()
+            result = await sup.run_setup_script(sup.repositories[0])
 
         assert result is False
         fake_proc.kill.assert_called_once()
@@ -218,7 +219,7 @@ class TestSetupScriptTimeout:
             import os
 
             os.environ.pop("SETUP_TIMEOUT_SECONDS", None)
-            await sup.run_setup_script()
+            await sup.run_setup_script(sup.repositories[0])
 
         assert captured_timeout["value"] == 300
 
@@ -239,7 +240,7 @@ class TestSetupScriptTimeout:
             patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc),
             patch("asyncio.wait_for", side_effect=capturing_wait_for),
         ):
-            await sup.run_setup_script()
+            await sup.run_setup_script(sup.repositories[0])
 
         assert captured_timeout["value"] == 60
 
@@ -260,7 +261,7 @@ class TestSetupScriptTimeout:
             patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc),
             patch("asyncio.wait_for", side_effect=capturing_wait_for),
         ):
-            result = await sup.run_setup_script()
+            result = await sup.run_setup_script(sup.repositories[0])
 
         assert result is True
         assert captured_timeout["value"] == 300
@@ -278,7 +279,7 @@ class TestSetupInRun:
         sup = _make_supervisor(tmp_path)
 
         # Mock all phases
-        sup.perform_git_sync = AsyncMock(return_value=True)
+        sup.sync_repositories = AsyncMock(return_value=[])
         sup.run_setup_script = AsyncMock(return_value=True)
         sup.run_start_script = AsyncMock(return_value=True)
         sup.start_opencode = AsyncMock()
@@ -307,7 +308,7 @@ class TestSetupInRun:
         sup = _make_supervisor(tmp_path)
 
         # Mock all phases
-        sup._quick_git_fetch = AsyncMock()
+        sup.sync_repositories = AsyncMock(return_value=[])
         sup.run_setup_script = AsyncMock(return_value=True)
         sup.run_start_script = AsyncMock(return_value=True)
         sup.start_opencode = AsyncMock()

--- a/packages/sandbox-runtime/tests/test_start_script.py
+++ b/packages/sandbox-runtime/tests/test_start_script.py
@@ -20,6 +20,7 @@ def _make_supervisor(tmp_path) -> SandboxSupervisor:
     ):
         sup = SandboxSupervisor()
     sup.repo_path = tmp_path / "app"
+    sup.repositories = sup._parse_repositories()
     return sup
 
 
@@ -51,7 +52,7 @@ class TestStartScriptSkip:
         sup.repo_path.mkdir(parents=True, exist_ok=True)
 
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
-            result = await sup.run_start_script()
+            result = await sup.run_start_script(sup.repositories[0])
 
         assert result is True
         mock_exec.assert_not_called()
@@ -60,7 +61,7 @@ class TestStartScriptSkip:
         sup = _make_supervisor(tmp_path)
 
         with patch("asyncio.create_subprocess_exec", new_callable=AsyncMock) as mock_exec:
-            result = await sup.run_start_script()
+            result = await sup.run_start_script(sup.repositories[0])
 
         assert result is True
         mock_exec.assert_not_called()
@@ -77,7 +78,7 @@ class TestStartScriptSuccess:
         with patch(
             "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
         ):
-            result = await sup.run_start_script()
+            result = await sup.run_start_script(sup.repositories[0])
 
         assert result is True
 
@@ -89,7 +90,7 @@ class TestStartScriptSuccess:
         with patch(
             "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
         ) as mock_exec:
-            await sup.run_start_script()
+            await sup.run_start_script(sup.repositories[0])
 
         mock_exec.assert_called_once()
         call_args = mock_exec.call_args
@@ -106,7 +107,7 @@ class TestStartScriptSuccess:
         with patch(
             "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
         ) as mock_exec:
-            await sup.run_start_script()
+            await sup.run_start_script(sup.repositories[0])
 
         env_arg = mock_exec.call_args[1]["env"]
         assert env_arg["OPENINSPECT_BOOT_MODE"] == "repo_image"
@@ -123,7 +124,7 @@ class TestStartScriptFailure:
         with patch(
             "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
         ):
-            result = await sup.run_start_script()
+            result = await sup.run_start_script(sup.repositories[0])
 
         assert result is False
 
@@ -136,7 +137,7 @@ class TestStartScriptFailure:
             new_callable=AsyncMock,
             side_effect=OSError("exec failed"),
         ):
-            result = await sup.run_start_script()
+            result = await sup.run_start_script(sup.repositories[0])
 
         assert result is False
 
@@ -155,7 +156,7 @@ class TestStartScriptTimeout:
         with patch(
             "asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc
         ):
-            result = await sup.run_start_script()
+            result = await sup.run_start_script(sup.repositories[0])
 
         assert result is False
         fake_proc.kill.assert_called_once()
@@ -181,7 +182,7 @@ class TestStartScriptTimeout:
             import os
 
             os.environ.pop("START_TIMEOUT_SECONDS", None)
-            await sup.run_start_script()
+            await sup.run_start_script(sup.repositories[0])
 
         assert captured_timeout["value"] == 120
 
@@ -202,7 +203,7 @@ class TestStartScriptTimeout:
             patch("asyncio.create_subprocess_exec", new_callable=AsyncMock, return_value=fake_proc),
             patch("asyncio.wait_for", side_effect=capturing_wait_for),
         ):
-            await sup.run_start_script()
+            await sup.run_start_script(sup.repositories[0])
 
         assert captured_timeout["value"] == 45
 
@@ -213,7 +214,7 @@ class TestStartInRunStrict:
     async def test_run_fails_fast_when_start_script_fails(self, tmp_path):
         sup = _make_supervisor(tmp_path)
 
-        sup.perform_git_sync = AsyncMock(return_value=True)
+        sup.sync_repositories = AsyncMock(return_value=[])
         sup.run_setup_script = AsyncMock(return_value=True)
         sup.run_start_script = AsyncMock(return_value=False)
         sup.start_opencode = AsyncMock()

--- a/packages/sandbox-runtime/tests/test_start_script.py
+++ b/packages/sandbox-runtime/tests/test_start_script.py
@@ -19,6 +19,7 @@ def _make_supervisor(tmp_path) -> SandboxSupervisor:
         },
     ):
         sup = SandboxSupervisor()
+    sup.workspace_path = tmp_path
     sup.repo_path = tmp_path / "app"
     sup.repositories = sup._parse_repositories()
     return sup

--- a/packages/sandbox-runtime/tests/test_types.py
+++ b/packages/sandbox-runtime/tests/test_types.py
@@ -41,3 +41,26 @@ class TestSandboxTypes:
         assert config.provider == "anthropic"
         assert config.model == "claude-sonnet-4-6"
         assert config.branch is None
+
+
+class TestSessionConfigRepositories:
+    def test_parses_repositories_and_working_branch(self):
+        config = SessionConfig(
+            session_id="s1",
+            repositories=[
+                {"repo_owner": "acme", "repo_name": "frontend", "branch": "main"},
+                {"repo_owner": "acme", "repo_name": "backend"},
+            ],
+            working_branch_name="open-inspect/s1",
+        )
+
+        round_tripped = SessionConfig.model_validate_json(config.model_dump_json())
+        assert round_tripped.repositories is not None
+        assert len(round_tripped.repositories) == 2
+        assert round_tripped.repositories[0]["repo_name"] == "frontend"
+        assert round_tripped.working_branch_name == "open-inspect/s1"
+
+    def test_absent_fields_default_to_none(self):
+        config = SessionConfig(session_id="s1")
+        assert config.repositories is None
+        assert config.working_branch_name is None


### PR DESCRIPTION
## Summary

PR-1 of the multi-repo sessions plan (`docs/multi-repo-sessions-implementation-plan.md`, design `docs/multi-repo-sessions-design.md` §6.6/§5.4/§6.5): the sandbox runtime becomes **list-native**. `SESSION_CONFIG.repositories` (ordered, first = primary) drives every code path; absent, a one-entry list is synthesized from `REPO_OWNER`/`REPO_NAME`, so single-repo sessions run the exact same code. **Inert until the control plane sends the new fields** (PR-2/PR-4).

### Runtime (`entrypoint.py`)
- **Unified per-repo sync rule** for every boot mode: existing checkout → set-url/fetch/checkout, missing → clone; members sync concurrently (`asyncio.gather`). Git primitives are parameterized by repo.
- **Failure policy split** (D§6.6): fresh/build boots are **fatal** on any member failure, naming the member (**deliberate behavior change** — previously a fresh boot limped on repo-less); image/snapshot boots keep their leniency and queue a `warning` instead (a deleted upstream branch must not brick a resume).
- **Hooks per member, position order**: setup only on fresh/build boots (build fatal on first failing member; fresh warns and continues); start on non-build boots (primary fatal, secondaries warn and continue).
- **OpenCode + code-server root**: `/workspace` when N>1 (or repo-less); the repo itself for single-repo sessions (unchanged).
- **Generated workspace manifest** (`/workspace/AGENTS.md`, multi-repo only, regenerated every boot): member table with base branches, the shared working-branch name read from `SESSION_CONFIG.working_branch_name` (computed control-plane-side — the runtime never derives branch names), per-member `AGENTS.md` enumeration, and the `create-pull-request repo:` instruction.
- **`.opencode` assembly** (multi-repo only): member repos' `.opencode/` merged into `/workspace/.opencode/` in position order, last-write-wins with a collision warning naming both members; system tools still install after (single-repo parity).
- **Boot warnings channel**: the supervisor has no control-plane event channel, so warnings append to `/tmp/oi-boot-warnings.jsonl` (cleared every boot); the bridge drains the file into `warning` sandbox events after its WebSocket handshake. The event schema member lands in PR-3 — until then live ingest drops them, harmlessly.

### Bridge (`bridge.py`)
- `_handle_push` targets the member named by `pushSpec.repoOwner/repoName`; unknown member → `push_error` naming it; specs without identity keep today's sole-clone behavior. `push_complete`/`push_error` echo repo identity when the spec carried it, and the "No repository found" path now includes `branchName` (today's key-less event is dropped at CP ingest, leaking the pending push resolver for 360s — PR-3/5 finish this fix).
- Git identity is configured in **every** member checkout (previously first-glob only).

### Contracts & plumbing
- `types.py` `SessionConfig` gains `repositories` + `working_branch_name` — load-bearing: this pydantic model is round-tripped by modal-infra and silently drops unknown keys.
- `inspect-plugin.js` `create-pull-request` gains an optional `repo` (`"owner/name"`) arg — required (with the valid list in the error) when the session spans multiple repositories; `headBranch` resolves via `git -C /workspace/{name}`; body forwards `repoOwner`/`repoName`. Also fixes the stale `baseBranch` doc (the handler already defaults to the **session** base branch — D§6.7-3 correction).
- `CACHE_BUSTER` → `v53-list-native-runtime` (the new runtime must be in the base image before any multi-repo session can boot).

### Tests
392 pass in sandbox-runtime (was 364 pre-PR), 179 in modal-infra. New coverage: repository-list parsing/synthesis; sync failure lists; fresh-fatal vs snapshot-warn policy (run()-level); hook ordering + full fatality matrix; workdir rule; manifest content; assembly order/collision/node_modules skip; boot-warning recorder + bridge drain (incl. malformed lines, exactly-once); push targeting/unknown-member/legacy-fallback/branch-on-no-repo; SessionConfig round-trip. Existing suites updated for the per-repo signatures.

Writing the tests surfaced a real bug in the first cut: passing `message` as a structured-log kwarg collides with Python logging's reserved LogRecord field and would have turned every boot warning into a fatal spawn error — now pinned by tests.

### Deploy note
Merge **after** PR #897 (phase order; no code dependency). Runtime changes are inert until the control plane sends `repositories` — single-repo boots exercise the synthesized one-entry path, covered by the full regression suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-repository session support across repository sync, per-repository setup/start hooks, and workspace preparation (including merged opencode assets).
  * Pull request creation can target a specific repository in multi-repo sessions, including repository identity in the request.
  * Multi-repo push now selects the correct checkout based on repo identity and reports identity details in success/errors.
* **Bug Fixes**
  * Boot warnings queued during startup are drained and emitted after the initial handshake.
  * Improved git commit attribution by applying user name/email to all member checkouts.
* **Tests**
  * Expanded coverage for multi-repo workspace, repo manifests, boot warnings, and push/error edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->