### PR TITLE
Consolidate shared model metadata catalog

### DIFF
--- a/packages/shared/src/models.test.ts
+++ b/packages/shared/src/models.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_ENABLED_MODELS,
   DEFAULT_MODEL,
+  MODEL_CATALOG,
   MODEL_OPTIONS,
+  MODEL_REASONING_CONFIG,
+  VALID_MODELS,
   extractProviderAndModel,
   getDefaultReasoningEffort,
   getReasoningConfig,
@@ -47,6 +50,42 @@ const DEEPSEEK_MODELS = ["deepseek/deepseek-v4-flash", "deepseek/deepseek-v4-pro
 const ZAI_CODING_PLAN_MODELS = ["zai-coding-plan/glm-5.2"] as const;
 
 describe("model utilities", () => {
+  it("derives every public model view from the authoritative catalog", () => {
+    const catalogModels = MODEL_CATALOG.flatMap((group) => group.models);
+
+    expect(VALID_MODELS).toEqual(catalogModels.map((model) => model.id));
+    expect(MODEL_OPTIONS).toEqual(
+      MODEL_CATALOG.map((group) => ({
+        category: group.category,
+        models: group.models.map(({ id, name, description }) => ({ id, name, description })),
+      }))
+    );
+    expect(DEFAULT_ENABLED_MODELS).toEqual(
+      MODEL_CATALOG.filter((group) => group.enabledByDefault).flatMap((group) =>
+        group.models.map((model) => model.id)
+      )
+    );
+
+    const defaultModels = catalogModels.filter((model) => "default" in model && model.default);
+    expect(defaultModels).toHaveLength(1);
+    expect(DEFAULT_MODEL).toBe(defaultModels[0]?.id);
+
+    expect(MODEL_REASONING_CONFIG).toEqual(
+      Object.fromEntries(
+        catalogModels.flatMap((model) =>
+          "reasoning" in model
+            ? [
+                [
+                  model.id,
+                  { efforts: [...model.reasoning.efforts], default: model.reasoning.default },
+                ],
+              ]
+            : []
+        )
+      )
+    );
+  });
+
   it("keeps DEFAULT_MODEL valid", () => {
     expect(isValidModel(DEFAULT_MODEL)).toBe(true);
   });

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -19,6 +19,23 @@ export interface ModelReasoningConfig {
   default: ReasoningEffort | undefined;
 }
 
+interface ModelCatalogGroup {
+  category: string;
+  enabledByDefault: boolean;
+  models: readonly ModelCatalogEntry[];
+}
+
+interface ModelCatalogEntry {
+  id: `${string}/${string}`;
+  name: string;
+  description: string;
+  default?: true;
+  reasoning?: {
+    readonly efforts: readonly ReasoningEffort[];
+    readonly default: ReasoningEffort | undefined;
+  };
+}
+
 /**
  * Authoritative model metadata, grouped in UI display order.
  */
@@ -175,7 +192,7 @@ export const MODEL_CATALOG = [
       { id: "deepseek/deepseek-v4-pro", name: "DeepSeek V4 Pro", description: "Most capable" },
     ],
   },
-] as const;
+] as const satisfies readonly ModelCatalogGroup[];
 
 export type ValidModel = (typeof MODEL_CATALOG)[number]["models"][number]["id"];
 
