### PR TITLE
fix(github-bot): preserve PR lifecycle webhook fields

### DIFF
--- a/packages/github-bot/src/index.ts
+++ b/packages/github-bot/src/index.ts
@@ -253,12 +253,6 @@ function dispatchHandler(
         if (!parsed.success) throw new Error("Malformed pull_request review_requested payload");
         return handleReviewRequested(env, log, parsed.data, traceId);
       }
-      if (p.action === "closed" || p.action === "synchronize") {
-        return Promise.resolve({
-          outcome: "skipped",
-          skip_reason: "automation_event_only",
-        });
-      }
       return Promise.resolve({
         outcome: "skipped",
         skip_reason: "unsupported_action",

--- a/packages/github-bot/src/index.ts
+++ b/packages/github-bot/src/index.ts
@@ -196,9 +196,11 @@ async function handleWebhook(
   log.info("webhook.handled", wideEvent);
 
   // Forward normalized event to control-plane for automation triggering.
-  // This is additive — failures here must not affect existing bot behavior.
+  // Use the passthrough parse so nested lifecycle fields are not stripped by
+  // the summary schema used for logging and bot dispatch.
   if (event) {
-    const normalizedEvent = normalizeGitHubEvent(event, p);
+    const normalizationPayload = actionResult.success ? actionResult.data : {};
+    const normalizedEvent = normalizeGitHubEvent(event, normalizationPayload);
     if (normalizedEvent !== null) {
       try {
         const body = JSON.stringify(normalizedEvent);
@@ -250,6 +252,12 @@ function dispatchHandler(
         const parsed = reviewRequestedPayloadSchema.safeParse(payload);
         if (!parsed.success) throw new Error("Malformed pull_request review_requested payload");
         return handleReviewRequested(env, log, parsed.data, traceId);
+      }
+      if (p.action === "closed" || p.action === "synchronize") {
+        return Promise.resolve({
+          outcome: "skipped",
+          skip_reason: "automation_event_only",
+        });
       }
       return Promise.resolve({
         outcome: "skipped",

--- a/packages/github-bot/test/webhook.test.ts
+++ b/packages/github-bot/test/webhook.test.ts
@@ -38,7 +38,11 @@ function makeEnv() {
   const githubKv = createMockKV();
   return {
     GITHUB_KV: githubKv,
+    CONTROL_PLANE: {
+      fetch: vi.fn(async () => new Response(null, { status: 204 })),
+    },
     GITHUB_WEBHOOK_SECRET: SECRET,
+    INTERNAL_CALLBACK_SECRET: "test-internal-secret",
     GITHUB_BOT_USERNAME: "test-bot[bot]",
     DEPLOYMENT_NAME: "test",
     DEFAULT_MODEL: "anthropic/claude-haiku-4-5",
@@ -229,13 +233,32 @@ describe("POST /webhooks/github", () => {
     await flushWaitUntil(ctx);
   });
 
-  it("returns 200 for handled event with non-matching action", async () => {
+  it("forwards closed pull request lifecycle fields to the control plane", async () => {
     const body = JSON.stringify({
       action: "closed",
       repository: { owner: { login: "test" }, name: "repo" },
+      sender: { login: "alice" },
+      pull_request: {
+        number: 42,
+        title: "Ship lifecycle updates",
+        body: null,
+        state: "closed",
+        draft: false,
+        merged: true,
+        html_url: "https://github.com/test/repo/pull/42",
+        created_at: "2026-07-10T10:00:00Z",
+        updated_at: "2026-07-14T11:00:00Z",
+        merged_at: "2026-07-14T10:59:00Z",
+        closed_at: "2026-07-14T11:00:00Z",
+        user: { login: "alice" },
+        labels: [{ name: "ready" }],
+        head: { ref: "feature/lifecycle", sha: "abc123", repo: { id: 99 } },
+        base: { ref: "main", repo: { id: 99 } },
+      },
     });
     const signature = await sign(SECRET, body);
     const ctx = makeCtx();
+    const env = makeEnv();
 
     const res = await app.fetch(
       new Request("http://localhost/webhooks/github", {
@@ -246,13 +269,42 @@ describe("POST /webhooks/github", () => {
           "X-GitHub-Event": "pull_request",
         },
       }),
-      makeEnv(),
+      env,
       ctx
     );
 
     expect(res.status).toBe(200);
     expect(ctx.waitUntil).toHaveBeenCalledOnce();
     await flushWaitUntil(ctx);
+
+    const controlPlaneFetch = (env.CONTROL_PLANE as unknown as { fetch: ReturnType<typeof vi.fn> })
+      .fetch;
+    expect(controlPlaneFetch).toHaveBeenCalledOnce();
+    const [url, init] = controlPlaneFetch.mock.calls[0];
+    expect(url).toBe("https://internal/internal/github-event");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      eventType: "pull_request.closed",
+      repoOwner: "test",
+      repoName: "repo",
+      branch: "feature/lifecycle",
+      targetBranch: "main",
+      labels: ["ready"],
+      pullRequest: {
+        number: 42,
+        state: "closed",
+        draft: false,
+        merged: true,
+        headSha: "abc123",
+        isCrossRepository: false,
+        url: "https://github.com/test/repo/pull/42",
+        repositoryExternalId: "99",
+        providerCreatedAt: Date.parse("2026-07-10T10:00:00Z"),
+        providerUpdatedAt: Date.parse("2026-07-14T11:00:00Z"),
+        mergedAt: Date.parse("2026-07-14T10:59:00Z"),
+        closedAt: Date.parse("2026-07-14T11:00:00Z"),
+      },
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- normalize GitHub automation events from the preserved webhook payload instead of the stripped logging summary
- keep bot dispatch behavior separate from lifecycle automation policy in the shared normalizer/catalog
- add regression coverage proving closed/merged PR state, repository identity, branches, SHA, URL, and timestamps reach the control plane

## Root cause
The webhook Worker received `pull_request.closed`, but the summary schema removed nested lifecycle fields before normalization. The resulting control-plane event lacked `pullRequest.state`, so lifecycle processing skipped the update.

## Verification
- `npm test -w @open-inspect/github-bot`
- `npm run typecheck -w @open-inspect/github-bot`
- Prettier and `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved control-plane forwarding for pull request webhook events by normalizing the forwarded payload using the parsed action data when available (falling back safely when not).
* **Tests**
  * Updated the webhook test suite to mock control-plane calls and added coverage to verify the forwarded lifecycle fields (event type, repository/branch/label, and pull request metadata with timestamp parsing).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->