### PR TITLE
refactor: inline one-use SessionContent middle man in session page

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -27,12 +27,6 @@ import type { ComboboxGroup } from "@/components/ui/combobox";
 
 type SessionState = ReturnType<typeof useSessionSocket>["sessionState"];
 
-type FallbackSessionInfo = {
-  repoOwner: string | null;
-  repoName: string | null;
-  title: string | null;
-};
-
 export default function SessionPage() {
   return (
     <Suspense>
@@ -43,7 +37,6 @@ export default function SessionPage() {
 
 function SessionPageContent() {
   const params = useParams();
-  const router = useRouter();
   const searchParams = useSearchParams();
   const sessionId = params.id as string;
 
@@ -76,274 +69,19 @@ function SessionPageContent() {
     [searchParams]
   );
 
-  const { trigger: triggerRename } = useSWRMutation(
-    `/api/sessions/${sessionId}/title`,
-    (url: string, { arg }: { arg: { title: string } }) =>
-      fetch(url, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title: arg.title }),
-      }).then((r) => {
-        if (r.ok) return true;
-        console.error("Failed to update session title");
-        return false;
-      }),
-    { throwOnError: false }
+  const { handleArchive, handleUnarchive, renameSession } = useSessionListActions(sessionId);
+  const { selectedModel, reasoningEffort, setReasoningEffort, handleModelChange, modelItems } =
+    useModelSelection(sessionState);
+  const { prompt, inputRef, handleSubmit, handleInputChange, handleKeyDown } = usePromptInput(
+    isProcessing,
+    sendPrompt,
+    sendTyping,
+    selectedModel,
+    reasoningEffort
   );
 
-  const handleArchive = useCallback(async () => {
-    const didArchive = await archiveSession(sessionId);
-    if (didArchive) {
-      await mutate<SessionListResponse>(
-        isUnarchivedSessionListKey,
-        (current) =>
-          current
-            ? { ...current, sessions: removeSessionFromList(current.sessions, sessionId) }
-            : current,
-        { revalidate: false, populateCache: true }
-      );
-      router.push("/");
-    }
-  }, [router, sessionId]);
-
-  const renameSession = useCallback(
-    async (title: string) => {
-      const updatedAt = Date.now();
-      const updateSessionsTitle = (data?: SessionListResponse): SessionListResponse | undefined => {
-        if (!data?.sessions) return data;
-        return {
-          ...data,
-          sessions: data.sessions.map((session) =>
-            session.id === sessionId ? { ...session, title, updatedAt } : session
-          ),
-        };
-      };
-
-      try {
-        const success = await triggerRename({ title });
-        if (!success) {
-          throw new Error("Failed to update session title");
-        }
-        await mutate<SessionListResponse>(isUnarchivedSessionListKey, updateSessionsTitle, {
-          populateCache: true,
-          revalidate: true,
-        });
-        await mutate<SessionListResponse>(isArchivedSessionListKey, updateSessionsTitle, {
-          populateCache: true,
-          revalidate: false,
-        });
-        return true;
-      } catch {
-        return false;
-      }
-    },
-    [sessionId, triggerRename]
-  );
-
-  const { trigger: handleUnarchive } = useSWRMutation(
-    `/api/sessions/${sessionId}/unarchive`,
-    (url: string) =>
-      fetch(url, { method: "POST" }).then(async (r) => {
-        if (r.ok) {
-          await mutate<SessionListResponse>(
-            isArchivedSessionListKey,
-            (current) =>
-              current
-                ? { ...current, sessions: removeSessionFromList(current.sessions, sessionId) }
-                : current,
-            { revalidate: false, populateCache: true }
-          );
-          mutate(isUnarchivedSessionListKey);
-        } else {
-          console.error("Failed to unarchive session");
-        }
-      }),
-    { throwOnError: false }
-  );
-
-  const [prompt, setPrompt] = useState("");
   const [selectedMediaArtifactId, setSelectedMediaArtifactId] = useState<string | null>(null);
-  const [selectedModel, setSelectedModel] = useState<string>(DEFAULT_MODEL);
-  const [reasoningEffort, setReasoningEffort] = useState<string | undefined>(
-    getDefaultReasoningEffort(DEFAULT_MODEL)
-  );
-  const inputRef = useRef<HTMLTextAreaElement>(null);
-  const typingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
-  const { enabledModels, enabledModelOptions } = useEnabledModels();
-  const modelItems = useMemo<ComboboxGroup[]>(
-    () =>
-      enabledModelOptions.map((group) => ({
-        category: group.category,
-        options: group.models.map((model) => ({
-          value: model.id,
-          label: model.name,
-          description: model.description,
-        })),
-      })),
-    [enabledModelOptions]
-  );
-
-  const handleModelChange = useCallback((model: string) => {
-    setSelectedModel(model);
-    setReasoningEffort(getDefaultReasoningEffort(model));
-  }, []);
-
-  // Reset to default if the selected model is no longer enabled
-  useEffect(() => {
-    if (enabledModels.length > 0 && !enabledModels.includes(selectedModel)) {
-      const fallback = enabledModels[0] ?? DEFAULT_MODEL;
-      setSelectedModel(fallback);
-      setReasoningEffort(getDefaultReasoningEffort(fallback));
-    }
-  }, [enabledModels, selectedModel]);
-
-  // Sync selectedModel and reasoningEffort with session state when it loads
-  useEffect(() => {
-    if (sessionState?.model) {
-      setSelectedModel(sessionState.model);
-      setReasoningEffort(
-        sessionState.reasoningEffort ?? getDefaultReasoningEffort(sessionState.model)
-      );
-    }
-  }, [sessionState?.model, sessionState?.reasoningEffort]);
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!prompt.trim() || isProcessing) return;
-
-    sendPrompt(prompt, selectedModel, reasoningEffort);
-    setPrompt("");
-    // Revalidate sidebar so this session bubbles to the top
-    mutate(isUnarchivedSessionListKey);
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.nativeEvent.isComposing) return;
-
-    if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
-      e.preventDefault();
-      handleSubmit(e);
-    }
-  };
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setPrompt(e.target.value);
-
-    // Send typing indicator (debounced)
-    if (typingTimeoutRef.current) {
-      clearTimeout(typingTimeoutRef.current);
-    }
-    typingTimeoutRef.current = setTimeout(() => {
-      sendTyping();
-    }, 300);
-  };
-
-  return (
-    <SessionContent
-      sessionState={sessionState}
-      connected={connected}
-      connecting={connecting}
-      replaying={replaying}
-      authError={authError}
-      connectionError={connectionError}
-      reconnect={reconnect}
-      participants={participants}
-      events={events}
-      artifacts={artifacts}
-      currentParticipantId={currentParticipantId}
-      prompt={prompt}
-      isProcessing={isProcessing}
-      selectedModel={selectedModel}
-      reasoningEffort={reasoningEffort}
-      inputRef={inputRef}
-      handleSubmit={handleSubmit}
-      handleInputChange={handleInputChange}
-      handleKeyDown={handleKeyDown}
-      setSelectedModel={handleModelChange}
-      setReasoningEffort={setReasoningEffort}
-      stopExecution={stopExecution}
-      handleArchive={handleArchive}
-      handleUnarchive={handleUnarchive}
-      renameSession={renameSession}
-      loadingHistory={loadingHistory}
-      loadOlderEvents={loadOlderEvents}
-      modelItems={modelItems}
-      fallbackSessionInfo={fallbackSessionInfo}
-      sessionId={sessionId}
-      selectedMediaArtifactId={selectedMediaArtifactId}
-      setSelectedMediaArtifactId={setSelectedMediaArtifactId}
-    />
-  );
-}
-
-function SessionContent({
-  sessionState,
-  connected,
-  connecting,
-  replaying,
-  authError,
-  connectionError,
-  reconnect,
-  participants,
-  events,
-  artifacts,
-  currentParticipantId,
-  prompt,
-  isProcessing,
-  selectedModel,
-  reasoningEffort,
-  inputRef,
-  handleSubmit,
-  handleInputChange,
-  handleKeyDown,
-  setSelectedModel,
-  setReasoningEffort,
-  stopExecution,
-  handleArchive,
-  handleUnarchive,
-  renameSession,
-  loadingHistory,
-  loadOlderEvents,
-  modelItems,
-  fallbackSessionInfo,
-  sessionId,
-  selectedMediaArtifactId,
-  setSelectedMediaArtifactId,
-}: {
-  sessionState: SessionState;
-  connected: boolean;
-  connecting: boolean;
-  replaying: boolean;
-  authError: string | null;
-  connectionError: string | null;
-  reconnect: () => void;
-  participants: ReturnType<typeof useSessionSocket>["participants"];
-  events: ReturnType<typeof useSessionSocket>["events"];
-  artifacts: ReturnType<typeof useSessionSocket>["artifacts"];
-  currentParticipantId: string | null;
-  prompt: string;
-  isProcessing: boolean;
-  selectedModel: string;
-  reasoningEffort: string | undefined;
-  inputRef: React.RefObject<HTMLTextAreaElement | null>;
-  handleSubmit: (e: React.FormEvent) => void;
-  handleInputChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
-  handleKeyDown: (e: React.KeyboardEvent) => void;
-  setSelectedModel: (model: string) => void;
-  setReasoningEffort: (value: string | undefined) => void;
-  stopExecution: () => void;
-  handleArchive: () => void | Promise<void>;
-  handleUnarchive: () => void | Promise<void>;
-  renameSession: (title: string) => Promise<boolean | undefined>;
-  loadingHistory: boolean;
-  loadOlderEvents: () => void;
-  modelItems: ComboboxGroup[];
-  fallbackSessionInfo: FallbackSessionInfo;
-  sessionId: string;
-  selectedMediaArtifactId: string | null;
-  setSelectedMediaArtifactId: (artifactId: string | null) => void;
-}) {
   const isBelowLg = useMediaQuery("(max-width: 1023px)");
   const isPhone = useMediaQuery("(max-width: 767px)");
 
@@ -515,10 +253,205 @@ function SessionContent({
           selectedModel,
           reasoningEffort,
           items: modelItems,
-          onModelChange: setSelectedModel,
+          onModelChange: handleModelChange,
           onReasoningEffortChange: setReasoningEffort,
         }}
       />
     </div>
   );
