### PR TITLE
refactor(control-plane): extract SessionStatusService from session DO

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -9,7 +9,6 @@
 
 import { DurableObject } from "cloudflare:workers";
 import { initSchema } from "./schema";
-import { buildSessionInternalUrl, SessionInternalPaths } from "./contracts";
 import {
   DEFAULT_MODEL,
   clientMessageSchema,
@@ -122,6 +121,7 @@ import { SessionDiffStore } from "./diffs/store";
 import { SessionDiffService } from "./diffs/service";
 import { SessionDiffsHandler } from "./http/handlers/session-diffs.handler";
 import { SessionMessengerImpl, type SessionMessenger } from "./messenger";
+import { SessionStatusService } from "./session-status-service";
 
 /**
  * Timeout for WebSocket authentication (in milliseconds).
@@ -137,9 +137,6 @@ const WS_AUTH_TIMEOUT_MS = 30000; // 30 seconds
  * the client to fetch a fresh token on reconnect.
  */
 const WS_TOKEN_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
-
-/** Statuses that indicate a session is finished — metrics are synced to D1 on these transitions. */
-const TERMINAL_STATUSES: SessionStatus[] = ["completed", "failed", "cancelled"];
 
 type BoundarySchema<T> = {
   safeParse(
@@ -200,6 +197,8 @@ export class SessionDO extends DurableObject<Env> {
   private _alarmHandler: AlarmHandler | null = null;
   // Sandbox event processor (lazily initialized)
   private _sandboxEventProcessor: SessionSandboxEventProcessor | null = null;
+  // Session status service (lazily initialized)
+  private _statusService: SessionStatusService | null = null;
 
   // Internal HTTP route table (transport wiring only; handlers remain on SessionDO).
   private readonly routes = createSessionInternalRoutes({
@@ -515,7 +514,7 @@ export class SessionDO extends DurableObject<Env> {
         getSandbox: () => this.getSandbox(),
         getPublicSessionId: (session) => this.getPublicSessionId(session),
         getParticipantByUserId: (userId) => this.participantService.getByUserId(userId),
-        transitionSessionStatus: (status) => this.transitionSessionStatus(status),
+        statusService: this.statusService,
         applySessionTitleUpdate: (title, options) => this.applySessionTitleUpdate(title, options),
         stopExecution: (options) => this.stopExecution(options),
         getSandboxSocket: () => this.wsManager.getSandboxSocket(),
@@ -635,9 +634,7 @@ export class SessionDO extends DurableObject<Env> {
         this.diffService,
         (title, options) => this.applySessionTitleUpdate(title, options),
         (reason) => this.triggerSnapshot(reason),
-        async (success) => {
-          await this.reconcileSessionStatusAfterExecution(success);
-        },
+        this.statusService,
         (timestamp) => this.updateLastActivity(timestamp),
         () => this.scheduleInactivityCheck(),
         () => this.messageQueue.processMessageQueue()
@@ -645,6 +642,26 @@ export class SessionDO extends DurableObject<Env> {
     }
 
     return this._sandboxEventProcessor;
+  }
+
+  /**
+   * Get the session status service, creating it lazily if needed.
+   * Lazy initialization ensures the session-scoped logger and messenger
+   * (set by ensureInitialized()) exist by the time the service is created.
+   */
+  private get statusService(): SessionStatusService {
+    if (!this._statusService) {
+      this._statusService = new SessionStatusService(
+        this.ctx,
+        this.log,
+        this.repository,
+        this.messenger,
+        this.env.DB ? new SessionIndexStore(this.env.DB) : null,
+        this.env.SESSION ?? null
+      );
+    }
+
+    return this._statusService;
   }
 
   /**
@@ -1553,59 +1570,6 @@ export class SessionDO extends DurableObject<Env> {
     return resolved?.session_name || resolved?.id || this.ctx.id.toString();
   }
 
-  private async syncSessionIndexStatus(
-    sessionId: string,
-    status: SessionStatus,
-    updatedAt: number
-  ): Promise<void> {
-    if (!this.env.DB) return;
-    const sessionStore = new SessionIndexStore(this.env.DB);
-    await sessionStore.updateStatus(sessionId, status, updatedAt);
-  }
-
-  private logSessionIndexStatusSyncError(
-    sessionId: string,
-    status: SessionStatus,
-    updatedAt: number,
-    error: unknown
-  ): void {
-    this.log.error("session_index.update_status.background_error", {
-      session_id: sessionId,
-      status,
-      updated_at: updatedAt,
-      error,
-    });
-  }
-
-  private syncSessionMetrics(sessionId: string): void {
-    if (!this.env.DB) return;
-
-    const session = this.repository.getSession();
-    if (!session) return;
-
-    const messageCount = this.repository.getMessageCount();
-    const activeDurationMs = this.repository.getActiveDurationMs();
-    const artifacts = this.repository.listArtifacts();
-    const prCount = artifacts.filter((a) => a.type === "pr").length;
-
-    const sessionStore = new SessionIndexStore(this.env.DB);
-    this.ctx.waitUntil(
-      sessionStore
-        .updateMetrics(sessionId, {
-          totalCost: session.total_cost ?? 0,
-          activeDurationMs,
-          messageCount,
-          prCount,
-        })
-        .catch((error) => {
-          this.log.error("session_index.update_metrics.background_error", {
-            session_id: sessionId,
-            error,
-          });
-        })
-    );
-  }
-
   private syncSessionIndexTitle(sessionId: string, title: string, updatedAt: number): void {
     if (!this.env.DB) return;
     const sessionStore = new SessionIndexStore(this.env.DB);
@@ -1622,37 +1586,7 @@ export class SessionDO extends DurableObject<Env> {
   }
 
   private async transitionSessionStatus(status: SessionStatus): Promise<boolean> {
-    const session = this.getSession();
-    if (!session) return false;
-
-    const publicSessionId = this.getPublicSessionId(session);
-    if (session.status === status) {
-      await this.syncSessionIndexStatus(publicSessionId, status, session.updated_at).catch(
-        (error) =>
-          this.logSessionIndexStatusSyncError(publicSessionId, status, session.updated_at, error)
-      );
-      if (TERMINAL_STATUSES.includes(status)) {
-        this.syncSessionMetrics(publicSessionId);
-      }
-      return false;
-    }
-
-    const updatedAt = Math.max(Date.now(), session.updated_at + 1);
-    this.repository.updateSessionStatus(session.id, status, updatedAt);
-    await this.syncSessionIndexStatus(publicSessionId, status, updatedAt).catch((error) =>
-      this.logSessionIndexStatusSyncError(publicSessionId, status, updatedAt, error)
-    );
-
-    this.broadcast({ type: "session_status", status });
-
-    if (TERMINAL_STATUSES.includes(status)) {
-      this.syncSessionMetrics(publicSessionId);
-    }
-
-    // Notify parent session (if this is a child) so its UI can refresh
-    this.notifyParentOfStatusChange(session, publicSessionId, status);
-
-    return true;
+    return this.statusService.transition(status);
   }
 
   private applySessionTitleUpdate(
@@ -1685,70 +1619,21 @@ export class SessionDO extends DurableObject<Env> {
     this.broadcast({ type: "session_title", title: titleText });
 
     if (session.parent_session_id) {
-      this.notifyParentOfChildUpdate({ ...session, title: titleText }, publicSessionId, {
-        status: session.status,
-        title: titleText,
-      });
+      this.statusService.notifyParentOfChildUpdate(
+        { ...session, title: titleText },
+        publicSessionId,
+        {
+          status: session.status,
+          title: titleText,
+        }
+      );
     }
 
     return { ok: true, title: titleText };
   }
 
-  /**
-   * Fire-and-forget notification to the parent session so its connected clients
-   * can refresh the child-sessions list in real time.
-   */
-  private notifyParentOfStatusChange(
-    session: Pick<SessionRow, "parent_session_id" | "title">,
-    childSessionId: string,
-    status: SessionStatus
-  ): void {
-    this.notifyParentOfChildUpdate(session, childSessionId, {
-      status,
-      title: session.title,
-    });
-  }
-
-  private notifyParentOfChildUpdate(
-    session: Pick<SessionRow, "parent_session_id" | "title">,
-    childSessionId: string,
-    update: { status: SessionStatus; title: string | null }
-  ): void {
-    const parentId = session.parent_session_id;
-    if (!parentId || !this.env.SESSION) return;
-
-    const parentDoId = this.env.SESSION.idFromName(parentId);
-    const parentStub = this.env.SESSION.get(parentDoId);
-
-    this.ctx.waitUntil(
-      parentStub
-        .fetch(
-          new Request(buildSessionInternalUrl(SessionInternalPaths.childSessionUpdate), {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              childSessionId,
-              status: update.status,
-              title: update.title,
-            }),
-          })
-        )
-        .catch((error) => {
-          this.log.error("notify_parent.failed", {
-            parent_id: parentId,
-            child_id: childSessionId,
-            status: update.status,
-            error,
-          });
-        })
-    );
-  }
-
   private async reconcileSessionStatusAfterExecution(success: boolean): Promise<void> {
-    const pendingOrProcessing = this.repository.getPendingOrProcessingCount();
-    const nextStatus: SessionStatus =
-      pendingOrProcessing > 0 ? "active" : success ? "completed" : "failed";
-    await this.transitionSessionStatus(nextStatus);
+    await this.statusService.reconcileAfterExecution(success);
   }
 
   /**

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { Logger } from "../../../logger";
 import type { ParticipantRow, SandboxRow, SessionRow } from "../../types";
 import { createSessionLifecycleHandler } from "./session-lifecycle.handler";
+import type { SessionStatusService } from "../../session-status-service";
 import { getValidModelOrDefault } from "@open-inspect/shared";
 
 function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
@@ -102,7 +103,8 @@ function createHandler() {
   const getSandbox = vi.fn<() => SandboxRow | null>();
   const getPublicSessionId = vi.fn<(session: SessionRow) => string>();
   const getParticipantByUserId = vi.fn<(userId: string) => ParticipantRow | null>();
-  const transitionSessionStatus = vi.fn<(status: SessionRow["status"]) => Promise<boolean>>();
+  const transition = vi.fn<(status: SessionRow["status"]) => Promise<boolean>>();
+  const statusService = { transition } as unknown as SessionStatusService;
   const applySessionTitleUpdate = vi.fn((title: string) => ({ ok: true as const, title }));
   const stopExecution = vi.fn();
   const getSandboxSocket = vi.fn<() => WebSocket | null>();
@@ -122,7 +124,7 @@ function createHandler() {
     getSandbox,
     getPublicSessionId,
     getParticipantByUserId,
-    transitionSessionStatus,
+    statusService,
     applySessionTitleUpdate,
     stopExecution,
     getSandboxSocket,
@@ -151,7 +153,7 @@ function createHandler() {
     getSandbox,
     getPublicSessionId,
     getParticipantByUserId,
-    transitionSessionStatus,
+    transition,
     applySessionTitleUpdate,
     stopExecution,
     getSandboxSocket,
@@ -661,11 +663,10 @@ describe("createSessionLifecycleHandler", () => {
   });
 
   it("archives successfully for participant", async () => {
-    const { handler, getSession, getParticipantByUserId, transitionSessionStatus } =
-      createHandler();
+    const { handler, getSession, getParticipantByUserId, transition } = createHandler();
     getSession.mockReturnValue(createSession());
     getParticipantByUserId.mockReturnValue(createParticipant());
-    transitionSessionStatus.mockResolvedValue(true);
+    transition.mockResolvedValue(true);
 
     const response = await handler.archive(
       new Request("http://internal/internal/archive", {
@@ -677,15 +678,14 @@ describe("createSessionLifecycleHandler", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ status: "archived" });
-    expect(transitionSessionStatus).toHaveBeenCalledWith("archived");
+    expect(transition).toHaveBeenCalledWith("archived");
   });
 
   it("unarchives successfully for participant", async () => {
-    const { handler, getSession, getParticipantByUserId, transitionSessionStatus } =
-      createHandler();
+    const { handler, getSession, getParticipantByUserId, transition } = createHandler();
     getSession.mockReturnValue(createSession({ status: "archived" }));
     getParticipantByUserId.mockReturnValue(createParticipant());
-    transitionSessionStatus.mockResolvedValue(true);
+    transition.mockResolvedValue(true);
 
     const response = await handler.unarchive(
       new Request("http://internal/internal/unarchive", {
@@ -697,7 +697,7 @@ describe("createSessionLifecycleHandler", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ status: "active" });
-    expect(transitionSessionStatus).toHaveBeenCalledWith("active");
+    expect(transition).toHaveBeenCalledWith("active");
   });
 
   it("returns 409 when cancelling terminal session", async () => {
@@ -716,7 +716,7 @@ describe("createSessionLifecycleHandler", () => {
       getSession,
       getSandbox,
       stopExecution,
-      transitionSessionStatus,
+      transition,
       getSandboxSocket,
       sendToSandbox,
       updateSandboxStatus,
@@ -725,7 +725,7 @@ describe("createSessionLifecycleHandler", () => {
     getSession.mockReturnValue(createSession({ status: "active" }));
     getSandbox.mockReturnValue(createSandbox({ status: "running" }));
     stopExecution.mockResolvedValue(undefined);
-    transitionSessionStatus.mockResolvedValue(true);
+    transition.mockResolvedValue(true);
     getSandboxSocket.mockReturnValue(ws);
 
     const response = await handler.cancel();
@@ -733,7 +733,7 @@ describe("createSessionLifecycleHandler", () => {
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ status: "cancelled" });
     expect(stopExecution).toHaveBeenCalledWith({ suppressStatusReconcile: true });
-    expect(transitionSessionStatus).toHaveBeenCalledWith("cancelled");
+    expect(transition).toHaveBeenCalledWith("cancelled");
     expect(sendToSandbox).toHaveBeenCalledWith(ws, { type: "shutdown" });
     expect(updateSandboxStatus).toHaveBeenCalledWith("stopped");
   });

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
@@ -8,6 +8,7 @@ import {
 } from "@open-inspect/shared";
 import type { SandboxStatus, SessionStatus, SpawnSource } from "../../../types";
 import type { SessionRepository } from "../../repository";
+import type { SessionStatusService } from "../../session-status-service";
 import {
   normalizeSessionTitle,
   type SessionTitleUpdateOptions,
@@ -71,7 +72,7 @@ export interface SessionLifecycleHandlerDeps {
   getSandbox: () => SandboxRow | null;
   getPublicSessionId: (session: SessionRow) => string;
   getParticipantByUserId: (userId: string) => ParticipantRow | null;
-  transitionSessionStatus: (status: SessionStatus) => Promise<boolean>;
+  statusService: SessionStatusService;
   applySessionTitleUpdate: (
     title: string,
     options?: SessionTitleUpdateOptions
@@ -343,7 +344,7 @@ export function createSessionLifecycleHandler(
         return Response.json({ error: "Not authorized to archive this session" }, { status: 403 });
       }
 
-      await deps.transitionSessionStatus("archived");
+      await deps.statusService.transition("archived");
 
       return Response.json({ status: "archived" });
     },
@@ -373,7 +374,7 @@ export function createSessionLifecycleHandler(
         );
       }
 
-      await deps.transitionSessionStatus("active");
+      await deps.statusService.transition("active");
 
       return Response.json({ status: "active" });
     },
@@ -389,7 +390,7 @@ export function createSessionLifecycleHandler(
       }
 
       await deps.stopExecution({ suppressStatusReconcile: true });
-      await deps.transitionSessionStatus("cancelled");
+      await deps.statusService.transition("cancelled");
 
       const sandbox = deps.getSandbox();
       if (sandbox && sandbox.status !== "stopped" && sandbox.status !== "failed") {

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -5,6 +5,7 @@ import type { SandboxEvent, ServerMessage } from "../types";
 import type { CallbackNotificationService } from "./callback-notification-service";
 import type { SessionDiffService } from "./diffs/service";
 import type { SessionRepository } from "./repository";
+import type { SessionStatusService } from "./session-status-service";
 import type { SessionWebSocketManager } from "./websocket-manager";
 
 function createPushSpec(repoOwner: string, repoName: string, targetBranch: string): GitPushSpec {
@@ -55,7 +56,7 @@ function createProcessor() {
   const messenger = { broadcast, sendToSandbox: vi.fn(() => true) };
   const diffService = { pinBaselines: vi.fn() };
   const triggerSnapshot = vi.fn(async (_reason: string) => {});
-  const reconcileSessionStatusAfterExecution = vi.fn(async (_success: boolean) => {});
+  const statusService = { reconcileAfterExecution: vi.fn(async (_success: boolean) => {}) };
   const scheduleInactivityCheck = vi.fn(async () => {});
   const processMessageQueue = vi.fn(async () => {});
   const updateLastActivity = vi.fn();
@@ -79,7 +80,7 @@ function createProcessor() {
     diffService as unknown as SessionDiffService,
     applySessionTitleUpdate,
     triggerSnapshot,
-    reconcileSessionStatusAfterExecution,
+    statusService as unknown as SessionStatusService,
     updateLastActivity,
     scheduleInactivityCheck,
     processMessageQueue
@@ -93,7 +94,7 @@ function createProcessor() {
     broadcast,
     diffService,
     triggerSnapshot,
-    reconcileSessionStatusAfterExecution,
+    statusService,
     scheduleInactivityCheck,
     processMessageQueue,
     updateLastActivity,
@@ -117,7 +118,7 @@ describe("SessionSandboxEventProcessor", () => {
     });
 
     expect(h.processMessageQueue).toHaveBeenCalledOnce();
-    expect(h.reconcileSessionStatusAfterExecution).toHaveBeenCalledWith(true);
+    expect(h.statusService.reconcileAfterExecution).toHaveBeenCalledWith(true);
   });
 
   it("updates heartbeat without broadcasting", async () => {
@@ -340,7 +341,7 @@ describe("SessionSandboxEventProcessor", () => {
     );
     expect(h.broadcast).toHaveBeenCalledWith({ type: "sandbox_event", event });
     expect(h.broadcast).toHaveBeenCalledWith({ type: "processing_status", isProcessing: false });
-    expect(h.reconcileSessionStatusAfterExecution).toHaveBeenCalledWith(true);
+    expect(h.statusService.reconcileAfterExecution).toHaveBeenCalledWith(true);
     expect(h.triggerSnapshot).toHaveBeenCalledWith("execution_complete");
     expect(h.scheduleInactivityCheck).toHaveBeenCalledTimes(1);
     expect(h.processMessageQueue).toHaveBeenCalledTimes(1);

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -9,6 +9,7 @@ import type { SessionRepository } from "./repository";
 import type { CallbackNotificationService } from "./callback-notification-service";
 import type { SessionDiffService } from "./diffs/service";
 import type { SessionMessenger } from "./messenger";
+import type { SessionStatusService } from "./session-status-service";
 import type { SessionWebSocketManager } from "./websocket-manager";
 import type { SessionTitleUpdateOptions, SessionTitleUpdateResult } from "./title";
 
@@ -47,7 +48,7 @@ export class SessionSandboxEventProcessor {
       options?: SessionTitleUpdateOptions
     ) => SessionTitleUpdateResult,
     private readonly triggerSnapshot: (reason: string) => Promise<void>,
-    private readonly reconcileSessionStatusAfterExecution: (success: boolean) => Promise<void>,
+    private readonly statusService: SessionStatusService,
     private readonly updateLastActivity: (timestamp: number) => void,
     private readonly scheduleInactivityCheck: () => Promise<void>,
     private readonly processMessageQueue: () => Promise<void>
@@ -229,7 +230,7 @@ export class SessionSandboxEventProcessor {
           this.callbackService.notifyComplete(completionMessageId, event.success, event.error)
         );
 
-        await this.reconcileSessionStatusAfterExecution(event.success);
+        await this.statusService.reconcileAfterExecution(event.success);
       } else {
         this.log.info("prompt.complete", {
           event: "prompt.complete",

--- a/packages/control-plane/src/session/session-status-service.test.ts
+++ b/packages/control-plane/src/session/session-status-service.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it, vi } from "vitest";
+import { SessionStatusService } from "./session-status-service";
+import { buildSessionInternalUrl, SessionInternalPaths } from "./contracts";
+import type { Logger } from "../logger";
+import type { SessionIndexStore } from "../db/session-index";
+import type { SessionRow, ArtifactRow } from "./types";
+import type { SessionRepository } from "./repository";
+import type { SessionMessenger } from "./messenger";
+
+function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
+  return {
+    id: "session-1",
+    session_name: "public-session-1",
+    title: "Session title",
+    repo_owner: "acme",
+    repo_name: "repo",
+    repo_id: 1,
+    base_branch: "main",
+    branch_name: "feature/test",
+    base_sha: "base-sha",
+    current_sha: "head-sha",
+    opencode_session_id: "oc-1",
+    model: "anthropic/claude-haiku-4-5",
+    reasoning_effort: "high",
+    status: "active",
+    parent_session_id: null,
+    spawn_source: "user",
+    spawn_depth: 0,
+    code_server_enabled: 0,
+    total_cost: 2.5,
+    sandbox_settings: null,
+    environment_id: null,
+    created_at: 1000,
+    updated_at: 2000,
+    ...overrides,
+  } as SessionRow;
+}
+
+function harness(options: { session?: SessionRow | null; sessionIndex?: null } = {}) {
+  const session = options.session === undefined ? createSession() : options.session;
+
+  const repository = {
+    getSession: vi.fn(() => session),
+    updateSessionStatus: vi.fn(),
+    getPendingOrProcessingCount: vi.fn(() => 0),
+    getMessageCount: vi.fn(() => 3),
+    getActiveDurationMs: vi.fn(() => 4500),
+    listArtifacts: vi.fn(
+      () => [{ type: "pr" }, { type: "screenshot" }, { type: "pr" }] as ArtifactRow[]
+    ),
+  };
+
+  const broadcast = vi.fn();
+  const messenger = { broadcast, sendToSandbox: vi.fn(() => true) } as SessionMessenger;
+
+  const sessionIndex =
+    options.sessionIndex === null
+      ? null
+      : {
+          updateStatus: vi.fn(async () => true),
+          updateMetrics: vi.fn(async () => true),
+        };
+
+  const waitUntil = vi.fn();
+  const ctx = { waitUntil, id: { toString: () => "do-id" } } as unknown as DurableObjectState;
+
+  const parentFetch = vi.fn(async (_request: Request) => new Response(null, { status: 200 }));
+  const parentStub = { fetch: parentFetch };
+  const parentSessions = {
+    idFromName: vi.fn(() => "parent-do-id"),
+    get: vi.fn(() => parentStub),
+  };
+
+  const log = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  };
+
+  const service = new SessionStatusService(
+    ctx,
+    log as unknown as Logger,
+    repository as unknown as SessionRepository,
+    messenger,
+    sessionIndex as unknown as SessionIndexStore | null,
+    parentSessions as unknown as DurableObjectNamespace
+  );
+
+  return {
+    service,
+    repository,
+    broadcast,
+    sessionIndex,
+    waitUntil,
+    parentSessions,
+    parentFetch,
+    log,
+  };
+}
+
+describe("SessionStatusService.transition", () => {
+  it("returns false without side effects when there is no session", async () => {
+    const h = harness({ session: null });
+
+    expect(await h.service.transition("active")).toBe(false);
+
+    expect(h.repository.updateSessionStatus).not.toHaveBeenCalled();
+    expect(h.sessionIndex!.updateStatus).not.toHaveBeenCalled();
+    expect(h.broadcast).not.toHaveBeenCalled();
+  });
+
+  it("persists, mirrors to the index, and broadcasts on a real transition", async () => {
+    const h = harness({ session: createSession({ status: "created" }) });
+
+    expect(await h.service.transition("active")).toBe(true);
+
+    expect(h.repository.updateSessionStatus).toHaveBeenCalledWith(
+      "session-1",
+      "active",
+      expect.any(Number)
+    );
+    const updatedAt = h.repository.updateSessionStatus.mock.calls[0][2] as number;
+    expect(updatedAt).toBeGreaterThan(2000);
+    expect(h.sessionIndex!.updateStatus).toHaveBeenCalledWith(
+      "public-session-1",
+      "active",
+      updatedAt
+    );
+    expect(h.broadcast).toHaveBeenCalledWith({ type: "session_status", status: "active" });
+  });
+
+  it("short-circuits on same status: refreshes the index but neither persists nor broadcasts", async () => {
+    const h = harness({ session: createSession({ status: "active" }) });
+
+    expect(await h.service.transition("active")).toBe(false);
+
+    expect(h.sessionIndex!.updateStatus).toHaveBeenCalledWith("public-session-1", "active", 2000);
+    expect(h.repository.updateSessionStatus).not.toHaveBeenCalled();
+    expect(h.broadcast).not.toHaveBeenCalled();
+    expect(h.parentFetch).not.toHaveBeenCalled();
+  });
+
+  it("syncs metrics on a terminal transition", async () => {
+    const h = harness({ session: createSession({ status: "active" }) });
+
+    await h.service.transition("completed");
+
+    expect(h.sessionIndex!.updateMetrics).toHaveBeenCalledWith("public-session-1", {
+      totalCost: 2.5,
+      activeDurationMs: 4500,
+      messageCount: 3,
+      prCount: 2,
+    });
+    expect(h.waitUntil).toHaveBeenCalled();
+  });
+
+  it("syncs metrics even when already in the terminal status", async () => {
+    const h = harness({ session: createSession({ status: "failed" }) });
+
+    expect(await h.service.transition("failed")).toBe(false);
+
+    expect(h.sessionIndex!.updateMetrics).toHaveBeenCalledWith(
+      "public-session-1",
+      expect.any(Object)
+    );
+  });
+
+  it("does not sync metrics on a non-terminal transition", async () => {
+    const h = harness({ session: createSession({ status: "created" }) });
+
+    await h.service.transition("active");
+
+    expect(h.sessionIndex!.updateMetrics).not.toHaveBeenCalled();
+  });
+
+  it("logs index sync failures without throwing", async () => {
+    const h = harness({ session: createSession({ status: "created" }) });
+    h.sessionIndex!.updateStatus.mockRejectedValue(new Error("d1 down"));
+
+    expect(await h.service.transition("active")).toBe(true);
+
+    expect(h.log.error).toHaveBeenCalledWith(
+      "session_index.update_status.background_error",
+      expect.objectContaining({
+        session_id: "public-session-1",
+        status: "active",
+        error: expect.any(Error),
+      })
+    );
+    expect(h.broadcast).toHaveBeenCalledWith({ type: "session_status", status: "active" });
+  });
+
+  it("skips index and metrics writes when no session index is bound", async () => {
+    const h = harness({ session: createSession({ status: "active" }), sessionIndex: null });
+
+    expect(await h.service.transition("completed")).toBe(true);
+
+    expect(h.broadcast).toHaveBeenCalledWith({ type: "session_status", status: "completed" });
+    expect(h.waitUntil).not.toHaveBeenCalled();
+  });
+
+  it("notifies the parent session fire-and-forget via ctx.waitUntil", async () => {
+    const h = harness({
+      session: createSession({ status: "active", parent_session_id: "parent-1" }),
+    });
+
+    await h.service.transition("completed");
+
+    expect(h.parentSessions.idFromName).toHaveBeenCalledWith("parent-1");
+    expect(h.parentFetch).toHaveBeenCalledTimes(1);
+    const request = h.parentFetch.mock.calls[0][0];
+    expect(request.url).toBe(buildSessionInternalUrl(SessionInternalPaths.childSessionUpdate));
+    expect(request.method).toBe("POST");
+    expect(await request.json()).toEqual({
+      childSessionId: "public-session-1",
+      status: "completed",
+      title: "Session title",
+    });
+    expect(h.waitUntil).toHaveBeenCalled();
+  });
+
+  it("does not notify a parent when the session has none", async () => {
+    const h = harness({ session: createSession({ status: "created" }) });
+
+    await h.service.transition("active");
+
+    expect(h.parentFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("SessionStatusService.reconcileAfterExecution", () => {
+  it("returns to active when more prompts are pending", async () => {
+    const h = harness({ session: createSession({ status: "created" }) });
+    h.repository.getPendingOrProcessingCount.mockReturnValue(2);
+
+    await h.service.reconcileAfterExecution(true);
+
+    expect(h.broadcast).toHaveBeenCalledWith({ type: "session_status", status: "active" });
+  });
+
+  it("completes when idle and the execution succeeded", async () => {
+    const h = harness({ session: createSession({ status: "active" }) });
+
+    await h.service.reconcileAfterExecution(true);
+
+    expect(h.broadcast).toHaveBeenCalledWith({ type: "session_status", status: "completed" });
+  });
+
+  it("fails when idle and the execution failed", async () => {
+    const h = harness({ session: createSession({ status: "active" }) });
+
+    await h.service.reconcileAfterExecution(false);
+
+    expect(h.broadcast).toHaveBeenCalledWith({ type: "session_status", status: "failed" });
+  });
+});
+
+describe("SessionStatusService.notifyParentOfChildUpdate", () => {
+  it("posts the child update to the parent Durable Object", async () => {
+    const h = harness();
+
+    h.service.notifyParentOfChildUpdate(
+      { parent_session_id: "parent-1", title: "Old title" },
+      "public-session-1",
+      { status: "active", title: "New title" }
+    );
+
+    expect(h.parentSessions.idFromName).toHaveBeenCalledWith("parent-1");
+    const request = h.parentFetch.mock.calls[0][0];
+    expect(await request.json()).toEqual({
+      childSessionId: "public-session-1",
+      status: "active",
+      title: "New title",
+    });
+    expect(h.waitUntil).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs (and does not throw) when the parent notification fails", async () => {
+    const h = harness();
+    h.parentFetch.mockRejectedValue(new Error("parent unreachable"));
+
+    h.service.notifyParentOfChildUpdate(
+      { parent_session_id: "parent-1", title: null },
+      "public-session-1",
+      { status: "failed", title: null }
+    );
+
+    // Drain the fire-and-forget promise handed to waitUntil.
+    await h.waitUntil.mock.calls[0][0];
+
+    expect(h.log.error).toHaveBeenCalledWith(
+      "notify_parent.failed",
+      expect.objectContaining({
+        parent_id: "parent-1",
+        child_id: "public-session-1",
+        status: "failed",
+        error: expect.any(Error),
+      })
+    );
+  });
+
+  it("is a no-op without a parent session id", () => {
+    const h = harness();
+
+    h.service.notifyParentOfChildUpdate({ parent_session_id: null, title: null }, "child-1", {
+      status: "active",
+      title: null,
+    });
+
+    expect(h.parentSessions.idFromName).not.toHaveBeenCalled();
+    expect(h.waitUntil).not.toHaveBeenCalled();
+  });
+});

--- a/packages/control-plane/src/session/session-status-service.ts
+++ b/packages/control-plane/src/session/session-status-service.ts
@@ -1,0 +1,187 @@
+/**
+ * SessionStatusService — owns the session's `status` and its projections.
+ *
+ * Every status change fans out to three places: the connected clients
+ * (broadcast), the D1 session index (status + terminal metrics mirror), and
+ * the parent session's Durable Object (child rollup). This service is the
+ * single place those projections are kept consistent; every public method is
+ * a transition on that one noun.
+ */
+
+import { buildSessionInternalUrl, SessionInternalPaths } from "./contracts";
+import type { Logger } from "../logger";
+import type { SessionIndexStore } from "../db/session-index";
+import type { SessionStatus } from "../types";
+import type { SessionRow } from "./types";
+import type { SessionRepository } from "./repository";
+import type { SessionMessenger } from "./messenger";
+
+/** Statuses that indicate a session is finished — metrics are synced to D1 on these transitions. */
+const TERMINAL_STATUSES: SessionStatus[] = ["completed", "failed", "cancelled"];
+
+export class SessionStatusService {
+  constructor(
+    private readonly ctx: DurableObjectState,
+    private readonly log: Logger,
+    private readonly repository: SessionRepository,
+    private readonly messenger: SessionMessenger,
+    private readonly sessionIndex: SessionIndexStore | null,
+    private readonly parentSessions: DurableObjectNamespace | null
+  ) {}
+
+  /**
+   * Transition the session to `status`, then project the change to clients,
+   * the D1 session index, and the parent session. Returns false when the
+   * session is missing or already in `status` (projections are still
+   * refreshed in the same-status case).
+   */
+  async transition(status: SessionStatus): Promise<boolean> {
+    const session = this.repository.getSession();
+    if (!session) return false;
+
+    const publicSessionId = this.getPublicSessionId(session);
+    if (session.status === status) {
+      await this.syncSessionIndexStatus(publicSessionId, status, session.updated_at).catch(
+        (error) =>
+          this.logSessionIndexStatusSyncError(publicSessionId, status, session.updated_at, error)
+      );
+      if (TERMINAL_STATUSES.includes(status)) {
+        this.syncSessionMetrics(publicSessionId);
+      }
+      return false;
+    }
+
+    const updatedAt = Math.max(Date.now(), session.updated_at + 1);
+    this.repository.updateSessionStatus(session.id, status, updatedAt);
+    await this.syncSessionIndexStatus(publicSessionId, status, updatedAt).catch((error) =>
+      this.logSessionIndexStatusSyncError(publicSessionId, status, updatedAt, error)
+    );
+
+    this.messenger.broadcast({ type: "session_status", status });
+
+    if (TERMINAL_STATUSES.includes(status)) {
+      this.syncSessionMetrics(publicSessionId);
+    }
+
+    // Notify parent session (if this is a child) so its UI can refresh
+    this.notifyParentOfStatusChange(session, publicSessionId, status);
+
+    return true;
+  }
+
+  /**
+   * After an execution finishes, settle the session status: back to active
+   * when more prompts are queued, otherwise completed/failed by outcome.
+   */
+  async reconcileAfterExecution(success: boolean): Promise<void> {
+    const pendingOrProcessing = this.repository.getPendingOrProcessingCount();
+    const nextStatus: SessionStatus =
+      pendingOrProcessing > 0 ? "active" : success ? "completed" : "failed";
+    await this.transition(nextStatus);
+  }
+
+  /**
+   * Fire-and-forget notification to the parent session so its connected
+   * clients can refresh the child-sessions list in real time.
+   */
+  notifyParentOfChildUpdate(
+    session: Pick<SessionRow, "parent_session_id" | "title">,
+    childSessionId: string,
+    update: { status: SessionStatus; title: string | null }
+  ): void {
+    const parentId = session.parent_session_id;
+    if (!parentId || !this.parentSessions) return;
+
+    const parentDoId = this.parentSessions.idFromName(parentId);
+    const parentStub = this.parentSessions.get(parentDoId);
+
+    this.ctx.waitUntil(
+      parentStub
+        .fetch(
+          new Request(buildSessionInternalUrl(SessionInternalPaths.childSessionUpdate), {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              childSessionId,
+              status: update.status,
+              title: update.title,
+            }),
+          })
+        )
+        .catch((error) => {
+          this.log.error("notify_parent.failed", {
+            parent_id: parentId,
+            child_id: childSessionId,
+            status: update.status,
+            error,
+          });
+        })
+    );
+  }
+
+  private notifyParentOfStatusChange(
+    session: Pick<SessionRow, "parent_session_id" | "title">,
+    childSessionId: string,
+    status: SessionStatus
+  ): void {
+    this.notifyParentOfChildUpdate(session, childSessionId, {
+      status,
+      title: session.title,
+    });
+  }
+
+  private getPublicSessionId(session: SessionRow): string {
+    return session.session_name || session.id || this.ctx.id.toString();
+  }
+
+  private async syncSessionIndexStatus(
+    sessionId: string,
+    status: SessionStatus,
+    updatedAt: number
+  ): Promise<void> {
+    if (!this.sessionIndex) return;
+    await this.sessionIndex.updateStatus(sessionId, status, updatedAt);
+  }
+
+  private logSessionIndexStatusSyncError(
+    sessionId: string,
+    status: SessionStatus,
+    updatedAt: number,
+    error: unknown
+  ): void {
+    this.log.error("session_index.update_status.background_error", {
+      session_id: sessionId,
+      status,
+      updated_at: updatedAt,
+      error,
+    });
+  }
+
+  private syncSessionMetrics(sessionId: string): void {
+    if (!this.sessionIndex) return;
+
+    const session = this.repository.getSession();
+    if (!session) return;
+
+    const messageCount = this.repository.getMessageCount();
+    const activeDurationMs = this.repository.getActiveDurationMs();
+    const artifacts = this.repository.listArtifacts();
+    const prCount = artifacts.filter((a) => a.type === "pr").length;
+
+    this.ctx.waitUntil(
+      this.sessionIndex
+        .updateMetrics(sessionId, {
+          totalCost: session.total_cost ?? 0,
+          activeDurationMs,
+          messageCount,
+          prCount,
+        })
+        .catch((error) => {
+          this.log.error("session_index.update_metrics.background_error", {
+            session_id: sessionId,
+            error,
+          });
+        })
+    );
+  }
+}


### PR DESCRIPTION
PR 1 of 3 in the campaign to dissolve the `SessionMessageQueue` deps bag. Strictly behavior-preserving.

## Why a `SessionStatusService`

The session's `status` has three projections that must stay consistent on every change: the client broadcast (`session_status`), the D1 session-index mirror (status + terminal-status metrics), and the parent-session rollup (child-sessions UI refresh). This service owns that one noun — every public method is a transition on it, and the projections live in one place instead of being spread across the Durable Object.

Constructor takes direct positional collaborators (no deps bag, no injected lambdas):

```ts
constructor(
  ctx: DurableObjectState,          // waitUntil + id fallback
  log: Logger,
  repository: SessionRepository,
  messenger: SessionMessenger,
  sessionIndex: SessionIndexStore | null,        // from env.DB, built once
  parentSessions: DurableObjectNamespace | null  // from env.SESSION
)
```

## What moved (verbatim) from `SessionDO`

- `transitionSessionStatus` → `SessionStatusService.transition`
- `reconcileSessionStatusAfterExecution` → `reconcileAfterExecution`
- `notifyParentOfStatusChange` / `notifyParentOfChildUpdate` (latter stays public — `applySessionTitleUpdate` on the DO calls it)
- `syncSessionIndexStatus`, `logSessionIndexStatusSyncError`, `syncSessionMetrics` (now private on the service; `env.DB` guard becomes the `sessionIndex: null` guard, same short-circuit)
- The `TERMINAL_STATUSES` constant (only consumer was `transitionSessionStatus`)

Statement order, await points, and log messages/fields are unchanged. `this.broadcast(...)` became `this.messenger.broadcast(...)` — the DO's `broadcast` was already a one-line delegation to the messenger.

The DO keeps one-line delegations for `transitionSessionStatus` / `reconcileSessionStatusAfterExecution` so remaining call sites are untouched. The service is wired as a lazily-constructed member, mirroring the existing singleton getters (constructed after `ensureInitialized()` so it captures the session-scoped logger and messenger; `this.log` is never reassigned).

## Three construction sites un-lambda'd

1. **`SessionSandboxEventProcessor`** — the `reconcileSessionStatusAfterExecution` lambda param is now the `SessionStatusService` itself (direct positional param, same position).
2. **`SessionLifecycleHandler`** — the `transitionSessionStatus` function dep is replaced by `statusService: SessionStatusService`; the archive/unarchive/cancel paths call `statusService.transition(...)`. No other deps refactored here.
3. **`SessionMessageQueue`** — deliberately **untouched**. Its `setSessionStatus` / `reconcileSessionStatusAfterExecution` bag lambdas now close over the DO's one-line delegations; the queue's deps bag is dissolved in PR 2/3 of this campaign.

## Tests

- New `session-status-service.test.ts` (16 tests): transition matrix incl. same-status short-circuit, terminal-status metrics sync (also on same-status terminal), D1 index sync failure logged without throwing, parent notify fire-and-forget via `ctx.waitUntil` (incl. failure logging), null-index short-circuits, reconcile outcomes (active/completed/failed).
- `sandbox-events.test.ts` and `session-lifecycle.handler.test.ts`: mechanical fake swaps only (lambda mock → `statusService` fake); no assertions weakened.

## Verification

- `npm run typecheck` — clean (all packages)
- `npm run test -w @open-inspect/control-plane` — **2005 passed** (baseline on main: 1989; +16 new service tests)
- control-plane integration suite (`vitest.integration.config.ts`) — **570 passed** (matches baseline exactly)
- `npm run lint` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved session status handling across archive, unarchive, cancellation, and execution completion workflows.
  * Session status updates now keep session listings, metrics, and connected-client notifications synchronized.
  * Parent sessions receive updates when child session status or titles change.
* **Bug Fixes**
  * Status synchronization failures are handled without interrupting session updates.
  * Repeated status updates avoid unnecessary processing while refreshing session data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->