### PR TITLE
fix(control-plane): normalize empty stored attachments

### DIFF
--- a/packages/control-plane/src/session/services/message.service.test.ts
+++ b/packages/control-plane/src/session/services/message.service.test.ts
@@ -241,4 +241,29 @@ describe("MessageService", () => {
       status: "pending",
     });
   });
+
+  it("returns null attachments for a stored empty array", () => {
+    const { service, repository } = createService();
+    vi.mocked(repository.listMessages).mockReturnValue([
+      {
+        id: "m1",
+        author_id: "p1",
+        content: "hello",
+        source: "web",
+        model: null,
+        reasoning_effort: null,
+        attachments: "[]",
+        callback_context: null,
+        status: "pending",
+        error_message: null,
+        created_at: 1000,
+        started_at: null,
+        completed_at: null,
+      },
+    ]);
+
+    const result = service.listMessages({ cursor: null, limit: 1, status: null });
+
+    expect(result.messages).toEqual([expect.objectContaining({ attachments: null })]);
+  });
 });

--- a/packages/control-plane/src/session/session-attachment-resolver.test.ts
+++ b/packages/control-plane/src/session/session-attachment-resolver.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { parseStoredSessionAttachments } from "./session-attachment-resolver";
+
+describe("parseStoredSessionAttachments", () => {
+  it("normalizes a stored empty array to undefined", () => {
+    expect(parseStoredSessionAttachments("[]")).toBeUndefined();
+  });
+});

--- a/packages/control-plane/src/session/session-attachment-resolver.ts
+++ b/packages/control-plane/src/session/session-attachment-resolver.ts
@@ -22,7 +22,7 @@ export function parseStoredSessionAttachments(
   if (!value) return undefined;
   try {
     const parsed = resolvedSessionAttachmentsSchema.safeParse(JSON.parse(value));
-    if (parsed.success) return parsed.data;
+    if (parsed.success) return parsed.data.length > 0 ? parsed.data : undefined;
   } catch {
     // Report malformed JSON through the same callback as invalid attachment metadata.
   }


### PR DESCRIPTION
## Summary
- normalize persisted empty attachment arrays to `undefined` in `parseStoredSessionAttachments`
- preserve the API contract that messages without attachments expose `attachments: null`
- add focused regression coverage for stored `[]` values

## Verification
- `npm test -w @open-inspect/control-plane -- src/session/session-attachment-resolver.test.ts src/session/services/message.service.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/595aad070ecfd0064ea83b101017d533)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stored session attachment metadata with an empty `data` payload is now treated as absent, so messages no longer surface empty attachment lists.
* **Tests**
  * Added unit coverage to ensure stored empty attachment arrays (`"[]"`) are normalized consistently (attachments become null/absent rather than an empty array).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->