### PR TITLE
Fix Linear follow-up completion delivery

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -345,6 +345,26 @@ configure this in **Step 7b** after running Terraform.
 
 ---
 
+## Step 4b: Create a Linear OAuth App (Optional)
+
+Skip this step if you don't need the Linear Agent integration.
+
+1. Create an application in **Linear Settings → API → Applications**.
+2. Enable webhooks and subscribe to **Agent session events**. **Permission changes** and **Inbox
+   notifications** are also useful operational signals.
+3. Enable **Client credentials tokens**. This Linear-side setting is not managed by Terraform.
+4. Configure these URLs, replacing the deployment name and Workers subdomain:
+   - Callback URL:
+     `https://open-inspect-linear-bot-{deployment_name}.YOUR-SUBDOMAIN.workers.dev/oauth/callback`
+   - Webhook URL:
+     `https://open-inspect-linear-bot-{deployment_name}.YOUR-SUBDOMAIN.workers.dev/webhook`
+5. Record the client ID, client secret, and webhook signing secret for `terraform.tfvars`.
+
+The app is installed after deployment in **Step 7d**. Runtime access uses replaceable
+client-credentials tokens; authorization-code refresh tokens are not stored as runtime credentials.
+
+---
+
 ## Step 5: Generate Security Secrets
 
 Generate these random secrets (you'll need them for `terraform.tfvars`):
@@ -466,6 +486,12 @@ slack_signing_secret = ""
 enable_github_bot      = false
 github_webhook_secret  = ""          # From Step 5 (required if enabled)
 github_bot_username    = ""          # e.g., "my-app[bot]" (your GitHub App's bot login)
+
+# Linear Agent (set enable_linear_bot = true to deploy the webhook worker)
+enable_linear_bot      = false
+linear_client_id       = ""          # From Step 4b (required if enabled)
+linear_client_secret   = ""          # From Step 4b (required if enabled)
+linear_webhook_secret  = ""          # From Step 4b (required if enabled)
 
 # API Keys
 anthropic_api_key = "sk-ant-..."
@@ -692,6 +718,26 @@ Or construct it from your App's slug: if your app is named `My-Inspect-App`, the
   `@my-app[bot] explain why this test is failing`)
 
 For day-to-day workflows, see [GitHub Integration](./integrations/GITHUB.md).
+
+---
+
+## Step 7d: Install the Linear Agent (If Using Linear)
+
+After the Linear bot Worker is deployed, visit:
+
+```text
+https://open-inspect-linear-bot-{deployment_name}.YOUR-SUBDOMAIN.workers.dev/oauth/authorize
+```
+
+A Linear workspace admin must approve the installation. After installation, the agent appears in
+mention and assignment menus. Test it by mentioning the agent on an issue, then use **View Session**
+to follow the corresponding Open-Inspect session.
+
+For upgrades, enable **Client credentials tokens** before deploying. No reinstall is expected for an
+eligible existing installation, but allow already-running sessions to finish before upgrading
+because older callback contexts may not contain the installed app-user identity.
+
+For configuration and troubleshooting, see [Linear Integration](./integrations/LINEAR.md).
 
 ---
 
@@ -977,12 +1023,13 @@ Terraform references the built worker bundles. Build them before running `terraf
 npm run build -w @open-inspect/shared
 
 # Build workers (required before Terraform)
-npm run build -w @open-inspect/control-plane -w @open-inspect/slack-bot -w @open-inspect/github-bot
+npm run build -w @open-inspect/control-plane -w @open-inspect/slack-bot -w @open-inspect/github-bot -w @open-inspect/linear-bot
 
 # Verify bundles exist
 ls packages/control-plane/dist/index.js
 ls packages/slack-bot/dist/index.js
 ls packages/github-bot/dist/index.js  # Only if enable_github_bot = true
+ls packages/linear-bot/dist/index.js  # Only if enable_linear_bot = true
 ```
 
 ### Slack bot not responding

--- a/docs/integrations/LINEAR.md
+++ b/docs/integrations/LINEAR.md
@@ -206,7 +206,8 @@ web session has completed but Linear has not:
    has `has_callback_context:true`; `false` means completion had no Linear callback destination.
 4. Confirm control-plane `prompt.complete`, followed by linear-bot `callback.complete`. If the first
    exists without the second, inspect callback routing and context. If both exist, inspect
