### PR TITLE
fix(opencomputer): keep checkpoint base secret store on build cleanup

### DIFF
--- a/packages/control-plane/src/image-builds/opencomputer-adapter.test.ts
+++ b/packages/control-plane/src/image-builds/opencomputer-adapter.test.ts
@@ -82,7 +82,7 @@ describe("OpenComputerImageBuildAdapter", () => {
     });
   });
 
-  it("cleans up completed build sandboxes and deletes checkpoints with session context", async () => {
+  it("tears down a completed build sandbox but keeps its checkpoint's secret store", async () => {
     const provider = createProvider();
     const adapter = new OpenComputerImageBuildAdapter(provider);
     const correlation = { request_id: "request-1", trace_id: "trace-1" };
@@ -97,9 +97,29 @@ describe("OpenComputerImageBuildAdapter", () => {
       correlation,
     });
 
+    // The checkpoint retains the store as its base layer, so the store must
+    // survive the build sandbox or every fork of the image fails.
+    expect(provider.deleteSandbox).toHaveBeenCalledWith("oc-session-1", {
+      deleteSecretStore: false,
+    });
+    expect(provider.deleteProviderImage).toHaveBeenCalledWith("oc-checkpoint-1", "oc-session-1");
+  });
+
+  it("deletes the secret store with the sandbox when a build fails", async () => {
+    const provider = createProvider();
+    const adapter = new OpenComputerImageBuildAdapter(provider);
+    const correlation = { request_id: "request-1", trace_id: "trace-1" };
+
+    await adapter.cleanupFailedBuild?.({
+      buildId: "build-1",
+      providerSessionId: "oc-session-1",
+      errorMessage: "boom",
+      correlation,
+    });
+
+    // No checkpoint was taken, so nothing references the store — delete it.
     expect(provider.deleteSandbox).toHaveBeenCalledWith("oc-session-1", {
       deleteSecretStore: true,
     });
-    expect(provider.deleteProviderImage).toHaveBeenCalledWith("oc-checkpoint-1", "oc-session-1");
   });
 });

--- a/packages/control-plane/src/image-builds/opencomputer-adapter.ts
+++ b/packages/control-plane/src/image-builds/opencomputer-adapter.ts
@@ -67,11 +67,25 @@ export class OpenComputerImageBuildAdapter implements ImageBuildAdapter<OpenComp
   }
 
   async cleanupCompletedBuild(input: FinalizeImageBuildInput): Promise<void> {
-    await this.deleteBuildSandbox(input.buildId, input.providerSessionId, input.correlation);
+    // Keep the secret store. A successful build was checkpointed in
+    // finalizeSuccessfulBuild, and an OpenComputer checkpoint retains its build
+    // sandbox's secret store as a base layer that every from-checkpoint fork
+    // re-merges. Deleting it here is what made spawns from the image fail with
+    // "secret store not found". The store is cheap encrypted-KV metadata; one
+    // that outlives its image is reclaimed by the orphaned-store sweep, not at
+    // build teardown (the sandbox is gone by the time the image is deleted, so
+    // there is no attachment left to delete it through).
+    await this.deleteBuildSandbox(input.buildId, input.providerSessionId, input.correlation, {
+      deleteSecretStore: false,
+    });
   }
 
   async cleanupFailedBuild(input: FailedImageBuildInput): Promise<void> {
-    await this.deleteBuildSandbox(input.buildId, input.providerSessionId, input.correlation);
+    // A failed build produced no checkpoint, so nothing references its store —
+    // delete it with the sandbox.
+    await this.deleteBuildSandbox(input.buildId, input.providerSessionId, input.correlation, {
+      deleteSecretStore: true,
+    });
   }
 
   async deleteImage(input: DeleteImageInput): Promise<void> {
@@ -84,10 +98,13 @@ export class OpenComputerImageBuildAdapter implements ImageBuildAdapter<OpenComp
   private async deleteBuildSandbox(
     buildId: string,
     providerSessionId: string,
-    correlation: FinalizeImageBuildInput["correlation"]
+    correlation: FinalizeImageBuildInput["correlation"],
+    options: { deleteSecretStore: boolean }
   ): Promise<void> {
     try {
-      await this.provider.deleteSandbox(providerSessionId, { deleteSecretStore: true });
+      await this.provider.deleteSandbox(providerSessionId, {
+        deleteSecretStore: options.deleteSecretStore,
+      });
     } catch (error) {
       logger.warn("image_build.opencomputer_build_cleanup_failed", {
         build_id: buildId,


### PR DESCRIPTION
## Problem

Spawning a session from an OpenComputer prebuilt image failed at fork time — the image built fine, but **every** fork of it 400'd, permanently:

```
restore failed at spawn: Failed to create OpenComputer sandbox:
{"error":"secret store not found: openinspect-imgb-...-26c59426"}
```

## Root cause

An OpenComputer image build runs in a sandbox that carries a per-build secret store. Checkpointing that sandbox into the image **retains its store as the checkpoint's base layer**; every later `from-checkpoint` fork merges a fresh session store *on top of* that base, so the base must persist for the image's lifetime.

Completed-build cleanup tore it down immediately:

```ts
// before — cleanupCompletedBuild
await this.provider.deleteSandbox(providerSessionId, { deleteSecretStore: true });
```

The build succeeded, the base store vanished, and the first spawn — and all after it — failed with `secret store not found`.

## Fix

Keep the store when tearing down a **completed** build's sandbox; failed builds (which produce no checkpoint, so nothing references the store) still delete it. The change is entirely within the OpenComputer adapter — `cleanupCompletedBuild` passes `deleteSecretStore: false`, `cleanupFailedBuild` passes `true`.

That's the whole bug fix. It is deliberately **OpenComputer-local**: no schema change, and nothing in the generic image-build model, workflow, or reaper is touched.

## Scope: why not reap the kept store here too?

A build store that outlives its image is a leak, but reaping it *precisely* is a separate, inherently cross-cutting problem: the store id is created in the build request and only needed later in a different image-delete request, and the OpenComputer API does not surface a checkpoint's base store, so recovering it requires persisting the id ourselves (a new `image_builds` column threaded through the model → workflow → reaper). That is out of proportion to this bug.

Instead, leaked build stores — cheap encrypted-KV metadata — are left to the **orphaned-store sweep** (tracked separately), which already needs to exist to reclaim the stores this bug and prior behavior have already leaked. If we later decide precise reaping is worth the cross-layer cost, it can be added without reverting this change.

(This supersedes the closed #1040, which bundled that precise-reap machinery.)

## Operational note

Images built before this change already had their base store deleted at teardown, so **existing OpenComputer prebuilt images must be rebuilt** — this cannot resurrect a store that is already gone. New builds are correct from the first one.

## Testing

- `npm run typecheck -w @open-inspect/control-plane` — clean
- Unit: **1939 passed**, including the updated adapter tests (completed build keeps the store; failed build deletes it)
- `prettier` + `eslint` clean on the changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed successful image builds so their checkpoint secret store remains available for subsequent image spawns.
  * Improved cleanup behavior to remove failed-build secret stores while preserving successful-build checkpoint data.
  * Ensured checkpoint provider images are deleted during completed-build cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->