### PR TITLE
feat(control-plane): per-repo push and PR flow for multi-repo sessions

### DIFF
--- a/packages/control-plane/src/routes/session-runtime-proxy.test.ts
+++ b/packages/control-plane/src/routes/session-runtime-proxy.test.ts
@@ -155,4 +155,62 @@ describe("session runtime proxy routes", () => {
     await expect(response.json()).resolves.toEqual({ error: "Invalid JSON body" });
     expect(fetch).not.toHaveBeenCalled();
   });
+
+  it("forwards the create-PR repo target to the runtime", async () => {
+    const requests: Request[] = [];
+    const fetch = vi.fn(async (request: Request) => {
+      requests.push(request);
+      return Response.json({ prNumber: 7 });
+    });
+    const { handler, match } = getHandler("POST", "/sessions/session-1/pr");
+
+    const response = await handler(
+      new Request("https://test.local/sessions/session-1/pr", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "PR",
+          body: "desc",
+          baseBranch: "main",
+          headBranch: "feature/x",
+          repoOwner: "acme",
+          repoName: "backend",
+        }),
+      }),
+      createEnv(fetch),
+      match,
+      createCtx()
+    );
+
+    expect(response.status).toBe(200);
+    expect(new URL(requests[0].url).pathname).toBe(SessionInternalPaths.createPr);
+    await expect(requests[0].json()).resolves.toEqual({
+      title: "PR",
+      body: "desc",
+      baseBranch: "main",
+      headBranch: "feature/x",
+      repoOwner: "acme",
+      repoName: "backend",
+    });
+  });
+
+  it("rejects a non-string create-PR repo target without forwarding", async () => {
+    const fetch = vi.fn(async () => Response.json({ status: "ok" }));
+    const { handler, match } = getHandler("POST", "/sessions/session-1/pr");
+
+    const response = await handler(
+      new Request("https://test.local/sessions/session-1/pr", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: "PR", body: "desc", repoOwner: 42, repoName: "backend" }),
+      }),
+      createEnv(fetch),
+      match,
+      createCtx()
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "repoOwner must be a string" });
+    expect(fetch).not.toHaveBeenCalled();
+  });
 });

--- a/packages/control-plane/src/routes/session-runtime-proxy.ts
+++ b/packages/control-plane/src/routes/session-runtime-proxy.ts
@@ -94,6 +94,14 @@ async function handleCreatePR(
     return error("headBranch must be a string");
   }
 
