### PR TITLE
fix(control-plane): project status rows to the wire contract

### DIFF
--- a/packages/control-plane/src/db/image-builds.test.ts
+++ b/packages/control-plane/src/db/image-builds.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { ImageBuildStore } from "./image-builds";
+
+/**
+ * The exact `ImageBuildRecordView` wire columns. The status reads must project
+ * these and only these — never the internal callback-token or provider-id
+ * columns the `image_builds` table also carries.
+ */
+const WIRE_KEYS = [
+  "id",
+  "scope_kind",
+  "scope_id",
+  "provider",
+  "status",
+  "repositories_fingerprint",
+  "repository_shas",
+  "runtime_version",
+  "build_duration_seconds",
+  "error_message",
+  "created_at",
+].sort();
+
+const INTERNAL_KEYS = [
+  "callback_token_hash",
+  "callback_token_expires_at",
+  "callback_token_used_at",
+  "provider_session_id",
+  "provider_image_id",
+];
+
+/** A full table row, including the internal columns (Vercel-shape values). */
+const FULL_ROW: Record<string, unknown> = {
+  id: "b1",
+  scope_kind: "environment",
+  scope_id: "env_1",
+  provider: "vercel",
+  status: "ready",
+  repositories_fingerprint: "fp",
+  repository_shas: "[]",
+  runtime_version: "v53",
+  build_duration_seconds: 12,
+  error_message: null,
+  created_at: 1000,
+  callback_token_hash: "hash-secret",
+  callback_token_expires_at: 2000,
+  callback_token_used_at: null,
+  provider_session_id: "session-secret",
+  provider_image_id: "image-secret",
+};
+
+/**
+ * Minimal D1 fake that emulates SQLite column projection: it returns only the
+ * columns named in the SELECT list, so a `SELECT *` regression surfaces as a
+ * leaked internal column rather than being masked by a canned row.
+ */
+function projectRow(query: string): Record<string, unknown> {
+  const normalized = query.replace(/\s+/g, " ").trim();
+  const match = /SELECT (.+?) FROM /.exec(normalized);
+  if (!match) throw new Error(`Unexpected query: ${query}`);
+  const columns = match[1].split(",").map((c) => c.trim());
+  if (columns.length === 1 && columns[0] === "*") return { ...FULL_ROW };
+  const projected: Record<string, unknown> = {};
+  for (const column of columns) projected[column] = FULL_ROW[column];
+  return projected;
+}
+
+function fakeDb(): D1Database {
+  const statement = (query: string) => ({
+    bind: () => statement(query),
+    all: async () => ({ results: [projectRow(query)] }),
+    first: async () => projectRow(query),
+    run: async () => ({ meta: { changes: 0 } }),
+  });
+  return { prepare: (query: string) => statement(query) } as unknown as D1Database;
+}
+
+describe("ImageBuildStore status projection", () => {
+  it("getStatus returns exactly the wire columns", async () => {
+    const rows = await new ImageBuildStore(fakeDb()).getStatus({
+      kind: "environment",
+      id: "env_1",
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(Object.keys(rows[0]).sort()).toEqual(WIRE_KEYS);
+    for (const key of INTERNAL_KEYS) expect(rows[0]).not.toHaveProperty(key);
+  });
+
+  it("getStatusForEnabledScopes returns exactly the wire columns", async () => {
+    const rows = await new ImageBuildStore(fakeDb()).getStatusForEnabledScopes([
+      { kind: "environment", id: "env_1" },
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(Object.keys(rows[0]).sort()).toEqual(WIRE_KEYS);
+    for (const key of INTERNAL_KEYS) expect(rows[0]).not.toHaveProperty(key);
+  });
+});

--- a/packages/control-plane/src/db/image-builds.ts
+++ b/packages/control-plane/src/db/image-builds.ts
@@ -23,10 +23,33 @@ const MAX_SCOPE_IDS_PER_QUERY = 50;
  * reads project this list rather than `SELECT *` so internal columns
  * (callback token, provider session/image ids) never reach a client — the
  * table carries columns the wire contract does not.
+ *
+ * `satisfies` rejects any key outside the wire contract (a leaking column is
+ * a compile error); the exhaustiveness assertion below rejects any wire field
+ * missing from the projection. The integration tests keep independent
+ * hand-written key-set pins on the runtime payload.
  */
-const STATUS_VIEW_COLUMNS =
-  "id, scope_kind, scope_id, provider, status, repositories_fingerprint, " +
-  "repository_shas, runtime_version, build_duration_seconds, error_message, created_at";
+const STATUS_VIEW_KEYS = [
+  "id",
+  "scope_kind",
+  "scope_id",
+  "provider",
+  "status",
+  "repositories_fingerprint",
+  "repository_shas",
+  "runtime_version",
+  "build_duration_seconds",
+  "error_message",
+  "created_at",
+] as const satisfies readonly (keyof ImageBuildRecordView)[];
+
+type MissingStatusViewKey = Exclude<keyof ImageBuildRecordView, (typeof STATUS_VIEW_KEYS)[number]>;
+// Fails to compile — naming the missing key — if ImageBuildRecordView gains a
+// field the projection does not carry.
+const _statusViewComplete: MissingStatusViewKey extends never ? true : MissingStatusViewKey = true;
+void _statusViewComplete;
+
+const STATUS_VIEW_COLUMNS = STATUS_VIEW_KEYS.join(", ");
 
 /** Row slice read by the callback-token auth checks. */
 interface CallbackTokenRow {

--- a/packages/control-plane/src/db/image-builds.ts
+++ b/packages/control-plane/src/db/image-builds.ts
@@ -18,6 +18,16 @@ const MS_PER_SECOND = 1000;
 /** D1 caps bound parameters per statement; IN-list queries chunk below it. */
 const MAX_SCOPE_IDS_PER_QUERY = 50;
 
+/**
+ * The exact `ImageBuildRecordView` wire columns, in declaration order. Status
+ * reads project this list rather than `SELECT *` so internal columns
+ * (callback token, provider session/image ids) never reach a client — the
+ * table carries columns the wire contract does not.
+ */
+const STATUS_VIEW_COLUMNS =
+  "id, scope_kind, scope_id, provider, status, repositories_fingerprint, " +
+  "repository_shas, runtime_version, build_duration_seconds, error_message, created_at";
+
 /** Row slice read by the callback-token auth checks. */
 interface CallbackTokenRow {
   id: string;
@@ -41,7 +51,12 @@ export interface ImageBuildRegistration {
   callbackTokenExpiresAt?: number;
 }
 
-/** One full row. Mirrors the `image_builds` table (migration 0039). */
+/**
+ * One full row, including the internal columns (callback token, provider
+ * session/image ids). Mirrors the `image_builds` table (migration 0039).
+ * Internal row — never serialized to clients; the outward wire contract is
+ * `ImageBuildRecordView`, and status reads project exactly its columns.
+ */
 export interface ImageBuildRow extends ImageBuildRecordView {
   provider: ImageBuildProvider;
   provider_image_id: string | null;
@@ -610,13 +625,13 @@ export class ImageBuildStore {
   }
 
   /** Per-scope recent non-superseded rows (settings UI / debugging view). */
-  async getStatus(scope: ImageBuildScope): Promise<ImageBuildRow[]> {
+  async getStatus(scope: ImageBuildScope): Promise<ImageBuildRecordView[]> {
     const result = await this.db
       .prepare(
-        "SELECT * FROM image_builds WHERE scope_kind = ? AND scope_id = ? AND status <> 'superseded' ORDER BY created_at DESC LIMIT 10"
+        `SELECT ${STATUS_VIEW_COLUMNS} FROM image_builds WHERE scope_kind = ? AND scope_id = ? AND status <> 'superseded' ORDER BY created_at DESC LIMIT 10`
       )
       .bind(scope.kind, scope.id)
-      .all<ImageBuildRow>();
+      .all<ImageBuildRecordView>();
 
     return result.results || [];
   }
@@ -630,7 +645,7 @@ export class ImageBuildStore {
    * via the cleanup pass, and a row cap would just reintroduce the risk of
    * ready images dropping out of the cron's view and re-triggering forever.
    */
-  async getStatusForEnabledScopes(scopes: ImageBuildScope[]): Promise<ImageBuildRow[]> {
+  async getStatusForEnabledScopes(scopes: ImageBuildScope[]): Promise<ImageBuildRecordView[]> {
     const idsByKind = new Map<ImageBuildScopeKind, string[]>();
     for (const scope of scopes) {
       const ids = idsByKind.get(scope.kind) ?? [];
@@ -638,18 +653,18 @@ export class ImageBuildStore {
       idsByKind.set(scope.kind, ids);
     }
 
-    const rows: ImageBuildRow[] = [];
+    const rows: ImageBuildRecordView[] = [];
     for (const [kind, ids] of idsByKind) {
       for (let offset = 0; offset < ids.length; offset += MAX_SCOPE_IDS_PER_QUERY) {
         const chunk = ids.slice(offset, offset + MAX_SCOPE_IDS_PER_QUERY);
         const placeholders = chunk.map(() => "?").join(", ");
         const result = await this.db
           .prepare(
-            `SELECT * FROM image_builds
+            `SELECT ${STATUS_VIEW_COLUMNS} FROM image_builds
              WHERE scope_kind = ? AND scope_id IN (${placeholders}) AND status <> 'superseded'`
           )
           .bind(kind, ...chunk)
-          .all<ImageBuildRow>();
+          .all<ImageBuildRecordView>();
         rows.push(...(result.results || []));
       }
     }

--- a/packages/control-plane/src/routes/image-builds.ts
+++ b/packages/control-plane/src/routes/image-builds.ts
@@ -9,8 +9,8 @@
  * - Maintenance operations (stale builds, cleanup + superseded-artifact reaping)
  */
 
-import type { RepositoryShaEntry } from "@open-inspect/shared";
-import { ImageBuildStore, type ImageBuildRow } from "../db/image-builds";
+import type { ImageBuildRecordView, RepositoryShaEntry } from "@open-inspect/shared";
+import { ImageBuildStore } from "../db/image-builds";
 import { RepoMetadataStore } from "../db/repo-metadata";
 import { createLogger } from "../logger";
 import { getImageBuildCallbackBearerToken } from "../image-builds/callback-auth";
@@ -485,7 +485,10 @@ function parseScopeParams(request: Request): ImageBuildScope | null | Response {
   return { kind: scopeKind, id: scopeId };
 }
 
-async function readStatusRows(env: Env, scope: ImageBuildScope | null): Promise<ImageBuildRow[]> {
+async function readStatusRows(
+  env: Env,
+  scope: ImageBuildScope | null
+): Promise<ImageBuildRecordView[]> {
   const store = new ImageBuildStore(env.DB);
   if (scope) return store.getStatus(scope);
   return store.getStatusForEnabledScopes(await listEnabledScopes(env.DB));
@@ -496,8 +499,9 @@ async function readStatusRows(env: Env, scope: ImageBuildScope | null): Promise<
  * With a scope: that scope's recent non-superseded rows (the settings UI /
  * debugging view). Without: the cron's cross-scope view over every
  * prebuild-enabled scope — non-superseded, so failed builds are visible in
- * the aggregate feed. Rows are returned verbatim (snake_case columns;
- * repository_shas is a JSON document).
+ * the aggregate feed. Rows are the `ImageBuildRecordView` projection
+ * (snake_case columns; repository_shas is a JSON document) — the store drops
+ * internal columns, so no callback token or provider id reaches a client.
  */
 async function handleGetStatus(
   request: Request,

--- a/packages/control-plane/test/integration/image-builds.test.ts
+++ b/packages/control-plane/test/integration/image-builds.test.ts
@@ -29,6 +29,25 @@ const BASE = "https://test.local";
 const RUNTIME_VERSION = "v53-list-native-runtime";
 const REPOSITORY_SHAS = [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }];
 
+/**
+ * The exact key set of the `ImageBuildRecordView` wire contract. The status
+ * endpoints must serve these and only these — no callback-token or
+ * provider-internal columns.
+ */
+const WIRE_KEYS = [
+  "id",
+  "scope_kind",
+  "scope_id",
+  "provider",
+  "status",
+  "repositories_fingerprint",
+  "repository_shas",
+  "runtime_version",
+  "build_duration_seconds",
+  "error_message",
+  "created_at",
+].sort();
+
 function environmentScope(id: string): ImageBuildScope {
   return { kind: "environment", id };
 }
@@ -112,6 +131,41 @@ async function seedImageRow(row: {
   createdAt?: number;
 }): Promise<void> {
   await seedImageRowForScope(environmentScope(row.environmentId), row);
+}
+
+/**
+ * The Vercel/OpenComputer shape: a row whose internal columns carry real
+ * values (Modal rows leave them null). If a status read leaks columns, this is
+ * the row that exposes a live callback-token hash and provider ids.
+ */
+async function seedRowWithInternalColumns(scope: ImageBuildScope, id: string): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO image_builds
+       (id, scope_kind, scope_id, provider, provider_image_id, provider_session_id,
+        callback_token_hash, callback_token_expires_at, callback_token_used_at,
+        repositories_fingerprint, repository_shas, runtime_version, status,
+        build_duration_seconds, error_message, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  )
+    .bind(
+      id,
+      scope.kind,
+      scope.id,
+      "vercel",
+      "vercel-image-secret",
+      "vercel-session-secret",
+      "callback-token-hash-secret",
+      Date.now() + 60_000,
+      null,
+      "fp-seeded",
+      JSON.stringify(REPOSITORY_SHAS),
+      RUNTIME_VERSION,
+      "ready",
+      12,
+      null,
+      Date.now()
+    )
+    .run();
 }
 
 async function getRow(id: string) {
@@ -469,6 +523,41 @@ describe("Image builds", () => {
       );
       const filteredBody = (await filtered.json()) as { images: Array<{ id: string }> };
       expect(filteredBody.images.map((i) => i.id)).toEqual(["st-ready", "st-failed"]);
+    });
+
+    it("GET /image-builds/status projects only the wire columns (no internal fields)", async () => {
+      const environmentId = await seedEnvironment({ prebuildEnabled: true });
+      await seedRowWithInternalColumns(environmentScope(environmentId), "leak-check");
+
+      const assertWireKeysOnly = (images: Array<Record<string, unknown>>) => {
+        expect(images).toHaveLength(1);
+        expect(Object.keys(images[0]).sort()).toEqual(WIRE_KEYS);
+        // Redundant with the exact-key-set check, but names the offenders.
+        for (const internal of [
+          "callback_token_hash",
+          "callback_token_expires_at",
+          "callback_token_used_at",
+          "provider_session_id",
+          "provider_image_id",
+        ]) {
+          expect(images[0]).not.toHaveProperty(internal);
+        }
+      };
+
+      const cross = await SELF.fetch(`${BASE}/image-builds/status`, {
+        headers: await authHeaders(),
+      });
+      assertWireKeysOnly(
+        ((await cross.json()) as { images: Array<Record<string, unknown>> }).images
+      );
+
+      const perScope = await SELF.fetch(
+        `${BASE}/image-builds/status?scope_kind=environment&scope_id=${environmentId}`,
+        { headers: await authHeaders() }
+      );
+      assertWireKeysOnly(
+        ((await perScope.json()) as { images: Array<Record<string, unknown>> }).images
+      );
     });
 
     it("GET /image-builds/status rejects a scope_kind/scope_id half-pair", async () => {


### PR DESCRIPTION
## The exposure

`GET /image-builds/status` (cross-scope and per-scope) served full D1 `image_builds`
rows to callers. The store's `getStatus`/`getStatusForEnabledScopes` used `SELECT *`
and typed results as the internal `ImageBuildRow`, so the JSON carried five columns
that are **not** part of the `ImageBuildRecordView` wire contract:

- `callback_token_hash`
- `callback_token_expires_at`
- `callback_token_used_at`
- `provider_session_id`
- `provider_image_id`

The web BFF proxies this endpoint to the browser and casts the payload
`as ImageBuildRecordView[]` — a compile-time cast that strips nothing at runtime — so
**every logged-in user's browser received these fields for every prebuild-enabled
scope.** Modal-built rows leave the callback-token/provider-session columns null, but
Vercel/OpenComputer builds populate a real callback-token hash and provider ids, so on
those providers this leaked live secret material and provider-internal identifiers.

The declared wire type and the actual payload had silently diverged.

## The fix

Both status-serving reads now project **exactly** the `ImageBuildRecordView` columns
via an explicit, shared column list (`STATUS_VIEW_COLUMNS`) and are typed
`ImageBuildRecordView`, not `ImageBuildRow`. The route's `readStatusRows` return type is
tightened to match. Internal reads that legitimately need the extra columns are
untouched — `getLatestReadyForSpawn` (spawn selection) keeps `SELECT *`, and the
callback-token / reaper / superseded reads already select explicit internal columns.
`ImageBuildRow`'s doc comment now states it is an internal row, never serialized to
clients.

### Queries changed vs. left alone

- **Changed** (`SELECT *` → projected wire columns): `getStatus`,
  `getStatusForEnabledScopes` — the only two reads that serve the outward status feed.
- **Left `SELECT *` deliberately**: `getLatestReadyForSpawn` — internal spawn-time image
  selection, needs `provider_image_id`/`provider_session_id`; never serialized.
- Internal reads already scoped (`readCallbackTokenRow`, `getCallbackBuild`,
  `getBuildRow`, `getSupersededImages`, the mark-ready supersede scan) list explicit
  internal columns and are correct as-is.

## Sweep of other outward serializations

Audited every handler in `routes/image-builds.ts` that returns store data outward:

- `handleGetStatus` → the leak (fixed).
- `handleGetEnabledUnits` — maps to an explicit `{ scopeKind, scopeId,
  repositoriesFingerprint, repositories }` shape; no row passthrough.
- `handleGetEnabledRepos` — `RepoMetadataStore.getImageBuildEnabledRepos()`, a separate
  store returning repo flags; no image-build columns.
- `handleMarkStale`, `handleCleanup`, trigger handlers, build callbacks — return counts
  / ids / `{ ok }` only.

No other endpoint leaked internal columns.

## Tests

- **Integration** (`test/integration/image-builds.test.ts`): seeds a Vercel-shape row
  with `callback_token_hash`, `provider_session_id`, `provider_image_id` populated, hits
  the cross-scope **and** per-scope status endpoints, and asserts the JSON rows' key set
  is **exactly** the `ImageBuildRecordView` keys (plus an explicit not-to-have check on
  each internal field). This is the regression pin — an exact key-set assertion, not
  mere absence of one field.
- **Unit** (`src/db/image-builds.test.ts`): a projection-emulating D1 fake proves
  `getStatus`/`getStatusForEnabledScopes` carry exactly the projected columns; reverting
  to `SELECT *` turns it red (verified: 15 keys vs 10).
- Existing suites stay green — spawn selection and the callback flows still read their
  internal columns. Full gate: shared build, typecheck, lint, control-plane unit
  (1683) + integration (505), web (669) all pass.

## Provenance

Finding #2 from the post-train audit of the image-build unification (#947–#952). The
leak most likely predates the unification — inherited from the old `environment_images`
status path — but it lives in the unified subsystem now and is fixed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated image build status endpoints to return only the intended public fields, omitting internal callback/provider metadata.
  * Kept existing filtering and result ordering consistent for both single-scope and multi-scope status requests.
* **Tests**
  * Added unit and integration coverage that verifies the exact response field set and fails if internal-only fields ever appear.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->