### PR TITLE
fix: keep prompt stream alive during compaction

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
@@ -82,6 +82,7 @@ class _PromptState:
     # Compaction tracking: after compaction, parentID changes so we must
     # accept all non-summary assistant messages from the parent session
     compaction_occurred: bool = False
+    correlated_compaction_summary_ids: set[str] = field(default_factory=set)
     emitted_error_messages: set[str] = field(default_factory=set)
 
 
@@ -334,9 +335,11 @@ class OpenCodePromptStream:
 
             events: list[dict[str, Any]] = []
             if role == "assistant" and oc_msg_id:
+                if is_compaction_summary and parent_matches:
+                    state.correlated_compaction_summary_ids.add(oc_msg_id)
                 belongs_to_prompt = (
                     parent_matches
-                    or is_compaction_summary
+                    or oc_msg_id in state.correlated_compaction_summary_ids
                     or (state.compaction_occurred and not is_compaction_summary)
                 )
                 if belongs_to_prompt and info.get("error"):

--- a/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 # Cap on parts buffered for assistant messages that have not been authorized
 # yet (their message.updated may arrive after their first parts).
 MAX_PENDING_PART_EVENTS: Final = 2000
+CONTEXT_OVERFLOW_ERROR_NAME: Final = "ContextOverflowError"
 
 # Anthropic extended thinking budget tokens by reasoning effort level.
 # "max" uses 31,999 — the API maximum for streaming responses.
@@ -81,6 +82,7 @@ class _PromptState:
     # Compaction tracking: after compaction, parentID changes so we must
     # accept all non-summary assistant messages from the parent session
     compaction_occurred: bool = False
+    emitted_error_messages: set[str] = field(default_factory=set)
 
 
 class _Disposition(Enum):
@@ -332,11 +334,26 @@ class OpenCodePromptStream:
 
             events: list[dict[str, Any]] = []
             if role == "assistant" and oc_msg_id:
+                belongs_to_prompt = (
+                    parent_matches
+                    or is_compaction_summary
+                    or (state.compaction_occurred and not is_compaction_summary)
+                )
+                if belongs_to_prompt and info.get("error"):
+                    error_event = self._parent_error_event_once(state, info["error"])
+                    if error_event:
+                        self._log.error(
+                            "bridge.message_error",
+                            error_msg=error_event["error"],
+                            oc_msg_id=oc_msg_id,
+                        )
+                        events.append(error_event)
+
                 # Accept if: parentID matches our message, OR compaction
                 # happened and this isn't the compaction summary itself
                 if parent_matches or (state.compaction_occurred and not is_compaction_summary):
                     state.allowed_assistant_msg_ids.add(oc_msg_id)
-                    events = self._drain_pending_parts(state, oc_msg_id, is_subtask=False)
+                    events.extend(self._drain_pending_parts(state, oc_msg_id, is_subtask=False))
 
             if finish and finish not in ("tool-calls", ""):
                 self._log.debug(
@@ -385,16 +402,20 @@ class OpenCodePromptStream:
         error_session_id = props.get("sessionID")
 
         if error_session_id == state.opencode_session_id:
-            error_msg = self._extract_error_message(props.get("error", {}))
-            self._log.error("bridge.session_error", error_msg=error_msg)
+            error = props.get("error", {})
+            if isinstance(error, dict) and error.get("name") == CONTEXT_OVERFLOW_ERROR_NAME:
+                # With OpenCode's default automatic compaction enabled, this event
+                # announces recovery; session.compacted and more work follow it.
+                self._log.info(
+                    "bridge.context_overflow_compacting",
+                    error_msg=self._extract_error_message(error),
+                )
+                return _StreamStep(events=[], disposition=_Disposition.CONTINUE)
+
+            error_event = self._parent_error_event_once(state, error)
+            self._log.error("bridge.session_error", error_msg=error_event and error_event["error"])
             return _StreamStep(
-                events=[
-                    {
-                        "type": "error",
-                        "error": error_msg or "Unknown error",
-                        "messageId": state.message_id,
-                    }
-                ],
+                events=[error_event] if error_event else [],
                 disposition=_Disposition.FAILED,
             )
 
@@ -419,6 +440,18 @@ class OpenCodePromptStream:
             )
 
         return _StreamStep(events=[], disposition=_Disposition.CONTINUE)
