### PR TITLE
feat: add Superserve sandbox provider

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -14,6 +14,7 @@ on:
       - "packages/daytona-infra/**"
       - "packages/opencomputer-infra/**"
       - "packages/e2b-infra/**"
+      - "packages/superserve-infra/**"
       - "packages/sandbox-runtime/**"
       - "packages/shared/**"
       - "packages/web/**" # Web app deployed via Terraform when web_platform = "cloudflare"
@@ -31,6 +32,7 @@ on:
       - "packages/daytona-infra/**"
       - "packages/opencomputer-infra/**"
       - "packages/e2b-infra/**"
+      - "packages/superserve-infra/**"
       - "packages/sandbox-runtime/**"
       - "packages/shared/**"
       - "packages/web/**"
@@ -251,6 +253,13 @@ jobs:
           TF_VAR_e2b_api_url: "${{ secrets.E2B_API_URL || 'https://api.e2b.app' }}"
           TF_VAR_e2b_sandbox_timeout_seconds: "${{ secrets.E2B_SANDBOX_TIMEOUT_SECONDS || '7200' }}"
           TF_VAR_e2b_auto_pause: "${{ secrets.E2B_AUTO_PAUSE || 'true' }}"
+          TF_VAR_superserve_api_url: "${{ secrets.SUPERSERVE_API_URL || 'https://api.superserve.ai' }}"
+          TF_VAR_superserve_api_key: ${{ secrets.SUPERSERVE_API_KEY }}
+          TF_VAR_superserve_template: ${{ secrets.SUPERSERVE_TEMPLATE }}
+          TF_VAR_superserve_sandbox_host: "${{ secrets.SUPERSERVE_SANDBOX_HOST || 'sandbox.superserve.ai' }}"
+          TF_VAR_superserve_auto_delete_seconds: "${{ secrets.SUPERSERVE_AUTO_DELETE_SECONDS || 'null' }}"
+          TF_VAR_superserve_network_allow_out: "${{ secrets.SUPERSERVE_NETWORK_ALLOW_OUT || '[]' }}"
+          TF_VAR_superserve_network_deny_out: "${{ secrets.SUPERSERVE_NETWORK_DENY_OUT || '[]' }}"
 
       - name: Post Plan Results
         uses: actions/github-script@v8
@@ -407,6 +416,13 @@ jobs:
           TF_VAR_e2b_api_url: "${{ secrets.E2B_API_URL || 'https://api.e2b.app' }}"
           TF_VAR_e2b_sandbox_timeout_seconds: "${{ secrets.E2B_SANDBOX_TIMEOUT_SECONDS || '7200' }}"
           TF_VAR_e2b_auto_pause: "${{ secrets.E2B_AUTO_PAUSE || 'true' }}"
+          TF_VAR_superserve_api_url: "${{ secrets.SUPERSERVE_API_URL || 'https://api.superserve.ai' }}"
+          TF_VAR_superserve_api_key: ${{ secrets.SUPERSERVE_API_KEY }}
+          TF_VAR_superserve_template: ${{ secrets.SUPERSERVE_TEMPLATE }}
+          TF_VAR_superserve_sandbox_host: "${{ secrets.SUPERSERVE_SANDBOX_HOST || 'sandbox.superserve.ai' }}"
+          TF_VAR_superserve_auto_delete_seconds: "${{ secrets.SUPERSERVE_AUTO_DELETE_SECONDS || 'null' }}"
+          TF_VAR_superserve_network_allow_out: "${{ secrets.SUPERSERVE_NETWORK_ALLOW_OUT || '[]' }}"
+          TF_VAR_superserve_network_deny_out: "${{ secrets.SUPERSERVE_NETWORK_DENY_OUT || '[]' }}"
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ built for internal use where all employees are trusted and have access to compan
 | [modal-infra](packages/modal-infra)               | Modal sandbox infrastructure                |
 | [daytona-infra](packages/daytona-infra)           | Daytona snapshot infrastructure             |
 | [opencomputer-infra](packages/opencomputer-infra) | OpenComputer template infrastructure        |
+| [superserve-infra](packages/superserve-infra)     | Superserve template infrastructure          |
 | [slack-bot](packages/slack-bot)                   | Slack integration (sessions from messages)  |
 | [github-bot](packages/github-bot)                 | GitHub integration (auto-review, @mention)  |
 | [linear-bot](packages/linear-bot)                 | Linear integration (issue → coding session) |