-   `linear.emit_activity_failed`, credential identity failures, and GraphQL errors.
+   `delivery_outcome`, `linear.emit_activity_failed`, credential identity failures, and GraphQL
+   errors. Only `delivery_outcome:success` confirms the terminal activity reached Linear.
 
 A completion that was skipped cannot repair itself later. After deploying a callback-context fix,
 send another follow-up through the same Linear Agent session to produce a new terminal activity, or

--- a/docs/integrations/LINEAR.md
+++ b/docs/integrations/LINEAR.md
@@ -154,6 +154,9 @@ Linear user preferences are currently admin/API-managed, not set from a self-ser
 - Linear client credentials, runtime access tokens, webhook secrets, and callback secrets stay
   server-side. Runtime access tokens are cached and replaced automatically; refresh tokens are not
   used for runtime API access.
+- Runtime tokens are cached under `oauth:client-credentials:{organizationId}` with their verified
+  workspace/app identity and expire with the provider lease. Do not edit cached token values
+  manually.
 - Linear does not provide Git credentials. Repository access still comes from the deployment's
   configured source-control integration, such as the GitHub App installation.
 - Repository scope in Linear settings controls which resolved repositories can receive
@@ -191,6 +194,29 @@ the Linear project or team.
 
 Open **View Session**. Linear shows status and completion activity, while detailed logs,
 transcripts, artifacts, and file changes live in the Open-Inspect web session.
+
+### Linear stays Working after the web session completes
+
+Linear leaves Working only after the bot delivers a terminal `response` or `error` activity. If the
+web session has completed but Linear has not:
+
+1. Find the Open-Inspect session ID from **View Session**.
+2. Confirm the Linear bot logged `agent_session.followup` for the follow-up webhook.
+3. In control-plane logs, find `prompt.enqueue` for the follow-up message. A healthy Linear prompt
+   has `has_callback_context:true`; `false` means completion had no Linear callback destination.
+4. Confirm control-plane `prompt.complete`, followed by linear-bot `callback.complete`. If the first
+   exists without the second, inspect callback routing and context. If both exist, inspect
+   `linear.emit_activity_failed`, credential identity failures, and GraphQL errors.
+
+A completion that was skipped cannot repair itself later. After deploying a callback-context fix,
+send another follow-up through the same Linear Agent session to produce a new terminal activity, or
+start a new Agent session if the issue mapping has expired.
+
+### Linear client secret was rotated
+
+Deploy the replacement `LINEAR_CLIENT_SECRET` promptly. Linear invalidates tokens minted with the
+old secret; the Worker replaces the cached token after a cache miss, expiry, or HTTP 401 and retries
+the rejected API request once. A reinstall is not normally required.
 
 ### The wrong model was used
 

--- a/packages/linear-bot/INTEGRATION.md
+++ b/packages/linear-bot/INTEGRATION.md
@@ -64,7 +64,7 @@ viewer organization must match the webhook organization.
 The `callbackContext` is stored on every queued message, including follow-ups. It includes the
 `agentSessionId`, `organizationId`, and installed `appUserId` so completion can verify the runtime
 credential and emit `AgentActivity` on the correct Linear session. It also carries issue, model,
-repository/settings, and tool-progress fields needed by callback delivery.
+optional repository/settings, and tool-progress fields needed by callback delivery.
 
 Callback context is message-scoped rather than inherited by the control plane. A producer that
 queues a follow-up must attach it again; otherwise the control plane has no safe callback

--- a/packages/linear-bot/INTEGRATION.md
+++ b/packages/linear-bot/INTEGRATION.md
@@ -43,7 +43,8 @@ own context (e.g. `agentSessionId` for Linear agent activities).
 - Verified runtime tokens are cached in KV at `oauth:client-credentials:{orgId}`
 - Missing, near-expiry, or explicitly rejected tokens are replaced automatically; no refresh token
   is maintained
-- No personal API key needed
+- No personal API key is needed for normal Agent API delivery. `LINEAR_API_KEY` remains an optional
+  legacy fallback for posting a completion comment when an old callback lacks Agent API context.
 
 For existing deployments, enable **Client credentials tokens** in **Linear Settings → API →
 Applications** before deploying this credential mode. Eligible single-workspace installations
