### PR TITLE
refactor(web): decompose session-sidebar into hook + subcomponents

### DIFF
--- a/packages/web/src/components/session-list-item.tsx
+++ b/packages/web/src/components/session-list-item.tsx
@@ -1,0 +1,379 @@
+"use client";
+
+import Link from "next/link";
+import { useState, useCallback, useEffect, useRef, type TouchEvent } from "react";
+import { ArchiveSessionDialog } from "@/components/archive-session-dialog";
+import { archiveSession } from "@/lib/archive-session";
+import { pullRequestSummaryDisplay } from "@/lib/pr-summary";
+import { PullRequestStateIcon } from "@/components/pr-state-icon";
+import { formatRelativeTime } from "@/lib/time";
+import { MoreIcon, ArchiveIcon, BranchIcon, BoxIcon } from "@/components/ui/icons";
+import { formatSessionRepositoriesLabel } from "@/lib/repo-label";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { SessionItem } from "@/hooks/use-sidebar-sessions";
+
+export const MOBILE_LONG_PRESS_MS = 450;
+const MOBILE_LONG_PRESS_MOVE_THRESHOLD_PX = 10;
+
+export function buildSessionHref(session: SessionItem) {
+  const query: Record<string, string> = {};
+  if (session.repoOwner && session.repoName) {
+    query.repoOwner = session.repoOwner;
+    query.repoName = session.repoName;
+  }
+  if (session.title) {
+    query.title = session.title;
+  }
+
+  return {
+    pathname: `/session/${session.id}`,
+    query,
+  };
+}
+
+export function SessionListItem({
+  session,
+  environmentName,
+  isActive,
+  isMobile,
+  onArchive,
+  onSessionSelect,
+  onSessionRenamed,
+}: {
+  session: SessionItem;
+  environmentName?: string;
+  isActive: boolean;
+  isMobile: boolean;
+  onArchive: (sessionId: string) => Promise<void>;
+  onSessionSelect?: () => void;
+  onSessionRenamed: (sessionId: string, title: string) => void;
+}) {
+  const timestamp = session.updatedAt || session.createdAt;
+  const relativeTime = formatRelativeTime(timestamp);
+  const repoInfo = formatSessionRepositoriesLabel(
+    session.repoOwner,
+    session.repoName,
+    session.repositories
+  );
+  const prDisplay = pullRequestSummaryDisplay(session.pullRequestSummary);
+  const displayTitle = session.title || repoInfo;
+  // Orphan child (parent filtered out) — show a subtle badge
+  const isOrphanChild = session.parentSessionId && session.spawnSource === "agent";
+  const [isRenaming, setIsRenaming] = useState(false);
+  const [isActionsOpen, setIsActionsOpen] = useState(false);
+  const [isArchiving, setIsArchiving] = useState(false);
+  const [showArchiveDialog, setShowArchiveDialog] = useState(false);
+  const [title, setTitle] = useState(displayTitle);
+  const renameInputRef = useRef<HTMLInputElement>(null);
+  const isStartingRenameRef = useRef(false);
+  const longPressTimerRef = useRef<number | null>(null);
+  const longPressTriggeredRef = useRef(false);
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
+
+  useEffect(() => {
+    if (!isRenaming) {
+      setTitle(displayTitle);
+    }
+  }, [displayTitle, isRenaming]);
+
+  const handleStartRename = () => {
+    isStartingRenameRef.current = true;
+    setIsActionsOpen(false);
+    setTitle(displayTitle);
+    setIsRenaming(true);
+  };
+
+  useEffect(() => {
+    if (!isRenaming) return;
+
+    const timeout = window.setTimeout(() => {
+      renameInputRef.current?.focus();
+      renameInputRef.current?.select();
+    }, 0);
+
+    return () => window.clearTimeout(timeout);
+  }, [isRenaming]);
+
+  const handleCancelRename = () => {
+    setTitle(displayTitle);
+    setIsRenaming(false);
+  };
+
+  const handleStartArchive = () => {
+    setIsActionsOpen(false);
+    setShowArchiveDialog(true);
+  };
+
+  const handleConfirmArchive = async () => {
+    setShowArchiveDialog(false);
+    setIsArchiving(true);
+
+    try {
+      const didArchive = await archiveSession(session.id);
+      if (didArchive) {
+        await onArchive(session.id);
+      }
+    } finally {
+      setIsArchiving(false);
+    }
+  };
+
+  const handleRenameSubmit = async () => {
+    const trimmed = title.trim();
+
+    if (!trimmed || trimmed === displayTitle) {
+      setIsRenaming(false);
+      return;
+    }
+
+    const previousTitle = displayTitle;
+    setIsRenaming(false);
+
+    try {
+      const response = await fetch(`/api/sessions/${session.id}/title`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: trimmed }),
+      });
+      if (!response.ok) {
+        throw new Error("Failed to update session title");
+      }
+      onSessionRenamed(session.id, trimmed);
+    } catch {
+      setTitle(previousTitle);
+      setIsRenaming(true);
+    }
+  };
+
+  const clearLongPressTimer = useCallback(() => {
+    if (longPressTimerRef.current !== null) {
+      window.clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  }, []);
+
+  const handleTouchStart = useCallback(
+    (event: TouchEvent<HTMLAnchorElement>) => {
+      if (!isMobile) return;
+
+      const touch = event.touches[0];
+      if (!touch) return;
+
+      longPressTriggeredRef.current = false;
+      touchStartRef.current = { x: touch.clientX, y: touch.clientY };
+      clearLongPressTimer();
+      longPressTimerRef.current = window.setTimeout(() => {
+        longPressTriggeredRef.current = true;
+        setIsActionsOpen(true);
+      }, MOBILE_LONG_PRESS_MS);
+    },
+    [clearLongPressTimer, isMobile]
+  );
+
+  const handleTouchMove = useCallback(
+    (event: TouchEvent<HTMLAnchorElement>) => {
+      if (!isMobile) return;
+
+      const start = touchStartRef.current;
+      const touch = event.touches[0];
+      if (!start || !touch) return;
+
+      const deltaX = touch.clientX - start.x;
+      const deltaY = touch.clientY - start.y;
+      if (Math.hypot(deltaX, deltaY) > MOBILE_LONG_PRESS_MOVE_THRESHOLD_PX) {
+        clearLongPressTimer();
+      }
+    },
+    [clearLongPressTimer, isMobile]
+  );
+
+  const handleTouchEnd = useCallback(() => {
+    clearLongPressTimer();
+    touchStartRef.current = null;
+  }, [clearLongPressTimer]);
+
+  useEffect(() => {
+    return () => clearLongPressTimer();
+  }, [clearLongPressTimer]);
+
+  return (
+    <>
+      <div
+        className={`group relative block px-4 py-2.5 border-l-2 transition ${
+          isActive ? "border-l-accent bg-accent-muted" : "border-l-transparent hover:bg-muted"
+        }`}
+      >
+        {isRenaming ? (
+          <>
+            <input
+              ref={renameInputRef}
+              autoFocus
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              onFocus={(e) => e.currentTarget.select()}
+              onBlur={handleRenameSubmit}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  e.currentTarget.blur();
+                }
+                if (e.key === "Escape") {
+                  e.preventDefault();
+                  handleCancelRename();
+                }
+              }}
+              className="w-full text-sm bg-transparent text-foreground outline-none focus:ring-inset focus:ring-ring font-medium pr-8"
+            />
+            <div className="flex items-center gap-1 mt-0.5 text-xs text-muted-foreground">
+              <span>{relativeTime}</span>
+              <span>·</span>
+              <span className="truncate">{repoInfo}</span>
+            </div>
+          </>
+        ) : (
+          <Link
+            href={buildSessionHref(session)}
+            onClick={(event) => {
+              if (longPressTriggeredRef.current) {
+                event.preventDefault();
+                longPressTriggeredRef.current = false;
+                return;
+              }
+              if (isMobile) {
+                onSessionSelect?.();
+              }
+            }}
+            onContextMenu={(event) => {
+              if (isMobile) {
+                event.preventDefault();
+              }
+            }}
+            onTouchStart={handleTouchStart}
+            onTouchMove={handleTouchMove}
+            onTouchEnd={handleTouchEnd}
+            onTouchCancel={handleTouchEnd}
+            className="block pr-8"
+          >
+            <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+              {prDisplay && (
+                <PullRequestStateIcon state={prDisplay.state} label={prDisplay.label} />
+              )}
+              <span className="truncate">{displayTitle}</span>
+            </div>
+            <div className="flex items-center gap-1 mt-0.5 text-xs text-muted-foreground">
+              <span>{relativeTime}</span>
+              <span>·</span>
+              <span className="truncate">{repoInfo}</span>
+              {environmentName && (
+                <>
+                  <span>·</span>
+                  <BoxIcon className="w-3 h-3 flex-shrink-0" />
+                  <span className="truncate">{environmentName}</span>
+                </>
+              )}
+              {isOrphanChild && (
+                <>
+                  <span>·</span>
+                  <span className="text-accent">sub-task</span>
+                </>
+              )}
+              {session.baseBranch && session.baseBranch !== "main" && (
+                <>
+                  <span>·</span>
+                  <BranchIcon className="w-3 h-3 flex-shrink-0" />
+                  <span className="truncate">{session.baseBranch}</span>
+                </>
+              )}
+            </div>
+          </Link>
+        )}
+
+        <div className="absolute inset-y-0 right-2 flex items-start pt-2">
+          <DropdownMenu open={isActionsOpen} onOpenChange={setIsActionsOpen}>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label="Session actions"
+                aria-hidden={isMobile ? "true" : undefined}
+                tabIndex={isMobile ? -1 : undefined}
+                className={`h-6 w-6 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition data-[state=open]:opacity-100 ${
+                  isMobile
+                    ? "pointer-events-none flex opacity-0"
+                    : "flex opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                }`}
+              >
+                <MoreIcon className="w-4 h-4" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              onCloseAutoFocus={(event) => {
+                if (isStartingRenameRef.current) {
+                  event.preventDefault();
+                  isStartingRenameRef.current = false;
+                }
+              }}
+            >
+              <DropdownMenuItem onSelect={handleStartRename}>Rename</DropdownMenuItem>
+              <DropdownMenuItem onClick={handleStartArchive} disabled={isArchiving}>
+                <ArchiveIcon className="w-4 h-4" />
+                Archive
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      <ArchiveSessionDialog
+        open={showArchiveDialog}
+        onOpenChange={setShowArchiveDialog}
+        onConfirm={handleConfirmArchive}
+      />
+    </>
+  );
+}
+
+export function ChildSessionListItem({
+  session,
+  isActive,
+  isMobile,
+  onSessionSelect,
+  depth,
+}: {
+  session: SessionItem;
+  isActive: boolean;
+  isMobile: boolean;
+  onSessionSelect?: () => void;
+  depth: number;
+}) {
+  const timestamp = session.updatedAt || session.createdAt;
+  const relativeTime = formatRelativeTime(timestamp);
+  const prDisplay = pullRequestSummaryDisplay(session.pullRequestSummary);
+  const displayTitle = session.title || "Sub-task";
+  const paddingLeftRem = 1.75 + Math.max(depth - 1, 0) * 1;
+  return (
+    <Link
+      href={buildSessionHref(session)}
+      onClick={() => {
+        if (isMobile) {
+          onSessionSelect?.();
+        }
+      }}
+      className={`block pr-4 py-1.5 border-l-2 transition ${
+        isActive ? "border-l-accent bg-accent-muted" : "border-l-transparent hover:bg-muted"
+      }`}
+      style={{ paddingLeft: `${paddingLeftRem}rem` }}
+    >
+      <div className="flex items-center gap-1.5 text-xs">
+        <span className="shrink-0 text-muted-foreground">{relativeTime}</span>
+        {prDisplay && <PullRequestStateIcon state={prDisplay.state} label={prDisplay.label} />}
+        <span className="truncate font-medium text-foreground">{displayTitle}</span>
+      </div>
+    </Link>
+  );
+}

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -1,63 +1,29 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
-import {
-  Fragment,
-  useState,
-  useMemo,
-  useCallback,
-  useEffect,
-  useRef,
-  type TouchEvent,
-} from "react";
-import { useSession, signOut } from "next-auth/react";
-import useSWR, { mutate } from "swr";
-import { ArchiveSessionDialog } from "@/components/archive-session-dialog";
-import { archiveSession } from "@/lib/archive-session";
-import { pullRequestSummaryDisplay } from "@/lib/pr-summary";
-import { PullRequestStateIcon } from "@/components/pr-state-icon";
-import { formatRelativeTime, isInactiveSession } from "@/lib/time";
-import {
-  applyTitleUpdate,
-  buildSessionsPageKey,
-  CURRENT_USER_CREATED_BY,
-  isUnarchivedSessionListKey,
-  mergeUniqueSessions,
-  removeSessionFromList,
-  type SessionListResponse,
-} from "@/lib/session-list";
+import { usePathname } from "next/navigation";
+import { useMemo, useCallback } from "react";
+import { useSession } from "next-auth/react";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import { useIsMobile } from "@/hooks/use-media-query";
+import { useSidebarSessions } from "@/hooks/use-sidebar-sessions";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import {
-  MoreIcon,
   SidebarIcon,
-  ArchiveIcon,
   PlusIcon,
   SearchIcon,
   SettingsIcon,
   AutomationsIcon,
-  BranchIcon,
-  BoxIcon,
   DataControlsIcon,
 } from "@/components/ui/icons";
