### PR TITLE
fix(web): inline collapsed sidebar controls

### DIFF
--- a/packages/web/src/app/(app)/analytics/page.tsx
+++ b/packages/web/src/app/(app)/analytics/page.tsx
@@ -9,11 +9,9 @@ import { AnalyticsRepoBarChart } from "@/components/analytics/repo-bar-chart";
 import { AnalyticsSummaryCards } from "@/components/analytics/summary-cards";
 import { AnalyticsTimeseriesChart } from "@/components/analytics/timeseries-chart";
 import { AnalyticsUserTable } from "@/components/analytics/user-table";
-import { useSidebarContext } from "@/components/sidebar-layout";
+import { CollapsedSidebarControls, useSidebarContext } from "@/components/sidebar-layout";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
-import { SidebarIcon } from "@/components/ui/icons";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { useAnalyticsDashboard } from "@/hooks/use-analytics";
 import {
@@ -25,10 +23,9 @@ import {
   type AnalyticsSortDirection,
   type AnalyticsUserSortKey,
 } from "@/lib/analytics";
-import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 
 export default function AnalyticsPage() {
-  const { isOpen, toggle } = useSidebarContext();
+  const { isOpen } = useSidebarContext();
   const [days, setDays] = useState<AnalyticsDays>(30);
   const [sortKey, setSortKey] = useState<AnalyticsUserSortKey>("sessions");
   const [sortDirection, setSortDirection] = useState<AnalyticsSortDirection>("desc");
@@ -66,15 +63,7 @@ export default function AnalyticsPage() {
       {!isOpen && (
         <header className="border-b border-border-muted flex-shrink-0">
           <div className="px-4 py-3">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={toggle}
-              title={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-              aria-label={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-            >
-              <SidebarIcon className="w-4 h-4" />
-            </Button>
+            <CollapsedSidebarControls />
           </div>
         </header>
       )}

--- a/packages/web/src/app/(app)/automations/[id]/edit/page.tsx
+++ b/packages/web/src/app/(app)/automations/[id]/edit/page.tsx
@@ -3,19 +3,18 @@
 import { useState, use } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { useSidebarContext } from "@/components/sidebar-layout";
+import { CollapsedSidebarControls, useSidebarContext } from "@/components/sidebar-layout";
 import { useAutomation } from "@/hooks/use-automations";
 import {
   AutomationForm,
   type AutomationFormValues,
 } from "@/components/automations/automation-form";
 import { ErrorBanner } from "@/components/ui/error-banner";
-import { SidebarIcon, BackIcon } from "@/components/ui/icons";
-import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
+import { BackIcon } from "@/components/ui/icons";
 
 export default function EditAutomationPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
-  const { isOpen, toggle } = useSidebarContext();
+  const { isOpen } = useSidebarContext();
   const router = useRouter();
   const { automation, loading } = useAutomation(id);
   const [submitting, setSubmitting] = useState(false);
@@ -69,14 +68,7 @@ export default function EditAutomationPage({ params }: { params: Promise<{ id: s
       {!isOpen && (
         <header className="border-b border-border-muted flex-shrink-0">
           <div className="px-4 py-3 flex items-center gap-2">
-            <button
-              onClick={toggle}
-              className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition"
-              title={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-              aria-label={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-            >
-              <SidebarIcon className="w-4 h-4" />
-            </button>
+            <CollapsedSidebarControls />
             <Link
               href={`/automations/${id}`}
               className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition"

--- a/packages/web/src/app/(app)/automations/[id]/page.tsx
+++ b/packages/web/src/app/(app)/automations/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useState, use } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { describeCron, getReasoningConfig } from "@open-inspect/shared";
-import { useSidebarContext } from "@/components/sidebar-layout";
+import { CollapsedSidebarControls, useSidebarContext } from "@/components/sidebar-layout";
 import { useAutomation, useAutomationInvocations } from "@/hooks/use-automations";
 import { useEnvironments } from "@/hooks/use-environments";
 import { RunHistory } from "@/components/automations/run-history";
@@ -12,8 +12,7 @@ import { AutomationStatusBadge } from "@/components/automations/automation-statu
 import { ConditionSummary } from "@/components/automations/condition-summary";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
-import { SidebarIcon, BackIcon, PencilIcon } from "@/components/ui/icons";
-import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
+import { BackIcon, PencilIcon } from "@/components/ui/icons";
 import { formatModelNameLower } from "@/lib/format";
 import { formatAutomationTargetsLabel } from "@/lib/repo-label";
 
@@ -21,7 +20,7 @@ const HISTORY_PAGE_SIZE = 20;
 
 export default function AutomationDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
-  const { isOpen, toggle } = useSidebarContext();
+  const { isOpen } = useSidebarContext();
   const router = useRouter();
   const { automation, loading, mutate } = useAutomation(id);
   const { environments } = useEnvironments();
@@ -100,15 +99,7 @@ export default function AutomationDetailPage({ params }: { params: Promise<{ id:
       {!isOpen && (
         <header className="border-b border-border-muted flex-shrink-0">
           <div className="px-4 py-3 flex items-center gap-2">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={toggle}
-              title={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-              aria-label={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-            >
-              <SidebarIcon className="w-4 h-4" />
-            </Button>
+            <CollapsedSidebarControls />
             <Link
               href="/automations"
               className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition"

--- a/packages/web/src/app/(app)/automations/new/page.tsx
+++ b/packages/web/src/app/(app)/automations/new/page.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useSidebarContext } from "@/components/sidebar-layout";
+import { CollapsedSidebarControls, useSidebarContext } from "@/components/sidebar-layout";
 import {
   AutomationForm,
   type AutomationFormValues,
@@ -11,12 +11,11 @@ import { WebhookConfig } from "@/components/automations/webhook-config";
 import { getTemplateById } from "@/lib/automation-templates";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
-import { SidebarIcon, BackIcon } from "@/components/ui/icons";
-import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
+import { BackIcon } from "@/components/ui/icons";
 import Link from "next/link";
 
 function NewAutomationContent() {
-  const { isOpen, toggle } = useSidebarContext();
+  const { isOpen } = useSidebarContext();
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -78,14 +77,7 @@ function NewAutomationContent() {
         {!isOpen && (
           <header className="border-b border-border-muted flex-shrink-0">
             <div className="px-4 py-3 flex items-center gap-2">
-              <button
-                onClick={toggle}
-                className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition"
-                title={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-                aria-label={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-              >
-                <SidebarIcon className="w-4 h-4" />
-              </button>
+              <CollapsedSidebarControls />
             </div>
           </header>
         )}
@@ -133,14 +125,7 @@ function NewAutomationContent() {
       {!isOpen && (
         <header className="border-b border-border-muted flex-shrink-0">
           <div className="px-4 py-3 flex items-center gap-2">
-            <button
-              onClick={toggle}
-              className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition"
-              title={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-              aria-label={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-            >
-              <SidebarIcon className="w-4 h-4" />
-            </button>
+            <CollapsedSidebarControls />
             <Link
               href="/automations"
               className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition"

--- a/packages/web/src/app/(app)/automations/page.tsx
+++ b/packages/web/src/app/(app)/automations/page.tsx
@@ -2,16 +2,15 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { useSidebarContext } from "@/components/sidebar-layout";
+import { CollapsedSidebarControls, useSidebarContext } from "@/components/sidebar-layout";
 import { useAutomations } from "@/hooks/use-automations";
 import { AutomationsList } from "@/components/automations/automations-list";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
-import { SidebarIcon, PlusIcon } from "@/components/ui/icons";
-import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
+import { PlusIcon } from "@/components/ui/icons";
 
 export default function AutomationsPage() {
-  const { isOpen, toggle } = useSidebarContext();
+  const { isOpen } = useSidebarContext();
   const { automations, loading, mutate } = useAutomations();
 
   const [actionError, setActionError] = useState<string | null>(null);
@@ -40,15 +39,7 @@ export default function AutomationsPage() {
       {!isOpen && (
         <header className="border-b border-border-muted flex-shrink-0">
           <div className="px-4 py-3">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={toggle}
-              title={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-              aria-label={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-            >
-              <SidebarIcon className="w-4 h-4" />
-            </Button>
+            <CollapsedSidebarControls />
           </div>
         </header>
       )}

--- a/packages/web/src/app/(app)/automations/templates/page.tsx
+++ b/packages/web/src/app/(app)/automations/templates/page.tsx
@@ -1,27 +1,19 @@
 "use client";
 
 import Link from "next/link";
-import { useSidebarContext } from "@/components/sidebar-layout";
+import { CollapsedSidebarControls, useSidebarContext } from "@/components/sidebar-layout";
 import { TemplateGallery } from "@/components/automations/template-gallery";
-import { SidebarIcon, BackIcon } from "@/components/ui/icons";
-import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
+import { BackIcon } from "@/components/ui/icons";
 
 export default function AutomationTemplatesPage() {
-  const { isOpen, toggle } = useSidebarContext();
+  const { isOpen } = useSidebarContext();
 
   return (
     <div className="h-full flex flex-col">
       {!isOpen && (
         <header className="border-b border-border-muted flex-shrink-0">
           <div className="px-4 py-3 flex items-center gap-2">
-            <button
-              onClick={toggle}
-              className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition"
-              title={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-              aria-label={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-            >
-              <SidebarIcon className="w-4 h-4" />
-            </button>
+            <CollapsedSidebarControls />
             <Link
               href="/automations"
               className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition"

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -5,8 +5,7 @@ import { useRouter } from "next/navigation";
 import { mutate } from "swr";
 import { useState, useEffect, useRef, useCallback } from "react";
 import Link from "next/link";
-import { useSidebarContext } from "@/components/sidebar-layout";
-import { Button } from "@/components/ui/button";
+import { CollapsedSidebarControls, useSidebarContext } from "@/components/sidebar-layout";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { formatModelNameLower } from "@/lib/format";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
@@ -21,7 +20,7 @@ import {
 } from "@/hooks/use-session-target-picker";
 import { SessionTargetPicker } from "@/components/session-target-picker";
 import { ReasoningEffortPills } from "@/components/reasoning-effort-pills";
-import { SidebarIcon, ModelIcon, SendIcon } from "@/components/ui/icons";
+import { ModelIcon, SendIcon } from "@/components/ui/icons";
 import { Combobox, type ComboboxGroup } from "@/components/ui/combobox";
 
 const LAST_SELECTED_MODEL_STORAGE_KEY = "open-inspect-last-selected-model";
@@ -295,7 +294,7 @@ function HomeContent({
   handleSubmit: (e: React.FormEvent) => void;
   modelOptions: ModelCategory[];
 }) {
-  const { isOpen, toggle } = useSidebarContext();
+  const { isOpen } = useSidebarContext();
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const { sessionTarget, selectedRepo, repos, loadingRepos, isLaunchable } = picker;
 
@@ -314,15 +313,7 @@ function HomeContent({
       {!isOpen && (
         <header className="border-b border-border-muted flex-shrink-0">
           <div className="px-4 py-3">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={toggle}
-              title={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-              aria-label={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-            >
-              <SidebarIcon className="w-4 h-4" />
-            </Button>
+            <CollapsedSidebarControls />
           </div>
         </header>
       )}

--- a/packages/web/src/app/(app)/settings/integrations/[id]/page.tsx
+++ b/packages/web/src/app/(app)/settings/integrations/[id]/page.tsx
@@ -3,9 +3,12 @@
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { INTEGRATION_DEFINITIONS } from "@open-inspect/shared";
-import { CollapsedSidebarControls, useSidebarContext } from "@/components/sidebar-layout";
-import { SidebarIcon, BackIcon } from "@/components/ui/icons";
-import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
+import {
+  CollapsedSidebarControls,
+  SidebarToggleButton,
+  useSidebarContext,
+} from "@/components/sidebar-layout";
+import { BackIcon } from "@/components/ui/icons";
 import { useIsMobile } from "@/hooks/use-media-query";
 import { integrationSettingsComponents } from "@/components/settings/integrations/integration-settings-registry";
 
@@ -15,7 +18,7 @@ function getIntegration(id: string) {
 
 export default function IntegrationDetailPage() {
   const params = useParams<{ id: string }>();
-  const { isOpen, toggle } = useSidebarContext();
+  const { isOpen } = useSidebarContext();
   const isMobile = useIsMobile();
 
   const integration = getIntegration(params.id);
@@ -34,16 +37,7 @@ export default function IntegrationDetailPage() {
       <header className="border-b border-border-muted flex-shrink-0">
         <div className="px-4 py-3 flex items-center gap-2">
           {!isOpen && <CollapsedSidebarControls />}
-          {isOpen && isMobile && (
-            <button
-              onClick={toggle}
-              className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition"
-              title={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-              aria-label={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-            >
-              <SidebarIcon className="w-4 h-4" />
-            </button>
-          )}
+          {isOpen && isMobile && <SidebarToggleButton label="Toggle sidebar" />}
           <Link
             href="/settings?tab=integrations"
             className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition"

--- a/packages/web/src/app/(app)/settings/integrations/[id]/page.tsx
+++ b/packages/web/src/app/(app)/settings/integrations/[id]/page.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { INTEGRATION_DEFINITIONS } from "@open-inspect/shared";
-import { useSidebarContext } from "@/components/sidebar-layout";
+import { CollapsedSidebarControls, useSidebarContext } from "@/components/sidebar-layout";
 import { SidebarIcon, BackIcon } from "@/components/ui/icons";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import { useIsMobile } from "@/hooks/use-media-query";
@@ -33,7 +33,8 @@ export default function IntegrationDetailPage() {
     <div className="h-full flex flex-col">
       <header className="border-b border-border-muted flex-shrink-0">
         <div className="px-4 py-3 flex items-center gap-2">
-          {(!isOpen || isMobile) && (
+          {!isOpen && <CollapsedSidebarControls />}
+          {isOpen && isMobile && (
             <button
               onClick={toggle}
               className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition"

--- a/packages/web/src/app/(app)/settings/page.tsx
+++ b/packages/web/src/app/(app)/settings/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { useSidebarContext } from "@/components/sidebar-layout";
+import { CollapsedSidebarControls, useSidebarContext } from "@/components/sidebar-layout";
 import { SettingsNav, type SettingsCategory } from "@/components/settings/settings-nav";
 import { SecretsSettings } from "@/components/settings/secrets-settings";
 import { EnvironmentsSettings } from "@/components/settings/environments-settings";
@@ -159,14 +159,7 @@ export default function SettingsPage() {
       {!isOpen && (
         <header className="border-b border-border-muted flex-shrink-0">
           <div className="px-4 py-3">
-            <button
-              onClick={toggle}
-              className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition"
-              title={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-              aria-label={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-            >
-              <SidebarIcon className="w-4 h-4" />
-            </button>
+            <CollapsedSidebarControls />
           </div>
         </header>
       )}

--- a/packages/web/src/components/session-header.tsx
+++ b/packages/web/src/components/session-header.tsx
@@ -1,11 +1,8 @@
 "use client";
 
 import { useEffect, useState, type RefObject } from "react";
-import { useSidebarContext } from "@/components/sidebar-layout";
-import { Button } from "@/components/ui/button";
-import { SidebarIcon } from "@/components/ui/icons";
+import { CollapsedSidebarControls, useSidebarContext } from "@/components/sidebar-layout";
 import type { useSessionSocket } from "@/hooks/use-session-socket";
-import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import { formatRepoLabel } from "@/lib/repo-label";
 
 type SessionSocketState = ReturnType<typeof useSessionSocket>;
@@ -37,7 +34,7 @@ export function SessionHeader({
   onToggleDetails,
   renameSession,
 }: SessionHeaderProps) {
-  const { isOpen, toggle } = useSidebarContext();
+  const { isOpen } = useSidebarContext();
   const hasFallbackSessionInfo =
     fallbackSessionInfo.repoOwner !== null ||
     fallbackSessionInfo.repoName !== null ||
@@ -101,17 +98,7 @@ export function SessionHeader({
     <header className="border-b border-border-muted flex-shrink-0">
       <div className="px-4 py-3 flex items-center justify-between">
         <div className="flex items-center gap-3">
-          {!isOpen && (
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={toggle}
-              title={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-              aria-label={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-            >
-              <SidebarIcon className="w-4 h-4" />
-            </Button>
-          )}
+          {!isOpen && <CollapsedSidebarControls />}
           <div>
             {isRenaming ? (
               <input

--- a/packages/web/src/components/sidebar-layout.test.tsx
+++ b/packages/web/src/components/sidebar-layout.test.tsx
@@ -4,7 +4,9 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { CollapsedSidebarActions } from "./sidebar-layout";
+import { CollapsedSidebarControls, SidebarLayout } from "./sidebar-layout";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
 
 expect.extend(matchers);
 
@@ -15,23 +17,51 @@ vi.mock("next-auth/react", () => ({
 
 vi.mock("next/navigation", () => ({
   useRouter: vi.fn(),
+  usePathname: () => "/",
+}));
+
+vi.mock("@/hooks/use-media-query", () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock("@/hooks/use-sidebar", () => ({
+  useSidebar: () => ({
+    isOpen: true,
+    toggle: vi.fn(),
+    open: vi.fn(),
+    close: vi.fn(),
+  }),
 }));
 
 afterEach(cleanup);
 
-describe("CollapsedSidebarActions", () => {
-  it("keeps search and new session actions available", () => {
-    const onSearchSessions = vi.fn();
-    const onNewSession = vi.fn();
+describe("CollapsedSidebarControls", () => {
+  it("renders the sidebar, search, and new session actions inline", () => {
+    vi.mocked(useSession).mockReturnValue({
+      data: { user: { name: "Test User" }, expires: "2099-01-01" },
+      status: "authenticated",
+      update: vi.fn(),
+    });
+    const push = vi.fn();
+    vi.mocked(useRouter).mockReturnValue({ push } as never);
 
     render(
-      <CollapsedSidebarActions onSearchSessions={onSearchSessions} onNewSession={onNewSession} />
+      <SidebarLayout>
+        <CollapsedSidebarControls />
+      </SidebarLayout>
     );
 
-    fireEvent.click(screen.getByRole("button", { name: /Search sessions/ }));
-    fireEvent.click(screen.getByRole("button", { name: /New session/ }));
+    const controls = screen.getByRole("button", { name: /Open sidebar/ }).parentElement;
+    expect(controls).toHaveClass("flex", "items-center");
+    const buttons = controls?.querySelectorAll("button");
+    expect(buttons).toHaveLength(3);
+    expect(Array.from(buttons!, (button) => button.getAttribute("aria-label"))).toEqual([
+      expect.stringMatching(/^Open sidebar/),
+      expect.stringMatching(/^Search sessions/),
+      expect.stringMatching(/^New session/),
+    ]);
 
-    expect(onSearchSessions).toHaveBeenCalledOnce();
-    expect(onNewSession).toHaveBeenCalledOnce();
+    fireEvent.click(buttons![2]);
+    expect(push).toHaveBeenCalledWith("/");
   });
 });

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -11,14 +11,17 @@ import { useIsMobile } from "@/hooks/use-media-query";
 import { useGlobalShortcuts } from "@/hooks/use-global-shortcuts";
 import { COMMAND_MENU_SESSIONS_KEY, type SessionListResponse } from "@/lib/session-list";
 import { Button } from "@/components/ui/button";
-import { GitHubIcon, GoogleIcon } from "@/components/ui/icons";
+import { GitHubIcon, GoogleIcon, SidebarIcon } from "@/components/ui/icons";
 import { APP_NAME, GOOGLE_LOGIN_ENABLED } from "@/lib/site-config";
+import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 
 interface SidebarContextValue {
   isOpen: boolean;
   toggle: () => void;
   open: () => void;
   close: () => void;
+  searchSessions: () => void;
+  newSession: () => void;
 }
 
 const SidebarContext = createContext<SidebarContextValue | null>(null);
@@ -35,19 +38,22 @@ interface SidebarLayoutProps {
   children: React.ReactNode;
 }
 
-interface CollapsedSidebarActionsProps {
-  onSearchSessions: () => void;
-  onNewSession: () => void;
-}
+export function CollapsedSidebarControls() {
+  const { toggle, searchSessions, newSession } = useSidebarContext();
 
-export function CollapsedSidebarActions({
-  onSearchSessions,
-  onNewSession,
-}: CollapsedSidebarActionsProps) {
   return (
-    <div className="w-12 flex-shrink-0 border-r border-border-muted bg-background px-2 py-3 flex flex-col items-center gap-2">
-      <SearchSessionsButton onClick={onSearchSessions} />
-      <NewSessionButton onClick={onNewSession} />
+    <div className="flex items-center gap-2">
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={toggle}
+        title={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
+        aria-label={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
+      >
+        <SidebarIcon className="w-4 h-4" />
+      </Button>
+      <SearchSessionsButton onClick={searchSessions} />
+      <NewSessionButton onClick={newSession} />
     </div>
   );
 }
@@ -132,7 +138,13 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
   }
 
   return (
-    <SidebarContext.Provider value={sidebar}>
+    <SidebarContext.Provider
+      value={{
+        ...sidebar,
+        searchSessions: handleSearchSessions,
+        newSession: handleNewSession,
+      }}
+    >
       <div className="flex h-dvh overflow-hidden">
         {/* Mobile: overlay backdrop */}
         {isMobile && (
@@ -164,12 +176,6 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
             onSessionSelect={sidebar.close}
           />
         </div>
-        {!isMobile && !sidebar.isOpen && (
-          <CollapsedSidebarActions
-            onSearchSessions={handleSearchSessions}
-            onNewSession={handleNewSession}
-          />
-        )}
         <main className="flex-1 overflow-hidden">{children}</main>
       </div>
       <GlobalCommandMenu

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -20,11 +20,15 @@ interface SidebarContextValue {
   toggle: () => void;
   open: () => void;
   close: () => void;
+}
+
+interface AppShellActionsContextValue {
   searchSessions: () => void;
   newSession: () => void;
 }
 
 const SidebarContext = createContext<SidebarContextValue | null>(null);
+const AppShellActionsContext = createContext<AppShellActionsContextValue | null>(null);
 
 export function useSidebarContext() {
   const context = useContext(SidebarContext);
@@ -38,22 +42,33 @@ interface SidebarLayoutProps {
   children: React.ReactNode;
 }
 
+export function SidebarToggleButton({ label = "Open sidebar" }: { label?: string }) {
+  const { toggle } = useSidebarContext();
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggle}
+      title={`${label} (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
+      aria-label={`${label} (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
+    >
+      <SidebarIcon className="w-4 h-4" />
+    </Button>
+  );
+}
+
 export function CollapsedSidebarControls() {
-  const { toggle, searchSessions, newSession } = useSidebarContext();
+  const actions = useContext(AppShellActionsContext);
+  if (!actions) {
+    throw new Error("CollapsedSidebarControls must be used within a SidebarLayout");
+  }
 
   return (
     <div className="flex items-center gap-2">
-      <Button
-        variant="ghost"
-        size="icon"
-        onClick={toggle}
-        title={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-        aria-label={`Open sidebar (${SHORTCUT_LABELS.TOGGLE_SIDEBAR})`}
-      >
-        <SidebarIcon className="w-4 h-4" />
-      </Button>
-      <SearchSessionsButton onClick={searchSessions} />
-      <NewSessionButton onClick={newSession} />
+      <SidebarToggleButton />
+      <SearchSessionsButton onClick={actions.searchSessions} />
+      <NewSessionButton onClick={actions.newSession} />
     </div>
   );
 }
@@ -138,53 +153,51 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
   }
 
   return (
-    <SidebarContext.Provider
-      value={{
-        ...sidebar,
-        searchSessions: handleSearchSessions,
-        newSession: handleNewSession,
-      }}
-    >
-      <div className="flex h-dvh overflow-hidden">
-        {/* Mobile: overlay backdrop */}
-        {isMobile && (
+    <SidebarContext.Provider value={sidebar}>
+      <AppShellActionsContext.Provider
+        value={{ searchSessions: handleSearchSessions, newSession: handleNewSession }}
+      >
+        <div className="flex h-dvh overflow-hidden">
+          {/* Mobile: overlay backdrop */}
+          {isMobile && (
+            <div
+              className={`fixed inset-0 z-30 bg-overlay transition-opacity duration-200 ${
+                sidebar.isOpen ? "opacity-100" : "opacity-0 pointer-events-none"
+              }`}
+              role="presentation"
+              aria-hidden="true"
+              onClick={sidebar.close}
+            />
+          )}
+          {/* Sidebar: overlay on mobile, push on desktop */}
           <div
-            className={`fixed inset-0 z-30 bg-overlay transition-opacity duration-200 ${
-              sidebar.isOpen ? "opacity-100" : "opacity-0 pointer-events-none"
-            }`}
-            role="presentation"
-            aria-hidden="true"
-            onClick={sidebar.close}
-          />
-        )}
-        {/* Sidebar: overlay on mobile, push on desktop */}
-        <div
-          className={
-            isMobile
-              ? `fixed inset-y-0 left-0 z-40 w-72 transition-transform duration-200 ease-in-out ${
-                  sidebar.isOpen ? "translate-x-0" : "-translate-x-full"
-                }`
-              : `transition-all duration-200 ease-in-out ${
-                  sidebar.isOpen ? "w-72" : "w-0"
-                } flex-shrink-0 overflow-hidden`
-          }
-        >
-          <SessionSidebar
-            onNewSession={handleNewSession}
-            onSearchSessions={handleSearchSessions}
-            onToggle={sidebar.toggle}
-            onSessionSelect={sidebar.close}
-          />
+            className={
+              isMobile
+                ? `fixed inset-y-0 left-0 z-40 w-72 transition-transform duration-200 ease-in-out ${
+                    sidebar.isOpen ? "translate-x-0" : "-translate-x-full"
+                  }`
+                : `transition-all duration-200 ease-in-out ${
+                    sidebar.isOpen ? "w-72" : "w-0"
+                  } flex-shrink-0 overflow-hidden`
+            }
+          >
+            <SessionSidebar
+              onNewSession={handleNewSession}
+              onSearchSessions={handleSearchSessions}
+              onToggle={sidebar.toggle}
+              onSessionSelect={sidebar.close}
+            />
+          </div>
+          <main className="flex-1 overflow-hidden">{children}</main>
         </div>
-        <main className="flex-1 overflow-hidden">{children}</main>
-      </div>
-      <GlobalCommandMenu
-        open={isCommandMenuOpen}
-        onOpenChange={setIsCommandMenuOpen}
-        onNavigate={handleNavigate}
-        onNewSession={handleNewSession}
-        sessions={sessionsResponse?.sessions ?? []}
-      />
+        <GlobalCommandMenu
+          open={isCommandMenuOpen}
+          onOpenChange={setIsCommandMenuOpen}
+          onNavigate={handleNavigate}
+          onNewSession={handleNewSession}
+          sessions={sessionsResponse?.sessions ?? []}
+        />
+      </AppShellActionsContext.Provider>
     </SidebarContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary
- remove the dedicated collapsed sidebar action rail
- place open-sidebar, search, and new-session controls inline in page headers
- reuse the collapsed control group across application routes and verify its order with a focused test

## Testing
- `npm test -w @open-inspect/web -- --run src/components/sidebar-layout.test.tsx src/components/session-header.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- ESLint, Prettier, and `git diff --check`

## Visual verification
- Recorded the sidebar collapse interaction at a desktop viewport
- Video artifact: `35ac4ed72bf0b4991a90eefabaf4568f`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/32972164d9a61e859c4351d4604791ce)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent collapsed-sidebar controls across the app, replacing scattered “open sidebar” buttons with a unified UI.
  * Collapsed sidebars now offer quick actions to open the sidebar, search sessions, and start a new session.
* **Bug Fixes**
  * Improved responsive sidebar header rendering (desktop collapsed vs. mobile toggle behavior) for settings, analytics, home, and automations pages.
* **Tests**
  * Expanded automated coverage for the collapsed-sidebar controls, including accessibility labels and new-session navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->