+  if (body.repoOwner != null && typeof body.repoOwner !== "string") {
+    return error("repoOwner must be a string");
+  }
+
+  if (body.repoName != null && typeof body.repoName !== "string") {
+    return error("repoName must be a string");
+  }
+
   return ctx.sessionRuntime.fetch(sessionId, SessionInternalPaths.createPr, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -102,6 +110,8 @@ async function handleCreatePR(
       body: body.body,
       baseBranch: body.baseBranch,
       headBranch: body.headBranch,
+      repoOwner: body.repoOwner,
+      repoName: body.repoName,
     }),
   });
 }

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -473,6 +473,7 @@ export class SessionDO extends DurableObject<Env> {
     if (!this._pullRequestHandler) {
       this._pullRequestHandler = createPullRequestHandler({
         getSession: () => this.getSession(),
+        getSessionRepositories: () => this.repository.getSessionRepositories(),
         getPromptingParticipantForPR: () => this.participantService.getPromptingParticipantForPR(),
         resolveAuthForPR: (participant) => this.participantService.resolveAuthForPR(participant),
         getSessionUrl: (session) => {
@@ -486,12 +487,13 @@ export class SessionDO extends DurableObject<Env> {
             sourceControlProvider: this.sourceControlProvider,
             log: this.log,
             generateId: () => generateId(),
-            pushBranchToRemote: (headBranch, pushSpec) =>
-              this.pushBranchToRemote(headBranch, pushSpec),
-            broadcastSessionBranch: (branchName) => {
+            pushBranchToRemote: (pushSpec) => this.pushBranchToRemote(pushSpec),
+            broadcastSessionBranch: (branchName, repo) => {
               this.broadcast({
                 type: "session_branch",
                 branchName,
+                repoOwner: repo.repoOwner,
+                repoName: repo.repoName,
               });
             },
             broadcastArtifactCreated: (artifact) => {
@@ -1386,10 +1388,9 @@ export class SessionDO extends DurableObject<Env> {
    * @returns Success result or error message
    */
   private async pushBranchToRemote(
-    branchName: string,
     pushSpec: GitPushSpec
   ): Promise<{ success: true } | { success: false; error: string }> {
-    return await this.sandboxEventProcessor.pushBranchToRemote(branchName, pushSpec);
+    return await this.sandboxEventProcessor.pushBranchToRemote(pushSpec);
   }
 
   /**
@@ -1704,12 +1705,12 @@ export class SessionDO extends DurableObject<Env> {
   /**
    * Member repositories for SessionState, in position order. Sessions that
    * predate the session_repositories table get a one-entry list synthesized
-   * from the scalar columns. Per-repo git state columns are written from
-   * PR-5 onward, so the primary entry is overlaid with the session scalars
-   * (which describe the primary until then); prUrl arrives with per-repo PR
-   * artifacts.
+   * from the scalar columns. Rows written before per-repo git state existed
+   * have null git columns while the scalars are set, so the primary entry is
+   * overlaid with the session scalars.
    */
   private getSessionRepositoryStates(session: SessionRow | null): SessionRepositoryState[] {
+    const prUrlForRepo = this.getPrUrlLookup();
     const rows = this.repository.getSessionRepositories();
     if (rows.length > 0) {
       return rows.map((row, index) => ({
@@ -1721,7 +1722,7 @@ export class SessionDO extends DurableObject<Env> {
         branchName: row.branch_name ?? (index === 0 ? (session?.branch_name ?? null) : null),
         baseSha: row.base_sha ?? (index === 0 ? (session?.base_sha ?? null) : null),
         currentSha: row.current_sha ?? (index === 0 ? (session?.current_sha ?? null) : null),
-        prUrl: null,
+        prUrl: prUrlForRepo(row.repo_owner, row.repo_name, index === 0),
       }));
     }
     if (session?.repo_owner && session.repo_name) {
@@ -1735,11 +1736,58 @@ export class SessionDO extends DurableObject<Env> {
           branchName: session.branch_name ?? null,
           baseSha: session.base_sha ?? null,
           currentSha: session.current_sha ?? null,
-          prUrl: null,
+          prUrl: prUrlForRepo(session.repo_owner, session.repo_name, true),
         },
       ];
     }
     return [];
+  }
+
+  /**
+   * Per-repo PR URL lookup over the session's PR artifacts. Artifact
+   * metadata without repo identity predates multi-repo sessions and belongs
+   * to the primary.
+   */
+  private getPrUrlLookup(): (
+    repoOwner: string,
+    repoName: string,
+    isPrimary: boolean
+  ) => string | null {
+    const prArtifacts = this.repository
+      .listArtifacts()
+      .filter((artifact) => artifact.type === "pr" && artifact.url);
+    if (prArtifacts.length === 0) {
+      return () => null;
+    }
+
+    const entries = prArtifacts.map((artifact) => {
+      let repo: { repoOwner: string; repoName: string } | null = null;
+      try {
+        const metadata: unknown = artifact.metadata ? JSON.parse(artifact.metadata) : null;
+        if (typeof metadata === "object" && metadata !== null) {
+          const { repoOwner, repoName } = metadata as { repoOwner?: unknown; repoName?: unknown };
+          if (typeof repoOwner === "string" && typeof repoName === "string") {
+            repo = { repoOwner, repoName };
+          }
+        }
+      } catch {
+        // Unparseable metadata — treat as identity-less (primary).
+      }
+      return { url: artifact.url, repo };
+    });
+
+    return (repoOwner, repoName, isPrimary) => {
+      for (const entry of entries) {
+        const matches = entry.repo
+          ? entry.repo.repoOwner.toLowerCase() === repoOwner.toLowerCase() &&
+            entry.repo.repoName.toLowerCase() === repoName.toLowerCase()
+          : isPrimary;
+        if (matches) {
+          return entry.url;
+        }
+      }
+      return null;
+    };
   }
 
   private getSandboxDashboardUrl(providerObjectId: string | null | undefined): string | null {

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -62,7 +62,8 @@ import type { SessionRow, ArtifactRow, SandboxRow } from "./types";
 import { SessionRepository } from "./repository";
 import { parseTunnelUrls } from "./tunnel-urls";
 import { SessionWebSocketManagerImpl, type SessionWebSocketManager } from "./websocket-manager";
-import { SessionPullRequestService } from "./pull-request-service";
+import { PullRequestCreationClaims, SessionPullRequestService } from "./pull-request-service";
+import { findPrArtifactForRepo } from "./pr-artifacts";
 import { RepoSecretsStore } from "../db/repo-secrets";
 import { GlobalSecretsStore } from "../db/global-secrets";
 import { mergeSecrets } from "../db/secrets-validation";
@@ -162,6 +163,7 @@ export class SessionDO extends DurableObject<Env> {
   private _sessionLifecycleHandler: SessionLifecycleHandler | null = null;
   // Pull request handler (lazily initialized)
   private _pullRequestHandler: PullRequestHandler | null = null;
+  private readonly prCreationClaims = new PullRequestCreationClaims();
   // Participants handler (lazily initialized)
   private _participantsHandler: ParticipantsHandler | null = null;
   // Alarm handler (lazily initialized)
@@ -484,6 +486,7 @@ export class SessionDO extends DurableObject<Env> {
         createPullRequest: async (input) => {
           const pullRequestService = new SessionPullRequestService({
             repository: this.repository,
+            claims: this.prCreationClaims,
             sourceControlProvider: this.sourceControlProvider,
             log: this.log,
             generateId: () => generateId(),
@@ -1743,51 +1746,15 @@ export class SessionDO extends DurableObject<Env> {
     return [];
   }
 
-  /**
-   * Per-repo PR URL lookup over the session's PR artifacts. Artifact
-   * metadata without repo identity predates multi-repo sessions and belongs
-   * to the primary.
-   */
+  /** Per-repo PR URL lookup over the session's PR artifacts. */
   private getPrUrlLookup(): (
     repoOwner: string,
     repoName: string,
     isPrimary: boolean
   ) => string | null {
-    const prArtifacts = this.repository
-      .listArtifacts()
-      .filter((artifact) => artifact.type === "pr" && artifact.url);
-    if (prArtifacts.length === 0) {
-      return () => null;
-    }
-
-    const entries = prArtifacts.map((artifact) => {
-      let repo: { repoOwner: string; repoName: string } | null = null;
-      try {
-        const metadata: unknown = artifact.metadata ? JSON.parse(artifact.metadata) : null;
-        if (typeof metadata === "object" && metadata !== null) {
-          const { repoOwner, repoName } = metadata as { repoOwner?: unknown; repoName?: unknown };
-          if (typeof repoOwner === "string" && typeof repoName === "string") {
-            repo = { repoOwner, repoName };
-          }
-        }
-      } catch {
-        // Unparseable metadata — treat as identity-less (primary).
-      }
-      return { url: artifact.url, repo };
-    });
-
-    return (repoOwner, repoName, isPrimary) => {
-      for (const entry of entries) {
-        const matches = entry.repo
-          ? entry.repo.repoOwner.toLowerCase() === repoOwner.toLowerCase() &&
-            entry.repo.repoName.toLowerCase() === repoName.toLowerCase()
-          : isPrimary;
-        if (matches) {
-          return entry.url;
-        }
-      }
-      return null;
-    };
+    const artifacts = this.repository.listArtifacts().filter((artifact) => artifact.url !== null);
+    return (repoOwner, repoName, isPrimary) =>
+      findPrArtifactForRepo(artifacts, { repoOwner, repoName }, isPrimary)?.url ?? null;
   }
 
   private getSandboxDashboardUrl(providerObjectId: string | null | undefined): string | null {

--- a/packages/control-plane/src/session/http/handlers/pull-request.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/pull-request.handler.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, it, vi } from "vitest";
+import type { SessionRepositoryRow } from "../../repository";
 import type { ParticipantRow, SessionRow } from "../../types";
 import { createPullRequestHandler } from "./pull-request.handler";
+
+function createRepositoryRow(
+  position: number,
+  repoOwner: string,
+  repoName: string
+): SessionRepositoryRow {
+  return {
+    position,
+    repo_owner: repoOwner,
+    repo_name: repoName,
+    repo_id: position + 1,
+    base_branch: "main",
+    branch_name: null,
+    base_sha: null,
+    current_sha: null,
+  };
+}
 
 function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
   return {
@@ -51,6 +69,7 @@ function createParticipant(overrides: Partial<ParticipantRow> = {}): Participant
 
 function createHandler() {
   const getSession = vi.fn<() => SessionRow | null>();
+  const getSessionRepositories = vi.fn<() => SessionRepositoryRow[]>(() => []);
   const getPromptingParticipantForPR = vi.fn();
   const resolveAuthForPR = vi.fn();
   const getSessionUrl = vi.fn();
@@ -58,6 +77,7 @@ function createHandler() {
 
   const handler = createPullRequestHandler({
     getSession,
+    getSessionRepositories,
     getPromptingParticipantForPR,
     resolveAuthForPR,
     getSessionUrl,
@@ -67,6 +87,7 @@ function createHandler() {
   return {
     handler,
     getSession,
+    getSessionRepositories,
     getPromptingParticipantForPR,
     resolveAuthForPR,
     getSessionUrl,
@@ -177,7 +198,7 @@ describe("createPullRequestHandler", () => {
     expect(await response.json()).toEqual({ error: "Token expired" });
   });
 
-  it("forwards service error and uses session base branch fallback", async () => {
+  it("forwards service error and passes the raw base branch through", async () => {
     const {
       handler,
       getSession,
@@ -208,11 +229,15 @@ describe("createPullRequestHandler", () => {
 
     expect(response.status).toBe(409);
     expect(await response.json()).toEqual({ error: "PR already exists" });
+    // Base-branch defaulting is the service's job (per target repo) — the
+    // handler forwards the request value untouched.
     expect(createPullRequest).toHaveBeenCalledWith({
       title: "PR",
       body: "desc",
       headBranch: "feature/pr",
-      baseBranch: "develop",
+      baseBranch: undefined,
+      repoOwner: "acme",
+      repoName: "repo",
       promptingUserId: "user-123",
       promptingAuth: { authType: "oauth", token: "token" },
       sessionUrl: "https://app.example.com/session/public-session-1",
@@ -253,6 +278,8 @@ describe("createPullRequestHandler", () => {
       title: "PR",
       body: "desc",
       baseBranch: undefined,
+      repoOwner: "acme",
+      repoName: "repo",
       promptingUserId: "user-123",
       promptingAuth: null,
       sessionUrl: "https://app.example.com/session/public-session-1",
@@ -305,9 +332,114 @@ describe("createPullRequestHandler", () => {
       body: "desc",
       baseBranch: "release",
       headBranch: "feature/pr",
+      repoOwner: "acme",
+      repoName: "repo",
       promptingUserId: "user-1",
       promptingAuth: null,
       sessionUrl: "https://app.example.com/session/public-session-1",
+    });
+  });
+
+  describe("repository targeting", () => {
+    function createMultiRepoHandler() {
+      const harness = createHandler();
+      harness.getSession.mockReturnValue(createSession());
+      harness.getSessionRepositories.mockReturnValue([
+        createRepositoryRow(0, "acme", "repo"),
+        createRepositoryRow(1, "acme", "backend"),
+      ]);
+      harness.getPromptingParticipantForPR.mockResolvedValue({
+        participant: createParticipant(),
+      });
+      harness.resolveAuthForPR.mockResolvedValue({ auth: null });
+      harness.getSessionUrl.mockReturnValue("https://app.example.com/session/public-session-1");
+      harness.createPullRequest.mockResolvedValue({
+        kind: "created",
+        prNumber: 7,
+        prUrl: "https://github.com/acme/backend/pull/7",
+        state: "open",
+      });
+      return harness;
+    }
+
+    function postPr(handler: ReturnType<typeof createHandler>["handler"], body: unknown) {
+      return handler.createPr(
+        new Request("http://internal/internal/create-pr", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        })
+      );
+    }
+
+    it("returns 400 listing member repos when a multi-repo session omits the target", async () => {
+      const { handler, createPullRequest } = createMultiRepoHandler();
+
+      const response = await postPr(handler, { title: "PR", body: "desc" });
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        error:
+          "This session spans multiple repositories — specify repoOwner and repoName (one of: acme/repo, acme/backend)",
+      });
+      expect(createPullRequest).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when only one of repoOwner/repoName is provided", async () => {
+      const { handler, createPullRequest } = createMultiRepoHandler();
+
+      const response = await postPr(handler, { title: "PR", body: "desc", repoOwner: "acme" });
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({
+        error: "repoOwner and repoName must be provided together",
+      });
+      expect(createPullRequest).not.toHaveBeenCalled();
+    });
+
+    it("returns 403 when the target repo is not a session member", async () => {
+      const { handler, createPullRequest } = createMultiRepoHandler();
+
+      const response = await postPr(handler, {
+        title: "PR",
+        body: "desc",
+        repoOwner: "evil",
+        repoName: "exfil",
+      });
+
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({
+        error: "Repository evil/exfil is not part of this session",
+      });
+      expect(createPullRequest).not.toHaveBeenCalled();
+    });
+
+    it("targets a secondary member with the list's canonical casing", async () => {
+      const { handler, createPullRequest } = createMultiRepoHandler();
+
+      const response = await postPr(handler, {
+        title: "PR",
+        body: "desc",
+        repoOwner: "Acme",
+        repoName: "Backend",
+      });
+
+      expect(response.status).toBe(200);
+      expect(createPullRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ repoOwner: "acme", repoName: "backend" })
+      );
+    });
+
+    it("defaults to the sole member when the target is omitted", async () => {
+      const harness = createMultiRepoHandler();
+      harness.getSessionRepositories.mockReturnValue([createRepositoryRow(0, "acme", "repo")]);
+
+      const response = await postPr(harness.handler, { title: "PR", body: "desc" });
+
+      expect(response.status).toBe(200);
+      expect(harness.createPullRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ repoOwner: "acme", repoName: "repo" })
+      );
     });
   });
 });

--- a/packages/control-plane/src/session/http/handlers/pull-request.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/pull-request.handler.ts
@@ -1,5 +1,6 @@
 import type { SourceControlAuthContext } from "../../../source-control";
 import type { CreatePullRequestInput, CreatePullRequestResult } from "../../pull-request-service";
+import type { SessionRepositoryRow } from "../../repository";
 import type { ParticipantRow, SessionRow } from "../../types";
 import { z } from "zod";
 
@@ -8,6 +9,8 @@ const createPrRequestSchema = z.object({
   body: z.string(),
   baseBranch: z.string().optional(),
   headBranch: z.string().optional(),
+  repoOwner: z.string().optional(),
+  repoName: z.string().optional(),
 });
 
 type CreatePrRequest = z.infer<typeof createPrRequestSchema>;
@@ -22,6 +25,7 @@ type ResolveAuthForPrResult =
 
 export interface PullRequestHandlerDeps {
   getSession: () => SessionRow | null;
+  getSessionRepositories: () => SessionRepositoryRow[];
   getPromptingParticipantForPR: () => Promise<PromptingParticipantResult>;
   resolveAuthForPR: (participant: ParticipantRow) => Promise<ResolveAuthForPrResult>;
   getSessionUrl: (session: SessionRow) => string;
@@ -30,6 +34,60 @@ export interface PullRequestHandlerDeps {
 
 export interface PullRequestHandler {
   createPr: (request: Request) => Promise<Response>;
+}
+
+/**
+ * Resolve and authorize the PR's target repository against the session's
+ * member list (sessions predating member rows fall back to the scalar
+ * mirror). Returns the member's canonical identity, or an error Response:
+ * 400 when the target is ambiguous or half-specified, 403 when it names a
+ * repo outside the session — creation is reachable with sandbox auth, so
+ * this is a security boundary, not just input validation.
+ */
+function resolveTargetRepository(
+  body: CreatePrRequest,
+  scalarRepo: { repoOwner: string; repoName: string },
+  memberRows: SessionRepositoryRow[]
+): { repoOwner: string; repoName: string } | Response {
+  const members =
+    memberRows.length > 0
+      ? memberRows.map((row) => ({ repoOwner: row.repo_owner, repoName: row.repo_name }))
+      : [scalarRepo];
+
+  if ((body.repoOwner == null) !== (body.repoName == null)) {
+    return Response.json(
+      { error: "repoOwner and repoName must be provided together" },
+      { status: 400 }
+    );
+  }
+
+  if (body.repoOwner == null || body.repoName == null) {
+    if (members.length > 1) {
+      const memberList = members.map((m) => `${m.repoOwner}/${m.repoName}`).join(", ");
+      return Response.json(
+        {
+          error: `This session spans multiple repositories — specify repoOwner and repoName (one of: ${memberList})`,
+        },
+        { status: 400 }
+      );
+    }
+    return members[0];
+  }
+
+  const requestedOwner = body.repoOwner.toLowerCase();
+  const requestedName = body.repoName.toLowerCase();
+  const match = members.find(
+    (member) =>
+      member.repoOwner.toLowerCase() === requestedOwner &&
+      member.repoName.toLowerCase() === requestedName
+  );
+  if (!match) {
+    return Response.json(
+      { error: `Repository ${body.repoOwner}/${body.repoName} is not part of this session` },
+      { status: 403 }
+    );
+  }
+  return match;
 }
 
 export function createPullRequestHandler(deps: PullRequestHandlerDeps): PullRequestHandler {
@@ -59,6 +117,15 @@ export function createPullRequestHandler(deps: PullRequestHandlerDeps): PullRequ
         );
       }
 
+      const target = resolveTargetRepository(
+        body,
+        { repoOwner: session.repo_owner, repoName: session.repo_name },
+        deps.getSessionRepositories()
+      );
+      if (target instanceof Response) {
+        return target;
+      }
+
       const promptingParticipantResult = await deps.getPromptingParticipantForPR();
       if (!promptingParticipantResult.participant) {
         return Response.json(
@@ -73,9 +140,16 @@ export function createPullRequestHandler(deps: PullRequestHandlerDeps): PullRequ
         return Response.json({ error: authResolution.error }, { status: authResolution.status });
       }
 
+      // Base-branch defaulting happens in the service (requested > target
+      // repo's base branch > repo default), so the raw request value passes
+      // through untouched.
       const result = await deps.createPullRequest({
-        ...body,
-        baseBranch: body.baseBranch || session.base_branch || undefined,
+        title: body.title,
+        body: body.body,
+        baseBranch: body.baseBranch,
+        headBranch: body.headBranch,
+        repoOwner: target.repoOwner,
+        repoName: target.repoName,
         promptingUserId: promptingParticipant.user_id,
         promptingAuth: authResolution.auth,
         sessionUrl: deps.getSessionUrl(session),

--- a/packages/control-plane/src/session/http/handlers/pull-request.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/pull-request.handler.ts
@@ -1,6 +1,7 @@
 import type { SourceControlAuthContext } from "../../../source-control";
 import type { CreatePullRequestInput, CreatePullRequestResult } from "../../pull-request-service";
 import type { SessionRepositoryRow } from "../../repository";
+import { resolveSessionRepositoryTarget } from "../../repository-target";
 import type { ParticipantRow, SessionRow } from "../../types";
 import { z } from "zod";
 
@@ -36,60 +37,6 @@ export interface PullRequestHandler {
   createPr: (request: Request) => Promise<Response>;
 }
 
-/**
- * Resolve and authorize the PR's target repository against the session's
- * member list (sessions predating member rows fall back to the scalar
- * mirror). Returns the member's canonical identity, or an error Response:
- * 400 when the target is ambiguous or half-specified, 403 when it names a
- * repo outside the session — creation is reachable with sandbox auth, so
- * this is a security boundary, not just input validation.
- */
-function resolveTargetRepository(
-  body: CreatePrRequest,
-  scalarRepo: { repoOwner: string; repoName: string },
-  memberRows: SessionRepositoryRow[]
-): { repoOwner: string; repoName: string } | Response {
-  const members =
-    memberRows.length > 0
-      ? memberRows.map((row) => ({ repoOwner: row.repo_owner, repoName: row.repo_name }))
-      : [scalarRepo];
-
-  if ((body.repoOwner == null) !== (body.repoName == null)) {
-    return Response.json(
-      { error: "repoOwner and repoName must be provided together" },
-      { status: 400 }
-    );
-  }
-
-  if (body.repoOwner == null || body.repoName == null) {
-    if (members.length > 1) {
-      const memberList = members.map((m) => `${m.repoOwner}/${m.repoName}`).join(", ");
-      return Response.json(
-        {
-          error: `This session spans multiple repositories — specify repoOwner and repoName (one of: ${memberList})`,
-        },
-        { status: 400 }
-      );
-    }
-    return members[0];
-  }
-
-  const requestedOwner = body.repoOwner.toLowerCase();
-  const requestedName = body.repoName.toLowerCase();
-  const match = members.find(
-    (member) =>
-      member.repoOwner.toLowerCase() === requestedOwner &&
-      member.repoName.toLowerCase() === requestedName
-  );
-  if (!match) {
-    return Response.json(
-      { error: `Repository ${body.repoOwner}/${body.repoName} is not part of this session` },
-      { status: 403 }
-    );
-  }
-  return match;
-}
-
 export function createPullRequestHandler(deps: PullRequestHandlerDeps): PullRequestHandler {
   return {
     async createPr(request: Request): Promise<Response> {
@@ -117,13 +64,19 @@ export function createPullRequestHandler(deps: PullRequestHandlerDeps): PullRequ
         );
       }
 
-      const target = resolveTargetRepository(
-        body,
-        { repoOwner: session.repo_owner, repoName: session.repo_name },
-        deps.getSessionRepositories()
-      );
-      if (target instanceof Response) {
-        return target;
+      // Membership is a security boundary (this route is reachable with
+      // sandbox auth): naming a repo outside the session is 403, an
+      // ambiguous or half-specified target is 400.
+      const target = resolveSessionRepositoryTarget({
+        requested: { repoOwner: body.repoOwner, repoName: body.repoName },
+        scalarRepo: { repoOwner: session.repo_owner, repoName: session.repo_name },
+        memberRows: deps.getSessionRepositories(),
+      });
+      if (!target.ok) {
+        return Response.json(
+          { error: target.error },
+          { status: target.reason === "not_member" ? 403 : 400 }
+        );
       }
 
       const promptingParticipantResult = await deps.getPromptingParticipantForPR();

--- a/packages/control-plane/src/session/pr-artifacts.ts
+++ b/packages/control-plane/src/session/pr-artifacts.ts
@@ -1,0 +1,39 @@
+import { repoIdentityEquals, type RepoIdentity } from "./repository-target";
+import type { ArtifactRow } from "./types";
+
+/**
+ * Repo identity from a PR artifact's metadata. Null when the metadata carries
+ * no identity — artifacts written before multi-repo support, which by
+ * construction belong to the session's primary repository. The canonical
+ * home of that convention: both the duplicate-PR guard and the per-repo
+ * prUrl projection go through here.
+ */
+export function parsePrArtifactRepo(metadata: string | null): RepoIdentity | null {
+  if (!metadata) return null;
+  try {
+    const parsed: unknown = JSON.parse(metadata);
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const { repoOwner, repoName } = parsed as { repoOwner?: unknown; repoName?: unknown };
+    if (typeof repoOwner !== "string" || typeof repoName !== "string") return null;
+    return { repoOwner, repoName };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find a PR artifact belonging to the target repo. Identity-less metadata
+ * matches only when the target is the primary.
+ */
+export function findPrArtifactForRepo(
+  artifacts: ArtifactRow[],
+  targetRepo: RepoIdentity,
+  isPrimary: boolean
+): ArtifactRow | undefined {
+  return artifacts.find((artifact) => {
+    if (artifact.type !== "pr") return false;
+    const artifactRepo = parsePrArtifactRepo(artifact.metadata);
+    if (!artifactRepo) return isPrimary;
+    return repoIdentityEquals(artifactRepo, targetRepo);
+  });
+}

--- a/packages/control-plane/src/session/pull-request-service.test.ts
+++ b/packages/control-plane/src/session/pull-request-service.test.ts
@@ -5,10 +5,12 @@ import * as branchResolution from "../source-control/branch-resolution";
 import type { SessionRepositoryRow } from "./repository";
 import type { ArtifactRow, SessionRow } from "./types";
 import {
+  PullRequestCreationClaims,
   SessionPullRequestService,
   type CreatePullRequestInput,
   type PullRequestRepository,
   type PullRequestServiceDeps,
+  type PushBranchResult,
 } from "./pull-request-service";
 
 function createMockLogger(): Logger {
@@ -151,6 +153,7 @@ function createTestHarness() {
   let idCounter = 0;
   const deps: PullRequestServiceDeps = {
     repository,
+    claims: new PullRequestCreationClaims(),
     sourceControlProvider: provider,
     log,
     generateId: () => `id-${++idCounter}`,
@@ -578,6 +581,81 @@ describe("SessionPullRequestService", () => {
         error: "Repository evil/exfil is not part of this session",
       });
       expect(harness.provider.generatePushAuth).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("in-flight creation claims", () => {
+    it("rejects a concurrent request for the same repo with 409", async () => {
+      let releasePush: (() => void) | undefined;
+      harness.deps.pushBranchToRemote = vi.fn(
+        () =>
+          new Promise<PushBranchResult>((resolve) => {
+            releasePush = () => resolve({ success: true });
+          })
+      );
+      harness.service = new SessionPullRequestService(harness.deps);
+
+      const first = harness.service.createPullRequest(createInput());
+      await vi.waitFor(() => expect(releasePush).toBeDefined());
+
+      const second = await harness.service.createPullRequest(createInput());
+      expect(second).toEqual({
+        kind: "error",
+        status: 409,
+        error: "A pull request is already being created for acme/web in this session.",
+      });
+
+      releasePush!();
+      expect((await first).kind).toBe("created");
+    });
+
+    it("releases the claim when creation fails, allowing a retry", async () => {
+      harness.deps.pushBranchToRemote = vi
+        .fn<(pushSpec: unknown) => Promise<PushBranchResult>>()
+        .mockResolvedValueOnce({ success: false, error: "Failed to push branch: boom" })
+        .mockResolvedValue({ success: true });
+      harness.service = new SessionPullRequestService(harness.deps);
+
+      const failed = await harness.service.createPullRequest(createInput());
+      expect(failed).toEqual({
+        kind: "error",
+        status: 500,
+        error: "Failed to push branch: boom",
+      });
+
+      const retried = await harness.service.createPullRequest(createInput());
+      expect(retried.kind).toBe("created");
+    });
+
+    it("allows concurrent creation for different repos", async () => {
+      harness.setRepositories([
+        createRepositoryRow({ position: 0 }),
+        createRepositoryRow({
+          position: 1,
+          repo_owner: "acme",
+          repo_name: "backend",
+          repo_id: 456,
+          base_branch: "develop",
+        }),
+      ]);
+      const resolvers: Array<() => void> = [];
+      harness.deps.pushBranchToRemote = vi.fn(
+        () =>
+          new Promise<PushBranchResult>((resolve) => {
+            resolvers.push(() => resolve({ success: true }));
+          })
+      );
+      harness.service = new SessionPullRequestService(harness.deps);
+
+      const first = harness.service.createPullRequest(createInput());
+      const second = harness.service.createPullRequest(
+        createInput({ repoOwner: "acme", repoName: "backend" })
+      );
+      await vi.waitFor(() => expect(resolvers).toHaveLength(2));
+      resolvers.forEach((resolve) => resolve());
+
+      expect((await first).kind).toBe("created");
+      expect((await second).kind).toBe("created");
     });
   });
 

--- a/packages/control-plane/src/session/pull-request-service.test.ts
+++ b/packages/control-plane/src/session/pull-request-service.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Logger } from "../logger";
 import type { SourceControlProvider } from "../source-control";
 import * as branchResolution from "../source-control/branch-resolution";
+import type { SessionRepositoryRow } from "./repository";
 import type { ArtifactRow, SessionRow } from "./types";
 import {
   SessionPullRequestService,
@@ -88,9 +89,25 @@ function createInput(overrides: Partial<CreatePullRequestInput> = {}): CreatePul
   return {
     title: "Test PR",
     body: "Body text",
+    repoOwner: "acme",
+    repoName: "web",
     promptingUserId: "user-1",
     promptingAuth: null,
     sessionUrl: "https://app.example.com/session/session-name-1",
+    ...overrides,
+  };
+}
+
+function createRepositoryRow(overrides: Partial<SessionRepositoryRow> = {}): SessionRepositoryRow {
+  return {
+    position: 0,
+    repo_owner: "acme",
+    repo_name: "web",
+    repo_id: 123,
+    base_branch: "main",
+    branch_name: null,
+    base_sha: null,
+    current_sha: null,
     ...overrides,
   };
 }
@@ -100,14 +117,25 @@ function createTestHarness() {
   const provider = createMockProvider();
   const artifacts: ArtifactRow[] = [];
   let session: SessionRow | null = createSession();
+  let repositoryRows: SessionRepositoryRow[] = [];
 
   const repository: PullRequestRepository = {
     getSession: () => session,
+    getSessionRepositories: () => [...repositoryRows],
     updateSessionBranch: vi.fn((sessionId: string, branchName: string) => {
       if (session && session.id === sessionId) {
         session = { ...session, branch_name: branchName };
       }
     }),
+    updateSessionRepositoryBranch: vi.fn(
+      (repoOwner: string, repoName: string, branchName: string) => {
+        repositoryRows = repositoryRows.map((row) =>
+          row.repo_owner === repoOwner && row.repo_name === repoName
+            ? { ...row, branch_name: branchName }
+            : row
+        );
+      }
+    ),
     listArtifacts: () => [...artifacts],
     createArtifact: (data) => {
       artifacts.unshift({
@@ -141,6 +169,9 @@ function createTestHarness() {
     artifacts,
     setSession: (next: SessionRow | null) => {
       session = next;
+    },
+    setRepositories: (rows: SessionRepositoryRow[]) => {
+      repositoryRows = rows;
     },
   };
 }
@@ -178,7 +209,7 @@ describe("SessionPullRequestService", () => {
     expect(result).toEqual({
       kind: "error",
       status: 409,
-      error: "A pull request has already been created for this session.",
+      error: "A pull request has already been created for acme/web in this session.",
     });
     expect(harness.provider.generatePushAuth).not.toHaveBeenCalled();
   });
@@ -219,7 +250,10 @@ describe("SessionPullRequestService", () => {
       "session-1",
       "open-inspect/session-name-1"
     );
-    expect(harness.deps.broadcastSessionBranch).toHaveBeenCalledWith("open-inspect/session-name-1");
+    expect(harness.deps.broadcastSessionBranch).toHaveBeenCalledWith(
+      "open-inspect/session-name-1",
+      { repoOwner: "acme", repoName: "web" }
+    );
   });
 
   it("uses the sanitized branch for push, PR creation, and branch sync", async () => {
@@ -239,7 +273,6 @@ describe("SessionPullRequestService", () => {
       })
     );
     expect(harness.deps.pushBranchToRemote).toHaveBeenCalledWith(
-      "feature/test",
       expect.objectContaining({
         targetBranch: "feature/test",
         refspec: "HEAD:refs/heads/feature/test",
@@ -255,7 +288,10 @@ describe("SessionPullRequestService", () => {
       "session-1",
       "feature/test"
     );
-    expect(harness.deps.broadcastSessionBranch).toHaveBeenCalledWith("feature/test");
+    expect(harness.deps.broadcastSessionBranch).toHaveBeenCalledWith("feature/test", {
+      repoOwner: "acme",
+      repoName: "web",
+    });
   });
 
   it("creates PR with OAuth token and stores PR artifact", async () => {
@@ -285,6 +321,8 @@ describe("SessionPullRequestService", () => {
         state: "open",
         head: "open-inspect/session-name-1",
         base: "main",
+        repoOwner: "acme",
+        repoName: "web",
       },
       createdAt: expect.any(Number),
     });
@@ -359,13 +397,188 @@ describe("SessionPullRequestService", () => {
       })
     );
     expect(harness.deps.pushBranchToRemote).toHaveBeenCalledWith(
-      "feature/test",
       expect.objectContaining({
         targetBranch: "feature/test",
         refspec: "HEAD:refs/heads/feature/test",
       })
     );
-    expect(harness.deps.broadcastSessionBranch).toHaveBeenCalledWith("feature/test");
+    expect(harness.deps.broadcastSessionBranch).toHaveBeenCalledWith("feature/test", {
+      repoOwner: "acme",
+      repoName: "web",
+    });
+  });
+
+  describe("multi-repo sessions", () => {
+    beforeEach(() => {
+      harness.setRepositories([
+        createRepositoryRow({ position: 0, repo_owner: "acme", repo_name: "web" }),
+        createRepositoryRow({
+          position: 1,
+          repo_owner: "acme",
+          repo_name: "backend",
+          repo_id: 456,
+          base_branch: "develop",
+        }),
+      ]);
+    });
+
+    it("creates a PR for a secondary member when the primary already has one", async () => {
+      harness.artifacts.push({
+        id: "artifact-pr-web",
+        type: "pr",
+        url: "https://github.com/acme/web/pull/1",
+        metadata: JSON.stringify({ number: 1, repoOwner: "acme", repoName: "web" }),
+        created_at: Date.now(),
+      });
+
+      const result = await harness.service.createPullRequest(
+        createInput({ repoOwner: "acme", repoName: "backend" })
+      );
+
+      expect(result.kind).toBe("created");
+      expect(harness.provider.getRepository).toHaveBeenCalledWith(expect.anything(), {
+        owner: "acme",
+        name: "backend",
+      });
+      expect(harness.provider.buildGitPushSpec).toHaveBeenCalledWith(
+        expect.objectContaining({ owner: "acme", name: "backend" })
+      );
+    });
+
+    it("returns 409 for a repo that already has a PR, naming the repo", async () => {
+      harness.artifacts.push({
+        id: "artifact-pr-backend",
+        type: "pr",
+        url: "https://github.com/acme/backend/pull/9",
+        metadata: JSON.stringify({ number: 9, repoOwner: "acme", repoName: "backend" }),
+        created_at: Date.now(),
+      });
+
+      const result = await harness.service.createPullRequest(
+        createInput({ repoOwner: "acme", repoName: "backend" })
+      );
+
+      expect(result).toEqual({
+        kind: "error",
+        status: 409,
+        error: "A pull request has already been created for acme/backend in this session.",
+      });
+      expect(harness.provider.generatePushAuth).not.toHaveBeenCalled();
+    });
+
+    it("treats a PR artifact without repo metadata as the primary's", async () => {
+      harness.artifacts.push({
+        id: "artifact-pr-legacy",
+        type: "pr",
+        url: "https://github.com/acme/web/pull/1",
+        metadata: JSON.stringify({ number: 1 }),
+        created_at: Date.now(),
+      });
+
+      const primaryResult = await harness.service.createPullRequest(createInput());
+      expect(primaryResult).toEqual({
+        kind: "error",
+        status: 409,
+        error: "A pull request has already been created for acme/web in this session.",
+      });
+
+      const secondaryResult = await harness.service.createPullRequest(
+        createInput({ repoOwner: "acme", repoName: "backend" })
+      );
+      expect(secondaryResult.kind).toBe("created");
+    });
+
+    it("defaults the base branch to the target member's base branch", async () => {
+      await harness.service.createPullRequest(
+        createInput({ repoOwner: "acme", repoName: "backend" })
+      );
+
+      expect(harness.provider.createPullRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ targetBranch: "develop" })
+      );
+    });
+
+    it("resolves the head branch from the target member's stored branch", async () => {
+      harness.setRepositories([
+        createRepositoryRow({ position: 0 }),
+        createRepositoryRow({
+          position: 1,
+          repo_owner: "acme",
+          repo_name: "backend",
+          base_branch: "develop",
+          branch_name: "feat/backend-work",
+        }),
+      ]);
+
+      await harness.service.createPullRequest(
+        createInput({ repoOwner: "acme", repoName: "backend" })
+      );
+
+      expect(harness.deps.pushBranchToRemote).toHaveBeenCalledWith(
+        expect.objectContaining({ targetBranch: "feat/backend-work" })
+      );
+    });
+
+    it("writes the member row without touching the scalar mirror for a secondary", async () => {
+      const result = await harness.service.createPullRequest(
+        createInput({ repoOwner: "acme", repoName: "backend" })
+      );
+
+      expect(result.kind).toBe("created");
+      expect(harness.deps.repository.updateSessionRepositoryBranch).toHaveBeenCalledWith(
+        "acme",
+        "backend",
+        "open-inspect/session-name-1"
+      );
+      expect(harness.deps.repository.updateSessionBranch).not.toHaveBeenCalled();
+      expect(harness.deps.broadcastSessionBranch).toHaveBeenCalledWith(
+        "open-inspect/session-name-1",
+        { repoOwner: "acme", repoName: "backend" }
+      );
+    });
+
+    it("writes both the member row and the scalar mirror for the primary", async () => {
+      const result = await harness.service.createPullRequest(createInput());
+
+      expect(result.kind).toBe("created");
+      expect(harness.deps.repository.updateSessionRepositoryBranch).toHaveBeenCalledWith(
+        "acme",
+        "web",
+        "open-inspect/session-name-1"
+      );
+      expect(harness.deps.repository.updateSessionBranch).toHaveBeenCalledWith(
+        "session-1",
+        "open-inspect/session-name-1"
+      );
+    });
+
+    it("stamps the target repo into the PR artifact metadata", async () => {
+      await harness.service.createPullRequest(
+        createInput({ repoOwner: "acme", repoName: "backend" })
+      );
+
+      expect(harness.deps.broadcastArtifactCreated).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ repoOwner: "acme", repoName: "backend" }),
+        })
+      );
+    });
+
+    it("returns 403 when the target is neither a member nor the scalar repo", async () => {
+      harness.setRepositories([]);
+
+      const result = await harness.service.createPullRequest(
+        createInput({ repoOwner: "evil", repoName: "exfil" })
+      );
+
+      expect(result).toEqual({
+        kind: "error",
+        status: 403,
+        error: "Repository evil/exfil is not part of this session",
+      });
+      expect(harness.provider.generatePushAuth).not.toHaveBeenCalled();
+    });
   });
 
   it("ignores prior manual branch artifact and creates PR", async () => {

--- a/packages/control-plane/src/session/pull-request-service.ts
+++ b/packages/control-plane/src/session/pull-request-service.ts
@@ -8,6 +8,7 @@ import {
   type GitPushAuthContext,
   type GitPushSpec,
 } from "../source-control";
+import type { SessionRepositoryRow } from "./repository";
 import type { ArtifactRow, SessionRow } from "./types";
 
 /**
@@ -18,6 +19,12 @@ export interface CreatePullRequestInput {
   body: string;
   baseBranch?: string;
   headBranch?: string;
+  /**
+   * Target member repository, already validated against the session's
+   * repository list by the HTTP handler (canonical casing).
+   */
+  repoOwner: string;
+  repoName: string;
   promptingUserId: string;
   promptingAuth: SourceControlAuthContext | null;
   sessionUrl: string;
@@ -34,12 +41,44 @@ export type CreatePullRequestResult =
 
 export type PushBranchResult = { success: true } | { success: false; error: string };
 
+function repoIdentityEquals(
+  a: { repoOwner: string; repoName: string },
+  b: { repoOwner: string; repoName: string }
+): boolean {
+  return (
+    a.repoOwner.toLowerCase() === b.repoOwner.toLowerCase() &&
+    a.repoName.toLowerCase() === b.repoName.toLowerCase()
+  );
+}
+
+/**
+ * Repo identity from a PR artifact's metadata. Null when the metadata carries
+ * no identity — artifacts written before multi-repo support, which by
+ * construction belong to the session's primary repository.
+ */
+function parseArtifactRepo(
+  metadata: string | null
+): { repoOwner: string; repoName: string } | null {
+  if (!metadata) return null;
+  try {
+    const parsed: unknown = JSON.parse(metadata);
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const { repoOwner, repoName } = parsed as { repoOwner?: unknown; repoName?: unknown };
+    if (typeof repoOwner !== "string" || typeof repoName !== "string") return null;
+    return { repoOwner, repoName };
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Session persistence operations required by pull request orchestration.
  */
 export interface PullRequestRepository {
   getSession(): SessionRow | null;
+  getSessionRepositories(): SessionRepositoryRow[];
   updateSessionBranch(sessionId: string, branchName: string): void;
+  updateSessionRepositoryBranch(repoOwner: string, repoName: string, branchName: string): void;
   listArtifacts(): ArtifactRow[];
   createArtifact(data: {
     id: string;
@@ -58,8 +97,11 @@ export interface PullRequestServiceDeps {
   sourceControlProvider: SourceControlProvider;
   log: Logger;
   generateId: () => string;
-  pushBranchToRemote: (headBranch: string, pushSpec: GitPushSpec) => Promise<PushBranchResult>;
-  broadcastSessionBranch: (branchName: string) => void;
+  pushBranchToRemote: (pushSpec: GitPushSpec) => Promise<PushBranchResult>;
+  broadcastSessionBranch: (
+    branchName: string,
+    repo: { repoOwner: string; repoName: string }
+  ) => void;
   broadcastArtifactCreated: (artifact: SessionArtifact) => void;
   /** Display name used in the PR body footer (e.g. "Created with [name](url)"). */
   appName: string;
@@ -85,20 +127,44 @@ export class SessionPullRequestService {
       return { kind: "error", status: 400, error: "Pull requests require a repository context" };
     }
 
-    this.deps.log.info("Creating PR", { user_id: input.promptingUserId });
+    const memberRow =
+      this.deps.repository
+        .getSessionRepositories()
+        .find((row) =>
+          repoIdentityEquals({ repoOwner: row.repo_owner, repoName: row.repo_name }, input)
+        ) ?? null;
+    const isPrimary = repoIdentityEquals(
+      { repoOwner: session.repo_owner, repoName: session.repo_name },
+      input
+    );
+    // Sessions predating the member table have no rows; the target must then
+    // be the scalar repository. Re-checked here (the handler already 403s)
+    // because this is a sandbox-auth security boundary.
+    if (!memberRow && !isPrimary) {
+      return {
+        kind: "error",
+        status: 403,
+        error: `Repository ${input.repoOwner}/${input.repoName} is not part of this session`,
+      };
+    }
+    const targetRepo = {
+      repoOwner: memberRow?.repo_owner ?? session.repo_owner,
+      repoName: memberRow?.repo_name ?? session.repo_name,
+    };
+
+    this.deps.log.info("Creating PR", {
+      user_id: input.promptingUserId,
+      repo_owner: targetRepo.repoOwner,
+      repo_name: targetRepo.repoName,
+    });
 
     try {
       const sessionId = session.session_name || session.id;
       const generatedHeadBranch = generateBranchName(sessionId);
 
       const initialArtifacts = this.deps.repository.listArtifacts();
-      const existingPrArtifact = initialArtifacts.find((artifact) => artifact.type === "pr");
-      if (existingPrArtifact) {
-        return {
-          kind: "error",
-          status: 409,
-          error: "A pull request has already been created for this session.",
-        };
+      if (this.findPrArtifactForRepo(initialArtifacts, targetRepo, isPrimary)) {
+        return this.duplicatePrError(targetRepo);
       }
 
       let pushAuth: GitPushAuthContext;
@@ -125,20 +191,28 @@ export class SessionPullRequestService {
       };
 
       const repoInfo = await this.deps.sourceControlProvider.getRepository(appAuth, {
-        owner: session.repo_owner,
-        name: session.repo_name,
+        owner: targetRepo.repoOwner,
+        name: targetRepo.repoName,
       });
-      const baseBranch = input.baseBranch || repoInfo.defaultBranch;
+      // Base: requested > target repo's base branch (scalar mirror for
+      // sessions without member rows) > repo default. Behavioral parity with
+      // the session-base injection the HTTP handler used to do.
+      const baseBranch =
+        input.baseBranch || memberRow?.base_branch || session.base_branch || repoInfo.defaultBranch;
+      // The target repo's working branch; member rows written before PR flow
+      // existed have a null branch_name while the scalar mirror is set, so
+      // the primary falls back to the scalar.
+      const targetBranchName = memberRow?.branch_name ?? (isPrimary ? session.branch_name : null);
       const branchResolution = resolveHeadBranchForPr({
         requestedHeadBranch: input.headBranch,
-        sessionBranchName: session.branch_name,
+        sessionBranchName: targetBranchName,
         generatedBranchName: generatedHeadBranch,
         baseBranch,
       });
       const headBranch = branchResolution.headBranch;
       this.deps.log.info("Resolved PR head branch", {
         requested_head_branch: input.headBranch ?? null,
-        session_branch_name: session.branch_name,
+        session_branch_name: targetBranchName,
         generated_head_branch: generatedHeadBranch,
         resolved_head_branch: headBranch,
         resolution_source: branchResolution.source,
@@ -154,34 +228,36 @@ export class SessionPullRequestService {
       }
 
       const pushSpec = this.deps.sourceControlProvider.buildGitPushSpec({
-        owner: session.repo_owner,
-        name: session.repo_name,
+        owner: targetRepo.repoOwner,
+        name: targetRepo.repoName,
         sourceRef: "HEAD",
         targetBranch: sanitizedHeadBranch,
         auth: pushAuth,
         force: true,
       });
 
-      const pushResult = await this.deps.pushBranchToRemote(sanitizedHeadBranch, pushSpec);
+      const pushResult = await this.deps.pushBranchToRemote(pushSpec);
       if (!pushResult.success) {
         return { kind: "error", status: 500, error: pushResult.error };
       }
 
-      if (session.branch_name !== sanitizedHeadBranch) {
+      if (memberRow && memberRow.branch_name !== sanitizedHeadBranch) {
+        this.deps.repository.updateSessionRepositoryBranch(
+          memberRow.repo_owner,
+          memberRow.repo_name,
+          sanitizedHeadBranch
+        );
+      }
+      if (isPrimary && session.branch_name !== sanitizedHeadBranch) {
         this.deps.repository.updateSessionBranch(session.id, sanitizedHeadBranch);
       }
       // Broadcast even when the stored branch is already current so connected clients converge
       // after missed or out-of-order updates.
-      this.deps.broadcastSessionBranch(sanitizedHeadBranch);
+      this.deps.broadcastSessionBranch(sanitizedHeadBranch, targetRepo);
 
       const latestArtifacts = this.deps.repository.listArtifacts();
-      const latestPrArtifact = latestArtifacts.find((artifact) => artifact.type === "pr");
-      if (latestPrArtifact) {
-        return {
-          kind: "error",
-          status: 409,
-          error: "A pull request has already been created for this session.",
-        };
+      if (this.findPrArtifactForRepo(latestArtifacts, targetRepo, isPrimary)) {
+        return this.duplicatePrError(targetRepo);
       }
 
       // Use user OAuth if available, otherwise fall back to GitHub App token
@@ -206,6 +282,8 @@ export class SessionPullRequestService {
         state: prResult.state,
         head: sanitizedHeadBranch,
         base: baseBranch,
+        repoOwner: targetRepo.repoOwner,
+        repoName: targetRepo.repoName,
       };
       this.deps.repository.createArtifact({
         id: artifactId,
@@ -248,5 +326,34 @@ export class SessionPullRequestService {
         error: error instanceof Error ? error.message : "Failed to create PR",
       };
     }
+  }
+
+  /**
+   * One PR per repo per session: find an existing PR artifact for the target
+   * repo. Artifact metadata without repo identity predates multi-repo
+   * sessions and belongs to the primary.
+   */
+  private findPrArtifactForRepo(
+    artifacts: ArtifactRow[],
+    targetRepo: { repoOwner: string; repoName: string },
+    isPrimary: boolean
+  ): ArtifactRow | undefined {
+    return artifacts.find((artifact) => {
+      if (artifact.type !== "pr") return false;
+      const artifactRepo = parseArtifactRepo(artifact.metadata);
+      if (!artifactRepo) return isPrimary;
+      return repoIdentityEquals(artifactRepo, targetRepo);
+    });
+  }
+
+  private duplicatePrError(targetRepo: {
+    repoOwner: string;
+    repoName: string;
+  }): CreatePullRequestResult {
+    return {
+      kind: "error",
+      status: 409,
+      error: `A pull request has already been created for ${targetRepo.repoOwner}/${targetRepo.repoName} in this session.`,
+    };
   }
 }

--- a/packages/control-plane/src/session/pull-request-service.ts
+++ b/packages/control-plane/src/session/pull-request-service.ts
@@ -8,7 +8,9 @@ import {
   type GitPushAuthContext,
   type GitPushSpec,
 } from "../source-control";
+import { findPrArtifactForRepo } from "./pr-artifacts";
 import type { SessionRepositoryRow } from "./repository";
+import { resolveSessionRepositoryTarget, type RepoIdentity } from "./repository-target";
 import type { ArtifactRow, SessionRow } from "./types";
 
 /**
@@ -41,33 +43,31 @@ export type CreatePullRequestResult =
 
 export type PushBranchResult = { success: true } | { success: false; error: string };
 
-function repoIdentityEquals(
-  a: { repoOwner: string; repoName: string },
-  b: { repoOwner: string; repoName: string }
-): boolean {
-  return (
-    a.repoOwner.toLowerCase() === b.repoOwner.toLowerCase() &&
-    a.repoName.toLowerCase() === b.repoName.toLowerCase()
-  );
+function claimKey(repo: RepoIdentity): string {
+  return `${repo.repoOwner.toLowerCase()}/${repo.repoName.toLowerCase()}`;
 }
 
 /**
- * Repo identity from a PR artifact's metadata. Null when the metadata carries
- * no identity — artifacts written before multi-repo support, which by
- * construction belong to the session's primary repository.
+ * In-flight PR creation claims, one per target repository. PR creation spans
+ * several awaits (push, provider calls) during which the DO serves other
+ * requests, so the persisted-artifact scan alone cannot enforce one PR per
+ * repo — two concurrent requests could both pass it. Claims are in-memory on
+ * the DO instance: a claim's lifetime is its request's, and both die with
+ * the instance.
  */
-function parseArtifactRepo(
-  metadata: string | null
-): { repoOwner: string; repoName: string } | null {
-  if (!metadata) return null;
-  try {
-    const parsed: unknown = JSON.parse(metadata);
-    if (typeof parsed !== "object" || parsed === null) return null;
-    const { repoOwner, repoName } = parsed as { repoOwner?: unknown; repoName?: unknown };
-    if (typeof repoOwner !== "string" || typeof repoName !== "string") return null;
-    return { repoOwner, repoName };
-  } catch {
-    return null;
+export class PullRequestCreationClaims {
+  private readonly inFlight = new Set<string>();
+
+  /** True when the claim was acquired; false when creation is already in flight. */
+  claim(repo: RepoIdentity): boolean {
+    const key = claimKey(repo);
+    if (this.inFlight.has(key)) return false;
+    this.inFlight.add(key);
+    return true;
+  }
+
+  release(repo: RepoIdentity): void {
+    this.inFlight.delete(claimKey(repo));
   }
 }
 
@@ -94,6 +94,8 @@ export interface PullRequestRepository {
  */
 export interface PullRequestServiceDeps {
   repository: PullRequestRepository;
+  /** DO-instance-scoped in-flight claims — must outlive individual requests. */
+  claims: PullRequestCreationClaims;
   sourceControlProvider: SourceControlProvider;
   log: Logger;
   generateId: () => string;
@@ -127,30 +129,23 @@ export class SessionPullRequestService {
       return { kind: "error", status: 400, error: "Pull requests require a repository context" };
     }
 
-    const memberRow =
-      this.deps.repository
-        .getSessionRepositories()
-        .find((row) =>
-          repoIdentityEquals({ repoOwner: row.repo_owner, repoName: row.repo_name }, input)
-        ) ?? null;
-    const isPrimary = repoIdentityEquals(
-      { repoOwner: session.repo_owner, repoName: session.repo_name },
-      input
-    );
-    // Sessions predating the member table have no rows; the target must then
-    // be the scalar repository. Re-checked here (the handler already 403s)
-    // because this is a sandbox-auth security boundary.
-    if (!memberRow && !isPrimary) {
+    // Re-resolved here even though the handler already validated the target:
+    // this is a sandbox-auth security boundary, so the service must not
+    // trust its caller (defense in depth).
+    const resolution = resolveSessionRepositoryTarget({
+      requested: input,
+      scalarRepo: { repoOwner: session.repo_owner, repoName: session.repo_name },
+      memberRows: this.deps.repository.getSessionRepositories(),
+    });
+    if (!resolution.ok) {
       return {
         kind: "error",
-        status: 403,
-        error: `Repository ${input.repoOwner}/${input.repoName} is not part of this session`,
+        status: resolution.reason === "not_member" ? 403 : 400,
+        error: resolution.error,
       };
     }
-    const targetRepo = {
-      repoOwner: memberRow?.repo_owner ?? session.repo_owner,
-      repoName: memberRow?.repo_name ?? session.repo_name,
-    };
+    const { memberRow, isPrimary } = resolution;
+    const targetRepo = { repoOwner: resolution.repoOwner, repoName: resolution.repoName };
 
     this.deps.log.info("Creating PR", {
       user_id: input.promptingUserId,
@@ -158,12 +153,20 @@ export class SessionPullRequestService {
       repo_name: targetRepo.repoName,
     });
 
+    if (!this.deps.claims.claim(targetRepo)) {
+      return {
+        kind: "error",
+        status: 409,
+        error: `A pull request is already being created for ${targetRepo.repoOwner}/${targetRepo.repoName} in this session.`,
+      };
+    }
     try {
       const sessionId = session.session_name || session.id;
       const generatedHeadBranch = generateBranchName(sessionId);
 
-      const initialArtifacts = this.deps.repository.listArtifacts();
-      if (this.findPrArtifactForRepo(initialArtifacts, targetRepo, isPrimary)) {
+      // The claim above serializes in-flight creation; this scan catches PRs
+      // persisted by earlier (completed) requests.
+      if (findPrArtifactForRepo(this.deps.repository.listArtifacts(), targetRepo, isPrimary)) {
         return this.duplicatePrError(targetRepo);
       }
 
@@ -255,11 +258,6 @@ export class SessionPullRequestService {
       // after missed or out-of-order updates.
       this.deps.broadcastSessionBranch(sanitizedHeadBranch, targetRepo);
 
-      const latestArtifacts = this.deps.repository.listArtifacts();
-      if (this.findPrArtifactForRepo(latestArtifacts, targetRepo, isPrimary)) {
-        return this.duplicatePrError(targetRepo);
-      }
-
       // Use user OAuth if available, otherwise fall back to GitHub App token
       // (e.g. sessions triggered from Linear or other integrations without user GitHub OAuth)
       const prAuth = input.promptingAuth ?? appAuth;
@@ -325,31 +323,12 @@ export class SessionPullRequestService {
         status: 500,
         error: error instanceof Error ? error.message : "Failed to create PR",
       };
+    } finally {
+      this.deps.claims.release(targetRepo);
     }
   }
 
-  /**
-   * One PR per repo per session: find an existing PR artifact for the target
-   * repo. Artifact metadata without repo identity predates multi-repo
-   * sessions and belongs to the primary.
-   */
-  private findPrArtifactForRepo(
-    artifacts: ArtifactRow[],
-    targetRepo: { repoOwner: string; repoName: string },
-    isPrimary: boolean
-  ): ArtifactRow | undefined {
-    return artifacts.find((artifact) => {
-      if (artifact.type !== "pr") return false;
-      const artifactRepo = parseArtifactRepo(artifact.metadata);
-      if (!artifactRepo) return isPrimary;
-      return repoIdentityEquals(artifactRepo, targetRepo);
-    });
-  }
-
-  private duplicatePrError(targetRepo: {
-    repoOwner: string;
-    repoName: string;
-  }): CreatePullRequestResult {
+  private duplicatePrError(targetRepo: RepoIdentity): CreatePullRequestResult {
     return {
       kind: "error",
       status: 409,

--- a/packages/control-plane/src/session/repository-target.ts
+++ b/packages/control-plane/src/session/repository-target.ts
@@ -1,0 +1,105 @@
+import {
+  normalizeOptionalRepositoryPair,
+  RepositoryPairValidationError,
+} from "@open-inspect/shared";
+import type { SessionRepositoryRow } from "./repository";
+
+/** A repository identified by owner and name (canonical casing unless noted). */
+export interface RepoIdentity {
+  repoOwner: string;
+  repoName: string;
+}
+
+export function repoIdentityEquals(a: RepoIdentity, b: RepoIdentity): boolean {
+  return (
+    a.repoOwner.toLowerCase() === b.repoOwner.toLowerCase() &&
+    a.repoName.toLowerCase() === b.repoName.toLowerCase()
+  );
+}
+
+export type SessionRepositoryTargetResolution =
+  | {
+      ok: true;
+      repoOwner: string;
+      repoName: string;
+      /** The matched member row; null for sessions predating member rows. */
+      memberRow: SessionRepositoryRow | null;
+      /** Whether the target is the session's primary (scalar-mirror) repo. */
+      isPrimary: boolean;
+    }
+  | { ok: false; reason: "half_specified" | "ambiguous" | "not_member"; error: string };
+
+/**
+ * Resolve a requested target repository against a session's member list.
+ * The single model for PR/push target resolution — normalization (via
+ * normalizeOptionalRepositoryPair), membership, and primary fallback live
+ * here so callers only translate the typed result into their error shape.
+ * Naming a repo outside the session is "not_member": the PR route is
+ * reachable with sandbox auth, so membership is a security boundary, not
+ * just input validation.
+ *
+ * Sessions predating member rows resolve against the scalar mirror alone.
+ * An unspecified target is only valid when the session has a sole member.
+ * Matching is case-insensitive; the returned identity carries the member
+ * list's canonical casing.
+ */
+export function resolveSessionRepositoryTarget(input: {
+  requested: { repoOwner?: string | null; repoName?: string | null };
+  scalarRepo: RepoIdentity;
+  memberRows: SessionRepositoryRow[];
+}): SessionRepositoryTargetResolution {
+  let requested: RepoIdentity | null;
+  try {
+    requested = normalizeOptionalRepositoryPair(input.requested);
+  } catch (error) {
+    if (error instanceof RepositoryPairValidationError) {
+      return { ok: false, reason: "half_specified", error: error.message };
+    }
+    throw error;
+  }
+
+  const members: Array<{ identity: RepoIdentity; row: SessionRepositoryRow | null }> =
+    input.memberRows.length > 0
+      ? input.memberRows.map((row) => ({
+          identity: { repoOwner: row.repo_owner, repoName: row.repo_name },
+          row,
+        }))
+      : [{ identity: input.scalarRepo, row: null }];
+
+  if (!requested) {
+    if (members.length > 1) {
+      const memberList = members
+        .map((member) => `${member.identity.repoOwner}/${member.identity.repoName}`)
+        .join(", ");
+      return {
+        ok: false,
+        reason: "ambiguous",
+        error: `This session spans multiple repositories — specify repoOwner and repoName (one of: ${memberList})`,
+      };
+    }
+    const [sole] = members;
+    return {
+      ok: true,
+      repoOwner: sole.identity.repoOwner,
+      repoName: sole.identity.repoName,
+      memberRow: sole.row,
+      isPrimary: repoIdentityEquals(sole.identity, input.scalarRepo),
+    };
+  }
+
+  const match = members.find((member) => repoIdentityEquals(member.identity, requested));
+  if (!match) {
+    return {
+      ok: false,
+      reason: "not_member",
+      error: `Repository ${requested.repoOwner}/${requested.repoName} is not part of this session`,
+    };
+  }
+  return {
+    ok: true,
+    repoOwner: match.identity.repoOwner,
+    repoName: match.identity.repoName,
+    memberRow: match.row,
+    isPrimary: repoIdentityEquals(match.identity, input.scalarRepo),
+  };
+}

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -402,6 +402,15 @@ export class SessionRepository {
     return this.rows<SessionRepositoryRow>(result);
   }
 
+  updateSessionRepositoryBranch(repoOwner: string, repoName: string, branchName: string): void {
+    this.sql.exec(
+      `UPDATE session_repositories SET branch_name = ? WHERE repo_owner = ? AND repo_name = ?`,
+      branchName,
+      repoOwner,
+      repoName
+    );
+  }
+
   // === SANDBOX ===
   // Note: Each session DO has exactly one sandbox row, so update methods use
   // a subquery `WHERE id = (SELECT id FROM sandbox LIMIT 1)` to find it.

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -410,6 +410,36 @@ describe("SessionSandboxEventProcessor", () => {
       });
     });
 
+    it("drops a fully identified event that mismatches the sole pending push", async () => {
+      const h = createProcessor();
+      connectSandbox(h);
+
+      const pushPromise = h.processor.pushBranchToRemote(
+        createPushSpec("acme", "web", "feature/test")
+      );
+
+      // A stale event for a different repo must not settle the pending push
+      // just because it is the only one in flight.
+      await h.processor.processSandboxEvent({
+        type: "push_error",
+        branchName: "feature/test",
+        repoOwner: "acme",
+        repoName: "backend",
+        error: "remote rejected",
+        timestamp: 1000,
+      });
+
+      await h.processor.processSandboxEvent({
+        type: "push_complete",
+        branchName: "feature/test",
+        repoOwner: "acme",
+        repoName: "web",
+        timestamp: 1001,
+      });
+
+      await expect(pushPromise).resolves.toEqual({ success: true });
+    });
+
     it("drops an identity-less terminal event when several pushes are pending", async () => {
       const h = createProcessor();
       connectSandbox(h);

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -1,6 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
 import { SessionSandboxEventProcessor } from "./sandbox-events";
+import type { GitPushSpec } from "../source-control";
 import type { SandboxEvent, ServerMessage } from "../types";
+
+function createPushSpec(repoOwner: string, repoName: string, targetBranch: string): GitPushSpec {
+  return {
+    remoteUrl: `https://token@example.com/${repoOwner}/${repoName}.git`,
+    redactedRemoteUrl: `https://***@example.com/${repoOwner}/${repoName}.git`,
+    refspec: `HEAD:refs/heads/${targetBranch}`,
+    targetBranch,
+    repoOwner,
+    repoName,
+    force: false,
+  };
+}
 
 function createProcessor() {
   const repository = {
@@ -296,17 +309,15 @@ describe("SessionSandboxEventProcessor", () => {
     const sandboxWs = { readyState: WebSocket.OPEN } as WebSocket;
     h.wsManager.getSandboxSocket.mockReturnValue(sandboxWs);
 
-    const pushPromise = h.processor.pushBranchToRemote("feature/test", {
-      remoteUrl: "https://token@example.com/repo.git",
-      redactedRemoteUrl: "https://***@example.com/repo.git",
-      refspec: "feature/test:feature/test",
-      targetBranch: "feature/test",
-      force: false,
-    });
+    const pushPromise = h.processor.pushBranchToRemote(
+      createPushSpec("acme", "web", "feature/test")
+    );
 
     await h.processor.processSandboxEvent({
       type: "push_complete",
       branchName: "feature/test",
+      repoOwner: "acme",
+      repoName: "web",
       timestamp: 1000,
     });
 
@@ -315,6 +326,124 @@ describe("SessionSandboxEventProcessor", () => {
       sandboxWs,
       expect.objectContaining({ type: "push" })
     );
+  });
+
+  describe("push resolver keying", () => {
+    function connectSandbox(h: ReturnType<typeof createProcessor>) {
+      const sandboxWs = { readyState: WebSocket.OPEN } as WebSocket;
+      h.wsManager.getSandboxSocket.mockReturnValue(sandboxWs);
+      return sandboxWs;
+    }
+
+    it("settles the matching push when two repos push the same branch name", async () => {
+      const h = createProcessor();
+      connectSandbox(h);
+
+      const webPush = h.processor.pushBranchToRemote(
+        createPushSpec("acme", "web", "open-inspect/session-1")
+      );
+      const backendPush = h.processor.pushBranchToRemote(
+        createPushSpec("acme", "backend", "open-inspect/session-1")
+      );
+
+      await h.processor.processSandboxEvent({
+        type: "push_error",
+        branchName: "open-inspect/session-1",
+        repoOwner: "acme",
+        repoName: "backend",
+        error: "remote rejected",
+        timestamp: 1000,
+      });
+      await h.processor.processSandboxEvent({
+        type: "push_complete",
+        branchName: "open-inspect/session-1",
+        repoOwner: "acme",
+        repoName: "web",
+        timestamp: 1001,
+      });
+
+      await expect(webPush).resolves.toEqual({ success: true });
+      await expect(backendPush).resolves.toEqual({
+        success: false,
+        error: expect.stringContaining("remote rejected"),
+      });
+    });
+
+    it("settles the sole pending push on a terminal event without repo identity", async () => {
+      const h = createProcessor();
+      connectSandbox(h);
+
+      const pushPromise = h.processor.pushBranchToRemote(
+        createPushSpec("acme", "web", "feature/test")
+      );
+
+      // Legacy single-repo runtimes echo no repo identity.
+      await h.processor.processSandboxEvent({
+        type: "push_complete",
+        branchName: "feature/test",
+        timestamp: 1000,
+      });
+
+      await expect(pushPromise).resolves.toEqual({ success: true });
+    });
+
+    it("rejects the sole pending push on a branch-less push_error", async () => {
+      const h = createProcessor();
+      connectSandbox(h);
+
+      const pushPromise = h.processor.pushBranchToRemote(
+        createPushSpec("acme", "web", "feature/test")
+      );
+
+      // The bridge's "no repository found" path emits push_error with no
+      // branchName at all; it must reject the pending push instead of
+      // leaking it to the 360 s timeout.
+      await h.processor.processSandboxEvent({
+        type: "push_error",
+        error: "No repository found for push",
+        timestamp: 1000,
+      });
+
+      await expect(pushPromise).resolves.toEqual({
+        success: false,
+        error: expect.stringContaining("No repository found for push"),
+      });
+    });
+
+    it("drops an identity-less terminal event when several pushes are pending", async () => {
+      const h = createProcessor();
+      connectSandbox(h);
+
+      const webPush = h.processor.pushBranchToRemote(createPushSpec("acme", "web", "feature/a"));
+      const backendPush = h.processor.pushBranchToRemote(
+        createPushSpec("acme", "backend", "feature/b")
+      );
+
+      await h.processor.processSandboxEvent({
+        type: "push_error",
+        error: "ambiguous",
+        timestamp: 1000,
+      });
+
+      // Neither push settles from the ambiguous event; identified events do.
+      await h.processor.processSandboxEvent({
+        type: "push_complete",
+        branchName: "feature/a",
+        repoOwner: "acme",
+        repoName: "web",
+        timestamp: 1001,
+      });
+      await h.processor.processSandboxEvent({
+        type: "push_complete",
+        branchName: "feature/b",
+        repoOwner: "acme",
+        repoName: "backend",
+        timestamp: 1002,
+      });
+
+      await expect(webPush).resolves.toEqual({ success: true });
+      await expect(backendPush).resolves.toEqual({ success: true });
+    });
   });
 
   describe("activity tracking for intermediate events", () => {

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -33,6 +33,9 @@ interface SessionSandboxEventProcessorDeps {
   processMessageQueue: () => Promise<void>;
 }
 
+/** How long a pending push waits for its terminal event before rejecting. */
+const PUSH_TIMEOUT_MS = 360_000;
+
 /** Event types that require delivery acknowledgement. */
 const CRITICAL_EVENT_TYPES: ReadonlySet<string> = new Set([
   "execution_complete",
@@ -282,9 +285,9 @@ export class SessionSandboxEventProcessor {
       timeoutId = setTimeout(() => {
         if (this.pendingPushResolvers.has(resolverKey)) {
           this.pendingPushResolvers.delete(resolverKey);
-          reject(new Error("Push operation timed out after 360 seconds"));
+          reject(new Error(`Push operation timed out after ${PUSH_TIMEOUT_MS / 1000} seconds`));
         }
-      }, 360000);
+      }, PUSH_TIMEOUT_MS);
     });
 
     this.deps.log.info("Sending push command", {
@@ -348,18 +351,18 @@ export class SessionSandboxEventProcessor {
 
   /**
    * Match a terminal push event to its pending resolver. Events carrying the
-   * full identity match by key; anything else (legacy single-repo runtimes
-   * echo no repo identity, and their "no repository found" push_error carries
-   * no branchName either) settles the sole pending push — by construction
-   * only one can be in flight when identity is missing.
+   * full identity match strictly by key — a fully identified miss is a stale
+   * or wrong-repo event and must not settle anything. Only events missing
+   * identity (legacy single-repo runtimes echo no repo identity, and their
+   * "no repository found" push_error carries no branchName either) settle
+   * the sole pending push — by construction only one can be in flight when
+   * identity is missing.
    */
   private findPushResolver(event: PushTerminalEvent): [string, PushResolver] | null {
     if (event.repoOwner && event.repoName && event.branchName) {
       const resolverKey = this.pushResolverKey(event.repoOwner, event.repoName, event.branchName);
       const resolver = this.pendingPushResolvers.get(resolverKey);
-      if (resolver) {
-        return [resolverKey, resolver];
-      }
+      return resolver ? [resolverKey, resolver] : null;
     }
     if (this.pendingPushResolvers.size === 1) {
       const [sole] = this.pendingPushResolvers.entries();

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -12,6 +12,7 @@ import type { SessionTitleUpdateOptions, SessionTitleUpdateResult } from "./titl
 
 type PushResolver = { resolve: () => void; reject: (err: Error) => void };
 type SandboxEventWithAck = SandboxEvent & { ackId?: string };
+type PushTerminalEvent = Extract<SandboxEvent, { type: "push_complete" | "push_error" }>;
 
 interface SessionSandboxEventProcessorDeps {
   ctx: DurableObjectState;
@@ -259,7 +260,6 @@ export class SessionSandboxEventProcessor {
   }
 
   async pushBranchToRemote(
-    branchName: string,
     pushSpec: GitPushSpec
   ): Promise<{ success: true } | { success: false; error: string }> {
     const sandboxWs = this.deps.wsManager.getSandboxSocket();
@@ -269,21 +269,29 @@ export class SessionSandboxEventProcessor {
       return { success: true };
     }
 
-    const normalizedBranch = this.normalizeBranchName(branchName);
+    const resolverKey = this.pushResolverKey(
+      pushSpec.repoOwner,
+      pushSpec.repoName,
+      pushSpec.targetBranch
+    );
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
     const pushPromise = new Promise<void>((resolve, reject) => {
-      this.pendingPushResolvers.set(normalizedBranch, { resolve, reject });
+      this.pendingPushResolvers.set(resolverKey, { resolve, reject });
 
       timeoutId = setTimeout(() => {
-        if (this.pendingPushResolvers.has(normalizedBranch)) {
-          this.pendingPushResolvers.delete(normalizedBranch);
+        if (this.pendingPushResolvers.has(resolverKey)) {
+          this.pendingPushResolvers.delete(resolverKey);
           reject(new Error("Push operation timed out after 360 seconds"));
         }
       }, 360000);
     });
 
-    this.deps.log.info("Sending push command", { branch_name: branchName });
+    this.deps.log.info("Sending push command", {
+      branch_name: pushSpec.targetBranch,
+      repo_owner: pushSpec.repoOwner,
+      repo_name: pushSpec.repoName,
+    });
     this.deps.wsManager.send(sandboxWs, {
       type: "push",
       pushSpec,
@@ -291,11 +299,11 @@ export class SessionSandboxEventProcessor {
 
     try {
       await pushPromise;
-      this.deps.log.info("Push completed successfully", { branch_name: branchName });
+      this.deps.log.info("Push completed successfully", { branch_name: pushSpec.targetBranch });
       return { success: true };
     } catch (pushError) {
       this.deps.log.error("Push failed", {
-        branch_name: branchName,
+        branch_name: pushSpec.targetBranch,
         error: pushError instanceof Error ? pushError : String(pushError),
       });
       return { success: false, error: `Failed to push branch: ${pushError}` };
@@ -306,33 +314,58 @@ export class SessionSandboxEventProcessor {
     }
   }
 
-  private handlePushEvent(event: SandboxEvent): void {
-    const branchName = (event as { branchName?: string }).branchName;
-
-    if (!branchName) {
+  private handlePushEvent(event: PushTerminalEvent): void {
+    const entry = this.findPushResolver(event);
+    if (!entry) {
+      this.deps.log.warn("Push event matched no pending resolver", {
+        event_type: event.type,
+        branch_name: event.branchName ?? null,
+        repo_owner: event.repoOwner ?? null,
+        repo_name: event.repoName ?? null,
+        pending_resolvers: Array.from(this.pendingPushResolvers.keys()),
+      });
       return;
     }
 
-    const normalizedBranch = this.normalizeBranchName(branchName);
-    const resolver = this.pendingPushResolvers.get(normalizedBranch);
-
-    if (!resolver) {
-      return;
-    }
-
+    const [resolverKey, resolver] = entry;
     if (event.type === "push_complete") {
       this.deps.log.info("Push completed, resolving promise", {
-        branch_name: branchName,
+        branch_name: event.branchName ?? null,
         pending_resolvers: Array.from(this.pendingPushResolvers.keys()),
       });
       resolver.resolve();
-    } else if (event.type === "push_error") {
-      const error = (event as { error?: string }).error || "Push failed";
-      this.deps.log.warn("Push failed for branch", { branch_name: branchName, error });
+    } else {
+      const error = event.error || "Push failed";
+      this.deps.log.warn("Push failed for branch", {
+        branch_name: event.branchName ?? null,
+        error,
+      });
       resolver.reject(new Error(error));
     }
 
-    this.pendingPushResolvers.delete(normalizedBranch);
+    this.pendingPushResolvers.delete(resolverKey);
+  }
+
+  /**
+   * Match a terminal push event to its pending resolver. Events carrying the
+   * full identity match by key; anything else (legacy single-repo runtimes
+   * echo no repo identity, and their "no repository found" push_error carries
+   * no branchName either) settles the sole pending push — by construction
+   * only one can be in flight when identity is missing.
+   */
+  private findPushResolver(event: PushTerminalEvent): [string, PushResolver] | null {
+    if (event.repoOwner && event.repoName && event.branchName) {
+      const resolverKey = this.pushResolverKey(event.repoOwner, event.repoName, event.branchName);
+      const resolver = this.pendingPushResolvers.get(resolverKey);
+      if (resolver) {
+        return [resolverKey, resolver];
+      }
+    }
+    if (this.pendingPushResolvers.size === 1) {
+      const [sole] = this.pendingPushResolvers.entries();
+      return sole;
+    }
+    return null;
   }
 
   private sendAck(ackId: string | undefined): void {
@@ -345,7 +378,7 @@ export class SessionSandboxEventProcessor {
     }
   }
 
-  private normalizeBranchName(name: string): string {
-    return name.trim().toLowerCase();
+  private pushResolverKey(repoOwner: string, repoName: string, branchName: string): string {
+    return `${repoOwner.toLowerCase()}/${repoName.toLowerCase()}::${branchName.trim().toLowerCase()}`;
   }
 }

--- a/packages/control-plane/src/source-control/providers/github-provider.test.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.test.ts
@@ -218,6 +218,8 @@ describe("GitHubSourceControlProvider", () => {
       redactedRemoteUrl: "https://x-access-token:<redacted>@github.com/acme/web.git",
       refspec: "HEAD:refs/heads/feature/one",
       targetBranch: "feature/one",
+      repoOwner: "acme",
+      repoName: "web",
       force: false,
     });
   });

--- a/packages/control-plane/src/source-control/providers/github-provider.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.ts
@@ -368,6 +368,8 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
       redactedRemoteUrl,
       refspec: `${config.sourceRef}:refs/heads/${config.targetBranch}`,
       targetBranch: config.targetBranch,
+      repoOwner: config.owner,
+      repoName: config.name,
       force,
     };
   }

--- a/packages/control-plane/src/source-control/providers/gitlab-provider.test.ts
+++ b/packages/control-plane/src/source-control/providers/gitlab-provider.test.ts
@@ -689,6 +689,8 @@ describe("GitLabSourceControlProvider", () => {
         redactedRemoteUrl: "https://oauth2:<redacted>@gitlab.com/acme/web.git",
         refspec: "HEAD:refs/heads/feature/one",
         targetBranch: "feature/one",
+        repoOwner: "acme",
+        repoName: "web",
         force: false,
       });
     });

--- a/packages/control-plane/src/source-control/providers/gitlab-provider.ts
+++ b/packages/control-plane/src/source-control/providers/gitlab-provider.ts
@@ -399,6 +399,8 @@ export class GitLabSourceControlProvider implements SourceControlProvider {
       redactedRemoteUrl,
       refspec: `${config.sourceRef}:refs/heads/${config.targetBranch}`,
       targetBranch: config.targetBranch,
+      repoOwner: config.owner,
+      repoName: config.name,
       force,
     };
   }

--- a/packages/control-plane/src/source-control/types.ts
+++ b/packages/control-plane/src/source-control/types.ts
@@ -116,6 +116,10 @@ export interface GitPushSpec {
   refspec: string;
   /** Remote branch name (for observability and event correlation) */
   targetBranch: string;
+  /** Target repository owner — selects the checkout in multi-repo sandboxes */
+  repoOwner: string;
+  /** Target repository name — selects the checkout in multi-repo sandboxes */
+  repoName: string;
   /** Whether force push is required */
   force: boolean;
 }

--- a/packages/control-plane/test/integration/create-pr.test.ts
+++ b/packages/control-plane/test/integration/create-pr.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { env, runInDurableObject } from "cloudflare:test";
+import { SELF, env, runInDurableObject } from "cloudflare:test";
 import type { SourceControlProvider } from "../../src/source-control";
 import type { SessionDO } from "../../src/session/durable-object";
-import { initSession, queryDO, seedMessage } from "./helpers";
+import { generateInternalToken } from "../../src/auth/internal";
+import { initNamedSession, initSession, queryDO, seedMessage } from "./helpers";
+
+async function authHeaders(): Promise<Record<string, string>> {
+  const token = await generateInternalToken(env.INTERNAL_CALLBACK_SECRET!);
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
 
 describe("POST /internal/create-pr", () => {
   it("returns 404 when session is not initialized", async () => {
@@ -313,6 +319,228 @@ describe("POST /internal/create-pr", () => {
 
     expect(res.status).toBe(409);
     const body = await res.json<{ error: string }>();
-    expect(body.error).toBe("A pull request has already been created for this session.");
+    expect(body.error).toBe(
+      "A pull request has already been created for acme/web-app in this session."
+    );
+  });
+
+  describe("multi-repo sessions", () => {
+    const multiRepoInit = {
+      repoOwner: "acme",
+      repoName: "web-app",
+      repoId: 1,
+      defaultBranch: "main",
+      repositories: [
+        { repoOwner: "acme", repoName: "web-app", repoId: 1, baseBranch: "main" },
+        { repoOwner: "acme", repoName: "backend", repoId: 2, baseBranch: "develop" },
+      ],
+    };
+
+    async function seedProcessingMessage(stub: DurableObjectStub, messageId: string) {
+      const participants = await queryDO<{ id: string }>(
+        stub,
+        "SELECT id FROM participants WHERE user_id = ?",
+        "user-1"
+      );
+      const ownerParticipantId = participants[0]?.id;
+      if (!ownerParticipantId) {
+        throw new Error("Expected owner participant");
+      }
+      await seedMessage(stub, {
+        id: messageId,
+        authorId: ownerParticipantId,
+        content: "Create a PR",
+        source: "web",
+        status: "processing",
+        createdAt: Date.now() - 1000,
+        startedAt: Date.now() - 500,
+      });
+    }
+
+    async function installMockProvider(stub: DurableObjectStub) {
+      await runInDurableObject(stub, (instance: SessionDO) => {
+        let prCounter = 0;
+        const mockProvider = {
+          name: "github",
+          generatePushAuth: async () => ({ authType: "app", token: "push-token" as const }),
+          getRepository: async (_auth: unknown, config: { owner: string; name: string }) => ({
+            owner: config.owner,
+            name: config.name,
+            fullName: `${config.owner}/${config.name}`,
+            defaultBranch: "main",
+            isPrivate: true,
+            providerRepoId: 12345,
+          }),
+          createPullRequest: async (
+            _auth: unknown,
+            config: { repository: { owner: string; name: string } }
+          ) => {
+            prCounter += 1;
+            return {
+              id: prCounter,
+              webUrl: `https://github.com/${config.repository.owner}/${config.repository.name}/pull/${prCounter}`,
+              apiUrl: `https://api.github.com/repos/${config.repository.owner}/${config.repository.name}/pulls/${prCounter}`,
+              state: "open" as const,
+              sourceBranch: "open-inspect/test-session",
+              targetBranch: "main",
+            };
+          },
+          buildManualPullRequestUrl: (config: {
+            owner: string;
+            name: string;
+            sourceBranch: string;
+            targetBranch: string;
+          }) =>
+            `https://github.com/${config.owner}/${config.name}/pull/new/${config.targetBranch}...${config.sourceBranch}`,
+          buildGitPushSpec: (config: { owner: string; name: string; targetBranch: string }) => ({
+            remoteUrl: `https://example.invalid/${config.owner}/${config.name}.git`,
+            redactedRemoteUrl: `https://example.invalid/<redacted>.git`,
+            refspec: `HEAD:refs/heads/${config.targetBranch}`,
+            targetBranch: config.targetBranch,
+            repoOwner: config.owner,
+            repoName: config.name,
+            force: true,
+          }),
+        } as unknown as SourceControlProvider;
+
+        (
+          instance as unknown as { _sourceControlProvider: SourceControlProvider | null }
+        )._sourceControlProvider = mockProvider;
+      });
+    }
+
+    function postPr(stub: DurableObjectStub, body: Record<string, unknown>) {
+      return stub.fetch("http://internal/internal/create-pr", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+    }
+
+    it("creates one PR per member repo with repo metadata on each artifact", async () => {
+      const { stub } = await initSession({ userId: "user-1", ...multiRepoInit });
+      await seedProcessingMessage(stub, "msg-multi-1");
+      await installMockProvider(stub);
+
+      const first = await postPr(stub, {
+        title: "Web PR",
+        body: "desc",
+        repoOwner: "acme",
+        repoName: "web-app",
+      });
+      expect(first.status).toBe(200);
+
+      const second = await postPr(stub, {
+        title: "Backend PR",
+        body: "desc",
+        repoOwner: "acme",
+        repoName: "backend",
+      });
+      expect(second.status).toBe(200);
+
+      const artifacts = await queryDO<{ type: string; url: string; metadata: string }>(
+        stub,
+        "SELECT type, url, metadata FROM artifacts WHERE type = 'pr' ORDER BY created_at"
+      );
+      expect(artifacts).toHaveLength(2);
+      const parsed = artifacts.map((artifact) => JSON.parse(artifact.metadata));
+      expect(parsed[0]).toMatchObject({ repoOwner: "acme", repoName: "web-app" });
+      expect(parsed[1]).toMatchObject({ repoOwner: "acme", repoName: "backend", base: "develop" });
+
+      // Per-repo branch state: both member rows carry the shared generated
+      // branch; the scalar mirror only tracks the primary.
+      const memberRows = await queryDO<{ repo_name: string; branch_name: string | null }>(
+        stub,
+        "SELECT repo_name, branch_name FROM session_repositories ORDER BY position"
+      );
+      expect(memberRows[0]?.branch_name).not.toBeNull();
+      expect(memberRows[1]?.branch_name).toBe(memberRows[0]?.branch_name);
+
+      // The WebSocket session state surfaces each member's own PR URL.
+      const state = await runInDurableObject(stub, (instance: SessionDO) =>
+        (
+          instance as unknown as {
+            getSessionState(): Promise<{
+              repositories: Array<{ repoName: string; prUrl: string | null }>;
+            }>;
+          }
+        ).getSessionState()
+      );
+      expect(state.repositories.map((repo) => repo.prUrl)).toEqual([
+        "https://github.com/acme/web-app/pull/1",
+        "https://github.com/acme/backend/pull/2",
+      ]);
+    });
+
+    it("returns 409 only for the member that already has a PR", async () => {
+      const { stub } = await initSession({ userId: "user-1", ...multiRepoInit });
+      await seedProcessingMessage(stub, "msg-multi-2");
+      await installMockProvider(stub);
+
+      const first = await postPr(stub, {
+        title: "Backend PR",
+        body: "desc",
+        repoOwner: "acme",
+        repoName: "backend",
+      });
+      expect(first.status).toBe(200);
+
+      const duplicate = await postPr(stub, {
+        title: "Backend PR again",
+        body: "desc",
+        repoOwner: "acme",
+        repoName: "backend",
+      });
+      expect(duplicate.status).toBe(409);
+      const dupBody = await duplicate.json<{ error: string }>();
+      expect(dupBody.error).toBe(
+        "A pull request has already been created for acme/backend in this session."
+      );
+
+      const other = await postPr(stub, {
+        title: "Web PR",
+        body: "desc",
+        repoOwner: "acme",
+        repoName: "web-app",
+      });
+      expect(other.status).toBe(200);
+    });
+
+    it("rejects an omitted target on a multi-repo session through the proxy route", async () => {
+      const sessionName = `pr-target-400-${Date.now()}`;
+      await initNamedSession(sessionName, multiRepoInit);
+
+      const res = await SELF.fetch(`https://test.local/sessions/${sessionName}/pr`, {
+        method: "POST",
+        headers: await authHeaders(),
+        body: JSON.stringify({ title: "PR", body: "desc" }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json<{ error: string }>();
+      expect(body.error).toBe(
+        "This session spans multiple repositories — specify repoOwner and repoName (one of: acme/web-app, acme/backend)"
+      );
+    });
+
+    it("rejects a non-member target with 403 through the proxy route", async () => {
+      const sessionName = `pr-target-403-${Date.now()}`;
+      await initNamedSession(sessionName, multiRepoInit);
+
+      const res = await SELF.fetch(`https://test.local/sessions/${sessionName}/pr`, {
+        method: "POST",
+        headers: await authHeaders(),
+        body: JSON.stringify({
+          title: "PR",
+          body: "desc",
+          repoOwner: "evil",
+          repoName: "exfil",
+        }),
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json<{ error: string }>();
+      expect(body.error).toBe("Repository evil/exfil is not part of this session");
+    });
   });
 });

--- a/packages/control-plane/test/integration/helpers.ts
+++ b/packages/control-plane/test/integration/helpers.ts
@@ -146,6 +146,13 @@ export async function initNamedSession(
     repoOwner?: string;
     repoName?: string;
     repoId?: number;
+    defaultBranch?: string;
+    repositories?: Array<{
+      repoOwner: string;
+      repoName: string;
+      repoId: number;
+      baseBranch: string;
+    }>;
     title?: string;
     model?: string;
     userId?: string;


### PR DESCRIPTION
## Summary

PR-5 of the multi-repo sessions plan (design §6.7, follows #899/#900/#901/#905): makes the push + PR flow repo-aware so a multi-repo session can produce **one PR per member repository**.

### Request targeting (sandbox-auth security boundary)

- `POST /sessions/:id/pr` (runtime proxy) now forwards `repoOwner`/`repoName` — without this the DO handler never sees the fields and multi-repo PR creation would 400 with everything else landed. The `create-pull-request` tool has been sending these since #899.
- The DO handler validates the target against the session's member list (scalar-mirror fallback for pre-list sessions):
  - both-or-neither: half-specified → **400**
  - absent on a multi-repo session → **400** listing the member repos
  - not a member → **403** — the route is reachable with sandbox auth, so a sandbox must not be able to push/PR against arbitrary repos. The service re-checks this independently (defense in depth).
  - matching is case-insensitive; the member list's canonical casing wins.

### One PR per repo

- The duplicate-PR guard re-keys from "any `type:"pr"` artifact" to the artifact's `(repoOwner, repoName)` metadata. Metadata without identity predates multi-repo and belongs to the primary. The 409 message now names the repo.
- PR artifacts and the `session_branch` broadcast carry `repoOwner`/`repoName` (shared contracts from #901).
- `SessionState.repositories[].prUrl` is now populated from the per-repo PR artifacts (was hardcoded `null` in #905).

### Per-repo head/base resolution (behavioral parity)

- Base: requested > target repo's `base_branch` > scalar `base_branch` (legacy sessions) > repo default. The handler previously injected `session.base_branch` before the service ran — that default now lives in the service, per repo. Parity is pinned by tests.
- Head: requested > target repo's stored `branch_name` (primary falls back to the scalar mirror) > `generateBranchName(sessionId)` — the same generated name across all repos (shared-branch invariant lives only in the PR service).

### Push targeting

- `GitPushSpec` gains required `repoOwner`/`repoName`, populated inside both providers' `buildGitPushSpec`. The spec flows to the bridge unchanged; the #899 bridge matches it against the repo manifest, and pre-#899 bridges ignore the extra keys (single clone).
- `pendingPushResolvers` re-keys from `branch` to `owner/name::branch` — required because every repo pushes the same generated branch name. Fallback: a terminal push event without full identity settles the **sole** pending push — including the bridge's branch-less "no repository found" `push_error`, which previously leaked the resolver to the 360 s timeout. With several pushes pending, an identity-less event is logged and dropped (only new runtimes can have several pending, and they echo identity).
- `pushBranchToRemote` now takes just the spec (the branch rode along redundantly as `targetBranch`).

### Persistence

- New `SessionRepository.updateSessionRepositoryBranch` writes the target member's `branch_name` (columns added by #905); the scalar mirror is written only when the target is the primary.

## Compatibility

- Single-repo sessions: byte-identical requests keep working (target defaults to the sole member); the only visible change is the more specific 409 message.
- Legacy runtimes: extra `pushSpec` keys are ignored; their identity-less terminal events settle via the sole-pending fallback.
- Pre-multi-repo PR artifacts (no repo metadata) are treated as the primary's everywhere (guard, prUrl).

## Testing

- `npm run typecheck` (both passes), `npm run lint` — clean
- Unit: **1572 passed** (+20: handler targeting matrix, service guard matrix incl. legacy artifacts, per-repo head/base precedence + parity pins, resolver keying/collision/branch-less fallback, proxy forwarding, provider spec identity)
- Integration: **455 passed** (+4: two-repo session → two PR artifacts with repo metadata + shared branch + per-repo `prUrl` in session state; per-repo 409; 400/403 exercised through the worker proxy route)

## Rollout

No migration. Deploys with the standard control-plane pipeline; safe before/after any Modal deploy (bridge tolerance both directions). Prod sync still requires Modal (#900) before control plane (#905/this).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-repository sessions can now create pull requests for a specific target repository.
  * Session state can display the correct PR link per repository.
* **Bug Fixes**
  * PR request validation now enforces correct repository context (including required string types when provided) and returns clearer 400/403 errors.
  * Duplicate PR detection is now scoped per repository.
  * Branch push completion/error handling now resolves against the correct repository+branch to prevent cross-repo mixups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->