### PR TITLE
refactor(sandbox-runtime): extract BufferedEventForwarder from bridge

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -489,7 +489,6 @@ class AgentBridge:
                 ping_timeout=10,
             ) as ws:
                 self.ws = ws
-                self.event_forwarder.bind(ws)
                 self._mark_connected()
                 heartbeat_task: asyncio.Task[None] | None = None
                 background_tasks: set[asyncio.Task[None]] = set()
@@ -502,10 +501,9 @@ class AgentBridge:
                         reconnect_count=max(0, self._connection_count - 1),
                         reconnect_attempt_count=self._reconnect_attempt_count,
                     )
+                    await self.event_forwarder.bind(ws)
                     await self._send_event(self._build_ready_event())
                     await self._drain_boot_warnings()
-                    just_flushed = await self.event_forwarder.flush_event_buffer()
-                    await self.event_forwarder.flush_pending_acks(skip_ack_ids=just_flushed)
 
                     heartbeat_task = asyncio.create_task(self._heartbeat_loop())
                     async for message in ws:

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -36,6 +36,7 @@ from .attachment_processor import (
 )
 from .constants import BOOT_WARNINGS_FILE_PATH, REPO_MANIFEST_FILE_PATH
 from .diff_capture import ControlPlaneDiffClient, SessionDiffRefreshWorker
+from .event_forwarder import BufferedEventForwarder
 from .log_config import configure_logging, get_logger
 from .repo_config import find_repo_entry, load_repo_manifest
 from .types import GitUser
@@ -215,18 +216,10 @@ class AgentBridge:
     GIT_CONFIG_TIMEOUT_SECONDS = 10.0
     DIFF_REFRESH_SHUTDOWN_TIMEOUT_SECONDS = 5.0
     MAX_PENDING_PART_EVENTS = 2000
-    MAX_EVENT_BUFFER_SIZE = 1000
     OPENCODE_DEFAULT_TITLE_RE = re.compile(
         r"^(new session|child session) - " r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$",
         re.IGNORECASE,
     )
-    CRITICAL_EVENT_TYPES: ClassVar[set[str]] = {
-        "execution_complete",
-        "error",
-        "snapshot_ready",
-        "push_complete",
-        "push_error",
-    }
 
     def __init__(
         self,
@@ -293,12 +286,9 @@ class AgentBridge:
             log=self.log,
         )
 
-        # Event buffer: survives WS reconnection, flushed on reconnect
-        self._event_buffer: list[dict[str, Any]] = []
-
-        # Pending ACKs: events sent but not yet acknowledged by the control plane.
-        # Keyed by ackId, re-sent on reconnect until the DO confirms receipt.
-        self._pending_acks: dict[str, dict[str, Any]] = {}
+        # Reconnect-safe event delivery: buffers while the WS is down and
+        # re-sends unacknowledged critical events (see event_forwarder.py).
+        self.event_forwarder = BufferedEventForwarder(sandbox_id=sandbox_id, log=self.log)
 
         self._last_forwarded_session_title: str | None = None
         self._connected_at_monotonic: float | None = None
@@ -499,6 +489,7 @@ class AgentBridge:
                 ping_timeout=10,
             ) as ws:
                 self.ws = ws
+                self.event_forwarder.bind(ws)
                 self._mark_connected()
                 heartbeat_task: asyncio.Task[None] | None = None
                 background_tasks: set[asyncio.Task[None]] = set()
@@ -513,8 +504,8 @@ class AgentBridge:
                     )
                     await self._send_event(self._build_ready_event())
                     await self._drain_boot_warnings()
-                    just_flushed = await self._flush_event_buffer()
-                    await self._flush_pending_acks(skip_ack_ids=just_flushed)
+                    just_flushed = await self.event_forwarder.flush_event_buffer()
+                    await self.event_forwarder.flush_pending_acks(skip_ack_ids=just_flushed)
 
                     heartbeat_task = asyncio.create_task(self._heartbeat_loop())
                     async for message in ws:
@@ -546,6 +537,7 @@ class AgentBridge:
                     for task in background_tasks:
                         task.cancel()
                     self.ws = None
+                    self.event_forwarder.unbind()
                     if self._connected_at_monotonic is not None:
                         close_code = getattr(ws, "close_code", None)
                         reason = (
@@ -617,127 +609,7 @@ class AgentBridge:
 
     async def _send_event(self, event: dict[str, Any]) -> None:
         """Send event to control plane, buffering if WS is unavailable."""
-        event_type = event.get("type", "unknown")
-        event["sandboxId"] = self.sandbox_id
-        event["timestamp"] = event.get("timestamp", time.time())
-
-        is_critical = event_type in self.CRITICAL_EVENT_TYPES
-        if is_critical and "ackId" not in event:
-            event["ackId"] = self._make_ack_id(event)
-
-        if not self.ws or self.ws.state != State.OPEN:
-            self._buffer_event(event)
-            return
-
-        try:
-            await self.ws.send(json.dumps(event))
-            if is_critical:
-                self._pending_acks[event["ackId"]] = event
-        except Exception as e:
-            self.log.warn("bridge.send_error", event_type=event_type, exc=e)
-            self._buffer_event(event)
-
-    async def _flush_event_buffer(self) -> set[str]:
-        """Flush buffered events to the control plane after reconnect.
-
-        Returns the set of ackIds that were added to _pending_acks during this
-        flush, so the caller can skip them in _flush_pending_acks (avoiding
-        double-send on the same reconnect).
-        """
-        if not self._event_buffer:
-            return set()
-
-        self.log.info("bridge.flush_buffer_start", buffer_size=len(self._event_buffer))
-        flushed = 0
-        just_added: set[str] = set()
-        while self._event_buffer:
-            event = self._event_buffer[0]
-            if not self.ws or self.ws.state != State.OPEN:
-                break
-            try:
-                await self.ws.send(json.dumps(event))
-                self._event_buffer.pop(0)
-                flushed += 1
-                # Track critical events sent from buffer as pending ACKs
-                if event.get("type") in self.CRITICAL_EVENT_TYPES and "ackId" in event:
-                    self._pending_acks[event["ackId"]] = event
-                    just_added.add(event["ackId"])
-            except Exception as e:
-                self.log.warn("bridge.flush_send_error", exc=e)
-                break
-
-        self.log.info(
-            "bridge.flush_buffer_complete",
-            flushed=flushed,
-            remaining=len(self._event_buffer),
-        )
-        return just_added
-
-    def _buffer_event(self, event: dict[str, Any]) -> None:
-        """Buffer an event for later delivery after WS reconnect."""
-        if len(self._event_buffer) >= self.MAX_EVENT_BUFFER_SIZE:
-            # Evict oldest non-critical event; fall back to oldest if all critical
-            evicted = False
-            for i, buffered in enumerate(self._event_buffer):
-                if buffered.get("type") not in self.CRITICAL_EVENT_TYPES:
-                    self._event_buffer.pop(i)
-                    evicted = True
-                    break
-            if not evicted:
-                self._event_buffer.pop(0)
-
-        self._event_buffer.append(event)
-        self.log.debug(
-            "bridge.event_buffered",
-            event_type=event.get("type", "unknown"),
-            buffer_size=len(self._event_buffer),
-        )
-
-    @staticmethod
-    def _make_ack_id(event: dict[str, Any]) -> str:
-        """Generate a deterministic ack ID for a critical event.
-
-        Format: "{type}:{messageId}" for events with messageId,
-        "{type}:{random_hex}" for events without (e.g., snapshot_ready).
-        Deterministic IDs give natural deduplication on the DO side.
-        """
-        event_type = event.get("type", "unknown")
-        message_id = event.get("messageId")
-        if message_id:
-            return f"{event_type}:{message_id}"
-        return f"{event_type}:{secrets.token_hex(8)}"
-
-    async def _flush_pending_acks(self, skip_ack_ids: set[str] | None = None) -> None:
-        """Re-send unacknowledged critical events on a new WS connection.
-
-        Events stay in _pending_acks until the DO sends an ACK command.
-
-        Args:
-            skip_ack_ids: ackIds to skip (already sent during _flush_event_buffer
-                          on this same reconnect).
-        """
-        if not self._pending_acks:
-            return
-
-        self.log.info("bridge.flush_pending_acks_start", count=len(self._pending_acks))
-        resent = 0
-        for ack_id, event in list(self._pending_acks.items()):
-            if skip_ack_ids and ack_id in skip_ack_ids:
-                continue
-            if not self.ws or self.ws.state != State.OPEN:
-                break
-            try:
-                await self.ws.send(json.dumps(event))
-                resent += 1
-            except Exception as e:
-                self.log.warn("bridge.flush_pending_ack_error", ack_id=ack_id, exc=e)
-                break
-
-        self.log.info(
-            "bridge.flush_pending_acks_complete",
-            resent=resent,
-            total=len(self._pending_acks),
-        )
+        await self.event_forwarder.send(event)
 
     async def _handle_command(self, cmd: dict[str, Any]) -> asyncio.Task[None] | None:
         """Handle command from control plane.
@@ -806,8 +678,7 @@ class AgentBridge:
             self.diff_refresh.request(None)
         elif cmd_type == "ack":
             ack_id = cmd.get("ackId")
-            if ack_id and ack_id in self._pending_acks:
-                del self._pending_acks[ack_id]
+            if ack_id and self.event_forwarder.acknowledge(ack_id):
                 self.log.debug("bridge.ack_received", ack_id=ack_id)
         else:
             self.log.debug("bridge.unknown_command", cmd_type=cmd_type)

--- a/packages/sandbox-runtime/src/sandbox_runtime/event_forwarder.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/event_forwarder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import secrets
 import time
@@ -27,6 +28,11 @@ CRITICAL_EVENT_TYPES: Final[frozenset[str]] = frozenset(
 )
 MAX_EVENT_BUFFER_SIZE: Final = 1000
 
+# Bound on each individual send inside recovery (bind / drain) paths. Those
+# paths hold the recovery lock, so an unbounded wedged send would turn into a
+# wedged reconnect: the next bind() could never recover.
+SEND_TIMEOUT_SECONDS: Final = 30.0
+
 
 class BufferedEventForwarder:
     """Forwards sandbox events over the currently bound WebSocket.
@@ -40,6 +46,8 @@ class BufferedEventForwarder:
     - ``bind`` is the single reconnect operation: it attaches the connection
       and recovers the backlog (buffered events, then unacknowledged
       criticals) without sending anything twice.
+    - All recovery flushing is serialized by one lock, so a stale-send drain
+      and a concurrent bind can never both walk the buffer.
 
     The owner drives the connection lifecycle explicitly via ``bind`` /
     ``unbind``; the forwarder never reaches back into its owner.
@@ -51,11 +59,18 @@ class BufferedEventForwarder:
         sandbox_id: str,
         log: StructuredLogger,
         max_buffer_size: int = MAX_EVENT_BUFFER_SIZE,
+        send_timeout_seconds: float = SEND_TIMEOUT_SECONDS,
     ) -> None:
         self._sandbox_id = sandbox_id
         self._log = log
         self._max_buffer_size = max_buffer_size
+        self._send_timeout_seconds = send_timeout_seconds
         self._ws: ClientConnection | None = None
+
+        # Serializes every buffer walk (bind recovery and stale-send drains).
+        # Concurrent flush loops would each claim the buffer head and pop
+        # events the other one sent — or never sent.
+        self._recovery_lock = asyncio.Lock()
 
         # Event buffer: survives WS reconnection, flushed on reconnect.
         self._event_buffer: list[dict[str, Any]] = []
@@ -68,16 +83,24 @@ class BufferedEventForwarder:
     async def bind(self, ws: ClientConnection) -> None:
         """Attach a live control-plane connection and recover the backlog.
 
-        Recovery order: snapshot the ackIds that were already pending, flush
-        the event buffer (which starts tracking any criticals it sends), then
-        re-send only the snapshotted entries that are still pending. The
-        snapshot is what keeps a critical event flushed from the buffer from
-        being sent a second time on the same reconnect.
+        The connection is attached before the lock is acquired on purpose: a
+        drain loop currently holding the lock re-reads the bound connection
+        every iteration, so it migrates onto the new connection instead of
+        stalling recovery on the dead one.
+
+        Recovery order (under the lock): snapshot the ackIds that were
+        already pending, flush the event buffer (which starts tracking any
+        criticals it sends), then re-send only the snapshotted entries that
+        are still pending. The snapshot is what keeps a critical event
+        flushed from the buffer from being sent a second time on the same
+        reconnect — and it is taken inside the lock so a drain that pends a
+        critical while we wait cannot get that event re-sent here.
         """
         self._ws = ws
-        pending_before_flush = list(self._pending_acks)
-        await self._flush_buffer()
-        await self._resend_pending(pending_before_flush)
+        async with self._recovery_lock:
+            pending_before_flush = list(self._pending_acks)
+            await self._flush_buffer()
+            await self._resend_pending(pending_before_flush)
 
     def unbind(self) -> None:
         """Detach the connection; subsequent sends buffer until the next bind."""
@@ -102,6 +125,11 @@ class BufferedEventForwarder:
             await ws.send(json.dumps(event))
             if is_critical:
                 self._pending_acks[event["ackId"]] = event
+        except asyncio.CancelledError:
+            # A prompt task cancelled mid-send must not strand its event:
+            # re-buffer it, then let the cancellation proceed.
+            self._buffer_event(event)
+            raise
         except Exception as e:
             self._log.warn("bridge.send_error", event_type=event_type, exc=e)
             self._buffer_event(event)
@@ -126,13 +154,27 @@ class BufferedEventForwarder:
         If a different open connection is bound by the time the failure
         surfaces, drain the buffer through it immediately. A drain failure
         just leaves events buffered — no retries.
