### PR TITLE
fix: preserve output when SSE stream drops

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -1456,9 +1456,21 @@ class AgentBridge:
                 f"(no data received). Total elapsed: {elapsed:.0f}s"
             )
 
-        except httpx.ReadError as e:
-            self.log.error("bridge.sse_read_error", exc=e)
-            raise SSEConnectionError(f"SSE read error: {e}")
+        except httpx.TransportError as e:
+            self.log.error("bridge.sse_transport_error", exc=e)
+            async for final_event in self._fetch_final_message_state(
+                message_id,
+                opencode_message_id,
+                cumulative_text,
+                allowed_assistant_msg_ids,
+                user_message_ids=user_message_ids,
+                compaction_occurred=compaction_occurred,
+            ):
+                yield final_event
+            raise SSEConnectionError(
+                "OpenCode event stream disconnected before completion; "
+                "partial output was preserved when available."
+            ) from e
 
     async def _fetch_final_message_state(
         self,

--- a/packages/sandbox-runtime/tests/test_bridge_sse.py
+++ b/packages/sandbox-runtime/tests/test_bridge_sse.py
@@ -15,9 +15,10 @@ from collections.abc import AsyncIterator
 from typing import Any
 from unittest.mock import AsyncMock
 
+import httpx
 import pytest
 
-from sandbox_runtime.bridge import AgentBridge, OpenCodeIdentifier
+from sandbox_runtime.bridge import AgentBridge, OpenCodeIdentifier, SSEConnectionError
 from tests.conftest import MockResponse
 
 
@@ -39,6 +40,15 @@ class MockSSEResponse:
 
     async def __aexit__(self, *args):
         pass
+
+
+class DroppingMockSSEResponse(MockSSEResponse):
+    """SSE response that drops after yielding the configured events."""
+
+    async def aiter_text(self) -> AsyncIterator[str]:
+        async for event in super().aiter_text():
+            yield event
+        raise httpx.RemoteProtocolError("peer closed connection without complete body")
 
 
 class MockHttpClient:
@@ -165,6 +175,63 @@ class TestSSEParser:
 
 class TestSSEStreaming:
     """Tests for _stream_opencode_response_sse method."""
+
+    @pytest.mark.asyncio
+    async def test_transport_drop_preserves_final_output(
+        self, bridge: AgentBridge, opencode_message_id: str
+    ):
+        """A mid-stream transport drop should fetch final text before failing cleanly."""
+        http_client = bridge.http_client
+        http_client.sse_events = [
+            create_sse_event("server.connected", {}),
+            create_sse_event(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "oc-msg-1",
+                        "role": "assistant",
+                        "sessionID": "oc-session-123",
+                        "parentID": opencode_message_id,
+                    }
+                },
+            ),
+            create_sse_event(
+                "message.part.updated",
+                {
+                    "part": {
+                        "type": "text",
+                        "id": "part-1",
+                        "sessionID": "oc-session-123",
+                        "messageID": "oc-msg-1",
+                        "text": "Partial",
+                    }
+                },
+            ),
+        ]
+        http_client.stream = lambda *args, **kwargs: DroppingMockSSEResponse(http_client.sse_events)
+        http_client.get_responses = [
+            MockResponse(
+                200,
+                [
+                    {
+                        "info": {
+                            "id": "oc-msg-1",
+                            "role": "assistant",
+                            "parentID": opencode_message_id,
+                        },
+                        "parts": [{"id": "part-1", "type": "text", "text": "Partial response"}],
+                    }
+                ],
+            )
+        ]
+
+        events = []
+        with pytest.raises(SSEConnectionError, match="OpenCode event stream disconnected"):
+            async for event in bridge._stream_opencode_response_sse("cp-msg-1", "Test prompt"):
+                events.append(event)
+
+        token_events = [event for event in events if event["type"] == "token"]
+        assert token_events[-1]["content"] == "Partial response"
 
     @pytest.mark.asyncio
     async def test_text_streaming_with_delta(self, bridge: AgentBridge, opencode_message_id: str):


### PR DESCRIPTION
## Summary
- handle all `httpx` transport failures from the OpenCode event stream
- fetch the final message state before failing so available assistant output is preserved
- replace raw transport details with a stable, user-facing disconnect error

## Problem
A mid-response SSE disconnect can raise `RemoteProtocolError`, which bypasses the existing `ReadError` handler. The run then exposes a raw transport error and skips the final-state recovery path, potentially losing assistant output that OpenCode had already persisted.

## Testing
- `uv run --project packages/sandbox-runtime --extra dev pytest packages/sandbox-runtime/tests -q` — 456 passed
- `uv run --project packages/sandbox-runtime --extra dev ruff check packages/sandbox-runtime/src packages/sandbox-runtime/tests` — passed
- `uv run --project packages/sandbox-runtime --extra dev ruff format --check packages/sandbox-runtime/src packages/sandbox-runtime/tests` — passed
- `git diff --check` — passed

Fixes #998


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unexpected streaming disconnections.
  * Preserves and retrieves any partial response available when a connection drops.
  * Reports a clear stream-disconnected error after attempting to recover the final output.

* **Tests**
  * Added coverage for interrupted streams and preservation of partial responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->