### PR TITLE
feat(control-plane): launch-unit secrets fold + cap enforcement

### DIFF
--- a/packages/control-plane/src/db/secrets-validation.test.ts
+++ b/packages/control-plane/src/db/secrets-validation.test.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  auditSecretsMerge,
+  formatSecretsAttribution,
+  MAX_COMBINED_SECRETS_BYTES,
+  mergeSecretSources,
   normalizeKey,
+  parseSecretsCapMode,
+  SecretsCapExceededError,
+  SecretsValidationError,
   validateKey,
   validateValue,
-  mergeSecrets,
-  SecretsValidationError,
   MAX_VALUE_SIZE,
   MAX_KEY_LENGTH,
 } from "./secrets-validation";
@@ -70,56 +75,193 @@ describe("validateValue", () => {
   });
 });
 
-describe("mergeSecrets", () => {
+describe("mergeSecretSources", () => {
+  // The old two-arg mergeSecrets(global, repo) is the two-source fold below.
   it("merges global and repo secrets", () => {
-    const result = mergeSecrets({ A: "global-a" }, { B: "repo-b" });
+    const result = mergeSecretSources([
+      { label: "global", secrets: { A: "global-a" } },
+      { label: "acme/web", secrets: { B: "repo-b" } },
+    ]);
     expect(result.merged).toEqual({ A: "global-a", B: "repo-b" });
     expect(result.exceedsLimit).toBe(false);
   });
 
-  it("repo overrides global for same key", () => {
-    const result = mergeSecrets({ FOO: "global" }, { FOO: "repo" });
+  it("later sources override earlier ones for the same key", () => {
+    const result = mergeSecretSources([
+      { label: "global", secrets: { FOO: "global" } },
+      { label: "acme/web", secrets: { FOO: "repo" } },
+    ]);
     expect(result.merged).toEqual({ FOO: "repo" });
   });
 
-  it("repo overrides global case-insensitively", () => {
-    const result = mergeSecrets({ foo: "global" }, { FOO: "repo" });
+  it("overrides case-insensitively", () => {
+    const result = mergeSecretSources([
+      { label: "global", secrets: { foo: "global" } },
+      { label: "acme/web", secrets: { FOO: "repo" } },
+    ]);
     expect(result.merged).toEqual({ FOO: "repo" });
   });
 
-  it("handles empty global", () => {
-    const result = mergeSecrets({}, { X: "val" });
-    expect(result.merged).toEqual({ X: "val" });
+  it("folds members lowest-precedence-first so the primary (last) wins", () => {
+    const result = mergeSecretSources([
+      { label: "global", secrets: { SHARED: "g", ONLY_GLOBAL: "g" } },
+      { label: "acme/backend", secrets: { SHARED: "backend", ONLY_BACKEND: "b" } },
+      { label: "acme/web", secrets: { SHARED: "web", ONLY_WEB: "w" } },
+    ]);
+    expect(result.merged).toEqual({
+      SHARED: "web",
+      ONLY_GLOBAL: "g",
+      ONLY_BACKEND: "b",
+      ONLY_WEB: "w",
+    });
   });
 
-  it("handles empty repo", () => {
-    const result = mergeSecrets({ X: "val" }, {});
-    expect(result.merged).toEqual({ X: "val" });
+  it("handles empty sources", () => {
+    expect(mergeSecretSources([]).merged).toEqual({});
+    expect(mergeSecretSources([{ label: "global", secrets: {} }]).totalBytes).toBe(0);
   });
 
-  it("handles both empty", () => {
-    const result = mergeSecrets({}, {});
-    expect(result.merged).toEqual({});
-    expect(result.totalBytes).toBe(0);
-    expect(result.exceedsLimit).toBe(false);
-  });
-
-  it("calculates total bytes correctly", () => {
-    const result = mergeSecrets({ A: "hello" }, { B: "world" });
-    // "hello" = 5 bytes, "world" = 5 bytes
+  it("calculates total bytes across the merged payload", () => {
+    const result = mergeSecretSources([
+      { label: "global", secrets: { A: "hello" } },
+      { label: "acme/web", secrets: { B: "world" } },
+    ]);
     expect(result.totalBytes).toBe(10);
+    expect(result.maxCombinedBytes).toBe(MAX_COMBINED_SECRETS_BYTES);
   });
 
-  it("reports exceedsLimit when over threshold", () => {
+  it("reports exceedsLimit above the threshold and not at the boundary", () => {
     const big = "x".repeat(100);
-    const result = mergeSecrets({ A: big }, { B: big }, 150);
-    expect(result.exceedsLimit).toBe(true);
-    expect(result.totalBytes).toBe(200);
+    const over = mergeSecretSources(
+      [
+        { label: "global", secrets: { A: big } },
+        { label: "acme/web", secrets: { B: big } },
+      ],
+      150
+    );
+    expect(over.exceedsLimit).toBe(true);
+    expect(over.totalBytes).toBe(200);
+
+    const boundary = mergeSecretSources([{ label: "global", secrets: { A: "12345" } }], 5);
+    expect(boundary.totalBytes).toBe(5);
+    expect(boundary.exceedsLimit).toBe(false);
   });
 
-  it("does not report exceedsLimit at exactly the boundary", () => {
-    const result = mergeSecrets({ A: "12345" }, {}, 5);
-    expect(result.totalBytes).toBe(5);
-    expect(result.exceedsLimit).toBe(false);
+  it("attributes surviving bytes and keys to the winning source, omitting empty sources", () => {
+    const result = mergeSecretSources([
+      { label: "global", secrets: { SHARED: "g", ONLY_GLOBAL: "gg" } },
+      { label: "acme/empty", secrets: {} },
+      { label: "acme/web", secrets: { SHARED: "webwin" } },
+    ]);
+    // global keeps ONLY_GLOBAL (2 bytes); web owns SHARED (6 bytes); empty omitted.
+    expect(result.attribution).toEqual([
+      { label: "global", keyCount: 1, bytes: 2 },
+      { label: "acme/web", keyCount: 1, bytes: 6 },
+    ]);
+  });
+
+  it("records cross-source collisions with winner and loser labels", () => {
+    const result = mergeSecretSources([
+      { label: "global", secrets: { SHARED: "g" } },
+      { label: "acme/backend", secrets: { SHARED: "b" } },
+      { label: "acme/web", secrets: { SHARED: "w", UNIQUE: "u" } },
+    ]);
+    expect(result.collisions).toEqual([
+      { key: "SHARED", winner: "acme/backend", loser: "global" },
+      { key: "SHARED", winner: "acme/web", loser: "acme/backend" },
+    ]);
+  });
+
+  it("reports no collisions when keys are disjoint", () => {
+    const result = mergeSecretSources([
+      { label: "global", secrets: { A: "1" } },
+      { label: "acme/web", secrets: { B: "2" } },
+    ]);
+    expect(result.collisions).toEqual([]);
+  });
+});
+
+describe("parseSecretsCapMode", () => {
+  it("returns enforce only for the literal 'enforce'", () => {
+    expect(parseSecretsCapMode("enforce")).toBe("enforce");
+  });
+
+  it("defaults to warn for unset or unknown values", () => {
+    expect(parseSecretsCapMode(undefined)).toBe("warn");
+    expect(parseSecretsCapMode("warn")).toBe("warn");
+    expect(parseSecretsCapMode("ENFORCE")).toBe("warn");
+  });
+});
+
+describe("formatSecretsAttribution", () => {
+  it("renders sources largest-first with byte and key counts", () => {
+    expect(
+      formatSecretsAttribution([
+        { label: "global", keyCount: 1, bytes: 10 },
+        { label: "acme/web", keyCount: 2, bytes: 100 },
+      ])
+    ).toBe("acme/web (100 bytes, 2 keys), global (10 bytes, 1 keys)");
+  });
+});
+
+describe("auditSecretsMerge", () => {
+  function createLog() {
+    return { warn: vi.fn(), error: vi.fn() };
+  }
+
+  it("logs each cross-source collision as a warning", () => {
+    const log = createLog();
+    const merge = mergeSecretSources([
+      { label: "global", secrets: { SHARED: "g" } },
+      { label: "acme/web", secrets: { SHARED: "w" } },
+    ]);
+    auditSecretsMerge({ merge, mode: "warn", log });
+    expect(log.warn).toHaveBeenCalledWith(
+      "secrets.key_collision",
+      expect.objectContaining({ key: "SHARED", winner: "acme/web", overridden: "global" })
+    );
+  });
+
+  it("warns but does not throw for an oversized payload in warn mode", () => {
+    const log = createLog();
+    const merge = mergeSecretSources([{ label: "global", secrets: { A: "x".repeat(10) } }], 5);
+    expect(() => auditSecretsMerge({ merge, mode: "warn", log })).not.toThrow();
+    expect(log.warn).toHaveBeenCalledWith(
+      "secrets.cap_exceeded",
+      expect.objectContaining({ enforcement: "warn", total_bytes: 10, max_bytes: 5 })
+    );
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it("throws SecretsCapExceededError and logs an error in enforce mode", () => {
+    const log = createLog();
+    const merge = mergeSecretSources([{ label: "global", secrets: { A: "x".repeat(10) } }], 5);
+    expect(() => auditSecretsMerge({ merge, mode: "enforce", log })).toThrow(
+      SecretsCapExceededError
+    );
+    expect(log.error).toHaveBeenCalledWith(
+      "secrets.cap_exceeded",
+      expect.objectContaining({ enforcement: "enforce" })
+    );
+  });
+
+  it("does not emit a cap log when under the limit", () => {
+    const log = createLog();
+    const merge = mergeSecretSources([{ label: "global", secrets: { A: "ok" } }]);
+    auditSecretsMerge({ merge, mode: "enforce", log });
+    expect(log.warn).not.toHaveBeenCalled();
+    expect(log.error).not.toHaveBeenCalled();
+  });
+});
+
+describe("SecretsCapExceededError", () => {
+  it("names the largest contributing scopes in its message", () => {
+    const error = new SecretsCapExceededError(200, 150, [
+      { label: "global", keyCount: 1, bytes: 40 },
+      { label: "acme/web", keyCount: 3, bytes: 160 },
+    ]);
+    expect(error.message).toContain("200 bytes");
+    expect(error.message).toContain("150-byte limit");
+    expect(error.message).toContain("acme/web (160 bytes, 3 keys)");
   });
 });

--- a/packages/control-plane/src/db/secrets-validation.ts
+++ b/packages/control-plane/src/db/secrets-validation.ts
@@ -52,32 +52,184 @@ export function validateValue(value: string): void {
     throw new SecretsValidationError(`Value exceeds ${MAX_VALUE_SIZE} bytes`);
 }
 
+/** Combined byte ceiling for a session's merged secret payload (128 KiB). */
+export const MAX_COMBINED_SECRETS_BYTES = 131072;
+
+/** A named contributor to a session's secret set, lowest precedence first. */
+export interface SecretSource {
+  /** Stable label for byte attribution and collision logs (e.g. "global", "acme/web"). */
+  label: string;
+  secrets: Record<string, string>;
+}
+
+/** One source's contribution to the final merged payload (after overrides). */
+export interface SecretSourceAttribution {
+  label: string;
+  /** Keys this source owns in the merged payload. */
+  keyCount: number;
+  /** Bytes those owned keys' values contribute to the payload. */
+  bytes: number;
+}
+
+/** A key defined by more than one source; the higher-precedence source wins. */
+export interface SecretKeyCollision {
+  key: string;
+  /** Label of the source whose value is used. */
+  winner: string;
+  /** Label of the overridden source. */
+  loser: string;
+}
+
+export interface MergedSecrets {
+  merged: Record<string, string>;
+  totalBytes: number;
+  maxCombinedBytes: number;
+  exceedsLimit: boolean;
+  /** Per-source contribution, in input (lowest-first) order, sources with keys only. */
+  attribution: SecretSourceAttribution[];
+  /** Cross-source key collisions, in the order they were resolved. */
+  collisions: SecretKeyCollision[];
+}
+
 /**
- * Merge global and repo secrets. Repo keys override global keys (case-insensitive).
- * Returns the merged record, total byte size, and whether the combined payload exceeds the limit.
+ * Fold an ordered list of secret sources into one payload. Sources are given
+ * lowest precedence first; a later source's key overrides (case-insensitively)
+ * an earlier one's — so `[global, repoB, repoA]` lets repoA win, which is how
+ * the launch-unit fold passes the primary member last (design §6.4). Reports
+ * per-source byte attribution and cross-source collisions for the cap-check and
+ * collision warnings; the pure merge stays identical to the old two-arg
+ * `mergeSecrets(global, repo)` for the single-source-plus-global case.
  */
-export function mergeSecrets(
-  global: Record<string, string>,
-  repo: Record<string, string>,
-  maxCombinedBytes = 131072
-): { merged: Record<string, string>; totalBytes: number; exceedsLimit: boolean } {
+export function mergeSecretSources(
+  sources: SecretSource[],
+  maxCombinedBytes = MAX_COMBINED_SECRETS_BYTES
+): MergedSecrets {
   const merged: Record<string, string> = {};
+  const owner = new Map<string, string>(); // normalized key -> winning source label
+  const collisions: SecretKeyCollision[] = [];
 
-  // Add global secrets first
-  for (const [key, value] of Object.entries(global)) {
-    merged[normalizeKey(key)] = value;
-  }
-
-  // Repo secrets override global
-  for (const [key, value] of Object.entries(repo)) {
-    merged[normalizeKey(key)] = value;
+  for (const source of sources) {
+    for (const [rawKey, value] of Object.entries(source.secrets)) {
+      const key = normalizeKey(rawKey);
+      const prevOwner = owner.get(key);
+      if (prevOwner !== undefined && prevOwner !== source.label) {
+        collisions.push({ key, winner: source.label, loser: prevOwner });
+      }
+      merged[key] = value;
+      owner.set(key, source.label);
+    }
   }
 
   const encoder = new TextEncoder();
+  const bytesByLabel = new Map<string, number>();
+  const keysByLabel = new Map<string, number>();
   let totalBytes = 0;
-  for (const value of Object.values(merged)) {
-    totalBytes += encoder.encode(value).length;
+  for (const [key, value] of Object.entries(merged)) {
+    const bytes = encoder.encode(value).length;
+    totalBytes += bytes;
+    const label = owner.get(key)!;
+    bytesByLabel.set(label, (bytesByLabel.get(label) ?? 0) + bytes);
+    keysByLabel.set(label, (keysByLabel.get(label) ?? 0) + 1);
   }
 
-  return { merged, totalBytes, exceedsLimit: totalBytes > maxCombinedBytes };
+  // Attribution follows input order; a source that owns no surviving key is omitted.
+  const emitted = new Set<string>();
+  const attribution: SecretSourceAttribution[] = [];
+  for (const source of sources) {
+    if (emitted.has(source.label)) continue;
+    emitted.add(source.label);
+    const keyCount = keysByLabel.get(source.label) ?? 0;
+    if (keyCount === 0) continue;
+    attribution.push({ label: source.label, keyCount, bytes: bytesByLabel.get(source.label) ?? 0 });
+  }
+
+  return {
+    merged,
+    totalBytes,
+    maxCombinedBytes,
+    exceedsLimit: totalBytes > maxCombinedBytes,
+    attribution,
+    collisions,
+  };
+}
+
+/**
+ * Cap enforcement mode. `warn` logs an oversized payload and proceeds (today's
+ * behavior plus telemetry); `enforce` rejects the spawn/build. Staged warn-first
+ * per the rollout plan, flipped to `enforce` before the Phase-1 gate.
+ */
+export type SecretsCapMode = "warn" | "enforce";
+
+export function parseSecretsCapMode(value: string | undefined): SecretsCapMode {
+  return value === "enforce" ? "enforce" : "warn";
+}
+
+/** Thrown in `enforce` mode when a merged payload exceeds the combined cap. */
+export class SecretsCapExceededError extends Error {
+  constructor(
+    readonly totalBytes: number,
+    readonly maxCombinedBytes: number,
+    readonly attribution: SecretSourceAttribution[]
+  ) {
+    super(
+      `Combined secrets payload is ${totalBytes} bytes, over the ${maxCombinedBytes}-byte limit. ` +
+        `Reduce secrets in: ${formatSecretsAttribution(attribution)}.`
+    );
+    this.name = "SecretsCapExceededError";
+  }
+}
+
+/** Render attribution largest-first for a cap error/log (never includes values). */
+export function formatSecretsAttribution(attribution: SecretSourceAttribution[]): string {
+  return [...attribution]
+    .sort((a, b) => b.bytes - a.bytes)
+    .map((entry) => `${entry.label} (${entry.bytes} bytes, ${entry.keyCount} keys)`)
+    .join(", ");
+}
+
+interface SecretsAuditLog {
+  warn(message: string, data?: Record<string, unknown>): void;
+  error(message: string, data?: Record<string, unknown>): void;
+}
+
+/**
+ * Log a merged payload's cross-source collisions and cap decision, and — in
+ * `enforce` mode — throw `SecretsCapExceededError` when over the limit. Shared
+ * by the spawn path (`getUserEnvVars`) and the repo-image build planner so both
+ * apply the cap identically. In `warn` mode nothing is thrown; the caller keeps
+ * using the oversized payload.
+ */
+export function auditSecretsMerge(params: {
+  merge: MergedSecrets;
+  mode: SecretsCapMode;
+  log: SecretsAuditLog;
+  context?: Record<string, unknown>;
+}): void {
+  const { merge, mode, log, context = {} } = params;
+  for (const collision of merge.collisions) {
+    log.warn("secrets.key_collision", {
+      key: collision.key,
+      winner: collision.winner,
+      overridden: collision.loser,
+      ...context,
+    });
+  }
+  if (!merge.exceedsLimit) return;
+
+  const fields = {
+    total_bytes: merge.totalBytes,
+    max_bytes: merge.maxCombinedBytes,
+    enforcement: mode,
+    attribution: merge.attribution.map((entry) => ({
+      scope: entry.label,
+      bytes: entry.bytes,
+      keys: entry.keyCount,
+    })),
+    ...context,
+  };
+  if (mode === "enforce") {
+    log.error("secrets.cap_exceeded", fields);
+    throw new SecretsCapExceededError(merge.totalBytes, merge.maxCombinedBytes, merge.attribution);
+  }
+  log.warn("secrets.cap_exceeded", fields);
 }

--- a/packages/control-plane/src/repo-images/planner.ts
+++ b/packages/control-plane/src/repo-images/planner.ts
@@ -1,7 +1,11 @@
 import { resolveBuildTimeoutSeconds } from "@open-inspect/shared";
 import { GlobalSecretsStore } from "../db/global-secrets";
 import { RepoSecretsStore } from "../db/repo-secrets";
-import { mergeSecrets } from "../db/secrets-validation";
+import {
+  auditSecretsMerge,
+  mergeSecretSources,
+  parseSecretsCapMode,
+} from "../db/secrets-validation";
 import { createLogger, type CorrelationContext } from "../logger";
 import { resolveSandboxSettings } from "../session/integration-settings-resolution";
 import {
@@ -228,21 +232,30 @@ export class RepoImageBuildPlanner {
       });
     }
 
-    const { merged, totalBytes, exceedsLimit } = mergeSecrets(globalSecrets, repoSecrets);
-    if (Object.keys(merged).length === 0) return undefined;
+    const merge = mergeSecretSources([
+      { label: "global", secrets: globalSecrets },
+      { label: `${params.repoOwner}/${params.repoName}`, secrets: repoSecrets },
+    ]);
+    auditSecretsMerge({
+      merge,
+      mode: parseSecretsCapMode(this.env.SECRETS_CAP_ENFORCEMENT),
+      log: logger,
+      context: { repo_owner: params.repoOwner, repo_name: params.repoName },
+    });
 
-    const logLevel = exceedsLimit ? "warn" : "info";
-    logger[logLevel]("repo_image.secrets_loaded", {
+    if (Object.keys(merge.merged).length === 0) return undefined;
+
+    logger.info("repo_image.secrets_loaded", {
       global_count: Object.keys(globalSecrets).length,
       repo_count: Object.keys(repoSecrets).length,
-      merged_count: Object.keys(merged).length,
-      payload_bytes: totalBytes,
-      exceeds_limit: exceedsLimit,
+      merged_count: Object.keys(merge.merged).length,
+      payload_bytes: merge.totalBytes,
+      exceeds_limit: merge.exceedsLimit,
       repo_owner: params.repoOwner,
       repo_name: params.repoName,
     });
 
-    return merged;
+    return merge.merged;
   }
 
   private async resolveCloneAuth(params: {

--- a/packages/control-plane/src/routes/session-create.ts
+++ b/packages/control-plane/src/routes/session-create.ts
@@ -15,10 +15,7 @@ import {
   resolveGitHubEnrichment,
   resolveProviderIdentity,
 } from "../session/identity";
-import {
-  resolveCodeServerEnabled,
-  resolveSandboxSettings,
-} from "../session/integration-settings-resolution";
+import { resolveSessionScopedSettings } from "../session/integration-settings-resolution";
 import type { CreateSessionResponse, Env } from "../types";
 import {
   normalizeOptionalRepositoryPair,
@@ -176,11 +173,14 @@ async function handleCreateSession(
       ? body.reasoningEffort
       : null;
 
-  // Resolve code-server integration setting and sandbox settings for this repo
-  const [codeServerEnabled, sandboxSettings] = await Promise.all([
-    resolveCodeServerEnabled(env.DB, repoOwner, repoName),
-    resolveSandboxSettings(env.DB, repoOwner, repoName),
-  ]);
+  // Session-scoped integration settings resolve from the primary member (design
+  // §6.2). In list mode that is repositories[0]; otherwise the scalar pair — the
+  // two are the same repo by the row-0-mirrors-scalars invariant.
+  const scopeMembers = repositories ?? (repoOwner && repoName ? [{ repoOwner, repoName }] : []);
+  const { codeServerEnabled, sandboxSettings } = await resolveSessionScopedSettings(
+    env.DB,
+    scopeMembers
+  );
 
   const sessionId = generateId();
 

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -70,8 +70,8 @@ import {
   auditSecretsMerge,
   mergeSecretSources,
   parseSecretsCapMode,
-  type SecretSource,
 } from "../db/secrets-validation";
+import { buildLaunchUnitSecretSources } from "./launch-unit-secrets";
 import type { SessionRepositoryEntry } from "./repository-target";
 import { OpenAITokenRefreshService } from "./openai-token-refresh-service";
 import { ScmCredentialsService } from "./scm-credentials-service";
@@ -1823,7 +1823,12 @@ export class SessionDO extends DurableObject<Env> {
     const globalSecrets = await globalStore.getDecryptedSecrets();
 
     const repoStore = new RepoSecretsStore(this.env.DB, encryptionKey);
-    const sources = await this.loadLaunchUnitSecretSources(session, globalSecrets, repoStore);
+    const sources = await buildLaunchUnitSecretSources({
+      environmentId: null, // PR-9: session.environment_id
+      globalSecrets,
+      members: this.repository.getSessionRepositories(),
+      loadMemberSecrets: (member) => this.loadMemberRepoSecrets(session, member, repoStore),
+    });
 
     const merge = mergeSecretSources(sources);
     auditSecretsMerge({
@@ -1847,41 +1852,8 @@ export class SessionDO extends DurableObject<Env> {
   }
 
   /**
-   * Build the ordered secret sources for a session's launch unit, lowest
-   * precedence first (design §6.4). Global is always the base; environment-
-   * launched sessions add environment secrets only, while repo-launched and
-   * ad-hoc sessions fold their member repos with the primary merged last so it
-   * wins collisions. A single-repo session degenerates to today's global+repo.
-   */
-  private async loadLaunchUnitSecretSources(
-    session: SessionRow,
-    globalSecrets: Record<string, string>,
-    repoStore: RepoSecretsStore
-  ): Promise<SecretSource[]> {
-    const sources: SecretSource[] = [{ label: "global", secrets: globalSecrets }];
-
-    // Environment-launched sessions draw from environment secrets only — member
-    // repo secrets never inherit (launch-unit scoping, design §6.4/§7.4). The
-    // sessions.environment_id column and EnvironmentSecretsStore arrive in
-    // PR-8/9; until then getLaunchUnitEnvironmentId is always null and every
-    // session is repo-launched.
-    if (this.getLaunchUnitEnvironmentId() !== null) {
-      return sources;
-    }
-
-    // Reverse position order: primary (position 0) merges last and wins.
-    const members = [...this.repository.getSessionRepositories()].reverse();
-    for (const member of members) {
-      const secrets = await this.loadMemberRepoSecrets(session, member, repoStore);
-      if (Object.keys(secrets).length > 0) {
-        sources.push({ label: `${member.repoOwner}/${member.repoName}`, secrets });
-      }
-    }
-    return sources;
-  }
-
-  /**
-   * Decrypt one member repo's secrets. The member row carries the repo id; a
+   * Decrypt one member repo's secrets — the injected leaf loader for
+   * buildLaunchUnitSecretSources. The member row carries the repo id; a
    * synthesized primary (legacy scalar row) resolves it lazily via ensureRepoId.
    * A member without a resolvable id (a secondary with a null row id) can't be
    * keyed, so it contributes nothing.
@@ -1897,16 +1869,6 @@ export class SessionDO extends DurableObject<Env> {
       return {};
     }
     return repoStore.getDecryptedSecrets(repoId);
-  }
-
-  /**
-   * The launch unit's environment id, or null for repo-launched sessions.
-   * PR-9 seam: reads `session.environment_id` once migration 0033 adds the
-   * column and the environment secrets store exists. Until then every session
-   * is repo-launched.
-   */
-  private getLaunchUnitEnvironmentId(): number | null {
-    return null;
   }
 
   /**

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -66,7 +66,13 @@ import { PullRequestCreationClaims, SessionPullRequestService } from "./pull-req
 import { findPrArtifactForRepo } from "./pr-artifacts";
 import { RepoSecretsStore } from "../db/repo-secrets";
 import { GlobalSecretsStore } from "../db/global-secrets";
-import { mergeSecrets } from "../db/secrets-validation";
+import {
+  auditSecretsMerge,
+  mergeSecretSources,
+  parseSecretsCapMode,
+  type SecretSource,
+} from "../db/secrets-validation";
+import type { SessionRepositoryEntry } from "./repository-target";
 import { OpenAITokenRefreshService } from "./openai-token-refresh-service";
 import { ScmCredentialsService } from "./scm-credentials-service";
 import { ParticipantService, getAvatarUrl } from "./participant-service";
@@ -676,8 +682,10 @@ export class SessionDO extends DurableObject<Env> {
       };
     }
 
-    // Token absence short-circuits to false so a misconfigured deployment
-    // never installs a tool that would 503 on every call.
+    // Session-scoped gate: resolved from the primary member (the scalar mirror
+    // this lookup is called with) — see resolveSessionScopedSettings for the
+    // per-feature scope rules. Token absence short-circuits to false so a
+    // misconfigured deployment never installs a tool that would 503 on every call.
     let slackAgentNotifyLookup: SlackAgentNotifyLookup | undefined;
     if (this.env.DB) {
       const tokenPresent = !!this.env.SLACK_BOT_TOKEN;
@@ -1810,34 +1818,95 @@ export class SessionDO extends DurableObject<Env> {
     }
 
     // Fail hard on secret loading — sandboxes must not silently lose secrets
-    const globalStore = new GlobalSecretsStore(this.env.DB, this.env.REPO_SECRETS_ENCRYPTION_KEY);
+    const encryptionKey = this.env.REPO_SECRETS_ENCRYPTION_KEY;
+    const globalStore = new GlobalSecretsStore(this.env.DB, encryptionKey);
     const globalSecrets = await globalStore.getDecryptedSecrets();
 
-    let repoSecrets: Record<string, string> = {};
-    if (session.repo_owner && session.repo_name) {
-      const repoId = await this.ensureRepoId(session);
-      const repoStore = new RepoSecretsStore(this.env.DB, this.env.REPO_SECRETS_ENCRYPTION_KEY);
-      repoSecrets = await repoStore.getDecryptedSecrets(repoId);
-    }
+    const repoStore = new RepoSecretsStore(this.env.DB, encryptionKey);
+    const sources = await this.loadLaunchUnitSecretSources(session, globalSecrets, repoStore);
 
-    // Merge: repo overrides global
-    const { merged, totalBytes, exceedsLimit } = mergeSecrets(globalSecrets, repoSecrets);
-    const globalCount = Object.keys(globalSecrets).length;
-    const repoCount = Object.keys(repoSecrets).length;
-    const mergedCount = Object.keys(merged).length;
+    const merge = mergeSecretSources(sources);
+    auditSecretsMerge({
+      merge,
+      mode: parseSecretsCapMode(this.env.SECRETS_CAP_ENFORCEMENT),
+      log: this.log,
+      context: { session_id: session.id },
+    });
 
+    const mergedCount = Object.keys(merge.merged).length;
     if (mergedCount > 0) {
-      const logLevel = exceedsLimit ? "warn" : "info";
-      this.log[logLevel]("Secrets merged for sandbox", {
-        global_count: globalCount,
-        repo_count: repoCount,
+      this.log.info("Secrets merged for sandbox", {
+        source_count: sources.length,
         merged_count: mergedCount,
-        payload_bytes: totalBytes,
-        exceeds_limit: exceedsLimit,
+        payload_bytes: merge.totalBytes,
+        exceeds_limit: merge.exceedsLimit,
       });
     }
 
-    return mergedCount === 0 ? undefined : merged;
+    return mergedCount === 0 ? undefined : merge.merged;
+  }
+
+  /**
+   * Build the ordered secret sources for a session's launch unit, lowest
+   * precedence first (design §6.4). Global is always the base; environment-
+   * launched sessions add environment secrets only, while repo-launched and
+   * ad-hoc sessions fold their member repos with the primary merged last so it
+   * wins collisions. A single-repo session degenerates to today's global+repo.
+   */
+  private async loadLaunchUnitSecretSources(
+    session: SessionRow,
+    globalSecrets: Record<string, string>,
+    repoStore: RepoSecretsStore
+  ): Promise<SecretSource[]> {
+    const sources: SecretSource[] = [{ label: "global", secrets: globalSecrets }];
+
+    // Environment-launched sessions draw from environment secrets only — member
+    // repo secrets never inherit (launch-unit scoping, design §6.4/§7.4). The
+    // sessions.environment_id column and EnvironmentSecretsStore arrive in
+    // PR-8/9; until then getLaunchUnitEnvironmentId is always null and every
+    // session is repo-launched.
+    if (this.getLaunchUnitEnvironmentId() !== null) {
+      return sources;
+    }
+
+    // Reverse position order: primary (position 0) merges last and wins.
+    const members = [...this.repository.getSessionRepositories()].reverse();
+    for (const member of members) {
+      const secrets = await this.loadMemberRepoSecrets(session, member, repoStore);
+      if (Object.keys(secrets).length > 0) {
+        sources.push({ label: `${member.repoOwner}/${member.repoName}`, secrets });
+      }
+    }
+    return sources;
+  }
+
+  /**
+   * Decrypt one member repo's secrets. The member row carries the repo id; a
+   * synthesized primary (legacy scalar row) resolves it lazily via ensureRepoId.
+   * A member without a resolvable id (a secondary with a null row id) can't be
+   * keyed, so it contributes nothing.
+   */
+  private async loadMemberRepoSecrets(
+    session: SessionRow,
+    member: SessionRepositoryEntry,
+    repoStore: RepoSecretsStore
+  ): Promise<Record<string, string>> {
+    const repoId =
+      member.row?.repo_id ?? (member.isPrimary ? await this.ensureRepoId(session) : null);
+    if (repoId === null) {
+      return {};
+    }
+    return repoStore.getDecryptedSecrets(repoId);
+  }
+
+  /**
+   * The launch unit's environment id, or null for repo-launched sessions.
+   * PR-9 seam: reads `session.environment_id` once migration 0033 adds the
+   * column and the environment secrets store exists. Until then every session
+   * is repo-launched.
+   */
+  private getLaunchUnitEnvironmentId(): number | null {
+    return null;
   }
 
   /**

--- a/packages/control-plane/src/session/integration-settings-resolution.test.ts
+++ b/packages/control-plane/src/session/integration-settings-resolution.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveSessionScopedSettings } from "./integration-settings-resolution";
+
+const mockState = vi.hoisted(() => ({
+  resolvedCalls: [] as Array<{ id: string; repo: string }>,
+  globalCalls: [] as string[],
+  resolved: {} as Record<
+    string,
+    { enabledRepos: string[] | null; settings: Record<string, unknown> }
+  >,
+  global: {} as Record<string, { defaults: Record<string, unknown> }>,
+}));
+
+vi.mock("../db/integration-settings", () => ({
+  IntegrationSettingsStore: class {
+    async getResolvedConfig(id: string, repo: string) {
+      mockState.resolvedCalls.push({ id, repo });
+      return mockState.resolved[id] ?? { enabledRepos: null, settings: {} };
+    }
+    async getGlobal(id: string) {
+      mockState.globalCalls.push(id);
+      return mockState.global[id] ?? null;
+    }
+  },
+}));
+
+const DB = {} as D1Database;
+
+describe("resolveSessionScopedSettings", () => {
+  beforeEach(() => {
+    mockState.resolvedCalls = [];
+    mockState.globalCalls = [];
+    mockState.resolved = {};
+    mockState.global = {};
+  });
+
+  it("resolves both settings from the primary (position 0) member", async () => {
+    mockState.resolved["code-server"] = { enabledRepos: null, settings: { enabled: true } };
+    mockState.resolved["sandbox"] = { enabledRepos: null, settings: { tunnelPorts: [8080] } };
+
+    const result = await resolveSessionScopedSettings(DB, [
+      { repoOwner: "acme", repoName: "web" },
+      { repoOwner: "acme", repoName: "backend" },
+    ]);
+
+    expect(result).toEqual({
+      codeServerEnabled: true,
+      sandboxSettings: { tunnelPorts: [8080] },
+    });
+    // Every resolution targets the primary member; the secondary is never asked about.
+    expect(mockState.resolvedCalls.map((c) => c.repo)).toEqual(["acme/web", "acme/web"]);
+    expect(mockState.resolvedCalls.map((c) => c.id).sort()).toEqual(["code-server", "sandbox"]);
+  });
+
+  it("falls back to global sandbox defaults and disabled code-server for a repo-less session", async () => {
+    mockState.global["sandbox"] = { defaults: { tunnelPorts: [3000] } };
+
+    const result = await resolveSessionScopedSettings(DB, []);
+
+    expect(result.codeServerEnabled).toBe(false);
+    expect(result.sandboxSettings).toEqual({ tunnelPorts: [3000] });
+    // No per-repo resolution happens without a primary member.
+    expect(mockState.resolvedCalls).toEqual([]);
+    expect(mockState.globalCalls).toContain("sandbox");
+  });
+});

--- a/packages/control-plane/src/session/integration-settings-resolution.ts
+++ b/packages/control-plane/src/session/integration-settings-resolution.ts
@@ -1,6 +1,7 @@
 import { type CodeServerSettings, type SandboxSettings } from "@open-inspect/shared";
 import { IntegrationSettingsStore } from "../db/integration-settings";
 import { createLogger } from "../logger";
+import type { RepoIdentity } from "./repository-target";
 
 const logger = createLogger("session-integration-settings");
 
@@ -66,4 +67,44 @@ export async function resolveSandboxSettings(
     });
     return {};
   }
+}
+
+/** The integration settings scoped to the whole session, resolved from its primary member. */
+export interface SessionScopedSettings {
+  codeServerEnabled: boolean;
+  sandboxSettings: SandboxSettings;
+}
+
+/**
+ * Resolve the integration settings scoped to the whole session — as opposed to
+ * bot- or trigger-scoped — from its member list.
+ *
+ * Per-feature scope rules (design §6.2), stated here in one place so callers
+ * stop re-deriving them from the scalar mirror:
+ *
+ * - **Sandbox settings, code-server enablement, and the Slack agent-notify gate
+ *   resolve from the PRIMARY member** (the ordinal-0 mirror). These configure
+ *   sandbox-wide singletons or are gating booleans, where an any-member-wins
+ *   union would let one member silently override another member owner's
+ *   explicit opt-out; `enabledRepos` allowlists are likewise evaluated against
+ *   the primary. The Slack gate is resolved live at spawn from the scalar mirror
+ *   (`resolveAgentSlackNotifyEnabled`) — the same rule on a different call path.
+ * - **MCP servers resolve as the UNION across members** (injecting a server
+ *   scoped to any member is additive and side-effect-free) — resolved
+ *   separately in `McpServerStore.getDecryptedForSession`.
+ *
+ * Members are in position order; index 0 is the primary. An empty list (a
+ * repo-less session) falls back to global defaults, matching the underlying
+ * resolvers' null-repo behavior.
+ */
+export async function resolveSessionScopedSettings(
+  db: D1Database | undefined,
+  members: readonly RepoIdentity[]
+): Promise<SessionScopedSettings> {
+  const primary = members[0] ?? null;
+  const [codeServerEnabled, sandboxSettings] = await Promise.all([
+    resolveCodeServerEnabled(db, primary?.repoOwner ?? null, primary?.repoName ?? null),
+    resolveSandboxSettings(db, primary?.repoOwner ?? null, primary?.repoName ?? null),
+  ]);
+  return { codeServerEnabled, sandboxSettings };
 }

--- a/packages/control-plane/src/session/launch-unit-secrets.test.ts
+++ b/packages/control-plane/src/session/launch-unit-secrets.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildLaunchUnitSecretSources } from "./launch-unit-secrets";
+import type { SessionRepositoryEntry } from "./repository-target";
+
+function member(
+  repoOwner: string,
+  repoName: string,
+  position: number,
+  isPrimary: boolean
+): SessionRepositoryEntry {
+  return { repoOwner, repoName, position, isPrimary, baseBranch: "main", row: null };
+}
+
+describe("buildLaunchUnitSecretSources", () => {
+  it("folds members lowest-precedence-first with the primary (position 0) last", async () => {
+    const secretsByRepo: Record<string, Record<string, string>> = {
+      "acme/web": { A: "web" },
+      "acme/backend": { B: "backend" },
+    };
+
+    const sources = await buildLaunchUnitSecretSources({
+      environmentId: null,
+      globalSecrets: { G: "g" },
+      members: [member("acme", "web", 0, true), member("acme", "backend", 1, false)],
+      loadMemberSecrets: async (m) => secretsByRepo[`${m.repoOwner}/${m.repoName}`] ?? {},
+    });
+
+    // Primary (acme/web) is appended last so mergeSecretSources lets it win.
+    expect(sources.map((s) => s.label)).toEqual(["global", "acme/backend", "acme/web"]);
+  });
+
+  it("returns only global for an environment-launched session — member repos never inherit", async () => {
+    const loadMemberSecrets = vi.fn();
+
+    const sources = await buildLaunchUnitSecretSources({
+      environmentId: 42,
+      globalSecrets: { G: "g" },
+      members: [member("acme", "web", 0, true)],
+      loadMemberSecrets,
+    });
+
+    expect(sources.map((s) => s.label)).toEqual(["global"]);
+    expect(loadMemberSecrets).not.toHaveBeenCalled();
+  });
+
+  it("omits members that contribute no secrets", async () => {
+    const sources = await buildLaunchUnitSecretSources({
+      environmentId: null,
+      globalSecrets: {},
+      members: [member("acme", "web", 0, true), member("acme", "empty", 1, false)],
+      loadMemberSecrets: async (m): Promise<Record<string, string>> =>
+        m.repoName === "empty" ? {} : { A: "1" },
+    });
+
+    expect(sources.map((s) => s.label)).toEqual(["global", "acme/web"]);
+  });
+
+  it("returns only global when there are no members", async () => {
+    const sources = await buildLaunchUnitSecretSources({
+      environmentId: null,
+      globalSecrets: { G: "g" },
+      members: [],
+      loadMemberSecrets: async () => ({}),
+    });
+
+    expect(sources).toEqual([{ label: "global", secrets: { G: "g" } }]);
+  });
+});

--- a/packages/control-plane/src/session/launch-unit-secrets.ts
+++ b/packages/control-plane/src/session/launch-unit-secrets.ts
@@ -1,0 +1,49 @@
+import type { SecretSource } from "../db/secrets-validation";
+import type { SessionRepositoryEntry } from "./repository-target";
+
+export interface LaunchUnitSecretSourcesInput {
+  /**
+   * The launch unit's environment id, or null for repo-launched sessions. PR-9
+   * passes `session.environment_id`; until migration 0033 adds the column this
+   * is always null and every session is repo-launched.
+   */
+  environmentId: number | null;
+  globalSecrets: Record<string, string>;
+  /** Session member repositories in position order (index 0 = primary). */
+  members: SessionRepositoryEntry[];
+  /** Decrypt a member's secrets, or {} when it has no resolvable repo id. */
+  loadMemberSecrets: (member: SessionRepositoryEntry) => Promise<Record<string, string>>;
+}
+
+/**
+ * Build the ordered secret sources for a session's launch unit, lowest
+ * precedence first (design §6.4). Global is always the base; environment-
+ * launched sessions add environment secrets only (member repo secrets never
+ * inherit — launch-unit scoping, §6.4/§7.4), while repo-launched and ad-hoc
+ * sessions fold their member repos with the primary (position 0) merged last so
+ * it wins collisions. A single-repo session degenerates to today's global+repo.
+ *
+ * This owns the launch-unit sourcing policy so the DO only loads sources, merges
+ * (mergeSecretSources), and audits the cap. The environment source is filled in
+ * by PR-9 with the environment secrets store; until then environmentId is always
+ * null and this is always the repo path.
+ */
+export async function buildLaunchUnitSecretSources(
+  input: LaunchUnitSecretSourcesInput
+): Promise<SecretSource[]> {
+  const sources: SecretSource[] = [{ label: "global", secrets: input.globalSecrets }];
+
+  if (input.environmentId !== null) {
+    // PR-9: sources.push({ label: "environment", secrets: <environment secrets> })
+    return sources;
+  }
+
+  // Reverse position order: the primary (position 0) merges last and wins.
+  for (const member of [...input.members].reverse()) {
+    const secrets = await input.loadMemberSecrets(member);
+    if (Object.keys(secrets).length > 0) {
+      sources.push({ label: `${member.repoOwner}/${member.repoName}`, secrets });
+    }
+  }
+  return sources;
+}

--- a/packages/control-plane/src/session/openai-token-refresh-service.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.ts
@@ -11,9 +11,20 @@ import type { SessionRow } from "./types";
 
 const OPENAI_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 
+/**
+ * Where a session's OpenAI token secrets live: its launch unit (the repo today,
+ * an environment in PR-9) or the global store used as fallback. This is the one
+ * launch-unit secrets-source seam in this service (design §6.4, §16.2 choke
+ * point) — the read/write paths route through it rather than picking a store
+ * inline. PR-9 adds `{ kind: "environment"; environmentId: number }`.
+ */
+type OpenAITokenSource =
+  | { kind: "repo"; repoId: number; repoOwner: string; repoName: string }
+  | { kind: "global" };
+
 type OpenAITokenState =
   | { type: "cached"; accessToken: string; expiresIn: number; accountId?: string }
-  | { type: "refresh"; refreshToken: string; source: "repo" | "global"; repoId: number | null };
+  | { type: "refresh"; refreshToken: string; source: OpenAITokenSource };
 
 export type OpenAITokenRefreshResult =
   | { ok: true; accessToken: string; expiresIn?: number; accountId?: string }
@@ -54,10 +65,10 @@ export class OpenAITokenRefreshService {
     }
 
     try {
-      return await this.attemptRefresh(tokenState, session);
+      return await this.attemptRefresh(tokenState);
     } catch (e) {
       if (e instanceof OpenAITokenRefreshError && e.status === 401) {
-        return this.handleUnauthorizedRefresh(tokenState, readTokenState, session);
+        return this.handleUnauthorizedRefresh(tokenState, readTokenState);
       }
 
       this.log.error("OpenAI token refresh failed", {
@@ -69,8 +80,7 @@ export class OpenAITokenRefreshService {
 
   private getTokenStateFromSecrets(
     secrets: Record<string, string>,
-    source: "repo" | "global",
-    repoId: number | null
+    source: OpenAITokenSource
   ): OpenAITokenState | null {
     if (!secrets.OPENAI_OAUTH_REFRESH_TOKEN) {
       return null;
@@ -93,31 +103,72 @@ export class OpenAITokenRefreshService {
       type: "refresh",
       refreshToken: secrets.OPENAI_OAUTH_REFRESH_TOKEN,
       source,
-      repoId,
     };
   }
 
-  private async readTokenState(session: SessionRow): Promise<OpenAITokenState | null> {
-    let repoId: number | null = null;
+  /**
+   * Resolve the session's launch-unit secrets source, or null when the session
+   * has no launch-unit repo (leaving global as the only source). PR-9 seam:
+   * environment-launched sessions resolve to an environment source once
+   * sessions.environment_id and the environment secrets store exist; until then
+   * every session is repo-launched.
+   */
+  private async resolveLaunchUnitSource(session: SessionRow): Promise<OpenAITokenSource | null> {
     if (session.repo_owner && session.repo_name) {
-      repoId = await this.ensureRepoId(session);
+      const repoId = await this.ensureRepoId(session);
+      return { kind: "repo", repoId, repoOwner: session.repo_owner, repoName: session.repo_name };
+    }
+    return null;
+  }
 
-      const repoStore = new RepoSecretsStore(this.db, this.encryptionKey);
-      const repoSecrets = await repoStore.getDecryptedSecrets(repoId);
-      const repoState = this.getTokenStateFromSecrets(repoSecrets, "repo", repoId);
-      if (repoState) {
-        return repoState;
+  private async readSecretsForSource(source: OpenAITokenSource): Promise<Record<string, string>> {
+    switch (source.kind) {
+      case "repo": {
+        const repoStore = new RepoSecretsStore(this.db, this.encryptionKey);
+        return repoStore.getDecryptedSecrets(source.repoId);
+      }
+      case "global": {
+        const globalStore = new GlobalSecretsStore(this.db, this.encryptionKey);
+        return globalStore.getDecryptedSecrets();
+      }
+    }
+  }
+
+  private async writeSecretsForSource(
+    source: OpenAITokenSource,
+    secrets: Record<string, string>
+  ): Promise<void> {
+    switch (source.kind) {
+      case "repo": {
+        const repoStore = new RepoSecretsStore(this.db, this.encryptionKey);
+        await repoStore.setSecrets(source.repoId, source.repoOwner, source.repoName, secrets);
+        break;
+      }
+      case "global": {
+        const globalStore = new GlobalSecretsStore(this.db, this.encryptionKey);
+        await globalStore.setSecrets(secrets);
+        break;
+      }
+    }
+  }
+
+  private async readTokenState(session: SessionRow): Promise<OpenAITokenState | null> {
+    const launchUnit = await this.resolveLaunchUnitSource(session);
+    if (launchUnit) {
+      const secrets = await this.readSecretsForSource(launchUnit);
+      const state = this.getTokenStateFromSecrets(secrets, launchUnit);
+      if (state) {
+        return state;
       }
     }
 
-    const globalStore = new GlobalSecretsStore(this.db, this.encryptionKey);
-    const globalSecrets = await globalStore.getDecryptedSecrets();
-    return this.getTokenStateFromSecrets(globalSecrets, "global", repoId);
+    const globalSource: OpenAITokenSource = { kind: "global" };
+    const globalSecrets = await this.readSecretsForSource(globalSource);
+    return this.getTokenStateFromSecrets(globalSecrets, globalSource);
   }
 
   private async attemptRefresh(
-    tokenState: Extract<OpenAITokenState, { type: "refresh" }>,
-    session: SessionRow
+    tokenState: Extract<OpenAITokenState, { type: "refresh" }>
   ): Promise<OpenAITokenRefreshResult> {
     const tokens = await refreshOpenAIToken(tokenState.refreshToken);
     const accountId = extractOpenAIAccountId(tokens);
@@ -134,28 +185,10 @@ export class OpenAITokenRefreshService {
         secretsToWrite.OPENAI_OAUTH_ACCOUNT_ID = accountId;
       }
 
-      if (tokenState.source === "repo") {
-        if (tokenState.repoId === null || !session.repo_owner || !session.repo_name) {
-          return {
-            ok: false,
-            status: 400,
-            error: "Repository-scoped OpenAI tokens require a repository context",
-          };
-        }
-        const repoStore = new RepoSecretsStore(this.db, this.encryptionKey);
-        await repoStore.setSecrets(
-          tokenState.repoId,
-          session.repo_owner,
-          session.repo_name,
-          secretsToWrite
-        );
-      } else {
-        const globalStore = new GlobalSecretsStore(this.db, this.encryptionKey);
-        await globalStore.setSecrets(secretsToWrite);
-      }
+      await this.writeSecretsForSource(tokenState.source, secretsToWrite);
 
       this.log.info("OpenAI tokens rotated and cached", {
-        source: tokenState.source,
+        source: tokenState.source.kind,
         has_account_id: !!accountId,
       });
     } catch (e) {
@@ -174,11 +207,10 @@ export class OpenAITokenRefreshService {
 
   private async handleUnauthorizedRefresh(
     tokenState: Extract<OpenAITokenState, { type: "refresh" }>,
-    readTokenState: () => Promise<OpenAITokenState | null>,
-    session: SessionRow
+    readTokenState: () => Promise<OpenAITokenState | null>
   ): Promise<OpenAITokenRefreshResult> {
     this.log.warn("OpenAI refresh got 401, checking for concurrent rotation", {
-      source: tokenState.source,
+      source: tokenState.source.kind,
     });
 
     await new Promise((resolve) => setTimeout(resolve, 500));
@@ -198,7 +230,7 @@ export class OpenAITokenRefreshService {
 
       if (reread?.type === "refresh" && reread.refreshToken !== tokenState.refreshToken) {
         this.log.info("Detected concurrent token rotation, retrying");
-        return this.attemptRefresh(reread, session);
+        return this.attemptRefresh(reread);
       }
     } catch (retryErr) {
       this.log.error("Retry after 401 also failed", {

--- a/packages/control-plane/src/session/openai-token-refresh-service.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.ts
@@ -11,20 +11,9 @@ import type { SessionRow } from "./types";
 
 const OPENAI_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 
-/**
- * Where a session's OpenAI token secrets live: its launch unit (the repo today,
- * an environment in PR-9) or the global store used as fallback. This is the one
- * launch-unit secrets-source seam in this service (design §6.4, §16.2 choke
- * point) — the read/write paths route through it rather than picking a store
- * inline. PR-9 adds `{ kind: "environment"; environmentId: number }`.
- */
-type OpenAITokenSource =
-  | { kind: "repo"; repoId: number; repoOwner: string; repoName: string }
-  | { kind: "global" };
-
 type OpenAITokenState =
   | { type: "cached"; accessToken: string; expiresIn: number; accountId?: string }
-  | { type: "refresh"; refreshToken: string; source: OpenAITokenSource };
+  | { type: "refresh"; refreshToken: string; source: "repo" | "global"; repoId: number | null };
 
 export type OpenAITokenRefreshResult =
   | { ok: true; accessToken: string; expiresIn?: number; accountId?: string }
@@ -65,10 +54,10 @@ export class OpenAITokenRefreshService {
     }
 
     try {
-      return await this.attemptRefresh(tokenState);
+      return await this.attemptRefresh(tokenState, session);
     } catch (e) {
       if (e instanceof OpenAITokenRefreshError && e.status === 401) {
-        return this.handleUnauthorizedRefresh(tokenState, readTokenState);
+        return this.handleUnauthorizedRefresh(tokenState, readTokenState, session);
       }
 
       this.log.error("OpenAI token refresh failed", {
@@ -80,7 +69,8 @@ export class OpenAITokenRefreshService {
 
   private getTokenStateFromSecrets(
     secrets: Record<string, string>,
-    source: OpenAITokenSource
+    source: "repo" | "global",
+    repoId: number | null
   ): OpenAITokenState | null {
     if (!secrets.OPENAI_OAUTH_REFRESH_TOKEN) {
       return null;
@@ -103,72 +93,31 @@ export class OpenAITokenRefreshService {
       type: "refresh",
       refreshToken: secrets.OPENAI_OAUTH_REFRESH_TOKEN,
       source,
+      repoId,
     };
   }
 
-  /**
-   * Resolve the session's launch-unit secrets source, or null when the session
-   * has no launch-unit repo (leaving global as the only source). PR-9 seam:
-   * environment-launched sessions resolve to an environment source once
-   * sessions.environment_id and the environment secrets store exist; until then
-   * every session is repo-launched.
-   */
-  private async resolveLaunchUnitSource(session: SessionRow): Promise<OpenAITokenSource | null> {
-    if (session.repo_owner && session.repo_name) {
-      const repoId = await this.ensureRepoId(session);
-      return { kind: "repo", repoId, repoOwner: session.repo_owner, repoName: session.repo_name };
-    }
-    return null;
-  }
-
-  private async readSecretsForSource(source: OpenAITokenSource): Promise<Record<string, string>> {
-    switch (source.kind) {
-      case "repo": {
-        const repoStore = new RepoSecretsStore(this.db, this.encryptionKey);
-        return repoStore.getDecryptedSecrets(source.repoId);
-      }
-      case "global": {
-        const globalStore = new GlobalSecretsStore(this.db, this.encryptionKey);
-        return globalStore.getDecryptedSecrets();
-      }
-    }
-  }
-
-  private async writeSecretsForSource(
-    source: OpenAITokenSource,
-    secrets: Record<string, string>
-  ): Promise<void> {
-    switch (source.kind) {
-      case "repo": {
-        const repoStore = new RepoSecretsStore(this.db, this.encryptionKey);
-        await repoStore.setSecrets(source.repoId, source.repoOwner, source.repoName, secrets);
-        break;
-      }
-      case "global": {
-        const globalStore = new GlobalSecretsStore(this.db, this.encryptionKey);
-        await globalStore.setSecrets(secrets);
-        break;
-      }
-    }
-  }
-
   private async readTokenState(session: SessionRow): Promise<OpenAITokenState | null> {
-    const launchUnit = await this.resolveLaunchUnitSource(session);
-    if (launchUnit) {
-      const secrets = await this.readSecretsForSource(launchUnit);
-      const state = this.getTokenStateFromSecrets(secrets, launchUnit);
-      if (state) {
-        return state;
+    let repoId: number | null = null;
+    if (session.repo_owner && session.repo_name) {
+      repoId = await this.ensureRepoId(session);
+
+      const repoStore = new RepoSecretsStore(this.db, this.encryptionKey);
+      const repoSecrets = await repoStore.getDecryptedSecrets(repoId);
+      const repoState = this.getTokenStateFromSecrets(repoSecrets, "repo", repoId);
+      if (repoState) {
+        return repoState;
       }
     }
 
-    const globalSource: OpenAITokenSource = { kind: "global" };
-    const globalSecrets = await this.readSecretsForSource(globalSource);
-    return this.getTokenStateFromSecrets(globalSecrets, globalSource);
+    const globalStore = new GlobalSecretsStore(this.db, this.encryptionKey);
+    const globalSecrets = await globalStore.getDecryptedSecrets();
+    return this.getTokenStateFromSecrets(globalSecrets, "global", repoId);
   }
 
   private async attemptRefresh(
-    tokenState: Extract<OpenAITokenState, { type: "refresh" }>
+    tokenState: Extract<OpenAITokenState, { type: "refresh" }>,
+    session: SessionRow
   ): Promise<OpenAITokenRefreshResult> {
     const tokens = await refreshOpenAIToken(tokenState.refreshToken);
     const accountId = extractOpenAIAccountId(tokens);
@@ -185,10 +134,28 @@ export class OpenAITokenRefreshService {
         secretsToWrite.OPENAI_OAUTH_ACCOUNT_ID = accountId;
       }
 
-      await this.writeSecretsForSource(tokenState.source, secretsToWrite);
+      if (tokenState.source === "repo") {
+        if (tokenState.repoId === null || !session.repo_owner || !session.repo_name) {
+          return {
+            ok: false,
+            status: 400,
+            error: "Repository-scoped OpenAI tokens require a repository context",
+          };
+        }
+        const repoStore = new RepoSecretsStore(this.db, this.encryptionKey);
+        await repoStore.setSecrets(
+          tokenState.repoId,
+          session.repo_owner,
+          session.repo_name,
+          secretsToWrite
+        );
+      } else {
+        const globalStore = new GlobalSecretsStore(this.db, this.encryptionKey);
+        await globalStore.setSecrets(secretsToWrite);
+      }
 
       this.log.info("OpenAI tokens rotated and cached", {
-        source: tokenState.source.kind,
+        source: tokenState.source,
         has_account_id: !!accountId,
       });
     } catch (e) {
@@ -207,10 +174,11 @@ export class OpenAITokenRefreshService {
 
   private async handleUnauthorizedRefresh(
     tokenState: Extract<OpenAITokenState, { type: "refresh" }>,
-    readTokenState: () => Promise<OpenAITokenState | null>
+    readTokenState: () => Promise<OpenAITokenState | null>,
+    session: SessionRow
   ): Promise<OpenAITokenRefreshResult> {
     this.log.warn("OpenAI refresh got 401, checking for concurrent rotation", {
-      source: tokenState.source.kind,
+      source: tokenState.source,
     });
 
     await new Promise((resolve) => setTimeout(resolve, 500));
@@ -230,7 +198,7 @@ export class OpenAITokenRefreshService {
 
       if (reread?.type === "refresh" && reread.refreshToken !== tokenState.refreshToken) {
         this.log.info("Detected concurrent token rotation, retrying");
-        return this.attemptRefresh(reread);
+        return this.attemptRefresh(reread, session);
       }
     } catch (retryErr) {
       this.log.error("Retry after 401 also failed", {

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -108,6 +108,7 @@ export interface Env {
   // Sandbox lifecycle configuration
   SANDBOX_INACTIVITY_TIMEOUT_MS?: string; // Inactivity timeout in ms (default: 600000 = 10 min)
   EXECUTION_TIMEOUT_MS?: string; // Max processing time before auto-fail (default: 5400000 = 90 min)
+  SECRETS_CAP_ENFORCEMENT?: string; // "warn" (default) logs oversized secret payloads; "enforce" fails spawn/build
 
   // Logging
   LOG_LEVEL?: string; // "debug" | "info" | "warn" | "error" (default: "info")

--- a/packages/control-plane/test/integration/session-secrets-fold.test.ts
+++ b/packages/control-plane/test/integration/session-secrets-fold.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { env, runInDurableObject } from "cloudflare:test";
+import type { SessionDO } from "../../src/session/durable-object";
+import { GlobalSecretsStore } from "../../src/db/global-secrets";
+import { RepoSecretsStore } from "../../src/db/repo-secrets";
+import { cleanD1Tables } from "./cleanup";
+import { initSession } from "./helpers";
+
+const KEY = () => env.REPO_SECRETS_ENCRYPTION_KEY as string;
+
+/** Invoke the DO's real (private) getUserEnvVars, exercising the launch-unit fold. */
+function getUserEnvVars(stub: DurableObjectStub): Promise<Record<string, string> | undefined> {
+  return runInDurableObject(stub, (instance: SessionDO) =>
+    (
+      instance as unknown as {
+        getUserEnvVars(): Promise<Record<string, string> | undefined>;
+      }
+    ).getUserEnvVars()
+  );
+}
+
+describe("getUserEnvVars launch-unit fold", () => {
+  beforeEach(cleanD1Tables);
+
+  it("folds member repo secrets with the primary winning collisions (ad-hoc list)", async () => {
+    await new GlobalSecretsStore(env.DB, KEY()).setSecrets({ SHARED: "global", ONLY_GLOBAL: "g" });
+    await new RepoSecretsStore(env.DB, KEY()).setSecrets(90101, "acme", "web", {
+      SHARED: "web",
+      ONLY_WEB: "w",
+    });
+    await new RepoSecretsStore(env.DB, KEY()).setSecrets(90102, "acme", "backend", {
+      SHARED: "backend",
+      ONLY_BACKEND: "b",
+    });
+
+    const { stub } = await initSession({
+      repoOwner: "acme",
+      repoName: "web",
+      repoId: 90101,
+      repositories: [
+        { repoOwner: "acme", repoName: "web", repoId: 90101, baseBranch: "main" },
+        { repoOwner: "acme", repoName: "backend", repoId: 90102, baseBranch: "main" },
+      ],
+    });
+
+    const envVars = await getUserEnvVars(stub);
+
+    // Primary (position 0 = acme/web) merges last and wins SHARED; every layer contributes.
+    expect(envVars).toMatchObject({
+      SHARED: "web",
+      ONLY_GLOBAL: "g",
+      ONLY_WEB: "w",
+      ONLY_BACKEND: "b",
+    });
+  });
+
+  it("merges global with the sole repo for a scalar session (single-repo parity)", async () => {
+    await new GlobalSecretsStore(env.DB, KEY()).setSecrets({ SHARED: "global", ONLY_GLOBAL: "g" });
+    await new RepoSecretsStore(env.DB, KEY()).setSecrets(90201, "acme", "solo", {
+      SHARED: "repo",
+      ONLY_REPO: "r",
+    });
+
+    const { stub } = await initSession({ repoOwner: "acme", repoName: "solo", repoId: 90201 });
+
+    const envVars = await getUserEnvVars(stub);
+
+    expect(envVars).toMatchObject({ SHARED: "repo", ONLY_GLOBAL: "g", ONLY_REPO: "r" });
+  });
+});


### PR DESCRIPTION
## PR-6 · launch-unit secrets + cap enforcement

Phase-1 slice of multi-repo sessions (design §6.4, §7.4 ad-hoc branch, §9 cap row). Generalizes secrets sourcing from a fixed `global + repo` merge to a **launch-unit fold**, adds a staged combined-size **cap**, and consolidates the session-scope integration-settings rules (committed on the #905 thread).

> Builds on #908 (merged to `main`). No migration in this PR.

### Launch-unit secrets fold (`getUserEnvVars`)
One rule: a session receives **global + its launch unit's secrets, never a blend of units**.
- **Repo-launched** (single repo, all bots): `global + that repo` — byte-for-byte today's behavior.
- **Ad-hoc list**: `global + members`, folded in reverse position so the **primary (position 0) wins** collisions. N=1 degenerates to the row above.
- **Environment-launched**: `global + environment secrets only` — member repo secrets never inherit. This branch is a **hardcoded-null seam** (`getLaunchUnitEnvironmentId()` returns `null`) until `sessions.environment_id` + the environment secrets store land in PR-8/9.

### Cap enforcement (behavior change #2, staged)
- Names `MAX_COMBINED_SECRETS_BYTES = 131072`.
- New `mergeSecretSources(sources)` primitive: folds an ordered source list, reporting **per-source byte attribution** and **cross-source key collisions** (key + both labels, never values).
- Shared `auditSecretsMerge` helper: logs collisions + the cap decision, and in **`enforce`** mode throws `SecretsCapExceededError` (message attributes bytes per scope). Used by **both** the spawn path and the repo-image build planner so they enforce identically.
- Staged: `SECRETS_CAP_ENFORCEMENT=warn` (default) logs oversized payloads and proceeds; a follow-up commit flips to `enforce` before the Phase-1 gate (the gate cannot pass in warn mode). **This PR ships warn → no functional change to oversized spawns yet.**

### OpenAI token-refresh seam (third secrets consumer)
Reads and writes now route through a launch-unit `OpenAITokenSource` seam (repo today, environment in PR-9) instead of picking a store inline — §16.2's choke point. Drops the dead `repoId === null` guard (the `repo` source now carries a non-null id + owner/name by construction). Repo-launched behavior unchanged.

### Session-scope integration-settings resolver (committed on #905)
`resolveSessionScopedSettings(db, members)` states every per-feature scope rule in one place: **sandbox settings, code-server, and the Slack agent-notify gate resolve from the primary member**; **MCP is the union across members**. `session-create` resolves through it; a pointer comment links the live Slack-gate path. Behavior-identical (the scalar mirror already is the primary by the row-0 invariant).

### Tests
- `secrets-validation.test.ts` — fold order per launch form, primary-last precedence, attribution, collisions, cap warn/enforce/boundary, error message.
- `session-secrets-fold.test.ts` (integration) — drives the **real** `getUserEnvVars` via `runInDurableObject`: multi-repo fold (primary wins) + single-repo parity.
- `integration-settings-resolution.test.ts` — resolver picks primary, empty list → global defaults.
- token-refresh tests unchanged and green (seam parity).
- 1601 unit + 457 integration + typecheck + lint clean.

### Rollout note
Modal PR-#900 must deploy to prod **before** this control-plane change (pydantic drops unknown keys otherwise). No migration in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secret handling now supports multiple sources with clear precedence, better attribution, and stricter size tracking.
  * Session setup now resolves code-server and sandbox settings together using session-specific repository context.

* **Bug Fixes**
  * Improved secret merge behavior so the correct repository wins when keys overlap.
  * Added optional warning or enforcement behavior when combined secrets exceed the allowed size, with clearer error details and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->