### PR TITLE
fix(web): show PR icons for child sessions

### DIFF
--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -456,7 +456,7 @@ export class SessionIndexStore {
       .prepare(`SELECT * FROM sessions WHERE parent_session_id = ? ORDER BY created_at DESC`)
       .bind(parentSessionId)
       .all<SessionRow>();
-    return (result.results || []).map(toEntry);
+    return this.decorateEntries((result.results || []).map(toEntry));
   }
 
   /** Count active (non-terminal) children for concurrent cap enforcement. */

--- a/packages/control-plane/test/integration/d1-session-index.test.ts
+++ b/packages/control-plane/test/integration/d1-session-index.test.ts
@@ -492,6 +492,41 @@ describe("D1 SessionIndexStore", () => {
       expect(children[1].id).toBe(childId1); // older
     });
 
+    it("listByParent attaches pull request summaries to children", async () => {
+      const now = Date.now();
+      await new SessionPullRequestStore(env.DB).upsert({
+        artifactId: "child-pr-artifact",
+        sessionId: childId1,
+        repositoryExternalId: "1",
+        repoOwner: "owner",
+        repoName: "repo",
+        prNumber: 42,
+        url: "https://github.com/owner/repo/pull/42",
+        lifecycleState: "open",
+        isDraft: false,
+        headBranch: "open-inspect/child-session-1",
+        baseBranch: "main",
+        headSha: null,
+        providerCreatedAt: null,
+        providerUpdatedAt: null,
+        mergedAt: null,
+        closedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const children = await store.listByParent(parentId);
+
+      expect(children.find((child) => child.id === childId1)?.pullRequestSummary).toEqual({
+        total: 1,
+        open: 1,
+        draft: 0,
+        merged: 0,
+        closed: 0,
+      });
+      expect(children.find((child) => child.id === childId2)?.pullRequestSummary).toBeUndefined();
+    });
+
     it("listByParent returns empty array when no children exist", async () => {
       const children = await store.listByParent("nonexistent-parent");
       expect(children).toEqual([]);

--- a/packages/web/src/components/session-sidebar.test.tsx
+++ b/packages/web/src/components/session-sidebar.test.tsx
@@ -165,6 +165,7 @@ describe("SessionSidebar", () => {
       spawnSource: "agent",
       spawnDepth: 1,
       updatedAt: 3000,
+      pullRequestSummary: { total: 1, open: 0, draft: 0, merged: 1, closed: 0 },
     });
     const grandchild = createSession(3, {
       title: "Grandchild session",
@@ -192,7 +193,9 @@ describe("SessionSidebar", () => {
     );
 
     expect(await screen.findByText("Session 1")).toBeInTheDocument();
-    expect(screen.getByText("Child session")).toBeInTheDocument();
+    const childLink = screen.getByText("Child session").closest("a");
+    expect(childLink).toBeInTheDocument();
+    expect(childLink).toContainElement(screen.getByLabelText("PR merged"));
     expect(screen.getByText("Grandchild session")).toBeInTheDocument();
   });
 

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -984,6 +984,7 @@ function ChildSessionListItem({
 }) {
   const timestamp = session.updatedAt || session.createdAt;
   const relativeTime = formatRelativeTime(timestamp);
+  const prDisplay = pullRequestSummaryDisplay(session.pullRequestSummary);
   const displayTitle = session.title || "Sub-task";
   const paddingLeftRem = 1.75 + Math.max(depth - 1, 0) * 1;
   return (
@@ -1001,6 +1002,7 @@ function ChildSessionListItem({
     >
       <div className="flex items-center gap-1.5 text-xs">
         <span className="shrink-0 text-muted-foreground">{relativeTime}</span>
+        {prDisplay && <PullRequestStateIcon state={prDisplay.state} label={prDisplay.label} />}
         <span className="truncate font-medium text-foreground">{displayTitle}</span>
       </div>
     </Link>

--- a/packages/web/src/components/sidebar/child-sessions-section.test.tsx
+++ b/packages/web/src/components/sidebar/child-sessions-section.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { SWRConfig } from "swr";
+import { ChildSessionsSection } from "./child-sessions-section";
+
+expect.extend(matchers);
+
+afterEach(cleanup);
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: React.ComponentProps<"a">) => (
+    <a href={typeof href === "string" ? href : "#"} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("ChildSessionsSection", () => {
+  it("renders a child's pull request state icon", async () => {
+    const sessionId = "parent-session";
+    render(
+      <SWRConfig
+        value={{
+          fallback: {
+            [`/api/sessions/${sessionId}/children`]: {
+              children: [
+                {
+                  id: "child-session",
+                  title: "Child session",
+                  repoOwner: "owner",
+                  repoName: "repo",
+                  parentSessionId: sessionId,
+                  spawnSource: "agent",
+                  spawnDepth: 1,
+                  status: "completed",
+                  createdAt: 1000,
+                  updatedAt: 2000,
+                  pullRequestSummary: {
+                    total: 1,
+                    open: 0,
+                    draft: 0,
+                    merged: 1,
+                    closed: 0,
+                  },
+                },
+              ],
+            },
+          },
+          provider: () => new Map(),
+          revalidateOnFocus: false,
+        }}
+      >
+        <ChildSessionsSection sessionId={sessionId} />
+      </SWRConfig>
+    );
+
+    const childLink = (await screen.findByText("Child session")).closest("a");
+    expect(childLink).toBeInTheDocument();
+    expect(childLink).toContainElement(screen.getByLabelText("PR merged"));
+  });
+});

--- a/packages/web/src/components/sidebar/child-sessions-section.tsx
+++ b/packages/web/src/components/sidebar/child-sessions-section.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import useSWR from "swr";
 import { CollapsibleSection } from "./collapsible-section";
 import { Badge } from "@/components/ui/badge";
+import { PullRequestStateIcon } from "@/components/pr-state-icon";
+import { pullRequestSummaryDisplay } from "@/lib/pr-summary";
 import { formatRelativeTime } from "@/lib/time";
 import { formatRepoLabel } from "@/lib/repo-label";
 import type { SessionItem } from "@/components/session-sidebar";
@@ -46,27 +48,33 @@ export function ChildSessionsSection({ sessionId }: ChildSessionsSectionProps) {
   return (
     <CollapsibleSection title="Sub-tasks" defaultOpen={true}>
       <div className="space-y-2">
-        {children.map((child) => (
-          <Link
-            key={child.id}
-            href={`/session/${child.id}`}
-            className="block p-2 hover:bg-muted transition-colors rounded"
-          >
-            <div className="flex items-center justify-between gap-2">
-              <div className="flex min-w-0 items-center gap-1.5">
-                <span className="text-xs text-muted-foreground shrink-0">
-                  {formatRelativeTime(child.updatedAt || child.createdAt)}
-                </span>
-                <span className="text-sm truncate">
-                  {child.title || formatRepoLabel(child.repoOwner, child.repoName)}
-                </span>
+        {children.map((child) => {
+          const prDisplay = pullRequestSummaryDisplay(child.pullRequestSummary);
+          return (
+            <Link
+              key={child.id}
+              href={`/session/${child.id}`}
+              className="block p-2 hover:bg-muted transition-colors rounded"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex min-w-0 items-center gap-1.5">
+                  <span className="text-xs text-muted-foreground shrink-0">
+                    {formatRelativeTime(child.updatedAt || child.createdAt)}
+                  </span>
+                  {prDisplay && (
+                    <PullRequestStateIcon state={prDisplay.state} label={prDisplay.label} />
+                  )}
+                  <span className="text-sm truncate">
+                    {child.title || formatRepoLabel(child.repoOwner, child.repoName)}
+                  </span>
+                </div>
+                <Badge variant={statusBadgeVariant(child.status)} className="shrink-0">
+                  {child.status}
+                </Badge>
               </div>
-              <Badge variant={statusBadgeVariant(child.status)} className="shrink-0">
-                {child.status}
-              </Badge>
-            </div>
-          </Link>
-        ))}
+            </Link>
+          );
+        })}
       </div>
     </CollapsibleSection>
   );


### PR DESCRIPTION
## Summary

- render pull request state icons for nested child rows in the global session sidebar
- decorate `listByParent()` results with pull request summaries and render them in the detail sidebar's Sub-tasks section
- add web component and D1 integration regressions for both child-session paths

## Root cause

Nested child sessions use dedicated row components that did not consume the existing `pullRequestSummary`. The detail sidebar's children endpoint also returned undecorated session index entries, so that view lacked both the summary data and icon rendering.

## Testing

- `npm test -w @open-inspect/web -- src/components/session-sidebar.test.tsx src/components/sidebar/child-sessions-section.test.tsx`
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/d1-session-index.test.ts`
- `npm run typecheck`
- `npm run lint -w @open-inspect/web`
- `npm run lint -w @open-inspect/control-plane`
- Prettier check for all changed files

The full web test run completed 776/779 tests successfully but had three unrelated failures under parallel suite load: timeout failures in `site-config.test.ts` and Slack integration settings, plus an existing delayed state update from `sandbox-settings.tsx`. Both directly failing test files passed when rerun in isolation.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/24885a64886722a6aad4fed8fa9263ec)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Child sessions now display pull request status icons in the sidebar.
  * Pull request summaries, including states such as “merged,” are shown for nested sessions when available.

* **Bug Fixes**
  * Child-session data now includes pull request summaries, ensuring sidebar status indicators are accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->