### PR TITLE
fix(control-plane): preserve message history attachments

### DIFF
--- a/packages/control-plane/src/session/http/handlers/messages.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/messages.handler.test.ts
@@ -221,30 +221,26 @@ describe("createMessagesHandler", () => {
     expect(await response.json()).toEqual({ error: "Invalid message status: invalid" });
   });
 
-  it("maps listMessages response", async () => {
+  it("returns listMessages response", async () => {
     const { handler, messageService } = createHandler();
     vi.mocked(messageService.listMessages).mockReturnValue({
       messages: [
         {
           id: "m1",
-          author_id: "p1",
+          authorId: "p1",
           content: "hello",
           source: "web",
-          model: null,
-          reasoning_effort: null,
-          attachments: JSON.stringify([
+          attachments: [
             {
               name: "screenshot.png",
               attachmentId: "attachment-1",
               mimeType: "image/png",
             },
-          ]),
-          callback_context: null,
+          ],
           status: "completed",
-          error_message: null,
-          created_at: 1000,
-          started_at: 1100,
-          completed_at: 1200,
+          createdAt: 1000,
+          startedAt: 1100,
+          completedAt: 1200,
         },
       ],
       cursor: "1000",
@@ -284,18 +280,14 @@ describe("createMessagesHandler", () => {
       messages: [
         {
           id: "m1",
-          author_id: "p1",
+          authorId: "p1",
           content: "hello",
           source: "web",
-          model: null,
-          reasoning_effort: null,
           attachments: null,
-          callback_context: null,
           status: "completed",
-          error_message: null,
-          created_at: 1000,
-          started_at: null,
-          completed_at: null,
+          createdAt: 1000,
+          startedAt: null,
+          completedAt: null,
         },
       ],
       cursor: "1000",

--- a/packages/control-plane/src/session/http/handlers/messages.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/messages.handler.test.ts
@@ -232,7 +232,13 @@ describe("createMessagesHandler", () => {
           source: "web",
           model: null,
           reasoning_effort: null,
-          attachments: null,
+          attachments: JSON.stringify([
+            {
+              name: "screenshot.png",
+              attachmentId: "attachment-1",
+              mimeType: "image/png",
+            },
+          ]),
           callback_context: null,
           status: "completed",
           error_message: null,
@@ -254,6 +260,13 @@ describe("createMessagesHandler", () => {
           authorId: "p1",
           content: "hello",
           source: "web",
+          attachments: [
+            {
+              name: "screenshot.png",
+              attachmentId: "attachment-1",
+              mimeType: "image/png",
+            },
+          ],
           status: "completed",
           createdAt: 1000,
           startedAt: 1100,
@@ -262,6 +275,37 @@ describe("createMessagesHandler", () => {
       ],
       cursor: "1000",
       hasMore: false,
+    });
+  });
+
+  it("includes null attachments when a message has none", async () => {
+    const { handler, messageService } = createHandler();
+    vi.mocked(messageService.listMessages).mockReturnValue({
+      messages: [
+        {
+          id: "m1",
+          author_id: "p1",
+          content: "hello",
+          source: "web",
+          model: null,
+          reasoning_effort: null,
+          attachments: null,
+          callback_context: null,
+          status: "completed",
+          error_message: null,
+          created_at: 1000,
+          started_at: null,
+          completed_at: null,
+        },
+      ],
+      cursor: "1000",
+      hasMore: false,
+    });
+
+    const response = handler.listMessages(new URL("http://internal/internal/messages"));
+
+    await expect(response.json()).resolves.toMatchObject({
+      messages: [{ attachments: null }],
     });
   });
 

--- a/packages/control-plane/src/session/http/handlers/messages.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/messages.handler.ts
@@ -1,3 +1,4 @@
+import { resolvedSessionAttachmentsSchema } from "@open-inspect/shared";
 import type { Logger } from "../../../logger";
 import type { EnqueuePromptRequest, MessageService } from "../../services/message.service";
 import { parseEventListCursor } from "../../event-cursor";
@@ -115,6 +116,9 @@ export function createMessagesHandler(deps: MessagesHandlerDeps): MessagesHandle
           authorId: message.author_id,
           content: message.content,
           source: message.source,
+          attachments: message.attachments
+            ? resolvedSessionAttachmentsSchema.parse(JSON.parse(message.attachments))
+            : null,
           status: message.status,
           createdAt: message.created_at,
           startedAt: message.started_at,

--- a/packages/control-plane/src/session/http/handlers/messages.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/messages.handler.ts
@@ -1,4 +1,3 @@
-import { resolvedSessionAttachmentsSchema } from "@open-inspect/shared";
 import type { Logger } from "../../../logger";
 import type { EnqueuePromptRequest, MessageService } from "../../services/message.service";
 import { parseEventListCursor } from "../../event-cursor";
@@ -110,23 +109,7 @@ export function createMessagesHandler(deps: MessagesHandlerDeps): MessagesHandle
 
       const result = deps.messageService.listMessages({ cursor, limit, status });
 
-      return Response.json({
-        messages: result.messages.map((message) => ({
-          id: message.id,
-          authorId: message.author_id,
-          content: message.content,
-          source: message.source,
-          attachments: message.attachments
-            ? resolvedSessionAttachmentsSchema.parse(JSON.parse(message.attachments))
-            : null,
-          status: message.status,
-          createdAt: message.created_at,
-          startedAt: message.started_at,
-          completedAt: message.completed_at,
-        })),
-        cursor: result.cursor,
-        hasMore: result.hasMore,
-      });
+      return Response.json(result);
     },
   };
 }

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -6,7 +6,6 @@ import {
   getDefaultReasoningEffort,
   getValidModelOrDefault,
   isValidModel,
-  resolvedSessionAttachmentsSchema,
   type SessionAttachmentReference,
   type ResolvedSessionAttachment,
 } from "@open-inspect/shared";
@@ -31,7 +30,11 @@ import type { CallbackNotificationService } from "./callback-notification-servic
 import type { EnqueuePromptRequest } from "./services/message.service";
 import { getAvatarUrl } from "./participant-service";
 import { resolveParticipantName } from "./participant-name";
-import { SessionAttachmentError, resolveSessionAttachments } from "./session-attachment-resolver";
+import {
+  parseStoredSessionAttachments,
+  SessionAttachmentError,
+  resolveSessionAttachments,
+} from "./session-attachment-resolver";
 
 interface PromptMessageData {
   content: string;
@@ -197,7 +200,9 @@ export class SessionMessageQueue {
         scmName: author?.scm_name ?? null,
         scmEmail: author?.scm_email ?? null,
       },
-      attachments: this.parseStoredAttachments(message.attachments),
+      attachments: parseStoredSessionAttachments(message.attachments, () =>
+        this.deps.log.error("prompt.invalid_stored_attachments")
+      ),
     };
 
     const sent = this.deps.wsManager.send(sandboxWs, command);
@@ -307,23 +312,6 @@ export class SessionMessageQueue {
       this.deps.callbackService.notifyComplete(processingMessage.id, false, stuckError)
     );
     await this.deps.reconcileSessionStatusAfterExecution(false);
-  }
-
-  private parseStoredAttachments(value: string | null): ResolvedSessionAttachment[] | undefined {
-    if (!value) return undefined;
-    let raw: unknown;
-    try {
-      raw = JSON.parse(value);
-    } catch {
-      this.deps.log.error("prompt.invalid_stored_attachments");
-      return undefined;
-    }
-    const parsed = resolvedSessionAttachmentsSchema.safeParse(raw);
-    if (!parsed.success) {
-      this.deps.log.error("prompt.invalid_stored_attachments");
-      return undefined;
-    }
-    return parsed.data;
   }
 
   writeUserMessageEvent(

--- a/packages/control-plane/src/session/services/message.service.test.ts
+++ b/packages/control-plane/src/session/services/message.service.test.ts
@@ -175,7 +175,13 @@ describe("MessageService", () => {
         source: "web",
         model: null,
         reasoning_effort: null,
-        attachments: null,
+        attachments: JSON.stringify([
+          {
+            name: "screenshot.png",
+            attachmentId: "attachment-1",
+            mimeType: "image/png",
+          },
+        ]),
         callback_context: null,
         status: "pending",
         error_message: null,
@@ -190,7 +196,7 @@ describe("MessageService", () => {
         source: "web",
         model: null,
         reasoning_effort: null,
-        attachments: null,
+        attachments: "invalid-json",
         callback_context: null,
         status: "pending",
         error_message: null,
@@ -221,6 +227,14 @@ describe("MessageService", () => {
     expect(result.hasMore).toBe(true);
     expect(result.cursor).toBe("2000");
     expect(result.messages).toHaveLength(2);
+    expect(result.messages[0]?.attachments).toEqual([
+      {
+        name: "screenshot.png",
+        attachmentId: "attachment-1",
+        mimeType: "image/png",
+      },
+    ]);
+    expect(result.messages[1]?.attachments).toBeNull();
     expect(repository.listMessages).toHaveBeenCalledWith({
       cursor: null,
       limit: 2,

--- a/packages/control-plane/src/session/services/message.service.ts
+++ b/packages/control-plane/src/session/services/message.service.ts
@@ -1,9 +1,10 @@
-import type { ArtifactRow, MessageRow } from "../types";
-import type { SessionAttachmentReference } from "@open-inspect/shared";
+import type { ArtifactRow } from "../types";
+import type { SessionAttachmentReference, SessionMessage } from "@open-inspect/shared";
 import type { ArtifactResponse, ListEventsResponse } from "../../types";
 import type { SessionRepository } from "../repository";
 import type { SessionMessageQueue } from "../message-queue";
 import { SessionEventStream, type SessionEventListRequest } from "../event-stream";
+import { parseStoredSessionAttachments } from "../session-attachment-resolver";
 
 export interface EnqueuePromptRequest {
   content: string;
@@ -105,7 +106,7 @@ export class MessageService {
   }
 
   listMessages(request: ListMessagesRequest): {
-    messages: MessageRow[];
+    messages: SessionMessage[];
     cursor: string | undefined;
     hasMore: boolean;
   } {
@@ -118,7 +119,17 @@ export class MessageService {
     if (hasMore) messages.pop();
 
     return {
-      messages,
+      messages: messages.map((message) => ({
+        id: message.id,
+        authorId: message.author_id,
+        content: message.content,
+        source: message.source,
+        attachments: parseStoredSessionAttachments(message.attachments) ?? null,
+        status: message.status,
+        createdAt: message.created_at,
+        startedAt: message.started_at,
+        completedAt: message.completed_at,
+      })),
       cursor: messages.length > 0 ? messages[messages.length - 1].created_at.toString() : undefined,
       hasMore,
     };

--- a/packages/control-plane/src/session/session-attachment-resolver.ts
+++ b/packages/control-plane/src/session/session-attachment-resolver.ts
@@ -1,4 +1,5 @@
 import {
+  resolvedSessionAttachmentsSchema,
   sessionAttachmentMimeTypeSchema,
   type SessionAttachmentReference,
   type ResolvedSessionAttachment,
@@ -13,6 +14,21 @@ export interface ResolvedSessionAttachments {
 }
 
 type SessionAttachmentLookup = Pick<SessionAttachmentRepository, "getUnreferenced">;
+
+export function parseStoredSessionAttachments(
+  value: string | null,
+  onInvalid?: () => void
+): ResolvedSessionAttachment[] | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed = resolvedSessionAttachmentsSchema.safeParse(JSON.parse(value));
+    if (parsed.success) return parsed.data;
+  } catch {
+    // Report malformed JSON through the same callback as invalid attachment metadata.
+  }
+  onInvalid?.();
+  return undefined;
+}
 
 /** Resolve client references against canonical, unclaimed attachment rows. */
 export function resolveSessionAttachments(


### PR DESCRIPTION
## Summary
- include the required `attachments` field in `/internal/messages` responses
- parse stored attachment JSON with the shared resolved attachment schema
- return `null` when a message has no attachments
- add focused regression coverage for populated and null attachment values

## Verification
- `npm test -w @open-inspect/control-plane`
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/events-messages-list.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `npx eslint packages/control-plane/src/session/http/handlers/messages.handler.ts packages/control-plane/src/session/http/handlers/messages.handler.test.ts`
- `npx prettier --check packages/control-plane/src/session/http/handlers/messages.handler.ts packages/control-plane/src/session/http/handlers/messages.handler.test.ts`
- `git diff --check origin/main...HEAD`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/69472daaea07337db10556632026e40a)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Message listing now preserves and returns message data in the expected shape, including attachment details when present.
  - Messages without attachments consistently return `attachments: null`.
  - Attachment payloads are now safely parsed/validated before being included in responses and during sandbox dispatch.
- **Tests**
  - Updated and expanded message-listing tests to cover valid attachment payloads and malformed/invalid attachment data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->