### PR TITLE
chore: sweep dead code and stale comments from PR lifecycle train

### DIFF
--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -225,7 +225,7 @@ export class SessionIndexStore {
   }
 
   /**
-   * Whether the session exists and the repository is one of its members
+   * Whether the session exists and the repository is in its repository set
    * (the scalar primary mirror or a session_repositories row). This is the
    * webhook branch-fallback gate (design §5.2): a branch-derived insert may
    * only attach to a session already associated with the event's repository.
@@ -329,7 +329,7 @@ export class SessionIndexStore {
   }
 
   /**
-   * Attach member repository lists and PR status summaries to the paged
+   * Attach repository lists and PR status summaries to the paged
    * entries. The two lookups are independent — each is one grouped query
    * keyed by the same session ids — so they run in parallel and merge onto
    * the entries in a single pass. Sessions without rows are returned without
@@ -356,7 +356,7 @@ export class SessionIndexStore {
     });
   }
 
-  /** Member repository lists for the given sessions, in one query. */
+  /** Repository lists for the given sessions, in one query. */
   private async repositoriesForSessions(
     sessionIds: readonly string[]
   ): Promise<Map<string, SessionIndexRepository[]>> {

--- a/packages/control-plane/src/db/session-pull-request-store.ts
+++ b/packages/control-plane/src/db/session-pull-request-store.ts
@@ -197,17 +197,6 @@ export class SessionPullRequestStore {
     return legacyRow ? toRecord(legacyRow) : null;
   }
 
-  async getBySession(sessionId: string): Promise<SessionPullRequestRecord[]> {
-    const result = await this.db
-      .prepare(
-        "SELECT * FROM session_pull_requests WHERE session_id = ? ORDER BY created_at, pr_number"
-      )
-      .bind(sessionId)
-      .all<SessionPullRequestRow>();
-
-    return (result.results || []).map(toRecord);
-  }
-
   /**
    * One grouped query producing per-session PR counts by display status for
    * the session list (mirrors the withRepositories join pattern). Sessions
@@ -245,17 +234,5 @@ export class SessionPullRequestStore {
       });
     }
     return summaries;
-  }
-
-  /**
-   * Explicit per-session cleanup. The FK cascade on sessions covers the
-   * normal delete path; this exists for callers that clear PR records
-   * without deleting the session.
-   */
-  async deleteBySession(sessionId: string): Promise<void> {
-    await this.db
-      .prepare("DELETE FROM session_pull_requests WHERE session_id = ?")
-      .bind(sessionId)
-      .run();
   }
 }

