### PR TITLE
feat: environment image builds

### DIFF
--- a/packages/control-plane/src/db/environment-images.ts
+++ b/packages/control-plane/src/db/environment-images.ts
@@ -2,7 +2,7 @@ import { timingSafeEqual } from "@open-inspect/shared";
 import type {
   EnvironmentImageBuildStatus,
   EnvironmentImageCallbackBuild,
-  EnvironmentImageMemberSha,
+  EnvironmentImageRepositorySha,
   EnvironmentImageProvider,
   MarkEnvironmentImageReadyResult,
   SupersededEnvironmentImage,
@@ -26,7 +26,7 @@ export interface EnvironmentImageBuild {
   id: string;
   environmentId: string;
   provider: EnvironmentImageProvider;
-  membersFingerprint: string;
+  repositoriesFingerprint: string;
   callbackTokenHash?: string;
   callbackTokenExpiresAt?: number;
 }
@@ -36,8 +36,8 @@ export interface EnvironmentImage {
   environment_id: string;
   provider: EnvironmentImageProvider;
   provider_image_id: string | null;
-  members_fingerprint: string;
-  member_shas: string; // JSON EnvironmentImageMemberSha[]
+  repositories_fingerprint: string;
+  repository_shas: string; // JSON EnvironmentImageRepositorySha[]
   runtime_version: string;
   status: EnvironmentImageBuildStatus;
   build_duration_seconds: number | null;
@@ -80,8 +80,8 @@ export class EnvironmentImageStore {
            id,
            environment_id,
            provider,
-           members_fingerprint,
-           member_shas,
+           repositories_fingerprint,
+           repository_shas,
            runtime_version,
            status,
            callback_token_hash,
@@ -94,7 +94,7 @@ export class EnvironmentImageStore {
         build.id,
         build.environmentId,
         build.provider,
-        build.membersFingerprint,
+        build.repositoriesFingerprint,
         build.callbackTokenHash ?? null,
         build.callbackTokenExpiresAt ?? null,
         Date.now()
@@ -233,19 +233,19 @@ export class EnvironmentImageStore {
       .first<{ id: string }>();
   }
 
-  /** Save-hook short-circuit: a ready image already matches the current member set. */
+  /** Save-hook short-circuit: a ready image already matches the current repository set. */
   async hasReadyImageForFingerprint(
     environmentId: string,
     provider: EnvironmentImageProvider,
-    membersFingerprint: string
+    repositoriesFingerprint: string
   ): Promise<boolean> {
     const row = await this.db
       .prepare(
         `SELECT 1 AS present FROM environment_images
-         WHERE environment_id = ? AND provider = ? AND status = 'ready' AND members_fingerprint = ?
+         WHERE environment_id = ? AND provider = ? AND status = 'ready' AND repositories_fingerprint = ?
          LIMIT 1`
       )
-      .bind(environmentId, provider, membersFingerprint)
+      .bind(environmentId, provider, repositoriesFingerprint)
       .first<{ present: number }>();
     return row !== null;
   }
@@ -278,7 +278,7 @@ export class EnvironmentImageStore {
     buildId: string,
     provider: EnvironmentImageProvider,
     providerImageId: string,
-    memberShas: EnvironmentImageMemberSha[],
+    repositoryShas: EnvironmentImageRepositorySha[],
     runtimeVersion: string,
     buildDurationMs: number
   ): Promise<MarkEnvironmentImageReadyResult> {
@@ -300,7 +300,7 @@ export class EnvironmentImageStore {
     const updateResult = await this.db
       .prepare(
         `UPDATE environment_images
-         SET status = 'ready', provider_image_id = ?, member_shas = ?, runtime_version = ?, build_duration_seconds = ?
+         SET status = 'ready', provider_image_id = ?, repository_shas = ?, runtime_version = ?, build_duration_seconds = ?
          WHERE id = ? AND provider = ? AND status = 'building'
            AND NOT EXISTS (
              SELECT 1 FROM environment_images newer
@@ -315,7 +315,7 @@ export class EnvironmentImageStore {
       )
       .bind(
         providerImageId,
-        JSON.stringify(memberShas),
+        JSON.stringify(repositoryShas),
         runtimeVersion,
         buildDurationMs / MS_PER_SECOND,
         buildId,
@@ -335,7 +335,7 @@ export class EnvironmentImageStore {
           provider,
           providerImageId,
           providerSessionId: build.provider_session_id,
-          memberShas,
+          repositoryShas,
           runtimeVersion,
           buildDurationMs,
           environmentId: build.environment_id,
@@ -393,7 +393,7 @@ export class EnvironmentImageStore {
     provider: EnvironmentImageProvider;
     providerImageId: string;
     providerSessionId: string | null;
-    memberShas: EnvironmentImageMemberSha[];
+    repositoryShas: EnvironmentImageRepositorySha[];
     runtimeVersion: string;
     buildDurationMs: number;
     environmentId: string;
@@ -405,7 +405,7 @@ export class EnvironmentImageStore {
     const result = await this.db
       .prepare(
         `UPDATE environment_images
-         SET status = 'superseded', provider_image_id = ?, member_shas = ?, runtime_version = ?, build_duration_seconds = ?
+         SET status = 'superseded', provider_image_id = ?, repository_shas = ?, runtime_version = ?, build_duration_seconds = ?
          WHERE id = ? AND provider = ? AND status = 'building'
            AND EXISTS (
              SELECT 1 FROM environment_images newer
@@ -420,7 +420,7 @@ export class EnvironmentImageStore {
       )
       .bind(
         params.providerImageId,
-        JSON.stringify(params.memberShas),
+        JSON.stringify(params.repositoryShas),
         params.runtimeVersion,
         params.buildDurationMs / MS_PER_SECOND,
         params.buildId,

--- a/packages/control-plane/src/db/environment-images.ts
+++ b/packages/control-plane/src/db/environment-images.ts
@@ -447,6 +447,48 @@ export class EnvironmentImageStore {
     };
   }
 
+  /** Any-status row lookup for late-completion handling. */
+  async getBuildRow(buildId: string): Promise<{
+    id: string;
+    environment_id: string;
+    provider: EnvironmentImageProvider;
+    status: EnvironmentImageBuildStatus;
+  } | null> {
+    return this.db
+      .prepare("SELECT id, environment_id, provider, status FROM environment_images WHERE id = ?")
+      .bind(buildId)
+      .first<{
+        id: string;
+        environment_id: string;
+        provider: EnvironmentImageProvider;
+        status: EnvironmentImageBuildStatus;
+      }>();
+  }
+
+  /**
+   * Late completion for a build superseded out-of-band (environment delete,
+   * secret change) while it was in flight: the callback is rejected, but the
+   * provider artifact it reports already exists — record it on the superseded
+   * row so the reaper reclaims it instead of leaking it (Modal snapshots
+   * never expire). Only artifact-less superseded rows are written, so a
+   * ready row's artifact can never be clobbered by a replayed callback.
+   */
+  async recordArtifactOnSupersededBuild(
+    buildId: string,
+    provider: EnvironmentImageProvider,
+    providerImageId: string
+  ): Promise<boolean> {
+    const result = await this.db
+      .prepare(
+        `UPDATE environment_images SET provider_image_id = ?
+         WHERE id = ? AND provider = ? AND status = 'superseded' AND provider_image_id IS NULL`
+      )
+      .bind(providerImageId, buildId, provider)
+      .run();
+
+    return (result.meta?.changes ?? 0) > 0;
+  }
+
   async deleteSupersededImage(environmentImageId: string): Promise<boolean> {
     const result = await this.db
       .prepare("DELETE FROM environment_images WHERE id = ? AND status = 'superseded'")

--- a/packages/control-plane/src/db/environment-images.ts
+++ b/packages/control-plane/src/db/environment-images.ts
@@ -73,8 +73,16 @@ export interface SupersededEnvironmentImageRow {
 export class EnvironmentImageStore {
   constructor(private readonly db: D1Database) {}
 
-  async registerBuild(build: EnvironmentImageBuild): Promise<void> {
-    await this.db
+  /**
+   * Registers a build unless one is already in flight for the same
+   * (environment, provider). The NOT EXISTS guard is the authoritative
+   * concurrency-1 gate: it is atomic within the single INSERT statement, so
+   * concurrent triggers cannot both insert (the workflow's earlier
+   * getActiveBuild read is only a cheap short-circuit). Returns false when a
+   * building row already existed and nothing was inserted.
+   */
+  async registerBuild(build: EnvironmentImageBuild): Promise<boolean> {
+    const result = await this.db
       .prepare(
         `INSERT INTO environment_images (
            id,
@@ -88,7 +96,11 @@ export class EnvironmentImageStore {
            callback_token_expires_at,
            created_at
          )
-         VALUES (?, ?, ?, ?, '[]', '', 'building', ?, ?, ?)`
+         SELECT ?, ?, ?, ?, '[]', '', 'building', ?, ?, ?
+         WHERE NOT EXISTS (
+           SELECT 1 FROM environment_images
+           WHERE environment_id = ? AND provider = ? AND status = 'building'
+         )`
       )
       .bind(
         build.id,
@@ -97,9 +109,13 @@ export class EnvironmentImageStore {
         build.repositoriesFingerprint,
         build.callbackTokenHash ?? null,
         build.callbackTokenExpiresAt ?? null,
-        Date.now()
+        Date.now(),
+        build.environmentId,
+        build.provider
       )
       .run();
+
+    return (result.meta?.changes ?? 0) > 0;
   }
 
   async bindProviderSession(
@@ -542,10 +558,21 @@ export class EnvironmentImageStore {
     return result.results || [];
   }
 
-  async getAllStatus(): Promise<EnvironmentImage[]> {
+  /**
+   * Scheduler-facing status: every row the cron's rebuild checks read —
+   * ready and building rows of prebuild-enabled environments. Unbounded on
+   * purpose: the state machine caps live rows per (environment, provider) at
+   * one ready (mark-ready supersedes older readies) plus one building (the
+   * registerBuild guard), so a row cap would just reintroduce the risk of
+   * ready images dropping out of view and the cron re-triggering forever.
+   */
+  async getStatusForEnabledEnvironments(): Promise<EnvironmentImage[]> {
     const result = await this.db
       .prepare(
-        "SELECT * FROM environment_images WHERE status <> 'superseded' ORDER BY created_at DESC LIMIT 100"
+        `SELECT ei.* FROM environment_images ei
+         JOIN environments e ON e.id = ei.environment_id AND e.prebuild_enabled = 1
+         WHERE ei.status IN ('building', 'ready')
+         ORDER BY ei.created_at DESC`
       )
       .all<EnvironmentImage>();
 

--- a/packages/control-plane/src/db/environment-images.ts
+++ b/packages/control-plane/src/db/environment-images.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "@open-inspect/shared";
 import type {
   EnvironmentImageBuildStatus,
   EnvironmentImageCallbackBuild,
@@ -8,6 +9,18 @@ import type {
 } from "../environment-images/model";
 
 const MS_PER_SECOND = 1000;
+
+/** Row slice read by the callback-token auth checks. */
+interface CallbackTokenRow {
+  id: string;
+  environment_id: string;
+  provider: EnvironmentImageProvider;
+  provider_session_id: string | null;
+  status: EnvironmentImageBuildStatus;
+  callback_token_hash: string | null;
+  callback_token_expires_at: number | null;
+  callback_token_used_at: number | null;
+}
 
 export interface EnvironmentImageBuild {
   id: string;
@@ -87,6 +100,122 @@ export class EnvironmentImageStore {
         Date.now()
       )
       .run();
+  }
+
+  async bindProviderSession(
+    buildId: string,
+    provider: EnvironmentImageProvider,
+    providerSessionId: string
+  ): Promise<boolean> {
+    const result = await this.db
+      .prepare(
+        "UPDATE environment_images SET provider_session_id = ? WHERE id = ? AND provider = ? AND status = 'building'"
+      )
+      .bind(providerSessionId, buildId, provider)
+      .run();
+
+    return (result.meta?.changes ?? 0) > 0;
+  }
+
+  async consumeCallbackToken(params: {
+    buildId: string;
+    provider: EnvironmentImageProvider;
+    tokenHash: string;
+    providerSessionId: string;
+    now: number;
+  }): Promise<EnvironmentImageCallbackBuild | null> {
+    const build = await this.readCallbackTokenRow(params.buildId, params.provider);
+    if (!this.callbackTokenRowIsUsable(build, params)) return null;
+
+    const result = await this.db
+      .prepare(
+        `UPDATE environment_images SET callback_token_used_at = ?
+         WHERE id = ? AND provider = ? AND provider_session_id = ? AND status = 'building'
+           AND callback_token_hash = ?
+           AND callback_token_expires_at >= ?
+           AND callback_token_used_at IS NULL`
+      )
+      .bind(
+        params.now,
+        params.buildId,
+        params.provider,
+        params.providerSessionId,
+        params.tokenHash,
+        params.now
+      )
+      .run();
+
+    if ((result.meta?.changes ?? 0) === 0) return null;
+
+    return {
+      id: build.id,
+      environmentId: build.environment_id,
+      provider: build.provider,
+      providerSessionId: build.provider_session_id,
+      status: build.status,
+    };
+  }
+
+  async markBuildFailedWithCallbackToken(params: {
+    buildId: string;
+    provider: EnvironmentImageProvider;
+    tokenHash: string;
+    providerSessionId: string;
+    error: string;
+    now: number;
+  }): Promise<boolean> {
+    const build = await this.readCallbackTokenRow(params.buildId, params.provider);
+    if (!this.callbackTokenRowIsUsable(build, params)) return false;
+
+    const result = await this.db
+      .prepare(
+        `UPDATE environment_images
+         SET status = 'failed', error_message = ?, callback_token_used_at = ?
+         WHERE id = ? AND provider = ? AND provider_session_id = ? AND status = 'building'
+           AND callback_token_hash = ?
+           AND callback_token_expires_at >= ?
+           AND callback_token_used_at IS NULL`
+      )
+      .bind(
+        params.error,
+        params.now,
+        params.buildId,
+        params.provider,
+        params.providerSessionId,
+        params.tokenHash,
+        params.now
+      )
+      .run();
+
+    return (result.meta?.changes ?? 0) > 0;
+  }
+
+  private async readCallbackTokenRow(
+    buildId: string,
+    provider: EnvironmentImageProvider
+  ): Promise<CallbackTokenRow | null> {
+    return this.db
+      .prepare(
+        `SELECT id, environment_id, provider, provider_session_id, status,
+                callback_token_hash, callback_token_expires_at, callback_token_used_at
+         FROM environment_images WHERE id = ? AND provider = ?`
+      )
+      .bind(buildId, provider)
+      .first<CallbackTokenRow>();
+  }
+
+  /** Timing-safe, single-use, unexpired token bound to the build's provider session. */
+  private callbackTokenRowIsUsable(
+    build: CallbackTokenRow | null,
+    params: { tokenHash: string; providerSessionId: string; now: number }
+  ): build is CallbackTokenRow {
+    if (!build || build.status !== "building") return false;
+    if (!build.callback_token_hash || !build.callback_token_expires_at) return false;
+    if (build.callback_token_used_at !== null) return false;
+    if (build.callback_token_expires_at < params.now) return false;
+    if (!timingSafeEqual(build.callback_token_hash, params.tokenHash)) return false;
+    if (build.provider_session_id !== params.providerSessionId) return false;
+    return true;
   }
 
   /** The per-environment concurrency guard: at most one in-flight build (design §7.3). */

--- a/packages/control-plane/src/db/environment-images.ts
+++ b/packages/control-plane/src/db/environment-images.ts
@@ -1,0 +1,424 @@
+import type {
+  EnvironmentImageBuildStatus,
+  EnvironmentImageCallbackBuild,
+  EnvironmentImageMemberSha,
+  EnvironmentImageProvider,
+  MarkEnvironmentImageReadyResult,
+  SupersededEnvironmentImage,
+} from "../environment-images/model";
+
+const MS_PER_SECOND = 1000;
+
+export interface EnvironmentImageBuild {
+  id: string;
+  environmentId: string;
+  provider: EnvironmentImageProvider;
+  membersFingerprint: string;
+  callbackTokenHash?: string;
+  callbackTokenExpiresAt?: number;
+}
+
+export interface EnvironmentImage {
+  id: string;
+  environment_id: string;
+  provider: EnvironmentImageProvider;
+  provider_image_id: string | null;
+  members_fingerprint: string;
+  member_shas: string; // JSON EnvironmentImageMemberSha[]
+  runtime_version: string;
+  status: EnvironmentImageBuildStatus;
+  build_duration_seconds: number | null;
+  error_message: string | null;
+  provider_session_id: string | null;
+  callback_token_hash: string | null;
+  callback_token_expires_at: number | null;
+  callback_token_used_at: number | null;
+  created_at: number;
+}
+
+/** Superseded row carrying its provider artifact (if any) for the reaper. */
+export interface SupersededEnvironmentImageRow {
+  id: string;
+  environment_id: string;
+  provider: EnvironmentImageProvider;
+  provider_image_id: string | null;
+  provider_session_id: string | null;
+}
+
+/**
+ * D1-backed environment image registry and state machine.
+ *
+ * Mirrors RepoImageStore semantics (conditional updates so duplicate
+ * callbacks and newer-build races need no provider-specific branching), with
+ * two differences owed to the environment model: the supersede scope is
+ * (environment_id, provider) — the fingerprint covers branches, so there is
+ * no branch dimension and at most one live image per environment/provider —
+ * and rows can be superseded out-of-band (environment delete, secret change),
+ * so a reaper query exposes superseded artifacts for cleanup instead of
+ * relying solely on inline deletion at mark-ready time.
+ */
+export class EnvironmentImageStore {
+  constructor(private readonly db: D1Database) {}
+
+  async registerBuild(build: EnvironmentImageBuild): Promise<void> {
+    await this.db
+      .prepare(
+        `INSERT INTO environment_images (
+           id,
+           environment_id,
+           provider,
+           members_fingerprint,
+           member_shas,
+           runtime_version,
+           status,
+           callback_token_hash,
+           callback_token_expires_at,
+           created_at
+         )
+         VALUES (?, ?, ?, ?, '[]', '', 'building', ?, ?, ?)`
+      )
+      .bind(
+        build.id,
+        build.environmentId,
+        build.provider,
+        build.membersFingerprint,
+        build.callbackTokenHash ?? null,
+        build.callbackTokenExpiresAt ?? null,
+        Date.now()
+      )
+      .run();
+  }
+
+  /** The per-environment concurrency guard: at most one in-flight build (design §7.3). */
+  async getActiveBuild(
+    environmentId: string,
+    provider: EnvironmentImageProvider
+  ): Promise<{ id: string } | null> {
+    return this.db
+      .prepare(
+        `SELECT id FROM environment_images
+         WHERE environment_id = ? AND provider = ? AND status = 'building'
+         ORDER BY created_at DESC LIMIT 1`
+      )
+      .bind(environmentId, provider)
+      .first<{ id: string }>();
+  }
+
+  /** Save-hook short-circuit: a ready image already matches the current member set. */
+  async hasReadyImageForFingerprint(
+    environmentId: string,
+    provider: EnvironmentImageProvider,
+    membersFingerprint: string
+  ): Promise<boolean> {
+    const row = await this.db
+      .prepare(
+        `SELECT 1 AS present FROM environment_images
+         WHERE environment_id = ? AND provider = ? AND status = 'ready' AND members_fingerprint = ?
+         LIMIT 1`
+      )
+      .bind(environmentId, provider, membersFingerprint)
+      .first<{ present: number }>();
+    return row !== null;
+  }
+
+  async getCallbackBuild(buildId: string): Promise<EnvironmentImageCallbackBuild | null> {
+    const build = await this.db
+      .prepare(
+        "SELECT id, environment_id, provider, provider_session_id, status FROM environment_images WHERE id = ?"
+      )
+      .bind(buildId)
+      .first<{
+        id: string;
+        environment_id: string;
+        provider: EnvironmentImageProvider;
+        provider_session_id: string | null;
+        status: EnvironmentImageBuildStatus;
+      }>();
+
+    if (!build || build.status !== "building") return null;
+    return {
+      id: build.id,
+      environmentId: build.environment_id,
+      provider: build.provider,
+      providerSessionId: build.provider_session_id,
+      status: build.status,
+    };
+  }
+
+  async tryMarkEnvironmentImageReady(
+    buildId: string,
+    provider: EnvironmentImageProvider,
+    providerImageId: string,
+    memberShas: EnvironmentImageMemberSha[],
+    runtimeVersion: string,
+    buildDurationMs: number
+  ): Promise<MarkEnvironmentImageReadyResult> {
+    const build = await this.db
+      .prepare(
+        "SELECT environment_id, provider_session_id, created_at FROM environment_images WHERE id = ? AND provider = ? AND status = 'building'"
+      )
+      .bind(buildId, provider)
+      .first<{
+        environment_id: string;
+        provider_session_id: string | null;
+        created_at: number;
+      }>();
+
+    if (!build) {
+      return { type: "not_accepting_completion" };
+    }
+
+    const updateResult = await this.db
+      .prepare(
+        `UPDATE environment_images
+         SET status = 'ready', provider_image_id = ?, member_shas = ?, runtime_version = ?, build_duration_seconds = ?
+         WHERE id = ? AND provider = ? AND status = 'building'
+           AND NOT EXISTS (
+             SELECT 1 FROM environment_images newer
+             WHERE newer.environment_id = ?
+               AND newer.provider = ?
+               AND newer.status = 'ready'
+               AND (
+                 newer.created_at > ?
+                 OR (newer.created_at = ? AND newer.id > ?)
+               )
+           )`
+      )
+      .bind(
+        providerImageId,
+        JSON.stringify(memberShas),
+        runtimeVersion,
+        buildDurationMs / MS_PER_SECOND,
+        buildId,
+        provider,
+        build.environment_id,
+        provider,
+        build.created_at,
+        build.created_at,
+        buildId
+      )
+      .run();
+
+    if ((updateResult.meta?.changes ?? 0) === 0) {
+      return (
+        (await this.tryMarkBuildingBuildSuperseded({
+          buildId,
+          provider,
+          providerImageId,
+          providerSessionId: build.provider_session_id,
+          memberShas,
+          runtimeVersion,
+          buildDurationMs,
+          environmentId: build.environment_id,
+          createdAt: build.created_at,
+        })) ?? { type: "not_accepting_completion" }
+      );
+    }
+
+    const superseded = await this.db
+      .prepare(
+        `SELECT id, provider_image_id, provider_session_id FROM environment_images
+         WHERE environment_id = ?
+           AND provider = ?
+           AND status = 'ready'
+           AND id <> ?
+           AND (
+             created_at < ?
+             OR (created_at = ? AND id < ?)
+           )
+         ORDER BY created_at DESC, id DESC`
+      )
+      .bind(build.environment_id, provider, buildId, build.created_at, build.created_at, buildId)
+      .all<{ id: string; provider_image_id: string | null; provider_session_id: string | null }>();
+
+    const supersededImages: SupersededEnvironmentImage[] = (superseded.results || []).map(
+      (image) => ({
+        environmentImageId: image.id,
+        image: {
+          providerImageId: image.provider_image_id ?? "",
+          providerSessionId: image.provider_session_id,
+        },
+      })
+    );
+
+    if (superseded.results?.length) {
+      await this.db.batch(
+        superseded.results.map((image) =>
+          this.db
+            .prepare(
+              "UPDATE environment_images SET status = 'superseded' WHERE id = ? AND status = 'ready'"
+            )
+            .bind(image.id)
+        )
+      );
+    }
+
+    return {
+      type: "marked_ready",
+      supersededImages,
+    };
+  }
+
+  private async tryMarkBuildingBuildSuperseded(params: {
+    buildId: string;
+    provider: EnvironmentImageProvider;
+    providerImageId: string;
+    providerSessionId: string | null;
+    memberShas: EnvironmentImageMemberSha[];
+    runtimeVersion: string;
+    buildDurationMs: number;
+    environmentId: string;
+    createdAt: number;
+  }): Promise<Extract<
+    MarkEnvironmentImageReadyResult,
+    { type: "superseded_by_newer_ready" }
+  > | null> {
+    const result = await this.db
+      .prepare(
+        `UPDATE environment_images
+         SET status = 'superseded', provider_image_id = ?, member_shas = ?, runtime_version = ?, build_duration_seconds = ?
+         WHERE id = ? AND provider = ? AND status = 'building'
+           AND EXISTS (
+             SELECT 1 FROM environment_images newer
+             WHERE newer.environment_id = ?
+               AND newer.provider = ?
+               AND newer.status = 'ready'
+               AND (
+                 newer.created_at > ?
+                 OR (newer.created_at = ? AND newer.id > ?)
+               )
+           )`
+      )
+      .bind(
+        params.providerImageId,
+        JSON.stringify(params.memberShas),
+        params.runtimeVersion,
+        params.buildDurationMs / MS_PER_SECOND,
+        params.buildId,
+        params.provider,
+        params.environmentId,
+        params.provider,
+        params.createdAt,
+        params.createdAt,
+        params.buildId
+      )
+      .run();
+
+    if ((result.meta?.changes ?? 0) === 0) return null;
+
+    return {
+      type: "superseded_by_newer_ready",
+      supersededImage: {
+        environmentImageId: params.buildId,
+        image: {
+          providerImageId: params.providerImageId,
+          providerSessionId: params.providerSessionId,
+        },
+      },
+    };
+  }
+
+  async deleteSupersededImage(environmentImageId: string): Promise<boolean> {
+    const result = await this.db
+      .prepare("DELETE FROM environment_images WHERE id = ? AND status = 'superseded'")
+      .bind(environmentImageId)
+      .run();
+
+    return (result.meta?.changes ?? 0) > 0;
+  }
+
+  async markBuildFailed(
+    buildId: string,
+    provider: EnvironmentImageProvider,
+    error: string
+  ): Promise<boolean> {
+    const result = await this.db
+      .prepare(
+        "UPDATE environment_images SET status = 'failed', error_message = ? WHERE id = ? AND provider = ? AND status = 'building'"
+      )
+      .bind(error, buildId, provider)
+      .run();
+
+    return (result.meta?.changes ?? 0) > 0;
+  }
+
+  /**
+   * Secret-change invalidation (design §7.4): flip every live image —
+   * including in-flight builds, which are baking the outdated values — to
+   * superseded. The status flip is the load-bearing part and happens in the
+   * save-hook; provider artifacts are reclaimed later by the reaper.
+   */
+  async supersedeActiveImages(environmentId: string): Promise<number> {
+    const result = await this.db
+      .prepare(
+        `UPDATE environment_images SET status = 'superseded'
+         WHERE environment_id = ? AND status IN ('building', 'ready')`
+      )
+      .bind(environmentId)
+      .run();
+
+    return result.meta?.changes ?? 0;
+  }
+
+  async getStatus(environmentId: string): Promise<EnvironmentImage[]> {
+    const result = await this.db
+      .prepare(
+        "SELECT * FROM environment_images WHERE environment_id = ? AND status <> 'superseded' ORDER BY created_at DESC LIMIT 10"
+      )
+      .bind(environmentId)
+      .all<EnvironmentImage>();
+
+    return result.results || [];
+  }
+
+  async getAllStatus(): Promise<EnvironmentImage[]> {
+    const result = await this.db
+      .prepare(
+        "SELECT * FROM environment_images WHERE status <> 'superseded' ORDER BY created_at DESC LIMIT 100"
+      )
+      .all<EnvironmentImage>();
+
+    return result.results || [];
+  }
+
+  /**
+   * Superseded rows for the cleanup reaper. Unlike repo images — whose
+   * superseded rows are deleted inline right after artifact deletion at
+   * mark-ready time — environment images are also superseded out-of-band
+   * (environment delete, secret change), so cleanup sweeps whatever is left.
+   */
+  async getSupersededImages(limit: number): Promise<SupersededEnvironmentImageRow[]> {
+    const result = await this.db
+      .prepare(
+        `SELECT id, environment_id, provider, provider_image_id, provider_session_id
+         FROM environment_images WHERE status = 'superseded'
+         ORDER BY created_at ASC LIMIT ?`
+      )
+      .bind(limit)
+      .all<SupersededEnvironmentImageRow>();
+
+    return result.results || [];
+  }
+
+  async markStaleBuildsAsFailed(maxAgeMs: number): Promise<number> {
+    const cutoff = Date.now() - maxAgeMs;
+    const result = await this.db
+      .prepare(
+        "UPDATE environment_images SET status = 'failed', error_message = ? WHERE status = 'building' AND created_at < ?"
+      )
+      .bind("build timed out (no callback received)", cutoff)
+      .run();
+
+    return result.meta?.changes ?? 0;
+  }
+
+  async deleteOldFailedBuilds(maxAgeMs: number): Promise<number> {
+    const cutoff = Date.now() - maxAgeMs;
+    const result = await this.db
+      .prepare("DELETE FROM environment_images WHERE status = 'failed' AND created_at < ?")
+      .bind(cutoff)
+      .run();
+
+    return result.meta?.changes ?? 0;
+  }
+}

--- a/packages/control-plane/src/environment-images/errors.ts
+++ b/packages/control-plane/src/environment-images/errors.ts
@@ -1,0 +1,97 @@
+/**
+ * Environment image build errors — mirrors the repo-image taxonomy
+ * (repo-images/errors.ts) with the environment-specific 404 in place of
+ * repository_not_installed. Kept parallel rather than shared so this PR does
+ * not reshape the merged repo-images module; folding both into one image-build
+ * taxonomy belongs to the tracked build-subsystem unification refactor.
+ */
+
+export type EnvironmentImageErrorCode =
+  | "environment_not_found"
+  | "planning_failed"
+  | "workflow_unavailable"
+  | "provider_unconfigured"
+  | "trigger_failed"
+  | "invalid_callback"
+  | "callback_auth_rejected"
+  | "callback_auth_unavailable"
+  | "completion_not_accepted"
+  | "failure_not_accepted"
+  | "build_complete_failed"
+  | "build_failed_update_failed";
+
+export abstract class EnvironmentImageError extends Error {
+  abstract readonly code: EnvironmentImageErrorCode;
+
+  constructor(message: string, cause?: unknown) {
+    super(message, cause === undefined ? undefined : { cause });
+    this.name = new.target.name;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, new.target);
+    }
+  }
+}
+
+export class EnvironmentImageEnvironmentNotFoundError extends EnvironmentImageError {
+  readonly code = "environment_not_found";
+
+  constructor(environmentId: string) {
+    super(`Environment not found: ${environmentId}`);
+  }
+}
+
+export class EnvironmentImagePlanningError extends EnvironmentImageError {
+  readonly code = "planning_failed";
+}
+
+export class EnvironmentImageWorkflowUnavailableError extends EnvironmentImageError {
+  readonly code = "workflow_unavailable";
+}
+
+export class EnvironmentImageProviderUnconfiguredError extends EnvironmentImageError {
+  readonly code = "provider_unconfigured";
+}
+
+export class EnvironmentImageTriggerFailedError extends EnvironmentImageError {
+  readonly code = "trigger_failed";
+
+  constructor(message = "Failed to trigger build", cause?: unknown) {
+    super(message, cause);
+  }
+}
+
+export class EnvironmentImageInvalidCallbackError extends EnvironmentImageError {
+  readonly code = "invalid_callback";
+}
+
+export class EnvironmentImageCallbackAuthRejectedError extends EnvironmentImageError {
+  readonly code = "callback_auth_rejected";
+}
+
+export class EnvironmentImageCallbackAuthUnavailableError extends EnvironmentImageError {
+  readonly code = "callback_auth_unavailable";
+}
+
+export class EnvironmentImageCompletionNotAcceptedError extends EnvironmentImageError {
+  readonly code = "completion_not_accepted";
+}
+
+export class EnvironmentImageFailureNotAcceptedError extends EnvironmentImageError {
+  readonly code = "failure_not_accepted";
+}
+
+export class EnvironmentImageBuildCompleteFailedError extends EnvironmentImageError {
+  readonly code = "build_complete_failed";
+
+  constructor(message = "Failed to mark build as ready", cause?: unknown) {
+    super(message, cause);
+  }
+}
+
+export class EnvironmentImageBuildFailedUpdateError extends EnvironmentImageError {
+  readonly code = "build_failed_update_failed";
+
+  constructor(message = "Failed to mark build as failed", cause?: unknown) {
+    super(message, cause);
+  }
+}

--- a/packages/control-plane/src/environment-images/fingerprint.test.ts
+++ b/packages/control-plane/src/environment-images/fingerprint.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { computeMembersFingerprint } from "./fingerprint";
+import { MIN_COMPATIBLE_RUNTIME_VERSION, parseRuntimeVersionNumber } from "./model";
+
+const members = [
+  { repoOwner: "Acme", repoName: "Web", baseBranch: "main" },
+  { repoOwner: "acme", repoName: "api", baseBranch: "develop" },
+];
+
+describe("computeMembersFingerprint", () => {
+  it("is deterministic", async () => {
+    const first = await computeMembersFingerprint(members);
+    const second = await computeMembersFingerprint(members);
+    expect(first).toBe(second);
+    expect(first).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("is case-insensitive on owner/name", async () => {
+    const upper = await computeMembersFingerprint(members);
+    const lower = await computeMembersFingerprint(
+      members.map((m) => ({
+        ...m,
+        repoOwner: m.repoOwner.toLowerCase(),
+        repoName: m.repoName.toLowerCase(),
+      }))
+    );
+    expect(upper).toBe(lower);
+  });
+
+  it("is case-sensitive on branch names (git refs are)", async () => {
+    const main = await computeMembersFingerprint(members);
+    const casedBranch = await computeMembersFingerprint([
+      { ...members[0], baseBranch: "Main" },
+      members[1],
+    ]);
+    expect(main).not.toBe(casedBranch);
+  });
+
+  it("is order-sensitive (members are position-ordered)", async () => {
+    const forward = await computeMembersFingerprint(members);
+    const reversed = await computeMembersFingerprint([...members].reverse());
+    expect(forward).not.toBe(reversed);
+  });
+
+  it("changes when the member set changes", async () => {
+    const two = await computeMembersFingerprint(members);
+    const one = await computeMembersFingerprint(members.slice(0, 1));
+    expect(two).not.toBe(one);
+  });
+});
+
+describe("parseRuntimeVersionNumber", () => {
+  it("parses the numeric prefix of a SANDBOX_VERSION", () => {
+    expect(parseRuntimeVersionNumber("v53-list-native-runtime")).toBe(53);
+    expect(parseRuntimeVersionNumber("v7")).toBe(7);
+  });
+
+  it("returns null on unparseable versions so callers fail closed", () => {
+    expect(parseRuntimeVersionNumber("")).toBeNull();
+    expect(parseRuntimeVersionNumber("53-no-prefix")).toBeNull();
+    expect(parseRuntimeVersionNumber("vNaN")).toBeNull();
+    expect(parseRuntimeVersionNumber("release-v53")).toBeNull();
+  });
+
+  it("keeps the floor itself parseable-shaped", () => {
+    expect(Number.isInteger(MIN_COMPATIBLE_RUNTIME_VERSION)).toBe(true);
+    expect(MIN_COMPATIBLE_RUNTIME_VERSION).toBeGreaterThan(0);
+  });
+});

--- a/packages/control-plane/src/environment-images/fingerprint.test.ts
+++ b/packages/control-plane/src/environment-images/fingerprint.test.ts
@@ -1,24 +1,24 @@
 import { describe, expect, it } from "vitest";
-import { computeMembersFingerprint } from "./fingerprint";
+import { computeRepositoriesFingerprint } from "./fingerprint";
 import { MIN_COMPATIBLE_RUNTIME_VERSION, parseRuntimeVersionNumber } from "./model";
 
-const members = [
+const repositories = [
   { repoOwner: "Acme", repoName: "Web", baseBranch: "main" },
   { repoOwner: "acme", repoName: "api", baseBranch: "develop" },
 ];
 
-describe("computeMembersFingerprint", () => {
+describe("computeRepositoriesFingerprint", () => {
   it("is deterministic", async () => {
-    const first = await computeMembersFingerprint(members);
-    const second = await computeMembersFingerprint(members);
+    const first = await computeRepositoriesFingerprint(repositories);
+    const second = await computeRepositoriesFingerprint(repositories);
     expect(first).toBe(second);
     expect(first).toMatch(/^[a-f0-9]{64}$/);
   });
 
   it("is case-insensitive on owner/name", async () => {
-    const upper = await computeMembersFingerprint(members);
-    const lower = await computeMembersFingerprint(
-      members.map((m) => ({
+    const upper = await computeRepositoriesFingerprint(repositories);
+    const lower = await computeRepositoriesFingerprint(
+      repositories.map((m) => ({
         ...m,
         repoOwner: m.repoOwner.toLowerCase(),
         repoName: m.repoName.toLowerCase(),
@@ -28,23 +28,23 @@ describe("computeMembersFingerprint", () => {
   });
 
   it("is case-sensitive on branch names (git refs are)", async () => {
-    const main = await computeMembersFingerprint(members);
-    const casedBranch = await computeMembersFingerprint([
-      { ...members[0], baseBranch: "Main" },
-      members[1],
+    const main = await computeRepositoriesFingerprint(repositories);
+    const casedBranch = await computeRepositoriesFingerprint([
+      { ...repositories[0], baseBranch: "Main" },
+      repositories[1],
     ]);
     expect(main).not.toBe(casedBranch);
   });
 
-  it("is order-sensitive (members are position-ordered)", async () => {
-    const forward = await computeMembersFingerprint(members);
-    const reversed = await computeMembersFingerprint([...members].reverse());
+  it("is order-sensitive (repositories are position-ordered)", async () => {
+    const forward = await computeRepositoriesFingerprint(repositories);
+    const reversed = await computeRepositoriesFingerprint([...repositories].reverse());
     expect(forward).not.toBe(reversed);
   });
 
-  it("changes when the member set changes", async () => {
-    const two = await computeMembersFingerprint(members);
-    const one = await computeMembersFingerprint(members.slice(0, 1));
+  it("changes when the repository set changes", async () => {
+    const two = await computeRepositoriesFingerprint(repositories);
+    const one = await computeRepositoriesFingerprint(repositories.slice(0, 1));
     expect(two).not.toBe(one);
   });
 });

--- a/packages/control-plane/src/environment-images/fingerprint.ts
+++ b/packages/control-plane/src/environment-images/fingerprint.ts
@@ -1,0 +1,37 @@
+/**
+ * Members fingerprint — the identity of an environment's buildable repo set.
+ *
+ * A fingerprint is a SHA-256 over the ordered (owner, name, base_branch)
+ * triples of an environment's members (design §7.3). It is computed
+ * control-plane-side only: at build registration (from the member set the
+ * build was handed) and at spawn matching (from the session's own snapshot,
+ * PR-11) — never by the data plane, so the algorithm has exactly one home.
+ */
+
+export interface FingerprintMemberInput {
+  repoOwner: string;
+  repoName: string;
+  baseBranch: string;
+}
+
+/**
+ * Order-sensitive by design: members are position-ordered and setup hooks run
+ * in that order, so a reordered environment is a different build. Owner/name
+ * are lowercased to match repo-identity comparisons elsewhere; branch names
+ * stay case-sensitive (git refs are).
+ */
+export async function computeMembersFingerprint(
+  members: FingerprintMemberInput[]
+): Promise<string> {
+  const canonical = JSON.stringify(
+    members.map((member) => [
+      member.repoOwner.toLowerCase(),
+      member.repoName.toLowerCase(),
+      member.baseBranch,
+    ])
+  );
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(canonical));
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/packages/control-plane/src/environment-images/fingerprint.ts
+++ b/packages/control-plane/src/environment-images/fingerprint.ts
@@ -1,33 +1,33 @@
 /**
- * Members fingerprint — the identity of an environment's buildable repo set.
+ * Repositories fingerprint — the identity of an environment's buildable repo set.
  *
  * A fingerprint is a SHA-256 over the ordered (owner, name, base_branch)
- * triples of an environment's members (design §7.3). It is computed
- * control-plane-side only: at build registration (from the member set the
+ * triples of an environment's repositories (design §7.3). It is computed
+ * control-plane-side only: at build registration (from the repository set the
  * build was handed) and at spawn matching (from the session's own snapshot,
  * PR-11) — never by the data plane, so the algorithm has exactly one home.
  */
 
-export interface FingerprintMemberInput {
+export interface FingerprintRepositoryInput {
   repoOwner: string;
   repoName: string;
   baseBranch: string;
 }
 
 /**
- * Order-sensitive by design: members are position-ordered and setup hooks run
- * in that order, so a reordered environment is a different build. Owner/name
+ * Order-sensitive by design: repositories are position-ordered and setup hooks
+ * run in that order, so a reordered environment is a different build. Owner/name
  * are lowercased to match repo-identity comparisons elsewhere; branch names
  * stay case-sensitive (git refs are).
  */
-export async function computeMembersFingerprint(
-  members: FingerprintMemberInput[]
+export async function computeRepositoriesFingerprint(
+  repositories: FingerprintRepositoryInput[]
 ): Promise<string> {
   const canonical = JSON.stringify(
-    members.map((member) => [
-      member.repoOwner.toLowerCase(),
-      member.repoName.toLowerCase(),
-      member.baseBranch,
+    repositories.map((repo) => [
+      repo.repoOwner.toLowerCase(),
+      repo.repoName.toLowerCase(),
+      repo.baseBranch,
     ])
   );
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(canonical));

--- a/packages/control-plane/src/environment-images/modal-adapter.ts
+++ b/packages/control-plane/src/environment-images/modal-adapter.ts
@@ -1,0 +1,36 @@
+import type { ModalEnvironmentImageBuildProvider } from "../sandbox/providers/modal-provider";
+import type {
+  DeleteEnvironmentImageInput,
+  EnvironmentImageBuildAdapter,
+  EnvironmentImageBuildStartCallbacks,
+  ModalEnvironmentImageBuildPlan,
+} from "./types";
+
+/**
+ * Modal adapter for direct provider-image callbacks.
+ *
+ * Modal's environment image builder returns the final provider image id in
+ * its callback, so no session binding or finalization step is needed here.
+ */
+export class ModalEnvironmentImageBuildAdapter implements EnvironmentImageBuildAdapter<ModalEnvironmentImageBuildPlan> {
+  constructor(private readonly provider: ModalEnvironmentImageBuildProvider) {}
+
+  async startBuild(
+    plan: ModalEnvironmentImageBuildPlan,
+    _callbacks: EnvironmentImageBuildStartCallbacks
+  ): Promise<void> {
+    await this.provider.triggerEnvironmentImageBuild({
+      environmentId: plan.environmentId,
+      buildId: plan.buildId,
+      callbackUrl: plan.callbackUrl,
+      repositories: plan.repositories,
+      userEnvVars: plan.userEnvVars,
+      buildTimeoutMs: plan.buildTimeoutMs,
+      correlation: plan.correlation,
+    });
+  }
+
+  async deleteImage(input: DeleteEnvironmentImageInput): Promise<void> {
+    await this.provider.deleteProviderImage(input.image.providerImageId, input.correlation);
+  }
+}

--- a/packages/control-plane/src/environment-images/model.ts
+++ b/packages/control-plane/src/environment-images/model.ts
@@ -3,7 +3,7 @@
  *
  * Environment images generalize repo images to a prebuildable repository set:
  * the artifact is provider-opaque exactly like a repo image, but the build
- * unit is an environment, drift is tracked per member (`member_shas`), and
+ * unit is an environment, drift is tracked per repository (`repository_shas`), and
  * spawn selection is gated by the runtime version baked at build time.
  */
 import type { RepoImageProvider } from "../repo-images/model";
@@ -18,15 +18,15 @@ export type EnvironmentImageProvider = RepoImageProvider;
 export type EnvironmentImageBuildStatus = "building" | "ready" | "failed" | "superseded";
 
 /**
- * One member's clone provenance at build time.
+ * One repository's clone provenance at build time.
  *
  * This is a single cross-language document shape: produced by the sandbox
  * runtime, echoed through build callbacks, stored verbatim in
- * `environment_images.member_shas`, and compared against `git ls-remote` by
+ * `environment_images.repository_shas`, and compared against `git ls-remote` by
  * the rebuild cron. Keep the field names in sync with
  * `sandbox_runtime/entrypoint.py` rather than remapping at each boundary.
  */
-export interface EnvironmentImageMemberSha {
+export interface EnvironmentImageRepositorySha {
   repoOwner: string;
   repoName: string;
   baseSha: string;

--- a/packages/control-plane/src/environment-images/model.ts
+++ b/packages/control-plane/src/environment-images/model.ts
@@ -1,0 +1,79 @@
+/**
+ * Domain terms for environment image builds (design §7.3).
+ *
+ * Environment images generalize repo images to a prebuildable repository set:
+ * the artifact is provider-opaque exactly like a repo image, but the build
+ * unit is an environment, drift is tracked per member (`member_shas`), and
+ * spawn selection is gated by the runtime version baked at build time.
+ */
+import type { RepoImageProvider } from "../repo-images/model";
+
+/**
+ * Environment images run on the same provider set and callback policy as repo
+ * images (design §7.3 "Provider coverage"): Modal images, Vercel snapshots,
+ * OpenComputer checkpoints. Daytona has no image support for either subsystem.
+ */
+export type EnvironmentImageProvider = RepoImageProvider;
+
+export type EnvironmentImageBuildStatus = "building" | "ready" | "failed" | "superseded";
+
+/**
+ * One member's clone provenance at build time.
+ *
+ * This is a single cross-language document shape: produced by the sandbox
+ * runtime, echoed through build callbacks, stored verbatim in
+ * `environment_images.member_shas`, and compared against `git ls-remote` by
+ * the rebuild cron. Keep the field names in sync with
+ * `sandbox_runtime/entrypoint.py` rather than remapping at each boundary.
+ */
+export interface EnvironmentImageMemberSha {
+  repoOwner: string;
+  repoName: string;
+  baseSha: string;
+}
+
+/** Opaque provider artifact reference, optionally tied to the build sandbox that produced it. */
+export interface EnvironmentImageProviderImageRef {
+  providerImageId: string;
+  providerSessionId?: string | null;
+}
+
+export interface SupersededEnvironmentImage {
+  environmentImageId: string;
+  image: EnvironmentImageProviderImageRef;
+}
+
+export type MarkEnvironmentImageReadyResult =
+  | { type: "marked_ready"; supersededImages: SupersededEnvironmentImage[] }
+  | { type: "superseded_by_newer_ready"; supersededImage: SupersededEnvironmentImage }
+  | { type: "not_accepting_completion" };
+
+/** Minimal build row shape needed before accepting a callback. */
+export interface EnvironmentImageCallbackBuild {
+  id: string;
+  environmentId: string;
+  provider: EnvironmentImageProvider;
+  providerSessionId: string | null;
+  status: EnvironmentImageBuildStatus;
+}
+
+/**
+ * Compatibility floor for environment-image runtimes (design §7.3).
+ *
+ * Bumped ONLY on breaking runtime changes, never on routine CACHE_BUSTER
+ * bumps. v53 is the list-native runtime — the first that can boot a
+ * multi-repo workspace — so no image baked by an earlier runtime may ever be
+ * selected for an environment session.
+ */
+export const MIN_COMPATIBLE_RUNTIME_VERSION = 53;
+
+/**
+ * Parse the numeric prefix of a SANDBOX_VERSION ("v53-list-native-runtime"
+ * → 53). Returns null when unparseable — callers fail closed: registration
+ * rejects the callback, and spawn selection treats the image as below the
+ * floor.
+ */
+export function parseRuntimeVersionNumber(runtimeVersion: string): number | null {
+  const match = /^v(\d+)/.exec(runtimeVersion);
+  return match ? Number.parseInt(match[1], 10) : null;
+}

--- a/packages/control-plane/src/environment-images/opencomputer-adapter.ts
+++ b/packages/control-plane/src/environment-images/opencomputer-adapter.ts
@@ -1,0 +1,98 @@
+import { createLogger } from "../logger";
+import type { OpenComputerSandboxProvider } from "../sandbox/providers/opencomputer-provider";
+import type { EnvironmentImageProviderImageRef } from "./model";
+import type {
+  DeleteEnvironmentImageInput,
+  EnvironmentImageBuildAdapter,
+  EnvironmentImageBuildStartCallbacks,
+  FailedEnvironmentImageBuildInput,
+  FinalizeEnvironmentImageBuildInput,
+  OpenComputerEnvironmentImageBuildPlan,
+} from "./types";
+
+const logger = createLogger("environment-images:opencomputer-adapter");
+const MS_PER_SECOND = 1000;
+
+/**
+ * OpenComputer adapter for provider-session environment image builds.
+ *
+ * Builds run in a temporary OpenComputer sandbox. On success, the adapter
+ * checkpoints that sandbox into the environment image artifact; cleanup hooks
+ * handle teardown.
+ */
+export class OpenComputerEnvironmentImageBuildAdapter implements EnvironmentImageBuildAdapter<OpenComputerEnvironmentImageBuildPlan> {
+  constructor(private readonly provider: OpenComputerSandboxProvider) {}
+
+  async startBuild(
+    plan: OpenComputerEnvironmentImageBuildPlan,
+    callbacks: EnvironmentImageBuildStartCallbacks
+  ): Promise<void> {
+    await this.provider.triggerEnvironmentImageBuild({
+      environmentId: plan.environmentId,
+      repositories: plan.repositories,
+      buildId: plan.buildId,
+      callbackUrl: plan.callbackUrl,
+      callbackToken: plan.callbackToken,
+      userEnvVars: plan.userEnvVars,
+      cloneToken: plan.cloneAuth.type === "credential_helper" ? plan.cloneAuth.token : undefined,
+      buildTimeoutSeconds: Math.ceil(plan.buildTimeoutMs / MS_PER_SECOND),
+      onProviderSessionCreated: callbacks.bindProviderSession,
+    });
+  }
+
+  async finalizeSuccessfulBuild(
+    input: FinalizeEnvironmentImageBuildInput
+  ): Promise<EnvironmentImageProviderImageRef> {
+    const snapshot = await this.provider.takeSnapshot({
+      providerObjectId: input.providerSessionId,
+      sessionId: input.buildId,
+      reason: "environment_image_build",
+      correlation: {
+        ...input.correlation,
+        sandbox_id: input.providerSessionId,
+      },
+    });
+
+    if (!snapshot.success || !snapshot.imageId) {
+      throw new Error(snapshot.error || "OpenComputer checkpoint did not return an image id");
+    }
+
+    return {
+      providerImageId: snapshot.imageId,
+      providerSessionId: input.providerSessionId,
+    };
+  }
+
+  async cleanupCompletedBuild(input: FinalizeEnvironmentImageBuildInput): Promise<void> {
+    await this.deleteBuildSandbox(input.buildId, input.providerSessionId, input.correlation);
+  }
+
+  async cleanupFailedBuild(input: FailedEnvironmentImageBuildInput): Promise<void> {
+    await this.deleteBuildSandbox(input.buildId, input.providerSessionId, input.correlation);
+  }
+
+  async deleteImage(input: DeleteEnvironmentImageInput): Promise<void> {
+    await this.provider.deleteProviderImage(
+      input.image.providerImageId,
+      input.image.providerSessionId
+    );
+  }
+
+  private async deleteBuildSandbox(
+    buildId: string,
+    providerSessionId: string,
+    correlation: FinalizeEnvironmentImageBuildInput["correlation"]
+  ): Promise<void> {
+    try {
+      await this.provider.deleteSandbox(providerSessionId, { deleteSecretStore: true });
+    } catch (error) {
+      logger.warn("environment_image.opencomputer_build_cleanup_failed", {
+        build_id: buildId,
+        provider_session_id: providerSessionId,
+        error: error instanceof Error ? error.message : String(error),
+        request_id: correlation.request_id,
+        trace_id: correlation.trace_id,
+      });
+    }
+  }
+}

--- a/packages/control-plane/src/environment-images/planner.ts
+++ b/packages/control-plane/src/environment-images/planner.ts
@@ -8,19 +8,36 @@ import {
   parseSecretsCapMode,
 } from "../db/secrets-validation";
 import { createLogger, type CorrelationContext } from "../logger";
-import { resolveSandboxSettings } from "../session/integration-settings-resolution";
-import type { Env } from "../types";
+// Environment images share the repo-image callback-token scheme and per-provider
+// policy wholesale (design §7.3 "Provider coverage") — one token scheme, one
+// policy table, both renamed together in the build-subsystem unification.
 import {
-  EnvironmentImageEnvironmentNotFoundError,
-  EnvironmentImagePlanningError,
-  EnvironmentImageProviderUnconfiguredError,
-} from "./errors";
+  generateRepoImageCallbackToken,
+  hashRepoImageCallbackToken,
+  REPO_IMAGE_CALLBACK_TOKEN_TTL_MS,
+} from "../repo-images/auth";
+import {
+  getRepoImageCallbackMode,
+  getRepoImageCloneAuthMode,
+} from "../repo-images/provider-policy";
+import { resolveSandboxSettings } from "../session/integration-settings-resolution";
+import { createSourceControlProviderFromEnv } from "../source-control";
+import type { Env } from "../types";
+import { EnvironmentImageEnvironmentNotFoundError, EnvironmentImagePlanningError } from "./errors";
 import { computeMembersFingerprint } from "./fingerprint";
 import type { EnvironmentImageProvider } from "./model";
-import type { EnvironmentImageBuildMember, PlannedEnvironmentImageBuild } from "./types";
+import type {
+  EnvironmentImageBuildMember,
+  EnvironmentImageCloneAuth,
+  PlannedEnvironmentImageBuild,
+} from "./types";
 
 const logger = createLogger("environment-images:planner");
 const MS_PER_SECOND = 1000;
+
+type PlannedCallbackAuth =
+  | { kind: "none" }
+  | { kind: "bearer_token"; token: string; tokenHash: string; expiresAt: number };
 
 /**
  * Resolves a trigger request into a concrete provider build plan.
@@ -65,11 +82,14 @@ export class EnvironmentImageBuildPlanner {
     }));
     const primary = repositories[0];
 
-    const [membersFingerprint, sandboxSettings, userEnvVars] = await Promise.all([
-      computeMembersFingerprint(repositories),
-      resolveSandboxSettings(this.env.DB, primary.repoOwner, primary.repoName),
-      this.loadUserEnvVars(params.environmentId),
-    ]);
+    const [membersFingerprint, sandboxSettings, userEnvVars, callbackAuth, cloneAuth] =
+      await Promise.all([
+        computeMembersFingerprint(repositories),
+        resolveSandboxSettings(this.env.DB, primary.repoOwner, primary.repoName),
+        this.loadUserEnvVars(params.environmentId),
+        this.createCallbackAuth(),
+        this.resolveCloneAuth(params.environmentId),
+      ]);
 
     const basePlan = {
       buildId: params.buildId,
@@ -85,20 +105,83 @@ export class EnvironmentImageBuildPlanner {
       },
     };
 
-    if (this.provider !== "modal") {
-      throw new EnvironmentImageProviderUnconfiguredError(
-        `Environment image builds are not supported for provider: ${this.provider}`
-      );
+    switch (this.provider) {
+      case "modal":
+        return {
+          plan: { ...basePlan, provider: "modal", callbackMode: "provider_image" },
+          callbackAuth: { type: "none" },
+        };
+      case "vercel": {
+        const bearerAuth = requireBearerCallbackAuth(this.provider, callbackAuth);
+        return {
+          plan: {
+            ...basePlan,
+            provider: "vercel",
+            callbackMode: "provider_session",
+            callbackToken: bearerAuth.token,
+            cloneAuth,
+          },
+          callbackAuth: {
+            type: "bearer_token",
+            tokenHash: bearerAuth.tokenHash,
+            expiresAt: bearerAuth.expiresAt,
+          },
+        };
+      }
+      case "opencomputer": {
+        const bearerAuth = requireBearerCallbackAuth(this.provider, callbackAuth);
+        return {
+          plan: {
+            ...basePlan,
+            provider: "opencomputer",
+            callbackMode: "provider_session",
+            callbackToken: bearerAuth.token,
+            cloneAuth,
+          },
+          callbackAuth: {
+            type: "bearer_token",
+            tokenHash: bearerAuth.tokenHash,
+            expiresAt: bearerAuth.expiresAt,
+          },
+        };
+      }
+      default: {
+        const exhaustive: never = this.provider;
+        throw new Error(`Unsupported environment image provider: ${String(exhaustive)}`);
+      }
+    }
+  }
+
+  private async createCallbackAuth(): Promise<PlannedCallbackAuth> {
+    if (getRepoImageCallbackMode(this.provider) !== "provider_session") {
+      return { kind: "none" };
     }
 
+    const token = generateRepoImageCallbackToken();
     return {
-      plan: {
-        ...basePlan,
-        provider: "modal",
-        callbackMode: "provider_image",
-      },
-      callbackAuth: { type: "none" },
+      kind: "bearer_token",
+      token,
+      tokenHash: await hashRepoImageCallbackToken(token, this.env),
+      expiresAt: Date.now() + REPO_IMAGE_CALLBACK_TOKEN_TTL_MS,
     };
+  }
+
+  private async resolveCloneAuth(environmentId: string): Promise<EnvironmentImageCloneAuth> {
+    if (getRepoImageCloneAuthMode(this.provider) !== "credential_helper") {
+      return { type: "unavailable" };
+    }
+
+    try {
+      const provider = createSourceControlProviderFromEnv(this.env);
+      const auth = await provider.generateCredentialHelperAuth();
+      return { type: "credential_helper", token: auth.password };
+    } catch (e) {
+      logger.warn("environment_image.clone_token_failed", {
+        error: errorMessage(e),
+        environment_id: environmentId,
+      });
+      return { type: "unavailable" };
+    }
   }
 
   private async loadUserEnvVars(
@@ -161,4 +244,14 @@ export class EnvironmentImageBuildPlanner {
 
 function errorMessage(errorValue: unknown): string {
   return errorValue instanceof Error ? errorValue.message : String(errorValue);
+}
+
+function requireBearerCallbackAuth(
+  provider: EnvironmentImageProvider,
+  callbackAuth: PlannedCallbackAuth
+): Extract<PlannedCallbackAuth, { kind: "bearer_token" }> {
+  if (callbackAuth.kind !== "bearer_token") {
+    throw new Error(`${provider} environment image builds require callback token auth`);
+  }
+  return callbackAuth;
 }

--- a/packages/control-plane/src/environment-images/planner.ts
+++ b/packages/control-plane/src/environment-images/planner.ts
@@ -1,0 +1,164 @@
+import { resolveBuildTimeoutSeconds } from "@open-inspect/shared";
+import { EnvironmentSecretsStore } from "../db/environment-secrets";
+import { EnvironmentStore } from "../db/environments";
+import { GlobalSecretsStore } from "../db/global-secrets";
+import {
+  auditSecretsMerge,
+  mergeSecretSources,
+  parseSecretsCapMode,
+} from "../db/secrets-validation";
+import { createLogger, type CorrelationContext } from "../logger";
+import { resolveSandboxSettings } from "../session/integration-settings-resolution";
+import type { Env } from "../types";
+import {
+  EnvironmentImageEnvironmentNotFoundError,
+  EnvironmentImagePlanningError,
+  EnvironmentImageProviderUnconfiguredError,
+} from "./errors";
+import { computeMembersFingerprint } from "./fingerprint";
+import type { EnvironmentImageProvider } from "./model";
+import type { EnvironmentImageBuildMember, PlannedEnvironmentImageBuild } from "./types";
+
+const logger = createLogger("environment-images:planner");
+const MS_PER_SECOND = 1000;
+
+/**
+ * Resolves a trigger request into a concrete provider build plan.
+ *
+ * The planner is the only environment-image layer that talks to the
+ * environment and secrets stores. Build-time secrets are the same set the
+ * environment's sessions get — global + environment, member repos never
+ * inherit (design §6.4/§7.3 build/session parity) — and the build timeout
+ * honors the primary member's sandbox settings.
+ */
+export class EnvironmentImageBuildPlanner {
+  constructor(
+    private readonly env: Env,
+    private readonly provider: EnvironmentImageProvider
+  ) {}
+
+  async planBuild(params: {
+    buildId: string;
+    environmentId: string;
+    callbackUrl: string;
+    correlation: CorrelationContext;
+  }): Promise<PlannedEnvironmentImageBuild> {
+    const store = new EnvironmentStore(this.env.DB);
+    const environment = await store.getById(params.environmentId);
+    if (!environment) {
+      throw new EnvironmentImageEnvironmentNotFoundError(params.environmentId);
+    }
+
+    const memberRows = await store.getRepositoriesForEnvironment(params.environmentId);
+    if (memberRows.length === 0) {
+      // Unreachable through the schema (environments require >= 1 repository);
+      // defensive against direct store writes.
+      throw new EnvironmentImagePlanningError(
+        `Environment has no repositories: ${params.environmentId}`
+      );
+    }
+
+    const repositories: EnvironmentImageBuildMember[] = memberRows.map((row) => ({
+      repoOwner: row.repo_owner,
+      repoName: row.repo_name,
+      baseBranch: row.base_branch,
+    }));
+    const primary = repositories[0];
+
+    const [membersFingerprint, sandboxSettings, userEnvVars] = await Promise.all([
+      computeMembersFingerprint(repositories),
+      resolveSandboxSettings(this.env.DB, primary.repoOwner, primary.repoName),
+      this.loadUserEnvVars(params.environmentId),
+    ]);
+
+    const basePlan = {
+      buildId: params.buildId,
+      environmentId: params.environmentId,
+      repositories,
+      membersFingerprint,
+      callbackUrl: params.callbackUrl,
+      buildTimeoutMs: resolveBuildTimeoutSeconds(sandboxSettings) * MS_PER_SECOND,
+      userEnvVars,
+      correlation: {
+        trace_id: params.correlation.trace_id,
+        request_id: params.correlation.request_id,
+      },
+    };
+
+    if (this.provider !== "modal") {
+      throw new EnvironmentImageProviderUnconfiguredError(
+        `Environment image builds are not supported for provider: ${this.provider}`
+      );
+    }
+
+    return {
+      plan: {
+        ...basePlan,
+        provider: "modal",
+        callbackMode: "provider_image",
+      },
+      callbackAuth: { type: "none" },
+    };
+  }
+
+  private async loadUserEnvVars(
+    environmentId: string
+  ): Promise<Record<string, string> | undefined> {
+    if (!this.env.REPO_SECRETS_ENCRYPTION_KEY) return undefined;
+
+    let globalSecrets: Record<string, string> = {};
+    try {
+      const globalStore = new GlobalSecretsStore(this.env.DB, this.env.REPO_SECRETS_ENCRYPTION_KEY);
+      globalSecrets = await globalStore.getDecryptedSecrets();
+    } catch (e) {
+      logger.warn("environment_image.global_secrets_failed", {
+        error: errorMessage(e),
+        environment_id: environmentId,
+      });
+    }
+
+    let environmentSecrets: Record<string, string> = {};
+    try {
+      const environmentStore = new EnvironmentSecretsStore(
+        this.env.DB,
+        this.env.REPO_SECRETS_ENCRYPTION_KEY
+      );
+      environmentSecrets = await environmentStore.getDecryptedSecrets(environmentId);
+    } catch (e) {
+      logger.warn("environment_image.environment_secrets_failed", {
+        error: errorMessage(e),
+        environment_id: environmentId,
+      });
+    }
+
+    // Same source labels as the session spawn fold (launch-unit-secrets.ts) so
+    // collision/cap logs attribute identically at build and session time.
+    const merge = mergeSecretSources([
+      { label: "global", secrets: globalSecrets },
+      { label: "environment", secrets: environmentSecrets },
+    ]);
+    auditSecretsMerge({
+      merge,
+      mode: parseSecretsCapMode(this.env.SECRETS_CAP_ENFORCEMENT),
+      log: logger,
+      context: { environment_id: environmentId },
+    });
+
+    if (Object.keys(merge.merged).length === 0) return undefined;
+
+    logger.info("environment_image.secrets_loaded", {
+      global_count: Object.keys(globalSecrets).length,
+      environment_count: Object.keys(environmentSecrets).length,
+      merged_count: Object.keys(merge.merged).length,
+      payload_bytes: merge.totalBytes,
+      exceeds_limit: merge.exceedsLimit,
+      environment_id: environmentId,
+    });
+
+    return merge.merged;
+  }
+}
+
+function errorMessage(errorValue: unknown): string {
+  return errorValue instanceof Error ? errorValue.message : String(errorValue);
+}

--- a/packages/control-plane/src/environment-images/planner.ts
+++ b/packages/control-plane/src/environment-images/planner.ts
@@ -35,18 +35,29 @@ import type {
 const logger = createLogger("environment-images:planner");
 const MS_PER_SECOND = 1000;
 
-type PlannedCallbackAuth =
+export type PlannedCallbackAuth =
   | { kind: "none" }
   | { kind: "bearer_token"; token: string; tokenHash: string; expiresAt: number };
+
+/** Members + fingerprint, resolved before a build row exists. */
+export interface ResolvedEnvironmentBuildTarget {
+  repositories: EnvironmentImageBuildMember[];
+  membersFingerprint: string;
+}
 
 /**
  * Resolves a trigger request into a concrete provider build plan.
  *
  * The planner is the only environment-image layer that talks to the
- * environment and secrets stores. Build-time secrets are the same set the
- * environment's sessions get — global + environment, member repos never
- * inherit (design §6.4/§7.3 build/session parity) — and the build timeout
- * honors the primary member's sandbox settings.
+ * environment and secrets stores. Split deliberately: resolveTarget and
+ * createCallbackAuth run BEFORE the build row is registered (cheap D1 read +
+ * pure crypto), while planBuild — which decrypts secrets — runs AFTER, so a
+ * concurrent secret change always sees a row to supersede and the build's
+ * now-stale secrets can never reach a still-selectable image (§7.4).
+ * Build-time secrets are the same set the environment's sessions get —
+ * global + environment, member repos never inherit (§6.4 build/session
+ * parity) — and the build timeout honors the primary member's sandbox
+ * settings.
  */
 export class EnvironmentImageBuildPlanner {
   constructor(
@@ -54,25 +65,18 @@ export class EnvironmentImageBuildPlanner {
     private readonly provider: EnvironmentImageProvider
   ) {}
 
-  async planBuild(params: {
-    buildId: string;
-    environmentId: string;
-    callbackUrl: string;
-    correlation: CorrelationContext;
-  }): Promise<PlannedEnvironmentImageBuild> {
+  async resolveTarget(environmentId: string): Promise<ResolvedEnvironmentBuildTarget> {
     const store = new EnvironmentStore(this.env.DB);
-    const environment = await store.getById(params.environmentId);
+    const environment = await store.getById(environmentId);
     if (!environment) {
-      throw new EnvironmentImageEnvironmentNotFoundError(params.environmentId);
+      throw new EnvironmentImageEnvironmentNotFoundError(environmentId);
     }
 
-    const memberRows = await store.getRepositoriesForEnvironment(params.environmentId);
+    const memberRows = await store.getRepositoriesForEnvironment(environmentId);
     if (memberRows.length === 0) {
       // Unreachable through the schema (environments require >= 1 repository);
       // defensive against direct store writes.
-      throw new EnvironmentImagePlanningError(
-        `Environment has no repositories: ${params.environmentId}`
-      );
+      throw new EnvironmentImagePlanningError(`Environment has no repositories: ${environmentId}`);
     }
 
     const repositories: EnvironmentImageBuildMember[] = memberRows.map((row) => ({
@@ -80,16 +84,44 @@ export class EnvironmentImageBuildPlanner {
       repoName: row.repo_name,
       baseBranch: row.base_branch,
     }));
-    const primary = repositories[0];
 
-    const [membersFingerprint, sandboxSettings, userEnvVars, callbackAuth, cloneAuth] =
-      await Promise.all([
-        computeMembersFingerprint(repositories),
-        resolveSandboxSettings(this.env.DB, primary.repoOwner, primary.repoName),
-        this.loadUserEnvVars(params.environmentId),
-        this.createCallbackAuth(),
-        this.resolveCloneAuth(params.environmentId),
-      ]);
+    return {
+      repositories,
+      membersFingerprint: await computeMembersFingerprint(repositories),
+    };
+  }
+
+  async createCallbackAuth(): Promise<PlannedCallbackAuth> {
+    if (getRepoImageCallbackMode(this.provider) !== "provider_session") {
+      return { kind: "none" };
+    }
+
+    const token = generateRepoImageCallbackToken();
+    return {
+      kind: "bearer_token",
+      token,
+      tokenHash: await hashRepoImageCallbackToken(token, this.env),
+      expiresAt: Date.now() + REPO_IMAGE_CALLBACK_TOKEN_TTL_MS,
+    };
+  }
+
+  async planBuild(params: {
+    buildId: string;
+    environmentId: string;
+    callbackUrl: string;
+    correlation: CorrelationContext;
+    target: ResolvedEnvironmentBuildTarget;
+    callbackAuth: PlannedCallbackAuth;
+  }): Promise<PlannedEnvironmentImageBuild> {
+    const { repositories, membersFingerprint } = params.target;
+    const primary = repositories[0];
+    const callbackAuth = params.callbackAuth;
+
+    const [sandboxSettings, userEnvVars, cloneAuth] = await Promise.all([
+      resolveSandboxSettings(this.env.DB, primary.repoOwner, primary.repoName),
+      this.loadUserEnvVars(params.environmentId),
+      this.resolveCloneAuth(params.environmentId),
+    ]);
 
     const basePlan = {
       buildId: params.buildId,
@@ -150,20 +182,6 @@ export class EnvironmentImageBuildPlanner {
         throw new Error(`Unsupported environment image provider: ${String(exhaustive)}`);
       }
     }
-  }
-
-  private async createCallbackAuth(): Promise<PlannedCallbackAuth> {
-    if (getRepoImageCallbackMode(this.provider) !== "provider_session") {
-      return { kind: "none" };
-    }
-
-    const token = generateRepoImageCallbackToken();
-    return {
-      kind: "bearer_token",
-      token,
-      tokenHash: await hashRepoImageCallbackToken(token, this.env),
-      expiresAt: Date.now() + REPO_IMAGE_CALLBACK_TOKEN_TTL_MS,
-    };
   }
 
   private async resolveCloneAuth(environmentId: string): Promise<EnvironmentImageCloneAuth> {

--- a/packages/control-plane/src/environment-images/planner.ts
+++ b/packages/control-plane/src/environment-images/planner.ts
@@ -24,10 +24,10 @@ import { resolveSandboxSettings } from "../session/integration-settings-resoluti
 import { createSourceControlProviderFromEnv } from "../source-control";
 import type { Env } from "../types";
 import { EnvironmentImageEnvironmentNotFoundError, EnvironmentImagePlanningError } from "./errors";
-import { computeMembersFingerprint } from "./fingerprint";
+import { computeRepositoriesFingerprint } from "./fingerprint";
 import type { EnvironmentImageProvider } from "./model";
 import type {
-  EnvironmentImageBuildMember,
+  EnvironmentImageBuildRepository,
   EnvironmentImageCloneAuth,
   PlannedEnvironmentImageBuild,
 } from "./types";
@@ -39,10 +39,10 @@ export type PlannedCallbackAuth =
   | { kind: "none" }
   | { kind: "bearer_token"; token: string; tokenHash: string; expiresAt: number };
 
-/** Members + fingerprint, resolved before a build row exists. */
+/** Repositories + fingerprint, resolved before a build row exists. */
 export interface ResolvedEnvironmentBuildTarget {
-  repositories: EnvironmentImageBuildMember[];
-  membersFingerprint: string;
+  repositories: EnvironmentImageBuildRepository[];
+  repositoriesFingerprint: string;
 }
 
 /**
@@ -55,8 +55,8 @@ export interface ResolvedEnvironmentBuildTarget {
  * concurrent secret change always sees a row to supersede and the build's
  * now-stale secrets can never reach a still-selectable image (§7.4).
  * Build-time secrets are the same set the environment's sessions get —
- * global + environment, member repos never inherit (§6.4 build/session
- * parity) — and the build timeout honors the primary member's sandbox
+ * global + environment, repo-scoped secrets never inherit (§6.4 build/session
+ * parity) — and the build timeout honors the primary repository's sandbox
  * settings.
  */
 export class EnvironmentImageBuildPlanner {
@@ -72,14 +72,14 @@ export class EnvironmentImageBuildPlanner {
       throw new EnvironmentImageEnvironmentNotFoundError(environmentId);
     }
 
-    const memberRows = await store.getRepositoriesForEnvironment(environmentId);
-    if (memberRows.length === 0) {
+    const repositoryRows = await store.getRepositoriesForEnvironment(environmentId);
+    if (repositoryRows.length === 0) {
       // Unreachable through the schema (environments require >= 1 repository);
       // defensive against direct store writes.
       throw new EnvironmentImagePlanningError(`Environment has no repositories: ${environmentId}`);
     }
 
-    const repositories: EnvironmentImageBuildMember[] = memberRows.map((row) => ({
+    const repositories: EnvironmentImageBuildRepository[] = repositoryRows.map((row) => ({
       repoOwner: row.repo_owner,
       repoName: row.repo_name,
       baseBranch: row.base_branch,
@@ -87,7 +87,7 @@ export class EnvironmentImageBuildPlanner {
 
     return {
       repositories,
-      membersFingerprint: await computeMembersFingerprint(repositories),
+      repositoriesFingerprint: await computeRepositoriesFingerprint(repositories),
     };
   }
 
@@ -113,7 +113,7 @@ export class EnvironmentImageBuildPlanner {
     target: ResolvedEnvironmentBuildTarget;
     callbackAuth: PlannedCallbackAuth;
   }): Promise<PlannedEnvironmentImageBuild> {
-    const { repositories, membersFingerprint } = params.target;
+    const { repositories, repositoriesFingerprint } = params.target;
     const primary = repositories[0];
     const callbackAuth = params.callbackAuth;
 
@@ -127,7 +127,7 @@ export class EnvironmentImageBuildPlanner {
       buildId: params.buildId,
       environmentId: params.environmentId,
       repositories,
-      membersFingerprint,
+      repositoriesFingerprint,
       callbackUrl: params.callbackUrl,
       buildTimeoutMs: resolveBuildTimeoutSeconds(sandboxSettings) * MS_PER_SECOND,
       userEnvVars,

--- a/packages/control-plane/src/environment-images/provider-factory.ts
+++ b/packages/control-plane/src/environment-images/provider-factory.ts
@@ -1,0 +1,38 @@
+import { createSandboxProviderFromEnv } from "../sandbox/provider-factory";
+import type { Env } from "../types";
+import { ModalEnvironmentImageBuildAdapter } from "./modal-adapter";
+import type { EnvironmentImageProvider } from "./model";
+import type { AnyEnvironmentImageBuildAdapter } from "./types";
+
+/**
+ * Composition boundary for environment image provider adapters.
+ *
+ * Environment images run on the repo-image provider set (design §7.3); Modal
+ * ships first, and the Vercel/OpenComputer adapters land with their
+ * provider-session parity step.
+ */
+export interface EnvironmentImageBuildAdapterFactory {
+  create(provider: EnvironmentImageProvider): AnyEnvironmentImageBuildAdapter;
+}
+
+export function createEnvironmentImageBuildAdapterFactory(
+  env: Env
+): EnvironmentImageBuildAdapterFactory {
+  return new EnvEnvironmentImageBuildAdapterFactory(env);
+}
+
+class EnvEnvironmentImageBuildAdapterFactory implements EnvironmentImageBuildAdapterFactory {
+  constructor(private readonly env: Env) {}
+
+  create(provider: EnvironmentImageProvider): AnyEnvironmentImageBuildAdapter {
+    switch (provider) {
+      case "modal":
+        return new ModalEnvironmentImageBuildAdapter(
+          createSandboxProviderFromEnv(this.env, "modal")
+        );
+      case "vercel":
+      case "opencomputer":
+        throw new Error(`Environment image builds are not supported for provider: ${provider}`);
+    }
+  }
+}

--- a/packages/control-plane/src/environment-images/provider-factory.ts
+++ b/packages/control-plane/src/environment-images/provider-factory.ts
@@ -2,16 +2,29 @@ import { createSandboxProviderFromEnv } from "../sandbox/provider-factory";
 import type { Env } from "../types";
 import { ModalEnvironmentImageBuildAdapter } from "./modal-adapter";
 import type { EnvironmentImageProvider } from "./model";
-import type { AnyEnvironmentImageBuildAdapter } from "./types";
+import { OpenComputerEnvironmentImageBuildAdapter } from "./opencomputer-adapter";
+import type {
+  AnyEnvironmentImageBuildAdapter,
+  EnvironmentImageBuildAdapter,
+  ModalEnvironmentImageBuildPlan,
+  OpenComputerEnvironmentImageBuildPlan,
+  VercelEnvironmentImageBuildPlan,
+} from "./types";
+import { VercelEnvironmentImageBuildAdapter } from "./vercel-adapter";
 
 /**
  * Composition boundary for environment image provider adapters.
  *
- * Environment images run on the repo-image provider set (design §7.3); Modal
- * ships first, and the Vercel/OpenComputer adapters land with their
- * provider-session parity step.
+ * Environment images run on the repo-image provider set (design §7.3);
+ * overloads preserve the provider→plan relationship so the workflow needs no
+ * unsafe casts.
  */
 export interface EnvironmentImageBuildAdapterFactory {
+  create(provider: "modal"): EnvironmentImageBuildAdapter<ModalEnvironmentImageBuildPlan>;
+  create(provider: "vercel"): EnvironmentImageBuildAdapter<VercelEnvironmentImageBuildPlan>;
+  create(
+    provider: "opencomputer"
+  ): EnvironmentImageBuildAdapter<OpenComputerEnvironmentImageBuildPlan>;
   create(provider: EnvironmentImageProvider): AnyEnvironmentImageBuildAdapter;
 }
 
@@ -24,6 +37,11 @@ export function createEnvironmentImageBuildAdapterFactory(
 class EnvEnvironmentImageBuildAdapterFactory implements EnvironmentImageBuildAdapterFactory {
   constructor(private readonly env: Env) {}
 
+  create(provider: "modal"): EnvironmentImageBuildAdapter<ModalEnvironmentImageBuildPlan>;
+  create(provider: "vercel"): EnvironmentImageBuildAdapter<VercelEnvironmentImageBuildPlan>;
+  create(
+    provider: "opencomputer"
+  ): EnvironmentImageBuildAdapter<OpenComputerEnvironmentImageBuildPlan>;
   create(provider: EnvironmentImageProvider): AnyEnvironmentImageBuildAdapter {
     switch (provider) {
       case "modal":
@@ -31,8 +49,13 @@ class EnvEnvironmentImageBuildAdapterFactory implements EnvironmentImageBuildAda
           createSandboxProviderFromEnv(this.env, "modal")
         );
       case "vercel":
+        return new VercelEnvironmentImageBuildAdapter(
+          createSandboxProviderFromEnv(this.env, "vercel")
+        );
       case "opencomputer":
-        throw new Error(`Environment image builds are not supported for provider: ${provider}`);
+        return new OpenComputerEnvironmentImageBuildAdapter(
+          createSandboxProviderFromEnv(this.env, "opencomputer")
+        );
     }
   }
 }

--- a/packages/control-plane/src/environment-images/save-hooks.ts
+++ b/packages/control-plane/src/environment-images/save-hooks.ts
@@ -1,0 +1,80 @@
+/**
+ * Environment save-hooks (design §7.3/§7.4).
+ *
+ * Saving an environment triggers an immediate prebuild instead of waiting for
+ * the cron, and a secret change additionally invalidates every live image
+ * before the new build starts — spawn matching sees members through the
+ * fingerprint but cannot see secrets, so without write-side invalidation a
+ * failed or in-flight rebuild would leave revoked values baked in a
+ * still-selectable image.
+ */
+
+import { EnvironmentImageStore } from "../db/environment-images";
+import { createLogger } from "../logger";
+import { resolveRepoImageProvider } from "../repo-images/provider-policy";
+import type { Env } from "../types";
+import type { RequestContext } from "../routes/shared";
+import { createEnvironmentImageBuildWorkflowFromEnv } from "./workflow";
+
+const logger = createLogger("environment-images:save-hooks");
+
+/**
+ * Kick a prebuild after an environment (or its secrets) changed. Best-effort
+ * and detached — a build-trigger failure must never fail the CRUD operation
+ * that invoked it. No-op on providers without image support; callers gate on
+ * the environment's prebuild_enabled flag (they already hold the row).
+ */
+export function scheduleEnvironmentImageBuildOnSave(
+  env: Env,
+  environmentId: string,
+  ctx: RequestContext
+): void {
+  if (!resolveRepoImageProvider(env.SANDBOX_PROVIDER)) return;
+
+  const task = createEnvironmentImageBuildWorkflowFromEnv(env)
+    .triggerBuildIfStale(environmentId, { request_id: ctx.request_id, trace_id: ctx.trace_id })
+    .then((result) => {
+      logger.info("environment_image.save_hook_trigger", {
+        environment_id: environmentId,
+        result: result.type,
+        build_id: result.type === "up_to_date" ? null : result.buildId,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+    })
+    .catch((e) => {
+      logger.warn("environment_image.save_hook_trigger_failed", {
+        environment_id: environmentId,
+        error: e instanceof Error ? e.message : String(e),
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+    });
+
+  if (ctx.executionCtx) {
+    ctx.executionCtx.waitUntil(task);
+  }
+}
+
+/**
+ * Secret-change invalidation. Synchronous, called right after a successful
+ * secret mutation and BEFORE the response: a failure here must surface as an
+ * error so the caller knows revoked values may still be baked in a selectable
+ * image and retries. Sessions in the rebuild window boot from base — never
+ * blocked, never stale.
+ */
+export async function supersedeEnvironmentImagesForSecretsChange(
+  env: Env,
+  environmentId: string,
+  ctx: RequestContext
+): Promise<void> {
+  const superseded = await new EnvironmentImageStore(env.DB).supersedeActiveImages(environmentId);
+  if (superseded > 0) {
+    logger.info("environment_image.secrets_change_superseded", {
+      environment_id: environmentId,
+      superseded,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+  }
+}

--- a/packages/control-plane/src/environment-images/save-hooks.ts
+++ b/packages/control-plane/src/environment-images/save-hooks.ts
@@ -3,7 +3,7 @@
  *
  * Saving an environment triggers an immediate prebuild instead of waiting for
  * the cron, and a secret change additionally invalidates every live image
- * before the new build starts — spawn matching sees members through the
+ * before the new build starts — spawn matching sees repositories through the
  * fingerprint but cannot see secrets, so without write-side invalidation a
  * failed or in-flight rebuild would leave revoked values baked in a
  * still-selectable image.

--- a/packages/control-plane/src/environment-images/types.ts
+++ b/packages/control-plane/src/environment-images/types.ts
@@ -1,14 +1,14 @@
 import type { CorrelationContext } from "../logger";
 import type {
-  EnvironmentImageMemberSha,
+  EnvironmentImageRepositorySha,
   EnvironmentImageProviderImageRef,
   SupersededEnvironmentImage,
 } from "./model";
 
 export type EnvironmentImageWorkflowContext = CorrelationContext;
 
-/** One environment member as handed to a build, in position order ([0] = primary). */
-export interface EnvironmentImageBuildMember {
+/** One environment repository as handed to a build, in position order ([0] = primary). */
+export interface EnvironmentImageBuildRepository {
   repoOwner: string;
   repoName: string;
   baseBranch: string;
@@ -19,7 +19,7 @@ export interface EnvironmentImageBuildMember {
  * (design §7.3): a second trigger while a build is in flight reports the
  * existing build instead of stacking another. `up_to_date` is returned only
  * by the save-hook variant, when a ready image already matches the current
- * member set.
+ * repository set.
  */
 export type TriggerEnvironmentImageBuildResult =
   | { type: "triggered"; buildId: string }
@@ -40,8 +40,8 @@ export type EnvironmentImageWorkflowResult =
 interface BaseEnvironmentImageBuildPlan {
   buildId: string;
   environmentId: string;
-  repositories: EnvironmentImageBuildMember[];
-  membersFingerprint: string;
+  repositories: EnvironmentImageBuildRepository[];
+  repositoriesFingerprint: string;
   callbackUrl: string;
   buildTimeoutMs: number;
   userEnvVars?: Record<string, string>;
@@ -98,7 +98,7 @@ export interface EnvironmentImageBuildStartCallbacks {
 
 /**
  * Wire form of the build-complete callback after route-level parsing.
- * member_shas and runtime_version are reported by the build itself
+ * repository_shas and runtime_version are reported by the build itself
  * (design §7.3) — registration fails closed when either is missing or
  * unparseable, because an unversioned image must never pass the floor check.
  */
@@ -106,7 +106,7 @@ export interface CompleteEnvironmentImageBuildCallback {
   buildId: string;
   providerImageId?: string;
   providerSessionId?: string;
-  memberShas?: EnvironmentImageMemberSha[];
+  repositoryShas?: EnvironmentImageRepositorySha[];
   runtimeVersion?: string;
   buildDurationMs?: number;
 }

--- a/packages/control-plane/src/environment-images/types.ts
+++ b/packages/control-plane/src/environment-images/types.ts
@@ -27,6 +27,7 @@ export type TriggerEnvironmentImageBuildResult =
   | { type: "up_to_date" };
 
 export type EnvironmentImageWorkflowResult =
+  | { type: "completion_accepted"; finalization: Promise<void> }
   | {
       type: "build_ready";
       replacedImages: SupersededEnvironmentImage[];
@@ -53,12 +54,42 @@ export interface ModalEnvironmentImageBuildPlan extends BaseEnvironmentImageBuil
   callbackMode: "provider_image";
 }
 
-export type EnvironmentImageBuildPlan = ModalEnvironmentImageBuildPlan;
+/** Same clone-auth shape as repo-image builds (repo-images/types.ts). */
+export type EnvironmentImageCloneAuth =
+  | { type: "credential_helper"; token: string }
+  | { type: "unavailable" };
 
-export type PlannedEnvironmentImageBuild = {
-  plan: ModalEnvironmentImageBuildPlan;
-  callbackAuth: { type: "none" };
-};
+/** Vercel builds inside a sandbox; the control plane snapshots it after callback success. */
+export interface VercelEnvironmentImageBuildPlan extends BaseEnvironmentImageBuildPlan {
+  provider: "vercel";
+  callbackMode: "provider_session";
+  callbackToken: string;
+  cloneAuth: EnvironmentImageCloneAuth;
+}
+
+/** OpenComputer builds inside a sandbox; the control plane checkpoints it after callback success. */
+export interface OpenComputerEnvironmentImageBuildPlan extends BaseEnvironmentImageBuildPlan {
+  provider: "opencomputer";
+  callbackMode: "provider_session";
+  callbackToken: string;
+  cloneAuth: EnvironmentImageCloneAuth;
+}
+
+export type EnvironmentImageBuildPlan =
+  | ModalEnvironmentImageBuildPlan
+  | VercelEnvironmentImageBuildPlan
+  | OpenComputerEnvironmentImageBuildPlan;
+
+export type PlannedEnvironmentImageBuild =
+  | { plan: ModalEnvironmentImageBuildPlan; callbackAuth: { type: "none" } }
+  | {
+      plan: VercelEnvironmentImageBuildPlan;
+      callbackAuth: { type: "bearer_token"; tokenHash: string; expiresAt: number };
+    }
+  | {
+      plan: OpenComputerEnvironmentImageBuildPlan;
+      callbackAuth: { type: "bearer_token"; tokenHash: string; expiresAt: number };
+    };
 
 /** Lets provider-session adapters bind the provider sandbox id before the runtime launches. */
 export interface EnvironmentImageBuildStartCallbacks {
@@ -91,15 +122,38 @@ export interface DeleteEnvironmentImageInput {
   correlation?: CorrelationContext;
 }
 
+/** Finalization input for provider-session builds (the deferred snapshot/checkpoint). */
+export interface FinalizeEnvironmentImageBuildInput {
+  buildId: string;
+  providerSessionId: string;
+  correlation: CorrelationContext;
+}
+
+export interface FailedEnvironmentImageBuildInput {
+  buildId: string;
+  providerSessionId: string;
+  errorMessage: string;
+  correlation: CorrelationContext;
+}
+
 /**
  * Provider-facing operations for environment image builds. The workflow owns
  * state transitions; adapters own translating lifecycle steps into provider
- * API calls (start build, delete artifact).
+ * API calls (start build, snapshot/checkpoint, teardown, artifact deletion).
+ * The finalize/cleanup hooks apply to provider_session builds only — Modal's
+ * callback already carries the artifact id.
  */
 export type EnvironmentImageBuildAdapter<Plan extends EnvironmentImageBuildPlan> = {
   startBuild(plan: Plan, callbacks: EnvironmentImageBuildStartCallbacks): Promise<void>;
   deleteImage(input: DeleteEnvironmentImageInput): Promise<void>;
+  finalizeSuccessfulBuild?(
+    input: FinalizeEnvironmentImageBuildInput
+  ): Promise<EnvironmentImageProviderImageRef>;
+  cleanupFailedBuild?(input: FailedEnvironmentImageBuildInput): Promise<void>;
+  cleanupCompletedBuild?(input: FinalizeEnvironmentImageBuildInput): Promise<void>;
 };
 
 export type AnyEnvironmentImageBuildAdapter =
-  EnvironmentImageBuildAdapter<ModalEnvironmentImageBuildPlan>;
+  | EnvironmentImageBuildAdapter<ModalEnvironmentImageBuildPlan>
+  | EnvironmentImageBuildAdapter<VercelEnvironmentImageBuildPlan>
+  | EnvironmentImageBuildAdapter<OpenComputerEnvironmentImageBuildPlan>;

--- a/packages/control-plane/src/environment-images/types.ts
+++ b/packages/control-plane/src/environment-images/types.ts
@@ -1,0 +1,105 @@
+import type { CorrelationContext } from "../logger";
+import type {
+  EnvironmentImageMemberSha,
+  EnvironmentImageProviderImageRef,
+  SupersededEnvironmentImage,
+} from "./model";
+
+export type EnvironmentImageWorkflowContext = CorrelationContext;
+
+/** One environment member as handed to a build, in position order ([0] = primary). */
+export interface EnvironmentImageBuildMember {
+  repoOwner: string;
+  repoName: string;
+  baseBranch: string;
+}
+
+/**
+ * Triggering is idempotent under the per-environment concurrency rule
+ * (design §7.3): a second trigger while a build is in flight reports the
+ * existing build instead of stacking another. `up_to_date` is returned only
+ * by the save-hook variant, when a ready image already matches the current
+ * member set.
+ */
+export type TriggerEnvironmentImageBuildResult =
+  | { type: "triggered"; buildId: string }
+  | { type: "already_building"; buildId: string }
+  | { type: "up_to_date" };
+
+export type EnvironmentImageWorkflowResult =
+  | {
+      type: "build_ready";
+      replacedImages: SupersededEnvironmentImage[];
+      cleanup?: Promise<void>;
+    }
+  | { type: "build_superseded"; cleanup?: Promise<void> }
+  | { type: "build_failed"; cleanup?: Promise<void> };
+
+/** Provider-neutral build request fields resolved before adapter-specific execution. */
+interface BaseEnvironmentImageBuildPlan {
+  buildId: string;
+  environmentId: string;
+  repositories: EnvironmentImageBuildMember[];
+  membersFingerprint: string;
+  callbackUrl: string;
+  buildTimeoutMs: number;
+  userEnvVars?: Record<string, string>;
+  correlation: CorrelationContext;
+}
+
+/** Modal's data-plane builder returns the provider image id directly in its callback. */
+export interface ModalEnvironmentImageBuildPlan extends BaseEnvironmentImageBuildPlan {
+  provider: "modal";
+  callbackMode: "provider_image";
+}
+
+export type EnvironmentImageBuildPlan = ModalEnvironmentImageBuildPlan;
+
+export type PlannedEnvironmentImageBuild = {
+  plan: ModalEnvironmentImageBuildPlan;
+  callbackAuth: { type: "none" };
+};
+
+/** Lets provider-session adapters bind the provider sandbox id before the runtime launches. */
+export interface EnvironmentImageBuildStartCallbacks {
+  bindProviderSession(providerSessionId: string): Promise<void>;
+}
+
+/**
+ * Wire form of the build-complete callback after route-level parsing.
+ * member_shas and runtime_version are reported by the build itself
+ * (design §7.3) — registration fails closed when either is missing or
+ * unparseable, because an unversioned image must never pass the floor check.
+ */
+export interface CompleteEnvironmentImageBuildCallback {
+  buildId: string;
+  providerImageId?: string;
+  providerSessionId?: string;
+  memberShas?: EnvironmentImageMemberSha[];
+  runtimeVersion?: string;
+  buildDurationMs?: number;
+}
+
+export interface FailEnvironmentImageBuildCallback {
+  buildId: string;
+  providerSessionId?: string;
+  errorMessage: string;
+}
+
+export interface DeleteEnvironmentImageInput {
+  image: EnvironmentImageProviderImageRef;
+  correlation?: CorrelationContext;
+}
+
+/**
+ * Provider-facing operations for environment image builds. The workflow owns
+ * state transitions; adapters own translating lifecycle steps into provider
+ * API calls (start build, delete artifact).
+ */
+export type EnvironmentImageBuildAdapter<Plan extends EnvironmentImageBuildPlan> = {
+  startBuild(plan: Plan, callbacks: EnvironmentImageBuildStartCallbacks): Promise<void>;
+  deleteImage(input: DeleteEnvironmentImageInput): Promise<void>;
+};
+
+export type AnyEnvironmentImageBuildAdapter =
+  EnvironmentImageBuildAdapter<ModalEnvironmentImageBuildPlan>;

--- a/packages/control-plane/src/environment-images/vercel-adapter.ts
+++ b/packages/control-plane/src/environment-images/vercel-adapter.ts
@@ -1,0 +1,107 @@
+import { createLogger } from "../logger";
+import type { VercelSandboxProvider } from "../sandbox/providers/vercel/provider";
+import type { EnvironmentImageProviderImageRef } from "./model";
+import type {
+  DeleteEnvironmentImageInput,
+  EnvironmentImageBuildAdapter,
+  EnvironmentImageBuildStartCallbacks,
+  FailedEnvironmentImageBuildInput,
+  FinalizeEnvironmentImageBuildInput,
+  VercelEnvironmentImageBuildPlan,
+} from "./types";
+
+const logger = createLogger("environment-images:vercel-adapter");
+const MS_PER_SECOND = 1000;
+
+/**
+ * Vercel adapter for provider-session environment image builds.
+ *
+ * Builds run in a temporary Vercel sandbox. On success, the adapter turns
+ * that sandbox into the durable environment image artifact; cleanup hooks
+ * handle teardown.
+ */
+export class VercelEnvironmentImageBuildAdapter implements EnvironmentImageBuildAdapter<VercelEnvironmentImageBuildPlan> {
+  constructor(private readonly provider: VercelSandboxProvider) {}
+
+  async startBuild(
+    plan: VercelEnvironmentImageBuildPlan,
+    callbacks: EnvironmentImageBuildStartCallbacks
+  ): Promise<void> {
+    await this.provider.triggerEnvironmentImageBuild({
+      environmentId: plan.environmentId,
+      repositories: plan.repositories,
+      buildId: plan.buildId,
+      callbackUrl: plan.callbackUrl,
+      callbackToken: plan.callbackToken,
+      userEnvVars: plan.userEnvVars,
+      cloneToken: plan.cloneAuth.type === "credential_helper" ? plan.cloneAuth.token : undefined,
+      buildTimeoutSeconds: Math.ceil(plan.buildTimeoutMs / MS_PER_SECOND),
+      onProviderSessionCreated: callbacks.bindProviderSession,
+      correlation: plan.correlation,
+    });
+  }
+
+  async finalizeSuccessfulBuild(
+    input: FinalizeEnvironmentImageBuildInput
+  ): Promise<EnvironmentImageProviderImageRef> {
+    try {
+      const snapshot = await this.provider.takeSnapshot({
+        providerObjectId: input.providerSessionId,
+        sessionId: input.buildId,
+        reason: "environment_image_build",
+        correlation: {
+          ...input.correlation,
+          sandbox_id: input.providerSessionId,
+        },
+      });
+
+      if (!snapshot.success || !snapshot.imageId) {
+        throw new Error(snapshot.error || "Vercel snapshot did not return an image id");
+      }
+
+      return {
+        providerImageId: snapshot.imageId,
+        providerSessionId: input.providerSessionId,
+      };
+    } finally {
+      await this.stopBuildSandbox(input);
+    }
+  }
+
+  async cleanupFailedBuild(input: FailedEnvironmentImageBuildInput): Promise<void> {
+    await this.stopBuildSandbox(input);
+  }
+
+  async deleteImage(input: DeleteEnvironmentImageInput): Promise<void> {
+    await this.provider.deleteProviderImage(input.image.providerImageId);
+  }
+
+  private async stopBuildSandbox(input: {
+    buildId: string;
+    providerSessionId: string;
+    correlation: FinalizeEnvironmentImageBuildInput["correlation"];
+  }): Promise<void> {
+    try {
+      const stopResult = await this.provider.stopSandbox({
+        providerObjectId: input.providerSessionId,
+        sessionId: input.buildId,
+        reason: "environment_image_build_complete",
+        correlation: {
+          ...input.correlation,
+          sandbox_id: input.providerSessionId,
+        },
+      });
+      if (!stopResult.success) {
+        throw new Error(stopResult.error || "Failed to stop Vercel build sandbox");
+      }
+    } catch (error) {
+      logger.warn("environment_image.vercel_build_stop_failed", {
+        build_id: input.buildId,
+        provider_session_id: input.providerSessionId,
+        error: error instanceof Error ? error.message : String(error),
+        request_id: input.correlation.request_id,
+        trace_id: input.correlation.trace_id,
+      });
+    }
+  }
+}

--- a/packages/control-plane/src/environment-images/workflow.test.ts
+++ b/packages/control-plane/src/environment-images/workflow.test.ts
@@ -32,6 +32,8 @@ function createStore() {
     getActiveBuild: vi.fn().mockResolvedValue(null),
     hasReadyImageForFingerprint: vi.fn().mockResolvedValue(false),
     getCallbackBuild: vi.fn().mockResolvedValue(null),
+    getBuildRow: vi.fn().mockResolvedValue(null),
+    recordArtifactOnSupersededBuild: vi.fn().mockResolvedValue(true),
     bindProviderSession: vi.fn().mockResolvedValue(true),
     consumeCallbackToken: vi.fn().mockResolvedValue(null),
     markBuildFailedWithCallbackToken: vi.fn().mockResolvedValue(false),
@@ -101,6 +103,8 @@ function createWorkflow(options: {
   store?: ReturnType<typeof createStore>;
   adapter?: ReturnType<typeof createAdapter>;
   planBuild?: ReturnType<typeof vi.fn>;
+  resolveTarget?: ReturnType<typeof vi.fn>;
+  createCallbackAuth?: ReturnType<typeof vi.fn>;
   env?: Env;
   provider?: "modal" | "vercel" | "opencomputer" | null;
 }) {
@@ -110,14 +114,24 @@ function createWorkflow(options: {
     create: vi.fn().mockReturnValue(adapter),
   };
   const planBuild = options.planBuild ?? vi.fn().mockResolvedValue(plannedBuild());
+  const resolveTarget =
+    options.resolveTarget ??
+    vi.fn().mockResolvedValue({
+      repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
+      membersFingerprint: "fp-1",
+    });
+  const createCallbackAuth =
+    options.createCallbackAuth ?? vi.fn().mockResolvedValue({ kind: "none" });
   const workflow = new EnvironmentImageBuildWorkflow(
     options.env ?? createEnv(),
     store as unknown as EnvironmentImageStore,
     factory,
     options.provider === undefined ? "modal" : options.provider,
-    { planBuild } as unknown as ConstructorParameters<typeof EnvironmentImageBuildWorkflow>[4]
+    { planBuild, resolveTarget, createCallbackAuth } as unknown as ConstructorParameters<
+      typeof EnvironmentImageBuildWorkflow
+    >[4]
   );
-  return { workflow, store, adapter, factory, planBuild };
+  return { workflow, store, adapter, factory, planBuild, resolveTarget, createCallbackAuth };
 }
 
 const ctx = { trace_id: "t", request_id: "r" };
@@ -172,16 +186,57 @@ describe("EnvironmentImageBuildWorkflow", () => {
       expect(store.registerBuild).not.toHaveBeenCalled();
     });
 
-    it("propagates environment-not-found from the planner", async () => {
-      const planBuild = vi
+    it("propagates environment-not-found from target resolution without writing a row", async () => {
+      const resolveTarget = vi
         .fn()
         .mockRejectedValue(new EnvironmentImageEnvironmentNotFoundError("env_missing"));
-      const { workflow, store } = createWorkflow({ planBuild });
+      const { workflow, store } = createWorkflow({ resolveTarget });
 
       await expect(workflow.triggerBuild("env_missing", ctx)).rejects.toBeInstanceOf(
         EnvironmentImageEnvironmentNotFoundError
       );
       expect(store.registerBuild).not.toHaveBeenCalled();
+    });
+
+    it("registers the build row before secrets are read (§7.4 supersede window)", async () => {
+      const { workflow, store, planBuild } = createWorkflow({});
+
+      await workflow.triggerBuild("env_1", ctx);
+
+      // planBuild is where secrets are decrypted; a concurrent secret change
+      // must always find a row to supersede.
+      expect(store.registerBuild.mock.invocationCallOrder[0]).toBeLessThan(
+        planBuild.mock.invocationCallOrder[0]
+      );
+    });
+
+    it("fails a misconfigured provider closed without writing a row", async () => {
+      const factoryError = vi.fn(() => {
+        throw new Error("MODAL_WORKSPACE not configured");
+      });
+      const store = createStore();
+      const adapter = createAdapter();
+      const workflow = new EnvironmentImageBuildWorkflow(
+        createEnv(),
+        store as unknown as EnvironmentImageStore,
+        { create: factoryError },
+        "modal",
+        {
+          planBuild: vi.fn(),
+          resolveTarget: vi.fn().mockResolvedValue({
+            repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
+            membersFingerprint: "fp-1",
+          }),
+          createCallbackAuth: vi.fn().mockResolvedValue({ kind: "none" }),
+        } as unknown as ConstructorParameters<typeof EnvironmentImageBuildWorkflow>[4]
+      );
+
+      await expect(workflow.triggerBuild("env_1", ctx)).rejects.toMatchObject({
+        code: "provider_unconfigured",
+      });
+      // No junk failed rows accumulate from a misconfigured provider.
+      expect(store.registerBuild).not.toHaveBeenCalled();
+      expect(adapter.startBuild).not.toHaveBeenCalled();
     });
 
     it("marks the build failed when the adapter cannot start it", async () => {
@@ -220,13 +275,15 @@ describe("EnvironmentImageBuildWorkflow", () => {
     it("skips when a ready image matches the current fingerprint", async () => {
       const store = createStore();
       store.hasReadyImageForFingerprint.mockResolvedValue(true);
-      const { workflow } = createWorkflow({ store });
+      const { workflow, planBuild } = createWorkflow({ store });
 
       const result = await workflow.triggerBuildIfStale("env_1", ctx);
 
       expect(result).toEqual({ type: "up_to_date" });
       expect(store.hasReadyImageForFingerprint).toHaveBeenCalledWith("env_1", "modal", "fp-1");
       expect(store.registerBuild).not.toHaveBeenCalled();
+      // A no-op save must not decrypt secrets or mint clone tokens.
+      expect(planBuild).not.toHaveBeenCalled();
     });
 
     it("builds when no ready image matches", async () => {
@@ -357,7 +414,7 @@ describe("EnvironmentImageBuildWorkflow", () => {
       expect(store.deleteSupersededImage).toHaveBeenCalledWith("late-1");
     });
 
-    it("rejects completion the state machine no longer accepts", async () => {
+    it("rejects completion the state machine no longer accepts, recording the artifact", async () => {
       const store = readyBuildStore();
       store.tryMarkEnvironmentImageReady.mockResolvedValue({
         type: "not_accepting_completion",
@@ -371,6 +428,58 @@ describe("EnvironmentImageBuildWorkflow", () => {
           context: ctx,
         })
       ).rejects.toBeInstanceOf(EnvironmentImageCompletionNotAcceptedError);
+      // Superseded mid-transition: the artifact must reach the reaper.
+      expect(store.recordArtifactOnSupersededBuild).toHaveBeenCalledWith(
+        "envimg-env_1-1-abcd",
+        "modal",
+        "im-modal-1"
+      );
+    });
+
+    it("records the artifact of an out-of-band superseded build before rejecting", async () => {
+      const store = createStore();
+      store.getCallbackBuild.mockResolvedValue(null);
+      store.getBuildRow.mockResolvedValue({
+        id: "envimg-env_1-1-abcd",
+        environment_id: "env_1",
+        provider: "modal",
+        status: "superseded",
+      });
+      const { workflow } = createWorkflow({ store });
+
+      await expect(
+        workflow.acceptBuildComplete({
+          completion: validCompletion(),
+          authorizationHeader: await validAuthHeader(),
+          context: ctx,
+        })
+      ).rejects.toBeInstanceOf(EnvironmentImageCompletionNotAcceptedError);
+      expect(store.recordArtifactOnSupersededBuild).toHaveBeenCalledWith(
+        "envimg-env_1-1-abcd",
+        "modal",
+        "im-modal-1"
+      );
+    });
+
+    it("never records late artifacts for unauthenticated callers", async () => {
+      const store = createStore();
+      store.getCallbackBuild.mockResolvedValue(null);
+      store.getBuildRow.mockResolvedValue({
+        id: "envimg-env_1-1-abcd",
+        environment_id: "env_1",
+        provider: "modal",
+        status: "superseded",
+      });
+      const { workflow } = createWorkflow({ store });
+
+      await expect(
+        workflow.acceptBuildComplete({
+          completion: validCompletion(),
+          authorizationHeader: "Bearer forged",
+          context: ctx,
+        })
+      ).rejects.toBeInstanceOf(EnvironmentImageCallbackAuthRejectedError);
+      expect(store.recordArtifactOnSupersededBuild).not.toHaveBeenCalled();
     });
   });
 
@@ -433,13 +542,26 @@ describe("EnvironmentImageBuildWorkflow", () => {
       return store;
     }
 
+    const bearerCallbackAuth = () =>
+      vi.fn().mockResolvedValue({
+        kind: "bearer_token",
+        token: "callback-token",
+        tokenHash: "hash-1",
+        expiresAt: 9_999_999_999_999,
+      });
+
     it("registers the callback token and binds the provider session on trigger", async () => {
       const planBuild = vi.fn().mockResolvedValue(vercelPlannedBuild());
       const adapter = createAdapter();
       adapter.startBuild.mockImplementation(async (_plan, callbacks) => {
         await callbacks.bindProviderSession("vercel-session-1");
       });
-      const { workflow, store } = createWorkflow({ planBuild, adapter, provider: "vercel" });
+      const { workflow, store } = createWorkflow({
+        planBuild,
+        adapter,
+        provider: "vercel",
+        createCallbackAuth: bearerCallbackAuth(),
+      });
 
       const result = await workflow.triggerBuild("env_1", ctx);
 
@@ -465,7 +587,12 @@ describe("EnvironmentImageBuildWorkflow", () => {
         await callbacks.bindProviderSession("vercel-session-1");
         throw new Error("launch failed");
       });
-      const { workflow, store } = createWorkflow({ planBuild, adapter, provider: "vercel" });
+      const { workflow, store } = createWorkflow({
+        planBuild,
+        adapter,
+        provider: "vercel",
+        createCallbackAuth: bearerCallbackAuth(),
+      });
 
       await expect(workflow.triggerBuild("env_1", ctx)).rejects.toBeInstanceOf(
         EnvironmentImageTriggerFailedError

--- a/packages/control-plane/src/environment-images/workflow.test.ts
+++ b/packages/control-plane/src/environment-images/workflow.test.ts
@@ -68,7 +68,7 @@ function plannedBuild(overrides: Record<string, unknown> = {}): PlannedEnvironme
       buildId: "envimg-env_1-1-abcd",
       environmentId: "env_1",
       repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
-      membersFingerprint: "fp-1",
+      repositoriesFingerprint: "fp-1",
       callbackUrl: "https://worker.test/environment-images/build-complete",
       buildTimeoutMs: 1800_000,
       correlation: { trace_id: "t", request_id: "r" },
@@ -86,7 +86,7 @@ function vercelPlannedBuild(): PlannedEnvironmentImageBuild {
       buildId: "envimg-env_1-1-abcd",
       environmentId: "env_1",
       repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
-      membersFingerprint: "fp-1",
+      repositoriesFingerprint: "fp-1",
       callbackUrl: "https://worker.test/environment-images/build-complete",
       buildTimeoutMs: 1800_000,
       correlation: { trace_id: "t", request_id: "r" },
@@ -118,7 +118,7 @@ function createWorkflow(options: {
     options.resolveTarget ??
     vi.fn().mockResolvedValue({
       repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
-      membersFingerprint: "fp-1",
+      repositoriesFingerprint: "fp-1",
     });
   const createCallbackAuth =
     options.createCallbackAuth ?? vi.fn().mockResolvedValue({ kind: "none" });
@@ -144,7 +144,7 @@ function validCompletion(overrides: Record<string, unknown> = {}) {
   return {
     buildId: "envimg-env_1-1-abcd",
     providerImageId: "im-modal-1",
-    memberShas: [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
+    repositoryShas: [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
     runtimeVersion: "v53-list-native-runtime",
     buildDurationMs: 12_500,
     ...overrides,
@@ -169,7 +169,7 @@ describe("EnvironmentImageBuildWorkflow", () => {
         id: result.buildId,
         environmentId: "env_1",
         provider: "modal",
-        membersFingerprint: "fp-1",
+        repositoriesFingerprint: "fp-1",
       });
       expect(adapter.startBuild).toHaveBeenCalledTimes(1);
     });
@@ -225,7 +225,7 @@ describe("EnvironmentImageBuildWorkflow", () => {
           planBuild: vi.fn(),
           resolveTarget: vi.fn().mockResolvedValue({
             repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
-            membersFingerprint: "fp-1",
+            repositoriesFingerprint: "fp-1",
           }),
           createCallbackAuth: vi.fn().mockResolvedValue({ kind: "none" }),
         } as unknown as ConstructorParameters<typeof EnvironmentImageBuildWorkflow>[4]
@@ -335,8 +335,8 @@ describe("EnvironmentImageBuildWorkflow", () => {
 
     it.each([
       ["missing provider_image_id", { providerImageId: undefined }],
-      ["missing member_shas", { memberShas: undefined }],
-      ["empty member_shas", { memberShas: [] }],
+      ["missing repository_shas", { repositoryShas: undefined }],
+      ["empty repository_shas", { repositoryShas: [] }],
       ["missing runtime_version", { runtimeVersion: undefined }],
       ["unparseable runtime_version", { runtimeVersion: "53-no-prefix" }],
       ["negative duration", { buildDurationMs: -1 }],

--- a/packages/control-plane/src/environment-images/workflow.test.ts
+++ b/packages/control-plane/src/environment-images/workflow.test.ts
@@ -32,6 +32,9 @@ function createStore() {
     getActiveBuild: vi.fn().mockResolvedValue(null),
     hasReadyImageForFingerprint: vi.fn().mockResolvedValue(false),
     getCallbackBuild: vi.fn().mockResolvedValue(null),
+    bindProviderSession: vi.fn().mockResolvedValue(true),
+    consumeCallbackToken: vi.fn().mockResolvedValue(null),
+    markBuildFailedWithCallbackToken: vi.fn().mockResolvedValue(false),
     tryMarkEnvironmentImageReady: vi.fn(),
     markBuildFailed: vi.fn().mockResolvedValue(true),
     deleteSupersededImage: vi.fn().mockResolvedValue(true),
@@ -48,6 +51,12 @@ function createAdapter() {
   return {
     startBuild: vi.fn().mockResolvedValue(undefined),
     deleteImage: vi.fn().mockResolvedValue(undefined),
+    finalizeSuccessfulBuild: vi.fn().mockResolvedValue({
+      providerImageId: "im-finalized",
+      providerSessionId: "vercel-session-1",
+    }),
+    cleanupFailedBuild: vi.fn().mockResolvedValue(undefined),
+    cleanupCompletedBuild: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -69,12 +78,31 @@ function plannedBuild(overrides: Record<string, unknown> = {}): PlannedEnvironme
   };
 }
 
+function vercelPlannedBuild(): PlannedEnvironmentImageBuild {
+  return {
+    plan: {
+      buildId: "envimg-env_1-1-abcd",
+      environmentId: "env_1",
+      repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
+      membersFingerprint: "fp-1",
+      callbackUrl: "https://worker.test/environment-images/build-complete",
+      buildTimeoutMs: 1800_000,
+      correlation: { trace_id: "t", request_id: "r" },
+      provider: "vercel",
+      callbackMode: "provider_session",
+      callbackToken: "callback-token",
+      cloneAuth: { type: "unavailable" },
+    },
+    callbackAuth: { type: "bearer_token", tokenHash: "hash-1", expiresAt: 9_999_999_999_999 },
+  };
+}
+
 function createWorkflow(options: {
   store?: ReturnType<typeof createStore>;
   adapter?: ReturnType<typeof createAdapter>;
   planBuild?: ReturnType<typeof vi.fn>;
   env?: Env;
-  provider?: "modal" | null;
+  provider?: "modal" | "vercel" | "opencomputer" | null;
 }) {
   const store = options.store ?? createStore();
   const adapter = options.adapter ?? createAdapter();
@@ -382,6 +410,219 @@ describe("EnvironmentImageBuildWorkflow", () => {
           context: ctx,
         })
       ).rejects.toBeInstanceOf(EnvironmentImageFailureNotAcceptedError);
+    });
+  });
+
+  describe("provider_session builds (Vercel/OpenComputer)", () => {
+    function sessionBuildStore() {
+      const store = createStore();
+      store.getCallbackBuild.mockResolvedValue({
+        id: "envimg-env_1-1-abcd",
+        environmentId: "env_1",
+        provider: "vercel",
+        providerSessionId: "vercel-session-1",
+        status: "building",
+      });
+      store.consumeCallbackToken.mockResolvedValue({
+        id: "envimg-env_1-1-abcd",
+        environmentId: "env_1",
+        provider: "vercel",
+        providerSessionId: "vercel-session-1",
+        status: "building",
+      });
+      return store;
+    }
+
+    it("registers the callback token and binds the provider session on trigger", async () => {
+      const planBuild = vi.fn().mockResolvedValue(vercelPlannedBuild());
+      const adapter = createAdapter();
+      adapter.startBuild.mockImplementation(async (_plan, callbacks) => {
+        await callbacks.bindProviderSession("vercel-session-1");
+      });
+      const { workflow, store } = createWorkflow({ planBuild, adapter, provider: "vercel" });
+
+      const result = await workflow.triggerBuild("env_1", ctx);
+
+      expect(result.type).toBe("triggered");
+      expect(store.registerBuild).toHaveBeenCalledWith(
+        expect.objectContaining({
+          provider: "vercel",
+          callbackTokenHash: "hash-1",
+          callbackTokenExpiresAt: 9_999_999_999_999,
+        })
+      );
+      expect(store.bindProviderSession).toHaveBeenCalledWith(
+        expect.stringMatching(/^envimg-env_1-/),
+        "vercel",
+        "vercel-session-1"
+      );
+    });
+
+    it("tears down the build sandbox when the trigger fails after binding", async () => {
+      const planBuild = vi.fn().mockResolvedValue(vercelPlannedBuild());
+      const adapter = createAdapter();
+      adapter.startBuild.mockImplementation(async (_plan, callbacks) => {
+        await callbacks.bindProviderSession("vercel-session-1");
+        throw new Error("launch failed");
+      });
+      const { workflow, store } = createWorkflow({ planBuild, adapter, provider: "vercel" });
+
+      await expect(workflow.triggerBuild("env_1", ctx)).rejects.toBeInstanceOf(
+        EnvironmentImageTriggerFailedError
+      );
+      expect(adapter.cleanupFailedBuild).toHaveBeenCalledWith(
+        expect.objectContaining({
+          providerSessionId: "vercel-session-1",
+          errorMessage: "launch failed",
+        })
+      );
+      expect(store.markBuildFailed).toHaveBeenCalled();
+    });
+
+    it("accepts completion with a valid callback token and finalizes deferred", async () => {
+      const store = sessionBuildStore();
+      store.tryMarkEnvironmentImageReady.mockResolvedValue({
+        type: "marked_ready",
+        supersededImages: [],
+      });
+      const adapter = createAdapter();
+      const { workflow } = createWorkflow({ store, adapter });
+
+      const result = await workflow.acceptBuildComplete({
+        completion: validCompletion({
+          providerImageId: undefined,
+          providerSessionId: "vercel-session-1",
+        }),
+        callbackToken: "callback-token",
+        context: ctx,
+      });
+
+      expect(result.type).toBe("completion_accepted");
+      if (result.type !== "completion_accepted") throw new Error("unreachable");
+      await result.finalization;
+
+      expect(store.consumeCallbackToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          buildId: "envimg-env_1-1-abcd",
+          provider: "vercel",
+          providerSessionId: "vercel-session-1",
+        })
+      );
+      expect(adapter.finalizeSuccessfulBuild).toHaveBeenCalledWith(
+        expect.objectContaining({ providerSessionId: "vercel-session-1" })
+      );
+      // The artifact id comes from finalization, never the callback.
+      expect(store.tryMarkEnvironmentImageReady).toHaveBeenCalledWith(
+        "envimg-env_1-1-abcd",
+        "vercel",
+        "im-finalized",
+        [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
+        "v53-list-native-runtime",
+        12_500
+      );
+      expect(adapter.cleanupCompletedBuild).toHaveBeenCalled();
+    });
+
+    it("rejects completion when the callback token does not consume", async () => {
+      const store = sessionBuildStore();
+      store.consumeCallbackToken.mockResolvedValue(null);
+      const { workflow } = createWorkflow({ store });
+
+      await expect(
+        workflow.acceptBuildComplete({
+          completion: validCompletion({
+            providerImageId: undefined,
+            providerSessionId: "vercel-session-1",
+          }),
+          callbackToken: "stale-token",
+          context: ctx,
+        })
+      ).rejects.toBeInstanceOf(EnvironmentImageCallbackAuthRejectedError);
+    });
+
+    it("requires provider_session_id on provider-session completions", async () => {
+      const { workflow } = createWorkflow({ store: sessionBuildStore() });
+
+      await expect(
+        workflow.acceptBuildComplete({
+          completion: validCompletion({ providerImageId: undefined }),
+          callbackToken: "callback-token",
+          context: ctx,
+        })
+      ).rejects.toBeInstanceOf(EnvironmentImageInvalidCallbackError);
+    });
+
+    it("marks the build failed when deferred finalization fails", async () => {
+      const store = sessionBuildStore();
+      const adapter = createAdapter();
+      adapter.finalizeSuccessfulBuild.mockRejectedValue(new Error("snapshot failed"));
+      const { workflow } = createWorkflow({ store, adapter });
+
+      const result = await workflow.acceptBuildComplete({
+        completion: validCompletion({
+          providerImageId: undefined,
+          providerSessionId: "vercel-session-1",
+        }),
+        callbackToken: "callback-token",
+        context: ctx,
+      });
+      if (result.type !== "completion_accepted") throw new Error("unreachable");
+      await result.finalization;
+
+      expect(store.markBuildFailed).toHaveBeenCalledWith(
+        "envimg-env_1-1-abcd",
+        "vercel",
+        "snapshot failed"
+      );
+      expect(adapter.cleanupCompletedBuild).toHaveBeenCalled();
+    });
+
+    it("marks provider-session failures through the callback token", async () => {
+      const store = sessionBuildStore();
+      store.markBuildFailedWithCallbackToken.mockResolvedValue(true);
+      const adapter = createAdapter();
+      const { workflow } = createWorkflow({ store, adapter });
+
+      const result = await workflow.acceptBuildFailed({
+        failure: {
+          buildId: "envimg-env_1-1-abcd",
+          providerSessionId: "vercel-session-1",
+          errorMessage: "setup.failed: boom",
+        },
+        callbackToken: "callback-token",
+        context: ctx,
+      });
+
+      expect(result.type).toBe("build_failed");
+      if (result.type !== "build_failed") throw new Error("unreachable");
+      await result.cleanup;
+      expect(store.markBuildFailedWithCallbackToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          buildId: "envimg-env_1-1-abcd",
+          provider: "vercel",
+          providerSessionId: "vercel-session-1",
+          error: "setup.failed: boom",
+        })
+      );
+      expect(adapter.cleanupFailedBuild).toHaveBeenCalled();
+    });
+
+    it("rejects provider-session failures whose token does not consume", async () => {
+      const store = sessionBuildStore();
+      store.markBuildFailedWithCallbackToken.mockResolvedValue(false);
+      const { workflow } = createWorkflow({ store });
+
+      await expect(
+        workflow.acceptBuildFailed({
+          failure: {
+            buildId: "envimg-env_1-1-abcd",
+            providerSessionId: "vercel-session-1",
+            errorMessage: "boom",
+          },
+          callbackToken: "stale-token",
+          context: ctx,
+        })
+      ).rejects.toBeInstanceOf(EnvironmentImageCallbackAuthRejectedError);
     });
   });
 

--- a/packages/control-plane/src/environment-images/workflow.test.ts
+++ b/packages/control-plane/src/environment-images/workflow.test.ts
@@ -28,7 +28,7 @@ function createEnv(overrides: Partial<Env> = {}): Env {
 
 function createStore() {
   return {
-    registerBuild: vi.fn().mockResolvedValue(undefined),
+    registerBuild: vi.fn().mockResolvedValue(true),
     getActiveBuild: vi.fn().mockResolvedValue(null),
     hasReadyImageForFingerprint: vi.fn().mockResolvedValue(false),
     getCallbackBuild: vi.fn().mockResolvedValue(null),
@@ -45,7 +45,7 @@ function createStore() {
     deleteOldFailedBuilds: vi.fn().mockResolvedValue(0),
     markStaleBuildsAsFailed: vi.fn().mockResolvedValue(0),
     getStatus: vi.fn().mockResolvedValue([]),
-    getAllStatus: vi.fn().mockResolvedValue([]),
+    getStatusForEnabledEnvironments: vi.fn().mockResolvedValue([]),
   };
 }
 
@@ -184,6 +184,26 @@ describe("EnvironmentImageBuildWorkflow", () => {
       expect(result).toEqual({ type: "already_building", buildId: "envimg-existing" });
       expect(planBuild).not.toHaveBeenCalled();
       expect(store.registerBuild).not.toHaveBeenCalled();
+    });
+
+    it("yields to a concurrent trigger that wins the registerBuild guard", async () => {
+      // The getActiveBuild read races: both triggers can pass it, but the
+      // registerBuild NOT EXISTS guard admits exactly one. The loser must
+      // report the winner's build, not start provider work.
+      const store = createStore();
+      store.getActiveBuild
+        .mockResolvedValueOnce(null) // pre-register short-circuit: nothing yet
+        .mockResolvedValueOnce({ id: "envimg-winner" }); // re-read after losing
+      store.registerBuild.mockResolvedValue(false);
+      const { workflow, adapter, planBuild } = createWorkflow({ store });
+
+      const result = await workflow.triggerBuild("env_1", ctx);
+
+      expect(result).toEqual({ type: "already_building", buildId: "envimg-winner" });
+      expect(planBuild).not.toHaveBeenCalled();
+      expect(adapter.startBuild).not.toHaveBeenCalled();
+      // The loser's phantom id must not be failed — no row was written.
+      expect(store.markBuildFailed).not.toHaveBeenCalled();
     });
 
     it("propagates environment-not-found from target resolution without writing a row", async () => {
@@ -700,6 +720,40 @@ describe("EnvironmentImageBuildWorkflow", () => {
         "envimg-env_1-1-abcd",
         "vercel",
         "snapshot failed"
+      );
+      expect(adapter.cleanupCompletedBuild).toHaveBeenCalled();
+    });
+
+    it("reclaims the finalized snapshot when the ready transition fails after it", async () => {
+      // finalize succeeded (artifact exists provider-side) but the D1 ready
+      // transition threw: nothing recorded the artifact id, so the deferred
+      // path must delete it and fail the build — not leave the row building
+      // with an orphaned snapshot.
+      const store = sessionBuildStore();
+      store.tryMarkEnvironmentImageReady.mockRejectedValue(new Error("D1 unavailable"));
+      const adapter = createAdapter();
+      const { workflow } = createWorkflow({ store, adapter });
+
+      const result = await workflow.acceptBuildComplete({
+        completion: validCompletion({
+          providerImageId: undefined,
+          providerSessionId: "vercel-session-1",
+        }),
+        callbackToken: "callback-token",
+        context: ctx,
+      });
+      if (result.type !== "completion_accepted") throw new Error("unreachable");
+      await result.finalization;
+
+      expect(adapter.deleteImage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          image: expect.objectContaining({ providerImageId: "im-finalized" }),
+        })
+      );
+      expect(store.markBuildFailed).toHaveBeenCalledWith(
+        "envimg-env_1-1-abcd",
+        "vercel",
+        "D1 unavailable"
       );
       expect(adapter.cleanupCompletedBuild).toHaveBeenCalled();
     });

--- a/packages/control-plane/src/environment-images/workflow.test.ts
+++ b/packages/control-plane/src/environment-images/workflow.test.ts
@@ -1,0 +1,431 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { generateInternalToken } from "../auth/internal";
+import type { EnvironmentImageStore } from "../db/environment-images";
+import type { Env } from "../types";
+import {
+  EnvironmentImageCallbackAuthRejectedError,
+  EnvironmentImageCompletionNotAcceptedError,
+  EnvironmentImageEnvironmentNotFoundError,
+  EnvironmentImageFailureNotAcceptedError,
+  EnvironmentImageInvalidCallbackError,
+  EnvironmentImageTriggerFailedError,
+  EnvironmentImageWorkflowUnavailableError,
+} from "./errors";
+import type { EnvironmentImageBuildAdapterFactory } from "./provider-factory";
+import type { PlannedEnvironmentImageBuild } from "./types";
+import { EnvironmentImageBuildWorkflow } from "./workflow";
+
+const INTERNAL_SECRET = "test-internal-secret";
+
+function createEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    DB: {} as D1Database,
+    WORKER_URL: "https://worker.test",
+    INTERNAL_CALLBACK_SECRET: INTERNAL_SECRET,
+    ...overrides,
+  } as Env;
+}
+
+function createStore() {
+  return {
+    registerBuild: vi.fn().mockResolvedValue(undefined),
+    getActiveBuild: vi.fn().mockResolvedValue(null),
+    hasReadyImageForFingerprint: vi.fn().mockResolvedValue(false),
+    getCallbackBuild: vi.fn().mockResolvedValue(null),
+    tryMarkEnvironmentImageReady: vi.fn(),
+    markBuildFailed: vi.fn().mockResolvedValue(true),
+    deleteSupersededImage: vi.fn().mockResolvedValue(true),
+    supersedeActiveImages: vi.fn().mockResolvedValue(0),
+    getSupersededImages: vi.fn().mockResolvedValue([]),
+    deleteOldFailedBuilds: vi.fn().mockResolvedValue(0),
+    markStaleBuildsAsFailed: vi.fn().mockResolvedValue(0),
+    getStatus: vi.fn().mockResolvedValue([]),
+    getAllStatus: vi.fn().mockResolvedValue([]),
+  };
+}
+
+function createAdapter() {
+  return {
+    startBuild: vi.fn().mockResolvedValue(undefined),
+    deleteImage: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function plannedBuild(overrides: Record<string, unknown> = {}): PlannedEnvironmentImageBuild {
+  return {
+    plan: {
+      buildId: "envimg-env_1-1-abcd",
+      environmentId: "env_1",
+      repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
+      membersFingerprint: "fp-1",
+      callbackUrl: "https://worker.test/environment-images/build-complete",
+      buildTimeoutMs: 1800_000,
+      correlation: { trace_id: "t", request_id: "r" },
+      provider: "modal",
+      callbackMode: "provider_image",
+      ...overrides,
+    },
+    callbackAuth: { type: "none" },
+  };
+}
+
+function createWorkflow(options: {
+  store?: ReturnType<typeof createStore>;
+  adapter?: ReturnType<typeof createAdapter>;
+  planBuild?: ReturnType<typeof vi.fn>;
+  env?: Env;
+  provider?: "modal" | null;
+}) {
+  const store = options.store ?? createStore();
+  const adapter = options.adapter ?? createAdapter();
+  const factory: EnvironmentImageBuildAdapterFactory = {
+    create: vi.fn().mockReturnValue(adapter),
+  };
+  const planBuild = options.planBuild ?? vi.fn().mockResolvedValue(plannedBuild());
+  const workflow = new EnvironmentImageBuildWorkflow(
+    options.env ?? createEnv(),
+    store as unknown as EnvironmentImageStore,
+    factory,
+    options.provider === undefined ? "modal" : options.provider,
+    { planBuild } as unknown as ConstructorParameters<typeof EnvironmentImageBuildWorkflow>[4]
+  );
+  return { workflow, store, adapter, factory, planBuild };
+}
+
+const ctx = { trace_id: "t", request_id: "r" };
+
+async function validAuthHeader(): Promise<string> {
+  return `Bearer ${await generateInternalToken(INTERNAL_SECRET)}`;
+}
+
+function validCompletion(overrides: Record<string, unknown> = {}) {
+  return {
+    buildId: "envimg-env_1-1-abcd",
+    providerImageId: "im-modal-1",
+    memberShas: [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
+    runtimeVersion: "v53-list-native-runtime",
+    buildDurationMs: 12_500,
+    ...overrides,
+  };
+}
+
+describe("EnvironmentImageBuildWorkflow", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("triggerBuild", () => {
+    it("plans, registers, and starts a build", async () => {
+      const { workflow, store, adapter } = createWorkflow({});
+
+      const result = await workflow.triggerBuild("env_1", ctx);
+
+      expect(result.type).toBe("triggered");
+      if (result.type !== "triggered") throw new Error("unreachable");
+      expect(result.buildId).toMatch(/^envimg-env_1-\d+-/);
+      expect(store.registerBuild).toHaveBeenCalledWith({
+        id: result.buildId,
+        environmentId: "env_1",
+        provider: "modal",
+        membersFingerprint: "fp-1",
+      });
+      expect(adapter.startBuild).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports the in-flight build instead of stacking another", async () => {
+      const store = createStore();
+      store.getActiveBuild.mockResolvedValue({ id: "envimg-existing" });
+      const { workflow, planBuild } = createWorkflow({ store });
+
+      const result = await workflow.triggerBuild("env_1", ctx);
+
+      expect(result).toEqual({ type: "already_building", buildId: "envimg-existing" });
+      expect(planBuild).not.toHaveBeenCalled();
+      expect(store.registerBuild).not.toHaveBeenCalled();
+    });
+
+    it("propagates environment-not-found from the planner", async () => {
+      const planBuild = vi
+        .fn()
+        .mockRejectedValue(new EnvironmentImageEnvironmentNotFoundError("env_missing"));
+      const { workflow, store } = createWorkflow({ planBuild });
+
+      await expect(workflow.triggerBuild("env_missing", ctx)).rejects.toBeInstanceOf(
+        EnvironmentImageEnvironmentNotFoundError
+      );
+      expect(store.registerBuild).not.toHaveBeenCalled();
+    });
+
+    it("marks the build failed when the adapter cannot start it", async () => {
+      const adapter = createAdapter();
+      adapter.startBuild.mockRejectedValue(new Error("modal down"));
+      const { workflow, store } = createWorkflow({ adapter });
+
+      await expect(workflow.triggerBuild("env_1", ctx)).rejects.toBeInstanceOf(
+        EnvironmentImageTriggerFailedError
+      );
+      expect(store.markBuildFailed).toHaveBeenCalledWith(
+        expect.stringMatching(/^envimg-env_1-/),
+        "modal",
+        "modal down"
+      );
+    });
+
+    it("is unavailable without a provider", async () => {
+      const { workflow } = createWorkflow({ provider: null });
+
+      await expect(workflow.triggerBuild("env_1", ctx)).rejects.toBeInstanceOf(
+        EnvironmentImageWorkflowUnavailableError
+      );
+    });
+
+    it("is unavailable without WORKER_URL", async () => {
+      const { workflow } = createWorkflow({ env: createEnv({ WORKER_URL: undefined }) });
+
+      await expect(workflow.triggerBuild("env_1", ctx)).rejects.toBeInstanceOf(
+        EnvironmentImageWorkflowUnavailableError
+      );
+    });
+  });
+
+  describe("triggerBuildIfStale", () => {
+    it("skips when a ready image matches the current fingerprint", async () => {
+      const store = createStore();
+      store.hasReadyImageForFingerprint.mockResolvedValue(true);
+      const { workflow } = createWorkflow({ store });
+
+      const result = await workflow.triggerBuildIfStale("env_1", ctx);
+
+      expect(result).toEqual({ type: "up_to_date" });
+      expect(store.hasReadyImageForFingerprint).toHaveBeenCalledWith("env_1", "modal", "fp-1");
+      expect(store.registerBuild).not.toHaveBeenCalled();
+    });
+
+    it("builds when no ready image matches", async () => {
+      const { workflow, store } = createWorkflow({});
+
+      const result = await workflow.triggerBuildIfStale("env_1", ctx);
+
+      expect(result.type).toBe("triggered");
+      expect(store.registerBuild).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("acceptBuildComplete", () => {
+    function readyBuildStore() {
+      const store = createStore();
+      store.getCallbackBuild.mockResolvedValue({
+        id: "envimg-env_1-1-abcd",
+        environmentId: "env_1",
+        provider: "modal",
+        providerSessionId: null,
+        status: "building",
+      });
+      return store;
+    }
+
+    it("rejects unknown builds", async () => {
+      const { workflow } = createWorkflow({});
+
+      await expect(
+        workflow.acceptBuildComplete({
+          completion: validCompletion(),
+          authorizationHeader: await validAuthHeader(),
+          context: ctx,
+        })
+      ).rejects.toBeInstanceOf(EnvironmentImageCompletionNotAcceptedError);
+    });
+
+    it("rejects bad internal auth", async () => {
+      const { workflow } = createWorkflow({ store: readyBuildStore() });
+
+      await expect(
+        workflow.acceptBuildComplete({
+          completion: validCompletion(),
+          authorizationHeader: "Bearer forged",
+          context: ctx,
+        })
+      ).rejects.toBeInstanceOf(EnvironmentImageCallbackAuthRejectedError);
+    });
+
+    it.each([
+      ["missing provider_image_id", { providerImageId: undefined }],
+      ["missing member_shas", { memberShas: undefined }],
+      ["empty member_shas", { memberShas: [] }],
+      ["missing runtime_version", { runtimeVersion: undefined }],
+      ["unparseable runtime_version", { runtimeVersion: "53-no-prefix" }],
+      ["negative duration", { buildDurationMs: -1 }],
+    ])("fails closed on %s", async (_label, overrides) => {
+      const { workflow, store } = createWorkflow({ store: readyBuildStore() });
+
+      await expect(
+        workflow.acceptBuildComplete({
+          completion: validCompletion(overrides),
+          authorizationHeader: await validAuthHeader(),
+          context: ctx,
+        })
+      ).rejects.toBeInstanceOf(EnvironmentImageInvalidCallbackError);
+      expect(store.tryMarkEnvironmentImageReady).not.toHaveBeenCalled();
+    });
+
+    it("marks ready and deletes replaced artifacts", async () => {
+      const store = readyBuildStore();
+      store.tryMarkEnvironmentImageReady.mockResolvedValue({
+        type: "marked_ready",
+        supersededImages: [
+          { environmentImageId: "old-1", image: { providerImageId: "im-old" } },
+          { environmentImageId: "old-2", image: { providerImageId: "" } },
+        ],
+      });
+      const adapter = createAdapter();
+      const { workflow } = createWorkflow({ store, adapter });
+
+      const result = await workflow.acceptBuildComplete({
+        completion: validCompletion(),
+        authorizationHeader: await validAuthHeader(),
+        context: ctx,
+      });
+
+      expect(store.tryMarkEnvironmentImageReady).toHaveBeenCalledWith(
+        "envimg-env_1-1-abcd",
+        "modal",
+        "im-modal-1",
+        [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }],
+        "v53-list-native-runtime",
+        12_500
+      );
+      expect(result.type).toBe("build_ready");
+      if (result.type !== "build_ready") throw new Error("unreachable");
+      await result.cleanup;
+      // Artifact-bearing row: provider delete then row delete. Artifact-less
+      // row: left for the reaper.
+      expect(adapter.deleteImage).toHaveBeenCalledTimes(1);
+      expect(adapter.deleteImage).toHaveBeenCalledWith(
+        expect.objectContaining({ image: expect.objectContaining({ providerImageId: "im-old" }) })
+      );
+      expect(store.deleteSupersededImage).toHaveBeenCalledTimes(1);
+      expect(store.deleteSupersededImage).toHaveBeenCalledWith("old-1");
+    });
+
+    it("reports a late build superseded by a newer ready image", async () => {
+      const store = readyBuildStore();
+      store.tryMarkEnvironmentImageReady.mockResolvedValue({
+        type: "superseded_by_newer_ready",
+        supersededImage: { environmentImageId: "late-1", image: { providerImageId: "im-late" } },
+      });
+      const adapter = createAdapter();
+      const { workflow } = createWorkflow({ store, adapter });
+
+      const result = await workflow.acceptBuildComplete({
+        completion: validCompletion(),
+        authorizationHeader: await validAuthHeader(),
+        context: ctx,
+      });
+
+      expect(result.type).toBe("build_superseded");
+      if (result.type !== "build_superseded") throw new Error("unreachable");
+      await result.cleanup;
+      expect(adapter.deleteImage).toHaveBeenCalledTimes(1);
+      expect(store.deleteSupersededImage).toHaveBeenCalledWith("late-1");
+    });
+
+    it("rejects completion the state machine no longer accepts", async () => {
+      const store = readyBuildStore();
+      store.tryMarkEnvironmentImageReady.mockResolvedValue({
+        type: "not_accepting_completion",
+      });
+      const { workflow } = createWorkflow({ store });
+
+      await expect(
+        workflow.acceptBuildComplete({
+          completion: validCompletion(),
+          authorizationHeader: await validAuthHeader(),
+          context: ctx,
+        })
+      ).rejects.toBeInstanceOf(EnvironmentImageCompletionNotAcceptedError);
+    });
+  });
+
+  describe("acceptBuildFailed", () => {
+    it("marks the build failed", async () => {
+      const store = createStore();
+      store.getCallbackBuild.mockResolvedValue({
+        id: "envimg-env_1-1-abcd",
+        environmentId: "env_1",
+        provider: "modal",
+        providerSessionId: null,
+        status: "building",
+      });
+      const { workflow } = createWorkflow({ store });
+
+      const result = await workflow.acceptBuildFailed({
+        failure: { buildId: "envimg-env_1-1-abcd", errorMessage: "setup.failed: boom" },
+        authorizationHeader: await validAuthHeader(),
+        context: ctx,
+      });
+
+      expect(result).toEqual({ type: "build_failed" });
+      expect(store.markBuildFailed).toHaveBeenCalledWith(
+        "envimg-env_1-1-abcd",
+        "modal",
+        "setup.failed: boom"
+      );
+    });
+
+    it("rejects failures for unknown builds", async () => {
+      const { workflow } = createWorkflow({});
+
+      await expect(
+        workflow.acceptBuildFailed({
+          failure: { buildId: "nope", errorMessage: "boom" },
+          authorizationHeader: await validAuthHeader(),
+          context: ctx,
+        })
+      ).rejects.toBeInstanceOf(EnvironmentImageFailureNotAcceptedError);
+    });
+  });
+
+  describe("cleanupImages", () => {
+    it("deletes old failed rows and reaps superseded artifacts", async () => {
+      const store = createStore();
+      store.deleteOldFailedBuilds.mockResolvedValue(3);
+      store.getSupersededImages.mockResolvedValue([
+        {
+          id: "s-artifact",
+          environment_id: "env_1",
+          provider: "modal",
+          provider_image_id: "im-a",
+          provider_session_id: null,
+        },
+        {
+          id: "s-bare",
+          environment_id: "env_1",
+          provider: "modal",
+          provider_image_id: null,
+          provider_session_id: null,
+        },
+        {
+          id: "s-stuck",
+          environment_id: "env_1",
+          provider: "modal",
+          provider_image_id: "im-stuck",
+          provider_session_id: null,
+        },
+      ]);
+      const adapter = createAdapter();
+      adapter.deleteImage.mockImplementation(async ({ image }) => {
+        if (image.providerImageId === "im-stuck") throw new Error("provider 500");
+      });
+      const { workflow } = createWorkflow({ store, adapter });
+
+      const result = await workflow.cleanupImages(86_400_000, ctx);
+
+      // s-artifact: artifact deleted then row reaped. s-bare: no artifact, row
+      // reaped directly. s-stuck: artifact delete failed, row kept for retry.
+      expect(result).toEqual({ deletedFailed: 3, reapedSuperseded: 2 });
+      expect(store.deleteSupersededImage).toHaveBeenCalledWith("s-artifact");
+      expect(store.deleteSupersededImage).toHaveBeenCalledWith("s-bare");
+      expect(store.deleteSupersededImage).not.toHaveBeenCalledWith("s-stuck");
+    });
+  });
+});

--- a/packages/control-plane/src/environment-images/workflow.ts
+++ b/packages/control-plane/src/environment-images/workflow.ts
@@ -22,7 +22,7 @@ import {
 } from "./errors";
 import {
   parseRuntimeVersionNumber,
-  type EnvironmentImageMemberSha,
+  type EnvironmentImageRepositorySha,
   type EnvironmentImageProvider,
   type EnvironmentImageProviderImageRef,
   type SupersededEnvironmentImage,
@@ -70,7 +70,7 @@ export interface AcceptEnvironmentBuildFailedCommand {
 /** Fields common to both callback modes; provider_image adds the artifact id. */
 interface ValidatedEnvironmentBuildCompletion {
   buildId: string;
-  memberShas: EnvironmentImageMemberSha[];
+  repositoryShas: EnvironmentImageRepositorySha[];
   runtimeVersion: string;
   buildDurationMs: number;
 }
@@ -120,7 +120,7 @@ export class EnvironmentImageBuildWorkflow {
   /**
    * Save-hook variant (design §7.3 "saving an environment triggers an
    * immediate build"): skips the build when a ready image already matches the
-   * current member set — that is the cron's trigger-1 check evaluated
+   * current repository set — that is the cron's trigger-1 check evaluated
    * eagerly. Unconditional rebuild reasons (sha drift, runtime floor) remain
    * the cron's job.
    */
@@ -167,7 +167,7 @@ export class EnvironmentImageBuildWorkflow {
         (await this.store.hasReadyImageForFingerprint(
           environmentId,
           provider,
-          target.membersFingerprint
+          target.repositoriesFingerprint
         ))
       ) {
         return { type: "up_to_date" };
@@ -202,7 +202,7 @@ export class EnvironmentImageBuildWorkflow {
         id: buildId,
         environmentId,
         provider,
-        membersFingerprint: target.membersFingerprint,
+        repositoriesFingerprint: target.repositoriesFingerprint,
         ...callbackAuthRegistration(callbackAuth),
       });
 
@@ -230,7 +230,7 @@ export class EnvironmentImageBuildWorkflow {
       logger.info("environment_image.build_triggered", {
         build_id: buildId,
         environment_id: environmentId,
-        members_fingerprint: planned.plan.membersFingerprint,
+        repositories_fingerprint: planned.plan.repositoriesFingerprint,
         request_id: ctx.request_id,
         trace_id: ctx.trace_id,
       });
@@ -393,7 +393,7 @@ export class EnvironmentImageBuildWorkflow {
         validated.buildId,
         provider,
         providerImageId,
-        validated.memberShas,
+        validated.repositoryShas,
         validated.runtimeVersion,
         validated.buildDurationMs
       );
@@ -518,7 +518,7 @@ export class EnvironmentImageBuildWorkflow {
         input.buildId,
         provider,
         finalized.providerImageId,
-        input.memberShas,
+        input.repositoryShas,
         input.runtimeVersion,
         input.buildDurationMs
       );
@@ -747,8 +747,8 @@ export class EnvironmentImageBuildWorkflow {
   private validateCompletion(
     completion: CompleteEnvironmentImageBuildCallback
   ): ValidatedEnvironmentBuildCompletion {
-    if (!completion.memberShas || completion.memberShas.length === 0) {
-      throw new EnvironmentImageInvalidCallbackError("member_shas is required");
+    if (!completion.repositoryShas || completion.repositoryShas.length === 0) {
+      throw new EnvironmentImageInvalidCallbackError("repository_shas is required");
     }
     if (
       typeof completion.runtimeVersion !== "string" ||
@@ -772,7 +772,7 @@ export class EnvironmentImageBuildWorkflow {
 
     return {
       buildId: completion.buildId,
-      memberShas: completion.memberShas,
+      repositoryShas: completion.repositoryShas,
       runtimeVersion: completion.runtimeVersion,
       buildDurationMs: completion.buildDurationMs,
     };

--- a/packages/control-plane/src/environment-images/workflow.ts
+++ b/packages/control-plane/src/environment-images/workflow.ts
@@ -198,13 +198,23 @@ export class EnvironmentImageBuildWorkflow {
     let providerSessionIdForCleanup: string | null = null;
     let startAdapter: AnyEnvironmentImageBuildAdapter | null = null;
     try {
-      await this.store.registerBuild({
+      const registered = await this.store.registerBuild({
         id: buildId,
         environmentId,
         provider,
         repositoriesFingerprint: target.repositoriesFingerprint,
         ...callbackAuthRegistration(callbackAuth),
       });
+      if (!registered) {
+        // A concurrent trigger won the registerBuild NOT EXISTS guard (the
+        // getActiveBuild read above is only a cheap short-circuit, not
+        // atomic with the insert). Report the winner's build.
+        const winner = await this.store.getActiveBuild(environmentId, provider);
+        if (!winner) {
+          throw new Error("Concurrent trigger raced registerBuild and its build is already gone");
+        }
+        return { type: "already_building", buildId: winner.id };
+      }
 
       const planned = await this.planner.planBuild({
         buildId,
@@ -500,6 +510,7 @@ export class EnvironmentImageBuildWorkflow {
   ): Promise<void> {
     const startedAt = Date.now();
     let finalized: EnvironmentImageProviderImageRef | null = null;
+    let commitResolved = false;
     let adapter: AnyEnvironmentImageBuildAdapter | null = null;
 
     try {
@@ -522,6 +533,10 @@ export class EnvironmentImageBuildWorkflow {
         input.runtimeVersion,
         input.buildDurationMs
       );
+      // Any returned variant means the row transition is settled (ready,
+      // superseded, or rejected-with-artifact-reclaimed) — from here the
+      // catch below must not fail the build or touch the artifact.
+      commitResolved = true;
 
       switch (result.type) {
         case "marked_ready": {
@@ -570,7 +585,14 @@ export class EnvironmentImageBuildWorkflow {
       if (adapter) {
         await this.cleanupCompletedBuild(provider, adapter, input, ctx);
       }
-      if (!finalized) {
+      if (!commitResolved) {
+        // The ready transition never settled: the row is still building and
+        // a snapshot taken by finalizeSuccessfulBuild would orphan — nothing
+        // records its id for the reaper — so reclaim it before failing the
+        // build.
+        if (finalized && adapter) {
+          await this.deleteImageBestEffort(provider, finalized, ctx, adapter);
+        }
         try {
           await this.store.markBuildFailed(input.buildId, provider, errorMessage(e));
         } catch (markFailedError) {

--- a/packages/control-plane/src/environment-images/workflow.ts
+++ b/packages/control-plane/src/environment-images/workflow.ts
@@ -1,7 +1,9 @@
 import { generateId } from "../auth/crypto";
 import { verifyInternalToken } from "../auth/internal";
-import { EnvironmentImageStore } from "../db/environment-images";
+import { EnvironmentImageStore, type EnvironmentImageBuild } from "../db/environment-images";
 import { createLogger } from "../logger";
+// Shared with repo images by design (§7.3): same token scheme, same provider policy.
+import { hashRepoImageCallbackToken } from "../repo-images/auth";
 import { getRepoImageCallbackMode, resolveRepoImageProvider } from "../repo-images/provider-policy";
 import type { Env } from "../types";
 import {
@@ -22,6 +24,7 @@ import {
   parseRuntimeVersionNumber,
   type EnvironmentImageMemberSha,
   type EnvironmentImageProvider,
+  type EnvironmentImageProviderImageRef,
   type SupersededEnvironmentImage,
 } from "./model";
 import { EnvironmentImageBuildPlanner } from "./planner";
@@ -34,7 +37,9 @@ import type {
   CompleteEnvironmentImageBuildCallback,
   EnvironmentImageWorkflowContext,
   EnvironmentImageWorkflowResult,
+  EnvironmentImageBuildStartCallbacks,
   FailEnvironmentImageBuildCallback,
+  PlannedEnvironmentImageBuild,
   TriggerEnvironmentImageBuildResult,
 } from "./types";
 
@@ -52,22 +57,29 @@ interface EnvironmentImageBuildPlannerLike {
 export interface AcceptEnvironmentBuildCompleteCommand {
   completion: CompleteEnvironmentImageBuildCallback;
   authorizationHeader?: string | null;
+  callbackToken?: string | null;
   context: EnvironmentImageWorkflowContext;
 }
 
 export interface AcceptEnvironmentBuildFailedCommand {
   failure: FailEnvironmentImageBuildCallback;
   authorizationHeader?: string | null;
+  callbackToken?: string | null;
   context: EnvironmentImageWorkflowContext;
 }
 
+/** Fields common to both callback modes; provider_image adds the artifact id. */
 interface ValidatedEnvironmentBuildCompletion {
   buildId: string;
-  providerImageId: string;
   memberShas: EnvironmentImageMemberSha[];
   runtimeVersion: string;
   buildDurationMs: number;
 }
+
+type PlannedBuildStart = {
+  adapter: AnyEnvironmentImageBuildAdapter;
+  start(callbacks: EnvironmentImageBuildStartCallbacks): Promise<void>;
+};
 
 /**
  * Application service for the environment image build lifecycle (design §7.3).
@@ -180,18 +192,26 @@ export class EnvironmentImageBuildWorkflow {
       return { type: "up_to_date" };
     }
 
+    let providerSessionIdForCleanup: string | null = null;
+    let startAdapter: AnyEnvironmentImageBuildAdapter | null = null;
     try {
       await this.store.registerBuild({
         id: buildId,
         environmentId,
         provider,
         membersFingerprint: planned.plan.membersFingerprint,
+        ...callbackAuthRegistration(planned),
       });
 
-      const adapter = this.createAdapterForOperation(provider, "trigger_build", ctx, buildId);
-      await adapter.startBuild(planned.plan, {
-        bindProviderSession: async () => {
-          throw new Error("provider_session builds are not supported for environment images");
+      const start = this.preparePlannedBuildStart(planned, ctx);
+      startAdapter = start.adapter;
+      await start.start({
+        bindProviderSession: async (providerSessionId) => {
+          providerSessionIdForCleanup = providerSessionId;
+          const bound = await this.store.bindProviderSession(buildId, provider, providerSessionId);
+          if (!bound) {
+            throw new Error(`Failed to bind ${provider} build session`);
+          }
         },
       });
 
@@ -205,6 +225,25 @@ export class EnvironmentImageBuildWorkflow {
 
       return { type: "triggered", buildId };
     } catch (e) {
+      if (providerSessionIdForCleanup && startAdapter?.cleanupFailedBuild) {
+        await startAdapter
+          .cleanupFailedBuild({
+            buildId,
+            providerSessionId: providerSessionIdForCleanup,
+            errorMessage: errorMessage(e),
+            correlation: ctx,
+          })
+          .catch((cleanupError) => {
+            logger.warn(`environment_image.${provider}_trigger_cleanup_failed`, {
+              build_id: buildId,
+              provider_session_id: providerSessionIdForCleanup,
+              error: errorMessage(cleanupError),
+              request_id: ctx.request_id,
+              trace_id: ctx.trace_id,
+            });
+          });
+      }
+
       try {
         await this.store.markBuildFailed(buildId, provider, errorMessage(e));
       } catch (markFailedError) {
@@ -226,6 +265,52 @@ export class EnvironmentImageBuildWorkflow {
     }
   }
 
+  /** Provider-typed start dispatch: each case keeps the plan/adapter pairing intact. */
+  private preparePlannedBuildStart(
+    planned: PlannedEnvironmentImageBuild,
+    ctx: EnvironmentImageWorkflowContext
+  ): PlannedBuildStart {
+    const plan = planned.plan;
+    switch (plan.provider) {
+      case "modal": {
+        const adapter = this.createAdapterGuarded(
+          plan.provider,
+          "trigger_build",
+          ctx,
+          () => this.adapterFactory.create("modal"),
+          plan.buildId
+        );
+        return { adapter, start: (callbacks) => adapter.startBuild(plan, callbacks) };
+      }
+      case "vercel": {
+        const adapter = this.createAdapterGuarded(
+          plan.provider,
+          "trigger_build",
+          ctx,
+          () => this.adapterFactory.create("vercel"),
+          plan.buildId
+        );
+        return { adapter, start: (callbacks) => adapter.startBuild(plan, callbacks) };
+      }
+      case "opencomputer": {
+        const adapter = this.createAdapterGuarded(
+          plan.provider,
+          "trigger_build",
+          ctx,
+          () => this.adapterFactory.create("opencomputer"),
+          plan.buildId
+        );
+        return { adapter, start: (callbacks) => adapter.startBuild(plan, callbacks) };
+      }
+      default: {
+        const exhaustive: never = plan;
+        throw new EnvironmentImageProviderUnconfiguredError(
+          `Unsupported environment image provider: ${String(exhaustive)}`
+        );
+      }
+    }
+  }
+
   async acceptBuildComplete(
     command: AcceptEnvironmentBuildCompleteCommand
   ): Promise<EnvironmentImageWorkflowResult> {
@@ -236,21 +321,59 @@ export class EnvironmentImageBuildWorkflow {
     }
 
     const provider = build.provider;
-    if (getRepoImageCallbackMode(provider) !== "provider_image") {
-      throw new EnvironmentImageInvalidCallbackError(
-        "provider_session callbacks are not supported for environment images"
+    const validated = this.validateCompletion(completion);
+
+    if (getRepoImageCallbackMode(provider) === "provider_session") {
+      // The sandbox itself reports completion with a bearer token; the
+      // artifact does not exist yet — snapshotting is the deferred
+      // finalization the route schedules via waitUntil.
+      if (!completion.providerSessionId) {
+        throw new EnvironmentImageInvalidCallbackError("provider_session_id is required");
+      }
+      const providerSessionId = completion.providerSessionId;
+
+      await this.requireTokenBuildCallbackAuth(command.callbackToken, {
+        buildId: build.id,
+        provider,
+        providerSessionId,
+        ctx,
+      });
+
+      logger.info("environment_image.build_complete_received", {
+        build_id: validated.buildId,
+        environment_id: build.environmentId,
+        provider,
+        provider_session_id: providerSessionId,
+        runtime_version: validated.runtimeVersion,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+
+      const finalization = this.finalizeAndCommit(
+        provider,
+        {
+          ...validated,
+          providerSessionId,
+          environmentId: build.environmentId,
+        },
+        ctx
       );
+
+      return { type: "completion_accepted", finalization };
     }
 
     await this.requireInternalBuildCallbackAuth(command.authorizationHeader, build.id, ctx);
-    const validated = this.validateCompletion(completion);
+    if (!completion.providerImageId) {
+      throw new EnvironmentImageInvalidCallbackError("provider_image_id is required");
+    }
+    const providerImageId = completion.providerImageId;
 
     let result;
     try {
       result = await this.store.tryMarkEnvironmentImageReady(
         validated.buildId,
         provider,
-        validated.providerImageId,
+        providerImageId,
         validated.memberShas,
         validated.runtimeVersion,
         validated.buildDurationMs
@@ -271,7 +394,7 @@ export class EnvironmentImageBuildWorkflow {
           build_id: validated.buildId,
           environment_id: build.environmentId,
           provider,
-          provider_image_id: validated.providerImageId,
+          provider_image_id: providerImageId,
           runtime_version: validated.runtimeVersion,
           replaced_image_id: result.supersededImages[0]?.image.providerImageId ?? null,
           request_id: ctx.request_id,
@@ -299,6 +422,141 @@ export class EnvironmentImageBuildWorkflow {
     }
   }
 
+  /**
+   * Deferred finalization for provider-session builds: snapshot/checkpoint the
+   * build sandbox, commit the artifact, reclaim what it replaced, tear the
+   * sandbox down. Runs behind waitUntil — errors are logged and the build is
+   * marked failed when no artifact was produced.
+   */
+  private async finalizeAndCommit(
+    provider: EnvironmentImageProvider,
+    input: ValidatedEnvironmentBuildCompletion & {
+      providerSessionId: string;
+      environmentId: string;
+    },
+    ctx: EnvironmentImageWorkflowContext
+  ): Promise<void> {
+    const startedAt = Date.now();
+    let finalized: EnvironmentImageProviderImageRef | null = null;
+    let adapter: AnyEnvironmentImageBuildAdapter | null = null;
+
+    try {
+      adapter = this.createAdapterForOperation(provider, "build_complete", ctx, input.buildId);
+      if (!adapter.finalizeSuccessfulBuild) {
+        throw new Error(`${provider} adapter cannot finalize provider-session builds`);
+      }
+
+      finalized = await adapter.finalizeSuccessfulBuild({
+        buildId: input.buildId,
+        providerSessionId: input.providerSessionId,
+        correlation: ctx,
+      });
+
+      const result = await this.store.tryMarkEnvironmentImageReady(
+        input.buildId,
+        provider,
+        finalized.providerImageId,
+        input.memberShas,
+        input.runtimeVersion,
+        input.buildDurationMs
+      );
+
+      switch (result.type) {
+        case "marked_ready": {
+          logger.info("environment_image.build_complete", {
+            build_id: input.buildId,
+            environment_id: input.environmentId,
+            provider,
+            provider_image_id: finalized.providerImageId,
+            runtime_version: input.runtimeVersion,
+            snapshot_duration_ms: Date.now() - startedAt,
+            request_id: ctx.request_id,
+            trace_id: ctx.trace_id,
+          });
+          await this.deleteReplacedImages(provider, result.supersededImages, ctx);
+          break;
+        }
+        case "superseded_by_newer_ready": {
+          logger.info("environment_image.build_superseded", {
+            build_id: input.buildId,
+            environment_id: input.environmentId,
+            provider,
+            provider_image_id: result.supersededImage.image.providerImageId,
+            request_id: ctx.request_id,
+            trace_id: ctx.trace_id,
+          });
+          await this.deleteReplacedImages(provider, [result.supersededImage], ctx);
+          break;
+        }
+        case "not_accepting_completion": {
+          // A newer build won while we were snapshotting — the artifact just
+          // produced would orphan, so reclaim it now.
+          await this.deleteImageBestEffort(provider, finalized, ctx, adapter);
+          logger.warn("environment_image.finalize_not_applied", {
+            build_id: input.buildId,
+            provider,
+            provider_image_id: finalized.providerImageId,
+            request_id: ctx.request_id,
+            trace_id: ctx.trace_id,
+          });
+          break;
+        }
+      }
+
+      await this.cleanupCompletedBuild(provider, adapter, input, ctx);
+    } catch (e) {
+      if (adapter) {
+        await this.cleanupCompletedBuild(provider, adapter, input, ctx);
+      }
+      if (!finalized) {
+        try {
+          await this.store.markBuildFailed(input.buildId, provider, errorMessage(e));
+        } catch (markFailedError) {
+          logger.error("environment_image.mark_failed_after_finalize_error", {
+            build_id: input.buildId,
+            error: errorMessage(markFailedError),
+            request_id: ctx.request_id,
+            trace_id: ctx.trace_id,
+          });
+        }
+      }
+      logger.error("environment_image.finalize_error", {
+        build_id: input.buildId,
+        provider,
+        provider_session_id: input.providerSessionId,
+        provider_image_id: finalized?.providerImageId,
+        error: errorMessage(e),
+        duration_ms: Date.now() - startedAt,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+    }
+  }
+
+  private async cleanupCompletedBuild(
+    provider: EnvironmentImageProvider,
+    adapter: AnyEnvironmentImageBuildAdapter,
+    input: { buildId: string; providerSessionId: string },
+    ctx: EnvironmentImageWorkflowContext
+  ): Promise<void> {
+    if (!adapter.cleanupCompletedBuild) return;
+    try {
+      await adapter.cleanupCompletedBuild({
+        buildId: input.buildId,
+        providerSessionId: input.providerSessionId,
+        correlation: ctx,
+      });
+    } catch (e) {
+      logger.warn(`environment_image.${provider}_completed_build_cleanup_failed`, {
+        build_id: input.buildId,
+        provider_session_id: input.providerSessionId,
+        error: errorMessage(e),
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+    }
+  }
+
   async acceptBuildFailed(
     command: AcceptEnvironmentBuildFailedCommand
   ): Promise<EnvironmentImageWorkflowResult> {
@@ -306,6 +564,37 @@ export class EnvironmentImageBuildWorkflow {
     const build = await this.store.getCallbackBuild(failure.buildId);
     if (!build) {
       throw new EnvironmentImageFailureNotAcceptedError("Build is not accepting failure");
+    }
+
+    if (getRepoImageCallbackMode(build.provider) === "provider_session") {
+      if (!failure.providerSessionId) {
+        throw new EnvironmentImageInvalidCallbackError("provider_session_id is required");
+      }
+      const providerSessionId = failure.providerSessionId;
+
+      await this.markProviderSessionBuildFailedWithCallbackToken(
+        build.provider,
+        { buildId: failure.buildId, providerSessionId, errorMessage: failure.errorMessage },
+        command.callbackToken,
+        ctx
+      );
+
+      logger.info("environment_image.build_failed", {
+        build_id: failure.buildId,
+        environment_id: build.environmentId,
+        provider: build.provider,
+        error_message: failure.errorMessage,
+        provider_session_id: providerSessionId,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+
+      const cleanup = this.cleanupFailedBuildBestEffort(
+        build.provider,
+        { buildId: failure.buildId, providerSessionId, errorMessage: failure.errorMessage },
+        ctx
+      );
+      return cleanup ? { type: "build_failed", cleanup } : { type: "build_failed" };
     }
 
     await this.requireInternalBuildCallbackAuth(command.authorizationHeader, build.id, ctx);
@@ -386,9 +675,6 @@ export class EnvironmentImageBuildWorkflow {
   private validateCompletion(
     completion: CompleteEnvironmentImageBuildCallback
   ): ValidatedEnvironmentBuildCompletion {
-    if (!completion.providerImageId) {
-      throw new EnvironmentImageInvalidCallbackError("provider_image_id is required");
-    }
     if (!completion.memberShas || completion.memberShas.length === 0) {
       throw new EnvironmentImageInvalidCallbackError("member_shas is required");
     }
@@ -414,11 +700,147 @@ export class EnvironmentImageBuildWorkflow {
 
     return {
       buildId: completion.buildId,
-      providerImageId: completion.providerImageId,
       memberShas: completion.memberShas,
       runtimeVersion: completion.runtimeVersion,
       buildDurationMs: completion.buildDurationMs,
     };
+  }
+
+  private async requireTokenBuildCallbackAuth(
+    token: string | null | undefined,
+    params: {
+      buildId: string;
+      provider: EnvironmentImageProvider;
+      providerSessionId: string;
+      ctx: EnvironmentImageWorkflowContext;
+    }
+  ): Promise<void> {
+    const tokenHash = await this.hashRequiredCallbackToken(token, params);
+
+    const build = await this.store.consumeCallbackToken({
+      buildId: params.buildId,
+      provider: params.provider,
+      providerSessionId: params.providerSessionId,
+      tokenHash,
+      now: Date.now(),
+    });
+
+    if (!build) {
+      this.logCallbackAuthFailed(params);
+      throw new EnvironmentImageCallbackAuthRejectedError("Unauthorized");
+    }
+  }
+
+  private async markProviderSessionBuildFailedWithCallbackToken(
+    provider: EnvironmentImageProvider,
+    failure: { buildId: string; providerSessionId: string; errorMessage: string },
+    callbackToken: string | null | undefined,
+    ctx: EnvironmentImageWorkflowContext
+  ): Promise<void> {
+    const tokenHash = await this.hashRequiredCallbackToken(callbackToken, {
+      buildId: failure.buildId,
+      provider,
+      providerSessionId: failure.providerSessionId,
+      ctx,
+    });
+
+    let updated: boolean;
+    try {
+      updated = await this.store.markBuildFailedWithCallbackToken({
+        buildId: failure.buildId,
+        provider,
+        providerSessionId: failure.providerSessionId,
+        tokenHash,
+        error: failure.errorMessage,
+        now: Date.now(),
+      });
+    } catch (e) {
+      logger.error("environment_image.build_failed_error", {
+        error: errorMessage(e),
+        build_id: failure.buildId,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+      throw new EnvironmentImageBuildFailedUpdateError("Failed to mark build as failed", e);
+    }
+
+    if (updated) return;
+
+    this.logCallbackAuthFailed({
+      buildId: failure.buildId,
+      provider,
+      providerSessionId: failure.providerSessionId,
+      ctx,
+    });
+    throw new EnvironmentImageCallbackAuthRejectedError("Unauthorized");
+  }
+
+  private async hashRequiredCallbackToken(
+    token: string | null | undefined,
+    params: {
+      buildId: string;
+      provider: EnvironmentImageProvider;
+      providerSessionId: string;
+      ctx: EnvironmentImageWorkflowContext;
+    }
+  ): Promise<string> {
+    if (!token) {
+      this.logCallbackAuthFailed(params);
+      throw new EnvironmentImageCallbackAuthRejectedError("Unauthorized");
+    }
+
+    try {
+      return await hashRepoImageCallbackToken(token, this.env);
+    } catch (e) {
+      logger.error("environment_image.callback_auth_misconfigured", {
+        build_id: params.buildId,
+        error: errorMessage(e),
+        request_id: params.ctx.request_id,
+        trace_id: params.ctx.trace_id,
+      });
+      throw new EnvironmentImageCallbackAuthUnavailableError(
+        "Internal authentication not configured"
+      );
+    }
+  }
+
+  private logCallbackAuthFailed(params: {
+    buildId: string;
+    provider: EnvironmentImageProvider;
+    providerSessionId: string;
+    ctx: EnvironmentImageWorkflowContext;
+  }): void {
+    logger.warn("environment_image.callback_auth_failed", {
+      build_id: params.buildId,
+      provider: params.provider,
+      provider_session_id: params.providerSessionId,
+      request_id: params.ctx.request_id,
+      trace_id: params.ctx.trace_id,
+    });
+  }
+
+  private cleanupFailedBuildBestEffort(
+    provider: EnvironmentImageProvider,
+    failure: { buildId: string; providerSessionId: string; errorMessage: string },
+    ctx: EnvironmentImageWorkflowContext
+  ): Promise<void> | undefined {
+    const adapter = this.createAdapterForBestEffortCleanup(provider, failure.buildId, ctx);
+    if (!adapter?.cleanupFailedBuild) return undefined;
+
+    return adapter
+      .cleanupFailedBuild({
+        ...failure,
+        correlation: ctx,
+      })
+      .catch((e) => {
+        logger.warn(`environment_image.${provider}_build_cleanup_failed`, {
+          build_id: failure.buildId,
+          provider_session_id: failure.providerSessionId,
+          error: errorMessage(e),
+          request_id: ctx.request_id,
+          trace_id: ctx.trace_id,
+        });
+      });
   }
 
   private async requireInternalBuildCallbackAuth(
@@ -457,8 +879,24 @@ export class EnvironmentImageBuildWorkflow {
     ctx: EnvironmentImageWorkflowContext,
     buildId?: string
   ): AnyEnvironmentImageBuildAdapter {
+    return this.createAdapterGuarded(
+      provider,
+      operation,
+      ctx,
+      () => this.adapterFactory.create(provider),
+      buildId
+    );
+  }
+
+  private createAdapterGuarded<TAdapter>(
+    provider: EnvironmentImageProvider,
+    operation: string,
+    ctx: EnvironmentImageWorkflowContext,
+    create: () => TAdapter,
+    buildId?: string
+  ): TAdapter {
     try {
-      return this.adapterFactory.create(provider);
+      return create();
     } catch (e) {
       logger.error("environment_image.adapter_config_error", {
         operation,
@@ -564,6 +1002,17 @@ export function createEnvironmentImageBuildWorkflowFromEnv(
 
 function createBuildId(environmentId: string, now = Date.now()): string {
   return `envimg-${environmentId}-${now}-${generateId(4)}`;
+}
+
+function callbackAuthRegistration(
+  planned: PlannedEnvironmentImageBuild
+): Partial<Pick<EnvironmentImageBuild, "callbackTokenHash" | "callbackTokenExpiresAt">> {
+  return planned.callbackAuth.type === "bearer_token"
+    ? {
+        callbackTokenHash: planned.callbackAuth.tokenHash,
+        callbackTokenExpiresAt: planned.callbackAuth.expiresAt,
+      }
+    : {};
 }
 
 function errorMessage(errorValue: unknown): string {

--- a/packages/control-plane/src/environment-images/workflow.ts
+++ b/packages/control-plane/src/environment-images/workflow.ts
@@ -27,7 +27,7 @@ import {
   type EnvironmentImageProviderImageRef,
   type SupersededEnvironmentImage,
 } from "./model";
-import { EnvironmentImageBuildPlanner } from "./planner";
+import { EnvironmentImageBuildPlanner, type PlannedCallbackAuth } from "./planner";
 import {
   createEnvironmentImageBuildAdapterFactory,
   type EnvironmentImageBuildAdapterFactory,
@@ -48,11 +48,10 @@ const logger = createLogger("environment-images:workflow");
 /** Superseded rows reclaimed per cleanup pass; leftovers wait for the next tick. */
 const SUPERSEDED_REAP_BATCH_LIMIT = 25;
 
-interface EnvironmentImageBuildPlannerLike {
-  planBuild(
-    params: Parameters<EnvironmentImageBuildPlanner["planBuild"]>[0]
-  ): ReturnType<EnvironmentImageBuildPlanner["planBuild"]>;
-}
+type EnvironmentImageBuildPlannerLike = Pick<
+  EnvironmentImageBuildPlanner,
+  "resolveTarget" | "createCallbackAuth" | "planBuild"
+>;
 
 export interface AcceptEnvironmentBuildCompleteCommand {
   completion: CompleteEnvironmentImageBuildCallback;
@@ -155,14 +154,29 @@ export class EnvironmentImageBuildWorkflow {
     const buildId = createBuildId(environmentId);
     const callbackUrl = `${this.env.WORKER_URL}/environment-images/build-complete`;
 
-    let planned;
+    // Everything before registerBuild must stay cheap and secret-free: the
+    // §7.4 secret-change supersede can only see builds that have a row, so
+    // the row is registered BEFORE secrets are decrypted (planBuild below).
+    let target;
+    let callbackAuth;
     try {
-      planned = await this.planner.planBuild({
-        buildId,
-        environmentId,
-        callbackUrl,
-        correlation: ctx,
-      });
+      target = await this.planner.resolveTarget(environmentId);
+
+      if (
+        options.onlyIfStale &&
+        (await this.store.hasReadyImageForFingerprint(
+          environmentId,
+          provider,
+          target.membersFingerprint
+        ))
+      ) {
+        return { type: "up_to_date" };
+      }
+
+      // Probe the adapter now so a misconfigured provider fails 503 without
+      // writing a failed row on every cron tick.
+      this.createAdapterForOperation(provider, "trigger_build", ctx, buildId);
+      callbackAuth = await this.planner.createCallbackAuth();
     } catch (e) {
       if (
         e instanceof EnvironmentImageEnvironmentNotFoundError ||
@@ -181,17 +195,6 @@ export class EnvironmentImageBuildWorkflow {
       throw new EnvironmentImageTriggerFailedError("Failed to trigger build", e);
     }
 
-    if (
-      options.onlyIfStale &&
-      (await this.store.hasReadyImageForFingerprint(
-        environmentId,
-        provider,
-        planned.plan.membersFingerprint
-      ))
-    ) {
-      return { type: "up_to_date" };
-    }
-
     let providerSessionIdForCleanup: string | null = null;
     let startAdapter: AnyEnvironmentImageBuildAdapter | null = null;
     try {
@@ -199,8 +202,17 @@ export class EnvironmentImageBuildWorkflow {
         id: buildId,
         environmentId,
         provider,
-        membersFingerprint: planned.plan.membersFingerprint,
-        ...callbackAuthRegistration(planned),
+        membersFingerprint: target.membersFingerprint,
+        ...callbackAuthRegistration(callbackAuth),
+      });
+
+      const planned = await this.planner.planBuild({
+        buildId,
+        environmentId,
+        callbackUrl,
+        correlation: ctx,
+        target,
+        callbackAuth,
       });
 
       const start = this.preparePlannedBuildStart(planned, ctx);
@@ -317,13 +329,17 @@ export class EnvironmentImageBuildWorkflow {
     const { completion, context: ctx } = command;
     const build = await this.store.getCallbackBuild(completion.buildId);
     if (!build) {
+      // The build may have been superseded out-of-band (environment delete,
+      // secret change) while in flight — record its artifact for the reaper
+      // before rejecting, or the provider-side snapshot leaks forever.
+      await this.recordLateProviderImageArtifact(completion, command, ctx);
       throw new EnvironmentImageCompletionNotAcceptedError("Build is not accepting completion");
     }
 
     const provider = build.provider;
-    const validated = this.validateCompletion(completion);
 
     if (getRepoImageCallbackMode(provider) === "provider_session") {
+      const validated = this.validateCompletion(completion);
       // The sandbox itself reports completion with a bearer token; the
       // artifact does not exist yet — snapshotting is the deferred
       // finalization the route schedules via waitUntil.
@@ -362,7 +378,10 @@ export class EnvironmentImageBuildWorkflow {
       return { type: "completion_accepted", finalization };
     }
 
+    // Internal-HMAC mode: authenticate before revealing anything about the
+    // payload's validity (parity with the repo-image workflow).
     await this.requireInternalBuildCallbackAuth(command.authorizationHeader, build.id, ctx);
+    const validated = this.validateCompletion(completion);
     if (!completion.providerImageId) {
       throw new EnvironmentImageInvalidCallbackError("provider_image_id is required");
     }
@@ -418,7 +437,50 @@ export class EnvironmentImageBuildWorkflow {
         return cleanup ? { type: "build_superseded", cleanup } : { type: "build_superseded" };
       }
       case "not_accepting_completion":
+        // Superseded between getCallbackBuild and the transition — record the
+        // artifact for the reaper (auth already passed above).
+        await this.store.recordArtifactOnSupersededBuild(
+          validated.buildId,
+          provider,
+          providerImageId
+        );
         throw new EnvironmentImageCompletionNotAcceptedError("Build is not accepting completion");
+    }
+  }
+
+  /**
+   * A provider_image completion for a build whose row is no longer building:
+   * the artifact already exists provider-side, so after authenticating,
+   * record it on the (out-of-band superseded) row for the reaper. No-ops for
+   * provider_session builds — their artifact is only created at finalization,
+   * so nothing has leaked when the callback is rejected.
+   */
+  private async recordLateProviderImageArtifact(
+    completion: CompleteEnvironmentImageBuildCallback,
+    command: AcceptEnvironmentBuildCompleteCommand,
+    ctx: EnvironmentImageWorkflowContext
+  ): Promise<void> {
+    if (!completion.providerImageId) return;
+
+    const row = await this.store.getBuildRow(completion.buildId);
+    if (!row || getRepoImageCallbackMode(row.provider) !== "provider_image") return;
+
+    await this.requireInternalBuildCallbackAuth(command.authorizationHeader, row.id, ctx);
+
+    const recorded = await this.store.recordArtifactOnSupersededBuild(
+      row.id,
+      row.provider,
+      completion.providerImageId
+    );
+    if (recorded) {
+      logger.info("environment_image.late_artifact_recorded", {
+        build_id: row.id,
+        environment_id: row.environment_id,
+        provider: row.provider,
+        provider_image_id: completion.providerImageId,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
     }
   }
 
@@ -647,10 +709,20 @@ export class EnvironmentImageBuildWorkflow {
 
     const superseded = await this.store.getSupersededImages(SUPERSEDED_REAP_BATCH_LIMIT);
     let reapedSuperseded = 0;
+    const adaptersByProvider = new Map<
+      EnvironmentImageProvider,
+      AnyEnvironmentImageBuildAdapter | null
+    >();
     await Promise.all(
       superseded.map(async (row) => {
         if (row.provider_image_id) {
-          const adapter = this.createAdapterForBestEffortCleanup(row.provider, row.id, ctx);
+          if (!adaptersByProvider.has(row.provider)) {
+            adaptersByProvider.set(
+              row.provider,
+              this.createAdapterForBestEffortCleanup(row.provider, row.id, ctx)
+            );
+          }
+          const adapter = adaptersByProvider.get(row.provider) ?? null;
           if (!adapter) return;
           const deleted = await this.deleteImageBestEffort(
             row.provider,
@@ -933,7 +1005,11 @@ export class EnvironmentImageBuildWorkflow {
   ): Promise<void> | undefined {
     if (replacedImages.length === 0) return undefined;
 
-    const adapter = this.createAdapterForBestEffortCleanup(provider, "", ctx);
+    const adapter = this.createAdapterForBestEffortCleanup(
+      provider,
+      replacedImages[0].environmentImageId,
+      ctx
+    );
     if (!adapter) return undefined;
 
     return Promise.all(
@@ -1005,12 +1081,12 @@ function createBuildId(environmentId: string, now = Date.now()): string {
 }
 
 function callbackAuthRegistration(
-  planned: PlannedEnvironmentImageBuild
+  callbackAuth: PlannedCallbackAuth
 ): Partial<Pick<EnvironmentImageBuild, "callbackTokenHash" | "callbackTokenExpiresAt">> {
-  return planned.callbackAuth.type === "bearer_token"
+  return callbackAuth.kind === "bearer_token"
     ? {
-        callbackTokenHash: planned.callbackAuth.tokenHash,
-        callbackTokenExpiresAt: planned.callbackAuth.expiresAt,
+        callbackTokenHash: callbackAuth.tokenHash,
+        callbackTokenExpiresAt: callbackAuth.expiresAt,
       }
     : {};
 }

--- a/packages/control-plane/src/environment-images/workflow.ts
+++ b/packages/control-plane/src/environment-images/workflow.ts
@@ -1,0 +1,571 @@
+import { generateId } from "../auth/crypto";
+import { verifyInternalToken } from "../auth/internal";
+import { EnvironmentImageStore } from "../db/environment-images";
+import { createLogger } from "../logger";
+import { getRepoImageCallbackMode, resolveRepoImageProvider } from "../repo-images/provider-policy";
+import type { Env } from "../types";
+import {
+  EnvironmentImageBuildCompleteFailedError,
+  EnvironmentImageBuildFailedUpdateError,
+  EnvironmentImageCallbackAuthRejectedError,
+  EnvironmentImageCallbackAuthUnavailableError,
+  EnvironmentImageCompletionNotAcceptedError,
+  EnvironmentImageEnvironmentNotFoundError,
+  EnvironmentImageFailureNotAcceptedError,
+  EnvironmentImageInvalidCallbackError,
+  EnvironmentImagePlanningError,
+  EnvironmentImageProviderUnconfiguredError,
+  EnvironmentImageTriggerFailedError,
+  EnvironmentImageWorkflowUnavailableError,
+} from "./errors";
+import {
+  parseRuntimeVersionNumber,
+  type EnvironmentImageMemberSha,
+  type EnvironmentImageProvider,
+  type SupersededEnvironmentImage,
+} from "./model";
+import { EnvironmentImageBuildPlanner } from "./planner";
+import {
+  createEnvironmentImageBuildAdapterFactory,
+  type EnvironmentImageBuildAdapterFactory,
+} from "./provider-factory";
+import type {
+  AnyEnvironmentImageBuildAdapter,
+  CompleteEnvironmentImageBuildCallback,
+  EnvironmentImageWorkflowContext,
+  EnvironmentImageWorkflowResult,
+  FailEnvironmentImageBuildCallback,
+  TriggerEnvironmentImageBuildResult,
+} from "./types";
+
+const logger = createLogger("environment-images:workflow");
+
+/** Superseded rows reclaimed per cleanup pass; leftovers wait for the next tick. */
+const SUPERSEDED_REAP_BATCH_LIMIT = 25;
+
+interface EnvironmentImageBuildPlannerLike {
+  planBuild(
+    params: Parameters<EnvironmentImageBuildPlanner["planBuild"]>[0]
+  ): ReturnType<EnvironmentImageBuildPlanner["planBuild"]>;
+}
+
+export interface AcceptEnvironmentBuildCompleteCommand {
+  completion: CompleteEnvironmentImageBuildCallback;
+  authorizationHeader?: string | null;
+  context: EnvironmentImageWorkflowContext;
+}
+
+export interface AcceptEnvironmentBuildFailedCommand {
+  failure: FailEnvironmentImageBuildCallback;
+  authorizationHeader?: string | null;
+  context: EnvironmentImageWorkflowContext;
+}
+
+interface ValidatedEnvironmentBuildCompletion {
+  buildId: string;
+  providerImageId: string;
+  memberShas: EnvironmentImageMemberSha[];
+  runtimeVersion: string;
+  buildDurationMs: number;
+}
+
+/**
+ * Application service for the environment image build lifecycle (design §7.3).
+ *
+ * Sequences planning, provider adapter calls, callback authorization, store
+ * state transitions, and best-effort artifact cleanup — the environment twin
+ * of RepoImageBuildWorkflow, trimmed to the provider_image callback mode
+ * Modal uses. HTTP parsing stays in routes, environment/secrets resolution in
+ * the planner, and provider API details in adapters.
+ *
+ * Public methods return successful domain outcomes and throw
+ * EnvironmentImageError subclasses for route-level error mapping.
+ */
+export class EnvironmentImageBuildWorkflow {
+  private readonly planner: EnvironmentImageBuildPlannerLike | null;
+
+  constructor(
+    private readonly env: Env,
+    private readonly store: EnvironmentImageStore,
+    private readonly adapterFactory: EnvironmentImageBuildAdapterFactory,
+    private readonly provider: EnvironmentImageProvider | null,
+    planner?: EnvironmentImageBuildPlannerLike
+  ) {
+    this.planner = planner ?? (provider ? new EnvironmentImageBuildPlanner(env, provider) : null);
+  }
+
+  /**
+   * Trigger a build for an environment. All trigger sources — the cron pass,
+   * save-hooks, and manual rebuilds — converge here, so the per-environment
+   * concurrency-1 rule is enforced here rather than in any one caller.
+   */
+  async triggerBuild(
+    environmentId: string,
+    ctx: EnvironmentImageWorkflowContext
+  ): Promise<TriggerEnvironmentImageBuildResult> {
+    return this.trigger(environmentId, ctx, { onlyIfStale: false });
+  }
+
+  /**
+   * Save-hook variant (design §7.3 "saving an environment triggers an
+   * immediate build"): skips the build when a ready image already matches the
+   * current member set — that is the cron's trigger-1 check evaluated
+   * eagerly. Unconditional rebuild reasons (sha drift, runtime floor) remain
+   * the cron's job.
+   */
+  async triggerBuildIfStale(
+    environmentId: string,
+    ctx: EnvironmentImageWorkflowContext
+  ): Promise<TriggerEnvironmentImageBuildResult> {
+    return this.trigger(environmentId, ctx, { onlyIfStale: true });
+  }
+
+  private async trigger(
+    environmentId: string,
+    ctx: EnvironmentImageWorkflowContext,
+    options: { onlyIfStale: boolean }
+  ): Promise<TriggerEnvironmentImageBuildResult> {
+    if (!this.provider || !this.planner) {
+      throw new EnvironmentImageWorkflowUnavailableError(
+        "Environment image provider is not configured"
+      );
+    }
+    if (!this.env.WORKER_URL) {
+      throw new EnvironmentImageWorkflowUnavailableError("WORKER_URL not configured");
+    }
+
+    const provider = this.provider;
+    const active = await this.store.getActiveBuild(environmentId, provider);
+    if (active) {
+      return { type: "already_building", buildId: active.id };
+    }
+
+    const buildId = createBuildId(environmentId);
+    const callbackUrl = `${this.env.WORKER_URL}/environment-images/build-complete`;
+
+    let planned;
+    try {
+      planned = await this.planner.planBuild({
+        buildId,
+        environmentId,
+        callbackUrl,
+        correlation: ctx,
+      });
+    } catch (e) {
+      if (
+        e instanceof EnvironmentImageEnvironmentNotFoundError ||
+        e instanceof EnvironmentImagePlanningError ||
+        e instanceof EnvironmentImageProviderUnconfiguredError
+      ) {
+        throw e;
+      }
+
+      logger.error("environment_image.trigger_error", {
+        error: errorMessage(e),
+        environment_id: environmentId,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+      throw new EnvironmentImageTriggerFailedError("Failed to trigger build", e);
+    }
+
+    if (
+      options.onlyIfStale &&
+      (await this.store.hasReadyImageForFingerprint(
+        environmentId,
+        provider,
+        planned.plan.membersFingerprint
+      ))
+    ) {
+      return { type: "up_to_date" };
+    }
+
+    try {
+      await this.store.registerBuild({
+        id: buildId,
+        environmentId,
+        provider,
+        membersFingerprint: planned.plan.membersFingerprint,
+      });
+
+      const adapter = this.createAdapterForOperation(provider, "trigger_build", ctx, buildId);
+      await adapter.startBuild(planned.plan, {
+        bindProviderSession: async () => {
+          throw new Error("provider_session builds are not supported for environment images");
+        },
+      });
+
+      logger.info("environment_image.build_triggered", {
+        build_id: buildId,
+        environment_id: environmentId,
+        members_fingerprint: planned.plan.membersFingerprint,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+
+      return { type: "triggered", buildId };
+    } catch (e) {
+      try {
+        await this.store.markBuildFailed(buildId, provider, errorMessage(e));
+      } catch (markFailedError) {
+        logger.warn("environment_image.trigger_mark_failed_error", {
+          error: errorMessage(markFailedError),
+          build_id: buildId,
+          request_id: ctx.request_id,
+          trace_id: ctx.trace_id,
+        });
+      }
+
+      logger.error("environment_image.trigger_error", {
+        error: errorMessage(e),
+        environment_id: environmentId,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+      throw new EnvironmentImageTriggerFailedError("Failed to trigger build", e);
+    }
+  }
+
+  async acceptBuildComplete(
+    command: AcceptEnvironmentBuildCompleteCommand
+  ): Promise<EnvironmentImageWorkflowResult> {
+    const { completion, context: ctx } = command;
+    const build = await this.store.getCallbackBuild(completion.buildId);
+    if (!build) {
+      throw new EnvironmentImageCompletionNotAcceptedError("Build is not accepting completion");
+    }
+
+    const provider = build.provider;
+    if (getRepoImageCallbackMode(provider) !== "provider_image") {
+      throw new EnvironmentImageInvalidCallbackError(
+        "provider_session callbacks are not supported for environment images"
+      );
+    }
+
+    await this.requireInternalBuildCallbackAuth(command.authorizationHeader, build.id, ctx);
+    const validated = this.validateCompletion(completion);
+
+    let result;
+    try {
+      result = await this.store.tryMarkEnvironmentImageReady(
+        validated.buildId,
+        provider,
+        validated.providerImageId,
+        validated.memberShas,
+        validated.runtimeVersion,
+        validated.buildDurationMs
+      );
+    } catch (e) {
+      logger.error("environment_image.build_complete_error", {
+        error: errorMessage(e),
+        build_id: validated.buildId,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+      throw new EnvironmentImageBuildCompleteFailedError("Failed to mark build as ready", e);
+    }
+
+    switch (result.type) {
+      case "marked_ready": {
+        logger.info("environment_image.build_complete", {
+          build_id: validated.buildId,
+          environment_id: build.environmentId,
+          provider,
+          provider_image_id: validated.providerImageId,
+          runtime_version: validated.runtimeVersion,
+          replaced_image_id: result.supersededImages[0]?.image.providerImageId ?? null,
+          request_id: ctx.request_id,
+          trace_id: ctx.trace_id,
+        });
+        const cleanup = this.deleteReplacedImages(provider, result.supersededImages, ctx);
+        return cleanup
+          ? { type: "build_ready", replacedImages: result.supersededImages, cleanup }
+          : { type: "build_ready", replacedImages: result.supersededImages };
+      }
+      case "superseded_by_newer_ready": {
+        logger.info("environment_image.build_superseded", {
+          build_id: validated.buildId,
+          environment_id: build.environmentId,
+          provider,
+          provider_image_id: result.supersededImage.image.providerImageId,
+          request_id: ctx.request_id,
+          trace_id: ctx.trace_id,
+        });
+        const cleanup = this.deleteReplacedImages(provider, [result.supersededImage], ctx);
+        return cleanup ? { type: "build_superseded", cleanup } : { type: "build_superseded" };
+      }
+      case "not_accepting_completion":
+        throw new EnvironmentImageCompletionNotAcceptedError("Build is not accepting completion");
+    }
+  }
+
+  async acceptBuildFailed(
+    command: AcceptEnvironmentBuildFailedCommand
+  ): Promise<EnvironmentImageWorkflowResult> {
+    const { failure, context: ctx } = command;
+    const build = await this.store.getCallbackBuild(failure.buildId);
+    if (!build) {
+      throw new EnvironmentImageFailureNotAcceptedError("Build is not accepting failure");
+    }
+
+    await this.requireInternalBuildCallbackAuth(command.authorizationHeader, build.id, ctx);
+
+    let updated: boolean;
+    try {
+      updated = await this.store.markBuildFailed(
+        failure.buildId,
+        build.provider,
+        failure.errorMessage
+      );
+    } catch (e) {
+      logger.error("environment_image.build_failed_error", {
+        error: errorMessage(e),
+        build_id: failure.buildId,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+      throw new EnvironmentImageBuildFailedUpdateError("Failed to mark build as failed", e);
+    }
+
+    if (!updated) {
+      throw new EnvironmentImageFailureNotAcceptedError("Build is not accepting failure");
+    }
+
+    logger.info("environment_image.build_failed", {
+      build_id: failure.buildId,
+      environment_id: build.environmentId,
+      provider: build.provider,
+      error_message: failure.errorMessage,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+
+    return { type: "build_failed" };
+  }
+
+  /**
+   * Cleanup pass: delete old failed rows, then reap superseded rows — delete
+   * the provider artifact (when one was recorded) and only then the row, so a
+   * failed artifact delete is retried on the next pass. Covers both inline
+   * supersedes whose deletion failed and out-of-band supersedes (environment
+   * delete, secret change), which nothing deletes inline.
+   */
+  async cleanupImages(
+    failedMaxAgeMs: number,
+    ctx: EnvironmentImageWorkflowContext
+  ): Promise<{ deletedFailed: number; reapedSuperseded: number }> {
+    const deletedFailed = await this.store.deleteOldFailedBuilds(failedMaxAgeMs);
+
+    const superseded = await this.store.getSupersededImages(SUPERSEDED_REAP_BATCH_LIMIT);
+    let reapedSuperseded = 0;
+    await Promise.all(
+      superseded.map(async (row) => {
+        if (row.provider_image_id) {
+          const adapter = this.createAdapterForBestEffortCleanup(row.provider, row.id, ctx);
+          if (!adapter) return;
+          const deleted = await this.deleteImageBestEffort(
+            row.provider,
+            {
+              providerImageId: row.provider_image_id,
+              providerSessionId: row.provider_session_id,
+            },
+            ctx,
+            adapter
+          );
+          if (!deleted) return;
+        }
+        if (await this.store.deleteSupersededImage(row.id)) {
+          reapedSuperseded += 1;
+        }
+      })
+    );
+
+    return { deletedFailed, reapedSuperseded };
+  }
+
+  private validateCompletion(
+    completion: CompleteEnvironmentImageBuildCallback
+  ): ValidatedEnvironmentBuildCompletion {
+    if (!completion.providerImageId) {
+      throw new EnvironmentImageInvalidCallbackError("provider_image_id is required");
+    }
+    if (!completion.memberShas || completion.memberShas.length === 0) {
+      throw new EnvironmentImageInvalidCallbackError("member_shas is required");
+    }
+    if (
+      typeof completion.runtimeVersion !== "string" ||
+      parseRuntimeVersionNumber(completion.runtimeVersion) === null
+    ) {
+      // Fail closed (design §7.3): an unversioned image must never be
+      // registered, or it could pass spawn selection's floor check.
+      throw new EnvironmentImageInvalidCallbackError(
+        "runtime_version is required and must start with v<number>"
+      );
+    }
+    if (
+      typeof completion.buildDurationMs !== "number" ||
+      !Number.isFinite(completion.buildDurationMs) ||
+      completion.buildDurationMs < 0
+    ) {
+      throw new EnvironmentImageInvalidCallbackError(
+        "build_duration_seconds must be a non-negative finite number"
+      );
+    }
+
+    return {
+      buildId: completion.buildId,
+      providerImageId: completion.providerImageId,
+      memberShas: completion.memberShas,
+      runtimeVersion: completion.runtimeVersion,
+      buildDurationMs: completion.buildDurationMs,
+    };
+  }
+
+  private async requireInternalBuildCallbackAuth(
+    authorizationHeader: string | null | undefined,
+    buildId: string,
+    ctx: EnvironmentImageWorkflowContext
+  ): Promise<void> {
+    if (!this.env.INTERNAL_CALLBACK_SECRET) {
+      logger.error("environment_image.callback_auth_misconfigured", {
+        build_id: buildId,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+      throw new EnvironmentImageCallbackAuthUnavailableError(
+        "Internal authentication not configured"
+      );
+    }
+
+    const authorized = await verifyInternalToken(
+      authorizationHeader ?? null,
+      this.env.INTERNAL_CALLBACK_SECRET
+    );
+    if (authorized) return;
+
+    logger.warn("environment_image.callback_auth_failed", {
+      build_id: buildId,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    throw new EnvironmentImageCallbackAuthRejectedError("Unauthorized");
+  }
+
+  private createAdapterForOperation(
+    provider: EnvironmentImageProvider,
+    operation: string,
+    ctx: EnvironmentImageWorkflowContext,
+    buildId?: string
+  ): AnyEnvironmentImageBuildAdapter {
+    try {
+      return this.adapterFactory.create(provider);
+    } catch (e) {
+      logger.error("environment_image.adapter_config_error", {
+        operation,
+        build_id: buildId,
+        provider,
+        error: errorMessage(e),
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+      throw new EnvironmentImageProviderUnconfiguredError(
+        "Environment image provider is not configured",
+        e
+      );
+    }
+  }
+
+  private createAdapterForBestEffortCleanup(
+    provider: EnvironmentImageProvider,
+    buildId: string,
+    ctx: EnvironmentImageWorkflowContext
+  ): AnyEnvironmentImageBuildAdapter | null {
+    try {
+      return this.createAdapterForOperation(provider, "cleanup", ctx, buildId);
+    } catch (e) {
+      if (e instanceof EnvironmentImageProviderUnconfiguredError) return null;
+      throw e;
+    }
+  }
+
+  private deleteReplacedImages(
+    provider: EnvironmentImageProvider,
+    replacedImages: SupersededEnvironmentImage[],
+    ctx: EnvironmentImageWorkflowContext
+  ): Promise<void> | undefined {
+    if (replacedImages.length === 0) return undefined;
+
+    const adapter = this.createAdapterForBestEffortCleanup(provider, "", ctx);
+    if (!adapter) return undefined;
+
+    return Promise.all(
+      replacedImages.map(async (replacedImage) => {
+        // Rows superseded before an artifact was recorded have nothing to
+        // delete provider-side; the reaper removes the row.
+        if (!replacedImage.image.providerImageId) return;
+        const deleted = await this.deleteImageBestEffort(
+          provider,
+          replacedImage.image,
+          ctx,
+          adapter
+        );
+        if (deleted) {
+          try {
+            await this.store.deleteSupersededImage(replacedImage.environmentImageId);
+          } catch (e) {
+            logger.warn("environment_image.delete_superseded_row_failed", {
+              environment_image_id: replacedImage.environmentImageId,
+              provider_image_id: replacedImage.image.providerImageId,
+              error: errorMessage(e),
+              request_id: ctx.request_id,
+              trace_id: ctx.trace_id,
+            });
+          }
+        }
+      })
+    ).then(() => undefined);
+  }
+
+  private async deleteImageBestEffort(
+    provider: EnvironmentImageProvider,
+    image: { providerImageId: string; providerSessionId?: string | null },
+    ctx: EnvironmentImageWorkflowContext,
+    adapter: AnyEnvironmentImageBuildAdapter
+  ): Promise<boolean> {
+    try {
+      await adapter.deleteImage({
+        image,
+        correlation: ctx,
+      });
+      return true;
+    } catch (e) {
+      logger.warn("environment_image.delete_old_failed", {
+        provider,
+        provider_image_id: image.providerImageId,
+        error: errorMessage(e),
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+      return false;
+    }
+  }
+}
+
+export function createEnvironmentImageBuildWorkflowFromEnv(
+  env: Env
+): EnvironmentImageBuildWorkflow {
+  return new EnvironmentImageBuildWorkflow(
+    env,
+    new EnvironmentImageStore(env.DB),
+    createEnvironmentImageBuildAdapterFactory(env),
+    resolveRepoImageProvider(env.SANDBOX_PROVIDER)
+  );
+}
+
+function createBuildId(environmentId: string, now = Date.now()): string {
+  return `envimg-${environmentId}-${now}-${generateId(4)}`;
+}
+
+function errorMessage(errorValue: unknown): string {
+  return errorValue instanceof Error ? errorValue.message : String(errorValue);
+}

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -29,6 +29,7 @@ import { repoImageRoutes } from "./routes/repo-images";
 import { secretsRoutes } from "./routes/secrets";
 import { environmentRoutes } from "./routes/environments";
 import { environmentSecretsRoutes } from "./routes/environment-secrets";
+import { environmentImageRoutes } from "./routes/environment-images";
 import { automationRoutes } from "./routes/automations";
 import { mcpServerRoutes } from "./routes/mcp-servers";
 import { analyticsRoutes } from "./routes/analytics";
@@ -60,6 +61,10 @@ const PUBLIC_ROUTES: RegExp[] = [
   /^\/webhooks\/automation\/[^/]+$/,
   /^\/repo-images\/build-complete$/,
   /^\/repo-images\/build-failed$/,
+  // Environment-image callbacks authenticate inside the workflow (internal
+  // HMAC for provider_image mode), same as the repo-image callbacks above.
+  /^\/environment-images\/build-complete$/,
+  /^\/environment-images\/build-failed$/,
 ];
 
 /**
@@ -317,6 +322,7 @@ const routes: Route[] = [
   // Environments (Phase-2 launch unit; internal-HMAC only, web BFF proxied)
   ...environmentRoutes,
   ...environmentSecretsRoutes,
+  ...environmentImageRoutes,
 
   // Model preferences
   ...modelPreferencesRoutes,

--- a/packages/control-plane/src/routes/environment-images.ts
+++ b/packages/control-plane/src/routes/environment-images.ts
@@ -1,0 +1,589 @@
+/**
+ * Environment image build routes (design §7.3).
+ *
+ * Handles:
+ * - Build callbacks from async environment image builders (build-complete, build-failed)
+ * - Build triggers (cron pass, save-hooks, manual rebuild)
+ * - Enabled-environments and status queries for the rebuild cron
+ * - Maintenance operations (stale builds, cleanup + superseded-artifact reaping)
+ */
+
+import { EnvironmentImageStore } from "../db/environment-images";
+import { EnvironmentStore } from "../db/environments";
+import { createLogger } from "../logger";
+import { EnvironmentImageError } from "../environment-images/errors";
+import { computeMembersFingerprint } from "../environment-images/fingerprint";
+import {
+  MIN_COMPATIBLE_RUNTIME_VERSION,
+  type EnvironmentImageMemberSha,
+} from "../environment-images/model";
+import { createEnvironmentImageBuildWorkflowFromEnv } from "../environment-images/workflow";
+import type {
+  CompleteEnvironmentImageBuildCallback,
+  EnvironmentImageWorkflowContext,
+  EnvironmentImageWorkflowResult,
+  FailEnvironmentImageBuildCallback,
+} from "../environment-images/types";
+import { getRepoImagesUnsupportedMessage } from "../repo-images/provider-policy";
+import type { Env } from "../types";
+import { type RequestContext, type Route, error, json, parsePattern } from "./shared";
+
+const logger = createLogger("router:environment-images");
+const MS_PER_SECOND = 1000;
+const MAX_CALLBACK_BODY_BYTES = 16 * 1024;
+const DEFAULT_STALE_BUILD_MAX_AGE_MS = 4200 * MS_PER_SECOND;
+const DEFAULT_FAILED_BUILD_CLEANUP_MAX_AGE_MS = 86400 * MS_PER_SECOND;
+
+interface EnvironmentImageBuildCompleteBody {
+  build_id?: unknown;
+  provider_image_id?: unknown;
+  provider_session_id?: unknown;
+  member_shas?: unknown;
+  runtime_version?: unknown;
+  build_duration_seconds?: unknown;
+}
+
+interface EnvironmentImageBuildFailedBody {
+  build_id?: unknown;
+  provider_session_id?: unknown;
+  error?: unknown;
+}
+
+function requireEnvironmentImages(env: Env): Response | null {
+  // Environment images run on the repo-image provider set (design §7.3).
+  const message = getRepoImagesUnsupportedMessage(env);
+  return message ? error(message, 501) : null;
+}
+
+function requireDb(env: Env): Response | null {
+  return env.DB ? null : error("Database not configured", 503);
+}
+
+function workflowContext(ctx: RequestContext): EnvironmentImageWorkflowContext {
+  return {
+    request_id: ctx.request_id,
+    trace_id: ctx.trace_id,
+  };
+}
+
+async function workflowResultToResponse(
+  result: EnvironmentImageWorkflowResult,
+  ctx: RequestContext
+): Promise<Response> {
+  if (result.cleanup) {
+    await scheduleWorkflowTask(result.cleanup, ctx);
+  }
+
+  switch (result.type) {
+    case "build_ready":
+      return json({
+        ok: true,
+        replacedImageId: result.replacedImages[0]?.image.providerImageId ?? null,
+      });
+    case "build_superseded":
+      return json({ ok: true, superseded: true });
+    case "build_failed":
+      return json({ ok: true });
+    default: {
+      const exhaustive: never = result;
+      return error(`Unhandled workflow result: ${String(exhaustive)}`, 500);
+    }
+  }
+}
+
+function environmentImageErrorToResponse(errorValue: unknown): Response {
+  if (!(errorValue instanceof EnvironmentImageError)) throw errorValue;
+
+  switch (errorValue.code) {
+    case "environment_not_found":
+      return error(errorValue.message, 404);
+    case "invalid_callback":
+      return error(errorValue.message, 400);
+    case "callback_auth_rejected":
+      return error(errorValue.message, 401);
+    case "completion_not_accepted":
+    case "failure_not_accepted":
+      return error(errorValue.message, 409);
+    case "workflow_unavailable":
+    case "provider_unconfigured":
+      return error(errorValue.message, 503);
+    case "planning_failed":
+    case "trigger_failed":
+    case "callback_auth_unavailable":
+    case "build_complete_failed":
+    case "build_failed_update_failed":
+      return error(errorValue.message, 500);
+    default: {
+      const exhaustive: never = errorValue.code;
+      return error(`Unhandled environment image error: ${String(exhaustive)}`, 500);
+    }
+  }
+}
+
+async function scheduleWorkflowTask(task: Promise<void>, ctx: RequestContext): Promise<void> {
+  if (ctx.executionCtx) {
+    ctx.executionCtx.waitUntil(task);
+    return;
+  }
+
+  await task;
+}
+
+async function parseCallbackBody<T>(request: Request): Promise<T | Response> {
+  const contentLength = Number.parseInt(request.headers.get("content-length") ?? "", 10);
+  if (Number.isFinite(contentLength) && contentLength > MAX_CALLBACK_BODY_BYTES) {
+    return error("Payload too large", 413);
+  }
+
+  let bodyText: string;
+  try {
+    bodyText = await request.text();
+  } catch {
+    return error("Invalid JSON body", 400);
+  }
+
+  const bodyBytes = new TextEncoder().encode(bodyText).byteLength;
+  if (bodyBytes > MAX_CALLBACK_BODY_BYTES) {
+    return error("Payload too large", 413);
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(bodyText);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return error("Invalid JSON body", 400);
+    }
+    return parsed as T;
+  } catch {
+    return error("Invalid JSON body", 400);
+  }
+}
+
+function requireStringField(value: unknown, field: string): string | Response {
+  return typeof value === "string" && value.length > 0 ? value : error(`${field} is required`, 400);
+}
+
+function optionalStringField(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+/**
+ * Parse the member_shas document ([{repoOwner, repoName, baseSha}], the
+ * single cross-language shape produced by the runtime). Malformed entries are
+ * a 400 — deeper requirements (non-empty) are the workflow's fail-close.
+ */
+function parseMemberShas(value: unknown): EnvironmentImageMemberSha[] | undefined | Response {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) return error("member_shas must be an array", 400);
+
+  const members: EnvironmentImageMemberSha[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      return error("member_shas entries must be objects", 400);
+    }
+    const { repoOwner, repoName, baseSha } = entry as Record<string, unknown>;
+    if (
+      typeof repoOwner !== "string" ||
+      repoOwner.length === 0 ||
+      typeof repoName !== "string" ||
+      repoName.length === 0 ||
+      typeof baseSha !== "string" ||
+      baseSha.length === 0
+    ) {
+      return error("member_shas entries require repoOwner, repoName, and baseSha", 400);
+    }
+    members.push({ repoOwner, repoName, baseSha });
+  }
+  return members;
+}
+
+function buildCompleteCommand(
+  body: EnvironmentImageBuildCompleteBody
+): CompleteEnvironmentImageBuildCallback | Response {
+  const buildId = requireStringField(body.build_id, "build_id");
+  if (buildId instanceof Response) return buildId;
+
+  let buildDurationMs: number | undefined;
+  if (body.build_duration_seconds !== undefined) {
+    if (typeof body.build_duration_seconds !== "number") {
+      return error("build_duration_seconds is required", 400);
+    }
+    buildDurationMs = body.build_duration_seconds * MS_PER_SECOND;
+  }
+
+  const memberShas = parseMemberShas(body.member_shas);
+  if (memberShas instanceof Response) return memberShas;
+
+  return {
+    buildId,
+    providerImageId:
+      typeof body.provider_image_id === "string" && body.provider_image_id.length > 0
+        ? body.provider_image_id
+        : undefined,
+    providerSessionId:
+      typeof body.provider_session_id === "string" && body.provider_session_id.length > 0
+        ? body.provider_session_id
+        : undefined,
+    memberShas,
+    runtimeVersion:
+      typeof body.runtime_version === "string" && body.runtime_version.length > 0
+        ? body.runtime_version
+        : undefined,
+    buildDurationMs,
+  };
+}
+
+function buildFailedCommand(
+  body: EnvironmentImageBuildFailedBody
+): FailEnvironmentImageBuildCallback | Response {
+  const buildId = requireStringField(body.build_id, "build_id");
+  if (buildId instanceof Response) return buildId;
+
+  return {
+    buildId,
+    providerSessionId:
+      typeof body.provider_session_id === "string" && body.provider_session_id.length > 0
+        ? body.provider_session_id
+        : undefined,
+    errorMessage: optionalStringField(body.error, "Unknown error"),
+  };
+}
+
+/**
+ * POST /environment-images/build-complete
+ * Callback from environment image builders on success.
+ */
+async function handleBuildComplete(
+  request: Request,
+  env: Env,
+  _match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const dbError = requireDb(env);
+  if (dbError) return dbError;
+
+  const body = await parseCallbackBody<EnvironmentImageBuildCompleteBody>(request);
+  if (body instanceof Response) return body;
+
+  const completion = buildCompleteCommand(body);
+  if (completion instanceof Response) return completion;
+
+  try {
+    const result = await createEnvironmentImageBuildWorkflowFromEnv(env).acceptBuildComplete({
+      completion,
+      authorizationHeader: request.headers.get("Authorization"),
+      context: workflowContext(ctx),
+    });
+    return workflowResultToResponse(result, ctx);
+  } catch (e) {
+    return environmentImageErrorToResponse(e);
+  }
+}
+
+/**
+ * POST /environment-images/build-failed
+ * Callback from environment image builders on failure.
+ */
+async function handleBuildFailed(
+  request: Request,
+  env: Env,
+  _match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const dbError = requireDb(env);
+  if (dbError) return dbError;
+
+  const body = await parseCallbackBody<EnvironmentImageBuildFailedBody>(request);
+  if (body instanceof Response) return body;
+
+  const failure = buildFailedCommand(body);
+  if (failure instanceof Response) return failure;
+
+  try {
+    const result = await createEnvironmentImageBuildWorkflowFromEnv(env).acceptBuildFailed({
+      failure,
+      authorizationHeader: request.headers.get("Authorization"),
+      context: workflowContext(ctx),
+    });
+    return workflowResultToResponse(result, ctx);
+  } catch (e) {
+    return environmentImageErrorToResponse(e);
+  }
+}
+
+/**
+ * POST /environment-images/trigger/:id
+ * Trigger a build for an environment (cron, save-hooks, manual rebuild).
+ */
+async function handleTriggerBuild(
+  _request: Request,
+  env: Env,
+  match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const providerError = requireEnvironmentImages(env);
+  if (providerError) return providerError;
+
+  const dbError = requireDb(env);
+  if (dbError) return dbError;
+
+  const environmentId = match.groups?.id;
+  if (!environmentId) return error("Environment ID required", 400);
+
+  try {
+    const result = await createEnvironmentImageBuildWorkflowFromEnv(env).triggerBuild(
+      environmentId,
+      workflowContext(ctx)
+    );
+    if (result.type === "up_to_date") {
+      // Unreachable via this route (triggerBuild is unconditional); guards
+      // the union exhaustively.
+      return json({ ok: true, upToDate: true });
+    }
+    return json({
+      buildId: result.buildId,
+      status: "building",
+      alreadyBuilding: result.type === "already_building",
+    });
+  } catch (e) {
+    return environmentImageErrorToResponse(e);
+  }
+}
+
+/**
+ * GET /environment-images/status[?environment_id=...]
+ * Image rows (non-superseded) for the cron and the settings UI. Rows are
+ * returned verbatim (snake_case columns; member_shas is a JSON document).
+ */
+async function handleGetStatus(
+  request: Request,
+  env: Env,
+  _match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const providerError = requireEnvironmentImages(env);
+  if (providerError) return providerError;
+
+  const dbError = requireDb(env);
+  if (dbError) return dbError;
+
+  const environmentId = new URL(request.url).searchParams.get("environment_id");
+  const store = new EnvironmentImageStore(env.DB);
+
+  try {
+    const images = environmentId
+      ? await store.getStatus(environmentId)
+      : await store.getAllStatus();
+    return json({ images });
+  } catch (e) {
+    logger.error("environment_image.status_error", {
+      error: e instanceof Error ? e.message : String(e),
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return error("Failed to get image status", 500);
+  }
+}
+
+/**
+ * GET /environment-images/enabled
+ * Prebuild-enabled environments with their current members and fingerprint,
+ * plus the runtime floor — everything the cron's trigger checks need, so the
+ * fingerprint algorithm never leaves the control plane (design §7.3).
+ */
+async function handleGetEnabledEnvironments(
+  _request: Request,
+  env: Env,
+  _match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const providerError = requireEnvironmentImages(env);
+  if (providerError) return providerError;
+
+  const dbError = requireDb(env);
+  if (dbError) return dbError;
+
+  const store = new EnvironmentStore(env.DB);
+
+  try {
+    const { environments } = await store.list();
+    const enabled = environments.filter((row) => row.prebuild_enabled === 1);
+    const repositoriesById = await store.getRepositoriesForEnvironmentIds(
+      enabled.map((row) => row.id)
+    );
+
+    const payload = await Promise.all(
+      enabled.map(async (row) => {
+        const members = (repositoriesById.get(row.id) ?? []).map((repo) => ({
+          repoOwner: repo.repo_owner,
+          repoName: repo.repo_name,
+          baseBranch: repo.base_branch,
+        }));
+        return {
+          id: row.id,
+          name: row.name,
+          membersFingerprint: await computeMembersFingerprint(members),
+          repositories: members,
+        };
+      })
+    );
+
+    return json({
+      environments: payload,
+      minRuntimeVersion: MIN_COMPATIBLE_RUNTIME_VERSION,
+    });
+  } catch (e) {
+    logger.error("environment_image.enabled_error", {
+      error: e instanceof Error ? e.message : String(e),
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return error("Failed to get enabled environments", 500);
+  }
+}
+
+/**
+ * POST /environment-images/mark-stale
+ * Mark old building rows as failed. Called by scheduler.
+ */
+async function handleMarkStale(
+  request: Request,
+  env: Env,
+  _match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const providerError = requireEnvironmentImages(env);
+  if (providerError) return providerError;
+
+  const dbError = requireDb(env);
+  if (dbError) return dbError;
+
+  let body: { max_age_seconds?: number };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    body = {};
+  }
+
+  const maxAgeMs =
+    body.max_age_seconds === undefined
+      ? DEFAULT_STALE_BUILD_MAX_AGE_MS
+      : body.max_age_seconds * MS_PER_SECOND;
+
+  const store = new EnvironmentImageStore(env.DB);
+
+  try {
+    const count = await store.markStaleBuildsAsFailed(maxAgeMs);
+
+    logger.info("environment_image.stale_marked", {
+      count,
+      max_age_seconds: maxAgeMs / MS_PER_SECOND,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+
+    return json({ ok: true, markedFailed: count });
+  } catch (e) {
+    logger.error("environment_image.mark_stale_error", {
+      error: e instanceof Error ? e.message : String(e),
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return error("Failed to mark stale builds", 500);
+  }
+}
+
+/**
+ * POST /environment-images/cleanup
+ * Delete old failed builds and reap superseded rows' provider artifacts.
+ * Called by scheduler.
+ */
+async function handleCleanup(
+  request: Request,
+  env: Env,
+  _match: RegExpMatchArray,
+  ctx: RequestContext
+): Promise<Response> {
+  const providerError = requireEnvironmentImages(env);
+  if (providerError) return providerError;
+
+  const dbError = requireDb(env);
+  if (dbError) return dbError;
+
+  let body: { max_age_seconds?: number };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    body = {};
+  }
+
+  const maxAgeMs =
+    body.max_age_seconds === undefined
+      ? DEFAULT_FAILED_BUILD_CLEANUP_MAX_AGE_MS
+      : body.max_age_seconds * MS_PER_SECOND;
+
+  try {
+    const result = await createEnvironmentImageBuildWorkflowFromEnv(env).cleanupImages(
+      maxAgeMs,
+      workflowContext(ctx)
+    );
+
+    logger.info("environment_image.cleanup", {
+      deleted: result.deletedFailed,
+      reaped_superseded: result.reapedSuperseded,
+      max_age_seconds: maxAgeMs / MS_PER_SECOND,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+
+    return json({
+      ok: true,
+      deleted: result.deletedFailed,
+      reapedSuperseded: result.reapedSuperseded,
+    });
+  } catch (e) {
+    logger.error("environment_image.cleanup_error", {
+      error: e instanceof Error ? e.message : String(e),
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return error("Failed to clean up old builds", 500);
+  }
+}
+
+export const environmentImageRoutes: Route[] = [
+  {
+    method: "POST",
+    pattern: parsePattern("/environment-images/build-complete"),
+    handler: handleBuildComplete,
+  },
+  {
+    method: "POST",
+    pattern: parsePattern("/environment-images/build-failed"),
+    handler: handleBuildFailed,
+  },
+  {
+    method: "POST",
+    pattern: parsePattern("/environment-images/trigger/:id"),
+    handler: handleTriggerBuild,
+  },
+  {
+    method: "GET",
+    pattern: parsePattern("/environment-images/status"),
+    handler: handleGetStatus,
+  },
+  {
+    method: "GET",
+    pattern: parsePattern("/environment-images/enabled"),
+    handler: handleGetEnabledEnvironments,
+  },
+  {
+    method: "POST",
+    pattern: parsePattern("/environment-images/mark-stale"),
+    handler: handleMarkStale,
+  },
+  {
+    method: "POST",
+    pattern: parsePattern("/environment-images/cleanup"),
+    handler: handleCleanup,
+  },
+];

--- a/packages/control-plane/src/routes/environment-images.ts
+++ b/packages/control-plane/src/routes/environment-images.ts
@@ -27,7 +27,14 @@ import type {
 import { getRepoImagesUnsupportedMessage } from "../repo-images/provider-policy";
 import type { Env } from "../types";
 import { getRepoImageCallbackBearerToken } from "./repo-image-callback-auth";
-import { type RequestContext, type Route, error, json, parsePattern } from "./shared";
+import {
+  type RequestContext,
+  type Route,
+  error,
+  json,
+  parseMaxAgeMs,
+  parsePattern,
+} from "./shared";
 
 const logger = createLogger("router:environment-images");
 const MS_PER_SECOND = 1000;
@@ -212,7 +219,7 @@ function buildCompleteCommand(
   let buildDurationMs: number | undefined;
   if (body.build_duration_seconds !== undefined) {
     if (typeof body.build_duration_seconds !== "number") {
-      return error("build_duration_seconds is required", 400);
+      return error("build_duration_seconds must be a number", 400);
     }
     buildDurationMs = body.build_duration_seconds * MS_PER_SECOND;
   }
@@ -360,8 +367,11 @@ async function handleTriggerBuild(
 
 /**
  * GET /environment-images/status[?environment_id=...]
- * Image rows (non-superseded) for the cron and the settings UI. Rows are
- * returned verbatim (snake_case columns; repository_shas is a JSON document).
+ * With environment_id: that environment's recent non-superseded rows (the
+ * settings UI / debugging view, failed rows included). Without: the cron's
+ * view — ready and building rows across all prebuild-enabled environments.
+ * Rows are returned verbatim (snake_case columns; repository_shas is a JSON
+ * document).
  */
 async function handleGetStatus(
   request: Request,
@@ -381,7 +391,7 @@ async function handleGetStatus(
   try {
     const images = environmentId
       ? await store.getStatus(environmentId)
-      : await store.getAllStatus();
+      : await store.getStatusForEnabledEnvironments();
     return json({ images });
   } catch (e) {
     logger.error("environment_image.status_error", {
@@ -466,17 +476,8 @@ async function handleMarkStale(
   const dbError = requireDb(env);
   if (dbError) return dbError;
 
-  let body: { max_age_seconds?: number };
-  try {
-    body = (await request.json()) as typeof body;
-  } catch {
-    body = {};
-  }
-
-  const maxAgeMs =
-    body.max_age_seconds === undefined
-      ? DEFAULT_STALE_BUILD_MAX_AGE_MS
-      : body.max_age_seconds * MS_PER_SECOND;
+  const maxAgeMs = await parseMaxAgeMs(request, DEFAULT_STALE_BUILD_MAX_AGE_MS);
+  if (maxAgeMs instanceof Response) return maxAgeMs;
 
   const store = new EnvironmentImageStore(env.DB);
 
@@ -518,17 +519,8 @@ async function handleCleanup(
   const dbError = requireDb(env);
   if (dbError) return dbError;
 
-  let body: { max_age_seconds?: number };
-  try {
-    body = (await request.json()) as typeof body;
-  } catch {
-    body = {};
-  }
-
-  const maxAgeMs =
-    body.max_age_seconds === undefined
-      ? DEFAULT_FAILED_BUILD_CLEANUP_MAX_AGE_MS
-      : body.max_age_seconds * MS_PER_SECOND;
+  const maxAgeMs = await parseMaxAgeMs(request, DEFAULT_FAILED_BUILD_CLEANUP_MAX_AGE_MS);
+  if (maxAgeMs instanceof Response) return maxAgeMs;
 
   try {
     const result = await createEnvironmentImageBuildWorkflowFromEnv(env).cleanupImages(

--- a/packages/control-plane/src/routes/environment-images.ts
+++ b/packages/control-plane/src/routes/environment-images.ts
@@ -26,6 +26,7 @@ import type {
 } from "../environment-images/types";
 import { getRepoImagesUnsupportedMessage } from "../repo-images/provider-policy";
 import type { Env } from "../types";
+import { getRepoImageCallbackBearerToken } from "./repo-image-callback-auth";
 import { type RequestContext, type Route, error, json, parsePattern } from "./shared";
 
 const logger = createLogger("router:environment-images");
@@ -70,11 +71,15 @@ async function workflowResultToResponse(
   result: EnvironmentImageWorkflowResult,
   ctx: RequestContext
 ): Promise<Response> {
-  if (result.cleanup) {
+  if (result.type === "completion_accepted") {
+    await scheduleWorkflowTask(result.finalization, ctx);
+  } else if (result.cleanup) {
     await scheduleWorkflowTask(result.cleanup, ctx);
   }
 
   switch (result.type) {
+    case "completion_accepted":
+      return json({ ok: true, snapshotPending: true });
     case "build_ready":
       return json({
         ok: true,
@@ -271,6 +276,7 @@ async function handleBuildComplete(
     const result = await createEnvironmentImageBuildWorkflowFromEnv(env).acceptBuildComplete({
       completion,
       authorizationHeader: request.headers.get("Authorization"),
+      callbackToken: getRepoImageCallbackBearerToken(request),
       context: workflowContext(ctx),
     });
     return workflowResultToResponse(result, ctx);
@@ -302,6 +308,7 @@ async function handleBuildFailed(
     const result = await createEnvironmentImageBuildWorkflowFromEnv(env).acceptBuildFailed({
       failure,
       authorizationHeader: request.headers.get("Authorization"),
+      callbackToken: getRepoImageCallbackBearerToken(request),
       context: workflowContext(ctx),
     });
     return workflowResultToResponse(result, ctx);

--- a/packages/control-plane/src/routes/environment-images.ts
+++ b/packages/control-plane/src/routes/environment-images.ts
@@ -12,10 +12,10 @@ import { EnvironmentImageStore } from "../db/environment-images";
 import { EnvironmentStore } from "../db/environments";
 import { createLogger } from "../logger";
 import { EnvironmentImageError } from "../environment-images/errors";
-import { computeMembersFingerprint } from "../environment-images/fingerprint";
+import { computeRepositoriesFingerprint } from "../environment-images/fingerprint";
 import {
   MIN_COMPATIBLE_RUNTIME_VERSION,
-  type EnvironmentImageMemberSha,
+  type EnvironmentImageRepositorySha,
 } from "../environment-images/model";
 import { createEnvironmentImageBuildWorkflowFromEnv } from "../environment-images/workflow";
 import type {
@@ -39,7 +39,7 @@ interface EnvironmentImageBuildCompleteBody {
   build_id?: unknown;
   provider_image_id?: unknown;
   provider_session_id?: unknown;
-  member_shas?: unknown;
+  repository_shas?: unknown;
   runtime_version?: unknown;
   build_duration_seconds?: unknown;
 }
@@ -172,18 +172,20 @@ function optionalStringField(value: unknown, fallback: string): string {
 }
 
 /**
- * Parse the member_shas document ([{repoOwner, repoName, baseSha}], the
+ * Parse the repository_shas document ([{repoOwner, repoName, baseSha}], the
  * single cross-language shape produced by the runtime). Malformed entries are
  * a 400 — deeper requirements (non-empty) are the workflow's fail-close.
  */
-function parseMemberShas(value: unknown): EnvironmentImageMemberSha[] | undefined | Response {
+function parseRepositoryShas(
+  value: unknown
+): EnvironmentImageRepositorySha[] | undefined | Response {
   if (value === undefined) return undefined;
-  if (!Array.isArray(value)) return error("member_shas must be an array", 400);
+  if (!Array.isArray(value)) return error("repository_shas must be an array", 400);
 
-  const members: EnvironmentImageMemberSha[] = [];
+  const shas: EnvironmentImageRepositorySha[] = [];
   for (const entry of value) {
     if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
-      return error("member_shas entries must be objects", 400);
+      return error("repository_shas entries must be objects", 400);
     }
     const { repoOwner, repoName, baseSha } = entry as Record<string, unknown>;
     if (
@@ -194,11 +196,11 @@ function parseMemberShas(value: unknown): EnvironmentImageMemberSha[] | undefine
       typeof baseSha !== "string" ||
       baseSha.length === 0
     ) {
-      return error("member_shas entries require repoOwner, repoName, and baseSha", 400);
+      return error("repository_shas entries require repoOwner, repoName, and baseSha", 400);
     }
-    members.push({ repoOwner, repoName, baseSha });
+    shas.push({ repoOwner, repoName, baseSha });
   }
-  return members;
+  return shas;
 }
 
 function buildCompleteCommand(
@@ -215,8 +217,8 @@ function buildCompleteCommand(
     buildDurationMs = body.build_duration_seconds * MS_PER_SECOND;
   }
 
-  const memberShas = parseMemberShas(body.member_shas);
-  if (memberShas instanceof Response) return memberShas;
+  const repositoryShas = parseRepositoryShas(body.repository_shas);
+  if (repositoryShas instanceof Response) return repositoryShas;
 
   return {
     buildId,
@@ -228,7 +230,7 @@ function buildCompleteCommand(
       typeof body.provider_session_id === "string" && body.provider_session_id.length > 0
         ? body.provider_session_id
         : undefined,
-    memberShas,
+    repositoryShas,
     runtimeVersion:
       typeof body.runtime_version === "string" && body.runtime_version.length > 0
         ? body.runtime_version
@@ -359,7 +361,7 @@ async function handleTriggerBuild(
 /**
  * GET /environment-images/status[?environment_id=...]
  * Image rows (non-superseded) for the cron and the settings UI. Rows are
- * returned verbatim (snake_case columns; member_shas is a JSON document).
+ * returned verbatim (snake_case columns; repository_shas is a JSON document).
  */
 async function handleGetStatus(
   request: Request,
@@ -393,7 +395,7 @@ async function handleGetStatus(
 
 /**
  * GET /environment-images/enabled
- * Prebuild-enabled environments with their current members and fingerprint,
+ * Prebuild-enabled environments with their current repositories and fingerprint,
  * plus the runtime floor — everything the cron's trigger checks need, so the
  * fingerprint algorithm never leaves the control plane (design §7.3).
  */
@@ -420,7 +422,7 @@ async function handleGetEnabledEnvironments(
 
     const payload = await Promise.all(
       enabled.map(async (row) => {
-        const members = (repositoriesById.get(row.id) ?? []).map((repo) => ({
+        const repositories = (repositoriesById.get(row.id) ?? []).map((repo) => ({
           repoOwner: repo.repo_owner,
           repoName: repo.repo_name,
           baseBranch: repo.base_branch,
@@ -428,8 +430,8 @@ async function handleGetEnabledEnvironments(
         return {
           id: row.id,
           name: row.name,
-          membersFingerprint: await computeMembersFingerprint(members),
-          repositories: members,
+          repositoriesFingerprint: await computeRepositoriesFingerprint(repositories),
+          repositories,
         };
       })
     );

--- a/packages/control-plane/src/routes/environment-secrets.ts
+++ b/packages/control-plane/src/routes/environment-secrets.ts
@@ -29,18 +29,34 @@ const logger = createLogger("router:environment-secrets");
 /**
  * Post-mutation hook (design §7.4): supersede every live image — their baked
  * secrets are now outdated — then kick a rebuild for prebuild-enabled
- * environments. The supersede is awaited so a failure surfaces to the caller;
- * the rebuild is detached and best-effort.
+ * environments. The supersede is awaited and fail-visible: the secrets are
+ * already stored at this point, so a failure returns a distinct error telling
+ * the caller to retry (a retried mutation re-runs the supersede) instead of
+ * masquerading as a failed write. The rebuild is detached and best-effort.
  */
 async function invalidateImagesAfterSecretsChange(
   env: Env,
   environment: EnvironmentRow,
   ctx: RequestContext
-): Promise<void> {
-  await supersedeEnvironmentImagesForSecretsChange(env, environment.id, ctx);
+): Promise<Response | null> {
+  try {
+    await supersedeEnvironmentImagesForSecretsChange(env, environment.id, ctx);
+  } catch (e) {
+    logger.error("environment.secrets_image_invalidation_failed", {
+      environment_id: environment.id,
+      error: e instanceof Error ? e.message : String(e),
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    });
+    return error(
+      "Secrets were saved, but prebuilt image invalidation failed — retry the update",
+      500
+    );
+  }
   if (environment.prebuild_enabled === 1) {
     scheduleEnvironmentImageBuildOnSave(env, environment.id, ctx);
   }
+  return null;
 }
 
 /**
@@ -128,7 +144,8 @@ async function handleSetEnvironmentSecrets(
       request_id: ctx.request_id,
       trace_id: ctx.trace_id,
     });
-    await invalidateImagesAfterSecretsChange(env, environment, ctx);
+    const invalidationError = await invalidateImagesAfterSecretsChange(env, environment, ctx);
+    if (invalidationError) return invalidationError;
     return json({
       status: "updated",
       environmentId: id,
@@ -177,7 +194,8 @@ async function handleDeleteEnvironmentSecret(
     });
     const environment = await new EnvironmentStore(env.DB).getById(id);
     if (environment) {
-      await invalidateImagesAfterSecretsChange(env, environment, ctx);
+      const invalidationError = await invalidateImagesAfterSecretsChange(env, environment, ctx);
+      if (invalidationError) return invalidationError;
     }
     return json({ status: "deleted", environmentId: id, key: normalizedKey });
   } catch (e) {
@@ -257,7 +275,8 @@ async function handleImportEnvironmentSecrets(
       request_id: ctx.request_id,
       trace_id: ctx.trace_id,
     });
-    await invalidateImagesAfterSecretsChange(env, environment, ctx);
+    const invalidationError = await invalidateImagesAfterSecretsChange(env, environment, ctx);
+    if (invalidationError) return invalidationError;
     return json({
       status: "imported",
       environmentId: id,

--- a/packages/control-plane/src/routes/environment-secrets.ts
+++ b/packages/control-plane/src/routes/environment-secrets.ts
@@ -4,10 +4,14 @@
  * Split from ./environments so each routes file stays focused.
  */
 
-import { EnvironmentStore } from "../db/environments";
+import { EnvironmentStore, type EnvironmentRow } from "../db/environments";
 import { EnvironmentSecretsStore } from "../db/environment-secrets";
 import { GlobalSecretsStore } from "../db/global-secrets";
 import { SecretsValidationError, normalizeKey, validateKey } from "../db/secrets-validation";
+import {
+  scheduleEnvironmentImageBuildOnSave,
+  supersedeEnvironmentImagesForSecretsChange,
+} from "../environment-images/save-hooks";
 import { createLogger } from "../logger";
 import {
   type Route,
@@ -21,6 +25,23 @@ import {
 import type { Env } from "../types";
 
 const logger = createLogger("router:environment-secrets");
+
+/**
+ * Post-mutation hook (design §7.4): supersede every live image — their baked
+ * secrets are now outdated — then kick a rebuild for prebuild-enabled
+ * environments. The supersede is awaited so a failure surfaces to the caller;
+ * the rebuild is detached and best-effort.
+ */
+async function invalidateImagesAfterSecretsChange(
+  env: Env,
+  environment: EnvironmentRow,
+  ctx: RequestContext
+): Promise<void> {
+  await supersedeEnvironmentImagesForSecretsChange(env, environment.id, ctx);
+  if (environment.prebuild_enabled === 1) {
+    scheduleEnvironmentImageBuildOnSave(env, environment.id, ctx);
+  }
+}
 
 /**
  * Require both D1 and the secrets encryption key, returning the resolved key so
@@ -86,7 +107,8 @@ async function handleSetEnvironmentSecrets(
   if (!id) return error("Environment ID required", 400);
 
   const store = new EnvironmentStore(env.DB);
-  if (!(await store.getById(id))) return error("Environment not found", 404);
+  const environment = await store.getById(id);
+  if (!environment) return error("Environment not found", 404);
 
   const body = await parseJsonBody<{ secrets?: Record<string, string> }>(request);
   if (body instanceof Response) return body;
@@ -106,6 +128,7 @@ async function handleSetEnvironmentSecrets(
       request_id: ctx.request_id,
       trace_id: ctx.trace_id,
     });
+    await invalidateImagesAfterSecretsChange(env, environment, ctx);
     return json({
       status: "updated",
       environmentId: id,
@@ -152,6 +175,10 @@ async function handleDeleteEnvironmentSecret(
       request_id: ctx.request_id,
       trace_id: ctx.trace_id,
     });
+    const environment = await new EnvironmentStore(env.DB).getById(id);
+    if (environment) {
+      await invalidateImagesAfterSecretsChange(env, environment, ctx);
+    }
     return json({ status: "deleted", environmentId: id, key: normalizedKey });
   } catch (e) {
     if (e instanceof SecretsValidationError) return error(e.message, 400);
@@ -184,7 +211,8 @@ async function handleImportEnvironmentSecrets(
   if (!id) return error("Environment ID required", 400);
 
   const store = new EnvironmentStore(env.DB);
-  if (!(await store.getById(id))) return error("Environment not found", 404);
+  const environment = await store.getById(id);
+  if (!environment) return error("Environment not found", 404);
 
   const body = await parseJsonBody<{ repoOwner?: string; repoName?: string; keys?: unknown }>(
     request
@@ -229,6 +257,7 @@ async function handleImportEnvironmentSecrets(
       request_id: ctx.request_id,
       trace_id: ctx.trace_id,
     });
+    await invalidateImagesAfterSecretsChange(env, environment, ctx);
     return json({
       status: "imported",
       environmentId: id,

--- a/packages/control-plane/src/routes/environments.ts
+++ b/packages/control-plane/src/routes/environments.ts
@@ -14,6 +14,7 @@ import {
   type EnvironmentRepositoryInsert,
 } from "../db/environments";
 import { generateId } from "../auth/crypto";
+import { scheduleEnvironmentImageBuildOnSave } from "../environment-images/save-hooks";
 import { createLogger } from "../logger";
 import {
   type Route,
@@ -144,6 +145,10 @@ async function handleCreateEnvironment(
     trace_id: ctx.trace_id,
   });
 
+  if (row.prebuild_enabled === 1) {
+    scheduleEnvironmentImageBuildOnSave(env, id, ctx);
+  }
+
   return json(
     { environment: toEnvironment(row, await store.getRepositoriesForEnvironment(id)) },
     201
@@ -219,6 +224,10 @@ async function handleUpdateEnvironment(
     request_id: ctx.request_id,
     trace_id: ctx.trace_id,
   });
+
+  if (updated.prebuild_enabled === 1) {
+    scheduleEnvironmentImageBuildOnSave(env, id, ctx);
+  }
 
   return json({
     environment: toEnvironment(updated, await store.getRepositoriesForEnvironment(id)),

--- a/packages/control-plane/src/routes/repo-images.ts
+++ b/packages/control-plane/src/routes/repo-images.ts
@@ -28,6 +28,7 @@ import {
   extractRepoParams,
   json,
   parseJsonBody,
+  parseMaxAgeMs,
   parsePattern,
 } from "./shared";
 import { getRepoImageCallbackBearerToken } from "./repo-image-callback-auth";
@@ -383,17 +384,8 @@ async function handleMarkStale(
     return error("Database not configured", 503);
   }
 
-  let body: { max_age_seconds?: number };
-  try {
-    body = (await request.json()) as typeof body;
-  } catch {
-    body = {};
-  }
-
-  const maxAgeMs =
-    body.max_age_seconds === undefined
-      ? DEFAULT_STALE_BUILD_MAX_AGE_MS
-      : body.max_age_seconds * MS_PER_SECOND;
+  const maxAgeMs = await parseMaxAgeMs(request, DEFAULT_STALE_BUILD_MAX_AGE_MS);
+  if (maxAgeMs instanceof Response) return maxAgeMs;
   const maxAgeSeconds = maxAgeMs / MS_PER_SECOND;
 
   const store = new RepoImageStore(env.DB);
@@ -436,17 +428,8 @@ async function handleCleanup(
     return error("Database not configured", 503);
   }
 
-  let body: { max_age_seconds?: number };
-  try {
-    body = (await request.json()) as typeof body;
-  } catch {
-    body = {};
-  }
-
-  const maxAgeMs =
-    body.max_age_seconds === undefined
-      ? DEFAULT_FAILED_BUILD_CLEANUP_MAX_AGE_MS
-      : body.max_age_seconds * MS_PER_SECOND;
+  const maxAgeMs = await parseMaxAgeMs(request, DEFAULT_FAILED_BUILD_CLEANUP_MAX_AGE_MS);
+  if (maxAgeMs instanceof Response) return maxAgeMs;
   const maxAgeSeconds = maxAgeMs / MS_PER_SECOND;
 
   const store = new RepoImageStore(env.DB);

--- a/packages/control-plane/src/routes/shared.ts
+++ b/packages/control-plane/src/routes/shared.ts
@@ -62,6 +62,34 @@ export function error(message: string, status = 400): Response {
 }
 
 /**
+ * max_age_seconds for the image-maintenance routes (repo + environment
+ * mark-stale/cleanup). Rejecting non-numbers matters: a null that fell
+ * through to `null * 1000 = 0` would mark every building row stale or delete
+ * every failed row.
+ */
+export async function parseMaxAgeMs(
+  request: Request,
+  defaultMs: number
+): Promise<number | Response> {
+  let body: { max_age_seconds?: unknown };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    body = {};
+  }
+
+  if (body.max_age_seconds === undefined) return defaultMs;
+  if (
+    typeof body.max_age_seconds !== "number" ||
+    !Number.isFinite(body.max_age_seconds) ||
+    body.max_age_seconds < 0
+  ) {
+    return error("max_age_seconds must be a non-negative number", 400);
+  }
+  return body.max_age_seconds * 1000;
+}
+
+/**
  * Raise from a route handler or helper to return an error response with a
  * specific status. Mapped centrally in router.ts's dispatch catch to
  * error(message, status), avoiding `| Response` plumbing in callers.

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -152,7 +152,7 @@ export interface BuildEnvironmentImageRequest {
   environmentId: string;
   buildId: string;
   callbackUrl: string;
-  /** Members in position order ([0] = primary), cloned at their base branches. */
+  /** Repositories in position order ([0] = primary), cloned at their base branches. */
   repositories: Array<{ repoOwner: string; repoName: string; baseBranch: string }>;
   userEnvVars?: Record<string, string>;
   /**

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -582,12 +582,7 @@ export class ModalClient {
           environment_id: request.environmentId,
           build_id: request.buildId,
           callback_url: request.callbackUrl,
-          // SessionRepositoryConfig wire form (sandbox_runtime/types.py).
-          repositories: request.repositories.map((repo) => ({
-            repo_owner: repo.repoOwner,
-            repo_name: repo.repoName,
-            branch: repo.baseBranch,
-          })),
+          repositories: request.repositories.map(toRepositoryConfigPayload),
           user_env_vars: request.userEnvVars,
           build_timeout_seconds: request.buildTimeoutSeconds ?? null,
         }),

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -148,6 +148,26 @@ export interface BuildRepoImageResponse {
   status: string;
 }
 
+export interface BuildEnvironmentImageRequest {
+  environmentId: string;
+  buildId: string;
+  callbackUrl: string;
+  /** Members in position order ([0] = primary), cloned at their base branches. */
+  repositories: Array<{ repoOwner: string; repoName: string; baseBranch: string }>;
+  userEnvVars?: Record<string, string>;
+  /**
+   * Build sandbox lifetime, in seconds. Already capped at
+   * MAX_BUILD_TIMEOUT_SECONDS by the trigger.
+   * Omitted → Modal applies DEFAULT_BUILD_TIMEOUT_SECONDS.
+   */
+  buildTimeoutSeconds?: number;
+}
+
+export interface BuildEnvironmentImageResponse {
+  buildId: string;
+  status: string;
+}
+
 export interface DeleteProviderImageRequest {
   providerImageId: string;
 }
@@ -188,6 +208,7 @@ export class ModalClient {
   private snapshotSandboxUrl: string;
   private restoreSandboxUrl: string;
   private buildRepoImageUrl: string;
+  private buildEnvironmentImageUrl: string;
   private deleteProviderImageUrl: string;
   private secret: string;
 
@@ -205,6 +226,7 @@ export class ModalClient {
     this.snapshotSandboxUrl = `${baseUrl}-api-snapshot-sandbox.modal.run`;
     this.restoreSandboxUrl = `${baseUrl}-api-restore-sandbox.modal.run`;
     this.buildRepoImageUrl = `${baseUrl}-api-build-repo-image.modal.run`;
+    this.buildEnvironmentImageUrl = `${baseUrl}-api-build-environment-image.modal.run`;
     this.deleteProviderImageUrl = `${baseUrl}-api-delete-provider-image.modal.run`;
   }
 
@@ -530,6 +552,74 @@ export class ModalClient {
         build_id: request.buildId,
         repo_owner: request.repoOwner,
         repo_name: request.repoName,
+        trace_id: correlation?.trace_id,
+        request_id: correlation?.request_id,
+        http_status: httpStatus,
+        duration_ms: Date.now() - startTime,
+        outcome,
+      });
+    }
+  }
+
+  /**
+   * Trigger an async environment image build on Modal (design §7.3).
+   */
+  async buildEnvironmentImage(
+    request: BuildEnvironmentImageRequest,
+    correlation?: CorrelationContext
+  ): Promise<BuildEnvironmentImageResponse> {
+    const startTime = Date.now();
+    const endpoint = "buildEnvironmentImage";
+    let httpStatus: number | undefined;
+    let outcome: "success" | "error" = "error";
+
+    try {
+      const headers = await this.getPostHeaders(correlation);
+      const response = await fetch(this.buildEnvironmentImageUrl, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          environment_id: request.environmentId,
+          build_id: request.buildId,
+          callback_url: request.callbackUrl,
+          // SessionRepositoryConfig wire form (sandbox_runtime/types.py).
+          repositories: request.repositories.map((repo) => ({
+            repo_owner: repo.repoOwner,
+            repo_name: repo.repoName,
+            branch: repo.baseBranch,
+          })),
+          user_env_vars: request.userEnvVars,
+          build_timeout_seconds: request.buildTimeoutSeconds ?? null,
+        }),
+      });
+
+      httpStatus = response.status;
+
+      if (!response.ok) {
+        const text = await response.text();
+        throw new ModalApiError(`Modal API error: ${response.status} ${text}`, response.status);
+      }
+
+      const result = (await response.json()) as ModalApiResponse<{
+        build_id: string;
+        status: string;
+      }>;
+
+      if (!result.success || !result.data) {
+        throw new Error(`Modal API error: ${result.error || "Unknown error"}`);
+      }
+
+      outcome = "success";
+      return {
+        buildId: result.data.build_id,
+        status: result.data.status,
+      };
+    } finally {
+      log.info("modal.request", {
+        event: "modal.request",
+        endpoint,
+        build_id: request.buildId,
+        environment_id: request.environmentId,
         trace_id: correlation?.trace_id,
         request_id: correlation?.request_id,
         http_status: httpStatus,

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -50,6 +50,33 @@ export interface ModalRepoImageBuildProvider {
   deleteProviderImage(providerImageId: string, correlation?: CorrelationContext): Promise<void>;
 }
 
+export interface TriggerModalEnvironmentImageBuildConfig {
+  buildId: string;
+  environmentId: string;
+  /** Members in position order ([0] = primary), cloned at their base branches. */
+  repositories: Array<{ repoOwner: string; repoName: string; baseBranch: string }>;
+  callbackUrl: string;
+  userEnvVars?: Record<string, string>;
+  /**
+   * Build sandbox lifetime, in milliseconds. Already capped by the trigger.
+   * Omitted -> Modal applies DEFAULT_BUILD_TIMEOUT_SECONDS.
+   */
+  buildTimeoutMs?: number;
+  correlation?: CorrelationContext;
+}
+
+export interface TriggerModalEnvironmentImageBuildResult {
+  buildId: string;
+  status: string;
+}
+
+export interface ModalEnvironmentImageBuildProvider {
+  triggerEnvironmentImageBuild(
+    config: TriggerModalEnvironmentImageBuildConfig
+  ): Promise<TriggerModalEnvironmentImageBuildResult>;
+  deleteProviderImage(providerImageId: string, correlation?: CorrelationContext): Promise<void>;
+}
+
 /**
  * Modal sandbox provider.
  *
@@ -70,7 +97,9 @@ export interface ModalRepoImageBuildProvider {
  * }
  * ```
  */
-export class ModalSandboxProvider implements SandboxProvider, ModalRepoImageBuildProvider {
+export class ModalSandboxProvider
+  implements SandboxProvider, ModalRepoImageBuildProvider, ModalEnvironmentImageBuildProvider
+{
   readonly name = "modal";
 
   readonly capabilities: SandboxProviderCapabilities = {
@@ -263,6 +292,47 @@ export class ModalSandboxProvider implements SandboxProvider, ModalRepoImageBuil
         throw error;
       }
       throw this.classifyError("Failed to trigger Modal repo image build", error);
+    }
+  }
+
+  /**
+   * Trigger a Modal environment-image build (design §7.3).
+   */
+  async triggerEnvironmentImageBuild(
+    config: TriggerModalEnvironmentImageBuildConfig
+  ): Promise<TriggerModalEnvironmentImageBuildResult> {
+    try {
+      const result = await this.client.buildEnvironmentImage(
+        {
+          environmentId: config.environmentId,
+          buildId: config.buildId,
+          callbackUrl: config.callbackUrl,
+          repositories: config.repositories,
+          userEnvVars: config.userEnvVars,
+          buildTimeoutSeconds:
+            config.buildTimeoutMs === undefined
+              ? undefined
+              : Math.ceil(config.buildTimeoutMs / MS_PER_SECOND),
+        },
+        config.correlation
+      );
+
+      return {
+        buildId: result.buildId,
+        status: result.status,
+      };
+    } catch (error) {
+      if (error instanceof ModalApiError) {
+        throw this.classifyErrorWithStatus(
+          `Environment image build failed with HTTP ${error.status}: ${error.message}`,
+          error.status,
+          error
+        );
+      }
+      if (error instanceof SandboxProviderError) {
+        throw error;
+      }
+      throw this.classifyError("Failed to trigger Modal environment image build", error);
     }
   }
 

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -53,7 +53,7 @@ export interface ModalRepoImageBuildProvider {
 export interface TriggerModalEnvironmentImageBuildConfig {
   buildId: string;
   environmentId: string;
-  /** Members in position order ([0] = primary), cloned at their base branches. */
+  /** Repositories in position order ([0] = primary), cloned at their base branches. */
   repositories: Array<{ repoOwner: string; repoName: string; baseBranch: string }>;
   callbackUrl: string;
   userEnvVars?: Record<string, string>;

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -624,6 +624,56 @@ describe("OpenComputerSandboxProvider", () => {
     });
   });
 
+  it("starts environment image builds with a repositories-bearing SESSION_CONFIG", async () => {
+    const client = createMockClient();
+    const onProviderSessionCreated = vi.fn(async () => undefined);
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await provider.triggerEnvironmentImageBuild({
+      buildId: "envimg-1",
+      environmentId: "env_flagship",
+      repositories: [
+        { repoOwner: "acme", repoName: "web", baseBranch: "main" },
+        { repoOwner: "acme", repoName: "api", baseBranch: "develop" },
+      ],
+      callbackUrl: "https://control.example/environment-images/build-complete",
+      callbackToken: "callback-token",
+      cloneToken: "clone-token",
+      onProviderSessionCreated,
+    });
+
+    const createCall = vi.mocked(client.createSandbox).mock.calls[0][0];
+    // Primary member mirrors into the scalar identity; the list drives the
+    // list-native runtime.
+    expect(createCall.env).toMatchObject({
+      IMAGE_BUILD_MODE: "true",
+      REPO_OWNER: "acme",
+      REPO_NAME: "web",
+      SANDBOX_ID: "build-env-env_flagship",
+      OI_REPO_IMAGE_BUILD_ID: "envimg-1",
+      OI_REPO_IMAGE_CALLBACK_URL: "https://control.example/environment-images/build-complete",
+      OI_REPO_IMAGE_CALLBACK_TOKEN: "callback-token",
+    });
+    expect(JSON.parse(createCall.env!.SESSION_CONFIG)).toEqual({
+      branch: "main",
+      repositories: [
+        { repo_owner: "acme", repo_name: "web", branch: "main" },
+        { repo_owner: "acme", repo_name: "api", branch: "develop" },
+      ],
+    });
+    expect(createCall.labels).toMatchObject({
+      openinspect_kind: "environment-image-build",
+      openinspect_environment: "env_flagship",
+    });
+    expect(onProviderSessionCreated).toHaveBeenCalledWith("oc-sandbox-1");
+    expect(client.startRuntime).toHaveBeenCalledWith("oc-sandbox-1", {
+      OI_REPO_IMAGE_PROVIDER_SESSION_ID: "oc-sandbox-1",
+    });
+  });
+
   it("cleans up a repo image build sandbox when runtime startup fails", async () => {
     const client = createMockClient({
       startRuntime: vi.fn(async () => {

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -646,7 +646,7 @@ describe("OpenComputerSandboxProvider", () => {
     });
 
     const createCall = vi.mocked(client.createSandbox).mock.calls[0][0];
-    // Primary member mirrors into the scalar identity; the list drives the
+    // Primary repository mirrors into the scalar identity; the list drives the
     // list-native runtime.
     expect(createCall.env).toMatchObject({
       IMAGE_BUILD_MODE: "true",

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -24,7 +24,7 @@ import {
   type OpenComputerSandboxResponse,
   type OpenComputerSecretStoreResponse,
 } from "../opencomputer-rest-client";
-import { buildSessionConfig } from "../sandbox-env";
+import { buildSessionConfig, toRepositoryConfigPayload } from "../sandbox-env";
 import {
   SandboxProviderError,
   type CreateSandboxConfig,
@@ -467,12 +467,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
         repoName: primary.repoName,
         sessionConfig: {
           branch: primary.baseBranch,
-          // SessionRepositoryConfig wire form (sandbox_runtime/types.py).
-          repositories: config.repositories.map((repo) => ({
-            repo_owner: repo.repoOwner,
-            repo_name: repo.repoName,
-            branch: repo.baseBranch,
-          })),
+          repositories: config.repositories.map(toRepositoryConfigPayload),
         },
         buildId: config.buildId,
         callbackUrl: config.callbackUrl,

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -72,6 +72,24 @@ export interface TriggerOpenComputerRepoImageBuildResult {
   status: string;
 }
 
+export interface TriggerOpenComputerEnvironmentImageBuildConfig {
+  buildId: string;
+  environmentId: string;
+  /** Members in position order ([0] = primary), cloned at their base branches. */
+  repositories: Array<{ repoOwner: string; repoName: string; baseBranch: string }>;
+  callbackUrl: string;
+  callbackToken: string;
+  userEnvVars?: Record<string, string>;
+  cloneToken?: string;
+  buildTimeoutSeconds?: number;
+  onProviderSessionCreated?: (providerSessionId: string) => Promise<void>;
+}
+
+export interface TriggerOpenComputerEnvironmentImageBuildResult {
+  buildId: string;
+  status: string;
+}
+
 export interface OpenComputerProviderConfig {
   scmProvider: SourceControlProviderName;
   /** Secret used for deterministic code-server password derivation */
@@ -361,7 +379,17 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     let providerObjectId: string | undefined;
     try {
       const sandboxName = `build-${config.repoOwner}-${config.repoName}-${Date.now()}`;
-      const environment = await this.buildBuildEnvironment(config);
+      const environment = this.buildBuildEnvironment({
+        userEnvVars: config.userEnvVars,
+        cloneToken: config.cloneToken,
+        sandboxId: `build-${config.repoOwner}-${config.repoName}`,
+        repoOwner: config.repoOwner,
+        repoName: config.repoName,
+        sessionConfig: { branch: config.defaultBranch },
+        buildId: config.buildId,
+        callbackUrl: config.callbackUrl,
+        callbackToken: config.callbackToken,
+      });
       secretStore = await this.createSecretStoreFor(config.buildId, environment.secretEnvVars);
       const sandbox = await this.client.createSandbox({
         name: sandboxName,
@@ -411,6 +439,93 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
       }
       if (error instanceof SandboxProviderError) throw error;
       throw this.classifyError("Failed to trigger OpenComputer repo image build", error);
+    }
+  }
+
+  /**
+   * Trigger an OpenComputer environment-image build (design §7.3). Same
+   * lifecycle as the repo-image build; the SESSION_CONFIG carries the member
+   * list so the list-native runtime clones and sets up every member.
+   */
+  async triggerEnvironmentImageBuild(
+    config: TriggerOpenComputerEnvironmentImageBuildConfig
+  ): Promise<TriggerOpenComputerEnvironmentImageBuildResult> {
+    let secretStore: OpenComputerSecretStoreResponse | undefined;
+    let providerObjectId: string | undefined;
+    try {
+      const primary = config.repositories[0];
+      if (!primary) {
+        throw new Error("environment build requires at least one repository");
+      }
+
+      const sandboxName = `build-env-${config.environmentId}-${Date.now()}`;
+      const environment = this.buildBuildEnvironment({
+        userEnvVars: config.userEnvVars,
+        cloneToken: config.cloneToken,
+        sandboxId: `build-env-${config.environmentId}`,
+        repoOwner: primary.repoOwner,
+        repoName: primary.repoName,
+        sessionConfig: {
+          branch: primary.baseBranch,
+          // SessionRepositoryConfig wire form (sandbox_runtime/types.py).
+          repositories: config.repositories.map((repo) => ({
+            repo_owner: repo.repoOwner,
+            repo_name: repo.repoName,
+            branch: repo.baseBranch,
+          })),
+        },
+        buildId: config.buildId,
+        callbackUrl: config.callbackUrl,
+        callbackToken: config.callbackToken,
+      });
+      secretStore = await this.createSecretStoreFor(config.buildId, environment.secretEnvVars);
+      const sandbox = await this.client.createSandbox({
+        name: sandboxName,
+        template: this.client.config.template,
+        env: environment.envVars,
+        labels: {
+          openinspect_framework: "open-inspect",
+          openinspect_provider: "opencomputer",
+          openinspect_kind: "environment-image-build",
+          openinspect_build_id: config.buildId,
+          openinspect_environment: config.environmentId,
+        },
+        timeoutSeconds: config.buildTimeoutSeconds ?? DEFAULT_BUILD_TIMEOUT_SECONDS,
+        secretStore: secretStore?.name,
+      });
+      providerObjectId = sandbox.id;
+
+      if (config.onProviderSessionCreated) {
+        await config.onProviderSessionCreated(sandbox.id);
+      }
+
+      await this.client.startRuntime(sandbox.id, {
+        [REPO_IMAGE_CALLBACK_ENV_KEYS[0]]: sandbox.id,
+      });
+      log.info("opencomputer.environment_image_build_triggered", {
+        build_id: config.buildId,
+        environment_id: config.environmentId,
+        sandbox_id: sandbox.id,
+      });
+
+      return { buildId: config.buildId, status: "building" };
+    } catch (error) {
+      if (providerObjectId) {
+        await this.cleanupSandboxAfterFailedCreate(providerObjectId, config.buildId);
+      }
+      if (secretStore) {
+        try {
+          await this.client.deleteSecretStore(secretStore.id);
+        } catch (cleanupError) {
+          log.warn("opencomputer.secret_store_cleanup_failed", {
+            build_id: config.buildId,
+            secret_store_id: secretStore.id,
+            error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+          });
+        }
+      }
+      if (error instanceof SandboxProviderError) throw error;
+      throw this.classifyError("Failed to trigger OpenComputer environment image build", error);
     }
   }
 
@@ -489,9 +604,18 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     return environment;
   }
 
-  private async buildBuildEnvironment(
-    config: TriggerOpenComputerRepoImageBuildConfig
-  ): Promise<PreparedOpenComputerEnvironment> {
+  /** Build-sandbox env for both repo- and environment-image builds; the caller owns identity + SESSION_CONFIG shape. */
+  private buildBuildEnvironment(config: {
+    userEnvVars?: Record<string, string>;
+    cloneToken?: string;
+    sandboxId: string;
+    repoOwner: string;
+    repoName: string;
+    sessionConfig: Record<string, unknown>;
+    buildId: string;
+    callbackUrl: string;
+    callbackToken: string;
+  }): PreparedOpenComputerEnvironment {
     const environment = this.prepareEnvironment(config.userEnvVars, {
       scrubReservedRepoImageEnv: true,
     });
@@ -499,11 +623,11 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
 
     Object.assign(envVars, {
       PYTHONUNBUFFERED: "1",
-      SANDBOX_ID: `build-${config.repoOwner}-${config.repoName}`,
+      SANDBOX_ID: config.sandboxId,
       REPO_OWNER: config.repoOwner,
       REPO_NAME: config.repoName,
       IMAGE_BUILD_MODE: "true",
-      SESSION_CONFIG: JSON.stringify({ branch: config.defaultBranch }),
+      SESSION_CONFIG: JSON.stringify(config.sessionConfig),
       [REPO_IMAGE_CALLBACK_ENV_KEYS[1]]: config.buildId,
       [REPO_IMAGE_CALLBACK_ENV_KEYS[2]]: config.callbackUrl,
       [REPO_IMAGE_CALLBACK_ENV_KEYS[3]]: config.callbackToken,

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -75,7 +75,7 @@ export interface TriggerOpenComputerRepoImageBuildResult {
 export interface TriggerOpenComputerEnvironmentImageBuildConfig {
   buildId: string;
   environmentId: string;
-  /** Members in position order ([0] = primary), cloned at their base branches. */
+  /** Repositories in position order ([0] = primary), cloned at their base branches. */
   repositories: Array<{ repoOwner: string; repoName: string; baseBranch: string }>;
   callbackUrl: string;
   callbackToken: string;
@@ -444,8 +444,8 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
 
   /**
    * Trigger an OpenComputer environment-image build (design §7.3). Same
-   * lifecycle as the repo-image build; the SESSION_CONFIG carries the member
-   * list so the list-native runtime clones and sets up every member.
+   * lifecycle as the repo-image build; the SESSION_CONFIG carries the repository
+   * list so the list-native runtime clones and sets up every repository.
    */
   async triggerEnvironmentImageBuild(
     config: TriggerOpenComputerEnvironmentImageBuildConfig

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
@@ -615,7 +615,7 @@ describe("VercelSandboxProvider", () => {
     });
 
     const createCall = vi.mocked(client.createSandbox).mock.calls[0][0];
-    // Primary member mirrors into the scalar identity; the list drives the
+    // Primary repository mirrors into the scalar identity; the list drives the
     // list-native runtime.
     expect(createCall.env).toEqual(
       expect.objectContaining({

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
@@ -596,6 +596,65 @@ describe("VercelSandboxProvider", () => {
     expect(result).toEqual({ buildId: "build-123", status: "building" });
   });
 
+  it("starts environment image builds with a repositories-bearing SESSION_CONFIG", async () => {
+    const client = createMockClient();
+    const onProviderSessionCreated = vi.fn(async () => undefined);
+    const provider = new VercelSandboxProvider(client, providerConfig);
+
+    const result = await provider.triggerEnvironmentImageBuild({
+      buildId: "envimg-1",
+      environmentId: "env_flagship",
+      repositories: [
+        { repoOwner: "acme", repoName: "web", baseBranch: "main" },
+        { repoOwner: "acme", repoName: "api", baseBranch: "develop" },
+      ],
+      callbackUrl: "https://control-plane.test/environment-images/build-complete",
+      callbackToken: "callback-token",
+      cloneToken: "clone-token",
+      onProviderSessionCreated,
+    });
+
+    const createCall = vi.mocked(client.createSandbox).mock.calls[0][0];
+    // Primary member mirrors into the scalar identity; the list drives the
+    // list-native runtime.
+    expect(createCall.env).toEqual(
+      expect.objectContaining({
+        IMAGE_BUILD_MODE: "true",
+        REPO_OWNER: "acme",
+        REPO_NAME: "web",
+        SANDBOX_ID: "build-env-env_flagship",
+        VCS_CLONE_TOKEN: "clone-token",
+      })
+    );
+    expect(JSON.parse(createCall.env?.SESSION_CONFIG as string)).toEqual({
+      branch: "main",
+      repositories: [
+        { repo_owner: "acme", repo_name: "web", branch: "main" },
+        { repo_owner: "acme", repo_name: "api", branch: "develop" },
+      ],
+    });
+    expect(createCall.tags).toEqual(
+      expect.objectContaining({
+        openinspect_kind: "environment-image-build",
+        openinspect_environment: "env_flagship",
+      })
+    );
+    expect(onProviderSessionCreated).toHaveBeenCalledWith("vercel-session-1");
+    expect(vi.mocked(client.startCommand)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: {
+          OI_REPO_IMAGE_PROVIDER_SESSION_ID: "vercel-session-1",
+          OI_REPO_IMAGE_BUILD_ID: "envimg-1",
+          OI_REPO_IMAGE_CALLBACK_URL:
+            "https://control-plane.test/environment-images/build-complete",
+          OI_REPO_IMAGE_CALLBACK_TOKEN: "callback-token",
+        },
+      }),
+      undefined
+    );
+    expect(result).toEqual({ buildId: "envimg-1", status: "building" });
+  });
+
   it("honors an explicit build timeout below the Vercel limit for repo image builds", async () => {
     const client = createMockClient();
     const provider = new VercelSandboxProvider(client, providerConfig);

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.ts
@@ -11,7 +11,7 @@ import { resolveServicePorts, resolveTunnelPorts } from "../port-resolution";
 import { createLogger } from "../../../logger";
 import type { CorrelationContext } from "../../../logger";
 import type { SourceControlProviderName } from "../../../source-control";
-import { buildSessionConfig } from "../../sandbox-env";
+import { buildSessionConfig, toRepositoryConfigPayload } from "../../sandbox-env";
 import {
   DEFAULT_SANDBOX_TIMEOUT_SECONDS,
   SandboxProviderError,
@@ -370,12 +370,7 @@ export class VercelSandboxProvider implements SandboxProvider {
         repoName: primary.repoName,
         sessionConfig: {
           branch: primary.baseBranch,
-          // SessionRepositoryConfig wire form (sandbox_runtime/types.py).
-          repositories: config.repositories.map((repo) => ({
-            repo_owner: repo.repoOwner,
-            repo_name: repo.repoName,
-            branch: repo.baseBranch,
-          })),
+          repositories: config.repositories.map(toRepositoryConfigPayload),
         },
       });
       const created = await this.client.createSandbox(

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.ts
@@ -101,7 +101,7 @@ export interface TriggerVercelRepoImageBuildResult {
 export interface TriggerVercelEnvironmentImageBuildConfig {
   buildId: string;
   environmentId: string;
-  /** Members in position order ([0] = primary), cloned at their base branches. */
+  /** Repositories in position order ([0] = primary), cloned at their base branches. */
   repositories: Array<{ repoOwner: string; repoName: string; baseBranch: string }>;
   callbackUrl: string;
   callbackToken: string;
@@ -342,8 +342,8 @@ export class VercelSandboxProvider implements SandboxProvider {
 
   /**
    * Trigger a Vercel environment-image build (design §7.3). Same lifecycle as
-   * the repo-image build; the SESSION_CONFIG carries the member list so the
-   * list-native runtime clones and sets up every member.
+   * the repo-image build; the SESSION_CONFIG carries the repository list so the
+   * list-native runtime clones and sets up every repository.
    */
   async triggerEnvironmentImageBuild(
     config: TriggerVercelEnvironmentImageBuildConfig

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.ts
@@ -98,6 +98,26 @@ export interface TriggerVercelRepoImageBuildResult {
   status: string;
 }
 
+export interface TriggerVercelEnvironmentImageBuildConfig {
+  buildId: string;
+  environmentId: string;
+  /** Members in position order ([0] = primary), cloned at their base branches. */
+  repositories: Array<{ repoOwner: string; repoName: string; baseBranch: string }>;
+  callbackUrl: string;
+  callbackToken: string;
+  userEnvVars?: Record<string, string>;
+  cloneToken?: string;
+  /** Same semantics as the repo-image build timeout above. */
+  buildTimeoutSeconds?: number;
+  onProviderSessionCreated?: (providerSessionId: string) => Promise<void>;
+  correlation?: CorrelationContext;
+}
+
+export interface TriggerVercelEnvironmentImageBuildResult {
+  buildId: string;
+  status: string;
+}
+
 export class VercelSandboxProvider implements SandboxProvider {
   readonly name = "vercel";
   private baseSnapshotIdPromise?: Promise<string>;
@@ -267,7 +287,14 @@ export class VercelSandboxProvider implements SandboxProvider {
       }
 
       const sandboxName = `build-${config.repoOwner}-${config.repoName}-${Date.now()}`;
-      const env = await this.buildBuildEnvVars(config);
+      const env = this.buildBuildEnvVars({
+        userEnvVars: config.userEnvVars,
+        cloneToken: config.cloneToken,
+        sandboxId: `build-${config.repoOwner}-${config.repoName}`,
+        repoOwner: config.repoOwner,
+        repoName: config.repoName,
+        sessionConfig: { branch: config.defaultBranch },
+      });
       const created = await this.client.createSandbox(
         {
           name: sandboxName,
@@ -310,6 +337,88 @@ export class VercelSandboxProvider implements SandboxProvider {
     } catch (error) {
       if (error instanceof SandboxProviderError) throw error;
       throw this.classifyError("Failed to trigger Vercel repo image build", error);
+    }
+  }
+
+  /**
+   * Trigger a Vercel environment-image build (design §7.3). Same lifecycle as
+   * the repo-image build; the SESSION_CONFIG carries the member list so the
+   * list-native runtime clones and sets up every member.
+   */
+  async triggerEnvironmentImageBuild(
+    config: TriggerVercelEnvironmentImageBuildConfig
+  ): Promise<TriggerVercelEnvironmentImageBuildResult> {
+    try {
+      const baseSnapshotId = await this.resolveBaseSnapshotId(config.correlation);
+      if (!baseSnapshotId) {
+        throw new Error(
+          "VERCEL_BASE_SNAPSHOT_ID or VERCEL_BASE_SNAPSHOT_NAME is required to build Vercel environment image snapshots"
+        );
+      }
+
+      const primary = config.repositories[0];
+      if (!primary) {
+        throw new Error("environment build requires at least one repository");
+      }
+
+      const sandboxName = `build-env-${config.environmentId}-${Date.now()}`;
+      const env = this.buildBuildEnvVars({
+        userEnvVars: config.userEnvVars,
+        cloneToken: config.cloneToken,
+        sandboxId: `build-env-${config.environmentId}`,
+        repoOwner: primary.repoOwner,
+        repoName: primary.repoName,
+        sessionConfig: {
+          branch: primary.baseBranch,
+          // SessionRepositoryConfig wire form (sandbox_runtime/types.py).
+          repositories: config.repositories.map((repo) => ({
+            repo_owner: repo.repoOwner,
+            repo_name: repo.repoName,
+            branch: repo.baseBranch,
+          })),
+        },
+      });
+      const created = await this.client.createSandbox(
+        {
+          name: sandboxName,
+          runtime: this.providerConfig.runtime || DEFAULT_VERCEL_RUNTIME,
+          timeoutMs: resolveVercelTimeoutMs(
+            config.buildTimeoutSeconds ?? DEFAULT_BUILD_TIMEOUT_SECONDS
+          ),
+          env,
+          tags: {
+            openinspect_framework: "open-inspect",
+            openinspect_kind: "environment-image-build",
+            openinspect_build_id: config.buildId,
+            openinspect_environment: config.environmentId,
+          },
+          sourceSnapshotId: baseSnapshotId,
+        },
+        config.correlation
+      );
+
+      if (config.onProviderSessionCreated) {
+        await config.onProviderSessionCreated(created.session.id);
+      }
+
+      const command = await this.launchEntrypoint(
+        created.session.id,
+        this.buildRepoImageCallbackEnv(config, created.session.id),
+        config.correlation
+      );
+
+      log.info("vercel.environment_image_build_triggered", {
+        build_id: config.buildId,
+        environment_id: config.environmentId,
+        session_id: created.session.id,
+        command_id: command.commandId,
+        sandbox_name: sandboxName,
+      });
+
+      return { buildId: config.buildId, status: "building" };
+    } catch (error) {
+      if (error instanceof SandboxProviderError) throw error;
+      throw this.classifyError("Failed to trigger Vercel environment image build", error);
     }
   }
 
@@ -378,9 +487,15 @@ export class VercelSandboxProvider implements SandboxProvider {
     return envVars;
   }
 
-  private async buildBuildEnvVars(
-    config: TriggerVercelRepoImageBuildConfig
-  ): Promise<Record<string, string>> {
+  /** Build-sandbox env for both repo- and environment-image builds; the caller owns identity + SESSION_CONFIG shape. */
+  private buildBuildEnvVars(config: {
+    userEnvVars?: Record<string, string>;
+    cloneToken?: string;
+    sandboxId: string;
+    repoOwner: string;
+    repoName: string;
+    sessionConfig: Record<string, unknown>;
+  }): Record<string, string> {
     const envVars: Record<string, string> = { ...(config.userEnvVars ?? {}) };
     for (const key of RESERVED_REPO_IMAGE_CALLBACK_ENV_KEYS) {
       delete envVars[key];
@@ -393,11 +508,11 @@ export class VercelSandboxProvider implements SandboxProvider {
       PYTHONPATH: "/app",
       PYTHONUNBUFFERED: "1",
       NODE_PATH: "/usr/lib/node_modules:/usr/local/lib/node_modules",
-      SANDBOX_ID: `build-${config.repoOwner}-${config.repoName}`,
+      SANDBOX_ID: config.sandboxId,
       REPO_OWNER: config.repoOwner,
       REPO_NAME: config.repoName,
       IMAGE_BUILD_MODE: "true",
-      SESSION_CONFIG: JSON.stringify({ branch: config.defaultBranch }),
+      SESSION_CONFIG: JSON.stringify(config.sessionConfig),
     });
 
     this.injectScmEnvVars(envVars, config.cloneToken);
@@ -569,7 +684,7 @@ export class VercelSandboxProvider implements SandboxProvider {
   }
 
   private buildRepoImageCallbackEnv(
-    config: TriggerVercelRepoImageBuildConfig,
+    config: { buildId: string; callbackUrl: string; callbackToken: string },
     sessionId: string
   ): Record<string, string> {
     return {

--- a/packages/control-plane/test/integration/environment-images.test.ts
+++ b/packages/control-plane/test/integration/environment-images.test.ts
@@ -176,6 +176,28 @@ describe("Environment images", () => {
       expect((await getRow("envimg-winner"))?.status).toBe("ready");
     });
 
+    it("registerBuild admits exactly one in-flight build per environment/provider", async () => {
+      const environmentId = await seedEnvironment();
+      const store = new EnvironmentImageStore(env.DB);
+      const build = (id: string) => ({
+        id,
+        environmentId,
+        provider: "modal" as const,
+        repositoriesFingerprint: "fp-race",
+      });
+
+      expect(await store.registerBuild(build("race-a"))).toBe(true);
+      // Concurrent trigger racing past the getActiveBuild read: the INSERT's
+      // NOT EXISTS guard is the authoritative gate.
+      expect(await store.registerBuild(build("race-b"))).toBe(false);
+      expect(await getRow("race-b")).toBeNull();
+
+      // Out-of-band supersede (secret change) releases the slot so the
+      // corrective rebuild can register.
+      await store.supersedeActiveImages(environmentId);
+      expect(await store.registerBuild(build("race-c"))).toBe(true);
+    });
+
     it("supersedeActiveImages flips building and ready rows for the secret-change hook", async () => {
       const environmentId = await seedEnvironment();
       const store = new EnvironmentImageStore(env.DB);
@@ -243,25 +265,42 @@ describe("Environment images", () => {
       );
     });
 
-    it("GET /environment-images/status returns non-superseded rows, filterable by environment", async () => {
-      const environmentId = await seedEnvironment();
-      const otherId = await seedEnvironment();
+    it("GET /environment-images/status serves the cron view unfiltered and the debug view per environment", async () => {
+      const environmentId = await seedEnvironment({ prebuildEnabled: true });
+      const otherId = await seedEnvironment({ prebuildEnabled: true });
+      const disabledId = await seedEnvironment();
       await seedImageRow({ id: "st-ready", environmentId, status: "ready", providerImageId: "im" });
       await seedImageRow({ id: "st-superseded", environmentId, status: "superseded" });
+      await seedImageRow({
+        id: "st-failed",
+        environmentId,
+        status: "failed",
+        createdAt: Date.now() - 1000,
+      });
       await seedImageRow({ id: "st-other", environmentId: otherId, status: "building" });
+      await seedImageRow({
+        id: "st-disabled",
+        environmentId: disabledId,
+        status: "ready",
+        providerImageId: "im-d",
+      });
 
+      // Cron view: ready + building rows of prebuild-enabled environments
+      // only — failed rows and disabled environments never crowd it, so a
+      // ready image can't drop out of the scheduler's sight.
       const all = await SELF.fetch(`${BASE}/environment-images/status`, {
         headers: await authHeaders(),
       });
       const allBody = (await all.json()) as { images: Array<{ id: string }> };
       expect(allBody.images.map((i) => i.id).sort()).toEqual(["st-other", "st-ready"]);
 
+      // Per-environment debug view keeps failed rows, drops only superseded.
       const filtered = await SELF.fetch(
         `${BASE}/environment-images/status?environment_id=${environmentId}`,
         { headers: await authHeaders() }
       );
       const filteredBody = (await filtered.json()) as { images: Array<{ id: string }> };
-      expect(filteredBody.images.map((i) => i.id)).toEqual(["st-ready"]);
+      expect(filteredBody.images.map((i) => i.id)).toEqual(["st-ready", "st-failed"]);
     });
 
     it("POST /environment-images/mark-stale fails old building rows", async () => {
@@ -320,6 +359,25 @@ describe("Environment images", () => {
       expect(await getRow("old-failed")).toBeNull();
       expect(await getRow("bare-superseded")).toBeNull();
       expect((await getRow("artifact-superseded"))?.status).toBe("superseded");
+    });
+
+    it("rejects non-numeric max_age_seconds instead of treating it as 0", async () => {
+      const environmentId = await seedEnvironment();
+      await seedImageRow({ id: "guard-building", environmentId, status: "building" });
+      await seedImageRow({ id: "guard-failed", environmentId, status: "failed" });
+
+      for (const path of ["mark-stale", "cleanup"]) {
+        const response = await SELF.fetch(`${BASE}/environment-images/${path}`, {
+          method: "POST",
+          headers: await authHeaders(),
+          body: JSON.stringify({ max_age_seconds: null }),
+        });
+        // A null that fell through to 0 would fail every building row or
+        // delete every failed row.
+        expect(response.status, path).toBe(400);
+      }
+      expect((await getRow("guard-building"))?.status).toBe("building");
+      expect((await getRow("guard-failed"))?.status).toBe("failed");
     });
 
     it("requires internal auth on cron-facing routes", async () => {

--- a/packages/control-plane/test/integration/environment-images.test.ts
+++ b/packages/control-plane/test/integration/environment-images.test.ts
@@ -1,0 +1,507 @@
+/**
+ * Environment image lifecycle against real D1 (design §7.3): store state
+ * machine (register → ready → supersede → reap), the cron-facing routes
+ * (enabled/status/mark-stale/cleanup), the build callbacks with internal
+ * HMAC auth and their fail-closed registration, and the secret-change
+ * supersede save-hook (§7.4).
+ *
+ * Builds are seeded via EnvironmentImageStore (or raw SQL when a test needs
+ * to control created_at) — actually triggering one needs a live Modal
+ * deployment, and the SCM-less harness split is the same as PR-4/PR-8.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { SELF, env } from "cloudflare:test";
+import { generateInternalToken } from "../../src/auth/internal";
+import { EnvironmentImageStore } from "../../src/db/environment-images";
+import { EnvironmentStore } from "../../src/db/environments";
+import { computeMembersFingerprint } from "../../src/environment-images/fingerprint";
+import { MIN_COMPATIBLE_RUNTIME_VERSION } from "../../src/environment-images/model";
+import { cleanD1Tables } from "./cleanup";
+
+const BASE = "https://test.local";
+const RUNTIME_VERSION = "v53-list-native-runtime";
+const MEMBER_SHAS = [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }];
+
+async function authHeaders(): Promise<Record<string, string>> {
+  const token = await generateInternalToken(env.INTERNAL_CALLBACK_SECRET!);
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+async function seedEnvironment(opts?: {
+  id?: string;
+  name?: string;
+  prebuildEnabled?: boolean;
+  repositories?: [string, string, number, string][];
+}): Promise<string> {
+  const store = new EnvironmentStore(env.DB);
+  const id = opts?.id ?? `env_${Math.random().toString(36).slice(2, 10)}`;
+  const now = Date.now();
+  await store.create(
+    {
+      id,
+      name: opts?.name ?? `Seeded ${id}`,
+      description: null,
+      prebuild_enabled: opts?.prebuildEnabled ? 1 : 0,
+      created_at: now,
+      updated_at: now,
+    },
+    (opts?.repositories ?? [["acme", "web", 1, "main"]]).map(([o, n, rid, b], position) => ({
+      position,
+      repo_owner: o,
+      repo_name: n,
+      repo_id: rid,
+      base_branch: b,
+    }))
+  );
+  return id;
+}
+
+/** Raw insert when a test needs to control created_at/status/artifact. */
+async function seedImageRow(row: {
+  id: string;
+  environmentId: string;
+  status: string;
+  providerImageId?: string | null;
+  membersFingerprint?: string;
+  createdAt?: number;
+}): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO environment_images
+       (id, environment_id, provider, provider_image_id, members_fingerprint,
+        member_shas, runtime_version, status, created_at)
+     VALUES (?, ?, 'modal', ?, ?, ?, ?, ?, ?)`
+  )
+    .bind(
+      row.id,
+      row.environmentId,
+      row.providerImageId ?? null,
+      row.membersFingerprint ?? "fp-seeded",
+      JSON.stringify(MEMBER_SHAS),
+      RUNTIME_VERSION,
+      row.status,
+      row.createdAt ?? Date.now()
+    )
+    .run();
+}
+
+async function getRow(id: string) {
+  return env.DB.prepare("SELECT * FROM environment_images WHERE id = ?")
+    .bind(id)
+    .first<Record<string, unknown>>();
+}
+
+describe("Environment images", () => {
+  beforeEach(cleanD1Tables);
+
+  describe("EnvironmentImageStore state machine", () => {
+    it("registers, marks ready, and supersedes older ready images", async () => {
+      const environmentId = await seedEnvironment();
+      const store = new EnvironmentImageStore(env.DB);
+
+      await seedImageRow({
+        id: "envimg-old",
+        environmentId,
+        status: "ready",
+        providerImageId: "im-old",
+        createdAt: Date.now() - 1000,
+      });
+
+      await store.registerBuild({
+        id: "envimg-new",
+        environmentId,
+        provider: "modal",
+        membersFingerprint: "fp-new",
+      });
+      expect(await store.getActiveBuild(environmentId, "modal")).toEqual({ id: "envimg-new" });
+
+      const result = await store.tryMarkEnvironmentImageReady(
+        "envimg-new",
+        "modal",
+        "im-new",
+        MEMBER_SHAS,
+        RUNTIME_VERSION,
+        12_500
+      );
+
+      expect(result.type).toBe("marked_ready");
+      if (result.type !== "marked_ready") throw new Error("unreachable");
+      expect(result.supersededImages).toEqual([
+        {
+          environmentImageId: "envimg-old",
+          image: { providerImageId: "im-old", providerSessionId: null },
+        },
+      ]);
+
+      const readyRow = await getRow("envimg-new");
+      expect(readyRow?.status).toBe("ready");
+      expect(readyRow?.provider_image_id).toBe("im-new");
+      expect(readyRow?.runtime_version).toBe(RUNTIME_VERSION);
+      expect(JSON.parse(readyRow?.member_shas as string)).toEqual(MEMBER_SHAS);
+      expect(readyRow?.build_duration_seconds).toBe(12.5);
+      expect((await getRow("envimg-old"))?.status).toBe("superseded");
+      expect(await store.getActiveBuild(environmentId, "modal")).toBeNull();
+    });
+
+    it("supersedes a late-finishing build when a newer ready image exists", async () => {
+      const environmentId = await seedEnvironment();
+      const store = new EnvironmentImageStore(env.DB);
+
+      await seedImageRow({
+        id: "envimg-late",
+        environmentId,
+        status: "building",
+        createdAt: Date.now() - 5000,
+      });
+      await seedImageRow({
+        id: "envimg-winner",
+        environmentId,
+        status: "ready",
+        providerImageId: "im-winner",
+      });
+
+      const result = await store.tryMarkEnvironmentImageReady(
+        "envimg-late",
+        "modal",
+        "im-late",
+        MEMBER_SHAS,
+        RUNTIME_VERSION,
+        10_000
+      );
+
+      expect(result.type).toBe("superseded_by_newer_ready");
+      expect((await getRow("envimg-late"))?.status).toBe("superseded");
+      // The late build recorded its artifact so the reaper can reclaim it.
+      expect((await getRow("envimg-late"))?.provider_image_id).toBe("im-late");
+      expect((await getRow("envimg-winner"))?.status).toBe("ready");
+    });
+
+    it("supersedeActiveImages flips building and ready rows for the secret-change hook", async () => {
+      const environmentId = await seedEnvironment();
+      const store = new EnvironmentImageStore(env.DB);
+      await seedImageRow({ id: "a-ready", environmentId, status: "ready", providerImageId: "im" });
+      await seedImageRow({ id: "a-building", environmentId, status: "building" });
+      await seedImageRow({ id: "a-failed", environmentId, status: "failed" });
+
+      const superseded = await store.supersedeActiveImages(environmentId);
+
+      expect(superseded).toBe(2);
+      expect((await getRow("a-ready"))?.status).toBe("superseded");
+      expect((await getRow("a-building"))?.status).toBe("superseded");
+      expect((await getRow("a-failed"))?.status).toBe("failed");
+    });
+
+    it("hasReadyImageForFingerprint matches only ready rows with the exact fingerprint", async () => {
+      const environmentId = await seedEnvironment();
+      const store = new EnvironmentImageStore(env.DB);
+      await seedImageRow({
+        id: "fp-row",
+        environmentId,
+        status: "ready",
+        providerImageId: "im",
+        membersFingerprint: "fp-x",
+      });
+
+      expect(await store.hasReadyImageForFingerprint(environmentId, "modal", "fp-x")).toBe(true);
+      expect(await store.hasReadyImageForFingerprint(environmentId, "modal", "fp-y")).toBe(false);
+    });
+  });
+
+  describe("cron-facing routes", () => {
+    it("GET /environment-images/enabled returns prebuild-enabled environments with fingerprints", async () => {
+      const enabledId = await seedEnvironment({
+        prebuildEnabled: true,
+        repositories: [
+          ["acme", "web", 1, "main"],
+          ["acme", "api", 2, "develop"],
+        ],
+      });
+      await seedEnvironment({ prebuildEnabled: false });
+
+      const response = await SELF.fetch(`${BASE}/environment-images/enabled`, {
+        headers: await authHeaders(),
+      });
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as {
+        environments: Array<{
+          id: string;
+          membersFingerprint: string;
+          repositories: Array<{ repoOwner: string; repoName: string; baseBranch: string }>;
+        }>;
+        minRuntimeVersion: number;
+      };
+      expect(body.minRuntimeVersion).toBe(MIN_COMPATIBLE_RUNTIME_VERSION);
+      expect(body.environments).toHaveLength(1);
+      expect(body.environments[0].id).toBe(enabledId);
+      expect(body.environments[0].repositories).toEqual([
+        { repoOwner: "acme", repoName: "web", baseBranch: "main" },
+        { repoOwner: "acme", repoName: "api", baseBranch: "develop" },
+      ]);
+      expect(body.environments[0].membersFingerprint).toBe(
+        await computeMembersFingerprint(body.environments[0].repositories)
+      );
+    });
+
+    it("GET /environment-images/status returns non-superseded rows, filterable by environment", async () => {
+      const environmentId = await seedEnvironment();
+      const otherId = await seedEnvironment();
+      await seedImageRow({ id: "st-ready", environmentId, status: "ready", providerImageId: "im" });
+      await seedImageRow({ id: "st-superseded", environmentId, status: "superseded" });
+      await seedImageRow({ id: "st-other", environmentId: otherId, status: "building" });
+
+      const all = await SELF.fetch(`${BASE}/environment-images/status`, {
+        headers: await authHeaders(),
+      });
+      const allBody = (await all.json()) as { images: Array<{ id: string }> };
+      expect(allBody.images.map((i) => i.id).sort()).toEqual(["st-other", "st-ready"]);
+
+      const filtered = await SELF.fetch(
+        `${BASE}/environment-images/status?environment_id=${environmentId}`,
+        { headers: await authHeaders() }
+      );
+      const filteredBody = (await filtered.json()) as { images: Array<{ id: string }> };
+      expect(filteredBody.images.map((i) => i.id)).toEqual(["st-ready"]);
+    });
+
+    it("POST /environment-images/mark-stale fails old building rows", async () => {
+      const environmentId = await seedEnvironment();
+      await seedImageRow({
+        id: "stale-build",
+        environmentId,
+        status: "building",
+        createdAt: Date.now() - 10_000_000,
+      });
+      await seedImageRow({ id: "fresh-build", environmentId, status: "building" });
+
+      const response = await SELF.fetch(`${BASE}/environment-images/mark-stale`, {
+        method: "POST",
+        headers: await authHeaders(),
+        body: JSON.stringify({ max_age_seconds: 3600 }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(((await response.json()) as { markedFailed: number }).markedFailed).toBe(1);
+      expect((await getRow("stale-build"))?.status).toBe("failed");
+      expect((await getRow("fresh-build"))?.status).toBe("building");
+    });
+
+    it("POST /environment-images/cleanup deletes old failed rows and reaps artifact-less superseded rows", async () => {
+      const environmentId = await seedEnvironment();
+      await seedImageRow({
+        id: "old-failed",
+        environmentId,
+        status: "failed",
+        createdAt: Date.now() - 100_000_000,
+      });
+      // Superseded before any artifact was recorded (environment delete or
+      // secret change mid-build) — reaped directly.
+      await seedImageRow({ id: "bare-superseded", environmentId, status: "superseded" });
+      // Superseded with an artifact: reclaiming it needs the provider adapter,
+      // which is unconfigured in the test env (no MODAL_WORKSPACE) — the row
+      // must survive for a later pass instead of leaking the artifact.
+      await seedImageRow({
+        id: "artifact-superseded",
+        environmentId,
+        status: "superseded",
+        providerImageId: "im-artifact",
+      });
+
+      const response = await SELF.fetch(`${BASE}/environment-images/cleanup`, {
+        method: "POST",
+        headers: await authHeaders(),
+        body: JSON.stringify({ max_age_seconds: 86400 }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = (await response.json()) as { deleted: number; reapedSuperseded: number };
+      expect(body.deleted).toBe(1);
+      expect(body.reapedSuperseded).toBe(1);
+      expect(await getRow("old-failed")).toBeNull();
+      expect(await getRow("bare-superseded")).toBeNull();
+      expect((await getRow("artifact-superseded"))?.status).toBe("superseded");
+    });
+
+    it("requires internal auth on cron-facing routes", async () => {
+      for (const [method, path] of [
+        ["GET", "/environment-images/enabled"],
+        ["GET", "/environment-images/status"],
+        ["POST", "/environment-images/mark-stale"],
+        ["POST", "/environment-images/cleanup"],
+        ["POST", "/environment-images/trigger/env_x"],
+      ] as const) {
+        const response = await SELF.fetch(`${BASE}${path}`, { method });
+        expect(response.status, `${method} ${path}`).toBe(401);
+      }
+    });
+  });
+
+  describe("build callbacks", () => {
+    async function registerBuild(environmentId: string, buildId: string): Promise<void> {
+      await new EnvironmentImageStore(env.DB).registerBuild({
+        id: buildId,
+        environmentId,
+        provider: "modal",
+        membersFingerprint: "fp-cb",
+      });
+    }
+
+    it("POST /environment-images/build-complete registers the image", async () => {
+      const environmentId = await seedEnvironment();
+      await registerBuild(environmentId, "cb-build");
+
+      const response = await SELF.fetch(`${BASE}/environment-images/build-complete`, {
+        method: "POST",
+        headers: await authHeaders(),
+        body: JSON.stringify({
+          build_id: "cb-build",
+          provider_image_id: "im-cb",
+          member_shas: MEMBER_SHAS,
+          runtime_version: RUNTIME_VERSION,
+          build_duration_seconds: 42.5,
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const row = await getRow("cb-build");
+      expect(row?.status).toBe("ready");
+      expect(row?.provider_image_id).toBe("im-cb");
+      expect(row?.runtime_version).toBe(RUNTIME_VERSION);
+      expect(JSON.parse(row?.member_shas as string)).toEqual(MEMBER_SHAS);
+    });
+
+    it("rejects callbacks without internal auth", async () => {
+      const environmentId = await seedEnvironment();
+      await registerBuild(environmentId, "cb-noauth");
+
+      const response = await SELF.fetch(`${BASE}/environment-images/build-complete`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          build_id: "cb-noauth",
+          provider_image_id: "im",
+          member_shas: MEMBER_SHAS,
+          runtime_version: RUNTIME_VERSION,
+          build_duration_seconds: 1,
+        }),
+      });
+
+      expect(response.status).toBe(401);
+      expect((await getRow("cb-noauth"))?.status).toBe("building");
+    });
+
+    it.each([
+      ["missing runtime_version", { runtime_version: undefined }],
+      ["unparseable runtime_version", { runtime_version: "53-no-prefix" }],
+      ["missing member_shas", { member_shas: undefined }],
+      ["member_shas entry without baseSha", { member_shas: [{ repoOwner: "a", repoName: "b" }] }],
+    ])("fails registration closed on %s", async (_label, overrides) => {
+      const environmentId = await seedEnvironment();
+      await registerBuild(environmentId, "cb-invalid");
+
+      const response = await SELF.fetch(`${BASE}/environment-images/build-complete`, {
+        method: "POST",
+        headers: await authHeaders(),
+        body: JSON.stringify({
+          build_id: "cb-invalid",
+          provider_image_id: "im",
+          member_shas: MEMBER_SHAS,
+          runtime_version: RUNTIME_VERSION,
+          build_duration_seconds: 1,
+          ...overrides,
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      expect((await getRow("cb-invalid"))?.status).toBe("building");
+    });
+
+    it("POST /environment-images/build-failed marks the build failed", async () => {
+      const environmentId = await seedEnvironment();
+      await registerBuild(environmentId, "cb-failed");
+
+      const response = await SELF.fetch(`${BASE}/environment-images/build-failed`, {
+        method: "POST",
+        headers: await authHeaders(),
+        body: JSON.stringify({ build_id: "cb-failed", error: "setup.failed: boom" }),
+      });
+
+      expect(response.status).toBe(200);
+      const row = await getRow("cb-failed");
+      expect(row?.status).toBe("failed");
+      expect(row?.error_message).toBe("setup.failed: boom");
+    });
+
+    it("rejects completion for unknown builds with 409", async () => {
+      const response = await SELF.fetch(`${BASE}/environment-images/build-complete`, {
+        method: "POST",
+        headers: await authHeaders(),
+        body: JSON.stringify({
+          build_id: "cb-unknown",
+          provider_image_id: "im",
+          member_shas: MEMBER_SHAS,
+          runtime_version: RUNTIME_VERSION,
+          build_duration_seconds: 1,
+        }),
+      });
+
+      expect(response.status).toBe(409);
+    });
+  });
+
+  describe("secret-change save-hook (design §7.4)", () => {
+    it("PUT /environments/:id/secrets supersedes live images", async () => {
+      const environmentId = await seedEnvironment();
+      await seedImageRow({
+        id: "sec-ready",
+        environmentId,
+        status: "ready",
+        providerImageId: "im-sec",
+      });
+      await seedImageRow({ id: "sec-building", environmentId, status: "building" });
+
+      const response = await SELF.fetch(`${BASE}/environments/${environmentId}/secrets`, {
+        method: "PUT",
+        headers: await authHeaders(),
+        body: JSON.stringify({ secrets: { API_KEY: "rotated-value" } }),
+      });
+
+      expect(response.status).toBe(200);
+      // Both the ready image (revoked value baked in) and the in-flight build
+      // (baking the outdated value) are invalidated in the same hook.
+      expect((await getRow("sec-ready"))?.status).toBe("superseded");
+      expect((await getRow("sec-building"))?.status).toBe("superseded");
+    });
+
+    it("DELETE /environments/:id/secrets/:key supersedes live images", async () => {
+      const environmentId = await seedEnvironment();
+      await seedImageRow({
+        id: "del-ready",
+        environmentId,
+        status: "ready",
+        providerImageId: "im-del",
+      });
+      await SELF.fetch(`${BASE}/environments/${environmentId}/secrets`, {
+        method: "PUT",
+        headers: await authHeaders(),
+        body: JSON.stringify({ secrets: { API_KEY: "v" } }),
+      });
+      // The PUT above already superseded del-ready; re-seed a fresh ready row
+      // to isolate the DELETE hook.
+      await seedImageRow({
+        id: "del-ready-2",
+        environmentId,
+        status: "ready",
+        providerImageId: "im-del-2",
+      });
+
+      const response = await SELF.fetch(`${BASE}/environments/${environmentId}/secrets/API_KEY`, {
+        method: "DELETE",
+        headers: await authHeaders(),
+      });
+
+      expect(response.status).toBe(200);
+      expect((await getRow("del-ready-2"))?.status).toBe("superseded");
+    });
+  });
+});

--- a/packages/control-plane/test/integration/environment-images.test.ts
+++ b/packages/control-plane/test/integration/environment-images.test.ts
@@ -432,6 +432,33 @@ describe("Environment images", () => {
       expect(row?.error_message).toBe("setup.failed: boom");
     });
 
+    it("records the artifact when a secret change superseded the build mid-flight", async () => {
+      const environmentId = await seedEnvironment();
+      await registerBuild(environmentId, "cb-late");
+      // Secret-change save-hook flips the in-flight build to superseded.
+      await new EnvironmentImageStore(env.DB).supersedeActiveImages(environmentId);
+
+      const response = await SELF.fetch(`${BASE}/environment-images/build-complete`, {
+        method: "POST",
+        headers: await authHeaders(),
+        body: JSON.stringify({
+          build_id: "cb-late",
+          provider_image_id: "im-late-orphan",
+          member_shas: MEMBER_SHAS,
+          runtime_version: RUNTIME_VERSION,
+          build_duration_seconds: 30,
+        }),
+      });
+
+      // Rejected — but the already-created provider artifact is recorded on
+      // the superseded row so the cleanup reaper reclaims it instead of
+      // leaking it (Modal snapshots never expire).
+      expect(response.status).toBe(409);
+      const row = await getRow("cb-late");
+      expect(row?.status).toBe("superseded");
+      expect(row?.provider_image_id).toBe("im-late-orphan");
+    });
+
     it("rejects completion for unknown builds with 409", async () => {
       const response = await SELF.fetch(`${BASE}/environment-images/build-complete`, {
         method: "POST",

--- a/packages/control-plane/test/integration/environment-images.test.ts
+++ b/packages/control-plane/test/integration/environment-images.test.ts
@@ -15,13 +15,13 @@ import { SELF, env } from "cloudflare:test";
 import { generateInternalToken } from "../../src/auth/internal";
 import { EnvironmentImageStore } from "../../src/db/environment-images";
 import { EnvironmentStore } from "../../src/db/environments";
-import { computeMembersFingerprint } from "../../src/environment-images/fingerprint";
+import { computeRepositoriesFingerprint } from "../../src/environment-images/fingerprint";
 import { MIN_COMPATIBLE_RUNTIME_VERSION } from "../../src/environment-images/model";
 import { cleanD1Tables } from "./cleanup";
 
 const BASE = "https://test.local";
 const RUNTIME_VERSION = "v53-list-native-runtime";
-const MEMBER_SHAS = [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }];
+const REPOSITORY_SHAS = [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }];
 
 async function authHeaders(): Promise<Record<string, string>> {
   const token = await generateInternalToken(env.INTERNAL_CALLBACK_SECRET!);
@@ -63,21 +63,21 @@ async function seedImageRow(row: {
   environmentId: string;
   status: string;
   providerImageId?: string | null;
-  membersFingerprint?: string;
+  repositoriesFingerprint?: string;
   createdAt?: number;
 }): Promise<void> {
   await env.DB.prepare(
     `INSERT INTO environment_images
-       (id, environment_id, provider, provider_image_id, members_fingerprint,
-        member_shas, runtime_version, status, created_at)
+       (id, environment_id, provider, provider_image_id, repositories_fingerprint,
+        repository_shas, runtime_version, status, created_at)
      VALUES (?, ?, 'modal', ?, ?, ?, ?, ?, ?)`
   )
     .bind(
       row.id,
       row.environmentId,
       row.providerImageId ?? null,
-      row.membersFingerprint ?? "fp-seeded",
-      JSON.stringify(MEMBER_SHAS),
+      row.repositoriesFingerprint ?? "fp-seeded",
+      JSON.stringify(REPOSITORY_SHAS),
       RUNTIME_VERSION,
       row.status,
       row.createdAt ?? Date.now()
@@ -111,7 +111,7 @@ describe("Environment images", () => {
         id: "envimg-new",
         environmentId,
         provider: "modal",
-        membersFingerprint: "fp-new",
+        repositoriesFingerprint: "fp-new",
       });
       expect(await store.getActiveBuild(environmentId, "modal")).toEqual({ id: "envimg-new" });
 
@@ -119,7 +119,7 @@ describe("Environment images", () => {
         "envimg-new",
         "modal",
         "im-new",
-        MEMBER_SHAS,
+        REPOSITORY_SHAS,
         RUNTIME_VERSION,
         12_500
       );
@@ -137,7 +137,7 @@ describe("Environment images", () => {
       expect(readyRow?.status).toBe("ready");
       expect(readyRow?.provider_image_id).toBe("im-new");
       expect(readyRow?.runtime_version).toBe(RUNTIME_VERSION);
-      expect(JSON.parse(readyRow?.member_shas as string)).toEqual(MEMBER_SHAS);
+      expect(JSON.parse(readyRow?.repository_shas as string)).toEqual(REPOSITORY_SHAS);
       expect(readyRow?.build_duration_seconds).toBe(12.5);
       expect((await getRow("envimg-old"))?.status).toBe("superseded");
       expect(await store.getActiveBuild(environmentId, "modal")).toBeNull();
@@ -164,7 +164,7 @@ describe("Environment images", () => {
         "envimg-late",
         "modal",
         "im-late",
-        MEMBER_SHAS,
+        REPOSITORY_SHAS,
         RUNTIME_VERSION,
         10_000
       );
@@ -199,7 +199,7 @@ describe("Environment images", () => {
         environmentId,
         status: "ready",
         providerImageId: "im",
-        membersFingerprint: "fp-x",
+        repositoriesFingerprint: "fp-x",
       });
 
       expect(await store.hasReadyImageForFingerprint(environmentId, "modal", "fp-x")).toBe(true);
@@ -226,7 +226,7 @@ describe("Environment images", () => {
       const body = (await response.json()) as {
         environments: Array<{
           id: string;
-          membersFingerprint: string;
+          repositoriesFingerprint: string;
           repositories: Array<{ repoOwner: string; repoName: string; baseBranch: string }>;
         }>;
         minRuntimeVersion: number;
@@ -238,8 +238,8 @@ describe("Environment images", () => {
         { repoOwner: "acme", repoName: "web", baseBranch: "main" },
         { repoOwner: "acme", repoName: "api", baseBranch: "develop" },
       ]);
-      expect(body.environments[0].membersFingerprint).toBe(
-        await computeMembersFingerprint(body.environments[0].repositories)
+      expect(body.environments[0].repositoriesFingerprint).toBe(
+        await computeRepositoriesFingerprint(body.environments[0].repositories)
       );
     });
 
@@ -342,7 +342,7 @@ describe("Environment images", () => {
         id: buildId,
         environmentId,
         provider: "modal",
-        membersFingerprint: "fp-cb",
+        repositoriesFingerprint: "fp-cb",
       });
     }
 
@@ -356,7 +356,7 @@ describe("Environment images", () => {
         body: JSON.stringify({
           build_id: "cb-build",
           provider_image_id: "im-cb",
-          member_shas: MEMBER_SHAS,
+          repository_shas: REPOSITORY_SHAS,
           runtime_version: RUNTIME_VERSION,
           build_duration_seconds: 42.5,
         }),
@@ -367,7 +367,7 @@ describe("Environment images", () => {
       expect(row?.status).toBe("ready");
       expect(row?.provider_image_id).toBe("im-cb");
       expect(row?.runtime_version).toBe(RUNTIME_VERSION);
-      expect(JSON.parse(row?.member_shas as string)).toEqual(MEMBER_SHAS);
+      expect(JSON.parse(row?.repository_shas as string)).toEqual(REPOSITORY_SHAS);
     });
 
     it("rejects callbacks without internal auth", async () => {
@@ -380,7 +380,7 @@ describe("Environment images", () => {
         body: JSON.stringify({
           build_id: "cb-noauth",
           provider_image_id: "im",
-          member_shas: MEMBER_SHAS,
+          repository_shas: REPOSITORY_SHAS,
           runtime_version: RUNTIME_VERSION,
           build_duration_seconds: 1,
         }),
@@ -393,8 +393,11 @@ describe("Environment images", () => {
     it.each([
       ["missing runtime_version", { runtime_version: undefined }],
       ["unparseable runtime_version", { runtime_version: "53-no-prefix" }],
-      ["missing member_shas", { member_shas: undefined }],
-      ["member_shas entry without baseSha", { member_shas: [{ repoOwner: "a", repoName: "b" }] }],
+      ["missing repository_shas", { repository_shas: undefined }],
+      [
+        "repository_shas entry without baseSha",
+        { repository_shas: [{ repoOwner: "a", repoName: "b" }] },
+      ],
     ])("fails registration closed on %s", async (_label, overrides) => {
       const environmentId = await seedEnvironment();
       await registerBuild(environmentId, "cb-invalid");
@@ -405,7 +408,7 @@ describe("Environment images", () => {
         body: JSON.stringify({
           build_id: "cb-invalid",
           provider_image_id: "im",
-          member_shas: MEMBER_SHAS,
+          repository_shas: REPOSITORY_SHAS,
           runtime_version: RUNTIME_VERSION,
           build_duration_seconds: 1,
           ...overrides,
@@ -444,7 +447,7 @@ describe("Environment images", () => {
         body: JSON.stringify({
           build_id: "cb-late",
           provider_image_id: "im-late-orphan",
-          member_shas: MEMBER_SHAS,
+          repository_shas: REPOSITORY_SHAS,
           runtime_version: RUNTIME_VERSION,
           build_duration_seconds: 30,
         }),
@@ -466,7 +469,7 @@ describe("Environment images", () => {
         body: JSON.stringify({
           build_id: "cb-unknown",
           provider_image_id: "im",
-          member_shas: MEMBER_SHAS,
+          repository_shas: REPOSITORY_SHAS,
           runtime_version: RUNTIME_VERSION,
           build_duration_seconds: 1,
         }),

--- a/packages/control-plane/test/integration/environment-store.test.ts
+++ b/packages/control-plane/test/integration/environment-store.test.ts
@@ -120,10 +120,10 @@ describe("EnvironmentStore", () => {
       .run();
     await env.DB.batch([
       env.DB.prepare(
-        "INSERT INTO environment_images (id, environment_id, members_fingerprint, member_shas, runtime_version, status, created_at) VALUES (?, ?, ?, ?, ?, 'ready', ?)"
+        "INSERT INTO environment_images (id, environment_id, repositories_fingerprint, repository_shas, runtime_version, status, created_at) VALUES (?, ?, ?, ?, ?, 'ready', ?)"
       ).bind("img_ready", row.id, "fp", "[]", "v3", now),
       env.DB.prepare(
-        "INSERT INTO environment_images (id, environment_id, members_fingerprint, member_shas, runtime_version, status, created_at) VALUES (?, ?, ?, ?, ?, 'failed', ?)"
+        "INSERT INTO environment_images (id, environment_id, repositories_fingerprint, repository_shas, runtime_version, status, created_at) VALUES (?, ?, ?, ?, ?, 'failed', ?)"
       ).bind("img_failed", row.id, "fp", "[]", "v3", now),
     ]);
 

--- a/packages/modal-infra/src/scheduler/image_builder.py
+++ b/packages/modal-infra/src/scheduler/image_builder.py
@@ -870,6 +870,97 @@ async def _rebuild_environment_images_pass(control_plane_url: str, clone_token: 
     return builds_triggered
 
 
+async def _rebuild_repo_images_pass(control_plane_url: str) -> int:
+    """
+    Repo-images pass:
+    1. Fetch list of repos with image building enabled from control plane
+    2. Fetch current image status for all repos
+    3. For each enabled repo, check remote HEAD SHA via git ls-remote
+    4. If SHA differs from latest ready image, trigger a build
+    5. Mark stale builds as failed
+    6. Clean up old failed D1 rows
+
+    Returns the number of builds triggered.
+    """
+    # 1. Get enabled repos
+    enabled_data = await _api_get(f"{control_plane_url}/repo-images/enabled-repos")
+    enabled_repos: list[dict] = enabled_data.get("repos", [])
+
+    if not enabled_repos:
+        log.info("scheduler.no_enabled_repos")
+        return 0
+
+    builds_triggered = 0
+
+    # 2. Get current image status (all repos)
+    status_data = await _api_get(f"{control_plane_url}/repo-images/status")
+    all_images: list[dict] = status_data.get("images", [])
+
+    # 3. Generate GitHub App token for ls-remote
+    clone_token = resolve_clone_token() or ""
+
+    # 4. Check each enabled repo
+    for repo in enabled_repos:
+        repo_owner = repo.get("repoOwner", "")
+        repo_name = repo.get("repoName", "")
+
+        if not repo_owner or not repo_name:
+            continue
+
+        # Detect changes on the repo's default branch via HEAD: ls-remote
+        # resolves HEAD to the default branch tip, so the scheduler never
+        # needs the branch name. The build path resolves the name when it
+        # tags the image (see handleTriggerBuild in repo-images.ts).
+        remote_sha = _git_ls_remote_sha(repo_owner, repo_name, "HEAD", clone_token)
+        if not remote_sha:
+            continue
+
+        if _should_rebuild(repo_owner, repo_name, remote_sha, all_images):
+            try:
+                await _api_post(
+                    f"{control_plane_url}/repo-images/trigger/{repo_owner}/{repo_name}",
+                )
+                builds_triggered += 1
+                log.info(
+                    "scheduler.build_triggered",
+                    repo_owner=repo_owner,
+                    repo_name=repo_name,
+                )
+            except Exception as e:
+                log.error(
+                    "scheduler.trigger_error",
+                    repo_owner=repo_owner,
+                    repo_name=repo_name,
+                    error=str(e),
+                )
+
+    # 5. Mark stale builds as failed
+    try:
+        result = await _api_post(
+            f"{control_plane_url}/repo-images/mark-stale",
+            {"max_age_seconds": STALE_BUILD_THRESHOLD_SECONDS},
+        )
+        stale_count = result.get("markedFailed", 0)
+        if stale_count:
+            log.info("scheduler.stale_marked", count=stale_count)
+    except Exception as e:
+        log.warn("scheduler.mark_stale_error", error=str(e))
+
+    # 6. Clean up old failed builds
+    try:
+        result = await _api_post(
+            f"{control_plane_url}/repo-images/cleanup",
+            {"max_age_seconds": FAILED_BUILD_CLEANUP_SECONDS},
+        )
+        deleted = result.get("deleted", 0)
+        if deleted:
+            log.info("scheduler.cleanup", deleted=deleted)
+    except Exception as e:
+        log.warn("scheduler.cleanup_error", error=str(e))
+
+    return builds_triggered
+
+
 @app.function(
     image=function_image,
     schedule=modal.Cron("*/30 * * * *"),
@@ -878,14 +969,12 @@ async def _rebuild_environment_images_pass(control_plane_url: str, clone_token: 
 )
 async def rebuild_repo_images():
     """
-    Every 30 minutes:
-    1. Fetch list of repos with image building enabled from control plane
-    2. Fetch current image status for all repos
-    3. For each enabled repo, check remote HEAD SHA via git ls-remote
-    4. If SHA differs from latest ready image, trigger a build
-    5. Mark stale builds as failed
-    6. Clean up old failed D1 rows
-    7. Run the environments pass (same skeleton, per-repository drift checks)
+    Every 30 minutes, run the repo-images pass and the environments pass.
+    Each pass is isolated in its own try/except so a failure — or an early
+    exit like "no enabled repos" — in one can never starve the other.
+
+    (The function keeps its historical name: it is the deployed Modal cron
+    entrypoint, and renaming it would replace the scheduled function.)
     """
     control_plane_url = os.environ.get("CONTROL_PLANE_URL", "")
     if not control_plane_url:
@@ -898,85 +987,10 @@ async def rebuild_repo_images():
     environment_builds_triggered = 0
 
     try:
-        # 1. Get enabled repos
-        enabled_data = await _api_get(f"{control_plane_url}/repo-images/enabled-repos")
-        enabled_repos: list[dict] = enabled_data.get("repos", [])
-
-        if not enabled_repos:
-            log.info("scheduler.no_enabled_repos")
-            return
-
-        # 2. Get current image status (all repos)
-        status_data = await _api_get(f"{control_plane_url}/repo-images/status")
-        all_images: list[dict] = status_data.get("images", [])
-
-        # 3. Generate GitHub App token for ls-remote
-        clone_token = resolve_clone_token() or ""
-
-        # 4. Check each enabled repo
-        for repo in enabled_repos:
-            repo_owner = repo.get("repoOwner", "")
-            repo_name = repo.get("repoName", "")
-
-            if not repo_owner or not repo_name:
-                continue
-
-            # Detect changes on the repo's default branch via HEAD: ls-remote
-            # resolves HEAD to the default branch tip, so the scheduler never
-            # needs the branch name. The build path resolves the name when it
-            # tags the image (see handleTriggerBuild in repo-images.ts).
-            remote_sha = _git_ls_remote_sha(repo_owner, repo_name, "HEAD", clone_token)
-            if not remote_sha:
-                continue
-
-            if _should_rebuild(repo_owner, repo_name, remote_sha, all_images):
-                try:
-                    await _api_post(
-                        f"{control_plane_url}/repo-images/trigger/{repo_owner}/{repo_name}",
-                    )
-                    builds_triggered += 1
-                    log.info(
-                        "scheduler.build_triggered",
-                        repo_owner=repo_owner,
-                        repo_name=repo_name,
-                    )
-                except Exception as e:
-                    log.error(
-                        "scheduler.trigger_error",
-                        repo_owner=repo_owner,
-                        repo_name=repo_name,
-                        error=str(e),
-                    )
-
-        # 5. Mark stale builds as failed
-        try:
-            result = await _api_post(
-                f"{control_plane_url}/repo-images/mark-stale",
-                {"max_age_seconds": STALE_BUILD_THRESHOLD_SECONDS},
-            )
-            stale_count = result.get("markedFailed", 0)
-            if stale_count:
-                log.info("scheduler.stale_marked", count=stale_count)
-        except Exception as e:
-            log.warn("scheduler.mark_stale_error", error=str(e))
-
-        # 6. Clean up old failed builds
-        try:
-            result = await _api_post(
-                f"{control_plane_url}/repo-images/cleanup",
-                {"max_age_seconds": FAILED_BUILD_CLEANUP_SECONDS},
-            )
-            deleted = result.get("deleted", 0)
-            if deleted:
-                log.info("scheduler.cleanup", deleted=deleted)
-        except Exception as e:
-            log.warn("scheduler.cleanup_error", error=str(e))
-
+        builds_triggered = await _rebuild_repo_images_pass(control_plane_url)
     except Exception as e:
         log.error("scheduler.error", error=str(e))
 
-    # Environments pass — isolated so a repo-pass failure never starves it
-    # and vice versa.
     try:
         clone_token = resolve_clone_token() or ""
         environment_builds_triggered = await _rebuild_environment_images_pass(

--- a/packages/modal-infra/src/scheduler/image_builder.py
+++ b/packages/modal-infra/src/scheduler/image_builder.py
@@ -23,9 +23,11 @@ The scheduler flow:
 import asyncio
 import json
 import os
+import re
 import subprocess
 import time
 from collections.abc import Iterable
+from dataclasses import dataclass, field
 
 import httpx
 import modal
@@ -174,24 +176,32 @@ async def _callback_with_retry(
     return False
 
 
-async def _stream_build_logs(
-    sandbox, redact_values: Iterable[str] = ()
-) -> tuple[str, bool, str | None]:
+@dataclass
+class BuildLogResult:
+    """What the build runtime reported through its structured log stream."""
+
+    head_sha: str = ""
+    member_shas: list[dict] = field(default_factory=list)
+    runtime_version: str = ""
+    complete: bool = False
+    error: str | None = None
+
+
+async def _stream_build_logs(sandbox, redact_values: Iterable[str] = ()) -> BuildLogResult:
     """
     Stream sandbox stdout and extract build results.
 
     The entrypoint logs structured JSON lines. We look for:
-    - event="git.sync_complete" with "head_sha" field
-    - event="image_build.complete" to know the build finished
+    - event="git.sync_complete" with "head_sha" (single-repo) and "member_shas"
+      (per-member provenance, [{repoOwner, repoName, baseSha}])
+    - event="image_build.complete" with "runtime_version" to know the build
+      finished and which runtime it baked
     - setup/supervisor errors to preserve the actual build failure
 
     The sandbox stays alive after logging image_build.complete (it awaits
     shutdown_event), so we can snapshot_filesystem() while it's still running.
-
-    Returns:
-        (head_sha, build_complete, error_message) tuple. head_sha is empty string if not found.
     """
-    head_sha = ""
+    result = BuildLogResult()
     setup_error: str | None = None
     supervisor_error: str | None = None
     redact_values = tuple(redact_values)
@@ -204,10 +214,16 @@ async def _stream_build_logs(
                 event = entry.get("event")
                 if not isinstance(event, str):
                     continue
-                if event == "git.sync_complete" and entry.get("head_sha"):
-                    head_sha = entry["head_sha"]
+                if event == "git.sync_complete":
+                    if entry.get("head_sha"):
+                        result.head_sha = entry["head_sha"]
+                    if isinstance(entry.get("member_shas"), list):
+                        result.member_shas = entry["member_shas"]
                 elif event == "image_build.complete":
-                    return head_sha, True, None
+                    if isinstance(entry.get("runtime_version"), str):
+                        result.runtime_version = entry["runtime_version"]
+                    result.complete = True
+                    return result
 
                 failure_message = _format_build_failure_event(entry, redact_values)
                 if failure_message and event in _SETUP_FAILURE_EVENTS and setup_error is None:
@@ -218,7 +234,8 @@ async def _stream_build_logs(
                 continue
     except Exception as e:
         log.warn("build.stream_error", error=str(e))
-    return head_sha, False, setup_error or supervisor_error
+    result.error = setup_error or supervisor_error
+    return result
 
 
 @app.function(
@@ -289,15 +306,16 @@ async def build_repo_image(
 
         # 3. Stream stdout until build completes (sandbox stays alive for snapshotting)
         redact_values = (clone_token, *((user_env_vars or {}).values()))
-        base_sha, build_complete, build_error = await _stream_build_logs(
+        build_logs = await _stream_build_logs(
             handle.modal_sandbox,
             redact_values=redact_values,
         )
-        if not build_complete:
+        if not build_logs.complete:
             exit_code = handle.modal_sandbox.returncode
-            if build_error:
-                raise BuildError(f"Build sandbox exited without completing: {build_error}")
+            if build_logs.error:
+                raise BuildError(f"Build sandbox exited without completing: {build_logs.error}")
             raise BuildError(f"Build sandbox exited without completing (exit_code={exit_code})")
+        base_sha = build_logs.head_sha
 
         # 4. Snapshot the running sandbox's filesystem
         image = await handle.modal_sandbox.snapshot_filesystem.aio(
@@ -358,6 +376,160 @@ async def build_repo_image(
             await _terminate_build_sandbox(handle, build_id, "cleanup")
 
 
+@app.function(
+    image=function_image,
+    secrets=[internal_api_secret, github_app_secrets],
+    timeout=build_function_timeout_seconds(DEFAULT_BUILD_TIMEOUT_SECONDS),
+)
+async def build_environment_image(
+    environment_id: str,
+    repositories: list[dict],
+    callback_url: str = "",
+    build_id: str = "",
+    user_env_vars: dict[str, str] | None = None,
+    build_timeout_seconds: int | None = None,
+) -> None:
+    """
+    Async worker: build an environment image (design §7.3).
+
+    Generalizes build_repo_image to a repository set: the build sandbox gets
+    SESSION_CONFIG.repositories and the list-native runtime clones every
+    member and runs each member's setup.sh sequentially, fatally. The success
+    callback carries what only the build knows — per-member clone provenance
+    (member_shas) and the baked runtime_version — while the members
+    fingerprint stays control-plane-side on the registered row.
+
+    Args:
+        environment_id: Environment the image belongs to (env_<id>)
+        repositories: SessionRepositoryConfig list ([{repo_owner, repo_name,
+            branch}], position order, [0] = primary)
+        callback_url: URL to POST success result to
+        build_id: Build identifier from the control plane
+        user_env_vars: Build secrets (global + environment, merged by the
+            control plane) injected into the build sandbox
+        build_timeout_seconds: Build sandbox lifetime (already clamped by the
+            control plane). None → DEFAULT_BUILD_TIMEOUT_SECONDS.
+    """
+    from ..sandbox.manager import SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS, SandboxManager
+
+    sandbox_timeout_seconds = build_timeout_seconds or DEFAULT_BUILD_TIMEOUT_SECONDS
+
+    # Validate callback URL against allowed hosts to prevent SSRF
+    if callback_url and not validate_control_plane_url(callback_url):
+        log.error("build.invalid_callback_url", url=callback_url, build_id=build_id)
+        return
+
+    start_time = time.time()
+    manager = SandboxManager()
+    handle = None
+    sandbox_terminated = False
+
+    try:
+        if not repositories:
+            raise BuildError("environment build requires at least one repository")
+        primary = repositories[0]
+
+        clone_token = resolve_clone_token() or ""
+
+        log.info(
+            "environment_build.start",
+            build_id=build_id,
+            environment_id=environment_id,
+            repository_count=len(repositories),
+        )
+
+        handle = await manager.create_build_sandbox(
+            repo_owner=primary.get("repo_owner", ""),
+            repo_name=primary.get("repo_name", ""),
+            default_branch=primary.get("branch") or "main",
+            clone_token=clone_token,
+            user_env_vars=user_env_vars,
+            timeout_seconds=sandbox_timeout_seconds,
+            repositories=repositories,
+        )
+
+        # Stream stdout until the build completes. Redaction covers the clone
+        # token and every build secret value (global + environment) so neither
+        # reaches the failure message, the callback payload, or D1.
+        redact_values = (clone_token, *((user_env_vars or {}).values()))
+        build_logs = await _stream_build_logs(
+            handle.modal_sandbox,
+            redact_values=redact_values,
+        )
+        if not build_logs.complete:
+            exit_code = handle.modal_sandbox.returncode
+            if build_logs.error:
+                raise BuildError(f"Build sandbox exited without completing: {build_logs.error}")
+            raise BuildError(f"Build sandbox exited without completing (exit_code={exit_code})")
+
+        # Registration fails closed on these (design §7.3) — surface the real
+        # cause here instead of an opaque callback rejection. Missing fields
+        # mean the base image bakes a runtime too old for environment builds.
+        if not build_logs.member_shas or not build_logs.runtime_version:
+            raise BuildError(
+                "build completed without member_shas/runtime_version — "
+                "base image runtime predates environment builds"
+            )
+
+        # Snapshot the running sandbox's filesystem
+        image = await handle.modal_sandbox.snapshot_filesystem.aio(
+            timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS
+        )
+        provider_image_id = image.object_id
+
+        sandbox_terminated = await _terminate_build_sandbox(handle, build_id, "snapshot_complete")
+
+        build_duration = time.time() - start_time
+
+        log.info(
+            "environment_build.success",
+            build_id=build_id,
+            environment_id=environment_id,
+            provider_image_id=provider_image_id,
+            runtime_version=build_logs.runtime_version,
+            build_duration_s=round(build_duration, 1),
+        )
+
+        if callback_url:
+            await _callback_with_retry(
+                callback_url,
+                {
+                    "build_id": build_id,
+                    "provider_image_id": provider_image_id,
+                    "member_shas": build_logs.member_shas,
+                    "runtime_version": build_logs.runtime_version,
+                    "build_duration_seconds": round(build_duration, 2),
+                },
+            )
+
+    except Exception as e:
+        build_duration = time.time() - start_time
+        if handle is not None and not sandbox_terminated:
+            sandbox_terminated = await _terminate_build_sandbox(handle, build_id, "build_failed")
+
+        log.error(
+            "environment_build.failed",
+            build_id=build_id,
+            environment_id=environment_id,
+            error=str(e),
+            build_duration_s=round(build_duration, 1),
+        )
+
+        if callback_url:
+            base_url = callback_url.rsplit("/", 1)[0]
+            failure_url = f"{base_url}/build-failed"
+            await _callback_with_retry(
+                failure_url,
+                {
+                    "build_id": build_id,
+                    "error": str(e),
+                },
+            )
+    finally:
+        if handle is not None and not sandbox_terminated:
+            await _terminate_build_sandbox(handle, build_id, "cleanup")
+
+
 # ---------------------------------------------------------------------------
 # Scheduler: cron-based rebuild logic
 # ---------------------------------------------------------------------------
@@ -367,6 +539,11 @@ STALE_BUILD_THRESHOLD_SECONDS = build_function_timeout_seconds(MAX_BUILD_TIMEOUT
 
 # Cleanup threshold: failed builds older than this are deleted
 FAILED_BUILD_CLEANUP_SECONDS = 86400  # 24 hours
+
+# Environment builds triggered per tick, at most — cheap storm insurance since
+# there is no global build-concurrency cap; the next tick picks up the rest
+# (design §7.3).
+ENVIRONMENT_TRIGGER_CAP_PER_TICK = 4
 
 
 async def _api_get(
@@ -521,6 +698,178 @@ def _should_rebuild(
     return False
 
 
+def _parse_runtime_version_number(runtime_version: str) -> int | None:
+    """Numeric prefix of a SANDBOX_VERSION ("v53-list-native" → 53), or None."""
+    match = re.match(r"^v(\d+)", runtime_version)
+    return int(match.group(1)) if match else None
+
+
+def _should_rebuild_environment(
+    environment: dict,
+    all_images: list[dict],
+    min_runtime_version: int | None,
+    clone_token: str,
+) -> bool:
+    """
+    Rebuild triggers for one environment (design §7.3), cheapest first:
+
+    1. no ready image matches the environment's current members fingerprint
+       (covers created/edited environments and failed builds);
+    3. the matching ready image's runtime_version is below the compatibility
+       floor, or unparseable (fail closed);
+    2. any member's remote branch tip drifted from the image's recorded
+       member_shas (needs one ls-remote per member, so it runs last).
+
+    Trigger 4 (provider-side snapshot expiry) is inert on modal 1.4.3 —
+    snapshots do not expire there; it activates with the snapshot-TTL
+    follow-up.
+    """
+    environment_id = environment.get("id", "")
+    fingerprint = environment.get("membersFingerprint", "")
+
+    environment_images = [img for img in all_images if img.get("environment_id") == environment_id]
+
+    # Per-environment concurrency 1: skip while a build is in flight. The
+    # trigger route enforces this too; checking here saves the HTTP call.
+    if any(img.get("status") == "building" for img in environment_images):
+        log.info("scheduler.environment_skip_building", environment_id=environment_id)
+        return False
+
+    matching_ready = [
+        img
+        for img in environment_images
+        if img.get("status") == "ready" and img.get("members_fingerprint") == fingerprint
+    ]
+    if not matching_ready:
+        log.info("scheduler.environment_no_ready_image", environment_id=environment_id)
+        return True
+
+    latest_ready = matching_ready[0]  # status endpoint orders by created_at DESC
+
+    version = _parse_runtime_version_number(latest_ready.get("runtime_version") or "")
+    if min_runtime_version is not None and (version is None or version < min_runtime_version):
+        log.info(
+            "scheduler.environment_runtime_below_floor",
+            environment_id=environment_id,
+            runtime_version=latest_ready.get("runtime_version"),
+            min_runtime_version=min_runtime_version,
+        )
+        return True
+
+    try:
+        recorded_shas = json.loads(latest_ready.get("member_shas") or "[]")
+    except json.JSONDecodeError:
+        recorded_shas = None
+    if not isinstance(recorded_shas, list):
+        log.warn("scheduler.environment_malformed_member_shas", environment_id=environment_id)
+        return True
+    recorded_by_repo = {
+        (str(m.get("repoOwner", "")).lower(), str(m.get("repoName", "")).lower()): m.get(
+            "baseSha", ""
+        )
+        for m in recorded_shas
+        if isinstance(m, dict)
+    }
+
+    for member in environment.get("repositories", []):
+        repo_owner = member.get("repoOwner", "")
+        repo_name = member.get("repoName", "")
+        base_branch = member.get("baseBranch", "")
+        if not repo_owner or not repo_name or not base_branch:
+            continue
+        remote_sha = _git_ls_remote_sha(
+            repo_owner, repo_name, f"refs/heads/{base_branch}", clone_token
+        )
+        if not remote_sha:
+            # Lookup failure is not a drift signal — rebuilding on transient
+            # git errors would storm every tick.
+            continue
+        if recorded_by_repo.get((repo_owner.lower(), repo_name.lower())) != remote_sha:
+            log.info(
+                "scheduler.environment_sha_mismatch",
+                environment_id=environment_id,
+                repo_owner=repo_owner,
+                repo_name=repo_name,
+                remote_sha=remote_sha[:12],
+            )
+            return True
+
+    return False
+
+
+async def _rebuild_environment_images_pass(control_plane_url: str, clone_token: str) -> int:
+    """
+    Environments pass (design §7.3): same skeleton as the repo pass — GET
+    enabled environments + status, evaluate the rebuild triggers, POST
+    triggers (capped per tick), then mark-stale and cleanup.
+    """
+    enabled_data = await _api_get(f"{control_plane_url}/environment-images/enabled")
+    environments: list[dict] = enabled_data.get("environments", [])
+    min_runtime_version = enabled_data.get("minRuntimeVersion")
+
+    builds_triggered = 0
+    if environments:
+        status_data = await _api_get(f"{control_plane_url}/environment-images/status")
+        all_images: list[dict] = status_data.get("images", [])
+
+        for environment in environments:
+            environment_id = environment.get("id", "")
+            if not environment_id:
+                continue
+            if builds_triggered >= ENVIRONMENT_TRIGGER_CAP_PER_TICK:
+                log.info(
+                    "scheduler.environment_trigger_cap_reached",
+                    cap=ENVIRONMENT_TRIGGER_CAP_PER_TICK,
+                )
+                break
+
+            if not _should_rebuild_environment(
+                environment, all_images, min_runtime_version, clone_token
+            ):
+                continue
+
+            try:
+                await _api_post(
+                    f"{control_plane_url}/environment-images/trigger/{environment_id}",
+                )
+                builds_triggered += 1
+                log.info(
+                    "scheduler.environment_build_triggered",
+                    environment_id=environment_id,
+                )
+            except Exception as e:
+                log.error(
+                    "scheduler.environment_trigger_error",
+                    environment_id=environment_id,
+                    error=str(e),
+                )
+
+    try:
+        result = await _api_post(
+            f"{control_plane_url}/environment-images/mark-stale",
+            {"max_age_seconds": STALE_BUILD_THRESHOLD_SECONDS},
+        )
+        stale_count = result.get("markedFailed", 0)
+        if stale_count:
+            log.info("scheduler.environment_stale_marked", count=stale_count)
+    except Exception as e:
+        log.warn("scheduler.environment_mark_stale_error", error=str(e))
+
+    try:
+        result = await _api_post(
+            f"{control_plane_url}/environment-images/cleanup",
+            {"max_age_seconds": FAILED_BUILD_CLEANUP_SECONDS},
+        )
+        deleted = result.get("deleted", 0)
+        reaped = result.get("reapedSuperseded", 0)
+        if deleted or reaped:
+            log.info("scheduler.environment_cleanup", deleted=deleted, reaped_superseded=reaped)
+    except Exception as e:
+        log.warn("scheduler.environment_cleanup_error", error=str(e))
+
+    return builds_triggered
+
+
 @app.function(
     image=function_image,
     schedule=modal.Cron("*/30 * * * *"),
@@ -536,6 +885,7 @@ async def rebuild_repo_images():
     4. If SHA differs from latest ready image, trigger a build
     5. Mark stale builds as failed
     6. Clean up old failed D1 rows
+    7. Run the environments pass (same skeleton, per-member drift checks)
     """
     control_plane_url = os.environ.get("CONTROL_PLANE_URL", "")
     if not control_plane_url:
@@ -545,6 +895,7 @@ async def rebuild_repo_images():
     log.info("scheduler.start")
     start_time = time.time()
     builds_triggered = 0
+    environment_builds_triggered = 0
 
     try:
         # 1. Get enabled repos
@@ -624,9 +975,20 @@ async def rebuild_repo_images():
     except Exception as e:
         log.error("scheduler.error", error=str(e))
 
+    # Environments pass — isolated so a repo-pass failure never starves it
+    # and vice versa.
+    try:
+        clone_token = resolve_clone_token() or ""
+        environment_builds_triggered = await _rebuild_environment_images_pass(
+            control_plane_url, clone_token
+        )
+    except Exception as e:
+        log.error("scheduler.environment_pass_error", error=str(e))
+
     duration_s = round(time.time() - start_time, 1)
     log.info(
         "scheduler.done",
         builds_triggered=builds_triggered,
+        environment_builds_triggered=environment_builds_triggered,
         duration_s=duration_s,
     )

--- a/packages/modal-infra/src/scheduler/image_builder.py
+++ b/packages/modal-infra/src/scheduler/image_builder.py
@@ -181,7 +181,7 @@ class BuildLogResult:
     """What the build runtime reported through its structured log stream."""
 
     head_sha: str = ""
-    member_shas: list[dict] = field(default_factory=list)
+    repository_shas: list[dict] = field(default_factory=list)
     runtime_version: str = ""
     complete: bool = False
     error: str | None = None
@@ -192,8 +192,8 @@ async def _stream_build_logs(sandbox, redact_values: Iterable[str] = ()) -> Buil
     Stream sandbox stdout and extract build results.
 
     The entrypoint logs structured JSON lines. We look for:
-    - event="git.sync_complete" with "head_sha" (single-repo) and "member_shas"
-      (per-member provenance, [{repoOwner, repoName, baseSha}])
+    - event="git.sync_complete" with "head_sha" (single-repo) and "repository_shas"
+      (per-repository provenance, [{repoOwner, repoName, baseSha}])
     - event="image_build.complete" with "runtime_version" to know the build
       finished and which runtime it baked
     - setup/supervisor errors to preserve the actual build failure
@@ -217,8 +217,8 @@ async def _stream_build_logs(sandbox, redact_values: Iterable[str] = ()) -> Buil
                 if event == "git.sync_complete":
                     if entry.get("head_sha"):
                         result.head_sha = entry["head_sha"]
-                    if isinstance(entry.get("member_shas"), list):
-                        result.member_shas = entry["member_shas"]
+                    if isinstance(entry.get("repository_shas"), list):
+                        result.repository_shas = entry["repository_shas"]
                 elif event == "image_build.complete":
                     if isinstance(entry.get("runtime_version"), str):
                         result.runtime_version = entry["runtime_version"]
@@ -394,10 +394,10 @@ async def build_environment_image(
 
     Generalizes build_repo_image to a repository set: the build sandbox gets
     SESSION_CONFIG.repositories and the list-native runtime clones every
-    member and runs each member's setup.sh sequentially, fatally. The success
-    callback carries what only the build knows — per-member clone provenance
-    (member_shas) and the baked runtime_version — while the members
-    fingerprint stays control-plane-side on the registered row.
+    repository and runs each repo's setup.sh sequentially, fatally. The
+    success callback carries what only the build knows — per-repository clone
+    provenance (repository_shas) and the baked runtime_version — while the
+    repositories fingerprint stays control-plane-side on the registered row.
 
     Args:
         environment_id: Environment the image belongs to (env_<id>)
@@ -465,9 +465,9 @@ async def build_environment_image(
         # Registration fails closed on these (design §7.3) — surface the real
         # cause here instead of an opaque callback rejection. Missing fields
         # mean the base image bakes a runtime too old for environment builds.
-        if not build_logs.member_shas or not build_logs.runtime_version:
+        if not build_logs.repository_shas or not build_logs.runtime_version:
             raise BuildError(
-                "build completed without member_shas/runtime_version — "
+                "build completed without repository_shas/runtime_version — "
                 "base image runtime predates environment builds"
             )
 
@@ -496,7 +496,7 @@ async def build_environment_image(
                 {
                     "build_id": build_id,
                     "provider_image_id": provider_image_id,
-                    "member_shas": build_logs.member_shas,
+                    "repository_shas": build_logs.repository_shas,
                     "runtime_version": build_logs.runtime_version,
                     "build_duration_seconds": round(build_duration, 2),
                 },
@@ -713,19 +713,19 @@ def _should_rebuild_environment(
     """
     Rebuild triggers for one environment (design §7.3), cheapest first:
 
-    1. no ready image matches the environment's current members fingerprint
+    1. no ready image matches the environment's current repositories fingerprint
        (covers created/edited environments and failed builds);
     3. the matching ready image's runtime_version is below the compatibility
        floor, or unparseable (fail closed);
-    2. any member's remote branch tip drifted from the image's recorded
-       member_shas (needs one ls-remote per member, so it runs last).
+    2. any repository's remote branch tip drifted from the image's recorded
+       repository_shas (needs one ls-remote per repository, so it runs last).
 
     Trigger 4 (provider-side snapshot expiry) is inert on modal 1.4.3 —
     snapshots do not expire there; it activates with the snapshot-TTL
     follow-up.
     """
     environment_id = environment.get("id", "")
-    fingerprint = environment.get("membersFingerprint", "")
+    fingerprint = environment.get("repositoriesFingerprint", "")
 
     environment_images = [img for img in all_images if img.get("environment_id") == environment_id]
 
@@ -738,7 +738,7 @@ def _should_rebuild_environment(
     matching_ready = [
         img
         for img in environment_images
-        if img.get("status") == "ready" and img.get("members_fingerprint") == fingerprint
+        if img.get("status") == "ready" and img.get("repositories_fingerprint") == fingerprint
     ]
     if not matching_ready:
         log.info("scheduler.environment_no_ready_image", environment_id=environment_id)
@@ -757,11 +757,11 @@ def _should_rebuild_environment(
         return True
 
     try:
-        recorded_shas = json.loads(latest_ready.get("member_shas") or "[]")
+        recorded_shas = json.loads(latest_ready.get("repository_shas") or "[]")
     except json.JSONDecodeError:
         recorded_shas = None
     if not isinstance(recorded_shas, list):
-        log.warn("scheduler.environment_malformed_member_shas", environment_id=environment_id)
+        log.warn("scheduler.environment_malformed_repository_shas", environment_id=environment_id)
         return True
     recorded_by_repo = {
         (str(m.get("repoOwner", "")).lower(), str(m.get("repoName", "")).lower()): m.get(
@@ -771,10 +771,10 @@ def _should_rebuild_environment(
         if isinstance(m, dict)
     }
 
-    for member in environment.get("repositories", []):
-        repo_owner = member.get("repoOwner", "")
-        repo_name = member.get("repoName", "")
-        base_branch = member.get("baseBranch", "")
+    for repo in environment.get("repositories", []):
+        repo_owner = repo.get("repoOwner", "")
+        repo_name = repo.get("repoName", "")
+        base_branch = repo.get("baseBranch", "")
         if not repo_owner or not repo_name or not base_branch:
             continue
         remote_sha = _git_ls_remote_sha(
@@ -885,7 +885,7 @@ async def rebuild_repo_images():
     4. If SHA differs from latest ready image, trigger a build
     5. Mark stale builds as failed
     6. Clean up old failed D1 rows
-    7. Run the environments pass (same skeleton, per-member drift checks)
+    7. Run the environments pass (same skeleton, per-repository drift checks)
     """
     control_plane_url = os.environ.get("CONTROL_PLANE_URL", "")
     if not control_plane_url:

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -571,6 +571,119 @@ async def api_build_repo_image(
 
 @app.function(
     image=function_image,
+    secrets=[internal_api_secret, github_app_secrets],
+)
+@fastapi_endpoint(method="POST")
+async def api_build_environment_image(
+    request: dict,
+    authorization: str | None = Header(None),
+    x_trace_id: str | None = Header(None),
+    x_request_id: str | None = Header(None),
+) -> dict:
+    """
+    Kick off an async environment image build (design §7.3). Returns immediately.
+
+    Spawns a build_environment_image worker that clones every member repo,
+    runs their setup hooks sequentially, snapshots the filesystem, and POSTs
+    the result (member_shas + runtime_version) to callback_url.
+
+    POST body:
+    {
+        "environment_id": "env_...",
+        "build_id": "...",
+        "callback_url": "...",
+        "repositories": [{"repo_owner": "...", "repo_name": "...", "branch": "..."}],
+        "user_env_vars": {...},          // optional
+        "build_timeout_seconds": 1800    // optional
+    }
+    """
+    start_time = time.time()
+    http_status = 200
+    outcome = "success"
+
+    require_auth(authorization)
+
+    try:
+        from .sandbox.manager import (
+            DEFAULT_BUILD_TIMEOUT_SECONDS,
+            build_function_timeout_seconds,
+        )
+        from .scheduler.image_builder import build_environment_image
+
+        environment_id = request.get("environment_id")
+        build_id = request.get("build_id", "")
+        callback_url = request.get("callback_url", "")
+        repositories = request.get("repositories")
+        user_env_vars = request.get("user_env_vars") or None
+        # Already capped by the control plane; default when absent/null.
+        build_timeout_seconds = int(
+            request.get("build_timeout_seconds") or DEFAULT_BUILD_TIMEOUT_SECONDS
+        )
+
+        if not environment_id:
+            raise HTTPException(status_code=400, detail="environment_id is required")
+
+        if not build_id:
+            raise HTTPException(status_code=400, detail="build_id is required")
+
+        if not isinstance(repositories, list) or not repositories:
+            raise HTTPException(status_code=400, detail="repositories must be a non-empty list")
+        for entry in repositories:
+            if (
+                not isinstance(entry, dict)
+                or not entry.get("repo_owner")
+                or not entry.get("repo_name")
+            ):
+                raise HTTPException(
+                    status_code=400,
+                    detail="repositories entries require repo_owner and repo_name",
+                )
+
+        function_timeout = build_function_timeout_seconds(build_timeout_seconds)
+
+        # Spawn the async builder — returns immediately
+        await build_environment_image.with_options(timeout=function_timeout).spawn.aio(
+            environment_id=environment_id,
+            repositories=repositories,
+            callback_url=callback_url,
+            build_id=build_id,
+            user_env_vars=user_env_vars,
+            build_timeout_seconds=build_timeout_seconds,
+        )
+
+        return {
+            "success": True,
+            "data": {
+                "build_id": build_id,
+                "status": "building",
+            },
+        }
+    except HTTPException as e:
+        outcome = "error"
+        http_status = e.status_code
+        raise
+    except Exception as e:
+        outcome = "error"
+        http_status = 500
+        log.error("api.error", exc=e, endpoint_name="api_build_environment_image")
+        return {"success": False, "error": str(e)}
+    finally:
+        duration_ms = int((time.time() - start_time) * 1000)
+        log.info(
+            "modal.http_request",
+            http_method="POST",
+            http_path="/api_build_environment_image",
+            http_status=http_status,
+            duration_ms=duration_ms,
+            outcome=outcome,
+            endpoint_name="api_build_environment_image",
+            trace_id=x_trace_id,
+            request_id=x_request_id,
+        )
+
+
+@app.function(
+    image=function_image,
     secrets=[internal_api_secret],
 )
 @fastapi_endpoint(method="POST")

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -583,9 +583,9 @@ async def api_build_environment_image(
     """
     Kick off an async environment image build (design §7.3). Returns immediately.
 
-    Spawns a build_environment_image worker that clones every member repo,
+    Spawns a build_environment_image worker that clones every repository in the environment,
     runs their setup hooks sequentially, snapshots the filesystem, and POSTs
-    the result (member_shas + runtime_version) to callback_url.
+    the result (repository_shas + runtime_version) to callback_url.
 
     POST body:
     {

--- a/packages/modal-infra/tests/test_image_builder_v2.py
+++ b/packages/modal-infra/tests/test_image_builder_v2.py
@@ -197,10 +197,10 @@ class TestStreamBuildLogs:
         mock_sandbox = MagicMock()
         mock_sandbox.stdout = self._async_stdout(log_lines)
 
-        sha, complete, error = await _stream_build_logs(mock_sandbox)
-        assert sha == "abc123def456"
-        assert complete is True
-        assert error is None
+        result = await _stream_build_logs(mock_sandbox)
+        assert result.head_sha == "abc123def456"
+        assert result.complete is True
+        assert result.error is None
 
     @pytest.mark.asyncio
     async def test_complete_without_sha(self):
@@ -212,10 +212,10 @@ class TestStreamBuildLogs:
         mock_sandbox = MagicMock()
         mock_sandbox.stdout = self._async_stdout(log_lines)
 
-        sha, complete, error = await _stream_build_logs(mock_sandbox)
-        assert sha == ""
-        assert complete is True
-        assert error is None
+        result = await _stream_build_logs(mock_sandbox)
+        assert result.head_sha == ""
+        assert result.complete is True
+        assert result.error is None
 
     @pytest.mark.asyncio
     async def test_incomplete_when_sandbox_exits(self):
@@ -228,10 +228,10 @@ class TestStreamBuildLogs:
         mock_sandbox = MagicMock()
         mock_sandbox.stdout = self._async_stdout(log_lines)
 
-        sha, complete, error = await _stream_build_logs(mock_sandbox)
-        assert sha == "abc123"
-        assert complete is False
-        assert error is None
+        result = await _stream_build_logs(mock_sandbox)
+        assert result.head_sha == "abc123"
+        assert result.complete is False
+        assert result.error is None
 
     @pytest.mark.asyncio
     async def test_captures_setup_failure_tail(self):
@@ -256,10 +256,10 @@ class TestStreamBuildLogs:
         mock_sandbox = MagicMock()
         mock_sandbox.stdout = self._async_stdout(log_lines)
 
-        sha, complete, error = await _stream_build_logs(mock_sandbox)
-        assert sha == "abc123"
-        assert complete is False
-        assert error == "setup.failed: npm install\nmissing dependency"
+        result = await _stream_build_logs(mock_sandbox)
+        assert result.head_sha == "abc123"
+        assert result.complete is False
+        assert result.error == "setup.failed: npm install\nmissing dependency"
 
     @pytest.mark.asyncio
     async def test_falls_back_to_supervisor_error(self):
@@ -276,10 +276,10 @@ class TestStreamBuildLogs:
         mock_sandbox = MagicMock()
         mock_sandbox.stdout = self._async_stdout(log_lines)
 
-        sha, complete, error = await _stream_build_logs(mock_sandbox)
-        assert sha == ""
-        assert complete is False
-        assert error == "supervisor.error: unexpected startup failure"
+        result = await _stream_build_logs(mock_sandbox)
+        assert result.head_sha == ""
+        assert result.complete is False
+        assert result.error == "supervisor.error: unexpected startup failure"
 
     @pytest.mark.asyncio
     async def test_falls_back_to_supervisor_fatal(self):
@@ -296,10 +296,10 @@ class TestStreamBuildLogs:
         mock_sandbox = MagicMock()
         mock_sandbox.stdout = self._async_stdout(log_lines)
 
-        sha, complete, error = await _stream_build_logs(mock_sandbox)
-        assert sha == ""
-        assert complete is False
-        assert error == "supervisor.fatal: unexpected startup failure"
+        result = await _stream_build_logs(mock_sandbox)
+        assert result.head_sha == ""
+        assert result.complete is False
+        assert result.error == "supervisor.fatal: unexpected startup failure"
 
     @pytest.mark.asyncio
     async def test_returns_incomplete_on_error(self):
@@ -312,10 +312,10 @@ class TestStreamBuildLogs:
         mock_sandbox = MagicMock()
         mock_sandbox.stdout = _raise()
 
-        sha, complete, error = await _stream_build_logs(mock_sandbox)
-        assert sha == ""
-        assert complete is False
-        assert error is None
+        result = await _stream_build_logs(mock_sandbox)
+        assert result.head_sha == ""
+        assert result.complete is False
+        assert result.error is None
 
     @pytest.mark.asyncio
     async def test_handles_malformed_json(self):
@@ -328,10 +328,10 @@ class TestStreamBuildLogs:
         mock_sandbox = MagicMock()
         mock_sandbox.stdout = self._async_stdout(log_lines)
 
-        sha, complete, error = await _stream_build_logs(mock_sandbox)
-        assert sha == "abc123"
-        assert complete is True
-        assert error is None
+        result = await _stream_build_logs(mock_sandbox)
+        assert result.head_sha == "abc123"
+        assert result.complete is True
+        assert result.error is None
 
 
 class TestBuildError:

--- a/packages/modal-infra/tests/test_scheduler.py
+++ b/packages/modal-infra/tests/test_scheduler.py
@@ -394,9 +394,19 @@ class TestRebuildRepoImages:
 
             await rebuild_repo_images.local()
 
-        # Check that mark-stale and cleanup were called
-        stale_calls = [c for c in mock_post.call_args_list if "mark-stale" in str(c)]
+        # Both passes run their own mark-stale and cleanup
+        stale_calls = [c for c in mock_post.call_args_list if "repo-images/mark-stale" in str(c)]
         assert len(stale_calls) == 1
 
-        cleanup_calls = [c for c in mock_post.call_args_list if "cleanup" in str(c)]
+        cleanup_calls = [c for c in mock_post.call_args_list if "repo-images/cleanup" in str(c)]
         assert len(cleanup_calls) == 1
+
+        environment_stale_calls = [
+            c for c in mock_post.call_args_list if "environment-images/mark-stale" in str(c)
+        ]
+        assert len(environment_stale_calls) == 1
+
+        environment_cleanup_calls = [
+            c for c in mock_post.call_args_list if "environment-images/cleanup" in str(c)
+        ]
+        assert len(environment_cleanup_calls) == 1

--- a/packages/modal-infra/tests/test_scheduler.py
+++ b/packages/modal-infra/tests/test_scheduler.py
@@ -181,7 +181,7 @@ def _environment(fingerprint="fp-current", repositories=None):
     return {
         "id": "env_1",
         "name": "Flagship",
-        "membersFingerprint": fingerprint,
+        "repositoriesFingerprint": fingerprint,
         "repositories": repositories
         or [
             {"repoOwner": "acme", "repoName": "web", "baseBranch": "main"},
@@ -195,8 +195,8 @@ def _environment_image(**overrides):
         "id": "envimg-1",
         "environment_id": "env_1",
         "status": "ready",
-        "members_fingerprint": "fp-current",
-        "member_shas": json.dumps(
+        "repositories_fingerprint": "fp-current",
+        "repository_shas": json.dumps(
             [
                 {"repoOwner": "acme", "repoName": "web", "baseSha": "sha-web"},
                 {"repoOwner": "acme", "repoName": "api", "baseSha": "sha-api"},
@@ -222,8 +222,8 @@ class TestShouldRebuildEnvironment:
         assert _should_rebuild_environment(_environment(), [], 53, "") is True
 
     def test_rebuild_when_fingerprint_mismatch(self):
-        """Trigger 1: ready image for an older member set → rebuild."""
-        images = [_environment_image(members_fingerprint="fp-old")]
+        """Trigger 1: ready image for an older repository set → rebuild."""
+        images = [_environment_image(repositories_fingerprint="fp-old")]
         assert _should_rebuild_environment(_environment(), images, 53, "") is True
 
     def test_skip_when_building(self):
@@ -241,13 +241,13 @@ class TestShouldRebuildEnvironment:
         images = [_environment_image(runtime_version="not-a-version")]
         assert _should_rebuild_environment(_environment(), images, 53, "") is True
 
-    def test_rebuild_when_member_shas_malformed(self):
+    def test_rebuild_when_repository_shas_malformed(self):
         """Malformed provenance means drift is undetectable → rebuild."""
-        images = [_environment_image(member_shas="not-json")]
+        images = [_environment_image(repository_shas="not-json")]
         assert _should_rebuild_environment(_environment(), images, 53, "") is True
 
-    def test_rebuild_when_member_branch_drifts(self):
-        """Trigger 2: any member's branch tip moved → rebuild."""
+    def test_rebuild_when_repository_branch_drifts(self):
+        """Trigger 2: any repository's branch tip moved → rebuild."""
         images = [_environment_image()]
         with patch(
             "src.scheduler.image_builder._git_ls_remote_sha",
@@ -255,7 +255,7 @@ class TestShouldRebuildEnvironment:
         ):
             assert _should_rebuild_environment(_environment(), images, 53, "") is True
 
-    def test_skip_when_all_members_match(self):
+    def test_skip_when_all_repositories_match(self):
         """All shas match, runtime fine, fingerprint matches → skip."""
         images = [_environment_image()]
         with patch(

--- a/packages/modal-infra/tests/test_scheduler.py
+++ b/packages/modal-infra/tests/test_scheduler.py
@@ -290,27 +290,56 @@ class TestRebuildRepoImages:
 
     @pytest.mark.asyncio
     async def test_skips_when_no_enabled_repos(self):
-        """Should return early when no repos have image building enabled."""
+        """Repo pass skips on empty enabled repos; the environment pass still runs."""
         env = {
             "CONTROL_PLANE_URL": "https://cp.test",
             "MODAL_API_SECRET": "test-secret",
         }
 
-        mock_enabled = {"repos": []}
+        async def mock_get_side_effect(url, **kwargs):
+            if "enabled-repos" in url:
+                return {"repos": []}
+            if "environment-images/enabled" in url:
+                return {"environments": [], "minRuntimeVersion": 53}
+            return {}
 
         with (
             patch.dict("os.environ", env, clear=False),
             patch(
                 "src.scheduler.image_builder._api_get",
                 new_callable=AsyncMock,
-                return_value=mock_enabled,
+                side_effect=mock_get_side_effect,
             ) as mock_get,
+            patch(
+                "src.scheduler.image_builder._api_post",
+                new_callable=AsyncMock,
+                return_value={"ok": True, "markedFailed": 0, "deleted": 0},
+            ) as mock_post,
+            patch(
+                "sandbox_runtime.auth.github_app.generate_installation_token",
+                return_value="gh-token",
+            ),
         ):
             from src.scheduler.image_builder import rebuild_repo_images
 
             await rebuild_repo_images.local()
 
-        mock_get.assert_called_once_with("https://cp.test/repo-images/enabled-repos")
+        # The repo pass stopped at the empty list: no repo status fetch, no
+        # repo maintenance calls.
+        assert [c for c in mock_get.call_args_list if "repo-images/status" in str(c)] == []
+        assert [c for c in mock_post.call_args_list if "repo-images/" in str(c)] == []
+
+        # The environment pass still ran its full skeleton.
+        env_enabled = [c for c in mock_get.call_args_list if "environment-images/enabled" in str(c)]
+        assert len(env_enabled) == 1
+        env_stale = [
+            c for c in mock_post.call_args_list if "environment-images/mark-stale" in str(c)
+        ]
+        assert len(env_stale) == 1
+        env_cleanup = [
+            c for c in mock_post.call_args_list if "environment-images/cleanup" in str(c)
+        ]
+        assert len(env_cleanup) == 1
 
     @pytest.mark.asyncio
     async def test_triggers_build_on_sha_mismatch(self):

--- a/packages/modal-infra/tests/test_scheduler.py
+++ b/packages/modal-infra/tests/test_scheduler.py
@@ -1,5 +1,6 @@
 """Tests for the image build scheduler (cron)."""
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -7,6 +8,7 @@ import pytest
 from src.scheduler.image_builder import (
     _git_ls_remote_sha,
     _should_rebuild,
+    _should_rebuild_environment,
 )
 
 
@@ -173,6 +175,103 @@ class TestShouldRebuild:
         ]
         result = _should_rebuild("acme", "repo", "abc123", images)
         assert result is True
+
+
+def _environment(fingerprint="fp-current", repositories=None):
+    return {
+        "id": "env_1",
+        "name": "Flagship",
+        "membersFingerprint": fingerprint,
+        "repositories": repositories
+        or [
+            {"repoOwner": "acme", "repoName": "web", "baseBranch": "main"},
+            {"repoOwner": "acme", "repoName": "api", "baseBranch": "develop"},
+        ],
+    }
+
+
+def _environment_image(**overrides):
+    image = {
+        "id": "envimg-1",
+        "environment_id": "env_1",
+        "status": "ready",
+        "members_fingerprint": "fp-current",
+        "member_shas": json.dumps(
+            [
+                {"repoOwner": "acme", "repoName": "web", "baseSha": "sha-web"},
+                {"repoOwner": "acme", "repoName": "api", "baseSha": "sha-api"},
+            ]
+        ),
+        "runtime_version": "v53-list-native-runtime",
+    }
+    image.update(overrides)
+    return image
+
+
+class TestShouldRebuildEnvironment:
+    """Test the _should_rebuild_environment trigger logic (design §7.3)."""
+
+    def _ls_remote(self, shas_by_repo):
+        def lookup(repo_owner, repo_name, ref, clone_token):
+            return shas_by_repo.get(f"{repo_owner}/{repo_name}")
+
+        return lookup
+
+    def test_rebuild_when_no_ready_image(self):
+        """Trigger 1: no images at all → rebuild."""
+        assert _should_rebuild_environment(_environment(), [], 53, "") is True
+
+    def test_rebuild_when_fingerprint_mismatch(self):
+        """Trigger 1: ready image for an older member set → rebuild."""
+        images = [_environment_image(members_fingerprint="fp-old")]
+        assert _should_rebuild_environment(_environment(), images, 53, "") is True
+
+    def test_skip_when_building(self):
+        """Per-environment concurrency 1: in-flight build → skip."""
+        images = [_environment_image(status="building")]
+        assert _should_rebuild_environment(_environment(), images, 53, "") is False
+
+    def test_rebuild_when_runtime_below_floor(self):
+        """Trigger 3: baked runtime below the compatibility floor → rebuild."""
+        images = [_environment_image(runtime_version="v52-old")]
+        assert _should_rebuild_environment(_environment(), images, 53, "") is True
+
+    def test_rebuild_when_runtime_unparseable(self):
+        """Trigger 3 fails closed: unparseable runtime_version → rebuild."""
+        images = [_environment_image(runtime_version="not-a-version")]
+        assert _should_rebuild_environment(_environment(), images, 53, "") is True
+
+    def test_rebuild_when_member_shas_malformed(self):
+        """Malformed provenance means drift is undetectable → rebuild."""
+        images = [_environment_image(member_shas="not-json")]
+        assert _should_rebuild_environment(_environment(), images, 53, "") is True
+
+    def test_rebuild_when_member_branch_drifts(self):
+        """Trigger 2: any member's branch tip moved → rebuild."""
+        images = [_environment_image()]
+        with patch(
+            "src.scheduler.image_builder._git_ls_remote_sha",
+            side_effect=self._ls_remote({"acme/web": "sha-web", "acme/api": "sha-api-NEW"}),
+        ):
+            assert _should_rebuild_environment(_environment(), images, 53, "") is True
+
+    def test_skip_when_all_members_match(self):
+        """All shas match, runtime fine, fingerprint matches → skip."""
+        images = [_environment_image()]
+        with patch(
+            "src.scheduler.image_builder._git_ls_remote_sha",
+            side_effect=self._ls_remote({"acme/web": "sha-web", "acme/api": "sha-api"}),
+        ):
+            assert _should_rebuild_environment(_environment(), images, 53, "") is False
+
+    def test_ls_remote_failure_is_not_drift(self):
+        """A transient lookup failure must not cause rebuild storms."""
+        images = [_environment_image()]
+        with patch(
+            "src.scheduler.image_builder._git_ls_remote_sha",
+            side_effect=self._ls_remote({"acme/web": "sha-web", "acme/api": None}),
+        ):
+            assert _should_rebuild_environment(_environment(), images, 53, "") is False
 
 
 class TestRebuildRepoImages:

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -1779,7 +1779,7 @@ class SandboxSupervisor:
 
         git_sync_success = False
         head_sha = ""
-        member_shas: list[dict[str, str]] = []
+        repository_shas: list[dict[str, str]] = []
         opencode_ready = False
         try:
             # Refuse to boot on an untrusted repository config — unsafe or
@@ -1820,13 +1820,13 @@ class SandboxSupervisor:
                         ),
                     )
             if image_build_mode and git_sync_success and self.repositories:
-                # member_shas is the cross-language provenance document
+                # repository_shas is the cross-language provenance document
                 # ([{repoOwner, repoName, baseSha}]): parsed from this event by
                 # the Modal build orchestrator, echoed through the
                 # build-complete callback, stored in environment_images, and
                 # compared against `git ls-remote` by the rebuild cron. The
                 # scalar head_sha stays for the single-repo repo-image path.
-                member_shas = [
+                repository_shas = [
                     {
                         "repoOwner": repo.owner,
                         "repoName": repo.name,
@@ -1834,9 +1834,11 @@ class SandboxSupervisor:
                     }
                     for repo in self.repositories
                 ]
-                head_sha = member_shas[0]["baseSha"]
+                head_sha = repository_shas[0]["baseSha"]
                 if head_sha:
-                    self.log.info("git.sync_complete", head_sha=head_sha, member_shas=member_shas)
+                    self.log.info(
+                        "git.sync_complete", head_sha=head_sha, repository_shas=repository_shas
+                    )
             self.git_sync_complete.set()
 
             # Phase 2: Setup hooks, members in position order, only for fresh
@@ -1909,7 +1911,7 @@ class SandboxSupervisor:
                     reported = await repo_image_callback.report_success(
                         base_sha=head_sha,
                         build_duration_seconds=time.time() - startup_start,
-                        member_shas=member_shas,
+                        repository_shas=repository_shas,
                         runtime_version=runtime_version,
                     )
                     if not reported:

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -1779,6 +1779,7 @@ class SandboxSupervisor:
 
         git_sync_success = False
         head_sha = ""
+        member_shas: list[dict[str, str]] = []
         opencode_ready = False
         try:
             # Refuse to boot on an untrusted repository config — unsafe or
@@ -1819,9 +1820,23 @@ class SandboxSupervisor:
                         ),
                     )
             if image_build_mode and git_sync_success and self.repositories:
-                head_sha = await self._get_head_sha(self.repositories[0])
+                # member_shas is the cross-language provenance document
+                # ([{repoOwner, repoName, baseSha}]): parsed from this event by
+                # the Modal build orchestrator, echoed through the
+                # build-complete callback, stored in environment_images, and
+                # compared against `git ls-remote` by the rebuild cron. The
+                # scalar head_sha stays for the single-repo repo-image path.
+                member_shas = [
+                    {
+                        "repoOwner": repo.owner,
+                        "repoName": repo.name,
+                        "baseSha": await self._get_head_sha(repo),
+                    }
+                    for repo in self.repositories
+                ]
+                head_sha = member_shas[0]["baseSha"]
                 if head_sha:
-                    self.log.info("git.sync_complete", head_sha=head_sha)
+                    self.log.info("git.sync_complete", head_sha=head_sha, member_shas=member_shas)
             self.git_sync_complete.set()
 
             # Phase 2: Setup hooks, members in position order, only for fresh
@@ -1881,11 +1896,21 @@ class SandboxSupervisor:
             # builds — they are installed at first use via npx at session start.
             if image_build_mode:
                 duration_ms = int((time.time() - startup_start) * 1000)
-                self.log.info("image_build.complete", duration_ms=duration_ms)
+                # runtime_version is reported by the build itself (design
+                # §7.3): the baked image's SANDBOX_VERSION is the ground
+                # truth, so orchestrators never guess it from their own code.
+                runtime_version = os.environ.get("SANDBOX_VERSION", "")
+                self.log.info(
+                    "image_build.complete",
+                    duration_ms=duration_ms,
+                    runtime_version=runtime_version,
+                )
                 if repo_image_callback:
                     reported = await repo_image_callback.report_success(
                         base_sha=head_sha,
                         build_duration_seconds=time.time() - startup_start,
+                        member_shas=member_shas,
+                        runtime_version=runtime_version,
                     )
                     if not reported:
                         raise RuntimeError("repo image build-complete callback failed")

--- a/packages/sandbox-runtime/src/sandbox_runtime/repo_image_callback.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/repo_image_callback.py
@@ -70,12 +70,12 @@ class RepoImageBuildCallback:
         *,
         base_sha: str,
         build_duration_seconds: float,
-        member_shas: list[dict[str, str]] | None = None,
+        repository_shas: list[dict[str, str]] | None = None,
         runtime_version: str = "",
     ) -> bool:
         """Report a successful image build.
 
-        member_shas ([{repoOwner, repoName, baseSha}]) and runtime_version are
+        repository_shas ([{repoOwner, repoName, baseSha}]) and runtime_version are
         required by environment-image registration (design §7.3) and ignored
         by the repo-image callback route.
         """
@@ -84,8 +84,8 @@ class RepoImageBuildCallback:
             "base_sha": base_sha,
             "build_duration_seconds": round(build_duration_seconds, 3),
         }
-        if member_shas:
-            payload["member_shas"] = member_shas
+        if repository_shas:
+            payload["repository_shas"] = repository_shas
         if runtime_version:
             payload["runtime_version"] = runtime_version
         if self.provider_session_id:

--- a/packages/sandbox-runtime/src/sandbox_runtime/repo_image_callback.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/repo_image_callback.py
@@ -65,13 +65,29 @@ class RepoImageBuildCallback:
             logger=log,
         )
 
-    async def report_success(self, *, base_sha: str, build_duration_seconds: float) -> bool:
-        """Report a successful repo-image build."""
+    async def report_success(
+        self,
+        *,
+        base_sha: str,
+        build_duration_seconds: float,
+        member_shas: list[dict[str, str]] | None = None,
+        runtime_version: str = "",
+    ) -> bool:
+        """Report a successful image build.
+
+        member_shas ([{repoOwner, repoName, baseSha}]) and runtime_version are
+        required by environment-image registration (design §7.3) and ignored
+        by the repo-image callback route.
+        """
         payload: dict[str, Any] = {
             "build_id": self.build_id,
             "base_sha": base_sha,
             "build_duration_seconds": round(build_duration_seconds, 3),
         }
+        if member_shas:
+            payload["member_shas"] = member_shas
+        if runtime_version:
+            payload["runtime_version"] = runtime_version
         if self.provider_session_id:
             payload["provider_session_id"] = self.provider_session_id
 

--- a/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
+++ b/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
@@ -1,5 +1,6 @@
 """Tests for entrypoint boot modes and git sync."""
 
+import json
 import os
 from dataclasses import replace
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
@@ -207,6 +208,66 @@ class TestImageBuildMode:
         assert sync_calls[0].kwargs["head_sha"] == "abc123def456"
 
     @pytest.mark.asyncio
+    async def test_build_mode_reports_member_shas_per_repo(self, build_env, tmp_path):
+        """Multi-repo builds report one member sha per repository, in position order."""
+        env = {
+            **build_env,
+            "SESSION_CONFIG": json.dumps(
+                {
+                    "branch": "main",
+                    "repositories": [
+                        {"repo_owner": "acme", "repo_name": "web", "branch": "main"},
+                        {"repo_owner": "acme", "repo_name": "api", "branch": "develop"},
+                    ],
+                }
+            ),
+        }
+        supervisor = _make_supervisor(env)
+        supervisor.workspace_path = tmp_path
+        supervisor.repositories = [
+            replace(repo, path=tmp_path / repo.name) for repo in supervisor.repositories
+        ]
+        for repo in supervisor.repositories:
+            repo.path.mkdir(parents=True, exist_ok=True)
+
+        supervisor.sync_repositories = AsyncMock(return_value=[])
+        supervisor.run_setup_script = AsyncMock(return_value=True)
+        supervisor.shutdown = AsyncMock()
+        supervisor.shutdown_event.set()
+        supervisor.log = MagicMock()
+
+        shas_by_cwd = {tmp_path / "web": b"aaa111\n", tmp_path / "api": b"bbb222\n"}
+
+        async def fake_subprocess(*args, **kwargs):
+            stdout = shas_by_cwd.get(kwargs.get("cwd"), b"")
+            mock_proc = MagicMock()
+            mock_proc.communicate = AsyncMock(return_value=(stdout, b""))
+            mock_proc.wait = AsyncMock(return_value=0)
+            mock_proc.returncode = 0
+            return mock_proc
+
+        with (
+            patch.dict(os.environ, env, clear=False),
+            patch(
+                "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
+                side_effect=fake_subprocess,
+            ),
+        ):
+            await supervisor.run()
+
+        sync_calls = [
+            c
+            for c in supervisor.log.info.call_args_list
+            if c.args and c.args[0] == "git.sync_complete"
+        ]
+        assert len(sync_calls) == 1
+        assert sync_calls[0].kwargs["head_sha"] == "aaa111"
+        assert sync_calls[0].kwargs["member_shas"] == [
+            {"repoOwner": "acme", "repoName": "web", "baseSha": "aaa111"},
+            {"repoOwner": "acme", "repoName": "api", "baseSha": "bbb222"},
+        ]
+
+    @pytest.mark.asyncio
     async def test_reports_success_callback_from_build_mode(self, build_env, tmp_path):
         """Build mode should report completion itself when callback metadata is configured."""
         supervisor = _make_supervisor(build_env)
@@ -229,7 +290,7 @@ class TestImageBuildMode:
             return mock_proc
 
         with (
-            patch.dict(os.environ, build_env, clear=False),
+            patch.dict(os.environ, {**build_env, "SANDBOX_VERSION": "v99-test"}, clear=False),
             patch(
                 "sandbox_runtime.entrypoint.asyncio.create_subprocess_exec",
                 side_effect=fake_subprocess,
@@ -244,6 +305,8 @@ class TestImageBuildMode:
         callback.report_success.assert_awaited_once_with(
             base_sha="abc123def456",
             build_duration_seconds=ANY,
+            member_shas=[{"repoOwner": "acme", "repoName": "my-repo", "baseSha": "abc123def456"}],
+            runtime_version="v99-test",
         )
         callback.report_failure.assert_not_called()
 

--- a/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
+++ b/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
@@ -208,8 +208,8 @@ class TestImageBuildMode:
         assert sync_calls[0].kwargs["head_sha"] == "abc123def456"
 
     @pytest.mark.asyncio
-    async def test_build_mode_reports_member_shas_per_repo(self, build_env, tmp_path):
-        """Multi-repo builds report one member sha per repository, in position order."""
+    async def test_build_mode_reports_repository_shas_per_repo(self, build_env, tmp_path):
+        """Multi-repo builds report one sha per repository, in position order."""
         env = {
             **build_env,
             "SESSION_CONFIG": json.dumps(
@@ -262,7 +262,7 @@ class TestImageBuildMode:
         ]
         assert len(sync_calls) == 1
         assert sync_calls[0].kwargs["head_sha"] == "aaa111"
-        assert sync_calls[0].kwargs["member_shas"] == [
+        assert sync_calls[0].kwargs["repository_shas"] == [
             {"repoOwner": "acme", "repoName": "web", "baseSha": "aaa111"},
             {"repoOwner": "acme", "repoName": "api", "baseSha": "bbb222"},
         ]
@@ -305,7 +305,9 @@ class TestImageBuildMode:
         callback.report_success.assert_awaited_once_with(
             base_sha="abc123def456",
             build_duration_seconds=ANY,
-            member_shas=[{"repoOwner": "acme", "repoName": "my-repo", "baseSha": "abc123def456"}],
+            repository_shas=[
+                {"repoOwner": "acme", "repoName": "my-repo", "baseSha": "abc123def456"}
+            ],
             runtime_version="v99-test",
         )
         callback.report_failure.assert_not_called()

--- a/terraform/d1/migrations/0034_rename_environment_image_provenance_columns.sql
+++ b/terraform/d1/migrations/0034_rename_environment_image_provenance_columns.sql
@@ -1,0 +1,10 @@
+-- Rename environment_images provenance columns to repository nomenclature.
+--
+-- 0033 shipped these as members_fingerprint/member_shas, but "members" does
+-- not say what it represents; the system's term for an environment's repo set
+-- is "repositories" (environment_repositories, the environments API field).
+-- Safe as a plain rename: nothing writes to environment_images until the
+-- environment-image build system lands, so the table is empty everywhere.
+
+ALTER TABLE environment_images RENAME COLUMN members_fingerprint TO repositories_fingerprint;
+ALTER TABLE environment_images RENAME COLUMN member_shas TO repository_shas;


### PR DESCRIPTION
## PR-10 · environment image builds

Phase-2 continuation of the multi-repo-sessions plan (follows #916). The environment prebuild pipeline (design §7.3/§7.4): environments get built as a unit — every repository cloned at its base branch, setup hooks run sequentially-fatally, filesystem snapshotted — and the resulting images are registered, invalidated, and reclaimed so PR-11 can select them at spawn. One migration: `0034` renames the `environment_images` provenance columns shipped in `0033` (PR-8) to repository nomenclature (`repositories_fingerprint`, `repository_shas`) — safe as a plain rename since nothing writes to the table until this PR lands.

Staged commits, as the plan sequences it: **Modal end-to-end first**, then the **Vercel/OpenComputer parity step**, followed by a review-fix pass and the member→repository nomenclature scrub.

### What it does

**Runtime (provider-neutral):** build mode now reports what only the build knows — per-repository clone provenance `repository_shas` (`[{repoOwner, repoName, baseSha}]`, one cross-language document shape used unchanged from runtime → callback → D1 → cron) and the baked `runtime_version` (read from the image's own `SANDBOX_VERSION`, so orchestrators never guess it from their code). Emitted via log events for Modal's orchestrator and via `report_success` for provider-session builds.

**Modal:** `build_environment_image` generalizes the repo-image worker (`SESSION_CONFIG.repositories` through the existing `create_build_sandbox` seam; redaction covers the clone token plus every build secret value; a completed build missing `repository_shas`/`runtime_version` fails with an actionable message instead of an opaque callback rejection). The 30-min cron gains an isolated **environments pass**: GET enabled environments + status → rebuild triggers, cheapest first — (1) no ready image matching the current repositories fingerprint, (3) runtime below the compatibility floor (or unparseable — fail closed), (2) per-repository `git ls-remote refs/heads/<branch>` drift (honors non-default branches, an improvement over repo images) — with a **per-tick trigger cap of 4** and per-environment concurrency 1.

**Control plane:** `EnvironmentImageStore` mirrors the repo-image state machine (conditional transitions, newer-ready races, `(created_at, id)` tiebreaks) with two model-owed differences: supersede scope is `(environment_id, provider)` — the fingerprint covers branches, so one live image per environment/provider — and rows are also superseded **out-of-band** (environment delete, secret change), so the cleanup pass gains a **superseded-artifact reaper** (artifact deleted first, row only after, failures retried next pass). The planner assembles build secrets as **global + environment** — the same set the environment's sessions get (§6.4 build/session parity) — through the PR-6 cap enforcement, and honors the primary repository's `buildTimeoutSeconds`. The workflow enforces **concurrency-1 at the trigger** (cron, save-hooks, and future "Rebuild now" all converge there) and **fails registration closed** on missing/unparseable `runtime_version` or `repository_shas` for *all* providers — an unversioned image must never pass PR-11's floor check. Routes: `/environment-images/{build-complete,build-failed,trigger/:id,status,enabled,mark-stale,cleanup}` mirroring the repo-image surface; `enabled` also serves each environment's fingerprint and the floor so the fingerprint algorithm never leaves the control plane.

**Save-hooks (§7.3/§7.4):** environment create/update triggers an immediate build (skipped when a ready image already matches the current repository set — trigger-1 evaluated eagerly); a secret change (PUT/DELETE/import) **supersedes every live image in the same request** — including in-flight builds, which are baking the outdated values — then kicks a rebuild. The supersede is awaited and fail-visible; the rebuild is detached and best-effort.

**Vercel/OpenComputer parity (commit 2):** both providers' hand-rolled branch-only build `SESSION_CONFIG`s are generalized so environment builds serialize the repositories-bearing payload; environment builds get the full provider-session lifecycle — bearer callback tokens (same token scheme as repo images), trigger-time session binding with teardown on failure, deferred snapshot/checkpoint finalization behind `waitUntil`, and build-sandbox cleanup hooks. Daytona untouched (base image), as designed.

### Tests
All green locally: control-plane unit 1656 (+44: workflow trigger/completion/failure/cleanup incl. provider-session paths, fingerprint/runtime-version parsing), control-plane integration 508 (+20 new `environment-images.test.ts`: store state machine vs real D1, cron-facing routes, callback auth + fail-closed registration matrix, secret-change supersede through the real PUT/DELETE routes, reaper leaves artifact-bearing rows for retry when the provider is unconfigured), sandbox-runtime 436 (+1 multi-repo repository_shas emission), modal-infra 195 (BuildLogResult + both cron passes); typecheck + eslint + prettier + ruff clean.

### Deliberate deviations from the plan doc
- **No `ttl=None` at snapshot time.** The Modal TTL change (#897) was rolled back and Modal is pinned at 1.4.3, where `snapshot_filesystem` has no `ttl` parameter and snapshots don't auto-expire — so **trigger 4 (provider-side expiry) is inert** and documented as the seam that activates with the snapshot-TTL follow-up. Nothing else in this PR depends on it.
- **`repositories_fingerprint` is computed control-plane-side at registration**, not echoed by the build callback. The same algorithm must run at spawn matching (PR-11); putting it in the callback would duplicate the hash across two languages. The callback carries only what the build alone knows: `repository_shas` + `runtime_version`.
- **`markRestoreFailed` is deferred to PR-11** with its caller (the spawn restore-failure fallback). It was specced here as "PR-0's twin", but PR-0 was reverted — repo-images has no such method today, and per the #909 precedent seams land with the code that uses them.
- **The concurrency-1 guard lives in the control-plane trigger path**, not cron-side like repo images — environment builds are triggered from three places (cron, save-hooks, later "Rebuild now"), so the guard sits where they converge. The cron still checks first to save the HTTP round-trip.
- **Mirror, not generalize.** The subsystem parallels repo-images (store/planner/workflow/adapters/errors) rather than parameterizing the merged, spawn-critical repo-image module; the genuinely shared leaves (callback-token scheme, provider policy, secrets cap enforcement, bearer-token extraction) are imported from their existing homes. Folding both into one image-build subsystem is a tracked follow-up refactor alongside the scoped-secrets-store unification.

### Not covered
- Live end-to-end (trigger → Modal build → callback → spawn selection) needs deployed infra — owed with the standing live-e2e pass; spawn selection itself is PR-11.
- Triggering a build via the route isn't integration-tested end-to-end (the harness has no Modal/Vercel credentials — the same suite-wide limitation as the SCM gap noted on #916); trigger orchestration is covered at the workflow layer with mocked adapters, and everything from the callback onward runs against real D1 through the real routes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced environment image builds across supported providers, including trigger, completion, failure, and cleanup workflows.
  * Added callback routes, status/enabled views, and maintenance endpoints for stale builds and cleanup.
  * Implemented multi-repository “repositories fingerprint” and environment-image build scheduling on save and after secrets changes.
* **Bug Fixes**
  * Enforced single in-flight builds and token-gated, fail-closed completion handling.
  * Improved superseding, late completion reporting, and reaping behavior (including artifact-retention edge cases).
* **Tests**
  * Added unit and integration coverage for fingerprints, workflow behavior, and scheduler rebuild decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->