### PR TITLE
feat(slack): environment channel associations

### DIFF
--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -64,7 +64,9 @@ repositories. The session sidebar lists every repository with its branch and any
 
 Bot-created sessions (GitHub, Linear) remain single-repository. Slack sessions are single-repository
 by default, but a Slack routing rule (Settings › Integrations › Slack) can target an environment,
-launching the full multi-repository workspace from a keyword.
+launching the full multi-repository workspace from a keyword. An environment can also be associated
+with Slack channels (`channelAssociations` on the environments API, like repository metadata):
+messages in an associated channel route to the environment without needing a keyword.
 
 ### Session Lifecycle
 

--- a/packages/control-plane/README.md
+++ b/packages/control-plane/README.md
@@ -122,17 +122,17 @@ can be launched from. `POST /sessions` accepts exactly one of the scalar repo fi
 (`repoOwner`/`repoName`), a `repositories` list (ad-hoc multi-repository session), or an
 `environmentId`.
 
-| Endpoint                           | Method | Description                                        |
-| ---------------------------------- | ------ | -------------------------------------------------- |
-| `/environments`                    | GET    | List environments                                  |
-| `/environments`                    | POST   | Create environment                                 |
-| `/environments/:id`                | GET    | Get environment with repositories                  |
-| `/environments/:id`                | PUT    | Update (name, description, repositories, prebuild) |
-| `/environments/:id`                | DELETE | Delete environment (sessions keep their snapshot)  |
-| `/environments/:id/secrets`        | GET    | List environment secret keys                       |
-| `/environments/:id/secrets`        | PUT    | Upsert environment secrets                         |
-| `/environments/:id/secrets/:key`   | DELETE | Delete an environment secret                       |
-| `/environments/:id/secrets/import` | POST   | Copy selected keys from a repository of the env    |
+| Endpoint                           | Method | Description                                                                     |
+| ---------------------------------- | ------ | ------------------------------------------------------------------------------- |
+| `/environments`                    | GET    | List environments                                                               |
+| `/environments`                    | POST   | Create environment                                                              |
+| `/environments/:id`                | GET    | Get environment with repositories                                               |
+| `/environments/:id`                | PUT    | Update name, description, repositories, prebuild, or Slack channel associations |
+| `/environments/:id`                | DELETE | Delete environment (sessions keep their snapshot)                               |
+| `/environments/:id/secrets`        | GET    | List environment secret keys                                                    |
+| `/environments/:id/secrets`        | PUT    | Upsert environment secrets                                                      |
+| `/environments/:id/secrets/:key`   | DELETE | Delete an environment secret                                                    |
+| `/environments/:id/secrets/import` | POST   | Copy selected keys from a repository of the env                                 |
 
 Environment image builds (prebuilds of the whole environment) are managed via
 `/environment-images/status`, `/environment-images/trigger/:id`, and the build callback routes,
@@ -249,7 +249,8 @@ sessions index, repo metadata, and encrypted secrets:
 
 - `session_repositories`: a session's ordered repository list (position 0 = primary; single-repo
   sessions also mirror the primary onto the session row's scalar columns).
-- `environments`: named repository sets (name, description, prebuild flag).
+- `environments`: named repository sets (name, description, prebuild flag, Slack channel
+  associations).
 - `environment_repositories`: the environment's ordered repository list with per-repository base
   branch.
 - `environment_secrets`: environment-scoped secrets, mirroring `repo_secrets` (same encryption key

--- a/packages/control-plane/src/db/environments.ts
+++ b/packages/control-plane/src/db/environments.ts
@@ -9,12 +9,14 @@
  */
 
 import type { Environment, EnvironmentRepository } from "@open-inspect/shared";
+import { parseJsonStringArray } from "./json-columns";
 
 export interface EnvironmentRow {
   id: string;
   name: string;
   description: string | null;
   prebuild_enabled: number; // SQLite integer boolean
+  channel_associations: string | null; // JSON string array (mirrors repo_metadata)
   created_at: number;
   updated_at: number;
 }
@@ -55,9 +57,22 @@ export function toEnvironment(
     prebuildEnabled: row.prebuild_enabled === 1,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+    channelAssociations: parseJsonStringArray(row.channel_associations),
     repositories: repositoryRows.map(toEnvironmentRepository),
   };
 }
