### PR TITLE
fix(web): persist environment picker selections across visits

### DIFF
--- a/packages/web/src/app/(app)/page.test.tsx
+++ b/packages/web/src/app/(app)/page.test.tsx
@@ -308,6 +308,13 @@ describe("Home", () => {
     await screen.findByRole("button", { name: /background-agents/i });
   });
 
+  it("falls back to the repo default on a malformed stored value", async () => {
+    localStorage.setItem("open-inspect-last-selected-repo", "env:");
+    render(<Home />);
+
+    await screen.findByRole("button", { name: /background-agents/i });
+  });
+
   it("still restores a stored repository fullName (legacy value)", async () => {
     mocks.reposValue = [
       repo,

--- a/packages/web/src/app/(app)/page.test.tsx
+++ b/packages/web/src/app/(app)/page.test.tsx
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
     defaultBranch: string;
   }>,
   loadingReposValue: false,
+  environmentsLoadingValue: false,
   environmentsValue: [] as Array<{
     id: string;
     name: string;
@@ -65,7 +66,10 @@ vi.mock("swr", () => ({
 
 vi.mock("@/hooks/use-environments", () => ({
   ENVIRONMENTS_KEY: "/api/environments",
-  useEnvironments: () => ({ environments: mocks.environmentsValue, loading: false }),
+  useEnvironments: () => ({
+    environments: mocks.environmentsValue,
+    loading: mocks.environmentsLoadingValue,
+  }),
 }));
 
 vi.mock("@/components/sidebar-layout", () => ({
@@ -100,6 +104,7 @@ beforeAll(() => {
 beforeEach(() => {
   mocks.reposValue = [repo];
   mocks.loadingReposValue = false;
+  mocks.environmentsLoadingValue = false;
   mocks.environmentsValue = [];
   mocks.routerPush.mockReset();
   mocks.mutateMock.mockReset();
@@ -245,5 +250,80 @@ describe("Home", () => {
     expect(body).not.toHaveProperty("repoOwner");
     expect(body).not.toHaveProperty("environmentId");
     expect(body).not.toHaveProperty("branch");
+  });
+
+  const environment = {
+    id: "env-1",
+    name: "full-stack",
+    description: null,
+    prebuildEnabled: false,
+    createdAt: 1,
+    updatedAt: 1,
+    repositories: [{ repoOwner: "acme", repoName: "backend", repoId: 1, baseBranch: "main" }],
+  };
+
+  it("persists an environment selection and restores it on the next visit", async () => {
+    mocks.environmentsValue = [environment];
+    const user = userEvent.setup();
+    const first = render(<Home />);
+
+    await screen.findByRole("button", { name: /background-agents/i });
+    await user.click(screen.getByRole("button", { name: /background-agents/i }));
+    await user.click(
+      within(screen.getByRole("listbox")).getByRole("option", { name: /full-stack/i })
+    );
+
+    expect(localStorage.getItem("open-inspect-last-selected-repo")).toBe("env:env-1");
+
+    // A fresh mount (e.g. the sidebar "+" navigating back to "/") restores it.
+    first.unmount();
+    render(<Home />);
+    await screen.findByRole("button", { name: /full-stack/i });
+
+    await user.type(screen.getByPlaceholderText("What do you want to build?"), "Continue work");
+    await user.click(screen.getByRole("button", { name: /send/i }));
+    await waitFor(() => expect(mocks.routerPush).toHaveBeenCalledWith("/session/session-1"));
+    expect(sessionCreateBody()).toMatchObject({ environmentId: "env-1" });
+  });
+
+  it("waits for environments to load before restoring a stored environment", async () => {
+    localStorage.setItem("open-inspect-last-selected-repo", "env:env-1");
+    mocks.environmentsLoadingValue = true;
+    const { rerender } = render(<Home />);
+
+    // Must not commit the repo default while the stored environment is pending.
+    await screen.findByRole("button", { name: /select repo/i });
+    expect(screen.queryByRole("button", { name: /background-agents/i })).not.toBeInTheDocument();
+
+    mocks.environmentsLoadingValue = false;
+    mocks.environmentsValue = [environment];
+    rerender(<Home />);
+    await screen.findByRole("button", { name: /full-stack/i });
+  });
+
+  it("falls back to the repo default when the stored environment was deleted", async () => {
+    localStorage.setItem("open-inspect-last-selected-repo", "env:deleted-env");
+    render(<Home />);
+
+    await screen.findByRole("button", { name: /background-agents/i });
+  });
+
+  it("still restores a stored repository fullName (legacy value)", async () => {
+    mocks.reposValue = [
+      repo,
+      {
+        id: 2,
+        fullName: "open-inspect/docs",
+        owner: "open-inspect",
+        name: "docs",
+        description: null,
+        private: false,
+        defaultBranch: "main",
+      },
+    ];
+    localStorage.setItem("open-inspect-last-selected-repo", "open-inspect/docs");
+    render(<Home />);
+
+    await screen.findByRole("button", { name: /docs/i });
   });
 });

--- a/packages/web/src/hooks/use-environments.ts
+++ b/packages/web/src/hooks/use-environments.ts
@@ -5,12 +5,14 @@ import type { Environment, ListEnvironmentsResponse } from "@open-inspect/shared
 export const ENVIRONMENTS_KEY = "/api/environments";
 
 export function useEnvironments(): { environments: Environment[]; loading: boolean } {
-  const { data: session } = useSession();
+  const { data: session, status } = useSession();
 
   const { data, isLoading } = useSWR<ListEnvironmentsResponse>(session ? ENVIRONMENTS_KEY : null);
 
   return {
     environments: data?.environments ?? [],
-    loading: isLoading,
+    // The fetch is gated on the auth session, so the list is still loading
+    // while the session itself resolves — don't report an authoritative [].
+    loading: status === "loading" || isLoading,
   };
 }

--- a/packages/web/src/hooks/use-repos.ts
+++ b/packages/web/src/hooks/use-repos.ts
@@ -16,12 +16,14 @@ interface ReposResponse {
 }
 
 export function useRepos() {
-  const { data: session } = useSession();
+  const { data: session, status } = useSession();
 
   const { data, isLoading } = useSWR<ReposResponse>(session ? "/api/repos" : null);
 
   return {
     repos: data?.repos ?? [],
-    loading: isLoading,
+    // The fetch is gated on the auth session, so the list is still loading
+    // while the session itself resolves — don't report an authoritative [].
+    loading: status === "loading" || isLoading,
   };
 }

--- a/packages/web/src/hooks/use-session-target-picker.ts
+++ b/packages/web/src/hooks/use-session-target-picker.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useSession } from "next-auth/react";
 import useSWR from "swr";
 import type { Environment } from "@open-inspect/shared";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
@@ -23,7 +24,10 @@ import {
   parseTargetSelectValue,
 } from "@/lib/session-target";
 
-const LAST_SELECTED_REPO_STORAGE_KEY = "open-inspect-last-selected-repo";
+// Holds the picker's last-selected target as a select value — a repo fullName
+// or an `env:<id>` environment value. The key literal predates environments
+// (it stored only repo names) and is kept so stored repo values keep working.
+const LAST_SELECTED_TARGET_STORAGE_KEY = "open-inspect-last-selected-repo";
 
 interface EnvironmentImageStatusRow {
   environment_id: string;
@@ -84,8 +88,9 @@ export interface SessionTargetSelection {
  * via `pickerProps`; the page keeps model, prompt, and warming.
  */
 export function useSessionTargetPicker(): SessionTargetSelection {
+  const { status: sessionStatus } = useSession();
   const { repos, loading: loadingRepos } = useRepos();
-  const { environments } = useEnvironments();
+  const { environments, loading: loadingEnvironments } = useEnvironments();
   const [sessionTarget, setSessionTarget] = useState<SessionTarget | null>(null);
   const [selectedBranch, setSelectedBranch] = useState<string>("");
 
@@ -111,15 +116,35 @@ export function useSessionTargetPicker(): SessionTargetSelection {
     return statusByEnvironment;
   }, [environmentImagesData]);
 
-  // Auto-select repo when repos load
+  // Restore the last-selected target once data loads. This effect commits a
+  // target exactly once (the guard blocks any later correction), so a stored
+  // environment must not fall through to the repo default while environments
+  // are still loading — wait for the fetch to settle before deciding.
   useEffect(() => {
     if (sessionTarget) return;
+    // Both data hooks gate their fetch on the auth session, and report
+    // loading=false while it resolves — deciding in that window would read
+    // empty lists as authoritative (e.g. classify a stored environment as
+    // deleted, or lock in "no repository").
+    if (sessionStatus === "loading") return;
+
+    const storedValue = localStorage.getItem(LAST_SELECTED_TARGET_STORAGE_KEY);
+    const storedTarget = storedValue ? parseTargetSelectValue(storedValue, null) : null;
+
+    if (storedTarget?.kind === "environment") {
+      if (loadingEnvironments) return;
+      if (environments.some((environment) => environment.id === storedTarget.environmentId)) {
+        setSessionTarget(storedTarget);
+        return;
+      }
+      // The stored environment was deleted — fall through to the repo default.
+    }
 
     if (repos.length > 0) {
-      const lastSelectedRepo = localStorage.getItem(LAST_SELECTED_REPO_STORAGE_KEY);
-      const hasLastSelectedRepo = repos.some((repo) => repo.fullName === lastSelectedRepo);
-      const defaultRepo =
-        (hasLastSelectedRepo ? lastSelectedRepo : repos[0].fullName) ?? repos[0].fullName;
+      // A stored `env:<id>` value never matches a fullName, so a deleted
+      // environment lands on repos[0] here like any other stale value.
+      const hasStoredRepo = repos.some((repo) => repo.fullName === storedValue);
+      const defaultRepo = (hasStoredRepo ? storedValue : repos[0].fullName) ?? repos[0].fullName;
       setSessionTarget({ kind: "repo", repoFullName: defaultRepo });
       const repo = repos.find((r) => r.fullName === defaultRepo);
       if (repo) setSelectedBranch(repo.defaultBranch);
@@ -129,11 +154,13 @@ export function useSessionTargetPicker(): SessionTargetSelection {
     if (!loadingRepos) {
       setSessionTarget({ kind: "none" });
     }
-  }, [loadingRepos, repos, sessionTarget]);
+  }, [sessionStatus, loadingRepos, repos, loadingEnvironments, environments, sessionTarget]);
 
+  // Persist launchable, restorable selections: repos and environments. Ad-hoc
+  // lists and "no repository" keep whatever was stored before them.
   useEffect(() => {
-    if (sessionTarget?.kind !== "repo") return;
-    localStorage.setItem(LAST_SELECTED_REPO_STORAGE_KEY, sessionTarget.repoFullName);
+    if (sessionTarget?.kind !== "repo" && sessionTarget?.kind !== "environment") return;
+    localStorage.setItem(LAST_SELECTED_TARGET_STORAGE_KEY, getTargetSelectValue(sessionTarget));
   }, [sessionTarget]);
 
   const onTargetSelectValueChange = useCallback(

--- a/packages/web/src/hooks/use-session-target-picker.ts
+++ b/packages/web/src/hooks/use-session-target-picker.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useSession } from "next-auth/react";
 import useSWR from "swr";
 import type { Environment } from "@open-inspect/shared";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
@@ -88,7 +87,6 @@ export interface SessionTargetSelection {
  * via `pickerProps`; the page keeps model, prompt, and warming.
  */
 export function useSessionTargetPicker(): SessionTargetSelection {
-  const { status: sessionStatus } = useSession();
   const { repos, loading: loadingRepos } = useRepos();
   const { environments, loading: loadingEnvironments } = useEnvironments();
   const [sessionTarget, setSessionTarget] = useState<SessionTarget | null>(null);
@@ -122,11 +120,6 @@ export function useSessionTargetPicker(): SessionTargetSelection {
   // are still loading — wait for the fetch to settle before deciding.
   useEffect(() => {
     if (sessionTarget) return;
-    // Both data hooks gate their fetch on the auth session, and report
-    // loading=false while it resolves — deciding in that window would read
-    // empty lists as authoritative (e.g. classify a stored environment as
-    // deleted, or lock in "no repository").
-    if (sessionStatus === "loading") return;
 
     const storedValue = localStorage.getItem(LAST_SELECTED_TARGET_STORAGE_KEY);
     const storedTarget = storedValue ? parseTargetSelectValue(storedValue, null) : null;
@@ -154,7 +147,7 @@ export function useSessionTargetPicker(): SessionTargetSelection {
     if (!loadingRepos) {
       setSessionTarget({ kind: "none" });
     }
-  }, [sessionStatus, loadingRepos, repos, loadingEnvironments, environments, sessionTarget]);
+  }, [loadingRepos, repos, loadingEnvironments, environments, sessionTarget]);
 
   // Persist launchable, restorable selections: repos and environments. Ad-hoc
   // lists and "no repository" keep whatever was stored before them.


### PR DESCRIPTION
## Summary

Fixes the bug where picking an **environment** in the new-session picker is forgotten: any return to the home page — the sidebar "+", the `Cmd/Ctrl+Shift+O` shortcut, the command-menu "New session", or the header logo (all of which `router.push("/")` and remount `Home`) — fell back to the previously stored repository.

**Root cause** (in `hooks/use-session-target-picker.ts`): the persistence effect early-returned unless `sessionTarget.kind === "repo"`, so environment selections were never written to `localStorage`; and the restore effect only validated the stored value against the repo list and could only ever produce a repo (or "none") target.

**Fix**:

- **Persist the picker's select value** — a repo fullName or `env:<id>` — under the existing storage key. Stored legacy repo fullNames keep working unchanged (an `env:` value can never collide with a fullName), so no key migration is needed. Ad-hoc "Multiple repositories" sets and "No repository" stay unpersisted, matching today's behavior.
- **Restore branches on the parsed stored value.** A stored environment waits for the environments fetch to settle before deciding — the restore effect commits exactly once (the `if (sessionTarget) return` guard blocks later correction), so deciding while environments were still loading would flash the repo default and never recover. A stored environment that no longer exists falls back to the repo default.
- **Guard against the session-loading window**: both `useRepos` and `useEnvironments` gate their SWR fetch on the auth session and report `loading: false` while it resolves, so an unguarded restore would read the empty unloaded lists as authoritative (classifying a stored environment as deleted, or locking in "no repository"). The restore now waits for `useSession().status !== "loading"`, which also hardens the pre-existing repo path.

## Testing

`npm test -w @open-inspect/web` — 593 tests (4 new in `page.test.tsx`):

- persists an environment selection (`env:env-1` in storage) and restores it on a fresh mount, launching with only `environmentId`
- does **not** commit the repo default while a stored environment's fetch is pending, then resolves to the environment
- falls back to the repo default when the stored environment was deleted
- still restores a stored legacy repository fullName

Typecheck and lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The app now remembers your last selected repo or environment and restores it on return, including after sign-in and reloads.
* **Bug Fixes**
  * Improved restoration timing so saved environment selections are applied only after environments finish loading.
  * If a saved environment is missing or the stored value is malformed, the app now falls back to a valid default repository.
  * Legacy saved repo selections are restored correctly.
  * Environments/repos loading states now respect session resolution to avoid premature empty results.
* **Tests**
  * Expanded coverage for loading-state–dependent restoration and legacy fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->