### PR TITLE
feat(control-plane): environment entity, CRUD, environment secrets

### DIFF
--- a/packages/control-plane/src/db/environment-secrets.ts
+++ b/packages/control-plane/src/db/environment-secrets.ts
@@ -23,8 +23,6 @@ import {
 } from "./secrets-validation";
 import type { SecretMetadata } from "./secrets-validation";
 
-export type { SecretMetadata } from "./secrets-validation";
-
 const log = createLogger("environment-secrets");
 
 export class EnvironmentSecretsStore {

--- a/packages/control-plane/src/db/environment-secrets.ts
+++ b/packages/control-plane/src/db/environment-secrets.ts
@@ -1,0 +1,216 @@
+/**
+ * EnvironmentSecretsStore — D1 persistence for environment-scoped secrets.
+ *
+ * Mirrors RepoSecretsStore exactly (same crypto: REPO_SECRETS_ENCRYPTION_KEY,
+ * same validation and per-scope caps), keyed by environment_id instead of
+ * repo_id. Environment sessions get global + environment secrets only; member
+ * repos' secrets never flow in (design §7.4).
+ *
+ * The per-key import copies ciphertext VERBATIM from a member repo's stored
+ * secrets — because both scopes share one encryption key, no decrypt/re-encrypt
+ * round-trip is needed, and plaintext never transits the control plane.
+ */
+
+import { encryptToken, decryptToken } from "../auth/crypto";
+import { createLogger } from "../logger";
+import {
+  MAX_TOTAL_VALUE_SIZE,
+  MAX_SECRETS_PER_SCOPE,
+  SecretsValidationError,
+  normalizeKey,
+  validateKey,
+  validateValue,
+} from "./secrets-validation";
+import type { SecretMetadata } from "./secrets-validation";
+
+export type { SecretMetadata } from "./secrets-validation";
+
+const log = createLogger("environment-secrets");
+
+export class EnvironmentSecretsStore {
+  constructor(
+    private readonly db: D1Database,
+    private readonly encryptionKey: string
+  ) {}
+
+  async setSecrets(
+    environmentId: string,
+    secrets: Record<string, string>
+  ): Promise<{ created: number; updated: number; keys: string[] }> {
+    const now = Date.now();
+
+    const normalized: Record<string, string> = {};
+    let totalValueBytes = 0;
+    for (const [rawKey, value] of Object.entries(secrets)) {
+      const key = normalizeKey(rawKey);
+      validateKey(key);
+      validateValue(value);
+      totalValueBytes += new TextEncoder().encode(value).length;
+      normalized[key] = value;
+    }
+
+    if (totalValueBytes > MAX_TOTAL_VALUE_SIZE) {
+      throw new SecretsValidationError(`Total secret size exceeds ${MAX_TOTAL_VALUE_SIZE} bytes`);
+    }
+
+    const existingKeySet = await this.existingKeys(environmentId);
+
+    const incomingKeys = Object.keys(normalized);
+    const netNew = incomingKeys.filter((k) => !existingKeySet.has(k)).length;
+    if (existingKeySet.size + netNew > MAX_SECRETS_PER_SCOPE) {
+      throw new SecretsValidationError(
+        `Environment would exceed ${MAX_SECRETS_PER_SCOPE} secrets limit ` +
+          `(current: ${existingKeySet.size}, adding: ${netNew})`
+      );
+    }
+
+    let created = 0;
+    let updated = 0;
+
+    const statements: D1PreparedStatement[] = [];
+    for (const [key, value] of Object.entries(normalized)) {
+      const encrypted = await encryptToken(value, this.encryptionKey);
+      if (existingKeySet.has(key)) updated++;
+      else created++;
+
+      statements.push(this.bindUpsert(environmentId, key, encrypted, now));
+    }
+
+    if (statements.length > 0) {
+      await this.db.batch(statements);
+    }
+
+    return { created, updated, keys: incomingKeys };
+  }
+
+  async listSecretKeys(environmentId: string): Promise<SecretMetadata[]> {
+    const result = await this.db
+      .prepare(
+        "SELECT key, created_at, updated_at FROM environment_secrets WHERE environment_id = ? ORDER BY key"
+      )
+      .bind(environmentId)
+      .all<{ key: string; created_at: number; updated_at: number }>();
+
+    return (result.results || []).map((row) => ({
+      key: row.key,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
+  }
+
+  async getDecryptedSecrets(environmentId: string): Promise<Record<string, string>> {
+    const result = await this.db
+      .prepare("SELECT key, encrypted_value FROM environment_secrets WHERE environment_id = ?")
+      .bind(environmentId)
+      .all<{ key: string; encrypted_value: string }>();
+
+    const rows = result.results || [];
+    const decryptedEntries = await Promise.all(
+      rows.map(async (row) => {
+        try {
+          const decryptedValue = await decryptToken(row.encrypted_value, this.encryptionKey);
+          return [row.key, decryptedValue] as const;
+        } catch (e) {
+          log.error("Failed to decrypt secret", {
+            environment_id: environmentId,
+            key: row.key,
+            error: e instanceof Error ? e.message : String(e),
+          });
+          throw new Error(`Failed to decrypt secret '${row.key}'`);
+        }
+      })
+    );
+
+    return Object.fromEntries(decryptedEntries);
+  }
+
+  async deleteSecret(environmentId: string, key: string): Promise<boolean> {
+    const result = await this.db
+      .prepare("DELETE FROM environment_secrets WHERE environment_id = ? AND key = ?")
+      .bind(environmentId, normalizeKey(key))
+      .run();
+
+    return (result.meta?.changes ?? 0) > 0;
+  }
+
+  /**
+   * Copy secrets from a member repo into this environment, ciphertext-verbatim.
+   * When `keys` is omitted, imports every key the source repo has. Enforces the
+   * per-scope key cap; the combined-value byte cap is left to the launch-unit
+   * fold at spawn/build time (PR-6) since measuring it here would require
+   * decrypting the copied ciphertext.
+   *
+   * @param sourceRepoId repo_id of a repo the caller has already verified to be
+   *   a current member of the environment (authorization is a route concern).
+   */
+  async importFromRepo(
+    environmentId: string,
+    sourceRepoId: number,
+    keys?: string[]
+  ): Promise<{ created: number; updated: number; keys: string[] }> {
+    let query = "SELECT key, encrypted_value FROM repo_secrets WHERE repo_id = ?";
+    const binds: unknown[] = [sourceRepoId];
+
+    if (keys !== undefined) {
+      const normalizedKeys = keys.map(normalizeKey);
+      normalizedKeys.forEach(validateKey);
+      if (normalizedKeys.length === 0) return { created: 0, updated: 0, keys: [] };
+      query += ` AND key IN (${normalizedKeys.map(() => "?").join(", ")})`;
+      binds.push(...normalizedKeys);
+    }
+
+    const source = await this.db
+      .prepare(query)
+      .bind(...binds)
+      .all<{ key: string; encrypted_value: string }>();
+    const rows = source.results || [];
+    if (rows.length === 0) return { created: 0, updated: 0, keys: [] };
+
+    const existingKeySet = await this.existingKeys(environmentId);
+    const netNew = rows.filter((r) => !existingKeySet.has(r.key)).length;
+    if (existingKeySet.size + netNew > MAX_SECRETS_PER_SCOPE) {
+      throw new SecretsValidationError(
+        `Environment would exceed ${MAX_SECRETS_PER_SCOPE} secrets limit ` +
+          `(current: ${existingKeySet.size}, adding: ${netNew})`
+      );
+    }
+
+    const now = Date.now();
+    let created = 0;
+    let updated = 0;
+    const statements = rows.map((row) => {
+      if (existingKeySet.has(row.key)) updated++;
+      else created++;
+      return this.bindUpsert(environmentId, row.key, row.encrypted_value, now);
+    });
+
+    await this.db.batch(statements);
+    return { created, updated, keys: rows.map((r) => r.key) };
+  }
+
+  private async existingKeys(environmentId: string): Promise<Set<string>> {
+    const existing = await this.db
+      .prepare("SELECT key FROM environment_secrets WHERE environment_id = ?")
+      .bind(environmentId)
+      .all<{ key: string }>();
+    return new Set((existing.results || []).map((r) => r.key));
+  }
+
+  private bindUpsert(
+    environmentId: string,
+    key: string,
+    encryptedValue: string,
+    now: number
+  ): D1PreparedStatement {
+    return this.db
+      .prepare(
+        `INSERT INTO environment_secrets
+         (environment_id, key, encrypted_value, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(environment_id, key) DO UPDATE SET
+           encrypted_value = excluded.encrypted_value,
+           updated_at = excluded.updated_at`
+      )
+      .bind(environmentId, key, encryptedValue, now, now);
+  }
+}

--- a/packages/control-plane/src/db/environments.ts
+++ b/packages/control-plane/src/db/environments.ts
@@ -10,8 +10,6 @@
 
 import type { Environment, EnvironmentRepository } from "@open-inspect/shared";
 
-// ─── Internal row types ──────────────────────────────────────────────────────
-
 export interface EnvironmentRow {
   id: string;
   name: string;
@@ -35,8 +33,6 @@ export type EnvironmentRepositoryInsert = Pick<
   EnvironmentRepositoryRow,
   "position" | "repo_owner" | "repo_name" | "repo_id" | "base_branch"
 >;
-
-// ─── Mappers ─────────────────────────────────────────────────────────────────
 
 export function toEnvironmentRepository(row: EnvironmentRepositoryRow): EnvironmentRepository {
   return {
@@ -65,8 +61,6 @@ export function toEnvironment(
 
 export class EnvironmentStore {
   constructor(private readonly db: D1Database) {}
-
-  // --- Environment CRUD ---
 
   bindEnvironmentInsert(row: EnvironmentRow): D1PreparedStatement {
     return this.db
@@ -211,8 +205,6 @@ export class EnvironmentStore {
     const envDelete = results[results.length - 1];
     return (envDelete?.meta?.changes ?? 0) > 0;
   }
-
-  // --- Repository selection (environment_repositories: single source of truth) ---
 
   async getRepositoriesForEnvironment(environmentId: string): Promise<EnvironmentRepositoryRow[]> {
     const result = await this.db

--- a/packages/control-plane/src/db/environments.ts
+++ b/packages/control-plane/src/db/environments.ts
@@ -1,0 +1,295 @@
+/**
+ * EnvironmentStore — D1 persistence for environments and their repositories.
+ *
+ * Follows the same pattern as AutomationStore / SessionIndexStore: constructor
+ * takes D1Database, snake_case rows in the database, camelCase types at the API
+ * boundary. Environment secrets live in a separate store (EnvironmentSecretsStore),
+ * but their DELETE cascade is composed here so it batches atomically with the
+ * repository and image rows (design §7.2).
+ */
+
+import type { Environment, EnvironmentRepository } from "@open-inspect/shared";
+
+// ─── Internal row types ──────────────────────────────────────────────────────
+
+export interface EnvironmentRow {
+  id: string;
+  name: string;
+  description: string | null;
+  prebuild_enabled: number; // SQLite integer boolean
+  created_at: number;
+  updated_at: number;
+}
+
+export interface EnvironmentRepositoryRow {
+  environment_id: string;
+  position: number;
+  repo_owner: string;
+  repo_name: string;
+  repo_id: number | null;
+  base_branch: string;
+}
+
+/** Repository values for insert/replace (environment_id supplied by the store). */
+export type EnvironmentRepositoryInsert = Pick<
+  EnvironmentRepositoryRow,
+  "position" | "repo_owner" | "repo_name" | "repo_id" | "base_branch"
+>;
+
+// ─── Mappers ─────────────────────────────────────────────────────────────────
+
+export function toEnvironmentRepository(row: EnvironmentRepositoryRow): EnvironmentRepository {
+  return {
+    repoOwner: row.repo_owner,
+    repoName: row.repo_name,
+    repoId: row.repo_id,
+    baseBranch: row.base_branch,
+  };
+}
+
+/** Map an environment row plus its (position-ordered) repository rows to the response shape. */
+export function toEnvironment(
+  row: EnvironmentRow,
+  repositoryRows: EnvironmentRepositoryRow[]
+): Environment {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    prebuildEnabled: row.prebuild_enabled === 1,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    repositories: repositoryRows.map(toEnvironmentRepository),
+  };
+}
+
+export class EnvironmentStore {
+  constructor(private readonly db: D1Database) {}
+
+  // --- Environment CRUD ---
+
+  bindEnvironmentInsert(row: EnvironmentRow): D1PreparedStatement {
+    return this.db
+      .prepare(
+        `INSERT INTO environments
+         (id, name, description, prebuild_enabled, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        row.id,
+        row.name,
+        row.description,
+        row.prebuild_enabled,
+        row.created_at,
+        row.updated_at
+      );
+  }
+
+  /** Insert an environment and its repositories atomically. */
+  async create(row: EnvironmentRow, repositories: EnvironmentRepositoryInsert[]): Promise<void> {
+    await this.db.batch([
+      this.bindEnvironmentInsert(row),
+      ...this.bindRepositoryInserts(row.id, repositories),
+    ]);
+  }
+
+  async getById(id: string): Promise<EnvironmentRow | null> {
+    return this.db
+      .prepare("SELECT * FROM environments WHERE id = ?")
+      .bind(id)
+      .first<EnvironmentRow>();
+  }
+
+  /**
+   * Look up an environment by name, case-insensitively (names are unique under
+   * lower(name)). Used to answer the uniqueness pre-check with a 409 before the
+   * insert would trip the unique index.
+   */
+  async getByName(name: string): Promise<EnvironmentRow | null> {
+    return this.db
+      .prepare("SELECT * FROM environments WHERE lower(name) = lower(?)")
+      .bind(name)
+      .first<EnvironmentRow>();
+  }
+
+  async list(): Promise<{ environments: EnvironmentRow[]; total: number }> {
+    const result = await this.db
+      .prepare("SELECT * FROM environments ORDER BY created_at DESC")
+      .all<EnvironmentRow>();
+    const environments = result.results || [];
+    return { environments, total: environments.length };
+  }
+
+  /**
+   * Build the dynamic UPDATE for the mutable scalar fields, or null when nothing
+   * scalar changed (a repositories-only edit). `updated_at` is always bumped when
+   * a scalar changes; the batch in {@link update} bumps it on repositories-only edits.
+   */
+  bindEnvironmentUpdate(
+    id: string,
+    fields: Partial<Pick<EnvironmentRow, "name" | "description" | "prebuild_enabled">>,
+    now: number
+  ): D1PreparedStatement | null {
+    const setClauses: string[] = [];
+    const params: unknown[] = [];
+
+    const allowed: (keyof Pick<EnvironmentRow, "name" | "description" | "prebuild_enabled">)[] = [
+      "name",
+      "description",
+      "prebuild_enabled",
+    ];
+    for (const field of allowed) {
+      if (field in fields) {
+        setClauses.push(`${field} = ?`);
+        params.push(fields[field] as unknown);
+      }
+    }
+
+    if (setClauses.length === 0) return null;
+
+    setClauses.push("updated_at = ?");
+    params.push(now);
+    params.push(id);
+
+    return this.db
+      .prepare(`UPDATE environments SET ${setClauses.join(", ")} WHERE id = ?`)
+      .bind(...params);
+  }
+
+  /**
+   * Update scalar fields and/or replace the repository set atomically.
+   * `repositories` of `undefined` leaves the set untouched; any array replaces it
+   * wholesale. Returns the refreshed row (null if the environment vanished
+   * concurrently).
+   */
+  async update(
+    id: string,
+    fields: Partial<Pick<EnvironmentRow, "name" | "description" | "prebuild_enabled">>,
+    repositories?: EnvironmentRepositoryInsert[]
+  ): Promise<EnvironmentRow | null> {
+    const now = Date.now();
+    const statements: D1PreparedStatement[] = [];
+
+    const updateStmt = this.bindEnvironmentUpdate(id, fields, now);
+    if (updateStmt) statements.push(updateStmt);
+
+    if (repositories !== undefined) {
+      statements.push(...this.bindReplaceRepositories(id, repositories));
+      // A repositories-only edit still bumps updated_at.
+      if (!updateStmt) {
+        statements.push(
+          this.db.prepare("UPDATE environments SET updated_at = ? WHERE id = ?").bind(now, id)
+        );
+      }
+    }
+
+    if (statements.length > 0) await this.db.batch(statements);
+    return this.getById(id);
+  }
+
+  /**
+   * Hard-delete an environment and cascade its dependent rows in one batch:
+   * repository rows, secret rows, and superseding any live (building|ready)
+   * images so the reaper (PR-10) reclaims their provider artifacts. Sessions
+   * created from the environment keep their snapshots and a benignly dangling
+   * environment_id (design §7.2).
+   *
+   * @returns true when the environment existed (idempotent on repeat).
+   */
+  async delete(id: string): Promise<boolean> {
+    const results = await this.db.batch([
+      this.db.prepare("DELETE FROM environment_repositories WHERE environment_id = ?").bind(id),
+      this.db.prepare("DELETE FROM environment_secrets WHERE environment_id = ?").bind(id),
+      this.db
+        .prepare(
+          `UPDATE environment_images SET status = 'superseded'
+           WHERE environment_id = ? AND status IN ('building', 'ready')`
+        )
+        .bind(id),
+      this.db.prepare("DELETE FROM environments WHERE id = ?").bind(id),
+    ]);
+    const envDelete = results[results.length - 1];
+    return (envDelete?.meta?.changes ?? 0) > 0;
+  }
+
+  // --- Repository selection (environment_repositories: single source of truth) ---
+
+  async getRepositoriesForEnvironment(environmentId: string): Promise<EnvironmentRepositoryRow[]> {
+    const result = await this.db
+      .prepare(
+        `SELECT * FROM environment_repositories
+         WHERE environment_id = ?
+         ORDER BY position`
+      )
+      .bind(environmentId)
+      .all<EnvironmentRepositoryRow>();
+    return result.results || [];
+  }
+
+  /** Batched variant for list hydration — one query for a page of environments. */
+  async getRepositoriesForEnvironmentIds(
+    environmentIds: string[]
+  ): Promise<Map<string, EnvironmentRepositoryRow[]>> {
+    const map = new Map<string, EnvironmentRepositoryRow[]>();
+    for (const id of environmentIds) map.set(id, []);
+    if (environmentIds.length === 0) return map;
+
+    const placeholders = environmentIds.map(() => "?").join(", ");
+    const result = await this.db
+      .prepare(
+        `SELECT * FROM environment_repositories
+         WHERE environment_id IN (${placeholders})
+         ORDER BY position`
+      )
+      .bind(...environmentIds)
+      .all<EnvironmentRepositoryRow>();
+
+    for (const row of result.results ?? []) {
+      map.get(row.environment_id)?.push(row);
+    }
+    return map;
+  }
+
+  /** INSERT statements for an environment's repository rows (composable into a batch). */
+  bindRepositoryInserts(
+    environmentId: string,
+    repositories: EnvironmentRepositoryInsert[]
+  ): D1PreparedStatement[] {
+    return repositories.map((repository) =>
+      this.db
+        .prepare(
+          `INSERT INTO environment_repositories
+           (environment_id, position, repo_owner, repo_name, repo_id, base_branch)
+           VALUES (?, ?, ?, ?, ?, ?)`
+        )
+        .bind(
+          environmentId,
+          repository.position,
+          repository.repo_owner,
+          repository.repo_name,
+          repository.repo_id,
+          repository.base_branch
+        )
+    );
+  }
+
+  /** Statements replacing an environment's repository selection. */
+  bindReplaceRepositories(
+    environmentId: string,
+    repositories: EnvironmentRepositoryInsert[]
+  ): D1PreparedStatement[] {
+    return [
+      this.db
+        .prepare("DELETE FROM environment_repositories WHERE environment_id = ?")
+        .bind(environmentId),
+      ...this.bindRepositoryInserts(environmentId, repositories),
+    ];
+  }
+
+  async replaceRepositories(
+    environmentId: string,
+    repositories: EnvironmentRepositoryInsert[]
+  ): Promise<void> {
+    await this.db.batch(this.bindReplaceRepositories(environmentId, repositories));
+  }
+}

--- a/packages/control-plane/src/db/environments.ts
+++ b/packages/control-plane/src/db/environments.ts
@@ -244,11 +244,9 @@ export class EnvironmentStore {
 
   /**
    * INSERT statements for an environment's repository rows (composable into a
-   * batch). Each insert is guarded on the parent environment still existing:
-   * with no foreign keys, a concurrent DELETE between a caller's existence check
-   * and this batch would otherwise commit orphan rows. Within a batch (one
-   * transaction) the create path's parent INSERT is already visible, so the
-   * guard holds for create as well as replace.
+   * batch). The environment_repositories → environments ON DELETE CASCADE FK
+   * enforces referential integrity, so a replace against a concurrently-deleted
+   * environment is rejected rather than left as orphan rows.
    */
   bindRepositoryInserts(
     environmentId: string,
@@ -259,8 +257,7 @@ export class EnvironmentStore {
         .prepare(
           `INSERT INTO environment_repositories
            (environment_id, position, repo_owner, repo_name, repo_id, base_branch)
-           SELECT ?, ?, ?, ?, ?, ?
-           WHERE EXISTS (SELECT 1 FROM environments WHERE id = ?)`
+           VALUES (?, ?, ?, ?, ?, ?)`
         )
         .bind(
           environmentId,
@@ -268,8 +265,7 @@ export class EnvironmentStore {
           repository.repo_owner,
           repository.repo_name,
           repository.repo_id,
-          repository.base_branch,
-          environmentId
+          repository.base_branch
         )
     );
   }

--- a/packages/control-plane/src/db/environments.ts
+++ b/packages/control-plane/src/db/environments.ts
@@ -242,7 +242,14 @@ export class EnvironmentStore {
     return map;
   }
 
-  /** INSERT statements for an environment's repository rows (composable into a batch). */
+  /**
+   * INSERT statements for an environment's repository rows (composable into a
+   * batch). Each insert is guarded on the parent environment still existing:
+   * with no foreign keys, a concurrent DELETE between a caller's existence check
+   * and this batch would otherwise commit orphan rows. Within a batch (one
+   * transaction) the create path's parent INSERT is already visible, so the
+   * guard holds for create as well as replace.
+   */
   bindRepositoryInserts(
     environmentId: string,
     repositories: EnvironmentRepositoryInsert[]
@@ -252,7 +259,8 @@ export class EnvironmentStore {
         .prepare(
           `INSERT INTO environment_repositories
            (environment_id, position, repo_owner, repo_name, repo_id, base_branch)
-           VALUES (?, ?, ?, ?, ?, ?)`
+           SELECT ?, ?, ?, ?, ?, ?
+           WHERE EXISTS (SELECT 1 FROM environments WHERE id = ?)`
         )
         .bind(
           environmentId,
@@ -260,7 +268,8 @@ export class EnvironmentStore {
           repository.repo_owner,
           repository.repo_name,
           repository.repo_id,
-          repository.base_branch
+          repository.base_branch,
+          environmentId
         )
     );
   }

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -28,6 +28,7 @@ import { reposRoutes } from "./routes/repos";
 import { repoImageRoutes } from "./routes/repo-images";
 import { secretsRoutes } from "./routes/secrets";
 import { environmentRoutes } from "./routes/environments";
+import { environmentSecretsRoutes } from "./routes/environment-secrets";
 import { automationRoutes } from "./routes/automations";
 import { mcpServerRoutes } from "./routes/mcp-servers";
 import { analyticsRoutes } from "./routes/analytics";
@@ -315,6 +316,7 @@ const routes: Route[] = [
 
   // Environments (Phase-2 launch unit; internal-HMAC only, web BFF proxied)
   ...environmentRoutes,
+  ...environmentSecretsRoutes,
 
   // Model preferences
   ...modelPreferencesRoutes,

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -27,6 +27,7 @@ import { modelPreferencesRoutes } from "./routes/model-preferences";
 import { reposRoutes } from "./routes/repos";
 import { repoImageRoutes } from "./routes/repo-images";
 import { secretsRoutes } from "./routes/secrets";
+import { environmentRoutes } from "./routes/environments";
 import { automationRoutes } from "./routes/automations";
 import { mcpServerRoutes } from "./routes/mcp-servers";
 import { analyticsRoutes } from "./routes/analytics";
@@ -311,6 +312,9 @@ const routes: Route[] = [
 
   // Secrets
   ...secretsRoutes,
+
+  // Environments (Phase-2 launch unit; internal-HMAC only, web BFF proxied)
+  ...environmentRoutes,
 
   // Model preferences
   ...modelPreferencesRoutes,

--- a/packages/control-plane/src/routes/environment-secrets.ts
+++ b/packages/control-plane/src/routes/environment-secrets.ts
@@ -1,0 +1,273 @@
+/**
+ * Environment secrets routes: per-environment secret CRUD plus the member-scoped,
+ * value-free import. Internal-HMAC authenticated (the web BFF proxies these).
+ * Split from ./environments so each routes file stays focused.
+ */
+
+import { EnvironmentStore } from "../db/environments";
+import { EnvironmentSecretsStore } from "../db/environment-secrets";
+import { GlobalSecretsStore } from "../db/global-secrets";
+import { SecretsValidationError, normalizeKey, validateKey } from "../db/secrets-validation";
+import { createLogger } from "../logger";
+import {
+  type Route,
+  type RequestContext,
+  parsePattern,
+  json,
+  error,
+  parseJsonBody,
+  resolveRepoOrError,
+} from "./shared";
+import type { Env } from "../types";
+
+const logger = createLogger("router:environment-secrets");
+
+/**
+ * Require both D1 and the secrets encryption key, returning the resolved key so
+ * handlers use `config.key` instead of a non-null assertion on the optional env.
+ */
+function requireSecretsConfig(env: Env): { key: string } | Response {
+  if (!env.DB) return error("Secrets storage is not configured", 503);
+  if (!env.REPO_SECRETS_ENCRYPTION_KEY)
+    return error("REPO_SECRETS_ENCRYPTION_KEY not configured", 500);
+  return { key: env.REPO_SECRETS_ENCRYPTION_KEY };
+}
+
+async function handleListEnvironmentSecrets(
+  _request: Request,
+  env: Env,
+  match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const config = requireSecretsConfig(env);
+  if (config instanceof Response) return config;
+
+  const id = match.groups?.id;
+  if (!id) return error("Environment ID required", 400);
+
+  const store = new EnvironmentStore(env.DB);
+  if (!(await store.getById(id))) return error("Environment not found", 404);
+
+  const secretsStore = new EnvironmentSecretsStore(env.DB, config.key);
+  const globalStore = new GlobalSecretsStore(env.DB, config.key);
+
+  try {
+    const [secrets, globalSecrets] = await Promise.all([
+      secretsStore.listSecretKeys(id),
+      globalStore.listSecretKeys().catch((e) => {
+        logger.warn("Failed to fetch global secrets for environment list", {
+          error: e instanceof Error ? e.message : String(e),
+        });
+        return [];
+      }),
+    ]);
+    return json({ environmentId: id, secrets, globalSecrets });
+  } catch (e) {
+    logger.error("Failed to list environment secrets", {
+      error: e instanceof Error ? e.message : String(e),
+      environment_id: id,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return error("Secrets storage unavailable", 503);
+  }
+}
+
+async function handleSetEnvironmentSecrets(
+  request: Request,
+  env: Env,
+  match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const config = requireSecretsConfig(env);
+  if (config instanceof Response) return config;
+
+  const id = match.groups?.id;
+  if (!id) return error("Environment ID required", 400);
+
+  const store = new EnvironmentStore(env.DB);
+  if (!(await store.getById(id))) return error("Environment not found", 404);
+
+  const body = await parseJsonBody<{ secrets?: Record<string, string> }>(request);
+  if (body instanceof Response) return body;
+  if (!body?.secrets || typeof body.secrets !== "object") {
+    return error("Request body must include secrets object", 400);
+  }
+
+  const secretsStore = new EnvironmentSecretsStore(env.DB, config.key);
+  try {
+    const result = await secretsStore.setSecrets(id, body.secrets);
+    logger.info("environment.secrets_updated", {
+      event: "environment.secrets_updated",
+      environment_id: id,
+      keys_count: result.keys.length,
+      created: result.created,
+      updated: result.updated,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return json({
+      status: "updated",
+      environmentId: id,
+      keys: result.keys,
+      created: result.created,
+      updated: result.updated,
+    });
+  } catch (e) {
+    if (e instanceof SecretsValidationError) return error(e.message, 400);
+    logger.error("Failed to update environment secrets", {
+      error: e instanceof Error ? e.message : String(e),
+      environment_id: id,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return error("Secrets storage unavailable", 503);
+  }
+}
+
+async function handleDeleteEnvironmentSecret(
+  _request: Request,
+  env: Env,
+  match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const config = requireSecretsConfig(env);
+  if (config instanceof Response) return config;
+
+  const id = match.groups?.id;
+  const key = match.groups?.key;
+  if (!id || !key) return error("Environment ID and key are required", 400);
+
+  const secretsStore = new EnvironmentSecretsStore(env.DB, config.key);
+  try {
+    const normalizedKey = normalizeKey(key);
+    validateKey(normalizedKey);
+
+    const deleted = await secretsStore.deleteSecret(id, key);
+    if (!deleted) return error("Secret not found", 404);
+
+    logger.info("environment.secret_deleted", {
+      event: "environment.secret_deleted",
+      environment_id: id,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return json({ status: "deleted", environmentId: id, key: normalizedKey });
+  } catch (e) {
+    if (e instanceof SecretsValidationError) return error(e.message, 400);
+    logger.error("Failed to delete environment secret", {
+      error: e instanceof Error ? e.message : String(e),
+      environment_id: id,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return error("Secrets storage unavailable", 503);
+  }
+}
+
+/**
+ * Import secrets from a member repo into the environment, ciphertext-verbatim.
+ * Authorization: the source repo MUST be a current member (non-members are
+ * rejected 403). The response carries key names only — never plaintext or
+ * ciphertext values (design §7.4).
+ */
+async function handleImportEnvironmentSecrets(
+  request: Request,
+  env: Env,
+  match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const config = requireSecretsConfig(env);
+  if (config instanceof Response) return config;
+
+  const id = match.groups?.id;
+  if (!id) return error("Environment ID required", 400);
+
+  const store = new EnvironmentStore(env.DB);
+  if (!(await store.getById(id))) return error("Environment not found", 404);
+
+  const body = await parseJsonBody<{ repoOwner?: string; repoName?: string; keys?: unknown }>(
+    request
+  );
+  if (body instanceof Response) return body;
+  if (!body?.repoOwner || !body?.repoName) {
+    return error("repoOwner and repoName are required", 400);
+  }
+  if (
+    body.keys !== undefined &&
+    (!Array.isArray(body.keys) || body.keys.some((k) => typeof k !== "string"))
+  ) {
+    return error("keys must be an array of strings", 400);
+  }
+
+  const srcOwner = body.repoOwner.trim().toLowerCase();
+  const srcName = body.repoName.trim().toLowerCase();
+
+  // Authorization: the source repo must be one of the environment's repositories.
+  const envRepos = await store.getRepositoriesForEnvironment(id);
+  const sourceRepo = envRepos.find((r) => r.repo_owner === srcOwner && r.repo_name === srcName);
+  if (!sourceRepo) {
+    return error(`${srcOwner}/${srcName} is not a member of this environment`, 403);
+  }
+
+  // Resolve the source repo_id (rows written before resolution may lack it).
+  let repoId = sourceRepo.repo_id;
+  if (repoId == null) {
+    repoId = (await resolveRepoOrError(env, srcOwner, srcName, ctx, logger)).repoId;
+  }
+
+  const secretsStore = new EnvironmentSecretsStore(env.DB, config.key);
+  try {
+    const result = await secretsStore.importFromRepo(id, repoId, body.keys as string[] | undefined);
+    logger.info("environment.secrets_imported", {
+      event: "environment.secrets_imported",
+      environment_id: id,
+      source_repo: `${srcOwner}/${srcName}`,
+      keys_count: result.keys.length,
+      created: result.created,
+      updated: result.updated,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return json({
+      status: "imported",
+      environmentId: id,
+      source: `${srcOwner}/${srcName}`,
+      keys: result.keys,
+      created: result.created,
+      updated: result.updated,
+    });
+  } catch (e) {
+    if (e instanceof SecretsValidationError) return error(e.message, 400);
+    logger.error("Failed to import environment secrets", {
+      error: e instanceof Error ? e.message : String(e),
+      environment_id: id,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return error("Secrets storage unavailable", 503);
+  }
+}
+
+export const environmentSecretsRoutes: Route[] = [
+  {
+    method: "GET",
+    pattern: parsePattern("/environments/:id/secrets"),
+    handler: handleListEnvironmentSecrets,
+  },
+  {
+    method: "PUT",
+    pattern: parsePattern("/environments/:id/secrets"),
+    handler: handleSetEnvironmentSecrets,
+  },
+  {
+    method: "POST",
+    pattern: parsePattern("/environments/:id/secrets/import"),
+    handler: handleImportEnvironmentSecrets,
+  },
+  {
+    method: "DELETE",
+    pattern: parsePattern("/environments/:id/secrets/:key"),
+    handler: handleDeleteEnvironmentSecret,
+  },
+];

--- a/packages/control-plane/src/routes/environments.ts
+++ b/packages/control-plane/src/routes/environments.ts
@@ -1,10 +1,9 @@
 /**
- * Environment CRUD + environment-secrets routes.
- *
- * Internal-HMAC authenticated (the web BFF proxies these). Environments are the
- * Phase-2 launch unit: a named, prebuildable repository set with its own
- * secrets. Routes are additive and dark until the web picker (PR-12) surfaces
- * them; the create-from-environment session path is PR-9.
+ * Environment CRUD routes. Internal-HMAC authenticated (the web BFF proxies
+ * these). Environments are the Phase-2 launch unit: a named, prebuildable
+ * repository set with its own secrets. Additive and dark until the web picker
+ * (PR-12); the create-from-environment session path is PR-9. Secrets routes
+ * live in ./environment-secrets.
  */
 
 import { createEnvironmentInputSchema, updateEnvironmentInputSchema } from "@open-inspect/shared";
@@ -14,9 +13,6 @@ import {
   type EnvironmentRow,
   type EnvironmentRepositoryInsert,
 } from "../db/environments";
-import { EnvironmentSecretsStore } from "../db/environment-secrets";
-import { GlobalSecretsStore } from "../db/global-secrets";
-import { SecretsValidationError, normalizeKey, validateKey } from "../db/secrets-validation";
 import { generateId } from "../auth/crypto";
 import { createLogger } from "../logger";
 import {
@@ -32,18 +28,9 @@ import type { Env } from "../types";
 
 const logger = createLogger("router:environments");
 
-// ─── Guards & helpers ────────────────────────────────────────────────────────
-
 function requireDb(env: Env): Response | null {
   if (!env.DB) return error("Environment storage is not configured", 503);
   return null;
-}
-
-function requireSecretsConfig(env: Env): { key: string } | Response {
-  if (!env.DB) return error("Secrets storage is not configured", 503);
-  if (!env.REPO_SECRETS_ENCRYPTION_KEY)
-    return error("REPO_SECRETS_ENCRYPTION_KEY not configured", 500);
-  return { key: env.REPO_SECRETS_ENCRYPTION_KEY };
 }
 
 /** Turn a zod validation failure into a 400 naming the first offending field. */
@@ -90,8 +77,6 @@ async function resolveEnvironmentRepositories(
     base_branch: repository.baseBranch ?? resolved[index].defaultBranch,
   }));
 }
-
-// ─── Environment CRUD ────────────────────────────────────────────────────────
 
 async function handleListEnvironments(
   _request: Request,
@@ -266,224 +251,6 @@ async function handleDeleteEnvironment(
   return json({ status: "deleted", id });
 }
 
-// ─── Environment secrets ─────────────────────────────────────────────────────
-
-async function handleListEnvironmentSecrets(
-  _request: Request,
-  env: Env,
-  match: RegExpMatchArray,
-  ctx: RequestContext
-): Promise<Response> {
-  const config = requireSecretsConfig(env);
-  if (config instanceof Response) return config;
-
-  const id = match.groups?.id;
-  if (!id) return error("Environment ID required", 400);
-
-  const store = new EnvironmentStore(env.DB);
-  if (!(await store.getById(id))) return error("Environment not found", 404);
-
-  const secretsStore = new EnvironmentSecretsStore(env.DB, config.key);
-  const globalStore = new GlobalSecretsStore(env.DB, config.key);
-
-  try {
-    const [secrets, globalSecrets] = await Promise.all([
-      secretsStore.listSecretKeys(id),
-      globalStore.listSecretKeys().catch((e) => {
-        logger.warn("Failed to fetch global secrets for environment list", {
-          error: e instanceof Error ? e.message : String(e),
-        });
-        return [];
-      }),
-    ]);
-    return json({ environmentId: id, secrets, globalSecrets });
-  } catch (e) {
-    logger.error("Failed to list environment secrets", {
-      error: e instanceof Error ? e.message : String(e),
-      environment_id: id,
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-    return error("Secrets storage unavailable", 503);
-  }
-}
-
-async function handleSetEnvironmentSecrets(
-  request: Request,
-  env: Env,
-  match: RegExpMatchArray,
-  ctx: RequestContext
-): Promise<Response> {
-  const config = requireSecretsConfig(env);
-  if (config instanceof Response) return config;
-
-  const id = match.groups?.id;
-  if (!id) return error("Environment ID required", 400);
-
-  const store = new EnvironmentStore(env.DB);
-  if (!(await store.getById(id))) return error("Environment not found", 404);
-
-  const body = await parseJsonBody<{ secrets?: Record<string, string> }>(request);
-  if (body instanceof Response) return body;
-  if (!body?.secrets || typeof body.secrets !== "object") {
-    return error("Request body must include secrets object", 400);
-  }
-
-  const secretsStore = new EnvironmentSecretsStore(env.DB, config.key);
-  try {
-    const result = await secretsStore.setSecrets(id, body.secrets);
-    logger.info("environment.secrets_updated", {
-      event: "environment.secrets_updated",
-      environment_id: id,
-      keys_count: result.keys.length,
-      created: result.created,
-      updated: result.updated,
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-    return json({
-      status: "updated",
-      environmentId: id,
-      keys: result.keys,
-      created: result.created,
-      updated: result.updated,
-    });
-  } catch (e) {
-    if (e instanceof SecretsValidationError) return error(e.message, 400);
-    logger.error("Failed to update environment secrets", {
-      error: e instanceof Error ? e.message : String(e),
-      environment_id: id,
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-    return error("Secrets storage unavailable", 503);
-  }
-}
-
-async function handleDeleteEnvironmentSecret(
-  _request: Request,
-  env: Env,
-  match: RegExpMatchArray,
-  ctx: RequestContext
-): Promise<Response> {
-  const config = requireSecretsConfig(env);
-  if (config instanceof Response) return config;
-
-  const id = match.groups?.id;
-  const key = match.groups?.key;
-  if (!id || !key) return error("Environment ID and key are required", 400);
-
-  const secretsStore = new EnvironmentSecretsStore(env.DB, config.key);
-  try {
-    const normalizedKey = normalizeKey(key);
-    validateKey(normalizedKey);
-
-    const deleted = await secretsStore.deleteSecret(id, key);
-    if (!deleted) return error("Secret not found", 404);
-
-    logger.info("environment.secret_deleted", {
-      event: "environment.secret_deleted",
-      environment_id: id,
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-    return json({ status: "deleted", environmentId: id, key: normalizedKey });
-  } catch (e) {
-    if (e instanceof SecretsValidationError) return error(e.message, 400);
-    logger.error("Failed to delete environment secret", {
-      error: e instanceof Error ? e.message : String(e),
-      environment_id: id,
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-    return error("Secrets storage unavailable", 503);
-  }
-}
-
-/**
- * Import secrets from a member repo into the environment, ciphertext-verbatim.
- * Authorization: the source repo MUST be a current member (non-members are
- * rejected 403). The response carries key names only — never plaintext or
- * ciphertext values (design §7.4).
- */
-async function handleImportEnvironmentSecrets(
-  request: Request,
-  env: Env,
-  match: RegExpMatchArray,
-  ctx: RequestContext
-): Promise<Response> {
-  const config = requireSecretsConfig(env);
-  if (config instanceof Response) return config;
-
-  const id = match.groups?.id;
-  if (!id) return error("Environment ID required", 400);
-
-  const store = new EnvironmentStore(env.DB);
-  if (!(await store.getById(id))) return error("Environment not found", 404);
-
-  const body = await parseJsonBody<{ repoOwner?: string; repoName?: string; keys?: unknown }>(
-    request
-  );
-  if (body instanceof Response) return body;
-  if (!body?.repoOwner || !body?.repoName) {
-    return error("repoOwner and repoName are required", 400);
-  }
-  if (
-    body.keys !== undefined &&
-    (!Array.isArray(body.keys) || body.keys.some((k) => typeof k !== "string"))
-  ) {
-    return error("keys must be an array of strings", 400);
-  }
-
-  const srcOwner = body.repoOwner.trim().toLowerCase();
-  const srcName = body.repoName.trim().toLowerCase();
-
-  // Authorization: the source repo must be one of the environment's repositories.
-  const envRepos = await store.getRepositoriesForEnvironment(id);
-  const sourceRepo = envRepos.find((r) => r.repo_owner === srcOwner && r.repo_name === srcName);
-  if (!sourceRepo) {
-    return error(`${srcOwner}/${srcName} is not a member of this environment`, 403);
-  }
-
-  // Resolve the source repo_id (rows written before resolution may lack it).
-  let repoId = sourceRepo.repo_id;
-  if (repoId == null) {
-    repoId = (await resolveRepoOrError(env, srcOwner, srcName, ctx, logger)).repoId;
-  }
-
-  const secretsStore = new EnvironmentSecretsStore(env.DB, config.key);
-  try {
-    const result = await secretsStore.importFromRepo(id, repoId, body.keys as string[] | undefined);
-    logger.info("environment.secrets_imported", {
-      event: "environment.secrets_imported",
-      environment_id: id,
-      source_repo: `${srcOwner}/${srcName}`,
-      keys_count: result.keys.length,
-      created: result.created,
-      updated: result.updated,
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-    return json({
-      status: "imported",
-      environmentId: id,
-      source: `${srcOwner}/${srcName}`,
-      keys: result.keys,
-      created: result.created,
-      updated: result.updated,
-    });
-  } catch (e) {
-    if (e instanceof SecretsValidationError) return error(e.message, 400);
-    logger.error("Failed to import environment secrets", {
-      error: e instanceof Error ? e.message : String(e),
-      environment_id: id,
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
-    return error("Secrets storage unavailable", 503);
-  }
-}
-
 export const environmentRoutes: Route[] = [
   { method: "GET", pattern: parsePattern("/environments"), handler: handleListEnvironments },
   { method: "POST", pattern: parsePattern("/environments"), handler: handleCreateEnvironment },
@@ -493,25 +260,5 @@ export const environmentRoutes: Route[] = [
     method: "DELETE",
     pattern: parsePattern("/environments/:id"),
     handler: handleDeleteEnvironment,
-  },
-  {
-    method: "GET",
-    pattern: parsePattern("/environments/:id/secrets"),
-    handler: handleListEnvironmentSecrets,
-  },
-  {
-    method: "PUT",
-    pattern: parsePattern("/environments/:id/secrets"),
-    handler: handleSetEnvironmentSecrets,
-  },
-  {
-    method: "POST",
-    pattern: parsePattern("/environments/:id/secrets/import"),
-    handler: handleImportEnvironmentSecrets,
-  },
-  {
-    method: "DELETE",
-    pattern: parsePattern("/environments/:id/secrets/:key"),
-    handler: handleDeleteEnvironmentSecret,
   },
 ];

--- a/packages/control-plane/src/routes/environments.ts
+++ b/packages/control-plane/src/routes/environments.ts
@@ -1,0 +1,517 @@
+/**
+ * Environment CRUD + environment-secrets routes.
+ *
+ * Internal-HMAC authenticated (the web BFF proxies these). Environments are the
+ * Phase-2 launch unit: a named, prebuildable repository set with its own
+ * secrets. Routes are additive and dark until the web picker (PR-12) surfaces
+ * them; the create-from-environment session path is PR-9.
+ */
+
+import { createEnvironmentInputSchema, updateEnvironmentInputSchema } from "@open-inspect/shared";
+import {
+  EnvironmentStore,
+  toEnvironment,
+  type EnvironmentRow,
+  type EnvironmentRepositoryInsert,
+} from "../db/environments";
+import { EnvironmentSecretsStore } from "../db/environment-secrets";
+import { GlobalSecretsStore } from "../db/global-secrets";
+import { SecretsValidationError, normalizeKey, validateKey } from "../db/secrets-validation";
+import { generateId } from "../auth/crypto";
+import { createLogger } from "../logger";
+import {
+  type Route,
+  type RequestContext,
+  parsePattern,
+  json,
+  error,
+  parseJsonBody,
+  resolveRepoOrError,
+} from "./shared";
+import type { Env } from "../types";
+
+const logger = createLogger("router:environments");
+
+// ─── Guards & helpers ────────────────────────────────────────────────────────
+
+function requireDb(env: Env): Response | null {
+  if (!env.DB) return error("Environment storage is not configured", 503);
+  return null;
+}
+
+function requireSecretsConfig(env: Env): { key: string } | Response {
+  if (!env.DB) return error("Secrets storage is not configured", 503);
+  if (!env.REPO_SECRETS_ENCRYPTION_KEY)
+    return error("REPO_SECRETS_ENCRYPTION_KEY not configured", 500);
+  return { key: env.REPO_SECRETS_ENCRYPTION_KEY };
+}
+
+/** Turn a zod validation failure into a 400 naming the first offending field. */
+function validationError(err: {
+  issues: { path: (string | number | symbol)[]; message: string }[];
+}): Response {
+  const issue = err.issues[0];
+  const prefix = issue && issue.path.length ? `${issue.path.map(String).join(".")}: ` : "";
+  return error(`${prefix}${issue?.message ?? "invalid request"}`, 400);
+}
+
+/** Empty/whitespace description collapses to null (the column is nullable). */
+function normalizeDescription(description: string | null | undefined): string | null {
+  return description && description.length > 0 ? description : null;
+}
+
+/**
+ * Resolve every requested repository through the SCM provider concurrently. The
+ * first failure IN INPUT ORDER wins (deterministic error). The resulting
+ * inserts carry the resolved repoId, the request branch (or the freshly
+ * resolved default), and position from list order. Propagates HttpError from
+ * resolveRepoOrError (mapped centrally in the router's dispatch catch).
+ */
+async function resolveEnvironmentRepositories(
+  env: Env,
+  repositories: { repoOwner: string; repoName: string; baseBranch: string | null }[],
+  ctx: RequestContext
+): Promise<EnvironmentRepositoryInsert[]> {
+  const settled = await Promise.allSettled(
+    repositories.map((repository) =>
+      resolveRepoOrError(env, repository.repoOwner, repository.repoName, ctx, logger)
+    )
+  );
+  const resolved = settled.map((result) => {
+    if (result.status === "rejected") throw result.reason;
+    return result.value;
+  });
+
+  return repositories.map((repository, index) => ({
+    position: index,
+    repo_owner: repository.repoOwner,
+    repo_name: repository.repoName,
+    repo_id: resolved[index].repoId,
+    base_branch: repository.baseBranch ?? resolved[index].defaultBranch,
+  }));
+}
+
+// ─── Environment CRUD ────────────────────────────────────────────────────────
+
+async function handleListEnvironments(
+  _request: Request,
+  env: Env,
+  _match: RegExpMatchArray,
+  _ctx: RequestContext
+): Promise<Response> {
+  const guard = requireDb(env);
+  if (guard) return guard;
+
+  const store = new EnvironmentStore(env.DB);
+  const { environments, total } = await store.list();
+  const repositoriesById = await store.getRepositoriesForEnvironmentIds(
+    environments.map((e) => e.id)
+  );
+
+  return json({
+    environments: environments.map((row) => toEnvironment(row, repositoriesById.get(row.id) ?? [])),
+    total,
+  });
+}
+
+async function handleCreateEnvironment(
+  request: Request,
+  env: Env,
+  _match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const guard = requireDb(env);
+  if (guard) return guard;
+
+  const body = await parseJsonBody<unknown>(request);
+  if (body instanceof Response) return body;
+
+  const parsed = createEnvironmentInputSchema.safeParse(body);
+  if (!parsed.success) return validationError(parsed.error);
+  const { name, description, prebuildEnabled, repositories } = parsed.data;
+
+  const store = new EnvironmentStore(env.DB);
+  if (await store.getByName(name)) {
+    return error(`An environment named "${name}" already exists`, 409);
+  }
+
+  const inserts = await resolveEnvironmentRepositories(env, repositories, ctx);
+
+  const now = Date.now();
+  const id = `env_${generateId()}`;
+  const row: EnvironmentRow = {
+    id,
+    name,
+    description: normalizeDescription(description),
+    prebuild_enabled: prebuildEnabled ? 1 : 0,
+    created_at: now,
+    updated_at: now,
+  };
+
+  await store.create(row, inserts);
+
+  logger.info("environment.created", {
+    event: "environment.created",
+    environment_id: id,
+    repository_count: inserts.length,
+    prebuild_enabled: row.prebuild_enabled === 1,
+    request_id: ctx.request_id,
+    trace_id: ctx.trace_id,
+  });
+
+  return json(
+    { environment: toEnvironment(row, await store.getRepositoriesForEnvironment(id)) },
+    201
+  );
+}
+
+async function handleGetEnvironment(
+  _request: Request,
+  env: Env,
+  match: RegExpMatchArray,
+  _ctx: RequestContext
+): Promise<Response> {
+  const guard = requireDb(env);
+  if (guard) return guard;
+
+  const id = match.groups?.id;
+  if (!id) return error("Environment ID required", 400);
+
+  const store = new EnvironmentStore(env.DB);
+  const row = await store.getById(id);
+  if (!row) return error("Environment not found", 404);
+
+  return json({ environment: toEnvironment(row, await store.getRepositoriesForEnvironment(id)) });
+}
+
+async function handleUpdateEnvironment(
+  request: Request,
+  env: Env,
+  match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const guard = requireDb(env);
+  if (guard) return guard;
+
+  const id = match.groups?.id;
+  if (!id) return error("Environment ID required", 400);
+
+  const store = new EnvironmentStore(env.DB);
+  const existing = await store.getById(id);
+  if (!existing) return error("Environment not found", 404);
+
+  const body = await parseJsonBody<unknown>(request);
+  if (body instanceof Response) return body;
+
+  const parsed = updateEnvironmentInputSchema.safeParse(body);
+  if (!parsed.success) return validationError(parsed.error);
+  const { name, description, prebuildEnabled, repositories } = parsed.data;
+
+  if (name !== undefined) {
+    const other = await store.getByName(name);
+    if (other && other.id !== id) {
+      return error(`An environment named "${name}" already exists`, 409);
+    }
+  }
+
+  const inserts =
+    repositories !== undefined
+      ? await resolveEnvironmentRepositories(env, repositories, ctx)
+      : undefined;
+
+  const fields: Partial<Pick<EnvironmentRow, "name" | "description" | "prebuild_enabled">> = {};
+  if (name !== undefined) fields.name = name;
+  if (description !== undefined) fields.description = normalizeDescription(description);
+  if (prebuildEnabled !== undefined) fields.prebuild_enabled = prebuildEnabled ? 1 : 0;
+
+  const updated = await store.update(id, fields, inserts);
+  if (!updated) return error("Environment not found", 404);
+
+  logger.info("environment.updated", {
+    event: "environment.updated",
+    environment_id: id,
+    repositories_replaced: inserts !== undefined,
+    request_id: ctx.request_id,
+    trace_id: ctx.trace_id,
+  });
+
+  return json({
+    environment: toEnvironment(updated, await store.getRepositoriesForEnvironment(id)),
+  });
+}
+
+async function handleDeleteEnvironment(
+  _request: Request,
+  env: Env,
+  match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const guard = requireDb(env);
+  if (guard) return guard;
+
+  const id = match.groups?.id;
+  if (!id) return error("Environment ID required", 400);
+
+  const store = new EnvironmentStore(env.DB);
+  const deleted = await store.delete(id);
+  if (!deleted) return error("Environment not found", 404);
+
+  logger.info("environment.deleted", {
+    event: "environment.deleted",
+    environment_id: id,
+    request_id: ctx.request_id,
+    trace_id: ctx.trace_id,
+  });
+
+  return json({ status: "deleted", id });
+}
+
+// ─── Environment secrets ─────────────────────────────────────────────────────
+
+async function handleListEnvironmentSecrets(
+  _request: Request,
+  env: Env,
+  match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const config = requireSecretsConfig(env);
+  if (config instanceof Response) return config;
+
+  const id = match.groups?.id;
+  if (!id) return error("Environment ID required", 400);
+
+  const store = new EnvironmentStore(env.DB);
+  if (!(await store.getById(id))) return error("Environment not found", 404);
+
+  const secretsStore = new EnvironmentSecretsStore(env.DB, config.key);
+  const globalStore = new GlobalSecretsStore(env.DB, config.key);
+
+  try {
+    const [secrets, globalSecrets] = await Promise.all([
+      secretsStore.listSecretKeys(id),
+      globalStore.listSecretKeys().catch((e) => {
+        logger.warn("Failed to fetch global secrets for environment list", {
+          error: e instanceof Error ? e.message : String(e),
+        });
+        return [];
+      }),
+    ]);
+    return json({ environmentId: id, secrets, globalSecrets });
+  } catch (e) {
+    logger.error("Failed to list environment secrets", {
+      error: e instanceof Error ? e.message : String(e),
+      environment_id: id,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return error("Secrets storage unavailable", 503);
+  }
+}
+
+async function handleSetEnvironmentSecrets(
+  request: Request,
+  env: Env,
+  match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const config = requireSecretsConfig(env);
+  if (config instanceof Response) return config;
+
+  const id = match.groups?.id;
+  if (!id) return error("Environment ID required", 400);
+
+  const store = new EnvironmentStore(env.DB);
+  if (!(await store.getById(id))) return error("Environment not found", 404);
+
+  const body = await parseJsonBody<{ secrets?: Record<string, string> }>(request);
+  if (body instanceof Response) return body;
+  if (!body?.secrets || typeof body.secrets !== "object") {
+    return error("Request body must include secrets object", 400);
+  }
+
+  const secretsStore = new EnvironmentSecretsStore(env.DB, config.key);
+  try {
+    const result = await secretsStore.setSecrets(id, body.secrets);
+    logger.info("environment.secrets_updated", {
+      event: "environment.secrets_updated",
+      environment_id: id,
+      keys_count: result.keys.length,
+      created: result.created,
+      updated: result.updated,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return json({
+      status: "updated",
+      environmentId: id,
+      keys: result.keys,
+      created: result.created,
+      updated: result.updated,
+    });
+  } catch (e) {
+    if (e instanceof SecretsValidationError) return error(e.message, 400);
+    logger.error("Failed to update environment secrets", {
+      error: e instanceof Error ? e.message : String(e),
+      environment_id: id,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return error("Secrets storage unavailable", 503);
+  }
+}
+
+async function handleDeleteEnvironmentSecret(
+  _request: Request,
+  env: Env,
+  match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const config = requireSecretsConfig(env);
+  if (config instanceof Response) return config;
+
+  const id = match.groups?.id;
+  const key = match.groups?.key;
+  if (!id || !key) return error("Environment ID and key are required", 400);
+
+  const secretsStore = new EnvironmentSecretsStore(env.DB, config.key);
+  try {
+    const normalizedKey = normalizeKey(key);
+    validateKey(normalizedKey);
+
+    const deleted = await secretsStore.deleteSecret(id, key);
+    if (!deleted) return error("Secret not found", 404);
+
+    logger.info("environment.secret_deleted", {
+      event: "environment.secret_deleted",
+      environment_id: id,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return json({ status: "deleted", environmentId: id, key: normalizedKey });
+  } catch (e) {
+    if (e instanceof SecretsValidationError) return error(e.message, 400);
+    logger.error("Failed to delete environment secret", {
+      error: e instanceof Error ? e.message : String(e),
+      environment_id: id,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return error("Secrets storage unavailable", 503);
+  }
+}
+
+/**
+ * Import secrets from a member repo into the environment, ciphertext-verbatim.
+ * Authorization: the source repo MUST be a current member (non-members are
+ * rejected 403). The response carries key names only — never plaintext or
+ * ciphertext values (design §7.4).
+ */
+async function handleImportEnvironmentSecrets(
+  request: Request,
+  env: Env,
+  match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const config = requireSecretsConfig(env);
+  if (config instanceof Response) return config;
+
+  const id = match.groups?.id;
+  if (!id) return error("Environment ID required", 400);
+
+  const store = new EnvironmentStore(env.DB);
+  if (!(await store.getById(id))) return error("Environment not found", 404);
+
+  const body = await parseJsonBody<{ repoOwner?: string; repoName?: string; keys?: unknown }>(
+    request
+  );
+  if (body instanceof Response) return body;
+  if (!body?.repoOwner || !body?.repoName) {
+    return error("repoOwner and repoName are required", 400);
+  }
+  if (
+    body.keys !== undefined &&
+    (!Array.isArray(body.keys) || body.keys.some((k) => typeof k !== "string"))
+  ) {
+    return error("keys must be an array of strings", 400);
+  }
+
+  const srcOwner = body.repoOwner.trim().toLowerCase();
+  const srcName = body.repoName.trim().toLowerCase();
+
+  // Authorization: the source repo must be one of the environment's repositories.
+  const envRepos = await store.getRepositoriesForEnvironment(id);
+  const sourceRepo = envRepos.find((r) => r.repo_owner === srcOwner && r.repo_name === srcName);
+  if (!sourceRepo) {
+    return error(`${srcOwner}/${srcName} is not a member of this environment`, 403);
+  }
+
+  // Resolve the source repo_id (rows written before resolution may lack it).
+  let repoId = sourceRepo.repo_id;
+  if (repoId == null) {
+    repoId = (await resolveRepoOrError(env, srcOwner, srcName, ctx, logger)).repoId;
+  }
+
+  const secretsStore = new EnvironmentSecretsStore(env.DB, config.key);
+  try {
+    const result = await secretsStore.importFromRepo(id, repoId, body.keys as string[] | undefined);
+    logger.info("environment.secrets_imported", {
+      event: "environment.secrets_imported",
+      environment_id: id,
+      source_repo: `${srcOwner}/${srcName}`,
+      keys_count: result.keys.length,
+      created: result.created,
+      updated: result.updated,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return json({
+      status: "imported",
+      environmentId: id,
+      source: `${srcOwner}/${srcName}`,
+      keys: result.keys,
+      created: result.created,
+      updated: result.updated,
+    });
+  } catch (e) {
+    if (e instanceof SecretsValidationError) return error(e.message, 400);
+    logger.error("Failed to import environment secrets", {
+      error: e instanceof Error ? e.message : String(e),
+      environment_id: id,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return error("Secrets storage unavailable", 503);
+  }
+}
+
+export const environmentRoutes: Route[] = [
+  { method: "GET", pattern: parsePattern("/environments"), handler: handleListEnvironments },
+  { method: "POST", pattern: parsePattern("/environments"), handler: handleCreateEnvironment },
+  { method: "GET", pattern: parsePattern("/environments/:id"), handler: handleGetEnvironment },
+  { method: "PUT", pattern: parsePattern("/environments/:id"), handler: handleUpdateEnvironment },
+  {
+    method: "DELETE",
+    pattern: parsePattern("/environments/:id"),
+    handler: handleDeleteEnvironment,
+  },
+  {
+    method: "GET",
+    pattern: parsePattern("/environments/:id/secrets"),
+    handler: handleListEnvironmentSecrets,
+  },
+  {
+    method: "PUT",
+    pattern: parsePattern("/environments/:id/secrets"),
+    handler: handleSetEnvironmentSecrets,
+  },
+  {
+    method: "POST",
+    pattern: parsePattern("/environments/:id/secrets/import"),
+    handler: handleImportEnvironmentSecrets,
+  },
+  {
+    method: "DELETE",
+    pattern: parsePattern("/environments/:id/secrets/:key"),
+    handler: handleDeleteEnvironmentSecret,
+  },
+];

--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -32,7 +32,7 @@ describe("buildModalSandboxDashboardUrl", () => {
     expect(
       buildModalSandboxDashboardUrl({
         workspace: "acme",
-        environment: "production",
+        modalEnvironment: "production",
         providerObjectId: "sb-123",
       })
     ).toBe(
@@ -44,7 +44,7 @@ describe("buildModalSandboxDashboardUrl", () => {
     expect(
       buildModalSandboxDashboardUrl({
         workspace: "acme team",
-        environment: "prod/main",
+        modalEnvironment: "prod/main",
         providerObjectId: "sb 123/456?x=1",
       })
     ).toBe(

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -39,14 +39,16 @@ function getModalBaseUrl(workspace: string, environmentWebSuffix?: string): stri
  */
 export function buildModalSandboxDashboardUrl(params: {
   workspace: string | undefined;
-  environment?: string | undefined;
+  // Modal workspace environment (unrelated to the Environment entity); named
+  // modalEnvironment to keep the term unambiguous (design §7.1).
+  modalEnvironment?: string | undefined;
   providerObjectId: string | null | undefined;
 }): string | null {
   if (!params.workspace || !params.providerObjectId) return null;
   const workspace = encodeURIComponent(params.workspace);
-  const environment = encodeURIComponent(params.environment || DEFAULT_MODAL_ENVIRONMENT);
+  const modalEnvironment = encodeURIComponent(params.modalEnvironment || DEFAULT_MODAL_ENVIRONMENT);
   const providerObjectId = encodeURIComponent(params.providerObjectId);
-  return `https://modal.com/apps/${workspace}/${environment}/deployed/${MODAL_APP_NAME}?activeTab=sandboxes&sandboxId=${providerObjectId}`;
+  return `https://modal.com/apps/${workspace}/${modalEnvironment}/deployed/${MODAL_APP_NAME}?activeTab=sandboxes&sandboxId=${providerObjectId}`;
 }
 
 export interface CreateSandboxRequest {

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1752,7 +1752,7 @@ export class SessionDO extends DurableObject<Env> {
     if (resolveSandboxBackendName(this.env.SANDBOX_PROVIDER) !== "modal") return null;
     return buildModalSandboxDashboardUrl({
       workspace: this.env.MODAL_WORKSPACE,
-      environment: this.env.MODAL_ENVIRONMENT,
+      modalEnvironment: this.env.MODAL_ENVIRONMENT,
       providerObjectId,
     });
   }

--- a/packages/control-plane/test/integration/cleanup.ts
+++ b/packages/control-plane/test/integration/cleanup.ts
@@ -6,6 +6,6 @@ import { env } from "cloudflare:test";
  */
 export async function cleanD1Tables(): Promise<void> {
   await env.DB.exec(
-    "DELETE FROM automation_slack_channels; DELETE FROM automation_runs; DELETE FROM automation_invocations; DELETE FROM automation_repositories; DELETE FROM automations; DELETE FROM session_repositories; DELETE FROM sessions; DELETE FROM user_scm_tokens; DELETE FROM repo_metadata; DELETE FROM repo_secrets; DELETE FROM global_secrets; DELETE FROM integration_settings; DELETE FROM integration_repo_settings; DELETE FROM repo_images; DELETE FROM mcp_servers; DELETE FROM user_identities; DELETE FROM users;"
+    "DELETE FROM automation_slack_channels; DELETE FROM automation_runs; DELETE FROM automation_invocations; DELETE FROM automation_repositories; DELETE FROM automations; DELETE FROM session_repositories; DELETE FROM sessions; DELETE FROM user_scm_tokens; DELETE FROM repo_metadata; DELETE FROM repo_secrets; DELETE FROM global_secrets; DELETE FROM integration_settings; DELETE FROM integration_repo_settings; DELETE FROM repo_images; DELETE FROM mcp_servers; DELETE FROM user_identities; DELETE FROM users; DELETE FROM environment_images; DELETE FROM environment_secrets; DELETE FROM environment_repositories; DELETE FROM environments;"
   );
 }

--- a/packages/control-plane/test/integration/environment-secrets.test.ts
+++ b/packages/control-plane/test/integration/environment-secrets.test.ts
@@ -1,0 +1,82 @@
+/**
+ * EnvironmentSecretsStore: per-environment CRUD parity with repo secrets, and
+ * the per-key import that copies ciphertext VERBATIM from a member repo (shared
+ * encryption key, so no decrypt/re-encrypt round-trip — the plaintext never
+ * transits the control plane).
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import { EnvironmentSecretsStore } from "../../src/db/environment-secrets";
+import { RepoSecretsStore } from "../../src/db/repo-secrets";
+import { decryptToken } from "../../src/auth/crypto";
+import { cleanD1Tables } from "./cleanup";
+
+const key = () => env.REPO_SECRETS_ENCRYPTION_KEY!;
+const ENV_ID = "env_secrets_test";
+
+describe("EnvironmentSecretsStore", () => {
+  beforeEach(cleanD1Tables);
+
+  it("sets, lists, decrypts, and deletes environment secrets", async () => {
+    const store = new EnvironmentSecretsStore(env.DB, key());
+    const res = await store.setSecrets(ENV_ID, { API_URL: "https://x", TOKEN: "abc" });
+    expect(res.created).toBe(2);
+    expect(res.keys.sort()).toEqual(["API_URL", "TOKEN"]);
+
+    expect((await store.listSecretKeys(ENV_ID)).map((k) => k.key)).toEqual(["API_URL", "TOKEN"]);
+    expect(await store.getDecryptedSecrets(ENV_ID)).toEqual({ API_URL: "https://x", TOKEN: "abc" });
+
+    expect(await store.deleteSecret(ENV_ID, "TOKEN")).toBe(true);
+    expect((await store.listSecretKeys(ENV_ID)).map((k) => k.key)).toEqual(["API_URL"]);
+  });
+
+  it("scopes secrets per environment", async () => {
+    const store = new EnvironmentSecretsStore(env.DB, key());
+    await store.setSecrets("env_a", { A: "1" });
+    await store.setSecrets("env_b", { B: "2" });
+    expect(Object.keys(await store.getDecryptedSecrets("env_a"))).toEqual(["A"]);
+    expect(Object.keys(await store.getDecryptedSecrets("env_b"))).toEqual(["B"]);
+  });
+
+  it("imports selected repo secrets, ciphertext-verbatim (no re-encryption)", async () => {
+    const repoStore = new RepoSecretsStore(env.DB, key());
+    await repoStore.setSecrets(42, "acme", "web", { DB_URL: "postgres://secret", ONLY_ONE: "x" });
+
+    const src = await env.DB.prepare(
+      "SELECT key, encrypted_value FROM repo_secrets WHERE repo_id = 42"
+    ).all<{ key: string; encrypted_value: string }>();
+    const srcCipher = new Map((src.results ?? []).map((r) => [r.key, r.encrypted_value]));
+
+    const envStore = new EnvironmentSecretsStore(env.DB, key());
+    const result = await envStore.importFromRepo(ENV_ID, 42, ["DB_URL"]);
+    expect(result.created).toBe(1);
+    expect(result.keys).toEqual(["DB_URL"]);
+
+    const copied = await env.DB.prepare(
+      "SELECT encrypted_value FROM environment_secrets WHERE environment_id = ? AND key = 'DB_URL'"
+    )
+      .bind(ENV_ID)
+      .first<{ encrypted_value: string }>();
+    // Byte-identical to the source ciphertext.
+    expect(copied?.encrypted_value).toBe(srcCipher.get("DB_URL"));
+    // ...and decrypts to the original plaintext under the shared key.
+    expect(await decryptToken(copied!.encrypted_value, key())).toBe("postgres://secret");
+    // Unrequested key was not imported.
+    expect((await envStore.listSecretKeys(ENV_ID)).map((k) => k.key)).toEqual(["DB_URL"]);
+  });
+
+  it("imports all repo keys when none are specified", async () => {
+    const repoStore = new RepoSecretsStore(env.DB, key());
+    await repoStore.setSecrets(7, "acme", "api", { A: "1", B: "2" });
+    const envStore = new EnvironmentSecretsStore(env.DB, key());
+    const result = await envStore.importFromRepo(ENV_ID, 7);
+    expect(result.keys.sort()).toEqual(["A", "B"]);
+  });
+
+  it("no-ops when the source repo has no matching keys", async () => {
+    const envStore = new EnvironmentSecretsStore(env.DB, key());
+    const result = await envStore.importFromRepo(ENV_ID, 999, ["NOPE"]);
+    expect(result).toEqual({ created: 0, updated: 0, keys: [] });
+  });
+});

--- a/packages/control-plane/test/integration/environment-secrets.test.ts
+++ b/packages/control-plane/test/integration/environment-secrets.test.ts
@@ -15,8 +15,19 @@ import { cleanD1Tables } from "./cleanup";
 const key = () => env.REPO_SECRETS_ENCRYPTION_KEY!;
 const ENV_ID = "env_secrets_test";
 
+/** Insert a parent environments row so the FK-backed secret writes are valid. */
+async function seedEnv(id: string): Promise<void> {
+  const now = Date.now();
+  await env.DB.prepare(
+    "INSERT INTO environments (id, name, prebuild_enabled, created_at, updated_at) VALUES (?, ?, 0, ?, ?)"
+  )
+    .bind(id, id, now, now)
+    .run();
+}
+
 describe("EnvironmentSecretsStore", () => {
   beforeEach(cleanD1Tables);
+  beforeEach(() => seedEnv(ENV_ID));
 
   it("sets, lists, decrypts, and deletes environment secrets", async () => {
     const store = new EnvironmentSecretsStore(env.DB, key());
@@ -33,6 +44,8 @@ describe("EnvironmentSecretsStore", () => {
 
   it("scopes secrets per environment", async () => {
     const store = new EnvironmentSecretsStore(env.DB, key());
+    await seedEnv("env_a");
+    await seedEnv("env_b");
     await store.setSecrets("env_a", { A: "1" });
     await store.setSecrets("env_b", { B: "2" });
     expect(Object.keys(await store.getDecryptedSecrets("env_a"))).toEqual(["A"]);

--- a/packages/control-plane/test/integration/environment-store.test.ts
+++ b/packages/control-plane/test/integration/environment-store.test.ts
@@ -1,0 +1,157 @@
+/**
+ * EnvironmentStore: D1 CRUD, case-insensitive name uniqueness, member ordering,
+ * and the application-level DELETE cascade (member + secret rows, image
+ * supersede). Exercises migration 0033 by construction — the queries fail if it
+ * did not apply.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import {
+  EnvironmentStore,
+  toEnvironment,
+  type EnvironmentRow,
+  type EnvironmentRepositoryInsert,
+} from "../../src/db/environments";
+import { cleanD1Tables } from "./cleanup";
+
+function makeEnv(overrides?: Partial<EnvironmentRow>): EnvironmentRow {
+  const now = Date.now();
+  return {
+    id: `env_${Math.random().toString(36).slice(2, 10)}`,
+    name: "Full Stack",
+    description: null,
+    prebuild_enabled: 0,
+    created_at: now,
+    updated_at: now,
+    ...overrides,
+  };
+}
+
+function repos(...specs: [string, string, number, string][]): EnvironmentRepositoryInsert[] {
+  return specs.map(([repo_owner, repo_name, repo_id, base_branch], position) => ({
+    position,
+    repo_owner,
+    repo_name,
+    repo_id,
+    base_branch,
+  }));
+}
+
+describe("EnvironmentStore", () => {
+  beforeEach(cleanD1Tables);
+
+  it("creates an environment with members in position order and reads them back", async () => {
+    const store = new EnvironmentStore(env.DB);
+    const row = makeEnv({ name: "Full Stack", description: "web + api", prebuild_enabled: 1 });
+    await store.create(row, repos(["acme", "web", 1, "main"], ["acme", "api", 2, "develop"]));
+
+    const got = await store.getById(row.id);
+    expect(got).not.toBeNull();
+    const environment = toEnvironment(got!, await store.getRepositoriesForEnvironment(row.id));
+    expect(environment.name).toBe("Full Stack");
+    expect(environment.description).toBe("web + api");
+    expect(environment.prebuildEnabled).toBe(true);
+    expect(environment.repositories).toEqual([
+      { repoOwner: "acme", repoName: "web", repoId: 1, baseBranch: "main" },
+      { repoOwner: "acme", repoName: "api", repoId: 2, baseBranch: "develop" },
+    ]);
+  });
+
+  it("resolves names case-insensitively via getByName", async () => {
+    const store = new EnvironmentStore(env.DB);
+    await store.create(makeEnv({ name: "Payments" }), repos(["acme", "web", 1, "main"]));
+    expect(await store.getByName("payments")).not.toBeNull();
+    expect(await store.getByName("PAYMENTS")).not.toBeNull();
+    expect(await store.getByName("other")).toBeNull();
+  });
+
+  it("rejects a case-insensitive duplicate name at the unique index", async () => {
+    const store = new EnvironmentStore(env.DB);
+    await store.create(makeEnv({ name: "Dup" }), repos(["acme", "web", 1, "main"]));
+    await expect(
+      store.create(makeEnv({ name: "dup" }), repos(["acme", "api", 2, "main"]))
+    ).rejects.toThrow();
+  });
+
+  it("lists environments newest-first", async () => {
+    const store = new EnvironmentStore(env.DB);
+    await store.create(makeEnv({ name: "A", created_at: 1000 }), repos(["acme", "web", 1, "main"]));
+    await store.create(makeEnv({ name: "B", created_at: 2000 }), repos(["acme", "api", 2, "main"]));
+    const { environments, total } = await store.list();
+    expect(total).toBe(2);
+    expect(environments.map((e) => e.name)).toEqual(["B", "A"]);
+  });
+
+  it("updates scalar fields and replaces the member set atomically", async () => {
+    const store = new EnvironmentStore(env.DB);
+    const row = makeEnv({ name: "Before", prebuild_enabled: 0 });
+    await store.create(row, repos(["acme", "web", 1, "main"]));
+
+    const updated = await store.update(
+      row.id,
+      { name: "After", prebuild_enabled: 1 },
+      repos(["acme", "api", 2, "develop"], ["acme", "worker", 3, "main"])
+    );
+    expect(updated?.name).toBe("After");
+    expect(updated?.prebuild_enabled).toBe(1);
+    const repoRows = await store.getRepositoriesForEnvironment(row.id);
+    expect(repoRows.map((r) => r.repo_name)).toEqual(["api", "worker"]);
+  });
+
+  it("bumps updated_at on a members-only edit", async () => {
+    const store = new EnvironmentStore(env.DB);
+    const row = makeEnv({ name: "Bump", created_at: 1000, updated_at: 1000 });
+    await store.create(row, repos(["acme", "web", 1, "main"]));
+    const updated = await store.update(row.id, {}, repos(["acme", "api", 2, "main"]));
+    expect(updated!.updated_at).toBeGreaterThan(1000);
+  });
+
+  it("cascade-deletes members + secrets and supersedes only live images", async () => {
+    const store = new EnvironmentStore(env.DB);
+    const row = makeEnv({ name: "Doomed" });
+    await store.create(row, repos(["acme", "web", 1, "main"], ["acme", "api", 2, "main"]));
+
+    const now = Date.now();
+    await env.DB.prepare(
+      "INSERT INTO environment_secrets (environment_id, key, encrypted_value, created_at, updated_at) VALUES (?, ?, ?, ?, ?)"
+    )
+      .bind(row.id, "TOKEN", "cipher", now, now)
+      .run();
+    await env.DB.batch([
+      env.DB.prepare(
+        "INSERT INTO environment_images (id, environment_id, members_fingerprint, member_shas, runtime_version, status, created_at) VALUES (?, ?, ?, ?, ?, 'ready', ?)"
+      ).bind("img_ready", row.id, "fp", "[]", "v3", now),
+      env.DB.prepare(
+        "INSERT INTO environment_images (id, environment_id, members_fingerprint, member_shas, runtime_version, status, created_at) VALUES (?, ?, ?, ?, ?, 'failed', ?)"
+      ).bind("img_failed", row.id, "fp", "[]", "v3", now),
+    ]);
+
+    expect(await store.delete(row.id)).toBe(true);
+
+    expect(await store.getById(row.id)).toBeNull();
+    expect((await store.getRepositoriesForEnvironment(row.id)).length).toBe(0);
+    const secretCount = await env.DB.prepare(
+      "SELECT COUNT(*) AS c FROM environment_secrets WHERE environment_id = ?"
+    )
+      .bind(row.id)
+      .first<{ c: number }>();
+    expect(secretCount?.c).toBe(0);
+    const ready = await env.DB.prepare(
+      "SELECT status FROM environment_images WHERE id = 'img_ready'"
+    ).first<{ status: string }>();
+    expect(ready?.status).toBe("superseded");
+    const failed = await env.DB.prepare(
+      "SELECT status FROM environment_images WHERE id = 'img_failed'"
+    ).first<{ status: string }>();
+    expect(failed?.status).toBe("failed"); // pre-existing terminal status untouched
+  });
+
+  it("delete is idempotent (false the second time)", async () => {
+    const store = new EnvironmentStore(env.DB);
+    const row = makeEnv({ name: "Once" });
+    await store.create(row, repos(["acme", "web", 1, "main"]));
+    expect(await store.delete(row.id)).toBe(true);
+    expect(await store.delete(row.id)).toBe(false);
+  });
+});

--- a/packages/control-plane/test/integration/environment-store.test.ts
+++ b/packages/control-plane/test/integration/environment-store.test.ts
@@ -155,21 +155,27 @@ describe("EnvironmentStore", () => {
     expect(await store.delete(row.id)).toBe(false);
   });
 
-  it("never inserts orphan repository rows when the parent is gone (no-FK guard)", async () => {
+  it("cascade-deletes child repository + secret rows via FK on parent delete", async () => {
     const store = new EnvironmentStore(env.DB);
-    // Stands in for the delete-between-check-and-batch race: updating a missing
-    // environment must not leave orphan environment_repositories rows behind.
-    const result = await store.update(
-      "env_missing",
-      { name: "x" },
-      repos(["acme", "web", 1, "main"])
-    );
-    expect(result).toBeNull();
-    const count = await env.DB.prepare(
-      "SELECT COUNT(*) AS c FROM environment_repositories WHERE environment_id = ?"
+    const row = makeEnv({ name: "FkCascade" });
+    await store.create(row, repos(["acme", "web", 1, "main"], ["acme", "api", 2, "main"]));
+    const now = Date.now();
+    await env.DB.prepare(
+      "INSERT INTO environment_secrets (environment_id, key, encrypted_value, created_at, updated_at) VALUES (?, ?, ?, ?, ?)"
     )
-      .bind("env_missing")
+      .bind(row.id, "TOKEN", "cipher", now, now)
+      .run();
+
+    // Raw parent delete (bypassing store.delete's explicit child deletes) so the
+    // ON DELETE CASCADE FK is what reclaims the children.
+    await env.DB.prepare("DELETE FROM environments WHERE id = ?").bind(row.id).run();
+
+    expect((await store.getRepositoriesForEnvironment(row.id)).length).toBe(0);
+    const secretCount = await env.DB.prepare(
+      "SELECT COUNT(*) AS c FROM environment_secrets WHERE environment_id = ?"
+    )
+      .bind(row.id)
       .first<{ c: number }>();
-    expect(count?.c).toBe(0);
+    expect(secretCount?.c).toBe(0);
   });
 });

--- a/packages/control-plane/test/integration/environment-store.test.ts
+++ b/packages/control-plane/test/integration/environment-store.test.ts
@@ -154,4 +154,22 @@ describe("EnvironmentStore", () => {
     expect(await store.delete(row.id)).toBe(true);
     expect(await store.delete(row.id)).toBe(false);
   });
+
+  it("never inserts orphan repository rows when the parent is gone (no-FK guard)", async () => {
+    const store = new EnvironmentStore(env.DB);
+    // Stands in for the delete-between-check-and-batch race: updating a missing
+    // environment must not leave orphan environment_repositories rows behind.
+    const result = await store.update(
+      "env_missing",
+      { name: "x" },
+      repos(["acme", "web", 1, "main"])
+    );
+    expect(result).toBeNull();
+    const count = await env.DB.prepare(
+      "SELECT COUNT(*) AS c FROM environment_repositories WHERE environment_id = ?"
+    )
+      .bind("env_missing")
+      .first<{ c: number }>();
+    expect(count?.c).toBe(0);
+  });
 });

--- a/packages/control-plane/test/integration/environments-routes.test.ts
+++ b/packages/control-plane/test/integration/environments-routes.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Environment routes over SELF.fetch: internal-HMAC auth, create-time validation
+ * (which short-circuits before SCM resolution), GET/DELETE, the environment
+ * secrets routes, and the member-scoped, value-free secret import.
+ *
+ * The happy-path create (POST /environments) resolves repositories through the SCM
+ * provider, which is unconfigured in the test env — so environments needing to
+ * exist are seeded directly via EnvironmentStore (mirroring PR-4's split).
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { SELF, env } from "cloudflare:test";
+import { generateInternalToken } from "../../src/auth/internal";
+import { EnvironmentStore } from "../../src/db/environments";
+import { RepoSecretsStore } from "../../src/db/repo-secrets";
+import { cleanD1Tables } from "./cleanup";
+
+const BASE = "https://test.local";
+
+async function authHeaders(): Promise<Record<string, string>> {
+  const token = await generateInternalToken(env.INTERNAL_CALLBACK_SECRET!);
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+async function seedEnvironment(opts?: {
+  id?: string;
+  name?: string;
+  repositories?: [string, string, number, string][];
+}): Promise<string> {
+  const store = new EnvironmentStore(env.DB);
+  const id = opts?.id ?? `env_${Math.random().toString(36).slice(2, 10)}`;
+  const now = Date.now();
+  await store.create(
+    {
+      id,
+      name: opts?.name ?? "Seeded",
+      description: null,
+      prebuild_enabled: 0,
+      created_at: now,
+      updated_at: now,
+    },
+    (opts?.repositories ?? [["acme", "web", 1, "main"]]).map(([o, n, rid, b], position) => ({
+      position,
+      repo_owner: o,
+      repo_name: n,
+      repo_id: rid,
+      base_branch: b,
+    }))
+  );
+  return id;
+}
+
+describe("Environments API (routes)", () => {
+  beforeEach(cleanD1Tables);
+
+  describe("auth", () => {
+    it("returns 401 without internal auth", async () => {
+      const cases = [
+        ["GET", "/environments"],
+        ["POST", "/environments"],
+        ["GET", "/environments/env_x"],
+        ["DELETE", "/environments/env_x"],
+        ["GET", "/environments/env_x/secrets"],
+        ["POST", "/environments/env_x/secrets/import"],
+      ] as const;
+      for (const [method, path] of cases) {
+        const res = await SELF.fetch(`${BASE}${path}`, {
+          method,
+          headers: { "Content-Type": "application/json" },
+          body: method === "GET" || method === "DELETE" ? undefined : "{}",
+        });
+        expect(res.status, `${method} ${path}`).toBe(401);
+      }
+    });
+  });
+
+  describe("POST /environments (validation before SCM resolution)", () => {
+    it("rejects a missing name (400)", async () => {
+      const res = await SELF.fetch(`${BASE}/environments`, {
+        method: "POST",
+        headers: await authHeaders(),
+        body: JSON.stringify({ repositories: [{ repoOwner: "acme", repoName: "web" }] }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects empty repositories (400)", async () => {
+      const res = await SELF.fetch(`${BASE}/environments`, {
+        method: "POST",
+        headers: await authHeaders(),
+        body: JSON.stringify({ name: "X", repositories: [] }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects a duplicate name before resolving repos (409)", async () => {
+      await seedEnvironment({ name: "Taken" });
+      const res = await SELF.fetch(`${BASE}/environments`, {
+        method: "POST",
+        headers: await authHeaders(),
+        body: JSON.stringify({
+          name: "taken",
+          repositories: [{ repoOwner: "acme", repoName: "api" }],
+        }),
+      });
+      expect(res.status).toBe(409);
+    });
+  });
+
+  describe("GET/DELETE /environments/:id", () => {
+    it("lists and fetches seeded environments", async () => {
+      const id = await seedEnvironment({
+        name: "Listed",
+        repositories: [
+          ["acme", "web", 1, "main"],
+          ["acme", "api", 2, "develop"],
+        ],
+      });
+      const headers = await authHeaders();
+
+      const listRes = await SELF.fetch(`${BASE}/environments`, { headers });
+      expect(listRes.status).toBe(200);
+      const list = await listRes.json<{
+        environments: { id: string; repositories: unknown[] }[];
+        total: number;
+      }>();
+      expect(list.total).toBe(1);
+      expect(list.environments[0].repositories.length).toBe(2);
+
+      const getRes = await SELF.fetch(`${BASE}/environments/${id}`, { headers });
+      expect(getRes.status).toBe(200);
+      const got = await getRes.json<{
+        environment: { name: string; repositories: { repoName: string }[] };
+      }>();
+      expect(got.environment.name).toBe("Listed");
+      expect(got.environment.repositories.map((m) => m.repoName)).toEqual(["web", "api"]);
+    });
+
+    it("returns 404 for an unknown environment", async () => {
+      const headers = await authHeaders();
+      expect((await SELF.fetch(`${BASE}/environments/env_missing`, { headers })).status).toBe(404);
+      expect(
+        (await SELF.fetch(`${BASE}/environments/env_missing`, { method: "DELETE", headers })).status
+      ).toBe(404);
+    });
+
+    it("deletes an environment and cascades its secret rows", async () => {
+      const id = await seedEnvironment({ name: "Gone" });
+      const headers = await authHeaders();
+      await SELF.fetch(`${BASE}/environments/${id}/secrets`, {
+        method: "PUT",
+        headers,
+        body: JSON.stringify({ secrets: { K: "v" } }),
+      });
+
+      const delRes = await SELF.fetch(`${BASE}/environments/${id}`, { method: "DELETE", headers });
+      expect(delRes.status).toBe(200);
+      expect((await SELF.fetch(`${BASE}/environments/${id}`, { headers })).status).toBe(404);
+      const secretCount = await env.DB.prepare(
+        "SELECT COUNT(*) AS c FROM environment_secrets WHERE environment_id = ?"
+      )
+        .bind(id)
+        .first<{ c: number }>();
+      expect(secretCount?.c).toBe(0);
+    });
+  });
+
+  describe("environment secrets routes", () => {
+    it("sets, lists (with global), and deletes secrets on a seeded environment", async () => {
+      const id = await seedEnvironment();
+      const headers = await authHeaders();
+
+      await SELF.fetch(`${BASE}/secrets`, {
+        method: "PUT",
+        headers,
+        body: JSON.stringify({ secrets: { GLOBAL_ONE: "g" } }),
+      });
+
+      const putRes = await SELF.fetch(`${BASE}/environments/${id}/secrets`, {
+        method: "PUT",
+        headers,
+        body: JSON.stringify({ secrets: { ENV_ONE: "1", ENV_TWO: "2" } }),
+      });
+      expect(putRes.status).toBe(200);
+
+      const listRes = await SELF.fetch(`${BASE}/environments/${id}/secrets`, { headers });
+      expect(listRes.status).toBe(200);
+      const list = await listRes.json<{
+        environmentId: string;
+        secrets: { key: string }[];
+        globalSecrets: { key: string }[];
+      }>();
+      expect(list.environmentId).toBe(id);
+      expect(list.secrets.map((s) => s.key)).toEqual(["ENV_ONE", "ENV_TWO"]);
+      expect(list.globalSecrets.map((s) => s.key)).toEqual(["GLOBAL_ONE"]);
+
+      const delRes = await SELF.fetch(`${BASE}/environments/${id}/secrets/ENV_ONE`, {
+        method: "DELETE",
+        headers,
+      });
+      expect(delRes.status).toBe(200);
+      const after = await SELF.fetch(`${BASE}/environments/${id}/secrets`, { headers });
+      expect(
+        (await after.json<{ secrets: { key: string }[] }>()).secrets.map((s) => s.key)
+      ).toEqual(["ENV_TWO"]);
+    });
+
+    it("returns 404 when the environment does not exist", async () => {
+      const res = await SELF.fetch(`${BASE}/environments/env_missing/secrets`, {
+        method: "PUT",
+        headers: await authHeaders(),
+        body: JSON.stringify({ secrets: { K: "v" } }),
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("POST /environments/:id/secrets/import", () => {
+    it("imports from a member repo and returns key names only", async () => {
+      const id = await seedEnvironment({ repositories: [["acme", "web", 1, "main"]] });
+      const headers = await authHeaders();
+      await new RepoSecretsStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY!).setSecrets(
+        1,
+        "acme",
+        "web",
+        {
+          DEPLOY_KEY: "supersecretvalue",
+        }
+      );
+
+      const res = await SELF.fetch(`${BASE}/environments/${id}/secrets/import`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ repoOwner: "acme", repoName: "web", keys: ["DEPLOY_KEY"] }),
+      });
+      expect(res.status).toBe(200);
+      const raw = await res.text();
+      // Value-free: neither plaintext nor ciphertext leaks into the response.
+      expect(raw).not.toContain("supersecretvalue");
+      const body = JSON.parse(raw) as { status: string; keys: string[]; created: number };
+      expect(body.status).toBe("imported");
+      expect(body.keys).toEqual(["DEPLOY_KEY"]);
+      expect(body.created).toBe(1);
+
+      const listRes = await SELF.fetch(`${BASE}/environments/${id}/secrets`, { headers });
+      expect(
+        (await listRes.json<{ secrets: { key: string }[] }>()).secrets.map((s) => s.key)
+      ).toEqual(["DEPLOY_KEY"]);
+    });
+
+    it("rejects a non-member source with 403 and imports nothing", async () => {
+      const id = await seedEnvironment({ repositories: [["acme", "web", 1, "main"]] });
+      const headers = await authHeaders();
+      await new RepoSecretsStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY!).setSecrets(
+        2,
+        "acme",
+        "other",
+        {
+          SECRET: "leakme",
+        }
+      );
+
+      const res = await SELF.fetch(`${BASE}/environments/${id}/secrets/import`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ repoOwner: "acme", repoName: "other", keys: ["SECRET"] }),
+      });
+      expect(res.status).toBe(403);
+      expect(await res.text()).not.toContain("leakme");
+
+      const listRes = await SELF.fetch(`${BASE}/environments/${id}/secrets`, { headers });
+      expect((await listRes.json<{ secrets: unknown[] }>()).secrets).toEqual([]);
+    });
+  });
+});

--- a/packages/shared/src/types/environments.test.ts
+++ b/packages/shared/src/types/environments.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  createEnvironmentInputSchema,
+  updateEnvironmentInputSchema,
+  MAX_ENVIRONMENT_NAME_LENGTH,
+} from "./index";
+
+describe("createEnvironmentInputSchema", () => {
+  it("parses a valid environment and normalizes member identifiers", () => {
+    const parsed = createEnvironmentInputSchema.parse({
+      name: "Full Stack",
+      description: "web + api",
+      prebuildEnabled: true,
+      repositories: [
+        { repoOwner: "Acme", repoName: "Web", baseBranch: "main" },
+        { repoOwner: "acme", repoName: "api" },
+      ],
+    });
+    expect(parsed.repositories).toEqual([
+      { repoOwner: "acme", repoName: "web", baseBranch: "main" },
+      { repoOwner: "acme", repoName: "api", baseBranch: null },
+    ]);
+    expect(parsed.prebuildEnabled).toBe(true);
+  });
+
+  it("requires a non-empty name", () => {
+    expect(
+      createEnvironmentInputSchema.safeParse({
+        name: "",
+        repositories: [{ repoOwner: "a", repoName: "b" }],
+      }).success
+    ).toBe(false);
+  });
+
+  it("rejects a name over the length cap", () => {
+    expect(
+      createEnvironmentInputSchema.safeParse({
+        name: "x".repeat(MAX_ENVIRONMENT_NAME_LENGTH + 1),
+        repositories: [{ repoOwner: "a", repoName: "b" }],
+      }).success
+    ).toBe(false);
+  });
+
+  it("rejects an empty member list", () => {
+    expect(createEnvironmentInputSchema.safeParse({ name: "X", repositories: [] }).success).toBe(
+      false
+    );
+  });
+
+  it("rejects duplicate owner/name repositories", () => {
+    expect(
+      createEnvironmentInputSchema.safeParse({
+        name: "X",
+        repositories: [
+          { repoOwner: "acme", repoName: "web" },
+          { repoOwner: "acme", repoName: "web" },
+        ],
+      }).success
+    ).toBe(false);
+  });
+
+  it("rejects duplicate repoName across owners (checkout path collision)", () => {
+    expect(
+      createEnvironmentInputSchema.safeParse({
+        name: "X",
+        repositories: [
+          { repoOwner: "acme", repoName: "web" },
+          { repoOwner: "other", repoName: "web" },
+        ],
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe("updateEnvironmentInputSchema", () => {
+  it("accepts an empty patch (nothing changes)", () => {
+    expect(updateEnvironmentInputSchema.parse({})).toEqual({});
+  });
+
+  it("still validates repositories when present", () => {
+    expect(updateEnvironmentInputSchema.safeParse({ repositories: [] }).success).toBe(false);
+  });
+
+  it("accepts a null description to clear it", () => {
+    expect(updateEnvironmentInputSchema.parse({ description: null }).description).toBeNull();
+  });
+});

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1220,6 +1220,68 @@ export const automationRepositoryInputSchema = repositoryInputSchema;
 export type AutomationRepositoryInput = RepositoryInput;
 export const automationRepositoriesInputSchema = repositoriesInputSchema;
 
+// ==================== Environments ====================
+
+/** Maximum characters in an environment's display name. */
+export const MAX_ENVIRONMENT_NAME_LENGTH = 200;
+/** Maximum characters in an environment's description. */
+export const MAX_ENVIRONMENT_DESCRIPTION_LENGTH = 2000;
+
+/**
+ * An environment's repositories share the session list contract: non-empty,
+ * deduplicated by owner/name AND by repoName (checkout paths are
+ * /workspace/{repoName}, so a name collision is rejected), and capped at
+ * MAX_TARGET_REPOSITORIES. An environment is a prebuildable repository set, so
+ * it inherits exactly the session's list rules.
+ */
+export const environmentRepositoriesInputSchema = sessionRepositoriesInputSchema;
+
+export const createEnvironmentInputSchema = z.object({
+  name: z.string().trim().min(1).max(MAX_ENVIRONMENT_NAME_LENGTH),
+  description: z.string().trim().max(MAX_ENVIRONMENT_DESCRIPTION_LENGTH).nullish(),
+  prebuildEnabled: z.boolean().optional(),
+  repositories: environmentRepositoriesInputSchema,
+});
+
+export const updateEnvironmentInputSchema = z.object({
+  name: z.string().trim().min(1).max(MAX_ENVIRONMENT_NAME_LENGTH).optional(),
+  description: z.string().trim().max(MAX_ENVIRONMENT_DESCRIPTION_LENGTH).nullish(),
+  prebuildEnabled: z.boolean().optional(),
+  repositories: environmentRepositoriesInputSchema.optional(),
+});
+
+export type CreateEnvironmentInput = z.input<typeof createEnvironmentInputSchema>;
+export type UpdateEnvironmentInput = z.input<typeof updateEnvironmentInputSchema>;
+
+/**
+ * A resolved environment repository. baseBranch is non-null (the DDL column is
+ * NOT NULL — resolution fills the repo's default branch when the request omits
+ * it); repoId is nullable to tolerate rows written before a repo resolved.
+ */
+export interface EnvironmentRepository {
+  repoOwner: string;
+  repoName: string;
+  repoId: number | null;
+  baseBranch: string;
+}
+
+/** An environment: a named, prebuildable repository set (design §7.1). */
+export interface Environment {
+  id: string;
+  name: string;
+  description: string | null;
+  prebuildEnabled: boolean;
+  createdAt: number;
+  updatedAt: number;
+  /** Ordered repositories; [0] is the primary (sandbox/code-server settings source). */
+  repositories: EnvironmentRepository[];
+}
+
+export interface ListEnvironmentsResponse {
+  environments: Environment[];
+  total: number;
+}
+
 export interface Automation {
   id: string;
   name: string;

--- a/packages/web/src/app/api/environments/[id]/route.ts
+++ b/packages/web/src/app/api/environments/[id]/route.ts
@@ -1,0 +1,71 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const response = await controlPlaneFetch(`/environments/${encodeURIComponent(id)}`);
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to fetch environment:", error);
+    return NextResponse.json({ error: "Failed to fetch environment" }, { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const body = await request.json();
+
+    const response = await controlPlaneFetch(`/environments/${encodeURIComponent(id)}`, {
+      method: "PUT",
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to update environment:", error);
+    return NextResponse.json({ error: "Failed to update environment" }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const response = await controlPlaneFetch(`/environments/${encodeURIComponent(id)}`, {
+      method: "DELETE",
+    });
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to delete environment:", error);
+    return NextResponse.json({ error: "Failed to delete environment" }, { status: 500 });
+  }
+}

--- a/packages/web/src/app/api/environments/[id]/secrets/[key]/route.ts
+++ b/packages/web/src/app/api/environments/[id]/secrets/[key]/route.ts
@@ -1,0 +1,29 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string; key: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id, key } = await params;
+
+  try {
+    const response = await controlPlaneFetch(
+      `/environments/${encodeURIComponent(id)}/secrets/${encodeURIComponent(key)}`,
+      { method: "DELETE" }
+    );
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to delete environment secret:", error);
+    return NextResponse.json({ error: "Failed to delete environment secret" }, { status: 500 });
+  }
+}

--- a/packages/web/src/app/api/environments/[id]/secrets/import/route.ts
+++ b/packages/web/src/app/api/environments/[id]/secrets/import/route.ts
@@ -1,0 +1,29 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const body = await request.json();
+
+    const response = await controlPlaneFetch(
+      `/environments/${encodeURIComponent(id)}/secrets/import`,
+      { method: "POST", body: JSON.stringify(body) }
+    );
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to import environment secrets:", error);
+    return NextResponse.json({ error: "Failed to import environment secrets" }, { status: 500 });
+  }
+}

--- a/packages/web/src/app/api/environments/[id]/secrets/route.ts
+++ b/packages/web/src/app/api/environments/[id]/secrets/route.ts
@@ -1,0 +1,47 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const response = await controlPlaneFetch(`/environments/${encodeURIComponent(id)}/secrets`);
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to fetch environment secrets:", error);
+    return NextResponse.json({ error: "Failed to fetch environment secrets" }, { status: 500 });
+  }
+}
+
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const body = await request.json();
+
+    const response = await controlPlaneFetch(`/environments/${encodeURIComponent(id)}/secrets`, {
+      method: "PUT",
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to update environment secrets:", error);
+    return NextResponse.json({ error: "Failed to update environment secrets" }, { status: 500 });
+  }
+}

--- a/packages/web/src/app/api/environments/route.ts
+++ b/packages/web/src/app/api/environments/route.ts
@@ -1,0 +1,43 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const response = await controlPlaneFetch("/environments");
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to list environments:", error);
+    return NextResponse.json({ error: "Failed to list environments" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+
+    const response = await controlPlaneFetch("/environments", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to create environment:", error);
+    return NextResponse.json({ error: "Failed to create environment" }, { status: 500 });
+  }
+}

--- a/terraform/d1/migrations/0033_environments.sql
+++ b/terraform/d1/migrations/0033_environments.sql
@@ -6,10 +6,12 @@
 -- session_repositories and record provenance in sessions.environment_id; the
 -- environment can later be edited or deleted without affecting those sessions.
 --
--- No foreign keys: cascade is application-level (DELETE /environments/:id
--- removes member + secret rows and supersedes images in one batch), matching
--- the rest of the D1 schema and letting sessions keep a benignly dangling
--- environment_id after their source environment is gone.
+-- Cascade model: environment_repositories and environment_secrets are owned
+-- children declared with ON DELETE CASCADE (matching session_repositories,
+-- 0032), so deleting an environment reclaims them. environment_images is
+-- deliberately FK-less — DELETE supersedes its rows so the reaper can still
+-- delete the provider artifacts — and sessions.environment_id is FK-less so a
+-- session keeps a benignly dangling id after its source environment is gone.
 
 CREATE TABLE environments (
   id               TEXT PRIMARY KEY,            -- env_<id>
@@ -30,7 +32,8 @@ CREATE TABLE environment_repositories (
   repo_name      TEXT NOT NULL,
   repo_id        INTEGER,
   base_branch    TEXT NOT NULL,
-  PRIMARY KEY (environment_id, repo_owner, repo_name)
+  PRIMARY KEY (environment_id, repo_owner, repo_name),
+  FOREIGN KEY (environment_id) REFERENCES environments(id) ON DELETE CASCADE
 );
 
 CREATE TABLE environment_secrets (          -- mirrors repo_secrets (0001)
@@ -39,7 +42,8 @@ CREATE TABLE environment_secrets (          -- mirrors repo_secrets (0001)
   encrypted_value TEXT NOT NULL,
   created_at      INTEGER NOT NULL,
   updated_at      INTEGER NOT NULL,
-  PRIMARY KEY (environment_id, key)
+  PRIMARY KEY (environment_id, key),
+  FOREIGN KEY (environment_id) REFERENCES environments(id) ON DELETE CASCADE
 );
 
 CREATE TABLE environment_images (           -- generalizes repo_images (0009/0022/0023)

--- a/terraform/d1/migrations/0033_environments.sql
+++ b/terraform/d1/migrations/0033_environments.sql
@@ -1,0 +1,69 @@
+-- Environments: a named, prebuildable repository set (the Phase-2 launch unit).
+--
+-- An environment bundles 1..MAX_TARGET_REPOSITORIES member repositories in
+-- position order plus its own secrets, and (once prebuild lands) its own image
+-- builds. Sessions created from an environment snapshot its members into
+-- session_repositories and record provenance in sessions.environment_id; the
+-- environment can later be edited or deleted without affecting those sessions.
+--
+-- No foreign keys: cascade is application-level (DELETE /environments/:id
+-- removes member + secret rows and supersedes images in one batch), matching
+-- the rest of the D1 schema and letting sessions keep a benignly dangling
+-- environment_id after their source environment is gone.
+
+CREATE TABLE environments (
+  id               TEXT PRIMARY KEY,            -- env_<id>
+  name             TEXT NOT NULL,
+  description      TEXT,
+  prebuild_enabled INTEGER NOT NULL DEFAULT 0,
+  created_at       INTEGER NOT NULL DEFAULT (unixepoch()),
+  updated_at       INTEGER NOT NULL DEFAULT (unixepoch())
+);
+-- Names are unique case-insensitively (they are user-editable display labels;
+-- the stable env_<id> is the reference used by Slack/Linear targets, §7.5).
+CREATE UNIQUE INDEX idx_environments_name ON environments (lower(name));
+
+CREATE TABLE environment_repositories (
+  environment_id TEXT NOT NULL,
+  position       INTEGER NOT NULL,
+  repo_owner     TEXT NOT NULL,
+  repo_name      TEXT NOT NULL,
+  repo_id        INTEGER,
+  base_branch    TEXT NOT NULL,
+  PRIMARY KEY (environment_id, repo_owner, repo_name)
+);
+
+CREATE TABLE environment_secrets (          -- mirrors repo_secrets (0001)
+  environment_id  TEXT NOT NULL,
+  key             TEXT NOT NULL,
+  encrypted_value TEXT NOT NULL,
+  created_at      INTEGER NOT NULL,
+  updated_at      INTEGER NOT NULL,
+  PRIMARY KEY (environment_id, key)
+);
+
+CREATE TABLE environment_images (           -- generalizes repo_images (0009/0022/0023)
+  id                    TEXT PRIMARY KEY,
+  environment_id        TEXT NOT NULL,
+  provider              TEXT NOT NULL DEFAULT 'modal',
+  provider_image_id     TEXT,
+  members_fingerprint   TEXT NOT NULL,      -- hash over ordered (owner, name, base_branch)
+  member_shas           TEXT NOT NULL,      -- JSON [{repoOwner, repoName, baseSha}]
+  runtime_version       TEXT NOT NULL,      -- SANDBOX_VERSION at build (§7.3)
+  status                TEXT NOT NULL DEFAULT 'building',  -- building|ready|failed|superseded
+  build_duration_seconds REAL,
+  error_message         TEXT,
+  provider_session_id   TEXT,               -- provider-callback parity with 0023
+  callback_token_hash   TEXT,
+  callback_token_expires_at INTEGER,
+  callback_token_used_at    INTEGER,
+  created_at            INTEGER NOT NULL DEFAULT (unixepoch())
+);
+CREATE INDEX idx_environment_images_env_status ON environment_images (environment_id, status, created_at);
+
+-- Snapshot provenance for sessions created from an environment; no FK so a
+-- deleted environment leaves the column dangling harmlessly. Written by PR-9.
+ALTER TABLE sessions ADD COLUMN environment_id TEXT;
+
+-- Reserved for the shared-workspace automation mode (§13.3); unused until then.
+ALTER TABLE automations ADD COLUMN environment_id TEXT;


### PR DESCRIPTION
## What

PR-8 of the multi-repo sessions & environments plan — the Phase-2 kickoff.
Introduces the **environment** entity: a named, prebuildable set of repositories
with its own secrets. Everything here is **additive and dark** until the web
picker lands (PR-12); the create-a-session-from-an-environment path is PR-9.

## Changes

- **Migration `0033_environments.sql`** (DDL from design §7.2): `environments`,
  `environment_repositories` (position-ordered), `environment_secrets` (mirrors
  `repo_secrets`), `environment_images` (mirrors `repo_images`), plus
  `sessions.environment_id` (written by PR-9) and a reserved
  `automations.environment_id` (§13.3).
- **shared**: `Environment` / `EnvironmentRepository` types and
  `create`/`updateEnvironmentInputSchema`. Repositories reuse the session list
  contract (non-empty, deduped by owner/name and repoName, capped at
  `MAX_TARGET_REPOSITORIES`).
- **`db/environments.ts`** — `EnvironmentStore`: CRUD, case-insensitive name
  uniqueness, atomic scalar + repository updates, and an application-level DELETE
  cascade (repository + secret rows in one batch, live images superseded so the
  PR-10 reaper reclaims provider artifacts).
- **`db/environment-secrets.ts`** — `EnvironmentSecretsStore`: repo-secrets
  parity keyed by `environment_id` (same `REPO_SECRETS_ENCRYPTION_KEY`), plus a
  per-key **import** that copies ciphertext **verbatim** from a member repo (no
  decrypt/re-encrypt — plaintext never transits the control plane).
- **`routes/environments.ts`** — `POST/GET/PUT/DELETE /environments[...]`,
  `GET/PUT/DELETE /environments/:id/secrets[...]`, and
  `POST /environments/:id/secrets/import`. Internal-HMAC only (web BFF proxied).
  Import authorization: the source repo must be a current member (else 403), and
  responses carry **key names only**.
- **web BFF** — proxy routes under `app/api/environments/**`.
- **hygiene** — rename the Modal client's `environment?` param to
  `modalEnvironment` to disambiguate from the new entity (§7.1).

## Naming

The repository list is `repositories` (the design prose said `members`): no
surveyed product uses "members" (Cursor `repos[]`, Codespaces `repositories`,
Gitpod `additionalRepositories`), the design's own API-shape reference is
Cursor's `repos[] XOR env`, and automations/sessions already use `repositories`.
"member" survives only in prose and the mirrored DB columns
(`members_fingerprint`, `member_shas`).

## Tests

- shared: environment schema validation (name bounds, non-empty/deduped repos).
- control-plane integration (real D1 + workerd): 0033 applies; store CRUD +
  cascade; secrets CRUD; verbatim-ciphertext import (byte-equality + decrypt),
  non-member 403, value-free responses; route auth / validation / 409 / 404.

The happy-path `POST /environments` resolves repositories through the SCM
provider, which is unconfigured in the test env — so environments are seeded via
`EnvironmentStore` and the routes are tested for auth/validation/secrets/import
(mirrors PR-4's DO/store-vs-route split).

## Follow-up (not in this PR)

The `repo` / `global` / `environment` secrets stores are now three
near-identical implementations. A `refactor: unify scoped secrets stores` PR
should extract a shared scoped-secrets base — deferred here to keep this PR
additive and avoid churning the spawn-critical `repo-secrets` path.

## Validation

`typecheck` (control-plane incl. test config + web route types + shared),
`eslint`, `prettier` clean. Full suites green: shared (343), control-plane unit
(1609) + integration (481), web (552).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment management endpoints in the control plane and web app (create, list, retrieve, update, delete) with ordered repository-set handling.
  * Added environment-scoped secrets APIs (list, replace, delete) and secret import of selected repo secrets.
  * Introduced new environments and environment secrets persistence plus corresponding API route groups.
* **Bug Fixes**
  * Updated Modal sandbox dashboard URL parameter naming and aligned related session/URL usage.
* **Tests**
  * Added integration coverage for environments and environment secrets, including import behavior and authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->