### PR TITLE
feat: GitHub-style PR state icon on session list rows

### DIFF
--- a/packages/web/src/components/pr-state-icon.tsx
+++ b/packages/web/src/components/pr-state-icon.tsx
@@ -1,0 +1,37 @@
+import type { PullRequestDisplayStatus } from "@open-inspect/shared";
+import { PR_STATE_TEXT_CLASS } from "@/components/ui/badge";
+import { GitMergeIcon, GitPrClosedIcon, GitPrDraftIcon, GitPrIcon } from "@/components/ui/icons";
+
+const PR_STATE_ICONS: Record<
+  PullRequestDisplayStatus,
+  (props: { className?: string }) => React.JSX.Element
+> = {
+  open: GitPrIcon,
+  draft: GitPrDraftIcon,
+  merged: GitMergeIcon,
+  closed: GitPrClosedIcon,
+};
+
+/**
+ * GitHub-style PR state icon for a session-list row. Colors come from
+ * PR_STATE_TEXT_CLASS — the same tokens the PR badge variants use.
+ */
+export function PullRequestStateIcon({
+  state,
+  label,
+}: {
+  state: PullRequestDisplayStatus;
+  label: string;
+}) {
+  const Icon = PR_STATE_ICONS[state];
+  return (
+    <span
+      className={`flex-shrink-0 ${PR_STATE_TEXT_CLASS[state]}`}
+      title={label}
+      aria-label={label}
+      data-testid={`pr-state-${state}`}
+    >
+      <Icon className="w-3.5 h-3.5" />
+    </span>
+  );
+}

