### PR TITLE
feat(slack): forward image attachments from Slack messages to sessions

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -376,7 +376,8 @@ Queued delivery applies to every Slack completion, including text-only replies. 
 
 1. Add **Account | Queues | Edit** to the Cloudflare API token used by Terraform. Terraform needs
    this permission to create the completion queue, dead-letter queue, Worker binding, and consumer.
-2. Add the Slack bot scope `files:write`, reinstall the app once for the workspace, and update
+2. Add the Slack bot scopes `files:write` and `files:read` (needed to forward images attached to
+   Slack messages into sessions), reinstall the app once for the workspace, and update
    `slack_bot_token` if Slack issued a replacement.
 3. Run `terraform apply`, then verify a text completion and a generated-media attachment. If the
    token lacks Queue access, the apply fails while provisioning the new resources; grant the

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -360,6 +360,7 @@ Skip this step if you don't need Slack integration.
    - `groups:read`
    - `im:history`
    - `im:read`
+   - `files:read` (lets the bot read images attached to messages and forward them to sessions)
    - `files:write`
    - `reactions:write`
 3. Click **"Install to Workspace"**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1817,6 +1817,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2572,6 +2573,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2594,6 +2596,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2616,6 +2619,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2632,6 +2636,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2648,6 +2653,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2664,6 +2670,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2680,6 +2687,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2696,6 +2704,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2712,6 +2721,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2728,6 +2738,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2744,6 +2755,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2760,6 +2772,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2776,6 +2789,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2798,6 +2812,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2820,6 +2835,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2842,6 +2858,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2864,6 +2881,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2886,6 +2904,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2908,6 +2927,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2930,6 +2950,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2952,6 +2973,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -2971,6 +2993,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -2990,6 +3013,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -3009,6 +3033,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [

--- a/packages/control-plane/src/media.ts
+++ b/packages/control-plane/src/media.ts
@@ -1,8 +1,11 @@
 import {
+  SESSION_ATTACHMENT_IMAGE_MAX_BYTES,
   SESSION_ATTACHMENT_IMAGE_MIME_TYPES,
   type SessionAttachmentMimeType,
   type VideoArtifactMetadata,
 } from "@open-inspect/shared";
+
+export { SESSION_ATTACHMENT_IMAGE_MAX_BYTES };
 
 export const SCREENSHOT_MAX_BYTES = 10 * 1024 * 1024;
 export const SCREENSHOT_UPLOAD_LIMIT_PER_SESSION = 100;
@@ -11,8 +14,6 @@ export const VIDEO_UPLOAD_LIMIT_PER_SESSION = 20;
 export const VIDEO_MAX_DURATION_MS = 90_000;
 export const VIDEO_TIMESTAMP_TOLERANCE_MS = 1_000;
 
-// User-attached prompt images (attached in the chat composer).
-export const SESSION_ATTACHMENT_IMAGE_MAX_BYTES = 10 * 1024 * 1024;
 // Allows multipart boundaries and headers while rejecting oversized requests
 // before request.formData() buffers them when Content-Length is available.
 export const SESSION_ATTACHMENT_MAX_REQUEST_BYTES = SESSION_ATTACHMENT_IMAGE_MAX_BYTES + 128 * 1024;

--- a/packages/shared/src/slack/client.test.ts
+++ b/packages/shared/src/slack/client.test.ts
@@ -5,6 +5,7 @@ import {
   completeExternalUpload,
   getExternalUploadUrl,
   getChannelInfo,
+  getMessageFiles,
   getPermalink,
   getThreadMessages,
   getUserInfo,
@@ -717,5 +718,74 @@ describe("listChannels", () => {
     if (!result.ok) {
       expect(result.error).toBe("missing_scope");
     }
+  });
+});
+
+describe("getMessageFiles", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches a single top-level message via conversations.history without oldest", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({
+        ok: true,
+        messages: [{ ts: "1.0", files: [{ id: "F1", mimetype: "image/png" }] }],
+      })
+    );
+
+    const files = await getMessageFiles("xoxb-token", "C123", "1.0");
+
+    expect(files).toHaveLength(1);
+    expect(files[0]!.id).toBe("F1");
+    const [url] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe(
+      "https://slack.com/api/conversations.history?channel=C123&latest=1.0&inclusive=true&limit=1"
+    );
+  });
+
+  it("fetches a thread reply via conversations.replies when threadTs differs", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({
+        ok: true,
+        messages: [{ ts: "1.0" }, { ts: "1.5", files: [{ id: "F2", mimetype: "image/jpeg" }] }],
+      })
+    );
+
+    const files = await getMessageFiles("xoxb-token", "C123", "1.5", "1.0");
+
+    expect(files).toHaveLength(1);
+    expect(files[0]!.id).toBe("F2");
+    const [url] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe(
+      "https://slack.com/api/conversations.replies?channel=C123&ts=1.0&latest=1.5&inclusive=true&limit=1"
+    );
+  });
+
+  it("uses conversations.history when threadTs equals ts (thread parent)", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ ok: true, messages: [{ ts: "1.0" }] }));
+
+    await getMessageFiles("xoxb-token", "C123", "1.0", "1.0");
+
+    const [url] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toContain("conversations.history");
+  });
+
+  it("returns [] when the message has no files or is not found", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ ok: true, messages: [{ ts: "9.9" }] })
+    );
+
+    expect(await getMessageFiles("xoxb-token", "C123", "1.0")).toEqual([]);
+  });
+
+  it("returns [] on Slack API errors (e.g. missing_scope)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ ok: false, error: "missing_scope" })
+    );
+
+    expect(await getMessageFiles("xoxb-token", "C123", "1.0")).toEqual([]);
   });
 });

--- a/packages/shared/src/slack/client.test.ts
+++ b/packages/shared/src/slack/client.test.ts
@@ -747,11 +747,14 @@ describe("getMessageFiles", () => {
     );
   });
 
-  it("fetches a thread reply via conversations.replies when threadTs differs", async () => {
+  it("fetches a thread reply via conversations.replies anchored on oldest", async () => {
+    // conversations.replies returns oldest-first, so an oldest=<ts> anchor puts
+    // the target reply first in the window; a latest anchor would return the
+    // thread root instead.
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       jsonResponse({
         ok: true,
-        messages: [{ ts: "1.0" }, { ts: "1.5", files: [{ id: "F2", mimetype: "image/jpeg" }] }],
+        messages: [{ ts: "1.5", files: [{ id: "F2", mimetype: "image/jpeg" }] }, { ts: "1.7" }],
       })
     );
 
@@ -764,8 +767,26 @@ describe("getMessageFiles", () => {
     }
     const [url] = fetchSpy.mock.calls[0]!;
     expect(url).toBe(
-      "https://slack.com/api/conversations.replies?channel=C123&ts=1.0&latest=1.5&inclusive=true&limit=1"
+      "https://slack.com/api/conversations.replies?channel=C123&ts=1.0&oldest=1.5&inclusive=true&limit=2"
     );
+  });
+
+  it("finds the target reply even when the thread root is included in the page", async () => {
+    // Some conversations.replies responses include the thread root alongside
+    // the windowed replies; find-by-ts must still pick the target.
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({
+        ok: true,
+        messages: [{ ts: "1.0" }, { ts: "1.5", files: [{ id: "F3", mimetype: "image/png" }] }],
+      })
+    );
+
+    const result = await getMessageFiles("xoxb-token", "C123", "1.5", "1.0");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.files[0]!.id).toBe("F3");
+    }
   });
 
   it("uses conversations.history when threadTs equals ts (thread parent)", async () => {

--- a/packages/shared/src/slack/client.test.ts
+++ b/packages/shared/src/slack/client.test.ts
@@ -734,10 +734,13 @@ describe("getMessageFiles", () => {
       })
     );
 
-    const files = await getMessageFiles("xoxb-token", "C123", "1.0");
+    const result = await getMessageFiles("xoxb-token", "C123", "1.0");
 
-    expect(files).toHaveLength(1);
-    expect(files[0]!.id).toBe("F1");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.files).toHaveLength(1);
+      expect(result.files[0]!.id).toBe("F1");
+    }
     const [url] = fetchSpy.mock.calls[0]!;
     expect(url).toBe(
       "https://slack.com/api/conversations.history?channel=C123&latest=1.0&inclusive=true&limit=1"
@@ -752,10 +755,13 @@ describe("getMessageFiles", () => {
       })
     );
 
-    const files = await getMessageFiles("xoxb-token", "C123", "1.5", "1.0");
+    const result = await getMessageFiles("xoxb-token", "C123", "1.5", "1.0");
 
-    expect(files).toHaveLength(1);
-    expect(files[0]!.id).toBe("F2");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.files).toHaveLength(1);
+      expect(result.files[0]!.id).toBe("F2");
+    }
     const [url] = fetchSpy.mock.calls[0]!;
     expect(url).toBe(
       "https://slack.com/api/conversations.replies?channel=C123&ts=1.0&latest=1.5&inclusive=true&limit=1"
@@ -773,19 +779,22 @@ describe("getMessageFiles", () => {
     expect(String(url)).toContain("conversations.history");
   });
 
-  it("returns [] when the message has no files or is not found", async () => {
+  it("returns empty files when the message has none or is not found", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       jsonResponse({ ok: true, messages: [{ ts: "9.9" }] })
     );
 
-    expect(await getMessageFiles("xoxb-token", "C123", "1.0")).toEqual([]);
+    expect(await getMessageFiles("xoxb-token", "C123", "1.0")).toEqual({ ok: true, files: [] });
   });
 
-  it("returns [] on Slack API errors (e.g. missing_scope)", async () => {
+  it("returns the failure arm on Slack API errors (e.g. missing_scope)", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       jsonResponse({ ok: false, error: "missing_scope" })
     );
 
-    expect(await getMessageFiles("xoxb-token", "C123", "1.0")).toEqual([]);
+    expect(await getMessageFiles("xoxb-token", "C123", "1.0")).toEqual({
+      ok: false,
+      error: "missing_scope",
+    });
   });
 });

--- a/packages/shared/src/slack/client.ts
+++ b/packages/shared/src/slack/client.ts
@@ -404,6 +404,8 @@ export interface SlackMessageFile {
   url_private?: string;
   url_private_download?: string;
   size?: number;
+  /** "external" marks remote files whose url_private is third-party-hosted. */
+  mode?: string;
 }
 
 /**
@@ -412,14 +414,15 @@ export interface SlackMessageFile {
  * `app_mention` events don't include the message's `files` array, so when an
  * event arrives without files we recover them from conversation history. Pass
  * `threadTs` when the message is a thread reply; otherwise the top-level
- * message at `ts` is fetched.
+ * message at `ts` is fetched. Returns the failure arm on API errors so callers
+ * can distinguish "the message has no files" from "the lookup failed".
  */
 export async function getMessageFiles(
   token: string,
   channelId: string,
   ts: string,
   threadTs?: string
-): Promise<SlackMessageFile[]> {
+): Promise<SlackEnvelope<{ files: SlackMessageFile[] }>> {
   // Single-message fetch: `latest=<ts>&inclusive=true&limit=1`. Do NOT also set
   // `oldest=<ts>` — an equal oldest/latest is a zero-width window that Slack
   // returns empty for. See conversations.history docs ("Retrieving messages").
@@ -439,9 +442,9 @@ export async function getMessageFiles(
           inclusive: "true",
           limit: "1",
         });
-  if (!res.ok) return [];
+  if (!res.ok) return res;
   const message = res.messages?.find((m) => m.ts === ts);
