### PR TITLE
feat(control-plane): sessions from environments

### DIFF
--- a/packages/control-plane/src/db/session-index.test.ts
+++ b/packages/control-plane/src/db/session-index.test.ts
@@ -22,6 +22,7 @@ type SessionRow = {
   active_duration_ms: number;
   message_count: number;
   pr_count: number;
+  environment_id: string | null;
   created_at: number;
   updated_at: number;
 };
@@ -168,6 +169,7 @@ class FakeD1Database {
         automationRunId,
         scmLogin,
         userId,
+        environmentId,
         createdAt,
         updatedAt,
       ] = args as [
@@ -182,6 +184,7 @@ class FakeD1Database {
         string | null,
         "user" | "agent" | "automation",
         number,
+        string | null,
         string | null,
         string | null,
         string | null,
@@ -212,6 +215,7 @@ class FakeD1Database {
           active_duration_ms: 0,
           message_count: 0,
           pr_count: 0,
+          environment_id: environmentId,
           created_at: createdAt,
           updated_at: updatedAt,
         });
@@ -455,6 +459,7 @@ describe("SessionIndexStore", () => {
         activeDurationMs: 0,
         messageCount: 0,
         prCount: 0,
+        environmentId: null,
       });
     });
 

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -36,6 +36,11 @@ export interface SessionEntry {
    * consumers synthesize from repoOwner/repoName.
    */
   repositories?: SessionIndexRepository[];
+  /**
+   * The environment this session was launched from (provenance), or null for
+   * repo-launched/ad-hoc sessions. PR-12 renders it on the session list.
+   */
+  environmentId?: string | null;
 }
 
 interface SessionRepositoryRow {
@@ -67,6 +72,7 @@ interface SessionRow {
   active_duration_ms: number;
   message_count: number;
   pr_count: number;
+  environment_id: string | null;
   created_at: number;
   updated_at: number;
 }
@@ -107,6 +113,7 @@ function toEntry(row: SessionRow): SessionEntry {
     activeDurationMs: row.active_duration_ms,
     messageCount: row.message_count,
     prCount: row.pr_count,
+    environmentId: row.environment_id,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -144,8 +151,8 @@ export class SessionIndexStore {
 
     const sessionStmt = this.db
       .prepare(
-        `INSERT OR IGNORE INTO sessions (id, title, repo_owner, repo_name, model, reasoning_effort, base_branch, status, parent_session_id, spawn_source, spawn_depth, automation_id, automation_run_id, scm_login, user_id, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        `INSERT OR IGNORE INTO sessions (id, title, repo_owner, repo_name, model, reasoning_effort, base_branch, status, parent_session_id, spawn_source, spawn_depth, automation_id, automation_run_id, scm_login, user_id, environment_id, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .bind(
         session.id,
@@ -163,6 +170,7 @@ export class SessionIndexStore {
         session.automationRunId ?? null,
         session.scmLogin ?? null,
         session.userId ?? null,
+        session.environmentId ?? null,
         session.createdAt,
         session.updatedAt
       );

--- a/packages/control-plane/src/repos/resolve.ts
+++ b/packages/control-plane/src/repos/resolve.ts
@@ -2,7 +2,7 @@ import type { CreateSessionRequest, RepositoryRef } from "@open-inspect/shared";
 import type { Env } from "../types";
 import type { Logger } from "../logger";
 import type { SourceControlProvider } from "../source-control";
-import { EnvironmentStore } from "../db/environments";
+import type { EnvironmentStore } from "../db/environments";
 import { createRouteSourceControlProvider, HttpError, type RequestContext } from "../routes/shared";
 
 /**
@@ -24,10 +24,9 @@ export type SessionRepositoryResolutionInput = NonNullable<
  * Raises HttpError(404) when the environment does not exist.
  */
 export async function resolveEnvironmentTarget(
-  db: D1Database,
+  store: EnvironmentStore,
   environmentId: string
 ): Promise<SessionRepositoryResolutionInput[]> {
-  const store = new EnvironmentStore(db);
   const environment = await store.getById(environmentId);
   if (!environment) {
     throw new HttpError(`Environment not found: ${environmentId}`, 404);

--- a/packages/control-plane/src/repos/resolve.ts
+++ b/packages/control-plane/src/repos/resolve.ts
@@ -2,6 +2,7 @@ import type { CreateSessionRequest, RepositoryRef } from "@open-inspect/shared";
 import type { Env } from "../types";
 import type { Logger } from "../logger";
 import type { SourceControlProvider } from "../source-control";
+import { EnvironmentStore } from "../db/environments";
 import { createRouteSourceControlProvider, HttpError, type RequestContext } from "../routes/shared";
 
 /**
@@ -11,6 +12,39 @@ import { createRouteSourceControlProvider, HttpError, type RequestContext } from
 export type SessionRepositoryResolutionInput = NonNullable<
   CreateSessionRequest["repositories"]
 >[number];
+
+/**
+ * Resolve a launch environment into the repository inputs its session should
+ * clone, in position order (design §7.6). The caller feeds these into
+ * resolveSessionRepositories, so an environment session gets the same
+ * all-or-nothing SCM check as an ad-hoc list: access to a member repo can be
+ * revoked after the environment was created, and a stale member must fail the
+ * create cleanly rather than boot a partial workspace.
+ *
+ * Raises HttpError(404) when the environment does not exist.
+ */
+export async function resolveEnvironmentTarget(
+  db: D1Database,
+  environmentId: string
+): Promise<SessionRepositoryResolutionInput[]> {
+  const store = new EnvironmentStore(db);
+  const environment = await store.getById(environmentId);
+  if (!environment) {
+    throw new HttpError(`Environment not found: ${environmentId}`, 404);
+  }
+  const repositories = await store.getRepositoriesForEnvironment(environmentId);
+  if (repositories.length === 0) {
+    // Environments always carry >=1 member by construction (the create/update
+    // schema requires it), so an empty set is a data-integrity fault, not a
+    // user mistake.
+    throw new HttpError(`Environment has no repositories: ${environmentId}`, 500);
+  }
+  return repositories.map((repo) => ({
+    repoOwner: repo.repo_owner,
+    repoName: repo.repo_name,
+    baseBranch: repo.base_branch,
+  }));
+}
 
 interface ResolutionOutcome {
   input: SessionRepositoryResolutionInput;

--- a/packages/control-plane/src/routes/session-create.ts
+++ b/packages/control-plane/src/routes/session-create.ts
@@ -4,7 +4,7 @@ import {
   type RepositoryRef,
 } from "@open-inspect/shared";
 import { encryptTokenPair, generateId } from "../auth/crypto";
-import { resolveSessionRepositories } from "../repos/resolve";
+import { resolveEnvironmentTarget, resolveSessionRepositories } from "../repos/resolve";
 import { DEFAULT_TOKEN_LIFETIME_MS, UserScmTokenStore } from "../db/user-scm-tokens";
 import { UserStore } from "../db/user-store";
 import { createLogger } from "../logger";
@@ -72,11 +72,23 @@ async function handleCreateSession(
   let repoOwner: string | null = null;
   let repoName: string | null = null;
   let repositories: RepositoryRef[] | undefined;
-  if (body.repositories) {
-    // List mode (mutually exclusive with the scalar fields by schema). The
-    // primary entry is mirrored into the scalar columns so filters, settings
-    // resolution, and pre-list consumers keep working unchanged.
+  let environmentId: string | null = null;
+  // Environment and ad-hoc list modes both produce a resolved member list;
+  // scalar mode stays a single lookup. The three are mutually exclusive by
+  // schema (hasExclusiveSessionTarget).
+  if (body.environmentId) {
+    // Snapshot the environment's members and resolve them like any other list
+    // (design §7.6); environment_id records provenance on the session.
+    const envInputs = await resolveEnvironmentTarget(env.DB, body.environmentId);
+    repositories = await resolveSessionRepositories(env, envInputs, ctx, logger);
+    environmentId = body.environmentId;
+  } else if (body.repositories) {
     repositories = await resolveSessionRepositories(env, body.repositories, ctx, logger);
+  }
+
+  if (repositories) {
+    // The primary entry is mirrored into the scalar columns so filters,
+    // settings resolution, and pre-list consumers keep working unchanged.
     const primary = repositories[0];
     repoOwner = primary.repoOwner;
     repoName = primary.repoName;
@@ -192,6 +204,7 @@ async function handleCreateSession(
     defaultBranch,
     branch: body.branch,
     repositories,
+    environmentId,
     title: body.title,
     model,
     reasoningEffort,

--- a/packages/control-plane/src/routes/session-create.ts
+++ b/packages/control-plane/src/routes/session-create.ts
@@ -5,6 +5,7 @@ import {
 } from "@open-inspect/shared";
 import { encryptTokenPair, generateId } from "../auth/crypto";
 import { resolveEnvironmentTarget, resolveSessionRepositories } from "../repos/resolve";
+import { EnvironmentStore } from "../db/environments";
 import { DEFAULT_TOKEN_LIFETIME_MS, UserScmTokenStore } from "../db/user-scm-tokens";
 import { UserStore } from "../db/user-store";
 import { createLogger } from "../logger";
@@ -79,7 +80,10 @@ async function handleCreateSession(
   if (body.environmentId) {
     // Snapshot the environment's members and resolve them like any other list
     // (design §7.6); environment_id records provenance on the session.
-    const envInputs = await resolveEnvironmentTarget(env.DB, body.environmentId);
+    const envInputs = await resolveEnvironmentTarget(
+      new EnvironmentStore(env.DB),
+      body.environmentId
+    );
     repositories = await resolveSessionRepositories(env, envInputs, ctx, logger);
     environmentId = body.environmentId;
   } else if (body.repositories) {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -60,6 +60,7 @@ function createMockSession(overrides: Partial<SessionRow> = {}): SessionRow {
     code_server_enabled: 0,
     total_cost: 0,
     sandbox_settings: null,
+    environment_id: null,
     created_at: Date.now() - 60000,
     updated_at: Date.now(),
     ...overrides,

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -66,6 +66,8 @@ import { PullRequestCreationClaims, SessionPullRequestService } from "./pull-req
 import { findPrArtifactForRepo } from "./pr-artifacts";
 import { RepoSecretsStore } from "../db/repo-secrets";
 import { GlobalSecretsStore } from "../db/global-secrets";
+import { EnvironmentSecretsStore } from "../db/environment-secrets";
+import { EnvironmentStore } from "../db/environments";
 import {
   auditSecretsMerge,
   mergeSecretSources,
@@ -1687,6 +1689,23 @@ export class SessionDO extends DurableObject<Env> {
       }
     }
 
+    // Environment provenance: the id is stored on the session; the name is
+    // resolved live so a deleted environment surfaces as a null name (design
+    // §7.6) — the UI renders "environment deleted" in that case.
+    const environmentId = session?.environment_id ?? null;
+    let environmentName: string | null = null;
+    if (environmentId && this.env.DB) {
+      try {
+        const environment = await new EnvironmentStore(this.env.DB).getById(environmentId);
+        environmentName = environment?.name ?? null;
+      } catch (e) {
+        this.log.warn("Failed to resolve environment name for session state", {
+          environment_id: environmentId,
+          error: e instanceof Error ? e.message : String(e),
+        });
+      }
+    }
+
     return {
       id: this.getPublicSessionId(session),
       title: session?.title ?? null,
@@ -1710,6 +1729,8 @@ export class SessionDO extends DurableObject<Env> {
       ttydToken,
       sandboxDashboardUrl: this.getSandboxDashboardUrl(sandbox?.modal_object_id),
       repositories: this.getSessionRepositoryStates(session),
+      environmentId,
+      environmentName,
     };
   }
 
@@ -1823,11 +1844,14 @@ export class SessionDO extends DurableObject<Env> {
     const globalSecrets = await globalStore.getDecryptedSecrets();
 
     const repoStore = new RepoSecretsStore(this.env.DB, encryptionKey);
+    const environmentSecretsStore = new EnvironmentSecretsStore(this.env.DB, encryptionKey);
     const sources = await buildLaunchUnitSecretSources({
-      environmentId: null, // PR-9: session.environment_id
+      environmentId: session.environment_id,
       globalSecrets,
       members: this.repository.getSessionRepositories(),
       loadMemberSecrets: (member) => this.loadMemberRepoSecrets(session, member, repoStore),
+      loadEnvironmentSecrets: (environmentId) =>
+        environmentSecretsStore.getDecryptedSecrets(environmentId),
     });
 
     const merge = mergeSecretSources(sources);

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1690,21 +1690,10 @@ export class SessionDO extends DurableObject<Env> {
     }
 
     // Environment provenance: the id is stored on the session; the name is
-    // resolved live so a deleted environment surfaces as a null name (design
-    // §7.6) — the UI renders "environment deleted" in that case.
+    // resolved live (resolveEnvironmentName) so a deleted environment surfaces
+    // as null — the UI renders "environment deleted" (§7.6).
     const environmentId = session?.environment_id ?? null;
-    let environmentName: string | null = null;
-    if (environmentId && this.env.DB) {
-      try {
-        const environment = await new EnvironmentStore(this.env.DB).getById(environmentId);
-        environmentName = environment?.name ?? null;
-      } catch (e) {
-        this.log.warn("Failed to resolve environment name for session state", {
-          environment_id: environmentId,
-          error: e instanceof Error ? e.message : String(e),
-        });
-      }
-    }
+    const environmentName = await this.resolveEnvironmentName(environmentId);
 
     return {
       id: this.getPublicSessionId(session),
@@ -1732,6 +1721,28 @@ export class SessionDO extends DurableObject<Env> {
       environmentId,
       environmentName,
     };
+  }
+
+  /**
+   * The launch environment's current display name, or null when the session has
+   * no environment or the environment was deleted after launch (§7.6). Resolved
+   * live rather than snapshotted so deletion is reflected; best-effort, so a
+   * lookup failure resolves null rather than failing the whole state read.
+   */
+  private async resolveEnvironmentName(environmentId: string | null): Promise<string | null> {
+    if (!environmentId || !this.env.DB) {
+      return null;
+    }
+    try {
+      const environment = await new EnvironmentStore(this.env.DB).getById(environmentId);
+      return environment?.name ?? null;
+    } catch (e) {
+      this.log.warn("Failed to resolve environment name for session state", {
+        environment_id: environmentId,
+        error: e instanceof Error ? e.message : String(e),
+      });
+      return null;
+    }
   }
 
   /**

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
@@ -36,6 +36,7 @@ function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
     code_server_enabled: 0,
     total_cost: 0,
     sandbox_settings: null,
+    environment_id: null,
     created_at: 1000,
     updated_at: 2000,
     ...overrides,

--- a/packages/control-plane/src/session/http/handlers/pull-request.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/pull-request.handler.test.ts
@@ -43,6 +43,7 @@ function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
     code_server_enabled: 0,
     total_cost: 0,
     sandbox_settings: null,
+    environment_id: null,
     created_at: 1000,
     updated_at: 2000,
     ...overrides,

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
@@ -25,6 +25,7 @@ function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
     code_server_enabled: 0,
     total_cost: 0,
     sandbox_settings: null,
+    environment_id: null,
     created_at: 1000,
     updated_at: 2000,
     ...overrides,
@@ -244,6 +245,7 @@ describe("createSessionLifecycleHandler", () => {
       spawnDepth: 1,
       codeServerEnabled: false,
       sandboxSettings: null,
+      environmentId: null,
       createdAt: 1234,
       updatedAt: 1234,
     });

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
@@ -34,6 +34,8 @@ interface InitRequest {
    * one-entry list for scalar callers) and an empty list for repo-less ones.
    */
   repositories?: RepositoryRef[];
+  /** Launch environment provenance; null for repo-launched/ad-hoc sessions. */
+  environmentId?: string | null;
   title?: string;
   model?: string;
   reasoningEffort?: string;
@@ -196,6 +198,7 @@ export function createSessionLifecycleHandler(
         spawnDepth: body.spawnDepth ?? 0,
         codeServerEnabled: body.codeServerEnabled ?? false,
         sandboxSettings: body.sandboxSettings ? JSON.stringify(body.sandboxSettings) : null,
+        environmentId: body.environmentId ?? null,
         createdAt: now,
         updatedAt: now,
       });

--- a/packages/control-plane/src/session/initialize.ts
+++ b/packages/control-plane/src/session/initialize.ts
@@ -30,6 +30,12 @@ export interface SessionInitInput {
    * one-entry list is synthesized from the scalar fields.
    */
   repositories?: RepositoryRef[];
+  /**
+   * The environment this session was launched from (design §7.6). Null for
+   * repo-launched/ad-hoc sessions. Recorded as provenance; the members are
+   * already snapshotted into `repositories`.
+   */
+  environmentId?: string | null;
 
   // Session config
   title?: string;
@@ -128,6 +134,7 @@ export async function initializeSession(
     reasoningEffort: input.reasoningEffort,
     baseBranch,
     repositories,
+    environmentId: input.environmentId ?? null,
     status: "created",
     parentSessionId: input.parentSessionId,
     spawnSource: input.spawnSource,
@@ -164,6 +171,7 @@ export async function initializeSession(
           defaultBranch,
           branch,
           repositories,
+          environmentId: input.environmentId ?? null,
           title: input.title,
           model: input.model,
           reasoningEffort: input.reasoningEffort,

--- a/packages/control-plane/src/session/launch-unit-secrets.test.ts
+++ b/packages/control-plane/src/session/launch-unit-secrets.test.ts
@@ -11,6 +11,9 @@ function member(
   return { repoOwner, repoName, position, isPrimary, baseBranch: "main", row: null };
 }
 
+/** Repo-launched sessions never load environment secrets; a stub keeps that explicit. */
+const noEnvironmentSecrets = async (): Promise<Record<string, string>> => ({});
+
 describe("buildLaunchUnitSecretSources", () => {
   it("folds members lowest-precedence-first with the primary (position 0) last", async () => {
     const secretsByRepo: Record<string, Record<string, string>> = {
@@ -23,24 +26,40 @@ describe("buildLaunchUnitSecretSources", () => {
       globalSecrets: { G: "g" },
       members: [member("acme", "web", 0, true), member("acme", "backend", 1, false)],
       loadMemberSecrets: async (m) => secretsByRepo[`${m.repoOwner}/${m.repoName}`] ?? {},
+      loadEnvironmentSecrets: noEnvironmentSecrets,
     });
 
     // Primary (acme/web) is appended last so mergeSecretSources lets it win.
     expect(sources.map((s) => s.label)).toEqual(["global", "acme/backend", "acme/web"]);
   });
 
-  it("returns only global for an environment-launched session — member repos never inherit", async () => {
+  it("folds global + environment for an environment-launched session — member repos never inherit", async () => {
     const loadMemberSecrets = vi.fn();
 
     const sources = await buildLaunchUnitSecretSources({
-      environmentId: 42,
+      environmentId: "env_flagship",
       globalSecrets: { G: "g" },
       members: [member("acme", "web", 0, true)],
       loadMemberSecrets,
+      loadEnvironmentSecrets: async (id): Promise<Record<string, string>> =>
+        id === "env_flagship" ? { E: "env" } : {},
+    });
+
+    expect(sources.map((s) => s.label)).toEqual(["global", "environment"]);
+    // Member repo secrets are never sourced for an environment session.
+    expect(loadMemberSecrets).not.toHaveBeenCalled();
+  });
+
+  it("returns only global for an environment session with no environment secrets", async () => {
+    const sources = await buildLaunchUnitSecretSources({
+      environmentId: "env_empty",
+      globalSecrets: { G: "g" },
+      members: [member("acme", "web", 0, true)],
+      loadMemberSecrets: vi.fn(),
+      loadEnvironmentSecrets: noEnvironmentSecrets,
     });
 
     expect(sources.map((s) => s.label)).toEqual(["global"]);
-    expect(loadMemberSecrets).not.toHaveBeenCalled();
   });
 
   it("omits members that contribute no secrets", async () => {
@@ -50,6 +69,7 @@ describe("buildLaunchUnitSecretSources", () => {
       members: [member("acme", "web", 0, true), member("acme", "empty", 1, false)],
       loadMemberSecrets: async (m): Promise<Record<string, string>> =>
         m.repoName === "empty" ? {} : { A: "1" },
+      loadEnvironmentSecrets: noEnvironmentSecrets,
     });
 
     expect(sources.map((s) => s.label)).toEqual(["global", "acme/web"]);
@@ -61,6 +81,7 @@ describe("buildLaunchUnitSecretSources", () => {
       globalSecrets: { G: "g" },
       members: [],
       loadMemberSecrets: async () => ({}),
+      loadEnvironmentSecrets: noEnvironmentSecrets,
     });
 
     expect(sources).toEqual([{ label: "global", secrets: { G: "g" } }]);

--- a/packages/control-plane/src/session/launch-unit-secrets.ts
+++ b/packages/control-plane/src/session/launch-unit-secrets.ts
@@ -3,16 +3,23 @@ import type { SessionRepositoryEntry } from "./repository-target";
 
 export interface LaunchUnitSecretSourcesInput {
   /**
-   * The launch unit's environment id, or null for repo-launched sessions. PR-9
-   * passes `session.environment_id`; until migration 0033 adds the column this
-   * is always null and every session is repo-launched.
+   * The launch unit's environment id (`session.environment_id`), or null for
+   * repo-launched/ad-hoc sessions. When set, secrets come from global +
+   * environment only — the session's member repos never contribute (launch-unit
+   * scoping, §6.4/§7.4).
    */
-  environmentId: number | null;
+  environmentId: string | null;
   globalSecrets: Record<string, string>;
   /** Session member repositories in position order (index 0 = primary). */
   members: SessionRepositoryEntry[];
   /** Decrypt a member's secrets, or {} when it has no resolvable repo id. */
   loadMemberSecrets: (member: SessionRepositoryEntry) => Promise<Record<string, string>>;
+  /**
+   * Decrypt a launch environment's secrets. Called only for environment-launched
+   * sessions (when environmentId is set), so repo-launched sessions never touch
+   * the environment store.
+   */
+  loadEnvironmentSecrets: (environmentId: string) => Promise<Record<string, string>>;
 }
 
 /**
@@ -24,9 +31,7 @@ export interface LaunchUnitSecretSourcesInput {
  * it wins collisions. A single-repo session degenerates to today's global+repo.
  *
  * This owns the launch-unit sourcing policy so the DO only loads sources, merges
- * (mergeSecretSources), and audits the cap. The environment source is filled in
- * by PR-9 with the environment secrets store; until then environmentId is always
- * null and this is always the repo path.
+ * (mergeSecretSources), and audits the cap.
  */
 export async function buildLaunchUnitSecretSources(
   input: LaunchUnitSecretSourcesInput
@@ -34,7 +39,10 @@ export async function buildLaunchUnitSecretSources(
   const sources: SecretSource[] = [{ label: "global", secrets: input.globalSecrets }];
 
   if (input.environmentId !== null) {
-    // PR-9: sources.push({ label: "environment", secrets: <environment secrets> })
+    const environmentSecrets = await input.loadEnvironmentSecrets(input.environmentId);
+    if (Object.keys(environmentSecrets).length > 0) {
+      sources.push({ label: "environment", secrets: environmentSecrets });
+    }
     return sources;
   }
 

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -44,6 +44,7 @@ function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
     code_server_enabled: 0,
     total_cost: 0,
     sandbox_settings: null,
+    environment_id: null,
     created_at: 1000,
     updated_at: 1000,
     ...overrides,

--- a/packages/control-plane/src/session/openai-token-refresh-service.test.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.test.ts
@@ -8,6 +8,7 @@ import { OpenAITokenRefreshError } from "../auth/openai";
 const mockState = vi.hoisted(() => ({
   repoSecrets: new Map<number, Record<string, string>>(),
   globalSecrets: {} as Record<string, string>,
+  environmentSecrets: new Map<string, Record<string, string>>(),
   refreshImpl: vi.fn(),
   repoWrites: [] as Array<{
     repoId: number;
@@ -16,6 +17,7 @@ const mockState = vi.hoisted(() => ({
     secrets: Record<string, string>;
   }>,
   globalWrites: [] as Array<Record<string, string>>,
+  environmentWrites: [] as Array<{ environmentId: string; secrets: Record<string, string> }>,
 }));
 
 vi.mock("../auth/openai", () => {
@@ -68,6 +70,20 @@ vi.mock("../db/global-secrets", () => ({
   },
 }));
 
+vi.mock("../db/environment-secrets", () => ({
+  EnvironmentSecretsStore: class {
+    async getDecryptedSecrets(environmentId: string): Promise<Record<string, string>> {
+      return mockState.environmentSecrets.get(environmentId) ?? {};
+    }
+
+    async setSecrets(environmentId: string, secrets: Record<string, string>): Promise<void> {
+      mockState.environmentWrites.push({ environmentId, secrets });
+      const existing = mockState.environmentSecrets.get(environmentId) ?? {};
+      mockState.environmentSecrets.set(environmentId, { ...existing, ...secrets });
+    }
+  },
+}));
+
 function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
   return {
     id: "session-1",
@@ -90,6 +106,7 @@ function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
     code_server_enabled: 0,
     total_cost: 0,
     sandbox_settings: null,
+    environment_id: null,
     created_at: 1,
     updated_at: 1,
     ...overrides,
@@ -110,8 +127,10 @@ describe("OpenAITokenRefreshService", () => {
   beforeEach(() => {
     mockState.repoSecrets.clear();
     mockState.globalSecrets = {};
+    mockState.environmentSecrets.clear();
     mockState.repoWrites = [];
     mockState.globalWrites = [];
+    mockState.environmentWrites = [];
     mockState.refreshImpl.mockReset();
   });
 
@@ -237,5 +256,70 @@ describe("OpenAITokenRefreshService", () => {
       accountId: "acct_concurrent",
     });
     expect(mockState.refreshImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads and rotates environment secrets for an environment-launched session", async () => {
+    // Repo secrets exist but must be ignored — launch-unit scoping means an
+    // environment session sources tokens from the environment, never its members.
+    mockState.repoSecrets.set(123, {
+      OPENAI_OAUTH_REFRESH_TOKEN: "repo-refresh-should-be-ignored",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    });
+    mockState.environmentSecrets.set("env_flagship", {
+      OPENAI_OAUTH_REFRESH_TOKEN: "env-refresh-old",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",
+    });
+    mockState.refreshImpl.mockResolvedValue({
+      access_token: "env-access-new",
+      refresh_token: "env-refresh-new",
+      expires_in: 1800,
+      account_id: "acct_env",
+    });
+
+    const service = new OpenAITokenRefreshService(
+      {} as Env["DB"],
+      "enc-key",
+      async () => 123,
+      createLogger()
+    );
+
+    const result = await service.refresh(createSession({ environment_id: "env_flagship" }));
+
+    expect(result).toEqual({
+      ok: true,
+      accessToken: "env-access-new",
+      expiresIn: 1800,
+      accountId: "acct_env",
+    });
+    // Refreshed the environment's token, not the repo's.
+    expect(mockState.refreshImpl).toHaveBeenCalledWith("env-refresh-old");
+    // Rotated credentials persisted back to the environment, never the repo.
+    expect(mockState.repoWrites).toHaveLength(0);
+    expect(mockState.environmentWrites).toHaveLength(1);
+    expect(mockState.environmentWrites[0].environmentId).toBe("env_flagship");
+    expect(mockState.environmentWrites[0].secrets.OPENAI_OAUTH_REFRESH_TOKEN).toBe(
+      "env-refresh-new"
+    );
+  });
+
+  it("falls back to global for an environment session with no environment token", async () => {
+    mockState.globalSecrets = {
+      OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh",
+      OPENAI_OAUTH_ACCESS_TOKEN: "global-access",
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 15 * 60 * 1000),
+    };
+
+    const service = new OpenAITokenRefreshService(
+      {} as Env["DB"],
+      "enc-key",
+      async () => 123,
+      createLogger()
+    );
+
+    const result = await service.refresh(createSession({ environment_id: "env_flagship" }));
+
+    expect(result.ok).toBe(true);
+    expect(result).toMatchObject({ accessToken: "global-access" });
+    expect(mockState.refreshImpl).not.toHaveBeenCalled();
   });
 });

--- a/packages/control-plane/src/session/openai-token-refresh-service.test.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.test.ts
@@ -303,10 +303,11 @@ describe("OpenAITokenRefreshService", () => {
   });
 
   it("falls back to global for an environment session with no environment token", async () => {
+    const globalCachedTokenTtlMs = 15 * 60 * 1000;
     mockState.globalSecrets = {
       OPENAI_OAUTH_REFRESH_TOKEN: "global-refresh",
       OPENAI_OAUTH_ACCESS_TOKEN: "global-access",
-      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + 15 * 60 * 1000),
+      OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: String(Date.now() + globalCachedTokenTtlMs),
     };
 
     const service = new OpenAITokenRefreshService(

--- a/packages/control-plane/src/session/openai-token-refresh-service.test.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.test.ts
@@ -259,8 +259,8 @@ describe("OpenAITokenRefreshService", () => {
   });
 
   it("reads and rotates environment secrets for an environment-launched session", async () => {
-    // Repo secrets exist but must be ignored — launch-unit scoping means an
-    // environment session sources tokens from the environment, never its members.
+    // Repo secrets exist but must be ignored — an environment session sources
+    // tokens from the environment, never its members (§6.4/§7.4).
     mockState.repoSecrets.set(123, {
       OPENAI_OAUTH_REFRESH_TOKEN: "repo-refresh-should-be-ignored",
       OPENAI_OAUTH_ACCESS_TOKEN_EXPIRES_AT: "0",

--- a/packages/control-plane/src/session/openai-token-refresh-service.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.ts
@@ -14,11 +14,11 @@ const OPENAI_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 
 /**
  * Where a session's OpenAI OAuth tokens are read from and rotated back to. A
- * session checks its launch unit first — the environment for environment-
- * launched sessions, the repo for repo-launched ones (launch-unit scoping,
- * §6.4/§7.4) — then falls back to global. Each variant carries everything
- * needed to write the rotated tokens back to the same place, so refresh never
- * has to re-derive the identity (and the old repoId-null guard disappears).
+ * session reads from its own secret scope first — the environment for
+ * environment-launched sessions, the repo for repo-launched ones (§6.4/§7.4) —
+ * then falls back to global. Each variant carries everything needed to write
+ * the rotated tokens back to the same place, so refresh never has to re-derive
+ * the identity (and the old repoId-null guard disappears).
  */
 type TokenSecretSource =
   | { kind: "environment"; environmentId: string }
@@ -110,11 +110,11 @@ export class OpenAITokenRefreshService {
   }
 
   /**
-   * The session's launch-unit secret source, or null for repo-less sessions
-   * with no environment (global-only). Environment-launched sessions resolve to
-   * the environment and never read member repo secrets — launch-unit scoping.
+   * The session's own secret source, or null for repo-less sessions with no
+   * environment (global-only). Environment-launched sessions resolve to the
+   * environment and never read member repo secrets (§6.4/§7.4).
    */
-  private async resolveLaunchUnitSource(session: SessionRow): Promise<TokenSecretSource | null> {
+  private async resolveSessionSecretSource(session: SessionRow): Promise<TokenSecretSource | null> {
     if (session.environment_id) {
       return { kind: "environment", environmentId: session.environment_id };
     }
@@ -169,12 +169,12 @@ export class OpenAITokenRefreshService {
   }
 
   private async readTokenState(session: SessionRow): Promise<OpenAITokenState | null> {
-    const launchUnit = await this.resolveLaunchUnitSource(session);
-    if (launchUnit) {
-      const secrets = await this.readSecretsForSource(launchUnit);
-      const launchUnitState = this.getTokenStateFromSecrets(secrets, launchUnit);
-      if (launchUnitState) {
-        return launchUnitState;
+    const source = await this.resolveSessionSecretSource(session);
+    if (source) {
+      const secrets = await this.readSecretsForSource(source);
+      const state = this.getTokenStateFromSecrets(secrets, source);
+      if (state) {
+        return state;
       }
     }
 

--- a/packages/control-plane/src/session/openai-token-refresh-service.ts
+++ b/packages/control-plane/src/session/openai-token-refresh-service.ts
@@ -5,15 +5,29 @@ import {
 } from "../auth/openai";
 import { GlobalSecretsStore } from "../db/global-secrets";
 import { RepoSecretsStore } from "../db/repo-secrets";
+import { EnvironmentSecretsStore } from "../db/environment-secrets";
 import type { Env } from "../types";
 import type { Logger } from "../logger";
 import type { SessionRow } from "./types";
 
 const OPENAI_TOKEN_REFRESH_BUFFER_MS = 5 * 60 * 1000;
 
+/**
+ * Where a session's OpenAI OAuth tokens are read from and rotated back to. A
+ * session checks its launch unit first — the environment for environment-
+ * launched sessions, the repo for repo-launched ones (launch-unit scoping,
+ * §6.4/§7.4) — then falls back to global. Each variant carries everything
+ * needed to write the rotated tokens back to the same place, so refresh never
+ * has to re-derive the identity (and the old repoId-null guard disappears).
+ */
+type TokenSecretSource =
+  | { kind: "environment"; environmentId: string }
+  | { kind: "repo"; repoId: number; repoOwner: string; repoName: string }
+  | { kind: "global" };
+
 type OpenAITokenState =
   | { type: "cached"; accessToken: string; expiresIn: number; accountId?: string }
-  | { type: "refresh"; refreshToken: string; source: "repo" | "global"; repoId: number | null };
+  | { type: "refresh"; refreshToken: string; source: TokenSecretSource };
 
 export type OpenAITokenRefreshResult =
   | { ok: true; accessToken: string; expiresIn?: number; accountId?: string }
@@ -54,10 +68,10 @@ export class OpenAITokenRefreshService {
     }
 
     try {
-      return await this.attemptRefresh(tokenState, session);
+      return await this.attemptRefresh(tokenState);
     } catch (e) {
       if (e instanceof OpenAITokenRefreshError && e.status === 401) {
-        return this.handleUnauthorizedRefresh(tokenState, readTokenState, session);
+        return this.handleUnauthorizedRefresh(tokenState, readTokenState);
       }
 
       this.log.error("OpenAI token refresh failed", {
@@ -69,8 +83,7 @@ export class OpenAITokenRefreshService {
 
   private getTokenStateFromSecrets(
     secrets: Record<string, string>,
-    source: "repo" | "global",
-    repoId: number | null
+    source: TokenSecretSource
   ): OpenAITokenState | null {
     if (!secrets.OPENAI_OAUTH_REFRESH_TOKEN) {
       return null;
@@ -93,31 +106,84 @@ export class OpenAITokenRefreshService {
       type: "refresh",
       refreshToken: secrets.OPENAI_OAUTH_REFRESH_TOKEN,
       source,
-      repoId,
     };
   }
 
-  private async readTokenState(session: SessionRow): Promise<OpenAITokenState | null> {
-    let repoId: number | null = null;
+  /**
+   * The session's launch-unit secret source, or null for repo-less sessions
+   * with no environment (global-only). Environment-launched sessions resolve to
+   * the environment and never read member repo secrets — launch-unit scoping.
+   */
+  private async resolveLaunchUnitSource(session: SessionRow): Promise<TokenSecretSource | null> {
+    if (session.environment_id) {
+      return { kind: "environment", environmentId: session.environment_id };
+    }
     if (session.repo_owner && session.repo_name) {
-      repoId = await this.ensureRepoId(session);
+      const repoId = await this.ensureRepoId(session);
+      return {
+        kind: "repo",
+        repoId,
+        repoOwner: session.repo_owner,
+        repoName: session.repo_name,
+      };
+    }
+    return null;
+  }
 
-      const repoStore = new RepoSecretsStore(this.db, this.encryptionKey);
-      const repoSecrets = await repoStore.getDecryptedSecrets(repoId);
-      const repoState = this.getTokenStateFromSecrets(repoSecrets, "repo", repoId);
-      if (repoState) {
-        return repoState;
+  private async readSecretsForSource(source: TokenSecretSource): Promise<Record<string, string>> {
+    switch (source.kind) {
+      case "environment":
+        return new EnvironmentSecretsStore(this.db, this.encryptionKey).getDecryptedSecrets(
+          source.environmentId
+        );
+      case "repo":
+        return new RepoSecretsStore(this.db, this.encryptionKey).getDecryptedSecrets(source.repoId);
+      case "global":
+        return new GlobalSecretsStore(this.db, this.encryptionKey).getDecryptedSecrets();
+    }
+  }
+
+  private async writeSecretsForSource(
+    source: TokenSecretSource,
+    secrets: Record<string, string>
+  ): Promise<void> {
+    switch (source.kind) {
+      case "environment":
+        await new EnvironmentSecretsStore(this.db, this.encryptionKey).setSecrets(
+          source.environmentId,
+          secrets
+        );
+        return;
+      case "repo":
+        await new RepoSecretsStore(this.db, this.encryptionKey).setSecrets(
+          source.repoId,
+          source.repoOwner,
+          source.repoName,
+          secrets
+        );
+        return;
+      case "global":
+        await new GlobalSecretsStore(this.db, this.encryptionKey).setSecrets(secrets);
+        return;
+    }
+  }
+
+  private async readTokenState(session: SessionRow): Promise<OpenAITokenState | null> {
+    const launchUnit = await this.resolveLaunchUnitSource(session);
+    if (launchUnit) {
+      const secrets = await this.readSecretsForSource(launchUnit);
+      const launchUnitState = this.getTokenStateFromSecrets(secrets, launchUnit);
+      if (launchUnitState) {
+        return launchUnitState;
       }
     }
 
-    const globalStore = new GlobalSecretsStore(this.db, this.encryptionKey);
-    const globalSecrets = await globalStore.getDecryptedSecrets();
-    return this.getTokenStateFromSecrets(globalSecrets, "global", repoId);
+    const globalSecrets = await this.readSecretsForSource({ kind: "global" });
+    return this.getTokenStateFromSecrets(globalSecrets, { kind: "global" });
   }
 
   private async attemptRefresh(
-    tokenState: Extract<OpenAITokenState, { type: "refresh" }>,
-    session: SessionRow
+    tokenState: Extract<OpenAITokenState, { type: "refresh" }>
   ): Promise<OpenAITokenRefreshResult> {
     const tokens = await refreshOpenAIToken(tokenState.refreshToken);
     const accountId = extractOpenAIAccountId(tokens);
@@ -134,28 +200,10 @@ export class OpenAITokenRefreshService {
         secretsToWrite.OPENAI_OAUTH_ACCOUNT_ID = accountId;
       }
 
-      if (tokenState.source === "repo") {
-        if (tokenState.repoId === null || !session.repo_owner || !session.repo_name) {
-          return {
-            ok: false,
-            status: 400,
-            error: "Repository-scoped OpenAI tokens require a repository context",
-          };
-        }
-        const repoStore = new RepoSecretsStore(this.db, this.encryptionKey);
-        await repoStore.setSecrets(
-          tokenState.repoId,
-          session.repo_owner,
-          session.repo_name,
-          secretsToWrite
-        );
-      } else {
-        const globalStore = new GlobalSecretsStore(this.db, this.encryptionKey);
-        await globalStore.setSecrets(secretsToWrite);
-      }
+      await this.writeSecretsForSource(tokenState.source, secretsToWrite);
 
       this.log.info("OpenAI tokens rotated and cached", {
-        source: tokenState.source,
+        source: tokenState.source.kind,
         has_account_id: !!accountId,
       });
     } catch (e) {
@@ -174,11 +222,10 @@ export class OpenAITokenRefreshService {
 
   private async handleUnauthorizedRefresh(
     tokenState: Extract<OpenAITokenState, { type: "refresh" }>,
-    readTokenState: () => Promise<OpenAITokenState | null>,
-    session: SessionRow
+    readTokenState: () => Promise<OpenAITokenState | null>
   ): Promise<OpenAITokenRefreshResult> {
     this.log.warn("OpenAI refresh got 401, checking for concurrent rotation", {
-      source: tokenState.source,
+      source: tokenState.source.kind,
     });
 
     await new Promise((resolve) => setTimeout(resolve, 500));
@@ -198,7 +245,7 @@ export class OpenAITokenRefreshService {
 
       if (reread?.type === "refresh" && reread.refreshToken !== tokenState.refreshToken) {
         this.log.info("Detected concurrent token rotation, retrying");
-        return this.attemptRefresh(reread, session);
+        return this.attemptRefresh(reread);
       }
     } catch (retryErr) {
       this.log.error("Retry after 401 also failed", {

--- a/packages/control-plane/src/session/pull-request-service.test.ts
+++ b/packages/control-plane/src/session/pull-request-service.test.ts
@@ -46,6 +46,7 @@ function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
     code_server_enabled: 0,
     total_cost: 0,
     sandbox_settings: null,
+    environment_id: null,
     created_at: 1,
     updated_at: 1,
     ...overrides,

--- a/packages/control-plane/src/session/repository.test.ts
+++ b/packages/control-plane/src/session/repository.test.ts
@@ -121,6 +121,7 @@ describe("SessionRepository", () => {
         0,
         0,
         null,
+        null,
         1000,
         2000,
       ]);

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -78,6 +78,8 @@ export interface UpsertSessionData {
   spawnDepth?: number;
   codeServerEnabled?: boolean;
   sandboxSettings?: string | null;
+  /** Launch environment provenance; null for repo-launched/ad-hoc sessions. */
+  environmentId?: string | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -293,8 +295,8 @@ export class SessionRepository {
     }
 
     this.sql.exec(
-      `INSERT OR REPLACE INTO session (id, session_name, title, repo_owner, repo_name, repo_id, base_branch, model, reasoning_effort, status, parent_session_id, spawn_source, spawn_depth, code_server_enabled, sandbox_settings, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT OR REPLACE INTO session (id, session_name, title, repo_owner, repo_name, repo_id, base_branch, model, reasoning_effort, status, parent_session_id, spawn_source, spawn_depth, code_server_enabled, sandbox_settings, environment_id, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       data.id,
       data.sessionName,
       data.title,
@@ -310,6 +312,7 @@ export class SessionRepository {
       data.spawnDepth ?? 0,
       data.codeServerEnabled ? 1 : 0,
       data.sandboxSettings ?? null,
+      data.environmentId ?? null,
       data.createdAt,
       data.updatedAt
     );

--- a/packages/control-plane/src/session/schema.ts
+++ b/packages/control-plane/src/session/schema.ts
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS session (
   code_server_enabled INTEGER NOT NULL DEFAULT 0,   -- 0 = disabled, 1 = enabled (opt-in)
   total_cost REAL NOT NULL DEFAULT 0,              -- Running session cost from step_finish events
   sandbox_settings TEXT DEFAULT NULL,               -- JSON blob of SandboxSettings (resolved at session creation)
+  environment_id TEXT,                              -- Launch environment provenance; NULL for repo-launched/ad-hoc sessions
   created_at INTEGER NOT NULL,
   updated_at INTEGER NOT NULL,
   CHECK (
@@ -416,6 +417,11 @@ export const MIGRATIONS: readonly SchemaMigration[] = [
     id: 31,
     description: "Add session_repositories table for multi-repo sessions",
     run: SESSION_REPOSITORIES_TABLE_SQL,
+  },
+  {
+    id: 32,
+    description: "Add environment_id to session (launch environment provenance)",
+    run: `ALTER TABLE session ADD COLUMN environment_id TEXT`,
   },
 ];
 

--- a/packages/control-plane/src/session/types.ts
+++ b/packages/control-plane/src/session/types.ts
@@ -39,6 +39,7 @@ export interface SessionRow {
   code_server_enabled: number; // 0 = disabled (default), 1 = enabled
   total_cost: number; // Running aggregate of step_finish event costs
   sandbox_settings: string | null; // JSON blob of SandboxSettings
+  environment_id: string | null; // Launch environment provenance; NULL for repo-launched/ad-hoc sessions
   created_at: number;
   updated_at: number;
 }

--- a/packages/control-plane/test/integration/helpers.ts
+++ b/packages/control-plane/test/integration/helpers.ts
@@ -19,6 +19,7 @@ export async function initSession(overrides?: {
     repoId: number;
     baseBranch: string;
   }>;
+  environmentId?: string | null;
   title?: string;
   model?: string;
   reasoningEffort?: string;

--- a/packages/control-plane/test/integration/session-from-environment.test.ts
+++ b/packages/control-plane/test/integration/session-from-environment.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Sessions launched from an environment (PR-9, design §7.6): the environment's
+ * repositories are snapshotted into session_repositories and sessions.environment_id
+ * records provenance. Secrets follow launch-unit scoping — global + environment
+ * only, never the member repos' — and editing/deleting the environment afterwards
+ * never mutates the session (its name simply resolves null once deleted).
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { env, runInDurableObject } from "cloudflare:test";
+import type { SessionState } from "@open-inspect/shared";
+import type { SessionDO } from "../../src/session/durable-object";
+import { EnvironmentStore } from "../../src/db/environments";
+import { EnvironmentSecretsStore } from "../../src/db/environment-secrets";
+import { GlobalSecretsStore } from "../../src/db/global-secrets";
+import { RepoSecretsStore } from "../../src/db/repo-secrets";
+import { resolveEnvironmentTarget } from "../../src/repos/resolve";
+import { cleanD1Tables } from "./cleanup";
+import { initSession, queryDO } from "./helpers";
+
+const KEY = () => env.REPO_SECRETS_ENCRYPTION_KEY as string;
+
+interface RepoSpec {
+  repoOwner: string;
+  repoName: string;
+  repoId: number;
+  baseBranch: string;
+}
+
+async function seedEnvironment(id: string, name: string, repos: RepoSpec[]): Promise<void> {
+  const now = Date.now();
+  await new EnvironmentStore(env.DB).create(
+    { id, name, description: null, prebuild_enabled: 0, created_at: now, updated_at: now },
+    repos.map((repo, position) => ({
+      position,
+      repo_owner: repo.repoOwner,
+      repo_name: repo.repoName,
+      repo_id: repo.repoId,
+      base_branch: repo.baseBranch,
+    }))
+  );
+}
+
+/** Invoke the DO's real (private) getUserEnvVars, exercising the launch-unit fold. */
+function getUserEnvVars(stub: DurableObjectStub): Promise<Record<string, string> | undefined> {
+  return runInDurableObject(stub, (instance: SessionDO) =>
+    (
+      instance as unknown as {
+        getUserEnvVars(): Promise<Record<string, string> | undefined>;
+      }
+    ).getUserEnvVars()
+  );
+}
+
+/** Invoke the DO's real (private) getSessionState. */
+function getSessionState(stub: DurableObjectStub): Promise<SessionState> {
+  return runInDurableObject(stub, (instance: SessionDO) =>
+    (instance as unknown as { getSessionState(): Promise<SessionState> }).getSessionState()
+  );
+}
+
+const WEB: RepoSpec = { repoOwner: "acme", repoName: "web", repoId: 1, baseBranch: "main" };
+const API: RepoSpec = { repoOwner: "acme", repoName: "api", repoId: 2, baseBranch: "develop" };
+
+describe("sessions from environments", () => {
+  beforeEach(cleanD1Tables);
+
+  describe("resolveEnvironmentTarget", () => {
+    it("returns the environment's members as resolution inputs in position order", async () => {
+      await seedEnvironment("env_fs", "Full Stack", [WEB, API]);
+
+      const inputs = await resolveEnvironmentTarget(env.DB, "env_fs");
+
+      expect(inputs).toEqual([
+        { repoOwner: "acme", repoName: "web", baseBranch: "main" },
+        { repoOwner: "acme", repoName: "api", baseBranch: "develop" },
+      ]);
+    });
+
+    it("raises 404 for a missing environment", async () => {
+      await expect(resolveEnvironmentTarget(env.DB, "env_missing")).rejects.toMatchObject({
+        status: 404,
+      });
+    });
+  });
+
+  it("snapshots environment members and records provenance on the session", async () => {
+    await seedEnvironment("env_fs", "Full Stack", [WEB, API]);
+
+    const { stub } = await initSession({
+      environmentId: "env_fs",
+      repoOwner: WEB.repoOwner,
+      repoName: WEB.repoName,
+      repoId: WEB.repoId,
+      repositories: [WEB, API],
+    });
+
+    const [session] = await queryDO<{ environment_id: string | null }>(
+      stub,
+      "SELECT environment_id FROM session"
+    );
+    expect(session.environment_id).toBe("env_fs");
+
+    const members = await queryDO<{ repo_name: string }>(
+      stub,
+      "SELECT repo_name FROM session_repositories ORDER BY position"
+    );
+    expect(members.map((m) => m.repo_name)).toEqual(["web", "api"]);
+  });
+
+  it("exposes environmentId in state and resolves environmentName live", async () => {
+    await seedEnvironment("env_fs", "Full Stack", [WEB]);
+
+    const { stub } = await initSession({
+      environmentId: "env_fs",
+      repoOwner: WEB.repoOwner,
+      repoName: WEB.repoName,
+      repoId: WEB.repoId,
+      repositories: [WEB],
+    });
+
+    const state = await getSessionState(stub);
+    expect(state.environmentId).toBe("env_fs");
+    expect(state.environmentName).toBe("Full Stack");
+  });
+
+  it("leaves the session snapshot intact when the environment is deleted (name resolves null)", async () => {
+    await seedEnvironment("env_fs", "Full Stack", [WEB]);
+
+    const { stub } = await initSession({
+      environmentId: "env_fs",
+      repoOwner: WEB.repoOwner,
+      repoName: WEB.repoName,
+      repoId: WEB.repoId,
+      repositories: [WEB],
+    });
+
+    expect(await new EnvironmentStore(env.DB).delete("env_fs")).toBe(true);
+
+    const state = await getSessionState(stub);
+    // Provenance id survives; the name can no longer be resolved.
+    expect(state.environmentId).toBe("env_fs");
+    expect(state.environmentName).toBeNull();
+    // The snapshotted member list is untouched by the deletion.
+    const members = await queryDO<{ repo_name: string }>(
+      stub,
+      "SELECT repo_name FROM session_repositories"
+    );
+    expect(members.map((m) => m.repo_name)).toEqual(["web"]);
+  });
+
+  it("sources global + environment secrets only — member repo secrets never inherit", async () => {
+    await seedEnvironment("env_fs", "Full Stack", [WEB]);
+    await new GlobalSecretsStore(env.DB, KEY()).setSecrets({ SHARED: "global", ONLY_GLOBAL: "g" });
+    await new EnvironmentSecretsStore(env.DB, KEY()).setSecrets("env_fs", {
+      SHARED: "env",
+      ONLY_ENV: "e",
+    });
+    // The member repo has its own secrets that must NOT leak into an
+    // environment-launched session (launch-unit scoping, §6.4/§7.4).
+    await new RepoSecretsStore(env.DB, KEY()).setSecrets(WEB.repoId, "acme", "web", {
+      SHARED: "web",
+      ONLY_WEB: "w",
+    });
+
+    const { stub } = await initSession({
+      environmentId: "env_fs",
+      repoOwner: WEB.repoOwner,
+      repoName: WEB.repoName,
+      repoId: WEB.repoId,
+      repositories: [WEB],
+    });
+
+    const envVars = await getUserEnvVars(stub);
+
+    // Environment wins collisions over global; the member repo secret is absent.
+    expect(envVars).toMatchObject({ SHARED: "env", ONLY_GLOBAL: "g", ONLY_ENV: "e" });
+    expect(envVars).not.toHaveProperty("ONLY_WEB");
+  });
+});

--- a/packages/control-plane/test/integration/session-from-environment.test.ts
+++ b/packages/control-plane/test/integration/session-from-environment.test.ts
@@ -69,7 +69,7 @@ describe("sessions from environments", () => {
     it("returns the environment's members as resolution inputs in position order", async () => {
       await seedEnvironment("env_fs", "Full Stack", [WEB, API]);
 
-      const inputs = await resolveEnvironmentTarget(env.DB, "env_fs");
+      const inputs = await resolveEnvironmentTarget(new EnvironmentStore(env.DB), "env_fs");
 
       expect(inputs).toEqual([
         { repoOwner: "acme", repoName: "web", baseBranch: "main" },
@@ -78,7 +78,9 @@ describe("sessions from environments", () => {
     });
 
     it("raises 404 for a missing environment", async () => {
-      await expect(resolveEnvironmentTarget(env.DB, "env_missing")).rejects.toMatchObject({
+      await expect(
+        resolveEnvironmentTarget(new EnvironmentStore(env.DB), "env_missing")
+      ).rejects.toMatchObject({
         status: 404,
       });
     });

--- a/packages/control-plane/test/integration/session-from-environment.test.ts
+++ b/packages/control-plane/test/integration/session-from-environment.test.ts
@@ -1,9 +1,9 @@
 /**
  * Sessions launched from an environment (PR-9, design §7.6): the environment's
  * repositories are snapshotted into session_repositories and sessions.environment_id
- * records provenance. Secrets follow launch-unit scoping — global + environment
- * only, never the member repos' — and editing/deleting the environment afterwards
- * never mutates the session (its name simply resolves null once deleted).
+ * records provenance. Secrets come from global + environment only — never the
+ * member repos' — and editing/deleting the environment afterwards never mutates
+ * the session (its name simply resolves null once deleted).
  */
 
 import { describe, it, expect, beforeEach } from "vitest";
@@ -41,7 +41,7 @@ async function seedEnvironment(id: string, name: string, repos: RepoSpec[]): Pro
   );
 }
 
-/** Invoke the DO's real (private) getUserEnvVars, exercising the launch-unit fold. */
+/** Invoke the DO's real (private) getUserEnvVars, exercising the session secret fold. */
 function getUserEnvVars(stub: DurableObjectStub): Promise<Record<string, string> | undefined> {
   return runInDurableObject(stub, (instance: SessionDO) =>
     (
@@ -159,7 +159,7 @@ describe("sessions from environments", () => {
       ONLY_ENV: "e",
     });
     // The member repo has its own secrets that must NOT leak into an
-    // environment-launched session (launch-unit scoping, §6.4/§7.4).
+    // environment-launched session (§6.4/§7.4).
     await new RepoSecretsStore(env.DB, KEY()).setSecrets(WEB.repoId, "acme", "web", {
       SHARED: "web",
       ONLY_WEB: "w",

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -144,6 +144,12 @@ export interface Session {
    * session list index (SessionEntry.repositories).
    */
   repositories?: SessionListRepository[];
+  /**
+   * The environment this session was launched from (provenance), or null.
+   * Populated by the session list index (SessionEntry.environmentId); PR-12
+   * renders it.
+   */
+  environmentId?: string | null;
 }
 
 // Message in a session
@@ -440,6 +446,14 @@ export interface SessionState {
    * consumers default to [] / synthesize from repoOwner/repoName.
    */
   repositories?: SessionRepositoryState[];
+  /**
+   * The environment this session was launched from (provenance), or null for
+   * repo-launched/ad-hoc sessions. `environmentName` is resolved live and is
+   * null when the environment has since been deleted (design §7.6) — the UI
+   * renders "environment deleted" in that case.
+   */
+  environmentId?: string | null;
+  environmentName?: string | null;
 }
 
 // Participant presence info
@@ -623,6 +637,10 @@ const sessionStateSchema = z.object({
    * session; synthesize from repoOwner/repoName when rendering).
    */
   repositories: z.array(sessionRepositoryStateSchema).optional(),
+  // Environment provenance (design §7.6). environmentName resolves live —
+  // null when the environment was deleted after launch.
+  environmentId: z.string().nullable().optional(),
+  environmentName: z.string().nullable().optional(),
 });
 
 const participantPresenceSchema = z.object({
@@ -890,20 +908,32 @@ function hasRepositoryForBranch(data: CreateSessionRepositoryFields): boolean {
   return hasRepositoryIdentifier(data.repoOwner) || !data.branch?.trim();
 }
 
-function hasExclusiveRepositoryTarget(
-  data: CreateSessionRepositoryFields & { repositories?: unknown[] | null }
-): boolean {
-  // Presence-based, not length-based: any provided array selects the
-  // repository-list mode (sessionRepositoriesInputSchema separately rejects
-  // empty lists, so [] can never smuggle scalar fields through).
-  if (!data.repositories) {
-    return true;
-  }
+function hasScalarRepositoryTarget(data: CreateSessionRepositoryFields): boolean {
   return (
-    !hasRepositoryIdentifier(data.repoOwner) &&
-    !hasRepositoryIdentifier(data.repoName) &&
-    !data.branch?.trim()
+    hasRepositoryIdentifier(data.repoOwner) ||
+    hasRepositoryIdentifier(data.repoName) ||
+    Boolean(data.branch?.trim())
   );
+}
+
+function hasExclusiveSessionTarget(
+  data: CreateSessionRepositoryFields & {
+    repositories?: unknown[] | null;
+    environmentId?: string | null;
+  }
+): boolean {
+  // At most one target mode may be selected: a named environment
+  // (environmentId), an ad-hoc repository list (repositories), or the scalar
+  // repoOwner/repoName/branch form. Presence-based, not length-based: any
+  // provided array selects the list mode (sessionRepositoriesInputSchema
+  // separately rejects empty lists, so [] can never smuggle another mode
+  // through).
+  const activeModes = [
+    Boolean(data.repositories),
+    hasRepositoryIdentifier(data.environmentId),
+    hasScalarRepositoryTarget(data),
+  ].filter(Boolean).length;
+  return activeModes <= 1;
 }
 
 // API response types
@@ -916,9 +946,15 @@ const createSessionRequestBaseSchema = z.object({
   branch: z.string().optional(),
   /**
    * Ordered member list for multi-repo sessions ([0] = primary). Mutually
-   * exclusive with the scalar repoOwner/repoName/branch fields.
+   * exclusive with the scalar repoOwner/repoName/branch fields and environmentId.
    */
   repositories: sessionRepositoriesInputSchema.optional(),
+  /**
+   * Launch from a named environment: its snapshotted repositories become the
+   * session's members and sessions.environment_id records provenance (design
+   * §5.5/§7.6). Mutually exclusive with repositories and the scalar fields.
+   */
+  environmentId: z.string().trim().min(1).nullish(),
 });
 
 export const createSessionRequestSchema = createSessionRequestBaseSchema
@@ -930,8 +966,8 @@ export const createSessionRequestSchema = createSessionRequestBaseSchema
     message: "branch requires repoOwner and repoName",
     path: ["branch"],
   })
-  .refine(hasExclusiveRepositoryTarget, {
-    message: "repositories is mutually exclusive with repoOwner/repoName/branch",
+  .refine(hasExclusiveSessionTarget, {
+    message: "environmentId, repositories, and repoOwner/repoName/branch are mutually exclusive",
     path: ["repositories"],
   });
 
@@ -967,8 +1003,8 @@ export const createSessionInputSchema = createSessionRequestBaseSchema
     message: "branch requires repoOwner and repoName",
     path: ["branch"],
   })
-  .refine(hasExclusiveRepositoryTarget, {
-    message: "repositories is mutually exclusive with repoOwner/repoName/branch",
+  .refine(hasExclusiveSessionTarget, {
+    message: "environmentId, repositories, and repoOwner/repoName/branch are mutually exclusive",
     path: ["repositories"],
   });
 

--- a/packages/shared/src/types/repository-contracts.test.ts
+++ b/packages/shared/src/types/repository-contracts.test.ts
@@ -133,6 +133,42 @@ describe("createSessionRequestSchema repositories", () => {
   });
 });
 
+describe("createSessionRequestSchema environmentId (three-way exclusivity)", () => {
+  it("accepts an environmentId without any repository target", () => {
+    const result = createSessionRequestSchema.safeParse({ environmentId: "env_abc123" });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects environmentId combined with scalar repo fields", () => {
+    const result = createSessionRequestSchema.safeParse({
+      environmentId: "env_abc123",
+      repoOwner: "acme",
+      repoName: "app",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects environmentId combined with a scalar branch", () => {
+    const result = createSessionRequestSchema.safeParse({
+      environmentId: "env_abc123",
+      branch: "main",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects environmentId combined with a repositories list", () => {
+    const result = createSessionRequestSchema.safeParse({
+      environmentId: "env_abc123",
+      repositories: [{ repoOwner: "acme", repoName: "frontend" }],
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
 describe("push event schemas", () => {
   it("accepts legacy events without repo identity", () => {
     const result = sandboxEventSchema.safeParse({


### PR DESCRIPTION
## PR-9 · sessions from environments

Phase-2 continuation of the multi-repo-sessions plan (follows #915). Wires the environment entity (PR-8) into session creation, filling the null seams PR-6 (#909) left. **Additive; no D1 migration file change** — `0033` already added `sessions.environment_id`; the DO gets it via a new SQLite schema migration (id 32).

### What it does
- **Three-way exclusivity** (shared): `createSessionRequestSchema`/`createSessionInputSchema` accept `environmentId`, mutually exclusive with `repositories` and the scalar `repoOwner/repoName/branch`. Replaced `hasExclusiveRepositoryTarget` with a presence-counting `hasExclusiveSessionTarget` (at most one mode active).
- **Environment resolution**: new `resolveEnvironmentTarget(store, id)` loads the environment (404 if missing) and returns its members as resolution inputs in position order. The create handler feeds those through the **same** `resolveSessionRepositories` all-or-nothing SCM check an ad-hoc list gets — a member whose access was revoked after the environment was created fails the create cleanly rather than booting a partial workspace — and records `environment_id` provenance. Scalar/list paths are untouched (keeps scalar's `404` semantics off the hot single-repo path).
- **Provenance storage**: `environment_id` threaded through `initialize.ts` → D1 `sessions` INSERT + DO init → `session` table (migration 32, `SessionRow`, `upsertSession`). `SessionEntry.environmentId` hydrates on the session list (PR-12 renders it).
- **Environment-scoped secrets** (fills PR-6's seam): the secret-sourcing builder's environment branch now loads real environment secrets — **global + environment only; member repos never inherit** (§6.4/§7.4). Also fixed a placeholder `environmentId: number` → `string` (environment ids are strings).
- **Token-refresh environment source** (re-adds what #909 reverted, now with a real source): `OpenAITokenRefreshService` resolves a `TokenSecretSource` (environment | repo | global) carrying everything needed to read *and* write. Environment sessions rotate against environment secrets, never the repo. The union makes the old `repoId === null` guard unrepresentable, so it (and the `session` params it needed) are deleted.
- **`SessionState.environmentId` + live `environmentName`**: `getSessionState` resolves the name live so a deleted environment surfaces as `null` (§7.6 "environment deleted"), with the snapshot left intact.

### Tests
All green locally: shared 347 (+4 exclusivity), control-plane unit 1612, control-plane integration 488 (+6 new `session-from-environment.test.ts`: resolver order/404, member+provenance snapshot, live name + deleted→null, and the key **member-repo-secrets-absent** assertion), web 552; typecheck + lint + prettier clean.

### Deliberate deviations
- Named the new function `resolveEnvironmentTarget` rather than the design's unified `resolveSessionTarget`. Scalar/list normalization already lives inline in the handler, and a 3-mode resolver with a single active caller would be a thin wrapper; unifying scalar into the list path would change the single-repo `404`→`400` error. The genuinely reusable piece (env → member inputs) is what got extracted — a unified funnel can come with the Slack/Linear surface PRs that actually need it.
- `environmentName` is resolved via a per-`getSessionState` D1 lookup for environment sessions — intentional, since deleted-env-shows-null requires live resolution, not a snapshot.
- **Naming**: new code deliberately avoids the `LaunchUnit` term (the token-refresh source resolver is `resolveSessionSecretSource`). The pre-existing secret-sourcing builder from PR-6 keeps its name in this PR — renaming it (and its file/type) is a standalone follow-up so we don't fold a broad rename into this change.

### Not covered (consistent with PR-4/PR-8)
The full route happy path (`POST /sessions {environmentId}` → SCM resolve → create) isn't integration-tested because the control-plane integration harness has no `GITHUB_APP_*` bindings, so the SCM provider raises `GitHub App not configured` (→ 500) before the environment snapshot logic runs — a suite-wide limitation for **any** repo-resolving create path, not specific to this PR. Instead, environments are seeded via the store and the SCM-free pieces are exercised directly (resolver, DO storage/provenance, `getSessionState`, secret scoping). Live e2e remains owed on deployed infra.

**Follow-up (tracked):** make the create route testable without live SCM — inject a `SourceControlProvider` into `handleCreateSession` (the seam already exists on `resolveSessionRepositories`), or add fake App bindings + a mocked GitHub API to the harness — so the full `POST /sessions` path (scalar, list, and environment) can be covered end-to-end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions can now be created from an environment via a new `environmentId` option.
  * Session state now exposes `environmentId` and `environmentName`.
  * Environment-scoped secrets are used for sandbox launches and OpenAI token refreshes.
* **Bug Fixes**
  * Session environment provenance is persisted and returned consistently, including after environment deletion.
  * OpenAI token refresh now reads/writes secrets to the correct scope.
* **Tests**
  * Added/updated unit and integration coverage for environment-targeted session creation, state, secret scoping, and refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