@@ -290,6 +291,7 @@ built with:
 - [Daytona](https://www.daytona.io) - Cloud development sandboxes
 - [Vercel Sandbox](https://vercel.com/docs/vercel-sandbox) - Cloud sandbox infrastructure
 - [OpenComputer](https://www.opencomputer.dev) - Cloud sandbox infrastructure
+- [Superserve](https://superserve.ai) - Firecracker microVM sandbox infrastructure
 - [Cloudflare Workers](https://workers.cloudflare.com) - Edge computing
 - [OpenCode](https://opencode.ai) - Coding agent runtime
 - [Next.js](https://nextjs.org) - Web framework

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -45,6 +45,7 @@ Create accounts on these services before continuing:
 | [Vercel Sandboxes](https://vercel.com) _(optional)_       | Sandbox infrastructure when `sandbox_provider = "vercel"`       |
 | [OpenComputer](https://app.opencomputer.dev) _(optional)_ | Sandbox infrastructure when `sandbox_provider = "opencomputer"` |
 | [E2B](https://e2b.dev) _(optional)_                       | Sandbox infrastructure when `sandbox_provider = "e2b"`          |
+| [Superserve](https://superserve.ai) _(optional)_          | Sandbox infrastructure when `sandbox_provider = "superserve"`   |
 | [GitHub](https://github.com/settings/developers)          | OAuth + repository access                                       |
 | [Anthropic](https://console.anthropic.com)                | Claude API                                                      |
 | [Slack](https://api.slack.com/apps) _(optional)_          | Slack bot integration                                           |
@@ -259,6 +260,21 @@ For the full runtime, lifecycle, and configuration model, see
 > **Important**: The E2B provider does not automatically inject LLM API keys into sandboxes. If you
 > plan to use Claude models, add `ANTHROPIC_API_KEY` as a **global secret** in Settings > Secrets
 > after deploying. See [Secrets Management](SECRETS.md) for details.
+
+### Superserve
+
+> Only required when `sandbox_provider = "superserve"`.
+
+1. Create a Superserve API key.
+2. Set `sandbox_provider = "superserve"` in `terraform.tfvars`.
+3. Set `superserve_api_url`, `superserve_api_key`, and the matching regional
+   `superserve_sandbox_host`.
+4. Leave `superserve_template = ""` to let Terraform build the Open-Inspect runtime template, or set
+   it to an existing Superserve template name.
+5. Run `terraform apply`.
+
+See [Superserve Sandbox Provider](SUPERSERVE_PROVIDER.md) for lifecycle, egress policy, template
+build, cron, and MVP security-boundary details.
 
 ### Anthropic
 
@@ -493,7 +509,7 @@ modal_workspace             = "your-modal-workspace"
 modal_environment           = "your-modal-environment"
 modal_environment_web_suffix = "your-modal-web-suffix" # Lowercase letters, digits, dashes; empty for https://workspace--... endpoints
 
-# Sandbox provider: "modal" (default), "daytona", or "vercel"
+# Sandbox provider: "modal" (default), "daytona", "vercel", "opencomputer", or "superserve"
 # sandbox_provider          = "modal"
 
 # Daytona (only required when sandbox_provider = "daytona")
@@ -512,6 +528,12 @@ modal_environment_web_suffix = "your-modal-web-suffix" # Lowercase letters, digi
 # E2B (only required when sandbox_provider = "e2b")
 # e2b_api_key               = "your-e2b-api-key"        # runtime REST API key (also auths the build)
 # e2b_template_id           = "open-inspect-sandbox"
+
+# Superserve (only required when sandbox_provider = "superserve")
+# superserve_api_url      = "https://api.superserve.ai"
+# superserve_api_key      = "ss_live_..."
+# superserve_sandbox_host = "sandbox.superserve.ai"
+# superserve_template     = "" # Empty builds a managed runtime template
 
 # GitHub App (used for both OAuth and repository access)
 github_client_id     = "Iv1.abc123..."           # From GitHub App settings
@@ -918,7 +940,7 @@ Go to your fork's Settings → Secrets and variables → Actions, and add:
 | `MODAL_WORKSPACE`                | Modal workspace name                                                                        |
 | `MODAL_ENVIRONMENT`              | Modal environment name (defaults to `main`)                                                 |
 | `MODAL_ENVIRONMENT_WEB_SUFFIX`   | Modal environment web suffix for endpoint URLs; lowercase letters, digits, dashes, or empty |
-| `SANDBOX_PROVIDER`               | `modal`, `daytona`, or `vercel`                                                             |
+| `SANDBOX_PROVIDER`               | `modal`, `daytona`, `vercel`, `opencomputer`, or `superserve`                               |
 | `DAYTONA_API_URL`                | Daytona API URL _(only if `sandbox_provider = "daytona"`)_                                  |
 | `DAYTONA_API_KEY`                | Daytona API key _(only if `sandbox_provider = "daytona"`)_                                  |
 | `DAYTONA_BASE_SNAPSHOT`          | Daytona base snapshot name _(only if `sandbox_provider = "daytona"`)_                       |
@@ -930,6 +952,13 @@ Go to your fork's Settings → Secrets and variables → Actions, and add:
 | `VERCEL_SANDBOX_RUNTIME`         | Optional Vercel Sandbox runtime (defaults to `node24`)                                      |
 | `VERCEL_SNAPSHOT_EXPIRATION_MS`  | Optional Vercel runtime snapshot expiration in milliseconds (`0` means no expiration)       |
 | `VERCEL_SANDBOX_API_BASE_URL`    | Optional advanced Vercel Sandbox API base URL override                                      |
+| `SUPERSERVE_API_URL`             | Superserve API URL _(only if `sandbox_provider = "superserve"`)_                            |
+| `SUPERSERVE_API_KEY`             | Superserve API key _(only if `sandbox_provider = "superserve"`)_                            |
+| `SUPERSERVE_TEMPLATE`            | Optional existing Superserve template; empty enables the managed template build             |
+| `SUPERSERVE_SANDBOX_HOST`        | Regional Superserve data-plane hostname                                                     |
+| `SUPERSERVE_AUTO_DELETE_SECONDS` | Optional paused-sandbox retention in seconds                                                |
+| `SUPERSERVE_NETWORK_ALLOW_OUT`   | Optional JSON list of domain/CIDR allow rules for Terraform CI                              |
+| `SUPERSERVE_NETWORK_DENY_OUT`    | Optional JSON list of CIDR deny rules for Terraform CI                                      |
 | `GH_OAUTH_CLIENT_ID`             | GitHub App OAuth client ID                                                                  |
 | `GH_OAUTH_CLIENT_SECRET`         | GitHub App OAuth client secret                                                              |
 | `GOOGLE_CLIENT_ID`               | Google OAuth client ID (only if Google login enabled; pair with `GOOGLE_CLIENT_SECRET`)     |

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -502,6 +502,10 @@ session. OpenComputer uses a managed template plus checkpoints for the same preb
 lifecycle. See [Vercel Sandbox Provider](VERCEL_SANDBOX_PROVIDER.md) and
 [OpenComputer Sandbox Provider](OPENCOMPUTER_PROVIDER.md) for provider-specific details.
 
+Superserve uses a managed runtime template and persistent microVM pause/resume for session
+continuity. Its MVP provider intentionally opts out of repository image prebuilds and snapshots. See
+[Superserve Sandbox Provider](SUPERSERVE_PROVIDER.md).
+
 ### Image Prebuilding
 
 For frequently-used repositories — and for [environments](#environments) — images can be prebuilt on

--- a/docs/SUPERSERVE_PROVIDER.md
+++ b/docs/SUPERSERVE_PROVIDER.md
@@ -1,0 +1,114 @@
+# Superserve Sandbox Provider
+
+Open-Inspect can run coding sessions in Superserve Firecracker microVMs. The Cloudflare control
+plane calls the Superserve REST API directly; no provider shim is deployed.
+
+## MVP Capabilities
+
+- Create a sandbox from an Open-Inspect runtime template.
+- Explicitly launch the runtime bridge with the session environment after creation.
+- Pause inactive sandboxes and activate them in place for later prompts.
+- Recover with a fresh sandbox when an auto-deleted sandbox no longer exists.
+- Expose code-server, terminal, and configured tunnel ports through Superserve preview URLs.
+- Apply optional sandbox-wide egress rules and paused-sandbox auto-deletion.
+- Run existing Open-Inspect cron and webhook automations in Superserve sandboxes without a second
+  scheduler.
+
+Superserve snapshots are intentionally not connected to Open-Inspect image prebuilds in this MVP.
+The provider reports persistent resume support, but not filesystem snapshot/restore support.
+
+## Configuration
+
+Set the provider in `terraform/environments/production/terraform.tfvars`:
+
+```hcl
+sandbox_provider = "superserve"
+
+superserve_api_url      = "https://api.superserve.ai"
+superserve_api_key      = "ss_live_..."
+superserve_sandbox_host = "sandbox.superserve.ai"
+
+# Leave empty for a Terraform-managed Open-Inspect runtime template.
+superserve_template = ""
+
+# Optional: delete a sandbox after seven continuously paused days.
+superserve_auto_delete_seconds = 604800
+```
+
+The API URL and sandbox host must belong to the same Superserve region. For example, the west-US
+cell uses `https://api-usw.superserve.ai` and `usw-sandbox.superserve.ai`.
+
+### Egress Policy
+
+Superserve egress is open unless deny rules are configured. For a strict allowlist, allow every host
+the runtime needs and deny all other IPv4 egress:
+
+```hcl
+superserve_network_allow_out = [
+  "open-inspect-control-plane-example.workers.dev",
+  "github.com",
+  "api.github.com",
+  "api.anthropic.com",
+]
+superserve_network_deny_out = ["0.0.0.0/0"]
+```
+
+Replace the control-plane hostname with the deployment's actual Worker/custom-domain hostname. Add
+the SCM, model, package registry, and MCP hosts required by your workloads. An incomplete allowlist
+can prevent the bridge from connecting or the agent from installing dependencies.
+
+## Runtime Template
+
+When `superserve_template = ""`, Terraform hashes the runtime and builder sources, creates a
+deterministically named template, and passes its name to the control plane. The builder installs
+OpenCode, Python dependencies, code-server, ttyd, agent-browser, GitHub CLI, and the Open-Inspect
+sandbox runtime. It checks out the current Git commit from the checkout's `origin` remote (GitHub
+SSH remotes are converted to HTTPS), so that repository and commit must be anonymously reachable
+before `terraform apply` runs. Set `OPENINSPECT_RUNTIME_REPOSITORY` when manually building from a
+different public source.
+
+To build a template manually:
+
+```bash
+SUPERSERVE_API_URL="https://api.superserve.ai" \
+SUPERSERVE_API_KEY="ss_live_..." \
+SUPERSERVE_TEMPLATE="openinspect-runtime" \
+npm run build:superserve-template
+```
+
+Then set `superserve_template = "openinspect-runtime"` so Terraform skips the managed build.
+
+## Lifecycle
+
+Creation sends the full session environment to Superserve, then calls the sandbox data plane's
+`/exec` endpoint to start `python3 -m sandbox_runtime.entrypoint`. This explicit launch is required
+because the template is a live snapshot and cannot start the bridge with per-session values baked at
+template-build time.
+
+Stopping maps to Superserve pause, preserving memory, processes, and files. Resume uses the
+idempotent activate endpoint, obtains a fresh data-plane token, and checks for the runtime process
+before starting it. This avoids duplicating a bridge that survived pause while still recovering if
+the process exited.
+
+## Security Boundary
+
+Superserve's microVM boundary isolates each sandbox from the provider host and other sandboxes. The
+current Open-Inspect runtime still places `SANDBOX_AUTH_TOKEN` and configured environment secrets in
+the guest process environment. Code running inside the same sandbox can therefore attempt to read
+those values. Treat this MVP as suitable for trusted repositories or workloads whose in-sandbox code
+shares the agent's credential trust level.
+
+Do not claim credential-safe execution of arbitrary hostile code until Open-Inspect models
+Superserve stored-secret names and lifecycle explicitly, scopes SCM credentials for untrusted runs,
+and separates the bridge identity from repository processes. Egress allowlisting materially reduces
+exfiltration paths, but does not by itself make plaintext guest credentials inaccessible.
+
+## Verification
+
+1. Run `terraform apply` and confirm the Superserve template reaches `ready`.
+2. Start an Open-Inspect session and confirm a Superserve sandbox becomes `active`.
+3. Confirm the session reaches `Connected` and responds to a repository question.
+4. Let the session become inactive and confirm the sandbox becomes `paused`.
+5. Send another prompt and confirm the same provider sandbox activates without a duplicate runtime.
+6. If using strict egress, inspect Superserve's network log for allowed control-plane, SCM, and
+   model traffic and blocked unexpected destinations.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1817,7 +1817,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2573,7 +2572,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2596,7 +2594,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2619,7 +2616,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2636,7 +2632,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2653,7 +2648,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2670,7 +2664,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2687,7 +2680,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2704,7 +2696,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2721,7 +2712,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2738,7 +2728,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2755,7 +2744,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2772,7 +2760,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2789,7 +2776,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2812,7 +2798,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2835,7 +2820,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2858,7 +2842,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2881,7 +2864,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2904,7 +2886,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2927,7 +2908,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2950,7 +2930,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2973,7 +2952,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -2993,7 +2971,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3013,7 +2990,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3033,7 +3009,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3501,6 +3476,10 @@
     },
     "node_modules/@open-inspect/slack-bot": {
       "resolved": "packages/slack-bot",
+      "link": true
+    },
+    "node_modules/@open-inspect/superserve-infra": {
+      "resolved": "packages/superserve-infra",
       "link": true
     },
     "node_modules/@open-inspect/web": {
@@ -5416,6 +5395,13 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@superserve/sdk": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@superserve/sdk/-/sdk-0.8.0.tgz",
+      "integrity": "sha512-H+7jvqcGIfb+rTS3A9JT8mr9JDrw8MpMwfmMQcK/45Swo3I7bLXI2GD9cYpg/vKade7Xw0lPkWoulY6vO+nvRA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -16061,6 +16047,15 @@
         "typescript": "^5.7.2",
         "vitest": "^4.1.0",
         "wrangler": "^4.103.0"
+      }
+    },
+    "packages/superserve-infra": {
+      "name": "@open-inspect/superserve-infra",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@superserve/sdk": "^0.8.0",
+        "esbuild": "^0.28.1",
+        "typescript": "^5.7.2"
       }
     },
     "packages/web": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "typecheck": "npm run typecheck --workspaces --if-present",
     "build": "npm run build --workspaces --if-present",
     "build:opencomputer-template": "npm run build-template -w @open-inspect/opencomputer-infra --",
+    "build:superserve-template": "npm run build-template -w @open-inspect/superserve-infra --",
     "prepare": "node -e \"if (process.env.CI) process.exit(0)\" && husky"
   },
   "devDependencies": {

--- a/packages/control-plane/src/sandbox/index.ts
+++ b/packages/control-plane/src/sandbox/index.ts
@@ -50,6 +50,11 @@ export {
   type OpenComputerProviderConfig,
 } from "./providers/opencomputer-provider";
 export {
+  SuperserveSandboxProvider,
+  createSuperserveProvider,
+  type SuperserveProviderConfig,
+} from "./providers/superserve-provider";
+export {
   VercelSandboxProvider,
   createVercelProvider,
   type VercelProviderConfig,
@@ -95,6 +100,16 @@ export {
   type OpenComputerCreateSandboxParams,
   type OpenComputerDeleteSandboxOptions,
 } from "./opencomputer-rest-client";
+export {
+  SuperserveRestClient,
+  SuperserveNotFoundError,
+  SuperserveApiError,
+  createSuperserveRestClient,
+  type SuperserveRestConfig,
+  type SuperserveNetworkConfig,
+  type SuperserveSandboxResponse,
+  type SuperserveCreateSandboxParams,
+} from "./superserve-rest-client";
 export {
   resolveSandboxBackendName,
   isModalSandboxBackend,

--- a/packages/control-plane/src/sandbox/provider-factory.test.ts
+++ b/packages/control-plane/src/sandbox/provider-factory.test.ts
@@ -64,4 +64,52 @@ describe("createSandboxProviderFromEnv", () => {
       "E2B_AUTO_PAUSE must be a valid boolean"
     );
   });
+
+  it("requires all Superserve endpoints and template settings", () => {
+    const env = createEnv({ SUPERSERVE_API_KEY: "superserve-key" });
+
+    expect(() => createSandboxProviderFromEnv(env, "superserve")).toThrow(
+      "SUPERSERVE_API_URL, SUPERSERVE_API_KEY, SUPERSERVE_TEMPLATE, and SUPERSERVE_SANDBOX_HOST are required"
+    );
+  });
+
+  it("rejects malformed Superserve auto-delete configuration", () => {
+    const env = createEnv({
+      SUPERSERVE_API_URL: "https://api.superserve.test",
+      SUPERSERVE_API_KEY: "superserve-key",
+      SUPERSERVE_TEMPLATE: "runtime",
+      SUPERSERVE_SANDBOX_HOST: "sandbox.superserve.test",
+      SUPERSERVE_AUTO_DELETE_SECONDS: "30.5",
+    });
+
+    expect(() => createSandboxProviderFromEnv(env, "superserve")).toThrow(
+      "SUPERSERVE_AUTO_DELETE_SECONDS must be an integer between 0 and 2592000"
+    );
+  });
+
+  it("constructs the Superserve provider with optional lifecycle and network policy", () => {
+    const env = createEnv({
+      SUPERSERVE_API_URL: "https://api.superserve.test",
+      SUPERSERVE_API_KEY: "superserve-key",
+      SUPERSERVE_TEMPLATE: "runtime",
+      SUPERSERVE_SANDBOX_HOST: "sandbox.superserve.test",
+      SUPERSERVE_AUTO_DELETE_SECONDS: "604800",
+      SUPERSERVE_NETWORK_ALLOW_OUT: "github.com, api.github.com",
+      SUPERSERVE_NETWORK_DENY_OUT: "0.0.0.0/0",
+    });
+
+    const provider = createSandboxProviderFromEnv(env, "superserve") as unknown as {
+      name: string;
+      client: { config: Record<string, unknown> };
+    };
+
+    expect(provider.name).toBe("superserve");
+    expect(provider.client.config).toMatchObject({
+      autoDeleteSeconds: 604800,
+      network: {
+        allowOut: ["github.com", "api.github.com"],
+        denyOut: ["0.0.0.0/0"],
+      },
+    });
+  });
 });

--- a/packages/control-plane/src/sandbox/provider-factory.ts
+++ b/packages/control-plane/src/sandbox/provider-factory.ts
@@ -2,6 +2,7 @@ import { createModalClient } from "./client";
 import { createDaytonaRestClient } from "./daytona-rest-client";
 import { createE2BRestClient } from "./e2b-rest-client";
 import { createOpenComputerRestClient } from "./opencomputer-rest-client";
+import { createSuperserveRestClient } from "./superserve-rest-client";
 import { resolveSandboxBackendName, type SandboxBackendName } from "./provider-name";
 import type { SandboxProvider } from "./provider";
 import { createDaytonaProvider, type DaytonaSandboxProvider } from "./providers/daytona-provider";
@@ -16,6 +17,10 @@ import {
   createOpenComputerProvider,
   type OpenComputerSandboxProvider,
 } from "./providers/opencomputer-provider";
+import {
+  createSuperserveProvider,
+  type SuperserveSandboxProvider,
+} from "./providers/superserve-provider";
 import { createVercelSandboxClient } from "./providers/vercel/client";
 import { createVercelProvider, type VercelSandboxProvider } from "./providers/vercel/provider";
 import { resolveScmProviderFromEnv } from "../source-control";
@@ -142,6 +147,43 @@ function createE2BProviderFromEnv(env: Env): E2BSandboxProvider {
   });
 }
 
+function createSuperserveProviderFromEnv(env: Env): SuperserveSandboxProvider {
+  if (
+    !env.SUPERSERVE_API_URL ||
+    !env.SUPERSERVE_API_KEY ||
+    !env.SUPERSERVE_TEMPLATE ||
+    !env.SUPERSERVE_SANDBOX_HOST
+  ) {
+    throw new Error(
+      "SUPERSERVE_API_URL, SUPERSERVE_API_KEY, SUPERSERVE_TEMPLATE, and SUPERSERVE_SANDBOX_HOST are required when SANDBOX_PROVIDER=superserve"
+    );
+  }
+
+  const allowOut = parseListEnv(env.SUPERSERVE_NETWORK_ALLOW_OUT);
+  const denyOut = parseListEnv(env.SUPERSERVE_NETWORK_DENY_OUT);
+  const client = createSuperserveRestClient({
+    apiUrl: env.SUPERSERVE_API_URL,
+    apiKey: env.SUPERSERVE_API_KEY,
+    template: env.SUPERSERVE_TEMPLATE,
+    sandboxHost: env.SUPERSERVE_SANDBOX_HOST,
+    autoDeleteSeconds: parseOptionalIntegerEnv(
+      "SUPERSERVE_AUTO_DELETE_SECONDS",
+      env.SUPERSERVE_AUTO_DELETE_SECONDS,
+      0,
+      2_592_000
+    ),
+    ...(allowOut.length > 0 || denyOut.length > 0 ? { network: { allowOut, denyOut } } : {}),
+  });
+
+  return createSuperserveProvider(client, {
+    scmProvider: resolveScmProviderFromEnv(env.SCM_PROVIDER),
+    codeServerPasswordSecret: env.SUPERSERVE_API_KEY,
+    llmEnvVars: {
+      ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY,
+    },
+  });
+}
+
 export function createSandboxProviderFromEnv(env: Env, backend: "daytona"): DaytonaSandboxProvider;
 export function createSandboxProviderFromEnv(env: Env, backend: "e2b"): E2BSandboxProvider;
 export function createSandboxProviderFromEnv(env: Env, backend: "modal"): ModalSandboxProvider;
@@ -150,6 +192,10 @@ export function createSandboxProviderFromEnv(
   env: Env,
   backend: "opencomputer"
 ): OpenComputerSandboxProvider;
+export function createSandboxProviderFromEnv(
+  env: Env,
+  backend: "superserve"
+): SuperserveSandboxProvider;
 export function createSandboxProviderFromEnv(
   env: Env,
   backend?: SandboxBackendName
@@ -167,9 +213,35 @@ export function createSandboxProviderFromEnv(
       return createOpenComputerProviderFromEnv(env);
     case "e2b":
       return createE2BProviderFromEnv(env);
+    case "superserve":
+      return createSuperserveProviderFromEnv(env);
     case "modal":
       return createModalProviderFromEnv(env);
   }
+}
+
+function parseOptionalIntegerEnv(
+  name: string,
+  value: string | undefined,
+  minimum: number,
+  maximum: number
+): number | undefined {
+  const raw = value?.trim();
+  if (!raw) return undefined;
+
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new Error(`${name} must be an integer between ${minimum} and ${maximum}`);
+  }
+  return parsed;
+}
+
+function parseListEnv(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
 }
 
 function parseNumericEnv(name: string, value: string | undefined, defaultValue: number): number {

--- a/packages/control-plane/src/sandbox/provider-name.test.ts
+++ b/packages/control-plane/src/sandbox/provider-name.test.ts
@@ -34,6 +34,10 @@ describe("resolveSandboxBackendName", () => {
     expect(resolveSandboxBackendName("opencomputer")).toBe("opencomputer");
   });
 
+  it('returns "superserve" for "superserve"', () => {
+    expect(resolveSandboxBackendName("superserve")).toBe("superserve");
+  });
+
   it("is case-insensitive", () => {
     expect(resolveSandboxBackendName("MODAL")).toBe("modal");
     expect(resolveSandboxBackendName("Daytona")).toBe("daytona");
@@ -41,6 +45,7 @@ describe("resolveSandboxBackendName", () => {
     expect(resolveSandboxBackendName("DAYTONA")).toBe("daytona");
     expect(resolveSandboxBackendName("VERCEL")).toBe("vercel");
     expect(resolveSandboxBackendName("OPENCOMPUTER")).toBe("opencomputer");
+    expect(resolveSandboxBackendName("SUPERSERVE")).toBe("superserve");
   });
 
   it("trims whitespace", () => {
@@ -49,6 +54,7 @@ describe("resolveSandboxBackendName", () => {
     expect(resolveSandboxBackendName("  vercel  ")).toBe("vercel");
     expect(resolveSandboxBackendName("  opencomputer  ")).toBe("opencomputer");
     expect(resolveSandboxBackendName("  e2b  ")).toBe("e2b");
+    expect(resolveSandboxBackendName("  superserve  ")).toBe("superserve");
   });
 
   it("throws for unsupported provider", () => {
@@ -80,5 +86,9 @@ describe("isModalSandboxBackend", () => {
 
   it("returns false for opencomputer", () => {
     expect(isModalSandboxBackend("opencomputer")).toBe(false);
+  });
+
+  it("returns false for superserve", () => {
+    expect(isModalSandboxBackend("superserve")).toBe(false);
   });
 });

--- a/packages/control-plane/src/sandbox/provider-name.ts
+++ b/packages/control-plane/src/sandbox/provider-name.ts
@@ -2,7 +2,13 @@
  * Sandbox backend selection utilities.
  */
 
-export type SandboxBackendName = "modal" | "daytona" | "vercel" | "opencomputer" | "e2b";
+export type SandboxBackendName =
+  | "modal"
+  | "daytona"
+  | "vercel"
+  | "opencomputer"
+  | "e2b"
+  | "superserve";
 
 /**
  * Resolve the configured sandbox backend.
@@ -30,6 +36,10 @@ export function resolveSandboxBackendName(value: string | undefined): SandboxBac
 
   if (normalized === "e2b") {
     return "e2b";
+  }
+
+  if (normalized === "superserve") {
+    return "superserve";
   }
 
   throw new Error(`Unsupported SANDBOX_PROVIDER: ${value}`);

--- a/packages/control-plane/src/sandbox/providers/superserve-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/superserve-provider.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it, vi } from "vitest";
+import type { CreateSandboxConfig } from "../provider";
+import { SandboxProviderError } from "../provider";
+import {
+  SuperserveApiError,
+  SuperserveNotFoundError,
+  type SuperserveRestClient,
+} from "../superserve-rest-client";
+import { createSuperserveProvider } from "./superserve-provider";
+
+function createClient(overrides: Partial<SuperserveRestClient> = {}): SuperserveRestClient {
+  return {
+    config: {
+      apiUrl: "https://api.superserve.test",
+      apiKey: "api-key",
+      template: "runtime",
+      sandboxHost: "sandbox.superserve.test",
+    },
+    createSandbox: vi.fn().mockResolvedValue({
+      id: "provider-id",
+      status: "active",
+      access_token: "sandbox-token",
+      created_at: "2026-07-17T00:00:00Z",
+    }),
+    activateSandbox: vi.fn().mockResolvedValue({
+      id: "provider-id",
+      status: "active",
+      access_token: "fresh-token",
+    }),
+    pauseSandbox: vi.fn().mockResolvedValue(undefined),
+    deleteSandbox: vi.fn().mockResolvedValue(undefined),
+    startRuntime: vi.fn().mockResolvedValue(undefined),
+    getPreviewUrl: vi.fn((id: string, port: number) => `https://${port}-${id}.preview.test`),
+    ...overrides,
+  } as unknown as SuperserveRestClient;
+}
+
+const baseConfig: CreateSandboxConfig = {
+  sessionId: "session-id",
+  sandboxId: "logical-id",
+  repoOwner: "owner/group",
+  repoName: "repo",
+  controlPlaneUrl: "https://control.test",
+  sandboxAuthToken: "control-token",
+  provider: "anthropic",
+  model: "claude-test",
+  branch: "main",
+  timeoutSeconds: 7200,
+};
+
+describe("SuperserveSandboxProvider", () => {
+  it("advertises persistent pause/resume without snapshot support", () => {
+    const provider = createSuperserveProvider(createClient(), {
+      scmProvider: "github",
+      codeServerPasswordSecret: "password-secret",
+    });
+
+    expect(provider.name).toBe("superserve");
+    expect(provider.capabilities).toEqual({
+      supportsSnapshots: false,
+      supportsRestore: false,
+      supportsPersistentResume: true,
+      supportsExplicitStop: true,
+    });
+  });
+
+  it("creates the sandbox, prepares previews, and explicitly launches the runtime", async () => {
+    const client = createClient();
+    const provider = createSuperserveProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "password-secret",
+      llmEnvVars: { ANTHROPIC_API_KEY: "provider-key" },
+    });
+
+    const result = await provider.createSandbox({
+      ...baseConfig,
+      userEnvVars: { CUSTOM_SECRET: "custom", ANTHROPIC_API_KEY: "repo-key" },
+      codeServerEnabled: true,
+      agentSlackNotifyEnabled: true,
+      sandboxSettings: {
+        terminalEnabled: true,
+        codeServerPort: 8080,
+        terminalPort: 7680,
+        tunnelPorts: [3000, 8080, 7680],
+      },
+    });
+
+    expect(client.createSandbox).toHaveBeenCalledOnce();
+    const createCall = vi.mocked(client.createSandbox).mock.calls[0][0];
+    expect(createCall).toMatchObject({
+      name: "logical-id",
+      timeoutSeconds: 7200,
+      metadata: {
+        openinspect_framework: "open-inspect",
+        openinspect_provider: "superserve",
+        openinspect_session_id: "session-id",
+        openinspect_expected_sandbox_id: "logical-id",
+        openinspect_repo: "owner/group/repo",
+      },
+    });
+    expect(createCall.envVars).toMatchObject({
+      ANTHROPIC_API_KEY: "repo-key",
+      CUSTOM_SECRET: "custom",
+      SANDBOX_ID: "logical-id",
+      CONTROL_PLANE_URL: "https://control.test",
+      SANDBOX_AUTH_TOKEN: "control-token",
+      REPO_OWNER: "owner/group",
+      REPO_NAME: "repo",
+      CODE_SERVER_PORT: "8080",
+      TERMINAL_ENABLED: "true",
+      TTYD_PROXY_PORT: "7680",
+      EXPECTED_TUNNEL_PORTS: "3000",
+      AGENT_SLACK_NOTIFY_ENABLED: "true",
+      VCS_HOST: "github.com",
+      VCS_CLONE_USERNAME: "x-access-token",
+    });
+    expect(JSON.parse(createCall.envVars.SESSION_CONFIG)).toMatchObject({
+      session_id: "session-id",
+      branch: "main",
+    });
+    expect(client.startRuntime).toHaveBeenCalledWith(
+      "provider-id",
+      "sandbox-token",
+      createCall.envVars,
+      { "3000": "https://3000-provider-id.preview.test" }
+    );
+    expect(result).toMatchObject({
+      sandboxId: "logical-id",
+      providerObjectId: "provider-id",
+      status: "active",
+      createdAt: Date.parse("2026-07-17T00:00:00Z"),
+      codeServerUrl: "https://8080-provider-id.preview.test",
+      ttydUrl: "https://7680-provider-id.preview.test",
+      tunnelUrls: { "3000": "https://3000-provider-id.preview.test" },
+    });
+    expect(result.codeServerPassword).toHaveLength(32);
+  });
+
+  it("deletes a partially created sandbox when runtime launch fails", async () => {
+    const client = createClient({
+      startRuntime: vi.fn().mockRejectedValue(new SuperserveApiError("exec failed", 503)),
+    });
+    const provider = createSuperserveProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "password-secret",
+    });
+
+    await expect(provider.createSandbox(baseConfig)).rejects.toMatchObject({
+      name: "SandboxProviderError",
+      errorType: "transient",
+    });
+    expect(client.deleteSandbox).toHaveBeenCalledWith("provider-id");
+  });
+
+  it("activates a paused sandbox and ensures the runtime is present", async () => {
+    const client = createClient();
+    const provider = createSuperserveProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "password-secret",
+    });
+
+    const result = await provider.resumeSandbox({
+      providerObjectId: "provider-id",
+      sessionId: "session-id",
+      sandboxId: "logical-id",
+      codeServerEnabled: true,
+      sandboxSettings: { codeServerPort: 8080, tunnelPorts: [3000] },
+    });
+
+    expect(client.activateSandbox).toHaveBeenCalledWith("provider-id");
+    expect(client.startRuntime).toHaveBeenCalledWith(
+      "provider-id",
+      "fresh-token",
+      { SANDBOX_ID: "logical-id" },
+      { "3000": "https://3000-provider-id.preview.test" }
+    );
+    expect(result).toMatchObject({
+      success: true,
+      providerObjectId: "provider-id",
+      codeServerUrl: "https://8080-provider-id.preview.test",
+      tunnelUrls: { "3000": "https://3000-provider-id.preview.test" },
+    });
+  });
+
+  it("requests a fresh spawn when the persistent sandbox was deleted", async () => {
+    const client = createClient({
+      activateSandbox: vi.fn().mockRejectedValue(new SuperserveNotFoundError("gone")),
+    });
+    const provider = createSuperserveProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "password-secret",
+    });
+
+    await expect(
+      provider.resumeSandbox({
+        providerObjectId: "missing",
+        sessionId: "session-id",
+        sandboxId: "logical-id",
+      })
+    ).resolves.toEqual({
+      success: false,
+      error: "Sandbox no longer exists in Superserve",
+      shouldSpawnFresh: true,
+    });
+  });
+
+  it("treats a missing sandbox as already stopped", async () => {
+    const client = createClient({
+      pauseSandbox: vi.fn().mockRejectedValue(new SuperserveNotFoundError("gone")),
+    });
+    const provider = createSuperserveProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "password-secret",
+    });
+
+    await expect(
+      provider.stopSandbox({
+        providerObjectId: "missing",
+        sessionId: "session-id",
+        reason: "inactivity",
+      })
+    ).resolves.toEqual({ success: true });
+  });
+
+  it("classifies permanent API failures for the lifecycle circuit breaker", async () => {
+    const client = createClient({
+      pauseSandbox: vi.fn().mockRejectedValue(new SuperserveApiError("unauthorized", 401)),
+    });
+    const provider = createSuperserveProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "password-secret",
+    });
+
+    await expect(
+      provider.stopSandbox({
+        providerObjectId: "provider-id",
+        sessionId: "session-id",
+        reason: "inactivity",
+      })
+    ).rejects.toBeInstanceOf(SandboxProviderError);
+  });
+});

--- a/packages/control-plane/src/sandbox/providers/superserve-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/superserve-provider.ts
@@ -1,0 +1,335 @@
+/** Superserve sandbox provider backed by the control-plane and data-plane REST APIs. */
+
+import { computeHmacHex, type SandboxSettings } from "@open-inspect/shared";
+import { createLogger } from "../../logger";
+import type { SourceControlProviderName } from "../../source-control";
+import {
+  SuperserveApiError,
+  SuperserveNotFoundError,
+  type SuperserveRestClient,
+} from "../superserve-rest-client";
+import { buildSessionConfig } from "../sandbox-env";
+import {
+  SandboxProviderError,
+  type CreateSandboxConfig,
+  type CreateSandboxResult,
+  type ResumeConfig,
+  type ResumeResult,
+  type SandboxProvider,
+  type SandboxProviderCapabilities,
+  type StopConfig,
+  type StopResult,
+} from "../provider";
+import { resolveServicePorts, resolveTunnelPorts } from "./port-resolution";
+
+const log = createLogger("superserve-provider");
+const EXPECTED_TUNNEL_PORTS_ENV_VAR = "EXPECTED_TUNNEL_PORTS";
+
+export interface SuperserveProviderConfig {
+  scmProvider: SourceControlProviderName;
+  /** Secret used for deterministic code-server password derivation. */
+  codeServerPasswordSecret: string;
+  /** Provider-level LLM credentials made available to the runtime. */
+  llmEnvVars?: Record<string, string | undefined>;
+}
+
+interface SuperserveSandboxAccess {
+  codeServerUrl?: string;
+  codeServerPassword?: string;
+  ttydUrl?: string;
+  tunnelUrls?: Record<string, string>;
+}
+
+export class SuperserveSandboxProvider implements SandboxProvider {
+  readonly name = "superserve";
+
+  readonly capabilities: SandboxProviderCapabilities = {
+    supportsSnapshots: false,
+    supportsRestore: false,
+    supportsPersistentResume: true,
+    supportsExplicitStop: true,
+  };
+
+  constructor(
+    private readonly client: SuperserveRestClient,
+    private readonly providerConfig: SuperserveProviderConfig
+  ) {}
+
+  async createSandbox(config: CreateSandboxConfig): Promise<CreateSandboxResult> {
+    let providerObjectId: string | undefined;
+    try {
+      const envVars = await this.buildEnvVars(config);
+      const sandbox = await this.client.createSandbox({
+        name: config.sandboxId,
+        envVars,
+        metadata: this.buildMetadata(config),
+        timeoutSeconds: config.timeoutSeconds,
+      });
+      providerObjectId = sandbox.id;
+      if (!providerObjectId || !sandbox.access_token) {
+        throw new SuperserveApiError(
+          "Superserve create response was missing id or access_token",
+          502
+        );
+      }
+
+      const access = await this.buildSandboxAccess(
+        providerObjectId,
+        config.sandboxId,
+        config.codeServerEnabled,
+        config.sandboxSettings
+      );
+      await this.client.startRuntime(
+        providerObjectId,
+        sandbox.access_token,
+        envVars,
+        access.tunnelUrls
+      );
+
+      return {
+        sandboxId: config.sandboxId,
+        providerObjectId,
+        status: sandbox.status || "active",
+        createdAt: parseCreatedAt(sandbox.created_at),
+        codeServerUrl: access.codeServerUrl,
+        codeServerPassword: access.codeServerPassword,
+        ttydUrl: access.ttydUrl,
+        tunnelUrls: access.tunnelUrls,
+      };
+    } catch (error) {
+      if (providerObjectId) {
+        try {
+          await this.client.deleteSandbox(providerObjectId);
+        } catch (cleanupError) {
+          log.warn("superserve.sandbox_cleanup_failed", {
+            session_id: config.sessionId,
+            provider_object_id: providerObjectId,
+            error: cleanupError instanceof Error ? cleanupError.message : String(cleanupError),
+          });
+        }
+      }
+      throw this.classifyError("Failed to create Superserve sandbox", error);
+    }
+  }
+
+  async resumeSandbox(config: ResumeConfig): Promise<ResumeResult> {
+    try {
+      let sandbox;
+      try {
+        sandbox = await this.client.activateSandbox(config.providerObjectId);
+      } catch (error) {
+        if (error instanceof SuperserveNotFoundError) {
+          return {
+            success: false,
+            error: "Sandbox no longer exists in Superserve",
+            shouldSpawnFresh: true,
+          };
+        }
+        throw error;
+      }
+
+      if (!sandbox.access_token) {
+        throw new SuperserveApiError("Superserve activate response was missing access_token", 502);
+      }
+
+      let access: SuperserveSandboxAccess = {};
+      try {
+        access = await this.buildSandboxAccess(
+          config.providerObjectId,
+          config.sandboxId,
+          config.codeServerEnabled,
+          config.sandboxSettings
+        );
+      } catch (error) {
+        log.warn("superserve.resume_tunnel_urls_failed", {
+          sandbox_id: config.sandboxId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+
+      await this.client.startRuntime(
+        config.providerObjectId,
+        sandbox.access_token,
+        { SANDBOX_ID: config.sandboxId },
+        access.tunnelUrls
+      );
+
+      return {
+        success: true,
+        providerObjectId: sandbox.id || config.providerObjectId,
+        codeServerUrl: access.codeServerUrl,
+        codeServerPassword: access.codeServerPassword,
+        tunnelUrls: access.tunnelUrls,
+      };
+    } catch (error) {
+      if (error instanceof SandboxProviderError) throw error;
+      throw this.classifyError("Failed to resume Superserve sandbox", error);
+    }
+  }
+
+  async stopSandbox(config: StopConfig): Promise<StopResult> {
+    try {
+      try {
+        await this.client.pauseSandbox(config.providerObjectId);
+      } catch (error) {
+        if (error instanceof SuperserveNotFoundError) return { success: true };
+        throw error;
+      }
+      return { success: true };
+    } catch (error) {
+      if (error instanceof SandboxProviderError) throw error;
+      throw this.classifyError("Failed to pause Superserve sandbox", error);
+    }
+  }
+
+  private async buildEnvVars(config: CreateSandboxConfig): Promise<Record<string, string>> {
+    const envVars: Record<string, string> = {};
+    copyDefinedEnvVars(envVars, this.providerConfig.llmEnvVars);
+    copyDefinedEnvVars(envVars, config.userEnvVars);
+
+    Object.assign(envVars, {
+      HOME: "/root",
+      NODE_ENV: "development",
+      PYTHONPATH: "/app",
+      PYTHONUNBUFFERED: "1",
+      NODE_PATH: "/usr/lib/node_modules:/usr/local/lib/node_modules",
+      SANDBOX_ID: config.sandboxId,
+      CONTROL_PLANE_URL: config.controlPlaneUrl,
+      SANDBOX_AUTH_TOKEN: config.sandboxAuthToken,
+      REPO_OWNER: config.repoOwner ?? "",
+      REPO_NAME: config.repoName ?? "",
+      SESSION_CONFIG: JSON.stringify(buildSessionConfig(config)),
+    });
+
+    const { codeServerPort, terminalPort } = resolveServicePorts(config.sandboxSettings);
+    if (config.codeServerEnabled) {
+      envVars.CODE_SERVER_PASSWORD = await this.deriveCodeServerPassword(config.sandboxId);
+      envVars.CODE_SERVER_PORT = String(codeServerPort);
+    }
+    if (config.sandboxSettings?.terminalEnabled) {
+      envVars.TERMINAL_ENABLED = "true";
+      envVars.TTYD_PROXY_PORT = String(terminalPort);
+    }
+    if (config.agentSlackNotifyEnabled) {
+      envVars.AGENT_SLACK_NOTIFY_ENABLED = "true";
+    }
+
+    const extraTunnelPorts = collectExtraTunnelPorts(
+      config.codeServerEnabled,
+      config.sandboxSettings
+    );
+    if (extraTunnelPorts.length > 0) {
+      envVars[EXPECTED_TUNNEL_PORTS_ENV_VAR] = extraTunnelPorts.join(",");
+    }
+
+    if (this.providerConfig.scmProvider === "gitlab") {
+      envVars.VCS_HOST = "gitlab.com";
+      envVars.VCS_CLONE_USERNAME = "oauth2";
+    } else if (this.providerConfig.scmProvider === "bitbucket") {
+      envVars.VCS_HOST = "bitbucket.org";
+      envVars.VCS_CLONE_USERNAME = "x-token-auth";
+    } else {
+      envVars.VCS_HOST = "github.com";
+      envVars.VCS_CLONE_USERNAME = "x-access-token";
+    }
+
+    return envVars;
+  }
+
+  private buildMetadata(config: CreateSandboxConfig): Record<string, string> {
+    return {
+      openinspect_framework: "open-inspect",
+      openinspect_provider: "superserve",
+      openinspect_session_id: config.sessionId,
+      openinspect_expected_sandbox_id: config.sandboxId,
+      ...(config.repoOwner && config.repoName
+        ? { openinspect_repo: `${config.repoOwner}/${config.repoName}` }
+        : {}),
+    };
+  }
+
+  private async buildSandboxAccess(
+    providerObjectId: string,
+    logicalSandboxId: string,
+    codeServerEnabled: boolean | undefined,
+    sandboxSettings: SandboxSettings | undefined
+  ): Promise<SuperserveSandboxAccess> {
+    const { codeServerPort, terminalPort } = resolveServicePorts(sandboxSettings);
+    const extraTunnelPorts = collectExtraTunnelPorts(codeServerEnabled, sandboxSettings);
+    const tunnelUrls =
+      extraTunnelPorts.length > 0
+        ? Object.fromEntries(
+            extraTunnelPorts.map((port) => [
+              String(port),
+              this.client.getPreviewUrl(providerObjectId, port),
+            ])
+          )
+        : undefined;
+
+    return {
+      codeServerUrl: codeServerEnabled
+        ? this.client.getPreviewUrl(providerObjectId, codeServerPort)
+        : undefined,
+      codeServerPassword: codeServerEnabled
+        ? await this.deriveCodeServerPassword(logicalSandboxId)
+        : undefined,
+      ttydUrl: sandboxSettings?.terminalEnabled
+        ? this.client.getPreviewUrl(providerObjectId, terminalPort)
+        : undefined,
+      tunnelUrls,
+    };
+  }
+
+  private async deriveCodeServerPassword(sandboxId: string): Promise<string> {
+    const digest = await computeHmacHex(
+      `code-server:${sandboxId}`,
+      this.providerConfig.codeServerPasswordSecret
+    );
+    return digest.slice(0, 32);
+  }
+
+  private classifyError(message: string, error: unknown): SandboxProviderError {
+    if (error instanceof SuperserveApiError) {
+      return SandboxProviderError.fromFetchError(
+        `${message}: ${error.message}`,
+        error,
+        error.status
+      );
+    }
+    return SandboxProviderError.fromFetchError(message, error);
+  }
+}
+
+function collectExtraTunnelPorts(
+  codeServerEnabled: boolean | undefined,
+  sandboxSettings: SandboxSettings | undefined
+): number[] {
+  const { codeServerPort, terminalPort } = resolveServicePorts(sandboxSettings);
+  const reserved = new Set<number>();
+  if (codeServerEnabled) reserved.add(codeServerPort);
+  if (sandboxSettings?.terminalEnabled) reserved.add(terminalPort);
+  return resolveTunnelPorts(sandboxSettings?.tunnelPorts).filter((port) => !reserved.has(port));
+}
+
+function copyDefinedEnvVars(
+  target: Record<string, string>,
+  source: Record<string, string | undefined> | undefined
+): void {
+  if (!source) return;
+  for (const [key, value] of Object.entries(source)) {
+    if (value !== undefined) target[key] = value;
+  }
+}
+
+function parseCreatedAt(value: string | undefined): number {
+  if (!value) return Date.now();
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : Date.now();
+}
+
+export function createSuperserveProvider(
+  client: SuperserveRestClient,
+  providerConfig: SuperserveProviderConfig
+): SuperserveSandboxProvider {
+  return new SuperserveSandboxProvider(client, providerConfig);
+}

--- a/packages/control-plane/src/sandbox/superserve-rest-client.test.ts
+++ b/packages/control-plane/src/sandbox/superserve-rest-client.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  SuperserveApiError,
+  SuperserveNotFoundError,
+  createSuperserveRestClient,
+} from "./superserve-rest-client";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("SuperserveRestClient", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("creates a sandbox with the documented Superserve wire shape", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(
+        {
+          id: "provider-id",
+          name: "logical-id",
+          status: "active",
+          access_token: "sandbox-token",
+          created_at: "2026-07-17T00:00:00Z",
+        },
+        201
+      )
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const client = createSuperserveRestClient({
+      apiUrl: "https://api.superserve.test/",
+      apiKey: "api-key",
+      template: "openinspect-runtime",
+      sandboxHost: "sandbox.superserve.test",
+      autoDeleteSeconds: 604800,
+      network: {
+        allowOut: ["github.com", "api.anthropic.com"],
+        denyOut: ["0.0.0.0/0"],
+      },
+    });
+
+    const result = await client.createSandbox({
+      name: "logical-id",
+      envVars: { SANDBOX_ID: "logical-id" },
+      metadata: { openinspect_session_id: "session-id" },
+      timeoutSeconds: 7200,
+    });
+
+    expect(result.id).toBe("provider-id");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.superserve.test/sandboxes");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toMatchObject({
+      "Content-Type": "application/json",
+      "X-API-Key": "api-key",
+    });
+    expect(JSON.parse(String(init.body))).toEqual({
+      name: "logical-id",
+      from_template: "openinspect-runtime",
+      env_vars: { SANDBOX_ID: "logical-id" },
+      metadata: { openinspect_session_id: "session-id" },
+      timeout_seconds: 7200,
+      auto_delete_seconds: 604800,
+      network: {
+        allow_out: ["github.com", "api.anthropic.com"],
+        deny_out: ["0.0.0.0/0"],
+      },
+    });
+  });
+
+  it("launches the runtime through the shared data-plane origin", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ stdout: "123\n", stderr: "", exit_code: 0 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = createSuperserveRestClient({
+      apiUrl: "https://api.superserve.ai",
+      apiKey: "api-key",
+      template: "openinspect-runtime",
+      sandboxHost: "https://sandbox.superserve.ai/",
+    });
+
+    await client.startRuntime(
+      "provider-id",
+      "sandbox-token",
+      { SANDBOX_ID: "logical-id", CONTROL_PLANE_URL: "https://control.test" },
+      { "3000": "https://3000-provider-id.sandbox.superserve.ai" }
+    );
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://sandbox.superserve.ai/exec");
+    expect(init.headers).toMatchObject({
+      "X-Access-Token": "sandbox-token",
+      "X-Superserve-Sandbox-Id": "provider-id",
+    });
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+    expect(body.env).toEqual({
+      SANDBOX_ID: "logical-id",
+      CONTROL_PLANE_URL: "https://control.test",
+    });
+    expect(body.command).toContain("TUNNEL_SANDBOX_ID=logical-id");
+    expect(body.command).toContain("TUNNEL_3000=https://3000-provider-id");
+    expect(body.command).toContain("pgrep -f '[s]andbox_runtime[.]entrypoint'");
+    expect(body.command).toContain('nohup python3 -m "$runtime_module"');
+  });
+
+  it("uses the per-sandbox boxd hostname for custom data-plane hosts", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ stdout: "", stderr: "", exit_code: 0 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const client = createSuperserveRestClient({
+      apiUrl: "https://api.example.test",
+      apiKey: "api-key",
+      template: "runtime",
+      sandboxHost: "sandboxes.example.test",
+    });
+
+    await client.startRuntime("provider-id", "sandbox-token");
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://boxd-provider-id.sandboxes.example.test/exec");
+    expect(init.headers).not.toHaveProperty("X-Superserve-Sandbox-Id");
+  });
+
+  it("classifies 404 responses separately", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ error: "gone" }, 404)));
+    const client = createSuperserveRestClient({
+      apiUrl: "https://api.superserve.ai",
+      apiKey: "api-key",
+      template: "runtime",
+      sandboxHost: "sandbox.superserve.ai",
+    });
+
+    await expect(client.activateSandbox("missing")).rejects.toBeInstanceOf(SuperserveNotFoundError);
+  });
+
+  it("rejects unsupported preview ports and builds valid URLs", () => {
+    const client = createSuperserveRestClient({
+      apiUrl: "https://api.superserve.ai",
+      apiKey: "api-key",
+      template: "runtime",
+      sandboxHost: "sandbox.superserve.ai",
+    });
+
+    expect(client.getPreviewUrl("provider-id", 8080)).toBe(
+      "https://8080-provider-id.sandbox.superserve.ai"
+    );
+    expect(() => client.getPreviewUrl("provider-id", 80)).toThrow(SuperserveApiError);
+  });
+});

--- a/packages/control-plane/src/sandbox/superserve-rest-client.ts
+++ b/packages/control-plane/src/sandbox/superserve-rest-client.ts
@@ -1,0 +1,293 @@
+/**
+ * Direct REST client for Superserve sandboxes.
+ *
+ * Lifecycle requests use the Superserve control plane with X-API-Key auth.
+ * Commands run against the per-sandbox data plane with the short-lived access
+ * token returned by create/activate.
+ */
+
+const CREATE_TIMEOUT_MS = 120_000;
+const ACTIVATE_TIMEOUT_MS = 120_000;
+const LIFECYCLE_TIMEOUT_MS = 30_000;
+const EXEC_TIMEOUT_MS = 20_000;
+const RUNTIME_ENTRYPOINT_TIMEOUT_SECONDS = 10;
+const MIN_PREVIEW_PORT = 1024;
+const MAX_PREVIEW_PORT = 65535;
+const RUNTIME_LOG_PATH = "/tmp/openinspect/runtime.log";
+const TUNNEL_ENV_FILE_PATH = "/workspace/.tunnels.env";
+const SHARED_DATA_PLANE_HOSTS = new Set([
+  "sandbox.superserve.ai",
+  "staging-sandbox.superserve.ai",
+  "usw-sandbox.superserve.ai",
+]);
+
+export interface SuperserveRestConfig {
+  apiUrl: string;
+  apiKey: string;
+  template: string;
+  sandboxHost: string;
+  /** Delete a sandbox after it remains paused for this many seconds. */
+  autoDeleteSeconds?: number;
+  /** Optional egress rules applied to every sandbox. */
+  network?: SuperserveNetworkConfig;
+}
+
+export interface SuperserveNetworkConfig {
+  allowOut?: string[];
+  denyOut?: string[];
+}
+
+export interface SuperserveCreateSandboxParams {
+  name: string;
+  envVars: Record<string, string>;
+  metadata: Record<string, string>;
+  timeoutSeconds?: number;
+}
+
+export interface SuperserveSandboxResponse {
+  id: string;
+  name?: string;
+  status: string;
+  access_token?: string;
+  created_at?: string;
+}
+
+interface SuperserveExecResult {
+  stdout: string;
+  stderr: string;
+  exit_code: number;
+}
+
+export class SuperserveApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number
+  ) {
+    super(message);
+    this.name = "SuperserveApiError";
+  }
+}
+
+export class SuperserveNotFoundError extends SuperserveApiError {
+  constructor(message: string) {
+    super(message, 404);
+    this.name = "SuperserveNotFoundError";
+  }
+}
+
+export class SuperserveRestClient {
+  readonly config: SuperserveRestConfig;
+  private readonly apiUrl: string;
+  private readonly sandboxHost: string;
+
+  constructor(config: SuperserveRestConfig) {
+    this.apiUrl = config.apiUrl.replace(/\/+$/, "");
+    this.sandboxHost = normalizeSandboxHost(config.sandboxHost);
+    this.config = {
+      ...config,
+      apiUrl: this.apiUrl,
+      sandboxHost: this.sandboxHost,
+    };
+  }
+
+  async createSandbox(params: SuperserveCreateSandboxParams): Promise<SuperserveSandboxResponse> {
+    const body: Record<string, unknown> = {
+      name: params.name,
+      from_template: this.config.template,
+      env_vars: params.envVars,
+      metadata: params.metadata,
+    };
+    if (params.timeoutSeconds !== undefined) {
+      body.timeout_seconds = params.timeoutSeconds;
+    }
+    if (this.config.autoDeleteSeconds !== undefined) {
+      body.auto_delete_seconds = this.config.autoDeleteSeconds;
+    }
+    if (this.config.network) {
+      body.network = {
+        allow_out: this.config.network.allowOut,
+        deny_out: this.config.network.denyOut,
+      };
+    }
+
+    return await this.controlPlaneRequest<SuperserveSandboxResponse>(
+      "POST",
+      "/sandboxes",
+      CREATE_TIMEOUT_MS,
+      body
+    );
+  }
+
+  async activateSandbox(id: string): Promise<SuperserveSandboxResponse> {
+    return await this.controlPlaneRequest<SuperserveSandboxResponse>(
+      "POST",
+      `/sandboxes/${encodeURIComponent(id)}/activate`,
+      ACTIVATE_TIMEOUT_MS
+    );
+  }
+
+  async pauseSandbox(id: string): Promise<void> {
+    await this.controlPlaneRequest<void>(
+      "POST",
+      `/sandboxes/${encodeURIComponent(id)}/pause`,
+      LIFECYCLE_TIMEOUT_MS
+    );
+  }
+
+  async deleteSandbox(id: string): Promise<void> {
+    await this.controlPlaneRequest<void>(
+      "DELETE",
+      `/sandboxes/${encodeURIComponent(id)}`,
+      LIFECYCLE_TIMEOUT_MS
+    );
+  }
+
+  /** Ensure the Open-Inspect bridge is running without duplicating a preserved process. */
+  async startRuntime(
+    id: string,
+    accessToken: string,
+    env: Record<string, string> = {},
+    tunnelUrls?: Record<string, string>
+  ): Promise<void> {
+    const commands = ["mkdir -p /workspace /tmp/openinspect"];
+    if (tunnelUrls && Object.keys(tunnelUrls).length > 0) {
+      const tunnelEnv = [
+        `TUNNEL_SANDBOX_ID=${env.SANDBOX_ID ?? ""}`,
+        ...Object.entries(tunnelUrls)
+          .sort(([left], [right]) => Number(left) - Number(right))
+          .map(([port, url]) => `TUNNEL_${port}=${url}`),
+      ].join("\n");
+      commands.push(`printf '%s\\n' ${shellQuote(tunnelEnv)} > ${TUNNEL_ENV_FILE_PATH}`);
+    }
+    commands.push(
+      "runtime_module='sandbox_runtime''.''entrypoint'; " +
+        "if ! pgrep -f '[s]andbox_runtime[.]entrypoint' >/dev/null 2>&1; then " +
+        `nohup python3 -m "$runtime_module" >>${RUNTIME_LOG_PATH} 2>&1 </dev/null & echo $!; ` +
+        "fi"
+    );
+
+    const result = await this.dataPlaneRequest<SuperserveExecResult>(id, accessToken, "/exec", {
+      command: commands.join("; "),
+      working_dir: "/workspace",
+      env,
+      timeout_s: RUNTIME_ENTRYPOINT_TIMEOUT_SECONDS,
+    });
+
+    if (result.exit_code !== 0) {
+      const detail = result.stderr.trim() || result.stdout.trim() || "unknown command failure";
+      throw new SuperserveApiError(`Failed to launch sandbox runtime: ${detail}`, 500);
+    }
+  }
+
+  getPreviewUrl(id: string, port: number): string {
+    if (!Number.isInteger(port) || port < MIN_PREVIEW_PORT || port > MAX_PREVIEW_PORT) {
+      throw new SuperserveApiError(
+        `Invalid Superserve preview port ${port}; expected ${MIN_PREVIEW_PORT}-${MAX_PREVIEW_PORT}`,
+        400
+      );
+    }
+    return `https://${port}-${id}.${this.sandboxHost}`;
+  }
+
+  private async controlPlaneRequest<T>(
+    method: "POST" | "DELETE",
+    path: string,
+    timeoutMs: number,
+    body?: unknown
+  ): Promise<T> {
+    return await this.request<T>(
+      `${this.apiUrl}${path}`,
+      {
+        method,
+        headers: {
+          "Content-Type": "application/json",
+          "X-API-Key": this.config.apiKey,
+        },
+        ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+      },
+      timeoutMs
+    );
+  }
+
+  private async dataPlaneRequest<T>(
+    id: string,
+    accessToken: string,
+    path: string,
+    body: unknown
+  ): Promise<T> {
+    const useSharedHost = SHARED_DATA_PLANE_HOSTS.has(this.sandboxHost.toLowerCase());
+    const baseUrl = useSharedHost
+      ? `https://${this.sandboxHost}`
+      : `https://boxd-${id}.${this.sandboxHost}`;
+    const routingHeaders: Record<string, string> = useSharedHost
+      ? { "X-Superserve-Sandbox-Id": id }
+      : {};
+
+    return await this.request<T>(
+      `${baseUrl}${path}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Access-Token": accessToken,
+          ...routingHeaders,
+        },
+        body: JSON.stringify(body),
+      },
+      EXEC_TIMEOUT_MS
+    );
+  }
+
+  private async request<T>(url: string, init: RequestInit, timeoutMs: number): Promise<T> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      let response: Response;
+      try {
+        response = await fetch(url, { ...init, signal: controller.signal });
+      } catch (error) {
+        if (controller.signal.aborted) {
+          throw new Error(`Superserve request timed out after ${timeoutMs}ms`);
+        }
+        throw error;
+      }
+
+      const responseText = await response.text();
+      if (response.status === 404) {
+        throw new SuperserveNotFoundError(responseText || `Not found: ${url}`);
+      }
+      if (!response.ok) {
+        throw new SuperserveApiError(responseText || response.statusText, response.status);
+      }
+      if (!responseText) return undefined as T;
+
+      try {
+        return JSON.parse(responseText) as T;
+      } catch {
+        throw new SuperserveApiError(`Invalid JSON response from Superserve: ${responseText}`, 502);
+      }
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+function normalizeSandboxHost(value: string): string {
+  const normalized = value
+    .trim()
+    .replace(/^https?:\/\//, "")
+    .replace(/\/+$/, "");
+  if (!normalized || normalized.includes("/")) {
+    throw new Error("SUPERSERVE_SANDBOX_HOST must be a bare hostname");
+  }
+  return normalized;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function createSuperserveRestClient(config: SuperserveRestConfig): SuperserveRestClient {
+  return new SuperserveRestClient(config);
+}

--- a/packages/control-plane/src/types.ts
+++ b/packages/control-plane/src/types.ts
@@ -67,6 +67,7 @@ export interface Env {
   ANTHROPIC_API_KEY?: string; // Anthropic API key for Claude models
   DAYTONA_API_KEY?: string; // Daytona REST API key (Bearer auth + HMAC derivation)
   OPENCOMPUTER_API_KEY?: string; // OpenComputer REST API key (X-API-Key auth + HMAC derivation)
+  SUPERSERVE_API_KEY?: string; // Superserve REST API key (X-API-Key auth + HMAC derivation)
   VERCEL_TOKEN?: string; // Vercel API access token for Sandbox API
   INTERNAL_CALLBACK_SECRET?: string; // For signing callbacks to slack-bot
   SLACK_BOT_TOKEN?: string; // Slack bot token for agent-initiated chat.postMessage calls
@@ -87,7 +88,7 @@ export interface Env {
   WORKER_URL?: string; // Base URL for the worker (for callbacks)
   WEB_APP_URL?: string; // Base URL for the web app (for PR links)
   CF_ACCOUNT_ID?: string; // Cloudflare account ID
-  SANDBOX_PROVIDER?: string; // "modal" (default), "daytona", "vercel", "opencomputer", or "e2b"
+  SANDBOX_PROVIDER?: string; // "modal" (default), "daytona", "vercel", "opencomputer", "e2b", or "superserve"
   MODAL_WORKSPACE?: string; // Modal workspace name
   MODAL_ENVIRONMENT?: string; // Modal environment name for dashboard URLs
   MODAL_ENVIRONMENT_WEB_SUFFIX?: string; // Modal environment web suffix for endpoint URLs
@@ -98,6 +99,12 @@ export interface Env {
   DAYTONA_TARGET?: string; // Optional Daytona target name
   OPENCOMPUTER_API_URL?: string; // OpenComputer REST API base URL
   OPENCOMPUTER_TEMPLATE?: string; // Declarative template containing sandbox runtime
+  SUPERSERVE_API_URL?: string; // Superserve control-plane REST API base URL
+  SUPERSERVE_TEMPLATE?: string; // Template containing the Open-Inspect sandbox runtime
+  SUPERSERVE_SANDBOX_HOST?: string; // Bare data-plane/preview hostname
+  SUPERSERVE_AUTO_DELETE_SECONDS?: string; // Optional paused-sandbox retention (0-2592000 seconds)
+  SUPERSERVE_NETWORK_ALLOW_OUT?: string; // Optional comma-separated domain/CIDR egress allow rules
+  SUPERSERVE_NETWORK_DENY_OUT?: string; // Optional comma-separated CIDR egress deny rules
   VERCEL_PROJECT_ID?: string; // Vercel project ID used for Sandbox API scope
   VERCEL_TEAM_ID?: string; // Optional Vercel team ID used for Sandbox API scope
   VERCEL_BASE_SNAPSHOT_ID?: string; // Optional prebuilt base snapshot with sandbox runtime

--- a/packages/superserve-infra/package.json
+++ b/packages/superserve-infra/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@open-inspect/superserve-infra",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "esbuild src/build-template.ts --bundle --format=esm --platform=node --target=node22 --outfile=dist/build-template.js --packages=external",
+    "build-template": "npm run build && npm run build-template:run --",
+    "build-template:run": "node dist/build-template.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@superserve/sdk": "^0.8.0",
+    "esbuild": "^0.28.1",
+    "typescript": "^5.7.2"
+  }
+}

--- a/packages/superserve-infra/src/build-template.ts
+++ b/packages/superserve-infra/src/build-template.ts
@@ -1,0 +1,214 @@
+import { execFileSync } from "node:child_process";
+import { NotFoundError, Template, type BuildStep } from "@superserve/sdk";
+
+const OPENCODE_VERSION = "1.17.18";
+const CODE_SERVER_VERSION = "4.109.5";
+const AGENT_BROWSER_VERSION = "0.21.2";
+const TTYD_VERSION = "1.7.7";
+const TTYD_SHA256 = "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55";
+const DEFAULT_RUNTIME_REPOSITORY = "https://github.com/ColeMurray/background-agents.git";
+const DEFAULT_TEMPLATE_NAME = "openinspect-runtime";
+const DEFAULT_BASE_IMAGE = "python:3.12-slim-bookworm";
+const DEFAULT_VCPU = 2;
+const DEFAULT_MEMORY_MIB = 2048;
+const DEFAULT_DISK_MIB = 8192;
+
+interface BuildOptions {
+  apiUrl: string;
+  apiKey: string;
+  templateName: string;
+  runtimeRepository: string;
+  runtimeRef: string;
+  dryRun: boolean;
+}
+
+async function main(): Promise<void> {
+  const options = resolveOptions(process.argv.slice(2));
+  const templateOptions = buildTemplateOptions(options);
+
+  if (options.dryRun) {
+    console.log(JSON.stringify(templateOptions, null, 2));
+    return;
+  }
+  if (!options.apiKey) {
+    throw new Error("SUPERSERVE_API_KEY is required to build a Superserve template");
+  }
+
+  console.log(`Building Superserve template ${options.templateName}`);
+  console.log(`API: ${options.apiUrl}`);
+  console.log(`Runtime source: ${options.runtimeRepository}@${options.runtimeRef}`);
+
+  const connection = { apiKey: options.apiKey, baseUrl: options.apiUrl };
+  let template: Template;
+  try {
+    template = await Template.connect(options.templateName, connection);
+    if (template.status === "ready") {
+      console.log(`Superserve template already ready: ${template.name} (${template.id})`);
+      return;
+    }
+    if (template.status === "failed") await template.rebuild();
+  } catch (error) {
+    if (!(error instanceof NotFoundError)) throw error;
+    template = await Template.create({ ...templateOptions, ...connection });
+  }
+  const result = await template.waitUntilReady({
+    onLog: (event) => {
+      if (event.stream !== "system") process.stdout.write(event.text);
+    },
+  });
+  console.log(`Superserve template ready: ${result.name} (${result.id})`);
+}
+
+function resolveOptions(args: string[]): BuildOptions {
+  const flags = new Set(args);
+  return {
+    apiUrl: (process.env.SUPERSERVE_API_URL || "https://api.superserve.ai").replace(/\/+$/, ""),
+    apiKey: process.env.SUPERSERVE_API_KEY || "",
+    templateName: process.env.SUPERSERVE_TEMPLATE || DEFAULT_TEMPLATE_NAME,
+    runtimeRepository: process.env.OPENINSPECT_RUNTIME_REPOSITORY || resolveGitRepository(),
+    runtimeRef: process.env.OPENINSPECT_RUNTIME_GIT_REF || resolveGitRef(),
+    dryRun: flags.has("--dry-run") || flags.has("--print-manifest"),
+  };
+}
+
+function resolveGitRepository(): string {
+  try {
+    const remote = execFileSync("git", ["remote", "get-url", "origin"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    const githubScpMatch = /^git@github\.com:(.+)$/.exec(remote);
+    if (githubScpMatch) return `https://github.com/${githubScpMatch[1]}`;
+    const githubSshMatch = /^ssh:\/\/git@github\.com\/(.+)$/.exec(remote);
+    if (githubSshMatch) return `https://github.com/${githubSshMatch[1]}`;
+    if (/^https?:\/\//.test(remote)) {
+      const url = new URL(remote);
+      url.username = "";
+      url.password = "";
+      return url.toString();
+    }
+  } catch {
+    // Fall back to the public upstream repository below.
+  }
+  return DEFAULT_RUNTIME_REPOSITORY;
+}
+
+function resolveGitRef(): string {
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "main";
+  }
+}
+
+function buildTemplateOptions(options: BuildOptions): {
+  name: string;
+  from: string;
+  vcpu: number;
+  memoryMib: number;
+  diskMib: number;
+  steps: BuildStep[];
+} {
+  const repository = shellQuote(options.runtimeRepository);
+  const runtimeRef = shellQuote(options.runtimeRef);
+  const steps: BuildStep[] = [
+    {
+      run:
+        "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y " +
+        "bash git curl build-essential ca-certificates gnupg openssh-client jq unzip procps " +
+        "libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 " +
+        "libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 " +
+        "libasound2 libpango-1.0-0 libcairo2 ffmpeg",
+    },
+    {
+      run:
+        "curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && " +
+        "DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs",
+    },
+    {
+      run:
+        "mkdir -p -m 755 /etc/apt/keyrings && " +
+        "curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg " +
+        "> /etc/apt/keyrings/githubcli-archive-keyring.gpg && " +
+        "chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && " +
+        'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" ' +
+        "> /etc/apt/sources.list.d/github-cli.list && apt-get update && " +
+        "DEBIAN_FRONTEND=noninteractive apt-get install -y gh",
+    },
+    {
+      run: 'python -m pip install --no-cache-dir --upgrade pip uv httpx websockets "pydantic>=2.0" "PyJWT[crypto]"',
+    },
+    {
+      run: `npm install -g pnpm@10 opencode-ai@${OPENCODE_VERSION} @opencode-ai/plugin@${OPENCODE_VERSION} zod@4.4.3 agent-browser@${AGENT_BROWSER_VERSION}`,
+    },
+    { run: "curl -fsSL https://bun.sh/install | bash" },
+    {
+      run:
+        `curl -fsSL -o /tmp/ttyd https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.x86_64 && ` +
+        `echo "${TTYD_SHA256}  /tmp/ttyd" | sha256sum -c - && ` +
+        "mv /tmp/ttyd /usr/local/bin/ttyd && chmod 0755 /usr/local/bin/ttyd",
+    },
+    {
+      run:
+        `curl -fsSL -o /tmp/code-server.deb https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/code-server_${CODE_SERVER_VERSION}_amd64.deb && ` +
+        "(dpkg -i /tmp/code-server.deb || (apt-get update && apt-get install -f -y)) && " +
+        "rm -f /tmp/code-server.deb",
+    },
+    { run: "PATH=/root/.bun/bin:$PATH agent-browser install || true" },
+    {
+      run:
+        `rm -rf /tmp/openinspect-source && git clone --filter=blob:none --no-checkout ${repository} /tmp/openinspect-source && ` +
+        `git -C /tmp/openinspect-source fetch --depth 1 origin ${runtimeRef} && ` +
+        "git -C /tmp/openinspect-source checkout --detach FETCH_HEAD && " +
+        "mkdir -p /app /workspace /tmp/opencode && " +
+        "cp -R /tmp/openinspect-source/packages/sandbox-runtime/src/sandbox_runtime /app/sandbox_runtime && " +
+        "rm -rf /tmp/openinspect-source",
+    },
+    {
+      run:
+        `mkdir -p /app/opencode-deps && printf '%s\\n' '${JSON.stringify({ name: "opencode-tools", type: "module", dependencies: { "@opencode-ai/plugin": OPENCODE_VERSION } })}' > /app/opencode-deps/package.json && ` +
+        "cd /app/opencode-deps && npm install --ignore-scripts --no-audit --no-fund",
+    },
+    {
+      run:
+        "printf '%s\\n' '#!/bin/sh' 'exec python3 -m sandbox_runtime.credentials.git_credential_helper \"$@\"' > /usr/local/bin/oi-git-credentials && " +
+        "chmod 0755 /usr/local/bin/oi-git-credentials && " +
+        "git config --system credential.helper /usr/local/bin/oi-git-credentials && " +
+        "git config --system credential.useHttpPath true",
+    },
+    {
+      run:
+        "printf '%s\\n' '#!/bin/sh' 'REAL_GH=\"/usr/bin/gh\"' 'token=$(python3 -m sandbox_runtime.credentials.git_credential_helper gh-token || true)' 'if [ -n \"$token\" ]; then' '  export GH_TOKEN=\"$token\"' 'fi' 'exec \"$REAL_GH\" \"$@\"' > /usr/local/bin/gh && " +
+        "chmod 0755 /usr/local/bin/gh",
+    },
+    { run: "rm -rf /var/lib/apt/lists/* /root/.cache/pip" },
+    { env: { key: "HOME", value: "/root" } },
+    { env: { key: "NODE_ENV", value: "development" } },
+    { env: { key: "PATH", value: "/root/.bun/bin:/usr/local/bin:/usr/bin:/bin" } },
+    { env: { key: "PYTHONPATH", value: "/app" } },
+    { env: { key: "NODE_PATH", value: "/usr/lib/node_modules:/usr/local/lib/node_modules" } },
+    { env: { key: "SANDBOX_VERSION", value: "superserve-v1-opencode-1-17-18" } },
+    { workdir: "/workspace" },
+  ];
+
+  return {
+    name: options.templateName,
+    from: DEFAULT_BASE_IMAGE,
+    vcpu: DEFAULT_VCPU,
+    memoryMib: DEFAULT_MEMORY_MIB,
+    diskMib: DEFAULT_DISK_MIB,
+    steps,
+  };
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/packages/superserve-infra/tsconfig.json
+++ b/packages/superserve-infra/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/web/src/lib/sandbox-provider.test.ts
+++ b/packages/web/src/lib/sandbox-provider.test.ts
@@ -63,6 +63,16 @@ describe("sandbox-provider", () => {
     expect(supportsRepoImages()).toBe(true);
   });
 
+  it("supports superserve without repo images", async () => {
+    delete process.env.NEXT_PUBLIC_SANDBOX_PROVIDER;
+    process.env.SANDBOX_PROVIDER = "superserve";
+
+    const { getPublicSandboxProvider, supportsRepoImages } = await loadProvider();
+
+    expect(getPublicSandboxProvider()).toBe("superserve");
+    expect(supportsRepoImages()).toBe(false);
+  });
+
   it("throws for unsupported providers", async () => {
     process.env.NEXT_PUBLIC_SANDBOX_PROVIDER = "fly";
 

--- a/packages/web/src/lib/sandbox-provider.ts
+++ b/packages/web/src/lib/sandbox-provider.ts
@@ -2,7 +2,13 @@
  * Public sandbox backend helpers for the web app.
  */
 
-export type PublicSandboxProvider = "modal" | "daytona" | "vercel" | "opencomputer" | "e2b";
+export type PublicSandboxProvider =
+  | "modal"
+  | "daytona"
+  | "vercel"
+  | "opencomputer"
+  | "e2b"
+  | "superserve";
 
 export function getPublicSandboxProvider(): PublicSandboxProvider {
   const rawValue = process.env.NEXT_PUBLIC_SANDBOX_PROVIDER ?? process.env.SANDBOX_PROVIDER;
@@ -16,7 +22,8 @@ export function getPublicSandboxProvider(): PublicSandboxProvider {
     value === "daytona" ||
     value === "vercel" ||
     value === "opencomputer" ||
-    value === "e2b"
+    value === "e2b" ||
+    value === "superserve"
   ) {
     return value;
   }

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -221,6 +221,15 @@ VERCEL_SANDBOX_RUNTIME # Optional; defaults to node24
 VERCEL_SNAPSHOT_EXPIRATION_MS # Optional; defaults to 0
 VERCEL_SANDBOX_API_BASE_URL # Optional advanced Vercel Sandbox API base URL override
 
+# Superserve (only if SANDBOX_PROVIDER=superserve)
+SUPERSERVE_API_URL
+SUPERSERVE_API_KEY
+SUPERSERVE_TEMPLATE # Optional existing template; empty builds a managed template
+SUPERSERVE_SANDBOX_HOST
+SUPERSERVE_AUTO_DELETE_SECONDS # Optional paused-sandbox retention
+SUPERSERVE_NETWORK_ALLOW_OUT # Optional Terraform list of domain/CIDR allow rules
+SUPERSERVE_NETWORK_DENY_OUT # Optional Terraform list of CIDR deny rules
+
 # GitHub OAuth App
 GH_OAUTH_CLIENT_ID
 GH_OAUTH_CLIENT_SECRET

--- a/terraform/environments/production/locals.tf
+++ b/terraform/environments/production/locals.tf
@@ -5,6 +5,7 @@ locals {
   use_vercel_backend       = var.sandbox_provider == "vercel"
   use_opencomputer_backend = var.sandbox_provider == "opencomputer"
   use_e2b_backend          = var.sandbox_provider == "e2b"
+  use_superserve_backend   = var.sandbox_provider == "superserve"
 
   # Google login is enabled only when both OAuth credentials are configured.
   # Drives the build-time NEXT_PUBLIC_GOOGLE_ENABLED flag (sign-in button) and

--- a/terraform/environments/production/outputs.tf
+++ b/terraform/environments/production/outputs.tf
@@ -81,6 +81,11 @@ output "sandbox_provider" {
   value       = var.sandbox_provider
 }
 
+output "superserve_template_name" {
+  description = "Superserve runtime template configured for sandbox creation"
+  value       = local.use_superserve_backend ? (var.superserve_template != "" ? var.superserve_template : module.superserve_infra[0].template_name) : null
+}
+
 output "vercel_base_snapshot_id" {
   description = "Vercel base runtime snapshot ID configured for sandbox creation"
   value       = local.use_vercel_backend && var.vercel_base_snapshot_id != "" ? var.vercel_base_snapshot_id : null

--- a/terraform/environments/production/superserve.tf
+++ b/terraform/environments/production/superserve.tf
@@ -1,0 +1,43 @@
+# =============================================================================
+# Superserve Sandbox Infrastructure
+# =============================================================================
+
+data "external" "superserve_source_hash" {
+  count = local.use_superserve_backend ? 1 : 0
+
+  program = ["bash", "-c", <<-EOF
+    set -euo pipefail
+    cd "${var.project_root}"
+    paths=(
+      packages/sandbox-runtime/src
+      packages/sandbox-runtime/pyproject.toml
+      packages/superserve-infra/src/build-template.ts
+      packages/superserve-infra/package.json
+      package-lock.json
+    )
+    if command -v sha256sum &> /dev/null; then
+      hash=$(find "$${paths[@]}" -type f \
+        -not -path '*/__pycache__/*' -not -path '*/.pytest_cache/*' -not -path '*/.ruff_cache/*' \
+        -not -name '*.pyc' -not -name '.DS_Store' \
+        -exec sha256sum {} \; | sort | sha256sum | cut -d' ' -f1)
+    else
+      hash=$(find "$${paths[@]}" -type f \
+        -not -path '*/__pycache__/*' -not -path '*/.pytest_cache/*' -not -path '*/.ruff_cache/*' \
+        -not -name '*.pyc' -not -name '.DS_Store' \
+        -exec shasum -a 256 {} \; | sort | shasum -a 256 | cut -d' ' -f1)
+    fi
+    echo "{\"hash\": \"$hash\"}"
+  EOF
+  ]
+}
+
+module "superserve_infra" {
+  count  = local.use_superserve_backend ? 1 : 0
+  source = "../../modules/superserve-infra"
+
+  api_url         = var.superserve_api_url
+  api_key         = var.superserve_api_key
+  manual_template = var.superserve_template
+  project_root    = var.project_root
+  source_hash     = data.external.superserve_source_hash[0].result.hash
+}

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -115,6 +115,18 @@ e2b_template_id = ""           # e.g., "open-inspect-sandbox"
 # sandbox on inbound activity. Default true; set false to kill on timeout.
 # e2b_auto_pause = true
 
+# Superserve REST API
+# Only required when sandbox_provider = "superserve".
+# Leave superserve_template empty to build a managed runtime template during apply.
+superserve_api_url       = "https://api.superserve.ai"
+superserve_api_key       = ""
+superserve_template      = ""
+superserve_sandbox_host  = "sandbox.superserve.ai"
+# superserve_auto_delete_seconds = 604800
+# Strict allowlist example: include the control-plane, SCM, and LLM hosts required by your deployment.
+# superserve_network_allow_out = ["open-inspect-control-plane-example.workers.dev", "github.com", "api.github.com", "api.anthropic.com"]
+# superserve_network_deny_out  = ["0.0.0.0/0"]
+
 # =============================================================================
 # GitHub App Credentials
 # =============================================================================

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -393,6 +393,73 @@ variable "opencomputer_template" {
   default     = ""
 }
 
+variable "superserve_api_url" {
+  description = "Base URL for the Superserve control-plane REST API"
+  type        = string
+  default     = "https://api.superserve.ai"
+
+  validation {
+    condition     = var.sandbox_provider != "superserve" || length(trimspace(var.superserve_api_url)) > 0
+    error_message = "superserve_api_url must be set when sandbox_provider = 'superserve'."
+  }
+}
+
+variable "superserve_api_key" {
+  description = "API key for the Superserve REST API (X-API-Key auth)"
+  type        = string
+  sensitive   = true
+  default     = ""
+
+  validation {
+    condition     = var.sandbox_provider != "superserve" || length(trimspace(var.superserve_api_key)) > 0
+    error_message = "superserve_api_key must be set when sandbox_provider = 'superserve'."
+  }
+}
+
+variable "superserve_template" {
+  description = "Optional existing Superserve template. When empty, Terraform builds a managed Open-Inspect runtime template."
+  type        = string
+  default     = ""
+}
+
+variable "superserve_sandbox_host" {
+  description = "Bare Superserve data-plane and preview hostname"
+  type        = string
+  default     = "sandbox.superserve.ai"
+
+  validation {
+    condition     = var.sandbox_provider != "superserve" || can(regex("^[a-zA-Z0-9.-]+$", var.superserve_sandbox_host))
+    error_message = "superserve_sandbox_host must be a bare hostname without a scheme, port, or path."
+  }
+}
+
+variable "superserve_auto_delete_seconds" {
+  description = "Optional seconds to retain a continuously paused Superserve sandbox; null keeps it indefinitely"
+  type        = number
+  default     = null
+
+  validation {
+    condition = var.superserve_auto_delete_seconds == null ? true : (
+      var.superserve_auto_delete_seconds >= 0 &&
+      var.superserve_auto_delete_seconds <= 2592000 &&
+      floor(var.superserve_auto_delete_seconds) == var.superserve_auto_delete_seconds
+    )
+    error_message = "superserve_auto_delete_seconds must be null or an integer from 0 to 2592000."
+  }
+}
+
+variable "superserve_network_allow_out" {
+  description = "Domain or CIDR egress allow rules applied to each Superserve sandbox"
+  type        = list(string)
+  default     = []
+}
+
+variable "superserve_network_deny_out" {
+  description = "CIDR egress deny rules applied to each Superserve sandbox"
+  type        = list(string)
+  default     = []
+}
+
 variable "vercel_sandbox_token" {
   description = "Vercel API token for the Vercel Sandbox API"
   type        = string
@@ -502,13 +569,13 @@ variable "nextauth_secret" {
 # =============================================================================
 
 variable "sandbox_provider" {
-  description = "Sandbox backend for session execution: 'modal', 'daytona', 'vercel', 'opencomputer', or 'e2b'"
+  description = "Sandbox backend for session execution: 'modal', 'daytona', 'vercel', 'opencomputer', 'e2b', or 'superserve'"
   type        = string
   default     = "modal"
 
   validation {
-    condition     = contains(["modal", "daytona", "vercel", "opencomputer", "e2b"], var.sandbox_provider)
-    error_message = "sandbox_provider must be 'modal', 'daytona', 'vercel', 'opencomputer', or 'e2b'."
+    condition     = contains(["modal", "daytona", "vercel", "opencomputer", "e2b", "superserve"], var.sandbox_provider)
+    error_message = "sandbox_provider must be 'modal', 'daytona', 'vercel', 'opencomputer', 'e2b', or 'superserve'."
   }
 }
 

--- a/terraform/environments/production/workers-control-plane.tf
+++ b/terraform/environments/production/workers-control-plane.tf
@@ -92,6 +92,23 @@ module "control_plane_worker" {
         value = var.opencomputer_template != "" ? var.opencomputer_template : module.opencomputer_infra[0].snapshot_name,
       },
     ] : [],
+    local.use_superserve_backend ? [
+      { name = "SUPERSERVE_API_URL", value = var.superserve_api_url },
+      { name = "SUPERSERVE_SANDBOX_HOST", value = var.superserve_sandbox_host },
+      {
+        name  = "SUPERSERVE_TEMPLATE",
+        value = var.superserve_template != "" ? var.superserve_template : module.superserve_infra[0].template_name,
+      },
+    ] : [],
+    local.use_superserve_backend && var.superserve_auto_delete_seconds != null ? [
+      { name = "SUPERSERVE_AUTO_DELETE_SECONDS", value = tostring(var.superserve_auto_delete_seconds) },
+    ] : [],
+    local.use_superserve_backend && length(var.superserve_network_allow_out) > 0 ? [
+      { name = "SUPERSERVE_NETWORK_ALLOW_OUT", value = join(",", var.superserve_network_allow_out) },
+    ] : [],
+    local.use_superserve_backend && length(var.superserve_network_deny_out) > 0 ? [
+      { name = "SUPERSERVE_NETWORK_DENY_OUT", value = join(",", var.superserve_network_deny_out) },
+    ] : [],
     local.use_vercel_backend ? [
       { name = "VERCEL_PROJECT_ID", value = var.vercel_sandbox_project_id },
       { name = "VERCEL_RUNTIME", value = var.vercel_sandbox_runtime },
@@ -140,6 +157,10 @@ module "control_plane_worker" {
       { name = "OPENCOMPUTER_API_KEY", value = var.opencomputer_api_key },
       { name = "ANTHROPIC_API_KEY", value = var.anthropic_api_key },
     ] : [],
+    local.use_superserve_backend ? [
+      { name = "SUPERSERVE_API_KEY", value = var.superserve_api_key },
+      { name = "ANTHROPIC_API_KEY", value = var.anthropic_api_key },
+    ] : [],
     local.use_vercel_backend ? [
       { name = "VERCEL_TOKEN", value = var.vercel_sandbox_token },
     ] : [],
@@ -178,5 +199,6 @@ module "control_plane_worker" {
     module.vercel_sandbox_infra,
     module.opencomputer_infra,
     module.e2b_infra,
+    module.superserve_infra,
   ]
 }

--- a/terraform/modules/superserve-infra/main.tf
+++ b/terraform/modules/superserve-infra/main.tf
@@ -1,0 +1,28 @@
+# Superserve template containing the Open-Inspect sandbox runtime.
+
+locals {
+  template_name = "openinspect-runtime-${substr(var.source_hash, 0, 16)}"
+}
+
+resource "null_resource" "superserve_template" {
+  count = var.manual_template == "" ? 1 : 0
+
+  triggers = {
+    source_hash = var.source_hash
+    name        = local.template_name
+    api_url     = var.api_url
+    script_hash = filesha256("${path.module}/scripts/build-template.sh")
+  }
+
+  provisioner "local-exec" {
+    command     = "${path.module}/scripts/build-template.sh"
+    interpreter = ["bash"]
+
+    environment = {
+      PROJECT_ROOT        = var.project_root
+      SUPERSERVE_API_URL  = var.api_url
+      SUPERSERVE_API_KEY  = var.api_key
+      SUPERSERVE_TEMPLATE = local.template_name
+    }
+  }
+}

--- a/terraform/modules/superserve-infra/outputs.tf
+++ b/terraform/modules/superserve-infra/outputs.tf
@@ -1,0 +1,4 @@
+output "template_name" {
+  description = "Deterministic Superserve template name containing the Open-Inspect runtime"
+  value       = local.template_name
+}

--- a/terraform/modules/superserve-infra/scripts/build-template.sh
+++ b/terraform/modules/superserve-infra/scripts/build-template.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${PROJECT_ROOT:-}" ]]; then
+    echo "Error: PROJECT_ROOT environment variable is not set"
+    exit 1
+fi
+
+if [[ -z "${SUPERSERVE_API_URL:-}" ]]; then
+    echo "Error: SUPERSERVE_API_URL environment variable is not set"
+    exit 1
+fi
+
+if [[ -z "${SUPERSERVE_API_KEY:-}" ]]; then
+    echo "Error: SUPERSERVE_API_KEY environment variable is not set"
+    exit 1
+fi
+
+if [[ -z "${SUPERSERVE_TEMPLATE:-}" ]]; then
+    echo "Error: SUPERSERVE_TEMPLATE environment variable is not set"
+    exit 1
+fi
+
+cd "${PROJECT_ROOT}"
+
+export OPENINSPECT_RUNTIME_GIT_REF="${OPENINSPECT_RUNTIME_GIT_REF:-$(git rev-parse HEAD)}"
+npm run build -w @open-inspect/superserve-infra
+node packages/superserve-infra/dist/build-template.js

--- a/terraform/modules/superserve-infra/variables.tf
+++ b/terraform/modules/superserve-infra/variables.tf
@@ -1,0 +1,26 @@
+variable "api_url" {
+  description = "Superserve control-plane API URL used to build the managed template"
+  type        = string
+}
+
+variable "api_key" {
+  description = "Superserve API key used to build the managed template"
+  type        = string
+  sensitive   = true
+}
+
+variable "manual_template" {
+  description = "Optional existing Superserve template name. When set, Terraform skips the managed build."
+  type        = string
+  default     = ""
+}
+
+variable "project_root" {
+  description = "Path to the Open-Inspect repository root"
+  type        = string
+}
+
+variable "source_hash" {
+  description = "Hash of files that should trigger a managed template rebuild"
+  type        = string
+}


### PR DESCRIPTION
## Summary

- add a Superserve sandbox provider with create, activate/resume, pause, delete, runtime launch, preview URL, networking, and auto-delete support
- add a managed Superserve runtime template builder plus Terraform, Worker binding, secret, and CI integration
- register Superserve in the control plane and web provider model, with lifecycle and REST client coverage
- document setup, capabilities, networking, lifecycle behavior, and the current trusted-repository security boundary

## Why

Open-Inspect currently depends on its existing sandbox data plane. This adds a working Superserve-backed MVP while preserving the existing sandbox-provider abstraction and session lifecycle.

## Behavior and impact

- Superserve sandboxes support persistent pause/resume and explicit stop.
- Missing paused sandboxes request a fresh spawn.
- Snapshots and snapshot restore remain unsupported for this provider.
- The runtime bridge is launched explicitly and guarded against duplicate processes after resume.
- This MVP passes runtime and repository credentials through sandbox environment variables, so it should currently be used with trusted repositories. Optional egress controls reduce exposure but are not credential isolation.

## Validation

- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/control-plane`
- control-plane full suite: 1,914 tests passed
- Superserve-focused control-plane suite: 35 tests passed
- `npm run typecheck -w @open-inspect/web`
- web sandbox-provider tests: 6 tests passed
- Superserve template package typecheck, build, and dry-run passed
- ESLint, Prettier, pre-commit checks, and `git diff --check` passed

## Remaining live checks

- A real Superserve template build and sandbox session require Superserve credentials and were not run locally.
- Terraform/OpenTofu was unavailable locally, so Terraform CLI validation was not run.
