### PR TITLE
fix: use sandbox filesystem for tunnel env writes

### DIFF
--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -294,11 +294,7 @@ class SandboxManager:
         lines = [f"TUNNEL_{port}={url}" for port, url in sorted(tunnel_urls.items())]
         content = "\n".join(lines) + "\n"
         try:
-            f = await sandbox.open.aio(TUNNEL_ENV_FILE_PATH, "w")
-            try:
-                await f.write.aio(content)
-            finally:
-                await f.close.aio()
+            await sandbox.filesystem.write_text.aio(content, TUNNEL_ENV_FILE_PATH)
             log.info(
                 "tunnel.urls_written",
                 sandbox_id=sandbox_id,

--- a/packages/modal-infra/tests/test_tunnel_ports.py
+++ b/packages/modal-infra/tests/test_tunnel_ports.py
@@ -14,13 +14,14 @@ from sandbox_runtime.constants import (
 from src.sandbox.manager import CODE_SERVER_PORT, SandboxConfig, SandboxManager
 
 
-def _mock_sandbox_with_open() -> tuple[MagicMock, AsyncMock]:
-    """Return (sandbox, file_handle) with sandbox.open.aio returning the handle."""
-    f = AsyncMock()
+def _mock_sandbox_with_filesystem() -> tuple[MagicMock, AsyncMock]:
+    """Return (sandbox, write_text) with sandbox.filesystem.write_text.aio mocked."""
+    write_text = AsyncMock()
     sandbox = MagicMock()
-    sandbox.open = MagicMock()
-    sandbox.open.aio = AsyncMock(return_value=f)
-    return sandbox, f
+    sandbox.filesystem = MagicMock()
+    sandbox.filesystem.write_text = MagicMock()
+    sandbox.filesystem.write_text.aio = write_text
+    return sandbox, write_text
 
 
 class TestResolveTunnels:
@@ -114,7 +115,7 @@ class TestResolveAndSetupTunnels:
     async def test_resolves_extra_ports(self):
         tunnel_urls = {3000: "https://tunnel-3000.example.com"}
 
-        sandbox, _f = _mock_sandbox_with_open()
+        sandbox, _write_text = _mock_sandbox_with_filesystem()
         with patch.object(
             SandboxManager,
             "_resolve_tunnels",
@@ -142,7 +143,7 @@ class TestResolveAndSetupTunnels:
             3000: "https://tunnel-3000.example.com",
         }
 
-        sandbox, _f = _mock_sandbox_with_open()
+        sandbox, _write_text = _mock_sandbox_with_filesystem()
 
         with patch.object(
             SandboxManager,
@@ -168,7 +169,7 @@ class TestResolveAndSetupTunnels:
     async def test_keeps_code_server_port_tunnel_when_code_server_disabled(self):
         """Regression: a user's own 8080 tunnel is kept, not misrouted to code_server_url."""
         resolved = {CODE_SERVER_PORT: "https://my-app.example.com"}
-        sandbox, _f = _mock_sandbox_with_open()
+        sandbox, _write_text = _mock_sandbox_with_filesystem()
 
         with patch.object(
             SandboxManager,
@@ -197,7 +198,7 @@ class TestResolveAndSetupTunnels:
             8081: "https://cs.example.com",
             CODE_SERVER_PORT: "https://my-app.example.com",
         }
-        sandbox, _f = _mock_sandbox_with_open()
+        sandbox, _write_text = _mock_sandbox_with_filesystem()
 
         with patch.object(
             SandboxManager,
@@ -224,7 +225,7 @@ class TestWriteTunnelEnvFile:
 
     @pytest.mark.asyncio
     async def test_writes_dotenv_format_to_expected_path(self):
-        sandbox, f = _mock_sandbox_with_open()
+        sandbox, write_text = _mock_sandbox_with_filesystem()
 
         await SandboxManager._write_tunnel_env_file(
             sandbox,
@@ -235,35 +236,19 @@ class TestWriteTunnelEnvFile:
             },
         )
 
-        sandbox.open.aio.assert_awaited_once_with(TUNNEL_ENV_FILE_PATH, "w")
-        f.write.aio.assert_awaited_once()
-        written = f.write.aio.call_args[0][0]
+        write_text.assert_awaited_once()
+        written, path = write_text.call_args[0]
+        assert path == TUNNEL_ENV_FILE_PATH
         # Sorted by port, dotenv format, trailing newline.
         assert written == (
             "TUNNEL_3000=https://tunnel-3000.example.com\n"
             "TUNNEL_3001=https://tunnel-3001.example.com\n"
         )
-        f.close.aio.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_closes_file_when_write_raises(self):
-        sandbox, f = _mock_sandbox_with_open()
-        f.write.aio = AsyncMock(side_effect=Exception("write failed"))
-
-        with patch("src.sandbox.manager.log") as mock_log:
-            await SandboxManager._write_tunnel_env_file(
-                sandbox, "sb-1", {3000: "https://tunnel-3000.example.com"}
-            )
-
-        f.close.aio.assert_awaited_once()
-        mock_log.warn.assert_called_once()
-        assert mock_log.warn.call_args[0][0] == "tunnel.urls_write_failed"
-
-    @pytest.mark.asyncio
-    async def test_open_failure_does_not_raise(self):
-        sandbox = MagicMock()
-        sandbox.open = MagicMock()
-        sandbox.open.aio = AsyncMock(side_effect=Exception("open failed"))
+    async def test_write_failure_does_not_raise(self):
+        sandbox, write_text = _mock_sandbox_with_filesystem()
+        write_text.side_effect = Exception("write failed")
 
         with patch("src.sandbox.manager.log") as mock_log:
             await SandboxManager._write_tunnel_env_file(
@@ -279,7 +264,7 @@ class TestResolveAndSetupTunnelsWritesFile:
 
     @pytest.mark.asyncio
     async def test_writes_file_when_extra_urls_present(self):
-        sandbox, f = _mock_sandbox_with_open()
+        sandbox, write_text = _mock_sandbox_with_filesystem()
         tunnel_urls = {3000: "https://tunnel-3000.example.com"}
 
         with patch.object(
@@ -298,13 +283,13 @@ class TestResolveAndSetupTunnelsWritesFile:
                 ttyd_proxy_port=TTYD_PROXY_PORT,
             )
 
-        sandbox.open.aio.assert_awaited_once_with(TUNNEL_ENV_FILE_PATH, "w")
-        written = f.write.aio.call_args[0][0]
+        write_text.assert_awaited_once()
+        written = write_text.call_args[0][0]
         assert "TUNNEL_3000=https://tunnel-3000.example.com" in written
 
     @pytest.mark.asyncio
     async def test_does_not_write_file_when_no_extra_urls(self):
-        sandbox, _f = _mock_sandbox_with_open()
+        sandbox, write_text = _mock_sandbox_with_filesystem()
 
         with patch.object(
             SandboxManager,
@@ -323,12 +308,12 @@ class TestResolveAndSetupTunnelsWritesFile:
             )
 
         assert extra is None
-        sandbox.open.aio.assert_not_called()
+        write_text.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_does_not_write_file_for_only_reserved_ports(self):
         """code-server / ttyd URLs aren't extras; no file is written when those are the only ones."""
-        sandbox, _f = _mock_sandbox_with_open()
+        sandbox, write_text = _mock_sandbox_with_filesystem()
 
         with patch.object(
             SandboxManager,
@@ -346,13 +331,12 @@ class TestResolveAndSetupTunnelsWritesFile:
                 ttyd_proxy_port=TTYD_PROXY_PORT,
             )
 
-        sandbox.open.aio.assert_not_called()
+        write_text.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_write_failure_does_not_block_return(self):
-        sandbox = MagicMock()
-        sandbox.open = MagicMock()
-        sandbox.open.aio = AsyncMock(side_effect=Exception("boom"))
+        sandbox, write_text = _mock_sandbox_with_filesystem()
+        write_text.side_effect = Exception("boom")
 
         with (
             patch.object(


### PR DESCRIPTION
## Summary
- Replace the deprecated sandbox file-handle write path for tunnel env files with the Modal filesystem writer.
- Update tunnel-port tests to mock the filesystem writer while preserving graceful failure behavior.

## Why
Modal deprecates the sandbox file-handle API. Writing through the filesystem API avoids deprecation warnings during sandbox setup.

## Validation
- `uv run ruff check src/sandbox/manager.py tests/test_tunnel_ports.py`
- `uv run ruff format --check src/sandbox/manager.py tests/test_tunnel_ports.py`
- `uv run pytest tests`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving tunnel environment data.
  * Tunnel configuration files are now written through a more robust file-writing path, with the same warning and error handling behavior.
  * Updated validation coverage to ensure tunnel settings are written in the correct order and format, and that write failures do not interrupt tunnel setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->