### PR TITLE
fix(control-plane): harden OpenComputer REST client request timeouts

### DIFF
--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.test.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.test.ts
@@ -52,3 +52,87 @@ describe("OpenComputerRestClient runtime SANDBOX_VERSION export", () => {
     expect(body.args[1]).toContain("SANDBOX_VERSION=v54-opencode-1-17-18");
   });
 });
+
+// A hung OpenComputer API call must fail fast with an attributed, greppable
+// timeout error instead of wedging fire-and-forget callers (e.g. the
+// image-build trigger under ctx.waitUntil). The message must contain "timeout"
+// so SandboxProviderError classifies it transient (isTransientNetworkError),
+// not permanent — otherwise provider instability trips the circuit breaker.
+describe("OpenComputerRestClient request timeouts", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function abortError(): DOMException {
+    return new DOMException("This operation was aborted", "AbortError");
+  }
+
+  // Mirrors real fetch: never settles until the abort signal fires, then
+  // rejects with an AbortError.
+  function stubHangingFetch(): void {
+    fetchSpy.mockImplementation(
+      (_url: unknown, init?: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(abortError()));
+        })
+    );
+  }
+
+  it("aborts a hung createSandbox call and rejects with an attributed timeout", async () => {
+    const client = new OpenComputerRestClient(config);
+    stubHangingFetch();
+
+    const promise = client.createSandbox({ name: "build-env-1", template: config.template });
+    const assertion = expect(promise).rejects.toThrow(
+      "OpenComputer request timeout after 90000ms (POST /sandboxes)"
+    );
+    await vi.advanceTimersByTimeAsync(90_000);
+    await assertion;
+  });
+
+  it("attributes a timeout that fires while reading the response body", async () => {
+    const client = new OpenComputerRestClient(config);
+    fetchSpy.mockImplementation((_url: unknown, init?: RequestInit) => {
+      const stalledBody = new ReadableStream<Uint8Array>({
+        start(streamController) {
+          init?.signal?.addEventListener("abort", () => streamController.error(abortError()));
+        },
+      });
+      return Promise.resolve(
+        new Response(stalledBody, { status: 200, headers: { "content-type": "application/json" } })
+      );
+    });
+
+    const promise = client.getSandbox("sb-1");
+    const assertion = expect(promise).rejects.toThrow(
+      "OpenComputer request timeout after 15000ms (GET /sandboxes/sb-1)"
+    );
+    await vi.advanceTimersByTimeAsync(15_000);
+    await assertion;
+  });
+
+  it("leaves fast responses unaffected and does not leak the timer", async () => {
+    const client = new OpenComputerRestClient(config);
+    fetchSpy.mockResolvedValue(jsonResponse({ id: "sb-1" }));
+
+    const sandbox = await client.getSandbox("sb-1");
+
+    expect(sandbox.id).toBe("sb-1");
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("rethrows API errors unchanged and clears the timer", async () => {
+    const client = new OpenComputerRestClient(config);
+    fetchSpy.mockResolvedValue(new Response("boom", { status: 500 }));
+
+    await expect(client.getSandbox("sb-1")).rejects.toMatchObject({
+      name: "OpenComputerApiError",
+      status: 500,
+    });
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
+++ b/packages/control-plane/src/sandbox/opencomputer-rest-client.ts
@@ -461,15 +461,7 @@ export class OpenComputerRestClient {
       };
       if (body !== undefined) init.body = JSON.stringify(body);
 
-      let response: Response;
-      try {
-        response = await fetch(url, init);
-      } catch (error) {
-        if (controller.signal.aborted) {
-          throw new Error(`OpenComputer request timed out after ${timeoutMs}ms`);
-        }
-        throw error;
-      }
+      const response = await fetch(url, init);
 
       if (response.status === 404) {
         const text = await response.text();
@@ -486,6 +478,18 @@ export class OpenComputerRestClient {
         return (await response.json()) as T;
       }
       return undefined as T;
+    } catch (error) {
+      // The per-call timeout fires controller.abort(); the resulting AbortError
+      // — from fetch OR a body read — must surface as an attributed timeout so
+      // it is actionable in logs and build error_messages. The message must
+      // contain "timeout" so SandboxProviderError classifies it transient
+      // (isTransientNetworkError), not permanent — otherwise it trips the
+      // circuit breaker. Our typed API errors (OpenComputer*Error) have
+      // distinct names and rethrow unchanged.
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new Error(`OpenComputer request timeout after ${timeoutMs}ms (${method} ${path})`);
+      }
+      throw error;
     } finally {
       clearTimeout(timeoutId);
     }


### PR DESCRIPTION
## Incident

Image build `imgb-colemurray-background-agents-1784433618644-4348fdfa` sat in status `building` for 90+ minutes during an OpenComputer platform-instability window (prod investigation, 2026-07-19):

- The build trigger runs fire-and-forget under `ctx.waitUntil` (`packages/control-plane/src/routes/image-builds.ts:146`).
- `triggerEnvironmentImageBuild` binds the provider session only **after** `createSandbox` returns. The call hung, the isolate was torn down, and neither `bindProviderSession` nor the workflow `catch` -> `markBuildFailed` ever ran — leaving a permanently-`building` row (`provider_session_id=NULL`, `error_message=NULL`).
- The only reaper today is the Modal scheduler's every-30-min mark-stale sweep gated at 4200s (Modal-sized), so the row wedged for ~90 min and suppressed new builds for its scope (`getActiveBuild` concurrency-1 / `skip_building`). Session spawns were not blocked (base-image fallback).

## Root cause (client side)

The OpenComputer REST client has had per-call `AbortController` timeouts since #818 (`TIMEOUT_CREATE_MS` etc., `clearTimeout` in `finally`), but the abort path had three defects that surface exactly during provider instability:

1. **Aborts during body reads escaped unmapped.** The abort -> timeout-error mapping wrapped only `fetch` itself. If the timer fired while awaiting `response.text()` / `response.json()` (headers received, body stalled — a typical instability failure mode), callers got a bare `AbortError: The operation was aborted` with no attribution.
2. **Timeouts were classified permanent and counted toward the circuit breaker.** `SandboxProviderError.isTransientNetworkError` matches `"timeout"` / `"etimedout"` / `"econnreset"` / ... — the old message `OpenComputer request timed out after 90000ms` matches **none** of them, so an aborted call was classified permanent. The E2B client words its message `E2B request timeout after ...ms (...)` for precisely this reason and pins it in a test.
3. **No method/path attribution.** Even when the error did land in `markBuildFailed`'s `error_message` or in logs, it did not say which call timed out.

## Change

Adopts the E2B client's established pattern in the single `request()` chokepoint (every OC API call flows through it):

- One outer `catch` maps any `AbortError` — from `fetch` **or** a body read — to `OpenComputer request timeout after <timeoutMs>ms (<METHOD> <path>)`, e.g. `OpenComputer request timeout after 90000ms (POST /sandboxes)` — greppable, attributed, and transient-classifiable.
- Typed API errors (`OpenComputerNotFoundError` / `OpenComputerApiError`) have distinct names and rethrow unchanged.
- `clearTimeout` stays in `finally`; timers cannot leak.

## Timeout values

The existing per-call budgets are kept unchanged: `TIMEOUT_CREATE_MS = 90_000` for create/fork-from-checkpoint (sized for checkpoint forks that legitimately take ~45-60s), down to 15s for GETs and up to 30 min for the foreground build exec. They are already defined once as named `_MS` constants per repo convention, so no new default constant or constructor override is introduced.

## Tests

Four new co-located unit tests in `opencomputer-rest-client.test.ts` (fake timers; the fetch stub rejects on signal abort like real fetch):

- aborts a hung `createSandbox` call and rejects with an attributed timeout
- attributes a timeout that fires while reading the response body
- leaves fast responses unaffected and does not leak the timer
- rethrows API errors unchanged and clears the timer

`npm run typecheck -w @open-inspect/control-plane` and `npm test -w @open-inspect/control-plane` (121 files / 2009 tests) pass.

## Deliberately out of scope (follow-ups)

A client-side timer only helps while the isolate survives; nothing client-side can run after a `ctx.waitUntil` teardown. The incident's remaining gaps are left for separate, deliberate changes rather than widened into this one:

- **Control-plane-side mark-stale for image builds** with a provider-aware threshold (today's only reaper is the Modal scheduler's 4200s sweep).
- **Binding a reap handle before the slow call** (bind-before-create ordering in `triggerEnvironmentImageBuild`) so an orphaned sandbox/row is reapable even if the isolate dies mid-call.

No schema, workflow, scheduler, or other-provider changes here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of timed-out sandbox API requests.
  * Timeout errors now clearly identify the affected request endpoint.
  * Preserved original error details for non-timeout API failures.
  * Ensured fast responses complete normally without leaving pending timers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->