### PR TITLE
feat: surface PR lifecycle status in session list and web UI

### DIFF
--- a/packages/control-plane/src/db/session-index.test.ts
+++ b/packages/control-plane/src/db/session-index.test.ts
@@ -40,6 +40,7 @@ const QUERY_PATTERNS = {
   INSERT_SESSION: /^INSERT OR IGNORE INTO sessions/,
   INSERT_SESSION_REPO: /^INSERT INTO session_repositories/,
   SELECT_SESSION_REPOS: /^SELECT \* FROM session_repositories WHERE session_id IN/,
+  SELECT_PR_SUMMARIES: /FROM session_pull_requests WHERE session_id IN/,
   DELETE_SESSION_REPOS: /^DELETE FROM session_repositories WHERE session_id = \?$/,
   SELECT_BY_ID: /^SELECT \* FROM sessions WHERE id = \?$/,
   SELECT_COUNT: /^SELECT COUNT\(\*\) as count FROM sessions\b/,
@@ -144,6 +145,11 @@ class FakeD1Database {
       return this.repositoryRows
         .filter((r) => ids.has(r.session_id))
         .sort((a, b) => a.session_id.localeCompare(b.session_id) || a.position - b.position);
+    }
+
+    // PR summaries attach only for sessions with records; this fake has none.
+    if (QUERY_PATTERNS.SELECT_PR_SUMMARIES.test(normalized)) {
+      return [];
     }
 
     throw new Error(`Unexpected all() query: ${query}`);

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -1,4 +1,10 @@
-import type { SessionListRepository, SessionStatus, SpawnSource } from "@open-inspect/shared";
+import type {
+  PullRequestSummary,
+  SessionListRepository,
+  SessionStatus,
+  SpawnSource,
+} from "@open-inspect/shared";
+import { SessionPullRequestStore } from "./session-pull-request-store";
 
 /**
  * One member of a session's repository set — the identity subset of the
@@ -41,6 +47,11 @@ export interface SessionEntry {
    * repo-launched/ad-hoc sessions. PR-12 renders it on the session list.
    */
   environmentId?: string | null;
+  /**
+   * Per-status PR counts from session_pull_requests; absent when the session
+   * has no tracked PRs. Attached by list() for the global sidebar.
+   */
+  pullRequestSummary?: PullRequestSummary;
 }
 
 interface SessionRepositoryRow {
@@ -309,12 +320,34 @@ export class SessionIndexStore {
       .all<SessionRow>();
 
     const rows = result.results || [];
-    const sessions = await this.withRepositories(rows.slice(0, limit).map(toEntry));
+    const sessions = await this.withPullRequestSummaries(
+      await this.withRepositories(rows.slice(0, limit).map(toEntry))
+    );
 
     return {
       sessions,
       hasMore: rows.length > limit,
     };
+  }
+
+  /**
+   * Return copies of the given entries with per-session PR status summaries
+   * attached, resolved in one grouped query over session_pull_requests
+   * (mirrors withRepositories). Sessions without PR records are returned
+   * as-is, without the field. PR state never influences session ordering —
+   * this only decorates the already-paged rows.
+   */
+  private async withPullRequestSummaries(sessions: SessionEntry[]): Promise<SessionEntry[]> {
+    if (sessions.length === 0) return sessions;
+
+    const summaries = await new SessionPullRequestStore(this.db).summariesForSessions(
+      sessions.map((session) => session.id)
+    );
+
+    return sessions.map((session) => {
+      const pullRequestSummary = summaries.get(session.id);
+      return pullRequestSummary ? { ...session, pullRequestSummary } : session;
+    });
   }
 
   /**

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -320,9 +320,7 @@ export class SessionIndexStore {
       .all<SessionRow>();
 
     const rows = result.results || [];
-    const sessions = await this.withPullRequestSummaries(
-      await this.withRepositories(rows.slice(0, limit).map(toEntry))
-    );
+    const sessions = await this.decorateEntries(rows.slice(0, limit).map(toEntry));
 
     return {
       sessions,
@@ -331,42 +329,45 @@ export class SessionIndexStore {
   }
 
   /**
-   * Return copies of the given entries with per-session PR status summaries
-   * attached, resolved in one grouped query over session_pull_requests
-   * (mirrors withRepositories). Sessions without PR records are returned
-   * as-is, without the field. PR state never influences session ordering —
-   * this only decorates the already-paged rows.
+   * Attach member repository lists and PR status summaries to the paged
+   * entries. The two lookups are independent — each is one grouped query
+   * keyed by the same session ids — so they run in parallel and merge onto
+   * the entries in a single pass. Sessions without rows are returned without
+   * the field: consumers fall back to the scalar repo columns, and PR state
+   * never influences session ordering (this only decorates paged rows).
    */
-  private async withPullRequestSummaries(sessions: SessionEntry[]): Promise<SessionEntry[]> {
+  private async decorateEntries(sessions: SessionEntry[]): Promise<SessionEntry[]> {
     if (sessions.length === 0) return sessions;
+    const sessionIds = sessions.map((session) => session.id);
 
-    const summaries = await new SessionPullRequestStore(this.db).summariesForSessions(
-      sessions.map((session) => session.id)
-    );
+    const [repositoriesBySession, summariesBySession] = await Promise.all([
+      this.repositoriesForSessions(sessionIds),
+      new SessionPullRequestStore(this.db).summariesForSessions(sessionIds),
+    ]);
 
     return sessions.map((session) => {
-      const pullRequestSummary = summaries.get(session.id);
-      return pullRequestSummary ? { ...session, pullRequestSummary } : session;
+      const repositories = repositoriesBySession.get(session.id);
+      const pullRequestSummary = summariesBySession.get(session.id);
+      return {
+        ...session,
+        ...(repositories ? { repositories } : {}),
+        ...(pullRequestSummary ? { pullRequestSummary } : {}),
+      };
     });
   }
 
-  /**
-   * Return copies of the given entries with member repository lists attached,
-   * resolved in one query. The input entries are not mutated. Sessions
-   * without rows (pre-feature) are returned as-is, without the field, so
-   * consumers fall back to the scalar columns.
-   */
-  private async withRepositories(sessions: SessionEntry[]): Promise<SessionEntry[]> {
-    if (sessions.length === 0) return sessions;
-
-    const placeholders = sessions.map(() => "?").join(", ");
+  /** Member repository lists for the given sessions, in one query. */
+  private async repositoriesForSessions(
+    sessionIds: readonly string[]
+  ): Promise<Map<string, SessionIndexRepository[]>> {
+    const placeholders = sessionIds.map(() => "?").join(", ");
     const result = await this.db
       .prepare(
         `SELECT * FROM session_repositories
          WHERE session_id IN (${placeholders})
          ORDER BY session_id, position`
       )
-      .bind(...sessions.map((s) => s.id))
+      .bind(...sessionIds)
       .all<SessionRepositoryRow>();
 
     const bySession = new Map<string, SessionIndexRepository[]>();
@@ -380,11 +381,7 @@ export class SessionIndexStore {
       });
       bySession.set(row.session_id, list);
     }
-
-    return sessions.map((session) => {
-      const repositories = bySession.get(session.id);
-      return repositories ? { ...session, repositories } : session;
-    });
+    return bySession;
   }
 
   async updateTitle(id: string, title: string): Promise<boolean> {

--- a/packages/control-plane/src/session/pr-artifacts.ts
+++ b/packages/control-plane/src/session/pr-artifacts.ts
@@ -1,4 +1,4 @@
-import { prArtifactBelongsToRepo } from "@open-inspect/shared";
+import { findPrArtifactForRepo as findPrArtifactForRepoShared } from "@open-inspect/shared";
 import type { RepoIdentity } from "./repository-target";
 import type { ArtifactRow } from "./types";
 
@@ -23,19 +23,23 @@ export function parsePrArtifactRepo(metadata: string | null): RepoIdentity | nul
 }
 
 /**
- * Find a PR artifact belonging to the target repo. Identity-less metadata
- * matches only when the target is the primary — the ownership convention lives
- * in shared {@link prArtifactBelongsToRepo}; this only supplies the parsed
- * identity from ArtifactRow metadata.
+ * Find a PR artifact belonging to the target repo. The find-over-convention
+ * step is the shared findPrArtifactForRepo (also used by the web sidebar and
+ * action bar); this adapter only parses the identity out of ArtifactRow's
+ * JSON metadata.
  */
 export function findPrArtifactForRepo(
   artifacts: ArtifactRow[],
   targetRepo: RepoIdentity,
   isPrimary: boolean
 ): ArtifactRow | undefined {
-  return artifacts.find(
-    (artifact) =>
-      artifact.type === "pr" &&
-      prArtifactBelongsToRepo(parsePrArtifactRepo(artifact.metadata), targetRepo, isPrimary)
-  );
+  return findPrArtifactForRepoShared(
+    artifacts.map((artifact) => ({
+      artifact,
+      type: artifact.type,
+      metadata: parsePrArtifactRepo(artifact.metadata),
+    })),
+    targetRepo,
+    isPrimary
+  )?.artifact;
 }

--- a/packages/control-plane/src/session/pr-artifacts.ts
+++ b/packages/control-plane/src/session/pr-artifacts.ts
@@ -1,4 +1,4 @@
-import { findPrArtifactForRepo as findPrArtifactForRepoShared } from "@open-inspect/shared";
+import { prArtifactBelongsToRepo } from "@open-inspect/shared";
 import type { RepoIdentity } from "./repository-target";
 import type { ArtifactRow } from "./types";
 
@@ -23,23 +23,19 @@ export function parsePrArtifactRepo(metadata: string | null): RepoIdentity | nul
 }
 
 /**
- * Find a PR artifact belonging to the target repo. The find-over-convention
- * step is the shared findPrArtifactForRepo (also used by the web sidebar and
- * action bar); this adapter only parses the identity out of ArtifactRow's
- * JSON metadata.
+ * Find a PR artifact belonging to the target repo. The ownership convention
+ * is the shared prArtifactBelongsToRepo (the same rule the web sidebar and
+ * action bar apply); this find works on ArtifactRow's native JSON-string
+ * metadata directly.
  */
 export function findPrArtifactForRepo(
   artifacts: ArtifactRow[],
   targetRepo: RepoIdentity,
   isPrimary: boolean
 ): ArtifactRow | undefined {
-  return findPrArtifactForRepoShared(
-    artifacts.map((artifact) => ({
-      artifact,
-      type: artifact.type,
-      metadata: parsePrArtifactRepo(artifact.metadata),
-    })),
-    targetRepo,
-    isPrimary
-  )?.artifact;
+  return artifacts.find(
+    (artifact) =>
+      artifact.type === "pr" &&
+      prArtifactBelongsToRepo(parsePrArtifactRepo(artifact.metadata), targetRepo, isPrimary)
+  );
 }

