### PR TITLE
feat(web): show repo prebuild status in session-target picker

### DIFF
--- a/docs/IMAGE_PREBUILD.md
+++ b/docs/IMAGE_PREBUILD.md
@@ -68,9 +68,13 @@ each scope:
 - **No image** — Image building is enabled but no build has completed yet.
 - **Disabled** — Image building is turned off for this scope.
 
-The new-session picker also annotates prebuild-enabled environments with "prebuilt", "prebuild
-building", or "prebuild failed", so a broken prebuild is visible where you launch sessions, not just
-in settings.
+The new-session picker also annotates prebuild-enabled repositories and environments so a broken
+prebuild is visible where you launch sessions, not just in settings. Each option carries one of four
+states: "prebuilt" (a current-fingerprint image is ready), "prebuild building", "prebuild failed",
+or "prebuilds on" (enabled, but no build has completed for the current fingerprint yet). Options
+with prebuilds disabled are shown unannotated. A repository annotation reflects its default-branch
+prebuild state and does not change with the picker's branch selector, since a repo image is only
+built for the default branch.
 
 ---
 

--- a/packages/web/src/hooks/use-session-target-picker.test.ts
+++ b/packages/web/src/hooks/use-session-target-picker.test.ts
@@ -127,6 +127,12 @@ describe("describeRepository", () => {
     expect(describeRepository(repo(), new Map(), enabled)).toBe("acme · prebuilds on");
   });
 
+  it("falls back to prebuilds on for a superseded scope", () => {
+    expect(describeRepository(repo(), repoStatusMap("superseded"), enabled)).toBe(
+      "acme · prebuilds on"
+    );
+  });
+
   it("looks up the fold map with a lowercased fullName", () => {
     const mixedCase = repo({ fullName: "Acme/Web", owner: "Acme", name: "Web" });
     const enabledMixed = new Set(["acme/web"]);

--- a/packages/web/src/hooks/use-session-target-picker.test.ts
+++ b/packages/web/src/hooks/use-session-target-picker.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { Environment, ImageBuildRecordView, ImageBuildStatus } from "@open-inspect/shared";
 import { foldImageBuildStatusByScope, imageBuildScopeKey } from "@/lib/image-builds";
-import { describeEnvironment } from "./use-session-target-picker";
+import type { Repo } from "@/hooks/use-repos";
+import { describeEnvironment, describeRepository } from "./use-session-target-picker";
 
 function environment(overrides: Partial<Environment> = {}): Environment {
   return {
@@ -73,5 +74,64 @@ describe("describeEnvironment", () => {
     );
 
     expect(describeEnvironment(environment(), folded)).toBe("2 repositories · prebuild failed");
+  });
+});
+
+function repo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 1,
+    fullName: "acme/web",
+    owner: "acme",
+    name: "web",
+    description: null,
+    private: false,
+    defaultBranch: "main",
+    ...overrides,
+  };
+}
+
+function repoStatusMap(status: ImageBuildStatus): Map<string, ImageBuildStatus> {
+  return new Map([[imageBuildScopeKey("repo", "acme/web"), status]]);
+}
+
+describe("describeRepository", () => {
+  const enabled = new Set(["acme/web"]);
+
+  it("shows only the base description when prebuilds are off for the repo", () => {
+    expect(describeRepository(repo(), new Map(), new Set())).toBe("acme");
+  });
+
+  it("marks private repos without a prebuild when prebuilds are off", () => {
+    expect(describeRepository(repo({ private: true }), new Map(), new Set())).toBe(
+      "acme • private"
+    );
+  });
+
+  it("shows prebuilt for a ready scope", () => {
+    expect(describeRepository(repo(), repoStatusMap("ready"), enabled)).toBe("acme · prebuilt");
+  });
+
+  it("shows prebuild building for a building scope", () => {
+    expect(describeRepository(repo(), repoStatusMap("building"), enabled)).toBe(
+      "acme · prebuild building"
+    );
+  });
+
+  it("shows prebuild failed for a failed scope", () => {
+    expect(describeRepository(repo(), repoStatusMap("failed"), enabled)).toBe(
+      "acme · prebuild failed"
+    );
+  });
+
+  it("falls back to prebuilds on when enabled with no build rows", () => {
+    expect(describeRepository(repo(), new Map(), enabled)).toBe("acme · prebuilds on");
+  });
+
+  it("looks up the fold map with a lowercased fullName", () => {
+    const mixedCase = repo({ fullName: "Acme/Web", owner: "Acme", name: "Web" });
+    const enabledMixed = new Set(["acme/web"]);
+    expect(describeRepository(mixedCase, repoStatusMap("ready"), enabledMixed)).toBe(
+      "Acme · prebuilt"
+    );
   });
 });

