### PR TITLE
fix: harden Slack session launch flows

### DIFF
--- a/packages/slack-bot/src/events/dispatcher.ts
+++ b/packages/slack-bot/src/events/dispatcher.ts
@@ -59,8 +59,20 @@ export async function handleSlackEvent(
     );
     return;
   }
-  if (event.type === "app_mention" && event.text && event.channel && event.ts) {
-    await handleAppMention(event as Required<typeof event>, env, traceId, scheduleBackground);
+  if (event.type === "app_mention" && event.text && event.user && event.channel && event.ts) {
+    await handleAppMention(
+      {
+        type: event.type,
+        text: event.text,
+        user: event.user,
+        channel: event.channel,
+        ts: event.ts,
+        thread_ts: event.thread_ts,
+      },
+      env,
+      traceId,
+      scheduleBackground
+    );
     return;
   }
   if (event.type === "message") await handleChannelTrigger(event, env, traceId);

--- a/packages/slack-bot/src/events/message-handler.ts
+++ b/packages/slack-bot/src/events/message-handler.ts
@@ -87,7 +87,7 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
         callbackContext,
         traceId
       );
-      if (promptResult) {
+      if (promptResult.ok) {
         const reactionResult = await addReaction(env.SLACK_BOT_TOKEN, channel, ts, "eyes");
         if (!reactionResult.ok && reactionResult.error !== "already_reacted") {
           log.warn("slack.reaction.add", {
@@ -98,6 +98,15 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
             slack_error: reactionResult.error,
           });
         }
+        return;
+      }
+      if (promptResult.reason === "transient") {
+        await postMessage(
+          env.SLACK_BOT_TOKEN,
+          channel,
+          "Sorry, I couldn't send your follow-up. Please try again.",
+          { thread_ts: threadTs }
+        );
         return;
       }
       log.warn("thread_session.stale", {

--- a/packages/slack-bot/src/events/message-handler.ts
+++ b/packages/slack-bot/src/events/message-handler.ts
@@ -64,27 +64,6 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
     return;
   }
 
-  let previousMessages: string[] | undefined;
-  if (threadTs) {
-    try {
-      const threadResult = await getThreadMessages(env.SLACK_BOT_TOKEN, channel, threadTs, 10);
-      if (threadResult.ok && threadResult.messages) {
-        const filtered = threadResult.messages.filter((m) => m.ts !== ts);
-        const uniqueUserIds = [...new Set(filtered.map((m) => m.user).filter(Boolean))] as string[];
-        const userNames = await resolveUserNames(env.SLACK_BOT_TOKEN, uniqueUserIds);
-        previousMessages = filtered
-          .map((m) => {
-            if (m.bot_id) return `[Bot]: ${m.text}`;
-            const name = m.user ? userNames.get(m.user) || m.user : "Unknown";
-            return `[${name}]: ${m.text}`;
-          })
-          .slice(-10);
-      }
-    } catch {
-      // Thread context is best effort.
-    }
-  }
-
   if (threadTs) {
     const existingSession = await lookupThreadSession(env, channel, threadTs);
     if (existingSession) {
@@ -128,6 +107,27 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
         thread_ts: threadTs,
       });
       await clearThreadSession(env, channel, threadTs);
+    }
+  }
+
+  let previousMessages: string[] | undefined;
+  if (threadTs) {
+    try {
+      const threadResult = await getThreadMessages(env.SLACK_BOT_TOKEN, channel, threadTs, 10);
+      if (threadResult.ok && threadResult.messages) {
+        const filtered = threadResult.messages.filter((m) => m.ts !== ts);
+        const uniqueUserIds = [...new Set(filtered.map((m) => m.user).filter(Boolean))] as string[];
+        const userNames = await resolveUserNames(env.SLACK_BOT_TOKEN, uniqueUserIds);
+        previousMessages = filtered
+          .map((m) => {
+            if (m.bot_id) return `[Bot]: ${m.text}`;
+            const name = m.user ? userNames.get(m.user) || m.user : "Unknown";
+            return `[${name}]: ${m.text}`;
+          })
+          .slice(-10);
+      }
+    } catch {
+      // Thread context is best effort.
     }
   }
 

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -158,7 +158,11 @@ async function flushWaitUntil(ctx: ReturnType<typeof makeCtx>, callIndex = 0): P
 
 function makeSessionEnv(
   order: string[] = [],
-  responses: { session?: unknown; prompt?: unknown | unknown[] } = {}
+  responses: {
+    session?: unknown;
+    prompt?: unknown | unknown[];
+    promptStatus?: number | number[];
+  } = {}
 ): Env {
   const env = makeEnv();
   let promptResponseIndex = 0;
@@ -203,8 +207,11 @@ function makeSessionEnv(
         const promptResponse = Array.isArray(responses.prompt)
           ? responses.prompt[promptResponseIndex++]
           : responses.prompt;
+        const promptStatus = Array.isArray(responses.promptStatus)
+          ? responses.promptStatus[promptResponseIndex - 1]
+          : responses.promptStatus;
         return new Response(JSON.stringify(promptResponse ?? { messageId: "msg-1" }), {
-          status: 200,
+          status: promptStatus ?? 200,
           headers: { "Content-Type": "application/json" },
         });
       }
@@ -764,12 +771,63 @@ describe("POST /events", () => {
     slackFetch.mockRestore();
   });
 
+  it("preserves an existing session mapping after a transient prompt failure", async () => {
+    const order: string[] = [];
+    const slackFetch = mockSlackFetch(order);
+    const env = makeSessionEnv(order, { prompt: {} });
+    const kv = env.SLACK_KV as unknown as {
+      put: (key: string, value: string) => Promise<void>;
+      delete: ReturnType<typeof vi.fn>;
+      get: (key: string, type: string) => Promise<unknown>;
+    };
+    const mapping = {
+      sessionId: "session-1",
+      repoId: "acme/app",
+      repoFullName: "acme/app",
+      model: "anthropic/claude-haiku-4-5",
+      createdAt: Date.now(),
+    };
+    await kv.put("thread:C123:111.222", JSON.stringify(mapping));
+    const ctx = makeCtx();
+
+    const response = await app.fetch(
+      slackEventRequest({
+        type: "app_mention",
+        text: "<@B123> now add coverage",
+        user: "U123",
+        channel: "C123",
+        ts: "333.444",
+        thread_ts: "111.222",
+      }),
+      env,
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    await flushWaitUntil(ctx);
+
+    expect(order).not.toContain("session");
+    expect(kv.delete).not.toHaveBeenCalledWith("thread:C123:111.222");
+    await expect(kv.get("thread:C123:111.222", "json")).resolves.toEqual(mapping);
+    expect(slackApiBodies(slackFetch, "chat.postMessage")).toContainEqual(
+      expect.objectContaining({ text: "Sorry, I couldn't send your follow-up. Please try again." })
+    );
+    expect(
+      slackFetch.mock.calls.some(([input]) => String(input).includes("conversations.replies"))
+    ).toBe(false);
+
+    slackFetch.mockRestore();
+  });
+
   it("fetches thread history after an existing session proves stale", async () => {
     const order: string[] = [];
     const slackFetch = mockSlackFetch(order, {
       threadMessages: [{ type: "message", text: "Earlier request", user: "U456", ts: "111.222" }],
     });
-    const env = makeSessionEnv(order, { prompt: [{}, { messageId: "msg-2" }] });
+    const env = makeSessionEnv(order, {
+      prompt: [{ error: "Session not found" }, { messageId: "msg-2" }],
+      promptStatus: [404, 200],
+    });
     await (env.SLACK_KV as unknown as { put: (k: string, v: string) => Promise<void> }).put(
       "thread:C123:111.222",
       JSON.stringify({

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -158,9 +158,10 @@ async function flushWaitUntil(ctx: ReturnType<typeof makeCtx>, callIndex = 0): P
 
 function makeSessionEnv(
   order: string[] = [],
-  responses: { session?: unknown; prompt?: unknown } = {}
+  responses: { session?: unknown; prompt?: unknown | unknown[] } = {}
 ): Env {
   const env = makeEnv();
+  let promptResponseIndex = 0;
   (env.CONTROL_PLANE.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
     async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input.toString();
@@ -199,7 +200,10 @@ function makeSessionEnv(
 
       if (url.includes("/prompt")) {
         order.push("prompt");
-        return new Response(JSON.stringify(responses.prompt ?? { messageId: "msg-1" }), {
+        const promptResponse = Array.isArray(responses.prompt)
+          ? responses.prompt[promptResponseIndex++]
+          : responses.prompt;
+        return new Response(JSON.stringify(promptResponse ?? { messageId: "msg-1" }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         });
@@ -397,6 +401,37 @@ describe("POST /events", () => {
         ]),
       })
     );
+  });
+
+  it("does not dispatch app mentions without a user", async () => {
+    const slackFetch = mockSlackFetch([]);
+    const env = makeSessionEnv([]);
+    const ctx = makeCtx();
+
+    const response = await app.fetch(
+      slackEventRequest({
+        type: "app_mention",
+        text: "<@B123> fix the auth tests",
+        channel: "C123",
+        ts: "111.222",
+      }),
+      env,
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    await flushWaitUntil(ctx);
+
+    expect(env.CONTROL_PLANE.fetch).not.toHaveBeenCalled();
+    expect(mockGetUserInfo).not.toHaveBeenCalled();
+    expect(slackFetch).not.toHaveBeenCalled();
+    expect((env.SLACK_KV as unknown as { put: ReturnType<typeof vi.fn> }).put).toHaveBeenCalledWith(
+      expect.stringMatching(/^event:/),
+      "1",
+      { expirationTtl: 3600 }
+    );
+
+    slackFetch.mockRestore();
   });
 
   it("sets Starting status for a new app mention before session creation", async () => {
@@ -621,6 +656,10 @@ describe("POST /events", () => {
         }),
       ])
     );
+    const threadMappingWrite = (
+      env.SLACK_KV as unknown as { put: ReturnType<typeof vi.fn> }
+    ).put.mock.calls.find(([key]) => key === "thread:C123:111.222");
+    expect(threadMappingWrite).toBeUndefined();
 
     slackFetch.mockRestore();
   });
@@ -718,6 +757,62 @@ describe("POST /events", () => {
     expect(promptBodies[0].content).toContain("Slack channel context");
     expect(promptBodies[0].content).not.toContain("Context from the Slack thread");
     expect(promptBodies[0].content).not.toContain("The latest commit is");
+    expect(
+      slackFetch.mock.calls.some(([input]) => String(input).includes("conversations.replies"))
+    ).toBe(false);
+
+    slackFetch.mockRestore();
+  });
+
+  it("fetches thread history after an existing session proves stale", async () => {
+    const order: string[] = [];
+    const slackFetch = mockSlackFetch(order, {
+      threadMessages: [{ type: "message", text: "Earlier request", user: "U456", ts: "111.222" }],
+    });
+    const env = makeSessionEnv(order, { prompt: [{}, { messageId: "msg-2" }] });
+    await (env.SLACK_KV as unknown as { put: (k: string, v: string) => Promise<void> }).put(
+      "thread:C123:111.222",
+      JSON.stringify({
+        sessionId: "stale-session",
+        repoId: "acme/app",
+        repoFullName: "acme/app",
+        model: "anthropic/claude-haiku-4-5",
+        createdAt: Date.now(),
+      })
+    );
+    const ctx = makeCtx();
+
+    const response = await app.fetch(
+      slackEventRequest({
+        type: "app_mention",
+        text: "<@B123> now add coverage",
+        user: "U123",
+        channel: "C123",
+        ts: "333.444",
+        thread_ts: "111.222",
+      }),
+      env,
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    await flushWaitUntil(ctx);
+
+    expect(
+      slackFetch.mock.calls.filter(([input]) => String(input).includes("conversations.replies"))
+    ).toHaveLength(1);
+    const promptBodies = promptFetchBodies(
+      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: readonly (readonly unknown[])[] } }
+    );
+    expect(promptBodies).toHaveLength(2);
+    expect(promptBodies[1].content).toContain("Context from the Slack thread");
+    expect(promptBodies[1].content).toContain("Earlier request");
+    const storedMapping = (
+      env.SLACK_KV as unknown as { get: (key: string, type: string) => Promise<unknown> }
+    ).get("thread:C123:111.222", "json");
+    await expect(storedMapping).resolves.toEqual(
+      expect.objectContaining({ sessionId: "session-1" })
+    );
 
     slackFetch.mockRestore();
   });
@@ -851,7 +946,7 @@ describe("POST /interactions", () => {
 
     await flushWaitUntil(ctx);
     await flushWaitUntil(ctx, 1);
-    expect(ctx.waitUntil).toHaveBeenCalledTimes(4);
+    expect(ctx.waitUntil).toHaveBeenCalledTimes(3);
 
     expect(statusFetchBodies(slackFetch)).toContainEqual({
       channel_id: "C123",
@@ -859,7 +954,7 @@ describe("POST /interactions", () => {
       status: "Starting...",
       loading_messages: ["Starting..."],
     });
-    expect(startingStatusBodies(slackFetch)).toHaveLength(3);
+    expect(startingStatusBodies(slackFetch)).toHaveLength(2);
     expect(order.indexOf("repos")).toBeLessThan(order.indexOf("status"));
     expect(order.indexOf("status")).toBeLessThan(order.indexOf("session"));
 
@@ -1359,7 +1454,7 @@ describe("POST /interactions", () => {
 
     await flushWaitUntil(ctx);
     await flushWaitUntil(ctx, 1);
-    expect(ctx.waitUntil).toHaveBeenCalledTimes(4);
+    expect(ctx.waitUntil).toHaveBeenCalledTimes(3);
 
     const sessionCall = (
       env.CONTROL_PLANE.fetch as unknown as { mock: { calls: unknown[][] } }

--- a/packages/slack-bot/src/interactions/target-selection.ts
+++ b/packages/slack-bot/src/interactions/target-selection.ts
@@ -50,7 +50,6 @@ export async function handleTargetSelection(
     blocks: buildWorkingMessageBlocks(label),
   });
   const ackTs = ackResult.ok ? ackResult.ts : undefined;
-  scheduleStartingStatus(scheduleBackground, env, channel, threadKey, traceId);
   const sessionResult = await startSessionAndSendPrompt(
     env,
     target,

--- a/packages/slack-bot/src/pending-requests/pending-request-store.test.ts
+++ b/packages/slack-bot/src/pending-requests/pending-request-store.test.ts
@@ -57,4 +57,33 @@ describe("pending request store", () => {
     await expect(getPendingRequest(mocks.env, "C123", "111.222")).resolves.toBeNull();
     await expect(getPendingRequest(mocks.env, "C123", "111.222")).resolves.toBeNull();
   });
+
+  it.each([
+    {},
+    [],
+    { message: "Fix it" },
+    { userId: "U123" },
+    { message: 123, userId: "U123" },
+    { message: "Fix it", userId: "" },
+    { message: "Fix it", userId: "U123", previousMessages: ["valid", 123] },
+    { message: "Fix it", userId: "U123", channelName: 123 },
+  ])("rejects malformed records: %j", async (record) => {
+    mocks.get.mockResolvedValue(record);
+
+    await expect(getPendingRequest(mocks.env, "C123", "111.222")).resolves.toBeNull();
+  });
+
+  it("accepts valid minimal and complete records", async () => {
+    const minimal = { message: "Fix it", userId: "U123" };
+    const complete = {
+      ...minimal,
+      previousMessages: ["Earlier context"],
+      channelName: "engineering",
+      channelDescription: "Build discussion",
+    };
+    mocks.get.mockResolvedValueOnce(minimal).mockResolvedValueOnce(complete);
+
+    await expect(getPendingRequest(mocks.env, "C123", "111.222")).resolves.toEqual(minimal);
+    await expect(getPendingRequest(mocks.env, "C123", "111.222")).resolves.toEqual(complete);
+  });
 });

--- a/packages/slack-bot/src/pending-requests/pending-request-store.ts
+++ b/packages/slack-bot/src/pending-requests/pending-request-store.ts
@@ -1,15 +1,18 @@
 import { createKvCacheStore } from "@open-inspect/shared";
+import { z } from "zod";
 import type { Env } from "../types";
 
 const PENDING_REQUEST_TTL_MS = 60 * 60 * 1000;
 
-export interface PendingRequest {
-  message: string;
-  userId: string;
-  previousMessages?: string[];
-  channelName?: string;
-  channelDescription?: string;
-}
+const pendingRequestSchema = z.object({
+  message: z.string().min(1),
+  userId: z.string().min(1),
+  previousMessages: z.array(z.string()).optional(),
+  channelName: z.string().optional(),
+  channelDescription: z.string().optional(),
+});
+
+export type PendingRequest = z.infer<typeof pendingRequestSchema>;
 
 function pendingRequestKey(channel: string, threadTs: string): string {
   return `pending:${channel}:${threadTs}`;
@@ -37,7 +40,8 @@ export async function getPendingRequest(
     pendingRequestKey(channel, threadTs),
     "json"
   );
-  return data && typeof data === "object" ? (data as PendingRequest) : null;
+  const result = pendingRequestSchema.safeParse(data);
+  return result.success ? result.data : null;
 }
 
 export async function deletePendingRequest(

--- a/packages/slack-bot/src/routes/events.ts
+++ b/packages/slack-bot/src/routes/events.ts
@@ -5,6 +5,7 @@ import { createLogger } from "../logger";
 import type { Env } from "../types";
 
 const log = createLogger("handler");
+const EVENT_DEDUPE_TTL_MS = 60 * 60 * 1000;
 export const eventRoutes = new Hono<{ Bindings: Env }>();
 
 eventRoutes.post("/events", async (c) => {
@@ -43,7 +44,7 @@ eventRoutes.post("/events", async (c) => {
       log.debug("slack.event.duplicate", { trace_id: traceId, event_id: eventId });
       return c.json({ ok: true });
     }
-    await cacheStore.put(dedupeKey, "1", { expirationTtl: 3600 });
+    await cacheStore.put(dedupeKey, "1", { expirationTtl: EVENT_DEDUPE_TTL_MS / 1000 });
   }
   const scheduleBackground = (promise: Promise<void>) => c.executionCtx.waitUntil(promise);
   const eventTask = Promise.resolve().then(() =>

--- a/packages/slack-bot/src/sessions/control-plane-client.test.ts
+++ b/packages/slack-bot/src/sessions/control-plane-client.test.ts
@@ -67,8 +67,20 @@ describe("control plane client timeouts", () => {
     await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce());
     controller.abort(new DOMException("Timed out", "TimeoutError"));
 
-    await expect(result).resolves.toBeNull();
+    await expect(result).resolves.toEqual({ ok: false, reason: "transient" });
     expect(timeoutSpy).toHaveBeenCalledWith(CONTROL_PLANE_REQUEST_TIMEOUT_MS);
     expect(fetch.mock.calls[0]?.[1]?.signal).toBe(controller.signal);
+  });
+
+  it("classifies only not-found prompt responses as stale", async () => {
+    const notFoundFetch = vi.fn(async () => new Response(null, { status: 404 }));
+    const serverErrorFetch = vi.fn(async () => new Response(null, { status: 503 }));
+
+    await expect(
+      sendPrompt(makeEnv(notFoundFetch), "missing-session", "Fix it", "slack:U123")
+    ).resolves.toEqual({ ok: false, reason: "stale" });
+    await expect(
+      sendPrompt(makeEnv(serverErrorFetch), "session-1", "Fix it", "slack:U123")
+    ).resolves.toEqual({ ok: false, reason: "transient" });
   });
 });

--- a/packages/slack-bot/src/sessions/control-plane-client.test.ts
+++ b/packages/slack-bot/src/sessions/control-plane-client.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "../types";
+import {
+  CONTROL_PLANE_REQUEST_TIMEOUT_MS,
+  createSession,
+  sendPrompt,
+} from "./control-plane-client";
+
+function makeEnv(fetch: ReturnType<typeof vi.fn>): Env {
+  return {
+    CONTROL_PLANE: { fetch } as unknown as Fetcher,
+    INTERNAL_CALLBACK_SECRET: "test-secret",
+    LOG_LEVEL: "error",
+  } as Env;
+}
+
+const target = {
+  kind: "repository" as const,
+  repo: {
+    id: "acme/app",
+    owner: "acme",
+    name: "app",
+    fullName: "acme/app",
+    displayName: "acme/app",
+    description: "Application repository",
+    defaultBranch: "main",
+    private: true,
+  },
+};
+
+describe("control plane client timeouts", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("aborts session creation after the control plane timeout", async () => {
+    const controller = new AbortController();
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
+    const fetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason));
+      });
+    });
+    const result = createSession(makeEnv(fetch), {
+      target,
+      model: "openai/gpt-5.4",
+    });
+
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    controller.abort(new DOMException("Timed out", "TimeoutError"));
+
+    await expect(result).resolves.toBeNull();
+    expect(timeoutSpy).toHaveBeenCalledWith(CONTROL_PLANE_REQUEST_TIMEOUT_MS);
+    expect(fetch.mock.calls[0]?.[1]?.signal).toBe(controller.signal);
+  });
+
+  it("aborts prompt delivery after the control plane timeout", async () => {
+    const controller = new AbortController();
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
+    const fetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason));
+      });
+    });
+    const result = sendPrompt(makeEnv(fetch), "session-1", "Fix it", "slack:U123");
+
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    controller.abort(new DOMException("Timed out", "TimeoutError"));
+
+    await expect(result).resolves.toBeNull();
+    expect(timeoutSpy).toHaveBeenCalledWith(CONTROL_PLANE_REQUEST_TIMEOUT_MS);
+    expect(fetch.mock.calls[0]?.[1]?.signal).toBe(controller.signal);
+  });
+});

