### PR TITLE
fix: cascade cancellation to nested tasks

### DIFF
--- a/packages/control-plane/src/db/session-index.test.ts
+++ b/packages/control-plane/src/db/session-index.test.ts
@@ -146,7 +146,8 @@ class FakeD1Database {
       const descendants: Array<{ row: SessionRow; depth: number }> = [];
       let parents = [args[0] as string];
       let depth = 1;
-      while (parents.length > 0) {
+      // Mirrors the CTE's MAX_DESCENDANT_DEPTH cycle guard.
+      while (parents.length > 0 && depth <= 10) {
         const children = Array.from(this.rows.values()).filter((row) =>
           parents.includes(row.parent_session_id ?? "")
         );

--- a/packages/control-plane/src/db/session-index.test.ts
+++ b/packages/control-plane/src/db/session-index.test.ts
@@ -54,6 +54,7 @@ const QUERY_PATTERNS = {
   DELETE_SESSION: /^DELETE FROM sessions WHERE id = \?$/,
   SELECT_BY_PARENT:
     /^SELECT \* FROM sessions WHERE parent_session_id = \? ORDER BY created_at DESC$/,
+  SELECT_ACTIVE_DESCENDANTS: /^WITH RECURSIVE descendants/,
   SELECT_1_CHILD: /^SELECT 1 FROM sessions WHERE id = \? AND parent_session_id = \?$/,
   SELECT_SPAWN_DEPTH: /^SELECT spawn_depth FROM sessions WHERE id = \?$/,
 } as const;
@@ -138,6 +139,25 @@ class FakeD1Database {
         .filter((r) => r.parent_session_id === parentId)
         .sort((a, b) => b.created_at - a.created_at);
       return children;
+    }
+
+    if (QUERY_PATTERNS.SELECT_ACTIVE_DESCENDANTS.test(normalized)) {
+      const terminalStatuses = new Set(["completed", "failed", "archived", "cancelled"]);
+      const descendants: Array<{ row: SessionRow; depth: number }> = [];
+      let parents = [args[0] as string];
+      let depth = 1;
+      while (parents.length > 0) {
+        const children = Array.from(this.rows.values()).filter((row) =>
+          parents.includes(row.parent_session_id ?? "")
+        );
+        descendants.push(...children.map((row) => ({ row, depth })));
+        parents = children.map((row) => row.id);
+        depth += 1;
+      }
+      return descendants
+        .filter(({ row }) => !terminalStatuses.has(row.status))
+        .sort((a, b) => b.depth - a.depth)
+        .map(({ row }) => ({ id: row.id }));
     }
 
     if (QUERY_PATTERNS.SELECT_SESSION_REPOS.test(normalized)) {
@@ -812,6 +832,29 @@ describe("SessionIndexStore", () => {
       it("returns empty array when no children exist", async () => {
         const children = await store.listByParent("no-children");
         expect(children).toEqual([]);
+      });
+    });
+
+    describe("listActiveDescendantIds", () => {
+      it("returns active descendants deepest-first through terminal ancestors", async () => {
+        await store.create(
+          makeSession({
+            id: "grandchild-1",
+            status: "active",
+            parentSessionId: "child-2",
+            spawnSource: "agent",
+            spawnDepth: 2,
+          })
+        );
+
+        await expect(store.listActiveDescendantIds(parentId)).resolves.toEqual([
+          "grandchild-1",
+          "child-1",
+        ]);
+      });
+
+      it("returns an empty array when no descendants exist", async () => {
+        await expect(store.listActiveDescendantIds("no-children")).resolves.toEqual([]);
       });
     });
 

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -7,7 +7,19 @@ import type {
 import { SessionPullRequestStore } from "./session-pull-request-store";
 import type { SqlDatabase } from "./sql-database";
 
-const TERMINAL_STATUS_SQL = "'completed', 'failed', 'archived', 'cancelled'";
+const TERMINAL_STATUSES = [
+  "completed",
+  "failed",
+  "archived",
+  "cancelled",
+] satisfies SessionStatus[];
+const TERMINAL_STATUS_SQL = TERMINAL_STATUSES.map((status) => `'${status}'`).join(", ");
+
+/**
+ * Insurance against a corrupt parent_session_id cycle making the recursive
+ * descendant CTE run away; spawn-time depth caps keep real trees far below it.
+ */
+const MAX_DESCENDANT_DEPTH = 10;
 
 /**
  * One member of a session's repository set — the identity subset of the
@@ -472,6 +484,7 @@ export class SessionIndexStore {
            SELECT sessions.id, sessions.status, descendants.depth + 1
            FROM sessions
            JOIN descendants ON sessions.parent_session_id = descendants.id
+           WHERE descendants.depth < ${MAX_DESCENDANT_DEPTH}
          )
          SELECT id FROM descendants
          WHERE status NOT IN (${TERMINAL_STATUS_SQL})

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -7,6 +7,8 @@ import type {
 import { SessionPullRequestStore } from "./session-pull-request-store";
 import type { SqlDatabase } from "./sql-database";
 
+const TERMINAL_STATUS_SQL = "'completed', 'failed', 'archived', 'cancelled'";
+
 /**
  * One member of a session's repository set — the identity subset of the
  * shared SessionRepositoryState (no git state; D1 doesn't store it).
@@ -472,7 +474,7 @@ export class SessionIndexStore {
            JOIN descendants ON sessions.parent_session_id = descendants.id
          )
          SELECT id FROM descendants
-         WHERE status NOT IN ('completed', 'failed', 'archived', 'cancelled')
+         WHERE status NOT IN (${TERMINAL_STATUS_SQL})
          ORDER BY depth DESC`
       )
       .bind(parentSessionId)
@@ -485,7 +487,7 @@ export class SessionIndexStore {
     const result = await this.db
       .prepare(
         `SELECT COUNT(*) as count FROM sessions
-         WHERE parent_session_id = ? AND status NOT IN ('completed', 'failed', 'archived', 'cancelled')`
+         WHERE parent_session_id = ? AND status NOT IN (${TERMINAL_STATUS_SQL})`
       )
       .bind(parentSessionId)
       .first<{ count: number }>();

--- a/packages/control-plane/src/db/session-index.ts
+++ b/packages/control-plane/src/db/session-index.ts
@@ -460,6 +460,26 @@ export class SessionIndexStore {
     return this.decorateEntries((result.results || []).map(toEntry));
   }
 
+  /** List non-terminal descendants, deepest first, so cancellation cascades bottom-up. */
+  async listActiveDescendantIds(parentSessionId: string): Promise<string[]> {
+    const result = await this.db
+      .prepare(
+        `WITH RECURSIVE descendants(id, status, depth) AS (
+           SELECT id, status, 1 FROM sessions WHERE parent_session_id = ?
+           UNION ALL
+           SELECT sessions.id, sessions.status, descendants.depth + 1
+           FROM sessions
+           JOIN descendants ON sessions.parent_session_id = descendants.id
+         )
+         SELECT id FROM descendants
+         WHERE status NOT IN ('completed', 'failed', 'archived', 'cancelled')
+         ORDER BY depth DESC`
+      )
+      .bind(parentSessionId)
+      .all<{ id: string }>();
+    return (result.results || []).map(({ id }) => id);
+  }
+
   /** Count active (non-terminal) children for concurrent cap enforcement. */
   async countActiveChildren(parentSessionId: string): Promise<number> {
     const result = await this.db

--- a/packages/control-plane/src/routes/session-children.test.ts
+++ b/packages/control-plane/src/routes/session-children.test.ts
@@ -4,6 +4,7 @@ import type { SessionRuntimeClient } from "../session/runtime-client";
 import type { Env } from "../types";
 import { handleCancelChild } from "./session-children";
 import type { SessionRouteContext } from "./session-route";
+import { parsePattern } from "./shared";
 
 describe("handleCancelChild", () => {
   afterEach(() => vi.restoreAllMocks());
@@ -24,7 +25,7 @@ describe("handleCancelChild", () => {
       return Response.json({ status: "cancelled" });
     });
     const match = "/sessions/parent/children/child/cancel".match(
-      /^\/sessions\/(?<id>[^/]+)\/children\/(?<childId>[^/]+)\/cancel$/
+      parsePattern("/sessions/:id/children/:childId/cancel")
     );
     if (!match) throw new Error("Expected route match");
 
@@ -49,8 +50,8 @@ describe("handleCancelChild", () => {
     ]);
     expect(response.status).toBe(502);
     await expect(response.json()).resolves.toEqual({
-      error:
-        "Task cancelled, but nested tasks could not be cancelled: deep-failure, shallow-failure",
+      error: "Nested tasks could not be cancelled: deep-failure, shallow-failure",
+      cancelledDescendantIds: ["later-success"],
     });
   });
 });

--- a/packages/control-plane/src/routes/session-children.test.ts
+++ b/packages/control-plane/src/routes/session-children.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SessionIndexStore } from "../db/session-index";
+import type { SessionRuntimeClient } from "../session/runtime-client";
+import type { Env } from "../types";
+import { handleCancelChild } from "./session-children";
+import type { SessionRouteContext } from "./session-route";
+
+describe("handleCancelChild", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("attempts every descendant and aggregates non-conflict failures", async () => {
+    vi.spyOn(SessionIndexStore.prototype, "isChildOf").mockResolvedValue(true);
+    vi.spyOn(SessionIndexStore.prototype, "listActiveDescendantIds").mockResolvedValue([
+      "deep-failure",
+      "later-success",
+      "shallow-failure",
+    ]);
+
+    const fetch = vi.fn<SessionRuntimeClient["fetch"]>(async (sessionId) => {
+      if (sessionId === "child") return Response.json({ status: "cancelled" });
+      if (sessionId === "deep-failure" || sessionId === "shallow-failure") {
+        return Response.json({ error: "failure" }, { status: 500 });
+      }
+      return Response.json({ status: "cancelled" });
+    });
+    const match = "/sessions/parent/children/child/cancel".match(
+      /^\/sessions\/(?<id>[^/]+)\/children\/(?<childId>[^/]+)\/cancel$/
+    );
+    if (!match) throw new Error("Expected route match");
+
+    const response = await handleCancelChild(
+      new Request("https://test.local/sessions/parent/children/child/cancel", { method: "POST" }),
+      {} as Env,
+      match,
+      {
+        db: {} as SessionRouteContext["db"],
+        metrics: {} as SessionRouteContext["metrics"],
+        request_id: "request-id",
+        trace_id: "trace-id",
+        sessionRuntime: { fetch },
+      }
+    );
+
+    expect(fetch.mock.calls.map(([sessionId]) => sessionId)).toEqual([
+      "child",
+      "deep-failure",
+      "later-success",
+      "shallow-failure",
+    ]);
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toEqual({
+      error:
+        "Task cancelled, but nested tasks could not be cancelled: deep-failure, shallow-failure",
+    });
+  });
+});

--- a/packages/control-plane/src/routes/session-children.ts
+++ b/packages/control-plane/src/routes/session-children.ts
@@ -45,7 +45,7 @@ async function handleGetChild(
 }
 
 async function handleCancelChild(
-  _request: Request,
+  request: Request,
   env: Env,
   match: RegExpMatchArray,
   ctx: SessionRouteContext
@@ -60,7 +60,38 @@ async function handleCancelChild(
     return error("Child session not found", 404);
   }
 
-  return ctx.sessionRuntime.fetch(childId, SessionInternalPaths.cancel, { method: "POST" });
+  let cancelNested: unknown;
+  try {
+    const body = await request.json();
+    if (body && typeof body === "object" && !Array.isArray(body)) {
+      cancelNested = (body as { cancelNested?: unknown }).cancelNested;
+    }
+  } catch {
+    // Existing callers send an empty body; recursive cancellation is the default.
+  }
+  if (cancelNested !== undefined && typeof cancelNested !== "boolean") {
+    return error("cancelNested must be a boolean");
+  }
+
+  const response = await ctx.sessionRuntime.fetch(childId, SessionInternalPaths.cancel, {
+    method: "POST",
+  });
+  if (!response.ok || cancelNested === false) return response;
+
+  const descendantIds = await sessionStore.listActiveDescendantIds(childId);
+  for (const descendantId of descendantIds) {
+    const descendantResponse = await ctx.sessionRuntime.fetch(
+      descendantId,
+      SessionInternalPaths.cancel,
+      { method: "POST" }
+    );
+    // A descendant may have reached a terminal state since the D1 query.
+    if (!descendantResponse.ok && descendantResponse.status !== 409) {
+      return error(`Task cancelled, but nested task ${descendantId} could not be cancelled`, 502);
+    }
+  }
+
+  return response;
 }
 
 export const sessionChildRoutes: Route[] = [

--- a/packages/control-plane/src/routes/session-children.ts
+++ b/packages/control-plane/src/routes/session-children.ts
@@ -1,3 +1,7 @@
+import {
+  cancelChildSessionRequestSchema,
+  type CancelChildSessionRequest,
+} from "@open-inspect/shared";
 import { SessionIndexStore } from "../db/session-index";
 import { SessionInternalPaths } from "../session/contracts";
 import type { Env } from "../types";
@@ -60,27 +64,32 @@ export async function handleCancelChild(
     return error("Child session not found", 404);
   }
 
-  let cancelNested: unknown;
+  // An empty body means "no options"; older clients POST without one.
+  let body: CancelChildSessionRequest = {};
   const rawBody = await request.text();
-  try {
-    const body: unknown = rawBody.trim() ? JSON.parse(rawBody) : undefined;
-    if (body && typeof body === "object" && !Array.isArray(body)) {
-      cancelNested = (body as { cancelNested?: unknown }).cancelNested;
+  if (rawBody.trim()) {
+    let parsedJson: unknown;
+    try {
+      parsedJson = JSON.parse(rawBody);
+    } catch {
+      return error("Invalid JSON body");
     }
-  } catch {
-    return error("Invalid JSON body");
+    const parsed = cancelChildSessionRequestSchema.safeParse(parsedJson);
+    if (!parsed.success) {
+      return error("cancelNested must be a boolean");
+    }
+    body = parsed.data;
   }
-  if (cancelNested !== undefined && typeof cancelNested !== "boolean") {
-    return error("cancelNested must be a boolean");
-  }
+  const cancelNested = body.cancelNested ?? true;
 
   const response = await ctx.sessionRuntime.fetch(childId, SessionInternalPaths.cancel, {
     method: "POST",
   });
   if (!response.ok && response.status !== 409) return response;
-  if (cancelNested === false) return response;
+  if (!cancelNested) return response;
 
   const descendantIds = await sessionStore.listActiveDescendantIds(childId);
+  const cancelledDescendantIds: string[] = [];
   const failedDescendantIds: string[] = [];
   for (const descendantId of descendantIds) {
     const descendantResponse = await ctx.sessionRuntime.fetch(
@@ -88,16 +97,27 @@ export async function handleCancelChild(
       SessionInternalPaths.cancel,
       { method: "POST" }
     );
-    // A descendant may have reached a terminal state since the D1 query.
-    if (!descendantResponse.ok && descendantResponse.status !== 409) {
+    if (descendantResponse.ok) {
+      cancelledDescendantIds.push(descendantId);
+    } else if (descendantResponse.status !== 409) {
+      // 409 means the descendant reached a terminal state since the D1 query.
       failedDescendantIds.push(descendantId);
     }
   }
   if (failedDescendantIds.length > 0) {
-    return error(
-      `Task cancelled, but nested tasks could not be cancelled: ${failedDescendantIds.join(", ")}`,
+    return json(
+      {
+        error: `Nested tasks could not be cancelled: ${failedDescendantIds.join(", ")}`,
+        cancelledDescendantIds,
+      },
       502
     );
+  }
+
+  // Cancelling descendants of an already-terminal child is still useful work;
+  // report it as success rather than passing through the child's 409.
+  if (response.ok || cancelledDescendantIds.length > 0) {
+    return json({ status: "cancelled", cancelledDescendantIds });
   }
 
   return response;

--- a/packages/control-plane/src/routes/session-children.ts
+++ b/packages/control-plane/src/routes/session-children.ts
@@ -44,7 +44,7 @@ async function handleGetChild(
   );
 }
 
-async function handleCancelChild(
+export async function handleCancelChild(
   request: Request,
   env: Env,
   match: RegExpMatchArray,
@@ -61,13 +61,14 @@ async function handleCancelChild(
   }
 
   let cancelNested: unknown;
+  const rawBody = await request.text();
   try {
-    const body = await request.json();
+    const body: unknown = rawBody.trim() ? JSON.parse(rawBody) : undefined;
     if (body && typeof body === "object" && !Array.isArray(body)) {
       cancelNested = (body as { cancelNested?: unknown }).cancelNested;
     }
   } catch {
-    // Existing callers send an empty body; recursive cancellation is the default.
+    return error("Invalid JSON body");
   }
   if (cancelNested !== undefined && typeof cancelNested !== "boolean") {
     return error("cancelNested must be a boolean");
@@ -76,9 +77,11 @@ async function handleCancelChild(
   const response = await ctx.sessionRuntime.fetch(childId, SessionInternalPaths.cancel, {
     method: "POST",
   });
-  if (!response.ok || cancelNested === false) return response;
+  if (!response.ok && response.status !== 409) return response;
+  if (cancelNested === false) return response;
 
   const descendantIds = await sessionStore.listActiveDescendantIds(childId);
+  const failedDescendantIds: string[] = [];
   for (const descendantId of descendantIds) {
     const descendantResponse = await ctx.sessionRuntime.fetch(
       descendantId,
@@ -87,8 +90,14 @@ async function handleCancelChild(
     );
     // A descendant may have reached a terminal state since the D1 query.
     if (!descendantResponse.ok && descendantResponse.status !== 409) {
-      return error(`Task cancelled, but nested task ${descendantId} could not be cancelled`, 502);
+      failedDescendantIds.push(descendantId);
     }
+  }
+  if (failedDescendantIds.length > 0) {
+    return error(
+      `Task cancelled, but nested tasks could not be cancelled: ${failedDescendantIds.join(", ")}`,
+      502
+    );
   }
 
   return response;

--- a/packages/control-plane/test/integration/child-session-ops.test.ts
+++ b/packages/control-plane/test/integration/child-session-ops.test.ts
@@ -266,6 +266,82 @@ describe("Child session operations (list, get, cancel)", () => {
       expect(rows[0].status).toBe("cancelled");
     });
 
+    it("cancels nested tasks by default", async () => {
+      const { pName, childName, sandboxToken, store } = await setupParentAndChild({
+        childStatus: "active",
+      });
+      const grandchildName = `grandchild-ops-${Date.now()}`;
+      await initNamedSession(grandchildName, { repoOwner: "acme", repoName: "web-app" });
+      const now = Date.now();
+      await store.create({
+        id: grandchildName,
+        title: "Grandchild Session",
+        repoOwner: "acme",
+        repoName: "web-app",
+        model: "anthropic/claude-sonnet-4-6",
+        reasoningEffort: null,
+        baseBranch: null,
+        status: "active",
+        parentSessionId: childName,
+        spawnSource: "agent",
+        spawnDepth: 2,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const res = await SELF.fetch(
+        `https://test.local/sessions/${pName}/children/${childName}/cancel`,
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${sandboxToken}` },
+        }
+      );
+
+      expect(res.status).toBe(200);
+      expect((await store.get(childName))?.status).toBe("cancelled");
+      expect((await store.get(grandchildName))?.status).toBe("cancelled");
+    });
+
+    it("leaves nested tasks running when cancelNested is false", async () => {
+      const { pName, childName, sandboxToken, store } = await setupParentAndChild({
+        childStatus: "active",
+      });
+      const grandchildName = `grandchild-no-cascade-${Date.now()}`;
+      await initNamedSession(grandchildName, { repoOwner: "acme", repoName: "web-app" });
+      const now = Date.now();
+      await store.create({
+        id: grandchildName,
+        title: "Grandchild Session",
+        repoOwner: "acme",
+        repoName: "web-app",
+        model: "anthropic/claude-sonnet-4-6",
+        reasoningEffort: null,
+        baseBranch: null,
+        status: "active",
+        parentSessionId: childName,
+        spawnSource: "agent",
+        spawnDepth: 2,
+        createdAt: now,
+        updatedAt: now,
+      });
+
+      const res = await SELF.fetch(
+        `https://test.local/sessions/${pName}/children/${childName}/cancel`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${sandboxToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ cancelNested: false }),
+        }
+      );
+
+      expect(res.status).toBe(200);
+      expect((await store.get(childName))?.status).toBe("cancelled");
+      expect((await store.get(grandchildName))?.status).toBe("active");
+    });
+
     it("returns 409 for completed session", async () => {
       const { pName, childName, sandboxToken } = await setupParentAndChild({
         childStatus: "completed",

--- a/packages/control-plane/test/integration/child-session-ops.test.ts
+++ b/packages/control-plane/test/integration/child-session-ops.test.ts
@@ -81,6 +81,33 @@ describe("Child session operations (list, get, cancel)", () => {
     return { pName, childName, parentStub, childStub, sandboxToken, store };
   }
 
+  async function setupNestedSession(
+    store: SessionIndexStore,
+    parentSessionId: string,
+    spawnDepth: number,
+    prefix: string
+  ): Promise<string> {
+    const id = `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    await initNamedSession(id, { repoOwner: "acme", repoName: "web-app" });
+    const now = Date.now();
+    await store.create({
+      id,
+      title: "Nested Session",
+      repoOwner: "acme",
+      repoName: "web-app",
+      model: "anthropic/claude-sonnet-4-6",
+      reasoningEffort: null,
+      baseBranch: null,
+      status: "active",
+      parentSessionId,
+      spawnSource: "agent",
+      spawnDepth,
+      createdAt: now,
+      updatedAt: now,
+    });
+    return id;
+  }
+
   describe("GET /sessions/:parentId/children", () => {
     it("returns children from D1", async () => {
       const { pName, childName, sandboxToken } = await setupParentAndChild();
@@ -270,24 +297,13 @@ describe("Child session operations (list, get, cancel)", () => {
       const { pName, childName, sandboxToken, store } = await setupParentAndChild({
         childStatus: "active",
       });
-      const grandchildName = `grandchild-ops-${Date.now()}`;
-      await initNamedSession(grandchildName, { repoOwner: "acme", repoName: "web-app" });
-      const now = Date.now();
-      await store.create({
-        id: grandchildName,
-        title: "Grandchild Session",
-        repoOwner: "acme",
-        repoName: "web-app",
-        model: "anthropic/claude-sonnet-4-6",
-        reasoningEffort: null,
-        baseBranch: null,
-        status: "active",
-        parentSessionId: childName,
-        spawnSource: "agent",
-        spawnDepth: 2,
-        createdAt: now,
-        updatedAt: now,
-      });
+      const grandchildName = await setupNestedSession(store, childName, 2, "grandchild-ops");
+      const greatGrandchildName = await setupNestedSession(
+        store,
+        grandchildName,
+        3,
+        "great-grandchild-ops"
+      );
 
       const res = await SELF.fetch(
         `https://test.local/sessions/${pName}/children/${childName}/cancel`,
@@ -300,30 +316,14 @@ describe("Child session operations (list, get, cancel)", () => {
       expect(res.status).toBe(200);
       expect((await store.get(childName))?.status).toBe("cancelled");
       expect((await store.get(grandchildName))?.status).toBe("cancelled");
+      expect((await store.get(greatGrandchildName))?.status).toBe("cancelled");
     });
 
     it("leaves nested tasks running when cancelNested is false", async () => {
       const { pName, childName, sandboxToken, store } = await setupParentAndChild({
         childStatus: "active",
       });
-      const grandchildName = `grandchild-no-cascade-${Date.now()}`;
-      await initNamedSession(grandchildName, { repoOwner: "acme", repoName: "web-app" });
-      const now = Date.now();
-      await store.create({
-        id: grandchildName,
-        title: "Grandchild Session",
-        repoOwner: "acme",
-        repoName: "web-app",
-        model: "anthropic/claude-sonnet-4-6",
-        reasoningEffort: null,
-        baseBranch: null,
-        status: "active",
-        parentSessionId: childName,
-        spawnSource: "agent",
-        spawnDepth: 2,
-        createdAt: now,
-        updatedAt: now,
-      });
+      const grandchildName = await setupNestedSession(store, childName, 2, "grandchild-no-cascade");
 
       const res = await SELF.fetch(
         `https://test.local/sessions/${pName}/children/${childName}/cancel`,
@@ -340,6 +340,49 @@ describe("Child session operations (list, get, cancel)", () => {
       expect(res.status).toBe(200);
       expect((await store.get(childName))?.status).toBe("cancelled");
       expect((await store.get(grandchildName))?.status).toBe("active");
+    });
+
+    it("returns 400 for malformed non-empty JSON without cancelling tasks", async () => {
+      const { pName, childName, sandboxToken, store } = await setupParentAndChild({
+        childStatus: "active",
+      });
+      const grandchildName = await setupNestedSession(store, childName, 2, "grandchild-malformed");
+
+      const res = await SELF.fetch(
+        `https://test.local/sessions/${pName}/children/${childName}/cancel`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${sandboxToken}`,
+            "Content-Type": "application/json",
+          },
+          body: '{"cancelNested":false',
+        }
+      );
+
+      expect(res.status).toBe(400);
+      expect((await store.get(childName))?.status).toBe("active");
+      expect((await store.get(grandchildName))?.status).toBe("active");
+    });
+
+    it("continues cascading when the direct child is already terminal", async () => {
+      const { pName, childName, childStub, sandboxToken, store } = await setupParentAndChild({
+        childStatus: "cancelled",
+      });
+      await queryDO(childStub, "UPDATE session SET status = 'cancelled'");
+      const grandchildName = await setupNestedSession(store, childName, 2, "grandchild-retry");
+
+      const res = await SELF.fetch(
+        `https://test.local/sessions/${pName}/children/${childName}/cancel`,
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${sandboxToken}` },
+        }
+      );
+
+      expect(res.status).toBe(409);
+      expect((await store.get(childName))?.status).toBe("cancelled");
+      expect((await store.get(grandchildName))?.status).toBe("cancelled");
     });
 
     it("returns 409 for completed session", async () => {

--- a/packages/control-plane/test/integration/child-session-ops.test.ts
+++ b/packages/control-plane/test/integration/child-session-ops.test.ts
@@ -314,6 +314,10 @@ describe("Child session operations (list, get, cancel)", () => {
       );
 
       expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toEqual({
+        status: "cancelled",
+        cancelledDescendantIds: [greatGrandchildName, grandchildName],
+      });
       expect((await store.get(childName))?.status).toBe("cancelled");
       expect((await store.get(grandchildName))?.status).toBe("cancelled");
       expect((await store.get(greatGrandchildName))?.status).toBe("cancelled");
@@ -380,9 +384,31 @@ describe("Child session operations (list, get, cancel)", () => {
         }
       );
 
-      expect(res.status).toBe(409);
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toEqual({
+        status: "cancelled",
+        cancelledDescendantIds: [grandchildName],
+      });
       expect((await store.get(childName))?.status).toBe("cancelled");
       expect((await store.get(grandchildName))?.status).toBe("cancelled");
+    });
+
+    it("returns 409 when the direct child is terminal and no descendants are active", async () => {
+      const { pName, childName, childStub, sandboxToken, store } = await setupParentAndChild({
+        childStatus: "cancelled",
+      });
+      await queryDO(childStub, "UPDATE session SET status = 'cancelled'");
+
+      const res = await SELF.fetch(
+        `https://test.local/sessions/${pName}/children/${childName}/cancel`,
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${sandboxToken}` },
+        }
+      );
+
+      expect(res.status).toBe(409);
+      expect((await store.get(childName))?.status).toBe("cancelled");
     });
 
     it("returns 409 for completed session", async () => {

--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/cancel-task.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/cancel-task.js
@@ -13,7 +13,6 @@ export default tool({
     taskId: z.string().describe("The task ID to cancel (from spawn-task or get-task-status)."),
     cancelNested: z
       .boolean()
-      .optional()
       .default(true)
       .describe("Whether to also cancel all nested child tasks. Defaults to true."),
   },
@@ -38,7 +37,11 @@ export default tool({
       }
 
       const result = await response.json();
-      return `Task "${args.taskId}" cancelled successfully. Status: ${(result.status || "cancelled").toUpperCase()}`;
+      const nestedCount = Array.isArray(result.cancelledDescendantIds)
+        ? result.cancelledDescendantIds.length
+        : 0;
+      const nestedNote = nestedCount > 0 ? ` Also cancelled ${nestedCount} nested task(s).` : "";
+      return `Task "${args.taskId}" cancelled successfully.${nestedNote} Status: ${(result.status || "cancelled").toUpperCase()}`;
     } catch (error) {
       return `Failed to cancel task: ${error instanceof Error ? error.message : String(error)}`;
     }

--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/cancel-task.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/cancel-task.js
@@ -8,15 +8,21 @@ import { bridgeFetch, extractError } from "./_bridge-client.js";
 export default tool({
   name: "cancel-task",
   description:
-    "Cancel a running child task. The task's sandbox will be stopped and its status set to cancelled. Use get-task-status to find the task ID.",
+    "Cancel a running child task. Nested tasks are cancelled by default. The task's sandbox will be stopped and its status set to cancelled. Use get-task-status to find the task ID.",
   args: {
     taskId: z.string().describe("The task ID to cancel (from spawn-task or get-task-status)."),
+    cancelNested: z
+      .boolean()
+      .optional()
+      .default(true)
+      .describe("Whether to also cancel all nested child tasks. Defaults to true."),
   },
   async execute(args) {
     try {
       const encodedTaskId = encodeURIComponent(args.taskId);
       const response = await bridgeFetch(`/children/${encodedTaskId}/cancel`, {
         method: "POST",
+        body: JSON.stringify({ cancelNested: args.cancelNested }),
       });
 
       if (!response.ok) {

--- a/packages/shared/src/types/boundary-schemas.test.ts
+++ b/packages/shared/src/types/boundary-schemas.test.ts
@@ -12,6 +12,7 @@ import {
   serverMessageSchema,
   sendPromptResponseSchema,
   spawnChildSessionRequestSchema,
+  cancelChildSessionRequestSchema,
   spawnContextSchema,
   userPreferencesRequestSchema,
 } from ".";
@@ -464,6 +465,26 @@ describe("boundary schemas", () => {
       const result = spawnChildSessionRequestSchema.safeParse({
         title: "Missing prompt",
       });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("cancelChildSessionRequestSchema", () => {
+    it("parses an empty options object", () => {
+      const result = cancelChildSessionRequestSchema.safeParse({});
+
+      expect(result.success).toBe(true);
+    });
+
+    it("parses an explicit cancelNested flag", () => {
+      const result = cancelChildSessionRequestSchema.safeParse({ cancelNested: false });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects a non-boolean cancelNested", () => {
+      const result = cancelChildSessionRequestSchema.safeParse({ cancelNested: "yes" });
 
       expect(result.success).toBe(false);
     });

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -159,6 +159,7 @@ export {
   createSessionResponseSchema,
   sendPromptResponseSchema,
   spawnChildSessionRequestSchema,
+  cancelChildSessionRequestSchema,
   spawnContextSchema,
 } from "./session-api";
 export type {
@@ -176,6 +177,7 @@ export type {
   SendPromptResponse,
   ListSessionsResponse,
   SpawnChildSessionRequest,
+  CancelChildSessionRequest,
   SpawnContext,
   ChildSessionFinalResponse,
   ChildSessionTrajectory,

--- a/packages/shared/src/types/session-api.ts
+++ b/packages/shared/src/types/session-api.ts
@@ -248,6 +248,13 @@ export const spawnChildSessionRequestSchema = z.object({
 
 export type SpawnChildSessionRequest = z.infer<typeof spawnChildSessionRequestSchema>;
 
+/** Request body for POST /sessions/:parentId/children/:childId/cancel. */
+export const cancelChildSessionRequestSchema = z.object({
+  cancelNested: z.boolean().optional(),
+});
+
+export type CancelChildSessionRequest = z.infer<typeof cancelChildSessionRequestSchema>;
+
 /**
  * Returned by the parent Durable Object's GET /internal/spawn-context.
  *


### PR DESCRIPTION
## Summary
- add a `cancelNested` option to the `cancel-task` tool, defaulting to `true`
- recursively discover active descendants and cancel them deepest-first
- preserve target-only cancellation with `cancelNested: false`
- tolerate descendants that reach a terminal state during cancellation and report other partial failures
- add unit and integration coverage for recursive and opt-out behavior

## Verification
- `npm test -w @open-inspect/control-plane -- src/db/session-index.test.ts`
- `npm run test:integration -w @open-inspect/control-plane -- child-session-ops.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run build -w @open-inspect/control-plane`
- ESLint and Prettier checks on changed files

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/89add2663f40ceee91e5b14164b48dc5)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Child task cancellation now supports deep nested cancellation by default (cascades to active descendants).
  * Added `cancelNested: false` to cancel only the specified child.
  * Updated the `cancel-task` tool to accept the `cancelNested` option and report cancelled nested counts.

* **Bug Fixes**
  * Improved request validation for `cancelNested` (malformed/invalid JSON now returns clear 400 errors).

* **Tests**
  * Extended unit/integration coverage for recursive descendant listing/cancellation, ordering, and error/edge cases (including tolerated conflict handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->