+
+        The event was buffered before this await, and an active recovery
+        cannot pass its final empty-check and release the lock without that
+        event being visible — so waiting on the lock (rather than skipping
+        when busy) guarantees the event is flushed exactly once.
         """
         current = self._ws
         if current is not None and current is not failed_ws and current.state == State.OPEN:
-            await self._flush_buffer()
+            async with self._recovery_lock:
+                await self._flush_buffer()
 
     async def _flush_buffer(self) -> None:
-        """Flush buffered events over the currently bound connection."""
+        """Flush buffered events over the currently bound connection.
+
+        Must run under ``_recovery_lock``. The connection is re-read every
+        iteration so a rebind while flushing migrates the walk onto the new
+        connection.
+
+        Known debt: an event ``json.dumps`` cannot serialize would be a
+        poison pill at the buffer head — every flush breaks on it.
+        """
         if not self._event_buffer:
             return
 
@@ -144,15 +186,23 @@ class BufferedEventForwarder:
             if not ws or ws.state != State.OPEN:
                 break
             try:
-                await ws.send(json.dumps(event))
-                self._event_buffer.pop(0)
-                flushed += 1
-                # Track critical events sent from buffer as pending ACKs
-                if event.get("type") in CRITICAL_EVENT_TYPES and "ackId" in event:
-                    self._pending_acks[event["ackId"]] = event
+                await asyncio.wait_for(
+                    ws.send(json.dumps(event)), timeout=self._send_timeout_seconds
+                )
             except Exception as e:
                 self._log.warn("bridge.flush_send_error", exc=e)
                 break
+
+            # The send succeeded, but a concurrent overflow eviction may have
+            # removed our claimed head while the send was in flight — pop by
+            # identity so we never pop an event nobody sent.
+            if self._event_buffer and self._event_buffer[0] is event:
+                self._event_buffer.pop(0)
+            flushed += 1
+            # Track critical events sent from buffer as pending ACKs; the
+            # event went out even if it is no longer at the buffer head.
+            if event.get("type") in CRITICAL_EVENT_TYPES and "ackId" in event:
+                self._pending_acks[event["ackId"]] = event
 
         self._log.info(
             "bridge.flush_buffer_complete",
@@ -163,9 +213,10 @@ class BufferedEventForwarder:
     async def _resend_pending(self, ack_ids: list[str]) -> None:
         """Re-send unacknowledged critical events on a new WS connection.
 
-        Only the given ackIds are considered (the ones pending before the
-        buffer flush), and only if they are still pending. Events stay
-        pending until the DO sends an ACK command.
+        Must run under ``_recovery_lock``. Only the given ackIds are
+        considered (the ones pending before the buffer flush), and only if
+        they are still pending. Events stay pending until the DO sends an
+        ACK command.
         """
         to_resend = [ack_id for ack_id in ack_ids if ack_id in self._pending_acks]
         if not to_resend:
@@ -181,7 +232,9 @@ class BufferedEventForwarder:
             if not ws or ws.state != State.OPEN:
                 break
             try:
-                await ws.send(json.dumps(event))
+                await asyncio.wait_for(
+                    ws.send(json.dumps(event)), timeout=self._send_timeout_seconds
+                )
                 resent += 1
             except Exception as e:
                 self._log.warn("bridge.flush_pending_ack_error", ack_id=ack_id, exc=e)
@@ -220,6 +273,9 @@ class BufferedEventForwarder:
         Format: "{type}:{messageId}" for events with messageId,
         "{type}:{random_hex}" for events without (e.g., snapshot_ready).
         Deterministic IDs give natural deduplication on the DO side.
+
+        Known debt: two distinct events reusing a messageId share an ackId,
+        so the later one overwrites the earlier pending entry.
         """
         event_type = event.get("type", "unknown")
         message_id = event.get("messageId")

--- a/packages/sandbox-runtime/src/sandbox_runtime/event_forwarder.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/event_forwarder.py
@@ -1,0 +1,207 @@
+"""Buffered, ack-aware event forwarding from the sandbox to the control plane."""
+
+from __future__ import annotations
+
+import json
+import secrets
+import time
+from typing import TYPE_CHECKING, Any, Final
+
+from websockets import State
+
+if TYPE_CHECKING:
+    from websockets import ClientConnection
+
+    from .log_config import StructuredLogger
+
+# Critical events are retained until the control plane acknowledges them and
+# are re-sent on reconnect; everything else is delivered at most once.
+CRITICAL_EVENT_TYPES: Final[frozenset[str]] = frozenset(
+    {
+        "execution_complete",
+        "error",
+        "snapshot_ready",
+        "push_complete",
+        "push_error",
+    }
+)
+MAX_EVENT_BUFFER_SIZE: Final = 1000
+
+
+class BufferedEventForwarder:
+    """Forwards sandbox events over the currently bound WebSocket.
+
+    Owns the reconnect-safe delivery state machine:
+
+    - While no connection is bound (or a send fails), events land in a
+      bounded buffer that evicts non-critical events first.
+    - Critical events carry an ``ackId`` and stay pending until the control
+      plane acknowledges them, so they can be re-sent on a new connection.
+    - ``flush_event_buffer`` returns the ackIds it just started tracking so
+      ``flush_pending_acks`` can skip them (no double-send on one reconnect).
+
+    The owner drives the connection lifecycle explicitly via ``bind`` /
+    ``unbind``; the forwarder never reaches back into its owner.
+    """
+
+    def __init__(
+        self,
+        *,
+        sandbox_id: str,
+        log: StructuredLogger,
+        max_buffer_size: int = MAX_EVENT_BUFFER_SIZE,
+    ) -> None:
+        self._sandbox_id = sandbox_id
+        self._log = log
+        self._max_buffer_size = max_buffer_size
+        self._ws: ClientConnection | None = None
+
+        # Event buffer: survives WS reconnection, flushed on reconnect.
+        self._event_buffer: list[dict[str, Any]] = []
+
+        # Pending ACKs: events sent but not yet acknowledged by the control
+        # plane. Keyed by ackId, re-sent on reconnect until the DO confirms
+        # receipt.
+        self._pending_acks: dict[str, dict[str, Any]] = {}
+
+    def bind(self, ws: ClientConnection) -> None:
+        """Attach a live control-plane connection; sends use it until unbind."""
+        self._ws = ws
+
+    def unbind(self) -> None:
+        """Detach the connection; subsequent sends buffer until the next bind."""
+        self._ws = None
+
+    async def send(self, event: dict[str, Any]) -> None:
+        """Send event to control plane, buffering if WS is unavailable."""
+        event_type = event.get("type", "unknown")
+        event["sandboxId"] = self._sandbox_id
+        event["timestamp"] = event.get("timestamp", time.time())
+
+        is_critical = event_type in CRITICAL_EVENT_TYPES
+        if is_critical and "ackId" not in event:
+            event["ackId"] = self._make_ack_id(event)
+
+        if not self._ws or self._ws.state != State.OPEN:
+            self._buffer_event(event)
+            return
+
+        try:
+            await self._ws.send(json.dumps(event))
+            if is_critical:
+                self._pending_acks[event["ackId"]] = event
+        except Exception as e:
+            self._log.warn("bridge.send_error", event_type=event_type, exc=e)
+            self._buffer_event(event)
+
+    async def flush_event_buffer(self) -> set[str]:
+        """Flush buffered events to the control plane after reconnect.
+
+        Returns the set of ackIds that were added to the pending-ACK set
+        during this flush, so the caller can skip them in
+        ``flush_pending_acks`` (avoiding double-send on the same reconnect).
+        """
+        if not self._event_buffer:
+            return set()
+
+        self._log.info("bridge.flush_buffer_start", buffer_size=len(self._event_buffer))
+        flushed = 0
+        just_added: set[str] = set()
+        while self._event_buffer:
+            event = self._event_buffer[0]
+            if not self._ws or self._ws.state != State.OPEN:
+                break
+            try:
+                await self._ws.send(json.dumps(event))
+                self._event_buffer.pop(0)
+                flushed += 1
+                # Track critical events sent from buffer as pending ACKs
+                if event.get("type") in CRITICAL_EVENT_TYPES and "ackId" in event:
+                    self._pending_acks[event["ackId"]] = event
+                    just_added.add(event["ackId"])
+            except Exception as e:
+                self._log.warn("bridge.flush_send_error", exc=e)
+                break
+
+        self._log.info(
+            "bridge.flush_buffer_complete",
+            flushed=flushed,
+            remaining=len(self._event_buffer),
+        )
+        return just_added
+
+    async def flush_pending_acks(self, skip_ack_ids: set[str] | None = None) -> None:
+        """Re-send unacknowledged critical events on a new WS connection.
+
+        Events stay pending until the DO sends an ACK command.
+
+        Args:
+            skip_ack_ids: ackIds to skip (already sent during
+                          ``flush_event_buffer`` on this same reconnect).
+        """
+        if not self._pending_acks:
+            return
+
+        self._log.info("bridge.flush_pending_acks_start", count=len(self._pending_acks))
+        resent = 0
+        for ack_id, event in list(self._pending_acks.items()):
+            if skip_ack_ids and ack_id in skip_ack_ids:
+                continue
+            if not self._ws or self._ws.state != State.OPEN:
+                break
+            try:
+                await self._ws.send(json.dumps(event))
+                resent += 1
+            except Exception as e:
+                self._log.warn("bridge.flush_pending_ack_error", ack_id=ack_id, exc=e)
+                break
+
+        self._log.info(
+            "bridge.flush_pending_acks_complete",
+            resent=resent,
+            total=len(self._pending_acks),
+        )
+
+    def acknowledge(self, ack_id: str) -> bool:
+        """Drop a pending critical event the control plane confirmed.
+
+        Returns True when the ackId was known (and is now cleared).
+        """
+        if ack_id in self._pending_acks:
+            del self._pending_acks[ack_id]
+            return True
+        return False
+
+    def _buffer_event(self, event: dict[str, Any]) -> None:
+        """Buffer an event for later delivery after WS reconnect."""
+        if len(self._event_buffer) >= self._max_buffer_size:
+            # Evict oldest non-critical event; fall back to oldest if all critical
+            evicted = False
+            for i, buffered in enumerate(self._event_buffer):
+                if buffered.get("type") not in CRITICAL_EVENT_TYPES:
+                    self._event_buffer.pop(i)
+                    evicted = True
+                    break
+            if not evicted:
+                self._event_buffer.pop(0)
+
+        self._event_buffer.append(event)
+        self._log.debug(
+            "bridge.event_buffered",
+            event_type=event.get("type", "unknown"),
+            buffer_size=len(self._event_buffer),
+        )
+
+    @staticmethod
+    def _make_ack_id(event: dict[str, Any]) -> str:
+        """Generate a deterministic ack ID for a critical event.
+
+        Format: "{type}:{messageId}" for events with messageId,
+        "{type}:{random_hex}" for events without (e.g., snapshot_ready).
+        Deterministic IDs give natural deduplication on the DO side.
+        """
+        event_type = event.get("type", "unknown")
+        message_id = event.get("messageId")
+        if message_id:
+            return f"{event_type}:{message_id}"
+        return f"{event_type}:{secrets.token_hex(8)}"

--- a/packages/sandbox-runtime/src/sandbox_runtime/event_forwarder.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/event_forwarder.py
@@ -37,8 +37,9 @@ class BufferedEventForwarder:
       bounded buffer that evicts non-critical events first.
     - Critical events carry an ``ackId`` and stay pending until the control
       plane acknowledges them, so they can be re-sent on a new connection.
-    - ``flush_event_buffer`` returns the ackIds it just started tracking so
-      ``flush_pending_acks`` can skip them (no double-send on one reconnect).
+    - ``bind`` is the single reconnect operation: it attaches the connection
+      and recovers the backlog (buffered events, then unacknowledged
+      criticals) without sending anything twice.
 
     The owner drives the connection lifecycle explicitly via ``bind`` /
     ``unbind``; the forwarder never reaches back into its owner.
@@ -64,9 +65,19 @@ class BufferedEventForwarder:
         # receipt.
         self._pending_acks: dict[str, dict[str, Any]] = {}
 
-    def bind(self, ws: ClientConnection) -> None:
-        """Attach a live control-plane connection; sends use it until unbind."""
+    async def bind(self, ws: ClientConnection) -> None:
+        """Attach a live control-plane connection and recover the backlog.
+
+        Recovery order: snapshot the ackIds that were already pending, flush
+        the event buffer (which starts tracking any criticals it sends), then
+        re-send only the snapshotted entries that are still pending. The
+        snapshot is what keeps a critical event flushed from the buffer from
+        being sent a second time on the same reconnect.
+        """
         self._ws = ws
+        pending_before_flush = list(self._pending_acks)
+        await self._flush_buffer()
+        await self._resend_pending(pending_before_flush)
 
     def unbind(self) -> None:
         """Detach the connection; subsequent sends buffer until the next bind."""
@@ -82,85 +93,19 @@ class BufferedEventForwarder:
         if is_critical and "ackId" not in event:
             event["ackId"] = self._make_ack_id(event)
 
-        if not self._ws or self._ws.state != State.OPEN:
+        ws = self._ws
+        if not ws or ws.state != State.OPEN:
             self._buffer_event(event)
             return
 
         try:
-            await self._ws.send(json.dumps(event))
+            await ws.send(json.dumps(event))
             if is_critical:
                 self._pending_acks[event["ackId"]] = event
         except Exception as e:
             self._log.warn("bridge.send_error", event_type=event_type, exc=e)
             self._buffer_event(event)
