### PR TITLE
fix: authenticate gh in E2B sandboxes

### DIFF
--- a/packages/e2b-infra/build-template.py
+++ b/packages/e2b-infra/build-template.py
@@ -85,6 +85,8 @@ template = (
     Template().from_dockerfile(dockerfile)
     # Staged into this dir above; imported via PYTHONPATH=/app as `sandbox_runtime`.
     .copy("sandbox_runtime", "/app/sandbox_runtime")
+    # E2B's non-root runtime cannot install this into /usr/local/bin itself.
+    .copy("sandbox_runtime/gh-wrapper.sh", "/usr/local/bin/gh", mode=0o755)
     # The launcher = the template start command (see oi-launch.py).
     .copy("oi-launch.py", "/usr/local/bin/oi-launch", mode=0o755)
     .set_workdir("/workspace")

--- a/packages/e2b-infra/build-template.py
+++ b/packages/e2b-infra/build-template.py
@@ -44,6 +44,7 @@ START_CMD = "python /usr/local/bin/oi-launch"
 READY_CMD = (
     "command -v python && command -v node && command -v opencode "
     "&& command -v code-server "
+    '&& test "$(command -v gh)" = /usr/local/bin/gh && test -x /usr/bin/gh '
     "&& PYTHONPATH=/app python -c 'import sandbox_runtime'"
 )
 

--- a/packages/e2b-infra/e2b.Dockerfile
+++ b/packages/e2b-infra/e2b.Dockerfile
@@ -73,15 +73,6 @@ RUN printf '%s\n' '#!/bin/sh' 'exec python3 -m sandbox_runtime.credentials.git_c
   && git config --system credential.helper /usr/local/bin/oi-git-credentials \
   && git config --system credential.useHttpPath true
 
-# Bake the gh auth wrapper for the same reason as the credential helper above:
-# the non-root runtime cannot create it under /usr/local/bin. Keep this body
-# byte-identical to GH_WRAPPER_BODY in sandbox_runtime/entrypoint.py.
-RUN printf '%s\n' '#!/bin/sh' 'REAL_GH="/usr/bin/gh"' \
-     'token=$(python3 -m sandbox_runtime.credentials.git_credential_helper gh-token || true)' \
-     'if [ -n "$token" ]; then' '  export GH_TOKEN="$token"' 'fi' \
-     'exec "$REAL_GH" "$@"' > /usr/local/bin/gh \
-  && chmod 0755 /usr/local/bin/gh
-
 # Build-time env only. E2B does NOT propagate Docker ENV to the runtime process,
 # so the start command (build-template.py) re-exports PYTHONPATH / NODE_PATH;
 # control-plane-injected vars (CONTROL_PLANE_URL, etc.) arrive via E2B envVars.

--- a/packages/e2b-infra/e2b.Dockerfile
+++ b/packages/e2b-infra/e2b.Dockerfile
@@ -73,6 +73,15 @@ RUN printf '%s\n' '#!/bin/sh' 'exec python3 -m sandbox_runtime.credentials.git_c
   && git config --system credential.helper /usr/local/bin/oi-git-credentials \
   && git config --system credential.useHttpPath true
 
+# Bake the gh auth wrapper for the same reason as the credential helper above:
+# the non-root runtime cannot create it under /usr/local/bin. Keep this body
+# byte-identical to GH_WRAPPER_BODY in sandbox_runtime/entrypoint.py.
+RUN printf '%s\n' '#!/bin/sh' 'REAL_GH="/usr/bin/gh"' \
+     'token=$(python3 -m sandbox_runtime.credentials.git_credential_helper gh-token || true)' \
+     'if [ -n "$token" ]; then' '  export GH_TOKEN="$token"' 'fi' \
+     'exec "$REAL_GH" "$@"' > /usr/local/bin/gh \
+  && chmod 0755 /usr/local/bin/gh
+
 # Build-time env only. E2B does NOT propagate Docker ENV to the runtime process,
 # so the start command (build-template.py) re-exports PYTHONPATH / NODE_PATH;
 # control-plane-injected vars (CONTROL_PLANE_URL, etc.) arrive via E2B envVars.

--- a/packages/opencomputer-infra/src/build-template.ts
+++ b/packages/opencomputer-infra/src/build-template.ts
@@ -201,22 +201,14 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
       "sudo chmod 0755 /usr/local/bin/oi-git-credentials",
       "sudo git config --system credential.helper /usr/local/bin/oi-git-credentials",
       "sudo git config --system credential.useHttpPath true",
-      // gh CLI auth wrapper — baked here as root, at build time, rather than
-      // left to the runtime's _install_gh_wrapper(). That runtime install
-      // writes /usr/local/bin/gh as the non-root `sandbox` user, but the dir is
-      // root-owned, so the write fails with a swallowed PermissionError and gh
-      // is left unauthenticated — agents then can't post PR comments. (It works
-      // on Modal only because that runtime is root and can self-install.) Keep
-      // this body byte-identical to GH_WRAPPER_BODY in
-      // sandbox-runtime/src/sandbox_runtime/entrypoint.py so the runtime install
-      // sees a matching file and no-ops instead of failing to overwrite it.
-      "printf '%s\\n' '#!/bin/sh' 'REAL_GH=\"/usr/bin/gh\"' 'token=$(python3 -m sandbox_runtime.credentials.git_credential_helper gh-token || true)' 'if [ -n \"$token\" ]; then' '  export GH_TOKEN=\"$token\"' 'fi' 'exec \"$REAL_GH\" \"$@\"' | sudo tee /usr/local/bin/gh >/dev/null",
-      "sudo chmod 0755 /usr/local/bin/gh",
       `[ -f ${OPENSANDBOX_PROXY_CA} ] && sudo update-ca-certificates || true`,
       `[ -f ${OPENSANDBOX_PROXY_CA} ] && sudo git config --system http.sslCAInfo ${OPENSANDBOX_PROXY_CA} || true`
     );
 
   image = addRuntimeDir(image, runtimeDir);
