### PR TITLE
refactor(control-plane): unify scoped-secrets store plumbing

### DIFF
--- a/packages/control-plane/src/db/environment-secrets.ts
+++ b/packages/control-plane/src/db/environment-secrets.ts
@@ -11,16 +11,16 @@
  * round-trip is needed, and plaintext never transits the control plane.
  */
 
-import { encryptToken, decryptToken } from "../auth/crypto";
 import { createLogger } from "../logger";
 import {
-  MAX_TOTAL_VALUE_SIZE,
-  MAX_SECRETS_PER_SCOPE,
-  SecretsValidationError,
-  normalizeKey,
-  validateKey,
-  validateValue,
-} from "./secrets-validation";
+  assertScopeKeyCapacity,
+  decryptSecretRows,
+  encryptSecretEntries,
+  prepareSecretsForWrite,
+  toSecretMetadata,
+} from "./scoped-secrets";
+import type { SecretsWriteResult } from "./scoped-secrets";
+import { normalizeKey, validateKey } from "./secrets-validation";
 import type { SecretMetadata } from "./secrets-validation";
 
 const log = createLogger("environment-secrets");
@@ -34,45 +34,24 @@ export class EnvironmentSecretsStore {
   async setSecrets(
     environmentId: string,
     secrets: Record<string, string>
-  ): Promise<{ created: number; updated: number; keys: string[] }> {
+  ): Promise<SecretsWriteResult> {
     const now = Date.now();
-
-    const normalized: Record<string, string> = {};
-    let totalValueBytes = 0;
-    for (const [rawKey, value] of Object.entries(secrets)) {
-      const key = normalizeKey(rawKey);
-      validateKey(key);
-      validateValue(value);
-      totalValueBytes += new TextEncoder().encode(value).length;
-      normalized[key] = value;
-    }
-
-    if (totalValueBytes > MAX_TOTAL_VALUE_SIZE) {
-      throw new SecretsValidationError(`Total secret size exceeds ${MAX_TOTAL_VALUE_SIZE} bytes`);
-    }
+    const normalized = prepareSecretsForWrite(secrets);
 
     const existingKeySet = await this.existingKeys(environmentId);
 
     const incomingKeys = Object.keys(normalized);
-    const netNew = incomingKeys.filter((k) => !existingKeySet.has(k)).length;
-    if (existingKeySet.size + netNew > MAX_SECRETS_PER_SCOPE) {
-      throw new SecretsValidationError(
-        `Environment would exceed ${MAX_SECRETS_PER_SCOPE} secrets limit ` +
-          `(current: ${existingKeySet.size}, adding: ${netNew})`
-      );
-    }
+    assertScopeKeyCapacity("Environment", existingKeySet, incomingKeys);
 
-    let created = 0;
-    let updated = 0;
+    const { entries, created, updated } = await encryptSecretEntries(
+      normalized,
+      existingKeySet,
+      this.encryptionKey
+    );
 
-    const statements: D1PreparedStatement[] = [];
-    for (const [key, value] of Object.entries(normalized)) {
-      const encrypted = await encryptToken(value, this.encryptionKey);
-      if (existingKeySet.has(key)) updated++;
-      else created++;
-
-      statements.push(this.bindUpsert(environmentId, key, encrypted, now));
-    }
+    const statements = entries.map((entry) =>
+      this.bindUpsert(environmentId, entry.key, entry.encryptedValue, now)
+    );
 
     if (statements.length > 0) {
       await this.db.batch(statements);
@@ -89,11 +68,7 @@ export class EnvironmentSecretsStore {
       .bind(environmentId)
       .all<{ key: string; created_at: number; updated_at: number }>();
 
-    return (result.results || []).map((row) => ({
-      key: row.key,
-      createdAt: row.created_at,
-      updatedAt: row.updated_at,
-    }));
+    return toSecretMetadata(result.results || []);
   }
 
   async getDecryptedSecrets(environmentId: string): Promise<Record<string, string>> {
@@ -102,24 +77,12 @@ export class EnvironmentSecretsStore {
       .bind(environmentId)
       .all<{ key: string; encrypted_value: string }>();
 
-    const rows = result.results || [];
-    const decryptedEntries = await Promise.all(
-      rows.map(async (row) => {
-        try {
-          const decryptedValue = await decryptToken(row.encrypted_value, this.encryptionKey);
-          return [row.key, decryptedValue] as const;
-        } catch (e) {
-          log.error("Failed to decrypt secret", {
-            environment_id: environmentId,
-            key: row.key,
-            error: e instanceof Error ? e.message : String(e),
-          });
-          throw new Error(`Failed to decrypt secret '${row.key}'`);
-        }
-      })
-    );
-
-    return Object.fromEntries(decryptedEntries);
+    return decryptSecretRows({
+      rows: result.results || [],
+      encryptionKey: this.encryptionKey,
+      log,
+      logContext: { environment_id: environmentId },
+    });
   }
 
   async deleteSecret(environmentId: string, key: string): Promise<boolean> {
@@ -145,7 +108,7 @@ export class EnvironmentSecretsStore {
     environmentId: string,
     sourceRepoId: number,
     keys?: string[]
-  ): Promise<{ created: number; updated: number; keys: string[] }> {
+  ): Promise<SecretsWriteResult> {
     let query = "SELECT key, encrypted_value FROM repo_secrets WHERE repo_id = ?";
     const binds: unknown[] = [sourceRepoId];
 
@@ -165,13 +128,11 @@ export class EnvironmentSecretsStore {
     if (rows.length === 0) return { created: 0, updated: 0, keys: [] };
 
     const existingKeySet = await this.existingKeys(environmentId);
-    const netNew = rows.filter((r) => !existingKeySet.has(r.key)).length;
-    if (existingKeySet.size + netNew > MAX_SECRETS_PER_SCOPE) {
-      throw new SecretsValidationError(
-        `Environment would exceed ${MAX_SECRETS_PER_SCOPE} secrets limit ` +
-          `(current: ${existingKeySet.size}, adding: ${netNew})`
-      );
-    }
+    assertScopeKeyCapacity(
+      "Environment",
+      existingKeySet,
+      rows.map((r) => r.key)
+    );
 
     const now = Date.now();
     let created = 0;

--- a/packages/control-plane/src/db/environment-secrets.ts
+++ b/packages/control-plane/src/db/environment-secrets.ts
@@ -13,6 +13,7 @@
 
 import { createLogger } from "../logger";
 import {
+  SecretDecryptionError,
   assertScopeKeyCapacity,
   decryptSecretRows,
   encryptSecretEntries,
@@ -77,12 +78,19 @@ export class EnvironmentSecretsStore {
       .bind(environmentId)
       .all<{ key: string; encrypted_value: string }>();
 
-    return decryptSecretRows({
-      rows: result.results || [],
-      encryptionKey: this.encryptionKey,
-      log,
-      logContext: { environment_id: environmentId },
-    });
+    try {
+      return await decryptSecretRows(result.results || [], this.encryptionKey);
+    } catch (e) {
+      if (e instanceof SecretDecryptionError) {
+        log.error("Failed to decrypt secret", {
+          environment_id: environmentId,
+          key: e.key,
+          error: e.cause instanceof Error ? e.cause.message : String(e.cause),
+        });
+        throw new Error(`Failed to decrypt secret '${e.key}'`);
+      }
+      throw e;
+    }
   }
 
   async deleteSecret(environmentId: string, key: string): Promise<boolean> {

--- a/packages/control-plane/src/db/global-secrets.test.ts
+++ b/packages/control-plane/src/db/global-secrets.test.ts
@@ -140,6 +140,12 @@ describe("GlobalSecretsStore", () => {
     expect(secrets).toEqual({ FOO: "two" });
   });
 
+  it("rejects keys that collide after normalization", async () => {
+    await expect(store.setSecrets({ foo: "one", FOO: "two" })).rejects.toThrow(
+      "Duplicate secret key 'FOO' after normalization"
+    );
+  });
+
   it("rejects reserved keys", async () => {
     await expect(store.setSecrets({ PATH: "nope" })).rejects.toBeInstanceOf(SecretsValidationError);
   });

--- a/packages/control-plane/src/db/global-secrets.ts
+++ b/packages/control-plane/src/db/global-secrets.ts
@@ -1,5 +1,6 @@
 import { createLogger } from "../logger";
 import {
+  SecretDecryptionError,
   assertScopeKeyCapacity,
   decryptSecretRows,
   encryptSecretEntries,
@@ -68,12 +69,18 @@ export class GlobalSecretsStore {
       .prepare("SELECT key, encrypted_value FROM global_secrets")
       .all<{ key: string; encrypted_value: string }>();
 
-    return decryptSecretRows({
-      rows: result.results || [],
-      encryptionKey: this.encryptionKey,
-      log,
-      noun: "global secret",
-    });
+    try {
+      return await decryptSecretRows(result.results || [], this.encryptionKey);
+    } catch (e) {
+      if (e instanceof SecretDecryptionError) {
+        log.error("Failed to decrypt global secret", {
+          key: e.key,
+          error: e.cause instanceof Error ? e.cause.message : String(e.cause),
+        });
+        throw new Error(`Failed to decrypt global secret '${e.key}'`);
+      }
+      throw e;
+    }
   }
 
   async deleteSecret(key: string): Promise<boolean> {

--- a/packages/control-plane/src/db/global-secrets.ts
+++ b/packages/control-plane/src/db/global-secrets.ts
@@ -1,13 +1,13 @@
-import { encryptToken, decryptToken } from "../auth/crypto";
 import { createLogger } from "../logger";
 import {
-  MAX_TOTAL_VALUE_SIZE,
-  MAX_SECRETS_PER_SCOPE,
-  SecretsValidationError,
-  normalizeKey,
-  validateKey,
-  validateValue,
-} from "./secrets-validation";
+  assertScopeKeyCapacity,
+  decryptSecretRows,
+  encryptSecretEntries,
+  prepareSecretsForWrite,
+  toSecretMetadata,
+} from "./scoped-secrets";
+import type { SecretsWriteResult } from "./scoped-secrets";
+import { normalizeKey } from "./secrets-validation";
 import type { SecretMetadata } from "./secrets-validation";
 
 const log = createLogger("global-secrets");
@@ -18,24 +18,9 @@ export class GlobalSecretsStore {
     private readonly encryptionKey: string
   ) {}
 
-  async setSecrets(
-    secrets: Record<string, string>
-  ): Promise<{ created: number; updated: number; keys: string[] }> {
+  async setSecrets(secrets: Record<string, string>): Promise<SecretsWriteResult> {
     const now = Date.now();
-
-    const normalized: Record<string, string> = {};
-    let totalValueBytes = 0;
-    for (const [rawKey, value] of Object.entries(secrets)) {
-      const key = normalizeKey(rawKey);
-      validateKey(key);
-      validateValue(value);
-      totalValueBytes += new TextEncoder().encode(value).length;
-      normalized[key] = value;
-    }
-
-    if (totalValueBytes > MAX_TOTAL_VALUE_SIZE) {
-      throw new SecretsValidationError(`Total secret size exceeds ${MAX_TOTAL_VALUE_SIZE} bytes`);
-    }
+    const normalized = prepareSecretsForWrite(secrets);
 
     const existingKeys = await this.db
       .prepare("SELECT key FROM global_secrets")
@@ -43,36 +28,25 @@ export class GlobalSecretsStore {
     const existingKeySet = new Set((existingKeys.results || []).map((r) => r.key));
 
     const incomingKeys = Object.keys(normalized);
-    const netNew = incomingKeys.filter((k) => !existingKeySet.has(k)).length;
-    if (existingKeySet.size + netNew > MAX_SECRETS_PER_SCOPE) {
-      throw new SecretsValidationError(
-        `Global secrets would exceed ${MAX_SECRETS_PER_SCOPE} secrets limit ` +
-          `(current: ${existingKeySet.size}, adding: ${netNew})`
-      );
-    }
+    assertScopeKeyCapacity("Global secrets", existingKeySet, incomingKeys);
 
-    let created = 0;
-    let updated = 0;
+    const { entries, created, updated } = await encryptSecretEntries(
+      normalized,
+      existingKeySet,
+      this.encryptionKey
+    );
 
-    const statements: D1PreparedStatement[] = [];
-    for (const [key, value] of Object.entries(normalized)) {
-      const encrypted = await encryptToken(value, this.encryptionKey);
-      const isNew = !existingKeySet.has(key);
-      if (isNew) created++;
-      else updated++;
-
-      statements.push(
-        this.db
-          .prepare(
-            `INSERT INTO global_secrets (key, encrypted_value, created_at, updated_at)
-             VALUES (?, ?, ?, ?)
-             ON CONFLICT(key) DO UPDATE SET
-               encrypted_value = excluded.encrypted_value,
-               updated_at = excluded.updated_at`
-          )
-          .bind(key, encrypted, now, now)
-      );
-    }
+    const statements = entries.map((entry) =>
+      this.db
+        .prepare(
+          `INSERT INTO global_secrets (key, encrypted_value, created_at, updated_at)
+           VALUES (?, ?, ?, ?)
+           ON CONFLICT(key) DO UPDATE SET
+             encrypted_value = excluded.encrypted_value,
+             updated_at = excluded.updated_at`
+        )
+        .bind(entry.key, entry.encryptedValue, now, now)
+    );
 
     if (statements.length > 0) {
       await this.db.batch(statements);
@@ -86,11 +60,7 @@ export class GlobalSecretsStore {
       .prepare("SELECT key, created_at, updated_at FROM global_secrets ORDER BY key")
       .all<{ key: string; created_at: number; updated_at: number }>();
 
-    return (result.results || []).map((row) => ({
-      key: row.key,
-      createdAt: row.created_at,
-      updatedAt: row.updated_at,
-    }));
+    return toSecretMetadata(result.results || []);
   }
 
   async getDecryptedSecrets(): Promise<Record<string, string>> {
@@ -98,23 +68,12 @@ export class GlobalSecretsStore {
       .prepare("SELECT key, encrypted_value FROM global_secrets")
       .all<{ key: string; encrypted_value: string }>();
 
-    const rows = result.results || [];
-    const decryptedEntries = await Promise.all(
-      rows.map(async (row) => {
-        try {
-          const decryptedValue = await decryptToken(row.encrypted_value, this.encryptionKey);
-          return [row.key, decryptedValue] as const;
-        } catch (e) {
-          log.error("Failed to decrypt global secret", {
-            key: row.key,
-            error: e instanceof Error ? e.message : String(e),
-          });
-          throw new Error(`Failed to decrypt global secret '${row.key}'`);
-        }
-      })
-    );
-
-    return Object.fromEntries(decryptedEntries);
+    return decryptSecretRows({
+      rows: result.results || [],
+      encryptionKey: this.encryptionKey,
+      log,
+      noun: "global secret",
+    });
   }
 
   async deleteSecret(key: string): Promise<boolean> {

--- a/packages/control-plane/src/db/repo-secrets.ts
+++ b/packages/control-plane/src/db/repo-secrets.ts
@@ -1,13 +1,13 @@
-import { encryptToken, decryptToken } from "../auth/crypto";
 import { createLogger } from "../logger";
 import {
-  MAX_TOTAL_VALUE_SIZE,
-  MAX_SECRETS_PER_SCOPE,
-  SecretsValidationError,
-  normalizeKey,
-  validateKey,
-  validateValue,
-} from "./secrets-validation";
+  assertScopeKeyCapacity,
+  decryptSecretRows,
+  encryptSecretEntries,
+  prepareSecretsForWrite,
+  toSecretMetadata,
+} from "./scoped-secrets";
+import type { SecretsWriteResult } from "./scoped-secrets";
+import { normalizeKey } from "./secrets-validation";
 import type { SecretMetadata } from "./secrets-validation";
 
 export type { SecretMetadata } from "./secrets-validation";
@@ -25,24 +25,11 @@ export class RepoSecretsStore {
     repoOwner: string,
     repoName: string,
     secrets: Record<string, string>
-  ): Promise<{ created: number; updated: number; keys: string[] }> {
+  ): Promise<SecretsWriteResult> {
     const owner = repoOwner.toLowerCase();
     const name = repoName.toLowerCase();
     const now = Date.now();
-
-    const normalized: Record<string, string> = {};
-    let totalValueBytes = 0;
-    for (const [rawKey, value] of Object.entries(secrets)) {
-      const key = normalizeKey(rawKey);
-      validateKey(key);
-      validateValue(value);
-      totalValueBytes += new TextEncoder().encode(value).length;
-      normalized[key] = value;
-    }
-
-    if (totalValueBytes > MAX_TOTAL_VALUE_SIZE) {
-      throw new SecretsValidationError(`Total secret size exceeds ${MAX_TOTAL_VALUE_SIZE} bytes`);
-    }
+    const normalized = prepareSecretsForWrite(secrets);
 
     const existingKeys = await this.db
       .prepare("SELECT key FROM repo_secrets WHERE repo_id = ?")
@@ -51,39 +38,28 @@ export class RepoSecretsStore {
     const existingKeySet = new Set((existingKeys.results || []).map((r) => r.key));
 
     const incomingKeys = Object.keys(normalized);
-    const netNew = incomingKeys.filter((k) => !existingKeySet.has(k)).length;
-    if (existingKeySet.size + netNew > MAX_SECRETS_PER_SCOPE) {
-      throw new SecretsValidationError(
-        `Repository would exceed ${MAX_SECRETS_PER_SCOPE} secrets limit ` +
-          `(current: ${existingKeySet.size}, adding: ${netNew})`
-      );
-    }
+    assertScopeKeyCapacity("Repository", existingKeySet, incomingKeys);
 
-    let created = 0;
-    let updated = 0;
+    const { entries, created, updated } = await encryptSecretEntries(
+      normalized,
+      existingKeySet,
+      this.encryptionKey
+    );
 
-    const statements: D1PreparedStatement[] = [];
-    for (const [key, value] of Object.entries(normalized)) {
-      const encrypted = await encryptToken(value, this.encryptionKey);
-      const isNew = !existingKeySet.has(key);
-      if (isNew) created++;
-      else updated++;
-
-      statements.push(
-        this.db
-          .prepare(
-            `INSERT INTO repo_secrets
-             (repo_id, repo_owner, repo_name, key, encrypted_value, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?)
-             ON CONFLICT(repo_id, key) DO UPDATE SET
-               repo_owner = excluded.repo_owner,
-               repo_name = excluded.repo_name,
-               encrypted_value = excluded.encrypted_value,
-               updated_at = excluded.updated_at`
-          )
-          .bind(repoId, owner, name, key, encrypted, now, now)
-      );
-    }
+    const statements = entries.map((entry) =>
+      this.db
+        .prepare(
+          `INSERT INTO repo_secrets
+           (repo_id, repo_owner, repo_name, key, encrypted_value, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(repo_id, key) DO UPDATE SET
+             repo_owner = excluded.repo_owner,
+             repo_name = excluded.repo_name,
+             encrypted_value = excluded.encrypted_value,
+             updated_at = excluded.updated_at`
+        )
+        .bind(repoId, owner, name, entry.key, entry.encryptedValue, now, now)
+    );
 
     if (statements.length > 0) {
       await this.db.batch(statements);
@@ -100,11 +76,7 @@ export class RepoSecretsStore {
       .bind(repoId)
       .all<{ key: string; created_at: number; updated_at: number }>();
 
-    return (result.results || []).map((row) => ({
-      key: row.key,
-      createdAt: row.created_at,
-      updatedAt: row.updated_at,
-    }));
+    return toSecretMetadata(result.results || []);
   }
 
   async getDecryptedSecrets(repoId: number): Promise<Record<string, string>> {
@@ -113,24 +85,12 @@ export class RepoSecretsStore {
       .bind(repoId)
       .all<{ key: string; encrypted_value: string }>();
 
-    const rows = result.results || [];
-    const decryptedEntries = await Promise.all(
-      rows.map(async (row) => {
-        try {
-          const decryptedValue = await decryptToken(row.encrypted_value, this.encryptionKey);
-          return [row.key, decryptedValue] as const;
-        } catch (e) {
-          log.error("Failed to decrypt secret", {
-            repo_id: repoId,
-            key: row.key,
-            error: e instanceof Error ? e.message : String(e),
-          });
-          throw new Error(`Failed to decrypt secret '${row.key}'`);
-        }
-      })
-    );
-
-    return Object.fromEntries(decryptedEntries);
+    return decryptSecretRows({
+      rows: result.results || [],
+      encryptionKey: this.encryptionKey,
+      log,
+      logContext: { repo_id: repoId },
+    });
   }
 
   async deleteSecret(repoId: number, key: string): Promise<boolean> {

--- a/packages/control-plane/src/db/repo-secrets.ts
+++ b/packages/control-plane/src/db/repo-secrets.ts
@@ -1,5 +1,6 @@
 import { createLogger } from "../logger";
 import {
+  SecretDecryptionError,
   assertScopeKeyCapacity,
   decryptSecretRows,
   encryptSecretEntries,
@@ -85,12 +86,19 @@ export class RepoSecretsStore {
       .bind(repoId)
       .all<{ key: string; encrypted_value: string }>();
 
-    return decryptSecretRows({
-      rows: result.results || [],
-      encryptionKey: this.encryptionKey,
-      log,
-      logContext: { repo_id: repoId },
-    });
+    try {
+      return await decryptSecretRows(result.results || [], this.encryptionKey);
+    } catch (e) {
+      if (e instanceof SecretDecryptionError) {
+        log.error("Failed to decrypt secret", {
+          repo_id: repoId,
+          key: e.key,
+          error: e.cause instanceof Error ? e.cause.message : String(e.cause),
+        });
+        throw new Error(`Failed to decrypt secret '${e.key}'`);
+      }
+      throw e;
+    }
   }
 
   async deleteSecret(repoId: number, key: string): Promise<boolean> {

--- a/packages/control-plane/src/db/scoped-secrets.ts
+++ b/packages/control-plane/src/db/scoped-secrets.ts
@@ -28,6 +28,8 @@ export interface SecretsWriteResult {
 /**
  * Normalize keys, validate every entry, and enforce the combined-value byte
  * cap. Returns the normalized key → plaintext record ready for encryption.
+ * Rejects inputs where two raw keys normalize to the same key (e.g. `foo`
+ * and `FOO`) rather than letting the last one silently win.
  */
 export function prepareSecretsForWrite(secrets: Record<string, string>): Record<string, string> {
   const normalized: Record<string, string> = {};
@@ -36,6 +38,9 @@ export function prepareSecretsForWrite(secrets: Record<string, string>): Record<
     const key = normalizeKey(rawKey);
     validateKey(key);
     validateValue(value);
+    if (key in normalized) {
+      throw new SecretsValidationError(`Duplicate secret key '${key}' after normalization`);
+    }
     totalValueBytes += new TextEncoder().encode(value).length;
     normalized[key] = value;
   }

--- a/packages/control-plane/src/db/scoped-secrets.ts
+++ b/packages/control-plane/src/db/scoped-secrets.ts
@@ -1,0 +1,139 @@
+/**
+ * Shared plumbing for the scoped-secrets D1 stores (global-secrets,
+ * repo-secrets, environment-secrets). This module owns only the
+ * scope-independent pieces — write validation, the per-scope key cap,
+ * value encryption bookkeeping, and row codecs. Each store keeps its own
+ * table-specific SQL and public API; none of the stored/encrypted formats
+ * change (all scopes encrypt with REPO_SECRETS_ENCRYPTION_KEY, as before).
+ */
+
+import { encryptToken, decryptToken } from "../auth/crypto";
+import {
+  MAX_TOTAL_VALUE_SIZE,
+  MAX_SECRETS_PER_SCOPE,
+  SecretsValidationError,
+  normalizeKey,
+  validateKey,
+  validateValue,
+} from "./secrets-validation";
+import type { SecretMetadata } from "./secrets-validation";
+
+/** Result shape shared by every scoped-secrets write (set/import). */
+export interface SecretsWriteResult {
+  created: number;
+  updated: number;
+  keys: string[];
+}
+
+/**
+ * Normalize keys, validate every entry, and enforce the combined-value byte
+ * cap. Returns the normalized key → plaintext record ready for encryption.
+ */
+export function prepareSecretsForWrite(secrets: Record<string, string>): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  let totalValueBytes = 0;
+  for (const [rawKey, value] of Object.entries(secrets)) {
+    const key = normalizeKey(rawKey);
+    validateKey(key);
+    validateValue(value);
+    totalValueBytes += new TextEncoder().encode(value).length;
+    normalized[key] = value;
+  }
+
+  if (totalValueBytes > MAX_TOTAL_VALUE_SIZE) {
+    throw new SecretsValidationError(`Total secret size exceeds ${MAX_TOTAL_VALUE_SIZE} bytes`);
+  }
+
+  return normalized;
+}
+
+/**
+ * Enforce the per-scope key-count cap for a pending write. `scopeSubject`
+ * opens the error message ("Global secrets", "Repository", "Environment").
+ */
+export function assertScopeKeyCapacity(
+  scopeSubject: string,
+  existingKeySet: ReadonlySet<string>,
+  incomingKeys: readonly string[]
+): void {
+  const netNew = incomingKeys.filter((k) => !existingKeySet.has(k)).length;
+  if (existingKeySet.size + netNew > MAX_SECRETS_PER_SCOPE) {
+    throw new SecretsValidationError(
+      `${scopeSubject} would exceed ${MAX_SECRETS_PER_SCOPE} secrets limit ` +
+        `(current: ${existingKeySet.size}, adding: ${netNew})`
+    );
+  }
+}
+
+/**
+ * Encrypt each value and tally created vs updated against the scope's
+ * existing key set. The store binds the returned entries into its own
+ * table-specific upsert statements.
+ */
+export async function encryptSecretEntries(
+  normalized: Record<string, string>,
+  existingKeySet: ReadonlySet<string>,
+  encryptionKey: string
+): Promise<{
+  entries: Array<{ key: string; encryptedValue: string }>;
+  created: number;
+  updated: number;
+}> {
+  const entries: Array<{ key: string; encryptedValue: string }> = [];
+  let created = 0;
+  let updated = 0;
+  for (const [key, value] of Object.entries(normalized)) {
+    if (existingKeySet.has(key)) updated++;
+    else created++;
+    entries.push({ key, encryptedValue: await encryptToken(value, encryptionKey) });
+  }
+  return { entries, created, updated };
+}
+
+/** Map `key, created_at, updated_at` rows to the wire metadata shape. */
+export function toSecretMetadata(
+  rows: Array<{ key: string; created_at: number; updated_at: number }>
+): SecretMetadata[] {
+  return rows.map((row) => ({
+    key: row.key,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }));
+}
+
+interface SecretsDecryptLog {
+  error(message: string, data?: Record<string, unknown>): void;
+}
+
+/**
+ * Decrypt `key, encrypted_value` rows into a key → plaintext record. On
+ * failure, logs (never the value) and throws. `noun` names the scope in the
+ * message ("secret" by default, "global secret" for the global scope);
+ * `logContext` adds scope identifiers such as repo_id or environment_id.
+ */
+export async function decryptSecretRows(params: {
+  rows: Array<{ key: string; encrypted_value: string }>;
+  encryptionKey: string;
+  log: SecretsDecryptLog;
+  noun?: string;
+  logContext?: Record<string, unknown>;
+}): Promise<Record<string, string>> {
+  const { rows, encryptionKey, log, noun = "secret", logContext = {} } = params;
+  const decryptedEntries = await Promise.all(
+    rows.map(async (row) => {
+      try {
+        const decryptedValue = await decryptToken(row.encrypted_value, encryptionKey);
+        return [row.key, decryptedValue] as const;
+      } catch (e) {
+        log.error(`Failed to decrypt ${noun}`, {
+          ...logContext,
+          key: row.key,
+          error: e instanceof Error ? e.message : String(e),
+        });
+        throw new Error(`Failed to decrypt ${noun} '${row.key}'`);
+      }
+    })
+  );
+
+  return Object.fromEntries(decryptedEntries);
+}

--- a/packages/control-plane/src/db/scoped-secrets.ts
+++ b/packages/control-plane/src/db/scoped-secrets.ts
@@ -106,36 +106,38 @@ export function toSecretMetadata(
   }));
 }
 
-interface SecretsDecryptLog {
-  error(message: string, data?: Record<string, unknown>): void;
+/**
+ * Thrown by `decryptSecretRows` when a stored value fails to decrypt. Carries
+ * the failing key (never the plaintext or ciphertext) and the underlying
+ * decryption error as `cause`, so each store can log with its own logger and
+ * scope fields before surfacing its user-facing error.
+ */
+export class SecretDecryptionError extends Error {
+  constructor(
+    readonly key: string,
+    options?: { cause?: unknown }
+  ) {
+    super(`Failed to decrypt secret '${key}'`, options);
+    this.name = "SecretDecryptionError";
+  }
 }
 
 /**
- * Decrypt `key, encrypted_value` rows into a key → plaintext record. On
- * failure, logs (never the value) and throws. `noun` names the scope in the
- * message ("secret" by default, "global secret" for the global scope);
- * `logContext` adds scope identifiers such as repo_id or environment_id.
+ * Decrypt `key, encrypted_value` rows in parallel into a key → plaintext
+ * record. Pure crypto: on failure, throws `SecretDecryptionError`; logging is
+ * the caller's concern.
  */
-export async function decryptSecretRows(params: {
-  rows: Array<{ key: string; encrypted_value: string }>;
-  encryptionKey: string;
-  log: SecretsDecryptLog;
-  noun?: string;
-  logContext?: Record<string, unknown>;
-}): Promise<Record<string, string>> {
-  const { rows, encryptionKey, log, noun = "secret", logContext = {} } = params;
+export async function decryptSecretRows(
+  rows: Array<{ key: string; encrypted_value: string }>,
+  encryptionKey: string
+): Promise<Record<string, string>> {
   const decryptedEntries = await Promise.all(
     rows.map(async (row) => {
       try {
         const decryptedValue = await decryptToken(row.encrypted_value, encryptionKey);
         return [row.key, decryptedValue] as const;
       } catch (e) {
-        log.error(`Failed to decrypt ${noun}`, {
-          ...logContext,
-          key: row.key,
-          error: e instanceof Error ? e.message : String(e),
-        });
-        throw new Error(`Failed to decrypt ${noun} '${row.key}'`);
+        throw new SecretDecryptionError(row.key, { cause: e });
       }
     })
   );


### PR DESCRIPTION
## Summary

Extracts the duplicated plumbing shared by the three scoped-secrets D1 stores (`global-secrets.ts`, `repo-secrets.ts`, `environment-secrets.ts`) into a new `src/db/scoped-secrets.ts` module. Each store keeps its class, public API (method names and signatures unchanged — no caller edits anywhere), and its own table-specific SQL; only the scope-independent pieces moved:

- `prepareSecretsForWrite` — key normalization + per-entry validation + combined-value byte cap (was copy-pasted 3x)
- `assertScopeKeyCapacity` — the per-scope `MAX_SECRETS_PER_SCOPE` check, parameterized only by the scope subject in the error message; used 4x (incl. `importFromRepo`)
- `encryptSecretEntries` — encrypt-and-tally created/updated loop (3x)
- `toSecretMetadata` — `created_at`/`updated_at` row → wire metadata mapping (3x)
- `decryptSecretRows` — parallel decrypt loop, pure crypto (3x). Reworked in 6954ef44: throws a typed `SecretDecryptionError` carrying only the failing key; each store logs at its own call site with its own logger and scope fields (no injected log sink/wording params). Log output and thrown messages unchanged.

**Deliberately NOT unified**: the upsert/list/delete SQL (different tables, key columns, and conflict targets — keeping it inline per store keeps each query greppable), the store classes themselves, `EnvironmentSecretsStore.importFromRepo`'s ciphertext-verbatim copy, and all route handlers (untouched).

## Size

- `global-secrets.ts`: 128 → 87 lines
- `repo-secrets.ts`: 144 → 104 lines
- `environment-secrets.ts`: 214 → 175 lines
- new `scoped-secrets.ts`: 139 lines (mostly doc comments)
- Net across the three stores: −224 / +104; whole change is −85 net after the shared module.

## Behavior changes

**One deliberate change, added in review (423f43ad):** secret writes where two raw keys collide after normalization (e.g. `foo` + `FOO`) are now rejected with a `SecretsValidationError` (→ 400) instead of silently letting the last one win while counting both values toward the total-size cap. The silent overwrite was pre-existing on main; rejecting is strictly safer. Regression test added.

Everything else is behavior-preserving:

- No D1 schema changes, no migrations, SQL statements byte-identical to before.
- Stored/encrypted format unchanged; all scopes still encrypt with `REPO_SECRETS_ENCRYPTION_KEY` via the same `encryptToken`/`decryptToken` — existing rows remain readable.
- Error messages and log fields preserved exactly (cap errors, `Failed to decrypt …`).
- All existing tests pass unmodified: control-plane unit 1716/1716, integration 525/525; `npm run typecheck` and `npm run lint` clean.

## Note for reviewers

`src/session/launch-unit-secrets.ts` (the secrets fold consumer) is intentionally untouched: a parallel PR is renaming it to session-target-secrets, and this refactor required no changes to it anyway since store APIs are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized secret validation, encryption/decryption, and metadata handling across global, repository, and environment secrets.
  * Secret writes now return consistent `created`, `updated`, and `keys` results.
  * Secret key capacity limits and input validation are enforced consistently across scopes.
  * Decryption failures now surface consistent error messages/behavior.
* **Tests**
  * Added coverage to ensure duplicate keys after normalization (e.g., `foo`/`FOO`) are rejected with a clear message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
