### PR TITLE
fix: log deferred session background failures

### DIFF
--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1094,7 +1094,13 @@ export class SessionDO extends DurableObject<Env> {
         });
 
         // Process any pending messages now that sandbox is connected
-        this.processMessageQueue();
+        this.ctx.waitUntil(
+          this.processMessageQueue().catch((error) => {
+            log.error("message_queue.process.background_error", {
+              error: error instanceof Error ? error : String(error),
+            });
+          })
+        );
       } else {
         const wsId = `ws-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
         this.wsManager.acceptClientSocket(server, wsId);

--- a/packages/control-plane/src/session/sandbox-events.test.ts
+++ b/packages/control-plane/src/session/sandbox-events.test.ts
@@ -104,6 +104,7 @@ function createProcessor() {
     applySessionTitleUpdate,
     waitUntil,
     recordTerminalMessage,
+    log,
   };
 }
 
@@ -123,6 +124,28 @@ describe("SessionSandboxEventProcessor", () => {
 
     expect(h.processMessageQueue).toHaveBeenCalledOnce();
     expect(h.statusService.reconcileAfterExecution).toHaveBeenCalledWith(true);
+  });
+
+  it("logs when the post-completion snapshot fails", async () => {
+    const h = createProcessor();
+    h.repository.getProcessingMessage.mockReturnValue({ id: "msg-1" });
+    h.repository.getMessageTimestamps.mockReturnValue({ created_at: 1000, started_at: 1100 });
+    h.triggerSnapshot.mockRejectedValue(new Error("snapshot backend down"));
+
+    await h.processor.processSandboxEvent({
+      type: "execution_complete",
+      messageId: "msg-1",
+      success: true,
+      sandboxId: "sb-1",
+      timestamp: 2000,
+    });
+
+    const settled = await Promise.allSettled(h.waitUntil.mock.calls.map(([promise]) => promise));
+    expect(settled.every(({ status }) => status === "fulfilled")).toBe(true);
+    expect(h.log.error).toHaveBeenCalledWith("snapshot.trigger.background_error", {
+      reason: "execution_complete",
+      error: expect.any(Error),
+    });
   });
 
   it("updates heartbeat without broadcasting", async () => {

--- a/packages/control-plane/src/session/sandbox-events.ts
+++ b/packages/control-plane/src/session/sandbox-events.ts
@@ -239,7 +239,14 @@ export class SessionSandboxEventProcessor {
         });
       }
 
-      this.ctx.waitUntil(this.triggerSnapshot("execution_complete"));
+      this.ctx.waitUntil(
+        this.triggerSnapshot("execution_complete").catch((error) => {
+          this.log.error("snapshot.trigger.background_error", {
+            reason: "execution_complete",
+            error,
+          });
+        })
+      );
       this.updateLastActivity(now);
       await this.scheduleInactivityCheck();
       await this.processMessageQueue();


### PR DESCRIPTION
## Summary

Narrow hygiene pass over two control-plane background-work sites:

1. `durable-object.ts` no longer leaves `processMessageQueue()` as a floating promise when a sandbox WebSocket connects. The promise is registered with the existing Durable Object background-work pattern and unexpected failures are logged as `message_queue.process.background_error`.
2. `sandbox-events.ts` now attaches structured error handling to the post-completion snapshot task, logging unexpected failures as `snapshot.trigger.background_error` with the snapshot reason.

## Scope corrections

- Child-spawn parent notification remains on the Worker `ExecutionContext.waitUntil()` path. It is a best-effort UI refresh, does not belong on the successful spawn response path, and later child status transitions also notify the parent.
- `CallbackNotificationService.notifyComplete()` retains its existing contract: expected delivery failures are returned and logged, while unexpected internal failures are logged and rethrown. Promises passed to `waitUntil()` are observed by the runtime, so a service-wide swallow policy is unnecessary.
- Durable Object `waitUntil()` is not described as extending object lifetime; Durable Objects remain active while they have ongoing work or pending I/O. The added catches provide explicit structured diagnostics.

## Behavior

- No successful-path behavior changes.
- Unexpected queue-processing and snapshot-task failures now produce structured logs.

## Tests

- Added coverage that a rejected post-completion snapshot task is handled and logged.
- The sandbox-connect flow remains covered by the control-plane integration suite; there is no direct SessionDO unit harness for the one-line queue-processing call site.

## Verification

- Control-plane unit: **155 files, 2320 tests passed**
- Control-plane integration (workerd + D1): **63 files, 744 tests passed**
- Control-plane typecheck (source + tests): passed
- Full repository lint and format check: passed
