### PR TITLE
docs: document multi-repo sessions, environments, and prebuilds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,10 +11,10 @@ Three tiers connected by WebSockets:
 1. **Web Client** (Next.js on Vercel or Cloudflare Workers via OpenNext) — UI with GitHub OAuth,
    session dashboard, real-time streaming
 2. **Control Plane** (Cloudflare Workers + Durable Objects) — session lifecycle, WebSocket hub,
-   GitHub/auth integration. Each session is a Durable Object with SQLite storage. Uses D1 for
-   session index, repo metadata, and encrypted repo secrets.
+   GitHub/auth integration. Each session is a Durable Object with SQLite storage. Uses D1 for the
+   session index, repo metadata, environments, and encrypted secrets.
 3. **Data Plane** (Modal, Python) — sandboxed environments running coding agents. Manages sandbox
-   creation, snapshots, and repo image builds.
+   creation, snapshots, and repository/environment image builds.
 
 **Bot integrations** — all Cloudflare Workers using Hono:
 

--- a/README.md
+++ b/README.md
@@ -146,10 +146,21 @@ Sessions start near-instantly through multiple layers of warming:
 
 - **Filesystem snapshots** — After each prompt, sandbox state is saved; follow-up sessions restore
   instead of re-cloning
-- **Pre-built repo images** — Toggle per-repo in Settings; rebuilt every 30 minutes with latest
-  commits and dependencies
+- **Pre-built images** — Toggle per-repo (Settings > Images) or per-environment (Settings >
+  Environments); rebuilt every 30 minutes with latest commits and dependencies
 - **Proactive warming** — Sandbox begins spinning up as soon as you start typing, before you hit
   Enter
