### PR TITLE
refactor: rename launch-unit secrets to session-target secrets

### DIFF
--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -554,7 +554,7 @@ restores still mint a fresh fallback token on restore.
 ### Secrets
 
 You can configure environment variables (API keys, credentials) at global, per-repository, or
-per-environment scope. A session receives global secrets plus its **launch unit's** secrets:
+per-environment scope. A session receives global secrets plus its **session target's** secrets:
 
 - **Global secrets** apply to all sessions (e.g., `ANTHROPIC_API_KEY`, `DEEPSEEK_API_KEY`,
   `ZHIPU_API_KEY`)

--- a/docs/IMAGE_PREBUILD.md
+++ b/docs/IMAGE_PREBUILD.md
@@ -144,7 +144,7 @@ A build clones every repository in the environment at its configured base branch
 repository's `.openinspect/setup.sh` **sequentially, in position order**. A failing setup script
 fails the whole build, and the error names the repository. Build-time secrets are exactly what the
 environment's sessions get: global + environment secrets
-([launch-unit scoping](SECRETS.md#which-secrets-a-session-receives)).
+([session-target scoping](SECRETS.md#which-secrets-a-session-receives)).
 
 ### When environment images rebuild
 

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -39,8 +39,8 @@ shows which scope overrode it.
 
 ### Which secrets a session receives
 
-A session receives **global secrets plus its launch unit's secrets** — the launch unit is whatever
-you picked when creating the session:
+A session receives **global secrets plus its session target's secrets** — the session target is
+whatever you picked when creating the session:
 
 - **Single repository** (web picker, Slack, GitHub, Linear): global + that repository's secrets.
 - **Environment**: global + that **environment's** secrets only. The repositories inside the
@@ -119,7 +119,7 @@ Click the delete button next to any secret row and confirm.
 | Max key length                   | 256 characters                                          |
 | Max value size                   | 16 KB                                                   |
 | Max total value size (per scope) | 64 KB                                                   |
-| Max combined size per session    | 128 KB (global + launch unit, after merging)            |
+| Max combined size per session    | 128 KB (global + session target, after merging)         |
 | Key format                       | `[A-Za-z_][A-Za-z0-9_]*` (letters, digits, underscores) |
 
 If the merged payload for a session (or an image build) exceeds the combined cap, the spawn fails

--- a/packages/control-plane/src/db/environment-secrets.ts
+++ b/packages/control-plane/src/db/environment-secrets.ts
@@ -134,7 +134,7 @@ export class EnvironmentSecretsStore {
   /**
    * Copy secrets from a member repo into this environment, ciphertext-verbatim.
    * When `keys` is omitted, imports every key the source repo has. Enforces the
-   * per-scope key cap; the combined-value byte cap is left to the launch-unit
+   * per-scope key cap; the combined-value byte cap is left to the session-target
    * fold at spawn/build time (PR-6) since measuring it here would require
    * decrypting the copied ciphertext.
    *

--- a/packages/control-plane/src/db/secrets-validation.ts
+++ b/packages/control-plane/src/db/secrets-validation.ts
@@ -95,7 +95,7 @@ export interface MergedSecrets {
  * Fold an ordered list of secret sources into one payload. Sources are given
  * lowest precedence first; a later source's key overrides (case-insensitively)
  * an earlier one's — so `[global, repoB, repoA]` lets repoA win, which is how
- * the launch-unit fold passes the primary member last (design §6.4). Reports
+ * the session-target fold passes the primary member last (design §6.4). Reports
  * per-source byte attribution and cross-source collisions for the cap-check and
  * collision warnings; the pure merge stays identical to the old two-arg
  * `mergeSecrets(global, repo)` for the single-source-plus-global case.

--- a/packages/control-plane/src/environment-images/planner.ts
+++ b/packages/control-plane/src/environment-images/planner.ts
@@ -237,7 +237,7 @@ export class EnvironmentImageBuildPlanner {
       });
     }
 
-    // Same source labels as the session spawn fold (launch-unit-secrets.ts) so
+    // Same source labels as the session spawn fold (session-target-secrets.ts) so
     // collision/cap logs attribute identically at build and session time.
     const merge = mergeSecretSources([
       { label: "global", secrets: globalSecrets },

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -319,7 +319,7 @@ const routes: Route[] = [
   // Secrets
   ...secretsRoutes,
 
-  // Environments (Phase-2 launch unit; internal-HMAC only, web BFF proxied)
+  // Environments (Phase-2 session target; internal-HMAC only, web BFF proxied)
   ...environmentRoutes,
   ...environmentSecretsRoutes,
   ...environmentImageRoutes,

--- a/packages/control-plane/src/routes/environments.ts
+++ b/packages/control-plane/src/routes/environments.ts
@@ -1,6 +1,6 @@
 /**
  * Environment CRUD routes. Internal-HMAC authenticated (the web BFF proxies
- * these). Environments are the Phase-2 launch unit: a named, prebuildable
+ * these). Environments are the Phase-2 session target: a named, prebuildable
  * repository set with its own secrets. Additive and dark until the web picker
  * (PR-12); the create-from-environment session path is PR-9. Secrets routes
  * live in ./environment-secrets.

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -75,7 +75,7 @@ import {
   mergeSecretSources,
   parseSecretsCapMode,
 } from "../db/secrets-validation";
-import { buildLaunchUnitSecretSources } from "./launch-unit-secrets";
+import { buildSessionTargetSecretSources } from "./session-target-secrets";
 import type { SessionRepositoryEntry } from "./repository-target";
 import { OpenAITokenRefreshService } from "./openai-token-refresh-service";
 import { ScmCredentialsService } from "./scm-credentials-service";
@@ -1869,7 +1869,7 @@ export class SessionDO extends DurableObject<Env> {
 
     const repoStore = new RepoSecretsStore(this.env.DB, encryptionKey);
     const environmentSecretsStore = new EnvironmentSecretsStore(this.env.DB, encryptionKey);
-    const sources = await buildLaunchUnitSecretSources({
+    const sources = await buildSessionTargetSecretSources({
       environmentId: session.environment_id,
       globalSecrets,
       members: this.repository.getSessionRepositories(),
@@ -1901,7 +1901,7 @@ export class SessionDO extends DurableObject<Env> {
 
   /**
    * Decrypt one member repo's secrets — the injected leaf loader for
-   * buildLaunchUnitSecretSources. The member row carries the repo id; a
+   * buildSessionTargetSecretSources. The member row carries the repo id; a
    * synthesized primary (legacy scalar row) resolves it lazily via ensureRepoId.
    * A member without a resolvable id (a secondary with a null row id) can't be
    * keyed, so it contributes nothing.

--- a/packages/control-plane/src/session/session-target-secrets.test.ts
+++ b/packages/control-plane/src/session/session-target-secrets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { buildLaunchUnitSecretSources } from "./launch-unit-secrets";
+import { buildSessionTargetSecretSources } from "./session-target-secrets";
 import type { SessionRepositoryEntry } from "./repository-target";
 
 function member(
@@ -14,14 +14,14 @@ function member(
 /** Repo-launched sessions never load environment secrets; a stub keeps that explicit. */
 const noEnvironmentSecrets = async (): Promise<Record<string, string>> => ({});
 
-describe("buildLaunchUnitSecretSources", () => {
+describe("buildSessionTargetSecretSources", () => {
   it("folds members lowest-precedence-first with the primary (position 0) last", async () => {
     const secretsByRepo: Record<string, Record<string, string>> = {
       "acme/web": { A: "web" },
       "acme/backend": { B: "backend" },
     };
 
-    const sources = await buildLaunchUnitSecretSources({
+    const sources = await buildSessionTargetSecretSources({
       environmentId: null,
       globalSecrets: { G: "g" },
       members: [member("acme", "web", 0, true), member("acme", "backend", 1, false)],
@@ -36,7 +36,7 @@ describe("buildLaunchUnitSecretSources", () => {
   it("folds global + environment for an environment-launched session — member repos never inherit", async () => {
     const loadMemberSecrets = vi.fn();
 
-    const sources = await buildLaunchUnitSecretSources({
+    const sources = await buildSessionTargetSecretSources({
       environmentId: "env_flagship",
       globalSecrets: { G: "g" },
       members: [member("acme", "web", 0, true)],
@@ -51,7 +51,7 @@ describe("buildLaunchUnitSecretSources", () => {
   });
 
   it("returns only global for an environment session with no environment secrets", async () => {
-    const sources = await buildLaunchUnitSecretSources({
+    const sources = await buildSessionTargetSecretSources({
       environmentId: "env_empty",
       globalSecrets: { G: "g" },
       members: [member("acme", "web", 0, true)],
@@ -63,7 +63,7 @@ describe("buildLaunchUnitSecretSources", () => {
   });
 
   it("omits members that contribute no secrets", async () => {
-    const sources = await buildLaunchUnitSecretSources({
+    const sources = await buildSessionTargetSecretSources({
       environmentId: null,
       globalSecrets: {},
       members: [member("acme", "web", 0, true), member("acme", "empty", 1, false)],
@@ -76,7 +76,7 @@ describe("buildLaunchUnitSecretSources", () => {
   });
 
   it("returns only global when there are no members", async () => {
-    const sources = await buildLaunchUnitSecretSources({
+    const sources = await buildSessionTargetSecretSources({
       environmentId: null,
       globalSecrets: { G: "g" },
       members: [],

--- a/packages/control-plane/src/session/session-target-secrets.ts
+++ b/packages/control-plane/src/session/session-target-secrets.ts
@@ -1,11 +1,11 @@
 import type { SecretSource } from "../db/secrets-validation";
 import type { SessionRepositoryEntry } from "./repository-target";
 
-export interface LaunchUnitSecretSourcesInput {
+export interface SessionTargetSecretSourcesInput {
   /**
-   * The launch unit's environment id (`session.environment_id`), or null for
+   * The session target's environment id (`session.environment_id`), or null for
    * repo-launched/ad-hoc sessions. When set, secrets come from global +
-   * environment only — the session's member repos never contribute (launch-unit
+   * environment only — the session's member repos never contribute (session-target
    * scoping, §6.4/§7.4).
    */
   environmentId: string | null;
@@ -23,18 +23,18 @@ export interface LaunchUnitSecretSourcesInput {
 }
 
 /**
- * Build the ordered secret sources for a session's launch unit, lowest
+ * Build the ordered secret sources for a session target, lowest
  * precedence first (design §6.4). Global is always the base; environment-
  * launched sessions add environment secrets only (member repo secrets never
- * inherit — launch-unit scoping, §6.4/§7.4), while repo-launched and ad-hoc
+ * inherit — session-target scoping, §6.4/§7.4), while repo-launched and ad-hoc
  * sessions fold their member repos with the primary (position 0) merged last so
  * it wins collisions. A single-repo session degenerates to today's global+repo.
  *
- * This owns the launch-unit sourcing policy so the DO only loads sources, merges
+ * This owns the session-target sourcing policy so the DO only loads sources, merges
  * (mergeSecretSources), and audits the cap.
  */
-export async function buildLaunchUnitSecretSources(
-  input: LaunchUnitSecretSourcesInput
+export async function buildSessionTargetSecretSources(
+  input: SessionTargetSecretSourcesInput
 ): Promise<SecretSource[]> {
   const sources: SecretSource[] = [{ label: "global", secrets: input.globalSecrets }];
 

--- a/packages/control-plane/test/integration/session-secrets-fold.test.ts
+++ b/packages/control-plane/test/integration/session-secrets-fold.test.ts
@@ -8,7 +8,7 @@ import { initSession } from "./helpers";
 
 const KEY = () => env.REPO_SECRETS_ENCRYPTION_KEY as string;
 
-/** Invoke the DO's real (private) getUserEnvVars, exercising the launch-unit fold. */
+/** Invoke the DO's real (private) getUserEnvVars, exercising the session-target fold. */
 function getUserEnvVars(stub: DurableObjectStub): Promise<Record<string, string> | undefined> {
   return runInDurableObject(stub, (instance: SessionDO) =>
     (
@@ -19,7 +19,7 @@ function getUserEnvVars(stub: DurableObjectStub): Promise<Record<string, string>
   );
 }
 
-describe("getUserEnvVars launch-unit fold", () => {
+describe("getUserEnvVars session-target fold", () => {
   beforeEach(cleanD1Tables);
 
   it("folds member repo secrets with the primary winning collisions (ad-hoc list)", async () => {

--- a/packages/github-bot/README.md
+++ b/packages/github-bot/README.md
@@ -148,7 +148,7 @@ people to request the GitHub App bot through the PR reviewer picker.
 **Review Comment:** Same as issue comment, but the prompt additionally includes `filePath`,
 `diffHunk`, and `commentId` for thread-specific context and reply threading.
 
-### Session Launch Target
+### Session Target
 
 Sessions are repo-bound by default: they open the webhook payload's repository. A repository can opt
 into launching a saved environment instead by setting `defaultEnvironmentId` in its repo metadata

--- a/packages/github-bot/src/session-target.ts
+++ b/packages/github-bot/src/session-target.ts
@@ -1,5 +1,5 @@
 /**
- * Session launch-target resolution for the GitHub bot (design §13.2).
+ * Session-target resolution for the GitHub bot (design §13.2).
  *
  * A repository may name a default environment
  * (`repo_metadata.default_environment_id`) so sessions triggered from it open
@@ -183,7 +183,7 @@ async function senderAuthorizedForEnvironment(
 }
 
 /**
- * Resolve the launch target for a session triggered from a repository: the
+ * Resolve the session target for a session triggered from a repository: the
  * repo's default environment when one is configured, still exists, contains
  * the trigger repo, and the sender is authorized for all of its repositories;
  * otherwise the repo itself.

--- a/packages/github-bot/test/handlers.test.ts
+++ b/packages/github-bot/test/handlers.test.ts
@@ -106,7 +106,7 @@ function getControlPlaneFetch(env: Env) {
 
 /**
  * Locate control-plane calls by URL rather than index — handlers make a
- * launch-target metadata lookup before creating the session.
+ * session-target metadata lookup before creating the session.
  */
 function findCallBody(cpFetch: ReturnType<typeof vi.fn>, urlPattern: RegExp) {
   const call = cpFetch.mock.calls.find(([url]) => urlPattern.test(String(url)));

--- a/packages/linear-bot/src/target-resolution.ts
+++ b/packages/linear-bot/src/target-resolution.ts
@@ -23,7 +23,7 @@ import { createLogger } from "./logger";
 
 const log = createLogger("target-resolution");
 
-/** A resolved session launch target: a repository or a saved environment. */
+/** A resolved session target: a repository or a saved environment. */
 export type SessionTarget =
   | { kind: "repository"; owner: string; name: string; fullName: string }
   | { kind: "environment"; environment: Environment };

--- a/packages/slack-bot/src/targets.ts
+++ b/packages/slack-bot/src/targets.ts
@@ -1,5 +1,5 @@
 /**
- * Session launch targets for the Slack bot.
+ * Session targets for the Slack bot.
  *
  * Every surface that picks "what to work on" — routing rules, clarification
  * quick-picks, the repository picker — resolves to a {@link SlackSessionTarget}:

--- a/packages/slack-bot/src/types/index.ts
+++ b/packages/slack-bot/src/types/index.ts
@@ -139,9 +139,9 @@ export type SlackBotCallbackContext = SlackCallbackContext;
  */
 export interface ThreadSession {
   sessionId: string;
-  /** Launch-target id: the repo id ("owner/name") or environment id ("env_…"). */
+  /** Session-target id: the repo id ("owner/name") or environment id ("env_…"). */
   repoId: string;
-  /** Launch-target display label: the repo fullName or environment name. */
+  /** Session-target display label: the repo fullName or environment name. */
   repoFullName: string;
   model: string;
   reasoningEffort?: string;

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -427,7 +427,7 @@ function HomeContent({
                 </div>
               </div>
 
-              {/* Secrets disclosure per launch unit (design §7.4) */}
+              {/* Secrets disclosure per session target (design §7.4) */}
               {sessionTarget?.kind === "environment" && (
                 <p className="mt-3 text-xs text-muted-foreground text-center">
                   Sessions from this environment use global secrets plus the environment&apos;s


### PR DESCRIPTION
Pure rename — zero behavior change. Replaces the banned "launch unit" nomenclature with the project's "session target" vocabulary across identifiers, comments, and docs.

## Commit 1: launch-unit secrets → session-target secrets

File renames (`git mv`):
- `packages/control-plane/src/session/launch-unit-secrets.ts` → `session-target-secrets.ts`
- `packages/control-plane/src/session/launch-unit-secrets.test.ts` → `session-target-secrets.test.ts`

Identifier renames:
- `LaunchUnitSecretSourcesInput` → `SessionTargetSecretSourcesInput`
- `buildLaunchUnitSecretSources` → `buildSessionTargetSecretSources`

Comment/doc prose ("launch unit" → "session target") in: `db/environment-secrets.ts`, `db/secrets-validation.ts`, `environment-images/planner.ts`, `session/durable-object.ts`, `router.ts`, `routes/environments.ts`, `test/integration/session-secrets-fold.test.ts`, `packages/web/src/app/(app)/page.tsx`, `docs/SECRETS.md`, `docs/HOW_IT_WORKS.md`, `docs/IMAGE_PREBUILD.md`.

## Commit 2 (droppable): bot "launch-target" prose → session-target

The control-plane `automation/launch-target.ts` rename already landed (it is `automation/session-target.ts` with `resolveAutomationSessionTarget` on main), so what remains is comment/doc prose only — no identifiers:
- `packages/github-bot/src/session-target.ts`, `packages/github-bot/test/handlers.test.ts`, `packages/github-bot/README.md`
- `packages/slack-bot/src/types/index.ts`, `packages/slack-bot/src/targets.ts`
- `packages/linear-bot/src/target-resolution.ts`

**This commit can be dropped independently if unwanted** — commit 1 does not depend on it.

## Not touched
- No persisted data, D1 columns, wire-protocol/API fields, or cross-service contracts renamed. Secret source labels (`"global"`, `"environment"`, repo full names) are unchanged.
- **No log event names or log fields renamed** (none contained the banned naming).
- `packages/web/src/lib/session-target.ts` already used correct vocabulary — untouched apart from the one comment in `page.tsx`.

## Verification
- `npm run typecheck`, `npm run lint`: clean
- control-plane unit: 1716 passed (100 files); integration: 525 passed (43 files)
- github-bot 123, slack-bot 227, linear-bot 136 passed
- Final sweep: zero case-insensitive `launch.?unit` / `launch.?target` matches outside node_modules/dist


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated terminology throughout the product and developer documentation from “launch unit” to “session target.”
  * Clarified that sessions receive global secrets plus secrets associated with their session target.
  * Updated related guidance, limits, and design references for consistency.

* **Refactor**
  * Renamed secret-source terminology and references to align with session-target concepts without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->