### PR TITLE
test: cover HMAC telemetry on non-sandbox routes

### DIFF
--- a/packages/control-plane/src/router.auth.test.ts
+++ b/packages/control-plane/src/router.auth.test.ts
@@ -73,4 +73,18 @@ describe("router authentication telemetry", () => {
     expect(response.status).toBe(401);
     expect(hasHmacFailure(warn)).toBe(true);
   });
+
+  it("logs an HMAC failure for a non-sandbox route", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const response = await handleRequest(
+      new Request("https://test.local/analytics/summary", {
+        headers: { Authorization: "Bearer invalid-token" },
+      }),
+      createEnv(401) as never
+    );
+
+    expect(response.status).toBe(401);
+    expect(hasHmacFailure(warn)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- add regression coverage for invalid HMAC authentication on a non-sandbox analytics route
- verify the centralized authentication path returns 401 and emits `auth.hmac_failed`

## Testing
- `npm test -w @open-inspect/control-plane -- src/router.auth.test.ts`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/fe964bd6a0f00e4f1c1da656e7ebeca6)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that failed authentication on non-sandbox routes returns a 401 response and records an HMAC failure warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->