### PR TITLE
fix(slack): forward interim thread messages to existing sessions

### DIFF
--- a/packages/shared/src/slack/client.test.ts
+++ b/packages/shared/src/slack/client.test.ts
@@ -350,6 +350,19 @@ describe("getThreadMessages", () => {
     expect(url).toBe("https://slack.com/api/conversations.replies?channel=C123&ts=1.0&limit=5");
   });
 
+  it("passes oldest to fetch only newer replies", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ ok: true, messages: [] }));
+
+    await getThreadMessages("xoxb-token", "C123", "1.0", 5, "1.5");
+
+    const [url] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe(
+      "https://slack.com/api/conversations.replies?channel=C123&ts=1.0&limit=5&oldest=1.5"
+    );
+  });
+
   it("defaults limit to 10 when not provided", async () => {
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")

--- a/packages/shared/src/slack/client.test.ts
+++ b/packages/shared/src/slack/client.test.ts
@@ -328,7 +328,7 @@ describe("getThreadMessages", () => {
     vi.restoreAllMocks();
   });
 
-  it("fetches replies via GET with channel/ts/limit", async () => {
+  it("fetches replies via GET with channel/ts", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       jsonResponse({
         ok: true,
@@ -339,7 +339,7 @@ describe("getThreadMessages", () => {
       })
     );
 
-    const result = await getThreadMessages("xoxb-token", "C123", "1.0", 5);
+    const result = await getThreadMessages("xoxb-token", "C123", "1.0");
 
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -347,7 +347,7 @@ describe("getThreadMessages", () => {
       expect(result.messages[0]!.text).toBe("first");
     }
     const [url] = fetchSpy.mock.calls[0]!;
-    expect(url).toBe("https://slack.com/api/conversations.replies?channel=C123&ts=1.0&limit=5");
+    expect(url).toBe("https://slack.com/api/conversations.replies?channel=C123&ts=1.0&limit=200");
   });
 
   it("passes oldest to fetch only newer replies", async () => {
@@ -355,23 +355,38 @@ describe("getThreadMessages", () => {
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(jsonResponse({ ok: true, messages: [] }));
 
-    await getThreadMessages("xoxb-token", "C123", "1.0", 5, "1.5");
+    await getThreadMessages("xoxb-token", "C123", "1.0", "1.5");
 
     const [url] = fetchSpy.mock.calls[0]!;
     expect(url).toBe(
-      "https://slack.com/api/conversations.replies?channel=C123&ts=1.0&limit=5&oldest=1.5"
+      "https://slack.com/api/conversations.replies?channel=C123&ts=1.0&limit=200&oldest=1.5"
     );
   });
 
-  it("defaults limit to 10 when not provided", async () => {
+  it("follows next_cursor pagination and concatenates pages", async () => {
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(jsonResponse({ ok: true, messages: [] }));
+      .mockResolvedValueOnce(
+        jsonResponse({
+          ok: true,
+          messages: [{ ts: "1.1", text: "first", user: "U1" }],
+          response_metadata: { next_cursor: "cursor-2" },
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ ok: true, messages: [{ ts: "1.2", text: "second", user: "U2" }] })
+      );
 
-    await getThreadMessages("xoxb-token", "C123", "1.0");
+    const result = await getThreadMessages("xoxb-token", "C123", "1.0", "1.0");
 
-    const [url] = fetchSpy.mock.calls[0]!;
-    expect(String(url)).toContain("limit=10");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.messages.map((m) => m.text)).toEqual(["first", "second"]);
+    }
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const [secondUrl] = fetchSpy.mock.calls[1]!;
+    expect(String(secondUrl)).toContain("cursor=cursor-2");
+    expect(String(secondUrl)).toContain("oldest=1.0");
   });
 
   it("returns Slack's error envelope on lookup failure", async () => {
@@ -383,6 +398,24 @@ describe("getThreadMessages", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toBe("thread_not_found");
+    }
+  });
+
+  it("returns the failure arm when a later page errors", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse({
+          ok: true,
+          messages: [{ ts: "1.1", text: "first", user: "U1" }],
+          response_metadata: { next_cursor: "cursor-2" },
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ ok: false, error: "ratelimited" }));
+
+    const result = await getThreadMessages("xoxb-token", "C123", "1.0");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toBe("ratelimited");
     }
   });
 });

--- a/packages/shared/src/slack/client.ts
+++ b/packages/shared/src/slack/client.ts
@@ -294,12 +294,14 @@ export function getThreadMessages(
   token: string,
   channelId: string,
   threadTs: string,
-  limit = 10
+  limit = 10,
+  oldest?: string
 ): Promise<SlackEnvelope<{ messages: SlackThreadMessage[] }>> {
   return slackGet(token, "conversations.replies", {
     channel: channelId,
     ts: threadTs,
     limit: String(limit),
+    ...(oldest ? { oldest } : {}),
   });
 }
 

--- a/packages/shared/src/slack/client.ts
+++ b/packages/shared/src/slack/client.ts
@@ -290,19 +290,42 @@ export interface SlackThreadMessage {
   bot_id?: string;
 }
 
-export function getThreadMessages(
+/**
+ * Fetch a thread's replies via `conversations.replies`, following
+ * `response_metadata.next_cursor` pagination so long threads are collected in
+ * full rather than truncated to Slack's first (oldest) page. Pass `oldest` to
+ * restrict the window to messages posted after that ts. Messages are returned
+ * oldest-first. Returns the SlackEnvelope failure arm on any page's error.
+ */
+export async function getThreadMessages(
   token: string,
   channelId: string,
   threadTs: string,
-  limit = 10,
   oldest?: string
 ): Promise<SlackEnvelope<{ messages: SlackThreadMessage[] }>> {
-  return slackGet(token, "conversations.replies", {
-    channel: channelId,
-    ts: threadTs,
-    limit: String(limit),
-    ...(oldest ? { oldest } : {}),
-  });
+  const messages: SlackThreadMessage[] = [];
+  let cursor: string | undefined;
+  // Bound the loop defensively: 200/page × 25 pages caps at 5k messages.
+  for (let page = 0; page < 25; page++) {
+    const query: Record<string, string> = {
+      channel: channelId,
+      ts: threadTs,
+      limit: "200",
+    };
+    if (oldest) query.oldest = oldest;
+    if (cursor) query.cursor = cursor;
+
+    const res = await slackGet<{
+      messages: SlackThreadMessage[];
+      response_metadata?: { next_cursor?: string };
+    }>(token, "conversations.replies", query);
+    if (!res.ok) return res;
+
+    messages.push(...(res.messages ?? []));
+    cursor = res.response_metadata?.next_cursor || undefined;
+    if (!cursor) break;
+  }
+  return { ok: true, messages };
 }
 
 export interface SlackUser {

--- a/packages/slack-bot/src/events/message-handler.ts
+++ b/packages/slack-bot/src/events/message-handler.ts
@@ -17,16 +17,69 @@ import {
   scheduleStartingStatus,
   type BackgroundTaskScheduler,
 } from "../messages/blocks";
-import { formatChannelContext } from "../messages/context";
+import { formatChannelContext, formatInterimThreadContext } from "../messages/context";
 import { storePendingRequest } from "../pending-requests/pending-request-store";
 import { sendPrompt } from "../sessions/control-plane-client";
 import { startSessionAndSendPrompt } from "../sessions/session-launcher";
-import { clearThreadSession, lookupThreadSession } from "../sessions/thread-session-store";
+import {
+  clearThreadSession,
+  lookupThreadSession,
+  storeThreadSession,
+} from "../sessions/thread-session-store";
 import { buildTargetClarificationBlocks } from "../target-clarification";
 import { targetLabel } from "../targets";
 import type { Env } from "../types";
 
 const log = createLogger("handler");
+const THREAD_HISTORY_MESSAGE_LIMIT = 10;
+
+interface ThreadHistoryOptions {
+  /** ts of the message currently being handled, excluded from the history. */
+  excludeTs: string;
+  /** Only include messages posted strictly after this Slack ts. */
+  sinceTs?: string;
+  includeBotMessages: boolean;
+}
+
+async function fetchThreadHistory(
+  env: Env,
+  channel: string,
+  threadTs: string,
+  options: ThreadHistoryOptions
+): Promise<string[] | undefined> {
+  const { excludeTs, sinceTs, includeBotMessages } = options;
+  try {
+    const threadResult = await getThreadMessages(
+      env.SLACK_BOT_TOKEN,
+      channel,
+      threadTs,
+      THREAD_HISTORY_MESSAGE_LIMIT,
+      sinceTs
+    );
+    if (!threadResult.ok || !threadResult.messages) return undefined;
+    const filtered = threadResult.messages.filter((m) => {
+      if (m.ts === excludeTs) return false;
+      if (!includeBotMessages && m.bot_id) return false;
+      // conversations.replies can still return the parent message when
+      // `oldest` is set, so re-check the boundary here.
+      if (sinceTs && parseFloat(m.ts) <= parseFloat(sinceTs)) return false;
+      return true;
+    });
+    if (filtered.length === 0) return undefined;
+    const uniqueUserIds = [...new Set(filtered.map((m) => m.user).filter(Boolean))] as string[];
+    const userNames = await resolveUserNames(env.SLACK_BOT_TOKEN, uniqueUserIds);
+    return filtered
+      .map((m) => {
+        if (m.bot_id) return `[Bot]: ${m.text}`;
+        const name = m.user ? userNames.get(m.user) || m.user : "Unknown";
+        return `[${name}]: ${m.text}`;
+      })
+      .slice(-THREAD_HISTORY_MESSAGE_LIMIT);
+  } catch {
+    // Thread context is best effort.
+    return undefined;
+  }
+}
 
 interface IncomingMessageParams {
   text: string;
@@ -79,15 +132,29 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
       const channelContext = channelName
         ? formatChannelContext(channelName, channelDescription)
         : "";
+      // The session already has its own turns, so only forward the human
+      // discussion that happened in the thread since the last prompt.
+      const interimMessages = existingSession.lastPromptTs
+        ? await fetchThreadHistory(env, channel, threadTs, {
+            excludeTs: ts,
+            sinceTs: existingSession.lastPromptTs,
+            includeBotMessages: false,
+          })
+        : undefined;
+      const interimContext = interimMessages ? formatInterimThreadContext(interimMessages) : "";
       const promptResult = await sendPrompt(
         env,
         existingSession.sessionId,
-        channelContext + messageText,
+        channelContext + interimContext + messageText,
         `slack:${user}`,
         callbackContext,
         traceId
       );
       if (promptResult.ok) {
+        await storeThreadSession(env, channel, threadTs, {
+          ...existingSession,
+          lastPromptTs: ts,
+        });
         const reactionResult = await addReaction(env.SLACK_BOT_TOKEN, channel, ts, "eyes");
         if (!reactionResult.ok && reactionResult.error !== "already_reacted") {
           log.warn("slack.reaction.add", {
@@ -119,26 +186,9 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
     }
   }
 
-  let previousMessages: string[] | undefined;
-  if (threadTs) {
-    try {
-      const threadResult = await getThreadMessages(env.SLACK_BOT_TOKEN, channel, threadTs, 10);
-      if (threadResult.ok && threadResult.messages) {
-        const filtered = threadResult.messages.filter((m) => m.ts !== ts);
-        const uniqueUserIds = [...new Set(filtered.map((m) => m.user).filter(Boolean))] as string[];
-        const userNames = await resolveUserNames(env.SLACK_BOT_TOKEN, uniqueUserIds);
-        previousMessages = filtered
-          .map((m) => {
-            if (m.bot_id) return `[Bot]: ${m.text}`;
-            const name = m.user ? userNames.get(m.user) || m.user : "Unknown";
-            return `[${name}]: ${m.text}`;
-          })
-          .slice(-10);
-      }
-    } catch {
-      // Thread context is best effort.
-    }
-  }
+  const previousMessages = threadTs
+    ? await fetchThreadHistory(env, channel, threadTs, { excludeTs: ts, includeBotMessages: true })
+    : undefined;
 
   const result = await createClassifier(env).classify(
     messageText,
@@ -183,18 +233,18 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
   });
   const ackTs = ackResult.ok ? ackResult.ts : undefined;
   scheduleStartingStatus(scheduleBackground, env, channel, threadKey, traceId);
-  const sessionResult = await startSessionAndSendPrompt(
-    env,
-    result.target,
+  const sessionResult = await startSessionAndSendPrompt(env, {
+    target: result.target,
     channel,
-    threadKey,
+    threadTs: threadKey,
     messageText,
-    user,
+    userId: user,
+    messageTs: ts,
     previousMessages,
     channelName,
     channelDescription,
-    traceId
-  );
+    traceId,
+  });
   if (!sessionResult) return;
   if (ackTs) {
     await updateMessage(env.SLACK_BOT_TOKEN, channel, ackTs, `Working on *${label}*...`, {

--- a/packages/slack-bot/src/events/message-handler.ts
+++ b/packages/slack-bot/src/events/message-handler.ts
@@ -22,9 +22,9 @@ import { storePendingRequest } from "../pending-requests/pending-request-store";
 import { sendPrompt } from "../sessions/control-plane-client";
 import { startSessionAndSendPrompt } from "../sessions/session-launcher";
 import {
+  advanceLastPromptTs,
   clearThreadSession,
   lookupThreadSession,
-  storeThreadSession,
 } from "../sessions/thread-session-store";
 import { buildTargetClarificationBlocks } from "../target-clarification";
 import { targetLabel } from "../targets";
@@ -41,6 +41,14 @@ interface ThreadHistoryOptions {
   includeBotMessages: boolean;
 }
 
+/**
+ * Collect the last THREAD_HISTORY_MESSAGE_LIMIT relevant thread messages as
+ * "[name]: text" lines. getThreadMessages paginates the full window, so the
+ * newest messages survive the cap even in long threads. Returns [] when the
+ * window holds no relevant messages and undefined when Slack could not be
+ * queried — callers use the distinction to decide whether the window was
+ * actually considered.
+ */
 async function fetchThreadHistory(
   env: Env,
   channel: string,
@@ -49,32 +57,26 @@ async function fetchThreadHistory(
 ): Promise<string[] | undefined> {
   const { excludeTs, sinceTs, includeBotMessages } = options;
   try {
-    const threadResult = await getThreadMessages(
-      env.SLACK_BOT_TOKEN,
-      channel,
-      threadTs,
-      THREAD_HISTORY_MESSAGE_LIMIT,
-      sinceTs
-    );
+    const threadResult = await getThreadMessages(env.SLACK_BOT_TOKEN, channel, threadTs, sinceTs);
     if (!threadResult.ok || !threadResult.messages) return undefined;
-    const filtered = threadResult.messages.filter((m) => {
-      if (m.ts === excludeTs) return false;
-      if (!includeBotMessages && m.bot_id) return false;
-      // conversations.replies can still return the parent message when
-      // `oldest` is set, so re-check the boundary here.
-      if (sinceTs && parseFloat(m.ts) <= parseFloat(sinceTs)) return false;
-      return true;
-    });
-    if (filtered.length === 0) return undefined;
-    const uniqueUserIds = [...new Set(filtered.map((m) => m.user).filter(Boolean))] as string[];
-    const userNames = await resolveUserNames(env.SLACK_BOT_TOKEN, uniqueUserIds);
-    return filtered
-      .map((m) => {
-        if (m.bot_id) return `[Bot]: ${m.text}`;
-        const name = m.user ? userNames.get(m.user) || m.user : "Unknown";
-        return `[${name}]: ${m.text}`;
+    const relevant = threadResult.messages
+      .filter((m) => {
+        if (m.ts === excludeTs) return false;
+        if (!includeBotMessages && m.bot_id) return false;
+        // conversations.replies can still return the parent message when
+        // `oldest` is set, so re-check the boundary here.
+        if (sinceTs && parseFloat(m.ts) <= parseFloat(sinceTs)) return false;
+        return true;
       })
       .slice(-THREAD_HISTORY_MESSAGE_LIMIT);
+    if (relevant.length === 0) return [];
+    const uniqueUserIds = [...new Set(relevant.map((m) => m.user).filter(Boolean))] as string[];
+    const userNames = await resolveUserNames(env.SLACK_BOT_TOKEN, uniqueUserIds);
+    return relevant.map((m) => {
+      if (m.bot_id) return `[Bot]: ${m.text}`;
+      const name = m.user ? userNames.get(m.user) || m.user : "Unknown";
+      return `[${name}]: ${m.text}`;
+    });
   } catch {
     // Thread context is best effort.
     return undefined;
@@ -151,10 +153,14 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
         traceId
       );
       if (promptResult.ok) {
-        await storeThreadSession(env, channel, threadTs, {
-          ...existingSession,
-          lastPromptTs: ts,
-        });
+        // Only advance the checkpoint past messages we know were considered.
+        // When the interim fetch failed, keeping the old watermark lets the
+        // next follow-up retry the window; at worst it re-includes this
+        // message's text as interim context.
+        const interimFetchFailed = Boolean(existingSession.lastPromptTs) && !interimMessages;
+        if (!interimFetchFailed) {
+          await advanceLastPromptTs(env, channel, threadTs, ts);
+        }
         const reactionResult = await addReaction(env.SLACK_BOT_TOKEN, channel, ts, "eyes");
         if (!reactionResult.ok && reactionResult.error !== "already_reacted") {
           log.warn("slack.reaction.add", {

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -227,7 +227,11 @@ function makeSessionEnv(
 
 function mockSlackFetch(
   order: string[] = [],
-  options: { statusResponse?: Response | Promise<Response>; threadMessages?: unknown[] } = {}
+  options: {
+    statusResponse?: Response | Promise<Response>;
+    threadMessages?: unknown[];
+    threadRepliesError?: string;
+  } = {}
 ) {
   return vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
     const url = typeof input === "string" ? input : input.toString();
@@ -254,7 +258,10 @@ function mockSlackFetch(
     }
 
     if (url.includes("conversations.replies")) {
-      return new Response(JSON.stringify({ ok: true, messages: options.threadMessages ?? [] }), {
+      const payload = options.threadRepliesError
+        ? { ok: false, error: options.threadRepliesError }
+        : { ok: true, messages: options.threadMessages ?? [] };
+      return new Response(JSON.stringify(payload), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
@@ -951,6 +958,59 @@ describe("POST /events", () => {
     expect(content).not.toContain("<@B123>");
     await expect(kv.get("thread:C123:111.222", "json")).resolves.toEqual(
       expect.objectContaining({ sessionId: "session-1", lastPromptTs: "333.444" })
+    );
+
+    slackFetch.mockRestore();
+  });
+
+  it("keeps the interim checkpoint when the thread fetch fails", async () => {
+    const order: string[] = [];
+    const slackFetch = mockSlackFetch(order, { threadRepliesError: "ratelimited" });
+    const env = makeSessionEnv(order);
+    const kv = env.SLACK_KV as unknown as {
+      put: (key: string, value: string) => Promise<void>;
+      get: (key: string, type: string) => Promise<unknown>;
+    };
+    await kv.put(
+      "thread:C123:111.222",
+      JSON.stringify({
+        sessionId: "session-1",
+        repoId: "acme/app",
+        repoFullName: "acme/app",
+        model: "anthropic/claude-haiku-4-5",
+        createdAt: Date.now(),
+        lastPromptTs: "111.222",
+      })
+    );
+    const ctx = makeCtx();
+
+    const response = await app.fetch(
+      slackEventRequest({
+        type: "app_mention",
+        text: "<@B123> see the above chat",
+        user: "U123",
+        channel: "C123",
+        ts: "333.444",
+        thread_ts: "111.222",
+      }),
+      env,
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    await flushWaitUntil(ctx);
+
+    // The prompt is still sent — thread context stays best effort — but the
+    // checkpoint is not advanced past messages that were never considered.
+    const promptBodies = promptFetchBodies(
+      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: readonly (readonly unknown[])[] } }
+    );
+    expect(promptBodies).toHaveLength(1);
+    expect(String(promptBodies[0].content)).not.toContain(
+      "New messages in the Slack thread since your last task"
+    );
+    await expect(kv.get("thread:C123:111.222", "json")).resolves.toEqual(
+      expect.objectContaining({ sessionId: "session-1", lastPromptTs: "111.222" })
     );
 
     slackFetch.mockRestore();

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -767,6 +767,14 @@ describe("POST /events", () => {
     expect(
       slackFetch.mock.calls.some(([input]) => String(input).includes("conversations.replies"))
     ).toBe(false);
+    // Legacy mappings without lastPromptTs get stamped so the next follow-up
+    // can scope interim thread context.
+    await expect(
+      (env.SLACK_KV as unknown as { get: (key: string, type: string) => Promise<unknown> }).get(
+        "thread:C123:111.222",
+        "json"
+      )
+    ).resolves.toEqual(expect.objectContaining({ lastPromptTs: "333.444" }));
 
     slackFetch.mockRestore();
   });
@@ -870,6 +878,79 @@ describe("POST /events", () => {
     ).get("thread:C123:111.222", "json");
     await expect(storedMapping).resolves.toEqual(
       expect.objectContaining({ sessionId: "session-1" })
+    );
+
+    slackFetch.mockRestore();
+  });
+
+  it("forwards interim human messages on follow-ups to an existing session", async () => {
+    const order: string[] = [];
+    const slackFetch = mockSlackFetch(order, {
+      threadMessages: [
+        { type: "message", text: "<@B123> do this action", user: "U123", ts: "111.222" },
+        { type: "message", text: "what do you think?", user: "U456", ts: "222.000" },
+        { type: "message", text: "i think we should do x", user: "U789", ts: "225.000" },
+        { type: "message", text: "Working on acme/app...", bot_id: "B123", ts: "230.000" },
+        { type: "message", text: "<@B123> see the above chat", user: "U123", ts: "333.444" },
+      ],
+    });
+    const env = makeSessionEnv(order);
+    const kv = env.SLACK_KV as unknown as {
+      put: (key: string, value: string) => Promise<void>;
+      get: (key: string, type: string) => Promise<unknown>;
+    };
+    await kv.put(
+      "thread:C123:111.222",
+      JSON.stringify({
+        sessionId: "session-1",
+        repoId: "acme/app",
+        repoFullName: "acme/app",
+        model: "anthropic/claude-haiku-4-5",
+        createdAt: Date.now(),
+        lastPromptTs: "111.222",
+      })
+    );
+    const ctx = makeCtx();
+
+    const response = await app.fetch(
+      slackEventRequest({
+        type: "app_mention",
+        text: "<@B123> see the above chat",
+        user: "U123",
+        channel: "C123",
+        ts: "333.444",
+        thread_ts: "111.222",
+      }),
+      env,
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    await flushWaitUntil(ctx);
+
+    expect(order).not.toContain("session");
+    const repliesCalls = slackFetch.mock.calls.filter(([input]) =>
+      String(input).includes("conversations.replies")
+    );
+    expect(repliesCalls).toHaveLength(1);
+    expect(String(repliesCalls[0][0])).toContain("oldest=111.222");
+
+    const promptBodies = promptFetchBodies(
+      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: readonly (readonly unknown[])[] } }
+    );
+    expect(promptBodies).toHaveLength(1);
+    const content = String(promptBodies[0].content);
+    expect(content).toContain("New messages in the Slack thread since your last task");
+    expect(content).toContain("what do you think?");
+    expect(content).toContain("i think we should do x");
+    // Bot replies and messages already forwarded stay out of the follow-up.
+    expect(content).not.toContain("Working on acme/app");
+    expect(content).not.toContain("do this action");
+    expect(content).toContain("see the above chat");
+    // The triggering message itself is the prompt, not interim context.
+    expect(content).not.toContain("<@B123>");
+    await expect(kv.get("thread:C123:111.222", "json")).resolves.toEqual(
+      expect.objectContaining({ sessionId: "session-1", lastPromptTs: "333.444" })
     );
 
     slackFetch.mockRestore();

--- a/packages/slack-bot/src/interactions/target-selection.ts
+++ b/packages/slack-bot/src/interactions/target-selection.ts
@@ -57,8 +57,9 @@ export async function handleTargetSelection(
     messageText: message,
     userId,
     // The original message ts isn't persisted with the pending request, so
-    // the "Working on..." ack marks where interim thread context resumes.
-    messageTs: ackTs,
+    // the "Working on..." ack — or the interaction message when the ack post
+    // fails — marks where interim thread context resumes.
+    messageTs: ackTs ?? messageTs,
     previousMessages,
     channelName,
     channelDescription,

--- a/packages/slack-bot/src/interactions/target-selection.ts
+++ b/packages/slack-bot/src/interactions/target-selection.ts
@@ -50,18 +50,20 @@ export async function handleTargetSelection(
     blocks: buildWorkingMessageBlocks(label),
   });
   const ackTs = ackResult.ok ? ackResult.ts : undefined;
-  const sessionResult = await startSessionAndSendPrompt(
-    env,
+  const sessionResult = await startSessionAndSendPrompt(env, {
     target,
     channel,
-    threadKey,
-    message,
+    threadTs: threadKey,
+    messageText: message,
     userId,
+    // The original message ts isn't persisted with the pending request, so
+    // the "Working on..." ack marks where interim thread context resumes.
+    messageTs: ackTs,
     previousMessages,
     channelName,
     channelDescription,
-    traceId
-  );
+    traceId,
+  });
   if (!sessionResult) return;
 
   await deletePendingRequest(env, channel, threadKey);

--- a/packages/slack-bot/src/messages/context.ts
+++ b/packages/slack-bot/src/messages/context.ts
@@ -3,6 +3,11 @@ export function formatThreadContext(previousMessages: string[]): string {
   return `Context from the Slack thread:\n---\n${previousMessages.join("\n")}\n---\n\n`;
 }
 
+export function formatInterimThreadContext(interimMessages: string[]): string {
+  if (interimMessages.length === 0) return "";
+  return `New messages in the Slack thread since your last task:\n---\n${interimMessages.join("\n")}\n---\n\n`;
+}
+
 export function formatChannelContext(channelName: string, channelDescription?: string): string {
   let context = `Slack channel context:\n---\nChannel: #${channelName}`;
   if (channelDescription) context += `\nDescription: ${channelDescription}`;

--- a/packages/slack-bot/src/messages/context.ts
+++ b/packages/slack-bot/src/messages/context.ts
@@ -1,11 +1,17 @@
+function formatMessageSection(header: string, messages: string[]): string {
+  if (messages.length === 0) return "";
+  return `${header}:\n---\n${messages.join("\n")}\n---\n\n`;
+}
+
 export function formatThreadContext(previousMessages: string[]): string {
-  if (previousMessages.length === 0) return "";
-  return `Context from the Slack thread:\n---\n${previousMessages.join("\n")}\n---\n\n`;
+  return formatMessageSection("Context from the Slack thread", previousMessages);
 }
 
 export function formatInterimThreadContext(interimMessages: string[]): string {
-  if (interimMessages.length === 0) return "";
-  return `New messages in the Slack thread since your last task:\n---\n${interimMessages.join("\n")}\n---\n\n`;
+  return formatMessageSection(
+    "New messages in the Slack thread since your last task",
+    interimMessages
+  );
 }
 
 export function formatChannelContext(channelName: string, channelDescription?: string): string {

--- a/packages/slack-bot/src/sessions/session-launcher.ts
+++ b/packages/slack-bot/src/sessions/session-launcher.ts
@@ -8,18 +8,39 @@ import { getResolvedUserPreferences } from "../user-preferences";
 import { createSession, sendPrompt } from "./control-plane-client";
 import { buildThreadSession, storeThreadSession } from "./thread-session-store";
 
+export interface StartSessionOptions {
+  target: SlackSessionTarget;
+  channel: string;
+  threadTs: string;
+  messageText: string;
+  userId: string;
+  /**
+   * Slack ts of the triggering message. Persisted on the thread mapping so
+   * follow-ups can scope interim thread context to newer messages.
+   */
+  messageTs?: string;
+  previousMessages?: string[];
+  channelName?: string;
+  channelDescription?: string;
+  traceId?: string;
+}
+
 export async function startSessionAndSendPrompt(
   env: Env,
-  target: SlackSessionTarget,
-  channel: string,
-  threadTs: string,
-  messageText: string,
-  userId: string,
-  previousMessages?: string[],
-  channelName?: string,
-  channelDescription?: string,
-  traceId?: string
+  options: StartSessionOptions
 ): Promise<{ sessionId: string } | null> {
+  const {
+    target,
+    channel,
+    threadTs,
+    messageText,
+    userId,
+    messageTs,
+    previousMessages,
+    channelName,
+    channelDescription,
+    traceId,
+  } = options;
   const [availableModels, slackDefaultModel] = await Promise.all([
     getAvailableModels(env, traceId),
     getSlackDefaultModel(env, traceId),
@@ -104,7 +125,7 @@ export async function startSessionAndSendPrompt(
     env,
     channel,
     threadTs,
-    buildThreadSession(session.sessionId, target, model, reasoningEffort)
+    buildThreadSession(session.sessionId, target, model, reasoningEffort, messageTs)
   );
   return { sessionId: session.sessionId };
 }

--- a/packages/slack-bot/src/sessions/thread-session-store.test.ts
+++ b/packages/slack-bot/src/sessions/thread-session-store.test.ts
@@ -78,7 +78,8 @@ describe("thread session store", () => {
           },
         },
         "openai/gpt-5.4",
-        "high"
+        "high",
+        "111.222"
       )
     ).toEqual({
       sessionId: "session-1",
@@ -87,6 +88,7 @@ describe("thread session store", () => {
       model: "openai/gpt-5.4",
       reasoningEffort: "high",
       createdAt: 456,
+      lastPromptTs: "111.222",
     });
   });
 
@@ -116,6 +118,14 @@ describe("thread session store", () => {
       reasoningEffort: 123,
       createdAt: 123,
     },
+    {
+      sessionId: "session-1",
+      repoId: "acme/app",
+      repoFullName: "acme/app",
+      model: "openai/gpt-5.4",
+      createdAt: 123,
+      lastPromptTs: 333.444,
+    },
   ])("rejects malformed records: %j", async (record) => {
     mocks.get.mockResolvedValue(record);
 
@@ -135,6 +145,23 @@ describe("thread session store", () => {
 
     await expect(lookupThreadSession(mocks.env, "C123", "111.222")).resolves.toEqual(base);
     await expect(lookupThreadSession(mocks.env, "C123", "111.222")).resolves.toEqual(withReasoning);
+  });
+
+  it("accepts persisted records with and without a last prompt ts", async () => {
+    const base: ThreadSession = {
+      sessionId: "session-1",
+      repoId: "acme/app",
+      repoFullName: "acme/app",
+      model: "openai/gpt-5.4",
+      createdAt: 123,
+    };
+    const withLastPrompt = { ...base, lastPromptTs: "333.444" };
+    mocks.get.mockResolvedValueOnce(base).mockResolvedValueOnce(withLastPrompt);
+
+    await expect(lookupThreadSession(mocks.env, "C123", "111.222")).resolves.toEqual(base);
+    await expect(lookupThreadSession(mocks.env, "C123", "111.222")).resolves.toEqual(
+      withLastPrompt
+    );
   });
 
   it("handles KV write and delete failures", async () => {

--- a/packages/slack-bot/src/sessions/thread-session-store.test.ts
+++ b/packages/slack-bot/src/sessions/thread-session-store.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env, ThreadSession } from "../types";
 import {
+  advanceLastPromptTs,
   buildThreadSession,
   clearThreadSession,
   lookupThreadSession,
@@ -162,6 +163,58 @@ describe("thread session store", () => {
     await expect(lookupThreadSession(mocks.env, "C123", "111.222")).resolves.toEqual(
       withLastPrompt
     );
+  });
+
+  describe("advanceLastPromptTs", () => {
+    const stored: ThreadSession = {
+      sessionId: "session-1",
+      repoId: "acme/app",
+      repoFullName: "acme/app",
+      model: "openai/gpt-5.4",
+      createdAt: 123,
+      lastPromptTs: "222.333",
+    };
+
+    it("advances the checkpoint when the new ts is newer", async () => {
+      mocks.get.mockResolvedValue(stored);
+
+      await advanceLastPromptTs(mocks.env, "C123", "111.222", "333.444");
+
+      expect(mocks.put).toHaveBeenCalledWith(
+        "thread:C123:111.222",
+        JSON.stringify({ ...stored, lastPromptTs: "333.444" }),
+        { expirationTtl: 7 * 24 * 60 * 60 }
+      );
+    });
+
+    it("stamps mappings that have no checkpoint yet", async () => {
+      const { lastPromptTs: _legacy, ...legacy } = stored;
+      mocks.get.mockResolvedValue(legacy);
+
+      await advanceLastPromptTs(mocks.env, "C123", "111.222", "333.444");
+
+      expect(mocks.put).toHaveBeenCalledWith(
+        "thread:C123:111.222",
+        JSON.stringify({ ...legacy, lastPromptTs: "333.444" }),
+        { expirationTtl: 7 * 24 * 60 * 60 }
+      );
+    });
+
+    it("does not move the checkpoint backwards on out-of-order completion", async () => {
+      mocks.get.mockResolvedValue({ ...stored, lastPromptTs: "999.999" });
+
+      await advanceLastPromptTs(mocks.env, "C123", "111.222", "333.444");
+
+      expect(mocks.put).not.toHaveBeenCalled();
+    });
+
+    it("does not resurrect a cleared mapping", async () => {
+      mocks.get.mockResolvedValue(null);
+
+      await advanceLastPromptTs(mocks.env, "C123", "111.222", "333.444");
+
+      expect(mocks.put).not.toHaveBeenCalled();
+    });
   });
 
   it("handles KV write and delete failures", async () => {

--- a/packages/slack-bot/src/sessions/thread-session-store.ts
+++ b/packages/slack-bot/src/sessions/thread-session-store.ts
@@ -82,6 +82,25 @@ export async function clearThreadSession(
   }
 }
 
+/**
+ * Advance the thread mapping's lastPromptTs checkpoint. The write is
+ * monotonic: concurrent follow-ups can complete out of order, and an older
+ * one must not move the checkpoint backwards or later prompts would
+ * re-include already-forwarded context. No-op when the mapping is gone
+ * (e.g. concurrently cleared) so a dead session is never resurrected.
+ */
+export async function advanceLastPromptTs(
+  env: Env,
+  channel: string,
+  threadTs: string,
+  promptTs: string
+): Promise<void> {
+  const current = await lookupThreadSession(env, channel, threadTs);
+  if (!current) return;
+  if (current.lastPromptTs && parseFloat(current.lastPromptTs) >= parseFloat(promptTs)) return;
+  await storeThreadSession(env, channel, threadTs, { ...current, lastPromptTs: promptTs });
+}
+
 export function buildThreadSession(
   sessionId: string,
   target: SlackSessionTarget,

--- a/packages/slack-bot/src/sessions/thread-session-store.ts
+++ b/packages/slack-bot/src/sessions/thread-session-store.ts
@@ -83,11 +83,14 @@ export async function clearThreadSession(
 }
 
 /**
- * Advance the thread mapping's lastPromptTs checkpoint. The write is
- * monotonic: concurrent follow-ups can complete out of order, and an older
- * one must not move the checkpoint backwards or later prompts would
- * re-include already-forwarded context. No-op when the mapping is gone
- * (e.g. concurrently cleared) so a dead session is never resurrected.
+ * Advance the thread mapping's lastPromptTs checkpoint. Concurrent follow-ups
+ * can complete out of order, and an older one must not move the checkpoint
+ * backwards or later prompts would re-include already-forwarded context, so
+ * the mapping is re-read and only written when the new ts is strictly newer.
+ * KV has no compare-and-swap, so truly simultaneous writes can still race in
+ * a narrow window; a lost race only re-includes a few already-forwarded
+ * thread messages in a later prompt. No-op when the mapping is gone (e.g.
+ * concurrently cleared) so a dead session is never resurrected.
  */
 export async function advanceLastPromptTs(
   env: Env,

--- a/packages/slack-bot/src/sessions/thread-session-store.ts
+++ b/packages/slack-bot/src/sessions/thread-session-store.ts
@@ -13,6 +13,7 @@ const threadSessionSchema: z.ZodType<ThreadSession> = z.object({
   model: z.string().min(1),
   reasoningEffort: z.string().min(1).optional(),
   createdAt: z.number().finite().nonnegative(),
+  lastPromptTs: z.string().min(1).optional(),
 });
 
 function getThreadSessionKey(channel: string, threadTs: string): string {
@@ -85,7 +86,8 @@ export function buildThreadSession(
   sessionId: string,
   target: SlackSessionTarget,
   model: string,
-  reasoningEffort?: string
+  reasoningEffort?: string,
+  lastPromptTs?: string
 ): ThreadSession {
   return {
     sessionId,
@@ -94,5 +96,6 @@ export function buildThreadSession(
     model,
     reasoningEffort,
     createdAt: Date.now(),
+    lastPromptTs,
   };
 }

--- a/packages/slack-bot/src/types/index.ts
+++ b/packages/slack-bot/src/types/index.ts
@@ -147,6 +147,12 @@ export interface ThreadSession {
   reasoningEffort?: string;
   /** Unix timestamp of when the session was created. Used for debugging and observability. */
   createdAt: number;
+  /**
+   * Slack ts of the last thread message forwarded to the session. Follow-up
+   * prompts include the human messages posted after this point so the agent
+   * sees discussion that happened between invocations.
+   */
+  lastPromptTs?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up mentions in a thread with an active session send only the new message text, so the agent never sees discussion that happened between invocations:

> `@agent do this action`
> `@teammate what do you think?`
> `@teammateB i think we should do x`
> `@agent see the above chat, can you do this` ← agent receives only this line

This has been the case since #646 dropped thread context from follow-up prompts to stop the bot's own replies from echoing stale answers — but that also dropped the interim *human* messages. #984 later moved the (by then unused) history fetch out of the follow-up path.

This PR forwards the human messages posted since the last prompt on every follow-up, without reintroducing the bot-echo problem:

- Track `lastPromptTs` on the KV thread mapping — the Slack ts of the last message forwarded to the session; stamped at launch and refreshed after each successful follow-up prompt.
- On follow-ups, fetch thread replies with `oldest=lastPromptTs` (new optional param on `getThreadMessages` in `@open-inspect/shared`) and prepend them to the prompt as a "New messages in the Slack thread since your last task" block. Bot messages, the boundary message, and the triggering message are filtered out.
- Legacy mappings without `lastPromptTs` skip interim context once, then self-heal: the first successful follow-up stamps the field, so subsequent follow-ups get context. Mappings expire in 7 days regardless.
- Convert `startSessionAndSendPrompt` to a named options API (same shape #984 gave `createSession`) to thread the trigger `messageTs` through; the clarification-picker path uses the "Working on…" ack ts as the boundary since the original message ts isn't persisted with the pending request.

Notes:
- New-session launches keep the existing behavior (last 10 thread messages, bots included, "Context from the Slack thread" block).
- Interim context is capped at the 10 messages following the last prompt.
- A successful follow-up now rewrites the mapping, which also refreshes the 7-day TTL — active threads keep their session mapping alive.

## Verification

- `npm test -w @open-inspect/shared` (401 passed), `npm test -w @open-inspect/slack-bot` (262 passed)
- `npm test` for control-plane (1817), web (774), github-bot (128), linear-bot (183) — all passing with the shared change
- `npm run typecheck`, `npm run lint`, `npm run build -w @open-inspect/shared -w @open-inspect/slack-bot`
- New tests: interim-context follow-up (boundary + bot filtering + `oldest` in the Slack call + `lastPromptTs` stamping), legacy-mapping self-heal, thread-session schema round-trip/rejection, `getThreadMessages` `oldest` pass-through

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Follow-up prompts now include an “interim” section populated with new human messages from the Slack thread since the last prompt.
  - Thread history fetching supports an optional starting timestamp and can include or exclude bot messages.

- **Bug Fixes**
  - Follow-up progress checkpointing is improved by recording the last forwarded thread timestamp, using it to scope the next interim window.
  - If interim thread history cannot be retrieved, the checkpoint will not be advanced, preventing incorrect future context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->