### PR TITLE
Remove dead Modal health client plumbing

### DIFF
--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -73,22 +73,6 @@ describe("ModalClient", () => {
     vi.restoreAllMocks();
   });
 
-  it("uses the Modal environment web suffix in endpoint URLs", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ success: true, data: { status: "ok", service: "modal" } }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      })
-    );
-
-    const client = createModalClient("secret", "acme", "prod-web");
-    await client.health();
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://acme-prod-web--open-inspect-api-health.modal.run"
-    );
-  });
-
   it("routes the restore session_config through buildSessionConfig (carries mcp_servers)", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ success: true, data: { sandbox_id: "sb-1" } }), {

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -251,7 +251,6 @@ export class ModalApiError extends Error {
  */
 export class ModalClient {
   private createSandboxUrl: string;
-  private healthUrl: string;
   private snapshotSandboxUrl: string;
   private restoreSandboxUrl: string;
   private buildImageUrl: string;
@@ -268,7 +267,6 @@ export class ModalClient {
     this.secret = secret;
     const baseUrl = getModalBaseUrl(workspace, environmentWebSuffix);
     this.createSandboxUrl = `${baseUrl}-api-create-sandbox.modal.run`;
-    this.healthUrl = `${baseUrl}-api-health.modal.run`;
     this.snapshotSandboxUrl = `${baseUrl}-api-snapshot-sandbox.modal.run`;
     this.restoreSandboxUrl = `${baseUrl}-api-restore-sandbox.modal.run`;
     this.buildImageUrl = `${baseUrl}-api-build-image.modal.run`;
@@ -506,29 +504,6 @@ export class ModalClient {
         outcome,
       });
     }
-  }
-
-  /**
-   * Check Modal API health.
-   * Note: Health endpoint does not require authentication.
-   */
-  async health(): Promise<{ status: string; service: string }> {
-    const response = await fetch(this.healthUrl);
-
-    if (!response.ok) {
-      throw new ModalApiError(`Modal API error: ${response.status}`, response.status);
-    }
-
-    const result = (await response.json()) as ModalApiResponse<{
-      status: string;
-      service: string;
-    }>;
-
-    if (!result.success || !result.data) {
-      throw new Error(`Modal API error: ${result.error || "Unknown error"}`);
-    }
-
-    return result.data;
   }
 
   /**


### PR DESCRIPTION
## Summary
- remove the unused `ModalClient.health()` method
- remove its private `healthUrl` field and constructor initialization
- remove the dedicated dead-method unit test
- preserve Modal's Python `api_health` endpoint because it is an intentional operator-facing probe documented in onboarding, deployment outputs, and troubleshooting guides

## Verification
- `npm test -w @open-inspect/control-plane -- src/sandbox/client.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane -- --no-warn-ignored src/sandbox/client.ts src/sandbox/client.test.ts`
- `uv run --extra dev pytest tests/test_web_api_create_sandbox.py tests/test_web_api_build_image.py -v`
- `uv run --extra dev ruff check src/web_api.py tests/test_web_api_create_sandbox.py tests/test_web_api_build_image.py`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/31e7e0c31614189375aaa5e1c797c0ed)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the sandbox health-check operation from the control-plane client.
  * Sandbox workflows now proceed directly after creating a snapshot, without performing a health check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->