-import { formatSessionRepositoriesLabel } from "@/lib/repo-label";
 import { Button } from "@/components/ui/button";
 import { useEnvironments } from "@/hooks/use-environments";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import type { Session } from "@open-inspect/shared";
+import { SessionWithChildren } from "@/components/session-with-children";
+import { UserMenu } from "@/components/sidebar-user-menu";
 
-export type SessionItem = Session;
+export type { SessionItem } from "@/hooks/use-sidebar-sessions";
 
-export const MOBILE_LONG_PRESS_MS = 450;
+export { buildSessionHref, MOBILE_LONG_PRESS_MS } from "@/components/session-list-item";
 
 interface SidebarActionButtonProps {
   onClick?: () => void;
@@ -90,24 +56,6 @@ export function NewSessionButton({ onClick }: SidebarActionButtonProps) {
     </Button>
   );
 }
-const MOBILE_LONG_PRESS_MOVE_THRESHOLD_PX = 10;
-type SessionCreatorFilter = "all" | "mine";
-
-export function buildSessionHref(session: SessionItem) {
-  const query: Record<string, string> = {};
-  if (session.repoOwner && session.repoName) {
-    query.repoOwner = session.repoOwner;
-    query.repoName = session.repoName;
-  }
-  if (session.title) {
-    query.title = session.title;
-  }
-
-  return {
-    pathname: `/session/${session.id}`,
-    query,
-  };
-}
 
 interface SessionSidebarProps {
   onNewSession?: () => void;
@@ -124,185 +72,25 @@ export function SessionSidebar({
 }: SessionSidebarProps) {
   const { data: authSession } = useSession();
   const pathname = usePathname();
-  const router = useRouter();
-  const [sessionCreatorFilter, setSessionCreatorFilter] = useState<SessionCreatorFilter>("all");
-  const [extraSessionsState, setExtraSessionsState] = useState<{
-    source: SessionListResponse | undefined;
-    sessions: SessionItem[];
-  }>({ source: undefined, sessions: [] });
-  const [hasMorePages, setHasMorePages] = useState(false);
-  const [loadingMore, setLoadingMore] = useState(false);
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const offsetRef = useRef(0);
-  const hasMoreRef = useRef(false);
-  const loadingMoreRef = useRef(false);
-  const sessionListVersionRef = useRef(0);
   const isMobile = useIsMobile();
 
-  const sidebarSessionsKey = useMemo(() => {
-    if (!authSession) return null;
-
-    return buildSessionsPageKey({
-      excludeStatus: "archived",
-      createdBy: sessionCreatorFilter === "mine" ? [CURRENT_USER_CREATED_BY] : undefined,
-    });
-  }, [authSession, sessionCreatorFilter]);
+  const currentSessionId = pathname?.startsWith("/session/") ? pathname.split("/")[2] : null;
 
   const {
-    data,
-    error: sessionsError,
-    isLoading: sessionsLoading,
-  } = useSWR<SessionListResponse>(sidebarSessionsKey);
-  const loading = sessionsLoading;
-  const firstPageSessions = useMemo(() => data?.sessions ?? [], [data?.sessions]);
-
-  // Hide paginated rows synchronously when SWR replaces their source page.
-  const extraSessions = useMemo(
-    () => (extraSessionsState.source === data ? extraSessionsState.sessions : []),
-    [data, extraSessionsState]
-  );
-
-  useEffect(() => {
-    sessionListVersionRef.current += 1;
-    setExtraSessionsState({ source: data, sessions: [] });
-    setLoadingMore(false);
-    loadingMoreRef.current = false;
-
-    const nextHasMore = data?.hasMore ?? false;
-    const nextOffset = data ? firstPageSessions.length : 0;
-
-    setHasMorePages(nextHasMore);
-    offsetRef.current = nextOffset;
-    hasMoreRef.current = nextHasMore;
-  }, [sidebarSessionsKey, data, firstPageSessions.length]);
-
-  const loadMoreSessions = useCallback(async () => {
-    if (!authSession || !sidebarSessionsKey || loadingMoreRef.current || !hasMoreRef.current) {
-      return;
-    }
-
-    loadingMoreRef.current = true;
-    setLoadingMore(true);
-    const sessionListVersion = sessionListVersionRef.current;
-
-    try {
-      const response = await fetch(
-        buildSessionsPageKey({
-          excludeStatus: "archived",
-          createdBy: sessionCreatorFilter === "mine" ? [CURRENT_USER_CREATED_BY] : undefined,
-          offset: offsetRef.current,
-        })
-      );
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch additional sessions: ${response.status}`);
-      }
-
-      const page: SessionListResponse = await response.json();
-      const fetched = page.sessions ?? [];
-
-      if (sessionListVersion !== sessionListVersionRef.current) {
-        return;
-      }
-
-      setExtraSessionsState((previous) => ({
-        source: data,
-        sessions: mergeUniqueSessions(previous.source === data ? previous.sessions : [], fetched),
-      }));
-      setHasMorePages(page.hasMore);
-      offsetRef.current += fetched.length;
-      hasMoreRef.current = page.hasMore;
-    } catch (error) {
-      console.error("Failed to fetch additional sessions:", error);
-    } finally {
-      if (sessionListVersion === sessionListVersionRef.current) {
-        loadingMoreRef.current = false;
-        setLoadingMore(false);
-      }
-    }
-  }, [authSession, data, sessionCreatorFilter, sidebarSessionsKey]);
-
-  const maybeLoadMoreSessions = useCallback(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
-
-    const nearBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 96;
-    if (nearBottom) {
-      void loadMoreSessions();
-    }
-  }, [loadMoreSessions]);
-
-  useEffect(() => {
-    const container = scrollContainerRef.current;
-    if (!container || loading || loadingMore || !hasMorePages) return;
-
-    if (container.clientHeight > 0 && container.scrollHeight <= container.clientHeight) {
-      void loadMoreSessions();
-    }
-  }, [
-    hasMorePages,
+    sessions,
+    activeSessions,
+    inactiveSessions,
+    childrenMap,
     loading,
     loadingMore,
-    loadMoreSessions,
-    firstPageSessions.length,
-    extraSessions.length,
-  ]);
-
-  const sessions = useMemo(
-    () => mergeUniqueSessions(firstPageSessions, extraSessions),
-    [firstPageSessions, extraSessions]
-  );
-
-  // Sort sessions by updatedAt (most recent first) and group children under their parent sessions.
-  const { activeSessions, inactiveSessions, childrenMap } = useMemo(() => {
-    const filtered = sessions.filter((session) => session.status !== "archived");
-
-    // Sort by updatedAt descending
-    const sorted = [...filtered].sort((a, b) => {
-      const aTime = a.updatedAt || a.createdAt;
-      const bTime = b.updatedAt || b.createdAt;
-      return bTime - aTime;
-    });
-
-    // Build set of visible session IDs for orphan detection
-    const visibleIds = new Set(sorted.map((s) => s.id));
-
-    // Group children by parent ID
-    const children = new Map<string, SessionItem[]>();
-    const topLevel: SessionItem[] = [];
-
-    for (const session of sorted) {
-      const parentId = session.parentSessionId;
-      if (parentId && visibleIds.has(parentId)) {
-        // Parent is visible — nest under it
-        const siblings = children.get(parentId) ?? [];
-        siblings.push(session);
-        children.set(parentId, siblings);
-      } else {
-        // Top-level session (or orphan child whose parent is filtered out)
-        topLevel.push(session);
-      }
-    }
-
-    const active: SessionItem[] = [];
-    const inactive: SessionItem[] = [];
-    const now = Date.now();
-
-    for (const session of topLevel) {
-      const timestamp = session.updatedAt || session.createdAt;
-      if (isInactiveSession(timestamp, now)) {
-        inactive.push(session);
-      } else {
-        active.push(session);
-      }
-    }
-
-    return {
-      activeSessions: active,
-      inactiveSessions: inactive,
-      childrenMap: children,
-    };
-  }, [sessions]);
+    sessionsError,
+    sessionCreatorFilter,
+    setSessionCreatorFilter,
+    scrollContainerRef,
+    maybeLoadMoreSessions,
+    handleSessionArchived,
+    handleSessionRenamed,
+  } = useSidebarSessions(currentSessionId);
 
   // Environment provenance for the cards, resolved once for the whole list.
   // Names are looked up so a deleted environment (or one still loading)
@@ -313,7 +101,6 @@ export function SessionSidebar({
     [environments]
   );
 
-  const currentSessionId = pathname?.startsWith("/session/") ? pathname.split("/")[2] : null;
   const hasSessionListError = sessionsError;
   const emptyMessage = hasSessionListError
     ? "Unable to load sessions"
@@ -321,55 +108,11 @@ export function SessionSidebar({
       ? "No sessions started by you"
       : "No sessions yet";
 
-  const handleSessionArchived = useCallback(
-    async (sessionId: string) => {
-      if (!sidebarSessionsKey) return;
-
-      await mutate<SessionListResponse>(
-        isUnarchivedSessionListKey,
-        (current) =>
-          current
-            ? { ...current, sessions: removeSessionFromList(current.sessions, sessionId) }
-            : current,
-        { revalidate: false, populateCache: true }
-      );
-      setExtraSessionsState((previous) => ({
-        ...previous,
-        sessions: previous.sessions.filter((session) => session.id !== sessionId),
-      }));
-
-      if (currentSessionId === sessionId) {
-        router.push("/");
-      }
-    },
-    [currentSessionId, router, sidebarSessionsKey]
-  );
-
   const handleNavigationSelect = useCallback(() => {
     if (isMobile) {
       onSessionSelect?.();
     }
   }, [isMobile, onSessionSelect]);
-
-  const handleSessionRenamed = useCallback(
-    (sessionId: string, title: string) => {
-      const updatedAt = Date.now();
-      setExtraSessionsState((previous) => ({
-        ...previous,
-        sessions: previous.sessions.map((session) =>
-          session.id === sessionId ? { ...session, title, updatedAt } : session
-        ),
-      }));
-      if (!sidebarSessionsKey) return;
-
-      void mutate<SessionListResponse>(
-        isUnarchivedSessionListKey,
-        (currentData) => applyTitleUpdate(currentData, sessionId, title, updatedAt),
-        { revalidate: false }
-      );
-    },
-    [sidebarSessionsKey]
-  );
 
   return (
     <aside className="w-72 h-dvh flex flex-col border-r border-border-muted bg-background">
@@ -533,486 +276,5 @@ export function SessionSidebar({
         <UserMenu user={authSession?.user} />
       </div>
     </aside>
-  );
-}
-
-function UserMenu({ user }: { user?: { name?: string | null; image?: string | null } | null }) {
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className="flex w-full items-center gap-3 rounded-md px-2 py-2 text-left text-sm font-medium text-foreground transition hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary"
-          aria-label={`Signed in as ${user?.name || "User"}`}
-          title={`Signed in as ${user?.name || "User"}`}
-        >
-          <span className="h-7 w-7 shrink-0 overflow-hidden rounded-full">
-            {user?.image ? (
-              <img src={user.image} alt="" className="h-full w-full object-cover" />
-            ) : (
-              <span className="flex h-full w-full items-center justify-center rounded-full bg-card text-xs font-medium text-foreground">
-                {user?.name?.charAt(0).toUpperCase() || "?"}
-              </span>
-            )}
-          </span>
-          <span className="min-w-0 truncate">{user?.name || "User"}</span>
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" side="top" sideOffset={4}>
-        <DropdownMenuLabel className="font-medium truncate">
-          {user?.name || "User"}
-        </DropdownMenuLabel>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem onClick={() => signOut()}>
-          <svg
-            className="w-4 h-4"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            strokeWidth={1.5}
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15m3-3l3-3m0 0l-3-3m3 3H9"
-            />
-          </svg>
-          Sign out
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
-function SessionWithChildren({
-  session,
-  environmentName,
-  childrenMap,
-  currentSessionId,
-  isMobile,
-  onArchive,
-  onSessionSelect,
-  onSessionRenamed,
-}: {
-  session: SessionItem;
-  environmentName?: string;
-  childrenMap: Map<string, SessionItem[]>;
-  currentSessionId: string | null;
-  isMobile: boolean;
-  onArchive: (sessionId: string) => Promise<void>;
-  onSessionSelect?: () => void;
-  onSessionRenamed: (sessionId: string, title: string) => void;
-}) {
-  return (
-    <>
-      <SessionListItem
-        session={session}
-        environmentName={environmentName}
-        isActive={session.id === currentSessionId}
-        isMobile={isMobile}
-        onArchive={onArchive}
-        onSessionSelect={onSessionSelect}
-        onSessionRenamed={onSessionRenamed}
-      />
-      <ChildSessionTree
-        parentId={session.id}
-        childrenMap={childrenMap}
-        currentSessionId={currentSessionId}
-        isMobile={isMobile}
-        onSessionSelect={onSessionSelect}
-        visitedIds={new Set([session.id])}
-      />
-    </>
-  );
-}
-
-function ChildSessionTree({
-  parentId,
-  childrenMap,
-  currentSessionId,
-  isMobile,
-  onSessionSelect,
-  visitedIds,
-  depth = 1,
-}: {
-  parentId: string;
-  childrenMap: Map<string, SessionItem[]>;
-  currentSessionId: string | null;
-  isMobile: boolean;
-  onSessionSelect?: () => void;
-  visitedIds: Set<string>;
-  depth?: number;
-}) {
-  const childSessions = childrenMap.get(parentId);
-  if (!childSessions?.length) return null;
-
-  return childSessions.map((child) => {
-    if (visitedIds.has(child.id)) return null;
-
-    const nextVisitedIds = new Set(visitedIds);
-    nextVisitedIds.add(child.id);
-
-    return (
-      <Fragment key={child.id}>
-        <ChildSessionListItem
-          session={child}
-          isActive={child.id === currentSessionId}
-          isMobile={isMobile}
-          onSessionSelect={onSessionSelect}
-          depth={depth}
-        />
-        <ChildSessionTree
-          parentId={child.id}
-          childrenMap={childrenMap}
-          currentSessionId={currentSessionId}
-          isMobile={isMobile}
-          onSessionSelect={onSessionSelect}
-          visitedIds={nextVisitedIds}
-          depth={depth + 1}
-        />
-      </Fragment>
-    );
-  });
-}
-
-function SessionListItem({
-  session,
-  environmentName,
-  isActive,
-  isMobile,
-  onArchive,
-  onSessionSelect,
-  onSessionRenamed,
-}: {
-  session: SessionItem;
-  environmentName?: string;
-  isActive: boolean;
-  isMobile: boolean;
-  onArchive: (sessionId: string) => Promise<void>;
-  onSessionSelect?: () => void;
-  onSessionRenamed: (sessionId: string, title: string) => void;
-}) {
-  const timestamp = session.updatedAt || session.createdAt;
-  const relativeTime = formatRelativeTime(timestamp);
-  const repoInfo = formatSessionRepositoriesLabel(
-    session.repoOwner,
-    session.repoName,
-    session.repositories
-  );
-  const prDisplay = pullRequestSummaryDisplay(session.pullRequestSummary);
-  const displayTitle = session.title || repoInfo;
-  // Orphan child (parent filtered out) — show a subtle badge
-  const isOrphanChild = session.parentSessionId && session.spawnSource === "agent";
-  const [isRenaming, setIsRenaming] = useState(false);
-  const [isActionsOpen, setIsActionsOpen] = useState(false);
-  const [isArchiving, setIsArchiving] = useState(false);
-  const [showArchiveDialog, setShowArchiveDialog] = useState(false);
-  const [title, setTitle] = useState(displayTitle);
-  const renameInputRef = useRef<HTMLInputElement>(null);
-  const isStartingRenameRef = useRef(false);
-  const longPressTimerRef = useRef<number | null>(null);
-  const longPressTriggeredRef = useRef(false);
-  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
-
-  useEffect(() => {
-    if (!isRenaming) {
-      setTitle(displayTitle);
-    }
-  }, [displayTitle, isRenaming]);
-
-  const handleStartRename = () => {
-    isStartingRenameRef.current = true;
-    setIsActionsOpen(false);
-    setTitle(displayTitle);
-    setIsRenaming(true);
-  };
-
-  useEffect(() => {
-    if (!isRenaming) return;
-
-    const timeout = window.setTimeout(() => {
-      renameInputRef.current?.focus();
-      renameInputRef.current?.select();
-    }, 0);
-
-    return () => window.clearTimeout(timeout);
-  }, [isRenaming]);
-
-  const handleCancelRename = () => {
-    setTitle(displayTitle);
-    setIsRenaming(false);
-  };
-
-  const handleStartArchive = () => {
-    setIsActionsOpen(false);
-    setShowArchiveDialog(true);
-  };
-
-  const handleConfirmArchive = async () => {
-    setShowArchiveDialog(false);
-    setIsArchiving(true);
-
-    try {
-      const didArchive = await archiveSession(session.id);
-      if (didArchive) {
-        await onArchive(session.id);
-      }
-    } finally {
-      setIsArchiving(false);
-    }
-  };
-
-  const handleRenameSubmit = async () => {
-    const trimmed = title.trim();
-
-    if (!trimmed || trimmed === displayTitle) {
-      setIsRenaming(false);
-      return;
-    }
-
-    const previousTitle = displayTitle;
-    setIsRenaming(false);
-
-    try {
-      const response = await fetch(`/api/sessions/${session.id}/title`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title: trimmed }),
-      });
-      if (!response.ok) {
-        throw new Error("Failed to update session title");
-      }
-      onSessionRenamed(session.id, trimmed);
-    } catch {
-      setTitle(previousTitle);
-      setIsRenaming(true);
-    }
-  };
-
-  const clearLongPressTimer = useCallback(() => {
-    if (longPressTimerRef.current !== null) {
-      window.clearTimeout(longPressTimerRef.current);
-      longPressTimerRef.current = null;
-    }
-  }, []);
-
-  const handleTouchStart = useCallback(
-    (event: TouchEvent<HTMLAnchorElement>) => {
-      if (!isMobile) return;
-
-      const touch = event.touches[0];
-      if (!touch) return;
-
-      longPressTriggeredRef.current = false;
-      touchStartRef.current = { x: touch.clientX, y: touch.clientY };
-      clearLongPressTimer();
-      longPressTimerRef.current = window.setTimeout(() => {
-        longPressTriggeredRef.current = true;
-        setIsActionsOpen(true);
-      }, MOBILE_LONG_PRESS_MS);
-    },
-    [clearLongPressTimer, isMobile]
-  );
-
-  const handleTouchMove = useCallback(
-    (event: TouchEvent<HTMLAnchorElement>) => {
-      if (!isMobile) return;
-
-      const start = touchStartRef.current;
-      const touch = event.touches[0];
-      if (!start || !touch) return;
-
-      const deltaX = touch.clientX - start.x;
-      const deltaY = touch.clientY - start.y;
-      if (Math.hypot(deltaX, deltaY) > MOBILE_LONG_PRESS_MOVE_THRESHOLD_PX) {
-        clearLongPressTimer();
-      }
-    },
-    [clearLongPressTimer, isMobile]
-  );
-
-  const handleTouchEnd = useCallback(() => {
-    clearLongPressTimer();
-    touchStartRef.current = null;
-  }, [clearLongPressTimer]);
-
-  useEffect(() => {
-    return () => clearLongPressTimer();
-  }, [clearLongPressTimer]);
-
-  return (
-    <>
-      <div
-        className={`group relative block px-4 py-2.5 border-l-2 transition ${
-          isActive ? "border-l-accent bg-accent-muted" : "border-l-transparent hover:bg-muted"
-        }`}
-      >
-        {isRenaming ? (
-          <>
-            <input
-              ref={renameInputRef}
-              autoFocus
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              onFocus={(e) => e.currentTarget.select()}
-              onBlur={handleRenameSubmit}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  e.currentTarget.blur();
-                }
-                if (e.key === "Escape") {
-                  e.preventDefault();
-                  handleCancelRename();
-                }
-              }}
-              className="w-full text-sm bg-transparent text-foreground outline-none focus:ring-inset focus:ring-ring font-medium pr-8"
-            />
-            <div className="flex items-center gap-1 mt-0.5 text-xs text-muted-foreground">
-              <span>{relativeTime}</span>
-              <span>·</span>
-              <span className="truncate">{repoInfo}</span>
-            </div>
-          </>
-        ) : (
-          <Link
-            href={buildSessionHref(session)}
-            onClick={(event) => {
-              if (longPressTriggeredRef.current) {
-                event.preventDefault();
-                longPressTriggeredRef.current = false;
-                return;
-              }
-              if (isMobile) {
-                onSessionSelect?.();
-              }
-            }}
-            onContextMenu={(event) => {
-              if (isMobile) {
-                event.preventDefault();
-              }
-            }}
-            onTouchStart={handleTouchStart}
-            onTouchMove={handleTouchMove}
-            onTouchEnd={handleTouchEnd}
-            onTouchCancel={handleTouchEnd}
-            className="block pr-8"
-          >
-            <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">
-              {prDisplay && (
-                <PullRequestStateIcon state={prDisplay.state} label={prDisplay.label} />
-              )}
-              <span className="truncate">{displayTitle}</span>
-            </div>
-            <div className="flex items-center gap-1 mt-0.5 text-xs text-muted-foreground">
-              <span>{relativeTime}</span>
-              <span>·</span>
-              <span className="truncate">{repoInfo}</span>
-              {environmentName && (
-                <>
-                  <span>·</span>
-                  <BoxIcon className="w-3 h-3 flex-shrink-0" />
-                  <span className="truncate">{environmentName}</span>
-                </>
-              )}
-              {isOrphanChild && (
-                <>
-                  <span>·</span>
-                  <span className="text-accent">sub-task</span>
-                </>
-              )}
-              {session.baseBranch && session.baseBranch !== "main" && (
-                <>
-                  <span>·</span>
-                  <BranchIcon className="w-3 h-3 flex-shrink-0" />
-                  <span className="truncate">{session.baseBranch}</span>
-                </>
-              )}
-            </div>
-          </Link>
-        )}
-
-        <div className="absolute inset-y-0 right-2 flex items-start pt-2">
-          <DropdownMenu open={isActionsOpen} onOpenChange={setIsActionsOpen}>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                aria-label="Session actions"
-                aria-hidden={isMobile ? "true" : undefined}
-                tabIndex={isMobile ? -1 : undefined}
-                className={`h-6 w-6 items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition data-[state=open]:opacity-100 ${
-                  isMobile
-                    ? "pointer-events-none flex opacity-0"
-                    : "flex opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
-                }`}
-              >
-                <MoreIcon className="w-4 h-4" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="end"
-              onCloseAutoFocus={(event) => {
-                if (isStartingRenameRef.current) {
-                  event.preventDefault();
-                  isStartingRenameRef.current = false;
-                }
-              }}
-            >
-              <DropdownMenuItem onSelect={handleStartRename}>Rename</DropdownMenuItem>
-              <DropdownMenuItem onClick={handleStartArchive} disabled={isArchiving}>
-                <ArchiveIcon className="w-4 h-4" />
-                Archive
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      </div>
-
-      <ArchiveSessionDialog
-        open={showArchiveDialog}
-        onOpenChange={setShowArchiveDialog}
-        onConfirm={handleConfirmArchive}
-      />
-    </>
-  );
-}
-
-function ChildSessionListItem({
-  session,
-  isActive,
-  isMobile,
-  onSessionSelect,
-  depth,
-}: {
-  session: SessionItem;
-  isActive: boolean;
-  isMobile: boolean;
-  onSessionSelect?: () => void;
-  depth: number;
-}) {
-  const timestamp = session.updatedAt || session.createdAt;
-  const relativeTime = formatRelativeTime(timestamp);
-  const prDisplay = pullRequestSummaryDisplay(session.pullRequestSummary);
-  const displayTitle = session.title || "Sub-task";
-  const paddingLeftRem = 1.75 + Math.max(depth - 1, 0) * 1;
-  return (
-    <Link
-      href={buildSessionHref(session)}
-      onClick={() => {
-        if (isMobile) {
-          onSessionSelect?.();
-        }
-      }}
-      className={`block pr-4 py-1.5 border-l-2 transition ${
-        isActive ? "border-l-accent bg-accent-muted" : "border-l-transparent hover:bg-muted"
-      }`}
-      style={{ paddingLeft: `${paddingLeftRem}rem` }}
-    >
-      <div className="flex items-center gap-1.5 text-xs">
-        <span className="shrink-0 text-muted-foreground">{relativeTime}</span>
-        {prDisplay && <PullRequestStateIcon state={prDisplay.state} label={prDisplay.label} />}
-        <span className="truncate font-medium text-foreground">{displayTitle}</span>
-      </div>
-    </Link>
   );
 }

--- a/packages/web/src/components/session-with-children.tsx
+++ b/packages/web/src/components/session-with-children.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { Fragment } from "react";
+import { SessionListItem, ChildSessionListItem } from "@/components/session-list-item";
+import type { SessionItem } from "@/hooks/use-sidebar-sessions";
+
+export function SessionWithChildren({
+  session,
+  environmentName,
+  childrenMap,
+  currentSessionId,
+  isMobile,
+  onArchive,
+  onSessionSelect,
+  onSessionRenamed,
+}: {
+  session: SessionItem;
+  environmentName?: string;
+  childrenMap: Map<string, SessionItem[]>;
+  currentSessionId: string | null;
+  isMobile: boolean;
+  onArchive: (sessionId: string) => Promise<void>;
+  onSessionSelect?: () => void;
+  onSessionRenamed: (sessionId: string, title: string) => void;
+}) {
+  return (
+    <>
+      <SessionListItem
+        session={session}
+        environmentName={environmentName}
+        isActive={session.id === currentSessionId}
+        isMobile={isMobile}
+        onArchive={onArchive}
+        onSessionSelect={onSessionSelect}
+        onSessionRenamed={onSessionRenamed}
+      />
+      <ChildSessionTree
+        parentId={session.id}
+        childrenMap={childrenMap}
+        currentSessionId={currentSessionId}
+        isMobile={isMobile}
+        onSessionSelect={onSessionSelect}
+        visitedIds={new Set([session.id])}
+      />
+    </>
+  );
+}
+
+function ChildSessionTree({
+  parentId,
+  childrenMap,
+  currentSessionId,
+  isMobile,
+  onSessionSelect,
+  visitedIds,
+  depth = 1,
+}: {
+  parentId: string;
+  childrenMap: Map<string, SessionItem[]>;
+  currentSessionId: string | null;
+  isMobile: boolean;
+  onSessionSelect?: () => void;
+  visitedIds: Set<string>;
+  depth?: number;
+}) {
+  const childSessions = childrenMap.get(parentId);
+  if (!childSessions?.length) return null;
+
+  return childSessions.map((child) => {
+    if (visitedIds.has(child.id)) return null;
+
+    const nextVisitedIds = new Set(visitedIds);
+    nextVisitedIds.add(child.id);
+
+    return (
+      <Fragment key={child.id}>
+        <ChildSessionListItem
+          session={child}
+          isActive={child.id === currentSessionId}
+          isMobile={isMobile}
+          onSessionSelect={onSessionSelect}
+          depth={depth}
+        />
+        <ChildSessionTree
+          parentId={child.id}
+          childrenMap={childrenMap}
+          currentSessionId={currentSessionId}
+          isMobile={isMobile}
+          onSessionSelect={onSessionSelect}
+          visitedIds={nextVisitedIds}
+          depth={depth + 1}
+        />
+      </Fragment>
+    );
+  });
+}

--- a/packages/web/src/components/sidebar-user-menu.tsx
+++ b/packages/web/src/components/sidebar-user-menu.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { signOut } from "next-auth/react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export function UserMenu({
+  user,
+}: {
+  user?: { name?: string | null; image?: string | null } | null;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="flex w-full items-center gap-3 rounded-md px-2 py-2 text-left text-sm font-medium text-foreground transition hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary"
+          aria-label={`Signed in as ${user?.name || "User"}`}
+          title={`Signed in as ${user?.name || "User"}`}
+        >
+          <span className="h-7 w-7 shrink-0 overflow-hidden rounded-full">
+            {user?.image ? (
+              <img src={user.image} alt="" className="h-full w-full object-cover" />
+            ) : (
+              <span className="flex h-full w-full items-center justify-center rounded-full bg-card text-xs font-medium text-foreground">
+                {user?.name?.charAt(0).toUpperCase() || "?"}
+              </span>
+            )}
+          </span>
+          <span className="min-w-0 truncate">{user?.name || "User"}</span>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" side="top" sideOffset={4}>
+        <DropdownMenuLabel className="font-medium truncate">
+          {user?.name || "User"}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={() => signOut()}>
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={1.5}
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15m3-3l3-3m0 0l-3-3m3 3H9"
+            />
+          </svg>
+          Sign out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/web/src/hooks/use-sidebar-sessions.ts
+++ b/packages/web/src/hooks/use-sidebar-sessions.ts
@@ -1,0 +1,263 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { useSession } from "next-auth/react";
+import useSWR, { mutate } from "swr";
+import { isInactiveSession } from "@/lib/time";
+import {
+  applyTitleUpdate,
+  buildSessionsPageKey,
+  CURRENT_USER_CREATED_BY,
+  isUnarchivedSessionListKey,
+  mergeUniqueSessions,
+  removeSessionFromList,
+  type SessionListResponse,
+} from "@/lib/session-list";
+import type { Session } from "@open-inspect/shared";
+
+export type SessionItem = Session;
+
+type SessionCreatorFilter = "all" | "mine";
+
+export function useSidebarSessions(currentSessionId: string | null) {
+  const { data: authSession } = useSession();
+  const router = useRouter();
+  const [sessionCreatorFilter, setSessionCreatorFilter] = useState<SessionCreatorFilter>("all");
+  const [extraSessionsState, setExtraSessionsState] = useState<{
+    source: SessionListResponse | undefined;
+    sessions: SessionItem[];
+  }>({ source: undefined, sessions: [] });
+  const [hasMorePages, setHasMorePages] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const offsetRef = useRef(0);
+  const hasMoreRef = useRef(false);
+  const loadingMoreRef = useRef(false);
+  const sessionListVersionRef = useRef(0);
+
+  const sidebarSessionsKey = useMemo(() => {
+    if (!authSession) return null;
+
+    return buildSessionsPageKey({
+      excludeStatus: "archived",
+      createdBy: sessionCreatorFilter === "mine" ? [CURRENT_USER_CREATED_BY] : undefined,
+    });
+  }, [authSession, sessionCreatorFilter]);
+
+  const {
+    data,
+    error: sessionsError,
+    isLoading: sessionsLoading,
+  } = useSWR<SessionListResponse>(sidebarSessionsKey);
+  const loading = sessionsLoading;
+  const firstPageSessions = useMemo(() => data?.sessions ?? [], [data?.sessions]);
+
+  // Hide paginated rows synchronously when SWR replaces their source page.
+  const extraSessions = useMemo(
+    () => (extraSessionsState.source === data ? extraSessionsState.sessions : []),
+    [data, extraSessionsState]
+  );
+
+  useEffect(() => {
+    sessionListVersionRef.current += 1;
+    setExtraSessionsState({ source: data, sessions: [] });
+    setLoadingMore(false);
+    loadingMoreRef.current = false;
+
+    const nextHasMore = data?.hasMore ?? false;
+    const nextOffset = data ? firstPageSessions.length : 0;
+
+    setHasMorePages(nextHasMore);
+    offsetRef.current = nextOffset;
+    hasMoreRef.current = nextHasMore;
+  }, [sidebarSessionsKey, data, firstPageSessions.length]);
+
+  const loadMoreSessions = useCallback(async () => {
+    if (!authSession || !sidebarSessionsKey || loadingMoreRef.current || !hasMoreRef.current) {
+      return;
+    }
+
+    loadingMoreRef.current = true;
+    setLoadingMore(true);
+    const sessionListVersion = sessionListVersionRef.current;
+
+    try {
+      const response = await fetch(
+        buildSessionsPageKey({
+          excludeStatus: "archived",
+          createdBy: sessionCreatorFilter === "mine" ? [CURRENT_USER_CREATED_BY] : undefined,
+          offset: offsetRef.current,
+        })
+      );
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch additional sessions: ${response.status}`);
+      }
+
+      const page: SessionListResponse = await response.json();
+      const fetched = page.sessions ?? [];
+
+      if (sessionListVersion !== sessionListVersionRef.current) {
+        return;
+      }
+
+      setExtraSessionsState((previous) => ({
+        source: data,
+        sessions: mergeUniqueSessions(previous.source === data ? previous.sessions : [], fetched),
+      }));
+      setHasMorePages(page.hasMore);
+      offsetRef.current += fetched.length;
+      hasMoreRef.current = page.hasMore;
+    } catch (error) {
+      console.error("Failed to fetch additional sessions:", error);
+    } finally {
+      if (sessionListVersion === sessionListVersionRef.current) {
+        loadingMoreRef.current = false;
+        setLoadingMore(false);
+      }
+    }
+  }, [authSession, data, sessionCreatorFilter, sidebarSessionsKey]);
+
+  const maybeLoadMoreSessions = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const nearBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 96;
+    if (nearBottom) {
+      void loadMoreSessions();
+    }
+  }, [loadMoreSessions]);
+
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container || loading || loadingMore || !hasMorePages) return;
+
+    if (container.clientHeight > 0 && container.scrollHeight <= container.clientHeight) {
+      void loadMoreSessions();
+    }
+  }, [
+    hasMorePages,
+    loading,
+    loadingMore,
+    loadMoreSessions,
+    firstPageSessions.length,
+    extraSessions.length,
+  ]);
+
+  const sessions = useMemo(
+    () => mergeUniqueSessions(firstPageSessions, extraSessions),
+    [firstPageSessions, extraSessions]
+  );
+
+  // Sort sessions by updatedAt (most recent first) and group children under their parent sessions.
+  const { activeSessions, inactiveSessions, childrenMap } = useMemo(() => {
+    const filtered = sessions.filter((session) => session.status !== "archived");
+
+    // Sort by updatedAt descending
+    const sorted = [...filtered].sort((a, b) => {
+      const aTime = a.updatedAt || a.createdAt;
+      const bTime = b.updatedAt || b.createdAt;
+      return bTime - aTime;
+    });
+
+    // Build set of visible session IDs for orphan detection
+    const visibleIds = new Set(sorted.map((s) => s.id));
+
+    // Group children by parent ID
+    const children = new Map<string, SessionItem[]>();
+    const topLevel: SessionItem[] = [];
+
+    for (const session of sorted) {
+      const parentId = session.parentSessionId;
+      if (parentId && visibleIds.has(parentId)) {
+        // Parent is visible — nest under it
+        const siblings = children.get(parentId) ?? [];
+        siblings.push(session);
+        children.set(parentId, siblings);
+      } else {
+        // Top-level session (or orphan child whose parent is filtered out)
+        topLevel.push(session);
+      }
+    }
+
+    const active: SessionItem[] = [];
+    const inactive: SessionItem[] = [];
+    const now = Date.now();
+
+    for (const session of topLevel) {
+      const timestamp = session.updatedAt || session.createdAt;
+      if (isInactiveSession(timestamp, now)) {
+        inactive.push(session);
+      } else {
+        active.push(session);
+      }
+    }
+
+    return {
+      activeSessions: active,
+      inactiveSessions: inactive,
+      childrenMap: children,
+    };
+  }, [sessions]);
+
+  const handleSessionArchived = useCallback(
+    async (sessionId: string) => {
+      if (!sidebarSessionsKey) return;
+
+      await mutate<SessionListResponse>(
+        isUnarchivedSessionListKey,
+        (current) =>
+          current
+            ? { ...current, sessions: removeSessionFromList(current.sessions, sessionId) }
+            : current,
+        { revalidate: false, populateCache: true }
+      );
+      setExtraSessionsState((previous) => ({
+        ...previous,
+        sessions: previous.sessions.filter((session) => session.id !== sessionId),
+      }));
+
+      if (currentSessionId === sessionId) {
+        router.push("/");
+      }
+    },
+    [currentSessionId, router, sidebarSessionsKey]
+  );
+
+  const handleSessionRenamed = useCallback(
+    (sessionId: string, title: string) => {
+      const updatedAt = Date.now();
+      setExtraSessionsState((previous) => ({
+        ...previous,
+        sessions: previous.sessions.map((session) =>
+          session.id === sessionId ? { ...session, title, updatedAt } : session
+        ),
+      }));
+      if (!sidebarSessionsKey) return;
+
+      void mutate<SessionListResponse>(
+        isUnarchivedSessionListKey,
+        (currentData) => applyTitleUpdate(currentData, sessionId, title, updatedAt),
+        { revalidate: false }
+      );
+    },
+    [sidebarSessionsKey]
+  );
+
+  return {
+    sessions,
+    activeSessions,
+    inactiveSessions,
+    childrenMap,
+    loading,
+    loadingMore,
+    sessionsError,
+    sessionCreatorFilter,
+    setSessionCreatorFilter,
+    scrollContainerRef,
+    maybeLoadMoreSessions,
+    handleSessionArchived,
+    handleSessionRenamed,
+  };
+}