--- a/packages/slack-bot/src/sessions/control-plane-client.ts
+++ b/packages/slack-bot/src/sessions/control-plane-client.ts
@@ -23,6 +23,10 @@ interface CreateSessionOptions {
   actorEmail?: string;
 }
 
+export type SendPromptResult =
+  | { ok: true; data: SendPromptResponse }
+  | { ok: false; reason: "stale" | "transient" };
+
 export async function createSession(
   env: Env,
   options: CreateSessionOptions
@@ -107,7 +111,7 @@ export async function sendPrompt(
   authorId: string,
   callbackContext?: CallbackContext,
   traceId?: string
-): Promise<SendPromptResponse | null> {
+): Promise<SendPromptResult> {
   const startTime = Date.now();
   const base = { trace_id: traceId, session_id: sessionId, source: "slack" };
   try {
@@ -128,7 +132,7 @@ export async function sendPrompt(
         http_status: response.status,
         duration_ms: Date.now() - startTime,
       });
-      return null;
+      return { ok: false, reason: response.status === 404 ? "stale" : "transient" };
     }
     const result = sendPromptResponseSchema.safeParse(await response.json());
     if (!result.success) {
@@ -138,7 +142,7 @@ export async function sendPrompt(
         error: new Error("Invalid control plane send prompt response"),
         duration_ms: Date.now() - startTime,
       });
-      return null;
+      return { ok: false, reason: "transient" };
     }
     log.info("control_plane.send_prompt", {
       ...base,
@@ -147,7 +151,7 @@ export async function sendPrompt(
       http_status: 200,
       duration_ms: Date.now() - startTime,
     });
-    return result.data;
+    return { ok: true, data: result.data };
   } catch (e) {
     log.error("control_plane.send_prompt", {
       ...base,
@@ -155,6 +159,6 @@ export async function sendPrompt(
       error: e instanceof Error ? e : new Error(String(e)),
       duration_ms: Date.now() - startTime,
     });
-    return null;
+    return { ok: false, reason: "transient" };
   }
 }

