### PR TITLE
Consolidate mobile session actions into kebab menu

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -388,6 +388,7 @@ function SessionPageContent() {
               : null),
           onArchive: handleArchive,
           onUnarchive: handleUnarchive,
+          onOpenDetails: () => setIsDetailsOpen(true),
         }}
         prompt={{
           value: prompt,

--- a/packages/web/src/components/action-bar.test.tsx
+++ b/packages/web/src/components/action-bar.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 /// <reference types="@testing-library/jest-dom" />
 
-import { afterEach, describe, expect, it } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { ActionBar } from "./action-bar";
 
@@ -89,6 +89,62 @@ describe("ActionBar", () => {
     render(<ActionBar sessionId="session-1" sessionStatus="active" artifacts={[]} />);
 
     expect(screen.queryByText(/Media/)).not.toBeInTheDocument();
+  });
+
+  it("consolidates all session actions into the menu on mobile", () => {
+    const onOpenDetails = vi.fn();
+    render(
+      <ActionBar
+        sessionId="session-1"
+        sessionStatus="active"
+        artifacts={[
+          {
+            id: "artifact-preview-1",
+            type: "preview",
+            url: "https://preview.example.com",
+            metadata: { previewStatus: "active" },
+            createdAt: 1234,
+          },
+          {
+            id: "artifact-pr-1",
+            type: "pr",
+            url: "https://github.com/acme/web-app/pull/42",
+            metadata: { prNumber: 42 },
+            createdAt: 1235,
+          },
+          {
+            id: "artifact-shot-1",
+            type: "screenshot",
+            url: "sessions/session-1/media/artifact-shot-1.png",
+            metadata: { mimeType: "image/png" },
+            createdAt: 1236,
+          },
+        ]}
+        onOpenDetails={onOpenDetails}
+      />
+    );
+
+    expect(screen.getByRole("link", { name: "View preview" })).toHaveClass(
+      "hidden",
+      "md:inline-flex"
+    );
+    expect(screen.getByRole("link", { name: "View PR" })).toHaveClass("hidden", "md:inline-flex");
+    expect(screen.getByRole("button", { name: "Archive" })).toHaveClass("hidden", "md:inline-flex");
+    expect(screen.getByText("Media (1)")).toHaveClass("hidden", "md:inline-flex");
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More session actions" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+
+    expect(screen.getAllByText("View preview")[1]).toHaveClass("md:hidden");
+    expect(screen.getAllByText("View PR")[1]).toHaveClass("md:hidden");
+    expect(screen.getAllByText("Archive")[1]).toHaveClass("md:hidden");
+    const mediaMenuItem = screen.getAllByText("Media (1)")[1];
+    expect(mediaMenuItem).toHaveClass("md:hidden");
+
+    fireEvent.click(mediaMenuItem);
+    expect(onOpenDetails).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/web/src/components/action-bar.test.tsx
+++ b/packages/web/src/components/action-bar.test.tsx
@@ -32,6 +32,7 @@ describe("ActionBar", () => {
             createdAt: 1234,
           },
         ]}
+        onOpenDetails={() => undefined}
       />
     );
 
@@ -79,6 +80,7 @@ describe("ActionBar", () => {
             createdAt: 1236,
           },
         ]}
+        onOpenDetails={() => undefined}
       />
     );
 
@@ -86,7 +88,14 @@ describe("ActionBar", () => {
   });
 
   it("does not render a media count indicator when no media artifacts exist", () => {
-    render(<ActionBar sessionId="session-1" sessionStatus="active" artifacts={[]} />);
+    render(
+      <ActionBar
+        sessionId="session-1"
+        sessionStatus="active"
+        artifacts={[]}
+        onOpenDetails={() => undefined}
+      />
+    );
 
     expect(screen.queryByText(/Media/)).not.toBeInTheDocument();
   });