--- a/packages/web/src/hooks/use-session-target-picker.ts
+++ b/packages/web/src/hooks/use-session-target-picker.ts
@@ -9,8 +9,10 @@ import { useEnvironments } from "@/hooks/use-environments";
 import { useRepos, type Repo } from "@/hooks/use-repos";
 import {
   IMAGE_BUILDS_KEY,
+  foldEnabledRepoScopeIds,
   foldImageBuildStatusByScope,
   imageBuildScopeKey,
+  repoImageBuildScopeId,
   type ImageBuildsFeed,
 } from "@/lib/image-builds";
 import { NO_REPOSITORY_LABEL } from "@/lib/repo-label";
@@ -80,19 +82,18 @@ export function describeEnvironment(
  * a session on any other branch fingerprint-misses to the base image. This
  * annotation describes the default-branch prebuild state and is intentionally
  * static: it does not react to the picker's branch selector (which itself
- * defaults to the default branch). Enablement comes from the persisted
- * `enabledRepos` flags, and both it and the fold-map lookup use the lowercased
- * fullName because the feed keys repo scopes lowercase.
+ * defaults to the default branch). Enablement and the fold-map lookup share the
+ * repo scope id (lowercased owner/name) via `repoImageBuildScopeId`.
  */
 export function describeRepository(
   repo: Repo,
   imageStatusByScope: Map<string, ImageBuildStatus>,
-  prebuildEnabledRepoKeys: Set<string>
+  prebuildEnabledRepoScopeIds: Set<string>
 ): string {
   const base = `${repo.owner}${repo.private ? " • private" : ""}`;
-  const key = repo.fullName.toLowerCase();
-  const status = imageStatusByScope.get(imageBuildScopeKey("repo", key));
-  return withAnnotation(base, prebuildAnnotation(prebuildEnabledRepoKeys.has(key), status));
+  const scopeId = repoImageBuildScopeId(repo.owner, repo.name);
+  const status = imageStatusByScope.get(imageBuildScopeKey("repo", scopeId));
+  return withAnnotation(base, prebuildAnnotation(prebuildEnabledRepoScopeIds.has(scopeId), status));
 }
 
 /** Render contract for SessionTargetPicker: the target/branch/multi-select controls. */
@@ -158,16 +159,10 @@ export function useSessionTargetPicker(): SessionTargetSelection {
     () => foldImageBuildStatusByScope(imageBuildsData?.images ?? [], imageBuildsData?.units ?? []),
     [imageBuildsData]
   );
