### PR TITLE
feat(web): render session repositories (read-only)

### DIFF
--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -1,17 +1,13 @@
-import type { SessionStatus, SpawnSource } from "@open-inspect/shared";
+import type { SessionListRepository, SessionStatus, SpawnSource } from "@open-inspect/shared";
 
 /**
  * One member of a session's repository set — the identity subset of the
  * shared SessionRepositoryState (no git state; D1 doesn't store it).
  * Ordered — array position is the persisted `position` column ([0] =
- * primary, mirrored into the scalar repo_owner/repo_name columns).
+ * primary, mirrored into the scalar repo_owner/repo_name columns). Aliases
+ * the shared wire type so Session.repositories and this share one shape.
  */
-export interface SessionIndexRepository {
-  repoOwner: string;
-  repoName: string;
-  repoId: number | null;
-  baseBranch: string;
-}
+export type SessionIndexRepository = SessionListRepository;
 
 export interface SessionEntry {
   id: string;

--- a/packages/control-plane/src/session/pr-artifacts.ts
+++ b/packages/control-plane/src/session/pr-artifacts.ts
@@ -1,4 +1,5 @@
-import { repoIdentityEquals, type RepoIdentity } from "./repository-target";
+import { prArtifactBelongsToRepo } from "@open-inspect/shared";
+import type { RepoIdentity } from "./repository-target";
 import type { ArtifactRow } from "./types";
 
 /**
@@ -23,17 +24,18 @@ export function parsePrArtifactRepo(metadata: string | null): RepoIdentity | nul
 
 /**
  * Find a PR artifact belonging to the target repo. Identity-less metadata
- * matches only when the target is the primary.
+ * matches only when the target is the primary — the ownership convention lives
+ * in shared {@link prArtifactBelongsToRepo}; this only supplies the parsed
+ * identity from ArtifactRow metadata.
  */
 export function findPrArtifactForRepo(
   artifacts: ArtifactRow[],
   targetRepo: RepoIdentity,
   isPrimary: boolean
 ): ArtifactRow | undefined {
-  return artifacts.find((artifact) => {
-    if (artifact.type !== "pr") return false;
-    const artifactRepo = parsePrArtifactRepo(artifact.metadata);
-    if (!artifactRepo) return isPrimary;
-    return repoIdentityEquals(artifactRepo, targetRepo);
-  });
+  return artifacts.find(
+    (artifact) =>
+      artifact.type === "pr" &&
+      prArtifactBelongsToRepo(parsePrArtifactRepo(artifact.metadata), targetRepo, isPrimary)
+  );
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -507,6 +507,26 @@ export interface SessionListRepository {
 }
 
 /**
+ * Whether a PR artifact belongs to a given session member. Artifacts written
+ * before multi-repo support carry no repo identity (`artifactRepo === null`)
+ * and by construction belong to the session's primary. Identity is compared
+ * case-insensitively, matching repo-identity comparison elsewhere. This is the
+ * single home of that convention — the control-plane per-repo prUrl projection
+ * (findPrArtifactForRepo) and the web per-repo PR chips both go through here.
+ */
+export function prArtifactBelongsToRepo(
+  artifactRepo: { repoOwner: string; repoName: string } | null,
+  targetRepo: { repoOwner: string; repoName: string },
+  targetIsPrimary: boolean
+): boolean {
+  if (!artifactRepo) return targetIsPrimary;
+  return (
+    artifactRepo.repoOwner.toLowerCase() === targetRepo.repoOwner.toLowerCase() &&
+    artifactRepo.repoName.toLowerCase() === targetRepo.repoName.toLowerCase()
+  );
+}
+
+/**
  * One repository entry on a create/update request. Identifiers are normalized
  * (trim + lowercase) by the schema, matching normalizeOptionalRepositoryPair —
  * the list-entry twin of that scalar helper.

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -138,6 +138,12 @@ export interface Session {
   spawnDepth: number;
   createdAt: number;
   updatedAt: number;
+  /**
+   * Ordered member list; [0] = primary. Absent on scalar-era sessions —
+   * consumers fall back to the scalar repoOwner/repoName. Populated by the
+   * session list index (SessionEntry.repositories).
+   */
+  repositories?: SessionListRepository[];
 }
 
 // Message in a session
@@ -484,6 +490,21 @@ export const sessionRepositoryStateSchema = z.object({
 });
 
 export type SessionRepositoryState = z.infer<typeof sessionRepositoryStateSchema>;
+
+/**
+ * A session's repository-set member as carried on the session list contract
+ * (Session.repositories / control-plane SessionEntry.repositories). The
+ * identity subset of SessionRepositoryState — no git state, since the list
+ * index doesn't store it. Ordered; [0] = primary (mirrored into the scalar
+ * repoOwner/repoName columns). Control-plane's SessionIndexRepository aliases
+ * this so the wire shape has a single home.
+ */
+export interface SessionListRepository {
+  repoOwner: string;
+  repoName: string;
+  repoId: number | null;
+  baseBranch: string;
+}
 
 /**
  * One repository entry on a create/update request. Identifiers are normalized

--- a/packages/shared/src/types/repository-contracts.test.ts
+++ b/packages/shared/src/types/repository-contracts.test.ts
@@ -5,6 +5,7 @@ import {
   MAX_AUTOMATION_REPOSITORIES,
   MAX_SESSION_REPOSITORIES,
   MAX_TARGET_REPOSITORIES,
+  prArtifactBelongsToRepo,
   sandboxEventSchema,
   serverMessageSchema,
   sessionRepositoriesInputSchema,
@@ -236,5 +237,24 @@ describe("toRepositoryRef", () => {
     expect(() =>
       toRepositoryRef({ repoOwner: "acme", repoName: "app", repoId: null, baseBranch: null })
     ).toThrow(/not resolved/);
+  });
+});
+
+describe("prArtifactBelongsToRepo", () => {
+  const web = { repoOwner: "acme", repoName: "web" };
+  const api = { repoOwner: "acme", repoName: "api" };
+
+  it("attributes an identity-less artifact to the primary only", () => {
+    expect(prArtifactBelongsToRepo(null, web, true)).toBe(true);
+    expect(prArtifactBelongsToRepo(null, api, false)).toBe(false);
+  });
+
+  it("matches on identity regardless of primary flag", () => {
+    expect(prArtifactBelongsToRepo(web, web, false)).toBe(true);
+    expect(prArtifactBelongsToRepo(web, api, true)).toBe(false);
+  });
+
+  it("compares identity case-insensitively", () => {
+    expect(prArtifactBelongsToRepo({ repoOwner: "Acme", repoName: "Web" }, web, false)).toBe(true);
   });
 });

--- a/packages/web/src/components/session-right-sidebar.tsx
+++ b/packages/web/src/components/session-right-sidebar.tsx
@@ -44,6 +44,13 @@ export function SessionRightSidebarContent({
 }: SessionRightSidebarContentProps) {
   const tasks = useMemo(() => extractLatestTasks(events), [events]);
   const filesChanged = useMemo(() => extractChangedFiles(events), [events]);
+  const warnings = useMemo(
+    () =>
+      events.filter(
+        (event): event is Extract<SandboxEvent, { type: "warning" }> => event.type === "warning"
+      ),
+    [events]
+  );
   const mediaArtifacts = useMemo(
     () =>
       artifacts.filter((artifact) => artifact.type === "screenshot" || artifact.type === "video"),
@@ -84,6 +91,8 @@ export function SessionRightSidebarContent({
           repoOwner={sessionState.repoOwner}
           repoName={sessionState.repoName}
           artifacts={artifacts}
+          repositories={sessionState.repositories}
+          warnings={warnings}
           parentSessionId={sessionState.parentSessionId}
           totalCost={sessionState.totalCost}
         />

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -39,7 +39,7 @@ import {
   DataControlsIcon,
 } from "@/components/ui/icons";
 import { APP_SHORT_NAME } from "@/lib/site-config";
-import { formatRepoLabel } from "@/lib/repo-label";
+import { formatRepoLabel, formatSessionRepositoriesLabel } from "@/lib/repo-label";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -645,7 +645,11 @@ function SessionListItem({
 }) {
   const timestamp = session.updatedAt || session.createdAt;
   const relativeTime = formatRelativeTime(timestamp);
-  const repoInfo = formatRepoLabel(session.repoOwner, session.repoName);
+  const repoInfo = formatSessionRepositoriesLabel(
+    session.repoOwner,
+    session.repoName,
+    session.repositories
+  );
   const displayTitle = session.title || repoInfo;
   // Orphan child (parent filtered out) — show a subtle badge
   const isOrphanChild = session.parentSessionId && session.spawnSource === "agent";

--- a/packages/web/src/components/sidebar/metadata-section.test.tsx
+++ b/packages/web/src/components/sidebar/metadata-section.test.tsx
@@ -1,12 +1,17 @@
 // @vitest-environment jsdom
 /// <reference types="@testing-library/jest-dom" />
 
-import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { MetadataSection } from "./metadata-section";
 
 expect.extend(matchers);
+
+// This suite renders into a shared document.body without vitest globals/auto-
+// cleanup, so unmount between cases to keep queries (e.g. PR state badges) from
+// matching leftover DOM from earlier renders.
+afterEach(cleanup);
 
 vi.mock("next/link", () => ({
   default: ({ children, href, ...props }: React.ComponentProps<"a">) => (
@@ -47,5 +52,102 @@ describe("MetadataSection", () => {
     );
 
     expect(screen.getByText("No repository")).toBeInTheDocument();
+  });
+
+  function member(repoOwner: string, repoName: string, position: number) {
+    return {
+      position,
+      repoOwner,
+      repoName,
+      repoId: position + 1,
+      baseBranch: "main",
+      branchName: null,
+      baseSha: null,
+      currentSha: null,
+      prUrl: null,
+    };
+  }
+
+  it("renders a per-repo member list with per-repo PR chips matched by artifact metadata", () => {
+    render(
+      <MetadataSection
+        createdAt={Date.now()}
+        baseBranch="main"
+        repoOwner="acme"
+        repoName="web"
+        repositories={[member("acme", "web", 0), member("acme", "api", 1)]}
+        artifacts={[
+          {
+            id: "pr-web",
+            type: "pr",
+            url: "https://github.com/acme/web/pull/1",
+            metadata: { prNumber: 1, prState: "open", repoOwner: "acme", repoName: "web" },
+            createdAt: 1,
+          },
+          {
+            id: "pr-api",
+            type: "pr",
+            url: "https://github.com/acme/api/pull/2",
+            metadata: { prNumber: 2, prState: "merged", repoOwner: "acme", repoName: "api" },
+            createdAt: 2,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByRole("link", { name: "acme/web" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "acme/api" })).toBeInTheDocument();
+    expect(screen.getByText("primary")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "#1" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "#2" })).toBeInTheDocument();
+    expect(screen.getByText("open")).toBeInTheDocument();
+    expect(screen.getByText("merged")).toBeInTheDocument();
+  });
+
+  it("attributes an identity-less PR artifact to the primary member only", () => {
+    render(
+      <MetadataSection
+        createdAt={Date.now()}
+        baseBranch="main"
+        repoOwner="acme"
+        repoName="web"
+        repositories={[member("acme", "web", 0), member("acme", "api", 1)]}
+        artifacts={[
+          {
+            id: "pr-legacy",
+            type: "pr",
+            url: "https://github.com/acme/web/pull/7",
+            metadata: { prNumber: 7, prState: "open" },
+            createdAt: 1,
+          },
+        ]}
+      />
+    );
+
+    // The identity-less PR belongs to the primary, so it renders exactly once.
+    expect(screen.getAllByRole("link", { name: "#7" })).toHaveLength(1);
+  });
+
+  it("renders non-fatal warnings with repo attribution", () => {
+    render(
+      <MetadataSection
+        createdAt={Date.now()}
+        baseBranch="main"
+        repoOwner="acme"
+        repoName="web"
+        warnings={[
+          {
+            type: "warning",
+            scope: "secrets",
+            message: "Secret key collision on API_KEY",
+            repoOwner: "acme",
+            repoName: "api",
+            timestamp: 1,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText("acme/api: Secret key collision on API_KEY")).toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/sidebar/metadata-section.tsx
+++ b/packages/web/src/components/sidebar/metadata-section.tsx
@@ -9,7 +9,7 @@ import { getSafeExternalUrl } from "@/lib/urls";
 import { getScmBranchUrl, getScmRepoUrl } from "@/lib/scm";
 import { NO_REPOSITORY_LABEL } from "@/lib/repo-label";
 import type { Artifact, SandboxEvent } from "@/types/session";
-import type { SessionRepositoryState } from "@open-inspect/shared";
+import { prArtifactBelongsToRepo, type SessionRepositoryState } from "@open-inspect/shared";
 import {
   ClockIcon,
   SparkleIcon,
@@ -44,9 +44,10 @@ interface MetadataSectionProps {
 }
 
 /**
- * The PR artifact belonging to a member repo. Mirrors the control-plane
- * findPrArtifactForRepo: identity-less artifact metadata (written before
- * multi-repo support) belongs to the primary.
+ * The PR artifact belonging to a member repo. The ownership convention
+ * (identity-less artifact → primary; case-insensitive match) lives in shared
+ * prArtifactBelongsToRepo — the same helper the control-plane prUrl projection
+ * uses; here we only supply the identity parsed from the UI artifact metadata.
  */
 function findPrArtifactForRepo(
   artifacts: Artifact[],
@@ -56,8 +57,8 @@ function findPrArtifactForRepo(
   return artifacts.find((artifact) => {
     if (artifact.type !== "pr") return false;
     const { repoOwner, repoName } = artifact.metadata ?? {};
-    if (!repoOwner || !repoName) return isPrimary;
-    return repoOwner === repo.repoOwner && repoName === repo.repoName;
+    const artifactRepo = repoOwner && repoName ? { repoOwner, repoName } : null;
+    return prArtifactBelongsToRepo(artifactRepo, repo, isPrimary);
   });
 }
 

--- a/packages/web/src/components/sidebar/metadata-section.tsx
+++ b/packages/web/src/components/sidebar/metadata-section.tsx
@@ -8,7 +8,8 @@ import { formatRelativeTime } from "@/lib/time";
 import { getSafeExternalUrl } from "@/lib/urls";
 import { getScmBranchUrl, getScmRepoUrl } from "@/lib/scm";
 import { NO_REPOSITORY_LABEL } from "@/lib/repo-label";
-import type { Artifact } from "@/types/session";
+import type { Artifact, SandboxEvent } from "@/types/session";
+import type { SessionRepositoryState } from "@open-inspect/shared";
 import {
   ClockIcon,
   SparkleIcon,
@@ -18,8 +19,11 @@ import {
   CopyIcon,
   CheckIcon,
   LinkIcon,
+  ErrorIcon,
 } from "@/components/ui/icons";
 import { Badge, prBadgeVariant } from "@/components/ui/badge";
+
+type WarningEvent = Extract<SandboxEvent, { type: "warning" }>;
 
 interface MetadataSectionProps {
   createdAt: number;
@@ -30,8 +34,31 @@ interface MetadataSectionProps {
   repoOwner?: string | null;
   repoName?: string | null;
   artifacts?: Artifact[];
+  /** Ordered member list ([0] = primary). Multi-member sessions render a
+   *  per-repo list instead of the scalar repo tag. */
+  repositories?: SessionRepositoryState[];
+  /** Non-fatal boot/runtime warnings surfaced to the user. */
+  warnings?: WarningEvent[];
   parentSessionId?: string | null;
   totalCost?: number;
+}
+
+/**
+ * The PR artifact belonging to a member repo. Mirrors the control-plane
+ * findPrArtifactForRepo: identity-less artifact metadata (written before
+ * multi-repo support) belongs to the primary.
+ */
+function findPrArtifactForRepo(
+  artifacts: Artifact[],
+  repo: SessionRepositoryState,
+  isPrimary: boolean
+): Artifact | undefined {
+  return artifacts.find((artifact) => {
+    if (artifact.type !== "pr") return false;
+    const { repoOwner, repoName } = artifact.metadata ?? {};
+    if (!repoOwner || !repoName) return isPrimary;
+    return repoOwner === repo.repoOwner && repoName === repo.repoName;
+  });
 }
 
 export function MetadataSection({
@@ -43,10 +70,14 @@ export function MetadataSection({
   repoOwner,
   repoName,
   artifacts = [],
+  repositories,
+  warnings = [],
   parentSessionId,
   totalCost,
 }: MetadataSectionProps) {
   const [copied, setCopied] = useState(false);
+
+  const isMultiRepo = (repositories?.length ?? 0) > 1;
 
   const prArtifact = artifacts.find((a) => a.type === "pr");
   const manualPrArtifact = artifacts.find(
@@ -106,101 +137,209 @@ export function MetadataSection({
         </div>
       )}
 
-      {/* PR Badge */}
-      {(prNumber || prUrl) && (
-        <div className="flex items-center gap-2 text-sm">
-          <RepoIcon className="w-4 h-4 text-muted-foreground" />
-          {prUrl ? (
-            <a
-              href={prUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-accent hover:underline"
-            >
-              {prNumber ? `#${prNumber}` : "Create PR"}
-            </a>
-          ) : (
-            <span className="text-foreground">#{prNumber}</span>
+      {/* Scalar repo/PR/branch rows — single-repo (and scalar-era) sessions
+          render exactly as before. Multi-repo sessions use the member list. */}
+      {!isMultiRepo && (
+        <>
+          {/* PR Badge */}
+          {(prNumber || prUrl) && (
+            <div className="flex items-center gap-2 text-sm">
+              <RepoIcon className="w-4 h-4 text-muted-foreground" />
+              {prUrl ? (
+                <a
+                  href={prUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-accent hover:underline"
+                >
+                  {prNumber ? `#${prNumber}` : "Create PR"}
+                </a>
+              ) : (
+                <span className="text-foreground">#{prNumber}</span>
+              )}
+              {prState && (
+                <Badge variant={prBadgeVariant(prState)} className="capitalize">
+                  {prState}
+                </Badge>
+              )}
+            </div>
           )}
-          {prState && (
-            <Badge variant={prBadgeVariant(prState)} className="capitalize">
-              {prState}
-            </Badge>
+
+          {/* Base Branch */}
+          {baseBranch && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <BranchIcon className="w-4 h-4" />
+              {repoOwner && repoName ? (
+                <a
+                  href={getScmBranchUrl(repoOwner, repoName, baseBranch)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-accent truncate max-w-[180px] hover:underline"
+                  title={baseBranch}
+                >
+                  {truncateBranch(baseBranch)}
+                </a>
+              ) : (
+                <span className="truncate max-w-[180px]" title={baseBranch}>
+                  {truncateBranch(baseBranch)}
+                </span>
+              )}
+            </div>
           )}
+
+          {/* Working Branch */}
+          {branchName && (
+            <div className="flex items-center gap-2 text-sm">
+              <GitPrIcon className="w-4 h-4 text-muted-foreground" />
+              {branchUrl ? (
+                <a
+                  href={branchUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-accent truncate max-w-[180px] hover:underline"
+                  title={branchName}
+                >
+                  {truncateBranch(branchName)}
+                </a>
+              ) : (
+                <span className="text-foreground truncate max-w-[180px]" title={branchName}>
+                  {truncateBranch(branchName)}
+                </span>
+              )}
+              <button
+                onClick={handleCopyBranch}
+                className="p-1 hover:bg-muted transition-colors"
+                title={copied ? "Copied!" : "Copy branch name"}
+              >
+                {copied ? (
+                  <CheckIcon className="w-3.5 h-3.5 text-success" />
+                ) : (
+                  <CopyIcon className="w-3.5 h-3.5 text-secondary-foreground" />
+                )}
+              </button>
+            </div>
+          )}
+
+          {/* Repository tag */}
+          {hasRepositoryMetadata && (
+            <div className="flex items-center gap-2 text-sm">
+              <RepoIcon className="w-4 h-4 text-muted-foreground" />
+              {repoOwner && repoName ? (
+                <a
+                  href={getScmRepoUrl(repoOwner, repoName)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-accent hover:underline"
+                >
+                  {repoOwner}/{repoName}
+                </a>
+              ) : (
+                <span className="text-muted-foreground">{NO_REPOSITORY_LABEL}</span>
+              )}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Repository member list (multi-repo sessions) */}
+      {isMultiRepo && repositories && (
+        <div className="space-y-2">
+          <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Repositories
+          </div>
+          {repositories.map((repo, index) => {
+            const memberPrArtifact = findPrArtifactForRepo(artifacts, repo, index === 0);
+            const memberPrNumber = memberPrArtifact?.metadata?.prNumber;
+            const memberPrState = memberPrArtifact?.metadata?.prState;
+            const memberPrUrl = getSafeExternalUrl(
+              memberPrArtifact?.url || repo.prUrl || undefined
+            );
+            const memberBranchUrl = repo.branchName
+              ? getScmBranchUrl(repo.repoOwner, repo.repoName, repo.branchName)
+              : null;
+            return (
+              <div key={`${repo.repoOwner}/${repo.repoName}`} className="space-y-1">
+                <div className="flex items-center gap-2 text-sm">
+                  <RepoIcon className="w-4 h-4 text-muted-foreground" />
+                  <a
+                    href={getScmRepoUrl(repo.repoOwner, repo.repoName)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-accent hover:underline truncate max-w-[170px]"
+                    title={`${repo.repoOwner}/${repo.repoName}`}
+                  >
+                    {repo.repoOwner}/{repo.repoName}
+                  </a>
+                  {index === 0 && (
+                    <Badge variant="info" className="text-[10px]">
+                      primary
+                    </Badge>
+                  )}
+                </div>
+                {(repo.branchName || memberPrNumber || memberPrUrl) && (
+                  <div className="ml-6 flex items-center gap-2 text-xs text-muted-foreground">
+                    {repo.branchName && (
+                      <span className="inline-flex min-w-0 items-center gap-1">
+                        <GitPrIcon className="w-3.5 h-3.5 flex-shrink-0" />
+                        {memberBranchUrl ? (
+                          <a
+                            href={memberBranchUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-accent truncate max-w-[120px] hover:underline"
+                            title={repo.branchName}
+                          >
+                            {truncateBranch(repo.branchName)}
+                          </a>
+                        ) : (
+                          <span className="truncate max-w-[120px]" title={repo.branchName}>
+                            {truncateBranch(repo.branchName)}
+                          </span>
+                        )}
+                      </span>
+                    )}
+                    {(memberPrNumber || memberPrUrl) &&
+                      (memberPrUrl ? (
+                        <a
+                          href={memberPrUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-accent hover:underline"
+                        >
+                          {memberPrNumber ? `#${memberPrNumber}` : "PR"}
+                        </a>
+                      ) : (
+                        <span className="text-foreground">#{memberPrNumber}</span>
+                      ))}
+                    {memberPrState && (
+                      <Badge variant={prBadgeVariant(memberPrState)} className="capitalize">
+                        {memberPrState}
+                      </Badge>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
 
-      {/* Base Branch */}
-      {baseBranch && (
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <BranchIcon className="w-4 h-4" />
-          {repoOwner && repoName ? (
-            <a
-              href={getScmBranchUrl(repoOwner, repoName, baseBranch)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-accent truncate max-w-[180px] hover:underline"
-              title={baseBranch}
+      {/* Non-fatal boot/runtime warnings */}
+      {warnings.length > 0 && (
+        <div className="space-y-1">
+          {warnings.map((warning, index) => (
+            <div
+              key={warning.ackId ?? `${warning.scope}-${warning.timestamp}-${index}`}
+              className="flex items-start gap-2 text-xs text-warning"
             >
-              {truncateBranch(baseBranch)}
-            </a>
-          ) : (
-            <span className="truncate max-w-[180px]" title={baseBranch}>
-              {truncateBranch(baseBranch)}
-            </span>
-          )}
-        </div>
-      )}
-
-      {/* Working Branch */}
-      {branchName && (
-        <div className="flex items-center gap-2 text-sm">
-          <GitPrIcon className="w-4 h-4 text-muted-foreground" />
-          {branchUrl ? (
-            <a
-              href={branchUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-accent truncate max-w-[180px] hover:underline"
-              title={branchName}
-            >
-              {truncateBranch(branchName)}
-            </a>
-          ) : (
-            <span className="text-foreground truncate max-w-[180px]" title={branchName}>
-              {truncateBranch(branchName)}
-            </span>
-          )}
-          <button
-            onClick={handleCopyBranch}
-            className="p-1 hover:bg-muted transition-colors"
-            title={copied ? "Copied!" : "Copy branch name"}
-          >
-            {copied ? (
-              <CheckIcon className="w-3.5 h-3.5 text-success" />
-            ) : (
-              <CopyIcon className="w-3.5 h-3.5 text-secondary-foreground" />
-            )}
-          </button>
-        </div>
-      )}
-
-      {/* Repository tag */}
-      {hasRepositoryMetadata && (
-        <div className="flex items-center gap-2 text-sm">
-          <RepoIcon className="w-4 h-4 text-muted-foreground" />
-          {repoOwner && repoName ? (
-            <a
-              href={getScmRepoUrl(repoOwner, repoName)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-accent hover:underline"
-            >
-              {repoOwner}/{repoName}
-            </a>
-          ) : (
-            <span className="text-muted-foreground">{NO_REPOSITORY_LABEL}</span>
-          )}
+              <ErrorIcon className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
+              <span className="min-w-0">
+                {(warning.repoOwner && warning.repoName
+                  ? `${warning.repoOwner}/${warning.repoName}: `
+                  : "") + warning.message}
+              </span>
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/packages/web/src/hooks/use-session-socket.test.tsx
+++ b/packages/web/src/hooks/use-session-socket.test.tsx
@@ -559,6 +559,63 @@ describe("useSessionSocket", () => {
     );
   });
 
+  it("ignores an unscoped session_branch for a multi-repo session", async () => {
+    const { result } = renderHook(() => useSessionSocket("session-1"));
+
+    await waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
+
+    const socket = FakeWebSocket.instances[0];
+    const multiRepoState = createSessionState({
+      branchName: "open-inspect/session-1",
+      repositories: [
+        {
+          position: 0,
+          repoOwner: "acme",
+          repoName: "web",
+          repoId: 1,
+          baseBranch: "main",
+          branchName: "open-inspect/session-1",
+          baseSha: null,
+          currentSha: null,
+          prUrl: null,
+        },
+        {
+          position: 1,
+          repoOwner: "acme",
+          repoName: "api",
+          repoId: 2,
+          baseBranch: "main",
+          branchName: null,
+          baseSha: null,
+          currentSha: null,
+          prUrl: null,
+        },
+      ],
+    });
+
+    act(() => {
+      socket.open();
+      socket.receive({ ...createSubscribedMessage(), state: multiRepoState });
+    });
+
+    // An identity-less update on a multi-repo session is anomalous — it must not
+    // be attributed to the primary or clobber the scalar branch.
+    act(() => {
+      socket.receive({ type: "session_branch", branchName: "open-inspect/session-1-orphan" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionState?.repositories).toBeTruthy();
+    });
+    expect(result.current.sessionState?.branchName).toBe("open-inspect/session-1");
+    expect(result.current.sessionState?.repositories?.[0].branchName).toBe(
+      "open-inspect/session-1"
+    );
+    expect(result.current.sessionState?.repositories?.[1].branchName).toBeNull();
+  });
+
   it("updates sessionState.sandboxDashboardUrl from sandbox_dashboard_url", async () => {
     const { result } = renderHook(() => useSessionSocket("session-1"));
 

--- a/packages/web/src/hooks/use-session-socket.test.tsx
+++ b/packages/web/src/hooks/use-session-socket.test.tsx
@@ -480,6 +480,85 @@ describe("useSessionSocket", () => {
     expect(mutateMock).not.toHaveBeenCalled();
   });
 
+  it("routes a repo-scoped session_branch to the matching member, mirroring the scalar only for the primary", async () => {
+    const { result } = renderHook(() => useSessionSocket("session-1"));
+
+    await waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
+
+    const socket = FakeWebSocket.instances[0];
+    const multiRepoState = createSessionState({
+      branchName: "open-inspect/session-1",
+      repositories: [
+        {
+          position: 0,
+          repoOwner: "acme",
+          repoName: "web",
+          repoId: 1,
+          baseBranch: "main",
+          branchName: "open-inspect/session-1",
+          baseSha: null,
+          currentSha: null,
+          prUrl: null,
+        },
+        {
+          position: 1,
+          repoOwner: "acme",
+          repoName: "api",
+          repoId: 2,
+          baseBranch: "main",
+          branchName: null,
+          baseSha: null,
+          currentSha: null,
+          prUrl: null,
+        },
+      ],
+    });
+
+    act(() => {
+      socket.open();
+      socket.receive({ ...createSubscribedMessage(), state: multiRepoState });
+    });
+
+    // Secondary push: update the member, leave the scalar (primary) branch alone.
+    act(() => {
+      socket.receive({
+        type: "session_branch",
+        branchName: "open-inspect/session-1-api",
+        repoOwner: "acme",
+        repoName: "api",
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionState?.repositories?.[1].branchName).toBe(
+        "open-inspect/session-1-api"
+      );
+    });
+    expect(result.current.sessionState?.repositories?.[0].branchName).toBe(
+      "open-inspect/session-1"
+    );
+    expect(result.current.sessionState?.branchName).toBe("open-inspect/session-1");
+
+    // Primary push: update the member and mirror to the scalar.
+    act(() => {
+      socket.receive({
+        type: "session_branch",
+        branchName: "open-inspect/session-1-web",
+        repoOwner: "acme",
+        repoName: "web",
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessionState?.branchName).toBe("open-inspect/session-1-web");
+    });
+    expect(result.current.sessionState?.repositories?.[0].branchName).toBe(
+      "open-inspect/session-1-web"
+    );
+  });
+
   it("updates sessionState.sandboxDashboardUrl from sandbox_dashboard_url", async () => {
     const { result } = renderHook(() => useSessionSocket("session-1"));
 

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -228,12 +228,18 @@ function toUiArtifact(artifact: SessionArtifact): Artifact {
 }
 
 /**
- * Apply a `session_branch` update. In a multi-repo session the message names
- * the member whose branch changed (repoOwner/repoName); we update that member's
- * `branchName` in `state.repositories` and mirror to the scalar `branchName`
- * only when it names the primary (position 0). An absent identity names the
- * session's sole repo (the primary), so it mirrors to the scalar too. Sessions
- * without a hydrated member list stay scalar-only, exactly as before.
+ * Apply a `session_branch` update, keeping `state.repositories` and the scalar
+ * `branchName` in sync. The invariant is explicit rather than a sole/primary
+ * guess:
+ *
+ * - No hydrated member list → scalar-only, exactly as before.
+ * - Exactly one member → the update names the sole repo (the primary): update
+ *   it and mirror the scalar.
+ * - Multi-repo (`length > 1`) → the message MUST name its member
+ *   (repoOwner/repoName); an unscoped or unknown-member update is anomalous
+ *   (multi-repo runtimes always echo identity) and is ignored rather than
+ *   attributed to the primary. The scalar mirrors only when the named member is
+ *   the primary (position 0).
  */
 function applySessionBranchUpdate(
   prev: SessionState,
@@ -242,29 +248,37 @@ function applySessionBranchUpdate(
   repoName: string | undefined
 ): SessionState {
   const repositories = prev.repositories;
+
   if (!repositories || repositories.length === 0) {
     return { ...prev, branchName };
   }
 
-  const targetIndex =
-    repoOwner && repoName
-      ? repositories.findIndex((r) => r.repoOwner === repoOwner && r.repoName === repoName)
-      : 0; // absent identity → the session's sole/primary repo
+  if (repositories.length === 1) {
+    return {
+      ...prev,
+      repositories: [{ ...repositories[0], branchName }],
+      branchName,
+    };
+  }
 
+  // Multi-repo: require identity; ignore an update we can't attribute.
+  if (!repoOwner || !repoName) {
+    return prev;
+  }
+  const targetIndex = repositories.findIndex(
+    (repo) => repo.repoOwner === repoOwner && repo.repoName === repoName
+  );
   if (targetIndex === -1) {
-    // Branch update for a repo not in the member list — leave state untouched
-    // rather than clobber the scalar branch.
     return prev;
   }
 
   const updatedRepositories = repositories.map((repo, index) =>
     index === targetIndex ? { ...repo, branchName } : repo
   );
-  const isPrimary = targetIndex === 0;
   return {
     ...prev,
     repositories: updatedRepositories,
-    ...(isPrimary ? { branchName } : {}),
+    ...(targetIndex === 0 ? { branchName } : {}),
   };
 }
 

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -220,8 +220,51 @@ function toUiArtifact(artifact: SessionArtifact): Artifact {
             meta.previewStatus === "stopped"
               ? meta.previewStatus
               : undefined,
+          repoOwner: typeof meta.repoOwner === "string" ? meta.repoOwner : undefined,
+          repoName: typeof meta.repoName === "string" ? meta.repoName : undefined,
         }
       : undefined,
+  };
+}
+
+/**
+ * Apply a `session_branch` update. In a multi-repo session the message names
+ * the member whose branch changed (repoOwner/repoName); we update that member's
+ * `branchName` in `state.repositories` and mirror to the scalar `branchName`
+ * only when it names the primary (position 0). An absent identity names the
+ * session's sole repo (the primary), so it mirrors to the scalar too. Sessions
+ * without a hydrated member list stay scalar-only, exactly as before.
+ */
+function applySessionBranchUpdate(
+  prev: SessionState,
+  branchName: string,
+  repoOwner: string | undefined,
+  repoName: string | undefined
+): SessionState {
+  const repositories = prev.repositories;
+  if (!repositories || repositories.length === 0) {
+    return { ...prev, branchName };
+  }
+
+  const targetIndex =
+    repoOwner && repoName
+      ? repositories.findIndex((r) => r.repoOwner === repoOwner && r.repoName === repoName)
+      : 0; // absent identity → the session's sole/primary repo
+
+  if (targetIndex === -1) {
+    // Branch update for a repo not in the member list — leave state untouched
+    // rather than clobber the scalar branch.
+    return prev;
+  }
+
+  const updatedRepositories = repositories.map((repo, index) =>
+    index === targetIndex ? { ...repo, branchName } : repo
+  );
+  const isPrimary = targetIndex === 0;
+  return {
+    ...prev,
+    repositories: updatedRepositories,
+    ...(isPrimary ? { branchName } : {}),
   };
 }
 
@@ -459,7 +502,11 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
 
         case "session_branch":
           // Branch updates apply only to the active session detail view.
-          setSessionState((prev) => (prev ? { ...prev, branchName: data.branchName } : null));
+          setSessionState((prev) =>
+            prev
+              ? applySessionBranchUpdate(prev, data.branchName, data.repoOwner, data.repoName)
+              : null
+          );
           break;
 
         case "session_title":

--- a/packages/web/src/lib/repo-label.test.ts
+++ b/packages/web/src/lib/repo-label.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { formatSessionRepositoriesLabel, NO_REPOSITORY_LABEL } from "./repo-label";
+
+describe("formatSessionRepositoriesLabel", () => {
+  it("renders the scalar repo when there is no member list", () => {
+    expect(formatSessionRepositoriesLabel("acme", "web")).toBe("acme/web");
+  });
+
+  it("renders 'No repository' when the scalar repo is absent and there is no member list", () => {
+    expect(formatSessionRepositoriesLabel(null, null)).toBe(NO_REPOSITORY_LABEL);
+  });
+
+  it("renders a single-member session exactly as the scalar repo", () => {
+    expect(
+      formatSessionRepositoriesLabel("acme", "web", [{ repoOwner: "acme", repoName: "web" }])
+    ).toBe("acme/web");
+  });
+
+  it("shows the primary with a +N suffix for the remaining members", () => {
+    expect(
+      formatSessionRepositoriesLabel("acme", "web", [
+        { repoOwner: "acme", repoName: "web" },
+        { repoOwner: "acme", repoName: "api" },
+        { repoOwner: "acme", repoName: "cli" },
+      ])
+    ).toBe("acme/web +2");
+  });
+
+  it("prefers the hydrated primary over the scalar when both are present", () => {
+    expect(
+      formatSessionRepositoriesLabel(null, null, [
+        { repoOwner: "acme", repoName: "web" },
+        { repoOwner: "acme", repoName: "api" },
+      ])
+    ).toBe("acme/web +1");
+  });
+});

--- a/packages/web/src/lib/repo-label.ts
+++ b/packages/web/src/lib/repo-label.ts
@@ -14,3 +14,23 @@ export function formatRepositoriesLabel(
   }
   return `${repositories.length} repositories`;
 }
+
+/**
+ * Session-card label: the primary repo with a "+N" suffix for the remaining
+ * members. Scalar-era sessions (no member list, or a single member) render
+ * exactly as `formatRepoLabel` — "owner/name" — so pre-multi-repo cards are
+ * unchanged. Prefers the hydrated primary (`repositories[0]`) when present,
+ * falling back to the scalar mirror so cards without a member list still render.
+ */
+export function formatSessionRepositoriesLabel(
+  repoOwner: string | null | undefined,
+  repoName: string | null | undefined,
+  repositories?: ReadonlyArray<{ repoOwner: string; repoName: string }>
+): string {
+  const primary = repositories?.[0];
+  const base = primary
+    ? formatRepoLabel(primary.repoOwner, primary.repoName)
+    : formatRepoLabel(repoOwner, repoName);
+  const extra = repositories && repositories.length > 1 ? repositories.length - 1 : 0;
+  return extra > 0 ? `${base} +${extra}` : base;
+}

--- a/packages/web/src/types/session.ts
+++ b/packages/web/src/types/session.ts
@@ -20,6 +20,10 @@ export interface Artifact {
     provider?: string;
     filename?: string;
     previewStatus?: "active" | "outdated" | "stopped";
+    // Repo a PR/branch artifact belongs to in a multi-repo session. Absent on
+    // artifacts written before multi-repo support → they belong to the primary.
+    repoOwner?: string;
+    repoName?: string;
   };
   createdAt: number;
 }


### PR DESCRIPTION
## What

PR-7 of the multi-repo sessions plan (§PR-7): the web read-only surface for multi-repo sessions. Renders the member list, per-repo PR chips, non-fatal boot warnings, and `+N` session cards. No picker changes (that's Phase 2 / PR-12) — this is the sole owner of the v1 session UI and is a hard prerequisite of PR-12, so a customer can't create a multi-repo session whose page shows one repo.

## Changes

**`use-session-socket.ts` — repo-aware `session_branch`**
- `state.repositories` already flows through the `subscribed` handler (wholesale state spread); no change needed there.
- New `applySessionBranchUpdate` helper: a repo-scoped `session_branch` (message carries optional `repoOwner`/`repoName`, added in PR-3) updates the matching member's `branchName` in `state.repositories`, and mirrors to the scalar `branchName` **only when it names the primary** (position 0). An absent identity names the session's sole repo (the primary) and mirrors too. Sessions without a hydrated member list stay scalar-only, exactly as before. A branch update for an unknown member leaves state untouched rather than clobbering the scalar.
- `toUiArtifact` now carries `repoOwner`/`repoName` through PR-artifact metadata (needed for per-repo chip matching).

**`metadata-section.tsx` — member list, per-repo PR chips, warnings**
- Multi-member sessions (`repositories.length > 1`) render a "Repositories" block: each member links to its repo, the primary is tagged, and each shows its own working branch + PR chip (`#number` + state badge). PR chips are matched by artifact metadata repo; identity-less artifacts (pre-multi-repo) attribute to the primary — mirrors the control-plane `findPrArtifactForRepo`.
- Single-repo / scalar-era sessions render **exactly as before** (the scalar PR badge / base branch / working branch / repo tag are untouched, just gated behind `!isMultiRepo`).
- Non-fatal `warning` sandbox events (`sync`/`setup`/`start`/`assembly`/`secrets` scopes) are now surfaced in the sidebar with repo attribution — previously defined in the shared schema but rendered nowhere.

**Session cards (`session-sidebar.tsx`)**
- New `formatSessionRepositoriesLabel` shows the primary repo with a `+N` suffix (`acme/web +1`) reading the hydrated `Session.repositories`. Scalar-only sessions render exactly as today. Kept the existing `formatRepositoriesLabel` (automation cards) unchanged rather than overloading it.

**Contracts (shared + control-plane)**
- Added `SessionListRepository` to shared and threaded `repositories?` onto the web-facing `Session` type. The `/sessions` list route already serializes this (PR-4 hydration), so the card is web-only.
- Re-pointed control-plane's `SessionIndexRepository` to alias `SessionListRepository` so the wire shape has a single home (no behavior change).

## Gating

No feature flag. The multi-repo UI is gated by data presence (`repositories.length > 1` / warning events present), and `repositories` is only populated for multi-repo sessions, which can't be created until the PR-12 picker ships. Single-repo/scalar sessions are byte-identical to today. This avoids the flag-removal coupling the plan flags ("removal of the flag is not [optional] — PR-12 requires it live").

## Tests

- `repo-label.test.ts` (new): `formatSessionRepositoriesLabel` — scalar, single-member, `+N`, hydrated-primary-over-scalar.
- `metadata-section.test.tsx`: per-repo member list + chips matched by artifact metadata, identity-less→primary attribution, warning rendering. (Added `afterEach(cleanup)` — this suite renders into a shared body without auto-cleanup.)
- `use-session-socket.test.tsx`: repo-scoped `session_branch` routes to the matching member and mirrors the scalar only for the primary.
- Full suite: 551 web + 331 shared pass; typecheck + lint clean across packages.

## Notes for reviewers

- Deviation from the plan's literal wording: the plan said "`+N` via `formatRepositoriesLabel`", but that helper (shared with automation cards) renders "N repositories". To get the plan's stated "primary +N" UX without regressing automations, I added a session-specific `formatSessionRepositoriesLabel` rather than overloading the existing one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-repository session support across the sidebar and metadata: per-repository PR/branch/primary-member details and improved repository labels (including “+N” for additional members).
  * Surfaced non-fatal session warnings in the session details, with optional repository attribution.
* **Bug Fixes**
  * Fixed multi-repo `session_branch` updates to apply to the correct repository member without overwriting unrelated members.
  * Ensured PR artifact attribution follows the correct repository, falling back to the primary member when repo identity is missing.
* **Tests**
  * Expanded coverage for multi-repo session routing, metadata rendering (including warnings), and repository label formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->