--- a/packages/web/src/components/session-sidebar.test.tsx
+++ b/packages/web/src/components/session-sidebar.test.tsx
@@ -123,6 +123,13 @@ describe("SessionSidebar", () => {
     expect(await screen.findByText("PR merged")).toBeInTheDocument();
     expect(screen.getByText("3 PRs · 2 open")).toBeInTheDocument();
     expect(screen.getAllByText(/PR/)).toHaveLength(2);
+
+    // GitHub-style state icon next to the title: merged for the single-PR
+    // session, open (dominant bucket) for the multi-PR session, none without
+    // tracked PRs.
+    expect(screen.getByTestId("pr-state-merged")).toBeInTheDocument();
+    expect(screen.getByTestId("pr-state-open")).toBeInTheDocument();
+    expect(screen.queryAllByTestId(/^pr-state-/)).toHaveLength(2);
   });
 
   it("renders nested child sessions under their immediate parent", async () => {

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -15,7 +15,8 @@ import { useSession, signOut } from "next-auth/react";
 import useSWR, { mutate } from "swr";
 import { ArchiveSessionDialog } from "@/components/archive-session-dialog";
 import { archiveSession } from "@/lib/archive-session";
-import { dominantPullRequestState, formatPullRequestSummaryLabel } from "@/lib/pr-summary";
+import { pullRequestSummaryDisplay } from "@/lib/pr-summary";
+import { PullRequestStateIcon } from "@/components/pr-state-icon";
 import { formatRelativeTime, isInactiveSession } from "@/lib/time";
 import {
   applyTitleUpdate,
@@ -39,9 +40,6 @@ import {
   BranchIcon,
   BoxIcon,
   GitPrIcon,
-  GitMergeIcon,
-  GitPrClosedIcon,
-  GitPrDraftIcon,
   DataControlsIcon,
 } from "@/components/ui/icons";
 import { APP_SHORT_NAME } from "@/lib/site-config";
@@ -57,7 +55,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import type { PullRequestDisplayStatus, Session } from "@open-inspect/shared";
+import type { Session } from "@open-inspect/shared";
 
 export type SessionItem = Session;
 
@@ -671,40 +669,6 @@ function ChildSessionTree({
   });
 }
 
-const PR_STATE_ICONS: Record<
-  PullRequestDisplayStatus,
-  { Icon: (props: { className?: string }) => React.JSX.Element; colorClass: string }
-> = {
-  open: { Icon: GitPrIcon, colorClass: "text-accent" },
-  draft: { Icon: GitPrDraftIcon, colorClass: "text-muted-foreground" },
-  merged: { Icon: GitMergeIcon, colorClass: "text-success" },
-  closed: { Icon: GitPrClosedIcon, colorClass: "text-destructive" },
-};
-
-/**
- * GitHub-style PR state icon next to a session row's title. Colors follow the
- * prBadgeVariant semantic tokens used by the session detail badges.
- */
-function PullRequestStateIcon({
-  state,
-  label,
-}: {
-  state: PullRequestDisplayStatus;
-  label: string | null;
-}) {
-  const { Icon, colorClass } = PR_STATE_ICONS[state];
-  return (
-    <span
-      className={`flex-shrink-0 ${colorClass}`}
-      title={label ?? undefined}
-      aria-label={label ?? `PR ${state}`}
-      data-testid={`pr-state-${state}`}
-    >
-      <Icon className="w-3.5 h-3.5" />
-    </span>
-  );
-}
-
 function SessionListItem({
   session,
   environmentName,
@@ -729,8 +693,7 @@ function SessionListItem({
     session.repoName,
     session.repositories
   );
-  const prSummaryLabel = formatPullRequestSummaryLabel(session.pullRequestSummary);
-  const prState = dominantPullRequestState(session.pullRequestSummary);
+  const prDisplay = pullRequestSummaryDisplay(session.pullRequestSummary);
   const displayTitle = session.title || repoInfo;
   // Orphan child (parent filtered out) — show a subtle badge
   const isOrphanChild = session.parentSessionId && session.spawnSource === "agent";
@@ -930,7 +893,9 @@ function SessionListItem({
             className="block pr-8"
           >
             <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">
-              {prState && <PullRequestStateIcon state={prState} label={prSummaryLabel} />}
+              {prDisplay && (
+                <PullRequestStateIcon state={prDisplay.state} label={prDisplay.label} />
+              )}
               <span className="truncate">{displayTitle}</span>
             </div>
             <div className="flex items-center gap-1 mt-0.5 text-xs text-muted-foreground">
@@ -957,11 +922,11 @@ function SessionListItem({
                   <span className="truncate">{session.baseBranch}</span>
                 </>
               )}
-              {prSummaryLabel && (
+              {prDisplay && (
                 <>
                   <span>·</span>
                   <GitPrIcon className="w-3 h-3 flex-shrink-0" />
-                  <span className="truncate">{prSummaryLabel}</span>
+                  <span className="truncate">{prDisplay.label}</span>
                 </>
               )}
             </div>

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -15,7 +15,7 @@ import { useSession, signOut } from "next-auth/react";
 import useSWR, { mutate } from "swr";
 import { ArchiveSessionDialog } from "@/components/archive-session-dialog";
 import { archiveSession } from "@/lib/archive-session";
-import { formatPullRequestSummaryLabel } from "@/lib/pr-summary";
+import { dominantPullRequestState, formatPullRequestSummaryLabel } from "@/lib/pr-summary";
 import { formatRelativeTime, isInactiveSession } from "@/lib/time";
 import {
   applyTitleUpdate,
@@ -39,6 +39,9 @@ import {
   BranchIcon,
   BoxIcon,
   GitPrIcon,
+  GitMergeIcon,
+  GitPrClosedIcon,
+  GitPrDraftIcon,
   DataControlsIcon,
 } from "@/components/ui/icons";
 import { APP_SHORT_NAME } from "@/lib/site-config";
@@ -54,7 +57,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import type { Session } from "@open-inspect/shared";
+import type { PullRequestDisplayStatus, Session } from "@open-inspect/shared";
 
 export type SessionItem = Session;
 
@@ -668,6 +671,40 @@ function ChildSessionTree({
   });
 }
 
+const PR_STATE_ICONS: Record<
+  PullRequestDisplayStatus,
+  { Icon: (props: { className?: string }) => React.JSX.Element; colorClass: string }
+> = {
+  open: { Icon: GitPrIcon, colorClass: "text-accent" },
+  draft: { Icon: GitPrDraftIcon, colorClass: "text-muted-foreground" },
+  merged: { Icon: GitMergeIcon, colorClass: "text-success" },
+  closed: { Icon: GitPrClosedIcon, colorClass: "text-destructive" },
+};
+
+/**
+ * GitHub-style PR state icon next to a session row's title. Colors follow the
+ * prBadgeVariant semantic tokens used by the session detail badges.
+ */
+function PullRequestStateIcon({
+  state,
+  label,
+}: {
+  state: PullRequestDisplayStatus;
+  label: string | null;
+}) {
+  const { Icon, colorClass } = PR_STATE_ICONS[state];
+  return (
+    <span
+      className={`flex-shrink-0 ${colorClass}`}
+      title={label ?? undefined}
+      aria-label={label ?? `PR ${state}`}
+      data-testid={`pr-state-${state}`}
+    >
+      <Icon className="w-3.5 h-3.5" />
+    </span>
+  );
+}
+
 function SessionListItem({
   session,
   environmentName,
@@ -693,6 +730,7 @@ function SessionListItem({
     session.repositories
   );
   const prSummaryLabel = formatPullRequestSummaryLabel(session.pullRequestSummary);
+  const prState = dominantPullRequestState(session.pullRequestSummary);
   const displayTitle = session.title || repoInfo;
   // Orphan child (parent filtered out) — show a subtle badge
   const isOrphanChild = session.parentSessionId && session.spawnSource === "agent";
@@ -891,7 +929,10 @@ function SessionListItem({
             onTouchCancel={handleTouchEnd}
             className="block pr-8"
           >
-            <div className="truncate text-sm font-medium text-foreground">{displayTitle}</div>
+            <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+              {prState && <PullRequestStateIcon state={prState} label={prSummaryLabel} />}
+              <span className="truncate">{displayTitle}</span>
+            </div>
             <div className="flex items-center gap-1 mt-0.5 text-xs text-muted-foreground">
               <span>{relativeTime}</span>
               <span>·</span>

--- a/packages/web/src/components/ui/badge.tsx
+++ b/packages/web/src/components/ui/badge.tsx
@@ -3,14 +3,26 @@ import { cva, type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * Canonical text-color token per PR display state. The PR badges below and
+ * the session-list state icon both derive from this map, so the color policy
+ * has exactly one home.
+ */
+export const PR_STATE_TEXT_CLASS = {
+  open: "text-accent",
+  draft: "text-muted-foreground",
+  merged: "text-success",
+  closed: "text-destructive",
+} as const;
+
 const badgeVariants = cva("inline-flex items-center rounded-sm px-1.5 py-0.5 text-xs font-medium", {
   variants: {
     variant: {
       default: "bg-muted text-muted-foreground",
-      "pr-merged": "bg-success-muted text-success",
-      "pr-closed": "bg-destructive-muted text-destructive",
-      "pr-draft": "bg-muted text-muted-foreground",
-      "pr-open": "bg-accent-muted text-accent",
+      "pr-merged": `bg-success-muted ${PR_STATE_TEXT_CLASS.merged}`,
+      "pr-closed": `bg-destructive-muted ${PR_STATE_TEXT_CLASS.closed}`,
+      "pr-draft": `bg-muted ${PR_STATE_TEXT_CLASS.draft}`,
+      "pr-open": `bg-accent-muted ${PR_STATE_TEXT_CLASS.open}`,
       info: "bg-info-muted text-info border border-info/20",
       kbd: "font-mono text-muted-foreground border border-border bg-input rounded",
     },

--- a/packages/web/src/components/ui/icons.tsx
+++ b/packages/web/src/components/ui/icons.tsx
@@ -323,6 +323,65 @@ export function GitPrIcon({ className }: IconProps) {
   );
 }
 
+export function GitMergeIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      viewBox="0 0 24 24"
+    >
+      <circle cx="18" cy="18" r="3" />
+      <circle cx="6" cy="6" r="3" />
+      <path d="M6 21V9a9 9 0 0 0 9 9" />
+    </svg>
+  );
+}
+
+export function GitPrClosedIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      viewBox="0 0 24 24"
+    >
+      <circle cx="6" cy="6" r="3" />
+      <path d="M6 9v12" />
+      <path d="m21 3-6 6" />
+      <path d="m21 9-6-6" />
+      <path d="M18 11.5V15" />
+      <circle cx="18" cy="18" r="3" />
+    </svg>
+  );
+}
+
+export function GitPrDraftIcon({ className }: IconProps) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      viewBox="0 0 24 24"
+    >
+      <circle cx="18" cy="18" r="3" />
+      <circle cx="6" cy="6" r="3" />
+      <path d="M18 6V5" />
+      <path d="M18 11v-1" />
+      <line x1="6" x2="6" y1="9" y2="21" />
+    </svg>
+  );
+}
+
 // --- Content & Files ---
 
 export function InspectIcon({ className }: IconProps) {

--- a/packages/web/src/lib/pr-summary.test.ts
+++ b/packages/web/src/lib/pr-summary.test.ts
@@ -1,65 +1,47 @@
 import { describe, expect, it } from "vitest";
-import { dominantPullRequestState, formatPullRequestSummaryLabel } from "./pr-summary";
+import { pullRequestSummaryDisplay } from "./pr-summary";
 
-describe("dominantPullRequestState", () => {
+describe("pullRequestSummaryDisplay", () => {
   it("returns null without a summary or with zero PRs", () => {
-    expect(dominantPullRequestState(undefined)).toBeNull();
+    expect(pullRequestSummaryDisplay(undefined)).toBeNull();
     expect(
-      dominantPullRequestState({ total: 0, open: 0, draft: 0, merged: 0, closed: 0 })
+      pullRequestSummaryDisplay({ total: 0, open: 0, draft: 0, merged: 0, closed: 0 })
     ).toBeNull();
   });
 
-  it("picks the most actionable bucket: open, draft, merged, closed", () => {
-    expect(dominantPullRequestState({ total: 3, open: 1, draft: 1, merged: 1, closed: 0 })).toBe(
-      "open"
-    );
-    expect(dominantPullRequestState({ total: 2, open: 0, draft: 1, merged: 1, closed: 0 })).toBe(
-      "draft"
-    );
-    expect(dominantPullRequestState({ total: 2, open: 0, draft: 0, merged: 1, closed: 1 })).toBe(
-      "merged"
-    );
-    expect(dominantPullRequestState({ total: 1, open: 0, draft: 0, merged: 0, closed: 1 })).toBe(
-      "closed"
-    );
-  });
-});
-
-describe("formatPullRequestSummaryLabel", () => {
-  it("returns null without a summary or with zero PRs", () => {
-    expect(formatPullRequestSummaryLabel(undefined)).toBeNull();
+  it("renders a single PR's display status as both state and label", () => {
     expect(
-      formatPullRequestSummaryLabel({ total: 0, open: 0, draft: 0, merged: 0, closed: 0 })
-    ).toBeNull();
+      pullRequestSummaryDisplay({ total: 1, open: 0, draft: 1, merged: 0, closed: 0 })
+    ).toEqual({ state: "draft", label: "PR draft" });
+    expect(
+      pullRequestSummaryDisplay({ total: 1, open: 1, draft: 0, merged: 0, closed: 0 })
+    ).toEqual({ state: "open", label: "PR open" });
+    expect(
+      pullRequestSummaryDisplay({ total: 1, open: 0, draft: 0, merged: 1, closed: 0 })
+    ).toEqual({ state: "merged", label: "PR merged" });
+    expect(
+      pullRequestSummaryDisplay({ total: 1, open: 0, draft: 0, merged: 0, closed: 1 })
+    ).toEqual({ state: "closed", label: "PR closed" });
   });
 
-  it("renders the single PR's display status", () => {
+  it("picks the most actionable state and counts drafts as open in the label", () => {
     expect(
-      formatPullRequestSummaryLabel({ total: 1, open: 0, draft: 1, merged: 0, closed: 0 })
-    ).toBe("PR draft");
+      pullRequestSummaryDisplay({ total: 3, open: 1, draft: 1, merged: 1, closed: 0 })
+    ).toEqual({ state: "open", label: "3 PRs · 2 open" });
     expect(
-      formatPullRequestSummaryLabel({ total: 1, open: 1, draft: 0, merged: 0, closed: 0 })
-    ).toBe("PR open");
-    expect(
-      formatPullRequestSummaryLabel({ total: 1, open: 0, draft: 0, merged: 1, closed: 0 })
-    ).toBe("PR merged");
-    expect(
-      formatPullRequestSummaryLabel({ total: 1, open: 0, draft: 0, merged: 0, closed: 1 })
-    ).toBe("PR closed");
-  });
-
-  it("counts drafts as open in the multi-PR label", () => {
-    expect(
-      formatPullRequestSummaryLabel({ total: 3, open: 1, draft: 1, merged: 1, closed: 0 })
-    ).toBe("3 PRs · 2 open");
+      pullRequestSummaryDisplay({ total: 2, open: 0, draft: 1, merged: 1, closed: 0 })
+    ).toEqual({ state: "draft", label: "2 PRs · 1 open" });
   });
 
   it("falls back to merged, then closed, when nothing is open", () => {
     expect(
-      formatPullRequestSummaryLabel({ total: 2, open: 0, draft: 0, merged: 2, closed: 0 })
-    ).toBe("2 PRs · 2 merged");
+      pullRequestSummaryDisplay({ total: 2, open: 0, draft: 0, merged: 2, closed: 0 })
+    ).toEqual({ state: "merged", label: "2 PRs · 2 merged" });
     expect(
-      formatPullRequestSummaryLabel({ total: 2, open: 0, draft: 0, merged: 0, closed: 2 })
-    ).toBe("2 PRs · 2 closed");
+      pullRequestSummaryDisplay({ total: 2, open: 0, draft: 0, merged: 1, closed: 1 })
+    ).toEqual({ state: "merged", label: "2 PRs · 1 merged" });
+    expect(
+      pullRequestSummaryDisplay({ total: 2, open: 0, draft: 0, merged: 0, closed: 2 })
+    ).toEqual({ state: "closed", label: "2 PRs · 2 closed" });
   });
 });

--- a/packages/web/src/lib/pr-summary.test.ts
+++ b/packages/web/src/lib/pr-summary.test.ts
@@ -1,5 +1,29 @@
 import { describe, expect, it } from "vitest";
-import { formatPullRequestSummaryLabel } from "./pr-summary";
+import { dominantPullRequestState, formatPullRequestSummaryLabel } from "./pr-summary";
+
+describe("dominantPullRequestState", () => {
+  it("returns null without a summary or with zero PRs", () => {
+    expect(dominantPullRequestState(undefined)).toBeNull();
+    expect(
+      dominantPullRequestState({ total: 0, open: 0, draft: 0, merged: 0, closed: 0 })
+    ).toBeNull();
+  });
+
+  it("picks the most actionable bucket: open, draft, merged, closed", () => {
+    expect(dominantPullRequestState({ total: 3, open: 1, draft: 1, merged: 1, closed: 0 })).toBe(
+      "open"
+    );
+    expect(dominantPullRequestState({ total: 2, open: 0, draft: 1, merged: 1, closed: 0 })).toBe(
+      "draft"
+    );
+    expect(dominantPullRequestState({ total: 2, open: 0, draft: 0, merged: 1, closed: 1 })).toBe(
+      "merged"
+    );
+    expect(dominantPullRequestState({ total: 1, open: 0, draft: 0, merged: 0, closed: 1 })).toBe(
+      "closed"
+    );
+  });
+});
 
 describe("formatPullRequestSummaryLabel", () => {
   it("returns null without a summary or with zero PRs", () => {

--- a/packages/web/src/lib/pr-summary.ts
+++ b/packages/web/src/lib/pr-summary.ts
@@ -1,4 +1,19 @@
-import type { PullRequestSummary } from "@open-inspect/shared";
+import type { PullRequestDisplayStatus, PullRequestSummary } from "@open-inspect/shared";
+
+/**
+ * The single display state a session-list row's PR icon shows. With several
+ * PRs the most actionable bucket wins: open, then draft, then merged, then
+ * closed. Null when the session has no tracked PRs.
+ */
+export function dominantPullRequestState(
+  summary: PullRequestSummary | undefined
+): PullRequestDisplayStatus | null {
+  if (!summary || summary.total === 0) return null;
+  if (summary.open > 0) return "open";
+  if (summary.draft > 0) return "draft";
+  if (summary.merged > 0) return "merged";
+  return "closed";
+}
 
 /**
  * Fixed-height PR indicator for a session list row (design §7): a single PR

--- a/packages/web/src/lib/pr-summary.ts
+++ b/packages/web/src/lib/pr-summary.ts
@@ -1,40 +1,48 @@
 import type { PullRequestDisplayStatus, PullRequestSummary } from "@open-inspect/shared";
 
 /**
- * The single display state a session-list row's PR icon shows. With several
- * PRs the most actionable bucket wins: open, then draft, then merged, then
- * closed. Null when the session has no tracked PRs.
+ * Everything a session-list row shows for its PRs, computed in one pass so
+ * the state icon and the text label can never disagree.
  */
-export function dominantPullRequestState(
-  summary: PullRequestSummary | undefined
-): PullRequestDisplayStatus | null {
-  if (!summary || summary.total === 0) return null;
-  if (summary.open > 0) return "open";
-  if (summary.draft > 0) return "draft";
-  if (summary.merged > 0) return "merged";
-  return "closed";
+export interface PullRequestSummaryDisplay {
+  /**
+   * The most actionable bucket: open, then draft, then merged, then closed.
+   * Drives the row's state icon.
+   */
+  state: PullRequestDisplayStatus;
+  /**
+   * Fixed-height indicator text (design §7): a single PR renders its display
+   * status ("PR merged"); several render the count plus the most informative
+   * bucket — open (incl. drafts) wins, then merged, then closed.
+   */
+  label: string;
 }
 
-/**
- * Fixed-height PR indicator for a session list row (design §7): a single PR
- * renders its display status ("PR merged"); several render the count plus the
- * most informative bucket — open (incl. drafts) wins, then merged, then
- * closed. Null when the session has no tracked PRs.
- */
-export function formatPullRequestSummaryLabel(
+/** Null when the session has no tracked PRs. */
+export function pullRequestSummaryDisplay(
   summary: PullRequestSummary | undefined
-): string | null {
+): PullRequestSummaryDisplay | null {
   if (!summary || summary.total === 0) return null;
 
+  const state: PullRequestDisplayStatus =
+    summary.open > 0
+      ? "open"
+      : summary.draft > 0
+        ? "draft"
+        : summary.merged > 0
+          ? "merged"
+          : "closed";
+
   if (summary.total === 1) {
-    if (summary.draft > 0) return "PR draft";
-    if (summary.open > 0) return "PR open";
-    if (summary.merged > 0) return "PR merged";
-    return "PR closed";
+    return { state, label: `PR ${state}` };
   }
 
   const openCount = summary.open + summary.draft;
-  if (openCount > 0) return `${summary.total} PRs · ${openCount} open`;
-  if (summary.merged > 0) return `${summary.total} PRs · ${summary.merged} merged`;
-  return `${summary.total} PRs · ${summary.closed} closed`;
+  const label =
+    openCount > 0
+      ? `${summary.total} PRs · ${openCount} open`
+      : summary.merged > 0
+        ? `${summary.total} PRs · ${summary.merged} merged`
+        : `${summary.total} PRs · ${summary.closed} closed`;
+  return { state, label };
 }


### PR DESCRIPTION
## Summary

Follow-up to the PR lifecycle tracking train (#960–#964), from e2e validation feedback: the session list should show PR state at a glance, GitHub-style — a colored state icon immediately left of the session title.

- **Icon per state**: open (accent), draft (muted), merged (success), closed (destructive) — colors follow the existing `prBadgeVariant` semantic tokens so light/dark themes are consistent with the session-detail badges.
- **Multi-PR sessions** show the dominant bucket via a new pure `dominantPullRequestState` helper: open > draft > merged > closed (most actionable wins). The icon's tooltip/aria-label is the existing summary label (e.g. "3 PRs · 2 open").
- **New icons** in the lucide style matching `GitPrIcon`: `GitMergeIcon`, `GitPrClosedIcon`, `GitPrDraftIcon`.
- The existing meta-row summary label is unchanged; rows without tracked PRs render exactly as before.

## Testing

- `dominantPullRequestState` unit tests (null cases + bucket precedence)
- Sidebar test asserts the merged icon on a single-PR row, the open icon on a multi-PR row, and no icon on rows without PRs
- Full web suite: 696 passed; typecheck + lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub-style pull request status icons to session titles.
  * Icons cover open, draft, merged, and closed states and match the corresponding state styling for better at-a-glance clarity.
* **Tests**
  * Expanded automated coverage for pull request state selection logic and for verifying the sidebar’s displayed PR status indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->