### PR TITLE
fix(web): match any session repo in search, show environment on cards

### DIFF
--- a/packages/web/src/components/session-sidebar.test.tsx
+++ b/packages/web/src/components/session-sidebar.test.tsx
@@ -51,12 +51,21 @@ vi.mock("@/hooks/use-media-query", () => ({
   useIsMobile: mockUseIsMobile,
 }));
 
+const { mockUseEnvironments } = vi.hoisted(() => ({
+  mockUseEnvironments: vi.fn(() => ({ environments: [] as unknown[], loading: false })),
+}));
+
+vi.mock("@/hooks/use-environments", () => ({
+  useEnvironments: mockUseEnvironments,
+}));
+
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
   vi.useRealTimers();
   mockUseIsMobile.mockReturnValue(false);
   mockPush.mockReset();
+  mockUseEnvironments.mockReturnValue({ environments: [], loading: false });
 });
 
 function createSession(index: number, overrides: Record<string, unknown> = {}) {
@@ -315,6 +324,68 @@ describe("SessionSidebar", () => {
       expect(fetchMock).toHaveBeenCalledWith(mineKey);
     });
     expect(screen.queryByText("Session 1")).not.toBeInTheDocument();
+  });
+
+  it("matches non-primary repository members in the sidebar search", async () => {
+    const session = createSession(1, {
+      repositories: [
+        { repoOwner: "open-inspect", repoName: "background-agents", repoId: 1, baseBranch: "main" },
+        { repoOwner: "acme", repoName: "api", repoId: 2, baseBranch: "main" },
+      ],
+    });
+
+    render(
+      <SWRConfig
+        value={{
+          fallback: { [SIDEBAR_SESSIONS_KEY]: { sessions: [session], hasMore: false } },
+          dedupingInterval: 0,
+          revalidateOnFocus: false,
+        }}
+      >
+        <SessionSidebar />
+      </SWRConfig>
+    );
+
+    expect(await screen.findByText("Session 1")).toBeInTheDocument();
+
+    const searchInput = screen.getByPlaceholderText("Search sessions...");
+    fireEvent.change(searchInput, { target: { value: "acme/api" } });
+
+    expect(screen.getByText("Session 1")).toBeInTheDocument();
+
+    fireEvent.change(searchInput, { target: { value: "acme/docs" } });
+
+    expect(screen.queryByText("Session 1")).not.toBeInTheDocument();
+    expect(screen.getByText("No matching sessions")).toBeInTheDocument();
+  });
+
+  it("shows the environment name on cards for environment-launched sessions", async () => {
+    mockUseEnvironments.mockReturnValue({
+      environments: [{ id: "env_1", name: "Full stack" }],
+      loading: false,
+    });
+
+    const sessions = [
+      createSession(1, { environmentId: "env_1" }),
+      // Deleted environment: the chip is dropped rather than showing a raw id.
+      createSession(2, { environmentId: "env_gone" }),
+    ];
+
+    render(
+      <SWRConfig
+        value={{
+          fallback: { [SIDEBAR_SESSIONS_KEY]: { sessions, hasMore: false } },
+          dedupingInterval: 0,
+          revalidateOnFocus: false,
+        }}
+      >
+        <SessionSidebar />
+      </SWRConfig>
+    );
+
+    expect(await screen.findByText("Session 1")).toBeInTheDocument();
+    expect(screen.getByText("Full stack")).toBeInTheDocument();
+    expect(screen.queryByText("env_gone")).not.toBeInTheDocument();
   });
 
   it("ignores stale load-more results after the creator filter changes", async () => {

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -278,6 +278,15 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
     };
   }, [sessions, searchQuery]);
 
+  // Environment provenance for the cards, resolved once for the whole list.
+  // Names are looked up so a deleted environment (or one still loading)
+  // simply drops the chip instead of showing a raw id.
+  const { environments } = useEnvironments();
+  const environmentNamesById = useMemo(
+    () => new Map(environments.map((environment) => [environment.id, environment.name])),
+    [environments]
+  );
+
   const currentSessionId = pathname?.startsWith("/session/") ? pathname.split("/")[2] : null;
   const hasSessionListError = sessionsError;
   const emptyMessage = hasSessionListError
@@ -464,6 +473,11 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
               <SessionWithChildren
                 key={session.id}
                 session={session}
+                environmentName={
+                  session.environmentId
+                    ? environmentNamesById.get(session.environmentId)
+                    : undefined
+                }
                 childrenMap={childrenMap}
                 currentSessionId={currentSessionId}
                 isMobile={isMobile}
@@ -485,6 +499,11 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
                   <SessionWithChildren
                     key={session.id}
                     session={session}
+                    environmentName={
+                      session.environmentId
+                        ? environmentNamesById.get(session.environmentId)
+                        : undefined
+                    }
                     childrenMap={childrenMap}
                     currentSessionId={currentSessionId}
                     isMobile={isMobile}
