### PR TITLE
Remove orphaned Modal image variants

### DIFF
--- a/packages/modal-infra/src/images/base.py
+++ b/packages/modal-infra/src/images/base.py
@@ -211,15 +211,3 @@ base_image = (
         remote_path="/app/sandbox_runtime",
     )
 )
-
-# Image variant optimized for Node.js/TypeScript projects
-node_image = base_image.run_commands(
-    # Pre-cache common Node.js development dependencies
-    "npm cache clean --force",
-)
-
-# Image variant optimized for Python projects
-python_image = base_image.run_commands(
-    # Pre-create virtual environment
-    "uv venv /workspace/.venv",
-)


### PR DESCRIPTION
## Summary
- remove the unused `node_image` Modal image definition
- remove the unused `python_image` Modal image definition
- leave the shared `base_image` definition unchanged

## Verification
- confirmed repository-wide source/test searches only found each name at its definition
- `uv run --frozen ruff check src/images/base.py`
- `uv run --frozen pytest tests/test_image_builder_v2.py tests/test_build_sandbox.py -v` (38 passed)
- pre-commit lint-staged hooks passed

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/c1d645c0d156c214f6930a8474fd9092)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the available application image configuration by consolidating it to a single base image.
  * Removed specialized preconfigured variants for Node.js/TypeScript and Python environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->