### PR TITLE
fix(control-plane): reap provider artifacts from failed image builds

### DIFF
--- a/packages/control-plane/src/db/image-builds.ts
+++ b/packages/control-plane/src/db/image-builds.ts
@@ -52,8 +52,8 @@ export interface ImageBuildRow extends ImageBuildRecordView {
   callback_token_used_at: number | null;
 }
 
-/** Superseded row carrying its provider artifact (if any) for the reaper. */
-export interface SupersededImageBuildRow {
+/** A row carrying its provider artifact (if any) for the reaper to reclaim. */
+export interface ReapableImageBuildRow {
   id: string;
   scope_kind: ImageBuildScopeKind;
   scope_id: string;
@@ -663,7 +663,7 @@ export class ImageBuildStore {
    * (mark-ready replacing an older ready) and out-of-band (entity delete,
    * secret change), so cleanup sweeps whatever is left.
    */
-  async getSupersededImages(limit: number): Promise<SupersededImageBuildRow[]> {
+  async getSupersededImages(limit: number): Promise<ReapableImageBuildRow[]> {
     const result = await this.db
       .prepare(
         `SELECT id, scope_kind, scope_id, provider, provider_image_id, provider_session_id
@@ -671,9 +671,50 @@ export class ImageBuildStore {
          ORDER BY created_at ASC LIMIT ?`
       )
       .bind(limit)
-      .all<SupersededImageBuildRow>();
+      .all<ReapableImageBuildRow>();
 
     return result.results || [];
+  }
+
+  /**
+   * Failed rows still pointing at a provider artifact, for the reaper to
+   * reclaim. A restore-failed spawn flips a ready row to failed while it still
+   * carries a live provider_image_id (Modal snapshots never expire), so the
+   * artifact must be deleted before the age-based sweep may remove the row.
+   * The failed row itself is kept — its error_message stays visible in the
+   * status feeds — until clearFailedImageArtifact nulls its artifact columns.
+   */
+  async getFailedImagesWithArtifacts(limit: number): Promise<ReapableImageBuildRow[]> {
+    const result = await this.db
+      .prepare(
+        `SELECT id, scope_kind, scope_id, provider, provider_image_id, provider_session_id
+         FROM image_builds WHERE status = 'failed' AND provider_image_id IS NOT NULL
+         ORDER BY created_at ASC LIMIT ?`
+      )
+      .bind(limit)
+      .all<ReapableImageBuildRow>();
+
+    return result.results || [];
+  }
+
+  /**
+   * Terminal reaper action for a failed row whose provider artifact was
+   * deleted: null the artifact columns while keeping status='failed' and its
+   * error_message. Scoped to status='failed' so a concurrent rebuild that
+   * already superseded/replaced the row can never have its live artifact
+   * cleared. Idempotent — a row with no artifact is not re-selected by
+   * getFailedImagesWithArtifacts.
+   */
+  async clearFailedImageArtifact(imageBuildId: string): Promise<boolean> {
+    const result = await this.db
+      .prepare(
+        `UPDATE image_builds SET provider_image_id = NULL, provider_session_id = NULL
+         WHERE id = ? AND status = 'failed'`
+      )
+      .bind(imageBuildId)
+      .run();
+
+    return (result.meta?.changes ?? 0) > 0;
   }
 
   async markStaleBuildsAsFailed(maxAgeMs: number): Promise<number> {
@@ -688,10 +729,19 @@ export class ImageBuildStore {
     return result.meta?.changes ?? 0;
   }
 
+  /**
+   * Age out failed rows once they hold no provider artifact. The
+   * provider_image_id IS NULL guard keeps a restore-failed row (which carries
+   * a live artifact) from being hard-deleted before the reaper reclaims the
+   * artifact and nulls its columns, which would otherwise orphan the snapshot.
+   */
   async deleteOldFailedBuilds(maxAgeMs: number): Promise<number> {
     const cutoff = Date.now() - maxAgeMs;
     const result = await this.db
-      .prepare("DELETE FROM image_builds WHERE status = 'failed' AND created_at < ?")
+      .prepare(
+        `DELETE FROM image_builds
+         WHERE status = 'failed' AND provider_image_id IS NULL AND created_at < ?`
+      )
       .bind(cutoff)
       .run();
 

--- a/packages/control-plane/src/db/image-builds.ts
+++ b/packages/control-plane/src/db/image-builds.ts
@@ -702,16 +702,22 @@ export class ImageBuildStore {
    * deleted: null the artifact columns while keeping status='failed' and its
    * error_message. Scoped to status='failed' so a concurrent rebuild that
    * already superseded/replaced the row can never have its live artifact
-   * cleared. Idempotent — a row with no artifact is not re-selected by
-   * getFailedImagesWithArtifacts.
+   * cleared, and to the exact provider_image_id the caller reaped so a newer
+   * artifact attached to the same failed row between select and clear is never
+   * nulled without being deleted provider-side. Idempotent — a row with no
+   * artifact is not re-selected by getFailedImagesWithArtifacts. A null id
+   * (never produced by that selector) matches nothing and clears no row.
    */
-  async clearFailedImageArtifact(imageBuildId: string): Promise<boolean> {
+  async clearFailedImageArtifact(
+    imageBuildId: string,
+    reapedProviderImageId: string | null
+  ): Promise<boolean> {
     const result = await this.db
       .prepare(
         `UPDATE image_builds SET provider_image_id = NULL, provider_session_id = NULL
-         WHERE id = ? AND status = 'failed'`
+         WHERE id = ? AND status = 'failed' AND provider_image_id = ?`
       )
-      .bind(imageBuildId)
+      .bind(imageBuildId, reapedProviderImageId)
       .run();
 
     return (result.meta?.changes ?? 0) > 0;

--- a/packages/control-plane/src/image-builds/reaper.ts
+++ b/packages/control-plane/src/image-builds/reaper.ts
@@ -1,4 +1,4 @@
-import type { ImageBuildStore } from "../db/image-builds";
+import type { ImageBuildStore, ReapableImageBuildRow } from "../db/image-builds";
 import { createLogger } from "../logger";
 import type { ImageBuildProvider, SupersededImageBuild } from "./model";
 import type { ImageBuildAdapterFactory } from "./provider-factory";
@@ -6,8 +6,10 @@ import type { AnyImageBuildAdapter, ImageBuildWorkflowContext } from "./types";
 
 const logger = createLogger("image-builds:reaper");
 
-/** Superseded rows reclaimed per cleanup pass; leftovers wait for the next tick. */
-const SUPERSEDED_REAP_BATCH_LIMIT = 25;
+/** Rows reclaimed per cleanup pass, per sweep; leftovers wait for the next tick. */
+const REAP_BATCH_LIMIT = 25;
+
+type AdapterCache = Map<ImageBuildProvider, AnyImageBuildAdapter | null>;
 
 /**
  * Best-effort provider-artifact reclamation: inline deletion of images a
@@ -22,31 +24,65 @@ export class ImageBuildReaper {
   ) {}
 
   /**
-   * Cleanup pass: delete old failed rows, then reap superseded rows — delete
-   * the provider artifact (when one was recorded) and only then the row, so a
-   * failed artifact delete is retried on the next pass. Covers both inline
-   * supersedes whose deletion failed and out-of-band supersedes (entity
-   * delete, secret change), which nothing deletes inline.
+   * Cleanup pass. Reaps provider artifacts through one best-effort machinery:
+   *
+   * - Failed-with-artifact rows first (restore-failed spawns leave a live
+   *   provider_image_id on a failed row): delete the artifact, then null the
+   *   row's artifact columns while keeping it `failed` so its error_message
+   *   stays visible. Doing this before the age sweep lets a now-artifact-free
+   *   old row be deleted in the same pass.
+   * - Old failed rows: deleted only once artifact-free (the store scopes the
+   *   DELETE to provider_image_id IS NULL).
+   * - Superseded rows: delete the artifact (when one was recorded), then the
+   *   row itself. Covers inline supersedes whose deletion failed and
+   *   out-of-band supersedes (entity delete, secret change).
+   *
+   * Every artifact delete degrades instead of throwing — a failed delete
+   * leaves the artifact on its row for the next tick to retry.
    */
   async cleanupImages(
     failedMaxAgeMs: number,
     ctx: ImageBuildWorkflowContext
-  ): Promise<{ deletedFailed: number; reapedSuperseded: number }> {
+  ): Promise<{ deletedFailed: number; reapedFailed: number; reapedSuperseded: number }> {
+    const adapters: AdapterCache = new Map();
+
+    const reapedFailed = await this.reapArtifactBearingRows(
+      await this.store.getFailedImagesWithArtifacts(REAP_BATCH_LIMIT),
+      ctx,
+      adapters,
+      (row) => this.store.clearFailedImageArtifact(row.id)
+    );
+
     const deletedFailed = await this.store.deleteOldFailedBuilds(failedMaxAgeMs);
 
-    const superseded = await this.store.getSupersededImages(SUPERSEDED_REAP_BATCH_LIMIT);
-    let reapedSuperseded = 0;
-    const adaptersByProvider = new Map<ImageBuildProvider, AnyImageBuildAdapter | null>();
+    const reapedSuperseded = await this.reapArtifactBearingRows(
+      await this.store.getSupersededImages(REAP_BATCH_LIMIT),
+      ctx,
+      adapters,
+      (row) => this.store.deleteSupersededImage(row.id)
+    );
+
+    return { deletedFailed, reapedFailed, reapedSuperseded };
+  }
+
+  /**
+   * Shared reap loop: for each artifact-bearing row, delete the provider
+   * artifact best-effort and run the terminal store action only once it is
+   * gone, so a failed provider delete keeps the artifact on its row. Rows with
+   * no artifact skip straight to the terminal action (a bare superseded row is
+   * reaped directly). Returns how many terminal actions committed.
+   */
+  private async reapArtifactBearingRows(
+    rows: ReapableImageBuildRow[],
+    ctx: ImageBuildWorkflowContext,
+    adapters: AdapterCache,
+    commit: (row: ReapableImageBuildRow) => Promise<boolean>
+  ): Promise<number> {
+    let reaped = 0;
     await Promise.all(
-      superseded.map(async (row) => {
+      rows.map(async (row) => {
         if (row.provider_image_id) {
-          if (!adaptersByProvider.has(row.provider)) {
-            adaptersByProvider.set(
-              row.provider,
-              this.createAdapterForBestEffortCleanup(row.provider, row.id, ctx)
-            );
-          }
-          const adapter = adaptersByProvider.get(row.provider) ?? null;
+          const adapter = this.resolveCleanupAdapter(row.provider, row.id, ctx, adapters);
           if (!adapter) return;
           const deleted = await this.deleteImageBestEffort(
             row.provider,
@@ -59,13 +95,22 @@ export class ImageBuildReaper {
           );
           if (!deleted) return;
         }
-        if (await this.store.deleteSupersededImage(row.id)) {
-          reapedSuperseded += 1;
-        }
+        if (await commit(row)) reaped += 1;
       })
     );
+    return reaped;
+  }
 
-    return { deletedFailed, reapedSuperseded };
+  private resolveCleanupAdapter(
+    provider: ImageBuildProvider,
+    buildId: string,
+    ctx: ImageBuildWorkflowContext,
+    adapters: AdapterCache
+  ): AnyImageBuildAdapter | null {
+    if (!adapters.has(provider)) {
+      adapters.set(provider, this.createAdapterForBestEffortCleanup(provider, buildId, ctx));
+    }
+    return adapters.get(provider) ?? null;
   }
 
   /** Delete the artifacts (and rows) of images a newer ready build replaced. */

--- a/packages/control-plane/src/image-builds/reaper.ts
+++ b/packages/control-plane/src/image-builds/reaper.ts
@@ -50,7 +50,7 @@ export class ImageBuildReaper {
       await this.store.getFailedImagesWithArtifacts(REAP_BATCH_LIMIT),
       ctx,
       adapters,
-      (row) => this.store.clearFailedImageArtifact(row.id)
+      (row) => this.store.clearFailedImageArtifact(row.id, row.provider_image_id)
     );
 
     const deletedFailed = await this.store.deleteOldFailedBuilds(failedMaxAgeMs);

--- a/packages/control-plane/src/image-builds/workflow.test.ts
+++ b/packages/control-plane/src/image-builds/workflow.test.ts
@@ -961,7 +961,7 @@ describe("ImageBuildWorkflow", () => {
       );
       // The failed row itself is kept for visibility — only the artifact
       // columns are nulled; it is never reaped as a superseded row.
-      expect(store.clearFailedImageArtifact).toHaveBeenCalledWith("f-restore");
+      expect(store.clearFailedImageArtifact).toHaveBeenCalledWith("f-restore", "im-restore");
       expect(store.deleteSupersededImage).not.toHaveBeenCalledWith("f-restore");
     });
 

--- a/packages/control-plane/src/image-builds/workflow.test.ts
+++ b/packages/control-plane/src/image-builds/workflow.test.ts
@@ -45,6 +45,8 @@ function createStore() {
     deleteSupersededImage: vi.fn().mockResolvedValue(true),
     supersedeActiveImages: vi.fn().mockResolvedValue(0),
     getSupersededImages: vi.fn().mockResolvedValue([]),
+    getFailedImagesWithArtifacts: vi.fn().mockResolvedValue([]),
+    clearFailedImageArtifact: vi.fn().mockResolvedValue(true),
     deleteOldFailedBuilds: vi.fn().mockResolvedValue(0),
     markStaleBuildsAsFailed: vi.fn().mockResolvedValue(0),
     getStatus: vi.fn().mockResolvedValue([]),
@@ -906,34 +908,24 @@ describe("ImageBuildWorkflow", () => {
   });
 
   describe("cleanupImages", () => {
+    function reapableRow(id: string, providerImageId: string | null) {
+      return {
+        id,
+        scope_kind: "environment" as const,
+        scope_id: "env_1",
+        provider: "modal" as const,
+        provider_image_id: providerImageId,
+        provider_session_id: null,
+      };
+    }
+
     it("deletes old failed rows and reaps superseded artifacts", async () => {
       const store = createStore();
       store.deleteOldFailedBuilds.mockResolvedValue(3);
       store.getSupersededImages.mockResolvedValue([
-        {
-          id: "s-artifact",
-          scope_kind: "environment",
-          scope_id: "env_1",
-          provider: "modal",
-          provider_image_id: "im-a",
-          provider_session_id: null,
-        },
-        {
-          id: "s-bare",
-          scope_kind: "environment",
-          scope_id: "env_1",
-          provider: "modal",
-          provider_image_id: null,
-          provider_session_id: null,
-        },
-        {
-          id: "s-stuck",
-          scope_kind: "environment",
-          scope_id: "env_1",
-          provider: "modal",
-          provider_image_id: "im-stuck",
-          provider_session_id: null,
-        },
+        reapableRow("s-artifact", "im-a"),
+        reapableRow("s-bare", null),
+        reapableRow("s-stuck", "im-stuck"),
       ]);
       const adapter = createAdapter();
       adapter.deleteImage.mockImplementation(async ({ image }) => {
@@ -945,10 +937,61 @@ describe("ImageBuildWorkflow", () => {
 
       // s-artifact: artifact deleted then row reaped. s-bare: no artifact, row
       // reaped directly. s-stuck: artifact delete failed, row kept for retry.
-      expect(result).toEqual({ deletedFailed: 3, reapedSuperseded: 2 });
+      expect(result).toEqual({ deletedFailed: 3, reapedFailed: 0, reapedSuperseded: 2 });
       expect(store.deleteSupersededImage).toHaveBeenCalledWith("s-artifact");
       expect(store.deleteSupersededImage).toHaveBeenCalledWith("s-bare");
       expect(store.deleteSupersededImage).not.toHaveBeenCalledWith("s-stuck");
+    });
+
+    it("reaps a restore-failed row's artifact then clears its columns, keeping it failed", async () => {
+      const store = createStore();
+      store.getFailedImagesWithArtifacts.mockResolvedValue([
+        reapableRow("f-restore", "im-restore"),
+      ]);
+      const adapter = createAdapter();
+      const { workflow } = createWorkflow({ store, adapter });
+
+      const result = await workflow.cleanupImages(86_400_000, ctx);
+
+      expect(result.reapedFailed).toBe(1);
+      expect(adapter.deleteImage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          image: { providerImageId: "im-restore", providerSessionId: null },
+        })
+      );
+      // The failed row itself is kept for visibility — only the artifact
+      // columns are nulled; it is never reaped as a superseded row.
+      expect(store.clearFailedImageArtifact).toHaveBeenCalledWith("f-restore");
+      expect(store.deleteSupersededImage).not.toHaveBeenCalledWith("f-restore");
+    });
+
+    it("keeps a failed row's artifact when the provider delete fails", async () => {
+      const store = createStore();
+      store.getFailedImagesWithArtifacts.mockResolvedValue([reapableRow("f-stuck", "im-stuck")]);
+      const adapter = createAdapter();
+      adapter.deleteImage.mockRejectedValue(new Error("provider 500"));
+      const { workflow } = createWorkflow({ store, adapter });
+
+      const result = await workflow.cleanupImages(86_400_000, ctx);
+
+      // Artifact not lost: the columns are left intact so the next tick retries.
+      expect(result.reapedFailed).toBe(0);
+      expect(store.clearFailedImageArtifact).not.toHaveBeenCalled();
+    });
+
+    it("does not select already-reaped failed rows (idempotent across ticks)", async () => {
+      const store = createStore();
+      // getFailedImagesWithArtifacts only returns artifact-bearing rows, so a
+      // previously-cleared failed row never reaches the adapter again.
+      store.getFailedImagesWithArtifacts.mockResolvedValue([]);
+      const adapter = createAdapter();
+      const { workflow } = createWorkflow({ store, adapter });
+
+      const result = await workflow.cleanupImages(86_400_000, ctx);
+
+      expect(result.reapedFailed).toBe(0);
+      expect(adapter.deleteImage).not.toHaveBeenCalled();
+      expect(store.clearFailedImageArtifact).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/control-plane/src/image-builds/workflow.ts
+++ b/packages/control-plane/src/image-builds/workflow.ts
@@ -741,7 +741,7 @@ export class ImageBuildWorkflow {
   async cleanupImages(
     failedMaxAgeMs: number,
     ctx: ImageBuildWorkflowContext
-  ): Promise<{ deletedFailed: number; reapedSuperseded: number }> {
+  ): Promise<{ deletedFailed: number; reapedFailed: number; reapedSuperseded: number }> {
     return this.reaper.cleanupImages(failedMaxAgeMs, ctx);
   }
 

--- a/packages/control-plane/src/routes/image-builds.ts
+++ b/packages/control-plane/src/routes/image-builds.ts
@@ -639,8 +639,8 @@ async function handleMarkStale(
 
 /**
  * POST /image-builds/cleanup
- * Delete old failed builds and reap superseded rows' provider artifacts.
- * Called by scheduler.
+ * Reap provider artifacts from failed and superseded rows, then delete old
+ * (artifact-free) failed rows. Called by scheduler.
  */
 async function handleCleanup(
   request: Request,
@@ -665,6 +665,7 @@ async function handleCleanup(
 
     logger.info("image_build.cleanup", {
       deleted: result.deletedFailed,
+      reaped_failed: result.reapedFailed,
       reaped_superseded: result.reapedSuperseded,
       max_age_seconds: maxAgeMs / MS_PER_SECOND,
       request_id: ctx.request_id,
@@ -674,6 +675,7 @@ async function handleCleanup(
     return json({
       ok: true,
       deleted: result.deletedFailed,
+      reapedFailed: result.reapedFailed,
       reapedSuperseded: result.reapedSuperseded,
     });
   } catch (e) {

--- a/packages/control-plane/test/integration/image-builds.test.ts
+++ b/packages/control-plane/test/integration/image-builds.test.ts
@@ -19,9 +19,13 @@ import { computeRepositoriesFingerprint } from "../../src/image-builds/fingerpri
 import {
   MIN_COMPATIBLE_RUNTIME_VERSION,
   repoImageBuildScope,
+  type ImageBuildProvider,
   type ImageBuildScope,
 } from "../../src/image-builds/model";
+import type { ImageBuildAdapterFactory } from "../../src/image-builds/provider-factory";
+import { ImageBuildReaper } from "../../src/image-builds/reaper";
 import { resolveScopeEnabled } from "../../src/image-builds/scope";
+import type { AnyImageBuildAdapter, DeleteImageInput } from "../../src/image-builds/types";
 import { evaluateImageBuildForSpawn } from "../../src/sandbox/lifecycle/image-selection";
 import { cleanD1Tables } from "./cleanup";
 
@@ -526,6 +530,17 @@ describe("Image builds", () => {
         status: "superseded",
         providerImageId: "im-artifact",
       });
+      // Restore-failed row carrying a live artifact and old enough to age out:
+      // with the adapter unconfigured the artifact can't be reaped, so the row
+      // must NOT be hard-deleted (that was the leak — the snapshot would be
+      // orphaned forever). It survives, artifact intact, for a later pass.
+      await seedImageRow({
+        id: "old-failed-with-artifact",
+        environmentId,
+        status: "failed",
+        providerImageId: "im-restore-orphan",
+        createdAt: Date.now() - 100_000_000,
+      });
 
       const response = await SELF.fetch(`${BASE}/image-builds/cleanup`, {
         method: "POST",
@@ -534,12 +549,59 @@ describe("Image builds", () => {
       });
 
       expect(response.status).toBe(200);
-      const body = (await response.json()) as { deleted: number; reapedSuperseded: number };
+      const body = (await response.json()) as {
+        deleted: number;
+        reapedFailed: number;
+        reapedSuperseded: number;
+      };
       expect(body.deleted).toBe(1);
+      expect(body.reapedFailed).toBe(0);
       expect(body.reapedSuperseded).toBe(1);
       expect(await getRow("old-failed")).toBeNull();
       expect(await getRow("bare-superseded")).toBeNull();
       expect((await getRow("artifact-superseded"))?.status).toBe("superseded");
+      const survivor = await getRow("old-failed-with-artifact");
+      expect(survivor?.status).toBe("failed");
+      expect(survivor?.provider_image_id).toBe("im-restore-orphan");
+    });
+
+    it("deleteOldFailedBuilds ages out only artifact-free failed rows", async () => {
+      const environmentId = await seedEnvironment();
+      const store = new ImageBuildStore(env.DB);
+      await seedImageRow({
+        id: "clean-old",
+        environmentId,
+        status: "failed",
+        createdAt: Date.now() - 100_000_000,
+      });
+      await seedImageRow({
+        id: "artifact-old",
+        environmentId,
+        status: "failed",
+        providerImageId: "im-live",
+        createdAt: Date.now() - 100_000_000,
+      });
+
+      expect(await store.deleteOldFailedBuilds(86_400_000)).toBe(1);
+      expect(await getRow("clean-old")).toBeNull();
+      // Still points at a live snapshot — the reaper must clear it first.
+      expect((await getRow("artifact-old"))?.status).toBe("failed");
+
+      // getFailedImagesWithArtifacts exposes exactly the artifact-bearing row.
+      const reapable = await store.getFailedImagesWithArtifacts(25);
+      expect(reapable.map((r) => r.id)).toEqual(["artifact-old"]);
+
+      // clearFailedImageArtifact nulls the columns, keeps status/error_message,
+      // and is idempotent (a cleared row is no longer selected).
+      expect(await store.clearFailedImageArtifact("artifact-old")).toBe(true);
+      const cleared = await getRow("artifact-old");
+      expect(cleared?.status).toBe("failed");
+      expect(cleared?.provider_image_id).toBeNull();
+      expect(await store.getFailedImagesWithArtifacts(25)).toEqual([]);
+
+      // Now artifact-free and old — the age sweep removes it.
+      expect(await store.deleteOldFailedBuilds(86_400_000)).toBe(1);
+      expect(await getRow("artifact-old")).toBeNull();
     });
 
     it("rejects non-numeric max_age_seconds instead of treating it as 0", async () => {
@@ -596,6 +658,116 @@ describe("Image builds", () => {
         status: "failed",
         scope_id: environmentId,
       });
+    });
+  });
+
+  describe("cleanup reaper end-to-end over real D1", () => {
+    /**
+     * Stub factory standing in for the unconfigured provider adapter: records
+     * every deleted artifact and throws for a nominated "stuck" id so the
+     * best-effort retry path is exercised against real rows.
+     */
+    function stubFactory(opts?: { stuckImageId?: string }): {
+      factory: ImageBuildAdapterFactory;
+      deleted: string[];
+    } {
+      const deleted: string[] = [];
+      const adapter = {
+        async deleteImage({ image }: DeleteImageInput) {
+          if (image.providerImageId === opts?.stuckImageId) throw new Error("provider 500");
+          deleted.push(image.providerImageId);
+        },
+      } as unknown as AnyImageBuildAdapter;
+      const factory: ImageBuildAdapterFactory = {
+        create: (_provider: ImageBuildProvider) => adapter,
+      } as ImageBuildAdapterFactory;
+      return { factory, deleted };
+    }
+
+    const ctx = { request_id: "req-reap", trace_id: "trace-reap" };
+
+    it("reaps failed and superseded artifacts, retains failed rows, deletes aged-out rows", async () => {
+      const environmentId = await seedEnvironment();
+      const old = Date.now() - 100_000_000;
+
+      await seedImageRow({
+        id: "e2e-superseded",
+        environmentId,
+        status: "superseded",
+        providerImageId: "im-superseded",
+      });
+      await seedImageRow({ id: "e2e-superseded-bare", environmentId, status: "superseded" });
+      // Restore-failed row (fresh) carrying a live artifact.
+      await seedImageRow({
+        id: "e2e-failed-artifact",
+        environmentId,
+        status: "failed",
+        providerImageId: "im-restore",
+      });
+      await env.DB.prepare(`UPDATE image_builds SET error_message = ? WHERE id = ?`)
+        .bind("restore failed at spawn: image expired", "e2e-failed-artifact")
+        .run();
+      // Failed row whose artifact delete fails — artifact must not be lost.
+      await seedImageRow({
+        id: "e2e-failed-stuck",
+        environmentId,
+        status: "failed",
+        providerImageId: "im-stuck",
+      });
+      // Artifact-free failed rows: old ages out, fresh survives.
+      await seedImageRow({ id: "e2e-failed-old", environmentId, status: "failed", createdAt: old });
+      await seedImageRow({ id: "e2e-failed-fresh", environmentId, status: "failed" });
+
+      const { factory, deleted } = stubFactory({ stuckImageId: "im-stuck" });
+      const reaper = new ImageBuildReaper(new ImageBuildStore(env.DB), factory);
+
+      const result = await reaper.cleanupImages(86_400_000, ctx);
+
+      expect(result).toEqual({ deletedFailed: 1, reapedFailed: 1, reapedSuperseded: 2 });
+      expect(deleted.sort()).toEqual(["im-restore", "im-superseded"]);
+
+      // Superseded rows: artifact deleted then row removed.
+      expect(await getRow("e2e-superseded")).toBeNull();
+      expect(await getRow("e2e-superseded-bare")).toBeNull();
+
+      // Failed-with-artifact: artifact reclaimed, row kept as failed with its
+      // error_message, artifact columns nulled.
+      const reaped = await getRow("e2e-failed-artifact");
+      expect(reaped?.status).toBe("failed");
+      expect(reaped?.provider_image_id).toBeNull();
+      expect(reaped?.error_message).toBe("restore failed at spawn: image expired");
+
+      // Stuck failed row: artifact NOT lost — still on the row for the next tick.
+      const stuck = await getRow("e2e-failed-stuck");
+      expect(stuck?.status).toBe("failed");
+      expect(stuck?.provider_image_id).toBe("im-stuck");
+
+      // Artifact-free failed rows age out by cutoff only.
+      expect(await getRow("e2e-failed-old")).toBeNull();
+      expect((await getRow("e2e-failed-fresh"))?.status).toBe("failed");
+    });
+
+    it("is idempotent: a second pass reaps nothing new", async () => {
+      const environmentId = await seedEnvironment();
+      await seedImageRow({
+        id: "idem-failed-artifact",
+        environmentId,
+        status: "failed",
+        providerImageId: "im-idem",
+      });
+
+      const first = stubFactory();
+      const reaper = new ImageBuildReaper(new ImageBuildStore(env.DB), first.factory);
+      await reaper.cleanupImages(86_400_000, ctx);
+      expect(first.deleted).toEqual(["im-idem"]);
+
+      const second = stubFactory();
+      const reaper2 = new ImageBuildReaper(new ImageBuildStore(env.DB), second.factory);
+      const result = await reaper2.cleanupImages(86_400_000, ctx);
+
+      expect(second.deleted).toEqual([]);
+      expect(result.reapedFailed).toBe(0);
+      expect((await getRow("idem-failed-artifact"))?.provider_image_id).toBeNull();
     });
   });
 

--- a/packages/control-plane/test/integration/image-builds.test.ts
+++ b/packages/control-plane/test/integration/image-builds.test.ts
@@ -591,9 +591,14 @@ describe("Image builds", () => {
       const reapable = await store.getFailedImagesWithArtifacts(25);
       expect(reapable.map((r) => r.id)).toEqual(["artifact-old"]);
 
+      // A stale artifact id (not the one on the row) clears nothing, so a
+      // newer artifact could never be nulled without being reaped first.
+      expect(await store.clearFailedImageArtifact("artifact-old", "im-stale")).toBe(false);
+      expect((await getRow("artifact-old"))?.provider_image_id).toBe("im-live");
+
       // clearFailedImageArtifact nulls the columns, keeps status/error_message,
       // and is idempotent (a cleared row is no longer selected).
-      expect(await store.clearFailedImageArtifact("artifact-old")).toBe(true);
+      expect(await store.clearFailedImageArtifact("artifact-old", "im-live")).toBe(true);
       const cleared = await getRow("artifact-old");
       expect(cleared?.status).toBe("failed");
       expect(cleared?.provider_image_id).toBeNull();


### PR DESCRIPTION
## The bug

Post-train audit finding #1 of the image-build unification (#947–#952).

A prebuilt-image restore failure at spawn permanently orphans one provider snapshot. The leak trace:

1. `sandbox/lifecycle/manager.ts` catches a `createSandbox` restore failure and calls `markImageBuildRestoreFailed` → `ImageBuildStore.markRestoreFailed`, which flips the `ready` row to `failed` **while it still carries a live `provider_image_id`** (and possibly `provider_session_id`). Restore failures are frequently transient (quota/network) per the manager's own comment.
2. The reaper (`image-builds/reaper.ts`) only reaps provider artifacts for `superseded` rows (`getSupersededImages` → best-effort `deleteImage` → row delete). For `failed` rows it called `deleteOldFailedBuilds`, a bare `DELETE ... WHERE status='failed' AND created_at < ?` with **no artifact deletion**.
3. Net: the failed row is hard-deleted ~24h later, the artifact reference is lost, and Modal snapshots never expire (pinned 1.4.3, no TTL) — the leak is unrecoverable.

## The fix

Reap artifact-bearing `failed` rows through the **same** best-effort machinery the superseded path uses, and never hard-delete a failed row that still points at a live artifact.

- **`reaper.ts`** — `cleanupImages` now runs one shared reap loop (`reapArtifactBearingRows`) with a shared adapter cache:
  - **Failed-with-artifact rows first**: delete the provider artifact best-effort, then `clearFailedImageArtifact` nulls the artifact columns while keeping the row `failed`. Running this before the age sweep lets a now-artifact-free old row age out in the same pass.
  - **Old failed rows**: deleted only once artifact-free (store scopes the DELETE to `provider_image_id IS NULL`).
  - **Superseded rows**: unchanged — delete artifact, then delete the row.
  - Every artifact delete degrades instead of throwing; a failed delete leaves the artifact on its row so the next tick retries.
- **`db/image-builds.ts`**:
  - `getFailedImagesWithArtifacts(limit)` — selects `status='failed' AND provider_image_id IS NOT NULL`, batch-limited.
  - `clearFailedImageArtifact(id)` — nulls `provider_image_id`/`provider_session_id` scoped to `status='failed'`; keeps status + `error_message`; idempotent (a cleared row is no longer selected).
  - `deleteOldFailedBuilds` — now scoped `AND provider_image_id IS NULL` so an artifact-bearing failed row is never hard-deleted before its artifact is reaped.
  - Renamed the reaper row type `SupersededImageBuildRow` → `ReapableImageBuildRow` (now shared by both sweeps).
- **`routes/image-builds.ts`** / **`workflow.ts`** — thread the new `reapedFailed` count through the return shape, `image_build.cleanup` log, and cleanup response body.

## Why failure visibility is preserved

`markRestoreFailed` is **not** switched to `superseded`. Restore-failed rows stay `status='failed'` with their `error_message` — the web settings and cross-scope status feeds that deliberately surface failed rows are unaffected. The reaper only reclaims the orphaned provider artifact and nulls the artifact columns; the row itself survives until it ages out via the normal artifact-free failed sweep.

## Other artifact-bearing failed paths covered / ruled out

`provider_image_id` is only written on transitions to `ready` / `superseded` (and `recordArtifactOnSupersededBuild`, superseded-only). Every `failed` write except `markRestoreFailed` is scoped to `status='building'` (`markBuildFailed`, `markBuildFailedWithCallbackToken`, `markStaleBuildsAsFailed`), and building rows never carry an artifact. So `markRestoreFailed` (ready→failed) is the **only** path today that produces an artifact-bearing failed row. The fix selects reap candidates by `provider_image_id IS NOT NULL` rather than by originating path, so any future artifact-bearing failed row is covered uniformly.

## Idempotency / interleaving

- `getFailedImagesWithArtifacts` returns only artifact-bearing rows, so a previously-cleared row never reaches the adapter again.
- A failed provider delete leaves the columns intact → retried next tick, artifact never lost.
- `clearFailedImageArtifact` is scoped to `status='failed'` (terminal, never flips back to `ready`), so a concurrent rebuild registering a new building/ready row for the same scope can't have a live artifact cleared. Same concurrency semantics as the existing superseded sweep.

## Log events

No new event names. Added a `reaped_failed` field to the existing `image_build.cleanup` log and a `reapedFailed` field to the cleanup response body.

## Test coverage

- **Unit** (`workflow.test.ts`): restore-failed row → artifact deleted via adapter, `clearFailedImageArtifact` called, row not treated as superseded; provider delete failure → artifact not cleared (retryable); already-reaped (empty selection) → no adapter call; superseded mix unchanged.
- **Integration** (`test/integration/image-builds.test.ts`, real D1):
  - Store: `deleteOldFailedBuilds` ages out only artifact-free rows; `getFailedImagesWithArtifacts` / `clearFailedImageArtifact` behavior + idempotency.
  - End-to-end reaper over a mix (superseded/superseded-bare/failed-with-artifact/failed-stuck/failed-old/failed-fresh) with a stub adapter: asserts artifact reaping, failed-row retention with error_message, stuck artifact not lost, aged-out deletion, and second-pass idempotency.
  - Cleanup route: an old failed-with-artifact row survives (not hard-deleted) when the provider adapter is unconfigured — the leak is closed.
- Full gate green: shared build, typecheck, lint, control-plane unit (1684) and integration (507).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cleanup now also reclaims provider artifacts from failed image builds, while keeping failure details for visibility and later retry.
  * `/image-builds/cleanup` response and logs now include an additional `reapedFailed` / `reaped_failed` metric.
* **Bug Fixes**
  * Old failed build records are deleted only after related provider artifacts are fully cleared.
  * Cleanup is idempotent: repeated runs won’t re-delete artifacts or re-clear already-cleared entries.
* **Documentation**
  * Updated cleanup endpoint documentation and metrics to match the new response shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->