### PR TITLE
fix: await session index status sync

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1528,13 +1528,20 @@ export class SessionDO extends DurableObject<Env> {
   ): Promise<void> {
     if (!this.env.DB) return;
     const sessionStore = new SessionIndexStore(this.env.DB);
-    await sessionStore.updateStatus(sessionId, status, updatedAt).catch((error) => {
-      this.log.error("session_index.update_status.background_error", {
-        session_id: sessionId,
-        status,
-        updated_at: updatedAt,
-        error,
-      });
+    await sessionStore.updateStatus(sessionId, status, updatedAt);
+  }
+
+  private logSessionIndexStatusSyncError(
+    sessionId: string,
+    status: SessionStatus,
+    updatedAt: number,
+    error: unknown
+  ): void {
+    this.log.error("session_index.update_status.background_error", {
+      session_id: sessionId,
+      status,
+      updated_at: updatedAt,
+      error,
     });
   }
 
@@ -1588,7 +1595,10 @@ export class SessionDO extends DurableObject<Env> {
 
     const publicSessionId = this.getPublicSessionId(session);
     if (session.status === status) {
-      await this.syncSessionIndexStatus(publicSessionId, status, session.updated_at);
+      await this.syncSessionIndexStatus(publicSessionId, status, session.updated_at).catch(
+        (error) =>
+          this.logSessionIndexStatusSyncError(publicSessionId, status, session.updated_at, error)
+      );
       if (TERMINAL_STATUSES.includes(status)) {
         this.syncSessionMetrics(publicSessionId);
       }
@@ -1597,7 +1607,9 @@ export class SessionDO extends DurableObject<Env> {
 
     const updatedAt = Math.max(Date.now(), session.updated_at + 1);
     this.repository.updateSessionStatus(session.id, status, updatedAt);
-    await this.syncSessionIndexStatus(publicSessionId, status, updatedAt);
+    await this.syncSessionIndexStatus(publicSessionId, status, updatedAt).catch((error) =>
+      this.logSessionIndexStatusSyncError(publicSessionId, status, updatedAt, error)
+    );
 
     this.broadcast({ type: "session_status", status });
 

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1521,23 +1521,21 @@ export class SessionDO extends DurableObject<Env> {
     return resolved?.session_name || resolved?.id || this.ctx.id.toString();
   }
 
-  private syncSessionIndexStatus(
+  private async syncSessionIndexStatus(
     sessionId: string,
     status: SessionStatus,
     updatedAt: number
-  ): void {
+  ): Promise<void> {
     if (!this.env.DB) return;
     const sessionStore = new SessionIndexStore(this.env.DB);
-    this.ctx.waitUntil(
-      sessionStore.updateStatus(sessionId, status, updatedAt).catch((error) => {
-        this.log.error("session_index.update_status.background_error", {
-          session_id: sessionId,
-          status,
-          updated_at: updatedAt,
-          error,
-        });
-      })
-    );
+    await sessionStore.updateStatus(sessionId, status, updatedAt).catch((error) => {
+      this.log.error("session_index.update_status.background_error", {
+        session_id: sessionId,
+        status,
+        updated_at: updatedAt,
+        error,
+      });
+    });
   }
 
   private syncSessionMetrics(sessionId: string): void {
@@ -1590,7 +1588,7 @@ export class SessionDO extends DurableObject<Env> {
 
     const publicSessionId = this.getPublicSessionId(session);
     if (session.status === status) {
-      this.syncSessionIndexStatus(publicSessionId, status, session.updated_at);
+      await this.syncSessionIndexStatus(publicSessionId, status, session.updated_at);
       if (TERMINAL_STATUSES.includes(status)) {
         this.syncSessionMetrics(publicSessionId);
       }
@@ -1599,7 +1597,7 @@ export class SessionDO extends DurableObject<Env> {
 
     const updatedAt = Math.max(Date.now(), session.updated_at + 1);
     this.repository.updateSessionStatus(session.id, status, updatedAt);
-    this.syncSessionIndexStatus(publicSessionId, status, updatedAt);
+    await this.syncSessionIndexStatus(publicSessionId, status, updatedAt);
 
     this.broadcast({ type: "session_status", status });
 


### PR DESCRIPTION
## Summary

- await session status writes to the D1 session index instead of deferring them with `ctx.waitUntil`
- ensure `session_status` websocket broadcasts happen only after the index reflects the new status
- preserve the existing behavior of logging and swallowing D1 update failures

## Why

Clients refetch the session list when they receive a `session_status` event. Broadcasting before the D1 index write completed created a read-after-write race where the refetch could return stale status and `updated_at` values, causing recently stopped parent sessions to fall out of the first page while their children remained visible.

## Verification

- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`
- `npm test -w @open-inspect/control-plane -- --run src/session/stop-execution.test.ts src/session/http/routes.test.ts`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/eacc73842a25680de6878f92e6b1b3e0)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization of session status updates to ensure changes are completed reliably.
  * Standardized error handling and logging when session status synchronization fails.
  * Improved consistency when updating sessions whose requested status matches their current status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->