@@ -188,9 +205,11 @@ const MODEL_DEFINITIONS: readonly CatalogModel[] = MODEL_CATALOG.flatMap((group)
 export const VALID_MODELS: ValidModel[] = MODEL_DEFINITIONS.map((model) => model.id);
 
 /** Default model to use when none is specified or valid. */
-export const DEFAULT_MODEL: ValidModel = MODEL_DEFINITIONS.find(
-  (model) => "default" in model && model.default
-)!.id;
+const defaultModels = MODEL_DEFINITIONS.filter((model) => "default" in model && model.default);
+if (defaultModels.length !== 1) {
+  throw new Error("MODEL_CATALOG must define exactly one model with `default: true`");
+}
+export const DEFAULT_MODEL: ValidModel = defaultModels[0].id;
 
 /** Per-model reasoning configuration. Models omitted do not support reasoning controls. */
 export const MODEL_REASONING_CONFIG: Partial<Record<ValidModel, ModelReasoningConfig>> =

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -6,44 +6,6 @@
  */
 
 /**
- * Valid model names supported by the system.
- * All models use "provider/model" format.
- */
-export const VALID_MODELS = [
-  "anthropic/claude-haiku-4-5",
-  "anthropic/claude-sonnet-4-5",
-  "anthropic/claude-sonnet-4-6",
-  "anthropic/claude-opus-4-5",
-  "anthropic/claude-opus-4-6",
-  "anthropic/claude-opus-4-7",
-  "anthropic/claude-opus-4-8",
-  "anthropic/claude-fable-5",
-  "openai/gpt-5.4",
-  "openai/gpt-5.5",
-  "openai/gpt-5.6-sol",
-  "openai/gpt-5.6-terra",
-  "openai/gpt-5.6-luna",
-  "openai/gpt-5.3-codex",
-  "openai/gpt-5.3-codex-spark",
-  "opencode/kimi-k2.5",
-  "opencode/kimi-k2.6",
-  "opencode/minimax-m2.5",
-  "opencode/qwen3.7-max",
-  "opencode/glm-5",
-  "opencode/glm-5.1",
-  "zai-coding-plan/glm-5.2",
-  "deepseek/deepseek-v4-flash",
-  "deepseek/deepseek-v4-pro",
-] as const;
-
-export type ValidModel = (typeof VALID_MODELS)[number];
-
-/**
- * Default model to use when none specified or invalid.
- */
-export const DEFAULT_MODEL: ValidModel = "anthropic/claude-sonnet-4-6";
-
-/**
  * Reasoning effort levels supported across providers.
  *
  * - "none": No reasoning (OpenAI only)
@@ -58,44 +20,194 @@ export interface ModelReasoningConfig {
 }
 
 /**
- * Per-model reasoning configuration.
- * Models not listed here do not support reasoning controls.
+ * Authoritative model metadata, grouped in UI display order.
  */
-export const MODEL_REASONING_CONFIG: Partial<Record<ValidModel, ModelReasoningConfig>> = {
-  "anthropic/claude-haiku-4-5": { efforts: ["high", "max"], default: "max" },
-  "anthropic/claude-sonnet-4-5": { efforts: ["high", "max"], default: "max" },
-  "anthropic/claude-sonnet-4-6": { efforts: ["low", "medium", "high", "max"], default: "high" },
-  "anthropic/claude-opus-4-5": { efforts: ["high", "max"], default: "max" },
-  "anthropic/claude-opus-4-6": { efforts: ["low", "medium", "high", "max"], default: "high" },
-  "anthropic/claude-opus-4-7": {
-    efforts: ["low", "medium", "high", "xhigh", "max"],
-    default: "high",
+export const MODEL_CATALOG = [
+  {
+    category: "Anthropic",
+    enabledByDefault: true,
+    models: [
+      {
+        id: "anthropic/claude-haiku-4-5",
+        name: "Claude Haiku 4.5",
+        description: "Fast and efficient",
+        reasoning: { efforts: ["high", "max"], default: "max" },
+      },
+      {
+        id: "anthropic/claude-sonnet-4-5",
+        name: "Claude Sonnet 4.5",
+        description: "Balanced performance",
+        reasoning: { efforts: ["high", "max"], default: "max" },
+      },
+      {
+        id: "anthropic/claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        description: "Latest balanced, fast coding",
+        default: true,
+        reasoning: { efforts: ["low", "medium", "high", "max"], default: "high" },
+      },
+      {
+        id: "anthropic/claude-opus-4-5",
+        name: "Claude Opus 4.5",
+        description: "Most capable",
+        reasoning: { efforts: ["high", "max"], default: "max" },
+      },
+      {
+        id: "anthropic/claude-opus-4-6",
+        name: "Claude Opus 4.6",
+        description: "Most capable, adaptive thinking",
+        reasoning: { efforts: ["low", "medium", "high", "max"], default: "high" },
+      },
+      {
+        id: "anthropic/claude-opus-4-7",
+        name: "Claude Opus 4.7",
+        description: "Most capable, adaptive thinking",
+        reasoning: {
+          efforts: ["low", "medium", "high", "xhigh", "max"],
+          default: "high",
+        },
+      },
+      {
+        id: "anthropic/claude-opus-4-8",
+        name: "Claude Opus 4.8",
+        description: "Most capable, adaptive thinking",
+        reasoning: {
+          efforts: ["low", "medium", "high", "xhigh", "max"],
+          default: "high",
+        },
+      },
+      {
+        id: "anthropic/claude-fable-5",
+        name: "Claude Fable 5",
+        description: "Most powerful, new tier above Opus",
+        reasoning: {
+          efforts: ["low", "medium", "high", "xhigh", "max"],
+          default: "high",
+        },
+      },
+    ],
   },
-  "anthropic/claude-opus-4-8": {
-    efforts: ["low", "medium", "high", "xhigh", "max"],
-    default: "high",
+  {
+    category: "OpenAI",
+    enabledByDefault: true,
+    models: [
+      {
+        id: "openai/gpt-5.4",
+        name: "GPT 5.4",
+        description: "Flagship model",
+        reasoning: {
+          efforts: ["none", "low", "medium", "high", "xhigh"],
+          default: undefined,
+        },
+      },
+      {
+        id: "openai/gpt-5.5",
+        name: "GPT 5.5",
+        description: "Latest flagship model",
+        reasoning: {
+          efforts: ["none", "low", "medium", "high", "xhigh"],
+          default: undefined,
+        },
+      },
+      {
+        id: "openai/gpt-5.6-sol",
+        name: "GPT 5.6 Sol",
+        description: "Frontier model for complex professional work",
+        reasoning: {
+          efforts: ["none", "low", "medium", "high", "xhigh"],
+          default: undefined,
+        },
+      },
+      {
+        id: "openai/gpt-5.6-terra",
+        name: "GPT 5.6 Terra",
+        description: "Balanced, cost-efficient everyday work",
+        reasoning: {
+          efforts: ["none", "low", "medium", "high", "xhigh"],
+          default: undefined,
+        },
+      },
+      {
+        id: "openai/gpt-5.6-luna",
+        name: "GPT 5.6 Luna",
+        description: "Fast, cost-efficient high-volume workloads",
+        reasoning: {
+          efforts: ["none", "low", "medium", "high", "xhigh"],
+          default: undefined,
+        },
+      },
+      {
+        id: "openai/gpt-5.3-codex",
+        name: "GPT 5.3 Codex",
+        description: "Latest codex",
+        reasoning: { efforts: ["low", "medium", "high", "xhigh"], default: "high" },
+      },
+      {
+        id: "openai/gpt-5.3-codex-spark",
+        name: "GPT 5.3 Codex Spark",
+        description: "Low-latency codex variant",
+        reasoning: { efforts: ["low", "medium", "high", "xhigh"], default: "high" },
+      },
+    ],
   },
-  "anthropic/claude-fable-5": {
-    efforts: ["low", "medium", "high", "xhigh", "max"],
-    default: "high",
+  {
+    category: "OpenCode Zen",
+    enabledByDefault: false,
+    models: [
+      { id: "opencode/kimi-k2.5", name: "Kimi K2.5", description: "Moonshot AI" },
+      { id: "opencode/kimi-k2.6", name: "Kimi K2.6", description: "Moonshot AI" },
+      { id: "opencode/minimax-m2.5", name: "MiniMax M2.5", description: "MiniMax" },
+      { id: "opencode/qwen3.7-max", name: "Qwen3.7 Max", description: "Alibaba Cloud" },
+      { id: "opencode/glm-5", name: "GLM 5", description: "Z.ai 744B MoE" },
+      { id: "opencode/glm-5.1", name: "GLM 5.1", description: "Z.ai" },
+    ],
   },
-  "openai/gpt-5.4": { efforts: ["none", "low", "medium", "high", "xhigh"], default: undefined },
-  "openai/gpt-5.5": { efforts: ["none", "low", "medium", "high", "xhigh"], default: undefined },
-  "openai/gpt-5.6-sol": {
-    efforts: ["none", "low", "medium", "high", "xhigh"],
-    default: undefined,
+  {
+    category: "Z.AI Coding Plan",
+    enabledByDefault: false,
+    models: [{ id: "zai-coding-plan/glm-5.2", name: "GLM 5.2", description: "Z.AI Coding Plan" }],
   },
-  "openai/gpt-5.6-terra": {
-    efforts: ["none", "low", "medium", "high", "xhigh"],
-    default: undefined,
+  {
+    category: "DeepSeek",
+    enabledByDefault: false,
+    models: [
+      { id: "deepseek/deepseek-v4-flash", name: "DeepSeek V4 Flash", description: "Fast model" },
+      { id: "deepseek/deepseek-v4-pro", name: "DeepSeek V4 Pro", description: "Most capable" },
+    ],
   },
-  "openai/gpt-5.6-luna": {
-    efforts: ["none", "low", "medium", "high", "xhigh"],
-    default: undefined,
-  },
-  "openai/gpt-5.3-codex": { efforts: ["low", "medium", "high", "xhigh"], default: "high" },
-  "openai/gpt-5.3-codex-spark": { efforts: ["low", "medium", "high", "xhigh"], default: "high" },
-};
+] as const;
+
+export type ValidModel = (typeof MODEL_CATALOG)[number]["models"][number]["id"];
+
+type CatalogModel = (typeof MODEL_CATALOG)[number]["models"][number];
+const MODEL_DEFINITIONS: readonly CatalogModel[] = MODEL_CATALOG.flatMap((group) => [
+  ...group.models,
+]);
+
+/** Valid model names supported by the system, in UI display order. */
+export const VALID_MODELS: ValidModel[] = MODEL_DEFINITIONS.map((model) => model.id);
+
+/** Default model to use when none is specified or valid. */
+export const DEFAULT_MODEL: ValidModel = MODEL_DEFINITIONS.find(
+  (model) => "default" in model && model.default
+)!.id;
+
+/** Per-model reasoning configuration. Models omitted do not support reasoning controls. */
+export const MODEL_REASONING_CONFIG: Partial<Record<ValidModel, ModelReasoningConfig>> =
+  Object.fromEntries(
+    MODEL_CATALOG.flatMap((group) =>
+      group.models.flatMap((model) =>
+        "reasoning" in model
+          ? [
+              [
+                model.id,
+                { efforts: [...model.reasoning.efforts], default: model.reasoning.default },
+              ],
+            ]
+          : []
+      )
+    )
+  );
 
 export interface ModelDisplayInfo {
   id: ValidModel;
@@ -112,124 +224,19 @@ export interface ModelCategory {
  * Model options grouped by provider, for use in UI dropdowns.
  */
 export const MODEL_OPTIONS: ModelCategory[] = [
-  {
-    category: "Anthropic",
-    models: [
-      {
-        id: "anthropic/claude-haiku-4-5",
-        name: "Claude Haiku 4.5",
-        description: "Fast and efficient",
-      },
-      {
-        id: "anthropic/claude-sonnet-4-5",
-        name: "Claude Sonnet 4.5",
-        description: "Balanced performance",
-      },
-      {
-        id: "anthropic/claude-sonnet-4-6",
-        name: "Claude Sonnet 4.6",
-        description: "Latest balanced, fast coding",
-      },
-      {
-        id: "anthropic/claude-opus-4-5",
-        name: "Claude Opus 4.5",
-        description: "Most capable",
-      },
-      {
-        id: "anthropic/claude-opus-4-6",
-        name: "Claude Opus 4.6",
-        description: "Most capable, adaptive thinking",
-      },
-      {
-        id: "anthropic/claude-opus-4-7",
-        name: "Claude Opus 4.7",
-        description: "Most capable, adaptive thinking",
-      },
-      {
-        id: "anthropic/claude-opus-4-8",
-        name: "Claude Opus 4.8",
-        description: "Most capable, adaptive thinking",
-      },
-      {
-        id: "anthropic/claude-fable-5",
-        name: "Claude Fable 5",
-        description: "Most powerful, new tier above Opus",
-      },
-    ],
-  },
-  {
-    category: "OpenAI",
-    models: [
-      { id: "openai/gpt-5.4", name: "GPT 5.4", description: "Flagship model" },
-      { id: "openai/gpt-5.5", name: "GPT 5.5", description: "Latest flagship model" },
-      {
-        id: "openai/gpt-5.6-sol",
-        name: "GPT 5.6 Sol",
-        description: "Frontier model for complex professional work",
-      },
-      {
-        id: "openai/gpt-5.6-terra",
-        name: "GPT 5.6 Terra",
-        description: "Balanced, cost-efficient everyday work",
-      },
-      {
-        id: "openai/gpt-5.6-luna",
-        name: "GPT 5.6 Luna",
-        description: "Fast, cost-efficient high-volume workloads",
-      },
-      { id: "openai/gpt-5.3-codex", name: "GPT 5.3 Codex", description: "Latest codex" },
-      {
-        id: "openai/gpt-5.3-codex-spark",
-        name: "GPT 5.3 Codex Spark",
-        description: "Low-latency codex variant",
-      },
-    ],
-  },
-  {
-    category: "OpenCode Zen",
-    models: [
-      { id: "opencode/kimi-k2.5", name: "Kimi K2.5", description: "Moonshot AI" },
-      { id: "opencode/kimi-k2.6", name: "Kimi K2.6", description: "Moonshot AI" },
-      { id: "opencode/minimax-m2.5", name: "MiniMax M2.5", description: "MiniMax" },
-      { id: "opencode/qwen3.7-max", name: "Qwen3.7 Max", description: "Alibaba Cloud" },
-      { id: "opencode/glm-5", name: "GLM 5", description: "Z.ai 744B MoE" },
-      { id: "opencode/glm-5.1", name: "GLM 5.1", description: "Z.ai" },
-    ],
-  },
-  {
-    category: "Z.AI Coding Plan",
-    models: [{ id: "zai-coding-plan/glm-5.2", name: "GLM 5.2", description: "Z.AI Coding Plan" }],
-  },
-  {
-    category: "DeepSeek",
-    models: [
-      { id: "deepseek/deepseek-v4-flash", name: "DeepSeek V4 Flash", description: "Fast model" },
-      { id: "deepseek/deepseek-v4-pro", name: "DeepSeek V4 Pro", description: "Most capable" },
-    ],
-  },
+  ...MODEL_CATALOG.map((group) => ({
+    category: group.category,
+    models: group.models.map(({ id, name, description }) => ({ id, name, description })),
+  })),
 ];
 
 /**
  * Models enabled by default when no preferences are stored.
  * Excludes opt-in providers which must be enabled via settings.
  */
-export const DEFAULT_ENABLED_MODELS: ValidModel[] = [
-  "anthropic/claude-haiku-4-5",
-  "anthropic/claude-sonnet-4-5",
-  "anthropic/claude-sonnet-4-6",
-  "anthropic/claude-opus-4-5",
-  "anthropic/claude-opus-4-6",
-  "anthropic/claude-opus-4-7",
-  "anthropic/claude-opus-4-8",
-  "anthropic/claude-fable-5",
-  "openai/gpt-5.4",
-  "openai/gpt-5.5",
-  "openai/gpt-5.6-sol",
-  "openai/gpt-5.6-terra",
-  "openai/gpt-5.6-luna",
-  "openai/gpt-5.3-codex",
-  "openai/gpt-5.3-codex-spark",
-];
+export const DEFAULT_ENABLED_MODELS: ValidModel[] = MODEL_CATALOG.filter(
+  (group) => group.enabledByDefault
+).flatMap((group) => group.models.map((model) => model.id));
 
 // === Normalization ===
 


### PR DESCRIPTION
## Summary
- add one readonly authoritative model catalog for IDs, display metadata, provider grouping, reasoning support, and defaults
- derive the existing public model exports while preserving ordering and runtime shapes
- add a focused consistency test covering all derived catalogs and the single fallback model

## Verification
- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/shared` (30 files, 398 tests passed)
- `npm run typecheck`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/8e28ecb107eb2e6c74b121350dc1e77f)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Centralized model catalog to keep model availability, ordering, and the default selection consistent.
  * Updated model dropdown options and “enabled by default” settings to be generated from the same source.
  * Kept reasoning presets and default reasoning settings aligned with the supported models.
* **Tests**
  * Added automated checks to ensure the derived model list, default model, dropdown mappings, and reasoning configuration remain synchronized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->