+  image = image
+    .addLocalFile(join(runtimeDir, "gh-wrapper.sh"), "/usr/local/bin/gh")
+    .runCommands("sudo chmod 0755 /usr/local/bin/gh");
 
   // The npm/bun/agent-browser installs above run as root (sudo) and write under the sandbox
   // user's HOME, and addRuntimeDir copies the runtime in as root too. Re-own HOME last so the

--- a/packages/opencomputer-infra/src/build-template.ts
+++ b/packages/opencomputer-infra/src/build-template.ts
@@ -164,16 +164,15 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
       `${NPM_PREFIX}/bin/opencode --version`
     )
     .runCommands(
-      // GitHub CLI — installed to /usr/bin/gh (the path the runtime's gh wrapper expects).
-      // Best-effort end-to-end (keyring + apt source + install) so a cli.github.com hiccup
-      // can't fail the build, matching how vercel/bootstrap.ts best-efforts its whole gh block.
-      "if ! command -v gh >/dev/null 2>&1; then " +
+      // GitHub CLI must exist at the path used by the authentication wrapper.
+      "if [ ! -x /usr/bin/gh ]; then " +
         "sudo mkdir -p -m 755 /etc/apt/keyrings && " +
         "curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null && " +
         "sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg && " +
         'echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list >/dev/null && ' +
         "sudo apt-get update && sudo apt-get install -y gh; " +
-        "fi || true",
+        "fi",
+      "test -x /usr/bin/gh",
       // ttyd (terminal) — pinned binary, checksum-verified (matches the Vercel base image).
       `curl -fsSL -o /tmp/ttyd https://github.com/tsl0922/ttyd/releases/download/${TTYD_VERSION}/ttyd.x86_64`,
       `echo "${TTYD_SHA256}  /tmp/ttyd" | sha256sum -c -`,
@@ -208,7 +207,10 @@ function buildImage(options: Pick<BuildOptions, "repoRoot" | "builderMemoryMb">)
   image = addRuntimeDir(image, runtimeDir);
   image = image
     .addLocalFile(join(runtimeDir, "gh-wrapper.sh"), "/usr/local/bin/gh")
-    .runCommands("sudo chmod 0755 /usr/local/bin/gh");
+    .runCommands(
+      "sudo chmod 0755 /usr/local/bin/gh",
+      "PYTHONPATH=/app /usr/local/bin/gh --version"
+    );
 
   // The npm/bun/agent-browser installs above run as root (sudo) and write under the sandbox
   // user's HOME, and addRuntimeDir copies the runtime in as root too. Re-own HOME last so the

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -83,6 +83,7 @@ AGENT_TOOLS_REQUIRING_REPOSITORY: set[str] = set()
 # fresh token is needed (the precedence logic lives there, in Python). If it
 # prints one we export it as GH_TOKEN; otherwise gh runs with its own env.
 GH_WRAPPER_REAL_PATH = "/usr/bin/gh"
+GH_WRAPPER_INSTALL_PATH = Path("/usr/local/bin/gh")
 GH_WRAPPER_BODY = Path(__file__).with_name("gh-wrapper.sh").read_text()
 
 
@@ -326,19 +327,26 @@ class SandboxSupervisor:
         """Install the gh CLI wrapper at /usr/local/bin/gh.
 
         The canonical wrapper artifact is also baked into non-root provider
-        images. Installing it at boot patches older snapshots and repo images.
+        images. Writable legacy images are patched at boot; a non-writable
+        legacy image fails clearly rather than running gh unauthenticated.
         """
-        wrapper_path = Path("/usr/local/bin/gh")
+        real_path = Path(GH_WRAPPER_REAL_PATH)
+        if not os.access(real_path, os.X_OK):
+            return
+
         try:
-            # Only install if the real gh exists and we're not about to shadow
-            # ourselves (defensive against a previous wrapper at /usr/bin/gh).
-            if Path(GH_WRAPPER_REAL_PATH).exists() and (
-                not wrapper_path.exists() or wrapper_path.read_text() != GH_WRAPPER_BODY
+            if (
+                GH_WRAPPER_INSTALL_PATH.exists()
+                and GH_WRAPPER_INSTALL_PATH.read_text() == GH_WRAPPER_BODY
+                and os.access(GH_WRAPPER_INSTALL_PATH, os.X_OK)
             ):
-                wrapper_path.write_text(GH_WRAPPER_BODY)
-                wrapper_path.chmod(0o755)
+                return
+            GH_WRAPPER_INSTALL_PATH.write_text(GH_WRAPPER_BODY)
+            GH_WRAPPER_INSTALL_PATH.chmod(0o755)
         except OSError as e:
-            self.log.debug("gh_wrapper.install_failed", error=str(e))
+            raise RuntimeError(
+                f"Cannot install authenticated gh wrapper at {GH_WRAPPER_INSTALL_PATH}: {e}"
+            ) from e
 
     async def _ensure_plain_origin(self, repo: RepoEntry) -> bool:
         """Rewrite the `origin` remote to a credential-free HTTPS URL.

--- a/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/entrypoint.py
@@ -83,18 +83,7 @@ AGENT_TOOLS_REQUIRING_REPOSITORY: set[str] = set()
 # fresh token is needed (the precedence logic lives there, in Python). If it
 # prints one we export it as GH_TOKEN; otherwise gh runs with its own env.
 GH_WRAPPER_REAL_PATH = "/usr/bin/gh"
-GH_WRAPPER_BODY = (
-    "#!/bin/sh\n"
-    f'REAL_GH="{GH_WRAPPER_REAL_PATH}"\n'
-    # stderr is left attached so the helper's diagnostic surfaces when a
-    # refresh fails — otherwise the user just sees an opaque gh 401.
-    "token=$(python3 -m sandbox_runtime.credentials.git_credential_helper gh-token || true)\n"
-    'if [ -n "$token" ]; then\n'
-    # export (not `env GH_TOKEN=… exec`) so the token never lands in argv.
-    '  export GH_TOKEN="$token"\n'
-    "fi\n"
-    'exec "$REAL_GH" "$@"\n'
-)
+GH_WRAPPER_BODY = Path(__file__).with_name("gh-wrapper.sh").read_text()
 
 
 class SandboxSupervisor:
@@ -336,9 +325,8 @@ class SandboxSupervisor:
     def _install_gh_wrapper(self) -> None:
         """Install the gh CLI wrapper at /usr/local/bin/gh.
 
-        See ``GH_WRAPPER_BODY`` for the wrapper's behaviour. Installed at boot
-        (rather than baked into the image) so it also patches snapshots and
-        repo images built before this migration.
+        The canonical wrapper artifact is also baked into non-root provider
+        images. Installing it at boot patches older snapshots and repo images.
         """
         wrapper_path = Path("/usr/local/bin/gh")
         try:

--- a/packages/sandbox-runtime/src/sandbox_runtime/gh-wrapper.sh
+++ b/packages/sandbox-runtime/src/sandbox_runtime/gh-wrapper.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+REAL_GH="/usr/bin/gh"
+token=$(python3 -m sandbox_runtime.credentials.git_credential_helper gh-token || true)
+if [ -n "$token" ]; then
+  export GH_TOKEN="$token"
+fi
+exec "$REAL_GH" "$@"

--- a/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
+++ b/packages/sandbox-runtime/tests/test_entrypoint_build_mode.py
@@ -1070,6 +1070,7 @@ class TestEnsureCredentialHelperConfigured:
             patch("sandbox_runtime.entrypoint.Path.write_text"),
             patch("sandbox_runtime.entrypoint.Path.chmod"),
             patch("sandbox_runtime.entrypoint.Path.exists", return_value=False),
+            patch.object(supervisor, "_install_gh_wrapper"),
         ):
             await supervisor._ensure_credential_helper_configured()
 
@@ -1099,6 +1100,7 @@ class TestEnsureCredentialHelperConfigured:
             ),
             patch("sandbox_runtime.entrypoint.Path.write_text", side_effect=OSError("read-only")),
             patch("sandbox_runtime.entrypoint.Path.exists", return_value=False),
+            patch.object(supervisor, "_install_gh_wrapper"),
         ):
             await supervisor._ensure_credential_helper_configured()
 

--- a/packages/sandbox-runtime/tests/test_gh_wrapper.py
+++ b/packages/sandbox-runtime/tests/test_gh_wrapper.py
@@ -18,7 +18,10 @@ import os
 import subprocess
 from typing import TYPE_CHECKING
 
-from sandbox_runtime.entrypoint import GH_WRAPPER_BODY
+import pytest
+
+from sandbox_runtime import entrypoint
+from sandbox_runtime.entrypoint import GH_WRAPPER_BODY, SandboxSupervisor
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -104,3 +107,35 @@ def test_falls_through_when_helper_fails(tmp_path: Path) -> None:
     out = _run(wrapper, {"VCS_HOST": "github.com", "GITHUB_TOKEN": "stale_token"})
     assert "GH_TOKEN=\n" in out
     assert "GITHUB_TOKEN=stale_token" in out
+
+
+def test_runtime_installs_canonical_wrapper(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real_gh = tmp_path / "real-gh"
+    real_gh.touch()
+    real_gh.chmod(0o755)
+    wrapper = tmp_path / "gh"
+    monkeypatch.setattr(entrypoint, "GH_WRAPPER_REAL_PATH", str(real_gh))
+    monkeypatch.setattr(entrypoint, "GH_WRAPPER_INSTALL_PATH", wrapper)
+
+    supervisor = object.__new__(SandboxSupervisor)
+    supervisor._install_gh_wrapper()
+
+    assert wrapper.read_text() == GH_WRAPPER_BODY
+    assert os.access(wrapper, os.X_OK)
+
+
+def test_runtime_fails_when_wrapper_cannot_be_installed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    real_gh = tmp_path / "real-gh"
+    real_gh.touch()
+    real_gh.chmod(0o755)
+    wrapper = tmp_path / "missing" / "gh"
+    monkeypatch.setattr(entrypoint, "GH_WRAPPER_REAL_PATH", str(real_gh))
+    monkeypatch.setattr(entrypoint, "GH_WRAPPER_INSTALL_PATH", wrapper)
+
+    with pytest.raises(RuntimeError, match="Cannot install authenticated gh wrapper"):
+        supervisor = object.__new__(SandboxSupervisor)
+        supervisor._install_gh_wrapper()


### PR DESCRIPTION
## Summary

- bake the existing brokered-auth `gh` wrapper into the E2B template image
- verify E2B template readiness resolves `gh` to `/usr/local/bin/gh`
- retain `/usr/bin/gh` as the real CLI invoked by the wrapper

E2B sandboxes run as a non-root user, so the runtime fallback cannot write the wrapper into `/usr/local/bin`. Without a build-time wrapper, `gh` receives none of the short-lived credentials supplied by the Git credential broker.

The existing E2B Terraform source hash includes these files, so the next apply will rebuild the template.

## Verification

- `44 passed` in focused sandbox-runtime wrapper and credential-helper tests
- Ruff check passed for the E2B builder
- Python compilation passed
- `git diff --check` passed

A live E2B template build was not run because it requires deployment credentials.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/57acd24e0d876a8e79c1b121633a7421)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced GitHub CLI preflight/readiness checks for sandbox images.
  * Added provisioning for an authenticated GitHub CLI wrapper that uses stored credentials when available.
* **Bug Fixes**
  * Improved reliability of GitHub CLI + wrapper installation across different sandbox build modes, including ensuring the wrapper is executable.
  * Refined TLS/CA setup so system GitHub HTTPS trust is configured during image build.
* **Tests**
  * Added/updated tests to validate wrapper installation behavior and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->