### PR TITLE
feat(control-plane): create, store, and spawn multi-repo sessions

### DIFF
--- a/packages/control-plane/src/db/mcp-servers.test.ts
+++ b/packages/control-plane/src/db/mcp-servers.test.ts
@@ -288,22 +288,46 @@ describe("McpServerStore", () => {
     it("returns global and matching repo-scoped servers", async () => {
       const { db } = createFakeD1({ allResults: [sampleRow, remoteRow] });
       const store = new McpServerStore(db);
-      const results = await store.getDecryptedForSession("carboncopyinc", "habakkuk");
+      const results = await store.getDecryptedForSession([
+        { repoOwner: "carboncopyinc", repoName: "habakkuk" },
+      ]);
       expect(results).toHaveLength(2); // global + matching scoped
     });
 
     it("excludes servers scoped to different repos", async () => {
       const { db } = createFakeD1({ allResults: [sampleRow, remoteRow] });
       const store = new McpServerStore(db);
-      const results = await store.getDecryptedForSession("bencered", "dom");
+      const results = await store.getDecryptedForSession([
+        { repoOwner: "bencered", repoName: "dom" },
+      ]);
       expect(results).toHaveLength(1); // only the global server
+      expect(results[0].name).toBe("playwright");
+    });
+
+    it("matches scoped servers through any member of a multi-repo session", async () => {
+      const { db } = createFakeD1({ allResults: [sampleRow, remoteRow] });
+      const store = new McpServerStore(db);
+      const results = await store.getDecryptedForSession([
+        { repoOwner: "bencered", repoName: "dom" },
+        { repoOwner: "carboncopyinc", repoName: "habakkuk" },
+      ]);
+      expect(results).toHaveLength(2); // global + scoped matched via the second member
+    });
+
+    it("returns only unscoped servers for repo-less sessions", async () => {
+      const { db } = createFakeD1({ allResults: [sampleRow, remoteRow] });
+      const store = new McpServerStore(db);
+      const results = await store.getDecryptedForSession([]);
+      expect(results).toHaveLength(1);
       expect(results[0].name).toBe("playwright");
     });
 
     it("returns headers (not env) for remote servers", async () => {
       const { db } = createFakeD1({ allResults: [remoteRowWithHeaders] });
       const store = new McpServerStore(db);
-      const results = await store.getDecryptedForSession("carboncopyinc", "habakkuk");
+      const results = await store.getDecryptedForSession([
+        { repoOwner: "carboncopyinc", repoName: "habakkuk" },
+      ]);
       expect(results).toHaveLength(1);
       const remote = results[0];
       expect(remote.type).toBe("remote");
@@ -317,7 +341,7 @@ describe("McpServerStore", () => {
     it("returns env (not headers) for local servers", async () => {
       const { db } = createFakeD1({ allResults: [sampleRow] });
       const store = new McpServerStore(db);
-      const results = await store.getDecryptedForSession("any", "repo");
+      const results = await store.getDecryptedForSession([{ repoOwner: "any", repoName: "repo" }]);
       expect(results).toHaveLength(1);
       const local = results[0];
       expect(local.type).toBe("local");
@@ -396,14 +420,14 @@ describe("McpServerStore", () => {
     it("no-key path returns plaintext env as-is", async () => {
       const { db } = createFakeD1({ allResults: [sampleRow] });
       const store = new McpServerStore(db); // no encryption key
-      const results = await store.getDecryptedForSession("any", "repo");
+      const results = await store.getDecryptedForSession([{ repoOwner: "any", repoName: "repo" }]);
       expect(results[0].env).toEqual({ DEBUG: "1" });
     });
 
     it("falls back to plaintext when decryption fails (pre-encryption row)", async () => {
       const { db } = createFakeD1({ allResults: [sampleRow] });
       const store = new McpServerStore(db, "bm90YXJlYWxrZXlub3RhcmVhbGtleW5vdGFyZWFsa2V5eA==");
-      const results = await store.getDecryptedForSession("any", "repo");
+      const results = await store.getDecryptedForSession([{ repoOwner: "any", repoName: "repo" }]);
       expect(results[0].env).toEqual({ DEBUG: "1" });
     });
 
@@ -412,7 +436,7 @@ describe("McpServerStore", () => {
         allResults: [{ ...sampleRow, env: "notjson_notcipher" }],
       });
       const store = new McpServerStore(db, "bm90YXJlYWxrZXlub3RhcmVhbGtleW5vdGFyZWFsa2V5eA==");
-      const results = await store.getDecryptedForSession("any", "repo");
+      const results = await store.getDecryptedForSession([{ repoOwner: "any", repoName: "repo" }]);
       expect(results[0].env).toEqual({});
     });
   });

--- a/packages/control-plane/src/db/mcp-servers.ts
+++ b/packages/control-plane/src/db/mcp-servers.ts
@@ -289,11 +289,17 @@ export class McpServerStore {
     return (result.meta?.changes ?? 0) > 0;
   }
 
+  /**
+   * Servers applicable to a session's member repositories: unscoped servers
+   * always apply; scoped servers apply when ANY member matches a scope.
+   * Pass an empty list for repo-less sessions (unscoped servers only).
+   */
   async getDecryptedForSession(
-    repoOwner: string | null,
-    repoName: string | null
+    repositories: Array<{ repoOwner: string; repoName: string }>
   ): Promise<McpServerConfig[]> {
-    const repoFullName = repoOwner && repoName ? `${repoOwner}/${repoName}`.toLowerCase() : null;
+    const repoFullNames = new Set(
+      repositories.map((repo) => `${repo.repoOwner}/${repo.repoName}`.toLowerCase())
+    );
     const { results } = await this.db
       .prepare("SELECT * FROM mcp_servers WHERE enabled = 1 ORDER BY name")
       .all<McpServerRow>();
@@ -301,8 +307,7 @@ export class McpServerStore {
     const filtered = results.filter((row) => {
       const scopes = parseRepoScopes(row.repo_scope);
       if (!scopes) return true;
-      if (!repoFullName) return false;
-      return scopes.some((s) => s.toLowerCase() === repoFullName);
+      return scopes.some((s) => repoFullNames.has(s.toLowerCase()));
     });
 
     return Promise.all(filtered.map((r) => this.decryptRow(r)));

--- a/packages/control-plane/src/db/session-index.test.ts
+++ b/packages/control-plane/src/db/session-index.test.ts
@@ -349,14 +349,26 @@ class FakeD1Database {
         rows = rows.filter((r) => r.status !== statusVal);
       }
 
-      if (conditions.includes("repo_owner = ?")) {
-        const ownerVal = args[argIdx++] as string;
-        rows = rows.filter((r) => r.repo_owner === ownerVal);
-      }
-
-      if (conditions.includes("repo_name = ?")) {
-        const nameVal = args[argIdx++] as string;
-        rows = rows.filter((r) => r.repo_name === nameVal);
+      if (conditions.includes("EXISTS (SELECT 1 FROM session_repositories")) {
+        // Combined member/scalar repo filter: params are the member arm's
+        // owner/name followed by the scalar arm's identical owner/name.
+        const hasOwner = conditions.includes("sr.repo_owner = ?");
+        const hasName = conditions.includes("sr.repo_name = ?");
+        const ownerVal = hasOwner ? (args[argIdx++] as string) : null;
+        const nameVal = hasName ? (args[argIdx++] as string) : null;
+        argIdx += (hasOwner ? 1 : 0) + (hasName ? 1 : 0); // scalar-arm copies
+        rows = rows.filter((r) => {
+          const memberMatch = this.repositoryRows.some(
+            (repo) =>
+              repo.session_id === r.id &&
+              (ownerVal === null || repo.repo_owner === ownerVal) &&
+              (nameVal === null || repo.repo_name === nameVal)
+          );
+          const scalarMatch =
+            (ownerVal === null || r.repo_owner === ownerVal) &&
+            (nameVal === null || r.repo_name === nameVal);
+          return memberMatch || scalarMatch;
+        });
       }
 
       const userIdMatch = conditions.match(/user_id IN \(([^)]+)\)/);
@@ -579,6 +591,33 @@ describe("SessionIndexStore", () => {
 
       expect(result.sessions).toHaveLength(1);
       expect(result.sessions[0].id).toBe("match");
+    });
+
+    it("matches sessions through secondary members, not just the scalar primary", async () => {
+      await store.create(
+        makeSession({
+          id: "multi",
+          repoOwner: "acme",
+          repoName: "frontend",
+          repositories: [
+            { repoOwner: "acme", repoName: "frontend", repoId: 1, baseBranch: "main" },
+            { repoOwner: "acme", repoName: "backend", repoId: 2, baseBranch: "main" },
+          ],
+        })
+      );
+      await store.create(makeSession({ id: "other", repoOwner: "acme", repoName: "unrelated" }));
+
+      const result = await store.list({ repoOwner: "acme", repoName: "backend" });
+
+      expect(result.sessions.map((s) => s.id)).toEqual(["multi"]);
+    });
+
+    it("falls back to the scalar columns for pre-feature sessions without member rows", async () => {
+      await store.create(makeSession({ id: "legacy", repoOwner: "acme", repoName: "app" }));
+
+      const result = await store.list({ repoOwner: "acme", repoName: "app" });
+
+      expect(result.sessions.map((s) => s.id)).toEqual(["legacy"]);
     });
 
     it("supports multiple creator user ids", async () => {

--- a/packages/control-plane/src/db/session-index.test.ts
+++ b/packages/control-plane/src/db/session-index.test.ts
@@ -26,8 +26,20 @@ type SessionRow = {
   updated_at: number;
 };
 
+type SessionRepositoryRow = {
+  session_id: string;
+  position: number;
+  repo_owner: string;
+  repo_name: string;
+  repo_id: number | null;
+  base_branch: string;
+};
+
 const QUERY_PATTERNS = {
   INSERT_SESSION: /^INSERT OR IGNORE INTO sessions/,
+  INSERT_SESSION_REPO: /^INSERT INTO session_repositories/,
+  SELECT_SESSION_REPOS: /^SELECT \* FROM session_repositories WHERE session_id IN/,
+  DELETE_SESSION_REPOS: /^DELETE FROM session_repositories WHERE session_id = \?$/,
   SELECT_BY_ID: /^SELECT \* FROM sessions WHERE id = \?$/,
   SELECT_COUNT: /^SELECT COUNT\(\*\) as count FROM sessions\b/,
   SELECT_LIST: /^SELECT \* FROM sessions\b.*ORDER BY updated_at DESC LIMIT/,
@@ -50,11 +62,20 @@ function normalizeQuery(query: string): string {
 
 class FakeD1Database {
   private rows = new Map<string, SessionRow>();
+  readonly repositoryRows: SessionRepositoryRow[] = [];
   readonly preparedQueries: string[] = [];
 
   prepare(query: string) {
     this.preparedQueries.push(normalizeQuery(query));
     return new FakePreparedStatement(this, query);
+  }
+
+  async batch(statements: FakePreparedStatement[]) {
+    const results = [];
+    for (const statement of statements) {
+      results.push(await statement.run());
+    }
+    return results;
   }
 
   first(query: string, args: unknown[]) {
@@ -115,6 +136,13 @@ class FakeD1Database {
         .filter((r) => r.parent_session_id === parentId)
         .sort((a, b) => b.created_at - a.created_at);
       return children;
+    }
+
+    if (QUERY_PATTERNS.SELECT_SESSION_REPOS.test(normalized)) {
+      const ids = new Set(args as string[]);
+      return this.repositoryRows
+        .filter((r) => ids.has(r.session_id))
+        .sort((a, b) => a.session_id.localeCompare(b.session_id) || a.position - b.position);
     }
 
     throw new Error(`Unexpected all() query: ${query}`);
@@ -222,6 +250,35 @@ class FakeD1Database {
         return { meta: { changes: 1 } };
       }
       return { meta: { changes: 0 } };
+    }
+
+    if (QUERY_PATTERNS.INSERT_SESSION_REPO.test(normalized)) {
+      const [sessionId, position, repoOwner, repoName, repoId, baseBranch] = args as [
+        string,
+        number,
+        string,
+        string,
+        number | null,
+        string,
+      ];
+      this.repositoryRows.push({
+        session_id: sessionId,
+        position,
+        repo_owner: repoOwner,
+        repo_name: repoName,
+        repo_id: repoId,
+        base_branch: baseBranch,
+      });
+      return { meta: { changes: 1 } };
+    }
+
+    if (QUERY_PATTERNS.DELETE_SESSION_REPOS.test(normalized)) {
+      const id = args[0] as string;
+      const before = this.repositoryRows.length;
+      for (let i = this.repositoryRows.length - 1; i >= 0; i--) {
+        if (this.repositoryRows[i].session_id === id) this.repositoryRows.splice(i, 1);
+      }
+      return { meta: { changes: before - this.repositoryRows.length } };
     }
 
     if (QUERY_PATTERNS.DELETE_SESSION.test(normalized)) {

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -233,16 +233,29 @@ export class SessionIndexStore {
       params.push(excludeStatus);
     }
 
+    // Repo filters match against the membership table so a session is found
+    // through ANY member, not just the scalar primary mirror. The scalar arm
+    // is the fallback for pre-feature sessions without member rows.
     const normalizedRepoOwner = normalizeRepoIdentifier(repoOwner);
-    if (normalizedRepoOwner) {
-      conditions.push("repo_owner = ?");
-      params.push(normalizedRepoOwner);
-    }
-
     const normalizedRepoName = normalizeRepoIdentifier(repoName);
-    if (normalizedRepoName) {
-      conditions.push("repo_name = ?");
-      params.push(normalizedRepoName);
+    if (normalizedRepoOwner || normalizedRepoName) {
+      const memberConditions: string[] = [];
+      const scalarConditions: string[] = [];
+      const repoFilterParams: unknown[] = [];
+      if (normalizedRepoOwner) {
+        memberConditions.push("sr.repo_owner = ?");
+        scalarConditions.push("repo_owner = ?");
+        repoFilterParams.push(normalizedRepoOwner);
+      }
+      if (normalizedRepoName) {
+        memberConditions.push("sr.repo_name = ?");
+        scalarConditions.push("repo_name = ?");
+        repoFilterParams.push(normalizedRepoName);
+      }
+      conditions.push(
+        `(EXISTS (SELECT 1 FROM session_repositories sr WHERE sr.session_id = sessions.id AND ${memberConditions.join(" AND ")}) OR (${scalarConditions.join(" AND ")}))`
+      );
+      params.push(...repoFilterParams, ...repoFilterParams);
     }
 
     if (createdByUserIds?.length) {
@@ -360,7 +373,8 @@ export class SessionIndexStore {
   }
 
   async delete(id: string): Promise<boolean> {
-    // Member rows first — they hold a foreign key onto sessions(id).
+    // Member rows are removed explicitly for clarity; the FK's ON DELETE
+    // CASCADE also covers callers that delete the session row directly.
     const [, result] = await this.db.batch([
       this.db.prepare("DELETE FROM session_repositories WHERE session_id = ?").bind(id),
       this.db.prepare("DELETE FROM sessions WHERE id = ?").bind(id),

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -1,14 +1,17 @@
-import type { SessionRepositoryState, SessionStatus, SpawnSource } from "@open-inspect/shared";
+import type { SessionStatus, SpawnSource } from "@open-inspect/shared";
 
 /**
- * One member of a session's repository set. Ordered — array position is the
- * persisted `position` column ([0] = primary, mirrored into the scalar
- * repo_owner/repo_name columns).
+ * One member of a session's repository set — the identity subset of the
+ * shared SessionRepositoryState (no git state; D1 doesn't store it).
+ * Ordered — array position is the persisted `position` column ([0] =
+ * primary, mirrored into the scalar repo_owner/repo_name columns).
  */
-export type SessionIndexRepository = Pick<
-  SessionRepositoryState,
-  "repoOwner" | "repoName" | "repoId" | "baseBranch"
->;
+export interface SessionIndexRepository {
+  repoOwner: string;
+  repoName: string;
+  repoId: number | null;
+  baseBranch: string;
+}
 
 export interface SessionEntry {
   id: string;

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -1,5 +1,17 @@
 import type { SessionStatus, SpawnSource } from "@open-inspect/shared";
 
+/**
+ * One member of a session's repository set. Ordered — array position is the
+ * persisted `position` column ([0] = primary, mirrored into the scalar
+ * repo_owner/repo_name columns).
+ */
+export interface SessionIndexRepository {
+  repoOwner: string;
+  repoName: string;
+  repoId: number | null;
+  baseBranch: string;
+}
+
 export interface SessionEntry {
   id: string;
   title: string | null;
@@ -22,6 +34,20 @@ export interface SessionEntry {
   prCount?: number;
   createdAt: number;
   updatedAt: number;
+  /**
+   * Ordered member list; [0] = primary. Absent on pre-feature sessions —
+   * consumers synthesize from repoOwner/repoName.
+   */
+  repositories?: SessionIndexRepository[];
+}
+
+interface SessionRepositoryRow {
+  session_id: string;
+  position: number;
+  repo_owner: string;
+  repo_name: string;
+  repo_id: number | null;
+  base_branch: string;
 }
 
 interface SessionRow {
@@ -119,7 +145,7 @@ export class SessionIndexStore {
   async create(session: SessionEntry): Promise<void> {
     const repository = normalizeSessionRepository(session);
 
-    const result = await this.db
+    const sessionStmt = this.db
       .prepare(
         `INSERT OR IGNORE INTO sessions (id, title, repo_owner, repo_name, model, reasoning_effort, base_branch, status, parent_session_id, spawn_source, spawn_depth, automation_id, automation_run_id, scm_login, user_id, created_at, updated_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
@@ -142,14 +168,31 @@ export class SessionIndexStore {
         session.userId ?? null,
         session.createdAt,
         session.updatedAt
-      )
-      .run();
+      );
+
+    const repositoryStmts = (session.repositories ?? []).map((repo, position) =>
+      this.db
+        .prepare(
+          `INSERT INTO session_repositories (session_id, position, repo_owner, repo_name, repo_id, base_branch)
+           VALUES (?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          session.id,
+          position,
+          normalizeRepoIdentifier(repo.repoOwner),
+          normalizeRepoIdentifier(repo.repoName),
+          repo.repoId,
+          repo.baseBranch
+        )
+    );
+
+    const results = await this.db.batch([sessionStmt, ...repositoryStmts]);
 
     // INSERT OR IGNORE swallows every constraint violation, which would leave
     // the session invisible to dashboards while the DO proceeds. Session ids
     // are always freshly generated, so a skipped insert is a bug — surface it;
     // initialize.ts relies on D1 failures being caught before sandbox spawn.
-    if ((result.meta?.changes ?? 0) === 0) {
+    if ((results[0]?.meta?.changes ?? 0) === 0) {
       throw new Error(
         `Session index insert was skipped for session ${session.id} (duplicate id or constraint violation)`
       );
@@ -216,11 +259,50 @@ export class SessionIndexStore {
 
     const rows = result.results || [];
     const sessions = rows.slice(0, limit).map(toEntry);
+    await this.hydrateRepositories(sessions);
 
     return {
       sessions,
       hasMore: rows.length > limit,
     };
+  }
+
+  /**
+   * Attach member repository lists to the given entries in one query.
+   * Sessions without rows (pre-feature) are left without the field so
+   * consumers fall back to the scalar columns.
+   */
+  private async hydrateRepositories(sessions: SessionEntry[]): Promise<void> {
+    if (sessions.length === 0) return;
+
+    const placeholders = sessions.map(() => "?").join(", ");
+    const result = await this.db
+      .prepare(
+        `SELECT * FROM session_repositories
+         WHERE session_id IN (${placeholders})
+         ORDER BY session_id, position`
+      )
+      .bind(...sessions.map((s) => s.id))
+      .all<SessionRepositoryRow>();
+
+    const bySession = new Map<string, SessionIndexRepository[]>();
+    for (const row of result.results || []) {
+      const list = bySession.get(row.session_id) ?? [];
+      list.push({
+        repoOwner: row.repo_owner,
+        repoName: row.repo_name,
+        repoId: row.repo_id,
+        baseBranch: row.base_branch,
+      });
+      bySession.set(row.session_id, list);
+    }
+
+    for (const session of sessions) {
+      const repositories = bySession.get(session.id);
+      if (repositories) {
+        session.repositories = repositories;
+      }
+    }
   }
 
   async updateTitle(id: string, title: string): Promise<boolean> {
@@ -279,7 +361,11 @@ export class SessionIndexStore {
   }
 
   async delete(id: string): Promise<boolean> {
-    const result = await this.db.prepare("DELETE FROM sessions WHERE id = ?").bind(id).run();
+    // Member rows first — they hold a foreign key onto sessions(id).
+    const [, result] = await this.db.batch([
+      this.db.prepare("DELETE FROM session_repositories WHERE session_id = ?").bind(id),
+      this.db.prepare("DELETE FROM sessions WHERE id = ?").bind(id),
+    ]);
 
     return (result.meta?.changes ?? 0) > 0;
   }

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -1,16 +1,14 @@
-import type { SessionStatus, SpawnSource } from "@open-inspect/shared";
+import type { SessionRepositoryState, SessionStatus, SpawnSource } from "@open-inspect/shared";
 
 /**
  * One member of a session's repository set. Ordered — array position is the
  * persisted `position` column ([0] = primary, mirrored into the scalar
  * repo_owner/repo_name columns).
  */
-export interface SessionIndexRepository {
-  repoOwner: string;
-  repoName: string;
-  repoId: number | null;
-  baseBranch: string;
-}
+export type SessionIndexRepository = Pick<
+  SessionRepositoryState,
+  "repoOwner" | "repoName" | "repoId" | "baseBranch"
+>;
 
 export interface SessionEntry {
   id: string;

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -258,8 +258,7 @@ export class SessionIndexStore {
       .all<SessionRow>();
 
     const rows = result.results || [];
-    const sessions = rows.slice(0, limit).map(toEntry);
-    await this.hydrateRepositories(sessions);
+    const sessions = await this.withRepositories(rows.slice(0, limit).map(toEntry));
 
     return {
       sessions,
@@ -268,12 +267,13 @@ export class SessionIndexStore {
   }
 
   /**
-   * Attach member repository lists to the given entries in one query.
-   * Sessions without rows (pre-feature) are left without the field so
+   * Return copies of the given entries with member repository lists attached,
+   * resolved in one query. The input entries are not mutated. Sessions
+   * without rows (pre-feature) are returned as-is, without the field, so
    * consumers fall back to the scalar columns.
    */
-  private async hydrateRepositories(sessions: SessionEntry[]): Promise<void> {
-    if (sessions.length === 0) return;
+  private async withRepositories(sessions: SessionEntry[]): Promise<SessionEntry[]> {
+    if (sessions.length === 0) return sessions;
 
     const placeholders = sessions.map(() => "?").join(", ");
     const result = await this.db
@@ -297,12 +297,10 @@ export class SessionIndexStore {
       bySession.set(row.session_id, list);
     }
 
-    for (const session of sessions) {
+    return sessions.map((session) => {
       const repositories = bySession.get(session.id);
-      if (repositories) {
-        session.repositories = repositories;
-      }
-    }
+      return repositories ? { ...session, repositories } : session;
+    });
   }
 
   async updateTitle(id: string, title: string): Promise<boolean> {

--- a/packages/control-plane/src/repos/resolve.test.ts
+++ b/packages/control-plane/src/repos/resolve.test.ts
@@ -3,10 +3,16 @@ import { resolveSessionRepositories } from "./resolve";
 import { HttpError, type RequestContext } from "../routes/shared";
 import type { SourceControlProvider, RepositoryAccessResult } from "../source-control";
 import type { Env } from "../types";
+import type { Logger } from "../logger";
 
 const ctx = { request_id: "req-1", trace_id: "trace-1" } as unknown as RequestContext;
 const env = {} as Env;
-const logger = { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() };
+const logger = {
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+} as unknown as Logger;
 
 function createFakeProvider(
   results: Record<string, RepositoryAccessResult | null | Error>

--- a/packages/control-plane/src/repos/resolve.test.ts
+++ b/packages/control-plane/src/repos/resolve.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveSessionRepositories } from "./resolve";
+import { HttpError, type RequestContext } from "../routes/shared";
+import type { SourceControlProvider, RepositoryAccessResult } from "../source-control";
+import type { Env } from "../types";
+
+const ctx = { request_id: "req-1", trace_id: "trace-1" } as unknown as RequestContext;
+const env = {} as Env;
+const logger = { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() };
+
+function createFakeProvider(
+  results: Record<string, RepositoryAccessResult | null | Error>
+): SourceControlProvider {
+  return {
+    checkRepositoryAccess: vi.fn(async ({ owner, name }: { owner: string; name: string }) => {
+      const result = results[`${owner}/${name}`];
+      if (result instanceof Error) throw result;
+      return result ?? null;
+    }),
+  } as unknown as SourceControlProvider;
+}
+
+function access(overrides: Partial<RepositoryAccessResult> = {}): RepositoryAccessResult {
+  return {
+    repoId: 1,
+    repoOwner: "acme",
+    repoName: "frontend",
+    defaultBranch: "main",
+    ...overrides,
+  };
+}
+
+describe("resolveSessionRepositories", () => {
+  it("resolves all entries in order, defaulting baseBranch per entry", async () => {
+    const provider = createFakeProvider({
+      "acme/frontend": access({ repoId: 1, repoName: "frontend", defaultBranch: "develop" }),
+      "acme/backend": access({ repoId: 2, repoName: "backend", defaultBranch: "" }),
+    });
+
+    const refs = await resolveSessionRepositories(
+      env,
+      [
+        { repoOwner: "acme", repoName: "frontend", baseBranch: null },
+        { repoOwner: "acme", repoName: "backend", baseBranch: "release" },
+      ],
+      ctx,
+      logger,
+      provider
+    );
+
+    expect(refs).toEqual([
+      // No input override → provider default branch.
+      { repoOwner: "acme", repoName: "frontend", repoId: 1, baseBranch: "develop" },
+      // Input override wins; empty provider default would fall back to "main".
+      { repoOwner: "acme", repoName: "backend", repoId: 2, baseBranch: "release" },
+    ]);
+  });
+
+  it("falls back to main when neither input nor provider names a branch", async () => {
+    const provider = createFakeProvider({
+      "acme/frontend": access({ defaultBranch: "" }),
+    });
+
+    const refs = await resolveSessionRepositories(
+      env,
+      [{ repoOwner: "acme", repoName: "frontend", baseBranch: null }],
+      ctx,
+      logger,
+      provider
+    );
+
+    expect(refs[0].baseBranch).toBe("main");
+  });
+
+  it("names every failing repository, 400 when access was cleanly denied", async () => {
+    const provider = createFakeProvider({
+      "acme/frontend": null,
+      "acme/backend": null,
+    });
+
+    const error = await resolveSessionRepositories(
+      env,
+      [
+        { repoOwner: "acme", repoName: "frontend", baseBranch: null },
+        { repoOwner: "acme", repoName: "backend", baseBranch: null },
+      ],
+      ctx,
+      logger,
+      provider
+    ).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(HttpError);
+    expect((error as HttpError).status).toBe(400);
+    expect((error as HttpError).message).toContain("acme/frontend");
+    expect((error as HttpError).message).toContain("acme/backend");
+  });
+
+  it("returns 500 when any lookup threw (aggregating with clean denials)", async () => {
+    const provider = createFakeProvider({
+      "acme/frontend": null,
+      "acme/backend": new Error("boom"),
+    });
+
+    const error = await resolveSessionRepositories(
+      env,
+      [
+        { repoOwner: "acme", repoName: "frontend", baseBranch: null },
+        { repoOwner: "acme", repoName: "backend", baseBranch: null },
+      ],
+      ctx,
+      logger,
+      provider
+    ).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(HttpError);
+    expect((error as HttpError).status).toBe(500);
+    expect((error as HttpError).message).toContain("acme/frontend (not installed");
+    expect((error as HttpError).message).toContain("acme/backend (resolution failed)");
+  });
+
+  it("rejects entries that resolve to the same canonical repository", async () => {
+    // GitLab-style canonicalization: a renamed project redirects, so two
+    // requested names can resolve to one repo.
+    const canonical = access({ repoId: 7, repoName: "renamed" });
+    const provider = createFakeProvider({
+      "acme/old-name": canonical,
+      "acme/renamed": canonical,
+    });
+
+    const error = await resolveSessionRepositories(
+      env,
+      [
+        { repoOwner: "acme", repoName: "old-name", baseBranch: null },
+        { repoOwner: "acme", repoName: "renamed", baseBranch: null },
+      ],
+      ctx,
+      logger,
+      provider
+    ).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(HttpError);
+    expect((error as HttpError).status).toBe(400);
+    expect((error as HttpError).message).toContain("resolve to the same repository: acme/renamed");
+  });
+
+  it("rejects distinct repositories whose canonical names collide on checkout path", async () => {
+    const provider = createFakeProvider({
+      "acme/app": access({ repoId: 1, repoOwner: "acme", repoName: "app" }),
+      "globex/legacy-app": access({ repoId: 2, repoOwner: "globex", repoName: "app" }),
+    });
+
+    const error = await resolveSessionRepositories(
+      env,
+      [
+        { repoOwner: "acme", repoName: "app", baseBranch: null },
+        { repoOwner: "globex", repoName: "legacy-app", baseBranch: null },
+      ],
+      ctx,
+      logger,
+      provider
+    ).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(HttpError);
+    expect((error as HttpError).status).toBe(400);
+    expect((error as HttpError).message).toContain("resolve to the same checkout path: app");
+  });
+});

--- a/packages/control-plane/src/repos/resolve.ts
+++ b/packages/control-plane/src/repos/resolve.ts
@@ -1,0 +1,88 @@
+import type { RepositoryRef } from "@open-inspect/shared";
+import type { Env } from "../types";
+import type { Logger } from "../logger";
+import { createRouteSourceControlProvider, HttpError, type RequestContext } from "../routes/shared";
+
+/** One requested member of a session's repository list (normalized by the input schema). */
+export interface SessionRepositoryResolutionInput {
+  repoOwner: string;
+  repoName: string;
+  baseBranch: string | null;
+}
+
+interface ResolutionOutcome {
+  input: SessionRepositoryResolutionInput;
+  ref: RepositoryRef | null;
+  reason: string | null;
+  /** True when the SCM provider threw (vs. cleanly reporting no access). */
+  errored: boolean;
+}
+
+/**
+ * Resolve a session's repository list against the SCM provider concurrently.
+ *
+ * All-or-nothing, unlike resolveAutomationRepositories: a session boots one
+ * sandbox for the whole set, so a single unresolvable member fails the create.
+ * Raises an HttpError naming every failing repository — 400 when the provider
+ * cleanly reported no access (bad request content), 500 when any lookup threw.
+ */
+export async function resolveSessionRepositories(
+  env: Env,
+  inputs: SessionRepositoryResolutionInput[],
+  ctx: RequestContext,
+  logger: Logger
+): Promise<RepositoryRef[]> {
+  const provider = createRouteSourceControlProvider(env);
+
+  const outcomes = await Promise.all(
+    inputs.map(async (input): Promise<ResolutionOutcome> => {
+      try {
+        const access = await provider.checkRepositoryAccess({
+          owner: input.repoOwner,
+          name: input.repoName,
+        });
+        if (!access) {
+          return {
+            input,
+            ref: null,
+            reason: "not installed for the GitHub App",
+            errored: false,
+          };
+        }
+        return {
+          input,
+          ref: {
+            repoOwner: access.repoOwner,
+            repoName: access.repoName,
+            repoId: access.repoId,
+            baseBranch: input.baseBranch?.trim() || access.defaultBranch || "main",
+          },
+          reason: null,
+          errored: false,
+        };
+      } catch (e) {
+        logger.error("Failed to resolve session repository", {
+          error: e instanceof Error ? e.message : String(e),
+          repo_owner: input.repoOwner,
+          repo_name: input.repoName,
+          request_id: ctx.request_id,
+          trace_id: ctx.trace_id,
+        });
+        return { input, ref: null, reason: "resolution failed", errored: true };
+      }
+    })
+  );
+
+  const failures = outcomes.filter((outcome) => outcome.ref === null);
+  if (failures.length > 0) {
+    const detail = failures
+      .map((failure) => `${failure.input.repoOwner}/${failure.input.repoName} (${failure.reason})`)
+      .join(", ");
+    throw new HttpError(
+      `Failed to resolve repositories: ${detail}`,
+      failures.some((failure) => failure.errored) ? 500 : 400
+    );
+  }
+
+  return outcomes.map((outcome) => outcome.ref as RepositoryRef);
+}

--- a/packages/control-plane/src/repos/resolve.ts
+++ b/packages/control-plane/src/repos/resolve.ts
@@ -1,14 +1,15 @@
-import type { RepositoryRef } from "@open-inspect/shared";
+import type { CreateSessionRequest, RepositoryRef } from "@open-inspect/shared";
 import type { Env } from "../types";
 import type { Logger } from "../logger";
 import { createRouteSourceControlProvider, HttpError, type RequestContext } from "../routes/shared";
 
-/** One requested member of a session's repository list (normalized by the input schema). */
-export interface SessionRepositoryResolutionInput {
-  repoOwner: string;
-  repoName: string;
-  baseBranch: string | null;
-}
+/**
+ * One requested member of a session's repository list, exactly as normalized
+ * by sessionRepositoriesInputSchema (derived, so it cannot drift from it).
+ */
+export type SessionRepositoryResolutionInput = NonNullable<
+  CreateSessionRequest["repositories"]
+>[number];
 
 interface ResolutionOutcome {
   input: SessionRepositoryResolutionInput;

--- a/packages/control-plane/src/repos/resolve.ts
+++ b/packages/control-plane/src/repos/resolve.ts
@@ -1,6 +1,7 @@
 import type { CreateSessionRequest, RepositoryRef } from "@open-inspect/shared";
 import type { Env } from "../types";
 import type { Logger } from "../logger";
+import type { SourceControlProvider } from "../source-control";
 import { createRouteSourceControlProvider, HttpError, type RequestContext } from "../routes/shared";
 
 /**
@@ -31,9 +32,10 @@ export async function resolveSessionRepositories(
   env: Env,
   inputs: SessionRepositoryResolutionInput[],
   ctx: RequestContext,
-  logger: Logger
+  logger: Logger,
+  sourceControlProvider?: SourceControlProvider
 ): Promise<RepositoryRef[]> {
-  const provider = createRouteSourceControlProvider(env);
+  const provider = sourceControlProvider ?? createRouteSourceControlProvider(env);
 
   const outcomes = await Promise.all(
     inputs.map(async (input): Promise<ResolutionOutcome> => {
@@ -85,5 +87,26 @@ export async function resolveSessionRepositories(
     );
   }
 
-  return outcomes.map((outcome) => outcome.ref as RepositoryRef);
+  const refs = outcomes.map((outcome) => outcome.ref as RepositoryRef);
+
+  // Providers may canonicalize identities (GitLab follows project redirects
+  // after renames), so the input schema's uniqueness invariants must be
+  // re-checked on the RESOLVED identities: distinct repositories (D1 keys
+  // member rows by owner/name) and distinct repo names (checkout paths are
+  // /workspace/{repoName}).
+  const seenFullNames = new Set<string>();
+  const seenNames = new Set<string>();
+  for (const ref of refs) {
+    const fullName = `${ref.repoOwner}/${ref.repoName}`;
+    if (seenFullNames.has(fullName)) {
+      throw new HttpError(`repositories resolve to the same repository: ${fullName}`, 400);
+    }
+    if (seenNames.has(ref.repoName)) {
+      throw new HttpError(`repositories resolve to the same checkout path: ${ref.repoName}`, 400);
+    }
+    seenFullNames.add(fullName);
+    seenNames.add(ref.repoName);
+  }
+
+  return refs;
 }

--- a/packages/control-plane/src/routes/session-child-spawn.ts
+++ b/packages/control-plane/src/routes/session-child-spawn.ts
@@ -100,6 +100,8 @@ async function handleSpawnChild(
     return error("repoOwner and repoName must be provided together", 400);
   }
 
+  // Children pin to the parent's scalar repository, which for a multi-repo
+  // parent is its primary member — child sessions are single-repo by design.
   const parentRepoOwner = spawnContext.repoOwner?.toLowerCase() ?? null;
   const parentRepoName = spawnContext.repoName?.toLowerCase() ?? null;
   if (requestedRepoOwner || requestedRepoName) {

--- a/packages/control-plane/src/routes/session-create.ts
+++ b/packages/control-plane/src/routes/session-create.ts
@@ -1,5 +1,10 @@
-import { getValidModelOrDefault, isValidReasoningEffort } from "@open-inspect/shared";
+import {
+  getValidModelOrDefault,
+  isValidReasoningEffort,
+  type RepositoryRef,
+} from "@open-inspect/shared";
 import { encryptTokenPair, generateId } from "../auth/crypto";
+import { resolveSessionRepositories } from "../repos/resolve";
 import { DEFAULT_TOKEN_LIFETIME_MS, UserScmTokenStore } from "../db/user-scm-tokens";
 import { UserStore } from "../db/user-store";
 import { createLogger } from "../logger";
@@ -32,6 +37,9 @@ import {
 const logger = createLogger("router:session-create");
 const INVALID_SESSION_REQUEST_BODY_ERROR = "Invalid session request body";
 
+// Defense in depth on top of schema validation — matches git ref charsets.
+const BRANCH_NAME_PATTERN = /^[\w.\-/]+$/;
+
 async function handleCreateSession(
   request: Request,
   env: Env,
@@ -52,16 +60,32 @@ async function handleCreateSession(
     throw e;
   }
 
-  // Validate branch name if provided (defense in depth)
-  if (body.branch && !/^[\w.\-/]+$/.test(body.branch)) {
+  // Validate branch names if provided (defense in depth)
+  if (body.branch && !BRANCH_NAME_PATTERN.test(body.branch)) {
     return error("Invalid branch name");
+  }
+  for (const entry of body.repositories ?? []) {
+    if (entry.baseBranch && !BRANCH_NAME_PATTERN.test(entry.baseBranch)) {
+      return error(`Invalid branch name for ${entry.repoOwner}/${entry.repoName}`);
+    }
   }
 
   let repoId: number | null = null;
   let defaultBranch: string | null = null;
   let repoOwner: string | null = null;
   let repoName: string | null = null;
-  if (repositoryContext) {
+  let repositories: RepositoryRef[] | undefined;
+  if (body.repositories) {
+    // List mode (mutually exclusive with the scalar fields by schema). The
+    // primary entry is mirrored into the scalar columns so filters, settings
+    // resolution, and pre-list consumers keep working unchanged.
+    repositories = await resolveSessionRepositories(env, body.repositories, ctx, logger);
+    const primary = repositories[0];
+    repoOwner = primary.repoOwner;
+    repoName = primary.repoName;
+    repoId = primary.repoId;
+    defaultBranch = primary.baseBranch;
+  } else if (repositoryContext) {
     repoOwner = repositoryContext.repoOwner;
     repoName = repositoryContext.repoName;
     const resolved = await resolveRepoOrError(env, repoOwner, repoName, ctx, logger);
@@ -167,6 +191,7 @@ async function handleCreateSession(
     repoId,
     defaultBranch,
     branch: body.branch,
+    repositories,
     title: body.title,
     model,
     reasoningEffort,

--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -122,6 +122,101 @@ describe("ModalClient", () => {
     });
   });
 
+  it("sends multi-repo members as flat snake_case create fields", async () => {
+    // Modal's create handler builds its SessionConfig from the request by
+    // field name, so the wire keys must match SessionConfig exactly.
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: { sandbox_id: "sb-1", status: "spawning", created_at: 1 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const client = createModalClient("secret", "acme", "prod-web");
+    await client.createSandbox({
+      sessionId: "session-123",
+      sandboxId: "sandbox-456",
+      repoOwner: "testowner",
+      repoName: "testrepo",
+      controlPlaneUrl: "https://control-plane.test",
+      sandboxAuthToken: "auth-token",
+      repositories: [
+        { repoOwner: "testowner", repoName: "testrepo", branch: "main" },
+        { repoOwner: "testowner", repoName: "backend", branch: "develop" },
+      ],
+      workingBranchName: "open-inspect/session-123",
+    });
+
+    const body = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string);
+    expect(body.repositories).toEqual([
+      { repo_owner: "testowner", repo_name: "testrepo", branch: "main" },
+      { repo_owner: "testowner", repo_name: "backend", branch: "develop" },
+    ]);
+    expect(body.working_branch_name).toBe("open-inspect/session-123");
+  });
+
+  it("sends null multi-repo create fields for single-repo sessions", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: { sandbox_id: "sb-1", status: "spawning", created_at: 1 },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
+    );
+
+    const client = createModalClient("secret", "acme", "prod-web");
+    await client.createSandbox({
+      sessionId: "session-123",
+      repoOwner: "testowner",
+      repoName: "testrepo",
+      controlPlaneUrl: "https://control-plane.test",
+      sandboxAuthToken: "auth-token",
+    });
+
+    const body = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string);
+    expect(body.repositories).toBeNull();
+    expect(body.working_branch_name).toBeNull();
+  });
+
+  it("routes multi-repo members through the restore session_config", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: { sandbox_id: "sb-1" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const client = createModalClient("secret", "acme", "prod-web");
+    await client.restoreSandbox({
+      snapshotImageId: "img-1",
+      sessionId: "session-123",
+      sandboxId: "sandbox-456",
+      sandboxAuthToken: "auth-token",
+      controlPlaneUrl: "https://control-plane.test",
+      repoOwner: "testowner",
+      repoName: "testrepo",
+      provider: "anthropic",
+      model: "anthropic/claude-sonnet-4-5",
+      repositories: [
+        { repoOwner: "testowner", repoName: "testrepo", branch: "main" },
+        { repoOwner: "testowner", repoName: "backend", branch: "develop" },
+      ],
+      workingBranchName: "open-inspect/session-123",
+    });
+
+    const body = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string);
+    expect(body.session_config.repositories).toEqual([
+      { repo_owner: "testowner", repo_name: "testrepo", branch: "main" },
+      { repo_owner: "testowner", repo_name: "backend", branch: "develop" },
+    ]);
+    expect(body.session_config.working_branch_name).toBe("open-inspect/session-123");
+  });
+
   it("threads the build timeout into the repo image build request body", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")

--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -147,7 +147,6 @@ describe("ModalClient", () => {
         { repoOwner: "testowner", repoName: "testrepo", branch: "main" },
         { repoOwner: "testowner", repoName: "backend", branch: "develop" },
       ],
-      workingBranchName: "open-inspect/session-123",
     });
 
     const body = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string);
@@ -155,10 +154,9 @@ describe("ModalClient", () => {
       { repo_owner: "testowner", repo_name: "testrepo", branch: "main" },
       { repo_owner: "testowner", repo_name: "backend", branch: "develop" },
     ]);
-    expect(body.working_branch_name).toBe("open-inspect/session-123");
   });
 
-  it("sends null multi-repo create fields for single-repo sessions", async () => {
+  it("sends a null repositories create field for single-repo sessions", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -180,7 +178,6 @@ describe("ModalClient", () => {
 
     const body = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string);
     expect(body.repositories).toBeNull();
-    expect(body.working_branch_name).toBeNull();
   });
 
   it("routes multi-repo members through the restore session_config", async () => {
@@ -206,7 +203,6 @@ describe("ModalClient", () => {
         { repoOwner: "testowner", repoName: "testrepo", branch: "main" },
         { repoOwner: "testowner", repoName: "backend", branch: "develop" },
       ],
-      workingBranchName: "open-inspect/session-123",
     });
 
     const body = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string);
@@ -214,7 +210,6 @@ describe("ModalClient", () => {
       { repo_owner: "testowner", repo_name: "testrepo", branch: "main" },
       { repo_owner: "testowner", repo_name: "backend", branch: "develop" },
     ]);
-    expect(body.session_config.working_branch_name).toBe("open-inspect/session-123");
   });
 
   it("threads the build timeout into the repo image build request body", async () => {

--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -144,8 +144,8 @@ describe("ModalClient", () => {
       controlPlaneUrl: "https://control-plane.test",
       sandboxAuthToken: "auth-token",
       repositories: [
-        { repoOwner: "testowner", repoName: "testrepo", branch: "main" },
-        { repoOwner: "testowner", repoName: "backend", branch: "develop" },
+        { repoOwner: "testowner", repoName: "testrepo", baseBranch: "main" },
+        { repoOwner: "testowner", repoName: "backend", baseBranch: "develop" },
       ],
     });
 
@@ -200,8 +200,8 @@ describe("ModalClient", () => {
       provider: "anthropic",
       model: "anthropic/claude-sonnet-4-5",
       repositories: [
-        { repoOwner: "testowner", repoName: "testrepo", branch: "main" },
-        { repoOwner: "testowner", repoName: "backend", branch: "develop" },
+        { repoOwner: "testowner", repoName: "testrepo", baseBranch: "main" },
+        { repoOwner: "testowner", repoName: "backend", baseBranch: "develop" },
       ],
     });
 

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -9,7 +9,8 @@ import { generateInternalToken, type SandboxSettings } from "@open-inspect/share
 import type { McpServerConfig } from "@open-inspect/shared";
 import { createLogger } from "../logger";
 import type { CorrelationContext } from "../logger";
-import { buildSessionConfig } from "./sandbox-env";
+import { buildSessionConfig, toRepositoryConfigPayload } from "./sandbox-env";
+import type { SessionRepositoryInfo } from "./provider";
 
 const log = createLogger("modal-client");
 
@@ -68,6 +69,8 @@ export interface CreateSandboxRequest {
   agentSlackNotifyEnabled?: boolean;
   mcpServers?: McpServerConfig[];
   sandboxSettings?: SandboxSettings;
+  repositories?: SessionRepositoryInfo[];
+  workingBranchName?: string;
 }
 
 export interface CreateSandboxResponse {
@@ -98,6 +101,8 @@ export interface RestoreSandboxRequest {
   agentSlackNotifyEnabled?: boolean;
   mcpServers?: McpServerConfig[];
   sandboxSettings?: SandboxSettings;
+  repositories?: SessionRepositoryInfo[];
+  workingBranchName?: string;
 }
 
 export interface RestoreSandboxResponse {
@@ -256,6 +261,13 @@ export class ModalClient {
           agent_slack_notify_enabled: request.agentSlackNotifyEnabled ?? false,
           mcp_servers: request.mcpServers || null,
           sandbox_settings: request.sandboxSettings ?? null,
+          // Flat keys matching SessionConfig field names — Modal's create
+          // handler builds its SessionConfig from the request by field name
+          // (unlike restore, which carries a nested session_config).
+          repositories: request.repositories?.length
+            ? request.repositories.map(toRepositoryConfigPayload)
+            : null,
+          working_branch_name: request.workingBranchName || null,
         }),
       });
 

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -70,7 +70,6 @@ export interface CreateSandboxRequest {
   mcpServers?: McpServerConfig[];
   sandboxSettings?: SandboxSettings;
   repositories?: SessionRepositoryInfo[];
-  workingBranchName?: string;
 }
 
 export interface CreateSandboxResponse {
@@ -102,7 +101,6 @@ export interface RestoreSandboxRequest {
   mcpServers?: McpServerConfig[];
   sandboxSettings?: SandboxSettings;
   repositories?: SessionRepositoryInfo[];
-  workingBranchName?: string;
 }
 
 export interface RestoreSandboxResponse {
@@ -267,7 +265,6 @@ export class ModalClient {
           repositories: request.repositories?.length
             ? request.repositories.map(toRepositoryConfigPayload)
             : null,
-          working_branch_name: request.workingBranchName || null,
         }),
       });
 

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -1854,8 +1854,8 @@ describe("SandboxLifecycleManager", () => {
 
   describe("multi-repo spawn", () => {
     const MULTI_REPO_MEMBERS: SessionRepositoryInfo[] = [
-      { repoOwner: "testowner", repoName: "testrepo", branch: "main" },
-      { repoOwner: "testowner", repoName: "backend", branch: "develop" },
+      { repoOwner: "testowner", repoName: "testrepo", baseBranch: "main" },
+      { repoOwner: "testowner", repoName: "backend", baseBranch: "develop" },
     ];
 
     function createMultiRepoManager(overrides?: {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
+import { generateBranchName } from "@open-inspect/shared";
 import {
   SandboxLifecycleManager,
   DEFAULT_LIFECYCLE_CONFIG,
@@ -14,6 +15,7 @@ import {
   type AlarmScheduler,
   type IdGenerator,
   type SandboxLifecycleConfig,
+  type McpServerLookup,
   type RepoImageLookup,
   type SlackAgentNotifyLookup,
 } from "./manager";
@@ -26,6 +28,7 @@ import {
   type RestoreResult,
   type ResumeConfig,
   type ResumeResult,
+  type SessionRepositoryInfo,
   type SnapshotConfig,
   type SnapshotResult,
   type StopConfig,
@@ -98,7 +101,8 @@ function createMockStorage(
   sandbox:
     | (SandboxRow & { spawn_failure_count: number; last_spawn_failure: number })
     | null = createMockSandbox(),
-  userEnvVars: Record<string, string> | undefined = undefined
+  userEnvVars: Record<string, string> | undefined = undefined,
+  sessionRepositories: SessionRepositoryInfo[] = []
 ): SandboxStorage & { calls: string[] } {
   const calls: string[] = [];
 
@@ -115,6 +119,10 @@ function createMockStorage(
     getSession: vi.fn(() => {
       calls.push("getSession");
       return session;
+    }),
+    getSessionRepositories: vi.fn(() => {
+      calls.push("getSessionRepositories");
+      return sessionRepositories;
     }),
     getUserEnvVars: vi.fn(async () => {
       calls.push("getUserEnvVars");
@@ -510,7 +518,7 @@ describe("SandboxLifecycleManager", () => {
           repoImageSha: null,
         })
       );
-      expect(mcpServerLookup.getDecryptedForSession).toHaveBeenCalledWith(null, null);
+      expect(mcpServerLookup.getDecryptedForSession).toHaveBeenCalledWith([]);
       expect(slackAgentNotifyLookup.isEnabledForRepo).toHaveBeenCalledWith(null, null);
       expect(repoImageLookup.getLatestReady).not.toHaveBeenCalled();
     });
@@ -1840,6 +1848,141 @@ describe("SandboxLifecycleManager", () => {
         expect.objectContaining({
           repoImageId: null,
           repoImageSha: null,
+        })
+      );
+    });
+  });
+
+  describe("multi-repo spawn", () => {
+    const MULTI_REPO_MEMBERS: SessionRepositoryInfo[] = [
+      { repoOwner: "testowner", repoName: "testrepo", branch: "main" },
+      { repoOwner: "testowner", repoName: "backend", branch: "develop" },
+    ];
+
+    function createMultiRepoManager(overrides?: {
+      provider?: SandboxProvider;
+      repoImageLookup?: RepoImageLookup;
+      mcpServerLookup?: McpServerLookup;
+      sandbox?: ReturnType<typeof createMockSandbox>;
+      sessionRepositories?: SessionRepositoryInfo[];
+    }) {
+      const sandbox =
+        overrides?.sandbox ??
+        createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const storage = createMockStorage(
+        createMockSession(),
+        sandbox,
+        undefined,
+        overrides?.sessionRepositories ?? MULTI_REPO_MEMBERS
+      );
+      const provider = overrides?.provider ?? createMockProvider();
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        { ...createTestConfig(), mcpServerLookup: overrides?.mcpServerLookup },
+        {},
+        overrides?.repoImageLookup
+      );
+      return { manager, provider, storage };
+    }
+
+    it("passes the member list and a derived working branch on fresh spawns", async () => {
+      const { manager, provider } = createMultiRepoManager();
+
+      await manager.spawnSandbox();
+
+      expect(provider.createSandbox).toHaveBeenCalledWith(
+        expect.objectContaining({
+          repositories: MULTI_REPO_MEMBERS,
+          workingBranchName: generateBranchName("test-session"),
+        })
+      );
+    });
+
+    it("omits multi-repo fields for single-member sessions", async () => {
+      const { manager, provider } = createMultiRepoManager({
+        sessionRepositories: [MULTI_REPO_MEMBERS[0]],
+      });
+
+      await manager.spawnSandbox();
+
+      const config = vi.mocked(provider.createSandbox).mock.calls[0][0];
+      expect(config.repositories).toBeUndefined();
+      expect(config.workingBranchName).toBeUndefined();
+    });
+
+    it("omits multi-repo fields for pre-list sessions with no member rows", async () => {
+      const { manager, provider } = createMultiRepoManager({ sessionRepositories: [] });
+
+      await manager.spawnSandbox();
+
+      const config = vi.mocked(provider.createSandbox).mock.calls[0][0];
+      expect(config.repositories).toBeUndefined();
+      expect(config.workingBranchName).toBeUndefined();
+    });
+
+    it("skips the repo image lookup for multi-repo sessions", async () => {
+      const repoImageLookup: RepoImageLookup = {
+        getLatestReady: vi.fn(async () => ({
+          provider_image_id: "img-abc123",
+          base_sha: "sha-def456",
+        })),
+      };
+      const { manager, provider } = createMultiRepoManager({ repoImageLookup });
+
+      await manager.spawnSandbox();
+
+      expect(repoImageLookup.getLatestReady).not.toHaveBeenCalled();
+      expect(provider.createSandbox).toHaveBeenCalledWith(
+        expect.objectContaining({ repoImageId: null, repoImageSha: null })
+      );
+    });
+
+    it("passes every member to the MCP server lookup", async () => {
+      const mcpServerLookup: McpServerLookup = {
+        getDecryptedForSession: vi.fn(async () => []),
+      };
+      const { manager } = createMultiRepoManager({ mcpServerLookup });
+
+      await manager.spawnSandbox();
+
+      expect(mcpServerLookup.getDecryptedForSession).toHaveBeenCalledWith([
+        { repoOwner: "testowner", repoName: "testrepo" },
+        { repoOwner: "testowner", repoName: "backend" },
+      ]);
+    });
+
+    it("synthesizes the scalar member for the MCP lookup on pre-list sessions", async () => {
+      const mcpServerLookup: McpServerLookup = {
+        getDecryptedForSession: vi.fn(async () => []),
+      };
+      const { manager } = createMultiRepoManager({ mcpServerLookup, sessionRepositories: [] });
+
+      await manager.spawnSandbox();
+
+      expect(mcpServerLookup.getDecryptedForSession).toHaveBeenCalledWith([
+        { repoOwner: "testowner", repoName: "testrepo" },
+      ]);
+    });
+
+    it("passes the member list and working branch on snapshot restores", async () => {
+      const sandbox = createMockSandbox({
+        status: "stopped",
+        snapshot_image_id: "snapshot-img-1",
+        created_at: Date.now() - 60000,
+      });
+      const { manager, provider } = createMultiRepoManager({ sandbox });
+
+      await manager.spawnSandbox();
+
+      expect(provider.restoreFromSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({
+          repositories: MULTI_REPO_MEMBERS,
+          workingBranchName: generateBranchName("test-session"),
         })
       );
     });

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -5,7 +5,6 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { generateBranchName } from "@open-inspect/shared";
 import {
   SandboxLifecycleManager,
   DEFAULT_LIFECYCLE_CONFIG,
@@ -1890,20 +1889,17 @@ describe("SandboxLifecycleManager", () => {
       return { manager, provider, storage };
     }
 
-    it("passes the member list and a derived working branch on fresh spawns", async () => {
+    it("passes the member list on fresh spawns", async () => {
       const { manager, provider } = createMultiRepoManager();
 
       await manager.spawnSandbox();
 
       expect(provider.createSandbox).toHaveBeenCalledWith(
-        expect.objectContaining({
-          repositories: MULTI_REPO_MEMBERS,
-          workingBranchName: generateBranchName("test-session"),
-        })
+        expect.objectContaining({ repositories: MULTI_REPO_MEMBERS })
       );
     });
 
-    it("omits multi-repo fields for single-member sessions", async () => {
+    it("omits the member list for single-member sessions", async () => {
       const { manager, provider } = createMultiRepoManager({
         sessionRepositories: [MULTI_REPO_MEMBERS[0]],
       });
@@ -1912,17 +1908,15 @@ describe("SandboxLifecycleManager", () => {
 
       const config = vi.mocked(provider.createSandbox).mock.calls[0][0];
       expect(config.repositories).toBeUndefined();
-      expect(config.workingBranchName).toBeUndefined();
     });
 
-    it("omits multi-repo fields for pre-list sessions with no member rows", async () => {
+    it("omits the member list for pre-list sessions with no member rows", async () => {
       const { manager, provider } = createMultiRepoManager({ sessionRepositories: [] });
 
       await manager.spawnSandbox();
 
       const config = vi.mocked(provider.createSandbox).mock.calls[0][0];
       expect(config.repositories).toBeUndefined();
-      expect(config.workingBranchName).toBeUndefined();
     });
 
     it("skips the repo image lookup for multi-repo sessions", async () => {
@@ -1969,7 +1963,7 @@ describe("SandboxLifecycleManager", () => {
       ]);
     });
 
-    it("passes the member list and working branch on snapshot restores", async () => {
+    it("passes the member list on snapshot restores", async () => {
       const sandbox = createMockSandbox({
         status: "stopped",
         snapshot_image_id: "snapshot-img-1",
@@ -1980,10 +1974,7 @@ describe("SandboxLifecycleManager", () => {
       await manager.spawnSandbox();
 
       expect(provider.restoreFromSnapshot).toHaveBeenCalledWith(
-        expect.objectContaining({
-          repositories: MULTI_REPO_MEMBERS,
-          workingBranchName: generateBranchName("test-session"),
-        })
+        expect.objectContaining({ repositories: MULTI_REPO_MEMBERS })
       );
     });
   });

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -12,12 +12,18 @@
 
 import {
   extractProviderAndModel,
+  generateBranchName,
   type McpServerConfig,
   type SandboxSettings,
 } from "@open-inspect/shared";
 import type { SandboxStatus } from "../../types";
 import { sessionHasRepository, type SandboxRow, type SessionRow } from "../../session/types";
-import { SandboxProviderError, type SandboxProvider, type CreateSandboxConfig } from "../provider";
+import {
+  SandboxProviderError,
+  type SandboxProvider,
+  type CreateSandboxConfig,
+  type SessionRepositoryInfo,
+} from "../provider";
 import {
   evaluateCircuitBreaker,
   evaluateSpawnDecision,
@@ -70,6 +76,8 @@ export interface SandboxStorage {
   getSandboxWithCircuitBreaker(): SandboxCircuitBreakerInfo | null;
   /** Get current session */
   getSession(): SessionRow | null;
+  /** Get the session's member repositories in position order (empty for pre-list sessions) */
+  getSessionRepositories(): SessionRepositoryInfo[];
   /** Get user env vars for sandbox injection */
   getUserEnvVars(): Promise<Record<string, string> | undefined>;
   /** Update sandbox status */
@@ -199,11 +207,12 @@ function buildSandboxIdForSession(session: SessionRow, now: number): string {
 /**
  * Lookup interface for MCP servers applicable to a session.
  * Keeps the lifecycle manager free of direct D1Database dependencies.
+ * Receives the session's member repositories (empty for repo-less sessions);
+ * a scoped server applies when any member matches one of its scopes.
  */
 export interface McpServerLookup {
   getDecryptedForSession(
-    repoOwner: string | null,
-    repoName: string | null
+    repositories: Array<{ repoOwner: string; repoName: string }>
   ): Promise<McpServerConfig[]>;
 }
 
@@ -407,11 +416,14 @@ export class SandboxLifecycleManager {
 
       const userEnvVars = await this.storage.getUserEnvVars();
       const { provider, model: modelId } = this.resolveProviderAndModel(session);
+      const multiRepoFields = this.multiRepoSpawnFields(session);
 
-      // Look up pre-built repo image (graceful fallback on failure)
+      // Look up pre-built repo image (graceful fallback on failure).
+      // Repo images bake a single checkout, so multi-repo sessions boot from
+      // the base image and clone every member.
       let repoImageId: string | null = null;
       let repoImageSha: string | null = null;
-      if (hasRepository && this.repoImageLookup) {
+      if (hasRepository && !multiRepoFields.repositories && this.repoImageLookup) {
         try {
           const repoImage = await this.repoImageLookup.getLatestReady(
             session.repo_owner,
@@ -460,6 +472,7 @@ export class SandboxLifecycleManager {
         agentSlackNotifyEnabled,
         mcpServers,
         sandboxSettings,
+        ...multiRepoFields,
       };
 
       const result = await this.provider.createSandbox(createConfig);
@@ -554,8 +567,10 @@ export class SandboxLifecycleManager {
     try {
       if (!this.config.mcpServerLookup) return undefined;
       const servers = await this.config.mcpServerLookup.getDecryptedForSession(
-        session.repo_owner,
-        session.repo_name
+        this.sessionRepositories(session).map(({ repoOwner, repoName }) => ({
+          repoOwner,
+          repoName,
+        }))
       );
       this.log.info("MCP servers loaded", {
         event: "mcp.loaded",
@@ -641,6 +656,7 @@ export class SandboxLifecycleManager {
         agentSlackNotifyEnabled,
         mcpServers,
         sandboxSettings,
+        ...this.multiRepoSpawnFields(session),
       });
 
       if (result.success) {
@@ -1181,6 +1197,48 @@ export class SandboxLifecycleManager {
    */
   private resolveProviderAndModel(session: SessionRow): { provider: string; model: string } {
     return extractProviderAndModel(session.model || this.config.model);
+  }
+
+  /**
+   * The session's member repositories in position order. Falls back to a
+   * one-entry list synthesized from the scalar columns for sessions that
+   * predate the session_repositories table.
+   */
+  private sessionRepositories(session: SessionRow): SessionRepositoryInfo[] {
+    const repositories = this.storage.getSessionRepositories();
+    if (repositories.length > 0) {
+      return repositories;
+    }
+    if (sessionHasRepository(session)) {
+      return [
+        {
+          repoOwner: session.repo_owner,
+          repoName: session.repo_name,
+          branch: session.base_branch ?? "main",
+        },
+      ];
+    }
+    return [];
+  }
+
+  /**
+   * Multi-repo additions to a spawn/restore config. Single-repo sessions keep
+   * the scalar wire form untouched (the runtime synthesizes its one-entry
+   * list from repo_owner/repo_name/branch), so nothing changes for them.
+   */
+  private multiRepoSpawnFields(
+    session: SessionRow
+  ): Pick<CreateSandboxConfig, "repositories" | "workingBranchName"> {
+    const repositories = this.sessionRepositories(session);
+    if (repositories.length <= 1) {
+      return {};
+    }
+    return {
+      repositories,
+      // Deterministic and shared across members; matches the head branch the
+      // create-pull-request path derives (pull-request-service.ts).
+      workingBranchName: generateBranchName(session.session_name || session.id),
+    };
   }
 
   /**

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -12,7 +12,6 @@
 
 import {
   extractProviderAndModel,
-  generateBranchName,
   type McpServerConfig,
   type SandboxSettings,
 } from "@open-inspect/shared";
@@ -1225,20 +1224,16 @@ export class SandboxLifecycleManager {
    * Multi-repo additions to a spawn/restore config. Single-repo sessions keep
    * the scalar wire form untouched (the runtime synthesizes its one-entry
    * list from repo_owner/repo_name/branch), so nothing changes for them.
+   * Working-branch names stay lazily derived at PR-creation time
+   * (pull-request-service) and reach the sandbox via per-repo push specs,
+   * never via spawn config.
    */
-  private multiRepoSpawnFields(
-    session: SessionRow
-  ): Pick<CreateSandboxConfig, "repositories" | "workingBranchName"> {
+  private multiRepoSpawnFields(session: SessionRow): Pick<CreateSandboxConfig, "repositories"> {
     const repositories = this.sessionRepositories(session);
     if (repositories.length <= 1) {
       return {};
     }
-    return {
-      repositories,
-      // Deterministic and shared across members; matches the head branch the
-      // create-pull-request path derives (pull-request-service.ts).
-      workingBranchName: generateBranchName(session.session_name || session.id),
-    };
+    return { repositories };
   }
 
   /**

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -1213,7 +1213,7 @@ export class SandboxLifecycleManager {
         {
           repoOwner: session.repo_owner,
           repoName: session.repo_name,
-          branch: session.base_branch ?? "main",
+          baseBranch: session.base_branch ?? "main",
         },
       ];
     }

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -201,6 +201,20 @@ function buildSandboxIdForSession(session: SessionRow, now: number): string {
   return `sandbox-${sandboxName}-${now}`;
 }
 
+/**
+ * Multi-repo additions to a spawn/restore config. Single-repo sessions keep
+ * the scalar wire form untouched (the runtime synthesizes its one-entry
+ * list from repo_owner/repo_name/branch), so nothing changes for them.
+ * Working-branch names stay lazily derived at PR-creation time
+ * (pull-request-service) and reach the sandbox via per-repo push specs,
+ * never via spawn config.
+ */
+function multiRepoSpawnFields(
+  repositories: SessionRepositoryInfo[]
+): Pick<CreateSandboxConfig, "repositories"> {
+  return repositories.length > 1 ? { repositories } : {};
+}
+
 // ==================== MCP Server Lookup ====================
 
 /**
@@ -415,7 +429,8 @@ export class SandboxLifecycleManager {
 
       const userEnvVars = await this.storage.getUserEnvVars();
       const { provider, model: modelId } = this.resolveProviderAndModel(session);
-      const multiRepoFields = this.multiRepoSpawnFields(session);
+      const repositories = this.sessionRepositories(session);
+      const multiRepoFields = multiRepoSpawnFields(repositories);
 
       // Look up pre-built repo image (graceful fallback on failure).
       // Repo images bake a single checkout, so multi-repo sessions boot from
@@ -448,7 +463,7 @@ export class SandboxLifecycleManager {
       const timeoutSeconds =
         session.spawn_source === "agent" ? CHILD_SANDBOX_TIMEOUT_SECONDS : undefined;
 
-      const mcpServers = await this.loadMcpServers(session);
+      const mcpServers = await this.loadMcpServers(repositories);
 
       const codeServerEnabled = session.code_server_enabled === 1;
       const agentSlackNotifyEnabled = await this.resolveAgentSlackNotifyEnabled(session);
@@ -562,14 +577,13 @@ export class SandboxLifecycleManager {
    * Load MCP servers applicable to the current session's repository.
    * Returns undefined if none are found or DB is not configured.
    */
-  private async loadMcpServers(session: SessionRow): Promise<McpServerConfig[] | undefined> {
+  private async loadMcpServers(
+    repositories: SessionRepositoryInfo[]
+  ): Promise<McpServerConfig[] | undefined> {
     try {
       if (!this.config.mcpServerLookup) return undefined;
       const servers = await this.config.mcpServerLookup.getDecryptedForSession(
-        this.sessionRepositories(session).map(({ repoOwner, repoName }) => ({
-          repoOwner,
-          repoName,
-        }))
+        repositories.map(({ repoOwner, repoName }) => ({ repoOwner, repoName }))
       );
       this.log.info("MCP servers loaded", {
         event: "mcp.loaded",
@@ -634,9 +648,10 @@ export class SandboxLifecycleManager {
       const timeoutSeconds =
         session.spawn_source === "agent" ? CHILD_SANDBOX_TIMEOUT_SECONDS : undefined;
 
+      const repositories = this.sessionRepositories(session);
       const codeServerEnabled = session.code_server_enabled === 1;
       const agentSlackNotifyEnabled = await this.resolveAgentSlackNotifyEnabled(session);
-      const mcpServers = await this.loadMcpServers(session);
+      const mcpServers = await this.loadMcpServers(repositories);
       const sandboxSettings = this.parseSandboxSettings(session);
       const result = await this.provider.restoreFromSnapshot({
         snapshotImageId,
@@ -655,7 +670,7 @@ export class SandboxLifecycleManager {
         agentSlackNotifyEnabled,
         mcpServers,
         sandboxSettings,
-        ...this.multiRepoSpawnFields(session),
+        ...multiRepoSpawnFields(repositories),
       });
 
       if (result.success) {
@@ -1218,22 +1233,6 @@ export class SandboxLifecycleManager {
       ];
     }
     return [];
-  }
-
-  /**
-   * Multi-repo additions to a spawn/restore config. Single-repo sessions keep
-   * the scalar wire form untouched (the runtime synthesizes its one-entry
-   * list from repo_owner/repo_name/branch), so nothing changes for them.
-   * Working-branch names stay lazily derived at PR-creation time
-   * (pull-request-service) and reach the sandbox via per-repo push specs,
-   * never via spawn config.
-   */
-  private multiRepoSpawnFields(session: SessionRow): Pick<CreateSandboxConfig, "repositories"> {
-    const repositories = this.sessionRepositories(session);
-    if (repositories.length <= 1) {
-      return {};
-    }
-    return { repositories };
   }
 
   /**

--- a/packages/control-plane/src/sandbox/provider.ts
+++ b/packages/control-plane/src/sandbox/provider.ts
@@ -5,7 +5,7 @@
  * enabling unit testing and future provider support.
  */
 
-import type { SandboxSettings, SessionRepositoryState } from "@open-inspect/shared";
+import type { SandboxSettings } from "@open-inspect/shared";
 import type { CorrelationContext } from "../logger";
 import type { McpServerConfig } from "@open-inspect/shared";
 
@@ -29,14 +29,16 @@ export interface SandboxProviderCapabilities {
 
 /**
  * One member repository of a session, in position order (first = primary).
- * Derived from the shared SessionRepositoryState contract; the runtime's
- * SessionRepositoryConfig is the snake_case wire twin (baseBranch maps to
- * its `branch` field in toRepositoryConfigPayload).
+ * Mirrors the runtime's SessionRepositoryConfig, whose snake_case wire form
+ * (with baseBranch renamed to `branch`) is produced by
+ * toRepositoryConfigPayload.
  */
-export type SessionRepositoryInfo = Pick<
-  SessionRepositoryState,
-  "repoOwner" | "repoName" | "baseBranch"
->;
+export interface SessionRepositoryInfo {
+  repoOwner: string;
+  repoName: string;
+  /** Base branch to clone (resolved at session create; never null). */
+  baseBranch: string;
+}
 
 /**
  * Configuration for creating a new sandbox.

--- a/packages/control-plane/src/sandbox/provider.ts
+++ b/packages/control-plane/src/sandbox/provider.ts
@@ -88,15 +88,11 @@ export interface CreateSandboxConfig {
    * Ordered member list for multi-repo sessions. Only set when the session
    * has more than one member — single-repo sessions keep the scalar
    * repoOwner/repoName/branch wire form (the runtime synthesizes its
-   * one-entry list from them).
+   * one-entry list from them). Working-branch names are not part of this
+   * config: they are derived lazily at PR-creation time
+   * (pull-request-service) and travel in per-repo push specs.
    */
   repositories?: SessionRepositoryInfo[];
-  /**
-   * Shared working-branch name across all members, computed control-plane
-   * side (generateBranchName) — the runtime never derives branch names.
-   * Set together with repositories.
-   */
-  workingBranchName?: string;
 }
 
 /**
@@ -161,8 +157,6 @@ export interface RestoreConfig {
   sandboxSettings?: SandboxSettings;
   /** Multi-repo member list — see CreateSandboxConfig. */
   repositories?: SessionRepositoryInfo[];
-  /** Shared working-branch name — see CreateSandboxConfig. */
-  workingBranchName?: string;
 }
 
 /**

--- a/packages/control-plane/src/sandbox/provider.ts
+++ b/packages/control-plane/src/sandbox/provider.ts
@@ -28,6 +28,17 @@ export interface SandboxProviderCapabilities {
 }
 
 /**
+ * One member repository of a session, in position order (first = primary).
+ * The runtime's SessionRepositoryConfig is the snake_case wire twin.
+ */
+export interface SessionRepositoryInfo {
+  repoOwner: string;
+  repoName: string;
+  /** Base branch to clone (resolved at session create; never null). */
+  branch: string;
+}
+
+/**
  * Configuration for creating a new sandbox.
  */
 export interface CreateSandboxConfig {
@@ -73,6 +84,19 @@ export interface CreateSandboxConfig {
   mcpServers?: McpServerConfig[];
   /** Sandbox settings (tunnel ports, etc.) resolved from integration settings */
   sandboxSettings?: SandboxSettings;
+  /**
+   * Ordered member list for multi-repo sessions. Only set when the session
+   * has more than one member — single-repo sessions keep the scalar
+   * repoOwner/repoName/branch wire form (the runtime synthesizes its
+   * one-entry list from them).
+   */
+  repositories?: SessionRepositoryInfo[];
+  /**
+   * Shared working-branch name across all members, computed control-plane
+   * side (generateBranchName) — the runtime never derives branch names.
+   * Set together with repositories.
+   */
+  workingBranchName?: string;
 }
 
 /**
@@ -135,6 +159,10 @@ export interface RestoreConfig {
   agentSlackNotifyEnabled?: boolean;
   /** Sandbox settings (tunnel ports, etc.) resolved from integration settings */
   sandboxSettings?: SandboxSettings;
+  /** Multi-repo member list — see CreateSandboxConfig. */
+  repositories?: SessionRepositoryInfo[];
+  /** Shared working-branch name — see CreateSandboxConfig. */
+  workingBranchName?: string;
 }
 
 /**

--- a/packages/control-plane/src/sandbox/provider.ts
+++ b/packages/control-plane/src/sandbox/provider.ts
@@ -5,7 +5,7 @@
  * enabling unit testing and future provider support.
  */
 
-import type { SandboxSettings } from "@open-inspect/shared";
+import type { SandboxSettings, SessionRepositoryState } from "@open-inspect/shared";
 import type { CorrelationContext } from "../logger";
 import type { McpServerConfig } from "@open-inspect/shared";
 
@@ -29,14 +29,14 @@ export interface SandboxProviderCapabilities {
 
 /**
  * One member repository of a session, in position order (first = primary).
- * The runtime's SessionRepositoryConfig is the snake_case wire twin.
+ * Derived from the shared SessionRepositoryState contract; the runtime's
+ * SessionRepositoryConfig is the snake_case wire twin (baseBranch maps to
+ * its `branch` field in toRepositoryConfigPayload).
  */
-export interface SessionRepositoryInfo {
-  repoOwner: string;
-  repoName: string;
-  /** Base branch to clone (resolved at session create; never null). */
-  branch: string;
-}
+export type SessionRepositoryInfo = Pick<
+  SessionRepositoryState,
+  "repoOwner" | "repoName" | "baseBranch"
+>;
 
 /**
  * Configuration for creating a new sandbox.

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -107,6 +107,8 @@ export class ModalSandboxProvider implements SandboxProvider, ModalRepoImageBuil
           agentSlackNotifyEnabled: config.agentSlackNotifyEnabled,
           mcpServers: config.mcpServers,
           sandboxSettings: config.sandboxSettings,
+          repositories: config.repositories,
+          workingBranchName: config.workingBranchName,
         },
         config.correlation
       );
@@ -149,6 +151,8 @@ export class ModalSandboxProvider implements SandboxProvider, ModalRepoImageBuil
           agentSlackNotifyEnabled: config.agentSlackNotifyEnabled,
           mcpServers: config.mcpServers,
           sandboxSettings: config.sandboxSettings,
+          repositories: config.repositories,
+          workingBranchName: config.workingBranchName,
         },
         config.correlation
       );

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -108,7 +108,6 @@ export class ModalSandboxProvider implements SandboxProvider, ModalRepoImageBuil
           mcpServers: config.mcpServers,
           sandboxSettings: config.sandboxSettings,
           repositories: config.repositories,
-          workingBranchName: config.workingBranchName,
         },
         config.correlation
       );
@@ -152,7 +151,6 @@ export class ModalSandboxProvider implements SandboxProvider, ModalRepoImageBuil
           mcpServers: config.mcpServers,
           sandboxSettings: config.sandboxSettings,
           repositories: config.repositories,
-          workingBranchName: config.workingBranchName,
         },
         config.correlation
       );

--- a/packages/control-plane/src/sandbox/sandbox-env.test.ts
+++ b/packages/control-plane/src/sandbox/sandbox-env.test.ts
@@ -34,6 +34,30 @@ describe("buildSessionConfig", () => {
     );
   });
 
+  it("maps multi-repo members and the working branch to snake_case wire fields", () => {
+    const config = buildSessionConfig({
+      ...baseInput,
+      repositories: [
+        { repoOwner: "testowner", repoName: "testrepo", branch: "main" },
+        { repoOwner: "testowner", repoName: "backend", branch: "develop" },
+      ],
+      workingBranchName: "open-inspect/session-123",
+    });
+
+    expect(config.repositories).toEqual([
+      { repo_owner: "testowner", repo_name: "testrepo", branch: "main" },
+      { repo_owner: "testowner", repo_name: "backend", branch: "develop" },
+    ]);
+    expect(config.working_branch_name).toBe("open-inspect/session-123");
+  });
+
+  it("omits repositories and working_branch_name for single-repo inputs", () => {
+    const parsed = JSON.parse(JSON.stringify(buildSessionConfig(baseInput)));
+
+    expect(parsed).not.toHaveProperty("repositories");
+    expect(parsed).not.toHaveProperty("working_branch_name");
+  });
+
   it("serializes to a SESSION_CONFIG that omits undefined mcp_servers", () => {
     // With no MCP servers configured, the key must not appear in the serialized
     // payload — the runtime treats an absent key and an empty list identically.

--- a/packages/control-plane/src/sandbox/sandbox-env.test.ts
+++ b/packages/control-plane/src/sandbox/sandbox-env.test.ts
@@ -34,28 +34,25 @@ describe("buildSessionConfig", () => {
     );
   });
 
-  it("maps multi-repo members and the working branch to snake_case wire fields", () => {
+  it("maps multi-repo members to snake_case wire fields", () => {
     const config = buildSessionConfig({
       ...baseInput,
       repositories: [
         { repoOwner: "testowner", repoName: "testrepo", branch: "main" },
         { repoOwner: "testowner", repoName: "backend", branch: "develop" },
       ],
-      workingBranchName: "open-inspect/session-123",
     });
 
     expect(config.repositories).toEqual([
       { repo_owner: "testowner", repo_name: "testrepo", branch: "main" },
       { repo_owner: "testowner", repo_name: "backend", branch: "develop" },
     ]);
-    expect(config.working_branch_name).toBe("open-inspect/session-123");
   });
 
-  it("omits repositories and working_branch_name for single-repo inputs", () => {
+  it("omits repositories for single-repo inputs", () => {
     const parsed = JSON.parse(JSON.stringify(buildSessionConfig(baseInput)));
 
     expect(parsed).not.toHaveProperty("repositories");
-    expect(parsed).not.toHaveProperty("working_branch_name");
   });
 
   it("serializes to a SESSION_CONFIG that omits undefined mcp_servers", () => {

--- a/packages/control-plane/src/sandbox/sandbox-env.test.ts
+++ b/packages/control-plane/src/sandbox/sandbox-env.test.ts
@@ -38,8 +38,8 @@ describe("buildSessionConfig", () => {
     const config = buildSessionConfig({
       ...baseInput,
       repositories: [
-        { repoOwner: "testowner", repoName: "testrepo", branch: "main" },
-        { repoOwner: "testowner", repoName: "backend", branch: "develop" },
+        { repoOwner: "testowner", repoName: "testrepo", baseBranch: "main" },
+        { repoOwner: "testowner", repoName: "backend", baseBranch: "develop" },
       ],
     });
 

--- a/packages/control-plane/src/sandbox/sandbox-env.ts
+++ b/packages/control-plane/src/sandbox/sandbox-env.ts
@@ -83,6 +83,6 @@ export function toRepositoryConfigPayload(
   return {
     repo_owner: repository.repoOwner,
     repo_name: repository.repoName,
-    branch: repository.branch,
+    branch: repository.baseBranch,
   };
 }

--- a/packages/control-plane/src/sandbox/sandbox-env.ts
+++ b/packages/control-plane/src/sandbox/sandbox-env.ts
@@ -37,8 +37,6 @@ export interface SessionConfigPayload {
   branch?: string | null;
   /** Ordered member list; only present for multi-repo sessions. */
   repositories?: SessionRepositoryConfigPayload[];
-  /** Shared working-branch name; only present with repositories. */
-  working_branch_name?: string;
 }
 
 /** Provider-agnostic inputs needed to assemble a {@link SessionConfigPayload}. */
@@ -51,7 +49,6 @@ export interface SessionConfigInput {
   mcpServers?: McpServerConfig[];
   branch?: string | null;
   repositories?: SessionRepositoryInfo[];
-  workingBranchName?: string;
 }
 
 /**
@@ -76,9 +73,6 @@ export function buildSessionConfig(input: SessionConfigInput): SessionConfigPayl
   }
   if (input.repositories?.length) {
     payload.repositories = input.repositories.map(toRepositoryConfigPayload);
-  }
-  if (input.workingBranchName) {
-    payload.working_branch_name = input.workingBranchName;
   }
   return payload;
 }

--- a/packages/control-plane/src/sandbox/sandbox-env.ts
+++ b/packages/control-plane/src/sandbox/sandbox-env.ts
@@ -1,4 +1,5 @@
 import type { McpServerConfig } from "@open-inspect/shared";
+import type { SessionRepositoryInfo } from "./provider";
 
 /**
  * Shared assembly for the sandbox environment contract.
@@ -16,6 +17,13 @@ import type { McpServerConfig } from "@open-inspect/shared";
  * mirror the full contract.
  */
 
+/** Snake_case wire twin of {@link SessionRepositoryInfo} (runtime SessionRepositoryConfig). */
+export interface SessionRepositoryConfigPayload {
+  repo_owner: string;
+  repo_name: string;
+  branch: string;
+}
+
 /** Canonical `SESSION_CONFIG` payload handed to the sandbox runtime. */
 export interface SessionConfigPayload {
   session_id: string;
@@ -27,6 +35,10 @@ export interface SessionConfigPayload {
   mcp_servers?: McpServerConfig[];
   /** Omitted from the serialized payload when undefined. */
   branch?: string | null;
+  /** Ordered member list; only present for multi-repo sessions. */
+  repositories?: SessionRepositoryConfigPayload[];
+  /** Shared working-branch name; only present with repositories. */
+  working_branch_name?: string;
 }
 
 /** Provider-agnostic inputs needed to assemble a {@link SessionConfigPayload}. */
@@ -38,6 +50,8 @@ export interface SessionConfigInput {
   model: string;
   mcpServers?: McpServerConfig[];
   branch?: string | null;
+  repositories?: SessionRepositoryInfo[];
+  workingBranchName?: string;
 }
 
 /**
@@ -60,5 +74,21 @@ export function buildSessionConfig(input: SessionConfigInput): SessionConfigPayl
   if (input.branch !== undefined) {
     payload.branch = input.branch;
   }
+  if (input.repositories?.length) {
+    payload.repositories = input.repositories.map(toRepositoryConfigPayload);
+  }
+  if (input.workingBranchName) {
+    payload.working_branch_name = input.workingBranchName;
+  }
   return payload;
+}
+
+export function toRepositoryConfigPayload(
+  repository: SessionRepositoryInfo
+): SessionRepositoryConfigPayload {
+  return {
+    repo_owner: repository.repoOwner,
+    repo_name: repository.repoName,
+    branch: repository.branch,
+  };
 }

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -53,6 +53,7 @@ import type {
   ClientInfo,
   ServerMessage,
   SandboxEvent,
+  SessionRepositoryState,
   SessionState,
   SessionStatus,
   SandboxStatus,
@@ -579,6 +580,12 @@ export class SessionDO extends DurableObject<Env> {
       getSandbox: () => this.repository.getSandbox(),
       getSandboxWithCircuitBreaker: () => this.repository.getSandboxWithCircuitBreaker(),
       getSession: () => this.repository.getSession(),
+      getSessionRepositories: () =>
+        this.repository.getSessionRepositories().map((row) => ({
+          repoOwner: row.repo_owner,
+          repoName: row.repo_name,
+          branch: row.base_branch,
+        })),
       getUserEnvVars: () => this.getUserEnvVars(),
       updateSandboxStatus: (status) => this.updateSandboxStatus(status),
       updateSandboxForSpawn: (data) => this.repository.updateSandboxForSpawn(data),
@@ -660,8 +667,7 @@ export class SessionDO extends DurableObject<Env> {
     if (this.env.DB) {
       const mcpStore = new McpServerStore(this.env.DB, this.env.REPO_SECRETS_ENCRYPTION_KEY);
       mcpServerLookup = {
-        getDecryptedForSession: (repoOwner, repoName) =>
-          mcpStore.getDecryptedForSession(repoOwner, repoName),
+        getDecryptedForSession: (repositories) => mcpStore.getDecryptedForSession(repositories),
       };
     }
 
@@ -1691,7 +1697,49 @@ export class SessionDO extends DurableObject<Env> {
       ttydUrl: sandbox?.ttyd_url ?? null,
       ttydToken,
       sandboxDashboardUrl: this.getSandboxDashboardUrl(sandbox?.modal_object_id),
+      repositories: this.getSessionRepositoryStates(session),
     };
+  }
+
+  /**
+   * Member repositories for SessionState, in position order. Sessions that
+   * predate the session_repositories table get a one-entry list synthesized
+   * from the scalar columns. Per-repo git state columns are written from
+   * PR-5 onward, so the primary entry is overlaid with the session scalars
+   * (which describe the primary until then); prUrl arrives with per-repo PR
+   * artifacts.
+   */
+  private getSessionRepositoryStates(session: SessionRow | null): SessionRepositoryState[] {
+    const rows = this.repository.getSessionRepositories();
+    if (rows.length > 0) {
+      return rows.map((row, index) => ({
+        position: row.position,
+        repoOwner: row.repo_owner,
+        repoName: row.repo_name,
+        repoId: row.repo_id,
+        baseBranch: row.base_branch,
+        branchName: row.branch_name ?? (index === 0 ? (session?.branch_name ?? null) : null),
+        baseSha: row.base_sha ?? (index === 0 ? (session?.base_sha ?? null) : null),
+        currentSha: row.current_sha ?? (index === 0 ? (session?.current_sha ?? null) : null),
+        prUrl: null,
+      }));
+    }
+    if (session?.repo_owner && session.repo_name) {
+      return [
+        {
+          position: 0,
+          repoOwner: session.repo_owner,
+          repoName: session.repo_name,
+          repoId: session.repo_id ?? null,
+          baseBranch: session.base_branch ?? "main",
+          branchName: session.branch_name ?? null,
+          baseSha: session.base_sha ?? null,
+          currentSha: session.current_sha ?? null,
+          prUrl: null,
+        },
+      ];
+    }
+    return [];
   }
 
   private getSandboxDashboardUrl(providerObjectId: string | null | undefined): string | null {

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -584,7 +584,7 @@ export class SessionDO extends DurableObject<Env> {
         this.repository.getSessionRepositories().map((row) => ({
           repoOwner: row.repo_owner,
           repoName: row.repo_name,
-          branch: row.base_branch,
+          baseBranch: row.base_branch,
         })),
       getUserEnvVars: () => this.getUserEnvVars(),
       updateSandboxStatus: (status) => this.updateSandboxStatus(status),

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
@@ -78,6 +78,7 @@ function createParticipant(overrides: Partial<ParticipantRow> = {}): Participant
 function createHandler() {
   const repository = {
     upsertSession: vi.fn(),
+    replaceSessionRepositories: vi.fn(),
     createSandbox: vi.fn(),
     createParticipant: vi.fn(),
   };
@@ -265,8 +266,147 @@ describe("createSessionLifecycleHandler", () => {
       role: "owner",
       joinedAt: 1234,
     });
+    // Scalar init synthesizes a one-entry member set.
+    expect(repository.replaceSessionRepositories).toHaveBeenCalledWith([
+      {
+        position: 0,
+        repoOwner: "acme",
+        repoName: "repo",
+        repoId: 123,
+        baseBranch: "feature/work",
+      },
+    ]);
     expect(scheduleWarmSandbox).toHaveBeenCalled();
     expect(log.info).toHaveBeenCalledWith("Triggering sandbox spawn for new session");
+  });
+
+  it("persists the repositories list in position order", async () => {
+    const { handler, repository, validateReasoningEffort, generateId } = createHandler();
+    validateReasoningEffort.mockReturnValue(null);
+    generateId.mockReturnValueOnce("sandbox-1").mockReturnValueOnce("participant-1");
+
+    const response = await handler.init(
+      new Request("http://internal/internal/init", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          sessionName: "session-public-id",
+          repoOwner: "acme",
+          repoName: "frontend",
+          repoId: 1,
+          defaultBranch: "main",
+          repositories: [
+            { repoOwner: "acme", repoName: "frontend", repoId: 1, baseBranch: "main" },
+            { repoOwner: "acme", repoName: "backend", repoId: 2, baseBranch: "develop" },
+          ],
+          userId: "user-1",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(repository.replaceSessionRepositories).toHaveBeenCalledWith([
+      { position: 0, repoOwner: "acme", repoName: "frontend", repoId: 1, baseBranch: "main" },
+      { position: 1, repoOwner: "acme", repoName: "backend", repoId: 2, baseBranch: "develop" },
+    ]);
+  });
+
+  it("persists an empty member set for repo-less sessions", async () => {
+    const { handler, repository, validateReasoningEffort, generateId } = createHandler();
+    validateReasoningEffort.mockReturnValue(null);
+    generateId.mockReturnValueOnce("sandbox-1").mockReturnValueOnce("participant-1");
+
+    const response = await handler.init(
+      new Request("http://internal/internal/init", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          sessionName: "session-public-id",
+          repoOwner: null,
+          repoName: null,
+          userId: "user-1",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(repository.replaceSessionRepositories).toHaveBeenCalledWith([]);
+  });
+
+  it("rejects a repositories list whose primary does not match the scalar mirror", async () => {
+    const { handler, repository } = createHandler();
+
+    const response = await handler.init(
+      new Request("http://internal/internal/init", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          sessionName: "session-public-id",
+          repoOwner: "acme",
+          repoName: "frontend",
+          repoId: 1,
+          defaultBranch: "main",
+          repositories: [{ repoOwner: "acme", repoName: "backend", repoId: 2, baseBranch: "main" }],
+          userId: "user-1",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "repositories[0] must match the scalar repository mirror",
+    });
+    expect(repository.upsertSession).not.toHaveBeenCalled();
+    expect(repository.replaceSessionRepositories).not.toHaveBeenCalled();
+  });
+
+  it("rejects an explicit empty repositories list alongside scalar context", async () => {
+    const { handler, repository } = createHandler();
+
+    const response = await handler.init(
+      new Request("http://internal/internal/init", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          sessionName: "session-public-id",
+          repoOwner: "acme",
+          repoName: "frontend",
+          repoId: 1,
+          repositories: [],
+          userId: "user-1",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "repositories must include the scalar repository",
+    });
+    expect(repository.upsertSession).not.toHaveBeenCalled();
+  });
+
+  it("rejects a repositories list on a repo-less session", async () => {
+    const { handler, repository } = createHandler();
+
+    const response = await handler.init(
+      new Request("http://internal/internal/init", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          sessionName: "session-public-id",
+          repoOwner: null,
+          repoName: null,
+          repositories: [{ repoOwner: "acme", repoName: "backend", repoId: 2, baseBranch: "main" }],
+          userId: "user-1",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "repositories[0] must match the scalar repository mirror",
+    });
+    expect(repository.upsertSession).not.toHaveBeenCalled();
   });
 
   it("falls back to pre-encrypted token when plain-token encryption fails", async () => {

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
@@ -1,6 +1,11 @@
 import type { Logger } from "../../../logger";
 import type { ParticipantRow, SandboxRow, SessionRow } from "../../types";
-import { getValidModelOrDefault, isValidModel, type SandboxSettings } from "@open-inspect/shared";
+import {
+  getValidModelOrDefault,
+  isValidModel,
+  type RepositoryRef,
+  type SandboxSettings,
+} from "@open-inspect/shared";
 import type { SandboxStatus, SessionStatus, SpawnSource } from "../../../types";
 import type { SessionRepository } from "../../repository";
 import {
@@ -23,6 +28,12 @@ interface InitRequest {
   repoId?: number | null;
   defaultBranch?: string | null;
   branch?: string | null;
+  /**
+   * Ordered member list ([0] = primary, matching the scalar fields).
+   * initialize.ts always sends it for repository sessions (synthesizing a
+   * one-entry list for scalar callers) and an empty list for repo-less ones.
+   */
+  repositories?: RepositoryRef[];
   title?: string;
   model?: string;
   reasoningEffort?: string;
@@ -43,7 +54,10 @@ interface InitRequest {
 }
 
 export interface SessionLifecycleHandlerDeps {
-  repository: Pick<SessionRepository, "upsertSession" | "createSandbox" | "createParticipant">;
+  repository: Pick<
+    SessionRepository,
+    "upsertSession" | "replaceSessionRepositories" | "createSandbox" | "createParticipant"
+  >;
   getDurableObjectId: () => string;
   tokenEncryptionKey?: string;
   encryptToken: (token: string, encryptionKey: string) => Promise<string>;
@@ -142,6 +156,30 @@ export function createSessionLifecycleHandler(
       const reasoningEffort = deps.validateReasoningEffort(model, body.reasoningEffort);
       const baseBranch = hasRepoOwner ? body.branch || body.defaultBranch || "main" : null;
 
+      const repositories = body.repositories ?? [];
+      if (repositories.length > 0) {
+        const primary = repositories[0];
+        if (
+          !hasRepoOwner ||
+          primary.repoOwner !== repoOwner ||
+          primary.repoName !== repoName ||
+          primary.repoId !== body.repoId ||
+          primary.baseBranch !== baseBranch
+        ) {
+          return Response.json(
+            { error: "repositories[0] must match the scalar repository mirror" },
+            { status: 400 }
+          );
+        }
+      } else if (hasRepoOwner && body.repositories !== undefined) {
+        // An explicit empty list alongside scalar context is a producer bug —
+        // initialize.ts synthesizes a one-entry list for scalar callers.
+        return Response.json(
+          { error: "repositories must include the scalar repository" },
+          { status: 400 }
+        );
+      }
+
       deps.repository.upsertSession({
         id: sessionId,
         sessionName,
@@ -161,6 +199,24 @@ export function createSessionLifecycleHandler(
         createdAt: now,
         updatedAt: now,
       });
+
+      // Legacy scalar producers (spawn paths not yet list-aware) still get a
+      // member row so spawn/read paths have one source of truth.
+      const memberRepositories: RepositoryRef[] =
+        repositories.length > 0
+          ? repositories
+          : repoOwner !== null && repoName !== null && body.repoId != null && baseBranch !== null
+            ? [{ repoOwner, repoName, repoId: body.repoId, baseBranch }]
+            : [];
+      deps.repository.replaceSessionRepositories(
+        memberRepositories.map((repo, position) => ({
+          position,
+          repoOwner: repo.repoOwner,
+          repoName: repo.repoName,
+          repoId: repo.repoId,
+          baseBranch: repo.baseBranch,
+        }))
+      );
 
       const sandboxId = deps.generateId();
       deps.repository.createSandbox({

--- a/packages/control-plane/src/session/initialize.ts
+++ b/packages/control-plane/src/session/initialize.ts
@@ -1,6 +1,6 @@
 import type { Env } from "../types";
 import type { RequestContext } from "../routes/shared";
-import type { SpawnSource, SandboxSettings } from "@open-inspect/shared";
+import type { RepositoryRef, SpawnSource, SandboxSettings } from "@open-inspect/shared";
 import { SessionIndexStore } from "../db/session-index";
 import { buildSessionInternalUrl, SessionInternalPaths } from "./contracts";
 import { createLogger } from "../logger";
@@ -24,6 +24,12 @@ export interface SessionInitInput {
   repoId?: number | null;
   defaultBranch?: string | null;
   branch?: string | null;
+  /**
+   * Ordered member list for multi-repo sessions ([0] = primary, which must
+   * match the scalar mirror above). Absent/empty for scalar callers — a
+   * one-entry list is synthesized from the scalar fields.
+   */
+  repositories?: RepositoryRef[];
 
   // Session config
   title?: string;
@@ -87,6 +93,30 @@ export async function initializeSession(
   const now = Date.now();
   const baseBranch = hasRepoOwner ? branch || defaultBranch || "main" : null;
 
+  if (input.repositories?.length) {
+    const primary = input.repositories[0];
+    if (
+      primary.repoOwner !== input.repoOwner ||
+      primary.repoName !== input.repoName ||
+      primary.repoId !== input.repoId ||
+      primary.baseBranch !== baseBranch
+    ) {
+      throw new Error("repositories[0] must match the scalar repository mirror");
+    }
+  }
+  const repositories: RepositoryRef[] = input.repositories?.length
+    ? input.repositories
+    : hasRepoOwner && input.repoOwner && input.repoName && input.repoId != null && baseBranch
+      ? [
+          {
+            repoOwner: input.repoOwner,
+            repoName: input.repoName,
+            repoId: input.repoId,
+            baseBranch,
+          },
+        ]
+      : [];
+
   // Step 1: D1 index (must succeed before DO init starts sandbox warming)
   const sessionStore = new SessionIndexStore(env.DB);
   await sessionStore.create({
@@ -97,6 +127,7 @@ export async function initializeSession(
     model: input.model,
     reasoningEffort: input.reasoningEffort,
     baseBranch,
+    repositories,
     status: "created",
     parentSessionId: input.parentSessionId,
     spawnSource: input.spawnSource,
@@ -132,6 +163,7 @@ export async function initializeSession(
           repoId: input.repoId,
           defaultBranch,
           branch,
+          repositories,
           title: input.title,
           model: input.model,
           reasoningEffort: input.reasoningEffort,

--- a/packages/control-plane/src/session/repository.test.ts
+++ b/packages/control-plane/src/session/repository.test.ts
@@ -238,6 +238,52 @@ describe("SessionRepository", () => {
     });
   });
 
+  // === SESSION REPOSITORIES ===
+
+  describe("replaceSessionRepositories", () => {
+    it("deletes existing rows before inserting the new set in order", () => {
+      repo.replaceSessionRepositories([
+        { position: 0, repoOwner: "acme", repoName: "frontend", repoId: 1, baseBranch: "main" },
+        {
+          position: 1,
+          repoOwner: "acme",
+          repoName: "backend",
+          repoId: null,
+          baseBranch: "develop",
+        },
+      ]);
+
+      expect(mock.calls.length).toBe(3);
+      expect(mock.calls[0].query).toContain("DELETE FROM session_repositories");
+      expect(mock.calls[1].query).toContain("INSERT INTO session_repositories");
+      expect(mock.calls[1].params).toEqual([0, "acme", "frontend", 1, "main"]);
+      expect(mock.calls[2].params).toEqual([1, "acme", "backend", null, "develop"]);
+    });
+
+    it("clears all rows when given an empty set", () => {
+      repo.replaceSessionRepositories([]);
+
+      expect(mock.calls.length).toBe(1);
+      expect(mock.calls[0].query).toContain("DELETE FROM session_repositories");
+    });
+  });
+
+  describe("getSessionRepositories", () => {
+    it("returns rows ordered by position", () => {
+      const rows = [
+        { position: 0, repo_owner: "acme", repo_name: "frontend" },
+        { position: 1, repo_owner: "acme", repo_name: "backend" },
+      ];
+      mock.setData(`SELECT * FROM session_repositories ORDER BY position`, rows);
+
+      expect(repo.getSessionRepositories()).toEqual(rows);
+    });
+
+    it("returns an empty list for pre-feature sessions", () => {
+      expect(repo.getSessionRepositories()).toEqual([]);
+    });
+  });
+
   // === SANDBOX ===
 
   describe("getSandbox", () => {

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -15,7 +15,6 @@ import type {
 } from "./types";
 import type {
   SessionStatus,
-  SessionRepositoryState,
   SandboxStatus,
   GitSyncStatus,
   MessageStatus,
@@ -97,12 +96,17 @@ export interface SessionRepositoryRow {
 }
 
 /**
- * Data for writing a session's member repository set.
+ * Data for writing a session's member repository set — mirrors the
+ * session_repositories columns the init path populates (per-repo git state
+ * is written separately, by push handling).
  */
-export type SessionRepositoryData = Pick<
-  SessionRepositoryState,
-  "position" | "repoOwner" | "repoName" | "repoId" | "baseBranch"
->;
+export interface SessionRepositoryData {
+  position: number;
+  repoOwner: string;
+  repoName: string;
+  repoId: number | null;
+  baseBranch: string;
+}
 
 /**
  * Data for creating a sandbox.

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -82,6 +82,31 @@ export interface UpsertSessionData {
 }
 
 /**
+ * One member repository row, in position order (position 0 = primary).
+ */
+export interface SessionRepositoryRow {
+  position: number;
+  repo_owner: string;
+  repo_name: string;
+  repo_id: number | null;
+  base_branch: string;
+  branch_name: string | null;
+  base_sha: string | null;
+  current_sha: string | null;
+}
+
+/**
+ * Data for writing a session's member repository set.
+ */
+export interface SessionRepositoryData {
+  position: number;
+  repoOwner: string;
+  repoName: string;
+  repoId: number | null;
+  baseBranch: string;
+}
+
+/**
  * Data for creating a sandbox.
  */
 export interface CreateSandboxData {
@@ -346,6 +371,33 @@ export class SessionRepository {
       cost,
       updatedAt
     );
+  }
+
+  // === SESSION REPOSITORIES ===
+
+  /**
+   * Replace the session's member repository set (DELETE + INSERT).
+   * Per-repo git state columns (branch_name, base_sha, current_sha) reset
+   * with the set — they describe work on the replaced members.
+   */
+  replaceSessionRepositories(repositories: SessionRepositoryData[]): void {
+    this.sql.exec(`DELETE FROM session_repositories`);
+    for (const repo of repositories) {
+      this.sql.exec(
+        `INSERT INTO session_repositories (position, repo_owner, repo_name, repo_id, base_branch)
+         VALUES (?, ?, ?, ?, ?)`,
+        repo.position,
+        repo.repoOwner,
+        repo.repoName,
+        repo.repoId,
+        repo.baseBranch
+      );
+    }
+  }
+
+  getSessionRepositories(): SessionRepositoryRow[] {
+    const result = this.sql.exec(`SELECT * FROM session_repositories ORDER BY position`);
+    return this.rows<SessionRepositoryRow>(result);
   }
 
   // === SANDBOX ===

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -15,6 +15,7 @@ import type {
 } from "./types";
 import type {
   SessionStatus,
+  SessionRepositoryState,
   SandboxStatus,
   GitSyncStatus,
   MessageStatus,
@@ -98,13 +99,10 @@ export interface SessionRepositoryRow {
 /**
  * Data for writing a session's member repository set.
  */
-export interface SessionRepositoryData {
-  position: number;
-  repoOwner: string;
-  repoName: string;
-  repoId: number | null;
-  baseBranch: string;
-}
+export type SessionRepositoryData = Pick<
+  SessionRepositoryState,
+  "position" | "repoOwner" | "repoName" | "repoId" | "baseBranch"
+>;
 
 /**
  * Data for creating a sandbox.

--- a/packages/control-plane/src/session/schema.test.ts
+++ b/packages/control-plane/src/session/schema.test.ts
@@ -202,6 +202,15 @@ describe("applyMigrations", () => {
     expect(transactionControlStatements).toEqual([]);
   });
 
+  it("creates session_repositories for both fresh DOs and migrated DOs", () => {
+    // Fresh DOs get the table from SCHEMA_SQL; existing DOs via migration 31.
+    expect(SCHEMA_SQL).toContain("CREATE TABLE IF NOT EXISTS session_repositories");
+
+    const migration = MIGRATIONS.find((m) => m.id === 31);
+    expect(migration).toBeDefined();
+    expect(migration?.run).toContain("CREATE TABLE IF NOT EXISTS session_repositories");
+  });
+
   it("keeps repository context consistent at the session table boundary", () => {
     expect(SCHEMA_SQL).toContain("(repo_owner IS NULL) = (repo_name IS NULL)");
     expect(SCHEMA_SQL).toContain("repo_owner IS NOT NULL");

--- a/packages/control-plane/src/session/schema.ts
+++ b/packages/control-plane/src/session/schema.ts
@@ -5,6 +5,20 @@
  * This ensures high performance even with hundreds of concurrent sessions.
  */
 
+// Shared between SCHEMA_SQL (fresh DOs) and migration 31 (existing DOs) so
+// the two paths can never diverge.
+const SESSION_REPOSITORIES_TABLE_SQL = `CREATE TABLE IF NOT EXISTS session_repositories (
+  position INTEGER NOT NULL,
+  repo_owner TEXT NOT NULL,
+  repo_name TEXT NOT NULL,
+  repo_id INTEGER,
+  base_branch TEXT NOT NULL,
+  branch_name TEXT,                                 -- Working branch (set after first push to this repo)
+  base_sha TEXT,
+  current_sha TEXT,
+  PRIMARY KEY (repo_owner, repo_name)
+)`;
+
 export const SCHEMA_SQL = `
 -- Core session state
 CREATE TABLE IF NOT EXISTS session (
@@ -125,17 +139,7 @@ CREATE TABLE IF NOT EXISTS sandbox (
 -- from the session scalar columns. Per-repo git state columns are written
 -- by push handling from PR-5 onward; until then the position-0 row is
 -- overlaid with the session scalar branch/sha columns at read time.
-CREATE TABLE IF NOT EXISTS session_repositories (
-  position INTEGER NOT NULL,
-  repo_owner TEXT NOT NULL,
-  repo_name TEXT NOT NULL,
-  repo_id INTEGER,
-  base_branch TEXT NOT NULL,
-  branch_name TEXT,                                 -- Working branch (set after first push to this repo)
-  base_sha TEXT,
-  current_sha TEXT,
-  PRIMARY KEY (repo_owner, repo_name)
-);
+${SESSION_REPOSITORIES_TABLE_SQL};
 
 -- WebSocket client mapping for hibernation recovery
 CREATE TABLE IF NOT EXISTS ws_client_mapping (
@@ -411,17 +415,7 @@ export const MIGRATIONS: readonly SchemaMigration[] = [
   {
     id: 31,
     description: "Add session_repositories table for multi-repo sessions",
-    run: `CREATE TABLE IF NOT EXISTS session_repositories (
-      position INTEGER NOT NULL,
-      repo_owner TEXT NOT NULL,
-      repo_name TEXT NOT NULL,
-      repo_id INTEGER,
-      base_branch TEXT NOT NULL,
-      branch_name TEXT,
-      base_sha TEXT,
-      current_sha TEXT,
-      PRIMARY KEY (repo_owner, repo_name)
-    )`,
+    run: SESSION_REPOSITORIES_TABLE_SQL,
   },
 ];
 

--- a/packages/control-plane/src/session/schema.ts
+++ b/packages/control-plane/src/session/schema.ts
@@ -119,6 +119,24 @@ CREATE TABLE IF NOT EXISTS sandbox (
   created_at INTEGER NOT NULL
 );
 
+-- Member repositories for multi-repo sessions, in position order
+-- (position 0 = primary, mirrored into session.repo_owner/repo_name).
+-- Pre-feature sessions have no rows; readers synthesize a one-entry list
+-- from the session scalar columns. Per-repo git state columns are written
+-- by push handling from PR-5 onward; until then the position-0 row is
+-- overlaid with the session scalar branch/sha columns at read time.
+CREATE TABLE IF NOT EXISTS session_repositories (
+  position INTEGER NOT NULL,
+  repo_owner TEXT NOT NULL,
+  repo_name TEXT NOT NULL,
+  repo_id INTEGER,
+  base_branch TEXT NOT NULL,
+  branch_name TEXT,                                 -- Working branch (set after first push to this repo)
+  base_sha TEXT,
+  current_sha TEXT,
+  PRIMARY KEY (repo_owner, repo_name)
+);
+
 -- WebSocket client mapping for hibernation recovery
 CREATE TABLE IF NOT EXISTS ws_client_mapping (
   ws_id TEXT PRIMARY KEY,
@@ -389,6 +407,21 @@ export const MIGRATIONS: readonly SchemaMigration[] = [
     id: 30,
     description: "Add total_cost to session",
     run: `ALTER TABLE session ADD COLUMN total_cost REAL NOT NULL DEFAULT 0`,
+  },
+  {
+    id: 31,
+    description: "Add session_repositories table for multi-repo sessions",
+    run: `CREATE TABLE IF NOT EXISTS session_repositories (
+      position INTEGER NOT NULL,
+      repo_owner TEXT NOT NULL,
+      repo_name TEXT NOT NULL,
+      repo_id INTEGER,
+      base_branch TEXT NOT NULL,
+      branch_name TEXT,
+      base_sha TEXT,
+      current_sha TEXT,
+      PRIMARY KEY (repo_owner, repo_name)
+    )`,
   },
 ];
 

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -29,6 +29,7 @@ export type {
   SandboxEvent,
   SandboxStatus,
   ServerMessage,
+  SessionRepositoryState,
   SessionState,
   SessionStatus,
 } from "@open-inspect/shared";

--- a/packages/control-plane/test/integration/cleanup.ts
+++ b/packages/control-plane/test/integration/cleanup.ts
@@ -6,6 +6,6 @@ import { env } from "cloudflare:test";
  */
 export async function cleanD1Tables(): Promise<void> {
   await env.DB.exec(
-    "DELETE FROM automation_slack_channels; DELETE FROM automation_runs; DELETE FROM automation_invocations; DELETE FROM automation_repositories; DELETE FROM automations; DELETE FROM sessions; DELETE FROM user_scm_tokens; DELETE FROM repo_metadata; DELETE FROM repo_secrets; DELETE FROM global_secrets; DELETE FROM integration_settings; DELETE FROM integration_repo_settings; DELETE FROM repo_images; DELETE FROM mcp_servers; DELETE FROM user_identities; DELETE FROM users;"
+    "DELETE FROM automation_slack_channels; DELETE FROM automation_runs; DELETE FROM automation_invocations; DELETE FROM automation_repositories; DELETE FROM automations; DELETE FROM session_repositories; DELETE FROM sessions; DELETE FROM user_scm_tokens; DELETE FROM repo_metadata; DELETE FROM repo_secrets; DELETE FROM global_secrets; DELETE FROM integration_settings; DELETE FROM integration_repo_settings; DELETE FROM repo_images; DELETE FROM mcp_servers; DELETE FROM user_identities; DELETE FROM users;"
   );
 }

--- a/packages/control-plane/test/integration/helpers.ts
+++ b/packages/control-plane/test/integration/helpers.ts
@@ -12,6 +12,13 @@ export async function initSession(overrides?: {
   repoOwner?: string;
   repoName?: string;
   repoId?: number;
+  defaultBranch?: string;
+  repositories?: Array<{
+    repoOwner: string;
+    repoName: string;
+    repoId: number;
+    baseBranch: string;
+  }>;
   title?: string;
   model?: string;
   reasoningEffort?: string;

--- a/packages/control-plane/test/integration/session-repositories.test.ts
+++ b/packages/control-plane/test/integration/session-repositories.test.ts
@@ -147,6 +147,37 @@ describe("D1 session index repositories", () => {
     expect(sessions[0].repositories).toBeUndefined();
   });
 
+  it("list repo filters match secondary members", async () => {
+    const store = new SessionIndexStore(env.DB);
+    await store.create(
+      makeEntry("multi-filter", [
+        { repoOwner: "acme", repoName: "frontend", repoId: 1, baseBranch: "main" },
+        { repoOwner: "acme", repoName: "backend", repoId: 2, baseBranch: "main" },
+      ])
+    );
+    await store.create(
+      makeEntry("other-filter", [
+        { repoOwner: "acme", repoName: "unrelated", repoId: 3, baseBranch: "main" },
+      ])
+    );
+
+    const bySecondary = await store.list({ repoOwner: "acme", repoName: "backend" });
+    expect(bySecondary.sessions.map((s) => s.id)).toEqual(["multi-filter"]);
+
+    const byPrimary = await store.list({ repoOwner: "acme", repoName: "frontend" });
+    expect(byPrimary.sessions.map((s) => s.id)).toEqual(["multi-filter"]);
+  });
+
+  it("list repo filters fall back to scalars for pre-feature sessions", async () => {
+    const store = new SessionIndexStore(env.DB);
+    // No repositories list — simulates a session created before the
+    // membership table existed (scalar columns only).
+    await store.create(makeEntry("legacy-filter"));
+
+    const result = await store.list({ repoOwner: "acme", repoName: "web-app" });
+    expect(result.sessions.map((s) => s.id)).toEqual(["legacy-filter"]);
+  });
+
   it("deletes member rows together with the session", async () => {
     const store = new SessionIndexStore(env.DB);
     await store.create(

--- a/packages/control-plane/test/integration/session-repositories.test.ts
+++ b/packages/control-plane/test/integration/session-repositories.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Multi-repo session storage: DO member rows, D1 index hydration, and
+ * route-level rejection of malformed repository lists.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { SELF, env } from "cloudflare:test";
+import { SessionIndexStore } from "../../src/db/session-index";
+import { generateInternalToken } from "../../src/auth/internal";
+import { cleanD1Tables } from "./cleanup";
+import { initSession, queryDO } from "./helpers";
+
+async function authHeaders(): Promise<Record<string, string>> {
+  const token = await generateInternalToken(env.INTERNAL_CALLBACK_SECRET!);
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+type MemberRow = {
+  position: number;
+  repo_owner: string;
+  repo_name: string;
+  repo_id: number | null;
+  base_branch: string;
+};
+
+describe("DO session_repositories rows", () => {
+  it("persists the repositories list in position order on init", async () => {
+    const { stub } = await initSession({
+      repoOwner: "acme",
+      repoName: "frontend",
+      repoId: 1,
+      defaultBranch: "main",
+      repositories: [
+        { repoOwner: "acme", repoName: "frontend", repoId: 1, baseBranch: "main" },
+        { repoOwner: "acme", repoName: "backend", repoId: 2, baseBranch: "develop" },
+      ],
+    });
+
+    const rows = await queryDO<MemberRow>(
+      stub,
+      "SELECT position, repo_owner, repo_name, repo_id, base_branch FROM session_repositories ORDER BY position"
+    );
+    expect(rows).toEqual([
+      { position: 0, repo_owner: "acme", repo_name: "frontend", repo_id: 1, base_branch: "main" },
+      { position: 1, repo_owner: "acme", repo_name: "backend", repo_id: 2, base_branch: "develop" },
+    ]);
+  });
+
+  it("synthesizes a one-entry member set for scalar inits", async () => {
+    const { stub } = await initSession({
+      repoOwner: "acme",
+      repoName: "web-app",
+      repoId: 12345,
+      defaultBranch: "main",
+    });
+
+    const rows = await queryDO<MemberRow>(
+      stub,
+      "SELECT position, repo_owner, repo_name, repo_id, base_branch FROM session_repositories ORDER BY position"
+    );
+    expect(rows).toEqual([
+      {
+        position: 0,
+        repo_owner: "acme",
+        repo_name: "web-app",
+        repo_id: 12345,
+        base_branch: "main",
+      },
+    ]);
+  });
+
+  it("rejects a list whose primary does not match the scalar mirror", async () => {
+    const id = env.SESSION.newUniqueId();
+    const stub = env.SESSION.get(id);
+
+    const res = await stub.fetch("http://internal/internal/init", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sessionName: "mirror-mismatch",
+        repoOwner: "acme",
+        repoName: "frontend",
+        repoId: 1,
+        defaultBranch: "main",
+        repositories: [{ repoOwner: "acme", repoName: "backend", repoId: 2, baseBranch: "main" }],
+        userId: "user-1",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "repositories[0] must match the scalar repository mirror",
+    });
+  });
+});
+
+describe("D1 session index repositories", () => {
+  beforeEach(cleanD1Tables);
+
+  function makeEntry(id: string, repositories?: SessionIndexRepositoryInput[]) {
+    const now = Date.now();
+    return {
+      id,
+      title: null,
+      repoOwner: repositories?.[0]?.repoOwner ?? "acme",
+      repoName: repositories?.[0]?.repoName ?? "web-app",
+      model: "anthropic/claude-haiku-4-5",
+      reasoningEffort: null,
+      baseBranch: repositories?.[0]?.baseBranch ?? "main",
+      status: "created" as const,
+      createdAt: now,
+      updatedAt: now,
+      repositories,
+    };
+  }
+
+  type SessionIndexRepositoryInput = {
+    repoOwner: string;
+    repoName: string;
+    repoId: number | null;
+    baseBranch: string;
+  };
+
+  it("persists member rows on create and hydrates them on list", async () => {
+    const store = new SessionIndexStore(env.DB);
+    await store.create(
+      makeEntry("multi-1", [
+        { repoOwner: "acme", repoName: "frontend", repoId: 1, baseBranch: "main" },
+        { repoOwner: "acme", repoName: "backend", repoId: 2, baseBranch: "develop" },
+      ])
+    );
+
+    const { sessions } = await store.list();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].repositories).toEqual([
+      { repoOwner: "acme", repoName: "frontend", repoId: 1, baseBranch: "main" },
+      { repoOwner: "acme", repoName: "backend", repoId: 2, baseBranch: "develop" },
+    ]);
+  });
+
+  it("leaves repositories absent for sessions without member rows", async () => {
+    const store = new SessionIndexStore(env.DB);
+    await store.create(makeEntry("scalar-1"));
+
+    const { sessions } = await store.list();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].repositories).toBeUndefined();
+  });
+
+  it("deletes member rows together with the session", async () => {
+    const store = new SessionIndexStore(env.DB);
+    await store.create(
+      makeEntry("multi-2", [
+        { repoOwner: "acme", repoName: "frontend", repoId: 1, baseBranch: "main" },
+      ])
+    );
+
+    expect(await store.delete("multi-2")).toBe(true);
+
+    const orphans = await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM session_repositories WHERE session_id = ?"
+    )
+      .bind("multi-2")
+      .first<{ count: number }>();
+    expect(orphans?.count).toBe(0);
+  });
+});
+
+describe("POST /sessions repository list validation", () => {
+  beforeEach(cleanD1Tables);
+
+  it("rejects repositories combined with scalar repo fields", async () => {
+    const res = await SELF.fetch("https://test.local/sessions", {
+      method: "POST",
+      headers: await authHeaders(),
+      body: JSON.stringify({
+        repoOwner: "acme",
+        repoName: "web-app",
+        repositories: [{ repoOwner: "acme", repoName: "frontend" }],
+        userId: "user-1",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid session request body" });
+  });
+
+  it("rejects an empty repositories list", async () => {
+    const res = await SELF.fetch("https://test.local/sessions", {
+      method: "POST",
+      headers: await authHeaders(),
+      body: JSON.stringify({ repositories: [], userId: "user-1" }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Invalid session request body" });
+  });
+
+  it("names every unresolvable repository in the failure", async () => {
+    // The test env has no GitHub App configured, so every lookup throws —
+    // the resolver must aggregate rather than fail on the first entry.
+    const res = await SELF.fetch("https://test.local/sessions", {
+      method: "POST",
+      headers: await authHeaders(),
+      body: JSON.stringify({
+        repositories: [
+          { repoOwner: "acme", repoName: "frontend" },
+          { repoOwner: "acme", repoName: "backend" },
+        ],
+        userId: "user-1",
+      }),
+    });
+
+    expect(res.status).toBe(500);
+    const body = await res.json<{ error: string }>();
+    expect(body.error).toContain("acme/frontend");
+    expect(body.error).toContain("acme/backend");
+  });
+});

--- a/terraform/d1/migrations/0032_session_repositories.sql
+++ b/terraform/d1/migrations/0032_session_repositories.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS session_repositories (
   repo_id     INTEGER,
   base_branch TEXT    NOT NULL,
   PRIMARY KEY (session_id, repo_owner, repo_name),
-  FOREIGN KEY (session_id) REFERENCES sessions(id)
+  FOREIGN KEY (session_id) REFERENCES sessions(id) ON DELETE CASCADE
 );
 
 -- Serves "sessions touching repo X" lookups across the member set.

--- a/terraform/d1/migrations/0032_session_repositories.sql
+++ b/terraform/d1/migrations/0032_session_repositories.sql
@@ -1,0 +1,25 @@
+-- Multi-repo sessions: normalized repository membership for the session index.
+--
+-- One row per member repository, in position order (position 0 = primary).
+-- The scalar sessions.repo_* columns stay authoritative for the primary
+-- (list-created sessions mirror their first entry into them), so existing
+-- filters and dashboards keep working unchanged; this table adds the full
+-- member set for list hydration and by-repo lookups.
+--
+-- No backfill: pre-feature sessions have no rows here and readers synthesize
+-- a one-entry list from the scalar columns.
+
+CREATE TABLE IF NOT EXISTS session_repositories (
+  session_id  TEXT    NOT NULL,
+  position    INTEGER NOT NULL,
+  repo_owner  TEXT    NOT NULL,
+  repo_name   TEXT    NOT NULL,
+  repo_id     INTEGER,
+  base_branch TEXT    NOT NULL,
+  PRIMARY KEY (session_id, repo_owner, repo_name),
+  FOREIGN KEY (session_id) REFERENCES sessions(id)
+);
+
+-- Serves "sessions touching repo X" lookups across the member set.
+CREATE INDEX IF NOT EXISTS idx_session_repositories_repo
+  ON session_repositories (repo_owner, repo_name, session_id);


### PR DESCRIPTION
## Summary

PR-4 of the multi-repo sessions plan: the control plane can now **create, store, and spawn** sessions that span N repositories in one sandbox. Builds on the merged runtime (#899), Modal ingest (#900), and shared contracts (#901).

### Create path
- `POST /sessions` accepts the `repositories` list from #901's `sessionRepositoriesInputSchema` (mutually exclusive with the scalar `repoOwner`/`repoName`/`branch` fields).
- New resolver `src/repos/resolve.ts` checks every member against the SCM provider **concurrently and all-or-nothing**: one sandbox boots the whole set, so a single unresolvable member fails the create with an error naming *every* failing repo (400 for clean no-access, 500 if a lookup threw).
- The primary entry (`repositories[0]`) is mirrored into the scalar `repo_owner`/`repo_name`/`repo_id`/`base_branch` columns, so filters, settings resolution, dashboards, and every pre-list consumer keep working unchanged. Bots and single-repo callers never migrate.

### Storage
- **D1 migration 0032**: `session_repositories` (session_id, position, owner, name, repo_id, base_branch), PK on (session_id, owner, name) + by-repo index. Written in the same `db.batch()` as the session insert; deleted together with the session.
- **DO SQLite migration 31**: per-session twin with per-repo git-state columns (`branch_name`/`base_sha`/`current_sha`) that PR-5's push handling will write.
- `initialize.ts` synthesizes a one-entry list from the scalars for legacy callers (child spawn, scheduler), so every new repo session has member rows — one source of truth for spawn/read paths. The DO init handler enforces the primary↔scalar mirror invariant (400 on mismatch).

### Reads
- `SessionState.repositories` is now populated (position order, primary overlaid with the session scalar git state until PR-5; synthesized for pre-feature sessions).
- `SessionIndexStore.list()` hydrates member lists via one `IN` query; pre-feature sessions keep the field absent so consumers fall back to scalars.
- MCP servers: scope matching is now **any-member** — a server scoped to any member repo is injected (repo-less sessions get unscoped servers only).

### Spawn
- New `SessionRepositoryInfo` on `CreateSandboxConfig`/`RestoreConfig`, threaded through the lifecycle manager to all providers.
- **Single-repo sessions keep the scalar wire form byte-for-byte** — `repositories` is only sent when the session has >1 member, matching the runtime's `len(repositories) > 1` gating. Zero behavior change until a multi-repo session exists.
- Working-branch names are **not** part of the spawn config: they stay lazily derived at PR-creation time by `pull-request-service` and will reach the sandbox via per-repo push specs (PR-5), avoiding a second source of truth baked in at spawn. The runtime's optional `working_branch_name` field remains as tolerance and is never populated.
- Modal create sends the flat snake_case `repositories` key that #900's field-name-driven `SessionConfig` construction picks up; restore carries it inside the nested `session_config` via `buildSessionConfig`. Direct-launch providers (Daytona/OpenComputer/Vercel) inherit the field structurally through `buildSessionConfig`.
- Repo-image lookup is skipped for multi-repo sessions (images bake a single checkout); they boot from the base image and clone every member.
- Child sessions stay single-repo, pinned to the parent's primary.

### Deploy order
Modal ingest (#900) must be deployed before this reaches production — pydantic drops unknown keys, so an old data plane would silently boot multi-repo sessions as single-repo. Both are already on main.

## Testing
- control-plane unit: 1544 passed (new coverage: repository rows, handler guards/synthesis, multi-repo spawn fields + repo-image gating + MCP union, wire-format assertions for Modal create/restore, session-index batch/hydration fakes)
- control-plane integration (workerd + real D1): 449 passed, incl. new `session-repositories.test.ts` (DO member rows, mirror-mismatch 400, D1 create/hydrate/delete, route-level list validation + aggregate resolution failure)
- shared: 331 passed; full-repo typecheck + lint clean

## Follow-ups (per plan)
- PR-5: per-repo push/PR handling (writes the per-repo git-state columns; per-repo `prUrl`)
- Unify Modal create to carry a nested `session_config` like restore (noted on #900)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ordered multi-repository session support, including persistence/restoration of per-member repositories in session state.
  * Session creation now accepts an ordered `repositories` list (primary at index 0) and includes it in the initialized session.
  * Sandbox create/restore can send multi-repo configuration to Modal (single-repo behavior unchanged).

* **Bug Fixes**
  * Improved repository list validation (including primary-entry matching) and clearer request failures.
  * MCP server configuration is now correctly scoped using repository-member lists.
  * Session cleanup now removes repository-member records to prevent orphaned data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