-  // Persisted repo prebuild flags, keyed by lowercased fullName to match the
-  // fold map. Enablement reads these flags (not `units`) so a transiently
-  // dropped scope still annotates as enabled.
-  const prebuildEnabledRepoKeys = useMemo(
-    () =>
-      new Set(
-        (imageBuildsData?.enabledRepos ?? []).map((flag) =>
-          `${flag.repoOwner}/${flag.repoName}`.toLowerCase()
-        )
-      ),
+  // Persisted repo prebuild scope ids, folded next to the feed shape so this
+  // hook doesn't re-encode the lowercased-repo-key invariant.
+  const prebuildEnabledRepoScopeIds = useMemo(
+    () => foldEnabledRepoScopeIds(imageBuildsData?.enabledRepos ?? []),
     [imageBuildsData]
   );
 
@@ -276,7 +271,7 @@ export function useSessionTargetPicker(): SessionTargetSelection {
     ...repos.map((repo) => ({
       value: repo.fullName,
       label: repo.name,
-      description: describeRepository(repo, imageStatusByScope, prebuildEnabledRepoKeys),
+      description: describeRepository(repo, imageStatusByScope, prebuildEnabledRepoScopeIds),
     })),
   ];
   // One unified list: environments (when any exist) alongside the repositories.

--- a/packages/web/src/hooks/use-session-target-picker.ts
+++ b/packages/web/src/hooks/use-session-target-picker.ts
@@ -34,6 +34,34 @@ import {
 // (it stored only repo names) and is kept so stored repo values keep working.
 const LAST_SELECTED_TARGET_STORAGE_KEY = "open-inspect-last-selected-repo";
 
+// Prebuild annotation labels, shared by the environment and repository
+// subtitles so the two scopes read identically.
+const PREBUILD_ANNOTATION_READY = "prebuilt";
+const PREBUILD_ANNOTATION_BUILDING = "prebuild building";
+const PREBUILD_ANNOTATION_FAILED = "prebuild failed";
+const PREBUILD_ANNOTATION_ENABLED = "prebuilds on";
+
+/**
+ * The prebuild annotation for a scope, or null when prebuilds are off for it
+ * (the common case must stay unannotated). `status` is the scope's folded build
+ * status; a prebuild-enabled scope with no current build row is undefined here
+ * and falls back to "prebuilds on".
+ */
+function prebuildAnnotation(
+  prebuildEnabled: boolean,
+  status: ImageBuildStatus | undefined
+): string | null {
+  if (!prebuildEnabled) return null;
+  if (status === "ready") return PREBUILD_ANNOTATION_READY;
+  if (status === "building") return PREBUILD_ANNOTATION_BUILDING;
+  if (status === "failed") return PREBUILD_ANNOTATION_FAILED;
+  return PREBUILD_ANNOTATION_ENABLED;
+}
+
+function withAnnotation(base: string, annotation: string | null): string {
+  return annotation ? `${base} · ${annotation}` : base;
+}
+
 /** Picker subtitle for an environment: repository count plus prebuild state. */
 export function describeEnvironment(
   environment: Environment,
@@ -41,12 +69,30 @@ export function describeEnvironment(
 ): string {
   const count = environment.repositories.length;
   const base = `${count} ${count === 1 ? "repository" : "repositories"}`;
-  if (!environment.prebuildEnabled) return base;
   const status = imageStatusByScope.get(imageBuildScopeKey("environment", environment.id));
-  if (status === "ready") return `${base} · prebuilt`;
-  if (status === "building") return `${base} · prebuild building`;
-  if (status === "failed") return `${base} · prebuild failed`;
-  return `${base} · prebuilds on`;
+  return withAnnotation(base, prebuildAnnotation(environment.prebuildEnabled, status));
+}
+
+/**
+ * Picker subtitle for a repository: owner (and privacy) plus prebuild state.
+ *
+ * Branch semantics: a repo image is only built for the repo's DEFAULT branch —
+ * a session on any other branch fingerprint-misses to the base image. This
+ * annotation describes the default-branch prebuild state and is intentionally
+ * static: it does not react to the picker's branch selector (which itself
+ * defaults to the default branch). Enablement comes from the persisted
+ * `enabledRepos` flags, and both it and the fold-map lookup use the lowercased
+ * fullName because the feed keys repo scopes lowercase.
+ */
+export function describeRepository(
+  repo: Repo,
+  imageStatusByScope: Map<string, ImageBuildStatus>,
+  prebuildEnabledRepoKeys: Set<string>
+): string {
+  const base = `${repo.owner}${repo.private ? " • private" : ""}`;
+  const key = repo.fullName.toLowerCase();
+  const status = imageStatusByScope.get(imageBuildScopeKey("repo", key));
+  return withAnnotation(base, prebuildAnnotation(prebuildEnabledRepoKeys.has(key), status));
 }
 
 /** Render contract for SessionTargetPicker: the target/branch/multi-select controls. */
@@ -101,14 +147,27 @@ export function useSessionTargetPicker(): SessionTargetSelection {
     selectedRepository?.name ?? ""
   );
 
-  // Prebuild status for the environment options: the unified cross-scope
-  // feed (repo and environment scopes, failed rows included), one call across
-  // all of them, folded to one status per scope.
+  // Prebuild status for the repository and environment options: the unified
+  // cross-scope feed (repo and environment scopes, failed rows included), one
+  // call across all of them, folded to one status per scope. Fetched whenever
+  // there is anything to annotate on a provider that supports repo images.
   const { data: imageBuildsData } = useSWR<ImageBuildsFeed>(
-    environments.length > 0 && supportsRepoImages() ? IMAGE_BUILDS_KEY : null
+    supportsRepoImages() && (environments.length > 0 || repos.length > 0) ? IMAGE_BUILDS_KEY : null
   );
   const imageStatusByScope = useMemo(
     () => foldImageBuildStatusByScope(imageBuildsData?.images ?? [], imageBuildsData?.units ?? []),
+    [imageBuildsData]
+  );
+  // Persisted repo prebuild flags, keyed by lowercased fullName to match the
+  // fold map. Enablement reads these flags (not `units`) so a transiently
+  // dropped scope still annotates as enabled.
+  const prebuildEnabledRepoKeys = useMemo(
+    () =>
+      new Set(
+        (imageBuildsData?.enabledRepos ?? []).map((flag) =>
+          `${flag.repoOwner}/${flag.repoName}`.toLowerCase()
+        )
+      ),
     [imageBuildsData]
   );
 
@@ -217,7 +276,7 @@ export function useSessionTargetPicker(): SessionTargetSelection {
     ...repos.map((repo) => ({
       value: repo.fullName,
       label: repo.name,
-      description: `${repo.owner}${repo.private ? " • private" : ""}`,
+      description: describeRepository(repo, imageStatusByScope, prebuildEnabledRepoKeys),
     })),
   ];
   // One unified list: environments (when any exist) alongside the repositories.

--- a/packages/web/src/lib/image-builds.test.ts
+++ b/packages/web/src/lib/image-builds.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import type { ImageBuildRecordView } from "@open-inspect/shared";
 import {
   excludeSupersededBuilds,
+  foldEnabledRepoScopeIds,
   foldImageBuildStatusByScope,
   imageBuildScopeKey,
   parsePrimaryBuildSha,
+  repoImageBuildScopeId,
   type ImageBuildUnitView,
 } from "./image-builds";
 
@@ -117,6 +119,27 @@ describe("foldImageBuildStatusByScope", () => {
     );
 
     expect(folded.get(imageBuildScopeKey("environment", "env-1"))).toBe("ready");
+  });
+});
+
+describe("repoImageBuildScopeId", () => {
+  it("lowercases owner/name to match the feed's repo scope keys", () => {
+    expect(repoImageBuildScopeId("Acme", "Web")).toBe("acme/web");
+  });
+});
+
+describe("foldEnabledRepoScopeIds", () => {
+  it("folds the persisted flags to a set of lowercased scope ids", () => {
+    const ids = foldEnabledRepoScopeIds([
+      { repoOwner: "Acme", repoName: "Web" },
+      { repoOwner: "acme", repoName: "api" },
+    ]);
+
+    expect(ids).toEqual(new Set(["acme/web", "acme/api"]));
+  });
+
+  it("returns an empty set for no flags", () => {
+    expect(foldEnabledRepoScopeIds([])).toEqual(new Set());
   });
 });
 

