### PR TITLE
refactor(sandbox-runtime): extract OpenCodeClient from prompt stream

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -23,7 +23,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, NoReturn
 
-import httpx
 import websockets
 from websockets import ClientConnection, State
 from websockets.exceptions import InvalidStatus
@@ -37,7 +36,7 @@ from .constants import BOOT_WARNINGS_FILE_PATH, REPO_MANIFEST_FILE_PATH
 from .diff_capture import ControlPlaneDiffClient, SessionDiffRefreshWorker
 from .event_forwarder import BufferedEventForwarder
 from .log_config import configure_logging, get_logger
-from .opencode_client import HTTP_CONNECT_TIMEOUT_SECONDS, OpenCodeClient
+from .opencode_client import OpenCodeClient
 from .prompt_stream import OpenCodePromptStream
 from .repo_config import find_repo_entry, load_repo_manifest
 from .types import GitUser
@@ -143,8 +142,6 @@ class AgentBridge:
     SSE_INACTIVITY_TIMEOUT = 120.0
     SSE_INACTIVITY_TIMEOUT_MIN = 5.0
     SSE_INACTIVITY_TIMEOUT_MAX = 3600.0
-    HTTP_CONNECT_TIMEOUT = HTTP_CONNECT_TIMEOUT_SECONDS
-    HTTP_DEFAULT_TIMEOUT = 30.0
     GIT_PUSH_TIMEOUT_SECONDS = 300.0
     GIT_PUSH_TERMINATE_GRACE_SECONDS = 5.0
     PROMPT_MAX_DURATION = 5400.0
@@ -158,6 +155,7 @@ class AgentBridge:
         control_plane_url: str,
         auth_token: str,
         opencode_port: int = 4096,
+        opencode_client: OpenCodeClient | None = None,
     ):
         self.sandbox_id = sandbox_id
         self.session_id = session_id
@@ -201,13 +199,15 @@ class AgentBridge:
         # names into the filesystem.
         self.repo_manifest_path = Path(REPO_MANIFEST_FILE_PATH)
 
-        # HTTP client for OpenCode API
-        self.http_client: httpx.AsyncClient | None = None
+        # OpenCode transport client; owns its connection pool unless one was
+        # injected (mirrors ControlPlaneDiffClient).
+        self.opencode_client = opencode_client or OpenCodeClient(
+            base_url=self.opencode_base_url,
+            log=self.log,
+        )
 
-        # OpenCode transport client and prompt SSE translator; created on
-        # first use because they share the HTTP client that only exists once
-        # run() has started.
-        self._opencode_client: OpenCodeClient | None = None
+        # Prompt SSE translator; created on first prompt so that
+        # sse_inactivity_timeout stays overridable until streaming starts.
         self._prompt_stream: OpenCodePromptStream | None = None
 
         # Track the current prompt task so _handle_stop can cancel it
@@ -272,12 +272,6 @@ class AgentBridge:
         """
         self.log.info("bridge.run_start")
 
-        self.http_client = httpx.AsyncClient(
-            timeout=httpx.Timeout(
-                self.HTTP_DEFAULT_TIMEOUT,
-                connect=self.HTTP_CONNECT_TIMEOUT,
-            )
-        )
         await self._load_session_id()
 
         reconnect_attempts = 0
@@ -336,8 +330,7 @@ class AgentBridge:
             await self.diff_refresh.close(
                 timeout_seconds=self.DIFF_REFRESH_SHUTDOWN_TIMEOUT_SECONDS
             )
-            if self.http_client:
-                await self.http_client.aclose()
+            await self.opencode_client.aclose()
             self.log.info(
                 "bridge.run_complete",
                 outcome=run_outcome,
@@ -725,7 +718,7 @@ class AgentBridge:
 
     async def _create_opencode_session(self) -> None:
         """Create a new OpenCode session."""
-        self.opencode_session_id = await self._ensure_opencode_client().create_session()
+        self.opencode_session_id = await self.opencode_client.create_session()
         self.log.info(
             "opencode.session.ensure",
             opencode_session_id=self.opencode_session_id,
@@ -734,27 +727,11 @@ class AgentBridge:
 
         await self._save_session_id()
 
-    def _ensure_opencode_client(self) -> OpenCodeClient:
-        """The long-lived OpenCode transport client, created on first use.
-
-        Lazy because it shares the bridge's HTTP client, which only exists
-        once run() has started.
-        """
-        if self._opencode_client is None:
-            if not self.http_client:
-                raise RuntimeError("HTTP client not initialized")
-            self._opencode_client = OpenCodeClient(
-                http_client=self.http_client,
-                base_url=self.opencode_base_url,
-                log=self.log,
-            )
-        return self._opencode_client
-
     def _ensure_prompt_stream(self) -> OpenCodePromptStream:
         """The long-lived prompt SSE translator, created on first use."""
         if self._prompt_stream is None:
             self._prompt_stream = OpenCodePromptStream(
-                client=self._ensure_opencode_client(),
+                client=self.opencode_client,
                 attachment_processor=self.attachment_processor,
                 log=self.log,
                 sse_inactivity_timeout_seconds=self.sse_inactivity_timeout,
@@ -771,7 +748,7 @@ class AgentBridge:
         attachments: list[HydratedSessionAttachment] | None = None,
     ) -> AsyncIterator[dict[str, Any]]:
         """Stream one prompt's response events (see prompt_stream.py)."""
-        if not self.http_client or not self.opencode_session_id:
+        if not self.opencode_session_id:
             raise RuntimeError("OpenCode session not initialized")
 
         stream = self._ensure_prompt_stream()
@@ -1080,17 +1057,15 @@ class AgentBridge:
                     action="loaded",
                 )
 
-                if self.http_client:
-                    try:
-                        client = self._ensure_opencode_client()
-                        if not await client.session_exists(self.opencode_session_id):
-                            self.log.info(
-                                "opencode.session.invalid",
-                                opencode_session_id=self.opencode_session_id,
-                            )
-                            self.opencode_session_id = None
-                    except Exception:
+                try:
+                    if not await self.opencode_client.session_exists(self.opencode_session_id):
+                        self.log.info(
+                            "opencode.session.invalid",
+                            opencode_session_id=self.opencode_session_id,
+                        )
                         self.opencode_session_id = None
+                except Exception:
+                    self.opencode_session_id = None
 
             except Exception as e:
                 self.log.error("opencode.session.load_error", exc=e)
@@ -1104,11 +1079,9 @@ class AgentBridge:
                 self.log.error("opencode.session.save_error", exc=e)
 
     async def _request_opencode_stop(self, reason: str) -> bool:
-        if not self.http_client or not self.opencode_session_id:
+        if not self.opencode_session_id:
             return False
