### PR TITLE
Fix terminal observability gaps across services

### DIFF
--- a/docs/DEBUGGING_PLAYBOOK.md
+++ b/docs/DEBUGGING_PLAYBOOK.md
@@ -123,28 +123,26 @@ One `image_build.*` vocabulary covers both scope kinds; events carry `scope_kind
 
 #### Session Durable Object (`component: "session-do"`)
 
-| Event                        | Level       | Key Fields                                                                                                            | Description                         |
-| ---------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| `do.request`                 | info        | `http_method`, `http_path`, `http_status`, `duration_ms`, `outcome`                                                   | One per DO internal route call      |
-| `ws.connect`                 | info, warn  | `ws_type` (sandbox\|client), `outcome`, `reject_reason`, `sandbox_id`, `participant_id`, `duration_ms`                | WebSocket lifecycle                 |
-| `prompt.enqueue`             | info        | `message_id`, `source`, `author_id`, `user_id`, `model`, `content_length`, `has_attachments`, `queue_position`        | Message queued                      |
-| `prompt.dispatch`            | info        | `message_id`, `outcome`, `reason`, `model`, `has_sandbox_ws`, `queue_wait_ms`                                         | Message sent to sandbox             |
-| `prompt.complete`            | info, warn  | `message_id`, `outcome`, `total_duration_ms`, `processing_duration_ms`, `queue_duration_ms`                           | Prompt run finished                 |
-| `callback.complete_delivery` | info, error | `session_id`, `message_id`, `source`, `outcome`, `duration_ms`, `attempts`, `retries`, `http_status`, `reject_reason` | Completion callback delivery result |
+| Event                        | Level       | Key Fields                                                                                                            | Description                           |
+| ---------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `do.request`                 | info        | `http_method`, `http_path`, `http_status`, `duration_ms`, `outcome`                                                   | One per DO internal route call        |
+| `ws.connect`                 | info, warn  | `ws_type` (sandbox\|client), `outcome`, `reject_reason`, `sandbox_id`, `participant_id`, `duration_ms`                | WebSocket lifecycle                   |
+| `prompt.enqueue`             | info        | `message_id`, `source`, `author_id`, `user_id`, `model`, `content_length`, `has_attachments`, `queue_position`        | Message queued                        |
+| `prompt.dispatch`            | info        | `message_id`, `outcome`, `reason`, `model`, `has_sandbox_ws`, `queue_wait_ms`                                         | Message sent to sandbox               |
+| `prompt.complete`            | info, warn  | `message_id`, `outcome`, `total_duration_ms`, `processing_duration_ms`, `queue_duration_ms`                           | Prompt run finished                   |
+| `callback.complete_delivery` | info, error | `session_id`, `message_id`, `source`, `outcome`, `duration_ms`, `attempts`, `retries`, `http_status`, `reject_reason` | Completion callback delivery result   |
+| `callback.started_delivery`  | info, error | `session_id`, `message_id`, `outcome`, `duration_ms`, `attempts`, `retries`, `http_status`, `reject_reason`           | Linear start-callback delivery result |
 
 #### Lifecycle Manager (`component: "lifecycle-manager"`)
 
-| Event                     | Level | Key Fields                                       | Description                |
-| ------------------------- | ----- | ------------------------------------------------ | -------------------------- |
-| `sandbox.spawn`           | info  | `expected_sandbox_id`, `repo_owner`, `repo_name` | Spawn attempt started      |
-| `sandbox.spawned`         | info  | `sandbox_id`, `provider_object_id`               | Spawn succeeded            |
-| `sandbox.spawn_failed`    | error | `error`                                          | Spawn failed               |
-| `sandbox.restore`         | info  | `snapshot_image_id`                              | Restore attempt started    |
-| `sandbox.restored`        | info  | `sandbox_id`, `provider_object_id`               | Restore succeeded          |
-| `sandbox.snapshot`        | info  | `reason`, `provider_object_id`                   | Snapshot attempt started   |
-| `sandbox.snapshot_saved`  | info  | `image_id`, `reason`                             | Snapshot saved             |
-| `sandbox.heartbeat_stale` | warn  | `last_heartbeat_ms`, `threshold_ms`              | Heartbeat missed           |
-| `sandbox.timeout`         | info  | `last_activity`, `timeout_ms`                    | Inactivity timeout reached |
+| Event                     | Level       | Key Fields                                                                                                              | Description                |
+| ------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `sandbox.spawn`           | info, error | `outcome`, `duration_ms`, `sandbox_id`, `expected_sandbox_id`, `provider_object_id`, `repo_owner`, `repo_name`, `error` | Spawn completed            |
+| `sandbox.restore`         | info, error | `outcome`, `duration_ms`, `snapshot_image_id`, `sandbox_id`, `provider_object_id`, `repo_owner`, `repo_name`, `error`   | Restore completed          |
+| `sandbox.snapshot`        | info        | `reason`, `provider_object_id`                                                                                          | Snapshot attempt started   |
+| `sandbox.snapshot_saved`  | info        | `image_id`, `reason`                                                                                                    | Snapshot saved             |
+| `sandbox.heartbeat_stale` | warn        | `last_heartbeat_ms`, `threshold_ms`                                                                                     | Heartbeat missed           |
+| `sandbox.timeout`         | info        | `last_activity`, `timeout_ms`                                                                                           | Inactivity timeout reached |
 
 #### Provider Clients
 
@@ -177,18 +175,16 @@ One `image_build.*` vocabulary covers both scope kinds; events carry `scope_kind
 The `build_image` worker and the 30-minute `rebuild_images` cron. Worker events carry
 `scope_kind`/`scope_id` like the control-plane side.
 