-
-    async def flush_event_buffer(self) -> set[str]:
-        """Flush buffered events to the control plane after reconnect.
-
-        Returns the set of ackIds that were added to the pending-ACK set
-        during this flush, so the caller can skip them in
-        ``flush_pending_acks`` (avoiding double-send on the same reconnect).
-        """
-        if not self._event_buffer:
-            return set()
-
-        self._log.info("bridge.flush_buffer_start", buffer_size=len(self._event_buffer))
-        flushed = 0
-        just_added: set[str] = set()
-        while self._event_buffer:
-            event = self._event_buffer[0]
-            if not self._ws or self._ws.state != State.OPEN:
-                break
-            try:
-                await self._ws.send(json.dumps(event))
-                self._event_buffer.pop(0)
-                flushed += 1
-                # Track critical events sent from buffer as pending ACKs
-                if event.get("type") in CRITICAL_EVENT_TYPES and "ackId" in event:
-                    self._pending_acks[event["ackId"]] = event
-                    just_added.add(event["ackId"])
-            except Exception as e:
-                self._log.warn("bridge.flush_send_error", exc=e)
-                break
-
-        self._log.info(
-            "bridge.flush_buffer_complete",
-            flushed=flushed,
-            remaining=len(self._event_buffer),
-        )
-        return just_added
-
-    async def flush_pending_acks(self, skip_ack_ids: set[str] | None = None) -> None:
-        """Re-send unacknowledged critical events on a new WS connection.
-
-        Events stay pending until the DO sends an ACK command.
-
-        Args:
-            skip_ack_ids: ackIds to skip (already sent during
-                          ``flush_event_buffer`` on this same reconnect).
-        """
-        if not self._pending_acks:
-            return
-
-        self._log.info("bridge.flush_pending_acks_start", count=len(self._pending_acks))
-        resent = 0
-        for ack_id, event in list(self._pending_acks.items()):
-            if skip_ack_ids and ack_id in skip_ack_ids:
-                continue
-            if not self._ws or self._ws.state != State.OPEN:
-                break
-            try:
-                await self._ws.send(json.dumps(event))
-                resent += 1
-            except Exception as e:
-                self._log.warn("bridge.flush_pending_ack_error", ack_id=ack_id, exc=e)
-                break
-
-        self._log.info(
-            "bridge.flush_pending_acks_complete",
-            resent=resent,
-            total=len(self._pending_acks),
-        )
+            await self._drain_if_rebound(failed_ws=ws)
 
     def acknowledge(self, ack_id: str) -> bool:
         """Drop a pending critical event the control plane confirmed.
@@ -171,6 +116,82 @@ class BufferedEventForwarder:
             del self._pending_acks[ack_id]
             return True
         return False
+
+    async def _drain_if_rebound(self, *, failed_ws: ClientConnection) -> None:
+        """Deliver events stranded by a send that outlived its connection.
+
+        A wedged send can fail only minutes later, after a replacement
+        connection was already bound and its recovery flush ran; the failed
+        event would then sit buffered until a reconnect that may never come.
+        If a different open connection is bound by the time the failure
+        surfaces, drain the buffer through it immediately. A drain failure
+        just leaves events buffered — no retries.
+        """
+        current = self._ws
+        if current is not None and current is not failed_ws and current.state == State.OPEN:
+            await self._flush_buffer()
+
+    async def _flush_buffer(self) -> None:
+        """Flush buffered events over the currently bound connection."""
+        if not self._event_buffer:
+            return
+
+        self._log.info("bridge.flush_buffer_start", buffer_size=len(self._event_buffer))
+        flushed = 0
+        while self._event_buffer:
+            event = self._event_buffer[0]
+            ws = self._ws
+            if not ws or ws.state != State.OPEN:
+                break
+            try:
+                await ws.send(json.dumps(event))
+                self._event_buffer.pop(0)
+                flushed += 1
+                # Track critical events sent from buffer as pending ACKs
+                if event.get("type") in CRITICAL_EVENT_TYPES and "ackId" in event:
+                    self._pending_acks[event["ackId"]] = event
+            except Exception as e:
+                self._log.warn("bridge.flush_send_error", exc=e)
+                break
+
+        self._log.info(
+            "bridge.flush_buffer_complete",
+            flushed=flushed,
+            remaining=len(self._event_buffer),
+        )
+
+    async def _resend_pending(self, ack_ids: list[str]) -> None:
+        """Re-send unacknowledged critical events on a new WS connection.
+
+        Only the given ackIds are considered (the ones pending before the
+        buffer flush), and only if they are still pending. Events stay
+        pending until the DO sends an ACK command.
+        """
+        to_resend = [ack_id for ack_id in ack_ids if ack_id in self._pending_acks]
+        if not to_resend:
+            return
+
+        self._log.info("bridge.flush_pending_acks_start", count=len(to_resend))
+        resent = 0
+        for ack_id in to_resend:
+            event = self._pending_acks.get(ack_id)
+            if event is None:
+                continue
+            ws = self._ws
+            if not ws or ws.state != State.OPEN:
+                break
+            try:
+                await ws.send(json.dumps(event))
+                resent += 1
+            except Exception as e:
+                self._log.warn("bridge.flush_pending_ack_error", ack_id=ack_id, exc=e)
+                break
+
+        self._log.info(
+            "bridge.flush_pending_acks_complete",
+            resent=resent,
+            total=len(self._pending_acks),
+        )
 
     def _buffer_event(self, event: dict[str, Any]) -> None:
         """Buffer an event for later delivery after WS reconnect."""

--- a/packages/sandbox-runtime/tests/test_bridge_ack.py
+++ b/packages/sandbox-runtime/tests/test_bridge_ack.py
@@ -12,6 +12,7 @@ import pytest
 from websockets import State
 
 from sandbox_runtime.bridge import AgentBridge
+from sandbox_runtime.event_forwarder import BufferedEventForwarder
 
 
 @pytest.fixture
@@ -40,12 +41,12 @@ class TestAckIdGeneration:
 
     def test_deterministic_ack_id_with_message_id(self):
         event = {"type": "execution_complete", "messageId": "msg-1"}
-        ack_id = AgentBridge._make_ack_id(event)
+        ack_id = BufferedEventForwarder._make_ack_id(event)
         assert ack_id == "execution_complete:msg-1"
 
     def test_random_ack_id_without_message_id(self):
         event = {"type": "snapshot_ready"}
-        ack_id = AgentBridge._make_ack_id(event)
+        ack_id = BufferedEventForwarder._make_ack_id(event)
         assert ack_id.startswith("snapshot_ready:")
         # Random suffix should be 16 hex chars
         suffix = ack_id.split(":", 1)[1]
@@ -54,7 +55,7 @@ class TestAckIdGeneration:
 
     def test_random_ack_ids_are_unique(self):
         event = {"type": "snapshot_ready"}
-        ids = {AgentBridge._make_ack_id(event) for _ in range(10)}
+        ids = {BufferedEventForwarder._make_ack_id(event) for _ in range(10)}
         assert len(ids) == 10
 
 
@@ -64,7 +65,7 @@ class TestSendCriticalEvent:
     @pytest.mark.asyncio
     async def test_send_critical_event_attaches_ack_id(self, bridge: AgentBridge):
         ws = _open_ws()
-        bridge.ws = ws
+        bridge.event_forwarder.bind(ws)
 
         await bridge._send_event(
             {"type": "execution_complete", "messageId": "msg-1", "success": True}
@@ -77,44 +78,47 @@ class TestSendCriticalEvent:
     @pytest.mark.asyncio
     async def test_send_critical_event_tracked_in_pending_acks(self, bridge: AgentBridge):
         ws = _open_ws()
-        bridge.ws = ws
+        bridge.event_forwarder.bind(ws)
 
         await bridge._send_event(
             {"type": "execution_complete", "messageId": "msg-1", "success": True}
         )
 
-        assert "execution_complete:msg-1" in bridge._pending_acks
-        assert bridge._pending_acks["execution_complete:msg-1"]["type"] == "execution_complete"
+        assert "execution_complete:msg-1" in bridge.event_forwarder._pending_acks
+        assert (
+            bridge.event_forwarder._pending_acks["execution_complete:msg-1"]["type"]
+            == "execution_complete"
+        )
 
     @pytest.mark.asyncio
     async def test_send_non_critical_event_no_ack_id(self, bridge: AgentBridge):
         ws = _open_ws()
-        bridge.ws = ws
+        bridge.event_forwarder.bind(ws)
 
         await bridge._send_event({"type": "token", "content": "hello", "messageId": "msg-1"})
 
         sent_data = json.loads(ws.send.call_args[0][0])
         assert "ackId" not in sent_data
-        assert len(bridge._pending_acks) == 0
+        assert len(bridge.event_forwarder._pending_acks) == 0
 
     @pytest.mark.asyncio
     async def test_send_failure_buffers_not_pending(self, bridge: AgentBridge):
         ws = _open_ws()
         ws.send = AsyncMock(side_effect=ConnectionError("broken pipe"))
-        bridge.ws = ws
+        bridge.event_forwarder.bind(ws)
 
         await bridge._send_event(
             {"type": "execution_complete", "messageId": "msg-1", "success": True}
         )
 
         # Should be in buffer, NOT in pending_acks
-        assert len(bridge._event_buffer) == 1
-        assert len(bridge._pending_acks) == 0
+        assert len(bridge.event_forwarder._event_buffer) == 1
+        assert len(bridge.event_forwarder._pending_acks) == 0
 
     @pytest.mark.asyncio
     async def test_existing_ack_id_not_overwritten(self, bridge: AgentBridge):
         ws = _open_ws()
-        bridge.ws = ws
+        bridge.event_forwarder.bind(ws)
 
         await bridge._send_event(
             {
@@ -134,7 +138,7 @@ class TestAckCommand:
 
     @pytest.mark.asyncio
     async def test_ack_command_clears_pending(self, bridge: AgentBridge):
-        bridge._pending_acks["execution_complete:msg-1"] = {
+        bridge.event_forwarder._pending_acks["execution_complete:msg-1"] = {
             "type": "execution_complete",
             "messageId": "msg-1",
             "ackId": "execution_complete:msg-1",
@@ -142,11 +146,11 @@ class TestAckCommand:
 
         await bridge._handle_command({"type": "ack", "ackId": "execution_complete:msg-1"})
 
-        assert "execution_complete:msg-1" not in bridge._pending_acks
+        assert "execution_complete:msg-1" not in bridge.event_forwarder._pending_acks
 
     @pytest.mark.asyncio
     async def test_ack_command_unknown_id_ignored(self, bridge: AgentBridge):
-        bridge._pending_acks["execution_complete:msg-1"] = {
+        bridge.event_forwarder._pending_acks["execution_complete:msg-1"] = {
             "type": "execution_complete",
             "ackId": "execution_complete:msg-1",
         }
@@ -154,18 +158,18 @@ class TestAckCommand:
         # ACK for a different ID should not affect existing entries
         await bridge._handle_command({"type": "ack", "ackId": "execution_complete:msg-999"})
 
-        assert "execution_complete:msg-1" in bridge._pending_acks
+        assert "execution_complete:msg-1" in bridge.event_forwarder._pending_acks
 
     @pytest.mark.asyncio
     async def test_ack_command_missing_ack_id_ignored(self, bridge: AgentBridge):
-        bridge._pending_acks["execution_complete:msg-1"] = {
+        bridge.event_forwarder._pending_acks["execution_complete:msg-1"] = {
             "type": "execution_complete",
             "ackId": "execution_complete:msg-1",
         }
 
         await bridge._handle_command({"type": "ack"})
 
-        assert len(bridge._pending_acks) == 1
+        assert len(bridge.event_forwarder._pending_acks) == 1
 
 
 class TestFlushPendingAcks:
@@ -173,7 +177,7 @@ class TestFlushPendingAcks:
 
     @pytest.mark.asyncio
     async def test_flush_pending_acks_resends(self, bridge: AgentBridge):
-        bridge._pending_acks = {
+        bridge.event_forwarder._pending_acks = {
             "execution_complete:msg-1": {
                 "type": "execution_complete",
                 "messageId": "msg-1",
@@ -187,20 +191,20 @@ class TestFlushPendingAcks:
         }
 
         ws = _open_ws()
-        bridge.ws = ws
+        bridge.event_forwarder.bind(ws)
 
-        await bridge._flush_pending_acks()
+        await bridge.event_forwarder.flush_pending_acks()
 
         assert ws.send.call_count == 2
         # Events should still be in _pending_acks (not removed until ACK arrives)
-        assert len(bridge._pending_acks) == 2
+        assert len(bridge.event_forwarder._pending_acks) == 2
 
     @pytest.mark.asyncio
     async def test_flush_pending_acks_noop_when_empty(self, bridge: AgentBridge):
         ws = _open_ws()
-        bridge.ws = ws
+        bridge.event_forwarder.bind(ws)
 
-        await bridge._flush_pending_acks()
+        await bridge.event_forwarder.flush_pending_acks()
 
         ws.send.assert_not_called()
 
@@ -214,20 +218,20 @@ class TestFlushPendingAcks:
             if call_count >= 2:
                 raise ConnectionError("broken")
 
-        bridge._pending_acks = {
+        bridge.event_forwarder._pending_acks = {
             "a:1": {"type": "execution_complete", "ackId": "a:1"},
             "b:2": {"type": "error", "ackId": "b:2"},
         }
 
         ws = _open_ws()
         ws.send = fail_on_second
-        bridge.ws = ws
+        bridge.event_forwarder.bind(ws)
 
-        await bridge._flush_pending_acks()
+        await bridge.event_forwarder.flush_pending_acks()
 
         # Both should still be in pending (first sent OK, second failed, but
         # neither removed — removal only happens on ACK command)
-        assert len(bridge._pending_acks) == 2
+        assert len(bridge.event_forwarder._pending_acks) == 2
 
 
 class TestBufferFlushAddsToPending:
@@ -235,7 +239,7 @@ class TestBufferFlushAddsToPending:
 
     @pytest.mark.asyncio
     async def test_buffer_flush_adds_critical_to_pending_acks(self, bridge: AgentBridge):
-        bridge._event_buffer = [
+        bridge.event_forwarder._event_buffer = [
             {
                 "type": "execution_complete",
                 "messageId": "msg-1",
@@ -245,28 +249,28 @@ class TestBufferFlushAddsToPending:
         ]
 
         ws = _open_ws()
-        bridge.ws = ws
+        bridge.event_forwarder.bind(ws)
 
-        just_added = await bridge._flush_event_buffer()
+        just_added = await bridge.event_forwarder.flush_event_buffer()
 
-        assert len(bridge._event_buffer) == 0
+        assert len(bridge.event_forwarder._event_buffer) == 0
         # Only the critical event should be in pending_acks
-        assert "execution_complete:msg-1" in bridge._pending_acks
-        assert len(bridge._pending_acks) == 1
+        assert "execution_complete:msg-1" in bridge.event_forwarder._pending_acks
+        assert len(bridge.event_forwarder._pending_acks) == 1
         # Return value should contain the ackId just added
         assert just_added == {"execution_complete:msg-1"}
 
     @pytest.mark.asyncio
     async def test_buffer_flush_returns_empty_set_for_non_critical(self, bridge: AgentBridge):
-        bridge._event_buffer = [{"type": "token", "content": "hello"}]
+        bridge.event_forwarder._event_buffer = [{"type": "token", "content": "hello"}]
 
         ws = _open_ws()
-        bridge.ws = ws
+        bridge.event_forwarder.bind(ws)
 
-        just_added = await bridge._flush_event_buffer()
+        just_added = await bridge.event_forwarder.flush_event_buffer()
 
         assert just_added == set()
-        assert len(bridge._pending_acks) == 0
+        assert len(bridge.event_forwarder._pending_acks) == 0
 
 
 class TestFlushPendingAcksSkip:
@@ -275,7 +279,7 @@ class TestFlushPendingAcksSkip:
     @pytest.mark.asyncio
     async def test_skip_ack_ids_prevents_double_send(self, bridge: AgentBridge):
         """Events just flushed from buffer should not be re-sent by pending ack flush."""
-        bridge._pending_acks = {
+        bridge.event_forwarder._pending_acks = {
             "execution_complete:msg-1": {
                 "type": "execution_complete",
                 "ackId": "execution_complete:msg-1",
@@ -287,17 +291,17 @@ class TestFlushPendingAcksSkip:
         }
 
         ws = _open_ws()
-        bridge.ws = ws
+        bridge.event_forwarder.bind(ws)
 
         # Simulate: msg-1 was just flushed from buffer, msg-2 was from a prior send
-        await bridge._flush_pending_acks(skip_ack_ids={"execution_complete:msg-1"})
+        await bridge.event_forwarder.flush_pending_acks(skip_ack_ids={"execution_complete:msg-1"})
 
         # Only msg-2 should have been sent
         assert ws.send.call_count == 1
         sent_data = json.loads(ws.send.call_args[0][0])
         assert sent_data["ackId"] == "error:msg-2"
         # Both should still be in _pending_acks
-        assert len(bridge._pending_acks) == 2
+        assert len(bridge.event_forwarder._pending_acks) == 2
 
 
 if __name__ == "__main__":

--- a/packages/sandbox-runtime/tests/test_bridge_ack.py
+++ b/packages/sandbox-runtime/tests/test_bridge_ack.py
@@ -1,8 +1,10 @@
 """
