### PR TITLE
refactor(web): converge automation form on session-target model

### DIFF
--- a/packages/web/src/components/automations/automation-form.test.tsx
+++ b/packages/web/src/components/automations/automation-form.test.tsx
@@ -269,6 +269,87 @@ describe("environment binding", () => {
     });
   });
 
+  it("replaces a repository with an environment in single-select mode", () => {
+    environmentsValue = [fullstackEnvironment];
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <AutomationForm
+        mode="edit"
+        submitting={false}
+        onSubmit={onSubmit}
+        initialValues={{ ...scheduleBase, repositories: singleRepository }}
+      />
+    );
+
+    openRepositoryPicker();
+    fireEvent.click(screen.getByRole("button", { name: /Fullstack/ }));
+    fireEvent.submit(container.querySelector("form")!);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({
+      environmentIds: ["env_1"],
+      repositories: [],
+    });
+  });
+
+  it("hydrates a mixed repository + environment selection in edit mode", () => {
+    environmentsValue = [fullstackEnvironment];
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <AutomationForm
+        mode="edit"
+        submitting={false}
+        onSubmit={onSubmit}
+        initialValues={{
+          ...scheduleBase,
+          repositories: singleRepository,
+          environmentIds: ["env_1"],
+        }}
+      />
+    );
+
+    expect(screen.getByText("1 repository + 1 environment")).toBeInTheDocument();
+
+    fireEvent.submit(container.querySelector("form")!);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({
+      environmentIds: ["env_1"],
+      repositories: [
+        { repoOwner: "open-inspect", repoName: "background-agents", baseBranch: "main" },
+      ],
+    });
+  });
+
+  it("keeps the repository when collapsing a mixed selection to single-select", () => {
+    environmentsValue = [fullstackEnvironment];
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <AutomationForm
+        mode="create"
+        submitting={false}
+        onSubmit={onSubmit}
+        initialValues={scheduleBase}
+      />
+    );
+
+    openRepositoryPicker();
+    fireEvent.click(screen.getByRole("button", { name: "Select Multiple" }));
+    // Environment first: the collapse still prefers the repository target.
+    fireEvent.click(screen.getByLabelText(/Fullstack/));
+    fireEvent.click(screen.getByLabelText("open-inspect/background-agents"));
+    fireEvent.click(screen.getByRole("button", { name: "Select One" }));
+    fireEvent.submit(container.querySelector("form")!);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit.mock.calls[0][0]).toMatchObject({
+      environmentIds: [],
+      repositories: [
+        { repoOwner: "open-inspect", repoName: "background-agents", baseBranch: "main" },
+      ],
+    });
+  });
+
   it("fans out repositories and environments together in multi-select mode", () => {
     environmentsValue = [fullstackEnvironment];
     const onSubmit = vi.fn();

--- a/packages/web/src/components/automations/automation-form.tsx
+++ b/packages/web/src/components/automations/automation-form.tsx
@@ -48,6 +48,7 @@ import { TriggerTypeSelector } from "./trigger-type-selector";
 import { ConditionBuilder } from "./condition-builder";
 import { cn } from "@/lib/utils";
 import { NO_REPOSITORY_LABEL, formatRepositoriesLabel } from "@/lib/repo-label";
+import { parseRepoFullName, type SessionTarget } from "@/lib/session-target";
 
 const COMMON_TIMEZONES = [
   "UTC",
@@ -80,6 +81,26 @@ function requiresRepositoryContext(triggerType: AutomationTriggerType): boolean 
 /** Selection key for a repository: the lowercase full name, as the API stores it. */
 function repositoryKey(repoOwner: string, repoName: string): string {
   return `${repoOwner}/${repoName}`.toLowerCase();
+}
+
+/**
+ * One entry of the automation's fan-out selection, reusing the shared
+ * session-target model (lib/session-target.ts). An automation targets an
+ * ordered list of launchable session targets: each `repo` entry runs in its
+ * own session and each `environment` entry opens one workspace session. The
+ * empty list is the repo-less selection ("No repository"). Single-select mode
+ * replaces the whole list, so repo/environment mutual exclusivity there is
+ * structural rather than enforced by cross-clearing effects.
+ */
+type AutomationSessionTarget = Extract<SessionTarget, { kind: "repo" | "environment" }>;
+
+/**
+ * Leaving multi-select keeps one target: the first repository, or the first
+ * environment when only environments are selected.
+ */
+function collapseToSingleTarget(targets: AutomationSessionTarget[]): AutomationSessionTarget[] {
+  const firstRepository = targets.find((target) => target.kind === "repo");
+  return firstRepository ? [firstRepository] : targets.slice(0, 1);
 }
 
 const toOption = (tz: string) => ({ value: tz, label: tz.replace(/_/g, " ") });
@@ -142,14 +163,19 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
   );
 
   const [name, setName] = useState(initialValues?.name ?? "");
-  const [selectedEnvironmentIds, setSelectedEnvironmentIds] = useState<string[]>(
-    () => initialValues?.environmentIds ?? []
-  );
-  const [selectedRepos, setSelectedRepos] = useState<string[]>(() =>
-    initialRepositories.map((repository) =>
-      repositoryKey(repository.repoOwner, repository.repoName)
-    )
-  );
+  // The fan-out selection as one ordered list of session targets; repositories
+  // and environments hydrate in selection order within each kind.
+  const [selectedTargets, setSelectedTargets] = useState<AutomationSessionTarget[]>(() => [
+    ...initialRepositories.map(
+      (repository): AutomationSessionTarget => ({
+        kind: "repo",
+        repoFullName: repositoryKey(repository.repoOwner, repository.repoName),
+      })
+    ),
+    ...(initialValues?.environmentIds ?? []).map(
+      (environmentId): AutomationSessionTarget => ({ kind: "environment", environmentId })
+    ),
+  ]);
   const [repoSelectionMode, setRepoSelectionMode] = useState<RepoSelectionMode>(() =>
     // Combined count: a lone-repo default here would let the single-select
     // collapse effect silently drop hydrated environment targets on edit.
@@ -159,13 +185,26 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
   );
   const [repoDropdownOpen, setRepoDropdownOpen] = useState(false);
   const [repoQuery, setRepoQuery] = useState("");
-  const selectedRepo = selectedRepos[0] ?? "";
-  const repoOwner = selectedRepo.split("/")[0] ?? "";
-  const repoName = selectedRepo.split("/")[1] ?? "";
-  const usesSingleRepository = selectedRepos.length === 1 && selectedEnvironmentIds.length === 0;
+  // Per-kind views of the selection, in target order. Payload fields and the
+  // render's selected-state checks derive from these.
+  const selectedRepoNames = useMemo(
+    () =>
+      selectedTargets.flatMap((target) => (target.kind === "repo" ? [target.repoFullName] : [])),
+    [selectedTargets]
+  );
+  const selectedEnvironmentIds = useMemo(
+    () =>
+      selectedTargets.flatMap((target) =>
+        target.kind === "environment" ? [target.environmentId] : []
+      ),
+    [selectedTargets]
+  );
+  const selectedRepoName = selectedRepoNames[0] ?? "";
+  const usesSingleRepository = selectedTargets.length === 1 && selectedTargets[0].kind === "repo";
+  const selectedRepository = usesSingleRepository ? parseRepoFullName(selectedRepoName) : null;
   const { branches, loading: loadingBranches } = useBranches(
-    usesSingleRepository ? repoOwner : "",
-    usesSingleRepository ? repoName : ""
+    selectedRepository?.owner ?? "",
+    selectedRepository?.name ?? ""
   );
   const [baseBranch, setBaseBranch] = useState(() =>
     initialRepositories.length === 1 ? (initialRepositories[0].baseBranch ?? "") : ""
@@ -243,11 +282,18 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
     [repos]
   );
 
-  const applySelectedRepos = useCallback(
-    (nextRepos: string[]) => {
-      setSelectedRepos(nextRepos);
-      if (nextRepos.length === 1) {
-        setBaseBranch(findRepo(nextRepos[0])?.defaultBranch ?? "");
+  // Branch state follows repository membership: exactly one selected
+  // repository pins baseBranch to its default, anything else clears it.
+  // Environment-only mutations bypass this (setSelectedTargets directly) so a
+  // branch pick survives adding and removing environments around its repo.
+  const applyTargets = useCallback(
+    (nextTargets: AutomationSessionTarget[]) => {
+      setSelectedTargets(nextTargets);
+      const nextRepoNames = nextTargets.flatMap((target) =>
+        target.kind === "repo" ? [target.repoFullName] : []
+      );
+      if (nextRepoNames.length === 1) {
+        setBaseBranch(findRepo(nextRepoNames[0])?.defaultBranch ?? "");
       } else {
         setBaseBranch("");
       }
@@ -261,87 +307,87 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
     }
   }, [multiRepoAllowed, repoSelectionMode]);
 
+  // Repo-scoped triggers stay bound to the webhook's repository, so any
+  // environment targets (e.g. hydrated before a trigger-type change) drop out.
   useEffect(() => {
-    if (repositoryRequired && selectedEnvironmentIds.length > 0) {
-      setSelectedEnvironmentIds([]);
-    }
-  }, [repositoryRequired, selectedEnvironmentIds]);
+    if (!repositoryRequired) return;
+    if (!selectedTargets.some((target) => target.kind === "environment")) return;
+    setSelectedTargets(selectedTargets.filter((target) => target.kind === "repo"));
+  }, [repositoryRequired, selectedTargets]);
 
-  // Collapsing to single-select keeps one target: the first repository, or the
-  // first environment when only environments are selected.
   useEffect(() => {
-    if (multipleSelectionEnabled || selectedRepos.length + selectedEnvironmentIds.length <= 1) {
-      return;
-    }
-    if (selectedRepos.length > 0) {
-      applySelectedRepos([selectedRepos[0]]);
-      setSelectedEnvironmentIds([]);
-    } else {
-      setSelectedEnvironmentIds([selectedEnvironmentIds[0]]);
-    }
-  }, [applySelectedRepos, multipleSelectionEnabled, selectedRepos, selectedEnvironmentIds]);
+    if (multipleSelectionEnabled || selectedTargets.length <= 1) return;
+    applyTargets(collapseToSingleTarget(selectedTargets));
+  }, [applyTargets, multipleSelectionEnabled, selectedTargets]);
 