@@ -55,13 +56,19 @@ viewer organization must match the webhook organization.
 1. User @mentions or assigns the agent → Linear sends `AgentSessionEvent`
 2. Agent emits `Thought` activities (visible as "thinking" in Linear)
 3. Agent creates Open-Inspect session and sends prompt
-4. Agent emits `Response` with session link
+4. Agent emits a `Thought` with the session link while work continues
 5. On completion callback, agent emits `Response` with PR link
 
 ### Callback Context
 
-The `callbackContext` includes `agentSessionId` and `organizationId` so the completion callback can
-emit `AgentActivity` on the correct session.
+The `callbackContext` is stored on every queued message, including follow-ups. It includes the
+`agentSessionId`, `organizationId`, and installed `appUserId` so completion can verify the runtime
+credential and emit `AgentActivity` on the correct Linear session. It also carries issue, model,
+repository/settings, and tool-progress fields needed by callback delivery.
+
+Callback context is message-scoped rather than inherited by the control plane. A producer that
+queues a follow-up must attach it again; otherwise the control plane has no safe callback
+destination and intentionally skips completion delivery.
 
 ## Terraform Variables
 
@@ -71,5 +78,5 @@ emit `AgentActivity` on the correct session.
 | `linear_client_secret`  | OAuth Application Client Secret |
 | `linear_webhook_secret` | Webhook Signing Secret          |
 
-The old `linear_api_key` variable is no longer required but kept for backward compatibility in the
-tfvars example.
+The old `linear_api_key` variable is optional and retained only for backward compatibility. It is
+not included in the tfvars example and is not used for normal Agent API delivery.

--- a/packages/linear-bot/README.md
+++ b/packages/linear-bot/README.md
@@ -88,7 +88,9 @@ this Linear-side setting.
 For a private, single-workspace deployment whose application credentials resolve to the installed
 workspace, deploy normally after enabling the setting. No uninstall/reinstall, new secret, webhook
 change, or scope reauthorization is expected. The first Linear request mints and verifies a runtime
-token, then removes the legacy refresh-token record.
+token, then removes the legacy refresh-token record. Allow already-running sessions to finish before
+upgrading; callback contexts created by older versions may not contain the installed app-user
+identity required for terminal Agent API delivery.
 
 If the setting is not enabled, Linear reports that the client does not support the
 `client_credentials` grant and the request fails without falling back to the legacy refresh token.

