### PR TITLE
feat(modal): pass repositories through spawn payload and SESSION_CONFIG

### DIFF
--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -520,6 +520,7 @@ class SandboxManager:
         clone_token: str = "",
         user_env_vars: dict[str, str] | None = None,
         timeout_seconds: int = DEFAULT_BUILD_TIMEOUT_SECONDS,
+        repositories: list[dict] | None = None,
     ) -> SandboxHandle:
         """
         Create a sandbox specifically for image building.
@@ -550,7 +551,13 @@ class SandboxManager:
                 "REPO_OWNER": repo_owner,
                 "REPO_NAME": repo_name,
                 "IMAGE_BUILD_MODE": "true",
-                "SESSION_CONFIG": json.dumps({"branch": default_branch}),
+                # Multi-repo builds (environment images) pass the member list;
+                # the list-native runtime clones and sets up every member.
+                "SESSION_CONFIG": json.dumps(
+                    {"branch": default_branch, "repositories": repositories}
+                    if repositories
+                    else {"branch": default_branch}
+                ),
             }
         )
 

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -27,7 +27,7 @@ from sandbox_runtime.constants import (
     TUNNEL_ENV_FILE_PATH,
 )
 from sandbox_runtime.log_config import get_logger
-from sandbox_runtime.types import SandboxStatus, SessionConfig
+from sandbox_runtime.types import SandboxStatus, SessionConfig, SessionRepositoryConfig
 
 from ..app import app, llm_secrets
 from ..images.base import base_image
@@ -520,7 +520,7 @@ class SandboxManager:
         clone_token: str = "",
         user_env_vars: dict[str, str] | None = None,
         timeout_seconds: int = DEFAULT_BUILD_TIMEOUT_SECONDS,
-        repositories: list[dict] | None = None,
+        repositories: list[SessionRepositoryConfig] | None = None,
     ) -> SandboxHandle:
         """
         Create a sandbox specifically for image building.

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -87,6 +87,30 @@ def _normalize_optional_repository_context(
     return normalized_owner, normalized_name
 
 
+def _session_config_from_create_request(
+    request: dict, *, repo_owner: str | None, repo_name: str | None
+):
+    """Build the create-path SessionConfig from the flat wire request.
+
+    Create is a lossy reconstruction — the manager re-serializes this typed
+    model into SESSION_CONFIG — while restore forwards its session_config
+    dict verbatim. Wire fields share their names with SessionConfig fields,
+    so the model's own field list drives the pickup: a new field only needs
+    the SessionConfig change, not another line here. repo_owner/repo_name
+    are set from the normalized pair, never the raw request.
+    """
+    from .sandbox import SessionConfig
+
+    fields = {
+        name: request[name]
+        for name in SessionConfig.model_fields
+        if name in request and request[name] is not None
+    }
+    fields["repo_owner"] = repo_owner
+    fields["repo_name"] = repo_name
+    return SessionConfig(**fields)
+
+
 @app.function(
     image=function_image,
     secrets=[github_app_secrets, internal_api_secret],
@@ -128,8 +152,6 @@ async def api_create_sandbox(
     require_valid_control_plane_url(control_plane_url)
 
     try:
-        # Import types and manager directly
-        from .sandbox import SessionConfig
         from .sandbox.manager import SandboxConfig, SandboxManager
 
         manager = SandboxManager()
@@ -144,21 +166,8 @@ async def api_create_sandbox(
             resolve_clone_token() if snapshot_id and repo_owner and repo_name else None
         )
 
-        # Create is a lossy reconstruction: this typed model is what the
-        # manager re-serializes into SESSION_CONFIG, so every new wire field
-        # must be threaded here (restore forwards its session_config dict
-        # verbatim and needs no equivalent).
-        session_config = SessionConfig(
-            session_id=request.get("session_id"),
-            repo_owner=repo_owner,
-            repo_name=repo_name,
-            branch=request.get("branch"),
-            opencode_session_id=request.get("opencode_session_id"),
-            provider=request.get("provider", "anthropic"),
-            model=request.get("model", "claude-sonnet-4-6"),
-            mcp_servers=request.get("mcp_servers"),
-            repositories=request.get("repositories"),
-            working_branch_name=request.get("working_branch_name"),
+        session_config = _session_config_from_create_request(
+            request, repo_owner=repo_owner, repo_name=repo_name
         )
 
         config = SandboxConfig(

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -144,6 +144,10 @@ async def api_create_sandbox(
             resolve_clone_token() if snapshot_id and repo_owner and repo_name else None
         )
 
+        # Create is a lossy reconstruction: this typed model is what the
+        # manager re-serializes into SESSION_CONFIG, so every new wire field
+        # must be threaded here (restore forwards its session_config dict
+        # verbatim and needs no equivalent).
         session_config = SessionConfig(
             session_id=request.get("session_id"),
             repo_owner=repo_owner,
@@ -153,6 +157,8 @@ async def api_create_sandbox(
             provider=request.get("provider", "anthropic"),
             model=request.get("model", "claude-sonnet-4-6"),
             mcp_servers=request.get("mcp_servers"),
+            repositories=request.get("repositories"),
+            working_branch_name=request.get("working_branch_name"),
         )
 
         config = SandboxConfig(

--- a/packages/modal-infra/tests/test_build_sandbox.py
+++ b/packages/modal-infra/tests/test_build_sandbox.py
@@ -285,3 +285,36 @@ async def test_system_vars_override_user_env_vars(monkeypatch):
     env = captured["env"]
     assert env["IMAGE_BUILD_MODE"] == "true"
     assert env["SANDBOX_ID"].startswith("build-acme-my-repo-")
+
+
+@pytest.mark.asyncio
+async def test_session_config_includes_repositories_when_passed(monkeypatch):
+    """Multi-repo builds (environment images) pass the member list through."""
+    captured = {}
+    monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", _fake_sandbox_create(captured))
+
+    manager = SandboxManager()
+    members = [
+        {"repo_owner": "acme", "repo_name": "frontend", "branch": "main"},
+        {"repo_owner": "acme", "repo_name": "backend", "branch": "develop"},
+    ]
+    await manager.create_build_sandbox(
+        repo_owner="acme",
+        repo_name="frontend",
+        repositories=members,
+    )
+
+    session_config = json.loads(captured["env"]["SESSION_CONFIG"])
+    assert session_config["repositories"] == members
+
+
+@pytest.mark.asyncio
+async def test_session_config_omits_repositories_by_default(monkeypatch):
+    captured = {}
+    monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", _fake_sandbox_create(captured))
+
+    manager = SandboxManager()
+    await manager.create_build_sandbox(repo_owner="acme", repo_name="my-repo")
+
+    session_config = json.loads(captured["env"]["SESSION_CONFIG"])
+    assert "repositories" not in session_config

--- a/packages/modal-infra/tests/test_web_api_create_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_create_sandbox.py
@@ -292,3 +292,87 @@ async def test_restore_sandbox_rejects_partial_repo_context(monkeypatch, session
 
     assert getattr(exc_info.value, "status_code", None) == 400
     assert "repo_owner and repo_name must be provided together" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_threads_repositories_into_session_config(monkeypatch):
+    """Create reconstructs a typed SessionConfig — new wire fields must be
+    threaded explicitly or pydantic silently drops them."""
+    captured = {}
+    _patch_auth(monkeypatch)
+    _patch_manager(monkeypatch, captured)
+
+    members = [
+        {"repo_owner": "acme", "repo_name": "frontend", "branch": "main"},
+        {"repo_owner": "acme", "repo_name": "backend", "branch": "develop"},
+    ]
+    result = await _call_create_sandbox(
+        {
+            "session_id": "sess-1",
+            "repo_owner": "acme",
+            "repo_name": "frontend",
+            "repositories": members,
+            "working_branch_name": "open-inspect/sess-1",
+            "control_plane_url": "https://control-plane.example",
+            "sandbox_auth_token": "sandbox-token",
+        }
+    )
+
+    assert result["success"] is True
+    session_config = captured["config"].session_config
+    assert [dict(r) for r in session_config.repositories] == members
+    assert session_config.working_branch_name == "open-inspect/sess-1"
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_repositories_default_to_none(monkeypatch):
+    captured = {}
+    _patch_auth(monkeypatch)
+    _patch_manager(monkeypatch, captured)
+
+    result = await _call_create_sandbox(
+        {
+            "session_id": "sess-1",
+            "repo_owner": "acme",
+            "repo_name": "repo",
+            "control_plane_url": "https://control-plane.example",
+            "sandbox_auth_token": "sandbox-token",
+        }
+    )
+
+    assert result["success"] is True
+    assert captured["config"].session_config.repositories is None
+    assert captured["config"].session_config.working_branch_name is None
+
+
+@pytest.mark.asyncio
+async def test_restore_sandbox_forwards_session_config_verbatim(monkeypatch):
+    """Restore is a pass-through: the session_config dict reaches the manager
+    unmodified, so extra keys (repositories, working_branch_name) survive
+    without any Python change."""
+    captured = {}
+    _patch_auth(monkeypatch)
+    _patch_restore_manager(monkeypatch, captured)
+
+    session_config = {
+        "session_id": "sess-1",
+        "repo_owner": "acme",
+        "repo_name": "frontend",
+        "repositories": [
+            {"repo_owner": "acme", "repo_name": "frontend", "branch": "main"},
+            {"repo_owner": "acme", "repo_name": "backend", "branch": "develop"},
+        ],
+        "working_branch_name": "open-inspect/sess-1",
+        "some_future_field": {"nested": True},
+    }
+    result = await _call_restore_sandbox(
+        {
+            "snapshot_image_id": "im-snap-1",
+            "session_config": session_config,
+            "control_plane_url": "https://control-plane.example",
+            "sandbox_auth_token": "sandbox-token",
+        }
+    )
+
+    assert result["success"] is True
+    assert captured["restore"]["session_config"] == session_config

--- a/packages/modal-infra/tests/test_web_api_create_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_create_sandbox.py
@@ -376,3 +376,28 @@ async def test_restore_sandbox_forwards_session_config_verbatim(monkeypatch):
 
     assert result["success"] is True
     assert captured["restore"]["session_config"] == session_config
+
+
+def test_session_config_helper_prefers_normalized_identity():
+    """The helper must take identity from the normalized pair, not the raw request."""
+    config = web_api._session_config_from_create_request(
+        {"session_id": "s1", "repo_owner": " Acme ", "repo_name": " App "},
+        repo_owner="acme",
+        repo_name="app",
+    )
+
+    assert config.repo_owner == "acme"
+    assert config.repo_name == "app"
+
+
+def test_session_config_helper_ignores_null_wire_values():
+    """Explicit nulls on the wire must not clobber SessionConfig defaults."""
+    config = web_api._session_config_from_create_request(
+        {"session_id": "s1", "provider": None, "model": None, "branch": None},
+        repo_owner=None,
+        repo_name=None,
+    )
+
+    assert config.provider == "anthropic"
+    assert config.model == "claude-sonnet-4-6"
+    assert config.branch is None


### PR DESCRIPTION
## Summary

PR-2 of the multi-repo sessions plan (D§6.5) — **stacked on #899** (needs its `SessionConfig` model fields). The two Modal ingest paths are asymmetric and are treated separately:

- **Create is a lossy reconstruction**: `api_create_sandbox` builds a typed `SessionConfig` that the manager re-serializes into the `SESSION_CONFIG` env var, and pydantic silently drops unknown keys — so `repositories` and `working_branch_name` are now read from the request (`request.get`, additive) and threaded into the construction. `REPO_OWNER`/`REPO_NAME` stay the first entry (the control plane keeps sending the scalar mirror).
- **Restore is already a tolerant pass-through**: the `session_config` dict is forwarded verbatim (`web_api.py` → `manager.py` `json.dumps`), so it needs **no Python change** once the control plane's `buildSessionConfig` carries the fields (PR-4) — pinned by a pass-through test asserting extra keys survive, instead of code.
- **Build-sandbox path**: `create_build_sandbox` accepts an optional member list and includes it in the build `SESSION_CONFIG` — used by environment-image builds (PR-10); inert until then.

Inert end-to-end until the control plane sends the fields (PR-4).

### Tests
184 pass in modal-infra (5 new): create-path threading (list + working branch), absent-fields default, restore verbatim pass-through (including an unknown future field), build-path list inclusion and default omission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox builds now support multiple repositories for environment images.
  * Sandbox creation now handles session settings more consistently, including repository and branch-related fields.

* **Bug Fixes**
  * Repository details are now normalized before creating a sandbox, reducing the chance of using incorrect source information.
  * Missing optional session fields now fall back more reliably to expected defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->