### PR TITLE
Fix scheduled automation next-run timestamps

### DIFF
--- a/packages/web/src/components/automations/automations-list.test.tsx
+++ b/packages/web/src/components/automations/automations-list.test.tsx
@@ -9,7 +9,10 @@ import type { Automation } from "@open-inspect/shared";
 import { AutomationsList } from "./automations-list";
 
 expect.extend(matchers);
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
 
 vi.mock("next/link", () => ({
   default: ({ children, ...props }: ComponentProps<"a">) => <a {...props}>{children}</a>,
@@ -78,6 +81,25 @@ describe("AutomationsList repository labels", () => {
       }),
     ]);
     expect(screen.getByText("No repository")).toBeInTheDocument();
+  });
+});
+
+describe("AutomationsList schedule metadata", () => {
+  it("shows how long remains until the next scheduled run", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T12:00:00Z"));
+
+    render(
+      <AutomationsList
+        automations={[makeAutomation({ nextRunAt: Date.now() + 2 * 60 * 60 * 1000 })]}
+        onPause={noop}
+        onResume={noop}
+        onTrigger={noop}
+        onDelete={noop}
+      />
+    );
+
+    expect(screen.getByText("Next: in 2h")).toBeInTheDocument();
   });
 });
 

--- a/packages/web/src/components/automations/automations-list.tsx
+++ b/packages/web/src/components/automations/automations-list.tsx
@@ -7,7 +7,7 @@ import type { Automation } from "@open-inspect/shared";
 import { AutomationStatusBadge } from "@/components/automations/automation-status-badge";
 import { Button } from "@/components/ui/button";
 import { FolderIcon, ClockIcon, BoltIcon } from "@/components/ui/icons";
-import { formatRelativeTime } from "@/lib/time";
+import { formatFutureRelativeTime } from "@/lib/time";
 import { formatRepositoriesLabel } from "@/lib/repo-label";
 
 interface AutomationsListProps {
@@ -153,7 +153,7 @@ export function AutomationsList({
             </span>
             {automation.triggerType === "schedule" && automation.nextRunAt && (
               <span className="inline-flex items-center gap-1">
-                Next: {formatRelativeTime(automation.nextRunAt)}
+                Next: {formatFutureRelativeTime(automation.nextRunAt)}
               </span>
             )}
           </div>

--- a/packages/web/src/lib/time.test.ts
+++ b/packages/web/src/lib/time.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatFutureRelativeTime, formatRelativeTime } from "./time";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-07-09T12:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("formatRelativeTime", () => {
+  it("keeps formatting past timestamps without future-time wording", () => {
+    expect(formatRelativeTime(Date.now() - 2 * 60 * 60 * 1000)).toBe("2h");
+  });
+});
+
+describe("formatFutureRelativeTime", () => {
+  it("formats a scheduled time in minutes", () => {
+    expect(formatFutureRelativeTime(Date.now() + 5 * 60 * 1000)).toBe("in 5m");
+  });
+
+  it("formats a scheduled time in hours", () => {
+    expect(formatFutureRelativeTime(Date.now() + 2 * 60 * 60 * 1000)).toBe("in 2h");
+  });
+
+  it("formats a scheduled time in days", () => {
+    expect(formatFutureRelativeTime(Date.now() + 24 * 60 * 60 * 1000)).toBe("in 1d");
+  });
+
+  it("formats a scheduled time less than one minute away", () => {
+    expect(formatFutureRelativeTime(Date.now() + 60 * 1000 - 1)).toBe("in <1m");
+  });
+
+  it("formats a scheduled time exactly one minute away", () => {
+    expect(formatFutureRelativeTime(Date.now() + 60 * 1000)).toBe("in 1m");
+  });
+});

--- a/packages/web/src/lib/time.ts
+++ b/packages/web/src/lib/time.ts
@@ -40,6 +40,26 @@ export function formatRelativeTime(timestamp: number): string {
 }
 
 /**
+ * Format a future timestamp as the time remaining until it occurs.
+ */
+export function formatFutureRelativeTime(timestamp: number): string {
+  const minutes = Math.floor((timestamp - Date.now()) / (60 * 1000));
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) {
+    return `in ${days}d`;
+  }
+  if (hours > 0) {
+    return `in ${hours}h`;
+  }
+  if (minutes > 0) {
+    return `in ${minutes}m`;
+  }
+  return "in <1m";
+}
+
+/**
  * Group sessions by activity status.
  * Sessions older than 7 days are considered "inactive".
  */


### PR DESCRIPTION
## What changed

- added a dedicated formatter for future relative timestamps (`in 5m`, `in 2h`, `in 1d`)
- defined sub-minute scheduled runs as `in <1m`
- updated automation list metadata to use the future formatter
- added formatter boundary tests and rendered list coverage

## Why

Scheduled automation timestamps are future values, but the list rendered them with a formatter designed for past activity. As a result, every future `nextRunAt` value fell through to `just now`.

## Root cause

`formatRelativeTime` subtracts the supplied timestamp from the current time and only handles positive past-time differences. Passing a future timestamp produces negative minute, hour, and day values, so the formatter returns its recent-past fallback.

## Checks

- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/web` (606 tests)
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web`
- `npx prettier --check packages/web/src/lib/time.ts packages/web/src/lib/time.test.ts packages/web/src/components/automations/automations-list.tsx packages/web/src/components/automations/automations-list.test.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer “Next” timing labels for scheduled automations, showing future run times like “in 2h” or “in 1d”.
  * Introduced improved future-time formatting for consistent countdown-style display.

* **Tests**
  * Expanded automated coverage for time formatting and scheduled automation timing display.
  * Added deterministic timer-based tests to verify past and future relative time outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->