### PR TITLE
Remove OpenComputer timeout identity helper

### DIFF
--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -117,7 +117,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
       });
       secretStore = await this.createSecretStoreFor(config.sessionId, environment.secretEnvVars);
       const labels = this.buildLabels(config);
-      const timeoutSeconds = resolveOpenComputerTimeoutSeconds(config.timeoutSeconds);
+      const timeoutSeconds = config.timeoutSeconds;
       const sandbox = config.prebuiltImageId
         ? await this.client.forkFromCheckpoint({
             checkpointId: config.prebuiltImageId,
@@ -184,7 +184,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
         restoredFromSnapshot: true,
       });
       secretStore = await this.createSecretStoreFor(config.sessionId, environment.secretEnvVars);
-      const timeoutSeconds = resolveOpenComputerTimeoutSeconds(config.timeoutSeconds);
+      const timeoutSeconds = config.timeoutSeconds;
       const sandbox = await this.client.forkFromCheckpoint({
         checkpointId: config.snapshotImageId,
         name: config.sandboxId,
@@ -286,7 +286,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
       }
 
       if (wokeSandbox) {
-        const timeoutSeconds = resolveOpenComputerTimeoutSeconds(config.timeoutSeconds);
+        const timeoutSeconds = config.timeoutSeconds;
         if (timeoutSeconds !== undefined) {
           await this.client.setSandboxTimeout(config.providerObjectId, timeoutSeconds);
         }
@@ -729,10 +729,6 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
     }
     return SandboxProviderError.fromFetchError(message, error);
   }
-}
-
-function resolveOpenComputerTimeoutSeconds(timeoutSeconds: number | undefined): number | undefined {
-  return timeoutSeconds;
 }
 
 function copyDefinedEnvVars(


### PR DESCRIPTION
## Summary
- remove the identity-only `resolveOpenComputerTimeoutSeconds` helper
- use `config.timeoutSeconds` directly at the create, restore, and resume call sites
- preserve the existing seconds units and `undefined` handling

## Verification
- `npm test -w @open-inspect/control-plane -- src/sandbox/providers/opencomputer-provider.test.ts` (29 tests passed)
- `npm run typecheck -w @open-inspect/control-plane`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/2de6be755e4f826dcb0288368ab5e2e5)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified sandbox session timeout handling.
  * Preserved existing timeout behavior when creating, restoring, or resuming sandbox sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->