### PR TITLE
feat(linear): environment targets in team and project mappings

### DIFF
--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -62,12 +62,13 @@ which settings apply. The agent sees all clones side by side and can make coordi
 them; pushes and pull requests are per-repository, so one session can produce PRs in several
 repositories. The session sidebar lists every repository with its branch and any PR created for it.
 
-Bot-created sessions (GitHub, Linear) remain single-repository. Slack sessions can target an
-environment three ways: a routing rule (Settings › Integrations › Slack) launches it from a keyword;
-a channel association (`channelAssociations` on the environments API, like repository metadata)
-routes messages in that channel to it automatically; and the LLM classifier considers environments
-alongside repositories, using their names and descriptions as signals — its clarification picker
-lists both kinds when it has to ask.
+GitHub-bot sessions remain single-repository. Slack sessions can target an environment three ways: a
+routing rule (Settings › Integrations › Slack) launches it from a keyword; a channel association
+(`channelAssociations` on the environments API, like repository metadata) routes messages in that
+channel to it automatically; and the LLM classifier considers environments alongside repositories,
+using their names and descriptions as signals — its clarification picker lists both kinds when it
+has to ask. Linear sessions can target an environment through the team and project mappings
+(`{"environmentId": "env_…"}` entries alongside repository entries).
 
 ### Session Lifecycle
 

--- a/packages/linear-bot/README.md
+++ b/packages/linear-bot/README.md
@@ -79,7 +79,7 @@ The agent resolves repos automatically in most cases (see [Repo Resolution](#rep
 Static mappings are optional overrides. All `/config/*` endpoints require an `Authorization` header
 with an HMAC-signed bearer token (from `INTERNAL_CALLBACK_SECRET`).
 
-**Team → repo mapping:**
+**Team → target mapping:**
 
 ```bash
 curl -X PUT https://<your-linear-bot-worker>/config/team-repos \
@@ -88,27 +88,31 @@ curl -X PUT https://<your-linear-bot-worker>/config/team-repos \
   -d '{
     "YOUR_TEAM_ID": [
       { "owner": "your-org", "name": "frontend", "label": "frontend" },
-      { "owner": "your-org", "name": "backend", "label": "backend" },
+      { "environmentId": "env_abc123", "label": "fullstack" },
       { "owner": "your-org", "name": "main-repo" }
     ]
   }'
 ```
 
-Each team maps to an array of repos. If a repo has a `label`, it only matches issues with that
-label. The first repo without a label is the default fallback.
+Each team maps to an array of targets — repositories (`owner`/`name`) or saved environments
+(`environmentId`, the stable `env_…` id shown in the web UI). If a target has a `label`, it only
+matches issues with that label. The first target without a label is the default fallback. An
+environment entry whose environment was deleted is skipped and resolution falls through to the next
+stage.
 
-**Project → repo mapping:**
+**Project → target mapping:**
 
 ```bash
 curl -X PUT https://<your-linear-bot-worker>/config/project-repos \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
   -d '{
-    "LINEAR_PROJECT_ID": { "owner": "your-org", "name": "my-repo" }
+    "LINEAR_PROJECT_ID": { "owner": "your-org", "name": "my-repo" },
+    "OTHER_PROJECT_ID": { "environmentId": "env_abc123" }
   }'
 ```
 
-Project mappings take the highest priority during repo resolution.
+Project mappings take the highest priority during target resolution.
 
 ### 5. Configure Integration Settings (Optional)
 
@@ -133,31 +137,37 @@ On any Linear issue:
 
 ## Repo Resolution
 
-When an issue is triggered, the agent resolves the target GitHub repo using a 4-step cascade:
+When an issue is triggered, the agent resolves the session target using a 4-step cascade:
 
-1. **Project → repo mapping** — static mapping from Linear project IDs (highest priority)
-2. **Team → repo mapping** — static mapping from Linear team IDs, with optional label filtering
+1. **Project → target mapping** — static mapping from Linear project IDs to a repository or a saved
+   environment (highest priority)
+2. **Team → target mapping** — static mapping from Linear team IDs to repositories or saved
+   environments, with optional label filtering
 3. **Linear's `issueRepositorySuggestions` API** — Linear's built-in repo suggestion (>= 70%
    confidence)
 4. **LLM classifier** — uses Claude Haiku to classify based on issue content, labels, and available
    repo descriptions. Asks the user to clarify if confidence is low.
 
+Environment sessions clone the environment's full repository set; integration settings (model,
+enabled-repos allowlist) resolve from the environment's primary repository until environment-level
+settings exist.
+
 ## API Endpoints
 
 All `/config/*` endpoints require HMAC auth via `Authorization: Bearer <token>`.
 
-| Endpoint                     | Method  | Description                               |
-| ---------------------------- | ------- | ----------------------------------------- |
-| `/health`                    | GET     | Health check                              |
-| `/webhook`                   | POST    | Linear webhook receiver                   |
-| `/oauth/authorize`           | GET     | Start OAuth installation flow             |
-| `/oauth/callback`            | GET     | OAuth callback handler                    |
-| `/config/team-repos`         | GET/PUT | Team → repo mapping                       |
-| `/config/project-repos`      | GET/PUT | Project → repo mapping                    |
-| `/config/user-prefs/:userId` | GET/PUT | Per-user model and reasoning preferences  |
-| `/config/triggers`           | GET/PUT | Trigger configuration (legacy)            |
-| `/callbacks/complete`        | POST    | Completion callback from control plane    |
-| `/callbacks/tool_call`       | POST    | Tool progress callback from control plane |
+| Endpoint                     | Method  | Description                                    |
+| ---------------------------- | ------- | ---------------------------------------------- |
+| `/health`                    | GET     | Health check                                   |
+| `/webhook`                   | POST    | Linear webhook receiver                        |
+| `/oauth/authorize`           | GET     | Start OAuth installation flow                  |
+| `/oauth/callback`            | GET     | OAuth callback handler                         |
+| `/config/team-repos`         | GET/PUT | Team → target mapping (repo or environment)    |
+| `/config/project-repos`      | GET/PUT | Project → target mapping (repo or environment) |
+| `/config/user-prefs/:userId` | GET/PUT | Per-user model and reasoning preferences       |
+| `/config/triggers`           | GET/PUT | Trigger configuration (legacy)                 |
+| `/callbacks/complete`        | POST    | Completion callback from control plane         |
+| `/callbacks/tool_call`       | POST    | Tool progress callback from control plane      |
 
 ## Agent Activity Types
 

--- a/packages/linear-bot/src/__tests__/pure-functions.test.ts
+++ b/packages/linear-bot/src/__tests__/pure-functions.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractModelFromLabels,
   resolveSessionModelSettings,
-  resolveStaticRepo,
+  resolveStaticTarget,
 } from "../model-resolution";
 import { isValidPayload, verifyCallbackSignature } from "../callbacks";
 import { buildOAuthSuccessHtml } from "../index";
@@ -63,9 +63,9 @@ describe("extractModelFromLabels", () => {
   });
 });
 
-// ─── resolveStaticRepo ──────────────────────────────────────────────────────
+// ─── resolveStaticTarget ────────────────────────────────────────────────────
 
