### PR TITLE
docs: expand Slack image attachment guidance

### DIFF
--- a/.claude/skills/onboarding/SKILL.md
+++ b/.claude/skills/onboarding/SKILL.md
@@ -177,12 +177,15 @@ Guide user:
 
 1. https://api.slack.com/apps → "Create New App" → "From scratch"
 2. OAuth & Permissions → Add scopes: `app_mentions:read`, `chat:write`, `channels:history`,
-   `channels:read`, `groups:history`, `groups:read`, `im:history`, `im:read`, `files:write`,
-   `reactions:write`
+   `channels:read`, `groups:history`, `groups:read`, `im:history`, `im:read`, `files:read`,
+   `files:write`, `reactions:write`
 3. Install to Workspace, note **Bot Token** (`xoxb-...`)
 4. Basic Information → note **Signing Secret**
 5. **App Home and Event Subscriptions configured AFTER deployment** (worker must be running for URL
    verification)
+
+`files:read` forwards user-attached images into sessions; `files:write` posts generated media back
+to Slack. Reinstall the app whenever either scope is added to an existing installation.
 
 ## Phase 6: Generate Security Secrets
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ New features, integrations, and notable improvements to Open-Inspect — newest 
 ## July 23, 2026
 
 **Slack image attachments.** Attach PNG, JPEG, WebP, and GIF images to Slack direct messages, app
-mentions, and thread follow-ups, and Open-Inspect forwards them to the agent with the prompt. Images
-also survive repository-selection clarification, and image-only requests are supported. Requires
-adding the Slack bot `files:read` scope and reinstalling the app.
+mentions, DM thread follow-ups, and channel follow-ups that mention the bot, and Open-Inspect
+forwards them to the agent with the prompt. Images also survive repository-selection clarification,
+and image-only requests are supported. Requires adding the Slack bot `files:read` scope and
+reinstalling the app.
 
 ## July 20, 2026
 

--- a/README.md
+++ b/README.md
@@ -204,8 +204,9 @@ Interact with agents from wherever your team already works:
 
 - **Web UI** — Full session management with real-time streaming, model/reasoning selectors, terminal
   panel, and multiplayer presence
-- **Slack Bot** — @mention or DM to start a session; replies thread back with results. Per-user
-  model and branch preferences via App Home. See [Slack integration](docs/integrations/SLACK.md)
+- **Slack Bot** — @mention or DM to start a session, with PNG, JPEG, WebP, and GIF prompt
+  attachments; replies thread back with results. Per-user model and branch preferences via App Home.
+  See [Slack integration](docs/integrations/SLACK.md)
 - **GitHub Bot** — Auto-review on PR open or respond to @mentions in PR comments. Configurable
   per-repo. See [GitHub integration](docs/integrations/GITHUB.md)
 - **Linear Bot** — Mention or assign the agent on an issue to start a coding session, post progress

--- a/docs/AUTOMATIONS.md
+++ b/docs/AUTOMATIONS.md
@@ -231,6 +231,10 @@ ingested once the flag is on.
 A Slack automation must define at least a **Slack Channel** condition; the rest are optional
 filters.
 
+Slack Message automations ingest text only. Slack file uploads have a `file_share` subtype and are
+ignored, so image-only messages do not trigger a run and attachments are not added to prompts. Use
+an interactive bot DM or `@mention` for image input.
+
 - **Slack Channel** (required) — the channels to watch. Pick channels by name in the web form;
   channel IDs (for example `C0123ABCD`) also work as a fallback when channel listing is unavailable.
   Only messages in these channels are considered, and the bot must be a member of each.
@@ -262,6 +266,9 @@ to match the trigger condition — conditions gate new runs, not replies that co
 thread. If a reply races the very first trigger before its session exists, it falls back to an
 ephemeral "a run is already active" notice (reason `concurrent_run_active`); a reply more than 7
 days after the first trigger starts a fresh run.
+
+These automation follow-ups also forward text only. Attachments on a thread reply are not delivered
+to the session.
 
 ---
 

--- a/docs/DEBUGGING_PLAYBOOK.md
+++ b/docs/DEBUGGING_PLAYBOOK.md
@@ -251,6 +251,19 @@ Dashboards and alerts must migrate `image_build.start`, `image_build.success`, a
 | `slack.app_home`                  | error       | `user_id`, `outcome`, `slack_error`                                                           | App Home publish failed          |
 | `kv.get` / `kv.put` / `kv.delete` | error, warn | `key_prefix`, contextual IDs                                                                  | KV storage operation failed      |
 