-| Event                                                                                   | Level | Key Fields                                                                                       | Description                                                      |
-| --------------------------------------------------------------------------------------- | ----- | ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
-| `image_build.start`                                                                     | info  | `build_id`, `scope_kind`, `scope_id`, `repository_count`                                         | Build worker started                                             |
-| `image_build.success`                                                                   | info  | `build_id`, `scope_kind`, `scope_id`, `provider_image_id`, `runtime_version`, `build_duration_s` | Filesystem snapshotted; success callback follows                 |
-| `image_build.failed`                                                                    | error | `build_id`, `scope_kind`, `scope_id`, `error`, `build_duration_s`                                | Build failed; failure callback follows                           |
-| `scheduler.start` / `scheduler.done`                                                    | info  | `builds_triggered`, `duration_s` (on done)                                                       | One cron pass over all enabled scope units                       |
-| `scheduler.build_triggered`                                                             | info  | `scope_kind`, `scope_id`                                                                         | Cron triggered a rebuild for a unit                              |
-| `scheduler.no_ready_image` / `scheduler.runtime_below_floor` / `scheduler.sha_mismatch` | info  | `scope_kind`, `scope_id` (+ trigger-specific fields)                                             | Which rebuild trigger fired for a unit                           |
-| `scheduler.skip_building`                                                               | info  | `scope_kind`, `scope_id`                                                                         | Unit skipped: a build is already in flight                       |
-| `scheduler.trigger_cap_reached`                                                         | info  | `cap`                                                                                            | Per-tick trigger cap hit; remaining units wait for the next tick |
-| `scheduler.malformed_repository_shas`                                                   | warn  | `scope_kind`, `scope_id`                                                                         | Stored provenance JSON did not parse; unit treated as stale      |
-| `scheduler.mark_stale_error` / `scheduler.cleanup_error`                                | warn  | `error`                                                                                          | Post-pass maintenance call (mark-stale / cleanup) failed         |
+| Event                                                                                   | Level       | Key Fields                                                                                                                               | Description                                                      |
+| --------------------------------------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `image_build.complete`                                                                  | info, error | `build_id`, `scope_kind`, `scope_id`, `outcome`, `duration_seconds`, `repository_count`, `provider_image_id`, `runtime_version`, `error` | Build completed; success or failure callback follows             |
+| `scheduler.start` / `scheduler.done`                                                    | info        | `builds_triggered`, `duration_s` (on done)                                                                                               | One cron pass over all enabled scope units                       |
+| `scheduler.build_triggered`                                                             | info        | `scope_kind`, `scope_id`                                                                                                                 | Cron triggered a rebuild for a unit                              |
+| `scheduler.no_ready_image` / `scheduler.runtime_below_floor` / `scheduler.sha_mismatch` | info        | `scope_kind`, `scope_id` (+ trigger-specific fields)                                                                                     | Which rebuild trigger fired for a unit                           |
+| `scheduler.skip_building`                                                               | info        | `scope_kind`, `scope_id`                                                                                                                 | Unit skipped: a build is already in flight                       |
+| `scheduler.trigger_cap_reached`                                                         | info        | `cap`                                                                                                                                    | Per-tick trigger cap hit; remaining units wait for the next tick |
+| `scheduler.malformed_repository_shas`                                                   | warn        | `scope_kind`, `scope_id`                                                                                                                 | Stored provenance JSON did not parse; unit treated as stale      |
+| `scheduler.mark_stale_error` / `scheduler.cleanup_error`                                | warn        | `error`                                                                                                                                  | Post-pass maintenance call (mark-stale / cleanup) failed         |
 
 #### Supervisor (`component: "supervisor"`)
 
@@ -201,14 +197,15 @@ The `build_image` worker and the 30-minute `rebuild_images` cron. Worker events 
 
 #### Bridge (`component: "bridge"`)
 
-| Event               | Level      | Key Fields                                      | Description                          |
-| ------------------- | ---------- | ----------------------------------------------- | ------------------------------------ |
-| `bridge.connect`    | info       | `outcome`                                       | WebSocket connected to control-plane |
-| `bridge.disconnect` | info, warn | `reason`, `ws_close_code`                       | WebSocket disconnected               |
-| `bridge.reconnect`  | info       | `attempt`, `delay_s`                            | Reconnection attempt                 |
-| `prompt.start`      | info       | `message_id`, `model`                           | Prompt processing started            |
-| `prompt.run`        | info       | `message_id`, `model`, `outcome`, `duration_ms` | Prompt processing completed (wide)   |
-| `prompt.error`      | error      | `message_id`, `exc`                             | Prompt processing failed             |
+| Event                 | Level      | Key Fields                                                                                                                                                     | Description                                           |
+| --------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `bridge.connect`      | info       | `outcome`                                                                                                                                                      | WebSocket connected to control-plane                  |
+| `bridge.disconnect`   | info, warn | `reason`, `ws_close_code`, `connection_duration_seconds`, `total_connected_duration_seconds`, `connection_count`, `reconnect_count`, `reconnect_attempt_count` | WebSocket disconnected with lifetime aggregates       |
+| `bridge.reconnect`    | info       | `attempt`, `reconnect_attempt_count`, `delay_s`                                                                                                                | Reconnection attempt                                  |
+| `bridge.run_complete` | info       | `outcome`, `connection_count`, `reconnect_count`, `reconnect_attempt_count`, `total_connected_duration_seconds`                                                | Bridge process exited with aggregate connection stats |
+| `prompt.start`        | info       | `message_id`, `model`                                                                                                                                          | Prompt processing started                             |
+| `prompt.run`          | info       | `message_id`, `model`, `outcome`, `duration_ms`                                                                                                                | Prompt processing completed (wide)                    |
+| `prompt.error`        | error      | `message_id`, `exc`                                                                                                                                            | Prompt processing failed                              |
 
 #### Git Operations (`component: "bridge"` / `"supervisor"`)
 

--- a/docs/DEBUGGING_PLAYBOOK.md
+++ b/docs/DEBUGGING_PLAYBOOK.md
@@ -135,6 +135,9 @@ One `image_build.*` vocabulary covers both scope kinds; events carry `scope_kind
 
 #### Lifecycle Manager (`component: "lifecycle-manager"`)
 
+Dashboards and alerts must migrate `sandbox.spawned` and `sandbox.spawn_failed` to `sandbox.spawn`
+outcomes, and `sandbox.restored` to `sandbox.restore` outcomes.
+
 | Event                     | Level       | Key Fields                                                                                                              | Description                |
 | ------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------------- |
 | `sandbox.spawn`           | info, error | `outcome`, `duration_ms`, `sandbox_id`, `expected_sandbox_id`, `provider_object_id`, `repo_owner`, `repo_name`, `error` | Spawn completed            |
@@ -174,6 +177,9 @@ One `image_build.*` vocabulary covers both scope kinds; events carry `scope_kind
 
 The `build_image` worker and the 30-minute `rebuild_images` cron. Worker events carry
 `scope_kind`/`scope_id` like the control-plane side.
+
+Dashboards and alerts must migrate `image_build.start`, `image_build.success`, and
+`image_build.failed` to `image_build.complete` outcomes.
 
 | Event                                                                                   | Level       | Key Fields                                                                                                                               | Description                                                      |
 | --------------------------------------------------------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -271,6 +271,12 @@ function createMockIdGenerator(): IdGenerator {
   };
 }
 
