### PR TITLE
fix(web): show session search empty state

### DIFF
--- a/packages/web/src/components/session-sidebar.test.tsx
+++ b/packages/web/src/components/session-sidebar.test.tsx
@@ -122,6 +122,81 @@ describe("SessionSidebar", () => {
     expect(screen.getByText("Grandchild session")).toBeInTheDocument();
   });
 
+  it("shows an empty state for an unmatched search and restores sessions when cleared", async () => {
+    render(
+      <SWRConfig
+        value={{
+          fallback: { [SIDEBAR_SESSIONS_KEY]: { sessions: [createSession(1)], hasMore: false } },
+          dedupingInterval: 0,
+          revalidateOnFocus: false,
+        }}
+      >
+        <SessionSidebar />
+      </SWRConfig>
+    );
+
+    expect(await screen.findByText("Session 1")).toBeInTheDocument();
+
+    const searchInput = screen.getByPlaceholderText("Search sessions...");
+    fireEvent.change(searchInput, { target: { value: "missing" } });
+
+    expect(screen.getByText("No matching sessions")).toBeInTheDocument();
+    expect(screen.queryByText("Session 1")).not.toBeInTheDocument();
+
+    fireEvent.change(searchInput, { target: { value: "" } });
+
+    expect(screen.getByText("Session 1")).toBeInTheDocument();
+    expect(screen.queryByText("No matching sessions")).not.toBeInTheDocument();
+  });
+
+  it("keeps the genuine empty-session state distinct from empty search results", () => {
+    render(
+      <SWRConfig
+        value={{
+          fallback: { [SIDEBAR_SESSIONS_KEY]: { sessions: [], hasMore: false } },
+          dedupingInterval: 0,
+          revalidateOnFocus: false,
+        }}
+      >
+        <SessionSidebar />
+      </SWRConfig>
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Search sessions..."), {
+      target: { value: "missing" },
+    });
+
+    expect(screen.getByText("No sessions yet")).toBeInTheDocument();
+    expect(screen.queryByText("No matching sessions")).not.toBeInTheDocument();
+  });
+
+  it("keeps the session-loading failure distinct from empty search results", async () => {
+    render(
+      <SWRConfig
+        value={{
+          provider: () => new Map(),
+          fetcher: async () => {
+            throw new Error("Failed to load sessions");
+          },
+          shouldRetryOnError: false,
+          dedupingInterval: 0,
+          revalidateOnFocus: false,
+        }}
+      >
+        <SessionSidebar />
+      </SWRConfig>
+    );
+
+    expect(await screen.findByText("Unable to load sessions")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText("Search sessions..."), {
+      target: { value: "missing" },
+    });
+
+    expect(screen.getByText("Unable to load sessions")).toBeInTheDocument();
+    expect(screen.queryByText("No matching sessions")).not.toBeInTheDocument();
+  });
+
   it("loads the next page when scrolled near the bottom", async () => {
     const firstPage = Array.from({ length: 50 }, (_, index) => createSession(index + 1));
     const secondPage = Array.from({ length: 5 }, (_, index) => createSession(index + 51));

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -441,6 +441,10 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
           </div>
         ) : sessions.length === 0 ? (
           <div className="px-4 py-8 text-center text-sm text-muted-foreground">{emptyMessage}</div>
+        ) : searchQuery && activeSessions.length === 0 && inactiveSessions.length === 0 ? (
+          <div className="px-4 py-8 text-center text-sm text-muted-foreground">
+            No matching sessions
+          </div>
         ) : (
           <>
             {/* Active Sessions */}

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -212,7 +212,7 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
 
   // Sort sessions by updatedAt (most recent first), filter by search query,
   // and group children under their parent sessions
-  const { activeSessions, inactiveSessions, childrenMap } = useMemo(() => {
+  const { activeSessions, inactiveSessions, childrenMap, hasFilteredSessions } = useMemo(() => {
     const filtered = sessions
       .filter((session) => session.status !== "archived")
       .filter((session) => {
@@ -263,7 +263,12 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
       }
     }
 
-    return { activeSessions: active, inactiveSessions: inactive, childrenMap: children };
+    return {
+      activeSessions: active,
+      inactiveSessions: inactive,
+      childrenMap: children,
+      hasFilteredSessions: filtered.length > 0,
+    };
   }, [sessions, searchQuery]);
 
   const currentSessionId = pathname?.startsWith("/session/") ? pathname.split("/")[2] : null;
@@ -441,7 +446,7 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
           </div>
         ) : sessions.length === 0 ? (
           <div className="px-4 py-8 text-center text-sm text-muted-foreground">{emptyMessage}</div>
-        ) : searchQuery && activeSessions.length === 0 && inactiveSessions.length === 0 ? (
+        ) : searchQuery && !hasFilteredSessions ? (
           <div className="px-4 py-8 text-center text-sm text-muted-foreground">
             No matching sessions
           </div>


### PR DESCRIPTION
## What

- Show `No matching sessions` when a non-empty sidebar search has no local matches.
- Restore the session list when the query is cleared.
- Keep genuine empty-session and fetch-failure messages distinct.
- Add public-UI regression coverage for all three states.

## Why

Searching for a session with no matches left the session panel blank, giving users no indication that the search completed successfully.

## Root cause

The sidebar filtered sessions into its active and inactive lists, but the empty-state render branch checked the unfiltered `sessions.length`. When sessions existed but none matched the query, neither the normal empty state nor any session rows rendered.

## Checks

- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/web -- src/components/session-sidebar.test.tsx` (12 passed)
- `npm test -w @open-inspect/web` (602 passed)
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web`
- `npx prettier --check packages/web/src/components/session-sidebar.tsx packages/web/src/components/session-sidebar.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the sessions sidebar so an active search with no results shows “No matching sessions”.
  * Kept “No sessions yet” for the genuine empty state (when there are no sessions).
  * Preserved the “Unable to load sessions” message when sessions fail to load, even after entering a search.
* **Tests**
  * Added coverage for search/no-results, true empty state, and load-error scenarios in the sessions sidebar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->