### PR TITLE
fix(web): keep sidebar actions available when collapsed

### DIFF
--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -58,6 +58,38 @@ import type { Session } from "@open-inspect/shared";
 export type SessionItem = Session;
 
 export const MOBILE_LONG_PRESS_MS = 450;
+
+interface SidebarActionButtonProps {
+  onClick?: () => void;
+}
+
+export function SearchSessionsButton({ onClick }: SidebarActionButtonProps) {
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={onClick}
+      title={`Search sessions (${SHORTCUT_LABELS.COMMAND_MENU})`}
+      aria-label={`Search sessions (${SHORTCUT_LABELS.COMMAND_MENU})`}
+    >
+      <SearchIcon className="w-4 h-4" />
+    </Button>
+  );
+}
+
+export function NewSessionButton({ onClick }: SidebarActionButtonProps) {
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={onClick}
+      title={`New session (${SHORTCUT_LABELS.NEW_SESSION})`}
+      aria-label={`New session (${SHORTCUT_LABELS.NEW_SESSION})`}
+    >
+      <PlusIcon className="w-4 h-4" />
+    </Button>
+  );
+}
 const MOBILE_LONG_PRESS_MOVE_THRESHOLD_PX = 10;
 type SessionCreatorFilter = "all" | "mine";
 
@@ -346,26 +378,10 @@ export function SessionSidebar({
           >
             <SidebarIcon className="w-4 h-4" />
           </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onSearchSessions}
-            title={`Search sessions (${SHORTCUT_LABELS.COMMAND_MENU})`}
-            aria-label={`Search sessions (${SHORTCUT_LABELS.COMMAND_MENU})`}
-          >
-            <SearchIcon className="w-4 h-4" />
-          </Button>
+          <SearchSessionsButton onClick={onSearchSessions} />
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onNewSession}
-            title={`New session (${SHORTCUT_LABELS.NEW_SESSION})`}
-            aria-label={`New session (${SHORTCUT_LABELS.NEW_SESSION})`}
-          >
-            <PlusIcon className="w-4 h-4" />
-          </Button>
+          <NewSessionButton onClick={onNewSession} />
           <Link
             href="/settings"
             onClick={handleNavigationSelect}

