### PR TITLE
fix: defer HMAC failure telemetry for sandbox auth

### DIFF
--- a/packages/control-plane/src/router.auth.test.ts
+++ b/packages/control-plane/src/router.auth.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleRequest } from "./router";
+
+const secret = "test-internal-secret";
+
+function createEnv(verifyStatus: number) {
+  const fetch = vi
+    .fn()
+    .mockResolvedValueOnce(new Response(null, { status: verifyStatus }))
+    .mockResolvedValueOnce(Response.json({ ok: true }, { status: 202 }));
+  const statement = {
+    bind: vi.fn(() => statement),
+    first: vi.fn(async () => null),
+    all: vi.fn(async () => ({ results: [] })),
+    run: vi.fn(async () => ({ meta: { changes: 0 } })),
+  };
+
+  return {
+    INTERNAL_CALLBACK_SECRET: secret,
+    SCM_PROVIDER: "gitlab",
+    GITLAB_ACCESS_TOKEN: "glpat-test",
+    DB: {
+      prepare: vi.fn(() => statement),
+      batch: vi.fn(),
+      exec: vi.fn(),
+      dump: vi.fn(),
+    },
+    SESSION: {
+      idFromName: (name: string) => name,
+      get: () => ({ fetch }),
+    },
+  };
+}
+
+function hasHmacFailure(warn: { mock: { calls: unknown[][] } }): boolean {
+  return warn.mock.calls.some(([message]: unknown[]) => {
+    const entry = JSON.parse(String(message)) as { event?: string };
+    return entry.event === "auth.hmac_failed";
+  });
+}
+
+describe("router authentication telemetry", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not log an HMAC failure for a valid sandbox token", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const response = await handleRequest(
+      new Request("https://test.local/sessions/session-1/scm-credentials", {
+        method: "POST",
+        headers: { Authorization: "Bearer valid-sandbox-token" },
+      }),
+      createEnv(204) as never
+    );
+
+    expect(response.status).toBe(202);
+    expect(hasHmacFailure(warn)).toBe(false);
+  });
+
+  it("logs an HMAC failure when all accepted authentication schemes fail", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const response = await handleRequest(
+      new Request("https://test.local/sessions/session-1/scm-credentials", {
+        method: "POST",
+        headers: { Authorization: "Bearer invalid-token" },
+      }),
+      createEnv(401) as never
+    );
+
+    expect(response.status).toBe(401);
+    expect(hasHmacFailure(warn)).toBe(true);
+  });
+});

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -251,16 +251,13 @@ async function verifySandboxAuth(
  *
  * @param request - The incoming request
  * @param env - Environment bindings
- * @param path - Request path for logging
  * @param ctx - Request correlation context
  * @returns null if authentication passes, or an error Response to return immediately
  */
 async function requireInternalAuth(
   request: Request,
   env: Env,
-  path: string,
-  ctx: RequestContext,
-  logFailure = true
+  ctx: RequestContext
 ): Promise<Response | null> {
   if (!env.INTERNAL_CALLBACK_SECRET) {
     logger.error("INTERNAL_CALLBACK_SECRET not configured - rejecting request", {
@@ -277,16 +274,6 @@ async function requireInternalAuth(
   );
 
   if (!isValid) {
-    const clientIP = request.headers.get("CF-Connecting-IP") || "unknown";
-    if (logFailure) {
-      logger.warn("Auth failed: HMAC", {
-        event: "auth.hmac_failed",
-        http_path: path,
-        client_ip: clientIP,
-        request_id: ctx.request_id,
-        trace_id: ctx.trace_id,
-      });
-    }
     return error("Unauthorized", 401);
   }
 
@@ -391,7 +378,8 @@ export async function handleRequest(
   if (!isPublicRoute(path)) {
     const acceptsSandboxAuth = isSandboxAuthRoute(path);
     // First try HMAC auth (for web app, slack bot, etc.)
-    const hmacAuthError = await requireInternalAuth(request, env, path, ctx, !acceptsSandboxAuth);
+    const hmacAuthError = await requireInternalAuth(request, env, ctx);
+    let authError = hmacAuthError;
 
     if (hmacAuthError) {
       // HMAC auth failed - check if this route accepts sandbox auth
@@ -402,24 +390,26 @@ export async function handleRequest(
           const sessionId = sessionIdMatch[1];
           const sandboxAuthError = await verifySandboxAuth(request, env, sessionId, ctx);
           if (!sandboxAuthError) {
-            // Sandbox auth passed, continue to route handler
+            authError = null;
           } else {
-            // Both HMAC and sandbox auth failed
-            const clientIP = request.headers.get("CF-Connecting-IP") || "unknown";
-            logger.warn("Auth failed: HMAC", {
-              event: "auth.hmac_failed",
-              http_path: path,
-              client_ip: clientIP,
-              request_id: ctx.request_id,
-              trace_id: ctx.trace_id,
-            });
-            return withCorsAndTraceHeaders(sandboxAuthError, ctx);
+            authError = sandboxAuthError;
           }
         }
-      } else {
-        // Not a sandbox auth route, return HMAC auth error
-        return withCorsAndTraceHeaders(hmacAuthError, ctx);
       }
+    }
+
+    if (authError) {
+      if (hmacAuthError?.status === 401) {
+        const clientIP = request.headers.get("CF-Connecting-IP") || "unknown";
+        logger.warn("Auth failed: HMAC", {
+          event: "auth.hmac_failed",
+          http_path: path,
+          client_ip: clientIP,
+          request_id: ctx.request_id,
+          trace_id: ctx.trace_id,
+        });
+      }
+      return withCorsAndTraceHeaders(authError, ctx);
     }
   }
 

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -259,7 +259,8 @@ async function requireInternalAuth(
   request: Request,
   env: Env,
   path: string,
-  ctx: RequestContext
+  ctx: RequestContext,
+  logFailure = true
 ): Promise<Response | null> {
   if (!env.INTERNAL_CALLBACK_SECRET) {
     logger.error("INTERNAL_CALLBACK_SECRET not configured - rejecting request", {
@@ -277,13 +278,15 @@ async function requireInternalAuth(
 
   if (!isValid) {
     const clientIP = request.headers.get("CF-Connecting-IP") || "unknown";
-    logger.warn("Auth failed: HMAC", {
-      event: "auth.hmac_failed",
-      http_path: path,
-      client_ip: clientIP,
-      request_id: ctx.request_id,
-      trace_id: ctx.trace_id,
-    });
+    if (logFailure) {
+      logger.warn("Auth failed: HMAC", {
+        event: "auth.hmac_failed",
+        http_path: path,
+        client_ip: clientIP,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+    }
     return error("Unauthorized", 401);
   }
 
@@ -386,12 +389,13 @@ export async function handleRequest(
 
   // Require authentication for non-public routes
   if (!isPublicRoute(path)) {
+    const acceptsSandboxAuth = isSandboxAuthRoute(path);
     // First try HMAC auth (for web app, slack bot, etc.)
-    const hmacAuthError = await requireInternalAuth(request, env, path, ctx);
+    const hmacAuthError = await requireInternalAuth(request, env, path, ctx, !acceptsSandboxAuth);
 
     if (hmacAuthError) {
       // HMAC auth failed - check if this route accepts sandbox auth
-      if (isSandboxAuthRoute(path)) {
+      if (acceptsSandboxAuth) {
         // Extract session ID from path (e.g., /sessions/abc123/pr -> abc123)
         const sessionIdMatch = path.match(/^\/sessions\/([^/]+)\//);
         if (sessionIdMatch) {
@@ -401,6 +405,14 @@ export async function handleRequest(
             // Sandbox auth passed, continue to route handler
           } else {
             // Both HMAC and sandbox auth failed
+            const clientIP = request.headers.get("CF-Connecting-IP") || "unknown";
+            logger.warn("Auth failed: HMAC", {
+              event: "auth.hmac_failed",
+              http_path: path,
+              client_ip: clientIP,
+              request_id: ctx.request_id,
+              trace_id: ctx.trace_id,
+            });
             return withCorsAndTraceHeaders(sandboxAuthError, ctx);
           }
         }


### PR DESCRIPTION
## Summary
- suppress premature `auth.hmac_failed` warnings while sandbox authentication is still eligible
- retain HMAC failure telemetry when both HMAC and sandbox authentication fail
- add regression coverage for successful and failed sandbox bearer tokens

## Verification
- `npm test -w @open-inspect/control-plane` (1770 tests passed)
- `npm run typecheck -w @open-inspect/control-plane`
- `npx eslint packages/control-plane/src/router.ts packages/control-plane/src/router.auth.test.ts`

Linear: COL-15

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/616db117932f1e5fecdcda8822fd4a1e)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication failure reporting for routes that support sandbox authentication.
  * Prevented misleading HMAC-failure warnings when sandbox authentication can still succeed.
  * Added more accurate warnings when both HMAC and sandbox authentication fail.
* **Tests**
  * Added a test suite to verify authentication telemetry and warning behavior for successful and failed token validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->