+function parseStructuredLogs(spy: ReturnType<typeof vi.spyOn>): Array<Record<string, unknown>> {
+  return spy.mock.calls.map(
+    (call: unknown[]) => JSON.parse(String(call[0])) as Record<string, unknown>
+  );
+}
+
 function createMockProvider(
   overrides: Partial<{
     createSandbox: (config: CreateSandboxConfig) => Promise<CreateSandboxResult>;
@@ -357,6 +363,74 @@ describe("SandboxLifecycleManager", () => {
       expect(
         broadcaster.messages.some((m) => (m as { type: string }).type === "sandbox_status")
       ).toBe(true);
+    });
+
+    it("logs one terminal sandbox.spawn event for success", async () => {
+      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const manager = new SandboxLifecycleManager(
+        createMockProvider(),
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+      await manager.spawnSandbox();
+
+      const spawnLogs = parseStructuredLogs(logSpy).filter(
+        (entry) => entry.msg === "Sandbox spawn completed" && entry.event === "sandbox.spawn"
+      );
+      logSpy.mockRestore();
+
+      expect(spawnLogs).toHaveLength(1);
+      expect(spawnLogs[0]).toEqual(
+        expect.objectContaining({
+          outcome: "success",
+          sandbox_id: expect.any(String),
+          provider_object_id: "provider-obj-123",
+          duration_ms: expect.any(Number),
+        })
+      );
+    });
+
+    it("logs one terminal sandbox.spawn event for failure", async () => {
+      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      const provider = createMockProvider({
+        createSandbox: vi.fn(async () => {
+          throw new Error("spawn exploded");
+        }),
+      });
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+      await manager.spawnSandbox();
+
+      const errorLogs = parseStructuredLogs(errorSpy);
+      errorSpy.mockRestore();
+
+      expect(errorLogs).toContainEqual(
+        expect.objectContaining({
+          msg: "Sandbox spawn completed",
+          event: "sandbox.spawn",
+          outcome: "error",
+          duration_ms: expect.any(Number),
+        })
+      );
     });
 
     it("broadcasts sandbox_dashboard_url after spawn when builder is configured", async () => {
@@ -606,6 +680,81 @@ describe("SandboxLifecycleManager", () => {
 
       expect(provider.restoreFromSnapshot).toHaveBeenCalled();
       expect(provider.createSandbox).not.toHaveBeenCalled();
+    });
+
+    it("logs one terminal sandbox.restore event for success", async () => {
+      const sandbox = createMockSandbox({
+        status: "stopped",
+        snapshot_image_id: "img-abc123",
+      });
+      const manager = new SandboxLifecycleManager(
+        createMockProvider(),
+        createMockStorage(createMockSession(), sandbox),
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+      await manager.spawnSandbox();
+
+      const infoLogs = parseStructuredLogs(logSpy);
+      logSpy.mockRestore();
+
+      expect(infoLogs).toContainEqual(
+        expect.objectContaining({
+          msg: "Sandbox restore completed",
+          event: "sandbox.restore",
+          outcome: "success",
+          snapshot_image_id: "img-abc123",
+          duration_ms: expect.any(Number),
+        })
+      );
+    });
+
+    it("logs one terminal sandbox.restore event for failure", async () => {
+      const sandbox = createMockSandbox({
+        status: "stopped",
+        snapshot_image_id: "img-abc123",
+      });
+      const provider = createMockProvider({
+        restoreFromSnapshot: vi.fn(
+          async (): Promise<RestoreResult> => ({
+            success: false,
+            error: "Snapshot not found",
+          })
+        ),
+      });
+      const manager = new SandboxLifecycleManager(
+        provider,
+        createMockStorage(createMockSession(), sandbox),
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+      await manager.spawnSandbox();
+
+      const errorLogs = parseStructuredLogs(errorSpy);
+      errorSpy.mockRestore();
+
+      expect(errorLogs).toContainEqual(
+        expect.objectContaining({
+          msg: "Sandbox restore completed",
+          event: "sandbox.restore",
+          outcome: "error",
+          snapshot_image_id: "img-abc123",
+          error: "Snapshot not found",
+          duration_ms: expect.any(Number),
+        })
+      );
     });
 
     it("schedules connecting timeout alarm after restore", async () => {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -433,6 +433,37 @@ describe("SandboxLifecycleManager", () => {
       );
     });
 
+    it("logs only an error terminal event when spawn success-side effects fail", async () => {
+      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      vi.mocked(storage.updateSandboxModalObjectId).mockImplementation(() => {
+        throw new Error("storage unavailable");
+      });
+      const manager = new SandboxLifecycleManager(
+        createMockProvider(),
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+      const infoSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+      await manager.spawnSandbox();
+
+      const terminalLogs = [
+        ...parseStructuredLogs(infoSpy),
+        ...parseStructuredLogs(errorSpy),
+      ].filter((entry) => entry.event === "sandbox.spawn");
+      infoSpy.mockRestore();
+      errorSpy.mockRestore();
+
+      expect(terminalLogs).toHaveLength(1);
+      expect(terminalLogs[0]).toEqual(expect.objectContaining({ outcome: "error" }));
+    });
+
     it("broadcasts sandbox_dashboard_url after spawn when builder is configured", async () => {
       const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
       const storage = createMockStorage(createMockSession(), sandbox);
@@ -755,6 +786,47 @@ describe("SandboxLifecycleManager", () => {
           duration_ms: expect.any(Number),
         })
       );
+    });
+
+    it("logs only an error terminal event when restore success-side effects fail", async () => {
+      const sandbox = createMockSandbox({
+        status: "stopped",
+        snapshot_image_id: "img-abc123",
+      });
+      const storage = createMockStorage(createMockSession(), sandbox);
+      vi.mocked(storage.updateSandboxModalObjectId).mockImplementation(() => {
+        throw new Error("storage unavailable");
+      });
+      const provider = createMockProvider({
+        restoreFromSnapshot: vi.fn(async (config: RestoreConfig) => ({
+          success: true,
+          sandboxId: config.sandboxId,
+          providerObjectId: "restored-object",
+        })),
+      });
+      const manager = new SandboxLifecycleManager(
+        provider,
+        storage,
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+      const infoSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+      await manager.spawnSandbox();
+
+      const terminalLogs = [
+        ...parseStructuredLogs(infoSpy),
+        ...parseStructuredLogs(errorSpy),
+      ].filter((entry) => entry.event === "sandbox.restore");
+      infoSpy.mockRestore();
+      errorSpy.mockRestore();
+
+      expect(terminalLogs).toHaveLength(1);
+      expect(terminalLogs[0]).toEqual(expect.objectContaining({ outcome: "error" }));
     });
 
     it("schedules connecting timeout alarm after restore", async () => {

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -395,9 +395,11 @@ export class SandboxLifecycleManager {
    */
   private async doSpawn(): Promise<void> {
     this.isSpawningSandbox = true;
+    const spawnStartedAt = Date.now();
+    let session: SessionRow | null = null;
 
     try {
-      const session = this.storage.getSession();
+      session = this.storage.getSession();
       if (!session) {
         this.log.error("Cannot spawn sandbox: no session");
         return;
@@ -419,13 +421,6 @@ export class SandboxLifecycleManager {
         modalSandboxId: expectedSandboxId,
       });
       this.broadcaster.broadcast({ type: "sandbox_status", status: "spawning" });
-
-      this.log.info("Spawning sandbox", {
-        event: "sandbox.spawn",
-        expected_sandbox_id: expectedSandboxId,
-        repo_owner: session.repo_owner,
-        repo_name: session.repo_name,
-      });
 
       const userEnvVars = await this.storage.getUserEnvVars();
       const { provider, model: modelId } = this.resolveProviderAndModel(session);
@@ -526,10 +521,15 @@ export class SandboxLifecycleManager {
         });
       }
 
-      this.log.info("Sandbox spawned", {
-        event: "sandbox.spawned",
+      this.log.info("Sandbox spawn completed", {
+        event: "sandbox.spawn",
+        outcome: "success",
+        duration_ms: Date.now() - spawnStartedAt,
+        expected_sandbox_id: expectedSandboxId,
         sandbox_id: result.sandboxId,
         provider_object_id: result.providerObjectId,
+        repo_owner: session.repo_owner,
+        repo_name: session.repo_name,
       });
 
       if (result.providerObjectId) {
@@ -561,9 +561,13 @@ export class SandboxLifecycleManager {
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Failed to spawn sandbox";
       this.storage.setLastSpawnError(errorMessage, Date.now());
-      this.log.error("Sandbox spawn failed", {
-        event: "sandbox.spawn_failed",
+      this.log.error("Sandbox spawn completed", {
+        event: "sandbox.spawn",
+        outcome: "error",
+        duration_ms: Date.now() - spawnStartedAt,
         error: error instanceof Error ? error : String(error),
+        repo_owner: session?.repo_owner,
+        repo_name: session?.repo_name,
       });
 
       // Only increment circuit breaker for permanent errors
@@ -714,9 +718,11 @@ export class SandboxLifecycleManager {
     }
 
     this.isSpawningSandbox = true;
+    const restoreStartedAt = Date.now();
+    let session: SessionRow | null = null;
 
     try {
-      const session = this.storage.getSession();
+      session = this.storage.getSession();
       if (!session) {
         this.log.error("Cannot restore: no session");
         return;
@@ -737,11 +743,6 @@ export class SandboxLifecycleManager {
         modalSandboxId: expectedSandboxId,
       });
       this.broadcaster.broadcast({ type: "sandbox_status", status: "spawning" });
-
-      this.log.info("Restoring from snapshot", {
-        event: "sandbox.restore",
-        snapshot_image_id: snapshotImageId,
-      });
 
       const userEnvVars = await this.storage.getUserEnvVars();
       const { provider, model: modelId } = this.resolveProviderAndModel(session);
@@ -776,10 +777,15 @@ export class SandboxLifecycleManager {
       });
 
       if (result.success) {
-        this.log.info("Sandbox restored", {
-          event: "sandbox.restored",
+        this.log.info("Sandbox restore completed", {
+          event: "sandbox.restore",
+          outcome: "success",
+          duration_ms: Date.now() - restoreStartedAt,
+          snapshot_image_id: snapshotImageId,
           sandbox_id: result.sandboxId,
           provider_object_id: result.providerObjectId,
+          repo_owner: session.repo_owner,
+          repo_name: session.repo_name,
         });
 
         if (result.providerObjectId) {
@@ -811,9 +817,14 @@ export class SandboxLifecycleManager {
           message: "Session restored from snapshot",
         });
       } else {
-        this.log.error("Snapshot restore failed", {
+        this.log.error("Sandbox restore completed", {
+          event: "sandbox.restore",
+          outcome: "error",
+          duration_ms: Date.now() - restoreStartedAt,
           error: result.error,
           snapshot_image_id: snapshotImageId,
+          repo_owner: session.repo_owner,
+          repo_name: session.repo_name,
         });
         this.storage.setLastSpawnError(
           result.error || "Failed to restore from snapshot",
@@ -828,9 +839,14 @@ export class SandboxLifecycleManager {
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Failed to restore sandbox";
       this.storage.setLastSpawnError(errorMessage, Date.now());
-      this.log.error("Snapshot restore request failed", {
+      this.log.error("Sandbox restore completed", {
+        event: "sandbox.restore",
+        outcome: "error",
+        duration_ms: Date.now() - restoreStartedAt,
         error: error instanceof Error ? error : String(error),
         snapshot_image_id: snapshotImageId,
+        repo_owner: session?.repo_owner,
+        repo_name: session?.repo_name,
       });
       this.storage.updateSandboxStatus("failed");
       this.broadcaster.broadcast({

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -521,17 +521,6 @@ export class SandboxLifecycleManager {
         });
       }
 
-      this.log.info("Sandbox spawn completed", {
-        event: "sandbox.spawn",
-        outcome: "success",
-        duration_ms: Date.now() - spawnStartedAt,
-        expected_sandbox_id: expectedSandboxId,
-        sandbox_id: result.sandboxId,
-        provider_object_id: result.providerObjectId,
-        repo_owner: session.repo_owner,
-        repo_name: session.repo_name,
-      });
-
       if (result.providerObjectId) {
         this.storeAndBroadcastProviderObjectId(result.providerObjectId);
       }
@@ -558,6 +547,17 @@ export class SandboxLifecycleManager {
 
       // Reset circuit breaker on successful spawn initiation
       this.storage.resetCircuitBreaker();
+
+      this.log.info("Sandbox spawn completed", {
+        event: "sandbox.spawn",
+        outcome: "success",
+        duration_ms: Date.now() - spawnStartedAt,
+        expected_sandbox_id: expectedSandboxId,
+        sandbox_id: result.sandboxId,
+        provider_object_id: result.providerObjectId,
+        repo_owner: session.repo_owner,
+        repo_name: session.repo_name,
+      });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : "Failed to spawn sandbox";
       this.storage.setLastSpawnError(errorMessage, Date.now());
@@ -777,17 +777,6 @@ export class SandboxLifecycleManager {
       });
 
       if (result.success) {
-        this.log.info("Sandbox restore completed", {
-          event: "sandbox.restore",
-          outcome: "success",
-          duration_ms: Date.now() - restoreStartedAt,
-          snapshot_image_id: snapshotImageId,
-          sandbox_id: result.sandboxId,
-          provider_object_id: result.providerObjectId,
-          repo_owner: session.repo_owner,
-          repo_name: session.repo_name,
-        });
-
         if (result.providerObjectId) {
           this.storeAndBroadcastProviderObjectId(result.providerObjectId);
         }
@@ -815,6 +804,17 @@ export class SandboxLifecycleManager {
         this.broadcaster.broadcast({
           type: "sandbox_restored",
           message: "Session restored from snapshot",
+        });
+
+        this.log.info("Sandbox restore completed", {
+          event: "sandbox.restore",
+          outcome: "success",
+          duration_ms: Date.now() - restoreStartedAt,
+          snapshot_image_id: snapshotImageId,
+          sandbox_id: result.sandboxId,
+          provider_object_id: result.providerObjectId,
+          repo_owner: session.repo_owner,
+          repo_name: session.repo_name,
         });
       } else {
         this.log.error("Sandbox restore completed", {

--- a/packages/control-plane/src/session/callback-notification-service.test.ts
+++ b/packages/control-plane/src/session/callback-notification-service.test.ts
@@ -345,6 +345,18 @@ describe("CallbackNotificationService", () => {
 
       expect(fetchMock).toHaveBeenCalledTimes(2);
       expect(harness.sleep).toHaveBeenCalledWith(1000);
+      expect(harness.log.info).toHaveBeenCalledWith(
+        "callback.started_delivery",
+        expect.objectContaining({
+          session_id: "session-123",
+          message_id: "msg-1",
+          outcome: "success",
+          attempts: 2,
+          retries: 1,
+          http_status: 200,
+          duration_ms: expect.any(Number),
+        })
+      );
     });
 
     it("retries when failure logging throws", async () => {
@@ -380,8 +392,15 @@ describe("CallbackNotificationService", () => {
 
       expect(fetchMock).toHaveBeenCalledTimes(2);
       expect(harness.log.error).toHaveBeenCalledWith(
-        "callback.started",
-        expect.objectContaining({ message_id: "msg-1", outcome: "failed" })
+        "callback.started_delivery",
+        expect.objectContaining({
+          session_id: "session-123",
+          message_id: "msg-1",
+          outcome: "error",
+          attempts: 2,
+          retries: 1,
+          duration_ms: expect.any(Number),
+        })
       );
     });
 

--- a/packages/control-plane/src/session/linear-start-callback.ts
+++ b/packages/control-plane/src/session/linear-start-callback.ts
@@ -12,7 +12,16 @@ interface LinearStartCallbackOptions {
   sleep: (ms: number) => Promise<void>;
 }
 
-export async function notifyLinearStarted({
+interface StartCallbackDeliverySummary {
+  outcome: "success" | "error" | "rejected";
+  attempts: number;
+  httpStatus?: number;
+  rejectReason?: string;
+  error?: unknown;
+  rethrow?: boolean;
+}
+
+async function deliverLinearStarted({
   messageId,
   callbackContext,
   sessionId,
@@ -20,23 +29,20 @@ export async function notifyLinearStarted({
   binding,
   log,
   sleep,
-}: LinearStartCallbackOptions): Promise<void> {
-  const startedAt = Date.now();
-  let context: unknown;
-  let delivered = false;
-  let attempts = 0;
-  let httpStatus: number | undefined;
-  let rejectReason: string | undefined;
-  let thrownError: unknown;
+}: LinearStartCallbackOptions): Promise<StartCallbackDeliverySummary> {
   try {
+    let context: unknown;
     try {
       context = JSON.parse(callbackContext);
     } catch {
       context = null;
     }
     if (!context || typeof context !== "object" || Array.isArray(context)) {
-      rejectReason = "invalid_callback_context";
-      return;
+      return {
+        outcome: "rejected",
+        attempts: 0,
+        rejectReason: "invalid_callback_context",
+      };
     }
 
     const payloadData = { sessionId, messageId, timestamp: Date.now(), context };
@@ -44,7 +50,6 @@ export async function notifyLinearStarted({
       ...payloadData,
       signature: await computeHmacHex(JSON.stringify(payloadData), secret),
     };
-
     const result = await deliverWithRetry(
       (signal) =>
         binding.fetch("https://internal/callbacks/start", {
@@ -69,35 +74,52 @@ export async function notifyLinearStarted({
         });
       }
     );
-    delivered = result.delivered;
-    attempts = result.attempts;
-    httpStatus = result.httpStatus;
-  } catch (error) {
-    thrownError = error;
-    throw error;
-  } finally {
-    const outcome =
-      thrownError !== undefined
-        ? "error"
-        : rejectReason
-          ? "rejected"
-          : delivered
-            ? "success"
-            : "error";
-    const fields = {
-      session_id: sessionId,
-      message_id: messageId,
-      outcome,
-      duration_ms: Date.now() - startedAt,
-      attempts,
-      retries: Math.max(0, attempts - 1),
-      ...(httpStatus !== undefined ? { http_status: httpStatus } : {}),
-      ...(rejectReason && thrownError === undefined ? { reject_reason: rejectReason } : {}),
-      ...(thrownError !== undefined
-        ? { error: thrownError instanceof Error ? thrownError : new Error(String(thrownError)) }
-        : {}),
+    return {
+      outcome: result.delivered ? "success" : "error",
+      attempts: result.attempts,
+      httpStatus: result.httpStatus,
     };
-    if (outcome === "error") log.error("callback.started_delivery", fields);
-    else log.info("callback.started_delivery", fields);
+  } catch (error) {
+    return { outcome: "error", attempts: 0, error, rethrow: true };
   }
+}
+
+export async function notifyLinearStarted({
+  messageId,
+  callbackContext,
+  sessionId,
+  secret,
+  binding,
+  log,
+  sleep,
+}: LinearStartCallbackOptions): Promise<void> {
+  const startedAt = Date.now();
+  const summary = await deliverLinearStarted({
+    messageId,
+    callbackContext,
+    sessionId,
+    secret,
+    binding,
+    log,
+    sleep,
+  });
+  const fields = {
+    session_id: sessionId,
+    message_id: messageId,
+    outcome: summary.outcome,
+    duration_ms: Date.now() - startedAt,
+    attempts: summary.attempts,
+    retries: Math.max(0, summary.attempts - 1),
+    ...(summary.httpStatus !== undefined ? { http_status: summary.httpStatus } : {}),
+    ...(summary.rejectReason ? { reject_reason: summary.rejectReason } : {}),
+    ...(summary.error !== undefined
+      ? {
+          error: summary.error instanceof Error ? summary.error : new Error(String(summary.error)),
+        }
+      : {}),
+  };
+  if (summary.outcome === "error") log.error("callback.started_delivery", fields);
+  else log.info("callback.started_delivery", fields);
+
+  if (summary.rethrow) throw summary.error;
 }

--- a/packages/control-plane/src/session/linear-start-callback.ts
+++ b/packages/control-plane/src/session/linear-start-callback.ts
@@ -21,54 +21,83 @@ export async function notifyLinearStarted({
   log,
   sleep,
 }: LinearStartCallbackOptions): Promise<void> {
+  const startedAt = Date.now();
   let context: unknown;
+  let delivered = false;
+  let attempts = 0;
+  let httpStatus: number | undefined;
+  let rejectReason: string | undefined;
+  let thrownError: unknown;
   try {
-    context = JSON.parse(callbackContext);
-  } catch {
-    context = null;
-  }
-  if (!context || typeof context !== "object" || Array.isArray(context)) {
-    log.warn("callback.started", {
-      message_id: messageId,
-      outcome: "skipped",
-      skip_reason: "invalid_callback_context",
-    });
-    return;
-  }
-
-  const payloadData = { sessionId, messageId, timestamp: Date.now(), context };
-  const payload = {
-    ...payloadData,
-    signature: await computeHmacHex(JSON.stringify(payloadData), secret),
-  };
-
-  const { delivered } = await deliverWithRetry(
-    (signal) =>
-      binding.fetch("https://internal/callbacks/start", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-        signal,
-      }),
-    sleep,
-    (failure) => {
-      log.warn("callback.started", {
-        message_id: messageId,
-        outcome: "error",
-        attempt: failure.attempt,
-        ...(failure.response
-          ? { http_status: failure.response.status }
-          : {
-              error:
-                failure.error instanceof Error ? failure.error : new Error(String(failure.error)),
-            }),
-      });
+    try {
+      context = JSON.parse(callbackContext);
+    } catch {
+      context = null;
     }
-  );
+    if (!context || typeof context !== "object" || Array.isArray(context)) {
+      rejectReason = "invalid_callback_context";
+      return;
+    }
 
-  if (delivered) {
-    log.info("callback.started", { message_id: messageId, outcome: "success" });
-    return;
+    const payloadData = { sessionId, messageId, timestamp: Date.now(), context };
+    const payload = {
+      ...payloadData,
+      signature: await computeHmacHex(JSON.stringify(payloadData), secret),
+    };
+
+    const result = await deliverWithRetry(
+      (signal) =>
+        binding.fetch("https://internal/callbacks/start", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+          signal,
+        }),
+      sleep,
+      (failure) => {
+        log.warn("callback.started_delivery_attempt_failed", {
+          session_id: sessionId,
+          message_id: messageId,
+          attempt: failure.attempt,
+          ...(failure.response ? { http_status: failure.response.status } : {}),
+          ...(failure.error !== undefined
+            ? {
+                error:
+                  failure.error instanceof Error ? failure.error : new Error(String(failure.error)),
+              }
+            : {}),
+        });
+      }
+    );
+    delivered = result.delivered;
+    attempts = result.attempts;
+    httpStatus = result.httpStatus;
+  } catch (error) {
+    thrownError = error;
+    throw error;
+  } finally {
+    const outcome =
+      thrownError !== undefined
+        ? "error"
+        : rejectReason
+          ? "rejected"
+          : delivered
+            ? "success"
+            : "error";
+    const fields = {
+      session_id: sessionId,
+      message_id: messageId,
+      outcome,
+      duration_ms: Date.now() - startedAt,
+      attempts,
+      retries: Math.max(0, attempts - 1),
+      ...(httpStatus !== undefined ? { http_status: httpStatus } : {}),
+      ...(rejectReason && thrownError === undefined ? { reject_reason: rejectReason } : {}),
+      ...(thrownError !== undefined
+        ? { error: thrownError instanceof Error ? thrownError : new Error(String(thrownError)) }
+        : {}),
+    };
+    if (outcome === "error") log.error("callback.started_delivery", fields);
+    else log.info("callback.started_delivery", fields);
   }
-  log.error("callback.started", { message_id: messageId, outcome: "failed" });
 }

--- a/packages/modal-infra/src/scheduler/image_builder.py
+++ b/packages/modal-infra/src/scheduler/image_builder.py
@@ -311,14 +311,6 @@ async def build_image(
 
         clone_token = resolve_clone_token() or ""
 
-        log.info(
-            "image_build.start",
-            build_id=build_id,
-            scope_kind=scope_kind,
-            scope_id=scope_id,
-            repository_count=len(repositories),
-        )
-
         handle = await manager.create_build_sandbox(
             repo_owner=primary.get("repo_owner", ""),
             repo_name=primary.get("repo_name", ""),
@@ -365,13 +357,15 @@ async def build_image(
         build_duration = time.time() - start_time
 
         log.info(
-            "image_build.success",
+            "image_build.complete",
             build_id=build_id,
             scope_kind=scope_kind,
             scope_id=scope_id,
+            outcome="success",
+            duration_seconds=round(build_duration, 3),
+            repository_count=len(repositories),
             provider_image_id=provider_image_id,
             runtime_version=build_logs.runtime_version,
-            build_duration_s=round(build_duration, 1),
         )
 
         if callback_url:
@@ -392,12 +386,14 @@ async def build_image(
             sandbox_terminated = await _terminate_build_sandbox(handle, build_id, "build_failed")
 
         log.error(
-            "image_build.failed",
+            "image_build.complete",
             build_id=build_id,
             scope_kind=scope_kind,
             scope_id=scope_id,
+            outcome="error",
             error=str(e),
-            build_duration_s=round(build_duration, 1),
+            duration_seconds=round(build_duration, 3),
+            repository_count=len(repositories),
         )
 
         if failure_callback_url:

--- a/packages/modal-infra/tests/test_image_builder_v2.py
+++ b/packages/modal-infra/tests/test_image_builder_v2.py
@@ -402,6 +402,7 @@ class TestBuildImage:
             patch("src.scheduler.image_builder.validate_control_plane_url", return_value=True),
             patch("src.scheduler.image_builder.resolve_clone_token", return_value="gh-token"),
             patch("src.sandbox.manager.SandboxManager", return_value=manager),
+            patch("src.scheduler.image_builder.log") as mock_log,
             patch(
                 "src.scheduler.image_builder._callback_with_retry",
                 new_callable=AsyncMock,
@@ -425,6 +426,19 @@ class TestBuildImage:
         assert callback_payload["provider_image_id"] == "im-test"
         assert callback_payload["repository_shas"] == REPOSITORY_SHAS
         assert callback_payload["runtime_version"] == RUNTIME_VERSION
+        event_call = next(
+            call for call in mock_log.info.call_args_list if call.args == ("image_build.complete",)
+        )
+        assert event_call.kwargs == {
+            "build_id": "img-1",
+            "scope_kind": "repo",
+            "scope_id": "acme/repo",
+            "outcome": "success",
+            "duration_seconds": pytest.approx(event_call.kwargs["duration_seconds"]),
+            "repository_count": 1,
+            "provider_image_id": "im-test",
+            "runtime_version": RUNTIME_VERSION,
+        }
 
     @pytest.mark.asyncio
     async def test_forwards_build_timeout_to_create_build_sandbox(self):
@@ -497,6 +511,7 @@ class TestBuildImage:
             patch("src.scheduler.image_builder.validate_control_plane_url", return_value=True),
             patch("src.scheduler.image_builder.resolve_clone_token", return_value="gh-token"),
             patch("src.sandbox.manager.SandboxManager", return_value=manager),
+            patch("src.scheduler.image_builder.log") as mock_log,
             patch(
                 "src.scheduler.image_builder._callback_with_retry",
                 new_callable=AsyncMock,
@@ -520,6 +535,18 @@ class TestBuildImage:
         assert failure_payload == {
             "build_id": "img-1",
             "error": "Timed out waiting for image to be created",
+        }
+        event_call = next(
+            call for call in mock_log.error.call_args_list if call.args == ("image_build.complete",)
+        )
+        assert event_call.kwargs == {
+            "build_id": "img-1",
+            "scope_kind": "repo",
+            "scope_id": "acme/repo",
+            "outcome": "error",
+            "error": "Timed out waiting for image to be created",
+            "duration_seconds": pytest.approx(event_call.kwargs["duration_seconds"]),
+            "repository_count": 1,
         }
 
     @pytest.mark.asyncio

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -319,8 +319,11 @@ class AgentBridge:
 
         try:
             while not self.shutdown_event.is_set():
+                run_outcome = "shutdown"
                 try:
                     await self._connect_and_run()
+                    if not self.shutdown_event.is_set():
+                        run_outcome = "connection_closed"
                     reconnect_attempts = 0
                 except SessionTerminatedError:
                     run_outcome = "session_terminated"
@@ -453,31 +456,29 @@ class AgentBridge:
             ) as ws:
                 self.ws = ws
                 self._mark_connected()
-                self.log.info(
-                    "bridge.connect",
-                    outcome="success",
-                    connection_count=self._connection_count,
-                    reconnect_count=max(0, self._connection_count - 1),
-                    reconnect_attempt_count=self._reconnect_attempt_count,
-                )
-
-                await self._send_event(
-                    {
-                        "type": "ready",
-                        "sandboxId": self.sandbox_id,
-                        "opencodeSessionId": self.opencode_session_id,
-                    }
-                )
-
-                await self._drain_boot_warnings()
-
-                just_flushed = await self._flush_event_buffer()
-                await self._flush_pending_acks(skip_ack_ids=just_flushed)
-
-                heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+                heartbeat_task: asyncio.Task[None] | None = None
                 background_tasks: set[asyncio.Task[None]] = set()
 
                 try:
+                    self.log.info(
+                        "bridge.connect",
+                        outcome="success",
+                        connection_count=self._connection_count,
+                        reconnect_count=max(0, self._connection_count - 1),
+                        reconnect_attempt_count=self._reconnect_attempt_count,
+                    )
+                    await self._send_event(
+                        {
+                            "type": "ready",
+                            "sandboxId": self.sandbox_id,
+                            "opencodeSessionId": self.opencode_session_id,
+                        }
+                    )
+                    await self._drain_boot_warnings()
+                    just_flushed = await self._flush_event_buffer()
+                    await self._flush_pending_acks(skip_ack_ids=just_flushed)
+
+                    heartbeat_task = asyncio.create_task(self._heartbeat_loop())
                     async for message in ws:
                         if self.shutdown_event.is_set():
                             break
@@ -502,7 +503,8 @@ class AgentBridge:
                     raise
 
                 finally:
-                    heartbeat_task.cancel()
+                    if heartbeat_task is not None:
+                        heartbeat_task.cancel()
                     for task in background_tasks:
                         task.cancel()
                     self.ws = None

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -278,6 +278,10 @@ class AgentBridge:
         self._pending_acks: dict[str, dict[str, Any]] = {}
 
         self._last_forwarded_session_title: str | None = None
+        self._connected_at_monotonic: float | None = None
+        self._connection_count = 0
+        self._reconnect_attempt_count = 0
+        self._total_connected_duration_seconds = 0.0
 
     @property
     def ws_url(self) -> str:
@@ -311,41 +315,29 @@ class AgentBridge:
         await self._load_session_id()
 
         reconnect_attempts = 0
+        run_outcome = "shutdown"
 
         try:
             while not self.shutdown_event.is_set():
                 try:
                     await self._connect_and_run()
                     reconnect_attempts = 0
-                except SessionTerminatedError as e:
-                    # Non-recoverable: session has been terminated by control plane
-                    self.log.info(
-                        "bridge.disconnect",
-                        reason="session_terminated",
-                        detail=str(e),
-                    )
+                except SessionTerminatedError:
+                    run_outcome = "session_terminated"
                     self.shutdown_event.set()
                     break
-                except websockets.ConnectionClosed as e:
-                    self.log.warn(
-                        "bridge.disconnect",
-                        reason="connection_closed",
-                        ws_close_code=e.code,
-                    )
+                except websockets.ConnectionClosed:
+                    run_outcome = "connection_closed"
                 except Exception as e:
                     error_str = str(e)
                     # Check for fatal HTTP errors that shouldn't trigger retry
                     if self._is_fatal_connection_error(error_str):
-                        self.log.error(
-                            "bridge.disconnect",
-                            reason="fatal_error",
-                            exc=e,
-                        )
+                        run_outcome = "fatal_error"
                         self.shutdown_event.set()
                         break
+                    run_outcome = "connection_error"
                     self.log.warn(
-                        "bridge.disconnect",
-                        reason="connection_error",
+                        "bridge.connect_error",
                         detail=error_str,
                     )
 
@@ -353,6 +345,7 @@ class AgentBridge:
                     break
 
                 reconnect_attempts += 1
+                self._reconnect_attempt_count += 1
                 delay = min(
                     self.RECONNECT_BACKOFF_BASE**reconnect_attempts,
                     self.RECONNECT_MAX_DELAY,
@@ -360,6 +353,7 @@ class AgentBridge:
                 self.log.info(
                     "bridge.reconnect",
                     attempt=reconnect_attempts,
+                    reconnect_attempt_count=self._reconnect_attempt_count,
                     delay_s=round(delay, 1),
                 )
                 await asyncio.sleep(delay)
@@ -372,6 +366,50 @@ class AgentBridge:
                     await self._current_prompt_task
             if self.http_client:
                 await self.http_client.aclose()
+            self.log.info(
+                "bridge.run_complete",
+                outcome=run_outcome,
+                connection_count=self._connection_count,
+                reconnect_count=max(0, self._connection_count - 1),
+                reconnect_attempt_count=self._reconnect_attempt_count,
+                total_connected_duration_seconds=round(self._total_connected_duration_seconds, 3),
+            )
+
+    def _mark_connected(self, *, now_monotonic: float | None = None) -> None:
+        self._connection_count += 1
+        self._connected_at_monotonic = time.monotonic() if now_monotonic is None else now_monotonic
+
+    def _finalize_connection(
+        self, *, now_monotonic: float | None = None
+    ) -> dict[str, float | int] | None:
+        if self._connected_at_monotonic is None:
+            return None
+
+        ended_at = time.monotonic() if now_monotonic is None else now_monotonic
+        connection_duration_seconds = max(0.0, ended_at - self._connected_at_monotonic)
+        self._connected_at_monotonic = None
+        self._total_connected_duration_seconds += connection_duration_seconds
+
+        return {
+            "connection_duration_seconds": round(connection_duration_seconds, 3),
+            "total_connected_duration_seconds": round(self._total_connected_duration_seconds, 3),
+            "connection_count": self._connection_count,
+            "reconnect_count": max(0, self._connection_count - 1),
+            "reconnect_attempt_count": self._reconnect_attempt_count,
+        }
+
+    def _log_disconnect(
+        self,
+        *,
+        reason: str,
+        level: str = "info",
+        **fields: Any,
+    ) -> None:
+        connection_fields = self._finalize_connection()
+        if connection_fields is None:
+            return
+        log_method = getattr(self.log, level)
+        log_method("bridge.disconnect", reason=reason, **connection_fields, **fields)
 
     def _is_fatal_connection_error(self, error_str: str) -> bool:
         """Check if a connection error is fatal and shouldn't trigger retry.
@@ -414,7 +452,14 @@ class AgentBridge:
                 ping_timeout=10,
             ) as ws:
                 self.ws = ws
-                self.log.info("bridge.connect", outcome="success")
+                self._mark_connected()
+                self.log.info(
+                    "bridge.connect",
+                    outcome="success",
+                    connection_count=self._connection_count,
+                    reconnect_count=max(0, self._connection_count - 1),
+                    reconnect_attempt_count=self._reconnect_attempt_count,
+                )
 
                 await self._send_event(
                     {
@@ -448,11 +493,31 @@ class AgentBridge:
                         except Exception as e:
                             self.log.error("bridge.command_error", exc=e)
 
+                except websockets.ConnectionClosed as e:
+                    self._log_disconnect(
+                        reason="connection_closed",
+                        level="warn",
+                        ws_close_code=e.code,
+                    )
+                    raise
+
                 finally:
                     heartbeat_task.cancel()
                     for task in background_tasks:
                         task.cancel()
                     self.ws = None
+                    if self._connected_at_monotonic is not None:
+                        close_code = getattr(ws, "close_code", None)
+                        reason = (
+                            "shutdown_requested"
+                            if self.shutdown_event.is_set()
+                            else "connection_closed"
+                        )
+                        level = "warn" if close_code not in (None, 1000, 1001) else "info"
+                        extra_fields = (
+                            {"ws_close_code": close_code} if close_code is not None else {}
+                        )
+                        self._log_disconnect(reason=reason, level=level, **extra_fields)
 
         except InvalidStatus as e:
             status = getattr(getattr(e, "response", None), "status_code", None)

--- a/packages/sandbox-runtime/tests/test_bridge_reconnection.py
+++ b/packages/sandbox-runtime/tests/test_bridge_reconnection.py
@@ -48,6 +48,33 @@ class TestIsFatalConnectionError:
     def test_empty_string_is_not_fatal(self, bridge):
         assert bridge._is_fatal_connection_error("") is False
 
+    def test_connection_aggregate_fields_track_lifetime_and_reconnects(self, bridge):
+        bridge._reconnect_attempt_count = 2
+
+        bridge._mark_connected(now_monotonic=10.0)
+        first = bridge._finalize_connection(now_monotonic=13.25)
+
+        bridge._mark_connected(now_monotonic=20.0)
+        second = bridge._finalize_connection(now_monotonic=21.5)
+
+        assert first == {
+            "connection_duration_seconds": 3.25,
+            "total_connected_duration_seconds": 3.25,
+            "connection_count": 1,
+            "reconnect_count": 0,
+            "reconnect_attempt_count": 2,
+        }
+        assert second == {
+            "connection_duration_seconds": 1.5,
+            "total_connected_duration_seconds": 4.75,
+            "connection_count": 2,
+            "reconnect_count": 1,
+            "reconnect_attempt_count": 2,
+        }
+
+    def test_finalize_connection_returns_none_without_active_connection(self, bridge):
+        assert bridge._finalize_connection(now_monotonic=5.0) is None
+
 
 class TestSessionTerminatedError:
     """Tests for SessionTerminatedError exception."""

--- a/packages/sandbox-runtime/tests/test_bridge_reconnection.py
+++ b/packages/sandbox-runtime/tests/test_bridge_reconnection.py
@@ -1,5 +1,8 @@
 """Tests for bridge reconnection and error handling logic."""
 
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 from sandbox_runtime.bridge import AgentBridge, SessionTerminatedError
@@ -74,6 +77,75 @@ class TestIsFatalConnectionError:
 
     def test_finalize_connection_returns_none_without_active_connection(self, bridge):
         assert bridge._finalize_connection(now_monotonic=5.0) is None
+
+    @pytest.mark.asyncio
+    async def test_pre_loop_cancellation_cleans_up_connection_state(self, bridge, monkeypatch):
+        class ConnectionContext:
+            def __init__(self, ws):
+                self.ws = ws
+
+            async def __aenter__(self):
+                return self.ws
+
+            async def __aexit__(self, *_args):
+                return False
+
+        ws = MagicMock(close_code=None)
+        monkeypatch.setattr(
+            "sandbox_runtime.bridge.websockets.connect",
+            lambda *_args, **_kwargs: ConnectionContext(ws),
+        )
+        bridge.log = MagicMock()
+        bridge._send_event = AsyncMock(side_effect=asyncio.CancelledError)
+
+        with pytest.raises(asyncio.CancelledError):
+            await bridge._connect_and_run()
+
+        assert bridge.ws is None
+        assert bridge._connected_at_monotonic is None
+        bridge.log.info.assert_any_call(
+            "bridge.disconnect",
+            reason="connection_closed",
+            connection_duration_seconds=pytest.approx(0, abs=0.1),
+            total_connected_duration_seconds=pytest.approx(0, abs=0.1),
+            connection_count=1,
+            reconnect_count=0,
+            reconnect_attempt_count=0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_complete_does_not_retain_transient_outcome(self, bridge, monkeypatch):
+        class HttpClient:
+            async def aclose(self):
+                return None
+
+        attempts = 0
+
+        async def connect_and_run():
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("temporary failure")
+            bridge.shutdown_event.set()
+
+        bridge.log = MagicMock()
+        bridge._load_session_id = AsyncMock()
+        bridge._connect_and_run = connect_and_run
+        monkeypatch.setattr(
+            "sandbox_runtime.bridge.httpx.AsyncClient", lambda **_kwargs: HttpClient()
+        )
+        monkeypatch.setattr("sandbox_runtime.bridge.asyncio.sleep", AsyncMock())
+
+        await bridge.run()
+
+        bridge.log.info.assert_any_call(
+            "bridge.run_complete",
+            outcome="shutdown",
+            connection_count=0,
+            reconnect_count=0,
+            reconnect_attempt_count=1,
+            total_connected_duration_seconds=0.0,
+        )
 
 
 class TestSessionTerminatedError:


### PR DESCRIPTION
## Summary
- consolidate sandbox spawn and restore logging into single terminal events with `outcome`, `duration_ms`, and retained context/error fields
- add aggregate WebSocket bridge observability for total connected lifetime, reconnect counts, retry attempts, and terminal run summaries
- collapse modal image-build start/success/failure logs into `image_build.complete` and standardize the duration field to Python seconds via `duration_seconds`
- add terminal start-callback delivery aggregates in the control plane with attempts, retries, duration, and status details
- extend focused tests for successful and failed paths plus aggregate values, and refresh the debugging playbook for the new events

## Verification
- `npm test -w @open-inspect/control-plane -- src/sandbox/lifecycle/manager.test.ts src/session/callback-notification-service.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`
- `npm run build -w @open-inspect/control-plane`
- `PYTHONPATH="src:../sandbox-runtime/src" uv run --extra dev pytest tests/test_image_builder_v2.py`
- `uv run --extra dev ruff check src/scheduler/image_builder.py tests/test_image_builder_v2.py`
- `PYTHONPATH="src" uv run --extra dev pytest tests/test_bridge_reconnection.py`
- `uv run --extra dev ruff check src/sandbox_runtime/bridge.py tests/test_bridge_reconnection.py`

## Notes
- left unrelated untracked workspace content under `.opencode/` untouched
- used `PYTHONPATH` during local verification so the Python tests exercised the repository sources in this sandbox environment

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/1535eb731b7085247444a8f9132ebe19)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Observability**
  * Updated sandbox spawn/restore logging with unified completion entries, including `outcome` and `duration_ms`.
  * Standardized image build lifecycle to a single `image_build.complete` event with `outcome`, `duration_seconds`, and `repository_count`.
  * Enhanced callback delivery logging with `callback.started_delivery`, including retries, attempts, HTTP status, duration, and rejection/error details.
  * Improved bridge websocket logging with reconnect/connection duration tracking plus `bridge.disconnect` and `bridge.run_complete` summaries.
* **Documentation**
  * Refreshed event catalog tables to match renamed/merged lifecycle and logging fields.
* **Tests**
  * Added/updated unit tests to verify the new structured logging contracts and reconnection metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->