### PR TITLE
Discourage premature child task cancellation

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/cancel-task.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/cancel-task.js
@@ -8,7 +8,7 @@ import { bridgeFetch, extractError } from "./_bridge-client.js";
 export default tool({
   name: "cancel-task",
   description:
-    "Cancel a running child task. Nested tasks are cancelled by default. The task's sandbox will be stopped and its status set to cancelled. Use get-task-status to find the task ID.",
+    "Cancel a running child task only when the user requests it or the work is clearly obsolete. Do not cancel because a task is slow, the parent is finished, or as cleanup. Nested tasks are cancelled by default. The task's sandbox will be stopped and its status set to cancelled.",
   args: {
     taskId: z.string().describe("The task ID to cancel (from spawn-task or get-task-status)."),
     cancelNested: z

--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/get-task-status.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/get-task-status.js
@@ -68,7 +68,7 @@ async function getChildDetail(taskId, options = {}) {
 export default tool({
   name: "get-task-status",
   description:
-    "Check child task status. Without a taskId, lists all child tasks with summary counts. With a taskId, returns details. Set includeResponse to retrieve the child's final assistant response when available. Set includeTrajectory for a paginated persisted event trajectory.",
+    "Check child task status only when its result is needed; do not poll repeatedly. Without a taskId, lists all child tasks with summary counts. With a taskId, returns details. Set includeResponse to retrieve the child's final assistant response when available. Set includeTrajectory for a paginated persisted event trajectory.",
   args: {
     taskId: z
       .string()

--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-task.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-task.js
@@ -11,7 +11,7 @@ import { bridgeFetch, extractError } from "./_bridge-client.js";
 export default tool({
   name: "spawn-task",
   description:
-    "Spawn a child coding task in a separate sandbox. Work directly by default. Use only for substantial, self-contained work that can run independently and materially benefits from parallel execution. Do not use for routine exploration, simple edits, tests, sequential steps, or merely multi-part requests. The child inherits the repository, not conversation context. Returns a task ID; check progress with get-task-status.",
+    "Spawn a child coding task in a separate sandbox. Work directly by default. Use only for substantial, self-contained work that can run independently and materially benefits from parallel execution. Do not use for routine exploration, simple edits, tests, sequential steps, or merely multi-part requests. The child inherits the repository, not conversation context, and continues running after the parent responds. Returns a task ID; continue other work and check status only when the result is needed.",
   args: {
     title: z.string().describe("Short title describing the child task (shown in the UI)."),
     prompt: z
@@ -57,7 +57,7 @@ export default tool({
         `  Task ID: ${result.sessionId}`,
         `  Status:  PENDING`,
         ``,
-        `Use get-task-status with this task ID to check progress.`,
+        `The task will continue independently. Check status only when you need its result; do not poll repeatedly.`,
       ].join("\n");
     } catch (error) {
       return `Failed to spawn task: ${error instanceof Error ? error.message : String(error)}`;


### PR DESCRIPTION
## Summary

- clarify that spawned child tasks continue after the parent responds
- tell agents to check status only when the child result is needed and avoid repeated polling
- restrict cancellation guidance to user-requested or clearly obsolete work rather than slow tasks or cleanup

## Testing

- `uv run --extra dev pytest tests/test_tool_installation.py -q` (25 passed)
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/bb73103febce442ab6d5ee57684cadc4)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified when task cancellation should be used, limiting it to explicit requests or obsolete work.
  * Updated task status guidance to discourage unnecessary or repeated polling.
  * Clarified that spawned tasks run independently and inherit only repository context, not conversation history.
  * Updated post-spawn guidance to recommend checking status only when the result is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->