+#### Attachments (`component: "attachments"`)
+
+| Event                              | Level | Key Fields                                                    | Description                              |
+| ---------------------------------- | ----- | ------------------------------------------------------------- | ---------------------------------------- |
+| `slack.attachment.untrusted_url`   | warn  | `trace_id`, `file_id`, `file_mode`                            | Non-Slack or remote file rejected        |
+| `slack.attachment.download_failed` | warn  | `trace_id`, `file_id`, `http_status`                          | Slack file download returned an error    |
+| `slack.attachment.download_error`  | warn  | `trace_id`, `file_id`, `error`                                | Slack file download threw or timed out   |
+| `slack.attachment.size_rejected`   | warn  | `trace_id`, `file_id`, `size_bytes`                           | Download response failed the byte cap    |
+| `slack.attachment.too_large`       | warn  | `trace_id`, `file_id`, `size_bytes`                           | Slack metadata exceeded the byte cap     |
+| `slack.attachment.upload_failed`   | warn  | `trace_id`, `session_id`, `file_id`, `http_status` or `error` | Session attachment upload was rejected   |
+| `slack.attachment.upload_error`    | warn  | `trace_id`, `session_id`, `file_id`, `error`                  | Session attachment upload threw          |
+| `slack.attachment.notify_failed`   | warn  | `trace_id`, `channel`, `slack_error`                          | Could not post the dropped-image warning |
+
 #### Callback (`component: "callback"`)
 
 | Event                          | Level       | Key Fields                                                                                                                                     | Description                            |
@@ -292,6 +305,30 @@ Dashboards and alerts must migrate `image_build.start`, `image_build.success`, a
 ---
 
 ## Debugging Scenarios
+
+### "Why did an attached Slack image not reach the agent?"
+
+Follow the request by `trace_id` through file discovery, download, session upload, and prompt
+submission.
+
+```
+# 1. Could the bot recover and trust the Slack file metadata?
+service="slack-bot" trace_id="<TRACE_ID>" msg="slack.attachment.file_lookup_failed"
+service="slack-bot" trace_id="<TRACE_ID>" msg="slack.attachment.untrusted_url"
+
+# 2. Did the Slack-hosted download fail or exceed 10 MiB?
+service="slack-bot" component="attachments" trace_id="<TRACE_ID>" msg="slack.attachment.*"
+
+# 3. Did the control plane accept the session attachment before the prompt?
+service="slack-bot" component="attachments" trace_id="<TRACE_ID>" msg="slack.attachment.upload*"
+service="slack-bot" component="handler" trace_id="<TRACE_ID>" msg="control_plane.send_prompt"
+```
+
+`slack.attachment.file_lookup_failed` is emitted by `handler` or `target-selection`, depending on
+whether lookup failed during initial handling or after repository clarification. An HTTP failure
+while downloading often means the bot lacks `files:read` or was not reinstalled after the scope was
+added. Size events enforce 10 MiB per image; the bot forwards at most six images per message. If a
+text-plus-image request loses images, the text still runs and the bot attempts an in-thread warning.
 
 ### "What happened to message X?"
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -379,9 +379,9 @@ Queued delivery applies to every Slack completion, including text-only replies. 
 2. Add the Slack bot scopes `files:write` and `files:read` (needed to forward images attached to
    Slack messages into sessions), reinstall the app once for the workspace, and update
    `slack_bot_token` if Slack issued a replacement.
-3. Run `terraform apply`, then verify a text completion and a generated-media attachment. If the
-   token lacks Queue access, the apply fails while provisioning the new resources; grant the
-   permission and rerun the apply.
+3. Run `terraform apply`, then verify a text completion, an inbound image attached to a prompt, and
+   a generated-media attachment. If the token lacks Queue access, the apply fails while provisioning
+   the new resources; grant the permission and rerun the apply.
 
 No individual Slack user needs to reauthorize the app. Teams with `enable_slack_bot = false` do not
 create the Queue resources.
@@ -1109,6 +1109,20 @@ If the bot doesn't see the original message when tagged in a thread reply:
    check these scopes and that the bot is invited to the target channel.
 3. If you added missing scopes, **reinstall the app** to your workspace for the new permissions to
    take effect.