@@ -558,6 +577,7 @@ function UserMenu({ user }: { user?: { name?: string | null; image?: string | nu
 
 function SessionWithChildren({
   session,
+  environmentName,
   childrenMap,
   currentSessionId,
   isMobile,
@@ -566,6 +586,7 @@ function SessionWithChildren({
   onSessionRenamed,
 }: {
   session: SessionItem;
+  environmentName?: string;
   childrenMap: Map<string, SessionItem[]>;
   currentSessionId: string | null;
   isMobile: boolean;
@@ -577,6 +598,7 @@ function SessionWithChildren({
     <>
       <SessionListItem
         session={session}
+        environmentName={environmentName}
         isActive={session.id === currentSessionId}
         isMobile={isMobile}
         onArchive={onArchive}
@@ -646,6 +668,7 @@ function ChildSessionTree({
 
 function SessionListItem({
   session,
+  environmentName,
   isActive,
   isMobile,
   onArchive,
@@ -653,6 +676,7 @@ function SessionListItem({
   onSessionRenamed,
 }: {
   session: SessionItem;
+  environmentName?: string;
   isActive: boolean;
   isMobile: boolean;
   onArchive: (sessionId: string) => Promise<void>;
@@ -666,12 +690,6 @@ function SessionListItem({
     session.repoName,
     session.repositories
   );
-  // Environment provenance chip: resolved by name so a deleted environment
-  // (or one still loading) simply drops the chip instead of showing a raw id.
-  const { environments } = useEnvironments();
-  const environmentName = session.environmentId
-    ? environments.find((environment) => environment.id === session.environmentId)?.name
-    : undefined;
   const displayTitle = session.title || repoInfo;
   // Orphan child (parent filtered out) — show a subtle badge
   const isOrphanChild = session.parentSessionId && session.spawnSource === "agent";

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -36,12 +36,14 @@ import {
   SettingsIcon,
   AutomationsIcon,
   BranchIcon,
+  BoxIcon,
   DataControlsIcon,
 } from "@/components/ui/icons";
 import { APP_SHORT_NAME } from "@/lib/site-config";
 import { formatRepoLabel, formatSessionRepositoriesLabel } from "@/lib/repo-label";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useEnvironments } from "@/hooks/use-environments";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -219,8 +221,13 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
         if (!searchQuery) return true;
         const query = searchQuery.toLowerCase();
         const title = session.title?.toLowerCase() || "";
-        const repo = formatRepoLabel(session.repoOwner, session.repoName).toLowerCase();
-        return title.includes(query) || repo.includes(query);
+        if (title.includes(query)) return true;
+        // Match against every member of the repository set, not just the
+        // primary; scalar fallback covers pre-multi-repo sessions.
+        const repoLabels = session.repositories?.length
+          ? session.repositories.map((repo) => formatRepoLabel(repo.repoOwner, repo.repoName))
+          : [formatRepoLabel(session.repoOwner, session.repoName)];
+        return repoLabels.some((label) => label.toLowerCase().includes(query));
       });
 
     // Sort by updatedAt descending
@@ -659,6 +666,12 @@ function SessionListItem({
     session.repoName,
     session.repositories
   );
+  // Environment provenance chip: resolved by name so a deleted environment
+  // (or one still loading) simply drops the chip instead of showing a raw id.
+  const { environments } = useEnvironments();
+  const environmentName = session.environmentId
+    ? environments.find((environment) => environment.id === session.environmentId)?.name
+    : undefined;
   const displayTitle = session.title || repoInfo;
   // Orphan child (parent filtered out) — show a subtle badge
   const isOrphanChild = session.parentSessionId && session.spawnSource === "agent";
@@ -862,6 +875,13 @@ function SessionListItem({
               <span>{relativeTime}</span>
               <span>·</span>
               <span className="truncate">{repoInfo}</span>
+              {environmentName && (
+                <>
+                  <span>·</span>
+                  <BoxIcon className="w-3 h-3 flex-shrink-0" />
+                  <span className="truncate">{environmentName}</span>
+                </>
+              )}
               {isOrphanChild && (
                 <>
                   <span>·</span>


### PR DESCRIPTION
## Summary

Two small session-list fixes that complete existing multi-repo behavior — no new UI surface:

- **Sidebar search matches every repository in a session's set.** Previously it only matched the primary repo's `owner/name`, so searching for a repo silently missed multi-repo sessions where that repo is a secondary member.
- **Session cards show the environment name** (small chip) when the session was launched from an environment, per design §5.3. Deleted or still-loading environments simply drop the chip rather than showing a raw id.

> Scope note: an earlier revision of this PR also added a repository filter dropdown backed by new `repoOwner`/`repoName` params on `GET /sessions`. That was cut as speculative — no one has asked for it. The store-level any-member query (`idx_session_repositories_repo`) remains available if demand appears.

## Testing

- Web (616): search matches a non-primary member and still excludes non-matches; environment name renders on cards and unknown environment ids render nothing.
- Lint, typecheck, prettier clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search now matches sessions across all repositories linked to a session, improving results for multi-repo sessions.
  * Session rows can display a friendly environment name when that environment exists.

* **Bug Fixes**
  * Improved sidebar search for sessions tied to non-primary repositories.
  * Avoids showing unclear raw or deleted/missing environment identifiers when the environment can’t be resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->