### PR TITLE
refactor(control-plane): dissolve SessionMessageQueue deps bag

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -271,12 +271,22 @@ export interface LifecycleCallbacks {
 // ==================== Manager ====================
 
 /**
+ * The narrow lifecycle surface consumed by collaborators (e.g. the session
+ * message queue) that spawn sandboxes and record activity but don't manage
+ * the rest of the sandbox lifecycle.
+ */
+export interface SandboxLifecycle {
+  spawnSandbox(): Promise<void>;
+  updateLastActivity(timestamp: number): void;
+}
+
+/**
  * Manages sandbox lifecycle operations.
  *
  * Uses dependency injection for all external interactions, enabling unit testing
  * with mocked dependencies.
  */
-export class SandboxLifecycleManager {
+export class SandboxLifecycleManager implements SandboxLifecycle {
   /**
    * In-memory flag to prevent concurrent spawn attempts within the same request.
    * This is NOT persisted - it protects against multiple spawns in one DO method call.

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -12,7 +12,6 @@ import { initSchema } from "./schema";
 import {
   DEFAULT_MODEL,
   clientMessageSchema,
-  isValidReasoningEffort,
   resolveAppName,
   sandboxEventSchema,
   timingSafeEqual,
@@ -55,13 +54,13 @@ import type {
   SandboxEvent,
   SessionRepositoryState,
   SessionState,
-  SessionStatus,
   SandboxStatus,
 } from "../types";
 import type { SessionRow, ArtifactRow, SandboxRow } from "./types";
 import { SessionRepository } from "./repository";
 import { SessionAttachmentRepository } from "./session-attachment-repository";
 import { resolveParticipantName } from "./participant-name";
+import { validateReasoningEffort } from "./reasoning-effort";
 import { parseTunnelUrls } from "./tunnel-urls";
 import { SessionWebSocketManagerImpl, type SessionWebSocketManager } from "./websocket-manager";
 import { SessionPullRequestStore } from "../db/session-pull-request-store";
@@ -363,36 +362,21 @@ export class SessionDO extends DurableObject<Env> {
 
   private get messageQueue(): SessionMessageQueue {
     if (!this._messageQueue) {
-      this._messageQueue = new SessionMessageQueue({
-        env: this.env,
-        ctx: this.ctx,
-        log: this.log,
-        repository: this.repository,
-        attachmentRepository: this.attachmentRepository,
-        wsManager: this.wsManager,
-        participantService: this.participantService,
-        callbackService: this.callbackService,
-        scmProvider: resolveScmProviderFromEnv(this.env.SCM_PROVIDER),
-        getClientInfo: (ws) => this.getClientInfo(ws),
-        validateReasoningEffort: (model, effort) => this.validateReasoningEffort(model, effort),
-        getSession: () => this.getSession(),
-        updateLastActivity: (timestamp) => this.updateLastActivity(timestamp),
-        spawnSandbox: () => this.spawnSandbox(),
-        messenger: this.messenger,
-        setSessionStatus: async (status) => {
-          await this.transitionSessionStatus(status);
-        },
-        reconcileSessionStatusAfterExecution: async (success) => {
-          await this.reconcileSessionStatusAfterExecution(success);
-        },
-        scheduleExecutionTimeout: async (startedAtMs: number) => {
-          const deadline = startedAtMs + this.executionTimeoutMs;
-          const currentAlarm = await this.ctx.storage.getAlarm();
-          if (!currentAlarm || deadline < currentAlarm) {
-            await this.ctx.storage.setAlarm(deadline);
-          }
-        },
-      });
+      this._messageQueue = new SessionMessageQueue(
+        this.ctx,
+        this.log,
+        this.repository,
+        this.attachmentRepository,
+        this.wsManager,
+        this.messenger,
+        this.participantService,
+        this.callbackService,
+        this.statusService,
+        this.lifecycleManager,
+        this.env.DB ? new SessionIndexStore(this.env.DB) : null,
+        resolveScmProviderFromEnv(this.env.SCM_PROVIDER),
+        this.executionTimeoutMs
+      );
     }
 
     return this._messageQueue;
@@ -506,7 +490,8 @@ export class SessionDO extends DurableObject<Env> {
           const { encryptToken } = await import("../auth/crypto");
           return encryptToken(token, encryptionKey);
         },
-        validateReasoningEffort: (model, effort) => this.validateReasoningEffort(model, effort),
+        validateReasoningEffort: (model, effort) =>
+          validateReasoningEffort(model, effort, this.log),
         generateId: (bytes) => generateId(bytes),
         now: () => Date.now(),
         scheduleWarmSandbox: () => this.ctx.waitUntil(this.warmSandbox()),
@@ -1433,7 +1418,17 @@ export class SessionDO extends DurableObject<Env> {
       attachments?: SessionAttachmentReference[];
     }
   ): Promise<void> {
-    await this.messageQueue.handlePromptMessage(ws, data);
+    const client = this.getClientInfo(ws);
+    if (!client) {
+      this.safeSend(ws, {
+        type: "error",
+        code: "NOT_SUBSCRIBED",
+        message: "Must subscribe first",
+      });
+      return;
+    }
+
+    await this.messageQueue.handlePromptMessage(ws, client, data);
   }
 
   /**
@@ -1551,20 +1546,6 @@ export class SessionDO extends DurableObject<Env> {
     this.messenger.broadcast(message);
   }
 
-  /**
-   * Validate reasoning effort against a model's allowed values.
-   * Returns the validated effort string or null if invalid/absent.
-   */
-  private validateReasoningEffort(model: string, effort: string | undefined): string | null {
-    if (!effort) return null;
-    if (isValidReasoningEffort(model, effort)) return effort;
-    this.log.warn("Invalid reasoning effort for model, ignoring", {
-      model,
-      reasoning_effort: effort,
-    });
-    return null;
-  }
-
   private getPublicSessionId(session?: SessionRow | null): string {
     const resolved = session ?? this.getSession();
     return resolved?.session_name || resolved?.id || this.ctx.id.toString();
@@ -1583,10 +1564,6 @@ export class SessionDO extends DurableObject<Env> {
         });
       })
     );