-Unit tests for the bridge ACK mechanism.
+Bridge boundary tests for event sending and the ACK command.
 
-Tests that critical events get ackId attached, are tracked in _pending_acks,
-cleared on ACK command, and re-sent on reconnect via _flush_pending_acks.
+Forwarder-level mechanics (ackId generation, pending tracking, bind-time
+backlog recovery) are covered in test_event_forwarder.py; these tests cover
+only the bridge's wiring into BufferedEventForwarder: `_send_event`
+delegation and the `ack` command routing into `acknowledge`.
 """
 
 import json
@@ -12,7 +14,6 @@ import pytest
 from websockets import State
 
 from sandbox_runtime.bridge import AgentBridge
-from sandbox_runtime.event_forwarder import BufferedEventForwarder
 
 
 @pytest.fixture
@@ -36,272 +37,56 @@ def _open_ws() -> MagicMock:
     return ws
 
 
-class TestAckIdGeneration:
-    """Tests for _make_ack_id deterministic ID generation."""
-
-    def test_deterministic_ack_id_with_message_id(self):
-        event = {"type": "execution_complete", "messageId": "msg-1"}
-        ack_id = BufferedEventForwarder._make_ack_id(event)
-        assert ack_id == "execution_complete:msg-1"
-
-    def test_random_ack_id_without_message_id(self):
-        event = {"type": "snapshot_ready"}
-        ack_id = BufferedEventForwarder._make_ack_id(event)
-        assert ack_id.startswith("snapshot_ready:")
-        # Random suffix should be 16 hex chars
-        suffix = ack_id.split(":", 1)[1]
-        assert len(suffix) == 16
-        int(suffix, 16)  # Should not raise
-
-    def test_random_ack_ids_are_unique(self):
-        event = {"type": "snapshot_ready"}
-        ids = {BufferedEventForwarder._make_ack_id(event) for _ in range(10)}
-        assert len(ids) == 10
+async def _send_critical(bridge: AgentBridge, message_id: str) -> MagicMock:
+    """Send a critical event through the bridge so its ACK is pending."""
+    ws = _open_ws()
+    await bridge.event_forwarder.bind(ws)
+    await bridge._send_event(
+        {"type": "execution_complete", "messageId": message_id, "success": True}
+    )
+    return ws
 
 
-class TestSendCriticalEvent:
-    """Tests that _send_event attaches ackId and tracks critical events."""
+class TestSendEventDelegation:
+    """_send_event routes through the forwarder, which stamps identity."""
 
     @pytest.mark.asyncio
-    async def test_send_critical_event_attaches_ack_id(self, bridge: AgentBridge):
-        ws = _open_ws()
-        bridge.event_forwarder.bind(ws)
-
-        await bridge._send_event(
-            {"type": "execution_complete", "messageId": "msg-1", "success": True}
-        )
+    async def test_send_event_delegates_to_forwarder(self, bridge: AgentBridge):
+        ws = await _send_critical(bridge, "msg-1")
 
         sent_data = json.loads(ws.send.call_args[0][0])
-        assert "ackId" in sent_data
+        assert sent_data["sandboxId"] == "test-sandbox"
         assert sent_data["ackId"] == "execution_complete:msg-1"
-
-    @pytest.mark.asyncio
-    async def test_send_critical_event_tracked_in_pending_acks(self, bridge: AgentBridge):
-        ws = _open_ws()
-        bridge.event_forwarder.bind(ws)
-
-        await bridge._send_event(
-            {"type": "execution_complete", "messageId": "msg-1", "success": True}
-        )
-
-        assert "execution_complete:msg-1" in bridge.event_forwarder._pending_acks
-        assert (
-            bridge.event_forwarder._pending_acks["execution_complete:msg-1"]["type"]
-            == "execution_complete"
-        )
-
-    @pytest.mark.asyncio
-    async def test_send_non_critical_event_no_ack_id(self, bridge: AgentBridge):
-        ws = _open_ws()
-        bridge.event_forwarder.bind(ws)
-
-        await bridge._send_event({"type": "token", "content": "hello", "messageId": "msg-1"})
-
-        sent_data = json.loads(ws.send.call_args[0][0])
-        assert "ackId" not in sent_data
-        assert len(bridge.event_forwarder._pending_acks) == 0
-
-    @pytest.mark.asyncio
-    async def test_send_failure_buffers_not_pending(self, bridge: AgentBridge):
-        ws = _open_ws()
-        ws.send = AsyncMock(side_effect=ConnectionError("broken pipe"))
-        bridge.event_forwarder.bind(ws)
-
-        await bridge._send_event(
-            {"type": "execution_complete", "messageId": "msg-1", "success": True}
-        )
-
-        # Should be in buffer, NOT in pending_acks
-        assert len(bridge.event_forwarder._event_buffer) == 1
-        assert len(bridge.event_forwarder._pending_acks) == 0
-
-    @pytest.mark.asyncio
-    async def test_existing_ack_id_not_overwritten(self, bridge: AgentBridge):
-        ws = _open_ws()
-        bridge.event_forwarder.bind(ws)
-
-        await bridge._send_event(
-            {
-                "type": "execution_complete",
-                "messageId": "msg-1",
-                "success": True,
-                "ackId": "custom:id",
-            }
-        )
-
-        sent_data = json.loads(ws.send.call_args[0][0])
-        assert sent_data["ackId"] == "custom:id"
 
 
 class TestAckCommand:
-    """Tests for handling ACK commands from control plane."""
+    """The `ack` command from the control plane clears the pending event."""
 
     @pytest.mark.asyncio
     async def test_ack_command_clears_pending(self, bridge: AgentBridge):
-        bridge.event_forwarder._pending_acks["execution_complete:msg-1"] = {
-            "type": "execution_complete",
-            "messageId": "msg-1",
-            "ackId": "execution_complete:msg-1",
-        }
+        await _send_critical(bridge, "msg-1")
 
         await bridge._handle_command({"type": "ack", "ackId": "execution_complete:msg-1"})
 
-        assert "execution_complete:msg-1" not in bridge.event_forwarder._pending_acks
+        # Already cleared: a second acknowledge reports not-found
+        assert bridge.event_forwarder.acknowledge("execution_complete:msg-1") is False
 
     @pytest.mark.asyncio
     async def test_ack_command_unknown_id_ignored(self, bridge: AgentBridge):
-        bridge.event_forwarder._pending_acks["execution_complete:msg-1"] = {
-            "type": "execution_complete",
-            "ackId": "execution_complete:msg-1",
-        }
+        await _send_critical(bridge, "msg-1")
 
         # ACK for a different ID should not affect existing entries
         await bridge._handle_command({"type": "ack", "ackId": "execution_complete:msg-999"})
 
-        assert "execution_complete:msg-1" in bridge.event_forwarder._pending_acks
+        assert bridge.event_forwarder.acknowledge("execution_complete:msg-1") is True
 
     @pytest.mark.asyncio
     async def test_ack_command_missing_ack_id_ignored(self, bridge: AgentBridge):
-        bridge.event_forwarder._pending_acks["execution_complete:msg-1"] = {
-            "type": "execution_complete",
-            "ackId": "execution_complete:msg-1",
-        }
+        await _send_critical(bridge, "msg-1")
 
         await bridge._handle_command({"type": "ack"})
 
-        assert len(bridge.event_forwarder._pending_acks) == 1
-
-
-class TestFlushPendingAcks:
-    """Tests for _flush_pending_acks re-sending on new WS."""
-
-    @pytest.mark.asyncio
-    async def test_flush_pending_acks_resends(self, bridge: AgentBridge):
-        bridge.event_forwarder._pending_acks = {
-            "execution_complete:msg-1": {
-                "type": "execution_complete",
-                "messageId": "msg-1",
-                "ackId": "execution_complete:msg-1",
-            },
-            "error:msg-2": {
-                "type": "error",
-                "messageId": "msg-2",
-                "ackId": "error:msg-2",
-            },
-        }
-
-        ws = _open_ws()
-        bridge.event_forwarder.bind(ws)
-
-        await bridge.event_forwarder.flush_pending_acks()
-
-        assert ws.send.call_count == 2
-        # Events should still be in _pending_acks (not removed until ACK arrives)
-        assert len(bridge.event_forwarder._pending_acks) == 2
-
-    @pytest.mark.asyncio
-    async def test_flush_pending_acks_noop_when_empty(self, bridge: AgentBridge):
-        ws = _open_ws()
-        bridge.event_forwarder.bind(ws)
-
-        await bridge.event_forwarder.flush_pending_acks()
-
-        ws.send.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_flush_pending_acks_stops_on_ws_failure(self, bridge: AgentBridge):
-        call_count = 0
-
-        async def fail_on_second(data):
-            nonlocal call_count
-            call_count += 1
-            if call_count >= 2:
-                raise ConnectionError("broken")
-
-        bridge.event_forwarder._pending_acks = {
-            "a:1": {"type": "execution_complete", "ackId": "a:1"},
-            "b:2": {"type": "error", "ackId": "b:2"},
-        }
-
-        ws = _open_ws()
-        ws.send = fail_on_second
-        bridge.event_forwarder.bind(ws)
-
-        await bridge.event_forwarder.flush_pending_acks()
-
-        # Both should still be in pending (first sent OK, second failed, but
-        # neither removed — removal only happens on ACK command)
-        assert len(bridge.event_forwarder._pending_acks) == 2
-
-
-class TestBufferFlushAddsToPending:
-    """Tests that flushing buffer events adds critical ones to _pending_acks."""
-
-    @pytest.mark.asyncio
-    async def test_buffer_flush_adds_critical_to_pending_acks(self, bridge: AgentBridge):
-        bridge.event_forwarder._event_buffer = [
-            {
-                "type": "execution_complete",
-                "messageId": "msg-1",
-                "ackId": "execution_complete:msg-1",
-            },
-            {"type": "token", "content": "hello"},
-        ]
-
-        ws = _open_ws()
-        bridge.event_forwarder.bind(ws)
-
-        just_added = await bridge.event_forwarder.flush_event_buffer()
-
-        assert len(bridge.event_forwarder._event_buffer) == 0
-        # Only the critical event should be in pending_acks
-        assert "execution_complete:msg-1" in bridge.event_forwarder._pending_acks
-        assert len(bridge.event_forwarder._pending_acks) == 1
-        # Return value should contain the ackId just added
-        assert just_added == {"execution_complete:msg-1"}
-
-    @pytest.mark.asyncio
-    async def test_buffer_flush_returns_empty_set_for_non_critical(self, bridge: AgentBridge):
-        bridge.event_forwarder._event_buffer = [{"type": "token", "content": "hello"}]
-
-        ws = _open_ws()
-        bridge.event_forwarder.bind(ws)
-
-        just_added = await bridge.event_forwarder.flush_event_buffer()
-
-        assert just_added == set()
-        assert len(bridge.event_forwarder._pending_acks) == 0
-
-
-class TestFlushPendingAcksSkip:
-    """Tests that _flush_pending_acks skips ackIds from buffer flush."""
-
-    @pytest.mark.asyncio
-    async def test_skip_ack_ids_prevents_double_send(self, bridge: AgentBridge):
-        """Events just flushed from buffer should not be re-sent by pending ack flush."""
-        bridge.event_forwarder._pending_acks = {
-            "execution_complete:msg-1": {
-                "type": "execution_complete",
-                "ackId": "execution_complete:msg-1",
-            },
-            "error:msg-2": {
-                "type": "error",
-                "ackId": "error:msg-2",
-            },
-        }
-
-        ws = _open_ws()
-        bridge.event_forwarder.bind(ws)
-
-        # Simulate: msg-1 was just flushed from buffer, msg-2 was from a prior send
-        await bridge.event_forwarder.flush_pending_acks(skip_ack_ids={"execution_complete:msg-1"})
-
-        # Only msg-2 should have been sent
-        assert ws.send.call_count == 1
-        sent_data = json.loads(ws.send.call_args[0][0])
-        assert sent_data["ackId"] == "error:msg-2"
-        # Both should still be in _pending_acks
-        assert len(bridge.event_forwarder._pending_acks) == 2
+        assert bridge.event_forwarder.acknowledge("execution_complete:msg-1") is True
 
 
 if __name__ == "__main__":

--- a/packages/sandbox-runtime/tests/test_bridge_event_buffer.py
+++ b/packages/sandbox-runtime/tests/test_bridge_event_buffer.py
@@ -95,24 +95,24 @@ class TestEventBuffering:
 
         await bridge._send_event({"type": "token", "content": "hello"})
 
-        assert len(bridge._event_buffer) == 1
-        assert bridge._event_buffer[0]["type"] == "token"
-        assert bridge._event_buffer[0]["content"] == "hello"
+        assert len(bridge.event_forwarder._event_buffer) == 1
+        assert bridge.event_forwarder._event_buffer[0]["type"] == "token"
+        assert bridge.event_forwarder._event_buffer[0]["content"] == "hello"
         # sandboxId and timestamp should be stamped
-        assert bridge._event_buffer[0]["sandboxId"] == "test-sandbox"
-        assert "timestamp" in bridge._event_buffer[0]
+        assert bridge.event_forwarder._event_buffer[0]["sandboxId"] == "test-sandbox"
+        assert "timestamp" in bridge.event_forwarder._event_buffer[0]
 
     @pytest.mark.asyncio
     async def test_send_event_buffers_when_ws_not_open(self, bridge: AgentBridge):
         """Events should be buffered when WS exists but is not OPEN."""
         mock_ws = MagicMock()
         mock_ws.state = State.CLOSED
-        bridge.ws = mock_ws
+        bridge.event_forwarder.bind(mock_ws)
 
         await bridge._send_event({"type": "execution_complete", "messageId": "msg-1"})
 
-        assert len(bridge._event_buffer) == 1
-        assert bridge._event_buffer[0]["type"] == "execution_complete"
+        assert len(bridge.event_forwarder._event_buffer) == 1
+        assert bridge.event_forwarder._event_buffer[0]["type"] == "execution_complete"
 
     @pytest.mark.asyncio
     async def test_send_event_buffers_on_send_exception(self, bridge: AgentBridge):
@@ -120,29 +120,29 @@ class TestEventBuffering:
         mock_ws = MagicMock()
         mock_ws.state = State.OPEN
         mock_ws.send = AsyncMock(side_effect=ConnectionError("broken pipe"))
-        bridge.ws = mock_ws
+        bridge.event_forwarder.bind(mock_ws)
 
         await bridge._send_event({"type": "token", "content": "data"})
 
-        assert len(bridge._event_buffer) == 1
-        assert bridge._event_buffer[0]["type"] == "token"
+        assert len(bridge.event_forwarder._event_buffer) == 1
+        assert bridge.event_forwarder._event_buffer[0]["type"] == "token"
 
     def test_buffer_overflow_evicts_non_critical_first(self, bridge: AgentBridge):
         """When buffer is full, non-critical events should be evicted before critical ones."""
         # Fill buffer with a mix of critical and non-critical events
-        bridge._event_buffer = [
+        bridge.event_forwarder._event_buffer = [
             {"type": "execution_complete", "messageId": "msg-1"},  # critical
             {"type": "token", "content": "a"},  # non-critical
             {"type": "error", "messageId": "msg-2"},  # critical
         ]
-        bridge.MAX_EVENT_BUFFER_SIZE = 3
+        bridge.event_forwarder._max_buffer_size = 3
 
-        bridge._buffer_event({"type": "snapshot_ready"})
+        bridge.event_forwarder._buffer_event({"type": "snapshot_ready"})
 
         # Buffer should still be size 3 (one evicted, one added)
-        assert len(bridge._event_buffer) == 3
+        assert len(bridge.event_forwarder._event_buffer) == 3
         # The non-critical "token" event should have been evicted
-        types = [e["type"] for e in bridge._event_buffer]
+        types = [e["type"] for e in bridge.event_forwarder._event_buffer]
         assert "token" not in types
         assert "execution_complete" in types
         assert "error" in types
@@ -150,17 +150,17 @@ class TestEventBuffering:
 
     def test_buffer_overflow_evicts_oldest_critical_if_all_critical(self, bridge: AgentBridge):
         """When all events are critical, oldest gets evicted."""
-        bridge._event_buffer = [
+        bridge.event_forwarder._event_buffer = [
             {"type": "execution_complete", "messageId": "msg-1"},
             {"type": "error", "messageId": "msg-2"},
         ]
-        bridge.MAX_EVENT_BUFFER_SIZE = 2
+        bridge.event_forwarder._max_buffer_size = 2
 
-        bridge._buffer_event({"type": "push_complete"})
+        bridge.event_forwarder._buffer_event({"type": "push_complete"})
 
-        assert len(bridge._event_buffer) == 2
+        assert len(bridge.event_forwarder._event_buffer) == 2
         # Oldest critical (execution_complete) should be evicted
-        types = [e["type"] for e in bridge._event_buffer]
+        types = [e["type"] for e in bridge.event_forwarder._event_buffer]
         assert "execution_complete" not in types
         assert "error" in types
         assert "push_complete" in types
@@ -176,16 +176,16 @@ class TestEventFlush:
         mock_ws.state = State.OPEN
         sent_data: list[str] = []
         mock_ws.send = AsyncMock(side_effect=lambda data: sent_data.append(data))
-        bridge.ws = mock_ws
+        bridge.event_forwarder.bind(mock_ws)
 
-        bridge._event_buffer = [
+        bridge.event_forwarder._event_buffer = [
             {"type": "token", "content": "a"},
             {"type": "execution_complete", "messageId": "msg-1"},
         ]
 
-        await bridge._flush_event_buffer()
+        await bridge.event_forwarder.flush_event_buffer()
 
-        assert len(bridge._event_buffer) == 0
+        assert len(bridge.event_forwarder._event_buffer) == 0
         assert len(sent_data) == 2
         assert json.loads(sent_data[0])["type"] == "token"
         assert json.loads(sent_data[1])["type"] == "execution_complete"
@@ -204,27 +204,27 @@ class TestEventFlush:
                 raise ConnectionError("broken")
 
         mock_ws.send = flaky_send
-        bridge.ws = mock_ws
+        bridge.event_forwarder.bind(mock_ws)
 
-        bridge._event_buffer = [
+        bridge.event_forwarder._event_buffer = [
             {"type": "token", "content": "a"},
             {"type": "token", "content": "b"},
             {"type": "execution_complete", "messageId": "msg-1"},
         ]
 
-        await bridge._flush_event_buffer()
+        await bridge.event_forwarder.flush_event_buffer()
 
         # First event sent successfully, second failed
-        assert len(bridge._event_buffer) == 2
-        assert bridge._event_buffer[0]["content"] == "b"
-        assert bridge._event_buffer[1]["type"] == "execution_complete"
+        assert len(bridge.event_forwarder._event_buffer) == 2
+        assert bridge.event_forwarder._event_buffer[0]["content"] == "b"
+        assert bridge.event_forwarder._event_buffer[1]["type"] == "execution_complete"
 
     @pytest.mark.asyncio
     async def test_flush_noop_when_buffer_empty(self, bridge: AgentBridge):
         """Flushing an empty buffer should be a no-op."""
-        assert len(bridge._event_buffer) == 0
-        await bridge._flush_event_buffer()
-        assert len(bridge._event_buffer) == 0
+        assert len(bridge.event_forwarder._event_buffer) == 0
+        await bridge.event_forwarder.flush_event_buffer()
+        assert len(bridge.event_forwarder._event_buffer) == 0
 
 
 class TestPromptTaskDecoupling:
@@ -301,19 +301,19 @@ class TestPromptTaskDecoupling:
             }
         )
 
-        assert len(bridge._event_buffer) == 1
-        assert bridge._event_buffer[0]["type"] == "execution_complete"
+        assert len(bridge.event_forwarder._event_buffer) == 1
+        assert bridge.event_forwarder._event_buffer[0]["type"] == "execution_complete"
 
         # Simulate reconnect
         mock_ws = MagicMock()
         mock_ws.state = State.OPEN
         sent_data: list[str] = []
         mock_ws.send = AsyncMock(side_effect=lambda data: sent_data.append(data))
-        bridge.ws = mock_ws
+        bridge.event_forwarder.bind(mock_ws)
 
-        await bridge._flush_event_buffer()
+        await bridge.event_forwarder.flush_event_buffer()
 
-        assert len(bridge._event_buffer) == 0
+        assert len(bridge.event_forwarder._event_buffer) == 0
         assert len(sent_data) == 1
         parsed = json.loads(sent_data[0])
         assert parsed["type"] == "execution_complete"

--- a/packages/sandbox-runtime/tests/test_bridge_event_buffer.py
+++ b/packages/sandbox-runtime/tests/test_bridge_event_buffer.py
@@ -1,8 +1,11 @@
 """
