### PR TITLE
feat(control-plane): enforce combined-secrets cap by default

### DIFF
--- a/packages/control-plane/src/db/secrets-validation.test.ts
+++ b/packages/control-plane/src/db/secrets-validation.test.ts
@@ -182,14 +182,14 @@ describe("mergeSecretSources", () => {
 });
 
 describe("parseSecretsCapMode", () => {
-  it("returns enforce only for the literal 'enforce'", () => {
-    expect(parseSecretsCapMode("enforce")).toBe("enforce");
+  it("returns warn only for the literal 'warn'", () => {
+    expect(parseSecretsCapMode("warn")).toBe("warn");
   });
 
-  it("defaults to warn for unset or unknown values", () => {
-    expect(parseSecretsCapMode(undefined)).toBe("warn");
-    expect(parseSecretsCapMode("warn")).toBe("warn");
-    expect(parseSecretsCapMode("ENFORCE")).toBe("warn");
+  it("defaults to enforce for unset or unknown values (fail-closed)", () => {
+    expect(parseSecretsCapMode(undefined)).toBe("enforce");
+    expect(parseSecretsCapMode("enforce")).toBe("enforce");
+    expect(parseSecretsCapMode("WARN")).toBe("enforce");
   });
 });
 

--- a/packages/control-plane/src/db/secrets-validation.ts
+++ b/packages/control-plane/src/db/secrets-validation.ts
@@ -154,14 +154,17 @@ export function mergeSecretSources(
 }
 
 /**
- * Cap enforcement mode. `warn` logs an oversized payload and proceeds (today's
- * behavior plus telemetry); `enforce` rejects the spawn/build. Staged warn-first
- * per the rollout plan, flipped to `enforce` before the Phase-1 gate.
+ * Cap enforcement mode. `warn` logs an oversized payload and proceeds (the
+ * warn-staged rollout behavior plus telemetry); `enforce` rejects the
+ * spawn/build. Defaults to `enforce` (D§6.4's ship-enforced spec) now that the
+ * Phase-1 gate has passed the warn window; set `SECRETS_CAP_ENFORCEMENT=warn`
+ * on the worker to fall back without a code revert. Fail-closed: only the
+ * literal `warn` opts out, so an unset or garbled value still enforces.
  */
 export type SecretsCapMode = "warn" | "enforce";
 
 export function parseSecretsCapMode(value: string | undefined): SecretsCapMode {
-  return value === "enforce" ? "enforce" : "warn";
+  return value === "warn" ? "warn" : "enforce";
 }
 
 /** Thrown in `enforce` mode when a merged payload exceeds the combined cap. */

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -108,7 +108,7 @@ export interface Env {
   // Sandbox lifecycle configuration
   SANDBOX_INACTIVITY_TIMEOUT_MS?: string; // Inactivity timeout in ms (default: 600000 = 10 min)
   EXECUTION_TIMEOUT_MS?: string; // Max processing time before auto-fail (default: 5400000 = 90 min)
-  SECRETS_CAP_ENFORCEMENT?: string; // "warn" (default) logs oversized secret payloads; "enforce" fails spawn/build
+  SECRETS_CAP_ENFORCEMENT?: string; // "enforce" (default) fails spawn/build on oversized secret payloads; set "warn" to only log
 
   // Logging
   LOG_LEVEL?: string; // "debug" | "info" | "warn" | "error" (default: "info")


### PR DESCRIPTION
## What

Flips the combined-secrets cap default from `warn` to **`enforce`**, completing
the staged rollout landed in PR-6 (#909). `parseSecretsCapMode` is now
**fail-closed**: only the literal `SECRETS_CAP_ENFORCEMENT=warn` opts out — unset
or garbled values enforce.

This is **behavior change #2** from the multi-repo-sessions plan (D§6.4's
ship-enforced spec). A merged secrets payload that exceeds
`MAX_COMBINED_SECRETS_BYTES` (128 KiB, after the global + member fold) now
**rejects the spawn/build** with a value-free `SecretsCapExceededError` that
attributes bytes/keys per source, instead of only emitting a `secrets.cap_exceeded`
warn log and proceeding. Applies identically on the spawn path
(`durable-object.getUserEnvVars`) and the repo-image build planner — both route
through the shared `auditSecretsMerge`.

## Why now

PR-7 (#912) merged, so all Phase-1 substrate PRs (PR-1…PR-7) are landed. The plan
gates the **Phase-1 verification checklist** on this flip:

> the `enforce` flip is the still-owed follow-up commit **owned by the PR-6 author
> and gated before the Phase-1 verification checklist runs — the phase gate cannot
> pass in warn mode.**

## Rollback

No code revert needed — set `SECRETS_CAP_ENFORCEMENT=warn` in the control-plane
worker vars (`terraform/environments/production/workers-control-plane.tf`) to fall
back to warn-only logging.

## ⚠️ Pre-deploy check

The warn window existed precisely to surface any launch unit already over the cap.
**Before this deploys, confirm no `secrets.cap_exceeded` warn logs are firing in
prod** — otherwise an existing oversized setup will start failing spawns. (Plan
risk-table mitigation for behavior change #2.)

## Tests

- `parseSecretsCapMode` unit assertions flipped to the fail-closed contract.
- Full Phase-1 regression green locally with the flip applied: all 9 TS suites
  (shared, control-plane unit + integration, web, slack/github/linear bots,
  typecheck) + pytest (435 sandbox-runtime, 186 modal-infra).

No test seeds a combined payload anywhere near the 128 KiB cap (largest is 20 KiB),
so the flip is behavior-neutral for the suite outside the `parseSecretsCapMode`
assertions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened secret-size handling so the safer enforcement mode is now the default.
  * Only an exact `warn` setting keeps the previous logging-only behavior; unset or unrecognized values now use enforcement.
  * Updated related guidance to match the new default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->