### PR TITLE
refactor: decompose diff refresh worker and type diff bundle wire shapes

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -35,7 +35,7 @@ from .attachment_processor import (
     parse_session_image_attachments,
 )
 from .constants import BOOT_WARNINGS_FILE_PATH, REPO_MANIFEST_FILE_PATH
-from .diff_capture import SessionDiffRefreshWorker
+from .diff_capture import ControlPlaneDiffClient, SessionDiffRefreshWorker
 from .log_config import configure_logging, get_logger
 from .repo_config import find_repo_entry, load_repo_manifest
 from .types import GitUser
@@ -284,12 +284,12 @@ class AgentBridge:
         # Track the current prompt task so _handle_stop can cancel it
         self._current_prompt_task: asyncio.Task[None] | None = None
         self.diff_refresh = SessionDiffRefreshWorker(
-            session_id=self.session_id,
-            control_plane_url=self.control_plane_url,
-            auth_token=self.auth_token,
-            load_repositories=lambda: load_repo_manifest(self.repo_manifest_path),
-            is_idle=lambda: self._current_prompt_task is None or self._current_prompt_task.done(),
-            get_http_client=lambda: self.http_client,
+            client=ControlPlaneDiffClient(
+                control_plane_url=self.control_plane_url,
+                session_id=self.session_id,
+                auth_token=self.auth_token,
+            ),
+            manifest_path=self.repo_manifest_path,
             log=self.log,
         )
 
@@ -757,6 +757,9 @@ class AgentBridge:
             self._current_prompt_task = task
 
             def handle_task_exception(t: asyncio.Task[None], mid: str = message_id) -> None:
+                # Release the diff worker's idle gate before any refresh request
+                # below so the refresh can start immediately.
+                self.diff_refresh.prompt_finished()
                 if self._current_prompt_task is t:
                     self._current_prompt_task = None
                 if t.cancelled():

--- a/packages/sandbox-runtime/src/sandbox_runtime/diff_capture.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/diff_capture.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import time
-from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Protocol
 from urllib.parse import quote
