### PR TITLE
fix(opencomputer): export SANDBOX_VERSION to the exec-launched runtime

### DIFF
--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.test.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { OpenComputerRestClient } from "./opencomputer-rest-client";
+
+const config = {
+  apiUrl: "https://api.opencomputer.dev",
+  apiKey: "test-key",
+  template: "openinspect-runtime-abc",
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchSpy = vi.fn();
+  vi.stubGlobal("fetch", fetchSpy);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// OpenComputer launches the runtime via `exec`, whose shell does NOT inherit the
+// image's baked env. SANDBOX_VERSION therefore has to be re-exported in the exec
+// command — otherwise the runtime reports an empty version and the image-build
+// build-complete callback is rejected by the runtime-version floor check.
+describe("OpenComputerRestClient runtime SANDBOX_VERSION export", () => {
+  it("startRuntime exports SANDBOX_VERSION to the exec shell", async () => {
+    const client = new OpenComputerRestClient(config);
+    fetchSpy.mockResolvedValue(jsonResponse({ exitCode: 0, stdout: "123", stderr: "" }));
+
+    await client.startRuntime("sb-1");
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toContain("/sandboxes/sb-1/exec/run");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.args[1]).toContain("SANDBOX_VERSION=v54-opencode-1-17-18");
+  });
+
+  it("runRuntimeForeground (image build path) exports SANDBOX_VERSION", async () => {
+    const client = new OpenComputerRestClient(config);
+    fetchSpy.mockResolvedValue(jsonResponse({ exitCode: 0, stdout: "", stderr: "" }));
+
+    await client.runRuntimeForeground("sb-1", 60);
+
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
+    expect(body.args[1]).toContain("SANDBOX_VERSION=v54-opencode-1-17-18");
+  });
+});

--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
@@ -186,6 +186,13 @@ const RUNTIME_HOSTS_BOOTSTRAP =
   "printf '%s\\n' '127.0.0.1 localhost' | sudo tee -a /etc/hosts >/dev/null; " +
   "grep -Eq '^[[:space:]]*::1[[:space:]].*\\blocalhost\\b' /etc/hosts || " +
   "printf '%s\\n' '::1 localhost ip6-localhost ip6-loopback' | sudo tee -a /etc/hosts >/dev/null";
+// Runtime version the sandbox reports back to the image-build callback.
+// OpenComputer launches the runtime via `exec`, which does NOT inherit the
+// image's baked env, so SANDBOX_VERSION must be re-exported here — otherwise the
+// runtime reports an empty version and the build-complete callback is rejected
+// (runtime-version floor check). Keep in sync with the value baked in
+// packages/opencomputer-infra/src/build-template.ts (SANDBOX_VERSION).
+const OPENCOMPUTER_SANDBOX_VERSION = "v54-opencode-1-17-18";
 const RUNTIME_ENV_EXPORTS =
   "export HOME=/home/sandbox " +
   `VIRTUAL_ENV=${PYTHON_VENV} ` +
@@ -196,6 +203,7 @@ const RUNTIME_ENV_EXPORTS =
   `NO_PROXY=${LOCAL_NO_PROXY} ` +
   `no_proxy=${LOCAL_NO_PROXY} ` +
   `PATH=${PYTHON_VENV}/bin:/home/sandbox/.npm-global/bin:${USER_BIN}:/home/sandbox/.local/share/pnpm:/usr/local/bin:/usr/bin:/bin ` +
+  `SANDBOX_VERSION=${OPENCOMPUTER_SANDBOX_VERSION} ` +
   RUNTIME_CA_EXPORTS;
 const RUNTIME_CA_BOOTSTRAP =
   `[ -f ${OPENSANDBOX_PROXY_CA} ] && sudo update-ca-certificates >/tmp/openinspect-update-ca.log 2>&1 || true; ` +


### PR DESCRIPTION
## Summary

Fixes the OpenComputer image-build failure where every build was rejected with a `400`.

> **Scope note:** an earlier revision of this PR also changed `build-template.ts` (added `--unsafe-perm` to the opencode install) to address a *separate* "opencode won't launch" session failure. That was **wrong** — `--unsafe-perm` doesn't affect the actual cause — and has been removed. This PR is now scoped to the SANDBOX_VERSION fix only; the opencode issue is described below and tracked separately.

## The fix — empty `runtime_version` → 400 on image builds

Image pre-builds completed, then the build-complete callback was rejected:

```
image_build.complete … runtime_version: ""
POST /image-builds/build-complete → 400
```

OpenComputer launches the runtime via `exec`, whose shell does **not** inherit the image's baked env — which is exactly why `RUNTIME_ENV_EXPORTS` manually re-exports `HOME`/`PATH`/`PYTHONPATH`/… `SANDBOX_VERSION` is baked into the image (`build-template.ts`) but was **missing from `RUNTIME_ENV_EXPORTS`**, so the runtime reported an empty version and the runtime-version floor check rejected the callback. Verified live: `SANDBOX_VERSION=[EMPTY]` in an OC exec shell.

**Fix:** export `SANDBOX_VERSION` in `RUNTIME_ENV_EXPORTS`, kept in sync with the value baked in `build-template.ts`. Adds a regression test asserting both runtime-launch paths (`startRuntime`, `runRuntimeForeground`) export it.

## Separate issue — opencode `Exec format error` (NOT fixed here)

OC sessions also die with `OSError: [Errno 8] Exec format error: 'opencode'`. Confirmed against a live OC sandbox: opencode ships its native binary as a **platform-specific `optionalDependency`** (`opencode-linux-x64`) plus a postinstall that copies it into `bin/opencode.exe`. In the OC image that optional dependency is **not installed**, leaving a 479-byte stub that `ENOEXEC`s at launch. The likely trigger — OpenComputer's egress proxy does TLS interception, which appears to interfere with the optional-dependency fetch — is still being pinned down, so no `build-template.ts` change ships here. (`--unsafe-perm` only changes lifecycle-script privileges and does not affect optional-dependency resolution, so it was the wrong fix.) Tracked separately.

## Testing

- New `opencomputer-rest-client.test.ts` (2 tests) — pass.
- `typecheck`, `eslint`, `prettier --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime shell sessions now include the sandbox version in their environment.
  * Sandbox version reporting is now consistent when starting or running runtimes.

* **Tests**
  * Added coverage to verify the sandbox version is correctly passed to runtime commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->