### PR TITLE
fix(web): add spacing below session owner filter

### DIFF
--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -425,7 +425,7 @@ export function SessionSidebar({
         </Link>
       </div>
 
-      <div className="px-3 pt-2">
+      <div className="px-3 py-2">
         <ToggleGroup
           type="single"
           value={sessionCreatorFilter}


### PR DESCRIPTION
## Summary
- add bottom padding below the All/Mine session owner filter
- keep highlighted session borders visually separated from the picker after search moved to the command menu

## Testing
- `npm test -w @open-inspect/web -- --run src/components/session-sidebar.test.tsx`
- `npm run lint -w @open-inspect/web`
- `git diff --check`

## Visual verification
A 1440x900 local viewport capture was uploaded as artifact `dd21a9855d68bf271db742430be50cc1`, but the local app remained on its startup/loading screen without an authenticated runtime session, so the populated sidebar state could not be captured.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/99a447428e48aaa42a608fa00dc19c91)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted vertical spacing around the owner-filter toggle for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->