+
+### Slack image attachment does not reach the agent
+
+1. Verify the bot has the `files:read` scope and reinstall the app after adding it. The
+   `files:write` scope is for generated media posted back to Slack, not images sent to the agent.
+2. Use PNG, JPEG, WebP, or GIF images no larger than 10 MiB. Open-Inspect forwards at most six
+   images per message.
+3. In a channel, `@mention` the bot with the image. DMs do not require a mention. Watched-channel
+   automations do not forward file attachments.
+4. For channel mentions and replies, verify `channels:history` for public channels or
+   `groups:history` for private channels. Slack may omit files from the mention event, so the bot
+   uses conversation history to retrieve them.
+5. Check the Slack thread for a warning about images that were too large or could not be downloaded
+   or uploaded. Other images and any text are still sent when possible.
 
 ### Slack completion does not attach generated media
 

--- a/docs/HOW_IT_WORKS.md
+++ b/docs/HOW_IT_WORKS.md
@@ -87,13 +87,14 @@ if needed.
 
 ### What's Stored in a Session
 
-| Data          | Description                                       |
-| ------------- | ------------------------------------------------- |
-| Messages      | Prompts you've sent and their metadata            |
-| Events        | Tool calls, token streams, status updates         |
-| Artifacts     | PRs created, screenshots captured                 |
-| Participants  | Users who have joined the session                 |
-| Sandbox state | Reference to the current sandbox and its snapshot |
+| Data               | Description                                       |
+| ------------------ | ------------------------------------------------- |
+| Messages           | Prompts you've sent and their metadata            |
+| Prompt attachments | Images uploaded with web or Slack prompts         |
+| Events             | Tool calls, token streams, status updates         |
+| Artifacts          | PRs created, screenshots captured                 |
+| Participants       | Users who have joined the session                 |
+| Sandbox state      | Reference to the current sandbox and its snapshot |
 
 Each session gets its own SQLite database in a Cloudflare Durable Object, ensuring isolation and
 high performance even with hundreds of concurrent sessions.
@@ -221,7 +222,8 @@ can make HTTP requests and maintain WebSocket connections can participate.
 **Current clients:**
 
 - **Web**: Next.js app with real-time streaming, session management, and settings
-- **Slack**: Bot that responds to @mentions and direct messages, classifies repos, and posts results
+- **Slack**: Bot that responds to @mentions and direct messages, forwards supported image
+  attachments, classifies repos, and posts results
 - **GitHub**: Bot that reviews PRs and responds to PR `@mentions`
 - **Linear**: Agent workflow that starts sessions from Linear issue activity
 

--- a/docs/integrations/SLACK.md
+++ b/docs/integrations/SLACK.md
@@ -33,6 +33,7 @@ notification controls and safety notes are covered near the end.
 | Start from a channel        | Invite the bot, then `@mention` it with a request                          |
 | Start from a DM             | Send the bot a direct message                                              |
 | Continue a session          | Reply in the same Slack thread                                             |
+| Send images to the agent    | Attach PNG, JPEG, WebP, or GIF images to an interactive request            |
 | Pick the repository         | Let Open-Inspect infer it, or choose from a dropdown when it is unsure     |
 | Set personal defaults       | Use the Slack app's **Home** tab for model, reasoning effort, and branch   |
 | Follow the result           | Read the completion reply or open the full session with **View Session**   |
@@ -53,6 +54,10 @@ media remains available through **View Session**. Files merely written into the 
 uploaded automatically. Queue delivery requires the Terraform operator's Cloudflare token to have
 **Queues: Edit**. Media delivery requires the Slack app's `files:write` bot scope and a one-time app
 reinstall for each workspace.
+
+Inbound images use a separate path and permission: images that you attach to a prompt require
+`files:read`, while generated media that Open-Inspect posts back requires `files:write`. Adding
+either scope to an existing Slack app requires reinstalling the app for the workspace.
 
 ---
 
@@ -88,6 +93,22 @@ request to the agent.
 
 To continue a session that started from a DM, reply in the Slack thread created for that DM request.
 Sending a new top-level DM is treated as a new request and may start repository selection again.
