### PR TITLE
feat: add Claude Opus 5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 New features, integrations, and notable improvements to Open-Inspect — newest first.
 
+## July 24, 2026
+
+**Claude Opus 5.** Adds `claude-opus-5` to the model picker and integrations, with adaptive thinking
+and reasoning efforts from low through max.
+
 ## July 23, 2026
 
 **Slack image attachments.** Attach PNG, JPEG, WebP, and GIF images to Slack direct messages, app

--- a/README.md
+++ b/README.md
@@ -187,12 +187,12 @@ await configureGitIdentity({
 
 Choose the AI model that fits your task, with per-session reasoning effort controls:
 
-| Provider         | Models                                                          |
-| ---------------- | --------------------------------------------------------------- |
-| Anthropic        | Claude Haiku 4.5, Sonnet 4.5/4.6, Opus 4.5/4.6/4.7/4.8, Fable 5 |
-| OpenAI           | GPT 5.4, GPT 5.5, 5.3 Codex, 5.3 Codex Spark                    |
-| OpenCode Zen     | Kimi K2.5/K2.6, MiniMax M2.5, Qwen3.7 Max, GLM 5/5.1 (opt-in)   |
-| Z.AI Coding Plan | GLM 5.2 (opt-in)                                                |
+| Provider         | Models                                                            |
+| ---------------- | ----------------------------------------------------------------- |
+| Anthropic        | Claude Haiku 4.5, Sonnet 4.5/4.6, Opus 4.5/4.6/4.7/4.8/5, Fable 5 |
+| OpenAI           | GPT 5.4, GPT 5.5, 5.3 Codex, 5.3 Codex Spark                      |
+| OpenCode Zen     | Kimi K2.5/K2.6, MiniMax M2.5, Qwen3.7 Max, GLM 5/5.1 (opt-in)     |
+| Z.AI Coding Plan | GLM 5.2 (opt-in)                                                  |
 
 OpenAI models work with your existing ChatGPT subscription via OAuth — no separate API key needed.
 See **[docs/AVAILABLE_MODELS.md](docs/AVAILABLE_MODELS.md)** for the full model list and

--- a/docs/AVAILABLE_MODELS.md
+++ b/docs/AVAILABLE_MODELS.md
@@ -16,6 +16,7 @@ models are available but must be enabled in **Settings > Models**. Z.AI Coding P
 | `anthropic/claude-opus-4-6`   | Claude Opus 4.6   | Most capable, adaptive thinking    | low, medium, high, max        | high           |
 | `anthropic/claude-opus-4-7`   | Claude Opus 4.7   | Most capable, adaptive thinking    | low, medium, high, xhigh, max | high           |
 | `anthropic/claude-opus-4-8`   | Claude Opus 4.8   | Most capable, adaptive thinking    | low, medium, high, xhigh, max | high           |
+| `anthropic/claude-opus-5`     | Claude Opus 5     | Latest Opus, adaptive thinking     | low, medium, high, xhigh, max | high           |
 | `anthropic/claude-fable-5`    | Claude Fable 5    | Most powerful, new tier above Opus | low, medium, high, xhigh, max | high           |
 
 ## OpenAI

--- a/packages/linear-bot/README.md
+++ b/packages/linear-bot/README.md
@@ -167,7 +167,7 @@ On any Linear issue:
 - Assign the issue to `OpenInspect` → agent picks it up
 - Agent status is visible directly in Linear (thinking, working, done)
 - Add a `model:<name>` label to override the model (e.g., `model:opus`, `model:sonnet`,
-  `model:haiku`, `model:gpt-5.4`, `model:gpt-5.3-codex`)
+  `model:opus-5`, `model:haiku`, `model:gpt-5.4`, `model:gpt-5.3-codex`)
 
 ## Repo Resolution
 

--- a/packages/linear-bot/src/__tests__/pure-functions.test.ts
+++ b/packages/linear-bot/src/__tests__/pure-functions.test.ts
@@ -63,6 +63,10 @@ describe("extractModelFromLabels", () => {
     expect(extractModelFromLabels([{ name: "model:opus-4-7" }])).toBe("anthropic/claude-opus-4-7");
   });
 
+  it("returns Opus 5 for model:opus-5 label", () => {
+    expect(extractModelFromLabels([{ name: "model:opus-5" }])).toBe("anthropic/claude-opus-5");
+  });
+
   it("returns null for unknown model label", () => {
     expect(extractModelFromLabels([{ name: "model:unknown-model" }])).toBeNull();
   });

--- a/packages/linear-bot/src/model-resolution.ts
+++ b/packages/linear-bot/src/model-resolution.ts
@@ -37,6 +37,7 @@ const MODEL_LABEL_MAP: Record<string, string> = {
   "opus-4-6": "anthropic/claude-opus-4-6",
   "opus-4-7": "anthropic/claude-opus-4-7",
   "opus-4-8": "anthropic/claude-opus-4-8",
+  "opus-5": "anthropic/claude-opus-5",
   fable: "anthropic/claude-fable-5",
   "fable-5": "anthropic/claude-fable-5",
   "gpt-5.4": "openai/gpt-5.4",

--- a/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
+++ b/packages/sandbox-runtime/src/sandbox_runtime/prompt_stream.py
@@ -41,6 +41,7 @@ ANTHROPIC_ADAPTIVE_THINKING_MODELS: Final[frozenset[str]] = frozenset(
         "claude-opus-4-6",
         "claude-opus-4-7",
         "claude-opus-4-8",
+        "claude-opus-5",
         "claude-sonnet-4-6",
     }
 )

--- a/packages/sandbox-runtime/tests/test_bridge_message_tracking.py
+++ b/packages/sandbox-runtime/tests/test_bridge_message_tracking.py
@@ -259,6 +259,23 @@ class TestBuildPromptRequestBody:
             "outputConfig": {"effort": "medium"},
         }
 
