### PR TITLE
Remove unsupported GPT-5.2 models

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,12 +186,12 @@ await configureGitIdentity({
 
 Choose the AI model that fits your task, with per-session reasoning effort controls:
 
-| Provider         | Models                                                               |
-| ---------------- | -------------------------------------------------------------------- |
-| Anthropic        | Claude Haiku 4.5, Sonnet 4.5/4.6, Opus 4.5/4.6/4.7/4.8, Fable 5      |
-| OpenAI           | GPT 5.2, GPT 5.4, GPT 5.5, GPT 5.2 Codex, 5.3 Codex, 5.3 Codex Spark |
-| OpenCode Zen     | Kimi K2.5/K2.6, MiniMax M2.5, Qwen3.7 Max, GLM 5/5.1 (opt-in)        |
-| Z.AI Coding Plan | GLM 5.2 (opt-in)                                                     |
+| Provider         | Models                                                          |
+| ---------------- | --------------------------------------------------------------- |
+| Anthropic        | Claude Haiku 4.5, Sonnet 4.5/4.6, Opus 4.5/4.6/4.7/4.8, Fable 5 |
+| OpenAI           | GPT 5.4, GPT 5.5, 5.3 Codex, 5.3 Codex Spark                    |
+| OpenCode Zen     | Kimi K2.5/K2.6, MiniMax M2.5, Qwen3.7 Max, GLM 5/5.1 (opt-in)   |
+| Z.AI Coding Plan | GLM 5.2 (opt-in)                                                |
 
 OpenAI models work with your existing ChatGPT subscription via OAuth — no separate API key needed.
 See **[docs/AVAILABLE_MODELS.md](docs/AVAILABLE_MODELS.md)** for the full model list and

--- a/docs/AVAILABLE_MODELS.md
+++ b/docs/AVAILABLE_MODELS.md
@@ -25,13 +25,11 @@ setup instructions.
 
 | Model ID                     | Display name        | Description                                  | Reasoning efforts              | Default effort |
 | ---------------------------- | ------------------- | -------------------------------------------- | ------------------------------ | -------------- |
-| `openai/gpt-5.2`             | GPT 5.2             | 400K context, fast                           | none, low, medium, high, xhigh | Not set        |
 | `openai/gpt-5.4`             | GPT 5.4             | Flagship model                               | none, low, medium, high, xhigh | Not set        |
 | `openai/gpt-5.5`             | GPT 5.5             | Latest flagship model                        | none, low, medium, high, xhigh | Not set        |
 | `openai/gpt-5.6-sol`         | GPT 5.6 Sol         | Frontier model for complex professional work | none, low, medium, high, xhigh | Not set        |
 | `openai/gpt-5.6-terra`       | GPT 5.6 Terra       | Balanced, cost-efficient everyday work       | none, low, medium, high, xhigh | Not set        |
 | `openai/gpt-5.6-luna`        | GPT 5.6 Luna        | Fast, cost-efficient high-volume workloads   | none, low, medium, high, xhigh | Not set        |
-| `openai/gpt-5.2-codex`       | GPT 5.2 Codex       | Optimized for code                           | low, medium, high, xhigh       | high           |
 | `openai/gpt-5.3-codex`       | GPT 5.3 Codex       | Latest codex                                 | low, medium, high, xhigh       | high           |
 | `openai/gpt-5.3-codex-spark` | GPT 5.3 Codex Spark | Low-latency codex variant                    | low, medium, high, xhigh       | high           |
 

--- a/docs/OPENAI_MODELS.md
+++ b/docs/OPENAI_MODELS.md
@@ -12,14 +12,12 @@ how to configure your deployment to use them.
 For the full model list, including Claude Fable 5 and other Anthropic models, see
 [Available Models](AVAILABLE_MODELS.md).
 
-| Model               | Description                    |
-| ------------------- | ------------------------------ |
-| GPT 5.2             | Fast baseline model (400K ctx) |
-| GPT 5.4             | Flagship model                 |
-| GPT 5.5             | Latest flagship model          |
-| GPT 5.2 Codex       | Optimized for code tasks       |
-| GPT 5.3 Codex       | Latest codex variant           |
-| GPT 5.3 Codex Spark | Lightweight Codex variant      |
+| Model               | Description               |
+| ------------------- | ------------------------- |
+| GPT 5.4             | Flagship model            |
+| GPT 5.5             | Latest flagship model     |
+| GPT 5.3 Codex       | Latest codex variant      |
+| GPT 5.3 Codex Spark | Lightweight Codex variant |
 
 OpenAI models support reasoning effort levels: none, low, medium, high, and extra high (default:
 high for Codex models).

--- a/docs/ramp-inspect-agent.md
+++ b/docs/ramp-inspect-agent.md
@@ -168,7 +168,7 @@ bot. They should just be able to chat with it, and it should figure it out.
 
 A critical piece is to build a classifier to determine what repository to work in. Take the user’s
 incoming message, any thread context (if sent in a thread), and the channel’s name. Give that to a
-fast model (we use GPT 5.2 with no reasoning), along with descriptions of every repository your
+fast model (we use GPT 5.4 with no reasoning), along with descriptions of every repository your
 coding agent can access. Be sure to give it hints on the most common repositories, and example
 classifications. Be sure to include an “unknown” option, so the AI can ask the user if unsure. You
 may need to tweak this at first, but this significantly lowers the barrier for entry.

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -1336,7 +1336,7 @@ export class SandboxLifecycleManager {
 
   /**
    * Resolve the provider and model ID from the session or config default.
-   * e.g., "openai/gpt-5.2-codex" -> { provider: "openai", model: "gpt-5.2-codex" }
+   * e.g., "openai/gpt-5.3-codex" -> { provider: "openai", model: "gpt-5.3-codex" }
    */
   private resolveProviderAndModel(session: SessionRow): { provider: string; model: string } {
     return extractProviderAndModel(session.model || this.config.model);

--- a/packages/linear-bot/README.md
+++ b/packages/linear-bot/README.md
@@ -133,7 +133,7 @@ On any Linear issue:
 - Assign the issue to `OpenInspect` → agent picks it up
 - Agent status is visible directly in Linear (thinking, working, done)
 - Add a `model:<name>` label to override the model (e.g., `model:opus`, `model:sonnet`,
-  `model:haiku`, `model:gpt-5.4`, `model:gpt-5.2-codex`)
+  `model:haiku`, `model:gpt-5.4`, `model:gpt-5.3-codex`)
 
 ## Repo Resolution
 

--- a/packages/linear-bot/src/__tests__/pure-functions.test.ts
+++ b/packages/linear-bot/src/__tests__/pure-functions.test.ts
@@ -46,6 +46,10 @@ describe("extractModelFromLabels", () => {
     expect(extractModelFromLabels([{ name: "model:gpt-5.5" }])).toBe("openai/gpt-5.5");
   });
 
+  it.each(["gpt-5.2", "gpt-5.2-codex"])("returns null for unsupported model:%s label", (model) => {
+    expect(extractModelFromLabels([{ name: `model:${model}` }])).toBeNull();
+  });
+
   it.each([
     ["sol", "openai/gpt-5.6-sol"],
     ["terra", "openai/gpt-5.6-terra"],

--- a/packages/linear-bot/src/model-resolution.ts
+++ b/packages/linear-bot/src/model-resolution.ts
@@ -39,13 +39,11 @@ const MODEL_LABEL_MAP: Record<string, string> = {
   "opus-4-8": "anthropic/claude-opus-4-8",
   fable: "anthropic/claude-fable-5",
   "fable-5": "anthropic/claude-fable-5",
-  "gpt-5.2": "openai/gpt-5.2",
   "gpt-5.4": "openai/gpt-5.4",
   "gpt-5.5": "openai/gpt-5.5",
   "gpt-5.6-sol": "openai/gpt-5.6-sol",
   "gpt-5.6-terra": "openai/gpt-5.6-terra",
   "gpt-5.6-luna": "openai/gpt-5.6-luna",
-  "gpt-5.2-codex": "openai/gpt-5.2-codex",
   "gpt-5.3-codex": "openai/gpt-5.3-codex",
 };
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/plugins/codex-auth-plugin.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/plugins/codex-auth-plugin.js
@@ -17,13 +17,11 @@ const REFRESH_BUFFER_MS = 5 * 60 * 1000; // 5 minutes before expiry
 const ALLOWED_MODELS = new Set([
   "gpt-5.1-codex-max",
   "gpt-5.1-codex-mini",
-  "gpt-5.2",
   "gpt-5.4",
   "gpt-5.5",
   "gpt-5.6-sol",
   "gpt-5.6-terra",
   "gpt-5.6-luna",
-  "gpt-5.2-codex",
   "gpt-5.3-codex",
   "gpt-5.3-codex-spark",
   "gpt-5.1-codex",

--- a/packages/sandbox-runtime/tests/test_codex_auth_plugin_setup.py
+++ b/packages/sandbox-runtime/tests/test_codex_auth_plugin_setup.py
@@ -43,6 +43,19 @@ class TestCodexAuthPluginSetup:
         for model in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
             assert f'"{model}"' in plugin_source
 
+    def test_oauth_proxy_excludes_unsupported_gpt_5_2_models(self):
+        """The OAuth model filter should remove unsupported GPT-5.2 variants."""
+        plugin_source = (
+            Path(__file__).parents[1]
+            / "src"
+            / "sandbox_runtime"
+            / "plugins"
+            / "codex-auth-plugin.js"
+        ).read_text()
+
+        for model in ("gpt-5.2", "gpt-5.2-codex"):
+            assert f'"{model}"' not in plugin_source
+
     def test_auth_json_uses_sentinel_token(self, tmp_path):
         """auth.json should contain the sentinel, not the real refresh token."""
         sup = _make_supervisor()

--- a/packages/shared/src/models.test.ts
+++ b/packages/shared/src/models.test.ts
@@ -25,13 +25,11 @@ const ANTHROPIC_MODELS = [
 ] as const;
 
 const OPENAI_MODELS = [
-  "openai/gpt-5.2",
   "openai/gpt-5.4",
   "openai/gpt-5.5",
   "openai/gpt-5.6-sol",
   "openai/gpt-5.6-terra",
   "openai/gpt-5.6-luna",
-  "openai/gpt-5.2-codex",
   "openai/gpt-5.3-codex",
   "openai/gpt-5.3-codex-spark",
 ] as const;
@@ -79,7 +77,18 @@ describe("model utilities", () => {
   });
 
   it("rejects invalid, legacy, empty, and case-mismatched models", () => {
-    for (const model of ["gpt-4", "claude-3-opus", "claude-3-haiku", "haiku", "", "invalid"]) {
+    for (const model of [
+      "gpt-4",
+      "gpt-5.2",
+      "openai/gpt-5.2",
+      "gpt-5.2-codex",
+      "openai/gpt-5.2-codex",
+      "claude-3-opus",
+      "claude-3-haiku",
+      "haiku",
+      "",
+      "invalid",
+    ]) {
       expect(isValidModel(model)).toBe(false);
     }
     expect(isValidModel("Claude-Haiku-4-5")).toBe(false);
@@ -110,7 +119,8 @@ describe("model utilities", () => {
 
   it("returns canonical valid models or the default fallback", () => {
     expect(getValidModelOrDefault("claude-sonnet-4-6")).toBe("anthropic/claude-sonnet-4-6");
-    expect(getValidModelOrDefault("gpt-5.2-codex")).toBe("openai/gpt-5.2-codex");
+    expect(getValidModelOrDefault("gpt-5.3-codex")).toBe("openai/gpt-5.3-codex");
+    expect(getValidModelOrDefault("gpt-5.2-codex")).toBe(DEFAULT_MODEL);
     expect(getValidModelOrDefault("invalid-model")).toBe(DEFAULT_MODEL);
     expect(getValidModelOrDefault(undefined)).toBe(DEFAULT_MODEL);
     expect(getValidModelOrDefault(null)).toBe(DEFAULT_MODEL);
@@ -120,7 +130,7 @@ describe("model utilities", () => {
   it("reports reasoning support and default efforts", () => {
     expect(supportsReasoning("anthropic/claude-sonnet-4-6")).toBe(true);
     expect(supportsReasoning("claude-opus-4-8")).toBe(true);
-    expect(supportsReasoning("openai/gpt-5.2")).toBe(true);
+    expect(supportsReasoning("openai/gpt-5.4")).toBe(true);
     expect(supportsReasoning("openai/gpt-5.6-terra")).toBe(true);
     expect(supportsReasoning("deepseek/deepseek-v4-flash")).toBe(false);
     expect(supportsReasoning("invalid")).toBe(false);
@@ -148,7 +158,7 @@ describe("model utilities", () => {
       efforts: ["low", "medium", "high", "xhigh", "max"],
       default: "high",
     });
-    expect(getReasoningConfig("openai/gpt-5.2")).toEqual({
+    expect(getReasoningConfig("openai/gpt-5.4")).toEqual({
       efforts: ["none", "low", "medium", "high", "xhigh"],
       default: undefined,
     });
@@ -156,7 +166,7 @@ describe("model utilities", () => {
       efforts: ["none", "low", "medium", "high", "xhigh"],
       default: undefined,
     });
-    expect(getReasoningConfig("openai/gpt-5.2-codex")).toEqual({
+    expect(getReasoningConfig("openai/gpt-5.3-codex")).toEqual({
       efforts: ["low", "medium", "high", "xhigh"],
       default: "high",
     });
@@ -169,10 +179,10 @@ describe("model utilities", () => {
     expect(isValidReasoningEffort("anthropic/claude-opus-4-8", "xhigh")).toBe(true);
     expect(isValidReasoningEffort("anthropic/claude-opus-4-8", "none")).toBe(false);
     expect(isValidReasoningEffort("anthropic/claude-fable-5", "max")).toBe(true);
-    expect(isValidReasoningEffort("openai/gpt-5.2", "none")).toBe(true);
+    expect(isValidReasoningEffort("openai/gpt-5.4", "none")).toBe(true);
     expect(isValidReasoningEffort("openai/gpt-5.6-sol", "xhigh")).toBe(true);
     expect(isValidReasoningEffort("openai/gpt-5.6-sol", "max")).toBe(false);
-    expect(isValidReasoningEffort("openai/gpt-5.2-codex", "max")).toBe(false);
+    expect(isValidReasoningEffort("openai/gpt-5.3-codex", "max")).toBe(false);
     expect(isValidReasoningEffort("deepseek/deepseek-v4-pro", "high")).toBe(false);
     expect(isValidReasoningEffort("invalid", "high")).toBe(false);
     expect(isValidReasoningEffort("anthropic/claude-sonnet-4-5", "")).toBe(false);

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -18,13 +18,11 @@ export const VALID_MODELS = [
   "anthropic/claude-opus-4-7",
   "anthropic/claude-opus-4-8",
   "anthropic/claude-fable-5",
-  "openai/gpt-5.2",
   "openai/gpt-5.4",
   "openai/gpt-5.5",
   "openai/gpt-5.6-sol",
   "openai/gpt-5.6-terra",
   "openai/gpt-5.6-luna",
-  "openai/gpt-5.2-codex",
   "openai/gpt-5.3-codex",
   "openai/gpt-5.3-codex-spark",
   "opencode/kimi-k2.5",
@@ -81,7 +79,6 @@ export const MODEL_REASONING_CONFIG: Partial<Record<ValidModel, ModelReasoningCo
     efforts: ["low", "medium", "high", "xhigh", "max"],
     default: "high",
   },
-  "openai/gpt-5.2": { efforts: ["none", "low", "medium", "high", "xhigh"], default: undefined },
   "openai/gpt-5.4": { efforts: ["none", "low", "medium", "high", "xhigh"], default: undefined },
   "openai/gpt-5.5": { efforts: ["none", "low", "medium", "high", "xhigh"], default: undefined },
   "openai/gpt-5.6-sol": {
@@ -96,7 +93,6 @@ export const MODEL_REASONING_CONFIG: Partial<Record<ValidModel, ModelReasoningCo
     efforts: ["none", "low", "medium", "high", "xhigh"],
     default: undefined,
   },
-  "openai/gpt-5.2-codex": { efforts: ["low", "medium", "high", "xhigh"], default: "high" },
   "openai/gpt-5.3-codex": { efforts: ["low", "medium", "high", "xhigh"], default: "high" },
   "openai/gpt-5.3-codex-spark": { efforts: ["low", "medium", "high", "xhigh"], default: "high" },
 };
@@ -164,7 +160,6 @@ export const MODEL_OPTIONS: ModelCategory[] = [
   {
     category: "OpenAI",
     models: [
-      { id: "openai/gpt-5.2", name: "GPT 5.2", description: "400K context, fast" },
       { id: "openai/gpt-5.4", name: "GPT 5.4", description: "Flagship model" },
       { id: "openai/gpt-5.5", name: "GPT 5.5", description: "Latest flagship model" },
       {
@@ -182,7 +177,6 @@ export const MODEL_OPTIONS: ModelCategory[] = [
         name: "GPT 5.6 Luna",
         description: "Fast, cost-efficient high-volume workloads",
       },
-      { id: "openai/gpt-5.2-codex", name: "GPT 5.2 Codex", description: "Optimized for code" },
       { id: "openai/gpt-5.3-codex", name: "GPT 5.3 Codex", description: "Latest codex" },
       {
         id: "openai/gpt-5.3-codex-spark",
@@ -228,13 +222,11 @@ export const DEFAULT_ENABLED_MODELS: ValidModel[] = [
   "anthropic/claude-opus-4-7",
   "anthropic/claude-opus-4-8",
   "anthropic/claude-fable-5",
-  "openai/gpt-5.2",
   "openai/gpt-5.4",
   "openai/gpt-5.5",
   "openai/gpt-5.6-sol",
   "openai/gpt-5.6-terra",
   "openai/gpt-5.6-luna",
-  "openai/gpt-5.2-codex",
   "openai/gpt-5.3-codex",
   "openai/gpt-5.3-codex-spark",
 ];
@@ -304,7 +296,7 @@ export function isValidReasoningEffort(model: string, effort: string): boolean {
  * @example
  * extractProviderAndModel("anthropic/claude-haiku-4-5") // { provider: "anthropic", model: "claude-haiku-4-5" }
  * extractProviderAndModel("claude-haiku-4-5") // { provider: "anthropic", model: "claude-haiku-4-5" }
- * extractProviderAndModel("openai/gpt-5.2-codex") // { provider: "openai", model: "gpt-5.2-codex" }
+ * extractProviderAndModel("openai/gpt-5.3-codex") // { provider: "openai", model: "gpt-5.3-codex" }
  */
 export function extractProviderAndModel(modelId: string): { provider: string; model: string } {
   const normalized = normalizeModelId(modelId);

--- a/packages/slack-bot/src/user-preferences.test.ts
+++ b/packages/slack-bot/src/user-preferences.test.ts
@@ -93,7 +93,7 @@ describe("updateUserPreferences", () => {
       "user_prefs:U123",
       JSON.stringify({
         userId: "U123",
-        model: "openai/gpt-5.2",
+        model: "openai/gpt-5.4",
         updatedAt: 1,
       })
     );
@@ -101,7 +101,7 @@ describe("updateUserPreferences", () => {
     await updateUserPreferences(env, "U123", { branch: "feature/test" });
 
     const prefs = await getUserPreferences(env, "U123");
-    expect(prefs?.model).toBe("openai/gpt-5.2");
+    expect(prefs?.model).toBe("openai/gpt-5.4");
     expect(prefs?.branch).toBe("feature/test");
   });
 
@@ -121,8 +121,8 @@ describe("updateUserPreferences", () => {
       "U123",
       { branch: "feature/test" },
       {
-        defaultModel: "openai/gpt-5.2",
-        enabledModels: ["openai/gpt-5.2"],
+        defaultModel: "openai/gpt-5.4",
+        enabledModels: ["openai/gpt-5.4"],
       }
     );
 
@@ -140,8 +140,8 @@ describe("updateUserPreferences", () => {
       "U123",
       { reasoningEffort: "none" },
       {
-        defaultModel: "openai/gpt-5.2",
-        enabledModels: ["openai/gpt-5.2"],
+        defaultModel: "openai/gpt-5.4",
+        enabledModels: ["openai/gpt-5.4"],
       }
     );
 
@@ -179,18 +179,18 @@ describe("resolveUserPreferences", () => {
     expect(resolved.model).toBe("anthropic/claude-haiku-4-5");
   });
 
-  it("uses the Slack default before the shared default for invalid stored models", () => {
+  it("uses the Slack default before the shared default for unsupported stored models", () => {
     const resolved = resolveUserPreferences(
       {
         userId: "U123",
-        model: "not-a-real-model",
+        model: "openai/gpt-5.2",
         updatedAt: 1,
       },
-      "openai/gpt-5.2",
-      ["anthropic/claude-sonnet-4-6", "openai/gpt-5.2"]
+      "openai/gpt-5.4",
+      ["anthropic/claude-sonnet-4-6", "openai/gpt-5.4"]
     );
 
-    expect(resolved.model).toBe("openai/gpt-5.2");
+    expect(resolved.model).toBe("openai/gpt-5.4");
   });
 
   it("falls back when the App Home model is no longer enabled", () => {
@@ -201,7 +201,7 @@ describe("resolveUserPreferences", () => {
         updatedAt: 1,
       },
       "anthropic/claude-sonnet-4-6",
-      ["openai/gpt-5.2", "anthropic/claude-sonnet-4-6"]
+      ["openai/gpt-5.4", "anthropic/claude-sonnet-4-6"]
     );
 
     expect(resolved.model).toBe("anthropic/claude-sonnet-4-6");
@@ -215,10 +215,10 @@ describe("resolveUserPreferences", () => {
         updatedAt: 1,
       },
       "anthropic/claude-sonnet-4-6",
-      ["openai/gpt-5.2"]
+      ["openai/gpt-5.4"]
     );
 
-    expect(resolved.model).toBe("openai/gpt-5.2");
+    expect(resolved.model).toBe("openai/gpt-5.4");
   });
 
   it("validates stored reasoning effort against the resolved Slack default model", () => {
@@ -228,11 +228,11 @@ describe("resolveUserPreferences", () => {
         reasoningEffort: "none",
         updatedAt: 1,
       },
-      "openai/gpt-5.2",
-      ["openai/gpt-5.2"]
+      "openai/gpt-5.4",
+      ["openai/gpt-5.4"]
     );
 
-    expect(resolved.model).toBe("openai/gpt-5.2");
+    expect(resolved.model).toBe("openai/gpt-5.4");
     expect(resolved.reasoningEffort).toBe("none");
   });
 });

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
@@ -213,12 +213,12 @@ describe("SlackIntegrationSettings", () => {
 
     const modelSection = screen.getByText("Default model").closest("div")!;
     await user.click(within(modelSection).getByRole("combobox"));
-    await user.click(await screen.findByRole("option", { name: "GPT 5.2" }));
+    await user.click(await screen.findByRole("option", { name: "GPT 5.4" }));
     await user.click(screen.getByRole("button", { name: /^save$/i }));
 
     const [, init] = fetchMock.mock.calls[0];
     const body = JSON.parse(init.body as string) as { settings: SlackGlobalConfig };
-    expect(body.settings.defaults?.model).toBe("openai/gpt-5.2");
+    expect(body.settings.defaults?.model).toBe("openai/gpt-5.4");
   });
 
   it("clearing the selected default model omits model while preserving other defaults", async () => {
@@ -227,7 +227,7 @@ describe("SlackIntegrationSettings", () => {
       global: {
         defaults: {
           agentNotificationsEnabled: true,
-          model: "openai/gpt-5.2",
+          model: "openai/gpt-5.4",
           mentionsPolicy: "strip",
           routingRules: [{ keyword: "frontend", target: "acme/web" }],
         },

--- a/packages/web/src/lib/format.ts
+++ b/packages/web/src/lib/format.ts
@@ -12,7 +12,7 @@ const MODEL_DISPLAY_NAMES = new Map<string, string>(
 /**
  * Format model ID to display name.
  * e.g., "anthropic/claude-sonnet-4-5" → "Claude Sonnet 4.5"
- * e.g., "openai/gpt-5.2-codex" → "GPT 5.2 Codex"
+ * e.g., "openai/gpt-5.3-codex" → "GPT 5.3 Codex"
  */
 export function formatModelName(modelId: string): string {
   if (!modelId) return "Unknown Model";


### PR DESCRIPTION
## Summary

- remove GPT-5.2 and GPT-5.2 Codex from shared model metadata and default-enabled models
- remove both variants from the Codex OAuth allowlist and Linear model labels
- refresh model examples, fixtures, and documentation to supported OpenAI models
- verify legacy GPT-5.2 values are rejected and fall back safely

## Why

The Codex backend no longer supports the GPT-5.2 variants. Keeping them selectable caused new sessions and integration overrides to target unavailable models.

## Impact

GPT-5.2 models no longer appear in model selectors or integration aliases. Existing stored preferences that reference them are treated as unsupported and resolve through the existing default-model fallback.

## Validation

- `npm run build -w @open-inspect/shared`
- focused Vitest suites for shared, Linear, Slack, and web (84 tests)
- sandbox-runtime Codex auth plugin tests (5 tests)
- type checks for shared, Linear, Slack, web, and control plane
- ESLint for shared, Linear, Slack, web, and control plane
- Ruff and Prettier checks for changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated supported model lists to include newer GPT 5.4/5.5/5.6 variants and GPT 5.3 Codex options.
* **Bug Fixes**
  * Removed outdated GPT 5.2 model references so unsupported models are no longer shown or selected by default.
  * Improved model fallback behavior when a saved model is no longer available.
* **Documentation**
  * Refreshed setup and usage docs to match the current supported model set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->