-  }
-
-  private async transitionSessionStatus(status: SessionStatus): Promise<boolean> {
-    return this.statusService.transition(status);
   }
 
   private applySessionTitleUpdate(
@@ -1630,10 +1607,6 @@ export class SessionDO extends DurableObject<Env> {
     }
 
     return { ok: true, title: titleText };
-  }
-
-  private async reconcileSessionStatusAfterExecution(success: boolean): Promise<void> {
-    await this.statusService.reconcileAfterExecution(success);
   }
 
   /**

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { SessionMessageQueue } from "./message-queue";
 import { AttachmentClaimConflictError } from "./session-attachment-repository";
-import type { ClientInfo, Env, ServerMessage } from "../types";
+import type { ClientInfo, ServerMessage } from "../types";
 import type { MessageRow, ParticipantRow, SessionRow, SessionAttachmentRow } from "./types";
 
 function createParticipant(overrides: Partial<ParticipantRow> = {}): ParticipantRow {
@@ -85,7 +85,9 @@ function createClientInfo(overrides: Partial<ClientInfo> = {}): ClientInfo {
   };
 }
 
-function buildQueue(options?: { getClientInfo?: (ws: WebSocket) => ClientInfo | null }) {
+const EXECUTION_TIMEOUT_MS = 60_000;
+
+function buildQueue() {
   const repository = {
     createMessageWithAttachments: vi.fn(),
     createEvent: vi.fn(),
@@ -94,6 +96,7 @@ function buildQueue(options?: { getClientInfo?: (ws: WebSocket) => ClientInfo | 
     getNextPendingMessage: vi.fn(() => null as MessageRow | null),
     updateMessageToProcessing: vi.fn(),
     getParticipantById: vi.fn(() => createParticipant()),
+    getSession: vi.fn(() => createSession()),
     updateParticipantCoalesce: vi.fn(),
     updateMessageCompletion: vi.fn(),
     upsertExecutionCompleteEvent: vi.fn(),
@@ -120,37 +123,39 @@ function buildQueue(options?: { getClientInfo?: (ws: WebSocket) => ClientInfo | 
 
   const broadcast = vi.fn((_message: ServerMessage) => {});
   const messenger = { broadcast, sendToSandbox: vi.fn(() => true) };
-  const spawnSandbox = vi.fn(async () => {});
-  const setSessionStatus = vi.fn(async (_status: string) => {});
-  const reconcileSessionStatusAfterExecution = vi.fn(async (_success: boolean) => {});
-  const updateLastActivity = vi.fn();
+  const sessionStatus = {
+    transition: vi.fn(async (_status: string) => true),
+    reconcileAfterExecution: vi.fn(async (_success: boolean) => {}),
+  };
+  const sandboxLifecycle = {
+    spawnSandbox: vi.fn(async () => {}),
+    updateLastActivity: vi.fn((_timestamp: number) => {}),
+  };
   const waitUntil = vi.fn();
+  const getAlarm = vi.fn(async () => null as number | null);
+  const setAlarm = vi.fn(async (_timestamp: number) => {});
 
-  const queue = new SessionMessageQueue({
-    env: {} as Env,
-    ctx: { waitUntil } as unknown as DurableObjectState,
-    log: {
+  const queue = new SessionMessageQueue(
+    { waitUntil, storage: { getAlarm, setAlarm } } as unknown as DurableObjectState,
+    {
       debug: vi.fn(),
       info: vi.fn(),
       warn: vi.fn(),
       error: vi.fn(),
       child: vi.fn(),
     },
-    repository: repository as never,
-    attachmentRepository: attachmentRepository as never,
-    wsManager: wsManager as never,
-    participantService: participantService as never,
-    callbackService: callbackService as never,
-    scmProvider: "github",
-    getClientInfo: options?.getClientInfo ?? (() => createClientInfo()),
-    validateReasoningEffort: vi.fn(() => null),
-    getSession: vi.fn(() => createSession()),
-    updateLastActivity,
-    spawnSandbox,
+    repository as never,
+    attachmentRepository as never,
+    wsManager as never,
     messenger,
-    setSessionStatus,
-    reconcileSessionStatusAfterExecution,
-  });
+    participantService as never,
+    callbackService as never,
+    sessionStatus as never,
+    sandboxLifecycle,
+    null,
+    "github",
+    EXECUTION_TIMEOUT_MS
+  );
 
   return {
     queue,
@@ -159,28 +164,16 @@ function buildQueue(options?: { getClientInfo?: (ws: WebSocket) => ClientInfo | 
     wsManager,
     participantService,
     broadcast,
-    spawnSandbox,
-    setSessionStatus,
-    reconcileSessionStatusAfterExecution,
+    sessionStatus,
+    sandboxLifecycle,
     waitUntil,
+    getAlarm,
+    setAlarm,
     callbackService,
   };
 }
 
 describe("SessionMessageQueue", () => {
-  it("sends NOT_SUBSCRIBED when prompt arrives before subscribe", async () => {
-    const h = buildQueue({ getClientInfo: () => null });
-
-    await h.queue.handlePromptMessage({} as WebSocket, { content: "hello" });
-
-    expect(h.wsManager.send).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ code: "NOT_SUBSCRIBED" })
-    );
-    expect(h.repository.createMessageWithAttachments).not.toHaveBeenCalled();
-    expect(h.setSessionStatus).not.toHaveBeenCalled();
-  });
-
   it("spawns sandbox when queue has work but no sandbox socket", async () => {
     const h = buildQueue();
     h.repository.getNextPendingMessage.mockReturnValue(createMessage());
@@ -188,7 +181,7 @@ describe("SessionMessageQueue", () => {
     await h.queue.processMessageQueue();
 
     expect(h.broadcast).toHaveBeenCalledWith({ type: "sandbox_spawning" });
-    expect(h.spawnSandbox).toHaveBeenCalledTimes(1);
+    expect(h.sandboxLifecycle.spawnSandbox).toHaveBeenCalledTimes(1);
     expect(h.repository.updateMessageToProcessing).not.toHaveBeenCalled();
     expect(h.callbackService.notifyStarted).not.toHaveBeenCalled();
   });
@@ -196,9 +189,9 @@ describe("SessionMessageQueue", () => {
   it("marks session active when a prompt is enqueued", async () => {
     const h = buildQueue();
 
-    await h.queue.handlePromptMessage({} as WebSocket, { content: "hello" });
+    await h.queue.handlePromptMessage({} as WebSocket, createClientInfo(), { content: "hello" });
 
-    expect(h.setSessionStatus).toHaveBeenCalledWith("active");
+    expect(h.sessionStatus.transition).toHaveBeenCalledWith("active");
   });
 
   it("stores attachments and embeds content-free metadata in the user_message event", async () => {
@@ -215,7 +208,7 @@ describe("SessionMessageQueue", () => {
       },
     ]);
 
-    await h.queue.handlePromptMessage({} as WebSocket, {
+    await h.queue.handlePromptMessage({} as WebSocket, createClientInfo(), {
       content: "look at this",
       attachments: [
         {
@@ -264,7 +257,7 @@ describe("SessionMessageQueue", () => {
       throw new AttachmentClaimConflictError("already claimed");
     });
 
-    await h.queue.handlePromptMessage({} as WebSocket, {
+    await h.queue.handlePromptMessage({} as WebSocket, createClientInfo(), {
       content: "look",
       attachments: [{ name: "shot.png", attachmentId: "up-1" }],
     });
@@ -274,13 +267,13 @@ describe("SessionMessageQueue", () => {
       expect.objectContaining({ code: "INVALID_ATTACHMENTS" })
     );
     expect(h.repository.createEvent).not.toHaveBeenCalled();
-    expect(h.setSessionStatus).not.toHaveBeenCalled();
+    expect(h.sessionStatus.transition).not.toHaveBeenCalled();
   });
 
   it("rejects upload references that cannot be claimed", async () => {
     const h = buildQueue();
 
-    await h.queue.handlePromptMessage({} as WebSocket, {
+    await h.queue.handlePromptMessage({} as WebSocket, createClientInfo(), {
       content: "look",
       attachments: [{ name: "missing.png", attachmentId: "missing" }],
     });
@@ -299,7 +292,7 @@ describe("SessionMessageQueue", () => {
     });
 
     await expect(
-      h.queue.handlePromptMessage({} as WebSocket, {
+      h.queue.handlePromptMessage({} as WebSocket, createClientInfo(), {
         content: "look",
         attachments: [{ name: "shot.png", attachmentId: "up-1" }],
       })
@@ -325,7 +318,7 @@ describe("SessionMessageQueue", () => {
       },
     ]);
 
-    await h.queue.handlePromptMessage({} as WebSocket, {
+    await h.queue.handlePromptMessage({} as WebSocket, createClientInfo(), {
       content: "watch this",
       attachments: [{ name: "document.pdf", attachmentId: "up-invalid" }],
     });
@@ -343,7 +336,7 @@ describe("SessionMessageQueue", () => {
   it("omits attachments from the user_message event when none are sent", async () => {
     const h = buildQueue();
 
-    await h.queue.handlePromptMessage({} as WebSocket, { content: "hello" });
+    await h.queue.handlePromptMessage({} as WebSocket, createClientInfo(), { content: "hello" });
 
     const broadcastCall = h.broadcast.mock.calls.find(
       ([message]) =>
@@ -419,6 +412,58 @@ describe("SessionMessageQueue", () => {
     expect(h.waitUntil).not.toHaveBeenCalled();
   });
 
+  describe("execution timeout scheduling", () => {
+    function dispatchPrompt(h: ReturnType<typeof buildQueue>) {
+      h.repository.getNextPendingMessage.mockReturnValue(createMessage());
+      h.wsManager.getSandboxSocket.mockReturnValue({ readyState: 1 } as WebSocket);
+      return h.queue.processMessageQueue();
+    }
+
+    it("schedules the execution deadline when no alarm is set", async () => {
+      const h = buildQueue();
+      const before = Date.now();
+
+      await dispatchPrompt(h);
+
+      expect(h.setAlarm).toHaveBeenCalledTimes(1);
+      const deadline = h.setAlarm.mock.calls[0][0];
+      expect(deadline).toBeGreaterThanOrEqual(before + EXECUTION_TIMEOUT_MS);
+      expect(deadline).toBeLessThanOrEqual(Date.now() + EXECUTION_TIMEOUT_MS);
+    });
+
+    it("keeps an earlier existing alarm", async () => {
+      const h = buildQueue();
+      h.getAlarm.mockResolvedValue(Date.now() + 1000);
+
+      await dispatchPrompt(h);
+
+      expect(h.setAlarm).not.toHaveBeenCalled();
+    });
+
+    it("replaces a later existing alarm with the execution deadline", async () => {
+      const h = buildQueue();
+      h.getAlarm.mockResolvedValue(Date.now() + EXECUTION_TIMEOUT_MS * 10);
+      const before = Date.now();
+
+      await dispatchPrompt(h);
+
+      expect(h.setAlarm).toHaveBeenCalledTimes(1);
+      const deadline = h.setAlarm.mock.calls[0][0];
+      expect(deadline).toBeGreaterThanOrEqual(before + EXECUTION_TIMEOUT_MS);
+      expect(deadline).toBeLessThanOrEqual(Date.now() + EXECUTION_TIMEOUT_MS);
+    });
+
+    it("does not schedule when the prompt is deferred for sandbox spawn", async () => {
+      const h = buildQueue();
+      h.repository.getNextPendingMessage.mockReturnValue(createMessage());
+
+      await h.queue.processMessageQueue();
+
+      expect(h.getAlarm).not.toHaveBeenCalled();
+      expect(h.setAlarm).not.toHaveBeenCalled();
+    });
+  });
+
   it("marks processing message failed and broadcasts synthetic completion on stop", async () => {
     const h = buildQueue();
     const sandboxWs = { readyState: 1 } as WebSocket;
@@ -440,7 +485,7 @@ describe("SessionMessageQueue", () => {
     expect(h.broadcast).toHaveBeenCalledWith({ type: "processing_status", isProcessing: false });
     expect(h.wsManager.send).toHaveBeenCalledWith(sandboxWs, { type: "stop" });
     expect(h.waitUntil).toHaveBeenCalledTimes(1);
-    expect(h.reconcileSessionStatusAfterExecution).toHaveBeenCalledWith(false);
+    expect(h.sessionStatus.reconcileAfterExecution).toHaveBeenCalledWith(false);
   });
 
   it("suppresses session status reconcile when stopExecution is called with suppress flag", async () => {
@@ -449,7 +494,7 @@ describe("SessionMessageQueue", () => {
 
     await h.queue.stopExecution({ suppressStatusReconcile: true });
 
-    expect(h.reconcileSessionStatusAfterExecution).not.toHaveBeenCalled();
+    expect(h.sessionStatus.reconcileAfterExecution).not.toHaveBeenCalled();
   });
 
   it("reconciles session status when failing a stuck processing message", async () => {
@@ -458,7 +503,7 @@ describe("SessionMessageQueue", () => {
 
     await h.queue.failStuckProcessingMessage();
 
-    expect(h.reconcileSessionStatusAfterExecution).toHaveBeenCalledWith(false);
+    expect(h.sessionStatus.reconcileAfterExecution).toHaveBeenCalledWith(false);
   });
 
   describe("enqueuePromptFromApi", () => {

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 import { SessionMessageQueue } from "./message-queue";
 import { AttachmentClaimConflictError } from "./session-attachment-repository";
+import type { SessionAttachmentRepository } from "./session-attachment-repository";
 import type { ClientInfo, ServerMessage } from "../types";
 import type { MessageRow, ParticipantRow, SessionRow, SessionAttachmentRow } from "./types";
+import type { SessionRepository } from "./repository";
+import type { SessionWebSocketManager } from "./websocket-manager";
+import type { ParticipantService } from "./participant-service";
+import type { CallbackNotificationService } from "./callback-notification-service";
+import type { SessionStatusService } from "./session-status-service";
 
 function createParticipant(overrides: Partial<ParticipantRow> = {}): ParticipantRow {
   return {
@@ -144,13 +150,13 @@ function buildQueue() {
       error: vi.fn(),
       child: vi.fn(),
     },
-    repository as never,
-    attachmentRepository as never,
-    wsManager as never,
+    repository as unknown as SessionRepository,
+    attachmentRepository as unknown as SessionAttachmentRepository,
+    wsManager as unknown as SessionWebSocketManager,
     messenger,
-    participantService as never,
-    callbackService as never,
-    sessionStatus as never,
+    participantService as unknown as ParticipantService,
+    callbackService as unknown as CallbackNotificationService,
+    sessionStatus as unknown as SessionStatusService,
     sandboxLifecycle,
     null,
     "github",

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -1,5 +1,5 @@
 import { generateId } from "../auth/crypto";
-import { SessionIndexStore } from "../db/session-index";
+import type { SessionIndexStore } from "../db/session-index";
 import type { Logger } from "../logger";
 import {
   DEFAULT_MODEL,
@@ -9,9 +9,10 @@ import {
   type SessionAttachmentReference,
   type ResolvedSessionAttachment,
 } from "@open-inspect/shared";
-import type { ClientInfo, Env, MessageSource, SandboxEvent, SessionStatus } from "../types";
+import type { ClientInfo, MessageSource, SandboxEvent } from "../types";
 import type { SourceControlProviderName } from "../source-control";
-import type { SessionRow, ParticipantRow, SandboxCommand } from "./types";
+import type { SandboxLifecycle } from "../sandbox/lifecycle/manager";
+import type { ParticipantRow, SandboxCommand } from "./types";
 import type { SessionRepository } from "./repository";
 import {
   AttachmentClaimConflictError,
@@ -21,9 +22,11 @@ import type { SessionMessenger } from "./messenger";
 import type { SessionWebSocketManager } from "./websocket-manager";
 import type { ParticipantService } from "./participant-service";
 import type { CallbackNotificationService } from "./callback-notification-service";
+import type { SessionStatusService } from "./session-status-service";
 import type { EnqueuePromptRequest } from "./services/message.service";
 import { getAvatarUrl } from "./participant-service";
 import { resolveParticipantName } from "./participant-name";
+import { validateReasoningEffort } from "./reasoning-effort";
 import {
   parseStoredSessionAttachments,
   SessionAttachmentError,
@@ -35,27 +38,6 @@ interface PromptMessageData {
   model?: string;
   reasoningEffort?: string;
   attachments?: SessionAttachmentReference[];
-}
-
-interface MessageQueueDeps {
-  env: Env;
-  ctx: DurableObjectState;
-  log: Logger;
-  repository: SessionRepository;
-  attachmentRepository: SessionAttachmentRepository;
-  wsManager: SessionWebSocketManager;
-  participantService: ParticipantService;
-  callbackService: CallbackNotificationService;
-  scmProvider: SourceControlProviderName;
-  getClientInfo: (ws: WebSocket) => ClientInfo | null;
-  validateReasoningEffort: (model: string, effort: string | undefined) => string | null;
-  getSession: () => SessionRow | null;
-  updateLastActivity: (timestamp: number) => void;
-  spawnSandbox: () => Promise<void>;
-  messenger: SessionMessenger;
-  setSessionStatus: (status: SessionStatus) => Promise<void>;
-  reconcileSessionStatusAfterExecution: (success: boolean) => Promise<void>;
-  scheduleExecutionTimeout?: (startedAtMs: number) => Promise<void>;
 }
 
 interface StopExecutionOptions {
@@ -79,24 +61,32 @@ interface EnqueuedPrompt {
 }
 
 export class SessionMessageQueue {
-  constructor(private readonly deps: MessageQueueDeps) {}
+  constructor(
+    private readonly ctx: DurableObjectState,
+    private readonly log: Logger,
+    private readonly repository: SessionRepository,
+    private readonly attachmentRepository: SessionAttachmentRepository,
+    private readonly wsManager: SessionWebSocketManager,
+    private readonly messenger: SessionMessenger,
+    private readonly participantService: ParticipantService,
+    private readonly callbackService: CallbackNotificationService,
+    private readonly sessionStatus: SessionStatusService,
+    private readonly sandboxLifecycle: SandboxLifecycle,
+    private readonly sessionIndex: SessionIndexStore | null,
+    private readonly scmProvider: SourceControlProviderName,
+    private readonly executionTimeoutMs: number
+  ) {}
 
-  async handlePromptMessage(ws: WebSocket, data: PromptMessageData): Promise<void> {
-    const client = this.deps.getClientInfo(ws);
-    if (!client) {
-      this.deps.wsManager.send(ws, {
-        type: "error",
-        code: "NOT_SUBSCRIBED",
-        message: "Must subscribe first",
-      });
-      return;
-    }
-
+  async handlePromptMessage(
+    ws: WebSocket,
+    client: ClientInfo,
+    data: PromptMessageData
+  ): Promise<void> {
     let enqueued: EnqueuedPrompt;
     try {
-      let participant = this.deps.participantService.getByUserId(client.userId);
+      let participant = this.participantService.getByUserId(client.userId);
       if (!participant) {
-        participant = this.deps.participantService.create(client.userId, client.name);
+        participant = this.participantService.create(client.userId, client.name);
       }
       enqueued = await this.enqueuePromptCore({
         participant,
@@ -109,7 +99,7 @@ export class SessionMessageQueue {
       });
     } catch (error) {
       if (!(error instanceof SessionAttachmentError)) throw error;
-      this.deps.wsManager.send(ws, {
+      this.wsManager.send(ws, {
         type: "error",
         code: "INVALID_ATTACHMENTS",
         message: error.message,
@@ -117,14 +107,14 @@ export class SessionMessageQueue {
       return;
     }
 
-    if (this.deps.env.DB) {
-      const store = new SessionIndexStore(this.deps.env.DB);
-      const session = this.deps.getSession();
+    const sessionIndex = this.sessionIndex;
+    if (sessionIndex) {
+      const session = this.repository.getSession();
       const sessionId = session?.session_name || session?.id;
       if (sessionId) {
-        this.deps.ctx.waitUntil(
-          store.touchUpdatedAt(sessionId).catch((error) => {
-            this.deps.log.error("session_index.touch_updated_at.background_error", {
+        this.ctx.waitUntil(
+          sessionIndex.touchUpdatedAt(sessionId).catch((error) => {
+            this.log.error("session_index.touch_updated_at.background_error", {
               session_id: sessionId,
               error,
             });
@@ -133,7 +123,7 @@ export class SessionMessageQueue {
       }
     }
 
-    this.deps.wsManager.send(ws, {
+    this.wsManager.send(ws, {
       type: "prompt_queued",
       messageId: enqueued.messageId,
       position: enqueued.position,
@@ -143,40 +133,44 @@ export class SessionMessageQueue {
   }
 
   async processMessageQueue(): Promise<void> {
-    if (this.deps.repository.getProcessingMessage()) {
-      this.deps.log.debug("processMessageQueue: already processing, returning");
+    if (this.repository.getProcessingMessage()) {
+      this.log.debug("processMessageQueue: already processing, returning");
       return;
     }
 
-    const message = this.deps.repository.getNextPendingMessage();
+    const message = this.repository.getNextPendingMessage();
     if (!message) {
       return;
     }
     const now = Date.now();
 
-    const sandboxWs = this.deps.wsManager.getSandboxSocket();
+    const sandboxWs = this.wsManager.getSandboxSocket();
     if (!sandboxWs) {
-      this.deps.log.info("prompt.dispatch", {
+      this.log.info("prompt.dispatch", {
         event: "prompt.dispatch",
         message_id: message.id,
         outcome: "deferred",
         reason: "no_sandbox",
       });
-      this.deps.messenger.broadcast({ type: "sandbox_spawning" });
-      await this.deps.spawnSandbox();
+      this.messenger.broadcast({ type: "sandbox_spawning" });
+      await this.sandboxLifecycle.spawnSandbox();
       return;
     }
 
-    this.deps.repository.updateMessageToProcessing(message.id, now);
-    this.deps.messenger.broadcast({ type: "processing_status", isProcessing: true });
-    this.deps.updateLastActivity(now);
+    this.repository.updateMessageToProcessing(message.id, now);
+    this.messenger.broadcast({ type: "processing_status", isProcessing: true });
+    this.sandboxLifecycle.updateLastActivity(now);
 
-    if (this.deps.scheduleExecutionTimeout) {
-      await this.deps.scheduleExecutionTimeout(now);
+    // Execution timeout shares the DO's single alarm slot with inactivity
+    // checks — the earlier deadline always wins.
+    const deadline = now + this.executionTimeoutMs;
+    const currentAlarm = await this.ctx.storage.getAlarm();
+    if (!currentAlarm || deadline < currentAlarm) {
+      await this.ctx.storage.setAlarm(deadline);
     }
 
-    const author = this.deps.repository.getParticipantById(message.author_id);
-    const session = this.deps.getSession();
+    const author = this.repository.getParticipantById(message.author_id);
+    const session = this.repository.getSession();
     const resolvedModel = getValidModelOrDefault(message.model || session?.model);
     const resolvedEffort =
       message.reasoning_effort ??
@@ -195,16 +189,16 @@ export class SessionMessageQueue {
         scmEmail: author?.scm_email ?? null,
       },
       attachments: parseStoredSessionAttachments(message.attachments, () =>
-        this.deps.log.error("prompt.invalid_stored_attachments")
+        this.log.error("prompt.invalid_stored_attachments")
       ),
     };
 
-    const sent = this.deps.wsManager.send(sandboxWs, command);
+    const sent = this.wsManager.send(sandboxWs, command);
 
     if (sent) {
-      this.deps.ctx.waitUntil(
-        this.deps.callbackService.notifyStarted(message.id).catch((error) => {
-          this.deps.log.error("callback.started.background_error", {
+      this.ctx.waitUntil(
+        this.callbackService.notifyStarted(message.id).catch((error) => {
+          this.log.error("callback.started.background_error", {
             message_id: message.id,
             error,
           });
@@ -212,7 +206,7 @@ export class SessionMessageQueue {
       );
     }
 
-    this.deps.log.info("prompt.dispatch", {
+    this.log.info("prompt.dispatch", {
       event: "prompt.dispatch",
       message_id: message.id,
       outcome: sent ? "sent" : "send_failed",
@@ -230,11 +224,11 @@ export class SessionMessageQueue {
 
   async stopExecution(options: StopExecutionOptions = {}): Promise<void> {
     const now = Date.now();
-    const processingMessage = this.deps.repository.getProcessingMessage();
+    const processingMessage = this.repository.getProcessingMessage();
 
     if (processingMessage) {
-      this.deps.repository.updateMessageCompletion(processingMessage.id, "failed", now);
-      this.deps.log.info("prompt.stopped", {
+      this.repository.updateMessageCompletion(processingMessage.id, "failed", now);
+      this.log.info("prompt.stopped", {
         event: "prompt.stopped",
         message_id: processingMessage.id,
       });
@@ -248,31 +242,31 @@ export class SessionMessageQueue {
         sandboxId: "",
         timestamp: now / 1000,
       };
-      this.deps.repository.upsertExecutionCompleteEvent(
+      this.repository.upsertExecutionCompleteEvent(
         processingMessage.id,
         syntheticExecutionComplete,
         now
       );
 
-      this.deps.messenger.broadcast({
+      this.messenger.broadcast({
         type: "sandbox_event",
         event: syntheticExecutionComplete,
       });
 
-      this.deps.ctx.waitUntil(
-        this.deps.callbackService.notifyComplete(processingMessage.id, false, stopError)
+      this.ctx.waitUntil(
+        this.callbackService.notifyComplete(processingMessage.id, false, stopError)
       );
 
       if (!options.suppressStatusReconcile) {
-        await this.deps.reconcileSessionStatusAfterExecution(false);
+        await this.sessionStatus.reconcileAfterExecution(false);
       }
     }
 
-    this.deps.messenger.broadcast({ type: "processing_status", isProcessing: false });
+    this.messenger.broadcast({ type: "processing_status", isProcessing: false });
 
-    const sandboxWs = this.deps.wsManager.getSandboxSocket();
+    const sandboxWs = this.wsManager.getSandboxSocket();
     if (sandboxWs) {
-      this.deps.wsManager.send(sandboxWs, { type: "stop" });
+      this.wsManager.send(sandboxWs, { type: "stop" });
     }
   }
 
@@ -285,10 +279,10 @@ export class SessionMessageQueue {
    */
   async failStuckProcessingMessage(): Promise<void> {
     const now = Date.now();
-    const processingMessage = this.deps.repository.getProcessingMessage();
+    const processingMessage = this.repository.getProcessingMessage();
     if (!processingMessage) return;
 
-    this.deps.repository.updateMessageCompletion(processingMessage.id, "failed", now);
+    this.repository.updateMessageCompletion(processingMessage.id, "failed", now);
 
     const stuckError = "Execution timed out (stuck processing)";
     const syntheticEvent: Extract<SandboxEvent, { type: "execution_complete" }> = {
@@ -299,13 +293,13 @@ export class SessionMessageQueue {
       sandboxId: "",
       timestamp: now / 1000,
     };
-    this.deps.repository.upsertExecutionCompleteEvent(processingMessage.id, syntheticEvent, now);
-    this.deps.messenger.broadcast({ type: "sandbox_event", event: syntheticEvent });
-    this.deps.messenger.broadcast({ type: "processing_status", isProcessing: false });
-    this.deps.ctx.waitUntil(
-      this.deps.callbackService.notifyComplete(processingMessage.id, false, stuckError)
+    this.repository.upsertExecutionCompleteEvent(processingMessage.id, syntheticEvent, now);
+    this.messenger.broadcast({ type: "sandbox_event", event: syntheticEvent });
+    this.messenger.broadcast({ type: "processing_status", isProcessing: false });
+    this.ctx.waitUntil(
+      this.callbackService.notifyComplete(processingMessage.id, false, stuckError)
     );
-    await this.deps.reconcileSessionStatusAfterExecution(false);
+    await this.sessionStatus.reconcileAfterExecution(false);
   }
 
   writeUserMessageEvent(
@@ -325,26 +319,26 @@ export class SessionMessageQueue {
       author: {
         participantId: participant.id,
         name: resolveParticipantName(participant),
-        avatar: getAvatarUrl(participant.scm_login, this.deps.scmProvider),
+        avatar: getAvatarUrl(participant.scm_login, this.scmProvider),
       },
       ...(attachments && attachments.length > 0 ? { attachments } : {}),
     };
-    this.deps.repository.createEvent({
+    this.repository.createEvent({
       id: generateId(),
       type: "user_message",
       data: JSON.stringify(userMessageEvent),
       messageId,
       createdAt: now,
     });
-    this.deps.messenger.broadcast({ type: "sandbox_event", event: userMessageEvent });
+    this.messenger.broadcast({ type: "sandbox_event", event: userMessageEvent });
   }
 
   async enqueuePromptFromApi(
     data: EnqueuePromptRequest
   ): Promise<{ messageId: string; status: "queued" }> {
-    let participant = this.deps.participantService.getByUserId(data.authorId);
+    let participant = this.participantService.getByUserId(data.authorId);
     if (!participant) {
-      participant = this.deps.participantService.create(
+      participant = this.participantService.create(
         data.authorId,
         data.authorDisplayName || data.authorId
       );
@@ -358,7 +352,7 @@ export class SessionMessageQueue {
       data.scmUserId ||
       data.scmAccessTokenEncrypted;
     if (hasEnrichment) {
-      this.deps.repository.updateParticipantCoalesce(participant.id, {
+      this.repository.updateParticipantCoalesce(participant.id, {
         scmName: data.authorDisplayName ?? null,
         scmEmail: data.authorEmail ?? null,
         scmLogin: data.authorLogin ?? null,
@@ -367,7 +361,7 @@ export class SessionMessageQueue {
         scmRefreshTokenEncrypted: data.scmRefreshTokenEncrypted ?? null,
         scmTokenExpiresAt: data.scmTokenExpiresAt ?? null,
       });
-      participant = this.deps.repository.getParticipantById(participant.id) ?? participant;
+      participant = this.repository.getParticipantById(participant.id) ?? participant;
     }
 
     const enqueued = await this.enqueuePromptCore({
@@ -389,7 +383,7 @@ export class SessionMessageQueue {
   private async enqueuePromptCore(data: EnqueuePromptCoreData): Promise<EnqueuedPrompt> {
     const resolvedAttachments = resolveSessionAttachments(
       data.attachments,
-      this.deps.attachmentRepository
+      this.attachmentRepository
     );
     const attachments = resolvedAttachments?.attachments;
     const messageId = generateId();
@@ -400,18 +394,20 @@ export class SessionMessageQueue {
       if (isValidModel(data.model)) {
         messageModel = data.model;
       } else {
-        this.deps.log.warn("Invalid message model, ignoring override", { model: data.model });
+        this.log.warn("Invalid message model, ignoring override", { model: data.model });
       }
     }
 
-    const effectiveModelForEffort = messageModel || this.deps.getSession()?.model || DEFAULT_MODEL;
-    const messageReasoningEffort = this.deps.validateReasoningEffort(
+    const effectiveModelForEffort =
+      messageModel || this.repository.getSession()?.model || DEFAULT_MODEL;
+    const messageReasoningEffort = validateReasoningEffort(
       effectiveModelForEffort,
-      data.reasoningEffort
+      data.reasoningEffort,
+      this.log
     );
 
     try {
-      this.deps.repository.createMessageWithAttachments(
+      this.repository.createMessageWithAttachments(
         {
           id: messageId,
           authorId: data.participant.id,
@@ -435,11 +431,11 @@ export class SessionMessageQueue {
       throw error;
     }
 
-    await this.deps.setSessionStatus("active");
+    await this.sessionStatus.transition("active");
     this.writeUserMessageEvent(data.participant, data.content, messageId, now, attachments);
 
-    const position = this.deps.repository.getPendingOrProcessingCount();
-    this.deps.log.info("prompt.enqueue", {
+    const position = this.repository.getPendingOrProcessingCount();
+    this.log.info("prompt.enqueue", {
       event: "prompt.enqueue",
       message_id: messageId,
       source: data.source,

--- a/packages/control-plane/src/session/reasoning-effort.ts
+++ b/packages/control-plane/src/session/reasoning-effort.ts
@@ -1,0 +1,21 @@
+/**
+ * Validate reasoning effort against a model's allowed values.
+ * Returns the validated effort string or null if invalid/absent.
+ */
+
+import { isValidReasoningEffort } from "@open-inspect/shared";
+import type { Logger } from "../logger";
+
+export function validateReasoningEffort(
+  model: string,
+  effort: string | undefined,
+  log: Logger
+): string | null {
+  if (!effort) return null;
+  if (isValidReasoningEffort(model, effort)) return effort;
+  log.warn("Invalid reasoning effort for model, ignoring", {
+    model,
+    reasoning_effort: effort,
+  });
+  return null;
+}

--- a/packages/control-plane/test/integration/websocket-client.test.ts
+++ b/packages/control-plane/test/integration/websocket-client.test.ts
@@ -20,6 +20,29 @@ describe("Client WebSocket (via SELF.fetch)", () => {
     ws.close();
   });
 
+  it("rejects a prompt sent before subscribing without enqueuing it", async () => {
+    const name = `ws-client-nosub-prompt-${Date.now()}`;
+    await initNamedSession(name);
+
+    const { ws } = await openClientWs(name);
+
+    const closed = new Promise<{ code: number }>((resolve) => {
+      ws.addEventListener("close", (evt) => resolve({ code: evt.code }));
+    });
+
+    ws.send(JSON.stringify({ type: "prompt", content: "hello" }));
+
+    // Unsubscribed sockets have no client mapping — the DO closes them
+    // with 4002 and never enqueues the prompt.
+    const { code } = await closed;
+    expect(code).toBe(4002);
+
+    const id = env.SESSION.idFromName(name);
+    const stub = env.SESSION.get(id);
+    const rows = await queryDO<{ count: number }>(stub, "SELECT COUNT(*) AS count FROM messages");
+    expect(rows[0].count).toBe(0);
+  });
+
   it("subscribe with valid token sends subscribed + state", async () => {
     const name = `ws-client-sub-${Date.now()}`;
     await initNamedSession(name, { repoOwner: "acme", repoName: "web-app" });


### PR DESCRIPTION
Completes the 3-PR campaign started by #1065 (`SessionStatusService` extraction): `SessionMessageQueue` no longer takes a `MessageQueueDeps` bag of ~18 fields. Every injected lambda and over-broad dependency is dissolved into either a direct collaborator or a plain value, passed as positional constructor params (the `SessionSandboxEventProcessor` precedent). `MessageQueueDeps` is deleted.

This is strictly behavior-preserving on the prompt-serialization hot path.

## Per-dep dissolution

| Old dep | What it became |
| --- | --- |
| `env` | `sessionIndex: SessionIndexStore \| null` — the queue only read `env.DB` to build a `SessionIndexStore`; the DO now passes `this.env.DB ? new SessionIndexStore(this.env.DB) : null` (same null short-circuit) |
| `ctx` | unchanged (positional) |
| `log` | unchanged (positional; the DO's session-scoped logger) |
| `repository`, `attachmentRepository`, `wsManager`, `participantService`, `callbackService`, `messenger` | unchanged (positional) |
| `scmProvider` | unchanged (plain value, positional) |
| `getClientInfo` lambda | deleted — client resolution + the NOT_SUBSCRIBED reply moved to the DO boundary (`SessionDO.handlePromptMessage`), mirroring `handleFetchHistory`; the queue method is now `handlePromptMessage(ws, client: ClientInfo, data)` |
| `validateReasoningEffort` lambda | free function in `src/session/reasoning-effort.ts` (`(model, effort, log)`); also replaces the identical lambda wired into `SessionLifecycleHandler`; the DO method is deleted |
| `getSession` lambda | deleted — it was literally `this.repository.getSession()`, and the repository is already a dep |
| `updateLastActivity` + `spawnSandbox` lambdas | `sandboxLifecycle: SandboxLifecycle` — a new explicit interface implemented by `SandboxLifecycleManager`; the DO passes `this.lifecycleManager` |
| `setSessionStatus` + `reconcileSessionStatusAfterExecution` lambdas | `sessionStatus: SessionStatusService` (from #1065) — the queue calls `transition(...)` / `reconcileAfterExecution(...)` at the exact same await points; the DO's one-line delegation methods (`transitionSessionStatus`, `reconcileSessionStatusAfterExecution`) had no other callers and are deleted |
| `scheduleExecutionTimeout?` (optional closure) | internalized — the queue takes a plain `executionTimeoutMs: number` (the DO's existing getter value) and inlines the compare-and-set at the same await point; min-compare semantics preserved exactly (the DO alarm slot is shared with inactivity checks — earlier alarm always wins). The optionality existed only for tests, which now fake `ctx.storage.getAlarm/setAlarm` |

## Final constructor

```ts
constructor(
  private readonly ctx: DurableObjectState,
  private readonly log: Logger,
  private readonly repository: SessionRepository,
  private readonly attachmentRepository: SessionAttachmentRepository,
  private readonly wsManager: SessionWebSocketManager,
  private readonly messenger: SessionMessenger,
  private readonly participantService: ParticipantService,
  private readonly callbackService: CallbackNotificationService,
  private readonly sessionStatus: SessionStatusService,
  private readonly sandboxLifecycle: SandboxLifecycle,
  private readonly sessionIndex: SessionIndexStore | null,
  private readonly scmProvider: SourceControlProviderName,
  private readonly executionTimeoutMs: number
) {}
```

Zero lambdas; every param is a plain value or an object owning the state it mutates. The queue still holds zero state of its own — all queue state remains `messages` table rows via `SessionRepository`.

## Correctness invariant (prompt serialization)

`SessionMessageQueue` is the only same-session prompt-serialization mechanism (the sandbox bridge deliberately does not serialize):

- The guard (`if (repository.getProcessingMessage()) return;`) and the claim (`updateMessageToProcessing`) remain adjacent in `processMessageQueue`, in the same order.
- No awaits were added, removed, or reordered anywhere in the queue. The inlined alarm compare-and-set sits at the exact await point where the optional `scheduleExecutionTimeout` closure previously ran (after claim/broadcast/`updateLastActivity`).
- The drain path (`SessionSandboxEventProcessor` → `processMessageQueue()` after `execution_complete`) is untouched.
- `stopExecution` and `failStuckProcessingMessage` keep their exact statement order; only `this.deps.X` became `this.X` and the status lambdas became direct `SessionStatusService` calls.

## No construction cycle

`SandboxLifecycleManager`'s `onSandboxTerminating: () => this.messageQueue.failStuckProcessingMessage()` closure is lazily evaluated — verified it is only invoked at termination time, never during construction. The `messageQueue` getter now touches `this.lifecycleManager` eagerly, but manager construction only captures the closure, so there is no cycle in either initialization order.

## Tests

- `message-queue.test.ts`: `buildQueue` harness rewritten to positional fakes (same `vi.fn` objects); status lambdas became a fake `SessionStatusService` (`transition`/`reconcileAfterExecution`), spawn/activity lambdas a fake `SandboxLifecycle`, and `ctx.storage` gained `getAlarm`/`setAlarm` fakes. Added 4 execution-timeout scheduling tests (no existing alarm / earlier existing alarm / later existing alarm / no scheduling when deferred for spawn).
- The queue-level NOT_SUBSCRIBED unit test moved with the code to the DO boundary: new integration test in `websocket-client.test.ts` proves a pre-subscribe prompt is rejected (4002 close — unsubscribed sockets have no client mapping, so `getClientInfo` closes them, same as before this PR) and that nothing is enqueued (`messages` count stays 0). No assertions were weakened.
- `stop-execution.test.ts` (unit + integration) unaffected.

## Verification

- `npm run typecheck` — clean (all packages)
- Unit: **2008 passed** (baseline on main: 2005 → −1 queue-level NOT_SUBSCRIBED test replaced at the boundary, +4 new alarm-scheduling tests)
- Integration: **571 passed** (baseline: 570 → +1 boundary NOT_SUBSCRIBED test)
- `npm run lint` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prompts sent before subscription are now rejected safely, with no prompt enqueued.
  * Invalid reasoning-effort values are ignored and recorded in logs.
* **Reliability**
  * Improved session timeout alarm scheduling and recovery for stalled or stopped sessions.
  * Better execution failure/timeout handling, including enhanced completion signaling and status reconciliation.
* **New Features**
  * Sessions can automatically spawn a sandbox when prompt handling requires it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->