+    def test_with_opus_5_adaptive_thinking(self, bridge: AgentBridge):
+        """Opus 5 should use adaptive thinking instead of manual budgets."""
+        body = bridge._ensure_prompt_stream()._build_prompt_request_body(
+            "Hello",
+            "anthropic/claude-opus-5",
+            reasoning_effort="xhigh",
+        )
+
+        assert body["model"] == {
+            "providerID": "anthropic",
+            "modelID": "claude-opus-5",
+            "options": {
+                "thinking": {"type": "adaptive"},
+                "outputConfig": {"effort": "xhigh"},
+            },
+        }
+
     def test_with_sonnet_4_6_adaptive_thinking(self, bridge: AgentBridge):
         """Sonnet 4.6 should use adaptive thinking instead of manual budgets."""
         body = bridge._ensure_prompt_stream()._build_prompt_request_body(

--- a/packages/shared/src/models.test.ts
+++ b/packages/shared/src/models.test.ts
@@ -26,6 +26,7 @@ const ANTHROPIC_MODELS = [
   "anthropic/claude-opus-4-6",
   "anthropic/claude-opus-4-7",
   "anthropic/claude-opus-4-8",
+  "anthropic/claude-opus-5",
   "anthropic/claude-fable-5",
 ] as const;
 
@@ -107,11 +108,13 @@ describe("model utilities", () => {
   it("normalizes and validates bare Claude and GPT model names", () => {
     expect(normalizeModelId("claude-sonnet-4-6")).toBe("anthropic/claude-sonnet-4-6");
     expect(normalizeModelId("claude-opus-4-8")).toBe("anthropic/claude-opus-4-8");
+    expect(normalizeModelId("claude-opus-5")).toBe("anthropic/claude-opus-5");
     expect(normalizeModelId("claude-fable-5")).toBe("anthropic/claude-fable-5");
     expect(normalizeModelId("gpt-5.3-codex")).toBe("openai/gpt-5.3-codex");
     expect(normalizeModelId("gpt-5.6-sol")).toBe("openai/gpt-5.6-sol");
     expect(isValidModel("claude-sonnet-4-6")).toBe(true);
     expect(isValidModel("claude-opus-4-8")).toBe(true);
+    expect(isValidModel("claude-opus-5")).toBe(true);
     expect(isValidModel("claude-fable-5")).toBe(true);
     expect(isValidModel("gpt-5.3-codex")).toBe(true);
     expect(isValidModel("gpt-5.6-sol")).toBe(true);
@@ -203,6 +206,10 @@ describe("model utilities", () => {
       provider: "anthropic",
       model: "claude-opus-4-8",
     });
+    expect(extractProviderAndModel("anthropic/claude-opus-5")).toEqual({
+      provider: "anthropic",
+      model: "claude-opus-5",
+    });
     expect(extractProviderAndModel("openai/gpt-5.3-codex-spark")).toEqual({
       provider: "openai",
       model: "gpt-5.3-codex-spark",
@@ -238,6 +245,7 @@ describe("model utilities", () => {
     expect(getDefaultReasoningEffort("anthropic/claude-haiku-4-5")).toBe("max");
     expect(getDefaultReasoningEffort("anthropic/claude-sonnet-4-6")).toBe("high");
     expect(getDefaultReasoningEffort("anthropic/claude-opus-4-8")).toBe("high");
+    expect(getDefaultReasoningEffort("anthropic/claude-opus-5")).toBe("high");
     expect(getDefaultReasoningEffort("anthropic/claude-fable-5")).toBe("high");
     expect(getDefaultReasoningEffort("openai/gpt-5.3-codex")).toBe("high");
     expect(getDefaultReasoningEffort("openai/gpt-5.5")).toBeUndefined();
@@ -255,6 +263,10 @@ describe("model utilities", () => {
       default: "high",
     });
     expect(getReasoningConfig("anthropic/claude-opus-4-8")).toEqual({
+      efforts: ["low", "medium", "high", "xhigh", "max"],
+      default: "high",
+    });
+    expect(getReasoningConfig("anthropic/claude-opus-5")).toEqual({
       efforts: ["low", "medium", "high", "xhigh", "max"],
       default: "high",
     });
@@ -278,6 +290,8 @@ describe("model utilities", () => {
     expect(isValidReasoningEffort("anthropic/claude-sonnet-4-5", "low")).toBe(false);
     expect(isValidReasoningEffort("anthropic/claude-opus-4-8", "xhigh")).toBe(true);
     expect(isValidReasoningEffort("anthropic/claude-opus-4-8", "none")).toBe(false);
+    expect(isValidReasoningEffort("anthropic/claude-opus-5", "xhigh")).toBe(true);
+    expect(isValidReasoningEffort("anthropic/claude-opus-5", "none")).toBe(false);
     expect(isValidReasoningEffort("anthropic/claude-fable-5", "max")).toBe(true);
     expect(isValidReasoningEffort("openai/gpt-5.4", "none")).toBe(true);
     expect(isValidReasoningEffort("openai/gpt-5.6-sol", "xhigh")).toBe(true);

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -94,6 +94,15 @@ export const MODEL_CATALOG = [
         },
       },
       {
+        id: "anthropic/claude-opus-5",
+        name: "Claude Opus 5",
+        description: "Latest Opus, adaptive thinking",
+        reasoning: {
+          efforts: ["low", "medium", "high", "xhigh", "max"],
+          default: "high",
+        },
+      },
+      {
         id: "anthropic/claude-fable-5",
         name: "Claude Fable 5",
         description: "Most powerful, new tier above Opus",


### PR DESCRIPTION
## Summary
- add `anthropic/claude-opus-5` to the shared model catalog and model pickers
- route Opus 5 requests with Anthropic adaptive thinking and low-through-max reasoning efforts
- support the `model:opus-5` Linear label and update model documentation
- cover model normalization, validation, reasoning configuration, provider extraction, and runtime request construction

## Testing
- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/shared`
- `npm test -w @open-inspect/linear-bot`
- `PYTHONPATH="$PWD/src" uv run --extra dev pytest tests/test_bridge_message_tracking.py -v`
- `npm run typecheck`
- Prettier and Ruff checks

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/e588213eff7023a33da45a5ea9184ad4)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Anthropic’s Claude Opus 5 model across the model picker and integrations.
  * Added adaptive reasoning controls with effort levels from low through max, defaulting to high.
  * Added support for selecting Claude Opus 5 through `model:opus-5` labels in Linear workflows.
* **Documentation**
  * Updated available-model lists, README guidance, and changelog details to include Claude Opus 5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->