### PR TITLE
test: cover authenticated terminal URLs

### DIFF
--- a/packages/web/src/lib/urls.test.ts
+++ b/packages/web/src/lib/urls.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, it } from "vitest";
-import { getSafeExternalUrl } from "./urls";
+import { buildAuthenticatedUrl, getSafeExternalUrl } from "./urls";
+
+describe("buildAuthenticatedUrl", () => {
+  it("adds the token while preserving existing query parameters", () => {
+    expect(buildAuthenticatedUrl("https://terminal.example.com/?theme=dark", "secret token")).toBe(
+      "https://terminal.example.com/?theme=dark&token=secret+token"
+    );
+  });
+
+  it("replaces an existing token", () => {
+    expect(buildAuthenticatedUrl("https://terminal.example.com/?token=old", "new")).toBe(
+      "https://terminal.example.com/?token=new"
+    );
+  });
+
+  it("rejects missing tokens and unsafe urls", () => {
+    expect(buildAuthenticatedUrl("https://terminal.example.com", undefined)).toBeNull();
+    expect(buildAuthenticatedUrl("http://terminal.example.com", "secret")).toBeNull();
+  });
+});
 
 describe("getSafeExternalUrl", () => {
   it("allows https urls", () => {


### PR DESCRIPTION
## Summary
- add direct unit coverage for authenticated terminal URL construction
- verify existing query parameters are preserved and stale tokens are replaced
- verify missing tokens and unsafe non-local HTTP URLs are rejected

## Why
`buildAuthenticatedUrl` is used by both terminal views and handles terminal authentication credentials, but only its underlying URL safety helper had direct coverage.

## Verification
- `npm test -w @open-inspect/web` (94 files, 845 tests)
- `npm run lint -w @open-inspect/web -- --no-warn-ignored src/lib/urls.test.ts`
- `npm run typecheck -w @open-inspect/web`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/78e121c7994ea63c436216a8f61ab5af)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for authenticated URL handling, including token insertion, token replacement, query parameter preservation, and invalid or unsafe URL cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->