-Unit tests for bridge event buffer and prompt task decoupling.
+Bridge boundary tests for the event-forwarder connection lifecycle and
+prompt task decoupling.
 
-Tests that events are buffered when WS is unavailable, flushed on reconnect,
-and that prompt tasks survive WS disconnects.
+Forwarder-level buffering/flush/eviction mechanics are covered in
+test_event_forwarder.py; here we test only what the bridge owns: binding and
+unbinding the forwarder around a connection, delivery of events produced
+while disconnected, and prompt tasks surviving WS disconnects.
 """
 
 import asyncio
@@ -18,17 +21,14 @@ from tests.conftest import MockResponse
 
 
 class MockHttpClient:
-    """Mock HTTP client for event buffer tests."""
+    """Mock HTTP client for bridge lifecycle tests."""
 
     def __init__(self):
         self.post_responses: list[Any] = []
         self.get_responses: list[Any] = []
-        self.sse_events: list[str] = []
-        self._post_call_count = 0
         self.post_urls: list[str] = []
 
     async def post(self, url: str, json: dict | None = None, timeout: float = 30.0) -> Any:
-        self._post_call_count += 1
         self.post_urls.append(url)
         if self.post_responses:
             return self.post_responses.pop(0)
@@ -39,36 +39,39 @@ class MockHttpClient:
             return self.get_responses.pop(0)
         return MockResponse(200, [])
 
-    def stream(self, method: str, url: str, timeout: Any = None):
-        return MockSSEResponse(self.sse_events)
-
     async def aclose(self):
         pass
 
 
-class MockSSEResponse:
-    """Mock SSE streaming response."""
+class FakeWs:
+    """Fake websocket connection: records sends, yields no inbound messages."""
 
-    def __init__(self, events: list[str], status_code: int = 200):
-        self.status_code = status_code
-        self._events = events
+    def __init__(self):
+        self.state = State.OPEN
+        self.sent: list[str] = []
+        self.close_code = 1000
 
-    async def aiter_text(self):
-        for event in self._events:
-            yield event
-            await asyncio.sleep(0)
+    async def send(self, data: str) -> None:
+        self.sent.append(data)
 
-    async def __aenter__(self):
+    def __aiter__(self):
         return self
 
-    async def __aexit__(self, *args):
-        pass
+    async def __anext__(self):
+        raise StopAsyncIteration
 
 
-def create_sse_event(event_type: str, properties: dict) -> str:
-    """Create an SSE event string."""
-    data = {"type": event_type, "properties": properties}
-    return f"data: {json.dumps(data)}\n\n"
+class ConnectionContext:
+    """Async context manager standing in for websockets.connect()."""
+
+    def __init__(self, ws: FakeWs):
+        self.ws = ws
+
+    async def __aenter__(self) -> FakeWs:
+        return self.ws
+
+    async def __aexit__(self, *_args) -> bool:
+        return False
 
 
 @pytest.fixture
@@ -85,146 +88,34 @@ def bridge() -> AgentBridge:
     return bridge
 
 
-class TestEventBuffering:
-    """Tests for event buffering when WS is unavailable."""
+class TestConnectionLifecycle:
+    """_connect_and_run binds the forwarder for the connection's lifetime."""
 
     @pytest.mark.asyncio
-    async def test_send_event_buffers_when_ws_none(self, bridge: AgentBridge):
-        """Events should be buffered, not dropped, when WS is None."""
-        bridge.ws = None
+    async def test_connect_binds_recovers_backlog_and_unbinds(
+        self, bridge: AgentBridge, monkeypatch
+    ):
+        ws = FakeWs()
+        monkeypatch.setattr(
+            "sandbox_runtime.bridge.websockets.connect",
+            lambda *_args, **_kwargs: ConnectionContext(ws),
+        )
 
-        await bridge._send_event({"type": "token", "content": "hello"})
-
-        assert len(bridge.event_forwarder._event_buffer) == 1
-        assert bridge.event_forwarder._event_buffer[0]["type"] == "token"
-        assert bridge.event_forwarder._event_buffer[0]["content"] == "hello"
-        # sandboxId and timestamp should be stamped
-        assert bridge.event_forwarder._event_buffer[0]["sandboxId"] == "test-sandbox"
-        assert "timestamp" in bridge.event_forwarder._event_buffer[0]
-
-    @pytest.mark.asyncio
-    async def test_send_event_buffers_when_ws_not_open(self, bridge: AgentBridge):
-        """Events should be buffered when WS exists but is not OPEN."""
-        mock_ws = MagicMock()
-        mock_ws.state = State.CLOSED
-        bridge.event_forwarder.bind(mock_ws)
-
+        # An event produced while disconnected waits in the forwarder
         await bridge._send_event({"type": "execution_complete", "messageId": "msg-1"})
 
