### PR TITLE
refactor(control-plane): inject SqlDatabase via DI at layer entry points, narrow instrumentD1

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,6 +65,28 @@ export default tseslint.config(
     },
   },
 
+  // Control-plane data-layer boundary: route and webhook handlers must use the
+  // injected SqlDatabase (ctx.db), never the raw env.DB binding — reading the
+  // binding there would silently bypass per-request query instrumentation.
+  // env.DB is read only at the injection points: the router and the two
+  // Durable Object constructors.
+  {
+    files: [
+      "packages/control-plane/src/routes/**/*.ts",
+      "packages/control-plane/src/webhooks/**/*.ts",
+    ],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: 'MemberExpression[property.name="DB"]',
+          message:
+            "Use ctx.db (injected SqlDatabase) instead of env.DB in route/webhook handlers so queries stay instrumented.",
+        },
+      ],
+    },
+  },
+
   // React-specific configuration for web package
   {
     files: ["packages/web/**/*.{ts,tsx}"],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -65,23 +65,23 @@ export default tseslint.config(
     },
   },
 
-  // Control-plane data-layer boundary: route and webhook handlers must use the
-  // injected SqlDatabase (ctx.db), never the raw env.DB binding — reading the
-  // binding there would silently bypass per-request query instrumentation.
-  // env.DB is read only at the injection points: the router and the two
-  // Durable Object constructors.
+  // Control-plane data-layer boundary: all production code must use the
+  // injected SqlDatabase (ctx.db, a DO's db field, or a db parameter), never
+  // the raw env.DB binding — reading the binding elsewhere would silently
+  // bypass the injection path and, on request paths, query instrumentation.
+  // The only legitimate reads are the composition roots (router.ts and the
+  // two Durable Object constructors), each carrying an inline
+  // eslint-disable with justification.
   {
-    files: [
-      "packages/control-plane/src/routes/**/*.ts",
-      "packages/control-plane/src/webhooks/**/*.ts",
-    ],
+    files: ["packages/control-plane/src/**/*.ts"],
+    ignores: ["packages/control-plane/src/**/*.test.ts"],
     rules: {
       "no-restricted-syntax": [
         "error",
         {
           selector: 'MemberExpression[property.name="DB"]',
           message:
-            "Use ctx.db (injected SqlDatabase) instead of env.DB in route/webhook handlers so queries stay instrumented.",
+            "Use the injected SqlDatabase (ctx.db / this.db / a db param) instead of env.DB; the binding is read only at composition roots.",
         },
       ],
     },

--- a/packages/control-plane/src/automation/session-target.test.ts
+++ b/packages/control-plane/src/automation/session-target.test.ts
@@ -27,6 +27,7 @@ const ctx: RequestContext = {
   trace_id: "trace-1",
   request_id: "req-1",
   metrics: {} as RequestContext["metrics"],
+  db: env.DB,
 };
 
 function run(overrides?: Partial<AutomationRunRow>): AutomationRunRow {

--- a/packages/control-plane/src/automation/session-target.ts
+++ b/packages/control-plane/src/automation/session-target.ts
@@ -41,7 +41,7 @@ export async function resolveAutomationSessionTarget(
 ): Promise<AutomationSessionTarget> {
   if (run.environment_id) {
     const environmentInputs = await resolveEnvironmentTarget(
-      new EnvironmentStore(env.DB),
+      new EnvironmentStore(ctx.db),
       run.environment_id
     );
     const repositories = await resolveSessionRepositories(env, environmentInputs, ctx, log);

--- a/packages/control-plane/src/db/instrumented-d1.test.ts
+++ b/packages/control-plane/src/db/instrumented-d1.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { createRequestMetrics, instrumentD1 } from "./instrumented-d1";
 import type { RequestMetrics } from "./instrumented-d1";
+import type { SqlDatabase } from "./sql-database";
 
 // ---------------------------------------------------------------------------
 // Fake D1 implementation for testing the instrumented wrapper
@@ -165,7 +166,7 @@ describe("createRequestMetrics", () => {
 describe("instrumentD1", () => {
   let fakeDb: FakeD1Database;
   let metrics: RequestMetrics;
-  let db: D1Database;
+  let db: SqlDatabase;
 
   beforeEach(() => {
     fakeDb = new FakeD1Database();
@@ -198,14 +199,6 @@ describe("instrumentD1", () => {
     expect(metrics.d1Queries).toHaveLength(1);
     expect(metrics.d1Queries[0].query_ms).toBeGreaterThanOrEqual(0);
     // first() does not return D1Meta
-    expect(metrics.d1Queries[0].d1_server_ms).toBeUndefined();
-  });
-
-  it("captures timing from raw()", async () => {
-    await db.prepare("SELECT id, name FROM t").raw();
-
-    expect(metrics.d1Queries).toHaveLength(1);
-    expect(metrics.d1Queries[0].query_ms).toBeGreaterThanOrEqual(0);
     expect(metrics.d1Queries[0].d1_server_ms).toBeUndefined();
   });
 
@@ -266,16 +259,6 @@ describe("instrumentD1", () => {
     expect(summary.d1_server_total_ms).toBe(13);
     expect(summary.d1_rows_read).toBe(10);
     expect(summary.d1_rows_written).toBe(1);
-  });
-
-  it("passes through exec() to the underlying database", async () => {
-    const result = await db.exec("CREATE TABLE t (id INT)");
-    expect(result).toEqual({ count: 0, duration: 0 });
-  });
-
-  it("passes through dump() to the underlying database", async () => {
-    const result = await db.dump();
-    expect(result).toBeInstanceOf(ArrayBuffer);
   });
 
   it("summarize includes both D1 and span fields", async () => {

--- a/packages/control-plane/src/db/instrumented-d1.ts
+++ b/packages/control-plane/src/db/instrumented-d1.ts
@@ -1,14 +1,16 @@
 /**
- * Instrumented D1 wrapper for per-request query timing.
+ * Instrumented SqlDatabase wrapper for per-request query timing.
  *
- * Wraps a D1Database so that every query's wall-clock time and D1-reported
+ * Wraps a SqlDatabase so that every query's wall-clock time and engine-reported
  * metadata (server duration, rows read/written) are recorded into a
  * RequestMetrics collector. The collector is created once per HTTP request
  * and its summary is spread into the http.request wide event.
  *
- * No changes required to the stores — they accept the SqlDatabase port
- * (which this wrapper satisfies) and receive the instrumented DB transparently.
+ * The router injects the instrumented database into RequestContext (`ctx.db`);
+ * stores accept the SqlDatabase port and receive it transparently.
  */
+
+import type { SqlDatabase, SqlResult, SqlStatement } from "./sql-database";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -18,11 +20,11 @@
 export interface D1QueryRecord {
   /** Wall-clock time in ms (includes network round-trip from Worker to D1 primary). */
   query_ms: number;
-  /** D1-reported server-side execution time in ms (from D1Meta.duration). */
+  /** Engine-reported server-side execution time in ms (from meta.duration). */
   d1_server_ms?: number;
-  /** Rows read, from D1Meta. */
+  /** Rows read, from result meta. */
   rows_read?: number;
-  /** Rows written, from D1Meta. */
+  /** Rows written, from result meta. */
   rows_written?: number;
 }
 
@@ -90,53 +92,42 @@ export function createRequestMetrics(): RequestMetrics {
 }
 
 // ---------------------------------------------------------------------------
-// D1 statement wrapper
+// Statement wrapper
 // ---------------------------------------------------------------------------
 
-/** Symbol used to store the original D1PreparedStatement on instrumented wrappers. */
-const ORIGINAL_STMT = Symbol("originalD1Statement");
+/** Symbol used to store the original SqlStatement on instrumented wrappers. */
+const ORIGINAL_STMT = Symbol("originalSqlStatement");
 
-type WrappedStatement = D1PreparedStatement & { [ORIGINAL_STMT]?: D1PreparedStatement };
+type WrappedStatement = SqlStatement & { [ORIGINAL_STMT]?: SqlStatement };
 
-type RawCapableStatement = D1PreparedStatement & {
-  raw: (options?: Record<string, unknown>) => Promise<unknown[]>;
-};
-
-function hasRawMethod(statement: D1PreparedStatement): statement is RawCapableStatement {
-  return "raw" in statement && typeof statement.raw === "function";
-}
-
-/** Extract the underlying D1PreparedStatement from an instrumented wrapper (or return as-is). */
-function unwrapStatement(stmt: D1PreparedStatement): D1PreparedStatement {
+/** Extract the underlying SqlStatement from an instrumented wrapper (or return as-is). */
+function unwrapStatement(stmt: SqlStatement): SqlStatement {
   return (stmt as WrappedStatement)[ORIGINAL_STMT] ?? stmt;
 }
 
 /**
- * Wrap a D1PreparedStatement to time its terminal methods (run, first, all, raw).
+ * Wrap a SqlStatement to time its terminal methods (run, first, all).
  * bind() returns a new instrumented statement so chaining works correctly.
  *
  * The original statement is stored via ORIGINAL_STMT so that batch() can
- * unwrap instrumented statements before passing them to the real D1.
+ * unwrap instrumented statements before passing them to the real database
+ * (which can only execute its own statements — see the same-origin contract
+ * in sql-database.ts).
  */
-function instrumentStatement(
-  stmt: D1PreparedStatement,
-  metrics: RequestMetrics
-): D1PreparedStatement {
-  const wrapper = {
-    bind(...values: unknown[]): D1PreparedStatement {
+function instrumentStatement(stmt: SqlStatement, metrics: RequestMetrics): SqlStatement {
+  const wrapper: WrappedStatement = {
+    bind(...values: unknown[]): SqlStatement {
       return instrumentStatement(stmt.bind(...values), metrics);
     },
 
-    async first<T = unknown>(colName?: string): Promise<T | null> {
+    async first<T = Record<string, unknown>>(): Promise<T | null> {
       const start = Date.now();
-      const result = colName
-        ? await (stmt.first as (col: string) => Promise<unknown>)(colName)
-        : await stmt.first<T>();
+      const result = await stmt.first<T>();
       metrics.d1Queries.push({ query_ms: Date.now() - start });
-      return result as T | null;
+      return result;
     },
 
-    async run<T = Record<string, unknown>>(): Promise<D1Result<T>> {
+    async run<T = Record<string, unknown>>(): Promise<SqlResult<T>> {
       const start = Date.now();
       const result = await stmt.run<T>();
       metrics.d1Queries.push({
@@ -148,7 +139,7 @@ function instrumentStatement(
       return result;
     },
 
-    async all<T = Record<string, unknown>>(): Promise<D1Result<T>> {
+    async all<T = Record<string, unknown>>(): Promise<SqlResult<T>> {
       const start = Date.now();
       const result = await stmt.all<T>();
       metrics.d1Queries.push({
@@ -159,41 +150,30 @@ function instrumentStatement(
       });
       return result;
     },
-
-    async raw(options?: Record<string, unknown>) {
-      const start = Date.now();
-      if (!hasRawMethod(stmt)) {
-        throw new Error("D1PreparedStatement.raw() is not available in this runtime");
-      }
-      const result = await stmt.raw(options);
-      metrics.d1Queries.push({ query_ms: Date.now() - start });
-      return result;
-    },
-  } as D1PreparedStatement as WrappedStatement;
+  };
 
   wrapper[ORIGINAL_STMT] = stmt;
   return wrapper;
 }
 
 // ---------------------------------------------------------------------------
-// D1 database wrapper
+// Database wrapper
 // ---------------------------------------------------------------------------
 
 /**
- * Wrap a D1Database to automatically record timing for all queries.
+ * Wrap a SqlDatabase to automatically record timing for all queries.
  *
- * Uses object composition for type safety and simplicity. The stores
- * (SessionIndexStore, RepoMetadataStore, etc.) accept the SqlDatabase port
- * in their constructor — passing an instrumented DB means all their queries
- * are timed without any changes to the store code.
+ * Uses object composition: the stores accept the SqlDatabase port in their
+ * constructor — passing an instrumented DB means all their queries are timed
+ * without any changes to the store code.
  */
-export function instrumentD1(db: D1Database, metrics: RequestMetrics): D1Database {
+export function instrumentD1(db: SqlDatabase, metrics: RequestMetrics): SqlDatabase {
   return {
-    prepare(query: string): D1PreparedStatement {
+    prepare(query: string): SqlStatement {
       return instrumentStatement(db.prepare(query), metrics);
     },
 
-    async batch<T = unknown>(statements: D1PreparedStatement[]): Promise<D1Result<T>[]> {
+    async batch<T = unknown>(statements: SqlStatement[]): Promise<SqlResult<T>[]> {
       const start = Date.now();
       const results = await db.batch<T>(statements.map(unwrapStatement));
       const elapsed = Date.now() - start;
@@ -216,13 +196,5 @@ export function instrumentD1(db: D1Database, metrics: RequestMetrics): D1Databas
 
       return results;
     },
-
-    exec(query: string): Promise<D1ExecResult> {
-      return db.exec(query);
-    },
-
-    dump(): Promise<ArrayBuffer> {
-      return db.dump();
-    },
-  } as D1Database;
+  };
 }

--- a/packages/control-plane/src/db/sql-database.ts
+++ b/packages/control-plane/src/db/sql-database.ts
@@ -29,6 +29,15 @@ export interface SqlResultMeta {
    * affected-row counts (0 for reads).
    */
   changes: number;
+
+  /**
+   * Optional observability metadata, read only by query instrumentation
+   * (instrumented-d1.ts). Engines may omit these; consumers must never gate
+   * correctness on them — `changes` is the only required field.
+   */
+  duration?: number;
+  rows_read?: number;
+  rows_written?: number;
 }
 
 export interface SqlResult<T = unknown> {

--- a/packages/control-plane/src/image-builds/planner.ts
+++ b/packages/control-plane/src/image-builds/planner.ts
@@ -2,6 +2,7 @@ import { resolveBuildTimeoutSeconds } from "@open-inspect/shared";
 import { createLogger, type CorrelationContext } from "../logger";
 import { createSourceControlProviderFromEnv } from "../source-control";
 import type { Env } from "../types";
+import type { SqlDatabase } from "../db/sql-database";
 import {
   generateImageBuildCallbackToken,
   hashImageBuildCallbackToken,
@@ -42,11 +43,12 @@ export type { ResolvedImageBuildTarget } from "./scope";
 export class ImageBuildPlanner {
   constructor(
     private readonly env: Env,
+    private readonly db: SqlDatabase,
     private readonly provider: ImageBuildProvider
   ) {}
 
   async resolveTarget(scope: ImageBuildScope): Promise<ResolvedImageBuildTarget> {
-    return resolveScopeTarget(this.env, scope);
+    return resolveScopeTarget(this.env, this.db, scope);
   }
 
   async createCallbackAuth(): Promise<PlannedCallbackAuth> {
@@ -77,8 +79,8 @@ export class ImageBuildPlanner {
     const callbackAuth = params.callbackAuth;
 
     const [sandboxSettings, userEnvVars, cloneAuth] = await Promise.all([
-      resolveScopeSandboxSettings(this.env.DB, params.scope, primary),
-      loadScopeBuildSecrets(this.env, params.scope, params.target),
+      resolveScopeSandboxSettings(this.db, params.scope, primary),
+      loadScopeBuildSecrets(this.env, this.db, params.scope, params.target),
       this.resolveCloneAuth(params.scope),
     ]);
 

--- a/packages/control-plane/src/image-builds/save-hooks.ts
+++ b/packages/control-plane/src/image-builds/save-hooks.ts
@@ -32,7 +32,7 @@ export function scheduleImageBuildOnSave(
 ): void {
   if (!resolveImageBuildProvider(env.SANDBOX_PROVIDER)) return;
 
-  const task = createImageBuildWorkflowFromEnv(env)
+  const task = createImageBuildWorkflowFromEnv(env, ctx.db)
     .triggerBuildIfStale(scope, { request_id: ctx.request_id, trace_id: ctx.trace_id })
     .then((result) => {
       logger.info("image_build.save_hook_trigger", {
@@ -67,11 +67,10 @@ export function scheduleImageBuildOnSave(
  * blocked, never stale.
  */
 export async function supersedeImageBuildsForSecretsChange(
-  env: Env,
   scope: ImageBuildScope,
   ctx: RequestContext
 ): Promise<void> {
-  const superseded = await new ImageBuildStore(env.DB).supersedeActiveImages(scope);
+  const superseded = await new ImageBuildStore(ctx.db).supersedeActiveImages(scope);
   if (superseded > 0) {
     logger.info("image_build.secrets_change_superseded", {
       scope_kind: scope.kind,

--- a/packages/control-plane/src/image-builds/scope.test.ts
+++ b/packages/control-plane/src/image-builds/scope.test.ts
@@ -132,7 +132,7 @@ describe("resolveScopeTarget", () => {
       ],
     });
 
-    const target = await resolveScopeTarget(envWith(db), ENV_SCOPE);
+    const target = await resolveScopeTarget(envWith(db), db, ENV_SCOPE);
 
     expect(target.repositories).toEqual([
       { repoOwner: "acme", repoName: "web", baseBranch: "main" },
@@ -149,7 +149,7 @@ describe("resolveScopeTarget", () => {
   it("throws scope-not-found for a missing environment", async () => {
     const db = fakeDb({ environment: null });
 
-    await expect(resolveScopeTarget(envWith(db), ENV_SCOPE)).rejects.toBeInstanceOf(
+    await expect(resolveScopeTarget(envWith(db), db, ENV_SCOPE)).rejects.toBeInstanceOf(
       ImageBuildScopeNotFoundError
     );
   });
@@ -157,7 +157,7 @@ describe("resolveScopeTarget", () => {
   it("fails planning on an environment without repositories", async () => {
     const db = fakeDb({ environment: { id: "env_1" }, repositories: [] });
 
-    await expect(resolveScopeTarget(envWith(db), ENV_SCOPE)).rejects.toBeInstanceOf(
+    await expect(resolveScopeTarget(envWith(db), db, ENV_SCOPE)).rejects.toBeInstanceOf(
       ImageBuildPlanningError
     );
   });
@@ -170,7 +170,7 @@ describe("resolveScopeTarget", () => {
       defaultBranch: "develop",
     });
 
-    const target = await resolveScopeTarget(envWith(fakeDb({})), REPO_SCOPE);
+    const target = await resolveScopeTarget(envWith(fakeDb({})), fakeDb({}), REPO_SCOPE);
 
     expect(scmProvider.checkRepositoryAccess).toHaveBeenCalledWith({
       owner: "acme",
@@ -197,6 +197,7 @@ describe("resolveScopeTarget", () => {
 
     const target = await resolveScopeTarget(
       envWith(fakeDb({})),
+      fakeDb({}),
       repoImageBuildScope("group/subgroup", "web")
     );
 
@@ -212,22 +213,22 @@ describe("resolveScopeTarget", () => {
   it("throws scope-not-found when the repository is not installed", async () => {
     scmProvider.checkRepositoryAccess.mockResolvedValue(null);
 
-    await expect(resolveScopeTarget(envWith(fakeDb({})), REPO_SCOPE)).rejects.toBeInstanceOf(
-      ImageBuildScopeNotFoundError
-    );
+    await expect(
+      resolveScopeTarget(envWith(fakeDb({})), fakeDb({}), REPO_SCOPE)
+    ).rejects.toBeInstanceOf(ImageBuildScopeNotFoundError);
   });
 
   it("fails planning when repository resolution fails", async () => {
     scmProvider.checkRepositoryAccess.mockRejectedValue(new Error("github unavailable"));
 
-    await expect(resolveScopeTarget(envWith(fakeDb({})), REPO_SCOPE)).rejects.toBeInstanceOf(
-      ImageBuildPlanningError
-    );
+    await expect(
+      resolveScopeTarget(envWith(fakeDb({})), fakeDb({}), REPO_SCOPE)
+    ).rejects.toBeInstanceOf(ImageBuildPlanningError);
   });
 
   it("fails planning on a malformed repo scope id without touching source control", async () => {
     await expect(
-      resolveScopeTarget(envWith(fakeDb({})), { kind: "repo", id: "not-a-pair" })
+      resolveScopeTarget(envWith(fakeDb({})), fakeDb({}), { kind: "repo", id: "not-a-pair" })
     ).rejects.toBeInstanceOf(ImageBuildPlanningError);
     expect(scmProvider.checkRepositoryAccess).not.toHaveBeenCalled();
   });
@@ -302,7 +303,7 @@ describe("listEnabledScopeUnits", () => {
       enabledRepos: [{ repo_owner: "acme", repo_name: "web" }],
     });
 
-    const units = await listEnabledScopeUnits(envWith(db));
+    const units = await listEnabledScopeUnits(envWith(db), db);
 
     expect(units).toHaveLength(2);
     expect(units[0].scope).toEqual({ kind: "environment", id: "env_1" });
@@ -323,7 +324,7 @@ describe("listEnabledScopeUnits", () => {
       enabledRepos: [{ repo_owner: "acme", repo_name: "web" }],
     });
 
-    const units = await listEnabledScopeUnits(envWith(db));
+    const units = await listEnabledScopeUnits(envWith(db), db);
 
     expect(units.map((unit) => unit.scope.kind)).toEqual(["environment"]);
   });
@@ -356,9 +357,9 @@ describe("loadScopeBuildSecrets", () => {
   const encryptedEnv = (db: D1Database) => envWith(db, { REPO_SECRETS_ENCRYPTION_KEY: "key" });
 
   it("returns undefined without an encryption key", async () => {
-    expect(await loadScopeBuildSecrets(envWith(fakeDb({})), REPO_SCOPE, repoTarget())).toBe(
-      undefined
-    );
+    expect(
+      await loadScopeBuildSecrets(envWith(fakeDb({})), fakeDb({}), REPO_SCOPE, repoTarget())
+    ).toBe(undefined);
     expect(secretsStores.global).not.toHaveBeenCalled();
   });
 
@@ -366,7 +367,7 @@ describe("loadScopeBuildSecrets", () => {
     secretsStores.global.mockResolvedValue({ SHARED: "global", GLOBAL_ONLY: "g" });
     secretsStores.environment.mockResolvedValue({ SHARED: "environment" });
 
-    const merged = await loadScopeBuildSecrets(encryptedEnv(fakeDb({})), ENV_SCOPE, {
+    const merged = await loadScopeBuildSecrets(encryptedEnv(fakeDb({})), fakeDb({}), ENV_SCOPE, {
       kind: "environment",
       repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
       repositoriesFingerprint: "fp-env",
@@ -381,7 +382,12 @@ describe("loadScopeBuildSecrets", () => {
     secretsStores.global.mockResolvedValue({ SHARED: "global", GLOBAL_ONLY: "g" });
     secretsStores.repo.mockResolvedValue({ SHARED: "repo", REPO_ONLY: "r" });
 
-    const merged = await loadScopeBuildSecrets(encryptedEnv(fakeDb({})), REPO_SCOPE, repoTarget());
+    const merged = await loadScopeBuildSecrets(
+      encryptedEnv(fakeDb({})),
+      fakeDb({}),
+      REPO_SCOPE,
+      repoTarget()
+    );
 
     expect(secretsStores.repo).toHaveBeenCalledWith(123);
     expect(secretsStores.environment).not.toHaveBeenCalled();
@@ -392,14 +398,19 @@ describe("loadScopeBuildSecrets", () => {
     secretsStores.global.mockResolvedValue({ GLOBAL_ONLY: "g" });
     secretsStores.repo.mockRejectedValue(new Error("decrypt failed"));
 
-    const merged = await loadScopeBuildSecrets(encryptedEnv(fakeDb({})), REPO_SCOPE, repoTarget());
+    const merged = await loadScopeBuildSecrets(
+      encryptedEnv(fakeDb({})),
+      fakeDb({}),
+      REPO_SCOPE,
+      repoTarget()
+    );
 
     expect(merged).toEqual({ GLOBAL_ONLY: "g" });
   });
 
   it("returns undefined when the fold is empty", async () => {
-    expect(await loadScopeBuildSecrets(encryptedEnv(fakeDb({})), REPO_SCOPE, repoTarget())).toBe(
-      undefined
-    );
+    expect(
+      await loadScopeBuildSecrets(encryptedEnv(fakeDb({})), fakeDb({}), REPO_SCOPE, repoTarget())
+    ).toBe(undefined);
   });
 });

--- a/packages/control-plane/src/image-builds/scope.ts
+++ b/packages/control-plane/src/image-builds/scope.ts
@@ -70,11 +70,12 @@ export interface EnabledScopeUnit {
 /** The scope's buildable repository set, in position order ([0] = primary). */
 export async function resolveScopeTarget(
   env: Env,
+  db: SqlDatabase,
   scope: ImageBuildScope
 ): Promise<ResolvedImageBuildTarget> {
   switch (scope.kind) {
     case "environment": {
-      const store = new EnvironmentStore(env.DB);
+      const store = new EnvironmentStore(db);
       const environment = await store.getById(scope.id);
       if (!environment) {
         throw new ImageBuildScopeNotFoundError(scope.kind, scope.id);
@@ -197,8 +198,11 @@ export async function listEnabledScopes(db: SqlDatabase): Promise<ImageBuildScop
  * cannot be resolved (uninstalled, source-control outage) is skipped with a
  * warning rather than failing the whole feed.
  */
-export async function listEnabledScopeUnits(env: Env): Promise<EnabledScopeUnit[]> {
-  const store = new EnvironmentStore(env.DB);
+export async function listEnabledScopeUnits(
+  env: Env,
+  db: SqlDatabase
+): Promise<EnabledScopeUnit[]> {
+  const store = new EnvironmentStore(db);
   const { environments } = await store.list();
   const enabled = environments.filter((row) => row.prebuild_enabled === 1);
   const repositoriesById = await store.getRepositoriesForEnvironmentIds(
@@ -220,12 +224,12 @@ export async function listEnabledScopeUnits(env: Env): Promise<EnabledScopeUnit[
     })
   );
 
-  const enabledRepos = await new RepoMetadataStore(env.DB).getImageBuildEnabledRepos();
+  const enabledRepos = await new RepoMetadataStore(db).getImageBuildEnabledRepos();
   const repoUnits = await Promise.all(
     enabledRepos.map(async (repo): Promise<EnabledScopeUnit | null> => {
       const scope = repoImageBuildScope(repo.repoOwner, repo.repoName);
       try {
-        const target = await resolveScopeTarget(env, scope);
+        const target = await resolveScopeTarget(env, db, scope);
         return {
           scope,
           repositories: target.repositories,
@@ -273,13 +277,14 @@ export async function resolveScopeSandboxSettings(
  */
 export async function loadScopeBuildSecrets(
   env: Env,
+  db: SqlDatabase,
   scope: ImageBuildScope,
   target: ResolvedImageBuildTarget
 ): Promise<Record<string, string> | undefined> {
   if (!env.REPO_SECRETS_ENCRYPTION_KEY) return undefined;
 
   const { sources, counts } = await loadScopeSecretSources(
-    env,
+    db,
     scope,
     target,
     env.REPO_SECRETS_ENCRYPTION_KEY
@@ -308,14 +313,14 @@ export async function loadScopeBuildSecrets(
 }
 
 async function loadScopeSecretSources(
-  env: Env,
+  db: SqlDatabase,
   scope: ImageBuildScope,
   target: ResolvedImageBuildTarget,
   encryptionKey: string
 ): Promise<{ sources: SecretSource[]; counts: Record<string, number> }> {
   let globalSecrets: Record<string, string> = {};
   try {
-    globalSecrets = await new GlobalSecretsStore(env.DB, encryptionKey).getDecryptedSecrets();
+    globalSecrets = await new GlobalSecretsStore(db, encryptionKey).getDecryptedSecrets();
   } catch (e) {
     logger.warn("image_build.global_secrets_failed", {
       error: errorMessage(e),
@@ -329,7 +334,7 @@ async function loadScopeSecretSources(
       let environmentSecrets: Record<string, string> = {};
       try {
         environmentSecrets = await new EnvironmentSecretsStore(
-          env.DB,
+          db,
           encryptionKey
         ).getDecryptedSecrets(scope.id);
       } catch (e) {
@@ -353,7 +358,7 @@ async function loadScopeSecretSources(
     case "repo": {
       let repoSecrets: Record<string, string> = {};
       try {
-        repoSecrets = await new RepoSecretsStore(env.DB, encryptionKey).getDecryptedSecrets(
+        repoSecrets = await new RepoSecretsStore(db, encryptionKey).getDecryptedSecrets(
           target.repoId
         );
       } catch (e) {

--- a/packages/control-plane/src/image-builds/workflow.test.ts
+++ b/packages/control-plane/src/image-builds/workflow.test.ts
@@ -132,14 +132,15 @@ function createWorkflow(options: {
     });
   const createCallbackAuth =
     options.createCallbackAuth ?? vi.fn().mockResolvedValue({ kind: "none" });
+  const provider = options.provider === undefined ? "modal" : options.provider;
+  const planner = { planBuild, resolveTarget, createCallbackAuth } as unknown as NonNullable<
+    ConstructorParameters<typeof ImageBuildWorkflow>[3]
+  >["planner"];
   const workflow = new ImageBuildWorkflow(
     options.env ?? createEnv(),
     store as unknown as ImageBuildStore,
     factory,
-    options.provider === undefined ? "modal" : options.provider,
-    { planBuild, resolveTarget, createCallbackAuth } as unknown as ConstructorParameters<
-      typeof ImageBuildWorkflow
-    >[4]
+    provider ? { provider, planner } : null
   );
   return { workflow, store, adapter, factory, planBuild, resolveTarget, createCallbackAuth };
 }
@@ -304,15 +305,19 @@ describe("ImageBuildWorkflow", () => {
         createEnv(),
         store as unknown as ImageBuildStore,
         { create: factoryError },
-        "modal",
         {
-          planBuild: vi.fn(),
-          resolveTarget: vi.fn().mockResolvedValue({
-            repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
-            repositoriesFingerprint: "fp-1",
-          }),
-          createCallbackAuth: vi.fn().mockResolvedValue({ kind: "none" }),
-        } as unknown as ConstructorParameters<typeof ImageBuildWorkflow>[4]
+          provider: "modal",
+          planner: {
+            planBuild: vi.fn(),
+            resolveTarget: vi.fn().mockResolvedValue({
+              repositories: [{ repoOwner: "acme", repoName: "web", baseBranch: "main" }],
+              repositoriesFingerprint: "fp-1",
+            }),
+            createCallbackAuth: vi.fn().mockResolvedValue({ kind: "none" }),
+          } as unknown as NonNullable<
+            ConstructorParameters<typeof ImageBuildWorkflow>[3]
+          >["planner"],
+        }
       );
 
       await expect(workflow.triggerBuild(ENV_SCOPE, ctx)).rejects.toMatchObject({

--- a/packages/control-plane/src/image-builds/workflow.ts
+++ b/packages/control-plane/src/image-builds/workflow.ts
@@ -82,6 +82,17 @@ type PlannedBuildStart = {
 };
 
 /**
+ * A configured image-build provider always travels with its planner — the
+ * pair is either supplied together or the workflow is unconfigured. Encoding
+ * the pairing here makes the invalid provider-without-planner state
+ * unconstructible.
+ */
+export type ImageBuildProviderDeps = {
+  provider: ImageBuildProvider;
+  planner: ImageBuildPlannerLike;
+} | null;
+
+/**
  * Application service for the image-build lifecycle.
  *
  * Sequences planning, provider adapter calls, callback authorization, store
@@ -93,17 +104,14 @@ type PlannedBuildStart = {
  * subclasses for route-level error mapping.
  */
 export class ImageBuildWorkflow {
-  private readonly planner: ImageBuildPlannerLike | null;
   private readonly reaper: ImageBuildReaper;
 
   constructor(
     private readonly env: Env,
     private readonly store: ImageBuildStore,
     private readonly adapterFactory: ImageBuildAdapterFactory,
-    private readonly provider: ImageBuildProvider | null,
-    planner?: ImageBuildPlannerLike
+    private readonly providerDeps: ImageBuildProviderDeps
   ) {
-    this.planner = planner ?? null;
     this.reaper = new ImageBuildReaper(store, adapterFactory);
   }
 
@@ -172,14 +180,14 @@ export class ImageBuildWorkflow {
     ctx: ImageBuildWorkflowContext,
     options: { onlyIfStale: boolean }
   ): Promise<TriggerImageBuildResult> {
-    if (!this.provider || !this.planner) {
+    if (!this.providerDeps) {
       throw new ImageBuildWorkflowUnavailableError("Image build provider is not configured");
     }
     if (!this.env.WORKER_URL) {
       throw new ImageBuildWorkflowUnavailableError("WORKER_URL not configured");
     }
 
-    const provider = this.provider;
+    const { provider, planner } = this.providerDeps;
     await this.failStaleScopeBuild(scope, provider, ctx);
 
     const active = await this.store.getActiveBuild(scope, provider);
@@ -197,7 +205,7 @@ export class ImageBuildWorkflow {
     let target;
     let callbackAuth;
     try {
-      target = await this.planner.resolveTarget(scope);
+      target = await planner.resolveTarget(scope);
 
       if (
         options.onlyIfStale &&
@@ -213,7 +221,7 @@ export class ImageBuildWorkflow {
       // Probe the adapter now so a misconfigured provider fails 503 without
       // writing a failed row on every cron tick.
       this.createAdapterForOperation(provider, "trigger_build", ctx, buildId);
-      callbackAuth = await this.planner.createCallbackAuth();
+      callbackAuth = await planner.createCallbackAuth();
     } catch (e) {
       if (
         e instanceof ImageBuildScopeNotFoundError ||
@@ -254,7 +262,7 @@ export class ImageBuildWorkflow {
         return { type: "already_building", buildId: winner.id };
       }
 
-      const planned = await this.planner.planBuild({
+      const planned = await planner.planBuild({
         buildId,
         scope,
         callbackUrl,
@@ -1014,8 +1022,7 @@ export function createImageBuildWorkflowFromEnv(env: Env, db: SqlDatabase): Imag
     env,
     new ImageBuildStore(db),
     createImageBuildAdapterFactory(env),
-    provider,
-    provider ? new ImageBuildPlanner(env, db, provider) : undefined
+    provider ? { provider, planner: new ImageBuildPlanner(env, db, provider) } : null
   );
 }
 

--- a/packages/control-plane/src/image-builds/workflow.ts
+++ b/packages/control-plane/src/image-builds/workflow.ts
@@ -2,6 +2,7 @@ import { generateId } from "../auth/crypto";
 import { ImageBuildStore, type ImageBuildRegistration } from "../db/image-builds";
 import { createLogger } from "../logger";
 import type { Env } from "../types";
+import type { SqlDatabase } from "../db/sql-database";
 import {
   consumeImageBuildCallbackTokenOrThrow,
   ImageBuildCallbackAuthError,
@@ -102,7 +103,7 @@ export class ImageBuildWorkflow {
     private readonly provider: ImageBuildProvider | null,
     planner?: ImageBuildPlannerLike
   ) {
-    this.planner = planner ?? (provider ? new ImageBuildPlanner(env, provider) : null);
+    this.planner = planner ?? null;
     this.reaper = new ImageBuildReaper(store, adapterFactory);
   }
 
@@ -1007,12 +1008,14 @@ export class ImageBuildWorkflow {
   }
 }
 
-export function createImageBuildWorkflowFromEnv(env: Env): ImageBuildWorkflow {
+export function createImageBuildWorkflowFromEnv(env: Env, db: SqlDatabase): ImageBuildWorkflow {
+  const provider = resolveImageBuildProvider(env.SANDBOX_PROVIDER);
   return new ImageBuildWorkflow(
     env,
-    new ImageBuildStore(env.DB),
+    new ImageBuildStore(db),
     createImageBuildAdapterFactory(env),
-    resolveImageBuildProvider(env.SANDBOX_PROVIDER)
+    provider,
+    provider ? new ImageBuildPlanner(env, db, provider) : undefined
   );
 }
 

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -359,17 +359,20 @@ export async function handleRequest(
   const method = request.method;
   const startTime = Date.now();
 
-  // Build correlation context with per-request metrics
+  // Build correlation context with per-request metrics and the instrumented
+  // database handle. Handlers use ctx.db (never env.DB) so all queries are
+  // automatically timed.
   const metrics = createRequestMetrics();
   const ctx: RequestContext = {
     trace_id: request.headers.get("x-trace-id") || crypto.randomUUID(),
     request_id: crypto.randomUUID().slice(0, 8),
     metrics,
+    // env.DB is typed required but some handlers guard its runtime absence
+    // (deployment misconfiguration) with degraded responses. The && preserves
+    // that observable truthiness: ctx.db is undefined exactly when env.DB is.
+    db: env.DB && instrumentD1(env.DB, metrics),
     executionCtx,
   };
-
-  // Instrument D1 so all queries are automatically timed
-  const instrumentedEnv: Env = { ...env, DB: instrumentD1(env.DB, metrics) };
 
   // CORS preflight
   if (method === "OPTIONS") {
@@ -438,7 +441,7 @@ export async function handleRequest(
       let response: Response;
       let outcome: "success" | "error";
       try {
-        response = await route.handler(request, instrumentedEnv, match, ctx);
+        response = await route.handler(request, env, match, ctx);
         outcome = response.status >= 500 ? "error" : "success";
       } catch (e) {
         if (e instanceof HttpError) {

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -359,6 +359,19 @@ export async function handleRequest(
   const method = request.method;
   const startTime = Date.now();
 
+  // The DB binding is required (types.ts) and the control plane cannot serve
+  // requests without it. Reject a missing binding once here — the single
+  // honest boundary — so ctx.db is genuinely always present in handlers and
+  // no per-route degraded-mode guards are needed.
+  // eslint-disable-next-line no-restricted-syntax -- composition root: the one route-layer env.DB read
+  if (!env.DB) {
+    logger.error("DB binding is not configured; refusing request", { http_path: path });
+    return new Response(JSON.stringify({ error: "Database not configured" }), {
+      status: 503,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   // Build correlation context with per-request metrics and the instrumented
   // database handle. Handlers use ctx.db (never env.DB) so all queries are
   // automatically timed.
@@ -367,10 +380,8 @@ export async function handleRequest(
     trace_id: request.headers.get("x-trace-id") || crypto.randomUUID(),
     request_id: crypto.randomUUID().slice(0, 8),
     metrics,
-    // env.DB is typed required but some handlers guard its runtime absence
-    // (deployment misconfiguration) with degraded responses. The && preserves
-    // that observable truthiness: ctx.db is undefined exactly when env.DB is.
-    db: env.DB && instrumentD1(env.DB, metrics),
+    // eslint-disable-next-line no-restricted-syntax -- composition root: the one route-layer env.DB read
+    db: instrumentD1(env.DB, metrics),
     executionCtx,
   };
 

--- a/packages/control-plane/src/routes/analytics.test.ts
+++ b/packages/control-plane/src/routes/analytics.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { analyticsRoutes } from "./analytics";
 import { HUMAN_SPAWN_SOURCES } from "../db/analytics-store";
 import type { RequestContext } from "./shared";
+import type { SqlDatabase } from "../db/sql-database";
 import type { Env } from "../types";
 
 const FIXED_NOW = 1_700_000_000_000;
@@ -44,6 +45,7 @@ function createCtx(): RequestContext {
   return {
     trace_id: "trace-1",
     request_id: "req-1",
+    db: {} as SqlDatabase,
     metrics: {
       d1Queries: [],
       spans: {},

--- a/packages/control-plane/src/routes/analytics.ts
+++ b/packages/control-plane/src/routes/analytics.ts
@@ -46,7 +46,7 @@ async function handleSummary(
   request: Request,
   env: Env,
   _match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const url = new URL(request.url);
   const days = parseDaysParam(url.searchParams.get("days"));
@@ -54,7 +54,7 @@ async function handleSummary(
     return error(`days must be one of: ${ANALYTICS_DAYS.join(", ")}`, 400);
   }
 
-  const store = new AnalyticsStore(env.DB);
+  const store = new AnalyticsStore(ctx.db);
   return json(await store.getSummary(getFilters(days)));
 }
 
@@ -62,7 +62,7 @@ async function handleTimeseries(
   request: Request,
   env: Env,
   _match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const url = new URL(request.url);
   const days = parseDaysParam(url.searchParams.get("days"));
@@ -70,7 +70,7 @@ async function handleTimeseries(
     return error(`days must be one of: ${ANALYTICS_DAYS.join(", ")}`, 400);
   }
 
-  const store = new AnalyticsStore(env.DB);
+  const store = new AnalyticsStore(ctx.db);
   return json(await store.getTimeseries(getFilters(days)));
 }
 
@@ -78,7 +78,7 @@ async function handleBreakdown(
   request: Request,
   env: Env,
   _match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const url = new URL(request.url);
   const days = parseDaysParam(url.searchParams.get("days"));
@@ -92,7 +92,7 @@ async function handleBreakdown(
     return error(`by must be one of: ${ANALYTICS_BREAKDOWN_BY.join(", ")}`, 400);
   }
 
-  const store = new AnalyticsStore(env.DB);
+  const store = new AnalyticsStore(ctx.db);
   return json(await store.getBreakdown(getFilters(days), by));
 }
 
@@ -100,7 +100,7 @@ async function handlePullRequests(
   request: Request,
   env: Env,
   _match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const url = new URL(request.url);
   const days = parseDaysParam(url.searchParams.get("days"));
@@ -108,7 +108,7 @@ async function handlePullRequests(
     return error(`days must be one of: ${ANALYTICS_DAYS.join(", ")}`, 400);
   }
 
-  const store = new PullRequestAnalyticsStore(env.DB);
+  const store = new PullRequestAnalyticsStore(ctx.db);
   return json(await store.get(getPullRequestFilters(days)));
 }
 

--- a/packages/control-plane/src/routes/automations.test.ts
+++ b/packages/control-plane/src/routes/automations.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { automationRoutes } from "./automations";
 import { HttpError, resolveRepoOrError, type RequestContext } from "./shared";
+import type { SqlDatabase } from "../db/sql-database";
 import type { Env } from "../types";
 
 // ─── Mocks ──────────────────────────────────────────────────────────────────
@@ -117,6 +118,7 @@ function createCtx(): RequestContext {
   return {
     trace_id: "trace-1",
     request_id: "req-1",
+    db: { batch: mockBatch } as unknown as SqlDatabase,
     metrics: {
       d1Queries: [],
       spans: {},

--- a/packages/control-plane/src/routes/automations.ts
+++ b/packages/control-plane/src/routes/automations.ts
@@ -175,9 +175,12 @@ function parseEnvironmentSelection(body: {
  *
  * @throws TargetSelectionError naming every missing environment.
  */
-async function resolveEnvironmentSelection(env: Env, environmentIds: string[]): Promise<void> {
+async function resolveEnvironmentSelection(
+  db: SqlDatabase,
+  environmentIds: string[]
+): Promise<void> {
   if (environmentIds.length === 0) return;
-  const store = new EnvironmentStore(env.DB);
+  const store = new EnvironmentStore(db);
   const found = await Promise.all(environmentIds.map((id) => store.getById(id)));
   const missing = environmentIds.filter((_, index) => !found[index]);
   if (missing.length > 0) {
@@ -266,13 +269,13 @@ async function handleListAutomations(
   request: Request,
   env: Env,
   _match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const url = new URL(request.url);
   const repoOwner = url.searchParams.get("repoOwner") ?? undefined;
   const repoName = url.searchParams.get("repoName") ?? undefined;
 
-  const store = new AutomationStore(env.DB);
+  const store = new AutomationStore(ctx.db);
   const result = await store.list({ repoOwner, repoName });
   const automationIds = result.automations.map((row) => row.id);
   const [repositoriesByAutomation, environmentsByAutomation] = await Promise.all([
@@ -347,7 +350,7 @@ async function handleCreateAutomation(
     requestedEnvironmentIds =
       environmentSelection.kind === "replace" ? environmentSelection.environmentIds : [];
     validateTargetCounts(triggerType, requestedRepositories.length, requestedEnvironmentIds.length);
-    await resolveEnvironmentSelection(env, requestedEnvironmentIds);
+    await resolveEnvironmentSelection(ctx.db, requestedEnvironmentIds);
   } catch (e) {
     if (e instanceof TargetSelectionError) return error(e.message, 400);
     throw e;
@@ -447,7 +450,7 @@ async function handleCreateAutomation(
   const providerIdentity = resolveProviderIdentity("user", body);
   if (providerIdentity) {
     try {
-      const userStore = new UserStore(env.DB);
+      const userStore = new UserStore(ctx.db);
       const resolvedUser = await userStore.resolveOrCreateUser(providerIdentity);
       resolvedUserId = resolvedUser.id;
     } catch (e) {
@@ -459,7 +462,7 @@ async function handleCreateAutomation(
     }
   }
 
-  const db: SqlDatabase = env.DB;
+  const db: SqlDatabase = ctx.db;
   const store = new AutomationStore(db);
   const row: AutomationRow = {
     id,
@@ -545,12 +548,12 @@ async function handleGetAutomation(
   _request: Request,
   env: Env,
   match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const id = match.groups?.id;
   if (!id) return error("Automation ID required", 400);
 
-  const store = new AutomationStore(env.DB);
+  const store = new AutomationStore(ctx.db);
   const row = await store.getById(id);
   if (!row) return error("Automation not found", 404);
 
@@ -572,7 +575,7 @@ async function handleUpdateAutomation(
   const id = match.groups?.id;
   if (!id) return error("Automation ID required", 400);
 
-  const db: SqlDatabase = env.DB;
+  const db: SqlDatabase = ctx.db;
   const store = new AutomationStore(db);
   const existing = await store.getById(id);
   if (!existing) return error("Automation not found", 404);
@@ -689,7 +692,7 @@ async function handleUpdateAutomation(
         finalEnvironmentCount
       );
       if (replacementEnvironmentIds !== null) {
-        await resolveEnvironmentSelection(env, replacementEnvironmentIds);
+        await resolveEnvironmentSelection(ctx.db, replacementEnvironmentIds);
       }
     } catch (e) {
       if (e instanceof TargetSelectionError) return error(e.message, 400);
@@ -824,7 +827,7 @@ async function handleDeleteAutomation(
   const id = match.groups?.id;
   if (!id) return error("Automation ID required", 400);
 
-  const store = new AutomationStore(env.DB);
+  const store = new AutomationStore(ctx.db);
   const deleted = await store.softDelete(id);
   if (!deleted) return error("Automation not found", 404);
 
@@ -847,7 +850,7 @@ async function handlePauseAutomation(
   const id = match.groups?.id;
   if (!id) return error("Automation ID required", 400);
 
-  const store = new AutomationStore(env.DB);
+  const store = new AutomationStore(ctx.db);
   const paused = await store.pause(id);
   if (!paused) return error("Automation not found", 404);
 
@@ -879,7 +882,7 @@ async function handleResumeAutomation(
   const id = match.groups?.id;
   if (!id) return error("Automation ID required", 400);
 
-  const store = new AutomationStore(env.DB);
+  const store = new AutomationStore(ctx.db);
   const existing = await store.getById(id);
   if (!existing) return error("Automation not found", 404);
 
@@ -927,7 +930,7 @@ async function handleTriggerAutomation(
   const id = match.groups?.id;
   if (!id) return error("Automation ID required", 400);
 
-  const store = new AutomationStore(env.DB);
+  const store = new AutomationStore(ctx.db);
   const automation = await store.getById(id);
   if (!automation) return error("Automation not found", 404);
 
@@ -986,12 +989,12 @@ async function handleListInvocations(
   request: Request,
   env: Env,
   match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const automationId = match.groups?.id;
   if (!automationId) return error("Automation ID required", 400);
 
-  const store = new AutomationStore(env.DB);
+  const store = new AutomationStore(ctx.db);
   const automation = await store.getById(automationId);
   if (!automation) return error("Automation not found", 404);
 
@@ -1008,13 +1011,13 @@ async function handleGetRun(
   _request: Request,
   env: Env,
   match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const automationId = match.groups?.id;
   const runId = match.groups?.runId;
   if (!automationId || !runId) return error("Automation ID and Run ID required", 400);
 
-  const store = new AutomationStore(env.DB);
+  const store = new AutomationStore(ctx.db);
   const run = await store.getRunById(automationId, runId);
   if (!run) return error("Run not found", 404);
 
@@ -1030,7 +1033,7 @@ async function handleRegenerateKey(
   const id = match.groups?.id;
   if (!id) return error("Automation ID required", 400);
 
-  const store = new AutomationStore(env.DB);
+  const store = new AutomationStore(ctx.db);
   const automation = await store.getById(id);
   if (!automation) return error("Automation not found", 404);
 
@@ -1103,9 +1106,9 @@ async function handleGetWatchedSlackChannels(
   _request: Request,
   env: Env,
   _match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
-  const channels = await new SlackChannelStore(env.DB).getWatchedSlackChannels();
+  const channels = await new SlackChannelStore(ctx.db).getWatchedSlackChannels();
   return json({ channels });
 }
 

--- a/packages/control-plane/src/routes/environment-secrets.ts
+++ b/packages/control-plane/src/routes/environment-secrets.ts
@@ -23,7 +23,6 @@ import {
   resolveRepoOrError,
 } from "./shared";
 import type { Env } from "../types";
-import type { SqlDatabase } from "../db/sql-database";
 
 const logger = createLogger("router:environment-secrets");
 
@@ -61,11 +60,10 @@ async function invalidateImagesAfterSecretsChange(
 }
 
 /**
- * Require both D1 and the secrets encryption key, returning the resolved key so
- * handlers use `config.key` instead of a non-null assertion on the optional env.
+ * Require the secrets encryption key, returning the resolved key so handlers
+ * use `config.key` instead of a non-null assertion on the optional env.
  */
-function requireSecretsConfig(env: Env, db: SqlDatabase): { key: string } | Response {
-  if (!db) return error("Secrets storage is not configured", 503);
+function requireSecretsConfig(env: Env): { key: string } | Response {
   if (!env.REPO_SECRETS_ENCRYPTION_KEY)
     return error("REPO_SECRETS_ENCRYPTION_KEY not configured", 500);
   return { key: env.REPO_SECRETS_ENCRYPTION_KEY };
@@ -77,7 +75,7 @@ async function handleListEnvironmentSecrets(
   match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const config = requireSecretsConfig(env, ctx.db);
+  const config = requireSecretsConfig(env);
   if (config instanceof Response) return config;
 
   const id = match.groups?.id;
@@ -117,7 +115,7 @@ async function handleSetEnvironmentSecrets(
   match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const config = requireSecretsConfig(env, ctx.db);
+  const config = requireSecretsConfig(env);
   if (config instanceof Response) return config;
 
   const id = match.groups?.id;
@@ -172,7 +170,7 @@ async function handleDeleteEnvironmentSecret(
   match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const config = requireSecretsConfig(env, ctx.db);
+  const config = requireSecretsConfig(env);
   if (config instanceof Response) return config;
 
   const id = match.groups?.id;
@@ -223,7 +221,7 @@ async function handleImportEnvironmentSecrets(
   match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const config = requireSecretsConfig(env, ctx.db);
+  const config = requireSecretsConfig(env);
   if (config instanceof Response) return config;
 
   const id = match.groups?.id;

--- a/packages/control-plane/src/routes/environment-secrets.ts
+++ b/packages/control-plane/src/routes/environment-secrets.ts
@@ -23,6 +23,7 @@ import {
   resolveRepoOrError,
 } from "./shared";
 import type { Env } from "../types";
+import type { SqlDatabase } from "../db/sql-database";
 
 const logger = createLogger("router:environment-secrets");
 
@@ -40,11 +41,7 @@ async function invalidateImagesAfterSecretsChange(
   ctx: RequestContext
 ): Promise<Response | null> {
   try {
-    await supersedeImageBuildsForSecretsChange(
-      env,
-      { kind: "environment", id: environment.id },
-      ctx
-    );
+    await supersedeImageBuildsForSecretsChange({ kind: "environment", id: environment.id }, ctx);
   } catch (e) {
     logger.error("environment.secrets_image_invalidation_failed", {
       environment_id: environment.id,
@@ -67,8 +64,8 @@ async function invalidateImagesAfterSecretsChange(
  * Require both D1 and the secrets encryption key, returning the resolved key so
  * handlers use `config.key` instead of a non-null assertion on the optional env.
  */
-function requireSecretsConfig(env: Env): { key: string } | Response {
-  if (!env.DB) return error("Secrets storage is not configured", 503);
+function requireSecretsConfig(env: Env, db: SqlDatabase): { key: string } | Response {
+  if (!db) return error("Secrets storage is not configured", 503);
   if (!env.REPO_SECRETS_ENCRYPTION_KEY)
     return error("REPO_SECRETS_ENCRYPTION_KEY not configured", 500);
   return { key: env.REPO_SECRETS_ENCRYPTION_KEY };
@@ -80,17 +77,17 @@ async function handleListEnvironmentSecrets(
   match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const config = requireSecretsConfig(env);
+  const config = requireSecretsConfig(env, ctx.db);
   if (config instanceof Response) return config;
 
   const id = match.groups?.id;
   if (!id) return error("Environment ID required", 400);
 
-  const store = new EnvironmentStore(env.DB);
+  const store = new EnvironmentStore(ctx.db);
   if (!(await store.getById(id))) return error("Environment not found", 404);
 
-  const secretsStore = new EnvironmentSecretsStore(env.DB, config.key);
-  const globalStore = new GlobalSecretsStore(env.DB, config.key);
+  const secretsStore = new EnvironmentSecretsStore(ctx.db, config.key);
+  const globalStore = new GlobalSecretsStore(ctx.db, config.key);
 
   try {
     const [secrets, globalSecrets] = await Promise.all([
@@ -120,13 +117,13 @@ async function handleSetEnvironmentSecrets(
   match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const config = requireSecretsConfig(env);
+  const config = requireSecretsConfig(env, ctx.db);
   if (config instanceof Response) return config;
 
   const id = match.groups?.id;
   if (!id) return error("Environment ID required", 400);
 
-  const store = new EnvironmentStore(env.DB);
+  const store = new EnvironmentStore(ctx.db);
   const environment = await store.getById(id);
   if (!environment) return error("Environment not found", 404);
 
@@ -136,7 +133,7 @@ async function handleSetEnvironmentSecrets(
     return error("Request body must include secrets object", 400);
   }
 
-  const secretsStore = new EnvironmentSecretsStore(env.DB, config.key);
+  const secretsStore = new EnvironmentSecretsStore(ctx.db, config.key);
   try {
     const result = await secretsStore.setSecrets(id, body.secrets);
     logger.info("environment.secrets_updated", {
@@ -175,14 +172,14 @@ async function handleDeleteEnvironmentSecret(
   match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const config = requireSecretsConfig(env);
+  const config = requireSecretsConfig(env, ctx.db);
   if (config instanceof Response) return config;
 
   const id = match.groups?.id;
   const key = match.groups?.key;
   if (!id || !key) return error("Environment ID and key are required", 400);
 
-  const secretsStore = new EnvironmentSecretsStore(env.DB, config.key);
+  const secretsStore = new EnvironmentSecretsStore(ctx.db, config.key);
   try {
     const normalizedKey = normalizeKey(key);
     validateKey(normalizedKey);
@@ -196,7 +193,7 @@ async function handleDeleteEnvironmentSecret(
       request_id: ctx.request_id,
       trace_id: ctx.trace_id,
     });
-    const environment = await new EnvironmentStore(env.DB).getById(id);
+    const environment = await new EnvironmentStore(ctx.db).getById(id);
     if (environment) {
       const invalidationError = await invalidateImagesAfterSecretsChange(env, environment, ctx);
       if (invalidationError) return invalidationError;
@@ -226,13 +223,13 @@ async function handleImportEnvironmentSecrets(
   match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const config = requireSecretsConfig(env);
+  const config = requireSecretsConfig(env, ctx.db);
   if (config instanceof Response) return config;
 
   const id = match.groups?.id;
   if (!id) return error("Environment ID required", 400);
 
-  const store = new EnvironmentStore(env.DB);
+  const store = new EnvironmentStore(ctx.db);
   const environment = await store.getById(id);
   if (!environment) return error("Environment not found", 404);
 
@@ -266,7 +263,7 @@ async function handleImportEnvironmentSecrets(
     repoId = (await resolveRepoOrError(env, srcOwner, srcName, ctx, logger)).repoId;
   }
 
-  const secretsStore = new EnvironmentSecretsStore(env.DB, config.key);
+  const secretsStore = new EnvironmentSecretsStore(ctx.db, config.key);
   try {
     const result = await secretsStore.importFromRepo(id, repoId, body.keys as string[] | undefined);
     logger.info("environment.secrets_imported", {

--- a/packages/control-plane/src/routes/environments.ts
+++ b/packages/control-plane/src/routes/environments.ts
@@ -27,11 +27,12 @@ import {
   resolveRepoOrError,
 } from "./shared";
 import type { Env } from "../types";
+import type { SqlDatabase } from "../db/sql-database";
 
 const logger = createLogger("router:environments");
 
-function requireDb(env: Env): Response | null {
-  if (!env.DB) return error("Environment storage is not configured", 503);
+function requireDb(db: SqlDatabase): Response | null {
+  if (!db) return error("Environment storage is not configured", 503);
   return null;
 }
 
@@ -95,12 +96,12 @@ async function handleListEnvironments(
   _request: Request,
   env: Env,
   _match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
-  const guard = requireDb(env);
+  const guard = requireDb(ctx.db);
   if (guard) return guard;
 
-  const store = new EnvironmentStore(env.DB);
+  const store = new EnvironmentStore(ctx.db);
   const { environments, total } = await store.list();
   const repositoriesById = await store.getRepositoriesForEnvironmentIds(
     environments.map((e) => e.id)
@@ -118,7 +119,7 @@ async function handleCreateEnvironment(
   _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const guard = requireDb(env);
+  const guard = requireDb(ctx.db);
   if (guard) return guard;
 
   const body = await parseJsonBody<unknown>(request);
@@ -128,7 +129,7 @@ async function handleCreateEnvironment(
   if (!parsed.success) return validationError(parsed.error);
   const { name, description, prebuildEnabled, channelAssociations, repositories } = parsed.data;
 
-  const store = new EnvironmentStore(env.DB);
+  const store = new EnvironmentStore(ctx.db);
   if (await store.getByName(name)) {
     return error(`An environment named "${name}" already exists`, 409);
   }
@@ -172,15 +173,15 @@ async function handleGetEnvironment(
   _request: Request,
   env: Env,
   match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
-  const guard = requireDb(env);
+  const guard = requireDb(ctx.db);
   if (guard) return guard;
 
   const id = match.groups?.id;
   if (!id) return error("Environment ID required", 400);
 
-  const store = new EnvironmentStore(env.DB);
+  const store = new EnvironmentStore(ctx.db);
   const row = await store.getById(id);
   if (!row) return error("Environment not found", 404);
 
@@ -193,13 +194,13 @@ async function handleUpdateEnvironment(
   match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const guard = requireDb(env);
+  const guard = requireDb(ctx.db);
   if (guard) return guard;
 
   const id = match.groups?.id;
   if (!id) return error("Environment ID required", 400);
 
-  const store = new EnvironmentStore(env.DB);
+  const store = new EnvironmentStore(ctx.db);
   const existing = await store.getById(id);
   if (!existing) return error("Environment not found", 404);
 
@@ -257,13 +258,13 @@ async function handleDeleteEnvironment(
   match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const guard = requireDb(env);
+  const guard = requireDb(ctx.db);
   if (guard) return guard;
 
   const id = match.groups?.id;
   if (!id) return error("Environment ID required", 400);
 
-  const store = new EnvironmentStore(env.DB);
+  const store = new EnvironmentStore(ctx.db);
   const deleted = await store.delete(id);
   if (!deleted) return error("Environment not found", 404);
 

--- a/packages/control-plane/src/routes/environments.ts
+++ b/packages/control-plane/src/routes/environments.ts
@@ -27,14 +27,8 @@ import {
   resolveRepoOrError,
 } from "./shared";
 import type { Env } from "../types";
-import type { SqlDatabase } from "../db/sql-database";
 
 const logger = createLogger("router:environments");
-
-function requireDb(db: SqlDatabase): Response | null {
-  if (!db) return error("Environment storage is not configured", 503);
-  return null;
-}
 
 /** Turn a zod validation failure into a 400 naming the first offending field. */
 function validationError(err: {
@@ -98,9 +92,6 @@ async function handleListEnvironments(
   _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const guard = requireDb(ctx.db);
-  if (guard) return guard;
-
   const store = new EnvironmentStore(ctx.db);
   const { environments, total } = await store.list();
   const repositoriesById = await store.getRepositoriesForEnvironmentIds(
@@ -119,9 +110,6 @@ async function handleCreateEnvironment(
   _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const guard = requireDb(ctx.db);
-  if (guard) return guard;
-
   const body = await parseJsonBody<unknown>(request);
   if (body instanceof Response) return body;
 
@@ -175,9 +163,6 @@ async function handleGetEnvironment(
   match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const guard = requireDb(ctx.db);
-  if (guard) return guard;
-
   const id = match.groups?.id;
   if (!id) return error("Environment ID required", 400);
 
@@ -194,9 +179,6 @@ async function handleUpdateEnvironment(
   match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const guard = requireDb(ctx.db);
-  if (guard) return guard;
-
   const id = match.groups?.id;
   if (!id) return error("Environment ID required", 400);
 
@@ -258,9 +240,6 @@ async function handleDeleteEnvironment(
   match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const guard = requireDb(ctx.db);
-  if (guard) return guard;
-
   const id = match.groups?.id;
   if (!id) return error("Environment ID required", 400);
 

--- a/packages/control-plane/src/routes/image-builds.trigger.test.ts
+++ b/packages/control-plane/src/routes/image-builds.trigger.test.ts
@@ -5,6 +5,7 @@ import { RepoMetadataStore } from "../db/repo-metadata";
 import { imageBuildRoutes } from "./image-builds";
 import type { Env } from "../types";
 import type { RequestContext, Route } from "./shared";
+import type { SqlDatabase } from "../db/sql-database";
 import type { RepositoryAccessResult } from "../source-control";
 import type * as SourceControlModule from "../source-control";
 import type * as SandboxClientModule from "../sandbox/client";
@@ -122,6 +123,7 @@ function createContext(waitUntilTasks?: Promise<unknown>[]): RequestContext {
   return {
     request_id: "request-1",
     trace_id: "trace-1",
+    db: {} as SqlDatabase,
     metrics: createRequestMetrics(),
     executionCtx: {
       waitUntil: (task: Promise<unknown>) => {

--- a/packages/control-plane/src/routes/image-builds.ts
+++ b/packages/control-plane/src/routes/image-builds.ts
@@ -73,10 +73,6 @@ function requireImageBuilds(env: Env): Response | null {
   return message ? error(message, 501) : null;
 }
 
-function requireDb(db: SqlDatabase): Response | null {
-  return db ? null : error("Database not configured", 503);
-}
-
 function workflowContext(ctx: RequestContext): ImageBuildWorkflowContext {
   return {
     request_id: ctx.request_id,
@@ -276,9 +272,6 @@ async function handleBuildComplete(
   _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const dbError = requireDb(ctx.db);
-  if (dbError) return dbError;
-
   const body = await parseCallbackBody<ImageBuildCompleteBody>(request);
   if (body instanceof Response) return body;
 
@@ -308,9 +301,6 @@ async function handleBuildFailed(
   _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const dbError = requireDb(ctx.db);
-  if (dbError) return dbError;
-
   const body = await parseCallbackBody<ImageBuildFailedBody>(request);
   if (body instanceof Response) return body;
 
@@ -369,9 +359,6 @@ async function handleTriggerEnvironmentBuild(
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
 
-  const dbError = requireDb(ctx.db);
-  if (dbError) return dbError;
-
   const environmentId = match.groups?.id;
   if (!environmentId) return error("Environment ID required", 400);
 
@@ -390,9 +377,6 @@ async function handleTriggerRepoBuild(
 ): Promise<Response> {
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
-
-  const dbError = requireDb(ctx.db);
-  if (dbError) return dbError;
 
   const params = extractRepoParams(match);
   if (params instanceof Response) return params;
@@ -415,9 +399,6 @@ async function handleToggleRepoImageBuilds(
 ): Promise<Response> {
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
-
-  const dbError = requireDb(ctx.db);
-  if (dbError) return dbError;
 
   const params = extractRepoParams(match);
   if (params instanceof Response) return params;
@@ -513,9 +494,6 @@ async function handleGetStatus(
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
 
-  const dbError = requireDb(ctx.db);
-  if (dbError) return dbError;
-
   const scope = parseScopeParams(request);
   if (scope instanceof Response) return scope;
 
@@ -545,9 +523,6 @@ async function handleGetEnabledUnits(
 ): Promise<Response> {
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
-
-  const dbError = requireDb(ctx.db);
-  if (dbError) return dbError;
 
   try {
     const units = await listEnabledScopeUnits(env, ctx.db);
@@ -585,9 +560,6 @@ async function handleGetEnabledRepos(
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
 
-  const dbError = requireDb(ctx.db);
-  if (dbError) return dbError;
-
   try {
     return json({ repos: await new RepoMetadataStore(ctx.db).getImageBuildEnabledRepos() });
   } catch (e) {
@@ -612,9 +584,6 @@ async function handleMarkStale(
 ): Promise<Response> {
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
-
-  const dbError = requireDb(ctx.db);
-  if (dbError) return dbError;
 
   const maxAgeMs = await parseMaxAgeMs(request, DEFAULT_STALE_BUILD_MAX_AGE_MS);
   if (maxAgeMs instanceof Response) return maxAgeMs;
@@ -655,9 +624,6 @@ async function handleCleanup(
 ): Promise<Response> {
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
-
-  const dbError = requireDb(ctx.db);
-  if (dbError) return dbError;
 
   const maxAgeMs = await parseMaxAgeMs(request, DEFAULT_FAILED_BUILD_CLEANUP_MAX_AGE_MS);
   if (maxAgeMs instanceof Response) return maxAgeMs;

--- a/packages/control-plane/src/routes/image-builds.ts
+++ b/packages/control-plane/src/routes/image-builds.ts
@@ -36,6 +36,7 @@ import type {
   ImageBuildWorkflowResult,
 } from "../image-builds/types";
 import type { Env } from "../types";
+import type { SqlDatabase } from "../db/sql-database";
 import {
   type RequestContext,
   type Route,
@@ -72,8 +73,8 @@ function requireImageBuilds(env: Env): Response | null {
   return message ? error(message, 501) : null;
 }
 
-function requireDb(env: Env): Response | null {
-  return env.DB ? null : error("Database not configured", 503);
+function requireDb(db: SqlDatabase): Response | null {
+  return db ? null : error("Database not configured", 503);
 }
 
 function workflowContext(ctx: RequestContext): ImageBuildWorkflowContext {
@@ -275,7 +276,7 @@ async function handleBuildComplete(
   _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const dbError = requireDb(env);
+  const dbError = requireDb(ctx.db);
   if (dbError) return dbError;
 
   const body = await parseCallbackBody<ImageBuildCompleteBody>(request);
@@ -285,7 +286,7 @@ async function handleBuildComplete(
   if (completion instanceof Response) return completion;
 
   try {
-    const result = await createImageBuildWorkflowFromEnv(env).acceptBuildComplete({
+    const result = await createImageBuildWorkflowFromEnv(env, ctx.db).acceptBuildComplete({
       completion,
       authorizationHeader: request.headers.get("Authorization"),
       callbackToken: getImageBuildCallbackBearerToken(request),
@@ -307,7 +308,7 @@ async function handleBuildFailed(
   _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const dbError = requireDb(env);
+  const dbError = requireDb(ctx.db);
   if (dbError) return dbError;
 
   const body = await parseCallbackBody<ImageBuildFailedBody>(request);
@@ -317,7 +318,7 @@ async function handleBuildFailed(
   if (failure instanceof Response) return failure;
 
   try {
-    const result = await createImageBuildWorkflowFromEnv(env).acceptBuildFailed({
+    const result = await createImageBuildWorkflowFromEnv(env, ctx.db).acceptBuildFailed({
       failure,
       authorizationHeader: request.headers.get("Authorization"),
       callbackToken: getImageBuildCallbackBearerToken(request),
@@ -336,7 +337,7 @@ async function triggerBuildForScope(
   ctx: RequestContext
 ): Promise<Response> {
   try {
-    const result = await createImageBuildWorkflowFromEnv(env).triggerBuild(
+    const result = await createImageBuildWorkflowFromEnv(env, ctx.db).triggerBuild(
       scope,
       workflowContext(ctx)
     );
@@ -368,7 +369,7 @@ async function handleTriggerEnvironmentBuild(
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
 
-  const dbError = requireDb(env);
+  const dbError = requireDb(ctx.db);
   if (dbError) return dbError;
 
   const environmentId = match.groups?.id;
@@ -390,7 +391,7 @@ async function handleTriggerRepoBuild(
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
 
-  const dbError = requireDb(env);
+  const dbError = requireDb(ctx.db);
   if (dbError) return dbError;
 
   const params = extractRepoParams(match);
@@ -415,7 +416,7 @@ async function handleToggleRepoImageBuilds(
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
 
-  const dbError = requireDb(env);
+  const dbError = requireDb(ctx.db);
   if (dbError) return dbError;
 
   const params = extractRepoParams(match);
@@ -437,14 +438,14 @@ async function handleToggleRepoImageBuilds(
   // a repo that became unresolvable must remain disableable.
   if (body.enabled) {
     try {
-      await resolveScopeTarget(env, scope);
+      await resolveScopeTarget(env, ctx.db, scope);
     } catch (e) {
       return imageBuildErrorToResponse(e);
     }
   }
 
   try {
-    await new RepoMetadataStore(env.DB).setImageBuildEnabled(owner, name, body.enabled);
+    await new RepoMetadataStore(ctx.db).setImageBuildEnabled(owner, name, body.enabled);
   } catch (e) {
     logger.error("image_build.toggle_error", {
       error: e instanceof Error ? e.message : String(e),
@@ -486,12 +487,12 @@ function parseScopeParams(request: Request): ImageBuildScope | null | Response {
 }
 
 async function readStatusRows(
-  env: Env,
+  db: SqlDatabase,
   scope: ImageBuildScope | null
 ): Promise<ImageBuildRecordView[]> {
-  const store = new ImageBuildStore(env.DB);
+  const store = new ImageBuildStore(db);
   if (scope) return store.getStatus(scope);
-  return store.getStatusForEnabledScopes(await listEnabledScopes(env.DB));
+  return store.getStatusForEnabledScopes(await listEnabledScopes(db));
 }
 
 /**
@@ -512,14 +513,14 @@ async function handleGetStatus(
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
 
-  const dbError = requireDb(env);
+  const dbError = requireDb(ctx.db);
   if (dbError) return dbError;
 
   const scope = parseScopeParams(request);
   if (scope instanceof Response) return scope;
 
   try {
-    return json({ images: await readStatusRows(env, scope) });
+    return json({ images: await readStatusRows(ctx.db, scope) });
   } catch (e) {
     logger.error("image_build.status_error", {
       error: e instanceof Error ? e.message : String(e),
@@ -545,11 +546,11 @@ async function handleGetEnabledUnits(
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
 
-  const dbError = requireDb(env);
+  const dbError = requireDb(ctx.db);
   if (dbError) return dbError;
 
   try {
-    const units = await listEnabledScopeUnits(env);
+    const units = await listEnabledScopeUnits(env, ctx.db);
     return json({
       units: units.map((unit) => ({
         scopeKind: unit.scope.kind,
@@ -584,11 +585,11 @@ async function handleGetEnabledRepos(
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
 
-  const dbError = requireDb(env);
+  const dbError = requireDb(ctx.db);
   if (dbError) return dbError;
 
   try {
-    return json({ repos: await new RepoMetadataStore(env.DB).getImageBuildEnabledRepos() });
+    return json({ repos: await new RepoMetadataStore(ctx.db).getImageBuildEnabledRepos() });
   } catch (e) {
     logger.error("image_build.enabled_repos_error", {
       error: e instanceof Error ? e.message : String(e),
@@ -612,13 +613,13 @@ async function handleMarkStale(
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
 
-  const dbError = requireDb(env);
+  const dbError = requireDb(ctx.db);
   if (dbError) return dbError;
 
   const maxAgeMs = await parseMaxAgeMs(request, DEFAULT_STALE_BUILD_MAX_AGE_MS);
   if (maxAgeMs instanceof Response) return maxAgeMs;
 
-  const store = new ImageBuildStore(env.DB);
+  const store = new ImageBuildStore(ctx.db);
 
   try {
     const count = await store.markStaleBuildsAsFailed(maxAgeMs);
@@ -655,14 +656,14 @@ async function handleCleanup(
   const providerError = requireImageBuilds(env);
   if (providerError) return providerError;
 
-  const dbError = requireDb(env);
+  const dbError = requireDb(ctx.db);
   if (dbError) return dbError;
 
   const maxAgeMs = await parseMaxAgeMs(request, DEFAULT_FAILED_BUILD_CLEANUP_MAX_AGE_MS);
   if (maxAgeMs instanceof Response) return maxAgeMs;
 
   try {
-    const result = await createImageBuildWorkflowFromEnv(env).cleanupImages(
+    const result = await createImageBuildWorkflowFromEnv(env, ctx.db).cleanupImages(
       maxAgeMs,
       workflowContext(ctx)
     );

--- a/packages/control-plane/src/routes/integration-settings.ts
+++ b/packages/control-plane/src/routes/integration-settings.ts
@@ -21,6 +21,7 @@ import {
 } from "../db/integration-settings";
 import { EnvironmentStore } from "../db/environments";
 import type { Env } from "../types";
+import type { SqlDatabase } from "../db/sql-database";
 import { createLogger } from "../logger";
 import {
   type Route,
@@ -47,7 +48,7 @@ function extractIntegrationId(match: RegExpMatchArray): IntegrationId | null {
  * `environments` — an environment that actually exists.
  */
 async function extractEnvironmentSettingsParams(
-  env: Env,
+  db: SqlDatabase,
   match: RegExpMatchArray
 ): Promise<
   | {
@@ -66,32 +67,32 @@ async function extractEnvironmentSettingsParams(
   const environmentId = match.groups?.environmentId;
   if (!environmentId) return error("Environment ID required", 400);
 
-  if (!env.DB) {
+  if (!db) {
     return error("Integration settings storage is not configured", 503);
   }
 
-  const environmentStore = new EnvironmentStore(env.DB);
+  const environmentStore = new EnvironmentStore(db);
   if (!(await environmentStore.getById(environmentId))) {
     return error("Environment not found", 404);
   }
 
-  return { integrationId: id, environmentId, store: new IntegrationSettingsStore(env.DB) };
+  return { integrationId: id, environmentId, store: new IntegrationSettingsStore(db) };
 }
 
 async function handleGetIntegrationSettings(
   _request: Request,
   env: Env,
   match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const id = extractIntegrationId(match);
   if (!id) return error(`Unknown integration: ${match.groups?.id}`, 404);
 
-  if (!env.DB) {
+  if (!ctx.db) {
     return json({ integrationId: id, settings: null });
   }
 
-  const store = new IntegrationSettingsStore(env.DB);
+  const store = new IntegrationSettingsStore(ctx.db);
   const settings = await store.getGlobal(id);
   return json({ integrationId: id, settings });
 }
@@ -105,7 +106,7 @@ async function handleSetIntegrationSettings(
   const id = extractIntegrationId(match);
   if (!id) return error(`Unknown integration: ${match.groups?.id}`, 404);
 
-  if (!env.DB) {
+  if (!ctx.db) {
     return error("Integration settings storage is not configured", 503);
   }
 
@@ -116,7 +117,7 @@ async function handleSetIntegrationSettings(
     return error("Request body must include settings object", 400);
   }
 
-  const store = new IntegrationSettingsStore(env.DB);
+  const store = new IntegrationSettingsStore(ctx.db);
 
   try {
     await store.setGlobal(id, body.settings);
@@ -151,11 +152,11 @@ async function handleDeleteIntegrationSettings(
   const id = extractIntegrationId(match);
   if (!id) return error(`Unknown integration: ${match.groups?.id}`, 404);
 
-  if (!env.DB) {
+  if (!ctx.db) {
     return error("Integration settings storage is not configured", 503);
   }
 
-  const store = new IntegrationSettingsStore(env.DB);
+  const store = new IntegrationSettingsStore(ctx.db);
 
   try {
     await store.deleteGlobal(id);
@@ -182,16 +183,16 @@ async function handleListRepoSettings(
   _request: Request,
   env: Env,
   match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const id = extractIntegrationId(match);
   if (!id) return error(`Unknown integration: ${match.groups?.id}`, 404);
 
-  if (!env.DB) {
+  if (!ctx.db) {
     return json({ integrationId: id, repos: [] });
   }
 
-  const store = new IntegrationSettingsStore(env.DB);
+  const store = new IntegrationSettingsStore(ctx.db);
   const repos = await store.listRepoSettings(id);
   return json({ integrationId: id, repos });
 }
@@ -200,7 +201,7 @@ async function handleGetRepoSettings(
   _request: Request,
   env: Env,
   match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const id = extractIntegrationId(match);
   if (!id) return error(`Unknown integration: ${match.groups?.id}`, 404);
@@ -211,11 +212,11 @@ async function handleGetRepoSettings(
 
   const repo = `${owner}/${name}`;
 
-  if (!env.DB) {
+  if (!ctx.db) {
     return json({ integrationId: id, repo, settings: null });
   }
 
-  const store = new IntegrationSettingsStore(env.DB);
+  const store = new IntegrationSettingsStore(ctx.db);
   const settings = await store.getRepoSettings(id, repo);
   return json({ integrationId: id, repo, settings });
 }
@@ -233,7 +234,7 @@ async function handleSetRepoSettings(
   if (params instanceof Response) return params;
   const { owner, name } = params;
 
-  if (!env.DB) {
+  if (!ctx.db) {
     return error("Integration settings storage is not configured", 503);
   }
 
@@ -244,7 +245,7 @@ async function handleSetRepoSettings(
     return error("Request body must include settings object", 400);
   }
 
-  const store = new IntegrationSettingsStore(env.DB);
+  const store = new IntegrationSettingsStore(ctx.db);
   const repo = `${owner}/${name}`;
 
   try {
@@ -285,11 +286,11 @@ async function handleDeleteRepoSettings(
   if (params instanceof Response) return params;
   const { owner, name } = params;
 
-  if (!env.DB) {
+  if (!ctx.db) {
     return error("Integration settings storage is not configured", 503);
   }
 
-  const store = new IntegrationSettingsStore(env.DB);
+  const store = new IntegrationSettingsStore(ctx.db);
   const repo = `${owner}/${name}`;
 
   try {
@@ -318,9 +319,9 @@ async function handleGetEnvironmentSettings(
   _request: Request,
   env: Env,
   match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
-  const params = await extractEnvironmentSettingsParams(env, match);
+  const params = await extractEnvironmentSettingsParams(ctx.db, match);
   if (params instanceof Response) return params;
   const { integrationId, environmentId, store } = params;
 
@@ -334,7 +335,7 @@ async function handleSetEnvironmentSettings(
   match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const params = await extractEnvironmentSettingsParams(env, match);
+  const params = await extractEnvironmentSettingsParams(ctx.db, match);
   if (params instanceof Response) return params;
   const { integrationId, environmentId, store } = params;
 
@@ -376,7 +377,7 @@ async function handleDeleteEnvironmentSettings(
   match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  const params = await extractEnvironmentSettingsParams(env, match);
+  const params = await extractEnvironmentSettingsParams(ctx.db, match);
   if (params instanceof Response) return params;
   const { integrationId, environmentId, store } = params;
 
@@ -406,7 +407,7 @@ async function handleGetResolvedConfig(
   _request: Request,
   env: Env,
   match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const id = extractIntegrationId(match);
   if (!id) return error(`Unknown integration: ${match.groups?.id}`, 404);
@@ -415,11 +416,11 @@ async function handleGetResolvedConfig(
   if (params instanceof Response) return params;
   const { owner, name } = params;
 
-  if (!env.DB) {
+  if (!ctx.db) {
     return json({ integrationId: id, repo: `${owner}/${name}`, config: null });
   }
 
-  const store = new IntegrationSettingsStore(env.DB);
+  const store = new IntegrationSettingsStore(ctx.db);
   const repo = `${owner}/${name}`;
   const { enabledRepos, settings } = await store.getResolvedConfig(id, repo);
 

--- a/packages/control-plane/src/routes/integration-settings.ts
+++ b/packages/control-plane/src/routes/integration-settings.ts
@@ -67,10 +67,6 @@ async function extractEnvironmentSettingsParams(
   const environmentId = match.groups?.environmentId;
   if (!environmentId) return error("Environment ID required", 400);
 
-  if (!db) {
-    return error("Integration settings storage is not configured", 503);
-  }
-
   const environmentStore = new EnvironmentStore(db);
   if (!(await environmentStore.getById(environmentId))) {
     return error("Environment not found", 404);
@@ -88,10 +84,6 @@ async function handleGetIntegrationSettings(
   const id = extractIntegrationId(match);
   if (!id) return error(`Unknown integration: ${match.groups?.id}`, 404);
 
-  if (!ctx.db) {
-    return json({ integrationId: id, settings: null });
-  }
-
   const store = new IntegrationSettingsStore(ctx.db);
   const settings = await store.getGlobal(id);
   return json({ integrationId: id, settings });
@@ -105,10 +97,6 @@ async function handleSetIntegrationSettings(
 ): Promise<Response> {
   const id = extractIntegrationId(match);
   if (!id) return error(`Unknown integration: ${match.groups?.id}`, 404);
-
-  if (!ctx.db) {
-    return error("Integration settings storage is not configured", 503);
-  }
 
   const body = await parseJsonBody<{ settings?: Record<string, unknown> }>(request);
   if (body instanceof Response) return body;
@@ -152,10 +140,6 @@ async function handleDeleteIntegrationSettings(
   const id = extractIntegrationId(match);
   if (!id) return error(`Unknown integration: ${match.groups?.id}`, 404);
 
-  if (!ctx.db) {
-    return error("Integration settings storage is not configured", 503);
-  }
-
   const store = new IntegrationSettingsStore(ctx.db);
 
   try {
@@ -188,10 +172,6 @@ async function handleListRepoSettings(
   const id = extractIntegrationId(match);
   if (!id) return error(`Unknown integration: ${match.groups?.id}`, 404);
 
-  if (!ctx.db) {
-    return json({ integrationId: id, repos: [] });
-  }
-
   const store = new IntegrationSettingsStore(ctx.db);
   const repos = await store.listRepoSettings(id);
   return json({ integrationId: id, repos });
@@ -212,10 +192,6 @@ async function handleGetRepoSettings(
 
   const repo = `${owner}/${name}`;
 
-  if (!ctx.db) {
-    return json({ integrationId: id, repo, settings: null });
-  }
-
   const store = new IntegrationSettingsStore(ctx.db);
   const settings = await store.getRepoSettings(id, repo);
   return json({ integrationId: id, repo, settings });
@@ -233,10 +209,6 @@ async function handleSetRepoSettings(
   const params = extractRepoParams(match);
   if (params instanceof Response) return params;
   const { owner, name } = params;
-
-  if (!ctx.db) {
-    return error("Integration settings storage is not configured", 503);
-  }
 
   const body = await parseJsonBody<{ settings?: Record<string, unknown> }>(request);
   if (body instanceof Response) return body;
@@ -285,10 +257,6 @@ async function handleDeleteRepoSettings(
   const params = extractRepoParams(match);
   if (params instanceof Response) return params;
   const { owner, name } = params;
-
-  if (!ctx.db) {
-    return error("Integration settings storage is not configured", 503);
-  }
 
   const store = new IntegrationSettingsStore(ctx.db);
   const repo = `${owner}/${name}`;
@@ -415,10 +383,6 @@ async function handleGetResolvedConfig(
   const params = extractRepoParams(match);
   if (params instanceof Response) return params;
   const { owner, name } = params;
-
-  if (!ctx.db) {
-    return json({ integrationId: id, repo: `${owner}/${name}`, config: null });
-  }
 
   const store = new IntegrationSettingsStore(ctx.db);
   const repo = `${owner}/${name}`;

--- a/packages/control-plane/src/routes/mcp-servers.ts
+++ b/packages/control-plane/src/routes/mcp-servers.ts
@@ -12,12 +12,12 @@ async function handleListMcpServers(
   _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  if (!env.DB) return error("Database not configured", 503);
+  if (!ctx.db) return error("Database not configured", 503);
 
   const url = new URL(request.url);
   const repo = url.searchParams.get("repo") ?? undefined;
 
-  const store = new McpServerStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
+  const store = new McpServerStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
   const servers = await store.list(repo);
   logger.info("MCP servers listed", {
     event: "mcp_server.list",
@@ -36,9 +36,9 @@ async function handleGetMcpServer(
 ): Promise<Response> {
   const id = match.groups?.id;
   if (!id) return error("Missing server ID", 400);
-  if (!env.DB) return error("Database not configured", 503);
+  if (!ctx.db) return error("Database not configured", 503);
 
-  const store = new McpServerStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
+  const store = new McpServerStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
   const server = await store.get(id);
   if (!server) return error("MCP server not found", 404);
   logger.info("MCP server retrieved", {
@@ -56,7 +56,7 @@ async function handleCreateMcpServer(
   _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  if (!env.DB) return error("Database not configured", 503);
+  if (!ctx.db) return error("Database not configured", 503);
 
   let body: Partial<McpServerConfig>;
   try {
@@ -90,7 +90,7 @@ async function handleCreateMcpServer(
   }
 
   try {
-    const store = new McpServerStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
+    const store = new McpServerStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
     const server = await store.create({
       name: body.name,
       type: body.type,
@@ -125,7 +125,7 @@ async function handleUpdateMcpServer(
 ): Promise<Response> {
   const id = match.groups?.id;
   if (!id) return error("Missing server ID", 400);
-  if (!env.DB) return error("Database not configured", 503);
+  if (!ctx.db) return error("Database not configured", 503);
 
   let body: Partial<McpServerConfig>;
   try {
@@ -160,7 +160,7 @@ async function handleUpdateMcpServer(
   }
 
   try {
-    const store = new McpServerStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
+    const store = new McpServerStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
     const updated = await store.update(id, body);
     if (!updated) return error("MCP server not found", 404);
 
@@ -187,9 +187,9 @@ async function handleDeleteMcpServer(
 ): Promise<Response> {
   const id = match.groups?.id;
   if (!id) return error("Missing server ID", 400);
-  if (!env.DB) return error("Database not configured", 503);
+  if (!ctx.db) return error("Database not configured", 503);
 
-  const store = new McpServerStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
+  const store = new McpServerStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
   const deleted = await store.delete(id);
   if (!deleted) return error("MCP server not found", 404);
 

--- a/packages/control-plane/src/routes/model-preferences.ts
+++ b/packages/control-plane/src/routes/model-preferences.ts
@@ -23,11 +23,11 @@ async function handleGetModelPreferences(
   _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  if (!env.DB) {
+  if (!ctx.db) {
     return json({ enabledModels: DEFAULT_ENABLED_MODELS });
   }
 
-  const store = new ModelPreferencesStore(env.DB);
+  const store = new ModelPreferencesStore(ctx.db);
 
   try {
     const enabledModels = await store.getEnabledModels();
@@ -63,7 +63,7 @@ async function handleSetModelPreferences(
   _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  if (!env.DB) {
+  if (!ctx.db) {
     return error("Model preferences storage is not configured", 503);
   }
 
@@ -77,7 +77,7 @@ async function handleSetModelPreferences(
     return error("enabledModels must contain only strings", 400);
   }
 
-  const store = new ModelPreferencesStore(env.DB);
+  const store = new ModelPreferencesStore(ctx.db);
 
   try {
     const enabledModels = await store.setEnabledModels(body.enabledModels);

--- a/packages/control-plane/src/routes/provider-identities.test.ts
+++ b/packages/control-plane/src/routes/provider-identities.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { providerIdentityRoutes } from "./provider-identities";
 import type { RequestContext } from "./shared";
+import type { SqlDatabase } from "../db/sql-database";
 import type { Env } from "../types";
 
 const mockUserStore = {
@@ -23,6 +24,7 @@ function createCtx(): RequestContext {
   return {
     trace_id: "trace-1",
     request_id: "req-1",
+    db: {} as SqlDatabase,
     metrics: {
       d1Queries: [],
       spans: {},

--- a/packages/control-plane/src/routes/provider-identities.ts
+++ b/packages/control-plane/src/routes/provider-identities.ts
@@ -48,7 +48,7 @@ export async function handleUpsertProviderIdentity(
   request: Request,
   env: Env,
   match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const body = await parseJsonBody<UpsertProviderIdentityRequest>(request);
   if (body instanceof Response) return body;
@@ -75,7 +75,7 @@ export async function handleUpsertProviderIdentity(
     avatarUrl: optionalString(body.avatarUrl),
   };
 
-  const resolvedUser = await new UserStore(env.DB).resolveOrCreateUser(identity);
+  const resolvedUser = await new UserStore(ctx.db).resolveOrCreateUser(identity);
   if (!isCanonicalUserId(resolvedUser.id)) {
     return error("Resolved user ID is invalid", 500);
   }

--- a/packages/control-plane/src/routes/repos.ts
+++ b/packages/control-plane/src/routes/repos.ts
@@ -4,6 +4,7 @@
 
 import { RepoMetadataStore } from "../db/repo-metadata";
 import type { Env } from "../types";
+import type { SqlDatabase } from "../db/sql-database";
 import { createKvCacheStore } from "@open-inspect/shared";
 import type {
   EnrichedRepository,
@@ -42,7 +43,7 @@ interface CachedReposList {
  * Fetch repos via the source control provider, enrich with D1 metadata, and write to KV cache.
  * Runs either in the foreground (cache miss) or background (stale-while-revalidate).
  */
-async function refreshReposCache(env: Env, traceId?: string): Promise<void> {
+async function refreshReposCache(env: Env, db: SqlDatabase, traceId?: string): Promise<void> {
   const provider = createRouteSourceControlProvider(env);
   const cacheStore = createKvCacheStore(env.REPOS_CACHE);
 
@@ -68,7 +69,7 @@ async function refreshReposCache(env: Env, traceId?: string): Promise<void> {
     return;
   }
 
-  const metadataStore = new RepoMetadataStore(env.DB);
+  const metadataStore = new RepoMetadataStore(db);
   let metadataMap: Map<string, RepoMetadata>;
   try {
     metadataMap = await metadataStore.getBatch(
@@ -146,7 +147,7 @@ async function handleListRepos(
         trace_id: ctx.trace_id,
         cached_at: cached.cachedAt,
       });
-      ctx.executionCtx.waitUntil(refreshReposCache(env, ctx.trace_id));
+      ctx.executionCtx.waitUntil(refreshReposCache(env, ctx.db, ctx.trace_id));
     }
 
     return json({
@@ -177,7 +178,7 @@ async function handleListRepos(
     total_repos: repos.length,
   });
 
-  const metadataStore = new RepoMetadataStore(env.DB);
+  const metadataStore = new RepoMetadataStore(ctx.db);
   let metadataMap: Map<string, RepoMetadata>;
   try {
     metadataMap = await metadataStore.getBatch(
@@ -225,7 +226,7 @@ async function handleUpdateRepoMetadata(
   request: Request,
   env: Env,
   match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const params = extractRepoParams(match);
   if (params instanceof Response) return params;
@@ -247,7 +248,7 @@ async function handleUpdateRepoMetadata(
     }).filter(([, v]) => v !== undefined)
   ) as RepoMetadata;
 
-  const metadataStore = new RepoMetadataStore(env.DB);
+  const metadataStore = new RepoMetadataStore(ctx.db);
 
   try {
     await metadataStore.upsert(owner, name, metadata);
@@ -277,14 +278,14 @@ async function handleGetRepoMetadata(
   request: Request,
   env: Env,
   match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const params = extractRepoParams(match);
   if (params instanceof Response) return params;
   const { owner, name } = params;
 
   const normalizedRepo = `${owner.toLowerCase()}/${name.toLowerCase()}`;
-  const metadataStore = new RepoMetadataStore(env.DB);
+  const metadataStore = new RepoMetadataStore(ctx.db);
 
   try {
     const metadata = await metadataStore.get(owner, name);

--- a/packages/control-plane/src/routes/secrets.ts
+++ b/packages/control-plane/src/routes/secrets.ts
@@ -29,7 +29,7 @@ async function handleSetRepoSecrets(
   match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  if (!env.DB) {
+  if (!ctx.db) {
     return error("Secrets storage is not configured", 503);
   }
   if (!env.REPO_SECRETS_ENCRYPTION_KEY) {
@@ -49,7 +49,7 @@ async function handleSetRepoSecrets(
     return error("Request body must include secrets object", 400);
   }
 
-  const store = new RepoSecretsStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
+  const store = new RepoSecretsStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
 
   try {
     const result = await store.setSecrets(
@@ -103,7 +103,7 @@ async function handleListRepoSecrets(
   match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  if (!env.DB) {
+  if (!ctx.db) {
     return error("Secrets storage is not configured", 503);
   }
   if (!env.REPO_SECRETS_ENCRYPTION_KEY) {
@@ -116,8 +116,8 @@ async function handleListRepoSecrets(
 
   const resolved = await resolveRepoOrError(env, owner, name, ctx, logger);
 
-  const store = new RepoSecretsStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
-  const globalStore = new GlobalSecretsStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
+  const store = new RepoSecretsStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
+  const globalStore = new GlobalSecretsStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
 
   try {
     const [secrets, globalSecrets] = await Promise.all([
@@ -168,7 +168,7 @@ async function handleDeleteRepoSecret(
   match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  if (!env.DB) {
+  if (!ctx.db) {
     return error("Secrets storage is not configured", 503);
   }
   if (!env.REPO_SECRETS_ENCRYPTION_KEY) {
@@ -186,7 +186,7 @@ async function handleDeleteRepoSecret(
 
   const resolved = await resolveRepoOrError(env, owner, name, ctx, logger);
 
-  const store = new RepoSecretsStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
+  const store = new RepoSecretsStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
 
   try {
     const normalizedKey = normalizeKey(key);
@@ -233,7 +233,7 @@ async function handleSetGlobalSecrets(
   _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  if (!env.DB) {
+  if (!ctx.db) {
     return error("Secrets storage is not configured", 503);
   }
   if (!env.REPO_SECRETS_ENCRYPTION_KEY) {
@@ -247,7 +247,7 @@ async function handleSetGlobalSecrets(
     return error("Request body must include secrets object", 400);
   }
 
-  const store = new GlobalSecretsStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
+  const store = new GlobalSecretsStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
 
   try {
     const result = await store.setSecrets(body.secrets);
@@ -286,14 +286,14 @@ async function handleListGlobalSecrets(
   _match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  if (!env.DB) {
+  if (!ctx.db) {
     return error("Secrets storage is not configured", 503);
   }
   if (!env.REPO_SECRETS_ENCRYPTION_KEY) {
     return error("REPO_SECRETS_ENCRYPTION_KEY not configured", 500);
   }
 
-  const store = new GlobalSecretsStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
+  const store = new GlobalSecretsStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
 
   try {
     const secrets = await store.listSecretKeys();
@@ -322,7 +322,7 @@ async function handleDeleteGlobalSecret(
   match: RegExpMatchArray,
   ctx: RequestContext
 ): Promise<Response> {
-  if (!env.DB) {
+  if (!ctx.db) {
     return error("Secrets storage is not configured", 503);
   }
   if (!env.REPO_SECRETS_ENCRYPTION_KEY) {
@@ -334,7 +334,7 @@ async function handleDeleteGlobalSecret(
     return error("Key is required");
   }
 
-  const store = new GlobalSecretsStore(env.DB, env.REPO_SECRETS_ENCRYPTION_KEY);
+  const store = new GlobalSecretsStore(ctx.db, env.REPO_SECRETS_ENCRYPTION_KEY);
 
   try {
     const normalizedKey = normalizeKey(key);

--- a/packages/control-plane/src/routes/session-attachments.test.ts
+++ b/packages/control-plane/src/routes/session-attachments.test.ts
@@ -3,6 +3,7 @@ import { SESSION_ATTACHMENT_MAX_REQUEST_BYTES } from "../media";
 import type { Env } from "../types";
 import { sessionAttachmentRoutes } from "./session-attachments";
 import type { RequestContext } from "./shared";
+import type { SqlDatabase } from "../db/sql-database";
 
 const PNG_BYTES = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
@@ -10,6 +11,7 @@ function createContext(): RequestContext {
   return {
     trace_id: "trace-1",
     request_id: "request-1",
+    db: {} as SqlDatabase,
     metrics: {
       d1Queries: [],
       spans: {},

--- a/packages/control-plane/src/routes/session-child-spawn.ts
+++ b/packages/control-plane/src/routes/session-child-spawn.ts
@@ -43,7 +43,7 @@ async function handleSpawnChild(
     return error("title and prompt are required");
   }
 
-  const sessionStore = new SessionIndexStore(env.DB);
+  const sessionStore = new SessionIndexStore(ctx.db);
 
   const parentSession = await sessionStore.get(parentId);
   const parentUserId = parentSession?.userId ?? null;
@@ -52,7 +52,7 @@ async function handleSpawnChild(
   // environment-launched parents, that environment's overrides (design §13.5).
   const childSandboxSettings = parentSession
     ? await resolveSandboxSettings(
-        env.DB,
+        ctx.db,
         parentSession.repoOwner,
         parentSession.repoName,
         parentEnvironmentId
@@ -143,7 +143,7 @@ async function handleSpawnChild(
   });
 
   const childCodeServerEnabled = await resolveCodeServerEnabled(
-    env.DB,
+    ctx.db,
     spawnContext.repoOwner,
     spawnContext.repoName,
     parentEnvironmentId

--- a/packages/control-plane/src/routes/session-children.ts
+++ b/packages/control-plane/src/routes/session-children.ts
@@ -8,12 +8,12 @@ async function handleListChildren(
   _request: Request,
   env: Env,
   match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const parentId = match.groups?.id;
   if (!parentId) return error("Parent session ID required");
 
-  const sessionStore = new SessionIndexStore(env.DB);
+  const sessionStore = new SessionIndexStore(ctx.db);
   const children = await sessionStore.listByParent(parentId);
 
   return json({ children });
@@ -29,7 +29,7 @@ async function handleGetChild(
   const childId = match.groups?.childId;
   if (!parentId || !childId) return error("Parent and child session IDs required");
 
-  const sessionStore = new SessionIndexStore(env.DB);
+  const sessionStore = new SessionIndexStore(ctx.db);
   const isChild = await sessionStore.isChildOf(childId, parentId);
   if (!isChild) {
     return error("Child session not found", 404);
@@ -54,7 +54,7 @@ async function handleCancelChild(
   const childId = match.groups?.childId;
   if (!parentId || !childId) return error("Parent and child session IDs required");
 
-  const sessionStore = new SessionIndexStore(env.DB);
+  const sessionStore = new SessionIndexStore(ctx.db);
   const isChild = await sessionStore.isChildOf(childId, parentId);
   if (!isChild) {
     return error("Child session not found", 404);

--- a/packages/control-plane/src/routes/session-create.ts
+++ b/packages/control-plane/src/routes/session-create.ts
@@ -81,7 +81,7 @@ async function handleCreateSession(
     // Snapshot the environment's members and resolve them like any other list
     // (design §7.6); environment_id records provenance on the session.
     const envInputs = await resolveEnvironmentTarget(
-      new EnvironmentStore(env.DB),
+      new EnvironmentStore(ctx.db),
       body.environmentId
     );
     repositories = await resolveSessionRepositories(env, envInputs, ctx, logger);
@@ -111,7 +111,7 @@ async function handleCreateSession(
 
   // Resolve canonical user model ID (for D1 session index).
   // Best-effort: if resolution fails, the session is created without a user_id.
-  const userStore = new UserStore(env.DB);
+  const userStore = new UserStore(ctx.db);
   let resolvedUserId: string | null = null;
   const providerIdentity = resolveProviderIdentity(body.spawnSource ?? "user", body);
   if (providerIdentity) {
@@ -163,7 +163,7 @@ async function handleCreateSession(
   // an SCM credential", not "a Google-authenticated session carries no SCM state".
   if (resolvedUserId) {
     try {
-      const enrichment = await resolveGitHubEnrichment(env, userStore, resolvedUserId);
+      const enrichment = await resolveGitHubEnrichment(env, ctx.db, userStore, resolvedUserId);
       if (enrichment) {
         scmUserId ??= enrichment.scmUserId;
         scmLogin ??= enrichment.scmLogin;
@@ -195,7 +195,7 @@ async function handleCreateSession(
   // from a saved environment layers its overrides on top (design §13.5).
   const scopeMembers = repositories ?? (repoOwner && repoName ? [{ repoOwner, repoName }] : []);
   const { codeServerEnabled, sandboxSettings } = await resolveSessionScopedSettings(
-    env.DB,
+    ctx.db,
     scopeMembers,
     environmentId
   );
@@ -242,7 +242,7 @@ async function handleCreateSession(
   // Populate D1 with the user's SCM tokens (non-blocking) so centralized refresh works
   if (scmUserId && scmToken && scmRefreshToken && env.TOKEN_ENCRYPTION_KEY) {
     ctx.executionCtx?.waitUntil(
-      new UserScmTokenStore(env.DB, env.TOKEN_ENCRYPTION_KEY)
+      new UserScmTokenStore(ctx.db, env.TOKEN_ENCRYPTION_KEY)
         .upsertTokens(
           scmUserId,
           scmToken,

--- a/packages/control-plane/src/routes/session-index.test.ts
+++ b/packages/control-plane/src/routes/session-index.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { sessionIndexRoutes } from "./session-index";
 import type { RequestContext } from "./shared";
+import type { SqlDatabase } from "../db/sql-database";
 import type { Env } from "../types";
 
 const mockSessionIndexStore = {
@@ -18,6 +19,7 @@ function createCtx(): RequestContext {
   return {
     trace_id: "trace-1",
     request_id: "req-1",
+    db: {} as SqlDatabase,
     metrics: {
       d1Queries: [],
       spans: {},

--- a/packages/control-plane/src/routes/session-index.ts
+++ b/packages/control-plane/src/routes/session-index.ts
@@ -52,7 +52,7 @@ async function handleListSessions(
   request: Request,
   env: Env,
   _match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const url = new URL(request.url);
   const limit = parsePaginationLimit(url.searchParams.get("limit"));
@@ -75,7 +75,7 @@ async function handleListSessions(
     return createdByUserIds;
   }
 
-  const store = new SessionIndexStore(env.DB);
+  const store = new SessionIndexStore(ctx.db);
   const result = await store.list({ status, excludeStatus, createdByUserIds, limit, offset });
 
   return json({
@@ -88,12 +88,12 @@ async function handleDeleteSession(
   _request: Request,
   env: Env,
   match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const sessionId = match.groups?.id;
   if (!sessionId) return error("Session ID required");
 
-  const sessionStore = new SessionIndexStore(env.DB);
+  const sessionStore = new SessionIndexStore(ctx.db);
   await sessionStore.delete(sessionId);
 
   return json({ status: "deleted", sessionId });

--- a/packages/control-plane/src/routes/session-prompt.ts
+++ b/packages/control-plane/src/routes/session-prompt.ts
@@ -61,10 +61,11 @@ async function handleSessionPrompt(
   const parsed = parseAuthorId(authorId);
   if (parsed) {
     try {
-      const userStore = new UserStore(env.DB);
+      const userStore = new UserStore(ctx.db);
       const identity = await userStore.getIdentity(parsed.provider, parsed.providerUserId);
       if (identity) {
-        enrichment = (await resolveGitHubEnrichment(env, userStore, identity.userId)) ?? undefined;
+        enrichment =
+          (await resolveGitHubEnrichment(env, ctx.db, userStore, identity.userId)) ?? undefined;
       }
     } catch (e) {
       logger.warn("Failed to enrich prompt with GitHub identity", {
@@ -95,7 +96,7 @@ async function handleSessionPrompt(
     }),
   });
 
-  const store = new SessionIndexStore(env.DB);
+  const store = new SessionIndexStore(ctx.db);
   ctx.executionCtx?.waitUntil(
     store.touchUpdatedAt(sessionId).catch((error) => {
       logger.error("session_index.touch_updated_at.background_error", {

--- a/packages/control-plane/src/routes/session-runtime-proxy.test.ts
+++ b/packages/control-plane/src/routes/session-runtime-proxy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { SessionInternalPaths } from "../session/contracts";
 import type { RequestContext } from "./shared";
+import type { SqlDatabase } from "../db/sql-database";
 import { sessionRuntimeProxyRoutes } from "./session-runtime-proxy";
 import type { Env } from "../types";
 
@@ -8,6 +9,7 @@ function createCtx(): RequestContext {
   return {
     trace_id: "trace-1",
     request_id: "req-1",
+    db: {} as SqlDatabase,
     metrics: {
       d1Queries: [],
       spans: {},

--- a/packages/control-plane/src/routes/session-ws-token.ts
+++ b/packages/control-plane/src/routes/session-ws-token.ts
@@ -63,7 +63,7 @@ async function handleSessionWsToken(
 
   if (scmUserId && scmToken && scmRefreshToken && env.TOKEN_ENCRYPTION_KEY) {
     ctx.executionCtx?.waitUntil(
-      new UserScmTokenStore(env.DB, env.TOKEN_ENCRYPTION_KEY)
+      new UserScmTokenStore(ctx.db, env.TOKEN_ENCRYPTION_KEY)
         .upsertTokens(
           scmUserId,
           scmToken,

--- a/packages/control-plane/src/routes/shared.ts
+++ b/packages/control-plane/src/routes/shared.ts
@@ -5,6 +5,7 @@
 import { decodeRepositoryPathSegments } from "@open-inspect/shared";
 import type { CorrelationContext } from "../logger";
 import type { RequestMetrics } from "../db/instrumented-d1";
+import type { SqlDatabase } from "../db/sql-database";
 import type { Env } from "../types";
 import type { Logger } from "../logger";
 import {
@@ -19,6 +20,13 @@ import {
  */
 export type RequestContext = CorrelationContext & {
   metrics: RequestMetrics;
+  /**
+   * The request's database handle (the DB binding wrapped with query
+   * instrumentation). Route handlers must use this instead of the raw binding
+   * so every query is timed — an ESLint rule forbids `.DB` access under
+   * src/routes and src/webhooks.
+   */
+  db: SqlDatabase;
   /** Worker ExecutionContext for waitUntil (background tasks). */
   executionCtx?: ExecutionContext;
 };

--- a/packages/control-plane/src/routes/slack-notify.test.ts
+++ b/packages/control-plane/src/routes/slack-notify.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionStatus } from "@open-inspect/shared";
 import { handleSlackNotify } from "./slack-notify";
 import type { RequestContext } from "./shared";
+import type { SqlDatabase } from "../db/sql-database";
 import type { Env } from "../types";
 
 const sessionStoreMock = {
@@ -44,6 +45,7 @@ function createCtx(): RequestContext {
   return {
     trace_id: "trace-1",
     request_id: "req-1",
+    db: {} as SqlDatabase,
     metrics: {
       d1Queries: [],
       spans: {},

--- a/packages/control-plane/src/routes/slack-notify.ts
+++ b/packages/control-plane/src/routes/slack-notify.ts
@@ -55,7 +55,7 @@ export async function handleSlackNotify(
   const parsed = await parseBody(request);
   if (parsed instanceof Response) return parsed;
 
-  const session = await new SessionIndexStore(env.DB).get(sessionId);
+  const session = await new SessionIndexStore(ctx.db).get(sessionId);
   if (!session) {
     return failureResponse("invalid_input", "Session not found.");
   }
@@ -84,7 +84,7 @@ export async function handleSlackNotify(
     return failureResponse("feature_unavailable", "Slack bot token is not configured.");
   }
 
-  const settingsStore = new IntegrationSettingsStore(env.DB);
+  const settingsStore = new IntegrationSettingsStore(ctx.db);
   const settings = repoScope
     ? (await settingsStore.getResolvedConfig("slack", repoScope)).settings
     : ((await settingsStore.getGlobal("slack"))?.defaults ?? {});

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -47,6 +47,7 @@ import { generateId } from "../auth/crypto";
 import { createLogger, parseLogLevel } from "../logger";
 import type { Logger } from "../logger";
 import type { Env } from "../types";
+import type { SqlDatabase } from "../db/sql-database";
 import { initializeSession } from "../session/initialize";
 import { resolveSessionScopedSettings } from "../session/integration-settings-resolution";
 import { resolveAutomationRepositories } from "../automation/repository";
@@ -159,10 +160,13 @@ type StartInvocationResult =
 
 export class SchedulerDO extends DurableObject<Env> {
   private readonly log: Logger;
+  /** The DO's database handle — the single point where env.DB is read. */
+  private readonly db: SqlDatabase;
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
     this.log = createLogger("scheduler-do", {}, parseLogLevel(env.LOG_LEVEL));
+    this.db = env.DB;
   }
 
   /**
@@ -493,7 +497,7 @@ export class SchedulerDO extends DurableObject<Env> {
   // ─── Tick handler ────────────────────────────────────────────────────────
 
   private async handleTick(): Promise<Response> {
-    const store = new AutomationStore(this.env.DB);
+    const store = new AutomationStore(this.db);
     const now = Date.now();
     let processed = 0;
     let skipped = 0;
@@ -794,7 +798,7 @@ export class SchedulerDO extends DurableObject<Env> {
     }
 
     const event = parsedEvent.data;
-    const store = new AutomationStore(this.env.DB);
+    const store = new AutomationStore(this.db);
 
     // 1. Find matching automations
     let candidates: AutomationRow[];
@@ -826,7 +830,7 @@ export class SchedulerDO extends DurableObject<Env> {
         );
         break;
       case "slack":
-        candidates = await new SlackChannelStore(this.env.DB).getSlackAutomationsForChannel(
+        candidates = await new SlackChannelStore(this.db).getSlackAutomationsForChannel(
           event.channelId
         );
         break;
@@ -938,7 +942,7 @@ export class SchedulerDO extends DurableObject<Env> {
 
     const { automationId } = parsedBody.data;
 
-    const store = new AutomationStore(this.env.DB);
+    const store = new AutomationStore(this.db);
     const automation = await store.getById(automationId);
     if (!automation) {
       return new Response(JSON.stringify({ error: "Automation not found" }), {
@@ -999,7 +1003,7 @@ export class SchedulerDO extends DurableObject<Env> {
 
     const body = parsedBody.data;
 
-    const store = new AutomationStore(this.env.DB);
+    const store = new AutomationStore(this.db);
 
     const run = await store.getRunById(body.automationId, body.runId);
     if (!run) {
@@ -1183,7 +1187,7 @@ export class SchedulerDO extends DurableObject<Env> {
   // ─── Health check ────────────────────────────────────────────────────────
 
   private async handleHealth(): Promise<Response> {
-    const store = new AutomationStore(this.env.DB);
+    const store = new AutomationStore(this.db);
     const overdueCount = await store.countOverdue(Date.now());
 
     return new Response(
@@ -1213,7 +1217,7 @@ export class SchedulerDO extends DurableObject<Env> {
     let userId = automation.user_id;
     if (!userId && automation.created_by && automation.created_by !== "anonymous") {
       try {
-        const userStore = new UserStore(this.env.DB);
+        const userStore = new UserStore(this.db);
         const identity = await userStore.getIdentity("github", automation.created_by);
         if (identity) {
           userId = identity.userId;
@@ -1227,6 +1231,7 @@ export class SchedulerDO extends DurableObject<Env> {
       trace_id: `automation:${automation.id}`,
       request_id: run.id,
       metrics: createRequestMetrics(),
+      db: this.db,
     };
 
     // What the session opens — the run's repository snapshot or, for
@@ -1244,7 +1249,7 @@ export class SchedulerDO extends DurableObject<Env> {
         ? [{ repoOwner: target.repoOwner, repoName: target.repoName }]
         : []);
     const { codeServerEnabled, sandboxSettings } = await resolveSessionScopedSettings(
-      this.env.DB,
+      this.db,
       scopeMembers,
       target.environmentId
     );

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -166,6 +166,7 @@ export class SchedulerDO extends DurableObject<Env> {
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
     this.log = createLogger("scheduler-do", {}, parseLogLevel(env.LOG_LEVEL));
+    // eslint-disable-next-line no-restricted-syntax -- composition root: the DO's one env.DB read
     this.db = env.DB;
   }
 

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -252,6 +252,7 @@ export class SessionDO extends DurableObject<Env> {
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
+    // eslint-disable-next-line no-restricted-syntax -- composition root: the DO's one env.DB read
     this.db = env.DB ?? null;
     this.sql = ctx.storage.sql;
     this.attachmentRepository = new SessionAttachmentRepository(this.sql);

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -56,6 +56,7 @@ import type {
   SessionState,
   SandboxStatus,
 } from "../types";
+import type { SqlDatabase } from "../db/sql-database";
 import type { SessionRow, ArtifactRow, SandboxRow } from "./types";
 import { SessionRepository } from "./repository";
 import { SessionAttachmentRepository } from "./session-attachment-repository";
@@ -145,6 +146,12 @@ type BoundarySchema<T> = {
 
 export class SessionDO extends DurableObject<Env> {
   private sql: SqlStorage;
+  /**
+   * The DO's global-database handle — the single point where env.DB is read.
+   * Nullable to preserve the existing defensive guards against a missing
+   * binding at runtime. Distinct from `this.sql`, the DO-embedded SQLite.
+   */
+  private readonly db: SqlDatabase | null;
   private repository: SessionRepository;
   private attachmentRepository: SessionAttachmentRepository;
   private initialized = false;
@@ -245,6 +252,7 @@ export class SessionDO extends DurableObject<Env> {
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
+    this.db = env.DB ?? null;
     this.sql = ctx.storage.sql;
     this.attachmentRepository = new SessionAttachmentRepository(this.sql);
     this.repository = new SessionRepository(
@@ -283,8 +291,8 @@ export class SessionDO extends DurableObject<Env> {
   private get participantService(): ParticipantService {
     if (!this._participantService) {
       const userScmTokenStore =
-        this.env.DB && this.env.TOKEN_ENCRYPTION_KEY
-          ? new UserScmTokenStore(this.env.DB, this.env.TOKEN_ENCRYPTION_KEY)
+        this.db && this.env.TOKEN_ENCRYPTION_KEY
+          ? new UserScmTokenStore(this.db, this.env.TOKEN_ENCRYPTION_KEY)
           : null;
       this._participantService = new ParticipantService({
         repository: this.repository,
@@ -373,7 +381,7 @@ export class SessionDO extends DurableObject<Env> {
         this.callbackService,
         this.statusService,
         this.lifecycleManager,
-        this.env.DB ? new SessionIndexStore(this.env.DB) : null,
+        this.db ? new SessionIndexStore(this.db) : null,
         resolveScmProviderFromEnv(this.env.SCM_PROVIDER),
         this.executionTimeoutMs
       );
@@ -438,15 +446,14 @@ export class SessionDO extends DurableObject<Env> {
         getSession: () => this.getSession(),
         refreshOpenAIToken: async (session, log) => {
           const service = new OpenAITokenRefreshService(
-            this.env.DB!,
+            this.db!,
             this.env.REPO_SECRETS_ENCRYPTION_KEY!,
             (sessionRow) => this.ensureRepoId(sessionRow),
             log
           );
           return service.refresh(session);
         },
-        isOpenAISecretsConfigured: () =>
-          Boolean(this.env.DB && this.env.REPO_SECRETS_ENCRYPTION_KEY),
+        isOpenAISecretsConfigured: () => Boolean(this.db && this.env.REPO_SECRETS_ENCRYPTION_KEY),
         getScmCredentials: (log) =>
           new ScmCredentialsService(this.sourceControlProvider, log).getCredentials(),
         messenger: this.messenger,
@@ -533,7 +540,7 @@ export class SessionDO extends DurableObject<Env> {
             pushBranchToRemote: (pushSpec) => this.pushBranchToRemote(pushSpec),
             messenger: this.messenger,
             appName: resolveAppName(this.env),
-            sessionPullRequests: this.env.DB ? new SessionPullRequestStore(this.env.DB) : undefined,
+            sessionPullRequests: this.db ? new SessionPullRequestStore(this.db) : undefined,
           });
 
           return pullRequestService.createPullRequest(input);
@@ -555,7 +562,7 @@ export class SessionDO extends DurableObject<Env> {
       refreshSessionPullRequests(
         this.repository,
         this.sourceControlProvider,
-        this.env.DB ? new SessionPullRequestStore(this.env.DB) : null
+        this.db ? new SessionPullRequestStore(this.db) : null
       )
         .then(({ updated, failures }) => {
           for (const artifact of updated) {
@@ -641,7 +648,7 @@ export class SessionDO extends DurableObject<Env> {
         this.log,
         this.repository,
         this.messenger,
-        this.env.DB ? new SessionIndexStore(this.env.DB) : null,
+        this.db ? new SessionIndexStore(this.db) : null,
         this.env.SESSION ?? null
       );
     }
@@ -754,8 +761,8 @@ export class SessionDO extends DurableObject<Env> {
 
     // Create D1-backed lookups if database is available
     let mcpServerLookup: McpServerLookup | undefined;
-    if (this.env.DB) {
-      const mcpStore = new McpServerStore(this.env.DB, this.env.REPO_SECRETS_ENCRYPTION_KEY);
+    if (this.db) {
+      const mcpStore = new McpServerStore(this.db, this.env.REPO_SECRETS_ENCRYPTION_KEY);
       mcpServerLookup = {
         getDecryptedForSession: (repositories) => mcpStore.getDecryptedForSession(repositories),
       };
@@ -766,9 +773,9 @@ export class SessionDO extends DurableObject<Env> {
     // per-feature scope rules. Token absence short-circuits to false so a
     // misconfigured deployment never installs a tool that would 503 on every call.
     let slackAgentNotifyLookup: SlackAgentNotifyLookup | undefined;
-    if (this.env.DB) {
+    if (this.db) {
       const tokenPresent = !!this.env.SLACK_BOT_TOKEN;
-      const settingsStore = new IntegrationSettingsStore(this.env.DB);
+      const settingsStore = new IntegrationSettingsStore(this.db);
       slackAgentNotifyLookup = {
         isEnabledForRepo: async (repoOwner, repoName) => {
           if (!tokenPresent) return false;
@@ -805,8 +812,8 @@ export class SessionDO extends DurableObject<Env> {
     // prebuilt images.
     let imageBuildLookup: ImageBuildLookup | undefined;
     const imageBuildProvider = resolveImageBuildProvider(sandboxBackend);
-    if (this.env.DB && imageBuildProvider) {
-      imageBuildLookup = createImageBuildLookup(this.env.DB, imageBuildProvider);
+    if (this.db && imageBuildProvider) {
+      imageBuildLookup = createImageBuildLookup(this.db, imageBuildProvider);
     }
 
     return new SandboxLifecycleManager(
@@ -1552,8 +1559,8 @@ export class SessionDO extends DurableObject<Env> {
   }
 
   private syncSessionIndexTitle(sessionId: string, title: string, updatedAt: number): void {
-    if (!this.env.DB) return;
-    const sessionStore = new SessionIndexStore(this.env.DB);
+    if (!this.db) return;
+    const sessionStore = new SessionIndexStore(this.db);
     this.ctx.waitUntil(
       sessionStore.updateTitleIfNewer(sessionId, title, updatedAt).catch((error) => {
         this.log.error("session_index.update_title.background_error", {
@@ -1684,11 +1691,11 @@ export class SessionDO extends DurableObject<Env> {
    * lookup failure resolves null rather than failing the whole state read.
    */
   private async resolveEnvironmentName(environmentId: string | null): Promise<string | null> {
-    if (!environmentId || !this.env.DB) {
+    if (!environmentId || !this.db) {
       return null;
     }
     try {
-      const environment = await new EnvironmentStore(this.env.DB).getById(environmentId);
+      const environment = await new EnvironmentStore(this.db).getById(environmentId);
       return environment?.name ?? null;
     } catch (e) {
       this.log.warn("Failed to resolve environment name for session state", {
@@ -1795,9 +1802,9 @@ export class SessionDO extends DurableObject<Env> {
       return undefined;
     }
 
-    if (!this.env.DB || !this.env.REPO_SECRETS_ENCRYPTION_KEY) {
+    if (!this.db || !this.env.REPO_SECRETS_ENCRYPTION_KEY) {
       this.log.debug("Secrets not configured, skipping", {
-        has_db: !!this.env.DB,
+        has_db: !!this.db,
         has_encryption_key: !!this.env.REPO_SECRETS_ENCRYPTION_KEY,
       });
       return undefined;
@@ -1805,11 +1812,11 @@ export class SessionDO extends DurableObject<Env> {
 
     // Fail hard on secret loading — sandboxes must not silently lose secrets
     const encryptionKey = this.env.REPO_SECRETS_ENCRYPTION_KEY;
-    const globalStore = new GlobalSecretsStore(this.env.DB, encryptionKey);
+    const globalStore = new GlobalSecretsStore(this.db, encryptionKey);
     const globalSecrets = await globalStore.getDecryptedSecrets();
 
-    const repoStore = new RepoSecretsStore(this.env.DB, encryptionKey);
-    const environmentSecretsStore = new EnvironmentSecretsStore(this.env.DB, encryptionKey);
+    const repoStore = new RepoSecretsStore(this.db, encryptionKey);
+    const environmentSecretsStore = new EnvironmentSecretsStore(this.db, encryptionKey);
     const sources = await buildSessionTargetSecretSources({
       environmentId: session.environment_id,
       globalSecrets,

--- a/packages/control-plane/src/session/identity.test.ts
+++ b/packages/control-plane/src/session/identity.test.ts
@@ -351,7 +351,7 @@ describe("resolveGitHubEnrichment", () => {
       { provider: "google", providerUserId: "google-sub-1", providerEmail: "pm@gmail.com" },
     ]);
 
-    await expect(resolveGitHubEnrichment(env, store, "user-1")).resolves.toBeNull();
+    await expect(resolveGitHubEnrichment(env, env.DB, store, "user-1")).resolves.toBeNull();
   });
 
   it("enriches from the linked GitHub identity, never the Google one", async () => {
@@ -368,7 +368,7 @@ describe("resolveGitHubEnrichment", () => {
       { id: "user-1", displayName: "PM Person", email: "pm@gmail.com" }
     );
 
-    const enrichment = await resolveGitHubEnrichment(env, store, "user-1");
+    const enrichment = await resolveGitHubEnrichment(env, env.DB, store, "user-1");
 
     expect(enrichment).not.toBeNull();
     // The SCM identifier is the GitHub provider id — never the Google sub.

--- a/packages/control-plane/src/session/identity.ts
+++ b/packages/control-plane/src/session/identity.ts
@@ -2,6 +2,7 @@ import type { SpawnSource } from "@open-inspect/shared";
 import { UserScmTokenStore } from "../db/user-scm-tokens";
 import type { ProviderIdentity, UserStore } from "../db/user-store";
 import type { Env } from "../types";
+import type { SqlDatabase } from "../db/sql-database";
 
 export interface GitHubEnrichment {
   scmUserId: string;
@@ -164,6 +165,7 @@ export function deriveParticipantUserId(body: SessionIdentityFields): string {
  */
 export async function resolveGitHubEnrichment(
   env: Env,
+  db: SqlDatabase,
   userStore: UserStore,
   userId: string
 ): Promise<GitHubEnrichment | null> {
@@ -174,7 +176,7 @@ export async function resolveGitHubEnrichment(
   const [user, tokens] = await Promise.all([
     userStore.getUserById(userId),
     env.TOKEN_ENCRYPTION_KEY
-      ? new UserScmTokenStore(env.DB, env.TOKEN_ENCRYPTION_KEY).getEncryptedTokens(
+      ? new UserScmTokenStore(db, env.TOKEN_ENCRYPTION_KEY).getEncryptedTokens(
           githubIdentity.providerUserId
         )
       : null,

--- a/packages/control-plane/src/session/initialize.ts
+++ b/packages/control-plane/src/session/initialize.ts
@@ -124,7 +124,7 @@ export async function initializeSession(
       : [];
 
   // Step 1: D1 index (must succeed before DO init starts sandbox warming)
-  const sessionStore = new SessionIndexStore(env.DB);
+  const sessionStore = new SessionIndexStore(ctx.db);
   await sessionStore.create({
     id: input.sessionId,
     title: input.title || null,

--- a/packages/control-plane/src/webhooks/automation-webhook.ts
+++ b/packages/control-plane/src/webhooks/automation-webhook.ts
@@ -16,7 +16,7 @@ async function handleAutomationWebhook(
   request: Request,
   env: Env,
   match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const automationId = match.groups?.id;
   if (!automationId) return error("Automation ID required", 400);
@@ -33,7 +33,7 @@ async function handleAutomationWebhook(
   if (!apiKey) return error("Missing API key", 401);
 
   // 3. Look up automation
-  const store = new AutomationStore(env.DB);
+  const store = new AutomationStore(ctx.db);
   const automation = await store.getById(automationId);
   if (!automation || automation.trigger_type !== "webhook") {
     return error("Not found", 404);

--- a/packages/control-plane/src/webhooks/github.ts
+++ b/packages/control-plane/src/webhooks/github.ts
@@ -47,7 +47,7 @@ async function trackPullRequestLifecycle(
     parseLogLevel(env.LOG_LEVEL)
   );
   try {
-    if (!env.DB || !env.SESSION) return;
+    if (!ctx.db || !env.SESSION) return;
 
     const parsed = automationEventSchema.safeParse(rawEvent);
     if (!parsed.success) {
@@ -67,8 +67,8 @@ async function trackPullRequestLifecycle(
 
     const sessionRuntime = createSessionRuntimeClient(env, ctx);
     const deps: PullRequestLifecycleDeps = {
-      store: new SessionPullRequestStore(env.DB),
-      sessions: new SessionIndexStore(env.DB),
+      store: new SessionPullRequestStore(ctx.db),
+      sessions: new SessionIndexStore(ctx.db),
       listSessionArtifacts: async (sessionId): Promise<SessionArtifactSummary[]> => {
         const response = await sessionRuntime.fetch(sessionId, SessionInternalPaths.artifacts, {
           method: "GET",

--- a/packages/control-plane/src/webhooks/github.ts
+++ b/packages/control-plane/src/webhooks/github.ts
@@ -47,7 +47,7 @@ async function trackPullRequestLifecycle(
     parseLogLevel(env.LOG_LEVEL)
   );
   try {
-    if (!ctx.db || !env.SESSION) return;
+    if (!env.SESSION) return;
 
     const parsed = automationEventSchema.safeParse(rawEvent);
     if (!parsed.success) {

--- a/packages/control-plane/src/webhooks/sentry.ts
+++ b/packages/control-plane/src/webhooks/sentry.ts
@@ -17,13 +17,13 @@ async function handleSentryWebhook(
   request: Request,
   env: Env,
   match: RegExpMatchArray,
-  _ctx: RequestContext
+  ctx: RequestContext
 ): Promise<Response> {
   const automationId = match.groups?.id;
   if (!automationId) return error("Automation ID required", 400);
 
   // 1. Look up the automation
-  const store = new AutomationStore(env.DB);
+  const store = new AutomationStore(ctx.db);
   const automation = await store.getById(automationId);
   if (!automation || automation.trigger_type !== "sentry") {
     return error("Not found", 404);

--- a/packages/control-plane/test/integration/image-build-stale-recovery.test.ts
+++ b/packages/control-plane/test/integration/image-build-stale-recovery.test.ts
@@ -51,13 +51,12 @@ function createTriggerWorkflow(scope: ImageBuildScope): ImageBuildWorkflow {
       },
       callbackAuth: { type: "none" },
     }),
-  } as unknown as ConstructorParameters<typeof ImageBuildWorkflow>[4];
+  } as unknown as NonNullable<ConstructorParameters<typeof ImageBuildWorkflow>[3]>["planner"];
   return new ImageBuildWorkflow(
     { ...env, WORKER_URL: "https://worker.test" } as Env,
     new ImageBuildStore(env.DB),
     factory,
-    "modal",
-    planner
+    { provider: "modal", planner }
   );
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1046. The `SqlDatabase` port now reaches consumers by **dependency injection at the top of each call layer** instead of riding through `Env`: the raw `env.DB` binding is read in exactly **three places** — the router's request entry and the two Durable Object constructors — and everything downstream receives an injected `SqlDatabase`.

This collects the payoff #1046 deferred: `instrumentD1` no longer impersonates the full `D1Database`, deleting its `exec`/`dump`/`raw` passthrough members, `RawCapableStatement`, `hasRawMethod`, and both `as` casts. The wrapper is now an honest, compile-checked implementation of the port.

## What changed

**Routes** (`src/routes/`, `src/webhooks/`, 22 files)
- `RequestContext` gains `db: SqlDatabase`. The router builds `instrumentD1(env.DB, metrics)` once per request and puts it on the context; the `{ ...env, DB: instrumentD1(...) }` spread is gone.
- Handlers construct stores from `ctx.db`. Helpers that used to dig `env.DB` out of an `Env` they were handed now take an explicit `db` parameter (`resolveScopeTarget`, `listEnabledScopeUnits`, `loadScopeBuildSecrets`, `createImageBuildWorkflowFromEnv`, `resolveGitHubEnrichment`, per-file `requireDb`-style guards).
- `ImageBuildPlanner` takes `db` in its constructor; `ImageBuildWorkflow` no longer self-constructs a planner (the factory injects it — the constructor fallback was factory-only, tests always inject fakes).

**Durable Objects**
- `SessionDO` and `SchedulerDO` each read `env.DB` once in the constructor into a `db` field; all store construction goes through the field. `SessionDO`'s field is nullable to preserve its existing defensive guards.
- `SchedulerDO`'s synthesized automation `RequestContext` carries `db: this.db`, so shared helpers (`initializeSession`, `resolveAutomationSessionTarget`) are uniform across routes and DOs.

**Instrumentation** (`src/db/instrumented-d1.ts`)
- `instrumentD1(db: SqlDatabase, metrics): SqlDatabase`. Impersonation surface deleted (~45 lines); zero casts claiming a shape the object doesn't have. The `ORIGINAL_STMT` unwrap stays — real D1 must receive its own statements in `batch()` (the same-origin contract documented in the port).
- `SqlResultMeta` gains optional `duration`/`rows_read`/`rows_written` — observability-only metadata the wrapper reads; `changes` remains the only required field and the only one consumers may gate correctness on.

**Boundary enforcement**
- New scoped ESLint rule: `.DB` member access is an error under `src/routes/` and `src/webhooks/` — a missed conversion would have silently bypassed query instrumentation; now it can't come back. `env.DB` outside the three injection points is grep-clean.

## Behavior notes

- Same object references flow as before on every instrumented path; the visible deltas are (a) the instrumented wrapper no longer exposes `exec`/`dump`/`raw`/`withSession` (nothing called them — enforced by the port since #1046), and (b) routes previously reading the instrumented DB via `env.DB` read the identical instance via `ctx.db`.
- Degraded-mode guards preserved: several handlers return 503/null-payload responses when the DB binding is absent at runtime (deployment misconfiguration). The router builds `ctx.db` as `env.DB && instrumentD1(...)`, so its runtime truthiness tracks the binding exactly and those guards behave as before.
- DO query instrumentation is deliberately unchanged (DOs still run uninstrumented). Turning it on is now a one-line decision per DO constructor plus a metrics-collector design question — proposed separately.

## Engine-selection point

When a second engine exists, backend selection lands at the three injection sites (router + two DO constructors), with the adapter contract-test suite committed to in #1046's review threads (atomicity/snapshot/positional-batch semantics, foreign-statement handling, required `meta.changes`).

## Test changes (12 files, +54/−43 — all mechanical)

- Route tests: `RequestContext` fixtures gain a `db` field (inert `{}` where stores are module-mocked, the existing `batch` fake in `automations.test.ts`).
- `scope.test.ts` / `identity.test.ts` / `session-target.test.ts`: new explicit `db` arguments mirroring the signature changes.
- `instrumented-d1.test.ts`: the three passthrough tests for deleted members (`raw`/`exec`/`dump`) are removed; all timing-capture tests unchanged and passing.

## Verification

- `npm run build`, `npm run typecheck` (prod + test tsconfigs, all packages), `npm run lint` (including the new boundary rule), `npm run format:check` — clean
- Unit: 121 files / **2009 passed**. Integration (workerd + real D1 through the real router, exercising `ctx.db` end-to-end): 49 files / **571 passed**
- Grep gates: `env.DB` appears only at `router.ts` and the two DO constructors; zero `.DB` under routes/webhooks (ESLint-enforced)
- No files moved or renamed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added request-scoped, instrumented database access across control-plane routes, webhooks, sessions, automations, and image builds.
  * Expanded query observability metadata with optional duration and row-count fields.

* **Bug Fixes**
  * Prevented direct access to the raw database binding by consistently using the request context database handle.
  * Improved “database not configured” behavior with clearer fallback responses for affected endpoints.

* **Tests**
  * Updated mocks and unit/integration coverage to reflect the revised request-context database wiring and instrumentation model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->