### PR TITLE
fix: resolve model preferences without repair effects

### DIFF
--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -12,12 +12,8 @@ import { formatModelNameLower } from "@/lib/format";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import { isUnarchivedSessionListKey } from "@/lib/session-list";
 import { APP_NAME } from "@/lib/site-config";
-import {
-  DEFAULT_MODEL,
-  getDefaultReasoningEffort,
-  isValidReasoningEffort,
-  type ModelCategory,
-} from "@open-inspect/shared";
+import { DEFAULT_MODEL, getDefaultReasoningEffort, type ModelCategory } from "@open-inspect/shared";
+import { resolveModelPreference, type ModelPreference } from "@/lib/model-selection";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
 import {
   useSessionTargetPicker,
@@ -36,10 +32,11 @@ export default function Home() {
   const router = useRouter();
   const picker = useSessionTargetPicker();
   const { sessionTarget, selectedBranch, configKey, buildRequestFields, isLaunchable } = picker;
-  const [selectedModel, setSelectedModel] = useState<string>(DEFAULT_MODEL);
-  const [reasoningEffort, setReasoningEffort] = useState<string | undefined>(
-    getDefaultReasoningEffort(DEFAULT_MODEL)
-  );
+  const [storedPreference, setStoredPreference] = useState<ModelPreference>({
+    model: DEFAULT_MODEL,
+    reasoningEffort: getDefaultReasoningEffort(DEFAULT_MODEL),
+  });
+  const [modelPreferenceDraft, setModelPreferenceDraft] = useState<ModelPreference | null>(null);
   const [prompt, setPrompt] = useState("");
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState("");
@@ -49,42 +46,31 @@ export default function Home() {
   const abortControllerRef = useRef<AbortController | null>(null);
   // Keyed by the picker's configKey so environment/ad-hoc selections
   // invalidate a warmed session exactly like repo/branch changes do.
-  const pendingConfigRef = useRef<{ target: string; model: string; branch: string } | null>(null);
+  const pendingConfigRef = useRef<{
+    target: string;
+    model: string;
+    reasoningEffort?: string;
+    branch: string;
+  } | null>(null);
   const [hasHydratedModelPreferences, setHasHydratedModelPreferences] = useState(false);
   const { enabledModels, enabledModelOptions } = useEnabledModels();
 
   useEffect(() => {
-    if (enabledModels.length === 0 || hasHydratedModelPreferences) return;
+    if (hasHydratedModelPreferences) return;
 
     const storedModel = localStorage.getItem(LAST_SELECTED_MODEL_STORAGE_KEY);
-    const selectedModelFromStorage =
-      storedModel && enabledModels.includes(storedModel)
-        ? storedModel
-        : (enabledModels[0] ?? DEFAULT_MODEL);
-
     const storedReasoningEffort = localStorage.getItem(LAST_SELECTED_REASONING_EFFORT_STORAGE_KEY);
-    const reasoningEffortFromStorage =
-      storedReasoningEffort &&
-      isValidReasoningEffort(selectedModelFromStorage, storedReasoningEffort)
-        ? storedReasoningEffort
-        : getDefaultReasoningEffort(selectedModelFromStorage);
-
-    setSelectedModel(selectedModelFromStorage);
-    setReasoningEffort(reasoningEffortFromStorage);
+    setStoredPreference({
+      model: storedModel ?? DEFAULT_MODEL,
+      reasoningEffort: storedReasoningEffort ?? undefined,
+    });
     setHasHydratedModelPreferences(true);
-  }, [enabledModels, hasHydratedModelPreferences]);
+  }, [hasHydratedModelPreferences]);
 
-  useEffect(() => {
-    if (!hasHydratedModelPreferences) return;
-    localStorage.setItem(LAST_SELECTED_MODEL_STORAGE_KEY, selectedModel);
-
-    if (reasoningEffort) {
-      localStorage.setItem(LAST_SELECTED_REASONING_EFFORT_STORAGE_KEY, reasoningEffort);
-      return;
-    }
-
-    localStorage.removeItem(LAST_SELECTED_REASONING_EFFORT_STORAGE_KEY);
-  }, [hasHydratedModelPreferences, selectedModel, reasoningEffort]);
+  const { model: selectedModel, reasoningEffort } = resolveModelPreference(
+    modelPreferenceDraft ?? storedPreference,
+    enabledModels
+  );
 
   useEffect(() => {
     if (abortControllerRef.current) {
@@ -95,7 +81,7 @@ export default function Home() {
     setIsCreatingSession(false);
     sessionCreationPromise.current = null;
     pendingConfigRef.current = null;
-  }, [sessionTarget, selectedModel, selectedBranch]);
+  }, [sessionTarget, selectedModel, reasoningEffort, selectedBranch]);
 
   const createSessionForWarming = useCallback(async () => {
     if (pendingSessionId) return pendingSessionId;
@@ -107,6 +93,7 @@ export default function Home() {
     const currentConfig = {
       target: configKey,
       model: selectedModel,
+      reasoningEffort,
       branch: sessionTarget?.kind === "repo" ? selectedBranch : "",
     };
     pendingConfigRef.current = currentConfig;
@@ -132,6 +119,7 @@ export default function Home() {
           if (
             pendingConfigRef.current?.target === currentConfig.target &&
             pendingConfigRef.current?.model === currentConfig.model &&
+            pendingConfigRef.current?.reasoningEffort === currentConfig.reasoningEffort &&
             pendingConfigRef.current?.branch === currentConfig.branch
           ) {
             setPendingSessionId(data.sessionId);
@@ -167,26 +155,29 @@ export default function Home() {
     pendingSessionId,
   ]);
 
-  // Reset selections when model preferences change (only after hydration)
-  useEffect(() => {
-    if (!hasHydratedModelPreferences) return;
-
-    if (enabledModels.length > 0 && !enabledModels.includes(selectedModel)) {
-      const fallback = enabledModels[0] ?? DEFAULT_MODEL;
-      setSelectedModel(fallback);
-      setReasoningEffort(getDefaultReasoningEffort(fallback));
-      return;
+  const saveModelPreferenceDraft = useCallback((preference: ModelPreference) => {
+    setModelPreferenceDraft(preference);
+    localStorage.setItem(LAST_SELECTED_MODEL_STORAGE_KEY, preference.model);
+    if (preference.reasoningEffort) {
+      localStorage.setItem(LAST_SELECTED_REASONING_EFFORT_STORAGE_KEY, preference.reasoningEffort);
+    } else {
+      localStorage.removeItem(LAST_SELECTED_REASONING_EFFORT_STORAGE_KEY);
     }
-
-    if (reasoningEffort && !isValidReasoningEffort(selectedModel, reasoningEffort)) {
-      setReasoningEffort(getDefaultReasoningEffort(selectedModel));
-    }
-  }, [hasHydratedModelPreferences, enabledModels, selectedModel, reasoningEffort]);
-
-  const handleModelChange = useCallback((model: string) => {
-    setSelectedModel(model);
-    setReasoningEffort(getDefaultReasoningEffort(model));
   }, []);
+
+  const handleModelChange = useCallback(
+    (model: string) => {
+      saveModelPreferenceDraft({ model, reasoningEffort: getDefaultReasoningEffort(model) });
+    },
+    [saveModelPreferenceDraft]
+  );
+
+  const handleReasoningEffortChange = useCallback(
+    (nextReasoningEffort: string | undefined) => {
+      saveModelPreferenceDraft({ model: selectedModel, reasoningEffort: nextReasoningEffort });
+    },
+    [saveModelPreferenceDraft, selectedModel]
+  );
 
   const handlePromptChange = (value: string) => {
     const wasEmpty = prompt.length === 0;
@@ -254,7 +245,7 @@ export default function Home() {
       selectedModel={selectedModel}
       setSelectedModel={handleModelChange}
       reasoningEffort={reasoningEffort}
-      setReasoningEffort={setReasoningEffort}
+      setReasoningEffort={handleReasoningEffortChange}
       prompt={prompt}
       handlePromptChange={handlePromptChange}
       creating={creating}

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -84,6 +84,7 @@ export default function Home() {
   }, [sessionTarget, selectedModel, reasoningEffort, selectedBranch]);
 
   const createSessionForWarming = useCallback(async () => {
+    if (loadingEnabledModels) return null;
     if (pendingSessionId) return pendingSessionId;
     if (sessionCreationPromise.current) return sessionCreationPromise.current;
     const targetRequestFields = buildRequestFields();
@@ -153,6 +154,7 @@ export default function Home() {
     selectedModel,
     reasoningEffort,
     pendingSessionId,
+    loadingEnabledModels,
   ]);
 
   const saveModelPreferenceDraft = useCallback((preference: ModelPreference) => {
@@ -182,14 +184,21 @@ export default function Home() {
   const handlePromptChange = (value: string) => {
     const wasEmpty = prompt.length === 0;
     setPrompt(value);
-    if (wasEmpty && value.length > 0 && !pendingSessionId && !isCreatingSession && isLaunchable) {
+    if (
+      wasEmpty &&
+      value.length > 0 &&
+      !pendingSessionId &&
+      !isCreatingSession &&
+      !loadingEnabledModels &&
+      isLaunchable
+    ) {
       createSessionForWarming();
     }
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!prompt.trim()) return;
+    if (!prompt.trim() || loadingEnabledModels) return;
     if (!isLaunchable) {
       setError(
         sessionTarget?.kind === "repos"

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -53,7 +53,7 @@ export default function Home() {
     branch: string;
   } | null>(null);
   const [hasHydratedModelPreferences, setHasHydratedModelPreferences] = useState(false);
-  const { enabledModels, enabledModelOptions } = useEnabledModels();
+  const { enabledModels, enabledModelOptions, loading: loadingEnabledModels } = useEnabledModels();
 
   useEffect(() => {
     if (hasHydratedModelPreferences) return;
@@ -69,7 +69,7 @@ export default function Home() {
 
   const { model: selectedModel, reasoningEffort } = resolveModelPreference(
     modelPreferenceDraft ?? storedPreference,
-    enabledModels
+    loadingEnabledModels ? undefined : enabledModels
   );
 
   useEffect(() => {

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/lib/session-list";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { DEFAULT_MODEL, getDefaultReasoningEffort } from "@open-inspect/shared";
+import { resolveModelPreference, type ModelPreference } from "@/lib/model-selection";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
 import type { ComboboxGroup } from "@/components/ui/combobox";
 
@@ -363,12 +364,18 @@ function useSessionListActions(sessionId: string) {
  * list and synced from session state once it loads.
  */
 function useModelSelection(sessionState: SessionState) {
-  const [selectedModel, setSelectedModel] = useState<string>(DEFAULT_MODEL);
-  const [reasoningEffort, setReasoningEffort] = useState<string | undefined>(
-    getDefaultReasoningEffort(DEFAULT_MODEL)
-  );
+  const [modelPreferenceDraft, setModelPreferenceDraft] = useState<ModelPreference | null>(null);
 
   const { enabledModels, enabledModelOptions } = useEnabledModels();
+  const { model: selectedModel, reasoningEffort } = resolveModelPreference(
+    modelPreferenceDraft ?? {
+      model: sessionState?.model ?? DEFAULT_MODEL,
+      reasoningEffort:
+        sessionState?.reasoningEffort ??
+        getDefaultReasoningEffort(sessionState?.model ?? DEFAULT_MODEL),
+    },
+    enabledModels
+  );
   const modelItems = useMemo<ComboboxGroup[]>(
     () =>
       enabledModelOptions.map((group) => ({
@@ -383,28 +390,15 @@ function useModelSelection(sessionState: SessionState) {
   );
 
   const handleModelChange = useCallback((model: string) => {
-    setSelectedModel(model);
-    setReasoningEffort(getDefaultReasoningEffort(model));
+    setModelPreferenceDraft({ model, reasoningEffort: getDefaultReasoningEffort(model) });
   }, []);
 
-  // Reset to default if the selected model is no longer enabled
-  useEffect(() => {
-    if (enabledModels.length > 0 && !enabledModels.includes(selectedModel)) {
-      const fallback = enabledModels[0] ?? DEFAULT_MODEL;
-      setSelectedModel(fallback);
-      setReasoningEffort(getDefaultReasoningEffort(fallback));
-    }
-  }, [enabledModels, selectedModel]);
-
-  // Sync selectedModel and reasoningEffort with session state when it loads
-  useEffect(() => {
-    if (sessionState?.model) {
-      setSelectedModel(sessionState.model);
-      setReasoningEffort(
-        sessionState.reasoningEffort ?? getDefaultReasoningEffort(sessionState.model)
-      );
-    }
-  }, [sessionState?.model, sessionState?.reasoningEffort]);
+  const setReasoningEffort = useCallback(
+    (nextReasoningEffort: string | undefined) => {
+      setModelPreferenceDraft({ model: selectedModel, reasoningEffort: nextReasoningEffort });
+    },
+    [selectedModel]
+  );
 
   return { selectedModel, reasoningEffort, setReasoningEffort, handleModelChange, modelItems };
 }

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -71,14 +71,21 @@ function SessionPageContent() {
   );
 
   const { handleArchive, handleUnarchive, renameSession } = useSessionListActions(sessionId);
-  const { selectedModel, reasoningEffort, setReasoningEffort, handleModelChange, modelItems } =
-    useModelSelection(sessionState);
+  const {
+    selectedModel,
+    reasoningEffort,
+    setReasoningEffort,
+    handleModelChange,
+    modelItems,
+    loadingEnabledModels,
+  } = useModelSelection(sessionState);
   const { prompt, inputRef, handleSubmit, handleInputChange, handleKeyDown } = usePromptInput(
     isProcessing,
     sendPrompt,
     sendTyping,
     selectedModel,
-    reasoningEffort
+    reasoningEffort,
+    loadingEnabledModels
   );
 
   const [selectedMediaArtifactId, setSelectedMediaArtifactId] = useState<string | null>(null);
@@ -360,8 +367,8 @@ function useSessionListActions(sessionId: string) {
 }
 
 /**
- * Model and reasoning-effort selection, kept consistent with the enabled-model
- * list and synced from session state once it loads.
+ * Model and reasoning-effort selection derived from session state until the
+ * user takes ownership of an explicit draft.
  */
 function useModelSelection(sessionState: SessionState) {
   const [modelPreferenceDraft, setModelPreferenceDraft] = useState<ModelPreference | null>(null);
@@ -400,7 +407,14 @@ function useModelSelection(sessionState: SessionState) {
     [selectedModel]
   );
 
-  return { selectedModel, reasoningEffort, setReasoningEffort, handleModelChange, modelItems };
+  return {
+    selectedModel,
+    reasoningEffort,
+    setReasoningEffort,
+    handleModelChange,
+    modelItems,
+    loadingEnabledModels,
+  };
 }
 
 /**
@@ -412,7 +426,8 @@ function usePromptInput(
   sendPrompt: ReturnType<typeof useSessionSocket>["sendPrompt"],
   sendTyping: ReturnType<typeof useSessionSocket>["sendTyping"],
   selectedModel: string,
-  reasoningEffort: string | undefined
+  reasoningEffort: string | undefined,
+  loadingEnabledModels: boolean
 ) {
   const [prompt, setPrompt] = useState("");
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -429,7 +444,7 @@ function usePromptInput(
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!prompt.trim() || isProcessing) return;
+    if (!prompt.trim() || isProcessing || loadingEnabledModels) return;
 
     // Drop any queued typing indicator — the prompt supersedes it
     clearTypingTimeout();

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -366,7 +366,7 @@ function useSessionListActions(sessionId: string) {
 function useModelSelection(sessionState: SessionState) {
   const [modelPreferenceDraft, setModelPreferenceDraft] = useState<ModelPreference | null>(null);
 
-  const { enabledModels, enabledModelOptions } = useEnabledModels();
+  const { enabledModels, enabledModelOptions, loading: loadingEnabledModels } = useEnabledModels();
   const { model: selectedModel, reasoningEffort } = resolveModelPreference(
     modelPreferenceDraft ?? {
       model: sessionState?.model ?? DEFAULT_MODEL,
@@ -374,7 +374,7 @@ function useModelSelection(sessionState: SessionState) {
         sessionState?.reasoningEffort ??
         getDefaultReasoningEffort(sessionState?.model ?? DEFAULT_MODEL),
     },
-    enabledModels
+    loadingEnabledModels ? undefined : enabledModels
   );
   const modelItems = useMemo<ComboboxGroup[]>(
     () =>

--- a/packages/web/src/lib/model-selection.test.ts
+++ b/packages/web/src/lib/model-selection.test.ts
@@ -79,6 +79,14 @@ describe("resolveModelPreference", () => {
     });
   });
 
+  it("uses the selected model default when only reasoning is invalid", () => {
+    const model = "anthropic/claude-opus-4-8";
+    expect(resolveModelPreference({ model, reasoningEffort: "not-valid" }, [model])).toEqual({
+      model,
+      reasoningEffort: getDefaultReasoningEffort(model),
+    });
+  });
+
   it("omits reasoning for models without reasoning controls", () => {
     expect(
       resolveModelPreference({ model: "opencode/kimi-k2.5", reasoningEffort: "high" }, [

--- a/packages/web/src/lib/model-selection.test.ts
+++ b/packages/web/src/lib/model-selection.test.ts
@@ -53,6 +53,21 @@ describe("resolveModelPreference", () => {
     ).toEqual({ model: "anthropic/claude-opus-4-8", reasoningEffort: "high" });
   });
 
+  it("preserves the upstream model while enabled models are loading", () => {
+    expect(
+      resolveModelPreference({ model: "claude-opus-4-8", reasoningEffort: "high" }, undefined)
+    ).toEqual({ model: "anthropic/claude-opus-4-8", reasoningEffort: "high" });
+  });
+
+  it("uses the default when the loaded enabled-model list is empty", () => {
+    expect(
+      resolveModelPreference({ model: "anthropic/claude-opus-4-8", reasoningEffort: "high" }, [])
+    ).toEqual({
+      model: DEFAULT_MODEL,
+      reasoningEffort: getDefaultReasoningEffort(DEFAULT_MODEL),
+    });
+  });
+
   it("uses the fallback model default when reasoning is invalid", () => {
     expect(
       resolveModelPreference({ model: "anthropic/claude-opus-4-8", reasoningEffort: "not-valid" }, [

--- a/packages/web/src/lib/model-selection.test.ts
+++ b/packages/web/src/lib/model-selection.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { DEFAULT_MODEL } from "@open-inspect/shared";
-import { resolveEnabledModel } from "./model-selection";
+import { DEFAULT_MODEL, getDefaultReasoningEffort } from "@open-inspect/shared";
+import { resolveEnabledModel, resolveModelPreference } from "./model-selection";
 
 describe("resolveEnabledModel", () => {
   it("keeps the desired model when it is enabled", () => {
@@ -33,5 +33,42 @@ describe("resolveEnabledModel", () => {
 
   it("falls back to the default when no models are enabled", () => {
     expect(resolveEnabledModel("anthropic/claude-opus-4-8", [])).toBe(DEFAULT_MODEL);
+  });
+});
+
+describe("resolveModelPreference", () => {
+  it("keeps a valid model and reasoning effort", () => {
+    expect(
+      resolveModelPreference({ model: "anthropic/claude-opus-4-8", reasoningEffort: "high" }, [
+        "anthropic/claude-opus-4-8",
+      ])
+    ).toEqual({ model: "anthropic/claude-opus-4-8", reasoningEffort: "high" });
+  });
+
+  it("normalizes the model before validating reasoning effort", () => {
+    expect(
+      resolveModelPreference({ model: "claude-opus-4-8", reasoningEffort: "high" }, [
+        "anthropic/claude-opus-4-8",
+      ])
+    ).toEqual({ model: "anthropic/claude-opus-4-8", reasoningEffort: "high" });
+  });
+
+  it("uses the fallback model default when reasoning is invalid", () => {
+    expect(
+      resolveModelPreference({ model: "anthropic/claude-opus-4-8", reasoningEffort: "not-valid" }, [
+        DEFAULT_MODEL,
+      ])
+    ).toEqual({
+      model: DEFAULT_MODEL,
+      reasoningEffort: getDefaultReasoningEffort(DEFAULT_MODEL),
+    });
+  });
+
+  it("omits reasoning for models without reasoning controls", () => {
+    expect(
+      resolveModelPreference({ model: "opencode/kimi-k2.5", reasoningEffort: "high" }, [
+        "opencode/kimi-k2.5",
+      ])
+    ).toEqual({ model: "opencode/kimi-k2.5", reasoningEffort: undefined });
   });
 });

--- a/packages/web/src/lib/model-selection.ts
+++ b/packages/web/src/lib/model-selection.ts
@@ -1,4 +1,14 @@
-import { DEFAULT_MODEL, getValidModelOrDefault } from "@open-inspect/shared";
+import {
+  DEFAULT_MODEL,
+  getDefaultReasoningEffort,
+  getValidModelOrDefault,
+  isValidReasoningEffort,
+} from "@open-inspect/shared";
+
+export interface ModelPreference {
+  model: string;
+  reasoningEffort?: string;
+}
 
 /**
  * Pick the model the automation form should actually use, given a desired model
@@ -17,4 +27,18 @@ export function resolveEnabledModel(model: string, enabledModels: string[]): str
   if (enabled.has(desired)) return desired;
   if (enabled.has(DEFAULT_MODEL)) return DEFAULT_MODEL;
   return enabledModels[0] ?? DEFAULT_MODEL;
+}
+
+export function resolveModelPreference(
+  preference: ModelPreference,
+  enabledModels: string[]
+): ModelPreference {
+  const model = resolveEnabledModel(preference.model, enabledModels);
+  return {
+    model,
+    reasoningEffort:
+      preference.reasoningEffort && isValidReasoningEffort(model, preference.reasoningEffort)
+        ? preference.reasoningEffort
+        : getDefaultReasoningEffort(model),
+  };
 }

--- a/packages/web/src/lib/model-selection.ts
+++ b/packages/web/src/lib/model-selection.ts
@@ -31,9 +31,11 @@ export function resolveEnabledModel(model: string, enabledModels: string[]): str
 
 export function resolveModelPreference(
   preference: ModelPreference,
-  enabledModels: string[]
+  enabledModels: string[] | undefined
 ): ModelPreference {
-  const model = resolveEnabledModel(preference.model, enabledModels);
+  const model = enabledModels
+    ? resolveEnabledModel(preference.model, enabledModels)
+    : getValidModelOrDefault(preference.model);
   return {
     model,
     reasoningEffort:


### PR DESCRIPTION
## Summary
- centralize enabled-model and reasoning-effort resolution in one pure model preference resolver
- derive home and session selections from upstream preferences until the user creates an explicit local draft
- persist only user-owned home-page changes and invalidate warmed sessions when reasoning effort changes
- cover normalization, fallback, invalid reasoning, and models without reasoning controls

## Verification
- `npm test -w @open-inspect/web` (698 tests passed)
- `npm run typecheck -w @open-inspect/web`
- ESLint and Prettier on changed files

Closes COL-16

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/db74e04cd9aa3aeb6b65fe92e6f4f1dd)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamlined model + reasoning-effort selection on home and session pages with a unified, persisted preference flow.
  * Session reuse now requires reasoning-effort to match the warmed configuration.
* **Bug Fixes**
  * Prevents invalid or unsupported reasoning-effort selections and applies sensible defaults when needed.
  * Prompt submission is blocked while enabled-model options are still loading.
* **Tests**
  * Added coverage for resolving combined model + reasoning-effort preferences, including normalization, defaulting, and models without reasoning controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->