### PR TITLE
Preserve event fields in structured logs

### DIFF
--- a/packages/shared/src/logger.test.ts
+++ b/packages/shared/src/logger.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createLogger } from "./logger";
+
+describe("createLogger", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("includes the caller's event name in structured output", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    createLogger("router:automations").info("Automation created", {
+      event: "automation.created",
+    });
+
+    expect(consoleSpy).toHaveBeenCalledOnce();
+    expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toMatchObject({
+      event: "automation.created",
+    });
+  });
+
+  it("protects logger-owned fields from context and per-call data", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const spoofedFields = {
+      level: "spoofed",
+      service: "spoofed",
+      component: "spoofed",
+      msg: "spoofed",
+      ts: "spoofed",
+    };
+    const logger = createLogger("router", spoofedFields, "info", "control-plane");
+
+    logger.info("Request received", spoofedFields);
+
+    expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toMatchObject({
+      level: "info",
+      service: "control-plane",
+      component: "router",
+      msg: "Request received",
+      ts: expect.any(Number),
+    });
+  });
+
+  it("lets per-call data override matching context fields", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const logger = createLogger("router", {
+      event: "request.started",
+      requestId: "context-request",
+    });
+
+    logger.info("Request completed", {
+      event: "request.completed",
+      requestId: "call-request",
+    });
+
+    expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toMatchObject({
+      event: "request.completed",
+      requestId: "call-request",
+    });
+  });
+
+  it("lets child context override parent context while inheriting other fields", () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const parent = createLogger("session-do", {
+      event: "session.started",
+      requestId: "parent-request",
+      sessionId: "session-123",
+    });
+    const child = parent.child({
+      event: "prompt.started",
+      requestId: "child-request",
+    });
+
+    child.info("Prompt started");
+
+    expect(JSON.parse(consoleSpy.mock.calls[0][0] as string)).toMatchObject({
+      event: "prompt.started",
+      requestId: "child-request",
+      sessionId: "session-123",
+    });
+  });
+});

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -8,9 +8,12 @@
  *   while keeping the JSON `level` field for programmatic filtering.
  * - JSON.stringify is wrapped in try/catch so a logging failure never crashes
  *   a request or Durable Object event.
- * - Reserved keys (`level`, `component`, `msg`, `ts`, `service`, `event`)
- *   cannot be overwritten by context or data — they are always set by the
- *   logger itself.
+ * - Logger-owned keys (`level`, `component`, `msg`, `ts`, `service`) cannot
+ *   be overwritten by context or data — they are always set by the logger
+ *   itself.
+ * - Other structured fields, including `event`, are merged in this order:
+ *   base context, child context, then per-call data. Later values override
+ *   earlier values when the same field is supplied more than once.
  *
  * Usage:
  *   const log = createLogger("worker", {}, "info", "my-service");
@@ -27,7 +30,7 @@ const LEVELS = { debug: 0, info: 1, warn: 2, error: 3 } as const;
 export type LogLevel = keyof typeof LEVELS;
 
 /** Keys that the logger owns — context and data cannot overwrite these. */
-const RESERVED_KEYS = new Set(["level", "component", "msg", "ts", "service", "event"]);
+const RESERVED_KEYS = new Set(["level", "component", "msg", "ts", "service"]);
 
 /** Map log level to the appropriate console method for severity semantics. */
 const CONSOLE_METHOD: Record<LogLevel, "log" | "warn" | "error"> = {


### PR DESCRIPTION
## What changed

- preserve caller-supplied `event` fields in structured JSON log output
- keep logger-owned envelope fields protected from context and per-call data
- document precedence across base context, child context, and per-call data
- add focused coverage for emitted events, protected fields, precedence, and child loggers

## Why

Control-plane callers attach stable event names such as `automation.created` for log indexing and queries, but those fields were silently missing from emitted JSON.

## Root cause

The shared logger included `event` in its reserved-key set, so it stripped the field from both context and per-call data. Unlike the other reserved keys, the logger never added an `event` value back to the output envelope.

## Checks

- `npm test -w @open-inspect/shared` (25 files, 364 tests)
- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/shared`
- `npm run lint -w @open-inspect/shared`
- `npx prettier --check packages/shared/src/logger.ts packages/shared/src/logger.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Structured logs now preserve user-provided `event` fields instead of stripping them.
  * Logging output more reliably keeps custom context values while still protecting core log fields from being overwritten.
  * Child loggers now correctly inherit parent context and allow later values to override matching fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->