### PR TITLE
fix: restrict sandbox authorization to running state

### DIFF
--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
@@ -316,45 +316,29 @@ describe("createSandboxHandler", () => {
     expect(log.warn).toHaveBeenCalledWith("Sandbox token verification failed: no sandbox");
   });
 
-  it("returns 410 when sandbox is stopped", async () => {
-    const { handler, getSandbox, log } = createHandler();
-    getSandbox.mockReturnValue({ status: "stopped" } as SandboxRow);
+  it.each(["pending", "stopped", "stale", "failed"] as const)(
+    "returns 410 when sandbox is %s",
+    async (status) => {
+      const { handler, getSandbox, isValidSandboxToken, log } = createHandler();
+      getSandbox.mockReturnValue({ status } as SandboxRow);
 
-    const response = await handler.verifySandboxToken(
-      new Request("http://internal/internal/verify-sandbox-token", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ token: "abc" }),
-      })
-    );
+      const response = await handler.verifySandboxToken(
+        new Request("http://internal/internal/verify-sandbox-token", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ token: "abc" }),
+        })
+      );
 
-    expect(response.status).toBe(410);
-    expect(await response.json()).toEqual({ valid: false, error: "Sandbox stopped" });
-    expect(log.warn).toHaveBeenCalledWith(
-      "Sandbox token verification failed: sandbox is stopped/stale",
-      { status: "stopped" }
-    );
-  });
-
-  it("returns 410 when sandbox is stale", async () => {
-    const { handler, getSandbox, log } = createHandler();
-    getSandbox.mockReturnValue({ status: "stale" } as SandboxRow);
-
-    const response = await handler.verifySandboxToken(
-      new Request("http://internal/internal/verify-sandbox-token", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ token: "abc" }),
-      })
-    );
-
-    expect(response.status).toBe(410);
-    expect(await response.json()).toEqual({ valid: false, error: "Sandbox stopped" });
-    expect(log.warn).toHaveBeenCalledWith(
-      "Sandbox token verification failed: sandbox is stopped/stale",
-      { status: "stale" }
-    );
-  });
+      expect(response.status).toBe(410);
+      expect(await response.json()).toEqual({ valid: false, error: "Sandbox not running" });
+      expect(log.warn).toHaveBeenCalledWith(
+        "Sandbox token verification failed: sandbox is not running",
+        { status }
+      );
+      expect(isValidSandboxToken).not.toHaveBeenCalled();
+    }
+  );
 
   it("returns 401 when sandbox token is invalid", async () => {
     const { handler, getSandbox, isValidSandboxToken, log } = createHandler();

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
@@ -183,11 +183,11 @@ export function createSandboxHandler(deps: SandboxHandlerDeps): SandboxHandler {
         return Response.json({ valid: false, error: "No sandbox" }, { status: 404 });
       }
 
-      if (sandbox.status === "stopped" || sandbox.status === "stale") {
-        deps.getLog().warn("Sandbox token verification failed: sandbox is stopped/stale", {
+      if (sandbox.status !== "running") {
+        deps.getLog().warn("Sandbox token verification failed: sandbox is not running", {
           status: sandbox.status,
         });
-        return Response.json({ valid: false, error: "Sandbox stopped" }, { status: 410 });
+        return Response.json({ valid: false, error: "Sandbox not running" }, { status: 410 });
       }
 
       const isTokenValid = await deps.isValidSandboxToken(token, sandbox);

--- a/packages/control-plane/test/integration/helpers.ts
+++ b/packages/control-plane/test/integration/helpers.ts
@@ -281,11 +281,12 @@ export async function seedSandboxAuth(
   stub: DurableObjectStub,
   opts: { authToken: string; sandboxId: string }
 ): Promise<void> {
+  await waitForSandboxStatus(stub, "failed");
   const tokenHash = await hashToken(opts.authToken);
 
   await runInDurableObject(stub, (instance: SessionDO) => {
     instance.ctx.storage.sql.exec(
-      "UPDATE sandbox SET auth_token = ?, auth_token_hash = ?, modal_sandbox_id = ?",
+      "UPDATE sandbox SET auth_token = ?, auth_token_hash = ?, modal_sandbox_id = ?, status = 'running'",
       opts.authToken,
       tokenHash,
       opts.sandboxId
@@ -294,17 +295,18 @@ export async function seedSandboxAuth(
 }
 
 /**
- * Seed auth_token_hash and modal_sandbox_id on the sandbox row.
+ * Seed a running sandbox with auth_token_hash and modal_sandbox_id.
  */
 export async function seedSandboxAuthHash(
   stub: DurableObjectStub,
   opts: { authToken: string; sandboxId: string }
 ): Promise<void> {
+  await waitForSandboxStatus(stub, "failed");
   const tokenHash = await hashToken(opts.authToken);
 
   await runInDurableObject(stub, (instance: SessionDO) => {
     instance.ctx.storage.sql.exec(
-      "UPDATE sandbox SET auth_token_hash = ?, auth_token = NULL, modal_sandbox_id = ?",
+      "UPDATE sandbox SET auth_token_hash = ?, auth_token = NULL, modal_sandbox_id = ?, status = 'running'",
       tokenHash,
       opts.sandboxId
     );

--- a/packages/control-plane/test/integration/session-lifecycle.test.ts
+++ b/packages/control-plane/test/integration/session-lifecycle.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { runInDurableObject } from "cloudflare:test";
 import type { SessionDO } from "../../src/session/durable-object";
-import { initSession, seedSandboxAuthHash } from "./helpers";
+import { initSession, seedSandboxAuthHash, waitForSandboxStatus } from "./helpers";
 
 describe("GET /internal/state", () => {
   it("state includes sandbox after init", async () => {
@@ -191,12 +191,13 @@ describe("POST /internal/verify-sandbox-token", () => {
 
   it("validates correct token and rejects wrong token", async () => {
     const { stub } = await initSession();
+    await waitForSandboxStatus(stub, "failed");
 
     // Seed auth_token on the sandbox directly
     const authToken = "test-sandbox-auth-token-12345";
     await runInDurableObject(stub, (instance: SessionDO) => {
       instance.ctx.storage.sql.exec(
-        "UPDATE sandbox SET auth_token = ?, auth_token_hash = NULL WHERE id = (SELECT id FROM sandbox LIMIT 1)",
+        "UPDATE sandbox SET auth_token = ?, auth_token_hash = NULL, status = 'running' WHERE id = (SELECT id FROM sandbox LIMIT 1)",
         authToken
       );
     });
@@ -220,5 +221,23 @@ describe("POST /internal/verify-sandbox-token", () => {
     expect(invalidRes.status).toBe(401);
     const invalidBody = await invalidRes.json<{ valid: boolean; error: string }>();
     expect(invalidBody.valid).toBe(false);
+  });
+
+  it("rejects a retained token after the sandbox fails", async () => {
+    const { stub } = await initSession();
+    const authToken = "test-failed-sandbox-token";
+    await seedSandboxAuthHash(stub, { authToken, sandboxId: "sb-failed-token" });
+    await runInDurableObject(stub, (instance: SessionDO) => {
+      instance.ctx.storage.sql.exec("UPDATE sandbox SET status = 'failed'");
+    });
+
+    const response = await stub.fetch("http://internal/internal/verify-sandbox-token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: authToken }),
+    });
+
+    expect(response.status).toBe(410);
+    expect(await response.json()).toEqual({ valid: false, error: "Sandbox not running" });
   });
 });

--- a/packages/control-plane/test/integration/websocket-sandbox.test.ts
+++ b/packages/control-plane/test/integration/websocket-sandbox.test.ts
@@ -82,11 +82,6 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
     const { stub } = await initNamedSession(name);
     await seedSandboxAuth(stub, { authToken: SANDBOX_TOKEN, sandboxId: SANDBOX_ID });
 
-    // Wait for init's fire-and-forget warmSandbox to fail (no Modal in test env).
-    // The spawn failure sets status to "failed" which we need to happen before
-    // the WS connect sets it to "ready", otherwise the two race.
-    await waitForSandboxStatus(stub, "failed");
-
     const { ws } = await openSandboxWs(name, {
       authToken: SANDBOX_TOKEN,
       sandboxId: SANDBOX_ID,


### PR DESCRIPTION
## Summary
- authorize sandbox tokens only while the sandbox is in the `running` lifecycle state
- reject failed, terminal, pre-operational, and future unknown states before token comparison
- extend handler coverage for failed and non-running sandbox states

## Verification
- `npm test -w @open-inspect/control-plane -- src/session/http/handlers/sandbox.handler.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `npx prettier --check packages/control-plane/src/session/http/handlers/sandbox.handler.ts packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts`

Linear: COL-14

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/19f270ab2d28fc5f3536a70898560dcb)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox token verification now rejects any sandbox that isn’t in the **running** state.
  * Non-running states consistently return **HTTP 410** with `{ valid: false, error: "Sandbox not running" }` (including pending, stopped, stale, and failed).
  * Diagnostic logging now includes the sandbox’s current status for easier troubleshooting.  
* **Tests**
  * Updated and expanded integration coverage around sandbox lifecycle and token verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->