### PR TITLE
refactor(control-plane): consolidate session repository resolution

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -1950,11 +1950,17 @@ describe("SandboxLifecycleManager", () => {
       ]);
     });
 
-    it("synthesizes the scalar member for the MCP lookup on pre-list sessions", async () => {
+    it("passes storage-synthesized members to the MCP lookup on pre-list sessions", async () => {
+      // Pre-list sessions get their scalar member synthesized by the storage
+      // adapter (buildSessionRepositories owns the rule) — the manager passes
+      // the list through as-is.
       const mcpServerLookup: McpServerLookup = {
         getDecryptedForSession: vi.fn(async () => []),
       };
-      const { manager } = createMultiRepoManager({ mcpServerLookup, sessionRepositories: [] });
+      const { manager } = createMultiRepoManager({
+        mcpServerLookup,
+        sessionRepositories: [{ repoOwner: "testowner", repoName: "testrepo", baseBranch: "main" }],
+      });
 
       await manager.spawnSandbox();
 

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -75,7 +75,12 @@ export interface SandboxStorage {
   getSandboxWithCircuitBreaker(): SandboxCircuitBreakerInfo | null;
   /** Get current session */
   getSession(): SessionRow | null;
-  /** Get the session's member repositories in position order (empty for pre-list sessions) */
+  /**
+   * Get the session's member repositories in position order. Pre-list
+   * sessions get a one-entry list synthesized from the scalar columns
+   * (buildSessionRepositories owns the rule); empty only for repo-less
+   * sessions.
+   */
   getSessionRepositories(): SessionRepositoryInfo[];
   /** Get user env vars for sandbox injection */
   getUserEnvVars(): Promise<Record<string, string> | undefined>;
@@ -429,7 +434,7 @@ export class SandboxLifecycleManager {
 
       const userEnvVars = await this.storage.getUserEnvVars();
       const { provider, model: modelId } = this.resolveProviderAndModel(session);
-      const repositories = this.sessionRepositories(session);
+      const repositories = this.storage.getSessionRepositories();
       const multiRepoFields = multiRepoSpawnFields(repositories);
 
       // Look up pre-built repo image (graceful fallback on failure).
@@ -648,7 +653,7 @@ export class SandboxLifecycleManager {
       const timeoutSeconds =
         session.spawn_source === "agent" ? CHILD_SANDBOX_TIMEOUT_SECONDS : undefined;
 
-      const repositories = this.sessionRepositories(session);
+      const repositories = this.storage.getSessionRepositories();
       const codeServerEnabled = session.code_server_enabled === 1;
       const agentSlackNotifyEnabled = await this.resolveAgentSlackNotifyEnabled(session);
       const mcpServers = await this.loadMcpServers(repositories);
@@ -1211,28 +1216,6 @@ export class SandboxLifecycleManager {
    */
   private resolveProviderAndModel(session: SessionRow): { provider: string; model: string } {
     return extractProviderAndModel(session.model || this.config.model);
-  }
-
-  /**
-   * The session's member repositories in position order. Falls back to a
-   * one-entry list synthesized from the scalar columns for sessions that
-   * predate the session_repositories table.
-   */
-  private sessionRepositories(session: SessionRow): SessionRepositoryInfo[] {
-    const repositories = this.storage.getSessionRepositories();
-    if (repositories.length > 0) {
-      return repositories;
-    }
-    if (sessionHasRepository(session)) {
-      return [
-        {
-          repoOwner: session.repo_owner,
-          repoName: session.repo_name,
-          baseBranch: session.base_branch ?? "main",
-        },
-      ];
-    }
-    return [];
   }
 
   /**

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -586,7 +586,7 @@ export class SessionDO extends DurableObject<Env> {
       getSandboxWithCircuitBreaker: () => this.repository.getSandboxWithCircuitBreaker(),
       getSession: () => this.repository.getSession(),
       getSessionRepositories: () =>
-        this.repository.getSessionRepositories().map((row) => ({
+        this.repository.getSessionRepositoryRows().map((row) => ({
           repoOwner: row.repo_owner,
           repoName: row.repo_name,
           baseBranch: row.base_branch,
@@ -1706,44 +1706,27 @@ export class SessionDO extends DurableObject<Env> {
   }
 
   /**
-   * Member repositories for SessionState, in position order. Sessions that
-   * predate the session_repositories table get a one-entry list synthesized
-   * from the scalar columns. Rows written before per-repo git state existed
-   * have null git columns while the scalars are set, so the primary entry is
-   * overlaid with the session scalars.
+   * Member repositories for SessionState, in position order (see
+   * buildSessionRepositories for the scalar-mirror fallback). Members synthesized
+   * from the scalars — and member rows written before per-repo git state
+   * existed, whose git columns are null while the scalars are set — have the
+   * primary entry overlaid with the session scalars.
    */
   private getSessionRepositoryStates(session: SessionRow | null): SessionRepositoryState[] {
     const prUrlForRepo = this.getPrUrlLookup();
-    const rows = this.repository.getSessionRepositories();
-    if (rows.length > 0) {
-      return rows.map((row, index) => ({
-        position: row.position,
-        repoOwner: row.repo_owner,
-        repoName: row.repo_name,
-        repoId: row.repo_id,
-        baseBranch: row.base_branch,
-        branchName: row.branch_name ?? (index === 0 ? (session?.branch_name ?? null) : null),
-        baseSha: row.base_sha ?? (index === 0 ? (session?.base_sha ?? null) : null),
-        currentSha: row.current_sha ?? (index === 0 ? (session?.current_sha ?? null) : null),
-        prUrl: prUrlForRepo(row.repo_owner, row.repo_name, index === 0),
-      }));
-    }
-    if (session?.repo_owner && session.repo_name) {
-      return [
-        {
-          position: 0,
-          repoOwner: session.repo_owner,
-          repoName: session.repo_name,
-          repoId: session.repo_id ?? null,
-          baseBranch: session.base_branch ?? "main",
-          branchName: session.branch_name ?? null,
-          baseSha: session.base_sha ?? null,
-          currentSha: session.current_sha ?? null,
-          prUrl: prUrlForRepo(session.repo_owner, session.repo_name, true),
-        },
-      ];
-    }
-    return [];
+    return this.repository.getSessionRepositories().map((member) => ({
+      position: member.position,
+      repoOwner: member.repoOwner,
+      repoName: member.repoName,
+      repoId: member.row ? member.row.repo_id : (session?.repo_id ?? null),
+      baseBranch: member.row ? member.row.base_branch : (session?.base_branch ?? "main"),
+      branchName:
+        member.row?.branch_name ?? (member.isPrimary ? (session?.branch_name ?? null) : null),
+      baseSha: member.row?.base_sha ?? (member.isPrimary ? (session?.base_sha ?? null) : null),
+      currentSha:
+        member.row?.current_sha ?? (member.isPrimary ? (session?.current_sha ?? null) : null),
+      prUrl: prUrlForRepo(member.repoOwner, member.repoName, member.isPrimary),
+    }));
   }
 
   /** Per-repo PR URL lookup over the session's PR artifacts. */

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -586,10 +586,10 @@ export class SessionDO extends DurableObject<Env> {
       getSandboxWithCircuitBreaker: () => this.repository.getSandboxWithCircuitBreaker(),
       getSession: () => this.repository.getSession(),
       getSessionRepositories: () =>
-        this.repository.getSessionRepositoryRows().map((row) => ({
-          repoOwner: row.repo_owner,
-          repoName: row.repo_name,
-          baseBranch: row.base_branch,
+        this.repository.getSessionRepositories().map((entry) => ({
+          repoOwner: entry.repoOwner,
+          repoName: entry.repoName,
+          baseBranch: entry.baseBranch ?? "main",
         })),
       getUserEnvVars: () => this.getUserEnvVars(),
       updateSandboxStatus: (status) => this.updateSandboxStatus(status),
@@ -1719,7 +1719,7 @@ export class SessionDO extends DurableObject<Env> {
       repoOwner: member.repoOwner,
       repoName: member.repoName,
       repoId: member.row ? member.row.repo_id : (session?.repo_id ?? null),
-      baseBranch: member.row ? member.row.base_branch : (session?.base_branch ?? "main"),
+      baseBranch: member.baseBranch ?? "main",
       branchName:
         member.row?.branch_name ?? (member.isPrimary ? (session?.branch_name ?? null) : null),
       baseSha: member.row?.base_sha ?? (member.isPrimary ? (session?.base_sha ?? null) : null),

--- a/packages/control-plane/src/session/http/handlers/pull-request.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/pull-request.handler.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { SessionRepositoryRow } from "../../repository";
+import { buildSessionRepositories, type SessionRepositoryEntry } from "../../repository-target";
 import type { ParticipantRow, SessionRow } from "../../types";
 import { createPullRequestHandler } from "./pull-request.handler";
 
@@ -69,7 +70,17 @@ function createParticipant(overrides: Partial<ParticipantRow> = {}): Participant
 
 function createHandler() {
   const getSession = vi.fn<() => SessionRow | null>();
-  const getSessionRepositories = vi.fn<() => SessionRepositoryRow[]>(() => []);
+  let repositoryRows: SessionRepositoryRow[] = [];
+  // Mirrors SessionRepository.getSessionRepositories: members derive from the
+  // session scalars plus whatever rows the test seeds.
+  const getSessionRepositories = vi.fn<() => SessionRepositoryEntry[]>(() => {
+    const session = getSession();
+    if (!session?.repo_owner || !session.repo_name) return [];
+    return buildSessionRepositories(
+      { repoOwner: session.repo_owner, repoName: session.repo_name },
+      repositoryRows
+    );
+  });
   const getPromptingParticipantForPR = vi.fn();
   const resolveAuthForPR = vi.fn();
   const getSessionUrl = vi.fn();
@@ -88,6 +99,9 @@ function createHandler() {
     handler,
     getSession,
     getSessionRepositories,
+    setRepositoryRows: (rows: SessionRepositoryRow[]) => {
+      repositoryRows = rows;
+    },
     getPromptingParticipantForPR,
     resolveAuthForPR,
     getSessionUrl,
@@ -344,7 +358,7 @@ describe("createPullRequestHandler", () => {
     function createMultiRepoHandler() {
       const harness = createHandler();
       harness.getSession.mockReturnValue(createSession());
-      harness.getSessionRepositories.mockReturnValue([
+      harness.setRepositoryRows([
         createRepositoryRow(0, "acme", "repo"),
         createRepositoryRow(1, "acme", "backend"),
       ]);
@@ -432,7 +446,7 @@ describe("createPullRequestHandler", () => {
 
     it("defaults to the sole member when the target is omitted", async () => {
       const harness = createMultiRepoHandler();
-      harness.getSessionRepositories.mockReturnValue([createRepositoryRow(0, "acme", "repo")]);
+      harness.setRepositoryRows([createRepositoryRow(0, "acme", "repo")]);
 
       const response = await postPr(harness.handler, { title: "PR", body: "desc" });
 

--- a/packages/control-plane/src/session/http/handlers/pull-request.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/pull-request.handler.ts
@@ -1,7 +1,12 @@
+import { RepositoryPairValidationError } from "@open-inspect/shared";
 import type { SourceControlAuthContext } from "../../../source-control";
 import type { CreatePullRequestInput, CreatePullRequestResult } from "../../pull-request-service";
-import type { SessionRepositoryRow } from "../../repository";
-import { resolveSessionRepositoryTarget } from "../../repository-target";
+import {
+  AmbiguousRepositoryTargetError,
+  RepositoryNotMemberError,
+  resolveSessionRepositoryTarget,
+  type SessionRepositoryEntry,
+} from "../../repository-target";
 import type { ParticipantRow, SessionRow } from "../../types";
 import { z } from "zod";
 
@@ -26,7 +31,7 @@ type ResolveAuthForPrResult =
 
 export interface PullRequestHandlerDeps {
   getSession: () => SessionRow | null;
-  getSessionRepositories: () => SessionRepositoryRow[];
+  getSessionRepositories: () => SessionRepositoryEntry[];
   getPromptingParticipantForPR: () => Promise<PromptingParticipantResult>;
   resolveAuthForPR: (participant: ParticipantRow) => Promise<ResolveAuthForPrResult>;
   getSessionUrl: (session: SessionRow) => string;
@@ -67,16 +72,23 @@ export function createPullRequestHandler(deps: PullRequestHandlerDeps): PullRequ
       // Membership is a security boundary (this route is reachable with
       // sandbox auth): naming a repo outside the session is 403, an
       // ambiguous or half-specified target is 400.
-      const target = resolveSessionRepositoryTarget({
-        requested: { repoOwner: body.repoOwner, repoName: body.repoName },
-        scalarRepo: { repoOwner: session.repo_owner, repoName: session.repo_name },
-        memberRows: deps.getSessionRepositories(),
-      });
-      if (!target.ok) {
-        return Response.json(
-          { error: target.error },
-          { status: target.reason === "not_member" ? 403 : 400 }
+      let target: SessionRepositoryEntry;
+      try {
+        target = resolveSessionRepositoryTarget(
+          { repoOwner: body.repoOwner, repoName: body.repoName },
+          deps.getSessionRepositories()
         );
+      } catch (error) {
+        if (error instanceof RepositoryNotMemberError) {
+          return Response.json({ error: error.message }, { status: 403 });
+        }
+        if (
+          error instanceof AmbiguousRepositoryTargetError ||
+          error instanceof RepositoryPairValidationError
+        ) {
+          return Response.json({ error: error.message }, { status: 400 });
+        }
+        throw error;
       }
 
       const promptingParticipantResult = await deps.getPromptingParticipantForPR();

--- a/packages/control-plane/src/session/http/handlers/pull-request.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/pull-request.handler.ts
@@ -1,9 +1,7 @@
-import { RepositoryPairValidationError } from "@open-inspect/shared";
 import type { SourceControlAuthContext } from "../../../source-control";
 import type { CreatePullRequestInput, CreatePullRequestResult } from "../../pull-request-service";
 import {
-  AmbiguousRepositoryTargetError,
-  RepositoryNotMemberError,
+  mapRepositoryTargetError,
   resolveSessionRepositoryTarget,
   type SessionRepositoryEntry,
 } from "../../repository-target";
@@ -79,16 +77,9 @@ export function createPullRequestHandler(deps: PullRequestHandlerDeps): PullRequ
           deps.getSessionRepositories()
         );
       } catch (error) {
-        if (error instanceof RepositoryNotMemberError) {
-          return Response.json({ error: error.message }, { status: 403 });
-        }
-        if (
-          error instanceof AmbiguousRepositoryTargetError ||
-          error instanceof RepositoryPairValidationError
-        ) {
-          return Response.json({ error: error.message }, { status: 400 });
-        }
-        throw error;
+        const mapped = mapRepositoryTargetError(error);
+        if (!mapped) throw error;
+        return Response.json({ error: mapped.error }, { status: mapped.status });
       }
 
       const promptingParticipantResult = await deps.getPromptingParticipantForPR();

--- a/packages/control-plane/src/session/pull-request-service.test.ts
+++ b/packages/control-plane/src/session/pull-request-service.test.ts
@@ -3,6 +3,7 @@ import type { Logger } from "../logger";
 import type { SourceControlProvider } from "../source-control";
 import * as branchResolution from "../source-control/branch-resolution";
 import type { SessionRepositoryRow } from "./repository";
+import { buildSessionRepositories } from "./repository-target";
 import type { ArtifactRow, SessionRow } from "./types";
 import {
   PullRequestCreationClaims,
@@ -123,7 +124,15 @@ function createTestHarness() {
 
   const repository: PullRequestRepository = {
     getSession: () => session,
-    getSessionRepositories: () => [...repositoryRows],
+    // Mirrors SessionRepository.getSessionRepositories: members derive from the
+    // session scalars plus whatever rows the test seeds.
+    getSessionRepositories: () =>
+      session?.repo_owner && session.repo_name
+        ? buildSessionRepositories(
+            { repoOwner: session.repo_owner, repoName: session.repo_name },
+            repositoryRows
+          )
+        : [],
     updateSessionBranch: vi.fn((sessionId: string, branchName: string) => {
       if (session && session.id === sessionId) {
         session = { ...session, branch_name: branchName };

--- a/packages/control-plane/src/session/pull-request-service.ts
+++ b/packages/control-plane/src/session/pull-request-service.ts
@@ -1,4 +1,8 @@
-import { generateBranchName, type SessionArtifact } from "@open-inspect/shared";
+import {
+  generateBranchName,
+  RepositoryPairValidationError,
+  type SessionArtifact,
+} from "@open-inspect/shared";
 import type { Logger } from "../logger";
 import { resolveHeadBranchForPr, sanitizeBranchName } from "../source-control/branch-resolution";
 import {
@@ -9,8 +13,13 @@ import {
   type GitPushSpec,
 } from "../source-control";
 import { findPrArtifactForRepo } from "./pr-artifacts";
-import type { SessionRepositoryRow } from "./repository";
-import { resolveSessionRepositoryTarget, type RepoIdentity } from "./repository-target";
+import {
+  AmbiguousRepositoryTargetError,
+  RepositoryNotMemberError,
+  resolveSessionRepositoryTarget,
+  type RepoIdentity,
+  type SessionRepositoryEntry,
+} from "./repository-target";
 import type { ArtifactRow, SessionRow } from "./types";
 
 /**
@@ -76,7 +85,7 @@ export class PullRequestCreationClaims {
  */
 export interface PullRequestRepository {
   getSession(): SessionRow | null;
-  getSessionRepositories(): SessionRepositoryRow[];
+  getSessionRepositories(): SessionRepositoryEntry[];
   updateSessionBranch(sessionId: string, branchName: string): void;
   updateSessionRepositoryBranch(repoOwner: string, repoName: string, branchName: string): void;
   listArtifacts(): ArtifactRow[];
@@ -132,20 +141,24 @@ export class SessionPullRequestService {
     // Re-resolved here even though the handler already validated the target:
     // this is a sandbox-auth security boundary, so the service must not
     // trust its caller (defense in depth).
-    const resolution = resolveSessionRepositoryTarget({
-      requested: input,
-      scalarRepo: { repoOwner: session.repo_owner, repoName: session.repo_name },
-      memberRows: this.deps.repository.getSessionRepositories(),
-    });
-    if (!resolution.ok) {
-      return {
-        kind: "error",
-        status: resolution.reason === "not_member" ? 403 : 400,
-        error: resolution.error,
-      };
+    let target: SessionRepositoryEntry;
+    try {
+      target = resolveSessionRepositoryTarget(input, this.deps.repository.getSessionRepositories());
+    } catch (error) {
+      if (error instanceof RepositoryNotMemberError) {
+        return { kind: "error", status: 403, error: error.message };
+      }
+      if (
+        error instanceof AmbiguousRepositoryTargetError ||
+        error instanceof RepositoryPairValidationError
+      ) {
+        return { kind: "error", status: 400, error: error.message };
+      }
+      throw error;
     }
-    const { memberRow, isPrimary } = resolution;
-    const targetRepo = { repoOwner: resolution.repoOwner, repoName: resolution.repoName };
+    const memberRow = target.row;
+    const isPrimary = target.isPrimary;
+    const targetRepo = { repoOwner: target.repoOwner, repoName: target.repoName };
 
     this.deps.log.info("Creating PR", {
       user_id: input.promptingUserId,

--- a/packages/control-plane/src/session/pull-request-service.ts
+++ b/packages/control-plane/src/session/pull-request-service.ts
@@ -1,8 +1,4 @@
-import {
-  generateBranchName,
-  RepositoryPairValidationError,
-  type SessionArtifact,
-} from "@open-inspect/shared";
+import { generateBranchName, type SessionArtifact } from "@open-inspect/shared";
 import type { Logger } from "../logger";
 import { resolveHeadBranchForPr, sanitizeBranchName } from "../source-control/branch-resolution";
 import {
@@ -14,8 +10,7 @@ import {
 } from "../source-control";
 import { findPrArtifactForRepo } from "./pr-artifacts";
 import {
-  AmbiguousRepositoryTargetError,
-  RepositoryNotMemberError,
+  mapRepositoryTargetError,
   resolveSessionRepositoryTarget,
   type RepoIdentity,
   type SessionRepositoryEntry,
@@ -145,16 +140,9 @@ export class SessionPullRequestService {
     try {
       target = resolveSessionRepositoryTarget(input, this.deps.repository.getSessionRepositories());
     } catch (error) {
-      if (error instanceof RepositoryNotMemberError) {
-        return { kind: "error", status: 403, error: error.message };
-      }
-      if (
-        error instanceof AmbiguousRepositoryTargetError ||
-        error instanceof RepositoryPairValidationError
-      ) {
-        return { kind: "error", status: 400, error: error.message };
-      }
-      throw error;
+      const mapped = mapRepositoryTargetError(error);
+      if (!mapped) throw error;
+      return { kind: "error", ...mapped };
     }
     const memberRow = target.row;
     const isPrimary = target.isPrimary;
@@ -210,11 +198,9 @@ export class SessionPullRequestService {
         owner: targetRepo.repoOwner,
         name: targetRepo.repoName,
       });
-      // Base: requested > target repo's base branch (scalar mirror for
-      // sessions without member rows) > repo default. Behavioral parity with
-      // the session-base injection the HTTP handler used to do.
-      const baseBranch =
-        input.baseBranch || memberRow?.base_branch || session.base_branch || repoInfo.defaultBranch;
+      // Base: requested > the entry's base branch (the row's, or the scalar
+      // mirror's for sessions without member rows) > repo default.
+      const baseBranch = input.baseBranch || target.baseBranch || repoInfo.defaultBranch;
       // The target repo's working branch; member rows written before PR flow
       // existed have a null branch_name while the scalar mirror is set, so
       // the primary falls back to the scalar.

--- a/packages/control-plane/src/session/repository-target.test.ts
+++ b/packages/control-plane/src/session/repository-target.test.ts
@@ -4,6 +4,7 @@ import type { SessionRepositoryRow } from "./repository";
 import {
   AmbiguousRepositoryTargetError,
   buildSessionRepositories,
+  mapRepositoryTargetError,
   RepositoryNotMemberError,
   resolveSessionRepositoryTarget,
 } from "./repository-target";
@@ -31,9 +32,29 @@ const SCALAR = { repoOwner: "acme", repoName: "web" };
 
 describe("buildSessionRepositories", () => {
   it("synthesizes a sole primary member from the scalar mirror when no rows exist", () => {
-    expect(buildSessionRepositories(SCALAR, [])).toEqual([
-      { repoOwner: "acme", repoName: "web", position: 0, isPrimary: true, row: null },
+    expect(buildSessionRepositories({ ...SCALAR, baseBranch: "develop" }, [])).toEqual([
+      {
+        repoOwner: "acme",
+        repoName: "web",
+        position: 0,
+        baseBranch: "develop",
+        isPrimary: true,
+        row: null,
+      },
     ]);
+  });
+
+  it("leaves the synthesized base branch null when the scalar mirror has none", () => {
+    expect(buildSessionRepositories(SCALAR, [])[0].baseBranch).toBeNull();
+  });
+
+  it("takes each entry's base branch from its row", () => {
+    const members = buildSessionRepositories({ ...SCALAR, baseBranch: "ignored" }, [
+      createRow(0, "acme", "web"),
+      createRow(1, "acme", "backend", { base_branch: "develop" }),
+    ]);
+
+    expect(members.map((member) => member.baseBranch)).toEqual(["main", "develop"]);
   });
 
   it("maps rows and marks the scalar-mirror member primary", () => {
@@ -106,5 +127,27 @@ describe("resolveSessionRepositoryTarget", () => {
     expect(() => resolveSessionRepositoryTarget({}, [])).toThrow(
       "Session has no member repositories"
     );
+  });
+});
+
+describe("mapRepositoryTargetError", () => {
+  const members = buildSessionRepositories(SCALAR, []);
+
+  it("maps non-membership to 403", () => {
+    expect(
+      mapRepositoryTargetError(new RepositoryNotMemberError({ repoOwner: "evil", repoName: "x" }))
+    ).toEqual({ status: 403, error: "Repository evil/x is not part of this session" });
+  });
+
+  it("maps ambiguous and half-specified targets to 400", () => {
+    expect(mapRepositoryTargetError(new AmbiguousRepositoryTargetError(members))?.status).toBe(400);
+    expect(mapRepositoryTargetError(new RepositoryPairValidationError("half"))).toEqual({
+      status: 400,
+      error: "half",
+    });
+  });
+
+  it("returns null for unrelated errors so callers rethrow", () => {
+    expect(mapRepositoryTargetError(new Error("boom"))).toBeNull();
   });
 });

--- a/packages/control-plane/src/session/repository-target.test.ts
+++ b/packages/control-plane/src/session/repository-target.test.ts
@@ -1,0 +1,110 @@
+import { RepositoryPairValidationError } from "@open-inspect/shared";
+import { describe, expect, it } from "vitest";
+import type { SessionRepositoryRow } from "./repository";
+import {
+  AmbiguousRepositoryTargetError,
+  buildSessionRepositories,
+  RepositoryNotMemberError,
+  resolveSessionRepositoryTarget,
+} from "./repository-target";
+
+function createRow(
+  position: number,
+  repoOwner: string,
+  repoName: string,
+  overrides: Partial<SessionRepositoryRow> = {}
+): SessionRepositoryRow {
+  return {
+    position,
+    repo_owner: repoOwner,
+    repo_name: repoName,
+    repo_id: position + 1,
+    base_branch: "main",
+    branch_name: null,
+    base_sha: null,
+    current_sha: null,
+    ...overrides,
+  };
+}
+
+const SCALAR = { repoOwner: "acme", repoName: "web" };
+
+describe("buildSessionRepositories", () => {
+  it("synthesizes a sole primary member from the scalar mirror when no rows exist", () => {
+    expect(buildSessionRepositories(SCALAR, [])).toEqual([
+      { repoOwner: "acme", repoName: "web", position: 0, isPrimary: true, row: null },
+    ]);
+  });
+
+  it("maps rows and marks the scalar-mirror member primary", () => {
+    const rows = [createRow(0, "acme", "web"), createRow(1, "acme", "backend")];
+
+    const members = buildSessionRepositories(SCALAR, rows);
+
+    expect(members).toHaveLength(2);
+    expect(members[0]).toMatchObject({ repoOwner: "acme", repoName: "web", isPrimary: true });
+    expect(members[0].row).toBe(rows[0]);
+    expect(members[1]).toMatchObject({ repoOwner: "acme", repoName: "backend", isPrimary: false });
+  });
+
+  it("marks primary by scalar identity, case-insensitively, not by position", () => {
+    const members = buildSessionRepositories({ repoOwner: "Acme", repoName: "Backend" }, [
+      createRow(0, "acme", "web"),
+      createRow(1, "acme", "backend"),
+    ]);
+
+    expect(members.map((member) => member.isPrimary)).toEqual([false, true]);
+  });
+});
+
+describe("resolveSessionRepositoryTarget", () => {
+  const members = buildSessionRepositories(SCALAR, [
+    createRow(0, "acme", "web"),
+    createRow(1, "acme", "backend"),
+  ]);
+
+  it("returns the sole member when no repo is requested", () => {
+    const sole = buildSessionRepositories(SCALAR, []);
+
+    expect(resolveSessionRepositoryTarget({}, sole)).toBe(sole[0]);
+  });
+
+  it("throws AmbiguousRepositoryTargetError listing members when no repo is requested", () => {
+    expect(() => resolveSessionRepositoryTarget({}, members)).toThrow(
+      new AmbiguousRepositoryTargetError(members)
+    );
+    expect(() => resolveSessionRepositoryTarget({}, members)).toThrow(
+      "This session spans multiple repositories — specify repoOwner and repoName (one of: acme/web, acme/backend)"
+    );
+  });
+
+  it("propagates RepositoryPairValidationError for a half-specified pair", () => {
+    expect(() => resolveSessionRepositoryTarget({ repoOwner: "acme" }, members)).toThrow(
+      RepositoryPairValidationError
+    );
+  });
+
+  it("matches case-insensitively and returns the member with canonical casing", () => {
+    const target = resolveSessionRepositoryTarget(
+      { repoOwner: "Acme", repoName: "Backend" },
+      members
+    );
+
+    expect(target).toBe(members[1]);
+  });
+
+  it("throws RepositoryNotMemberError for a repo outside the session", () => {
+    expect(() =>
+      resolveSessionRepositoryTarget({ repoOwner: "evil", repoName: "exfil" }, members)
+    ).toThrow("Repository evil/exfil is not part of this session");
+    expect(() =>
+      resolveSessionRepositoryTarget({ repoOwner: "evil", repoName: "exfil" }, members)
+    ).toThrow(RepositoryNotMemberError);
+  });
+
+  it("rejects an empty member list as a caller contract violation", () => {
+    expect(() => resolveSessionRepositoryTarget({}, [])).toThrow(
+      "Session has no member repositories"
+    );
+  });
+});

--- a/packages/control-plane/src/session/repository-target.ts
+++ b/packages/control-plane/src/session/repository-target.ts
@@ -1,7 +1,4 @@
-import {
-  normalizeOptionalRepositoryPair,
-  RepositoryPairValidationError,
-} from "@open-inspect/shared";
+import { normalizeOptionalRepositoryPair } from "@open-inspect/shared";
 import type { SessionRepositoryRow } from "./repository";
 
 /** A repository identified by owner and name (canonical casing unless noted). */
@@ -17,89 +14,106 @@ export function repoIdentityEquals(a: RepoIdentity, b: RepoIdentity): boolean {
   );
 }
 
-export type SessionRepositoryTargetResolution =
-  | {
-      ok: true;
-      repoOwner: string;
-      repoName: string;
-      /** The matched member row; null for sessions predating member rows. */
-      memberRow: SessionRepositoryRow | null;
-      /** Whether the target is the session's primary (scalar-mirror) repo. */
-      isPrimary: boolean;
-    }
-  | { ok: false; reason: "half_specified" | "ambiguous" | "not_member"; error: string };
+/** One member repository of a session, with its role and backing storage. */
+export interface SessionRepositoryEntry {
+  repoOwner: string;
+  repoName: string;
+  position: number;
+  /** Whether this member is the session's primary (scalar-mirror) repo. */
+  isPrimary: boolean;
+  /** Backing member row; null when synthesized from the scalar mirror. */
+  row: SessionRepositoryRow | null;
+}
+
+/**
+ * Build a session's member list: its rows, or — for sessions predating the
+ * member table — a one-entry list synthesized from the scalar mirror. The
+ * single home of that fallback rule. Primary means identity-equal to the
+ * scalar mirror (the mirror is what legacy consumers read), which coincides
+ * with position 0 by the row-0-mirrors-scalars invariant.
+ */
+export function buildSessionRepositories(
+  scalarRepo: RepoIdentity,
+  rows: SessionRepositoryRow[]
+): SessionRepositoryEntry[] {
+  if (rows.length === 0) {
+    return [
+      {
+        repoOwner: scalarRepo.repoOwner,
+        repoName: scalarRepo.repoName,
+        position: 0,
+        isPrimary: true,
+        row: null,
+      },
+    ];
+  }
+  return rows.map((row) => ({
+    repoOwner: row.repo_owner,
+    repoName: row.repo_name,
+    position: row.position,
+    isPrimary: repoIdentityEquals(
+      { repoOwner: row.repo_owner, repoName: row.repo_name },
+      scalarRepo
+    ),
+    row,
+  }));
+}
+
+/** The requested repo names a repository outside the session's member list. */
+export class RepositoryNotMemberError extends Error {
+  constructor(requested: RepoIdentity) {
+    super(`Repository ${requested.repoOwner}/${requested.repoName} is not part of this session`);
+    this.name = "RepositoryNotMemberError";
+  }
+}
+
+/** No repo was requested and the session has more than one member. */
+export class AmbiguousRepositoryTargetError extends Error {
+  constructor(members: SessionRepositoryEntry[]) {
+    const memberList = members.map((member) => `${member.repoOwner}/${member.repoName}`).join(", ");
+    super(
+      `This session spans multiple repositories — specify repoOwner and repoName (one of: ${memberList})`
+    );
+    this.name = "AmbiguousRepositoryTargetError";
+  }
+}
 
 /**
  * Resolve a requested target repository against a session's member list.
- * The single model for PR/push target resolution — normalization (via
- * normalizeOptionalRepositoryPair), membership, and primary fallback live
- * here so callers only translate the typed result into their error shape.
- * Naming a repo outside the session is "not_member": the PR route is
- * reachable with sandbox auth, so membership is a security boundary, not
- * just input validation.
+ * The single model for PR/push target resolution. Matching is
+ * case-insensitive (via normalizeOptionalRepositoryPair); the returned
+ * member carries the list's canonical casing.
  *
- * Sessions predating member rows resolve against the scalar mirror alone.
- * An unspecified target is only valid when the session has a sole member.
- * Matching is case-insensitive; the returned identity carries the member
- * list's canonical casing.
+ * Throws instead of returning an error shape — callers own the mapping:
+ * - RepositoryPairValidationError (propagated from the shared helper) when
+ *   only one of repoOwner/repoName is given;
+ * - AmbiguousRepositoryTargetError when no repo is requested and the
+ *   session has several members;
+ * - RepositoryNotMemberError when the requested repo is not a member — a
+ *   security boundary, not just input validation: the PR route is reachable
+ *   with sandbox auth.
+ *
+ * `members` must be non-empty (callers reject repo-less sessions first).
  */
-export function resolveSessionRepositoryTarget(input: {
-  requested: { repoOwner?: string | null; repoName?: string | null };
-  scalarRepo: RepoIdentity;
-  memberRows: SessionRepositoryRow[];
-}): SessionRepositoryTargetResolution {
-  let requested: RepoIdentity | null;
-  try {
-    requested = normalizeOptionalRepositoryPair(input.requested);
-  } catch (error) {
-    if (error instanceof RepositoryPairValidationError) {
-      return { ok: false, reason: "half_specified", error: error.message };
-    }
-    throw error;
+export function resolveSessionRepositoryTarget(
+  requested: { repoOwner?: string | null; repoName?: string | null },
+  members: SessionRepositoryEntry[]
+): SessionRepositoryEntry {
+  if (members.length === 0) {
+    throw new Error("Session has no member repositories");
   }
 
-  const members: Array<{ identity: RepoIdentity; row: SessionRepositoryRow | null }> =
-    input.memberRows.length > 0
-      ? input.memberRows.map((row) => ({
-          identity: { repoOwner: row.repo_owner, repoName: row.repo_name },
-          row,
-        }))
-      : [{ identity: input.scalarRepo, row: null }];
-
-  if (!requested) {
+  const pair = normalizeOptionalRepositoryPair(requested);
+  if (!pair) {
     if (members.length > 1) {
-      const memberList = members
-        .map((member) => `${member.identity.repoOwner}/${member.identity.repoName}`)
-        .join(", ");
-      return {
-        ok: false,
-        reason: "ambiguous",
-        error: `This session spans multiple repositories — specify repoOwner and repoName (one of: ${memberList})`,
-      };
+      throw new AmbiguousRepositoryTargetError(members);
     }
-    const [sole] = members;
-    return {
-      ok: true,
-      repoOwner: sole.identity.repoOwner,
-      repoName: sole.identity.repoName,
-      memberRow: sole.row,
-      isPrimary: repoIdentityEquals(sole.identity, input.scalarRepo),
-    };
+    return members[0];
   }
 
-  const match = members.find((member) => repoIdentityEquals(member.identity, requested));
+  const match = members.find((member) => repoIdentityEquals(member, pair));
   if (!match) {
-    return {
-      ok: false,
-      reason: "not_member",
-      error: `Repository ${requested.repoOwner}/${requested.repoName} is not part of this session`,
-    };
+    throw new RepositoryNotMemberError(pair);
   }
-  return {
-    ok: true,
-    repoOwner: match.identity.repoOwner,
-    repoName: match.identity.repoName,
-    memberRow: match.row,
-    isPrimary: repoIdentityEquals(match.identity, input.scalarRepo),
-  };
+  return match;
 }

--- a/packages/control-plane/src/session/repository-target.ts
+++ b/packages/control-plane/src/session/repository-target.ts
@@ -1,4 +1,7 @@
-import { normalizeOptionalRepositoryPair } from "@open-inspect/shared";
+import {
+  normalizeOptionalRepositoryPair,
+  RepositoryPairValidationError,
+} from "@open-inspect/shared";
 import type { SessionRepositoryRow } from "./repository";
 
 /** A repository identified by owner and name (canonical casing unless noted). */
@@ -19,6 +22,13 @@ export interface SessionRepositoryEntry {
   repoOwner: string;
   repoName: string;
   position: number;
+  /**
+   * The entry's base branch: the row's, or the scalar mirror's for
+   * synthesized entries. Null only for legacy sessions without a stored
+   * base branch — consumers apply their own default ("main" for state and
+   * spawn, the repo's default branch for PR creation).
+   */
+  baseBranch: string | null;
   /** Whether this member is the session's primary (scalar-mirror) repo. */
   isPrimary: boolean;
   /** Backing member row; null when synthesized from the scalar mirror. */
@@ -33,7 +43,7 @@ export interface SessionRepositoryEntry {
  * with position 0 by the row-0-mirrors-scalars invariant.
  */
 export function buildSessionRepositories(
-  scalarRepo: RepoIdentity,
+  scalarRepo: RepoIdentity & { baseBranch?: string | null },
   rows: SessionRepositoryRow[]
 ): SessionRepositoryEntry[] {
   if (rows.length === 0) {
@@ -42,6 +52,7 @@ export function buildSessionRepositories(
         repoOwner: scalarRepo.repoOwner,
         repoName: scalarRepo.repoName,
         position: 0,
+        baseBranch: scalarRepo.baseBranch ?? null,
         isPrimary: true,
         row: null,
       },
@@ -51,6 +62,7 @@ export function buildSessionRepositories(
     repoOwner: row.repo_owner,
     repoName: row.repo_name,
     position: row.position,
+    baseBranch: row.base_branch,
     isPrimary: repoIdentityEquals(
       { repoOwner: row.repo_owner, repoName: row.repo_name },
       scalarRepo
@@ -116,4 +128,24 @@ export function resolveSessionRepositoryTarget(
     throw new RepositoryNotMemberError(pair);
   }
   return match;
+}
+
+/**
+ * Map a resolveSessionRepositoryTarget throw to its status/message shape,
+ * or null for unrelated errors (callers rethrow those). Shared by the HTTP
+ * handler and the PR service so the two mappings cannot drift — 403 for
+ * non-membership (the security boundary), 400 for a malformed or ambiguous
+ * target.
+ */
+export function mapRepositoryTargetError(error: unknown): { status: number; error: string } | null {
+  if (error instanceof RepositoryNotMemberError) {
+    return { status: 403, error: error.message };
+  }
+  if (
+    error instanceof AmbiguousRepositoryTargetError ||
+    error instanceof RepositoryPairValidationError
+  ) {
+    return { status: 400, error: error.message };
+  }
+  return null;
 }

--- a/packages/control-plane/src/session/repository.test.ts
+++ b/packages/control-plane/src/session/repository.test.ts
@@ -268,7 +268,7 @@ describe("SessionRepository", () => {
     });
   });
 
-  describe("getSessionRepositories", () => {
+  describe("getSessionRepositoryRows", () => {
     it("returns rows ordered by position", () => {
       const rows = [
         { position: 0, repo_owner: "acme", repo_name: "frontend" },
@@ -276,11 +276,11 @@ describe("SessionRepository", () => {
       ];
       mock.setData(`SELECT * FROM session_repositories ORDER BY position`, rows);
 
-      expect(repo.getSessionRepositories()).toEqual(rows);
+      expect(repo.getSessionRepositoryRows()).toEqual(rows);
     });
 
     it("returns an empty list for pre-feature sessions", () => {
-      expect(repo.getSessionRepositories()).toEqual([]);
+      expect(repo.getSessionRepositoryRows()).toEqual([]);
     });
   });
 

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -29,6 +29,7 @@ import {
   type EventListCursor,
   type EventTimelineCursor,
 } from "./event-cursor";
+import { buildSessionRepositories, type SessionRepositoryEntry } from "./repository-target";
 
 type TokenEvent = Extract<SandboxEvent, { type: "token" }>;
 type ExecutionCompleteEvent = Extract<SandboxEvent, { type: "execution_complete" }>;
@@ -397,9 +398,23 @@ export class SessionRepository {
     }
   }
 
-  getSessionRepositories(): SessionRepositoryRow[] {
+  getSessionRepositoryRows(): SessionRepositoryRow[] {
     const result = this.sql.exec(`SELECT * FROM session_repositories ORDER BY position`);
     return this.rows<SessionRepositoryRow>(result);
+  }
+
+  /**
+   * The session's repositories (see buildSessionRepositories for the
+   * scalar-mirror fallback). Empty only for sessions without a repository
+   * context.
+   */
+  getSessionRepositories(): SessionRepositoryEntry[] {
+    const session = this.getSession();
+    if (!session?.repo_owner || !session.repo_name) return [];
+    return buildSessionRepositories(
+      { repoOwner: session.repo_owner, repoName: session.repo_name },
+      this.getSessionRepositoryRows()
+    );
   }
 
   updateSessionRepositoryBranch(repoOwner: string, repoName: string, branchName: string): void {

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -412,7 +412,11 @@ export class SessionRepository {
     const session = this.getSession();
     if (!session?.repo_owner || !session.repo_name) return [];
     return buildSessionRepositories(
-      { repoOwner: session.repo_owner, repoName: session.repo_name },
+      {
+        repoOwner: session.repo_owner,
+        repoName: session.repo_name,
+        baseBranch: session.base_branch,
+      },
       this.getSessionRepositoryRows()
     );
   }


### PR DESCRIPTION
## Summary

Follow-up to #906, addressing the structural review discussion there (single target-resolution model, `ok:true/false` union smell, `getPrUrlLookup`/state-projection duplication). No behavior change — pure consolidation.

### One home for the member-list rule

The "members = `session_repositories` rows, or a one-entry list synthesized from the scalar mirror" rule existed in three places: `resolveSessionRepositoryTarget`, the DO's `getSessionRepositoryStates`, and implicitly in the PR service. It now lives once:

- **`SessionRepositoryEntry`** — `{repoOwner, repoName, position, isPrimary, row | null}` (`row: null` = synthesized from the scalar mirror).
- **`buildSessionRepositories(scalarRepo, rows)`** builds the list; **`SessionRepository.getSessionRepositories()`** is the accessor (it has both the session row and the member rows, so it needs no inputs). The raw-row accessor is renamed **`getSessionRepositoryRows()`**; the spawn path stays on raw rows deliberately (spawn must not synthesize a scalar entry — the `len > 1` wire gating relies on it).
- The DO's `getSessionRepositoryStates` collapses from two branches to a single `.map()` over entries.

### Primary rule unified

The DO projection previously used `position === 0` while the resolver/service compared identity against the scalar mirror. They agree today only by the #905 row-0-mirrors-scalars invariant. `buildSessionRepositories` now owns the one rule: **scalar-identity equality** (the mirror is what legacy consumers read). Pinned by a direct test.

### Resolver throws domain errors

`resolveSessionRepositoryTarget(requested, entries)` returns the matched entry (subsuming the old `memberRow`/`isPrimary` fields) and throws instead of returning an `ok:true/false` union:

- `RepositoryPairValidationError` — propagated uncaught from `normalizeOptionalRepositoryPair` (half-specified pair), matching the `session-create.ts` precedent
- `AmbiguousRepositoryTargetError` — no target on a multi-repo session
- `RepositoryNotMemberError` — target outside the session (the sandbox-auth security boundary)

The HTTP handler maps these to 400/400/403 in one try/catch; the PR service maps the same errors into its `CreatePullRequestResult` shape (defense in depth unchanged). Deliberately **not** `HttpError`: that's mapped only in the worker-level router dispatch — the DO's internal routes have no central catch, and `session/` shouldn't know HTTP statuses.

## Compatibility

- All HTTP statuses, error messages, WS state shapes, and wire payloads are byte-identical; existing handler/service/integration tests pass unmodified (only mock plumbing changed).
- Deferred, per #906 discussion: whether `PullRequestCreationClaims` stays (the guard race it closes predates multi-repo — the double artifact scan dates to #109). Untouched here.

## Testing

- `npm run typecheck` (both passes), `npm run lint` — clean
- Unit: **1585 passed** (+9: new `repository-target.test.ts` covering synthesis, the scalar-equality primary rule, and all three throw paths)
- Integration: **455 passed** (unchanged — behavior parity)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced pull request creation for multi-repository sessions with improved repository target selection (case-insensitive matching and better defaulting when only one repository is available).
* **Bug Fixes**
  * Improved error handling and messaging when the requested repository is ambiguous, incomplete, or not part of the session.
  * More consistent session repository fallback behavior and base branch defaults for PR creation.
* **Tests**
  * Updated handler and service tests to use derived session repository members for more realistic coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->