### PR TITLE
fix(web): contain attachment layouts on mobile

### DIFF
--- a/packages/web/src/app/(app)/page.test.tsx
+++ b/packages/web/src/app/(app)/page.test.tsx
@@ -137,6 +137,33 @@ function sessionCreateBody(): Record<string, unknown> {
 }
 
 describe("Home", () => {
+  it("keeps the attachment control anchored while the sandbox warms", async () => {
+    let resolveCreate: ((response: Response) => void) | undefined;
+    vi.mocked(fetch).mockImplementation(
+      (input) =>
+        new Promise<Response>((resolve) => {
+          if (String(input) === "/api/sessions") {
+            resolveCreate = resolve;
+          } else {
+            resolve(Response.json({ error: "unexpected request" }, { status: 500 }));
+          }
+        })
+    );
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByPlaceholderText("What do you want to build?"), "I");
+
+    const warmingStatus = await screen.findByText("Warming sandbox...");
+    const attachmentButton = screen.getByRole("button", { name: "Attach images" });
+    expect(
+      warmingStatus.compareDocumentPosition(attachmentButton) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+
+    resolveCreate?.(Response.json({ sessionId: "session-1" }));
+    await waitFor(() => expect(screen.queryByText("Warming sandbox...")).not.toBeInTheDocument());
+  });
+
   it("can start a new session without a repository from the primary selector", async () => {
     const user = userEvent.setup();
     render(<Home />);

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -433,6 +433,11 @@ function HomeContent({
                   />
                   {/* Submit button */}
                   <div className="absolute bottom-3 right-3 flex items-center gap-2">
+                    {isCreatingSession && (
+                      <span className="whitespace-nowrap text-xs text-accent">
+                        Warming sandbox...
+                      </span>
+                    )}
                     <button
                       type="button"
                       onClick={() => fileInputRef.current?.click()}
@@ -443,9 +448,6 @@ function HomeContent({
                     >
                       <PaperclipIcon className="w-5 h-5" />
                     </button>
-                    {isCreatingSession && (
-                      <span className="text-xs text-accent">Warming sandbox...</span>
-                    )}
                     <button
                       type="submit"
                       disabled={

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -155,7 +155,7 @@ function SessionPageContent() {
   const showTimelineSkeleton = events.length === 0 && (connecting || replaying);
 
   return (
-    <div className="h-full flex flex-col">
+    <div className="h-full min-w-0 overflow-x-hidden flex flex-col">
       <SessionHeader
         sessionState={sessionState}
         fallbackSessionInfo={fallbackSessionInfo}
@@ -181,8 +181,8 @@ function SessionPageContent() {
       )}
 
       {/* Main content */}
-      <main className="flex-1 flex overflow-hidden">
-        <div className="flex-1 flex flex-col overflow-hidden">
+      <main className="min-w-0 flex-1 flex overflow-hidden">
+        <div className="min-w-0 flex-1 flex flex-col overflow-hidden">
           <PanelGroup orientation="vertical" id="session-terminal">
             {/* Chat / Event Timeline */}
             <Panel defaultSize={showTerminal ? "70%" : "100%"} minSize="30%">

--- a/packages/web/src/components/session-prompt-composer.tsx
+++ b/packages/web/src/components/session-prompt-composer.tsx
@@ -69,8 +69,8 @@ export function SessionPromptComposer({
   } = useAttachmentDropZone({ locked: attachmentsLocked, onAdd: attachments.onAdd });
 
   return (
-    <footer className="border-t border-border-muted flex-shrink-0">
-      <form onSubmit={prompt.onSubmit} className="max-w-4xl mx-auto p-4 pb-6">
+    <footer className="min-w-0 border-t border-border-muted flex-shrink-0">
+      <form onSubmit={prompt.onSubmit} className="w-full min-w-0 max-w-4xl mx-auto p-4 pb-6">
         {/* Action bar above input */}
         <div className="mb-3">
           <ActionBar
@@ -116,10 +116,10 @@ export function SessionPromptComposer({
             {/* Floating action buttons */}
             <div className="absolute bottom-3 right-3 flex items-center gap-2">
               {attachments.isUploading && (
-                <span className="text-xs text-muted-foreground">Uploading…</span>
+                <span className="whitespace-nowrap text-xs text-muted-foreground">Uploading…</span>
               )}
               {prompt.isProcessing && prompt.value.trim() && (
-                <span className="text-xs text-warning">Waiting...</span>
+                <span className="whitespace-nowrap text-xs text-warning">Waiting...</span>
               )}
               <input
                 ref={fileInputRef}

--- a/packages/web/src/components/session-timeline.tsx
+++ b/packages/web/src/components/session-timeline.tsx
@@ -177,7 +177,7 @@ export function SessionTimeline({
       onScroll={handleScroll}
       className="h-full overflow-y-auto overflow-x-hidden p-4"
     >
-      <div className="max-w-3xl mx-auto space-y-2">
+      <div className="w-full min-w-0 max-w-3xl mx-auto space-y-2">
         <div ref={topSentinelRef} className="h-1" />
         {loadingHistory && (
           <div className="text-center text-muted-foreground text-sm py-2">Loading...</div>
@@ -352,7 +352,7 @@ function UserMessageAttachments({
   sessionId: string;
 }) {
   return (
-    <div className="flex flex-wrap gap-2 mt-3">
+    <div className="min-w-0 max-w-full flex flex-wrap gap-2 mt-3">
       {attachments.map((attachment, index) => {
         return (
           <img
@@ -362,7 +362,7 @@ function UserMessageAttachments({
             title={attachment.name}
             loading="lazy"
             decoding="async"
-            className="max-h-48 max-w-full border border-border object-contain"
+            className="block h-auto max-h-48 max-w-full border border-border object-contain"
           />
         );
       })}

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -188,7 +188,7 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
               onSessionSelect={sidebar.close}
             />
           </div>
-          <main className="flex-1 overflow-hidden">{children}</main>
+          <main className="min-w-0 flex-1 overflow-hidden">{children}</main>
         </div>
         <GlobalCommandMenu
           open={isCommandMenuOpen}


### PR DESCRIPTION
## Summary
- keep the dashboard warming status to the left of the attachment control so the paperclip remains anchored
- add explicit flex and image width containment across the app shell, session page, composer, and timeline
- add a regression test for dashboard action ordering during sandbox warming

## Verification
- `npm test -w @open-inspect/web` (807 tests passed)
- `npm run lint -w @open-inspect/web`
- `npm run typecheck -w @open-inspect/web`
- `git diff --check`
- visually verified dashboard and session attachment states at 390x844 and 1440x900; document and body scroll widths matched each viewport

## Visual artifacts
- Mobile dashboard: `1902f4cd7c70bb7c6e93b78fe001d777`
- Mobile session: `4e27482e555755fe66a3d44548159021`
- Desktop dashboard: `918694fae8f30a883a3b6f884721255e`
- Desktop session: `c918573102b31ad98651ef25ef85bb0c`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/28f43d2d26e227ca69c4cc68c485185a)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible “Warming sandbox…” status while a new session is being prepared.
  * Kept the “Attach images” control anchored consistently during session startup.

* **Bug Fixes**
  * Improved responsive layout behavior across session views, sidebars, timelines, and prompt controls.
  * Prevented status labels from wrapping unexpectedly.
  * Improved image attachment sizing and overflow handling.

* **Tests**
  * Added coverage verifying attachment control positioning while the sandbox warms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->