--- a/packages/linear-bot/src/callbacks.ts
+++ b/packages/linear-bot/src/callbacks.ts
@@ -307,10 +307,25 @@ async function handleCompletionCallback(
     if (context.agentSessionId && context.organizationId && context.appUserId) {
       const client = await getLinearClient(env, context.organizationId, context.appUserId);
       if (client) {
-        await emitAgentActivity(client, context.agentSessionId, {
+        const activityDelivered = await emitAgentActivity(client, context.agentSessionId, {
           type: activityType,
           body: message,
         });
+        if (!activityDelivered) {
+          log.error("callback.complete", {
+            trace_id: traceId,
+            session_id: sessionId,
+            issue_id: context.issueId,
+            issue_identifier: context.issueIdentifier,
+            agent_session_id: context.agentSessionId,
+            outcome: "error",
+            agent_success: payload.success,
+            delivery: "agent_activity",
+            delivery_outcome: "error",
+            duration_ms: Date.now() - startTime,
+          });
+          return;
+        }
 
         // Update plan to completed/failed
         await updateAgentSession(client, context.agentSessionId, {

--- a/packages/linear-bot/src/target-resolution.ts
+++ b/packages/linear-bot/src/target-resolution.ts
@@ -9,7 +9,13 @@
  * never stop working; environments join them.
  */
 
-import type { Env, Environment, AgentSessionWebhookIssue, StaticTargetConfig } from "./types";
+import type {
+  Env,
+  Environment,
+  AgentSessionWebhookIssue,
+  IssueSession,
+  StaticTargetConfig,
+} from "./types";
 import type { LinearApiClient } from "./utils/linear-client";
 import { emitAgentActivity, getRepoSuggestions } from "./utils/linear-client";
 import { splitRepoFullName } from "./utils/repo";
@@ -104,6 +110,26 @@ export function targetRequestFields(
 
 function repositoryTarget(owner: string, name: string, fullName?: string): SessionTarget {
   return { kind: "repository", owner, name, fullName: fullName ?? `${owner}/${name}` };
+}
+
+/** Rehydrate the stable target identity stored for an existing issue session. */
+export async function resolveStoredSessionTarget(
+  env: Env,
+  session: IssueSession,
+  traceId: string
+): Promise<SessionTarget | null> {
+  if (session.repoOwner && session.repoName) {
+    return repositoryTarget(session.repoOwner, session.repoName);
+  }
+  if (session.environmentId) {
+    const environment = await getEnvironmentById(env, session.environmentId, traceId);
+    if (environment) return { kind: "environment", environment };
+    log.warn("target.stored_environment_not_found", {
+      trace_id: traceId,
+      environment_id: session.environmentId,
+    });
+  }
+  return null;
 }
 
 /**

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -110,6 +110,9 @@ export interface IssueSession {
   environmentId?: string;
   model: string;
   agentSessionId?: string;
+  /** Repository used to resolve callback integration settings. */
+  callbackRepoFullName?: string;
+  emitToolProgressActivities?: boolean;
   createdAt: number;
 }
 

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -110,9 +110,6 @@ export interface IssueSession {
   environmentId?: string;
   model: string;
   agentSessionId?: string;
-  /** Repository used to resolve callback integration settings. */
-  callbackRepoFullName?: string;
-  emitToolProgressActivities?: boolean;
   createdAt: number;
 }
 

--- a/packages/linear-bot/src/utils/linear-client.test.ts
+++ b/packages/linear-bot/src/utils/linear-client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { fetchUser } from "./linear-client";
+import { emitAgentActivity, fetchUser } from "./linear-client";
 import type { LinearApiClient } from "./linear-client";
 
 const client: LinearApiClient = {
@@ -85,5 +85,24 @@ describe("fetchUser", () => {
 
     const result = await fetchUser(client, "user-1");
     expect(result).toBeNull();
+  });
+});
+
+describe("emitAgentActivity", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("reports a failed terminal activity delivery", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(null, { status: 500 })));
+
+    await expect(
+      emitAgentActivity(client, "agent-session-1", {
+        type: "response",
+        body: "Finished",
+      })
+    ).resolves.toBe(false);
   });
 });

--- a/packages/linear-bot/src/utils/linear-client.ts
+++ b/packages/linear-bot/src/utils/linear-client.ts
@@ -148,7 +148,7 @@ export async function emitAgentActivity(
   agentSessionId: string,
   content: Record<string, unknown>,
   ephemeral?: boolean
-): Promise<void> {
+): Promise<boolean> {
   try {
     await linearGraphQL(
       client,
@@ -163,11 +163,13 @@ export async function emitAgentActivity(
         input: { agentSessionId, content, ephemeral },
       }
     );
+    return true;
   } catch (err) {
     log.error("linear.emit_activity_failed", {
       agent_session_id: agentSessionId,
       error: err instanceof Error ? err : new Error(String(err)),
     });
+    return false;
   }
 }
 

--- a/packages/linear-bot/src/webhook-handler.test.ts
+++ b/packages/linear-bot/src/webhook-handler.test.ts
@@ -316,7 +316,12 @@ describe("handleAgentSessionEvent environment targets", () => {
       string,
       unknown
     > | null;
-    expect(issueSession).toMatchObject({ sessionId: "session-xyz", environmentId: "env_abc" });
+    expect(issueSession).toMatchObject({
+      sessionId: "session-xyz",
+      environmentId: "env_abc",
+      callbackRepoFullName: "acme/backend",
+      emitToolProgressActivities: true,
+    });
     expect(issueSession).not.toHaveProperty("repoOwner");
     expect(store.has("oauth:token:org-1")).toBe(false);
     expect(store.get("oauth:client-credentials:org-1")).toContain("transitioned-runtime-token");
@@ -404,6 +409,8 @@ describe("handleAgentSessionEvent environment targets", () => {
         sessionId: "session-xyz",
         issueId: "issue-1",
         issueIdentifier: "ENG-42",
+        repoOwner: "acme",
+        repoName: "backend",
         model: "anthropic/claude-haiku-4-5",
         createdAt: Date.now(),
       }),
@@ -431,6 +438,17 @@ describe("handleAgentSessionEvent environment targets", () => {
     );
     expect(JSON.parse(String(promptCall?.[1]?.body))).toMatchObject({
       authorId: "linear:follow-up-human-user",
+      callbackContext: {
+        source: "linear",
+        issueId: "issue-1",
+        issueIdentifier: "ENG-42",
+        issueUrl: "https://linear.app/acme/issue/ENG-42/wire",
+        repoFullName: "acme/backend",
+        model: "anthropic/claude-haiku-4-5",
+        agentSessionId: "agent-session-1",
+        organizationId: "org-1",
+        appUserId: "app-user-1",
+      },
     });
   });
 

--- a/packages/linear-bot/src/webhook-handler.test.ts
+++ b/packages/linear-bot/src/webhook-handler.test.ts
@@ -319,9 +319,9 @@ describe("handleAgentSessionEvent environment targets", () => {
     expect(issueSession).toMatchObject({
       sessionId: "session-xyz",
       environmentId: "env_abc",
-      callbackRepoFullName: "acme/backend",
-      emitToolProgressActivities: true,
     });
+    expect(issueSession).not.toHaveProperty("callbackRepoFullName");
+    expect(issueSession).not.toHaveProperty("emitToolProgressActivities");
     expect(issueSession).not.toHaveProperty("repoOwner");
     expect(store.has("oauth:token:org-1")).toBe(false);
     expect(store.get("oauth:client-credentials:org-1")).toContain("transitioned-runtime-token");
@@ -448,6 +448,63 @@ describe("handleAgentSessionEvent environment targets", () => {
         agentSessionId: "agent-session-1",
         organizationId: "org-1",
         appUserId: "app-user-1",
+      },
+    });
+  });
+
+  it("resolves current callback settings for an environment follow-up", async () => {
+    const { kv } = createFakeKV({
+      "oauth:client-credentials:org-1": validToken(),
+      "issue:issue-1": JSON.stringify({
+        sessionId: "session-xyz",
+        issueId: "issue-1",
+        issueIdentifier: "ENG-42",
+        environmentId: "env_abc",
+        model: "anthropic/claude-haiku-4-5",
+        createdAt: Date.now(),
+      }),
+    });
+    const env = makeLinearBotEnv(kv, { INTERNAL_CALLBACK_SECRET: "internal-secret" });
+    const controlPlaneFetch = (env.CONTROL_PLANE as unknown as { fetch: ReturnType<typeof vi.fn> })
+      .fetch;
+    controlPlaneFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "https://internal/environments") {
+        return Response.json({ environments: [environment], total: 1 });
+      }
+      if (url.endsWith("/integration-settings/linear/resolved/acme/backend")) {
+        return Response.json({
+          config: {
+            model: null,
+            reasoningEffort: null,
+            allowUserPreferenceOverride: true,
+            allowLabelModelOverride: true,
+            emitToolProgressActivities: false,
+            issueSessionInstructions: null,
+            enabledRepos: null,
+          },
+        });
+      }
+      if (url.endsWith("/events?limit=20")) return Response.json({ events: [] });
+      if (url.endsWith("/prompt")) return Response.json({ ok: true });
+      throw new Error(`Unexpected control-plane fetch to ${url}`);
+    });
+    const webhook = makeWebhook();
+    webhook.action = "prompted";
+    webhook.agentActivity = {
+      userId: "follow-up-human-user",
+      content: { type: "prompt", body: "Please continue." },
+    };
+
+    await handleAgentSessionEvent(webhook, env, "trace-environment-follow-up");
+
+    const promptCall = controlPlaneFetch.mock.calls.find(([input]) =>
+      String(input).endsWith("/prompt")
+    );
+    expect(JSON.parse(String(promptCall?.[1]?.body))).toMatchObject({
+      callbackContext: {
+        repoFullName: "acme/backend",
+        emitToolProgressActivities: false,
       },
     });
   });