--- a/packages/web/src/lib/image-builds.ts
+++ b/packages/web/src/lib/image-builds.ts
@@ -55,6 +55,24 @@ export function imageBuildScopeKey(scopeKind: ImageBuildScopeKind, scopeId: stri
   return `${scopeKind}:${scopeId}`;
 }
 
+/**
+ * The repo scope id (lowercased owner/name). Repo scopes are keyed lowercase in
+ * the feed, so both the enabled-set fold and per-repo status lookups must fold
+ * case through here to line up with folded scope ids.
+ */
+export function repoImageBuildScopeId(repoOwner: string, repoName: string): string {
+  return `${repoOwner}/${repoName}`.toLowerCase();
+}
+
+/**
+ * The set of prebuild-enabled repo scope ids from the feed's persisted flags.
+ * Reads `enabledRepos` (not `units`) so a transiently dropped scope still reads
+ * as enabled.
+ */
+export function foldEnabledRepoScopeIds(enabledRepos: ImageBuildEnabledRepoView[]): Set<string> {
+  return new Set(enabledRepos.map((flag) => repoImageBuildScopeId(flag.repoOwner, flag.repoName)));
+}
+
 const STATUS_FOLD_PRECEDENCE: Record<ImageBuildStatus, number> = {
   ready: 3,
   building: 2,


### PR DESCRIPTION
## What

The new-session target picker now annotates **repository** options with their prebuild state, matching the annotation environments already had. Owner-requested: a prebuilt repo image existed but was invisible where sessions are launched.

## What shows where

Each repository option's subtitle appends one of four states, from the same feed the environment annotation uses:

- ready → `prebuilt`
- building → `prebuild building`
- failed → `prebuild failed`
- enabled but no current-fingerprint build row → `prebuilds on`

Repositories with prebuilds **disabled** are unchanged (no annotation) — the common case stays quiet.

## Default-branch semantics (decision)

A repo image is only built for the repo's **default branch**; a session on any other branch fingerprint-misses to the base image. The annotation describes the default-branch prebuild state and is intentionally **static** — it does not react to the picker's branch selector (which itself defaults to the default branch). Keeping the option-list annotation static is the simple, predictable v1.

## Data source

Zero new requests: the picker already fetches the unified `/api/image-builds` feed (`units`, `enabledRepos`, `images`), which already carries repo scopes. The fold map is keyed `imageBuildScopeKey("repo", fullName.toLowerCase())`; enablement comes from the persisted `enabledRepos` flags, both compared lowercased since the feed keys repo scopes lowercase. The SWR gate was broadened to fetch when repos exist (previously environments-only).

## Implementation

- New exported pure `describeRepository(...)` mirroring `describeEnvironment`, both routed through a shared `prebuildAnnotation` helper and shared subtitle-label constants (no duplicated literals).
- Unit tests cover all four states + disabled-no-annotation + mixed-case fullName lookup.

## Docs

`docs/IMAGE_PREBUILD.md` picker-annotation paragraph now covers both scopes and all four states (previously environments-only and omitted `prebuilds on`) — closes audit finding #15.

Owner-requested surface following the image-build unification (#947–#952). Scope limited to `packages/web` + the one docs file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added prebuild status annotations to repository options in the new-session picker.
  - Repository and environment entries now show states including ready, building, failed, or enabled without a current build.
  - Repository annotations reflect default-branch prebuild availability regardless of the selected picker branch.

- **Documentation**
  - Updated UI guidance to explain repository and environment prebuild annotations and their supported states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->