### PR TITLE
fix(control-plane): correct bitbucket clone identity on all providers

### DIFF
--- a/packages/control-plane/src/sandbox/providers/daytona-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/daytona-provider.test.ts
@@ -188,10 +188,10 @@ describe("DaytonaSandboxProvider", () => {
       expect(envVars.VCS_CLONE_TOKEN).toBeUndefined();
     });
 
-    it("collapses bitbucket to the GitHub clone identity (historical behavior)", async () => {
-      // Daytona predates Bitbucket support: only GitLab is mapped, everything
-      // else — including bitbucket — resolves to the GitHub identity. Locked
-      // in so the shared env assembly can't silently change it.
+    it("maps bitbucket to the Bitbucket clone identity", async () => {
+      // Daytona historically collapsed bitbucket to the GitHub identity (a
+      // pre-Bitbucket-support drift that made bitbucket clones impossible);
+      // it now resolves the real Bitbucket identity like every provider.
       const client = createMockClient();
       const provider = new DaytonaSandboxProvider(client, {
         scmProvider: "bitbucket",
@@ -201,8 +201,8 @@ describe("DaytonaSandboxProvider", () => {
       await provider.createSandbox(baseCreateConfig);
 
       const envVars = (client.createSandbox as ReturnType<typeof vi.fn>).mock.calls[0][0].env;
-      expect(envVars.VCS_HOST).toBe("github.com");
-      expect(envVars.VCS_CLONE_USERNAME).toBe("x-access-token");
+      expect(envVars.VCS_HOST).toBe("bitbucket.org");
+      expect(envVars.VCS_CLONE_USERNAME).toBe("x-token-auth");
     });
 
     it("includes branch in SESSION_CONFIG when provided", async () => {

--- a/packages/control-plane/src/sandbox/providers/daytona-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/daytona-provider.ts
@@ -11,11 +11,7 @@ import { createLogger } from "../../logger";
 import type { SourceControlProviderName } from "../../source-control";
 import type { DaytonaRestClient, DaytonaCreateSandboxParams } from "../daytona-rest-client";
 import { DaytonaApiError, DaytonaNotFoundError } from "../daytona-rest-client";
-import {
-  buildSandboxEnvVars,
-  deriveCodeServerPassword,
-  legacyScmCloneIdentity,
-} from "../sandbox-env";
+import { buildSandboxEnvVars, deriveCodeServerPassword, scmCloneIdentity } from "../sandbox-env";
 import {
   SandboxProviderError,
   type CreateSandboxConfig,
@@ -196,7 +192,7 @@ export class DaytonaSandboxProvider implements SandboxProvider {
 
   private async buildEnvVars(config: CreateSandboxConfig): Promise<Record<string, string>> {
     return buildSandboxEnvVars(config, {
-      scmIdentity: legacyScmCloneIdentity(this.providerConfig.scmProvider),
+      scmIdentity: scmCloneIdentity(this.providerConfig.scmProvider),
       codeServerPassword: config.codeServerEnabled
         ? await deriveCodeServerPassword(
             config.sandboxId,

--- a/packages/control-plane/src/sandbox/providers/e2b-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/e2b-provider.test.ts
@@ -92,6 +92,23 @@ describe("E2BSandboxProvider", () => {
     expect(env).not.toHaveProperty("GITHUB_APP_TOKEN");
   });
 
+  it("maps bitbucket to the Bitbucket clone identity", async () => {
+    // E2B historically collapsed bitbucket to the GitHub identity (a
+    // pre-Bitbucket-support drift that made bitbucket clones impossible);
+    // it now resolves the real Bitbucket identity like every provider.
+    const client = mockClient();
+    const provider = new E2BSandboxProvider(client, {
+      ...providerConfig,
+      scmProvider: "bitbucket",
+    });
+
+    await provider.createSandbox(baseCreateConfig);
+
+    const [, env] = vi.mocked(client.writeSessionEnv).mock.calls[0];
+    expect(env.VCS_HOST).toBe("bitbucket.org");
+    expect(env.VCS_CLONE_USERNAME).toBe("x-token-auth");
+  });
+
   it("resumeSandbox paused uses connectSandbox", async () => {
     const client = mockClient();
     const provider = new E2BSandboxProvider(client, providerConfig);

--- a/packages/control-plane/src/sandbox/providers/e2b-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/e2b-provider.ts
@@ -12,11 +12,7 @@
 
 import type { SandboxSettings } from "@open-inspect/shared";
 import { createLogger } from "../../logger";
-import {
-  buildSandboxEnvVars,
-  deriveCodeServerPassword,
-  legacyScmCloneIdentity,
-} from "../sandbox-env";
+import { buildSandboxEnvVars, deriveCodeServerPassword, scmCloneIdentity } from "../sandbox-env";
 import { resolveServicePorts, resolveTunnelPorts } from "./port-resolution";
 import type { SourceControlProviderName } from "../../source-control";
 import type { E2BRestClient, E2BSandboxDetail } from "../e2b-rest-client";
@@ -83,7 +79,7 @@ export class E2BSandboxProvider implements SandboxProvider {
           )
         : undefined;
       const envVars = buildSandboxEnvVars(config, {
-        scmIdentity: legacyScmCloneIdentity(this.providerConfig.scmProvider),
+        scmIdentity: scmCloneIdentity(this.providerConfig.scmProvider),
         codeServerPassword,
       });
       // E2B sandboxes run as a non-root user and /run is a root-owned tmpfs, so

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -267,6 +267,25 @@ describe("OpenComputerSandboxProvider", () => {
     });
   });
 
+  it("maps bitbucket to the Bitbucket clone identity", async () => {
+    // OpenComputer historically collapsed bitbucket to the GitHub identity (a
+    // pre-Bitbucket-support drift that made bitbucket clones impossible); it
+    // now resolves the real Bitbucket identity like every provider.
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "bitbucket",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await provider.createSandbox(baseConfig);
+
+    const createCall = vi.mocked(client.createSandbox).mock.calls[0][0];
+    expect(createCall.env).toMatchObject({
+      VCS_HOST: "bitbucket.org",
+      VCS_CLONE_USERNAME: "x-token-auth",
+    });
+  });
+
   it("cleans up a created sandbox when runtime startup fails", async () => {
     const client = createMockClient({
       startRuntime: vi.fn(async () => {

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -277,13 +277,53 @@ describe("OpenComputerSandboxProvider", () => {
       codeServerPasswordSecret: "secret",
     });
 
-    await provider.createSandbox(baseConfig);
+    await provider.createSandbox({
+      ...baseConfig,
+      userEnvVars: { VCS_CLONE_TOKEN: "bb-token" },
+    });
 
     const createCall = vi.mocked(client.createSandbox).mock.calls[0][0];
     expect(createCall.env).toMatchObject({
       VCS_HOST: "bitbucket.org",
       VCS_CLONE_USERNAME: "x-token-auth",
     });
+    expect(client.setSecret).toHaveBeenCalledWith({
+      storeId: "secret-store-1",
+      name: "VCS_CLONE_TOKEN",
+      value: "bb-token",
+      allowedHosts: ["bitbucket.org", "api.bitbucket.org"],
+    });
+  });
+
+  it("uses the Bitbucket clone identity for image builds", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "bitbucket",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await provider.triggerEnvironmentImageBuild({
+      buildId: "build-bb",
+      environmentId: "env_flagship",
+      repositories: [{ repoOwner: "acme", repoName: "repo", baseBranch: "main" }],
+      callbackUrl: "https://control.example/image-builds/build-complete",
+      failureCallbackUrl: "https://control.example/image-builds/build-failed",
+      callbackToken: "callback-token",
+      cloneToken: "clone-token",
+      userEnvVars: {},
+      onProviderSessionCreated: vi.fn(async () => undefined),
+    });
+
+    expect(client.createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: expect.objectContaining({
+          IMAGE_BUILD_MODE: "true",
+          VCS_HOST: "bitbucket.org",
+          VCS_CLONE_USERNAME: "x-token-auth",
+          VCS_CLONE_TOKEN: "clone-token",
+        }),
+      })
+    );
   });
 
   it("cleans up a created sandbox when runtime startup fails", async () => {

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -295,6 +295,26 @@ describe("OpenComputerSandboxProvider", () => {
     });
   });
 
+  it("keeps GITHUB-named secrets scoped to GitHub hosts on non-GitHub providers", async () => {
+    const client = createMockClient();
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "bitbucket",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await provider.createSandbox({
+      ...baseConfig,
+      userEnvVars: { GITHUB_TOKEN: "gh-token" },
+    });
+
+    expect(client.setSecret).toHaveBeenCalledWith({
+      storeId: "secret-store-1",
+      name: "GITHUB_TOKEN",
+      value: "gh-token",
+      allowedHosts: ["github.com", "api.github.com"],
+    });
+  });
+
   it("uses the Bitbucket clone identity for image builds", async () => {
     const client = createMockClient();
     const provider = new OpenComputerSandboxProvider(client, {

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -617,8 +617,14 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     const normalized = name.toUpperCase();
     if (normalized.includes("ANTHROPIC")) return ["api.anthropic.com"];
     if (normalized.includes("OPENAI")) return ["api.openai.com"];
-    if (normalized.includes("GITHUB") || normalized.includes("VCS_CLONE")) {
+    // VCS_CLONE_* is the provider-generic clone credential, so it follows the
+    // configured SCM provider; GITHUB-named secrets are GitHub credentials no
+    // matter which provider the deployment clones from.
+    if (normalized.includes("VCS_CLONE")) {
       return [...scmCloneIdentity(this.providerConfig.scmProvider).secretHosts];
+    }
+    if (normalized.includes("GITHUB")) {
+      return [...scmCloneIdentity("github").secretHosts];
     }
     return undefined;
   }

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -25,7 +25,7 @@ import {
   buildSandboxEnvVars,
   deriveCodeServerPassword,
   IMAGE_BUILD_MODE_ENV_VAR,
-  legacyScmCloneIdentity,
+  scmCloneIdentity,
   SESSION_CONFIG_ENV_VAR,
   toRepositoryConfigPayload,
   VCS_CLONE_TOKEN_ENV_VAR,
@@ -468,7 +468,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     const { envVars: baseEnvVars, secretEnvVars } = this.prepareEnvironment(config.userEnvVars);
     const envVars = buildSandboxEnvVars(config, {
       baseEnvVars,
-      scmIdentity: legacyScmCloneIdentity(this.providerConfig.scmProvider),
+      scmIdentity: scmCloneIdentity(this.providerConfig.scmProvider),
       codeServerPassword: config.codeServerEnabled
         ? await deriveCodeServerPassword(
             config.sandboxId,
@@ -532,11 +532,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
       [REPO_IMAGE_CALLBACK_ENV_KEYS[4]]: config.failureCallbackUrl,
     });
 
-    applyScmCloneEnv(
-      envVars,
-      legacyScmCloneIdentity(this.providerConfig.scmProvider),
-      config.cloneToken
-    );
+    applyScmCloneEnv(envVars, scmCloneIdentity(this.providerConfig.scmProvider), config.cloneToken);
 
     return environment;
   }

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -618,9 +618,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     if (normalized.includes("ANTHROPIC")) return ["api.anthropic.com"];
     if (normalized.includes("OPENAI")) return ["api.openai.com"];
     if (normalized.includes("GITHUB") || normalized.includes("VCS_CLONE")) {
-      return this.providerConfig.scmProvider === "gitlab"
-        ? ["gitlab.com", "api.gitlab.com"]
-        : ["github.com", "api.github.com"];
+      return [...scmCloneIdentity(this.providerConfig.scmProvider).secretHosts];
     }
     return undefined;
   }

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
@@ -225,10 +225,8 @@ describe("VercelSandboxProvider", () => {
     );
   });
 
-  it("maps bitbucket to its own clone identity (unlike the other providers)", async () => {
-    // Vercel is the only provider with real Bitbucket support; the others
-    // collapse bitbucket to the GitHub identity. Locked in so the shared env
-    // assembly can't silently change either side.
+  it("maps bitbucket to its own clone identity", async () => {
+    // Locked in so the shared env assembly can't silently change it.
     const client = createMockClient();
     const provider = new VercelSandboxProvider(client, {
       ...providerConfig,

--- a/packages/control-plane/src/sandbox/sandbox-env.test.ts
+++ b/packages/control-plane/src/sandbox/sandbox-env.test.ts
@@ -101,18 +101,21 @@ describe("buildSessionConfig", () => {
 });
 
 describe("scmCloneIdentity", () => {
-  it("maps each SCM provider to its clone host and username", () => {
+  it("maps each SCM provider to its clone host, username, and secret hosts", () => {
     expect(scmCloneIdentity("github")).toEqual({
       host: "github.com",
       cloneUsername: "x-access-token",
+      secretHosts: ["github.com", "api.github.com"],
     });
     expect(scmCloneIdentity("gitlab")).toEqual({
       host: "gitlab.com",
       cloneUsername: "oauth2",
+      secretHosts: ["gitlab.com", "api.gitlab.com"],
     });
     expect(scmCloneIdentity("bitbucket")).toEqual({
       host: "bitbucket.org",
       cloneUsername: "x-token-auth",
+      secretHosts: ["bitbucket.org", "api.bitbucket.org"],
     });
   });
 });

--- a/packages/control-plane/src/sandbox/sandbox-env.test.ts
+++ b/packages/control-plane/src/sandbox/sandbox-env.test.ts
@@ -3,7 +3,6 @@ import {
   applyScmCloneEnv,
   buildSandboxEnvVars,
   buildSessionConfig,
-  legacyScmCloneIdentity,
   scmCloneIdentity,
 } from "./sandbox-env";
 import type { CreateSandboxConfig } from "./provider";
@@ -115,17 +114,6 @@ describe("scmCloneIdentity", () => {
       host: "bitbucket.org",
       cloneUsername: "x-token-auth",
     });
-  });
-});
-
-describe("legacyScmCloneIdentity", () => {
-  it("resolves gitlab normally", () => {
-    expect(legacyScmCloneIdentity("gitlab")).toEqual(scmCloneIdentity("gitlab"));
-  });
-
-  it("collapses bitbucket to the GitHub identity (historical pre-Bitbucket behavior)", () => {
-    expect(legacyScmCloneIdentity("bitbucket")).toEqual(scmCloneIdentity("github"));
-    expect(legacyScmCloneIdentity("github")).toEqual(scmCloneIdentity("github"));
   });
 });
 

--- a/packages/control-plane/src/sandbox/sandbox-env.ts
+++ b/packages/control-plane/src/sandbox/sandbox-env.ts
@@ -117,18 +117,6 @@ export function scmCloneIdentity(scmProvider: SourceControlProviderName): ScmClo
   return SCM_CLONE_IDENTITIES[scmProvider];
 }
 
-/**
- * Clone identity for providers that predate Bitbucket support (Daytona, E2B,
- * OpenComputer): GitLab resolves normally, every other value — including
- * "bitbucket" — collapses to the GitHub identity. This preserves each
- * provider's historical behavior verbatim; only the Vercel provider maps
- * Bitbucket today. Moving a provider to {@link scmCloneIdentity} is a
- * deliberate behavior change, not a refactor.
- */
-export function legacyScmCloneIdentity(scmProvider: SourceControlProviderName): ScmCloneIdentity {
-  return scmCloneIdentity(scmProvider === "gitlab" ? "gitlab" : "github");
-}
-
 /** Set `VCS_HOST`/`VCS_CLONE_USERNAME` (and the clone token, when given) on an env map. */
 export function applyScmCloneEnv(
   envVars: Record<string, string>,
@@ -154,10 +142,7 @@ export async function deriveCodeServerPassword(sandboxId: string, secret: string
 
 /** Provider-specific inputs to {@link buildSandboxEnvVars}. */
 export interface SandboxEnvVarsOptions {
-  /**
-   * Resolved clone identity — {@link scmCloneIdentity} for providers with full
-   * SCM support, {@link legacyScmCloneIdentity} for the historical mapping.
-   */
+  /** Resolved clone identity — {@link scmCloneIdentity} of the configured SCM provider. */
   scmIdentity: ScmCloneIdentity;
   /**
    * Precomputed code-server password (derivation is provider-specific and

--- a/packages/control-plane/src/sandbox/sandbox-env.ts
+++ b/packages/control-plane/src/sandbox/sandbox-env.ts
@@ -104,12 +104,26 @@ export interface ScmCloneIdentity {
   readonly host: string;
   /** `VCS_CLONE_USERNAME` — username git sends alongside the brokered token. */
   readonly cloneUsername: string;
+  /** Hosts an SCM credential secret may be released to (clone host + API host). */
+  readonly secretHosts: readonly string[];
 }
 
 const SCM_CLONE_IDENTITIES: Record<SourceControlProviderName, ScmCloneIdentity> = {
-  github: { host: "github.com", cloneUsername: "x-access-token" },
-  gitlab: { host: "gitlab.com", cloneUsername: "oauth2" },
-  bitbucket: { host: "bitbucket.org", cloneUsername: "x-token-auth" },
+  github: {
+    host: "github.com",
+    cloneUsername: "x-access-token",
+    secretHosts: ["github.com", "api.github.com"],
+  },
+  gitlab: {
+    host: "gitlab.com",
+    cloneUsername: "oauth2",
+    secretHosts: ["gitlab.com", "api.gitlab.com"],
+  },
+  bitbucket: {
+    host: "bitbucket.org",
+    cloneUsername: "x-token-auth",
+    secretHosts: ["bitbucket.org", "api.bitbucket.org"],
+  },
 };
 
 /** Clone identity for an SCM provider (full github/gitlab/bitbucket mapping). */


### PR DESCRIPTION
## The bug

`sandbox-env.ts` carried two clone-identity resolvers:

- `scmCloneIdentity` — the full, correct map (`github` → `github.com`/`x-access-token`, `gitlab` → `gitlab.com`/`oauth2`, `bitbucket` → `bitbucket.org`/`x-token-auth`). Used only by the Vercel provider.
- `legacyScmCloneIdentity` — historical drift: `gitlab` resolved normally, but **everything else — including `bitbucket`, a valid `SourceControlProviderName` — collapsed to the GitHub identity**. Used by the **Daytona, E2B, and OpenComputer** providers (session env, and OpenComputer's image-build env).

Consequence: a Bitbucket-configured deployment on any of those three providers got

```
VCS_HOST=github.com
VCS_CLONE_USERNAME=x-access-token
```

so the sandbox pointed its credential helper and clone URLs at github.com and clones could never work.

## Why it survived #1059

#1059 was a behavior-preserving env-assembly refactor: it deliberately kept the drift verbatim as `legacyScmCloneIdentity`, locked it with tests, and left unifying on the correct map to a dedicated, reviewable follow-up. This is that follow-up.

## The change

- Every `legacyScmCloneIdentity` call site (Daytona `buildEnvVars`, E2B `createSandbox`, OpenComputer `buildRuntimeEnvironment` + `buildBuildEnvironment`) now uses `scmCloneIdentity`.
- `legacyScmCloneIdentity` is deleted.
- The #1059 drift-lock tests are flipped: the Daytona bitbucket assertion now expects `bitbucket.org`/`x-token-auth`, the `legacyScmCloneIdentity` unit tests are removed, and E2B and OpenComputer gain bitbucket-identity tests so all three providers pin the correct mapping.

**Behavior change**: Bitbucket sessions on Daytona/E2B/OpenComputer switch from the broken GitHub identity to the correct Bitbucket one. No working setup can regress — the old identity could never clone from Bitbucket. GitHub and GitLab identities are unchanged (`legacyScmCloneIdentity` and `scmCloneIdentity` always agreed on those). The credential broker (`/scm-credentials`) is already provider-aware, so only this env-identity layer was wrong.

## Testing

- `npm run build -w @open-inspect/shared` — pass
- `npm run typecheck -w @open-inspect/control-plane` — pass
- Unit: **1987 passed (120 files)**
- Integration: **570 passed (49 files)**
- Prettier + ESLint clean on all changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bitbucket sandbox setup so generated VCS environment values use Bitbucket-specific host and clone username across providers.
  * Updated SCM credential scoping and secret allowlisting to align with the resolved clone identity, ensuring tokens are applied to the correct host set.
* **Tests**
  * Expanded and added coverage for Bitbucket-to-identity mapping during sandbox creation and environment image builds.
  * Removed/updated assertions tied to deprecated legacy SCM identity behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->