+
+### With image attachments
+
+Attach PNG, JPEG, WebP, or GIF images to a DM, a channel request that `@mentions` the bot, or an
+interactive thread follow-up. You can include instructions with the images or send images alone; for
+example, attach a screenshot and ask Open-Inspect to fix the visible error. Open-Inspect forwards at
+most six images per message, and each image must be no larger than 10 MiB.
+
+If Open-Inspect asks you to choose a repository or environment, make the selection normally. The bot
+retrieves the original message's images after you choose and forwards them with the saved request.
+If only some images can be read, the remaining images and any message text still reach the agent,
+and the bot posts a warning in the thread. If an image-only request loses every image, no empty
+session or follow-up is sent.
+
+This feature requires the Slack app's `files:read` bot scope and a reinstall after adding the scope.
+Remote files hosted outside Slack and non-image attachments are not forwarded.
 
 ### Repository dropdowns
 
@@ -132,6 +153,10 @@ conversation to a different repository.
 A top-level Slack request starts a new Slack thread. Reply in that thread to send follow-up prompts
 to the same Open-Inspect session. This applies in both channels and DMs: in a direct message, the
 follow-up still needs to be a thread reply, not a fresh top-level DM.
+
+Image attachments on interactive channel follow-ups must accompany an `@mention` of the bot. In a DM
+thread, no mention is needed. Watched-channel automation threads are text-only, as described in
+[Channel Message Triggers](#channel-message-triggers).
 
 Open-Inspect keeps the Slack thread connected to the session for about 7 days. If you reply after
 that mapping expires, or if you reply outside the thread, the bot may start repository selection
@@ -244,6 +269,10 @@ The feature is **disabled by default** and gated by the `SLACK_TRIGGERS_ENABLED`
 When the flag is off, the bot ignores channel messages and forwards nothing; authoring a Slack
 automation in the web app is still allowed, but it will not run until the flag is enabled.
 
+Slack Message automations currently ingest text only. File uploads, including image-only
+`file_share` messages, do not start these automations, and attachments on automation thread replies
+are not forwarded to the session. Use an interactive DM or `@mention` when the agent needs an image.
+
 ### Slack app setup
 
 In addition to the standard event subscription the bot already uses, enable the bot to receive
@@ -337,6 +366,18 @@ dropdown expires after one hour.
 
 Reply inside the same Slack thread as the original request. Thread-to-session mappings last about 7
 days, so older threads may need a fresh request.
+
+### An attached image did not reach the agent
+
+Confirm the Slack app has the `files:read` bot scope and was reinstalled after that scope was added.
+Use PNG, JPEG, WebP, or GIF images no larger than 10 MiB, with at most six images in one message.
+For a channel request or interactive channel follow-up, `@mention` the bot; DMs do not need a
+mention.
+
+The bot may also need `channels:history` for public-channel messages or `groups:history` for
+private-channel messages so it can recover file details that Slack omits from `app_mention` events.
+If some images fail, check the warning posted in the thread. `files:write` does not grant inbound
+image access; it is used only when Open-Inspect posts generated media back to Slack.
 
 ### The wrong model or branch was used
 


### PR DESCRIPTION
## Summary

- document inbound Slack image formats, limits, image-only prompts, clarification recovery, and partial-failure behavior
- distinguish the `files:read` inbound permission from `files:write` generated-media delivery in setup and onboarding guidance
- clarify that watched-channel automations and their follow-ups remain text-only
- add Slack attachment troubleshooting, logging references, architecture notes, and feature summaries
- narrow the changelog wording to the supported DM and mentioned-channel follow-up paths

## Verification

- `git diff --check origin/main...HEAD`
- Prettier via the repository's staged-file commit hook
- `npx prettier --check README.md CHANGELOG.md docs/integrations/SLACK.md docs/GETTING_STARTED.md docs/AUTOMATIONS.md docs/DEBUGGING_PLAYBOOK.md docs/HOW_IT_WORKS.md .claude/skills/onboarding/SKILL.md`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/5d0d7469f44240d726d0cfdc3608f44f)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Slack image support, including supported formats, size limits, mentions, threads, and direct messages.
  * Documented required permissions for receiving images and posting generated media, including app reinstallation after scope changes.
  * Clarified that automated Slack message triggers and follow-ups process text only; attachments do not start runs or reach sessions.
  * Added setup verification, troubleshooting guidance, and debugging steps for missing Slack attachments.
  * Expanded Slack integration details and changelog notes for image forwarding and generated-media replies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->