+
+    def _parent_error_event_once(self, state: _PromptState, error: object) -> dict[str, Any] | None:
+        """Build one parent error event across message.updated and session.error."""
+        error_msg = self._extract_error_message(error) or "Unknown error"
+        if error_msg in state.emitted_error_messages:
+            return None
+        state.emitted_error_messages.add(error_msg)
+        return {
+            "type": "error",
+            "error": error_msg,
+            "messageId": state.message_id,
+        }
 
     def _handle_part(
         self,

--- a/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
@@ -84,6 +84,10 @@ class _PromptState:
     compaction_occurred: bool = False
     correlated_compaction_summary_ids: set[str] = field(default_factory=set)
     emitted_error_messages: set[str] = field(default_factory=set)
+    # Set when a parent context-overflow announcement was swallowed; cleared by
+    # session.compacted. If still set at idle with no error emitted, the
+    # promised compaction never happened and the prompt must fail.
+    pending_overflow_error: str | None = None
 
 
 class _Disposition(Enum):
@@ -268,6 +272,7 @@ class OpenCodePromptStream:
             # Only parent idle terminates the stream
             if props.get("sessionID") == state.opencode_session_id:
                 self._log_parent_idle(state, "bridge.session_idle")
+                events.extend(self._unrecovered_overflow_events(state))
                 return _StreamStep(events=events, disposition=_Disposition.FINISHED_IDLE)
 
         elif event_type == "session.status":
@@ -275,6 +280,7 @@ class OpenCodePromptStream:
             # Only parent status=idle terminates the stream
             if props.get("sessionID") == state.opencode_session_id and status.get("type") == "idle":
                 self._log_parent_idle(state, "bridge.session_status_idle")
+                events.extend(self._unrecovered_overflow_events(state))
                 return _StreamStep(events=events, disposition=_Disposition.FINISHED_IDLE)
 
         elif event_type == "session.error":
@@ -283,6 +289,7 @@ class OpenCodePromptStream:
         elif event_type == "session.compacted":
             if props.get("sessionID") == state.opencode_session_id:
                 state.compaction_occurred = True
+                state.pending_overflow_error = None
                 self._log.info("bridge.session_compacted", message_id=state.message_id)
 
         return _StreamStep(events=events, disposition=_Disposition.CONTINUE)
@@ -353,8 +360,11 @@ class OpenCodePromptStream:
                         events.append(error_event)
 
                 # Accept if: parentID matches our message, OR compaction
-                # happened and this isn't the compaction summary itself
-                if parent_matches or (state.compaction_occurred and not is_compaction_summary):
+                # happened — but never the compaction summary itself, whose
+                # text is internal context, not assistant output. Its parentID
+                # is the compaction user message, so parentID alone cannot
+                # exclude it.
+                if not is_compaction_summary and (parent_matches or state.compaction_occurred):
                     state.allowed_assistant_msg_ids.add(oc_msg_id)
                     events.extend(self._drain_pending_parts(state, oc_msg_id, is_subtask=False))
 
@@ -409,21 +419,40 @@ class OpenCodePromptStream:
             if isinstance(error, dict) and error.get("name") == CONTEXT_OVERFLOW_ERROR_NAME:
                 # With OpenCode's default automatic compaction enabled, this event
                 # announces recovery; session.compacted and more work follow it.
+                # Remember the error so idle-without-compaction still fails.
+                state.pending_overflow_error = (
+                    self._extract_error_message(error) or "Context overflow"
+                )
                 self._log.info(
                     "bridge.context_overflow_compacting",
-                    error_msg=self._extract_error_message(error),
+                    error_msg=state.pending_overflow_error,
                 )
                 return _StreamStep(events=[], disposition=_Disposition.CONTINUE)
 
             error_event = self._parent_error_event_once(state, error)
-            self._log.error("bridge.session_error", error_msg=error_event and error_event["error"])
+            self._log.error(
+                "bridge.session_error",
+                error_msg=self._extract_error_message(error),
+                deduped=error_event is None,
+            )
             return _StreamStep(
                 events=[error_event] if error_event else [],
                 disposition=_Disposition.FAILED,
             )
 
         if error_session_id in state.tracked_child_session_ids:
-            error_msg = self._extract_error_message(props.get("error", {}))
+            error = props.get("error", {})
+            if isinstance(error, dict) and error.get("name") == CONTEXT_OVERFLOW_ERROR_NAME:
+                # Child sessions recover through the same automatic compaction;
+                # surfacing this would fail the whole prompt spuriously.
+                self._log.info(
+                    "bridge.child_context_overflow_compacting",
+                    error_msg=self._extract_error_message(error),
+                    child_session_id=error_session_id,
+                )
+                return _StreamStep(events=[], disposition=_Disposition.CONTINUE)
+
+            error_msg = self._extract_error_message(error)
             self._log.error(
                 "bridge.child_session_error",
                 error_msg=error_msg,
@@ -443,6 +472,29 @@ class OpenCodePromptStream:
             )
 
         return _StreamStep(events=[], disposition=_Disposition.CONTINUE)
+
+    def _unrecovered_overflow_events(self, state: _PromptState) -> list[dict[str, Any]]:
+        """Fail the prompt if a swallowed overflow's promised compaction never came.
+
+        The context-overflow announcement is only safe to swallow because
+        compaction normally follows it. If the session goes idle without
+        compacting and without any error emitted, surface the original
+        overflow error instead of reporting silent success.
+        """
+        if state.pending_overflow_error is None or state.emitted_error_messages:
+            return []
+        self._log.error(
+            "bridge.context_overflow_unrecovered",
+            error_msg=state.pending_overflow_error,
+        )
+        state.emitted_error_messages.add(state.pending_overflow_error)
+        return [
+            {
+                "type": "error",
+                "error": state.pending_overflow_error,
+                "messageId": state.message_id,
+            }
+        ]
 
     def _parent_error_event_once(self, state: _PromptState, error: object) -> dict[str, Any] | None:
         """Build one parent error event across message.updated and session.error."""
@@ -715,8 +767,9 @@ class OpenCodePromptStream:
 
         Accepts an assistant message when its parentID matches one of the
         prompt's user message IDs, when it was already authorized during SSE
-        streaming, or — after compaction, which rewrites the message chain —
-        when it is not the compaction summary itself.
+        streaming, or after compaction, which rewrites the message chain.
+        The compaction summary itself is never accepted: its text is internal
+        context, and its parentID (the compaction user message) matches.
         """
         if not state.opencode_session_id:
             return
@@ -740,11 +793,10 @@ class OpenCodePromptStream:
                 is_compaction_summary = info.get("summary") is True
 
                 # Accept if: parentID matches, was tracked during SSE, or
-                # compaction occurred and this isn't the summary message
-                should_accept = (
-                    parent_matches
-                    or in_tracked_set
-                    or (state.compaction_occurred and not is_compaction_summary)
+                # compaction occurred — but never the compaction summary
+                # itself; its parentID (the compaction user message) matches.
+                should_accept = not is_compaction_summary and (
+                    parent_matches or in_tracked_set or state.compaction_occurred
                 )
                 if not should_accept:
                     continue

--- a/packages/sandbox-runtime/tests/test_bridge_sse.py
+++ b/packages/sandbox-runtime/tests/test_bridge_sse.py
@@ -2341,7 +2341,16 @@ class TestCompactionHandling:
                     },
                 },
             ),
-            create_sse_event("session.compacted", {"sessionID": "oc-session-123"}),
+            create_sse_event(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "msg_compaction_user",
+                        "role": "user",
+                        "sessionID": "oc-session-123",
+                    }
+                },
+            ),
             create_sse_event(
                 "message.updated",
                 {
@@ -2354,6 +2363,19 @@ class TestCompactionHandling:
                     }
                 },
             ),
+            create_sse_event(
+                "message.part.updated",
+                {
+                    "part": {
+                        "type": "text",
+                        "id": "part-summary",
+                        "sessionID": "oc-session-123",
+                        "messageID": "oc-msg-summary",
+                        "text": "## Goal\nThe user was working on...",
+                    }
+                },
+            ),
+            create_sse_event("session.compacted", {"sessionID": "oc-session-123"}),
             create_sse_event(
                 "message.updated",
                 {
@@ -2506,6 +2528,18 @@ class TestCompactionHandling:
             create_sse_event(
                 "session.compacted",
                 {"sessionID": "oc-session-123"},
+            ),
+            # Compaction user message (the summary's parent) — observing it must
+            # not authorize the summary's text via parentID matching
+            create_sse_event(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "msg_compaction_user",
+                        "role": "user",
+                        "sessionID": "oc-session-123",
+                    }
+                },
             ),
             # Compaction summary with summary=True
             create_sse_event(

--- a/packages/sandbox-runtime/tests/test_bridge_sse.py
+++ b/packages/sandbox-runtime/tests/test_bridge_sse.py
@@ -2435,6 +2435,16 @@ class TestCompactionHandling:
                 "message.updated",
                 {
                     "info": {
+                        "id": "msg_compaction_user",
+                        "role": "user",
+                        "sessionID": "oc-session-123",
+                    }
+                },
+            ),
+            create_sse_event(
+                "message.updated",
+                {
+                    "info": {
                         "id": "oc-msg-summary",
                         "role": "assistant",
                         "sessionID": "oc-session-123",

--- a/packages/sandbox-runtime/tests/test_bridge_sse.py
+++ b/packages/sandbox-runtime/tests/test_bridge_sse.py
@@ -2301,6 +2301,178 @@ class TestCompactionHandling:
         assert token_events[1]["content"] == "Here is the answer."
 
     @pytest.mark.asyncio
+    async def test_context_overflow_compacts_and_completes_successfully(
+        self, bridge: AgentBridge, opencode_message_id: str
+    ):
+        bridge._configure_git_identity = AsyncMock()
+        bridge._send_event = AsyncMock()
+        bridge.http_client.sse_events = [
+            create_sse_event("server.connected", {}),
+            create_sse_event(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "oc-msg-before",
+                        "role": "assistant",
+                        "sessionID": "oc-session-123",
+                        "parentID": opencode_message_id,
+                    }
+                },
+            ),
+            create_sse_event(
+                "message.part.updated",
+                {
+                    "part": {
+                        "type": "text",
+                        "id": "part-before",
+                        "sessionID": "oc-session-123",
+                        "messageID": "oc-msg-before",
+                        "text": "Before compaction",
+                    }
+                },
+            ),
+            create_sse_event(
+                "session.error",
+                {
+                    "sessionID": "oc-session-123",
+                    "error": {
+                        "name": "ContextOverflowError",
+                        "data": {"message": "Context window exceeded"},
+                    },
+                },
+            ),
+            create_sse_event("session.compacted", {"sessionID": "oc-session-123"}),
+            create_sse_event(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "oc-msg-summary",
+                        "role": "assistant",
+                        "sessionID": "oc-session-123",
+                        "parentID": "msg_compaction_user",
+                        "summary": True,
+                    }
+                },
+            ),
+            create_sse_event(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "oc-msg-after",
+                        "role": "assistant",
+                        "sessionID": "oc-session-123",
+                        "parentID": "msg_synthetic_continue",
+                    }
+                },
+            ),
+            create_sse_event(
+                "message.part.updated",
+                {
+                    "part": {
+                        "type": "text",
+                        "id": "part-after",
+                        "sessionID": "oc-session-123",
+                        "messageID": "oc-msg-after",
+                        "text": "After compaction",
+                    }
+                },
+            ),
+            create_sse_event("session.idle", {"sessionID": "oc-session-123"}),
+        ]
+
+        await bridge._handle_prompt(
+            {
+                "messageId": "cp-msg-1",
+                "content": "Test prompt",
+                "author": {"gitIdentity": {"mode": "agent-only"}},
+            }
+        )
+
+        events = [call.args[0] for call in bridge._send_event.await_args_list]
+        assert [event["content"] for event in events if event["type"] == "token"] == [
+            "Before compaction",
+            "After compaction",
+        ]
+        assert [event for event in events if event["type"] == "error"] == []
+        assert events[-1] == {
+            "type": "execution_complete",
+            "messageId": "cp-msg-1",
+            "success": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_compaction_overflow_fails_after_partial_output(
+        self, bridge: AgentBridge, opencode_message_id: str
+    ):
+        bridge._configure_git_identity = AsyncMock()
+        bridge._send_event = AsyncMock()
+        bridge.http_client.sse_events = [
+            create_sse_event("server.connected", {}),
+            create_sse_event(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "oc-msg-before",
+                        "role": "assistant",
+                        "sessionID": "oc-session-123",
+                        "parentID": opencode_message_id,
+                    }
+                },
+            ),
+            create_sse_event(
+                "message.part.updated",
+                {
+                    "part": {
+                        "type": "text",
+                        "id": "part-before",
+                        "sessionID": "oc-session-123",
+                        "messageID": "oc-msg-before",
+                        "text": "Partial output",
+                    }
+                },
+            ),
+            create_sse_event(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "oc-msg-summary",
+                        "role": "assistant",
+                        "sessionID": "oc-session-123",
+                        "parentID": "msg_compaction_user",
+                        "summary": True,
+                        "error": {
+                            "name": "ContextOverflowError",
+                            "data": {"message": "Session too large to compact"},
+                        },
+                    }
+                },
+            ),
+            create_sse_event("session.idle", {"sessionID": "oc-session-123"}),
+        ]
+
+        await bridge._handle_prompt(
+            {
+                "messageId": "cp-msg-1",
+                "content": "Test prompt",
+                "author": {"gitIdentity": {"mode": "agent-only"}},
+            }
+        )
+
+        events = [call.args[0] for call in bridge._send_event.await_args_list]
+        assert [event["type"] for event in events] == ["token", "error", "execution_complete"]
+        assert events[1] == {
+            "type": "error",
+            "error": "Session too large to compact",
+            "messageId": "cp-msg-1",
+        }
+        assert events[-1] == {
+            "type": "execution_complete",
+            "messageId": "cp-msg-1",
+            "success": False,
+            "error": "Session too large to compact",
+        }
+
+    @pytest.mark.asyncio
     async def test_compaction_summary_text_not_forwarded(
         self, bridge: AgentBridge, opencode_message_id: str
     ):

--- a/packages/sandbox-runtime/tests/test_prompt_stream.py
+++ b/packages/sandbox-runtime/tests/test_prompt_stream.py
@@ -146,6 +146,85 @@ class TestApplySseEventDispositions:
         assert session_step.disposition is _Disposition.FAILED
         assert session_step.events == []
 
+    def test_unrelated_compaction_summary_error_is_ignored(self):
+        step = make_stream()._apply_sse_event(
+            make_state(),
+            sse(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "oc-old-summary",
+                        "role": "assistant",
+                        "sessionID": PARENT_SESSION_ID,
+                        "parentID": "msg-old-compaction-user",
+                        "summary": True,
+                        "error": {
+                            "name": "ContextOverflowError",
+                            "data": {"message": "Old compaction failed"},
+                        },
+                    }
+                },
+            ),
+        )
+
+        assert step.events == []
+        assert step.disposition is _Disposition.CONTINUE
+
+    def test_correlated_compaction_summary_error_is_emitted(self):
+        stream = make_stream()
+        state = make_state()
+        stream._apply_sse_event(
+            state,
+            sse(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "msg-compaction-user",
+                        "role": "user",
+                        "sessionID": PARENT_SESSION_ID,
+                    }
+                },
+            ),
+        )
+        stream._apply_sse_event(
+            state,
+            sse(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "oc-summary",
+                        "role": "assistant",
+                        "sessionID": PARENT_SESSION_ID,
+                        "parentID": "msg-compaction-user",
+                        "summary": True,
+                    }
+                },
+            ),
+        )
+
+        step = stream._apply_sse_event(
+            state,
+            sse(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "oc-summary",
+                        "role": "assistant",
+                        "sessionID": PARENT_SESSION_ID,
+                        "summary": True,
+                        "error": {
+                            "name": "ContextOverflowError",
+                            "data": {"message": "Compaction failed"},
+                        },
+                    }
+                },
+            ),
+        )
+
+        assert step.events == [
+            {"type": "error", "error": "Compaction failed", "messageId": "cp-msg-1"}
+        ]
+
     def test_child_session_error_emits_subtask_error_and_continues(self):
         state = make_state()
         state.tracked_child_session_ids.add(CHILD_SESSION_ID)

--- a/packages/sandbox-runtime/tests/test_prompt_stream.py
+++ b/packages/sandbox-runtime/tests/test_prompt_stream.py
@@ -225,6 +225,125 @@ class TestApplySseEventDispositions:
             {"type": "error", "error": "Compaction failed", "messageId": "cp-msg-1"}
         ]
 
+    def test_compaction_summary_parts_not_forwarded_despite_parent_match(self):
+        stream = make_stream()
+        state = make_state()
+        stream._apply_sse_event(
+            state,
+            sse(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "msg-compaction-user",
+                        "role": "user",
+                        "sessionID": PARENT_SESSION_ID,
+                    }
+                },
+            ),
+        )
+        stream._apply_sse_event(
+            state,
+            sse(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "oc-summary",
+                        "role": "assistant",
+                        "sessionID": PARENT_SESSION_ID,
+                        "parentID": "msg-compaction-user",
+                        "summary": True,
+                    }
+                },
+            ),
+        )
+
+        step = stream._apply_sse_event(
+            state,
+            sse(
+                "message.part.updated",
+                {
+                    "part": {
+                        "type": "text",
+                        "id": "part-summary",
+                        "sessionID": PARENT_SESSION_ID,
+                        "messageID": "oc-summary",
+                        "text": "## Goal\nInternal summary text",
+                    }
+                },
+            ),
+        )
+
+        assert "oc-summary" not in state.allowed_assistant_msg_ids
+        assert step.events == []
+
+    def test_child_context_overflow_continues_without_error(self):
+        state = make_state()
+        state.tracked_child_session_ids.add(CHILD_SESSION_ID)
+
+        step = make_stream()._apply_sse_event(
+            state,
+            sse(
+                "session.error",
+                {
+                    "sessionID": CHILD_SESSION_ID,
+                    "error": {
+                        "name": "ContextOverflowError",
+                        "data": {"message": "Context window exceeded"},
+                    },
+                },
+            ),
+        )
+
+        assert step.disposition is _Disposition.CONTINUE
+        assert step.events == []
+
+    def test_unrecovered_overflow_fails_at_idle(self):
+        stream = make_stream()
+        state = make_state()
+        stream._apply_sse_event(
+            state,
+            sse(
+                "session.error",
+                {
+                    "sessionID": PARENT_SESSION_ID,
+                    "error": {
+                        "name": "ContextOverflowError",
+                        "data": {"message": "Context window exceeded"},
+                    },
+                },
+            ),
+        )
+
+        step = stream._apply_sse_event(state, sse("session.idle", {"sessionID": PARENT_SESSION_ID}))
+
+        assert step.disposition is _Disposition.FINISHED_IDLE
+        assert step.events == [
+            {"type": "error", "error": "Context window exceeded", "messageId": "cp-msg-1"}
+        ]
+
+    def test_recovered_overflow_stays_clean_at_idle(self):
+        stream = make_stream()
+        state = make_state()
+        stream._apply_sse_event(
+            state,
+            sse(
+                "session.error",
+                {
+                    "sessionID": PARENT_SESSION_ID,
+                    "error": {
+                        "name": "ContextOverflowError",
+                        "data": {"message": "Context window exceeded"},
+                    },
+                },
+            ),
+        )
+        stream._apply_sse_event(state, sse("session.compacted", {"sessionID": PARENT_SESSION_ID}))
+
+        step = stream._apply_sse_event(state, sse("session.idle", {"sessionID": PARENT_SESSION_ID}))
+
+        assert step.disposition is _Disposition.FINISHED_IDLE
+        assert step.events == []
+
     def test_child_session_error_emits_subtask_error_and_continues(self):
         state = make_state()
         state.tracked_child_session_ids.add(CHILD_SESSION_ID)

--- a/packages/sandbox-runtime/tests/test_prompt_stream.py
+++ b/packages/sandbox-runtime/tests/test_prompt_stream.py
@@ -97,6 +97,55 @@ class TestApplySseEventDispositions:
         assert step.disposition is _Disposition.FAILED
         assert step.events == [{"type": "error", "error": "It broke", "messageId": "cp-msg-1"}]
 
+    def test_parent_context_overflow_continues_without_error(self):
+        step = make_stream()._apply_sse_event(
+            make_state(),
+            sse(
+                "session.error",
+                {
+                    "sessionID": PARENT_SESSION_ID,
+                    "error": {
+                        "name": "ContextOverflowError",
+                        "data": {"message": "Context window exceeded"},
+                    },
+                },
+            ),
+        )
+
+        assert step.disposition is _Disposition.CONTINUE
+        assert step.events == []
+
+    def test_message_error_is_deduped_against_session_error(self):
+        stream = make_stream()
+        state = make_state()
+        error = {"name": "SomeError", "data": {"message": "It broke"}}
+
+        message_step = stream._apply_sse_event(
+            state,
+            sse(
+                "message.updated",
+                {
+                    "info": {
+                        "id": "oc-msg-1",
+                        "role": "assistant",
+                        "sessionID": PARENT_SESSION_ID,
+                        "parentID": "msg_test",
+                        "error": error,
+                    }
+                },
+            ),
+        )
+        session_step = stream._apply_sse_event(
+            state,
+            sse("session.error", {"sessionID": PARENT_SESSION_ID, "error": error}),
+        )
+
+        assert message_step.events == [
+            {"type": "error", "error": "It broke", "messageId": "cp-msg-1"}
+        ]
+        assert session_step.disposition is _Disposition.FAILED
+        assert session_step.events == []
+
     def test_child_session_error_emits_subtask_error_and_continues(self):
         state = make_state()
         state.tracked_child_session_ids.add(CHILD_SESSION_ID)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of OpenCode “context overflow” so recoverable compaction flows continue instead of failing early.
  * Prevented duplicate parent-level error emissions and aligned error output with related token/step events.
  * Added clearer failure behavior when overflow is not successfully recovered (including correct error surface on idle).
* **Tests**
  * Added new SSE bridge async tests covering both recovered and unrecovered overflow, including correct event ordering and success/failure completion.
  * Expanded prompt-stream unit coverage for deduplication, compaction-summary filtering, and overflow continuation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->