-  const targetCount = selectedRepos.length + selectedEnvironmentIds.length;
+  const targetCount = selectedTargets.length;
 
   const handleRepoToggle = useCallback(
     (repoFullName: string) => {
-      const key = repoFullName.toLowerCase();
+      const target: AutomationSessionTarget = {
+        kind: "repo",
+        repoFullName: repoFullName.toLowerCase(),
+      };
       if (!multipleSelectionEnabled) {
-        applySelectedRepos([key]);
-        setSelectedEnvironmentIds([]);
+        applyTargets([target]);
         setRepoDropdownOpen(false);
         return;
       }
 
-      const selected = selectedRepos.includes(key);
+      const selected = selectedRepoNames.includes(target.repoFullName);
       if (!selected && targetCount >= MAX_AUTOMATION_REPOSITORIES) return;
-      applySelectedRepos(
-        selected ? selectedRepos.filter((repo) => repo !== key) : [...selectedRepos, key]
+      applyTargets(
+        selected
+          ? selectedTargets.filter(
+              (entry) => !(entry.kind === "repo" && entry.repoFullName === target.repoFullName)
+            )
+          : [...selectedTargets, target]
       );
     },
-    [applySelectedRepos, multipleSelectionEnabled, selectedRepos, targetCount]
+    [applyTargets, multipleSelectionEnabled, selectedRepoNames, selectedTargets, targetCount]
   );
 
   const handleEnvironmentToggle = useCallback(
     (environmentId: string) => {
+      const target: AutomationSessionTarget = { kind: "environment", environmentId };
       if (!multipleSelectionEnabled) {
-        setSelectedEnvironmentIds([environmentId]);
-        applySelectedRepos([]);
+        applyTargets([target]);
         setRepoDropdownOpen(false);
         return;
       }
 
       const selected = selectedEnvironmentIds.includes(environmentId);
       if (!selected && targetCount >= MAX_AUTOMATION_REPOSITORIES) return;
-      setSelectedEnvironmentIds(
+      setSelectedTargets(
         selected
-          ? selectedEnvironmentIds.filter((id) => id !== environmentId)
-          : [...selectedEnvironmentIds, environmentId]
+          ? selectedTargets.filter(
+              (entry) => !(entry.kind === "environment" && entry.environmentId === environmentId)
+            )
+          : [...selectedTargets, target]
       );
     },
-    [applySelectedRepos, multipleSelectionEnabled, selectedEnvironmentIds, targetCount]
+    [applyTargets, multipleSelectionEnabled, selectedEnvironmentIds, selectedTargets, targetCount]
   );
 
   const handleNoRepository = useCallback(() => {
     if (repositoryRequired) return;
-    applySelectedRepos([]);
-    setSelectedEnvironmentIds([]);
+    applyTargets([]);
     setRepoDropdownOpen(false);
-  }, [applySelectedRepos, repositoryRequired]);
+  }, [applyTargets, repositoryRequired]);
 
   const handleRepoSelectionModeToggle = useCallback(() => {
     if (!multiRepoAllowed) return;
 
     if (repoSelectionMode === "multiple") {
       setRepoSelectionMode("single");
-      if (selectedRepos.length > 1) {
-        applySelectedRepos([selectedRepos[0]]);
+      if (selectedTargets.length > 1) {
+        applyTargets(collapseToSingleTarget(selectedTargets));
       }
       return;
     }
 
     setRepoSelectionMode("multiple");
-  }, [applySelectedRepos, multiRepoAllowed, repoSelectionMode, selectedRepos]);
+  }, [applyTargets, multiRepoAllowed, repoSelectionMode, selectedTargets]);
 
   useEffect(() => {
     if (!repoDropdownOpen) {
@@ -356,7 +402,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
     if (loadingModels) return;
     if (
       !name.trim() ||
-      (repositoryRequired && selectedRepos.length === 0) ||
+      (repositoryRequired && selectedRepoNames.length === 0) ||
       !instructions.trim() ||
       !isScheduleValid
     ) {
@@ -383,7 +429,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
       instructions: instructions.trim(),
       triggerType,
       // Always send the full selection — an empty list means repo-less.
-      repositories: selectedRepos.map((key) => {
+      repositories: selectedRepoNames.map((key) => {
         const [entryOwner = "", entryName = ""] = key.split("/");
         const entry: AutomationRepositoryInput = { repoOwner: entryOwner, repoName: entryName };
         if (usesSingleRepository) {
@@ -440,16 +486,16 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
     (loadingEnvironments ? "Loading..." : environmentId);
   const repositoryLabel = (() => {
     if (targetCount === 0) return NO_REPOSITORY_LABEL;
-    if (selectedRepos.length === 1 && selectedEnvironmentIds.length === 0) {
-      return findRepo(selectedRepo)?.fullName ?? selectedRepo;
+    if (selectedRepoNames.length === 1 && selectedEnvironmentIds.length === 0) {
+      return findRepo(selectedRepoName)?.fullName ?? selectedRepoName;
     }
-    if (selectedEnvironmentIds.length === 1 && selectedRepos.length === 0) {
+    if (selectedEnvironmentIds.length === 1 && selectedRepoNames.length === 0) {
       return environmentName(selectedEnvironmentIds[0]);
     }
     const parts: string[] = [];
-    if (selectedRepos.length > 0) {
+    if (selectedRepoNames.length > 0) {
       parts.push(
-        selectedRepos.length === 1 ? "1 repository" : `${selectedRepos.length} repositories`
+        selectedRepoNames.length === 1 ? "1 repository" : `${selectedRepoNames.length} repositories`
       );
     }
     if (selectedEnvironmentIds.length > 0) {
@@ -521,7 +567,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
               className="flex w-full items-center gap-2 rounded-sm border border-border bg-input px-3 py-2 text-sm text-foreground transition hover:border-foreground/20 focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
               aria-label="Repository selection"
             >
-              {selectedEnvironmentIds.length > 0 && selectedRepos.length === 0 ? (
+              {selectedEnvironmentIds.length > 0 && selectedRepoNames.length === 0 ? (
                 <BoxIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
               ) : (
                 <RepoIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
@@ -664,7 +710,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
                 </button>
               )}
               {filteredRepos.map((repo) => {
-                const checked = selectedRepos.includes(repo.fullName.toLowerCase());
+                const checked = selectedRepoNames.includes(repo.fullName.toLowerCase());
                 const disabled =
                   multipleSelectionEnabled &&
                   !checked &&
@@ -735,7 +781,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
             searchPlaceholder="Search branches..."
             filterFn={(option, query) => option.label.toLowerCase().includes(query)}
             dropdownWidth="w-56"
-            disabled={!selectedRepo || loadingBranches}
+            disabled={!selectedRepoName || loadingBranches}
             triggerClassName="flex w-full items-center gap-1.5 px-3 py-2 text-sm border border-border bg-input text-foreground hover:border-foreground/20 transition"
           >
             <BranchIcon className="w-3.5 h-3.5 text-muted-foreground" />
@@ -977,7 +1023,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
             submitting ||
             loadingModels ||
             !name.trim() ||
-            (repositoryRequired && selectedRepos.length === 0) ||
+            (repositoryRequired && selectedRepoNames.length === 0) ||
             !instructions.trim() ||
             !isScheduleValid ||
             !slackConditionsValid ||

--- a/packages/web/src/components/automations/automation-form.tsx
+++ b/packages/web/src/components/automations/automation-form.tsx
@@ -168,7 +168,6 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
     targetCount,
     usesSingleRepository,
     selectedRepository,
-    repositoryLabel,
     multipleSelectionEnabled,
     baseBranch,
     setBaseBranch,
@@ -183,8 +182,6 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
     multiRepoAllowed,
     repositoryRequired,
     repos,
-    environments,
-    loadingEnvironments,
   });
   // Branch options for the sole selected repository (the only branch-pickable shape).
   const { branches, loading: loadingBranches } = useBranches(
@@ -333,6 +330,38 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
     if (!query) return environments;
     return environments.filter((environment) => environment.name.toLowerCase().includes(query));
   }, [environments, repositoryRequired, repoQuery]);
+  const environmentName = (environmentId: string) =>
+    environments.find((environment) => environment.id === environmentId)?.name ??
+    (loadingEnvironments ? "Loading..." : environmentId);
+  // Trigger-button label for the current selection, in the repos list's
+  // display casing (the selection stores lowercase keys).
+  const repositoryLabel = (() => {
+    if (targetCount === 0) return NO_REPOSITORY_LABEL;
+    if (selectedRepoNames.length === 1 && selectedEnvironmentIds.length === 0) {
+      const selectedRepoName = selectedRepoNames[0];
+      return (
+        repos.find((repo) => repo.fullName.toLowerCase() === selectedRepoName)?.fullName ??
+        selectedRepoName
+      );
+    }
+    if (selectedEnvironmentIds.length === 1 && selectedRepoNames.length === 0) {
+      return environmentName(selectedEnvironmentIds[0]);
+    }
+    const parts: string[] = [];
+    if (selectedRepoNames.length > 0) {
+      parts.push(
+        selectedRepoNames.length === 1 ? "1 repository" : `${selectedRepoNames.length} repositories`
+      );
+    }
+    if (selectedEnvironmentIds.length > 0) {
+      parts.push(
+        selectedEnvironmentIds.length === 1
+          ? "1 environment"
+          : `${selectedEnvironmentIds.length} environments`
+      );
+    }
+    return parts.join(" + ");
+  })();
   const reasoningConfig = getReasoningConfig(resolvedModel);
 
   return (

--- a/packages/web/src/components/automations/automation-form.tsx
+++ b/packages/web/src/components/automations/automation-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo } from "react";
 import {
   DEFAULT_MODEL,
   getReasoningConfig,
@@ -46,9 +46,9 @@ import {
 import { CronPicker } from "./cron-picker";
 import { TriggerTypeSelector } from "./trigger-type-selector";
 import { ConditionBuilder } from "./condition-builder";
+import { useAutomationTargets } from "./use-automation-targets";
 import { cn } from "@/lib/utils";
 import { NO_REPOSITORY_LABEL, formatRepositoriesLabel } from "@/lib/repo-label";
-import { parseRepoFullName, type SessionTarget } from "@/lib/session-target";
 
 const COMMON_TIMEZONES = [
   "UTC",
@@ -72,35 +72,9 @@ const DEFAULT_REASONING_VALUE = "__default__";
 // packages/control-plane/src/routes/automations.ts.
 const INSTRUCTIONS_MAX_LENGTH = 15000;
 const INSTRUCTIONS_WARNING_THRESHOLD = Math.floor(INSTRUCTIONS_MAX_LENGTH * 0.9);
-type RepoSelectionMode = "single" | "multiple";
 
 function requiresRepositoryContext(triggerType: AutomationTriggerType): boolean {
   return triggerType === "github_event" || triggerType === "linear_event";
-}
-
-/** Selection key for a repository: the lowercase full name, as the API stores it. */
-function repositoryKey(repoOwner: string, repoName: string): string {
-  return `${repoOwner}/${repoName}`.toLowerCase();
-}
-
-/**
- * One entry of the automation's fan-out selection, reusing the shared
- * session-target model (lib/session-target.ts). An automation targets an
- * ordered list of launchable session targets: each `repo` entry runs in its
- * own session and each `environment` entry opens one workspace session. The
- * empty list is the repo-less selection ("No repository"). Single-select mode
- * replaces the whole list, so repo/environment mutual exclusivity there is
- * structural rather than enforced by cross-clearing effects.
- */
-type AutomationSessionTarget = Extract<SessionTarget, { kind: "repo" | "environment" }>;
-
-/**
- * Leaving multi-select keeps one target: the first repository, or the first
- * environment when only environments are selected.
- */
-function collapseToSingleTarget(targets: AutomationSessionTarget[]): AutomationSessionTarget[] {
-  const firstRepository = targets.find((target) => target.kind === "repo");
-  return firstRepository ? [firstRepository] : targets.slice(0, 1);
 }
 
 const toOption = (tz: string) => ({ value: tz, label: tz.replace(/_/g, " ") });
@@ -163,52 +137,8 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
   );
 
   const [name, setName] = useState(initialValues?.name ?? "");
-  // The fan-out selection as one ordered list of session targets; repositories
-  // and environments hydrate in selection order within each kind.
-  const [selectedTargets, setSelectedTargets] = useState<AutomationSessionTarget[]>(() => [
-    ...initialRepositories.map(
-      (repository): AutomationSessionTarget => ({
-        kind: "repo",
-        repoFullName: repositoryKey(repository.repoOwner, repository.repoName),
-      })
-    ),
-    ...(initialValues?.environmentIds ?? []).map(
-      (environmentId): AutomationSessionTarget => ({ kind: "environment", environmentId })
-    ),
-  ]);
-  const [repoSelectionMode, setRepoSelectionMode] = useState<RepoSelectionMode>(() =>
-    // Combined count: a lone-repo default here would let the single-select
-    // collapse effect silently drop hydrated environment targets on edit.
-    initialRepositories.length + (initialValues?.environmentIds?.length ?? 0) > 1
-      ? "multiple"
-      : "single"
-  );
   const [repoDropdownOpen, setRepoDropdownOpen] = useState(false);
   const [repoQuery, setRepoQuery] = useState("");
-  // Per-kind views of the selection, in target order. Payload fields and the
-  // render's selected-state checks derive from these.
-  const selectedRepoNames = useMemo(
-    () =>
-      selectedTargets.flatMap((target) => (target.kind === "repo" ? [target.repoFullName] : [])),
-    [selectedTargets]
-  );
-  const selectedEnvironmentIds = useMemo(
-    () =>
-      selectedTargets.flatMap((target) =>
-        target.kind === "environment" ? [target.environmentId] : []
-      ),
-    [selectedTargets]
-  );
-  const selectedRepoName = selectedRepoNames[0] ?? "";
-  const usesSingleRepository = selectedTargets.length === 1 && selectedTargets[0].kind === "repo";
-  const selectedRepository = usesSingleRepository ? parseRepoFullName(selectedRepoName) : null;
-  const { branches, loading: loadingBranches } = useBranches(
-    selectedRepository?.owner ?? "",
-    selectedRepository?.name ?? ""
-  );
-  const [baseBranch, setBaseBranch] = useState(() =>
-    initialRepositories.length === 1 ? (initialRepositories[0].baseBranch ?? "") : ""
-  );
   const [model, setModel] = useState(initialValues?.model ?? DEFAULT_MODEL);
   const [reasoningEffort, setReasoningEffort] = useState(initialValues?.reasoningEffort ?? "");
   const [scheduleCron, setScheduleCron] = useState(initialValues?.scheduleCron ?? "0 9 * * *");
@@ -231,7 +161,37 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
   // Multi-repository selections are schedule-only (the server rejects them for
   // event triggers), so the mode toggle only exists there.
   const multiRepoAllowed = isSchedule;
-  const multipleSelectionEnabled = multiRepoAllowed && repoSelectionMode === "multiple";
+
+  const {
+    selectedRepoNames,
+    selectedEnvironmentIds,
+    targetCount,
+    usesSingleRepository,
+    selectedRepository,
+    repositoryLabel,
+    multipleSelectionEnabled,
+    baseBranch,
+    setBaseBranch,
+    toggleRepository,
+    toggleEnvironment,
+    clearTargets,
+    toggleSelectionMode,
+    buildRepositoriesPayload,
+  } = useAutomationTargets({
+    initialRepositories,
+    initialEnvironmentIds: initialValues?.environmentIds ?? [],
+    multiRepoAllowed,
+    repositoryRequired,
+    repos,
+    environments,
+    loadingEnvironments,
+  });
+  // Branch options for the sole selected repository (the only branch-pickable shape).
+  const { branches, loading: loadingBranches } = useBranches(
+    selectedRepository?.owner ?? "",
+    selectedRepository?.name ?? ""
+  );
+
   const isSlack = triggerType === "slack_event";
   const isScheduleValid = !isSchedule || isValidCron(scheduleCron);
   const repositorySelectionDescription = repositoryRequired
@@ -277,117 +237,23 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
     }
   }, [showEventTypeSelector, eventType]);
 
-  const findRepo = useCallback(
-    (key: string) => repos.find((repo) => repo.fullName.toLowerCase() === key),
-    [repos]
-  );
+  // Selection transitions live in useAutomationTargets; the form only adds the
+  // dropdown-close behavior (single-select picks close the picker).
+  const handleRepoToggle = (repoFullName: string) => {
+    toggleRepository(repoFullName);
+    if (!multipleSelectionEnabled) setRepoDropdownOpen(false);
+  };
 
-  // Branch state follows repository membership: exactly one selected
-  // repository pins baseBranch to its default, anything else clears it.
-  // Environment-only mutations bypass this (setSelectedTargets directly) so a
-  // branch pick survives adding and removing environments around its repo.
-  const applyTargets = useCallback(
-    (nextTargets: AutomationSessionTarget[]) => {
-      setSelectedTargets(nextTargets);
-      const nextRepoNames = nextTargets.flatMap((target) =>
-        target.kind === "repo" ? [target.repoFullName] : []
-      );
-      if (nextRepoNames.length === 1) {
-        setBaseBranch(findRepo(nextRepoNames[0])?.defaultBranch ?? "");
-      } else {
-        setBaseBranch("");
-      }
-    },
-    [findRepo]
-  );
+  const handleEnvironmentToggle = (environmentId: string) => {
+    toggleEnvironment(environmentId);
+    if (!multipleSelectionEnabled) setRepoDropdownOpen(false);
+  };
 
-  useEffect(() => {
-    if (!multiRepoAllowed && repoSelectionMode === "multiple") {
-      setRepoSelectionMode("single");
-    }
-  }, [multiRepoAllowed, repoSelectionMode]);
-
-  // Repo-scoped triggers stay bound to the webhook's repository, so any
-  // environment targets (e.g. hydrated before a trigger-type change) drop out.
-  useEffect(() => {
-    if (!repositoryRequired) return;
-    if (!selectedTargets.some((target) => target.kind === "environment")) return;
-    setSelectedTargets(selectedTargets.filter((target) => target.kind === "repo"));
-  }, [repositoryRequired, selectedTargets]);
-
-  useEffect(() => {
-    if (multipleSelectionEnabled || selectedTargets.length <= 1) return;
-    applyTargets(collapseToSingleTarget(selectedTargets));
-  }, [applyTargets, multipleSelectionEnabled, selectedTargets]);
-
-  const targetCount = selectedTargets.length;
-
-  const handleRepoToggle = useCallback(
-    (repoFullName: string) => {
-      const target: AutomationSessionTarget = {
-        kind: "repo",
-        repoFullName: repoFullName.toLowerCase(),
-      };
-      if (!multipleSelectionEnabled) {
-        applyTargets([target]);
-        setRepoDropdownOpen(false);
-        return;
-      }
-
-      const selected = selectedRepoNames.includes(target.repoFullName);
-      if (!selected && targetCount >= MAX_AUTOMATION_REPOSITORIES) return;
-      applyTargets(
-        selected
-          ? selectedTargets.filter(
-              (entry) => !(entry.kind === "repo" && entry.repoFullName === target.repoFullName)
-            )
-          : [...selectedTargets, target]
-      );
-    },
-    [applyTargets, multipleSelectionEnabled, selectedRepoNames, selectedTargets, targetCount]
-  );
-
-  const handleEnvironmentToggle = useCallback(
-    (environmentId: string) => {
-      const target: AutomationSessionTarget = { kind: "environment", environmentId };
-      if (!multipleSelectionEnabled) {
-        applyTargets([target]);
-        setRepoDropdownOpen(false);
-        return;
-      }
-
-      const selected = selectedEnvironmentIds.includes(environmentId);
-      if (!selected && targetCount >= MAX_AUTOMATION_REPOSITORIES) return;
-      setSelectedTargets(
-        selected
-          ? selectedTargets.filter(
-              (entry) => !(entry.kind === "environment" && entry.environmentId === environmentId)
-            )
-          : [...selectedTargets, target]
-      );
-    },
-    [applyTargets, multipleSelectionEnabled, selectedEnvironmentIds, selectedTargets, targetCount]
-  );
-
-  const handleNoRepository = useCallback(() => {
+  const handleNoRepository = () => {
     if (repositoryRequired) return;
-    applyTargets([]);
+    clearTargets();
     setRepoDropdownOpen(false);
-  }, [applyTargets, repositoryRequired]);
-
-  const handleRepoSelectionModeToggle = useCallback(() => {
-    if (!multiRepoAllowed) return;
-
-    if (repoSelectionMode === "multiple") {
-      setRepoSelectionMode("single");
-      if (selectedTargets.length > 1) {
-        applyTargets(collapseToSingleTarget(selectedTargets));
-      }
-      return;
-    }
-
-    setRepoSelectionMode("multiple");
-  }, [applyTargets, multiRepoAllowed, repoSelectionMode, selectedTargets]);
+  };
 
   useEffect(() => {
     if (!repoDropdownOpen) {
@@ -429,21 +295,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
       instructions: instructions.trim(),
       triggerType,
       // Always send the full selection — an empty list means repo-less.
-      repositories: selectedRepoNames.map((key) => {
-        const [entryOwner = "", entryName = ""] = key.split("/");
-        const entry: AutomationRepositoryInput = { repoOwner: entryOwner, repoName: entryName };
-        if (usesSingleRepository) {
-          if (baseBranch.trim()) entry.baseBranch = baseBranch.trim();
-        } else {
-          // Multi-repo selections have no branch picker; keep the branch each
-          // already-selected repository had so an unrelated edit can't reset it.
-          const existing = initialRepositories.find(
-            (repository) => repositoryKey(repository.repoOwner, repository.repoName) === key
-          );
-          if (existing?.baseBranch) entry.baseBranch = existing.baseBranch;
-        }
-        return entry;
-      }),
+      repositories: buildRepositoriesPayload(),
     };
 
     if (!isSchedule) {
@@ -481,32 +333,6 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
     if (!query) return environments;
     return environments.filter((environment) => environment.name.toLowerCase().includes(query));
   }, [environments, repositoryRequired, repoQuery]);
-  const environmentName = (environmentId: string) =>
-    environments.find((environment) => environment.id === environmentId)?.name ??
-    (loadingEnvironments ? "Loading..." : environmentId);
-  const repositoryLabel = (() => {
-    if (targetCount === 0) return NO_REPOSITORY_LABEL;
-    if (selectedRepoNames.length === 1 && selectedEnvironmentIds.length === 0) {
-      return findRepo(selectedRepoName)?.fullName ?? selectedRepoName;
-    }
-    if (selectedEnvironmentIds.length === 1 && selectedRepoNames.length === 0) {
-      return environmentName(selectedEnvironmentIds[0]);
-    }
-    const parts: string[] = [];
-    if (selectedRepoNames.length > 0) {
-      parts.push(
-        selectedRepoNames.length === 1 ? "1 repository" : `${selectedRepoNames.length} repositories`
-      );
-    }
-    if (selectedEnvironmentIds.length > 0) {
-      parts.push(
-        selectedEnvironmentIds.length === 1
-          ? "1 environment"
-          : `${selectedEnvironmentIds.length} environments`
-      );
-    }
-    return parts.join(" + ");
-  })();
   const reasoningConfig = getReasoningConfig(resolvedModel);
 
   return (
@@ -664,12 +490,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
                 All repositories
               </span>
               {multiRepoAllowed && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="xs"
-                  onClick={handleRepoSelectionModeToggle}
-                >
+                <Button type="button" variant="outline" size="xs" onClick={toggleSelectionMode}>
                   {multipleSelectionEnabled ? "Select One" : "Select Multiple"}
                 </Button>
               )}
@@ -781,7 +602,7 @@ export function AutomationForm({ mode, initialValues, onSubmit, submitting }: Au
             searchPlaceholder="Search branches..."
             filterFn={(option, query) => option.label.toLowerCase().includes(query)}
             dropdownWidth="w-56"
-            disabled={!selectedRepoName || loadingBranches}
+            disabled={!selectedRepository || loadingBranches}
             triggerClassName="flex w-full items-center gap-1.5 px-3 py-2 text-sm border border-border bg-input text-foreground hover:border-foreground/20 transition"
           >
             <BranchIcon className="w-3.5 h-3.5 text-muted-foreground" />

--- a/packages/web/src/components/automations/automation-target-selection.test.ts
+++ b/packages/web/src/components/automations/automation-target-selection.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest";
+import {
+  type AutomationSessionTarget,
+  buildRepositoriesPayload,
+  collapseToSingleTarget,
+  hydrateTargets,
+  initialBaseBranch,
+  initialSelectionMode,
+  nextBaseBranch,
+  toggleTarget,
+} from "./automation-target-selection";
+
+const repoTarget = (repoFullName: string): AutomationSessionTarget => ({
+  kind: "repo",
+  repoFullName,
+});
+const environmentTarget = (environmentId: string): AutomationSessionTarget => ({
+  kind: "environment",
+  environmentId,
+});
+
+const repos = [
+  { fullName: "open-inspect/background-agents", defaultBranch: "main" },
+  { fullName: "Acme/Web-App", defaultBranch: "trunk" },
+];
+
+describe("hydrateTargets", () => {
+  it("lowercases repository keys and appends environments after repositories", () => {
+    expect(
+      hydrateTargets(
+        [{ repoOwner: "Acme", repoName: "Web-App", baseBranch: "release" }],
+        ["env_1", "env_2"]
+      )
+    ).toEqual([repoTarget("acme/web-app"), environmentTarget("env_1"), environmentTarget("env_2")]);
+  });
+
+  it("hydrates the empty selection as no targets", () => {
+    expect(hydrateTargets([], [])).toEqual([]);
+  });
+});
+
+describe("initialSelectionMode", () => {
+  it("opens in single-select for at most one target", () => {
+    expect(initialSelectionMode([], [])).toBe("single");
+    expect(initialSelectionMode([{ repoOwner: "acme", repoName: "web-app" }], [])).toBe("single");
+    expect(initialSelectionMode([], ["env_1"])).toBe("single");
+  });
+
+  it("opens in multi-select for combined repository + environment counts above one", () => {
+    expect(initialSelectionMode([{ repoOwner: "acme", repoName: "web-app" }], ["env_1"])).toBe(
+      "multiple"
+    );
+    expect(
+      initialSelectionMode(
+        [
+          { repoOwner: "acme", repoName: "web-app" },
+          { repoOwner: "acme", repoName: "api" },
+        ],
+        []
+      )
+    ).toBe("multiple");
+  });
+});
+
+describe("initialBaseBranch", () => {
+  it("hydrates the stored branch of a sole stored repository", () => {
+    expect(
+      initialBaseBranch([{ repoOwner: "acme", repoName: "web-app", baseBranch: "release" }])
+    ).toBe("release");
+  });
+
+  it("hydrates empty when the sole repository has no stored branch", () => {
+    expect(initialBaseBranch([{ repoOwner: "acme", repoName: "web-app" }])).toBe("");
+  });
+
+  it("hydrates empty for anything other than exactly one repository", () => {
+    expect(initialBaseBranch([])).toBe("");
+    expect(
+      initialBaseBranch([
+        { repoOwner: "acme", repoName: "web-app", baseBranch: "release" },
+        { repoOwner: "acme", repoName: "api", baseBranch: "develop" },
+      ])
+    ).toBe("");
+  });
+});
+
+describe("collapseToSingleTarget", () => {
+  it("keeps the first repository even when an environment was selected first", () => {
+    expect(
+      collapseToSingleTarget([
+        environmentTarget("env_1"),
+        repoTarget("acme/web-app"),
+        repoTarget("acme/api"),
+      ])
+    ).toEqual([repoTarget("acme/web-app")]);
+  });
+
+  it("keeps the first environment when only environments are selected", () => {
+    expect(
+      collapseToSingleTarget([environmentTarget("env_1"), environmentTarget("env_2")])
+    ).toEqual([environmentTarget("env_1")]);
+  });
+});
+
+describe("toggleTarget", () => {
+  it("appends an unselected target below the cap", () => {
+    expect(toggleTarget([repoTarget("acme/web-app")], environmentTarget("env_1"), 3)).toEqual([
+      repoTarget("acme/web-app"),
+      environmentTarget("env_1"),
+    ]);
+  });
+
+  it("removes a selected target, even at the cap", () => {
+    expect(
+      toggleTarget(
+        [repoTarget("acme/web-app"), environmentTarget("env_1")],
+        repoTarget("acme/web-app"),
+        2
+      )
+    ).toEqual([environmentTarget("env_1")]);
+  });
+
+  it("returns null when adding would exceed the cap", () => {
+    expect(
+      toggleTarget(
+        [repoTarget("acme/web-app"), environmentTarget("env_1")],
+        repoTarget("acme/api"),
+        2
+      )
+    ).toBeNull();
+  });
+});
+
+describe("nextBaseBranch", () => {
+  it("pins the default branch when membership changes to exactly one repository", () => {
+    expect(nextBaseBranch([], [repoTarget("open-inspect/background-agents")], repos)).toBe("main");
+  });
+
+  it("matches the repos list case-insensitively (the selection stores lowercase keys)", () => {
+    expect(nextBaseBranch([], [repoTarget("acme/web-app")], repos)).toBe("trunk");
+  });
+
+  it("falls back to empty for a repository missing from the repos list", () => {
+    expect(nextBaseBranch([], [repoTarget("acme/unknown")], repos)).toBe("");
+  });
+
+  it("clears the branch when membership changes away from exactly one repository", () => {
+    const soleRepo = [repoTarget("open-inspect/background-agents")];
+    expect(nextBaseBranch(soleRepo, [...soleRepo, repoTarget("acme/web-app")], repos)).toBe("");
+    expect(nextBaseBranch(soleRepo, [], repos)).toBe("");
+  });
+
+  it("re-pins the default branch when the identical selection is re-committed", () => {
+    // A single-select re-click of the current repository resets a branch pick.
+    const soleRepo = [repoTarget("open-inspect/background-agents")];
+    expect(nextBaseBranch(soleRepo, [repoTarget("open-inspect/background-agents")], repos)).toBe(
+      "main"
+    );
+  });
+
+  it("leaves the branch alone when only environments change around the repository", () => {
+    const soleRepo = [repoTarget("open-inspect/background-agents")];
+    expect(nextBaseBranch(soleRepo, [...soleRepo, environmentTarget("env_1")], repos)).toBeNull();
+    // Collapsing a mixed selection back to its repository keeps the pick too:
+    // repository membership never changed while the environment came and went.
+    expect(nextBaseBranch([...soleRepo, environmentTarget("env_1")], soleRepo, repos)).toBeNull();
+  });
+});
+
+describe("buildRepositoriesPayload", () => {
+  it("includes the trimmed branch for a single-repository selection", () => {
+    expect(buildRepositoriesPayload(["acme/web-app"], true, " release ", [])).toEqual([
+      { repoOwner: "acme", repoName: "web-app", baseBranch: "release" },
+    ]);
+  });
+
+  it("omits the branch for a single-repository selection with no pick", () => {
+    expect(buildRepositoriesPayload(["acme/web-app"], true, " ", [])).toEqual([
+      { repoOwner: "acme", repoName: "web-app" },
+    ]);
+  });
+
+  it("keeps each already-stored branch and leaves new entries branchless otherwise", () => {
+    expect(
+      buildRepositoriesPayload(["acme/web-app", "acme/api"], false, "ignored", [
+        { repoOwner: "Acme", repoName: "Web-App", baseBranch: "release" },
+      ])
+    ).toEqual([
+      { repoOwner: "acme", repoName: "web-app", baseBranch: "release" },
+      { repoOwner: "acme", repoName: "api" },
+    ]);
+  });
+});

--- a/packages/web/src/components/automations/automation-target-selection.ts
+++ b/packages/web/src/components/automations/automation-target-selection.ts
@@ -1,0 +1,162 @@
+import type { AutomationRepositoryInput } from "@open-inspect/shared";
+import type { SessionTarget } from "@/lib/session-target";
+
+/**
+ * One entry of the automation's fan-out selection, reusing the shared
+ * session-target model (lib/session-target.ts). An automation targets an
+ * ordered list of launchable session targets: each `repo` entry runs in its
+ * own session and each `environment` entry opens one workspace session. The
+ * empty list is the repo-less selection ("No repository"). Single-select mode
+ * replaces the whole list, so repo/environment mutual exclusivity there is
+ * structural rather than enforced by cross-clearing effects.
+ */
+export type AutomationSessionTarget = Extract<SessionTarget, { kind: "repo" | "environment" }>;
+
+export type SelectionMode = "single" | "multiple";
+
+/** Selection key for a repository: the lowercase full name, as the API stores it. */
+function repositoryKey(repoOwner: string, repoName: string): string {
+  return `${repoOwner}/${repoName}`.toLowerCase();
+}
+
+/**
+ * The stored selection as a target list: repositories first, then
+ * environments, each in stored order.
+ */
+export function hydrateTargets(
+  initialRepositories: AutomationRepositoryInput[],
+  initialEnvironmentIds: string[]
+): AutomationSessionTarget[] {
+  return [
+    ...initialRepositories.map(
+      (repository): AutomationSessionTarget => ({
+        kind: "repo",
+        repoFullName: repositoryKey(repository.repoOwner, repository.repoName),
+      })
+    ),
+    ...initialEnvironmentIds.map(
+      (environmentId): AutomationSessionTarget => ({ kind: "environment", environmentId })
+    ),
+  ];
+}
+
+/**
+ * A hydrated selection with more than one target opens in multi-select mode.
+ * The count combines repositories and environments: a lone-repo rule here
+ * would let the single-select collapse effect silently drop hydrated
+ * environment targets on edit.
+ */
+export function initialSelectionMode(
+  initialRepositories: AutomationRepositoryInput[],
+  initialEnvironmentIds: string[]
+): SelectionMode {
+  return initialRepositories.length + initialEnvironmentIds.length > 1 ? "multiple" : "single";
+}
+
+/** The hydrated branch: the stored branch when exactly one repository is stored. */
+export function initialBaseBranch(initialRepositories: AutomationRepositoryInput[]): string {
+  return initialRepositories.length === 1 ? (initialRepositories[0].baseBranch ?? "") : "";
+}
+
+/** Lowercase repository full names of the selection, in target order. */
+export function repoNamesOf(targets: AutomationSessionTarget[]): string[] {
+  return targets.flatMap((target) => (target.kind === "repo" ? [target.repoFullName] : []));
+}
+
+function sameStringList(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+function sameTarget(a: AutomationSessionTarget, b: AutomationSessionTarget): boolean {
+  return a.kind === "repo"
+    ? b.kind === "repo" && b.repoFullName === a.repoFullName
+    : b.kind === "environment" && b.environmentId === a.environmentId;
+}
+
+function sameTargetList(a: AutomationSessionTarget[], b: AutomationSessionTarget[]): boolean {
+  return a.length === b.length && a.every((target, index) => sameTarget(target, b[index]));
+}
+
+/**
+ * Leaving multi-select keeps one target: the first repository, or the first
+ * environment when only environments are selected.
+ */
+export function collapseToSingleTarget(
+  targets: AutomationSessionTarget[]
+): AutomationSessionTarget[] {
+  const firstRepository = targets.find((target) => target.kind === "repo");
+  return firstRepository ? [firstRepository] : targets.slice(0, 1);
+}
+
+/**
+ * Toggled multi-select membership: removes the target when selected, appends
+ * it otherwise. Returns null when adding would exceed the cap.
+ */
+export function toggleTarget(
+  targets: AutomationSessionTarget[],
+  target: AutomationSessionTarget,
+  cap: number
+): AutomationSessionTarget[] | null {
+  const selected = targets.some((entry) => sameTarget(entry, target));
+  if (!selected && targets.length >= cap) return null;
+  return selected ? targets.filter((entry) => !sameTarget(entry, target)) : [...targets, target];
+}
+
+/** Exactly one selected repository pins its default branch; anything else clears the branch. */
+function pinnedBranchFor(
+  repoNames: string[],
+  repos: Array<{ fullName: string; defaultBranch: string }>
+): string {
+  if (repoNames.length !== 1) return "";
+  return repos.find((repo) => repo.fullName.toLowerCase() === repoNames[0])?.defaultBranch ?? "";
+}
+
+/**
+ * The branch policy for a selection transition: the next baseBranch value, or
+ * null to leave the current value unchanged. Decided from the transition
+ * itself, so callers never choose between branch-updating and branch-keeping
+ * setters.
+ */
+export function nextBaseBranch(
+  prevTargets: AutomationSessionTarget[],
+  nextTargets: AutomationSessionTarget[],
+  repos: Array<{ fullName: string; defaultBranch: string }>
+): string | null {
+  const prevRepoNames = repoNamesOf(prevTargets);
+  const nextRepoNames = repoNamesOf(nextTargets);
+  if (sameStringList(prevRepoNames, nextRepoNames)) {
+    // Identical selection: a single-select re-click of the current target is
+    // an explicit re-selection, so "selecting a repository resets this to that
+    // repo's default branch" holds even for the same repository.
+    if (sameTargetList(prevTargets, nextTargets)) return pinnedBranchFor(nextRepoNames, repos);
+    // Environment-only change: leave a (possibly hidden) branch pick alone so
+    // it survives adding and removing environments around its repository.
+    return null;
+  }
+  // Repository membership changed: re-derive the branch from the new membership.
+  return pinnedBranchFor(nextRepoNames, repos);
+}
+
+/** The `repositories` payload field: the full selection with branch rules applied. */
+export function buildRepositoriesPayload(
+  selectedRepoNames: string[],
+  usesSingleRepository: boolean,
+  baseBranch: string,
+  initialRepositories: AutomationRepositoryInput[]
+): AutomationRepositoryInput[] {
+  return selectedRepoNames.map((key) => {
+    const [entryOwner = "", entryName = ""] = key.split("/");
+    const entry: AutomationRepositoryInput = { repoOwner: entryOwner, repoName: entryName };
+    if (usesSingleRepository) {
+      if (baseBranch.trim()) entry.baseBranch = baseBranch.trim();
+    } else {
+      // Multi-repo selections have no branch picker; keep the branch each
+      // already-selected repository had so an unrelated edit can't reset it.
+      const existing = initialRepositories.find(
+        (repository) => repositoryKey(repository.repoOwner, repository.repoName) === key
+      );
+      if (existing?.baseBranch) entry.baseBranch = existing.baseBranch;
+    }
+    return entry;
+  });
+}

--- a/packages/web/src/components/automations/use-automation-targets.ts
+++ b/packages/web/src/components/automations/use-automation-targets.ts
@@ -2,54 +2,19 @@
 
 import { useCallback, useMemo, useEffect, useState } from "react";
 import { MAX_AUTOMATION_REPOSITORIES, type AutomationRepositoryInput } from "@open-inspect/shared";
-import { parseRepoFullName, type SessionTarget } from "@/lib/session-target";
-
-/**
- * One entry of the automation's fan-out selection, reusing the shared
- * session-target model (lib/session-target.ts). An automation targets an
- * ordered list of launchable session targets: each `repo` entry runs in its
- * own session and each `environment` entry opens one workspace session. The
- * empty list is the repo-less selection ("No repository"). Single-select mode
- * replaces the whole list, so repo/environment mutual exclusivity there is
- * structural rather than enforced by cross-clearing effects.
- */
-export type AutomationSessionTarget = Extract<SessionTarget, { kind: "repo" | "environment" }>;
-
-type SelectionMode = "single" | "multiple";
-
-/** Selection key for a repository: the lowercase full name, as the API stores it. */
-function repositoryKey(repoOwner: string, repoName: string): string {
-  return `${repoOwner}/${repoName}`.toLowerCase();
-}
-
-function repoNamesOf(targets: AutomationSessionTarget[]): string[] {
-  return targets.flatMap((target) => (target.kind === "repo" ? [target.repoFullName] : []));
-}
-
-function sameStringList(a: string[], b: string[]): boolean {
-  return a.length === b.length && a.every((value, index) => value === b[index]);
-}
-
-function sameTargetList(a: AutomationSessionTarget[], b: AutomationSessionTarget[]): boolean {
-  return (
-    a.length === b.length &&
-    a.every((target, index) => {
-      const other = b[index];
-      return target.kind === "repo"
-        ? other.kind === "repo" && other.repoFullName === target.repoFullName
-        : other.kind === "environment" && other.environmentId === target.environmentId;
-    })
-  );
-}
-
-/**
- * Leaving multi-select keeps one target: the first repository, or the first
- * environment when only environments are selected.
- */
-function collapseToSingleTarget(targets: AutomationSessionTarget[]): AutomationSessionTarget[] {
-  const firstRepository = targets.find((target) => target.kind === "repo");
-  return firstRepository ? [firstRepository] : targets.slice(0, 1);
-}
+import { parseRepoFullName } from "@/lib/session-target";
+import {
+  type AutomationSessionTarget,
+  type SelectionMode,
+  buildRepositoriesPayload,
+  collapseToSingleTarget,
+  hydrateTargets,
+  initialBaseBranch,
+  initialSelectionMode,
+  nextBaseBranch,
+  repoNamesOf,
+  toggleTarget,
+} from "./automation-target-selection";
 
 export interface UseAutomationTargetsOptions {
   /** Stored selection hydrated in edit mode (or a template pre-fill). */
@@ -96,6 +61,8 @@ export interface UseAutomationTargetsResult {
  * Owns the automation form's target selection: the session-target list and its
  * hydration, single/multi selection mode, every selection transition, base
  * branch state coupled to those transitions, and the payload derivation. The
+ * selection rules themselves are pure functions in
+ * automation-target-selection.ts; this hook wires them to React state. The
  * form renders from the derived views and never mutates the selection
  * directly.
  */
@@ -110,59 +77,31 @@ export function useAutomationTargets(
     repos,
   } = options;
 
-  // The fan-out selection as one ordered list of session targets; repositories
-  // and environments hydrate in selection order within each kind.
-  const [selectedTargets, setSelectedTargets] = useState<AutomationSessionTarget[]>(() => [
-    ...initialRepositories.map(
-      (repository): AutomationSessionTarget => ({
-        kind: "repo",
-        repoFullName: repositoryKey(repository.repoOwner, repository.repoName),
-      })
-    ),
-    ...initialEnvironmentIds.map(
-      (environmentId): AutomationSessionTarget => ({ kind: "environment", environmentId })
-    ),
-  ]);
+  // State: the ordered session-target list, the selection mode, and the branch.
+  const [selectedTargets, setSelectedTargets] = useState<AutomationSessionTarget[]>(() =>
+    hydrateTargets(initialRepositories, initialEnvironmentIds)
+  );
   const [selectionMode, setSelectionMode] = useState<SelectionMode>(() =>
-    // Combined count: a lone-repo default here would let the single-select
-    // collapse effect silently drop hydrated environment targets on edit.
-    initialRepositories.length + initialEnvironmentIds.length > 1 ? "multiple" : "single"
+    initialSelectionMode(initialRepositories, initialEnvironmentIds)
   );
-  const [baseBranch, setBaseBranch] = useState(() =>
-    initialRepositories.length === 1 ? (initialRepositories[0].baseBranch ?? "") : ""
-  );
+  const [baseBranch, setBaseBranch] = useState(() => initialBaseBranch(initialRepositories));
 
   const multipleSelectionEnabled = multiRepoAllowed && selectionMode === "multiple";
 
-  const findRepo = useCallback(
-    (key: string) => repos.find((repo) => repo.fullName.toLowerCase() === key),
-    [repos]
-  );
-
-  // The single mutation path for the selection. Branch policy is decided here
-  // from the transition itself, never by callers picking a setter:
-  // - Repository membership changed: exactly one selected repository pins
-  //   baseBranch to its default, anything else clears it.
-  // - Identical selection (a single-select re-click of the current target):
-  //   treated as an explicit re-selection, so "selecting a repository resets
-  //   this to that repo's default branch" holds even for the same repository.
-  // - Otherwise (an environment-only change): baseBranch is left alone so a
-  //   branch pick survives adding and removing environments around its repo.
+  // The single mutation path for the selection: every transition below commits
+  // here, and nextBaseBranch decides the branch policy from the transition
+  // itself — callers never choose between branch-updating and branch-keeping
+  // setters.
   const commitTargets = useCallback(
     (nextTargets: AutomationSessionTarget[]) => {
       setSelectedTargets(nextTargets);
-      const currentRepoNames = repoNamesOf(selectedTargets);
-      const nextRepoNames = repoNamesOf(nextTargets);
-      const membershipUnchanged = sameStringList(currentRepoNames, nextRepoNames);
-      const reselectedCurrent = membershipUnchanged && sameTargetList(selectedTargets, nextTargets);
-      if (membershipUnchanged && !reselectedCurrent) return;
-      setBaseBranch(
-        nextRepoNames.length === 1 ? (findRepo(nextRepoNames[0])?.defaultBranch ?? "") : ""
-      );
+      const branch = nextBaseBranch(selectedTargets, nextTargets, repos);
+      if (branch !== null) setBaseBranch(branch);
     },
-    [findRepo, selectedTargets]
+    [repos, selectedTargets]
   );
 
+  // Multi-select mode is schedule-only; leaving schedule forces single-select.
   useEffect(() => {
     if (!multiRepoAllowed && selectionMode === "multiple") {
       setSelectionMode("single");
@@ -177,11 +116,13 @@ export function useAutomationTargets(
     commitTargets(selectedTargets.filter((target) => target.kind === "repo"));
   }, [commitTargets, repositoryRequired, selectedTargets]);
 
+  // Single-select holds at most one target; collapse anything larger.
   useEffect(() => {
     if (multipleSelectionEnabled || selectedTargets.length <= 1) return;
     commitTargets(collapseToSingleTarget(selectedTargets));
   }, [commitTargets, multipleSelectionEnabled, selectedTargets]);
 
+  // Per-kind views of the selection, in target order.
   const selectedRepoNames = useMemo(() => repoNamesOf(selectedTargets), [selectedTargets]);
   const selectedEnvironmentIds = useMemo(
     () =>
@@ -192,8 +133,9 @@ export function useAutomationTargets(
   );
   const targetCount = selectedTargets.length;
   const usesSingleRepository = selectedTargets.length === 1 && selectedTargets[0].kind === "repo";
-  const selectedRepoName = selectedRepoNames[0] ?? "";
-  const selectedRepository = usesSingleRepository ? parseRepoFullName(selectedRepoName) : null;
+  const selectedRepository = usesSingleRepository
+    ? parseRepoFullName(selectedRepoNames[0] ?? "")
+    : null;
 
   const toggleRepository = useCallback(
     (repoFullName: string) => {
@@ -205,18 +147,10 @@ export function useAutomationTargets(
         commitTargets([target]);
         return;
       }
-
-      const selected = selectedRepoNames.includes(target.repoFullName);
-      if (!selected && targetCount >= MAX_AUTOMATION_REPOSITORIES) return;
-      commitTargets(
-        selected
-          ? selectedTargets.filter(
-              (entry) => !(entry.kind === "repo" && entry.repoFullName === target.repoFullName)
-            )
-          : [...selectedTargets, target]
-      );
+      const nextTargets = toggleTarget(selectedTargets, target, MAX_AUTOMATION_REPOSITORIES);
+      if (nextTargets) commitTargets(nextTargets);
     },
-    [commitTargets, multipleSelectionEnabled, selectedRepoNames, selectedTargets, targetCount]
+    [commitTargets, multipleSelectionEnabled, selectedTargets]
   );
 
   const toggleEnvironment = useCallback(
@@ -226,18 +160,10 @@ export function useAutomationTargets(
         commitTargets([target]);
         return;
       }
-
-      const selected = selectedEnvironmentIds.includes(environmentId);
-      if (!selected && targetCount >= MAX_AUTOMATION_REPOSITORIES) return;
-      commitTargets(
-        selected
-          ? selectedTargets.filter(
-              (entry) => !(entry.kind === "environment" && entry.environmentId === environmentId)
-            )
-          : [...selectedTargets, target]
-      );
+      const nextTargets = toggleTarget(selectedTargets, target, MAX_AUTOMATION_REPOSITORIES);
+      if (nextTargets) commitTargets(nextTargets);
     },
-    [commitTargets, multipleSelectionEnabled, selectedEnvironmentIds, selectedTargets, targetCount]
+    [commitTargets, multipleSelectionEnabled, selectedTargets]
   );
 
   const clearTargets = useCallback(() => {
@@ -259,23 +185,14 @@ export function useAutomationTargets(
     setSelectionMode("multiple");
   }, [commitTargets, multiRepoAllowed, selectionMode, selectedTargets]);
 
-  const buildRepositoriesPayload = useCallback(
-    (): AutomationRepositoryInput[] =>
-      selectedRepoNames.map((key) => {
-        const [entryOwner = "", entryName = ""] = key.split("/");
-        const entry: AutomationRepositoryInput = { repoOwner: entryOwner, repoName: entryName };
-        if (usesSingleRepository) {
-          if (baseBranch.trim()) entry.baseBranch = baseBranch.trim();
-        } else {
-          // Multi-repo selections have no branch picker; keep the branch each
-          // already-selected repository had so an unrelated edit can't reset it.
-          const existing = initialRepositories.find(
-            (repository) => repositoryKey(repository.repoOwner, repository.repoName) === key
-          );
-          if (existing?.baseBranch) entry.baseBranch = existing.baseBranch;
-        }
-        return entry;
-      }),
+  const buildPayload = useCallback(
+    () =>
+      buildRepositoriesPayload(
+        selectedRepoNames,
+        usesSingleRepository,
+        baseBranch,
+        initialRepositories
+      ),
     [baseBranch, initialRepositories, selectedRepoNames, usesSingleRepository]
   );
 
@@ -292,6 +209,6 @@ export function useAutomationTargets(
     toggleEnvironment,
     clearTargets,
     toggleSelectionMode,
-    buildRepositoriesPayload,
+    buildRepositoriesPayload: buildPayload,
   };
 }

--- a/packages/web/src/components/automations/use-automation-targets.ts
+++ b/packages/web/src/components/automations/use-automation-targets.ts
@@ -2,7 +2,6 @@
 
 import { useCallback, useMemo, useEffect, useState } from "react";
 import { MAX_AUTOMATION_REPOSITORIES, type AutomationRepositoryInput } from "@open-inspect/shared";
-import { NO_REPOSITORY_LABEL } from "@/lib/repo-label";
 import { parseRepoFullName, type SessionTarget } from "@/lib/session-target";
 
 /**
@@ -67,11 +66,9 @@ export interface UseAutomationTargetsOptions {
    */
   repositoryRequired: boolean;
   repos: Array<{ fullName: string; defaultBranch: string }>;
-  environments: Array<{ id: string; name: string }>;
-  loadingEnvironments: boolean;
 }
 
-export interface AutomationTargetSelection {
+export interface UseAutomationTargetsResult {
   /** Lowercase repository full names of the selection, in target order. */
   selectedRepoNames: string[];
   /** Environment ids of the selection, in target order. */
@@ -81,8 +78,6 @@ export interface AutomationTargetSelection {
   usesSingleRepository: boolean;
   /** Owner/name of the sole selected repository, for the branch fetch. */
   selectedRepository: { owner: string; name: string } | null;
-  /** Trigger-button label for the current selection. */
-  repositoryLabel: string;
   multipleSelectionEnabled: boolean;
   baseBranch: string;
   setBaseBranch: (branch: string) => void;
@@ -100,21 +95,19 @@ export interface AutomationTargetSelection {
 /**
  * Owns the automation form's target selection: the session-target list and its
  * hydration, single/multi selection mode, every selection transition, base
- * branch state coupled to those transitions, and the label/payload
- * derivations. The form renders from the derived views and never mutates the
- * selection directly.
+ * branch state coupled to those transitions, and the payload derivation. The
+ * form renders from the derived views and never mutates the selection
+ * directly.
  */
 export function useAutomationTargets(
   options: UseAutomationTargetsOptions
-): AutomationTargetSelection {
+): UseAutomationTargetsResult {
   const {
     initialRepositories,
     initialEnvironmentIds,
     multiRepoAllowed,
     repositoryRequired,
     repos,
-    environments,
-    loadingEnvironments,
   } = options;
 
   // The fan-out selection as one ordered list of session targets; repositories
@@ -286,40 +279,12 @@ export function useAutomationTargets(
     [baseBranch, initialRepositories, selectedRepoNames, usesSingleRepository]
   );
 
-  const environmentName = (environmentId: string) =>
-    environments.find((environment) => environment.id === environmentId)?.name ??
-    (loadingEnvironments ? "Loading..." : environmentId);
-  const repositoryLabel = (() => {
-    if (targetCount === 0) return NO_REPOSITORY_LABEL;
-    if (selectedRepoNames.length === 1 && selectedEnvironmentIds.length === 0) {
-      return findRepo(selectedRepoName)?.fullName ?? selectedRepoName;
-    }
-    if (selectedEnvironmentIds.length === 1 && selectedRepoNames.length === 0) {
-      return environmentName(selectedEnvironmentIds[0]);
-    }
-    const parts: string[] = [];
-    if (selectedRepoNames.length > 0) {
-      parts.push(
-        selectedRepoNames.length === 1 ? "1 repository" : `${selectedRepoNames.length} repositories`
-      );
-    }
-    if (selectedEnvironmentIds.length > 0) {
-      parts.push(
-        selectedEnvironmentIds.length === 1
-          ? "1 environment"
-          : `${selectedEnvironmentIds.length} environments`
-      );
-    }
-    return parts.join(" + ");
-  })();
-
   return {
     selectedRepoNames,
     selectedEnvironmentIds,
     targetCount,
     usesSingleRepository,
     selectedRepository,
-    repositoryLabel,
     multipleSelectionEnabled,
     baseBranch,
     setBaseBranch,

--- a/packages/web/src/components/automations/use-automation-targets.ts
+++ b/packages/web/src/components/automations/use-automation-targets.ts
@@ -1,0 +1,332 @@
+"use client";
+
+import { useCallback, useMemo, useEffect, useState } from "react";
+import { MAX_AUTOMATION_REPOSITORIES, type AutomationRepositoryInput } from "@open-inspect/shared";
+import { NO_REPOSITORY_LABEL } from "@/lib/repo-label";
+import { parseRepoFullName, type SessionTarget } from "@/lib/session-target";
+
+/**
+ * One entry of the automation's fan-out selection, reusing the shared
+ * session-target model (lib/session-target.ts). An automation targets an
+ * ordered list of launchable session targets: each `repo` entry runs in its
+ * own session and each `environment` entry opens one workspace session. The
+ * empty list is the repo-less selection ("No repository"). Single-select mode
+ * replaces the whole list, so repo/environment mutual exclusivity there is
+ * structural rather than enforced by cross-clearing effects.
+ */
+export type AutomationSessionTarget = Extract<SessionTarget, { kind: "repo" | "environment" }>;
+
+type SelectionMode = "single" | "multiple";
+
+/** Selection key for a repository: the lowercase full name, as the API stores it. */
+function repositoryKey(repoOwner: string, repoName: string): string {
+  return `${repoOwner}/${repoName}`.toLowerCase();
+}
+
+function repoNamesOf(targets: AutomationSessionTarget[]): string[] {
+  return targets.flatMap((target) => (target.kind === "repo" ? [target.repoFullName] : []));
+}
+
+function sameStringList(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((value, index) => value === b[index]);
+}
+
+function sameTargetList(a: AutomationSessionTarget[], b: AutomationSessionTarget[]): boolean {
+  return (
+    a.length === b.length &&
+    a.every((target, index) => {
+      const other = b[index];
+      return target.kind === "repo"
+        ? other.kind === "repo" && other.repoFullName === target.repoFullName
+        : other.kind === "environment" && other.environmentId === target.environmentId;
+    })
+  );
+}
+
+/**
+ * Leaving multi-select keeps one target: the first repository, or the first
+ * environment when only environments are selected.
+ */
+function collapseToSingleTarget(targets: AutomationSessionTarget[]): AutomationSessionTarget[] {
+  const firstRepository = targets.find((target) => target.kind === "repo");
+  return firstRepository ? [firstRepository] : targets.slice(0, 1);
+}
+
+export interface UseAutomationTargetsOptions {
+  /** Stored selection hydrated in edit mode (or a template pre-fill). */
+  initialRepositories: AutomationRepositoryInput[];
+  initialEnvironmentIds: string[];
+  /**
+   * Multi-target selections are schedule-only (the server rejects them for
+   * event triggers), so multi-select mode only exists there.
+   */
+  multiRepoAllowed: boolean;
+  /**
+   * Repo-scoped triggers stay bound to the webhook's repository: exactly one
+   * repository, no environments, no repo-less selection.
+   */
+  repositoryRequired: boolean;
+  repos: Array<{ fullName: string; defaultBranch: string }>;
+  environments: Array<{ id: string; name: string }>;
+  loadingEnvironments: boolean;
+}
+
+export interface AutomationTargetSelection {
+  /** Lowercase repository full names of the selection, in target order. */
+  selectedRepoNames: string[];
+  /** Environment ids of the selection, in target order. */
+  selectedEnvironmentIds: string[];
+  targetCount: number;
+  /** Whether the selection is exactly one repository (the branch-pickable shape). */
+  usesSingleRepository: boolean;
+  /** Owner/name of the sole selected repository, for the branch fetch. */
+  selectedRepository: { owner: string; name: string } | null;
+  /** Trigger-button label for the current selection. */
+  repositoryLabel: string;
+  multipleSelectionEnabled: boolean;
+  baseBranch: string;
+  setBaseBranch: (branch: string) => void;
+  /** Single-select replaces the selection; multi-select toggles up to the cap. */
+  toggleRepository: (repoFullName: string) => void;
+  toggleEnvironment: (environmentId: string) => void;
+  /** The "No repository" selection; ignored while a repository is required. */
+  clearTargets: () => void;
+  /** Switches single/multi-select, collapsing a multi-selection to one target. */
+  toggleSelectionMode: () => void;
+  /** The `repositories` payload field: full selection with branch rules applied. */
+  buildRepositoriesPayload: () => AutomationRepositoryInput[];
+}
+
+/**
+ * Owns the automation form's target selection: the session-target list and its
+ * hydration, single/multi selection mode, every selection transition, base
+ * branch state coupled to those transitions, and the label/payload
+ * derivations. The form renders from the derived views and never mutates the
+ * selection directly.
+ */
+export function useAutomationTargets(
+  options: UseAutomationTargetsOptions
+): AutomationTargetSelection {
+  const {
+    initialRepositories,
+    initialEnvironmentIds,
+    multiRepoAllowed,
+    repositoryRequired,
+    repos,
+    environments,
+    loadingEnvironments,
+  } = options;
+
+  // The fan-out selection as one ordered list of session targets; repositories
+  // and environments hydrate in selection order within each kind.
+  const [selectedTargets, setSelectedTargets] = useState<AutomationSessionTarget[]>(() => [
+    ...initialRepositories.map(
+      (repository): AutomationSessionTarget => ({
+        kind: "repo",
+        repoFullName: repositoryKey(repository.repoOwner, repository.repoName),
+      })
+    ),
+    ...initialEnvironmentIds.map(
+      (environmentId): AutomationSessionTarget => ({ kind: "environment", environmentId })
+    ),
+  ]);
+  const [selectionMode, setSelectionMode] = useState<SelectionMode>(() =>
+    // Combined count: a lone-repo default here would let the single-select
+    // collapse effect silently drop hydrated environment targets on edit.
+    initialRepositories.length + initialEnvironmentIds.length > 1 ? "multiple" : "single"
+  );
+  const [baseBranch, setBaseBranch] = useState(() =>
+    initialRepositories.length === 1 ? (initialRepositories[0].baseBranch ?? "") : ""
+  );
+
+  const multipleSelectionEnabled = multiRepoAllowed && selectionMode === "multiple";
+
+  const findRepo = useCallback(
+    (key: string) => repos.find((repo) => repo.fullName.toLowerCase() === key),
+    [repos]
+  );
+
+  // The single mutation path for the selection. Branch policy is decided here
+  // from the transition itself, never by callers picking a setter:
+  // - Repository membership changed: exactly one selected repository pins
+  //   baseBranch to its default, anything else clears it.
+  // - Identical selection (a single-select re-click of the current target):
+  //   treated as an explicit re-selection, so "selecting a repository resets
+  //   this to that repo's default branch" holds even for the same repository.
+  // - Otherwise (an environment-only change): baseBranch is left alone so a
+  //   branch pick survives adding and removing environments around its repo.
+  const commitTargets = useCallback(
+    (nextTargets: AutomationSessionTarget[]) => {
+      setSelectedTargets(nextTargets);
+      const currentRepoNames = repoNamesOf(selectedTargets);
+      const nextRepoNames = repoNamesOf(nextTargets);
+      const membershipUnchanged = sameStringList(currentRepoNames, nextRepoNames);
+      const reselectedCurrent = membershipUnchanged && sameTargetList(selectedTargets, nextTargets);
+      if (membershipUnchanged && !reselectedCurrent) return;
+      setBaseBranch(
+        nextRepoNames.length === 1 ? (findRepo(nextRepoNames[0])?.defaultBranch ?? "") : ""
+      );
+    },
+    [findRepo, selectedTargets]
+  );
+
+  useEffect(() => {
+    if (!multiRepoAllowed && selectionMode === "multiple") {
+      setSelectionMode("single");
+    }
+  }, [multiRepoAllowed, selectionMode]);
+
+  // Repo-scoped triggers stay bound to the webhook's repository, so any
+  // environment targets (e.g. hydrated before a trigger-type change) drop out.
+  useEffect(() => {
+    if (!repositoryRequired) return;
+    if (!selectedTargets.some((target) => target.kind === "environment")) return;
+    commitTargets(selectedTargets.filter((target) => target.kind === "repo"));
+  }, [commitTargets, repositoryRequired, selectedTargets]);
+
+  useEffect(() => {
+    if (multipleSelectionEnabled || selectedTargets.length <= 1) return;
+    commitTargets(collapseToSingleTarget(selectedTargets));
+  }, [commitTargets, multipleSelectionEnabled, selectedTargets]);
+
+  const selectedRepoNames = useMemo(() => repoNamesOf(selectedTargets), [selectedTargets]);
+  const selectedEnvironmentIds = useMemo(
+    () =>
+      selectedTargets.flatMap((target) =>
+        target.kind === "environment" ? [target.environmentId] : []
+      ),
+    [selectedTargets]
+  );
+  const targetCount = selectedTargets.length;
+  const usesSingleRepository = selectedTargets.length === 1 && selectedTargets[0].kind === "repo";
+  const selectedRepoName = selectedRepoNames[0] ?? "";
+  const selectedRepository = usesSingleRepository ? parseRepoFullName(selectedRepoName) : null;
+
+  const toggleRepository = useCallback(
+    (repoFullName: string) => {
+      const target: AutomationSessionTarget = {
+        kind: "repo",
+        repoFullName: repoFullName.toLowerCase(),
+      };
+      if (!multipleSelectionEnabled) {
+        commitTargets([target]);
+        return;
+      }
+
+      const selected = selectedRepoNames.includes(target.repoFullName);
+      if (!selected && targetCount >= MAX_AUTOMATION_REPOSITORIES) return;
+      commitTargets(
+        selected
+          ? selectedTargets.filter(
+              (entry) => !(entry.kind === "repo" && entry.repoFullName === target.repoFullName)
+            )
+          : [...selectedTargets, target]
+      );
+    },
+    [commitTargets, multipleSelectionEnabled, selectedRepoNames, selectedTargets, targetCount]
+  );
+
+  const toggleEnvironment = useCallback(
+    (environmentId: string) => {
+      const target: AutomationSessionTarget = { kind: "environment", environmentId };
+      if (!multipleSelectionEnabled) {
+        commitTargets([target]);
+        return;
+      }
+
+      const selected = selectedEnvironmentIds.includes(environmentId);
+      if (!selected && targetCount >= MAX_AUTOMATION_REPOSITORIES) return;
+      commitTargets(
+        selected
+          ? selectedTargets.filter(
+              (entry) => !(entry.kind === "environment" && entry.environmentId === environmentId)
+            )
+          : [...selectedTargets, target]
+      );
+    },
+    [commitTargets, multipleSelectionEnabled, selectedEnvironmentIds, selectedTargets, targetCount]
+  );
+
+  const clearTargets = useCallback(() => {
+    if (repositoryRequired) return;
+    commitTargets([]);
+  }, [commitTargets, repositoryRequired]);
+
+  const toggleSelectionMode = useCallback(() => {
+    if (!multiRepoAllowed) return;
+
+    if (selectionMode === "multiple") {
+      setSelectionMode("single");
+      if (selectedTargets.length > 1) {
+        commitTargets(collapseToSingleTarget(selectedTargets));
+      }
+      return;
+    }
+
+    setSelectionMode("multiple");
+  }, [commitTargets, multiRepoAllowed, selectionMode, selectedTargets]);
+
+  const buildRepositoriesPayload = useCallback(
+    (): AutomationRepositoryInput[] =>
+      selectedRepoNames.map((key) => {
+        const [entryOwner = "", entryName = ""] = key.split("/");
+        const entry: AutomationRepositoryInput = { repoOwner: entryOwner, repoName: entryName };
+        if (usesSingleRepository) {
+          if (baseBranch.trim()) entry.baseBranch = baseBranch.trim();
+        } else {
+          // Multi-repo selections have no branch picker; keep the branch each
+          // already-selected repository had so an unrelated edit can't reset it.
+          const existing = initialRepositories.find(
+            (repository) => repositoryKey(repository.repoOwner, repository.repoName) === key
+          );
+          if (existing?.baseBranch) entry.baseBranch = existing.baseBranch;
+        }
+        return entry;
+      }),
+    [baseBranch, initialRepositories, selectedRepoNames, usesSingleRepository]
+  );
+
+  const environmentName = (environmentId: string) =>
+    environments.find((environment) => environment.id === environmentId)?.name ??
+    (loadingEnvironments ? "Loading..." : environmentId);
+  const repositoryLabel = (() => {
+    if (targetCount === 0) return NO_REPOSITORY_LABEL;
+    if (selectedRepoNames.length === 1 && selectedEnvironmentIds.length === 0) {
+      return findRepo(selectedRepoName)?.fullName ?? selectedRepoName;
+    }
+    if (selectedEnvironmentIds.length === 1 && selectedRepoNames.length === 0) {
+      return environmentName(selectedEnvironmentIds[0]);
+    }
+    const parts: string[] = [];
+    if (selectedRepoNames.length > 0) {
+      parts.push(
+        selectedRepoNames.length === 1 ? "1 repository" : `${selectedRepoNames.length} repositories`
+      );
+    }
+    if (selectedEnvironmentIds.length > 0) {
+      parts.push(
+        selectedEnvironmentIds.length === 1
+          ? "1 environment"
+          : `${selectedEnvironmentIds.length} environments`
+      );
+    }
+    return parts.join(" + ");
+  })();
+
+  return {
+    selectedRepoNames,
+    selectedEnvironmentIds,
+    targetCount,
+    usesSingleRepository,
+    selectedRepository,
+    repositoryLabel,
+    multipleSelectionEnabled,
+    baseBranch,
+    setBaseBranch,
+    toggleRepository,
+    toggleEnvironment,
+    clearTargets,
+    toggleSelectionMode,
+    buildRepositoriesPayload,
+  };
+}


### PR DESCRIPTION
## Motivation

Committed follow-up from the PR #938 deep review ([form thread](https://github.com/ColeMurray/background-agents/pull/938#discussion_r3554245207), [owner reply](https://github.com/ColeMurray/background-agents/pull/938#discussion_r3554318825)): the automation form kept repository selection and environment binding as two parallel pieces of state (`selectedRepos: string[]`, `selectedEnvironmentIds: string[]`) that cleared each other through callbacks and effects, instead of reusing the shared session-target model in `lib/session-target.ts`.

## Before / after

**Before:** two independent state arrays with cross-clearing conventions — `handleRepoToggle` (single mode) had to remember to clear environments, `handleEnvironmentToggle` had to clear repositories, `handleNoRepository` cleared both, and the single-select collapse effect coordinated across both arrays. Counts, labels, and validation summed the two arrays ad hoc.

**After:** one state value — `selectedTargets: AutomationSessionTarget[]`, where `AutomationSessionTarget = Extract<SessionTarget, { kind: "repo" | "environment" }>` from the shared `lib/session-target.ts` model. The automation's fan-out selection is an ordered list of session targets; the empty list is the repo-less selection. Consequences:

- Mutual exclusivity in single-select mode is structural: replacing the list (`applyTargets([target])`) cannot leave a stale sibling selection behind.
- `selectedRepoNames` / `selectedEnvironmentIds` are derived read-only views (`useMemo` filters), so payload fields, labels, and validation all read from one source of truth.
- The collapse rule is a named pure function (`collapseToSingleTarget`: first repository, else first environment) shared by the mode toggle and the trigger-type effect, instead of two hand-rolled branches over both arrays.
- Branch handling reuses the shared `parseRepoFullName` helper the session-create picker uses.

`useSessionTargetPicker` itself is deliberately **not** reused: it models exactly one target (plus localStorage restore, branch state, and prebuild badges for the new-session page), while the automation form fans out over a repo+environment *set* with a combined cap, a search popover, and repo-scoped trigger gating. Per the #938 discussion, this shares the model and helpers and keeps the form-specific rendering explicit.

## Behavior / payload

No UI or contract changes intended:

- `AutomationFormValues` is unchanged; create/update payloads still send the full `repositories: AutomationRepositoryInput[]` and `environmentIds: string[]` on every submit (empty = none).
- Edit-mode hydration, validation rules (repo-scoped triggers need exactly one repository, combined `MAX_AUTOMATION_REPOSITORIES` cap), single/multi-select behavior, branch reset semantics, and all labels/controls are preserved.
- Preserved subtlety: base-branch recomputation still happens only on repository-membership mutations, so a branch pick survives adding/removing environments around its repo (environment-only mutations bypass `applyTargets`).

## Tests

Added to `automation-form.test.tsx` (37 tests in the suite, all passing):

- replaces a repository with an environment in single-select mode (switching clears old state)
- hydrates a mixed repository + environment selection in edit mode (label + untouched submit)
- keeps the repository when collapsing a mixed selection to single-select

Existing coverage already exercised repo target, multi-repo, environment target, environment→repository switching, multi-environment edit hydration, cap, and repo-scoped trigger gating — all unchanged and passing.

`npm run typecheck`, `npm run lint`, and `npm test -w @open-inspect/web` (58 files, 623 tests) pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automation target selection when mixing repositories and environments, including correct behavior when switching between single- and multi-select modes.
  * Preserved repository/branch choices and updated base-branch handling for single-repo selections and mixed hydrated edits.
  * Fixed submission payloads and selection summaries for environment-only, repository+environment, and mixed repository+environment states.
* **Tests**
  * Added additional coverage for repository/environment selection-collision scenarios in create/edit modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->