-        assert len(bridge.event_forwarder._event_buffer) == 1
-        assert bridge.event_forwarder._event_buffer[0]["type"] == "execution_complete"
+        await bridge._connect_and_run()
 
-    @pytest.mark.asyncio
-    async def test_send_event_buffers_on_send_exception(self, bridge: AgentBridge):
-        """Events should be buffered when ws.send() throws."""
-        mock_ws = MagicMock()
-        mock_ws.state = State.OPEN
-        mock_ws.send = AsyncMock(side_effect=ConnectionError("broken pipe"))
-        bridge.event_forwarder.bind(mock_ws)
+        types = [json.loads(data)["type"] for data in ws.sent]
+        # bind() delivered the disconnected-era backlog, then the ready event
+        assert types[0] == "execution_complete"
+        assert "ready" in types
 
-        await bridge._send_event({"type": "token", "content": "data"})
-
-        assert len(bridge.event_forwarder._event_buffer) == 1
-        assert bridge.event_forwarder._event_buffer[0]["type"] == "token"
-
-    def test_buffer_overflow_evicts_non_critical_first(self, bridge: AgentBridge):
-        """When buffer is full, non-critical events should be evicted before critical ones."""
-        # Fill buffer with a mix of critical and non-critical events
-        bridge.event_forwarder._event_buffer = [
-            {"type": "execution_complete", "messageId": "msg-1"},  # critical
-            {"type": "token", "content": "a"},  # non-critical
-            {"type": "error", "messageId": "msg-2"},  # critical
-        ]
-        bridge.event_forwarder._max_buffer_size = 3
-
-        bridge.event_forwarder._buffer_event({"type": "snapshot_ready"})
-
-        # Buffer should still be size 3 (one evicted, one added)
-        assert len(bridge.event_forwarder._event_buffer) == 3
-        # The non-critical "token" event should have been evicted
-        types = [e["type"] for e in bridge.event_forwarder._event_buffer]
-        assert "token" not in types
-        assert "execution_complete" in types
-        assert "error" in types
-        assert "snapshot_ready" in types
-
-    def test_buffer_overflow_evicts_oldest_critical_if_all_critical(self, bridge: AgentBridge):
-        """When all events are critical, oldest gets evicted."""
-        bridge.event_forwarder._event_buffer = [
-            {"type": "execution_complete", "messageId": "msg-1"},
-            {"type": "error", "messageId": "msg-2"},
-        ]
-        bridge.event_forwarder._max_buffer_size = 2
-
-        bridge.event_forwarder._buffer_event({"type": "push_complete"})
-
-        assert len(bridge.event_forwarder._event_buffer) == 2
-        # Oldest critical (execution_complete) should be evicted
-        types = [e["type"] for e in bridge.event_forwarder._event_buffer]
-        assert "execution_complete" not in types
-        assert "error" in types
-        assert "push_complete" in types
-
-
-class TestEventFlush:
-    """Tests for flushing buffered events on reconnect."""
-
-    @pytest.mark.asyncio
-    async def test_flush_sends_all_and_clears_buffer(self, bridge: AgentBridge):
-        """Flushing should send all buffered events and clear the buffer."""
-        mock_ws = MagicMock()
-        mock_ws.state = State.OPEN
-        sent_data: list[str] = []
-        mock_ws.send = AsyncMock(side_effect=lambda data: sent_data.append(data))
-        bridge.event_forwarder.bind(mock_ws)
-
-        bridge.event_forwarder._event_buffer = [
-            {"type": "token", "content": "a"},
-            {"type": "execution_complete", "messageId": "msg-1"},
-        ]
-
-        await bridge.event_forwarder.flush_event_buffer()
-
-        assert len(bridge.event_forwarder._event_buffer) == 0
-        assert len(sent_data) == 2
-        assert json.loads(sent_data[0])["type"] == "token"
-        assert json.loads(sent_data[1])["type"] == "execution_complete"
-
-    @pytest.mark.asyncio
-    async def test_flush_stops_on_send_failure(self, bridge: AgentBridge):
-        """Flushing should stop when a send fails, keeping remaining events buffered."""
-        mock_ws = MagicMock()
-        mock_ws.state = State.OPEN
-        call_count = 0
-
-        async def flaky_send(data):
-            nonlocal call_count
-            call_count += 1
-            if call_count >= 2:
-                raise ConnectionError("broken")
-
-        mock_ws.send = flaky_send
-        bridge.event_forwarder.bind(mock_ws)
-
-        bridge.event_forwarder._event_buffer = [
-            {"type": "token", "content": "a"},
-            {"type": "token", "content": "b"},
-            {"type": "execution_complete", "messageId": "msg-1"},
-        ]
-
-        await bridge.event_forwarder.flush_event_buffer()
-
-        # First event sent successfully, second failed
-        assert len(bridge.event_forwarder._event_buffer) == 2
-        assert bridge.event_forwarder._event_buffer[0]["content"] == "b"
-        assert bridge.event_forwarder._event_buffer[1]["type"] == "execution_complete"
-
-    @pytest.mark.asyncio
-    async def test_flush_noop_when_buffer_empty(self, bridge: AgentBridge):
-        """Flushing an empty buffer should be a no-op."""
-        assert len(bridge.event_forwarder._event_buffer) == 0
-        await bridge.event_forwarder.flush_event_buffer()
-        assert len(bridge.event_forwarder._event_buffer) == 0
+        # The connection closed, so the forwarder is unbound again: new
+        # events buffer instead of going to the dead socket.
+        sent_before = len(ws.sent)
+        await bridge._send_event({"type": "token", "content": "after close"})
+        assert len(ws.sent) == sent_before
 
 
 class TestPromptTaskDecoupling:
@@ -253,6 +144,7 @@ class TestPromptTaskDecoupling:
         # cancel heartbeat + background_tasks, set ws = None.
         # The prompt task should NOT be in background_tasks anymore.
         bridge.ws = None
+        bridge.event_forwarder.unbind()
 
         # The task should still be running
         assert not task.done()
@@ -288,11 +180,10 @@ class TestPromptTaskDecoupling:
         assert task.done()
 
     @pytest.mark.asyncio
-    async def test_execution_complete_buffered_and_flushed(self, bridge: AgentBridge):
-        """execution_complete should be buffered when WS is down and flushed on reconnect."""
-        bridge.ws = None
-
-        # Simulate _handle_prompt completing and sending execution_complete
+    async def test_execution_complete_while_disconnected_delivered_on_bind(
+        self, bridge: AgentBridge
+    ):
+        """execution_complete sent while WS is down must arrive on reconnect."""
         await bridge._send_event(
             {
                 "type": "execution_complete",
@@ -301,19 +192,12 @@ class TestPromptTaskDecoupling:
             }
         )
 
-        assert len(bridge.event_forwarder._event_buffer) == 1
-        assert bridge.event_forwarder._event_buffer[0]["type"] == "execution_complete"
-
-        # Simulate reconnect
         mock_ws = MagicMock()
         mock_ws.state = State.OPEN
         sent_data: list[str] = []
         mock_ws.send = AsyncMock(side_effect=lambda data: sent_data.append(data))
-        bridge.event_forwarder.bind(mock_ws)
+        await bridge.event_forwarder.bind(mock_ws)
 
-        await bridge.event_forwarder.flush_event_buffer()
-
-        assert len(bridge.event_forwarder._event_buffer) == 0
         assert len(sent_data) == 1
         parsed = json.loads(sent_data[0])
         assert parsed["type"] == "execution_complete"

--- a/packages/sandbox-runtime/tests/test_event_forwarder.py
+++ b/packages/sandbox-runtime/tests/test_event_forwarder.py
@@ -14,14 +14,18 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from websockets import State
 
-from sandbox_runtime.event_forwarder import BufferedEventForwarder
+from sandbox_runtime.event_forwarder import SEND_TIMEOUT_SECONDS, BufferedEventForwarder
 
 
-def make_forwarder(max_buffer_size: int = 1000) -> BufferedEventForwarder:
+def make_forwarder(
+    max_buffer_size: int = 1000,
+    send_timeout_seconds: float = SEND_TIMEOUT_SECONDS,
+) -> BufferedEventForwarder:
     return BufferedEventForwarder(
         sandbox_id="test-sandbox",
         log=MagicMock(),
         max_buffer_size=max_buffer_size,
+        send_timeout_seconds=send_timeout_seconds,
     )
 
 
@@ -34,6 +38,51 @@ def open_ws() -> MagicMock:
 
 def sent_events(ws: MagicMock) -> list[dict]:
     return [json.loads(call.args[0]) for call in ws.send.await_args_list]
+
+
+def wedged_ws(fail_signal: asyncio.Event) -> MagicMock:
+    """A connection whose sends hang until signalled, then fail."""
+    ws = MagicMock()
+    ws.state = State.OPEN
+
+    async def wedged_send(data: str) -> None:
+        await fail_signal.wait()
+        raise ConnectionError("stale connection flap")
+
+    ws.send = wedged_send
+    return ws
+
+
+class GatedWs:
+    """Fake connection: every send records its payload, then suspends until
+    the test releases that send by index (with success or an exception)."""
+
+    def __init__(self):
+        self.state = State.OPEN
+        self.calls: list[dict] = []  # decoded payloads, in send order
+
+        self._results: list[asyncio.Future] = []
+
+    async def send(self, data: str) -> None:
+        future = asyncio.get_running_loop().create_future()
+        self.calls.append(json.loads(data))
+        self._results.append(future)
+        await future
+
+    def release(self, index: int, exc: Exception | None = None) -> None:
+        if exc is None:
+            self._results[index].set_result(None)
+        else:
+            self._results[index].set_exception(exc)
+
+    def message_ids(self) -> list[str | None]:
+        return [call.get("messageId") for call in self.calls]
+
+
+async def settle() -> None:
+    """Let every runnable coroutine advance to its next suspension point."""
+    for _ in range(5):
+        await asyncio.sleep(0)
 
 
 class TestBufferWhileDisconnected:
@@ -297,6 +346,202 @@ class TestStaleSendRecovery:
 
         assert ws.send.await_count == 1
         assert len(forwarder._event_buffer) == 1
