### PR TITLE
refactor: share bot read-through cache engine

### DIFF
--- a/packages/linear-bot/src/cached-resource.ts
+++ b/packages/linear-bot/src/cached-resource.ts
@@ -8,7 +8,11 @@
  * classifier/cached-resource.ts.
  */
 
-import { createKvCacheStore } from "@open-inspect/shared";
+import {
+  createKvCacheStore,
+  createReadThroughCache,
+  type ReadThroughCache,
+} from "@open-inspect/shared";
 import type { Env } from "./types";
 import {
   ControlPlaneRequestError,
@@ -34,74 +38,36 @@ export interface CachedResourceOptions<T> {
   fallback: T;
 }
 
-export interface CachedResource<T> {
-  get(env: Env, traceId?: string): Promise<T>;
-  /**
-   * Drop the in-memory copy so the next get() reloads. The KV copy is
-   * deliberately kept — it is fallback data, not authority.
-   */
-  invalidate(): void;
-}
+export type CachedResource<T> = ReadThroughCache<T, Env>;
 
 export function createCachedResource<T>(options: CachedResourceOptions<T>): CachedResource<T> {
   const log = createLogger(options.name);
   const loadFailureEvent = `control_plane.fetch_${options.name}`;
   const kvLogKeyPrefix = `${options.name}_cache`;
-  let memory: { value: T; timestamp: number } | null = null;
 
-  async function readKvFallback(env: Env): Promise<T> {
-    try {
-      const cached = await createKvCacheStore(env.LINEAR_KV).get(options.kvKey, "json");
-      const value = cached === null ? null : options.deserialize(cached);
-      if (value !== null) return value;
-    } catch (e) {
-      log.warn("kv.get", {
-        key_prefix: kvLogKeyPrefix,
-        error: e instanceof Error ? e : new Error(String(e)),
-      });
-    }
-    return options.fallback;
-  }
-
-  async function get(env: Env, traceId?: string): Promise<T> {
-    if (memory && Date.now() - memory.timestamp < LOCAL_CACHE_TTL_MS) {
-      return memory.value;
-    }
-
-    const startTime = Date.now();
-    try {
-      const value = await options.load(env, traceId);
-      memory = { value, timestamp: Date.now() };
-
-      try {
-        await createKvCacheStore(env.LINEAR_KV).put(options.kvKey, JSON.stringify(value), {
-          expirationTtl: KV_CACHE_TTL_SECONDS,
-        });
-      } catch (e) {
-        log.warn("kv.put", {
-          trace_id: traceId,
-          key_prefix: kvLogKeyPrefix,
-          error: e instanceof Error ? e : new Error(String(e)),
-        });
-      }
-
-      return value;
-    } catch (e) {
+  return createReadThroughCache<T, Env>({
+    cacheKey: options.kvKey,
+    cacheTtlSeconds: KV_CACHE_TTL_SECONDS,
+    localTtlMs: LOCAL_CACHE_TTL_MS,
+    load: options.load,
+    getCacheStore: (env) => createKvCacheStore(env.LINEAR_KV),
+    deserialize: options.deserialize,
+    fallback: options.fallback,
+    onLoadError: (error, { traceId, durationMs }) => {
       log.warn(loadFailureEvent, {
         trace_id: traceId,
         outcome: "error",
-        http_status: e instanceof ControlPlaneRequestError ? e.status : undefined,
-        error: e instanceof Error ? e : new Error(String(e)),
-        duration_ms: Date.now() - startTime,
+        http_status: error instanceof ControlPlaneRequestError ? error.status : undefined,
+        error: error instanceof Error ? error : new Error(String(error)),
+        duration_ms: durationMs,
       });
-      return readKvFallback(env);
-    }
-  }
-
-  return {
-    get,
-    invalidate() {
-      memory = null;
     },
-  };
+    onCacheError: (operation, error, traceId) => {
+      log.warn(`kv.${operation}`, {
+        trace_id: traceId,
+        key_prefix: kvLogKeyPrefix,
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
+    },
+  });
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -12,6 +12,7 @@ export * from "./triggers";
 export * from "./completion/extractor";
 export * from "./logger";
 export * from "./cache-store";
+export * from "./read-through-cache";
 export * from "./app-name";
 export * from "./user-id";
 export * from "./slack";

--- a/packages/shared/src/read-through-cache.test.ts
+++ b/packages/shared/src/read-through-cache.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CacheStore } from "./cache-store";
+import { createReadThroughCache } from "./read-through-cache";
+
+interface Context {
+  store: CacheStore;
+}
+
+function createStore(): CacheStore {
+  return {
+    get: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  } as CacheStore;
+}
+
+function createCache(
+  overrides: Partial<Parameters<typeof createReadThroughCache<string[], Context>>[0]> = {}
+) {
+  return createReadThroughCache<string[], Context>({
+    cacheKey: "resources:cache",
+    cacheTtlSeconds: 300,
+    localTtlMs: 60_000,
+    load: vi.fn().mockResolvedValue(["fresh"]),
+    getCacheStore: (context) => context.store,
+    deserialize: (cached) => (Array.isArray(cached) ? (cached as string[]) : null),
+    fallback: [],
+    ...overrides,
+  });
+}
+
+describe("createReadThroughCache", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("loads once and serves the value from memory within the local TTL", async () => {
+    const store = createStore();
+    const load = vi.fn().mockResolvedValue(["fresh"]);
+    const cache = createCache({ load });
+
+    await expect(cache.get({ store }, "trace-1")).resolves.toEqual(["fresh"]);
+    vi.advanceTimersByTime(59_999);
+    await expect(cache.get({ store }, "trace-2")).resolves.toEqual(["fresh"]);
+
+    expect(load).toHaveBeenCalledOnce();
+    expect(store.put).toHaveBeenCalledWith("resources:cache", '["fresh"]', {
+      expirationTtl: 300,
+    });
+  });
+
+  it("reloads after the local TTL expires", async () => {
+    const store = createStore();
+    const load = vi.fn().mockResolvedValueOnce(["first"]).mockResolvedValueOnce(["second"]);
+    const cache = createCache({ load });
+
+    await expect(cache.get({ store })).resolves.toEqual(["first"]);
+    vi.advanceTimersByTime(60_000);
+    await expect(cache.get({ store })).resolves.toEqual(["second"]);
+
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses a valid last-known-good cache value when loading fails", async () => {
+    const store = createStore();
+    vi.mocked(store.get).mockResolvedValue(["stale"] as never);
+    const loadError = new Error("control plane unavailable");
+    const onLoadError = vi.fn();
+    const cache = createCache({
+      load: vi.fn().mockRejectedValue(loadError),
+      onLoadError,
+    });
+
+    await expect(cache.get({ store }, "trace-1")).resolves.toEqual(["stale"]);
+
+    expect(store.get).toHaveBeenCalledWith("resources:cache", "json");
+    expect(onLoadError).toHaveBeenCalledWith(loadError, {
+      traceId: "trace-1",
+      durationMs: 0,
+    });
+  });
+
+  it("uses the terminal fallback when the cached value is invalid", async () => {
+    const store = createStore();
+    vi.mocked(store.get).mockResolvedValue({ invalid: true } as never);
+    const cache = createCache({
+      load: vi.fn().mockRejectedValue(new Error("load failed")),
+      fallback: ["fallback"],
+    });
+
+    await expect(cache.get({ store })).resolves.toEqual(["fallback"]);
+  });
+
+  it("reports cache read failures and uses the terminal fallback", async () => {
+    const store = createStore();
+    const cacheError = new Error("KV unavailable");
+    vi.mocked(store.get).mockRejectedValue(cacheError);
+    const onCacheError = vi.fn();
+    const cache = createCache({
+      load: vi.fn().mockRejectedValue(new Error("load failed")),
+      fallback: ["fallback"],
+      onCacheError,
+    });
+
+    await expect(cache.get({ store }, "trace-1")).resolves.toEqual(["fallback"]);
+
+    expect(onCacheError).toHaveBeenCalledWith("get", cacheError);
+  });
+
+  it("reports cache write failures without discarding the loaded value", async () => {
+    const store = createStore();
+    const cacheError = new Error("KV unavailable");
+    vi.mocked(store.put).mockRejectedValue(cacheError);
+    const onCacheError = vi.fn();
+    const cache = createCache({ onCacheError });
+
+    await expect(cache.get({ store }, "trace-1")).resolves.toEqual(["fresh"]);
+
+    expect(onCacheError).toHaveBeenCalledWith("put", cacheError, "trace-1");
+  });
+
+  it("reloads after invalidation", async () => {
+    const store = createStore();
+    const load = vi.fn().mockResolvedValueOnce(["first"]).mockResolvedValueOnce(["second"]);
+    const cache = createCache({ load });
+
+    await expect(cache.get({ store })).resolves.toEqual(["first"]);
+    cache.invalidate();
+    await expect(cache.get({ store })).resolves.toEqual(["second"]);
+
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/shared/src/read-through-cache.ts
+++ b/packages/shared/src/read-through-cache.ts
@@ -1,0 +1,75 @@
+import type { CacheStore } from "./cache-store";
+
+export interface ReadThroughCacheOptions<T, Context> {
+  cacheKey: string;
+  cacheTtlSeconds: number;
+  localTtlMs: number;
+  load: (context: Context, traceId?: string) => Promise<T>;
+  getCacheStore: (context: Context) => CacheStore;
+  deserialize: (cached: unknown) => T | null;
+  fallback: T;
+  onLoadError?: (error: unknown, details: { traceId?: string; durationMs: number }) => void;
+  onCacheError?: (operation: "get" | "put", error: unknown, traceId?: string) => void;
+}
+
+export interface ReadThroughCache<T, Context> {
+  get(context: Context, traceId?: string): Promise<T>;
+  /** Drops only the in-memory value; the persistent fallback remains intact. */
+  invalidate(): void;
+}
+
+/**
+ * Creates a fail-open cache backed by local memory and a persistent
+ * last-known-good store. Callers retain control of loading and diagnostics.
+ */
+export function createReadThroughCache<T, Context>(
+  options: ReadThroughCacheOptions<T, Context>
+): ReadThroughCache<T, Context> {
+  let memory: { value: T; timestamp: number } | null = null;
+
+  async function readCacheFallback(context: Context): Promise<T> {
+    try {
+      const cached = await options.getCacheStore(context).get<unknown>(options.cacheKey, "json");
+      const value = cached === null ? null : options.deserialize(cached);
+      if (value !== null) return value;
+    } catch (error) {
+      options.onCacheError?.("get", error);
+    }
+    return options.fallback;
+  }
+
+  async function get(context: Context, traceId?: string): Promise<T> {
+    if (memory && Date.now() - memory.timestamp < options.localTtlMs) {
+      return memory.value;
+    }
+
+    const startTime = Date.now();
+    try {
+      const value = await options.load(context, traceId);
+      memory = { value, timestamp: Date.now() };
+
+      try {
+        await options.getCacheStore(context).put(options.cacheKey, JSON.stringify(value), {
+          expirationTtl: options.cacheTtlSeconds,
+        });
+      } catch (error) {
+        options.onCacheError?.("put", error, traceId);
+      }
+
+      return value;
+    } catch (error) {
+      options.onLoadError?.(error, {
+        traceId,
+        durationMs: Date.now() - startTime,
+      });
+      return readCacheFallback(context);
+    }
+  }
+
+  return {
+    get,
+    invalidate() {
+      memory = null;
+    },
+  };
+}

--- a/packages/slack-bot/src/classifier/cached-resource.ts
+++ b/packages/slack-bot/src/classifier/cached-resource.ts
@@ -10,7 +10,11 @@
  * KV-first, no memory tier).
  */
 
-import { createKvCacheStore } from "@open-inspect/shared";
+import {
+  createKvCacheStore,
+  createReadThroughCache,
+  type ReadThroughCache,
+} from "@open-inspect/shared";
 import type { Env } from "../types";
 import {
   ControlPlaneRequestError,
@@ -36,74 +40,36 @@ export interface CachedResourceOptions<T> {
   fallback: T;
 }
 
-export interface CachedResource<T> {
-  get(env: Env, traceId?: string): Promise<T>;
-  /**
-   * Drop the in-memory copy so the next get() reloads. The KV copy is
-   * deliberately kept — it is fallback data, not authority.
-   */
-  invalidate(): void;
-}
+export type CachedResource<T> = ReadThroughCache<T, Env>;
 
 export function createCachedResource<T>(options: CachedResourceOptions<T>): CachedResource<T> {
   const log = createLogger(options.name);
   const loadFailureEvent = `control_plane.fetch_${options.name}`;
   const kvLogKeyPrefix = `${options.name}_cache`;
-  let memory: { value: T; timestamp: number } | null = null;
 
-  async function readKvFallback(env: Env): Promise<T> {
-    try {
-      const cached = await createKvCacheStore(env.SLACK_KV).get(options.kvKey, "json");
-      const value = cached === null ? null : options.deserialize(cached);
-      if (value !== null) return value;
-    } catch (e) {
-      log.warn("kv.get", {
-        key_prefix: kvLogKeyPrefix,
-        error: e instanceof Error ? e : new Error(String(e)),
-      });
-    }
-    return options.fallback;
-  }
-
-  async function get(env: Env, traceId?: string): Promise<T> {
-    if (memory && Date.now() - memory.timestamp < LOCAL_CACHE_TTL_MS) {
-      return memory.value;
-    }
-
-    const startTime = Date.now();
-    try {
-      const value = await options.load(env, traceId);
-      memory = { value, timestamp: Date.now() };
-
-      try {
-        await createKvCacheStore(env.SLACK_KV).put(options.kvKey, JSON.stringify(value), {
-          expirationTtl: KV_CACHE_TTL_SECONDS,
-        });
-      } catch (e) {
-        log.warn("kv.put", {
-          trace_id: traceId,
-          key_prefix: kvLogKeyPrefix,
-          error: e instanceof Error ? e : new Error(String(e)),
-        });
-      }
-
-      return value;
-    } catch (e) {
+  return createReadThroughCache<T, Env>({
+    cacheKey: options.kvKey,
+    cacheTtlSeconds: KV_CACHE_TTL_SECONDS,
+    localTtlMs: LOCAL_CACHE_TTL_MS,
+    load: options.load,
+    getCacheStore: (env) => createKvCacheStore(env.SLACK_KV),
+    deserialize: options.deserialize,
+    fallback: options.fallback,
+    onLoadError: (error, { traceId, durationMs }) => {
       log.warn(loadFailureEvent, {
         trace_id: traceId,
         outcome: "error",
-        http_status: e instanceof ControlPlaneRequestError ? e.status : undefined,
-        error: e instanceof Error ? e : new Error(String(e)),
-        duration_ms: Date.now() - startTime,
+        http_status: error instanceof ControlPlaneRequestError ? error.status : undefined,
+        error: error instanceof Error ? error : new Error(String(error)),
+        duration_ms: durationMs,
       });
-      return readKvFallback(env);
-    }
-  }
-
-  return {
-    get,
-    invalidate() {
-      memory = null;
     },
-  };
+    onCacheError: (operation, error, traceId) => {
+      log.warn(`kv.${operation}`, {
+        trace_id: traceId,
+        key_prefix: kvLogKeyPrefix,
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
+    },
+  });
 }


### PR DESCRIPTION
## Summary
- add a dependency-injected read-through cache engine to `@open-inspect/shared`
- keep Slack and Linear KV bindings, fallback values, and structured diagnostics in package-local adapters
- cover memory TTL, persistent fallback, KV failures, writes, diagnostics, and invalidation with focused tests

## Testing
- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/shared`
- `npm run lint -w @open-inspect/shared`
- `npm test -w @open-inspect/slack-bot`
- `npm run typecheck -w @open-inspect/slack-bot`
- `npm run lint -w @open-inspect/slack-bot`
- `npm run build -w @open-inspect/slack-bot`
- `npm test -w @open-inspect/linear-bot`
- `npm run typecheck -w @open-inspect/linear-bot`
- `npm run lint -w @open-inspect/linear-bot`
- `npm run build -w @open-inspect/linear-bot`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/9343ce5713d53e0eb384a5955e39dd6c)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared read-through caching with in-memory caching, persistent last-known-good values, configurable expiration, and fallback support.
  * Added cache invalidation to force fresh data retrieval.
  * Added diagnostic reporting for load and cache operation failures.

* **Bug Fixes**
  * Improved resilience when data loading or cache operations fail, preserving available values where possible.

* **Tests**
  * Added coverage for cache reuse, expiration, fallback behavior, error handling, persistence, and invalidation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->