### PR TITLE
refactor: type diff error codes with shared SessionDiffErrorCode

### DIFF
--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -117,6 +117,8 @@ export {
   SESSION_DIFF_ID_PATTERN,
   SESSION_DIFF_REVISION_STALE_CODE,
   SESSION_DIFF_FILE_NOT_FOUND_CODE,
+  SESSION_DIFF_ERROR_CODES,
+  isSessionDiffErrorCode,
   diffRenderStateSchema,
   diffFileStatusSchema,
   sessionDiffBaselineRepositorySchema,

--- a/packages/shared/src/types/session-diffs.ts
+++ b/packages/shared/src/types/session-diffs.ts
@@ -16,9 +16,17 @@ export const SESSION_DIFF_ID_PATTERN = /^[A-Za-z0-9._-]{1,200}$/;
 export const SESSION_DIFF_REVISION_STALE_CODE = "diff_revision_stale" as const;
 export const SESSION_DIFF_FILE_NOT_FOUND_CODE = "diff_file_not_found" as const;
 
-export type SessionDiffErrorCode =
-  | typeof SESSION_DIFF_REVISION_STALE_CODE
-  | typeof SESSION_DIFF_FILE_NOT_FOUND_CODE;
+/** Every wire error code the session diff endpoints produce. */
+export const SESSION_DIFF_ERROR_CODES = [
+  SESSION_DIFF_REVISION_STALE_CODE,
+  SESSION_DIFF_FILE_NOT_FOUND_CODE,
+] as const;
+
+export type SessionDiffErrorCode = (typeof SESSION_DIFF_ERROR_CODES)[number];
+
+export function isSessionDiffErrorCode(value: unknown): value is SessionDiffErrorCode {
+  return (SESSION_DIFF_ERROR_CODES as readonly unknown[]).includes(value);
+}
 
 export const diffRenderStateSchema = z.enum(["renderable", "binary", "too_large", "metadata_only"]);
 export const diffFileStatusSchema = z.enum([

--- a/packages/web/src/components/session-changes-panel.tsx
+++ b/packages/web/src/components/session-changes-panel.tsx
@@ -5,7 +5,8 @@ import { useTheme } from "next-themes";
 import { mutate } from "swr";
 import useSWR from "swr";
 import { useEffect, useRef } from "react";
-import { formatRepositoryFullName } from "@open-inspect/shared";
+import { formatRepositoryFullName, SESSION_DIFF_REVISION_STALE_CODE } from "@open-inspect/shared";
+import type { SessionDiffErrorCode } from "@open-inspect/shared";
 import type { SessionDiffFile, SessionDiffState } from "@open-inspect/shared";
 import { useSessionDiffPreferences, type DiffStyle } from "@/hooks/use-session-diff-preferences";
 import { sessionDiffKey } from "@/hooks/use-session-diffs";
@@ -29,7 +30,7 @@ type ReadyDiffSelection = Extract<ResolvedDiffSelection, { status: "ready" }>;
 class DiffPatchError extends Error {
   constructor(
     message: string,
-    readonly code?: string
+    readonly code?: SessionDiffErrorCode
   ) {
     super(message);
   }
@@ -38,7 +39,7 @@ class DiffPatchError extends Error {
 async function fetchPatch(url: string): Promise<string> {
   const response = await fetch(url);
   if (!response.ok) {
-    let code: string | undefined;
+    let code: SessionDiffErrorCode | undefined;
     try {
       code = parseDiffErrorBody(await response.json()).code;
     } catch {
@@ -234,7 +235,8 @@ export function SessionChangesPanel({
   } = useSWR<string>(patchKey, fetchPatch, {
     revalidateOnFocus: false,
   });
-  const stale = patchError instanceof DiffPatchError && patchError.code === "diff_revision_stale";
+  const stale =
+    patchError instanceof DiffPatchError && patchError.code === SESSION_DIFF_REVISION_STALE_CODE;
   const allowSplit = !mobile && panelWidth >= SPLIT_DIFF_MIN_PANEL_WIDTH;
   const effectiveDiffStyle = allowSplit ? diffStyle : "unified";
   const availableDiffStyles: readonly DiffStyle[] = allowSplit ? ["unified", "split"] : ["unified"];

--- a/packages/web/src/lib/session-diffs.test.ts
+++ b/packages/web/src/lib/session-diffs.test.ts
@@ -132,12 +132,20 @@ describe("session diff view model", () => {
 });
 
 describe("parseDiffErrorBody", () => {
-  it("keeps only string code and error fields from untrusted bodies", () => {
+  it("keeps only known codes and string error fields from untrusted bodies", () => {
     expect(parseDiffErrorBody({ code: "diff_revision_stale", error: "stale" })).toEqual({
       code: "diff_revision_stale",
       error: "stale",
     });
+    expect(parseDiffErrorBody({ code: "diff_file_not_found" })).toEqual({
+      code: "diff_file_not_found",
+    });
     expect(parseDiffErrorBody({ code: 42, error: { message: "nope" } })).toEqual({});
+    // Unknown code strings are dropped: the field is typed as the shared
+    // SessionDiffErrorCode union, so only codes the UI acts on survive.
+    expect(parseDiffErrorBody({ code: "some_future_code", error: "boom" })).toEqual({
+      error: "boom",
+    });
   });
 
   it("returns an empty body for non-object values", () => {

--- a/packages/web/src/lib/session-diffs.ts
+++ b/packages/web/src/lib/session-diffs.ts
@@ -1,6 +1,5 @@
 import {
-  SESSION_DIFF_FILE_NOT_FOUND_CODE,
-  SESSION_DIFF_REVISION_STALE_CODE,
+  isSessionDiffErrorCode,
   type SessionDiffErrorCode,
   type SessionDiffFile,
   type SessionDiffManifest,
@@ -93,15 +92,6 @@ export function resolveDiffSelection(
 export interface DiffErrorBody {
   code?: SessionDiffErrorCode;
   error?: string;
-}
-
-const SESSION_DIFF_ERROR_CODES: readonly SessionDiffErrorCode[] = [
-  SESSION_DIFF_REVISION_STALE_CODE,
-  SESSION_DIFF_FILE_NOT_FOUND_CODE,
-];
-
-function isSessionDiffErrorCode(value: unknown): value is SessionDiffErrorCode {
-  return (SESSION_DIFF_ERROR_CODES as readonly unknown[]).includes(value);
 }
 
 /** Narrows an untrusted diff error-response body to the fields the UI reads. */

--- a/packages/web/src/lib/session-diffs.ts
+++ b/packages/web/src/lib/session-diffs.ts
@@ -1,8 +1,11 @@
-import type {
-  SessionDiffFile,
-  SessionDiffManifest,
-  SessionDiffRepository,
-  SessionDiffState,
+import {
+  SESSION_DIFF_FILE_NOT_FOUND_CODE,
+  SESSION_DIFF_REVISION_STALE_CODE,
+  type SessionDiffErrorCode,
+  type SessionDiffFile,
+  type SessionDiffManifest,
+  type SessionDiffRepository,
+  type SessionDiffState,
 } from "@open-inspect/shared";
 
 type ReadySessionDiffRepository = Extract<SessionDiffRepository, { status: "ready" }>;
@@ -88,8 +91,17 @@ export function resolveDiffSelection(
 }
 
 export interface DiffErrorBody {
-  code?: string;
+  code?: SessionDiffErrorCode;
   error?: string;
+}
+
+const SESSION_DIFF_ERROR_CODES: readonly SessionDiffErrorCode[] = [
+  SESSION_DIFF_REVISION_STALE_CODE,
+  SESSION_DIFF_FILE_NOT_FOUND_CODE,
+];
+
+function isSessionDiffErrorCode(value: unknown): value is SessionDiffErrorCode {
+  return (SESSION_DIFF_ERROR_CODES as readonly unknown[]).includes(value);
 }
 
 /** Narrows an untrusted diff error-response body to the fields the UI reads. */
@@ -97,7 +109,7 @@ export function parseDiffErrorBody(value: unknown): DiffErrorBody {
   if (typeof value !== "object" || value === null) return {};
   const record = value as Record<string, unknown>;
   const body: DiffErrorBody = {};
-  if (typeof record.code === "string") body.code = record.code;
+  if (isSessionDiffErrorCode(record.code)) body.code = record.code;
   if (typeof record.error === "string") body.error = record.error;
   return body;
 }


### PR DESCRIPTION
Follow-up promised in the #1052 review thread (deferred there to avoid conflicting with the then-open #1053): connect the producer and consumer of the diff error codes through the shared type.

- `DiffErrorBody.code` and `DiffPatchError.code` are now typed as `SessionDiffErrorCode` (the shared union of `SESSION_DIFF_REVISION_STALE_CODE` / `SESSION_DIFF_FILE_NOT_FOUND_CODE`) instead of `string`.
- `parseDiffErrorBody` narrows untrusted bodies via a membership guard, so unknown code strings are dropped rather than smuggled into the typed field (test added documenting this).
- The panel's stale check now compares against `SESSION_DIFF_REVISION_STALE_CODE` — a control-plane code rename now surfaces as a compile error in the consumer instead of silently breaking stale-refresh handling.

## Testing
- `npm run typecheck` clean (with `set -o pipefail`)
- `npm test -w @open-inspect/web` — 826 passed (1 test expanded for the unknown-code case)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session difference error handling by recognizing only supported error codes.
  * Invalid or unrecognized error details are now safely filtered while valid messages remain available.
  * Improved detection and handling of outdated session difference data.
* **Reliability**
  * Added consistent validation for session difference errors, helping provide more predictable behavior when loading or parsing comparison results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->