+
+
+class TestConcurrentRecovery:
+    """Races between bind() recovery, stale-send drains, sends, and eviction."""
+
+    @pytest.mark.asyncio
+    async def test_drain_waits_for_bind_flush_no_loss_or_duplicates(self):
+        """Bug A: a stale-send drain must not walk the buffer concurrently
+        with bind()'s recovery flush. Unserialized, both loops claim the same
+        head (double-send) and pop events the other loop sent — or never
+        sent, permanently losing a critical when a send then flaps."""
+        forwarder = make_forwarder()
+
+        # W goes in flight on a connection that will only fail much later
+        fail_old = asyncio.Event()
+        old_ws = wedged_ws(fail_old)
+        await forwarder.bind(old_ws)
+        send_w = asyncio.create_task(
+            forwarder.send({"type": "execution_complete", "messageId": "msg-W"})
+        )
+        await settle()  # W is now suspended inside old_ws.send
+
+        # Watchdog reconnects; X was buffered during the disconnected window
+        forwarder.unbind()
+        await forwarder.send({"type": "execution_complete", "messageId": "msg-X"})
+
+        new_ws = GatedWs()
+        bind_task = asyncio.create_task(forwarder.bind(new_ws))
+        await settle()
+        assert new_ws.message_ids() == ["msg-X"]  # bind flush suspended on X
+
+        # The stale W send fails now; its drain must WAIT on the lock instead
+        # of claiming the in-flight head X a second time
+        fail_old.set()
+        await settle()
+        assert new_ws.message_ids() == ["msg-X"]
+
+        # X completes; bind's flush moves on to W and hits a second flap
+        new_ws.release(0)
+        await settle()
+        assert new_ws.message_ids() == ["msg-X", "msg-W"]
+        new_ws.release(1, ConnectionError("second connection flap"))
+        await settle()
+        await bind_task
+        # The drain now holds the lock and retries W on the live connection
+        new_ws.release(2)
+        await settle()
+        await send_w
+
+        # Each event hit the wire exactly once per delivery attempt sequence:
+        # X once, W once failed + once delivered — nothing lost, nothing duped
+        assert new_ws.message_ids() == ["msg-X", "msg-W", "msg-W"]
+        assert forwarder._event_buffer == []
+        assert forwarder.acknowledge("execution_complete:msg-X") is True
+        assert forwarder.acknowledge("execution_complete:msg-W") is True
+
+    @pytest.mark.asyncio
+    async def test_event_buffered_as_flush_drains_to_empty_is_delivered(self):
+        """Bug A (empty-window variant): an event buffered by a failing send
+        while the recovery flush is on its last item must still be delivered
+        exactly once, with its ACK tracked."""
+        forwarder = make_forwarder()
+
+        fail_old = asyncio.Event()
+        old_ws = wedged_ws(fail_old)
+        await forwarder.bind(old_ws)
+        send_w = asyncio.create_task(
+            forwarder.send({"type": "execution_complete", "messageId": "msg-W"})
+        )
+        await settle()
+
+        forwarder.unbind()
+        await forwarder.send({"type": "token", "content": "x"})
+
+        new_ws = GatedWs()
+        bind_task = asyncio.create_task(forwarder.bind(new_ws))
+        await settle()  # flush suspended sending the token (its only item)
+
+        # W fails and is appended while the flush is mid-final-iteration
+        fail_old.set()
+        await settle()
+        assert len(new_ws.calls) == 1  # the waiting drain claimed nothing
+
+        new_ws.release(0)  # token delivered; the same walk picks up W next
+        await settle()
+        assert new_ws.message_ids() == [None, "msg-W"]
+        new_ws.release(1)
+        await settle()
+        await bind_task
+        await send_w
+
+        assert new_ws.message_ids() == [None, "msg-W"]
+        assert forwarder._event_buffer == []
+        assert forwarder.acknowledge("execution_complete:msg-W") is True
+
+    @pytest.mark.asyncio
+    async def test_eviction_of_in_flight_head_does_not_pop_shifted_critical(self):
+        """Bug B: while the flush is suspended sending the head, an overflow
+        eviction can remove that head and shift a critical into position 0.
+        A positional pop would discard the critical unsent."""
+        forwarder = make_forwarder(max_buffer_size=2)
+        await forwarder.send({"type": "token", "content": "x"})
+        await forwarder.send({"type": "execution_complete", "messageId": "msg-Y"})
+        # Buffer is at capacity: [token, Y]
+
+        ws = GatedWs()
+        bind_task = asyncio.create_task(forwarder.bind(ws))
+        await settle()  # flush suspended sending the token head (call #0)
+
+        # A direct send fails instantly; buffering it overflows the buffer,
+        # evicting the in-flight token head and shifting Y to the front
+        send_z = asyncio.create_task(
+            forwarder.send({"type": "push_complete", "messageId": "msg-Z", "branchName": "b"})
+        )
+        await settle()
+        ws.release(1, ConnectionError("broken"))  # the direct Z send fails
+        await settle()
+        await send_z
+        assert [event["messageId"] for event in forwarder._event_buffer] == ["msg-Y", "msg-Z"]
+
+        # The token send completes; the head is now Y, which the flush never
+        # sent — it must stay put and be delivered next
+        ws.release(0)
+        await settle()
+        assert ws.calls[2]["messageId"] == "msg-Y"
+        ws.release(2)
+        await settle()
+        assert ws.calls[3]["messageId"] == "msg-Z"
+        ws.release(3)
+        await settle()
+        await bind_task
+
+        assert ws.message_ids().count("msg-Y") == 1
+        assert forwarder._event_buffer == []
+        assert forwarder.acknowledge("execution_complete:msg-Y") is True
+        assert forwarder.acknowledge("push_complete:msg-Z") is True
+
+    @pytest.mark.asyncio
+    async def test_cancelled_send_rebuffers_event_and_propagates(self):
+        """Bug C: cancelling a task suspended in send() must re-buffer the
+        event before the cancellation propagates."""
+        forwarder = make_forwarder()
+
+        started = asyncio.Event()
+        ws = MagicMock()
+        ws.state = State.OPEN
+
+        async def hanging_send(data: str) -> None:
+            started.set()
+            await asyncio.Event().wait()
+
+        ws.send = hanging_send
+        await forwarder.bind(ws)
+
+        send_task = asyncio.create_task(
+            forwarder.send({"type": "execution_complete", "messageId": "msg-1"})
+        )
+        await started.wait()
+        send_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await send_task
+
+        assert [event["type"] for event in forwarder._event_buffer] == ["execution_complete"]
+
+        # The next bind delivers the re-buffered event
+        replacement = open_ws()
+        await forwarder.bind(replacement)
+        assert [event["ackId"] for event in sent_events(replacement)] == [
+            "execution_complete:msg-1"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_recovery_send_timeout_breaks_flush_and_keeps_event(self):
+        """A wedged send inside recovery would hold the lock forever and turn
+        into a wedged reconnect; it must time out, leave the event buffered,
+        and let a later bind deliver it."""
+        forwarder = make_forwarder(send_timeout_seconds=0.05)
+        await forwarder.send({"type": "execution_complete", "messageId": "msg-1"})
+
+        hung_ws = MagicMock()
+        hung_ws.state = State.OPEN
+
+        async def never_completes(data: str) -> None:
+            await asyncio.Event().wait()
+
+        hung_ws.send = never_completes
+
+        await forwarder.bind(hung_ws)  # returns: the timeout breaks the flush
+
+        assert len(forwarder._event_buffer) == 1
+
+        replacement = open_ws()
+        await forwarder.bind(replacement)
+        assert [event["ackId"] for event in sent_events(replacement)] == [
+            "execution_complete:msg-1"
+        ]
 
 
 class TestOverflowEviction:

--- a/packages/sandbox-runtime/tests/test_event_forwarder.py
+++ b/packages/sandbox-runtime/tests/test_event_forwarder.py
@@ -1,11 +1,13 @@
 """
 Unit tests for BufferedEventForwarder.
 
-Covers the reconnect-safe delivery state machine on its own: buffering while
-no connection is bound, flushing on bind, the flush ack-skip contract, and
+Covers the reconnect-safe delivery state machine through its public surface:
+buffering while no connection is bound, bind-time backlog recovery (without
+double-sends), the ACK lifecycle, stale-send recovery after a rebind, and
 bounded-buffer overflow eviction.
 """
 
+import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock
 
@@ -51,7 +53,7 @@ class TestBufferWhileDisconnected:
     @pytest.mark.asyncio
     async def test_send_buffers_after_unbind(self):
         forwarder = make_forwarder()
-        forwarder.bind(open_ws())
+        await forwarder.bind(open_ws())
         forwarder.unbind()
 
         await forwarder.send({"type": "token", "content": "hello"})
@@ -63,7 +65,7 @@ class TestBufferWhileDisconnected:
         forwarder = make_forwarder()
         ws = open_ws()
         ws.state = State.CLOSED
-        forwarder.bind(ws)
+        await forwarder.bind(ws)
 
         await forwarder.send({"type": "token", "content": "hello"})
 
@@ -75,7 +77,7 @@ class TestBufferWhileDisconnected:
         forwarder = make_forwarder()
         ws = open_ws()
         ws.send = AsyncMock(side_effect=ConnectionError("broken pipe"))
-        forwarder.bind(ws)
+        await forwarder.bind(ws)
 
         await forwarder.send({"type": "execution_complete", "messageId": "msg-1"})
 
@@ -88,7 +90,7 @@ class TestSendWhileConnected:
     async def test_critical_event_gets_ack_id_and_pends(self):
         forwarder = make_forwarder()
         ws = open_ws()
-        forwarder.bind(ws)
+        await forwarder.bind(ws)
 
         await forwarder.send({"type": "execution_complete", "messageId": "msg-1"})
 
@@ -100,7 +102,7 @@ class TestSendWhileConnected:
     async def test_non_critical_event_has_no_ack_id(self):
         forwarder = make_forwarder()
         ws = open_ws()
-        forwarder.bind(ws)
+        await forwarder.bind(ws)
 
         await forwarder.send({"type": "token", "content": "hello"})
 
@@ -109,9 +111,40 @@ class TestSendWhileConnected:
         assert len(forwarder._pending_acks) == 0
 
     @pytest.mark.asyncio
+    async def test_ack_id_is_random_and_unique_without_message_id(self):
+        forwarder = make_forwarder()
+        ws = open_ws()
+        await forwarder.bind(ws)
+
+        await forwarder.send({"type": "snapshot_ready"})
+        await forwarder.send({"type": "snapshot_ready"})
+
+        ack_ids = [event["ackId"] for event in sent_events(ws)]
+        for ack_id in ack_ids:
+            prefix, suffix = ack_id.split(":", 1)
+            assert prefix == "snapshot_ready"
+            assert len(suffix) == 16
+            int(suffix, 16)  # Should not raise
+        assert len(set(ack_ids)) == 2
+
+    @pytest.mark.asyncio
+    async def test_existing_ack_id_not_overwritten(self):
+        forwarder = make_forwarder()
+        ws = open_ws()
+        await forwarder.bind(ws)
+
+        await forwarder.send(
+            {"type": "execution_complete", "messageId": "msg-1", "ackId": "custom:id"}
+        )
+
+        [event] = sent_events(ws)
+        assert event["ackId"] == "custom:id"
+        assert forwarder.acknowledge("custom:id") is True
+
+    @pytest.mark.asyncio
     async def test_acknowledge_clears_pending(self):
         forwarder = make_forwarder()
-        forwarder.bind(open_ws())
+        await forwarder.bind(open_ws())
         await forwarder.send({"type": "execution_complete", "messageId": "msg-1"})
 
         assert forwarder.acknowledge("execution_complete:msg-1") is True
@@ -120,71 +153,60 @@ class TestSendWhileConnected:
         assert forwarder.acknowledge("execution_complete:msg-1") is False
 
 
-class TestFlushOnBind:
+class TestBindRecovery:
     @pytest.mark.asyncio
-    async def test_flush_after_bind_sends_all_and_clears_buffer(self):
+    async def test_bind_flushes_buffered_events_in_order(self):
         forwarder = make_forwarder()
         await forwarder.send({"type": "token", "content": "a"})
         await forwarder.send({"type": "execution_complete", "messageId": "msg-1"})
 
         ws = open_ws()
-        forwarder.bind(ws)
-        just_added = await forwarder.flush_event_buffer()
+        await forwarder.bind(ws)
 
         assert len(forwarder._event_buffer) == 0
         assert [event["type"] for event in sent_events(ws)] == ["token", "execution_complete"]
-        # The critical event starts pending on flush, and is reported as such
-        assert just_added == {"execution_complete:msg-1"}
-        assert "execution_complete:msg-1" in forwarder._pending_acks
+        # The critical event starts pending on flush, awaiting its ACK
+        assert forwarder.acknowledge("execution_complete:msg-1") is True
 
     @pytest.mark.asyncio
-    async def test_flush_without_bind_keeps_buffer(self):
+    async def test_bind_with_no_backlog_sends_nothing(self):
         forwarder = make_forwarder()
-        await forwarder.send({"type": "token", "content": "a"})
 
-        just_added = await forwarder.flush_event_buffer()
+        ws = open_ws()
+        await forwarder.bind(ws)
 
-        assert just_added == set()
-        assert len(forwarder._event_buffer) == 1
+        ws.send.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_flush_stops_on_send_failure_and_keeps_remainder(self):
+    async def test_bind_flush_stops_on_send_failure_and_keeps_remainder(self):
         forwarder = make_forwarder()
         await forwarder.send({"type": "token", "content": "a"})
         await forwarder.send({"type": "token", "content": "b"})
 
         ws = open_ws()
         ws.send = AsyncMock(side_effect=[None, ConnectionError("broken")])
-        forwarder.bind(ws)
-
-        await forwarder.flush_event_buffer()
+        await forwarder.bind(ws)
 
         assert len(forwarder._event_buffer) == 1
         assert forwarder._event_buffer[0]["content"] == "b"
 
-
-class TestAckSkipContract:
-    """flush_event_buffer reports the ackIds it just started tracking, and
-    flush_pending_acks must skip exactly those to avoid a double-send."""
-
     @pytest.mark.asyncio
-    async def test_reconnect_flush_does_not_double_send_buffered_criticals(self):
+    async def test_bind_does_not_double_send_buffered_criticals(self):
+        """A critical event flushed from the buffer must not also be re-sent
+        by the pending-ack recovery on the same bind."""
         forwarder = make_forwarder()
         # msg-1 was sent on a previous connection and never acknowledged
-        forwarder.bind(open_ws())
+        await forwarder.bind(open_ws())
         await forwarder.send({"type": "execution_complete", "messageId": "msg-1"})
         forwarder.unbind()
         # msg-2 completed while disconnected, so it sits in the buffer
         await forwarder.send({"type": "execution_complete", "messageId": "msg-2"})
 
         ws = open_ws()
-        forwarder.bind(ws)
-        just_flushed = await forwarder.flush_event_buffer()
-        await forwarder.flush_pending_acks(skip_ack_ids=just_flushed)
+        await forwarder.bind(ws)
 
-        events = sent_events(ws)
         # msg-2 once from the buffer, msg-1 once from pending acks — no dupes
-        assert [event["ackId"] for event in events] == [
+        assert [event["ackId"] for event in sent_events(ws)] == [
             "execution_complete:msg-2",
             "execution_complete:msg-1",
         ]
@@ -194,20 +216,87 @@ class TestAckSkipContract:
         }
 
     @pytest.mark.asyncio
-    async def test_flush_pending_acks_resends_everything_without_skip(self):
+    async def test_bind_resends_all_unacknowledged_criticals(self):
         forwarder = make_forwarder()
-        forwarder.bind(open_ws())
+        await forwarder.bind(open_ws())
         await forwarder.send({"type": "execution_complete", "messageId": "msg-1"})
         await forwarder.send({"type": "error", "messageId": "msg-2"})
         forwarder.unbind()
 
         ws = open_ws()
-        forwarder.bind(ws)
-        await forwarder.flush_pending_acks()
+        await forwarder.bind(ws)
 
         assert ws.send.await_count == 2
-        # Pending entries survive the resend; only an ACK command clears them
-        assert len(forwarder._pending_acks) == 2
+        # Both stay pending until an ACK command clears them
+        assert forwarder.acknowledge("execution_complete:msg-1") is True
+        assert forwarder.acknowledge("error:msg-2") is True
+
+    @pytest.mark.asyncio
+    async def test_bind_does_not_resend_acknowledged_events(self):
+        forwarder = make_forwarder()
+        await forwarder.bind(open_ws())
+        await forwarder.send({"type": "execution_complete", "messageId": "msg-1"})
+        assert forwarder.acknowledge("execution_complete:msg-1") is True
+        forwarder.unbind()
+
+        ws = open_ws()
+        await forwarder.bind(ws)
+
+        ws.send.assert_not_awaited()
+
+
+class TestStaleSendRecovery:
+    @pytest.mark.asyncio
+    async def test_send_failure_after_rebind_drains_through_new_connection(self):
+        """A wedged send can fail only after the watchdog already bound and
+        flushed a replacement connection; the event must be delivered on the
+        new connection instead of sitting stranded in the buffer."""
+        forwarder = make_forwarder()
+
+        release_failure = asyncio.Event()
+        old_ws = MagicMock()
+        old_ws.state = State.OPEN
+
+        async def wedged_send(data):
+            await release_failure.wait()
+            raise ConnectionError("connection timed out")
+
+        old_ws.send = wedged_send
+        await forwarder.bind(old_ws)
+
+        send_task = asyncio.create_task(
+            forwarder.send({"type": "execution_complete", "messageId": "msg-1"})
+        )
+        await asyncio.sleep(0)  # the send is now in flight on old_ws
+
+        # Watchdog reconnects: replacement bound, recovery already ran (empty)
+        forwarder.unbind()
+        new_ws = open_ws()
+        await forwarder.bind(new_ws)
+        assert sent_events(new_ws) == []
+
+        # The wedged send finally fails, long after the rebind
+        release_failure.set()
+        await send_task
+
+        assert [event["ackId"] for event in sent_events(new_ws)] == ["execution_complete:msg-1"]
+        assert forwarder._event_buffer == []
+        # Delivered via the buffer drain, so it is tracked for ACK
+        assert forwarder.acknowledge("execution_complete:msg-1") is True
+
+    @pytest.mark.asyncio
+    async def test_send_failure_without_rebind_stays_buffered(self):
+        """When the failed connection is still the bound one there is nothing
+        to drain through — the event stays buffered, with no retry loop."""
+        forwarder = make_forwarder()
+        ws = open_ws()
+        ws.send = AsyncMock(side_effect=ConnectionError("broken pipe"))
+        await forwarder.bind(ws)
+
+        await forwarder.send({"type": "execution_complete", "messageId": "msg-1"})
+
+        assert ws.send.await_count == 1
+        assert len(forwarder._event_buffer) == 1
 
 
 class TestOverflowEviction:

--- a/packages/sandbox-runtime/tests/test_event_forwarder.py
+++ b/packages/sandbox-runtime/tests/test_event_forwarder.py
@@ -1,0 +1,239 @@
+"""
+Unit tests for BufferedEventForwarder.
+
+Covers the reconnect-safe delivery state machine on its own: buffering while
+no connection is bound, flushing on bind, the flush ack-skip contract, and
+bounded-buffer overflow eviction.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from websockets import State
+
+from sandbox_runtime.event_forwarder import BufferedEventForwarder
+
+
+def make_forwarder(max_buffer_size: int = 1000) -> BufferedEventForwarder:
+    return BufferedEventForwarder(
+        sandbox_id="test-sandbox",
+        log=MagicMock(),
+        max_buffer_size=max_buffer_size,
+    )
+
+
+def open_ws() -> MagicMock:
+    ws = MagicMock()
+    ws.state = State.OPEN
+    ws.send = AsyncMock()
+    return ws
+
+
+def sent_events(ws: MagicMock) -> list[dict]:
+    return [json.loads(call.args[0]) for call in ws.send.await_args_list]
+
+
+class TestBufferWhileDisconnected:
+    @pytest.mark.asyncio
+    async def test_send_buffers_when_never_bound(self):
+        forwarder = make_forwarder()
+
+        await forwarder.send({"type": "token", "content": "hello"})
+
+        assert len(forwarder._event_buffer) == 1
+        buffered = forwarder._event_buffer[0]
+        assert buffered["type"] == "token"
+        # Sandbox identity and timestamp are stamped even while buffering
+        assert buffered["sandboxId"] == "test-sandbox"
+        assert "timestamp" in buffered
+
+    @pytest.mark.asyncio
+    async def test_send_buffers_after_unbind(self):
+        forwarder = make_forwarder()
+        forwarder.bind(open_ws())
+        forwarder.unbind()
+
+        await forwarder.send({"type": "token", "content": "hello"})
+
+        assert len(forwarder._event_buffer) == 1
+
+    @pytest.mark.asyncio
+    async def test_send_buffers_when_bound_ws_not_open(self):
+        forwarder = make_forwarder()
+        ws = open_ws()
+        ws.state = State.CLOSED
+        forwarder.bind(ws)
+
+        await forwarder.send({"type": "token", "content": "hello"})
+
+        ws.send.assert_not_awaited()
+        assert len(forwarder._event_buffer) == 1
+
+    @pytest.mark.asyncio
+    async def test_send_failure_buffers_and_does_not_track_pending(self):
+        forwarder = make_forwarder()
+        ws = open_ws()
+        ws.send = AsyncMock(side_effect=ConnectionError("broken pipe"))
+        forwarder.bind(ws)
+
+        await forwarder.send({"type": "execution_complete", "messageId": "msg-1"})
+
+        assert len(forwarder._event_buffer) == 1
+        assert len(forwarder._pending_acks) == 0
+
+
+class TestSendWhileConnected:
+    @pytest.mark.asyncio
+    async def test_critical_event_gets_ack_id_and_pends(self):
+        forwarder = make_forwarder()
+        ws = open_ws()
+        forwarder.bind(ws)
+
+        await forwarder.send({"type": "execution_complete", "messageId": "msg-1"})
+
+        [event] = sent_events(ws)
+        assert event["ackId"] == "execution_complete:msg-1"
+        assert forwarder._pending_acks["execution_complete:msg-1"]["type"] == "execution_complete"
+
+    @pytest.mark.asyncio
+    async def test_non_critical_event_has_no_ack_id(self):
+        forwarder = make_forwarder()
+        ws = open_ws()
+        forwarder.bind(ws)
+
+        await forwarder.send({"type": "token", "content": "hello"})
+
+        [event] = sent_events(ws)
+        assert "ackId" not in event
+        assert len(forwarder._pending_acks) == 0
+
+    @pytest.mark.asyncio
+    async def test_acknowledge_clears_pending(self):
+        forwarder = make_forwarder()
+        forwarder.bind(open_ws())
+        await forwarder.send({"type": "execution_complete", "messageId": "msg-1"})
+
+        assert forwarder.acknowledge("execution_complete:msg-1") is True
+        assert len(forwarder._pending_acks) == 0
+        # Unknown ackIds report not-found
+        assert forwarder.acknowledge("execution_complete:msg-1") is False
+
+
+class TestFlushOnBind:
+    @pytest.mark.asyncio
+    async def test_flush_after_bind_sends_all_and_clears_buffer(self):
+        forwarder = make_forwarder()
+        await forwarder.send({"type": "token", "content": "a"})
+        await forwarder.send({"type": "execution_complete", "messageId": "msg-1"})
+
+        ws = open_ws()
+        forwarder.bind(ws)
+        just_added = await forwarder.flush_event_buffer()
+
+        assert len(forwarder._event_buffer) == 0
+        assert [event["type"] for event in sent_events(ws)] == ["token", "execution_complete"]
+        # The critical event starts pending on flush, and is reported as such
+        assert just_added == {"execution_complete:msg-1"}
+        assert "execution_complete:msg-1" in forwarder._pending_acks
+
+    @pytest.mark.asyncio
+    async def test_flush_without_bind_keeps_buffer(self):
+        forwarder = make_forwarder()
+        await forwarder.send({"type": "token", "content": "a"})
+
+        just_added = await forwarder.flush_event_buffer()
+
+        assert just_added == set()
+        assert len(forwarder._event_buffer) == 1
+
+    @pytest.mark.asyncio
+    async def test_flush_stops_on_send_failure_and_keeps_remainder(self):
+        forwarder = make_forwarder()
+        await forwarder.send({"type": "token", "content": "a"})
+        await forwarder.send({"type": "token", "content": "b"})
+
+        ws = open_ws()
+        ws.send = AsyncMock(side_effect=[None, ConnectionError("broken")])
+        forwarder.bind(ws)
+
+        await forwarder.flush_event_buffer()
+
+        assert len(forwarder._event_buffer) == 1
+        assert forwarder._event_buffer[0]["content"] == "b"
+
+
+class TestAckSkipContract:
+    """flush_event_buffer reports the ackIds it just started tracking, and
+    flush_pending_acks must skip exactly those to avoid a double-send."""
+
+    @pytest.mark.asyncio
+    async def test_reconnect_flush_does_not_double_send_buffered_criticals(self):
+        forwarder = make_forwarder()
+        # msg-1 was sent on a previous connection and never acknowledged
+        forwarder.bind(open_ws())
+        await forwarder.send({"type": "execution_complete", "messageId": "msg-1"})
+        forwarder.unbind()
+        # msg-2 completed while disconnected, so it sits in the buffer
+        await forwarder.send({"type": "execution_complete", "messageId": "msg-2"})
+
+        ws = open_ws()
+        forwarder.bind(ws)
+        just_flushed = await forwarder.flush_event_buffer()
+        await forwarder.flush_pending_acks(skip_ack_ids=just_flushed)
+
+        events = sent_events(ws)
+        # msg-2 once from the buffer, msg-1 once from pending acks — no dupes
+        assert [event["ackId"] for event in events] == [
+            "execution_complete:msg-2",
+            "execution_complete:msg-1",
+        ]
+        assert set(forwarder._pending_acks) == {
+            "execution_complete:msg-1",
+            "execution_complete:msg-2",
+        }
+
+    @pytest.mark.asyncio
+    async def test_flush_pending_acks_resends_everything_without_skip(self):
+        forwarder = make_forwarder()
+        forwarder.bind(open_ws())
+        await forwarder.send({"type": "execution_complete", "messageId": "msg-1"})
+        await forwarder.send({"type": "error", "messageId": "msg-2"})
+        forwarder.unbind()
+
+        ws = open_ws()
+        forwarder.bind(ws)
+        await forwarder.flush_pending_acks()
+
+        assert ws.send.await_count == 2
+        # Pending entries survive the resend; only an ACK command clears them
+        assert len(forwarder._pending_acks) == 2
+
+
+class TestOverflowEviction:
+    @pytest.mark.asyncio
+    async def test_overflow_evicts_oldest_non_critical_first(self):
+        forwarder = make_forwarder(max_buffer_size=3)
+        await forwarder.send({"type": "execution_complete", "messageId": "msg-1"})
+        await forwarder.send({"type": "token", "content": "a"})
+        await forwarder.send({"type": "error", "messageId": "msg-2"})
+
+        await forwarder.send({"type": "snapshot_ready"})
+
+        types = [event["type"] for event in forwarder._event_buffer]
+        assert types == ["execution_complete", "error", "snapshot_ready"]
+
+    @pytest.mark.asyncio
+    async def test_overflow_evicts_oldest_when_all_critical(self):
+        forwarder = make_forwarder(max_buffer_size=2)
+        await forwarder.send({"type": "execution_complete", "messageId": "msg-1"})
+        await forwarder.send({"type": "error", "messageId": "msg-2"})
+
+        await forwarder.send({"type": "push_complete", "branchName": "b"})
+
+        types = [event["type"] for event in forwarder._event_buffer]
+        assert types == ["error", "push_complete"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

Extracts the WebSocket event buffering + pending-ACK machinery out of `AgentBridge` (`bridge.py`) into a dedicated `BufferedEventForwarder` class in `src/sandbox_runtime/event_forwarder.py`, following the same house style as `diff_capture.py` (`ControlPlaneDiffClient` / `SessionDiffRefreshWorker`).

**This is a behavior-preserving extraction** — the send/buffer/flush/ack logic, log event names, eviction policy, and error handling are byte-for-byte the same; only ownership moved.

### What moved

- `_send_event` body, `_flush_event_buffer`, `_flush_pending_acks`, `_buffer_event`, `_make_ack_id`
- `_event_buffer` / `_pending_acks` state
- `CRITICAL_EVENT_TYPES` and `MAX_EVENT_BUFFER_SIZE` (now `Final` module constants in `event_forwarder.py`)

### Design decisions

- **Explicit `bind(ws)` / `unbind()` lifecycle**: the bridge binds the connection when `websockets.connect` yields and unbinds in the same `finally` block that clears `self.ws`. The forwarder never reaches back into the bridge's mutable `ws` field (no injected lambdas/callbacks).
- **Ack-skip contract preserved**: `flush_event_buffer()` still returns the set of ackIds it just started tracking, and `flush_pending_acks(skip_ack_ids=...)` skips exactly those so a critical event flushed from the buffer is not double-sent on the same reconnect. Covered by a dedicated test (`TestAckSkipContract`).
- `AgentBridge._send_event` remains as a one-line delegate — it is the seam every producer in the bridge (heartbeat, prompt streaming, push, boot warnings) already uses, and it keeps the wire-facing behavior in one place.
- ACK commands route through `event_forwarder.acknowledge(ack_id) -> bool`; the bridge keeps the `bridge.ack_received` debug log on success.

### Public surface

```python
BufferedEventForwarder(*, sandbox_id: str, log: StructuredLogger, max_buffer_size: int = MAX_EVENT_BUFFER_SIZE)
  .bind(ws) / .unbind()
  async .send(event: dict) -> None
  async .flush_event_buffer() -> set[str]           # ackIds just added to pending
  async .flush_pending_acks(skip_ack_ids=None) -> None
  .acknowledge(ack_id: str) -> bool
```

## Testing

- New `tests/test_event_forwarder.py`: 14 focused unit tests — buffer-while-unbound/unbound-after-unbind/non-OPEN socket, flush-on-bind, flush-stops-on-failure, the ack-skip double-send wrinkle, ack lifecycle, and overflow eviction (non-critical evicted first, oldest evicted when all critical).
- `tests/test_bridge_ack.py` / `tests/test_bridge_event_buffer.py`: mechanically retargeted at `bridge.event_forwarder` where they previously poked `bridge._event_buffer` / `bridge._pending_acks` / `bridge.ws` directly; assertions unchanged. All other bridge test files pass unmodified.

```
pytest                    535 passed (baseline on main: 521)
ruff check src tests      All checks passed
ruff format --check       59 files already formatted
mypy src/                 13 pre-existing errors, all in entrypoint.py / auth/github_app.py
                          (unchanged from main; bridge.py and event_forwarder.py are clean)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Reliability**
  - Improved sandbox-to-control-plane event delivery across WebSocket interruptions, reconnections, and transient send failures.
  - Buffered events are automatically delivered once the connection is restored.
  - Critical events are tracked and resent until acknowledged, preventing missed or duplicated delivery.
  - Event buffering is capacity-bounded, prioritizing retention of critical events during overflow.

- **Bug Fixes**
  - Reduced the risk of event loss or duplicate delivery during reconnects and temporary send failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->