+}
+
+/**
+ * Archive, unarchive, and rename actions for the current session, each keeping
+ * the SWR session-list caches in sync.
+ */
+function useSessionListActions(sessionId: string) {
+  const router = useRouter();
+
+  const { trigger: triggerRename } = useSWRMutation(
+    `/api/sessions/${sessionId}/title`,
+    (url: string, { arg }: { arg: { title: string } }) =>
+      fetch(url, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: arg.title }),
+      }).then((r) => {
+        if (r.ok) return true;
+        console.error("Failed to update session title");
+        return false;
+      }),
+    { throwOnError: false }
+  );
+
+  const handleArchive = useCallback(async () => {
+    const didArchive = await archiveSession(sessionId);
+    if (didArchive) {
+      await mutate<SessionListResponse>(
+        isUnarchivedSessionListKey,
+        (current) =>
+          current
+            ? { ...current, sessions: removeSessionFromList(current.sessions, sessionId) }
+            : current,
+        { revalidate: false, populateCache: true }
+      );
+      router.push("/");
+    }
+  }, [router, sessionId]);
+
+  const renameSession = useCallback(
+    async (title: string) => {
+      const updatedAt = Date.now();
+      const updateSessionsTitle = (data?: SessionListResponse): SessionListResponse | undefined => {
+        if (!data?.sessions) return data;
+        return {
+          ...data,
+          sessions: data.sessions.map((session) =>
+            session.id === sessionId ? { ...session, title, updatedAt } : session
+          ),
+        };
+      };
+
+      try {
+        const success = await triggerRename({ title });
+        if (!success) {
+          throw new Error("Failed to update session title");
+        }
+        await mutate<SessionListResponse>(isUnarchivedSessionListKey, updateSessionsTitle, {
+          populateCache: true,
+          revalidate: true,
+        });
+        await mutate<SessionListResponse>(isArchivedSessionListKey, updateSessionsTitle, {
+          populateCache: true,
+          revalidate: false,
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [sessionId, triggerRename]
+  );
+
+  const { trigger: handleUnarchive } = useSWRMutation(
+    `/api/sessions/${sessionId}/unarchive`,
+    (url: string) =>
+      fetch(url, { method: "POST" }).then(async (r) => {
+        if (r.ok) {
+          await mutate<SessionListResponse>(
+            isArchivedSessionListKey,
+            (current) =>
+              current
+                ? { ...current, sessions: removeSessionFromList(current.sessions, sessionId) }
+                : current,
+            { revalidate: false, populateCache: true }
+          );
+          mutate(isUnarchivedSessionListKey);
+        } else {
+          console.error("Failed to unarchive session");
+        }
+      }),
+    { throwOnError: false }
+  );
+
+  return { handleArchive, handleUnarchive, renameSession };
+}
+
+/**
+ * Model and reasoning-effort selection, kept consistent with the enabled-model
+ * list and synced from session state once it loads.
+ */
+function useModelSelection(sessionState: SessionState) {
+  const [selectedModel, setSelectedModel] = useState<string>(DEFAULT_MODEL);
+  const [reasoningEffort, setReasoningEffort] = useState<string | undefined>(
+    getDefaultReasoningEffort(DEFAULT_MODEL)
+  );
+
+  const { enabledModels, enabledModelOptions } = useEnabledModels();
+  const modelItems = useMemo<ComboboxGroup[]>(
+    () =>
+      enabledModelOptions.map((group) => ({
+        category: group.category,
+        options: group.models.map((model) => ({
+          value: model.id,
+          label: model.name,
+          description: model.description,
+        })),
+      })),
+    [enabledModelOptions]
+  );
+
+  const handleModelChange = useCallback((model: string) => {
+    setSelectedModel(model);
+    setReasoningEffort(getDefaultReasoningEffort(model));
+  }, []);
+
+  // Reset to default if the selected model is no longer enabled
+  useEffect(() => {
+    if (enabledModels.length > 0 && !enabledModels.includes(selectedModel)) {
+      const fallback = enabledModels[0] ?? DEFAULT_MODEL;
+      setSelectedModel(fallback);
+      setReasoningEffort(getDefaultReasoningEffort(fallback));
+    }
+  }, [enabledModels, selectedModel]);
+
+  // Sync selectedModel and reasoningEffort with session state when it loads
+  useEffect(() => {
+    if (sessionState?.model) {
+      setSelectedModel(sessionState.model);
+      setReasoningEffort(
+        sessionState.reasoningEffort ?? getDefaultReasoningEffort(sessionState.model)
+      );
+    }
+  }, [sessionState?.model, sessionState?.reasoningEffort]);
+
+  return { selectedModel, reasoningEffort, setReasoningEffort, handleModelChange, modelItems };
+}
+
+/**
+ * Prompt textarea state and handlers: submit, Cmd/Ctrl+Enter, and the
+ * debounced typing indicator.
+ */
+function usePromptInput(
+  isProcessing: boolean,
+  sendPrompt: ReturnType<typeof useSessionSocket>["sendPrompt"],
+  sendTyping: ReturnType<typeof useSessionSocket>["sendTyping"],
+  selectedModel: string,
+  reasoningEffort: string | undefined
+) {
+  const [prompt, setPrompt] = useState("");
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const typingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!prompt.trim() || isProcessing) return;
+
+    sendPrompt(prompt, selectedModel, reasoningEffort);
+    setPrompt("");
+    // Revalidate sidebar so this session bubbles to the top
+    mutate(isUnarchivedSessionListKey);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.nativeEvent.isComposing) return;
+
+    if (e.key === "Enter" && (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setPrompt(e.target.value);
+
+    // Send typing indicator (debounced)
+    if (typingTimeoutRef.current) {
+      clearTimeout(typingTimeoutRef.current);
+    }
+    typingTimeoutRef.current = setTimeout(() => {
+      sendTyping();
+    }, 300);
+  };
+
+  return { prompt, inputRef, handleSubmit, handleInputChange, handleKeyDown };
 }

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -316,14 +316,16 @@ function useSessionListActions(sessionId: string) {
         if (!success) {
           throw new Error("Failed to update session title");
         }
-        await mutate<SessionListResponse>(isUnarchivedSessionListKey, updateSessionsTitle, {
-          populateCache: true,
-          revalidate: true,
-        });
-        await mutate<SessionListResponse>(isArchivedSessionListKey, updateSessionsTitle, {
-          populateCache: true,
-          revalidate: false,
-        });
+        await Promise.all([
+          mutate<SessionListResponse>(isUnarchivedSessionListKey, updateSessionsTitle, {
+            populateCache: true,
+            revalidate: true,
+          }),
+          mutate<SessionListResponse>(isArchivedSessionListKey, updateSessionsTitle, {
+            populateCache: true,
+            revalidate: false,
+          }),
+        ]);
         return true;
       } catch {
         return false;
@@ -422,10 +424,21 @@ function usePromptInput(
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const typingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
+  const clearTypingTimeout = useCallback(() => {
+    if (typingTimeoutRef.current) {
+      clearTimeout(typingTimeoutRef.current);
+      typingTimeoutRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => clearTypingTimeout, [clearTypingTimeout]);
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!prompt.trim() || isProcessing) return;
 
+    // Drop any queued typing indicator — the prompt supersedes it
+    clearTypingTimeout();
     sendPrompt(prompt, selectedModel, reasoningEffort);
     setPrompt("");
     // Revalidate sidebar so this session bubbles to the top
@@ -445,9 +458,7 @@ function usePromptInput(
     setPrompt(e.target.value);
 
     // Send typing indicator (debounced)
-    if (typingTimeoutRef.current) {
-      clearTimeout(typingTimeoutRef.current);
-    }
+    clearTypingTimeout();
     typingTimeoutRef.current = setTimeout(() => {
       sendTyping();
     }, 300);


### PR DESCRIPTION
## Summary

Addresses the review finding that the session page's `SessionContent` component is a one-use middle man with ~30 relayed props (`packages/web/src/app/(app)/session/[id]/page.tsx:280`).

`SessionContent` was declared and used exactly once in the same file, with no `React.memo`, Suspense, or lazy boundary — so the seam provided no render-isolation or code-splitting value, and the sidebar cluster (`sessionState`, `participants`, `events`, `artifacts`, terminal/media callbacks) was relayed through it verbatim to both `SessionRightSidebar` and `SessionDetailsOverlay`.

Two standard, behavior-preserving refactorings:

1. **Extract Function (custom hooks)** — the container's three unrelated concerns become page-local hooks so the merged component stays readable:
   - `useSessionListActions(sessionId)` — archive / unarchive / rename, each with its SWR session-list cache synchronization (absorbs the `useRouter` call only archive needed)
   - `useModelSelection(sessionState)` — model + reasoning-effort state, disabled-model fallback effect, session-state sync effect, combobox items
   - `usePromptInput(...)` — prompt state, submit / keydown / change handlers, debounced typing indicator
2. **Inline Function / Remove Middle Man** — merge `SessionContent`'s body into `SessionPageContent`, deleting the 31-prop call site, the 66-line props type literal, and the now-unused `FallbackSessionInfo` alias.

Chose inlining over grouping props into view models because the component is single-use in the same module — view models would reshape the plumbing while keeping the pointless seam. The one real grouped boundary, `SessionPromptComposer`'s `session`/`prompt`/`model` props, is untouched; the only JSX delta is the composer now receives `handleModelChange` directly instead of the relayed `setSelectedModel` alias.

Net **−67 lines**, all within the one file.

## Testing

- `npm run typecheck -w @open-inspect/web` clean
- `npm test -w @open-inspect/web` — 694 tests / 64 files pass
- ESLint + Prettier clean (pre-commit lint-staged passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Session actions such as archiving, renaming, and restoring now behave more consistently.
  - Model and reasoning selections stay properly synced with the active session.
  - Prompt typing experience has been refined, with smoother keyboard submission behavior.
  - Session prompt interactions feel more responsive while composing and sending messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->