### PR TITLE
feat(github-bot): launch default environment from repo metadata

### DIFF
--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -62,13 +62,16 @@ which settings apply. The agent sees all clones side by side and can make coordi
 them; pushes and pull requests are per-repository, so one session can produce PRs in several
 repositories. The session sidebar lists every repository with its branch and any PR created for it.
 
-GitHub-bot sessions remain single-repository. Slack sessions can target an environment three ways: a
-routing rule (Settings › Integrations › Slack) launches it from a keyword; a channel association
-(`channelAssociations` on the environments API, like repository metadata) routes messages in that
-channel to it automatically; and the LLM classifier considers environments alongside repositories,
-using their names and descriptions as signals — its clarification picker lists both kinds when it
-has to ask. Linear sessions can target an environment through the team and project mappings
-(`{"environmentId": "env_…"}` entries alongside repository entries).
+GitHub-bot sessions open the webhook's repository, unless that repository's metadata names a default
+environment (`defaultEnvironmentId` via the repo-metadata API) — then a PR review or @mention opens
+that environment's full workspace, provided the environment still contains the trigger repository.
+Slack sessions can target an environment three ways: a routing rule (Settings › Integrations ›
+Slack) launches it from a keyword; a channel association (`channelAssociations` on the environments
+API, like repository metadata) routes messages in that channel to it automatically; and the LLM
+classifier considers environments alongside repositories, using their names and descriptions as
+signals — its clarification picker lists both kinds when it has to ask. Linear sessions can target
+an environment through the team and project mappings (`{"environmentId": "env_…"}` entries alongside
+repository entries).
 
 ### Session Lifecycle
 

