### PR TITLE
fix(web): remove redundant header participant avatar

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -144,7 +144,6 @@ function SessionPageContent() {
         fallbackSessionInfo={fallbackSessionInfo}
         connected={connected}
         connecting={connecting}
-        participants={participants}
         isDetailsOpen={isDetailsOpen}
         detailsButtonRef={detailsButtonRef}
         onToggleDetails={toggleDetails}

--- a/packages/web/src/components/session-header.test.tsx
+++ b/packages/web/src/components/session-header.test.tsx
@@ -24,7 +24,6 @@ describe("SessionHeader", () => {
         fallbackSessionInfo={{ repoOwner: null, repoName: null, title: "Incident sweep" }}
         connected={false}
         connecting={true}
-        participants={[]}
         isDetailsOpen={false}
         detailsButtonRef={createRef<HTMLButtonElement>()}
         onToggleDetails={vi.fn()}

--- a/packages/web/src/components/session-header.tsx
+++ b/packages/web/src/components/session-header.tsx
@@ -16,7 +16,6 @@ export type SessionHeaderProps = {
   };
   connected: boolean;
   connecting: boolean;
-  participants: SessionSocketState["participants"];
   isDetailsOpen: boolean;
   detailsButtonRef: RefObject<HTMLButtonElement | null>;
   onToggleDetails: () => void;
@@ -28,7 +27,6 @@ export function SessionHeader({
   fallbackSessionInfo,
   connected,
   connecting,
-  participants,
   isDetailsOpen,
   detailsButtonRef,
   onToggleDetails,
@@ -163,7 +161,6 @@ export function SessionHeader({
               status={sessionState?.sandboxStatus}
               dashboardUrl={sessionState?.sandboxDashboardUrl}
             />
-            <ParticipantsList participants={participants} />
           </div>
         </div>
       </div>
@@ -283,34 +280,5 @@ export function CombinedStatusDot({
     <span title={label} className="flex items-center">
       <span className={`w-2.5 h-2.5 rounded-full ${color}${pulse ? " animate-pulse" : ""}`} />
     </span>
-  );
-}
-
-export function ParticipantsList({
-  participants,
-}: {
-  participants: SessionSocketState["participants"];
-}) {
-  if (participants.length === 0) return null;
-
-  const uniqueParticipants = Array.from(new Map(participants.map((p) => [p.userId, p])).values());
-
-  return (
-    <div className="flex -space-x-2">
-      {uniqueParticipants.slice(0, 3).map((p) => (
-        <div
-          key={p.userId}
-          className="w-8 h-8 rounded-full bg-card flex items-center justify-center text-xs font-medium text-foreground border-2 border-white"
-          title={p.name}
-        >
-          {p.name.charAt(0).toUpperCase()}
-        </div>
-      ))}
-      {uniqueParticipants.length > 3 && (
-        <div className="w-8 h-8 rounded-full bg-muted flex items-center justify-center text-xs font-medium text-foreground border-2 border-white">
-          +{uniqueParticipants.length - 3}
-        </div>
-      )}
-    </div>
   );
 }


### PR DESCRIPTION
## Summary
- remove the initial-based participant avatar displayed beside the connection and sandbox statuses
- remove the now-unused `participants` prop from `SessionHeader`
- preserve participant presence in the session details/sidebar

## Verification
- `npm test -w @open-inspect/web` (778 tests passed)
- `npm run typecheck -w @open-inspect/web`
- ESLint on changed files
- Prettier check on changed files
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/800f651cc6e485263cfa0082073a8711)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Removed participant avatars from the session header.
  * Simplified the session header display while preserving session status, connection controls, and session actions.
* **Bug Fixes**
  * Updated the no-repository session view to continue displaying its existing status and action controls correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->