### PR TITLE
docs: announce Slack image attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 New features, integrations, and notable improvements to Open-Inspect — newest first.
 
+## July 23, 2026
+
+**Slack image attachments.** Attach PNG, JPEG, WebP, and GIF images to Slack direct messages, app
+mentions, and thread follow-ups, and Open-Inspect forwards them to the agent with the prompt. Images
+also survive repository-selection clarification, and image-only requests are supported. Requires
+adding the Slack bot `files:read` scope and reinstalling the app.
+
 ## July 20, 2026
 
 **Delegated commit signing.** Agent commits are now SSH-signed by a single deployment-wide


### PR DESCRIPTION
## Summary

- add a July 23 changelog entry announcing Slack image attachment support
- note support across DMs, app mentions, thread follow-ups, and repository clarification
- document the required `files:read` Slack scope and app reinstall

## Testing

- `git diff --check -- CHANGELOG.md`
- Prettier via the commit hook

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/91a639455cf3187bf1743d96628b7f1f)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Slack image attachments in direct messages, app mentions, and thread follow-ups.
  * Images are forwarded to the agent, including image-only requests, and remain available during repository-selection clarification.
  * Slack bot installations must include the `files:read` permission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->