-        return await self._ensure_opencode_client().request_stop(
-            self.opencode_session_id, reason=reason
-        )
+        return await self.opencode_client.request_stop(self.opencode_session_id, reason=reason)
 
     def _resolve_timeout_seconds(
         self,

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -37,11 +37,12 @@ from .constants import BOOT_WARNINGS_FILE_PATH, REPO_MANIFEST_FILE_PATH
 from .diff_capture import ControlPlaneDiffClient, SessionDiffRefreshWorker
 from .event_forwarder import BufferedEventForwarder
 from .log_config import configure_logging, get_logger
-from .prompt_stream import (
+from .opencode_client import (
     HTTP_CONNECT_TIMEOUT_SECONDS,
     OPENCODE_REQUEST_TIMEOUT_SECONDS,
-    OpenCodePromptStream,
+    OpenCodeClient,
 )
+from .prompt_stream import OpenCodePromptStream
 from .repo_config import find_repo_entry, load_repo_manifest
 from .types import GitUser
 
@@ -208,8 +209,10 @@ class AgentBridge:
         # HTTP client for OpenCode API
         self.http_client: httpx.AsyncClient | None = None
 
-        # Prompt SSE translator; created on first use because it shares the
-        # HTTP client that only exists once run() has started.
+        # OpenCode transport client and prompt SSE translator; created on
+        # first use because they share the HTTP client that only exists once
+        # run() has started.
+        self._opencode_client: OpenCodeClient | None = None
         self._prompt_stream: OpenCodePromptStream | None = None
 
         # Track the current prompt task so _handle_stop can cancel it
@@ -747,18 +750,27 @@ class AgentBridge:
 
         await self._save_session_id()
 
-    def _ensure_prompt_stream(self) -> OpenCodePromptStream:
-        """The long-lived prompt SSE translator, created on first use.
+    def _ensure_opencode_client(self) -> OpenCodeClient:
+        """The long-lived OpenCode transport client, created on first use.
 
         Lazy because it shares the bridge's HTTP client, which only exists
         once run() has started.
         """
-        if self._prompt_stream is None:
+        if self._opencode_client is None:
             if not self.http_client:
                 raise RuntimeError("HTTP client not initialized")
-            self._prompt_stream = OpenCodePromptStream(
+            self._opencode_client = OpenCodeClient(
                 http_client=self.http_client,
-                opencode_base_url=self.opencode_base_url,
+                base_url=self.opencode_base_url,
+                log=self.log,
+            )
+        return self._opencode_client
+
+    def _ensure_prompt_stream(self) -> OpenCodePromptStream:
+        """The long-lived prompt SSE translator, created on first use."""
+        if self._prompt_stream is None:
+            self._prompt_stream = OpenCodePromptStream(
+                client=self._ensure_opencode_client(),
                 attachment_processor=self.attachment_processor,
                 log=self.log,
                 sse_inactivity_timeout_seconds=self.sse_inactivity_timeout,
@@ -1113,7 +1125,7 @@ class AgentBridge:
     async def _request_opencode_stop(self, reason: str) -> bool:
         if not self.http_client or not self.opencode_session_id:
             return False
-        return await self._ensure_prompt_stream().request_stop(
+        return await self._ensure_opencode_client().request_stop(
             self.opencode_session_id, reason=reason
         )
 

--- a/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/bridge.py
@@ -37,11 +37,7 @@ from .constants import BOOT_WARNINGS_FILE_PATH, REPO_MANIFEST_FILE_PATH
 from .diff_capture import ControlPlaneDiffClient, SessionDiffRefreshWorker
 from .event_forwarder import BufferedEventForwarder
 from .log_config import configure_logging, get_logger
-from .opencode_client import (
-    HTTP_CONNECT_TIMEOUT_SECONDS,
-    OPENCODE_REQUEST_TIMEOUT_SECONDS,
-    OpenCodeClient,
-)
+from .opencode_client import HTTP_CONNECT_TIMEOUT_SECONDS, OpenCodeClient
 from .prompt_stream import OpenCodePromptStream
 from .repo_config import find_repo_entry, load_repo_manifest
 from .types import GitUser
@@ -149,7 +145,6 @@ class AgentBridge:
     SSE_INACTIVITY_TIMEOUT_MAX = 3600.0
     HTTP_CONNECT_TIMEOUT = HTTP_CONNECT_TIMEOUT_SECONDS
     HTTP_DEFAULT_TIMEOUT = 30.0
-    OPENCODE_REQUEST_TIMEOUT = OPENCODE_REQUEST_TIMEOUT_SECONDS
     GIT_PUSH_TIMEOUT_SECONDS = 300.0
     GIT_PUSH_TERMINATE_GRACE_SECONDS = 5.0
     PROMPT_MAX_DURATION = 5400.0
@@ -730,18 +725,7 @@ class AgentBridge:
 
     async def _create_opencode_session(self) -> None:
         """Create a new OpenCode session."""
-        if not self.http_client:
-            raise RuntimeError("HTTP client not initialized")
-
-        resp = await self.http_client.post(
-            f"{self.opencode_base_url}/session",
-            json={},
-            timeout=self.OPENCODE_REQUEST_TIMEOUT,
-        )
-        resp.raise_for_status()
-        data = resp.json()
-
-        self.opencode_session_id = data.get("id")
+        self.opencode_session_id = await self._ensure_opencode_client().create_session()
         self.log.info(
             "opencode.session.ensure",
             opencode_session_id=self.opencode_session_id,
@@ -1098,11 +1082,8 @@ class AgentBridge:
 
                 if self.http_client:
                     try:
-                        resp = await self.http_client.get(
-                            f"{self.opencode_base_url}/session/{self.opencode_session_id}",
-                            timeout=self.OPENCODE_REQUEST_TIMEOUT,
-                        )
-                        if resp.status_code != 200:
+                        client = self._ensure_opencode_client()
+                        if not await client.session_exists(self.opencode_session_id):
                             self.log.info(
                                 "opencode.session.invalid",
                                 opencode_session_id=self.opencode_session_id,

--- a/packages/sandbox-runtime/src/sandbox_runtime/opencode_client.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/opencode_client.py
@@ -22,14 +22,22 @@ class SSEConnectionError(Exception):
     """Raised when SSE connection fails."""
 
 
+class SSEStreamDisconnectedError(SSEConnectionError):
+    """Raised when the SSE transport fails while connecting or mid-stream."""
+
+
+class SSEInactivityTimeoutError(Exception):
+    """Raised when no SSE data arrives within the inactivity deadline."""
+
+
 class OpenCodeClient:
     """HTTP/SSE transport for the local OpenCode server.
 
-    Owns the OpenCode base URL and every raw wire concern: opening the
-    ``/event`` SSE stream, parsing SSE frames, kicking off async prompts,
-    aborting sessions, and fetching message state. Prompt-lifecycle policy
-    (inactivity/max-duration timeouts, request-body construction, event
-    translation) stays in ``OpenCodePromptStream``.
+    Owns the OpenCode base URL and every raw wire concern: session
+    creation/lookup, the ``/event`` SSE stream and its frame parsing, kicking
+    off async prompts, aborting sessions, and fetching message state.
+    Prompt-lifecycle policy (inactivity/max-duration values, request-body
+    construction, event translation) stays in ``OpenCodePromptStream``.
     """
 
     def __init__(
@@ -47,17 +55,56 @@ class OpenCodeClient:
         self._connect_timeout_seconds = connect_timeout_seconds
         self._request_timeout_seconds = request_timeout_seconds
 
+    async def create_session(self) -> str | None:
+        """Create a new OpenCode session, returning its id."""
+        response = await self._http_client.post(
+            f"{self._base_url}/session",
+            json={},
+            timeout=self._request_timeout_seconds,
+        )
+        response.raise_for_status()
+        data: dict[str, Any] = response.json()
+        session_id: str | None = data.get("id")
+        return session_id
+
+    async def session_exists(self, opencode_session_id: str) -> bool:
+        """Whether OpenCode still knows the session (a 200 from its lookup)."""
+        response = await self._http_client.get(
+            f"{self._base_url}/session/{opencode_session_id}",
+            timeout=self._request_timeout_seconds,
+        )
+        return response.status_code == 200
+
     @asynccontextmanager
-    async def open_event_stream(self) -> AsyncIterator[httpx.Response]:
-        """Open the ``/event`` SSE stream, failing fast on a non-200 response."""
-        async with self._http_client.stream(
-            "GET",
-            f"{self._base_url}/event",
-            timeout=httpx.Timeout(None, connect=self._connect_timeout_seconds, read=None),
-        ) as response:
-            if response.status_code != 200:
-                raise SSEConnectionError(f"SSE connection failed: {response.status_code}")
-            yield response
+    async def events(
+        self, *, inactivity_timeout_seconds: float
+    ) -> AsyncIterator[AsyncIterator[dict[str, Any]]]:
+        """Open the ``/event`` SSE stream and hand back decoded event dicts.
+
+        Owns the response lifecycle and the inactivity deadline: the deadline
+        is armed before connecting, reset on every chunk received, and covers
+        the caller's body for the lifetime of the context; expiry raises
+        ``SSEInactivityTimeoutError``. A non-200 handshake raises
+        ``SSEConnectionError``; httpx transport failures (while connecting or
+        mid-stream) are translated into ``SSEStreamDisconnectedError``.
+        """
+        try:
+            async with asyncio.timeout(inactivity_timeout_seconds) as timeout_ctx:
+                async with self._http_client.stream(
+                    "GET",
+                    f"{self._base_url}/event",
+                    timeout=httpx.Timeout(None, connect=self._connect_timeout_seconds, read=None),
+                ) as response:
+                    if response.status_code != 200:
+                        raise SSEConnectionError(f"SSE connection failed: {response.status_code}")
+                    yield self._decoded_events(response, timeout_ctx, inactivity_timeout_seconds)
+        except TimeoutError:
+            raise SSEInactivityTimeoutError(
+                f"SSE stream inactive for {inactivity_timeout_seconds:.0f}s (no data received)."
+            )
+        except httpx.TransportError as e:
+            self._log.error("bridge.sse_transport_error", exc=e)
+            raise SSEStreamDisconnectedError(str(e)) from e
 
     async def post_prompt(self, opencode_session_id: str, request_body: dict[str, Any]) -> None:
         """Kick off the async prompt; the response arrives on the SSE stream."""
@@ -106,7 +153,7 @@ class OpenCodeClient:
         messages: list[Any] = response.json()
         return messages
 
-    async def parse_sse_stream(
+    async def _decoded_events(
         self,
         response: httpx.Response,
         timeout_ctx: asyncio.Timeout | None = None,

--- a/packages/sandbox-runtime/src/sandbox_runtime/opencode_client.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/opencode_client.py
@@ -1,0 +1,156 @@
+"""HTTP/SSE transport client for the bundled local OpenCode server."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any, Final
+
+import httpx
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from .log_config import StructuredLogger
+
+HTTP_CONNECT_TIMEOUT_SECONDS: Final = 30.0
+OPENCODE_REQUEST_TIMEOUT_SECONDS: Final = 30.0
+
+
+class SSEConnectionError(Exception):
+    """Raised when SSE connection fails."""
+
+
+class OpenCodeClient:
+    """HTTP/SSE transport for the local OpenCode server.
+
+    Owns the OpenCode base URL and every raw wire concern: opening the
+    ``/event`` SSE stream, parsing SSE frames, kicking off async prompts,
+    aborting sessions, and fetching message state. Prompt-lifecycle policy
+    (inactivity/max-duration timeouts, request-body construction, event
+    translation) stays in ``OpenCodePromptStream``.
+    """
+
+    def __init__(
+        self,
+        *,
+        http_client: httpx.AsyncClient,
+        base_url: str,
+        log: StructuredLogger,
+        connect_timeout_seconds: float = HTTP_CONNECT_TIMEOUT_SECONDS,
+        request_timeout_seconds: float = OPENCODE_REQUEST_TIMEOUT_SECONDS,
+    ) -> None:
+        self._http_client = http_client
+        self._base_url = base_url
+        self._log = log
+        self._connect_timeout_seconds = connect_timeout_seconds
+        self._request_timeout_seconds = request_timeout_seconds
+
+    @asynccontextmanager
+    async def open_event_stream(self) -> AsyncIterator[httpx.Response]:
+        """Open the ``/event`` SSE stream, failing fast on a non-200 response."""
+        async with self._http_client.stream(
+            "GET",
+            f"{self._base_url}/event",
+            timeout=httpx.Timeout(None, connect=self._connect_timeout_seconds, read=None),
+        ) as response:
+            if response.status_code != 200:
+                raise SSEConnectionError(f"SSE connection failed: {response.status_code}")
+            yield response
+
+    async def post_prompt(self, opencode_session_id: str, request_body: dict[str, Any]) -> None:
+        """Kick off the async prompt; the response arrives on the SSE stream."""
+        prompt_response = await self._http_client.post(
+            f"{self._base_url}/session/{opencode_session_id}/prompt_async",
+            json=request_body,
+            timeout=self._request_timeout_seconds,
+        )
+        if prompt_response.status_code not in [200, 204]:
+            error_body = prompt_response.text
+            self._log.error(
+                "bridge.prompt_request_error",
+                status_code=prompt_response.status_code,
+                error_body=error_body,
+            )
+            raise RuntimeError(f"Async prompt failed: {prompt_response.status_code} - {error_body}")
+
+    async def request_stop(self, opencode_session_id: str | None, *, reason: str) -> bool:
+        """Best-effort abort of the active OpenCode prompt (saves LLM compute)."""
+        if not opencode_session_id:
+            return False
+
+        try:
+            await self._http_client.post(
+                f"{self._base_url}/session/{opencode_session_id}/abort",
+                timeout=self._request_timeout_seconds,
+            )
+            self._log.info("bridge.stop_requested", reason=reason)
+            return True
+        except Exception as e:
+            self._log.warn("bridge.stop_request_error", exc=e, reason=reason)
+            return False
+
+    async def get_messages(self, opencode_session_id: str) -> list[Any] | None:
+        """Fetch the session's message list; ``None`` when OpenCode rejects the fetch."""
+        response = await self._http_client.get(
+            f"{self._base_url}/session/{opencode_session_id}/message",
+            timeout=self._request_timeout_seconds,
+        )
+        if response.status_code != 200:
+            self._log.warn(
+                "bridge.final_state_fetch_error",
+                status_code=response.status_code,
+            )
+            return None
+        messages: list[Any] = response.json()
+        return messages
+
+    async def parse_sse_stream(
+        self,
+        response: httpx.Response,
+        timeout_ctx: asyncio.Timeout | None = None,
+        inactivity_timeout_seconds: float | None = None,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Parse Server-Sent Events stream from OpenCode.
+
+        SSE format:
+            data: {"type": "...", "properties": {...}}
+
+            data: {"type": "...", "properties": {...}}
+
+        Events are separated by double newlines.
+        If timeout_ctx is provided, its deadline is reset to now plus
+        ``inactivity_timeout_seconds`` on every chunk received.
+        """
+        buffer = ""
+        async for chunk in response.aiter_text():
+            buffer += chunk
+            if timeout_ctx is not None and inactivity_timeout_seconds is not None:
+                timeout_ctx.reschedule(
+                    asyncio.get_running_loop().time() + inactivity_timeout_seconds
+                )
+
+            # Frames split on LF-LF only: the peer is the bundled localhost
+            # OpenCode server (Bun/Hono), which emits LF-framed SSE. CRLF
+            # framing is deliberately not handled.
+            while "\n\n" in buffer:
+                event_str, buffer = buffer.split("\n\n", 1)
+
+                # Parse the event lines
+                data_lines: list[str] = []
+                for line in event_str.split("\n"):
+                    if line.startswith("data:"):
+                        # Handle both "data: {...}" and "data:{...}" formats
+                        data_content = line[5:].lstrip()
+                        if data_content:
+                            data_lines.append(data_content)
+
+                # Join multi-line data and parse JSON
+                if data_lines:
+                    try:
+                        raw_data = "\n".join(data_lines)
+                        event = json.loads(raw_data)
+                        yield event
+                    except json.JSONDecodeError as e:
+                        self._log.debug("bridge.sse_parse_error", exc=e)

--- a/packages/sandbox-runtime/src/sandbox_runtime/opencode_client.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/opencode_client.py
@@ -38,26 +38,45 @@ class OpenCodeClient:
     off async prompts, aborting sessions, and fetching message state.
     Prompt-lifecycle policy (inactivity/max-duration values, request-body
     construction, event translation) stays in ``OpenCodePromptStream``.
+
+    Owns its connection pool unless one is injected.
     """
 
     def __init__(
         self,
         *,
-        http_client: httpx.AsyncClient,
         base_url: str,
         log: StructuredLogger,
+        http_client: httpx.AsyncClient | None = None,
         connect_timeout_seconds: float = HTTP_CONNECT_TIMEOUT_SECONDS,
         request_timeout_seconds: float = OPENCODE_REQUEST_TIMEOUT_SECONDS,
     ) -> None:
-        self._http_client = http_client
         self._base_url = base_url
         self._log = log
+        self._http_client = http_client
+        self._owns_http_client = http_client is None
         self._connect_timeout_seconds = connect_timeout_seconds
         self._request_timeout_seconds = request_timeout_seconds
 
+    async def aclose(self) -> None:
+        if self._owns_http_client and self._http_client is not None:
+            await self._http_client.aclose()
+
+    def _client(self) -> httpx.AsyncClient:
+        # Created on first request so constructing a bridge that never runs
+        # (common in tests) does not leak an unclosed connection pool.
+        if self._http_client is None:
+            self._http_client = httpx.AsyncClient(
+                timeout=httpx.Timeout(
+                    self._request_timeout_seconds,
+                    connect=self._connect_timeout_seconds,
+                )
+            )
+        return self._http_client
+
     async def create_session(self) -> str | None:
         """Create a new OpenCode session, returning its id."""
-        response = await self._http_client.post(
+        response = await self._client().post(
             f"{self._base_url}/session",
             json={},
             timeout=self._request_timeout_seconds,
@@ -69,7 +88,7 @@ class OpenCodeClient:
 
     async def session_exists(self, opencode_session_id: str) -> bool:
         """Whether OpenCode still knows the session (a 200 from its lookup)."""
-        response = await self._http_client.get(
+        response = await self._client().get(
             f"{self._base_url}/session/{opencode_session_id}",
             timeout=self._request_timeout_seconds,
         )
@@ -90,7 +109,7 @@ class OpenCodeClient:
         """
         try:
             async with asyncio.timeout(inactivity_timeout_seconds) as timeout_ctx:
-                async with self._http_client.stream(
+                async with self._client().stream(
                     "GET",
                     f"{self._base_url}/event",
                     timeout=httpx.Timeout(None, connect=self._connect_timeout_seconds, read=None),
@@ -108,7 +127,7 @@ class OpenCodeClient:
 
     async def post_prompt(self, opencode_session_id: str, request_body: dict[str, Any]) -> None:
         """Kick off the async prompt; the response arrives on the SSE stream."""
-        prompt_response = await self._http_client.post(
+        prompt_response = await self._client().post(
             f"{self._base_url}/session/{opencode_session_id}/prompt_async",
             json=request_body,
             timeout=self._request_timeout_seconds,
@@ -128,7 +147,7 @@ class OpenCodeClient:
             return False
 
         try:
-            await self._http_client.post(
+            await self._client().post(
                 f"{self._base_url}/session/{opencode_session_id}/abort",
                 timeout=self._request_timeout_seconds,
             )
@@ -140,7 +159,7 @@ class OpenCodeClient:
 
     async def get_messages(self, opencode_session_id: str) -> list[Any] | None:
         """Fetch the session's message list; ``None`` when OpenCode rejects the fetch."""
-        response = await self._http_client.get(
+        response = await self._client().get(
             f"{self._base_url}/session/{opencode_session_id}/message",
             timeout=self._request_timeout_seconds,
         )

--- a/packages/sandbox-runtime/src/sandbox_runtime/opencode_identifier.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/opencode_identifier.py
@@ -1,0 +1,66 @@
+"""OpenCode-compatible ascending ID generation."""
+
+from __future__ import annotations
+
+import secrets
+import time
+from typing import ClassVar
+
+
+class OpenCodeIdentifier:
+    """
+    Generate OpenCode-compatible ascending IDs.
+
+    Port of OpenCode's TypeScript implementation:
+    https://github.com/anomalyco/opencode/blob/8f0d08fae07c97a090fcd31d0d4c4a6fa7eeaa1d/packages/opencode/src/id/id.ts
+
+    Format: {prefix}_{timestamp_hex}{random_base62}
+    - prefix: type identifier (e.g., "msg" for messages)
+    - timestamp_hex: 12 hex chars encoding (timestamp_ms * 0x1000 + counter)
+    - random_base62: 14 random base62 characters
+
+    IDs are monotonically increasing, ensuring new user messages always have
+    IDs greater than previous assistant messages (required for OpenCode's
+    prompt loop).
+
+    Note: Uses class-level state for monotonic generation. Safe for async code
+    but NOT thread-safe.
+    """
+
+    PREFIXES: ClassVar[dict[str, str]] = {
+        "session": "ses",
+        "message": "msg",
+        "part": "prt",
+    }
+    BASE62_CHARS: ClassVar[str] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+    RANDOM_LENGTH: ClassVar[int] = 14
+
+    _last_timestamp: ClassVar[int] = 0
+    _counter: ClassVar[int] = 0
+
+    @classmethod
+    def ascending(cls, prefix: str) -> str:
+        """Generate an ascending ID with the given prefix."""
+        if prefix not in cls.PREFIXES:
+            raise ValueError(f"Unknown prefix: {prefix}")
+
+        prefix_str = cls.PREFIXES[prefix]
+        current_timestamp = int(time.time() * 1000)
+
+        if current_timestamp != cls._last_timestamp:
+            cls._last_timestamp = current_timestamp
+            cls._counter = 0
+        cls._counter += 1
+
+        encoded = current_timestamp * 0x1000 + cls._counter
+        encoded_48bit = encoded & 0xFFFFFFFFFFFF
+        timestamp_bytes = encoded_48bit.to_bytes(6, byteorder="big")
+        timestamp_hex = timestamp_bytes.hex()
+        random_suffix = cls._random_base62(cls.RANDOM_LENGTH)
+
+        return f"{prefix_str}_{timestamp_hex}{random_suffix}"
+
+    @classmethod
+    def _random_base62(cls, length: int) -> str:
+        """Generate random base62 string."""
+        return "".join(cls.BASE62_CHARS[secrets.randbelow(62)] for _ in range(length))

--- a/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
@@ -3,24 +3,23 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import re
-import secrets
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, ClassVar, Final
+from typing import TYPE_CHECKING, Any, Final
 
 import httpx
+
+from .opencode_client import SSEConnectionError
+from .opencode_identifier import OpenCodeIdentifier
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
     from .attachment_processor import AttachmentProcessor, HydratedSessionAttachment
     from .log_config import StructuredLogger
-
-HTTP_CONNECT_TIMEOUT_SECONDS: Final = 30.0
-OPENCODE_REQUEST_TIMEOUT_SECONDS: Final = 30.0
+    from .opencode_client import OpenCodeClient
 
 # Cap on parts buffered for assistant messages that have not been authorized
 # yet (their message.updated may arrive after their first parts).
@@ -50,69 +49,6 @@ OPENCODE_DEFAULT_TITLE_RE: Final = re.compile(
     r"^(new session|child session) - " r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$",
     re.IGNORECASE,
 )
-
-
-class SSEConnectionError(Exception):
-    """Raised when SSE connection fails."""
-
-
-class OpenCodeIdentifier:
-    """
-    Generate OpenCode-compatible ascending IDs.
-
-    Port of OpenCode's TypeScript implementation:
-    https://github.com/anomalyco/opencode/blob/8f0d08fae07c97a090fcd31d0d4c4a6fa7eeaa1d/packages/opencode/src/id/id.ts
-
-    Format: {prefix}_{timestamp_hex}{random_base62}
-    - prefix: type identifier (e.g., "msg" for messages)
-    - timestamp_hex: 12 hex chars encoding (timestamp_ms * 0x1000 + counter)
-    - random_base62: 14 random base62 characters
-
-    IDs are monotonically increasing, ensuring new user messages always have
-    IDs greater than previous assistant messages (required for OpenCode's
-    prompt loop).
-
-    Note: Uses class-level state for monotonic generation. Safe for async code
-    but NOT thread-safe.
-    """
-
-    PREFIXES: ClassVar[dict[str, str]] = {
-        "session": "ses",
-        "message": "msg",
-        "part": "prt",
-    }
-    BASE62_CHARS: ClassVar[str] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-    RANDOM_LENGTH: ClassVar[int] = 14
-
-    _last_timestamp: ClassVar[int] = 0
-    _counter: ClassVar[int] = 0
-
-    @classmethod
-    def ascending(cls, prefix: str) -> str:
-        """Generate an ascending ID with the given prefix."""
-        if prefix not in cls.PREFIXES:
-            raise ValueError(f"Unknown prefix: {prefix}")
-
-        prefix_str = cls.PREFIXES[prefix]
-        current_timestamp = int(time.time() * 1000)
-
-        if current_timestamp != cls._last_timestamp:
-            cls._last_timestamp = current_timestamp
-            cls._counter = 0
-        cls._counter += 1
-
-        encoded = current_timestamp * 0x1000 + cls._counter
-        encoded_48bit = encoded & 0xFFFFFFFFFFFF
-        timestamp_bytes = encoded_48bit.to_bytes(6, byteorder="big")
-        timestamp_hex = timestamp_bytes.hex()
-        random_suffix = cls._random_base62(cls.RANDOM_LENGTH)
-
-        return f"{prefix_str}_{timestamp_hex}{random_suffix}"
-
-    @classmethod
-    def _random_base62(cls, length: int) -> str:
-        """Generate random base62 string."""
-        return "".join(cls.BASE62_CHARS[secrets.randbelow(62)] for _ in range(length))
 
 
 @dataclass(frozen=True)
@@ -181,15 +117,13 @@ class OpenCodePromptStream:
     def __init__(
         self,
         *,
-        http_client: httpx.AsyncClient,
-        opencode_base_url: str,
+        client: OpenCodeClient,
         attachment_processor: AttachmentProcessor,
         log: StructuredLogger,
         sse_inactivity_timeout_seconds: float,
         prompt_max_duration_seconds: float,
     ) -> None:
-        self._http_client = http_client
-        self._opencode_base_url = opencode_base_url
+        self._client = client
         self._attachment_processor = attachment_processor
         self._log = log
         self._sse_inactivity_timeout_seconds = sse_inactivity_timeout_seconds
@@ -219,9 +153,6 @@ class OpenCodePromptStream:
             content, model, opencode_message_id, reasoning_effort, attachments
         )
 
-        sse_url = f"{self._opencode_base_url}/event"
-        async_url = f"{self._opencode_base_url}/session/{opencode_session_id}/prompt_async"
-
         state = _PromptState(
             opencode_session_id=opencode_session_id,
             message_id=message_id,
@@ -234,20 +165,15 @@ class OpenCodePromptStream:
         try:
             deadline = loop.time() + self._sse_inactivity_timeout_seconds
             async with asyncio.timeout_at(deadline) as timeout_ctx:
-                async with self._http_client.stream(
-                    "GET",
-                    sse_url,
-                    timeout=httpx.Timeout(None, connect=HTTP_CONNECT_TIMEOUT_SECONDS, read=None),
-                ) as sse_response:
-                    if sse_response.status_code != 200:
-                        raise SSEConnectionError(
-                            f"SSE connection failed: {sse_response.status_code}"
-                        )
-
+                async with self._client.open_event_stream() as sse_response:
                     prompt_start = loop.time()
-                    await self._post_prompt(async_url, request_body)
+                    await self._client.post_prompt(opencode_session_id, request_body)
 
-                    async for sse_event in self._parse_sse_stream(sse_response, timeout_ctx):
+                    async for sse_event in self._client.parse_sse_stream(
+                        sse_response,
+                        timeout_ctx,
+                        inactivity_timeout_seconds=self._sse_inactivity_timeout_seconds,
+                    ):
                         step = self._apply_sse_event(state, sse_event)
                         for event in step.events:
                             yield event
@@ -267,7 +193,7 @@ class OpenCodePromptStream:
                                 elapsed_ms=int(elapsed * 1000),
                                 message_id=message_id,
                             )
-                            await self.request_stop(
+                            await self._client.request_stop(
                                 opencode_session_id, reason="prompt_max_duration_timeout"
                             )
                             async for final_event in self._fetch_final_message_state(state):
@@ -287,7 +213,7 @@ class OpenCodePromptStream:
                 operation="bridge.sse",
                 message_id=message_id,
             )
-            await self.request_stop(opencode_session_id, reason="inactivity_timeout")
+            await self._client.request_stop(opencode_session_id, reason="inactivity_timeout")
             async for final_event in self._fetch_final_message_state(state):
                 yield final_event
             raise RuntimeError(
@@ -303,85 +229,6 @@ class OpenCodePromptStream:
                 "OpenCode event stream disconnected before completion; "
                 "partial output was preserved when available."
             ) from e
-
-    async def request_stop(self, opencode_session_id: str | None, *, reason: str) -> bool:
-        """Best-effort abort of the active OpenCode prompt (saves LLM compute)."""
-        if not opencode_session_id:
-            return False
-
-        try:
-            await self._http_client.post(
-                f"{self._opencode_base_url}/session/{opencode_session_id}/abort",
-                timeout=OPENCODE_REQUEST_TIMEOUT_SECONDS,
-            )
-            self._log.info("bridge.stop_requested", reason=reason)
-            return True
-        except Exception as e:
-            self._log.warn("bridge.stop_request_error", exc=e, reason=reason)
-            return False
-
-    async def _post_prompt(self, async_url: str, request_body: dict[str, Any]) -> None:
-        """Kick off the async prompt; the response arrives on the SSE stream."""
-        prompt_response = await self._http_client.post(
-            async_url,
-            json=request_body,
-            timeout=OPENCODE_REQUEST_TIMEOUT_SECONDS,
-        )
-        if prompt_response.status_code not in [200, 204]:
-            error_body = prompt_response.text
-            self._log.error(
-                "bridge.prompt_request_error",
-                status_code=prompt_response.status_code,
-                error_body=error_body,
-            )
-            raise RuntimeError(f"Async prompt failed: {prompt_response.status_code} - {error_body}")
-
-    async def _parse_sse_stream(
-        self,
-        response: httpx.Response,
-        timeout_ctx: asyncio.Timeout | None = None,
-    ) -> AsyncIterator[dict[str, Any]]:
-        """Parse Server-Sent Events stream from OpenCode.
-
-        SSE format:
-            data: {"type": "...", "properties": {...}}
-
-            data: {"type": "...", "properties": {...}}
-
-        Events are separated by double newlines.
-        If timeout_ctx is provided, the deadline is reset on every chunk received.
-        """
-        buffer = ""
-        async for chunk in response.aiter_text():
-            buffer += chunk
-            if timeout_ctx is not None:
-                timeout_ctx.reschedule(
-                    asyncio.get_running_loop().time() + self._sse_inactivity_timeout_seconds
-                )
-
-            # Frames split on LF-LF only: the peer is the bundled localhost
-            # OpenCode server (Bun/Hono), which emits LF-framed SSE. CRLF
-            # framing is deliberately not handled.
-            while "\n\n" in buffer:
-                event_str, buffer = buffer.split("\n\n", 1)
-
-                # Parse the event lines
-                data_lines: list[str] = []
-                for line in event_str.split("\n"):
-                    if line.startswith("data:"):
-                        # Handle both "data: {...}" and "data:{...}" formats
-                        data_content = line[5:].lstrip()
-                        if data_content:
-                            data_lines.append(data_content)
-
-                # Join multi-line data and parse JSON
-                if data_lines:
-                    try:
-                        raw_data = "\n".join(data_lines)
-                        event = json.loads(raw_data)
-                        yield event
-                    except json.JSONDecodeError as e:
-                        self._log.debug("bridge.sse_parse_error", exc=e)
 
     def _apply_sse_event(self, state: _PromptState, sse_event: dict[str, Any]) -> _StreamStep:
         """Translate one OpenCode SSE event into bridge events, mutating state."""
@@ -841,21 +688,10 @@ class OpenCodePromptStream:
         if not state.opencode_session_id:
             return
 
-        messages_url = f"{self._opencode_base_url}/session/{state.opencode_session_id}/message"
-
         try:
-            response = await self._http_client.get(
-                messages_url,
-                timeout=OPENCODE_REQUEST_TIMEOUT_SECONDS,
-            )
-            if response.status_code != 200:
-                self._log.warn(
-                    "bridge.final_state_fetch_error",
-                    status_code=response.status_code,
-                )
+            messages = await self._client.get_messages(state.opencode_session_id)
+            if messages is None:
                 return
-
-            messages = response.json()
 
             for msg in messages:
                 info = msg.get("info", {})

--- a/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
@@ -9,9 +9,11 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Final
 
-import httpx
-
-from .opencode_client import SSEConnectionError
+from .opencode_client import (
+    SSEConnectionError,
+    SSEInactivityTimeoutError,
+    SSEStreamDisconnectedError,
+)
 from .opencode_identifier import OpenCodeIdentifier
 
 if TYPE_CHECKING:
@@ -163,47 +165,43 @@ class OpenCodePromptStream:
         loop = asyncio.get_running_loop()
 
         try:
-            deadline = loop.time() + self._sse_inactivity_timeout_seconds
-            async with asyncio.timeout_at(deadline) as timeout_ctx:
-                async with self._client.open_event_stream() as sse_response:
-                    prompt_start = loop.time()
-                    await self._client.post_prompt(opencode_session_id, request_body)
+            async with self._client.events(
+                inactivity_timeout_seconds=self._sse_inactivity_timeout_seconds
+            ) as sse_events:
+                prompt_start = loop.time()
+                await self._client.post_prompt(opencode_session_id, request_body)
 
-                    async for sse_event in self._client.parse_sse_stream(
-                        sse_response,
-                        timeout_ctx,
-                        inactivity_timeout_seconds=self._sse_inactivity_timeout_seconds,
-                    ):
-                        step = self._apply_sse_event(state, sse_event)
-                        for event in step.events:
-                            yield event
+                async for sse_event in sse_events:
+                    step = self._apply_sse_event(state, sse_event)
+                    for event in step.events:
+                        yield event
 
-                        if step.disposition is _Disposition.FINISHED_IDLE:
-                            async for final_event in self._fetch_final_message_state(state):
-                                yield final_event
-                            return
-                        if step.disposition is _Disposition.FAILED:
-                            return
+                    if step.disposition is _Disposition.FINISHED_IDLE:
+                        async for final_event in self._fetch_final_message_state(state):
+                            yield final_event
+                        return
+                    if step.disposition is _Disposition.FAILED:
+                        return
 
-                        if loop.time() > prompt_start + self._prompt_max_duration_seconds:
-                            elapsed = time.time() - state.start_time
-                            self._log.error(
-                                "bridge.prompt_max_duration_timeout",
-                                timeout_ms=int(self._prompt_max_duration_seconds * 1000),
-                                elapsed_ms=int(elapsed * 1000),
-                                message_id=message_id,
-                            )
-                            await self._client.request_stop(
-                                opencode_session_id, reason="prompt_max_duration_timeout"
-                            )
-                            async for final_event in self._fetch_final_message_state(state):
-                                yield final_event
-                            raise RuntimeError(
-                                f"Prompt exceeded max duration of "
-                                f"{self._prompt_max_duration_seconds:.0f}s."
-                            )
+                    if loop.time() > prompt_start + self._prompt_max_duration_seconds:
+                        elapsed = time.time() - state.start_time
+                        self._log.error(
+                            "bridge.prompt_max_duration_timeout",
+                            timeout_ms=int(self._prompt_max_duration_seconds * 1000),
+                            elapsed_ms=int(elapsed * 1000),
+                            message_id=message_id,
+                        )
+                        await self._client.request_stop(
+                            opencode_session_id, reason="prompt_max_duration_timeout"
+                        )
+                        async for final_event in self._fetch_final_message_state(state):
+                            yield final_event
+                        raise RuntimeError(
+                            f"Prompt exceeded max duration of "
+                            f"{self._prompt_max_duration_seconds:.0f}s."
+                        )
 
-        except TimeoutError:
+        except SSEInactivityTimeoutError:
             elapsed = time.time() - state.start_time
             self._log.error(
                 "bridge.sse_inactivity_timeout",
@@ -221,8 +219,7 @@ class OpenCodePromptStream:
                 f"(no data received). Total elapsed: {elapsed:.0f}s"
             )
 
-        except httpx.TransportError as e:
-            self._log.error("bridge.sse_transport_error", exc=e)
+        except SSEStreamDisconnectedError as e:
             async for final_event in self._fetch_final_message_state(state):
                 yield final_event
             raise SSEConnectionError(

--- a/packages/sandbox-runtime/tests/conftest.py
+++ b/packages/sandbox-runtime/tests/conftest.py
@@ -1,8 +1,31 @@
 """Shared test fixtures and utilities for sandbox-runtime tests."""
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
+
+from sandbox_runtime.opencode_client import OpenCodeClient
+
+if TYPE_CHECKING:
+    from sandbox_runtime.bridge import AgentBridge
+
+
+def wire_opencode_transport(bridge: "AgentBridge", http_client: Any) -> Any:
+    """Point a bridge's OpenCode client at a fake HTTP transport (test seam).
+
+    Rebuilds ``bridge.opencode_client`` around the fake, resets the lazily
+    built prompt stream so it rebinds to the new client, and stashes the fake
+    on ``bridge.http_client`` so tests can read it back to script responses.
+    Returns the fake for convenience.
+    """
+    bridge.opencode_client = OpenCodeClient(
+        base_url=bridge.opencode_base_url,
+        log=bridge.log,
+        http_client=http_client,
+    )
+    bridge._prompt_stream = None
+    bridge.http_client = http_client
+    return http_client
 
 
 class MockResponse:

--- a/packages/sandbox-runtime/tests/test_bridge_attachments.py
+++ b/packages/sandbox-runtime/tests/test_bridge_attachments.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from sandbox_runtime.bridge import AgentBridge
+from tests.conftest import wire_opencode_transport
 
 
 @pytest.fixture
@@ -15,7 +16,7 @@ def bridge() -> AgentBridge:
         control_plane_url="http://localhost:8787",
         auth_token="test-token",
     )
-    bridge.http_client = MagicMock()
+    wire_opencode_transport(bridge, MagicMock())
     return bridge
 
 

--- a/packages/sandbox-runtime/tests/test_bridge_event_buffer.py
+++ b/packages/sandbox-runtime/tests/test_bridge_event_buffer.py
@@ -17,7 +17,7 @@ import pytest
 from websockets import State
 
 from sandbox_runtime.bridge import AgentBridge
-from tests.conftest import MockResponse
+from tests.conftest import MockResponse, wire_opencode_transport
 
 
 class MockHttpClient:
@@ -84,7 +84,7 @@ def bridge() -> AgentBridge:
         auth_token="test-token",
     )
     bridge.opencode_session_id = "oc-session-123"
-    bridge.http_client = MockHttpClient()
+    wire_opencode_transport(bridge, MockHttpClient())
     return bridge
 
 

--- a/packages/sandbox-runtime/tests/test_bridge_message_tracking.py
+++ b/packages/sandbox-runtime/tests/test_bridge_message_tracking.py
@@ -15,7 +15,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from sandbox_runtime.bridge import AgentBridge
-from sandbox_runtime.prompt_stream import OpenCodeIdentifier, _PromptState
+from sandbox_runtime.opencode_identifier import OpenCodeIdentifier
+from sandbox_runtime.prompt_stream import _PromptState
 
 
 def create_text_part(part_id: str, text: str) -> dict:

--- a/packages/sandbox-runtime/tests/test_bridge_message_tracking.py
+++ b/packages/sandbox-runtime/tests/test_bridge_message_tracking.py
@@ -17,6 +17,7 @@ import pytest
 from sandbox_runtime.bridge import AgentBridge
 from sandbox_runtime.opencode_identifier import OpenCodeIdentifier
 from sandbox_runtime.prompt_stream import _PromptState
+from tests.conftest import wire_opencode_transport
 
 
 def create_text_part(part_id: str, text: str) -> dict:
@@ -59,7 +60,7 @@ def bridge() -> AgentBridge:
         auth_token="test-token",
     )
     bridge.opencode_session_id = "oc-session-123"
-    bridge.http_client = MagicMock()
+    wire_opencode_transport(bridge, MagicMock())
     return bridge
 
 

--- a/packages/sandbox-runtime/tests/test_bridge_reconnection.py
+++ b/packages/sandbox-runtime/tests/test_bridge_reconnection.py
@@ -115,10 +115,6 @@ class TestIsFatalConnectionError:
 
     @pytest.mark.asyncio
     async def test_run_complete_does_not_retain_transient_outcome(self, bridge, monkeypatch):
-        class HttpClient:
-            async def aclose(self):
-                return None
-
         attempts = 0
 
         async def connect_and_run():
@@ -131,9 +127,6 @@ class TestIsFatalConnectionError:
         bridge.log = MagicMock()
         bridge._load_session_id = AsyncMock()
         bridge._connect_and_run = connect_and_run
-        monkeypatch.setattr(
-            "sandbox_runtime.bridge.httpx.AsyncClient", lambda **_kwargs: HttpClient()
-        )
         monkeypatch.setattr("sandbox_runtime.bridge.asyncio.sleep", AsyncMock())
 
         await bridge.run()

--- a/packages/sandbox-runtime/tests/test_bridge_sse.py
+++ b/packages/sandbox-runtime/tests/test_bridge_sse.py
@@ -138,7 +138,7 @@ def opencode_message_id(monkeypatch) -> str:
 
 
 class TestSSEParser:
-    """Tests for OpenCodeClient.parse_sse_stream."""
+    """Tests for OpenCodeClient SSE frame decoding."""
 
     @pytest.mark.asyncio
     async def test_parse_single_event(self, bridge: AgentBridge):
@@ -147,7 +147,7 @@ class TestSSEParser:
         response = MockSSEResponse(events_text)
 
         events = []
-        async for event in bridge._ensure_opencode_client().parse_sse_stream(response):
+        async for event in bridge._ensure_opencode_client()._decoded_events(response):
             events.append(event)
 
         assert len(events) == 1
@@ -175,7 +175,7 @@ class TestSSEParser:
         response = MockSSEResponse(events_text)
 
         events = []
-        async for event in bridge._ensure_opencode_client().parse_sse_stream(response):
+        async for event in bridge._ensure_opencode_client()._decoded_events(response):
             events.append(event)
 
         assert len(events) == 3
@@ -193,7 +193,7 @@ class TestSSEParser:
         response = MockSSEResponse(events_text)
 
         events = []
-        async for event in bridge._ensure_opencode_client().parse_sse_stream(response):
+        async for event in bridge._ensure_opencode_client()._decoded_events(response):
             events.append(event)
 
         assert len(events) == 2

--- a/packages/sandbox-runtime/tests/test_bridge_sse.py
+++ b/packages/sandbox-runtime/tests/test_bridge_sse.py
@@ -19,10 +19,10 @@ import httpx
 import pytest
 
 from sandbox_runtime.bridge import AgentBridge
+from sandbox_runtime.opencode_client import SSEConnectionError
+from sandbox_runtime.opencode_identifier import OpenCodeIdentifier
 from sandbox_runtime.prompt_stream import (
-    OpenCodeIdentifier,
     OpenCodePromptStream,
-    SSEConnectionError,
     _PromptState,
 )
 from tests.conftest import MockResponse
@@ -138,7 +138,7 @@ def opencode_message_id(monkeypatch) -> str:
 
 
 class TestSSEParser:
-    """Tests for _parse_sse_stream method."""
+    """Tests for OpenCodeClient.parse_sse_stream."""
 
     @pytest.mark.asyncio
     async def test_parse_single_event(self, bridge: AgentBridge):
@@ -147,7 +147,7 @@ class TestSSEParser:
         response = MockSSEResponse(events_text)
 
         events = []
-        async for event in bridge._ensure_prompt_stream()._parse_sse_stream(response):
+        async for event in bridge._ensure_opencode_client().parse_sse_stream(response):
             events.append(event)
 
         assert len(events) == 1
@@ -175,7 +175,7 @@ class TestSSEParser:
         response = MockSSEResponse(events_text)
 
         events = []
-        async for event in bridge._ensure_prompt_stream()._parse_sse_stream(response):
+        async for event in bridge._ensure_opencode_client().parse_sse_stream(response):
             events.append(event)
 
         assert len(events) == 3
@@ -193,7 +193,7 @@ class TestSSEParser:
         response = MockSSEResponse(events_text)
 
         events = []
-        async for event in bridge._ensure_prompt_stream()._parse_sse_stream(response):
+        async for event in bridge._ensure_opencode_client().parse_sse_stream(response):
             events.append(event)
 
         assert len(events) == 2

--- a/packages/sandbox-runtime/tests/test_bridge_sse.py
+++ b/packages/sandbox-runtime/tests/test_bridge_sse.py
@@ -25,7 +25,7 @@ from sandbox_runtime.prompt_stream import (
     OpenCodePromptStream,
     _PromptState,
 )
-from tests.conftest import MockResponse
+from tests.conftest import MockResponse, wire_opencode_transport
 
 
 class MockSSEResponse:
@@ -122,7 +122,7 @@ def bridge() -> AgentBridge:
         auth_token="test-token",
     )
     bridge.opencode_session_id = "oc-session-123"
-    bridge.http_client = MockHttpClient()
+    wire_opencode_transport(bridge, MockHttpClient())
     return bridge
 
 
@@ -147,7 +147,7 @@ class TestSSEParser:
         response = MockSSEResponse(events_text)
 
         events = []
-        async for event in bridge._ensure_opencode_client()._decoded_events(response):
+        async for event in bridge.opencode_client._decoded_events(response):
             events.append(event)
 
         assert len(events) == 1
@@ -175,7 +175,7 @@ class TestSSEParser:
         response = MockSSEResponse(events_text)
 
         events = []
-        async for event in bridge._ensure_opencode_client()._decoded_events(response):
+        async for event in bridge.opencode_client._decoded_events(response):
             events.append(event)
 
         assert len(events) == 3
@@ -193,7 +193,7 @@ class TestSSEParser:
         response = MockSSEResponse(events_text)
 
         events = []
-        async for event in bridge._ensure_opencode_client()._decoded_events(response):
+        async for event in bridge.opencode_client._decoded_events(response):
             events.append(event)
 
         assert len(events) == 2
@@ -908,7 +908,7 @@ class TestFetchFinalMessageState:
             auth_token="test-token",
         )
         bridge.opencode_session_id = "oc-session-123"
-        bridge.http_client = AsyncMock()
+        wire_opencode_transport(bridge, AsyncMock())
         return bridge
 
     @pytest.mark.asyncio
@@ -1349,7 +1349,7 @@ class TestInactivityTimeout:
         sse_response = HangingMockSSEResponse(
             initial_events=[create_sse_event("server.connected", {})]
         )
-        bridge.http_client = DelayedMockHttpClient(sse_response)
+        wire_opencode_transport(bridge, DelayedMockHttpClient(sse_response))
 
         with pytest.raises(RuntimeError, match="SSE stream inactive"):
             async for _event in bridge._stream_opencode_response_sse("msg-1", "test"):
@@ -1419,7 +1419,7 @@ class TestInactivityTimeout:
                 (create_sse_event("session.idle", {"sessionID": "oc-session-123"}), 0.1),
             ]
         )
