### PR TITLE
fix(types): validate unsafe callback casts

### DIFF
--- a/packages/control-plane/src/scheduler/slack-completion.test.ts
+++ b/packages/control-plane/src/scheduler/slack-completion.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildSlackCompletionNotification,
   buildSlackSkipNotification,
+  parseSlackTriggerMetadata,
   type SlackRunMetadata,
   type SlackCompletionContext,
 } from "./slack-completion";
@@ -24,6 +25,20 @@ function ctx(overrides?: Partial<SlackCompletionContext>): SlackCompletionContex
     ...overrides,
   };
 }
+
+describe("parseSlackTriggerMetadata", () => {
+  it("parses valid Slack trigger metadata", () => {
+    expect(parseSlackTriggerMetadata(JSON.stringify(meta()))).toEqual(meta());
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(parseSlackTriggerMetadata("{")).toBeNull();
+  });
+
+  it("returns null for partial metadata", () => {
+    expect(parseSlackTriggerMetadata(JSON.stringify({ channel: "C1" }))).toBeNull();
+  });
+});
 
 describe("buildSlackCompletionNotification", () => {
   it("returns null for a non-slack run (no metadata)", () => {

--- a/packages/control-plane/src/scheduler/slack-completion.ts
+++ b/packages/control-plane/src/scheduler/slack-completion.ts
@@ -9,16 +9,20 @@
  * with no actor to address.
  */
 
+import { z } from "zod";
+
+const slackRunMetadataSchema = z.object({
+  channel: z.string(),
+  messageTs: z.string(),
+});
+
 /**
  * Slack coordinates captured at trigger time, serialized into the invocation's
  * `trigger_metadata` column (slack-origin firings only; legacy rows carry the
  * same JSON in the run's frozen `trigger_run_metadata`). `messageTs` is the
  * triggering message, used to clear the `eyes` reaction on completion.
  */
-export interface SlackRunMetadata {
-  channel: string;
-  messageTs: string;
-}
+export type SlackRunMetadata = z.infer<typeof slackRunMetadataSchema>;
 
 /**
  * Parse serialized trigger metadata as slack coordinates — null when absent
@@ -28,7 +32,8 @@ export interface SlackRunMetadata {
 export function parseSlackTriggerMetadata(raw: string | null | undefined): SlackRunMetadata | null {
   if (!raw) return null;
   try {
-    return JSON.parse(raw) as SlackRunMetadata;
+    const parsed = slackRunMetadataSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : null;
   } catch {
     return null;
   }

--- a/packages/slack-bot/src/callbacks.test.ts
+++ b/packages/slack-bot/src/callbacks.test.ts
@@ -290,6 +290,69 @@ async function postCallback(path: string, payload: unknown, env = makeEnv(), ctx
   return { response, env, ctx };
 }
 
+describe("POST /callbacks/complete", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function completeCallbackData(overrides: Record<string, unknown> = {}) {
+    return {
+      sessionId: "session-1",
+      messageId: "message-1",
+      success: true,
+      timestamp: 1778900000000,
+      context: {
+        source: "slack",
+        channel: "C123",
+        threadTs: "111.222",
+        repoFullName: "acme/app",
+        model: "anthropic/claude-haiku-4-5",
+      },
+      ...overrides,
+    };
+  }
+
+  it("rejects a partial completion payload", async () => {
+    const payload = await signPayload(completeCallbackData({ context: { channel: "C123" } }));
+    const { response, ctx } = await postCallback("/callbacks/complete", payload);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "invalid payload" });
+    expect(ctx.waitUntil).not.toHaveBeenCalled();
+  });
+
+  it("accepts signed completion payloads without stripping unknown signed fields", async () => {
+    vi.mocked(extractAgentResponse).mockResolvedValue({
+      textContent: "All set.",
+      toolCalls: [],
+      artifacts: [],
+      success: true,
+    });
+    const fetchMock = okFetchMock();
+    const payload = await signPayload(
+      completeCallbackData({
+        extraTopLevel: "preserve-me",
+        context: {
+          source: "slack",
+          channel: "C123",
+          threadTs: "111.222",
+          repoFullName: "acme/app",
+          model: "anthropic/claude-haiku-4-5",
+          extraNested: "preserve-me-too",
+        },
+      })
+    );
+    const { response, ctx } = await postCallback("/callbacks/complete", payload);
+
+    expect(response.status).toBe(200);
+    await flushWaitUntil(ctx);
+
+    const post = slackCall(fetchMock, "chat.postMessage");
+    expect(post).toBeDefined();
+    expect(post!.body).toMatchObject({ channel: "C123", thread_ts: "111.222" });
+  });
+});
+
 describe("POST /callbacks/automation-complete", () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/packages/slack-bot/src/callbacks.test.ts
+++ b/packages/slack-bot/src/callbacks.test.ts
@@ -125,6 +125,21 @@ describe("POST /callbacks/tool_call", () => {
     expect(ctx.waitUntil).not.toHaveBeenCalled();
   });
 
+  it("rejects signed tool calls with partial Slack context", async () => {
+    const payload = await makeToolCallPayload({
+      context: {
+        source: "slack",
+        channel: "C123",
+        threadTs: "111.222",
+      },
+    });
+    const { response, ctx } = await postToolCall(payload);
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: "invalid payload" });
+    expect(ctx.waitUntil).not.toHaveBeenCalled();
+  });
+
   it("rejects malformed JSON payloads", async () => {
     const ctx = makeCtx();
     const response = await makeApp().fetch(
@@ -313,7 +328,15 @@ describe("POST /callbacks/complete", () => {
   }
 
   it("rejects a partial completion payload", async () => {
-    const payload = await signPayload(completeCallbackData({ context: { channel: "C123" } }));
+    const payload = await signPayload(
+      completeCallbackData({
+        context: {
+          source: "slack",
+          channel: "C123",
+          threadTs: "111.222",
+        },
+      })
+    );
     const { response, ctx } = await postCallback("/callbacks/complete", payload);
 
     expect(response.status).toBe(400);

--- a/packages/slack-bot/src/callbacks.ts
+++ b/packages/slack-bot/src/callbacks.ts
@@ -60,46 +60,37 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
-const completionCallbackSchema = z
-  .object({
-    sessionId: z.string(),
-    messageId: z.string(),
-    success: z.boolean(),
-    error: z.string().optional(),
-    timestamp: z.number(),
-    signature: z.string(),
-    context: z
-      .object({
-        channel: z.string(),
-        threadTs: z.string(),
-        repoFullName: z.string().optional(),
-        model: z.string().optional(),
-        reasoningEffort: z.string().optional(),
-        reactionMessageTs: z.string().optional(),
-      })
-      .passthrough(),
-  })
-  .passthrough();
+const slackCallbackContextSchema = z.looseObject({
+  source: z.literal("slack"),
+  channel: z.string(),
+  threadTs: z.string(),
+  repoFullName: z.string(),
+  model: z.string(),
+  reasoningEffort: z.string().optional(),
+  reactionMessageTs: z.string().optional(),
+});
+
+const completionCallbackSchema = z.looseObject({
+  sessionId: z.string(),
+  messageId: z.string(),
+  success: z.boolean(),
+  error: z.string().optional(),
+  timestamp: z.number(),
+  signature: z.string(),
+  context: slackCallbackContextSchema,
+});
 
 type CompletionCallbackPayload = z.infer<typeof completionCallbackSchema>;
 
-const toolCallCallbackSchema = z
-  .object({
-    sessionId: z.string(),
-    tool: z.string(),
-    args: z.record(z.string(), z.unknown()),
-    callId: z.string(),
-    timestamp: z.number(),
-    signature: z.string(),
-    context: z
-      .object({
-        source: z.literal("slack"),
-        channel: z.string(),
-        threadTs: z.string(),
-      })
-      .passthrough(),
-  })
-  .passthrough();
+const toolCallCallbackSchema = z.looseObject({
+  sessionId: z.string(),
+  tool: z.string(),
+  args: z.record(z.string(), z.unknown()),
+  callId: z.string(),
+  timestamp: z.number(),
+  signature: z.string(),
+  context: slackCallbackContextSchema,
+});
 
 type ToolCallCallbackPayload = z.infer<typeof toolCallCallbackSchema>;
 
@@ -484,20 +475,7 @@ async function handleCompletionCallback(
     }
 
     // Build and post completion message
-    const blocks = buildCompletionBlocks(
-      sessionId,
-      agentResponse,
-      {
-        source: "slack",
-        channel: context.channel,
-        threadTs: context.threadTs,
-        repoFullName: context.repoFullName ?? "",
-        model: context.model ?? "",
-        reasoningEffort: context.reasoningEffort,
-        reactionMessageTs: context.reactionMessageTs,
-      },
-      env.WEB_APP_URL
-    );
+    const blocks = buildCompletionBlocks(sessionId, agentResponse, context, env.WEB_APP_URL);
 
     await postMessage(env.SLACK_BOT_TOKEN, context.channel, getFallbackText(agentResponse), {
       thread_ts: context.threadTs,

--- a/packages/slack-bot/src/callbacks.ts
+++ b/packages/slack-bot/src/callbacks.ts
@@ -10,7 +10,8 @@ import {
   timingSafeEqual,
 } from "@open-inspect/shared";
 import { Hono, type Context } from "hono";
-import type { Env, CompletionCallback, ToolCallCallback } from "./types";
+import { z } from "zod";
+import type { Env } from "./types";
 import { extractAgentResponse } from "./completion/extractor";
 import { buildCompletionBlocks, getFallbackText, truncateError } from "./completion/blocks";
 import { createLogger } from "./logger";
@@ -59,47 +60,56 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
-/**
- * Validate callback payload shape.
- */
-function isValidPayload(payload: unknown): payload is CompletionCallback {
-  if (!isPlainRecord(payload)) return false;
-  const p = payload;
-  return (
-    typeof p.sessionId === "string" &&
-    typeof p.messageId === "string" &&
-    typeof p.success === "boolean" &&
-    typeof p.timestamp === "number" &&
-    typeof p.signature === "string" &&
-    isPlainRecord(p.context) &&
-    typeof p.context.channel === "string" &&
-    typeof p.context.threadTs === "string"
-  );
-}
+const completionCallbackSchema = z
+  .object({
+    sessionId: z.string(),
+    messageId: z.string(),
+    success: z.boolean(),
+    error: z.string().optional(),
+    timestamp: z.number(),
+    signature: z.string(),
+    context: z
+      .object({
+        channel: z.string(),
+        threadTs: z.string(),
+        repoFullName: z.string().optional(),
+        model: z.string().optional(),
+        reasoningEffort: z.string().optional(),
+        reactionMessageTs: z.string().optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
 
-function isValidSlackCallbackContext(context: unknown): boolean {
-  return (
-    isPlainRecord(context) &&
-    context.source === "slack" &&
-    typeof context.channel === "string" &&
-    typeof context.threadTs === "string"
-  );
-}
+type CompletionCallbackPayload = z.infer<typeof completionCallbackSchema>;
 
-/**
- * Validate tool-call callback payload shape.
- */
-function isValidToolCallPayload(payload: unknown): payload is ToolCallCallback {
-  if (!isPlainRecord(payload)) return false;
-  const p = payload;
+const toolCallCallbackSchema = z
+  .object({
+    sessionId: z.string(),
+    tool: z.string(),
+    args: z.record(z.string(), z.unknown()),
+    callId: z.string(),
+    timestamp: z.number(),
+    signature: z.string(),
+    context: z
+      .object({
+        source: z.literal("slack"),
+        channel: z.string(),
+        threadTs: z.string(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+type ToolCallCallbackPayload = z.infer<typeof toolCallCallbackSchema>;
+
+function isSignedCallbackPayload(
+  payload: unknown
+): payload is Record<string, unknown> & { signature: string; sessionId?: string } {
   return (
-    typeof p.sessionId === "string" &&
-    typeof p.tool === "string" &&
-    isPlainRecord(p.args) &&
-    typeof p.callId === "string" &&
-    typeof p.timestamp === "number" &&
-    typeof p.signature === "string" &&
-    isValidSlackCallbackContext(p.context)
+    isPlainRecord(payload) &&
+    typeof payload.signature === "string" &&
+    (payload.sessionId === undefined || typeof payload.sessionId === "string")
   );
 }
 
@@ -165,24 +175,10 @@ function isValidAutomationSkipPayload(payload: unknown): payload is AutomationSk
  */
 async function rejectInvalidCallback(
   c: Context<{ Bindings: Env }>,
-  payload: unknown,
-  isValid: (p: unknown) => boolean,
+  payload: { signature: string; sessionId?: string },
   opts: { path: string; traceId: string; startTime: number }
 ): Promise<Response | null> {
   const { path, traceId, startTime } = opts;
-
-  if (!isValid(payload)) {
-    log.warn("http.request", {
-      trace_id: traceId,
-      http_method: "POST",
-      http_path: path,
-      http_status: 400,
-      outcome: "rejected",
-      reject_reason: "invalid_payload",
-      duration_ms: Date.now() - startTime,
-    });
-    return c.json({ error: "invalid payload" }, 400);
-  }
 
   if (!c.env.INTERNAL_CALLBACK_SECRET) {
     log.error("http.request", {
@@ -197,10 +193,7 @@ async function rejectInvalidCallback(
     return c.json({ error: "not configured" }, 500);
   }
 
-  const authentic = await verifyCallbackSignature(
-    payload as { signature: string },
-    c.env.INTERNAL_CALLBACK_SECRET
-  );
+  const authentic = await verifyCallbackSignature(payload, c.env.INTERNAL_CALLBACK_SECRET);
   if (!authentic) {
     log.warn("http.request", {
       trace_id: traceId,
@@ -209,13 +202,31 @@ async function rejectInvalidCallback(
       http_status: 401,
       outcome: "rejected",
       reject_reason: "invalid_signature",
-      session_id: (payload as { sessionId?: string }).sessionId,
+      session_id: payload.sessionId,
       duration_ms: Date.now() - startTime,
     });
     return c.json({ error: "unauthorized" }, 401);
   }
 
   return null;
+}
+
+function rejectInvalidPayload(
+  c: Context<{ Bindings: Env }>,
+  path: string,
+  traceId: string,
+  startTime: number
+): Response {
+  log.warn("http.request", {
+    trace_id: traceId,
+    http_method: "POST",
+    http_path: path,
+    http_status: 400,
+    outcome: "rejected",
+    reject_reason: "invalid_payload",
+    duration_ms: Date.now() - startTime,
+  });
+  return c.json({ error: "invalid payload" }, 400);
 }
 
 export const callbacksRouter = new Hono<{ Bindings: Env }>();
@@ -228,14 +239,18 @@ callbacksRouter.post("/complete", async (c) => {
   // Use trace_id from control-plane if present, otherwise generate one
   const traceId = c.req.header("x-trace-id") || crypto.randomUUID();
   const payload = await c.req.json();
+  const parsed = completionCallbackSchema.safeParse(payload);
+  if (!parsed.success || !isSignedCallbackPayload(payload)) {
+    return rejectInvalidPayload(c, "/callbacks/complete", traceId, startTime);
+  }
+  const valid = parsed.data;
 
-  const rejection = await rejectInvalidCallback(c, payload, isValidPayload, {
+  const rejection = await rejectInvalidCallback(c, payload, {
     path: "/callbacks/complete",
     traceId,
     startTime,
   });
   if (rejection) return rejection;
-  const valid = payload as CompletionCallback;
 
   // Process in background
   c.executionCtx.waitUntil(handleCompletionCallback(valid, c.env, traceId));
@@ -276,13 +291,18 @@ callbacksRouter.post("/tool_call", async (c) => {
     return c.json({ error: "invalid payload" }, 400);
   }
 
-  const rejection = await rejectInvalidCallback(c, payload, isValidToolCallPayload, {
+  const parsed = toolCallCallbackSchema.safeParse(payload);
+  if (!parsed.success || !isSignedCallbackPayload(payload)) {
+    return rejectInvalidPayload(c, "/callbacks/tool_call", traceId, startTime);
+  }
+  const valid = parsed.data;
+
+  const rejection = await rejectInvalidCallback(c, payload, {
     path: "/callbacks/tool_call",
     traceId,
     startTime,
   });
   if (rejection) return rejection;
-  const valid = payload as ToolCallCallback;
 
   c.executionCtx.waitUntil(handleToolCallCallback(valid, c.env, traceId));
 
@@ -316,7 +336,11 @@ callbacksRouter.post("/automation-complete", async (c) => {
     return c.json({ error: "invalid payload" }, 400);
   }
 
-  const rejection = await rejectInvalidCallback(c, payload, isValidAutomationCompletePayload, {
+  if (!isValidAutomationCompletePayload(payload)) {
+    return rejectInvalidPayload(c, "/callbacks/automation-complete", traceId, startTime);
+  }
+
+  const rejection = await rejectInvalidCallback(c, payload, {
     path: "/callbacks/automation-complete",
     traceId,
     startTime,
@@ -346,7 +370,11 @@ callbacksRouter.post("/automation-skip", async (c) => {
     return c.json({ error: "invalid payload" }, 400);
   }
 
-  const rejection = await rejectInvalidCallback(c, payload, isValidAutomationSkipPayload, {
+  if (!isValidAutomationSkipPayload(payload)) {
+    return rejectInvalidPayload(c, "/callbacks/automation-skip", traceId, startTime);
+  }
+
+  const rejection = await rejectInvalidCallback(c, payload, {
     path: "/callbacks/automation-skip",
     traceId,
     startTime,
@@ -359,7 +387,7 @@ callbacksRouter.post("/automation-skip", async (c) => {
 });
 
 async function handleToolCallCallback(
-  payload: ToolCallCallback,
+  payload: ToolCallCallbackPayload,
   env: Env,
   traceId?: string
 ): Promise<void> {
@@ -394,7 +422,7 @@ async function handleToolCallCallback(
  * Handle completion callback - fetch events and post to Slack.
  */
 async function handleCompletionCallback(
-  payload: CompletionCallback,
+  payload: CompletionCallbackPayload,
   env: Env,
   traceId?: string
 ): Promise<void> {
@@ -456,7 +484,20 @@ async function handleCompletionCallback(
     }
 
     // Build and post completion message
-    const blocks = buildCompletionBlocks(sessionId, agentResponse, context, env.WEB_APP_URL);
+    const blocks = buildCompletionBlocks(
+      sessionId,
+      agentResponse,
+      {
+        source: "slack",
+        channel: context.channel,
+        threadTs: context.threadTs,
+        repoFullName: context.repoFullName ?? "",
+        model: context.model ?? "",
+        reasoningEffort: context.reasoningEffort,
+        reactionMessageTs: context.reactionMessageTs,
+      },
+      env.WEB_APP_URL
+    );
 
     await postMessage(env.SLACK_BOT_TOKEN, context.channel, getFallbackText(agentResponse), {
       thread_ts: context.threadTs,


### PR DESCRIPTION
This is an automated nightly unsafe-cast remediation sweep. It replaces selected high/medium-risk TypeScript assertions at trust boundaries with parse-don't-assert validation, following the TypeScript Coding Standards for unsafe casts and the Zod boundary-validation pattern established in PR #807.

## Findings Fixed

| file:line | risk | cast removed | fix |
| --- | --- | --- | --- |
| `packages/slack-bot/src/callbacks.ts:242` | HIGH | `payload as CompletionCallback` after `request.json()` | Added a Zod `completionCallbackSchema` and route-local `safeParse`; HMAC verification still uses the original payload object so signed unknown fields are preserved. |
| `packages/slack-bot/src/callbacks.ts:294` | HIGH | `payload as ToolCallCallback` after `request.json()` | Added a Zod `toolCallCallbackSchema` and route-local `safeParse`; malformed Slack context continues to return the existing 400 response. |
| `packages/control-plane/src/scheduler/slack-completion.ts:35` | MEDIUM | `JSON.parse(raw) as SlackRunMetadata` from persisted trigger metadata | Added a Zod `slackRunMetadataSchema`, made `SlackRunMetadata` a `z.infer` type, and return `null` on parse/shape failure to preserve the existing skip contract. |

## Verification

| command | result |
| --- | --- |
| `npm run build -w @open-inspect/shared` | passed |
| `npm run build -w @open-inspect/control-plane` | passed |
| `npm run build -w @open-inspect/slack-bot` | passed |
| `npm run typecheck` | passed |
| `npm run format` | passed |
| `npm run lint` | passed in a clean temporary worktree with this patch applied; the main worktree has a pre-existing untracked `.opencode/` directory that causes root lint to scan non-repo tool files |
| `npm run lint -w @open-inspect/control-plane` | passed |
| `npm run lint -w @open-inspect/slack-bot` | passed |
| `npm test -w @open-inspect/control-plane` | passed |
| `npm test -w @open-inspect/slack-bot` | passed |

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/a20ac15ca97c48a0ccb3c1d3ea968bf9)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for Slack callback requests using stricter schema checks, ensuring malformed or partially populated signed payloads fail cleanly.
  * Hardened completion and tool-call handling to reject invalid payloads early while preserving unknown signed fields on valid requests.
  * Added safer Slack run metadata parsing with schema validation, returning `null` for malformed or incomplete metadata.
* **Tests**
  * Added coverage for callback validation and completion handling, including malformed/partial payload rejection and correct message routing for signed completions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->