### PR TITLE
fix(linear): handle null automation actor IDs

### DIFF
--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -206,7 +206,7 @@ export interface AgentSessionWebhook {
   appUserId: string;
   agentSession: {
     id: string;
-    creatorId?: string;
+    creatorId?: string | null;
     issue?: AgentSessionWebhookIssue;
     comment?: { body: string; userId?: string };
     promptContext?: string;

--- a/packages/linear-bot/src/webhook-handler.test.ts
+++ b/packages/linear-bot/src/webhook-handler.test.ts
@@ -411,7 +411,7 @@ describe("handleAgentSessionEvent environment targets", () => {
     expect(issueSession).not.toHaveProperty("environmentId");
   });
 
-  it("does not opt an automation-created session into the issue transition", async () => {
+  it("omits actor identity and issue transition for an automation-created session", async () => {
     const { kv } = createFakeKV({
       "oauth:client-credentials:org-1": validToken(),
       "config:project-repos": JSON.stringify({
@@ -421,10 +421,11 @@ describe("handleAgentSessionEvent environment targets", () => {
     const env = makeLinearBotEnv(kv);
     const fetchMock = stubControlPlane(env);
     const webhook = makeWebhook();
-    delete webhook.agentSession.creatorId;
+    webhook.agentSession.creatorId = null;
 
     await handleAgentSessionEvent(webhook, env, "trace-automation");
 
+    expect(createSessionBody(fetchMock)).not.toHaveProperty("actorUserId");
     expect(promptBody(fetchMock)).toMatchObject({
       callbackContext: { transitionIssueOnStart: false },
     });

--- a/packages/linear-bot/src/webhook-handler.ts
+++ b/packages/linear-bot/src/webhook-handler.ts
@@ -239,7 +239,7 @@ async function handleStop(webhook: AgentSessionWebhook, env: Env, traceId: strin
 }
 
 function getNewSessionActorUserId(webhook: AgentSessionWebhook): string | undefined {
-  return webhook.agentSession.comment?.userId ?? webhook.agentSession.creatorId;
+  return webhook.agentSession.comment?.userId ?? webhook.agentSession.creatorId ?? undefined;
 }
 
 function shouldTransitionIssueOnStart(webhook: AgentSessionWebhook): boolean {


### PR DESCRIPTION
## Summary
- normalize Linear automation webhooks with `creatorId: null` to an omitted session actor ID
- update the webhook type to match Linear's nullable payload
- add regression coverage asserting automation-created sessions omit `actorUserId`

## Verification
- `npm test -w @open-inspect/linear-bot -- src/webhook-handler.test.ts`
- `npm run typecheck -w @open-inspect/linear-bot`
- `npm run lint -w @open-inspect/linear-bot`

Fixes #1010

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/a1d2d650a8e2fcf86be357fd599882da)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of sessions created without an identified creator.
  * Prevented empty creator identifiers from being included when creating sessions.
  * Preserved existing automation behavior, including disabled initial issue transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->