-        bridge.http_client = DelayedMockHttpClient(sse_response)
+        wire_opencode_transport(bridge, DelayedMockHttpClient(sse_response))
 
         events = []
         async for event in bridge._stream_opencode_response_sse("msg-1", "test"):
@@ -1481,7 +1481,7 @@ class TestInactivityTimeout:
                 (create_sse_event("session.idle", {"sessionID": "oc-session-123"}), 0),
             ]
         )
-        bridge.http_client = DelayedMockHttpClient(sse_response)
+        wire_opencode_transport(bridge, DelayedMockHttpClient(sse_response))
 
         events = []
         async for event in bridge._stream_opencode_response_sse("msg-1", "test"):
@@ -1517,7 +1517,7 @@ class TestPromptMaxDuration:
         )
         http_client = DelayedMockHttpClient(sse_response)
         http_client.get_responses = [MockResponse(200, [])]
-        bridge.http_client = http_client
+        wire_opencode_transport(bridge, http_client)
 
         with pytest.raises(RuntimeError, match="Prompt exceeded max duration"):
             async for _event in bridge._stream_opencode_response_sse("msg-1", "test"):
@@ -2478,7 +2478,7 @@ class TestCompactionHandling:
             auth_token="test-token",
         )
         bridge.opencode_session_id = "oc-session-123"
