### PR TITLE
fix: reject dead sandbox states in token verification

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/decisions.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.ts
@@ -11,6 +11,25 @@
 
 import type { SandboxStatus } from "../../types";
 
+// ==================== Dead-Sandbox Policy ====================
+
+/**
+ * States in which no live sandbox can legitimately act on the session: spawn
+ * gave up (failed) or the sandbox was shut down (stopped/stale). Deny-list,
+ * not allowlist: an unknown future state is treated as live, so callers fall
+ * through to their own checks (e.g. token comparison) instead of locking out
+ * every sandbox.
+ */
+export const DEAD_SANDBOX_STATUSES: ReadonlySet<SandboxStatus> = new Set([
+  "stopped",
+  "stale",
+  "failed",
+]);
+
+export function isDeadSandboxStatus(status: SandboxStatus): boolean {
+  return DEAD_SANDBOX_STATUSES.has(status);
+}
+
 // ==================== Circuit Breaker ====================
 
 /**
@@ -346,7 +365,7 @@ export function evaluateInactivityTimeout(
   now: number
 ): InactivityAction {
   // Skip for terminal states - they don't need inactivity monitoring
-  if (state.status === "stopped" || state.status === "failed" || state.status === "stale") {
+  if (isDeadSandboxStatus(state.status)) {
     return { action: "schedule", nextCheckMs: config.minCheckIntervalMs };
   }
 

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -31,6 +31,7 @@ import {
   evaluateHeartbeatHealth,
   evaluateConnectingTimeout,
   evaluateWarmDecision,
+  isDeadSandboxStatus,
   DEFAULT_CIRCUIT_BREAKER_CONFIG,
   DEFAULT_SPAWN_CONFIG,
   DEFAULT_INACTIVITY_CONFIG,
@@ -949,8 +950,7 @@ export class SandboxLifecycleManager {
     }
 
     // Track previous status for non-terminal states
-    const isTerminalState =
-      sandbox.status === "stopped" || sandbox.status === "stale" || sandbox.status === "failed";
+    const isTerminalState = isDeadSandboxStatus(sandbox.status);
     const previousStatus = sandbox.status;
 
     if (!isTerminalState) {
@@ -1078,7 +1078,7 @@ export class SandboxLifecycleManager {
     });
 
     // Skip if sandbox is already in terminal state
-    if (sandbox.status === "stopped" || sandbox.status === "failed" || sandbox.status === "stale") {
+    if (isDeadSandboxStatus(sandbox.status)) {
       this.log.debug("Alarm: sandbox in terminal state, skipping", {
         sandbox_status: sandbox.status,
       });

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -909,7 +909,10 @@ export class SessionDO extends DurableObject<Env> {
       const sandbox = this.getSandbox();
       const expectedSandboxId = sandbox?.modal_sandbox_id;
 
-      // Reject connection if sandbox should be stopped (prevents reconnection after inactivity timeout)
+      // Reject connection if sandbox should be stopped (prevents reconnection after inactivity timeout).
+      // Deliberately narrower than isDeadSandboxStatus: a "failed" sandbox may
+      // still connect — a slow boot that outlived the connecting watchdog
+      // self-heals here by flipping the status back to ready.
       if (sandbox?.status === "stopped" || sandbox?.status === "stale") {
         this.log.warn("ws.connect", {
           event: "ws.connect",

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
@@ -316,45 +316,52 @@ describe("createSandboxHandler", () => {
     expect(log.warn).toHaveBeenCalledWith("Sandbox token verification failed: no sandbox");
   });
 
-  it("returns 410 when sandbox is stopped", async () => {
-    const { handler, getSandbox, log } = createHandler();
-    getSandbox.mockReturnValue({ status: "stopped" } as SandboxRow);
+  it.each(["stopped", "stale", "failed"] as const)(
+    "returns 410 without comparing the token when sandbox is %s",
+    async (status) => {
+      const { handler, getSandbox, isValidSandboxToken, log } = createHandler();
+      getSandbox.mockReturnValue({ status } as SandboxRow);
 
-    const response = await handler.verifySandboxToken(
-      new Request("http://internal/internal/verify-sandbox-token", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ token: "abc" }),
-      })
-    );
+      const response = await handler.verifySandboxToken(
+        new Request("http://internal/internal/verify-sandbox-token", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ token: "abc" }),
+        })
+      );
 
-    expect(response.status).toBe(410);
-    expect(await response.json()).toEqual({ valid: false, error: "Sandbox stopped" });
-    expect(log.warn).toHaveBeenCalledWith(
-      "Sandbox token verification failed: sandbox is stopped/stale",
-      { status: "stopped" }
-    );
-  });
+      expect(response.status).toBe(410);
+      expect(await response.json()).toEqual({ valid: false, error: "Sandbox not active" });
+      expect(log.warn).toHaveBeenCalledWith("Sandbox token verification failed: sandbox is dead", {
+        status,
+      });
+      expect(isValidSandboxToken).not.toHaveBeenCalled();
+    }
+  );
 
-  it("returns 410 when sandbox is stale", async () => {
-    const { handler, getSandbox, log } = createHandler();
-    getSandbox.mockReturnValue({ status: "stale" } as SandboxRow);
+  // Boot-time states (spawning/connecting) must authenticate — the git
+  // credential broker is called during the initial clone, before the sandbox
+  // WebSocket connect flips the status to ready. "running" is not currently
+  // produced by any lifecycle path but remains a valid live state.
+  it.each(["pending", "spawning", "connecting", "warming", "syncing", "ready", "running"] as const)(
+    "accepts a valid token when sandbox is %s",
+    async (status) => {
+      const { handler, getSandbox, isValidSandboxToken } = createHandler();
+      getSandbox.mockReturnValue({ status } as SandboxRow);
+      vi.mocked(isValidSandboxToken).mockResolvedValue(true);
 
-    const response = await handler.verifySandboxToken(
-      new Request("http://internal/internal/verify-sandbox-token", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ token: "abc" }),
-      })
-    );
+      const response = await handler.verifySandboxToken(
+        new Request("http://internal/internal/verify-sandbox-token", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ token: "abc" }),
+        })
+      );
 
-    expect(response.status).toBe(410);
-    expect(await response.json()).toEqual({ valid: false, error: "Sandbox stopped" });
-    expect(log.warn).toHaveBeenCalledWith(
-      "Sandbox token verification failed: sandbox is stopped/stale",
-      { status: "stale" }
-    );
-  });
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ valid: true });
+    }
+  );
 
   it("returns 401 when sandbox token is invalid", async () => {
     const { handler, getSandbox, isValidSandboxToken, log } = createHandler();

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
@@ -343,25 +343,31 @@ describe("createSandboxHandler", () => {
   // credential broker is called during the initial clone, before the sandbox
   // WebSocket connect flips the status to ready. "running" is not currently
   // produced by any lifecycle path but remains a valid live state.
-  it.each(["pending", "spawning", "connecting", "warming", "syncing", "ready", "running"] as const)(
-    "accepts a valid token when sandbox is %s",
-    async (status) => {
-      const { handler, getSandbox, isValidSandboxToken } = createHandler();
-      getSandbox.mockReturnValue({ status } as SandboxRow);
-      vi.mocked(isValidSandboxToken).mockResolvedValue(true);
+  it.each([
+    "pending",
+    "spawning",
+    "connecting",
+    "warming",
+    "syncing",
+    "ready",
+    "running",
+    "snapshotting",
+  ] as const)("accepts a valid token when sandbox is %s", async (status) => {
+    const { handler, getSandbox, isValidSandboxToken } = createHandler();
+    getSandbox.mockReturnValue({ status } as SandboxRow);
+    vi.mocked(isValidSandboxToken).mockResolvedValue(true);
 
-      const response = await handler.verifySandboxToken(
-        new Request("http://internal/internal/verify-sandbox-token", {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ token: "abc" }),
-        })
-      );
+    const response = await handler.verifySandboxToken(
+      new Request("http://internal/internal/verify-sandbox-token", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ token: "abc" }),
+      })
+    );
 
-      expect(response.status).toBe(200);
-      expect(await response.json()).toEqual({ valid: true });
-    }
-  );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ valid: true });
+  });
 
   it("returns 401 when sandbox token is invalid", async () => {
     const { handler, getSandbox, isValidSandboxToken, log } = createHandler();

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
@@ -5,6 +5,7 @@ import {
   type CreateMediaArtifactRequest,
   type SessionArtifact,
 } from "@open-inspect/shared";
+import type { SandboxStatus } from "@open-inspect/shared";
 import type { ParticipantRole, SandboxEvent, ServerMessage } from "../../../types";
 import type { OpenAITokenRefreshResult } from "../../openai-token-refresh-service";
 import type { ScmCredentialsResult } from "../../scm-credentials-service";
@@ -12,6 +13,15 @@ import type { SessionRepository } from "../../repository";
 import type { SandboxRow, SessionRow } from "../../types";
 import { assertArtifactType } from "../../artifacts";
 import { parseTunnelUrls } from "../../tunnel-urls";
+
+/**
+ * States in which no live sandbox can legitimately hold this token. Everything
+ * else — including boot-time states (spawning/connecting), where the git
+ * credential broker is already called, and the post-connect steady state
+ * (ready) — must authenticate. Deny-list, not allowlist: an unknown future
+ * state defaults to letting the token comparison decide.
+ */
+const DEAD_SANDBOX_STATUSES: ReadonlySet<SandboxStatus> = new Set(["stopped", "stale", "failed"]);
 
 interface AddParticipantRequest {
   userId: string;
@@ -183,11 +193,11 @@ export function createSandboxHandler(deps: SandboxHandlerDeps): SandboxHandler {
         return Response.json({ valid: false, error: "No sandbox" }, { status: 404 });
       }
 
-      if (sandbox.status === "stopped" || sandbox.status === "stale") {
-        deps.getLog().warn("Sandbox token verification failed: sandbox is stopped/stale", {
+      if (DEAD_SANDBOX_STATUSES.has(sandbox.status)) {
+        deps.getLog().warn("Sandbox token verification failed: sandbox is dead", {
           status: sandbox.status,
         });
-        return Response.json({ valid: false, error: "Sandbox stopped" }, { status: 410 });
+        return Response.json({ valid: false, error: "Sandbox not active" }, { status: 410 });
       }
 
       const isTokenValid = await deps.isValidSandboxToken(token, sandbox);

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
@@ -5,23 +5,14 @@ import {
   type CreateMediaArtifactRequest,
   type SessionArtifact,
 } from "@open-inspect/shared";
-import type { SandboxStatus } from "@open-inspect/shared";
 import type { ParticipantRole, SandboxEvent, ServerMessage } from "../../../types";
+import { isDeadSandboxStatus } from "../../../sandbox/lifecycle/decisions";
 import type { OpenAITokenRefreshResult } from "../../openai-token-refresh-service";
 import type { ScmCredentialsResult } from "../../scm-credentials-service";
 import type { SessionRepository } from "../../repository";
 import type { SandboxRow, SessionRow } from "../../types";
 import { assertArtifactType } from "../../artifacts";
 import { parseTunnelUrls } from "../../tunnel-urls";
-
-/**
- * States in which no live sandbox can legitimately hold this token. Everything
- * else — including boot-time states (spawning/connecting), where the git
- * credential broker is already called, and the post-connect steady state
- * (ready) — must authenticate. Deny-list, not allowlist: an unknown future
- * state defaults to letting the token comparison decide.
- */
-const DEAD_SANDBOX_STATUSES: ReadonlySet<SandboxStatus> = new Set(["stopped", "stale", "failed"]);
 
 interface AddParticipantRequest {
   userId: string;
@@ -193,7 +184,10 @@ export function createSandboxHandler(deps: SandboxHandlerDeps): SandboxHandler {
         return Response.json({ valid: false, error: "No sandbox" }, { status: 404 });
       }
 
-      if (DEAD_SANDBOX_STATUSES.has(sandbox.status)) {
+      // Boot-time states (spawning/connecting) must authenticate — the git
+      // credential broker is already called during the initial clone, before
+      // the WebSocket connect flips the status to ready.
+      if (isDeadSandboxStatus(sandbox.status)) {
         deps.getLog().warn("Sandbox token verification failed: sandbox is dead", {
           status: sandbox.status,
         });

--- a/packages/control-plane/test/integration/helpers.ts
+++ b/packages/control-plane/test/integration/helpers.ts
@@ -1,4 +1,5 @@
 import { SELF, env, runInDurableObject } from "cloudflare:test";
+import type { SandboxStatus } from "../../src/types";
 import type { SessionDO } from "../../src/session/durable-object";
 import { hashToken } from "../../src/auth/crypto";
 
@@ -274,44 +275,48 @@ export async function openSandboxWs(
 }
 
 /**
- * Seed a live sandbox with auth_token and modal_sandbox_id so sandbox
- * WebSocket auth can pass. Waits out the (always-failing) test spawn first so
- * its status write can't clobber the seeded 'ready' state.
+ * Seed a sandbox with auth_token and modal_sandbox_id so sandbox auth can
+ * pass, in the given lifecycle status (default: the "ready" steady state).
+ * Waits out the (always-failing) test spawn first so its status write can't
+ * clobber the seeded status.
  */
 export async function seedSandboxAuth(
   stub: DurableObjectStub,
-  opts: { authToken: string; sandboxId: string }
+  opts: { authToken: string; sandboxId: string; status?: SandboxStatus }
 ): Promise<void> {
   await waitForSandboxStatus(stub, "failed");
   const tokenHash = await hashToken(opts.authToken);
 
   await runInDurableObject(stub, (instance: SessionDO) => {
     instance.ctx.storage.sql.exec(
-      "UPDATE sandbox SET auth_token = ?, auth_token_hash = ?, modal_sandbox_id = ?, status = 'ready'",
+      "UPDATE sandbox SET auth_token = ?, auth_token_hash = ?, modal_sandbox_id = ?, status = ?",
       opts.authToken,
       tokenHash,
-      opts.sandboxId
+      opts.sandboxId,
+      opts.status ?? "ready"
     );
   });
 }
 
 /**
- * Seed a live sandbox with auth_token_hash and modal_sandbox_id. Waits out the
+ * Seed a sandbox with auth_token_hash and modal_sandbox_id, in the given
+ * lifecycle status (default: the "ready" steady state). Waits out the
  * (always-failing) test spawn first so its status write can't clobber the
- * seeded 'ready' state.
+ * seeded status.
  */
 export async function seedSandboxAuthHash(
   stub: DurableObjectStub,
-  opts: { authToken: string; sandboxId: string }
+  opts: { authToken: string; sandboxId: string; status?: SandboxStatus }
 ): Promise<void> {
   await waitForSandboxStatus(stub, "failed");
   const tokenHash = await hashToken(opts.authToken);
 
   await runInDurableObject(stub, (instance: SessionDO) => {
     instance.ctx.storage.sql.exec(
-      "UPDATE sandbox SET auth_token_hash = ?, auth_token = NULL, modal_sandbox_id = ?, status = 'ready'",
+      "UPDATE sandbox SET auth_token_hash = ?, auth_token = NULL, modal_sandbox_id = ?, status = ?",
       tokenHash,
-      opts.sandboxId
+      opts.sandboxId,
+      opts.status ?? "ready"
     );
   });
 }

--- a/packages/control-plane/test/integration/helpers.ts
+++ b/packages/control-plane/test/integration/helpers.ts
@@ -274,18 +274,20 @@ export async function openSandboxWs(
 }
 
 /**
- * Seed auth_token and modal_sandbox_id on the sandbox row so sandbox
- * WebSocket auth can pass.
+ * Seed a live sandbox with auth_token and modal_sandbox_id so sandbox
+ * WebSocket auth can pass. Waits out the (always-failing) test spawn first so
+ * its status write can't clobber the seeded 'ready' state.
  */
 export async function seedSandboxAuth(
   stub: DurableObjectStub,
   opts: { authToken: string; sandboxId: string }
 ): Promise<void> {
+  await waitForSandboxStatus(stub, "failed");
   const tokenHash = await hashToken(opts.authToken);
 
   await runInDurableObject(stub, (instance: SessionDO) => {
     instance.ctx.storage.sql.exec(
-      "UPDATE sandbox SET auth_token = ?, auth_token_hash = ?, modal_sandbox_id = ?",
+      "UPDATE sandbox SET auth_token = ?, auth_token_hash = ?, modal_sandbox_id = ?, status = 'ready'",
       opts.authToken,
       tokenHash,
       opts.sandboxId
@@ -294,17 +296,20 @@ export async function seedSandboxAuth(
 }
 
 /**
- * Seed auth_token_hash and modal_sandbox_id on the sandbox row.
+ * Seed a live sandbox with auth_token_hash and modal_sandbox_id. Waits out the
+ * (always-failing) test spawn first so its status write can't clobber the
+ * seeded 'ready' state.
  */
 export async function seedSandboxAuthHash(
   stub: DurableObjectStub,
   opts: { authToken: string; sandboxId: string }
 ): Promise<void> {
+  await waitForSandboxStatus(stub, "failed");
   const tokenHash = await hashToken(opts.authToken);
 
   await runInDurableObject(stub, (instance: SessionDO) => {
     instance.ctx.storage.sql.exec(
-      "UPDATE sandbox SET auth_token_hash = ?, auth_token = NULL, modal_sandbox_id = ?",
+      "UPDATE sandbox SET auth_token_hash = ?, auth_token = NULL, modal_sandbox_id = ?, status = 'ready'",
       tokenHash,
       opts.sandboxId
     );

--- a/packages/control-plane/test/integration/session-lifecycle.test.ts
+++ b/packages/control-plane/test/integration/session-lifecycle.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { runInDurableObject } from "cloudflare:test";
 import type { SessionDO } from "../../src/session/durable-object";
-import { initSession, seedSandboxAuthHash } from "./helpers";
+import { initSession, seedSandboxAuthHash, waitForSandboxStatus } from "./helpers";
 
 describe("GET /internal/state", () => {
   it("state includes sandbox after init", async () => {
@@ -191,12 +191,13 @@ describe("POST /internal/verify-sandbox-token", () => {
 
   it("validates correct token and rejects wrong token", async () => {
     const { stub } = await initSession();
+    await waitForSandboxStatus(stub, "failed");
 
-    // Seed auth_token on the sandbox directly
+    // Seed auth_token on a live sandbox directly
     const authToken = "test-sandbox-auth-token-12345";
     await runInDurableObject(stub, (instance: SessionDO) => {
       instance.ctx.storage.sql.exec(
-        "UPDATE sandbox SET auth_token = ?, auth_token_hash = NULL WHERE id = (SELECT id FROM sandbox LIMIT 1)",
+        "UPDATE sandbox SET auth_token = ?, auth_token_hash = NULL, status = 'ready' WHERE id = (SELECT id FROM sandbox LIMIT 1)",
         authToken
       );
     });

--- a/packages/control-plane/test/integration/websocket-sandbox.test.ts
+++ b/packages/control-plane/test/integration/websocket-sandbox.test.ts
@@ -102,6 +102,28 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
     ws!.close();
   });
 
+  it("failed sandbox can reconnect and self-heal to ready", async () => {
+    const name = `ws-sandbox-selfheal-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+    // The WS upgrade gate deliberately admits "failed" sandboxes: a slow boot
+    // that outlived the connecting watchdog recovers here, unlike stopped or
+    // stale which are rejected with 410.
+    await seedSandboxAuth(stub, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+      status: "failed",
+    });
+
+    const { ws } = await openSandboxWs(name, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+    });
+    expect(ws).not.toBeNull();
+    ws!.accept();
+    await waitForSandboxStatus(stub, "ready");
+    ws!.close();
+  });
+
   it("sandbox WS message is stored as event", async () => {
     const name = `ws-sandbox-event-${Date.now()}`;
     const { stub } = await initNamedSession(name);

--- a/packages/control-plane/test/integration/websocket-sandbox.test.ts
+++ b/packages/control-plane/test/integration/websocket-sandbox.test.ts
@@ -61,12 +61,11 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
     const name = `ws-sandbox-stopped-${Date.now()}`;
     const { stub } = await initNamedSession(name);
 
-    // Wait for init's fire-and-forget warmSandbox to fail (no Modal in test env)
-    // before forcing stopped, otherwise it can race and overwrite the status.
-    await waitForSandboxStatus(stub, "failed");
-
-    await seedSandboxAuth(stub, { authToken: SANDBOX_TOKEN, sandboxId: SANDBOX_ID });
-    await queryDO(stub, "UPDATE sandbox SET status = ?", "stopped");
+    await seedSandboxAuth(stub, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+      status: "stopped",
+    });
 
     const { ws, response } = await openSandboxWs(name, {
       authToken: SANDBOX_TOKEN,
@@ -80,11 +79,13 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
   it("sandbox connect sets status to ready", async () => {
     const name = `ws-sandbox-ready-${Date.now()}`;
     const { stub } = await initNamedSession(name);
-    await seedSandboxAuth(stub, { authToken: SANDBOX_TOKEN, sandboxId: SANDBOX_ID });
-
     // Model the production boot sequence: the sandbox connects while the
     // lifecycle is still in "connecting", and the WS accept flips it to ready.
-    await queryDO(stub, "UPDATE sandbox SET status = ?", "connecting");
+    await seedSandboxAuth(stub, {
+      authToken: SANDBOX_TOKEN,
+      sandboxId: SANDBOX_ID,
+      status: "connecting",
+    });
 
     const { ws } = await openSandboxWs(name, {
       authToken: SANDBOX_TOKEN,

--- a/packages/control-plane/test/integration/websocket-sandbox.test.ts
+++ b/packages/control-plane/test/integration/websocket-sandbox.test.ts
@@ -82,10 +82,9 @@ describe("Sandbox WebSocket (via SELF.fetch)", () => {
     const { stub } = await initNamedSession(name);
     await seedSandboxAuth(stub, { authToken: SANDBOX_TOKEN, sandboxId: SANDBOX_ID });
 
-    // Wait for init's fire-and-forget warmSandbox to fail (no Modal in test env).
-    // The spawn failure sets status to "failed" which we need to happen before
-    // the WS connect sets it to "ready", otherwise the two race.
-    await waitForSandboxStatus(stub, "failed");
+    // Model the production boot sequence: the sandbox connects while the
+    // lifecycle is still in "connecting", and the WS accept flips it to ready.
+    await queryDO(stub, "UPDATE sandbox SET status = ?", "connecting");
 
     const { ws } = await openSandboxWs(name, {
       authToken: SANDBOX_TOKEN,


### PR DESCRIPTION
## Summary

Fix-forward for #970 (reverted in #980). Reintroduces its legitimate intent — rejecting dead sandboxes before token comparison — as a **deny-list** instead of an allowlist of a state that never occurs.

`verifySandboxToken` now returns 410 for `stopped | stale | failed` (previously only `stopped | stale`; `failed` is the state #970 legitimately added). All live states authenticate normally:

- **`spawning` / `connecting`** — boot-time states during which the sandbox already calls `/scm-credentials` (git credential broker) for the initial clone, before the WebSocket connect flips status to `ready`
- **`ready`** — the post-connect steady state (what #970's `!== "running"` allowlist broke, since no lifecycle path ever sets `"running"`)
- deny-list semantics mean an unknown future state defaults to letting the token comparison decide, rather than silently locking out every sandbox again

## Test changes

- Handler unit tests: parameterized 410 case over `stopped`/`stale`/`failed` asserting the token comparison is never reached, plus a new acceptance guard asserting a valid token passes in **every** live state (`pending`, `spawning`, `connecting`, `warming`, `syncing`, `ready`, `running`) — this is the test that would have caught #970.
- Integration seed helpers (`seedSandboxAuth`/`seedSandboxAuthHash`): now wait out the always-failing test spawn and seed `status = 'ready'` — the real steady state, not the fictional `'running'` #970 seeded.
- `websocket-sandbox` "connect sets status to ready" test now models the production boot sequence: seeds, forces `connecting`, and proves the WS accept flips it to `ready`.

## Verification

- `npm test -w @open-inspect/control-plane` — 1793 tests pass
- `npm run test:integration -w @open-inspect/control-plane` — 539 tests pass (real workerd + D1)
- `npm run typecheck -w @open-inspect/control-plane` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox token validation now consistently rejects all inactive “dead” states (`stopped`, `stale`, `failed`) with HTTP `410` and `{ valid: false, error: "Sandbox not active" }`.
  * Tokens remain valid throughout supported boot and operational lifecycle states until the sandbox is active.
  * Sandbox WebSocket upgrade flow now more reliably transitions the sandbox to `ready` during connection.
* **Tests**
  * Expanded parameterized coverage for sandbox lifecycle states and token verification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Known trade-off

If the connecting-timeout watchdog marks a sandbox `failed` while it is actually still booting **and** the provider stop call fails, that sandbox's boot-time HTTP calls (e.g. the git credential broker) now get 410/401 until it self-heals. This is deliberate: the control plane has already declared that sandbox dead, and the WebSocket upgrade gate still admits `failed` sandboxes — a late connect flips the status back to `ready` (now covered by an integration test), after which HTTP auth works again. This window cannot reproduce the #970 incident mode: all 8 live states pass verification.

## Independent validation

An adversarial validation pass confirmed: the policy consolidation is behavior-identical at all four sites (each previously checked exactly `{stopped, stale, failed}`); the 410 body-string change is wire-inert (the router only checks `response.ok`; no package matches on the old strings; `bridge.py`'s 410 handling applies only to the unchanged WS path); and the new live-state acceptance guard empirically fails 10 tests against the #970 implementation — it is a real regression tripwire.
