### PR TITLE
Fix warning event filtering in control plane

### DIFF
--- a/packages/control-plane/src/session/http/handlers/messages.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/messages.handler.ts
@@ -12,6 +12,7 @@ const VALID_EVENT_TYPES = [
   "tool_result",
   "token",
   "error",
+  "warning",
   "git_sync",
   "step_start",
   "step_finish",

--- a/packages/control-plane/test/integration/events-messages-list.test.ts
+++ b/packages/control-plane/test/integration/events-messages-list.test.ts
@@ -192,6 +192,33 @@ describe("GET /internal/events", () => {
       expect(event.type).toBe("tool_call");
     }
   });
+
+  it("filters warning events", async () => {
+    const { stub } = await initSession();
+    const baseTime = Date.now();
+
+    await seedEvents(stub, [
+      {
+        id: "evt-warning",
+        type: "warning",
+        data: JSON.stringify({ type: "warning", scope: "media", message: "Upload skipped" }),
+        createdAt: baseTime,
+      },
+      {
+        id: "evt-error",
+        type: "error",
+        data: JSON.stringify({ type: "error", message: "Upload failed" }),
+        createdAt: baseTime + 1,
+      },
+    ]);
+
+    const res = await stub.fetch("http://internal/internal/events?type=warning");
+    expect(res.status).toBe(200);
+
+    const body = await res.json<{ events: Array<{ id: string; type: string }> }>();
+    expect(body.events.map((event) => event.id)).toEqual(["evt-warning"]);
+    expect(body.events[0]?.type).toBe("warning");
+  });
 });
 
 describe("GET /internal/messages", () => {


### PR DESCRIPTION
## Summary

- add the shared `warning` event type to the control-plane event filter allowlist
- add integration coverage proving `/internal/events?type=warning` is accepted and returns only warning events

## Verification

- `npm test -w @open-inspect/control-plane -- src/session/http/handlers/messages.handler.test.ts`
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/events-messages-list.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`
- `npx eslint packages/control-plane/test/integration/events-messages-list.test.ts`
- `npx prettier --check packages/control-plane/src/session/http/handlers/messages.handler.ts packages/control-plane/test/integration/events-messages-list.test.ts`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/1630961bbd2a6d27b06191a1b6e74642)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for filtering events by the `warning` type.
  * Requests using `type=warning` now return matching warning events instead of being rejected as invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->