### PR TITLE
feat: add callback delivery completion event

### DIFF
--- a/docs/DEBUGGING_PLAYBOOK.md
+++ b/docs/DEBUGGING_PLAYBOOK.md
@@ -116,13 +116,14 @@ One `image_build.*` vocabulary covers both scope kinds; events carry `scope_kind
 
 #### Session Durable Object (`component: "session-do"`)
 
-| Event             | Level      | Key Fields                                                                                                     | Description                    |
-| ----------------- | ---------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------ |
-| `do.request`      | info       | `http_method`, `http_path`, `http_status`, `duration_ms`, `outcome`                                            | One per DO internal route call |
-| `ws.connect`      | info, warn | `ws_type` (sandbox\|client), `outcome`, `reject_reason`, `sandbox_id`, `participant_id`, `duration_ms`         | WebSocket lifecycle            |
-| `prompt.enqueue`  | info       | `message_id`, `source`, `author_id`, `user_id`, `model`, `content_length`, `has_attachments`, `queue_position` | Message queued                 |
-| `prompt.dispatch` | info       | `message_id`, `outcome`, `reason`, `model`, `has_sandbox_ws`, `queue_wait_ms`                                  | Message sent to sandbox        |
-| `prompt.complete` | info, warn | `message_id`, `outcome`, `total_duration_ms`, `processing_duration_ms`, `queue_duration_ms`                    | Prompt run finished            |
+| Event                        | Level       | Key Fields                                                                                                            | Description                         |
+| ---------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| `do.request`                 | info        | `http_method`, `http_path`, `http_status`, `duration_ms`, `outcome`                                                   | One per DO internal route call      |
+| `ws.connect`                 | info, warn  | `ws_type` (sandbox\|client), `outcome`, `reject_reason`, `sandbox_id`, `participant_id`, `duration_ms`                | WebSocket lifecycle                 |
+| `prompt.enqueue`             | info        | `message_id`, `source`, `author_id`, `user_id`, `model`, `content_length`, `has_attachments`, `queue_position`        | Message queued                      |
+| `prompt.dispatch`            | info        | `message_id`, `outcome`, `reason`, `model`, `has_sandbox_ws`, `queue_wait_ms`                                         | Message sent to sandbox             |
+| `prompt.complete`            | info, warn  | `message_id`, `outcome`, `total_duration_ms`, `processing_duration_ms`, `queue_duration_ms`                           | Prompt run finished                 |
+| `callback.complete_delivery` | info, error | `session_id`, `message_id`, `source`, `outcome`, `duration_ms`, `attempts`, `retries`, `http_status`, `reject_reason` | Completion callback delivery result |
 
 #### Lifecycle Manager (`component: "lifecycle-manager"`)
 

--- a/packages/control-plane/src/session/callback-delivery.test.ts
+++ b/packages/control-plane/src/session/callback-delivery.test.ts
@@ -6,21 +6,29 @@ describe("deliverWithRetry", () => {
     vi.useRealTimers();
   });
 
-  it("returns true without retrying after a successful response", async () => {
+  it("returns delivery aggregates without retrying after a successful response", async () => {
     const send = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     const onFailure = vi.fn();
 
-    await expect(deliverWithRetry(send, vi.fn(), onFailure)).resolves.toBe(true);
+    await expect(deliverWithRetry(send, vi.fn(), onFailure)).resolves.toEqual({
+      delivered: true,
+      attempts: 1,
+      httpStatus: 204,
+    });
     expect(send).toHaveBeenCalledOnce();
     expect(onFailure).not.toHaveBeenCalled();
   });
 
-  it("retries non-OK responses before returning false", async () => {
+  it("retries non-OK responses before returning failure aggregates", async () => {
     const send = vi.fn().mockResolvedValue(new Response(null, { status: 503 }));
     const sleep = vi.fn();
     const onFailure = vi.fn();
 
-    await expect(deliverWithRetry(send, sleep, onFailure)).resolves.toBe(false);
+    await expect(deliverWithRetry(send, sleep, onFailure)).resolves.toEqual({
+      delivered: false,
+      attempts: 2,
+      httpStatus: 503,
+    });
     expect(send).toHaveBeenCalledTimes(2);
     expect(sleep).toHaveBeenCalledWith(1000);
     expect(onFailure).toHaveBeenCalledTimes(2);
@@ -32,7 +40,11 @@ describe("deliverWithRetry", () => {
       throw new Error("observer unavailable");
     });
 
-    await expect(deliverWithRetry(send, vi.fn(), onFailure)).resolves.toBe(false);
+    await expect(deliverWithRetry(send, vi.fn(), onFailure)).resolves.toEqual({
+      delivered: false,
+      attempts: 2,
+      httpStatus: 503,
+    });
     expect(send).toHaveBeenCalledTimes(2);
     expect(onFailure).toHaveBeenCalledTimes(2);
   });
@@ -50,8 +62,20 @@ describe("deliverWithRetry", () => {
     await vi.advanceTimersByTimeAsync(10_000);
     await vi.advanceTimersByTimeAsync(10_000);
 
-    await expect(delivery).resolves.toBe(false);
+    await expect(delivery).resolves.toEqual({ delivered: false, attempts: 2 });
     expect(send).toHaveBeenCalledTimes(2);
     expect(send.mock.calls.every(([signal]) => signal instanceof AbortSignal)).toBe(true);
+  });
+
+  it("does not retain an HTTP status when the final attempt throws", async () => {
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 503 }))
+      .mockRejectedValueOnce(new Error("network error"));
+
+    await expect(deliverWithRetry(send, vi.fn(), vi.fn())).resolves.toEqual({
+      delivered: false,
+      attempts: 2,
+    });
   });
 });

--- a/packages/control-plane/src/session/callback-delivery.ts
+++ b/packages/control-plane/src/session/callback-delivery.ts
@@ -6,18 +6,27 @@ type DeliveryFailure =
   | { attempt: number; response: Response; error?: never }
   | { attempt: number; response?: never; error: unknown };
 
+interface DeliveryResult {
+  delivered: boolean;
+  attempts: number;
+  httpStatus?: number;
+}
+
 export async function deliverWithRetry(
   send: (signal: AbortSignal) => Promise<Response>,
   sleep: (ms: number) => Promise<void>,
   onFailure: (failure: DeliveryFailure) => void | Promise<void>
-): Promise<boolean> {
+): Promise<DeliveryResult> {
+  let httpStatus: number | undefined;
   for (let attempt = 1; attempt <= CALLBACK_ATTEMPTS; attempt++) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), CALLBACK_ATTEMPT_TIMEOUT_MS);
     let failure: DeliveryFailure;
+    httpStatus = undefined;
     try {
       const response = await send(controller.signal);
-      if (response.ok) return true;
+      httpStatus = response.status;
+      if (response.ok) return { delivered: true, attempts: attempt, httpStatus };
       failure = { attempt, response };
     } catch (error) {
       failure = { attempt, error };
@@ -32,5 +41,9 @@ export async function deliverWithRetry(
 
     if (attempt < CALLBACK_ATTEMPTS) await sleep(CALLBACK_RETRY_DELAY_MS);
   }
-  return false;
+  return {
+    delivered: false,
+    attempts: CALLBACK_ATTEMPTS,
+    ...(httpStatus !== undefined ? { httpStatus } : {}),
+  };
 }

--- a/packages/control-plane/src/session/callback-notification-service.test.ts
+++ b/packages/control-plane/src/session/callback-notification-service.test.ts
@@ -81,9 +81,15 @@ describe("CallbackNotificationService", () => {
 
       await harness.service.notifyComplete("msg-1", true);
 
-      expect(harness.log.debug).toHaveBeenCalledWith(
-        "No callback context for message, skipping notification",
-        expect.objectContaining({ message_id: "msg-1" })
+      expect(harness.log.info).toHaveBeenCalledWith(
+        "callback.complete_delivery",
+        expect.objectContaining({
+          session_id: "session-123",
+          message_id: "msg-1",
+          outcome: "rejected",
+          reject_reason: "no_callback_context",
+          duration_ms: expect.any(Number),
+        })
       );
       expect(
         (harness.slackBot as unknown as { fetch: ReturnType<typeof vi.fn> }).fetch
@@ -128,9 +134,16 @@ describe("CallbackNotificationService", () => {
 
       await h.service.notifyComplete("msg-1", true);
 
-      expect(h.log.debug).toHaveBeenCalledWith(
-        "No callback binding for source, skipping notification",
-        expect.objectContaining({ message_id: "msg-1", source: "slack" })
+      expect(h.log.info).toHaveBeenCalledWith(
+        "callback.complete_delivery",
+        expect.objectContaining({
+          session_id: "session-123",
+          message_id: "msg-1",
+          source: "slack",
+          outcome: "rejected",
+          reject_reason: "no_binding",
+          duration_ms: expect.any(Number),
+        })
       );
     });
 
@@ -168,9 +181,21 @@ describe("CallbackNotificationService", () => {
       expect(body.signature).toEqual(expect.any(String));
       expect(body.timestamp).toEqual(expect.any(Number));
 
-      expect(harness.log.info).toHaveBeenCalledWith(
-        "Callback succeeded",
-        expect.objectContaining({ message_id: "msg-1", source: "slack" })
+      const terminalEvents = vi
+        .mocked(harness.log.info)
+        .mock.calls.filter(([event]) => event === "callback.complete_delivery");
+      expect(terminalEvents).toHaveLength(1);
+      expect(terminalEvents[0][1]).toEqual(
+        expect.objectContaining({
+          session_id: "session-123",
+          message_id: "msg-1",
+          source: "slack",
+          outcome: "success",
+          duration_ms: expect.any(Number),
+          attempts: 1,
+          retries: 0,
+          http_status: 200,
+        })
       );
     });
 
@@ -191,31 +216,34 @@ describe("CallbackNotificationService", () => {
 
       expect(fetchMock).toHaveBeenCalledTimes(2);
       expect(harness.log.info).toHaveBeenCalledWith(
-        "Callback succeeded",
-        expect.objectContaining({ message_id: "msg-1" })
+        "callback.complete_delivery",
+        expect.objectContaining({ message_id: "msg-1", attempts: 2, retries: 1 })
       );
     });
 
-    it("safely bounds failed response bodies in logs", async () => {
+    it("emits one terminal event after retries are exhausted", async () => {
       vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
         callback_context: JSON.stringify({ channel: "C123" }),
         source: "slack",
       });
-      const unreadableResponse = new Response("unreadable", { status: 503 });
-      vi.spyOn(unreadableResponse, "text").mockRejectedValue(new Error("body unavailable"));
-      harness.slackBot.fetch
-        .mockResolvedValueOnce(unreadableResponse)
-        .mockResolvedValueOnce(new Response("x".repeat(600), { status: 503 }));
+      harness.slackBot.fetch.mockResolvedValue(new Response("unavailable", { status: 503 }));
 
       await harness.service.notifyComplete("msg-1", false);
 
-      expect(harness.log.error).toHaveBeenCalledWith(
-        "Callback failed",
-        expect.objectContaining({ response_text: "" })
-      );
-      expect(harness.log.error).toHaveBeenCalledWith(
-        "Callback failed",
-        expect.objectContaining({ response_text: "x".repeat(500) })
+      const terminalEvents = vi
+        .mocked(harness.log.error)
+        .mock.calls.filter(([event]) => event === "callback.complete_delivery");
+      expect(terminalEvents).toHaveLength(1);
+      expect(terminalEvents[0][1]).toEqual(
+        expect.objectContaining({
+          session_id: "session-123",
+          message_id: "msg-1",
+          outcome: "error",
+          duration_ms: expect.any(Number),
+          attempts: 2,
+          retries: 1,
+          http_status: 503,
+        })
       );
     });
 
@@ -765,8 +793,21 @@ describe("CallbackNotificationService", () => {
 
       await h.service.notifyComplete("msg-1", true);
 
-      expect(h.log.warn).toHaveBeenCalledWith(
-        "No SCHEDULER_CALLBACK binding, skipping automation notification"
+      const terminalEvents = vi
+        .mocked(h.log.info)
+        .mock.calls.filter(([event]) => event === "callback.complete_delivery");
+      expect(terminalEvents).toHaveLength(1);
+      expect(terminalEvents[0][1]).toEqual(
+        expect.objectContaining({
+          session_id: "session-123",
+          message_id: "msg-1",
+          source: "automation",
+          outcome: "rejected",
+          reject_reason: "no_binding",
+          duration_ms: expect.any(Number),
+          attempts: 0,
+          retries: 0,
+        })
       );
     });
 
@@ -797,8 +838,8 @@ describe("CallbackNotificationService", () => {
 
       expect(fetchMock).toHaveBeenCalledTimes(2);
       expect(h.log.info).toHaveBeenCalledWith(
-        "Automation callback succeeded",
-        expect.objectContaining({ automation_id: "auto-1" })
+        "callback.complete_delivery",
+        expect.objectContaining({ source: "automation", attempts: 2, retries: 1 })
       );
     });
 

--- a/packages/control-plane/src/session/callback-notification-service.test.ts
+++ b/packages/control-plane/src/session/callback-notification-service.test.ts
@@ -247,6 +247,26 @@ describe("CallbackNotificationService", () => {
       );
     });
 
+    it("does not report a stale HTTP status when the final attempt throws", async () => {
+      vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
+        callback_context: JSON.stringify({ channel: "C123" }),
+        source: "slack",
+      });
+      harness.slackBot.fetch
+        .mockResolvedValueOnce(new Response("unavailable", { status: 503 }))
+        .mockRejectedValueOnce(new Error("network error"));
+
+      await harness.service.notifyComplete("msg-1", false);
+
+      const terminalEvent = vi
+        .mocked(harness.log.error)
+        .mock.calls.find(([event]) => event === "callback.complete_delivery");
+      expect(terminalEvent?.[1]).toEqual(
+        expect.objectContaining({ outcome: "error", attempts: 2, retries: 1 })
+      );
+      expect(terminalEvent?.[1]).not.toHaveProperty("http_status");
+    });
+
     it("routes to LINEAR_BOT for linear source", async () => {
       vi.mocked(harness.repository.getMessageCallbackContext).mockReturnValue({
         callback_context: JSON.stringify({ issueId: "LIN-123" }),

--- a/packages/control-plane/src/session/callback-notification-service.ts
+++ b/packages/control-plane/src/session/callback-notification-service.ts
@@ -202,21 +202,14 @@ export class CallbackNotificationService {
       };
       const signature = await this.signPayload(payloadData, this.env.INTERNAL_CALLBACK_SECRET);
       const payload = { ...payloadData, signature };
-      let attempts = 0;
-      let httpStatus: number | undefined;
-
-      const delivered = await deliverWithRetry(
-        async (signal) => {
-          attempts++;
-          const response = await binding.fetch("https://internal/callbacks/complete", {
+      result = await deliverWithRetry(
+        (signal) =>
+          binding.fetch("https://internal/callbacks/complete", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(payload),
             signal,
-          });
-          httpStatus = response.status;
-          return response;
-        },
+          }),
         this.sleep,
         ({ attempt, response, error: deliveryError }) => {
           this.log.warn("callback.complete_delivery_attempt_failed", {
@@ -231,7 +224,6 @@ export class CallbackNotificationService {
           });
         }
       );
-      result = { delivered, attempts, ...(httpStatus !== undefined ? { httpStatus } : {}) };
     } catch (caught) {
       thrownError = caught;
       throw caught;
@@ -291,20 +283,14 @@ export class CallbackNotificationService {
       automationName: context.automationName,
     };
 
-    let attempts = 0;
-    let httpStatus: number | undefined;
-    const delivered = await deliverWithRetry(
-      async (signal) => {
-        attempts++;
-        const response = await binding.fetch("https://internal/internal/run-complete", {
+    return deliverWithRetry(
+      (signal) =>
+        binding.fetch("https://internal/internal/run-complete", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload),
           signal,
-        });
-        httpStatus = response.status;
-        return response;
-      },
+        }),
       this.sleep,
       ({ attempt, response, error: deliveryError }) => {
         this.log.warn("callback.complete_delivery_attempt_failed", {
@@ -321,7 +307,6 @@ export class CallbackNotificationService {
         });
       }
     );
-    return { delivered, attempts, ...(httpStatus !== undefined ? { httpStatus } : {}) };
   }
 
   /**

--- a/packages/control-plane/src/session/callback-notification-service.ts
+++ b/packages/control-plane/src/session/callback-notification-service.ts
@@ -52,6 +52,13 @@ export interface CallbackServiceDeps {
  */
 const NOTIFIED_CALL_IDS_CAP = 500;
 
+interface CallbackDeliveryResult {
+  delivered: boolean;
+  attempts: number;
+  httpStatus?: number;
+  rejectReason?: string;
+}
+
 export class CallbackNotificationService {
   private readonly repository: CallbackRepository;
   private readonly env: CallbackServiceEnv;
@@ -147,93 +154,115 @@ export class CallbackNotificationService {
    * Routes to the correct service binding based on the message source.
    */
   async notifyComplete(messageId: string, success: boolean, error?: string): Promise<void> {
-    // Safely query for callback context
-    const message = this.repository.getMessageCallbackContext(messageId);
-    if (!message?.callback_context) {
-      this.log.debug("No callback context for message, skipping notification", {
-        message_id: messageId,
-      });
-      return;
-    }
+    const sessionId = this.getSessionId();
+    const startedAt = Date.now();
+    let source: string | null = null;
+    let result: CallbackDeliveryResult = {
+      delivered: false,
+      attempts: 0,
+      rejectReason: "unexpected_error",
+    };
+    let thrownError: unknown;
 
-    const context = JSON.parse(message.callback_context);
+    try {
+      const message = this.repository.getMessageCallbackContext(messageId);
+      if (!message?.callback_context) {
+        result.rejectReason = "no_callback_context";
+        return;
+      }
 
-    // Route automation callbacks to SchedulerDO (different URL + payload)
-    if (context.source === "automation") {
-      return this.notifyAutomationComplete(context, success, error, messageId);
-    }
+      const context = JSON.parse(message.callback_context);
+      source = context.source === "automation" ? "automation" : (message.source ?? null);
 
-    if (!this.env.INTERNAL_CALLBACK_SECRET) {
-      this.log.debug("INTERNAL_CALLBACK_SECRET not configured, skipping notification");
-      return;
-    }
+      // Route automation callbacks to SchedulerDO (different URL + payload).
+      if (source === "automation") {
+        result = await this.notifyAutomationComplete(context, success, error, messageId);
+        return;
+      }
 
-    // Resolve the callback binding based on message source
-    const source = message.source ?? null;
-    const binding = this.getBinding(source);
-    if (!binding) {
-      this.log.debug("No callback binding for source, skipping notification", {
+      if (!this.env.INTERNAL_CALLBACK_SECRET) {
+        result.rejectReason = "no_secret";
+        return;
+      }
+
+      const binding = this.getBinding(source);
+      if (!binding) {
+        result.rejectReason = "no_binding";
+        return;
+      }
+
+      const timestamp = Date.now();
+      const payloadData = {
+        sessionId,
+        messageId,
+        success,
+        ...(error != null ? { error } : {}),
+        timestamp,
+        context,
+      };
+      const signature = await this.signPayload(payloadData, this.env.INTERNAL_CALLBACK_SECRET);
+      const payload = { ...payloadData, signature };
+      let attempts = 0;
+      let httpStatus: number | undefined;
+
+      const delivered = await deliverWithRetry(
+        async (signal) => {
+          attempts++;
+          const response = await binding.fetch("https://internal/callbacks/complete", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(payload),
+            signal,
+          });
+          httpStatus = response.status;
+          return response;
+        },
+        this.sleep,
+        ({ attempt, response, error: deliveryError }) => {
+          this.log.warn("callback.complete_delivery_attempt_failed", {
+            message_id: messageId,
+            session_id: sessionId,
+            source,
+            attempt,
+            ...(response ? { http_status: response.status } : {}),
+            ...(deliveryError !== undefined
+              ? { error: deliveryError instanceof Error ? deliveryError : String(deliveryError) }
+              : {}),
+          });
+        }
+      );
+      result = { delivered, attempts, ...(httpStatus !== undefined ? { httpStatus } : {}) };
+    } catch (caught) {
+      thrownError = caught;
+      throw caught;
+    } finally {
+      const outcome =
+        thrownError !== undefined
+          ? "error"
+          : result.rejectReason
+            ? "rejected"
+            : result.delivered
+              ? "success"
+              : "error";
+      const fields = {
+        session_id: sessionId,
         message_id: messageId,
         source,
-      });
-      return;
+        outcome,
+        duration_ms: Date.now() - startedAt,
+        attempts: result.attempts,
+        retries: Math.max(0, result.attempts - 1),
+        ...(result.httpStatus !== undefined ? { http_status: result.httpStatus } : {}),
+        ...(result.rejectReason && thrownError === undefined
+          ? { reject_reason: result.rejectReason }
+          : {}),
+        ...(thrownError !== undefined
+          ? { error: thrownError instanceof Error ? thrownError : new Error(String(thrownError)) }
+          : {}),
+      };
+      if (outcome === "error") this.log.error("callback.complete_delivery", fields);
+      else this.log.info("callback.complete_delivery", fields);
     }
-
-    const sessionId = this.getSessionId();
-    const timestamp = Date.now();
-
-    // Build payload without signature
-    const payloadData = {
-      sessionId,
-      messageId,
-      success,
-      ...(error != null ? { error } : {}),
-      timestamp,
-      context,
-    };
-
-    // Sign the payload
-    const signature = await this.signPayload(payloadData, this.env.INTERNAL_CALLBACK_SECRET);
-
-    const payload = { ...payloadData, signature };
-
-    const delivered = await deliverWithRetry(
-      (signal) =>
-        binding.fetch("https://internal/callbacks/complete", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(payload),
-          signal,
-        }),
-      this.sleep,
-      async ({ attempt, response, error: deliveryError }) => {
-        if (response) {
-          const responseText = await response.text().catch(() => "");
-          this.log.error("Callback failed", {
-            message_id: messageId,
-            source,
-            status: response.status,
-            response_text: responseText.slice(0, 500),
-          });
-          return;
-        }
-        this.log.error("Callback attempt failed", {
-          message_id: messageId,
-          source,
-          attempt,
-          error: deliveryError instanceof Error ? deliveryError : String(deliveryError),
-        });
-      }
-    );
-    if (delivered) {
-      this.log.info("Callback succeeded", { message_id: messageId, source });
-      return;
-    }
-
-    this.log.error("Failed to notify callback client after retries", {
-      message_id: messageId,
-      source,
-    });
   }
 
   /**
@@ -245,11 +274,10 @@ export class CallbackNotificationService {
     success: boolean,
     error: string | undefined,
     messageId: string
-  ): Promise<void> {
+  ): Promise<CallbackDeliveryResult> {
     const binding = this.env.SCHEDULER_CALLBACK;
     if (!binding) {
-      this.log.warn("No SCHEDULER_CALLBACK binding, skipping automation notification");
-      return;
+      return { delivered: false, attempts: 0, rejectReason: "no_binding" };
     }
 
     const payload = {
@@ -263,46 +291,37 @@ export class CallbackNotificationService {
       automationName: context.automationName,
     };
 
+    let attempts = 0;
+    let httpStatus: number | undefined;
     const delivered = await deliverWithRetry(
-      (signal) =>
-        binding.fetch("https://internal/internal/run-complete", {
+      async (signal) => {
+        attempts++;
+        const response = await binding.fetch("https://internal/internal/run-complete", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload),
           signal,
-        }),
+        });
+        httpStatus = response.status;
+        return response;
+      },
       this.sleep,
-      async ({ attempt, response, error: deliveryError }) => {
-        if (response) {
-          const responseText = await response.text().catch(() => "");
-          this.log.error("Automation callback failed", {
-            automation_id: context.automationId,
-            run_id: context.runId,
-            status: response.status,
-            response_text: responseText.slice(0, 500),
-          });
-          return;
-        }
-        this.log.error("Automation callback attempt failed", {
+      ({ attempt, response, error: deliveryError }) => {
+        this.log.warn("callback.complete_delivery_attempt_failed", {
+          message_id: messageId,
+          session_id: this.getSessionId(),
+          source: "automation",
           automation_id: context.automationId,
           run_id: context.runId,
           attempt,
-          error: deliveryError instanceof Error ? deliveryError : String(deliveryError),
+          ...(response ? { http_status: response.status } : {}),
+          ...(deliveryError !== undefined
+            ? { error: deliveryError instanceof Error ? deliveryError : String(deliveryError) }
+            : {}),
         });
       }
     );
-    if (delivered) {
-      this.log.info("Automation callback succeeded", {
-        automation_id: context.automationId,
-        run_id: context.runId,
-      });
-      return;
-    }
-
-    this.log.error("Failed to notify scheduler after retries", {
-      automation_id: context.automationId,
-      run_id: context.runId,
-    });
+    return { delivered, attempts, ...(httpStatus !== undefined ? { httpStatus } : {}) };
   }
 
   /**

--- a/packages/control-plane/src/session/linear-start-callback.ts
+++ b/packages/control-plane/src/session/linear-start-callback.ts
@@ -42,7 +42,7 @@ export async function notifyLinearStarted({
     signature: await computeHmacHex(JSON.stringify(payloadData), secret),
   };
 
-  const delivered = await deliverWithRetry(
+  const { delivered } = await deliverWithRetry(
     (signal) =>
       binding.fetch("https://internal/callbacks/start", {
         method: "POST",


### PR DESCRIPTION
## Summary

- replace ad hoc callback success/failure logs with one terminal `callback.complete_delivery` event emitted from a `finally` path
- include outcome, duration, session/message correlation, source, attempt/retry counts, HTTP status, and rejection reason when available
- normalize retry diagnostics as `callback.complete_delivery_attempt_failed` and stop logging callback response bodies
- document the new canonical event in the debugging playbook

## Testing

- `npm test -w @open-inspect/control-plane -- --run src/session/callback-notification-service.test.ts`
- `npm test -w @open-inspect/control-plane`
- `npm run typecheck`
- Prettier, ESLint pre-commit hooks, and `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/ffe1f2dc8e64b4c5aaa0572812e210c4)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured callback completion/terminal delivery events with outcome, retry/attempt counts, duration, optional HTTP status, and failure details.
  * Standardized delivery handling across callback types for consistent success, retry, and rejection reporting.
* **Documentation**
  * Updated the session event catalog formatting and added `callback.complete_delivery` details.
* **Bug Fixes**
  * Improved outcomes and metadata reporting for missing delivery configuration and retry-exhausted failures (including clearer reject reasons).
* **Tests**
  * Updated and expanded test assertions to verify structured delivery results across success, retry, rejection, and final-throw scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->