### PR TITLE
feat: add PR lifecycle contracts and app-authed getPullRequest

### DIFF
--- a/packages/control-plane/src/source-control/errors.ts
+++ b/packages/control-plane/src/source-control/errors.ts
@@ -4,6 +4,8 @@
  * Error classes and types for source control operations.
  */
 
+import type { z } from "zod";
+
 /**
  * Error classification for source control operations.
  *
@@ -91,4 +93,36 @@ export class SourceControlProviderError extends Error {
       error instanceof Error ? error : undefined
     );
   }
+}
+
+/**
+ * Parse a provider API response body against its wire schema.
+ *
+ * A body that is not JSON or does not match the schema throws a permanent
+ * SourceControlProviderError naming the offending fields — provider/schema
+ * drift must fail loudly rather than flow onward as apparently-valid state.
+ */
+export async function parseProviderResponse<Schema extends z.ZodType>(
+  response: Response,
+  schema: Schema,
+  context: string
+): Promise<z.output<Schema>> {
+  let raw: unknown;
+  try {
+    raw = await response.json();
+  } catch {
+    throw new SourceControlProviderError(`${context}: response body is not JSON`, "permanent");
+  }
+
+  const parsed = schema.safeParse(raw);
+  if (!parsed.success) {
+    const fields = [
+      ...new Set(parsed.error.issues.map((issue) => issue.path.join(".") || "(root)")),
+    ].join(", ");
+    throw new SourceControlProviderError(
+      `${context}: unexpected response shape (${fields})`,
+      "permanent"
+    );
+  }
+  return parsed.data;
 }

--- a/packages/control-plane/src/source-control/providers/github-provider.test.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.test.ts
@@ -633,3 +633,102 @@ describe("createPullRequest state capture", () => {
     expect(result.repositoryExternalId).toBeUndefined();
   });
 });
+
+describe("response validation (zod boundary)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCachedInstallationToken.mockResolvedValue("installation-token");
+  });
+
+  it("getPullRequest throws a permanent provider error on an unexpected state value", async () => {
+    // Schema drift must fail loudly, never be silently stored as "open".
+    mockFetchWithTimeout.mockResolvedValueOnce(
+      makeJsonResponse({ ...basePullResponse, state: "reopened" })
+    );
+
+    const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+    const err = await provider
+      .getPullRequest({ owner: "acme", name: "web", number: 7 })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(SourceControlProviderError);
+    expect((err as SourceControlProviderError).errorType).toBe("permanent");
+    expect((err as SourceControlProviderError).message).toContain("state");
+  });
+
+  it("getPullRequest throws a permanent provider error on a malformed response", async () => {
+    mockFetchWithTimeout.mockResolvedValueOnce(
+      makeJsonResponse({ ...basePullResponse, head: {} }) // missing head.ref
+    );
+
+    const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+    const err = await provider
+      .getPullRequest({ owner: "acme", name: "web", number: 7 })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(SourceControlProviderError);
+    expect((err as SourceControlProviderError).errorType).toBe("permanent");
+  });
+
+  it("getPullRequest throws a permanent provider error on non-JSON response body", async () => {
+    mockFetchWithTimeout.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.reject(new SyntaxError("Unexpected token <")),
+      text: () => Promise.resolve("<html>"),
+    } as unknown as Response);
+
+    const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+    const err = await provider
+      .getPullRequest({ owner: "acme", name: "web", number: 7 })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(SourceControlProviderError);
+    expect((err as SourceControlProviderError).errorType).toBe("permanent");
+  });
+
+  it("falls back to the original 404 when the by-id resolution body is malformed", async () => {
+    mockFetchWithTimeout
+      .mockResolvedValueOnce(makeJsonResponse({ message: "Not Found" }, 404))
+      .mockResolvedValueOnce(makeJsonResponse({ id: 9001 })); // no owner/name
+
+    const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+    const err = await provider
+      .getPullRequest({ owner: "acme", name: "web", number: 7, repositoryExternalId: "9001" })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(SourceControlProviderError);
+    expect((err as SourceControlProviderError).httpStatus).toBe(404);
+    expect(mockFetchWithTimeout).toHaveBeenCalledTimes(2);
+  });
+
+  it("createPullRequest throws a permanent provider error on a malformed response", async () => {
+    mockFetchWithTimeout.mockResolvedValueOnce(
+      makeJsonResponse({ html_url: "https://github.com/acme/web/pull/7" }) // missing number etc.
+    );
+
+    const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+    const err = await provider
+      .createPullRequest(
+        { authType: "oauth", token: "user-token" },
+        {
+          repository: {
+            owner: "acme",
+            name: "web",
+            fullName: "acme/web",
+            defaultBranch: "main",
+            isPrivate: true,
+            providerRepoId: 9001,
+          },
+          title: "Add feature",
+          body: "Description",
+          sourceBranch: "open-inspect/session-1",
+          targetBranch: "main",
+        }
+      )
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(SourceControlProviderError);
+    expect((err as SourceControlProviderError).errorType).toBe("permanent");
+  });
+});

--- a/packages/control-plane/src/source-control/providers/github-provider.test.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.test.ts
@@ -348,3 +348,288 @@ describe("GitHubSourceControlProvider", () => {
     });
   });
 });
