### PR TITLE
fix: match sidebar PR icons to GitHub colors

### DIFF
--- a/packages/web/src/components/pr-state-icon.tsx
+++ b/packages/web/src/components/pr-state-icon.tsx
@@ -1,6 +1,12 @@
 import type { PullRequestDisplayStatus } from "@open-inspect/shared";
-import { PR_STATE_TEXT_CLASS } from "@/components/ui/badge";
 import { GitMergeIcon, GitPrClosedIcon, GitPrDraftIcon, GitPrIcon } from "@/components/ui/icons";
+
+export const PR_STATE_TEXT_CLASS: Record<PullRequestDisplayStatus, string> = {
+  open: "text-[#1f883d] dark:text-[#3fb950]",
+  draft: "text-[#656d76] dark:text-[#8c959f]",
+  merged: "text-[#8250df] dark:text-[#a371f7]",
+  closed: "text-[#cf222e] dark:text-[#f85149]",
+};
 
 const PR_STATE_ICONS: Record<
   PullRequestDisplayStatus,
@@ -13,8 +19,7 @@ const PR_STATE_ICONS: Record<
 };
 
 /**
- * GitHub-style PR state icon for a session-list row. Colors come from
- * PR_STATE_TEXT_CLASS — the same tokens the PR badge variants use.
+ * GitHub-style PR state icon for a session-list row.
  */
 export function PullRequestStateIcon({
   state,

--- a/packages/web/src/components/pr-state-icon.tsx
+++ b/packages/web/src/components/pr-state-icon.tsx
@@ -1,7 +1,7 @@
 import type { PullRequestDisplayStatus } from "@open-inspect/shared";
 import { GitMergeIcon, GitPrClosedIcon, GitPrDraftIcon, GitPrIcon } from "@/components/ui/icons";
 
-export const PR_STATE_TEXT_CLASS: Record<PullRequestDisplayStatus, string> = {
+const PR_STATE_ICON_TEXT_CLASS: Record<PullRequestDisplayStatus, string> = {
   open: "text-[#1f883d] dark:text-[#3fb950]",
   draft: "text-[#656d76] dark:text-[#8c959f]",
   merged: "text-[#8250df] dark:text-[#a371f7]",
@@ -31,7 +31,7 @@ export function PullRequestStateIcon({
   const Icon = PR_STATE_ICONS[state];
   return (
     <span
-      className={`flex-shrink-0 ${PR_STATE_TEXT_CLASS[state]}`}
+      className={`flex-shrink-0 ${PR_STATE_ICON_TEXT_CLASS[state]}`}
       title={label}
       aria-label={label}
       data-testid={`pr-state-${state}`}

--- a/packages/web/src/components/session-sidebar.test.tsx
+++ b/packages/web/src/components/session-sidebar.test.tsx
@@ -120,16 +120,23 @@ describe("SessionSidebar", () => {
       </SWRConfig>
     );
 
-    expect(await screen.findByText("PR merged")).toBeInTheDocument();
-    expect(screen.getByText("3 PRs · 2 open")).toBeInTheDocument();
-    expect(screen.getAllByText(/PR/)).toHaveLength(2);
-
     // GitHub-style state icon next to the title: merged for the single-PR
     // session, open (dominant bucket) for the multi-PR session, none without
     // tracked PRs.
-    expect(screen.getByTestId("pr-state-merged")).toBeInTheDocument();
-    expect(screen.getByTestId("pr-state-open")).toBeInTheDocument();
+    expect(await screen.findByTestId("pr-state-merged")).toHaveClass(
+      "text-[#8250df]",
+      "dark:text-[#a371f7]"
+    );
+    expect(screen.getByTestId("pr-state-open")).toHaveClass(
+      "text-[#1f883d]",
+      "dark:text-[#3fb950]"
+    );
     expect(screen.queryAllByTestId(/^pr-state-/)).toHaveLength(2);
+
+    // PR state is conveyed by the title icon without repeating the summary in
+    // the lower repository and branch metadata.
+    expect(screen.getByText("Session 1").closest("a")).not.toHaveTextContent("PR merged");
+    expect(screen.getByText("Session 2").closest("a")).not.toHaveTextContent("3 PRs · 2 open");
   });
 
   it("renders nested child sessions under their immediate parent", async () => {

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -39,7 +39,6 @@ import {
   AutomationsIcon,
   BranchIcon,
   BoxIcon,
-  GitPrIcon,
   DataControlsIcon,
 } from "@/components/ui/icons";
 import { APP_SHORT_NAME } from "@/lib/site-config";
@@ -920,13 +919,6 @@ function SessionListItem({
                   <span>·</span>
                   <BranchIcon className="w-3 h-3 flex-shrink-0" />
                   <span className="truncate">{session.baseBranch}</span>
-                </>
-              )}
-              {prDisplay && (
-                <>
-                  <span>·</span>
-                  <GitPrIcon className="w-3 h-3 flex-shrink-0" />
-                  <span className="truncate">{prDisplay.label}</span>
                 </>
               )}
             </div>

--- a/packages/web/src/components/ui/badge.tsx
+++ b/packages/web/src/components/ui/badge.tsx
@@ -4,9 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 /**
- * Canonical text-color token per PR display state. The PR badges below and
- * the session-list state icon both derive from this map, so the color policy
- * has exactly one home.
+ * Text-color token per PR badge display state.
  */
 export const PR_STATE_TEXT_CLASS = {
   open: "text-accent",


### PR DESCRIPTION
## Summary
- use GitHub's light and dark theme colors for open, draft, merged, and closed PR status icons in the sessions sidebar
- remove the duplicated PR summary from the lower session metadata row
- update sidebar tests to verify GitHub colors and the streamlined metadata

## Verification
- `npm test -w @open-inspect/web -- --run src/components/session-sidebar.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- `npx prettier --check packages/web/src/components/pr-state-icon.tsx packages/web/src/components/session-sidebar.tsx packages/web/src/components/session-sidebar.test.tsx`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/5446b6327961bb5efd5f0f87803af8a8)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session sidebar items now display a base-branch chip when a non-default branch is used.
  * Pull request states are shown via GitHub-style colored state icons.

* **Bug Fixes**
  * Session rows no longer render redundant pull-request summary/label text.
  * Pull request state icon text colors were updated to match the intended display styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->