--- a/packages/linear-bot/src/webhook-handler.ts
+++ b/packages/linear-bot/src/webhook-handler.ts
@@ -272,7 +272,7 @@ function buildLinearCallbackContext(params: {
   webhook: AgentSessionWebhook;
   issue: AgentSessionWebhookIssue;
   model: string;
-  repoFullName: string;
+  repoFullName?: string;
   emitToolProgressActivities?: boolean;
 }): LinearCallbackContext {
   const { webhook, issue, model, repoFullName, emitToolProgressActivities } = params;
@@ -290,11 +290,10 @@ function buildLinearCallbackContext(params: {
   };
 }
 
-function getCallbackRepoFullName(session: IssueSession): string {
+function getCallbackRepoFullName(session: IssueSession): string | undefined {
   if (session.callbackRepoFullName) return session.callbackRepoFullName;
   if (session.repoOwner && session.repoName) return `${session.repoOwner}/${session.repoName}`;
-  if (session.environmentId) return `environment:${session.environmentId}`;
-  return "legacy-session";
+  return undefined;
 }
 
 async function handleFollowUp(

--- a/packages/linear-bot/src/webhook-handler.ts
+++ b/packages/linear-bot/src/webhook-handler.ts
@@ -5,7 +5,6 @@
 
 import type {
   Env,
-  IssueSession,
   LinearCallbackContext,
   LinearIssueDetails,
   AgentSessionWebhook,
@@ -26,6 +25,7 @@ import { makePlan } from "./plan";
 import { extractModelFromLabels, resolveSessionModelSettings } from "./model-resolution";
 import {
   resolveSessionTarget,
+  resolveStoredSessionTarget,
   resolveTargetIntegration,
   targetId,
   targetLabel,
@@ -290,12 +290,6 @@ function buildLinearCallbackContext(params: {
   };
 }
 
-function getCallbackRepoFullName(session: IssueSession): string | undefined {
-  if (session.callbackRepoFullName) return session.callbackRepoFullName;
-  if (session.repoOwner && session.repoName) return `${session.repoOwner}/${session.repoName}`;
-  return undefined;
-}
-
 async function handleFollowUp(
   webhook: AgentSessionWebhook,
   issue: AgentSessionWebhookIssue,
@@ -320,12 +314,16 @@ async function handleFollowUp(
 
   const existingSession = await lookupIssueSession(env, issue.id);
   if (!existingSession) return;
+  const existingTarget = await resolveStoredSessionTarget(env, existingSession, traceId);
+  const currentIntegration = existingTarget
+    ? await resolveTargetIntegration(env, existingTarget)
+    : null;
   const callbackContext = buildLinearCallbackContext({
     webhook,
     issue,
     model: existingSession.model,
-    repoFullName: getCallbackRepoFullName(existingSession),
-    emitToolProgressActivities: existingSession.emitToolProgressActivities,
+    repoFullName: currentIntegration?.callbackRepoFullName,
+    emitToolProgressActivities: currentIntegration?.config.emitToolProgressActivities,
   });
 
   await emitAgentActivity(
@@ -565,8 +563,6 @@ async function handleNewSession(
     ...targetRequestFields(target),
     model,
     agentSessionId,
-    callbackRepoFullName: integration.callbackRepoFullName,
-    emitToolProgressActivities: integrationConfig.emitToolProgressActivities,
     createdAt: Date.now(),
   });
 

--- a/packages/linear-bot/src/webhook-handler.ts
+++ b/packages/linear-bot/src/webhook-handler.ts
@@ -5,7 +5,8 @@
 
 import type {
   Env,
-  CallbackContext,
+  IssueSession,
+  LinearCallbackContext,
   LinearIssueDetails,
   AgentSessionWebhook,
   AgentSessionWebhookIssue,
@@ -267,6 +268,35 @@ function getFollowUp(webhook: AgentSessionWebhook): {
   return { content: "Follow-up on the issue.", source: "linear_fallback" };
 }
 
+function buildLinearCallbackContext(params: {
+  webhook: AgentSessionWebhook;
+  issue: AgentSessionWebhookIssue;
+  model: string;
+  repoFullName: string;
+  emitToolProgressActivities?: boolean;
+}): LinearCallbackContext {
+  const { webhook, issue, model, repoFullName, emitToolProgressActivities } = params;
+  return {
+    source: "linear",
+    issueId: issue.id,
+    issueIdentifier: issue.identifier,
+    issueUrl: issue.url,
+    repoFullName,
+    model,
+    agentSessionId: webhook.agentSession.id,
+    organizationId: webhook.organizationId,
+    appUserId: webhook.appUserId,
+    emitToolProgressActivities,
+  };
+}
+
+function getCallbackRepoFullName(session: IssueSession): string {
+  if (session.callbackRepoFullName) return session.callbackRepoFullName;
+  if (session.repoOwner && session.repoName) return `${session.repoOwner}/${session.repoName}`;
+  if (session.environmentId) return `environment:${session.environmentId}`;
+  return "legacy-session";
+}
+
 async function handleFollowUp(
   webhook: AgentSessionWebhook,
   issue: AgentSessionWebhookIssue,
@@ -291,6 +321,13 @@ async function handleFollowUp(
 
   const existingSession = await lookupIssueSession(env, issue.id);
   if (!existingSession) return;
+  const callbackContext = buildLinearCallbackContext({
+    webhook,
+    issue,
+    model: existingSession.model,
+    repoFullName: getCallbackRepoFullName(existingSession),
+    emitToolProgressActivities: existingSession.emitToolProgressActivities,
+  });
 
   await emitAgentActivity(
     client,
@@ -340,6 +377,7 @@ async function handleFollowUp(
         }),
         authorId: followUp.actorUserId ? `linear:${followUp.actorUserId}` : undefined,
         source: "linear",
+        callbackContext,
       }),
     }
   );
@@ -513,6 +551,13 @@ async function handleNewSession(
 
   const headers = await getAuthHeaders(env, traceId);
   const session = sessionResult;
+  const callbackContext = buildLinearCallbackContext({
+    webhook,
+    issue,
+    model,
+    repoFullName: integration.callbackRepoFullName,
+    emitToolProgressActivities: integrationConfig.emitToolProgressActivities,
+  });
 
   await storeIssueSession(env, issue.id, {
     sessionId: session.sessionId,
@@ -521,6 +566,8 @@ async function handleNewSession(
     ...targetRequestFields(target),
     model,
     agentSessionId,
+    callbackRepoFullName: integration.callbackRepoFullName,
+    emitToolProgressActivities: integrationConfig.emitToolProgressActivities,
     createdAt: Date.now(),
   });
 
@@ -542,19 +589,6 @@ async function handleNewSession(
   if (integrationConfig.issueSessionInstructions) {
     prompt += `\n\n## Additional Instructions\n\n${integrationConfig.issueSessionInstructions}`;
   }
-
-  const callbackContext: CallbackContext = {
-    source: "linear",
-    issueId: issue.id,
-    issueIdentifier: issue.identifier,
-    issueUrl: issue.url,
-    repoFullName: integration.callbackRepoFullName,
-    model,
-    agentSessionId,
-    organizationId: orgId,
-    appUserId: webhook.appUserId,
-    emitToolProgressActivities: integrationConfig.emitToolProgressActivities,
-  };
 
   const promptRes = await env.CONTROL_PLANE.fetch(
     `https://internal/sessions/${session.sessionId}/prompt`,

--- a/packages/shared/src/types/session-api.ts
+++ b/packages/shared/src/types/session-api.ts
@@ -40,7 +40,8 @@ export interface LinearCallbackContext {
   issueId: string;
   issueIdentifier: string;
   issueUrl: string;
-  repoFullName: string;
+  /** Settings repository when one can be resolved for this Linear message. */
+  repoFullName?: string;
   model: string;
   agentSessionId?: string;
   organizationId?: string;


### PR DESCRIPTION
## Summary

- attach a complete, current Linear callback context to every follow-up prompt
- persist callback target/settings fields in the issue-session mapping for repository and environment sessions
- retain compatibility with mappings created before these fields existed
- add Linear setup, upgrade, callback-lifecycle, token-operation, and stuck-Working troubleshooting guidance

## Root cause

The control plane stores callback metadata per message. The Linear bot attached `callbackContext` to the initial prompt but omitted it from follow-ups. The follow-up executed successfully, but completion notification was intentionally skipped because that message had no callback destination. Linear had last received a non-terminal thought activity and therefore remained Working indefinitely.

Production logs confirmed the affected message was enqueued with `has_callback_context:false`, completed successfully, and never produced a Linear `callback.complete`.

## Validation

- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/linear-bot` — 161 tests passed
- `npm run lint -w @open-inspect/linear-bot`
- `npm run typecheck -w @open-inspect/linear-bot`
- `npm run build -w @open-inspect/linear-bot`
- `npm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Linear Agent follow-up handling with richer session and callback context.
  * Added more reliable delivery status reporting for Linear responses.
  * Added support for resolving repositories and environments for existing sessions.

* **Bug Fixes**
  * Prevented completion updates when Linear activity delivery fails.
  * Improved handling of expired, rotated, or missing Linear credentials.

* **Documentation**
  * Expanded setup, upgrade, troubleshooting, OAuth, credential, and callback guidance for Linear integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->