### PR TITLE
refactor(control-plane): inject SessionMessenger into session services

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -329,7 +329,7 @@ export class SessionDO extends DurableObject<Env> {
       this._presenceService = new PresenceService({
         getAuthenticatedClients: () => this.wsManager.getAuthenticatedClients(),
         getClientInfo: (ws) => this.getClientInfo(ws),
-        broadcast: (msg) => this.broadcast(msg),
+        messenger: this.messenger,
         send: (ws, msg) => this.safeSend(ws, msg),
         getSandboxSocket: () => this.wsManager.getSandboxSocket(),
         isSpawning: () => this.lifecycleManager.isSpawning(),
@@ -375,7 +375,7 @@ export class SessionDO extends DurableObject<Env> {
         getSession: () => this.getSession(),
         updateLastActivity: (timestamp) => this.updateLastActivity(timestamp),
         spawnSandbox: () => this.spawnSandbox(),
-        broadcast: (message) => this.broadcast(message),
+        messenger: this.messenger,
         setSessionStatus: async (status) => {
           await this.transitionSessionStatus(status);
         },
@@ -435,7 +435,7 @@ export class SessionDO extends DurableObject<Env> {
         getSandbox: () => this.getSandbox(),
         getPublicSessionId: (session) => this.getPublicSessionId(session),
         parseArtifactMetadata: (artifact) => this.parseArtifactMetadata(artifact),
-        broadcast: (message) => this.broadcast(message),
+        messenger: this.messenger,
       });
     }
 
@@ -463,7 +463,7 @@ export class SessionDO extends DurableObject<Env> {
           Boolean(this.env.DB && this.env.REPO_SECRETS_ENCRYPTION_KEY),
         getScmCredentials: () =>
           new ScmCredentialsService(this.sourceControlProvider, this.log).getCredentials(),
-        broadcast: (message) => this.broadcast(message),
+        messenger: this.messenger,
         generateId: () => generateId(),
         now: () => Date.now(),
         getLog: () => this.log,
@@ -547,20 +547,7 @@ export class SessionDO extends DurableObject<Env> {
             log: this.log,
             generateId: () => generateId(),
             pushBranchToRemote: (pushSpec) => this.pushBranchToRemote(pushSpec),
-            broadcastSessionBranch: (branchName, repo) => {
-              this.broadcast({
-                type: "session_branch",
-                branchName,
-                repoOwner: repo.repoOwner,
-                repoName: repo.repoName,
-              });
-            },
-            broadcastArtifactCreated: (artifact) => {
-              this.broadcast({
-                type: "artifact_created",
-                artifact,
-              });
-            },
+            messenger: this.messenger,
             appName: resolveAppName(this.env),
             sessionPullRequests: this.env.DB ? new SessionPullRequestStore(this.env.DB) : undefined,
           });
@@ -569,12 +556,7 @@ export class SessionDO extends DurableObject<Env> {
         },
         getArtifactById: (artifactId) => this.repository.getArtifactById(artifactId),
         updateArtifact: (artifactId, data) => this.repository.updateArtifact(artifactId, data),
-        broadcastArtifactUpdated: (artifact) => {
-          this.broadcast({
-            type: "artifact_updated",
-            artifact,
-          });
-        },
+        messenger: this.messenger,
         now: () => Date.now(),
         triggerPullRequestRefresh: () => this.schedulePullRequestRefresh("manual"),
       });
