### PR TITLE
feat(web): Settings › Environments + unified session picker

### DIFF
--- a/packages/web/src/app/(app)/page.test.tsx
+++ b/packages/web/src/app/(app)/page.test.tsx
@@ -23,6 +23,20 @@ const mocks = vi.hoisted(() => ({
     defaultBranch: string;
   }>,
   loadingReposValue: false,
+  environmentsValue: [] as Array<{
+    id: string;
+    name: string;
+    description: string | null;
+    prebuildEnabled: boolean;
+    createdAt: number;
+    updatedAt: number;
+    repositories: Array<{
+      repoOwner: string;
+      repoName: string;
+      repoId: number | null;
+      baseBranch: string;
+    }>;
+  }>,
 }));
 
 const repo = {
@@ -44,7 +58,14 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("swr", () => ({
+  // Home uses the default export only for the picker's prebuild-status text.
+  default: () => ({ data: undefined, isLoading: false }),
   mutate: mocks.mutateMock,
+}));
+
+vi.mock("@/hooks/use-environments", () => ({
+  ENVIRONMENTS_KEY: "/api/environments",
+  useEnvironments: () => ({ environments: mocks.environmentsValue, loading: false }),
 }));
 
 vi.mock("@/components/sidebar-layout", () => ({
@@ -79,6 +100,7 @@ beforeAll(() => {
 beforeEach(() => {
   mocks.reposValue = [repo];
   mocks.loadingReposValue = false;
+  mocks.environmentsValue = [];
   mocks.routerPush.mockReset();
   mocks.mutateMock.mockReset();
   vi.stubGlobal(
@@ -147,5 +169,81 @@ describe("Home", () => {
       model: DEFAULT_MODEL,
     });
     expect(screen.getByText(/you can start without a repository/i)).toBeInTheDocument();
+  });
+
+  it("launches from an environment sending only environmentId", async () => {
+    mocks.environmentsValue = [
+      {
+        id: "env-1",
+        name: "full-stack",
+        description: null,
+        prebuildEnabled: true,
+        createdAt: 1,
+        updatedAt: 1,
+        repositories: [
+          { repoOwner: "acme", repoName: "backend", repoId: 1, baseBranch: "main" },
+          { repoOwner: "acme", repoName: "frontend", repoId: 2, baseBranch: "main" },
+        ],
+      },
+    ];
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await screen.findByRole("button", { name: /background-agents/i });
+    await user.click(screen.getByRole("button", { name: /background-agents/i }));
+    const listbox = screen.getByRole("listbox");
+    await user.click(within(listbox).getByRole("option", { name: /full-stack/i }));
+
+    await user.type(screen.getByPlaceholderText("What do you want to build?"), "Wire the API");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+
+    await waitFor(() => expect(mocks.routerPush).toHaveBeenCalledWith("/session/session-1"));
+    const body = sessionCreateBody();
+    expect(body).toMatchObject({ environmentId: "env-1", model: DEFAULT_MODEL });
+    expect(body).not.toHaveProperty("repoOwner");
+    expect(body).not.toHaveProperty("repositories");
+    expect(body).not.toHaveProperty("branch");
+  });
+
+  it("launches an ad-hoc set sending only repositories, seeded from the selected repo", async () => {
+    mocks.reposValue = [
+      repo,
+      {
+        id: 2,
+        fullName: "open-inspect/docs",
+        owner: "open-inspect",
+        name: "docs",
+        description: null,
+        private: false,
+        defaultBranch: "main",
+      },
+    ];
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await screen.findByRole("button", { name: /background-agents/i });
+    await user.click(screen.getByRole("button", { name: /background-agents/i }));
+    const listbox = screen.getByRole("listbox");
+    await user.click(within(listbox).getByRole("option", { name: /multiple repositories/i }));
+
+    // The multi-select opens seeded with the previously selected repo; add docs.
+    await user.click(screen.getByRole("button", { name: /repository selection/i }));
+    await user.click(screen.getByRole("checkbox", { name: /open-inspect\/docs/i }));
+    await user.click(screen.getByRole("button", { name: /done/i }));
+
+    await user.type(screen.getByPlaceholderText("What do you want to build?"), "Sync the docs");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+
+    await waitFor(() => expect(mocks.routerPush).toHaveBeenCalledWith("/session/session-1"));
+    const body = sessionCreateBody();
+    expect(body).toMatchObject({
+      repositories: [
+        { repoOwner: "open-inspect", repoName: "background-agents" },
+        { repoOwner: "open-inspect", repoName: "docs" },
+      ],
+    });
+    expect(body).not.toHaveProperty("repoOwner");
+    expect(body).not.toHaveProperty("environmentId");
+    expect(body).not.toHaveProperty("branch");
   });
 });

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -3,7 +3,7 @@
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { mutate } from "swr";
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import Link from "next/link";
 import { useSidebarContext } from "@/components/sidebar-layout";
 import { Button } from "@/components/ui/button";
@@ -17,11 +17,28 @@ import {
   DEFAULT_MODEL,
   getDefaultReasoningEffort,
   isValidReasoningEffort,
+  type Environment,
   type ModelCategory,
 } from "@open-inspect/shared";
+import useSWR from "swr";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
 import { useRepos, type Repo } from "@/hooks/use-repos";
 import { useBranches } from "@/hooks/use-branches";
+import { useEnvironments } from "@/hooks/use-environments";
+import { supportsRepoImages } from "@/lib/sandbox-provider";
+import {
+  type SessionTarget,
+  NO_REPOSITORY_OPTION_VALUE,
+  MULTIPLE_REPOSITORIES_OPTION_VALUE,
+  buildSessionTargetRequestFields,
+  environmentOptionValue,
+  getTargetConfigKey,
+  getTargetSelectValue,
+  isSessionTargetLaunchable,
+  parseRepoFullName,
+  parseTargetSelectValue,
+} from "@/lib/session-target";
+import { RepositoryMultiSelect } from "@/components/repository-multi-select";
 import { ReasoningEffortPills } from "@/components/reasoning-effort-pills";
 import {
   SidebarIcon,
@@ -36,30 +53,31 @@ import { Combobox, type ComboboxGroup } from "@/components/ui/combobox";
 const LAST_SELECTED_REPO_STORAGE_KEY = "open-inspect-last-selected-repo";
 const LAST_SELECTED_MODEL_STORAGE_KEY = "open-inspect-last-selected-model";
 const LAST_SELECTED_REASONING_EFFORT_STORAGE_KEY = "open-inspect-last-selected-reasoning-effort";
-const NO_REPOSITORY_OPTION_VALUE = "__no_repository__";
 
-type SessionTarget = { kind: "none" } | { kind: "repo"; repoFullName: string };
-
-function parseRepoFullName(repoFullName: string): { owner: string; name: string } | null {
-  const [owner, name] = repoFullName.split("/");
-  return owner && name ? { owner, name } : null;
+interface EnvironmentImageStatusRow {
+  environment_id: string;
+  status: "building" | "ready" | "failed";
 }
 
-function getTargetSelectValue(target: SessionTarget | null): string {
-  if (!target) return "";
-  return target.kind === "none" ? NO_REPOSITORY_OPTION_VALUE : target.repoFullName;
-}
-
-function parseTargetSelectValue(value: string): SessionTarget {
-  return value === NO_REPOSITORY_OPTION_VALUE
-    ? { kind: "none" }
-    : { kind: "repo", repoFullName: value };
+/** Picker subtitle for an environment: repository count plus prebuild state. */
+function describeEnvironment(
+  environment: Environment,
+  imageStatusByEnvironment: Map<string, EnvironmentImageStatusRow["status"]>
+): string {
+  const count = environment.repositories.length;
+  const base = `${count} ${count === 1 ? "repository" : "repositories"}`;
+  if (!environment.prebuildEnabled) return base;
+  const status = imageStatusByEnvironment.get(environment.id);
+  if (status === "ready") return `${base} · prebuilt`;
+  if (status === "building") return `${base} · prebuild building`;
+  return `${base} · prebuilds on`;
 }
 
 export default function Home() {
   const { data: session } = useSession();
   const router = useRouter();
   const { repos, loading: loadingRepos } = useRepos();
+  const { environments } = useEnvironments();
   const [sessionTarget, setSessionTarget] = useState<SessionTarget | null>(null);
   const [selectedModel, setSelectedModel] = useState<string>(DEFAULT_MODEL);
   const [reasoningEffort, setReasoningEffort] = useState<string | undefined>(
@@ -73,6 +91,8 @@ export default function Home() {
   const [isCreatingSession, setIsCreatingSession] = useState(false);
   const sessionCreationPromise = useRef<Promise<string | null> | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
+  // Keyed by getTargetConfigKey so environment/ad-hoc selections invalidate
+  // a warmed session exactly like repo/branch changes do.
   const pendingConfigRef = useRef<{ target: string; model: string; branch: string } | null>(null);
   const [hasHydratedModelPreferences, setHasHydratedModelPreferences] = useState(false);
   const { enabledModels, enabledModelOptions } = useEnabledModels();
@@ -82,6 +102,21 @@ export default function Home() {
   const selectedRepoOwner = selectedRepository?.owner ?? "";
   const selectedRepoName = selectedRepository?.name ?? "";
   const { branches, loading: loadingBranches } = useBranches(selectedRepoOwner, selectedRepoName);
+
+  // Prebuild status for the environment options (ready/building rows of
+  // prebuild-enabled environments, one call across all of them).
+  const { data: environmentImagesData } = useSWR<{ images: EnvironmentImageStatusRow[] }>(
+    environments.length > 0 && supportsRepoImages() ? "/api/environment-images" : null
+  );
+  const imageStatusByEnvironment = useMemo(() => {
+    const statusByEnvironment = new Map<string, EnvironmentImageStatusRow["status"]>();
+    for (const row of environmentImagesData?.images ?? []) {
+      if (row.status === "ready" || !statusByEnvironment.has(row.environment_id)) {
+        statusByEnvironment.set(row.environment_id, row.status);
+      }
+    }
+    return statusByEnvironment;
+  }, [environmentImagesData]);
 
   // Auto-select repo when repos load
   useEffect(() => {
@@ -155,13 +190,11 @@ export default function Home() {
   const createSessionForWarming = useCallback(async () => {
     if (pendingSessionId) return pendingSessionId;
     if (sessionCreationPromise.current) return sessionCreationPromise.current;
-    if (!sessionTarget) return null;
+    if (!sessionTarget || !isSessionTargetLaunchable(sessionTarget)) return null;
 
     setIsCreatingSession(true);
-    const repository =
-      sessionTarget.kind === "repo" ? parseRepoFullName(sessionTarget.repoFullName) : null;
     const currentConfig = {
-      target: getTargetSelectValue(sessionTarget),
+      target: getTargetConfigKey(sessionTarget),
       model: selectedModel,
       branch: sessionTarget.kind === "repo" ? selectedBranch : "",
     };
@@ -176,11 +209,9 @@ export default function Home() {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            repoOwner: repository?.owner ?? null,
-            repoName: repository?.name ?? null,
+            ...buildSessionTargetRequestFields(sessionTarget, selectedBranch),
             model: selectedModel,
             reasoningEffort,
-            ...(repository ? { branch: selectedBranch || undefined } : {}),
           }),
           signal: abortController.signal,
         });
@@ -235,17 +266,21 @@ export default function Home() {
 
   const handleSessionTargetChange = useCallback(
     (value: string) => {
-      const nextTarget = parseTargetSelectValue(value);
+      const nextTarget = parseTargetSelectValue(value, sessionTarget);
       setSessionTarget(nextTarget);
-      if (nextTarget.kind === "none") {
+      if (nextTarget.kind !== "repo") {
         setSelectedBranch("");
         return;
       }
       const repo = repos.find((r) => r.fullName === nextTarget.repoFullName);
       if (repo) setSelectedBranch(repo.defaultBranch);
     },
-    [repos]
+    [repos, sessionTarget]
   );
+
+  const handleMultiSelectionChange = useCallback((repoFullNames: string[]) => {
+    setSessionTarget({ kind: "repos", repoFullNames });
+  }, []);
 
   const handleModelChange = useCallback((model: string) => {
     setSelectedModel(model);
@@ -255,7 +290,13 @@ export default function Home() {
   const handlePromptChange = (value: string) => {
     const wasEmpty = prompt.length === 0;
     setPrompt(value);
-    if (wasEmpty && value.length > 0 && !pendingSessionId && !isCreatingSession && sessionTarget) {
+    if (
+      wasEmpty &&
+      value.length > 0 &&
+      !pendingSessionId &&
+      !isCreatingSession &&
+      isSessionTargetLaunchable(sessionTarget)
+    ) {
       createSessionForWarming();
     }
   };
@@ -263,8 +304,12 @@ export default function Home() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!prompt.trim()) return;
-    if (!sessionTarget) {
-      setError("Please select a repository");
+    if (!isSessionTargetLaunchable(sessionTarget)) {
+      setError(
+        sessionTarget?.kind === "repos"
+          ? "Select at least one repository"
+          : "Please select a repository or environment"
+      );
       return;
     }
 
@@ -312,9 +357,12 @@ export default function Home() {
       isAuthenticated={!!session}
       repos={repos}
       loadingRepos={loadingRepos}
+      environments={environments}
+      imageStatusByEnvironment={imageStatusByEnvironment}
       sessionTarget={sessionTarget}
       targetSelectValue={targetSelectValue}
       setSessionTargetSelectValue={handleSessionTargetChange}
+      onMultiSelectionChange={handleMultiSelectionChange}
       selectedBranch={selectedBranch}
       setSelectedBranch={setSelectedBranch}
       branches={branches}
@@ -338,9 +386,12 @@ function HomeContent({
   isAuthenticated,
   repos,
   loadingRepos,
+  environments,
+  imageStatusByEnvironment,
   sessionTarget,
   targetSelectValue,
   setSessionTargetSelectValue,
+  onMultiSelectionChange,
   selectedBranch,
   setSelectedBranch,
   branches,
@@ -360,9 +411,12 @@ function HomeContent({
   isAuthenticated: boolean;
   repos: Repo[];
   loadingRepos: boolean;
+  environments: Environment[];
+  imageStatusByEnvironment: Map<string, EnvironmentImageStatusRow["status"]>;
   sessionTarget: SessionTarget | null;
   targetSelectValue: string;
   setSessionTargetSelectValue: (value: string) => void;
+  onMultiSelectionChange: (repoFullNames: string[]) => void;
   selectedBranch: string;
   setSelectedBranch: (value: string) => void;
   branches: { name: string }[];
@@ -395,17 +449,37 @@ function HomeContent({
     sessionTarget?.kind === "repo"
       ? repos.find((r) => r.fullName === sessionTarget.repoFullName)
       : undefined;
-  const displayRepoName =
-    sessionTarget?.kind === "none"
-      ? NO_REPOSITORY_LABEL
-      : sessionTarget?.kind === "repo"
-        ? (selectedRepoObj?.name ?? sessionTarget.repoFullName)
-        : "Select repo";
+  const selectedEnvironment =
+    sessionTarget?.kind === "environment"
+      ? environments.find((environment) => environment.id === sessionTarget.environmentId)
+      : undefined;
+  const displayTargetName = (() => {
+    switch (sessionTarget?.kind) {
+      case "none":
+        return NO_REPOSITORY_LABEL;
+      case "repo":
+        return selectedRepoObj?.name ?? sessionTarget.repoFullName;
+      case "environment":
+        return selectedEnvironment?.name ?? "Environment";
+      case "repos": {
+        const count = sessionTarget.repoFullNames.length;
+        if (count === 0) return "Select repositories";
+        return `${count} ${count === 1 ? "repository" : "repositories"}`;
+      }
+      default:
+        return "Select repo";
+    }
+  })();
   const repositoryOptions = [
     {
       value: NO_REPOSITORY_OPTION_VALUE,
       label: NO_REPOSITORY_LABEL,
       description: "Start without cloning a repository",
+    },
+    {
+      value: MULTIPLE_REPOSITORIES_OPTION_VALUE,
+      label: "Multiple repositories",
+      description: "Pick an ad-hoc set of repositories",
     },
     ...repos.map((repo) => ({
       value: repo.fullName,
@@ -413,6 +487,21 @@ function HomeContent({
       description: `${repo.owner}${repo.private ? " \u2022 private" : ""}`,
     })),
   ];
+  // One unified list: environments (when any exist) alongside the repositories.
+  const targetOptions =
+    environments.length > 0
+      ? [
+          {
+            category: "Environments",
+            options: environments.map((environment) => ({
+              value: environmentOptionValue(environment.id),
+              label: environment.name,
+              description: describeEnvironment(environment, imageStatusByEnvironment),
+            })),
+          },
+          { category: "Repositories", options: repositoryOptions },
+        ]
+      : repositoryOptions;
 
   return (
     <div className="h-full flex flex-col">
@@ -472,7 +561,9 @@ function HomeContent({
                     )}
                     <button
                       type="submit"
-                      disabled={!prompt.trim() || creating || !sessionTarget}
+                      disabled={
+                        !prompt.trim() || creating || !isSessionTargetLaunchable(sessionTarget)
+                      }
                       className="p-2 text-secondary-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition"
                       title={`Send (${SHORTCUT_LABELS.SEND_PROMPT})`}
                       aria-label={`Send (${SHORTCUT_LABELS.SEND_PROMPT})`}
@@ -494,9 +585,9 @@ function HomeContent({
                     <Combobox
                       value={targetSelectValue}
                       onChange={(value) => setSessionTargetSelectValue(value)}
-                      items={repositoryOptions}
+                      items={targetOptions}
                       searchable
-                      searchPlaceholder="Search repositories..."
+                      searchPlaceholder="Search environments and repositories..."
                       filterFn={(option, query) =>
                         option.label.toLowerCase().includes(query) ||
                         (option.description?.toLowerCase().includes(query) ?? false) ||
@@ -509,10 +600,27 @@ function HomeContent({
                     >
                       <RepoIcon className="w-4 h-4" />
                       <span className="truncate max-w-[12rem] sm:max-w-none">
-                        {loadingRepos ? "Loading..." : displayRepoName}
+                        {loadingRepos ? "Loading..." : displayTargetName}
                       </span>
                       <ChevronDownIcon className="w-3 h-3" />
                     </Combobox>
+
+                    {/* Ad-hoc repository set editor */}
+                    {sessionTarget?.kind === "repos" && (
+                      <RepositoryMultiSelect
+                        repos={repos}
+                        loadingRepos={loadingRepos}
+                        selected={sessionTarget.repoFullNames}
+                        onChange={onMultiSelectionChange}
+                        disabled={creating || loadingRepos}
+                        triggerLabel={
+                          sessionTarget.repoFullNames.length === 0
+                            ? "Choose repositories"
+                            : sessionTarget.repoFullNames.join(", ")
+                        }
+                        triggerClassName="max-w-[16rem] border-0 bg-transparent px-0 py-0 text-sm text-muted-foreground hover:text-foreground"
+                      />
+                    )}
 
                     {/* Branch selector */}
                     {sessionTarget?.kind === "repo" && (
@@ -579,6 +687,24 @@ function HomeContent({
                   </span>
                 </div>
               </div>
+
+              {/* Secrets disclosure per launch unit (design §7.4) */}
+              {sessionTarget?.kind === "environment" && (
+                <p className="mt-3 text-xs text-muted-foreground text-center">
+                  Sessions from this environment use global secrets plus the environment&apos;s
+                  secrets.
+                </p>
+              )}
+              {sessionTarget?.kind === "repos" && (
+                <p className="mt-3 text-xs text-muted-foreground text-center">
+                  Ad-hoc sessions use global secrets plus the selected repositories&apos; secrets,
+                  and don&apos;t get prebuilt images —{" "}
+                  <Link href="/settings?tab=environments" className="text-accent hover:underline">
+                    save this set as an environment
+                  </Link>
+                  .
+                </p>
+              )}
 
               {selectedRepoObj && (
                 <div className="mt-3 text-center">

--- a/packages/web/src/app/(app)/settings/page.tsx
+++ b/packages/web/src/app/(app)/settings/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import { useSidebarContext } from "@/components/sidebar-layout";
 import { SettingsNav, type SettingsCategory } from "@/components/settings/settings-nav";
 import { SecretsSettings } from "@/components/settings/secrets-settings";
+import { EnvironmentsSettings } from "@/components/settings/environments-settings";
 import { ModelsSettings } from "@/components/settings/models-settings";
 import { DataControlsSettings } from "@/components/settings/data-controls-settings";
 import { KeyboardShortcutsSettings } from "@/components/settings/keyboard-shortcuts-settings";
@@ -20,6 +21,7 @@ import { supportsRepoImages } from "@/lib/sandbox-provider";
 
 const CATEGORY_LABELS: Record<SettingsCategory, string> = {
   secrets: "Secrets",
+  environments: "Environments",
   models: "Models",
   images: "Images",
   appearance: "Appearance",
@@ -32,6 +34,7 @@ const CATEGORY_LABELS: Record<SettingsCategory, string> = {
 
 const VALID_CATEGORIES = new Set<string>([
   "secrets",
+  "environments",
   "models",
   "images",
   "appearance",
@@ -81,6 +84,7 @@ export default function SettingsPage() {
   const content = (
     <>
       {activeCategory === "secrets" && <SecretsSettings />}
+      {activeCategory === "environments" && <EnvironmentsSettings />}
       {activeCategory === "models" && <ModelsSettings />}
       {activeCategory === "images" && repoImagesEnabled && <ImagesSettings />}
       {activeCategory === "appearance" && <AppearanceSettings />}

--- a/packages/web/src/app/api/environment-images/route.test.ts
+++ b/packages/web/src/app/api/environment-images/route.test.ts
@@ -1,0 +1,80 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  supportsRepoImagesValue: true,
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  authOptions: {},
+}));
+
+vi.mock("@/lib/control-plane", () => ({
+  controlPlaneFetch: vi.fn(),
+}));
+
+vi.mock("@/lib/sandbox-provider", () => ({
+  supportsRepoImages: () => mocks.supportsRepoImagesValue,
+}));
+
+import { getServerSession } from "next-auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+import { GET as getAllStatus } from "./route";
+import { GET as getEnvironmentStatus } from "../environments/[id]/images/route";
+import { POST as triggerBuild } from "../environments/[id]/images/trigger/route";
+
+const request = {} as NextRequest;
+const params = { params: Promise.resolve({ id: "env-1" }) };
+
+const routes = [
+  { name: "GET /api/environment-images", call: () => getAllStatus() },
+  {
+    name: "GET /api/environments/[id]/images",
+    call: () => getEnvironmentStatus(request, params),
+  },
+  {
+    name: "POST /api/environments/[id]/images/trigger",
+    call: () => triggerBuild(request, params),
+  },
+];
+
+describe.each(routes)("$name", ({ call }) => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.supportsRepoImagesValue = true;
+  });
+
+  it("returns 401 before disclosing provider support when unauthenticated", async () => {
+    mocks.supportsRepoImagesValue = false;
+    vi.mocked(getServerSession).mockResolvedValue(null);
+
+    const response = await call();
+
+    expect(response.status).toBe(401);
+    expect(controlPlaneFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 501 for authenticated users on a provider without image support", async () => {
+    mocks.supportsRepoImagesValue = false;
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "12345" } } as never);
+
+    const response = await call();
+
+    expect(response.status).toBe(501);
+    expect(controlPlaneFetch).not.toHaveBeenCalled();
+  });
+
+  it("proxies to the control plane for authenticated users", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "12345" } } as never);
+    vi.mocked(controlPlaneFetch).mockImplementation(async () => Response.json({ images: [] }));
+
+    const response = await call();
+
+    expect(response.status).toBe(200);
+    expect(controlPlaneFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/app/api/environment-images/route.ts
+++ b/packages/web/src/app/api/environment-images/route.ts
@@ -10,6 +10,11 @@ import { supportsRepoImages } from "@/lib/sandbox-provider";
  * rows are per-environment detail: /api/environments/[id]/images.
  */
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   if (!supportsRepoImages()) {
     return NextResponse.json(
       {
@@ -18,11 +23,6 @@ export async function GET() {
       },
       { status: 501 }
     );
-  }
-
-  const session = await getServerSession(authOptions);
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   try {

--- a/packages/web/src/app/api/environment-images/route.ts
+++ b/packages/web/src/app/api/environment-images/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+import { supportsRepoImages } from "@/lib/sandbox-provider";
+
+/**
+ * Cross-environment image status (ready and building rows of prebuild-enabled
+ * environments) — the picker's one-call source for prebuild status. Failed
+ * rows are per-environment detail: /api/environments/[id]/images.
+ */
+export async function GET() {
+  if (!supportsRepoImages()) {
+    return NextResponse.json(
+      {
+        error:
+          "Environment images are only available when SANDBOX_PROVIDER=modal, vercel, or opencomputer",
+      },
+      { status: 501 }
+    );
+  }
+
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const response = await controlPlaneFetch("/environment-images/status");
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to fetch environment image status:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch environment image status" },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/web/src/app/api/environments/[id]/images/route.ts
+++ b/packages/web/src/app/api/environments/[id]/images/route.ts
@@ -1,0 +1,39 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+import { supportsRepoImages } from "@/lib/sandbox-provider";
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  if (!supportsRepoImages()) {
+    return NextResponse.json(
+      {
+        error:
+          "Environment images are only available when SANDBOX_PROVIDER=modal, vercel, or opencomputer",
+      },
+      { status: 501 }
+    );
+  }
+
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const response = await controlPlaneFetch(
+      `/environment-images/status?environment_id=${encodeURIComponent(id)}`
+    );
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to fetch environment image status:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch environment image status" },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/web/src/app/api/environments/[id]/images/route.ts
+++ b/packages/web/src/app/api/environments/[id]/images/route.ts
@@ -6,6 +6,11 @@ import { controlPlaneFetch } from "@/lib/control-plane";
 import { supportsRepoImages } from "@/lib/sandbox-provider";
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   if (!supportsRepoImages()) {
     return NextResponse.json(
       {
@@ -14,11 +19,6 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
       },
       { status: 501 }
     );
-  }
-
-  const session = await getServerSession(authOptions);
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const { id } = await params;

--- a/packages/web/src/app/api/environments/[id]/images/trigger/route.ts
+++ b/packages/web/src/app/api/environments/[id]/images/trigger/route.ts
@@ -1,0 +1,40 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+import { supportsRepoImages } from "@/lib/sandbox-provider";
+
+export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  if (!supportsRepoImages()) {
+    return NextResponse.json(
+      {
+        error:
+          "Environment images are only available when SANDBOX_PROVIDER=modal, vercel, or opencomputer",
+      },
+      { status: 501 }
+    );
+  }
+
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  try {
+    const response = await controlPlaneFetch(
+      `/environment-images/trigger/${encodeURIComponent(id)}`,
+      { method: "POST" }
+    );
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Failed to trigger environment image build:", error);
+    return NextResponse.json(
+      { error: "Failed to trigger environment image build" },
+      { status: 500 }
+    );
+  }
+}

--- a/packages/web/src/app/api/environments/[id]/images/trigger/route.ts
+++ b/packages/web/src/app/api/environments/[id]/images/trigger/route.ts
@@ -6,6 +6,11 @@ import { controlPlaneFetch } from "@/lib/control-plane";
 import { supportsRepoImages } from "@/lib/sandbox-provider";
 
 export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   if (!supportsRepoImages()) {
     return NextResponse.json(
       {
@@ -14,11 +19,6 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
       },
       { status: 501 }
     );
-  }
-
-  const session = await getServerSession(authOptions);
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const { id } = await params;

--- a/packages/web/src/app/api/repo-images/[owner]/[name]/toggle/route.ts
+++ b/packages/web/src/app/api/repo-images/[owner]/[name]/toggle/route.ts
@@ -9,6 +9,11 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ owner: string; name: string }> }
 ) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   if (!supportsRepoImages()) {
     return NextResponse.json(
       {
@@ -17,11 +22,6 @@ export async function PUT(
       },
       { status: 501 }
     );
-  }
-
-  const session = await getServerSession(authOptions);
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const { owner, name } = await params;

--- a/packages/web/src/app/api/repo-images/[owner]/[name]/trigger/route.ts
+++ b/packages/web/src/app/api/repo-images/[owner]/[name]/trigger/route.ts
@@ -9,6 +9,11 @@ export async function POST(
   _request: NextRequest,
   { params }: { params: Promise<{ owner: string; name: string }> }
 ) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   if (!supportsRepoImages()) {
     return NextResponse.json(
       {
@@ -17,11 +22,6 @@ export async function POST(
       },
       { status: 501 }
     );
-  }
-
-  const session = await getServerSession(authOptions);
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   const { owner, name } = await params;

--- a/packages/web/src/app/api/repo-images/route.test.ts
+++ b/packages/web/src/app/api/repo-images/route.test.ts
@@ -1,0 +1,82 @@
+import type { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  supportsRepoImagesValue: true,
+}));
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  authOptions: {},
+}));
+
+vi.mock("@/lib/control-plane", () => ({
+  controlPlaneFetch: vi.fn(),
+}));
+
+vi.mock("@/lib/sandbox-provider", () => ({
+  supportsRepoImages: () => mocks.supportsRepoImagesValue,
+}));
+
+import { getServerSession } from "next-auth";
+import { controlPlaneFetch } from "@/lib/control-plane";
+import { GET as getRegistry } from "./route";
+import { POST as triggerBuild } from "./[owner]/[name]/trigger/route";
+import { PUT as toggleBuild } from "./[owner]/[name]/toggle/route";
+
+const params = { params: Promise.resolve({ owner: "acme", name: "web" }) };
+
+const routes = [
+  { name: "GET /api/repo-images", call: () => getRegistry() },
+  {
+    name: "POST /api/repo-images/[owner]/[name]/trigger",
+    call: () => triggerBuild({} as NextRequest, params),
+  },
+  {
+    name: "PUT /api/repo-images/[owner]/[name]/toggle",
+    call: () => toggleBuild({ json: async () => ({ enabled: true }) } as NextRequest, params),
+  },
+];
+
+describe.each(routes)("$name", ({ call }) => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.supportsRepoImagesValue = true;
+  });
+
+  it("returns 401 before disclosing provider support when unauthenticated", async () => {
+    mocks.supportsRepoImagesValue = false;
+    vi.mocked(getServerSession).mockResolvedValue(null);
+
+    const response = await call();
+
+    expect(response.status).toBe(401);
+    expect(controlPlaneFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns 501 for authenticated users on a provider without image support", async () => {
+    mocks.supportsRepoImagesValue = false;
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "12345" } } as never);
+
+    const response = await call();
+
+    expect(response.status).toBe(501);
+    expect(controlPlaneFetch).not.toHaveBeenCalled();
+  });
+
+  it("proxies to the control plane for authenticated users", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "12345" } } as never);
+    // Fresh Response per call — the registry route consumes two bodies.
+    vi.mocked(controlPlaneFetch).mockImplementation(async () =>
+      Response.json({ repos: [], images: [] })
+    );
+
+    const response = await call();
+
+    expect(response.status).toBe(200);
+    expect(controlPlaneFetch).toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/app/api/repo-images/route.ts
+++ b/packages/web/src/app/api/repo-images/route.ts
@@ -5,6 +5,11 @@ import { controlPlaneFetch } from "@/lib/control-plane";
 import { supportsRepoImages } from "@/lib/sandbox-provider";
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   if (!supportsRepoImages()) {
     return NextResponse.json(
       {
@@ -13,11 +18,6 @@ export async function GET() {
       },
       { status: 501 }
     );
-  }
-
-  const session = await getServerSession(authOptions);
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
   try {

--- a/packages/web/src/app/api/sessions/route.test.ts
+++ b/packages/web/src/app/api/sessions/route.test.ts
@@ -318,4 +318,67 @@ describe("sessions API route (POST)", () => {
     expect(sent.scmLogin).toBeUndefined();
     expect(sent.scmEmail).toBeUndefined();
   });
+
+  it("forwards environmentId for environment launches", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "12345", provider: "github" },
+    } as never);
+    vi.mocked(getToken).mockResolvedValue(null);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(Response.json({ id: "sess3" }, { status: 201 }));
+
+    const response = await POST(postRequest({ environmentId: "env-1", model: "m" }));
+
+    expect(response.status).toBe(201);
+    const sent = controlPlaneBody();
+    expect(sent.environmentId).toBe("env-1");
+    expect(sent.repositories).toBeUndefined();
+    expect(sent.repoOwner).toBeUndefined();
+    expect(sent.repoName).toBeUndefined();
+  });
+
+  it("forwards the repositories list for ad-hoc multi-repo launches", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "12345", provider: "github" },
+    } as never);
+    vi.mocked(getToken).mockResolvedValue(null);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(Response.json({ id: "sess4" }, { status: 201 }));
+
+    const repositories = [
+      { repoOwner: "acme", repoName: "backend" },
+      { repoOwner: "acme", repoName: "frontend" },
+    ];
+    const response = await POST(postRequest({ repositories, model: "m" }));
+
+    expect(response.status).toBe(201);
+    const sent = controlPlaneBody();
+    expect(sent.repositories).toEqual(repositories);
+    expect(sent.environmentId).toBeUndefined();
+  });
+
+  it("still strips fields outside the allowlist", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({
+      user: { id: "12345", provider: "github" },
+    } as never);
+    vi.mocked(getToken).mockResolvedValue(null);
+    vi.mocked(controlPlaneFetch).mockResolvedValue(Response.json({ id: "sess5" }, { status: 201 }));
+
+    const response = await POST(
+      postRequest({
+        environmentId: "env-1",
+        userId: "attacker",
+        spawnSource: "automation",
+        scmToken: "gho_forged",
+        authUserId: "someone-else",
+      })
+    );
+
+    expect(response.status).toBe(201);
+    const sent = controlPlaneBody();
+    expect(sent.environmentId).toBe("env-1");
+    // Identity fields stay server-derived.
+    expect(sent.userId).toBe("12345");
+    expect(sent.spawnSource).toBe("user");
+    expect(sent.scmToken).toBeUndefined();
+    expect(sent.authUserId).toBe("12345");
+  });
 });

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -87,6 +87,11 @@ export async function POST(request: NextRequest) {
       reasoningEffort: body.reasoningEffort,
       branch: body.branch,
       title: body.title,
+      // The picker's other two target modes (mutually exclusive with the
+      // scalar fields — enforced by createSessionRequestSchema control-plane
+      // side): a named environment or an ad-hoc repository list.
+      environmentId: body.environmentId,
+      repositories: body.repositories,
       spawnSource: "user" as const,
       userId,
       // Provider-agnostic auth identity (GitHub or Google) resolves the

--- a/packages/web/src/components/repository-multi-select.tsx
+++ b/packages/web/src/components/repository-multi-select.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { MAX_TARGET_REPOSITORIES } from "@open-inspect/shared";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { RepoIcon, FolderIcon, SearchIcon, ChevronDownIcon } from "@/components/ui/icons";
+import type { Repo } from "@/hooks/use-repos";
+import { cn } from "@/lib/utils";
+
+/** Selection key for a repository: the lowercase full name, as the API stores it. */
+export function repositorySelectionKey(repoOwner: string, repoName: string): string {
+  return `${repoOwner}/${repoName}`.toLowerCase();
+}
+
+/**
+ * Ordered multi-select of repositories behind a searchable popover (the
+ * automation form's selector pattern) — selection order is list order, so
+ * `selected[0]` is the primary. Enforces the session/environment list rules
+ * client-side: at most MAX_TARGET_REPOSITORIES entries, and no duplicate
+ * repository *name* across owners (checkout paths are /workspace/{repoName}).
+ */
+export function RepositoryMultiSelect({
+  repos,
+  loadingRepos,
+  selected,
+  onChange,
+  disabled = false,
+  triggerLabel,
+  triggerClassName,
+}: {
+  repos: Repo[];
+  loadingRepos: boolean;
+  /** Ordered lowercase "owner/name" keys; [0] is the primary. */
+  selected: string[];
+  onChange: (next: string[]) => void;
+  disabled?: boolean;
+  triggerLabel: string;
+  triggerClassName?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    if (!open) setQuery("");
+  }, [open]);
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const filteredRepos = useMemo(
+    () =>
+      normalizedQuery
+        ? repos.filter((repo) => repo.fullName.toLowerCase().includes(normalizedQuery))
+        : repos,
+    [repos, normalizedQuery]
+  );
+
+  const selectedNamesByKey = useMemo(() => {
+    const names = new Map<string, string>();
+    for (const key of selected) {
+      const name = key.split("/")[1];
+      if (name) names.set(name, key);
+    }
+    return names;
+  }, [selected]);
+
+  const handleToggle = (repo: Repo) => {
+    const key = repositorySelectionKey(repo.owner, repo.name);
+    if (selected.includes(key)) {
+      onChange(selected.filter((entry) => entry !== key));
+      return;
+    }
+    if (selected.length >= MAX_TARGET_REPOSITORIES) return;
+    onChange([...selected, key]);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          className={cn(
+            "flex items-center gap-2 rounded-sm border border-border bg-input px-3 py-2 text-sm text-foreground transition hover:border-foreground/20 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 disabled:cursor-not-allowed disabled:opacity-50",
+            triggerClassName
+          )}
+          aria-label="Repository selection"
+        >
+          <RepoIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 truncate text-left">
+            {loadingRepos && selected.length === 0 ? "Loading..." : triggerLabel}
+          </span>
+          <span className="shrink-0 text-xs text-muted-foreground">
+            {selected.length}/{MAX_TARGET_REPOSITORIES}
+          </span>
+          <ChevronDownIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[min(34rem,calc(100vw-2rem))] p-0 sm:w-[var(--radix-popover-trigger-width)]"
+      >
+        <div className="border-b border-border-muted p-2">
+          <div className="relative">
+            <SearchIcon className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={loadingRepos ? "Loading repositories..." : "Search repositories"}
+              disabled={loadingRepos}
+              autoFocus
+              className="pl-8"
+            />
+          </div>
+        </div>
+        <div className="max-h-72 overflow-y-auto py-1">
+          {filteredRepos.map((repo) => {
+            const key = repositorySelectionKey(repo.owner, repo.name);
+            const checked = selected.includes(key);
+            const atCap = !checked && selected.length >= MAX_TARGET_REPOSITORIES;
+            const nameCollision =
+              !checked && selectedNamesByKey.get(repo.name.toLowerCase()) !== undefined;
+            const itemDisabled = atCap || nameCollision;
+
+            return (
+              <label
+                key={repo.fullName}
+                title={
+                  nameCollision
+                    ? `Another selected repository is also named "${repo.name}" — checkout paths would collide`
+                    : undefined
+                }
+                className={cn(
+                  "flex min-h-10 w-full items-center gap-2 px-3 py-2 text-left text-sm transition",
+                  checked ? "bg-muted text-foreground" : "hover:bg-muted/60",
+                  itemDisabled && "cursor-not-allowed opacity-50"
+                )}
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  disabled={itemDisabled}
+                  onChange={() => handleToggle(repo)}
+                  className="h-4 w-4 rounded border-border accent-accent"
+                />
+                <FolderIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="min-w-0 flex-1 truncate">
+                  {repo.owner}/{repo.name}
+                </span>
+                {repo.private && <span className="text-xs text-muted-foreground">private</span>}
+              </label>
+            );
+          })}
+          {filteredRepos.length === 0 && (
+            <div className="px-3 py-3 text-sm text-muted-foreground">No repositories found</div>
+          )}
+        </div>
+        <div className="flex justify-end border-t border-border-muted px-3 py-2">
+          <Button type="button" variant="outline" size="xs" onClick={() => setOpen(false)}>
+            Done
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/web/src/components/secrets-editor.tsx
+++ b/packages/web/src/components/secrets-editor.tsx
@@ -82,13 +82,16 @@ function createRow(partial?: Partial<SecretRow>): SecretRow {
 export function SecretsEditor({
   owner,
   name,
+  environmentId,
   disabled = false,
   scope = "repo",
 }: {
   owner?: string;
   name?: string;
+  /** Required for scope "environment". */
+  environmentId?: string;
   disabled?: boolean;
-  scope?: "repo" | "global";
+  scope?: "repo" | "global" | "environment";
 }) {
   const [rows, setRows] = useState<SecretRow[]>([]);
   const [saving, setSaving] = useState(false);
@@ -96,10 +99,15 @@ export function SecretsEditor({
   const [deletingKey, setDeletingKey] = useState<string | null>(null);
 
   const isGlobal = scope === "global";
-  const ready = isGlobal || Boolean(owner && name);
+  const isEnvironment = scope === "environment";
+  const ready = isGlobal || (isEnvironment ? Boolean(environmentId) : Boolean(owner && name));
   const repoLabel = owner && name ? `${owner}/${name}` : "";
 
-  const apiBase = isGlobal ? "/api/secrets" : `/api/repos/${owner}/${name}/secrets`;
+  const apiBase = isGlobal
+    ? "/api/secrets"
+    : isEnvironment
+      ? `/api/environments/${environmentId}/secrets`
+      : `/api/repos/${owner}/${name}/secrets`;
 
   const {
     data: secretsData,
@@ -341,7 +349,9 @@ export function SecretsEditor({
 
   const descriptionText = isGlobal
     ? "Secrets apply to all repositories."
-    : `Values are never shown after save. Secrets apply to ${repoLabel || "the selected repo"}.`;
+    : isEnvironment
+      ? "Values are never shown after save. Secrets apply to sessions launched from this environment."
+      : `Values are never shown after save. Secrets apply to ${repoLabel || "the selected repo"}.`;
 
   return (
     <div className="mt-4 rounded-md border border-border bg-background p-4">
@@ -371,7 +381,11 @@ export function SecretsEditor({
 
           {!loading && rows.length === 0 && globalRows.length === 0 && (
             <p className="text-xs text-muted-foreground">
-              {isGlobal ? "No global secrets set." : "No secrets set for this repo."}
+              {isGlobal
+                ? "No global secrets set."
+                : isEnvironment
+                  ? "No secrets set for this environment."
+                  : "No secrets set for this repo."}
             </p>
           )}
 
@@ -459,7 +473,9 @@ export function SecretsEditor({
                         className="flex-1 min-w-[200px] h-auto px-2 py-1 text-xs"
                       />
                       {overridden && (
-                        <span className="text-xs text-muted-foreground">(overridden by repo)</span>
+                        <span className="text-xs text-muted-foreground">
+                          (overridden by {isEnvironment ? "environment" : "repo"})
+                        </span>
                       )}
                     </div>
                   );

--- a/packages/web/src/components/secrets-editor.tsx
+++ b/packages/web/src/components/secrets-editor.tsx
@@ -79,6 +79,64 @@ function createRow(partial?: Partial<SecretRow>): SecretRow {
   };
 }
 
+type SecretsScope = "repo" | "global" | "environment";
+
+/**
+ * Everything scope-specific in one place: where the secrets live, when the
+ * scope is addressable, and the scope's copy. Adding a scope means adding a
+ * case here, not another conditional in the component body.
+ */
+interface SecretsScopePolicy {
+  apiBase: string;
+  ready: boolean;
+  description: string;
+  emptyStateText: string;
+  notReadyText: string;
+  /** Names the scope in the inherited-global override note; null hides the
+   *  inherited section entirely (the global scope inherits from nothing). */
+  overriddenByLabel: string | null;
+}
+
+function resolveScopePolicy(
+  scope: SecretsScope,
+  owner: string | undefined,
+  name: string | undefined,
+  environmentId: string | undefined
+): SecretsScopePolicy {
+  switch (scope) {
+    case "global":
+      return {
+        apiBase: "/api/secrets",
+        ready: true,
+        description: "Secrets apply to all repositories.",
+        emptyStateText: "No global secrets set.",
+        notReadyText: "",
+        overriddenByLabel: null,
+      };
+    case "environment":
+      return {
+        apiBase: `/api/environments/${environmentId}/secrets`,
+        ready: Boolean(environmentId),
+        description:
+          "Values are never shown after save. Secrets apply to sessions launched from this environment.",
+        emptyStateText: "No secrets set for this environment.",
+        notReadyText: "Select an environment to manage secrets.",
+        overriddenByLabel: "environment",
+      };
+    case "repo": {
+      const repoLabel = owner && name ? `${owner}/${name}` : "";
+      return {
+        apiBase: `/api/repos/${owner}/${name}/secrets`,
+        ready: Boolean(owner && name),
+        description: `Values are never shown after save. Secrets apply to ${repoLabel || "the selected repo"}.`,
+        emptyStateText: "No secrets set for this repo.",
+        notReadyText: "Select a repository to manage secrets.",
+        overriddenByLabel: "repo",
+      };
+    }
+  }
+}
+
 export function SecretsEditor({
   owner,
   name,
@@ -91,23 +149,15 @@ export function SecretsEditor({
   /** Required for scope "environment". */
   environmentId?: string;
   disabled?: boolean;
-  scope?: "repo" | "global" | "environment";
+  scope?: SecretsScope;
 }) {
   const [rows, setRows] = useState<SecretRow[]>([]);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   const [deletingKey, setDeletingKey] = useState<string | null>(null);
 
-  const isGlobal = scope === "global";
-  const isEnvironment = scope === "environment";
-  const ready = isGlobal || (isEnvironment ? Boolean(environmentId) : Boolean(owner && name));
-  const repoLabel = owner && name ? `${owner}/${name}` : "";
-
-  const apiBase = isGlobal
-    ? "/api/secrets"
-    : isEnvironment
-      ? `/api/environments/${environmentId}/secrets`
-      : `/api/repos/${owner}/${name}/secrets`;
+  const scopePolicy = resolveScopePolicy(scope, owner, name, environmentId);
+  const { apiBase, ready } = scopePolicy;
 
   const {
     data: secretsData,
@@ -137,7 +187,9 @@ export function SecretsEditor({
   }, [fetchError]);
 
   const globalRows: GlobalSecretMeta[] =
-    !isGlobal && Array.isArray(secretsData?.globalSecrets) ? secretsData.globalSecrets : [];
+    scopePolicy.overriddenByLabel !== null && Array.isArray(secretsData?.globalSecrets)
+      ? secretsData.globalSecrets
+      : [];
 
   const existingKeySet = useMemo(() => {
     return new Set(rows.filter((row) => row.existing).map((row) => normalizeKey(row.key)));
@@ -347,18 +399,12 @@ export function SecretsEditor({
     }
   };
 
-  const descriptionText = isGlobal
-    ? "Secrets apply to all repositories."
-    : isEnvironment
-      ? "Values are never shown after save. Secrets apply to sessions launched from this environment."
-      : `Values are never shown after save. Secrets apply to ${repoLabel || "the selected repo"}.`;
-
   return (
     <div className="mt-4 rounded-md border border-border bg-background p-4">
       <div className="flex items-center justify-between mb-3">
         <div>
           <h3 className="text-sm font-semibold text-foreground">Secrets</h3>
-          <p className="text-xs text-muted-foreground">{descriptionText}</p>
+          <p className="text-xs text-muted-foreground">{scopePolicy.description}</p>
         </div>
         <Button
           type="button"
@@ -371,22 +417,14 @@ export function SecretsEditor({
         </Button>
       </div>
 
-      {!ready && (
-        <p className="text-xs text-muted-foreground">Select a repository to manage secrets.</p>
-      )}
+      {!ready && <p className="text-xs text-muted-foreground">{scopePolicy.notReadyText}</p>}
 
       {ready && (
         <>
           {loading && <p className="text-xs text-muted-foreground">Loading secrets...</p>}
 
           {!loading && rows.length === 0 && globalRows.length === 0 && (
-            <p className="text-xs text-muted-foreground">
-              {isGlobal
-                ? "No global secrets set."
-                : isEnvironment
-                  ? "No secrets set for this environment."
-                  : "No secrets set for this repo."}
-            </p>
+            <p className="text-xs text-muted-foreground">{scopePolicy.emptyStateText}</p>
           )}
 
           <div className="space-y-2">
@@ -449,8 +487,8 @@ export function SecretsEditor({
             ))}
           </div>
 
-          {/* Inherited global secrets (repo scope only) */}
-          {!isGlobal && globalRows.length > 0 && (
+          {/* Inherited global secrets (scopes that layer on top of global) */}
+          {globalRows.length > 0 && (
             <div className="mt-4">
               <p className="text-xs text-muted-foreground mb-2">Inherited from global scope</p>
               <div className="space-y-2">
@@ -474,7 +512,7 @@ export function SecretsEditor({
                       />
                       {overridden && (
                         <span className="text-xs text-muted-foreground">
-                          (overridden by {isEnvironment ? "environment" : "repo"})
+                          (overridden by {scopePolicy.overriddenByLabel})
                         </span>
                       )}
                     </div>

--- a/packages/web/src/components/session-right-sidebar.tsx
+++ b/packages/web/src/components/session-right-sidebar.tsx
@@ -92,6 +92,8 @@ export function SessionRightSidebarContent({
           repoName={sessionState.repoName}
           artifacts={artifacts}
           repositories={sessionState.repositories}
+          environmentId={sessionState.environmentId}
+          environmentName={sessionState.environmentName}
           warnings={warnings}
           parentSessionId={sessionState.parentSessionId}
           totalCost={sessionState.totalCost}

--- a/packages/web/src/components/settings/environment-form.test.tsx
+++ b/packages/web/src/components/settings/environment-form.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { MAX_TARGET_REPOSITORIES, type Environment } from "@open-inspect/shared";
+import { EnvironmentForm } from "./environment-form";
+
+expect.extend(matchers);
+
+afterEach(cleanup);
+
+const mocks = vi.hoisted(() => ({
+  reposValue: [] as Array<{
+    id: number;
+    fullName: string;
+    owner: string;
+    name: string;
+    description: string | null;
+    private: boolean;
+    defaultBranch: string;
+  }>,
+}));
+
+vi.mock("@/hooks/use-repos", () => ({
+  useRepos: () => ({ repos: mocks.reposValue, loading: false }),
+}));
+
+vi.mock("@/hooks/use-branches", () => ({
+  useBranches: () => ({ branches: [{ name: "main" }, { name: "develop" }], loading: false }),
+}));
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  // Radix Switch measures itself via ResizeObserver, which jsdom lacks.
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+});
+
+function repo(owner: string, name: string, id: number) {
+  return {
+    id,
+    fullName: `${owner}/${name}`,
+    owner,
+    name,
+    description: null,
+    private: false,
+    defaultBranch: "main",
+  };
+}
+
+function environment(
+  repositories: Array<{ repoOwner: string; repoName: string }>,
+  overrides: Partial<Environment> = {}
+): Environment {
+  return {
+    id: "env-1",
+    name: "full-stack",
+    description: null,
+    prebuildEnabled: false,
+    createdAt: 1,
+    updatedAt: 1,
+    repositories: repositories.map((entry, index) => ({
+      ...entry,
+      repoId: index + 1,
+      baseBranch: "main",
+    })),
+    ...overrides,
+  };
+}
+
+describe("EnvironmentForm", () => {
+  it("marks the first repository as primary and reordering changes the submitted order", async () => {
+    mocks.reposValue = [repo("acme", "backend", 1), repo("acme", "frontend", 2)];
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <EnvironmentForm
+        mode="edit"
+        initialValues={environment([
+          { repoOwner: "acme", repoName: "backend" },
+          { repoOwner: "acme", repoName: "frontend" },
+        ])}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+        submitting={false}
+      />
+    );
+
+    // The primary badge sits on the first ordered row.
+    const backendRow = screen.getByTitle("acme/backend").closest("div");
+    expect(backendRow).not.toBeNull();
+    expect(within(backendRow as HTMLElement).getByText("primary")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Move acme/frontend up" }));
+    await user.click(screen.getByRole("button", { name: /save environment/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repositories: [
+          { repoOwner: "acme", repoName: "frontend", baseBranch: "main" },
+          { repoOwner: "acme", repoName: "backend", baseBranch: "main" },
+        ],
+      })
+    );
+  });
+
+  it("disables further selection at the repository cap", async () => {
+    const selected = Array.from({ length: MAX_TARGET_REPOSITORIES }, (_, index) => ({
+      repoOwner: "acme",
+      repoName: `repo${index + 1}`,
+    }));
+    mocks.reposValue = [
+      ...selected.map((entry, index) => repo(entry.repoOwner, entry.repoName, index + 1)),
+      repo("acme", "overflow", 99),
+    ];
+    const user = userEvent.setup();
+    render(
+      <EnvironmentForm
+        mode="edit"
+        initialValues={environment(selected)}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+        submitting={false}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Repository selection" }));
+    expect(
+      screen.getByText(`${MAX_TARGET_REPOSITORIES}/${MAX_TARGET_REPOSITORIES}`)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: /acme\/overflow/i })).toBeDisabled();
+    // Already-selected entries stay toggleable.
+    expect(screen.getByRole("checkbox", { name: /acme\/repo1$/i })).toBeEnabled();
+  });
+
+  it("blocks selecting a repository whose name collides with a selected one", async () => {
+    mocks.reposValue = [repo("acme", "web", 1), repo("beta", "web", 2)];
+    const user = userEvent.setup();
+    render(
+      <EnvironmentForm
+        mode="edit"
+        initialValues={environment([{ repoOwner: "acme", repoName: "web" }])}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+        submitting={false}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Repository selection" }));
+    expect(screen.getByRole("checkbox", { name: /beta\/web/i })).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: /acme\/web/i })).toBeEnabled();
+  });
+
+  it("requires a name and at least one repository to submit", () => {
+    mocks.reposValue = [repo("acme", "backend", 1)];
+    render(
+      <EnvironmentForm mode="create" onSubmit={vi.fn()} onCancel={vi.fn()} submitting={false} />
+    );
+
+    expect(screen.getByRole("button", { name: /create environment/i })).toBeDisabled();
+  });
+});

--- a/packages/web/src/components/settings/environment-form.tsx
+++ b/packages/web/src/components/settings/environment-form.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  MAX_ENVIRONMENT_NAME_LENGTH,
+  MAX_ENVIRONMENT_DESCRIPTION_LENGTH,
+  type Environment,
+  type RepositoryInput,
+} from "@open-inspect/shared";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+import { Combobox } from "@/components/ui/combobox";
+import { BranchIcon, ChevronDownIcon, RepoIcon } from "@/components/ui/icons";
+import { useBranches } from "@/hooks/use-branches";
+import { useRepos, type Repo } from "@/hooks/use-repos";
+import {
+  RepositoryMultiSelect,
+  repositorySelectionKey,
+} from "@/components/repository-multi-select";
+import { supportsRepoImages } from "@/lib/sandbox-provider";
+
+export interface EnvironmentFormValues {
+  name: string;
+  description: string | null;
+  prebuildEnabled: boolean;
+  repositories: RepositoryInput[];
+}
+
+/**
+ * Create/edit form for an environment: name, description, the ordered
+ * repository list ([0] = primary) with a per-repository base branch, and the
+ * prebuild toggle. Repositories keep their selection order; rows can be
+ * reordered so any repository can become the primary (the sandbox/settings
+ * source).
+ */
+export function EnvironmentForm({
+  mode,
+  initialValues,
+  onSubmit,
+  onCancel,
+  submitting,
+}: {
+  mode: "create" | "edit";
+  initialValues?: Environment;
+  onSubmit: (values: EnvironmentFormValues) => void;
+  onCancel: () => void;
+  submitting: boolean;
+}) {
+  const { repos, loading: loadingRepos } = useRepos();
+  const prebuildsSupported = supportsRepoImages();
+
+  const [name, setName] = useState(initialValues?.name ?? "");
+  const [description, setDescription] = useState(initialValues?.description ?? "");
+  const [prebuildEnabled, setPrebuildEnabled] = useState(initialValues?.prebuildEnabled ?? false);
+  const [selectedKeys, setSelectedKeys] = useState<string[]>(() =>
+    (initialValues?.repositories ?? []).map((repository) =>
+      repositorySelectionKey(repository.repoOwner, repository.repoName)
+    )
+  );
+  const [branchByKey, setBranchByKey] = useState<Record<string, string>>(() =>
+    Object.fromEntries(
+      (initialValues?.repositories ?? []).map((repository) => [
+        repositorySelectionKey(repository.repoOwner, repository.repoName),
+        repository.baseBranch,
+      ])
+    )
+  );
+
+  const repoByKey = useMemo(() => {
+    const byKey = new Map<string, Repo>();
+    for (const repo of repos) {
+      byKey.set(repositorySelectionKey(repo.owner, repo.name), repo);
+    }
+    return byKey;
+  }, [repos]);
+
+  const handleSelectionChange = useCallback(
+    (next: string[]) => {
+      setSelectedKeys(next);
+      setBranchByKey((current) => {
+        const updated = { ...current };
+        for (const key of next) {
+          if (updated[key] === undefined) {
+            updated[key] = repoByKey.get(key)?.defaultBranch ?? "";
+          }
+        }
+        return updated;
+      });
+    },
+    [repoByKey]
+  );
+
+  const moveRepository = (index: number, delta: -1 | 1) => {
+    setSelectedKeys((current) => {
+      const target = index + delta;
+      if (target < 0 || target >= current.length) return current;
+      const next = [...current];
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+  };
+
+  const removeRepository = (key: string) => {
+    setSelectedKeys((current) => current.filter((entry) => entry !== key));
+  };
+
+  const canSubmit = name.trim().length > 0 && selectedKeys.length > 0 && !submitting;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    onSubmit({
+      name: name.trim(),
+      description: description.trim() ? description.trim() : null,
+      prebuildEnabled,
+      repositories: selectedKeys.map((key) => {
+        const [repoOwner = "", repoName = ""] = key.split("/");
+        const entry: RepositoryInput = { repoOwner, repoName };
+        const branch = branchByKey[key]?.trim();
+        if (branch) entry.baseBranch = branch;
+        return entry;
+      }),
+    });
+  };
+
+  const triggerLabel =
+    selectedKeys.length === 0
+      ? "Select repositories"
+      : selectedKeys.length === 1
+        ? selectedKeys[0]
+        : `${selectedKeys.length} repositories`;
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label
+          htmlFor="environment-name"
+          className="block text-sm font-medium text-foreground mb-1.5"
+        >
+          Name
+        </label>
+        <Input
+          id="environment-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="full-stack"
+          maxLength={MAX_ENVIRONMENT_NAME_LENGTH}
+          required
+        />
+      </div>
+
+      <div>
+        <label
+          htmlFor="environment-description"
+          className="block text-sm font-medium text-foreground mb-1.5"
+        >
+          Description
+        </label>
+        <Input
+          id="environment-description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Frontend + backend for the main app (optional)"
+          maxLength={MAX_ENVIRONMENT_DESCRIPTION_LENGTH}
+        />
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-foreground mb-1.5">Repositories</label>
+        <RepositoryMultiSelect
+          repos={repos}
+          loadingRepos={loadingRepos}
+          selected={selectedKeys}
+          onChange={handleSelectionChange}
+          disabled={submitting}
+          triggerLabel={triggerLabel}
+          triggerClassName="w-full"
+        />
+        <p className="text-xs text-muted-foreground mt-1 leading-normal">
+          Sessions clone every repository into one workspace. The first repository is the primary —
+          it provides the sandbox and editor settings.
+        </p>
+      </div>
+
+      {selectedKeys.length > 0 && (
+        <div className="space-y-2">
+          {selectedKeys.map((key, index) => (
+            <EnvironmentRepositoryRow
+              key={key}
+              repositoryKey={key}
+              isPrimary={index === 0}
+              branch={branchByKey[key] ?? ""}
+              onBranchChange={(branch) =>
+                setBranchByKey((current) => ({ ...current, [key]: branch }))
+              }
+              canMoveUp={index > 0}
+              canMoveDown={index < selectedKeys.length - 1}
+              onMoveUp={() => moveRepository(index, -1)}
+              onMoveDown={() => moveRepository(index, 1)}
+              onRemove={() => removeRepository(key)}
+              disabled={submitting}
+            />
+          ))}
+        </div>
+      )}
+
+      <div className="flex items-center gap-3">
+        {prebuildsSupported ? (
+          <>
+            <Switch
+              checked={prebuildEnabled}
+              onCheckedChange={setPrebuildEnabled}
+              disabled={submitting}
+              aria-label="Toggle prebuilt images"
+            />
+            <div>
+              <p className="text-sm font-medium text-foreground">Prebuild images</p>
+              <p className="text-xs text-muted-foreground">
+                Build an image with all repositories cloned and setup complete, so sessions start in
+                seconds. Saving with prebuilds enabled starts a build.
+              </p>
+            </div>
+          </>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            Prebuilt images are only available when <code>SANDBOX_PROVIDER=modal</code>,{" "}
+            <code>vercel</code>, or <code>opencomputer</code>.
+          </p>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button type="submit" disabled={!canSubmit}>
+          {submitting ? "Saving..." : mode === "create" ? "Create environment" : "Save environment"}
+        </Button>
+        <Button type="button" variant="ghost" onClick={onCancel} disabled={submitting}>
+          Cancel
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+/**
+ * One ordered repository row: identity, primary badge, base-branch picker,
+ * reorder and remove controls. A subcomponent so each row can call
+ * useBranches for its own repository.
+ */
+function EnvironmentRepositoryRow({
+  repositoryKey,
+  isPrimary,
+  branch,
+  onBranchChange,
+  canMoveUp,
+  canMoveDown,
+  onMoveUp,
+  onMoveDown,
+  onRemove,
+  disabled,
+}: {
+  repositoryKey: string;
+  isPrimary: boolean;
+  branch: string;
+  onBranchChange: (branch: string) => void;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onRemove: () => void;
+  disabled: boolean;
+}) {
+  const [repoOwner = "", repoName = ""] = repositoryKey.split("/");
+  const { branches, loading: loadingBranches } = useBranches(repoOwner, repoName);
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 border border-border-muted px-3 py-2">
+      <RepoIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1 truncate text-sm text-foreground" title={repositoryKey}>
+        {repositoryKey}
+      </span>
+      {isPrimary && (
+        <Badge variant="info" className="text-[10px]">
+          primary
+        </Badge>
+      )}
+      <Combobox
+        value={branch}
+        onChange={onBranchChange}
+        items={branches.map((b) => ({ value: b.name, label: b.name }))}
+        searchable
+        searchPlaceholder="Search branches..."
+        filterFn={(option, query) => option.label.toLowerCase().includes(query)}
+        dropdownWidth="w-56"
+        disabled={disabled || loadingBranches}
+        triggerClassName="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
+      >
+        <BranchIcon className="w-3.5 h-3.5" />
+        <span className="truncate max-w-[9rem]">
+          {loadingBranches ? "Loading..." : branch || "branch"}
+        </span>
+        <ChevronDownIcon className="w-3 h-3" />
+      </Combobox>
+      <div className="flex items-center gap-1">
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          onClick={onMoveUp}
+          disabled={disabled || !canMoveUp}
+          aria-label={`Move ${repositoryKey} up`}
+        >
+          ↑
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          onClick={onMoveDown}
+          disabled={disabled || !canMoveDown}
+          aria-label={`Move ${repositoryKey} down`}
+        >
+          ↓
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          onClick={onRemove}
+          disabled={disabled}
+          aria-label={`Remove ${repositoryKey}`}
+        >
+          Remove
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/environment-secrets-import.tsx
+++ b/packages/web/src/components/settings/environment-secrets-import.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import useSWR, { mutate } from "swr";
+import { toast } from "sonner";
+import type { EnvironmentRepository } from "@open-inspect/shared";
+import { Button } from "@/components/ui/button";
+import { Combobox } from "@/components/ui/combobox";
+import { RepoIcon, ChevronDownIcon } from "@/components/ui/icons";
+
+interface RepoSecretsResponse {
+  secrets: { key: string }[];
+}
+
+/**
+ * Per-key import of a repository's secrets into an environment (design §7.4).
+ * The source must be one of the environment's repositories (the control plane
+ * rejects other sources); values are copied server-side and never displayed.
+ * Imports are copies — they don't follow later rotations of the repo secret.
+ */
+export function EnvironmentSecretsImport({
+  environmentId,
+  repositories,
+  disabled = false,
+}: {
+  environmentId: string;
+  repositories: EnvironmentRepository[];
+  disabled?: boolean;
+}) {
+  const [sourceKey, setSourceKey] = useState("");
+  const [selectedSecretKeys, setSelectedSecretKeys] = useState<Set<string>>(new Set());
+  const [importing, setImporting] = useState(false);
+
+  const source = useMemo(
+    () =>
+      repositories.find(
+        (repository) => `${repository.repoOwner}/${repository.repoName}` === sourceKey
+      ) ?? null,
+    [repositories, sourceKey]
+  );
+
+  const { data, isLoading } = useSWR<RepoSecretsResponse>(
+    source ? `/api/repos/${source.repoOwner}/${source.repoName}/secrets` : null
+  );
+  const sourceSecretKeys = data?.secrets?.map((secret) => secret.key) ?? [];
+
+  const handleSourceChange = (value: string) => {
+    setSourceKey(value);
+    setSelectedSecretKeys(new Set());
+  };
+
+  const toggleSecretKey = (key: string) => {
+    setSelectedSecretKeys((current) => {
+      const next = new Set(current);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
+  const handleImport = async () => {
+    if (!source || selectedSecretKeys.size === 0) return;
+    setImporting(true);
+
+    try {
+      const response = await fetch(`/api/environments/${environmentId}/secrets/import`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          repoOwner: source.repoOwner,
+          repoName: source.repoName,
+          keys: [...selectedSecretKeys],
+        }),
+      });
+      const result = await response.json();
+
+      if (!response.ok) {
+        toast.error(result?.error || "Failed to import secrets");
+        return;
+      }
+
+      const count = Array.isArray(result?.keys) ? result.keys.length : selectedSecretKeys.size;
+      toast.success(`Imported ${count} secret${count === 1 ? "" : "s"}`);
+      setSelectedSecretKeys(new Set());
+      mutate(`/api/environments/${environmentId}/secrets`);
+    } catch {
+      toast.error("Failed to import secrets");
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  return (
+    <div className="mt-4 rounded-md border border-border bg-background p-4">
+      <h3 className="text-sm font-semibold text-foreground">Import from a repository</h3>
+      <p className="text-xs text-muted-foreground mb-3">
+        Copy secrets from one of this environment&apos;s repositories. Values are copied server-side
+        and never shown; later changes to the repository secret do not carry over.
+      </p>
+
+      <Combobox
+        value={sourceKey}
+        onChange={handleSourceChange}
+        items={repositories.map((repository) => ({
+          value: `${repository.repoOwner}/${repository.repoName}`,
+          label: `${repository.repoOwner}/${repository.repoName}`,
+        }))}
+        dropdownWidth="w-72"
+        disabled={disabled || importing}
+        triggerClassName="flex items-center gap-1.5 px-3 py-2 text-sm border border-border bg-input text-foreground hover:border-foreground/20 transition"
+      >
+        <RepoIcon className="w-4 h-4 text-muted-foreground" />
+        <span className="truncate flex-1 text-left">{sourceKey || "Select source repository"}</span>
+        <ChevronDownIcon className="w-3 h-3 text-muted-foreground" />
+      </Combobox>
+
+      {source && (
+        <div className="mt-3">
+          {isLoading && <p className="text-xs text-muted-foreground">Loading secret keys...</p>}
+          {!isLoading && sourceSecretKeys.length === 0 && (
+            <p className="text-xs text-muted-foreground">No secrets set on {sourceKey}.</p>
+          )}
+          {sourceSecretKeys.length > 0 && (
+            <>
+              <div className="space-y-1">
+                {sourceSecretKeys.map((key) => (
+                  <label key={key} className="flex items-center gap-2 text-sm text-foreground">
+                    <input
+                      type="checkbox"
+                      checked={selectedSecretKeys.has(key)}
+                      onChange={() => toggleSecretKey(key)}
+                      disabled={disabled || importing}
+                      className="h-4 w-4 rounded border-border accent-accent"
+                    />
+                    <span className="font-mono text-xs">{key}</span>
+                  </label>
+                ))}
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="xs"
+                className="mt-3"
+                onClick={handleImport}
+                disabled={disabled || importing || selectedSecretKeys.size === 0}
+              >
+                {importing
+                  ? "Importing..."
+                  : `Import ${selectedSecretKeys.size || ""} selected`.trim()}
+              </Button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/environments-settings.tsx
+++ b/packages/web/src/components/settings/environments-settings.tsx
@@ -1,0 +1,477 @@
+"use client";
+
+import { useState } from "react";
+import useSWR, { mutate } from "swr";
+import { toast } from "sonner";
+import type { Environment } from "@open-inspect/shared";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { ErrorBanner } from "@/components/ui/error-banner";
+import { RefreshIcon } from "@/components/ui/icons";
+import { formatRelativeTime } from "@/lib/time";
+import { formatSessionRepositoriesLabel } from "@/lib/repo-label";
+import { supportsRepoImages } from "@/lib/sandbox-provider";
+import { useEnvironments, ENVIRONMENTS_KEY } from "@/hooks/use-environments";
+import { EnvironmentForm, type EnvironmentFormValues } from "./environment-form";
+import { EnvironmentSecretsImport } from "./environment-secrets-import";
+import { SecretsEditor } from "@/components/secrets-editor";
+
+/** Latest environment image row as returned by /api/environments/[id]/images. */
+interface EnvironmentImageRow {
+  id: string;
+  status: "building" | "ready" | "failed";
+  repository_shas: string;
+  build_duration_seconds: number | null;
+  error_message: string | null;
+  created_at: number;
+}
+
+type View =
+  | { mode: "list" }
+  | { mode: "create" }
+  | { mode: "edit"; environmentId: string; tab: "configuration" | "secrets" };
+
+export function EnvironmentsSettings() {
+  const { environments, loading } = useEnvironments();
+  const [view, setView] = useState<View>({ mode: "list" });
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [togglingIds, setTogglingIds] = useState<Set<string>>(new Set());
+  const [triggeringIds, setTriggeringIds] = useState<Set<string>>(new Set());
+
+  const prebuildsSupported = supportsRepoImages();
+
+  const handleCreate = async (values: EnvironmentFormValues) => {
+    setSubmitting(true);
+    setError("");
+    try {
+      const response = await fetch("/api/environments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(values),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        setError(data?.error || "Failed to create environment");
+        return;
+      }
+      mutate(ENVIRONMENTS_KEY);
+      toast.success(`Created ${values.name}`);
+      const createdId = data?.environment?.id;
+      setView(
+        createdId ? { mode: "edit", environmentId: createdId, tab: "secrets" } : { mode: "list" }
+      );
+    } catch {
+      setError("Failed to create environment");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleUpdate = async (environmentId: string, values: EnvironmentFormValues) => {
+    setSubmitting(true);
+    setError("");
+    try {
+      const response = await fetch(`/api/environments/${environmentId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(values),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        setError(data?.error || "Failed to update environment");
+        return;
+      }
+      mutate(ENVIRONMENTS_KEY);
+      toast.success(`Saved ${values.name}`);
+      setView({ mode: "list" });
+    } catch {
+      setError("Failed to update environment");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleDelete = async (environment: Environment) => {
+    setError("");
+    try {
+      const response = await fetch(`/api/environments/${environment.id}`, { method: "DELETE" });
+      if (!response.ok) {
+        const data = await response.json();
+        setError(data?.error || "Failed to delete environment");
+        return;
+      }
+      mutate(ENVIRONMENTS_KEY);
+      toast.success(`Deleted ${environment.name}`);
+    } catch {
+      setError("Failed to delete environment");
+    }
+  };
+
+  const handlePrebuildToggle = async (environment: Environment, enabled: boolean) => {
+    setTogglingIds((prev) => new Set(prev).add(environment.id));
+    setError("");
+    try {
+      const response = await fetch(`/api/environments/${environment.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prebuildEnabled: enabled }),
+      });
+      if (!response.ok) {
+        const data = await response.json();
+        setError(data?.error || "Failed to toggle prebuilds");
+      } else {
+        mutate(ENVIRONMENTS_KEY);
+        mutate(environmentImagesKey(environment.id));
+      }
+    } catch {
+      setError("Failed to toggle prebuilds");
+    } finally {
+      setTogglingIds((prev) => {
+        const next = new Set(prev);
+        next.delete(environment.id);
+        return next;
+      });
+    }
+  };
+
+  const handleRebuild = async (environment: Environment) => {
+    setTriggeringIds((prev) => new Set(prev).add(environment.id));
+    setError("");
+    try {
+      const response = await fetch(`/api/environments/${environment.id}/images/trigger`, {
+        method: "POST",
+      });
+      if (!response.ok) {
+        const data = await response.json();
+        setError(data?.error || "Failed to trigger build");
+      } else {
+        mutate(environmentImagesKey(environment.id));
+      }
+    } catch {
+      setError("Failed to trigger build");
+    } finally {
+      setTriggeringIds((prev) => {
+        const next = new Set(prev);
+        next.delete(environment.id);
+        return next;
+      });
+    }
+  };
+
+  if (view.mode === "create") {
+    return (
+      <div>
+        <h2 className="text-xl font-semibold text-foreground mb-1">New Environment</h2>
+        <p className="text-sm text-muted-foreground mb-6">
+          A named set of repositories that launch together in one workspace.
+        </p>
+        {error && <ErrorBanner className="mb-4">{error}</ErrorBanner>}
+        <EnvironmentForm
+          mode="create"
+          onSubmit={handleCreate}
+          onCancel={() => setView({ mode: "list" })}
+          submitting={submitting}
+        />
+      </div>
+    );
+  }
+
+  if (view.mode === "edit") {
+    const environment = environments.find((entry) => entry.id === view.environmentId);
+    if (!environment) {
+      return (
+        <div>
+          {loading ? (
+            <p className="text-sm text-muted-foreground">Loading environment...</p>
+          ) : (
+            <>
+              <p className="text-sm text-muted-foreground mb-3">Environment not found.</p>
+              <Button variant="outline" size="xs" onClick={() => setView({ mode: "list" })}>
+                Back to environments
+              </Button>
+            </>
+          )}
+        </div>
+      );
+    }
+
+    return (
+      <div>
+        <h2 className="text-xl font-semibold text-foreground mb-1">{environment.name}</h2>
+        <p className="text-sm text-muted-foreground mb-4">
+          {environment.description || "Edit this environment."}
+        </p>
+
+        <div className="flex items-center gap-1 border-b border-border-muted mb-4">
+          {(["configuration", "secrets"] as const).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setView({ ...view, tab })}
+              className={`px-3 py-2 text-sm capitalize transition border-b-2 -mb-px ${
+                view.tab === tab
+                  ? "border-accent text-foreground font-medium"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+
+        {error && <ErrorBanner className="mb-4">{error}</ErrorBanner>}
+
+        {view.tab === "configuration" ? (
+          <EnvironmentForm
+            mode="edit"
+            initialValues={environment}
+            onSubmit={(values) => handleUpdate(environment.id, values)}
+            onCancel={() => setView({ mode: "list" })}
+            submitting={submitting}
+          />
+        ) : (
+          <div>
+            <p className="text-xs text-muted-foreground">
+              Sessions launched from this environment get global secrets plus these — repository
+              secrets do not carry over automatically. Changing secrets invalidates prebuilt images
+              and triggers a rebuild.
+            </p>
+            <SecretsEditor scope="environment" environmentId={environment.id} />
+            <EnvironmentSecretsImport
+              environmentId={environment.id}
+              repositories={environment.repositories}
+            />
+            <div className="mt-4">
+              <Button variant="outline" size="xs" onClick={() => setView({ mode: "list" })}>
+                Back to environments
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <TooltipProvider>
+      <div>
+        <div className="flex items-center justify-between mb-1">
+          <h2 className="text-xl font-semibold text-foreground">Environments</h2>
+          <Button size="xs" onClick={() => setView({ mode: "create" })}>
+            New environment
+          </Button>
+        </div>
+        <p className="text-sm text-muted-foreground mb-6">
+          Named repository sets that launch together in one workspace, with their own secrets
+          {prebuildsSupported ? " and prebuilt images" : ""}.
+        </p>
+
+        {error && <ErrorBanner className="mb-4">{error}</ErrorBanner>}
+
+        {loading && <p className="text-sm text-muted-foreground">Loading environments...</p>}
+
+        {!loading && environments.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            No environments yet. Create one to launch multi-repository sessions with prebuilt
+            images.
+          </p>
+        )}
+
+        <div className="space-y-2">
+          {environments.map((environment) => {
+            const isToggling = togglingIds.has(environment.id);
+            const isTriggering = triggeringIds.has(environment.id);
+
+            return (
+              <div key={environment.id} className="border border-border px-4 py-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium text-foreground truncate">
+                        {environment.name}
+                      </span>
+                      <span className="text-xs text-muted-foreground truncate">
+                        {formatSessionRepositoriesLabel(null, null, environment.repositories)}
+                      </span>
+                    </div>
+                    {environment.description && (
+                      <p className="text-xs text-muted-foreground truncate">
+                        {environment.description}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    {prebuildsSupported && (
+                      <>
+                        <EnvironmentImageStatus environment={environment} />
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <span>
+                              <Switch
+                                checked={environment.prebuildEnabled}
+                                onCheckedChange={(checked) =>
+                                  handlePrebuildToggle(environment, checked)
+                                }
+                                disabled={isToggling}
+                                aria-label={`Toggle prebuilt images for ${environment.name}`}
+                              />
+                            </span>
+                          </TooltipTrigger>
+                          <TooltipContent>Prebuild images</TooltipContent>
+                        </Tooltip>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleRebuild(environment)}
+                          disabled={!environment.prebuildEnabled || isTriggering}
+                          title="Rebuild image"
+                        >
+                          <RefreshIcon
+                            className={`w-4 h-4 ${isTriggering ? "animate-spin" : ""}`}
+                          />
+                        </Button>
+                      </>
+                    )}
+                    <Button
+                      variant="ghost"
+                      size="xs"
+                      onClick={() =>
+                        setView({
+                          mode: "edit",
+                          environmentId: environment.id,
+                          tab: "configuration",
+                        })
+                      }
+                    >
+                      Edit
+                    </Button>
+                    {confirmDeleteId === environment.id ? (
+                      <div className="flex items-center gap-1">
+                        <Button
+                          variant="destructive"
+                          size="xs"
+                          onClick={() => {
+                            handleDelete(environment);
+                            setConfirmDeleteId(null);
+                          }}
+                        >
+                          Confirm
+                        </Button>
+                        <Button variant="ghost" size="xs" onClick={() => setConfirmDeleteId(null)}>
+                          Cancel
+                        </Button>
+                      </div>
+                    ) : (
+                      <Button
+                        variant="destructive"
+                        size="xs"
+                        onClick={() => setConfirmDeleteId(environment.id)}
+                      >
+                        Delete
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+}
+
+function environmentImagesKey(environmentId: string): string {
+  return `/api/environments/${environmentId}/images`;
+}
+
+/** The primary repository's baseSha out of the build's provenance document. */
+function parsePrimaryBuildSha(repositoryShas: string): string | null {
+  try {
+    const parsed: unknown = JSON.parse(repositoryShas);
+    if (!Array.isArray(parsed)) return null;
+    const primary: unknown = parsed[0];
+    if (primary && typeof primary === "object" && "baseSha" in primary) {
+      const sha = (primary as { baseSha?: unknown }).baseSha;
+      return typeof sha === "string" ? sha : null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Latest build status for an environment (mirrors the repo ImageStatus
+ * rendering). Fetches only while prebuilds are enabled — disabled
+ * environments show a static label.
+ */
+function EnvironmentImageStatus({ environment }: { environment: Environment }) {
+  const { data } = useSWR<{ images: EnvironmentImageRow[] }>(
+    environment.prebuildEnabled ? environmentImagesKey(environment.id) : null
+  );
+
+  if (!environment.prebuildEnabled) {
+    return <span className="text-xs text-muted-foreground">Disabled</span>;
+  }
+
+  const image = data?.images?.[0];
+  if (!image) {
+    return <span className="text-xs text-muted-foreground">No image</span>;
+  }
+
+  if (image.status === "ready") {
+    const sha = parsePrimaryBuildSha(image.repository_shas)?.slice(0, 7) ?? "";
+    const duration = image.build_duration_seconds
+      ? `${Math.round(image.build_duration_seconds)}s`
+      : "";
+    const details = [sha, duration].filter(Boolean).join(" · ");
+
+    return (
+      <div className="text-right">
+        <div className="flex items-center gap-1.5">
+          <span className="w-2 h-2 rounded-full bg-success flex-shrink-0" />
+          <span className="text-xs text-foreground">
+            Ready {formatRelativeTime(image.created_at)}
+          </span>
+        </div>
+        {details && <span className="text-xs text-muted-foreground">{details}</span>}
+      </div>
+    );
+  }
+
+  if (image.status === "building") {
+    return (
+      <div className="flex items-center gap-1.5">
+        <span className="w-2 h-2 rounded-full bg-warning animate-pulse flex-shrink-0" />
+        <span className="text-xs text-foreground">
+          Building... {formatRelativeTime(image.created_at)}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-right">
+      <div className="flex items-center gap-1.5">
+        <span className="w-2 h-2 rounded-full bg-destructive flex-shrink-0" />
+        <span className="text-xs text-foreground">Failed</span>
+      </div>
+      {image.error_message && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="text-xs text-muted-foreground truncate max-w-[200px] block cursor-help">
+              {image.error_message}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-md overflow-visible whitespace-pre-wrap break-words">
+            {image.error_message}
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/environments-settings.tsx
+++ b/packages/web/src/components/settings/environments-settings.tsx
@@ -9,12 +9,12 @@ import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { RefreshIcon } from "@/components/ui/icons";
-import { formatRelativeTime } from "@/lib/time";
 import { formatSessionRepositoriesLabel } from "@/lib/repo-label";
 import { supportsRepoImages } from "@/lib/sandbox-provider";
 import { useEnvironments, ENVIRONMENTS_KEY } from "@/hooks/use-environments";
 import { EnvironmentForm, type EnvironmentFormValues } from "./environment-form";
 import { EnvironmentSecretsImport } from "./environment-secrets-import";
+import { ImageBuildStatus, formatReadyDetails } from "./image-build-status";
 import { SecretsEditor } from "@/components/secrets-editor";
 
 /** Latest environment image row as returned by /api/environments/[id]/images. */
@@ -57,7 +57,9 @@ export function EnvironmentsSettings() {
         setError(data?.error || "Failed to create environment");
         return;
       }
-      mutate(ENVIRONMENTS_KEY);
+      // Await the revalidation: the edit view resolves the environment from
+      // the SWR cache, so switching before it refreshes flashes "not found".
+      await mutate(ENVIRONMENTS_KEY);
       toast.success(`Created ${values.name}`);
       const createdId = data?.environment?.id;
       setView(
@@ -405,73 +407,31 @@ function parsePrimaryBuildSha(repositoryShas: string): string | null {
 }
 
 /**
- * Latest build status for an environment (mirrors the repo ImageStatus
- * rendering). Fetches only while prebuilds are enabled — disabled
- * environments show a static label.
+ * Latest build status for an environment. Fetches only while prebuilds are
+ * enabled — disabled environments show the static label. Presentation is the
+ * shared ImageBuildStatus.
  */
 function EnvironmentImageStatus({ environment }: { environment: Environment }) {
   const { data } = useSWR<{ images: EnvironmentImageRow[] }>(
     environment.prebuildEnabled ? environmentImagesKey(environment.id) : null
   );
 
-  if (!environment.prebuildEnabled) {
-    return <span className="text-xs text-muted-foreground">Disabled</span>;
-  }
-
-  const image = data?.images?.[0];
-  if (!image) {
-    return <span className="text-xs text-muted-foreground">No image</span>;
-  }
-
-  if (image.status === "ready") {
-    const sha = parsePrimaryBuildSha(image.repository_shas)?.slice(0, 7) ?? "";
-    const duration = image.build_duration_seconds
-      ? `${Math.round(image.build_duration_seconds)}s`
-      : "";
-    const details = [sha, duration].filter(Boolean).join(" · ");
-
-    return (
-      <div className="text-right">
-        <div className="flex items-center gap-1.5">
-          <span className="w-2 h-2 rounded-full bg-success flex-shrink-0" />
-          <span className="text-xs text-foreground">
-            Ready {formatRelativeTime(image.created_at)}
-          </span>
-        </div>
-        {details && <span className="text-xs text-muted-foreground">{details}</span>}
-      </div>
-    );
-  }
-
-  if (image.status === "building") {
-    return (
-      <div className="flex items-center gap-1.5">
-        <span className="w-2 h-2 rounded-full bg-warning animate-pulse flex-shrink-0" />
-        <span className="text-xs text-foreground">
-          Building... {formatRelativeTime(image.created_at)}
-        </span>
-      </div>
-    );
-  }
+  const image = environment.prebuildEnabled ? data?.images?.[0] : undefined;
 
   return (
-    <div className="text-right">
-      <div className="flex items-center gap-1.5">
-        <span className="w-2 h-2 rounded-full bg-destructive flex-shrink-0" />
-        <span className="text-xs text-foreground">Failed</span>
-      </div>
-      {image.error_message && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="text-xs text-muted-foreground truncate max-w-[200px] block cursor-help">
-              {image.error_message}
-            </span>
-          </TooltipTrigger>
-          <TooltipContent className="max-w-md overflow-visible whitespace-pre-wrap break-words">
-            {image.error_message}
-          </TooltipContent>
-        </Tooltip>
-      )}
-    </div>
+    <ImageBuildStatus
+      isEnabled={environment.prebuildEnabled}
+      image={
+        image && {
+          status: image.status,
+          createdAt: image.created_at,
+          readyDetails: formatReadyDetails(
+            parsePrimaryBuildSha(image.repository_shas),
+            image.build_duration_seconds
+          ),
+          errorMessage: image.error_message,
+        }
+      }
+    />
   );
 }

--- a/packages/web/src/components/settings/image-build-status.tsx
+++ b/packages/web/src/components/settings/image-build-status.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { formatRelativeTime } from "@/lib/time";
+
+/** Presentation-ready view of one prebuilt image's latest build. */
+export interface ImageBuildStatusView {
+  status: "building" | "ready" | "failed";
+  createdAt: number;
+  /** Extra line under a ready status, e.g. "abc1234 · 45s". */
+  readyDetails?: string;
+  errorMessage?: string | null;
+}
+
+/**
+ * Shared build-status rendering for prebuilt images (repo images and
+ * environment images): status dot, relative time, ready details, and the
+ * failed-error tooltip. Callers map their row shape to ImageBuildStatusView.
+ * Must render inside a TooltipProvider.
+ */
+export function ImageBuildStatus({
+  image,
+  isEnabled,
+}: {
+  image: ImageBuildStatusView | undefined;
+  isEnabled: boolean;
+}) {
+  if (!isEnabled) {
+    return <span className="text-xs text-muted-foreground">Disabled</span>;
+  }
+
+  if (!image) {
+    return <span className="text-xs text-muted-foreground">No image</span>;
+  }
+
+  if (image.status === "ready") {
+    return (
+      <div className="text-right">
+        <div className="flex items-center gap-1.5">
+          <span className="w-2 h-2 rounded-full bg-success flex-shrink-0" />
+          <span className="text-xs text-foreground">
+            Ready {formatRelativeTime(image.createdAt)}
+          </span>
+        </div>
+        {image.readyDetails && (
+          <span className="text-xs text-muted-foreground">{image.readyDetails}</span>
+        )}
+      </div>
+    );
+  }
+
+  if (image.status === "building") {
+    return (
+      <div className="flex items-center gap-1.5">
+        <span className="w-2 h-2 rounded-full bg-warning animate-pulse flex-shrink-0" />
+        <span className="text-xs text-foreground">
+          Building... {formatRelativeTime(image.createdAt)}
+        </span>
+      </div>
+    );
+  }
+
+  if (image.status === "failed") {
+    return (
+      <div className="text-right">
+        <div className="flex items-center gap-1.5">
+          <span className="w-2 h-2 rounded-full bg-destructive flex-shrink-0" />
+          <span className="text-xs text-foreground">Failed</span>
+        </div>
+        {image.errorMessage && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="text-xs text-muted-foreground truncate max-w-[200px] block cursor-help">
+                {image.errorMessage}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-md overflow-visible whitespace-pre-wrap break-words">
+              {image.errorMessage}
+            </TooltipContent>
+          </Tooltip>
+        )}
+      </div>
+    );
+  }
+
+  return null;
+}
+
+/** Formats the ready-details line shared by both image families. */
+export function formatReadyDetails(
+  buildSha: string | null | undefined,
+  buildDurationSeconds: number | null | undefined
+): string {
+  const sha = buildSha ? buildSha.slice(0, 7) : "";
+  const duration = buildDurationSeconds ? `${Math.round(buildDurationSeconds)}s` : "";
+  return [sha, duration].filter(Boolean).join(" · ");
+}

--- a/packages/web/src/components/settings/images-settings.tsx
+++ b/packages/web/src/components/settings/images-settings.tsx
@@ -5,11 +5,11 @@ import useSWR, { mutate } from "swr";
 import { useRepos } from "@/hooks/use-repos";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { RefreshIcon } from "@/components/ui/icons";
-import { formatRelativeTime } from "@/lib/time";
 import { supportsRepoImages } from "@/lib/sandbox-provider";
+import { ImageBuildStatus, formatReadyDetails } from "./image-build-status";
 
 interface RepoImage {
   repo_owner: string;
@@ -165,7 +165,20 @@ export function ImagesSettings() {
                 </div>
 
                 <div className="flex items-center gap-3 flex-shrink-0 ml-4">
-                  <ImageStatus image={image} isEnabled={isEnabled} />
+                  <ImageBuildStatus
+                    isEnabled={isEnabled}
+                    image={
+                      image && {
+                        status: image.status,
+                        createdAt: image.created_at,
+                        readyDetails: formatReadyDetails(
+                          image.base_sha,
+                          image.build_duration_seconds
+                        ),
+                        errorMessage: image.error_message,
+                      }
+                    }
+                  />
                   <Button
                     variant="ghost"
                     size="icon"
@@ -189,70 +202,4 @@ export function ImagesSettings() {
       </div>
     </TooltipProvider>
   );
-}
-
-function ImageStatus({ image, isEnabled }: { image: RepoImage | undefined; isEnabled: boolean }) {
-  if (!isEnabled) {
-    return <span className="text-xs text-muted-foreground">Disabled</span>;
-  }
-
-  if (!image) {
-    return <span className="text-xs text-muted-foreground">No image</span>;
-  }
-
-  if (image.status === "ready") {
-    const sha = image.base_sha ? image.base_sha.slice(0, 7) : "";
-    const duration = image.build_duration_seconds
-      ? `${Math.round(image.build_duration_seconds)}s`
-      : "";
-    const details = [sha, duration].filter(Boolean).join(" · ");
-
-    return (
-      <div className="text-right">
-        <div className="flex items-center gap-1.5">
-          <span className="w-2 h-2 rounded-full bg-success flex-shrink-0" />
-          <span className="text-xs text-foreground">
-            Ready {formatRelativeTime(image.created_at)}
-          </span>
-        </div>
-        {details && <span className="text-xs text-muted-foreground">{details}</span>}
-      </div>
-    );
-  }
-
-  if (image.status === "building") {
-    return (
-      <div className="flex items-center gap-1.5">
-        <span className="w-2 h-2 rounded-full bg-warning animate-pulse flex-shrink-0" />
-        <span className="text-xs text-foreground">
-          Building... {formatRelativeTime(image.created_at)}
-        </span>
-      </div>
-    );
-  }
-
-  if (image.status === "failed") {
-    return (
-      <div className="text-right">
-        <div className="flex items-center gap-1.5">
-          <span className="w-2 h-2 rounded-full bg-destructive flex-shrink-0" />
-          <span className="text-xs text-foreground">Failed</span>
-        </div>
-        {image.error_message && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span className="text-xs text-muted-foreground truncate max-w-[200px] block cursor-help">
-                {image.error_message}
-              </span>
-            </TooltipTrigger>
-            <TooltipContent className="max-w-md overflow-visible whitespace-pre-wrap break-words">
-              {image.error_message}
-            </TooltipContent>
-          </Tooltip>
-        )}
-      </div>
-    );
-  }
-
-  return null;
 }

--- a/packages/web/src/components/settings/settings-nav.tsx
+++ b/packages/web/src/components/settings/settings-nav.tsx
@@ -5,6 +5,7 @@ import {
   KeyIcon,
   ModelIcon,
   BoxIcon,
+  FolderIcon,
   KeyboardIcon,
   DataControlsIcon,
   IntegrationsIcon,
@@ -19,6 +20,11 @@ const NAV_ITEMS = [
     id: "secrets",
     label: "Secrets",
     icon: KeyIcon,
+  },
+  {
+    id: "environments",
+    label: "Environments",
+    icon: FolderIcon,
   },
   {
     id: "models",

--- a/packages/web/src/components/sidebar/metadata-section.test.tsx
+++ b/packages/web/src/components/sidebar/metadata-section.test.tsx
@@ -150,4 +150,50 @@ describe("MetadataSection", () => {
 
     expect(screen.getByText("acme/api: Secret key collision on API_KEY")).toBeInTheDocument();
   });
+
+  it("renders the environment name for environment-launched sessions", () => {
+    render(
+      <MetadataSection
+        createdAt={Date.now()}
+        baseBranch="main"
+        repoOwner="acme"
+        repoName="web"
+        environmentId="env-1"
+        environmentName="full-stack"
+      />
+    );
+
+    expect(screen.getByText("full-stack")).toBeInTheDocument();
+    expect(screen.queryByText("Environment deleted")).not.toBeInTheDocument();
+  });
+
+  it("renders the deleted state when the environment name resolves null", () => {
+    render(
+      <MetadataSection
+        createdAt={Date.now()}
+        baseBranch="main"
+        repoOwner="acme"
+        repoName="web"
+        environmentId="env-1"
+        environmentName={null}
+      />
+    );
+
+    expect(screen.getByText("Environment deleted")).toBeInTheDocument();
+  });
+
+  it("renders no environment row for repo-launched sessions", () => {
+    render(
+      <MetadataSection
+        createdAt={Date.now()}
+        baseBranch="main"
+        repoOwner="acme"
+        repoName="web"
+        environmentId={null}
+        environmentName={null}
+      />
+    );
+
+    expect(screen.queryByText("Environment deleted")).not.toBeInTheDocument();
+  });
 });

--- a/packages/web/src/components/sidebar/metadata-section.tsx
+++ b/packages/web/src/components/sidebar/metadata-section.tsx
@@ -16,6 +16,7 @@ import {
   GitPrIcon,
   BranchIcon,
   RepoIcon,
+  FolderIcon,
   CopyIcon,
   CheckIcon,
   LinkIcon,
@@ -37,6 +38,10 @@ interface MetadataSectionProps {
   /** Ordered member list ([0] = primary). Multi-member sessions render a
    *  per-repo list instead of the scalar repo tag. */
   repositories?: SessionRepositoryState[];
+  /** Environment provenance (design §7.6): the name resolves live, so a
+   *  non-null id with a null name means the environment was deleted. */
+  environmentId?: string | null;
+  environmentName?: string | null;
   /** Non-fatal boot/runtime warnings surfaced to the user. */
   warnings?: WarningEvent[];
   parentSessionId?: string | null;
@@ -72,6 +77,8 @@ export function MetadataSection({
   repoName,
   artifacts = [],
   repositories,
+  environmentId,
+  environmentName,
   warnings = [],
   parentSessionId,
   totalCost,
@@ -135,6 +142,20 @@ export function MetadataSection({
       {typeof totalCost === "number" && totalCost > 0 && (
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <span>Session cost: {formatSessionCost(totalCost)}</span>
+        </div>
+      )}
+
+      {/* Environment provenance */}
+      {environmentId && (
+        <div className="flex items-center gap-2 text-sm">
+          <FolderIcon className="w-4 h-4 text-muted-foreground" />
+          {environmentName ? (
+            <span className="text-foreground truncate max-w-[180px]" title={environmentName}>
+              {environmentName}
+            </span>
+          ) : (
+            <span className="text-muted-foreground">Environment deleted</span>
+          )}
         </div>
       )}
 

--- a/packages/web/src/hooks/use-environments.ts
+++ b/packages/web/src/hooks/use-environments.ts
@@ -1,0 +1,16 @@
+import useSWR from "swr";
+import { useSession } from "next-auth/react";
+import type { Environment, ListEnvironmentsResponse } from "@open-inspect/shared";
+
+export const ENVIRONMENTS_KEY = "/api/environments";
+
+export function useEnvironments(): { environments: Environment[]; loading: boolean } {
+  const { data: session } = useSession();
+
+  const { data, isLoading } = useSWR<ListEnvironmentsResponse>(session ? ENVIRONMENTS_KEY : null);
+
+  return {
+    environments: data?.environments ?? [],
+    loading: isLoading,
+  };
+}

--- a/packages/web/src/lib/session-target.test.ts
+++ b/packages/web/src/lib/session-target.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  type SessionTarget,
+  MULTIPLE_REPOSITORIES_OPTION_VALUE,
+  NO_REPOSITORY_OPTION_VALUE,
+  buildSessionTargetRequestFields,
+  environmentOptionValue,
+  getTargetConfigKey,
+  getTargetSelectValue,
+  isSessionTargetLaunchable,
+  parseTargetSelectValue,
+} from "./session-target";
+
+describe("buildSessionTargetRequestFields", () => {
+  it("emits exactly one target mode per kind (createSessionRequestSchema exclusivity)", () => {
+    const branch = "develop";
+
+    const none = buildSessionTargetRequestFields({ kind: "none" }, branch);
+    expect(none).toEqual({ repoOwner: null, repoName: null });
+
+    const repo = buildSessionTargetRequestFields(
+      { kind: "repo", repoFullName: "acme/backend" },
+      branch
+    );
+    expect(repo).toEqual({ repoOwner: "acme", repoName: "backend", branch: "develop" });
+    expect(repo).not.toHaveProperty("environmentId");
+    expect(repo).not.toHaveProperty("repositories");
+
+    const environment = buildSessionTargetRequestFields(
+      { kind: "environment", environmentId: "env-1" },
+      branch
+    );
+    expect(environment).toEqual({ environmentId: "env-1" });
+
+    const repos = buildSessionTargetRequestFields(
+      { kind: "repos", repoFullNames: ["acme/backend", "acme/frontend"] },
+      branch
+    );
+    expect(repos).toEqual({
+      repositories: [
+        { repoOwner: "acme", repoName: "backend" },
+        { repoOwner: "acme", repoName: "frontend" },
+      ],
+    });
+    expect(repos).not.toHaveProperty("branch");
+  });
+
+  it("omits branch for a repo target when no branch is selected", () => {
+    const fields = buildSessionTargetRequestFields(
+      { kind: "repo", repoFullName: "acme/backend" },
+      ""
+    );
+    expect(fields).toEqual({ repoOwner: "acme", repoName: "backend", branch: undefined });
+    expect(JSON.parse(JSON.stringify(fields))).not.toHaveProperty("branch");
+  });
+});
+
+describe("select-value round trip", () => {
+  it("round-trips each target kind through its option value", () => {
+    const targets: SessionTarget[] = [
+      { kind: "none" },
+      { kind: "repo", repoFullName: "acme/backend" },
+      { kind: "environment", environmentId: "env_abc123" },
+    ];
+    for (const target of targets) {
+      expect(parseTargetSelectValue(getTargetSelectValue(target), null)).toEqual(target);
+    }
+  });
+
+  it("maps the sentinels to their option values", () => {
+    expect(getTargetSelectValue({ kind: "none" })).toBe(NO_REPOSITORY_OPTION_VALUE);
+    expect(getTargetSelectValue({ kind: "repos", repoFullNames: ["a/b"] })).toBe(
+      MULTIPLE_REPOSITORIES_OPTION_VALUE
+    );
+    expect(getTargetSelectValue({ kind: "environment", environmentId: "env-1" })).toBe(
+      environmentOptionValue("env-1")
+    );
+  });
+
+  it("seeds the multi-repository mode from the previously selected repo", () => {
+    expect(
+      parseTargetSelectValue(MULTIPLE_REPOSITORIES_OPTION_VALUE, {
+        kind: "repo",
+        repoFullName: "Acme/Backend",
+      })
+    ).toEqual({ kind: "repos", repoFullNames: ["acme/backend"] });
+
+    expect(parseTargetSelectValue(MULTIPLE_REPOSITORIES_OPTION_VALUE, { kind: "none" })).toEqual({
+      kind: "repos",
+      repoFullNames: [],
+    });
+
+    const existing: SessionTarget = { kind: "repos", repoFullNames: ["a/b", "a/c"] };
+    expect(parseTargetSelectValue(MULTIPLE_REPOSITORIES_OPTION_VALUE, existing)).toBe(existing);
+  });
+});
+
+describe("getTargetConfigKey", () => {
+  it("distinguishes ad-hoc lists so edits invalidate a warmed session", () => {
+    const one = getTargetConfigKey({ kind: "repos", repoFullNames: ["a/b"] });
+    const two = getTargetConfigKey({ kind: "repos", repoFullNames: ["a/b", "a/c"] });
+    expect(one).not.toBe(two);
+  });
+});
+
+describe("isSessionTargetLaunchable", () => {
+  it("requires at least one repository in the ad-hoc mode", () => {
+    expect(isSessionTargetLaunchable(null)).toBe(false);
+    expect(isSessionTargetLaunchable({ kind: "repos", repoFullNames: [] })).toBe(false);
+    expect(isSessionTargetLaunchable({ kind: "repos", repoFullNames: ["a/b"] })).toBe(true);
+    expect(isSessionTargetLaunchable({ kind: "none" })).toBe(true);
+    expect(isSessionTargetLaunchable({ kind: "environment", environmentId: "env-1" })).toBe(true);
+  });
+});

--- a/packages/web/src/lib/session-target.ts
+++ b/packages/web/src/lib/session-target.ts
@@ -1,0 +1,116 @@
+/**
+ * The new-session picker's target selection: nothing, a single repository
+ * (today's behavior, branch dropdown included), a named environment, or an
+ * ad-hoc ordered repository list ([0] = primary). The three launchable forms
+ * map onto the mutually exclusive modes of createSessionRequestSchema —
+ * buildSessionTargetRequestFields emits exactly one mode's fields so the
+ * exclusivity refinement can never trip on picker-built requests.
+ */
+
+export type SessionTarget =
+  | { kind: "none" }
+  | { kind: "repo"; repoFullName: string }
+  | { kind: "environment"; environmentId: string }
+  | { kind: "repos"; repoFullNames: string[] };
+
+export const NO_REPOSITORY_OPTION_VALUE = "__no_repository__";
+export const MULTIPLE_REPOSITORIES_OPTION_VALUE = "__multiple_repositories__";
+const ENVIRONMENT_OPTION_PREFIX = "env:";
+
+export function parseRepoFullName(repoFullName: string): { owner: string; name: string } | null {
+  const [owner, name] = repoFullName.split("/");
+  return owner && name ? { owner, name } : null;
+}
+
+export function environmentOptionValue(environmentId: string): string {
+  return `${ENVIRONMENT_OPTION_PREFIX}${environmentId}`;
+}
+
+export function getTargetSelectValue(target: SessionTarget | null): string {
+  if (!target) return "";
+  switch (target.kind) {
+    case "none":
+      return NO_REPOSITORY_OPTION_VALUE;
+    case "repo":
+      return target.repoFullName;
+    case "environment":
+      return environmentOptionValue(target.environmentId);
+    case "repos":
+      return MULTIPLE_REPOSITORIES_OPTION_VALUE;
+  }
+}
+
+/**
+ * Parse a picker option value back into a target. The multi-repository
+ * sentinel seeds the list from the previous selection so switching modes
+ * keeps the current repo instead of starting empty.
+ */
+export function parseTargetSelectValue(
+  value: string,
+  previous: SessionTarget | null
+): SessionTarget {
+  if (value === NO_REPOSITORY_OPTION_VALUE) return { kind: "none" };
+  if (value === MULTIPLE_REPOSITORIES_OPTION_VALUE) {
+    if (previous?.kind === "repos") return previous;
+    return {
+      kind: "repos",
+      repoFullNames: previous?.kind === "repo" ? [previous.repoFullName.toLowerCase()] : [],
+    };
+  }
+  if (value.startsWith(ENVIRONMENT_OPTION_PREFIX)) {
+    return { kind: "environment", environmentId: value.slice(ENVIRONMENT_OPTION_PREFIX.length) };
+  }
+  return { kind: "repo", repoFullName: value };
+}
+
+/**
+ * Identity of a selection for the sandbox-warming config check — unlike
+ * getTargetSelectValue it distinguishes different ad-hoc lists, so editing
+ * the list invalidates a warmed session.
+ */
+export function getTargetConfigKey(target: SessionTarget | null): string {
+  if (!target) return "";
+  return target.kind === "repos"
+    ? `repos:${target.repoFullNames.join(",")}`
+    : getTargetSelectValue(target);
+}
+
+/** Whether the selection is complete enough to create a session from. */
+export function isSessionTargetLaunchable(target: SessionTarget | null): boolean {
+  if (!target) return false;
+  return target.kind !== "repos" || target.repoFullNames.length > 0;
+}
+
+/**
+ * The target's fields for the POST /api/sessions body: exactly one of the
+ * scalar repo form, `environmentId`, or `repositories` (design §5.5).
+ */
+export function buildSessionTargetRequestFields(
+  target: SessionTarget,
+  selectedBranch: string
+): Record<string, unknown> {
+  switch (target.kind) {
+    case "none":
+      return { repoOwner: null, repoName: null };
+    case "repo": {
+      const repository = parseRepoFullName(target.repoFullName);
+      if (!repository) return { repoOwner: null, repoName: null };
+      return {
+        repoOwner: repository.owner,
+        repoName: repository.name,
+        branch: selectedBranch || undefined,
+      };
+    }
+    case "environment":
+      return { environmentId: target.environmentId };
+    case "repos":
+      return {
+        repositories: target.repoFullNames
+          .map(parseRepoFullName)
+          .filter(
+            (repository): repository is { owner: string; name: string } => repository !== null
+          )
+          .map((repository) => ({ repoOwner: repository.owner, repoName: repository.name })),
+      };
+  }
+}


### PR DESCRIPTION
PR-12 of the multi-repo sessions plan (design §5.1, §5.2, §7.5 web row). The last web-facing feature PR of Phase 2: environments become creatable and launchable from the UI.

## Settings › Environments

New settings tab (`environments-settings.tsx`) with the full lifecycle:

- **List** — name, description, repository summary (`primary +N`), prebuild toggle, build status (ready/building/failed dot + last build duration + error tooltip, mirroring Settings › Images), **Rebuild now**, edit, and inline-confirm delete.
- **Create/edit form** (`environment-form.tsx`) — name, description, and the ordered repository list: a searchable multi-select popover (the automation form's selector pattern, extracted into a shared `repository-multi-select.tsx`) plus one row per selected repository with a per-repository base-branch picker, reorder controls (`repositories[0]` is the primary and gets the badge), and remove. Client-side guards mirror the shared schema: `MAX_TARGET_REPOSITORIES` cap and no duplicate repository *name* across owners (checkout paths are `/workspace/{repoName}`).
- **Secrets tab** — reuses `secrets-editor.tsx` via a new `environment` scope (`/api/environments/{id}/secrets`), with the inherited-global rendering intact, plus the per-key **import from a repository** flow (`environment-secrets-import.tsx`): pick a source repository, check keys, values copied server-side (PR-8's endpoint enforces that the source is a current repository of the environment and never returns values). Creating an environment lands on the Secrets tab so setup can finish in one pass.

Prebuild-specific UI (toggle, status, rebuild) is gated on `supportsRepoImages()`; the tab itself works on any provider.

## Unified new-session picker

`SessionTarget` grows from `none | repo` to `none | repo | environment | repos`, moved out of `page.tsx` into `lib/session-target.ts` together with the option-value round-trip and `buildSessionTargetRequestFields`, which emits **exactly one** of the three mutually exclusive create modes (scalar / `environmentId` / `repositories`) so the picker can never trip `createSessionRequestSchema`'s exclusivity refinement.

- The repo combobox becomes one unified searchable list: an **Environments** group (name + "N repositories · prebuilt/prebuild building/prebuilds on", driven by one `GET /api/environment-images` call) above the **Repositories** group. Instances with no environments see the flat repo list as today.
- **Ad-hoc multi-select**: a "Multiple repositories" option switches to the `repos` mode, seeded with the currently selected repo, edited through the same multi-select popover. Order is primary order.
- Secrets-disclosure copy per §7.4 under the prompt box: environment sessions use global + environment secrets; ad-hoc sessions use global + the selected repositories' secrets — with the "save this set as an environment" nudge (ad-hoc sets don't get prebuilds).
- The sandbox-warming config key now distinguishes environment ids and ad-hoc lists, so changing the selection invalidates a warmed session exactly like repo/branch changes do. Single-repo behavior (branch dropdown, localStorage restore, warm-on-type) is byte-identical.

## BFF

- `POST /api/sessions` allowlist forwards `environmentId` and `repositories`; identity fields stay server-derived and everything else is still stripped (tested).
- New proxies: `GET /api/environments/[id]/images` (per-environment status incl. failed rows, for settings), `POST /api/environments/[id]/images/trigger` (Rebuild now), `GET /api/environment-images` (cross-environment ready/building, for the picker) — all 501-gated like the repo-images routes.

## Session page

`MetadataSection` gains the environment provenance row (threaded from `SessionState.environmentId/environmentName`, which PR-9 already hydrates through the socket): the environment name when it resolves, and **"Environment deleted"** when the name resolves null (§7.6 contract).

## Tests

571 web tests pass (19 new):

- `session-target.test.ts` — per-mode request-field exclusivity, option-value round trip, multi-mode seeding, warm-config identity, launchability.
- `page.test.tsx` — environment launch sends only `environmentId`; ad-hoc launch sends only `repositories` (seeded from the selected repo, edited through the popover); existing no-repository flows unchanged.
- `environment-form.test.tsx` — primary marking + reorder changes submitted order, cap disables further selection, name-collision guard, submit gating.
- `sessions/route.test.ts` — forwards `environmentId` / `repositories`, still strips `userId`/`spawnSource`/`scmToken`/`authUserId`.
- `metadata-section.test.tsx` — environment name, deleted state, absent for repo-launched sessions.

## Not in this PR

- Environment names on session-list cards (`Session` carries `environmentId` but not a resolved name; list rendering is a fast follow if wanted).
- Slack/Linear/GitHub-bot environment targets (Phase 3, §7.5 — targets unify, nothing migrates).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Environments** settings tab with create/edit/list, delete, and prebuilt image management (status, rebuild, enable/disable).
  * Enhanced the launch flow to support **environment targets** and **ordered multi-repo selection**.
  * Added **environment-scoped secrets** and secret import from a selected repository.
* **Bug Fixes**
  * Improved session creation so environment and multi-repo launches send the correct fields, and invalid/extra fields are stripped.
  * Strengthened authentication gating for environment/repo image actions.
* **Documentation**
  * Updated launch help/disclosures to reflect environment vs repository launch modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->