### PR TITLE
feat(web): move session search to command menu

### DIFF
--- a/packages/web/src/components/global-command-menu.tsx
+++ b/packages/web/src/components/global-command-menu.tsx
@@ -5,6 +5,7 @@ import type { Session } from "@open-inspect/shared";
 import { formatRelativeTime } from "@/lib/time";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import { formatRepoLabel } from "@/lib/repo-label";
+import { buildSessionSearchValue } from "@/lib/session-list";
 import { AutomationsIcon, BranchIcon, PlusIcon, SettingsIcon } from "@/components/ui/icons";
 import { AppIcon } from "@/components/ui/app-icon";
 import {
@@ -50,8 +51,8 @@ export function GlobalCommandMenu({
   onNewSession,
   sessions,
 }: GlobalCommandMenuProps) {
-  const recentSessions = useMemo(
-    () => sessions.filter((session) => session.status !== "archived").slice(0, 25),
+  const searchableSessions = useMemo(
+    () => sessions.filter((session) => session.status !== "archived"),
     [sessions]
   );
 
@@ -91,11 +92,11 @@ export function GlobalCommandMenu({
             </CommandItem>
           </CommandGroup>
 
-          {recentSessions.length > 0 && (
+          {searchableSessions.length > 0 && (
             <>
               <CommandSeparator />
               <CommandGroup heading="Sessions">
-                {recentSessions.map((session) => {
+                {searchableSessions.map((session) => {
                   const repoLabel = formatRepoLabel(session.repoOwner, session.repoName);
                   const sessionTitle = session.title || repoLabel;
                   const timestamp = session.updatedAt || session.createdAt;
@@ -103,7 +104,7 @@ export function GlobalCommandMenu({
                   return (
                     <CommandItem
                       key={session.id}
-                      value={`${session.id} ${sessionTitle} ${repoLabel}`}
+                      value={buildSessionSearchValue(session)}
                       onSelect={() => handleSelect(() => onNavigate(buildSessionUrl(session)))}
                       className="items-start"
                     >

--- a/packages/web/src/components/session-sidebar.test.tsx
+++ b/packages/web/src/components/session-sidebar.test.tsx
@@ -178,7 +178,9 @@ describe("SessionSidebar", () => {
     expect(screen.getByText("Grandchild session")).toBeInTheDocument();
   });
 
-  it("shows an empty state for an unmatched search and restores sessions when cleared", async () => {
+  it("opens session search from the header", async () => {
+    const onSearchSessions = vi.fn();
+
     render(
       <SWRConfig
         value={{
@@ -187,70 +189,13 @@ describe("SessionSidebar", () => {
           revalidateOnFocus: false,
         }}
       >
-        <SessionSidebar />
+        <SessionSidebar onSearchSessions={onSearchSessions} />
       </SWRConfig>
     );
 
     expect(await screen.findByText("Session 1")).toBeInTheDocument();
-
-    const searchInput = screen.getByPlaceholderText("Search sessions...");
-    fireEvent.change(searchInput, { target: { value: "missing" } });
-
-    expect(screen.getByText("No matching sessions")).toBeInTheDocument();
-    expect(screen.queryByText("Session 1")).not.toBeInTheDocument();
-
-    fireEvent.change(searchInput, { target: { value: "" } });
-
-    expect(screen.getByText("Session 1")).toBeInTheDocument();
-    expect(screen.queryByText("No matching sessions")).not.toBeInTheDocument();
-  });
-
-  it("keeps the genuine empty-session state distinct from empty search results", () => {
-    render(
-      <SWRConfig
-        value={{
-          fallback: { [SIDEBAR_SESSIONS_KEY]: { sessions: [], hasMore: false } },
-          dedupingInterval: 0,
-          revalidateOnFocus: false,
-        }}
-      >
-        <SessionSidebar />
-      </SWRConfig>
-    );
-
-    fireEvent.change(screen.getByPlaceholderText("Search sessions..."), {
-      target: { value: "missing" },
-    });
-
-    expect(screen.getByText("No sessions yet")).toBeInTheDocument();
-    expect(screen.queryByText("No matching sessions")).not.toBeInTheDocument();
-  });
-
-  it("keeps the session-loading failure distinct from empty search results", async () => {
-    render(
-      <SWRConfig
-        value={{
-          provider: () => new Map(),
-          fetcher: async () => {
-            throw new Error("Failed to load sessions");
-          },
-          shouldRetryOnError: false,
-          dedupingInterval: 0,
-          revalidateOnFocus: false,
-        }}
-      >
-        <SessionSidebar />
-      </SWRConfig>
-    );
-
-    expect(await screen.findByText("Unable to load sessions")).toBeInTheDocument();
-
-    fireEvent.change(screen.getByPlaceholderText("Search sessions..."), {
-      target: { value: "missing" },
-    });
-
-    expect(screen.getByText("Unable to load sessions")).toBeInTheDocument();
-    expect(screen.queryByText("No matching sessions")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Search sessions/ }));
+    expect(onSearchSessions).toHaveBeenCalledOnce();
   });
 
   it("loads the next page when scrolled near the bottom", async () => {
@@ -371,39 +316,6 @@ describe("SessionSidebar", () => {
       expect(fetchMock).toHaveBeenCalledWith(mineKey);
     });
     expect(screen.queryByText("Session 1")).not.toBeInTheDocument();
-  });
-
-  it("matches non-primary repository members in the sidebar search", async () => {
-    const session = createSession(1, {
-      repositories: [
-        { repoOwner: "open-inspect", repoName: "background-agents", repoId: 1, baseBranch: "main" },
-        { repoOwner: "acme", repoName: "api", repoId: 2, baseBranch: "main" },
-      ],
-    });
-
-    render(
-      <SWRConfig
-        value={{
-          fallback: { [SIDEBAR_SESSIONS_KEY]: { sessions: [session], hasMore: false } },
-          dedupingInterval: 0,
-          revalidateOnFocus: false,
-        }}
-      >
-        <SessionSidebar />
-      </SWRConfig>
-    );
-
-    expect(await screen.findByText("Session 1")).toBeInTheDocument();
-
-    const searchInput = screen.getByPlaceholderText("Search sessions...");
-    fireEvent.change(searchInput, { target: { value: "acme/api" } });
-
-    expect(screen.getByText("Session 1")).toBeInTheDocument();
-
-    fireEvent.change(searchInput, { target: { value: "acme/docs" } });
-
-    expect(screen.queryByText("Session 1")).not.toBeInTheDocument();
-    expect(screen.getByText("No matching sessions")).toBeInTheDocument();
   });
 
   it("shows the environment name on cards for environment-launched sessions", async () => {
@@ -563,12 +475,11 @@ describe("SessionSidebar", () => {
       </SWRConfig>
     );
 
-    fireEvent.click(screen.getByRole("link", { name: /^inspect$/i }));
     fireEvent.click(screen.getByTitle("Settings"));
     fireEvent.click(screen.getByRole("link", { name: /automations/i }));
     fireEvent.click(screen.getByRole("link", { name: /analytics/i }));
 
-    expect(onSessionSelect).toHaveBeenCalledTimes(4);
+    expect(onSessionSelect).toHaveBeenCalledTimes(3);
   });
 
   it("opens rename actions on mobile long press", async () => {

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -35,16 +35,15 @@ import {
   SidebarIcon,
   ArchiveIcon,
   PlusIcon,
+  SearchIcon,
   SettingsIcon,
   AutomationsIcon,
   BranchIcon,
   BoxIcon,
   DataControlsIcon,
 } from "@/components/ui/icons";
-import { APP_SHORT_NAME } from "@/lib/site-config";
-import { formatRepoLabel, formatSessionRepositoriesLabel } from "@/lib/repo-label";
+import { formatSessionRepositoriesLabel } from "@/lib/repo-label";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { useEnvironments } from "@/hooks/use-environments";
 import {
   DropdownMenu,
@@ -80,15 +79,20 @@ export function buildSessionHref(session: SessionItem) {
 
 interface SessionSidebarProps {
   onNewSession?: () => void;
+  onSearchSessions?: () => void;
   onToggle?: () => void;
   onSessionSelect?: () => void;
 }
 
-export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: SessionSidebarProps) {
+export function SessionSidebar({
+  onNewSession,
+  onSearchSessions,
+  onToggle,
+  onSessionSelect,
+}: SessionSidebarProps) {
   const { data: authSession } = useSession();
   const pathname = usePathname();
   const router = useRouter();
-  const [searchQuery, setSearchQuery] = useState("");
   const [sessionCreatorFilter, setSessionCreatorFilter] = useState<SessionCreatorFilter>("all");
   const [extraSessions, setExtraSessions] = useState<SessionItem[]>([]);
   const [hasMorePages, setHasMorePages] = useState(false);
@@ -214,23 +218,9 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
     [firstPageSessions, effectiveExtraSessions]
   );
 
-  // Sort sessions by updatedAt (most recent first), filter by search query,
-  // and group children under their parent sessions
-  const { activeSessions, inactiveSessions, childrenMap, hasFilteredSessions } = useMemo(() => {
-    const filtered = sessions
-      .filter((session) => session.status !== "archived")
-      .filter((session) => {
-        if (!searchQuery) return true;
-        const query = searchQuery.toLowerCase();
-        const title = session.title?.toLowerCase() || "";
-        if (title.includes(query)) return true;
-        // Match against every member of the repository set, not just the
-        // primary; scalar fallback covers pre-multi-repo sessions.
-        const repoLabels = session.repositories?.length
-          ? session.repositories.map((repo) => formatRepoLabel(repo.repoOwner, repo.repoName))
-          : [formatRepoLabel(session.repoOwner, session.repoName)];
-        return repoLabels.some((label) => label.toLowerCase().includes(query));
-      });
+  // Sort sessions by updatedAt (most recent first) and group children under their parent sessions.
+  const { activeSessions, inactiveSessions, childrenMap } = useMemo(() => {
+    const filtered = sessions.filter((session) => session.status !== "archived");
 
     // Sort by updatedAt descending
     const sorted = [...filtered].sort((a, b) => {
@@ -276,9 +266,8 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
       activeSessions: active,
       inactiveSessions: inactive,
       childrenMap: children,
-      hasFilteredSessions: filtered.length > 0,
     };
-  }, [sessions, searchQuery]);
+  }, [sessions]);
 
   // Environment provenance for the cards, resolved once for the whole list.
   // Names are looked up so a deleted environment (or one still loading)
@@ -357,9 +346,15 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
           >
             <SidebarIcon className="w-4 h-4" />
           </Button>
-          <Link href="/" onClick={handleNavigationSelect} className="min-w-0">
-            <span className="block truncate font-semibold text-foreground">{APP_SHORT_NAME}</span>
-          </Link>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onSearchSessions}
+            title={`Search sessions (${SHORTCUT_LABELS.COMMAND_MENU})`}
+            aria-label={`Search sessions (${SHORTCUT_LABELS.COMMAND_MENU})`}
+          >
+            <SearchIcon className="w-4 h-4" />
+          </Button>
         </div>
         <div className="flex shrink-0 items-center gap-2">
           <Button
@@ -442,16 +437,6 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
         </ToggleGroup>
       </div>
 
-      {/* Search */}
-      <div className="px-3 py-2">
-        <Input
-          type="text"
-          placeholder="Search sessions..."
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-        />
-      </div>
-
       {/* Session List */}
       <div
         ref={scrollContainerRef}
@@ -464,10 +449,6 @@ export function SessionSidebar({ onNewSession, onToggle, onSessionSelect }: Sess
           </div>
         ) : sessions.length === 0 ? (
           <div className="px-4 py-8 text-center text-sm text-muted-foreground">{emptyMessage}</div>
-        ) : searchQuery && !hasFilteredSessions ? (
-          <div className="px-4 py-8 text-center text-sm text-muted-foreground">
-            No matching sessions
-          </div>
         ) : (
           <>
             {/* Active Sessions */}

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -70,6 +70,10 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
     setIsCommandMenuOpen((prev) => !prev);
   }, []);
 
+  const handleSearchSessions = useCallback(() => {
+    setIsCommandMenuOpen(true);
+  }, []);
+
   useGlobalShortcuts({
     enabled: status === "authenticated" && Boolean(session),
     onOpenCommandMenu: handleOpenCommandMenu,
@@ -138,6 +142,7 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
         >
           <SessionSidebar
             onNewSession={handleNewSession}
+            onSearchSessions={handleSearchSessions}
             onToggle={sidebar.toggle}
             onSessionSelect={sidebar.close}
           />

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -9,7 +9,7 @@ import { GlobalCommandMenu } from "./global-command-menu";
 import { useSidebar } from "@/hooks/use-sidebar";
 import { useIsMobile } from "@/hooks/use-media-query";
 import { useGlobalShortcuts } from "@/hooks/use-global-shortcuts";
-import { SIDEBAR_SESSIONS_KEY, type SessionListResponse } from "@/lib/session-list";
+import { COMMAND_MENU_SESSIONS_KEY, type SessionListResponse } from "@/lib/session-list";
 import { Button } from "@/components/ui/button";
 import { GitHubIcon, GoogleIcon } from "@/components/ui/icons";
 import { APP_NAME, GOOGLE_LOGIN_ENABLED } from "@/lib/site-config";
@@ -44,7 +44,7 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
 
   const { data: sessionsResponse } = useSWR<SessionListResponse>(
     status === "authenticated" && Boolean(session) && isCommandMenuOpen
-      ? SIDEBAR_SESSIONS_KEY
+      ? COMMAND_MENU_SESSIONS_KEY
       : null
   );
 

--- a/packages/web/src/lib/session-list.test.ts
+++ b/packages/web/src/lib/session-list.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   applyTitleUpdate,
+  buildSessionSearchValue,
   buildSessionsPageKey,
   CURRENT_USER_CREATED_BY,
   isArchivedSessionListKey,
@@ -47,6 +48,33 @@ describe("buildSessionsPageKey", () => {
     ).toBe(
       "/api/sessions?limit=50&offset=0&excludeStatus=archived&createdBy=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&createdBy=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     );
+  });
+});
+
+describe("buildSessionSearchValue", () => {
+  it("includes every repository attached to a multi-repository session", () => {
+    const value = buildSessionSearchValue(
+      session("multi", {
+        title: "Update services",
+        repositories: [
+          {
+            repoOwner: "open-inspect",
+            repoName: "background-agents",
+            repoId: 1,
+            baseBranch: "main",
+          },
+          { repoOwner: "acme", repoName: "api", repoId: 2, baseBranch: "main" },
+        ],
+      })
+    );
+
+    expect(value).toContain("Update services");
+    expect(value).toContain("open-inspect/background-agents");
+    expect(value).toContain("acme/api");
+  });
+
+  it("falls back to the scalar repository fields", () => {
+    expect(buildSessionSearchValue(session("legacy"))).toContain("open-inspect/background-agents");
   });
 });
 

--- a/packages/web/src/lib/session-list.ts
+++ b/packages/web/src/lib/session-list.ts
@@ -1,12 +1,18 @@
 import type { Session } from "@open-inspect/shared";
+import { formatRepoLabel } from "./repo-label";
 
 export const SESSIONS_PAGE_SIZE = 50;
+const COMMAND_MENU_SESSIONS_LIMIT = 100;
 export const SESSIONS_API_PATH = "/api/sessions";
 export const CURRENT_USER_CREATED_BY = "me";
 export const SIDEBAR_SESSIONS_KEY = buildSessionsPageKey({
   excludeStatus: "archived",
   limit: SESSIONS_PAGE_SIZE,
   offset: 0,
+});
+export const COMMAND_MENU_SESSIONS_KEY = buildSessionsPageKey({
+  excludeStatus: "archived",
+  limit: COMMAND_MENU_SESSIONS_LIMIT,
 });
 
 export interface SessionListResponse {
@@ -100,4 +106,14 @@ export function mergeUniqueSessions(existing: Session[], incoming: Session[]) {
 
 export function removeSessionFromList(sessions: Session[], sessionId: string) {
   return sessions.filter((session) => session.id !== sessionId);
+}
+
+export function buildSessionSearchValue(session: Session): string {
+  const repositoryLabels = session.repositories?.length
+    ? session.repositories.map((repository) =>
+        formatRepoLabel(repository.repoOwner, repository.repoName)
+      )
+    : [formatRepoLabel(session.repoOwner, session.repoName)];
+
+  return [session.id, session.title, ...repositoryLabels].filter(Boolean).join(" ");
 }


### PR DESCRIPTION
## Summary
- replace the space-consuming inline session search with a compact header search action
- open the existing Cmd/Ctrl+K command menu from the search icon
- remove the Inspect label and position search beside the sidebar toggle
- update sidebar tests for the new interaction and navigation layout

## Verification
- `npm test -w @open-inspect/web -- --run src/components/session-sidebar.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web`
- visually verified at 1512x982 (artifact `29a52b091df215fbcb38dd98905e8d82`)

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/44e4190e04c84c9547615ce4e9d98740)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Search sessions” button to the session sidebar header.
  * Session search is now opened via the unified command/search menu.
* **Changes**
  * Removed the sidebar’s inline filtering field and matching-results message.
  * Session list display now relies on standard groupings and empty states (without query filtering).
  * Command menu “Sessions” now searches across sessions by title and repository labels.
* **Tests**
  * Updated and added coverage for the new sidebar search trigger and command search behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->