### PR TITLE
Compact the mobile session prompt composer

### DIFF
--- a/packages/web/src/components/session-prompt-composer.test.tsx
+++ b/packages/web/src/components/session-prompt-composer.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { useRef, useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { SessionPromptComposer } from "./session-prompt-composer";
+
+expect.extend(matchers);
+
+vi.mock("@/components/action-bar", () => ({ ActionBar: () => null }));
+vi.mock("@/components/attachment-preview-strip", () => ({
+  AttachmentPreviewStrip: () => null,
+}));
+vi.mock("@/components/reasoning-effort-pills", () => ({
+  ReasoningEffortPills: () => null,
+}));
+vi.mock("@/components/ui/combobox", () => ({
+  Combobox: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+function ComposerHarness() {
+  const [value, setValue] = useState("");
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  return (
+    <SessionPromptComposer
+      session={{
+        id: "session-1",
+        status: "active",
+        artifacts: [],
+        onArchive: vi.fn(),
+        onUnarchive: vi.fn(),
+      }}
+      prompt={{
+        value,
+        isProcessing: false,
+        draftLocked: false,
+        inputRef,
+        onSubmit: vi.fn(),
+        onChange: (event) => setValue(event.target.value),
+        onKeyDown: vi.fn(),
+        onStopExecution: vi.fn(),
+      }}
+      attachments={{
+        items: [],
+        error: null,
+        isUploading: false,
+        onAdd: vi.fn(),
+        onRemove: vi.fn(),
+      }}
+      model={{
+        selectedModel: "model-1",
+        reasoningEffort: undefined,
+        items: [],
+        onModelChange: vi.fn(),
+        onReasoningEffortChange: vi.fn(),
+      }}
+    />
+  );
+}
+
+describe("SessionPromptComposer", () => {
+  it("starts with one row and grows and shrinks with its content", () => {
+    render(<ComposerHarness />);
+
+    const input = screen.getByPlaceholderText<HTMLTextAreaElement>("Ask or build anything");
+    expect(input).toHaveAttribute("rows", "1");
+
+    let scrollHeight = 48;
+    Object.defineProperty(input, "scrollHeight", {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+
+    scrollHeight = 112;
+    fireEvent.change(input, { target: { value: "A prompt that wraps onto multiple lines" } });
+    expect(input).toHaveStyle({ height: "112px" });
+
+    scrollHeight = 48;
+    fireEvent.change(input, { target: { value: "" } });
+    expect(input).toHaveStyle({ height: "48px" });
+
+    scrollHeight = 72;
+    fireEvent(window, new Event("resize"));
+    expect(input).toHaveStyle({ height: "72px" });
+  });
+});

--- a/packages/web/src/components/session-prompt-composer.test.tsx
+++ b/packages/web/src/components/session-prompt-composer.test.tsx
@@ -22,10 +22,19 @@ vi.mock("@/components/ui/combobox", () => ({
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
 });
 
-function ComposerHarness() {
-  const [value, setValue] = useState("");
+function ComposerHarness({
+  initialValue = "",
+  isProcessing = false,
+  isUploading = false,
+}: {
+  initialValue?: string;
+  isProcessing?: boolean;
+  isUploading?: boolean;
+}) {
+  const [value, setValue] = useState(initialValue);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   return (
@@ -39,8 +48,8 @@ function ComposerHarness() {
       }}
       prompt={{
         value,
-        isProcessing: false,
-        draftLocked: false,
+        isProcessing,
+        draftLocked: isUploading,
         inputRef,
         onSubmit: vi.fn(),
         onChange: (event) => setValue(event.target.value),
@@ -50,7 +59,7 @@ function ComposerHarness() {
       attachments={{
         items: [],
         error: null,
-        isUploading: false,
+        isUploading,
         onAdd: vi.fn(),
         onRemove: vi.fn(),
       }}
@@ -67,27 +76,40 @@ function ComposerHarness() {
 
 describe("SessionPromptComposer", () => {
   it("starts with one row and grows and shrinks with its content", () => {
+    const scrollHeight = vi
+      .spyOn(HTMLTextAreaElement.prototype, "scrollHeight", "get")
+      .mockReturnValue(48);
     render(<ComposerHarness />);
 
     const input = screen.getByPlaceholderText<HTMLTextAreaElement>("Ask or build anything");
     expect(input).toHaveAttribute("rows", "1");
+    expect(input).toHaveStyle({ height: "48px" });
 
-    let scrollHeight = 48;
-    Object.defineProperty(input, "scrollHeight", {
-      configurable: true,
-      get: () => scrollHeight,
-    });
-
-    scrollHeight = 112;
+    scrollHeight.mockReturnValue(112);
     fireEvent.change(input, { target: { value: "A prompt that wraps onto multiple lines" } });
     expect(input).toHaveStyle({ height: "112px" });
 
-    scrollHeight = 48;
+    scrollHeight.mockReturnValue(48);
     fireEvent.change(input, { target: { value: "" } });
     expect(input).toHaveStyle({ height: "48px" });
 
-    scrollHeight = 72;
+    scrollHeight.mockReturnValue(72);
     fireEvent(window, new Event("resize"));
     expect(input).toHaveStyle({ height: "72px" });
+  });
+
+  it("keeps processing and uploading controls in the mobile layout flow", () => {
+    render(<ComposerHarness initialValue="Queued prompt" isProcessing isUploading />);
+
+    const input = screen.getByPlaceholderText("Type your next message...");
+    const actions = screen.getByTestId("prompt-actions");
+
+    expect(screen.getByText("Uploading…")).toBeInTheDocument();
+    expect(screen.getByText("Waiting...")).toBeInTheDocument();
+    expect(screen.getByTitle("Stop")).toBeInTheDocument();
+    expect(input).toHaveClass("min-w-48", "flex-1");
+    expect(input).not.toHaveClass("pr-24");
+    expect(input.parentElement).toHaveClass("flex-wrap", "justify-end");
+    expect(actions).toHaveClass("shrink-0", "sm:absolute");
   });
 });

--- a/packages/web/src/components/session-prompt-composer.tsx
+++ b/packages/web/src/components/session-prompt-composer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useLayoutEffect, useRef } from "react";
 import { ActionBar } from "@/components/action-bar";
 import { AttachmentPreviewStrip } from "@/components/attachment-preview-strip";
 import { ReasoningEffortPills } from "@/components/reasoning-effort-pills";
@@ -68,6 +68,20 @@ export function SessionPromptComposer({
     handleDragLeave,
   } = useAttachmentDropZone({ locked: attachmentsLocked, onAdd: attachments.onAdd });
 
+  useLayoutEffect(() => {
+    const input = prompt.inputRef.current;
+    if (!input) return;
+
+    const resizeInput = () => {
+      input.style.height = "auto";
+      input.style.height = `${input.scrollHeight}px`;
+    };
+
+    resizeInput();
+    window.addEventListener("resize", resizeInput);
+    return () => window.removeEventListener("resize", resizeInput);
+  }, [prompt.inputRef, prompt.value]);
+
   return (
     <footer className="min-w-0 border-t border-border-muted flex-shrink-0">
       <form onSubmit={prompt.onSubmit} className="w-full min-w-0 max-w-4xl mx-auto p-4 pb-6">
@@ -110,8 +124,8 @@ export function SessionPromptComposer({
               placeholder={
                 prompt.isProcessing ? "Type your next message..." : "Ask or build anything"
               }
-              className="w-full resize-none bg-transparent px-4 pt-4 pb-12 focus:outline-none text-foreground placeholder:text-secondary-foreground"
-              rows={3}
+              className="min-h-12 max-h-40 w-full resize-none overflow-y-auto bg-transparent py-3 pl-4 pr-24 leading-6 text-foreground placeholder:text-secondary-foreground focus:outline-none sm:min-h-[7.75rem] sm:px-4 sm:pt-4 sm:pb-12"
+              rows={1}
             />
             {/* Floating action buttons */}
             <div className="absolute bottom-3 right-3 flex items-center gap-2">

--- a/packages/web/src/components/session-prompt-composer.tsx
+++ b/packages/web/src/components/session-prompt-composer.tsx
@@ -113,7 +113,7 @@ export function SessionPromptComposer({
           />
 
           {/* Text input area with floating send button */}
-          <div className="relative">
+          <div className="relative flex flex-wrap items-end justify-end sm:block">
             <textarea
               ref={prompt.inputRef}
               value={prompt.value}
@@ -124,11 +124,14 @@ export function SessionPromptComposer({
               placeholder={
                 prompt.isProcessing ? "Type your next message..." : "Ask or build anything"
               }
-              className="min-h-12 max-h-40 w-full resize-none overflow-y-auto bg-transparent py-3 pl-4 pr-24 leading-6 text-foreground placeholder:text-secondary-foreground focus:outline-none sm:min-h-[7.75rem] sm:px-4 sm:pt-4 sm:pb-12"
+              className="min-h-12 max-h-40 w-0 min-w-48 flex-1 resize-none overflow-y-auto bg-transparent px-4 py-3 leading-6 text-foreground placeholder:text-secondary-foreground focus:outline-none sm:block sm:min-h-[7.75rem] sm:w-full sm:px-4 sm:pt-4 sm:pb-12"
               rows={1}
             />
             {/* Floating action buttons */}
-            <div className="absolute bottom-3 right-3 flex items-center gap-2">
+            <div
+              data-testid="prompt-actions"
+              className="flex shrink-0 items-center gap-1 pb-1.5 pr-2 sm:absolute sm:bottom-3 sm:right-3 sm:gap-2 sm:p-0"
+            >
               {attachments.isUploading && (
                 <span className="whitespace-nowrap text-xs text-muted-foreground">Uploading…</span>
               )}


### PR DESCRIPTION
## Summary
- start the session-detail prompt textarea at one line on mobile while preserving the existing desktop baseline
- grow and shrink the textarea with its content up to a scrollable maximum height
- recalculate the measured height when the viewport changes to support resizing and device rotation
- add focused coverage for initial size, content-driven resizing, and viewport resizing

## Validation
- `npm test -w @open-inspect/web` (846 tests passed)
- `npm test -w @open-inspect/web -- --run src/components/session-prompt-composer.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web -- --no-cache`

## Visual verification
- mobile initial state at 390x844: artifact `22fc9c0238b359ad1055d48fdb5e3eb0`
- mobile expanded state at 390x844: artifact `b7c3f6813c2606ec2a0911479c945ad5`
- desktop baseline at 1280x800: artifact `b4576c05b35922cb9e85966423a98f5f`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/789e2e93161bcfc10b6705d8ea6cd0f6)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prompt text areas now auto-expand with content, capped at a maximum height.
  * The prompt composer responds to window resizing to keep the editor correctly sized.

* **Bug Fixes**
  * Improved sizing and scrolling behavior for more consistent text entry.
  * Mobile/processing layout now shows the expected controls and state more reliably.

* **Tests**
  * Added/extended automated UI tests for the prompt composer, including resizing and processing-related layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->