+
+import httpx
 
 from .diff_collector import (
     CaptureLimits,
@@ -15,17 +18,108 @@ from .diff_collector import (
     collect_session_diff_bundle,
     encode_bundle,
 )
+from .repo_config import load_repo_manifest
 
 if TYPE_CHECKING:
-    import httpx
+    from collections.abc import Awaitable
+    from pathlib import Path
 
     from .log_config import StructuredLogger
     from .repo_config import RepoEntry
 
 DEFAULT_REFRESH_TIMEOUT_SECONDS = 60.0
-DEFAULT_IDLE_POLL_SECONDS = 0.05
 
-BundleCollector = Callable[..., Awaitable[SessionDiffBundle]]
+
+class BundleCollector(Protocol):
+    """Collects every session repository into one bounded upload bundle."""
+
+    def __call__(
+        self,
+        repositories: list[RepoEntry],
+        *,
+        trigger_message_id: str | None,
+        captured_at: int,
+        limits: CaptureLimits | None = None,
+    ) -> Awaitable[SessionDiffBundle]: ...
+
+
+class DiffUploadOutcome(Enum):
+    """The control plane's disposition of a diff endpoint call."""
+
+    ACCEPTED = "accepted"
+    UNSUPPORTED = "unsupported"
+
+
+class ControlPlaneDiffClient:
+    """HTTP client for the control plane's session diff endpoints.
+
+    Owns its connection pool unless one is injected. A 404 from either
+    endpoint means this control plane predates the diff feature; callers
+    should stop uploading for the rest of the sandbox's life.
+    """
+
+    def __init__(
+        self,
+        *,
+        control_plane_url: str,
+        session_id: str,
+        auth_token: str,
+        timeout_seconds: float = DEFAULT_REFRESH_TIMEOUT_SECONDS,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        base_url = control_plane_url.rstrip("/")
+        self._diff_url = f"{base_url}/sessions/{quote(session_id, safe='')}/diff"
+        self._auth_token = auth_token
+        self._timeout_seconds = timeout_seconds
+        self._http_client = http_client
+        self._owns_http_client = http_client is None
+
+    async def upload_bundle(self, bundle: SessionDiffBundle) -> DiffUploadOutcome:
+        response = await self._client().put(
+            self._diff_url,
+            headers={
+                "Authorization": f"Bearer {self._auth_token}",
+                "Content-Type": "application/json",
+            },
+            content=encode_bundle(bundle),
+            timeout=self._timeout_seconds,
+        )
+        return self._outcome(response)
+
+    async def report_failure(self, message: str) -> DiffUploadOutcome:
+        response = await self._client().post(
+            f"{self._diff_url}/failure",
+            headers={"Authorization": f"Bearer {self._auth_token}"},
+            json={"error": message},
+            timeout=self._timeout_seconds,
+        )
+        return self._outcome(response)
+
+    async def aclose(self) -> None:
+        if self._owns_http_client and self._http_client is not None:
+            await self._http_client.aclose()
+
+    def _client(self) -> httpx.AsyncClient:
+        # Created on first request so constructing a bridge that never runs
+        # (common in tests) does not leak an unclosed connection pool.
+        if self._http_client is None:
+            self._http_client = httpx.AsyncClient()
+        return self._http_client
+
+    def _outcome(self, response: httpx.Response) -> DiffUploadOutcome:
+        if response.status_code == 404:
+            return DiffUploadOutcome.UNSUPPORTED
+        response.raise_for_status()
+        return DiffUploadOutcome.ACCEPTED
+
+
+@dataclass(frozen=True)
+class _RefreshAttempt:
+    """One coalesced refresh request, snapshotted before collection starts."""
+
+    generation: int
+    activity_generation: int
+    trigger_message_id: str | None
 
 
 class SessionDiffRefreshWorker:
@@ -34,41 +128,42 @@ class SessionDiffRefreshWorker:
     def __init__(
         self,
         *,
-        session_id: str,
-        control_plane_url: str,
-        auth_token: str,
-        load_repositories: Callable[[], list[RepoEntry]],
-        is_idle: Callable[[], bool],
-        get_http_client: Callable[[], httpx.AsyncClient | None],
+        client: ControlPlaneDiffClient,
+        manifest_path: Path,
         log: StructuredLogger,
         collector: BundleCollector = collect_session_diff_bundle,
         limits: CaptureLimits | None = None,
         refresh_timeout_seconds: float = DEFAULT_REFRESH_TIMEOUT_SECONDS,
-        idle_poll_seconds: float = DEFAULT_IDLE_POLL_SECONDS,
     ) -> None:
-        self.session_id = session_id
-        self.control_plane_url = control_plane_url.rstrip("/")
-        self.auth_token = auth_token
-        self.load_repositories = load_repositories
-        self.is_idle = is_idle
-        self.get_http_client = get_http_client
+        self.client = client
+        self.manifest_path = manifest_path
         self.log = log
         self.collector = collector
         self.limits = limits or CaptureLimits.defaults()
         self.refresh_timeout_seconds = refresh_timeout_seconds
-        self.idle_poll_seconds = idle_poll_seconds
 
         self._requested_generation = 0
         self._settled_generation = 0
         self._activity_generation = 0
         self._trigger_message_id: str | None = None
+        self._active_prompt_count = 0
+        self._idle = asyncio.Event()
+        self._idle.set()
         self._task: asyncio.Task[None] | None = None
         self._unsupported = False
         self._closed = False
 
     def prompt_started(self) -> None:
-        """Invalidate any collection that overlaps a newly mutating prompt."""
+        """Invalidate overlapping collections and hold refreshes until idle."""
         self._activity_generation += 1
+        self._active_prompt_count += 1
+        self._idle.clear()
+
+    def prompt_finished(self) -> None:
+        """Release the idle gate once every started prompt has terminated."""
+        self._active_prompt_count = max(0, self._active_prompt_count - 1)
+        if self._active_prompt_count == 0:
+            self._idle.set()
 
     def request(self, trigger_message_id: str | None) -> None:
         """Request a refresh without waiting for Git or the control plane."""
@@ -94,128 +189,116 @@ class SessionDiffRefreshWorker:
         """Stop accepting refreshes and bound shutdown waiting to ``timeout_seconds``."""
         self._closed = True
         await self.flush(timeout_seconds=timeout_seconds)
+        await self.client.aclose()
 
     async def _run(self) -> None:
         try:
             while not self._unsupported and self._settled_generation < self._requested_generation:
-                while not self.is_idle():
-                    await asyncio.sleep(self.idle_poll_seconds)
-
-                generation = self._requested_generation
-                activity_generation = self._activity_generation
-                trigger_message_id = self._trigger_message_id
-                repositories = self.load_repositories()
-                if not repositories:
-                    self._settled_generation = generation
-                    continue
-
-                try:
-                    bundle = await asyncio.wait_for(
-                        self.collector(
-                            repositories,
-                            trigger_message_id=trigger_message_id,
-                            captured_at=int(time.time() * 1_000),
-                            limits=self.limits,
-                        ),
-                        timeout=self.refresh_timeout_seconds,
-                    )
-                    ready_count = sum(
-                        1
-                        for repository in bundle["repositories"]
-                        if isinstance(repository, dict) and repository.get("status") == "ready"
-                    )
-                    if ready_count == 0:
-                        raise DiffCaptureError("All repositories failed to collect changes")
-                except asyncio.CancelledError:
-                    raise
-                except Exception as error:
-                    if self._is_stale(generation, activity_generation):
-                        continue
-                    await self._report_failure(error)
-                    self._settled_generation = generation
-                    continue
-
-                if self._is_stale(generation, activity_generation):
-                    self.log.info(
-                        "session_diff.refresh_discarded",
-                        generation=generation,
-                    )
-                    continue
-
-                try:
-                    supported = await self._upload(bundle)
-                except asyncio.CancelledError:
-                    raise
-                except Exception as error:
-                    await self._report_failure(error)
-                else:
-                    if supported:
-                        self.log.info(
-                            "session_diff.collection_completed",
-                            repository_count=len(bundle["repositories"]),
-                            encoded_bytes=len(encode_bundle(bundle)),
-                        )
-                self._settled_generation = generation
+                await self._idle.wait()
+                await self._settle(self._snapshot_attempt())
         finally:
             self._task = None
-            if (
-                not self._unsupported
-                and not self._closed
-                and self._settled_generation < self._requested_generation
-            ):
-                self._task = asyncio.create_task(self._run())
+            self._restart_if_requested_during_exit()
 
-    def _is_stale(self, generation: int, activity_generation: int) -> bool:
-        return (
-            not self.is_idle()
-            or generation != self._requested_generation
-            or activity_generation != self._activity_generation
+    def _snapshot_attempt(self) -> _RefreshAttempt:
+        return _RefreshAttempt(
+            generation=self._requested_generation,
+            activity_generation=self._activity_generation,
+            trigger_message_id=self._trigger_message_id,
         )
 
-    async def _upload(self, bundle: SessionDiffBundle) -> bool:
-        client = self.get_http_client()
-        if client is None:
-            raise DiffCaptureError("Bridge HTTP client is unavailable")
-        response = await client.request(
-            "PUT",
-            f"{self.control_plane_url}/sessions/{quote(self.session_id, safe='')}/diff",
-            headers={
-                "Authorization": f"Bearer {self.auth_token}",
-                "Content-Type": "application/json",
-            },
-            content=encode_bundle(bundle),
+    async def _settle(self, attempt: _RefreshAttempt) -> None:
+        """Collect and upload one bundle, settling ``attempt`` unless it went stale.
+
+        Returning without settling leaves the loop condition true, so the next
+        iteration retries against the checkout's current state.
+        """
+        repositories = load_repo_manifest(self.manifest_path)
+        if not repositories:
+            self._settled_generation = attempt.generation
+            return
+
+        try:
+            bundle = await self._collect_bundle(attempt, repositories)
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            if not self._is_stale(attempt):
+                await self._report_failure(error)
+                self._settled_generation = attempt.generation
+            return
+
+        if self._is_stale(attempt):
+            self.log.info("session_diff.refresh_discarded", generation=attempt.generation)
+            return
+
+        try:
+            outcome = await self.client.upload_bundle(bundle)
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            await self._report_failure(error)
+        else:
+            if outcome is DiffUploadOutcome.UNSUPPORTED:
+                self._mark_unsupported()
+            else:
+                self.log.info(
+                    "session_diff.collection_completed",
+                    repository_count=len(bundle["repositories"]),
+                    encoded_bytes=len(encode_bundle(bundle)),
+                )
+        self._settled_generation = attempt.generation
+
+    async def _collect_bundle(
+        self, attempt: _RefreshAttempt, repositories: list[RepoEntry]
+    ) -> SessionDiffBundle:
+        bundle = await asyncio.wait_for(
+            self.collector(
+                repositories,
+                trigger_message_id=attempt.trigger_message_id,
+                captured_at=int(time.time() * 1_000),
+                limits=self.limits,
+            ),
             timeout=self.refresh_timeout_seconds,
         )
-        if response.status_code == 404:
-            self._unsupported = True
-            self.log.info("session_diff.unsupported")
-            return False
-        response.raise_for_status()
-        return True
+        if all(repository["status"] != "ready" for repository in bundle["repositories"]):
+            raise DiffCaptureError("All repositories failed to collect changes")
+        return bundle
+
+    def _is_stale(self, attempt: _RefreshAttempt) -> bool:
+        return (
+            self._active_prompt_count > 0
+            or attempt.generation != self._requested_generation
+            or attempt.activity_generation != self._activity_generation
+        )
 
     async def _report_failure(self, error: Exception) -> None:
         message = str(error)[:2_000] or "Session diff refresh failed"
         self.log.warn("session_diff.refresh_failed", error=message)
-        client = self.get_http_client()
-        if client is None or self._unsupported:
+        if self._unsupported:
             return
         try:
-            response = await client.request(
-                "POST",
-                f"{self.control_plane_url}/sessions/{quote(self.session_id, safe='')}/diff/failure",
-                headers={
-                    "Authorization": f"Bearer {self.auth_token}",
-                    "Content-Type": "application/json",
-                },
-                json={"error": message},
-                timeout=self.refresh_timeout_seconds,
-            )
-            if response.status_code == 404:
-                self._unsupported = True
-                return
-            response.raise_for_status()
+            outcome = await self.client.report_failure(message)
         except Exception as report_error:
             self.log.warn(
                 "session_diff.failure_report_failed",
                 error=str(report_error)[:2_000],
             )
+        else:
+            if outcome is DiffUploadOutcome.UNSUPPORTED:
+                self._mark_unsupported()
+
+    def _mark_unsupported(self) -> None:
+        self._unsupported = True
+        self.log.info("session_diff.unsupported")
+
+    def _restart_if_requested_during_exit(self) -> None:
+        # request() may bump the generation after the loop condition was read
+        # but before this task is observably done; respawn so that refresh is
+        # not silently lost.
+        if (
+            not self._unsupported
+            and not self._closed
+            and self._settled_generation < self._requested_generation
+        ):
+            self._task = asyncio.create_task(self._run())

--- a/packages/sandbox-runtime/src/sandbox_runtime/diff_collector.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/diff_collector.py
@@ -13,13 +13,11 @@ import json
 import os
 import uuid
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, TypedDict
+from typing import TYPE_CHECKING, Literal, NotRequired, TypedDict
 
 from .git_excludes import is_runtime_git_excluded, read_runtime_git_excludes
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
-
     from .repo_config import RepoEntry
 
 DEFAULT_MAX_FILES = 1_000
@@ -34,13 +32,59 @@ class DiffCaptureError(RuntimeError):
     """A repository could not produce a trustworthy capture."""
 
 
+class DiffFileUpload(TypedDict):
+    """Wire representation of one changed file within a repository upload."""
+
+    id: str
+    path: str
+    status: str
+    additions: int | None
+    deletions: int | None
+    renderState: str
+    oldPath: NotRequired[str]
+    patch: NotRequired[str]
+    oldMode: NotRequired[str]
+    newMode: NotRequired[str]
+    oldSubmoduleSha: NotRequired[str]
+    newSubmoduleSha: NotRequired[str]
+
+
+class ReadyRepositoryUpload(TypedDict):
+    """A repository whose checkout changes were captured successfully."""
+
+    status: Literal["ready"]
+    position: int
+    repoOwner: str
+    repoName: str
+    baseSha: str
+    headSha: str
+    truncated: bool
+    omittedFileCount: int
+    files: list[DiffFileUpload]
+
+
+class UnavailableRepositoryUpload(TypedDict):
+    """A repository whose capture failed; the bundle still uploads atomically."""
+
+    status: Literal["unavailable"]
+    position: int
+    repoOwner: str
+    repoName: str
+    baseSha: str
+    error: str
+    files: list[DiffFileUpload]
+
+
+RepositoryUpload = ReadyRepositoryUpload | UnavailableRepositoryUpload
+
+
 class SessionDiffBundle(TypedDict):
     """Wire representation uploaded atomically for all session repositories."""
 
     version: int
     triggerMessageId: str | None
     capturedAt: int
-    repositories: list[dict[str, object]]
+    repositories: list[RepositoryUpload]
 
 
 class _GitOutputTooLarge(RuntimeError):
@@ -662,13 +706,13 @@ async def collect_repository_diff(
     )
 
 
-def encode_bundle(bundle: Mapping[str, object]) -> bytes:
+def encode_bundle(bundle: SessionDiffBundle) -> bytes:
     """Encode the exact JSON representation measured against the wire limit."""
     return json.dumps(bundle, ensure_ascii=True, separators=(",", ":")).encode("utf-8")
 
 
-def _file_upload(changed: CapturedFile) -> dict[str, object]:
-    file: dict[str, object] = {
+def _file_upload(changed: CapturedFile) -> DiffFileUpload:
+    file: DiffFileUpload = {
         "id": changed.id,
         "path": changed.path,
         "status": changed.status,
@@ -676,34 +720,33 @@ def _file_upload(changed: CapturedFile) -> dict[str, object]:
         "deletions": changed.deletions,
         "renderState": changed.render_state,
     }
-    optional = {
-        "oldPath": changed.old_path,
-        "patch": changed.patch if changed.render_state == "renderable" else None,
-        "oldMode": changed.old_mode,
-        "newMode": changed.new_mode,
-        "oldSubmoduleSha": changed.old_submodule_sha,
-        "newSubmoduleSha": changed.new_submodule_sha,
-    }
-    file.update({key: value for key, value in optional.items() if value is not None})
+    if changed.old_path is not None:
+        file["oldPath"] = changed.old_path
+    if changed.render_state == "renderable" and changed.patch is not None:
+        file["patch"] = changed.patch
+    if changed.old_mode is not None:
+        file["oldMode"] = changed.old_mode
+    if changed.new_mode is not None:
+        file["newMode"] = changed.new_mode
+    if changed.old_submodule_sha is not None:
+        file["oldSubmoduleSha"] = changed.old_submodule_sha
+    if changed.new_submodule_sha is not None:
+        file["newSubmoduleSha"] = changed.new_submodule_sha
     return file
 
 
 def _bound_encoded_bundle(bundle: SessionDiffBundle, max_bundle_bytes: int) -> None:
     """Shed patches, then trailing metadata records, until the bundle fits."""
-    repositories = bundle["repositories"]
-    if not isinstance(repositories, list):
-        raise DiffCaptureError("Malformed session diff bundle")
+    ready_repositories = [
+        repository for repository in bundle["repositories"] if repository["status"] == "ready"
+    ]
 
-    patches: list[tuple[int, dict[str, object]]] = []
-    for repository in repositories:
-        if not isinstance(repository, dict) or repository.get("status") != "ready":
-            continue
-        files = repository.get("files")
-        if not isinstance(files, list):
-            continue
-        for file in files:
-            if isinstance(file, dict) and isinstance(file.get("patch"), str):
-                patches.append((len(file["patch"].encode("utf-8")), file))
+    patches: list[tuple[int, DiffFileUpload]] = []
+    for repository in ready_repositories:
+        for file in repository["files"]:
+            patch = file.get("patch")
+            if patch is not None:
+                patches.append((len(patch.encode("utf-8")), file))
 
     for _size, file in sorted(patches, key=lambda item: item[0], reverse=True):
         if len(encode_bundle(bundle)) <= max_bundle_bytes:
@@ -714,19 +757,12 @@ def _bound_encoded_bundle(bundle: SessionDiffBundle, max_bundle_bytes: int) -> N
     if len(encode_bundle(bundle)) <= max_bundle_bytes:
         return
 
-    for repository in reversed(repositories):
-        if not isinstance(repository, dict) or repository.get("status") != "ready":
-            continue
-        files = repository.get("files")
-        if not isinstance(files, list):
-            continue
+    for repository in reversed(ready_repositories):
+        files = repository["files"]
         while files and len(encode_bundle(bundle)) > max_bundle_bytes:
             files.pop()
             repository["truncated"] = True
-            omitted_file_count = repository.get("omittedFileCount", 0)
-            repository["omittedFileCount"] = (
-                omitted_file_count if isinstance(omitted_file_count, int) else 0
-            ) + 1
+            repository["omittedFileCount"] += 1
 
     if len(encode_bundle(bundle)) > max_bundle_bytes:
         raise DiffCaptureError("Session diff metadata exceeded the bundle limit")
@@ -743,7 +779,7 @@ async def collect_session_diff_bundle(
     active_limits = limits or CaptureLimits.defaults()
     remaining_files = active_limits.max_files
     remaining_patch_bytes = active_limits.max_capture_bytes
-    outcomes: list[dict[str, object]] = []
+    outcomes: list[RepositoryUpload] = []
 
     for position, repository in enumerate(repositories):
         if not repository.base_sha:

--- a/packages/sandbox-runtime/tests/test_bridge_diff_capture.py
+++ b/packages/sandbox-runtime/tests/test_bridge_diff_capture.py
@@ -6,7 +6,12 @@ import httpx
 import pytest
 
 from sandbox_runtime.bridge import AgentBridge
-from sandbox_runtime.diff_capture import SessionDiffRefreshWorker
+from sandbox_runtime.diff_capture import (
+    BundleCollector,
+    ControlPlaneDiffClient,
+    SessionDiffRefreshWorker,
+)
+from sandbox_runtime.log_config import get_logger
 from sandbox_runtime.repo_config import RepoEntry, dump_repo_manifest
 
 
@@ -16,6 +21,34 @@ def _bridge() -> AgentBridge:
         session_id="session-1",
         control_plane_url="https://control.example.com",
         auth_token="sandbox-token",
+    )
+
+
+def _manifest(tmp_path: Path) -> Path:
+    manifest = tmp_path / "repositories.json"
+    manifest.write_text(
+        dump_repo_manifest(
+            [RepoEntry("open-inspect", "viewer", "main", tmp_path / "viewer", base_sha="a" * 40)]
+        )
+    )
+    return manifest
+
+
+def _worker(
+    tmp_path: Path,
+    collector: BundleCollector,
+    http_client: httpx.AsyncClient | None,
+) -> SessionDiffRefreshWorker:
+    return SessionDiffRefreshWorker(
+        client=ControlPlaneDiffClient(
+            control_plane_url="https://control.example.com",
+            session_id="session-1",
+            auth_token="sandbox-token",
+            http_client=http_client,
+        ),
+        manifest_path=_manifest(tmp_path),
+        log=get_logger("test"),
+        collector=collector,
     )
 
 
@@ -41,22 +74,8 @@ def _bundle(trigger_message_id: str | None) -> dict[str, object]:
 
 
 def test_ready_event_reports_fixed_baselines_without_a_capability_gate(tmp_path: Path) -> None:
-    manifest = tmp_path / "repositories.json"
-    manifest.write_text(
-        dump_repo_manifest(
-            [
-                RepoEntry(
-                    owner="open-inspect",
-                    name="viewer",
-                    branch="main",
-                    path=tmp_path / "viewer",
-                    base_sha="a" * 40,
-                )
-            ]
-        )
-    )
     bridge = _bridge()
-    bridge.repo_manifest_path = manifest
+    bridge.repo_manifest_path = _manifest(tmp_path)
 
     assert bridge._build_ready_event() == {
         "type": "ready",
@@ -77,7 +96,6 @@ def test_ready_event_reports_fixed_baselines_without_a_capability_gate(tmp_path:
 async def test_refresh_request_returns_before_collection_and_uploads_one_bundle(
     tmp_path: Path,
 ) -> None:
-    repository = RepoEntry("open-inspect", "viewer", "main", tmp_path / "viewer", base_sha="a" * 40)
     started = asyncio.Event()
     release = asyncio.Event()
     requests: list[httpx.Request] = []
@@ -92,17 +110,7 @@ async def test_refresh_request_returns_before_collection_and_uploads_one_bundle(
         return httpx.Response(200)
 
     client = httpx.AsyncClient(transport=httpx.MockTransport(respond))
-    bridge = _bridge()
-    worker = SessionDiffRefreshWorker(
-        session_id="session-1",
-        control_plane_url="https://control.example.com",
-        auth_token="sandbox-token",
-        load_repositories=lambda: [repository],
-        is_idle=lambda: True,
-        get_http_client=lambda: client,
-        log=bridge.log,
-        collector=collect,
-    )
+    worker = _worker(tmp_path, collect, client)
 
     worker.request("message-1")
     await asyncio.wait_for(started.wait(), timeout=1)
@@ -121,8 +129,6 @@ async def test_refresh_request_returns_before_collection_and_uploads_one_bundle(
 async def test_prompt_activity_discards_stale_collection_and_coalesces_to_latest_request(
     tmp_path: Path,
 ) -> None:
-    repository = RepoEntry("open-inspect", "viewer", "main", tmp_path / "viewer", base_sha="a" * 40)
-    idle = {"value": True}
     first_started = asyncio.Event()
     release_first = asyncio.Event()
     calls = 0
@@ -141,28 +147,16 @@ async def test_prompt_activity_discards_stale_collection_and_coalesces_to_latest
             lambda request: uploads.append(request) or httpx.Response(200)
         )
     )
-    bridge = _bridge()
-    worker = SessionDiffRefreshWorker(
-        session_id="session-1",
-        control_plane_url="https://control.example.com",
-        auth_token="sandbox-token",
-        load_repositories=lambda: [repository],
-        is_idle=lambda: idle["value"],
-        get_http_client=lambda: client,
-        log=bridge.log,
-        collector=collect,
-        idle_poll_seconds=0,
-    )
+    worker = _worker(tmp_path, collect, client)
 
     worker.request("message-1")
     await asyncio.wait_for(first_started.wait(), timeout=1)
-    idle["value"] = False
     worker.prompt_started()
     worker.request("message-2")
     release_first.set()
     await asyncio.sleep(0)
     assert uploads == []
-    idle["value"] = True
+    worker.prompt_finished()
     await worker.flush(timeout_seconds=1)
     await client.aclose()
 
@@ -175,7 +169,6 @@ async def test_prompt_activity_discards_stale_collection_and_coalesces_to_latest
 async def test_refresh_failure_is_reported_without_terminating_future_requests(
     tmp_path: Path,
 ) -> None:
-    repository = RepoEntry("open-inspect", "viewer", "main", tmp_path / "viewer", base_sha="a" * 40)
     calls = 0
     requests: list[httpx.Request] = []
 
@@ -191,17 +184,7 @@ async def test_refresh_failure_is_reported_without_terminating_future_requests(
             lambda request: requests.append(request) or httpx.Response(204)
         )
     )
-    bridge = _bridge()
-    worker = SessionDiffRefreshWorker(
-        session_id="session-1",
-        control_plane_url="https://control.example.com",
-        auth_token="sandbox-token",
-        load_repositories=lambda: [repository],
-        is_idle=lambda: True,
-        get_http_client=lambda: client,
-        log=bridge.log,
-        collector=collect,
-    )
+    worker = _worker(tmp_path, collect, client)
 
     worker.request("message-1")
     await worker.flush(timeout_seconds=1)
@@ -219,7 +202,6 @@ async def test_refresh_failure_is_reported_without_terminating_future_requests(
 async def test_unsupported_control_plane_disables_refresh_without_failing_the_bridge(
     tmp_path: Path,
 ) -> None:
-    repository = RepoEntry("open-inspect", "viewer", "main", tmp_path / "viewer", base_sha="a" * 40)
     requests: list[httpx.Request] = []
 
     async def collect(_repositories, *, trigger_message_id, captured_at, limits):
@@ -230,17 +212,7 @@ async def test_unsupported_control_plane_disables_refresh_without_failing_the_br
             lambda request: requests.append(request) or httpx.Response(404)
         )
     )
-    bridge = _bridge()
-    worker = SessionDiffRefreshWorker(
-        session_id="session-1",
-        control_plane_url="https://control.example.com",
-        auth_token="sandbox-token",
-        load_repositories=lambda: [repository],
-        is_idle=lambda: True,
-        get_http_client=lambda: client,
-        log=bridge.log,
-        collector=collect,
-    )
+    worker = _worker(tmp_path, collect, client)
 
     worker.request("message-1")
     await worker.flush(timeout_seconds=1)
@@ -266,15 +238,15 @@ async def test_refresh_command_is_accepted_without_waiting_for_collection() -> N
 @pytest.mark.asyncio
 async def test_terminal_prompt_completion_schedules_refresh_without_blocking_command_loop() -> None:
     bridge = _bridge()
-    requested = []
-    prompt_started = []
+    lifecycle = []
 
     async def complete_prompt(_command):
         return None
 
     bridge._handle_prompt = complete_prompt
-    bridge.diff_refresh.request = requested.append
-    bridge.diff_refresh.prompt_started = lambda: prompt_started.append(True)
+    bridge.diff_refresh.request = lambda mid: lifecycle.append(("request", mid))
+    bridge.diff_refresh.prompt_started = lambda: lifecycle.append("prompt_started")
+    bridge.diff_refresh.prompt_finished = lambda: lifecycle.append("prompt_finished")
 
     result = await bridge._handle_command({"type": "prompt", "messageId": "message-1"})
     task = bridge._current_prompt_task
@@ -283,13 +255,11 @@ async def test_terminal_prompt_completion_schedules_refresh_without_blocking_com
     await task
     await asyncio.sleep(0)
 
-    assert prompt_started == [True]
-    assert requested == ["message-1"]
+    assert lifecycle == ["prompt_started", "prompt_finished", ("request", "message-1")]
 
 
 @pytest.mark.asyncio
 async def test_timed_out_close_cancels_without_rescheduling_refresh(tmp_path: Path) -> None:
-    repository = RepoEntry("open-inspect", "viewer", "main", tmp_path / "viewer", base_sha="a" * 40)
     started = asyncio.Event()
     cancelled = asyncio.Event()
 
@@ -300,17 +270,7 @@ async def test_timed_out_close_cancels_without_rescheduling_refresh(tmp_path: Pa
         finally:
             cancelled.set()
 
-    bridge = _bridge()
-    worker = SessionDiffRefreshWorker(
-        session_id="session-1",
-        control_plane_url="https://control.example.com",
-        auth_token="sandbox-token",
-        load_repositories=lambda: [repository],
-        is_idle=lambda: True,
-        get_http_client=lambda: None,
-        log=bridge.log,
-        collector=collect,
-    )
+    worker = _worker(tmp_path, collect, None)
 
     worker.request("message-1")
     await asyncio.wait_for(started.wait(), timeout=1)


### PR DESCRIPTION
Follow-up to #1045/#1047, applying the same maintainability standards to the sandbox side of the session diff feature.

## What changed

### 1. `SessionDiffRefreshWorker` no longer takes lambdas peeking into bridge state

The worker previously received three closures (`load_repositories`, `is_idle`, `get_http_client`) that each reached back into the bridge's mutable state. Each had a different root cause and gets a different fix:

- **`get_http_client` → new `ControlPlaneDiffClient`.** The worker's `_upload`/`_report_failure` methods, plus `session_id`/`control_plane_url`/`auth_token` and the 404→unsupported detection, were a complete HTTP client for the control plane's two diff endpoints smeared across the worker. They're now a cohesive class with `upload_bundle`/`report_failure` returning a `DiffUploadOutcome` (`ACCEPTED`/`UNSUPPORTED`). It owns its connection pool (created lazily on first request, closed by `worker.close()`), with an injection seam for tests, so the `"Bridge HTTP client is unavailable"` failure mode is gone.
- **`is_idle` → explicit `prompt_started()`/`prompt_finished()` signals.** The bridge's prompt-task done-callback is the single place every prompt terminates (success, exception, or cancel), so it now releases the worker's internal idle gate (`asyncio.Event` + active-prompt counter). This deletes the 50 ms busy-poll loop and the `idle_poll_seconds` knob, and is slightly more correct than the old check, which only observed the latest prompt task.
- **`load_repositories` → pass `manifest_path: Path`.** The lambda just applied the canonical `load_repo_manifest` loader to a constant path; the worker now does that directly.

### 2. Typed wire shapes instead of `dict[str, object]`

`SessionDiffBundle.repositories` was `list[dict[str, object]]`, forcing `isinstance` defensive checks against data we built ourselves (`_bound_encoded_bundle`, the worker's ready-count). New `TypedDict`s mirror the control plane's `sessionDiffUploadSchema`: `DiffFileUpload` (with `NotRequired` optional keys), `ReadyRepositoryUpload` / `UnavailableRepositoryUpload` discriminated on `status: Literal[...]`. Every `isinstance` guard is deleted; mypy (strict, already in CI) checks the shapes; runtime JSON is byte-identical. `BundleCollector` is now a `Protocol` with the real call signature instead of `Callable[..., ...]`, which erased all keyword-arg checking.

### 3. `_run` decomposed

The 60-line loop nested generation bookkeeping, an idle poll loop, a try/except that raised an exception into its own handler (the ready-count check), staleness checks in two branches, and an uncommented `finally`-block self-resurrection. Now:

- `_RefreshAttempt` frozen dataclass snapshots one coalesced request; `_is_stale(attempt)` replaces three loose locals.
- `_run` is the loop + respawn; `_settle(attempt)` is one screen handling collect → staleness gate → upload/report; `_collect_bundle` folds the all-repositories-failed validation into collection instead of raise-and-catch-yourself.
- The `finally` respawn survives with a comment naming the race it closes (`request()` bumping the generation as the loop exits).

## Behavior notes

Two deliberate deltas, both strict improvements: idleness is event-driven instead of polled every 50 ms, and diff uploads use a dedicated connection pool instead of sharing the bridge's OpenCode client. Wire format, endpoints, and coalescing/staleness semantics are unchanged.

## Testing

- `pytest tests/` — 520 passed (worker tests now exercise `prompt_started`/`prompt_finished` and inject `MockTransport` via `ControlPlaneDiffClient`; added an ordering assertion for the done-callback lifecycle)
- `ruff check` + `ruff format --check` clean
- `mypy src/` — no errors in touched files (13 pre-existing errors in `entrypoint.py`/`auth/github_app.py` untouched)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Session changes are refreshed more reliably after prompts finish.
  * Diff updates now avoid unnecessary activity while a prompt is running.
  * Oversized session diff bundles are handled more consistently by trimming file details.
  * Sessions without ready repositories are rejected instead of sending incomplete updates.
  * Unsupported diff endpoints are detected and no longer retried repeatedly.
* **Bug Fixes**
  * Improved failure reporting for diff collection and upload issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->