### PR DESCRIPTION
Decomposes the ~1018-line `session-sidebar.tsx`, which mixed data fetching (SWR + pagination), the stale-response race guard, and presentation, into a data hook plus presentational subcomponents with a thin composition root. Mirrors the `SessionChangesPanel` decomposition (#1053). Pure refactor: every moved block is verbatim; no logic, markup, or styling changes.

## What moved where

| File | Lines | Contents |
| --- | --- | --- |
| `components/session-sidebar.tsx` | 1018 → 280 | Thin composition root: `SessionSidebar`, header action buttons (`SearchSessionsButton`, `NewSessionButton`), nav links, creator-filter toggle, list rendering. Re-exports `SessionItem`, `buildSessionHref`, `MOBILE_LONG_PRESS_MS` so existing import sites (`sidebar-layout`, `child-sessions-section`, `data-controls-settings`, the test file) are untouched. |
| `hooks/use-sidebar-sessions.ts` (new) | 263 | `useSidebarSessions`: SWR wiring + key construction, pagination state/refs, `sessionListVersionRef` race guard, load-more + fill-viewport effects, active/inactive/children grouping, and the archive/rename cache mutations. Also defines `SessionItem`. |
| `components/session-list-item.tsx` (new) | 379 | `SessionListItem`, `ChildSessionListItem`, `buildSessionHref`, `MOBILE_LONG_PRESS_MS`, long-press/rename/archive interaction state. |
| `components/session-with-children.tsx` (new) | 96 | `SessionWithChildren` + recursive `ChildSessionTree` (cycle-guarded via `visitedIds`). |
| `components/sidebar-user-menu.tsx` (new) | 63 | `UserMenu` footer dropdown. |

Net: 5 files changed, +822/−759.

## Behavior preservation

- **Test suite byte-unmodified**: `session-sidebar.test.tsx` was not touched at all — it still imports `MOBILE_LONG_PRESS_MS` and `SessionSidebar` from `./session-sidebar`, satisfied by re-exports.
- **Race guard preserved exactly**: `sessionListVersionRef` moved wholesale into the hook — same increment point (the key/data reset effect), same snapshot before the fetch, same comparison points after `await response.json()` and in the `finally` block. The "ignores stale load-more results after the creator filter changes" test exercises it and passes.
- All moved code is byte-identical; no renames, no reordering, no style changes.

## Verification (all with `set -o pipefail`)

- `npm run test -w @open-inspect/web` — **826 passed (92 files)**, exit 0, no count regression vs main
- `npm run lint` — exit 0
- `npm run typecheck -w @open-inspect/web` — reports only the 2 **pre-existing** errors already present on pristine `origin/main` (verified via stash): `session/[id]/page.tsx` imports `@/components/ui/sheet`, which #1043 deleted. This branch introduces **zero** new type errors; the `ui/sheet` breakage is unrelated and left out of scope for this behavior-preserving refactor.
- `prettier --check` clean on all touched files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a redesigned session sidebar with active/inactive grouping and nested child sessions.
  * Added inline session renaming and archive actions, including mobile long-press controls.
  * Added session metadata such as relative time, repository, branch, environment, and pull request status.
  * Added incremental loading for longer session lists and creator filtering.
  * Added a user menu with profile display and sign-out support.
* **Bug Fixes**
  * Improved handling of archived sessions and navigation after archiving the current session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->