### PR TITLE
refactor: replace SessionDiffService deps bag with direct dependencies

### DIFF
--- a/packages/control-plane/src/session/diffs/service.test.ts
+++ b/packages/control-plane/src/session/diffs/service.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
+import type { Logger } from "../../logger";
+import type { SessionMessenger } from "../messenger";
 import type { SessionRepository } from "../repository";
 import type { SqlResult, SqlStorage } from "../sql-storage";
 import { SessionDiffService } from "./service";
@@ -87,24 +89,31 @@ function harness() {
     ],
     setSessionDiffBaselines: vi.fn(),
   } as unknown as SessionRepository;
-  const broadcast = vi.fn();
-  const service = new SessionDiffService({
-    store: new SessionDiffStore(sql),
+  const messenger: SessionMessenger = {
+    broadcast: vi.fn(),
+    sendToSandbox: vi.fn(() => true),
+  };
+  const log: Logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => log,
+  };
+  const service = new SessionDiffService(
+    new SessionDiffStore(sql),
     repository,
-    storage: { transactionSync: <T>(closure: () => T) => closure() },
-    log: { warn: vi.fn() },
-    generateId: () => "revision-1",
-    now: () => 200,
-    hasSandboxConnection: () => true,
-    sendRefreshCommand: vi.fn(() => true),
-    broadcast,
-  });
-  return { service, repository, broadcast };
+    messenger,
+    log,
+    () => "revision-1",
+    () => 200
+  );
+  return { service, repository, messenger };
 }
 
 describe("SessionDiffService", () => {
   it("accepts one matching bundle and serves a revision-pinned patch", async () => {
-    const { service, broadcast } = harness();
+    const { service, messenger } = harness();
 
     const uploaded = await service.handleUpload(
       new Request("http://internal/diff", { method: "POST", body: JSON.stringify(upload) })
@@ -122,7 +131,7 @@ describe("SessionDiffService", () => {
         )
       ).text()
     ).toContain("diff --git");
-    expect(broadcast).toHaveBeenCalledWith({
+    expect(messenger.broadcast).toHaveBeenCalledWith({
       type: "diff_state_changed",
       revisionId: "revision-1",
       updatedAt: 200,
@@ -170,10 +179,18 @@ describe("SessionDiffService", () => {
   });
 
   it("accepts retry as a non-blocking refresh command", () => {
-    const { service } = harness();
+    const { service, messenger } = harness();
 
     const response = service.handleRetry();
 
     expect(response.status).toBe(202);
+    expect(messenger.sendToSandbox).toHaveBeenCalledWith({ type: "refresh_diff" });
+  });
+
+  it("rejects retry when the sandbox is not connected", () => {
+    const { service, messenger } = harness();
+    vi.mocked(messenger.sendToSandbox).mockReturnValue(false);
+
+    expect(service.handleRetry().status).toBe(409);
   });
 });

--- a/packages/control-plane/src/session/diffs/service.ts
+++ b/packages/control-plane/src/session/diffs/service.ts
@@ -2,41 +2,33 @@ import {
   sessionDiffFailureSchema,
   sessionDiffUploadSchema,
   type SandboxEvent,
-  type ServerMessage,
   type SessionDiffState,
   type SessionDiffUpload,
 } from "@open-inspect/shared";
+import { generateId } from "../../auth/crypto";
 import type { Logger } from "../../logger";
+import type { SessionMessenger } from "../messenger";
 import type { SessionRepository } from "../repository";
 import type { SessionDiffStore } from "./store";
-
-interface TransactionStorage {
-  transactionSync<T>(closure: () => T): T;
-}
-
-interface SessionDiffServiceDeps {
-  store: SessionDiffStore;
-  repository: Pick<SessionRepository, "getSessionRepositories" | "setSessionDiffBaselines">;
-  storage: TransactionStorage;
-  log: Pick<Logger, "warn">;
-  generateId: () => string;
-  now: () => number;
-  hasSandboxConnection: () => boolean;
-  sendRefreshCommand: (command: { type: "refresh_diff" }) => boolean;
-  broadcast: (message: Extract<ServerMessage, { type: "diff_state_changed" }>) => void;
-}
 
 const DIFF_ID_PATTERN = /^[A-Za-z0-9._-]{1,200}$/;
 
 /** Owns validation and the single latest-bundle publication boundary. */
 export class SessionDiffService {
-  constructor(private readonly deps: SessionDiffServiceDeps) {}
+  constructor(
+    private readonly store: SessionDiffStore,
+    private readonly repository: SessionRepository,
+    private readonly messenger: SessionMessenger,
+    private readonly log: Logger,
+    private readonly generateRevisionId: () => string = () => generateId(),
+    private readonly now: () => number = () => Date.now()
+  ) {}
 
   /** Return the latest patch-free manifest and any non-destructive refresh error. */
   getPublicState(): SessionDiffState {
-    const repositories = this.deps.repository.getSessionRepositories();
+    const repositories = this.repository.getSessionRepositories();
     const missingBaseline = repositories.some((repository) => !repository.row?.base_sha);
-    return this.deps.store.getPublicState(
+    return this.store.getPublicState(
       missingBaseline ? "Changes unavailable for this session" : null
     );
   }
@@ -51,7 +43,7 @@ export class SessionDiffService {
    * Repository order and identity must match the session's configured repositories.
    */
   async handleReady(event: Extract<SandboxEvent, { type: "ready" }>): Promise<void> {
-    const sessionRepositories = this.deps.repository.getSessionRepositories();
+    const sessionRepositories = this.repository.getSessionRepositories();
     const advertised = event.repositories ?? [];
     const repositoriesMatch =
       advertised.length === sessionRepositories.length &&
@@ -66,7 +58,7 @@ export class SessionDiffService {
         );
       });
     if (!repositoriesMatch) {
-      this.deps.log.warn("session_diff.baseline_repository_mismatch", {
+      this.log.warn("session_diff.baseline_repository_mismatch", {
         advertised_repositories: advertised.length,
         session_repositories: sessionRepositories.length,
       });
@@ -77,7 +69,7 @@ export class SessionDiffService {
       const existing = sessionRepository.row?.base_sha;
       const next = advertised[index]!.baseSha;
       if (existing && existing.toLocaleLowerCase("en-US") !== next.toLocaleLowerCase("en-US")) {
-        this.deps.log.warn("session_diff.baseline_conflict", {
+        this.log.warn("session_diff.baseline_conflict", {
           repository_position: sessionRepository.position,
           repo_owner: sessionRepository.repoOwner,
           repo_name: sessionRepository.repoName,
@@ -85,17 +77,15 @@ export class SessionDiffService {
       }
     }
 
-    this.deps.storage.transactionSync(() => {
-      this.deps.repository.setSessionDiffBaselines(
-        sessionRepositories.map((sessionRepository, index) => ({
-          position: sessionRepository.position,
-          repoOwner: sessionRepository.repoOwner,
-          repoName: sessionRepository.repoName,
-          baseSha: advertised[index]!.baseSha,
-          isPrimary: sessionRepository.isPrimary,
-        }))
-      );
-    });
+    this.repository.setSessionDiffBaselines(
+      sessionRepositories.map((sessionRepository, index) => ({
+        position: sessionRepository.position,
+        repoOwner: sessionRepository.repoOwner,
+        repoName: sessionRepository.repoName,
+        baseSha: advertised[index]!.baseSha,
+        isPrimary: sessionRepository.isPrimary,
+      }))
+    );
   }
 
   /** Validate and atomically publish a sandbox-produced bundle as the latest revision. */
@@ -109,11 +99,9 @@ export class SessionDiffService {
       return Response.json({ error: repositoryError.message }, { status: repositoryError.status });
     }
 
-    const revisionId = this.deps.generateId();
-    const now = this.deps.now();
-    this.deps.storage.transactionSync(() => {
-      this.deps.store.replaceBundle(parsed.data, revisionId, now);
-    });
+    const revisionId = this.generateRevisionId();
+    const now = this.now();
+    this.store.replaceBundle(parsed.data, revisionId, now);
     this.broadcastState(now);
     return Response.json({ revisionId });
   }
@@ -124,10 +112,8 @@ export class SessionDiffService {
     if (!parsed.success) {
       return Response.json({ error: "Invalid session diff failure" }, { status: 400 });
     }
-    const now = this.deps.now();
-    this.deps.storage.transactionSync(() => {
-      this.deps.store.recordFailure(parsed.data.error, now);
-    });
+    const now = this.now();
+    this.store.recordFailure(parsed.data.error, now);
     this.broadcastState(now);
     return new Response(null, { status: 204 });
   }
@@ -139,7 +125,7 @@ export class SessionDiffService {
     if (!revisionId || !fileId) {
       return Response.json({ error: "Invalid diff file identity" }, { status: 400 });
     }
-    const result = this.deps.store.resolveFile(revisionId, fileId);
+    const result = this.store.resolveFile(revisionId, fileId);
     if (!result.ok) {
       return Response.json(
         {
@@ -161,10 +147,7 @@ export class SessionDiffService {
 
   /** Request a non-blocking refresh when the session sandbox is connected. */
   handleRetry(): Response {
-    if (!this.deps.hasSandboxConnection()) {
-      return Response.json({ error: "Sandbox is not connected" }, { status: 409 });
-    }
-    if (!this.deps.sendRefreshCommand({ type: "refresh_diff" })) {
+    if (!this.messenger.sendToSandbox({ type: "refresh_diff" })) {
       return Response.json({ error: "Sandbox is not connected" }, { status: 409 });
     }
     return Response.json({ accepted: true }, { status: 202 });
@@ -173,7 +156,7 @@ export class SessionDiffService {
   private validateRepositorySet(
     bundle: SessionDiffUpload
   ): { status: 400 | 409; message: string } | null {
-    const sessionRepositories = this.deps.repository.getSessionRepositories();
+    const sessionRepositories = this.repository.getSessionRepositories();
     if (bundle.repositories.length !== sessionRepositories.length) {
       return { status: 400, message: "Repository set does not match session" };
     }
@@ -202,7 +185,7 @@ export class SessionDiffService {
   }
 
   private broadcastState(updatedAt: number): void {
-    this.deps.broadcast({
+    this.messenger.broadcast({
       type: "diff_state_changed",
       revisionId: this.getPublicState().current?.revisionId ?? null,
       updatedAt,

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -150,12 +150,14 @@ export class SessionDO extends DurableObject<Env> {
   private sql: SqlStorage;
   private repository: SessionRepository;
   private attachmentRepository: SessionAttachmentRepository;
-  private diffService: SessionDiffService;
-  private messenger: SessionMessenger;
   private initialized = false;
   private log: Logger;
   // WebSocket manager (lazily initialized like lifecycleManager)
   private _wsManager: SessionWebSocketManager | null = null;
+  // Session messenger (lazily initialized)
+  private _messenger: SessionMessenger | null = null;
+  // Session diff service (lazily initialized)
+  private _diffService: SessionDiffService | null = null;
   // Lifecycle manager (lazily initialized)
   private _lifecycleManager: SandboxLifecycleManager | null = null;
   // Source control provider (lazily initialized)
@@ -246,13 +248,6 @@ export class SessionDO extends DurableObject<Env> {
       this.attachmentRepository
     );
     this.log = createLogger("session-do", {}, parseLogLevel(env.LOG_LEVEL));
-    this.messenger = new SessionMessengerImpl(this.wsManager);
-    this.diffService = new SessionDiffService(
-      new SessionDiffStore(this.sql),
-      this.repository,
-      this.messenger,
-      this.log
-    );
     // Note: session_id context is set in ensureInitialized() once DB is ready
   }
 
@@ -354,6 +349,33 @@ export class SessionDO extends DurableObject<Env> {
       });
     }
     return this._wsManager;
+  }
+
+  /**
+   * Get the session messenger, creating it lazily if needed.
+   * Lazy initialization preserves the WebSocket manager's own lazy
+   * construction so it captures the session_id-scoped logger.
+   */
+  private get messenger(): SessionMessenger {
+    if (!this._messenger) {
+      this._messenger = new SessionMessengerImpl(this.wsManager);
+    }
+    return this._messenger;
+  }
+
+  /**
+   * Get the session diff service, creating it lazily if needed.
+   */
+  private get diffService(): SessionDiffService {
+    if (!this._diffService) {
+      this._diffService = new SessionDiffService(
+        new SessionDiffStore(this.sql),
+        this.repository,
+        this.messenger,
+        this.log
+      );
+    }
+    return this._diffService;
   }
 
   private get executionTimeoutMs(): number {

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -154,10 +154,10 @@ export class SessionDO extends DurableObject<Env> {
   private log: Logger;
   // WebSocket manager (lazily initialized like lifecycleManager)
   private _wsManager: SessionWebSocketManager | null = null;
-  // Session messenger (lazily initialized)
-  private _messenger: SessionMessenger | null = null;
-  // Session diff service (lazily initialized)
-  private _diffService: SessionDiffService | null = null;
+  // Session messenger (constructed in ensureInitialized once the session logger exists)
+  private messenger!: SessionMessenger;
+  // Session diff service (constructed in ensureInitialized once the session logger exists)
+  private diffService!: SessionDiffService;
   // Lifecycle manager (lazily initialized)
   private _lifecycleManager: SandboxLifecycleManager | null = null;
   // Source control provider (lazily initialized)
@@ -349,33 +349,6 @@ export class SessionDO extends DurableObject<Env> {
       });
     }
     return this._wsManager;
-  }
-
-  /**
-   * Get the session messenger, creating it lazily if needed.
-   * Lazy initialization preserves the WebSocket manager's own lazy
-   * construction so it captures the session_id-scoped logger.
-   */
-  private get messenger(): SessionMessenger {
-    if (!this._messenger) {
-      this._messenger = new SessionMessengerImpl(this.wsManager);
-    }
-    return this._messenger;
-  }
-
-  /**
-   * Get the session diff service, creating it lazily if needed.
-   */
-  private get diffService(): SessionDiffService {
-    if (!this._diffService) {
-      this._diffService = new SessionDiffService(
-        new SessionDiffStore(this.sql),
-        this.repository,
-        this.messenger,
-        this.log
-      );
-    }
-    return this._diffService;
   }
 
   private get executionTimeoutMs(): number {
@@ -885,6 +858,16 @@ export class SessionDO extends DurableObject<Env> {
       "session-do",
       { session_id: sessionId },
       parseLogLevel(this.env.LOG_LEVEL)
+    );
+    // Constructed here rather than in the constructor so they (and the
+    // WebSocket manager they force) capture the session-scoped logger,
+    // never the request-scoped child installed by fetch().
+    this.messenger = new SessionMessengerImpl(this.wsManager);
+    this.diffService = new SessionDiffService(
+      new SessionDiffStore(this.sql),
+      this.repository,
+      this.messenger,
+      this.log
     );
     this.wsManager.enableAutoPingPong();
   }

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -120,6 +120,7 @@ import { MessageService } from "./services/message.service";
 import { createAlarmHandler, type AlarmHandler } from "./alarm/handler";
 import { SessionDiffStore } from "./diffs/store";
 import { SessionDiffService } from "./diffs/service";
+import { SessionMessengerImpl, type SessionMessenger } from "./messenger";
 
 /**
  * Timeout for WebSocket authentication (in milliseconds).
@@ -150,6 +151,7 @@ export class SessionDO extends DurableObject<Env> {
   private repository: SessionRepository;
   private attachmentRepository: SessionAttachmentRepository;
   private diffService: SessionDiffService;
+  private messenger: SessionMessenger;
   private initialized = false;
   private log: Logger;
   // WebSocket manager (lazily initialized like lifecycleManager)
@@ -244,20 +246,13 @@ export class SessionDO extends DurableObject<Env> {
       this.attachmentRepository
     );
     this.log = createLogger("session-do", {}, parseLogLevel(env.LOG_LEVEL));
-    this.diffService = new SessionDiffService({
-      store: new SessionDiffStore(this.sql),
-      repository: this.repository,
-      storage: ctx.storage,
-      log: this.log,
-      generateId: () => generateId(),
-      now: () => Date.now(),
-      hasSandboxConnection: () => Boolean(this.wsManager.getSandboxSocket()),
-      sendRefreshCommand: (command) => {
-        const sandboxSocket = this.wsManager.getSandboxSocket();
-        return sandboxSocket ? this.wsManager.send(sandboxSocket, command) : false;
-      },
-      broadcast: (message) => this.broadcast(message),
-    });
+    this.messenger = new SessionMessengerImpl(this.wsManager);
+    this.diffService = new SessionDiffService(
+      new SessionDiffStore(this.sql),
+      this.repository,
+      this.messenger,
+      this.log
+    );
     // Note: session_id context is set in ensureInitialized() once DB is ready
   }
 
@@ -1548,9 +1543,7 @@ export class SessionDO extends DurableObject<Env> {
    * Broadcast message to all authenticated clients.
    */
   private broadcast(message: ServerMessage): void {
-    this.wsManager.forEachClientSocket("authenticated_only", (ws) => {
-      this.wsManager.send(ws, message);
-    });
+    this.messenger.broadcast(message);
   }
 
   /**

--- a/packages/control-plane/src/session/messenger.test.ts
+++ b/packages/control-plane/src/session/messenger.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { SessionMessengerImpl } from "./messenger";
+import type { SessionWebSocketManager } from "./websocket-manager";
+
+function harness(sandboxSocket: WebSocket | null = null) {
+  const clientSockets = [{} as WebSocket, {} as WebSocket];
+  const send = vi.fn(() => true);
+  const wsManager = {
+    forEachClientSocket: vi.fn(
+      (_mode: "all_clients" | "authenticated_only", fn: (ws: WebSocket) => void) => {
+        for (const ws of clientSockets) fn(ws);
+      }
+    ),
+    getSandboxSocket: vi.fn(() => sandboxSocket),
+    send,
+  } as unknown as SessionWebSocketManager;
+  return { messenger: new SessionMessengerImpl(wsManager), wsManager, clientSockets, send };
+}
+
+describe("SessionMessengerImpl", () => {
+  it("broadcasts to every authenticated client socket", () => {
+    const { messenger, wsManager, clientSockets, send } = harness();
+    const message = { type: "diff_state_changed", revisionId: "r1", updatedAt: 1 } as const;
+
+    messenger.broadcast(message);
+
+    expect(wsManager.forEachClientSocket).toHaveBeenCalledWith(
+      "authenticated_only",
+      expect.any(Function)
+    );
+    expect(send).toHaveBeenCalledTimes(clientSockets.length);
+    for (const ws of clientSockets) expect(send).toHaveBeenCalledWith(ws, message);
+  });
+
+  it("sends a command to the connected sandbox socket", () => {
+    const sandboxSocket = {} as WebSocket;
+    const { messenger, send } = harness(sandboxSocket);
+
+    expect(messenger.sendToSandbox({ type: "refresh_diff" })).toBe(true);
+    expect(send).toHaveBeenCalledWith(sandboxSocket, { type: "refresh_diff" });
+  });
+
+  it("reports failure when no sandbox is connected", () => {
+    const { messenger, send } = harness(null);
+
+    expect(messenger.sendToSandbox({ type: "refresh_diff" })).toBe(false);
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/packages/control-plane/src/session/messenger.ts
+++ b/packages/control-plane/src/session/messenger.ts
@@ -1,0 +1,35 @@
+/**
+ * SessionMessenger — higher-level session messaging on top of the
+ * WebSocket registry: fan-out to authenticated clients and command
+ * delivery to the sandbox socket.
+ */
+
+import type { ServerMessage } from "@open-inspect/shared";
+import type { SandboxCommand } from "./types";
+import type { SessionWebSocketManager } from "./websocket-manager";
+
+export interface SessionMessenger {
+  /** Broadcast a message to all authenticated client sockets. */
+  broadcast(message: ServerMessage): void;
+
+  /**
+   * Send a command to the active sandbox socket. Returns false when no
+   * sandbox is connected or the send fails.
+   */
+  sendToSandbox(command: SandboxCommand): boolean;
+}
+
+export class SessionMessengerImpl implements SessionMessenger {
+  constructor(private readonly wsManager: SessionWebSocketManager) {}
+
+  broadcast(message: ServerMessage): void {
+    this.wsManager.forEachClientSocket("authenticated_only", (ws) => {
+      this.wsManager.send(ws, message);
+    });
+  }
+
+  sendToSandbox(command: SandboxCommand): boolean {
+    const sandboxSocket = this.wsManager.getSandboxSocket();
+    return sandboxSocket ? this.wsManager.send(sandboxSocket, command) : false;
+  }
+}

--- a/packages/control-plane/src/session/repository.test.ts
+++ b/packages/control-plane/src/session/repository.test.ts
@@ -329,6 +329,38 @@ describe("SessionRepository", () => {
       expect(mock.calls[2].query).toContain("WHERE position = ?");
       expect(mock.calls[2].params).toEqual(["b".repeat(40), 1, "acme", "web"]);
     });
+
+    it("applies all baseline updates in one transaction", () => {
+      let transactions = 0;
+      repo = new SessionRepository(
+        mock.sql,
+        (closure) => {
+          transactions += 1;
+          return closure();
+        },
+        new SessionAttachmentRepository(mock.sql)
+      );
+
+      repo.setSessionDiffBaselines([
+        {
+          position: 0,
+          repoOwner: "acme",
+          repoName: "web",
+          baseSha: "a".repeat(40),
+          isPrimary: true,
+        },
+        {
+          position: 1,
+          repoOwner: "acme",
+          repoName: "api",
+          baseSha: "b".repeat(40),
+          isPrimary: false,
+        },
+      ]);
+
+      expect(transactions).toBe(1);
+      expect(mock.calls).toHaveLength(3);
+    });
   });
 
   // === SANDBOX ===

--- a/packages/control-plane/src/session/repository.ts
+++ b/packages/control-plane/src/session/repository.ts
@@ -446,31 +446,33 @@ export class SessionRepository {
       isPrimary: boolean;
     }>
   ): void {
-    for (const repository of repositories) {
-      this.sql.exec(
-        `UPDATE session_repositories
-         SET base_sha = ?
-         WHERE position = ?
-           AND repo_owner = ? COLLATE NOCASE
-           AND repo_name = ? COLLATE NOCASE
-           AND base_sha IS NULL`,
-        repository.baseSha,
-        repository.position,
-        repository.repoOwner,
-        repository.repoName
-      );
-      if (repository.isPrimary) {
+    this.transactionSync(() => {
+      for (const repository of repositories) {
         this.sql.exec(
-          `UPDATE session SET base_sha = ?
-           WHERE repo_owner = ? COLLATE NOCASE
+          `UPDATE session_repositories
+           SET base_sha = ?
+           WHERE position = ?
+             AND repo_owner = ? COLLATE NOCASE
              AND repo_name = ? COLLATE NOCASE
              AND base_sha IS NULL`,
           repository.baseSha,
+          repository.position,
           repository.repoOwner,
           repository.repoName
         );
+        if (repository.isPrimary) {
+          this.sql.exec(
+            `UPDATE session SET base_sha = ?
+             WHERE repo_owner = ? COLLATE NOCASE
+               AND repo_name = ? COLLATE NOCASE
+               AND base_sha IS NULL`,
+            repository.baseSha,
+            repository.repoOwner,
+            repository.repoName
+          );
+        }
       }
-    }
+    });
   }
 
   // === SANDBOX ===


### PR DESCRIPTION
## Summary

Follow-up refactor to the session diff viewer (#1036). `SessionDiffService` used a "bag of deps" constructor object, including ad-hoc closures (`hasSandboxConnection`, `sendRefreshCommand`, `broadcast`) that leaked DO wiring concerns into the service. This PR replaces the bag with direct constructor dependencies and introduces a small composition class for outbound messaging.

## Changes

### `SessionDiffService` takes direct dependencies

Direct positional constructor parameters (`store`, `repository`, `messenger`, `log`), matching the existing idiom of `SessionWebSocketManagerImpl` and `SessionRepository`. `generateRevisionId` and `now` are trailing parameters with production defaults; only tests override them.

### New `SessionMessenger` (`src/session/messenger.ts`)

Interface + `SessionMessengerImpl` (same naming convention as `SessionWebSocketManager`/`Impl`), composing over the socket registry:

- `broadcast(message)` — fan-out to authenticated clients. `SessionDO`'s private `broadcast()` now delegates here, so the fan-out logic exists once.
- `sendToSandbox(command)` — typed against the existing `SandboxCommand` union; returns `false` when no sandbox is connected.

This replaces the three injected closures. `handleRetry` collapses to a single `sendToSandbox({ type: "refresh_diff" })` check — the previous `hasSandboxConnection` + `sendRefreshCommand` two-step checked the same state twice and returned the same 409. Observable behavior is unchanged.

### `storage: TransactionStorage` dependency removed

- The `transactionSync` wrappers around `SessionDiffStore.replaceBundle` / `recordFailure` were no-ops: each is a single SQL statement, already atomic.
- The one real multi-statement transaction now lives inside `SessionRepository.setSessionDiffBaselines` itself, which already owns a `transactionSync` and has precedent for self-contained transactions (`createMessageWithAttachments`). Callers no longer orchestrate the repository's transactional boundaries.

Net effect: the DO wiring collapses from 15 lines of closure plumbing to a plain 4-argument construction.

## Testing

- `npm run typecheck -w @open-inspect/control-plane` — clean (prod + test tsconfigs)
- `npm test -w @open-inspect/control-plane` — 1964 passed, including a new `messenger.test.ts` and a new 409-retry case in `service.test.ts`
- `npm run test:integration -w @open-inspect/control-plane` — 569 passed, including the end-to-end `session-diffs` suite against the real DO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a session messaging layer to broadcast diff updates to authenticated clients and send targeted sandbox refresh commands on diff retry.
* **Bug Fixes**
  * Improved consistency of retry responses based on sandbox availability.
  * Strengthened baseline updates and diff state updates to ensure changes are applied reliably.
* **Tests**
  * Added coverage for client fan-out and sandbox refresh behavior.
  * Updated diff service retry assertions and added transaction verification for baseline updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->