### PR TITLE
fix(sandbox): tag tunnel env file so boot cleanup keeps fresh writes

### DIFF
--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -310,17 +310,21 @@ can read them locally.
 
 ```dotenv
 # /workspace/.tunnels.env
+TUNNEL_SANDBOX_ID=sandbox-acme-app-1783614336426
 TUNNEL_3000=https://abc123-3000.modal.host
 TUNNEL_5173=https://abc123-5173.modal.host
 ```
 
 This dotenv shape works directly with tools that accept an env-file path — `node --env-file=...`,
 `bun --env-file=...`, `docker compose --env-file=...`. The format is plain `KEY=value`, so any other
-dotenv consumer can read it without parsing.
+dotenv consumer can read it without parsing. The `TUNNEL_SANDBOX_ID` line names the sandbox the URLs
+were resolved for; the supervisor uses it to tell a fresh write from a snapshot leftover.
 
 **Boot ordering.** On every non-build boot, the supervisor:
 
-1. Clears any stale file inherited from a snapshot.
+1. Clears a file left by a previous sandbox (its `TUNNEL_SANDBOX_ID` doesn't match), such as one
+   inherited from a snapshot. A file already written for _this_ sandbox is kept — the backend's
+   write can land before the supervisor starts.
 2. Waits up to `TUNNEL_WAIT_TIMEOUT_SECONDS` (default `30`) for fresh URLs.
 3. Runs `.openinspect/start.sh`.
 

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
@@ -377,7 +377,9 @@ describe("VercelSandboxProvider", () => {
         args: expect.arrayContaining([
           "/usr/bin/python3.12",
           "-c",
-          expect.stringContaining("TUNNEL_3000"),
+          // Tagged with the logical sandbox ID (first line) so the supervisor's
+          // stale-file cleanup keeps this write, then the port URLs.
+          expect.stringContaining("TUNNEL_SANDBOX_ID=sandbox-456\\nTUNNEL_3000"),
         ]),
       }),
       undefined

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.ts
@@ -39,6 +39,10 @@ import { DEFAULT_VERCEL_RUNTIME, VERCEL_PYTHON_BIN } from "./bootstrap";
 const log = createLogger("vercel-provider");
 
 const TUNNEL_ENV_FILE_PATH = "/workspace/.tunnels.env";
+// Mirrors TUNNEL_ENV_SANDBOX_ID_KEY in sandbox_runtime/constants.py: tags the
+// tunnel env file with the sandbox it was written for, so the supervisor's
+// stale-file cleanup keeps a fresh write instead of deleting it.
+const TUNNEL_ENV_SANDBOX_ID_KEY = "TUNNEL_SANDBOX_ID";
 const EXPECTED_TUNNEL_PORTS_ENV_VAR = "EXPECTED_TUNNEL_PORTS";
 const DEFAULT_SNAPSHOT_EXPIRATION_MS = 0;
 const VERCEL_MAX_SANDBOX_TIMEOUT_MS = 45 * 60 * 1000;
@@ -564,7 +568,7 @@ export class VercelSandboxProvider implements SandboxProvider {
     }
 
     if (Object.keys(tunnelUrls).length > 0) {
-      await this.writeTunnelEnvFile(created.session.id, tunnelUrls, correlation);
+      await this.writeTunnelEnvFile(created.session.id, logicalSandboxId, tunnelUrls, correlation);
     }
 
     const { codeServerPort, terminalPort } = resolveServicePorts(sandboxSettings);
@@ -587,14 +591,17 @@ export class VercelSandboxProvider implements SandboxProvider {
 
   private async writeTunnelEnvFile(
     sessionId: string,
+    logicalSandboxId: string,
     tunnelUrls: Record<string, string>,
     correlation?: CreateSandboxConfig["correlation"]
   ): Promise<void> {
-    const content =
-      Object.entries(tunnelUrls)
+    const lines = [
+      `${TUNNEL_ENV_SANDBOX_ID_KEY}=${logicalSandboxId}`,
+      ...Object.entries(tunnelUrls)
         .sort(([a], [b]) => Number(a) - Number(b))
-        .map(([port, url]) => `TUNNEL_${port}=${url}`)
-        .join("\n") + "\n";
+        .map(([port, url]) => `TUNNEL_${port}=${url}`),
+    ];
+    const content = lines.join("\n") + "\n";
 
     const script = [
       "from pathlib import Path",

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -25,6 +25,7 @@ from sandbox_runtime.constants import (
     TTYD_PROXY_PORT,
     TTYD_PROXY_PORT_ENV_VAR,
     TUNNEL_ENV_FILE_PATH,
+    TUNNEL_ENV_SANDBOX_ID_KEY,
 )
 from sandbox_runtime.log_config import get_logger
 from sandbox_runtime.types import SandboxStatus, SessionConfig, SessionRepositoryConfig
@@ -288,10 +289,15 @@ class SandboxManager:
     ) -> None:
         """Write tunnel URLs to TUNNEL_ENV_FILE_PATH as a dotenv file.
 
+        The first line tags the file with this sandbox's ID so the supervisor's
+        stale-file cleanup can tell a fresh write (this write can land before
+        the entrypoint runs) from a snapshot/image leftover.
+
         Failures are logged but do not block sandbox creation; URLs are also
         returned to the control plane via the SandboxHandle.
         """
-        lines = [f"TUNNEL_{port}={url}" for port, url in sorted(tunnel_urls.items())]
+        lines = [f"{TUNNEL_ENV_SANDBOX_ID_KEY}={sandbox_id}"]
+        lines += [f"TUNNEL_{port}={url}" for port, url in sorted(tunnel_urls.items())]
         content = "\n".join(lines) + "\n"
         try:
             await sandbox.filesystem.write_text.aio(content, TUNNEL_ENV_FILE_PATH)

--- a/packages/modal-infra/tests/test_tunnel_ports.py
+++ b/packages/modal-infra/tests/test_tunnel_ports.py
@@ -10,6 +10,7 @@ from sandbox_runtime.constants import (
     TTYD_PROXY_PORT,
     TTYD_PROXY_PORT_ENV_VAR,
     TUNNEL_ENV_FILE_PATH,
+    TUNNEL_ENV_SANDBOX_ID_KEY,
 )
 from src.sandbox.manager import CODE_SERVER_PORT, SandboxConfig, SandboxManager
 
@@ -239,8 +240,9 @@ class TestWriteTunnelEnvFile:
         write_text.assert_awaited_once()
         written, path = write_text.call_args[0]
         assert path == TUNNEL_ENV_FILE_PATH
-        # Sorted by port, dotenv format, trailing newline.
+        # Sandbox-ID tag first, then sorted by port, dotenv format, trailing newline.
         assert written == (
+            f"{TUNNEL_ENV_SANDBOX_ID_KEY}=sb-1\n"
             "TUNNEL_3000=https://tunnel-3000.example.com\n"
             "TUNNEL_3001=https://tunnel-3001.example.com\n"
         )
@@ -285,6 +287,7 @@ class TestResolveAndSetupTunnelsWritesFile:
 
         write_text.assert_awaited_once()
         written = write_text.call_args[0][0]
+        assert written.startswith(f"{TUNNEL_ENV_SANDBOX_ID_KEY}=sb-1\n")
         assert "TUNNEL_3000=https://tunnel-3000.example.com" in written
 
     @pytest.mark.asyncio

--- a/packages/sandbox-runtime/src/sandbox_runtime/constants.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/constants.py
@@ -17,6 +17,14 @@ TTYD_PROXY_PORT_ENV_VAR = "TTYD_PROXY_PORT"
 # services via `--env-file` or direct read.
 TUNNEL_ENV_FILE_PATH = "/workspace/.tunnels.env"
 
+# First line of the tunnel env file: names the sandbox the URLs were resolved
+# for. The manager's write can land before the entrypoint starts (it only
+# needs the container agent, not the supervisor), so the entrypoint's stale
+# cleanup keeps a file whose value matches its own SANDBOX_ID and clears
+# everything else (snapshot/image leftovers with dead URLs). Mirrored as a
+# string literal in the Vercel provider (control-plane).
+TUNNEL_ENV_SANDBOX_ID_KEY = "TUNNEL_SANDBOX_ID"
+
 # Comma-separated tunnel ports the manager will resolve. Read by the entrypoint
 # to gate stale-file cleanup and the wait-for-fresh-URLs before start.sh.
 EXPECTED_TUNNEL_PORTS_ENV_VAR = "EXPECTED_TUNNEL_PORTS"

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -1675,7 +1675,9 @@ class SandboxSupervisor:
         cleared so `_wait_for_tunnel_env_file` blocks until fresh URLs arrive.
         """
         path = Path(TUNNEL_ENV_FILE_PATH)
-        if not path.exists():
+        # exists() follows symlinks, so a dangling symlink reads as absent —
+        # but it must still be cleared or it can break the manager's write.
+        if not path.exists() and not path.is_symlink():
             return
         if self.sandbox_id and self.sandbox_id != "unknown":
             try:

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -33,6 +33,7 @@ from .constants import (
     TTYD_PROXY_PORT,
     TTYD_PROXY_PORT_ENV_VAR,
     TUNNEL_ENV_FILE_PATH,
+    TUNNEL_ENV_SANDBOX_ID_KEY,
 )
 from .log_config import configure_logging, get_logger
 from .repo_config import RepoConfigError, RepoEntry, dump_repo_manifest, parse_repositories
@@ -1665,8 +1666,25 @@ class SandboxSupervisor:
         return ports
 
     def _clear_stale_tunnel_env_file(self) -> None:
-        """Remove any pre-existing tunnel env file inherited from a snapshot."""
+        """Remove a tunnel env file left behind by a previous sandbox.
+
+        Presence alone doesn't mean stale: the manager's write only needs the
+        container agent, so it can land before this entrypoint runs. A file
+        tagged with our own SANDBOX_ID is that fresh write and must survive;
+        anything else (snapshot/image leftover with dead URLs, or untagged) is
+        cleared so `_wait_for_tunnel_env_file` blocks until fresh URLs arrive.
+        """
         path = Path(TUNNEL_ENV_FILE_PATH)
+        if not path.exists():
+            return
+        if self.sandbox_id and self.sandbox_id != "unknown":
+            try:
+                own_marker = f"{TUNNEL_ENV_SANDBOX_ID_KEY}={self.sandbox_id}"
+                if own_marker in path.read_text().splitlines():
+                    self.log.info("tunnel.fresh_file_kept", path=str(path))
+                    return
+            except Exception as e:
+                self.log.warn("tunnel.stale_check_read_failed", path=str(path), exc=e)
         try:
             path.unlink(missing_ok=True)
             self.log.info("tunnel.stale_file_cleared", path=str(path))

--- a/packages/sandbox-runtime/tests/test_entrypoint_tunnel_urls.py
+++ b/packages/sandbox-runtime/tests/test_entrypoint_tunnel_urls.py
@@ -1,7 +1,9 @@
 """Tests for SandboxSupervisor tunnel-env-file handling.
 
 The supervisor owns the tunnel env file lifecycle from inside the sandbox:
-- clears any stale file at boot when tunnels are expected this session
+- at boot, keeps a file the manager already wrote for THIS sandbox (the
+  manager's write can land before the entrypoint runs) and clears anything
+  else as a snapshot/image leftover
 - blocks `start.sh` until the manager has written fresh URLs (bounded)
 """
 
@@ -13,6 +15,7 @@ import pytest
 from sandbox_runtime.constants import (
     EXPECTED_TUNNEL_PORTS_ENV_VAR,
     TUNNEL_ENV_FILE_PATH,
+    TUNNEL_ENV_SANDBOX_ID_KEY,
 )
 from sandbox_runtime.entrypoint import SandboxSupervisor
 
@@ -67,12 +70,58 @@ class TestExpectedTunnelPorts:
 
 
 class TestClearStaleTunnelEnvFile:
-    def test_removes_existing_file(self, tmp_path, monkeypatch):
+    def test_removes_untagged_file(self, tmp_path, monkeypatch):
+        """A file with no sandbox-ID tag (pre-tag writer, or user-made) is stale."""
         stub_path = tmp_path / "tunnels.env"
         stub_path.write_text("TUNNEL_3000=https://stale.example.com\n")
         monkeypatch.setattr("sandbox_runtime.entrypoint.TUNNEL_ENV_FILE_PATH", str(stub_path))
 
         sup = _make_supervisor()
+        sup._clear_stale_tunnel_env_file()
+
+        assert not stub_path.exists()
+
+    def test_keeps_file_tagged_with_own_sandbox_id(self, tmp_path, monkeypatch):
+        """The manager's write can land before the entrypoint runs; keep it."""
+        stub_path = tmp_path / "tunnels.env"
+        content = (
+            f"{TUNNEL_ENV_SANDBOX_ID_KEY}=test-sandbox\nTUNNEL_3000=https://fresh.example.com\n"
+        )
+        stub_path.write_text(content)
+        monkeypatch.setattr("sandbox_runtime.entrypoint.TUNNEL_ENV_FILE_PATH", str(stub_path))
+
+        sup = _make_supervisor()
+        sup._clear_stale_tunnel_env_file()
+
+        assert stub_path.read_text() == content
+
+    def test_removes_file_tagged_with_other_sandbox_id(self, tmp_path, monkeypatch):
+        """A snapshot/image leftover carries the previous sandbox's ID."""
+        stub_path = tmp_path / "tunnels.env"
+        stub_path.write_text(
+            f"{TUNNEL_ENV_SANDBOX_ID_KEY}=previous-sandbox\nTUNNEL_3000=https://stale.example.com\n"
+        )
+        monkeypatch.setattr("sandbox_runtime.entrypoint.TUNNEL_ENV_FILE_PATH", str(stub_path))
+
+        sup = _make_supervisor()
+        sup._clear_stale_tunnel_env_file()
+
+        assert not stub_path.exists()
+
+    def test_removes_tagged_file_when_own_sandbox_id_unknown(self, tmp_path, monkeypatch):
+        """Without a SANDBOX_ID identity, never trust a pre-existing file."""
+        stub_path = tmp_path / "tunnels.env"
+        stub_path.write_text(f"{TUNNEL_ENV_SANDBOX_ID_KEY}=unknown\n")
+        monkeypatch.setattr("sandbox_runtime.entrypoint.TUNNEL_ENV_FILE_PATH", str(stub_path))
+
+        base_env = {
+            "CONTROL_PLANE_URL": "https://cp.example.com",
+            "SANDBOX_AUTH_TOKEN": "tok",
+            "REPO_OWNER": "acme",
+            "REPO_NAME": "app",
+        }
+        with patch.dict("os.environ", base_env, clear=True):
+            sup = SandboxSupervisor()
         sup._clear_stale_tunnel_env_file()
 
         assert not stub_path.exists()

--- a/packages/sandbox-runtime/tests/test_entrypoint_tunnel_urls.py
+++ b/packages/sandbox-runtime/tests/test_entrypoint_tunnel_urls.py
@@ -126,6 +126,18 @@ class TestClearStaleTunnelEnvFile:
 
         assert not stub_path.exists()
 
+    def test_removes_dangling_symlink(self, tmp_path, monkeypatch):
+        """exists() is False for a broken symlink, but it must still be cleared."""
+        stub_path = tmp_path / "tunnels.env"
+        stub_path.symlink_to(tmp_path / "missing-target")
+        monkeypatch.setattr("sandbox_runtime.entrypoint.TUNNEL_ENV_FILE_PATH", str(stub_path))
+
+        sup = _make_supervisor()
+        sup._clear_stale_tunnel_env_file()
+
+        assert not stub_path.is_symlink()
+        assert not stub_path.exists()
+
     def test_no_op_when_file_missing(self, tmp_path, monkeypatch):
         stub_path = tmp_path / "tunnels.env"
         monkeypatch.setattr("sandbox_runtime.entrypoint.TUNNEL_ENV_FILE_PATH", str(stub_path))


### PR DESCRIPTION
## Problem

Since #926 deployed, sessions with `tunnelPorts` boot without `/workspace/.tunnels.env`: the supervisor logs `tunnel.stale_file_cleared` followed 30s later by `tunnel.env_file_wait_timeout`, delaying every boot by the full wait and leaving `start.sh` without tunnel URLs — even though the manager logs `tunnel.urls_written`.

## Root cause

The supervisor's boot-time stale-file cleanup and the manager's tunnel env write have **no ordering guarantee** — the design (from #663) only works when the write lands *after* the clear:

| ts (from prod logs) | who | event |
|---|---|---|
| 1783614343447 | manager | `tunnel.urls_written` — write completes |
| 1783614343542 | supervisor | `supervisor.start` (+95ms) |
| 1783614343543 | supervisor | `tunnel.stale_file_cleared` — **deletes the fresh file** |
| 1783614374781 | supervisor | `tunnel.env_file_wait_timeout` (30s later) |

#926 switched the write from the deprecated file-handle API (3–4 sequential gRPC round trips after container start — always slow enough to land after the clear) to `sandbox.filesystem.write_text`, which is implemented as a single exec of a fs-tools helper. That exec completes while the entrypoint is still importing Python modules, so the write now lands *before* `run()` begins and the clear deletes it on essentially every boot. The manager writes exactly once, so nothing recovers.

Compounding the confusion: the old cleanup logged `tunnel.stale_file_cleared` unconditionally (`unlink(missing_ok=True)`), so a boot that deleted the fresh file was indistinguishable from a healthy no-op.

## Fix

Remove the ordering dependency instead of re-tuning the race. Writers now tag the file's first line with the sandbox it was written for:

```dotenv
TUNNEL_SANDBOX_ID=sandbox-acme-app-1783614336426
TUNNEL_3000=https://...
```

The supervisor's cleanup keeps a file tagged with its own `SANDBOX_ID` (the manager won the race — the URLs are for this sandbox and valid for its lifetime) and clears everything else: files tagged with another sandbox's ID (snapshot/image leftovers with dead URLs), untagged files, and anything it can't read. A supervisor without a `SANDBOX_ID` identity never trusts a pre-existing file. Write ordering no longer matters on either side of the race, on both fresh-create and snapshot-restore paths.

The Vercel provider writes the same file via exec and had the same latent race, so it tags too. Cleanup logging is now truthful: `tunnel.fresh_file_kept` / `tunnel.stale_file_cleared` only when a file actually existed.

## Mixed-version rollout

Safe in both directions, no version gate needed:
- **Old runtime image + new writer**: the tag line is inert (the wait loop matches `TUNNEL_<port>=` prefixes); the old cleanup still clears unconditionally — status quo until images rebuild.
- **New runtime + untagged writer**: untagged files are treated as stale — exactly today's behavior.

The consumer-facing format is unchanged apart from the extra `KEY=value` line, which any dotenv consumer tolerates.

## Validation

- `uv run --extra dev pytest tests/` — sandbox-runtime **439 passed** (new cases: keep-own-tag, clear-other-tag, clear-untagged, clear-when-identity-unknown), modal-infra **194 passed**
- `npm test -w @open-inspect/control-plane` — **1686 passed**
- `npm run typecheck -w @open-inspect/control-plane`, `ruff check` / `ruff format --check`, `eslint`, `prettier --check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated tunnel env-file documentation to reflect how stale files are cleared and how current-sandbox files are preserved.
* **New Features**
  * Added sandbox ID tagging to tunnel environment files to make the owning sandbox identifiable.
  * Ensured tunnel env-file writing includes the sandbox ID marker followed by sorted port URL entries.
* **Bug Fixes**
  * Improved boot cleanup to retain a correctly tagged tunnel file and remove only truly stale/untagged or mismatched ones.
* **Tests**
  * Updated unit/integration tests to validate the new sandbox ID marker and content ordering/cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Tracking issue

Fixes #936
