### PR TITLE
fix(opencomputer): reap build secret store with image, not sandbox

### DIFF
--- a/packages/control-plane/src/db/image-builds.ts
+++ b/packages/control-plane/src/db/image-builds.ts
@@ -89,6 +89,7 @@ export interface ImageBuildRow extends ImageBuildRecordView {
   provider_image_id: string | null;
   repositories_fingerprint: string;
   provider_session_id: string | null;
+  provider_secret_store_id: string | null;
   callback_token_hash: string | null;
   callback_token_expires_at: number | null;
   callback_token_used_at: number | null;
@@ -102,6 +103,7 @@ export interface ReapableImageBuildRow {
   provider: ImageBuildProvider;
   provider_image_id: string | null;
   provider_session_id: string | null;
+  provider_secret_store_id: string | null;
 }
 
 /**
@@ -172,13 +174,14 @@ export class ImageBuildStore {
   async bindProviderSession(
     buildId: string,
     provider: ImageBuildProvider,
-    providerSessionId: string
+    providerSessionId: string,
+    providerSecretStoreId?: string | null
   ): Promise<boolean> {
     const result = await this.db
       .prepare(
-        "UPDATE image_builds SET provider_session_id = ? WHERE id = ? AND provider = ? AND status = 'building'"
+        "UPDATE image_builds SET provider_session_id = ?, provider_secret_store_id = ? WHERE id = ? AND provider = ? AND status = 'building'"
       )
-      .bind(providerSessionId, buildId, provider)
+      .bind(providerSessionId, providerSecretStoreId ?? null, buildId, provider)
       .run();
 
     return (result.meta?.changes ?? 0) > 0;
@@ -430,7 +433,7 @@ export class ImageBuildStore {
 
     const superseded = await this.db
       .prepare(
-        `SELECT id, provider_image_id, provider_session_id FROM image_builds
+        `SELECT id, provider_image_id, provider_session_id, provider_secret_store_id FROM image_builds
          WHERE scope_kind = ?
            AND scope_id = ?
            AND provider = ?
@@ -451,13 +454,19 @@ export class ImageBuildStore {
         build.created_at,
         buildId
       )
-      .all<{ id: string; provider_image_id: string | null; provider_session_id: string | null }>();
+      .all<{
+        id: string;
+        provider_image_id: string | null;
+        provider_session_id: string | null;
+        provider_secret_store_id: string | null;
+      }>();
 
     const supersededImages: SupersededImageBuild[] = (superseded.results || []).map((image) => ({
       imageBuildId: image.id,
       image: {
         providerImageId: image.provider_image_id ?? "",
         providerSessionId: image.provider_session_id,
+        providerSecretStoreId: image.provider_secret_store_id,
       },
     }));
 
@@ -719,7 +728,7 @@ export class ImageBuildStore {
   async getSupersededImages(limit: number): Promise<ReapableImageBuildRow[]> {
     const result = await this.db
       .prepare(
-        `SELECT id, scope_kind, scope_id, provider, provider_image_id, provider_session_id
+        `SELECT id, scope_kind, scope_id, provider, provider_image_id, provider_session_id, provider_secret_store_id
          FROM image_builds WHERE status = 'superseded'
          ORDER BY created_at ASC LIMIT ?`
       )
@@ -740,7 +749,7 @@ export class ImageBuildStore {
   async getFailedImagesWithArtifacts(limit: number): Promise<ReapableImageBuildRow[]> {
     const result = await this.db
       .prepare(
-        `SELECT id, scope_kind, scope_id, provider, provider_image_id, provider_session_id
+        `SELECT id, scope_kind, scope_id, provider, provider_image_id, provider_session_id, provider_secret_store_id
          FROM image_builds WHERE status = 'failed' AND provider_image_id IS NOT NULL
          ORDER BY created_at ASC LIMIT ?`
       )
@@ -767,7 +776,7 @@ export class ImageBuildStore {
   ): Promise<boolean> {
     const result = await this.db
       .prepare(
-        `UPDATE image_builds SET provider_image_id = NULL, provider_session_id = NULL
+        `UPDATE image_builds SET provider_image_id = NULL, provider_session_id = NULL, provider_secret_store_id = NULL
          WHERE id = ? AND status = 'failed' AND provider_image_id = ?`
       )
       .bind(imageBuildId, reapedProviderImageId)

--- a/packages/control-plane/src/image-builds/model.ts
+++ b/packages/control-plane/src/image-builds/model.ts
@@ -54,6 +54,12 @@ export function parseRepoScopeId(scopeId: string): { repoOwner: string; repoName
 export interface ImageBuildProviderImageRef {
   providerImageId: string;
   providerSessionId?: string | null;
+  /**
+   * OpenComputer only: the per-build secret store the checkpoint retains as its
+   * base layer, reaped together with the image. Null for Modal/Vercel, whose
+   * artifacts are self-contained.
+   */
+  providerSecretStoreId?: string | null;
 }
 
 export interface SupersededImageBuild {

--- a/packages/control-plane/src/image-builds/opencomputer-adapter.test.ts
+++ b/packages/control-plane/src/image-builds/opencomputer-adapter.test.ts
@@ -82,7 +82,7 @@ describe("OpenComputerImageBuildAdapter", () => {
     });
   });
 