--- a/packages/web/src/components/sidebar-layout.test.tsx
+++ b/packages/web/src/components/sidebar-layout.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CollapsedSidebarActions } from "./sidebar-layout";
+
+expect.extend(matchers);
+
+vi.mock("next-auth/react", () => ({
+  useSession: vi.fn(),
+  signIn: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(),
+}));
+
+afterEach(cleanup);
+
+describe("CollapsedSidebarActions", () => {
+  it("keeps search and new session actions available", () => {
+    const onSearchSessions = vi.fn();
+    const onNewSession = vi.fn();
+
+    render(
+      <CollapsedSidebarActions onSearchSessions={onSearchSessions} onNewSession={onNewSession} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Search sessions/ }));
+    fireEvent.click(screen.getByRole("button", { name: /New session/ }));
+
+    expect(onSearchSessions).toHaveBeenCalledOnce();
+    expect(onNewSession).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -11,8 +11,9 @@ import { useIsMobile } from "@/hooks/use-media-query";
 import { useGlobalShortcuts } from "@/hooks/use-global-shortcuts";
 import { COMMAND_MENU_SESSIONS_KEY, type SessionListResponse } from "@/lib/session-list";
 import { Button } from "@/components/ui/button";
-import { GitHubIcon, GoogleIcon } from "@/components/ui/icons";
+import { GitHubIcon, GoogleIcon, PlusIcon, SearchIcon } from "@/components/ui/icons";
 import { APP_NAME, GOOGLE_LOGIN_ENABLED } from "@/lib/site-config";
+import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 
 interface SidebarContextValue {
   isOpen: boolean;
@@ -33,6 +34,39 @@ export function useSidebarContext() {
 
 interface SidebarLayoutProps {
   children: React.ReactNode;
+}
+
+interface CollapsedSidebarActionsProps {
+  onSearchSessions: () => void;
+  onNewSession: () => void;
+}
+
+export function CollapsedSidebarActions({
+  onSearchSessions,
+  onNewSession,
+}: CollapsedSidebarActionsProps) {
+  return (
+    <div className="w-12 flex-shrink-0 border-r border-border-muted bg-background px-2 py-3 flex flex-col items-center gap-2">
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onSearchSessions}
+        title={`Search sessions (${SHORTCUT_LABELS.COMMAND_MENU})`}
+        aria-label={`Search sessions (${SHORTCUT_LABELS.COMMAND_MENU})`}
+      >
+        <SearchIcon className="w-4 h-4" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onNewSession}
+        title={`New session (${SHORTCUT_LABELS.NEW_SESSION})`}
+        aria-label={`New session (${SHORTCUT_LABELS.NEW_SESSION})`}
+      >
+        <PlusIcon className="w-4 h-4" />
+      </Button>
+    </div>
+  );
 }
 
 export function SidebarLayout({ children }: SidebarLayoutProps) {
@@ -147,6 +181,12 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
             onSessionSelect={sidebar.close}
           />
         </div>
+        {!isMobile && !sidebar.isOpen && (
+          <CollapsedSidebarActions
+            onSearchSessions={handleSearchSessions}
+            onNewSession={handleNewSession}
+          />
+        )}
         <main className="flex-1 overflow-hidden">{children}</main>
       </div>
       <GlobalCommandMenu

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -4,16 +4,15 @@ import { createContext, useCallback, useContext, useState } from "react";
 import { useSession, signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
-import { SessionSidebar } from "./session-sidebar";
+import { NewSessionButton, SearchSessionsButton, SessionSidebar } from "./session-sidebar";
 import { GlobalCommandMenu } from "./global-command-menu";
 import { useSidebar } from "@/hooks/use-sidebar";
 import { useIsMobile } from "@/hooks/use-media-query";
 import { useGlobalShortcuts } from "@/hooks/use-global-shortcuts";
 import { COMMAND_MENU_SESSIONS_KEY, type SessionListResponse } from "@/lib/session-list";
 import { Button } from "@/components/ui/button";
-import { GitHubIcon, GoogleIcon, PlusIcon, SearchIcon } from "@/components/ui/icons";
+import { GitHubIcon, GoogleIcon } from "@/components/ui/icons";
 import { APP_NAME, GOOGLE_LOGIN_ENABLED } from "@/lib/site-config";
-import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 
 interface SidebarContextValue {
   isOpen: boolean;
@@ -47,24 +46,8 @@ export function CollapsedSidebarActions({
 }: CollapsedSidebarActionsProps) {
   return (
     <div className="w-12 flex-shrink-0 border-r border-border-muted bg-background px-2 py-3 flex flex-col items-center gap-2">
-      <Button
-        variant="ghost"
-        size="icon"
-        onClick={onSearchSessions}
-        title={`Search sessions (${SHORTCUT_LABELS.COMMAND_MENU})`}
-        aria-label={`Search sessions (${SHORTCUT_LABELS.COMMAND_MENU})`}
-      >
-        <SearchIcon className="w-4 h-4" />
-      </Button>
-      <Button
-        variant="ghost"
-        size="icon"
-        onClick={onNewSession}
-        title={`New session (${SHORTCUT_LABELS.NEW_SESSION})`}
-        aria-label={`New session (${SHORTCUT_LABELS.NEW_SESSION})`}
-      >
-        <PlusIcon className="w-4 h-4" />
-      </Button>
+      <SearchSessionsButton onClick={onSearchSessions} />
+      <NewSessionButton onClick={onNewSession} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a compact desktop action rail when the session sidebar is collapsed
- keep session search and new-session creation available through the existing handlers
- add a focused interaction test for both collapsed actions

## Validation
- `npm test -w @open-inspect/web -- src/components/sidebar-layout.test.tsx`
- `npm run lint -w @open-inspect/web`
- `npm run typecheck -w @open-inspect/web`

Closes COL-18

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/bfc9110c8ca04cf9716488fd7b4a1180)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quick-access buttons for searching sessions and starting a new session when the desktop sidebar is collapsed.
  * Preserved existing button labels, accessibility support, and visual styling.
  * Sidebar actions now consistently trigger the corresponding search and new-session workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->