### PR TITLE
refactor: enforce HTTP boundary between SessionDiffService and transport

### DIFF
--- a/packages/control-plane/src/session/diffs/errors.ts
+++ b/packages/control-plane/src/session/diffs/errors.ts
@@ -1,0 +1,114 @@
+/**
+ * Session-diff error taxonomy. The HTTP handler maps codes to statuses;
+ * the service and store throw these instead of returning Responses.
+ */
+
+export type SessionDiffErrorCode =
+  | "invalid_bundle"
+  | "repository_mismatch"
+  | "baseline_unavailable"
+  | "baseline_mismatch"
+  | "invalid_failure"
+  | "invalid_file_identity"
+  | "diff_revision_stale"
+  | "diff_file_not_found"
+  | "sandbox_not_connected";
+
+export abstract class SessionDiffError extends Error {
+  abstract readonly code: SessionDiffErrorCode;
+
+  constructor(message: string, cause?: unknown) {
+    super(message, cause === undefined ? undefined : { cause });
+    this.name = new.target.name;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, new.target);
+    }
+  }
+}
+
+export class InvalidDiffBundleError extends SessionDiffError {
+  readonly code = "invalid_bundle";
+
+  constructor() {
+    super("Invalid session diff bundle");
+  }
+}
+
+export class DiffRepositoryMismatchError extends SessionDiffError {
+  readonly code = "repository_mismatch";
+
+  constructor() {
+    super("Repository set does not match session");
+  }
+}
+
+export class DiffBaselineUnavailableError extends SessionDiffError {
+  readonly code = "baseline_unavailable";
+
+  constructor() {
+    super("Session start baseline is unavailable");
+  }
+}
+
+export class DiffBaselineMismatchError extends SessionDiffError {
+  readonly code = "baseline_mismatch";
+
+  constructor() {
+    super("Repository baseline does not match session");
+  }
+}
+
+export class InvalidDiffFailureError extends SessionDiffError {
+  readonly code = "invalid_failure";
+
+  constructor() {
+    super("Invalid session diff failure");
+  }
+}
+
+export class InvalidDiffFileIdentityError extends SessionDiffError {
+  readonly code = "invalid_file_identity";
+
+  constructor() {
+    super("Invalid diff file identity");
+  }
+}
+
+export class DiffRevisionStaleError extends SessionDiffError {
+  readonly code = "diff_revision_stale";
+
+  constructor(readonly currentRevisionId: string | null) {
+    super("Diff revision is stale");
+  }
+}
+
+export class DiffFileNotFoundError extends SessionDiffError {
+  readonly code = "diff_file_not_found";
+
+  constructor(readonly currentRevisionId: string | null) {
+    super("Diff file not found");
+  }
+}
+
+export class SandboxNotConnectedError extends SessionDiffError {
+  readonly code = "sandbox_not_connected";
+
+  constructor() {
+    super("Sandbox is not connected");
+  }
+}
+
+/**
+ * Closed union of every concrete session-diff error. Lets handlers switch
+ * exhaustively on `code` and reach payload fields like `currentRevisionId`.
+ */
+export type SessionDiffDomainError =
+  | InvalidDiffBundleError
+  | DiffRepositoryMismatchError
+  | DiffBaselineUnavailableError
+  | DiffBaselineMismatchError
+  | InvalidDiffFailureError
+  | InvalidDiffFileIdentityError
+  | DiffRevisionStaleError
+  | DiffFileNotFoundError
+  | SandboxNotConnectedError;

--- a/packages/control-plane/src/session/diffs/errors.ts
+++ b/packages/control-plane/src/session/diffs/errors.ts
@@ -1,114 +1,68 @@
 /**
- * Session-diff error taxonomy. The HTTP handler maps codes to statuses;
- * the service and store throw these instead of returning Responses.
+ * Session-diff domain errors. The service and store throw these instead of
+ * returning Responses; the HTTP handler maps each class to a status via
+ * instanceof (see routes/automations.ts TargetSelectionError for precedent).
  */
 
