### PR TITLE
test: isolate sandbox-runtime tests from live runtime file paths

### DIFF
--- a/packages/sandbox-runtime/tests/conftest.py
+++ b/packages/sandbox-runtime/tests/conftest.py
@@ -3,11 +3,36 @@
 from typing import TYPE_CHECKING, Any
 
 import httpx
+import pytest
 
 from sandbox_runtime.opencode_client import OpenCodeClient
 
 if TYPE_CHECKING:
     from sandbox_runtime.bridge import AgentBridge
+
+
+@pytest.fixture(autouse=True)
+def isolate_runtime_file_paths(tmp_path, monkeypatch):
+    """Redirect the runtime's fixed file paths to per-test locations.
+
+    This suite routinely runs inside a live Open-Inspect sandbox (agents
+    dogfooding on this repo), where /tmp/oi-repo-manifest.json is the running
+    session's real manifest. A test that drives a real SandboxSupervisor
+    (e.g. ``await sup.run()``) would otherwise overwrite it with fixture
+    repos, which breaks push targeting and PR creation for the live session —
+    and likewise delete the live boot-warnings file or read the live
+    tunnel-env file. Tests that care about a specific path still patch it
+    themselves; this fixture is the backstop that keeps every other test off
+    the real files.
+    """
+    manifest_path = str(tmp_path / "oi-repo-manifest.json")
+    boot_warnings_path = str(tmp_path / "oi-boot-warnings.jsonl")
+    tunnel_env_path = str(tmp_path / ".tunnels.env")
+    monkeypatch.setattr("sandbox_runtime.entrypoint.REPO_MANIFEST_FILE_PATH", manifest_path)
+    monkeypatch.setattr("sandbox_runtime.bridge.REPO_MANIFEST_FILE_PATH", manifest_path)
+    monkeypatch.setattr("sandbox_runtime.entrypoint.BOOT_WARNINGS_FILE_PATH", boot_warnings_path)
+    monkeypatch.setattr("sandbox_runtime.bridge.BOOT_WARNINGS_FILE_PATH", boot_warnings_path)
+    monkeypatch.setattr("sandbox_runtime.entrypoint.TUNNEL_ENV_FILE_PATH", tunnel_env_path)
 
 
 def wire_opencode_transport(bridge: "AgentBridge", http_client: Any) -> Any:


### PR DESCRIPTION
## Problem

The sandbox-runtime test suite writes to the runtime's real fixed file paths. When the suite runs **inside a live Open-Inspect sandbox** (agents dogfooding on this repo do this routinely), that corrupts the running session:

- `test_start_script.py::TestStartInRunStrict::test_run_fails_fast_when_start_script_fails` and two tests in `test_setup_script.py` drive a real `SandboxSupervisor.run()`, which calls `_write_repo_manifest()` and **overwrites the live `/tmp/oi-repo-manifest.json`** with the fixture repo (`acme/app` under a pytest tmpdir).
- The same `run()` path also unlinks the live `/tmp/oi-boot-warnings.jsonl`.

After the clobber, the bridge's push targeting (`_member_checkout`) no longer finds the session's repo in the manifest, so the control plane's push command — and therefore `create-pull-request` — fails with `Repository <owner>/<name> is not part of this session`, while direct `git push` keeps working (credential helper doesn't consult the manifest).

This was observed in production on 2026-07-20: a session working on this repo ran `pytest`, and its subsequent PR-creation attempt was rejected with the tool reporting it "only authorizes acme/app". The live sandbox's manifest contained exactly the fixture entry, mtime'd at the pytest run:

```json
{"repositories": [{"owner": "acme", "name": "app", "branch": "main",
  "path": "/tmp/pytest-of-sandbox/pytest-1/test_run_fails_fast_when_start0/app"}]}
```

## Fix

Add an autouse fixture in `tests/conftest.py` that redirects the module-level path constants (`REPO_MANIFEST_FILE_PATH`, `BOOT_WARNINGS_FILE_PATH`, `TUNNEL_ENV_FILE_PATH`) in `sandbox_runtime.entrypoint` and `sandbox_runtime.bridge` to per-test `tmp_path` locations. Tests that already patch a specific path (e.g. `test_multi_repo_workspace.py`, `test_entrypoint_tunnel_urls.py`) keep doing so — their patches layer on top; this fixture is the backstop for everything else.

Readers with default arguments bound at import time (`repo_config.load_repo_manifest` / `read_repo_manifest`) are unaffected: no test calls them without an explicit path.

## Verification

- Full suite: `583 passed`.
- Reproduced the incident locally: with a sentinel at `/tmp/oi-repo-manifest.json`, running the offending test **without** this change overwrites it with the `acme/app` fixture entry; **with** this change the sentinel is untouched.

## Not covered (follow-up candidate)

`bridge.session_id_file` (`$TMPDIR/opencode-session-id`) is an instance attribute built from `tempfile.gettempdir()` rather than a module constant, so it isn't covered by this fixture. No current test was observed writing it, but it's the same hazard class if one ever does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by ensuring sandbox runtime files are written to temporary locations.
  * Prevented tests from overwriting or deleting real sandbox session files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->