+
+// ─── PR lifecycle tracking (getPullRequest + status derivation) ───────────────
+
+import { fetchWithTimeout, getCachedInstallationToken } from "../../auth/github-app";
+import { deriveGitHubPullRequestStatus } from "./github-provider";
+
+const mockFetchWithTimeout = vi.mocked(fetchWithTimeout);
+const mockGetCachedInstallationToken = vi.mocked(getCachedInstallationToken);
+
+function makeJsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+const basePullResponse = {
+  number: 7,
+  html_url: "https://github.com/acme/web/pull/7",
+  url: "https://api.github.com/repos/acme/web/pulls/7",
+  state: "open",
+  draft: false,
+  merged: false,
+  updated_at: "2026-07-10T12:00:00Z",
+  head: { ref: "open-inspect/session-1", sha: "abc123", repo: { id: 9001, full_name: "acme/web" } },
+  base: {
+    ref: "main",
+    repo: { id: 9001, name: "web", full_name: "acme/web", owner: { login: "acme" } },
+  },
+};
+
+describe("deriveGitHubPullRequestStatus", () => {
+  it("maps an open ready PR", () => {
+    expect(deriveGitHubPullRequestStatus({ state: "open", draft: false, merged: false })).toEqual({
+      lifecycleState: "open",
+      isDraft: false,
+    });
+  });
+
+  it("maps an open draft PR", () => {
+    expect(deriveGitHubPullRequestStatus({ state: "open", draft: true, merged: false })).toEqual({
+      lifecycleState: "open",
+      isDraft: true,
+    });
+  });
+
+  it("maps a closed unmerged PR", () => {
+    expect(deriveGitHubPullRequestStatus({ state: "closed", draft: false, merged: false })).toEqual(
+      { lifecycleState: "closed", isDraft: false }
+    );
+  });
+
+  it("maps a merged PR and never leaks a stale draft flag (invariant)", () => {
+    expect(deriveGitHubPullRequestStatus({ state: "closed", draft: true, merged: true })).toEqual({
+      lifecycleState: "merged",
+      isDraft: false,
+    });
+  });
+
+  it("treats null draft/merged (GitHub sends null on old PRs) as false", () => {
+    expect(deriveGitHubPullRequestStatus({ state: "open", draft: null, merged: null })).toEqual({
+      lifecycleState: "open",
+      isDraft: false,
+    });
+  });
+});
+
+describe("getPullRequest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCachedInstallationToken.mockResolvedValue("installation-token");
+  });
+
+  it("throws a permanent error when the App is not configured", async () => {
+    const provider = new GitHubSourceControlProvider();
+    const err = await provider
+      .getPullRequest({ owner: "acme", name: "web", number: 7 })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(SourceControlProviderError);
+    expect((err as SourceControlProviderError).errorType).toBe("permanent");
+  });
+
+  it("reads with app auth and maps the response to a snapshot", async () => {
+    mockFetchWithTimeout.mockResolvedValueOnce(
+      makeJsonResponse({ ...basePullResponse, draft: true })
+    );
+
+    const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+    const snapshot = await provider.getPullRequest({ owner: "acme", name: "web", number: 7 });
+
+    expect(snapshot).toEqual({
+      number: 7,
+      url: "https://github.com/acme/web/pull/7",
+      lifecycleState: "open",
+      isDraft: true,
+      headBranch: "open-inspect/session-1",
+      baseBranch: "main",
+      headSha: "abc123",
+      repoOwner: "acme",
+      repoName: "web",
+      repositoryExternalId: "9001",
+      providerUpdatedAt: Date.parse("2026-07-10T12:00:00Z"),
+    });
+
+    // App-authenticated: installation token, resolved inside the provider.
+    expect(mockFetchWithTimeout).toHaveBeenCalledWith(
+      "https://api.github.com/repos/acme/web/pulls/7",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer installation-token" }),
+      })
+    );
+  });
+
+  it("maps a merged PR to merged with the draft flag suppressed", async () => {
+    mockFetchWithTimeout.mockResolvedValueOnce(
+      makeJsonResponse({ ...basePullResponse, state: "closed", merged: true, draft: true })
+    );
+
+    const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+    const snapshot = await provider.getPullRequest({ owner: "acme", name: "web", number: 7 });
+
+    expect(snapshot.lifecycleState).toBe("merged");
+    expect(snapshot.isDraft).toBe(false);
+  });
+
+  it("maps a closed unmerged PR to closed", async () => {
+    mockFetchWithTimeout.mockResolvedValueOnce(
+      makeJsonResponse({ ...basePullResponse, state: "closed", merged: false })
+    );
+
+    const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+    const snapshot = await provider.getPullRequest({ owner: "acme", name: "web", number: 7 });
+
+    expect(snapshot.lifecycleState).toBe("closed");
+  });
+
+  it("resolves the repository by stable id and retries once on 404 (rename tolerance)", async () => {
+    mockFetchWithTimeout
+      .mockResolvedValueOnce(makeJsonResponse({ message: "Not Found" }, 404))
+      .mockResolvedValueOnce(
+        makeJsonResponse({
+          id: 9001,
+          name: "web-renamed",
+          full_name: "acme/web-renamed",
+          owner: { login: "acme" },
+        })
+      )
+      .mockResolvedValueOnce(
+        makeJsonResponse({
+          ...basePullResponse,
+          html_url: "https://github.com/acme/web-renamed/pull/7",
+          base: {
+            ref: "main",
+            repo: {
+              id: 9001,
+              name: "web-renamed",
+              full_name: "acme/web-renamed",
+              owner: { login: "acme" },
+            },
+          },
+        })
+      );
+
+    const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+    const snapshot = await provider.getPullRequest({
+      owner: "acme",
+      name: "web",
+      number: 7,
+      repositoryExternalId: "9001",
+    });
+
+    expect(snapshot.repoName).toBe("web-renamed");
+    expect(mockFetchWithTimeout).toHaveBeenNthCalledWith(
+      2,
+      "https://api.github.com/repositories/9001",
+      expect.anything()
+    );
+    expect(mockFetchWithTimeout).toHaveBeenNthCalledWith(
+      3,
+      "https://api.github.com/repos/acme/web-renamed/pulls/7",
+      expect.anything()
+    );
+  });
+
+  it("throws with httpStatus 404 when the PR is gone and no stable id is known", async () => {
+    mockFetchWithTimeout.mockResolvedValueOnce(makeJsonResponse({ message: "Not Found" }, 404));
+
+    const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+    const err = await provider
+      .getPullRequest({ owner: "acme", name: "web", number: 7 })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(SourceControlProviderError);
+    expect((err as SourceControlProviderError).httpStatus).toBe(404);
+    expect(mockFetchWithTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry more than once when id resolution also fails", async () => {
+    mockFetchWithTimeout
+      .mockResolvedValueOnce(makeJsonResponse({ message: "Not Found" }, 404))
+      .mockResolvedValueOnce(makeJsonResponse({ message: "Not Found" }, 404));
+
+    const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+    const err = await provider
+      .getPullRequest({ owner: "acme", name: "web", number: 7, repositoryExternalId: "9001" })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(SourceControlProviderError);
+    expect((err as SourceControlProviderError).httpStatus).toBe(404);
+    expect(mockFetchWithTimeout).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("createPullRequest state capture", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("captures headSha and repositoryExternalId from the create response", async () => {
+    mockFetchWithTimeout.mockResolvedValueOnce(makeJsonResponse(basePullResponse, 201));
+
+    const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+    const result = await provider.createPullRequest(
+      { authType: "oauth", token: "user-token" },
+      {
+        repository: {
+          owner: "acme",
+          name: "web",
+          fullName: "acme/web",
+          defaultBranch: "main",
+          isPrivate: true,
+          providerRepoId: 9001,
+        },
+        title: "Add feature",
+        body: "Description",
+        sourceBranch: "open-inspect/session-1",
+        targetBranch: "main",
+      }
+    );
+
+    expect(result.headSha).toBe("abc123");
+    expect(result.repositoryExternalId).toBe("9001");
+    expect(result.state).toBe("open");
+  });
+
+  it("leaves capture fields undefined when the response omits them", async () => {
+    mockFetchWithTimeout.mockResolvedValueOnce(
+      makeJsonResponse({
+        number: 7,
+        html_url: "https://github.com/acme/web/pull/7",
+        url: "https://api.github.com/repos/acme/web/pulls/7",
+        state: "open",
+        draft: false,
+        merged: false,
+        head: { ref: "open-inspect/session-1" },
+        base: { ref: "main" },
+      })
+    );
+
+    const provider = new GitHubSourceControlProvider({ appConfig: fakeAppConfig });
+    const result = await provider.createPullRequest(
+      { authType: "oauth", token: "user-token" },
+      {
+        repository: {
+          owner: "acme",
+          name: "web",
+          fullName: "acme/web",
+          defaultBranch: "main",
+          isPrivate: true,
+          providerRepoId: 9001,
+        },
+        title: "Add feature",
+        body: "Description",
+        sourceBranch: "open-inspect/session-1",
+        targetBranch: "main",
+      }
+    );
+
+    expect(result.headSha).toBeUndefined();
+    expect(result.repositoryExternalId).toBeUndefined();
+  });
+});

--- a/packages/control-plane/src/source-control/providers/github-provider.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.ts
@@ -5,7 +5,8 @@
  * wrapping existing GitHub API functions.
  */
 
-import type { InstallationRepository } from "@open-inspect/shared";
+import { toDisplayStatus, type InstallationRepository } from "@open-inspect/shared";
+import type { PullRequestStatus } from "@open-inspect/shared";
 import type {
   SourceControlProvider,
   SourceControlAuthContext,
@@ -14,6 +15,8 @@ import type {
   RepositoryInfo,
   CreatePullRequestConfig,
   CreatePullRequestResult,
+  GetPullRequestConfig,
+  PullRequestSnapshot,
   BuildManualPullRequestUrlConfig,
   BuildGitPushSpecConfig,
   GitPushSpec,
@@ -38,6 +41,50 @@ function extractHttpStatus(error: unknown): number | undefined {
     return error.status;
   }
   return undefined;
+}
+
+/** GitHub pull-request state fields as the REST API reports them. */
+interface GitHubPullRequestStateFields {
+  state: string;
+  draft?: boolean | null;
+  merged?: boolean | null;
+}
+
+/**
+ * Pure mapping from GitHub's PR state fields to the stored status. GitHub
+ * models merged as state "closed" + merged true; terminal states win over a
+ * stale draft flag (isDraft is only meaningful while open). Shared by
+ * createPullRequest (user-authed) and getPullRequest (app-authed).
+ */
+export function deriveGitHubPullRequestStatus(
+  data: GitHubPullRequestStateFields
+): PullRequestStatus {
+  if (data.merged) return { lifecycleState: "merged", isDraft: false };
+  if (data.state === "closed") return { lifecycleState: "closed", isDraft: false };
+  return { lifecycleState: "open", isDraft: data.draft === true };
+}
+
+/** Wire shape of a GitHub REST pull request, limited to the fields we read. */
+interface GitHubPullResponse {
+  number: number;
+  html_url: string;
+  url: string;
+  state: string;
+  draft?: boolean | null;
+  merged?: boolean | null;
+  updated_at?: string;
+  head: { ref: string; sha?: string };
+  base: {
+    ref: string;
+    repo?: { id?: number; name?: string; owner?: { login?: string } } | null;
+  };
+}
+
+/** Parse GitHub's ISO-8601 updated_at into epoch ms; undefined when absent/invalid. */
+function parseProviderUpdatedAt(updatedAt: string | undefined): number | undefined {
+  if (!updatedAt) return undefined;
+  const parsed = Date.parse(updatedAt);
+  return Number.isNaN(parsed) ? undefined : parsed;
 }
 
 /**
@@ -144,39 +191,19 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
       );
     }
 
-    const data = (await response.json()) as {
-      number: number;
-      html_url: string;
-      url: string;
-      state: string;
-      draft: boolean;
-      merged: boolean;
-      head: { ref: string };
-      base: { ref: string };
-    };
+    const data = (await response.json()) as GitHubPullResponse;
 
-    // Map GitHub state to our state type
-    // GitHub uses state: "closed" + merged: true for merged PRs
-    let state: CreatePullRequestResult["state"];
-    if (data.draft) {
-      state = "draft";
-    } else if (data.merged) {
-      state = "merged";
-    } else if (data.state === "open") {
-      state = "open";
-    } else if (data.state === "closed") {
-      state = "closed";
-    } else {
-      state = "open"; // Default to open for unknown states
-    }
-
+    const repositoryExternalId = data.base.repo?.id;
     const result: CreatePullRequestResult = {
       id: data.number,
       webUrl: data.html_url,
       apiUrl: data.url,
-      state,
+      state: toDisplayStatus(deriveGitHubPullRequestStatus(data)),
       sourceBranch: data.head.ref,
       targetBranch: data.base.ref,
+      headSha: data.head.sha,
+      repositoryExternalId:
+        repositoryExternalId !== undefined ? String(repositoryExternalId) : undefined,
     };
 
     // Add labels if requested
@@ -202,6 +229,117 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
     }
 
     return result;
+  }
+
+  /**
+   * Read the current state of a pull request using GitHub App credentials.
+   *
+   * On a 404 with a known stable repo id, re-resolves the repository's
+   * current owner/name by id and retries once (rename/transfer tolerance).
+   */
+  async getPullRequest(config: GetPullRequestConfig): Promise<PullRequestSnapshot> {
+    if (!this.appConfig) {
+      throw new SourceControlProviderError(
+        "GitHub App not configured - cannot get pull request",
+        "permanent"
+      );
+    }
+
+    let token: string;
+    try {
+      token = await getCachedInstallationToken(this.appConfig, {
+        cacheStore: this.cacheStore,
+        userAgent: this.userAgent,
+      });
+    } catch (error) {
+      throw SourceControlProviderError.fromFetchError(
+        `Failed to generate GitHub App token: ${error instanceof Error ? error.message : String(error)}`,
+        error,
+        extractHttpStatus(error)
+      );
+    }
+
+    let response = await this.fetchPullRequest(token, config.owner, config.name, config.number);
+
+    if (response.status === 404 && config.repositoryExternalId) {
+      const resolved = await this.resolveRepositoryLocationById(token, config.repositoryExternalId);
+      if (resolved) {
+        response = await this.fetchPullRequest(token, resolved.owner, resolved.name, config.number);
+      }
+    }
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw SourceControlProviderError.fromFetchError(
+        `Failed to get pull request: ${response.status} ${error}`,
+        new Error(error),
+        response.status
+      );
+    }
+
+    const data = (await response.json()) as GitHubPullResponse;
+    const status = deriveGitHubPullRequestStatus(data);
+    const repositoryExternalId = data.base.repo?.id;
+
+    return {
+      number: data.number,
+      url: data.html_url,
+      lifecycleState: status.lifecycleState,
+      isDraft: status.isDraft,
+      headBranch: data.head.ref,
+      baseBranch: data.base.ref,
+      headSha: data.head.sha,
+      // The response's base repo is authoritative for the current location.
+      repoOwner: data.base.repo?.owner?.login ?? config.owner,
+      repoName: data.base.repo?.name ?? config.name,
+      repositoryExternalId:
+        repositoryExternalId !== undefined
+          ? String(repositoryExternalId)
+          : config.repositoryExternalId,
+      providerUpdatedAt: parseProviderUpdatedAt(data.updated_at),
+    };
+  }
+
+  private fetchPullRequest(
+    token: string,
+    owner: string,
+    name: string,
+    number: number
+  ): Promise<Response> {
+    return fetchWithTimeout(`${GITHUB_API_BASE}/repos/${owner}/${name}/pulls/${number}`, {
+      headers: {
+        Accept: "application/vnd.github.v3+json",
+        Authorization: `Bearer ${token}`,
+        "User-Agent": this.userAgent,
+      },
+    });
+  }
+
+  /** Resolve a repository's current owner/name from its stable numeric id. */
+  private async resolveRepositoryLocationById(
+    token: string,
+    repositoryExternalId: string
+  ): Promise<{ owner: string; name: string } | null> {
+    const response = await fetchWithTimeout(
+      `${GITHUB_API_BASE}/repositories/${encodeURIComponent(repositoryExternalId)}`,
+      {
+        headers: {
+          Accept: "application/vnd.github.v3+json",
+          Authorization: `Bearer ${token}`,
+          "User-Agent": this.userAgent,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = (await response.json()) as { name?: string; owner?: { login?: string } };
+    if (!data.owner?.login || !data.name) {
+      return null;
+    }
+    return { owner: data.owner.login, name: data.name };
   }
 
   /**

--- a/packages/control-plane/src/source-control/providers/github-provider.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.ts
@@ -342,7 +342,15 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
     });
   }
 
-  /** Resolve a repository's current owner/name from its stable numeric id. */
+  /**
+   * Resolve a repository's current owner/name from its stable numeric id.
+   *
+   * GET /repositories/{id} is GitHub's stable-but-undocumented by-id alias of
+   * GET /repos/{owner}/{name} (identical response schema; acknowledged by
+   * GitHub staff). Acceptable here because this is a best-effort repair path:
+   * if the endpoint ever disappears, resolution degrades to "not resolved"
+   * and the caller surfaces the original 404.
+   */
   private async resolveRepositoryLocationById(
     token: string,
     repositoryExternalId: string

--- a/packages/control-plane/src/source-control/providers/github-provider.ts
+++ b/packages/control-plane/src/source-control/providers/github-provider.ts
@@ -5,6 +5,7 @@
  * wrapping existing GitHub API functions.
  */
 
+import { z } from "zod";
 import { toDisplayStatus, type InstallationRepository } from "@open-inspect/shared";
 import type { PullRequestStatus } from "@open-inspect/shared";
 import type {
@@ -23,7 +24,7 @@ import type {
   GitPushAuthContext,
   CredentialHelperAuth,
 } from "../types";
-import { SourceControlProviderError } from "../errors";
+import { SourceControlProviderError, parseProviderResponse } from "../errors";
 import {
   getCachedInstallationToken,
   getCachedInstallationTokenWithExpiry,
@@ -45,7 +46,8 @@ function extractHttpStatus(error: unknown): number | undefined {
 
 /** GitHub pull-request state fields as the REST API reports them. */
 interface GitHubPullRequestStateFields {
-  state: string;
+  /** GitHub's wire state is strictly open/closed; merged is a separate flag. */
+  state: "open" | "closed";
   draft?: boolean | null;
   merged?: boolean | null;
 }
@@ -64,21 +66,38 @@ export function deriveGitHubPullRequestStatus(
   return { lifecycleState: "open", isDraft: data.draft === true };
 }
 
-/** Wire shape of a GitHub REST pull request, limited to the fields we read. */
-interface GitHubPullResponse {
-  number: number;
-  html_url: string;
-  url: string;
-  state: string;
-  draft?: boolean | null;
-  merged?: boolean | null;
-  updated_at?: string;
-  head: { ref: string; sha?: string };
-  base: {
-    ref: string;
-    repo?: { id?: number; name?: string; owner?: { login?: string } } | null;
-  };
-}
+/**
+ * Wire schema of a GitHub REST pull request, limited to the fields we read.
+ * `state` is a strict enum — an unexpected value is schema drift and fails
+ * the parse rather than being coerced into an apparently-valid status.
+ */
+const githubPullResponseSchema = z.object({
+  number: z.number(),
+  html_url: z.string(),
+  url: z.string(),
+  state: z.enum(["open", "closed"]),
+  draft: z.boolean().nullable().optional(),
+  merged: z.boolean().nullable().optional(),
+  updated_at: z.string().optional(),
+  head: z.object({ ref: z.string(), sha: z.string().optional() }),
+  base: z.object({
+    ref: z.string(),
+    repo: z
+      .object({
+        id: z.number().optional(),
+        name: z.string().optional(),
+        owner: z.object({ login: z.string().optional() }).optional(),
+      })
+      .nullable()
+      .optional(),
+  }),
+});
+
+/** Wire shape of GET /repositories/{id}, limited to the location fields. */
+const githubRepositoryLocationSchema = z.object({
+  name: z.string(),
+  owner: z.object({ login: z.string() }),
+});
 
 /** Parse GitHub's ISO-8601 updated_at into epoch ms; undefined when absent/invalid. */
 function parseProviderUpdatedAt(updatedAt: string | undefined): number | undefined {
@@ -191,7 +210,11 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
       );
     }
 
-    const data = (await response.json()) as GitHubPullResponse;
+    const data = await parseProviderResponse(
+      response,
+      githubPullResponseSchema,
+      "Failed to create PR"
+    );
 
     const repositoryExternalId = data.base.repo?.id;
     const result: CreatePullRequestResult = {
@@ -277,7 +300,11 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
       );
     }
 
-    const data = (await response.json()) as GitHubPullResponse;
+    const data = await parseProviderResponse(
+      response,
+      githubPullResponseSchema,
+      "Failed to get pull request"
+    );
     const status = deriveGitHubPullRequestStatus(data);
     const repositoryExternalId = data.base.repo?.id;
 
@@ -335,11 +362,15 @@ export class GitHubSourceControlProvider implements SourceControlProvider {
       return null;
     }
 
-    const data = (await response.json()) as { name?: string; owner?: { login?: string } };
-    if (!data.owner?.login || !data.name) {
+    // Best-effort repair path: a malformed resolution body degrades to "not
+    // resolved" so the caller surfaces the original 404 instead.
+    const parsed = githubRepositoryLocationSchema.safeParse(
+      await response.json().catch(() => null)
+    );
+    if (!parsed.success) {
       return null;
     }
-    return { owner: data.owner.login, name: data.name };
+    return { owner: parsed.data.owner.login, name: parsed.data.name };
   }
 
   /**

--- a/packages/control-plane/src/source-control/providers/gitlab-provider.test.ts
+++ b/packages/control-plane/src/source-control/providers/gitlab-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { GitLabSourceControlProvider } from "./gitlab-provider";
+import { GitLabSourceControlProvider, deriveGitLabMergeRequestStatus } from "./gitlab-provider";
 import { SourceControlProviderError } from "../errors";
 
 // Mock global fetch
@@ -751,5 +751,182 @@ describe("GitLabSourceControlProvider", () => {
       expect(spec.remoteUrl).toBe("https://oauth2:glpat-secret@gitlab.com/acme/my-repo.git");
       expect(spec.redactedRemoteUrl).toBe("https://oauth2:<redacted>@gitlab.com/acme/my-repo.git");
     });
+  });
+});
+
+// ─── PR lifecycle tracking (getPullRequest + status derivation) ───────────────
+
+describe("deriveGitLabMergeRequestStatus", () => {
+  it("maps an opened ready MR", () => {
+    expect(deriveGitLabMergeRequestStatus({ state: "opened", draft: false })).toEqual({
+      lifecycleState: "open",
+      isDraft: false,
+    });
+  });
+
+  it("maps an opened draft MR", () => {
+    expect(deriveGitLabMergeRequestStatus({ state: "opened", draft: true })).toEqual({
+      lifecycleState: "open",
+      isDraft: true,
+    });
+  });
+
+  it("maps merged terminal-first and never leaks a stale draft flag (invariant)", () => {
+    expect(deriveGitLabMergeRequestStatus({ state: "merged", draft: true })).toEqual({
+      lifecycleState: "merged",
+      isDraft: false,
+    });
+  });
+
+  it("maps closed terminal-first", () => {
+    expect(deriveGitLabMergeRequestStatus({ state: "closed", draft: true })).toEqual({
+      lifecycleState: "closed",
+      isDraft: false,
+    });
+  });
+
+  it("treats the transient locked state as open", () => {
+    expect(deriveGitLabMergeRequestStatus({ state: "locked", draft: false })).toEqual({
+      lifecycleState: "open",
+      isDraft: false,
+    });
+  });
+});
+
+describe("getPullRequest", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const baseMrResponse = {
+    iid: 7,
+    web_url: "https://gitlab.com/acme/web/-/merge_requests/7",
+    state: "opened",
+    draft: true,
+    source_branch: "open-inspect/session-1",
+    target_branch: "main",
+    sha: "abc123",
+    project_id: 9001,
+    updated_at: "2026-07-10T12:00:00.000Z",
+  };
+
+  it("reads with the provider PAT and maps the response to a snapshot", async () => {
+    mockFetch.mockResolvedValueOnce(makeResponse(baseMrResponse));
+
+    const provider = new GitLabSourceControlProvider(fakeConfig);
+    const snapshot = await provider.getPullRequest({ owner: "acme", name: "web", number: 7 });
+
+    expect(snapshot).toEqual({
+      number: 7,
+      url: "https://gitlab.com/acme/web/-/merge_requests/7",
+      lifecycleState: "open",
+      isDraft: true,
+      headBranch: "open-inspect/session-1",
+      baseBranch: "main",
+      headSha: "abc123",
+      repoOwner: "acme",
+      repoName: "web",
+      repositoryExternalId: "9001",
+      providerUpdatedAt: Date.parse("2026-07-10T12:00:00.000Z"),
+    });
+
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://gitlab.com/api/v4/projects/acme%2Fweb/merge_requests/7");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer glpat-test-token");
+  });
+
+  it("maps a merged MR to merged", async () => {
+    mockFetch.mockResolvedValueOnce(makeResponse({ ...baseMrResponse, state: "merged" }));
+
+    const provider = new GitLabSourceControlProvider(fakeConfig);
+    const snapshot = await provider.getPullRequest({ owner: "acme", name: "web", number: 7 });
+
+    expect(snapshot.lifecycleState).toBe("merged");
+    expect(snapshot.isDraft).toBe(false);
+  });
+
+  it("resolves the project by stable id and retries once on 404 (rename tolerance)", async () => {
+    mockFetch
+      .mockResolvedValueOnce(makeResponse({ message: "404 Not Found" }, 404))
+      .mockResolvedValueOnce(
+        makeResponse({ id: 9001, path: "web-renamed", namespace: { full_path: "acme" } })
+      )
+      .mockResolvedValueOnce(
+        makeResponse({
+          ...baseMrResponse,
+          web_url: "https://gitlab.com/acme/web-renamed/-/merge_requests/7",
+        })
+      );
+
+    const provider = new GitLabSourceControlProvider(fakeConfig);
+    const snapshot = await provider.getPullRequest({
+      owner: "acme",
+      name: "web",
+      number: 7,
+      repositoryExternalId: "9001",
+    });
+
+    expect(snapshot.repoName).toBe("web-renamed");
+    expect(mockFetch.mock.calls[1][0]).toBe("https://gitlab.com/api/v4/projects/9001");
+    expect(mockFetch.mock.calls[2][0]).toBe(
+      "https://gitlab.com/api/v4/projects/acme%2Fweb-renamed/merge_requests/7"
+    );
+  });
+
+  it("throws with httpStatus 404 when the MR is gone and no stable id is known", async () => {
+    mockFetch.mockResolvedValueOnce(makeResponse({ message: "404 Not Found" }, 404));
+
+    const provider = new GitLabSourceControlProvider(fakeConfig);
+    const err = await provider
+      .getPullRequest({ owner: "acme", name: "web", number: 7 })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(SourceControlProviderError);
+    expect((err as SourceControlProviderError).httpStatus).toBe(404);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("createPullRequest state capture", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("captures headSha and repositoryExternalId from the create response", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeResponse({
+        iid: 5,
+        web_url: "https://gitlab.com/acme/web/-/merge_requests/5",
+        _links: { self: "https://gitlab.com/api/v4/projects/acme%2Fweb/merge_requests/5" },
+        state: "opened",
+        draft: false,
+        source_branch: "open-inspect/session-1",
+        target_branch: "main",
+        sha: "abc123",
+        project_id: 9001,
+      })
+    );
+
+    const provider = new GitLabSourceControlProvider(fakeConfig);
+    const result = await provider.createPullRequest(
+      { authType: "pat", token: "user-token" },
+      {
+        repository: {
+          owner: "acme",
+          name: "web",
+          fullName: "acme/web",
+          defaultBranch: "main",
+          isPrivate: true,
+          providerRepoId: 9001,
+        },
+        title: "Add feature",
+        body: "Description",
+        sourceBranch: "open-inspect/session-1",
+        targetBranch: "main",
+      }
+    );
+
+    expect(result.headSha).toBe("abc123");
+    expect(result.repositoryExternalId).toBe("9001");
   });
 });

--- a/packages/control-plane/src/source-control/providers/gitlab-provider.test.ts
+++ b/packages/control-plane/src/source-control/providers/gitlab-provider.test.ts
@@ -930,3 +930,96 @@ describe("createPullRequest state capture", () => {
     expect(result.repositoryExternalId).toBe("9001");
   });
 });
+
+describe("response validation (zod boundary)", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("getPullRequest maps the transient locked state to open at the response level", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeResponse({
+        iid: 7,
+        web_url: "https://gitlab.com/acme/web/-/merge_requests/7",
+        state: "locked",
+        draft: false,
+        source_branch: "open-inspect/session-1",
+        target_branch: "main",
+      })
+    );
+
+    const provider = new GitLabSourceControlProvider(fakeConfig);
+    const snapshot = await provider.getPullRequest({ owner: "acme", name: "web", number: 7 });
+
+    expect(snapshot.lifecycleState).toBe("open");
+    expect(snapshot.isDraft).toBe(false);
+  });
+
+  it("getPullRequest throws a permanent provider error on an unexpected state value", async () => {
+    // Schema drift must fail loudly, never be silently stored as "open".
+    mockFetch.mockResolvedValueOnce(
+      makeResponse({
+        iid: 7,
+        web_url: "https://gitlab.com/acme/web/-/merge_requests/7",
+        state: "hidden",
+        draft: false,
+        source_branch: "open-inspect/session-1",
+        target_branch: "main",
+      })
+    );
+
+    const provider = new GitLabSourceControlProvider(fakeConfig);
+    const err = await provider
+      .getPullRequest({ owner: "acme", name: "web", number: 7 })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(SourceControlProviderError);
+    expect((err as SourceControlProviderError).errorType).toBe("permanent");
+    expect((err as SourceControlProviderError).message).toContain("state");
+  });
+
+  it("createPullRequest throws a permanent provider error on a malformed response", async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeResponse({ web_url: "https://gitlab.com/acme/web/-/merge_requests/5" }) // missing iid etc.
+    );
+
+    const provider = new GitLabSourceControlProvider(fakeConfig);
+    const err = await provider
+      .createPullRequest(
+        { authType: "pat", token: "user-token" },
+        {
+          repository: {
+            owner: "acme",
+            name: "web",
+            fullName: "acme/web",
+            defaultBranch: "main",
+            isPrivate: true,
+            providerRepoId: 42,
+          },
+          title: "Add feature",
+          body: "Description",
+          sourceBranch: "feature/foo",
+          targetBranch: "main",
+        }
+      )
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(SourceControlProviderError);
+    expect((err as SourceControlProviderError).errorType).toBe("permanent");
+  });
+
+  it("falls back to the original 404 when the by-id resolution body is malformed", async () => {
+    mockFetch
+      .mockResolvedValueOnce(makeResponse({ message: "404 Not Found" }, 404))
+      .mockResolvedValueOnce(makeResponse({ id: 9001 })); // no path/namespace
+
+    const provider = new GitLabSourceControlProvider(fakeConfig);
+    const err = await provider
+      .getPullRequest({ owner: "acme", name: "web", number: 7, repositoryExternalId: "9001" })
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(SourceControlProviderError);
+    expect((err as SourceControlProviderError).httpStatus).toBe(404);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/control-plane/src/source-control/providers/gitlab-provider.ts
+++ b/packages/control-plane/src/source-control/providers/gitlab-provider.ts
@@ -5,6 +5,7 @@
  * using Personal Access Tokens (PAT) for authentication.
  */
 
+import { z } from "zod";
 import { toDisplayStatus } from "@open-inspect/shared";
 import type { InstallationRepository, PullRequestStatus } from "@open-inspect/shared";
 import type {
@@ -23,7 +24,7 @@ import type {
   GitPushAuthContext,
   CredentialHelperAuth,
 } from "../types";
-import { SourceControlProviderError } from "../errors";
+import { SourceControlProviderError, parseProviderResponse } from "../errors";
 import type { GitLabProviderConfig } from "./types";
 import { USER_AGENT } from "./constants";
 
@@ -58,7 +59,12 @@ function encodeProjectWebPath(owner: string, name: string): string {
 
 /** GitLab merge-request state fields as the REST API reports them. */
 interface GitLabMergeRequestStateFields {
-  state: string;
+  /**
+   * GitLab's wire states we accept: merged/closed are terminal, opened is
+   * live, and locked is the transient mid-merge state. Anything else is
+   * schema drift and is rejected at the parse boundary.
+   */
+  state: "opened" | "closed" | "merged" | "locked";
   draft?: boolean | null;
 }
 
@@ -77,18 +83,33 @@ export function deriveGitLabMergeRequestStatus(
   return { lifecycleState: "open", isDraft: data.draft === true };
 }
 
-/** Wire shape of a GitLab REST merge request, limited to the fields we read. */
-interface GitLabMergeRequestResponse {
-  iid: number;
-  web_url: string;
-  state: string;
-  draft?: boolean | null;
-  source_branch: string;
-  target_branch: string;
-  sha?: string;
-  project_id?: number;
-  updated_at?: string;
-}
+/**
+ * Wire schema of a GitLab REST merge request, limited to the fields we read.
+ * `state` is a strict enum — an unexpected value is schema drift and fails
+ * the parse rather than being coerced into an apparently-valid status.
+ */
+const gitlabMergeRequestResponseSchema = z.object({
+  iid: z.number(),
+  web_url: z.string(),
+  state: z.enum(["opened", "closed", "merged", "locked"]),
+  draft: z.boolean().nullable().optional(),
+  source_branch: z.string(),
+  target_branch: z.string(),
+  sha: z.string().nullable().optional(),
+  project_id: z.number().optional(),
+  updated_at: z.string().optional(),
+});
+
+/** The create response additionally carries the API self link. */
+const gitlabCreateMergeRequestResponseSchema = gitlabMergeRequestResponseSchema.extend({
+  _links: z.object({ self: z.string() }),
+});
+
+/** Wire shape of GET /projects/{id}, limited to the location fields. */
+const gitlabProjectLocationSchema = z.object({
+  path: z.string(),
+  namespace: z.object({ full_path: z.string() }),
+});
 
 /** Parse GitLab's ISO-8601 updated_at into epoch ms; undefined when absent/invalid. */
 function parseProviderUpdatedAt(updatedAt: string | undefined): number | undefined {
@@ -223,9 +244,11 @@ export class GitLabSourceControlProvider implements SourceControlProvider {
       );
     }
 
-    const data = (await response.json()) as GitLabMergeRequestResponse & {
-      _links: { self: string };
-    };
+    const data = await parseProviderResponse(
+      response,
+      gitlabCreateMergeRequestResponseSchema,
+      "Failed to create merge request"
+    );
 
     return {
       id: data.iid,
@@ -234,7 +257,7 @@ export class GitLabSourceControlProvider implements SourceControlProvider {
       state: toDisplayStatus(deriveGitLabMergeRequestStatus(data)),
       sourceBranch: data.source_branch,
       targetBranch: data.target_branch,
-      headSha: data.sha,
+      headSha: data.sha ?? undefined,
       repositoryExternalId: data.project_id !== undefined ? String(data.project_id) : undefined,
     };
   }
@@ -267,7 +290,11 @@ export class GitLabSourceControlProvider implements SourceControlProvider {
       );
     }
 
-    const data = (await response.json()) as GitLabMergeRequestResponse;
+    const data = await parseProviderResponse(
+      response,
+      gitlabMergeRequestResponseSchema,
+      "Failed to get merge request"
+    );
     const status = deriveGitLabMergeRequestStatus(data);
 
     return {
@@ -277,7 +304,7 @@ export class GitLabSourceControlProvider implements SourceControlProvider {
       isDraft: status.isDraft,
       headBranch: data.source_branch,
       baseBranch: data.target_branch,
-      headSha: data.sha,
+      headSha: data.sha ?? undefined,
       // The MR response has no namespace path; the path we successfully read
       // from (config, or the by-id resolution) is the current location.
       repoOwner: owner,
@@ -308,14 +335,13 @@ export class GitLabSourceControlProvider implements SourceControlProvider {
       return null;
     }
 
-    const data = (await response.json()) as {
-      path?: string;
-      namespace?: { full_path?: string };
-    };
-    if (!data.namespace?.full_path || !data.path) {
+    // Best-effort repair path: a malformed resolution body degrades to "not
+    // resolved" so the caller surfaces the original 404 instead.
+    const parsed = gitlabProjectLocationSchema.safeParse(await response.json().catch(() => null));
+    if (!parsed.success) {
       return null;
     }
-    return { owner: data.namespace.full_path, name: data.path };
+    return { owner: parsed.data.namespace.full_path, name: parsed.data.path };
   }
 
   /**

--- a/packages/control-plane/src/source-control/providers/gitlab-provider.ts
+++ b/packages/control-plane/src/source-control/providers/gitlab-provider.ts
@@ -5,7 +5,8 @@
  * using Personal Access Tokens (PAT) for authentication.
  */
 
-import type { InstallationRepository } from "@open-inspect/shared";
+import { toDisplayStatus } from "@open-inspect/shared";
+import type { InstallationRepository, PullRequestStatus } from "@open-inspect/shared";
 import type {
   SourceControlProvider,
   SourceControlAuthContext,
@@ -14,6 +15,8 @@ import type {
   RepositoryInfo,
   CreatePullRequestConfig,
   CreatePullRequestResult,
+  GetPullRequestConfig,
+  PullRequestSnapshot,
   BuildManualPullRequestUrlConfig,
   BuildGitPushSpecConfig,
   GitPushSpec,
@@ -51,6 +54,47 @@ function encodeProjectPath(owner: string, name: string): string {
 function encodeProjectWebPath(owner: string, name: string): string {
   const encodedOwner = owner.split("/").map(encodeURIComponent).join("/");
   return `${encodedOwner}/${encodeURIComponent(name)}`;
+}
+
+/** GitLab merge-request state fields as the REST API reports them. */
+interface GitLabMergeRequestStateFields {
+  state: string;
+  draft?: boolean | null;
+}
+
+/**
+ * Pure mapping from GitLab's MR state fields to the stored status. GitLab
+ * models merged as a first-class state; terminal states win over a stale
+ * draft flag (isDraft is only meaningful while open), and the transient
+ * "locked" state (mid-merge) counts as open. Shared by createPullRequest
+ * (user-authed) and getPullRequest (PAT/app-authed).
+ */
+export function deriveGitLabMergeRequestStatus(
+  data: GitLabMergeRequestStateFields
+): PullRequestStatus {
+  if (data.state === "merged") return { lifecycleState: "merged", isDraft: false };
+  if (data.state === "closed") return { lifecycleState: "closed", isDraft: false };
+  return { lifecycleState: "open", isDraft: data.draft === true };
+}
+
+/** Wire shape of a GitLab REST merge request, limited to the fields we read. */
+interface GitLabMergeRequestResponse {
+  iid: number;
+  web_url: string;
+  state: string;
+  draft?: boolean | null;
+  source_branch: string;
+  target_branch: string;
+  sha?: string;
+  project_id?: number;
+  updated_at?: string;
+}
+
+/** Parse GitLab's ISO-8601 updated_at into epoch ms; undefined when absent/invalid. */
+function parseProviderUpdatedAt(updatedAt: string | undefined): number | undefined {
+  if (!updatedAt) return undefined;
+  const parsed = Date.parse(updatedAt);
+  return Number.isNaN(parsed) ? undefined : parsed;
 }
 
 /**
@@ -179,36 +223,99 @@ export class GitLabSourceControlProvider implements SourceControlProvider {
       );
     }
 
-    const data = (await response.json()) as {
-      iid: number;
-      web_url: string;
+    const data = (await response.json()) as GitLabMergeRequestResponse & {
       _links: { self: string };
-      state: string;
-      draft: boolean;
-      source_branch: string;
-      target_branch: string;
     };
-
-    // Check terminal states first — a merged/closed MR cannot also be a draft.
-    let state: CreatePullRequestResult["state"];
-    if (data.state === "merged") {
-      state = "merged";
-    } else if (data.state === "closed") {
-      state = "closed";
-    } else if (data.draft) {
-      state = "draft";
-    } else {
-      state = "open";
-    }
 
     return {
       id: data.iid,
       webUrl: data.web_url,
       apiUrl: data._links.self,
-      state,
+      state: toDisplayStatus(deriveGitLabMergeRequestStatus(data)),
       sourceBranch: data.source_branch,
       targetBranch: data.target_branch,
+      headSha: data.sha,
+      repositoryExternalId: data.project_id !== undefined ? String(data.project_id) : undefined,
     };
+  }
+
+  /**
+   * Read the current state of a merge request using the provider PAT.
+   *
+   * On a 404 with a known stable project id, re-resolves the project's
+   * current path by id and retries once (rename/transfer tolerance).
+   */
+  async getPullRequest(config: GetPullRequestConfig): Promise<PullRequestSnapshot> {
+    let owner = config.owner;
+    let name = config.name;
+    let response = await this.fetchMergeRequest(owner, name, config.number);
+
+    if (response.status === 404 && config.repositoryExternalId) {
+      const resolved = await this.resolveProjectLocationById(config.repositoryExternalId);
+      if (resolved) {
+        ({ owner, name } = resolved);
+        response = await this.fetchMergeRequest(owner, name, config.number);
+      }
+    }
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw SourceControlProviderError.fromFetchError(
+        `Failed to get merge request: ${response.status} ${error}`,
+        new Error(error),
+        response.status
+      );
+    }
+
+    const data = (await response.json()) as GitLabMergeRequestResponse;
+    const status = deriveGitLabMergeRequestStatus(data);
+
+    return {
+      number: data.iid,
+      url: data.web_url,
+      lifecycleState: status.lifecycleState,
+      isDraft: status.isDraft,
+      headBranch: data.source_branch,
+      baseBranch: data.target_branch,
+      headSha: data.sha,
+      // The MR response has no namespace path; the path we successfully read
+      // from (config, or the by-id resolution) is the current location.
+      repoOwner: owner,
+      repoName: name,
+      repositoryExternalId:
+        data.project_id !== undefined ? String(data.project_id) : config.repositoryExternalId,
+      providerUpdatedAt: parseProviderUpdatedAt(data.updated_at),
+    };
+  }
+
+  private fetchMergeRequest(owner: string, name: string, number: number): Promise<Response> {
+    const projectPath = encodeProjectPath(owner, name);
+    return fetchWithTimeout(`${GITLAB_API_BASE}/projects/${projectPath}/merge_requests/${number}`, {
+      headers: this.headers(this.accessToken),
+    });
+  }
+
+  /** Resolve a project's current namespace/path from its stable numeric id. */
+  private async resolveProjectLocationById(
+    repositoryExternalId: string
+  ): Promise<{ owner: string; name: string } | null> {
+    const response = await fetchWithTimeout(
+      `${GITLAB_API_BASE}/projects/${encodeURIComponent(repositoryExternalId)}`,
+      { headers: this.headers(this.accessToken) }
+    );
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = (await response.json()) as {
+      path?: string;
+      namespace?: { full_path?: string };
+    };
+    if (!data.namespace?.full_path || !data.path) {
+      return null;
+    }
+    return { owner: data.namespace.full_path, name: data.path };
   }
 
   /**

--- a/packages/control-plane/src/source-control/types.ts
+++ b/packages/control-plane/src/source-control/types.ts
@@ -4,7 +4,7 @@
  * Core interfaces and type definitions for source control platform abstraction.
  */
 
-import type { InstallationRepository } from "@open-inspect/shared";
+import type { InstallationRepository, PullRequestLifecycleState } from "@open-inspect/shared";
 
 /**
  * Repository information.
@@ -186,6 +186,57 @@ export interface CreatePullRequestResult {
   sourceBranch: string;
   /** Target branch */
   targetBranch: string;
+  /** Head commit SHA at creation, when the provider response carries it */
+  headSha?: string;
+  /** Stable provider repo id (canonical PR identity), when carried */
+  repositoryExternalId?: string;
+}
+
+/**
+ * Configuration for reading a pull request's current state.
+ */
+export interface GetPullRequestConfig {
+  /** Repository owner */
+  owner: string;
+  /** Repository name */
+  name: string;
+  /** Pull request number */
+  number: number;
+  /**
+   * Stable provider repo id, when known. Enables rename/transfer tolerance:
+   * on a 404 the provider re-resolves the repository's current location by
+   * id and retries once.
+   */
+  repositoryExternalId?: string;
+}
+
+/**
+ * Snapshot of a pull request's current provider state.
+ *
+ * Field names mirror PullRequestArtifactMetadata (shared) so the snapshot
+ * flows into the D1 record and DO artifact without a mapping layer;
+ * lifecycleState/isDraft structurally satisfy PullRequestStatus.
+ */
+export interface PullRequestSnapshot {
+  number: number;
+  /** Web URL of the pull request */
+  url: string;
+  lifecycleState: PullRequestLifecycleState;
+  /** Draft readiness; false whenever the PR is not open (invariant) */
+  isDraft: boolean;
+  /** Head (source) branch name */
+  headBranch: string;
+  /** Base (target) branch name */
+  baseBranch: string;
+  headSha?: string;
+  /** Canonical current owner (refreshed when a rename/transfer is detected) */
+  repoOwner: string;
+  /** Canonical current name (refreshed when a rename/transfer is detected) */
+  repoName: string;
+  /** Stable provider repo id */
+  repositoryExternalId?: string;
+  /** Provider's updated_at (epoch ms) — the monotonic write guard source */
+  providerUpdatedAt?: number;
 }
 
 /**
@@ -291,6 +342,20 @@ export interface SourceControlProvider {
    * @throws SourceControlProviderError on configuration or API errors
    */
   listBranches(config: GetRepositoryConfig): Promise<{ name: string }[]>;
+
+  /**
+   * Read the current state of a pull request.
+   *
+   * App-authenticated: credentials come from provider-level configuration
+   * (matching listRepositories), never a caller token — the webhook and
+   * read-through freshness paths run with no user in the loop.
+   *
+   * @param config - PR identifier; include repositoryExternalId when known
+   *   so a 404 triggers a resolve-by-id + single retry (rename tolerance)
+   * @returns Current PR snapshot
+   * @throws SourceControlProviderError
+   */
+  getPullRequest(config: GetPullRequestConfig): Promise<PullRequestSnapshot>;
 
   /**
    * Generate authentication for git push operations.

--- a/packages/shared/src/triggers/github/normalizer.test.ts
+++ b/packages/shared/src/triggers/github/normalizer.test.ts
@@ -462,3 +462,135 @@ describe("normalizeGitHubEvent", () => {
     });
   });
 });
+
+// ─── Typed pull-request facts (PR lifecycle tracking) ─────────────────────────
+
+describe("typed pullRequest facts on pull_request events", () => {
+  const sameRepo = { id: 9001, full_name: "acme-org/my-app" };
+  const forkRepo = { id: 4242, full_name: "quueli/my-app" };
+
+  const trackedPR = {
+    ...basePR,
+    state: "open",
+    draft: false,
+    merged: false,
+    head: { ref: "open-inspect/session-1", sha: "abc1234def5678", repo: sameRepo },
+    base: { ref: "main", repo: sameRepo },
+  };
+
+  it("carries number, state, draft, and merged for an open ready PR", () => {
+    const event = normalizeGitHubEvent("pull_request", {
+      action: "opened",
+      repository: repo,
+      sender,
+      pull_request: trackedPR,
+    });
+
+    expect(event?.pullRequest).toEqual({
+      number: 42,
+      state: "open",
+      draft: false,
+      merged: false,
+      headSha: "abc1234def5678",
+      isCrossRepository: false,
+    });
+  });
+
+  it("carries draft readiness for a draft PR", () => {
+    const event = normalizeGitHubEvent("pull_request", {
+      action: "opened",
+      repository: repo,
+      sender,
+      pull_request: { ...trackedPR, draft: true },
+    });
+
+    expect(event?.pullRequest?.draft).toBe(true);
+  });
+
+  it("distinguishes merged from closed via the merged flag", () => {
+    const event = normalizeGitHubEvent("pull_request", {
+      action: "closed",
+      repository: repo,
+      sender,
+      pull_request: { ...trackedPR, state: "closed", merged: true },
+    });
+
+    expect(event?.pullRequest?.state).toBe("closed");
+    expect(event?.pullRequest?.merged).toBe(true);
+  });
+
+  it("flags a fork-head PR as cross-repository", () => {
+    const event = normalizeGitHubEvent("pull_request", {
+      action: "opened",
+      repository: repo,
+      sender,
+      pull_request: {
+        ...trackedPR,
+        head: { ...trackedPR.head, repo: forkRepo },
+      },
+    });
+
+    expect(event?.pullRequest?.isCrossRepository).toBe(true);
+  });
+
+  it("treats a deleted head repository (null) as cross-repository", () => {
+    // A null head.repo means the fork was deleted; an agent PR's head lives in
+    // the base repository, so this can never be ours.
+    const event = normalizeGitHubEvent("pull_request", {
+      action: "closed",
+      repository: repo,
+      sender,
+      pull_request: { ...trackedPR, head: { ...trackedPR.head, repo: null } },
+    });
+
+    expect(event?.pullRequest?.isCrossRepository).toBe(true);
+  });
+
+  it("leaves isCrossRepository unknown when repo identity is absent from the payload", () => {
+    const event = normalizeGitHubEvent("pull_request", {
+      action: "opened",
+      repository: repo,
+      sender,
+      pull_request: basePR, // no head.repo / base.repo
+    });
+
+    expect(event?.pullRequest?.number).toBe(42);
+    expect(event?.pullRequest?.isCrossRepository).toBeUndefined();
+  });
+
+  it("omits state fields the payload does not carry instead of guessing", () => {
+    const event = normalizeGitHubEvent("pull_request", {
+      action: "opened",
+      repository: repo,
+      sender,
+      pull_request: basePR,
+    });
+
+    expect(event?.pullRequest?.state).toBeUndefined();
+    expect(event?.pullRequest?.draft).toBeUndefined();
+    expect(event?.pullRequest?.merged).toBeUndefined();
+  });
+
+  it("does not attach pullRequest to non-pull_request events", () => {
+    const event = normalizeGitHubEvent("issue_comment", issueCommentPayload);
+
+    expect(event).not.toBeNull();
+    expect(event!.pullRequest).toBeUndefined();
+  });
+
+  it("round-trips pullRequest through the automation event schema boundary", async () => {
+    const { automationEventSchema } = await import("../types");
+    const event = normalizeGitHubEvent("pull_request", {
+      action: "opened",
+      repository: repo,
+      sender,
+      pull_request: trackedPR,
+    });
+
+    const parsed = automationEventSchema.parse(event);
+    expect(parsed.source).toBe("github");
+    if (parsed.source === "github") {
+      expect(parsed.pullRequest).toEqual(event!.pullRequest);
+    }
+  });
+});

--- a/packages/shared/src/triggers/github/normalizer.ts
+++ b/packages/shared/src/triggers/github/normalizer.ts
@@ -116,6 +116,35 @@ export function normalizeGitHubEvent(
 
 // ─── Per-event normalizers ────────────────────────────────────────────────────
 
+/**
+ * Compare head vs base repository identity to detect a fork (cross-repository)
+ * PR. A null head repo means the fork was deleted — never the base repository,
+ * so it counts as cross-repository. Returns undefined when the payload lacks
+ * the identity to compare.
+ */
+function isCrossRepositoryHead(pr: PullRequestPayload["pull_request"]): boolean | undefined {
+  const headRepo = pr.head?.repo;
+  if (headRepo === null) return true;
+  const headId = headRepo?.id;
+  const baseId = pr.base?.repo?.id;
+  if (headId === undefined || baseId === undefined) return undefined;
+  return headId !== baseId;
+}
+
+/** Extract the typed PR facts the payload actually carries (no guessing). */
+function getPullRequestFacts(
+  pr: PullRequestPayload["pull_request"]
+): GitHubAutomationEvent["pullRequest"] {
+  return {
+    number: pr.number,
+    state: pr.state === "open" || pr.state === "closed" ? pr.state : undefined,
+    draft: pr.draft ?? undefined,
+    merged: pr.merged ?? undefined,
+    headSha: pr.head?.sha,
+    isCrossRepository: isCrossRepositoryHead(pr),
+  };
+}
+
 function normalizePullRequest(
   eventType: string,
   action: string,
@@ -137,6 +166,7 @@ function normalizePullRequest(
     targetBranch,
     labels: getPRLabels(pr),
     actor: getActor(payload),
+    pullRequest: getPullRequestFacts(pr),
     contextBlock: buildPullRequestContextBlock(eventType, payload),
     meta: {
       prNumber: pr.number,

--- a/packages/shared/src/triggers/github/webhook-types.ts
+++ b/packages/shared/src/triggers/github/webhook-types.ts
@@ -101,15 +101,33 @@ const baseEventSchema = z.object({
   sender: userSchema.optional(),
 });
 
+// Repo identity on a PR's head/base. `id` is the stable provider repo id used
+// to detect cross-repository (fork) heads; GitHub sends head.repo as null when
+// the fork was deleted.
+const prRepoRefSchema = z.object({
+  id: z.number().optional(),
+  full_name: z.string().optional(),
+});
+
 const pullRequestObjectSchema = z.object({
   number: z.number(),
   title: z.string().optional(),
   body: z.string().nullable().optional(),
+  state: z.string().optional(),
+  draft: z.boolean().nullable().optional(),
   merged: z.boolean().nullable().optional(),
   user: userSchema.optional(),
   labels: labelArraySchema.optional(),
-  head: z.object({ ref: z.string().optional(), sha: z.string().optional() }).optional(),
-  base: z.object({ ref: z.string().optional() }).optional(),
+  head: z
+    .object({
+      ref: z.string().optional(),
+      sha: z.string().optional(),
+      repo: prRepoRefSchema.nullable().optional(),
+    })
+    .optional(),
+  base: z
+    .object({ ref: z.string().optional(), repo: prRepoRefSchema.nullable().optional() })
+    .optional(),
 });
 
 const commentSchema = z.object({

--- a/packages/shared/src/triggers/types.ts
+++ b/packages/shared/src/triggers/types.ts
@@ -44,6 +44,25 @@ interface BaseAutomationEvent {
 
 // ─── Source-Specific Variants ─────────────────────────────────────────────────
 
+/**
+ * Typed pull-request facts carried on pull_request events. Every field beyond
+ * the number is optional and reflects only what the webhook payload actually
+ * said — consumers fall back to a provider read when a field is absent.
+ */
+export interface GitHubPullRequestEventFacts {
+  number: number;
+  /** Raw provider state; merged-vs-closed is disambiguated by `merged`. */
+  state?: "open" | "closed";
+  draft?: boolean;
+  merged?: boolean;
+  headSha?: string;
+  /**
+   * True when the head branch lives in a different repository than the base
+   * (fork PR). Undefined when the payload lacks repo identity to compare.
+   */
+  isCrossRepository?: boolean;
+}
+
 export interface GitHubAutomationEvent extends BaseAutomationEvent {
   source: "github";
   repoOwner: string;
@@ -56,6 +75,8 @@ export interface GitHubAutomationEvent extends BaseAutomationEvent {
   actor?: string;
   changedFiles?: string[];
   checkConclusion?: string;
+  /** Present only on pull_request events. */
+  pullRequest?: GitHubPullRequestEventFacts;
 }
 
 export interface LinearAutomationEvent extends BaseAutomationEvent {
@@ -123,6 +144,16 @@ export const automationEventSchema = z.discriminatedUnion("source", [
     actor: z.string().optional(),
     changedFiles: z.array(z.string()).optional(),
     checkConclusion: z.string().optional(),
+    pullRequest: z
+      .object({
+        number: z.number(),
+        state: z.enum(["open", "closed"]).optional(),
+        draft: z.boolean().optional(),
+        merged: z.boolean().optional(),
+        headSha: z.string().optional(),
+        isCrossRepository: z.boolean().optional(),
+      })
+      .optional(),
   }),
   z.object({
     ...baseAutomationEventSchema,

--- a/packages/shared/src/types/artifacts.test.ts
+++ b/packages/shared/src/types/artifacts.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  sessionArtifactSchema,
+  toDisplayStatus,
+  type PullRequestArtifactMetadata,
+  type PullRequestStatus,
+} from "./artifacts";
+
+describe("toDisplayStatus", () => {
+  it("maps merged lifecycle to merged", () => {
+    expect(toDisplayStatus({ lifecycleState: "merged", isDraft: false })).toBe("merged");
+  });
+
+  it("maps closed lifecycle to closed", () => {
+    expect(toDisplayStatus({ lifecycleState: "closed", isDraft: false })).toBe("closed");
+  });
+
+  it("maps open + draft to draft", () => {
+    expect(toDisplayStatus({ lifecycleState: "open", isDraft: true })).toBe("draft");
+  });
+
+  it("maps open + ready to open", () => {
+    expect(toDisplayStatus({ lifecycleState: "open", isDraft: false })).toBe("open");
+  });
+
+  it("ignores a stray draft flag on terminal states (isDraft is only meaningful while open)", () => {
+    // The invariant is enforced at the write boundaries; display must not
+    // resurrect "draft" for a PR that already merged or closed.
+    expect(toDisplayStatus({ lifecycleState: "merged", isDraft: true })).toBe("merged");
+    expect(toDisplayStatus({ lifecycleState: "closed", isDraft: true })).toBe("closed");
+  });
+});
+
+describe("sessionArtifactSchema.updatedAt", () => {
+  const base = {
+    id: "artifact-1",
+    type: "pr",
+    url: "https://github.com/acme/web/pull/7",
+    metadata: null,
+    createdAt: 1_700_000_000_000,
+  };
+
+  it("accepts an artifact without updatedAt (rolling deploy: old producers)", () => {
+    const parsed = sessionArtifactSchema.parse(base);
+    expect(parsed.updatedAt).toBeUndefined();
+  });
+
+  it("accepts an artifact with updatedAt", () => {
+    const parsed = sessionArtifactSchema.parse({ ...base, updatedAt: 1_700_000_001_000 });
+    expect(parsed.updatedAt).toBe(1_700_000_001_000);
+  });
+
+  it("rejects a non-numeric updatedAt", () => {
+    expect(sessionArtifactSchema.safeParse({ ...base, updatedAt: "later" }).success).toBe(false);
+  });
+});
+
+describe("PullRequestArtifactMetadata", () => {
+  it("is structurally compatible with the untyped artifact metadata record", () => {
+    // The DO stores metadata as Record<string, unknown>; the typed shape must
+    // round-trip through that boundary without a cast at write sites.
+    const metadata: PullRequestArtifactMetadata = {
+      number: 7,
+      lifecycleState: "open",
+      isDraft: true,
+      head: "open-inspect/session-1",
+      base: "main",
+      headSha: "abc123",
+      repoOwner: "acme",
+      repoName: "web",
+      repositoryExternalId: "9001",
+      providerUpdatedAt: 1_700_000_000_000,
+    };
+    const record: Record<string, unknown> = { ...metadata };
+    expect(record.number).toBe(7);
+
+    const status: PullRequestStatus = {
+      lifecycleState: metadata.lifecycleState,
+      isDraft: metadata.isDraft,
+    };
+    expect(toDisplayStatus(status)).toBe("draft");
+  });
+});

--- a/packages/shared/src/types/artifacts.ts
+++ b/packages/shared/src/types/artifacts.ts
@@ -11,6 +11,11 @@ export interface SessionArtifact {
   url: string | null;
   metadata: Record<string, unknown> | null;
   createdAt: number;
+  /**
+   * Last content change (epoch ms). Optional for rolling deploys — producers
+   * predating PR lifecycle tracking omit it; consumers fall back to createdAt.
+   */
+  updatedAt?: number;
 }
 
 export const sessionArtifactSchema = z.object({
@@ -19,7 +24,56 @@ export const sessionArtifactSchema = z.object({
   url: z.string().nullable(),
   metadata: recordSchema.nullable(),
   createdAt: z.number(),
+  updatedAt: z.number().optional(),
 });
+
+// ─── Pull request lifecycle ───────────────────────────────────────────────────
+
+/** Base lifecycle of a pull request as stored (merged is terminal). */
+export type PullRequestLifecycleState = "open" | "closed" | "merged";
+
+/**
+ * Stored PR state: lifecycle and draft readiness are independent facts.
+ * Invariant (enforced at write boundaries): isDraft is true only while
+ * lifecycleState === "open".
+ */
+export interface PullRequestStatus {
+  lifecycleState: PullRequestLifecycleState;
+  isDraft: boolean;
+}
+
+/** UI-facing status derived from PullRequestStatus. Never persisted. */
+export type PullRequestDisplayStatus = "draft" | "open" | "merged" | "closed";
+
+export function toDisplayStatus(status: PullRequestStatus): PullRequestDisplayStatus {
+  if (status.lifecycleState === "merged") return "merged";
+  if (status.lifecycleState === "closed") return "closed";
+  return status.isDraft ? "draft" : "open";
+}
+
+/**
+ * Typed metadata stored on `pr` artifacts. Mirrors the D1
+ * session_pull_requests record's provider-derived fields; the DO artifact is a
+ * live view of that record. Spread-compatible with the untyped
+ * Record<string, unknown> metadata boundary.
+ */
+export interface PullRequestArtifactMetadata {
+  number: number;
+  lifecycleState: PullRequestLifecycleState;
+  isDraft: boolean;
+  /** Head (source) branch name. */
+  head: string;
+  /** Base (target) branch name. */
+  base: string;
+  headSha?: string;
+  repoOwner: string;
+  repoName: string;
+  /** Stable provider repo id (canonical identity); absent on legacy rows. */
+  repositoryExternalId?: string;
+  /** Provider's updated_at (epoch ms) — the monotonic write guard source. */
+  providerUpdatedAt?: number;
+  // No `provider` field: provider is deployment state (ADR-0001).
+}
 
 /**
  * Metadata stored on branch artifacts when PR creation falls back to manual flow.

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -51,12 +51,17 @@ export type {
   ClassificationResult,
 } from "./repository-catalog";
 
+export { toDisplayStatus } from "./artifacts";
 export type {
   SessionArtifact,
   ManualPullRequestArtifactMetadata,
   ScreenshotArtifactMetadata,
   VideoArtifactMetadata,
   PullRequest,
+  PullRequestLifecycleState,
+  PullRequestStatus,
+  PullRequestDisplayStatus,
+  PullRequestArtifactMetadata,
   ArtifactResponse,
   ListArtifactsResponse,
   ToolCallSummary,
@@ -73,6 +78,7 @@ export type {
   SessionMessage,
   SessionState,
   ParticipantPresence,
+  PullRequestSummary,
 } from "./sessions";
 
 export { serverMessageSchema } from "./server-messages";

--- a/packages/shared/src/types/server-messages.test.ts
+++ b/packages/shared/src/types/server-messages.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { serverMessageSchema } from "./server-messages";
+import type { PullRequestSummary, Session } from "./sessions";
+
+describe("artifact_updated server message", () => {
+  const artifact = {
+    id: "artifact-1",
+    type: "pr",
+    url: "https://github.com/acme/web/pull/7",
+    metadata: { number: 7, lifecycleState: "merged", isDraft: false },
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_005_000,
+  };
+
+  it("parses artifact_updated mirroring artifact_created", () => {
+    const parsed = serverMessageSchema.parse({ type: "artifact_updated", artifact });
+    expect(parsed.type).toBe("artifact_updated");
+    if (parsed.type === "artifact_updated") {
+      expect(parsed.artifact.id).toBe("artifact-1");
+      expect(parsed.artifact.updatedAt).toBe(1_700_000_005_000);
+    }
+  });
+
+  it("still parses artifact_created (rolling compatibility)", () => {
+    const parsed = serverMessageSchema.parse({ type: "artifact_created", artifact });
+    expect(parsed.type).toBe("artifact_created");
+  });
+
+  it("rejects artifact_updated without an artifact", () => {
+    expect(serverMessageSchema.safeParse({ type: "artifact_updated" }).success).toBe(false);
+  });
+});
+
+describe("Session.pullRequestSummary contract", () => {
+  it("is optional on the session list contract and counts by display status", () => {
+    expectTypeOf<Session["pullRequestSummary"]>().toEqualTypeOf<PullRequestSummary | undefined>();
+    const summary: PullRequestSummary = { total: 2, open: 1, draft: 0, merged: 1, closed: 0 };
+    expect(summary.total).toBe(2);
+  });
+});

--- a/packages/shared/src/types/server-messages.ts
+++ b/packages/shared/src/types/server-messages.ts
@@ -44,6 +44,10 @@ export const serverMessageSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("sandbox_ready") }),
   z.object({ type: z.literal("sandbox_error"), error: z.string() }),
   z.object({ type: z.literal("artifact_created"), artifact: sessionArtifactSchema }),
+  // Existing artifact changed (e.g. PR lifecycle update). Consumers upsert by
+  // artifact id; clients predating this message ignore it and resync on
+  // reconnect via `subscribed.artifacts`.
+  z.object({ type: z.literal("artifact_updated"), artifact: sessionArtifactSchema }),
   // repoOwner/repoName identify the repository whose branch updated in a
   // multi-repo session (absent means the session's sole repository).
   z.object({

--- a/packages/shared/src/types/sessions.ts
+++ b/packages/shared/src/types/sessions.ts
@@ -25,6 +25,19 @@ export interface SessionParticipant {
   role: ParticipantRole;
 }
 
+/**
+ * Aggregate PR counts for a session, grouped by display status. Computed from
+ * the D1 session_pull_requests table for the session list; total = open +
+ * draft + merged + closed.
+ */
+export interface PullRequestSummary {
+  total: number;
+  open: number;
+  draft: number;
+  merged: number;
+  closed: number;
+}
+
 export interface Session {
   id: string;
   title: string | null;
@@ -53,6 +66,12 @@ export interface Session {
    * renders it.
    */
   environmentId?: string | null;
+  /**
+   * Aggregate PR status counts for the global sidebar. Populated by the
+   * session list index from session_pull_requests; absent while versions
+   * overlap or when the session has no tracked PRs.
+   */
+  pullRequestSummary?: PullRequestSummary;
 }
 
 export interface SessionMessage {


### PR DESCRIPTION
## Summary

PR 1 of 5 for **pull request lifecycle tracking** (design: `docs/internal/2026-07-09-pull-request-artifact-tracking-design.md`, v2 simplified). Pure contracts + provider read — no runtime callers yet, so nothing can regress.

### Shared contracts
- `PullRequestLifecycleState` / `PullRequestStatus` (lifecycle and draft are independent facts; invariant: `isDraft` only while open) + pure `toDisplayStatus` — `types/artifacts.ts`
- `PullRequestArtifactMetadata` — typed successor to the untyped `pr` artifact metadata (no `provider` field, ADR-0001)
- `SessionArtifact.updatedAt` (optional in Zod for rolling deploys; consumers fall back to `createdAt`)
- `artifact_updated` server message mirroring `artifact_created` — `types/server-messages.ts`
- `PullRequestSummary` riding the `Session` list contract (optional) — `types/sessions.ts`

### Normalizer extension (webhook path needs no provider call)
- Typed `pullRequest` facts on `GitHubAutomationEvent`: promotes `prNumber` out of the untyped `meta` bag and carries `state` / `draft` / `merged` / `headSha` / `isCrossRepository`
- `isCrossRepository` compares head vs base repo id; a deleted-fork `null` head repo counts as cross-repository (Superset PR #3625 lesson — branch names alone must never attach a fork PR)
- Fields reflect only what the payload said — absent fields stay `undefined`, no guessing

### Provider contract
- `getPullRequest(config)` on `SourceControlProvider` — **app-authenticated** (installation token / PAT resolved inside the provider, no caller token), returns a `PullRequestSnapshot` whose field names mirror the artifact metadata
- Rename/transfer tolerance: on 404 with a known stable repo id, resolve the current location by id and retry once
- Pure per-provider state mapping (`deriveGitHubPullRequestStatus`, `deriveGitLabMergeRequestStatus`) now shared with `createPullRequest`; terminal states suppress stale draft flags
- `createPullRequest` now captures `headSha` + `repositoryExternalId` (both optional)

## Test plan
- [x] TDD: all new behavior covered red→green (`artifacts.test.ts`, `server-messages.test.ts`, normalizer + both provider suites)
- [x] `npm test` green across all 6 TS packages (shared 394, control-plane 1713, github-bot 123, web 680, slack-bot 227, linear-bot 136)
- [x] `npm run typecheck` + `npm run lint` clean

## Next
PR 2: D1 `session_pull_requests` migration + `SessionPullRequestStore`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized pull request lifecycle/status handling across GitHub and GitLab (draft/open/merged/closed), including freshness timestamps.
  * PR create/get results now include head SHA and repository external id when available.
  * GitHub webhook normalization now emits typed pull request facts and cross-repository detection.
  * Added `artifact_updated` messaging support and session-level pull request summaries.

* **Bug Fixes**
  * Improved rename resilience by retrying once when a stable repository/project external id is available.
  * Added stricter provider response validation with clearer permanent errors for malformed or unexpected data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->