-export type SessionDiffErrorCode =
-  | "invalid_bundle"
-  | "repository_mismatch"
-  | "baseline_unavailable"
-  | "baseline_mismatch"
-  | "invalid_failure"
-  | "invalid_file_identity"
-  | "diff_revision_stale"
-  | "diff_file_not_found"
-  | "sandbox_not_connected";
-
-export abstract class SessionDiffError extends Error {
-  abstract readonly code: SessionDiffErrorCode;
-
-  constructor(message: string, cause?: unknown) {
-    super(message, cause === undefined ? undefined : { cause });
-    this.name = new.target.name;
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, new.target);
-    }
-  }
-}
-
-export class InvalidDiffBundleError extends SessionDiffError {
-  readonly code = "invalid_bundle";
-
+export class InvalidDiffBundleError extends Error {
   constructor() {
     super("Invalid session diff bundle");
+    this.name = "InvalidDiffBundleError";
   }
 }
 
-export class DiffRepositoryMismatchError extends SessionDiffError {
-  readonly code = "repository_mismatch";
-
+export class DiffRepositoryMismatchError extends Error {
   constructor() {
     super("Repository set does not match session");
+    this.name = "DiffRepositoryMismatchError";
   }
 }
 
-export class DiffBaselineUnavailableError extends SessionDiffError {
-  readonly code = "baseline_unavailable";
-
+export class DiffBaselineUnavailableError extends Error {
   constructor() {
     super("Session start baseline is unavailable");
+    this.name = "DiffBaselineUnavailableError";
   }
 }
 
-export class DiffBaselineMismatchError extends SessionDiffError {
-  readonly code = "baseline_mismatch";
-
+export class DiffBaselineMismatchError extends Error {
   constructor() {
     super("Repository baseline does not match session");
+    this.name = "DiffBaselineMismatchError";
   }
 }
 
-export class InvalidDiffFailureError extends SessionDiffError {
-  readonly code = "invalid_failure";
-
+export class InvalidDiffFailureError extends Error {
   constructor() {
     super("Invalid session diff failure");
+    this.name = "InvalidDiffFailureError";
   }
 }
 
-export class InvalidDiffFileIdentityError extends SessionDiffError {
-  readonly code = "invalid_file_identity";
-
+export class InvalidDiffFileIdentityError extends Error {
   constructor() {
     super("Invalid diff file identity");
+    this.name = "InvalidDiffFileIdentityError";
   }
 }
 
-export class DiffRevisionStaleError extends SessionDiffError {
-  readonly code = "diff_revision_stale";
-
+export class DiffRevisionStaleError extends Error {
   constructor(readonly currentRevisionId: string | null) {
     super("Diff revision is stale");
+    this.name = "DiffRevisionStaleError";
   }
 }
 
-export class DiffFileNotFoundError extends SessionDiffError {
-  readonly code = "diff_file_not_found";
-
+export class DiffFileNotFoundError extends Error {
   constructor(readonly currentRevisionId: string | null) {
     super("Diff file not found");
+    this.name = "DiffFileNotFoundError";
   }
 }
 
-export class SandboxNotConnectedError extends SessionDiffError {
-  readonly code = "sandbox_not_connected";
-
+export class SandboxNotConnectedError extends Error {
   constructor() {
     super("Sandbox is not connected");
+    this.name = "SandboxNotConnectedError";
   }
 }
-
-/**
- * Closed union of every concrete session-diff error. Lets handlers switch
- * exhaustively on `code` and reach payload fields like `currentRevisionId`.
- */
-export type SessionDiffDomainError =
-  | InvalidDiffBundleError
-  | DiffRepositoryMismatchError
-  | DiffBaselineUnavailableError
-  | DiffBaselineMismatchError
-  | InvalidDiffFailureError
-  | InvalidDiffFileIdentityError
-  | DiffRevisionStaleError
-  | DiffFileNotFoundError
-  | SandboxNotConnectedError;

--- a/packages/control-plane/src/session/diffs/service.test.ts
+++ b/packages/control-plane/src/session/diffs/service.test.ts
@@ -3,6 +3,15 @@ import type { Logger } from "../../logger";
 import type { SessionMessenger } from "../messenger";
 import type { SessionRepository } from "../repository";
 import type { SqlResult, SqlStorage } from "../sql-storage";
+import {
+  DiffBaselineMismatchError,
+  DiffFileNotFoundError,
+  DiffRepositoryMismatchError,
+  DiffRevisionStaleError,
+  InvalidDiffBundleError,
+  InvalidDiffFileIdentityError,
+  SandboxNotConnectedError,
+} from "./errors";
 import { SessionDiffService } from "./service";
 import { SessionDiffStore } from "./store";
 
@@ -112,25 +121,14 @@ function harness() {
 }
 
 describe("SessionDiffService", () => {
-  it("accepts one matching bundle and serves a revision-pinned patch", async () => {
+  it("publishes one matching bundle and serves a revision-pinned patch", () => {
     const { service, messenger } = harness();
 
-    const uploaded = await service.handleUpload(
-      new Request("http://internal/diff", { method: "POST", body: JSON.stringify(upload) })
-    );
-
-    expect(uploaded.status).toBe(200);
-    await expect(uploaded.json()).resolves.toEqual({ revisionId: "revision-1" });
-    expect(await (await service.handleState()).json()).toMatchObject({
+    expect(service.publishBundle(upload)).toBe("revision-1");
+    expect(service.getPublicState()).toMatchObject({
       current: { revisionId: "revision-1" },
     });
-    expect(
-      await (
-        await service.handleResolveFile(
-          new URL("http://internal/file?revisionId=revision-1&fileId=file-1")
-        )
-      ).text()
-    ).toContain("diff --git");
+    expect(service.resolveFile("revision-1", "file-1")).toContain("diff --git");
     expect(messenger.broadcast).toHaveBeenCalledWith({
       type: "diff_state_changed",
       revisionId: "revision-1",
@@ -138,59 +136,55 @@ describe("SessionDiffService", () => {
     });
   });
 
-  it("rejects a mismatched repository set and immutable baselines", async () => {
+  it("rejects a mismatched repository set and immutable baselines", () => {
     const { service } = harness();
-    const request = (body: unknown) =>
-      service.handleUpload(
-        new Request("http://internal/diff", { method: "POST", body: JSON.stringify(body) })
-      );
 
-    expect((await request({ ...upload, repositories: [] })).status).toBe(400);
-    expect(
-      (
-        await request({
-          ...upload,
-          repositories: [{ ...upload.repositories[0], baseSha: "c".repeat(40) }],
-        })
-      ).status
-    ).toBe(400);
+    expect(() => service.publishBundle(null)).toThrow(InvalidDiffBundleError);
+    expect(() =>
+      service.publishBundle({
+        ...upload,
+        repositories: [{ ...upload.repositories[0], repoOwner: "other" }],
+      })
+    ).toThrow(DiffRepositoryMismatchError);
+    expect(() =>
+      service.publishBundle({
+        ...upload,
+        repositories: [{ ...upload.repositories[0], baseSha: "c".repeat(40) }],
+      })
+    ).toThrow(DiffBaselineMismatchError);
   });
 
-  it("retains a successful bundle when a later refresh fails", async () => {
+  it("retains a successful bundle when a later refresh fails", () => {
     const { service } = harness();
-    await service.handleUpload(
-      new Request("http://internal/diff", { method: "POST", body: JSON.stringify(upload) })
-    );
+    service.publishBundle(upload);
 
-    expect(
-      (
-        await service.handleFailure(
-          new Request("http://internal/failure", {
-            method: "POST",
-            body: JSON.stringify({ error: "collector timed out" }),
-          })
-        )
-      ).status
-    ).toBe(204);
-    expect(await (await service.handleState()).json()).toMatchObject({
+    service.recordRefreshFailure({ error: "collector timed out" });
+
+    expect(service.getPublicState()).toMatchObject({
       current: { revisionId: "revision-1" },
       lastError: { message: "collector timed out", occurredAt: 200 },
     });
   });
 
-  it("accepts retry as a non-blocking refresh command", () => {
-    const { service, messenger } = harness();
+  it("rejects invalid, stale, and unknown file identities", () => {
+    const { service } = harness();
+    service.publishBundle(upload);
 
-    const response = service.handleRetry();
-
-    expect(response.status).toBe(202);
-    expect(messenger.sendToSandbox).toHaveBeenCalledWith({ type: "refresh_diff" });
+    expect(() => service.resolveFile(null, "file-1")).toThrow(InvalidDiffFileIdentityError);
+    expect(() => service.resolveFile("revision-1", "not a valid id!")).toThrow(
+      InvalidDiffFileIdentityError
+    );
+    expect(() => service.resolveFile("revision-0", "file-1")).toThrow(DiffRevisionStaleError);
+    expect(() => service.resolveFile("revision-1", "missing")).toThrow(DiffFileNotFoundError);
   });
 
-  it("rejects retry when the sandbox is not connected", () => {
+  it("requests a refresh only while the sandbox is connected", () => {
     const { service, messenger } = harness();
-    vi.mocked(messenger.sendToSandbox).mockReturnValue(false);
 
-    expect(service.handleRetry().status).toBe(409);
+    service.requestRefresh();
+    expect(messenger.sendToSandbox).toHaveBeenCalledWith({ type: "refresh_diff" });
+
+    vi.mocked(messenger.sendToSandbox).mockReturnValue(false);
+    expect(() => service.requestRefresh()).toThrow(SandboxNotConnectedError);
   });
 });

--- a/packages/control-plane/src/session/diffs/service.ts
+++ b/packages/control-plane/src/session/diffs/service.ts
@@ -9,11 +9,24 @@ import { generateId } from "../../auth/crypto";
 import type { Logger } from "../../logger";
 import type { SessionMessenger } from "../messenger";
 import type { SessionRepository } from "../repository";
+import {
+  DiffBaselineMismatchError,
+  DiffBaselineUnavailableError,
+  DiffRepositoryMismatchError,
+  InvalidDiffBundleError,
+  InvalidDiffFailureError,
+  InvalidDiffFileIdentityError,
+  SandboxNotConnectedError,
+} from "./errors";
 import type { SessionDiffStore } from "./store";
 
 const DIFF_ID_PATTERN = /^[A-Za-z0-9._-]{1,200}$/;
 
-/** Owns validation and the single latest-bundle publication boundary. */
+/**
+ * Owns validation and the single latest-bundle publication boundary.
+ * Domain layer: methods throw SessionDiffError subclasses; the HTTP
+ * handler maps them to responses.
+ */
 export class SessionDiffService {
   constructor(
     private readonly store: SessionDiffStore,
@@ -33,16 +46,11 @@ export class SessionDiffService {
     );
   }
 
-  /** Serialize the browser-safe state returned by the authenticated manifest route. */
-  handleState(): Response {
-    return Response.json(this.getPublicState());
-  }
-
   /**
    * Pin immutable baselines advertised by the sandbox's ready event.
    * Repository order and identity must match the session's configured repositories.
    */
-  async handleReady(event: Extract<SandboxEvent, { type: "ready" }>): Promise<void> {
+  pinBaselines(event: Extract<SandboxEvent, { type: "ready" }>): void {
     const sessionRepositories = this.repository.getSessionRepositories();
     const advertised = event.repositories ?? [];
     const repositoriesMatch =
@@ -88,77 +96,54 @@ export class SessionDiffService {
     );
   }
 
-  /** Validate and atomically publish a sandbox-produced bundle as the latest revision. */
-  async handleUpload(request: Request): Promise<Response> {
-    const parsed = sessionDiffUploadSchema.safeParse(await this.readJson(request));
+  /**
+   * Validate and atomically publish a sandbox-produced bundle as the latest
+   * revision, returning its revision id.
+   */
+  publishBundle(input: unknown): string {
+    const parsed = sessionDiffUploadSchema.safeParse(input);
     if (!parsed.success) {
-      return Response.json({ error: "Invalid session diff bundle" }, { status: 400 });
+      throw new InvalidDiffBundleError();
     }
-    const repositoryError = this.validateRepositorySet(parsed.data);
-    if (repositoryError) {
-      return Response.json({ error: repositoryError.message }, { status: repositoryError.status });
-    }
+    this.assertRepositorySetMatches(parsed.data);
 
     const revisionId = this.generateRevisionId();
     const now = this.now();
     this.store.replaceBundle(parsed.data, revisionId, now);
     this.broadcastState(now);
-    return Response.json({ revisionId });
+    return revisionId;
   }
 
   /** Record a bounded refresh error without discarding the previous successful bundle. */
-  async handleFailure(request: Request): Promise<Response> {
-    const parsed = sessionDiffFailureSchema.safeParse(await this.readJson(request));
+  recordRefreshFailure(input: unknown): void {
+    const parsed = sessionDiffFailureSchema.safeParse(input);
     if (!parsed.success) {
-      return Response.json({ error: "Invalid session diff failure" }, { status: 400 });
+      throw new InvalidDiffFailureError();
     }
     const now = this.now();
     this.store.recordFailure(parsed.data.error, now);
     this.broadcastState(now);
-    return new Response(null, { status: 204 });
   }
 
   /** Resolve a patch only when both its revision and file identity are current. */
-  handleResolveFile(url: URL): Response {
-    const revisionId = this.readId(url.searchParams.get("revisionId"));
-    const fileId = this.readId(url.searchParams.get("fileId"));
-    if (!revisionId || !fileId) {
-      return Response.json({ error: "Invalid diff file identity" }, { status: 400 });
+  resolveFile(revisionId: string | null, fileId: string | null): string {
+    if (!this.isValidId(revisionId) || !this.isValidId(fileId)) {
+      throw new InvalidDiffFileIdentityError();
     }
-    const result = this.store.resolveFile(revisionId, fileId);
-    if (!result.ok) {
-      return Response.json(
-        {
-          error: result.status === 409 ? "Diff revision is stale" : "Diff file not found",
-          code: result.status === 409 ? "diff_revision_stale" : "diff_file_not_found",
-          currentRevisionId: result.currentRevisionId,
-        },
-        { status: result.status }
-      );
-    }
-    return new Response(result.patch, {
-      headers: {
-        "Content-Type": "text/x-diff; charset=utf-8",
-        "Cache-Control": "private, no-store",
-        "X-Content-Type-Options": "nosniff",
-      },
-    });
+    return this.store.resolveFile(revisionId, fileId);
   }
 
-  /** Request a non-blocking refresh when the session sandbox is connected. */
-  handleRetry(): Response {
+  /** Request a non-blocking refresh from the connected session sandbox. */
+  requestRefresh(): void {
     if (!this.messenger.sendToSandbox({ type: "refresh_diff" })) {
-      return Response.json({ error: "Sandbox is not connected" }, { status: 409 });
+      throw new SandboxNotConnectedError();
     }
-    return Response.json({ accepted: true }, { status: 202 });
   }
 
-  private validateRepositorySet(
-    bundle: SessionDiffUpload
-  ): { status: 400 | 409; message: string } | null {
+  private assertRepositorySetMatches(bundle: SessionDiffUpload): void {
     const sessionRepositories = this.repository.getSessionRepositories();
     if (bundle.repositories.length !== sessionRepositories.length) {
-      return { status: 400, message: "Repository set does not match session" };
+      throw new DiffRepositoryMismatchError();
     }
     for (const sessionRepository of sessionRepositories) {
       const repository = bundle.repositories.find(
@@ -171,17 +156,16 @@ export class SessionDiffService {
         repository.repoName.toLocaleLowerCase("en-US") !==
           sessionRepository.repoName.toLocaleLowerCase("en-US")
       ) {
-        return { status: 400, message: "Repository set does not match session" };
+        throw new DiffRepositoryMismatchError();
       }
       const baseSha = sessionRepository.row?.base_sha;
       if (!baseSha) {
-        return { status: 409, message: "Session start baseline is unavailable" };
+        throw new DiffBaselineUnavailableError();
       }
       if (repository.baseSha.toLocaleLowerCase("en-US") !== baseSha.toLocaleLowerCase("en-US")) {
-        return { status: 400, message: "Repository baseline does not match session" };
+        throw new DiffBaselineMismatchError();
       }
     }
-    return null;
   }
 
   private broadcastState(updatedAt: number): void {
@@ -192,15 +176,7 @@ export class SessionDiffService {
     });
   }
 
-  private async readJson(request: Request): Promise<unknown> {
-    try {
-      return await request.json();
-    } catch {
-      return null;
-    }
-  }
-
-  private readId(value: unknown): string | null {
-    return typeof value === "string" && DIFF_ID_PATTERN.test(value) ? value : null;
+  private isValidId(value: string | null): value is string {
+    return typeof value === "string" && DIFF_ID_PATTERN.test(value);
   }
 }

--- a/packages/control-plane/src/session/diffs/service.ts
+++ b/packages/control-plane/src/session/diffs/service.ts
@@ -24,8 +24,8 @@ const DIFF_ID_PATTERN = /^[A-Za-z0-9._-]{1,200}$/;
 
 /**
  * Owns validation and the single latest-bundle publication boundary.
- * Domain layer: methods throw SessionDiffError subclasses; the HTTP
- * handler maps them to responses.
+ * Domain layer: methods throw the errors in ./errors; the HTTP handler
+ * maps them to responses.
  */
 export class SessionDiffService {
   constructor(

--- a/packages/control-plane/src/session/diffs/store.test.ts
+++ b/packages/control-plane/src/session/diffs/store.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { SqlResult, SqlStorage } from "../sql-storage";
+import { DiffFileNotFoundError, DiffRevisionStaleError } from "./errors";
 import { SessionDiffStore } from "./store";
 
 class MemoryDiffSql implements SqlStorage {
@@ -104,10 +105,9 @@ describe("SessionDiffStore", () => {
     });
     expect(JSON.stringify(store.getPublicState(null))).not.toContain("diff --git");
     expect(JSON.parse(String(sql.row?.bundle_json))).not.toHaveProperty("revisionId");
-    expect(store.resolveFile("revision-1", "file-1")).toEqual({
-      ok: true,
-      patch: "diff --git a/src/app.ts b/src/app.ts\n",
-    });
+    expect(store.resolveFile("revision-1", "file-1")).toBe(
+      "diff --git a/src/app.ts b/src/app.ts\n"
+    );
   });
 
   it("records a bounded failure without replacing the prior bundle", () => {
@@ -120,23 +120,22 @@ describe("SessionDiffStore", () => {
       current: { revisionId: "revision-1" },
       lastError: { message: "collector timed out", occurredAt: 300 },
     });
-    expect(store.resolveFile("revision-1", "file-1")).toMatchObject({ ok: true });
+    expect(store.resolveFile("revision-1", "file-1")).toContain("diff --git");
   });
 
   it("pins selected-file reads to the current revision", () => {
     const store = new SessionDiffStore(new MemoryDiffSql());
     store.replaceBundle(upload, "revision-2", 200);
 
-    expect(store.resolveFile("revision-1", "file-1")).toEqual({
-      ok: false,
-      status: 409,
-      currentRevisionId: "revision-2",
-    });
-    expect(store.resolveFile("revision-2", "missing-file")).toEqual({
-      ok: false,
-      status: 404,
-      currentRevisionId: "revision-2",
-    });
+    let stale: unknown;
+    try {
+      store.resolveFile("revision-1", "file-1");
+    } catch (e) {
+      stale = e;
+    }
+    expect(stale).toBeInstanceOf(DiffRevisionStaleError);
+    expect((stale as DiffRevisionStaleError).currentRevisionId).toBe("revision-2");
+    expect(() => store.resolveFile("revision-2", "missing-file")).toThrow(DiffFileNotFoundError);
   });
 
   it("stores a partial multi-repository bundle without mixing prior state", () => {

--- a/packages/control-plane/src/session/diffs/store.ts
+++ b/packages/control-plane/src/session/diffs/store.ts
@@ -10,6 +10,7 @@ import {
   type StoredSessionDiffBundle,
 } from "@open-inspect/shared";
 import type { SqlStorage } from "../sql-storage";
+import { DiffFileNotFoundError, DiffRevisionStaleError } from "./errors";
 
 interface SessionDiffRow {
   revision_id: string | null;
@@ -81,25 +82,23 @@ export class SessionDiffStore {
     });
   }
 
-  /** Resolve a renderable patch from the current revision without accepting stale identities. */
-  resolveFile(
-    revisionId: string,
-    fileId: string
-  ):
-    | { ok: true; patch: string }
-    | { ok: false; status: 404 | 409; currentRevisionId: string | null } {
+  /**
+   * Resolve a renderable patch from the current revision without accepting
+   * stale identities. Throws DiffRevisionStaleError or DiffFileNotFoundError.
+   */
+  resolveFile(revisionId: string, fileId: string): string {
     const bundle = this.parseBundle(this.readRow());
     const currentRevisionId = bundle?.revisionId ?? null;
     if (revisionId !== currentRevisionId) {
-      return { ok: false, status: 409, currentRevisionId };
+      throw new DiffRevisionStaleError(currentRevisionId);
     }
     const file = bundle?.repositories
       .flatMap((repository) => repository.files)
       .find((candidate) => candidate.id === fileId);
     if (!file || file.renderState !== "renderable" || !("patch" in file) || !file.patch) {
-      return { ok: false, status: 404, currentRevisionId };
+      throw new DiffFileNotFoundError(currentRevisionId);
     }
-    return { ok: true, patch: file.patch };
+    return file.patch;
   }
 
   private readRow(): SessionDiffRow | null {

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -120,6 +120,7 @@ import { MessageService } from "./services/message.service";
 import { createAlarmHandler, type AlarmHandler } from "./alarm/handler";
 import { SessionDiffStore } from "./diffs/store";
 import { SessionDiffService } from "./diffs/service";
+import { SessionDiffsHandler } from "./http/handlers/session-diffs.handler";
 import { SessionMessengerImpl, type SessionMessenger } from "./messenger";
 
 /**
@@ -158,6 +159,8 @@ export class SessionDO extends DurableObject<Env> {
   private messenger!: SessionMessenger;
   // Session diff service (constructed in ensureInitialized once the session logger exists)
   private diffService!: SessionDiffService;
+  // Session diffs HTTP handler (constructed in ensureInitialized alongside the service)
+  private diffsHandler!: SessionDiffsHandler;
   // Lifecycle manager (lazily initialized)
   private _lifecycleManager: SandboxLifecycleManager | null = null;
   // Source control provider (lazily initialized)
@@ -231,11 +234,11 @@ export class SessionDO extends DurableObject<Env> {
     childSummary: (_request, url) => this.childSessionsHandler.getChildSummary(url),
     cancel: () => this.sessionLifecycleHandler.cancel(),
     childSessionUpdate: (request) => this.childSessionsHandler.childSessionUpdate(request),
-    diffState: () => this.diffService.handleState(),
-    diffStore: (request) => this.diffService.handleUpload(request),
-    diffFailure: (request) => this.diffService.handleFailure(request),
-    diffResolveFile: (_request, url) => this.diffService.handleResolveFile(url),
-    diffRetry: () => this.diffService.handleRetry(),
+    diffState: () => this.diffsHandler.state(),
+    diffStore: (request) => this.diffsHandler.storeBundle(request),
+    diffFailure: (request) => this.diffsHandler.recordFailure(request),
+    diffResolveFile: (_request, url) => this.diffsHandler.resolveFile(url),
+    diffRetry: () => this.diffsHandler.retry(),
   });
 
   constructor(ctx: DurableObjectState, env: Env) {
@@ -656,7 +659,7 @@ export class SessionDO extends DurableObject<Env> {
         updateLastActivity: (timestamp) => this.updateLastActivity(timestamp),
         scheduleInactivityCheck: () => this.scheduleInactivityCheck(),
         processMessageQueue: () => this.messageQueue.processMessageQueue(),
-        handleReady: (event) => this.diffService.handleReady(event),
+        handleReady: async (event) => this.diffService.pinBaselines(event),
       });
     }
 
@@ -869,6 +872,7 @@ export class SessionDO extends DurableObject<Env> {
       this.messenger,
       this.log
     );
+    this.diffsHandler = new SessionDiffsHandler(this.diffService);
     this.wsManager.enableAutoPingPong();
   }
 

--- a/packages/control-plane/src/session/http/handlers/session-diffs.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/session-diffs.handler.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  DiffBaselineUnavailableError,
+  DiffFileNotFoundError,
+  DiffRevisionStaleError,
+  InvalidDiffBundleError,
+  InvalidDiffFileIdentityError,
+  SandboxNotConnectedError,
+} from "../../diffs/errors";
+import type { SessionDiffService } from "../../diffs/service";
+import { SessionDiffsHandler } from "./session-diffs.handler";
+
+function harness(overrides: Partial<SessionDiffService> = {}) {
+  const service = {
+    getPublicState: vi.fn(() => ({ version: 1, current: null, lastError: null })),
+    publishBundle: vi.fn(() => "revision-1"),
+    recordRefreshFailure: vi.fn(),
+    resolveFile: vi.fn(() => "diff --git a/src/app.ts b/src/app.ts\n"),
+    requestRefresh: vi.fn(),
+    ...overrides,
+  } as unknown as SessionDiffService;
+  return { handler: new SessionDiffsHandler(service), service };
+}
+
+const jsonRequest = (body: unknown) =>
+  new Request("http://internal/diff", { method: "POST", body: JSON.stringify(body) });
+
+describe("SessionDiffsHandler", () => {
+  it("serializes the public state", async () => {
+    const { handler } = harness();
+
+    const response = handler.state();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ version: 1, current: null });
+  });
+
+  it("returns the published revision id and passes the parsed body through", async () => {
+    const { handler, service } = harness();
+
+    const response = await handler.storeBundle(jsonRequest({ triggerMessageId: "m-1" }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ revisionId: "revision-1" });
+    expect(service.publishBundle).toHaveBeenCalledWith({ triggerMessageId: "m-1" });
+  });
+
+  it("passes null through when the request body is not JSON", async () => {
+    const { handler, service } = harness({
+      publishBundle: vi.fn(() => {
+        throw new InvalidDiffBundleError();
+      }),
+    });
+
+    const response = await handler.storeBundle(
+      new Request("http://internal/diff", { method: "POST", body: "not json" })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid session diff bundle" });
+    expect(service.publishBundle).toHaveBeenCalledWith(null);
+  });
+
+  it("maps baseline_unavailable to a conflict", async () => {
+    const { handler } = harness({
+      publishBundle: vi.fn(() => {
+        throw new DiffBaselineUnavailableError();
+      }),
+    });
+
+    const response = await handler.storeBundle(jsonRequest({}));
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Session start baseline is unavailable",
+    });
+  });
+
+  it("records a failure with no content", async () => {
+    const { handler, service } = harness();
+
+    const response = await handler.recordFailure(jsonRequest({ error: "collector timed out" }));
+
+    expect(response.status).toBe(204);
+    expect(service.recordRefreshFailure).toHaveBeenCalledWith({ error: "collector timed out" });
+  });
+
+  it("serves a resolved patch with diff headers", () => {
+    const { handler, service } = harness();
+
+    const response = handler.resolveFile(
+      new URL("http://internal/file?revisionId=revision-1&fileId=file-1")
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("text/x-diff; charset=utf-8");
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(service.resolveFile).toHaveBeenCalledWith("revision-1", "file-1");
+  });
+
+  it("maps file resolution errors onto stable status codes and payloads", async () => {
+    const cases = [
+      {
+        error: new InvalidDiffFileIdentityError(),
+        status: 400,
+        body: { error: "Invalid diff file identity" },
+      },
+      {
+        error: new DiffRevisionStaleError("revision-2"),
+        status: 409,
+        body: {
+          error: "Diff revision is stale",
+          code: "diff_revision_stale",
+          currentRevisionId: "revision-2",
+        },
+      },
+      {
+        error: new DiffFileNotFoundError("revision-2"),
+        status: 404,
+        body: {
+          error: "Diff file not found",
+          code: "diff_file_not_found",
+          currentRevisionId: "revision-2",
+        },
+      },
+    ];
+
+    for (const { error, status, body } of cases) {
+      const { handler } = harness({
+        resolveFile: vi.fn(() => {
+          throw error;
+        }),
+      });
+
+      const response = handler.resolveFile(new URL("http://internal/file?revisionId=r&fileId=f"));
+
+      expect(response.status).toBe(status);
+      await expect(response.json()).resolves.toEqual(body);
+    }
+  });
+
+  it("accepts retry and reports a disconnected sandbox as a conflict", async () => {
+    const { handler } = harness();
+    expect(handler.retry().status).toBe(202);
+
+    const disconnected = harness({
+      requestRefresh: vi.fn(() => {
+        throw new SandboxNotConnectedError();
+      }),
+    });
+    const response = disconnected.handler.retry();
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({ error: "Sandbox is not connected" });
+  });
+
+  it("rethrows errors that are not session diff errors", () => {
+    const { handler } = harness({
+      requestRefresh: vi.fn(() => {
+        throw new TypeError("unexpected");
+      }),
+    });
+
+    expect(() => handler.retry()).toThrow(TypeError);
+  });
+});

--- a/packages/control-plane/src/session/http/handlers/session-diffs.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/session-diffs.handler.ts
@@ -1,0 +1,117 @@
+import { SessionDiffError, type SessionDiffDomainError } from "../../diffs/errors";
+import type { SessionDiffService } from "../../diffs/service";
+
+/**
+ * HTTP boundary for the session diff endpoints: reads requests, delegates
+ * to the domain service, and maps thrown SessionDiffError codes to
+ * statuses and response bodies.
+ */
+export class SessionDiffsHandler {
+  constructor(private readonly diffService: SessionDiffService) {}
+
+  /** Serialize the browser-safe state returned by the authenticated manifest route. */
+  state(): Response {
+    return Response.json(this.diffService.getPublicState());
+  }
+
+  /** Accept a sandbox-produced bundle as the latest revision. */
+  async storeBundle(request: Request): Promise<Response> {
+    try {
+      const revisionId = this.diffService.publishBundle(await this.readJson(request));
+      return Response.json({ revisionId });
+    } catch (e) {
+      return this.errorResponse(e);
+    }
+  }
+
+  /** Record a refresh failure reported by the sandbox. */
+  async recordFailure(request: Request): Promise<Response> {
+    try {
+      this.diffService.recordRefreshFailure(await this.readJson(request));
+      return new Response(null, { status: 204 });
+    } catch (e) {
+      return this.errorResponse(e);
+    }
+  }
+
+  /** Serve a revision-pinned patch for a single file. */
+  resolveFile(url: URL): Response {
+    try {
+      const patch = this.diffService.resolveFile(
+        url.searchParams.get("revisionId"),
+        url.searchParams.get("fileId")
+      );
+      return new Response(patch, {
+        headers: {
+          "Content-Type": "text/x-diff; charset=utf-8",
+          "Cache-Control": "private, no-store",
+          "X-Content-Type-Options": "nosniff",
+        },
+      });
+    } catch (e) {
+      return this.errorResponse(e);
+    }
+  }
+
+  /** Request a non-blocking diff refresh from the session sandbox. */
+  retry(): Response {
+    try {
+      this.diffService.requestRefresh();
+      return Response.json({ accepted: true }, { status: 202 });
+    } catch (e) {
+      return this.errorResponse(e);
+    }
+  }
+
+  private errorResponse(errorValue: unknown): Response {
+    if (!(errorValue instanceof SessionDiffError)) throw errorValue;
+
+    // SessionDiffError is abstract, so every instance is one of the
+    // concrete union members and the `code` switch discriminates payloads.
+    const domainError = errorValue as SessionDiffDomainError;
+    switch (domainError.code) {
+      case "invalid_bundle":
+      case "repository_mismatch":
+      case "baseline_mismatch":
+      case "invalid_failure":
+      case "invalid_file_identity":
+        return Response.json({ error: domainError.message }, { status: 400 });
+      case "baseline_unavailable":
+      case "sandbox_not_connected":
+        return Response.json({ error: domainError.message }, { status: 409 });
+      case "diff_revision_stale":
+        return Response.json(
+          {
+            error: domainError.message,
+            code: domainError.code,
+            currentRevisionId: domainError.currentRevisionId,
+          },
+          { status: 409 }
+        );
+      case "diff_file_not_found":
+        return Response.json(
+          {
+            error: domainError.message,
+            code: domainError.code,
+            currentRevisionId: domainError.currentRevisionId,
+          },
+          { status: 404 }
+        );
+      default: {
+        const exhaustive: never = domainError;
+        return Response.json(
+          { error: `Unhandled session diff error: ${String(exhaustive)}` },
+          { status: 500 }
+        );
+      }
+    }
+  }
+
+  private async readJson(request: Request): Promise<unknown> {
+    try {
+      return await request.json();
+    } catch {
+      return null;
+    }
+  }
+}

--- a/packages/control-plane/src/session/http/handlers/session-diffs.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/session-diffs.handler.ts
@@ -1,10 +1,20 @@
-import { SessionDiffError, type SessionDiffDomainError } from "../../diffs/errors";
+import {
+  DiffBaselineMismatchError,
+  DiffBaselineUnavailableError,
+  DiffFileNotFoundError,
+  DiffRepositoryMismatchError,
+  DiffRevisionStaleError,
+  InvalidDiffBundleError,
+  InvalidDiffFailureError,
+  InvalidDiffFileIdentityError,
+  SandboxNotConnectedError,
+} from "../../diffs/errors";
 import type { SessionDiffService } from "../../diffs/service";
 
 /**
  * HTTP boundary for the session diff endpoints: reads requests, delegates
- * to the domain service, and maps thrown SessionDiffError codes to
- * statuses and response bodies.
+ * to the domain service, and maps thrown domain errors to statuses and
+ * response bodies.
  */
 export class SessionDiffsHandler {
   constructor(private readonly diffService: SessionDiffService) {}
@@ -63,48 +73,44 @@ export class SessionDiffsHandler {
     }
   }
 
+  /** Map each domain error to its status; anything unrecognized is rethrown. */
   private errorResponse(errorValue: unknown): Response {
-    if (!(errorValue instanceof SessionDiffError)) throw errorValue;
-
-    // SessionDiffError is abstract, so every instance is one of the
-    // concrete union members and the `code` switch discriminates payloads.
-    const domainError = errorValue as SessionDiffDomainError;
-    switch (domainError.code) {
-      case "invalid_bundle":
-      case "repository_mismatch":
-      case "baseline_mismatch":
-      case "invalid_failure":
-      case "invalid_file_identity":
-        return Response.json({ error: domainError.message }, { status: 400 });
-      case "baseline_unavailable":
-      case "sandbox_not_connected":
-        return Response.json({ error: domainError.message }, { status: 409 });
-      case "diff_revision_stale":
-        return Response.json(
-          {
-            error: domainError.message,
-            code: domainError.code,
-            currentRevisionId: domainError.currentRevisionId,
-          },
-          { status: 409 }
-        );
-      case "diff_file_not_found":
-        return Response.json(
-          {
-            error: domainError.message,
-            code: domainError.code,
-            currentRevisionId: domainError.currentRevisionId,
-          },
-          { status: 404 }
-        );
-      default: {
-        const exhaustive: never = domainError;
-        return Response.json(
-          { error: `Unhandled session diff error: ${String(exhaustive)}` },
-          { status: 500 }
-        );
-      }
+    if (
+      errorValue instanceof InvalidDiffBundleError ||
+      errorValue instanceof DiffRepositoryMismatchError ||
+      errorValue instanceof DiffBaselineMismatchError ||
+      errorValue instanceof InvalidDiffFailureError ||
+      errorValue instanceof InvalidDiffFileIdentityError
+    ) {
+      return Response.json({ error: errorValue.message }, { status: 400 });
     }
+    if (
+      errorValue instanceof DiffBaselineUnavailableError ||
+      errorValue instanceof SandboxNotConnectedError
+    ) {
+      return Response.json({ error: errorValue.message }, { status: 409 });
+    }
+    if (errorValue instanceof DiffRevisionStaleError) {
+      return Response.json(
+        {
+          error: errorValue.message,
+          code: "diff_revision_stale",
+          currentRevisionId: errorValue.currentRevisionId,
+        },
+        { status: 409 }
+      );
+    }
+    if (errorValue instanceof DiffFileNotFoundError) {
+      return Response.json(
+        {
+          error: errorValue.message,
+          code: "diff_file_not_found",
+          currentRevisionId: errorValue.currentRevisionId,
+        },
+        { status: 404 }
+      );
+    }
+    throw errorValue;
   }
 
   private async readJson(request: Request): Promise<unknown> {


### PR DESCRIPTION
## Summary

Follow-up to #1045. `SessionDiffService` was operating at the wrong layer: it took raw `Request`/`URL` inputs, returned `Response` objects, and encoded HTTP status codes in its internal contracts — `SessionDiffStore.resolveFile` even returned `{ status: 404 | 409 }` from the persistence layer. This PR enforces a boundary: the domain layer throws typed errors, and a dedicated HTTP handler owns all transport semantics.

The structure mirrors the existing `image-builds` pattern (`errors.ts` taxonomy + `imageBuildErrorToResponse`), whose header states the same principle: *"Route handlers map codes to HTTP statuses; workflow and planner throw these instead of returning Responses."*

## Changes

### New `session/diffs/errors.ts`

`SessionDiffError` abstract base (same shape as `ImageBuildError`) with nine concrete subclasses keyed by a `code` discriminant (`invalid_bundle`, `repository_mismatch`, `baseline_unavailable`, `diff_revision_stale`, `sandbox_not_connected`, …). `DiffRevisionStaleError`/`DiffFileNotFoundError` carry `currentRevisionId` as payload. A closed `SessionDiffDomainError` union enables exhaustive `switch` with a `never` check.

### `SessionDiffService` is now pure domain

No `Request`, `Response`, `URL`, or status codes. Methods take parsed values, return domain values, and throw on failure:

- `publishBundle(input: unknown): string` (revision id)
- `recordRefreshFailure(input: unknown): void`
- `resolveFile(revisionId, fileId): string` (patch text)
- `requestRefresh(): void`
- `handleReady` → renamed `pinBaselines` (handler nomenclature removed from the domain API)

Zod validation stays in the service (schemas are domain contracts); only body-reading moved out. The `DIFF_ID_PATTERN` identity check stays as a domain rule. The `diff_state_changed` broadcast stays — it is a domain side effect, not HTTP.

### `SessionDiffStore.resolveFile` no longer speaks HTTP

Returns the patch string; throws `DiffRevisionStaleError` / `DiffFileNotFoundError` instead of `{ ok: false; status: 404 | 409 }`.

### New `SessionDiffsHandler` (`session/http/handlers/session-diffs.handler.ts`)

The diff endpoints were the only routes bypassing the `http/handlers/` layer and hitting a service directly. The handler owns request-body reading, query-param extraction, the patch response headers, and a single exhaustive error-code → status/payload mapping. Non-domain errors are rethrown, matching `imageBuildErrorToResponse`. Wire behavior is byte-for-byte identical.

### Wiring

DO routes table points at the handler; the sandbox-event processor keeps calling the service directly (`pinBaselines`) since that path is not HTTP.

## Testing

- `service.test.ts` is now pure domain — asserts thrown error types, no `Request`/`Response` construction. The error taxonomy also let it distinguish cases the old status-based test could not (schema-invalid vs repository-mismatch, both formerly 400).
- New `session-diffs.handler.test.ts` covers the full reason→status mapping, patch headers, non-JSON bodies, and that unknown errors are rethrown.
- `npm test -w @open-inspect/control-plane` — 1974 passed
- `npm run test:integration -w @open-inspect/control-plane` — 569 passed, including the end-to-end `session-diffs` suite **unchanged** — the proof that observable HTTP behavior did not move.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session diff handling for publishing bundles, viewing diff state, resolving file patches, recording refresh failures, and requesting refreshes.
  * Added revision-pinned file resolution with clear responses for stale revisions or unavailable files.
  * Added consistent HTTP error responses for invalid diff data, baseline conflicts, and disconnected sandboxes.

* **Bug Fixes**
  * Preserved the last successful diff revision after a refresh failure.
  * Improved validation of diff bundles, file identities, repository data, and baselines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->