### PR TITLE
revert: "fix: restrict sandbox authorization to running state (#970)"

### DIFF
--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
@@ -316,29 +316,45 @@ describe("createSandboxHandler", () => {
     expect(log.warn).toHaveBeenCalledWith("Sandbox token verification failed: no sandbox");
   });
 
-  it.each(["pending", "stopped", "stale", "failed"] as const)(
-    "returns 410 when sandbox is %s",
-    async (status) => {
-      const { handler, getSandbox, isValidSandboxToken, log } = createHandler();
-      getSandbox.mockReturnValue({ status } as SandboxRow);
+  it("returns 410 when sandbox is stopped", async () => {
+    const { handler, getSandbox, log } = createHandler();
+    getSandbox.mockReturnValue({ status: "stopped" } as SandboxRow);
 
-      const response = await handler.verifySandboxToken(
-        new Request("http://internal/internal/verify-sandbox-token", {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ token: "abc" }),
-        })
-      );
+    const response = await handler.verifySandboxToken(
+      new Request("http://internal/internal/verify-sandbox-token", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ token: "abc" }),
+      })
+    );
 
-      expect(response.status).toBe(410);
-      expect(await response.json()).toEqual({ valid: false, error: "Sandbox not running" });
-      expect(log.warn).toHaveBeenCalledWith(
-        "Sandbox token verification failed: sandbox is not running",
-        { status }
-      );
-      expect(isValidSandboxToken).not.toHaveBeenCalled();
-    }
-  );
+    expect(response.status).toBe(410);
+    expect(await response.json()).toEqual({ valid: false, error: "Sandbox stopped" });
+    expect(log.warn).toHaveBeenCalledWith(
+      "Sandbox token verification failed: sandbox is stopped/stale",
+      { status: "stopped" }
+    );
+  });
+
+  it("returns 410 when sandbox is stale", async () => {
+    const { handler, getSandbox, log } = createHandler();
+    getSandbox.mockReturnValue({ status: "stale" } as SandboxRow);
+
+    const response = await handler.verifySandboxToken(
+      new Request("http://internal/internal/verify-sandbox-token", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ token: "abc" }),
+      })
+    );
+
+    expect(response.status).toBe(410);
+    expect(await response.json()).toEqual({ valid: false, error: "Sandbox stopped" });
+    expect(log.warn).toHaveBeenCalledWith(
+      "Sandbox token verification failed: sandbox is stopped/stale",
+      { status: "stale" }
+    );
+  });
 
   it("returns 401 when sandbox token is invalid", async () => {
     const { handler, getSandbox, isValidSandboxToken, log } = createHandler();

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
@@ -183,11 +183,11 @@ export function createSandboxHandler(deps: SandboxHandlerDeps): SandboxHandler {
         return Response.json({ valid: false, error: "No sandbox" }, { status: 404 });
       }
 
-      if (sandbox.status !== "running") {
-        deps.getLog().warn("Sandbox token verification failed: sandbox is not running", {
+      if (sandbox.status === "stopped" || sandbox.status === "stale") {
+        deps.getLog().warn("Sandbox token verification failed: sandbox is stopped/stale", {
           status: sandbox.status,
         });
-        return Response.json({ valid: false, error: "Sandbox not running" }, { status: 410 });
+        return Response.json({ valid: false, error: "Sandbox stopped" }, { status: 410 });
       }
 
       const isTokenValid = await deps.isValidSandboxToken(token, sandbox);

--- a/packages/control-plane/test/integration/helpers.ts
+++ b/packages/control-plane/test/integration/helpers.ts
@@ -281,12 +281,11 @@ export async function seedSandboxAuth(
   stub: DurableObjectStub,
   opts: { authToken: string; sandboxId: string }
 ): Promise<void> {
-  await waitForSandboxStatus(stub, "failed");
   const tokenHash = await hashToken(opts.authToken);
 
   await runInDurableObject(stub, (instance: SessionDO) => {
     instance.ctx.storage.sql.exec(
-      "UPDATE sandbox SET auth_token = ?, auth_token_hash = ?, modal_sandbox_id = ?, status = 'running'",
+      "UPDATE sandbox SET auth_token = ?, auth_token_hash = ?, modal_sandbox_id = ?",
       opts.authToken,
       tokenHash,
       opts.sandboxId
@@ -295,18 +294,17 @@ export async function seedSandboxAuth(
 }
 
 /**
- * Seed a running sandbox with auth_token_hash and modal_sandbox_id.
+ * Seed auth_token_hash and modal_sandbox_id on the sandbox row.
  */
 export async function seedSandboxAuthHash(
   stub: DurableObjectStub,
   opts: { authToken: string; sandboxId: string }
 ): Promise<void> {
-  await waitForSandboxStatus(stub, "failed");
   const tokenHash = await hashToken(opts.authToken);
 
   await runInDurableObject(stub, (instance: SessionDO) => {
     instance.ctx.storage.sql.exec(
-      "UPDATE sandbox SET auth_token_hash = ?, auth_token = NULL, modal_sandbox_id = ?, status = 'running'",
+      "UPDATE sandbox SET auth_token_hash = ?, auth_token = NULL, modal_sandbox_id = ?",
       tokenHash,
       opts.sandboxId
     );

--- a/packages/control-plane/test/integration/session-lifecycle.test.ts
+++ b/packages/control-plane/test/integration/session-lifecycle.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { runInDurableObject } from "cloudflare:test";
 import type { SessionDO } from "../../src/session/durable-object";
-import { initSession, seedSandboxAuthHash, waitForSandboxStatus } from "./helpers";
+import { initSession, seedSandboxAuthHash } from "./helpers";
 
 describe("GET /internal/state", () => {
   it("state includes sandbox after init", async () => {
@@ -191,13 +191,12 @@ describe("POST /internal/verify-sandbox-token", () => {
 
   it("validates correct token and rejects wrong token", async () => {
     const { stub } = await initSession();
-    await waitForSandboxStatus(stub, "failed");
 
     // Seed auth_token on the sandbox directly
     const authToken = "test-sandbox-auth-token-12345";
     await runInDurableObject(stub, (instance: SessionDO) => {
       instance.ctx.storage.sql.exec(
-        "UPDATE sandbox SET auth_token = ?, auth_token_hash = NULL, status = 'running' WHERE id = (SELECT id FROM sandbox LIMIT 1)",
+        "UPDATE sandbox SET auth_token = ?, auth_token_hash = NULL WHERE id = (SELECT id FROM sandbox LIMIT 1)",
         authToken
       );
     });
@@ -221,23 +220,5 @@ describe("POST /internal/verify-sandbox-token", () => {
     expect(invalidRes.status).toBe(401);
     const invalidBody = await invalidRes.json<{ valid: boolean; error: string }>();
     expect(invalidBody.valid).toBe(false);
-  });
-
-  it("rejects a retained token after the sandbox fails", async () => {
-    const { stub } = await initSession();
-    const authToken = "test-failed-sandbox-token";
-    await seedSandboxAuthHash(stub, { authToken, sandboxId: "sb-failed-token" });
-    await runInDurableObject(stub, (instance: SessionDO) => {
-      instance.ctx.storage.sql.exec("UPDATE sandbox SET status = 'failed'");
-    });
-
-    const response = await stub.fetch("http://internal/internal/verify-sandbox-token", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ token: authToken }),
-    });
-
-    expect(response.status).toBe(410);
-    expect(await response.json()).toEqual({ valid: false, error: "Sandbox not running" });
   });
 });

--- a/packages/control-plane/test/integration/websocket-sandbox.test.ts
+++ b/packages/control-plane/test/integration/websocket-sandbox.test.ts
@@ -82,6 +82,11 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
     const { stub } = await initNamedSession(name);
     await seedSandboxAuth(stub, { authToken: SANDBOX_TOKEN, sandboxId: SANDBOX_ID });
 
+    // Wait for init's fire-and-forget warmSandbox to fail (no Modal in test env).
+    // The spawn failure sets status to "failed" which we need to happen before
+    // the WS connect sets it to "ready", otherwise the two race.
+    await waitForSandboxStatus(stub, "failed");
+
     const { ws } = await openSandboxWs(name, {
       authToken: SANDBOX_TOKEN,
       sandboxId: SANDBOX_ID,


### PR DESCRIPTION
## Summary

Reverts #970 (`040154e8`), which broke sandbox token verification for **all** sandboxes in production.

**Symptom:** every sandbox-authenticated call fails — users see `Execution failed: Token refresh failed (401): {"error":"Unauthorized: Invalid sandbox token"}` when the sandbox hits `/sessions/:id/openai-token-refresh`.

**Root cause:** #970 changed the verification gate in `sandbox.handler.ts` to reject any sandbox whose status isn't `"running"` — but no production code path ever sets a sandbox row to `"running"`. The lifecycle is `spawning → connecting → ready`; the steady operational state is `"ready"` (set on sandbox WebSocket connect, `durable-object.ts:970`), and `sandbox/lifecycle/decisions.ts` treats `ready`/`running` as the operational pair. The DO's 410 is flattened by `router.ts` into the user-visible `401 "Unauthorized: Invalid sandbox token"`.

**Blast radius:** all `SANDBOX_AUTH_ROUTES` — OpenAI token refresh, PR creation, `/scm-credentials` (git credential broker, called during boot while status is still `spawning`/`connecting`, so fresh-boot clones fail too), tunnel URLs, media upload, child session spawn/list/cancel, Slack notify.

**Why #970's tests passed:** its unit tests mock `getSandbox` returning `{ status: "running" }` — a state production never produces — and the same PR edited the integration seed helpers to force `status = 'running'` into the sandbox row.

A follow-up PR will reintroduce the legitimate part of #970's intent (rejecting dead sandboxes before token comparison) with a deny-list of actually-dead states (`stopped` / `stale` / `failed`) instead of an allowlist of a state that never occurs.

## Verification

- `npm test -w @open-inspect/control-plane` — 1785 tests pass
- `npm run test:integration -w @open-inspect/control-plane` — 539 tests pass (real workerd + D1)
- `npm run typecheck -w @open-inspect/control-plane` clean
- Clean revert, no conflicts with subsequent main commits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox token verification now rejects stopped or stale sandboxes with a clear `410` response.
  * Token validation can continue for sandbox states that are not stopped or stale.
  * Improved handling of sandbox shutdown state during WebSocket upgrades.

* **Tests**
  * Updated coverage for stopped and stale sandbox token scenarios.
  * Improved integration test synchronization for sandbox lifecycle transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->