-describe("resolveStaticRepo", () => {
+describe("resolveStaticTarget", () => {
   const mapping = {
     "team-1": [
       { owner: "org", name: "frontend", label: "frontend" },
@@ -75,21 +75,44 @@ describe("resolveStaticRepo", () => {
   };
 
   it("matches by label", () => {
-    const result = resolveStaticRepo(mapping, "team-1", ["Frontend"]);
+    const result = resolveStaticTarget(mapping, "team-1", ["Frontend"]);
     expect(result).toEqual({ owner: "org", name: "frontend", label: "frontend" });
   });
 
   it("falls back to entry without label", () => {
-    const result = resolveStaticRepo(mapping, "team-1", ["unrelated"]);
+    const result = resolveStaticTarget(mapping, "team-1", ["unrelated"]);
     expect(result).toEqual({ owner: "org", name: "default-repo" });
   });
 
   it("returns null for empty mapping", () => {
-    expect(resolveStaticRepo({}, "team-1")).toBeNull();
+    expect(resolveStaticTarget({}, "team-1")).toBeNull();
   });
 
   it("returns null for unknown team", () => {
-    expect(resolveStaticRepo(mapping, "team-unknown")).toBeNull();
+    expect(resolveStaticTarget(mapping, "team-unknown")).toBeNull();
+  });
+
+  it("matches an environment entry by label", () => {
+    const mixed = {
+      "team-1": [
+        { environmentId: "env_fullstack", label: "fullstack" },
+        { owner: "org", name: "default-repo" },
+      ],
+    };
+    expect(resolveStaticTarget(mixed, "team-1", ["Fullstack"])).toEqual({
+      environmentId: "env_fullstack",
+      label: "fullstack",
+    });
+  });
+
+  it("falls back to a label-less environment entry", () => {
+    const mixed = {
+      "team-1": [
+        { owner: "org", name: "frontend", label: "frontend" },
+        { environmentId: "env_fullstack" },
+      ],
+    };
+    expect(resolveStaticTarget(mixed, "team-1", [])).toEqual({ environmentId: "env_fullstack" });
   });
 });
 

--- a/packages/linear-bot/src/cached-resource.ts
+++ b/packages/linear-bot/src/cached-resource.ts
@@ -1,0 +1,107 @@
+/**
+ * Read-through cache with tiered fallback for the bot's best-effort
+ * control-plane reads: in-memory (TTL) → loader → KV last-known-good copy →
+ * fallback value. **Fails open** — a load problem never blocks issue
+ * handling; callers get the last-known-good copy, or the fallback.
+ *
+ * Repos and environments are declarations over this. Mirrors slack-bot's
+ * classifier/cached-resource.ts.
+ */
+
+import { createKvCacheStore } from "@open-inspect/shared";
+import type { Env } from "./types";
+import {
+  ControlPlaneRequestError,
+  KV_CACHE_TTL_SECONDS,
+  LOCAL_CACHE_TTL_MS,
+} from "./control-plane";
+import { createLogger } from "./logger";
+
+export interface CachedResourceOptions<T> {
+  /**
+   * Snake-case resource name. Names the logger and derives the log
+   * identities: load failures log `control_plane.fetch_<name>` and KV
+   * warnings use `key_prefix: "<name>_cache"`.
+   */
+  name: string;
+  /** KV key for the last-known-good copy (stores the value as JSON). */
+  kvKey: string;
+  /** Fetch and parse the fresh value. A throw falls back to the KV copy. */
+  load: (env: Env, traceId?: string) => Promise<T>;
+  /** Revive a KV hit; return null to treat it as a miss. */
+  deserialize: (cached: unknown) => T | null;
+  /** Served when the loader and the KV copy both fail — the fail-open value. */
+  fallback: T;
+}
+
+export interface CachedResource<T> {
+  get(env: Env, traceId?: string): Promise<T>;
+  /**
+   * Drop the in-memory copy so the next get() reloads. The KV copy is
+   * deliberately kept — it is fallback data, not authority.
+   */
+  invalidate(): void;
+}
+
+export function createCachedResource<T>(options: CachedResourceOptions<T>): CachedResource<T> {
+  const log = createLogger(options.name);
+  const loadFailureEvent = `control_plane.fetch_${options.name}`;
+  const kvLogKeyPrefix = `${options.name}_cache`;
+  let memory: { value: T; timestamp: number } | null = null;
+
+  async function readKvFallback(env: Env): Promise<T> {
+    try {
+      const cached = await createKvCacheStore(env.LINEAR_KV).get(options.kvKey, "json");
+      const value = cached === null ? null : options.deserialize(cached);
+      if (value !== null) return value;
+    } catch (e) {
+      log.warn("kv.get", {
+        key_prefix: kvLogKeyPrefix,
+        error: e instanceof Error ? e : new Error(String(e)),
+      });
+    }
+    return options.fallback;
+  }
+
+  async function get(env: Env, traceId?: string): Promise<T> {
+    if (memory && Date.now() - memory.timestamp < LOCAL_CACHE_TTL_MS) {
+      return memory.value;
+    }
+
+    const startTime = Date.now();
+    try {
+      const value = await options.load(env, traceId);
+      memory = { value, timestamp: Date.now() };
+
+      try {
+        await createKvCacheStore(env.LINEAR_KV).put(options.kvKey, JSON.stringify(value), {
+          expirationTtl: KV_CACHE_TTL_SECONDS,
+        });
+      } catch (e) {
+        log.warn("kv.put", {
+          trace_id: traceId,
+          key_prefix: kvLogKeyPrefix,
+          error: e instanceof Error ? e : new Error(String(e)),
+        });
+      }
+
+      return value;
+    } catch (e) {
+      log.warn(loadFailureEvent, {
+        trace_id: traceId,
+        outcome: "error",
+        http_status: e instanceof ControlPlaneRequestError ? e.status : undefined,
+        error: e instanceof Error ? e : new Error(String(e)),
+        duration_ms: Date.now() - startTime,
+      });
+      return readKvFallback(env);
+    }
+  }
+
+  return {
+    get,
+    invalidate() {
+      memory = null;
+    },
+  };
+}

--- a/packages/linear-bot/src/classifier/repos.ts
+++ b/packages/linear-bot/src/classifier/repos.ts
@@ -1,20 +1,13 @@
 /**
- * Dynamic repository fetching from the control plane.
- * Same pattern as slack-bot: local cache + KV cache + fallback.
+ * Dynamic repository fetching from the control plane. A cached resource
+ * (in-memory → control plane → KV, fail open to an empty list); an empty
+ * repo list surfaces to the user as a clarification asking for the
+ * repository name.
  */
 
 import type { Env, RepoConfig, ControlPlaneRepo, ControlPlaneReposResponse } from "../types";
-import { buildInternalAuthHeaders } from "../utils/internal";
-import { createLogger } from "../logger";
-
-const log = createLogger("repos");
-
-const LOCAL_CACHE_TTL_MS = 60 * 1000;
-
-let localCache: {
-  repos: RepoConfig[];
-  timestamp: number;
-} | null = null;
+import { createCachedResource } from "../cached-resource";
+import { fetchControlPlaneJson } from "../control-plane";
 
 function toRepoConfig(repo: ControlPlaneRepo): RepoConfig {
   const owner = repo.owner.toLowerCase();
@@ -35,82 +28,26 @@ function toRepoConfig(repo: ControlPlaneRepo): RepoConfig {
   };
 }
 
+const reposResource = createCachedResource<RepoConfig[]>({
+  name: "repos",
+  kvKey: "repos:cache",
+  load: async (env, traceId) => {
+    const body = await fetchControlPlaneJson(env, "/repos", traceId);
+    return (body as ControlPlaneReposResponse).repos.map(toRepoConfig);
+  },
+  deserialize: (cached) => (Array.isArray(cached) ? (cached as RepoConfig[]) : null),
+  fallback: [],
+});
+
 export async function getAvailableRepos(env: Env, traceId?: string): Promise<RepoConfig[]> {
-  if (localCache && Date.now() - localCache.timestamp < LOCAL_CACHE_TTL_MS) {
-    return localCache.repos;
-  }
-
-  const startTime = Date.now();
-  try {
-    const headers: Record<string, string> = {
-      Accept: "application/json",
-      ...(await buildInternalAuthHeaders(env.INTERNAL_CALLBACK_SECRET, traceId)),
-    };
-
-    const response = await env.CONTROL_PLANE.fetch("https://internal/repos", { headers });
-
-    if (!response.ok) {
-      log.error("control_plane.fetch_repos", {
-        trace_id: traceId,
-        outcome: "error",
-        http_status: response.status,
-        duration_ms: Date.now() - startTime,
-      });
-      return getFromCacheOrFallback(env);
-    }
-
-    const data = (await response.json()) as ControlPlaneReposResponse;
-    const repos = data.repos.map(toRepoConfig);
-
-    localCache = { repos, timestamp: Date.now() };
-
-    try {
-      await env.LINEAR_KV.put("repos:cache", JSON.stringify(repos), { expirationTtl: 300 });
-    } catch (e) {
-      log.warn("kv.put", {
-        trace_id: traceId,
-        key_prefix: "repos_cache",
-        error: e instanceof Error ? e : new Error(String(e)),
-      });
-    }
-
-    log.info("control_plane.fetch_repos", {
-      trace_id: traceId,
-      outcome: "success",
-      repo_count: repos.length,
-      duration_ms: Date.now() - startTime,
-    });
-
-    return repos;
-  } catch (e) {
-    log.error("control_plane.fetch_repos", {
-      trace_id: traceId,
-      outcome: "error",
-      error: e instanceof Error ? e : new Error(String(e)),
-      duration_ms: Date.now() - startTime,
-    });
-    return getFromCacheOrFallback(env);
-  }
+  return reposResource.get(env, traceId);
 }
 
-async function getFromCacheOrFallback(env: Env): Promise<RepoConfig[]> {
-  try {
-    const cached = await env.LINEAR_KV.get("repos:cache", "json");
-    if (cached && Array.isArray(cached)) {
-      log.info("control_plane.fetch_repos", { source: "kv_cache" });
-      return cached as RepoConfig[];
-    }
-  } catch (e) {
-    log.warn("kv.get", {
-      key_prefix: "repos_cache",
-      error: e instanceof Error ? e : new Error(String(e)),
-    });
-  }
-
-  log.error("control_plane.fetch_repos", {
-    error_message: "No repos available from any source.",
-  });
-  return [];
+/**
+ * Clear the in-memory cache (for testing).
+ */
+export function clearReposLocalCache(): void {
+  reposResource.invalidate();
 }
 
 export async function buildRepoDescriptions(env: Env, traceId?: string): Promise<string> {

--- a/packages/linear-bot/src/control-plane.ts
+++ b/packages/linear-bot/src/control-plane.ts
@@ -1,0 +1,49 @@
+/**
+ * Control-plane read plumbing shared by the bot's cached data modules
+ * (repos, environments): the authenticated fetch and the cache TTLs every
+ * cached read uses. Mirrors slack-bot's classifier/control-plane.ts.
+ */
+
+import { buildInternalAuthHeaders } from "@open-inspect/shared";
+import type { Env } from "./types";
+
+/** Local cache TTL in milliseconds (1 minute). */
+export const LOCAL_CACHE_TTL_MS = 60 * 1000;
+
+/**
+ * Expiration for the KV last-known-good caches (repos, environments), in
+ * seconds — the unit Cloudflare KV's `expirationTtl` expects.
+ */
+export const KV_CACHE_TTL_SECONDS = 300;
+
+/** A non-OK control-plane response, carrying the status for structured logs. */
+export class ControlPlaneRequestError extends Error {
+  constructor(
+    path: string,
+    readonly status: number
+  ) {
+    super(`Control plane GET ${path} failed with ${status}`);
+    this.name = "ControlPlaneRequestError";
+  }
+}
+
+/**
+ * GET a control-plane endpoint and return its JSON body, throwing
+ * {@link ControlPlaneRequestError} on a non-OK response — the loader shape
+ * cached resources expect.
+ */
+export async function fetchControlPlaneJson(
+  env: Env,
+  path: string,
+  traceId?: string
+): Promise<unknown> {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    ...(await buildInternalAuthHeaders(env.INTERNAL_CALLBACK_SECRET, traceId)),
+  };
+  const response = await env.CONTROL_PLANE.fetch(`https://internal${path}`, { headers });
+  if (!response.ok) {
+    throw new ControlPlaneRequestError(path, response.status);
+  }
+  return response.json();
+}

--- a/packages/linear-bot/src/environments.ts
+++ b/packages/linear-bot/src/environments.ts
@@ -1,99 +1,32 @@
 /**
  * Environment fetching from the control plane, for team/project mappings that
- * target a saved environment. Same pattern as classifier/repos.ts: local
- * cache + KV cache + fail open to an empty list, so an environments-fetch
- * problem never blocks issue handling — mappings targeting an environment are
- * simply skipped and resolution falls through to the next stage.
+ * target a saved environment. A cached resource (in-memory → control plane →
+ * KV, **fail open to an empty list**) so an environments-fetch problem never
+ * blocks issue handling — mappings targeting an environment are simply
+ * skipped and resolution falls through to the next stage.
  */
 
 import type { Env, Environment, ListEnvironmentsResponse } from "./types";
-import { buildInternalAuthHeaders } from "./utils/internal";
-import { createLogger } from "./logger";
+import { createCachedResource } from "./cached-resource";
+import { fetchControlPlaneJson } from "./control-plane";
 
-const log = createLogger("environments");
+const environments = createCachedResource<Environment[]>({
+  name: "environments",
+  kvKey: "environments:cache",
+  load: async (env, traceId) => {
+    const body = await fetchControlPlaneJson(env, "/environments", traceId);
+    const list = (body as ListEnvironmentsResponse).environments;
+    return Array.isArray(list) ? list : [];
+  },
+  deserialize: (cached) => (Array.isArray(cached) ? (cached as Environment[]) : null),
+  fallback: [],
+});
 
-const LOCAL_CACHE_TTL_MS = 60 * 1000;
-
-let localCache: {
-  environments: Environment[];
-  timestamp: number;
-} | null = null;
-
+/**
+ * Fetch the workspace's environments from the control plane.
+ */
 export async function getAvailableEnvironments(env: Env, traceId?: string): Promise<Environment[]> {
-  if (localCache && Date.now() - localCache.timestamp < LOCAL_CACHE_TTL_MS) {
-    return localCache.environments;
-  }
-
-  const startTime = Date.now();
-  try {
-    const headers: Record<string, string> = {
-      Accept: "application/json",
-      ...(await buildInternalAuthHeaders(env.INTERNAL_CALLBACK_SECRET, traceId)),
-    };
-
-    const response = await env.CONTROL_PLANE.fetch("https://internal/environments", { headers });
-
-    if (!response.ok) {
-      log.error("control_plane.fetch_environments", {
-        trace_id: traceId,
-        outcome: "error",
-        http_status: response.status,
-        duration_ms: Date.now() - startTime,
-      });
-      return getFromCacheOrFallback(env);
-    }
-
-    const data = (await response.json()) as ListEnvironmentsResponse;
-    const environments = Array.isArray(data.environments) ? data.environments : [];
-
-    localCache = { environments, timestamp: Date.now() };
-
-    try {
-      await env.LINEAR_KV.put("environments:cache", JSON.stringify(environments), {
-        expirationTtl: 300,
-      });
-    } catch (e) {
-      log.warn("kv.put", {
-        trace_id: traceId,
-        key_prefix: "environments_cache",
-        error: e instanceof Error ? e : new Error(String(e)),
-      });
-    }
-
-    log.info("control_plane.fetch_environments", {
-      trace_id: traceId,
-      outcome: "success",
-      environment_count: environments.length,
-      duration_ms: Date.now() - startTime,
-    });
-
-    return environments;
-  } catch (e) {
-    log.error("control_plane.fetch_environments", {
-      trace_id: traceId,
-      outcome: "error",
-      error: e instanceof Error ? e : new Error(String(e)),
-      duration_ms: Date.now() - startTime,
-    });
-    return getFromCacheOrFallback(env);
-  }
-}
-
-async function getFromCacheOrFallback(env: Env): Promise<Environment[]> {
-  try {
-    const cached = await env.LINEAR_KV.get("environments:cache", "json");
-    if (cached && Array.isArray(cached)) {
-      log.info("control_plane.fetch_environments", { source: "kv_cache" });
-      return cached as Environment[];
-    }
-  } catch (e) {
-    log.warn("kv.get", {
-      key_prefix: "environments_cache",
-      error: e instanceof Error ? e : new Error(String(e)),
-    });
-  }
-
-  return [];
+  return environments.get(env, traceId);
 }
 
 /**
@@ -112,5 +45,5 @@ export async function getEnvironmentById(
  * Clear the in-memory cache (for testing).
  */
 export function clearEnvironmentsLocalCache(): void {
-  localCache = null;
+  environments.invalidate();
 }

--- a/packages/linear-bot/src/environments.ts
+++ b/packages/linear-bot/src/environments.ts
@@ -1,0 +1,116 @@
+/**
+ * Environment fetching from the control plane, for team/project mappings that
+ * target a saved environment. Same pattern as classifier/repos.ts: local
+ * cache + KV cache + fail open to an empty list, so an environments-fetch
+ * problem never blocks issue handling — mappings targeting an environment are
+ * simply skipped and resolution falls through to the next stage.
+ */
+
+import type { Env, Environment, ListEnvironmentsResponse } from "./types";
+import { buildInternalAuthHeaders } from "./utils/internal";
+import { createLogger } from "./logger";
+
+const log = createLogger("environments");
+
+const LOCAL_CACHE_TTL_MS = 60 * 1000;
+
+let localCache: {
+  environments: Environment[];
+  timestamp: number;
+} | null = null;
+
+export async function getAvailableEnvironments(env: Env, traceId?: string): Promise<Environment[]> {
+  if (localCache && Date.now() - localCache.timestamp < LOCAL_CACHE_TTL_MS) {
+    return localCache.environments;
+  }
+
+  const startTime = Date.now();
+  try {
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+      ...(await buildInternalAuthHeaders(env.INTERNAL_CALLBACK_SECRET, traceId)),
+    };
+
+    const response = await env.CONTROL_PLANE.fetch("https://internal/environments", { headers });
+
+    if (!response.ok) {
+      log.error("control_plane.fetch_environments", {
+        trace_id: traceId,
+        outcome: "error",
+        http_status: response.status,
+        duration_ms: Date.now() - startTime,
+      });
+      return getFromCacheOrFallback(env);
+    }
+
+    const data = (await response.json()) as ListEnvironmentsResponse;
+    const environments = Array.isArray(data.environments) ? data.environments : [];
+
+    localCache = { environments, timestamp: Date.now() };
+
+    try {
+      await env.LINEAR_KV.put("environments:cache", JSON.stringify(environments), {
+        expirationTtl: 300,
+      });
+    } catch (e) {
+      log.warn("kv.put", {
+        trace_id: traceId,
+        key_prefix: "environments_cache",
+        error: e instanceof Error ? e : new Error(String(e)),
+      });
+    }
+
+    log.info("control_plane.fetch_environments", {
+      trace_id: traceId,
+      outcome: "success",
+      environment_count: environments.length,
+      duration_ms: Date.now() - startTime,
+    });
+
+    return environments;
+  } catch (e) {
+    log.error("control_plane.fetch_environments", {
+      trace_id: traceId,
+      outcome: "error",
+      error: e instanceof Error ? e : new Error(String(e)),
+      duration_ms: Date.now() - startTime,
+    });
+    return getFromCacheOrFallback(env);
+  }
+}
+
+async function getFromCacheOrFallback(env: Env): Promise<Environment[]> {
+  try {
+    const cached = await env.LINEAR_KV.get("environments:cache", "json");
+    if (cached && Array.isArray(cached)) {
+      log.info("control_plane.fetch_environments", { source: "kv_cache" });
+      return cached as Environment[];
+    }
+  } catch (e) {
+    log.warn("kv.get", {
+      key_prefix: "environments_cache",
+      error: e instanceof Error ? e : new Error(String(e)),
+    });
+  }
+
+  return [];
+}
+
+/**
+ * Find an environment by its stable id.
+ */
+export async function getEnvironmentById(
+  env: Env,
+  environmentId: string,
+  traceId?: string
+): Promise<Environment | undefined> {
+  const all = await getAvailableEnvironments(env, traceId);
+  return all.find((environment) => environment.id === environmentId);
+}
+
+/**
+ * Clear the in-memory cache (for testing).
+ */
+export function clearEnvironmentsLocalCache(): void {
+  localCache = null;
+}

--- a/packages/linear-bot/src/index.ts
+++ b/packages/linear-bot/src/index.ts
@@ -30,7 +30,7 @@ import {
 
 // Re-export pure functions for existing test imports
 export {
-  resolveStaticRepo,
+  resolveStaticTarget,
   extractModelFromLabels,
   resolveSessionModelSettings,
 } from "./model-resolution";

--- a/packages/linear-bot/src/model-resolution.ts
+++ b/packages/linear-bot/src/model-resolution.ts
@@ -2,7 +2,7 @@
  * Pure functions for resolving models and repos from configuration + labels.
  */
 
-import type { TeamRepoMapping, StaticRepoConfig } from "./types";
+import type { TeamRepoMapping, StaticTargetConfig } from "./types";
 import {
   getDefaultReasoningEffort,
   getValidModelOrDefault,
@@ -10,20 +10,22 @@ import {
 } from "@open-inspect/shared";
 
 /**
- * Resolve repo from static team mapping (legacy/override).
+ * Resolve a target (repository or environment) from the static team mapping:
+ * the first entry whose label matches an issue label, else the first
+ * label-less entry.
  */
-export function resolveStaticRepo(
+export function resolveStaticTarget(
   teamMapping: TeamRepoMapping,
   teamId: string,
   issueLabels?: string[]
-): StaticRepoConfig | null {
-  const repoConfigs = teamMapping[teamId];
-  if (!repoConfigs || repoConfigs.length === 0) return null;
+): StaticTargetConfig | null {
+  const targetConfigs = teamMapping[teamId];
+  if (!targetConfigs || targetConfigs.length === 0) return null;
 
   const labelSet = new Set((issueLabels || []).map((l) => l.toLowerCase()));
   return (
-    repoConfigs.find((r) => r.label && labelSet.has(r.label.toLowerCase())) ||
-    repoConfigs.find((r) => !r.label) ||
+    targetConfigs.find((t) => t.label && labelSet.has(t.label.toLowerCase())) ||
+    targetConfigs.find((t) => !t.label) ||
     null
   );
 }

--- a/packages/linear-bot/src/target-resolution.ts
+++ b/packages/linear-bot/src/target-resolution.ts
@@ -16,6 +16,7 @@ import { splitRepoFullName } from "./utils/repo";
 import { classifyRepo } from "./classifier";
 import { getAvailableRepos } from "./classifier/repos";
 import { getEnvironmentById } from "./environments";
+import { getLinearConfig, type ResolvedLinearConfig } from "./utils/integration-config";
 import { resolveStaticTarget } from "./model-resolution";
 import { getProjectRepoMapping, getTeamRepoMapping } from "./kv-store";
 import { createLogger } from "./logger";
@@ -40,12 +41,53 @@ export function targetId(target: SessionTarget): string {
 /**
  * The repository whose integration settings govern this launch: the repo
  * itself, or the environment's primary repository — environment-level
- * integration settings are deferred (design §13.5).
+ * integration settings are deferred (design §13.5). Private: every consumer
+ * of the primary-repo rule goes through {@link resolveTargetIntegration}, so
+ * environment-level settings later change exactly one function.
  */
-export function targetSettingsRepoFullName(target: SessionTarget): string {
+function targetSettingsRepoFullName(target: SessionTarget): string {
   if (target.kind === "repository") return target.fullName;
   const primary = target.environment.repositories[0];
   return `${primary.repoOwner}/${primary.repoName}`;
+}
+
+/**
+ * Everything the handler derives from a target's integration settings, so the
+ * primary-repo rule for environments stays inside this module.
+ */
+export interface TargetIntegration {
+  config: ResolvedLinearConfig;
+  /** Whether the integration's enabled-repos allowlist admits this target. */
+  enabled: boolean;
+  /** Lowercased fullName of the repo whose settings governed the lookup. */
+  settingsRepo: string;
+  /** Display subject for the "integration is not enabled" error. */
+  notEnabledSubject: string;
+  /** Value for `LinearCallbackContext.repoFullName` — the context is echoed
+   * back by the control plane and nothing reads this field today. */
+  callbackRepoFullName: string;
+}
+
+/**
+ * Resolve the integration settings governing a target launch.
+ */
+export async function resolveTargetIntegration(
+  env: Env,
+  target: SessionTarget
+): Promise<TargetIntegration> {
+  const callbackRepoFullName = targetSettingsRepoFullName(target);
+  const settingsRepo = callbackRepoFullName.toLowerCase();
+  const config = await getLinearConfig(env, settingsRepo);
+  return {
+    config,
+    enabled: config.enabledRepos === null || config.enabledRepos.includes(settingsRepo),
+    settingsRepo,
+    notEnabledSubject:
+      target.kind === "environment"
+        ? `environment \`${targetLabel(target)}\` (primary repository \`${settingsRepo}\`)`
+        : `\`${targetLabel(target)}\``,
+    callbackRepoFullName,
+  };
 }
 
 /**

--- a/packages/linear-bot/src/target-resolution.ts
+++ b/packages/linear-bot/src/target-resolution.ts
@@ -1,0 +1,214 @@
+/**
+ * Session target resolution for Linear issues.
+ *
+ * Owns the four-stage ladder — project mapping → team mapping → Linear's
+ * repo-suggestions API → LLM classification — and the target-kind policy.
+ * Team and project mappings may name a repository or a saved environment
+ * (design §7.5); the suggestion and classification stages remain
+ * repository-only. Targets unify instead of migrate — repository entries
+ * never stop working; environments join them.
+ */
+
+import type { Env, Environment, AgentSessionWebhookIssue, StaticTargetConfig } from "./types";
+import type { LinearApiClient } from "./utils/linear-client";
+import { emitAgentActivity, getRepoSuggestions } from "./utils/linear-client";
+import { splitRepoFullName } from "./utils/repo";
+import { classifyRepo } from "./classifier";
+import { getAvailableRepos } from "./classifier/repos";
+import { getEnvironmentById } from "./environments";
+import { resolveStaticTarget } from "./model-resolution";
+import { getProjectRepoMapping, getTeamRepoMapping } from "./kv-store";
+import { createLogger } from "./logger";
+
+const log = createLogger("target-resolution");
+
+/** A resolved session launch target: a repository or a saved environment. */
+export type SessionTarget =
+  | { kind: "repository"; owner: string; name: string; fullName: string }
+  | { kind: "environment"; environment: Environment };
+
+/** Display label: the repo fullName or the environment name. */
+export function targetLabel(target: SessionTarget): string {
+  return target.kind === "environment" ? target.environment.name : target.fullName;
+}
+
+/** Stable id for logs: the repo fullName or the environment id ("env_…"). */
+export function targetId(target: SessionTarget): string {
+  return target.kind === "environment" ? target.environment.id : target.fullName;
+}
+
+/**
+ * The repository whose integration settings govern this launch: the repo
+ * itself, or the environment's primary repository — environment-level
+ * integration settings are deferred (design §13.5).
+ */
+export function targetSettingsRepoFullName(target: SessionTarget): string {
+  if (target.kind === "repository") return target.fullName;
+  const primary = target.environment.repositories[0];
+  return `${primary.repoOwner}/${primary.repoName}`;
+}
+
+/**
+ * Create-session request fields for a target: scalar repoOwner/repoName or
+ * environmentId only — the create schema makes the two mutually exclusive.
+ */
+export function targetRequestFields(
+  target: SessionTarget
+): { repoOwner: string; repoName: string } | { environmentId: string } {
+  return target.kind === "environment"
+    ? { environmentId: target.environment.id }
+    : { repoOwner: target.owner, repoName: target.name };
+}
+
+function repositoryTarget(owner: string, name: string, fullName?: string): SessionTarget {
+  return { kind: "repository", owner, name, fullName: fullName ?? `${owner}/${name}` };
+}
+
+/**
+ * Resolve a mapping entry to a target. Environment entries are validated
+ * against the live environment list; an unknown (deleted or unfetchable)
+ * environment returns null so resolution falls through to the next stage,
+ * like a rule targeting an inaccessible repository.
+ */
+async function resolveMappedTarget(
+  env: Env,
+  config: StaticTargetConfig,
+  traceId: string
+): Promise<SessionTarget | null> {
+  if ("environmentId" in config) {
+    const environment = await getEnvironmentById(env, config.environmentId, traceId);
+    if (!environment) {
+      log.warn("target.environment_not_found", {
+        trace_id: traceId,
+        environment_id: config.environmentId,
+      });
+      return null;
+    }
+    return { kind: "environment", environment };
+  }
+  return repositoryTarget(config.owner, config.name);
+}
+
+export interface ResolveSessionTargetParams {
+  env: Env;
+  client: LinearApiClient;
+  agentSessionId: string;
+  issue: AgentSessionWebhookIssue;
+  labelNames: string[];
+  projectInfo: { id: string; name: string } | null | undefined;
+  comment: { body: string } | null | undefined;
+  traceId: string;
+}
+
+export interface ResolvedSessionTarget {
+  target: SessionTarget;
+  reasoning: string | null;
+}
+
+/**
+ * Resolve the session target for an issue, or null after eliciting
+ * clarification from the user (classification too uncertain to act on).
+ */
+export async function resolveSessionTarget(
+  params: ResolveSessionTargetParams
+): Promise<ResolvedSessionTarget | null> {
+  const { env, client, agentSessionId, issue, labelNames, projectInfo, comment, traceId } = params;
+
+  // 1. Check project→target mapping FIRST
+  if (projectInfo?.id) {
+    const projectMapping = await getProjectRepoMapping(env);
+    const mapped = projectMapping[projectInfo.id];
+    if (mapped) {
+      const target = await resolveMappedTarget(env, mapped, traceId);
+      if (target) {
+        return {
+          target,
+          reasoning: `Project "${projectInfo.name}" is mapped to ${targetLabel(target)}`,
+        };
+      }
+    }
+  }
+
+  // 2. Check static team→target mapping (override)
+  const teamId = issue.team?.id ?? "";
+  if (teamId) {
+    const teamMapping = await getTeamRepoMapping(env);
+    const staticConfig = resolveStaticTarget(teamMapping, teamId, labelNames);
+    if (staticConfig) {
+      const target = await resolveMappedTarget(env, staticConfig, traceId);
+      if (target) return { target, reasoning: "Team static mapping" };
+    }
+  }
+
+  // 3. Try Linear's built-in issueRepositorySuggestions API
+  const repos = await getAvailableRepos(env, traceId);
+  if (repos.length > 0) {
+    const candidates = repos.map((r) => ({
+      hostname: "github.com",
+      repositoryFullName: `${r.owner}/${r.name}`,
+    }));
+
+    const suggestions = await getRepoSuggestions(client, issue.id, agentSessionId, candidates);
+    const topSuggestion = suggestions.find((s) => s.confidence >= 0.7);
+    if (topSuggestion) {
+      // Split on the last slash — GitLab nested-group paths
+      // ("group/subgroup/project") carry slashes in the owner.
+      const { owner, name } = splitRepoFullName(topSuggestion.repositoryFullName);
+      return {
+        target: repositoryTarget(owner, name, topSuggestion.repositoryFullName),
+        reasoning: `Linear suggested ${topSuggestion.repositoryFullName} (confidence: ${Math.round(topSuggestion.confidence * 100)}%)`,
+      };
+    }
+  }
+
+  // 4. Fall back to our LLM classification
+  await emitAgentActivity(
+    client,
+    agentSessionId,
+    {
+      type: "thought",
+      body: "Classifying repository using AI...",
+    },
+    true
+  );
+
+  const classification = await classifyRepo(
+    env,
+    issue.title,
+    issue.description,
+    labelNames,
+    projectInfo?.name,
+    issue.team?.name ?? null,
+    issue.team?.key ?? null,
+    comment?.body,
+    traceId
+  );
+
+  if (classification.needsClarification || !classification.repo) {
+    const altList = (classification.alternatives || [])
+      .map((r) => `- **${r.fullName}**: ${r.description}`)
+      .join("\n");
+
+    await emitAgentActivity(client, agentSessionId, {
+      type: "elicitation",
+      body: `I couldn't determine which repository to work on.\n\n${classification.reasoning}\n\n**Available repositories:**\n${altList || "None available"}\n\nPlease reply with the repository name (e.g., \`owner/repo\`).`,
+    });
+
+    log.warn("agent_session.classification_uncertain", {
+      trace_id: traceId,
+      issue_identifier: issue.identifier,
+      confidence: classification.confidence,
+      reasoning: classification.reasoning,
+    });
+    return null;
+  }
+
+  return {
+    target: repositoryTarget(
+      classification.repo.owner,
+      classification.repo.name,
+      classification.repo.fullName
+    ),
+    reasoning: classification.reasoning,
+  };
+}

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -63,10 +63,25 @@ export interface StaticRepoConfig {
 }
 
 /**
- * Static team→repo mapping stored in KV under "config:team-repos".
+ * An environment target with an optional label filter. References the stable
+ * `env_…` id, not the rename-able display name.
+ */
+export interface StaticEnvironmentConfig {
+  environmentId: string;
+  label?: string;
+}
+
+/**
+ * A mapping entry: a repository or a saved environment. Targets unify instead
+ * of migrate — repository entries never stop working; environments join them.
+ */
+export type StaticTargetConfig = StaticRepoConfig | StaticEnvironmentConfig;
+
+/**
+ * Static team→target mapping stored in KV under "config:team-repos".
  */
 export interface TeamRepoMapping {
-  [teamId: string]: StaticRepoConfig[];
+  [teamId: string]: StaticTargetConfig[];
 }
 
 /**
@@ -77,13 +92,15 @@ export type {
   RepoMetadata,
   ControlPlaneRepo,
   ControlPlaneReposResponse,
+  Environment,
+  ListEnvironmentsResponse,
 } from "@open-inspect/shared";
 
 /**
- * Project→repo mapping stored in KV under "config:project-repos".
+ * Project→target mapping stored in KV under "config:project-repos".
  */
 export interface ProjectRepoMapping {
-  [projectId: string]: { owner: string; name: string };
+  [projectId: string]: { owner: string; name: string } | { environmentId: string };
 }
 
 /**
@@ -102,8 +119,11 @@ export interface IssueSession {
   sessionId: string;
   issueId: string;
   issueIdentifier: string;
-  repoOwner: string;
-  repoName: string;
+  /** Set for repository sessions; absent for environment sessions. */
+  repoOwner?: string;
+  repoName?: string;
+  /** Set for environment sessions. */
+  environmentId?: string;
   model: string;
   agentSessionId?: string;
   createdAt: number;

--- a/packages/linear-bot/src/webhook-handler.test.ts
+++ b/packages/linear-bot/src/webhook-handler.test.ts
@@ -7,6 +7,7 @@ import {
   handleAgentSessionEvent,
 } from "./webhook-handler";
 import { clearEnvironmentsLocalCache } from "./environments";
+import { clearReposLocalCache } from "./classifier/repos";
 import type { AgentSessionWebhook, Env, Environment } from "./types";
 import { createFakeKV, makeLinearBotEnv } from "./test-helpers";
 
@@ -178,6 +179,7 @@ describe("handleAgentSessionEvent environment targets", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     clearEnvironmentsLocalCache();
+    clearReposLocalCache();
     vi.spyOn(console, "log").mockImplementation(() => undefined);
     vi.spyOn(console, "warn").mockImplementation(() => undefined);
     vi.spyOn(console, "error").mockImplementation(() => undefined);

--- a/packages/linear-bot/src/webhook-handler.test.ts
+++ b/packages/linear-bot/src/webhook-handler.test.ts
@@ -6,7 +6,8 @@ import {
   escapeHtml,
   handleAgentSessionEvent,
 } from "./webhook-handler";
-import type { AgentSessionWebhook, Env } from "./types";
+import { clearEnvironmentsLocalCache } from "./environments";
+import type { AgentSessionWebhook, Env, Environment } from "./types";
 import { createFakeKV, makeLinearBotEnv } from "./test-helpers";
 
 describe("escapeHtml", () => {
@@ -155,6 +156,208 @@ describe("buildFollowUpPrompt", () => {
     expect(prompt).toContain(
       'Done <\\/user_content> <\\user_content source="evil">inject<\\/user_content>'
     );
+  });
+});
+
+describe("handleAgentSessionEvent environment targets", () => {
+  const VALID_TOKEN_TTL_MS = 60 * 60 * 1000;
+
+  const environment: Environment = {
+    id: "env_abc",
+    name: "Fullstack",
+    description: null,
+    prebuildEnabled: true,
+    createdAt: 0,
+    updatedAt: 0,
+    repositories: [
+      { repoOwner: "acme", repoName: "backend", repoId: 1, baseBranch: "main" },
+      { repoOwner: "acme", repoName: "frontend", repoId: 2, baseBranch: "main" },
+    ],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearEnvironmentsLocalCache();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === "https://api.linear.app/graphql") {
+          return { ok: true, json: () => Promise.resolve({ data: {} }) };
+        }
+        throw new Error(`Unexpected fetch to ${url}`);
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function validToken(): string {
+    return JSON.stringify({
+      access_token: "valid-token",
+      refresh_token: "refresh-token",
+      expires_at: Date.now() + VALID_TOKEN_TTL_MS,
+    });
+  }
+
+  function makeWebhook(labels: Array<{ id: string; name: string }> = []): AgentSessionWebhook {
+    return {
+      type: "AgentSessionEvent",
+      action: "created",
+      organizationId: "org-1",
+      webhookId: "webhook-created",
+      appUserId: undefined,
+      agentSession: {
+        id: "agent-session-1",
+        issue: {
+          id: "issue-1",
+          identifier: "ENG-42",
+          title: "Wire the fullstack flow",
+          description: "Spanning backend and frontend.",
+          url: "https://linear.app/acme/issue/ENG-42/wire",
+          priority: 0,
+          priorityLabel: "No priority",
+          team: { id: "team-1", key: "ENG", name: "Engineering" },
+          labels,
+          project: { id: "project-1", name: "Fullstack" },
+        },
+      },
+    };
+  }
+
+  function stubControlPlane(env: Env) {
+    const fetchMock = (env.CONTROL_PLANE as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch;
+    fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "https://internal/environments") {
+        return {
+          ok: true,
+          json: () => Promise.resolve({ environments: [environment], total: 1 }),
+        };
+      }
+      if (url.startsWith("https://internal/integration-settings/linear/resolved/")) {
+        return { ok: true, json: () => Promise.resolve({ config: null }) };
+      }
+      if (url === "https://internal/sessions") {
+        return { ok: true, json: () => Promise.resolve({ sessionId: "session-xyz" }) };
+      }
+      if (url === "https://internal/sessions/session-xyz/prompt") {
+        return { ok: true, json: () => Promise.resolve({ ok: true }) };
+      }
+      if (url === "https://internal/repos") {
+        return { ok: true, json: () => Promise.resolve({ repos: [] }) };
+      }
+      throw new Error(`Unexpected control-plane fetch to ${url}`);
+    });
+    return fetchMock;
+  }
+
+  function createSessionBody(fetchMock: ReturnType<typeof vi.fn>): Record<string, unknown> | null {
+    const call = fetchMock.mock.calls.find(
+      ([input]) => String(input) === "https://internal/sessions"
+    );
+    if (!call) return null;
+    return JSON.parse(String((call[1] as RequestInit).body)) as Record<string, unknown>;
+  }
+
+  it("creates an environment session from a project mapping", async () => {
+    const { kv, store } = createFakeKV({
+      "oauth:token:org-1": validToken(),
+      "config:project-repos": JSON.stringify({ "project-1": { environmentId: "env_abc" } }),
+    });
+    const env = makeLinearBotEnv(kv, { INTERNAL_CALLBACK_SECRET: "internal-secret" });
+    const fetchMock = stubControlPlane(env);
+
+    await handleAgentSessionEvent(makeWebhook(), env, "trace-env-1");
+
+    const body = createSessionBody(fetchMock);
+    expect(body).toMatchObject({
+      environmentId: "env_abc",
+      title: "ENG-42: Wire the fullstack flow",
+      spawnSource: "linear-bot",
+    });
+    expect(body).not.toHaveProperty("repoOwner");
+    expect(body).not.toHaveProperty("repoName");
+
+    // Integration settings resolve from the environment's primary repository
+    const settingsUrls = fetchMock.mock.calls
+      .map(([input]) => String(input))
+      .filter((url) => url.includes("/integration-settings/"));
+    expect(settingsUrls).toEqual([
+      "https://internal/integration-settings/linear/resolved/acme/backend",
+    ]);
+
+    const issueSession = JSON.parse(store.get("issue:issue-1") ?? "null") as Record<
+      string,
+      unknown
+    > | null;
+    expect(issueSession).toMatchObject({ sessionId: "session-xyz", environmentId: "env_abc" });
+    expect(issueSession).not.toHaveProperty("repoOwner");
+  });
+
+  it("creates an environment session from a label-matched team mapping", async () => {
+    const { kv } = createFakeKV({
+      "oauth:token:org-1": validToken(),
+      "config:team-repos": JSON.stringify({
+        "team-1": [
+          { owner: "acme", name: "backend" },
+          { environmentId: "env_abc", label: "fullstack" },
+        ],
+      }),
+    });
+    const env = makeLinearBotEnv(kv);
+    const fetchMock = stubControlPlane(env);
+
+    const webhook = makeWebhook([{ id: "label-1", name: "Fullstack" }]);
+    delete webhook.agentSession.issue!.project;
+
+    await handleAgentSessionEvent(webhook, env, "trace-env-2");
+
+    expect(createSessionBody(fetchMock)).toMatchObject({ environmentId: "env_abc" });
+  });
+
+  it("falls through when the mapped environment does not exist", async () => {
+    const { kv } = createFakeKV({
+      "oauth:token:org-1": validToken(),
+      "config:project-repos": JSON.stringify({ "project-1": { environmentId: "env_missing" } }),
+    });
+    const env = makeLinearBotEnv(kv);
+    const fetchMock = stubControlPlane(env);
+
+    await handleAgentSessionEvent(makeWebhook(), env, "trace-env-3");
+
+    // No repos and no matching environment → clarification, never a session
+    expect(createSessionBody(fetchMock)).toBeNull();
+  });
+
+  it("still creates repository sessions from repo mappings", async () => {
+    const { kv, store } = createFakeKV({
+      "oauth:token:org-1": validToken(),
+      "config:project-repos": JSON.stringify({
+        "project-1": { owner: "acme", name: "backend" },
+      }),
+    });
+    const env = makeLinearBotEnv(kv);
+    const fetchMock = stubControlPlane(env);
+
+    await handleAgentSessionEvent(makeWebhook(), env, "trace-env-4");
+
+    const body = createSessionBody(fetchMock);
+    expect(body).toMatchObject({ repoOwner: "acme", repoName: "backend" });
+    expect(body).not.toHaveProperty("environmentId");
+
+    const issueSession = JSON.parse(store.get("issue:issue-1") ?? "null") as Record<
+      string,
+      unknown
+    > | null;
+    expect(issueSession).toMatchObject({ repoOwner: "acme", repoName: "backend" });
+    expect(issueSession).not.toHaveProperty("environmentId");
   });
 });
 

--- a/packages/linear-bot/src/webhook-handler.ts
+++ b/packages/linear-bot/src/webhook-handler.ts
@@ -20,16 +20,15 @@ import {
 } from "./utils/linear-client";
 import type { LinearApiClient } from "./utils/linear-client";
 import { buildInternalAuthHeaders } from "./utils/internal";
-import { getLinearConfig } from "./utils/integration-config";
 import { createLogger } from "./logger";
 import { makePlan } from "./plan";
 import { extractModelFromLabels, resolveSessionModelSettings } from "./model-resolution";
 import {
   resolveSessionTarget,
+  resolveTargetIntegration,
   targetId,
   targetLabel,
   targetRequestFields,
-  targetSettingsRepoFullName,
   type SessionTarget,
 } from "./target-resolution";
 import { getUserPreferences, lookupIssueSession, storeIssueSession } from "./kv-store";
@@ -395,28 +394,19 @@ async function handleNewSession(
 
   const { target, reasoning: classificationReasoning } = resolved;
   const label = targetLabel(target);
-  // Integration settings resolve per repository; environments use their
-  // primary repository's settings until env-level settings exist (§13.5).
-  const settingsRepo = targetSettingsRepoFullName(target).toLowerCase();
 
-  const integrationConfig = await getLinearConfig(env, settingsRepo);
-  if (
-    integrationConfig.enabledRepos !== null &&
-    !integrationConfig.enabledRepos.includes(settingsRepo)
-  ) {
-    const subject =
-      target.kind === "environment"
-        ? `environment \`${label}\` (primary repository \`${settingsRepo}\`)`
-        : `\`${label}\``;
+  const integration = await resolveTargetIntegration(env, target);
+  const integrationConfig = integration.config;
+  if (!integration.enabled) {
     await emitAgentActivity(client, agentSessionId, {
       type: "error",
-      body: `The Linear integration is not enabled for ${subject}.`,
+      body: `The Linear integration is not enabled for ${integration.notEnabledSubject}.`,
     });
     log.info("agent_session.repo_not_enabled", {
       trace_id: traceId,
       issue_identifier: issue.identifier,
       target: targetId(target),
-      repo: settingsRepo,
+      repo: integration.settingsRepo,
     });
     return;
   }
@@ -502,9 +492,7 @@ async function handleNewSession(
     sessionId: session.sessionId,
     issueId: issue.id,
     issueIdentifier: issue.identifier,
-    ...(target.kind === "environment"
-      ? { environmentId: target.environment.id }
-      : { repoOwner: target.owner, repoName: target.name }),
+    ...targetRequestFields(target),
     model,
     agentSessionId,
     createdAt: Date.now(),
@@ -534,9 +522,7 @@ async function handleNewSession(
     issueId: issue.id,
     issueIdentifier: issue.identifier,
     issueUrl: issue.url,
-    // Environment sessions carry the primary repository — the context is
-    // echoed back by the control plane and nothing reads this field today.
-    repoFullName: targetSettingsRepoFullName(target),
+    repoFullName: integration.callbackRepoFullName,
     model,
     agentSessionId,
     organizationId: orgId,

--- a/packages/linear-bot/src/webhook-handler.ts
+++ b/packages/linear-bot/src/webhook-handler.ts
@@ -17,28 +17,22 @@ import {
   fetchIssueDetails,
   fetchUser,
   updateAgentSession,
-  getRepoSuggestions,
 } from "./utils/linear-client";
 import type { LinearApiClient } from "./utils/linear-client";
 import { buildInternalAuthHeaders } from "./utils/internal";
-import { splitRepoFullName } from "./utils/repo";
-import { classifyRepo } from "./classifier";
-import { getAvailableRepos } from "./classifier/repos";
 import { getLinearConfig } from "./utils/integration-config";
 import { createLogger } from "./logger";
 import { makePlan } from "./plan";
+import { extractModelFromLabels, resolveSessionModelSettings } from "./model-resolution";
 import {
-  resolveStaticRepo,
-  extractModelFromLabels,
-  resolveSessionModelSettings,
-} from "./model-resolution";
-import {
-  getTeamRepoMapping,
-  getProjectRepoMapping,
-  getUserPreferences,
-  lookupIssueSession,
-  storeIssueSession,
-} from "./kv-store";
+  resolveSessionTarget,
+  targetId,
+  targetLabel,
+  targetRequestFields,
+  targetSettingsRepoFullName,
+  type SessionTarget,
+} from "./target-resolution";
+import { getUserPreferences, lookupIssueSession, storeIssueSession } from "./kv-store";
 
 const log = createLogger("handler");
 
@@ -137,9 +131,8 @@ async function getAuthHeaders(env: Env, traceId?: string): Promise<Record<string
  */
 async function createSession(
   env: Env,
+  target: SessionTarget,
   params: {
-    repoOwner: string;
-    repoName: string;
     title: string;
     model: string;
     reasoningEffort?: string;
@@ -154,6 +147,7 @@ async function createSession(
     method: "POST",
     headers,
     body: JSON.stringify({
+      ...targetRequestFields(target),
       ...params,
       spawnSource: "linear-bot",
     }),
@@ -385,137 +379,44 @@ async function handleNewSession(
   const labelNames = labels.map((l) => l.name);
   const projectInfo = issueDetails?.project || issue.project;
 
-  // ─── Resolve repo ─────────────────────────────────────────────────────
+  // ─── Resolve target ───────────────────────────────────────────────────
 
-  let repoOwner: string | null = null;
-  let repoName: string | null = null;
-  let repoFullName: string | null = null;
-  let classificationReasoning: string | null = null;
+  const resolved = await resolveSessionTarget({
+    env,
+    client,
+    agentSessionId,
+    issue,
+    labelNames,
+    projectInfo,
+    comment,
+    traceId,
+  });
+  if (!resolved) return;
 
-  // 1. Check project→repo mapping FIRST
-  if (projectInfo?.id) {
-    const projectMapping = await getProjectRepoMapping(env);
-    const mapped = projectMapping[projectInfo.id];
-    if (mapped) {
-      repoOwner = mapped.owner;
-      repoName = mapped.name;
-      repoFullName = `${mapped.owner}/${mapped.name}`;
-      classificationReasoning = `Project "${projectInfo.name}" is mapped to ${repoFullName}`;
-    }
-  }
+  const { target, reasoning: classificationReasoning } = resolved;
+  const label = targetLabel(target);
+  // Integration settings resolve per repository; environments use their
+  // primary repository's settings until env-level settings exist (§13.5).
+  const settingsRepo = targetSettingsRepoFullName(target).toLowerCase();
 
-  // 2. Check static team→repo mapping (override)
-  if (!repoOwner) {
-    const teamMapping = await getTeamRepoMapping(env);
-    const teamId = issue.team?.id ?? "";
-    if (teamId && teamMapping[teamId] && teamMapping[teamId].length > 0) {
-      const staticRepo = resolveStaticRepo(teamMapping, teamId, labelNames);
-      if (staticRepo) {
-        repoOwner = staticRepo.owner;
-        repoName = staticRepo.name;
-        repoFullName = `${staticRepo.owner}/${staticRepo.name}`;
-        classificationReasoning = `Team static mapping`;
-      }
-    }
-  }
-
-  // 3. Try Linear's built-in issueRepositorySuggestions API
-  if (!repoOwner) {
-    const repos = await getAvailableRepos(env, traceId);
-    if (repos.length > 0) {
-      const candidates = repos.map((r) => ({
-        hostname: "github.com",
-        repositoryFullName: `${r.owner}/${r.name}`,
-      }));
-
-      const suggestions = await getRepoSuggestions(client, issue.id, agentSessionId, candidates);
-      const topSuggestion = suggestions.find((s) => s.confidence >= 0.7);
-      if (topSuggestion) {
-        // Split on the last slash — GitLab nested-group paths
-        // ("group/subgroup/project") carry slashes in the owner.
-        const { owner, name } = splitRepoFullName(topSuggestion.repositoryFullName);
-        repoOwner = owner;
-        repoName = name;
-        repoFullName = topSuggestion.repositoryFullName;
-        classificationReasoning = `Linear suggested ${repoFullName} (confidence: ${Math.round(topSuggestion.confidence * 100)}%)`;
-      }
-    }
-  }
-
-  // 4. Fall back to our LLM classification
-  if (!repoOwner) {
-    await emitAgentActivity(
-      client,
-      agentSessionId,
-      {
-        type: "thought",
-        body: "Classifying repository using AI...",
-      },
-      true
-    );
-
-    const classification = await classifyRepo(
-      env,
-      issue.title,
-      issue.description,
-      labelNames,
-      projectInfo?.name,
-      issue.team?.name ?? null,
-      issue.team?.key ?? null,
-      comment?.body,
-      traceId
-    );
-
-    if (classification.needsClarification || !classification.repo) {
-      const altList = (classification.alternatives || [])
-        .map((r) => `- **${r.fullName}**: ${r.description}`)
-        .join("\n");
-
-      await emitAgentActivity(client, agentSessionId, {
-        type: "elicitation",
-        body: `I couldn't determine which repository to work on.\n\n${classification.reasoning}\n\n**Available repositories:**\n${altList || "None available"}\n\nPlease reply with the repository name (e.g., \`owner/repo\`).`,
-      });
-
-      log.warn("agent_session.classification_uncertain", {
-        trace_id: traceId,
-        issue_identifier: issue.identifier,
-        confidence: classification.confidence,
-        reasoning: classification.reasoning,
-      });
-      return;
-    }
-
-    repoOwner = classification.repo.owner;
-    repoName = classification.repo.name;
-    repoFullName = classification.repo.fullName;
-    classificationReasoning = classification.reasoning;
-  }
-
-  if (!repoOwner || !repoName || !repoFullName) {
-    await emitAgentActivity(client, agentSessionId, {
-      type: "elicitation",
-      body: "I couldn't determine which repository to work on. Please reply with the repository name (e.g., `owner/repo`).",
-    });
-    log.warn("agent_session.repo_resolution_failed", {
-      trace_id: traceId,
-      issue_identifier: issue.identifier,
-    });
-    return;
-  }
-
-  const integrationConfig = await getLinearConfig(env, repoFullName.toLowerCase());
+  const integrationConfig = await getLinearConfig(env, settingsRepo);
   if (
     integrationConfig.enabledRepos !== null &&
-    !integrationConfig.enabledRepos.includes(repoFullName.toLowerCase())
+    !integrationConfig.enabledRepos.includes(settingsRepo)
   ) {
+    const subject =
+      target.kind === "environment"
+        ? `environment \`${label}\` (primary repository \`${settingsRepo}\`)`
+        : `\`${label}\``;
     await emitAgentActivity(client, agentSessionId, {
       type: "error",
-      body: `The Linear integration is not enabled for \`${repoFullName}\`.`,
+      body: `The Linear integration is not enabled for ${subject}.`,
     });
     log.info("agent_session.repo_not_enabled", {
       trace_id: traceId,
       issue_identifier: issue.identifier,
-      repo: repoFullName,
+      target: targetId(target),
+      repo: settingsRepo,
     });
     return;
   }
@@ -559,16 +460,15 @@ async function handleNewSession(
     agentSessionId,
     {
       type: "thought",
-      body: `Creating coding session on ${repoFullName} (model: ${model})...`,
+      body: `Creating coding session on ${label} (model: ${model})...`,
     },
     true
   );
 
   const sessionResult = await createSession(
     env,
+    target,
     {
-      repoOwner: repoOwner!,
-      repoName: repoName!,
       title: `${issue.identifier}: ${issue.title}`,
       model,
       reasoningEffort,
@@ -587,7 +487,7 @@ async function handleNewSession(
     log.error("control_plane.create_session", {
       trace_id: traceId,
       issue_identifier: issue.identifier,
-      repo: repoFullName,
+      target: targetId(target),
       http_status: sessionResult.status,
       response_body: sessionResult.body.slice(0, 500),
       duration_ms: Date.now() - startTime,
@@ -602,8 +502,9 @@ async function handleNewSession(
     sessionId: session.sessionId,
     issueId: issue.id,
     issueIdentifier: issue.identifier,
-    repoOwner: repoOwner!,
-    repoName: repoName!,
+    ...(target.kind === "environment"
+      ? { environmentId: target.environment.id }
+      : { repoOwner: target.owner, repoName: target.name }),
     model,
     agentSessionId,
     createdAt: Date.now(),
@@ -633,7 +534,9 @@ async function handleNewSession(
     issueId: issue.id,
     issueIdentifier: issue.identifier,
     issueUrl: issue.url,
-    repoFullName: repoFullName!,
+    // Environment sessions carry the primary repository — the context is
+    // echoed back by the control plane and nothing reads this field today.
+    repoFullName: targetSettingsRepoFullName(target),
     model,
     agentSessionId,
     organizationId: orgId,
@@ -678,7 +581,7 @@ async function handleNewSession(
 
   await emitAgentActivity(client, agentSessionId, {
     type: "thought",
-    body: `Working on \`${repoFullName}\` with **${model}**.\n\n${classificationReasoning ? `*${classificationReasoning}*\n\n` : ""}[View session](${env.WEB_APP_URL}/session/${session.sessionId})`,
+    body: `Working on \`${label}\` with **${model}**.\n\n${classificationReasoning ? `*${classificationReasoning}*\n\n` : ""}[View session](${env.WEB_APP_URL}/session/${session.sessionId})`,
   });
 
   log.info("agent_session.session_created", {
@@ -686,7 +589,7 @@ async function handleNewSession(
     session_id: session.sessionId,
     agent_session_id: agentSessionId,
     issue_identifier: issue.identifier,
-    repo: repoFullName,
+    target: targetId(target),
     model,
     classification_reasoning: classificationReasoning,
     duration_ms: Date.now() - startTime,


### PR DESCRIPTION
## Summary

Linear-bot slice of the environments Phase 3 rollout (design §7.5): the team and project KV mappings can now target a saved environment alongside repositories, so a Linear issue can launch a full multi-repo workspace deterministically.

- **Mapping entries accept `{ "environmentId": "env_…" }`** (the stable id, not the rename-able display name) alongside `{ "owner", "name" }`, in both `config:team-repos` (with the existing optional `label` filter) and `config:project-repos`. Targets unify instead of migrate — repository entries never stop working.
- **New `target-resolution.ts`** extracts the 4-stage ladder (project mapping → team mapping → Linear repo suggestions → LLM classifier) out of `webhook-handler.ts` and owns the target-kind policy (`SessionTarget` union, labels, create-request fields). The suggestion and classifier stages remain repository-only for now (parity with the design's staged rollout).
- **Unknown environments fail open**: an entry whose environment was deleted (or when the environments fetch fails) is skipped with a warning and resolution falls through to the next stage — mirroring how the Slack classifier skips rules targeting inaccessible targets.
- **New `environments.ts`** fetch helper mirroring `classifier/repos.ts` (in-memory 60s → control plane → KV 300s, fail open to `[]`).
- **Session creation** sends `{ environmentId }` XOR `{ repoOwner, repoName }` (the create schema makes the two mutually exclusive). The issue→session KV record stores the environment id for environment sessions.
- **Integration settings** (enabled-repos gate, model config) resolve from the environment's **primary repository** until environment-level integration settings exist (design §13.5); `callbackContext.repoFullName` carries the primary repo (the field is echoed back and unread today).
- `resolveStaticRepo` → `resolveStaticTarget` (it no longer resolves only repos).

## Behavior notes

- Deterministic paths only: ambient issues with no mapping still classify over repositories.
- Repository mappings, label filtering, and the elicitation flow are byte-for-byte unchanged in behavior.
- The previously unreachable final "couldn't determine repository" guard in `handleNewSession` is gone — the extracted resolver always returns a full target or elicits.

## Testing

- `resolveStaticTarget`: environment entries match by label and as label-less fallback.
- Handler tests (new): project→environment mapping creates a session with `environmentId` and no repo scalars, settings resolve from the primary repo, KV issue record stores the environment id; label-matched team→environment mapping; unknown environment falls through without creating a session; repository mappings still produce repo sessions.
- Full suite: 131 linear-bot tests green; repo-wide lint, typecheck, format clean.

Part of the multi-repo sessions / environments Phase 3 rollout (after #924, #927, #928).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linear sessions can now target either a GitHub repository or a saved environment.
  * Team and project mappings support environment-based routing, including label-aware matching and consistent fallback behavior.
* **Bug Fixes**
  * Improved control-plane fetching with read-through caching and fail-open behavior, reducing failures when environment/repo data can’t be loaded.
* **Documentation**
  * Updated session-targeting and repo-resolution docs with environment vs repository guidance and refreshed configuration examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->