### PR TITLE
refactor: use repoIdentityEquals in session diff service

### DIFF
--- a/packages/control-plane/src/session/diffs/service.ts
+++ b/packages/control-plane/src/session/diffs/service.ts
@@ -2,6 +2,7 @@ import {
   sessionDiffFailureSchema,
   sessionDiffUploadSchema,
   type SandboxEvent,
+  type SessionDiffBaselineRepository,
   type SessionDiffState,
   type SessionDiffUpload,
 } from "@open-inspect/shared";
@@ -9,6 +10,7 @@ import { generateId } from "../../auth/crypto";
 import type { Logger } from "../../logger";
 import type { SessionMessenger } from "../messenger";
 import type { SessionRepository } from "../repository";
+import { repoIdentityEquals, type SessionRepositoryEntry } from "../repository-target";
 import {
   DiffBaselineMismatchError,
   DiffBaselineUnavailableError,
@@ -21,6 +23,11 @@ import {
 import type { SessionDiffStore } from "./store";
 
 const DIFF_ID_PATTERN = /^[A-Za-z0-9._-]{1,200}$/;
+
+/** SHAs are hex, so a plain case-insensitive comparison suffices. */
+function shaEquals(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
 
 /**
  * Owns validation and the single latest-bundle publication boundary.
@@ -53,19 +60,7 @@ export class SessionDiffService {
   pinBaselines(event: Extract<SandboxEvent, { type: "ready" }>): void {
     const sessionRepositories = this.repository.getSessionRepositories();
     const advertised = event.repositories ?? [];
-    const repositoriesMatch =
-      advertised.length === sessionRepositories.length &&
-      sessionRepositories.every((sessionRepository, index) => {
-        const baseline = advertised[index];
-        return (
-          baseline?.position === sessionRepository.position &&
-          baseline.repoOwner.toLocaleLowerCase("en-US") ===
-            sessionRepository.repoOwner.toLocaleLowerCase("en-US") &&
-          baseline.repoName.toLocaleLowerCase("en-US") ===
-            sessionRepository.repoName.toLocaleLowerCase("en-US")
-        );
-      });
-    if (!repositoriesMatch) {
+    if (!this.advertisedMatchesSession(advertised, sessionRepositories)) {
       this.log.warn("session_diff.baseline_repository_mismatch", {
         advertised_repositories: advertised.length,
         session_repositories: sessionRepositories.length,
@@ -73,10 +68,36 @@ export class SessionDiffService {
       return;
     }
 
+    this.logBaselineConflicts(advertised, sessionRepositories);
+    this.repository.setSessionDiffBaselines(
+      this.toBaselineUpdates(advertised, sessionRepositories)
+    );
+  }
+
+  private advertisedMatchesSession(
+    advertised: SessionDiffBaselineRepository[],
+    sessionRepositories: SessionRepositoryEntry[]
+  ): boolean {
+    return (
+      advertised.length === sessionRepositories.length &&
+      sessionRepositories.every((sessionRepository, index) => {
+        const baseline = advertised[index];
+        return (
+          baseline?.position === sessionRepository.position &&
+          repoIdentityEquals(baseline, sessionRepository)
+        );
+      })
+    );
+  }
+
+  private logBaselineConflicts(
+    advertised: SessionDiffBaselineRepository[],
+    sessionRepositories: SessionRepositoryEntry[]
+  ): void {
     for (const [index, sessionRepository] of sessionRepositories.entries()) {
       const existing = sessionRepository.row?.base_sha;
       const next = advertised[index]!.baseSha;
-      if (existing && existing.toLocaleLowerCase("en-US") !== next.toLocaleLowerCase("en-US")) {
+      if (existing && !shaEquals(existing, next)) {
         this.log.warn("session_diff.baseline_conflict", {
           repository_position: sessionRepository.position,
           repo_owner: sessionRepository.repoOwner,
@@ -84,16 +105,19 @@ export class SessionDiffService {
         });
       }
     }
+  }
 
-    this.repository.setSessionDiffBaselines(
-      sessionRepositories.map((sessionRepository, index) => ({
-        position: sessionRepository.position,
-        repoOwner: sessionRepository.repoOwner,
-        repoName: sessionRepository.repoName,
-        baseSha: advertised[index]!.baseSha,
-        isPrimary: sessionRepository.isPrimary,
-      }))
-    );
+  private toBaselineUpdates(
+    advertised: SessionDiffBaselineRepository[],
+    sessionRepositories: SessionRepositoryEntry[]
+  ) {
+    return sessionRepositories.map((sessionRepository, index) => ({
+      position: sessionRepository.position,
+      repoOwner: sessionRepository.repoOwner,
+      repoName: sessionRepository.repoName,
+      baseSha: advertised[index]!.baseSha,
+      isPrimary: sessionRepository.isPrimary,
+    }));
   }
 
   /**
@@ -149,20 +173,14 @@ export class SessionDiffService {
       const repository = bundle.repositories.find(
         (candidate) => candidate.position === sessionRepository.position
       );
-      if (
-        !repository ||
-        repository.repoOwner.toLocaleLowerCase("en-US") !==
-          sessionRepository.repoOwner.toLocaleLowerCase("en-US") ||
-        repository.repoName.toLocaleLowerCase("en-US") !==
-          sessionRepository.repoName.toLocaleLowerCase("en-US")
-      ) {
+      if (!repository || !repoIdentityEquals(repository, sessionRepository)) {
         throw new DiffRepositoryMismatchError();
       }
       const baseSha = sessionRepository.row?.base_sha;
       if (!baseSha) {
         throw new DiffBaselineUnavailableError();
       }
-      if (repository.baseSha.toLocaleLowerCase("en-US") !== baseSha.toLocaleLowerCase("en-US")) {
+      if (!shaEquals(repository.baseSha, baseSha)) {
         throw new DiffBaselineMismatchError();
       }
     }


### PR DESCRIPTION
## Problem

`SessionDiffService` hand-rolled repository-identity comparison with ten `.toLocaleLowerCase("en-US")` calls across two sites (the match predicate in `pinBaselines` and `assertRepositorySetMatches`), while the rest of the codebase answers the same question through the canonical helper `repoIdentityEquals` in `session/repository-target.ts`, which uses `.toLowerCase()`. Two normalization strategies for one question is the bug: they can drift independently, and every new call site has to pick one.

## Changes

- **Repo identity**: both sites now use `repoIdentityEquals`. The advertised baseline (`SessionDiffBaselineRepository`) and bundle repository objects carry plain-string `repoOwner`/`repoName`, so they satisfy its `RepoIdentity` parameter structurally — no casts, no `Pick<>`.
- **Base SHAs**: the two SHA comparisons (baseline-conflict detection in `pinBaselines`, baseline match in `assertRepositorySetMatches`) go through a small module-local `shaEquals` using plain `.toLowerCase()` — SHAs are hex, so locale is irrelevant.
- **`pinBaselines` decomposition**: it interleaved three jobs (guard, conflict logging, persistence mapping). Extracted three private methods so the public method reads as guard → log → persist:
  - `advertisedMatchesSession(advertised, sessionRepositories): boolean`
  - `logBaselineConflicts(advertised, sessionRepositories)`
  - `toBaselineUpdates(advertised, sessionRepositories)` — produces the `setSessionDiffBaselines` payload

## On `.toLowerCase()` vs `.toLocaleLowerCase("en-US")`

Standardizing on the helper's `.toLowerCase()` is deliberate: it is the spec-stable, locale-independent form, and having the diff service normalize differently from `repoIdentityEquals` was precisely the smell being removed. For ASCII owner/name/SHA values — the actual domain — the two are behavior-identical.

## Behavior

No behavior change. Warn log events `session_diff.baseline_repository_mismatch` and `session_diff.baseline_conflict` keep their names and fields; error types and ordering in `assertRepositorySetMatches` are unchanged. `DIFF_ID_PATTERN` and other constants untouched.

## Verification

- `npm run build -w @open-inspect/shared` — clean
- `npm run typecheck` — clean, all packages
- `npm test -w @open-inspect/control-plane` — 1974 passed (120 files)
- `npm run test:integration -w @open-inspect/control-plane` — 569 passed (49 files)
- Zero test expectations modified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository and baseline matching by treating repository names and commit identifiers consistently, regardless of letter casing.
  * Strengthened validation when preparing and publishing session bundles.
  * Preserved clear error handling for repository mismatches, unavailable baselines, and conflicting commit identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->