-  it("cleans up completed build sandboxes and deletes checkpoints with session context", async () => {
+  it("keeps the secret store when tearing down a build whose image is ready", async () => {
     const provider = createProvider();
     const adapter = new OpenComputerImageBuildAdapter(provider);
     const correlation = { request_id: "request-1", trace_id: "trace-1" };
@@ -91,15 +91,68 @@ describe("OpenComputerImageBuildAdapter", () => {
       buildId: "build-1",
       providerSessionId: "oc-session-1",
       correlation,
+      keepSecretStore: true,
     });
-    await adapter.deleteImage({
-      image: { providerImageId: "oc-checkpoint-1", providerSessionId: "oc-session-1" },
+
+    // The checkpoint retains the store as its base layer, so the store must
+    // survive the build sandbox and be reaped later with the image.
+    expect(provider.deleteSandbox).toHaveBeenCalledWith("oc-session-1", {
+      deleteSecretStore: false,
+    });
+  });
+
+  it("deletes the secret store when the completed build's checkpoint was discarded", async () => {
+    const provider = createProvider();
+    const adapter = new OpenComputerImageBuildAdapter(provider);
+    const correlation = { request_id: "request-1", trace_id: "trace-1" };
+
+    await adapter.cleanupCompletedBuild?.({
+      buildId: "build-1",
+      providerSessionId: "oc-session-1",
+      correlation,
+      keepSecretStore: false,
+    });
+
+    expect(provider.deleteSandbox).toHaveBeenCalledWith("oc-session-1", {
+      deleteSecretStore: true,
+    });
+  });
+
+  it("deletes the secret store with the sandbox when a build fails", async () => {
+    const provider = createProvider();
+    const adapter = new OpenComputerImageBuildAdapter(provider);
+    const correlation = { request_id: "request-1", trace_id: "trace-1" };
+
+    await adapter.cleanupFailedBuild?.({
+      buildId: "build-1",
+      providerSessionId: "oc-session-1",
+      errorMessage: "boom",
       correlation,
     });
 
     expect(provider.deleteSandbox).toHaveBeenCalledWith("oc-session-1", {
       deleteSecretStore: true,
     });
-    expect(provider.deleteProviderImage).toHaveBeenCalledWith("oc-checkpoint-1", "oc-session-1");
+  });
+
+  it("reaps the checkpoint and its base secret store when deleting an image", async () => {
+    const provider = createProvider();
+    const adapter = new OpenComputerImageBuildAdapter(provider);
+    const correlation = { request_id: "request-1", trace_id: "trace-1" };
+
+    await adapter.deleteImage({
+      image: {
+        providerImageId: "oc-checkpoint-1",
+        providerSessionId: "oc-session-1",
+        providerSecretStoreId: "secret-store-9",
+      },
+      correlation,
+    });
+
+    expect(provider.deleteProviderImage).toHaveBeenCalledWith(
+      "oc-checkpoint-1",
+      "oc-session-1",
+      "secret-store-9"
+    );
   });
 });

--- a/packages/control-plane/src/image-builds/opencomputer-adapter.ts
+++ b/packages/control-plane/src/image-builds/opencomputer-adapter.ts
@@ -2,6 +2,7 @@ import { createLogger } from "../logger";
 import type { OpenComputerSandboxProvider } from "../sandbox/providers/opencomputer-provider";
 import type { ImageBuildProviderImageRef } from "./model";
 import type {
+  CleanupCompletedBuildInput,
   DeleteImageInput,
   FailedImageBuildInput,
   FinalizeImageBuildInput,
@@ -66,28 +67,43 @@ export class OpenComputerImageBuildAdapter implements ImageBuildAdapter<OpenComp
     };
   }
 
-  async cleanupCompletedBuild(input: FinalizeImageBuildInput): Promise<void> {
-    await this.deleteBuildSandbox(input.buildId, input.providerSessionId, input.correlation);
+  async cleanupCompletedBuild(input: CleanupCompletedBuildInput): Promise<void> {
+    // Keep the secret store when a durable image depends on it: the checkpoint
+    // taken in finalizeSuccessfulBuild retains it as a base layer, so deleting
+    // it here would break every future fork of the image. It is reaped with the
+    // image in deleteImage. When the checkpoint was discarded (not marked
+    // ready), nothing depends on the store, so it is deleted with the sandbox.
+    await this.deleteBuildSandbox(input.buildId, input.providerSessionId, input.correlation, {
+      deleteSecretStore: !input.keepSecretStore,
+    });
   }
 
   async cleanupFailedBuild(input: FailedImageBuildInput): Promise<void> {
-    await this.deleteBuildSandbox(input.buildId, input.providerSessionId, input.correlation);
+    // A failed build produced no checkpoint, so nothing references the store —
+    // delete it with the sandbox.
+    await this.deleteBuildSandbox(input.buildId, input.providerSessionId, input.correlation, {
+      deleteSecretStore: true,
+    });
   }
 
   async deleteImage(input: DeleteImageInput): Promise<void> {
     await this.provider.deleteProviderImage(
       input.image.providerImageId,
-      input.image.providerSessionId
+      input.image.providerSessionId,
+      input.image.providerSecretStoreId
     );
   }
 
   private async deleteBuildSandbox(
     buildId: string,
     providerSessionId: string,
-    correlation: FinalizeImageBuildInput["correlation"]
+    correlation: FinalizeImageBuildInput["correlation"],
+    options: { deleteSecretStore: boolean }
   ): Promise<void> {
     try {
-      await this.provider.deleteSandbox(providerSessionId, { deleteSecretStore: true });
+      await this.provider.deleteSandbox(providerSessionId, {
+        deleteSecretStore: options.deleteSecretStore,
+      });
     } catch (error) {
       logger.warn("image_build.opencomputer_build_cleanup_failed", {
         build_id: buildId,

--- a/packages/control-plane/src/image-builds/reaper.ts
+++ b/packages/control-plane/src/image-builds/reaper.ts
@@ -81,14 +81,19 @@ export class ImageBuildReaper {
     let reaped = 0;
     await Promise.all(
       rows.map(async (row) => {
-        if (row.provider_image_id) {
+        // A row may carry a checkpoint, a secret store, or both. The store is
+        // reaped here too: it outlives the build sandbox as the checkpoint's
+        // base layer, so a bare store id (a build superseded before it
+        // finalized) still needs reclaiming.
+        if (row.provider_image_id || row.provider_secret_store_id) {
           const adapter = this.resolveCleanupAdapter(row.provider, row.id, ctx, adapters);
           if (!adapter) return;
           const deleted = await this.deleteImageBestEffort(
             row.provider,
             {
-              providerImageId: row.provider_image_id,
+              providerImageId: row.provider_image_id ?? "",
               providerSessionId: row.provider_session_id,
+              providerSecretStoreId: row.provider_secret_store_id,
             },
             ctx,
             adapter
@@ -158,7 +163,11 @@ export class ImageBuildReaper {
 
   async deleteImageBestEffort(
     provider: ImageBuildProvider,
-    image: { providerImageId: string; providerSessionId?: string | null },
+    image: {
+      providerImageId: string;
+      providerSessionId?: string | null;
+      providerSecretStoreId?: string | null;
+    },
     ctx: ImageBuildWorkflowContext,
     adapter: AnyImageBuildAdapter
   ): Promise<boolean> {

--- a/packages/control-plane/src/image-builds/types.ts
+++ b/packages/control-plane/src/image-builds/types.ts
@@ -95,7 +95,15 @@ export type PlannedImageBuild =
 
 /** Lets provider-session adapters bind the provider sandbox id before the runtime launches. */
 export interface ImageBuildStartCallbacks {
-  bindProviderSession(providerSessionId: string): Promise<void>;
+  /**
+   * `providerSecretStoreId` records a per-build secret store the provider
+   * created for the build sandbox (OpenComputer), so the reaper can delete it
+   * with the image. Providers without one omit it.
+   */
+  bindProviderSession(
+    providerSessionId: string,
+    providerSecretStoreId?: string | null
+  ): Promise<void>;
 }
 
 /**
@@ -139,6 +147,19 @@ export interface FailedImageBuildInput {
 }
 
 /**
+ * Teardown input for a build sandbox whose completion already settled.
+ * `keepSecretStore` is the workflow's judgement about whether a durable image
+ * now depends on the build's secret store: true only when the build was marked
+ * ready (its checkpoint retains the store as a base layer, so it must outlive
+ * the sandbox and be reaped with the image); false when the checkpoint was
+ * discarded (superseded, or the commit never settled), so the store is deleted
+ * with the sandbox. Providers without per-build secret stores ignore it.
+ */
+export interface CleanupCompletedBuildInput extends FinalizeImageBuildInput {
+  keepSecretStore: boolean;
+}
+
+/**
  * Provider-facing operations for image builds. The workflow owns state
  * transitions; adapters own translating lifecycle steps into provider API
  * calls (start build, snapshot/checkpoint, teardown, artifact deletion).
@@ -150,7 +171,7 @@ export type ImageBuildAdapter<Plan extends ImageBuildPlan> = {
   deleteImage(input: DeleteImageInput): Promise<void>;
   finalizeSuccessfulBuild?(input: FinalizeImageBuildInput): Promise<ImageBuildProviderImageRef>;
   cleanupFailedBuild?(input: FailedImageBuildInput): Promise<void>;
-  cleanupCompletedBuild?(input: FinalizeImageBuildInput): Promise<void>;
+  cleanupCompletedBuild?(input: CleanupCompletedBuildInput): Promise<void>;
 };
 
 export type AnyImageBuildAdapter =

--- a/packages/control-plane/src/image-builds/workflow.test.ts
+++ b/packages/control-plane/src/image-builds/workflow.test.ts
@@ -720,7 +720,8 @@ describe("ImageBuildWorkflow", () => {
       expect(store.bindProviderSession).toHaveBeenCalledWith(
         expect.stringMatching(/^imgb-env_1-/),
         "vercel",
-        "vercel-session-1"
+        "vercel-session-1",
+        undefined
       );
     });
 
@@ -1004,6 +1005,7 @@ describe("ImageBuildWorkflow", () => {
         provider: "modal" as const,
         provider_image_id: providerImageId,
         provider_session_id: null,
+        provider_secret_store_id: null,
       };
     }
 
@@ -1044,7 +1046,11 @@ describe("ImageBuildWorkflow", () => {
       expect(result.reapedFailed).toBe(1);
       expect(adapter.deleteImage).toHaveBeenCalledWith(
         expect.objectContaining({
-          image: { providerImageId: "im-restore", providerSessionId: null },
+          image: {
+            providerImageId: "im-restore",
+            providerSessionId: null,
+            providerSecretStoreId: null,
+          },
         })
       );
       // The failed row itself is kept for visibility — only the artifact

--- a/packages/control-plane/src/image-builds/workflow.ts
+++ b/packages/control-plane/src/image-builds/workflow.ts
@@ -266,9 +266,14 @@ export class ImageBuildWorkflow {
       const start = this.preparePlannedBuildStart(planned, ctx);
       startAdapter = start.adapter;
       await start.start({
-        bindProviderSession: async (providerSessionId) => {
+        bindProviderSession: async (providerSessionId, providerSecretStoreId) => {
           providerSessionIdForCleanup = providerSessionId;
-          const bound = await this.store.bindProviderSession(buildId, provider, providerSessionId);
+          const bound = await this.store.bindProviderSession(
+            buildId,
+            provider,
+            providerSessionId,
+            providerSecretStoreId
+          );
           if (!bound) {
             throw new Error(`Failed to bind ${provider} build session`);
           }
@@ -637,10 +642,22 @@ export class ImageBuildWorkflow {
         }
       }
 
-      await this.cleanupCompletedBuild(provider, adapter, input, ctx);
+      // Keep the build's secret store only when a ready image now depends on
+      // it (its checkpoint's base layer); every other outcome discarded the
+      // checkpoint, so the store is torn down with the sandbox.
+      await this.cleanupCompletedBuild(
+        provider,
+        adapter,
+        input,
+        ctx,
+        result.type === "marked_ready"
+      );
     } catch (e) {
       if (adapter) {
-        await this.cleanupCompletedBuild(provider, adapter, input, ctx);
+        // If the commit settled before the throw, a ready image may own the
+        // store — keep it (the reaper reclaims it if the row is not ready).
+        // Otherwise no durable image exists, so delete it with the sandbox.
+        await this.cleanupCompletedBuild(provider, adapter, input, ctx, commitResolved);
       }
       if (!commitResolved) {
         // The ready transition never settled: the row is still building and
@@ -678,7 +695,8 @@ export class ImageBuildWorkflow {
     provider: ImageBuildProvider,
     adapter: AnyImageBuildAdapter,
     input: { buildId: string; providerSessionId: string },
-    ctx: ImageBuildWorkflowContext
+    ctx: ImageBuildWorkflowContext,
+    keepSecretStore: boolean
   ): Promise<void> {
     if (!adapter.cleanupCompletedBuild) return;
     try {
@@ -686,6 +704,7 @@ export class ImageBuildWorkflow {
         buildId: input.buildId,
         providerSessionId: input.providerSessionId,
         correlation: ctx,
+        keepSecretStore,
       });
     } catch (e) {
       logger.warn(`image_build.${provider}_completed_build_cleanup_failed`, {

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -314,6 +314,51 @@ describe("OpenComputerSandboxProvider", () => {
     });
   });
 
+  it("reaps a checkpoint and its base secret store together", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await provider.deleteProviderImage("oc-checkpoint-1", "oc-session-1", "secret-store-9");
+
+    expect(client.deleteCheckpoint).toHaveBeenCalledWith("oc-session-1", "oc-checkpoint-1");
+    expect(client.deleteSecretStore).toHaveBeenCalledWith("secret-store-9");
+  });
+
+  it("reaps a bare secret store when no checkpoint pair is present", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await provider.deleteProviderImage("", null, "secret-store-9");
+
+    expect(client.deleteCheckpoint).not.toHaveBeenCalled();
+    expect(client.deleteSecretStore).toHaveBeenCalledWith("secret-store-9");
+  });
+
+  it("ignores a missing checkpoint or secret store when reaping an image", async () => {
+    const client = createMockClient({
+      deleteCheckpoint: vi.fn(async () => {
+        throw new OpenComputerNotFoundError("checkpoint gone");
+      }),
+      deleteSecretStore: vi.fn(async () => {
+        throw new OpenComputerNotFoundError("store gone");
+      }),
+    });
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await expect(
+      provider.deleteProviderImage("oc-checkpoint-1", "oc-session-1", "secret-store-9")
+    ).resolves.toBeUndefined();
+  });
+
   it("derives a unique secret-store name per sandbox", async () => {
     const client = createMockClient();
     const provider = new OpenComputerSandboxProvider(client, {
@@ -619,7 +664,7 @@ describe("OpenComputerSandboxProvider", () => {
     expect(client.setSecret).not.toHaveBeenCalledWith(
       expect.objectContaining({ name: "OI_REPO_IMAGE_CALLBACK_SECRET" })
     );
-    expect(onProviderSessionCreated).toHaveBeenCalledWith("oc-sandbox-1");
+    expect(onProviderSessionCreated).toHaveBeenCalledWith("oc-sandbox-1", "secret-store-1");
     expect(client.startRuntime).toHaveBeenCalledWith("oc-sandbox-1", {
       OI_REPO_IMAGE_PROVIDER_SESSION_ID: "oc-sandbox-1",
     });
@@ -671,7 +716,7 @@ describe("OpenComputerSandboxProvider", () => {
       openinspect_kind: "environment-image-build",
       openinspect_environment: "env_flagship",
     });
-    expect(onProviderSessionCreated).toHaveBeenCalledWith("oc-sandbox-1");
+    expect(onProviderSessionCreated).toHaveBeenCalledWith("oc-sandbox-1", "secret-store-1");
     expect(client.startRuntime).toHaveBeenCalledWith("oc-sandbox-1", {
       OI_REPO_IMAGE_PROVIDER_SESSION_ID: "oc-sandbox-1",
     });

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -66,7 +66,10 @@ export interface TriggerOpenComputerEnvironmentImageBuildConfig {
   userEnvVars?: Record<string, string>;
   cloneToken?: string;
   buildTimeoutSeconds?: number;
-  onProviderSessionCreated?: (providerSessionId: string) => Promise<void>;
+  onProviderSessionCreated?: (
+    providerSessionId: string,
+    providerSecretStoreId?: string | null
+  ) => Promise<void>;
 }
 
 export interface TriggerOpenComputerEnvironmentImageBuildResult {
@@ -406,7 +409,10 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
       providerObjectId = sandbox.id;
 
       if (config.onProviderSessionCreated) {
-        await config.onProviderSessionCreated(sandbox.id);
+        // Report the build's secret store id too: the checkpoint taken from
+        // this sandbox retains the store as its base layer, so it must be
+        // reaped with the image rather than deleted at sandbox teardown.
+        await config.onProviderSessionCreated(sandbox.id, secretStore?.id);
       }
 
       await this.client.startRuntime(sandbox.id, {
@@ -441,14 +447,31 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
 
   async deleteProviderImage(
     providerImageId: string,
-    providerSessionId?: string | null
+    providerSessionId?: string | null,
+    providerSecretStoreId?: string | null
   ): Promise<void> {
-    if (!providerSessionId) return;
-    try {
-      await this.client.deleteCheckpoint(providerSessionId, providerImageId);
-    } catch (error) {
-      if (error instanceof OpenComputerNotFoundError) return;
-      throw this.classifyError("Failed to delete OpenComputer checkpoint", error);
+    // Checkpoint deletion is keyed by its source sandbox; skip when the pair is
+    // incomplete (e.g. a build superseded before it produced a checkpoint).
+    if (providerSessionId && providerImageId) {
+      try {
+        await this.client.deleteCheckpoint(providerSessionId, providerImageId);
+      } catch (error) {
+        if (!(error instanceof OpenComputerNotFoundError)) {
+          throw this.classifyError("Failed to delete OpenComputer checkpoint", error);
+        }
+      }
+    }
+    // The build's secret store is the checkpoint's base layer, kept alive past
+    // sandbox teardown, so it is reclaimed here with the image. Idempotent — an
+    // already-deleted store is treated as done.
+    if (providerSecretStoreId) {
+      try {
+        await this.client.deleteSecretStore(providerSecretStoreId);
+      } catch (error) {
+        if (!(error instanceof OpenComputerNotFoundError)) {
+          throw this.classifyError("Failed to delete OpenComputer secret store", error);
+        }
+      }
     }
   }
 

--- a/packages/control-plane/test/integration/image-builds.test.ts
+++ b/packages/control-plane/test/integration/image-builds.test.ts
@@ -154,7 +154,11 @@ describe("Image builds", () => {
       expect(result.supersededImages).toEqual([
         {
           imageBuildId: "imgb-old",
-          image: { providerImageId: "im-old", providerSessionId: null },
+          image: {
+            providerImageId: "im-old",
+            providerSessionId: null,
+            providerSecretStoreId: null,
+          },
         },
       ]);
 

--- a/terraform/d1/migrations/0043_image_builds_secret_store.sql
+++ b/terraform/d1/migrations/0043_image_builds_secret_store.sql
@@ -1,0 +1,17 @@
+-- Provider secret store backing an image, reaped with the image.
+--
+-- OpenComputer image builds run in a sandbox that carries a per-build secret
+-- store; checkpointing that sandbox (the image artifact) retains the store as
+-- the checkpoint's base layer, so every later fork of the image MERGES that
+-- store back in. Deleting it at build-sandbox teardown — which the completed
+-- build cleanup used to do — leaves every spawn from the image failing with
+-- "secret store not found". The store must therefore outlive the build sandbox
+-- and be reclaimed only when the image itself is (superseded, restore-failed,
+-- or the owning entity deleted).
+--
+-- This column records that store's provider id on the build row so the cleanup
+-- reaper deletes it alongside provider_image_id/provider_session_id. Nullable:
+-- only OpenComputer populates it; Modal images and Vercel snapshots are
+-- self-contained and leave it NULL. No backfill — images built before this
+-- column already had their store deleted at teardown and must be rebuilt.
+ALTER TABLE image_builds ADD COLUMN provider_secret_store_id TEXT;


### PR DESCRIPTION
## Problem

Spawning a session from an OpenComputer prebuilt image failed at fork time:

```
restore failed at spawn: Failed to create OpenComputer sandbox:
{"error":"secret store not found: openinspect-imgb-...-26c59426"}
```

The image built fine, but **every** fork of it 400'd — the image was permanently unusable.

## Root cause

OpenComputer image builds run in a sandbox that carries a per-build secret store. When we checkpoint that sandbox into the image artifact, the checkpoint **retains its creation-time secret store as a base layer**; every later `from-checkpoint` fork merges a fresh session store *on top of* that base. So the base store must live for the image's lifetime.

Our completed-build cleanup tore it down immediately:

```ts
// opencomputer-adapter.ts — cleanupCompletedBuild (before)
await this.provider.deleteSandbox(providerSessionId, { deleteSecretStore: true });
```

`deleteSecretStore: true` deleted the very store the just-taken checkpoint depends on. The build succeeded, the store vanished, and the first spawn — and all after it — failed with `secret store not found`.

This is a client-side lifecycle bug, not an OpenComputer platform bug: the base store is meant to persist, and we deleted it.

## Fix

Treat the build's secret store as another **reapable artifact of the image**, exactly like `provider_image_id` (checkpoint) and `provider_session_id` (build sandbox) already are — persist it on the build row and reap it *with* the image, not with the build sandbox.

- **Persist it** — new nullable `image_builds.provider_secret_store_id` (migration `0043`). The OpenComputer provider reports the store id via `onProviderSessionCreated`, and it is written alongside `provider_session_id` at bind time. Only OpenComputer populates it; Modal images and Vercel snapshots are self-contained and leave it `NULL`.
- **Keep it while an image needs it** — completed-build cleanup keeps the store when the build was marked ready (its checkpoint's base layer). When the checkpoint is discarded (superseded, or the commit never settled), nothing depends on the store, so it is still torn down with the sandbox.
- **Reap it with the image** — `deleteProviderImage` now deletes the checkpoint *and* the store, and the cleanup reaper (`getSupersededImages` / `getFailedImagesWithArtifacts` → `deleteImage`) carries the store id through so superseded/restore-failed images reclaim it. Both deletes swallow `NotFound`, so reaping is idempotent.
- **Failed builds** still delete the store with the sandbox — no checkpoint was produced, so nothing references it.

### Store lifetime by outcome

| Build outcome | Checkpoint | Secret store |
| --- | --- | --- |
| Marked ready (live image) | kept, reaped when image is | **kept**, reaped with the image |
| Superseded by newer / commit not settled | discarded | deleted with the build sandbox |
| Build failed | never taken | deleted with the build sandbox |
| Image later superseded / restore-failed | reaper deletes it | reaper deletes it (via persisted id) |

Modal and Vercel are untouched — Vercel's `deleteImage` is self-contained and it hibernates (rather than deletes) its build sandbox, so only OpenComputer has the store↔checkpoint coupling.

## Operational note

Images built before this change already had their base store deleted at teardown, so **existing OpenComputer prebuilt images must be rebuilt** — this fix cannot resurrect a store that is already gone. New builds are correct from the first one.

Orphaned secret stores from the old behavior are out of scope here; they are reclaimable separately by listing `openinspect-*` stores (`GET /secret-stores`) and deleting the ones no live image depends on.

## Testing

- `npm run typecheck -w @open-inspect/control-plane` — clean (main + test configs)
- Unit: **1944 passed** (incl. new adapter/provider tests: store kept on ready, deleted on discard/failure, checkpoint+store reaped together, bare-store reap, `NotFound` swallowed)
- Integration: **560 passed** — applies the `0043` migration in the real D1 harness and exercises the reaper end-to-end
- `prettier` + `eslint` clean on all changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image builds now retain and track associated provider secret stores.
  * Ready images can preserve their secret stores for future use.
  * Superseded or failed build artifacts, including standalone secret stores, are automatically cleaned up.

* **Bug Fixes**
  * Improved cleanup handling for completed, failed, and deleted image builds.
  * Missing provider artifacts are handled safely during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->