### PR TITLE
Remove unused Modal sandbox backend helper

### DIFF
--- a/packages/control-plane/src/sandbox/index.ts
+++ b/packages/control-plane/src/sandbox/index.ts
@@ -95,11 +95,7 @@ export {
   type OpenComputerCreateSandboxParams,
   type OpenComputerDeleteSandboxOptions,
 } from "./opencomputer-rest-client";
-export {
-  resolveSandboxBackendName,
-  isModalSandboxBackend,
-  type SandboxBackendName,
-} from "./provider-name";
+export { resolveSandboxBackendName, type SandboxBackendName } from "./provider-name";
 
 // Lifecycle decisions
 export {

--- a/packages/control-plane/src/sandbox/provider-name.test.ts
+++ b/packages/control-plane/src/sandbox/provider-name.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveSandboxBackendName, isModalSandboxBackend } from "./provider-name";
+import { resolveSandboxBackendName } from "./provider-name";
 
 describe("resolveSandboxBackendName", () => {
   it("defaults to modal when undefined", () => {
@@ -54,31 +54,5 @@ describe("resolveSandboxBackendName", () => {
   it("throws for unsupported provider", () => {
     expect(() => resolveSandboxBackendName("k8s")).toThrow("Unsupported SANDBOX_PROVIDER: k8s");
     expect(() => resolveSandboxBackendName("fly")).toThrow("Unsupported SANDBOX_PROVIDER: fly");
-  });
-});
-
-describe("isModalSandboxBackend", () => {
-  it("returns true for modal", () => {
-    expect(isModalSandboxBackend("modal")).toBe(true);
-  });
-
-  it("returns true for undefined (default)", () => {
-    expect(isModalSandboxBackend(undefined)).toBe(true);
-  });
-
-  it("returns false for e2b", () => {
-    expect(isModalSandboxBackend("e2b")).toBe(false);
-  });
-
-  it("returns false for daytona", () => {
-    expect(isModalSandboxBackend("daytona")).toBe(false);
-  });
-
-  it("returns false for vercel", () => {
-    expect(isModalSandboxBackend("vercel")).toBe(false);
-  });
-
-  it("returns false for opencomputer", () => {
-    expect(isModalSandboxBackend("opencomputer")).toBe(false);
   });
 });

--- a/packages/control-plane/src/sandbox/provider-name.ts
+++ b/packages/control-plane/src/sandbox/provider-name.ts
@@ -34,7 +34,3 @@ export function resolveSandboxBackendName(value: string | undefined): SandboxBac
 
   throw new Error(`Unsupported SANDBOX_PROVIDER: ${value}`);
 }
-
-export function isModalSandboxBackend(value: string | undefined): boolean {
-  return resolveSandboxBackendName(value) === "modal";
-}


### PR DESCRIPTION
## Summary
- remove the unused exported `isModalSandboxBackend` helper
- remove its sandbox barrel re-export
- remove the helper-specific unit tests while preserving resolver coverage
- leave the inline Modal dashboard URL gate unchanged

## Verification
- `npm test -w @open-inspect/control-plane -- src/sandbox/provider-name.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/c4c1204f320f65a6f518fc91d65c1305)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sandbox provider recognition by normalizing supported provider names consistently.
  - Added clearer errors when an unsupported sandbox provider is configured.
- **Refactor**
  - Consolidated provider resolution into a single helper, improving consistency across sandbox configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->