### PR TITLE
fix(web): keep session trees stable in sidebar

### DIFF
--- a/packages/control-plane/src/db/session-index.test.ts
+++ b/packages/control-plane/src/db/session-index.test.ts
@@ -12,6 +12,7 @@ type SessionRow = {
   base_branch: string | null;
   status: string;
   parent_session_id: string | null;
+  root_session_id: string | null;
   spawn_source: "user" | "agent" | "automation";
   spawn_depth: number;
   automation_id: string | null;
@@ -169,6 +170,7 @@ class FakeD1Database {
         baseBranch,
         status,
         parentSessionId,
+        rootSessionId,
         spawnSource,
         spawnDepth,
         automationId,
@@ -188,6 +190,7 @@ class FakeD1Database {
         string | null,
         string,
         string | null,
+        string,
         "user" | "agent" | "automation",
         number,
         string | null,
@@ -211,6 +214,7 @@ class FakeD1Database {
           base_branch: baseBranch,
           status,
           parent_session_id: parentSessionId,
+          root_session_id: rootSessionId,
           spawn_source: spawnSource,
           spawn_depth: spawnDepth,
           automation_id: automationId,
@@ -455,6 +459,7 @@ describe("SessionIndexStore", () => {
         ...session,
         // Defaults applied for missing optional fields
         parentSessionId: null,
+        rootSessionId: "test-id",
         spawnSource: "user",
         spawnDepth: 0,
         automationId: null,
@@ -517,6 +522,7 @@ describe("SessionIndexStore", () => {
 
       const result = await store.get("child-1");
       expect(result?.parentSessionId).toBe("parent-1");
+      expect(result?.rootSessionId).toBe("child-1");
       expect(result?.spawnSource).toBe("agent");
       expect(result?.spawnDepth).toBe(1);
     });

--- a/packages/control-plane/src/db/session-index.test.ts
+++ b/packages/control-plane/src/db/session-index.test.ts
@@ -512,6 +512,7 @@ describe("SessionIndexStore", () => {
     });
 
     it("stores parent fields when provided", async () => {
+      await store.create(makeSession({ id: "parent-1" }));
       const session = makeSession({
         id: "child-1",
         parentSessionId: "parent-1",
@@ -522,9 +523,17 @@ describe("SessionIndexStore", () => {
 
       const result = await store.get("child-1");
       expect(result?.parentSessionId).toBe("parent-1");
-      expect(result?.rootSessionId).toBe("child-1");
+      expect(result?.rootSessionId).toBe("parent-1");
       expect(result?.spawnSource).toBe("agent");
       expect(result?.spawnDepth).toBe(1);
+    });
+
+    it("uses the child as root when its parent is missing", async () => {
+      await store.create(
+        makeSession({ id: "orphan-1", parentSessionId: "missing-parent", spawnSource: "agent" })
+      );
+
+      expect((await store.get("orphan-1"))?.rootSessionId).toBe("orphan-1");
     });
 
     it("stores userId when provided", async () => {

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -15,6 +15,7 @@ import { SessionPullRequestStore } from "./session-pull-request-store";
  */
 export type SessionIndexRepository = SessionListRepository;
 const SESSION_DECORATION_BATCH_SIZE = 90;
+const DEFAULT_SIDEBAR_LIMIT = 25;
 
 export interface SessionEntry {
   id: string;
@@ -359,7 +360,7 @@ export class SessionIndexStore {
   }
 
   async listSidebar(options: ListSidebarSessionsOptions = {}): Promise<ListSidebarSessionsResult> {
-    const { createdByUserIds, limit = 25, cursor } = options;
+    const { createdByUserIds, limit = DEFAULT_SIDEBAR_LIMIT, cursor } = options;
     const conditions = ["status != 'archived'", "root_session_id IS NOT NULL"];
     const params: unknown[] = [];
 

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -14,6 +14,7 @@ import { SessionPullRequestStore } from "./session-pull-request-store";
  * the shared wire type so Session.repositories and this share one shape.
  */
 export type SessionIndexRepository = SessionListRepository;
+const SESSION_DECORATION_BATCH_SIZE = 90;
 
 export interface SessionEntry {
   id: string;
@@ -25,6 +26,7 @@ export interface SessionEntry {
   baseBranch: string | null;
   status: SessionStatus;
   parentSessionId?: string | null;
+  rootSessionId?: string;
   spawnSource?: SpawnSource;
   spawnDepth?: number;
   automationId?: string | null;
@@ -73,6 +75,7 @@ interface SessionRow {
   base_branch: string | null;
   status: SessionStatus;
   parent_session_id: string | null;
+  root_session_id: string | null;
   spawn_source: SpawnSource;
   spawn_depth: number;
   automation_id: string | null;
@@ -103,6 +106,26 @@ export interface ListSessionsResult {
   hasMore: boolean;
 }
 
+export interface SidebarSessionCursor {
+  activityAt: number;
+  rootSessionId: string;
+}
+
+export interface ListSidebarSessionsOptions {
+  createdByUserIds?: readonly string[];
+  limit?: number;
+  cursor?: SidebarSessionCursor;
+}
+
+export interface ListSidebarSessionsResult {
+  trees: Array<{
+    rootSessionId: string;
+    activityAt: number;
+    sessions: SessionEntry[];
+  }>;
+  nextCursor: SidebarSessionCursor | null;
+}
+
 function toEntry(row: SessionRow): SessionEntry {
   return {
     id: row.id,
@@ -114,6 +137,7 @@ function toEntry(row: SessionRow): SessionEntry {
     baseBranch: row.base_branch,
     status: row.status,
     parentSessionId: row.parent_session_id,
+    rootSessionId: row.root_session_id ?? row.id,
     spawnSource: row.spawn_source,
     spawnDepth: row.spawn_depth,
     automationId: row.automation_id,
@@ -159,11 +183,16 @@ export class SessionIndexStore {
 
   async create(session: SessionEntry): Promise<void> {
     const repository = normalizeSessionRepository(session);
+    let rootSessionId = session.rootSessionId ?? session.id;
+    if (session.parentSessionId && !session.rootSessionId) {
+      const parent = await this.get(session.parentSessionId);
+      rootSessionId = parent?.rootSessionId ?? parent?.id ?? session.id;
+    }
 
     const sessionStmt = this.db
       .prepare(
-        `INSERT OR IGNORE INTO sessions (id, title, repo_owner, repo_name, model, reasoning_effort, base_branch, status, parent_session_id, spawn_source, spawn_depth, automation_id, automation_run_id, scm_login, user_id, environment_id, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        `INSERT OR IGNORE INTO sessions (id, title, repo_owner, repo_name, model, reasoning_effort, base_branch, status, parent_session_id, root_session_id, spawn_source, spawn_depth, automation_id, automation_run_id, scm_login, user_id, environment_id, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .bind(
         session.id,
@@ -175,6 +204,7 @@ export class SessionIndexStore {
         repository.baseBranch,
         session.status,
         session.parentSessionId ?? null,
+        rootSessionId,
         session.spawnSource ?? "user",
         session.spawnDepth ?? 0,
         session.automationId ?? null,
@@ -328,6 +358,80 @@ export class SessionIndexStore {
     };
   }
 
+  async listSidebar(options: ListSidebarSessionsOptions = {}): Promise<ListSidebarSessionsResult> {
+    const { createdByUserIds, limit = 25, cursor } = options;
+    const conditions = ["status != 'archived'", "root_session_id IS NOT NULL"];
+    const params: unknown[] = [];
+
+    if (createdByUserIds?.length) {
+      conditions.push(
+        `EXISTS (
+          SELECT 1 FROM sessions root
+          WHERE root.id = sessions.root_session_id
+            AND root.user_id IN (${createdByUserIds.map(() => "?").join(", ")})
+        )`
+      );
+      params.push(...createdByUserIds);
+    }
+
+    const having = cursor
+      ? "HAVING MAX(updated_at) < ? OR (MAX(updated_at) = ? AND root_session_id < ?)"
+      : "";
+    if (cursor) {
+      params.push(cursor.activityAt, cursor.activityAt, cursor.rootSessionId);
+    }
+
+    const result = await this.db
+      .prepare(
+        `SELECT root_session_id, MAX(updated_at) AS activity_at
+         FROM sessions
+         WHERE ${conditions.join(" AND ")}
+         GROUP BY root_session_id
+         ${having}
+         ORDER BY activity_at DESC, root_session_id DESC
+         LIMIT ?`
+      )
+      .bind(...params, limit + 1)
+      .all<{ root_session_id: string; activity_at: number }>();
+
+    const pageRoots = (result.results ?? []).slice(0, limit);
+    if (pageRoots.length === 0) {
+      return { trees: [], nextCursor: null };
+    }
+
+    const rootIds = pageRoots.map((row) => row.root_session_id);
+    const sessionResult = await this.db
+      .prepare(
+        `SELECT * FROM sessions
+         WHERE root_session_id IN (${rootIds.map(() => "?").join(", ")})
+           AND status != 'archived'
+         ORDER BY updated_at DESC, id DESC`
+      )
+      .bind(...rootIds)
+      .all<SessionRow>();
+    const sessions = await this.decorateEntriesBatched((sessionResult.results ?? []).map(toEntry));
+    const sessionsByRoot = new Map<string, SessionEntry[]>();
+    for (const session of sessions) {
+      const rootId = session.rootSessionId ?? session.id;
+      const treeSessions = sessionsByRoot.get(rootId) ?? [];
+      treeSessions.push(session);
+      sessionsByRoot.set(rootId, treeSessions);
+    }
+
+    const lastRoot = pageRoots.at(-1);
+    return {
+      trees: pageRoots.map((root) => ({
+        rootSessionId: root.root_session_id,
+        activityAt: root.activity_at,
+        sessions: sessionsByRoot.get(root.root_session_id) ?? [],
+      })),
+      nextCursor:
+        (result.results?.length ?? 0) > limit && lastRoot
+          ? { activityAt: lastRoot.activity_at, rootSessionId: lastRoot.root_session_id }
+          : null,
+    };
+  }
+
   /**
    * Attach repository lists and PR status summaries to the paged
    * entries. The two lookups are independent — each is one grouped query
@@ -354,6 +458,15 @@ export class SessionIndexStore {
         ...(pullRequestSummary ? { pullRequestSummary } : {}),
       };
     });
+  }
+
+  private async decorateEntriesBatched(sessions: SessionEntry[]): Promise<SessionEntry[]> {
+    const decorated: SessionEntry[] = [];
+    for (let index = 0; index < sessions.length; index += SESSION_DECORATION_BATCH_SIZE) {
+      const batch = sessions.slice(index, index + SESSION_DECORATION_BATCH_SIZE);
+      decorated.push(...(await this.decorateEntries(batch)));
+    }
+    return decorated;
   }
 
   /** Repository lists for the given sessions, in one query. */

--- a/packages/control-plane/src/routes/session-index.ts
+++ b/packages/control-plane/src/routes/session-index.ts
@@ -48,6 +48,23 @@ function parsePaginationOffset(value: string | null): number {
   return Math.max(parsed, 0);
 }
 
+function parseSidebarCursor(
+  value: string | null
+): { activityAt: number; rootSessionId: string } | null | Response {
+  if (!value) return null;
+  const separator = value.indexOf(":");
+  const activityAt = Number(value.slice(0, separator));
+  const rootSessionId = value.slice(separator + 1);
+  if (separator < 1 || !Number.isSafeInteger(activityAt) || activityAt < 0 || !rootSessionId) {
+    return error("Invalid cursor", 400);
+  }
+  return { activityAt, rootSessionId };
+}
+
+function encodeSidebarCursor(cursor: { activityAt: number; rootSessionId: string } | null) {
+  return cursor ? `${cursor.activityAt}:${cursor.rootSessionId}` : null;
+}
+
 async function handleListSessions(
   request: Request,
   env: Env,
@@ -62,6 +79,7 @@ async function handleListSessions(
   const status = parseSessionStatus(statusParam);
   const excludeStatus = parseSessionStatus(excludeStatusParam);
   const createdByUserIds = parseCreatedByFilters(url.searchParams);
+  const view = url.searchParams.get("view");
 
   if (statusParam && !status) {
     return error("Invalid status", 400);
@@ -76,6 +94,21 @@ async function handleListSessions(
   }
 
   const store = new SessionIndexStore(env.DB);
+  if (view === "sidebar") {
+    const cursor = parseSidebarCursor(url.searchParams.get("cursor"));
+    if (cursor instanceof Response) return cursor;
+    const result = await store.listSidebar({
+      createdByUserIds,
+      limit,
+      cursor: cursor ?? undefined,
+    });
+    return json({
+      trees: result.trees,
+      nextCursor: encodeSidebarCursor(result.nextCursor),
+    });
+  }
+  if (view) return error("Invalid view", 400);
+
   const result = await store.list({ status, excludeStatus, createdByUserIds, limit, offset });
 
   return json({

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1521,23 +1521,23 @@ export class SessionDO extends DurableObject<Env> {
     return resolved?.session_name || resolved?.id || this.ctx.id.toString();
   }
 
-  private syncSessionIndexStatus(
+  private async syncSessionIndexStatus(
     sessionId: string,
     status: SessionStatus,
     updatedAt: number
-  ): void {
+  ): Promise<void> {
     if (!this.env.DB) return;
     const sessionStore = new SessionIndexStore(this.env.DB);
-    this.ctx.waitUntil(
-      sessionStore.updateStatus(sessionId, status, updatedAt).catch((error) => {
-        this.log.error("session_index.update_status.background_error", {
-          session_id: sessionId,
-          status,
-          updated_at: updatedAt,
-          error,
-        });
-      })
-    );
+    try {
+      await sessionStore.updateStatus(sessionId, status, updatedAt);
+    } catch (error) {
+      this.log.error("session_index.update_status.error", {
+        session_id: sessionId,
+        status,
+        updated_at: updatedAt,
+        error,
+      });
+    }
   }
 
   private syncSessionMetrics(sessionId: string): void {
@@ -1590,7 +1590,7 @@ export class SessionDO extends DurableObject<Env> {
 
     const publicSessionId = this.getPublicSessionId(session);
     if (session.status === status) {
-      this.syncSessionIndexStatus(publicSessionId, status, session.updated_at);
+      await this.syncSessionIndexStatus(publicSessionId, status, session.updated_at);
       if (TERMINAL_STATUSES.includes(status)) {
         this.syncSessionMetrics(publicSessionId);
       }
@@ -1599,7 +1599,7 @@ export class SessionDO extends DurableObject<Env> {
 
     const updatedAt = Math.max(Date.now(), session.updated_at + 1);
     this.repository.updateSessionStatus(session.id, status, updatedAt);
-    this.syncSessionIndexStatus(publicSessionId, status, updatedAt);
+    await this.syncSessionIndexStatus(publicSessionId, status, updatedAt);
 
     this.broadcast({ type: "session_status", status });
 

--- a/packages/control-plane/test/integration/auth.test.ts
+++ b/packages/control-plane/test/integration/auth.test.ts
@@ -54,6 +54,26 @@ describe("HMAC authentication", () => {
     expect(body.hasMore).toBe(false);
   });
 
+  it("returns cursor-paginated sidebar trees", async () => {
+    const token = await generateInternalToken(env.INTERNAL_CALLBACK_SECRET!);
+    const response = await SELF.fetch("https://test.local/sessions?view=sidebar", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ trees: [], nextCursor: null });
+  });
+
+  it("rejects malformed sidebar cursors", async () => {
+    const token = await generateInternalToken(env.INTERNAL_CALLBACK_SECRET!);
+    const response = await SELF.fetch("https://test.local/sessions?view=sidebar&cursor=invalid", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid cursor" });
+  });
+
   it("filters the session list by creator user id", async () => {
     const aliceId = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     const bobId = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";

--- a/packages/control-plane/test/integration/d1-session-index.test.ts
+++ b/packages/control-plane/test/integration/d1-session-index.test.ts
@@ -7,6 +7,126 @@ import { cleanD1Tables } from "./cleanup";
 describe("D1 SessionIndexStore", () => {
   beforeEach(cleanD1Tables);
 
+  describe("sidebar trees", () => {
+    it("paginates complete trees by activity from any descendant", async () => {
+      const store = new SessionIndexStore(env.DB);
+      const create = (id: string, updatedAt: number, parentSessionId: string | null = null) =>
+        store.create({
+          id,
+          title: id,
+          repoOwner: "acme",
+          repoName: "web-app",
+          model: "anthropic/claude-haiku-4-5",
+          reasoningEffort: null,
+          baseBranch: "main",
+          status: "active",
+          parentSessionId,
+          spawnSource: parentSessionId ? "agent" : "user",
+          spawnDepth: parentSessionId ? 1 : 0,
+          createdAt: updatedAt,
+          updatedAt,
+        });
+
+      await create("tree-a", 100);
+      await create("tree-a-child", 500, "tree-a");
+      await create("tree-a-grandchild", 300, "tree-a-child");
+      await create("tree-b", 400);
+
+      const firstPage = await store.listSidebar({ limit: 1 });
+      expect(firstPage.trees).toHaveLength(1);
+      expect(firstPage.trees[0]?.rootSessionId).toBe("tree-a");
+      expect(firstPage.trees[0]?.activityAt).toBe(500);
+      expect(firstPage.trees[0]?.sessions.map((session) => session.id).sort()).toEqual([
+        "tree-a",
+        "tree-a-child",
+        "tree-a-grandchild",
+      ]);
+      expect(firstPage.nextCursor).toEqual({ activityAt: 500, rootSessionId: "tree-a" });
+
+      const secondPage = await store.listSidebar({ limit: 1, cursor: firstPage.nextCursor! });
+      expect(secondPage.trees.map((tree) => tree.rootSessionId)).toEqual(["tree-b"]);
+      expect(secondPage.nextCursor).toBeNull();
+    });
+
+    it("filters by root owner without dropping descendants", async () => {
+      const store = new SessionIndexStore(env.DB);
+      await store.create({
+        id: "owned-root",
+        title: null,
+        repoOwner: null,
+        repoName: null,
+        model: "anthropic/claude-haiku-4-5",
+        reasoningEffort: null,
+        baseBranch: null,
+        status: "active",
+        userId: "owner-1",
+        createdAt: 100,
+        updatedAt: 100,
+      });
+      await store.create({
+        id: "owned-child",
+        title: null,
+        repoOwner: null,
+        repoName: null,
+        model: "anthropic/claude-haiku-4-5",
+        reasoningEffort: null,
+        baseBranch: null,
+        status: "active",
+        userId: null,
+        parentSessionId: "owned-root",
+        spawnSource: "agent",
+        spawnDepth: 1,
+        createdAt: 200,
+        updatedAt: 200,
+      });
+
+      const result = await store.listSidebar({ createdByUserIds: ["owner-1"] });
+      expect(result.trees).toHaveLength(1);
+      expect(result.trees[0]?.sessions.map((session) => session.id).sort()).toEqual([
+        "owned-child",
+        "owned-root",
+      ]);
+    });
+
+    it("decorates trees larger than the D1 bound-parameter limit in batches", async () => {
+      const store = new SessionIndexStore(env.DB);
+      await store.create({
+        id: "large-root",
+        title: null,
+        repoOwner: null,
+        repoName: null,
+        model: "anthropic/claude-haiku-4-5",
+        reasoningEffort: null,
+        baseBranch: null,
+        status: "active",
+        createdAt: 100,
+        updatedAt: 100,
+      });
+
+      for (let index = 0; index < 105; index += 1) {
+        await store.create({
+          id: `large-child-${index}`,
+          title: null,
+          repoOwner: null,
+          repoName: null,
+          model: "anthropic/claude-haiku-4-5",
+          reasoningEffort: null,
+          baseBranch: null,
+          status: "active",
+          parentSessionId: "large-root",
+          spawnSource: "agent",
+          spawnDepth: 1,
+          createdAt: 200 + index,
+          updatedAt: 200 + index,
+        });
+      }
+
+      const result = await store.listSidebar({ limit: 1 });
+      expect(result.trees).toHaveLength(1);
+      expect(result.trees[0]?.sessions).toHaveLength(106);
+    });
+  });
+
   it("creates and retrieves a session", async () => {
     const store = new SessionIndexStore(env.DB);
     const now = Date.now();

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -77,6 +77,8 @@ export type {
   Session,
   SessionMessage,
   SessionState,
+  SidebarSessionTree,
+  SidebarSessionsResponse,
   ParticipantPresence,
   PullRequestSummary,
 } from "./sessions";

--- a/packages/shared/src/types/sessions.ts
+++ b/packages/shared/src/types/sessions.ts
@@ -50,6 +50,7 @@ export interface Session {
   opencodeSessionId: string | null;
   status: SessionStatus;
   parentSessionId: string | null;
+  rootSessionId?: string;
   spawnSource: SpawnSource;
   spawnDepth: number;
   createdAt: number;
@@ -72,6 +73,17 @@ export interface Session {
    * overlap or when the session has no tracked PRs.
    */
   pullRequestSummary?: PullRequestSummary;
+}
+
+export interface SidebarSessionTree {
+  rootSessionId: string;
+  activityAt: number;
+  sessions: Session[];
+}
+
+export interface SidebarSessionsResponse {
+  trees: SidebarSessionTree[];
+  nextCursor: string | null;
 }
 
 export interface SessionMessage {

--- a/packages/web/src/components/session-sidebar.test.tsx
+++ b/packages/web/src/components/session-sidebar.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { SWRConfig } from "swr";
+import type { Session } from "@open-inspect/shared";
 import { MOBILE_LONG_PRESS_MS, SessionSidebar } from "./session-sidebar";
 import {
   buildSessionsPageKey,
@@ -68,12 +69,17 @@ afterEach(() => {
   mockUseEnvironments.mockReturnValue({ environments: [], loading: false });
 });
 
-function createSession(index: number, overrides: Record<string, unknown> = {}) {
+function createSession(index: number, overrides: Partial<Session> = {}): Session {
   return {
     id: `session-${index}`,
     title: `Session ${index}`,
     repoOwner: "open-inspect",
     repoName: "background-agents",
+    baseBranch: "main",
+    branchName: null,
+    baseSha: null,
+    currentSha: null,
+    opencodeSessionId: null,
     parentSessionId: null,
     spawnSource: "user",
     spawnDepth: 0,
@@ -91,18 +97,63 @@ function jsonResponse(body: unknown) {
   });
 }
 
+function sidebarPage(sessions: Session[], nextCursor: string | null = null) {
+  const byId = new Map(sessions.map((session) => [session.id, session]));
+  const trees = new Map<string, Session[]>();
+
+  for (const session of sessions) {
+    let root = session;
+    const visited = new Set([session.id]);
+    while (root.parentSessionId && byId.has(root.parentSessionId)) {
+      if (visited.has(root.parentSessionId)) break;
+      visited.add(root.parentSessionId);
+      root = byId.get(root.parentSessionId)!;
+    }
+    const members = trees.get(root.id) ?? [];
+    members.push({ ...session, rootSessionId: root.id });
+    trees.set(root.id, members);
+  }
+
+  return {
+    trees: [...trees].map(([rootSessionId, members]) => ({
+      rootSessionId,
+      activityAt: Math.max(...members.map((session) => session.updatedAt)),
+      sessions: members,
+    })),
+    nextCursor,
+  };
+}
+
+function SidebarTestConfig({
+  page,
+  children,
+}: {
+  page: ReturnType<typeof sidebarPage>;
+  children: React.ReactNode;
+}) {
+  return (
+    <SWRConfig
+      value={{
+        provider: () => new Map(),
+        dedupingInterval: 0,
+        revalidateOnFocus: false,
+        fetcher: async (url: string) => {
+          if (url !== SIDEBAR_SESSIONS_KEY) throw new Error(`Unexpected fetch for ${url}`);
+          return page;
+        },
+      }}
+    >
+      {children}
+    </SWRConfig>
+  );
+}
+
 describe("SessionSidebar", () => {
   it("shows the user profile at the bottom of the sidebar", async () => {
     const { container } = render(
-      <SWRConfig
-        value={{
-          fallback: { [SIDEBAR_SESSIONS_KEY]: { sessions: [], hasMore: false } },
-          dedupingInterval: 0,
-          revalidateOnFocus: false,
-        }}
-      >
+      <SidebarTestConfig page={sidebarPage([])}>
         <SessionSidebar />
-      </SWRConfig>
+      </SidebarTestConfig>
     );
 
     const profileButton = await screen.findByRole("button", { name: "Signed in as Test User" });
@@ -122,20 +173,9 @@ describe("SessionSidebar", () => {
     const none = createSession(3, { updatedAt: 2000 });
 
     render(
-      <SWRConfig
-        value={{
-          fallback: {
-            [SIDEBAR_SESSIONS_KEY]: {
-              sessions: [single, multi, none],
-              hasMore: false,
-            },
-          },
-          dedupingInterval: 0,
-          revalidateOnFocus: false,
-        }}
-      >
+      <SidebarTestConfig page={sidebarPage([single, multi, none])}>
         <SessionSidebar />
-      </SWRConfig>
+      </SidebarTestConfig>
     );
 
     // GitHub-style state icon next to the title: merged for the single-PR
@@ -175,40 +215,28 @@ describe("SessionSidebar", () => {
     });
 
     render(
-      <SWRConfig
-        value={{
-          fallback: {
-            [SIDEBAR_SESSIONS_KEY]: {
-              sessions: [parent, child, grandchild],
-              hasMore: false,
-            },
-          },
-          dedupingInterval: 0,
-          revalidateOnFocus: false,
-        }}
-      >
+      <SidebarTestConfig page={sidebarPage([parent, child, grandchild])}>
         <SessionSidebar />
-      </SWRConfig>
+      </SidebarTestConfig>
     );
 
     expect(await screen.findByText("Session 1")).toBeInTheDocument();
     expect(screen.getByText("Child session")).toBeInTheDocument();
     expect(screen.getByText("Grandchild session")).toBeInTheDocument();
+    expect(screen.queryByText("sub-task")).not.toBeInTheDocument();
+    expect(screen.getByText("Child session").closest("a")).toHaveStyle({ paddingLeft: "1.75rem" });
+    expect(screen.getByText("Grandchild session").closest("a")).toHaveStyle({
+      paddingLeft: "2.75rem",
+    });
   });
 
   it("opens session search from the header", async () => {
     const onSearchSessions = vi.fn();
 
     render(
-      <SWRConfig
-        value={{
-          fallback: { [SIDEBAR_SESSIONS_KEY]: { sessions: [createSession(1)], hasMore: false } },
-          dedupingInterval: 0,
-          revalidateOnFocus: false,
-        }}
-      >
+      <SidebarTestConfig page={sidebarPage([createSession(1)])}>
         <SessionSidebar onSearchSessions={onSearchSessions} />
-      </SWRConfig>
+      </SidebarTestConfig>
     );
 
     expect(await screen.findByText("Session 1")).toBeInTheDocument();
@@ -224,11 +252,11 @@ describe("SessionSidebar", () => {
       const url = String(input);
 
       if (url === SIDEBAR_SESSIONS_KEY) {
-        return jsonResponse({ sessions: firstPage, hasMore: true });
+        return jsonResponse(sidebarPage(firstPage, "next-page"));
       }
 
-      if (url === buildSessionsPageKey({ excludeStatus: "archived", offset: 50 })) {
-        return jsonResponse({ sessions: secondPage, hasMore: false });
+      if (url === buildSessionsPageKey({ view: "sidebar", cursor: "next-page" })) {
+        return jsonResponse(sidebarPage(secondPage));
       }
 
       throw new Error(`Unexpected fetch for ${url}`);
@@ -279,14 +307,14 @@ describe("SessionSidebar", () => {
     expect(await screen.findByText("Session 55")).toBeInTheDocument();
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
-        buildSessionsPageKey({ excludeStatus: "archived", offset: 50 })
+        buildSessionsPageKey({ view: "sidebar", cursor: "next-page" })
       );
     });
   });
 
   it("filters sessions to the current user when Mine is selected", async () => {
     const mineKey = buildSessionsPageKey({
-      excludeStatus: "archived",
+      view: "sidebar",
       createdBy: [CURRENT_USER_CREATED_BY],
     });
 
@@ -294,14 +322,11 @@ describe("SessionSidebar", () => {
       const url = String(input);
 
       if (url === SIDEBAR_SESSIONS_KEY) {
-        return jsonResponse({ sessions: [createSession(1)], hasMore: false });
+        return jsonResponse(sidebarPage([createSession(1)]));
       }
 
       if (url === mineKey) {
-        return jsonResponse({
-          sessions: [createSession(2, { title: "Mine only" })],
-          hasMore: false,
-        });
+        return jsonResponse(sidebarPage([createSession(2, { title: "Mine only" })]));
       }
 
       throw new Error(`Unexpected fetch for ${url}`);
@@ -349,15 +374,9 @@ describe("SessionSidebar", () => {
     ];
 
     render(
-      <SWRConfig
-        value={{
-          fallback: { [SIDEBAR_SESSIONS_KEY]: { sessions, hasMore: false } },
-          dedupingInterval: 0,
-          revalidateOnFocus: false,
-        }}
-      >
+      <SidebarTestConfig page={sidebarPage(sessions)}>
         <SessionSidebar />
-      </SWRConfig>
+      </SidebarTestConfig>
     );
 
     expect(await screen.findByText("Session 1")).toBeInTheDocument();
@@ -367,9 +386,9 @@ describe("SessionSidebar", () => {
 
   it("ignores stale load-more results after the creator filter changes", async () => {
     const firstPage = Array.from({ length: 50 }, (_, index) => createSession(index + 1));
-    const allNextPageKey = buildSessionsPageKey({ excludeStatus: "archived", offset: 50 });
+    const allNextPageKey = buildSessionsPageKey({ view: "sidebar", cursor: "next-page" });
     const mineKey = buildSessionsPageKey({
-      excludeStatus: "archived",
+      view: "sidebar",
       createdBy: [CURRENT_USER_CREATED_BY],
     });
     let resolveAllNextPage!: (response: Response) => void;
@@ -381,7 +400,7 @@ describe("SessionSidebar", () => {
       const url = String(input);
 
       if (url === SIDEBAR_SESSIONS_KEY) {
-        return jsonResponse({ sessions: firstPage, hasMore: true });
+        return jsonResponse(sidebarPage(firstPage, "next-page"));
       }
 
       if (url === allNextPageKey) {
@@ -389,10 +408,7 @@ describe("SessionSidebar", () => {
       }
 
       if (url === mineKey) {
-        return jsonResponse({
-          sessions: [createSession(99, { title: "Mine only" })],
-          hasMore: false,
-        });
+        return jsonResponse(sidebarPage([createSession(99, { title: "Mine only" })]));
       }
 
       throw new Error(`Unexpected fetch for ${url}`);
@@ -441,12 +457,7 @@ describe("SessionSidebar", () => {
     expect(await screen.findByText("Mine only")).toBeInTheDocument();
 
     await act(async () => {
-      resolveAllNextPage(
-        jsonResponse({
-          sessions: [createSession(51, { title: "Stale page" })],
-          hasMore: false,
-        })
-      );
+      resolveAllNextPage(jsonResponse(sidebarPage([createSession(51, { title: "Stale page" })])));
       await allNextPage;
     });
 
@@ -459,15 +470,9 @@ describe("SessionSidebar", () => {
     const onSessionSelect = vi.fn();
 
     render(
-      <SWRConfig
-        value={{
-          fallback: { [SIDEBAR_SESSIONS_KEY]: { sessions: [createSession(1)], hasMore: false } },
-          dedupingInterval: 0,
-          revalidateOnFocus: false,
-        }}
-      >
+      <SidebarTestConfig page={sidebarPage([createSession(1)])}>
         <SessionSidebar onSessionSelect={onSessionSelect} />
-      </SWRConfig>
+      </SidebarTestConfig>
     );
 
     const link = await screen.findByRole("link", { name: /session 1/i });
@@ -482,15 +487,9 @@ describe("SessionSidebar", () => {
     const onSessionSelect = vi.fn();
 
     render(
-      <SWRConfig
-        value={{
-          fallback: { [SIDEBAR_SESSIONS_KEY]: { sessions: [createSession(1)], hasMore: false } },
-          dedupingInterval: 0,
-          revalidateOnFocus: false,
-        }}
-      >
+      <SidebarTestConfig page={sidebarPage([createSession(1)])}>
         <SessionSidebar onSessionSelect={onSessionSelect} />
-      </SWRConfig>
+      </SidebarTestConfig>
     );
 
     fireEvent.click(screen.getByTitle("Settings"));
@@ -504,15 +503,9 @@ describe("SessionSidebar", () => {
     mockUseIsMobile.mockReturnValue(true);
 
     render(
-      <SWRConfig
-        value={{
-          fallback: { [SIDEBAR_SESSIONS_KEY]: { sessions: [createSession(1)], hasMore: false } },
-          dedupingInterval: 0,
-          revalidateOnFocus: false,
-        }}
-      >
+      <SidebarTestConfig page={sidebarPage([createSession(1)])}>
         <SessionSidebar />
-      </SWRConfig>
+      </SidebarTestConfig>
     );
 
     const link = await screen.findByRole("link", { name: /session 1/i });
@@ -540,15 +533,9 @@ describe("SessionSidebar", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     render(
-      <SWRConfig
-        value={{
-          fallback: { [SIDEBAR_SESSIONS_KEY]: { sessions: [createSession(1)], hasMore: false } },
-          dedupingInterval: 0,
-          revalidateOnFocus: false,
-        }}
-      >
+      <SidebarTestConfig page={sidebarPage([createSession(1)])}>
         <SessionSidebar />
-      </SWRConfig>
+      </SidebarTestConfig>
     );
 
     const link = await screen.findByRole("link", { name: /session 1/i });
@@ -581,15 +568,9 @@ describe("SessionSidebar", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     render(
-      <SWRConfig
-        value={{
-          fallback: { [SIDEBAR_SESSIONS_KEY]: { sessions: [createSession(1)], hasMore: false } },
-          dedupingInterval: 0,
-          revalidateOnFocus: false,
-        }}
-      >
+      <SidebarTestConfig page={sidebarPage([createSession(1)])}>
         <SessionSidebar />
-      </SWRConfig>
+      </SidebarTestConfig>
     );
 
     const link = await screen.findByRole("link", { name: /session 1/i });

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -21,7 +21,7 @@ import { PullRequestStateIcon } from "@/components/pr-state-icon";
 import { formatRelativeTime, isInactiveSession } from "@/lib/time";
 import {
   applySidebarTitleUpdate,
-  buildSidebarSessionsPageKey,
+  createSidebarSessionsKeyLoader,
   CURRENT_USER_CREATED_BY,
   isUnarchivedSessionListKey,
   removeSessionFromSidebar,
@@ -129,12 +129,11 @@ export function SessionSidebar({
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const isMobile = useIsMobile();
 
-  const sidebarSessionsKey = useMemo(() => {
-    if (!authSession) return null;
-
-    return buildSidebarSessionsPageKey({
-      createdBy: sessionCreatorFilter === "mine" ? [CURRENT_USER_CREATED_BY] : undefined,
-    });
+  const sidebarSessionsKeyLoader = useMemo(() => {
+    if (!authSession) return () => null;
+    return createSidebarSessionsKeyLoader(
+      sessionCreatorFilter === "mine" ? [CURRENT_USER_CREATED_BY] : undefined
+    );
   }, [authSession, sessionCreatorFilter]);
 
   const {
@@ -145,17 +144,9 @@ export function SessionSidebar({
     size,
     setSize,
     mutate: mutateSidebar,
-  } = useSWRInfinite<SidebarSessionListResponse>(
-    (pageIndex, previousPage) => {
-      if (!sidebarSessionsKey) return null;
-      if (pageIndex > 0 && !previousPage?.nextCursor) return null;
-      return buildSidebarSessionsPageKey({
-        createdBy: sessionCreatorFilter === "mine" ? [CURRENT_USER_CREATED_BY] : undefined,
-        cursor: pageIndex > 0 ? (previousPage?.nextCursor ?? undefined) : undefined,
-      });
-    },
-    { revalidateAll: true }
-  );
+  } = useSWRInfinite<SidebarSessionListResponse>(sidebarSessionsKeyLoader, {
+    revalidateAll: true,
+  });
   const loading = sessionsLoading;
   const hasMorePages = Boolean(data?.at(-1)?.nextCursor);
   const loadingMore = isValidating && size > (data?.length ?? 0);
@@ -273,7 +264,7 @@ export function SessionSidebar({
 
   const handleSessionArchived = useCallback(
     async (sessionId: string) => {
-      if (!sidebarSessionsKey) return;
+      if (!authSession) return;
 
       await mutateSidebar((current) => removeSessionFromSidebar(current, sessionId), {
         revalidate: true,
@@ -284,7 +275,7 @@ export function SessionSidebar({
         router.push("/");
       }
     },
-    [currentSessionId, mutateSidebar, router, sidebarSessionsKey]
+    [authSession, currentSessionId, mutateSidebar, router]
   );
 
   const handleNavigationSelect = useCallback(() => {
@@ -296,7 +287,7 @@ export function SessionSidebar({
   const handleSessionRenamed = useCallback(
     (sessionId: string, title: string) => {
       const updatedAt = Date.now();
-      if (!sidebarSessionsKey) return;
+      if (!authSession) return;
 
       void mutateSidebar(
         (currentData) => applySidebarTitleUpdate(currentData, sessionId, title, updatedAt),
@@ -304,7 +295,7 @@ export function SessionSidebar({
       );
       void mutate(isUnarchivedSessionListKey);
     },
-    [mutateSidebar, sidebarSessionsKey]
+    [authSession, mutateSidebar]
   );
 
   return (

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -12,20 +12,20 @@ import {
   type TouchEvent,
 } from "react";
 import { useSession, signOut } from "next-auth/react";
-import useSWR, { mutate } from "swr";
+import { mutate } from "swr";
+import useSWRInfinite from "swr/infinite";
 import { ArchiveSessionDialog } from "@/components/archive-session-dialog";
 import { archiveSession } from "@/lib/archive-session";
 import { pullRequestSummaryDisplay } from "@/lib/pr-summary";
 import { PullRequestStateIcon } from "@/components/pr-state-icon";
 import { formatRelativeTime, isInactiveSession } from "@/lib/time";
 import {
-  applyTitleUpdate,
-  buildSessionsPageKey,
+  applySidebarTitleUpdate,
+  buildSidebarSessionsPageKey,
   CURRENT_USER_CREATED_BY,
   isUnarchivedSessionListKey,
-  mergeUniqueSessions,
-  removeSessionFromList,
-  type SessionListResponse,
+  removeSessionFromSidebar,
+  type SidebarSessionListResponse,
 } from "@/lib/session-list";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import { useIsMobile } from "@/hooks/use-media-query";
@@ -126,21 +126,13 @@ export function SessionSidebar({
   const pathname = usePathname();
   const router = useRouter();
   const [sessionCreatorFilter, setSessionCreatorFilter] = useState<SessionCreatorFilter>("all");
-  const [extraSessions, setExtraSessions] = useState<SessionItem[]>([]);
-  const [hasMorePages, setHasMorePages] = useState(false);
-  const [loadingMore, setLoadingMore] = useState(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const offsetRef = useRef(0);
-  const hasMoreRef = useRef(false);
-  const loadingMoreRef = useRef(false);
-  const sessionListVersionRef = useRef(0);
   const isMobile = useIsMobile();
 
   const sidebarSessionsKey = useMemo(() => {
     if (!authSession) return null;
 
-    return buildSessionsPageKey({
-      excludeStatus: "archived",
+    return buildSidebarSessionsPageKey({
       createdBy: sessionCreatorFilter === "mine" ? [CURRENT_USER_CREATED_BY] : undefined,
     });
   }, [authSession, sessionCreatorFilter]);
@@ -149,75 +141,28 @@ export function SessionSidebar({
     data,
     error: sessionsError,
     isLoading: sessionsLoading,
-  } = useSWR<SessionListResponse>(sidebarSessionsKey);
+    isValidating,
+    size,
+    setSize,
+    mutate: mutateSidebar,
+  } = useSWRInfinite<SidebarSessionListResponse>(
+    (pageIndex, previousPage) => {
+      if (!sidebarSessionsKey) return null;
+      if (pageIndex > 0 && !previousPage?.nextCursor) return null;
+      return buildSidebarSessionsPageKey({
+        createdBy: sessionCreatorFilter === "mine" ? [CURRENT_USER_CREATED_BY] : undefined,
+        cursor: pageIndex > 0 ? (previousPage?.nextCursor ?? undefined) : undefined,
+      });
+    },
+    { revalidateAll: true }
+  );
   const loading = sessionsLoading;
-  const firstPageSessions = useMemo(() => data?.sessions ?? [], [data?.sessions]);
-
-  // Track data reference to clear extraSessions synchronously during render,
-  // preventing one frame of stale extra sessions after SWR revalidation.
-  const prevDataRef = useRef(data);
-  let effectiveExtraSessions = extraSessions;
-  if (prevDataRef.current !== data) {
-    prevDataRef.current = data;
-    effectiveExtraSessions = [];
-  }
-
-  useEffect(() => {
-    sessionListVersionRef.current += 1;
-    setExtraSessions([]);
-    setLoadingMore(false);
-    loadingMoreRef.current = false;
-
-    const nextHasMore = data?.hasMore ?? false;
-    const nextOffset = data ? firstPageSessions.length : 0;
-
-    setHasMorePages(nextHasMore);
-    offsetRef.current = nextOffset;
-    hasMoreRef.current = nextHasMore;
-  }, [sidebarSessionsKey, data, firstPageSessions.length]);
-
-  const loadMoreSessions = useCallback(async () => {
-    if (!authSession || !sidebarSessionsKey || loadingMoreRef.current || !hasMoreRef.current) {
-      return;
-    }
-
-    loadingMoreRef.current = true;
-    setLoadingMore(true);
-    const sessionListVersion = sessionListVersionRef.current;
-
-    try {
-      const response = await fetch(
-        buildSessionsPageKey({
-          excludeStatus: "archived",
-          createdBy: sessionCreatorFilter === "mine" ? [CURRENT_USER_CREATED_BY] : undefined,
-          offset: offsetRef.current,
-        })
-      );
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch additional sessions: ${response.status}`);
-      }
-
-      const page: SessionListResponse = await response.json();
-      const fetched = page.sessions ?? [];
-
-      if (sessionListVersion !== sessionListVersionRef.current) {
-        return;
-      }
-
-      setExtraSessions((prev) => mergeUniqueSessions(prev, fetched));
-      setHasMorePages(page.hasMore);
-      offsetRef.current += fetched.length;
-      hasMoreRef.current = page.hasMore;
-    } catch (error) {
-      console.error("Failed to fetch additional sessions:", error);
-    } finally {
-      if (sessionListVersion === sessionListVersionRef.current) {
-        loadingMoreRef.current = false;
-        setLoadingMore(false);
-      }
-    }
-  }, [authSession, sessionCreatorFilter, sidebarSessionsKey]);
+  const hasMorePages = Boolean(data?.at(-1)?.nextCursor);
+  const loadingMore = isValidating && size > (data?.length ?? 0);
+  const loadMoreSessions = useCallback(() => {
+    if (!hasMorePages || loadingMore) return;
+    void setSize((currentSize) => currentSize + 1);
+  }, [hasMorePages, loadingMore, setSize]);
 
   const maybeLoadMoreSessions = useCallback(() => {
     const container = scrollContainerRef.current;
@@ -236,19 +181,19 @@ export function SessionSidebar({
     if (container.clientHeight > 0 && container.scrollHeight <= container.clientHeight) {
       void loadMoreSessions();
     }
-  }, [
-    hasMorePages,
-    loading,
-    loadingMore,
-    loadMoreSessions,
-    firstPageSessions.length,
-    extraSessions.length,
-  ]);
+  }, [hasMorePages, loading, loadingMore, loadMoreSessions, data]);
 
-  const sessions = useMemo(
-    () => mergeUniqueSessions(firstPageSessions, effectiveExtraSessions),
-    [firstPageSessions, effectiveExtraSessions]
-  );
+  const trees = useMemo(() => {
+    const seen = new Set<string>();
+    return (data ?? []).flatMap((page) =>
+      (page?.trees ?? []).filter((tree) => {
+        if (seen.has(tree.rootSessionId)) return false;
+        seen.add(tree.rootSessionId);
+        return true;
+      })
+    );
+  }, [data]);
+  const sessions = useMemo(() => trees.flatMap((tree) => tree.sessions), [trees]);
 
   // Sort sessions by updatedAt (most recent first) and group children under their parent sessions.
   const { activeSessions, inactiveSessions, childrenMap } = useMemo(() => {
@@ -261,7 +206,8 @@ export function SessionSidebar({
       return bTime - aTime;
     });
 
-    // Build set of visible session IDs for orphan detection
+    // Complete trees normally contain every ancestor. Missing or archived
+    // ancestors promote their nearest visible descendants to top-level rows.
     const visibleIds = new Set(sorted.map((s) => s.id));
 
     // Group children by parent ID
@@ -284,9 +230,16 @@ export function SessionSidebar({
     const active: SessionItem[] = [];
     const inactive: SessionItem[] = [];
     const now = Date.now();
+    const activityByRoot = new Map(trees.map((tree) => [tree.rootSessionId, tree.activityAt]));
+    topLevel.sort((a, b) => {
+      const aActivity = activityByRoot.get(a.rootSessionId ?? a.id) ?? a.updatedAt;
+      const bActivity = activityByRoot.get(b.rootSessionId ?? b.id) ?? b.updatedAt;
+      return bActivity - aActivity || b.id.localeCompare(a.id);
+    });
 
     for (const session of topLevel) {
-      const timestamp = session.updatedAt || session.createdAt;
+      const timestamp =
+        activityByRoot.get(session.rootSessionId ?? session.id) ?? session.updatedAt;
       if (isInactiveSession(timestamp, now)) {
         inactive.push(session);
       } else {
@@ -299,7 +252,7 @@ export function SessionSidebar({
       inactiveSessions: inactive,
       childrenMap: children,
     };
-  }, [sessions]);
+  }, [sessions, trees]);
 
   // Environment provenance for the cards, resolved once for the whole list.
   // Names are looked up so a deleted environment (or one still loading)
@@ -322,21 +275,16 @@ export function SessionSidebar({
     async (sessionId: string) => {
       if (!sidebarSessionsKey) return;
 
-      await mutate<SessionListResponse>(
-        isUnarchivedSessionListKey,
-        (current) =>
-          current
-            ? { ...current, sessions: removeSessionFromList(current.sessions, sessionId) }
-            : current,
-        { revalidate: false, populateCache: true }
-      );
-      setExtraSessions((prev) => prev.filter((session) => session.id !== sessionId));
+      await mutateSidebar((current) => removeSessionFromSidebar(current, sessionId), {
+        revalidate: true,
+      });
+      void mutate(isUnarchivedSessionListKey);
 
       if (currentSessionId === sessionId) {
         router.push("/");
       }
     },
-    [currentSessionId, router, sidebarSessionsKey]
+    [currentSessionId, mutateSidebar, router, sidebarSessionsKey]
   );
 
   const handleNavigationSelect = useCallback(() => {
@@ -348,20 +296,15 @@ export function SessionSidebar({
   const handleSessionRenamed = useCallback(
     (sessionId: string, title: string) => {
       const updatedAt = Date.now();
-      setExtraSessions((prev) =>
-        prev.map((session) =>
-          session.id === sessionId ? { ...session, title, updatedAt } : session
-        )
-      );
       if (!sidebarSessionsKey) return;
 
-      void mutate<SessionListResponse>(
-        isUnarchivedSessionListKey,
-        (currentData) => applyTitleUpdate(currentData, sessionId, title, updatedAt),
+      void mutateSidebar(
+        (currentData) => applySidebarTitleUpdate(currentData, sessionId, title, updatedAt),
         { revalidate: false }
       );
+      void mutate(isUnarchivedSessionListKey);
     },
-    [sidebarSessionsKey]
+    [mutateSidebar, sidebarSessionsKey]
   );
 
   return (
@@ -693,8 +636,6 @@ function SessionListItem({
   );
   const prDisplay = pullRequestSummaryDisplay(session.pullRequestSummary);
   const displayTitle = session.title || repoInfo;
-  // Orphan child (parent filtered out) — show a subtle badge
-  const isOrphanChild = session.parentSessionId && session.spawnSource === "agent";
   const [isRenaming, setIsRenaming] = useState(false);
   const [isActionsOpen, setIsActionsOpen] = useState(false);
   const [isArchiving, setIsArchiving] = useState(false);
@@ -905,12 +846,6 @@ function SessionListItem({
                   <span>·</span>
                   <BoxIcon className="w-3 h-3 flex-shrink-0" />
                   <span className="truncate">{environmentName}</span>
-                </>
-              )}
-              {isOrphanChild && (
-                <>
-                  <span>·</span>
-                  <span className="text-accent">sub-task</span>
                 </>
               )}
               {session.baseBranch && session.baseBranch !== "main" && (

--- a/packages/web/src/components/settings/data-controls-settings.test.tsx
+++ b/packages/web/src/components/settings/data-controls-settings.test.tsx
@@ -8,7 +8,7 @@ import * as matchers from "@testing-library/jest-dom/matchers";
 import { SWRConfig, mutate as globalMutate } from "swr";
 import useSWRInfinite from "swr/infinite";
 import { DataControlsSettings } from "./data-controls-settings";
-import { SIDEBAR_INFINITE_KEYS, SIDEBAR_SESSIONS_KEY } from "@/lib/session-list";
+import { createSidebarSessionsKeyLoader, SIDEBAR_SESSIONS_KEY } from "@/lib/session-list";
 
 expect.extend(matchers);
 
@@ -104,7 +104,7 @@ function installFetch(handlers: FetchHandlers) {
       if (params.get("view") === "sidebar") {
         return handlers.onListSidebar
           ? handlers.onListSidebar()
-          : jsonResponse({ sessions: [], hasMore: false });
+          : jsonResponse({ trees: [], nextCursor: null });
       }
     }
 
@@ -298,7 +298,7 @@ describe("DataControlsSettings — unarchive flow", () => {
 function SidebarProbe() {
   // Mounting this subscribes to SIDEBAR_SESSIONS_KEY so that mutate(key)
   // from the component-under-test triggers a real refetch we can observe.
-  useSWRInfinite(() => SIDEBAR_SESSIONS_KEY);
+  useSWRInfinite(createSidebarSessionsKeyLoader());
   return null;
 }
 
@@ -331,6 +331,5 @@ describe("DataControlsSettings — sidebar invalidation", () => {
       expect(sidebarHandler).toHaveBeenCalledTimes(2);
     });
     expect(fetchMock).toHaveBeenCalledWith(SIDEBAR_SESSIONS_KEY);
-    expect(SIDEBAR_INFINITE_KEYS[0]).toContain(SIDEBAR_SESSIONS_KEY);
   });
 });

--- a/packages/web/src/components/settings/data-controls-settings.test.tsx
+++ b/packages/web/src/components/settings/data-controls-settings.test.tsx
@@ -5,9 +5,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as matchers from "@testing-library/jest-dom/matchers";
-import useSWR, { SWRConfig, mutate as globalMutate } from "swr";
+import { SWRConfig, mutate as globalMutate } from "swr";
+import useSWRInfinite from "swr/infinite";
 import { DataControlsSettings } from "./data-controls-settings";
-import { SIDEBAR_SESSIONS_KEY } from "@/lib/session-list";
+import { SIDEBAR_INFINITE_KEYS, SIDEBAR_SESSIONS_KEY } from "@/lib/session-list";
 
 expect.extend(matchers);
 
@@ -100,7 +101,7 @@ function installFetch(handlers: FetchHandlers) {
           total: archived.length,
         });
       }
-      if (params.get("excludeStatus") === "archived") {
+      if (params.get("view") === "sidebar") {
         return handlers.onListSidebar
           ? handlers.onListSidebar()
           : jsonResponse({ sessions: [], hasMore: false });
@@ -297,13 +298,13 @@ describe("DataControlsSettings — unarchive flow", () => {
 function SidebarProbe() {
   // Mounting this subscribes to SIDEBAR_SESSIONS_KEY so that mutate(key)
   // from the component-under-test triggers a real refetch we can observe.
-  useSWR<{ sessions: unknown[]; hasMore: boolean }>(SIDEBAR_SESSIONS_KEY);
+  useSWRInfinite(() => SIDEBAR_SESSIONS_KEY);
   return null;
 }
 
 describe("DataControlsSettings — sidebar invalidation", () => {
   it("refetches the sidebar session list after a successful unarchive", async () => {
-    const sidebarHandler = vi.fn(() => jsonResponse({ sessions: [], hasMore: false }));
+    const sidebarHandler = vi.fn(() => jsonResponse({ trees: [], nextCursor: null }));
     const fetchMock = installFetch({
       archivedSessions: [createArchivedSession(1)],
       onUnarchive: () => jsonResponse({ status: "active" }),
@@ -330,5 +331,6 @@ describe("DataControlsSettings — sidebar invalidation", () => {
       expect(sidebarHandler).toHaveBeenCalledTimes(2);
     });
     expect(fetchMock).toHaveBeenCalledWith(SIDEBAR_SESSIONS_KEY);
+    expect(SIDEBAR_INFINITE_KEYS[0]).toContain(SIDEBAR_SESSIONS_KEY);
   });
 });

--- a/packages/web/src/components/settings/data-controls-settings.tsx
+++ b/packages/web/src/components/settings/data-controls-settings.tsx
@@ -11,6 +11,7 @@ import {
   buildSessionsPageKey,
   isUnarchivedSessionListKey,
   removeSessionFromList,
+  SIDEBAR_INFINITE_KEYS,
   type SessionListResponse,
 } from "@/lib/session-list";
 import { formatRelativeTime } from "@/lib/time";
@@ -86,6 +87,7 @@ export function DataControlsSettings() {
       // this row's slot.
       setOffset((prev) => prev - 1);
       mutate(isUnarchivedSessionListKey);
+      for (const key of SIDEBAR_INFINITE_KEYS) mutate(key);
     } catch {
       toast.error("Failed to unarchive session");
     }

--- a/packages/web/src/components/settings/data-controls-settings.tsx
+++ b/packages/web/src/components/settings/data-controls-settings.tsx
@@ -9,9 +9,8 @@ import { buildSessionHref, type SessionItem } from "@/components/session-sidebar
 import { formatRepoLabel } from "@/lib/repo-label";
 import {
   buildSessionsPageKey,
-  isUnarchivedSessionListKey,
   removeSessionFromList,
-  SIDEBAR_INFINITE_KEYS,
+  unarchivedSessionListRevalidationKeys,
   type SessionListResponse,
 } from "@/lib/session-list";
 import { formatRelativeTime } from "@/lib/time";
@@ -86,8 +85,7 @@ export function DataControlsSettings() {
       // start one offset earlier to avoid skipping the session that took
       // this row's slot.
       setOffset((prev) => prev - 1);
-      mutate(isUnarchivedSessionListKey);
-      for (const key of SIDEBAR_INFINITE_KEYS) mutate(key);
+      for (const key of unarchivedSessionListRevalidationKeys()) mutate(key);
     } catch {
       toast.error("Failed to unarchive session");
     }

--- a/packages/web/src/lib/control-plane-query.ts
+++ b/packages/web/src/lib/control-plane-query.ts
@@ -4,6 +4,8 @@ export const SESSION_CONTROL_PLANE_QUERY_PARAMS = [
   ...DEFAULT_CONTROL_PLANE_QUERY_PARAMS,
   "excludeStatus",
   "createdBy",
+  "view",
+  "cursor",
 ] as const;
 
 export function buildControlPlanePath(

--- a/packages/web/src/lib/session-list.test.ts
+++ b/packages/web/src/lib/session-list.test.ts
@@ -91,7 +91,6 @@ describe("isSessionListKey", () => {
   it("matches all session list cache keys", () => {
     expect(isSessionListKey("/api/sessions")).toBe(true);
     expect(isSessionListKey("/api/sessions?limit=50&offset=0")).toBe(true);
-    expect(isSessionListKey("$inf$/api/sessions?limit=50&offset=0&view=sidebar")).toBe(true);
   });
 
   it("ignores other cache keys", () => {

--- a/packages/web/src/lib/session-list.test.ts
+++ b/packages/web/src/lib/session-list.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
+  applySidebarTitleUpdate,
   applyTitleUpdate,
+  buildSidebarSessionsPageKey,
   buildSessionSearchValue,
   buildSessionsPageKey,
   CURRENT_USER_CREATED_BY,
   isArchivedSessionListKey,
   isSessionListKey,
   isUnarchivedSessionListKey,
+  removeSessionFromSidebar,
   type SessionListResponse,
 } from "./session-list";
 import type { Session } from "@open-inspect/shared";
@@ -49,6 +52,12 @@ describe("buildSessionsPageKey", () => {
       "/api/sessions?limit=50&offset=0&excludeStatus=archived&createdBy=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&createdBy=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     );
   });
+
+  it("builds cursor-based sidebar page keys", () => {
+    expect(buildSidebarSessionsPageKey({ cursor: "500:root-a" })).toBe(
+      "/api/sessions?limit=50&offset=0&view=sidebar&cursor=500%3Aroot-a"
+    );
+  });
 });
 
 describe("buildSessionSearchValue", () => {
@@ -82,6 +91,7 @@ describe("isSessionListKey", () => {
   it("matches all session list cache keys", () => {
     expect(isSessionListKey("/api/sessions")).toBe(true);
     expect(isSessionListKey("/api/sessions?limit=50&offset=0")).toBe(true);
+    expect(isSessionListKey("$inf$/api/sessions?limit=50&offset=0&view=sidebar")).toBe(true);
   });
 
   it("ignores other cache keys", () => {
@@ -167,5 +177,38 @@ describe("applyTitleUpdate", () => {
     applyTitleUpdate(before, "a", "Mutated", 9999);
 
     expect(before).toEqual(beforeSnapshot);
+  });
+});
+
+describe("sidebar cache updates", () => {
+  const pages = [
+    {
+      trees: [
+        {
+          rootSessionId: "root",
+          activityAt: 2000,
+          sessions: [session("root"), session("child", { parentSessionId: "root" })],
+        },
+      ],
+      nextCursor: null,
+    },
+  ];
+
+  it("updates nested session titles and tree activity", () => {
+    const updated = applySidebarTitleUpdate(pages, "child", "Renamed", 9999);
+
+    expect(updated?.[0]?.trees[0]?.activityAt).toBe(9999);
+    expect(updated?.[0]?.trees[0]?.sessions[1]).toMatchObject({
+      id: "child",
+      title: "Renamed",
+      updatedAt: 9999,
+    });
+    expect(pages[0]?.trees[0]?.sessions[1]?.title).toBe("CHILD");
+  });
+
+  it("removes a session without dropping the rest of its tree", () => {
+    const updated = removeSessionFromSidebar(pages, "child");
+
+    expect(updated?.[0]?.trees[0]?.sessions.map((item) => item.id)).toEqual(["root"]);
   });
 });

--- a/packages/web/src/lib/session-list.ts
+++ b/packages/web/src/lib/session-list.ts
@@ -1,15 +1,32 @@
-import type { Session } from "@open-inspect/shared";
+import type { Session, SidebarSessionsResponse } from "@open-inspect/shared";
 import { formatRepoLabel } from "./repo-label";
 
 export const SESSIONS_PAGE_SIZE = 50;
 const COMMAND_MENU_SESSIONS_LIMIT = 100;
 export const SESSIONS_API_PATH = "/api/sessions";
 export const CURRENT_USER_CREATED_BY = "me";
+const SWR_INFINITE_PREFIX = "$inf$";
 export const SIDEBAR_SESSIONS_KEY = buildSessionsPageKey({
-  excludeStatus: "archived",
-  limit: SESSIONS_PAGE_SIZE,
-  offset: 0,
+  view: "sidebar",
 });
+export const SIDEBAR_MINE_SESSIONS_KEY = buildSessionsPageKey({
+  view: "sidebar",
+  createdBy: [CURRENT_USER_CREATED_BY],
+});
+export const SIDEBAR_INFINITE_KEYS = [
+  `${SWR_INFINITE_PREFIX}${SIDEBAR_SESSIONS_KEY}`,
+  `${SWR_INFINITE_PREFIX}${SIDEBAR_MINE_SESSIONS_KEY}`,
+] as const;
+
+export function buildSidebarSessionsPageKey({
+  createdBy,
+  cursor,
+}: {
+  createdBy?: readonly string[];
+  cursor?: string;
+} = {}) {
+  return buildSessionsPageKey({ view: "sidebar", createdBy, cursor });
+}
 export const COMMAND_MENU_SESSIONS_KEY = buildSessionsPageKey({
   excludeStatus: "archived",
   limit: COMMAND_MENU_SESSIONS_LIMIT,
@@ -20,18 +37,24 @@ export interface SessionListResponse {
   hasMore: boolean;
 }
 
+export type SidebarSessionListResponse = SidebarSessionsResponse;
+
 export function buildSessionsPageKey({
   limit = SESSIONS_PAGE_SIZE,
   offset = 0,
   status,
   excludeStatus,
   createdBy,
+  view,
+  cursor,
 }: {
   limit?: number;
   offset?: number;
   status?: string;
   excludeStatus?: string;
   createdBy?: readonly string[];
+  view?: "sidebar";
+  cursor?: string;
 }) {
   const searchParams = new URLSearchParams({
     limit: String(limit),
@@ -46,6 +69,14 @@ export function buildSessionsPageKey({
     searchParams.set("excludeStatus", excludeStatus);
   }
 
+  if (view) {
+    searchParams.set("view", view);
+  }
+
+  if (cursor) {
+    searchParams.set("cursor", cursor);
+  }
+
   for (const userId of createdBy ?? []) {
     searchParams.append("createdBy", userId);
   }
@@ -54,23 +85,31 @@ export function buildSessionsPageKey({
 }
 
 export function isSessionListKey(key: unknown): key is string {
+  const normalizedKey =
+    typeof key === "string" && key.startsWith(SWR_INFINITE_PREFIX)
+      ? key.slice(SWR_INFINITE_PREFIX.length)
+      : key;
   return (
-    typeof key === "string" &&
-    (key === SESSIONS_API_PATH || key.startsWith(`${SESSIONS_API_PATH}?`))
+    typeof normalizedKey === "string" &&
+    (normalizedKey === SESSIONS_API_PATH || normalizedKey.startsWith(`${SESSIONS_API_PATH}?`))
   );
+}
+
+function normalizeSessionListKey(key: string): string {
+  return key.startsWith(SWR_INFINITE_PREFIX) ? key.slice(SWR_INFINITE_PREFIX.length) : key;
 }
 
 export function isUnarchivedSessionListKey(key: unknown): key is string {
   if (!isSessionListKey(key)) return false;
 
-  const url = new URL(key, "http://localhost");
+  const url = new URL(normalizeSessionListKey(key), "http://localhost");
   return url.searchParams.get("status") !== "archived";
 }
 
 export function isArchivedSessionListKey(key: unknown): key is string {
   if (!isSessionListKey(key)) return false;
 
-  const url = new URL(key, "http://localhost");
+  const url = new URL(normalizeSessionListKey(key), "http://localhost");
   return url.searchParams.get("status") === "archived";
 }
 
@@ -89,6 +128,41 @@ export function applyTitleUpdate(
       session.id === sessionId ? { ...session, title, updatedAt } : session
     ),
   };
+}
+
+export function applySidebarTitleUpdate(
+  data: SidebarSessionsResponse[] | undefined,
+  sessionId: string,
+  title: string,
+  updatedAt: number
+): SidebarSessionsResponse[] | undefined {
+  return data?.map((page) => ({
+    ...page,
+    trees: page.trees.map((tree) => ({
+      ...tree,
+      activityAt: tree.sessions.some((session) => session.id === sessionId)
+        ? Math.max(tree.activityAt, updatedAt)
+        : tree.activityAt,
+      sessions: tree.sessions.map((session) =>
+        session.id === sessionId ? { ...session, title, updatedAt } : session
+      ),
+    })),
+  }));
+}
+
+export function removeSessionFromSidebar(
+  data: SidebarSessionsResponse[] | undefined,
+  sessionId: string
+): SidebarSessionsResponse[] | undefined {
+  return data?.map((page) => ({
+    ...page,
+    trees: page.trees
+      .map((tree) => ({
+        ...tree,
+        sessions: tree.sessions.filter((session) => session.id !== sessionId),
+      }))
+      .filter((tree) => tree.sessions.length > 0),
+  }));
 }
 
 export function mergeUniqueSessions(existing: Session[], incoming: Session[]) {

--- a/packages/web/src/lib/session-list.ts
+++ b/packages/web/src/lib/session-list.ts
@@ -1,22 +1,14 @@
 import type { Session, SidebarSessionsResponse } from "@open-inspect/shared";
+import { unstable_serialize } from "swr/infinite";
 import { formatRepoLabel } from "./repo-label";
 
 export const SESSIONS_PAGE_SIZE = 50;
 const COMMAND_MENU_SESSIONS_LIMIT = 100;
 export const SESSIONS_API_PATH = "/api/sessions";
 export const CURRENT_USER_CREATED_BY = "me";
-const SWR_INFINITE_PREFIX = "$inf$";
 export const SIDEBAR_SESSIONS_KEY = buildSessionsPageKey({
   view: "sidebar",
 });
-export const SIDEBAR_MINE_SESSIONS_KEY = buildSessionsPageKey({
-  view: "sidebar",
-  createdBy: [CURRENT_USER_CREATED_BY],
-});
-export const SIDEBAR_INFINITE_KEYS = [
-  `${SWR_INFINITE_PREFIX}${SIDEBAR_SESSIONS_KEY}`,
-  `${SWR_INFINITE_PREFIX}${SIDEBAR_MINE_SESSIONS_KEY}`,
-] as const;
 
 export function buildSidebarSessionsPageKey({
   createdBy,
@@ -38,6 +30,23 @@ export interface SessionListResponse {
 }
 
 export type SidebarSessionListResponse = SidebarSessionsResponse;
+
+export function createSidebarSessionsKeyLoader(createdBy?: readonly string[]) {
+  return (pageIndex: number, previousPage: SidebarSessionsResponse | null) => {
+    if (pageIndex > 0 && !previousPage?.nextCursor) return null;
+    return buildSidebarSessionsPageKey({
+      createdBy,
+      cursor: pageIndex > 0 ? (previousPage?.nextCursor ?? undefined) : undefined,
+    });
+  };
+}
+
+function sidebarSessionsRevalidationKeys(): string[] {
+  return [
+    unstable_serialize(createSidebarSessionsKeyLoader()),
+    unstable_serialize(createSidebarSessionsKeyLoader([CURRENT_USER_CREATED_BY])),
+  ];
+}
 
 export function buildSessionsPageKey({
   limit = SESSIONS_PAGE_SIZE,
@@ -85,32 +94,30 @@ export function buildSessionsPageKey({
 }
 
 export function isSessionListKey(key: unknown): key is string {
-  const normalizedKey =
-    typeof key === "string" && key.startsWith(SWR_INFINITE_PREFIX)
-      ? key.slice(SWR_INFINITE_PREFIX.length)
-      : key;
   return (
-    typeof normalizedKey === "string" &&
-    (normalizedKey === SESSIONS_API_PATH || normalizedKey.startsWith(`${SESSIONS_API_PATH}?`))
+    typeof key === "string" &&
+    (key === SESSIONS_API_PATH || key.startsWith(`${SESSIONS_API_PATH}?`))
   );
-}
-
-function normalizeSessionListKey(key: string): string {
-  return key.startsWith(SWR_INFINITE_PREFIX) ? key.slice(SWR_INFINITE_PREFIX.length) : key;
 }
 
 export function isUnarchivedSessionListKey(key: unknown): key is string {
   if (!isSessionListKey(key)) return false;
 
-  const url = new URL(normalizeSessionListKey(key), "http://localhost");
+  const url = new URL(key, "http://localhost");
   return url.searchParams.get("status") !== "archived";
 }
 
 export function isArchivedSessionListKey(key: unknown): key is string {
   if (!isSessionListKey(key)) return false;
 
-  const url = new URL(normalizeSessionListKey(key), "http://localhost");
+  const url = new URL(key, "http://localhost");
   return url.searchParams.get("status") === "archived";
+}
+
+export type SessionListRevalidationKey = string | ((key: unknown) => boolean);
+
+export function unarchivedSessionListRevalidationKeys(): SessionListRevalidationKey[] {
+  return [isUnarchivedSessionListKey, ...sidebarSessionsRevalidationKeys()];
 }
 
 // Extracted from session-sidebar so the cache-shape transformation can be unit

--- a/packages/web/src/lib/session-socket/swr-revalidation.test.ts
+++ b/packages/web/src/lib/session-socket/swr-revalidation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isUnarchivedSessionListKey } from "@/lib/session-list";
+import { isUnarchivedSessionListKey, SIDEBAR_INFINITE_KEYS } from "@/lib/session-list";
 import type { SessionArtifact } from "@open-inspect/shared";
 import { swrKeysToRevalidate } from "./swr-revalidation";
 
@@ -16,13 +16,14 @@ function artifact(type: SessionArtifact["type"]): SessionArtifact {
 }
 
 describe("swrKeysToRevalidate", () => {
+  const listKeys = [isUnarchivedSessionListKey, ...SIDEBAR_INFINITE_KEYS];
   it("revalidates the session list for PR artifact creates and updates", () => {
     expect(
       swrKeysToRevalidate({ type: "artifact_created", artifact: artifact("pr") }, SESSION_ID)
-    ).toEqual([isUnarchivedSessionListKey]);
+    ).toEqual(listKeys);
     expect(
       swrKeysToRevalidate({ type: "artifact_updated", artifact: artifact("pr") }, SESSION_ID)
-    ).toEqual([isUnarchivedSessionListKey]);
+    ).toEqual(listKeys);
   });
 
   it("does not revalidate for non-PR artifacts", () => {
@@ -35,16 +36,16 @@ describe("swrKeysToRevalidate", () => {
   });
 
   it("revalidates the session list on a non-empty title", () => {
-    expect(swrKeysToRevalidate({ type: "session_title", title: "New title" }, SESSION_ID)).toEqual([
-      isUnarchivedSessionListKey,
-    ]);
+    expect(swrKeysToRevalidate({ type: "session_title", title: "New title" }, SESSION_ID)).toEqual(
+      listKeys
+    );
     expect(swrKeysToRevalidate({ type: "session_title", title: "" }, SESSION_ID)).toEqual([]);
   });
 
   it("revalidates the session list on status changes", () => {
     expect(
       swrKeysToRevalidate({ type: "session_status", status: "completed" }, SESSION_ID)
-    ).toEqual([isUnarchivedSessionListKey]);
+    ).toEqual(listKeys);
   });
 
   it("revalidates the child list and the session list on child session updates", () => {
@@ -58,7 +59,7 @@ describe("swrKeysToRevalidate", () => {
         },
         SESSION_ID
       )
-    ).toEqual([`/api/sessions/${SESSION_ID}/children`, isUnarchivedSessionListKey]);
+    ).toEqual([`/api/sessions/${SESSION_ID}/children`, ...listKeys]);
   });
 
   it("returns nothing for view-only messages", () => {

--- a/packages/web/src/lib/session-socket/swr-revalidation.test.ts
+++ b/packages/web/src/lib/session-socket/swr-revalidation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isUnarchivedSessionListKey, SIDEBAR_INFINITE_KEYS } from "@/lib/session-list";
+import { unarchivedSessionListRevalidationKeys } from "@/lib/session-list";
 import type { SessionArtifact } from "@open-inspect/shared";
 import { swrKeysToRevalidate } from "./swr-revalidation";
 
@@ -16,7 +16,7 @@ function artifact(type: SessionArtifact["type"]): SessionArtifact {
 }
 
 describe("swrKeysToRevalidate", () => {
-  const listKeys = [isUnarchivedSessionListKey, ...SIDEBAR_INFINITE_KEYS];
+  const listKeys = unarchivedSessionListRevalidationKeys();
   it("revalidates the session list for PR artifact creates and updates", () => {
     expect(
       swrKeysToRevalidate({ type: "artifact_created", artifact: artifact("pr") }, SESSION_ID)

--- a/packages/web/src/lib/session-socket/swr-revalidation.ts
+++ b/packages/web/src/lib/session-socket/swr-revalidation.ts
@@ -1,12 +1,9 @@
-import { isUnarchivedSessionListKey, SIDEBAR_INFINITE_KEYS } from "@/lib/session-list";
+import { unarchivedSessionListRevalidationKeys } from "@/lib/session-list";
 import type { ServerMessage } from "@open-inspect/shared";
 
 /** An SWR cache key or key matcher to pass to `mutate`. */
 export type SwrRevalidationKey = string | ((key: unknown) => boolean);
-const SESSION_LIST_REVALIDATION_KEYS: SwrRevalidationKey[] = [
-  isUnarchivedSessionListKey,
-  ...SIDEBAR_INFINITE_KEYS,
-];
+const SESSION_LIST_REVALIDATION_KEYS = unarchivedSessionListRevalidationKeys();
 
 /**
  * Which SWR caches a server message invalidates. Session-socket messages can

--- a/packages/web/src/lib/session-socket/swr-revalidation.ts
+++ b/packages/web/src/lib/session-socket/swr-revalidation.ts
@@ -1,8 +1,12 @@
-import { isUnarchivedSessionListKey } from "@/lib/session-list";
+import { isUnarchivedSessionListKey, SIDEBAR_INFINITE_KEYS } from "@/lib/session-list";
 import type { ServerMessage } from "@open-inspect/shared";
 
 /** An SWR cache key or key matcher to pass to `mutate`. */
 export type SwrRevalidationKey = string | ((key: unknown) => boolean);
+const SESSION_LIST_REVALIDATION_KEYS: SwrRevalidationKey[] = [
+  isUnarchivedSessionListKey,
+  ...SIDEBAR_INFINITE_KEYS,
+];
 
 /**
  * Which SWR caches a server message invalidates. Session-socket messages can
@@ -22,18 +26,18 @@ export function swrKeysToRevalidate(
   switch (message.type) {
     case "artifact_created":
     case "artifact_updated":
-      return message.artifact.type === "pr" ? [isUnarchivedSessionListKey] : [];
+      return message.artifact.type === "pr" ? SESSION_LIST_REVALIDATION_KEYS : [];
 
     case "session_title":
-      return message.title ? [isUnarchivedSessionListKey] : [];
+      return message.title ? SESSION_LIST_REVALIDATION_KEYS : [];
 
     case "session_status":
       // Revalidate so the status change is reflected in the sidebar.
-      return [isUnarchivedSessionListKey];
+      return SESSION_LIST_REVALIDATION_KEYS;
 
     case "child_session_update":
       // Child session spawned or changed status — revalidate child list and sidebar.
-      return [`/api/sessions/${sessionId}/children`, isUnarchivedSessionListKey];
+      return [`/api/sessions/${sessionId}/children`, ...SESSION_LIST_REVALIDATION_KEYS];
 
     default:
       return [];

--- a/terraform/d1/migrations/0043_session_tree_roots.sql
+++ b/terraform/d1/migrations/0043_session_tree_roots.sql
@@ -1,0 +1,26 @@
+-- Keep session hierarchies together when paginating the global sidebar.
+ALTER TABLE sessions ADD COLUMN root_session_id TEXT;
+
+-- Resolve every hierarchy from its top-level ancestor. Rows in malformed
+-- legacy cycles or with missing parents safely become their own roots.
+WITH RECURSIVE session_roots(id, root_id, path) AS (
+  SELECT s.id, s.id, ',' || s.id || ','
+  FROM sessions s
+  WHERE s.parent_session_id IS NULL
+     OR NOT EXISTS (SELECT 1 FROM sessions parent WHERE parent.id = s.parent_session_id)
+
+  UNION ALL
+
+  SELECT child.id, session_roots.root_id, session_roots.path || child.id || ','
+  FROM sessions child
+  JOIN session_roots ON child.parent_session_id = session_roots.id
+  WHERE instr(session_roots.path, ',' || child.id || ',') = 0
+)
+UPDATE sessions
+SET root_session_id = COALESCE(
+  (SELECT root_id FROM session_roots WHERE session_roots.id = sessions.id),
+  id
+);
+
+CREATE INDEX idx_sessions_root_status_updated
+  ON sessions(root_session_id, status, updated_at DESC);


### PR DESCRIPTION
## Summary
- add persistent root-session identity and a migration that backfills existing parent/child hierarchies
- add a tree-complete, cursor-paginated sidebar view ordered by activity across each hierarchy
- migrate the sidebar to `useSWRInfinite` so revalidation preserves loaded pages and cannot split parent/child formatting
- explicitly revalidate infinite sidebar caches for status, title, child, PR, and unarchive updates
- wait for D1 status synchronization before broadcasting sidebar revalidation events
- batch metadata decoration for large trees to stay within D1 parameter and concurrency limits

## Validation
- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`
- `npm test -w @open-inspect/control-plane` (1,817 tests)
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web`
- `npm test -w @open-inspect/web` (777 tests)
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/auth.test.ts test/integration/d1-session-index.test.ts` (38 tests)

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/e96976bb5362094477d2a9fb6b98c861)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sidebar sessions view that groups related sessions by their root session.
  * Introduced cursor-based pagination for sidebar session trees.
  * “Mine” filtering is now supported within the sidebar view.
* **Bug Fixes**
  * Sidebar ordering/activity now updates consistently across entire session trees after renaming, archiving, unarchiving, and status changes.
  * Large sidebar trees paginate reliably without missing items.
  * Malformed sidebar cursors now return a clear 400 error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->