-        bridge.http_client = AsyncMock()
+        wire_opencode_transport(bridge, AsyncMock())
 
         # API returns: compaction summary + post-compaction response
         messages = [
@@ -2527,7 +2527,7 @@ class TestCompactionHandling:
             auth_token="test-token",
         )
         bridge.opencode_session_id = "oc-session-123"
-        bridge.http_client = AsyncMock()
+        wire_opencode_transport(bridge, AsyncMock())
 
         messages = [
             {

--- a/packages/sandbox-runtime/tests/test_bridge_stop.py
+++ b/packages/sandbox-runtime/tests/test_bridge_stop.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from sandbox_runtime.bridge import AgentBridge
-from tests.conftest import MockResponse
+from tests.conftest import MockResponse, wire_opencode_transport
 
 
 class MockHttpClient:
@@ -80,7 +80,7 @@ def bridge() -> AgentBridge:
         auth_token="test-token",
     )
     bridge.opencode_session_id = "oc-session-123"
-    bridge.http_client = MockHttpClient()
+    wire_opencode_transport(bridge, MockHttpClient())
     return bridge
 
 

--- a/packages/sandbox-runtime/tests/test_opencode_client.py
+++ b/packages/sandbox-runtime/tests/test_opencode_client.py
@@ -103,6 +103,27 @@ class TestGetMessages:
         assert await make_client(http_client).get_messages(SESSION_ID) is None
 
 
+class TestPoolOwnership:
+    async def test_aclose_leaves_injected_pool_open(self):
+        pool = httpx.AsyncClient(transport=httpx.MockTransport(lambda _: httpx.Response(200)))
+        client = OpenCodeClient(base_url=BASE_URL, log=MagicMock(), http_client=pool)
+
+        assert await client.session_exists(SESSION_ID) is True
+        await client.aclose()
+
+        assert pool.is_closed is False
+        await pool.aclose()
+
+    async def test_owned_pool_created_lazily_and_closed_by_aclose(self):
+        client = OpenCodeClient(base_url=BASE_URL, log=MagicMock())
+
+        pool = client._client()
+
+        assert client._client() is pool
+        await client.aclose()
+        assert pool.is_closed
+
+
 class TestCreateSession:
     async def test_returns_created_session_id(self):
         http_client = AsyncMock()

--- a/packages/sandbox-runtime/tests/test_opencode_client.py
+++ b/packages/sandbox-runtime/tests/test_opencode_client.py
@@ -2,15 +2,25 @@
 Unit tests for OpenCodeClient transport seams exposed by the extraction.
 
 SSE frame parsing and end-to-end streaming stay covered by test_bridge_sse.py;
-these tests target the plain request methods (post_prompt / request_stop /
-get_messages) against a fake HTTP transport.
+these tests target the plain request methods (create_session / session_exists /
+post_prompt / request_stop / get_messages) and the events() context manager
+against a fake HTTP transport.
 """
 
+import asyncio
+import json
+from collections.abc import AsyncIterator
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
 
-from sandbox_runtime.opencode_client import OpenCodeClient, SSEConnectionError
+from sandbox_runtime.opencode_client import (
+    OpenCodeClient,
+    SSEConnectionError,
+    SSEInactivityTimeoutError,
+    SSEStreamDisconnectedError,
+)
 from tests.conftest import MockResponse
 
 BASE_URL = "http://localhost:4096"
@@ -93,20 +103,112 @@ class TestGetMessages:
         assert await make_client(http_client).get_messages(SESSION_ID) is None
 
 
-class TestOpenEventStream:
-    async def test_raises_on_non_200_response(self):
-        class FailingStream:
-            status_code = 503
+class TestCreateSession:
+    async def test_returns_created_session_id(self):
+        http_client = AsyncMock()
+        http_client.post.return_value = MockResponse(200, {"id": "oc-new-session"})
 
-            async def __aenter__(self):
-                return self
+        session_id = await make_client(http_client).create_session()
 
-            async def __aexit__(self, *args):
-                return None
+        assert session_id == "oc-new-session"
+        args, kwargs = http_client.post.await_args
+        assert args[0] == f"{BASE_URL}/session"
+        assert kwargs["json"] == {}
 
+    async def test_raises_on_error_status(self):
+        http_client = AsyncMock()
+        http_client.post.return_value = MockResponse(500, {})
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await make_client(http_client).create_session()
+
+
+class TestSessionExists:
+    async def test_true_on_200(self):
+        http_client = AsyncMock()
+        http_client.get.return_value = MockResponse(200, {"id": SESSION_ID})
+
+        assert await make_client(http_client).session_exists(SESSION_ID) is True
+        args, _ = http_client.get.await_args
+        assert args[0] == f"{BASE_URL}/session/{SESSION_ID}"
+
+    async def test_false_on_non_200(self):
+        http_client = AsyncMock()
+        http_client.get.return_value = MockResponse(404)
+
+        assert await make_client(http_client).session_exists(SESSION_ID) is False
+
+
+class MockSSEStream:
+    """Fake httpx streaming response: a context manager yielding text chunks."""
+
+    def __init__(self, chunks: list[str], status_code: int = 200):
+        self.status_code = status_code
+        self._chunks = chunks
+
+    async def aiter_text(self) -> AsyncIterator[str]:
+        for chunk in self._chunks:
+            yield chunk
+            await asyncio.sleep(0)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+
+def sse_frame(event_type: str) -> str:
+    return f"data: {json.dumps({'type': event_type, 'properties': {}})}\n\n"
+
+
+class TestEvents:
+    async def test_yields_decoded_event_dicts(self):
         http_client = MagicMock()
-        http_client.stream.return_value = FailingStream()
+        http_client.stream.return_value = MockSSEStream(
+            [sse_frame("server.connected"), sse_frame("session.idle")]
+        )
+
+        received = []
+        async with make_client(http_client).events(inactivity_timeout_seconds=5.0) as events:
+            async for event in events:
+                received.append(event)
+
+        assert [e["type"] for e in received] == ["server.connected", "session.idle"]
+
+    async def test_raises_on_non_200_response(self):
+        http_client = MagicMock()
+        http_client.stream.return_value = MockSSEStream([], status_code=503)
 
         with pytest.raises(SSEConnectionError, match="SSE connection failed: 503"):
-            async with make_client(http_client).open_event_stream():
+            async with make_client(http_client).events(inactivity_timeout_seconds=5.0):
                 pass
+
+    async def test_translates_transport_failure(self):
+        class DroppingSSEStream(MockSSEStream):
+            async def aiter_text(self) -> AsyncIterator[str]:
+                async for chunk in super().aiter_text():
+                    yield chunk
+                raise httpx.RemoteProtocolError("peer closed connection")
+
+        http_client = MagicMock()
+        http_client.stream.return_value = DroppingSSEStream([sse_frame("server.connected")])
+
+        with pytest.raises(SSEStreamDisconnectedError):
+            async with make_client(http_client).events(inactivity_timeout_seconds=5.0) as events:
+                async for _event in events:
+                    pass
+
+    async def test_raises_inactivity_error_when_stream_hangs(self):
+        class HangingSSEStream(MockSSEStream):
+            async def aiter_text(self) -> AsyncIterator[str]:
+                yield sse_frame("server.connected")
+                await asyncio.sleep(60)
+
+        http_client = MagicMock()
+        http_client.stream.return_value = HangingSSEStream([])
+
+        with pytest.raises(SSEInactivityTimeoutError, match="SSE stream inactive"):
+            async with make_client(http_client).events(inactivity_timeout_seconds=0.05) as events:
+                async for _event in events:
+                    pass

--- a/packages/sandbox-runtime/tests/test_opencode_client.py
+++ b/packages/sandbox-runtime/tests/test_opencode_client.py
@@ -1,0 +1,112 @@
+"""
+Unit tests for OpenCodeClient transport seams exposed by the extraction.
+
+SSE frame parsing and end-to-end streaming stay covered by test_bridge_sse.py;
+these tests target the plain request methods (post_prompt / request_stop /
+get_messages) against a fake HTTP transport.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from sandbox_runtime.opencode_client import OpenCodeClient, SSEConnectionError
+from tests.conftest import MockResponse
+
+BASE_URL = "http://localhost:4096"
+SESSION_ID = "oc-session-123"
+
+
+def make_client(http_client: AsyncMock) -> OpenCodeClient:
+    return OpenCodeClient(
+        http_client=http_client,
+        base_url=BASE_URL,
+        log=MagicMock(),
+    )
+
+
+class TestPostPrompt:
+    async def test_posts_body_to_prompt_async_endpoint(self):
+        http_client = AsyncMock()
+        http_client.post.return_value = MockResponse(204)
+        body = {"parts": [{"type": "text", "text": "hi"}]}
+
+        await make_client(http_client).post_prompt(SESSION_ID, body)
+
+        assert http_client.post.await_count == 1
+        args, kwargs = http_client.post.await_args
+        assert args[0] == f"{BASE_URL}/session/{SESSION_ID}/prompt_async"
+        assert kwargs["json"] == body
+
+    async def test_raises_on_error_status(self):
+        http_client = AsyncMock()
+        http_client.post.return_value = MockResponse(500, text="boom")
+
+        with pytest.raises(RuntimeError, match="Async prompt failed: 500 - boom"):
+            await make_client(http_client).post_prompt(SESSION_ID, {"parts": []})
+
+
+class TestRequestStop:
+    async def test_posts_abort_and_reports_success(self):
+        http_client = AsyncMock()
+        http_client.post.return_value = MockResponse(200)
+
+        stopped = await make_client(http_client).request_stop(SESSION_ID, reason="command")
+
+        assert stopped is True
+        args, _ = http_client.post.await_args
+        assert args[0] == f"{BASE_URL}/session/{SESSION_ID}/abort"
+
+    async def test_no_session_id_is_a_noop(self):
+        http_client = AsyncMock()
+
+        stopped = await make_client(http_client).request_stop(None, reason="command")
+
+        assert stopped is False
+        http_client.post.assert_not_awaited()
+
+    async def test_transport_error_reports_failure(self):
+        http_client = AsyncMock()
+        http_client.post.side_effect = ConnectionError("refused")
+
+        stopped = await make_client(http_client).request_stop(SESSION_ID, reason="command")
+
+        assert stopped is False
+
+
+class TestGetMessages:
+    async def test_returns_parsed_message_list(self):
+        messages = [{"info": {"id": "oc-msg-1", "role": "assistant"}, "parts": []}]
+        http_client = AsyncMock()
+        http_client.get.return_value = MockResponse(200, messages)
+
+        result = await make_client(http_client).get_messages(SESSION_ID)
+
+        assert result == messages
+        args, _ = http_client.get.await_args
+        assert args[0] == f"{BASE_URL}/session/{SESSION_ID}/message"
+
+    async def test_returns_none_on_error_status(self):
+        http_client = AsyncMock()
+        http_client.get.return_value = MockResponse(500)
+
+        assert await make_client(http_client).get_messages(SESSION_ID) is None
+
+
+class TestOpenEventStream:
+    async def test_raises_on_non_200_response(self):
+        class FailingStream:
+            status_code = 503
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return None
+
+        http_client = MagicMock()
+        http_client.stream.return_value = FailingStream()
+
+        with pytest.raises(SSEConnectionError, match="SSE connection failed: 503"):
+            async with make_client(http_client).open_event_stream():
+                pass

--- a/packages/sandbox-runtime/tests/test_prompt_stream.py
+++ b/packages/sandbox-runtime/tests/test_prompt_stream.py
@@ -23,8 +23,7 @@ CHILD_SESSION_ID = "oc-child-456"
 
 def make_stream() -> OpenCodePromptStream:
     return OpenCodePromptStream(
-        http_client=MagicMock(),
-        opencode_base_url="http://localhost:4096",
+        client=MagicMock(),
         attachment_processor=MagicMock(),
         log=MagicMock(),
         sse_inactivity_timeout_seconds=120.0,


### PR DESCRIPTION
## Summary

Behavior-preserving extraction of an `OpenCodeClient` transport class out of `OpenCodePromptStream`, fulfilling the client/translator split committed to in the #1060 review thread. No behavior changes: every moved method keeps its exact request shapes, status handling, log event names, and error semantics.

## What moved where

**New `src/sandbox_runtime/opencode_client.py` — `OpenCodeClient` (transport)**

Owns the OpenCode base URL and every raw wire concern:

- `open_event_stream()` — opens the `/event` SSE stream (async context manager), failing fast with `SSEConnectionError` on non-200 (was inline in `stream_prompt`)
- `post_prompt(session_id, request_body)` — was `_post_prompt`
- `request_stop(session_id, *, reason)` — moved verbatim; the bridge's `_request_opencode_stop` now delegates to the client
- `get_messages(session_id)` — the `GET /session/{id}/message` fetch extracted from `_fetch_final_message_state`; returns the parsed list, or `None` on a non-200 (same log event)
- `parse_sse_stream(response, timeout_ctx, inactivity_timeout_seconds)` — SSE framing is transport; the LF-only framing comment is preserved
- `SSEConnectionError`, `HTTP_CONNECT_TIMEOUT_SECONDS`, `OPENCODE_REQUEST_TIMEOUT_SECONDS` moved here (each default still defined exactly once; the bridge imports them from the new module)

**New `src/sandbox_runtime/opencode_identifier.py` — `OpenCodeIdentifier`**

Moved verbatim to its own module. It is ID-generation policy used by the prompt stream (and tests), not by the transport client, so it belongs in neither `opencode_client.py` (the stream would import IDs from the transport layer) nor the translator module (it is independently reusable). `bridge.py` does not import it.

**`OpenCodePromptStream` keeps (policy)**

- The translation state machine (`_apply_sse_event` / `_StreamStep` / `_Disposition` / `_handle_part` / `_tool_call_event`), pending-part buffering, child-session tracking
- Reconciliation: `_fetch_final_message_state(state)` keeps all accept/emit policy and now calls `client.get_messages`
- Session-title dedupe policy
- Request-body / reasoning-effort construction (`_build_prompt_request_body`) — this is prompt policy (model spec, thinking budgets, attachments); the client receives the built payload
- **Timeout ownership**: `sse_inactivity_timeout_seconds` and `prompt_max_duration_seconds` stay on the stream — they are prompt-lifecycle policy (when to give up on a prompt), not connection settings. The inactivity value is passed into `parse_sse_stream` per call so the transport can reset the deadline per chunk without owning the policy. `connect`/`request` timeouts are transport-owned and live on the client.

**`bridge.py`** — minimal diff: new `_ensure_opencode_client()` builds the client lazily (same HTTP-client-lifetime reason as before); `_ensure_prompt_stream()` builds the stream on top of it; `_request_opencode_stop` points at the client.

## Line counts

- `opencode_client.py`: 156 lines (`OpenCodeClient` class: 132)
- `opencode_identifier.py`: 66 lines
- `prompt_stream.py`: 950 → 741 lines (`OpenCodePromptStream` class: 640)

## Testing

- `pytest -q`: **545 passed** (537 pre-existing, all unmodified in behavior, + 8 new `OpenCodeClient` unit tests in `tests/test_opencode_client.py` covering `post_prompt` / `request_stop` / `get_messages` / `open_event_stream` against a fake transport)
- Pre-existing tests were only retargeted where they constructed or reached into moved pieces:
  - `test_prompt_stream.py`: `make_stream()` now passes `client=` instead of `http_client=`/`opencode_base_url=`
  - `test_bridge_sse.py`: imports of `SSEConnectionError` / `OpenCodeIdentifier` retargeted; 3 `_parse_sse_stream` call sites → `bridge._ensure_opencode_client().parse_sse_stream(...)`
  - `test_bridge_message_tracking.py`: `OpenCodeIdentifier` import retargeted
- `ruff check src tests` + `ruff format --check src tests`: clean
- `mypy src/` (strict): the same 13 pre-existing errors confined to `entrypoint.py` / `auth/github_app.py`; both new modules and all touched modules are clean

Follow-up committed in the review thread of #1060.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved prompt streaming by routing session setup, SSE event handling, message retrieval, and stop/abort through a dedicated long-lived OpenCode client.
  * Enhanced OpenCode session management with validation and safer stop behavior.
  * Added OpenCode-compatible ascending session identifiers for better ID generation consistency.
  * Improved streaming reliability and error handling for inactivity/disconnections.
* **Tests**
  * Expanded and adjusted unit tests for OpenCode client requests, SSE frame decoding, session lifecycle checks, and prompt-stream behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->