### PR TITLE
fix(opencomputer): allow opencode-ai's postinstall so the native binary ships (npm 12)

### DIFF
--- a/packages/opencomputer-infra/src/build-template.ts
+++ b/packages/opencomputer-infra/src/build-template.ts
@@ -152,7 +152,16 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
       `ln -sf ${PYTHON_VENV}/bin/python ${USER_BIN}/python`,
       `HOME=${SANDBOX_HOME} UV_CACHE_DIR=${UV_CACHE} uv pip install --python ${PYTHON_VENV}/bin/python httpx websockets "pydantic>=2.0" "PyJWT[crypto]"`,
       `sudo rm -rf /app && sudo ln -s ${SANDBOX_APP_DIR} /app`,
-      `sudo env npm_config_cache=${NPM_CACHE} npm install -g --prefix ${NPM_PREFIX} pnpm@10 opencode-ai@${OPENCODE_VERSION} @opencode-ai/plugin@${OPENCODE_VERSION} zod@4.4.3 agent-browser@${AGENT_BROWSER_VERSION}`
+      // Install the JS toolchain into the sandbox-owned prefix. --allow-scripts=opencode-ai is
+      // REQUIRED: the OpenComputer base image ships npm 12, which does not run package lifecycle
+      // scripts by default. opencode-ai's postinstall copies the real ~180MB native binary over
+      // the shipped bin/opencode.exe stub; without allowing it the stub survives and every
+      // session dies with "Exec format error: opencode". opencode-ai is the only co-installed
+      // package with an install-time lifecycle script.
+      `sudo env npm_config_cache=${NPM_CACHE} npm install -g --prefix ${NPM_PREFIX} --allow-scripts=opencode-ai pnpm@10 opencode-ai@${OPENCODE_VERSION} @opencode-ai/plugin@${OPENCODE_VERSION} zod@4.4.3 agent-browser@${AGENT_BROWSER_VERSION}`,
+      // Fail the build loudly if opencode is still a stub / not runnable (e.g. if the flag above
+      // ever stops taking effect), so a broken image can never ship silently.
+      `${NPM_PREFIX}/bin/opencode --version`
     )
     .runCommands(
       // GitHub CLI — installed to /usr/bin/gh (the path the runtime's gh wrapper expects).


### PR DESCRIPTION
## Summary

Fixes the OpenComputer session failure where **every** session dies at launch with:

```
OSError: [Errno 8] Exec format error: 'opencode'
```

## Root cause — npm 12 blocks opencode-ai's postinstall

`opencode-ai` ships `bin/opencode.exe` as a **479-byte placeholder stub**; its `postinstall.mjs`
replaces it with the platform-native binary (shipped as an `optionalDependency`, a ~180 MB ELF).

The OpenComputer base image (`@opencomputer/sdk` `Image.base()`) ships **Node 22 but npm 12.0.1**,
and **npm 12 does not run package lifecycle scripts by default** (a security change). So the build
installs the platform binary as an optional dep but **never runs opencode-ai's postinstall** — the
stub survives and `ENOEXEC`s the moment the runtime launches `opencode`.

Every other provider (Modal, E2B, Daytona) works because it runs on Node 22's default **npm 10**,
which still runs postinstall.

Verified live on an OpenComputer sandbox — npm even prints the remedy:

```
npm warn install-scripts 1 package had install scripts blocked because they are not covered by allowScripts:
npm warn install-scripts   opencode-ai@1.17.18 (postinstall: node ./postinstall.mjs)
npm warn install-scripts Run `npm install -g --allow-scripts=opencode-ai` to allow these scripts once …
```

`opencode-ai` is the **only** co-installed package with an install-time lifecycle script
(`@opencode-ai/plugin`, `agent-browser`, `pnpm`, `zod` have only dev/build/publish scripts).

## The fix

1. Add **`--allow-scripts=opencode-ai`** to the toolchain install — npm's own recommended remedy — so
   opencode-ai's postinstall runs and copies the real native binary over the stub.
2. Add a build-time **`opencode --version` gate** so a broken image can never ship silently again: if
   the postinstall is ever skipped, the build fails loudly instead of every session ENOEXEC-ing.

## Testing

Verified end-to-end on a live OpenComputer sandbox with the **exact build command** (sudo + full
package set + `--allow-scripts=opencode-ai`): after the install, `bin/opencode.exe` is a real ELF
and `opencode --version` → `1.17.18` (vs. the 479-byte stub without the flag).

- `npm run typecheck`, `eslint`, `prettier --check` clean.

> Unrelated to (and previously masked behind) the SANDBOX_VERSION image-build fix in #1038.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox setup for the JavaScript toolchain.
  * Added build-time validation to ensure the OpenCode command is installed and executable before the build completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->