### PR TITLE
fix: update Slack launcher tests for options API

### DIFF
--- a/packages/slack-bot/src/sessions/session-launcher.test.ts
+++ b/packages/slack-bot/src/sessions/session-launcher.test.ts
@@ -120,18 +120,17 @@ describe("startSessionAndSendPrompt", () => {
     const env = makeEnv();
 
     await expect(
-      startSessionAndSendPrompt(
-        env,
-        repositoryTarget,
-        "C123",
-        "111.222",
-        "Fix the failing deploy",
-        "U123",
-        ["[Alice]: Earlier request", "[Bot]: Earlier response"],
-        "engineering",
-        "Build and deploy discussion",
-        "trace-1"
-      )
+      startSessionAndSendPrompt(env, {
+        target: repositoryTarget,
+        channel: "C123",
+        threadTs: "111.222",
+        messageText: "Fix the failing deploy",
+        userId: "U123",
+        previousMessages: ["[Alice]: Earlier request", "[Bot]: Earlier response"],
+        channelName: "engineering",
+        channelDescription: "Build and deploy discussion",
+        traceId: "trace-1",
+      })
     ).resolves.toEqual({ sessionId: "session-1" });
 
     expect(getResolvedUserPreferences).toHaveBeenCalledWith(env, "U123", {
@@ -170,7 +169,8 @@ describe("startSessionAndSendPrompt", () => {
       "session-1",
       repositoryTarget,
       "openai/gpt-5.4",
-      "high"
+      "high",
+      undefined
     );
     expect(storeThreadSession).toHaveBeenCalledWith(env, "C123", "111.222", {
       sessionId: "session-1",
@@ -185,14 +185,13 @@ describe("startSessionAndSendPrompt", () => {
   it("does not apply repository branch overrides to environment sessions", async () => {
     const env = makeEnv();
 
-    await startSessionAndSendPrompt(
-      env,
-      environmentTarget,
-      "C123",
-      "111.222",
-      "Inspect production",
-      "U123"
-    );
+    await startSessionAndSendPrompt(env, {
+      target: environmentTarget,
+      channel: "C123",
+      threadTs: "111.222",
+      messageText: "Inspect production",
+      userId: "U123",
+    });
 
     expect(getUserRepoBranchPreference).not.toHaveBeenCalled();
     expect(createSession).toHaveBeenCalledWith(
@@ -214,7 +213,13 @@ describe("startSessionAndSendPrompt", () => {
     const env = makeEnv();
 
     await expect(
-      startSessionAndSendPrompt(env, repositoryTarget, "C123", "111.222", "Fix it", "U123")
+      startSessionAndSendPrompt(env, {
+        target: repositoryTarget,
+        channel: "C123",
+        threadTs: "111.222",
+        messageText: "Fix it",
+        userId: "U123",
+      })
     ).resolves.toBeNull();
 
     expect(postMessage).toHaveBeenCalledWith(
@@ -232,7 +237,13 @@ describe("startSessionAndSendPrompt", () => {
     const env = makeEnv();
 
     await expect(
-      startSessionAndSendPrompt(env, repositoryTarget, "C123", "111.222", "Fix it", "U123")
+      startSessionAndSendPrompt(env, {
+        target: repositoryTarget,
+        channel: "C123",
+        threadTs: "111.222",
+        messageText: "Fix it",
+        userId: "U123",
+      })
     ).resolves.toBeNull();
 
     expect(postMessage).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- update `startSessionAndSendPrompt` tests to use the current `StartSessionOptions` object API
- align the thread-session builder assertion with the optional `messageTs` argument
- resolve the TypeScript errors reported by CI job 87016478505

## Verification
- `npm run typecheck`
- `npm test -w @open-inspect/slack-bot`
- `npm run lint -w @open-inspect/slack-bot`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/bb5911f71794e76e0065eca6f63b64f0)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated session-launching test coverage to use the latest options-based interface.
  * Adjusted thread session test setup to match the current parameter requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->