### PR TITLE
feat(shared): image-build wire contract

### DIFF
--- a/packages/shared/src/types/image-builds.ts
+++ b/packages/shared/src/types/image-builds.ts
@@ -1,0 +1,74 @@
+/**
+ * Wire contract for the unified image-build subsystem.
+ *
+ * An image build bakes a provider image for a *scope* — either a single
+ * repository or an environment (an ordered repository set). These types
+ * mirror the D1 `image_builds` table and the Modal worker callback payloads;
+ * they are consumed by the control plane, the web BFF, and (by comment
+ * convention) the Python data plane.
+ */
+
+/** Mirrors the `image_builds.status` column. */
+export type ImageBuildStatus = "building" | "ready" | "failed" | "superseded";
+
+/** Mirrors the `image_builds.scope_kind` column. */
+export type ImageBuildScopeKind = "repo" | "environment";
+
+/**
+ * One repository's clone provenance at build time.
+ *
+ * A single cross-language document shape: produced by the sandbox runtime,
+ * echoed through build callbacks, stored verbatim as one entry of the
+ * `image_builds.repository_shas` JSON column, and compared against
+ * `git ls-remote` by the rebuild cron. Keep the field names in sync with
+ * `sandbox_runtime/entrypoint.py` rather than remapping at each boundary.
+ */
+export interface RepositoryShaEntry {
+  repoOwner: string;
+  repoName: string;
+  baseSha: string;
+}
+
+/**
+ * One build row as returned by the image-build status endpoints.
+ *
+ * Mirrors the D1 SELECT in the control plane's `db/image-builds.ts` —
+ * snake_case column names pass through unmapped. `scope_id` is a lowercase
+ * `owner/name` pair for repo scopes and an environment id for environment
+ * scopes. `repository_shas` is the JSON-encoded `RepositoryShaEntry[]`
+ * column value. `provider` values come from the control plane's provider
+ * union (deploy configuration, not part of this contract).
+ */
+export interface ImageBuildRecordView {
+  id: string;
+  scope_kind: ImageBuildScopeKind;
+  scope_id: string;
+  provider: string;
+  status: ImageBuildStatus;
+  repository_shas: string;
+  runtime_version: string;
+  build_duration_seconds: number | null;
+  error_message: string | null;
+  created_at: number;
+}
+
+/**
+ * Success callback POSTed by the Modal build worker
+ * (`image_builder.py`) to `/image-builds/build-complete`.
+ */
+export interface ImageBuildCompleteCallback {
+  build_id: string;
+  provider_image_id: string;
+  repository_shas: RepositoryShaEntry[];
+  runtime_version: string;
+  build_duration_seconds: number;
+}
+
+/**
+ * Failure callback POSTed by the Modal build worker
+ * (`image_builder.py`) to `/image-builds/build-failed`.
+ */
+export interface ImageBuildFailedCallback {
+  build_id: string;
+  error: string;
+}

--- a/packages/shared/src/types/image-builds.ts
+++ b/packages/shared/src/types/image-builds.ts
@@ -36,8 +36,10 @@ export interface RepositoryShaEntry {
  * snake_case column names pass through unmapped. `scope_id` is a lowercase
  * `owner/name` pair for repo scopes and an environment id for environment
  * scopes. `repository_shas` is the JSON-encoded `RepositoryShaEntry[]`
- * column value. `provider` values come from the control plane's provider
- * union (deploy configuration, not part of this contract).
+ * column value — `JSON.parse` before use; `ImageBuildCompleteCallback`
+ * carries the same data already parsed. `provider` values come from the
+ * control plane's provider union (deploy configuration, not part of this
+ * contract).
  */
 export interface ImageBuildRecordView {
   id: string;
@@ -55,6 +57,9 @@ export interface ImageBuildRecordView {
 /**
  * Success callback POSTed by the Modal build worker
  * (`image_builder.py`) to `/image-builds/build-complete`.
+ *
+ * `repository_shas` arrives as a parsed array here and is stored
+ * JSON-encoded (see `ImageBuildRecordView.repository_shas`).
  */
 export interface ImageBuildCompleteCallback {
   build_id: string;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -150,6 +150,15 @@ export type {
   ListAutomationInvocationsResponse,
 } from "./automations";
 
+export type {
+  ImageBuildStatus,
+  ImageBuildScopeKind,
+  RepositoryShaEntry,
+  ImageBuildRecordView,
+  ImageBuildCompleteCallback,
+  ImageBuildFailedCallback,
+} from "./image-builds";
+
 export { ANALYTICS_DAYS, ANALYTICS_BREAKDOWN_BY } from "./analytics";
 export type {
   AnalyticsDays,


### PR DESCRIPTION
Slice 1 of 6 of the image-build unification train (unifying the twin repo-image / environment-image prebuild subsystems into one scope-generic `image-builds` subsystem — design: repo = image of a one-repository set).

Contract-only: adds `packages/shared/src/types/image-builds.ts` with `ImageBuildStatus`, `ImageBuildScopeKind`, `RepositoryShaEntry`, `ImageBuildRecordView`, `ImageBuildCompleteCallback`, `ImageBuildFailedCallback`, exported through the types barrel. No consumers change.

Mirroring sources (doc-commented on each type): the D1 `image_builds` table introduced in slice 2, the status-endpoint SELECT in `db/image-builds.ts`, and the Modal worker callback POST bodies (`image_builder.py`). Python mirrors by comment, as today.

Verification: shared build + typecheck + tests (372 passed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared type definitions for unified image-build statuses and scope kinds.
  * Introduced repository provenance entries and a build record view shape for consistent build status display.
  * Added completion and failure callback payload definitions to standardize how build results are communicated throughout the application.
  * Re-exported these image-build types so they’re available everywhere needed for consistent status handling and events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->