@@ -643,24 +625,23 @@ export class SessionDO extends DurableObject<Env> {
 
   private get sandboxEventProcessor(): SessionSandboxEventProcessor {
     if (!this._sandboxEventProcessor) {
-      this._sandboxEventProcessor = new SessionSandboxEventProcessor({
-        ctx: this.ctx,
-        log: this.log,
-        repository: this.repository,
-        callbackService: this.callbackService,
-        wsManager: this.wsManager,
-        broadcast: (message) => this.broadcast(message),
-        applySessionTitleUpdate: (title, options) => this.applySessionTitleUpdate(title, options),
-        getIsProcessing: () => this.getIsProcessing(),
-        triggerSnapshot: (reason) => this.triggerSnapshot(reason),
-        reconcileSessionStatusAfterExecution: async (success) => {
+      this._sandboxEventProcessor = new SessionSandboxEventProcessor(
+        this.ctx,
+        () => this.log,
+        this.repository,
+        this.callbackService,
+        this.wsManager,
+        this.messenger,
+        this.diffService,
+        (title, options) => this.applySessionTitleUpdate(title, options),
+        (reason) => this.triggerSnapshot(reason),
+        async (success) => {
           await this.reconcileSessionStatusAfterExecution(success);
         },
-        updateLastActivity: (timestamp) => this.updateLastActivity(timestamp),
-        scheduleInactivityCheck: () => this.scheduleInactivityCheck(),
-        processMessageQueue: () => this.messageQueue.processMessageQueue(),
-        handleReady: async (event) => this.diffService.pinBaselines(event),
-      });
+        (timestamp) => this.updateLastActivity(timestamp),
+        () => this.scheduleInactivityCheck(),
+        () => this.messageQueue.processMessageQueue()
+      );
     }
 
     return this._sandboxEventProcessor;

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
@@ -145,6 +145,7 @@ function createHandler() {
     artifact.metadata ? (JSON.parse(artifact.metadata) as Record<string, unknown>) : null
   );
   const broadcast = vi.fn();
+  const messenger = { broadcast, sendToSandbox: vi.fn(() => true) };
 
   const handler = createChildSessionsHandler({
     repository,
@@ -152,7 +153,7 @@ function createHandler() {
     getSandbox,
     getPublicSessionId,
     parseArtifactMetadata,
-    broadcast,
+    messenger,
   });
 
   return {

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
@@ -1,5 +1,6 @@
 import type { SpawnContext } from "@open-inspect/shared";
 import type { SessionStatus } from "../../../types";
+import type { SessionMessenger } from "../../messenger";
 import type { SessionRepository } from "../../repository";
 import type { ArtifactRow, SandboxRow, SessionRow } from "../../types";
 import {
@@ -26,12 +27,7 @@ export interface ChildSessionsHandlerDeps {
   parseArtifactMetadata: (
     artifact: Pick<ArtifactRow, "id" | "metadata">
   ) => Record<string, unknown> | null;
-  broadcast: (message: {
-    type: "child_session_update";
-    childSessionId: string;
-    status: SessionStatus;
-    title: string | null;
-  }) => void;
+  messenger: SessionMessenger;
 }
 
 export interface ChildSessionsHandler {
@@ -141,7 +137,7 @@ export function createChildSessionsHandler(deps: ChildSessionsHandlerDeps): Chil
         return Response.json({ error: "childSessionId and status are required" }, { status: 400 });
       }
 
-      deps.broadcast({
+      deps.messenger.broadcast({
         type: "child_session_update",
         childSessionId: body.childSessionId,
         status: body.status,

--- a/packages/control-plane/src/session/http/handlers/pull-request.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/pull-request.handler.test.ts
@@ -89,7 +89,8 @@ function createHandler() {
   const createPullRequest = vi.fn();
   const getArtifactById = vi.fn<(artifactId: string) => ArtifactRow | null>(() => null);
   const updateArtifact = vi.fn();
-  const broadcastArtifactUpdated = vi.fn();
+  const broadcast = vi.fn();
+  const messenger = { broadcast, sendToSandbox: vi.fn(() => true) };
   const now = vi.fn(() => 5000);
   const triggerPullRequestRefresh = vi.fn();
 
@@ -102,7 +103,7 @@ function createHandler() {
     createPullRequest,
     getArtifactById,
     updateArtifact,
-    broadcastArtifactUpdated,
+    messenger,
     now,
     triggerPullRequestRefresh,
   });
@@ -120,7 +121,7 @@ function createHandler() {
     createPullRequest,
     getArtifactById,
     updateArtifact,
-    broadcastArtifactUpdated,
+    broadcast,
     now,
     triggerPullRequestRefresh,
   };
@@ -571,7 +572,7 @@ describe("pullRequestArtifactSnapshot", () => {
   });
 
   it("applies a changed snapshot, advances updatedAt, and broadcasts artifact_updated", async () => {
-    const { handler, getArtifactById, updateArtifact, broadcastArtifactUpdated } = createHandler();
+    const { handler, getArtifactById, updateArtifact, broadcast } = createHandler();
     getArtifactById.mockReturnValue(createPrArtifact());
 
     const response = await postSnapshot(
@@ -603,13 +604,16 @@ describe("pullRequestArtifactSnapshot", () => {
       metadata: JSON.stringify(expectedMetadata),
       updatedAt: 5000,
     });
-    expect(broadcastArtifactUpdated).toHaveBeenCalledWith({
-      id: "artifact-1",
-      type: "pr",
-      url: "https://github.com/acme/repo/pull/7",
-      metadata: expectedMetadata,
-      createdAt: 1000,
-      updatedAt: 5000,
+    expect(broadcast).toHaveBeenCalledWith({
+      type: "artifact_updated",
+      artifact: {
+        id: "artifact-1",
+        type: "pr",
+        url: "https://github.com/acme/repo/pull/7",
+        metadata: expectedMetadata,
+        createdAt: 1000,
+        updatedAt: 5000,
+      },
     });
   });
 
@@ -636,7 +640,7 @@ describe("pullRequestArtifactSnapshot", () => {
   });
 
   it("no-ops when the snapshot is materially identical", async () => {
-    const { handler, getArtifactById, updateArtifact, broadcastArtifactUpdated } = createHandler();
+    const { handler, getArtifactById, updateArtifact, broadcast } = createHandler();
     getArtifactById.mockReturnValue(createPrArtifact());
 
     const response = await postSnapshot(handler, createSnapshotPayload());
@@ -644,11 +648,11 @@ describe("pullRequestArtifactSnapshot", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ applied: false });
     expect(updateArtifact).not.toHaveBeenCalled();
-    expect(broadcastArtifactUpdated).not.toHaveBeenCalled();
+    expect(broadcast).not.toHaveBeenCalled();
   });
 
   it("rejects a snapshot older than the stored provider timestamp", async () => {
-    const { handler, getArtifactById, updateArtifact, broadcastArtifactUpdated } = createHandler();
+    const { handler, getArtifactById, updateArtifact, broadcast } = createHandler();
     getArtifactById.mockReturnValue(
       createPrArtifact({
         metadata: JSON.stringify({
@@ -668,7 +672,7 @@ describe("pullRequestArtifactSnapshot", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ applied: false });
     expect(updateArtifact).not.toHaveBeenCalled();
-    expect(broadcastArtifactUpdated).not.toHaveBeenCalled();
+    expect(broadcast).not.toHaveBeenCalled();
   });
 
   it("applies when either side lacks a provider timestamp", async () => {

--- a/packages/control-plane/src/session/http/handlers/pull-request.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/pull-request.handler.ts
@@ -1,5 +1,5 @@
-import type { SessionArtifact } from "@open-inspect/shared";
 import type { SourceControlAuthContext } from "../../../source-control";
+import type { SessionMessenger } from "../../messenger";
 import type { CreatePullRequestInput, CreatePullRequestResult } from "../../pull-request-service";
 import {
   preparePullRequestArtifactUpdate,
@@ -42,7 +42,7 @@ export interface PullRequestHandlerDeps {
   createPullRequest: (input: CreatePullRequestInput) => Promise<CreatePullRequestResult>;
   getArtifactById: (artifactId: string) => ArtifactRow | null;
   updateArtifact: (artifactId: string, data: UpdateArtifactData) => void;
-  broadcastArtifactUpdated: (artifact: SessionArtifact) => void;
+  messenger: SessionMessenger;
   now: () => number;
   /** Kicks off a background read-through refresh. */
   triggerPullRequestRefresh: () => void;
@@ -172,7 +172,7 @@ export function createPullRequestHandler(deps: PullRequestHandlerDeps): PullRequ
       }
 
       deps.updateArtifact(artifact.id, artifactUpdate.update);
-      deps.broadcastArtifactUpdated(artifactUpdate.artifact);
+      deps.messenger.broadcast({ type: "artifact_updated", artifact: artifactUpdate.artifact });
       return Response.json({ applied: true });
     },
 

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.test.ts
@@ -18,6 +18,7 @@ function createHandler() {
   const isOpenAISecretsConfigured = vi.fn();
   const getScmCredentials = vi.fn();
   const broadcast = vi.fn();
+  const messenger = { broadcast, sendToSandbox: vi.fn(() => true) };
   const generateId = vi.fn(() => "participant-1");
   const now = vi.fn(() => 1234);
 
@@ -38,7 +39,7 @@ function createHandler() {
     refreshOpenAIToken,
     isOpenAISecretsConfigured,
     getScmCredentials,
-    broadcast,
+    messenger,
     generateId,
     now,
     getLog: () => log,

--- a/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/sandbox.handler.ts
@@ -5,10 +5,11 @@ import {
   type CreateMediaArtifactRequest,
   type SessionArtifact,
 } from "@open-inspect/shared";
-import type { ParticipantRole, SandboxEvent, ServerMessage } from "../../../types";
+import type { ParticipantRole, SandboxEvent } from "../../../types";
 import { isDeadSandboxStatus } from "../../../sandbox/lifecycle/decisions";
 import type { OpenAITokenRefreshResult } from "../../openai-token-refresh-service";
 import type { ScmCredentialsResult } from "../../scm-credentials-service";
+import type { SessionMessenger } from "../../messenger";
 import type { SessionRepository } from "../../repository";
 import type { SandboxRow, SessionRow } from "../../types";
 import { assertArtifactType } from "../../artifacts";
@@ -34,7 +35,7 @@ export interface SandboxHandlerDeps {
   refreshOpenAIToken: (session: SessionRow) => Promise<OpenAITokenRefreshResult>;
   isOpenAISecretsConfigured: () => boolean;
   getScmCredentials: () => Promise<ScmCredentialsResult>;
-  broadcast: (message: ServerMessage) => void;
+  messenger: SessionMessenger;
   generateId: () => string;
   now: () => number;
   getLog: () => Logger;
@@ -138,8 +139,8 @@ export function createSandboxHandler(deps: SandboxHandlerDeps): SandboxHandler {
         createdAt: now,
       });
 
-      deps.broadcast({ type: "artifact_created", artifact });
-      deps.broadcast({ type: "sandbox_event", event });
+      deps.messenger.broadcast({ type: "artifact_created", artifact });
+      deps.messenger.broadcast({ type: "sandbox_event", event });
 
       return Response.json({ status: "ok", artifactId: artifact.id });
     },

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -119,6 +119,7 @@ function buildQueue(options?: { getClientInfo?: (ws: WebSocket) => ClientInfo | 
   };
 
   const broadcast = vi.fn((_message: ServerMessage) => {});
+  const messenger = { broadcast, sendToSandbox: vi.fn(() => true) };
   const spawnSandbox = vi.fn(async () => {});
   const setSessionStatus = vi.fn(async (_status: string) => {});
   const reconcileSessionStatusAfterExecution = vi.fn(async (_success: boolean) => {});
@@ -146,7 +147,7 @@ function buildQueue(options?: { getClientInfo?: (ws: WebSocket) => ClientInfo | 
     getSession: vi.fn(() => createSession()),
     updateLastActivity,
     spawnSandbox,
-    broadcast,
+    messenger,
     setSessionStatus,
     reconcileSessionStatusAfterExecution,
   });

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -9,14 +9,7 @@ import {
   type SessionAttachmentReference,
   type ResolvedSessionAttachment,
 } from "@open-inspect/shared";
-import type {
-  ClientInfo,
-  Env,
-  MessageSource,
-  SandboxEvent,
-  ServerMessage,
-  SessionStatus,
-} from "../types";
+import type { ClientInfo, Env, MessageSource, SandboxEvent, SessionStatus } from "../types";
 import type { SourceControlProviderName } from "../source-control";
 import type { SessionRow, ParticipantRow, SandboxCommand } from "./types";
 import type { SessionRepository } from "./repository";
@@ -24,6 +17,7 @@ import {
   AttachmentClaimConflictError,
   type SessionAttachmentRepository,
 } from "./session-attachment-repository";
+import type { SessionMessenger } from "./messenger";
 import type { SessionWebSocketManager } from "./websocket-manager";
 import type { ParticipantService } from "./participant-service";
 import type { CallbackNotificationService } from "./callback-notification-service";
@@ -58,7 +52,7 @@ interface MessageQueueDeps {
   getSession: () => SessionRow | null;
   updateLastActivity: (timestamp: number) => void;
   spawnSandbox: () => Promise<void>;
-  broadcast: (message: ServerMessage) => void;
+  messenger: SessionMessenger;
   setSessionStatus: (status: SessionStatus) => Promise<void>;
   reconcileSessionStatusAfterExecution: (success: boolean) => Promise<void>;
   scheduleExecutionTimeout?: (startedAtMs: number) => Promise<void>;
@@ -168,13 +162,13 @@ export class SessionMessageQueue {
         outcome: "deferred",
         reason: "no_sandbox",
       });
-      this.deps.broadcast({ type: "sandbox_spawning" });
+      this.deps.messenger.broadcast({ type: "sandbox_spawning" });
       await this.deps.spawnSandbox();
       return;
     }
 
     this.deps.repository.updateMessageToProcessing(message.id, now);
-    this.deps.broadcast({ type: "processing_status", isProcessing: true });
+    this.deps.messenger.broadcast({ type: "processing_status", isProcessing: true });
     this.deps.updateLastActivity(now);
 
     if (this.deps.scheduleExecutionTimeout) {
@@ -260,7 +254,7 @@ export class SessionMessageQueue {
         now
       );
 
-      this.deps.broadcast({
+      this.deps.messenger.broadcast({
         type: "sandbox_event",
         event: syntheticExecutionComplete,
       });
@@ -274,7 +268,7 @@ export class SessionMessageQueue {
       }
     }
 
-    this.deps.broadcast({ type: "processing_status", isProcessing: false });
+    this.deps.messenger.broadcast({ type: "processing_status", isProcessing: false });
 
     const sandboxWs = this.deps.wsManager.getSandboxSocket();
     if (sandboxWs) {
@@ -306,8 +300,8 @@ export class SessionMessageQueue {
       timestamp: now / 1000,
     };
     this.deps.repository.upsertExecutionCompleteEvent(processingMessage.id, syntheticEvent, now);
-    this.deps.broadcast({ type: "sandbox_event", event: syntheticEvent });
-    this.deps.broadcast({ type: "processing_status", isProcessing: false });
+    this.deps.messenger.broadcast({ type: "sandbox_event", event: syntheticEvent });
+    this.deps.messenger.broadcast({ type: "processing_status", isProcessing: false });
     this.deps.ctx.waitUntil(
       this.deps.callbackService.notifyComplete(processingMessage.id, false, stuckError)
     );
@@ -342,7 +336,7 @@ export class SessionMessageQueue {
       messageId,
       createdAt: now,
     });
-    this.deps.broadcast({ type: "sandbox_event", event: userMessageEvent });
+    this.deps.messenger.broadcast({ type: "sandbox_event", event: userMessageEvent });
   }
 
   async enqueuePromptFromApi(

--- a/packages/control-plane/src/session/presence-service.test.ts
+++ b/packages/control-plane/src/session/presence-service.test.ts
@@ -36,7 +36,7 @@ function createTestHarness() {
   const deps: PresenceServiceDeps = {
     getAuthenticatedClients: vi.fn(() => clients.values()),
     getClientInfo: vi.fn(() => null),
-    broadcast: vi.fn(),
+    messenger: { broadcast: vi.fn(), sendToSandbox: vi.fn(() => true) },
     send: vi.fn(() => true),
     getSandboxSocket: vi.fn(() => null),
     isSpawning: vi.fn(() => false),
@@ -208,7 +208,7 @@ describe("PresenceService", () => {
 
       harness.service.broadcastPresence();
 
-      expect(harness.deps.broadcast).toHaveBeenCalledWith({
+      expect(harness.deps.messenger.broadcast).toHaveBeenCalledWith({
         type: "presence_update",
         participants: [
           {
@@ -234,7 +234,7 @@ describe("PresenceService", () => {
 
       expect(client.status).toBe("idle");
       expect(client.lastSeen).toBeGreaterThan(1000);
-      expect(harness.deps.broadcast).toHaveBeenCalled();
+      expect(harness.deps.messenger.broadcast).toHaveBeenCalled();
     });
 
     it("skips when client not found (no broadcast)", () => {
@@ -243,7 +243,7 @@ describe("PresenceService", () => {
 
       harness.service.updatePresence(ws, { status: "idle" });
 
-      expect(harness.deps.broadcast).not.toHaveBeenCalled();
+      expect(harness.deps.messenger.broadcast).not.toHaveBeenCalled();
     });
   });
 
@@ -254,7 +254,7 @@ describe("PresenceService", () => {
 
       await harness.service.handleTyping();
 
-      expect(harness.deps.broadcast).toHaveBeenCalledWith({ type: "sandbox_warming" });
+      expect(harness.deps.messenger.broadcast).toHaveBeenCalledWith({ type: "sandbox_warming" });
       expect(harness.deps.spawnSandbox).toHaveBeenCalled();
     });
 
@@ -263,7 +263,7 @@ describe("PresenceService", () => {
       vi.mocked(harness.deps.isSpawning).mockReturnValue(false);
 
       const callOrder: string[] = [];
-      vi.mocked(harness.deps.broadcast).mockImplementation(() => {
+      vi.mocked(harness.deps.messenger.broadcast).mockImplementation(() => {
         callOrder.push("broadcast");
       });
       vi.mocked(harness.deps.spawnSandbox).mockImplementation(async () => {
@@ -281,7 +281,7 @@ describe("PresenceService", () => {
 
       await harness.service.handleTyping();
 
-      expect(harness.deps.broadcast).not.toHaveBeenCalled();
+      expect(harness.deps.messenger.broadcast).not.toHaveBeenCalled();
       expect(harness.deps.spawnSandbox).not.toHaveBeenCalled();
     });
 
@@ -290,7 +290,7 @@ describe("PresenceService", () => {
 
       await harness.service.handleTyping();
 
-      expect(harness.deps.broadcast).not.toHaveBeenCalled();
+      expect(harness.deps.messenger.broadcast).not.toHaveBeenCalled();
       expect(harness.deps.spawnSandbox).not.toHaveBeenCalled();
     });
   });

--- a/packages/control-plane/src/session/presence-service.ts
+++ b/packages/control-plane/src/session/presence-service.ts
@@ -10,6 +10,7 @@
 
 import type { Logger } from "../logger";
 import type { ClientInfo, ServerMessage, ParticipantPresence } from "../types";
+import type { SessionMessenger } from "./messenger";
 
 /**
  * Dependencies injected into PresenceService.
@@ -18,7 +19,7 @@ import type { ClientInfo, ServerMessage, ParticipantPresence } from "../types";
 export interface PresenceServiceDeps {
   getAuthenticatedClients: () => IterableIterator<ClientInfo>;
   getClientInfo: (ws: WebSocket) => ClientInfo | null;
-  broadcast: (message: ServerMessage) => void;
+  messenger: SessionMessenger;
   send: (ws: WebSocket, message: ServerMessage) => boolean;
   getSandboxSocket: () => WebSocket | null;
   isSpawning: () => boolean;
@@ -74,7 +75,7 @@ export class PresenceService {
    */
   broadcastPresence(): void {
     const participants = this.getPresenceList();
-    this.deps.broadcast({ type: "presence_update", participants });
+    this.deps.messenger.broadcast({ type: "presence_update", participants });
   }
 
   /**
@@ -98,7 +99,7 @@ export class PresenceService {
   async handleTyping(): Promise<void> {
     if (!this.deps.getSandboxSocket()) {
       if (!this.deps.isSpawning()) {
-        this.deps.broadcast({ type: "sandbox_warming" });
+        this.deps.messenger.broadcast({ type: "sandbox_warming" });
         await this.deps.spawnSandbox();
       }
     }

--- a/packages/control-plane/src/session/pull-request-service.test.ts
+++ b/packages/control-plane/src/session/pull-request-service.test.ts
@@ -14,6 +14,13 @@ import {
   type PushBranchResult,
 } from "./pull-request-service";
 
+function artifactCreatedBroadcasts(deps: PullRequestServiceDeps) {
+  return vi
+    .mocked(deps.messenger.broadcast)
+    .mock.calls.map(([message]) => message)
+    .filter((message) => message.type === "artifact_created");
+}
+
 function createMockLogger(): Logger {
   return {
     debug: vi.fn(),
@@ -172,8 +179,7 @@ function createTestHarness() {
     log,
     generateId: () => `id-${++idCounter}`,
     pushBranchToRemote: vi.fn(async () => ({ success: true as const })),
-    broadcastSessionBranch: vi.fn(),
-    broadcastArtifactCreated: vi.fn(),
+    messenger: { broadcast: vi.fn(), sendToSandbox: vi.fn(() => true) },
     appName: "Open-Inspect",
     sessionPullRequests,
   };
@@ -251,7 +257,7 @@ describe("SessionPullRequestService", () => {
       status: 500,
       error: "Failed to push branch: timeout",
     });
-    expect(harness.deps.broadcastSessionBranch).not.toHaveBeenCalled();
+    expect(harness.deps.messenger.broadcast).not.toHaveBeenCalled();
   });
 
   it("creates PR with app auth when prompting auth is unavailable", async () => {
@@ -266,15 +272,17 @@ describe("SessionPullRequestService", () => {
     const createPrCall = (harness.provider.createPullRequest as ReturnType<typeof vi.fn>).mock
       .calls[0];
     expect(createPrCall[0]).toEqual({ authType: "app", token: "app-token" });
-    expect(harness.deps.broadcastArtifactCreated).toHaveBeenCalledTimes(1);
+    expect(artifactCreatedBroadcasts(harness.deps)).toHaveLength(1);
     expect(harness.deps.repository.updateSessionBranch).toHaveBeenCalledWith(
       "session-1",
       "open-inspect/session-name-1"
     );
-    expect(harness.deps.broadcastSessionBranch).toHaveBeenCalledWith(
-      "open-inspect/session-name-1",
-      { repoOwner: "acme", repoName: "web" }
-    );
+    expect(harness.deps.messenger.broadcast).toHaveBeenCalledWith({
+      type: "session_branch",
+      branchName: "open-inspect/session-name-1",
+      repoOwner: "acme",
+      repoName: "web",
+    });
   });
 
   it("uses the sanitized branch for push, PR creation, and branch sync", async () => {
@@ -309,7 +317,9 @@ describe("SessionPullRequestService", () => {
       "session-1",
       "feature/test"
     );
-    expect(harness.deps.broadcastSessionBranch).toHaveBeenCalledWith("feature/test", {
+    expect(harness.deps.messenger.broadcast).toHaveBeenCalledWith({
+      type: "session_branch",
+      branchName: "feature/test",
       repoOwner: "acme",
       repoName: "web",
     });
@@ -333,22 +343,25 @@ describe("SessionPullRequestService", () => {
     expect(createPrCall[1].body).toContain(
       "*Created with [Open-Inspect](https://app.example.com/session/session-name-1)*"
     );
-    expect(harness.deps.broadcastArtifactCreated).toHaveBeenCalledWith({
-      id: "id-1",
-      type: "pr",
-      url: "https://github.com/acme/web/pull/42",
-      metadata: {
-        number: 42,
-        state: "open",
-        lifecycleState: "open",
-        isDraft: false,
-        head: "open-inspect/session-name-1",
-        base: "main",
-        repoOwner: "acme",
-        repoName: "web",
+    expect(harness.deps.messenger.broadcast).toHaveBeenCalledWith({
+      type: "artifact_created",
+      artifact: {
+        id: "id-1",
+        type: "pr",
+        url: "https://github.com/acme/web/pull/42",
+        metadata: {
+          number: 42,
+          state: "open",
+          lifecycleState: "open",
+          isDraft: false,
+          head: "open-inspect/session-name-1",
+          base: "main",
+          repoOwner: "acme",
+          repoName: "web",
+        },
+        createdAt: expect.any(Number),
+        updatedAt: expect.any(Number),
       },
-      createdAt: expect.any(Number),
-      updatedAt: expect.any(Number),
     });
   });
 
@@ -371,8 +384,9 @@ describe("SessionPullRequestService", () => {
   it("syncs the branch after push and before PR creation", async () => {
     await harness.service.createPullRequest(createInput());
 
+    // The session_branch broadcast is the first messenger fan-out in the flow.
     const pushOrder = vi.mocked(harness.deps.pushBranchToRemote).mock.invocationCallOrder[0];
-    const syncOrder = vi.mocked(harness.deps.broadcastSessionBranch).mock.invocationCallOrder[0];
+    const syncOrder = vi.mocked(harness.deps.messenger.broadcast).mock.invocationCallOrder[0];
     const createPrOrder = (harness.provider.createPullRequest as ReturnType<typeof vi.fn>).mock
       .invocationCallOrder[0];
 
@@ -398,7 +412,7 @@ describe("SessionPullRequestService", () => {
     expect(harness.provider.buildGitPushSpec).not.toHaveBeenCalled();
     expect(harness.deps.pushBranchToRemote).not.toHaveBeenCalled();
     expect(harness.provider.createPullRequest).not.toHaveBeenCalled();
-    expect(harness.deps.broadcastSessionBranch).not.toHaveBeenCalled();
+    expect(harness.deps.messenger.broadcast).not.toHaveBeenCalled();
   });
 
   it("skips branch writes when the sanitized branch is unchanged but still broadcasts", async () => {
@@ -426,7 +440,9 @@ describe("SessionPullRequestService", () => {
         refspec: "HEAD:refs/heads/feature/test",
       })
     );
-    expect(harness.deps.broadcastSessionBranch).toHaveBeenCalledWith("feature/test", {
+    expect(harness.deps.messenger.broadcast).toHaveBeenCalledWith({
+      type: "session_branch",
+      branchName: "feature/test",
       repoOwner: "acme",
       repoName: "web",
     });
@@ -559,10 +575,12 @@ describe("SessionPullRequestService", () => {
         "open-inspect/session-name-1"
       );
       expect(harness.deps.repository.updateSessionBranch).not.toHaveBeenCalled();
-      expect(harness.deps.broadcastSessionBranch).toHaveBeenCalledWith(
-        "open-inspect/session-name-1",
-        { repoOwner: "acme", repoName: "backend" }
-      );
+      expect(harness.deps.messenger.broadcast).toHaveBeenCalledWith({
+        type: "session_branch",
+        branchName: "open-inspect/session-name-1",
+        repoOwner: "acme",
+        repoName: "backend",
+      });
     });
 
     it("writes both the member row and the scalar mirror for the primary", async () => {
@@ -585,9 +603,12 @@ describe("SessionPullRequestService", () => {
         createInput({ repoOwner: "acme", repoName: "backend" })
       );
 
-      expect(harness.deps.broadcastArtifactCreated).toHaveBeenCalledWith(
+      expect(harness.deps.messenger.broadcast).toHaveBeenCalledWith(
         expect.objectContaining({
-          metadata: expect.objectContaining({ repoOwner: "acme", repoName: "backend" }),
+          type: "artifact_created",
+          artifact: expect.objectContaining({
+            metadata: expect.objectContaining({ repoOwner: "acme", repoName: "backend" }),
+          }),
         })
       );
     });
@@ -736,8 +757,11 @@ describe("SessionPullRequestService", () => {
       });
 
       const upsertOrder = harness.sessionPullRequests.upsert.mock.invocationCallOrder[0];
-      const broadcastOrder = vi.mocked(harness.deps.broadcastArtifactCreated).mock
-        .invocationCallOrder[0];
+      const broadcastMock = vi.mocked(harness.deps.messenger.broadcast).mock;
+      const artifactCreatedIndex = broadcastMock.calls.findIndex(
+        ([message]) => message.type === "artifact_created"
+      );
+      const broadcastOrder = broadcastMock.invocationCallOrder[artifactCreatedIndex];
       expect(upsertOrder).toBeLessThan(broadcastOrder);
     });
 
@@ -762,11 +786,14 @@ describe("SessionPullRequestService", () => {
           repositoryExternalId: "999",
         })
       );
-      expect(harness.deps.broadcastArtifactCreated).toHaveBeenCalledWith(
+      expect(harness.deps.messenger.broadcast).toHaveBeenCalledWith(
         expect.objectContaining({
-          metadata: expect.objectContaining({
-            headSha: "abc123",
-            repositoryExternalId: "999",
+          type: "artifact_created",
+          artifact: expect.objectContaining({
+            metadata: expect.objectContaining({
+              headSha: "abc123",
+              repositoryExternalId: "999",
+            }),
           }),
         })
       );
@@ -791,9 +818,12 @@ describe("SessionPullRequestService", () => {
       expect(harness.sessionPullRequests.upsert).toHaveBeenCalledWith(
         expect.objectContaining({ providerUpdatedAt: 1_720_000_000_000 })
       );
-      expect(harness.deps.broadcastArtifactCreated).toHaveBeenCalledWith(
+      expect(harness.deps.messenger.broadcast).toHaveBeenCalledWith(
         expect.objectContaining({
-          metadata: expect.objectContaining({ providerUpdatedAt: 1_720_000_000_000 }),
+          type: "artifact_created",
+          artifact: expect.objectContaining({
+            metadata: expect.objectContaining({ providerUpdatedAt: 1_720_000_000_000 }),
+          }),
         })
       );
     });
@@ -814,12 +844,15 @@ describe("SessionPullRequestService", () => {
       expect(harness.sessionPullRequests.upsert).toHaveBeenCalledWith(
         expect.objectContaining({ lifecycleState: "open", isDraft: true })
       );
-      expect(harness.deps.broadcastArtifactCreated).toHaveBeenCalledWith(
+      expect(harness.deps.messenger.broadcast).toHaveBeenCalledWith(
         expect.objectContaining({
-          metadata: expect.objectContaining({
-            lifecycleState: "open",
-            isDraft: true,
-            state: "draft",
+          type: "artifact_created",
+          artifact: expect.objectContaining({
+            metadata: expect.objectContaining({
+              lifecycleState: "open",
+              isDraft: true,
+              state: "draft",
+            }),
           }),
         })
       );
@@ -836,7 +869,7 @@ describe("SessionPullRequestService", () => {
         prUrl: "https://github.com/acme/web/pull/42",
         state: "open",
       });
-      expect(harness.deps.broadcastArtifactCreated).toHaveBeenCalledTimes(1);
+      expect(artifactCreatedBroadcasts(harness.deps)).toHaveLength(1);
       expect(harness.log.error).toHaveBeenCalledWith(
         "Failed to write session pull request record",
         expect.objectContaining({ artifact_id: "id-1", pr_number: 42 })

--- a/packages/control-plane/src/session/pull-request-service.ts
+++ b/packages/control-plane/src/session/pull-request-service.ts
@@ -1,4 +1,4 @@
-import { generateBranchName, toDisplayStatus, type SessionArtifact } from "@open-inspect/shared";
+import { generateBranchName, toDisplayStatus } from "@open-inspect/shared";
 import type {
   SessionPullRequestRecord,
   SessionPullRequestStore,
@@ -12,6 +12,7 @@ import {
   type GitPushAuthContext,
   type GitPushSpec,
 } from "../source-control";
+import type { SessionMessenger } from "./messenger";
 import { findPrArtifactForRepo } from "./pr-artifacts";
 import {
   mergeSnapshotMetadata,
@@ -113,11 +114,7 @@ export interface PullRequestServiceDeps {
   log: Logger;
   generateId: () => string;
   pushBranchToRemote: (pushSpec: GitPushSpec) => Promise<PushBranchResult>;
-  broadcastSessionBranch: (
-    branchName: string,
-    repo: { repoOwner: string; repoName: string }
-  ) => void;
-  broadcastArtifactCreated: (artifact: SessionArtifact) => void;
+  messenger: SessionMessenger;
   /** Display name used in the PR body footer (e.g. "Created with [name](url)"). */
   appName: string;
   /**
@@ -269,7 +266,12 @@ export class SessionPullRequestService {
       }
       // Broadcast even when the stored branch is already current so connected clients converge
       // after missed or out-of-order updates.
-      this.deps.broadcastSessionBranch(sanitizedHeadBranch, targetRepo);
+      this.deps.messenger.broadcast({
+        type: "session_branch",
+        branchName: sanitizedHeadBranch,
+        repoOwner: targetRepo.repoOwner,
+        repoName: targetRepo.repoName,
+      });
 
       // Use user OAuth if available, otherwise fall back to GitHub App token
       // (e.g. sessions triggered from Linear or other integrations without user GitHub OAuth)
@@ -317,13 +319,16 @@ export class SessionPullRequestService {
         snapshotToRecord(snapshot, { artifactId, sessionId, createdAt: now, updatedAt: now })
       );
 
-      this.deps.broadcastArtifactCreated({
-        id: artifactId,
-        type: "pr",
-        url: prResult.webUrl,
-        metadata: artifactMetadata,
-        createdAt: now,
-        updatedAt: now,
+      this.deps.messenger.broadcast({
+        type: "artifact_created",
+        artifact: {
+          id: artifactId,
+          type: "pr",
+          url: prResult.webUrl,
+          metadata: artifactMetadata,
+          createdAt: now,
+          updatedAt: now,
+        },
       });
 
       return {

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -16,15 +16,20 @@ function createPushSpec(repoOwner: string, repoName: string, targetBranch: strin
 }
 
 function createProcessor() {
+  const getProcessingMessage = vi.fn(() => null as { id: string } | null);
   const repository = {
     updateSandboxHeartbeat: vi.fn(),
-    getProcessingMessage: vi.fn(() => null as { id: string } | null),
+    getProcessingMessage,
     upsertTokenEvent: vi.fn(),
     createArtifact: vi.fn(),
     createEvent: vi.fn(),
     addSessionCost: vi.fn(),
     upsertExecutionCompleteEvent: vi.fn(),
-    updateMessageCompletion: vi.fn(),
+    // The real repository stops reporting a processing message once it is
+    // completed; the processing_status broadcast derives from that.
+    updateMessageCompletion: vi.fn(() => {
+      getProcessingMessage.mockReturnValue(null);
+    }),
     getMessageTimestamps: vi.fn(
       () => null as { created_at: number; started_at: number | null } | null
     ),
@@ -43,38 +48,38 @@ function createProcessor() {
   };
 
   const broadcast = vi.fn((_message: ServerMessage) => {});
+  const messenger = { broadcast, sendToSandbox: vi.fn(() => true) };
+  const diffService = { pinBaselines: vi.fn() };
   const triggerSnapshot = vi.fn(async (_reason: string) => {});
   const reconcileSessionStatusAfterExecution = vi.fn(async (_success: boolean) => {});
   const scheduleInactivityCheck = vi.fn(async () => {});
   const processMessageQueue = vi.fn(async () => {});
-  const handleReady = vi.fn(async () => {});
   const updateLastActivity = vi.fn();
-  const getIsProcessing = vi.fn(() => false);
   const applySessionTitleUpdate = vi.fn((title: string) => ({ ok: true as const, title }));
   const waitUntil = vi.fn();
+  const log = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  };
 
-  const processor = new SessionSandboxEventProcessor({
-    ctx: { waitUntil } as unknown as DurableObjectState,
-    log: {
-      debug: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      child: vi.fn(),
-    },
-    repository: repository as never,
-    callbackService: callbackService as never,
-    wsManager: wsManager as never,
-    broadcast,
+  const processor = new SessionSandboxEventProcessor(
+    { waitUntil } as unknown as DurableObjectState,
+    () => log,
+    repository as never,
+    callbackService as never,
+    wsManager as never,
+    messenger as never,
+    diffService as never,
     applySessionTitleUpdate,
-    getIsProcessing,
     triggerSnapshot,
     reconcileSessionStatusAfterExecution,
     updateLastActivity,
     scheduleInactivityCheck,
-    processMessageQueue,
-    handleReady,
-  });
+    processMessageQueue
+  );
 
   return {
     processor,
@@ -82,11 +87,11 @@ function createProcessor() {
     wsManager,
     callbackService,
     broadcast,
+    diffService,
     triggerSnapshot,
     reconcileSessionStatusAfterExecution,
     scheduleInactivityCheck,
     processMessageQueue,
-    handleReady,
     updateLastActivity,
     applySessionTitleUpdate,
     waitUntil,
@@ -143,6 +148,19 @@ describe("SessionSandboxEventProcessor", () => {
     expect(h.repository.createEvent).not.toHaveBeenCalled();
     expect(h.broadcast).not.toHaveBeenCalled();
     expect(h.updateLastActivity).not.toHaveBeenCalled();
+  });
+
+  it("pins diff baselines on ready", async () => {
+    const h = createProcessor();
+    const event: SandboxEvent = {
+      type: "ready",
+      sandboxId: "sb-1",
+      timestamp: 1000,
+    };
+
+    await h.processor.processSandboxEvent(event);
+
+    expect(h.diffService.pinBaselines).toHaveBeenCalledWith(event);
   });
 
   it("persists token event and broadcasts it", async () => {

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 import { SessionSandboxEventProcessor } from "./sandbox-events";
 import type { GitPushSpec } from "../source-control";
 import type { SandboxEvent, ServerMessage } from "../types";
+import type { CallbackNotificationService } from "./callback-notification-service";
+import type { SessionDiffService } from "./diffs/service";
+import type { SessionRepository } from "./repository";
+import type { SessionWebSocketManager } from "./websocket-manager";
 
 function createPushSpec(repoOwner: string, repoName: string, targetBranch: string): GitPushSpec {
   return {
@@ -68,11 +72,11 @@ function createProcessor() {
   const processor = new SessionSandboxEventProcessor(
     { waitUntil } as unknown as DurableObjectState,
     () => log,
-    repository as never,
-    callbackService as never,
-    wsManager as never,
-    messenger as never,
-    diffService as never,
+    repository as unknown as SessionRepository,
+    callbackService as unknown as CallbackNotificationService,
+    wsManager as unknown as SessionWebSocketManager,
+    messenger,
+    diffService as unknown as SessionDiffService,
     applySessionTitleUpdate,
     triggerSnapshot,
     reconcileSessionStatusAfterExecution,

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -2,37 +2,19 @@ import type { SessionArtifact } from "@open-inspect/shared";
 import { generateId } from "../auth/crypto";
 import type { Logger } from "../logger";
 import type { GitPushSpec } from "../source-control";
-import type { SandboxEvent, ServerMessage } from "../types";
+import type { SandboxEvent } from "../types";
 import { shouldPersistToolCallEvent } from "./event-persistence";
 import { assertArtifactType } from "./artifacts";
 import type { SessionRepository } from "./repository";
 import type { CallbackNotificationService } from "./callback-notification-service";
+import type { SessionDiffService } from "./diffs/service";
+import type { SessionMessenger } from "./messenger";
 import type { SessionWebSocketManager } from "./websocket-manager";
 import type { SessionTitleUpdateOptions, SessionTitleUpdateResult } from "./title";
 
 type PushResolver = { resolve: () => void; reject: (err: Error) => void };
 type SandboxEventWithAck = SandboxEvent & { ackId?: string };
 type PushTerminalEvent = Extract<SandboxEvent, { type: "push_complete" | "push_error" }>;
-
-interface SessionSandboxEventProcessorDeps {
-  ctx: DurableObjectState;
-  log: Logger;
-  repository: SessionRepository;
-  callbackService: CallbackNotificationService;
-  wsManager: SessionWebSocketManager;
-  broadcast: (message: ServerMessage) => void;
-  applySessionTitleUpdate: (
-    title: string,
-    options?: SessionTitleUpdateOptions
-  ) => SessionTitleUpdateResult;
-  getIsProcessing: () => boolean;
-  triggerSnapshot: (reason: string) => Promise<void>;
-  reconcileSessionStatusAfterExecution: (success: boolean) => Promise<void>;
-  updateLastActivity: (timestamp: number) => void;
-  scheduleInactivityCheck: () => Promise<void>;
-  processMessageQueue: () => Promise<void>;
-  handleReady: (event: Extract<SandboxEvent, { type: "ready" }>) => Promise<void>;
-}
 
 /** How long a pending push waits for its terminal event before rejecting. */
 const PUSH_TIMEOUT_MS = 360_000;
@@ -49,13 +31,37 @@ const CRITICAL_EVENT_TYPES: ReadonlySet<string> = new Set([
 export class SessionSandboxEventProcessor {
   private pendingPushResolvers = new Map<string, PushResolver>();
 
-  constructor(private readonly deps: SessionSandboxEventProcessorDeps) {}
+  constructor(
+    private readonly ctx: DurableObjectState,
+    // The DO swaps its logger for a request-scoped child during fetch();
+    // a getter keeps this singleton reading the current logger instead of
+    // capturing one by value at construction time.
+    private readonly getLog: () => Logger,
+    private readonly repository: SessionRepository,
+    private readonly callbackService: CallbackNotificationService,
+    private readonly wsManager: SessionWebSocketManager,
+    private readonly messenger: SessionMessenger,
+    private readonly diffService: SessionDiffService,
+    private readonly applySessionTitleUpdate: (
+      title: string,
+      options?: SessionTitleUpdateOptions
+    ) => SessionTitleUpdateResult,
+    private readonly triggerSnapshot: (reason: string) => Promise<void>,
+    private readonly reconcileSessionStatusAfterExecution: (success: boolean) => Promise<void>,
+    private readonly updateLastActivity: (timestamp: number) => void,
+    private readonly scheduleInactivityCheck: () => Promise<void>,
+    private readonly processMessageQueue: () => Promise<void>
+  ) {}
+
+  private get log(): Logger {
+    return this.getLog();
+  }
 
   async processSandboxEvent(event: SandboxEventWithAck): Promise<void> {
     if (event.type === "heartbeat" || event.type === "token") {
-      this.deps.log.debug("Sandbox event", { event_type: event.type });
+      this.log.debug("Sandbox event", { event_type: event.type });
     } else if (event.type !== "execution_complete") {
-      this.deps.log.info("Sandbox event", { event_type: event.type });
+      this.log.info("Sandbox event", { event_type: event.type });
     }
     const now = Date.now();
 
@@ -63,25 +69,25 @@ export class SessionSandboxEventProcessor {
     const ackId = event.ackId;
 
     if (event.type === "heartbeat") {
-      this.deps.repository.updateSandboxHeartbeat(now);
+      this.repository.updateSandboxHeartbeat(now);
       return;
     }
 
     if (event.type === "session_title") {
-      this.deps.applySessionTitleUpdate(event.title, { onlyIfUnset: true });
+      this.applySessionTitleUpdate(event.title, { onlyIfUnset: true });
       return;
     }
 
     if (event.type === "ready") {
-      await this.deps.handleReady(event);
+      this.diffService.pinBaselines(event);
     }
 
     const eventMessageId = "messageId" in event ? event.messageId : null;
-    const processingMessage = this.deps.repository.getProcessingMessage();
+    const processingMessage = this.repository.getProcessingMessage();
     const messageId = eventMessageId ?? processingMessage?.id ?? null;
 
     if (event.type === "artifact") {
-      this.deps.updateLastActivity(now);
+      this.updateLastActivity(now);
 
       const artifactType = assertArtifactType(event.artifactType);
       const artifactId =
@@ -103,14 +109,14 @@ export class SessionSandboxEventProcessor {
         updatedAt: now,
       };
 
-      this.deps.repository.createArtifact({
+      this.repository.createArtifact({
         id: artifact.id,
         type: artifact.type,
         url: artifact.url,
         metadata: artifact.metadata ? JSON.stringify(artifact.metadata) : null,
         createdAt: now,
       });
-      this.deps.repository.createEvent({
+      this.repository.createEvent({
         id: generateId(),
         type: event.type,
         data: JSON.stringify(augmentedEvent),
@@ -118,37 +124,37 @@ export class SessionSandboxEventProcessor {
         createdAt: now,
       });
 
-      this.deps.broadcast({ type: "artifact_created", artifact });
-      this.deps.broadcast({ type: "sandbox_event", event: augmentedEvent });
+      this.messenger.broadcast({ type: "artifact_created", artifact });
+      this.messenger.broadcast({ type: "sandbox_event", event: augmentedEvent });
       return;
     }
 
     if (event.type === "token") {
       if (messageId) {
-        this.deps.repository.upsertTokenEvent(messageId, event, now);
+        this.repository.upsertTokenEvent(messageId, event, now);
       }
-      this.deps.broadcast({ type: "sandbox_event", event });
+      this.messenger.broadcast({ type: "sandbox_event", event });
       return;
     }
 
     if (event.type === "step_start" || event.type === "step_finish") {
-      this.deps.updateLastActivity(now);
+      this.updateLastActivity(now);
       if (
         event.type === "step_finish" &&
         typeof event.cost === "number" &&
         Number.isFinite(event.cost) &&
         event.cost > 0
       ) {
-        this.deps.repository.addSessionCost(event.cost, now);
+        this.repository.addSessionCost(event.cost, now);
       }
-      this.deps.broadcast({ type: "sandbox_event", event });
+      this.messenger.broadcast({ type: "sandbox_event", event });
       return;
     }
 
     if (event.type === "tool_call") {
-      this.deps.updateLastActivity(now);
+      this.updateLastActivity(now);
       if (shouldPersistToolCallEvent(event.status)) {
-        this.deps.repository.createEvent({
+        this.repository.createEvent({
           id: generateId(),
           type: event.type,
           data: JSON.stringify(event),
@@ -156,12 +162,12 @@ export class SessionSandboxEventProcessor {
           createdAt: now,
         });
       }
-      this.deps.broadcast({ type: "sandbox_event", event });
+      this.messenger.broadcast({ type: "sandbox_event", event });
 
       if (messageId) {
-        this.deps.ctx.waitUntil(
-          this.deps.callbackService.notifyToolCall(messageId, event).catch((error) => {
-            this.deps.log.error("callback.tool_call.background_error", {
+        this.ctx.waitUntil(
+          this.callbackService.notifyToolCall(messageId, event).catch((error) => {
+            this.log.error("callback.tool_call.background_error", {
               message_id: messageId,
               error,
             });
@@ -172,30 +178,30 @@ export class SessionSandboxEventProcessor {
     }
 
     if (event.type === "tool_result") {
-      this.deps.repository.createEvent({
+      this.repository.createEvent({
         id: generateId(),
         type: event.type,
         data: JSON.stringify(event),
         messageId,
         createdAt: now,
       });
-      this.deps.broadcast({ type: "sandbox_event", event });
+      this.messenger.broadcast({ type: "sandbox_event", event });
       return;
     }
 
     if (event.type === "execution_complete") {
       const completionMessageId = messageId;
       if (messageId) {
-        this.deps.repository.upsertExecutionCompleteEvent(messageId, event, now);
+        this.repository.upsertExecutionCompleteEvent(messageId, event, now);
       }
       const isStillProcessing =
         completionMessageId != null && processingMessage?.id === completionMessageId;
 
       if (isStillProcessing) {
         const status = event.success ? "completed" : "failed";
-        this.deps.repository.updateMessageCompletion(completionMessageId, status, now);
+        this.repository.updateMessageCompletion(completionMessageId, status, now);
 
-        const timestamps = this.deps.repository.getMessageTimestamps(completionMessageId);
+        const timestamps = this.repository.getMessageTimestamps(completionMessageId);
         const totalDurationMs = timestamps ? now - timestamps.created_at : undefined;
         const processingDurationMs =
           timestamps?.started_at != null ? now - timestamps.started_at : undefined;
@@ -204,7 +210,7 @@ export class SessionSandboxEventProcessor {
             ? timestamps.started_at - timestamps.created_at
             : undefined;
 
-        this.deps.log.info("prompt.complete", {
+        this.log.info("prompt.complete", {
           event: "prompt.complete",
           message_id: completionMessageId,
           outcome: event.success ? "success" : "failure",
@@ -214,33 +220,33 @@ export class SessionSandboxEventProcessor {
           queue_duration_ms: queueDurationMs,
         });
 
-        this.deps.broadcast({ type: "sandbox_event", event });
-        this.deps.broadcast({
+        this.messenger.broadcast({ type: "sandbox_event", event });
+        this.messenger.broadcast({
           type: "processing_status",
-          isProcessing: this.deps.getIsProcessing(),
+          isProcessing: this.repository.getProcessingMessage() !== null,
         });
-        this.deps.ctx.waitUntil(
-          this.deps.callbackService.notifyComplete(completionMessageId, event.success, event.error)
+        this.ctx.waitUntil(
+          this.callbackService.notifyComplete(completionMessageId, event.success, event.error)
         );
 
-        await this.deps.reconcileSessionStatusAfterExecution(event.success);
+        await this.reconcileSessionStatusAfterExecution(event.success);
       } else {
-        this.deps.log.info("prompt.complete", {
+        this.log.info("prompt.complete", {
           event: "prompt.complete",
           message_id: completionMessageId,
           outcome: "already_stopped",
         });
       }
 
-      this.deps.ctx.waitUntil(this.deps.triggerSnapshot("execution_complete"));
-      this.deps.updateLastActivity(now);
-      await this.deps.scheduleInactivityCheck();
-      await this.deps.processMessageQueue();
+      this.ctx.waitUntil(this.triggerSnapshot("execution_complete"));
+      this.updateLastActivity(now);
+      await this.scheduleInactivityCheck();
+      await this.processMessageQueue();
       this.sendAck(ackId);
       return;
     }
 
-    this.deps.repository.createEvent({
+    this.repository.createEvent({
       id: generateId(),
       type: event.type,
       data: JSON.stringify(event),
@@ -249,10 +255,10 @@ export class SessionSandboxEventProcessor {
     });
 
     if (event.type === "git_sync") {
-      this.deps.repository.updateSandboxGitSyncStatus(event.status);
+      this.repository.updateSandboxGitSyncStatus(event.status);
 
       if (event.sha) {
-        this.deps.repository.updateSessionCurrentSha(event.sha);
+        this.repository.updateSessionCurrentSha(event.sha);
       }
     }
 
@@ -260,7 +266,7 @@ export class SessionSandboxEventProcessor {
       this.handlePushEvent(event);
     }
 
-    this.deps.broadcast({ type: "sandbox_event", event });
+    this.messenger.broadcast({ type: "sandbox_event", event });
 
     if (CRITICAL_EVENT_TYPES.has(event.type)) {
       this.sendAck(ackId);
@@ -270,10 +276,10 @@ export class SessionSandboxEventProcessor {
   async pushBranchToRemote(
     pushSpec: GitPushSpec
   ): Promise<{ success: true } | { success: false; error: string }> {
-    const sandboxWs = this.deps.wsManager.getSandboxSocket();
+    const sandboxWs = this.wsManager.getSandboxSocket();
 
     if (!sandboxWs) {
-      this.deps.log.info("No sandbox connected, assuming branch was pushed manually");
+      this.log.info("No sandbox connected, assuming branch was pushed manually");
       return { success: true };
     }
 
@@ -295,22 +301,22 @@ export class SessionSandboxEventProcessor {
       }, PUSH_TIMEOUT_MS);
     });
 
-    this.deps.log.info("Sending push command", {
+    this.log.info("Sending push command", {
       branch_name: pushSpec.targetBranch,
       repo_owner: pushSpec.repoOwner,
       repo_name: pushSpec.repoName,
     });
-    this.deps.wsManager.send(sandboxWs, {
+    this.wsManager.send(sandboxWs, {
       type: "push",
       pushSpec,
     });
 
     try {
       await pushPromise;
-      this.deps.log.info("Push completed successfully", { branch_name: pushSpec.targetBranch });
+      this.log.info("Push completed successfully", { branch_name: pushSpec.targetBranch });
       return { success: true };
     } catch (pushError) {
-      this.deps.log.error("Push failed", {
+      this.log.error("Push failed", {
         branch_name: pushSpec.targetBranch,
         error: pushError instanceof Error ? pushError : String(pushError),
       });
@@ -325,7 +331,7 @@ export class SessionSandboxEventProcessor {
   private handlePushEvent(event: PushTerminalEvent): void {
     const entry = this.findPushResolver(event);
     if (!entry) {
-      this.deps.log.warn("Push event matched no pending resolver", {
+      this.log.warn("Push event matched no pending resolver", {
         event_type: event.type,
         branch_name: event.branchName ?? null,
         repo_owner: event.repoOwner ?? null,
@@ -337,14 +343,14 @@ export class SessionSandboxEventProcessor {
 
     const [resolverKey, resolver] = entry;
     if (event.type === "push_complete") {
-      this.deps.log.info("Push completed, resolving promise", {
+      this.log.info("Push completed, resolving promise", {
         branch_name: event.branchName ?? null,
         pending_resolvers: Array.from(this.pendingPushResolvers.keys()),
       });
       resolver.resolve();
     } else {
       const error = event.error || "Push failed";
-      this.deps.log.warn("Push failed for branch", {
+      this.log.warn("Push failed for branch", {
         branch_name: event.branchName ?? null,
         error,
       });
@@ -378,11 +384,11 @@ export class SessionSandboxEventProcessor {
 
   private sendAck(ackId: string | undefined): void {
     if (!ackId) return;
-    const sandboxWs = this.deps.wsManager.getSandboxSocket();
+    const sandboxWs = this.wsManager.getSandboxSocket();
     if (sandboxWs) {
-      this.deps.wsManager.send(sandboxWs, { type: "ack", ackId });
+      this.wsManager.send(sandboxWs, { type: "ack", ackId });
     } else {
-      this.deps.log.debug("Cannot send ACK: no sandbox socket", { ack_id: ackId });
+      this.log.debug("Cannot send ACK: no sandbox socket", { ack_id: ackId });
     }
   }
 


### PR DESCRIPTION
## What

Continuation of the session-service refactor campaign (#1045, #1047–#1053). PR #1045 introduced `SessionMessenger` (client fan-out + sandbox command delivery) and the DO's private `broadcast` method now just delegates to it — but the lazily-built session services were still being handed `broadcast: (msg) => this.broadcast(msg)` closures. This PR sweeps those closures away and injects the real collaborator instead.

### Messenger sweep

Every service/handler that received a `broadcast:` (or typed broadcast-wrapper) lambda now takes the `SessionMessenger` directly and calls `messenger.broadcast(...)` itself:

- **`PresenceService`** — `broadcast` dep → `messenger` (its other owner-state closures are a separate backlog item and are left untouched)
- **`SessionMessageQueue`** — only the `broadcast` field of its deps bag is replaced with `messenger`; the rest of the bag is deliberately not restructured here (separate staged effort)
- **`createChildSessionsHandler`** — narrow `broadcast` message-typed lambda → `messenger`
- **`createSandboxHandler`** — `broadcast` → `messenger`
- **`createPullRequestHandler`** — `broadcastArtifactUpdated` wrapper → `messenger.broadcast({ type: "artifact_updated", ... })`
- **`SessionPullRequestService`** — `broadcastSessionBranch` + `broadcastArtifactCreated` wrappers → `messenger.broadcast({ type: "session_branch" | "artifact_created", ... })`

### `SessionSandboxEventProcessor`: deps bag → direct constructor params

Same treatment #1045 gave `SessionDiffService`:

- Deps-bag constructor object replaced with direct positional constructor parameters
- `getIsProcessing` lambda dropped — it was a one-liner over the repository; the processor now injects the full `SessionRepository` and computes `repository.getProcessingMessage() !== null` itself
- `handleReady` closure killed — it just wrapped `diffService.pinBaselines`; the `SessionDiffService` is injected directly
- `broadcast` lambda → injected `SessionMessenger`
- Logger is taken as `getLog: () => this.log` (same pattern as the DO's HTTP handlers and `alarm/handler.ts`): the DO's `fetch()` swaps in a request-scoped child logger per request, so a lazily-built singleton must not capture the logger by value

## Deliberately out of scope

A parallel PR addresses the lazy `log: this.log` by-value captures on the other lazily-built services (`participantService`, `callbackService`, `presenceService`, `messageQueue`, `attachmentsHandler`) — those lines are intentionally left untouched here to keep the diffs disjoint.

Also untouched: the `SandboxBroadcaster` adapter handed to `SandboxLifecycleManager` (different interface/message type, not one of the lambda-closure sites), and the remaining fields of the `SessionMessageQueue` deps bag.

No behavior change — pure refactor.

## Testing

- `npm run typecheck -w @open-inspect/control-plane` — clean (src + test tsconfigs)
- Unit: `npx vitest run` — **1975 passed** (baseline 1974 + 1 new test covering `ready` → `diffService.pinBaselines`)
- Integration: `npx vitest run --config vitest.integration.config.ts` — **569 passed** (matches baseline)
- `npm run lint -w @open-inspect/control-plane` + `prettier --write` on all touched files — clean

Test fakes for the messenger are plain objects implementing the `SessionMessenger` interface (`{ broadcast, sendToSandbox }`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Session notifications now flow through a unified messaging pathway, keeping presence, sandbox, child-session, artifact, branch, and processing updates consistent.
  * Sandbox “ready” handling now pins diff baselines to improve subsequent sandbox event processing.
  * PR sandbox execution completion continues to persist completion state, reconcile session status, update activity, trigger snapshots, and process any queued messages.

* **Tests**
  * Updated and expanded messaging-focused coverage, including notification ordering and negative-path “no notification” scenarios, plus diff baseline pinning verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->