+
+/** The mutable scalar columns of an environment row (everything but id/timestamps). */
+export type EnvironmentScalarFields = Partial<
+  Pick<EnvironmentRow, "name" | "description" | "prebuild_enabled" | "channel_associations">
+>;
+
+const MUTABLE_SCALAR_COLUMNS = [
+  "name",
+  "description",
+  "prebuild_enabled",
+  "channel_associations",
+] as const satisfies readonly (keyof EnvironmentScalarFields)[];
 
 export class EnvironmentStore {
   constructor(private readonly db: D1Database) {}
@@ -66,14 +81,15 @@ export class EnvironmentStore {
     return this.db
       .prepare(
         `INSERT INTO environments
-         (id, name, description, prebuild_enabled, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?)`
+         (id, name, description, prebuild_enabled, channel_associations, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`
       )
       .bind(
         row.id,
         row.name,
         row.description,
         row.prebuild_enabled,
+        row.channel_associations,
         row.created_at,
         row.updated_at
       );
@@ -121,18 +137,13 @@ export class EnvironmentStore {
    */
   bindEnvironmentUpdate(
     id: string,
-    fields: Partial<Pick<EnvironmentRow, "name" | "description" | "prebuild_enabled">>,
+    fields: EnvironmentScalarFields,
     now: number
   ): D1PreparedStatement | null {
     const setClauses: string[] = [];
     const params: unknown[] = [];
 
-    const allowed: (keyof Pick<EnvironmentRow, "name" | "description" | "prebuild_enabled">)[] = [
-      "name",
-      "description",
-      "prebuild_enabled",
-    ];
-    for (const field of allowed) {
+    for (const field of MUTABLE_SCALAR_COLUMNS) {
       if (field in fields) {
         setClauses.push(`${field} = ?`);
         params.push(fields[field] as unknown);
@@ -158,7 +169,7 @@ export class EnvironmentStore {
    */
   async update(
     id: string,
-    fields: Partial<Pick<EnvironmentRow, "name" | "description" | "prebuild_enabled">>,
+    fields: EnvironmentScalarFields,
     repositories?: EnvironmentRepositoryInsert[]
   ): Promise<EnvironmentRow | null> {
     const now = Date.now();

--- a/packages/control-plane/src/db/json-columns.test.ts
+++ b/packages/control-plane/src/db/json-columns.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { parseJsonStringArray } from "./json-columns";
+
+describe("parseJsonStringArray", () => {
+  it("parses a well-formed string array", () => {
+    expect(parseJsonStringArray('["C1","C2"]')).toEqual(["C1", "C2"]);
+    expect(parseJsonStringArray("[]")).toEqual([]);
+  });
+
+  it("reads NULL and empty values as unset", () => {
+    expect(parseJsonStringArray(null)).toBeUndefined();
+    expect(parseJsonStringArray("")).toBeUndefined();
+  });
+
+  it("reads corrupt values as unset instead of failing the row", () => {
+    expect(parseJsonStringArray("not json")).toBeUndefined();
+    expect(parseJsonStringArray('{"a":1}')).toBeUndefined();
+    expect(parseJsonStringArray('"C1"')).toBeUndefined();
+  });
+
+  it("rejects arrays containing non-string elements (the string[] contract)", () => {
+    expect(parseJsonStringArray('["C1", 42, null]')).toBeUndefined();
+    expect(parseJsonStringArray("[42]")).toBeUndefined();
+    expect(parseJsonStringArray('[["C1"]]')).toBeUndefined();
+  });
+});

--- a/packages/control-plane/src/db/json-columns.ts
+++ b/packages/control-plane/src/db/json-columns.ts
@@ -1,14 +1,18 @@
 /**
  * Parse a TEXT column holding a JSON string array (repo_metadata and
- * environments channel-association columns). NULL, malformed JSON, and
- * non-array payloads all read as `undefined` — a corrupt column degrades to
- * "unset" rather than failing the row.
+ * environments channel-association columns). NULL, malformed JSON, non-array
+ * payloads, and arrays with non-string elements all read as `undefined` — the
+ * writers only ever store string arrays, so anything else is a corrupt value
+ * that degrades to "unset" rather than failing the row or leaking junk through
+ * the `string[]` contract.
  */
 export function parseJsonStringArray(value: string | null): string[] | undefined {
   if (!value) return undefined;
   try {
-    const parsed = JSON.parse(value);
-    return Array.isArray(parsed) ? parsed : undefined;
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed) && parsed.every((element) => typeof element === "string")
+      ? parsed
+      : undefined;
   } catch {
     return undefined;
   }

--- a/packages/control-plane/src/db/json-columns.ts
+++ b/packages/control-plane/src/db/json-columns.ts
@@ -1,0 +1,15 @@
+/**
+ * Parse a TEXT column holding a JSON string array (repo_metadata and
+ * environments channel-association columns). NULL, malformed JSON, and
+ * non-array payloads all read as `undefined` — a corrupt column degrades to
+ * "unset" rather than failing the row.
+ */
+export function parseJsonStringArray(value: string | null): string[] | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/control-plane/src/db/repo-metadata.ts
+++ b/packages/control-plane/src/db/repo-metadata.ts
@@ -1,4 +1,5 @@
 import type { RepoMetadata } from "@open-inspect/shared";
+import { parseJsonStringArray } from "./json-columns";
 
 /** D1 batch() supports at most 100 statements per call. */
 const D1_BATCH_LIMIT = 100;
@@ -20,24 +21,14 @@ export interface ImageBuildEnabledRepo {
   repoName: string;
 }
 
-function parseJsonArray(value: string | null): string[] | undefined {
-  if (!value) return undefined;
-  try {
-    const parsed = JSON.parse(value);
-    return Array.isArray(parsed) ? parsed : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 function toMetadata(row: RepoMetadataRow): RepoMetadata {
   const metadata: RepoMetadata = {};
   if (row.description != null) metadata.description = row.description;
-  const aliases = parseJsonArray(row.aliases);
+  const aliases = parseJsonStringArray(row.aliases);
   if (aliases) metadata.aliases = aliases;
-  const channelAssociations = parseJsonArray(row.channel_associations);
+  const channelAssociations = parseJsonStringArray(row.channel_associations);
   if (channelAssociations) metadata.channelAssociations = channelAssociations;
-  const keywords = parseJsonArray(row.keywords);
+  const keywords = parseJsonStringArray(row.keywords);
   if (keywords) metadata.keywords = keywords;
   return metadata;
 }

--- a/packages/control-plane/src/routes/environments.ts
+++ b/packages/control-plane/src/routes/environments.ts
@@ -12,6 +12,7 @@ import {
   toEnvironment,
   type EnvironmentRow,
   type EnvironmentRepositoryInsert,
+  type EnvironmentScalarFields,
 } from "../db/environments";
 import { generateId } from "../auth/crypto";
 import { scheduleEnvironmentImageBuildOnSave } from "../environment-images/save-hooks";
@@ -46,6 +47,17 @@ function validationError(err: {
 /** Empty/whitespace description collapses to null (the column is nullable). */
 function normalizeDescription(description: string | null | undefined): string | null {
   return description && description.length > 0 ? description : null;
+}
+
+/**
+ * Column value for a channel-association set: deduplicated JSON array, with an
+ * empty set collapsing to NULL. `undefined` (field absent from the request)
+ * stays `undefined` so updates leave the column untouched.
+ */
+function normalizeChannelAssociations(channels: string[] | undefined): string | null | undefined {
+  if (channels === undefined) return undefined;
+  const unique = [...new Set(channels)];
+  return unique.length > 0 ? JSON.stringify(unique) : null;
 }
 
 /**
@@ -114,7 +126,7 @@ async function handleCreateEnvironment(
 
   const parsed = createEnvironmentInputSchema.safeParse(body);
   if (!parsed.success) return validationError(parsed.error);
-  const { name, description, prebuildEnabled, repositories } = parsed.data;
+  const { name, description, prebuildEnabled, channelAssociations, repositories } = parsed.data;
 
   const store = new EnvironmentStore(env.DB);
   if (await store.getByName(name)) {
@@ -130,6 +142,7 @@ async function handleCreateEnvironment(
     name,
     description: normalizeDescription(description),
     prebuild_enabled: prebuildEnabled ? 1 : 0,
+    channel_associations: normalizeChannelAssociations(channelAssociations) ?? null,
     created_at: now,
     updated_at: now,
   };
@@ -195,7 +208,7 @@ async function handleUpdateEnvironment(
 
   const parsed = updateEnvironmentInputSchema.safeParse(body);
   if (!parsed.success) return validationError(parsed.error);
-  const { name, description, prebuildEnabled, repositories } = parsed.data;
+  const { name, description, prebuildEnabled, channelAssociations, repositories } = parsed.data;
 
   if (name !== undefined) {
     const other = await store.getByName(name);
@@ -209,10 +222,14 @@ async function handleUpdateEnvironment(
       ? await resolveEnvironmentRepositories(env, repositories, ctx)
       : undefined;
 
-  const fields: Partial<Pick<EnvironmentRow, "name" | "description" | "prebuild_enabled">> = {};
+  const fields: EnvironmentScalarFields = {};
   if (name !== undefined) fields.name = name;
   if (description !== undefined) fields.description = normalizeDescription(description);
   if (prebuildEnabled !== undefined) fields.prebuild_enabled = prebuildEnabled ? 1 : 0;
+  const channelAssociationsColumn = normalizeChannelAssociations(channelAssociations);
+  if (channelAssociationsColumn !== undefined) {
+    fields.channel_associations = channelAssociationsColumn;
+  }
 
   const updated = await store.update(id, fields, inserts);
   if (!updated) return error("Environment not found", 404);

--- a/packages/control-plane/test/integration/environment-images.test.ts
+++ b/packages/control-plane/test/integration/environment-images.test.ts
@@ -43,6 +43,7 @@ async function seedEnvironment(opts?: {
       name: opts?.name ?? `Seeded ${id}`,
       description: null,
       prebuild_enabled: opts?.prebuildEnabled ? 1 : 0,
+      channel_associations: null,
       created_at: now,
       updated_at: now,
     },

--- a/packages/control-plane/test/integration/environment-store.test.ts
+++ b/packages/control-plane/test/integration/environment-store.test.ts
@@ -22,6 +22,7 @@ function makeEnv(overrides?: Partial<EnvironmentRow>): EnvironmentRow {
     name: "Full Stack",
     description: null,
     prebuild_enabled: 0,
+    channel_associations: null,
     created_at: now,
     updated_at: now,
     ...overrides,
@@ -97,6 +98,23 @@ describe("EnvironmentStore", () => {
     expect(updated?.prebuild_enabled).toBe(1);
     const repoRows = await store.getRepositoriesForEnvironment(row.id);
     expect(repoRows.map((r) => r.repo_name)).toEqual(["api", "worker"]);
+  });
+
+  it("round-trips channel associations through the JSON column", async () => {
+    const store = new EnvironmentStore(env.DB);
+    const row = makeEnv({ name: "Channelled", channel_associations: JSON.stringify(["C1", "C2"]) });
+    await store.create(row, repos(["acme", "web", 1, "main"]));
+
+    const created = toEnvironment(
+      (await store.getById(row.id))!,
+      await store.getRepositoriesForEnvironment(row.id)
+    );
+    expect(created.channelAssociations).toEqual(["C1", "C2"]);
+
+    const updated = await store.update(row.id, { channel_associations: null });
+    expect(
+      toEnvironment(updated!, await store.getRepositoriesForEnvironment(row.id)).channelAssociations
+    ).toBeUndefined();
   });
 
   it("bumps updated_at on a members-only edit", async () => {

--- a/packages/control-plane/test/integration/environments-routes.test.ts
+++ b/packages/control-plane/test/integration/environments-routes.test.ts
@@ -25,6 +25,7 @@ async function authHeaders(): Promise<Record<string, string>> {
 async function seedEnvironment(opts?: {
   id?: string;
   name?: string;
+  channelAssociations?: string[];
   repositories?: [string, string, number, string][];
 }): Promise<string> {
   const store = new EnvironmentStore(env.DB);
@@ -36,6 +37,9 @@ async function seedEnvironment(opts?: {
       name: opts?.name ?? "Seeded",
       description: null,
       prebuild_enabled: 0,
+      channel_associations: opts?.channelAssociations
+        ? JSON.stringify(opts.channelAssociations)
+        : null,
       created_at: now,
       updated_at: now,
     },
@@ -162,6 +166,67 @@ describe("Environments API (routes)", () => {
         .bind(id)
         .first<{ c: number }>();
       expect(secretCount?.c).toBe(0);
+    });
+  });
+
+  describe("PUT /environments/:id (channel associations)", () => {
+    it("sets, dedupes, and clears channel associations without touching repositories", async () => {
+      const id = await seedEnvironment({ name: "Channelled" });
+      const headers = await authHeaders();
+
+      const putRes = await SELF.fetch(`${BASE}/environments/${id}`, {
+        method: "PUT",
+        headers,
+        body: JSON.stringify({ channelAssociations: ["C111", "C222", "C111"] }),
+      });
+      expect(putRes.status).toBe(200);
+      const updated = await putRes.json<{
+        environment: { channelAssociations?: string[]; repositories: unknown[] };
+      }>();
+      expect(updated.environment.channelAssociations).toEqual(["C111", "C222"]);
+      expect(updated.environment.repositories.length).toBe(1);
+
+      // A patch that omits the field leaves the set untouched.
+      await SELF.fetch(`${BASE}/environments/${id}`, {
+        method: "PUT",
+        headers,
+        body: JSON.stringify({ description: "still channelled" }),
+      });
+      const got = await (
+        await SELF.fetch(`${BASE}/environments/${id}`, { headers })
+      ).json<{ environment: { channelAssociations?: string[] } }>();
+      expect(got.environment.channelAssociations).toEqual(["C111", "C222"]);
+
+      // An empty array clears the set (the column collapses to NULL).
+      const clearRes = await SELF.fetch(`${BASE}/environments/${id}`, {
+        method: "PUT",
+        headers,
+        body: JSON.stringify({ channelAssociations: [] }),
+      });
+      const cleared = await clearRes.json<{ environment: { channelAssociations?: string[] } }>();
+      expect(cleared.environment.channelAssociations).toBeUndefined();
+    });
+
+    it("lists seeded channel associations", async () => {
+      await seedEnvironment({ name: "Listed", channelAssociations: ["C123"] });
+      const headers = await authHeaders();
+      const list = await (
+        await SELF.fetch(`${BASE}/environments`, { headers })
+      ).json<{ environments: { channelAssociations?: string[] }[] }>();
+      expect(list.environments[0].channelAssociations).toEqual(["C123"]);
+    });
+
+    it("rejects malformed channel associations (400)", async () => {
+      const id = await seedEnvironment({ name: "Strict" });
+      const headers = await authHeaders();
+      for (const channelAssociations of ["C123", [""], [42]]) {
+        const res = await SELF.fetch(`${BASE}/environments/${id}`, {
+          method: "PUT",
+          headers,
+          body: JSON.stringify({ channelAssociations }),
+        });
+        expect(res.status, JSON.stringify(channelAssociations)).toBe(400);
+      }
     });
   });
 

--- a/packages/control-plane/test/integration/session-from-environment.test.ts
+++ b/packages/control-plane/test/integration/session-from-environment.test.ts
@@ -30,7 +30,15 @@ interface RepoSpec {
 async function seedEnvironment(id: string, name: string, repos: RepoSpec[]): Promise<void> {
   const now = Date.now();
   await new EnvironmentStore(env.DB).create(
-    { id, name, description: null, prebuild_enabled: 0, created_at: now, updated_at: now },
+    {
+      id,
+      name,
+      description: null,
+      prebuild_enabled: 0,
+      channel_associations: null,
+      created_at: now,
+      updated_at: now,
+    },
     repos.map((repo, position) => ({
       position,
       repo_owner: repo.repoOwner,

--- a/packages/shared/src/types/environments.test.ts
+++ b/packages/shared/src/types/environments.test.ts
@@ -4,6 +4,7 @@ import {
   isEnvironmentId,
   updateEnvironmentInputSchema,
   MAX_ENVIRONMENT_NAME_LENGTH,
+  MAX_ENVIRONMENT_CHANNEL_ASSOCIATIONS,
 } from "./index";
 
 describe("isEnvironmentId", () => {
@@ -85,6 +86,35 @@ describe("createEnvironmentInputSchema", () => {
       }).success
     ).toBe(false);
   });
+
+  it("accepts channel associations, trimming ids", () => {
+    const parsed = createEnvironmentInputSchema.parse({
+      name: "X",
+      channelAssociations: [" C0123ABC "],
+      repositories: [{ repoOwner: "a", repoName: "b" }],
+    });
+    expect(parsed.channelAssociations).toEqual(["C0123ABC"]);
+  });
+
+  it("rejects empty channel ids and oversized association lists", () => {
+    expect(
+      createEnvironmentInputSchema.safeParse({
+        name: "X",
+        channelAssociations: ["   "],
+        repositories: [{ repoOwner: "a", repoName: "b" }],
+      }).success
+    ).toBe(false);
+    expect(
+      createEnvironmentInputSchema.safeParse({
+        name: "X",
+        channelAssociations: Array.from(
+          { length: MAX_ENVIRONMENT_CHANNEL_ASSOCIATIONS + 1 },
+          (_, i) => `C${i}`
+        ),
+        repositories: [{ repoOwner: "a", repoName: "b" }],
+      }).success
+    ).toBe(false);
+  });
 });
 
 describe("updateEnvironmentInputSchema", () => {
@@ -98,5 +128,11 @@ describe("updateEnvironmentInputSchema", () => {
 
   it("accepts a null description to clear it", () => {
     expect(updateEnvironmentInputSchema.parse({ description: null }).description).toBeNull();
+  });
+
+  it("accepts an empty channelAssociations array to clear the set", () => {
+    expect(updateEnvironmentInputSchema.parse({ channelAssociations: [] })).toEqual({
+      channelAssociations: [],
+    });
   });
 });

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1262,6 +1262,8 @@ export const automationRepositoriesInputSchema = repositoriesInputSchema;
 export const MAX_ENVIRONMENT_NAME_LENGTH = 200;
 /** Maximum characters in an environment's description. */
 export const MAX_ENVIRONMENT_DESCRIPTION_LENGTH = 2000;
+/** Maximum Slack channel associations per environment. */
+export const MAX_ENVIRONMENT_CHANNEL_ASSOCIATIONS = 50;
 
 /**
  * Shape check for stable environment ids (`env_` + generated suffix). Loose on
@@ -1283,10 +1285,21 @@ export function isEnvironmentId(value: string): boolean {
  */
 export const environmentRepositoriesInputSchema = sessionRepositoriesInputSchema;
 
+/**
+ * Slack channel ids associated with an environment (mirrors
+ * RepoMetadata.channelAssociations). Ids are opaque Slack identifiers, so the
+ * schema checks only basic hygiene; `undefined` on update leaves the set
+ * untouched, an array replaces it wholesale (empty clears).
+ */
+const environmentChannelAssociationsSchema = z
+  .array(z.string().trim().min(1).max(64))
+  .max(MAX_ENVIRONMENT_CHANNEL_ASSOCIATIONS);
+
 export const createEnvironmentInputSchema = z.object({
   name: z.string().trim().min(1).max(MAX_ENVIRONMENT_NAME_LENGTH),
   description: z.string().trim().max(MAX_ENVIRONMENT_DESCRIPTION_LENGTH).nullish(),
   prebuildEnabled: z.boolean().optional(),
+  channelAssociations: environmentChannelAssociationsSchema.optional(),
   repositories: environmentRepositoriesInputSchema,
 });
 
@@ -1294,6 +1307,7 @@ export const updateEnvironmentInputSchema = z.object({
   name: z.string().trim().min(1).max(MAX_ENVIRONMENT_NAME_LENGTH).optional(),
   description: z.string().trim().max(MAX_ENVIRONMENT_DESCRIPTION_LENGTH).nullish(),
   prebuildEnabled: z.boolean().optional(),
+  channelAssociations: environmentChannelAssociationsSchema.optional(),
   repositories: environmentRepositoriesInputSchema.optional(),
 });
 
@@ -1320,6 +1334,11 @@ export interface Environment {
   prebuildEnabled: boolean;
   createdAt: number;
   updatedAt: number;
+  /**
+   * Slack channel ids associated with this environment (classifier
+   * channel-association stage). Absent when the environment has none.
+   */
+  channelAssociations?: string[];
   /** Ordered repositories; [0] is the primary (sandbox/code-server settings source). */
   repositories: EnvironmentRepository[];
 }

--- a/packages/slack-bot/src/classifier/environments.ts
+++ b/packages/slack-bot/src/classifier/environments.ts
@@ -1,11 +1,11 @@
 /**
- * Environment fetching from the control plane, for routing rules that target a
- * saved environment.
+ * Environment fetching from the control plane, for routing rules and channel
+ * associations that target a saved environment.
  *
  * A cached resource (in-memory → control plane → KV, **fail open to an empty
  * list**) so an environments-fetch problem never blocks classification —
- * rules targeting an environment are simply skipped, like rules targeting an
- * inaccessible repository.
+ * rules and channel associations targeting an environment are simply skipped,
+ * like rules targeting an inaccessible repository.
  */
 
 import type { Environment, ListEnvironmentsResponse } from "@open-inspect/shared";

--- a/packages/slack-bot/src/classifier/index.test.ts
+++ b/packages/slack-bot/src/classifier/index.test.ts
@@ -5,14 +5,12 @@ const {
   mockMessagesCreate,
   mockGetAvailableRepos,
   mockBuildRepoDescriptions,
-  mockGetReposByChannel,
   mockGetRoutingRules,
   mockGetAvailableEnvironments,
 } = vi.hoisted(() => ({
   mockMessagesCreate: vi.fn(),
   mockGetAvailableRepos: vi.fn(),
   mockBuildRepoDescriptions: vi.fn(),
-  mockGetReposByChannel: vi.fn(),
   mockGetRoutingRules: vi.fn(),
   mockGetAvailableEnvironments: vi.fn(),
 }));
@@ -32,7 +30,6 @@ vi.mock("@anthropic-ai/sdk", () => ({
 vi.mock("./repos", () => ({
   getAvailableRepos: mockGetAvailableRepos,
   buildRepoDescriptions: mockBuildRepoDescriptions,
-  getReposByChannel: mockGetReposByChannel,
   getRoutingRules: mockGetRoutingRules,
 }));
 
@@ -100,7 +97,6 @@ describe("RepoClassifier", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetAvailableRepos.mockResolvedValue(TEST_REPOS);
-    mockGetReposByChannel.mockResolvedValue([]);
     mockGetRoutingRules.mockResolvedValue([]);
     mockGetAvailableEnvironments.mockResolvedValue([]);
     mockBuildRepoDescriptions.mockResolvedValue("- acme/prod\n- acme/web");
@@ -285,7 +281,10 @@ describe("RepoClassifier", () => {
 
     it("takes precedence over a channel association", async () => {
       // Channel maps to acme/prod, but an explicit keyword maps to acme/web.
-      mockGetReposByChannel.mockResolvedValue([TEST_REPOS[0]]); // acme/prod
+      mockGetAvailableRepos.mockResolvedValue([
+        { ...TEST_REPOS[0], channelAssociations: ["C123"] },
+        TEST_REPOS[1],
+      ]);
       mockGetRoutingRules.mockResolvedValue([{ keyword: "frontend", target: "acme/web" }]);
 
       const classifier = new RepoClassifier(TEST_ENV);
@@ -395,6 +394,131 @@ describe("RepoClassifier", () => {
 
       expect(classifiedRepoFullName(result)).toBe("acme/web");
       expect(mockMessagesCreate).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("channel associations", () => {
+    it("routes to the repository associated with the channel, without the LLM", async () => {
+      mockGetAvailableRepos.mockResolvedValue([
+        { ...TEST_REPOS[0], channelAssociations: ["C123"] },
+        TEST_REPOS[1],
+      ]);
+
+      const classifier = new RepoClassifier(TEST_ENV);
+      const result = await classifier.classify("anything", { channelId: "C123" });
+
+      expect(classifiedRepoFullName(result)).toBe("acme/prod");
+      expect(result.confidence).toBe("high");
+      expect(result.reasoning).toContain("associated with repository acme/prod");
+      expect(mockMessagesCreate).not.toHaveBeenCalled();
+    });
+
+    it("routes to the environment associated with the channel", async () => {
+      const environment = { ...TEST_ENVIRONMENT, channelAssociations: ["C123"] };
+      mockGetAvailableEnvironments.mockResolvedValue([environment]);
+
+      const classifier = new RepoClassifier(TEST_ENV);
+      const result = await classifier.classify("anything", { channelId: "C123" });
+
+      expect(result.target).toEqual({ kind: "environment", environment });
+      expect(result.confidence).toBe("high");
+      expect(result.reasoning).toContain("associated with environment full-stack");
+      expect(mockMessagesCreate).not.toHaveBeenCalled();
+    });
+
+    it("escapes the environment name in the mrkdwn reasoning", async () => {
+      mockGetAvailableEnvironments.mockResolvedValue([
+        { ...TEST_ENVIRONMENT, name: "<!channel> & co", channelAssociations: ["C123"] },
+      ]);
+
+      const classifier = new RepoClassifier(TEST_ENV);
+      const result = await classifier.classify("anything", { channelId: "C123" });
+
+      expect(result.reasoning).toContain("&lt;!channel&gt; &amp; co");
+      expect(result.reasoning).not.toContain("<!channel>");
+    });
+
+    it("routes an environment association even when only one repository is available", async () => {
+      // The single-repo shortcut must not shadow the channel's environment.
+      mockGetAvailableRepos.mockResolvedValue([TEST_REPOS[0]]);
+      const environment = { ...TEST_ENVIRONMENT, channelAssociations: ["C123"] };
+      mockGetAvailableEnvironments.mockResolvedValue([environment]);
+
+      const classifier = new RepoClassifier(TEST_ENV);
+      const result = await classifier.classify("anything", { channelId: "C123" });
+
+      expect(result.target).toEqual({ kind: "environment", environment });
+      expect(mockMessagesCreate).not.toHaveBeenCalled();
+    });
+
+    it("asks for clarification when the channel maps to a repo and an environment", async () => {
+      const associatedRepo = { ...TEST_REPOS[0], channelAssociations: ["C123"] };
+      mockGetAvailableRepos.mockResolvedValue([associatedRepo, TEST_REPOS[1]]);
+      const environment = { ...TEST_ENVIRONMENT, channelAssociations: ["C123"] };
+      mockGetAvailableEnvironments.mockResolvedValue([environment]);
+
+      const classifier = new RepoClassifier(TEST_ENV);
+      const result = await classifier.classify("anything", { channelId: "C123" });
+
+      expect(result.target).toBeNull();
+      expect(result.needsClarification).toBe(true);
+      expect(result.alternatives).toEqual([
+        { kind: "environment", environment },
+        { kind: "repository", repo: associatedRepo },
+      ]);
+      expect(mockMessagesCreate).not.toHaveBeenCalled();
+    });
+
+    it("falls through to the LLM when several repositories share the channel", async () => {
+      // The LLM sees channel associations as a prompt signal and can arbitrate
+      // between repositories — only environments force a clarification.
+      mockGetAvailableRepos.mockResolvedValue(
+        TEST_REPOS.map((repo) => ({ ...repo, channelAssociations: ["C123"] }))
+      );
+      mockMessagesCreate.mockResolvedValue({
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_c",
+            name: "classify_repository",
+            input: {
+              repoId: "acme/web",
+              confidence: "high",
+              reasoning: "Mentions the web app.",
+              alternatives: [],
+            },
+          },
+        ],
+      });
+
+      const classifier = new RepoClassifier(TEST_ENV);
+      const result = await classifier.classify("web app issue", { channelId: "C123" });
+
+      expect(classifiedRepoFullName(result)).toBe("acme/web");
+      expect(mockMessagesCreate).toHaveBeenCalledOnce();
+    });
+
+    it("does not consult environments for messages outside a channel context", async () => {
+      mockMessagesCreate.mockResolvedValue({
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_d",
+            name: "classify_repository",
+            input: {
+              repoId: "acme/web",
+              confidence: "high",
+              reasoning: "Mentions the web app.",
+              alternatives: [],
+            },
+          },
+        ],
+      });
+
+      const classifier = new RepoClassifier(TEST_ENV);
+      await classifier.classify("web app issue");
+
+      expect(mockGetAvailableEnvironments).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/slack-bot/src/classifier/index.ts
+++ b/packages/slack-bot/src/classifier/index.ts
@@ -7,8 +7,8 @@
 
 import Anthropic from "@anthropic-ai/sdk";
 import type { Env, RepoConfig, ThreadContext, ClassificationResult } from "../types";
-import { getAvailableRepos, buildRepoDescriptions, getReposByChannel } from "./repos";
-import { resolveRoutingRuleTargets } from "./routing";
+import { getAvailableRepos, buildRepoDescriptions } from "./repos";
+import { resolveChannelTargets, resolveRoutingRuleTargets } from "./routing";
 import { escapeMrkdwnText, type ConfidenceLevel } from "@open-inspect/shared";
 import { targetId, targetLabel, type SlackSessionTarget } from "../targets";
 import { createLogger } from "../logger";
@@ -230,6 +230,53 @@ export class RepoClassifier {
   }
 
   /**
+   * Route on the channel's associated targets (resolution lives in
+   * {@link resolveChannelTargets}).
+   *
+   * Returns a high-confidence result when the channel is associated with
+   * exactly one target. Several associated repositories fall through (`null`)
+   * to the LLM, which already sees channel associations as a prompt signal —
+   * but the LLM cannot pick an environment until environments join its
+   * candidate set (Phase B), so a multi-target set that includes an
+   * environment asks the user instead of silently dropping it.
+   */
+  private async classifyByChannelAssociations(
+    channelId: string,
+    repos: RepoConfig[],
+    traceId?: string
+  ): Promise<ClassificationResult | null> {
+    const targets = await resolveChannelTargets(this.env, channelId, repos, traceId);
+
+    if (targets.length === 1) {
+      const target = targets[0];
+      log.info("classifier.channel_association_match", {
+        trace_id: traceId,
+        channel_id: channelId,
+        target_id: targetId(target),
+      });
+      return {
+        target,
+        confidence: "high",
+        // Reasoning renders as mrkdwn; the label is user text.
+        reasoning: `Channel is associated with ${target.kind} ${escapeMrkdwnText(targetLabel(target))}`,
+        needsClarification: false,
+      };
+    }
+
+    if (targets.length > 1 && targets.some((target) => target.kind === "environment")) {
+      return {
+        target: null,
+        confidence: "medium",
+        reasoning: "This channel is associated with several targets; asking which one to use.",
+        alternatives: targets,
+        needsClarification: true,
+      };
+    }
+
+    return null;
+  }
+
+  /**
    * Classify which repository a message refers to.
    */
   async classify(
@@ -260,6 +307,16 @@ export class RepoClassifier {
       return routed;
     }
 
+    // Channel associations are the second deterministic stage. Like routing
+    // rules, they run before the single-repo shortcut so a channel associated
+    // with an environment stays reachable in one-repo workspaces.
+    const channelRouted = context?.channelId
+      ? await this.classifyByChannelAssociations(context.channelId, repos, traceId)
+      : null;
+    if (channelRouted) {
+      return channelRouted;
+    }
+
     // If only one repo, skip classification
     if (repos.length === 1) {
       return {
@@ -268,19 +325,6 @@ export class RepoClassifier {
         reasoning: "Only one repository is available.",
         needsClarification: false,
       };
-    }
-
-    // Check for channel-specific repos first
-    if (context?.channelId) {
-      const channelRepos = await getReposByChannel(this.env, context.channelId, traceId);
-      if (channelRepos.length === 1) {
-        return {
-          target: { kind: "repository", repo: channelRepos[0] },
-          confidence: "high",
-          reasoning: `Channel is associated with repository ${channelRepos[0].fullName}`,
-          needsClarification: false,
-        };
-      }
     }
 
     // Use LLM for classification

--- a/packages/slack-bot/src/classifier/repos.ts
+++ b/packages/slack-bot/src/classifier/repos.ts
@@ -294,18 +294,6 @@ export async function getRepoById(
 }
 
 /**
- * Find repositories associated with a Slack channel.
- */
-export async function getReposByChannel(
-  env: Env,
-  channelId: string,
-  traceId?: string
-): Promise<RepoConfig[]> {
-  const repos = await getAvailableRepos(env, traceId);
-  return repos.filter((r) => r.channelAssociations?.includes(channelId));
-}
-
-/**
  * Build a description string for all available repos.
  * Used in the classification prompt.
  */

--- a/packages/slack-bot/src/classifier/routing.ts
+++ b/packages/slack-bot/src/classifier/routing.ts
@@ -1,8 +1,9 @@
 /**
- * Deterministic routing-rule target resolution: matched keyword rules →
- * launchable {@link SlackSessionTarget}s. Owns the environment fetch and
- * target-kind dispatch so the classifier only chooses between deterministic
- * routing, channel association, and LLM classification.
+ * Deterministic target resolution for the classifier's rule-based stages:
+ * matched keyword rules and channel associations → launchable
+ * {@link SlackSessionTarget}s. Owns the environment fetch and target-kind
+ * dispatch so the classifier only chooses between deterministic routing,
+ * channel association, and LLM classification.
  */
 
 import { matchRoutingRules } from "@open-inspect/shared";
@@ -56,4 +57,27 @@ export async function resolveRoutingRuleTargets(
   }
 
   return [...targets.values()];
+}
+
+/**
+ * Resolve the targets associated with a Slack channel: environments and
+ * repositories whose channel-association lists name the channel (environments
+ * first, matching the web picker's grouping). The environments fetch fails
+ * open to an empty list, so an outage degrades to repository-only matching.
+ */
+export async function resolveChannelTargets(
+  env: Env,
+  channelId: string,
+  repos: RepoConfig[],
+  traceId?: string
+): Promise<SlackSessionTarget[]> {
+  const environments = await getAvailableEnvironments(env, traceId);
+  return [
+    ...environments
+      .filter((environment) => environment.channelAssociations?.includes(channelId))
+      .map((environment): SlackSessionTarget => ({ kind: "environment", environment })),
+    ...repos
+      .filter((repo) => repo.channelAssociations?.includes(channelId))
+      .map((repo): SlackSessionTarget => ({ kind: "repository", repo })),
+  ];
 }

--- a/terraform/d1/migrations/0035_environment_channel_associations.sql
+++ b/terraform/d1/migrations/0035_environment_channel_associations.sql
@@ -1,0 +1,10 @@
+-- Slack channel associations for environments (design §7.5, Slack Phase A).
+--
+-- Mirrors repo_metadata.channel_associations (0002): a JSON array of Slack
+-- channel ids, consulted by the slack-bot classifier's channel-association
+-- stage so a channel can route to an environment the same way it routes to a
+-- repository. NULL means the environment has no channel associations.
+--
+-- Additive and dark until the environments routes read/write it; rollback =
+-- stop reading the column, leave it inert.
+ALTER TABLE environments ADD COLUMN channel_associations TEXT;


### PR DESCRIPTION
## Summary

Slack Phase A2 of the multi-repo environments work (follows #924): environments can now be associated with Slack channels, the same way repositories can via repo metadata. A message in an associated channel routes deterministically to the environment — no keyword needed.

### Control plane

- **Migration 0035**: additive `channel_associations TEXT` column on `environments` (JSON string array, mirroring `repo_metadata.channel_associations` from 0002). Rollback = stop reading the column.
- `Environment` gains optional `channelAssociations`; `create/updateEnvironmentInputSchema` accept it (trimmed, non-empty ids, capped at 50). Update semantics match the rest of the patch shape: field absent → untouched, array → wholesale replace, `[]` → cleared (column collapses to NULL). The route dedupes before storing.
- Extracted the JSON-array column parser shared with `repo_metadata` into `db/json-columns.ts` instead of duplicating it.
- API-only, like repository channel associations — no web UI in this slice.

### Slack bot

- The classifier's channel-association stage is now target-aware: `resolveChannelTargets` (in `classifier/routing.ts`, beside its routing-rule sibling) returns environments and repositories whose association lists name the channel.
- **The stage moves ahead of the single-repo shortcut** — same reachability argument as the routing-rule stage in #924: without this, an environment-associated channel in a one-repo workspace could never route to the environment. For repository associations this is behavior-preserving (in a one-repo workspace a channel can only ever match that one repo).
- Semantics:
  - exactly one associated target → high-confidence route (reasoning escapes the environment name for mrkdwn, per the escape-at-render policy from #924);
  - several targets including an environment → clarification with those targets as quick picks (the LLM can't select environments until Phase B, so silently falling through would drop them);
  - several repositories only → falls through to the LLM as today (channel associations are already a prompt signal it can arbitrate with).
- The environments fetch stays the #924 cached resource (60s memory / 5min KV, **fail-open to `[]`**), so an environments outage degrades to today's repository-only matching. It is consulted only for messages that reach the channel stage inside a channel context.
- `getReposByChannel` folded into `resolveChannelTargets` (its only caller was the classifier).

## Deploy-order safety

The column is additive and dark: an old bot ignores `channelAssociations` on the API response; a new bot against an un-migrated DB simply sees no environment associations. No coordination needed.

## Testing

- shared: schema accept/reject cases for `channelAssociations` (360 ✓)
- control-plane: store JSON-column round-trip; route tests for set/dedupe/omit-untouched/clear and 400s on malformed payloads (1679 unit + 518 integration ✓)
- slack-bot: repo association routing, environment association routing, mrkdwn escaping of hostile environment names, environment-beats-single-repo-shortcut, mixed repo+environment clarification, repo-only multi-match LLM fallthrough, no environments fetch outside channel context (205 ✓)
- web/github-bot/linear-bot suites unaffected and green (599/115/125 ✓)

Part of the multi-repo sessions Phase 3 plan (design §7.5, Slack Phase A). Next slice: Phase B — environments in the LLM classifier candidate set + unified clarification picker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environments can now be linked to Slack channels, allowing messages in those channels to route directly to the right environment.
  * Create and update environment endpoints now support channel associations, including automatic de-duplication.
  * Routing recognizes both repository and environment channel links for more reliable direct session targeting.
* **Bug Fixes**
  * Clarified behavior for empty vs omitted channel associations: existing associations remain when omitted, and can be cleared when an empty list is provided.
* **Documentation**
  * Updated “Session Targets” documentation to reflect channel-association routing without requiring a keyword.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->