@@ -171,6 +180,7 @@ describe("repository-aware PR selection", () => {
         sessionStatus="active"
         artifacts={[backendPr, webPr]}
         primaryRepo={{ repoOwner: "acme", repoName: "web" }}
+        onOpenDetails={() => undefined}
       />
     );
 
@@ -180,7 +190,12 @@ describe("repository-aware PR selection", () => {
 
   it("falls back to the first PR artifact without repo context", () => {
     render(
-      <ActionBar sessionId="session-1" sessionStatus="active" artifacts={[backendPr, webPr]} />
+      <ActionBar
+        sessionId="session-1"
+        sessionStatus="active"
+        artifacts={[backendPr, webPr]}
+        onOpenDetails={() => undefined}
+      />
     );
 
     const link = screen.getByRole("link", { name: /view pr/i });

--- a/packages/web/src/components/action-bar.tsx
+++ b/packages/web/src/components/action-bar.tsx
@@ -35,7 +35,7 @@ interface ActionBarProps {
   primaryRepo?: { repoOwner: string; repoName: string } | null;
   onArchive?: () => void | Promise<void>;
   onUnarchive?: () => void | Promise<void>;
-  onOpenDetails?: () => void;
+  onOpenDetails: () => void;
 }
 
 export function ActionBar({
@@ -169,7 +169,7 @@ export function ActionBar({
               <ArchiveIcon className="w-4 h-4" />
               {isArchived ? "Unarchive" : "Archive"}
             </DropdownMenuItem>
-            {mediaCount > 0 && onOpenDetails && (
+            {mediaCount > 0 && (
               <DropdownMenuItem className="md:hidden" onClick={onOpenDetails}>
                 <FolderIcon className="w-4 h-4" />
                 Media ({mediaCount})

--- a/packages/web/src/components/action-bar.tsx
+++ b/packages/web/src/components/action-bar.tsx
@@ -11,6 +11,7 @@ import {
   MoreIcon,
   LinkIcon,
   GitHubIcon,
+  FolderIcon,
 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import {
@@ -34,6 +35,7 @@ interface ActionBarProps {
   primaryRepo?: { repoOwner: string; repoName: string } | null;
   onArchive?: () => void | Promise<void>;
   onUnarchive?: () => void | Promise<void>;
+  onOpenDetails?: () => void;
 }
 
 export function ActionBar({
@@ -43,6 +45,7 @@ export function ActionBar({
   primaryRepo,
   onArchive,
   onUnarchive,
+  onOpenDetails,
 }: ActionBarProps) {
   const [isArchiving, setIsArchiving] = useState(false);
   const [showArchiveDialog, setShowArchiveDialog] = useState(false);
@@ -94,7 +97,7 @@ export function ActionBar({
       <div className="flex flex-wrap items-stretch gap-2">
         {/* View Preview */}
         {previewUrl && (
-          <Button variant="outline" size="sm" className="gap-1.5" asChild>
+          <Button variant="outline" size="sm" className="hidden gap-1.5 md:inline-flex" asChild>
             <a href={previewUrl} target="_blank" rel="noopener noreferrer">
               <GlobeIcon className="w-4 h-4" />
               <span>View preview</span>
@@ -107,7 +110,7 @@ export function ActionBar({
 
         {/* View PR */}
         {prUrl && (
-          <Button variant="outline" size="sm" className="gap-1.5" asChild>
+          <Button variant="outline" size="sm" className="hidden gap-1.5 md:inline-flex" asChild>
             <a href={prUrl} target="_blank" rel="noopener noreferrer">
               <GitPrIcon className="w-4 h-4" />
               <span>View PR</span>
@@ -121,14 +124,14 @@ export function ActionBar({
           size="sm"
           onClick={handleArchiveToggle}
           disabled={isArchiving}
-          className="gap-1.5"
+          className="hidden gap-1.5 md:inline-flex"
         >
           <ArchiveIcon className="w-4 h-4" />
           <span>{isArchived ? "Unarchive" : "Archive"}</span>
         </Button>
 
         {mediaCount > 0 && (
-          <div className="inline-flex items-center rounded-md border border-border-muted px-3 text-sm text-muted-foreground">
+          <div className="hidden items-center rounded-md border border-border-muted px-3 text-sm text-muted-foreground md:inline-flex">
             Media ({mediaCount})
           </div>
         )}
@@ -136,17 +139,48 @@ export function ActionBar({
         {/* More menu */}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="sm" className="!px-2">
+            <Button variant="outline" size="sm" className="!px-2" aria-label="More session actions">
               <MoreIcon className="w-4 h-4" />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" side="top">
+            {previewUrl && (
+              <DropdownMenuItem className="md:hidden" asChild>
+                <a href={previewUrl} target="_blank" rel="noopener noreferrer">
+                  <GlobeIcon className="w-4 h-4" />
+                  View preview
+                  {previewArtifact?.metadata?.previewStatus === "outdated" && " (outdated)"}
+                </a>
+              </DropdownMenuItem>
+            )}
+            {prUrl && (
+              <DropdownMenuItem className="md:hidden" asChild>
+                <a href={prUrl} target="_blank" rel="noopener noreferrer">
+                  <GitPrIcon className="w-4 h-4" />
+                  View PR
+                </a>
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuItem
+              className="md:hidden"
+              onClick={handleArchiveToggle}
+              disabled={isArchiving}
+            >
+              <ArchiveIcon className="w-4 h-4" />
+              {isArchived ? "Unarchive" : "Archive"}
+            </DropdownMenuItem>
+            {mediaCount > 0 && onOpenDetails && (
+              <DropdownMenuItem className="md:hidden" onClick={onOpenDetails}>
+                <FolderIcon className="w-4 h-4" />
+                Media ({mediaCount})
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem onClick={handleCopyLink}>
               <LinkIcon className="w-4 h-4" />
               Copy link
             </DropdownMenuItem>
             {prUrl && (
-              <DropdownMenuItem asChild>
+              <DropdownMenuItem className="hidden md:flex" asChild>
                 <a href={prUrl} target="_blank" rel="noopener noreferrer">
                   <GitHubIcon className="w-4 h-4" />
                   View in GitHub

--- a/packages/web/src/components/session-prompt-composer.test.tsx
+++ b/packages/web/src/components/session-prompt-composer.test.tsx
@@ -45,6 +45,7 @@ function ComposerHarness({
         artifacts: [],
         onArchive: vi.fn(),
         onUnarchive: vi.fn(),
+        onOpenDetails: vi.fn(),
       }}
       prompt={{
         value,

--- a/packages/web/src/components/session-prompt-composer.tsx
+++ b/packages/web/src/components/session-prompt-composer.tsx
@@ -20,6 +20,7 @@ type SessionPromptComposerProps = {
     primaryRepo?: { repoOwner: string; repoName: string } | null;
     onArchive: () => void | Promise<void>;
     onUnarchive: () => void | Promise<void>;
+    onOpenDetails: () => void;
   };
   prompt: {
     value: string;
@@ -94,6 +95,7 @@ export function SessionPromptComposer({
             primaryRepo={session.primaryRepo}
             onArchive={session.onArchive}
             onUnarchive={session.onUnarchive}
+            onOpenDetails={session.onOpenDetails}
           />
         </div>
 


### PR DESCRIPTION
## Summary
- collapse preview, PR, archive, and media controls into the existing kebab menu on mobile
- preserve the current inline action layout on tablet and desktop
- open the session details sheet from the mobile Media action
- add an accessible label to the kebab trigger and test the responsive action behavior

## Verification
- `npm test -w @open-inspect/web -- --run src/components/action-bar.test.tsx src/components/session-prompt-composer.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- ESLint on changed files
- mobile viewport screenshot verified at 390x844

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/319df59b5fac75ad348f07bc30d569a4)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mobile-friendly “More session actions” menu to preview sessions, view pull requests, and archive/unarchive sessions.
  * Added a media “Media (count)” option in the menu that opens the session media details view.
  * Improved accessibility by adding an aria-label to the “More” trigger.
* **Tests**
  * Updated and added tests to verify mobile action consolidation, menu selection, and that media details open exactly once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->