--- a/packages/slack-bot/src/sessions/control-plane-client.ts
+++ b/packages/slack-bot/src/sessions/control-plane-client.ts
@@ -10,18 +10,33 @@ import { buildSessionTargetRequestFields, targetId, type SlackSessionTarget } fr
 import type { CallbackContext, Env } from "../types";
 
 const log = createLogger("handler");
+export const CONTROL_PLANE_REQUEST_TIMEOUT_MS = 10_000;
+
+interface CreateSessionOptions {
+  target: SlackSessionTarget;
+  model: string;
+  reasoningEffort?: string;
+  branch?: string;
+  traceId?: string;
+  slackUserId?: string;
+  actorDisplayName?: string;
+  actorEmail?: string;
+}
 
 export async function createSession(
   env: Env,
-  target: SlackSessionTarget,
-  model: string,
-  reasoningEffort: string | undefined,
-  branch: string | undefined,
-  traceId?: string,
-  slackUserId?: string,
-  actorDisplayName?: string,
-  actorEmail?: string
+  options: CreateSessionOptions
 ): Promise<CreateSessionResponse | null> {
+  const {
+    target,
+    model,
+    reasoningEffort,
+    branch,
+    traceId,
+    slackUserId,
+    actorDisplayName,
+    actorEmail,
+  } = options;
   const startTime = Date.now();
   const base = {
     trace_id: traceId,
@@ -45,6 +60,7 @@ export async function createSession(
         actorDisplayName,
         actorEmail,
       }),
+      signal: AbortSignal.timeout(CONTROL_PLANE_REQUEST_TIMEOUT_MS),
     });
     if (!response.ok) {
       log.error("control_plane.create_session", {
@@ -102,6 +118,7 @@ export async function sendPrompt(
         method: "POST",
         headers,
         body: JSON.stringify({ content, authorId, source: "slack", callbackContext }),
+        signal: AbortSignal.timeout(CONTROL_PLANE_REQUEST_TIMEOUT_MS),
       }
     );
     if (!response.ok) {

--- a/packages/slack-bot/src/sessions/session-launcher.ts
+++ b/packages/slack-bot/src/sessions/session-launcher.ts
@@ -53,17 +53,16 @@ export async function startSessionAndSendPrompt(
     // Identity linking is best effort.
   }
 
-  const session = await createSession(
-    env,
+  const session = await createSession(env, {
     target,
     model,
     reasoningEffort,
     branch,
     traceId,
-    userId,
-    displayName,
-    email
-  );
+    slackUserId: userId,
+    actorDisplayName: displayName,
+    actorEmail: email,
+  });
   if (!session) {
     await postMessage(
       env.SLACK_BOT_TOKEN,
@@ -74,12 +73,6 @@ export async function startSessionAndSendPrompt(
     return null;
   }
 
-  await storeThreadSession(
-    env,
-    channel,
-    threadTs,
-    buildThreadSession(session.sessionId, target, model, reasoningEffort)
-  );
   const callbackContext: CallbackContext = {
     source: "slack",
     channel,
@@ -107,5 +100,11 @@ export async function startSessionAndSendPrompt(
     );
     return null;
   }
+  await storeThreadSession(
+    env,
+    channel,
+    threadTs,
+    buildThreadSession(session.sessionId, target, model, reasoningEffort)
+  );
   return { sessionId: session.sessionId };
 }

--- a/packages/slack-bot/src/sessions/session-launcher.ts
+++ b/packages/slack-bot/src/sessions/session-launcher.ts
@@ -91,7 +91,7 @@ export async function startSessionAndSendPrompt(
     callbackContext,
     traceId
   );
-  if (!promptResult) {
+  if (!promptResult.ok) {
     await postMessage(
       env.SLACK_BOT_TOKEN,
       channel,

--- a/packages/slack-bot/src/sessions/thread-session-store.test.ts
+++ b/packages/slack-bot/src/sessions/thread-session-store.test.ts
@@ -97,6 +97,46 @@ describe("thread session store", () => {
     await expect(lookupThreadSession(mocks.env, "C123", "111.222")).resolves.toBeNull();
   });
 
+  it.each([
+    {},
+    [],
+    { sessionId: "session-1" },
+    {
+      sessionId: "session-1",
+      repoId: "acme/app",
+      repoFullName: "acme/app",
+      model: "openai/gpt-5.4",
+      createdAt: "123",
+    },
+    {
+      sessionId: "session-1",
+      repoId: "acme/app",
+      repoFullName: "acme/app",
+      model: "openai/gpt-5.4",
+      reasoningEffort: 123,
+      createdAt: 123,
+    },
+  ])("rejects malformed records: %j", async (record) => {
+    mocks.get.mockResolvedValue(record);
+
+    await expect(lookupThreadSession(mocks.env, "C123", "111.222")).resolves.toBeNull();
+  });
+
+  it("accepts persisted records with and without reasoning effort", async () => {
+    const base: ThreadSession = {
+      sessionId: "session-1",
+      repoId: "acme/app",
+      repoFullName: "acme/app",
+      model: "openai/gpt-5.4",
+      createdAt: 123,
+    };
+    const withReasoning = { ...base, reasoningEffort: "high" };
+    mocks.get.mockResolvedValueOnce(base).mockResolvedValueOnce(withReasoning);
+
+    await expect(lookupThreadSession(mocks.env, "C123", "111.222")).resolves.toEqual(base);
+    await expect(lookupThreadSession(mocks.env, "C123", "111.222")).resolves.toEqual(withReasoning);
+  });
+
   it("handles KV write and delete failures", async () => {
     const session: ThreadSession = {
       sessionId: "session-1",

--- a/packages/slack-bot/src/sessions/thread-session-store.ts
+++ b/packages/slack-bot/src/sessions/thread-session-store.ts
@@ -1,10 +1,19 @@
 import { createKvCacheStore } from "@open-inspect/shared";
+import { z } from "zod";
 import { createLogger } from "../logger";
 import { targetId, targetLabel, type SlackSessionTarget } from "../targets";
 import type { Env, ThreadSession } from "../types";
 
 const log = createLogger("handler");
-const THREAD_SESSION_TTL_SECONDS = 7 * 24 * 60 * 60;
+const THREAD_SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const threadSessionSchema = z.object({
+  sessionId: z.string().min(1),
+  repoId: z.string().min(1),
+  repoFullName: z.string().min(1),
+  model: z.string().min(1),
+  reasoningEffort: z.string().min(1).optional(),
+  createdAt: z.number().finite().nonnegative(),
+});
 
 function getThreadSessionKey(channel: string, threadTs: string): string {
   return `thread:${channel}:${threadTs}`;
@@ -20,7 +29,8 @@ export async function lookupThreadSession(
       getThreadSessionKey(channel, threadTs),
       "json"
     );
-    return data && typeof data === "object" ? (data as ThreadSession) : null;
+    const result = threadSessionSchema.safeParse(data);
+    return result.success ? result.data : null;
   } catch (e) {
     log.error("kv.get", {
       key_prefix: "thread",
@@ -42,7 +52,7 @@ export async function storeThreadSession(
     await createKvCacheStore(env.SLACK_KV).put(
       getThreadSessionKey(channel, threadTs),
       JSON.stringify(session),
-      { expirationTtl: THREAD_SESSION_TTL_SECONDS }
+      { expirationTtl: THREAD_SESSION_TTL_MS / 1000 }
     );
   } catch (e) {
     log.error("kv.put", {

--- a/packages/slack-bot/src/sessions/thread-session-store.ts
+++ b/packages/slack-bot/src/sessions/thread-session-store.ts
@@ -6,7 +6,7 @@ import type { Env, ThreadSession } from "../types";
 
 const log = createLogger("handler");
 const THREAD_SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
-const threadSessionSchema = z.object({
+const threadSessionSchema: z.ZodType<ThreadSession> = z.object({
   sessionId: z.string().min(1),
   repoId: z.string().min(1),
   repoFullName: z.string().min(1),


### PR DESCRIPTION
## Summary
- validate pending-request and thread-session KV records at runtime, preserving valid persisted thread records with optional reasoning effort
- reject malformed app mentions, avoid unused thread-history calls for active sessions, and preserve history when stale sessions fall back to new launches
- remove the redundant target-selection status update while preserving the pre-launch and post-link status timing
- add 10-second control-plane request timeouts and convert `createSession` to a named options API
- store thread mappings only after the initial prompt succeeds, preventing mappings to unusable sessions
- normalize extracted TypeScript TTL constants to milliseconds with conversion at KV boundaries

## Verification
- `npm test -w @open-inspect/slack-bot` (257 tests passed)
- `npm run typecheck -w @open-inspect/slack-bot`
- `npm run build -w @open-inspect/slack-bot`
- `npm run lint -w @open-inspect/slack-bot`
- `npx prettier --check <touched Slack bot files>`
- `git diff --check`

## Declined Findings
- **Shared working-message lifecycle helper:** declined because the two call sites have materially different ownership around classifier reasoning, pending-request deletion, and failure behavior. A helper would mostly parameterize the existing control flow rather than establish clearer ownership.
- **Atomic event idempotency:** declined because Slack bot KV `get` + `put` cannot provide an atomic claim. SchedulerDO/D1 only atomically deduplicates new automation invocation materialization; interactive DMs/app mentions bypass it, and scheduler steering can occur before invocation deduplication. A correct fix requires a dedicated DO/D1 ingress claim or idempotency keys in the create-session/prompt contract.
- **Identifier logging changes:** declined because `session_id` and `message_id` are established cross-service correlation fields. Slack user fields are inconsistent across the package, but changing only the extracted client would worsen that inconsistency; standardization should update all Slack logs, documentation, and dependent queries together.

## Notes
- Existing KV deduplication remains a best-effort retry cache and is not represented as concurrency-safe.
- Existing prompt-failure stale-session fallback behavior is preserved; exactly-once handling of ambiguous accepted-but-timed-out prompts depends on the declined idempotency contract work.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/85f22202d7a0f031182a1d913d20ee78)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Tightened handling for Slack mentions missing required sender details to avoid unnecessary processing.
  - Improved transient prompt-failure behavior in threads (shows an in-thread follow-up error and stops early).
  - Prevented stale/failed thread and pending request data from being persisted or reused.
  - Ensured background “starting” status updates only run after the initial message is successfully acknowledged.

- **Improvements**
  - Added stronger validation for stored pending requests and thread sessions in KV, with safer handling of malformed entries.
  - Standardized control-plane request timeouts and clarified transient vs stale prompt outcomes.
  - Clarified the event deduplication window for more predictable event processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->