### PR TITLE
refactor(web): extract session target picker from home page

### DIFF
--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -21,7 +21,7 @@ import {
 import { useEnabledModels } from "@/hooks/use-enabled-models";
 import {
   useSessionTargetPicker,
-  type SessionTargetPickerState,
+  type SessionTargetSelection,
 } from "@/hooks/use-session-target-picker";
 import { SessionTargetPicker } from "@/components/session-target-picker";
 import { ReasoningEffortPills } from "@/components/reasoning-effort-pills";
@@ -282,7 +282,7 @@ function HomeContent({
   modelOptions,
 }: {
   isAuthenticated: boolean;
-  picker: SessionTargetPickerState;
+  picker: SessionTargetSelection;
   selectedModel: string;
   setSelectedModel: (value: string) => void;
   reasoningEffort: string | undefined;
@@ -384,7 +384,7 @@ function HomeContent({
                 <div className="flex flex-col gap-2 px-4 py-2 border-t border-border-muted sm:flex-row sm:items-center sm:justify-between sm:gap-0">
                   {/* Left side - Target selector + Model selector */}
                   <div className="flex flex-wrap items-center gap-2 sm:gap-4 min-w-0">
-                    <SessionTargetPicker picker={picker} disabled={creating} />
+                    <SessionTargetPicker {...picker.pickerProps} disabled={creating} />
 
                     {/* Model selector */}
                     <Combobox

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -3,87 +3,43 @@
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { mutate } from "swr";
-import { useState, useEffect, useMemo, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import Link from "next/link";
 import { useSidebarContext } from "@/components/sidebar-layout";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { formatModelNameLower } from "@/lib/format";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
-import { NO_REPOSITORY_LABEL } from "@/lib/repo-label";
 import { isUnarchivedSessionListKey } from "@/lib/session-list";
 import { APP_NAME } from "@/lib/site-config";
 import {
   DEFAULT_MODEL,
   getDefaultReasoningEffort,
   isValidReasoningEffort,
-  type Environment,
   type ModelCategory,
 } from "@open-inspect/shared";
-import useSWR from "swr";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
-import { useRepos, type Repo } from "@/hooks/use-repos";
-import { useBranches } from "@/hooks/use-branches";
-import { useEnvironments } from "@/hooks/use-environments";
-import { supportsRepoImages } from "@/lib/sandbox-provider";
 import {
-  type SessionTarget,
-  NO_REPOSITORY_OPTION_VALUE,
-  MULTIPLE_REPOSITORIES_OPTION_VALUE,
-  buildSessionTargetRequestFields,
-  environmentOptionValue,
-  getTargetConfigKey,
-  getTargetSelectValue,
-  isSessionTargetLaunchable,
-  parseRepoFullName,
-  parseTargetSelectValue,
-} from "@/lib/session-target";
-import { RepositoryMultiSelect } from "@/components/repository-multi-select";
+  useSessionTargetPicker,
+  type SessionTargetPickerState,
+} from "@/hooks/use-session-target-picker";
+import { SessionTargetPicker } from "@/components/session-target-picker";
 import { ReasoningEffortPills } from "@/components/reasoning-effort-pills";
-import {
-  SidebarIcon,
-  RepoIcon,
-  ModelIcon,
-  BranchIcon,
-  ChevronDownIcon,
-  SendIcon,
-} from "@/components/ui/icons";
+import { SidebarIcon, ModelIcon, SendIcon } from "@/components/ui/icons";
 import { Combobox, type ComboboxGroup } from "@/components/ui/combobox";
 
-const LAST_SELECTED_REPO_STORAGE_KEY = "open-inspect-last-selected-repo";
 const LAST_SELECTED_MODEL_STORAGE_KEY = "open-inspect-last-selected-model";
 const LAST_SELECTED_REASONING_EFFORT_STORAGE_KEY = "open-inspect-last-selected-reasoning-effort";
-
-interface EnvironmentImageStatusRow {
-  environment_id: string;
-  status: "building" | "ready" | "failed";
-}
-
-/** Picker subtitle for an environment: repository count plus prebuild state. */
-function describeEnvironment(
-  environment: Environment,
-  imageStatusByEnvironment: Map<string, EnvironmentImageStatusRow["status"]>
-): string {
-  const count = environment.repositories.length;
-  const base = `${count} ${count === 1 ? "repository" : "repositories"}`;
-  if (!environment.prebuildEnabled) return base;
-  const status = imageStatusByEnvironment.get(environment.id);
-  if (status === "ready") return `${base} · prebuilt`;
-  if (status === "building") return `${base} · prebuild building`;
-  return `${base} · prebuilds on`;
-}
 
 export default function Home() {
   const { data: session } = useSession();
   const router = useRouter();
-  const { repos, loading: loadingRepos } = useRepos();
-  const { environments } = useEnvironments();
-  const [sessionTarget, setSessionTarget] = useState<SessionTarget | null>(null);
+  const picker = useSessionTargetPicker();
+  const { sessionTarget, selectedBranch, configKey, buildRequestFields, isLaunchable } = picker;
   const [selectedModel, setSelectedModel] = useState<string>(DEFAULT_MODEL);
   const [reasoningEffort, setReasoningEffort] = useState<string | undefined>(
     getDefaultReasoningEffort(DEFAULT_MODEL)
   );
-  const [selectedBranch, setSelectedBranch] = useState<string>("");
   const [prompt, setPrompt] = useState("");
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState("");
@@ -91,57 +47,11 @@ export default function Home() {
   const [isCreatingSession, setIsCreatingSession] = useState(false);
   const sessionCreationPromise = useRef<Promise<string | null> | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
-  // Keyed by getTargetConfigKey so environment/ad-hoc selections invalidate
-  // a warmed session exactly like repo/branch changes do.
+  // Keyed by the picker's configKey so environment/ad-hoc selections
+  // invalidate a warmed session exactly like repo/branch changes do.
   const pendingConfigRef = useRef<{ target: string; model: string; branch: string } | null>(null);
   const [hasHydratedModelPreferences, setHasHydratedModelPreferences] = useState(false);
   const { enabledModels, enabledModelOptions } = useEnabledModels();
-  const targetSelectValue = getTargetSelectValue(sessionTarget);
-  const selectedRepository =
-    sessionTarget?.kind === "repo" ? parseRepoFullName(sessionTarget.repoFullName) : null;
-  const selectedRepoOwner = selectedRepository?.owner ?? "";
-  const selectedRepoName = selectedRepository?.name ?? "";
-  const { branches, loading: loadingBranches } = useBranches(selectedRepoOwner, selectedRepoName);
-
-  // Prebuild status for the environment options (ready/building rows of
-  // prebuild-enabled environments, one call across all of them).
-  const { data: environmentImagesData } = useSWR<{ images: EnvironmentImageStatusRow[] }>(
-    environments.length > 0 && supportsRepoImages() ? "/api/environment-images" : null
-  );
-  const imageStatusByEnvironment = useMemo(() => {
-    const statusByEnvironment = new Map<string, EnvironmentImageStatusRow["status"]>();
-    for (const row of environmentImagesData?.images ?? []) {
-      if (row.status === "ready" || !statusByEnvironment.has(row.environment_id)) {
-        statusByEnvironment.set(row.environment_id, row.status);
-      }
-    }
-    return statusByEnvironment;
-  }, [environmentImagesData]);
-
-  // Auto-select repo when repos load
-  useEffect(() => {
-    if (sessionTarget) return;
-
-    if (repos.length > 0) {
-      const lastSelectedRepo = localStorage.getItem(LAST_SELECTED_REPO_STORAGE_KEY);
-      const hasLastSelectedRepo = repos.some((repo) => repo.fullName === lastSelectedRepo);
-      const defaultRepo =
-        (hasLastSelectedRepo ? lastSelectedRepo : repos[0].fullName) ?? repos[0].fullName;
-      setSessionTarget({ kind: "repo", repoFullName: defaultRepo });
-      const repo = repos.find((r) => r.fullName === defaultRepo);
-      if (repo) setSelectedBranch(repo.defaultBranch);
-      return;
-    }
-
-    if (!loadingRepos) {
-      setSessionTarget({ kind: "none" });
-    }
-  }, [loadingRepos, repos, sessionTarget]);
-
-  useEffect(() => {
-    if (sessionTarget?.kind !== "repo") return;
-    localStorage.setItem(LAST_SELECTED_REPO_STORAGE_KEY, sessionTarget.repoFullName);
-  }, [sessionTarget]);
 
   useEffect(() => {
     if (enabledModels.length === 0 || hasHydratedModelPreferences) return;
@@ -190,13 +100,14 @@ export default function Home() {
   const createSessionForWarming = useCallback(async () => {
     if (pendingSessionId) return pendingSessionId;
     if (sessionCreationPromise.current) return sessionCreationPromise.current;
-    if (!sessionTarget || !isSessionTargetLaunchable(sessionTarget)) return null;
+    const targetRequestFields = buildRequestFields();
+    if (!targetRequestFields) return null;
 
     setIsCreatingSession(true);
     const currentConfig = {
-      target: getTargetConfigKey(sessionTarget),
+      target: configKey,
       model: selectedModel,
-      branch: sessionTarget.kind === "repo" ? selectedBranch : "",
+      branch: sessionTarget?.kind === "repo" ? selectedBranch : "",
     };
     pendingConfigRef.current = currentConfig;
 
@@ -209,7 +120,7 @@ export default function Home() {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            ...buildSessionTargetRequestFields(sessionTarget, selectedBranch),
+            ...targetRequestFields,
             model: selectedModel,
             reasoningEffort,
           }),
@@ -246,7 +157,15 @@ export default function Home() {
 
     sessionCreationPromise.current = promise;
     return promise;
-  }, [sessionTarget, selectedModel, reasoningEffort, selectedBranch, pendingSessionId]);
+  }, [
+    sessionTarget,
+    selectedBranch,
+    configKey,
+    buildRequestFields,
+    selectedModel,
+    reasoningEffort,
+    pendingSessionId,
+  ]);
 
   // Reset selections when model preferences change (only after hydration)
   useEffect(() => {
@@ -264,24 +183,6 @@ export default function Home() {
     }
   }, [hasHydratedModelPreferences, enabledModels, selectedModel, reasoningEffort]);
 
-  const handleSessionTargetChange = useCallback(
-    (value: string) => {
-      const nextTarget = parseTargetSelectValue(value, sessionTarget);
-      setSessionTarget(nextTarget);
-      if (nextTarget.kind !== "repo") {
-        setSelectedBranch("");
-        return;
-      }
-      const repo = repos.find((r) => r.fullName === nextTarget.repoFullName);
-      if (repo) setSelectedBranch(repo.defaultBranch);
-    },
-    [repos, sessionTarget]
-  );
-
-  const handleMultiSelectionChange = useCallback((repoFullNames: string[]) => {
-    setSessionTarget({ kind: "repos", repoFullNames });
-  }, []);
-
   const handleModelChange = useCallback((model: string) => {
     setSelectedModel(model);
     setReasoningEffort(getDefaultReasoningEffort(model));
@@ -290,13 +191,7 @@ export default function Home() {
   const handlePromptChange = (value: string) => {
     const wasEmpty = prompt.length === 0;
     setPrompt(value);
-    if (
-      wasEmpty &&
-      value.length > 0 &&
-      !pendingSessionId &&
-      !isCreatingSession &&
-      isSessionTargetLaunchable(sessionTarget)
-    ) {
+    if (wasEmpty && value.length > 0 && !pendingSessionId && !isCreatingSession && isLaunchable) {
       createSessionForWarming();
     }
   };
@@ -304,7 +199,7 @@ export default function Home() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!prompt.trim()) return;
-    if (!isSessionTargetLaunchable(sessionTarget)) {
+    if (!isLaunchable) {
       setError(
         sessionTarget?.kind === "repos"
           ? "Select at least one repository"
@@ -355,18 +250,7 @@ export default function Home() {
   return (
     <HomeContent
       isAuthenticated={!!session}
-      repos={repos}
-      loadingRepos={loadingRepos}
-      environments={environments}
-      imageStatusByEnvironment={imageStatusByEnvironment}
-      sessionTarget={sessionTarget}
-      targetSelectValue={targetSelectValue}
-      setSessionTargetSelectValue={handleSessionTargetChange}
-      onMultiSelectionChange={handleMultiSelectionChange}
-      selectedBranch={selectedBranch}
-      setSelectedBranch={setSelectedBranch}
-      branches={branches}
-      loadingBranches={loadingBranches}
+      picker={picker}
       selectedModel={selectedModel}
       setSelectedModel={handleModelChange}
       reasoningEffort={reasoningEffort}
@@ -384,18 +268,7 @@ export default function Home() {
 
 function HomeContent({
   isAuthenticated,
-  repos,
-  loadingRepos,
-  environments,
-  imageStatusByEnvironment,
-  sessionTarget,
-  targetSelectValue,
-  setSessionTargetSelectValue,
-  onMultiSelectionChange,
-  selectedBranch,
-  setSelectedBranch,
-  branches,
-  loadingBranches,
+  picker,
   selectedModel,
   setSelectedModel,
   reasoningEffort,
@@ -409,18 +282,7 @@ function HomeContent({
   modelOptions,
 }: {
   isAuthenticated: boolean;
-  repos: Repo[];
-  loadingRepos: boolean;
-  environments: Environment[];
-  imageStatusByEnvironment: Map<string, EnvironmentImageStatusRow["status"]>;
-  sessionTarget: SessionTarget | null;
-  targetSelectValue: string;
-  setSessionTargetSelectValue: (value: string) => void;
-  onMultiSelectionChange: (repoFullNames: string[]) => void;
-  selectedBranch: string;
-  setSelectedBranch: (value: string) => void;
-  branches: { name: string }[];
-  loadingBranches: boolean;
+  picker: SessionTargetPickerState;
   selectedModel: string;
   setSelectedModel: (value: string) => void;
   reasoningEffort: string | undefined;
@@ -435,6 +297,7 @@ function HomeContent({
 }) {
   const { isOpen, toggle } = useSidebarContext();
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const { sessionTarget, selectedRepo, repos, loadingRepos, isLaunchable } = picker;
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.nativeEvent.isComposing) return;
@@ -444,64 +307,6 @@ function HomeContent({
       handleSubmit(e);
     }
   };
-
-  const selectedRepoObj =
-    sessionTarget?.kind === "repo"
-      ? repos.find((r) => r.fullName === sessionTarget.repoFullName)
-      : undefined;
-  const selectedEnvironment =
-    sessionTarget?.kind === "environment"
-      ? environments.find((environment) => environment.id === sessionTarget.environmentId)
-      : undefined;
-  const displayTargetName = (() => {
-    switch (sessionTarget?.kind) {
-      case "none":
-        return NO_REPOSITORY_LABEL;
-      case "repo":
-        return selectedRepoObj?.name ?? sessionTarget.repoFullName;
-      case "environment":
-        return selectedEnvironment?.name ?? "Environment";
-      case "repos": {
-        const count = sessionTarget.repoFullNames.length;
-        if (count === 0) return "Select repositories";
-        return `${count} ${count === 1 ? "repository" : "repositories"}`;
-      }
-      default:
-        return "Select repo";
-    }
-  })();
-  const repositoryOptions = [
-    {
-      value: NO_REPOSITORY_OPTION_VALUE,
-      label: NO_REPOSITORY_LABEL,
-      description: "Start without cloning a repository",
-    },
-    {
-      value: MULTIPLE_REPOSITORIES_OPTION_VALUE,
-      label: "Multiple repositories",
-      description: "Pick an ad-hoc set of repositories",
-    },
-    ...repos.map((repo) => ({
-      value: repo.fullName,
-      label: repo.name,
-      description: `${repo.owner}${repo.private ? " \u2022 private" : ""}`,
-    })),
-  ];
-  // One unified list: environments (when any exist) alongside the repositories.
-  const targetOptions =
-    environments.length > 0
-      ? [
-          {
-            category: "Environments",
-            options: environments.map((environment) => ({
-              value: environmentOptionValue(environment.id),
-              label: environment.name,
-              description: describeEnvironment(environment, imageStatusByEnvironment),
-            })),
-          },
-          { category: "Repositories", options: repositoryOptions },
-        ]
-      : repositoryOptions;
 
   return (
     <div className="h-full flex flex-col">
@@ -561,9 +366,7 @@ function HomeContent({
                     )}
                     <button
                       type="submit"
-                      disabled={
-                        !prompt.trim() || creating || !isSessionTargetLaunchable(sessionTarget)
-                      }
+                      disabled={!prompt.trim() || creating || !isLaunchable}
                       className="p-2 text-secondary-foreground hover:text-foreground disabled:opacity-30 disabled:cursor-not-allowed transition"
                       title={`Send (${SHORTCUT_LABELS.SEND_PROMPT})`}
                       aria-label={`Send (${SHORTCUT_LABELS.SEND_PROMPT})`}
@@ -577,75 +380,11 @@ function HomeContent({
                   </div>
                 </div>
 
-                {/* Footer row with repo and model selectors */}
+                {/* Footer row with target and model selectors */}
                 <div className="flex flex-col gap-2 px-4 py-2 border-t border-border-muted sm:flex-row sm:items-center sm:justify-between sm:gap-0">
-                  {/* Left side - Repo selector + Model selector */}
+                  {/* Left side - Target selector + Model selector */}
                   <div className="flex flex-wrap items-center gap-2 sm:gap-4 min-w-0">
-                    {/* Repo selector */}
-                    <Combobox
-                      value={targetSelectValue}
-                      onChange={(value) => setSessionTargetSelectValue(value)}
-                      items={targetOptions}
-                      searchable
-                      searchPlaceholder="Search environments and repositories..."
-                      filterFn={(option, query) =>
-                        option.label.toLowerCase().includes(query) ||
-                        (option.description?.toLowerCase().includes(query) ?? false) ||
-                        String(option.value).toLowerCase().includes(query)
-                      }
-                      direction="up"
-                      dropdownWidth="w-72"
-                      disabled={creating || loadingRepos}
-                      triggerClassName="flex max-w-full items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
-                    >
-                      <RepoIcon className="w-4 h-4" />
-                      <span className="truncate max-w-[12rem] sm:max-w-none">
-                        {loadingRepos ? "Loading..." : displayTargetName}
-                      </span>
-                      <ChevronDownIcon className="w-3 h-3" />
-                    </Combobox>
-
-                    {/* Ad-hoc repository set editor */}
-                    {sessionTarget?.kind === "repos" && (
-                      <RepositoryMultiSelect
-                        repos={repos}
-                        loadingRepos={loadingRepos}
-                        selected={sessionTarget.repoFullNames}
-                        onChange={onMultiSelectionChange}
-                        disabled={creating || loadingRepos}
-                        triggerLabel={
-                          sessionTarget.repoFullNames.length === 0
-                            ? "Choose repositories"
-                            : sessionTarget.repoFullNames.join(", ")
-                        }
-                        triggerClassName="max-w-[16rem] border-0 bg-transparent px-0 py-0 text-sm text-muted-foreground hover:text-foreground"
-                      />
-                    )}
-
-                    {/* Branch selector */}
-                    {sessionTarget?.kind === "repo" && (
-                      <Combobox
-                        value={selectedBranch}
-                        onChange={(value) => setSelectedBranch(value)}
-                        items={branches.map((b) => ({
-                          value: b.name,
-                          label: b.name,
-                        }))}
-                        searchable
-                        searchPlaceholder="Search branches..."
-                        filterFn={(option, query) => option.label.toLowerCase().includes(query)}
-                        direction="up"
-                        dropdownWidth="w-56"
-                        disabled={creating || loadingBranches}
-                        triggerClassName="flex max-w-full items-center gap-1 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
-                      >
-                        <BranchIcon className="w-3.5 h-3.5" />
-                        <span className="truncate max-w-[9rem] sm:max-w-none">
-                          {loadingBranches ? "Loading..." : selectedBranch || "branch"}
-                        </span>
-                        <ChevronDownIcon className="w-3 h-3" />
-                      </Combobox>
-                    )}
+                    <SessionTargetPicker picker={picker} disabled={creating} />
 
                     {/* Model selector */}
                     <Combobox
@@ -706,7 +445,7 @@ function HomeContent({
                 </p>
               )}
 
-              {selectedRepoObj && (
+              {selectedRepo && (
                 <div className="mt-3 text-center">
                   <Link
                     href="/settings"

--- a/packages/web/src/components/session-target-picker.tsx
+++ b/packages/web/src/components/session-target-picker.tsx
@@ -3,7 +3,7 @@
 import { RepositoryMultiSelect } from "@/components/repository-multi-select";
 import { Combobox } from "@/components/ui/combobox";
 import { BranchIcon, ChevronDownIcon, RepoIcon } from "@/components/ui/icons";
-import type { SessionTargetPickerState } from "@/hooks/use-session-target-picker";
+import type { SessionTargetPickerProps } from "@/hooks/use-session-target-picker";
 
 /**
  * The new-session target controls: the unified environment/repository
@@ -11,27 +11,20 @@ import type { SessionTargetPickerState } from "@/hooks/use-session-target-picker
  * State and option building live in useSessionTargetPicker.
  */
 export function SessionTargetPicker({
-  picker,
+  sessionTarget,
+  targetSelectValue,
+  targetOptions,
+  displayTargetName,
+  onTargetSelectValueChange,
+  onMultiSelectionChange,
+  selectedBranch,
+  setSelectedBranch,
+  branches,
+  loadingBranches,
+  repos,
+  loadingRepos,
   disabled,
-}: {
-  picker: SessionTargetPickerState;
-  disabled: boolean;
-}) {
-  const {
-    sessionTarget,
-    targetSelectValue,
-    targetOptions,
-    displayTargetName,
-    onTargetSelectValueChange,
-    onMultiSelectionChange,
-    selectedBranch,
-    setSelectedBranch,
-    branches,
-    loadingBranches,
-    repos,
-    loadingRepos,
-  } = picker;
-
+}: SessionTargetPickerProps & { disabled: boolean }) {
   return (
     <>
       {/* Target selector */}

--- a/packages/web/src/components/session-target-picker.tsx
+++ b/packages/web/src/components/session-target-picker.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { RepositoryMultiSelect } from "@/components/repository-multi-select";
+import { Combobox } from "@/components/ui/combobox";
+import { BranchIcon, ChevronDownIcon, RepoIcon } from "@/components/ui/icons";
+import type { SessionTargetPickerState } from "@/hooks/use-session-target-picker";
+
+/**
+ * The new-session target controls: the unified environment/repository
+ * selector, the ad-hoc repository set editor, and the branch selector.
+ * State and option building live in useSessionTargetPicker.
+ */
+export function SessionTargetPicker({
+  picker,
+  disabled,
+}: {
+  picker: SessionTargetPickerState;
+  disabled: boolean;
+}) {
+  const {
+    sessionTarget,
+    targetSelectValue,
+    targetOptions,
+    displayTargetName,
+    onTargetSelectValueChange,
+    onMultiSelectionChange,
+    selectedBranch,
+    setSelectedBranch,
+    branches,
+    loadingBranches,
+    repos,
+    loadingRepos,
+  } = picker;
+
+  return (
+    <>
+      {/* Target selector */}
+      <Combobox
+        value={targetSelectValue}
+        onChange={(value) => onTargetSelectValueChange(value)}
+        items={targetOptions}
+        searchable
+        searchPlaceholder="Search environments and repositories..."
+        filterFn={(option, query) =>
+          option.label.toLowerCase().includes(query) ||
+          (option.description?.toLowerCase().includes(query) ?? false) ||
+          String(option.value).toLowerCase().includes(query)
+        }
+        direction="up"
+        dropdownWidth="w-72"
+        disabled={disabled || loadingRepos}
+        triggerClassName="flex max-w-full items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
+      >
+        <RepoIcon className="w-4 h-4" />
+        <span className="truncate max-w-[12rem] sm:max-w-none">
+          {loadingRepos ? "Loading..." : displayTargetName}
+        </span>
+        <ChevronDownIcon className="w-3 h-3" />
+      </Combobox>
+
+      {/* Ad-hoc repository set editor */}
+      {sessionTarget?.kind === "repos" && (
+        <RepositoryMultiSelect
+          repos={repos}
+          loadingRepos={loadingRepos}
+          selected={sessionTarget.repoFullNames}
+          onChange={onMultiSelectionChange}
+          disabled={disabled || loadingRepos}
+          triggerLabel={
+            sessionTarget.repoFullNames.length === 0
+              ? "Choose repositories"
+              : sessionTarget.repoFullNames.join(", ")
+          }
+          triggerClassName="max-w-[16rem] border-0 bg-transparent px-0 py-0 text-sm text-muted-foreground hover:text-foreground"
+        />
+      )}
+
+      {/* Branch selector */}
+      {sessionTarget?.kind === "repo" && (
+        <Combobox
+          value={selectedBranch}
+          onChange={(value) => setSelectedBranch(value)}
+          items={branches.map((b) => ({
+            value: b.name,
+            label: b.name,
+          }))}
+          searchable
+          searchPlaceholder="Search branches..."
+          filterFn={(option, query) => option.label.toLowerCase().includes(query)}
+          direction="up"
+          dropdownWidth="w-56"
+          disabled={disabled || loadingBranches}
+          triggerClassName="flex max-w-full items-center gap-1 text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition"
+        >
+          <BranchIcon className="w-3.5 h-3.5" />
+          <span className="truncate max-w-[9rem] sm:max-w-none">
+            {loadingBranches ? "Loading..." : selectedBranch || "branch"}
+          </span>
+          <ChevronDownIcon className="w-3 h-3" />
+        </Combobox>
+      )}
+    </>
+  );
+}

--- a/packages/web/src/hooks/use-session-target-picker.ts
+++ b/packages/web/src/hooks/use-session-target-picker.ts
@@ -11,6 +11,7 @@ import { NO_REPOSITORY_LABEL } from "@/lib/repo-label";
 import { supportsRepoImages } from "@/lib/sandbox-provider";
 import {
   type SessionTarget,
+  type SessionTargetRequestFields,
   NO_REPOSITORY_OPTION_VALUE,
   MULTIPLE_REPOSITORIES_OPTION_VALUE,
   buildSessionTargetRequestFields,
@@ -43,7 +44,8 @@ function describeEnvironment(
   return `${base} · prebuilds on`;
 }
 
-export interface SessionTargetPickerState {
+/** Render contract for SessionTargetPicker: the target/branch/multi-select controls. */
+export interface SessionTargetPickerProps {
   sessionTarget: SessionTarget | null;
   targetSelectValue: string;
   targetOptions: ComboboxOption[] | ComboboxGroup[];
@@ -56,22 +58,32 @@ export interface SessionTargetPickerState {
   loadingBranches: boolean;
   repos: Repo[];
   loadingRepos: boolean;
+}
+
+/** Launch-facing selection state for the page: warming identity and request construction. */
+export interface SessionTargetSelection {
+  sessionTarget: SessionTarget | null;
+  selectedBranch: string;
+  repos: Repo[];
+  loadingRepos: boolean;
   /** The selected repository's metadata when the target is a single repo. */
   selectedRepo: Repo | undefined;
   isLaunchable: boolean;
   /** Selection identity for the sandbox-warming config check. */
   configKey: string;
   /** Request-body fields for the current target, or null when not launchable. */
-  buildRequestFields: () => Record<string, unknown> | null;
+  buildRequestFields: () => SessionTargetRequestFields | null;
+  /** Everything SessionTargetPicker needs to render the controls. */
+  pickerProps: SessionTargetPickerProps;
 }
 
 /**
  * Owns the new-session target selection: SessionTarget state, the unified
  * environment/repository option list, branch and multi-repo handling, and
- * request-field construction. Rendered by SessionTargetPicker; the page keeps
- * model, prompt, and warming.
+ * request-field construction. The controls render through SessionTargetPicker
+ * via `pickerProps`; the page keeps model, prompt, and warming.
  */
-export function useSessionTargetPicker(): SessionTargetPickerState {
+export function useSessionTargetPicker(): SessionTargetSelection {
   const { repos, loading: loadingRepos } = useRepos();
   const { environments } = useEnvironments();
   const [sessionTarget, setSessionTarget] = useState<SessionTarget | null>(null);
@@ -142,7 +154,7 @@ export function useSessionTargetPicker(): SessionTargetPickerState {
     setSessionTarget({ kind: "repos", repoFullNames });
   }, []);
 
-  const buildRequestFields = useCallback((): Record<string, unknown> | null => {
+  const buildRequestFields = useCallback((): SessionTargetRequestFields | null => {
     if (!sessionTarget || !isSessionTargetLaunchable(sessionTarget)) return null;
     return buildSessionTargetRequestFields(sessionTarget, selectedBranch);
   }, [sessionTarget, selectedBranch]);
@@ -208,20 +220,26 @@ export function useSessionTargetPicker(): SessionTargetPickerState {
 
   return {
     sessionTarget,
-    targetSelectValue: getTargetSelectValue(sessionTarget),
-    targetOptions,
-    displayTargetName,
-    onTargetSelectValueChange,
-    onMultiSelectionChange,
     selectedBranch,
-    setSelectedBranch,
-    branches,
-    loadingBranches,
     repos,
     loadingRepos,
     selectedRepo,
     isLaunchable: isSessionTargetLaunchable(sessionTarget),
     configKey: getTargetConfigKey(sessionTarget),
     buildRequestFields,
+    pickerProps: {
+      sessionTarget,
+      targetSelectValue: getTargetSelectValue(sessionTarget),
+      targetOptions,
+      displayTargetName,
+      onTargetSelectValueChange,
+      onMultiSelectionChange,
+      selectedBranch,
+      setSelectedBranch,
+      branches,
+      loadingBranches,
+      repos,
+      loadingRepos,
+    },
   };
 }

--- a/packages/web/src/hooks/use-session-target-picker.ts
+++ b/packages/web/src/hooks/use-session-target-picker.ts
@@ -1,0 +1,227 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import useSWR from "swr";
+import type { Environment } from "@open-inspect/shared";
+import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
+import { useBranches } from "@/hooks/use-branches";
+import { useEnvironments } from "@/hooks/use-environments";
+import { useRepos, type Repo } from "@/hooks/use-repos";
+import { NO_REPOSITORY_LABEL } from "@/lib/repo-label";
+import { supportsRepoImages } from "@/lib/sandbox-provider";
+import {
+  type SessionTarget,
+  NO_REPOSITORY_OPTION_VALUE,
+  MULTIPLE_REPOSITORIES_OPTION_VALUE,
+  buildSessionTargetRequestFields,
+  environmentOptionValue,
+  getTargetConfigKey,
+  getTargetSelectValue,
+  isSessionTargetLaunchable,
+  parseRepoFullName,
+  parseTargetSelectValue,
+} from "@/lib/session-target";
+
+const LAST_SELECTED_REPO_STORAGE_KEY = "open-inspect-last-selected-repo";
+
+interface EnvironmentImageStatusRow {
+  environment_id: string;
+  status: "building" | "ready" | "failed";
+}
+
+/** Picker subtitle for an environment: repository count plus prebuild state. */
+function describeEnvironment(
+  environment: Environment,
+  imageStatusByEnvironment: Map<string, EnvironmentImageStatusRow["status"]>
+): string {
+  const count = environment.repositories.length;
+  const base = `${count} ${count === 1 ? "repository" : "repositories"}`;
+  if (!environment.prebuildEnabled) return base;
+  const status = imageStatusByEnvironment.get(environment.id);
+  if (status === "ready") return `${base} · prebuilt`;
+  if (status === "building") return `${base} · prebuild building`;
+  return `${base} · prebuilds on`;
+}
+
+export interface SessionTargetPickerState {
+  sessionTarget: SessionTarget | null;
+  targetSelectValue: string;
+  targetOptions: ComboboxOption[] | ComboboxGroup[];
+  displayTargetName: string;
+  onTargetSelectValueChange: (value: string) => void;
+  onMultiSelectionChange: (repoFullNames: string[]) => void;
+  selectedBranch: string;
+  setSelectedBranch: (branch: string) => void;
+  branches: { name: string }[];
+  loadingBranches: boolean;
+  repos: Repo[];
+  loadingRepos: boolean;
+  /** The selected repository's metadata when the target is a single repo. */
+  selectedRepo: Repo | undefined;
+  isLaunchable: boolean;
+  /** Selection identity for the sandbox-warming config check. */
+  configKey: string;
+  /** Request-body fields for the current target, or null when not launchable. */
+  buildRequestFields: () => Record<string, unknown> | null;
+}
+
+/**
+ * Owns the new-session target selection: SessionTarget state, the unified
+ * environment/repository option list, branch and multi-repo handling, and
+ * request-field construction. Rendered by SessionTargetPicker; the page keeps
+ * model, prompt, and warming.
+ */
+export function useSessionTargetPicker(): SessionTargetPickerState {
+  const { repos, loading: loadingRepos } = useRepos();
+  const { environments } = useEnvironments();
+  const [sessionTarget, setSessionTarget] = useState<SessionTarget | null>(null);
+  const [selectedBranch, setSelectedBranch] = useState<string>("");
+
+  const selectedRepository =
+    sessionTarget?.kind === "repo" ? parseRepoFullName(sessionTarget.repoFullName) : null;
+  const { branches, loading: loadingBranches } = useBranches(
+    selectedRepository?.owner ?? "",
+    selectedRepository?.name ?? ""
+  );
+
+  // Prebuild status for the environment options (ready/building rows of
+  // prebuild-enabled environments, one call across all of them).
+  const { data: environmentImagesData } = useSWR<{ images: EnvironmentImageStatusRow[] }>(
+    environments.length > 0 && supportsRepoImages() ? "/api/environment-images" : null
+  );
+  const imageStatusByEnvironment = useMemo(() => {
+    const statusByEnvironment = new Map<string, EnvironmentImageStatusRow["status"]>();
+    for (const row of environmentImagesData?.images ?? []) {
+      if (row.status === "ready" || !statusByEnvironment.has(row.environment_id)) {
+        statusByEnvironment.set(row.environment_id, row.status);
+      }
+    }
+    return statusByEnvironment;
+  }, [environmentImagesData]);
+
+  // Auto-select repo when repos load
+  useEffect(() => {
+    if (sessionTarget) return;
+
+    if (repos.length > 0) {
+      const lastSelectedRepo = localStorage.getItem(LAST_SELECTED_REPO_STORAGE_KEY);
+      const hasLastSelectedRepo = repos.some((repo) => repo.fullName === lastSelectedRepo);
+      const defaultRepo =
+        (hasLastSelectedRepo ? lastSelectedRepo : repos[0].fullName) ?? repos[0].fullName;
+      setSessionTarget({ kind: "repo", repoFullName: defaultRepo });
+      const repo = repos.find((r) => r.fullName === defaultRepo);
+      if (repo) setSelectedBranch(repo.defaultBranch);
+      return;
+    }
+
+    if (!loadingRepos) {
+      setSessionTarget({ kind: "none" });
+    }
+  }, [loadingRepos, repos, sessionTarget]);
+
+  useEffect(() => {
+    if (sessionTarget?.kind !== "repo") return;
+    localStorage.setItem(LAST_SELECTED_REPO_STORAGE_KEY, sessionTarget.repoFullName);
+  }, [sessionTarget]);
+
+  const onTargetSelectValueChange = useCallback(
+    (value: string) => {
+      const nextTarget = parseTargetSelectValue(value, sessionTarget);
+      setSessionTarget(nextTarget);
+      if (nextTarget.kind !== "repo") {
+        setSelectedBranch("");
+        return;
+      }
+      const repo = repos.find((r) => r.fullName === nextTarget.repoFullName);
+      if (repo) setSelectedBranch(repo.defaultBranch);
+    },
+    [repos, sessionTarget]
+  );
+
+  const onMultiSelectionChange = useCallback((repoFullNames: string[]) => {
+    setSessionTarget({ kind: "repos", repoFullNames });
+  }, []);
+
+  const buildRequestFields = useCallback((): Record<string, unknown> | null => {
+    if (!sessionTarget || !isSessionTargetLaunchable(sessionTarget)) return null;
+    return buildSessionTargetRequestFields(sessionTarget, selectedBranch);
+  }, [sessionTarget, selectedBranch]);
+
+  const selectedRepo =
+    sessionTarget?.kind === "repo"
+      ? repos.find((r) => r.fullName === sessionTarget.repoFullName)
+      : undefined;
+  const selectedEnvironment =
+    sessionTarget?.kind === "environment"
+      ? environments.find((environment) => environment.id === sessionTarget.environmentId)
+      : undefined;
+  const displayTargetName = (() => {
+    switch (sessionTarget?.kind) {
+      case "none":
+        return NO_REPOSITORY_LABEL;
+      case "repo":
+        return selectedRepo?.name ?? sessionTarget.repoFullName;
+      case "environment":
+        return selectedEnvironment?.name ?? "Environment";
+      case "repos": {
+        const count = sessionTarget.repoFullNames.length;
+        if (count === 0) return "Select repositories";
+        return `${count} ${count === 1 ? "repository" : "repositories"}`;
+      }
+      default:
+        return "Select repo";
+    }
+  })();
+
+  const repositoryOptions: ComboboxOption[] = [
+    {
+      value: NO_REPOSITORY_OPTION_VALUE,
+      label: NO_REPOSITORY_LABEL,
+      description: "Start without cloning a repository",
+    },
+    {
+      value: MULTIPLE_REPOSITORIES_OPTION_VALUE,
+      label: "Multiple repositories",
+      description: "Pick an ad-hoc set of repositories",
+    },
+    ...repos.map((repo) => ({
+      value: repo.fullName,
+      label: repo.name,
+      description: `${repo.owner}${repo.private ? " • private" : ""}`,
+    })),
+  ];
+  // One unified list: environments (when any exist) alongside the repositories.
+  const targetOptions: ComboboxOption[] | ComboboxGroup[] =
+    environments.length > 0
+      ? [
+          {
+            category: "Environments",
+            options: environments.map((environment) => ({
+              value: environmentOptionValue(environment.id),
+              label: environment.name,
+              description: describeEnvironment(environment, imageStatusByEnvironment),
+            })),
+          },
+          { category: "Repositories", options: repositoryOptions },
+        ]
+      : repositoryOptions;
+
+  return {
+    sessionTarget,
+    targetSelectValue: getTargetSelectValue(sessionTarget),
+    targetOptions,
+    displayTargetName,
+    onTargetSelectValueChange,
+    onMultiSelectionChange,
+    selectedBranch,
+    setSelectedBranch,
+    branches,
+    loadingBranches,
+    repos,
+    loadingRepos,
+    selectedRepo,
+    isLaunchable: isSessionTargetLaunchable(sessionTarget),
+    configKey: getTargetConfigKey(sessionTarget),
+    buildRequestFields,
+  };
+}

--- a/packages/web/src/lib/session-target.ts
+++ b/packages/web/src/lib/session-target.ts
@@ -83,12 +83,19 @@ export function isSessionTargetLaunchable(target: SessionTarget | null): boolean
 
 /**
  * The target's fields for the POST /api/sessions body: exactly one of the
- * scalar repo form, `environmentId`, or `repositories` (design §5.5).
+ * scalar repo form, `environmentId`, or `repositories` (design §5.5). Mirrors
+ * the mutually exclusive modes of createSessionRequestSchema.
  */
+export type SessionTargetRequestFields =
+  | { repoOwner: null; repoName: null }
+  | { repoOwner: string; repoName: string; branch?: string }
+  | { environmentId: string }
+  | { repositories: Array<{ repoOwner: string; repoName: string }> };
+
 export function buildSessionTargetRequestFields(
   target: SessionTarget,
   selectedBranch: string
-): Record<string, unknown> {
+): SessionTargetRequestFields {
   switch (target.kind) {
     case "none":
       return { repoOwner: null, repoName: null };


### PR DESCRIPTION
## Summary

Fast-follow committed on the #919 review thread ([discussion](https://github.com/ColeMurray/background-agents/pull/919)): extract the session-target picker from the home page now that the unified environment/repository picker landed.

- **`useSessionTargetPicker`** (new hook) owns the `SessionTarget` state, the unified environment/repository option list (including prebuild-status subtitles), display labels, branch and multi-repo selection handling, and request-field construction (`buildRequestFields()`, which returns `null` when the selection isn't launchable).
- **`SessionTargetPicker`** (new component) owns the three target controls: the unified target combobox, the ad-hoc repository multi-select, and the branch combobox.
- **`page.tsx`** keeps exactly what the review discussion scoped to it — model selection, prompt state, and sandbox warming — and shrinks from 733 to 437 lines. The 24-prop `HomeContent` boundary collapses to 13 props (one of which is the picker state object).

The pure pieces were already in `lib/session-target.ts`, so this is the mechanical half: no behavior change, no new API calls, no markup changes.

## Testing

- `npm test -w @open-inspect/web` — 589 tests pass, including the four `Home` tests that drive the real picker end-to-end (no-repository, environment-only body, ad-hoc seeded multi-select).
- `npm run typecheck -w @open-inspect/web`, `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified session target picker to select environments, repositories, and branches in a single interface.
  * Automatically selects a default repository, restores the last-used choice when available, and persists repository selection for future sessions.
  * Launch eligibility and request payloads are now driven by the picker’s selection state.

* **Bug Fixes**
  * Improved warm-session behavior by ensuring the returned warmed session matches the currently selected target configuration before proceeding.
  * Submit and prompt-triggered actions are disabled until the selected target is ready to launch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->