### PR TITLE
fix(control-plane): lazily fail timed-out builds at trigger time

### DIFF
--- a/packages/control-plane/src/db/image-builds.ts
+++ b/packages/control-plane/src/db/image-builds.ts
@@ -51,6 +51,10 @@ void _statusViewComplete;
 
 const STATUS_VIEW_COLUMNS = STATUS_VIEW_KEYS.join(", ");
 
+// One message for both sweeps (global cron + lazy trigger-time) so a stale
+// mark is attributable regardless of which path performed it.
+const STALE_BUILD_TIMEOUT_MESSAGE = "build timed out (no callback received)";
+
 /** Row slice read by the callback-token auth checks. */
 interface CallbackTokenRow {
   id: string;
@@ -778,7 +782,30 @@ export class ImageBuildStore {
       .prepare(
         "UPDATE image_builds SET status = 'failed', error_message = ? WHERE status = 'building' AND created_at < ?"
       )
-      .bind("build timed out (no callback received)", cutoff)
+      .bind(STALE_BUILD_TIMEOUT_MESSAGE, cutoff)
+      .run();
+
+    return result.meta?.changes ?? 0;
+  }
+
+  /**
+   * Scoped twin of markStaleBuildsAsFailed for lazy trigger-time recovery: a
+   * dead `building` row otherwise wedges its scope forever on deployments
+   * with no sweep (the concurrency-1 guard has no age cutoff).
+   */
+  async markScopeStaleBuildFailed(
+    scope: ImageBuildScope,
+    provider: ImageBuildProvider,
+    maxAgeMs: number
+  ): Promise<number> {
+    const cutoff = Date.now() - maxAgeMs;
+    const result = await this.db
+      .prepare(
+        `UPDATE image_builds SET status = 'failed', error_message = ?
+         WHERE scope_kind = ? AND scope_id = ? AND provider = ? AND status = 'building'
+           AND created_at < ?`
+      )
+      .bind(STALE_BUILD_TIMEOUT_MESSAGE, scope.kind, scope.id, provider, cutoff)
       .run();
 
     return result.meta?.changes ?? 0;

--- a/packages/control-plane/src/image-builds/maintenance.test.ts
+++ b/packages/control-plane/src/image-builds/maintenance.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { MAX_BUILD_TIMEOUT_SECONDS } from "@open-inspect/shared";
+import { VERCEL_MAX_SANDBOX_TIMEOUT_MS } from "../sandbox/providers/vercel/provider";
+import { DEFAULT_STALE_BUILD_MAX_AGE_MS } from "./maintenance";
+
+describe("DEFAULT_STALE_BUILD_MAX_AGE_MS", () => {
+  it("matches the historical 70-minute sweep threshold", () => {
+    expect(DEFAULT_STALE_BUILD_MAX_AGE_MS).toBe(4_200_000);
+  });
+
+  // A `building` row older than the threshold must be provably dead, or the
+  // stale mark fails live builds mid-flight and the scope loops on rebuilds.
+  // Each provider's build-sandbox lifetime ceiling must stay at or under it.
+
+  it("covers the shared build-timeout ceiling (Modal and OpenComputer)", () => {
+    // Both providers' sandbox lifetimes are capped at MAX_BUILD_TIMEOUT_SECONDS
+    // by the planner (resolveBuildTimeoutSeconds). Strict: the Modal build
+    // worker additionally idles through the snapshot budget plus a margin —
+    // build_function_timeout_seconds in packages/modal-infra/src/sandbox/manager.py.
+    expect(MAX_BUILD_TIMEOUT_SECONDS * 1000).toBeLessThan(DEFAULT_STALE_BUILD_MAX_AGE_MS);
+  });
+
+  it("covers Vercel's sandbox lifetime ceiling", () => {
+    expect(VERCEL_MAX_SANDBOX_TIMEOUT_MS).toBeLessThanOrEqual(DEFAULT_STALE_BUILD_MAX_AGE_MS);
+  });
+});

--- a/packages/control-plane/src/image-builds/maintenance.test.ts
+++ b/packages/control-plane/src/image-builds/maintenance.test.ts
@@ -8,9 +8,11 @@ describe("DEFAULT_STALE_BUILD_MAX_AGE_MS", () => {
     expect(DEFAULT_STALE_BUILD_MAX_AGE_MS).toBe(4_200_000);
   });
 
-  // A `building` row older than the threshold must be provably dead, or the
-  // stale mark fails live builds mid-flight and the scope loops on rebuilds.
-  // Each provider's build-sandbox lifetime ceiling must stay at or under it.
+  // The stale mark presumes a `building` row older than the threshold is
+  // dead, so each provider's build-sandbox lifetime ceiling must stay at or
+  // under it — otherwise the mark fails live builds mid-flight and the scope
+  // loops on rebuilds. (Dispatch/queue delay before sandbox start is absorbed
+  // by the margin, not modeled; see the constant's doc comment.)
 
   it("covers the shared build-timeout ceiling (Modal and OpenComputer)", () => {
     // Both providers' sandbox lifetimes are capped at MAX_BUILD_TIMEOUT_SECONDS

--- a/packages/control-plane/src/image-builds/maintenance.ts
+++ b/packages/control-plane/src/image-builds/maintenance.ts
@@ -6,7 +6,7 @@ const SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS = 300;
 const BUILD_FUNCTION_TIMEOUT_MARGIN_SECONDS = 300;
 
 /**
- * Age past which a `building` row is provably dead and safe to fail: sized at
+ * Age past which a `building` row is presumed dead and safe to fail: sized at
  * the longest possible build's worker lifetime so a long-but-live build is
  * never reaped. Modal is the worst case — sandbox lifetime is capped at
  * MAX_BUILD_TIMEOUT_SECONDS, and its build worker idles through the snapshot
@@ -14,8 +14,16 @@ const BUILD_FUNCTION_TIMEOUT_MARGIN_SECONDS = 300;
  * packages/modal-infra/src/sandbox/manager.py). Vercel and OpenComputer
  * ceilings sit at or under this; maintenance.test.ts pins all three, so a
  * provider lifetime bump past the threshold fails CI instead of live-failing
- * long builds. The clock starts at row registration (`created_at`), not
- * sandbox start, so provider queueing eats into the margin.
+ * long builds.
+ *
+ * The clock starts at row registration (`created_at`), not sandbox start, so
+ * dispatch latency and provider queueing eat into the margin: a build that
+ * both runs to its full timeout AND is queued longer than the margin before
+ * executing would be misclassified. That residual window is inherited from
+ * the cron sweep (the Modal scheduler has always posted this same threshold
+ * to /image-builds/mark-stale), and the blast radius is a redundant rebuild —
+ * the misclassified build's late callback is rejected by the
+ * `status = 'building'` completion guards, never recorded over the new build.
  */
 export const DEFAULT_STALE_BUILD_MAX_AGE_MS =
   (MAX_BUILD_TIMEOUT_SECONDS +

--- a/packages/control-plane/src/image-builds/maintenance.ts
+++ b/packages/control-plane/src/image-builds/maintenance.ts
@@ -1,0 +1,24 @@
+import { MAX_BUILD_TIMEOUT_SECONDS } from "@open-inspect/shared";
+
+// Mirrors SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS in packages/modal-infra/src/sandbox/manager.py.
+const SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS = 300;
+// Mirrors BUILD_FUNCTION_TIMEOUT_MARGIN_SECONDS in packages/modal-infra/src/sandbox/manager.py.
+const BUILD_FUNCTION_TIMEOUT_MARGIN_SECONDS = 300;
+
+/**
+ * Age past which a `building` row is provably dead and safe to fail: sized at
+ * the longest possible build's worker lifetime so a long-but-live build is
+ * never reaped. Modal is the worst case — sandbox lifetime is capped at
+ * MAX_BUILD_TIMEOUT_SECONDS, and its build worker idles through the snapshot
+ * budget plus a margin on top (build_function_timeout_seconds in
+ * packages/modal-infra/src/sandbox/manager.py). Vercel and OpenComputer
+ * ceilings sit at or under this; maintenance.test.ts pins all three, so a
+ * provider lifetime bump past the threshold fails CI instead of live-failing
+ * long builds. The clock starts at row registration (`created_at`), not
+ * sandbox start, so provider queueing eats into the margin.
+ */
+export const DEFAULT_STALE_BUILD_MAX_AGE_MS =
+  (MAX_BUILD_TIMEOUT_SECONDS +
+    SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS +
+    BUILD_FUNCTION_TIMEOUT_MARGIN_SECONDS) *
+  1000;

--- a/packages/control-plane/src/image-builds/workflow.test.ts
+++ b/packages/control-plane/src/image-builds/workflow.test.ts
@@ -11,6 +11,7 @@ import {
   ImageBuildTriggerFailedError,
   ImageBuildWorkflowUnavailableError,
 } from "./errors";
+import { DEFAULT_STALE_BUILD_MAX_AGE_MS } from "./maintenance";
 import type { ImageBuildScope } from "./model";
 import type { ImageBuildAdapterFactory } from "./provider-factory";
 import type { PlannedImageBuild } from "./types";
@@ -33,6 +34,7 @@ function createStore() {
   return {
     registerBuild: vi.fn().mockResolvedValue(true),
     getActiveBuild: vi.fn().mockResolvedValue(null),
+    markScopeStaleBuildFailed: vi.fn().mockResolvedValue(0),
     hasReadyImageForFingerprint: vi.fn().mockResolvedValue(false),
     getCallbackBuild: vi.fn().mockResolvedValue(null),
     getBuildRow: vi.fn().mockResolvedValue(null),
@@ -192,6 +194,60 @@ describe("ImageBuildWorkflow", () => {
       expect(result).toEqual({ type: "already_building", buildId: "imgb-existing" });
       expect(planBuild).not.toHaveBeenCalled();
       expect(store.registerBuild).not.toHaveBeenCalled();
+    });
+
+    it("lazily fails a timed-out build before the in-flight check", async () => {
+      const store = createStore();
+      store.markScopeStaleBuildFailed.mockResolvedValue(1);
+      const { workflow } = createWorkflow({ store });
+
+      const result = await workflow.triggerBuild(ENV_SCOPE, ctx);
+
+      expect(result.type).toBe("triggered");
+      expect(store.markScopeStaleBuildFailed).toHaveBeenCalledWith(
+        ENV_SCOPE,
+        "modal",
+        DEFAULT_STALE_BUILD_MAX_AGE_MS
+      );
+      // The wedged row must be failed before the in-flight read, or the read
+      // still sees it and re-wedges the scope.
+      expect(store.markScopeStaleBuildFailed.mock.invocationCallOrder[0]).toBeLessThan(
+        store.getActiveBuild.mock.invocationCallOrder[0]
+      );
+    });
+
+    it("still reports a fresh in-flight build after the lazy stale check", async () => {
+      const store = createStore();
+      store.getActiveBuild.mockResolvedValue({ id: "imgb-fresh" });
+      const { workflow, planBuild } = createWorkflow({ store });
+
+      const result = await workflow.triggerBuild(ENV_SCOPE, ctx);
+
+      expect(result).toEqual({ type: "already_building", buildId: "imgb-fresh" });
+      expect(store.markScopeStaleBuildFailed).toHaveBeenCalled();
+      expect(planBuild).not.toHaveBeenCalled();
+    });
+
+    it("a lazy stale-mark failure never blocks the in-flight report", async () => {
+      const store = createStore();
+      store.markScopeStaleBuildFailed.mockRejectedValue(new Error("D1 unavailable"));
+      store.getActiveBuild.mockResolvedValue({ id: "imgb-existing" });
+      const { workflow } = createWorkflow({ store });
+
+      const result = await workflow.triggerBuild(ENV_SCOPE, ctx);
+
+      expect(result).toEqual({ type: "already_building", buildId: "imgb-existing" });
+    });
+
+    it("a lazy stale-mark failure never blocks a fresh trigger", async () => {
+      const store = createStore();
+      store.markScopeStaleBuildFailed.mockRejectedValue(new Error("D1 unavailable"));
+      const { workflow } = createWorkflow({ store });
+
+      const result = await workflow.triggerBuild(ENV_SCOPE, ctx);
+
+      expect(result.type).toBe("triggered");
+      expect(store.registerBuild).toHaveBeenCalled();
     });
 
     it("yields to a concurrent trigger that wins the registerBuild guard", async () => {

--- a/packages/control-plane/src/image-builds/workflow.ts
+++ b/packages/control-plane/src/image-builds/workflow.ts
@@ -23,6 +23,7 @@ import {
   ImageBuildTriggerFailedError,
   ImageBuildWorkflowUnavailableError,
 } from "./errors";
+import { DEFAULT_STALE_BUILD_MAX_AGE_MS } from "./maintenance";
 import {
   parseRuntimeVersionNumber,
   type ImageBuildProvider,
@@ -134,6 +135,37 @@ export class ImageBuildWorkflow {
     return await this.trigger(scope, ctx, { onlyIfStale: true });
   }
 
+  /**
+   * Lazy wedge recovery: a build whose sandbox died without a callback would
+   * hold the concurrency-1 guard forever (getActiveBuild has no age cutoff).
+   * Best-effort — a hygiene failure must never fail the trigger.
+   */
+  private async failStaleScopeBuild(
+    scope: ImageBuildScope,
+    provider: ImageBuildProvider,
+    ctx: ImageBuildWorkflowContext
+  ): Promise<void> {
+    const logContext = {
+      scope_kind: scope.kind,
+      scope_id: scope.id,
+      provider,
+      request_id: ctx.request_id,
+      trace_id: ctx.trace_id,
+    };
+    try {
+      const staleFailed = await this.store.markScopeStaleBuildFailed(
+        scope,
+        provider,
+        DEFAULT_STALE_BUILD_MAX_AGE_MS
+      );
+      if (staleFailed > 0) {
+        logger.warn("image_build.stale_lazy_marked", { build_count: staleFailed, ...logContext });
+      }
+    } catch (e) {
+      logger.warn("image_build.stale_lazy_mark_error", { error: errorMessage(e), ...logContext });
+    }
+  }
+
   private async trigger(
     scope: ImageBuildScope,
     ctx: ImageBuildWorkflowContext,
@@ -147,6 +179,8 @@ export class ImageBuildWorkflow {
     }
 
     const provider = this.provider;
+    await this.failStaleScopeBuild(scope, provider, ctx);
+
     const active = await this.store.getActiveBuild(scope, provider);
     if (active) {
       return { type: "already_building", buildId: active.id };

--- a/packages/control-plane/src/routes/image-builds.ts
+++ b/packages/control-plane/src/routes/image-builds.ts
@@ -15,6 +15,7 @@ import { RepoMetadataStore } from "../db/repo-metadata";
 import { createLogger } from "../logger";
 import { getImageBuildCallbackBearerToken } from "../image-builds/callback-auth";
 import { ImageBuildError } from "../image-builds/errors";
+import { DEFAULT_STALE_BUILD_MAX_AGE_MS } from "../image-builds/maintenance";
 import {
   MIN_COMPATIBLE_RUNTIME_VERSION,
   repoImageBuildScope,
@@ -49,7 +50,6 @@ import {
 const logger = createLogger("router:image-builds");
 const MS_PER_SECOND = 1000;
 const MAX_CALLBACK_BODY_BYTES = 16 * 1024;
-const DEFAULT_STALE_BUILD_MAX_AGE_MS = 4200 * MS_PER_SECOND;
 const DEFAULT_FAILED_BUILD_CLEANUP_MAX_AGE_MS = 86400 * MS_PER_SECOND;
 
 interface ImageBuildCompleteBody {

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.ts
@@ -45,7 +45,8 @@ const TUNNEL_ENV_FILE_PATH = "/workspace/.tunnels.env";
 const TUNNEL_ENV_SANDBOX_ID_KEY = "TUNNEL_SANDBOX_ID";
 const EXPECTED_TUNNEL_PORTS_ENV_VAR = "EXPECTED_TUNNEL_PORTS";
 const DEFAULT_SNAPSHOT_EXPIRATION_MS = 0;
-const VERCEL_MAX_SANDBOX_TIMEOUT_MS = 45 * 60 * 1000;
+// Exported for the stale-threshold ceiling assertion in image-builds/maintenance.test.ts.
+export const VERCEL_MAX_SANDBOX_TIMEOUT_MS = 45 * 60 * 1000;
 const VERCEL_MEMORY_MIB_PER_VCPU = 2048;
 const VERCEL_SUPPORTED_VCPUS: readonly VercelVcpus[] = [1, 2, 4, 8];
 const VERCEL_MAX_VCPUS = VERCEL_SUPPORTED_VCPUS[VERCEL_SUPPORTED_VCPUS.length - 1];

--- a/packages/control-plane/test/integration/image-build-helpers.ts
+++ b/packages/control-plane/test/integration/image-build-helpers.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared D1 seed/read helpers for the image-build integration suites
+ * (image-builds.test.ts, image-build-stale-recovery.test.ts).
+ */
+import { env } from "cloudflare:test";
+import { EnvironmentStore } from "../../src/db/environments";
+import type { ImageBuildScope } from "../../src/image-builds/model";
+
+export const RUNTIME_VERSION = "v53-list-native-runtime";
+export const REPOSITORY_SHAS = [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }];
+
+export function environmentScope(id: string): ImageBuildScope {
+  return { kind: "environment", id };
+}
+
+export async function seedEnvironment(opts?: {
+  id?: string;
+  name?: string;
+  prebuildEnabled?: boolean;
+  repositories?: [string, string, number, string][];
+}): Promise<string> {
+  const store = new EnvironmentStore(env.DB);
+  const id = opts?.id ?? `env_${Math.random().toString(36).slice(2, 10)}`;
+  const now = Date.now();
+  await store.create(
+    {
+      id,
+      name: opts?.name ?? `Seeded ${id}`,
+      description: null,
+      prebuild_enabled: opts?.prebuildEnabled ? 1 : 0,
+      channel_associations: null,
+      created_at: now,
+      updated_at: now,
+    },
+    (opts?.repositories ?? [["acme", "web", 1, "main"]]).map(([o, n, rid, b], position) => ({
+      position,
+      repo_owner: o,
+      repo_name: n,
+      repo_id: rid,
+      base_branch: b,
+    }))
+  );
+  return id;
+}
+
+/** Raw insert when a test needs to control created_at/status/artifact. */
+export async function seedImageRowForScope(
+  scope: ImageBuildScope,
+  row: {
+    id: string;
+    status: string;
+    provider?: string;
+    providerImageId?: string | null;
+    repositoriesFingerprint?: string;
+    runtimeVersion?: string;
+    createdAt?: number;
+  }
+): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO image_builds
+       (id, scope_kind, scope_id, provider, provider_image_id, repositories_fingerprint,
+        repository_shas, runtime_version, status, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  )
+    .bind(
+      row.id,
+      scope.kind,
+      scope.id,
+      row.provider ?? "modal",
+      row.providerImageId ?? null,
+      row.repositoriesFingerprint ?? "fp-seeded",
+      JSON.stringify(REPOSITORY_SHAS),
+      row.runtimeVersion ?? RUNTIME_VERSION,
+      row.status,
+      row.createdAt ?? Date.now()
+    )
+    .run();
+}
+
+export async function seedImageRow(row: {
+  id: string;
+  environmentId: string;
+  status: string;
+  provider?: string;
+  providerImageId?: string | null;
+  repositoriesFingerprint?: string;
+  createdAt?: number;
+}): Promise<void> {
+  await seedImageRowForScope(environmentScope(row.environmentId), row);
+}
+
+export async function getRow(id: string) {
+  return env.DB.prepare("SELECT * FROM image_builds WHERE id = ?")
+    .bind(id)
+    .first<Record<string, unknown>>();
+}

--- a/packages/control-plane/test/integration/image-build-stale-recovery.test.ts
+++ b/packages/control-plane/test/integration/image-build-stale-recovery.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Lazy trigger-time stale recovery over real D1: a `building` row whose
+ * sandbox died without a callback would hold the concurrency-1 guard forever
+ * (getActiveBuild has no age cutoff), so the workflow fails timed-out rows for
+ * the triggering scope before the in-flight check. Kept separate from the
+ * image-build lifecycle suite (image-builds.test.ts): these tests wire a real
+ * ImageBuildWorkflow over the shared D1 binding, and each integration file
+ * gets its own isolated D1 instance.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import { ImageBuildStore } from "../../src/db/image-builds";
+import { DEFAULT_STALE_BUILD_MAX_AGE_MS } from "../../src/image-builds/maintenance";
+import type { ImageBuildScope } from "../../src/image-builds/model";
+import type { ImageBuildAdapterFactory } from "../../src/image-builds/provider-factory";
+import type { AnyImageBuildAdapter } from "../../src/image-builds/types";
+import { ImageBuildWorkflow } from "../../src/image-builds/workflow";
+import type { Env } from "../../src/types";
+import { cleanD1Tables } from "./cleanup";
+import { environmentScope, getRow, seedEnvironment, seedImageRow } from "./image-build-helpers";
+
+const TWO_HOURS_AGO = () => Date.now() - 2 * 60 * 60 * 1000;
+
+/**
+ * Workflow wired to the real D1 store with the provider layers stubbed
+ * out (the harness has no live provider): a no-op adapter and a planner
+ * echoing a fixed modal plan. The casts confine the stub shapes to this
+ * one seam.
+ */
+function createTriggerWorkflow(scope: ImageBuildScope): ImageBuildWorkflow {
+  const adapter = { async startBuild() {} } as unknown as AnyImageBuildAdapter;
+  const factory = { create: () => adapter } as ImageBuildAdapterFactory;
+  const planner = {
+    resolveTarget: async () => ({
+      repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
+      repositoriesFingerprint: "fp-heal",
+    }),
+    createCallbackAuth: async () => ({ kind: "none" }),
+    planBuild: async () => ({
+      plan: {
+        buildId: "imgb-heal-plan",
+        scope,
+        repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
+        repositoriesFingerprint: "fp-heal",
+        callbackUrl: "https://worker.test/image-builds/build-complete",
+        failureCallbackUrl: "https://worker.test/image-builds/build-failed",
+        buildTimeoutMs: 1800_000,
+        correlation: { trace_id: "trace-heal", request_id: "req-heal" },
+        provider: "modal",
+        callbackMode: "provider_image",
+      },
+      callbackAuth: { type: "none" },
+    }),
+  } as unknown as ConstructorParameters<typeof ImageBuildWorkflow>[4];
+  return new ImageBuildWorkflow(
+    { ...env, WORKER_URL: "https://worker.test" } as Env,
+    new ImageBuildStore(env.DB),
+    factory,
+    "modal",
+    planner
+  );
+}
+
+describe("lazy trigger-time stale recovery over real D1", () => {
+  beforeEach(cleanD1Tables);
+
+  it("markScopeStaleBuildFailed fails only the scope+provider's timed-out building rows", async () => {
+    const environmentId = await seedEnvironment();
+    const otherEnvironmentId = await seedEnvironment();
+    await seedImageRow({
+      id: "lazy-stale",
+      environmentId,
+      status: "building",
+      createdAt: TWO_HOURS_AGO(),
+    });
+    await seedImageRow({ id: "lazy-fresh", environmentId, status: "building" });
+    await seedImageRow({
+      id: "lazy-other-scope",
+      environmentId: otherEnvironmentId,
+      status: "building",
+      createdAt: TWO_HOURS_AGO(),
+    });
+    await seedImageRow({
+      id: "lazy-other-provider",
+      environmentId,
+      status: "building",
+      provider: "vercel",
+      createdAt: TWO_HOURS_AGO(),
+    });
+
+    const marked = await new ImageBuildStore(env.DB).markScopeStaleBuildFailed(
+      environmentScope(environmentId),
+      "modal",
+      DEFAULT_STALE_BUILD_MAX_AGE_MS
+    );
+
+    expect(marked).toBe(1);
+    const stale = await getRow("lazy-stale");
+    expect(stale?.status).toBe("failed");
+    expect(stale?.error_message).toBe("build timed out (no callback received)");
+    expect((await getRow("lazy-fresh"))?.status).toBe("building");
+    expect((await getRow("lazy-other-scope"))?.status).toBe("building");
+    expect((await getRow("lazy-other-provider"))?.status).toBe("building");
+  });
+
+  it("triggerBuild heals a wedged scope: dead row failed, fresh build registered", async () => {
+    const environmentId = await seedEnvironment();
+    const scope = environmentScope(environmentId);
+    await seedImageRow({
+      id: "wedged",
+      environmentId,
+      status: "building",
+      createdAt: TWO_HOURS_AGO(),
+    });
+
+    const workflow = createTriggerWorkflow(scope);
+
+    const result = await workflow.triggerBuild(scope, {
+      request_id: "req-heal",
+      trace_id: "trace-heal",
+    });
+
+    expect(result.type).toBe("triggered");
+    if (result.type !== "triggered") throw new Error("unreachable");
+    expect((await getRow("wedged"))?.status).toBe("failed");
+    expect((await getRow(result.buildId))?.status).toBe("building");
+  });
+
+  it("triggerBuild still yields to a live in-flight build", async () => {
+    const environmentId = await seedEnvironment();
+    await seedImageRow({ id: "live-build", environmentId, status: "building" });
+
+    const workflow = createTriggerWorkflow(environmentScope(environmentId));
+
+    await expect(
+      workflow.triggerBuild(environmentScope(environmentId), {
+        request_id: "req-live",
+        trace_id: "trace-live",
+      })
+    ).resolves.toEqual({ type: "already_building", buildId: "live-build" });
+    expect((await getRow("live-build"))?.status).toBe("building");
+  });
+});

--- a/packages/control-plane/test/integration/image-builds.test.ts
+++ b/packages/control-plane/test/integration/image-builds.test.ts
@@ -17,6 +17,7 @@ import { EnvironmentStore } from "../../src/db/environments";
 import { RepoMetadataStore } from "../../src/db/repo-metadata";
 import { computeRepositoriesFingerprint } from "../../src/image-builds/fingerprint";
 import { hashImageBuildCallbackToken } from "../../src/image-builds/callback-auth";
+import { DEFAULT_STALE_BUILD_MAX_AGE_MS } from "../../src/image-builds/maintenance";
 import {
   MIN_COMPATIBLE_RUNTIME_VERSION,
   repoImageBuildScope,
@@ -28,6 +29,7 @@ import { ImageBuildReaper } from "../../src/image-builds/reaper";
 import { resolveScopeEnabled } from "../../src/image-builds/scope";
 import type { AnyImageBuildAdapter, DeleteImageInput } from "../../src/image-builds/types";
 import { evaluateImageBuildForSpawn } from "../../src/sandbox/lifecycle/image-selection";
+import { ImageBuildWorkflow } from "../../src/image-builds/workflow";
 import type { Env } from "../../src/types";
 import { cleanD1Tables } from "./cleanup";
 
@@ -754,6 +756,127 @@ describe("Image builds", () => {
         status: "failed",
         scope_id: environmentId,
       });
+    });
+  });
+
+  describe("lazy trigger-time stale recovery over real D1", () => {
+    const TWO_HOURS_AGO = () => Date.now() - 2 * 60 * 60 * 1000;
+
+    /**
+     * Workflow wired to the real D1 store with the provider layers stubbed
+     * out (the harness has no live provider): a no-op adapter and a planner
+     * echoing a fixed modal plan. The casts confine the stub shapes to this
+     * one seam.
+     */
+    function createTriggerWorkflow(scope: ImageBuildScope): ImageBuildWorkflow {
+      const adapter = { async startBuild() {} } as unknown as AnyImageBuildAdapter;
+      const factory = { create: () => adapter } as ImageBuildAdapterFactory;
+      const planner = {
+        resolveTarget: async () => ({
+          repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
+          repositoriesFingerprint: "fp-heal",
+        }),
+        createCallbackAuth: async () => ({ kind: "none" }),
+        planBuild: async () => ({
+          plan: {
+            buildId: "imgb-heal-plan",
+            scope,
+            repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
+            repositoriesFingerprint: "fp-heal",
+            callbackUrl: "https://worker.test/image-builds/build-complete",
+            failureCallbackUrl: "https://worker.test/image-builds/build-failed",
+            buildTimeoutMs: 1800_000,
+            correlation: { trace_id: "trace-heal", request_id: "req-heal" },
+            provider: "modal",
+            callbackMode: "provider_image",
+          },
+          callbackAuth: { type: "none" },
+        }),
+      } as unknown as ConstructorParameters<typeof ImageBuildWorkflow>[4];
+      return new ImageBuildWorkflow(
+        { ...env, WORKER_URL: "https://worker.test" } as Env,
+        new ImageBuildStore(env.DB),
+        factory,
+        "modal",
+        planner
+      );
+    }
+
+    it("markScopeStaleBuildFailed fails only the scope+provider's timed-out building rows", async () => {
+      const environmentId = await seedEnvironment();
+      const otherEnvironmentId = await seedEnvironment();
+      await seedImageRow({
+        id: "lazy-stale",
+        environmentId,
+        status: "building",
+        createdAt: TWO_HOURS_AGO(),
+      });
+      await seedImageRow({ id: "lazy-fresh", environmentId, status: "building" });
+      await seedImageRow({
+        id: "lazy-other-scope",
+        environmentId: otherEnvironmentId,
+        status: "building",
+        createdAt: TWO_HOURS_AGO(),
+      });
+      await seedImageRow({
+        id: "lazy-other-provider",
+        environmentId,
+        status: "building",
+        provider: "vercel",
+        createdAt: TWO_HOURS_AGO(),
+      });
+
+      const marked = await new ImageBuildStore(env.DB).markScopeStaleBuildFailed(
+        environmentScope(environmentId),
+        "modal",
+        DEFAULT_STALE_BUILD_MAX_AGE_MS
+      );
+
+      expect(marked).toBe(1);
+      const stale = await getRow("lazy-stale");
+      expect(stale?.status).toBe("failed");
+      expect(stale?.error_message).toBe("build timed out (no callback received)");
+      expect((await getRow("lazy-fresh"))?.status).toBe("building");
+      expect((await getRow("lazy-other-scope"))?.status).toBe("building");
+      expect((await getRow("lazy-other-provider"))?.status).toBe("building");
+    });
+
+    it("triggerBuild heals a wedged scope: dead row failed, fresh build registered", async () => {
+      const environmentId = await seedEnvironment();
+      const scope = environmentScope(environmentId);
+      await seedImageRow({
+        id: "wedged",
+        environmentId,
+        status: "building",
+        createdAt: TWO_HOURS_AGO(),
+      });
+
+      const workflow = createTriggerWorkflow(scope);
+
+      const result = await workflow.triggerBuild(scope, {
+        request_id: "req-heal",
+        trace_id: "trace-heal",
+      });
+
+      expect(result.type).toBe("triggered");
+      if (result.type !== "triggered") throw new Error("unreachable");
+      expect((await getRow("wedged"))?.status).toBe("failed");
+      expect((await getRow(result.buildId))?.status).toBe("building");
+    });
+
+    it("triggerBuild still yields to a live in-flight build", async () => {
+      const environmentId = await seedEnvironment();
+      await seedImageRow({ id: "live-build", environmentId, status: "building" });
+
+      const workflow = createTriggerWorkflow(environmentScope(environmentId));
+
+      await expect(
+        workflow.triggerBuild(environmentScope(environmentId), {
+          request_id: "req-live",
+          trace_id: "trace-live",
+        })
+      ).resolves.toEqual({ type: "already_building", buildId: "live-build" });
+      expect((await getRow("live-build"))?.status).toBe("building");
     });
   });
 

--- a/packages/control-plane/test/integration/image-builds.test.ts
+++ b/packages/control-plane/test/integration/image-builds.test.ts
@@ -13,11 +13,9 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { SELF, env } from "cloudflare:test";
 import { generateInternalToken } from "../../src/auth/internal";
 import { ImageBuildStore } from "../../src/db/image-builds";
-import { EnvironmentStore } from "../../src/db/environments";
 import { RepoMetadataStore } from "../../src/db/repo-metadata";
 import { computeRepositoriesFingerprint } from "../../src/image-builds/fingerprint";
 import { hashImageBuildCallbackToken } from "../../src/image-builds/callback-auth";
-import { DEFAULT_STALE_BUILD_MAX_AGE_MS } from "../../src/image-builds/maintenance";
 import {
   MIN_COMPATIBLE_RUNTIME_VERSION,
   repoImageBuildScope,
@@ -29,13 +27,19 @@ import { ImageBuildReaper } from "../../src/image-builds/reaper";
 import { resolveScopeEnabled } from "../../src/image-builds/scope";
 import type { AnyImageBuildAdapter, DeleteImageInput } from "../../src/image-builds/types";
 import { evaluateImageBuildForSpawn } from "../../src/sandbox/lifecycle/image-selection";
-import { ImageBuildWorkflow } from "../../src/image-builds/workflow";
 import type { Env } from "../../src/types";
 import { cleanD1Tables } from "./cleanup";
+import {
+  RUNTIME_VERSION,
+  REPOSITORY_SHAS,
+  environmentScope,
+  getRow,
+  seedEnvironment,
+  seedImageRow,
+  seedImageRowForScope,
+} from "./image-build-helpers";
 
 const BASE = "https://test.local";
-const RUNTIME_VERSION = "v53-list-native-runtime";
-const REPOSITORY_SHAS = [{ repoOwner: "acme", repoName: "web", baseSha: "abc123" }];
 
 /**
  * The exact key set of the `ImageBuildRecordView` wire contract. The status
@@ -56,89 +60,9 @@ const WIRE_KEYS = [
   "created_at",
 ].sort();
 
-function environmentScope(id: string): ImageBuildScope {
-  return { kind: "environment", id };
-}
-
 async function authHeaders(): Promise<Record<string, string>> {
   const token = await generateInternalToken(env.INTERNAL_CALLBACK_SECRET!);
   return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
-}
-
-async function seedEnvironment(opts?: {
-  id?: string;
-  name?: string;
-  prebuildEnabled?: boolean;
-  repositories?: [string, string, number, string][];
-}): Promise<string> {
-  const store = new EnvironmentStore(env.DB);
-  const id = opts?.id ?? `env_${Math.random().toString(36).slice(2, 10)}`;
-  const now = Date.now();
-  await store.create(
-    {
-      id,
-      name: opts?.name ?? `Seeded ${id}`,
-      description: null,
-      prebuild_enabled: opts?.prebuildEnabled ? 1 : 0,
-      channel_associations: null,
-      created_at: now,
-      updated_at: now,
-    },
-    (opts?.repositories ?? [["acme", "web", 1, "main"]]).map(([o, n, rid, b], position) => ({
-      position,
-      repo_owner: o,
-      repo_name: n,
-      repo_id: rid,
-      base_branch: b,
-    }))
-  );
-  return id;
-}
-
-/** Raw insert when a test needs to control created_at/status/artifact. */
-async function seedImageRowForScope(
-  scope: ImageBuildScope,
-  row: {
-    id: string;
-    status: string;
-    provider?: string;
-    providerImageId?: string | null;
-    repositoriesFingerprint?: string;
-    runtimeVersion?: string;
-    createdAt?: number;
-  }
-): Promise<void> {
-  await env.DB.prepare(
-    `INSERT INTO image_builds
-       (id, scope_kind, scope_id, provider, provider_image_id, repositories_fingerprint,
-        repository_shas, runtime_version, status, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-  )
-    .bind(
-      row.id,
-      scope.kind,
-      scope.id,
-      row.provider ?? "modal",
-      row.providerImageId ?? null,
-      row.repositoriesFingerprint ?? "fp-seeded",
-      JSON.stringify(REPOSITORY_SHAS),
-      row.runtimeVersion ?? RUNTIME_VERSION,
-      row.status,
-      row.createdAt ?? Date.now()
-    )
-    .run();
-}
-
-async function seedImageRow(row: {
-  id: string;
-  environmentId: string;
-  status: string;
-  provider?: string;
-  providerImageId?: string | null;
-  repositoriesFingerprint?: string;
-  createdAt?: number;
-}): Promise<void> {
-  await seedImageRowForScope(environmentScope(row.environmentId), row);
 }
 
 /**
@@ -174,12 +98,6 @@ async function seedRowWithInternalColumns(scope: ImageBuildScope, id: string): P
       Date.now()
     )
     .run();
-}
-
-async function getRow(id: string) {
-  return env.DB.prepare("SELECT * FROM image_builds WHERE id = ?")
-    .bind(id)
-    .first<Record<string, unknown>>();
 }
 
 /**
@@ -756,127 +674,6 @@ describe("Image builds", () => {
         status: "failed",
         scope_id: environmentId,
       });
-    });
-  });
-
-  describe("lazy trigger-time stale recovery over real D1", () => {
-    const TWO_HOURS_AGO = () => Date.now() - 2 * 60 * 60 * 1000;
-
-    /**
-     * Workflow wired to the real D1 store with the provider layers stubbed
-     * out (the harness has no live provider): a no-op adapter and a planner
-     * echoing a fixed modal plan. The casts confine the stub shapes to this
-     * one seam.
-     */
-    function createTriggerWorkflow(scope: ImageBuildScope): ImageBuildWorkflow {
-      const adapter = { async startBuild() {} } as unknown as AnyImageBuildAdapter;
-      const factory = { create: () => adapter } as ImageBuildAdapterFactory;
-      const planner = {
-        resolveTarget: async () => ({
-          repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
-          repositoriesFingerprint: "fp-heal",
-        }),
-        createCallbackAuth: async () => ({ kind: "none" }),
-        planBuild: async () => ({
-          plan: {
-            buildId: "imgb-heal-plan",
-            scope,
-            repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
-            repositoriesFingerprint: "fp-heal",
-            callbackUrl: "https://worker.test/image-builds/build-complete",
-            failureCallbackUrl: "https://worker.test/image-builds/build-failed",
-            buildTimeoutMs: 1800_000,
-            correlation: { trace_id: "trace-heal", request_id: "req-heal" },
-            provider: "modal",
-            callbackMode: "provider_image",
-          },
-          callbackAuth: { type: "none" },
-        }),
-      } as unknown as ConstructorParameters<typeof ImageBuildWorkflow>[4];
-      return new ImageBuildWorkflow(
-        { ...env, WORKER_URL: "https://worker.test" } as Env,
-        new ImageBuildStore(env.DB),
-        factory,
-        "modal",
-        planner
-      );
-    }
-
-    it("markScopeStaleBuildFailed fails only the scope+provider's timed-out building rows", async () => {
-      const environmentId = await seedEnvironment();
-      const otherEnvironmentId = await seedEnvironment();
-      await seedImageRow({
-        id: "lazy-stale",
-        environmentId,
-        status: "building",
-        createdAt: TWO_HOURS_AGO(),
-      });
-      await seedImageRow({ id: "lazy-fresh", environmentId, status: "building" });
-      await seedImageRow({
-        id: "lazy-other-scope",
-        environmentId: otherEnvironmentId,
-        status: "building",
-        createdAt: TWO_HOURS_AGO(),
-      });
-      await seedImageRow({
-        id: "lazy-other-provider",
-        environmentId,
-        status: "building",
-        provider: "vercel",
-        createdAt: TWO_HOURS_AGO(),
-      });
-
-      const marked = await new ImageBuildStore(env.DB).markScopeStaleBuildFailed(
-        environmentScope(environmentId),
-        "modal",
-        DEFAULT_STALE_BUILD_MAX_AGE_MS
-      );
-
-      expect(marked).toBe(1);
-      const stale = await getRow("lazy-stale");
-      expect(stale?.status).toBe("failed");
-      expect(stale?.error_message).toBe("build timed out (no callback received)");
-      expect((await getRow("lazy-fresh"))?.status).toBe("building");
-      expect((await getRow("lazy-other-scope"))?.status).toBe("building");
-      expect((await getRow("lazy-other-provider"))?.status).toBe("building");
-    });
-
-    it("triggerBuild heals a wedged scope: dead row failed, fresh build registered", async () => {
-      const environmentId = await seedEnvironment();
-      const scope = environmentScope(environmentId);
-      await seedImageRow({
-        id: "wedged",
-        environmentId,
-        status: "building",
-        createdAt: TWO_HOURS_AGO(),
-      });
-
-      const workflow = createTriggerWorkflow(scope);
-
-      const result = await workflow.triggerBuild(scope, {
-        request_id: "req-heal",
-        trace_id: "trace-heal",
-      });
-
-      expect(result.type).toBe("triggered");
-      if (result.type !== "triggered") throw new Error("unreachable");
-      expect((await getRow("wedged"))?.status).toBe("failed");
-      expect((await getRow(result.buildId))?.status).toBe("building");
-    });
-
-    it("triggerBuild still yields to a live in-flight build", async () => {
-      const environmentId = await seedEnvironment();
-      await seedImageRow({ id: "live-build", environmentId, status: "building" });
-
-      const workflow = createTriggerWorkflow(environmentScope(environmentId));
-
-      await expect(
-        workflow.triggerBuild(environmentScope(environmentId), {
-          request_id: "req-live",
-          trace_id: "trace-live",
-        })
-      ).resolves.toEqual({ type: "already_building", buildId: "live-build" });
-      expect((await getRow("live-build"))?.status).toBe("building");
     });
   });
 


### PR DESCRIPTION
## Summary
- Recover wedged image-build scopes at trigger time: a build whose sandbox died without a completion/failure callback previously held the per-scope concurrency-1 guard forever (`getActiveBuild`/`registerBuild` filter on bare `status='building'` with no age cutoff), permanently blocking rebuilds for that scope.
- The only existing recovery is the Modal scheduler's 30-minute `mark-stale` cron, which is not deployed when `SANDBOX_PROVIDER` is `vercel` or `opencomputer` — on those deployments a wedged scope never healed. (Follow-up to the maintenance scheduling deferred out of #1029.)
- `triggerBuild`/`triggerBuildIfStale` now best-effort fail `building` rows older than the stale threshold for the target scope+provider before the in-flight check, so the next trigger heals the scope on every deployment — no scheduler, cron, or config required. A hygiene failure never fails the trigger (contained + logged as `image_build.stale_lazy_mark_error`; heals logged as `image_build.stale_lazy_marked`).
- New `image-builds/maintenance.ts` derives `DEFAULT_STALE_BUILD_MAX_AGE_MS` from shared `MAX_BUILD_TIMEOUT_SECONDS` plus the mirrored Modal snapshot/margin budgets (= the historical 4200s route default, now defined once); the mark-stale route imports it instead of its private copy.
- Ceiling assertions pin every provider's build-sandbox lifetime cap (Modal/OpenComputer shared cap, Vercel's 45-minute `VERCEL_MAX_SANDBOX_TIMEOUT_MS`, now exported) at or under the threshold, so raising a provider cap past the threshold fails CI instead of live-failing long builds.

## Verification
- `npm test -w @open-inspect/control-plane` (1,904 tests)
- `npm run test:integration -w @open-inspect/control-plane` (560 tests, incl. new real-D1 coverage: scoped stale-mark isolation, end-to-end heal of a wedged scope, fresh in-flight builds still short-circuit)
- `npm run typecheck -w @open-inspect/control-plane`
- Prettier + ESLint on all changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically detects and fails timed-out “building” image builds as part of new build requests, including “lazy” recovery for wedged scopes.
  * Ensures stale-recovery attempts never block returning an existing in-flight build or starting a new build when appropriate.
  * Uses a consistent error message when marking stale builds as failed.

* **Reliability**
  * Stale-build thresholds now reference a shared default max-age and account for provider execution/processing time limits.

* **Tests**
  * Added/expanded unit and real D1 integration coverage for stale thresholds and recovery/trigger behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->