-  return message?.files ?? [];
+  return { ok: true, files: message?.files ?? [] };
 }
 
 export interface SlackUser {

--- a/packages/shared/src/slack/client.ts
+++ b/packages/shared/src/slack/client.ts
@@ -395,6 +395,55 @@ export async function getThreadMessages(
   return { ok: true, messages };
 }
 
+/** A file object as it appears on a Slack message (subset of fields we use). */
+export interface SlackMessageFile {
+  id?: string;
+  name?: string;
+  title?: string;
+  mimetype?: string;
+  url_private?: string;
+  url_private_download?: string;
+  size?: number;
+}
+
+/**
+ * Fetch the files attached to a single message.
+ *
+ * `app_mention` events don't include the message's `files` array, so when an
+ * event arrives without files we recover them from conversation history. Pass
+ * `threadTs` when the message is a thread reply; otherwise the top-level
+ * message at `ts` is fetched.
+ */
+export async function getMessageFiles(
+  token: string,
+  channelId: string,
+  ts: string,
+  threadTs?: string
+): Promise<SlackMessageFile[]> {
+  // Single-message fetch: `latest=<ts>&inclusive=true&limit=1`. Do NOT also set
+  // `oldest=<ts>` — an equal oldest/latest is a zero-width window that Slack
+  // returns empty for. See conversations.history docs ("Retrieving messages").
+  type HistoryResult = { messages?: Array<{ ts?: string; files?: SlackMessageFile[] }> };
+  const res =
+    threadTs && threadTs !== ts
+      ? await slackGet<HistoryResult>(token, "conversations.replies", {
+          channel: channelId,
+          ts: threadTs,
+          latest: ts,
+          inclusive: "true",
+          limit: "1",
+        })
+      : await slackGet<HistoryResult>(token, "conversations.history", {
+          channel: channelId,
+          latest: ts,
+          inclusive: "true",
+          limit: "1",
+        });
+  if (!res.ok) return [];
+  const message = res.messages?.find((m) => m.ts === ts);
+  return message?.files ?? [];
+}
+
 export interface SlackUser {
   id: string;
   name: string;

--- a/packages/shared/src/slack/client.ts
+++ b/packages/shared/src/slack/client.ts
@@ -423,18 +423,23 @@ export async function getMessageFiles(
   ts: string,
   threadTs?: string
 ): Promise<SlackEnvelope<{ files: SlackMessageFile[] }>> {
-  // Single-message fetch: `latest=<ts>&inclusive=true&limit=1`. Do NOT also set
-  // `oldest=<ts>` — an equal oldest/latest is a zero-width window that Slack
-  // returns empty for. See conversations.history docs ("Retrieving messages").
+  // Single-message fetch. The two endpoints sort differently, so the window
+  // anchor differs: conversations.history returns newest-first, so
+  // `latest=<ts>&inclusive=true&limit=1` yields the target; conversations.replies
+  // returns oldest-first, so the anchor must be `oldest=<ts>&inclusive=true` (a
+  // `latest` anchor would yield the thread root instead). Never set oldest and
+  // latest to the same ts — an equal pair is a zero-width window that Slack
+  // returns empty for. `limit=2` on replies tolerates the thread root being
+  // included alongside the target; the find-by-ts below is the source of truth.
   type HistoryResult = { messages?: Array<{ ts?: string; files?: SlackMessageFile[] }> };
   const res =
     threadTs && threadTs !== ts
       ? await slackGet<HistoryResult>(token, "conversations.replies", {
           channel: channelId,
           ts: threadTs,
-          latest: ts,
+          oldest: ts,
           inclusive: "true",
-          limit: "1",
+          limit: "2",
         })
       : await slackGet<HistoryResult>(token, "conversations.history", {
           channel: channelId,

--- a/packages/shared/src/slack/index.ts
+++ b/packages/shared/src/slack/index.ts
@@ -4,6 +4,7 @@ export {
   completeExternalUpload,
   getChannelInfo,
   getExternalUploadUrl,
+  getMessageFiles,
   getPermalink,
   getThreadMessages,
   getUserInfo,
@@ -24,6 +25,7 @@ export type {
   SlackEnvelope,
   CompleteExternalUploadOptions,
   ExternalUploadUrlOptions,
+  SlackMessageFile,
   SlackThreadMessage,
   SlackUser,
 } from "./client";

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -8,6 +8,7 @@
 export {
   MAX_SESSION_ATTACHMENTS_PER_MESSAGE,
   SESSION_ATTACHMENT_IMAGE_MIME_TYPES,
+  SESSION_ATTACHMENT_IMAGE_MAX_BYTES,
   sessionAttachmentMimeTypeSchema,
   sessionAttachmentIdSchema,
   sessionAttachmentReferenceSchema,

--- a/packages/shared/src/types/session-attachments.ts
+++ b/packages/shared/src/types/session-attachments.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 
 export const MAX_SESSION_ATTACHMENTS_PER_MESSAGE = 6;
+/** Per-image byte cap, enforced by the attachment store and every producer. */
+export const SESSION_ATTACHMENT_IMAGE_MAX_BYTES = 10 * 1024 * 1024;
 export const SESSION_ATTACHMENT_IMAGE_MIME_TYPES = [
   "image/png",
   "image/jpeg",

--- a/packages/slack-bot/src/attachments.test.ts
+++ b/packages/slack-bot/src/attachments.test.ts
@@ -1,9 +1,11 @@
 import { SESSION_ATTACHMENT_IMAGE_MAX_BYTES, type SlackMessageFile } from "@open-inspect/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  extractImageFiles,
   notifyDroppedAttachments,
-  uploadSlackImageAttachments,
+  prepareImageAttachments,
+  toImageAttachments,
+  uploadPreparedAttachments,
+  type SlackImageAttachment,
 } from "./attachments";
 import type { Env } from "./types";
 
@@ -33,6 +35,14 @@ const pngFile: SlackMessageFile = {
   size: 1024,
 };
 
+const pngAttachment: SlackImageAttachment = {
+  id: "F1",
+  name: "screenshot.png",
+  mimetype: "image/png",
+  size: 1024,
+  downloadUrl: "https://files.slack.com/files-pri/T1-F1/screenshot.png",
+};
+
 function imageBytesResponse(size = 16): Response {
   return new Response(new Uint8Array(size).fill(1), { status: 200 });
 }
@@ -41,103 +51,84 @@ function uploadCreatedResponse(attachmentId = "att-1"): Response {
   return new Response(JSON.stringify({ attachmentId, mimeType: "image/png" }), { status: 201 });
 }
 
+/** Download + upload in one step, as the delivery pipeline runs them. */
+async function prepareAndUpload(env: Env, sessionId: string, files: SlackMessageFile[]) {
+  const prepared = await prepareImageAttachments(env, toImageAttachments(files));
+  return uploadPreparedAttachments(env, sessionId, prepared);
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("extractImageFiles", () => {
+describe("toImageAttachments", () => {
   it("keeps only supported image mime types", () => {
     const files: SlackMessageFile[] = [
       pngFile,
-      { id: "F2", mimetype: "application/pdf", url_private: "https://x/pdf" },
-      { id: "F3", mimetype: "image/webp", url_private: "https://x/webp" },
+      { id: "F2", mimetype: "application/pdf", url_private: "https://files.slack.com/pdf" },
+      { id: "F3", mimetype: "image/webp", url_private: "https://files.slack.com/webp" },
       { id: "F4" },
     ];
-    expect(extractImageFiles(files).map((f) => f.id)).toEqual(["F1", "F3"]);
+    expect(toImageAttachments(files).map((f) => f.id)).toEqual(["F1", "F3"]);
   });
 
   it("returns [] for undefined or empty input", () => {
-    expect(extractImageFiles(undefined)).toEqual([]);
-    expect(extractImageFiles([])).toEqual([]);
+    expect(toImageAttachments(undefined)).toEqual([]);
+    expect(toImageAttachments([])).toEqual([]);
+  });
+
+  it("never admits non-Slack hosts, so the bot token cannot reach them", () => {
+    const files: SlackMessageFile[] = [
+      { ...pngFile, url_private: "https://evil.example.com/steal-token.png" },
+      { ...pngFile, id: "F2", url_private: "http://files.slack.com/not-https.png" },
+      { ...pngFile, id: "F3", url_private: "https://files.slack.com.evil.com/x.png" },
+    ];
+    expect(toImageAttachments(files)).toEqual([]);
+  });
+
+  it("skips remote (mode external) files whose URLs are registrant-controlled", () => {
+    expect(toImageAttachments([{ ...pngFile, mode: "external" }])).toEqual([]);
+  });
+
+  it("skips files with no download URL", () => {
+    expect(toImageAttachments([{ id: "F1", mimetype: "image/png" }])).toEqual([]);
+  });
+
+  it("prefers url_private_download and carries the declared size", () => {
+    const [attachment] = toImageAttachments([
+      { ...pngFile, url_private_download: "https://files.slack.com/download/F1" },
+    ]);
+    expect(attachment!.downloadUrl).toBe("https://files.slack.com/download/F1");
+    expect(attachment!.size).toBe(1024);
   });
 });
 
-describe("uploadSlackImageAttachments", () => {
-  it("downloads from Slack with the bot token and uploads to the session", async () => {
+describe("prepareImageAttachments", () => {
+  it("downloads from Slack with the bot token and no redirect following", async () => {
     const downloadSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(imageBytesResponse());
-    const controlPlaneFetch = vi.fn().mockResolvedValueOnce(uploadCreatedResponse());
-    const env = makeEnv(controlPlaneFetch);
+    const env = makeEnv();
 
-    const result = await uploadSlackImageAttachments(env, "sess-1", [pngFile]);
+    const prepared = await prepareImageAttachments(env, [pngAttachment]);
 
-    expect(result.references).toEqual([{ attachmentId: "att-1", name: "screenshot.png" }]);
-    expect(result.dropped).toEqual([]);
-
+    expect(prepared.files).toHaveLength(1);
+    expect(prepared.dropped).toEqual([]);
     const [downloadUrl, downloadInit] = downloadSpy.mock.calls[0]!;
-    expect(downloadUrl).toBe(pngFile.url_private);
+    expect(downloadUrl).toBe(pngAttachment.downloadUrl);
     expect((downloadInit!.headers as Record<string, string>).Authorization).toBe(
       "Bearer xoxb-test"
     );
     expect(downloadInit!.redirect).toBe("manual");
-
-    const [uploadUrl, uploadInit] = controlPlaneFetch.mock.calls[0]!;
-    expect(uploadUrl).toBe("https://internal/sessions/sess-1/attachments");
-    expect(uploadInit.method).toBe("POST");
-    expect(uploadInit.body).toBeInstanceOf(FormData);
-    // Workers-types FormData.get() is typed string | null, so narrow via unknown.
-    const uploaded = (uploadInit.body as FormData).get("file") as unknown as File;
-    expect(uploaded).toBeInstanceOf(File);
-    expect(uploaded.name).toBe("screenshot.png");
-    expect(uploaded.type).toBe("image/png");
-  });
-
-  it("prefers url_private_download when present", async () => {
-    const downloadSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(imageBytesResponse());
-    const env = makeEnv(vi.fn().mockResolvedValueOnce(uploadCreatedResponse()));
-
-    await uploadSlackImageAttachments(env, "sess-1", [
-      { ...pngFile, url_private_download: "https://files.slack.com/download/F1" },
-    ]);
-
-    expect(downloadSpy.mock.calls[0]![0]).toBe("https://files.slack.com/download/F1");
-  });
-
-  it("never sends the bot token to non-Slack hosts", async () => {
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
-    const env = makeEnv();
-
-    const result = await uploadSlackImageAttachments(env, "sess-1", [
-      { ...pngFile, url_private: "https://evil.example.com/steal-token.png" },
-      { ...pngFile, id: "F2", url_private: "http://files.slack.com/not-https.png" },
-      { ...pngFile, id: "F3", url_private: "https://files.slack.com.evil.com/x.png" },
-    ]);
-
-    expect(fetchSpy).not.toHaveBeenCalled();
-    expect(result.references).toEqual([]);
-    expect(result.dropped).toEqual(["download_failed", "download_failed", "download_failed"]);
-  });
-
-  it("skips remote (mode external) files without fetching", async () => {
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
-    const env = makeEnv();
-
-    const result = await uploadSlackImageAttachments(env, "sess-1", [
-      { ...pngFile, mode: "external" },
-    ]);
-
-    expect(fetchSpy).not.toHaveBeenCalled();
-    expect(result.dropped).toEqual(["download_failed"]);
   });
 
   it("treats redirects as failures so the token cannot leak downstream", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       new Response(null, { status: 302, headers: { Location: "https://evil.example.com" } })
     );
-    const env = makeEnv();
 
-    const result = await uploadSlackImageAttachments(env, "sess-1", [pngFile]);
+    const prepared = await prepareImageAttachments(makeEnv(), [pngAttachment]);
 
-    expect(result.dropped).toEqual(["download_failed"]);
+    expect(prepared.files).toEqual([]);
+    expect(prepared.dropped).toEqual(["download_failed"]);
   });
 
   it("rejects oversized bodies via Content-Length before reading them", async () => {
@@ -147,13 +138,12 @@ describe("uploadSlackImageAttachments", () => {
         headers: { "Content-Length": String(SESSION_ATTACHMENT_IMAGE_MAX_BYTES + 1) },
       })
     );
-    const env = makeEnv();
 
-    const result = await uploadSlackImageAttachments(env, "sess-1", [
-      { ...pngFile, size: undefined },
+    const prepared = await prepareImageAttachments(makeEnv(), [
+      { ...pngAttachment, size: undefined },
     ]);
 
-    expect(result.dropped).toEqual(["too_large"]);
+    expect(prepared.dropped).toEqual(["too_large"]);
   });
 
   it("caps streamed bodies that exceed the limit without a Content-Length", async () => {
@@ -170,94 +160,139 @@ describe("uploadSlackImageAttachments", () => {
       },
     });
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(body, { status: 200 }));
-    const controlPlaneFetch = vi.fn();
-    const env = makeEnv(controlPlaneFetch);
 
-    const result = await uploadSlackImageAttachments(env, "sess-1", [
-      { ...pngFile, size: undefined },
+    const prepared = await prepareImageAttachments(makeEnv(), [
+      { ...pngAttachment, size: undefined },
     ]);
 
-    expect(result.dropped).toEqual(["too_large"]);
-    expect(controlPlaneFetch).not.toHaveBeenCalled();
-  });
-
-  it("returns immediately when there are no image files", async () => {
-    const fetchSpy = vi.spyOn(globalThis, "fetch");
-    const env = makeEnv();
-
-    const result = await uploadSlackImageAttachments(env, "sess-1", [
-      { id: "F2", mimetype: "text/plain", url_private: "https://x/txt" },
-    ]);
-
-    expect(result).toEqual({ references: [], dropped: [] });
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(prepared.dropped).toEqual(["too_large"]);
   });
 
   it("drops files whose declared size exceeds the cap without downloading", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
-    const env = makeEnv();
 
-    const result = await uploadSlackImageAttachments(env, "sess-1", [
-      { ...pngFile, size: SESSION_ATTACHMENT_IMAGE_MAX_BYTES + 1 },
+    const prepared = await prepareImageAttachments(makeEnv(), [
+      { ...pngAttachment, size: SESSION_ATTACHMENT_IMAGE_MAX_BYTES + 1 },
     ]);
 
-    expect(result).toEqual({ references: [], dropped: ["too_large"] });
+    expect(prepared).toEqual({ files: [], dropped: ["too_large"] });
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("counts failed downloads as dropped and keeps processing later files", async () => {
+  it("counts failed downloads as dropped and keeps later files", async () => {
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(new Response("denied", { status: 403 }))
       .mockResolvedValueOnce(imageBytesResponse());
-    const controlPlaneFetch = vi.fn().mockResolvedValueOnce(uploadCreatedResponse("att-2"));
-    const env = makeEnv(controlPlaneFetch);
 
-    const result = await uploadSlackImageAttachments(env, "sess-1", [
-      pngFile,
-      { ...pngFile, id: "F2", name: "second.png" },
+    const prepared = await prepareImageAttachments(makeEnv(), [
+      pngAttachment,
+      { ...pngAttachment, id: "F2", name: "second.png" },
     ]);
 
-    expect(result.references).toEqual([{ attachmentId: "att-2", name: "second.png" }]);
-    expect(result.dropped).toEqual(["download_failed"]);
+    expect(prepared.files.map((f) => f.attachment.name)).toEqual(["second.png"]);
+    expect(prepared.dropped).toEqual(["download_failed"]);
   });
 
-  it("counts rejected uploads as dropped", async () => {
+  it("caps downloads at the per-message maximum and drops the rest", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => imageBytesResponse());
+    const attachments = Array.from({ length: 8 }, (_, i) => ({
+      ...pngAttachment,
+      id: `F${i}`,
+      name: `img-${i}.png`,
+    }));
+
+    const prepared = await prepareImageAttachments(makeEnv(), attachments);
+
+    expect(prepared.files).toHaveLength(6);
+    expect(prepared.dropped).toEqual(["over_cap", "over_cap"]);
+    expect(fetchSpy).toHaveBeenCalledTimes(6);
+  });
+
+  it("returns immediately when there are no attachments", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const prepared = await prepareImageAttachments(makeEnv(), []);
+
+    expect(prepared).toEqual({ files: [], dropped: [] });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("uploadPreparedAttachments", () => {
+  it("uploads to the session and returns prompt references", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(imageBytesResponse());
+    const controlPlaneFetch = vi.fn().mockResolvedValueOnce(uploadCreatedResponse());
+    const env = makeEnv(controlPlaneFetch);
+
+    const result = await prepareAndUpload(env, "sess-1", [pngFile]);
+
+    expect(result.references).toEqual([{ attachmentId: "att-1", name: "screenshot.png" }]);
+    expect(result.dropped).toEqual([]);
+    expect(result.sessionMissing).toBe(false);
+
+    const [uploadUrl, uploadInit] = controlPlaneFetch.mock.calls[0]!;
+    expect(uploadUrl).toBe("https://internal/sessions/sess-1/attachments");
+    expect(uploadInit.method).toBe("POST");
+    expect(uploadInit.body).toBeInstanceOf(FormData);
+    // Workers-types FormData.get() is typed string | null, so narrow via unknown.
+    const uploaded = (uploadInit.body as FormData).get("file") as unknown as File;
+    expect(uploaded).toBeInstanceOf(File);
+    expect(uploaded.name).toBe("screenshot.png");
+    expect(uploaded.type).toBe("image/png");
+  });
+
+  it("counts rejected uploads as dropped and carries prepare-stage drops forward", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("denied", { status: 403 }))
+      .mockResolvedValueOnce(imageBytesResponse());
     const controlPlaneFetch = vi
       .fn()
       .mockResolvedValueOnce(new Response(JSON.stringify({ error: "quota" }), { status: 429 }));
     const env = makeEnv(controlPlaneFetch);
 
-    const result = await uploadSlackImageAttachments(env, "sess-1", [pngFile]);
-
-    expect(result).toEqual({ references: [], dropped: ["upload_rejected"] });
-  });
-
-  it("caps forwarded images at the per-message maximum and drops the rest", async () => {
-    vi.spyOn(globalThis, "fetch").mockImplementation(async () => imageBytesResponse());
-    const controlPlaneFetch = vi.fn().mockImplementation(async () => uploadCreatedResponse());
-    const env = makeEnv(controlPlaneFetch);
-    const files = Array.from({ length: 8 }, (_, i) => ({
-      ...pngFile,
-      id: `F${i}`,
-      name: `img-${i}.png`,
-    }));
-
-    const result = await uploadSlackImageAttachments(env, "sess-1", files);
-
-    expect(result.references).toHaveLength(6);
-    expect(result.dropped).toEqual(["over_cap", "over_cap"]);
-    expect(controlPlaneFetch).toHaveBeenCalledTimes(6);
-  });
-
-  it("skips files with no download URL", async () => {
-    const env = makeEnv();
-
-    const result = await uploadSlackImageAttachments(env, "sess-1", [
-      { id: "F1", mimetype: "image/png" },
+    const result = await prepareAndUpload(env, "sess-1", [
+      pngFile,
+      { ...pngFile, id: "F2", name: "second.png" },
     ]);
 
-    expect(result).toEqual({ references: [], dropped: ["download_failed"] });
+    expect(result.references).toEqual([]);
+    expect(result.dropped).toEqual(["download_failed", "upload_rejected"]);
+    expect(result.sessionMissing).toBe(false);
+  });
+
+  it("flags the session as missing when every upload 404s", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => imageBytesResponse());
+    const controlPlaneFetch = vi
+      .fn()
+      .mockImplementation(async () => new Response(null, { status: 404 }));
+    const env = makeEnv(controlPlaneFetch);
+
+    const result = await prepareAndUpload(env, "sess-gone", [
+      pngFile,
+      { ...pngFile, id: "F2", name: "second.png" },
+    ]);
+
+    expect(result.references).toEqual([]);
+    expect(result.dropped).toEqual(["upload_rejected", "upload_rejected"]);
+    expect(result.sessionMissing).toBe(true);
+  });
+
+  it("does not flag a missing session when any upload succeeds or fails differently", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => imageBytesResponse());
+    const controlPlaneFetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(new Response(null, { status: 500 }));
+    const env = makeEnv(controlPlaneFetch);
+
+    const result = await prepareAndUpload(env, "sess-1", [
+      pngFile,
+      { ...pngFile, id: "F2", name: "second.png" },
+    ]);
+
+    expect(result.sessionMissing).toBe(false);
   });
 });
 
@@ -303,5 +338,22 @@ describe("notifyDroppedAttachments", () => {
     expect(body.text).not.toContain("files:read");
     expect(body.text).toContain("10 MB or smaller");
     expect(body.text).toContain("at most 6 images");
+  });
+
+  it("says no run started when notified with nothingSent", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    await notifyDroppedAttachments(
+      makeEnv(),
+      "C1",
+      "1.0",
+      { references: [], dropped: ["download_failed"] },
+      { nothingSent: true }
+    );
+
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string);
+    expect(body.text).toContain("didn't start on this request");
   });
 });

--- a/packages/slack-bot/src/attachments.test.ts
+++ b/packages/slack-bot/src/attachments.test.ts
@@ -1,9 +1,8 @@
-import type { SlackMessageFile } from "@open-inspect/shared";
+import { SESSION_ATTACHMENT_IMAGE_MAX_BYTES, type SlackMessageFile } from "@open-inspect/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   extractImageFiles,
   notifyDroppedAttachments,
-  SLACK_ATTACHMENT_MAX_FILE_BYTES,
   uploadSlackImageAttachments,
 } from "./attachments";
 import type { Env } from "./types";
@@ -72,13 +71,14 @@ describe("uploadSlackImageAttachments", () => {
     const result = await uploadSlackImageAttachments(env, "sess-1", [pngFile]);
 
     expect(result.references).toEqual([{ attachmentId: "att-1", name: "screenshot.png" }]);
-    expect(result.droppedCount).toBe(0);
+    expect(result.dropped).toEqual([]);
 
     const [downloadUrl, downloadInit] = downloadSpy.mock.calls[0]!;
     expect(downloadUrl).toBe(pngFile.url_private);
     expect((downloadInit!.headers as Record<string, string>).Authorization).toBe(
       "Bearer xoxb-test"
     );
+    expect(downloadInit!.redirect).toBe("manual");
 
     const [uploadUrl, uploadInit] = controlPlaneFetch.mock.calls[0]!;
     expect(uploadUrl).toBe("https://internal/sessions/sess-1/attachments");
@@ -102,6 +102,85 @@ describe("uploadSlackImageAttachments", () => {
     expect(downloadSpy.mock.calls[0]![0]).toBe("https://files.slack.com/download/F1");
   });
 
+  it("never sends the bot token to non-Slack hosts", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const env = makeEnv();
+
+    const result = await uploadSlackImageAttachments(env, "sess-1", [
+      { ...pngFile, url_private: "https://evil.example.com/steal-token.png" },
+      { ...pngFile, id: "F2", url_private: "http://files.slack.com/not-https.png" },
+      { ...pngFile, id: "F3", url_private: "https://files.slack.com.evil.com/x.png" },
+    ]);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.references).toEqual([]);
+    expect(result.dropped).toEqual(["download_failed", "download_failed", "download_failed"]);
+  });
+
+  it("skips remote (mode external) files without fetching", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const env = makeEnv();
+
+    const result = await uploadSlackImageAttachments(env, "sess-1", [
+      { ...pngFile, mode: "external" },
+    ]);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.dropped).toEqual(["download_failed"]);
+  });
+
+  it("treats redirects as failures so the token cannot leak downstream", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(null, { status: 302, headers: { Location: "https://evil.example.com" } })
+    );
+    const env = makeEnv();
+
+    const result = await uploadSlackImageAttachments(env, "sess-1", [pngFile]);
+
+    expect(result.dropped).toEqual(["download_failed"]);
+  });
+
+  it("rejects oversized bodies via Content-Length before reading them", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(new Uint8Array(16), {
+        status: 200,
+        headers: { "Content-Length": String(SESSION_ATTACHMENT_IMAGE_MAX_BYTES + 1) },
+      })
+    );
+    const env = makeEnv();
+
+    const result = await uploadSlackImageAttachments(env, "sess-1", [
+      { ...pngFile, size: undefined },
+    ]);
+
+    expect(result.dropped).toEqual(["too_large"]);
+  });
+
+  it("caps streamed bodies that exceed the limit without a Content-Length", async () => {
+    const chunk = new Uint8Array(1024 * 1024).fill(1);
+    let pushed = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (pushed * chunk.byteLength > SESSION_ATTACHMENT_IMAGE_MAX_BYTES) {
+          controller.close();
+          return;
+        }
+        pushed += 1;
+        controller.enqueue(chunk);
+      },
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(new Response(body, { status: 200 }));
+    const controlPlaneFetch = vi.fn();
+    const env = makeEnv(controlPlaneFetch);
+
+    const result = await uploadSlackImageAttachments(env, "sess-1", [
+      { ...pngFile, size: undefined },
+    ]);
+
+    expect(result.dropped).toEqual(["too_large"]);
+    expect(controlPlaneFetch).not.toHaveBeenCalled();
+  });
+
   it("returns immediately when there are no image files", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     const env = makeEnv();
@@ -110,7 +189,7 @@ describe("uploadSlackImageAttachments", () => {
       { id: "F2", mimetype: "text/plain", url_private: "https://x/txt" },
     ]);
 
-    expect(result).toEqual({ references: [], droppedCount: 0 });
+    expect(result).toEqual({ references: [], dropped: [] });
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
@@ -119,10 +198,10 @@ describe("uploadSlackImageAttachments", () => {
     const env = makeEnv();
 
     const result = await uploadSlackImageAttachments(env, "sess-1", [
-      { ...pngFile, size: SLACK_ATTACHMENT_MAX_FILE_BYTES + 1 },
+      { ...pngFile, size: SESSION_ATTACHMENT_IMAGE_MAX_BYTES + 1 },
     ]);
 
-    expect(result).toEqual({ references: [], droppedCount: 1 });
+    expect(result).toEqual({ references: [], dropped: ["too_large"] });
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
@@ -139,7 +218,7 @@ describe("uploadSlackImageAttachments", () => {
     ]);
 
     expect(result.references).toEqual([{ attachmentId: "att-2", name: "second.png" }]);
-    expect(result.droppedCount).toBe(1);
+    expect(result.dropped).toEqual(["download_failed"]);
   });
 
   it("counts rejected uploads as dropped", async () => {
@@ -151,7 +230,7 @@ describe("uploadSlackImageAttachments", () => {
 
     const result = await uploadSlackImageAttachments(env, "sess-1", [pngFile]);
 
-    expect(result).toEqual({ references: [], droppedCount: 1 });
+    expect(result).toEqual({ references: [], dropped: ["upload_rejected"] });
   });
 
   it("caps forwarded images at the per-message maximum and drops the rest", async () => {
@@ -167,7 +246,7 @@ describe("uploadSlackImageAttachments", () => {
     const result = await uploadSlackImageAttachments(env, "sess-1", files);
 
     expect(result.references).toHaveLength(6);
-    expect(result.droppedCount).toBe(2);
+    expect(result.dropped).toEqual(["over_cap", "over_cap"]);
     expect(controlPlaneFetch).toHaveBeenCalledTimes(6);
   });
 
@@ -178,25 +257,28 @@ describe("uploadSlackImageAttachments", () => {
       { id: "F1", mimetype: "image/png" },
     ]);
 
-    expect(result).toEqual({ references: [], droppedCount: 1 });
+    expect(result).toEqual({ references: [], dropped: ["download_failed"] });
   });
 });
 
 describe("notifyDroppedAttachments", () => {
-  it("does nothing when droppedCount is 0", async () => {
+  it("does nothing when nothing was dropped", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
 
-    await notifyDroppedAttachments(makeEnv(), "C1", "1.0", 0);
+    await notifyDroppedAttachments(makeEnv(), "C1", "1.0", { references: [], dropped: [] });
 
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("posts a threaded warning naming the files:read scope", async () => {
+  it("names the files:read scope only for download failures", async () => {
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
 
-    await notifyDroppedAttachments(makeEnv(), "C1", "1.0", 2);
+    await notifyDroppedAttachments(makeEnv(), "C1", "1.0", {
+      references: [],
+      dropped: ["download_failed", "download_failed"],
+    });
 
     const [url, init] = fetchSpy.mock.calls[0]!;
     expect(String(url)).toContain("chat.postMessage");
@@ -205,5 +287,21 @@ describe("notifyDroppedAttachments", () => {
     expect(body.thread_ts).toBe("1.0");
     expect(body.text).toContain("2 attached images");
     expect(body.text).toContain("files:read");
+  });
+
+  it("gives size and cap guidance instead of the scope hint when those caused the drops", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    await notifyDroppedAttachments(makeEnv(), "C1", "1.0", {
+      references: [],
+      dropped: ["too_large", "over_cap"],
+    });
+
+    const body = JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string);
+    expect(body.text).not.toContain("files:read");
+    expect(body.text).toContain("10 MB or smaller");
+    expect(body.text).toContain("at most 6 images");
   });
 });

--- a/packages/slack-bot/src/attachments.test.ts
+++ b/packages/slack-bot/src/attachments.test.ts
@@ -1,0 +1,208 @@
+import type { SlackMessageFile } from "@open-inspect/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  extractImageFiles,
+  notifyDroppedAttachments,
+  SLACK_ATTACHMENT_MAX_FILE_BYTES,
+  uploadSlackImageAttachments,
+} from "./attachments";
+import type { Env } from "./types";
+
+function makeEnv(controlPlaneFetch = vi.fn()): Env {
+  return {
+    SLACK_KV: {} as KVNamespace,
+    SLACK_COMPLETION_QUEUE: { send: vi.fn(async () => {}) } as unknown as Queue,
+    CONTROL_PLANE: { fetch: controlPlaneFetch } as unknown as Fetcher,
+    DEPLOYMENT_NAME: "test",
+    CONTROL_PLANE_URL: "https://control-plane.test",
+    WEB_APP_URL: "https://app.test",
+    DEFAULT_MODEL: "anthropic/claude-haiku-4-5",
+    CLASSIFICATION_MODEL: "anthropic/claude-haiku-4-5",
+    SLACK_BOT_TOKEN: "xoxb-test",
+    SLACK_SIGNING_SECRET: "signing-secret",
+    ANTHROPIC_API_KEY: "test-key",
+    INTERNAL_CALLBACK_SECRET: "callback-secret",
+    LOG_LEVEL: "error",
+  } as Env;
+}
+
+const pngFile: SlackMessageFile = {
+  id: "F1",
+  name: "screenshot.png",
+  mimetype: "image/png",
+  url_private: "https://files.slack.com/files-pri/T1-F1/screenshot.png",
+  size: 1024,
+};
+
+function imageBytesResponse(size = 16): Response {
+  return new Response(new Uint8Array(size).fill(1), { status: 200 });
+}
+
+function uploadCreatedResponse(attachmentId = "att-1"): Response {
+  return new Response(JSON.stringify({ attachmentId, mimeType: "image/png" }), { status: 201 });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("extractImageFiles", () => {
+  it("keeps only supported image mime types", () => {
+    const files: SlackMessageFile[] = [
+      pngFile,
+      { id: "F2", mimetype: "application/pdf", url_private: "https://x/pdf" },
+      { id: "F3", mimetype: "image/webp", url_private: "https://x/webp" },
+      { id: "F4" },
+    ];
+    expect(extractImageFiles(files).map((f) => f.id)).toEqual(["F1", "F3"]);
+  });
+
+  it("returns [] for undefined or empty input", () => {
+    expect(extractImageFiles(undefined)).toEqual([]);
+    expect(extractImageFiles([])).toEqual([]);
+  });
+});
+
+describe("uploadSlackImageAttachments", () => {
+  it("downloads from Slack with the bot token and uploads to the session", async () => {
+    const downloadSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(imageBytesResponse());
+    const controlPlaneFetch = vi.fn().mockResolvedValueOnce(uploadCreatedResponse());
+    const env = makeEnv(controlPlaneFetch);
+
+    const result = await uploadSlackImageAttachments(env, "sess-1", [pngFile]);
+
+    expect(result.references).toEqual([{ attachmentId: "att-1", name: "screenshot.png" }]);
+    expect(result.droppedCount).toBe(0);
+
+    const [downloadUrl, downloadInit] = downloadSpy.mock.calls[0]!;
+    expect(downloadUrl).toBe(pngFile.url_private);
+    expect((downloadInit!.headers as Record<string, string>).Authorization).toBe(
+      "Bearer xoxb-test"
+    );
+
+    const [uploadUrl, uploadInit] = controlPlaneFetch.mock.calls[0]!;
+    expect(uploadUrl).toBe("https://internal/sessions/sess-1/attachments");
+    expect(uploadInit.method).toBe("POST");
+    expect(uploadInit.body).toBeInstanceOf(FormData);
+    const uploaded = (uploadInit.body as FormData).get("file");
+    expect(uploaded).toBeInstanceOf(File);
+    expect((uploaded as File).name).toBe("screenshot.png");
+    expect((uploaded as File).type).toBe("image/png");
+  });
+
+  it("prefers url_private_download when present", async () => {
+    const downloadSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(imageBytesResponse());
+    const env = makeEnv(vi.fn().mockResolvedValueOnce(uploadCreatedResponse()));
+
+    await uploadSlackImageAttachments(env, "sess-1", [
+      { ...pngFile, url_private_download: "https://files.slack.com/download/F1" },
+    ]);
+
+    expect(downloadSpy.mock.calls[0]![0]).toBe("https://files.slack.com/download/F1");
+  });
+
+  it("returns immediately when there are no image files", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const env = makeEnv();
+
+    const result = await uploadSlackImageAttachments(env, "sess-1", [
+      { id: "F2", mimetype: "text/plain", url_private: "https://x/txt" },
+    ]);
+
+    expect(result).toEqual({ references: [], droppedCount: 0 });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("drops files whose declared size exceeds the cap without downloading", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const env = makeEnv();
+
+    const result = await uploadSlackImageAttachments(env, "sess-1", [
+      { ...pngFile, size: SLACK_ATTACHMENT_MAX_FILE_BYTES + 1 },
+    ]);
+
+    expect(result).toEqual({ references: [], droppedCount: 1 });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("counts failed downloads as dropped and keeps processing later files", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("denied", { status: 403 }))
+      .mockResolvedValueOnce(imageBytesResponse());
+    const controlPlaneFetch = vi.fn().mockResolvedValueOnce(uploadCreatedResponse("att-2"));
+    const env = makeEnv(controlPlaneFetch);
+
+    const result = await uploadSlackImageAttachments(env, "sess-1", [
+      pngFile,
+      { ...pngFile, id: "F2", name: "second.png" },
+    ]);
+
+    expect(result.references).toEqual([{ attachmentId: "att-2", name: "second.png" }]);
+    expect(result.droppedCount).toBe(1);
+  });
+
+  it("counts rejected uploads as dropped", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(imageBytesResponse());
+    const controlPlaneFetch = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ error: "quota" }), { status: 429 }));
+    const env = makeEnv(controlPlaneFetch);
+
+    const result = await uploadSlackImageAttachments(env, "sess-1", [pngFile]);
+
+    expect(result).toEqual({ references: [], droppedCount: 1 });
+  });
+
+  it("caps forwarded images at the per-message maximum and drops the rest", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => imageBytesResponse());
+    const controlPlaneFetch = vi.fn().mockImplementation(async () => uploadCreatedResponse());
+    const env = makeEnv(controlPlaneFetch);
+    const files = Array.from({ length: 8 }, (_, i) => ({
+      ...pngFile,
+      id: `F${i}`,
+      name: `img-${i}.png`,
+    }));
+
+    const result = await uploadSlackImageAttachments(env, "sess-1", files);
+
+    expect(result.references).toHaveLength(6);
+    expect(result.droppedCount).toBe(2);
+    expect(controlPlaneFetch).toHaveBeenCalledTimes(6);
+  });
+
+  it("skips files with no download URL", async () => {
+    const env = makeEnv();
+
+    const result = await uploadSlackImageAttachments(env, "sess-1", [
+      { id: "F1", mimetype: "image/png" },
+    ]);
+
+    expect(result).toEqual({ references: [], droppedCount: 1 });
+  });
+});
+
+describe("notifyDroppedAttachments", () => {
+  it("does nothing when droppedCount is 0", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    await notifyDroppedAttachments(makeEnv(), "C1", "1.0", 0);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("posts a threaded warning naming the files:read scope", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    await notifyDroppedAttachments(makeEnv(), "C1", "1.0", 2);
+
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toContain("chat.postMessage");
+    const body = JSON.parse(init!.body as string);
+    expect(body.channel).toBe("C1");
+    expect(body.thread_ts).toBe("1.0");
+    expect(body.text).toContain("2 attached images");
+    expect(body.text).toContain("files:read");
+  });
+});

--- a/packages/slack-bot/src/attachments.test.ts
+++ b/packages/slack-bot/src/attachments.test.ts
@@ -84,10 +84,11 @@ describe("uploadSlackImageAttachments", () => {
     expect(uploadUrl).toBe("https://internal/sessions/sess-1/attachments");
     expect(uploadInit.method).toBe("POST");
     expect(uploadInit.body).toBeInstanceOf(FormData);
-    const uploaded = (uploadInit.body as FormData).get("file");
+    // Workers-types FormData.get() is typed string | null, so narrow via unknown.
+    const uploaded = (uploadInit.body as FormData).get("file") as unknown as File;
     expect(uploaded).toBeInstanceOf(File);
-    expect((uploaded as File).name).toBe("screenshot.png");
-    expect((uploaded as File).type).toBe("image/png");
+    expect(uploaded.name).toBe("screenshot.png");
+    expect(uploaded.type).toBe("image/png");
   });
 
   it("prefers url_private_download when present", async () => {

--- a/packages/slack-bot/src/attachments.ts
+++ b/packages/slack-bot/src/attachments.ts
@@ -3,10 +3,13 @@
  * attachments.
  *
  * Slack file bytes live behind `url_private`, which requires the bot token to
- * download (and the `files:read` scope). Each supported image is downloaded and
- * uploaded to the control plane's session-attachments store; the prompt then
- * carries only `{ attachmentId, name }` references, matching how the web
- * composer attaches images.
+ * download (and the `files:read` scope). Raw Slack file payloads are
+ * normalized into {@link SlackImageAttachment} once at event ingress; every
+ * later stage (download, upload, pending-request state) works only with that
+ * model. Each supported image is downloaded and uploaded to the control
+ * plane's session-attachments store; the prompt then carries only
+ * `{ attachmentId, name }` references, matching how the web composer attaches
+ * images.
  */
 
 import {
@@ -28,6 +31,27 @@ const ATTACHMENT_NAME_MAX_LENGTH = 255;
 
 const SUPPORTED_MIME_TYPES = new Set<string>(SESSION_ATTACHMENT_IMAGE_MIME_TYPES);
 
+/** Prompt body used when a message carries images but no user text. */
+export const IMAGE_ONLY_PROMPT_TEXT = "See the attached image(s).";
+
+/**
+ * A Slack-attached image validated at event ingress: supported mime type and a
+ * Slack-hosted download URL the bot token may be sent to. This is the only
+ * shape that flows past the event handlers — raw `SlackMessageFile` payloads
+ * never reach downloads, session launch, or KV state.
+ */
+export interface SlackImageAttachment {
+  /** Slack file id, used for log correlation only. */
+  id?: string;
+  /** Display name, bounded to the attachment store's length limit. */
+  name: string;
+  mimetype: string;
+  /** Declared size in bytes, when Slack provided one. */
+  size?: number;
+  /** https URL on slack.com / *.slack.com serving the file bytes. */
+  downloadUrl: string;
+}
+
 /** Why an attached image did not make it to the session. */
 export type SlackAttachmentDropReason =
   | "download_failed"
@@ -35,26 +59,26 @@ export type SlackAttachmentDropReason =
   | "over_cap"
   | "upload_rejected";
 
-export interface SlackAttachmentUploadResult {
-  references: SessionAttachmentReference[];
+/** Downloaded image bytes plus a record of every image that was lost. */
+export interface PreparedImageAttachments {
+  files: Array<{ attachment: SlackImageAttachment; bytes: Uint8Array }>;
   /**
-   * One entry per image file the user attached that did NOT make it through.
-   * Lets callers surface a visible "couldn't read your image" note — tailored
+   * One entry per image the user attached that did NOT make it through, so
+   * callers can surface a visible "couldn't read your image" note — tailored
    * to the reason — instead of silently dropping it.
    */
   dropped: SlackAttachmentDropReason[];
 }
 
-/** The image files on a message, i.e. the ones eligible for forwarding. */
-export function extractImageFiles(files: SlackMessageFile[] | undefined): SlackMessageFile[] {
-  if (!files?.length) return [];
-  return files.filter((file) => file.mimetype && SUPPORTED_MIME_TYPES.has(file.mimetype));
-}
-
-/** Display name for the attachment, bounded to the store's length limit. */
-function attachmentName(file: SlackMessageFile): string {
-  const name = file.name || file.title || `${file.id ?? "image"}.png`;
-  return name.slice(0, ATTACHMENT_NAME_MAX_LENGTH);
+export interface SlackAttachmentUploadResult {
+  references: SessionAttachmentReference[];
+  /** Drop reasons carried over from download plus any upload failures. */
+  dropped: SlackAttachmentDropReason[];
+  /**
+   * True when every upload was rejected with 404 — the session no longer
+   * exists, so the failures are stale-session noise rather than real drops.
+   */
+  sessionMissing: boolean;
 }
 
 /**
@@ -72,6 +96,44 @@ function isTrustedSlackFileUrl(raw: string): boolean {
   }
   if (url.protocol !== "https:") return false;
   return url.hostname === "slack.com" || url.hostname.endsWith(".slack.com");
+}
+
+/**
+ * Normalize raw Slack file payloads into validated image attachments. Called
+ * once where files enter the bot (event handlers, pending-request delivery);
+ * everything downstream accepts only the result. Non-images are ignored;
+ * images that can never be fetched safely — remote (`mode: "external"`) files
+ * and non-Slack-hosted URLs — are skipped with a log so the drop is visible.
+ */
+export function toImageAttachments(
+  files: SlackMessageFile[] | undefined,
+  traceId?: string
+): SlackImageAttachment[] {
+  if (!files?.length) return [];
+  const attachments: SlackImageAttachment[] = [];
+  for (const file of files) {
+    if (!file.mimetype || !SUPPORTED_MIME_TYPES.has(file.mimetype)) continue;
+    const downloadUrl = file.url_private_download || file.url_private;
+    // Remote files are third-party-hosted and not fetchable with the bot
+    // token; their URLs must never receive it either.
+    if (!downloadUrl || file.mode === "external" || !isTrustedSlackFileUrl(downloadUrl)) {
+      log.warn("slack.attachment.untrusted_url", {
+        trace_id: traceId,
+        file_id: file.id,
+        file_mode: file.mode,
+      });
+      continue;
+    }
+    const name = file.name || file.title || `${file.id ?? "image"}.png`;
+    attachments.push({
+      id: file.id,
+      name: name.slice(0, ATTACHMENT_NAME_MAX_LENGTH),
+      mimetype: file.mimetype,
+      size: file.size,
+      downloadUrl,
+    });
+  }
+  return attachments;
 }
 
 /** Read the body with a hard byte cap, cancelling as soon as it is exceeded. */
@@ -100,28 +162,21 @@ async function readBodyCapped(res: Response, maxBytes: number): Promise<Uint8Arr
 }
 
 /**
- * Fetch a Slack-hosted file's bytes with the bot token, enforcing the trusted
- * host policy and the image byte cap. Returns a drop reason instead of bytes
- * when the file cannot be safely fetched.
+ * Fetch an image's bytes with the bot token, enforcing the trusted host policy
+ * (re-checked here as defense in depth) and the image byte cap. Returns a drop
+ * reason instead of bytes when the file cannot be safely fetched.
  */
 async function downloadSlackFile(
   token: string,
-  file: SlackMessageFile,
+  attachment: SlackImageAttachment,
   traceId?: string
 ): Promise<{ bytes: Uint8Array } | { dropReason: SlackAttachmentDropReason }> {
-  const downloadUrl = file.url_private_download || file.url_private;
-  // Remote files (mode "external") are third-party-hosted and not fetchable
-  // with the bot token; their URLs must never receive it either.
-  if (!downloadUrl || file.mode === "external" || !isTrustedSlackFileUrl(downloadUrl)) {
-    log.warn("slack.attachment.untrusted_url", {
-      trace_id: traceId,
-      file_id: file.id,
-      file_mode: file.mode,
-    });
+  if (!isTrustedSlackFileUrl(attachment.downloadUrl)) {
+    log.warn("slack.attachment.untrusted_url", { trace_id: traceId, file_id: attachment.id });
     return { dropReason: "download_failed" };
   }
   try {
-    const res = await fetch(downloadUrl, {
+    const res = await fetch(attachment.downloadUrl, {
       headers: { Authorization: `Bearer ${token}` },
       // A redirect off *.slack.com must not carry the token; fail instead.
       redirect: "manual",
@@ -130,7 +185,7 @@ async function downloadSlackFile(
     if (!res.ok) {
       log.warn("slack.attachment.download_failed", {
         trace_id: traceId,
-        file_id: file.id,
+        file_id: attachment.id,
         http_status: res.status,
       });
       return { dropReason: "download_failed" };
@@ -139,7 +194,7 @@ async function downloadSlackFile(
     if (Number.isFinite(contentLength) && contentLength > SESSION_ATTACHMENT_IMAGE_MAX_BYTES) {
       log.warn("slack.attachment.size_rejected", {
         trace_id: traceId,
-        file_id: file.id,
+        file_id: attachment.id,
         size_bytes: contentLength,
       });
       return { dropReason: "too_large" };
@@ -148,7 +203,7 @@ async function downloadSlackFile(
     if (bytes === null || bytes.byteLength === 0) {
       log.warn("slack.attachment.size_rejected", {
         trace_id: traceId,
-        file_id: file.id,
+        file_id: attachment.id,
         size_bytes: bytes === null ? -1 : 0,
       });
       return { dropReason: bytes === null ? "too_large" : "download_failed" };
@@ -157,7 +212,7 @@ async function downloadSlackFile(
   } catch (e) {
     log.warn("slack.attachment.download_error", {
       trace_id: traceId,
-      file_id: file.id,
+      file_id: attachment.id,
       error: e instanceof Error ? e : new Error(String(e)),
     });
     return { dropReason: "download_failed" };
@@ -165,23 +220,69 @@ async function downloadSlackFile(
 }
 
 /**
+ * Download image bytes for the (capped) attachments concurrently. Runs before
+ * a session exists — callers can bail out of session creation when an
+ * image-only request yields nothing — and bounds wall-clock time to a single
+ * download timeout regardless of file count, keeping the work well inside the
+ * Worker's post-response `waitUntil` window.
+ */
+export async function prepareImageAttachments(
+  env: Env,
+  attachments: SlackImageAttachment[],
+  traceId?: string
+): Promise<PreparedImageAttachments> {
+  if (attachments.length === 0) return { files: [], dropped: [] };
+
+  const eligible = attachments.slice(0, MAX_SESSION_ATTACHMENTS_PER_MESSAGE);
+  const dropped: SlackAttachmentDropReason[] = [];
+  type DownloadOutcome =
+    | { attachment: SlackImageAttachment; bytes: Uint8Array }
+    | { attachment: SlackImageAttachment; dropReason: SlackAttachmentDropReason };
+  const outcomes = await Promise.all(
+    eligible.map(async (attachment): Promise<DownloadOutcome> => {
+      if (
+        typeof attachment.size === "number" &&
+        attachment.size > SESSION_ATTACHMENT_IMAGE_MAX_BYTES
+      ) {
+        log.warn("slack.attachment.too_large", {
+          trace_id: traceId,
+          file_id: attachment.id,
+          size_bytes: attachment.size,
+        });
+        return { attachment, dropReason: "too_large" as const };
+      }
+      const download = await downloadSlackFile(env.SLACK_BOT_TOKEN, attachment, traceId);
+      return "dropReason" in download
+        ? { attachment, dropReason: download.dropReason }
+        : { attachment, bytes: download.bytes };
+    })
+  );
+
+  const files: PreparedImageAttachments["files"] = [];
+  for (const outcome of outcomes) {
+    if ("bytes" in outcome) files.push({ attachment: outcome.attachment, bytes: outcome.bytes });
+    else dropped.push(outcome.dropReason);
+  }
+  for (const _ of attachments.slice(MAX_SESSION_ATTACHMENTS_PER_MESSAGE)) {
+    dropped.push("over_cap");
+  }
+  return { files, dropped };
+}
+
+/**
  * Store one image in the session's attachment store and return the prompt
- * reference, or null when the control plane rejects it.
+ * reference, or the failure kind when the control plane rejects it.
  */
 async function uploadToSession(
   env: Env,
   sessionId: string,
-  file: SlackMessageFile,
-  bytes: Uint8Array,
+  file: PreparedImageAttachments["files"][number],
   traceId?: string
-): Promise<SessionAttachmentReference | null> {
-  const name = attachmentName(file);
+): Promise<{ reference: SessionAttachmentReference } | { sessionMissing: boolean }> {
+  const { attachment, bytes } = file;
   try {
     const formData = new FormData();
-    formData.append(
-      "file",
-      new File([bytes], name, { type: file.mimetype ?? "application/octet-stream" })
-    );
+    formData.append("file", new File([bytes], attachment.name, { type: attachment.mimetype }));
     const response = await env.CONTROL_PLANE.fetch(
       `https://internal/sessions/${sessionId}/attachments`,
       {
@@ -196,75 +297,64 @@ async function uploadToSession(
       log.warn("slack.attachment.upload_failed", {
         trace_id: traceId,
         session_id: sessionId,
-        file_id: file.id,
+        file_id: attachment.id,
         http_status: response.status,
       });
-      return null;
+      return { sessionMissing: response.status === 404 };
     }
     const body = (await response.json()) as { attachmentId?: unknown };
     if (typeof body.attachmentId !== "string" || !body.attachmentId) {
       log.warn("slack.attachment.upload_failed", {
         trace_id: traceId,
         session_id: sessionId,
-        file_id: file.id,
+        file_id: attachment.id,
         error: new Error("Invalid attachment upload response"),
       });
-      return null;
+      return { sessionMissing: false };
     }
-    return { attachmentId: body.attachmentId, name };
+    return { reference: { attachmentId: body.attachmentId, name: attachment.name } };
   } catch (e) {
     log.warn("slack.attachment.upload_error", {
       trace_id: traceId,
       session_id: sessionId,
-      file_id: file.id,
+      file_id: attachment.id,
       error: e instanceof Error ? e : new Error(String(e)),
     });
-    return null;
+    return { sessionMissing: false };
   }
 }
 
 /**
- * Download the image files in `files` and store them as attachments on
- * `sessionId`, returning prompt references. Non-images, oversized files, and
- * failed downloads/uploads are skipped (logged) so a bad file never blocks the
- * message; `dropped` records each lost image with the reason so the caller can
- * tell the user.
+ * Store the prepared images as attachments on `sessionId` concurrently,
+ * returning prompt references in the original order. Failed uploads are
+ * recorded (never thrown) so a bad file never blocks the message; the result
+ * carries the prepare-stage drops forward so one notification covers both.
  */
-export async function uploadSlackImageAttachments(
+export async function uploadPreparedAttachments(
   env: Env,
   sessionId: string,
-  files: SlackMessageFile[] | undefined,
+  prepared: PreparedImageAttachments,
   traceId?: string
 ): Promise<SlackAttachmentUploadResult> {
-  const images = extractImageFiles(files);
-  if (images.length === 0) return { references: [], dropped: [] };
-
+  const outcomes = await Promise.all(
+    prepared.files.map((file) => uploadToSession(env, sessionId, file, traceId))
+  );
   const references: SessionAttachmentReference[] = [];
-  const dropped: SlackAttachmentDropReason[] = [];
-  for (const file of images.slice(0, MAX_SESSION_ATTACHMENTS_PER_MESSAGE)) {
-    if (typeof file.size === "number" && file.size > SESSION_ATTACHMENT_IMAGE_MAX_BYTES) {
-      log.warn("slack.attachment.too_large", {
-        trace_id: traceId,
-        file_id: file.id,
-        size_bytes: file.size,
-      });
-      dropped.push("too_large");
-      continue;
+  const dropped: SlackAttachmentDropReason[] = [...prepared.dropped];
+  const failures: Array<{ sessionMissing: boolean }> = [];
+  for (const outcome of outcomes) {
+    if ("reference" in outcome) references.push(outcome.reference);
+    else {
+      dropped.push("upload_rejected");
+      failures.push(outcome);
     }
-    const download = await downloadSlackFile(env.SLACK_BOT_TOKEN, file, traceId);
-    if ("dropReason" in download) {
-      dropped.push(download.dropReason);
-      continue;
-    }
-    const reference = await uploadToSession(env, sessionId, file, download.bytes, traceId);
-    if (reference) references.push(reference);
-    else dropped.push("upload_rejected");
   }
-  for (const _ of images.slice(MAX_SESSION_ATTACHMENTS_PER_MESSAGE)) {
-    dropped.push("over_cap");
-  }
-
-  return { references, dropped };
+  return {
+    references,
+    dropped,
+    sessionMissing:
+      references.length === 0 && failures.length > 0 && failures.every((f) => f.sessionMissing),
+  };
 }
 
 /**
@@ -277,9 +367,14 @@ export async function notifyDroppedAttachments(
   env: Env,
   channel: string,
   threadTs: string,
-  result: SlackAttachmentUploadResult,
-  traceId?: string
+  result: { references: SessionAttachmentReference[]; dropped: SlackAttachmentDropReason[] },
+  options: {
+    traceId?: string;
+    /** True when no run started at all because every image was lost. */
+    nothingSent?: boolean;
+  } = {}
 ): Promise<void> {
+  const { traceId, nothingSent } = options;
   const droppedCount = result.dropped.length;
   if (droppedCount <= 0) return;
   const noun = droppedCount === 1 ? "image" : "images";
@@ -298,8 +393,11 @@ export async function notifyDroppedAttachments(
   if (reasons.has("over_cap")) {
     hints.push(`I can forward at most ${MAX_SESSION_ATTACHMENTS_PER_MESSAGE} images per message.`);
   }
+  const consequence = nothingSent
+    ? "so I didn't start on this request"
+    : `so ${pronoun} sent to the agent`;
   const message = [
-    `:warning: I couldn't read ${droppedCount} attached ${noun}, so ${pronoun} sent to the agent.`,
+    `:warning: I couldn't read ${droppedCount} attached ${noun}, ${consequence}.`,
     ...hints,
   ].join(" ");
   const postResult = await postMessage(env.SLACK_BOT_TOKEN, channel, message, {

--- a/packages/slack-bot/src/attachments.ts
+++ b/packages/slack-bot/src/attachments.ts
@@ -51,6 +51,7 @@ export function extractImageFiles(files: SlackMessageFile[] | undefined): SlackM
   return files.filter((file) => file.mimetype && SUPPORTED_MIME_TYPES.has(file.mimetype));
 }
 
+/** Display name for the attachment, bounded to the store's length limit. */
 function attachmentName(file: SlackMessageFile): string {
   const name = file.name || file.title || `${file.id ?? "image"}.png`;
   return name.slice(0, ATTACHMENT_NAME_MAX_LENGTH);
@@ -98,6 +99,11 @@ async function readBodyCapped(res: Response, maxBytes: number): Promise<Uint8Arr
   return body;
 }
 
+/**
+ * Fetch a Slack-hosted file's bytes with the bot token, enforcing the trusted
+ * host policy and the image byte cap. Returns a drop reason instead of bytes
+ * when the file cannot be safely fetched.
+ */
 async function downloadSlackFile(
   token: string,
   file: SlackMessageFile,
@@ -158,6 +164,10 @@ async function downloadSlackFile(
   }
 }
 
+/**
+ * Store one image in the session's attachment store and return the prompt
+ * reference, or null when the control plane rejects it.
+ */
 async function uploadToSession(
   env: Env,
   sessionId: string,

--- a/packages/slack-bot/src/attachments.ts
+++ b/packages/slack-bot/src/attachments.ts
@@ -1,0 +1,217 @@
+/**
+ * Forward image files attached to Slack messages into a session as prompt
+ * attachments.
+ *
+ * Slack file bytes live behind `url_private`, which requires the bot token to
+ * download (and the `files:read` scope). Each supported image is downloaded and
+ * uploaded to the control plane's session-attachments store; the prompt then
+ * carries only `{ attachmentId, name }` references, matching how the web
+ * composer attaches images.
+ */
+
+import {
+  buildInternalAuthHeaders,
+  MAX_SESSION_ATTACHMENTS_PER_MESSAGE,
+  postMessage,
+  SESSION_ATTACHMENT_IMAGE_MIME_TYPES,
+  type SessionAttachmentReference,
+  type SlackMessageFile,
+} from "@open-inspect/shared";
+import { createLogger } from "./logger";
+import { OUTBOUND_REQUEST_TIMEOUT_MS } from "./request-options";
+import type { Env } from "./types";
+
+const log = createLogger("attachments");
+
+/** Mirrors the control plane's SESSION_ATTACHMENT_IMAGE_MAX_BYTES cap. */
+export const SLACK_ATTACHMENT_MAX_FILE_BYTES = 10 * 1024 * 1024;
+
+const ATTACHMENT_NAME_MAX_LENGTH = 255;
+
+const SUPPORTED_MIME_TYPES = new Set<string>(SESSION_ATTACHMENT_IMAGE_MIME_TYPES);
+
+export interface SlackAttachmentUploadResult {
+  references: SessionAttachmentReference[];
+  /**
+   * How many image files the user attached that did NOT make it through
+   * (download failure, oversized, upload rejection, or over the per-message
+   * cap). Lets callers surface a visible "couldn't read your image" note
+   * instead of silently dropping it — the most common cause is a missing
+   * `files:read` scope.
+   */
+  droppedCount: number;
+}
+
+/** The image files on a message, i.e. the ones eligible for forwarding. */
+export function extractImageFiles(files: SlackMessageFile[] | undefined): SlackMessageFile[] {
+  if (!files?.length) return [];
+  return files.filter((file) => file.mimetype && SUPPORTED_MIME_TYPES.has(file.mimetype));
+}
+
+function attachmentName(file: SlackMessageFile): string {
+  const name = file.name || file.title || `${file.id ?? "image"}.png`;
+  return name.slice(0, ATTACHMENT_NAME_MAX_LENGTH);
+}
+
+async function downloadSlackFile(
+  token: string,
+  file: SlackMessageFile,
+  traceId?: string
+): Promise<Uint8Array | null> {
+  const downloadUrl = file.url_private_download || file.url_private;
+  if (!downloadUrl) return null;
+  try {
+    const res = await fetch(downloadUrl, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(OUTBOUND_REQUEST_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      log.warn("slack.attachment.download_failed", {
+        trace_id: traceId,
+        file_id: file.id,
+        http_status: res.status,
+      });
+      return null;
+    }
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    if (bytes.byteLength === 0 || bytes.byteLength > SLACK_ATTACHMENT_MAX_FILE_BYTES) {
+      log.warn("slack.attachment.size_rejected", {
+        trace_id: traceId,
+        file_id: file.id,
+        size_bytes: bytes.byteLength,
+      });
+      return null;
+    }
+    return bytes;
+  } catch (e) {
+    log.warn("slack.attachment.download_error", {
+      trace_id: traceId,
+      file_id: file.id,
+      error: e instanceof Error ? e : new Error(String(e)),
+    });
+    return null;
+  }
+}
+
+async function uploadToSession(
+  env: Env,
+  sessionId: string,
+  file: SlackMessageFile,
+  bytes: Uint8Array,
+  traceId?: string
+): Promise<SessionAttachmentReference | null> {
+  const name = attachmentName(file);
+  try {
+    const formData = new FormData();
+    formData.append(
+      "file",
+      new File([bytes], name, { type: file.mimetype ?? "application/octet-stream" })
+    );
+    const response = await env.CONTROL_PLANE.fetch(
+      `https://internal/sessions/${sessionId}/attachments`,
+      {
+        method: "POST",
+        // No Content-Type here: FormData sets the multipart boundary itself.
+        headers: await buildInternalAuthHeaders(env.INTERNAL_CALLBACK_SECRET, traceId),
+        body: formData,
+        signal: AbortSignal.timeout(OUTBOUND_REQUEST_TIMEOUT_MS),
+      }
+    );
+    if (!response.ok) {
+      log.warn("slack.attachment.upload_failed", {
+        trace_id: traceId,
+        session_id: sessionId,
+        file_id: file.id,
+        http_status: response.status,
+      });
+      return null;
+    }
+    const body = (await response.json()) as { attachmentId?: unknown };
+    if (typeof body.attachmentId !== "string" || !body.attachmentId) {
+      log.warn("slack.attachment.upload_failed", {
+        trace_id: traceId,
+        session_id: sessionId,
+        file_id: file.id,
+        error: new Error("Invalid attachment upload response"),
+      });
+      return null;
+    }
+    return { attachmentId: body.attachmentId, name };
+  } catch (e) {
+    log.warn("slack.attachment.upload_error", {
+      trace_id: traceId,
+      session_id: sessionId,
+      file_id: file.id,
+      error: e instanceof Error ? e : new Error(String(e)),
+    });
+    return null;
+  }
+}
+
+/**
+ * Download the image files in `files` and store them as attachments on
+ * `sessionId`, returning prompt references. Non-images, oversized files, and
+ * failed downloads/uploads are skipped (logged) so a bad file never blocks the
+ * message; `droppedCount` reports how many images were lost so the caller can
+ * tell the user.
+ */
+export async function uploadSlackImageAttachments(
+  env: Env,
+  sessionId: string,
+  files: SlackMessageFile[] | undefined,
+  traceId?: string
+): Promise<SlackAttachmentUploadResult> {
+  const images = extractImageFiles(files);
+  if (images.length === 0) return { references: [], droppedCount: 0 };
+
+  const references: SessionAttachmentReference[] = [];
+  for (const file of images.slice(0, MAX_SESSION_ATTACHMENTS_PER_MESSAGE)) {
+    if (typeof file.size === "number" && file.size > SLACK_ATTACHMENT_MAX_FILE_BYTES) {
+      log.warn("slack.attachment.too_large", {
+        trace_id: traceId,
+        file_id: file.id,
+        size_bytes: file.size,
+      });
+      continue;
+    }
+    const bytes = await downloadSlackFile(env.SLACK_BOT_TOKEN, file, traceId);
+    if (!bytes) continue;
+    const reference = await uploadToSession(env, sessionId, file, bytes, traceId);
+    if (reference) references.push(reference);
+  }
+
+  // Everything the user attached as an image that didn't survive (failed
+  // downloads/uploads, oversized files, and anything beyond the per-message cap).
+  return { references, droppedCount: images.length - references.length };
+}
+
+/**
+ * Tell the user how many of their attached images could not be forwarded. The
+ * most common root cause is the Slack app missing the `files:read` scope, so
+ * the note names it. Best effort — never blocks the message.
+ */
+export async function notifyDroppedAttachments(
+  env: Env,
+  channel: string,
+  threadTs: string,
+  droppedCount: number,
+  traceId?: string
+): Promise<void> {
+  if (droppedCount <= 0) return;
+  const noun = droppedCount === 1 ? "image" : "images";
+  const pronoun = droppedCount === 1 ? "it wasn't" : "they weren't";
+  const result = await postMessage(
+    env.SLACK_BOT_TOKEN,
+    channel,
+    `:warning: I couldn't read ${droppedCount} attached ${noun}, so ${pronoun} sent to the agent. ` +
+      "If this keeps happening, the bot may be missing the `files:read` Slack scope — an admin can add it and reinstall the app.",
+    { thread_ts: threadTs }
+  );
+  if (!result.ok) {
+    log.warn("slack.attachment.notify_failed", {
+      trace_id: traceId,
+      channel,
+      slack_error: result.error,
+    });
+  }
+}

--- a/packages/slack-bot/src/attachments.ts
+++ b/packages/slack-bot/src/attachments.ts
@@ -13,6 +13,7 @@ import {
   buildInternalAuthHeaders,
   MAX_SESSION_ATTACHMENTS_PER_MESSAGE,
   postMessage,
+  SESSION_ATTACHMENT_IMAGE_MAX_BYTES,
   SESSION_ATTACHMENT_IMAGE_MIME_TYPES,
   type SessionAttachmentReference,
   type SlackMessageFile,
@@ -23,23 +24,25 @@ import type { Env } from "./types";
 
 const log = createLogger("attachments");
 
-/** Mirrors the control plane's SESSION_ATTACHMENT_IMAGE_MAX_BYTES cap. */
-export const SLACK_ATTACHMENT_MAX_FILE_BYTES = 10 * 1024 * 1024;
-
 const ATTACHMENT_NAME_MAX_LENGTH = 255;
 
 const SUPPORTED_MIME_TYPES = new Set<string>(SESSION_ATTACHMENT_IMAGE_MIME_TYPES);
 
+/** Why an attached image did not make it to the session. */
+export type SlackAttachmentDropReason =
+  | "download_failed"
+  | "too_large"
+  | "over_cap"
+  | "upload_rejected";
+
 export interface SlackAttachmentUploadResult {
   references: SessionAttachmentReference[];
   /**
-   * How many image files the user attached that did NOT make it through
-   * (download failure, oversized, upload rejection, or over the per-message
-   * cap). Lets callers surface a visible "couldn't read your image" note
-   * instead of silently dropping it — the most common cause is a missing
-   * `files:read` scope.
+   * One entry per image file the user attached that did NOT make it through.
+   * Lets callers surface a visible "couldn't read your image" note — tailored
+   * to the reason — instead of silently dropping it.
    */
-  droppedCount: number;
+  dropped: SlackAttachmentDropReason[];
 }
 
 /** The image files on a message, i.e. the ones eligible for forwarding. */
@@ -53,16 +56,69 @@ function attachmentName(file: SlackMessageFile): string {
   return name.slice(0, ATTACHMENT_NAME_MAX_LENGTH);
 }
 
+/**
+ * Only Slack-hosted file URLs may see the bot token. File objects arrive on
+ * webhook payloads, and Slack "remote" files (files.remote.add) carry an
+ * arbitrary registrant-supplied `url_private` — following one would hand the
+ * `Authorization: Bearer` header to that host.
+ */
+function isTrustedSlackFileUrl(raw: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "https:") return false;
+  return url.hostname === "slack.com" || url.hostname.endsWith(".slack.com");
+}
+
+/** Read the body with a hard byte cap, cancelling as soon as it is exceeded. */
+async function readBodyCapped(res: Response, maxBytes: number): Promise<Uint8Array | null> {
+  if (!res.body) return new Uint8Array();
+  const reader = res.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    totalBytes += value.byteLength;
+    if (totalBytes > maxBytes) {
+      await reader.cancel().catch(() => undefined);
+      return null;
+    }
+    chunks.push(value);
+  }
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body;
+}
+
 async function downloadSlackFile(
   token: string,
   file: SlackMessageFile,
   traceId?: string
-): Promise<Uint8Array | null> {
+): Promise<{ bytes: Uint8Array } | { dropReason: SlackAttachmentDropReason }> {
   const downloadUrl = file.url_private_download || file.url_private;
-  if (!downloadUrl) return null;
+  // Remote files (mode "external") are third-party-hosted and not fetchable
+  // with the bot token; their URLs must never receive it either.
+  if (!downloadUrl || file.mode === "external" || !isTrustedSlackFileUrl(downloadUrl)) {
+    log.warn("slack.attachment.untrusted_url", {
+      trace_id: traceId,
+      file_id: file.id,
+      file_mode: file.mode,
+    });
+    return { dropReason: "download_failed" };
+  }
   try {
     const res = await fetch(downloadUrl, {
       headers: { Authorization: `Bearer ${token}` },
+      // A redirect off *.slack.com must not carry the token; fail instead.
+      redirect: "manual",
       signal: AbortSignal.timeout(OUTBOUND_REQUEST_TIMEOUT_MS),
     });
     if (!res.ok) {
@@ -71,25 +127,34 @@ async function downloadSlackFile(
         file_id: file.id,
         http_status: res.status,
       });
-      return null;
+      return { dropReason: "download_failed" };
     }
-    const bytes = new Uint8Array(await res.arrayBuffer());
-    if (bytes.byteLength === 0 || bytes.byteLength > SLACK_ATTACHMENT_MAX_FILE_BYTES) {
+    const contentLength = Number(res.headers.get("Content-Length"));
+    if (Number.isFinite(contentLength) && contentLength > SESSION_ATTACHMENT_IMAGE_MAX_BYTES) {
       log.warn("slack.attachment.size_rejected", {
         trace_id: traceId,
         file_id: file.id,
-        size_bytes: bytes.byteLength,
+        size_bytes: contentLength,
       });
-      return null;
+      return { dropReason: "too_large" };
     }
-    return bytes;
+    const bytes = await readBodyCapped(res, SESSION_ATTACHMENT_IMAGE_MAX_BYTES);
+    if (bytes === null || bytes.byteLength === 0) {
+      log.warn("slack.attachment.size_rejected", {
+        trace_id: traceId,
+        file_id: file.id,
+        size_bytes: bytes === null ? -1 : 0,
+      });
+      return { dropReason: bytes === null ? "too_large" : "download_failed" };
+    }
+    return { bytes };
   } catch (e) {
     log.warn("slack.attachment.download_error", {
       trace_id: traceId,
       file_id: file.id,
       error: e instanceof Error ? e : new Error(String(e)),
     });
-    return null;
+    return { dropReason: "download_failed" };
   }
 }
 
@@ -152,7 +217,7 @@ async function uploadToSession(
  * Download the image files in `files` and store them as attachments on
  * `sessionId`, returning prompt references. Non-images, oversized files, and
  * failed downloads/uploads are skipped (logged) so a bad file never blocks the
- * message; `droppedCount` reports how many images were lost so the caller can
+ * message; `dropped` records each lost image with the reason so the caller can
  * tell the user.
  */
 export async function uploadSlackImageAttachments(
@@ -162,56 +227,79 @@ export async function uploadSlackImageAttachments(
   traceId?: string
 ): Promise<SlackAttachmentUploadResult> {
   const images = extractImageFiles(files);
-  if (images.length === 0) return { references: [], droppedCount: 0 };
+  if (images.length === 0) return { references: [], dropped: [] };
 
   const references: SessionAttachmentReference[] = [];
+  const dropped: SlackAttachmentDropReason[] = [];
   for (const file of images.slice(0, MAX_SESSION_ATTACHMENTS_PER_MESSAGE)) {
-    if (typeof file.size === "number" && file.size > SLACK_ATTACHMENT_MAX_FILE_BYTES) {
+    if (typeof file.size === "number" && file.size > SESSION_ATTACHMENT_IMAGE_MAX_BYTES) {
       log.warn("slack.attachment.too_large", {
         trace_id: traceId,
         file_id: file.id,
         size_bytes: file.size,
       });
+      dropped.push("too_large");
       continue;
     }
-    const bytes = await downloadSlackFile(env.SLACK_BOT_TOKEN, file, traceId);
-    if (!bytes) continue;
-    const reference = await uploadToSession(env, sessionId, file, bytes, traceId);
+    const download = await downloadSlackFile(env.SLACK_BOT_TOKEN, file, traceId);
+    if ("dropReason" in download) {
+      dropped.push(download.dropReason);
+      continue;
+    }
+    const reference = await uploadToSession(env, sessionId, file, download.bytes, traceId);
     if (reference) references.push(reference);
+    else dropped.push("upload_rejected");
+  }
+  for (const _ of images.slice(MAX_SESSION_ATTACHMENTS_PER_MESSAGE)) {
+    dropped.push("over_cap");
   }
 
-  // Everything the user attached as an image that didn't survive (failed
-  // downloads/uploads, oversized files, and anything beyond the per-message cap).
-  return { references, droppedCount: images.length - references.length };
+  return { references, dropped };
 }
 
 /**
- * Tell the user how many of their attached images could not be forwarded. The
- * most common root cause is the Slack app missing the `files:read` scope, so
- * the note names it. Best effort — never blocks the message.
+ * Tell the user how many of their attached images could not be forwarded, with
+ * guidance matched to why. Call this only once the prompt outcome is known —
+ * uploads against a stale session fail spuriously and are retried against the
+ * replacement session. Best effort — never blocks the message.
  */
 export async function notifyDroppedAttachments(
   env: Env,
   channel: string,
   threadTs: string,
-  droppedCount: number,
+  result: SlackAttachmentUploadResult,
   traceId?: string
 ): Promise<void> {
+  const droppedCount = result.dropped.length;
   if (droppedCount <= 0) return;
   const noun = droppedCount === 1 ? "image" : "images";
   const pronoun = droppedCount === 1 ? "it wasn't" : "they weren't";
-  const result = await postMessage(
-    env.SLACK_BOT_TOKEN,
-    channel,
-    `:warning: I couldn't read ${droppedCount} attached ${noun}, so ${pronoun} sent to the agent. ` +
-      "If this keeps happening, the bot may be missing the `files:read` Slack scope — an admin can add it and reinstall the app.",
-    { thread_ts: threadTs }
-  );
-  if (!result.ok) {
+  const reasons = new Set(result.dropped);
+  const hints: string[] = [];
+  if (reasons.has("download_failed")) {
+    hints.push(
+      "If this keeps happening, the bot may be missing the `files:read` Slack scope — an admin can add it and reinstall the app."
+    );
+  }
+  if (reasons.has("too_large")) {
+    const maxMb = Math.floor(SESSION_ATTACHMENT_IMAGE_MAX_BYTES / (1024 * 1024));
+    hints.push(`Images must be ${maxMb} MB or smaller.`);
+  }
+  if (reasons.has("over_cap")) {
+    hints.push(`I can forward at most ${MAX_SESSION_ATTACHMENTS_PER_MESSAGE} images per message.`);
+  }
+  const message = [
+    `:warning: I couldn't read ${droppedCount} attached ${noun}, so ${pronoun} sent to the agent.`,
+    ...hints,
+  ].join(" ");
+  const postResult = await postMessage(env.SLACK_BOT_TOKEN, channel, message, {
+    thread_ts: threadTs,
+  });
+  if (!postResult.ok) {
     log.warn("slack.attachment.notify_failed", {
       trace_id: traceId,
       channel,
-      slack_error: result.error,
+      slack_error: postResult.error,
     });
   }
 }

--- a/packages/slack-bot/src/dm-utils.test.ts
+++ b/packages/slack-bot/src/dm-utils.test.ts
@@ -66,6 +66,24 @@ describe("isDmDispatchable", () => {
   it("returns false for non-message event type", () => {
     expect(isDmDispatchable({ ...baseEvent, type: "app_mention" })).toBe(false);
   });
+
+  it("returns true for a file_share message with text", () => {
+    expect(isDmDispatchable({ ...baseEvent, subtype: "file_share" })).toBe(true);
+  });
+
+  it("returns true for a text-less file_share message with files", () => {
+    expect(
+      isDmDispatchable({ ...baseEvent, subtype: "file_share", text: undefined, files: [{}] })
+    ).toBe(true);
+  });
+
+  it("returns false for a text-less file_share message without files", () => {
+    expect(isDmDispatchable({ ...baseEvent, subtype: "file_share", text: undefined })).toBe(false);
+  });
+
+  it("still rejects other subtypes even when files are present", () => {
+    expect(isDmDispatchable({ ...baseEvent, subtype: "message_changed", files: [{}] })).toBe(false);
+  });
 });
 
 describe("isChannelTriggerCandidate", () => {

--- a/packages/slack-bot/src/dm-utils.ts
+++ b/packages/slack-bot/src/dm-utils.ts
@@ -12,7 +12,9 @@ export function stripMentions(text: string): string {
 /**
  * Returns true if a Slack message event should be dispatched as a DM.
  * Filters out subtypes (bot_message, message_changed, message_deleted, etc.)
- * to prevent processing bot replies and edit/delete notifications.
+ * to prevent processing bot replies and edit/delete notifications. Messages
+ * with file uploads arrive as the `file_share` subtype and may carry no text,
+ * so they dispatch on their attachments instead.
  */
 export function isDmDispatchable(event: {
   type: string;
@@ -22,12 +24,15 @@ export function isDmDispatchable(event: {
   channel?: string;
   ts?: string;
   user?: string;
+  files?: unknown[];
 }): boolean {
+  const subtypeOk = !event.subtype || event.subtype === "file_share";
+  const hasContent = !!event.text || (event.files?.length ?? 0) > 0;
   return (
     event.type === "message" &&
-    !event.subtype &&
+    subtypeOk &&
     event.channel_type === "im" &&
-    !!event.text &&
+    hasContent &&
     !!event.channel &&
     !!event.ts &&
     !!event.user

--- a/packages/slack-bot/src/events/dispatcher.ts
+++ b/packages/slack-bot/src/events/dispatcher.ts
@@ -1,3 +1,4 @@
+import type { SlackMessageFile } from "@open-inspect/shared";
 import { publishAppHome } from "../app-home";
 import { handleChannelTrigger } from "../channel-trigger";
 import { isDmDispatchable } from "../dm-utils";
@@ -18,6 +19,7 @@ export interface SlackEventPayload {
     tab?: string;
     channel_type?: string;
     subtype?: string;
+    files?: SlackMessageFile[];
     attachments?: Array<{
       text?: string;
       pretext?: string;
@@ -46,12 +48,14 @@ export async function handleSlackEvent(
     await handleDirectMessage(
       {
         type: event.type,
-        text: event.text!,
+        // file_share messages may carry no text at all.
+        text: event.text ?? "",
         user: event.user!,
         channel: event.channel!,
         ts: event.ts!,
         thread_ts: event.thread_ts,
         channel_type: event.channel_type,
+        files: event.files,
       },
       env,
       traceId,
@@ -68,6 +72,7 @@ export async function handleSlackEvent(
         channel: event.channel,
         ts: event.ts,
         thread_ts: event.thread_ts,
+        files: event.files,
       },
       env,
       traceId,

--- a/packages/slack-bot/src/events/message-handler.ts
+++ b/packages/slack-bot/src/events/message-handler.ts
@@ -157,13 +157,12 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
           })
         : undefined;
       const interimContext = interimMessages ? formatInterimThreadContext(interimMessages) : "";
-      const { references, droppedCount } = await uploadSlackImageAttachments(
+      const uploadResult = await uploadSlackImageAttachments(
         env,
         existingSession.sessionId,
         imageFiles,
         traceId
       );
-      await notifyDroppedAttachments(env, channel, threadTs, droppedCount, traceId);
       const promptResult = await sendPrompt(
         env,
         existingSession.sessionId,
@@ -171,9 +170,13 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
         `slack:${user}`,
         callbackContext,
         traceId,
-        references
+        uploadResult.references
       );
       if (promptResult.ok) {
+        // Notify about dropped images only now that the session proved live —
+        // uploads against a stale session fail spuriously and are retried
+        // against the replacement session below.
+        await notifyDroppedAttachments(env, channel, threadTs, uploadResult, traceId);
         // Only advance the checkpoint past messages we know were considered.
         // When the interim fetch failed, keeping the old watermark lets the
         // next follow-up retry the window; at worst it re-includes this
@@ -302,28 +305,41 @@ export async function handleAppMention(
   scheduleBackground: BackgroundTaskScheduler
 ): Promise<void> {
   const messageText = stripMentions(event.text);
-  // app_mention events don't carry the message's `files` array, so when the
-  // event has none we recover them from conversation history.
-  let files = event.files;
-  if (!files?.length) {
-    files = await getMessageFiles(env.SLACK_BOT_TOKEN, event.channel, event.ts, event.thread_ts);
-  }
-  const hasContent = Boolean(messageText) || extractImageFiles(files).length > 0;
   const threadKey = event.thread_ts || event.ts;
-  if (hasContent)
+  if (messageText)
     scheduleStartingStatus(scheduleBackground, env, event.channel, threadKey, traceId);
+
+  // app_mention events don't carry the message's `files` array, so when the
+  // event has none we recover them from conversation history — overlapped with
+  // the channel-info fetch to keep the extra round trip off the critical path.
+  const filesPromise: Promise<SlackMessageFile[]> = event.files?.length
+    ? Promise.resolve(event.files)
+    : getMessageFiles(env.SLACK_BOT_TOKEN, event.channel, event.ts, event.thread_ts).then(
+        (lookup) => {
+          if (lookup.ok) return lookup.files;
+          // Failure is not "no files": any images on the message are lost
+          // here, so make the drop visible in logs.
+          log.warn("slack.attachment.file_lookup_failed", {
+            trace_id: traceId,
+            channel: event.channel,
+            message_ts: event.ts,
+            slack_error: lookup.error,
+          });
+          return [];
+        }
+      );
+  const channelInfoPromise = messageText
+    ? getChannelInfo(env.SLACK_BOT_TOKEN, event.channel).catch(() => undefined)
+    : Promise.resolve(undefined);
+  const [files, channelInfo] = await Promise.all([filesPromise, channelInfoPromise]);
+  if (!messageText && extractImageFiles(files).length > 0) {
+    scheduleStartingStatus(scheduleBackground, env, event.channel, threadKey, traceId);
+  }
   let channelName: string | undefined;
   let channelDescription: string | undefined;
-  if (hasContent) {
-    try {
-      const channelInfo = await getChannelInfo(env.SLACK_BOT_TOKEN, event.channel);
-      if (channelInfo.ok && channelInfo.channel) {
-        channelName = channelInfo.channel.name;
-        channelDescription = channelInfo.channel.topic?.value || channelInfo.channel.purpose?.value;
-      }
-    } catch {
-      // Channel context is best effort.
-    }
+  if (channelInfo?.ok && channelInfo.channel) {
+    channelName = channelInfo.channel.name;
+    channelDescription = channelInfo.channel.topic?.value || channelInfo.channel.purpose?.value;
   }
   await handleIncomingMessage({
     text: messageText,

--- a/packages/slack-bot/src/events/message-handler.ts
+++ b/packages/slack-bot/src/events/message-handler.ts
@@ -2,12 +2,19 @@ import {
   addReaction,
   escapeMrkdwnText,
   getChannelInfo,
+  getMessageFiles,
   getThreadMessages,
   postMessage,
   resolveUserNames,
   updateMessage,
   type CallbackContext,
+  type SlackMessageFile,
 } from "@open-inspect/shared";
+import {
+  extractImageFiles,
+  notifyDroppedAttachments,
+  uploadSlackImageAttachments,
+} from "../attachments";
 import { createClassifier } from "../classifier";
 import { loadTargetCatalog } from "../classifier/catalog";
 import { stripMentions } from "../dm-utils";
@@ -91,6 +98,8 @@ interface IncomingMessageParams {
   threadTs?: string;
   channelName?: string;
   channelDescription?: string;
+  /** Files attached to the Slack message; images are forwarded to the session. */
+  files?: SlackMessageFile[];
   env: Env;
   traceId?: string;
   scheduleBackground: BackgroundTaskScheduler;
@@ -105,11 +114,13 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
     threadTs,
     channelName,
     channelDescription,
+    files,
     env,
     traceId,
     scheduleBackground,
   } = params;
-  if (!messageText) {
+  const imageFiles = extractImageFiles(files);
+  if (!messageText && imageFiles.length === 0) {
     await postMessage(
       env.SLACK_BOT_TOKEN,
       channel,
@@ -118,6 +129,8 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
     );
     return;
   }
+  // An image-only message still needs prompt content for the agent to act on.
+  const promptText = messageText || "See the attached image(s).";
 
   if (threadTs) {
     const existingSession = await lookupThreadSession(env, channel, threadTs);
@@ -144,13 +157,21 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
           })
         : undefined;
       const interimContext = interimMessages ? formatInterimThreadContext(interimMessages) : "";
+      const { references, droppedCount } = await uploadSlackImageAttachments(
+        env,
+        existingSession.sessionId,
+        imageFiles,
+        traceId
+      );
+      await notifyDroppedAttachments(env, channel, threadTs, droppedCount, traceId);
       const promptResult = await sendPrompt(
         env,
         existingSession.sessionId,
-        channelContext + interimContext + messageText,
+        channelContext + interimContext + promptText,
         `slack:${user}`,
         callbackContext,
-        traceId
+        traceId,
+        references
       );
       if (promptResult.ok) {
         // Only advance the checkpoint past messages we know were considered.
@@ -197,7 +218,7 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
     : undefined;
 
   const result = await createClassifier(env).classify(
-    messageText,
+    promptText,
     { channelId: channel, channelName, channelDescription, threadTs, previousMessages },
     traceId
   );
@@ -213,11 +234,12 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
       return;
     }
     await storePendingRequest(env, channel, threadTs || ts, {
-      message: messageText,
+      message: promptText,
       userId: user,
       previousMessages,
       channelName,
       channelDescription,
+      files: imageFiles.length > 0 ? imageFiles : undefined,
     });
     await postMessage(
       env.SLACK_BOT_TOKEN,
@@ -243,12 +265,13 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
     target: result.target,
     channel,
     threadTs: threadKey,
-    messageText,
+    messageText: promptText,
     userId: user,
     messageTs: ts,
     previousMessages,
     channelName,
     channelDescription,
+    files: imageFiles,
     traceId,
   });
   if (!sessionResult) return;
@@ -272,18 +295,26 @@ export async function handleAppMention(
     channel: string;
     ts: string;
     thread_ts?: string;
+    files?: SlackMessageFile[];
   },
   env: Env,
   traceId: string | undefined,
   scheduleBackground: BackgroundTaskScheduler
 ): Promise<void> {
   const messageText = stripMentions(event.text);
+  // app_mention events don't carry the message's `files` array, so when the
+  // event has none we recover them from conversation history.
+  let files = event.files;
+  if (!files?.length) {
+    files = await getMessageFiles(env.SLACK_BOT_TOKEN, event.channel, event.ts, event.thread_ts);
+  }
+  const hasContent = Boolean(messageText) || extractImageFiles(files).length > 0;
   const threadKey = event.thread_ts || event.ts;
-  if (messageText)
+  if (hasContent)
     scheduleStartingStatus(scheduleBackground, env, event.channel, threadKey, traceId);
   let channelName: string | undefined;
   let channelDescription: string | undefined;
-  if (messageText) {
+  if (hasContent) {
     try {
       const channelInfo = await getChannelInfo(env.SLACK_BOT_TOKEN, event.channel);
       if (channelInfo.ok && channelInfo.channel) {
@@ -302,6 +333,7 @@ export async function handleAppMention(
     threadTs: event.thread_ts,
     channelName,
     channelDescription,
+    files,
     env,
     traceId,
     scheduleBackground,
@@ -317,6 +349,7 @@ export async function handleDirectMessage(
     ts: string;
     thread_ts?: string;
     channel_type?: string;
+    files?: SlackMessageFile[];
   },
   env: Env,
   traceId: string | undefined,
@@ -324,8 +357,9 @@ export async function handleDirectMessage(
 ): Promise<void> {
   log.info("slack.dm.received", { trace_id: traceId, user: event.user, channel: event.channel });
   const messageText = stripMentions(event.text);
+  const hasContent = Boolean(messageText) || extractImageFiles(event.files).length > 0;
   const threadKey = event.thread_ts || event.ts;
-  if (messageText)
+  if (hasContent)
     scheduleStartingStatus(scheduleBackground, env, event.channel, threadKey, traceId);
   await handleIncomingMessage({
     text: messageText,
@@ -333,6 +367,7 @@ export async function handleDirectMessage(
     channel: event.channel,
     ts: event.ts,
     threadTs: event.thread_ts,
+    files: event.files,
     env,
     traceId,
     scheduleBackground,

--- a/packages/slack-bot/src/events/message-handler.ts
+++ b/packages/slack-bot/src/events/message-handler.ts
@@ -11,9 +11,10 @@ import {
   type SlackMessageFile,
 } from "@open-inspect/shared";
 import {
-  extractImageFiles,
-  notifyDroppedAttachments,
-  uploadSlackImageAttachments,
+  IMAGE_ONLY_PROMPT_TEXT,
+  prepareImageAttachments,
+  toImageAttachments,
+  type SlackImageAttachment,
 } from "../attachments";
 import { createClassifier } from "../classifier";
 import { loadTargetCatalog } from "../classifier/catalog";
@@ -26,7 +27,7 @@ import {
 } from "../messages/blocks";
 import { formatChannelContext, formatInterimThreadContext } from "../messages/context";
 import { storePendingRequest } from "../pending-requests/pending-request-store";
-import { sendPrompt } from "../sessions/control-plane-client";
+import { deliverPrompt } from "../sessions/prompt-delivery";
 import { startSessionAndSendPrompt } from "../sessions/session-launcher";
 import {
   advanceLastPromptTs,
@@ -98,8 +99,8 @@ interface IncomingMessageParams {
   threadTs?: string;
   channelName?: string;
   channelDescription?: string;
-  /** Files attached to the Slack message; images are forwarded to the session. */
-  files?: SlackMessageFile[];
+  /** Images attached to the Slack message, normalized at event ingress. */
+  images: SlackImageAttachment[];
   env: Env;
   traceId?: string;
   scheduleBackground: BackgroundTaskScheduler;
@@ -119,13 +120,12 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
     threadTs,
     channelName,
     channelDescription,
-    files,
+    images,
     env,
     traceId,
     scheduleBackground,
   } = params;
-  const imageFiles = extractImageFiles(files);
-  if (!messageText && imageFiles.length === 0) {
+  if (!messageText && images.length === 0) {
     await postMessage(
       env.SLACK_BOT_TOKEN,
       channel,
@@ -135,7 +135,8 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
     return;
   }
   // An image-only message still needs prompt content for the agent to act on.
-  const promptText = messageText || "See the attached image(s).";
+  const imageOnly = !messageText;
+  const promptText = messageText || IMAGE_ONLY_PROMPT_TEXT;
 
   if (threadTs) {
     const existingSession = await lookupThreadSession(env, channel, threadTs);
@@ -162,26 +163,18 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
           })
         : undefined;
       const interimContext = interimMessages ? formatInterimThreadContext(interimMessages) : "";
-      const uploadResult = await uploadSlackImageAttachments(
-        env,
-        existingSession.sessionId,
-        imageFiles,
-        traceId
-      );
-      const promptResult = await sendPrompt(
-        env,
-        existingSession.sessionId,
-        channelContext + interimContext + promptText,
-        `slack:${user}`,
+      const promptResult = await deliverPrompt(env, {
+        sessionId: existingSession.sessionId,
+        content: channelContext + interimContext + promptText,
+        authorId: `slack:${user}`,
+        attachments: await prepareImageAttachments(env, images, traceId),
+        imageOnly,
         callbackContext,
+        channel,
+        threadTs,
         traceId,
-        uploadResult.references
-      );
+      });
       if (promptResult.ok) {
-        // Notify about dropped images only now that the session proved live —
-        // uploads against a stale session fail spuriously and are retried
-        // against the replacement session below.
-        await notifyDroppedAttachments(env, channel, threadTs, uploadResult, traceId);
         // Only advance the checkpoint past messages we know were considered.
         // When the interim fetch failed, keeping the old watermark lets the
         // next follow-up retry the window; at worst it re-includes this
@@ -202,6 +195,9 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
         }
         return;
       }
+      // An image-only follow-up that lost every image sends no prompt; the
+      // user was already told inside deliverPrompt.
+      if (promptResult.reason === "no_images_delivered") return;
       if (promptResult.reason === "transient") {
         await postMessage(
           env.SLACK_BOT_TOKEN,
@@ -247,7 +243,10 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
       previousMessages,
       channelName,
       channelDescription,
-      files: imageFiles.length > 0 ? imageFiles : undefined,
+      imageOnly: imageOnly || undefined,
+      // Persist where the images live, not the file objects; they are
+      // re-fetched from Slack when the user resolves the clarification.
+      sourceMessage: images.length > 0 ? { ts, threadTs } : undefined,
     });
     await postMessage(
       env.SLACK_BOT_TOKEN,
@@ -279,7 +278,8 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
     previousMessages,
     channelName,
     channelDescription,
-    files: imageFiles,
+    images,
+    imageOnly,
     traceId,
   });
   if (!sessionResult) return;
@@ -344,7 +344,8 @@ export async function handleAppMention(
     () => undefined
   );
   const [files, channelInfo] = await Promise.all([filesPromise, channelInfoPromise]);
-  if (!messageText && extractImageFiles(files).length > 0) {
+  const images = toImageAttachments(files, traceId);
+  if (!messageText && images.length > 0) {
     scheduleStartingStatus(scheduleBackground, env, event.channel, threadKey, traceId);
   }
   let channelName: string | undefined;
@@ -361,7 +362,7 @@ export async function handleAppMention(
     threadTs: event.thread_ts,
     channelName,
     channelDescription,
-    files,
+    images,
     env,
     traceId,
     scheduleBackground,
@@ -386,7 +387,8 @@ export async function handleDirectMessage(
 ): Promise<void> {
   log.info("slack.dm.received", { trace_id: traceId, user: event.user, channel: event.channel });
   const messageText = stripMentions(event.text);
-  const hasContent = Boolean(messageText) || extractImageFiles(event.files).length > 0;
+  const images = toImageAttachments(event.files, traceId);
+  const hasContent = Boolean(messageText) || images.length > 0;
   const threadKey = event.thread_ts || event.ts;
   if (hasContent)
     scheduleStartingStatus(scheduleBackground, env, event.channel, threadKey, traceId);
@@ -396,7 +398,7 @@ export async function handleDirectMessage(
     channel: event.channel,
     ts: event.ts,
     threadTs: event.thread_ts,
-    files: event.files,
+    images,
     env,
     traceId,
     scheduleBackground,

--- a/packages/slack-bot/src/events/message-handler.ts
+++ b/packages/slack-bot/src/events/message-handler.ts
@@ -105,6 +105,11 @@ interface IncomingMessageParams {
   scheduleBackground: BackgroundTaskScheduler;
 }
 
+/**
+ * Route one user message: follow up on the thread's existing session when there
+ * is one, otherwise classify the target and launch a new session (or ask for
+ * clarification). Image files are forwarded as session attachments.
+ */
 async function handleIncomingMessage(params: IncomingMessageParams): Promise<void> {
   const {
     text: messageText,
@@ -290,6 +295,11 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
   }
 }
 
+/**
+ * Handle an `app_mention` event: strip the mention, recover the message's
+ * files (mention events never carry them), and hand off to the shared
+ * message flow.
+ */
 export async function handleAppMention(
   event: {
     type: string;
@@ -328,9 +338,11 @@ export async function handleAppMention(
           return [];
         }
       );
-  const channelInfoPromise = messageText
-    ? getChannelInfo(env.SLACK_BOT_TOKEN, event.channel).catch(() => undefined)
-    : Promise.resolve(undefined);
+  // Fetched unconditionally: image-only mentions rely on channel context as
+  // their main classifier signal, and filesPromise is awaited anyway.
+  const channelInfoPromise = getChannelInfo(env.SLACK_BOT_TOKEN, event.channel).catch(
+    () => undefined
+  );
   const [files, channelInfo] = await Promise.all([filesPromise, channelInfoPromise]);
   if (!messageText && extractImageFiles(files).length > 0) {
     scheduleStartingStatus(scheduleBackground, env, event.channel, threadKey, traceId);
@@ -356,6 +368,7 @@ export async function handleAppMention(
   });
 }
 
+/** Handle a direct message to the bot, including image-only file_share DMs. */
 export async function handleDirectMessage(
   event: {
     type: string;

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -205,6 +205,14 @@ function makeSessionEnv(
         );
       }
 
+      if (url.includes("/attachments")) {
+        order.push("attachment");
+        return new Response(JSON.stringify({ attachmentId: "att-1", mimeType: "image/png" }), {
+          status: 201,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
       if (url.includes("/prompt")) {
         order.push("prompt");
         const promptResponse = Array.isArray(responses.prompt)
@@ -268,6 +276,11 @@ function mockSlackFetch(
         status: 200,
         headers: { "Content-Type": "application/json" },
       });
+    }
+
+    if (url.includes("files.slack.com")) {
+      order.push("filedownload");
+      return new Response(new Uint8Array(16).fill(1), { status: 200 });
     }
 
     if (url.includes("chat.postMessage")) {
@@ -972,6 +985,139 @@ describe("POST /events", () => {
     await expect(kv.get("thread:C123:111.222", "json")).resolves.toEqual(
       expect.objectContaining({ sessionId: "session-1", lastPromptTs: "333.444" })
     );
+
+    slackFetch.mockRestore();
+  });
+
+  it("uploads event-carried images on follow-ups and references them in the prompt", async () => {
+    const order: string[] = [];
+    const slackFetch = mockSlackFetch(order);
+    const env = makeSessionEnv(order);
+    await (env.SLACK_KV as unknown as { put: (k: string, v: string) => Promise<void> }).put(
+      "thread:C123:111.222",
+      JSON.stringify({
+        sessionId: "session-1",
+        repoId: "acme/app",
+        repoFullName: "acme/app",
+        model: "anthropic/claude-haiku-4-5",
+        createdAt: Date.now(),
+        lastPromptTs: "111.222",
+      })
+    );
+    const ctx = makeCtx();
+
+    const response = await app.fetch(
+      slackEventRequest({
+        type: "app_mention",
+        text: "<@B123> what is wrong in this screenshot?",
+        user: "U123",
+        channel: "C123",
+        ts: "333.444",
+        thread_ts: "111.222",
+        files: [
+          {
+            id: "F1",
+            name: "screenshot.png",
+            mimetype: "image/png",
+            url_private: "https://files.slack.com/files-pri/T1-F1/screenshot.png",
+            size: 16,
+          },
+        ],
+      }),
+      env,
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    await flushWaitUntil(ctx);
+
+    // Event already carried files, so no single-message recovery lookup runs
+    // (limit=1); the interim-history fetch (limit=200) is unrelated.
+    expect(
+      slackFetch.mock.calls.some(
+        ([input]) =>
+          String(input).includes("conversations.replies") && String(input).includes("limit=1")
+      )
+    ).toBe(false);
+    expect(order).toContain("filedownload");
+    expect(order).toContain("attachment");
+    expect(order).not.toContain("session");
+    expect(order.indexOf("attachment")).toBeLessThan(order.indexOf("prompt"));
+    const promptBodies = promptFetchBodies(
+      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: readonly (readonly unknown[])[] } }
+    );
+    expect(promptBodies).toHaveLength(1);
+    expect(promptBodies[0].attachments).toEqual([
+      { attachmentId: "att-1", name: "screenshot.png" },
+    ]);
+
+    slackFetch.mockRestore();
+  });
+
+  it("recovers files for mentions whose event lacks them via conversation history", async () => {
+    const order: string[] = [];
+    const slackFetch = mockSlackFetch(order, {
+      threadMessages: [
+        {
+          type: "message",
+          text: "<@B123> look at this",
+          user: "U123",
+          ts: "333.444",
+          files: [
+            {
+              id: "F1",
+              name: "bug.png",
+              mimetype: "image/png",
+              url_private: "https://files.slack.com/files-pri/T1-F1/bug.png",
+              size: 16,
+            },
+          ],
+        },
+      ],
+    });
+    const env = makeSessionEnv(order);
+    await (env.SLACK_KV as unknown as { put: (k: string, v: string) => Promise<void> }).put(
+      "thread:C123:111.222",
+      JSON.stringify({
+        sessionId: "session-1",
+        repoId: "acme/app",
+        repoFullName: "acme/app",
+        model: "anthropic/claude-haiku-4-5",
+        createdAt: Date.now(),
+        lastPromptTs: "111.222",
+      })
+    );
+    const ctx = makeCtx();
+
+    const response = await app.fetch(
+      slackEventRequest({
+        type: "app_mention",
+        text: "<@B123> look at this",
+        user: "U123",
+        channel: "C123",
+        ts: "333.444",
+        thread_ts: "111.222",
+      }),
+      env,
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    await flushWaitUntil(ctx);
+
+    // The single-message lookup recovered the file, which was then forwarded.
+    const lookupCalls = slackFetch.mock.calls.filter(
+      ([input]) =>
+        String(input).includes("conversations.replies") && String(input).includes("limit=1")
+    );
+    expect(lookupCalls).toHaveLength(1);
+    expect(order).toContain("filedownload");
+    expect(order).toContain("attachment");
+    const promptBodies = promptFetchBodies(
+      env.CONTROL_PLANE.fetch as unknown as { mock: { calls: readonly (readonly unknown[])[] } }
+    );
+    expect(promptBodies).toHaveLength(1);
+    expect(promptBodies[0].attachments).toEqual([{ attachmentId: "att-1", name: "bug.png" }]);
 
     slackFetch.mockRestore();
   });

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -1032,11 +1032,12 @@ describe("POST /events", () => {
     await flushWaitUntil(ctx);
 
     // Event already carried files, so no single-message recovery lookup runs
-    // (limit=1); the interim-history fetch (limit=200) is unrelated.
+    // (inclusive-anchored); the interim-history fetch (limit=200) is unrelated.
     expect(
       slackFetch.mock.calls.some(
         ([input]) =>
-          String(input).includes("conversations.replies") && String(input).includes("limit=1")
+          String(input).includes("conversations.replies") &&
+          String(input).includes("inclusive=true")
       )
     ).toBe(false);
     expect(order).toContain("filedownload");
@@ -1106,9 +1107,13 @@ describe("POST /events", () => {
     await flushWaitUntil(ctx);
 
     // The single-message lookup recovered the file, which was then forwarded.
+    // The lookup anchors on oldest=<target ts> with inclusive=true (replies are
+    // oldest-first); the interim-history fetch never sets inclusive.
     const lookupCalls = slackFetch.mock.calls.filter(
       ([input]) =>
-        String(input).includes("conversations.replies") && String(input).includes("limit=1")
+        String(input).includes("conversations.replies") &&
+        String(input).includes("oldest=333.444") &&
+        String(input).includes("inclusive=true")
     );
     expect(lookupCalls).toHaveLength(1);
     expect(order).toContain("filedownload");

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -775,7 +775,10 @@ describe("POST /events", () => {
     expect(promptBodies[0].content).not.toContain("Context from the Slack thread");
     expect(promptBodies[0].content).not.toContain("The latest commit is");
     expect(
-      slackFetch.mock.calls.some(([input]) => String(input).includes("conversations.replies"))
+      slackFetch.mock.calls.some(
+        ([input]) =>
+          String(input).includes("conversations.replies") && String(input).includes("limit=200")
+      )
     ).toBe(false);
     // Legacy mappings without lastPromptTs get stamped so the next follow-up
     // can scope interim thread context.
@@ -831,7 +834,10 @@ describe("POST /events", () => {
       expect.objectContaining({ text: "Sorry, I couldn't send your follow-up. Please try again." })
     );
     expect(
-      slackFetch.mock.calls.some(([input]) => String(input).includes("conversations.replies"))
+      slackFetch.mock.calls.some(
+        ([input]) =>
+          String(input).includes("conversations.replies") && String(input).includes("limit=200")
+      )
     ).toBe(false);
 
     slackFetch.mockRestore();
@@ -875,7 +881,10 @@ describe("POST /events", () => {
     await flushWaitUntil(ctx);
 
     expect(
-      slackFetch.mock.calls.filter(([input]) => String(input).includes("conversations.replies"))
+      slackFetch.mock.calls.filter(
+        ([input]) =>
+          String(input).includes("conversations.replies") && String(input).includes("limit=200")
+      )
     ).toHaveLength(1);
     const promptBodies = promptFetchBodies(
       env.CONTROL_PLANE.fetch as unknown as { mock: { calls: readonly (readonly unknown[])[] } }
@@ -939,8 +948,9 @@ describe("POST /events", () => {
     await flushWaitUntil(ctx);
 
     expect(order).not.toContain("session");
-    const repliesCalls = slackFetch.mock.calls.filter(([input]) =>
-      String(input).includes("conversations.replies")
+    const repliesCalls = slackFetch.mock.calls.filter(
+      ([input]) =>
+        String(input).includes("conversations.replies") && String(input).includes("limit=200")
     );
     expect(repliesCalls).toHaveLength(1);
     expect(String(repliesCalls[0][0])).toContain("oldest=111.222");

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -242,6 +242,8 @@ function mockSlackFetch(
     statusResponse?: Response | Promise<Response>;
     threadMessages?: unknown[];
     threadRepliesError?: string;
+    /** HTTP status for files.slack.com downloads (default 200 with bytes). */
+    fileDownloadStatus?: number;
   } = {}
 ) {
   return vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
@@ -280,6 +282,9 @@ function mockSlackFetch(
 
     if (url.includes("files.slack.com")) {
       order.push("filedownload");
+      if (options.fileDownloadStatus && options.fileDownloadStatus !== 200) {
+        return new Response("denied", { status: options.fileDownloadStatus });
+      }
       return new Response(new Uint8Array(16).fill(1), { status: 200 });
     }
 
@@ -1123,6 +1128,53 @@ describe("POST /events", () => {
     );
     expect(promptBodies).toHaveLength(1);
     expect(promptBodies[0].attachments).toEqual([{ attachmentId: "att-1", name: "bug.png" }]);
+
+    slackFetch.mockRestore();
+  });
+
+  it("starts nothing for an image-only DM whose images all fail to download", async () => {
+    const order: string[] = [];
+    const slackFetch = mockSlackFetch(order, { fileDownloadStatus: 403 });
+    const env = makeSessionEnv(order);
+    const ctx = makeCtx();
+
+    const response = await app.fetch(
+      slackEventRequest({
+        type: "message",
+        subtype: "file_share",
+        user: "U123",
+        channel: "D123",
+        ts: "444.555",
+        channel_type: "im",
+        files: [
+          {
+            id: "F1",
+            name: "screenshot.png",
+            mimetype: "image/png",
+            url_private: "https://files.slack.com/files-pri/T1-F1/screenshot.png",
+            size: 16,
+          },
+        ],
+      }),
+      env,
+      ctx
+    );
+
+    expect(response.status).toBe(200);
+    await flushWaitUntil(ctx);
+
+    // The placeholder prompt would be meaningless with no image attached, so
+    // no session is created and the user is told nothing ran.
+    expect(order).toContain("filedownload");
+    expect(order).not.toContain("session");
+    expect(order).not.toContain("prompt");
+    expect(slackApiBodies(slackFetch, "chat.postMessage")).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          text: expect.stringContaining("didn't start on this request"),
+        }),
+      ])
+    );
 
     slackFetch.mockRestore();
   });

--- a/packages/slack-bot/src/interactions/target-selection.test.ts
+++ b/packages/slack-bot/src/interactions/target-selection.test.ts
@@ -1,14 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getMessageFiles, postMessage } from "@open-inspect/shared";
 import type { Env } from "../types";
 import { handleTargetSelection } from "./target-selection";
 import { getPendingRequest, deletePendingRequest } from "../pending-requests/pending-request-store";
 import { startSessionAndSendPrompt } from "../sessions/session-launcher";
 import { resolveTargetValue } from "../target-clarification";
 
-vi.mock("@open-inspect/shared", () => ({
+vi.mock(import("@open-inspect/shared"), async (importOriginal) => ({
+  ...(await importOriginal()),
   escapeMrkdwnText: (text: string) => text,
-  postMessage: vi.fn(async () => ({ ok: true, channel: "C123", ts: "222.333" })),
-  updateMessage: vi.fn(async () => ({ ok: true })),
+  getMessageFiles: vi.fn(),
+  postMessage: vi.fn(async () => ({ ok: true as const, channel: "C123", ts: "222.333" })),
+  updateMessage: vi.fn(async () => ({ ok: true as const })),
 }));
 
 vi.mock("../messages/blocks", () => ({
@@ -57,37 +60,49 @@ beforeEach(() => {
 });
 
 describe("handleTargetSelection", () => {
-  it("replays pending-request files into the launched session", async () => {
-    const files = [
-      {
-        id: "F1",
-        name: "screenshot.png",
-        mimetype: "image/png",
-        url_private: "https://files.slack.com/files-pri/T1-F1/screenshot.png",
-        size: 16,
-      },
-    ];
+  it("re-fetches the source message's files and forwards them into the launch", async () => {
     vi.mocked(getPendingRequest).mockResolvedValue({
       message: "What is wrong in this screenshot?",
       userId: "U123",
-      files,
+      sourceMessage: { ts: "111.222" },
+    });
+    vi.mocked(getMessageFiles).mockResolvedValue({
+      ok: true,
+      files: [
+        {
+          id: "F1",
+          name: "screenshot.png",
+          mimetype: "image/png",
+          url_private: "https://files.slack.com/files-pri/T1-F1/screenshot.png",
+          size: 16,
+        },
+      ],
     });
     const env = makeEnv();
 
     await handleTargetSelection("acme/app", "C123", "111.222", undefined, env, "trace-1", vi.fn());
 
+    expect(getMessageFiles).toHaveBeenCalledWith("xoxb-test", "C123", "111.222", undefined);
     expect(startSessionAndSendPrompt).toHaveBeenCalledWith(
       env,
       expect.objectContaining({
         messageText: "What is wrong in this screenshot?",
         userId: "U123",
-        files,
+        images: [
+          {
+            id: "F1",
+            name: "screenshot.png",
+            mimetype: "image/png",
+            size: 16,
+            downloadUrl: "https://files.slack.com/files-pri/T1-F1/screenshot.png",
+          },
+        ],
       })
     );
     expect(deletePendingRequest).toHaveBeenCalledWith(env, "C123", "111.222");
   });
 
-  it("launches without files when the pending request has none", async () => {
+  it("launches without images when the pending request has no source message", async () => {
     vi.mocked(getPendingRequest).mockResolvedValue({
       message: "Fix the deploy",
       userId: "U123",
@@ -103,9 +118,56 @@ describe("handleTargetSelection", () => {
       vi.fn()
     );
 
+    expect(getMessageFiles).not.toHaveBeenCalled();
     expect(startSessionAndSendPrompt).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ messageText: "Fix the deploy", files: undefined })
+      expect.objectContaining({ messageText: "Fix the deploy", images: [] })
+    );
+  });
+
+  it("still launches a text request when the file re-fetch fails", async () => {
+    vi.mocked(getPendingRequest).mockResolvedValue({
+      message: "Fix what's in the screenshot",
+      userId: "U123",
+      sourceMessage: { ts: "111.222", threadTs: "100.000" },
+    });
+    vi.mocked(getMessageFiles).mockResolvedValue({ ok: false, error: "ratelimited" });
+
+    await handleTargetSelection(
+      "acme/app",
+      "C123",
+      "111.222",
+      undefined,
+      makeEnv(),
+      "trace-1",
+      vi.fn()
+    );
+
+    expect(getMessageFiles).toHaveBeenCalledWith("xoxb-test", "C123", "111.222", "100.000");
+    expect(startSessionAndSendPrompt).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ messageText: "Fix what's in the screenshot", images: [] })
+    );
+  });
+
+  it("aborts an image-only request when its images cannot be recovered", async () => {
+    vi.mocked(getPendingRequest).mockResolvedValue({
+      message: "See the attached image(s).",
+      userId: "U123",
+      imageOnly: true,
+      sourceMessage: { ts: "111.222" },
+    });
+    vi.mocked(getMessageFiles).mockResolvedValue({ ok: false, error: "message_not_found" });
+    const env = makeEnv();
+
+    await handleTargetSelection("acme/app", "C123", "111.222", undefined, env, "trace-1", vi.fn());
+
+    expect(startSessionAndSendPrompt).not.toHaveBeenCalled();
+    expect(vi.mocked(postMessage)).toHaveBeenCalledWith(
+      "xoxb-test",
+      "C123",
+      expect.stringContaining("couldn't retrieve the attached image(s)"),
+      { thread_ts: "111.222" }
     );
   });
 });

--- a/packages/slack-bot/src/interactions/target-selection.test.ts
+++ b/packages/slack-bot/src/interactions/target-selection.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "../types";
+import { handleTargetSelection } from "./target-selection";
+import { getPendingRequest, deletePendingRequest } from "../pending-requests/pending-request-store";
+import { startSessionAndSendPrompt } from "../sessions/session-launcher";
+import { resolveTargetValue } from "../target-clarification";
+
+vi.mock("@open-inspect/shared", () => ({
+  escapeMrkdwnText: (text: string) => text,
+  postMessage: vi.fn(async () => ({ ok: true, channel: "C123", ts: "222.333" })),
+  updateMessage: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../messages/blocks", () => ({
+  buildWorkingMessageBlocks: vi.fn(() => []),
+  scheduleStartingStatus: vi.fn(),
+}));
+
+vi.mock("../pending-requests/pending-request-store", () => ({
+  getPendingRequest: vi.fn(),
+  deletePendingRequest: vi.fn(async () => {}),
+}));
+
+vi.mock("../sessions/session-launcher", () => ({
+  startSessionAndSendPrompt: vi.fn(async () => ({ sessionId: "session-1" })),
+}));
+
+vi.mock("../target-clarification", () => ({
+  resolveTargetValue: vi.fn(),
+}));
+
+const repositoryTarget = {
+  kind: "repository" as const,
+  repo: {
+    id: "acme/app",
+    owner: "acme",
+    name: "app",
+    fullName: "acme/app",
+    displayName: "acme/app",
+    description: "",
+    defaultBranch: "main",
+    private: true,
+  },
+};
+
+function makeEnv(): Env {
+  return {
+    SLACK_BOT_TOKEN: "xoxb-test",
+    WEB_APP_URL: "https://app.test",
+    LOG_LEVEL: "error",
+  } as Env;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(resolveTargetValue).mockResolvedValue(repositoryTarget);
+});
+
+describe("handleTargetSelection", () => {
+  it("replays pending-request files into the launched session", async () => {
+    const files = [
+      {
+        id: "F1",
+        name: "screenshot.png",
+        mimetype: "image/png",
+        url_private: "https://files.slack.com/files-pri/T1-F1/screenshot.png",
+        size: 16,
+      },
+    ];
+    vi.mocked(getPendingRequest).mockResolvedValue({
+      message: "What is wrong in this screenshot?",
+      userId: "U123",
+      files,
+    });
+    const env = makeEnv();
+
+    await handleTargetSelection("acme/app", "C123", "111.222", undefined, env, "trace-1", vi.fn());
+
+    expect(startSessionAndSendPrompt).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({
+        messageText: "What is wrong in this screenshot?",
+        userId: "U123",
+        files,
+      })
+    );
+    expect(deletePendingRequest).toHaveBeenCalledWith(env, "C123", "111.222");
+  });
+
+  it("launches without files when the pending request has none", async () => {
+    vi.mocked(getPendingRequest).mockResolvedValue({
+      message: "Fix the deploy",
+      userId: "U123",
+    });
+
+    await handleTargetSelection(
+      "acme/app",
+      "C123",
+      "111.222",
+      undefined,
+      makeEnv(),
+      "trace-1",
+      vi.fn()
+    );
+
+    expect(startSessionAndSendPrompt).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ messageText: "Fix the deploy", files: undefined })
+    );
+  });
+});

--- a/packages/slack-bot/src/interactions/target-selection.ts
+++ b/packages/slack-bot/src/interactions/target-selection.ts
@@ -31,7 +31,7 @@ export async function handleTargetSelection(
     return;
   }
 
-  const { message, userId, previousMessages, channelName, channelDescription } = pendingData;
+  const { message, userId, previousMessages, channelName, channelDescription, files } = pendingData;
   const target = await resolveTargetValue(env, selectedValue, traceId);
   if (!target) {
     await postMessage(
@@ -63,6 +63,7 @@ export async function handleTargetSelection(
     previousMessages,
     channelName,
     channelDescription,
+    files,
     traceId,
   });
   if (!sessionResult) return;

--- a/packages/slack-bot/src/interactions/target-selection.ts
+++ b/packages/slack-bot/src/interactions/target-selection.ts
@@ -1,4 +1,11 @@
-import { escapeMrkdwnText, postMessage, updateMessage } from "@open-inspect/shared";
+import {
+  escapeMrkdwnText,
+  getMessageFiles,
+  postMessage,
+  updateMessage,
+} from "@open-inspect/shared";
+import { toImageAttachments, type SlackImageAttachment } from "../attachments";
+import { createLogger } from "../logger";
 import {
   buildWorkingMessageBlocks,
   scheduleStartingStatus,
@@ -9,6 +16,8 @@ import { startSessionAndSendPrompt } from "../sessions/session-launcher";
 import { resolveTargetValue } from "../target-clarification";
 import { targetLabel } from "../targets";
 import type { Env } from "../types";
+
+const log = createLogger("target-selection");
 
 export async function handleTargetSelection(
   selectedValue: string,
@@ -31,7 +40,15 @@ export async function handleTargetSelection(
     return;
   }
 
-  const { message, userId, previousMessages, channelName, channelDescription, files } = pendingData;
+  const {
+    message,
+    userId,
+    previousMessages,
+    channelName,
+    channelDescription,
+    imageOnly,
+    sourceMessage,
+  } = pendingData;
   const target = await resolveTargetValue(env, selectedValue, traceId);
   if (!target) {
     await postMessage(
@@ -41,6 +58,38 @@ export async function handleTargetSelection(
       { thread_ts: threadKey }
     );
     return;
+  }
+
+  // Pending requests persist only the source-message locator; re-fetch the
+  // files from Slack now that the target is known.
+  let images: SlackImageAttachment[] = [];
+  if (sourceMessage) {
+    const lookup = await getMessageFiles(
+      env.SLACK_BOT_TOKEN,
+      channel,
+      sourceMessage.ts,
+      sourceMessage.threadTs
+    );
+    if (lookup.ok) {
+      images = toImageAttachments(lookup.files, traceId);
+    } else {
+      log.warn("slack.attachment.file_lookup_failed", {
+        trace_id: traceId,
+        channel,
+        message_ts: sourceMessage.ts,
+        slack_error: lookup.error,
+      });
+    }
+    if (imageOnly && images.length === 0) {
+      // The request had no text: without its images there is nothing to run.
+      await postMessage(
+        env.SLACK_BOT_TOKEN,
+        channel,
+        "Sorry, I couldn't retrieve the attached image(s) from Slack, so I didn't start on this request. Please try again.",
+        { thread_ts: threadKey }
+      );
+      return;
+    }
   }
 
   const label = escapeMrkdwnText(targetLabel(target));
@@ -63,7 +112,8 @@ export async function handleTargetSelection(
     previousMessages,
     channelName,
     channelDescription,
-    files,
+    images,
+    imageOnly,
     traceId,
   });
   if (!sessionResult) return;

--- a/packages/slack-bot/src/pending-requests/pending-request-store.ts
+++ b/packages/slack-bot/src/pending-requests/pending-request-store.ts
@@ -4,14 +4,14 @@ import type { Env } from "../types";
 
 const PENDING_REQUEST_TTL_MS = 60 * 60 * 1000;
 
-const pendingFileSchema = z.object({
-  id: z.string().optional(),
-  name: z.string().optional(),
-  title: z.string().optional(),
-  mimetype: z.string().optional(),
-  url_private: z.string().optional(),
-  url_private_download: z.string().optional(),
-  size: z.number().optional(),
+/**
+ * Locator of the Slack message whose image files are re-fetched at launch.
+ * Only the coordinates are persisted — never the file objects themselves — so
+ * no URL-bearing Slack payloads sit in KV across the clarification round-trip.
+ */
+const sourceMessageSchema = z.object({
+  ts: z.string().min(1),
+  threadTs: z.string().optional(),
 });
 
 const pendingRequestSchema = z.object({
@@ -20,8 +20,9 @@ const pendingRequestSchema = z.object({
   previousMessages: z.array(z.string()).optional(),
   channelName: z.string().optional(),
   channelDescription: z.string().optional(),
-  /** Image files from the original message, re-fetched from Slack at launch. */
-  files: z.array(pendingFileSchema).optional(),
+  /** True when the original message had no user text, only images. */
+  imageOnly: z.boolean().optional(),
+  sourceMessage: sourceMessageSchema.optional(),
 });
 
 export type PendingRequest = z.infer<typeof pendingRequestSchema>;
@@ -38,7 +39,8 @@ export async function storePendingRequest(
 ): Promise<void> {
   await createKvCacheStore(env.SLACK_KV).put(
     pendingRequestKey(channel, threadTs),
-    JSON.stringify(request),
+    // Parse before persisting so only schema-known fields reach KV.
+    JSON.stringify(pendingRequestSchema.parse(request)),
     { expirationTtl: PENDING_REQUEST_TTL_MS / 1000 }
   );
 }

--- a/packages/slack-bot/src/pending-requests/pending-request-store.ts
+++ b/packages/slack-bot/src/pending-requests/pending-request-store.ts
@@ -4,12 +4,24 @@ import type { Env } from "../types";
 
 const PENDING_REQUEST_TTL_MS = 60 * 60 * 1000;
 
+const pendingFileSchema = z.object({
+  id: z.string().optional(),
+  name: z.string().optional(),
+  title: z.string().optional(),
+  mimetype: z.string().optional(),
+  url_private: z.string().optional(),
+  url_private_download: z.string().optional(),
+  size: z.number().optional(),
+});
+
 const pendingRequestSchema = z.object({
   message: z.string().min(1),
   userId: z.string().min(1),
   previousMessages: z.array(z.string()).optional(),
   channelName: z.string().optional(),
   channelDescription: z.string().optional(),
+  /** Image files from the original message, re-fetched from Slack at launch. */
+  files: z.array(pendingFileSchema).optional(),
 });
 
 export type PendingRequest = z.infer<typeof pendingRequestSchema>;

--- a/packages/slack-bot/src/sessions/control-plane-client.test.ts
+++ b/packages/slack-bot/src/sessions/control-plane-client.test.ts
@@ -59,7 +59,11 @@ describe("control plane client timeouts", () => {
         init?.signal?.addEventListener("abort", () => reject(init.signal?.reason));
       });
     });
-    const result = sendPrompt(makeEnv(fetch), "session-1", "Fix it", "slack:U123");
+    const result = sendPrompt(makeEnv(fetch), {
+      sessionId: "session-1",
+      content: "Fix it",
+      authorId: "slack:U123",
+    });
 
     await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce());
     controller.abort(new DOMException("Timed out", "TimeoutError"));
@@ -74,10 +78,18 @@ describe("control plane client timeouts", () => {
     const serverErrorFetch = vi.fn(async () => new Response(null, { status: 503 }));
 
     await expect(
-      sendPrompt(makeEnv(notFoundFetch), "missing-session", "Fix it", "slack:U123")
+      sendPrompt(makeEnv(notFoundFetch), {
+        sessionId: "missing-session",
+        content: "Fix it",
+        authorId: "slack:U123",
+      })
     ).resolves.toEqual({ ok: false, reason: "stale" });
     await expect(
-      sendPrompt(makeEnv(serverErrorFetch), "session-1", "Fix it", "slack:U123")
+      sendPrompt(makeEnv(serverErrorFetch), {
+        sessionId: "session-1",
+        content: "Fix it",
+        authorId: "slack:U123",
+      })
     ).resolves.toEqual({ ok: false, reason: "transient" });
   });
 });

--- a/packages/slack-bot/src/sessions/control-plane-client.ts
+++ b/packages/slack-bot/src/sessions/control-plane-client.ts
@@ -3,6 +3,7 @@ import {
   sendPromptResponseSchema,
   type CreateSessionResponse,
   type SendPromptResponse,
+  type SessionAttachmentReference,
 } from "@open-inspect/shared";
 import { getAuthHeaders } from "../internal-auth";
 import { createLogger } from "../logger";
@@ -110,7 +111,8 @@ export async function sendPrompt(
   content: string,
   authorId: string,
   callbackContext?: CallbackContext,
-  traceId?: string
+  traceId?: string,
+  attachments?: SessionAttachmentReference[]
 ): Promise<SendPromptResult> {
   const startTime = Date.now();
   const base = { trace_id: traceId, session_id: sessionId, source: "slack" };
@@ -121,7 +123,13 @@ export async function sendPrompt(
       {
         method: "POST",
         headers,
-        body: JSON.stringify({ content, authorId, source: "slack", callbackContext }),
+        body: JSON.stringify({
+          content,
+          authorId,
+          source: "slack",
+          callbackContext,
+          ...(attachments?.length ? { attachments } : {}),
+        }),
         signal: AbortSignal.timeout(OUTBOUND_REQUEST_TIMEOUT_MS),
       }
     );

--- a/packages/slack-bot/src/sessions/control-plane-client.ts
+++ b/packages/slack-bot/src/sessions/control-plane-client.ts
@@ -105,15 +105,17 @@ export async function createSession(
   }
 }
 
-export async function sendPrompt(
-  env: Env,
-  sessionId: string,
-  content: string,
-  authorId: string,
-  callbackContext?: CallbackContext,
-  traceId?: string,
-  attachments?: SessionAttachmentReference[]
-): Promise<SendPromptResult> {
+export interface SendPromptOptions {
+  sessionId: string;
+  content: string;
+  authorId: string;
+  callbackContext?: CallbackContext;
+  attachments?: SessionAttachmentReference[];
+  traceId?: string;
+}
+
+export async function sendPrompt(env: Env, options: SendPromptOptions): Promise<SendPromptResult> {
+  const { sessionId, content, authorId, callbackContext, attachments, traceId } = options;
   const startTime = Date.now();
   const base = { trace_id: traceId, session_id: sessionId, source: "slack" };
   try {

--- a/packages/slack-bot/src/sessions/prompt-delivery.test.ts
+++ b/packages/slack-bot/src/sessions/prompt-delivery.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "../types";
+import { deliverPrompt } from "./prompt-delivery";
+import { sendPrompt } from "./control-plane-client";
+import {
+  notifyDroppedAttachments,
+  uploadPreparedAttachments,
+  type PreparedImageAttachments,
+} from "../attachments";
+
+vi.mock("../attachments", () => ({
+  uploadPreparedAttachments: vi.fn(),
+  notifyDroppedAttachments: vi.fn(async () => {}),
+}));
+
+vi.mock("./control-plane-client", () => ({
+  sendPrompt: vi.fn(),
+}));
+
+const env = { LOG_LEVEL: "error" } as Env;
+
+const emptyPrepared: PreparedImageAttachments = { files: [], dropped: [] };
+
+function options(overrides: Partial<Parameters<typeof deliverPrompt>[1]> = {}) {
+  return {
+    sessionId: "session-1",
+    content: "Fix it",
+    authorId: "slack:U123",
+    attachments: emptyPrepared,
+    imageOnly: false,
+    channel: "C123",
+    threadTs: "111.222",
+    traceId: "trace-1",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(uploadPreparedAttachments).mockResolvedValue({
+    references: [],
+    dropped: [],
+    sessionMissing: false,
+  });
+  vi.mocked(sendPrompt).mockResolvedValue({ ok: true, data: { messageId: "message-1" } });
+});
+
+describe("deliverPrompt", () => {
+  it("uploads attachments, sends the prompt with references, then notifies drops", async () => {
+    vi.mocked(uploadPreparedAttachments).mockResolvedValue({
+      references: [{ attachmentId: "att-1", name: "screenshot.png" }],
+      dropped: ["too_large"],
+      sessionMissing: false,
+    });
+
+    const result = await deliverPrompt(env, options());
+
+    expect(result).toEqual({ ok: true, data: { messageId: "message-1" } });
+    expect(sendPrompt).toHaveBeenCalledWith(env, {
+      sessionId: "session-1",
+      content: "Fix it",
+      authorId: "slack:U123",
+      callbackContext: undefined,
+      attachments: [{ attachmentId: "att-1", name: "screenshot.png" }],
+      traceId: "trace-1",
+    });
+    expect(notifyDroppedAttachments).toHaveBeenCalledWith(
+      env,
+      "C123",
+      "111.222",
+      expect.objectContaining({ dropped: ["too_large"] }),
+      { traceId: "trace-1" }
+    );
+    const sendOrder = vi.mocked(sendPrompt).mock.invocationCallOrder[0]!;
+    const notifyOrder = vi.mocked(notifyDroppedAttachments).mock.invocationCallOrder[0]!;
+    expect(sendOrder).toBeLessThan(notifyOrder);
+  });
+
+  it("does not notify drops when the prompt send fails", async () => {
+    vi.mocked(uploadPreparedAttachments).mockResolvedValue({
+      references: [],
+      dropped: ["download_failed"],
+      sessionMissing: false,
+    });
+    vi.mocked(sendPrompt).mockResolvedValue({ ok: false, reason: "stale" });
+
+    const result = await deliverPrompt(env, options());
+
+    expect(result).toEqual({ ok: false, reason: "stale" });
+    expect(notifyDroppedAttachments).not.toHaveBeenCalled();
+  });
+
+  it("sends no prompt for an image-only request that lost every image", async () => {
+    vi.mocked(uploadPreparedAttachments).mockResolvedValue({
+      references: [],
+      dropped: ["upload_rejected"],
+      sessionMissing: false,
+    });
+
+    const result = await deliverPrompt(env, options({ imageOnly: true }));
+
+    expect(result).toEqual({ ok: false, reason: "no_images_delivered" });
+    expect(sendPrompt).not.toHaveBeenCalled();
+    expect(notifyDroppedAttachments).toHaveBeenCalledWith(
+      env,
+      "C123",
+      "111.222",
+      expect.objectContaining({ dropped: ["upload_rejected"] }),
+      { traceId: "trace-1", nothingSent: true }
+    );
+  });
+
+  it("surfaces staleness instead of a drop notice when the session is gone", async () => {
+    vi.mocked(uploadPreparedAttachments).mockResolvedValue({
+      references: [],
+      dropped: ["upload_rejected"],
+      sessionMissing: true,
+    });
+
+    const result = await deliverPrompt(env, options({ imageOnly: true }));
+
+    expect(result).toEqual({ ok: false, reason: "stale" });
+    expect(sendPrompt).not.toHaveBeenCalled();
+    expect(notifyDroppedAttachments).not.toHaveBeenCalled();
+  });
+
+  it("still sends a text prompt when images dropped but user text exists", async () => {
+    vi.mocked(uploadPreparedAttachments).mockResolvedValue({
+      references: [],
+      dropped: ["download_failed"],
+      sessionMissing: false,
+    });
+
+    const result = await deliverPrompt(env, options({ imageOnly: false }));
+
+    expect(result.ok).toBe(true);
+    expect(sendPrompt).toHaveBeenCalled();
+  });
+});

--- a/packages/slack-bot/src/sessions/prompt-delivery.ts
+++ b/packages/slack-bot/src/sessions/prompt-delivery.ts
@@ -1,0 +1,91 @@
+/**
+ * The one place a prompt with Slack image attachments is delivered to a
+ * session: upload the prepared images, send the prompt with their references,
+ * and notify the user about dropped images only once the prompt outcome is
+ * known. Both the follow-up path and the new-session launcher go through this,
+ * so the sequencing lives in exactly one place.
+ */
+
+import type { CallbackContext, SendPromptResponse } from "@open-inspect/shared";
+import {
+  notifyDroppedAttachments,
+  uploadPreparedAttachments,
+  type PreparedImageAttachments,
+} from "../attachments";
+import type { Env } from "../types";
+import { sendPrompt } from "./control-plane-client";
+
+export interface DeliverPromptOptions {
+  sessionId: string;
+  /** Full prompt body, already including any channel/thread context. */
+  content: string;
+  authorId: string;
+  /** Downloaded images from {@link prepareImageAttachments}. */
+  attachments: PreparedImageAttachments;
+  /**
+   * True when the user's message carried no text — the prompt is a generic
+   * placeholder that is only meaningful if at least one image lands.
+   */
+  imageOnly: boolean;
+  callbackContext?: CallbackContext;
+  /** Thread where attachment-drop notices are posted. */
+  channel: string;
+  threadTs: string;
+  traceId?: string;
+}
+
+export type DeliverPromptResult =
+  | { ok: true; data: SendPromptResponse }
+  /**
+   * "stale": the session no longer exists (retry against a new session).
+   * "transient": the prompt send failed; the user should be told to retry.
+   * "no_images_delivered": an image-only request lost every image, so no
+   * prompt was sent — the user has already been notified.
+   */
+  | { ok: false; reason: "stale" | "transient" | "no_images_delivered" };
+
+/** Deliver one prompt and its image attachments to a session. */
+export async function deliverPrompt(
+  env: Env,
+  options: DeliverPromptOptions
+): Promise<DeliverPromptResult> {
+  const {
+    sessionId,
+    content,
+    authorId,
+    attachments,
+    imageOnly,
+    callbackContext,
+    channel,
+    threadTs,
+    traceId,
+  } = options;
+  const upload = await uploadPreparedAttachments(env, sessionId, attachments, traceId);
+
+  if (imageOnly && upload.references.length === 0) {
+    // The placeholder prompt would launch a meaningless run with nothing
+    // attached. When the uploads failed only because the session is gone,
+    // surface staleness instead so the caller retries on a fresh session.
+    if (upload.sessionMissing) return { ok: false, reason: "stale" };
+    await notifyDroppedAttachments(env, channel, threadTs, upload, {
+      traceId,
+      nothingSent: true,
+    });
+    return { ok: false, reason: "no_images_delivered" };
+  }
+
+  const promptResult = await sendPrompt(env, {
+    sessionId,
+    content,
+    authorId,
+    callbackContext,
+    attachments: upload.references,
+    traceId,
+  });
+  if (!promptResult.ok) return promptResult;
+  // Notify about dropped images only now that the session proved live —
+  // uploads against a stale session fail spuriously and are retried against
+  // the replacement session.
+  await notifyDroppedAttachments(env, channel, threadTs, upload, { traceId });
+  return promptResult;
+}

--- a/packages/slack-bot/src/sessions/session-launcher.test.ts
+++ b/packages/slack-bot/src/sessions/session-launcher.test.ts
@@ -16,7 +16,7 @@ vi.mock("@open-inspect/shared", () => ({
 }));
 
 vi.mock("../attachments", () => ({
-  uploadSlackImageAttachments: vi.fn(async () => ({ references: [], droppedCount: 0 })),
+  uploadSlackImageAttachments: vi.fn(async () => ({ references: [], dropped: [] })),
   notifyDroppedAttachments: vi.fn(async () => {}),
 }));
 
@@ -266,7 +266,7 @@ describe("startSessionAndSendPrompt", () => {
   it("uploads message images to the new session and passes references with the prompt", async () => {
     vi.mocked(uploadSlackImageAttachments).mockResolvedValue({
       references: [{ attachmentId: "att-1", name: "screenshot.png" }],
-      droppedCount: 1,
+      dropped: ["download_failed"],
     });
     const env = makeEnv();
     const files = [{ id: "F1", mimetype: "image/png", url_private: "https://files/x" }];
@@ -284,7 +284,16 @@ describe("startSessionAndSendPrompt", () => {
     ).resolves.toEqual({ sessionId: "session-1" });
 
     expect(uploadSlackImageAttachments).toHaveBeenCalledWith(env, "session-1", files, "trace-1");
-    expect(notifyDroppedAttachments).toHaveBeenCalledWith(env, "C123", "111.222", 1, "trace-1");
+    expect(notifyDroppedAttachments).toHaveBeenCalledWith(
+      env,
+      "C123",
+      "111.222",
+      {
+        references: [{ attachmentId: "att-1", name: "screenshot.png" }],
+        dropped: ["download_failed"],
+      },
+      "trace-1"
+    );
     expect(sendPrompt).toHaveBeenCalledWith(
       env,
       "session-1",

--- a/packages/slack-bot/src/sessions/session-launcher.test.ts
+++ b/packages/slack-bot/src/sessions/session-launcher.test.ts
@@ -5,10 +5,15 @@ import { startSessionAndSendPrompt } from "./session-launcher";
 import { getAvailableModels, getSlackDefaultModel } from "../app-home/models";
 import { getUserRepoBranchPreference } from "../branch-preferences";
 import { getResolvedUserPreferences } from "../user-preferences";
-import { createSession, sendPrompt } from "./control-plane-client";
+import { createSession } from "./control-plane-client";
+import { deliverPrompt } from "./prompt-delivery";
 import { buildThreadSession, storeThreadSession } from "./thread-session-store";
 import { getUserInfo, postMessage } from "@open-inspect/shared";
-import { notifyDroppedAttachments, uploadSlackImageAttachments } from "../attachments";
+import {
+  notifyDroppedAttachments,
+  prepareImageAttachments,
+  type SlackImageAttachment,
+} from "../attachments";
 
 vi.mock("@open-inspect/shared", () => ({
   getUserInfo: vi.fn(),
@@ -16,8 +21,12 @@ vi.mock("@open-inspect/shared", () => ({
 }));
 
 vi.mock("../attachments", () => ({
-  uploadSlackImageAttachments: vi.fn(async () => ({ references: [], dropped: [] })),
+  prepareImageAttachments: vi.fn(async () => ({ files: [], dropped: [] })),
   notifyDroppedAttachments: vi.fn(async () => {}),
+}));
+
+vi.mock("./prompt-delivery", () => ({
+  deliverPrompt: vi.fn(),
 }));
 
 vi.mock("../app-home/models", () => ({
@@ -35,7 +44,6 @@ vi.mock("../user-preferences", () => ({
 
 vi.mock("./control-plane-client", () => ({
   createSession: vi.fn(),
-  sendPrompt: vi.fn(),
 }));
 
 vi.mock("./thread-session-store", () => ({
@@ -110,7 +118,8 @@ describe("startSessionAndSendPrompt", () => {
       },
     } as Awaited<ReturnType<typeof getUserInfo>>);
     vi.mocked(createSession).mockResolvedValue({ sessionId: "session-1", status: "created" });
-    vi.mocked(sendPrompt).mockResolvedValue({ ok: true, data: { messageId: "message-1" } });
+    vi.mocked(prepareImageAttachments).mockResolvedValue({ files: [], dropped: [] });
+    vi.mocked(deliverPrompt).mockResolvedValue({ ok: true, data: { messageId: "message-1" } });
     vi.mocked(buildThreadSession).mockReturnValue({
       sessionId: "session-1",
       repoId: "acme/app",
@@ -154,14 +163,16 @@ describe("startSessionAndSendPrompt", () => {
       actorDisplayName: "Display Name",
       actorEmail: "user@example.com",
     });
-    expect(sendPrompt).toHaveBeenCalledWith(
-      env,
-      "session-1",
-      "Slack channel context:\n---\nChannel: #engineering\nDescription: Build and deploy discussion\n---\n\n" +
+    expect(deliverPrompt).toHaveBeenCalledWith(env, {
+      sessionId: "session-1",
+      content:
+        "Slack channel context:\n---\nChannel: #engineering\nDescription: Build and deploy discussion\n---\n\n" +
         "Context from the Slack thread:\n---\n[Alice]: Earlier request\n[Bot]: Earlier response\n---\n\n" +
         "Fix the failing deploy",
-      "slack:U123",
-      {
+      authorId: "slack:U123",
+      attachments: { files: [], dropped: [] },
+      imageOnly: false,
+      callbackContext: {
         source: "slack",
         channel: "C123",
         threadTs: "111.222",
@@ -169,9 +180,10 @@ describe("startSessionAndSendPrompt", () => {
         model: "openai/gpt-5.4",
         reasoningEffort: "high",
       },
-      "trace-1",
-      []
-    );
+      channel: "C123",
+      threadTs: "111.222",
+      traceId: "trace-1",
+    });
     expect(buildThreadSession).toHaveBeenCalledWith(
       "session-1",
       repositoryTarget,
@@ -205,14 +217,12 @@ describe("startSessionAndSendPrompt", () => {
       env,
       expect.objectContaining({ target: environmentTarget, branch: undefined })
     );
-    expect(sendPrompt).toHaveBeenCalledWith(
+    expect(deliverPrompt).toHaveBeenCalledWith(
       env,
-      "session-1",
-      "Inspect production",
-      "slack:U123",
-      expect.objectContaining({ repoFullName: "Production Debug" }),
-      undefined,
-      []
+      expect.objectContaining({
+        content: "Inspect production",
+        callbackContext: expect.objectContaining({ repoFullName: "Production Debug" }),
+      })
     );
   });
 
@@ -236,12 +246,12 @@ describe("startSessionAndSendPrompt", () => {
       "Sorry, I couldn't create a session. Please try again.",
       { thread_ts: "111.222" }
     );
-    expect(sendPrompt).not.toHaveBeenCalled();
+    expect(deliverPrompt).not.toHaveBeenCalled();
     expect(storeThreadSession).not.toHaveBeenCalled();
   });
 
   it("notifies Slack and avoids storing thread state when prompt delivery fails", async () => {
-    vi.mocked(sendPrompt).mockResolvedValue({ ok: false, reason: "transient" });
+    vi.mocked(deliverPrompt).mockResolvedValue({ ok: false, reason: "transient" });
     const env = makeEnv();
 
     await expect(
@@ -263,13 +273,21 @@ describe("startSessionAndSendPrompt", () => {
     expect(storeThreadSession).not.toHaveBeenCalled();
   });
 
-  it("uploads message images to the new session and passes references with the prompt", async () => {
-    vi.mocked(uploadSlackImageAttachments).mockResolvedValue({
-      references: [{ attachmentId: "att-1", name: "screenshot.png" }],
-      dropped: ["download_failed"],
-    });
+  it("downloads message images before session creation and hands them to delivery", async () => {
+    const images: SlackImageAttachment[] = [
+      {
+        id: "F1",
+        name: "screenshot.png",
+        mimetype: "image/png",
+        downloadUrl: "https://files.slack.com/x",
+      },
+    ];
+    const prepared = {
+      files: [{ attachment: images[0]!, bytes: new Uint8Array(4) }],
+      dropped: ["download_failed" as const],
+    };
+    vi.mocked(prepareImageAttachments).mockResolvedValue(prepared);
     const env = makeEnv();
-    const files = [{ id: "F1", mimetype: "image/png", url_private: "https://files/x" }];
 
     await expect(
       startSessionAndSendPrompt(env, {
@@ -278,30 +296,101 @@ describe("startSessionAndSendPrompt", () => {
         threadTs: "111.222",
         messageText: "What is wrong in this screenshot?",
         userId: "U123",
-        files,
+        images,
         traceId: "trace-1",
       })
     ).resolves.toEqual({ sessionId: "session-1" });
 
-    expect(uploadSlackImageAttachments).toHaveBeenCalledWith(env, "session-1", files, "trace-1");
+    expect(prepareImageAttachments).toHaveBeenCalledWith(env, images, "trace-1");
+    const prepareOrder = vi.mocked(prepareImageAttachments).mock.invocationCallOrder[0]!;
+    const createOrder = vi.mocked(createSession).mock.invocationCallOrder[0]!;
+    expect(prepareOrder).toBeLessThan(createOrder);
+    expect(deliverPrompt).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({
+        sessionId: "session-1",
+        content: expect.stringContaining("What is wrong in this screenshot?"),
+        attachments: prepared,
+        imageOnly: false,
+      })
+    );
+  });
+
+  it("never creates a session for an image-only request whose images were all lost", async () => {
+    vi.mocked(prepareImageAttachments).mockResolvedValue({
+      files: [],
+      dropped: ["download_failed"],
+    });
+    const env = makeEnv();
+
+    await expect(
+      startSessionAndSendPrompt(env, {
+        target: repositoryTarget,
+        channel: "C123",
+        threadTs: "111.222",
+        messageText: "See the attached image(s).",
+        userId: "U123",
+        images: [
+          {
+            id: "F1",
+            name: "screenshot.png",
+            mimetype: "image/png",
+            downloadUrl: "https://files.slack.com/x",
+          },
+        ],
+        imageOnly: true,
+      })
+    ).resolves.toBeNull();
+
+    expect(createSession).not.toHaveBeenCalled();
+    expect(deliverPrompt).not.toHaveBeenCalled();
     expect(notifyDroppedAttachments).toHaveBeenCalledWith(
       env,
       "C123",
       "111.222",
-      {
-        references: [{ attachmentId: "att-1", name: "screenshot.png" }],
-        dropped: ["download_failed"],
-      },
-      "trace-1"
+      { references: [], dropped: ["download_failed"] },
+      { traceId: undefined, nothingSent: true }
     );
-    expect(sendPrompt).toHaveBeenCalledWith(
-      env,
-      "session-1",
-      expect.stringContaining("What is wrong in this screenshot?"),
-      "slack:U123",
-      expect.anything(),
-      "trace-1",
-      [{ attachmentId: "att-1", name: "screenshot.png" }]
-    );
+  });
+
+  it("posts no extra error when delivery already notified an image-only total loss", async () => {
+    vi.mocked(deliverPrompt).mockResolvedValue({ ok: false, reason: "no_images_delivered" });
+    vi.mocked(prepareImageAttachments).mockResolvedValue({
+      files: [
+        {
+          attachment: {
+            id: "F1",
+            name: "screenshot.png",
+            mimetype: "image/png",
+            downloadUrl: "https://files.slack.com/x",
+          },
+          bytes: new Uint8Array(4),
+        },
+      ],
+      dropped: [],
+    });
+    const env = makeEnv();
+
+    await expect(
+      startSessionAndSendPrompt(env, {
+        target: repositoryTarget,
+        channel: "C123",
+        threadTs: "111.222",
+        messageText: "See the attached image(s).",
+        userId: "U123",
+        images: [
+          {
+            id: "F1",
+            name: "screenshot.png",
+            mimetype: "image/png",
+            downloadUrl: "https://files.slack.com/x",
+          },
+        ],
+        imageOnly: true,
+      })
+    ).resolves.toBeNull();
+
+    expect(postMessage).not.toHaveBeenCalled();
+    expect(storeThreadSession).not.toHaveBeenCalled();
   });
 });

--- a/packages/slack-bot/src/sessions/session-launcher.test.ts
+++ b/packages/slack-bot/src/sessions/session-launcher.test.ts
@@ -8,10 +8,16 @@ import { getResolvedUserPreferences } from "../user-preferences";
 import { createSession, sendPrompt } from "./control-plane-client";
 import { buildThreadSession, storeThreadSession } from "./thread-session-store";
 import { getUserInfo, postMessage } from "@open-inspect/shared";
+import { notifyDroppedAttachments, uploadSlackImageAttachments } from "../attachments";
 
 vi.mock("@open-inspect/shared", () => ({
   getUserInfo: vi.fn(),
   postMessage: vi.fn(),
+}));
+
+vi.mock("../attachments", () => ({
+  uploadSlackImageAttachments: vi.fn(async () => ({ references: [], droppedCount: 0 })),
+  notifyDroppedAttachments: vi.fn(async () => {}),
 }));
 
 vi.mock("../app-home/models", () => ({
@@ -163,7 +169,8 @@ describe("startSessionAndSendPrompt", () => {
         model: "openai/gpt-5.4",
         reasoningEffort: "high",
       },
-      "trace-1"
+      "trace-1",
+      []
     );
     expect(buildThreadSession).toHaveBeenCalledWith(
       "session-1",
@@ -204,7 +211,8 @@ describe("startSessionAndSendPrompt", () => {
       "Inspect production",
       "slack:U123",
       expect.objectContaining({ repoFullName: "Production Debug" }),
-      undefined
+      undefined,
+      []
     );
   });
 
@@ -253,5 +261,38 @@ describe("startSessionAndSendPrompt", () => {
       { thread_ts: "111.222" }
     );
     expect(storeThreadSession).not.toHaveBeenCalled();
+  });
+
+  it("uploads message images to the new session and passes references with the prompt", async () => {
+    vi.mocked(uploadSlackImageAttachments).mockResolvedValue({
+      references: [{ attachmentId: "att-1", name: "screenshot.png" }],
+      droppedCount: 1,
+    });
+    const env = makeEnv();
+    const files = [{ id: "F1", mimetype: "image/png", url_private: "https://files/x" }];
+
+    await expect(
+      startSessionAndSendPrompt(env, {
+        target: repositoryTarget,
+        channel: "C123",
+        threadTs: "111.222",
+        messageText: "What is wrong in this screenshot?",
+        userId: "U123",
+        files,
+        traceId: "trace-1",
+      })
+    ).resolves.toEqual({ sessionId: "session-1" });
+
+    expect(uploadSlackImageAttachments).toHaveBeenCalledWith(env, "session-1", files, "trace-1");
+    expect(notifyDroppedAttachments).toHaveBeenCalledWith(env, "C123", "111.222", 1, "trace-1");
+    expect(sendPrompt).toHaveBeenCalledWith(
+      env,
+      "session-1",
+      expect.stringContaining("What is wrong in this screenshot?"),
+      "slack:U123",
+      expect.anything(),
+      "trace-1",
+      [{ attachmentId: "att-1", name: "screenshot.png" }]
+    );
   });
 });

--- a/packages/slack-bot/src/sessions/session-launcher.ts
+++ b/packages/slack-bot/src/sessions/session-launcher.ts
@@ -1,5 +1,11 @@
-import { getUserInfo, postMessage, type CallbackContext } from "@open-inspect/shared";
+import {
+  getUserInfo,
+  postMessage,
+  type CallbackContext,
+  type SlackMessageFile,
+} from "@open-inspect/shared";
 import { getAvailableModels, getSlackDefaultModel } from "../app-home/models";
+import { notifyDroppedAttachments, uploadSlackImageAttachments } from "../attachments";
 import { getUserRepoBranchPreference } from "../branch-preferences";
 import { formatChannelContext, formatThreadContext } from "../messages/context";
 import { branchPreferenceRepo, targetLabel, type SlackSessionTarget } from "../targets";
@@ -22,6 +28,8 @@ export interface StartSessionOptions {
   previousMessages?: string[];
   channelName?: string;
   channelDescription?: string;
+  /** Files attached to the triggering Slack message; images are forwarded. */
+  files?: SlackMessageFile[];
   traceId?: string;
 }
 
@@ -39,6 +47,7 @@ export async function startSessionAndSendPrompt(
     previousMessages,
     channelName,
     channelDescription,
+    files,
     traceId,
   } = options;
   const [availableModels, slackDefaultModel] = await Promise.all([
@@ -104,13 +113,21 @@ export async function startSessionAndSendPrompt(
   };
   const channelContext = channelName ? formatChannelContext(channelName, channelDescription) : "";
   const threadContext = previousMessages ? formatThreadContext(previousMessages) : "";
+  const { references, droppedCount } = await uploadSlackImageAttachments(
+    env,
+    session.sessionId,
+    files,
+    traceId
+  );
+  await notifyDroppedAttachments(env, channel, threadTs, droppedCount, traceId);
   const promptResult = await sendPrompt(
     env,
     session.sessionId,
     channelContext + threadContext + messageText,
     `slack:${userId}`,
     callbackContext,
-    traceId
+    traceId,
+    references
   );
   if (!promptResult.ok) {
     await postMessage(

--- a/packages/slack-bot/src/sessions/session-launcher.ts
+++ b/packages/slack-bot/src/sessions/session-launcher.ts
@@ -1,17 +1,17 @@
-import {
-  getUserInfo,
-  postMessage,
-  type CallbackContext,
-  type SlackMessageFile,
-} from "@open-inspect/shared";
+import { getUserInfo, postMessage, type CallbackContext } from "@open-inspect/shared";
 import { getAvailableModels, getSlackDefaultModel } from "../app-home/models";
-import { notifyDroppedAttachments, uploadSlackImageAttachments } from "../attachments";
+import {
+  notifyDroppedAttachments,
+  prepareImageAttachments,
+  type SlackImageAttachment,
+} from "../attachments";
 import { getUserRepoBranchPreference } from "../branch-preferences";
 import { formatChannelContext, formatThreadContext } from "../messages/context";
 import { branchPreferenceRepo, targetLabel, type SlackSessionTarget } from "../targets";
 import type { Env } from "../types";
 import { getResolvedUserPreferences } from "../user-preferences";
-import { createSession, sendPrompt } from "./control-plane-client";
+import { createSession } from "./control-plane-client";
+import { deliverPrompt } from "./prompt-delivery";
 import { buildThreadSession, storeThreadSession } from "./thread-session-store";
 
 export interface StartSessionOptions {
@@ -28,8 +28,10 @@ export interface StartSessionOptions {
   previousMessages?: string[];
   channelName?: string;
   channelDescription?: string;
-  /** Files attached to the triggering Slack message; images are forwarded. */
-  files?: SlackMessageFile[];
+  /** Images attached to the triggering Slack message, normalized at ingress. */
+  images?: SlackImageAttachment[];
+  /** True when the triggering message had no user text, only images. */
+  imageOnly?: boolean;
   traceId?: string;
 }
 
@@ -47,9 +49,23 @@ export async function startSessionAndSendPrompt(
     previousMessages,
     channelName,
     channelDescription,
-    files,
+    images,
+    imageOnly,
     traceId,
   } = options;
+  // Download image bytes before creating the session: an image-only request
+  // whose images are all lost must never create a session it will not prompt.
+  const preparedImages = await prepareImageAttachments(env, images ?? [], traceId);
+  if (imageOnly && preparedImages.files.length === 0) {
+    await notifyDroppedAttachments(
+      env,
+      channel,
+      threadTs,
+      { references: [], dropped: preparedImages.dropped },
+      { traceId, nothingSent: true }
+    );
+    return null;
+  }
   const [availableModels, slackDefaultModel] = await Promise.all([
     getAvailableModels(env, traceId),
     getSlackDefaultModel(env, traceId),
@@ -113,28 +129,30 @@ export async function startSessionAndSendPrompt(
   };
   const channelContext = channelName ? formatChannelContext(channelName, channelDescription) : "";
   const threadContext = previousMessages ? formatThreadContext(previousMessages) : "";
-  const uploadResult = await uploadSlackImageAttachments(env, session.sessionId, files, traceId);
-  const promptResult = await sendPrompt(
-    env,
-    session.sessionId,
-    channelContext + threadContext + messageText,
-    `slack:${userId}`,
+  const delivery = await deliverPrompt(env, {
+    sessionId: session.sessionId,
+    content: channelContext + threadContext + messageText,
+    authorId: `slack:${userId}`,
+    attachments: preparedImages,
+    imageOnly: Boolean(imageOnly),
     callbackContext,
+    channel,
+    threadTs,
     traceId,
-    uploadResult.references
-  );
-  if (!promptResult.ok) {
-    await postMessage(
-      env.SLACK_BOT_TOKEN,
-      channel,
-      "Session created but failed to send prompt. Please try again.",
-      { thread_ts: threadTs }
-    );
+  });
+  if (!delivery.ok) {
+    // "no_images_delivered" already told the user nothing ran; the other
+    // failures deserve an explicit retry hint against the created session.
+    if (delivery.reason !== "no_images_delivered") {
+      await postMessage(
+        env.SLACK_BOT_TOKEN,
+        channel,
+        "Session created but failed to send prompt. Please try again.",
+        { thread_ts: threadTs }
+      );
+    }
     return null;
   }
-  // Only notify about dropped images once the prompt landed — a failed prompt
-  // already gets its own error message above.
-  await notifyDroppedAttachments(env, channel, threadTs, uploadResult, traceId);
   await storeThreadSession(
     env,
     channel,

--- a/packages/slack-bot/src/sessions/session-launcher.ts
+++ b/packages/slack-bot/src/sessions/session-launcher.ts
@@ -113,13 +113,7 @@ export async function startSessionAndSendPrompt(
   };
   const channelContext = channelName ? formatChannelContext(channelName, channelDescription) : "";
   const threadContext = previousMessages ? formatThreadContext(previousMessages) : "";
-  const { references, droppedCount } = await uploadSlackImageAttachments(
-    env,
-    session.sessionId,
-    files,
-    traceId
-  );
-  await notifyDroppedAttachments(env, channel, threadTs, droppedCount, traceId);
+  const uploadResult = await uploadSlackImageAttachments(env, session.sessionId, files, traceId);
   const promptResult = await sendPrompt(
     env,
     session.sessionId,
@@ -127,7 +121,7 @@ export async function startSessionAndSendPrompt(
     `slack:${userId}`,
     callbackContext,
     traceId,
-    references
+    uploadResult.references
   );
   if (!promptResult.ok) {
     await postMessage(
@@ -138,6 +132,9 @@ export async function startSessionAndSendPrompt(
     );
     return null;
   }
+  // Only notify about dropped images once the prompt landed — a failed prompt
+  // already gets its own error message above.
+  await notifyDroppedAttachments(env, channel, threadTs, uploadResult, traceId);
   await storeThreadSession(
     env,
     channel,

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -116,12 +116,12 @@ Create at [Slack API](https://api.slack.com/apps) and note:
 - Signing Secret
 
 The bot token requires `app_mentions:read`, `chat:write`, `channels:history`, `channels:read`,
-`groups:history`, `groups:read`, `im:history`, `im:read`, `files:write`, and `reactions:write`.
-Reinstall the app after changing scopes.
+`groups:history`, `groups:read`, `im:history`, `im:read`, `files:read`, `files:write`, and
+`reactions:write`. Reinstall the app after changing scopes.
 
 When upgrading an existing Slack deployment, add **Queues: Edit** to the Cloudflare API token before
-running `terraform apply`. Add `files:write`, reinstall the Slack app, and update the deployed bot
-token if Slack issued a replacement before deploying this version.
+running `terraform apply`. Add `files:write` and `files:read`, reinstall the Slack app, and update
+the deployed bot token if Slack issued a replacement before deploying this version.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

The Slack bot currently forwards only message text. This PR makes images attached to Slack messages reach the agent as prompt attachments, using the session-attachments pipeline introduced in #1019 — the bot becomes a second producer alongside the web composer. No control-plane or sandbox-runtime changes.

**Flow**: Slack file (`url_private`, bot-token download) → multipart POST to the existing `/sessions/:id/attachments` store → `{attachmentId, name}` references on the prompt.

## What's covered

- **DMs** — including image-only messages: Slack delivers file uploads as the `file_share` subtype, possibly with no text, so DM dispatchability accepts them and an image-only message gets a synthesized prompt body.
- **App mentions** — `app_mention` events don't carry the message's `files` array, so files are recovered with a single-message `conversations.history`/`replies` lookup (`latest` + `inclusive=true` + `limit=1`; setting `oldest=ts` too would create a zero-width window Slack returns empty). The lookup runs concurrently with the channel-info fetch to stay off the critical path, and lookup failures are logged rather than silently treated as "no files".
- **Thread follow-ups** — images on replies are attached to the existing session's next prompt.
- **Clarification flow** — file metadata rides the pending request, so images survive the "which repo?" round-trip.

## Security

File objects arrive on webhook payloads, so their URLs are not trusted: the bot token is only ever sent to `https://slack.com` / `https://*.slack.com`, remote files (`mode: "external"`, whose `url_private` is registrant-supplied) are skipped, and downloads use `redirect: "manual"` so the token can't follow a redirect off Slack infrastructure. Bodies are streamed with a hard byte cap rather than buffered before the size check.

## Limits and failure behavior

The existing caps are enforced bot-side before upload (`MAX_SESSION_ATTACHMENTS_PER_MESSAGE`, `SESSION_ATTACHMENT_IMAGE_MAX_BYTES` — now single-sourced in shared, png/jpeg/webp/gif). Oversized files, failed downloads, and rejected uploads never block the message — each drop is logged with a reason, and once the prompt outcome is known the bot posts a threaded note telling the user how many images were dropped, with guidance matched to the cause (the `files:read` hint only when downloads failed).

## Setup

Requires the `files:read` bot scope (added to GETTING_STARTED; app reinstall needed).

## Testing

- Unit tests for the attachments module: download/upload flow, the token-protection cases (non-Slack hosts, external mode, redirects), streaming cap, drop accounting, and notice wording per reason.
- App-level tests for the follow-up upload path and the app_mention history recovery; unit tests for `getMessageFiles` (both lookup shapes, failure arm), `file_share` DM dispatch, launcher reference passing, and the pending-request file round-trip.
- Running in production on our own single-tenant deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Forward Slack image attachments into sessions for direct messages, mentions, follow-ups, and new sessions, including image-only requests.
  * Added support for fetching attached files from Slack messages and thread replies for use in session prompts.
* **Bug Fixes**
  * Improved resilience for Slack file lookup and attachment handling failures—no longer throws on API errors and properly handles cases where sessions can’t start due to missing/undeliverable images.
* **Documentation**
  * Updated Slack setup and upgrade instructions to include the `files:read` scope (and `files:write` where applicable) for image forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->