--- a/packages/control-plane/src/routes/session-pull-requests.ts
+++ b/packages/control-plane/src/routes/session-pull-requests.ts
@@ -6,9 +6,8 @@ import { sessionRoute, type SessionRouteContext } from "./session-route";
 /**
  * Manual PR sync (design §5.3): forwards to the session DO's internal
  * refresh route, which kicks a background read-through and answers 202
- * immediately. Per-PR rate limiting lives in the DO's refresh service.
- * Deliberately no session-index touch — PR changes must never reorder the
- * session list.
+ * immediately. Deliberately no session-index touch — PR changes must never
+ * reorder the session list.
  */
 async function handleRefreshPullRequests(
   _request: Request,

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -527,10 +527,6 @@ export class SessionDO extends DurableObject<Env> {
         },
         getArtifactById: (artifactId) => this.repository.getArtifactById(artifactId),
         updateArtifact: (artifactId, data) => this.repository.updateArtifact(artifactId, data),
-        // Backend-only until the stack completes: the snapshot route's callers
-        // (webhook + read-through) and the web artifact_updated consumer land
-        // in the next two slices. Interim clients ignore unknown message types
-        // and converge on reconnect (rolling-compat contract).
         broadcastArtifactUpdated: (artifact) => {
           this.broadcast({
             type: "artifact_updated",

--- a/packages/control-plane/src/session/pr-artifacts.ts
+++ b/packages/control-plane/src/session/pr-artifacts.ts
@@ -7,9 +7,9 @@ import type { ArtifactRow } from "./types";
  * no identity — artifacts written before multi-repo support, which by
  * construction belong to the session's primary repository. The canonical
  * home of that convention: both the duplicate-PR guard and the per-repo
- * prUrl projection go through here.
+ * artifact find go through here.
  */
-export function parsePrArtifactRepo(metadata: string | null): RepoIdentity | null {
+function parsePrArtifactRepo(metadata: string | null): RepoIdentity | null {
   if (!metadata) return null;
   try {
     const parsed: unknown = JSON.parse(metadata);

--- a/packages/control-plane/src/session/pull-request-snapshot.ts
+++ b/packages/control-plane/src/session/pull-request-snapshot.ts
@@ -1,6 +1,6 @@
 /**
  * The canonical PR lifecycle snapshot mapping (design §5). Every writer —
- * creation, and the webhook/read-through paths in later slices — maps a
+ * creation, the webhook path, and read-through refresh — maps a
  * provider snapshot through this module, so the field mapping between the
  * snapshot, the D1 authority record, the DO artifact metadata, and the
  * artifact_updated broadcast has exactly one home and cannot drift per-writer.

--- a/packages/control-plane/src/session/repository.test.ts
+++ b/packages/control-plane/src/session/repository.test.ts
@@ -978,18 +978,7 @@ describe("SessionRepository", () => {
   });
 
   describe("updateArtifact", () => {
-    it("updates metadata and updated_at without touching url when url is omitted", () => {
-      repo.updateArtifact("art-1", { metadata: '{"number":2}', updatedAt: 2000 });
-
-      expect(mock.calls.length).toBe(1);
-      expect(mock.calls[0].query).toContain(
-        "UPDATE artifacts SET metadata = ?, updated_at = ? WHERE id = ?"
-      );
-      expect(mock.calls[0].query).not.toContain("url");
-      expect(mock.calls[0].params).toEqual(['{"number":2}', 2000, "art-1"]);
-    });
-
-    it("updates url together with metadata when provided", () => {
+    it("updates url, metadata, and updated_at in place", () => {
       repo.updateArtifact("art-1", {
         url: "https://github.com/owner/renamed/pull/1",
         metadata: '{"number":1}',

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -231,10 +231,9 @@ export interface CreateArtifactData {
 
 /**
  * Data for updating an artifact's content in place (PR lifecycle updates).
- * `url` is omitted to leave the stored URL unchanged.
  */
 export interface UpdateArtifactData {
-  url?: string;
+  url: string;
   metadata: string | null;
   updatedAt: number;
 }
@@ -982,18 +981,9 @@ export class SessionRepository {
   }
 
   updateArtifact(artifactId: string, data: UpdateArtifactData): void {
-    if (data.url !== undefined) {
-      this.sql.exec(
-        `UPDATE artifacts SET url = ?, metadata = ?, updated_at = ? WHERE id = ?`,
-        data.url,
-        data.metadata,
-        data.updatedAt,
-        artifactId
-      );
-      return;
-    }
     this.sql.exec(
-      `UPDATE artifacts SET metadata = ?, updated_at = ? WHERE id = ?`,
+      `UPDATE artifacts SET url = ?, metadata = ?, updated_at = ? WHERE id = ?`,
+      data.url,
       data.metadata,
       data.updatedAt,
       artifactId

--- a/packages/control-plane/src/source-control/index.ts
+++ b/packages/control-plane/src/source-control/index.ts
@@ -18,7 +18,6 @@ export type {
   GetRepositoryConfig,
   CreatePullRequestConfig,
   CreatePullRequestResult,
-  GetPullRequestConfig,
   PullRequestSnapshot,
   RepositoryAccessResult,
 } from "./types";

--- a/packages/control-plane/test/integration/d1-session-index.test.ts
+++ b/packages/control-plane/test/integration/d1-session-index.test.ts
@@ -35,7 +35,7 @@ describe("D1 SessionIndexStore", () => {
   });
 
   describe("isRepositoryAssociated", () => {
-    it("matches the scalar primary and member rows case-insensitively", async () => {
+    it("matches the scalar primary and session_repositories rows case-insensitively", async () => {
       const store = new SessionIndexStore(env.DB);
       const now = Date.now();
 
@@ -64,7 +64,7 @@ describe("D1 SessionIndexStore", () => {
       expect(await store.isRepositoryAssociated("missing-session", "acme", "web-app")).toBe(false);
     });
 
-    it("matches the scalar primary for pre-multi-repo sessions without member rows", async () => {
+    it("matches the scalar primary for pre-multi-repo sessions without session_repositories rows", async () => {
       const store = new SessionIndexStore(env.DB);
       const now = Date.now();
 

--- a/packages/control-plane/test/integration/session-pull-requests.test.ts
+++ b/packages/control-plane/test/integration/session-pull-requests.test.ts
@@ -30,6 +30,15 @@ async function seedSession(id: string): Promise<void> {
   });
 }
 
+async function countRecordsForSession(sessionId: string): Promise<number> {
+  const row = await env.DB.prepare(
+    "SELECT COUNT(*) AS n FROM session_pull_requests WHERE session_id = ?"
+  )
+    .bind(sessionId)
+    .first<{ n: number }>();
+  return row?.n ?? 0;
+}
+
 function makeRecord(overrides?: Partial<SessionPullRequestRecord>): SessionPullRequestRecord {
   const now = Date.now();
   return {
@@ -104,9 +113,8 @@ describe("SessionPullRequestStore", () => {
       const second = await store.upsert(record);
 
       expect(second.applied).toBe(true);
-      const rows = await store.getBySession("session-1");
-      expect(rows).toHaveLength(1);
-      expect(rows[0]).toEqual(record);
+      expect(await store.getByArtifactId("artifact-1")).toEqual(record);
+      expect(await countRecordsForSession("session-1")).toBe(1);
     });
 
     it("applies a newer provider state", async () => {
@@ -218,8 +226,7 @@ describe("SessionPullRequestStore", () => {
 
       const row = await store.getByArtifactId("artifact-1");
       expect(row?.repositoryExternalId).toBe("9001");
-      const rows = await store.getBySession("session-1");
-      expect(rows).toHaveLength(1);
+      expect(await countRecordsForSession("session-1")).toBe(1);
     });
 
     it("rejects a second record for the same PR identity under a different artifact id", async () => {
@@ -302,25 +309,6 @@ describe("SessionPullRequestStore", () => {
       await env.DB.prepare("DELETE FROM sessions WHERE id = ?").bind("session-1").run();
 
       expect(await store.getByArtifactId("artifact-1")).toBeNull();
-    });
-
-    it("deleteBySession removes only that session's records", async () => {
-      await seedSession("session-2");
-      const store = new SessionPullRequestStore(env.DB);
-      await store.upsert(makeRecord());
-      await store.upsert(
-        makeRecord({
-          artifactId: "b1",
-          sessionId: "session-2",
-          prNumber: 8,
-          repositoryExternalId: "9001",
-        })
-      );
-
-      await store.deleteBySession("session-1");
-
-      expect(await store.getByArtifactId("artifact-1")).toBeNull();
-      expect(await store.getByArtifactId("b1")).not.toBeNull();
     });
   });
 });

--- a/packages/shared/src/triggers/github/normalizer.test.ts
+++ b/packages/shared/src/triggers/github/normalizer.test.ts
@@ -466,8 +466,8 @@ describe("normalizeGitHubEvent", () => {
 // ─── Typed pull-request facts (PR lifecycle tracking) ─────────────────────────
 
 describe("typed pullRequest facts on pull_request events", () => {
-  const sameRepo = { id: 9001, full_name: "acme-org/my-app" };
-  const forkRepo = { id: 4242, full_name: "quueli/my-app" };
+  const sameRepo = { id: 9001 };
+  const forkRepo = { id: 4242 };
 
   const trackedPR = {
     ...basePR,

--- a/packages/shared/src/triggers/github/webhook-types.ts
+++ b/packages/shared/src/triggers/github/webhook-types.ts
@@ -106,7 +106,6 @@ const baseEventSchema = z.object({
 // the fork was deleted.
 const prRepoRefSchema = z.object({
   id: z.number().optional(),
-  full_name: z.string().optional(),
 });
 
 const pullRequestObjectSchema = z.object({

--- a/packages/web/src/components/ui/badge.tsx
+++ b/packages/web/src/components/ui/badge.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 /**
  * Text-color token per PR badge display state.
  */
-export const PR_STATE_TEXT_CLASS = {
+const PR_STATE_TEXT_CLASS = {
   open: "text-accent",
   draft: "text-muted-foreground",
   merged: "text-success",

--- a/packages/web/src/lib/pr-summary.ts
+++ b/packages/web/src/lib/pr-summary.ts
@@ -11,9 +11,9 @@ export interface PullRequestSummaryDisplay {
    */
   state: PullRequestDisplayStatus;
   /**
-   * Fixed-height indicator text (design §7): a single PR renders its display
-   * status ("PR merged"); several render the count plus the most informative
-   * bucket — open (incl. drafts) wins, then merged, then closed.
+   * The state icon's tooltip / accessible name: a single PR renders its
+   * display status ("PR merged"); several render the count plus the most
+   * informative bucket — open (incl. drafts) wins, then merged, then closed.
    */
   label: string;
 }


### PR DESCRIPTION
## Summary

Post-ship sweep (PR-R2 of the post-ship review remediation plan) removing residue left by the PR-lifecycle-tracking train's mid-flight refactors (#960–#964, #966, #967). No behavior changes — every deletion had zero production consumers, verified by repo-wide grep.

### Stale comments corrected

- `routes/session-pull-requests.ts` — dropped the claim that "per-PR rate limiting lives in the DO's refresh service" (both the limiter and the service were deleted before merge)
- `session/durable-object.ts` — removed the "consumers land in the next two slices" interim note (all slices shipped)
- `session/pull-request-snapshot.ts` — "webhook/read-through paths in later slices" → the paths as they exist today
- `session/pr-artifacts.ts` — "prUrl projection" wording survived the projection→snapshot rename
- `web/lib/pr-summary.ts` — the label docstring described the rendered label row that #967 removed; it now documents the tooltip/aria-label role

### Dead code removed

- `SessionPullRequestStore.getBySession` / `.deleteBySession` — no production caller (test observations reworked onto `getByArtifactId` + a raw count helper)
- `UpdateArtifactData.url` made required and the unreachable omit-url `UPDATE` branch deleted — both callers always set it via `preparePullRequestArtifactUpdate`
- `full_name` dropped from `prRepoRefSchema` — parsed but never read (`isCrossRepositoryHead` uses only `id`)
- Un-exported `PR_STATE_TEXT_CLASS` (its cross-file consumer was removed by #967; still used internally by the badge variants) and `parsePrArtifactRepo` (file-internal)
- Dropped the unused `GetPullRequestConfig` barrel re-export (providers import it from `../types`)

### Wording

- Replaced "member" with repository-set wording in the doc comments and integration-test names this train added (`session-index.ts`, `d1-session-index.test.ts`)

## Test plan

- [x] `npm run build -w @open-inspect/shared` + full `npm run typecheck`
- [x] `npm run lint`
- [x] shared 397 / control-plane unit 1766 / control-plane integration 539 / web 694 — all passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Artifact updates now consistently save the latest URL, metadata, and timestamp together.
  * Pull request and repository data handling has been streamlined for more consistent session information.
  * GitHub pull request repository references now use a simpler, more reliable identity format.

* **Documentation**
  * Clarified terminology and guidance around repository associations, session results, and pull request lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->