### PR TITLE
refactor: decompose SessionChangesPanel

### DIFF
--- a/packages/web/src/components/diff-retry-notice.test.tsx
+++ b/packages/web/src/components/diff-retry-notice.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DiffRetryNotice } from "./diff-retry-notice";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("DiffRetryNotice", () => {
+  it("retries through the explicit retry endpoint from the banner variant", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({}, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+    render(<DiffRetryNotice sessionId="session-1" message="timed out" variant="banner" />);
+
+    expect(screen.getByText("timed out")).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(fetchMock).toHaveBeenCalledWith("/api/sessions/session-1/diff/retry", {
+      method: "POST",
+    });
+  });
+
+  it("announces an authoritative retry failure", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(Response.json({ error: "Sandbox is not connected" }, { status: 409 }));
+    vi.stubGlobal("fetch", fetchMock);
+    render(<DiffRetryNotice sessionId="session-1" message="timed out" variant="banner" />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Sandbox is not connected");
+  });
+
+  it("renders the inline variant with the same retry action", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(Response.json({ error: "Still failing" }, { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+    render(<DiffRetryNotice sessionId="session-2" message="capture failed" variant="inline" />);
+
+    expect(screen.getByText("capture failed")).toBeVisible();
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(fetchMock).toHaveBeenCalledWith("/api/sessions/session-2/diff/retry", {
+      method: "POST",
+    });
+    expect(await screen.findByRole("alert")).toHaveTextContent("Still failing");
+  });
+});

--- a/packages/web/src/components/diff-retry-notice.tsx
+++ b/packages/web/src/components/diff-retry-notice.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useSessionDiffRetry } from "@/hooks/use-session-diffs";
+
+/**
+ * Diff refresh failure notice with a retry action. The "banner" variant renders
+ * a full-width strip for the changes panel; the "inline" variant fits inside a
+ * sidebar section.
+ */
+export function DiffRetryNotice({
+  sessionId,
+  message,
+  variant,
+}: {
+  sessionId: string;
+  message: string;
+  variant: "banner" | "inline";
+}) {
+  const { retry, isRetrying, retryError } = useSessionDiffRetry(sessionId);
+  const retryLabel = isRetrying ? "Retrying…" : "Retry";
+
+  if (variant === "banner") {
+    return (
+      <>
+        <div className="flex items-center gap-2 border-b border-destructive-border bg-destructive-muted px-3 py-2 text-xs text-destructive">
+          <span className="min-w-0 flex-1 truncate">{message}</span>
+          <button
+            type="button"
+            onClick={() => void retry()}
+            disabled={isRetrying}
+            className="font-medium underline underline-offset-2"
+          >
+            {retryLabel}
+          </button>
+        </div>
+        {retryError && (
+          <p
+            role="alert"
+            className="border-b border-destructive-border px-3 py-2 text-xs text-destructive"
+          >
+            {retryError}
+          </p>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div className="space-y-1.5">
+        <p className="text-xs text-destructive">{message}</p>
+        <button
+          type="button"
+          onClick={() => void retry()}
+          disabled={isRetrying}
+          className="text-xs font-medium text-accent underline underline-offset-2 disabled:opacity-50"
+        >
+          {retryLabel}
+        </button>
+      </div>
+      {retryError && (
+        <p role="alert" className="mt-1.5 text-xs text-destructive">
+          {retryError}
+        </p>
+      )}
+    </>
+  );
+}

--- a/packages/web/src/components/diff-retry-notice.tsx
+++ b/packages/web/src/components/diff-retry-notice.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useSessionDiffRetry } from "@/hooks/use-session-diffs";
+import { cn } from "@/lib/utils";
 
 /**
- * Diff refresh failure notice with a retry action. The "banner" variant renders
- * a full-width strip for the changes panel; the "inline" variant fits inside a
- * sidebar section.
+ * Diff refresh failure notice with a retry action. One render tree for both
+ * contexts: "banner" lays out as a full-width strip for the changes panel,
+ * "inline" as a stacked block inside a sidebar section — the variant only
+ * selects layout classes.
  */
 export function DiffRetryNotice({
   sessionId,
@@ -17,49 +19,40 @@ export function DiffRetryNotice({
   variant: "banner" | "inline";
 }) {
   const { retry, isRetrying, retryError } = useSessionDiffRetry(sessionId);
-  const retryLabel = isRetrying ? "Retrying…" : "Retry";
-
-  if (variant === "banner") {
-    return (
-      <>
-        <div className="flex items-center gap-2 border-b border-destructive-border bg-destructive-muted px-3 py-2 text-xs text-destructive">
-          <span className="min-w-0 flex-1 truncate">{message}</span>
-          <button
-            type="button"
-            onClick={() => void retry()}
-            disabled={isRetrying}
-            className="font-medium underline underline-offset-2"
-          >
-            {retryLabel}
-          </button>
-        </div>
-        {retryError && (
-          <p
-            role="alert"
-            className="border-b border-destructive-border px-3 py-2 text-xs text-destructive"
-          >
-            {retryError}
-          </p>
-        )}
-      </>
-    );
-  }
+  const banner = variant === "banner";
 
   return (
     <>
-      <div className="space-y-1.5">
-        <p className="text-xs text-destructive">{message}</p>
+      <div
+        className={
+          banner
+            ? "flex items-center gap-2 border-b border-destructive-border bg-destructive-muted px-3 py-2"
+            : "space-y-1.5"
+        }
+      >
+        <p className={cn("text-xs text-destructive", banner && "min-w-0 flex-1 truncate")}>
+          {message}
+        </p>
         <button
           type="button"
           onClick={() => void retry()}
           disabled={isRetrying}
-          className="text-xs font-medium text-accent underline underline-offset-2 disabled:opacity-50"
+          className={cn(
+            "text-xs font-medium underline underline-offset-2 disabled:opacity-50",
+            !banner && "text-accent"
+          )}
         >
-          {retryLabel}
+          {isRetrying ? "Retrying…" : "Retry"}
         </button>
       </div>
       {retryError && (
-        <p role="alert" className="mt-1.5 text-xs text-destructive">
+        <p
+          role="alert"
+          className={cn(
+            "text-xs text-destructive",
+            banner ? "border-b border-destructive-border px-3 py-2" : "mt-1.5"
+          )}
+        >
           {retryError}
         </p>
       )}

--- a/packages/web/src/components/session-changes-panel.tsx
+++ b/packages/web/src/components/session-changes-panel.tsx
@@ -5,6 +5,7 @@ import { useTheme } from "next-themes";
 import { mutate } from "swr";
 import useSWR from "swr";
 import { useEffect, useRef } from "react";
+import { formatRepositoryFullName } from "@open-inspect/shared";
 import type { SessionDiffFile, SessionDiffState } from "@open-inspect/shared";
 import { useSessionDiffPreferences, type DiffStyle } from "@/hooks/use-session-diff-preferences";
 import { sessionDiffKey } from "@/hooks/use-session-diffs";
@@ -93,9 +94,7 @@ function ChangesPanelHeader({
     <div className="flex min-h-14 items-center gap-2 border-b border-border-muted px-3">
       <div className="min-w-0 flex-1">
         <p className="truncate text-xs font-medium text-muted-foreground">
-          {selected
-            ? `${selected.repository.repoOwner}/${selected.repository.repoName}`
-            : "Changes"}
+          {selected ? formatRepositoryFullName(selected.repository) : "Changes"}
         </p>
         <h2 className="truncate text-sm font-medium" title={selected?.file.path}>
           {selected?.file.path ?? "File no longer changed"}

--- a/packages/web/src/components/session-changes-panel.tsx
+++ b/packages/web/src/components/session-changes-panel.tsx
@@ -4,18 +4,26 @@ import dynamic from "next/dynamic";
 import { useTheme } from "next-themes";
 import { mutate } from "swr";
 import useSWR from "swr";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import type { SessionDiffFile, SessionDiffState } from "@open-inspect/shared";
-import { useSessionDiffPreferences } from "@/hooks/use-session-diff-preferences";
-import { sessionDiffKey, useSessionDiffRetry } from "@/hooks/use-session-diffs";
+import { useSessionDiffPreferences, type DiffStyle } from "@/hooks/use-session-diff-preferences";
+import { sessionDiffKey } from "@/hooks/use-session-diffs";
+import { useDiffFileNavigation } from "@/hooks/use-diff-file-navigation";
+import { usePanelWidth } from "@/hooks/use-panel-width";
+import { parseDiffErrorBody } from "@/lib/session-diffs";
 import type { DiffSelection, ResolvedDiffSelection } from "@/lib/session-diffs";
 import { cn } from "@/lib/utils";
+import { DiffRetryNotice } from "@/components/diff-retry-notice";
 import { FilesChangedSection } from "@/components/sidebar/files-changed-section";
 
 const PierreDiffRenderer = dynamic(() => import("./pierre-diff-renderer"), {
   ssr: false,
   loading: () => <PanelMessage>Loading diff renderer…</PanelMessage>,
 });
+
+const SPLIT_DIFF_MIN_PANEL_WIDTH = 720;
+
+type ReadyDiffSelection = Extract<ResolvedDiffSelection, { status: "ready" }>;
 
 class DiffPatchError extends Error {
   constructor(
@@ -31,7 +39,7 @@ async function fetchPatch(url: string): Promise<string> {
   if (!response.ok) {
     let code: string | undefined;
     try {
-      code = (await response.json()).code;
+      code = parseDiffErrorBody(await response.json()).code;
     } catch {
       // Non-JSON errors still retain their HTTP status.
     }
@@ -57,13 +65,135 @@ function fileMessage(file: SessionDiffFile): string {
       return "This binary file changed, but it does not have a text diff.";
     case "too_large":
       return "This patch is too large to display safely.";
-    case "metadata_only":
-      return file.oldMode || file.newMode
-        ? `File metadata changed${file.oldMode || file.newMode ? ` (${file.oldMode ?? "—"} → ${file.newMode ?? "—"})` : ""}.`
+    case "metadata_only": {
+      const hasModeChange = Boolean(file.oldMode || file.newMode);
+      return hasModeChange
+        ? `File metadata changed (${file.oldMode ?? "—"} → ${file.newMode ?? "—"}).`
         : "This file changed without renderable text content.";
+    }
     default:
       return "This file does not have a renderable patch.";
   }
+}
+
+function ChangesPanelHeader({
+  selected,
+  selectedIndex,
+  fileCount,
+  onMoveSelection,
+  onClose,
+}: {
+  selected: ReadyDiffSelection | null;
+  selectedIndex: number;
+  fileCount: number;
+  onMoveSelection: (offset: number) => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="flex min-h-14 items-center gap-2 border-b border-border-muted px-3">
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-xs font-medium text-muted-foreground">
+          {selected
+            ? `${selected.repository.repoOwner}/${selected.repository.repoName}`
+            : "Changes"}
+        </p>
+        <h2 className="truncate text-sm font-medium" title={selected?.file.path}>
+          {selected?.file.path ?? "File no longer changed"}
+        </h2>
+        {selected && (
+          <p className="truncate text-[11px] text-muted-foreground">
+            {selected.file.status.replace("_", " ")}
+            {selected.file.additions !== null && selected.file.deletions !== null
+              ? ` · +${selected.file.additions} -${selected.file.deletions}`
+              : ""}
+          </p>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={() => onMoveSelection(-1)}
+        disabled={selectedIndex <= 0}
+        aria-label="Previous changed file"
+        className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-30"
+      >
+        ↑
+      </button>
+      <button
+        type="button"
+        onClick={() => onMoveSelection(1)}
+        disabled={selectedIndex < 0 || selectedIndex >= fileCount - 1}
+        aria-label="Next changed file"
+        className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-30"
+      >
+        ↓
+      </button>
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close changes"
+        className="rounded p-1.5 text-lg text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        ×
+      </button>
+    </div>
+  );
+}
+
+function ChangesPanelToolbar({
+  selected,
+  availableDiffStyles,
+  activeDiffStyle,
+  onDiffStyleChange,
+  wrap,
+  onWrapChange,
+}: {
+  selected: ReadyDiffSelection | null;
+  availableDiffStyles: readonly DiffStyle[];
+  activeDiffStyle: DiffStyle;
+  onDiffStyleChange: (style: DiffStyle) => void;
+  wrap: boolean;
+  onWrapChange: (wrap: boolean) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 border-b border-border-muted px-3 py-2">
+      {selected && (
+        <details className="text-xs text-muted-foreground">
+          <summary className="cursor-pointer">Compared with session start</summary>
+          <p className="mt-1 font-mono text-[10px]">
+            {selected.repository.baseSha.slice(0, 12)} → {selected.repository.headSha.slice(0, 12)}
+          </p>
+        </details>
+      )}
+      <div
+        role="group"
+        className="inline-flex rounded-md border border-border-muted p-0.5"
+        aria-label="Diff layout"
+      >
+        {availableDiffStyles.map((style) => (
+          <button
+            key={style}
+            type="button"
+            aria-pressed={activeDiffStyle === style}
+            onClick={() => onDiffStyleChange(style)}
+            className={cn(
+              "rounded px-2 py-1 text-xs capitalize",
+              activeDiffStyle === style ? "bg-muted text-foreground" : "text-muted-foreground"
+            )}
+          >
+            {style === "unified" ? "Unified" : "Split"}
+          </button>
+        ))}
+      </div>
+      <label className="ml-auto flex items-center gap-1.5 text-xs text-muted-foreground">
+        <input
+          type="checkbox"
+          checked={wrap}
+          onChange={(event) => onWrapChange(event.target.checked)}
+        />
+        Wrap lines
+      </label>
+    </div>
+  );
 }
 
 export function SessionChangesPanel({
@@ -82,11 +212,18 @@ export function SessionChangesPanel({
   mobile?: boolean;
 }) {
   const panelRef = useRef<HTMLElement>(null);
-  const [panelWidth, setPanelWidth] = useState(0);
+  const panelWidth = usePanelWidth(panelRef, { enabled: !mobile });
   const { resolvedTheme } = useTheme();
   const { diffStyle, setDiffStyle, wrap, setWrap } = useSessionDiffPreferences();
-  const { retry, isRetrying, retryError } = useSessionDiffRetry(sessionId);
   const selected = resolved.status === "ready" ? resolved : null;
+  const selection = selected
+    ? { repositoryPosition: selected.repository.position, path: selected.file.path }
+    : null;
+  const { files, selectedIndex, moveSelection } = useDiffFileNavigation({
+    manifest: state.current,
+    selection,
+    onSelect,
+  });
   const patchKey =
     selected?.file.renderState === "renderable"
       ? `/api/sessions/${sessionId}/diff/${selected.revisionId}/files/${selected.file.id}`
@@ -98,36 +235,10 @@ export function SessionChangesPanel({
   } = useSWR<string>(patchKey, fetchPatch, {
     revalidateOnFocus: false,
   });
-  const files =
-    state.current?.repositories.flatMap((repository) =>
-      repository.files.map((file) => ({ repository, file }))
-    ) ?? [];
-  const selectedIndex = selected
-    ? files.findIndex(
-        ({ repository, file }) =>
-          repository.position === selected.repository.position && file.path === selected.file.path
-      )
-    : -1;
-  const move = (offset: number) => {
-    const target = files[selectedIndex + offset];
-    if (target)
-      onSelect({ repositoryPosition: target.repository.position, path: target.file.path });
-  };
   const stale = patchError instanceof DiffPatchError && patchError.code === "diff_revision_stale";
-  const allowSplit = !mobile && panelWidth >= 720;
+  const allowSplit = !mobile && panelWidth >= SPLIT_DIFF_MIN_PANEL_WIDTH;
   const effectiveDiffStyle = allowSplit ? diffStyle : "unified";
-
-  useEffect(() => {
-    const panel = panelRef.current;
-    if (!panel || mobile || typeof ResizeObserver === "undefined") return;
-    const updateWidth = () => setPanelWidth(panel.getBoundingClientRect().width);
-    updateWidth();
-    const observer = new ResizeObserver((entries) => {
-      setPanelWidth(entries[0]?.contentRect.width ?? panel.getBoundingClientRect().width);
-    });
-    observer.observe(panel);
-    return () => observer.disconnect();
-  }, [mobile]);
+  const availableDiffStyles: readonly DiffStyle[] = allowSplit ? ["unified", "split"] : ["unified"];
 
   useEffect(() => {
     panelRef.current?.focus();
@@ -151,113 +262,25 @@ export function SessionChangesPanel({
       }}
       className="flex h-full min-w-0 flex-col bg-background outline-none"
     >
-      <div className="flex min-h-14 items-center gap-2 border-b border-border-muted px-3">
-        <div className="min-w-0 flex-1">
-          <p className="truncate text-xs font-medium text-muted-foreground">
-            {selected
-              ? `${selected.repository.repoOwner}/${selected.repository.repoName}`
-              : "Changes"}
-          </p>
-          <h2 className="truncate text-sm font-medium" title={selected?.file.path}>
-            {selected?.file.path ?? "File no longer changed"}
-          </h2>
-          {selected && (
-            <p className="truncate text-[11px] text-muted-foreground">
-              {selected.file.status.replace("_", " ")}
-              {selected.file.additions !== null && selected.file.deletions !== null
-                ? ` · +${selected.file.additions} -${selected.file.deletions}`
-                : ""}
-            </p>
-          )}
-        </div>
-        <button
-          type="button"
-          onClick={() => move(-1)}
-          disabled={selectedIndex <= 0}
-          aria-label="Previous changed file"
-          className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-30"
-        >
-          ↑
-        </button>
-        <button
-          type="button"
-          onClick={() => move(1)}
-          disabled={selectedIndex < 0 || selectedIndex >= files.length - 1}
-          aria-label="Next changed file"
-          className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-30"
-        >
-          ↓
-        </button>
-        <button
-          type="button"
-          onClick={onClose}
-          aria-label="Close changes"
-          className="rounded p-1.5 text-lg text-muted-foreground hover:bg-muted hover:text-foreground"
-        >
-          ×
-        </button>
-      </div>
+      <ChangesPanelHeader
+        selected={selected}
+        selectedIndex={selectedIndex}
+        fileCount={files.length}
+        onMoveSelection={moveSelection}
+        onClose={onClose}
+      />
 
-      <div className="flex flex-wrap items-center gap-2 border-b border-border-muted px-3 py-2">
-        {selected && (
-          <details className="text-xs text-muted-foreground">
-            <summary className="cursor-pointer">Compared with session start</summary>
-            <p className="mt-1 font-mono text-[10px]">
-              {selected.repository.baseSha.slice(0, 12)} →{" "}
-              {selected.repository.headSha.slice(0, 12)}
-            </p>
-          </details>
-        )}
-        <div
-          role="group"
-          className="inline-flex rounded-md border border-border-muted p-0.5"
-          aria-label="Diff layout"
-        >
-          {(["unified", ...(allowSplit ? (["split"] as const) : [])] as const).map((style) => (
-            <button
-              key={style}
-              type="button"
-              aria-pressed={effectiveDiffStyle === style}
-              onClick={() => setDiffStyle(style)}
-              className={cn(
-                "rounded px-2 py-1 text-xs capitalize",
-                effectiveDiffStyle === style ? "bg-muted text-foreground" : "text-muted-foreground"
-              )}
-            >
-              {style === "unified" ? "Unified" : "Split"}
-            </button>
-          ))}
-        </div>
-        <label className="ml-auto flex items-center gap-1.5 text-xs text-muted-foreground">
-          <input
-            type="checkbox"
-            checked={wrap}
-            onChange={(event) => setWrap(event.target.checked)}
-          />
-          Wrap lines
-        </label>
-      </div>
+      <ChangesPanelToolbar
+        selected={selected}
+        availableDiffStyles={availableDiffStyles}
+        activeDiffStyle={effectiveDiffStyle}
+        onDiffStyleChange={setDiffStyle}
+        wrap={wrap}
+        onWrapChange={setWrap}
+      />
 
       {state.lastError && (
-        <div className="flex items-center gap-2 border-b border-destructive-border bg-destructive-muted px-3 py-2 text-xs text-destructive">
-          <span className="min-w-0 flex-1 truncate">{state.lastError.message}</span>
-          <button
-            type="button"
-            onClick={() => void retry()}
-            disabled={isRetrying}
-            className="font-medium underline underline-offset-2"
-          >
-            {isRetrying ? "Retrying…" : "Retry"}
-          </button>
-        </div>
-      )}
-      {retryError && (
-        <p
-          role="alert"
-          className="border-b border-destructive-border px-3 py-2 text-xs text-destructive"
-        >
-          {retryError}
-        </p>
+        <DiffRetryNotice sessionId={sessionId} message={state.lastError.message} variant="banner" />
       )}
 
       <div className={cn("flex min-h-0 flex-1", mobile && "flex-col")}>
@@ -272,11 +295,7 @@ export function SessionChangesPanel({
         >
           <FilesChangedSection
             repositories={state.current?.repositories ?? []}
-            selected={
-              selected
-                ? { repositoryPosition: selected.repository.position, path: selected.file.path }
-                : null
-            }
+            selected={selection}
             onSelect={(repository, file) =>
               onSelect({ repositoryPosition: repository.position, path: file.path })
             }

--- a/packages/web/src/components/session-right-sidebar.tsx
+++ b/packages/web/src/components/session-right-sidebar.tsx
@@ -23,7 +23,7 @@ import type {
 } from "@open-inspect/shared";
 import type { DiffSelection } from "@/lib/session-diffs";
 import { deriveSessionDiffView } from "@/lib/session-diffs";
-import { useSessionDiffRetry } from "@/hooks/use-session-diffs";
+import { DiffRetryNotice } from "@/components/diff-retry-notice";
 
 interface SessionRightSidebarProps {
   sessionId: string;
@@ -73,7 +73,6 @@ export function SessionRightSidebarContent({
     () => buildAuthenticatedUrl(sessionState?.ttydUrl, sessionState?.ttydToken),
     [sessionState?.ttydUrl, sessionState?.ttydToken]
   );
-  const { retry, isRetrying, retryError } = useSessionDiffRetry(sessionId);
   const hasRepository = Boolean(
     sessionState?.repositories?.length || (sessionState?.repoOwner && sessionState.repoName)
   );
@@ -223,19 +222,12 @@ export function SessionRightSidebarContent({
               <p className="text-xs text-muted-foreground">No file changes in the latest diff.</p>
             )}
             {diffView.kind === "failed" && (
-              <div className="space-y-1.5">
-                <p className="text-xs text-destructive">{diffView.message}</p>
-                <button
-                  type="button"
-                  disabled={isRetrying}
-                  onClick={() => void retry()}
-                  className="text-xs font-medium text-accent underline underline-offset-2 disabled:opacity-50"
-                >
-                  {isRetrying ? "Retrying…" : "Retry changes refresh"}
-                </button>
-              </div>
+              <DiffRetryNotice
+                sessionId={sessionId}
+                message={diffView.message ?? ""}
+                variant="inline"
+              />
             )}
-            {retryError && <p className="mt-1.5 text-xs text-destructive">{retryError}</p>}
           </div>
         </CollapsibleSection>
       )}

--- a/packages/web/src/hooks/use-diff-file-navigation.test.tsx
+++ b/packages/web/src/hooks/use-diff-file-navigation.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { SessionDiffManifest } from "@open-inspect/shared";
+import { useDiffFileNavigation } from "./use-diff-file-navigation";
+
+const manifest: SessionDiffManifest = {
+  version: 1,
+  revisionId: "revision-1",
+  capturedAt: 100,
+  triggerMessageId: "message-1",
+  repositories: [
+    {
+      status: "ready",
+      position: 0,
+      repoOwner: "acme",
+      repoName: "web",
+      baseSha: "a".repeat(40),
+      headSha: "b".repeat(40),
+      truncated: false,
+      omittedFileCount: 0,
+      files: [
+        {
+          id: "file-1",
+          path: "src/app.ts",
+          status: "modified",
+          additions: 2,
+          deletions: 1,
+          renderState: "renderable",
+        },
+        {
+          id: "file-2",
+          path: "src/lib.ts",
+          status: "modified",
+          additions: 1,
+          deletions: 0,
+          renderState: "renderable",
+        },
+      ],
+    },
+    {
+      status: "ready",
+      position: 1,
+      repoOwner: "acme",
+      repoName: "api",
+      baseSha: "c".repeat(40),
+      headSha: "d".repeat(40),
+      truncated: false,
+      omittedFileCount: 0,
+      files: [
+        {
+          id: "file-3",
+          path: "src/index.ts",
+          status: "added",
+          additions: 5,
+          deletions: 0,
+          renderState: "renderable",
+        },
+      ],
+    },
+  ],
+};
+
+describe("useDiffFileNavigation", () => {
+  it("flattens files across repositories in manifest order", () => {
+    const { result } = renderHook(() =>
+      useDiffFileNavigation({ manifest, selection: null, onSelect: vi.fn() })
+    );
+
+    expect(
+      result.current.files.map(({ repository, file }) => [repository.position, file.path])
+    ).toEqual([
+      [0, "src/app.ts"],
+      [0, "src/lib.ts"],
+      [1, "src/index.ts"],
+    ]);
+    expect(result.current.selectedIndex).toBe(-1);
+  });
+
+  it("returns an empty list without a manifest", () => {
+    const { result } = renderHook(() =>
+      useDiffFileNavigation({ manifest: null, selection: null, onSelect: vi.fn() })
+    );
+
+    expect(result.current.files).toEqual([]);
+    expect(result.current.selectedIndex).toBe(-1);
+  });
+
+  it("locates the selection by repository position and path", () => {
+    const { result } = renderHook(() =>
+      useDiffFileNavigation({
+        manifest,
+        selection: { repositoryPosition: 0, path: "src/lib.ts" },
+        onSelect: vi.fn(),
+      })
+    );
+
+    expect(result.current.selectedIndex).toBe(1);
+  });
+
+  it("moves the selection across the repository boundary", () => {
+    const onSelect = vi.fn();
+    const { result } = renderHook(() =>
+      useDiffFileNavigation({
+        manifest,
+        selection: { repositoryPosition: 0, path: "src/lib.ts" },
+        onSelect,
+      })
+    );
+
+    result.current.moveSelection(1);
+    expect(onSelect).toHaveBeenCalledWith({ repositoryPosition: 1, path: "src/index.ts" });
+    result.current.moveSelection(-1);
+    expect(onSelect).toHaveBeenCalledWith({ repositoryPosition: 0, path: "src/app.ts" });
+  });
+
+  it("ignores moves past either end of the file list", () => {
+    const onSelect = vi.fn();
+    const { result } = renderHook(() =>
+      useDiffFileNavigation({
+        manifest,
+        selection: { repositoryPosition: 1, path: "src/index.ts" },
+        onSelect,
+      })
+    );
+
+    result.current.moveSelection(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/hooks/use-diff-file-navigation.ts
+++ b/packages/web/src/hooks/use-diff-file-navigation.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import type {
+  SessionDiffFile,
+  SessionDiffManifest,
+  SessionDiffRepository,
+} from "@open-inspect/shared";
+import type { DiffSelection } from "@/lib/session-diffs";
+
+export interface DiffFileEntry {
+  repository: SessionDiffRepository;
+  file: SessionDiffFile;
+}
+
+/** Flattens a diff manifest into an ordered file list and exposes prev/next navigation. */
+export function useDiffFileNavigation({
+  manifest,
+  selection,
+  onSelect,
+}: {
+  manifest: SessionDiffManifest | null;
+  selection: DiffSelection | null;
+  onSelect: (selection: DiffSelection) => void;
+}): {
+  files: DiffFileEntry[];
+  selectedIndex: number;
+  moveSelection: (offset: number) => void;
+} {
+  const files = useMemo(
+    () =>
+      manifest?.repositories.flatMap((repository) =>
+        repository.files.map((file) => ({ repository, file }))
+      ) ?? [],
+    [manifest]
+  );
+  const selectedIndex = useMemo(
+    () =>
+      selection
+        ? files.findIndex(
+            ({ repository, file }) =>
+              repository.position === selection.repositoryPosition && file.path === selection.path
+          )
+        : -1,
+    [files, selection]
+  );
+  const moveSelection = useCallback(
+    (offset: number) => {
+      const target = files[selectedIndex + offset];
+      if (target)
+        onSelect({ repositoryPosition: target.repository.position, path: target.file.path });
+    },
+    [files, selectedIndex, onSelect]
+  );
+  return { files, selectedIndex, moveSelection };
+}

--- a/packages/web/src/hooks/use-diff-file-navigation.ts
+++ b/packages/web/src/hooks/use-diff-file-navigation.ts
@@ -34,15 +34,19 @@ export function useDiffFileNavigation({
       ) ?? [],
     [manifest]
   );
+  // Depend on the selection's primitives: callers build the selection object
+  // inline per render, which would otherwise defeat this memo.
+  const selectedPosition = selection?.repositoryPosition;
+  const selectedPath = selection?.path;
   const selectedIndex = useMemo(
     () =>
-      selection
-        ? files.findIndex(
+      selectedPosition === undefined || selectedPath === undefined
+        ? -1
+        : files.findIndex(
             ({ repository, file }) =>
-              repository.position === selection.repositoryPosition && file.path === selection.path
-          )
-        : -1,
-    [files, selection]
+              repository.position === selectedPosition && file.path === selectedPath
+          ),
+    [files, selectedPosition, selectedPath]
   );
   const moveSelection = useCallback(
     (offset: number) => {

--- a/packages/web/src/hooks/use-panel-width.test.tsx
+++ b/packages/web/src/hooks/use-panel-width.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { usePanelWidth } from "./use-panel-width";
+
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = [];
+  readonly observed: Element[] = [];
+  disconnected = false;
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    FakeResizeObserver.instances.push(this);
+  }
+
+  observe(element: Element): void {
+    this.observed.push(element);
+  }
+
+  unobserve(): void {}
+
+  disconnect(): void {
+    this.disconnected = true;
+  }
+
+  emitWidth(width: number): void {
+    this.callback(
+      [{ contentRect: { width } } as ResizeObserverEntry],
+      this as unknown as ResizeObserver
+    );
+  }
+}
+
+function panelElement(width: number): HTMLElement {
+  const element = document.createElement("section");
+  element.getBoundingClientRect = () => ({ width }) as DOMRect;
+  return element;
+}
+
+afterEach(() => {
+  FakeResizeObserver.instances = [];
+  vi.unstubAllGlobals();
+});
+
+describe("usePanelWidth", () => {
+  it("measures the element on mount and follows resize notifications", () => {
+    vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+    const ref = { current: panelElement(800) };
+    const { result } = renderHook(() => usePanelWidth(ref, { enabled: true }));
+
+    expect(result.current).toBe(800);
+    const observer = FakeResizeObserver.instances[0]!;
+    expect(observer.observed).toEqual([ref.current]);
+    act(() => observer.emitWidth(640));
+    expect(result.current).toBe(640);
+  });
+
+  it("does not observe when disabled", () => {
+    vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+    const ref = { current: panelElement(800) };
+    const { result } = renderHook(() => usePanelWidth(ref, { enabled: false }));
+
+    expect(result.current).toBe(0);
+    expect(FakeResizeObserver.instances).toHaveLength(0);
+  });
+
+  it("disconnects the observer on unmount", () => {
+    vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+    const ref = { current: panelElement(800) };
+    const { unmount } = renderHook(() => usePanelWidth(ref, { enabled: true }));
+
+    unmount();
+    expect(FakeResizeObserver.instances[0]!.disconnected).toBe(true);
+  });
+
+  it("stays at zero when ResizeObserver is unavailable", () => {
+    const ref = { current: panelElement(800) };
+    const { result } = renderHook(() => usePanelWidth(ref, { enabled: true }));
+
+    expect(result.current).toBe(0);
+  });
+});

--- a/packages/web/src/hooks/use-panel-width.ts
+++ b/packages/web/src/hooks/use-panel-width.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect, useState, type RefObject } from "react";
+
+/** Tracks the rendered width of an element in pixels via ResizeObserver. */
+export function usePanelWidth(
+  ref: RefObject<HTMLElement | null>,
+  { enabled }: { enabled: boolean }
+): number {
+  const [width, setWidth] = useState(0);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!enabled || !element || typeof ResizeObserver === "undefined") return;
+    setWidth(element.getBoundingClientRect().width);
+    const observer = new ResizeObserver((entries) => {
+      setWidth(entries[0]?.contentRect.width ?? element.getBoundingClientRect().width);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [ref, enabled]);
+
+  return width;
+}

--- a/packages/web/src/hooks/use-session-diffs.ts
+++ b/packages/web/src/hooks/use-session-diffs.ts
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useState } from "react";
 import useSWR from "swr";
 import { mutate } from "swr";
 import { sessionDiffStateSchema, type SessionDiffState } from "@open-inspect/shared";
+import { parseDiffErrorBody } from "@/lib/session-diffs";
 
 export function sessionDiffKey(sessionId: string): string {
   return `/api/sessions/${sessionId}/diff`;
@@ -41,10 +42,8 @@ export function useSessionDiffRetry(sessionId: string): {
     try {
       const response = await fetch(`/api/sessions/${sessionId}/diff/retry`, { method: "POST" });
       if (!response.ok) {
-        const body = await response.json().catch(() => null);
-        setRetryError(
-          body && typeof body.error === "string" ? body.error : "Changes could not be retried."
-        );
+        const body = parseDiffErrorBody(await response.json().catch(() => null));
+        setRetryError(body.error ?? "Changes could not be retried.");
         return false;
       }
       await mutate(sessionDiffKey(sessionId));

--- a/packages/web/src/lib/session-diffs.test.ts
+++ b/packages/web/src/lib/session-diffs.test.ts
@@ -3,6 +3,7 @@ import type { SessionDiffManifest, SessionDiffState } from "@open-inspect/shared
 import {
   buildUniquePathLabels,
   deriveSessionDiffView,
+  parseDiffErrorBody,
   resolveDiffSelection,
 } from "./session-diffs";
 
@@ -127,6 +128,22 @@ describe("session diff view model", () => {
       kind: "unavailable",
       message: "Changes unavailable for this session",
     });
+  });
+});
+
+describe("parseDiffErrorBody", () => {
+  it("keeps only string code and error fields from untrusted bodies", () => {
+    expect(parseDiffErrorBody({ code: "diff_revision_stale", error: "stale" })).toEqual({
+      code: "diff_revision_stale",
+      error: "stale",
+    });
+    expect(parseDiffErrorBody({ code: 42, error: { message: "nope" } })).toEqual({});
+  });
+
+  it("returns an empty body for non-object values", () => {
+    expect(parseDiffErrorBody(null)).toEqual({});
+    expect(parseDiffErrorBody("boom")).toEqual({});
+    expect(parseDiffErrorBody(undefined)).toEqual({});
   });
 });
 

--- a/packages/web/src/lib/session-diffs.ts
+++ b/packages/web/src/lib/session-diffs.ts
@@ -87,6 +87,21 @@ export function resolveDiffSelection(
     : { status: "missing", revisionId: manifest.revisionId };
 }
 
+export interface DiffErrorBody {
+  code?: string;
+  error?: string;
+}
+
+/** Narrows an untrusted diff error-response body to the fields the UI reads. */
+export function parseDiffErrorBody(value: unknown): DiffErrorBody {
+  if (typeof value !== "object" || value === null) return {};
+  const record = value as Record<string, unknown>;
+  const body: DiffErrorBody = {};
+  if (typeof record.code === "string") body.code = record.code;
+  if (typeof record.error === "string") body.error = record.error;
+  return body;
+}
+
 export function buildUniquePathLabels(paths: string[]): Record<string, string> {
   const result: Record<string, string> = {};
   for (const path of paths) {


### PR DESCRIPTION
Decomposes the oversized `SessionChangesPanel` component and deduplicates the diff retry banner. Pure refactor: rendered output is unchanged except for the deliberate copy reconciliation noted below.

## Extractions

**`usePanelWidth` (new `src/hooks/use-panel-width.ts`)** — wraps the ResizeObserver width-measurement effect. Signature `usePanelWidth(ref, { enabled })` returning the measured width; the panel passes `enabled: !mobile`, preserving the previous "skip on mobile / no ResizeObserver" guard. Unit-tested with a fake ResizeObserver (initial measure, resize notifications, disabled, disconnect on unmount, no-ResizeObserver fallback).

**`useDiffFileNavigation` (new `src/hooks/use-diff-file-navigation.ts`)** — pure derivation of the flattened cross-repository file list, the selected index, and prev/next movement: `{ files, selectedIndex, moveSelection }`. Same matching semantics as before (repository `position` + file `path`); focused unit tests cover flattening order, selection lookup, cross-repository moves, and boundary no-ops.

**Named subcomponents in the panel file** — `ChangesPanelHeader` (repo/file metadata, prev/next/close buttons) and `ChangesPanelToolbar` (base-sha details, layout toggle, wrap checkbox). The inline `(["unified", ...(allowSplit ? (["split"] as const) : [])] as const)` construction is replaced by a plainly-computed `availableDiffStyles: readonly DiffStyle[]`.

## Retry banner unification

**`DiffRetryNotice` (new `src/components/diff-retry-notice.tsx`)** — both `SessionChangesPanel` and `SessionRightSidebarContent` called `useSessionDiffRetry` solely to render a message + retry button + retry-error line. The shared component takes `sessionId` (it owns the retry hook — the cleaner seam, since neither parent used the retry state elsewhere), `message`, and a `variant` (`"banner"` for the panel strip, `"inline"` for the sidebar section) that keeps each context's existing layout classes.

Copy/markup reconciliation (deliberate):
- Button label unified to **"Retry"** / "Retrying…" in both places. The sidebar previously said "Retry changes refresh"; the adjacent error message already provides the context, and the panel's existing label (and its test) used "Retry".
- The retry-error paragraph now carries `role="alert"` in both variants (previously panel-only) so the sidebar failure is announced too.
- The sidebar's retry-error line now renders inside the `failed` block (it could previously linger outside it); since the error is only ever set from the retry button inside that block, behavior is equivalent in practice.

## Other cleanups

- **`fileMessage` dead branch**: the `metadata_only` case tested `file.oldMode || file.newMode` and then re-tested the identical expression inside the template literal, so the inner ternary could never be false. Now computed once as `hasModeChange`.
- **Typed error-body parsing**: new `parseDiffErrorBody(value: unknown): { code?: string; error?: string }` in `src/lib/session-diffs.ts` with proper narrowing, used by the panel's `fetchPatch` (`code`) and `useSessionDiffRetry` (`error`). The `"diff_revision_stale"` handling is byte-for-byte unchanged; the string stays local pending a follow-up that unifies the constant with `@open-inspect/shared`.
- The magic `720` split-view threshold is now `SPLIT_DIFF_MIN_PANEL_WIDTH`.

## Verification

- `npm run build -w @open-inspect/shared` — clean
- `npm run typecheck` — clean (all packages)
- `npm test -w @open-inspect/web` — 92 files, 826 tests passed (includes 14 new tests: 4 `usePanelWidth`, 5 `useDiffFileNavigation`, 3 `DiffRetryNotice`, 2 `parseDiffErrorBody`)
- `npx prettier --write` + `npx eslint --fix` on all changed files, then re-typecheck + re-test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added retry controls for failed diff refreshes, with banner and inline display options.
  - Added previous/next navigation across changed files.
  - Diff layouts now adapt between split and unified views based on available panel width.
- **Bug Fixes**
  - Improved diff error handling by safely extracting and displaying server-provided error messages.
  - Retry actions provide clearer “retrying” status and are disabled during in-progress refreshes.
- **Tests**
  - Added coverage for diff retry notices, error parsing, panel width measurement, and file navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->