### PR TITLE
fix(sandbox-runtime): discourage unnecessary child sessions

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-task.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-task.js
@@ -11,7 +11,7 @@ import { bridgeFetch, extractError } from "./_bridge-client.js";
 export default tool({
   name: "spawn-task",
   description:
-    "Spawn a child coding task in a separate sandbox. Use sparingly: working directly in the current session is the default. Spawn only for a substantial, self-contained task that can run independently and where parallel execution will materially reduce total completion time. Do not spawn for routine exploration, simple edits, tests, sequential steps, or work you can complete efficiently yourself, even if the overall request has multiple parts. The child inherits the current repository but no conversation context. Returns immediately with a task ID; use get-task-status to check progress later.",
+    "Spawn a child coding task in a separate sandbox. Work directly by default. Use only for substantial, self-contained work that can run independently and materially benefits from parallel execution. Do not use for routine exploration, simple edits, tests, sequential steps, or merely multi-part requests. The child inherits the repository, not conversation context. Returns a task ID; check progress with get-task-status.",
   args: {
     title: z.string().describe("Short title describing the child task (shown in the UI)."),
     prompt: z

--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-task.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-task.js
@@ -11,7 +11,7 @@ import { bridgeFetch, extractError } from "./_bridge-client.js";
 export default tool({
   name: "spawn-task",
   description:
-    "Spawn a child coding task that runs in its own sandbox. The child inherits the current repository and works independently. Returns immediately with a task ID — use get-task-status to check progress later. Use this to parallelize work: delegate sub-tasks while you continue on the main task.",
+    "Spawn a child coding task in a separate sandbox. Use sparingly: working directly in the current session is the default. Spawn only for a substantial, self-contained task that can run independently and where parallel execution will materially reduce total completion time. Do not spawn for routine exploration, simple edits, tests, sequential steps, or work you can complete efficiently yourself, even if the overall request has multiple parts. The child inherits the current repository but no conversation context. Returns immediately with a task ID; use get-task-status to check progress later.",
   args: {
     title: z.string().describe("Short title describing the child task (shown in the UI)."),
     prompt: z


### PR DESCRIPTION
## Summary

- make direct work the default in the `spawn-task` tool guidance
- reserve child sessions for substantial, independent work with meaningful parallelization benefits
- explicitly discourage spawning for routine exploration, simple edits, tests, sequential steps, and merely multi-part requests
- clarify that child sessions do not inherit conversation context

## Verification

- `npx prettier --check .opencode/tool/spawn-task.js packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-task.js`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/37ddfa89fc0abd2c536870097b20b5ba)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for when to use the task-spawning tool.
  * Discouraged spawning separate tasks for routine exploration, simple edits, testing, sequential steps, or work manageable in the current session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->