--- a/packages/control-plane/test/integration/d1-session-index.test.ts
+++ b/packages/control-plane/test/integration/d1-session-index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { env } from "cloudflare:test";
 import { SessionIndexStore } from "../../src/db/session-index";
+import { SessionPullRequestStore } from "../../src/db/session-pull-request-store";
 import { cleanD1Tables } from "./cleanup";
 
 describe("D1 SessionIndexStore", () => {
@@ -82,6 +83,69 @@ describe("D1 SessionIndexStore", () => {
 
       expect(await store.isRepositoryAssociated("assoc-session-2", "acme", "solo")).toBe(true);
       expect(await store.isRepositoryAssociated("assoc-session-2", "acme", "web-app")).toBe(false);
+    });
+  });
+
+  it("attaches pullRequestSummary from session_pull_requests without reordering", async () => {
+    const store = new SessionIndexStore(env.DB);
+    const prStore = new SessionPullRequestStore(env.DB);
+    const now = Date.now();
+
+    for (const [id, updatedAt] of [
+      ["summary-session-new", now],
+      ["summary-session-old", now - 10_000],
+    ] as const) {
+      await store.create({
+        id,
+        title: null,
+        repoOwner: "acme",
+        repoName: "web-app",
+        model: "anthropic/claude-haiku-4-5",
+        reasoningEffort: null,
+        baseBranch: null,
+        status: "active",
+        createdAt: now - 20_000,
+        updatedAt,
+      });
+    }
+
+    // Two PRs on the OLDER session — its list position must not change.
+    for (const [artifactId, prNumber, lifecycleState, isDraft] of [
+      ["summary-artifact-1", 1, "open", true],
+      ["summary-artifact-2", 2, "merged", false],
+    ] as const) {
+      await prStore.upsert({
+        artifactId,
+        sessionId: "summary-session-old",
+        repositoryExternalId: String(prNumber),
+        repoOwner: "acme",
+        repoName: "web-app",
+        prNumber,
+        url: `https://github.com/acme/web-app/pull/${prNumber}`,
+        lifecycleState,
+        isDraft,
+        headBranch: "open-inspect/summary-session-old",
+        baseBranch: "main",
+        headSha: null,
+        providerUpdatedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
+
+    const { sessions } = await store.list();
+
+    expect(sessions.map((session) => session.id)).toEqual([
+      "summary-session-new",
+      "summary-session-old",
+    ]);
+    expect(sessions[0].pullRequestSummary).toBeUndefined();
+    expect(sessions[1].pullRequestSummary).toEqual({
+      total: 2,
+      open: 0,
+      draft: 1,
+      merged: 1,
+      closed: 0,
     });
   });
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -27,6 +27,7 @@ export {
   MAX_SESSION_REPOSITORIES,
   sessionRepositoryStateSchema,
   prArtifactBelongsToRepo,
+  findPrArtifactForRepo,
   repositoryInputSchema,
   repositoriesInputSchema,
   sessionRepositoriesInputSchema,
@@ -39,6 +40,7 @@ export type {
   SessionListRepository,
   RepositoryInput,
   RepositoryPair,
+  PrArtifactLike,
 } from "./repositories";
 
 export type {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -27,7 +27,6 @@ export {
   MAX_SESSION_REPOSITORIES,
   sessionRepositoryStateSchema,
   prArtifactBelongsToRepo,
-  findPrArtifactForRepo,
   repositoryInputSchema,
   repositoriesInputSchema,
   sessionRepositoriesInputSchema,
@@ -40,7 +39,6 @@ export type {
   SessionListRepository,
   RepositoryInput,
   RepositoryPair,
-  PrArtifactLike,
 } from "./repositories";
 
 export type {

--- a/packages/shared/src/types/repositories.ts
+++ b/packages/shared/src/types/repositories.ts
@@ -60,8 +60,8 @@ export interface SessionListRepository {
  * before multi-repo support carry no repo identity (`artifactRepo === null`)
  * and by construction belong to the session's primary. Identity is compared
  * case-insensitively, matching repo-identity comparison elsewhere. This is the
- * single home of that convention — the control-plane per-repo prUrl projection
- * (findPrArtifactForRepo) and the web per-repo PR chips both go through here.
+ * single home of that convention — the control-plane and web PR-artifact
+ * lookups (each a native find over its own artifact shape) go through here.
  */
 export function prArtifactBelongsToRepo(
   artifactRepo: { repoOwner: string; repoName: string } | null,
@@ -73,37 +73,6 @@ export function prArtifactBelongsToRepo(
     artifactRepo.repoOwner.toLowerCase() === targetRepo.repoOwner.toLowerCase() &&
     artifactRepo.repoName.toLowerCase() === targetRepo.repoName.toLowerCase()
   );
-}
-
-/**
- * The shape findPrArtifactForRepo needs: the artifact type discriminator plus
- * parsed metadata that may carry the owning repo identity.
- */
-export interface PrArtifactLike {
-  type: string;
-  metadata?: { repoOwner?: unknown; repoName?: unknown } | null;
-}
-
-/**
- * Find the PR artifact belonging to a member repository — the find step over
- * the prArtifactBelongsToRepo convention, shared by the control-plane per-repo
- * prUrl projection and the web sidebar/action-bar selection. Callers with
- * unparsed (JSON string) metadata parse before calling.
- */
-export function findPrArtifactForRepo<T extends PrArtifactLike>(
-  artifacts: readonly T[],
-  targetRepo: { repoOwner: string; repoName: string },
-  targetIsPrimary: boolean
-): T | undefined {
-  return artifacts.find((artifact) => {
-    if (artifact.type !== "pr") return false;
-    const { repoOwner, repoName } = artifact.metadata ?? {};
-    const artifactRepo =
-      typeof repoOwner === "string" && typeof repoName === "string"
-        ? { repoOwner, repoName }
-        : null;
-    return prArtifactBelongsToRepo(artifactRepo, targetRepo, targetIsPrimary);
-  });
 }
 
 /**

--- a/packages/shared/src/types/repositories.ts
+++ b/packages/shared/src/types/repositories.ts
@@ -76,6 +76,37 @@ export function prArtifactBelongsToRepo(
 }
 
 /**
+ * The shape findPrArtifactForRepo needs: the artifact type discriminator plus
+ * parsed metadata that may carry the owning repo identity.
+ */
+export interface PrArtifactLike {
+  type: string;
+  metadata?: { repoOwner?: unknown; repoName?: unknown } | null;
+}
+
+/**
+ * Find the PR artifact belonging to a member repository — the find step over
+ * the prArtifactBelongsToRepo convention, shared by the control-plane per-repo
+ * prUrl projection and the web sidebar/action-bar selection. Callers with
+ * unparsed (JSON string) metadata parse before calling.
+ */
+export function findPrArtifactForRepo<T extends PrArtifactLike>(
+  artifacts: readonly T[],
+  targetRepo: { repoOwner: string; repoName: string },
+  targetIsPrimary: boolean
+): T | undefined {
+  return artifacts.find((artifact) => {
+    if (artifact.type !== "pr") return false;
+    const { repoOwner, repoName } = artifact.metadata ?? {};
+    const artifactRepo =
+      typeof repoOwner === "string" && typeof repoName === "string"
+        ? { repoOwner, repoName }
+        : null;
+    return prArtifactBelongsToRepo(artifactRepo, targetRepo, targetIsPrimary);
+  });
+}
+
+/**
  * One repository entry on a create/update request. Identifiers are normalized
  * (trim + lowercase) by the schema, matching normalizeOptionalRepositoryPair —
  * the list-entry twin of that scalar helper.

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -494,6 +494,11 @@ function SessionContent({
           id: sessionId,
           status: sessionState?.status || "",
           artifacts,
+          primaryRepo:
+            sessionState?.repositories?.[0] ??
+            (sessionState?.repoOwner && sessionState?.repoName
+              ? { repoOwner: sessionState.repoOwner, repoName: sessionState.repoName }
+              : null),
           onArchive: handleArchive,
           onUnarchive: handleUnarchive,
         }}

--- a/packages/web/src/components/action-bar.test.tsx
+++ b/packages/web/src/components/action-bar.test.tsx
@@ -91,3 +91,43 @@ describe("ActionBar", () => {
     expect(screen.queryByText(/Media/)).not.toBeInTheDocument();
   });
 });
+
+describe("repository-aware PR selection", () => {
+  const webPr = {
+    id: "artifact-pr-web",
+    type: "pr" as const,
+    url: "https://github.com/acme/web/pull/1",
+    metadata: { prNumber: 1, repoOwner: "acme", repoName: "web" },
+    createdAt: 1,
+  };
+  const backendPr = {
+    id: "artifact-pr-backend",
+    type: "pr" as const,
+    url: "https://github.com/acme/backend/pull/9",
+    metadata: { prNumber: 9, repoOwner: "acme", repoName: "backend" },
+    createdAt: 2,
+  };
+
+  it("selects the primary repo's PR, not the first PR artifact", () => {
+    render(
+      <ActionBar
+        sessionId="session-1"
+        sessionStatus="active"
+        artifacts={[backendPr, webPr]}
+        primaryRepo={{ repoOwner: "acme", repoName: "web" }}
+      />
+    );
+
+    const link = screen.getByRole("link", { name: /view pr/i });
+    expect(link).toHaveAttribute("href", "https://github.com/acme/web/pull/1");
+  });
+
+  it("falls back to the first PR artifact without repo context", () => {
+    render(
+      <ActionBar sessionId="session-1" sessionStatus="active" artifacts={[backendPr, webPr]} />
+    );
+
+    const link = screen.getByRole("link", { name: /view pr/i });
+    expect(link).toHaveAttribute("href", "https://github.com/acme/backend/pull/9");
+  });
+});

--- a/packages/web/src/components/action-bar.tsx
+++ b/packages/web/src/components/action-bar.tsx
@@ -20,11 +20,18 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { getSafeExternalUrl } from "@/lib/urls";
+import { findPrArtifactForRepo } from "@open-inspect/shared";
 
 interface ActionBarProps {
   sessionId: string;
   sessionStatus: string;
   artifacts: Artifact[];
+  /**
+   * The session's primary repository. When present, "View PR" is selected
+   * repository-aware (the primary's PR) instead of taking the first PR
+   * artifact — in a multi-repo session those can differ.
+   */
+  primaryRepo?: { repoOwner: string; repoName: string } | null;
   onArchive?: () => void | Promise<void>;
   onUnarchive?: () => void | Promise<void>;
 }
@@ -33,13 +40,16 @@ export function ActionBar({
   sessionId,
   sessionStatus,
   artifacts,
+  primaryRepo,
   onArchive,
   onUnarchive,
 }: ActionBarProps) {
   const [isArchiving, setIsArchiving] = useState(false);
   const [showArchiveDialog, setShowArchiveDialog] = useState(false);
 
-  const prArtifact = artifacts.find((a) => a.type === "pr");
+  const prArtifact = primaryRepo
+    ? findPrArtifactForRepo(artifacts, primaryRepo, true)
+    : artifacts.find((a) => a.type === "pr");
   const previewArtifact = artifacts.find((a) => a.type === "preview");
   const mediaCount = artifacts.filter(
     (artifact) => artifact.type === "screenshot" || artifact.type === "video"

--- a/packages/web/src/components/action-bar.tsx
+++ b/packages/web/src/components/action-bar.tsx
@@ -20,7 +20,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { getSafeExternalUrl } from "@/lib/urls";
-import { findPrArtifactForRepo } from "@open-inspect/shared";
+import { findPrArtifactForRepo } from "@/lib/pr-artifacts";
 
 interface ActionBarProps {
   sessionId: string;

--- a/packages/web/src/components/session-prompt-composer.tsx
+++ b/packages/web/src/components/session-prompt-composer.tsx
@@ -13,6 +13,7 @@ type SessionPromptComposerProps = {
     id: string;
     status: string;
     artifacts: Artifact[];
+    primaryRepo?: { repoOwner: string; repoName: string } | null;
     onArchive: () => void | Promise<void>;
     onUnarchive: () => void | Promise<void>;
   };
@@ -44,6 +45,7 @@ export function SessionPromptComposer({ session, prompt, model }: SessionPromptC
             sessionId={session.id}
             sessionStatus={session.status}
             artifacts={session.artifacts}
+            primaryRepo={session.primaryRepo}
             onArchive={session.onArchive}
             onUnarchive={session.onUnarchive}
           />

--- a/packages/web/src/components/session-right-sidebar.tsx
+++ b/packages/web/src/components/session-right-sidebar.tsx
@@ -83,6 +83,7 @@ export function SessionRightSidebarContent({
       {/* Metadata */}
       <div className="px-4 py-4 border-b border-border-muted">
         <MetadataSection
+          sessionId={sessionId}
           createdAt={sessionState.createdAt}
           model={sessionState.model}
           reasoningEffort={sessionState.reasoningEffort}

--- a/packages/web/src/components/session-sidebar.test.tsx
+++ b/packages/web/src/components/session-sidebar.test.tsx
@@ -92,6 +92,39 @@ function jsonResponse(body: unknown) {
 }
 
 describe("SessionSidebar", () => {
+  it("renders the PR status summary on session rows", async () => {
+    const single = createSession(1, {
+      updatedAt: 4000,
+      pullRequestSummary: { total: 1, open: 0, draft: 0, merged: 1, closed: 0 },
+    });
+    const multi = createSession(2, {
+      updatedAt: 3000,
+      pullRequestSummary: { total: 3, open: 1, draft: 1, merged: 1, closed: 0 },
+    });
+    const none = createSession(3, { updatedAt: 2000 });
+
+    render(
+      <SWRConfig
+        value={{
+          fallback: {
+            [SIDEBAR_SESSIONS_KEY]: {
+              sessions: [single, multi, none],
+              hasMore: false,
+            },
+          },
+          dedupingInterval: 0,
+          revalidateOnFocus: false,
+        }}
+      >
+        <SessionSidebar />
+      </SWRConfig>
+    );
+
+    expect(await screen.findByText("PR merged")).toBeInTheDocument();
+    expect(screen.getByText("3 PRs · 2 open")).toBeInTheDocument();
+    expect(screen.getAllByText(/PR/)).toHaveLength(2);
+  });
+
   it("renders nested child sessions under their immediate parent", async () => {
     const parent = createSession(1, { updatedAt: 4000 });
     const child = createSession(2, {

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -15,6 +15,7 @@ import { useSession, signOut } from "next-auth/react";
 import useSWR, { mutate } from "swr";
 import { ArchiveSessionDialog } from "@/components/archive-session-dialog";
 import { archiveSession } from "@/lib/archive-session";
+import { formatPullRequestSummaryLabel } from "@/lib/pr-summary";
 import { formatRelativeTime, isInactiveSession } from "@/lib/time";
 import {
   applyTitleUpdate,
@@ -37,6 +38,7 @@ import {
   AutomationsIcon,
   BranchIcon,
   BoxIcon,
+  GitPrIcon,
   DataControlsIcon,
 } from "@/components/ui/icons";
 import { APP_SHORT_NAME } from "@/lib/site-config";
@@ -690,6 +692,7 @@ function SessionListItem({
     session.repoName,
     session.repositories
   );
+  const prSummaryLabel = formatPullRequestSummaryLabel(session.pullRequestSummary);
   const displayTitle = session.title || repoInfo;
   // Orphan child (parent filtered out) — show a subtle badge
   const isOrphanChild = session.parentSessionId && session.spawnSource === "agent";
@@ -911,6 +914,13 @@ function SessionListItem({
                   <span>·</span>
                   <BranchIcon className="w-3 h-3 flex-shrink-0" />
                   <span className="truncate">{session.baseBranch}</span>
+                </>
+              )}
+              {prSummaryLabel && (
+                <>
+                  <span>·</span>
+                  <GitPrIcon className="w-3 h-3 flex-shrink-0" />
+                  <span className="truncate">{prSummaryLabel}</span>
                 </>
               )}
             </div>

--- a/packages/web/src/components/sidebar/metadata-section.test.tsx
+++ b/packages/web/src/components/sidebar/metadata-section.test.tsx
@@ -2,7 +2,7 @@
 /// <reference types="@testing-library/jest-dom" />
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { MetadataSection } from "./metadata-section";
 
@@ -195,5 +195,58 @@ describe("MetadataSection", () => {
     );
 
     expect(screen.queryByText("Environment deleted")).not.toBeInTheDocument();
+  });
+});
+
+describe("PR sync button", () => {
+  const prArtifact = {
+    id: "artifact-pr-1",
+    type: "pr" as const,
+    url: "https://github.com/acme/web-app/pull/42",
+    metadata: { prNumber: 42, prState: "open" as const },
+    createdAt: 1234,
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("kicks the refresh endpoint when clicked", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ status: "refreshing" })));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <MetadataSection
+        sessionId="session-1"
+        createdAt={Date.now()}
+        baseBranch="main"
+        artifacts={[prArtifact]}
+      />
+    );
+
+    const button = screen.getByRole("button", { name: "Sync PR status" });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/sessions/session-1/pull-requests/refresh", {
+        method: "POST",
+      });
+    });
+  });
+
+  it("does not render without a sessionId or without PR artifacts", () => {
+    render(<MetadataSection createdAt={Date.now()} baseBranch="main" artifacts={[prArtifact]} />);
+    expect(screen.queryByRole("button", { name: "Sync PR status" })).not.toBeInTheDocument();
+    cleanup();
+
+    render(
+      <MetadataSection
+        sessionId="session-1"
+        createdAt={Date.now()}
+        baseBranch="main"
+        artifacts={[]}
+      />
+    );
+    expect(screen.queryByRole("button", { name: "Sync PR status" })).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/sidebar/metadata-section.tsx
+++ b/packages/web/src/components/sidebar/metadata-section.tsx
@@ -9,7 +9,7 @@ import { getSafeExternalUrl } from "@/lib/urls";
 import { getScmBranchUrl, getScmRepoUrl } from "@/lib/scm";
 import { NO_REPOSITORY_LABEL } from "@/lib/repo-label";
 import type { Artifact, SandboxEvent } from "@/types/session";
-import { prArtifactBelongsToRepo, type SessionRepositoryState } from "@open-inspect/shared";
+import { findPrArtifactForRepo, type SessionRepositoryState } from "@open-inspect/shared";
 import {
   ClockIcon,
   SparkleIcon,
@@ -21,12 +21,15 @@ import {
   CheckIcon,
   LinkIcon,
   ErrorIcon,
+  RefreshIcon,
 } from "@/components/ui/icons";
 import { Badge, prBadgeVariant } from "@/components/ui/badge";
 
 type WarningEvent = Extract<SandboxEvent, { type: "warning" }>;
 
 interface MetadataSectionProps {
+  /** Enables the PR sync button; older callers without it just omit it. */
+  sessionId?: string;
   createdAt: number;
   model?: string;
   reasoningEffort?: string;
@@ -49,25 +52,39 @@ interface MetadataSectionProps {
 }
 
 /**
- * The PR artifact belonging to a member repo. The ownership convention
- * (identity-less artifact → primary; case-insensitive match) lives in shared
- * prArtifactBelongsToRepo — the same helper the control-plane prUrl projection
- * uses; here we only supply the identity parsed from the UI artifact metadata.
+ * Manual PR sync (design §7): kicks the rate-limited read-through; fresh
+ * state arrives over the session socket as artifact_updated.
  */
-function findPrArtifactForRepo(
-  artifacts: Artifact[],
-  repo: SessionRepositoryState,
-  isPrimary: boolean
-): Artifact | undefined {
-  return artifacts.find((artifact) => {
-    if (artifact.type !== "pr") return false;
-    const { repoOwner, repoName } = artifact.metadata ?? {};
-    const artifactRepo = repoOwner && repoName ? { repoOwner, repoName } : null;
-    return prArtifactBelongsToRepo(artifactRepo, repo, isPrimary);
-  });
+function PullRequestSyncButton({ sessionId }: { sessionId: string }) {
+  const [syncing, setSyncing] = useState(false);
+
+  const handleSync = async () => {
+    if (syncing) return;
+    setSyncing(true);
+    try {
+      await fetch(`/api/sessions/${sessionId}/pull-requests/refresh`, { method: "POST" });
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleSync}
+      disabled={syncing}
+      className="p-1 hover:bg-muted transition-colors"
+      title="Sync PR status"
+      aria-label="Sync PR status"
+    >
+      <RefreshIcon
+        className={`w-3.5 h-3.5 text-secondary-foreground ${syncing ? "animate-spin" : ""}`}
+      />
+    </button>
+  );
 }
 
 export function MetadataSection({
+  sessionId,
   createdAt,
   model,
   reasoningEffort,
@@ -86,6 +103,8 @@ export function MetadataSection({
   const [copied, setCopied] = useState(false);
 
   const isMultiRepo = (repositories?.length ?? 0) > 1;
+  const hasPrArtifact = artifacts.some((a) => a.type === "pr");
+  const showSyncButton = Boolean(sessionId) && hasPrArtifact;
 
   const prArtifact = artifacts.find((a) => a.type === "pr");
   const manualPrArtifact = artifacts.find(
@@ -184,6 +203,7 @@ export function MetadataSection({
                   {prState}
                 </Badge>
               )}
+              {showSyncButton && sessionId && <PullRequestSyncButton sessionId={sessionId} />}
             </div>
           )}
 
@@ -266,8 +286,9 @@ export function MetadataSection({
       {/* Repository member list (multi-repo sessions) */}
       {isMultiRepo && repositories && (
         <div className="space-y-2">
-          <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-            Repositories
+          <div className="flex items-center gap-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            <span>Repositories</span>
+            {showSyncButton && sessionId && <PullRequestSyncButton sessionId={sessionId} />}
           </div>
           {repositories.map((repo, index) => {
             const memberPrArtifact = findPrArtifactForRepo(artifacts, repo, index === 0);

--- a/packages/web/src/components/sidebar/metadata-section.tsx
+++ b/packages/web/src/components/sidebar/metadata-section.tsx
@@ -9,7 +9,8 @@ import { getSafeExternalUrl } from "@/lib/urls";
 import { getScmBranchUrl, getScmRepoUrl } from "@/lib/scm";
 import { NO_REPOSITORY_LABEL } from "@/lib/repo-label";
 import type { Artifact, SandboxEvent } from "@/types/session";
-import { findPrArtifactForRepo, type SessionRepositoryState } from "@open-inspect/shared";
+import type { SessionRepositoryState } from "@open-inspect/shared";
+import { findPrArtifactForRepo } from "@/lib/pr-artifacts";
 import {
   ClockIcon,
   SparkleIcon,
@@ -291,13 +292,11 @@ export function MetadataSection({
             {showSyncButton && sessionId && <PullRequestSyncButton sessionId={sessionId} />}
           </div>
           {repositories.map((repo, index) => {
-            const memberPrArtifact = findPrArtifactForRepo(artifacts, repo, index === 0);
-            const memberPrNumber = memberPrArtifact?.metadata?.prNumber;
-            const memberPrState = memberPrArtifact?.metadata?.prState;
-            const memberPrUrl = getSafeExternalUrl(
-              memberPrArtifact?.url || repo.prUrl || undefined
-            );
-            const memberBranchUrl = repo.branchName
+            const repoPrArtifact = findPrArtifactForRepo(artifacts, repo, index === 0);
+            const repoPrNumber = repoPrArtifact?.metadata?.prNumber;
+            const repoPrState = repoPrArtifact?.metadata?.prState;
+            const repoPrUrl = getSafeExternalUrl(repoPrArtifact?.url || repo.prUrl || undefined);
+            const repoBranchUrl = repo.branchName
               ? getScmBranchUrl(repo.repoOwner, repo.repoName, repo.branchName)
               : null;
             return (
@@ -319,14 +318,14 @@ export function MetadataSection({
                     </Badge>
                   )}
                 </div>
-                {(repo.branchName || memberPrNumber || memberPrUrl) && (
+                {(repo.branchName || repoPrNumber || repoPrUrl) && (
                   <div className="ml-6 flex items-center gap-2 text-xs text-muted-foreground">
                     {repo.branchName && (
                       <span className="inline-flex min-w-0 items-center gap-1">
                         <GitPrIcon className="w-3.5 h-3.5 flex-shrink-0" />
-                        {memberBranchUrl ? (
+                        {repoBranchUrl ? (
                           <a
-                            href={memberBranchUrl}
+                            href={repoBranchUrl}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-accent truncate max-w-[120px] hover:underline"
@@ -341,22 +340,22 @@ export function MetadataSection({
                         )}
                       </span>
                     )}
-                    {(memberPrNumber || memberPrUrl) &&
-                      (memberPrUrl ? (
+                    {(repoPrNumber || repoPrUrl) &&
+                      (repoPrUrl ? (
                         <a
-                          href={memberPrUrl}
+                          href={repoPrUrl}
                           target="_blank"
                           rel="noopener noreferrer"
                           className="text-accent hover:underline"
                         >
-                          {memberPrNumber ? `#${memberPrNumber}` : "PR"}
+                          {repoPrNumber ? `#${repoPrNumber}` : "PR"}
                         </a>
                       ) : (
-                        <span className="text-foreground">#{memberPrNumber}</span>
+                        <span className="text-foreground">#{repoPrNumber}</span>
                       ))}
-                    {memberPrState && (
-                      <Badge variant={prBadgeVariant(memberPrState)} className="capitalize">
-                        {memberPrState}
+                    {repoPrState && (
+                      <Badge variant={prBadgeVariant(repoPrState)} className="capitalize">
+                        {repoPrState}
                       </Badge>
                     )}
                   </div>

--- a/packages/web/src/components/sidebar/metadata-section.tsx
+++ b/packages/web/src/components/sidebar/metadata-section.tsx
@@ -53,8 +53,8 @@ interface MetadataSectionProps {
 }
 
 /**
- * Manual PR sync (design §7): kicks the rate-limited read-through; fresh
- * state arrives over the session socket as artifact_updated.
+ * Manual PR sync (design §7): kicks the read-through refresh; fresh state
+ * arrives over the session socket as artifact_updated.
  */
 function PullRequestSyncButton({ sessionId }: { sessionId: string }) {
   const [syncing, setSyncing] = useState(false);
@@ -64,6 +64,9 @@ function PullRequestSyncButton({ sessionId }: { sessionId: string }) {
     setSyncing(true);
     try {
       await fetch(`/api/sessions/${sessionId}/pull-requests/refresh`, { method: "POST" });
+    } catch {
+      // Fire-and-forget: the socket stream is the source of truth, so a
+      // failed trigger only means no update arrives.
     } finally {
       setSyncing(false);
     }

--- a/packages/web/src/hooks/use-session-socket.test.tsx
+++ b/packages/web/src/hooks/use-session-socket.test.tsx
@@ -835,6 +835,10 @@ describe("useSessionSocket", () => {
         },
       ]);
     });
+
+    // A new PR changes the sidebar summary, so creation revalidates the
+    // session list just like artifact_updated.
+    expect(mutateMock).toHaveBeenCalledWith(isUnarchivedSessionListKey);
   });
 
   it("applies artifact_updated in place and revalidates the session list", async () => {

--- a/packages/web/src/hooks/use-session-socket.test.tsx
+++ b/packages/web/src/hooks/use-session-socket.test.tsx
@@ -836,4 +836,107 @@ describe("useSessionSocket", () => {
       ]);
     });
   });
+
+  it("applies artifact_updated in place and revalidates the session list", async () => {
+    const { result } = renderHook(() => useSessionSocket("session-1"));
+
+    await waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
+
+    const socket = FakeWebSocket.instances[0];
+    act(() => {
+      socket.open();
+      socket.receive(
+        createSubscribedMessage([
+          {
+            id: "artifact-pr-2",
+            type: "pr",
+            url: "https://github.com/acme/web-app/pull/2",
+            metadata: { number: 2, state: "open" },
+            createdAt: 200,
+          },
+          {
+            id: "artifact-pr-1",
+            type: "pr",
+            url: "https://github.com/acme/web-app/pull/1",
+            metadata: { number: 1, state: "open" },
+            createdAt: 100,
+          },
+        ])
+      );
+    });
+    mutateMock.mockClear();
+
+    act(() => {
+      socket.receive({
+        type: "artifact_updated",
+        artifact: {
+          id: "artifact-pr-1",
+          type: "pr",
+          url: "https://github.com/acme/web-app/pull/1",
+          metadata: {
+            number: 1,
+            state: "merged",
+            lifecycleState: "merged",
+            isDraft: false,
+          },
+          createdAt: 100,
+          updatedAt: 500,
+        },
+      });
+    });
+
+    await waitFor(() => {
+      // Updated in place — the list order is stable, no reshuffle.
+      expect(
+        result.current.artifacts.map((artifact) => [artifact.id, artifact.metadata?.prState])
+      ).toEqual([
+        ["artifact-pr-2", "open"],
+        ["artifact-pr-1", "merged"],
+      ]);
+      expect(result.current.artifacts[1].updatedAt).toBe(500);
+    });
+
+    expect(mutateMock).toHaveBeenCalledWith(isUnarchivedSessionListKey);
+  });
+
+  it("derives prState from tracked lifecycle metadata over the legacy state key", async () => {
+    const { result } = renderHook(() => useSessionSocket("session-1"));
+
+    await waitFor(() => {
+      expect(FakeWebSocket.instances).toHaveLength(1);
+    });
+
+    const socket = FakeWebSocket.instances[0];
+    act(() => {
+      socket.open();
+      socket.receive(
+        createSubscribedMessage([
+          {
+            id: "artifact-pr-draft",
+            type: "pr",
+            url: "https://github.com/acme/web-app/pull/3",
+            // Stale legacy display key vs. tracked lifecycle: lifecycle wins.
+            metadata: { number: 3, state: "open", lifecycleState: "open", isDraft: true },
+            createdAt: 100,
+          },
+          {
+            id: "artifact-pr-legacy",
+            type: "pr",
+            url: "https://github.com/acme/web-app/pull/4",
+            metadata: { number: 4, state: "closed" },
+            createdAt: 50,
+          },
+        ])
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.artifacts.map((artifact) => artifact.metadata?.prState)).toEqual([
+        "draft",
+        "closed",
+      ]);
+    });
+  });
 });

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -532,13 +532,11 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
           break;
 
         case "artifact_created":
-          setArtifacts((prev) => upsertArtifact(prev, toUiArtifact(data.artifact)));
-          break;
-
         case "artifact_updated":
-          // Same upsert-by-id as artifact_created — an update replaces in
-          // place, so the artifact list order stays stable. Revalidate the
-          // session list so sidebar PR summaries reflect the change.
+          // Upsert-by-id: a create appends, an update replaces in place so
+          // the artifact list order stays stable. Both revalidate the
+          // session list — a new PR changes the sidebar summary just like a
+          // lifecycle update does.
           setArtifacts((prev) => upsertArtifact(prev, toUiArtifact(data.artifact)));
           mutate(isUnarchivedSessionListKey);
           break;

--- a/packages/web/src/hooks/use-session-socket.ts
+++ b/packages/web/src/hooks/use-session-socket.ts
@@ -4,9 +4,10 @@ import { type MutableRefObject, useCallback, useEffect, useRef, useState } from 
 import { mutate } from "swr";
 import { isUnarchivedSessionListKey } from "@/lib/session-list";
 import type { Artifact, SandboxEvent } from "@/types/session";
-import { serverMessageSchema } from "@open-inspect/shared";
+import { serverMessageSchema, toDisplayStatus } from "@open-inspect/shared";
 import type {
   ParticipantPresence,
+  PullRequestDisplayStatus,
   SandboxEvent as SharedSandboxEvent,
   ScreenshotArtifactMetadata,
   ServerMessage,
@@ -148,8 +149,40 @@ function toUiSandboxEvent(event: SharedSandboxEvent): SandboxEvent {
   };
 }
 
-type PrState = NonNullable<NonNullable<Artifact["metadata"]>["prState"]>;
-const PR_STATES = new Set<string>(["open", "merged", "closed", "draft"]);
+/** Replace an artifact in place by id, or prepend when it is new. */
+function upsertArtifact(artifacts: Artifact[], nextArtifact: Artifact): Artifact[] {
+  const existingIndex = artifacts.findIndex((artifact) => artifact.id === nextArtifact.id);
+  if (existingIndex === -1) {
+    return [nextArtifact, ...artifacts];
+  }
+  return artifacts.map((artifact, index) => (index === existingIndex ? nextArtifact : artifact));
+}
+
+const PR_DISPLAY_STATUSES = new Set<PullRequestDisplayStatus>([
+  "open",
+  "merged",
+  "closed",
+  "draft",
+]);
+
+/**
+ * The PR display status for an artifact's metadata. Prefers the tracked
+ * lifecycleState/isDraft pair (derived via shared toDisplayStatus); falls
+ * back to the legacy `state` display key on artifacts that predate PR
+ * lifecycle tracking.
+ */
+function derivePrState(meta: Record<string, unknown>): PullRequestDisplayStatus | undefined {
+  if (meta.lifecycleState === "open" || meta.lifecycleState === "closed") {
+    return toDisplayStatus({ lifecycleState: meta.lifecycleState, isDraft: meta.isDraft === true });
+  }
+  if (meta.lifecycleState === "merged") {
+    return "merged";
+  }
+  return typeof meta.state === "string" &&
+    PR_DISPLAY_STATUSES.has(meta.state as PullRequestDisplayStatus)
+    ? (meta.state as PullRequestDisplayStatus)
+    : undefined;
+}
 type MediaMimeType = ScreenshotArtifactMetadata["mimeType"] | VideoArtifactMetadata["mimeType"];
 const MEDIA_MIME_TYPES = new Set<MediaMimeType>([
   "image/png",
@@ -181,13 +214,11 @@ function toUiArtifact(artifact: SessionArtifact): Artifact {
     type: artifact.type as Artifact["type"],
     url: artifact.url,
     createdAt: artifact.createdAt,
+    updatedAt: artifact.updatedAt,
     metadata: meta
       ? {
           prNumber: typeof meta.number === "number" ? meta.number : undefined,
-          prState:
-            typeof meta.state === "string" && PR_STATES.has(meta.state)
-              ? (meta.state as PrState)
-              : undefined,
+          prState: derivePrState(meta),
           mode: meta.mode === "manual_pr" ? "manual_pr" : undefined,
           createPrUrl: typeof meta.createPrUrl === "string" ? meta.createPrUrl : undefined,
           head: typeof meta.head === "string" ? meta.head : undefined,
@@ -501,17 +532,15 @@ export function useSessionSocket(sessionId: string): UseSessionSocketReturn {
           break;
 
         case "artifact_created":
-          setArtifacts((prev) => {
-            const nextArtifact = toUiArtifact(data.artifact);
-            const existingIndex = prev.findIndex((artifact) => artifact.id === nextArtifact.id);
-            if (existingIndex === -1) {
-              return [nextArtifact, ...prev];
-            }
+          setArtifacts((prev) => upsertArtifact(prev, toUiArtifact(data.artifact)));
+          break;
 
-            return prev.map((artifact, index) =>
-              index === existingIndex ? nextArtifact : artifact
-            );
-          });
+        case "artifact_updated":
+          // Same upsert-by-id as artifact_created — an update replaces in
+          // place, so the artifact list order stays stable. Revalidate the
+          // session list so sidebar PR summaries reflect the change.
+          setArtifacts((prev) => upsertArtifact(prev, toUiArtifact(data.artifact)));
+          mutate(isUnarchivedSessionListKey);
           break;
 
         case "session_branch":

--- a/packages/web/src/lib/pr-artifacts.test.ts
+++ b/packages/web/src/lib/pr-artifacts.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import type { Artifact } from "@/types/session";
+import { findPrArtifactForRepo } from "./pr-artifacts";
+
+function artifact(overrides: Partial<Artifact>): Artifact {
+  return {
+    id: "artifact-1",
+    type: "pr",
+    url: "https://github.com/acme/web/pull/7",
+    createdAt: 1,
+    ...overrides,
+  };
+}
+
+describe("findPrArtifactForRepo", () => {
+  it("matches by repo identity, case-insensitively", () => {
+    const match = artifact({
+      id: "artifact-web",
+      metadata: { repoOwner: "Acme", repoName: "Web" },
+    });
+    const other = artifact({
+      id: "artifact-api",
+      metadata: { repoOwner: "acme", repoName: "api" },
+    });
+
+    const found = findPrArtifactForRepo(
+      [other, match],
+      { repoOwner: "acme", repoName: "web" },
+      false
+    );
+
+    expect(found?.id).toBe("artifact-web");
+  });
+
+  it("attributes identity-less legacy metadata to the primary repository only", () => {
+    const legacy = artifact({ id: "artifact-legacy", metadata: {} });
+    const target = { repoOwner: "acme", repoName: "web" };
+
+    expect(findPrArtifactForRepo([legacy], target, true)?.id).toBe("artifact-legacy");
+    expect(findPrArtifactForRepo([legacy], target, false)).toBeUndefined();
+  });
+
+  it("ignores non-PR artifacts", () => {
+    const branch = artifact({
+      id: "artifact-branch",
+      type: "branch",
+      metadata: { repoOwner: "acme", repoName: "web" },
+    });
+
+    expect(
+      findPrArtifactForRepo([branch], { repoOwner: "acme", repoName: "web" }, true)
+    ).toBeUndefined();
+  });
+});

--- a/packages/web/src/lib/pr-artifacts.ts
+++ b/packages/web/src/lib/pr-artifacts.ts
@@ -1,0 +1,23 @@
+import { prArtifactBelongsToRepo } from "@open-inspect/shared";
+import type { Artifact } from "@/types/session";
+
+/**
+ * Find the PR artifact belonging to the target repository. The ownership
+ * convention (identity-less legacy metadata belongs to the primary) is the
+ * shared prArtifactBelongsToRepo — the same rule the control plane applies.
+ */
+export function findPrArtifactForRepo(
+  artifacts: readonly Artifact[],
+  targetRepo: { repoOwner: string; repoName: string },
+  targetIsPrimary: boolean
+): Artifact | undefined {
+  return artifacts.find((artifact) => {
+    if (artifact.type !== "pr") return false;
+    const { repoOwner, repoName } = artifact.metadata ?? {};
+    return prArtifactBelongsToRepo(
+      repoOwner !== undefined && repoName !== undefined ? { repoOwner, repoName } : null,
+      targetRepo,
+      targetIsPrimary
+    );
+  });
+}

--- a/packages/web/src/lib/pr-summary.test.ts
+++ b/packages/web/src/lib/pr-summary.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { formatPullRequestSummaryLabel } from "./pr-summary";
+
+describe("formatPullRequestSummaryLabel", () => {
+  it("returns null without a summary or with zero PRs", () => {
+    expect(formatPullRequestSummaryLabel(undefined)).toBeNull();
+    expect(
+      formatPullRequestSummaryLabel({ total: 0, open: 0, draft: 0, merged: 0, closed: 0 })
+    ).toBeNull();
+  });
+
+  it("renders the single PR's display status", () => {
+    expect(
+      formatPullRequestSummaryLabel({ total: 1, open: 0, draft: 1, merged: 0, closed: 0 })
+    ).toBe("PR draft");
+    expect(
+      formatPullRequestSummaryLabel({ total: 1, open: 1, draft: 0, merged: 0, closed: 0 })
+    ).toBe("PR open");
+    expect(
+      formatPullRequestSummaryLabel({ total: 1, open: 0, draft: 0, merged: 1, closed: 0 })
+    ).toBe("PR merged");
+    expect(
+      formatPullRequestSummaryLabel({ total: 1, open: 0, draft: 0, merged: 0, closed: 1 })
+    ).toBe("PR closed");
+  });
+
+  it("counts drafts as open in the multi-PR label", () => {
+    expect(
+      formatPullRequestSummaryLabel({ total: 3, open: 1, draft: 1, merged: 1, closed: 0 })
+    ).toBe("3 PRs · 2 open");
+  });
+
+  it("falls back to merged, then closed, when nothing is open", () => {
+    expect(
+      formatPullRequestSummaryLabel({ total: 2, open: 0, draft: 0, merged: 2, closed: 0 })
+    ).toBe("2 PRs · 2 merged");
+    expect(
+      formatPullRequestSummaryLabel({ total: 2, open: 0, draft: 0, merged: 0, closed: 2 })
+    ).toBe("2 PRs · 2 closed");
+  });
+});

--- a/packages/web/src/lib/pr-summary.ts
+++ b/packages/web/src/lib/pr-summary.ts
@@ -1,0 +1,25 @@
+import type { PullRequestSummary } from "@open-inspect/shared";
+
+/**
+ * Fixed-height PR indicator for a session list row (design §7): a single PR
+ * renders its display status ("PR merged"); several render the count plus the
+ * most informative bucket — open (incl. drafts) wins, then merged, then
+ * closed. Null when the session has no tracked PRs.
+ */
+export function formatPullRequestSummaryLabel(
+  summary: PullRequestSummary | undefined
+): string | null {
+  if (!summary || summary.total === 0) return null;
+
+  if (summary.total === 1) {
+    if (summary.draft > 0) return "PR draft";
+    if (summary.open > 0) return "PR open";
+    if (summary.merged > 0) return "PR merged";
+    return "PR closed";
+  }
+
+  const openCount = summary.open + summary.draft;
+  if (openCount > 0) return `${summary.total} PRs · ${openCount} open`;
+  if (summary.merged > 0) return `${summary.total} PRs · ${summary.merged} merged`;
+  return `${summary.total} PRs · ${summary.closed} closed`;
+}

--- a/packages/web/src/types/session.ts
+++ b/packages/web/src/types/session.ts
@@ -1,4 +1,5 @@
 import type {
+  PullRequestDisplayStatus,
   SandboxEvent as SharedSandboxEvent,
   ScreenshotArtifactMetadata,
   VideoArtifactMetadata,
@@ -12,7 +13,7 @@ export interface Artifact {
   url: string | null;
   metadata?: (Partial<ScreenshotArtifactMetadata> | Partial<VideoArtifactMetadata>) & {
     prNumber?: number;
-    prState?: "open" | "merged" | "closed" | "draft";
+    prState?: PullRequestDisplayStatus;
     mode?: "manual_pr";
     createPrUrl?: string;
     head?: string;
@@ -26,6 +27,8 @@ export interface Artifact {
     repoName?: string;
   };
   createdAt: number;
+  /** Last content change (PR lifecycle updates); falls back to createdAt. */
+  updatedAt?: number;
 }
 
 export type SandboxEvent = SharedSandboxEvent;


### PR DESCRIPTION
## Summary

PR 5 of 5 for pull request lifecycle tracking (design: `docs/internal/2026-07-09-pull-request-artifact-tracking-design.md` v2 §5.4/§7; **stacked on #963**). Surfaces tracked PR status everywhere the user looks, from the D1 authority record — no DO reads and no provider calls on the list path.

### Global session list
- `SessionIndexStore.list` attaches `pullRequestSummary` per page via one grouped query over `session_pull_requests` (`withPullRequestSummaries`, mirroring the `withRepositories` join). PR state never influences ordering — it only decorates the already-paged rows.
- Sidebar rows render a fixed-height indicator: a single PR shows its display status ("PR merged"); several show `N PRs · X open` (drafts count as open; falls back to merged, then closed). Pure `formatPullRequestSummaryLabel` helper with tests.

### Session detail
- `artifact_updated` handled via the same upsert-by-id as `artifact_created` — replaced in place so the artifact list order stays stable — and revalidates the session list so sidebar summaries follow.
- `toUiArtifact` now derives the badge from the tracked `lifecycleState`/`isDraft` pair via shared `toDisplayStatus`, keeping the legacy `state` key only as a fallback for pre-tracking artifacts; the web-local PR-state enum is gone. `updatedAt` flows onto the UI artifact.
- Sync button (`RefreshIcon`) in the metadata section — scalar PR row and the multi-repo "Repositories" header — POSTs the PR-4 refresh endpoint; fresh state arrives over the socket.

### ActionBar fix (design §7)
- `findPrArtifactForRepo` lifted to shared (`types/repositories.ts`) — the single home of the find-over-convention step; the control-plane twin (`session/pr-artifacts.ts`) and the metadata section both delegate to it.
- "View PR" is now repository-aware: with a `primaryRepo` threaded from session state it selects the primary repo's PR instead of the first `pr` artifact (which can be a secondary repo's in multi-repo sessions); falls back to first-PR without repo context.

## Testing
- control-plane: 1763 unit / 539 integration — new: `list()` attaches grouped summaries without reordering (real D1); unit fake covers the summaries join.
- web: 691 — new: sidebar summary labels; `artifact_updated` in-place upsert + list revalidation; lifecycle-over-legacy badge derivation; sync button endpoint call + absence without sessionId/PRs; repo-aware vs fallback ActionBar selection; summary label formatter.
- shared 397, bots green; typecheck and lint clean.

This completes the 5-PR train (#960, #961, #962, #963, this).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session lists and sidebars now show pull request status summaries (including counts/labels).
  * Added a “Sync PR status” button for sessions that have PR artifacts.
  * “View PR” links are now primary-repository aware when selecting which PR artifact to show.
* **Bug Fixes**
  * Improved PR lifecycle status derivation by preferring tracked lifecycle/draft metadata over legacy state.
  * WebSocket PR updates now maintain stable artifact ordering and update in-place.
* **Tests**
  * Added integration and component/hook unit tests covering PR summaries, link selection, and sync behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->