### PR TITLE
feat(web): move profile to sidebar footer

### DIFF
--- a/packages/web/src/components/session-sidebar.test.tsx
+++ b/packages/web/src/components/session-sidebar.test.tsx
@@ -92,6 +92,24 @@ function jsonResponse(body: unknown) {
 }
 
 describe("SessionSidebar", () => {
+  it("shows the user profile at the bottom of the sidebar", async () => {
+    const { container } = render(
+      <SWRConfig
+        value={{
+          fallback: { [SIDEBAR_SESSIONS_KEY]: { sessions: [], hasMore: false } },
+          dedupingInterval: 0,
+          revalidateOnFocus: false,
+        }}
+      >
+        <SessionSidebar />
+      </SWRConfig>
+    );
+
+    const profileButton = await screen.findByRole("button", { name: "Signed in as Test User" });
+    expect(profileButton).toHaveTextContent("Test User");
+    expect(container.querySelector("aside")?.lastElementChild).toContainElement(profileButton);
+  });
+
   it("renders the PR status summary on session rows", async () => {
     const single = createSession(1, {
       updatedAt: 4000,

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -378,7 +378,6 @@ export function SessionSidebar({
           >
             <SettingsIcon className="w-4 h-4" />
           </Link>
-          <UserMenu user={authSession?.user} />
         </div>
       </div>
 
@@ -506,6 +505,10 @@ export function SessionSidebar({
           </>
         )}
       </div>
+
+      <div className="border-t border-border-muted p-2">
+        <UserMenu user={authSession?.user} />
+      </div>
     </aside>
   );
 }
@@ -515,24 +518,23 @@ function UserMenu({ user }: { user?: { name?: string | null; image?: string | nu
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
-          className="w-7 h-7 rounded-full overflow-hidden focus:outline-none focus:ring-2 focus:ring-primary"
+          className="flex w-full items-center gap-3 rounded-md px-2 py-2 text-left text-sm font-medium text-foreground transition hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary"
           aria-label={`Signed in as ${user?.name || "User"}`}
           title={`Signed in as ${user?.name || "User"}`}
         >
-          {user?.image ? (
-            <img
-              src={user.image}
-              alt={user.name || "User"}
-              className="w-full h-full object-cover"
-            />
-          ) : (
-            <span className="w-full h-full rounded-full bg-card flex items-center justify-center text-xs font-medium text-foreground">
-              {user?.name?.charAt(0).toUpperCase() || "?"}
-            </span>
-          )}
+          <span className="h-7 w-7 shrink-0 overflow-hidden rounded-full">
+            {user?.image ? (
+              <img src={user.image} alt="" className="h-full w-full object-cover" />
+            ) : (
+              <span className="flex h-full w-full items-center justify-center rounded-full bg-card text-xs font-medium text-foreground">
+                {user?.name?.charAt(0).toUpperCase() || "?"}
+              </span>
+            )}
+          </span>
+          <span className="min-w-0 truncate">{user?.name || "User"}</span>
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" sideOffset={4}>
+      <DropdownMenuContent align="start" side="top" sideOffset={4}>
         <DropdownMenuLabel className="font-medium truncate">
           {user?.name || "User"}
         </DropdownMenuLabel>


### PR DESCRIPTION
## Summary
- move the existing profile menu from the session sidebar header to a fixed footer below the scrollable session list
- show the user's avatar and display name in the full-width profile trigger
- open the existing profile menu upward to keep it visible at the bottom edge
- add focused coverage for profile visibility and footer placement

## Verification
- `npm test -w @open-inspect/web -- src/components/session-sidebar.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web`
- visually verified at 1440x900 and 390x844 with the profile menu open

Linear: COL-17

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/9dc05a99364a80d5031284da2fcc80b3)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Moved the user profile menu to the bottom of the session sidebar.
  * Updated the profile menu trigger to display the user’s avatar and name in a bordered horizontal row.
  * Improved the profile image presentation and accessibility labeling.

* **Tests**
  * Added coverage verifying that the signed-in user profile appears when no sessions are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->