### PR TITLE
fix(sandbox-runtime): accept nested-namespace repo owners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,13 @@ under 72 characters. Use the PR body for details, not the commit message.
   web app to Cloudflare Workers via OpenNext instead of Vercel. When using Cloudflare, Vercel
   credentials are not required (dummy defaults are used). `NEXT_PUBLIC_WS_URL` must be available at
   build time since Next.js inlines `NEXT_PUBLIC_*` vars into the client bundle.
+- **Repo owners can be nested namespaces**: a `repo_owner` is not always a single segment. GitHub
+  owners are (`octocat`), but GitLab subgroups nest (`group/subgroup`), so an owner may contain `/`.
+  Only `repo_name` is a single path segment (it's the checkout directory under `/workspace`); the
+  owner is used solely in the clone URL. Don't validate or split owners as single segments —
+  `repo_config.parse_repositories` accepts `/`-joined owners (see `is_safe_repo_owner`), and any
+  `owner/name` splitting must split on the **last** `/`, not the first, or nested-namespace repos
+  break (a recurring bug class for non-GitHub providers).
 
 ## CI/CD
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/repo_config.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/repo_config.py
@@ -17,9 +17,8 @@ from typing import Any
 
 from .constants import REPO_MANIFEST_FILE_PATH
 
-# GitHub owner/repo identifiers: a single path segment with no separators.
-# Leading dots are legal (a repo can be named ".github"); "." and ".." are
-# rejected separately below.
+# A single path segment with no separators. Leading dots are legal (a repo can
+# be named ".github"); "." and ".." are rejected separately below.
 _SAFE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
 
@@ -47,10 +46,24 @@ def is_safe_repo_segment(value: str) -> bool:
     return bool(_SAFE_SEGMENT_RE.match(value)) and value not in (".", "..")
 
 
+def is_safe_repo_owner(value: str) -> bool:
+    """True when ``value`` is a namespace path of safe segments.
+
+    An owner may be a single segment (GitHub, ``octocat``) or a nested
+    namespace (GitLab subgroups, ``group/subgroup``). The owner is never used
+    as a filesystem path — checkout directories derive from repo_name — so a
+    ``/`` between safe segments is fine; this only rejects empty segments and
+    traversal ("", "..", "a//b", "/etc", "a/") that could poison the clone URL.
+    """
+    parts = value.split("/")
+    return len(parts) >= 1 and all(is_safe_repo_segment(part) for part in parts)
+
+
 def _require_safe(*, owner: str, name: str) -> None:
-    for label, value in (("repo_owner", owner), ("repo_name", name)):
-        if not is_safe_repo_segment(value):
-            raise RepoConfigError(f"unsafe {label} {value!r}: not a single path segment")
+    if not is_safe_repo_owner(owner):
+        raise RepoConfigError(f"unsafe repo_owner {owner!r}: not a safe namespace path")
+    if not is_safe_repo_segment(name):
+        raise RepoConfigError(f"unsafe repo_name {name!r}: not a single path segment")
 
 
 def _str_field(item: Mapping[str, Any], key: str) -> str:

--- a/packages/sandbox-runtime/tests/test_repo_config.py
+++ b/packages/sandbox-runtime/tests/test_repo_config.py
@@ -48,8 +48,25 @@ class TestParseRepositories:
         with pytest.raises(RepoConfigError, match="repo_name"):
             parse_repositories(config, workspace_path=WORKSPACE)
 
-    def test_rejects_unsafe_owner(self):
-        config = _config({"repo_owner": "a/b", "repo_name": "app"})
+    def test_accepts_nested_namespace_owner(self):
+        # Owners may be nested namespaces (e.g. GitLab subgroups); the owner is
+        # never a filesystem path (checkout dirs derive from repo_name), so
+        # slashes between safe segments are allowed.
+        config = _config(
+            {"repo_owner": "chattermill/frontend", "repo_name": "react-app", "branch": "master"},
+            {"repo_owner": "chattermill/backend", "repo_name": "inspect", "branch": "main"},
+        )
+
+        entries = parse_repositories(config, workspace_path=WORKSPACE)
+
+        assert [(e.owner, e.name) for e in entries] == [
+            ("chattermill/frontend", "react-app"),
+            ("chattermill/backend", "inspect"),
+        ]
+
+    @pytest.mark.parametrize("owner", ["a/../b", "..", "/etc", "a//b", "a/", "a b/c"])
+    def test_rejects_unsafe_owner(self, owner):
+        config = _config({"repo_owner": owner, "repo_name": "app"})
 
         with pytest.raises(RepoConfigError, match="repo_owner"):
             parse_repositories(config, workspace_path=WORKSPACE)


### PR DESCRIPTION
## Summary

`parse_repositories` (in `packages/sandbox-runtime/.../repo_config.py`) rejects any `repo_owner` containing a `/` via `_require_safe` → `unsafe repo_owner '…': not a single path segment`. This breaks **multi-repo sessions for any provider whose owners are nested namespaces** — e.g. GitLab subgroups like `group/subgroup`. Every non-primary repo whose owner has a `/` raises `RepoConfigError`, which drops the whole `repositories` list to the scalar fallback, so only the primary repo is ever cloned.

The owner is never used as a filesystem path — checkout directories derive from `repo_name` (`/workspace/<name>`) — and the owner appears only in the clone URL (`https://<host>/<owner>/<name>.git`), where a `/` is exactly what a nested namespace needs. So validating the owner as a single segment is unnecessary and wrong for non-GitHub providers.

### Change
- Add `is_safe_repo_owner`: accepts a `/`-joined path of safe segments, still rejecting empty segments and traversal (``, `..`, `a//b`, `/etc`, `a/`).
- `_require_safe` uses it for `repo_owner`; `repo_name` stays a single path segment (it's the checkout directory).
- Document the nested-namespace owner convention (and the last-vs-first-slash split pitfall) in `AGENTS.md` → Key Gotchas.

GitHub owners (`octocat`) are unaffected — a single segment is a valid one-element namespace path.

## Test plan

- [x] New `test_accepts_nested_namespace_owner`: a 2-repo config with `chattermill/frontend` + `chattermill/backend` owners now yields 2 `RepoEntry` instead of raising.
- [x] `test_rejects_unsafe_owner` reworked to assert traversal/empty owners still raise (`a/../b`, `..`, `/etc`, `a//b`, `a/`, `a b/c`).
- [x] `repo_name` single-segment validation unchanged (traversal/absolute names still rejected).
- [x] `pytest packages/sandbox-runtime` — 449 passed; `ruff` + `mypy` clean.

## Note

If the control-plane applies an equivalent single-segment owner validation at session-create time, it would need the same relaxation for this to work end-to-end for nested-namespace providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for repositories whose owners use nested namespaces, such as subgroup paths.
  * Repository names continue to require a single path segment.

* **Bug Fixes**
  * Improved repository configuration validation to safely handle nested owners.
  * Invalid, empty, absolute, or traversal-based owner paths are now rejected with clearer errors.

* **Documentation**
  * Added guidance explaining how repository owners and names are interpreted for non-GitHub providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->