+
+### Multi-Repository Sessions & Environments
+
+One session can work across several repositories in a single sandbox:
+
+- **Ad-hoc sets** — Pick up to 10 repositories in the new-session picker; each is cloned side by
+  side and the agent can make coordinated changes and open a PR per repository
+- **Environments** — Save a repository set as a named environment with its own secrets scope and
+  optional prebuilt images, then launch it from the picker like any repository
+- See [docs/HOW_IT_WORKS.md](docs/HOW_IT_WORKS.md#environments) for the model and
+  [docs/IMAGE_PREBUILD.md](docs/IMAGE_PREBUILD.md#environment-images) for environment prebuilds
 
 ### Multiplayer Sessions
 
@@ -225,8 +236,8 @@ Every session runs in an isolated sandbox backend with a full development enviro
 - **Port tunneling:** Expose up to 10 dev server ports via encrypted tunnels. URLs are available
   in-sandbox at `/workspace/.tunnels.env` before `.openinspect/start.sh` runs
   ([details](docs/HOW_IT_WORKS.md#tunnel-urls-inside-the-sandbox))
-- **Repo secrets:** AES-256-GCM encrypted, scoped per-repo or globally, injected as env vars at
-  spawn time. Supports bulk `.env` paste import
+- **Secrets:** AES-256-GCM encrypted, scoped globally, per-repo, or per-environment, injected as env
+  vars at spawn time. Supports bulk `.env` paste import
 
 ### Sub-Task Spawning
 

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -112,7 +112,7 @@ An environment defines:
 Sessions snapshot the environment at creation time: editing or deleting an environment never changes
 what an existing session works on (the session page shows "Environment deleted" if the source is
 gone). Ad-hoc "Multiple repositories" selections are the unsaved counterpart — same workspace shape,
-but no secrets scope and no prebuilds; the picker offers to save the set as an environment.
+but no environment-scoped secrets or prebuilds; the picker offers to save the set as an environment.
 
 ---
 

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -38,10 +38,31 @@ This enables workflows that aren't possible with interactive tools:
 
 A **session** is the core unit of work in Open-Inspect. Each session is:
 
-- **Tied to a repository**: The agent works in a clone of your repo
+- **Tied to a workspace**: The agent works in clones of the repositories you selected — a single
+  repository, an ad-hoc set of up to 10, a saved [environment](#environments), or no repository at
+  all
 - **Persistent**: State survives across connections—close the browser, come back later
 - **Multiplayer**: Multiple users can join, send prompts, and see events in real-time
 - **Stateful**: Contains messages, events, artifacts, and sandbox state
+
+### Session Targets
+
+When creating a session from the web picker you choose what the sandbox works on:
+
+| Target                    | What you get                                                                 |
+| ------------------------- | ---------------------------------------------------------------------------- |
+| **A single repository**   | Today's classic flow: one clone, one branch selector                         |
+| **Multiple repositories** | An ad-hoc ordered set (up to 10) cloned side by side                         |
+| **An environment**        | A saved, reusable repository set — with optional prebuilt images and secrets |
+| **No repository**         | An empty sandbox for scratch work                                            |
+
+In multi-repository sessions each repository is cloned into its own directory under `/workspace`
+(named after the repository), and the **first repository is the primary** — it drives defaults like
+which settings apply. The agent sees all clones side by side and can make coordinated changes across
+them; pushes and pull requests are per-repository, so one session can produce PRs in several
+repositories. The session sidebar lists every repository with its branch and any PR created for it.
+
+Bot-created sessions (Slack, GitHub, Linear) remain single-repository.
 
 ### Session Lifecycle
 
@@ -67,6 +88,31 @@ if needed.
 
 Each session gets its own SQLite database in a Cloudflare Durable Object, ensuring isolation and
 high performance even with hundreds of concurrent sessions.
+
+---
+
+## Environments
+
+An **environment** is a named, reusable set of repositories — the thing you reach for when the same
+multi-repository workspace comes up again and again (a frontend + its API, a service + its shared
+library). Environments are managed under **Settings > Environments** and appear at the top of the
+new-session picker.
+
+An environment defines:
+
+- **An ordered repository list** (up to 10) with a base branch per repository; the first repository
+  is the primary
+- **Environment secrets** — sessions launched from the environment receive global secrets plus the
+  environment's secrets (repository secrets do not flow in; see
+  [Secrets Management](./SECRETS.md#which-secrets-a-session-receives))
+- **Optional prebuilt images** — the whole environment (all clones + all setup scripts) is built
+  ahead of time so sessions boot in seconds (see
+  [Pre-Built Images](./IMAGE_PREBUILD.md#environment-images))
+
+Sessions snapshot the environment at creation time: editing or deleting an environment never changes
+what an existing session works on (the session page shows "Environment deleted" if the source is
+gone). Ad-hoc "Multiple repositories" selections are the unsaved counterpart — same workspace shape,
+but no secrets scope and no prebuilds; the picker offers to save the set as an environment.
 
 ---
 
@@ -201,6 +247,10 @@ When you create a session for a repo without an existing snapshot:
 5. **Agent start**: OpenCode server starts and connects back to the control plane
 6. **Ready**: Sandbox accepts prompts
 
+For multi-repository sessions, steps 2–4 run per repository in position order: every repository is
+cloned into its own `/workspace` directory and each repository's setup and start scripts run in
+sequence.
+
 ### Restore (From Snapshot)
 
 When restoring from a previous snapshot:
@@ -221,11 +271,13 @@ When restoring from a previous snapshot:
 Snapshots include installed dependencies, built artifacts, and workspace state. This is why
 follow-up prompts in an existing session are much faster than the first prompt.
 
-### Repo Image Start
+### Prebuilt Image Start
 
-When starting from a pre-built repo image:
+When starting from a pre-built image (a repository image, or an environment image for sessions
+launched from a prebuild-enabled environment):
 
-1. **Incremental git sync**: Fast fetch + hard reset to latest branch head
+1. **Incremental git sync**: Fast fetch + hard reset to latest branch head (per repository for
+   environment images)
 2. **Setup skipped**: `.openinspect/setup.sh` already ran when the image was built
 3. **Start script runs**: `.openinspect/start.sh` executes for per-session runtime startup
 4. **Ready**: Agent starts once runtime hook succeeds
@@ -439,13 +491,16 @@ See [Vercel Sandbox Provider](VERCEL_SANDBOX_PROVIDER.md) and
 
 ### Image Prebuilding
 
-For frequently-used repositories, images can be prebuilt on a schedule:
+For frequently-used repositories — and for [environments](#environments) — images can be prebuilt on
+a schedule:
 
-- Clone repo, install dependencies, run initial build
+- Clone the repository (or every repository of the environment), install dependencies, run initial
+  build
 - Save as a provider image artifact
 - Sessions start from this artifact, only syncing recent changes
 
-This means even "cold" sessions (no previous snapshot) start from a recent baseline.
+This means even "cold" sessions (no previous snapshot) start from a recent baseline. See
+[Pre-Built Images](./IMAGE_PREBUILD.md) for details.
 
 ---
 
@@ -485,11 +540,16 @@ restores still mint a fresh fallback token on restore.
 
 ### Secrets
 
-You can configure environment variables (API keys, credentials) at global or per-repository scope:
+You can configure environment variables (API keys, credentials) at global, per-repository, or
+per-environment scope. A session receives global secrets plus its **launch unit's** secrets:
 
-- **Global secrets** apply to all repositories (e.g., `ANTHROPIC_API_KEY`, `DEEPSEEK_API_KEY`,
+- **Global secrets** apply to all sessions (e.g., `ANTHROPIC_API_KEY`, `DEEPSEEK_API_KEY`,
   `ZHIPU_API_KEY`)
-- **Repository secrets** apply to a single repo and override global secrets with the same key
+- **Repository secrets** apply to sessions launched from that repo (including all bot-created
+  sessions) and override global secrets with the same key; ad-hoc multi-repository sessions receive
+  each selected repository's secrets, with the primary winning collisions
+- **Environment secrets** apply to sessions launched from that environment — its repositories'
+  repository secrets do not flow in
 - Stored encrypted (AES-256-GCM) in D1 database
 - Injected into sandboxes at startup
 - Never exposed to clients (only key names are visible)

--- a/docs/IMAGE_PREBUILD.md
+++ b/docs/IMAGE_PREBUILD.md
@@ -1,9 +1,16 @@
 # Pre-Built Images
 
 Pre-built images make your sessions start faster. Instead of cloning your repository and installing
-dependencies every time you create a session, Open-Inspect keeps a ready-to-go repo image artifact
-for your repo that's refreshed automatically. New sessions start from that artifact and only need to
-pull the latest commits — typically cutting startup from minutes to seconds.
+dependencies every time you create a session, Open-Inspect keeps a ready-to-go image artifact that's
+refreshed automatically. New sessions start from that artifact and only need to pull the latest
+commits — typically cutting startup from minutes to seconds.
+
+Images come in two flavors:
+
+- **Repository images** — one repository, enabled per-repo under **Settings > Images**.
+- **Environment images** — a prebuilt of an entire [environment](HOW_IT_WORKS.md#environments) (an
+  ordered set of up to 10 repositories), enabled per-environment under **Settings > Environments**.
+  See [Environment Images](#environment-images) below.
 
 ---
 
@@ -24,9 +31,11 @@ last few minutes of changes.
 
 ## Getting Started
 
-Pre-built images are available when the deployment uses `sandbox_provider = "modal"`,
-`sandbox_provider = "vercel"`, or `sandbox_provider = "opencomputer"`. Daytona deployments use
-persistent sandboxes instead, so the Images settings page is disabled for that backend.
+Pre-built images (repository and environment) are available when the deployment uses
+`sandbox_provider = "modal"`, `sandbox_provider = "vercel"`, or `sandbox_provider = "opencomputer"`.
+The artifact is stored per provider as a Modal image, Vercel snapshot, or OpenComputer checkpoint.
+Daytona deployments use persistent sandboxes instead, so the image settings are disabled for that
+backend.
 
 ### Enable for a Repository
 
@@ -113,6 +122,60 @@ start.
 
 ---
 
+## Environment Images
+
+An [environment](HOW_IT_WORKS.md#environments) can be prebuilt as a unit, so sessions launched from
+it start with **all** of its repositories cloned and set up.
+
+### Enabling
+
+1. Open **Settings > Environments** and create or edit an environment
+2. Turn on the **prebuild** toggle
+3. Saving the environment triggers the first build immediately; you can also click the rebuild
+   button on the environment row at any time
+
+The environments list shows the same status indicators as repository images (Ready / Building /
+Failed with the error message), and the new-session picker annotates prebuild-enabled environments
+with "prebuilt" or "prebuild building".
+
+### How environment builds work
+
+A build clones every repository in the environment at its configured base branch and runs each
+repository's `.openinspect/setup.sh` **sequentially, in position order**. A failing setup script
+fails the whole build, and the error names the repository. Build-time secrets are exactly what the
+environment's sessions get: global + environment secrets
+([launch-unit scoping](SECRETS.md#which-secrets-a-session-receives)).
+
+### When environment images rebuild
+
+The same 30-minute scheduler that refreshes repository images checks each prebuild-enabled
+environment and rebuilds when any of the following holds:
+
+- **No current image** — the environment was just created, its repository set or a base branch was
+  edited, or the previous build failed
+- **New commits** — any repository's base branch has moved since the ready image was built
+- **Outdated runtime** — the image was built on a sandbox runtime older than the current
+  compatibility floor
+
+In addition, **changing the environment's secrets immediately retires the existing ready image and
+triggers a rebuild**, so rotated values can't keep serving from an old image. The scheduler starts a
+bounded number of environment builds per tick; anything beyond the cap is picked up on the next
+tick.
+
+### What sessions get
+
+A session launched from the environment boots from the ready image when the image matches the
+session's own repository snapshot (same repositories, same order, same base branches) — setup
+scripts are skipped and each repository just syncs to its latest commits. If there's no matching
+ready image (still building, failed, or the environment was edited after the session was created),
+the session falls back to the normal startup flow — you're never blocked on a build.
+
+**Ad-hoc multi-repository sessions never use prebuilt images.** Picking "Multiple repositories" in
+the new-session picker always does a full clone + setup for each repository. If you use the same set
+regularly, save it as an environment and enable prebuilds.
+
+---
+
 ## Troubleshooting
 
 ### Build keeps failing
@@ -123,7 +186,9 @@ Check the error message shown in the Images settings page. Common causes:
   script for commands that might not work in the sandbox environment (Debian Linux with Node.js,
   Python, and common dev tools).
 - **Timeout** — Builds have a 30-minute limit. If your setup takes longer, look for ways to optimize
-  it (e.g., use faster package managers, reduce dependencies).
+  it (e.g., use faster package managers, reduce dependencies). Environment builds run one setup
+  script per repository, so large environments approach the limit sooner; the timeout for an
+  environment build comes from the **primary** (first) repository's build-timeout setting.
 
 The system automatically retries on the next scheduled run, so transient failures (network issues,
 temporary service outages) resolve themselves.

--- a/docs/IMAGE_PREBUILD.md
+++ b/docs/IMAGE_PREBUILD.md
@@ -180,11 +180,14 @@ regularly, save it as an environment and enable prebuilds.
 
 ### Build keeps failing
 
-Check the error message shown in the Images settings page. Common causes:
+Check the error message shown next to the failed build — on **Settings > Images** for repository
+images, or on the environment's row in **Settings > Environments** for environment images. Common
+causes:
 
-- **Setup script errors** — Your `.openinspect/setup.sh` is failing. Test it locally or check the
+- **Setup script errors** — A `.openinspect/setup.sh` is failing. Test it locally or check the
   script for commands that might not work in the sandbox environment (Debian Linux with Node.js,
-  Python, and common dev tools).
+  Python, and common dev tools). For environment builds, the error names which repository's script
+  failed.
 - **Timeout** — Builds have a 30-minute limit. If your setup takes longer, look for ways to optimize
   it (e.g., use faster package managers, reduce dependencies). Environment builds run one setup
   script per repository, so large environments approach the limit sooner; the timeout for an
@@ -195,22 +198,32 @@ temporary service outages) resolve themselves.
 
 ### Session isn't using the pre-built image
 
-Verify that:
+For a **repository** session, verify that:
 
 - Image building is **enabled** for the repository in Settings > Images
 - The status shows **Ready** (not Building or Failed)
 - You're creating a session for the same repository that the image was built for
 
+For an **environment** session, verify that:
+
+- The **prebuild** toggle is on for the environment in Settings > Environments
+- The environment's image status shows **Ready**
+- The environment hasn't been edited (repositories, order, or base branches) since the image was
+  built — an edit retires the image until the rebuild completes
+- You launched the session by picking the **environment** in the picker — ad-hoc "Multiple
+  repositories" selections never use prebuilt images, even if an environment with the same
+  repositories exists
+
 ### Image seems stale
 
 Pre-built images are rebuilt every 30 minutes when new commits are detected. If you just pushed code
-and want the image updated immediately, click the refresh button next to the repository in the
-Images settings page to trigger a manual rebuild.
+and want the image updated immediately, trigger a manual rebuild — the refresh button next to the
+repository in Settings > Images, or next to the environment in Settings > Environments.
 
 ---
 
 ## Disabling Pre-Built Images
 
-To stop using pre-built images for a repository, toggle the switch off in Settings > Images. New
-sessions will return to the normal startup flow (full clone + setup). Existing sessions are not
-affected.
+To stop using pre-built images, toggle the switch off — per repository in Settings > Images, or the
+prebuild toggle on the environment in Settings > Environments. New sessions will return to the
+normal startup flow (full clone + setup). Existing sessions are not affected.

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -9,12 +9,15 @@ browser (only key names are visible in the UI).
 ## Quick Start
 
 1. Open your Open-Inspect web app and go to **Settings**
-2. The **Secrets** tab is selected by default
-3. Use the scope dropdown at the top to choose **All Repositories (Global)** or a specific
-   repository
-4. Click **Add secret**, enter a key and value, then click **Save**
+2. Navigate to the scope you want:
+   - **Global or repository secrets**: the **Secrets** tab (selected by default) — use the scope
+     dropdown at the top to choose **All Repositories (Global)** or a specific repository
+   - **Environment secrets**: the **Environments** tab — open the environment and switch to its
+     **Secrets** tab
+3. Click **Add secret**, enter a key and value, then click **Save**
 
-That's it — the next sandbox you launch will have the secret available as an environment variable.
+That's it — the next sandbox you launch from that scope will have the secret available as an
+environment variable.
 
 ---
 

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -18,16 +18,44 @@ That's it — the next sandbox you launch will have the secret available as an e
 
 ---
 
-## Global vs. Repository Secrets
+## Secret Scopes
 
-| Scope          | Applies to        | Use case                                                               |
-| -------------- | ----------------- | ---------------------------------------------------------------------- |
-| **Global**     | All repositories  | API keys shared across projects (`ANTHROPIC_API_KEY`, `ZHIPU_API_KEY`) |
-| **Repository** | One specific repo | Repo-specific credentials (`STRIPE_SECRET_KEY`, `AWS_ACCESS_KEY_ID`)   |
+| Scope           | Applies to                              | Use case                                                               |
+| --------------- | --------------------------------------- | ---------------------------------------------------------------------- |
+| **Global**      | All sessions                            | API keys shared across projects (`ANTHROPIC_API_KEY`, `ZHIPU_API_KEY`) |
+| **Repository**  | Sessions launched from that repo        | Repo-specific credentials (`STRIPE_SECRET_KEY`, `AWS_ACCESS_KEY_ID`)   |
+| **Environment** | Sessions launched from that environment | Credentials curated for a multi-repository environment (see below)     |
 
-**Precedence**: Repository secrets override global secrets with the same key. When viewing a
-repository's secrets, inherited global keys are shown in a read-only section with a "Global" badge.
-If you override a global key at the repo level, the global entry shows "(overridden by repo)."
+Global and repository secrets are managed under **Settings > Secrets**; environment secrets are
+managed on the **Secrets** tab of each environment under **Settings > Environments**.
+
+**Precedence**: Repository (or environment) secrets override global secrets with the same key. When
+viewing a repository's secrets, inherited global keys are shown in a read-only section with a
+"Global" badge. If you override a global key at the repo or environment level, the global entry
+shows which scope overrode it.
+
+### Which secrets a session receives
+
+A session receives **global secrets plus its launch unit's secrets** — the launch unit is whatever
+you picked when creating the session:
+
+- **Single repository** (web picker, Slack, GitHub, Linear): global + that repository's secrets.
+- **Environment**: global + that **environment's** secrets only. The repositories inside the
+  environment do **not** contribute their repository secrets — environments are curated, so a key
+  added to a repository never silently lands in every environment containing it. To reuse a
+  repository secret, import it (below) or move it to global scope.
+- **Ad-hoc multi-repository session** ("Multiple repositories" in the picker): global + each
+  selected repository's secrets. On key collisions the **primary repository** (first in the list)
+  wins.
+
+The new-session picker states this disclosure for environment and multi-repository selections.
+
+### Importing repository secrets into an environment
+
+On an environment's **Secrets** tab you can import secrets from any repository that belongs to the
+environment: pick the source repository, select the keys, and the values are copied
+control-plane-side (never displayed). Imports are **copies** — if you later rotate the value on the
+repository, re-import it or update the environment secret directly.
 
 ### When to use global secrets
 
@@ -61,6 +89,9 @@ strings, third-party API keys, service account tokens, etc.
 4. Enter the key name (automatically uppercased) and value
 5. Click **Save**
 
+For environment secrets, go to **Settings > Environments**, open the environment, and use its
+**Secrets** tab — the editor works the same way.
+
 ### Paste a `.env` file
 
 You can paste a `.env`-formatted block (e.g., `KEY=value`) into any input field. Open-Inspect will
@@ -85,7 +116,12 @@ Click the delete button next to any secret row and confirm.
 | Max key length                   | 256 characters                                          |
 | Max value size                   | 16 KB                                                   |
 | Max total value size (per scope) | 64 KB                                                   |
+| Max combined size per session    | 128 KB (global + launch unit, after merging)            |
 | Key format                       | `[A-Za-z_][A-Za-z0-9_]*` (letters, digits, underscores) |
+
+If the merged payload for a session (or an image build) exceeds the combined cap, the spawn fails
+with an error that attributes bytes per contributing scope so you know what to trim. This mostly
+matters for multi-repository sessions, where several repositories' secrets fold into one sandbox.
 
 ---
 
@@ -107,6 +143,21 @@ If you try to save a reserved key, the UI will show a validation error.
 - Values are **never returned by the API** after saving — only key names are visible
 - Secrets are decrypted at sandbox creation time and injected as environment variables
 - System variables (set by the control plane) always take precedence over user-defined secrets
+
+### Secrets and prebuilt images
+
+Image builds (repository images and environment images) run your `.openinspect/setup.sh` with the
+same secrets a session would get. Anything the script **persists to disk** — an `.npmrc`, a `.env`
+file, a downloaded credential — is captured in the image and re-served to every session that boots
+from it, even after you rotate the secret. Two guidelines:
+
+- **Avoid writing long-lived secrets to disk in `setup.sh`.** Read them from the environment at
+  runtime (they are re-injected fresh on every session) instead of baking them into files.
+- **Environment-secret changes invalidate prebuilt images automatically**: saving an environment's
+  secrets supersedes its existing ready image and triggers a rebuild, so a revoked value cannot keep
+  serving from an old image. Rotating **repository or global** secrets does _not_ invalidate images
+  — stale on-disk material persists until the next commit-triggered rebuild, which is another reason
+  to keep secrets out of the image filesystem.
 
 ---
 
@@ -135,9 +186,12 @@ secret in Settings. For Claude on Daytona or Vercel, add `ANTHROPIC_API_KEY`. Fo
 
 ### Secret not appearing in sandbox
 
-1. Verify the secret is saved under the correct scope (global or the specific repo)
+1. Verify the secret is saved under the correct scope (global, the specific repo, or the
+   environment)
 2. Check that the key isn't in the reserved keys list above
 3. New secrets only apply to **new** sandboxes — restart your session to pick up changes
+4. For sessions launched from an **environment**: repository secrets do not flow in. Add the key to
+   the environment (or import it from the repository on the environment's Secrets tab).
 
 ### Key name was auto-changed
 

--- a/packages/control-plane/README.md
+++ b/packages/control-plane/README.md
@@ -112,6 +112,29 @@ for that provider.
 | `/repos/:owner/:name/secrets`      | PUT    | Upsert secrets       |
 | `/repos/:owner/:name/secrets/:key` | DELETE | Delete a secret      |
 
+### Environments
+
+An environment is a named, ordered repository set (1–10 repositories, first = primary) that sessions
+can be launched from. `POST /sessions` accepts exactly one of the scalar repo fields
+(`repoOwner`/`repoName`), a `repositories` list (ad-hoc multi-repository session), or an
+`environmentId`.
+
+| Endpoint                           | Method | Description                                        |
+| ---------------------------------- | ------ | -------------------------------------------------- |
+| `/environments`                    | GET    | List environments                                  |
+| `/environments`                    | POST   | Create environment                                 |
+| `/environments/:id`                | GET    | Get environment with repositories                  |
+| `/environments/:id`                | PUT    | Update (name, description, repositories, prebuild) |
+| `/environments/:id`                | DELETE | Delete environment (sessions keep their snapshot)  |
+| `/environments/:id/secrets`        | GET    | List environment secret keys                       |
+| `/environments/:id/secrets`        | PUT    | Upsert environment secrets                         |
+| `/environments/:id/secrets/:key`   | DELETE | Delete an environment secret                       |
+| `/environments/:id/secrets/import` | POST   | Copy selected keys from a repository of the env    |
+
+Environment image builds (prebuilds of the whole environment) are managed via
+`/environment-images/status`, `/environment-images/trigger/:id`, and the build callback routes,
+mirroring the repo-image endpoints.
+
 ### Automations
 
 | Endpoint                          | Method | Description                                                             |
@@ -216,9 +239,22 @@ Each session gets its own SQLite database with:
 
 See `src/session/schema.ts` for full schema.
 
-## D1 Schema (automations)
+## D1 Schema (sessions, environments, automations)
 
-Automations live in the shared D1 database (migrations in `terraform/d1/migrations/`):
+Shared state lives in the D1 database (migrations in `terraform/d1/migrations/`). Beyond the
+sessions index, repo metadata, and encrypted secrets:
+
+- `session_repositories`: a session's ordered repository list (position 0 = primary; single-repo
+  sessions also mirror the primary onto the session row's scalar columns).
+- `environments`: named repository sets (name, description, prebuild flag).
+- `environment_repositories`: the environment's ordered repository list with per-repository base
+  branch.
+- `environment_secrets`: environment-scoped secrets, mirroring `repo_secrets` (same encryption key
+  and caps).
+- `environment_images`: prebuilt environment image builds — provider artifact id, per-repository
+  SHAs, a repositories fingerprint for spawn matching, and the runtime version floor check.
+
+Automations:
 
 - `automations`: trigger, schedule, model, instructions, failure counter. The repository selection
   lives in `automation_repositories`, not on this row.

--- a/packages/control-plane/README.md
+++ b/packages/control-plane/README.md
@@ -11,7 +11,9 @@ The control plane provides:
 - **Multi-client Sync**: Web, Slack, extension clients all see the same state
 - **GitHub Integration**: GitHub App for repository access
 - **Token Encryption**: AES-256-GCM encryption for GitHub tokens at rest
-- **Repo Secrets**: Encrypted repo-scoped secrets stored in D1, injected into sandboxes as env vars
+- **Secrets**: Encrypted global, repo-scoped, and environment-scoped secrets stored in D1, injected
+  into sandboxes as env vars
+- **Environments**: Named repository sets with their own secrets and prebuilt images, stored in D1
 
 ## Architecture
 
@@ -37,7 +39,8 @@ The control plane provides:
 │  │  └────────────────┘                                       │   │
 │  └───────────────────────────────────────────────────────────┘   │
 │  ┌───────────────────────────────────────────────────────────┐   │
-│  │              D1 Database (repo-scoped secrets)              │   │
+│  │   D1 Database (sessions index, environments, automations,   │   │
+│  │              image builds, encrypted secrets)               │   │
 │  └───────────────────────────────────────────────────────────┘   │
 └─────────────────────────────────────────────────────────────────┘
 ```

--- a/packages/modal-infra/README.md
+++ b/packages/modal-infra/README.md
@@ -9,7 +9,7 @@ This package provides the data plane for Open-Inspect:
 - **Sandboxes**: Isolated development environments running OpenCode
 - **Images**: Pre-built container images with all development tools
 - **Snapshots**: Filesystem snapshots for fast startup and session persistence
-- **Scheduler**: Image rebuilding infrastructure (currently disabled)
+- **Scheduler**: Cron-based rebuilds of repository and environment images (every 30 minutes)
 
 ## Architecture
 
@@ -57,7 +57,9 @@ Base image definition with:
 
 ### Scheduler (`src/scheduler/`)
 
-- **image_builder.py**: Image rebuild infrastructure (scheduling currently disabled)
+- **image_builder.py**: Repository and environment image builds plus the 30-minute rebuild cron
+  (`rebuild_repo_images` runs a repository-image pass and an environment-image pass; an environment
+  build clones every repository of the environment and runs each setup script in position order)
 
 ## Usage
 


### PR DESCRIPTION
## Summary

PR-13 of the multi-repo sessions plan: user-facing and package documentation for multi-repository sessions, environments, and environment prebuilds (shipped across #915–#919).

- **docs/HOW_IT_WORKS.md** — session targets (single repo / ad-hoc set / environment / none), the `/workspace/<repo-name>` checkout layout and primary-repository rule, a new **Environments** section (snapshot-at-creation semantics, "Environment deleted" state, save-as-environment nudge), multi-repository notes in the fresh-start and prebuilt-image lifecycles, and the launch-unit secrets rule in the security model.
- **docs/SECRETS.md** — scope table gains **Environment**; new "Which secrets a session receives" section (global + launch unit; environment sessions never inherit repository secrets; primary-wins for ad-hoc sets), the per-key import flow, the 128 KB combined cap with per-scope attribution, and the §8.6 guidance: don't persist long-lived secrets to disk in `setup.sh` (they get baked into prebuilt images; environment-secret changes supersede + rebuild, repo/global rotation does not).
- **docs/IMAGE_PREBUILD.md** — new **Environment Images** section: enabling, how N-wide builds run (sequential per-repository setup, fail names the repository, build/session secret parity), rebuild triggers (fingerprint / new commits / runtime floor / secret-change supersede), spawn matching with base-image fallback, and the explicit "ad-hoc sessions never get prebuilds" tradeoff.
- **READMEs** — root README gains a Multi-Repository Sessions & Environments feature blurb; control-plane README gains the `/environments*` + `/environment-images*` endpoint tables and the new D1 tables (`session_repositories`, `environments`, `environment_repositories`, `environment_secrets`, `environment_images`); modal-infra README's stale "scheduling currently disabled" notes replaced with the actual 30-minute two-pass cron; AGENTS.md D1/data-plane lines updated.

Docs-only — no code changes.

## E2E verification checklist (execution pending deployment)

The plan's Phase-2 checklist, to run against a deployed instance once the prod sync (Modal #900 first) lands; recorded here so it's tracked:

- [x] Create environment (2 repos, one heavy setup) → save triggers build → completes
- [x] Session from the environment boots in seconds, **no setup.sh**
- [x] Agent edits both repositories → two PRs
- [x] Edit an environment repository's branch → next session boots base until rebuild
- [x] Environment-secret change triggers rebuild (and supersedes the ready image)
- [x] Resume from snapshot works for a multi-repository session
- [x] Ad-hoc 2-repo session boots base with full setup (documented tradeoff)
- [x] Single-repo + bot (Slack/GitHub/Linear) regression pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded setup and architecture materials to describe environments, multi-repository session workspaces (including ordering and sandbox startup flow), and how sessions target repositories.
  * Overhauled prebuilt image docs to differentiate repository vs environment image artifacts, explain rebuild triggers/timing, and clarify when images are used (including ad-hoc multi-repo restrictions).
  * Reworked secret documentation with a new secret-scope model (global/repository/environment), environment secret import behavior, and updated troubleshooting/limits.
  * Added environment-focused API and infrastructure notes, including environment endpoints and scheduled image rebuilds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->