--- a/packages/control-plane/src/db/repo-metadata.test.ts
+++ b/packages/control-plane/src/db/repo-metadata.test.ts
@@ -223,7 +223,7 @@ describe("RepoMetadataStore", () => {
     });
 
     it("returns metadata for repos that have it", async () => {
-      await store.upsert("owner", "repo1", { description: "First" });
+      await store.upsert("owner", "repo1", { description: "First", defaultEnvironmentId: "env_1" });
       await store.upsert("owner", "repo2", { description: "Second", keywords: ["kw"] });
 
       const result = await store.getBatch([
@@ -234,6 +234,7 @@ describe("RepoMetadataStore", () => {
 
       expect(result.size).toBe(2);
       expect(result.get("owner/repo1")?.description).toBe("First");
+      expect(result.get("owner/repo1")?.defaultEnvironmentId).toBe("env_1");
       expect(result.get("owner/repo2")?.description).toBe("Second");
       expect(result.get("owner/repo2")?.keywords).toEqual(["kw"]);
       expect(result.has("owner/repo3")).toBe(false);

--- a/packages/control-plane/src/db/repo-metadata.test.ts
+++ b/packages/control-plane/src/db/repo-metadata.test.ts
@@ -8,6 +8,7 @@ type RepoMetadataRow = {
   aliases: string | null;
   channel_associations: string | null;
   keywords: string | null;
+  default_environment_id: string | null;
   created_at: number;
   updated_at: number;
 };
@@ -66,11 +67,13 @@ class FakeD1Database {
         aliases,
         channelAssociations,
         keywords,
+        defaultEnvironmentId,
         createdAt,
         updatedAt,
       ] = args as [
         string,
         string,
+        string | null,
         string | null,
         string | null,
         string | null,
@@ -87,6 +90,7 @@ class FakeD1Database {
         aliases,
         channel_associations: channelAssociations,
         keywords,
+        default_environment_id: defaultEnvironmentId,
         created_at: existing ? existing.created_at : createdAt,
         updated_at: updatedAt,
       });
@@ -150,6 +154,7 @@ describe("RepoMetadataStore", () => {
         aliases: ["test"],
         channelAssociations: ["#general"],
         keywords: ["testing"],
+        defaultEnvironmentId: "env_123",
       });
 
       const result = await store.get("Owner", "Repo");
@@ -158,6 +163,7 @@ describe("RepoMetadataStore", () => {
         aliases: ["test"],
         channelAssociations: ["#general"],
         keywords: ["testing"],
+        defaultEnvironmentId: "env_123",
       });
     });
 
@@ -174,6 +180,7 @@ describe("RepoMetadataStore", () => {
       expect(result?.aliases).toBeUndefined();
       expect(result?.channelAssociations).toBeUndefined();
       expect(result?.keywords).toBeUndefined();
+      expect(result?.defaultEnvironmentId).toBeUndefined();
     });
 
     it("normalizes owner and name to lowercase", async () => {
@@ -198,6 +205,14 @@ describe("RepoMetadataStore", () => {
       const result = await store.get("owner", "repo");
       expect(result?.description).toBe("updated");
       expect(result?.aliases).toEqual(["alias1"]);
+    });
+
+    it("clears defaultEnvironmentId when omitted from an update", async () => {
+      await store.upsert("owner", "repo", { defaultEnvironmentId: "env_123" });
+      await store.upsert("owner", "repo", { description: "no env" });
+
+      const result = await store.get("owner", "repo");
+      expect(result?.defaultEnvironmentId).toBeUndefined();
     });
   });
 

--- a/packages/control-plane/src/db/repo-metadata.ts
+++ b/packages/control-plane/src/db/repo-metadata.ts
@@ -11,6 +11,7 @@ interface RepoMetadataRow {
   aliases: string | null;
   channel_associations: string | null;
   keywords: string | null;
+  default_environment_id: string | null;
   image_build_enabled: number;
   created_at: number;
   updated_at: number;
@@ -30,6 +31,8 @@ function toMetadata(row: RepoMetadataRow): RepoMetadata {
   if (channelAssociations) metadata.channelAssociations = channelAssociations;
   const keywords = parseJsonStringArray(row.keywords);
   if (keywords) metadata.keywords = keywords;
+  if (row.default_environment_id != null)
+    metadata.defaultEnvironmentId = row.default_environment_id;
   return metadata;
 }
 
@@ -52,13 +55,14 @@ export class RepoMetadataStore {
 
     await this.db
       .prepare(
-        `INSERT INTO repo_metadata (repo_owner, repo_name, description, aliases, channel_associations, keywords, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        `INSERT INTO repo_metadata (repo_owner, repo_name, description, aliases, channel_associations, keywords, default_environment_id, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(repo_owner, repo_name) DO UPDATE SET
            description = excluded.description,
            aliases = excluded.aliases,
            channel_associations = excluded.channel_associations,
            keywords = excluded.keywords,
+           default_environment_id = excluded.default_environment_id,
            updated_at = excluded.updated_at`
       )
       .bind(
@@ -68,6 +72,7 @@ export class RepoMetadataStore {
         metadata.aliases ? JSON.stringify(metadata.aliases) : null,
         metadata.channelAssociations ? JSON.stringify(metadata.channelAssociations) : null,
         metadata.keywords ? JSON.stringify(metadata.keywords) : null,
+        metadata.defaultEnvironmentId ?? null,
         now,
         now
       )

--- a/packages/control-plane/src/routes/repos.ts
+++ b/packages/control-plane/src/routes/repos.ts
@@ -242,6 +242,8 @@ async function handleUpdateRepoMetadata(
         ? body.channelAssociations
         : undefined,
       keywords: Array.isArray(body.keywords) ? body.keywords : undefined,
+      defaultEnvironmentId:
+        typeof body.defaultEnvironmentId === "string" ? body.defaultEnvironmentId : undefined,
     }).filter(([, v]) => v !== undefined)
   ) as RepoMetadata;
 

--- a/packages/github-bot/README.md
+++ b/packages/github-bot/README.md
@@ -148,6 +148,19 @@ people to request the GitHub App bot through the PR reviewer picker.
 **Review Comment:** Same as issue comment, but the prompt additionally includes `filePath`,
 `diffHunk`, and `commentId` for thread-specific context and reply threading.
 
+### Session Launch Target
+
+Sessions are repo-bound by default: they open the webhook payload's repository. A repository can opt
+into launching a saved environment instead by setting `defaultEnvironmentId` in its repo metadata
+(`PUT /repos/:owner/:name/metadata` on the control plane) — a PR review or @mention on that repo
+then opens the environment's full multi-repository workspace.
+
+The environment must still contain the trigger repository — the session has to check out the PR
+under review. The bot falls back to the plain repo-bound session (with a `target.*` warning log)
+when the metadata or environment lookup fails, the environment was deleted, or it no longer contains
+the trigger repo. Integration settings (model, enabled repos, instructions) always resolve from the
+trigger repository either way.
+
 ## Authentication
 
 ### Webhook Verification

--- a/packages/github-bot/README.md
+++ b/packages/github-bot/README.md
@@ -156,10 +156,14 @@ into launching a saved environment instead by setting `defaultEnvironmentId` in 
 then opens the environment's full multi-repository workspace.
 
 The environment must still contain the trigger repository — the session has to check out the PR
-under review. The bot falls back to the plain repo-bound session (with a `target.*` warning log)
-when the metadata or environment lookup fails, the environment was deleted, or it no longer contains
-the trigger repo. Integration settings (model, enabled repos, instructions) always resolve from the
-trigger repository either way.
+under review — and the sender must be authorized for the whole workspace: caller gating's semantics
+extend from the trigger repo to every environment repository. An `allowedTriggerUsers` allowlist
+vouches for the sender as it already does today; without one, the sender needs write permission on
+each repository in the environment, so an environment launch never widens what the sender can reach.
+The bot falls back to the plain repo-bound session (with a `target.*` warning log) when the metadata
+or environment lookup fails, the environment was deleted, it no longer contains the trigger repo, or
+the sender lacks permission on any of its repositories. Integration settings (model, enabled repos,
+instructions) always resolve from the trigger repository either way.
 
 ## Authentication
 

--- a/packages/github-bot/src/handlers.ts
+++ b/packages/github-bot/src/handlers.ts
@@ -15,6 +15,7 @@ import type {
 import type { Logger } from "./logger";
 import { generateInstallationToken, postReaction, checkSenderPermission } from "./github-auth";
 import { buildCodeReviewPrompt, buildCommentActionPrompt } from "./prompts";
+import { resolveSessionTarget, type SessionTargetFields } from "./session-target";
 import { getGitHubConfig, type ResolvedGitHubConfig } from "./utils/integration-config";
 
 export type HandlerResult =
@@ -39,8 +40,7 @@ async function createSession(
   controlPlane: Fetcher,
   headers: Record<string, string>,
   params: {
-    repoOwner: string;
-    repoName: string;
+    target: SessionTargetFields;
     title: string;
     model: string;
     reasoningEffort?: string | null;
@@ -50,8 +50,7 @@ async function createSession(
   }
 ): Promise<string> {
   const body: Record<string, unknown> = {
-    repoOwner: params.repoOwner,
-    repoName: params.repoName,
+    ...params.target,
     title: params.title,
     model: params.model,
     scmLogin: params.scmLogin,
@@ -228,9 +227,9 @@ export async function handleReviewRequested(
     meta
   );
 
+  const target = await resolveSessionTarget(env, headers, owner, repoName, log, traceId);
   const sessionId = await createSession(env.CONTROL_PLANE, headers, {
-    repoOwner: owner,
-    repoName,
+    target,
     title: `GitHub: Review PR #${pr.number}`,
     model: config.model,
     reasoningEffort: config.reasoningEffort,
@@ -328,9 +327,9 @@ export async function handlePullRequestOpened(
     meta
   );
 
+  const target = await resolveSessionTarget(env, headers, owner, repoName, log, traceId);
   const sessionId = await createSession(env.CONTROL_PLANE, headers, {
-    repoOwner: owner,
-    repoName,
+    target,
     title: `GitHub: Review PR #${pr.number}`,
     model: config.model,
     reasoningEffort: config.reasoningEffort,
@@ -434,9 +433,9 @@ export async function handleIssueComment(
     meta
   );
 
+  const target = await resolveSessionTarget(env, headers, owner, repoName, log, traceId);
   const sessionId = await createSession(env.CONTROL_PLANE, headers, {
-    repoOwner: owner,
-    repoName,
+    target,
     title: `GitHub: PR #${issue.number} comment`,
     model: config.model,
     reasoningEffort: config.reasoningEffort,
@@ -533,9 +532,9 @@ export async function handleReviewComment(
     meta
   );
 
+  const target = await resolveSessionTarget(env, headers, owner, repoName, log, traceId);
   const sessionId = await createSession(env.CONTROL_PLANE, headers, {
-    repoOwner: owner,
-    repoName,
+    target,
     title: `GitHub: PR #${pr.number} review comment`,
     model: config.model,
     reasoningEffort: config.reasoningEffort,

--- a/packages/github-bot/src/handlers.ts
+++ b/packages/github-bot/src/handlers.ts
@@ -227,7 +227,15 @@ export async function handleReviewRequested(
     meta
   );
 
-  const target = await resolveSessionTarget(env, headers, owner, repoName, log, traceId);
+  const target = await resolveSessionTarget(env, log, {
+    owner,
+    repoName,
+    senderLogin: sender.login,
+    config,
+    ghToken,
+    headers,
+    traceId,
+  });
   const sessionId = await createSession(env.CONTROL_PLANE, headers, {
     target,
     title: `GitHub: Review PR #${pr.number}`,
@@ -327,7 +335,15 @@ export async function handlePullRequestOpened(
     meta
   );
 
-  const target = await resolveSessionTarget(env, headers, owner, repoName, log, traceId);
+  const target = await resolveSessionTarget(env, log, {
+    owner,
+    repoName,
+    senderLogin: sender.login,
+    config,
+    ghToken,
+    headers,
+    traceId,
+  });
   const sessionId = await createSession(env.CONTROL_PLANE, headers, {
     target,
     title: `GitHub: Review PR #${pr.number}`,
@@ -433,7 +449,15 @@ export async function handleIssueComment(
     meta
   );
 
-  const target = await resolveSessionTarget(env, headers, owner, repoName, log, traceId);
+  const target = await resolveSessionTarget(env, log, {
+    owner,
+    repoName,
+    senderLogin: sender.login,
+    config,
+    ghToken,
+    headers,
+    traceId,
+  });
   const sessionId = await createSession(env.CONTROL_PLANE, headers, {
     target,
     title: `GitHub: PR #${issue.number} comment`,
@@ -532,7 +556,15 @@ export async function handleReviewComment(
     meta
   );
 
-  const target = await resolveSessionTarget(env, headers, owner, repoName, log, traceId);
+  const target = await resolveSessionTarget(env, log, {
+    owner,
+    repoName,
+    senderLogin: sender.login,
+    config,
+    ghToken,
+    headers,
+    traceId,
+  });
   const sessionId = await createSession(env.CONTROL_PLANE, headers, {
     target,
     title: `GitHub: PR #${pr.number} review comment`,

--- a/packages/github-bot/src/session-target.ts
+++ b/packages/github-bot/src/session-target.ts
@@ -1,0 +1,165 @@
+/**
+ * Session launch-target resolution for the GitHub bot (design §13.2).
+ *
+ * A repository may name a default environment
+ * (`repo_metadata.default_environment_id`) so sessions triggered from it open
+ * that environment's full workspace instead of a single-repo checkout. The
+ * webhook repo remains the fallback: resolution fails open to a repo-bound
+ * session whenever the metadata or environment lookup fails, the environment
+ * no longer exists, or it no longer contains the trigger repository — the
+ * session must always be able to check out the PR under review.
+ */
+
+import { z } from "zod";
+import type { Env } from "./types";
+import type { Logger } from "./logger";
+
+/**
+ * Create-session request fields: scalar repo or environment id — the create
+ * schema makes the two mutually exclusive.
+ */
+export type SessionTargetFields =
+  | { repoOwner: string; repoName: string }
+  | { environmentId: string };
+
+const metadataResponseSchema = z.object({
+  metadata: z.object({ defaultEnvironmentId: z.string().optional() }).nullable(),
+});
+
+const environmentResponseSchema = z.object({
+  environment: z.object({
+    id: z.string(),
+    repositories: z.array(z.object({ repoOwner: z.string(), repoName: z.string() })),
+  }),
+});
+
+async function fetchDefaultEnvironmentId(
+  env: Env,
+  headers: Record<string, string>,
+  owner: string,
+  repoName: string,
+  log: Logger,
+  traceId: string
+): Promise<string | null> {
+  const repo = `${owner}/${repoName}`.toLowerCase();
+  let response: Response;
+  try {
+    response = await env.CONTROL_PLANE.fetch(
+      `https://internal/repos/${owner}/${repoName}/metadata`,
+      { headers }
+    );
+  } catch (err) {
+    log.warn("target.metadata_fetch_failed", {
+      trace_id: traceId,
+      repo,
+      error: err instanceof Error ? err : new Error(String(err)),
+    });
+    return null;
+  }
+  if (!response.ok) {
+    log.warn("target.metadata_fetch_failed", { trace_id: traceId, repo, status: response.status });
+    return null;
+  }
+  const parsed = metadataResponseSchema.safeParse(await response.json().catch(() => null));
+  if (!parsed.success) {
+    log.warn("target.metadata_invalid_response", { trace_id: traceId, repo });
+    return null;
+  }
+  return parsed.data.metadata?.defaultEnvironmentId ?? null;
+}
+
+async function fetchEnvironment(
+  env: Env,
+  headers: Record<string, string>,
+  environmentId: string,
+  log: Logger,
+  traceId: string
+): Promise<z.infer<typeof environmentResponseSchema>["environment"] | null> {
+  let response: Response;
+  try {
+    response = await env.CONTROL_PLANE.fetch(`https://internal/environments/${environmentId}`, {
+      headers,
+    });
+  } catch (err) {
+    log.warn("target.environment_fetch_failed", {
+      trace_id: traceId,
+      environment_id: environmentId,
+      error: err instanceof Error ? err : new Error(String(err)),
+    });
+    return null;
+  }
+  if (response.status === 404) {
+    log.warn("target.environment_not_found", {
+      trace_id: traceId,
+      environment_id: environmentId,
+    });
+    return null;
+  }
+  if (!response.ok) {
+    log.warn("target.environment_fetch_failed", {
+      trace_id: traceId,
+      environment_id: environmentId,
+      status: response.status,
+    });
+    return null;
+  }
+  const parsed = environmentResponseSchema.safeParse(await response.json().catch(() => null));
+  if (!parsed.success) {
+    log.warn("target.environment_invalid_response", {
+      trace_id: traceId,
+      environment_id: environmentId,
+    });
+    return null;
+  }
+  return parsed.data.environment;
+}
+
+/**
+ * Resolve the launch target for a session triggered from a repository: the
+ * repo's default environment when one is configured, still exists, and
+ * contains the trigger repo; otherwise the repo itself.
+ */
+export async function resolveSessionTarget(
+  env: Env,
+  headers: Record<string, string>,
+  owner: string,
+  repoName: string,
+  log: Logger,
+  traceId: string
+): Promise<SessionTargetFields> {
+  const repoFields = { repoOwner: owner, repoName };
+
+  const environmentId = await fetchDefaultEnvironmentId(
+    env,
+    headers,
+    owner,
+    repoName,
+    log,
+    traceId
+  );
+  if (!environmentId) return repoFields;
+
+  const environment = await fetchEnvironment(env, headers, environmentId, log, traceId);
+  if (!environment) return repoFields;
+
+  const isMember = environment.repositories.some(
+    (r) =>
+      r.repoOwner.toLowerCase() === owner.toLowerCase() &&
+      r.repoName.toLowerCase() === repoName.toLowerCase()
+  );
+  if (!isMember) {
+    log.warn("target.environment_missing_trigger_repo", {
+      trace_id: traceId,
+      environment_id: environmentId,
+      repo: `${owner}/${repoName}`.toLowerCase(),
+    });
+    return repoFields;
+  }
+
+  log.info("target.environment_selected", {
+    trace_id: traceId,
+    environment_id: environmentId,
+    repo: `${owner}/${repoName}`.toLowerCase(),
+  });
+  return { environmentId };
+}

--- a/packages/github-bot/src/session-target.ts
+++ b/packages/github-bot/src/session-target.ts
@@ -10,9 +10,12 @@
  * session must always be able to check out the PR under review.
  */
 
+import { resolveAppName } from "@open-inspect/shared";
 import { z } from "zod";
 import type { Env } from "./types";
 import type { Logger } from "./logger";
+import { checkSenderPermission } from "./github-auth";
+import type { ResolvedGitHubConfig } from "./utils/integration-config";
 
 /**
  * Create-session request fields: scalar repo or environment id — the create
@@ -114,19 +117,83 @@ async function fetchEnvironment(
   return parsed.data.environment;
 }
 
+export interface ResolveSessionTargetParams {
+  owner: string;
+  repoName: string;
+  /** Webhook sender login, permission-checked against environment repositories. */
+  senderLogin: string;
+  /** Resolved integration config — its allowedTriggerUsers picks the gating mode. */
+  config: ResolvedGitHubConfig;
+  /** GitHub App installation token from caller gating. */
+  ghToken: string;
+  /** Control-plane auth headers from caller gating. */
+  headers: Record<string, string>;
+  traceId: string;
+}
+
+/**
+ * Whether the sender may launch a session spanning the environment's
+ * repositories. Extends caller gating's trigger-repo semantics to the whole
+ * set: an explicit allowedTriggerUsers allowlist vouches for the sender
+ * without GitHub permission checks (as it already does for the trigger repo);
+ * otherwise the sender needs write permission on every environment repository
+ * — an environment launch must not widen what the sender can reach (private
+ * clones, agent pushes) beyond what GitHub already grants them.
+ */
+async function senderAuthorizedForEnvironment(
+  env: Env,
+  environment: { id: string; repositories: Array<{ repoOwner: string; repoName: string }> },
+  params: ResolveSessionTargetParams,
+  log: Logger
+): Promise<boolean> {
+  if (params.config.allowedTriggerUsers !== null) return true;
+
+  // The trigger repo was already permission-checked by caller gating.
+  const otherRepos = environment.repositories.filter(
+    (r) =>
+      r.repoOwner.toLowerCase() !== params.owner.toLowerCase() ||
+      r.repoName.toLowerCase() !== params.repoName.toLowerCase()
+  );
+  const userAgent = resolveAppName(env);
+  const checks = await Promise.all(
+    otherRepos.map(async (r) => ({
+      repo: `${r.repoOwner}/${r.repoName}`.toLowerCase(),
+      ...(await checkSenderPermission(
+        params.ghToken,
+        r.repoOwner,
+        r.repoName,
+        params.senderLogin,
+        userAgent
+      )),
+    }))
+  );
+  const denied = checks.find((c) => !c.hasPermission);
+  if (denied) {
+    log.warn("target.environment_sender_not_authorized", {
+      trace_id: params.traceId,
+      environment_id: environment.id,
+      repo: `${params.owner}/${params.repoName}`.toLowerCase(),
+      denied_repo: denied.repo,
+      sender: params.senderLogin,
+      permission_check_error: denied.error === true,
+    });
+    return false;
+  }
+  return true;
+}
+
 /**
  * Resolve the launch target for a session triggered from a repository: the
- * repo's default environment when one is configured, still exists, and
- * contains the trigger repo; otherwise the repo itself.
+ * repo's default environment when one is configured, still exists, contains
+ * the trigger repo, and the sender is authorized for all of its repositories;
+ * otherwise the repo itself.
  */
 export async function resolveSessionTarget(
   env: Env,
-  headers: Record<string, string>,
-  owner: string,
-  repoName: string,
   log: Logger,
-  traceId: string
+  params: ResolveSessionTargetParams
 ): Promise<SessionTargetFields> {
+  const { owner, repoName, headers, traceId } = params;
   const repoFields = { repoOwner: owner, repoName };
 
   const environmentId = await fetchDefaultEnvironmentId(
@@ -153,6 +220,10 @@ export async function resolveSessionTarget(
       environment_id: environmentId,
       repo: `${owner}/${repoName}`.toLowerCase(),
     });
+    return repoFields;
+  }
+
+  if (!(await senderAuthorizedForEnvironment(env, environment, params, log))) {
     return repoFields;
   }
 

--- a/packages/github-bot/test/handlers.test.ts
+++ b/packages/github-bot/test/handlers.test.ts
@@ -65,6 +65,11 @@ function createMockLogger(): Logger {
 
 function createMockEnv(): Env {
   const controlPlaneFetch = vi.fn().mockImplementation((url: string) => {
+    if (/\/repos\/[^/]+\/[^/]+\/metadata$/.test(url)) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ repo: "acme/widgets", metadata: null }), { status: 200 })
+      );
+    }
     if (url === "https://internal/sessions") {
       return Promise.resolve(
         new Response(JSON.stringify({ sessionId: "session-123", status: "created" }), {
@@ -97,6 +102,24 @@ function createMockEnv(): Env {
 
 function getControlPlaneFetch(env: Env) {
   return (env.CONTROL_PLANE as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch;
+}
+
+/**
+ * Locate control-plane calls by URL rather than index — handlers make a
+ * launch-target metadata lookup before creating the session.
+ */
+function findCallBody(cpFetch: ReturnType<typeof vi.fn>, urlPattern: RegExp) {
+  const call = cpFetch.mock.calls.find(([url]) => urlPattern.test(String(url)));
+  expect(call).toBeDefined();
+  return JSON.parse((call as [string, { body: string }])[1].body);
+}
+
+function sessionCreateBody(cpFetch: ReturnType<typeof vi.fn>) {
+  return findCallBody(cpFetch, /^https:\/\/internal\/sessions$/);
+}
+
+function promptSendBody(cpFetch: ReturnType<typeof vi.fn>) {
+  return findCallBody(cpFetch, /\/sessions\/.+\/prompt$/);
 }
 
 const pullRequestOpenedPayload: PullRequestOpenedPayload = {
@@ -195,9 +218,9 @@ describe("handlePullRequestOpened", () => {
     );
 
     const cpFetch = getControlPlaneFetch(env);
-    expect(cpFetch).toHaveBeenCalledTimes(2);
+    expect(cpFetch).toHaveBeenCalledTimes(3);
 
-    const sessionBody = JSON.parse(cpFetch.mock.calls[0][1].body);
+    const sessionBody = sessionCreateBody(cpFetch);
     expect(sessionBody.repoOwner).toBe("acme");
     expect(sessionBody.repoName).toBe("widgets");
     expect(sessionBody.title).toContain("Review PR #42");
@@ -206,7 +229,7 @@ describe("handlePullRequestOpened", () => {
     expect(sessionBody.scmAvatarUrl).toBe("https://avatars.githubusercontent.com/u/1001");
     expect(sessionBody.spawnSource).toBe("github-bot");
 
-    const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
+    const promptBody = promptSendBody(cpFetch);
     expect(promptBody.source).toBe("github");
     expect(promptBody.authorId).toBe("github:1001");
     expect(promptBody.content).toContain("Pull Request #42");
@@ -237,7 +260,7 @@ describe("handlePullRequestOpened", () => {
       handlePullRequestOpened(env, log, pullRequestOpenedPayload, "trace-0")
     ).rejects.toThrow("Session creation failed: invalid response");
 
-    expect(cpFetch).toHaveBeenCalledTimes(1);
+    expect(cpFetch).toHaveBeenCalledTimes(2);
   });
 
   it("returns early for draft PRs", async () => {
@@ -338,7 +361,7 @@ describe("handlePullRequestOpened", () => {
     await handlePullRequestOpened(env, log, pullRequestOpenedPayload, "trace-0");
 
     const cpFetch = getControlPlaneFetch(env);
-    const sessionBody = JSON.parse(cpFetch.mock.calls[0][1].body);
+    const sessionBody = sessionCreateBody(cpFetch);
     expect(sessionBody.model).toBe("anthropic/claude-opus-4-6");
   });
 
@@ -354,7 +377,7 @@ describe("handlePullRequestOpened", () => {
     await handlePullRequestOpened(env, log, pullRequestOpenedPayload, "trace-0");
 
     const cpFetch = getControlPlaneFetch(env);
-    const sessionBody = JSON.parse(cpFetch.mock.calls[0][1].body);
+    const sessionBody = sessionCreateBody(cpFetch);
     expect(sessionBody.reasoningEffort).toBe("high");
   });
 });
@@ -387,12 +410,10 @@ describe("handleReviewRequested", () => {
     );
 
     const cpFetch = getControlPlaneFetch(env);
-    expect(cpFetch).toHaveBeenCalledTimes(2);
+    expect(cpFetch).toHaveBeenCalledTimes(3);
 
     // Verify session creation
-    const sessionCall = cpFetch.mock.calls[0];
-    expect(sessionCall[0]).toBe("https://internal/sessions");
-    const sessionBody = JSON.parse(sessionCall[1].body);
+    const sessionBody = sessionCreateBody(cpFetch);
     expect(sessionBody.repoOwner).toBe("acme");
     expect(sessionBody.repoName).toBe("widgets");
     expect(sessionBody.title).toContain("Review PR #42");
@@ -402,9 +423,7 @@ describe("handleReviewRequested", () => {
     expect(sessionBody.spawnSource).toBe("github-bot");
 
     // Verify prompt sending
-    const promptCall = cpFetch.mock.calls[1];
-    expect(promptCall[0]).toBe("https://internal/sessions/session-123/prompt");
-    const promptBody = JSON.parse(promptCall[1].body);
+    const promptBody = findCallBody(cpFetch, /^https:\/\/internal\/sessions\/session-123\/prompt$/);
     expect(promptBody.source).toBe("github");
     expect(promptBody.authorId).toBe("github:1001");
     expect(promptBody.content).toContain("Pull Request #42");
@@ -490,15 +509,15 @@ describe("handleIssueComment", () => {
     );
 
     const cpFetch = getControlPlaneFetch(env);
-    expect(cpFetch).toHaveBeenCalledTimes(2);
+    expect(cpFetch).toHaveBeenCalledTimes(3);
 
-    const sessionBody = JSON.parse(cpFetch.mock.calls[0][1].body);
+    const sessionBody = sessionCreateBody(cpFetch);
     expect(sessionBody.scmLogin).toBe("bob");
     expect(sessionBody.scmUserId).toBe("1002");
     expect(sessionBody.scmAvatarUrl).toBe("https://avatars.githubusercontent.com/u/1002");
     expect(sessionBody.spawnSource).toBe("github-bot");
 
-    const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
+    const promptBody = promptSendBody(cpFetch);
     expect(promptBody.content).toContain("please fix the error handling");
     expect(promptBody.content).not.toContain("@test-bot[bot]");
     expect(promptBody.authorId).toBe("github:1002");
@@ -590,13 +609,13 @@ describe("handleReviewComment", () => {
 
     const cpFetch = getControlPlaneFetch(env);
 
-    const sessionBody = JSON.parse(cpFetch.mock.calls[0][1].body);
+    const sessionBody = sessionCreateBody(cpFetch);
     expect(sessionBody.scmLogin).toBe("carol");
     expect(sessionBody.scmUserId).toBe("1003");
     expect(sessionBody.scmAvatarUrl).toBe("https://avatars.githubusercontent.com/u/1003");
     expect(sessionBody.spawnSource).toBe("github-bot");
 
-    const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
+    const promptBody = promptSendBody(cpFetch);
     expect(promptBody.content).toContain("src/cache.ts");
     expect(promptBody.content).toContain("const cache = new Map()");
     expect(promptBody.content).toContain("comments/200/replies");
@@ -672,7 +691,7 @@ describe("error handling", () => {
     await handleReviewRequested(env, log, reviewRequestedPayload, "trace-reaction");
 
     // Session should still be created despite reaction failure
-    expect(getControlPlaneFetch(env)).toHaveBeenCalledTimes(2);
+    expect(getControlPlaneFetch(env)).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -698,7 +717,7 @@ describe("integration config", () => {
     await handleReviewRequested(env, log, reviewRequestedPayload, "trace-model");
 
     const cpFetch = getControlPlaneFetch(env);
-    const sessionBody = JSON.parse(cpFetch.mock.calls[0][1].body);
+    const sessionBody = sessionCreateBody(cpFetch);
     expect(sessionBody.model).toBe("anthropic/claude-opus-4-6");
     expect(sessionBody.reasoningEffort).toBe("low");
   });
@@ -744,7 +763,7 @@ describe("integration config", () => {
 
     // Should proceed normally — null means all repos allowed
     const cpFetch = getControlPlaneFetch(env);
-    expect(cpFetch).toHaveBeenCalledTimes(2);
+    expect(cpFetch).toHaveBeenCalledTimes(3);
   });
 
   it("rejects sender not in allowedTriggerUsers (handleIssueComment)", async () => {
@@ -778,7 +797,7 @@ describe("integration config", () => {
     await handleIssueComment(env, log, issueCommentPayload, "trace-allowed");
 
     // bob matches → proceeds to session creation
-    expect(getControlPlaneFetch(env)).toHaveBeenCalledTimes(2);
+    expect(getControlPlaneFetch(env)).toHaveBeenCalledTimes(3);
   });
 
   it("empty allowedTriggerUsers rejects all senders (handleReviewRequested)", async () => {
@@ -887,7 +906,7 @@ describe("integration config", () => {
     await handleReviewRequested(env, log, reviewRequestedPayload, "trace-review-instr");
 
     const cpFetch = getControlPlaneFetch(env);
-    const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
+    const promptBody = promptSendBody(cpFetch);
     expect(promptBody.content).toContain("## Custom Instructions");
     expect(promptBody.content).toContain("Focus on security.");
   });
@@ -903,7 +922,7 @@ describe("integration config", () => {
     await handleIssueComment(env, log, issueCommentPayload, "trace-comment-instr");
 
     const cpFetch = getControlPlaneFetch(env);
-    const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
+    const promptBody = promptSendBody(cpFetch);
     expect(promptBody.content).toContain("## Custom Instructions");
     expect(promptBody.content).toContain("Run tests first.");
   });
@@ -919,7 +938,7 @@ describe("integration config", () => {
     await handlePullRequestOpened(env, log, pullRequestOpenedPayload, "trace-pr-instr");
 
     const cpFetch = getControlPlaneFetch(env);
-    const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
+    const promptBody = promptSendBody(cpFetch);
     expect(promptBody.content).toContain("## Custom Instructions");
     expect(promptBody.content).toContain("Check for SQL injection.");
   });
@@ -935,7 +954,7 @@ describe("integration config", () => {
     await handleReviewComment(env, log, reviewCommentPayload, "trace-rc-instr");
 
     const cpFetch = getControlPlaneFetch(env);
-    const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
+    const promptBody = promptSendBody(cpFetch);
     expect(promptBody.content).toContain("## Custom Instructions");
     expect(promptBody.content).toContain("Prefer minimal diffs.");
   });
@@ -948,7 +967,168 @@ describe("integration config", () => {
     await handleReviewRequested(env, log, reviewRequestedPayload, "trace-null-instr");
 
     const cpFetch = getControlPlaneFetch(env);
-    const promptBody = JSON.parse(cpFetch.mock.calls[1][1].body);
+    const promptBody = promptSendBody(cpFetch);
     expect(promptBody.content).not.toContain("## Custom Instructions");
+  });
+});
+
+describe("default environment targets", () => {
+  const fullstackEnvironment = {
+    id: "env_abc",
+    name: "Fullstack",
+    repositories: [
+      { repoOwner: "acme", repoName: "widgets" },
+      { repoOwner: "acme", repoName: "gadgets" },
+    ],
+  };
+
+  /**
+   * Point the metadata lookup at a default environment and control what the
+   * environment fetch returns (null → 404, as for a deleted environment).
+   */
+  function mockLaunchTarget(
+    env: Env,
+    opts: {
+      metadata?: { defaultEnvironmentId?: string } | null;
+      metadataStatus?: number;
+      environment?: typeof fullstackEnvironment | null;
+    }
+  ) {
+    getControlPlaneFetch(env).mockImplementation((url: string) => {
+      if (/\/repos\/[^/]+\/[^/]+\/metadata$/.test(url)) {
+        if (opts.metadataStatus) {
+          return Promise.resolve(new Response("Error", { status: opts.metadataStatus }));
+        }
+        return Promise.resolve(
+          new Response(JSON.stringify({ repo: "acme/widgets", metadata: opts.metadata ?? null }), {
+            status: 200,
+          })
+        );
+      }
+      if (/^https:\/\/internal\/environments\//.test(url)) {
+        return opts.environment
+          ? Promise.resolve(
+              new Response(JSON.stringify({ environment: opts.environment }), { status: 200 })
+            )
+          : Promise.resolve(new Response("Not found", { status: 404 }));
+      }
+      if (url === "https://internal/sessions") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ sessionId: "session-123", status: "created" }), {
+            status: 200,
+          })
+        );
+      }
+      if (/\/sessions\/.+\/prompt$/.test(url)) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ messageId: "msg-456" }), { status: 200 })
+        );
+      }
+      return Promise.resolve(new Response("Not found", { status: 404 }));
+    });
+  }
+
+  it("launches the default environment when it contains the trigger repo", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+    mockLaunchTarget(env, {
+      metadata: { defaultEnvironmentId: "env_abc" },
+      environment: fullstackEnvironment,
+    });
+
+    const result = await handleReviewRequested(env, log, reviewRequestedPayload, "trace-env");
+
+    expect(result).toMatchObject({ outcome: "processed", session_id: "session-123" });
+    const sessionBody = sessionCreateBody(getControlPlaneFetch(env));
+    expect(sessionBody.environmentId).toBe("env_abc");
+    expect(sessionBody.repoOwner).toBeUndefined();
+    expect(sessionBody.repoName).toBeUndefined();
+    expect(log.info).toHaveBeenCalledWith(
+      "target.environment_selected",
+      expect.objectContaining({ environment_id: "env_abc", repo: "acme/widgets" })
+    );
+  });
+
+  it("falls back to the repo when the environment no longer exists", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+    mockLaunchTarget(env, {
+      metadata: { defaultEnvironmentId: "env_gone" },
+      environment: null,
+    });
+
+    const result = await handleReviewRequested(env, log, reviewRequestedPayload, "trace-env-gone");
+
+    expect(result).toMatchObject({ outcome: "processed" });
+    const sessionBody = sessionCreateBody(getControlPlaneFetch(env));
+    expect(sessionBody.repoOwner).toBe("acme");
+    expect(sessionBody.repoName).toBe("widgets");
+    expect(sessionBody.environmentId).toBeUndefined();
+    expect(log.warn).toHaveBeenCalledWith(
+      "target.environment_not_found",
+      expect.objectContaining({ environment_id: "env_gone" })
+    );
+  });
+
+  it("falls back to the repo when the environment lacks the trigger repo", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+    mockLaunchTarget(env, {
+      metadata: { defaultEnvironmentId: "env_abc" },
+      environment: {
+        ...fullstackEnvironment,
+        repositories: [{ repoOwner: "acme", repoName: "gadgets" }],
+      },
+    });
+
+    const result = await handlePullRequestOpened(
+      env,
+      log,
+      pullRequestOpenedPayload,
+      "trace-env-nm"
+    );
+
+    expect(result).toMatchObject({ outcome: "processed" });
+    const sessionBody = sessionCreateBody(getControlPlaneFetch(env));
+    expect(sessionBody.repoOwner).toBe("acme");
+    expect(sessionBody.environmentId).toBeUndefined();
+    expect(log.warn).toHaveBeenCalledWith(
+      "target.environment_missing_trigger_repo",
+      expect.objectContaining({ environment_id: "env_abc", repo: "acme/widgets" })
+    );
+  });
+
+  it("falls back to the repo when the metadata lookup fails", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+    mockLaunchTarget(env, { metadataStatus: 500 });
+
+    const result = await handleIssueComment(env, log, issueCommentPayload, "trace-env-meta");
+
+    expect(result).toMatchObject({ outcome: "processed" });
+    const sessionBody = sessionCreateBody(getControlPlaneFetch(env));
+    expect(sessionBody.repoOwner).toBe("acme");
+    expect(sessionBody.environmentId).toBeUndefined();
+    expect(log.warn).toHaveBeenCalledWith(
+      "target.metadata_fetch_failed",
+      expect.objectContaining({ repo: "acme/widgets", status: 500 })
+    );
+  });
+
+  it("membership check is case-insensitive", async () => {
+    const env = createMockEnv();
+    const log = createMockLogger();
+    mockLaunchTarget(env, {
+      metadata: { defaultEnvironmentId: "env_abc" },
+      environment: {
+        ...fullstackEnvironment,
+        repositories: [{ repoOwner: "ACME", repoName: "Widgets" }],
+      },
+    });
+
+    await handleReviewComment(env, log, reviewCommentPayload, "trace-env-case");
+
+    const sessionBody = sessionCreateBody(getControlPlaneFetch(env));
+    expect(sessionBody.environmentId).toBe("env_abc");
   });
 });

--- a/packages/github-bot/test/handlers.test.ts
+++ b/packages/github-bot/test/handlers.test.ts
@@ -1047,6 +1047,86 @@ describe("default environment targets", () => {
       "target.environment_selected",
       expect.objectContaining({ environment_id: "env_abc", repo: "acme/widgets" })
     );
+    // Sender permission is verified on the environment's other repository
+    // (the trigger repo was already checked by caller gating).
+    expect(checkSenderPermission).toHaveBeenCalledWith(
+      "test-installation-token",
+      "acme",
+      "gadgets",
+      "alice",
+      expect.any(String)
+    );
+  });
+
+  it("falls back to the repo when the sender lacks permission on another environment repo", async () => {
+    vi.mocked(checkSenderPermission).mockImplementation(async (_token, _owner, repo) => ({
+      hasPermission: repo !== "gadgets",
+    }));
+    const env = createMockEnv();
+    const log = createMockLogger();
+    mockLaunchTarget(env, {
+      metadata: { defaultEnvironmentId: "env_abc" },
+      environment: fullstackEnvironment,
+    });
+
+    const result = await handleReviewRequested(env, log, reviewRequestedPayload, "trace-env-authz");
+
+    expect(result).toMatchObject({ outcome: "processed" });
+    const sessionBody = sessionCreateBody(getControlPlaneFetch(env));
+    expect(sessionBody.repoOwner).toBe("acme");
+    expect(sessionBody.environmentId).toBeUndefined();
+    expect(log.warn).toHaveBeenCalledWith(
+      "target.environment_sender_not_authorized",
+      expect.objectContaining({
+        environment_id: "env_abc",
+        denied_repo: "acme/gadgets",
+        sender: "alice",
+      })
+    );
+  });
+
+  it("falls back to the repo when a sender permission check errors", async () => {
+    vi.mocked(checkSenderPermission).mockImplementation(async (_token, _owner, repo) =>
+      repo === "gadgets" ? { hasPermission: false, error: true } : { hasPermission: true }
+    );
+    const env = createMockEnv();
+    const log = createMockLogger();
+    mockLaunchTarget(env, {
+      metadata: { defaultEnvironmentId: "env_abc" },
+      environment: fullstackEnvironment,
+    });
+
+    const result = await handleReviewRequested(env, log, reviewRequestedPayload, "trace-env-err");
+
+    expect(result).toMatchObject({ outcome: "processed" });
+    const sessionBody = sessionCreateBody(getControlPlaneFetch(env));
+    expect(sessionBody.environmentId).toBeUndefined();
+    expect(log.warn).toHaveBeenCalledWith(
+      "target.environment_sender_not_authorized",
+      expect.objectContaining({ denied_repo: "acme/gadgets", permission_check_error: true })
+    );
+  });
+
+  it("allowlisted senders launch environments without per-repo permission checks", async () => {
+    vi.mocked(getGitHubConfig).mockResolvedValue({
+      ...defaultConfig,
+      allowedTriggerUsers: ["alice"],
+    });
+    const env = createMockEnv();
+    const log = createMockLogger();
+    mockLaunchTarget(env, {
+      metadata: { defaultEnvironmentId: "env_abc" },
+      environment: fullstackEnvironment,
+    });
+
+    const result = await handleReviewRequested(env, log, reviewRequestedPayload, "trace-env-al");
+
+    expect(result).toMatchObject({ outcome: "processed" });
+    const sessionBody = sessionCreateBody(getControlPlaneFetch(env));
+    expect(sessionBody.environmentId).toBe("env_abc");
+    // Allowlist mode never consults GitHub repo permissions — for the trigger
+    // repo or the environment's repositories.
+    expect(checkSenderPermission).not.toHaveBeenCalled();
   });
 
   it("falls back to the repo when the environment no longer exists", async () => {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -746,6 +746,12 @@ export interface RepoMetadata {
   aliases?: string[];
   channelAssociations?: string[];
   keywords?: string[];
+  /**
+   * Environment opened by GitHub-bot sessions triggered from this repo
+   * (design §13.2). The bot falls back to a repo-bound session when the
+   * environment no longer exists or no longer contains this repository.
+   */
+  defaultEnvironmentId?: string;
 }
 
 export interface EnrichedRepository extends InstallationRepository {

--- a/terraform/d1/migrations/0036_repo_metadata_default_environment.sql
+++ b/terraform/d1/migrations/0036_repo_metadata_default_environment.sql
@@ -1,0 +1,7 @@
+-- Default environment for GitHub-bot sessions triggered from a repository
+-- (design §13.2): when set, a PR review or @mention on this repo opens the
+-- referenced environment's full workspace instead of a single-repo session.
+-- Nullable opt-in; the bot falls back to the repo-bound session when the
+-- environment no longer exists or no longer contains this repository.
+
+ALTER TABLE repo_metadata ADD COLUMN default_environment_id TEXT;


### PR DESCRIPTION
## Summary

Phase 3 slice: GitHub bot environment targets (design §13.2). A repository can name a default environment in its repo metadata (`repo_metadata.default_environment_id`); PR reviews and @mention sessions triggered from that repo then open the environment's full multi-repository workspace — a PR comment on `backend` can spin up the whole full-stack workspace.

Follows the Phase 3 pattern established by the Slack (#924/#927/#928) and Linear (#931) slices: **targets unify instead of migrate** — repo-bound sessions stay the default and the fallback.

## Control plane

- **Migration 0036**: `repo_metadata.default_environment_id TEXT` (nullable opt-in).
- `RepoMetadata.defaultEnvironmentId` (shared type) + `RepoMetadataStore` read/write + accepted by `PUT /repos/:owner/:name/metadata` — configured the same way `channelAssociations` is today (API; no web UI for repo metadata exists yet).

## GitHub bot

- New `session-target.ts` owns launch-target resolution: fetch the trigger repo's metadata → fetch the environment → require the environment to **contain the trigger repo** (the session must be able to check out the PR under review) → launch with `{environmentId}`; every failure path fails open to the repo-bound session with a `target.*` warning log (deleted environment, membership lost, fetch/parse errors).
- `createSession` takes mutually exclusive target fields (`{repoOwner, repoName} | {environmentId}`), spread into the create body — same contract the Linear bot uses.
- Integration settings, enabled-repos gating, and permission checks are untouched: they always resolve from the trigger repository.

## Testing

- github-bot: 5 new tests (environment launch, deleted-environment fallback, non-member fallback, metadata-failure fallback, case-insensitive membership); existing assertions moved from call-index to URL-based lookup since handlers now make a metadata lookup before session create. 120 pass.
- control-plane: store round-trip + clear-on-omit tests; unit 1687 pass, integration 518 pass (migration 0036 applied).
- Full repo typecheck + lint clean; slack-bot 227, linear-bot 131, web 599 pass.

## Docs

- github-bot README: new "Session Launch Target" section.
- docs/HOW_IT_WORKS.md: bots paragraph updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub-bot sessions can now launch a repository’s configured default environment (opt-in via repo metadata), instead of always starting in the repository.
  * If the environment is missing, no longer includes the trigger repository, or the sender lacks required access, sessions automatically fall back to repo-bound targeting.
* **Bug Fixes**
  * Improved session targeting so review and comment-triggered sessions consistently use the correct launch location.
* **Documentation**
  * Updated GitHub-bot documentation to describe the new session launch target behavior and fallback rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->