### PR TITLE
fix: unify mobile session header actions

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -130,6 +130,7 @@ function SessionPageContent() {
 
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
   const detailsButtonRef = useRef<HTMLButtonElement>(null);
+  const mobileActionsButtonRef = useRef<HTMLButtonElement>(null);
 
   // Terminal panel state
   const [terminalOpen, setTerminalOpen] = useState(() => {
@@ -167,6 +168,11 @@ function SessionPageContent() {
     () => mediaArtifacts.find((artifact) => artifact.id === selectedMediaArtifactId) ?? null,
     [mediaArtifacts, selectedMediaArtifactId]
   );
+  const primaryRepo =
+    sessionState?.repositories?.[0] ??
+    (sessionState?.repoOwner && sessionState?.repoName
+      ? { repoOwner: sessionState.repoOwner, repoName: sessionState.repoName }
+      : null);
 
   const showTimelineSkeleton = events.length === 0 && (connecting || replaying);
   const resolvedDiff = useMemo(
@@ -243,13 +249,22 @@ function SessionPageContent() {
   return (
     <div className="h-full min-w-0 overflow-x-hidden flex flex-col">
       <SessionHeader
+        sessionId={sessionId}
+        sessionStatus={sessionState?.status || ""}
+        artifacts={artifacts}
+        primaryRepo={primaryRepo}
         sessionState={sessionState}
         fallbackSessionInfo={fallbackSessionInfo}
         connected={connected}
         connecting={connecting}
         isDetailsOpen={isDetailsOpen}
         detailsButtonRef={detailsButtonRef}
+        mobileActionsButtonRef={mobileActionsButtonRef}
         onToggleDetails={toggleDetails}
+        onOpenDetails={() => setIsDetailsOpen(true)}
+        onOpenMedia={() => setIsDetailsOpen(true)}
+        onArchive={handleArchive}
+        onUnarchive={handleUnarchive}
         renameSession={renameSession}
       />
 
@@ -328,7 +343,7 @@ function SessionPageContent() {
           open={isDetailsOpen}
           onOpenChange={setIsDetailsOpen}
           isPhone={isPhone}
-          returnFocusRef={detailsButtonRef}
+          returnFocusRef={isPhone ? mobileActionsButtonRef : detailsButtonRef}
           sessionId={sessionId}
           sessionState={sessionState}
           participants={participants}
@@ -377,15 +392,12 @@ function SessionPageContent() {
       />
 
       <SessionPromptComposer
+        showActionBar={!isPhone}
         session={{
           id: sessionId,
           status: sessionState?.status || "",
           artifacts,
-          primaryRepo:
-            sessionState?.repositories?.[0] ??
-            (sessionState?.repoOwner && sessionState?.repoName
-              ? { repoOwner: sessionState.repoOwner, repoName: sessionState.repoName }
-              : null),
+          primaryRepo,
           onArchive: handleArchive,
           onUnarchive: handleUnarchive,
           onOpenDetails: () => setIsDetailsOpen(true),

--- a/packages/web/src/components/action-bar.test.tsx
+++ b/packages/web/src/components/action-bar.test.tsx
@@ -100,7 +100,7 @@ describe("ActionBar", () => {
     expect(screen.queryByText(/Media/)).not.toBeInTheDocument();
   });
 
-  it("consolidates all session actions into the menu on mobile", () => {
+  it("keeps the inline controls hidden until md and leaves the menu trigger available", () => {
     const onOpenDetails = vi.fn();
     render(
       <ActionBar
@@ -140,6 +140,8 @@ describe("ActionBar", () => {
     expect(screen.getByRole("link", { name: "View PR" })).toHaveClass("hidden", "md:inline-flex");
     expect(screen.getByRole("button", { name: "Archive" })).toHaveClass("hidden", "md:inline-flex");
     expect(screen.getByText("Media (1)")).toHaveClass("hidden", "md:inline-flex");
+
+    expect(screen.getByRole("button", { name: "More session actions" })).toBeInTheDocument();
 
     fireEvent.pointerDown(screen.getByRole("button", { name: "More session actions" }), {
       button: 0,

--- a/packages/web/src/components/action-bar.tsx
+++ b/packages/web/src/components/action-bar.tsx
@@ -20,8 +20,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { getSafeExternalUrl } from "@/lib/urls";
-import { findPrArtifactForRepo } from "@/lib/pr-artifacts";
+import { getSessionActionState } from "@/lib/session-actions";
 
 interface ActionBarProps {
   sessionId: string;
@@ -50,15 +49,10 @@ export function ActionBar({
   const [isArchiving, setIsArchiving] = useState(false);
   const [showArchiveDialog, setShowArchiveDialog] = useState(false);
 
-  const prArtifact = primaryRepo
-    ? findPrArtifactForRepo(artifacts, primaryRepo, true)
-    : artifacts.find((a) => a.type === "pr");
-  const previewArtifact = artifacts.find((a) => a.type === "preview");
-  const mediaCount = artifacts.filter(
-    (artifact) => artifact.type === "screenshot" || artifact.type === "video"
-  ).length;
-  const previewUrl = getSafeExternalUrl(previewArtifact?.url);
-  const prUrl = getSafeExternalUrl(prArtifact?.url);
+  const { prUrl, previewArtifact, previewUrl, mediaCount } = getSessionActionState(
+    artifacts,
+    primaryRepo
+  );
 
   const isArchived = sessionStatus === "archived";
 

--- a/packages/web/src/components/session-header.test.tsx
+++ b/packages/web/src/components/session-header.test.tsx
@@ -1,13 +1,19 @@
 // @vitest-environment jsdom
 /// <reference types="@testing-library/jest-dom" />
 
-import { createRef } from "react";
-import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { createRef, type ComponentProps } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { SessionHeader } from "./session-header";
 
 expect.extend(matchers);
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+  },
+}));
 
 vi.mock("@/components/sidebar-layout", () => ({
   useSidebarContext: () => ({
@@ -16,23 +22,167 @@ vi.mock("@/components/sidebar-layout", () => ({
   }),
 }));
 
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderHeader(overrides: Partial<ComponentProps<typeof SessionHeader>> = {}) {
+  return render(
+    <SessionHeader
+      sessionId="session-1"
+      sessionStatus="active"
+      artifacts={[]}
+      primaryRepo={null}
+      sessionState={null}
+      fallbackSessionInfo={{ repoOwner: null, repoName: null, title: "Incident sweep" }}
+      connected={false}
+      connecting={true}
+      isDetailsOpen={false}
+      detailsButtonRef={createRef<HTMLButtonElement>()}
+      mobileActionsButtonRef={createRef<HTMLButtonElement>()}
+      onToggleDetails={vi.fn()}
+      onOpenDetails={vi.fn()}
+      onOpenMedia={vi.fn()}
+      onArchive={vi.fn()}
+      onUnarchive={vi.fn()}
+      renameSession={vi.fn()}
+      {...overrides}
+    />
+  );
+}
+
 describe("SessionHeader", () => {
   it("renders no-repository fallback data as loaded while socket state is absent", () => {
-    render(
-      <SessionHeader
-        sessionState={null}
-        fallbackSessionInfo={{ repoOwner: null, repoName: null, title: "Incident sweep" }}
-        connected={false}
-        connecting={true}
-        isDetailsOpen={false}
-        detailsButtonRef={createRef<HTMLButtonElement>()}
-        onToggleDetails={vi.fn()}
-        renameSession={vi.fn()}
-      />
-    );
+    renderHeader();
 
     expect(screen.getByRole("button", { name: "Incident sweep" })).toBeInTheDocument();
     expect(screen.getByText("No repository")).toBeInTheDocument();
     expect(screen.queryByText("Loading session...")).not.toBeInTheDocument();
+  });
+
+  it("uses a phone-only session actions menu and preserves the tablet details button classes", () => {
+    renderHeader();
+
+    expect(screen.getByRole("button", { name: "Toggle session details" })).toHaveClass(
+      "hidden",
+      "md:inline-flex",
+      "lg:hidden"
+    );
+    expect(screen.getByRole("button", { name: "Session actions" })).toHaveClass("md:hidden");
+  });
+
+  it("renders the unified mobile actions in the required order", () => {
+    renderHeader({
+      artifacts: [
+        {
+          id: "artifact-preview-1",
+          type: "preview",
+          url: "https://preview.example.com",
+          metadata: { previewStatus: "active" },
+          createdAt: 1234,
+        },
+        {
+          id: "artifact-pr-1",
+          type: "pr",
+          url: "https://github.com/acme/web/pull/42",
+          metadata: { prNumber: 42, repoOwner: "acme", repoName: "web" },
+          createdAt: 1235,
+        },
+        {
+          id: "artifact-shot-1",
+          type: "screenshot",
+          url: "sessions/session-1/media/artifact-shot-1.png",
+          metadata: { mimeType: "image/png" },
+          createdAt: 1236,
+        },
+      ],
+      primaryRepo: { repoOwner: "acme", repoName: "web" },
+    });
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Session actions" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+
+    expect(screen.getAllByRole("menuitem").map((item) => item.textContent)).toEqual([
+      "Details",
+      "View preview",
+      "View PR",
+      "Media (1)",
+      "Copy link",
+      "Archive",
+    ]);
+  });
+
+  it("calls the details and media callbacks from the unified phone menu", () => {
+    const onOpenDetails = vi.fn();
+    const onOpenMedia = vi.fn();
+    renderHeader({
+      onOpenDetails,
+      onOpenMedia,
+      artifacts: [
+        {
+          id: "artifact-shot-1",
+          type: "screenshot",
+          url: "sessions/session-1/media/artifact-shot-1.png",
+          metadata: { mimeType: "image/png" },
+          createdAt: 1236,
+        },
+      ],
+    });
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Session actions" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(screen.getByRole("menuitem", { name: "Details" }));
+    expect(onOpenDetails).toHaveBeenCalledOnce();
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Session actions" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(screen.getByRole("menuitem", { name: "Media (1)" }));
+    expect(onOpenMedia).toHaveBeenCalledOnce();
+  });
+
+  it("retains archive confirmation before archiving from the phone menu", () => {
+    const onArchive = vi.fn();
+    renderHeader({ onArchive });
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Session actions" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    fireEvent.click(screen.getByRole("menuitem", { name: "Archive" }));
+
+    expect(screen.getByText("Archive session")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Archive" }));
+
+    expect(onArchive).toHaveBeenCalledOnce();
+  });
+
+  it("unarchives directly from the phone menu when the session is already archived", async () => {
+    let resolveUnarchive: (() => void) | undefined;
+    const onUnarchive = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveUnarchive = resolve;
+        })
+    );
+    renderHeader({ sessionStatus: "archived", onUnarchive });
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Session actions" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    const unarchiveItem = screen.getByRole("menuitem", { name: "Unarchive" });
+    fireEvent.click(unarchiveItem);
+
+    expect(onUnarchive).toHaveBeenCalledOnce();
+    expect(screen.queryByText("Archive session")).not.toBeInTheDocument();
+
+    resolveUnarchive?.();
   });
 });

--- a/packages/web/src/components/session-header.tsx
+++ b/packages/web/src/components/session-header.tsx
@@ -2,8 +2,29 @@
 
 import { useEffect, useState, type RefObject } from "react";
 import { CollapsedSidebarControls, useSidebarContext } from "@/components/sidebar-layout";
+import { ArchiveSessionDialog } from "@/components/archive-session-dialog";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  ArchiveIcon,
+  FolderIcon,
+  GitPrIcon,
+  GlobeIcon,
+  LinkIcon,
+  MoreIcon,
+  SettingsIcon,
+} from "@/components/ui/icons";
 import type { useSessionSocket } from "@/hooks/use-session-socket";
 import { formatRepoLabel } from "@/lib/repo-label";
+import { getSessionActionState } from "@/lib/session-actions";
+import { toast } from "sonner";
+import type { Artifact } from "@/types/session";
 
 type SessionSocketState = ReturnType<typeof useSessionSocket>;
 
@@ -20,6 +41,10 @@ const SANDBOX_STATUS_COLORS: Record<string, string> = {
 };
 
 export type SessionHeaderProps = {
+  sessionId: string;
+  sessionStatus: string;
+  artifacts: Artifact[];
+  primaryRepo?: { repoOwner: string; repoName: string } | null;
   sessionState: SessionSocketState["sessionState"];
   fallbackSessionInfo: {
     repoOwner: string | null;
@@ -30,21 +55,37 @@ export type SessionHeaderProps = {
   connecting: boolean;
   isDetailsOpen: boolean;
   detailsButtonRef: RefObject<HTMLButtonElement | null>;
+  mobileActionsButtonRef: RefObject<HTMLButtonElement | null>;
   onToggleDetails: () => void;
+  onOpenDetails: () => void;
+  onOpenMedia: () => void;
+  onArchive?: () => void | Promise<void>;
+  onUnarchive?: () => void | Promise<void>;
   renameSession: (title: string) => Promise<boolean | undefined>;
 };
 
 export function SessionHeader({
+  sessionId,
+  sessionStatus,
+  artifacts,
+  primaryRepo,
   sessionState,
   fallbackSessionInfo,
   connected,
   connecting,
   isDetailsOpen,
   detailsButtonRef,
+  mobileActionsButtonRef,
   onToggleDetails,
+  onOpenDetails,
+  onOpenMedia,
+  onArchive,
+  onUnarchive,
   renameSession,
 }: SessionHeaderProps) {
   const { isOpen } = useSidebarContext();
+  const [isArchiving, setIsArchiving] = useState(false);
+  const [showArchiveDialog, setShowArchiveDialog] = useState(false);
   const hasFallbackSessionInfo =
     fallbackSessionInfo.repoOwner !== null ||
     fallbackSessionInfo.repoName !== null ||
@@ -62,6 +103,11 @@ export function SessionHeader({
 
   const resolvedTitle =
     optimisticTitle ?? sessionState?.title ?? fallbackSessionInfo.title ?? repoLabel;
+  const { prUrl, previewArtifact, previewUrl, mediaCount } = getSessionActionState(
+    artifacts,
+    primaryRepo
+  );
+  const isArchived = sessionStatus === "archived";
 
   const handleStartRename = () => {
     setTitle(resolvedTitle);
@@ -104,80 +150,169 @@ export function SessionHeader({
     if (!isRenaming) setTitle(sessionState?.title ?? fallbackSessionInfo.title ?? "");
   }, [fallbackSessionInfo.title, sessionState?.title, isRenaming]);
 
+  const handleArchiveToggle = async () => {
+    if (!isArchived) {
+      setShowArchiveDialog(true);
+      return;
+    }
+
+    setIsArchiving(true);
+    try {
+      if (onUnarchive) await onUnarchive();
+    } finally {
+      setIsArchiving(false);
+    }
+  };
+
+  const handleConfirmArchive = async () => {
+    setShowArchiveDialog(false);
+    setIsArchiving(true);
+    try {
+      if (onArchive) await onArchive();
+    } finally {
+      setIsArchiving(false);
+    }
+  };
+
+  const handleCopyLink = async () => {
+    const url = `${window.location.origin}/session/${sessionId}`;
+    await navigator.clipboard.writeText(url);
+    toast.success("Link copied to clipboard");
+  };
+
   return (
-    <header className="border-b border-border-muted flex-shrink-0">
-      <div className="px-4 py-3 flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          {!isOpen && <CollapsedSidebarControls />}
-          <div>
-            {isRenaming ? (
-              <input
-                autoFocus
-                aria-label="Session title"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                onFocus={(e) => e.currentTarget.select()}
-                onBlur={handleRenameSubmit}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    e.currentTarget.blur();
-                  }
-                  if (e.key === "Escape") {
-                    setIsRenaming(false);
-                  }
-                }}
-                className="text-sm bg-transparent text-foreground outline-none focus:ring-inset focus:ring-ring font-medium max-w-40 truncate"
+    <>
+      <header className="border-b border-border-muted flex-shrink-0">
+        <div className="px-4 py-3 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            {!isOpen && <CollapsedSidebarControls />}
+            <div>
+              {isRenaming ? (
+                <input
+                  autoFocus
+                  aria-label="Session title"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  onFocus={(e) => e.currentTarget.select()}
+                  onBlur={handleRenameSubmit}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      e.currentTarget.blur();
+                    }
+                    if (e.key === "Escape") {
+                      setIsRenaming(false);
+                    }
+                  }}
+                  className="text-sm bg-transparent text-foreground outline-none focus:ring-inset focus:ring-ring font-medium max-w-40 truncate"
+                />
+              ) : (
+                <h1
+                  className="text-sm font-medium text-foreground max-w-40 truncate cursor-text"
+                  onClick={handleStartRename}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      handleStartRename();
+                    }
+                  }}
+                  role="button"
+                  tabIndex={0}
+                  title="Click to rename"
+                >
+                  {resolvedTitle}
+                </h1>
+              )}
+              <p className="text-sm text-muted-foreground">{repoLabel}</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-4">
+            <button
+              ref={detailsButtonRef}
+              type="button"
+              onClick={onToggleDetails}
+              className="hidden md:inline-flex lg:hidden px-3 py-1.5 text-sm text-muted-foreground border border-border-muted hover:text-foreground hover:bg-muted transition"
+              aria-label="Toggle session details"
+              aria-controls="session-details-dialog"
+              aria-expanded={isDetailsOpen}
+            >
+              Details
+            </button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  ref={mobileActionsButtonRef}
+                  variant="outline"
+                  size="sm"
+                  className="!px-2 md:hidden"
+                  aria-label="Session actions"
+                >
+                  <MoreIcon className="w-4 h-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={onOpenDetails}>
+                  <SettingsIcon className="w-4 h-4" />
+                  Details
+                </DropdownMenuItem>
+                {previewUrl && (
+                  <DropdownMenuItem asChild>
+                    <a href={previewUrl} target="_blank" rel="noopener noreferrer">
+                      <GlobeIcon className="w-4 h-4" />
+                      View preview
+                      {previewArtifact?.metadata?.previewStatus === "outdated" && " (outdated)"}
+                    </a>
+                  </DropdownMenuItem>
+                )}
+                {prUrl && (
+                  <DropdownMenuItem asChild>
+                    <a href={prUrl} target="_blank" rel="noopener noreferrer">
+                      <GitPrIcon className="w-4 h-4" />
+                      View PR
+                    </a>
+                  </DropdownMenuItem>
+                )}
+                {mediaCount > 0 && (
+                  <DropdownMenuItem onClick={onOpenMedia}>
+                    <FolderIcon className="w-4 h-4" />
+                    Media ({mediaCount})
+                  </DropdownMenuItem>
+                )}
+                <DropdownMenuItem onClick={handleCopyLink}>
+                  <LinkIcon className="w-4 h-4" />
+                  Copy link
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={handleArchiveToggle} disabled={isArchiving}>
+                  <ArchiveIcon className="w-4 h-4" />
+                  {isArchived ? "Unarchive" : "Archive"}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <div className="md:hidden">
+              <CombinedStatusDot
+                connected={connected}
+                connecting={connecting}
+                sandboxStatus={sessionState?.sandboxStatus}
               />
-            ) : (
-              <h1
-                className="text-sm font-medium text-foreground max-w-40 truncate cursor-text"
-                onClick={handleStartRename}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    handleStartRename();
-                  }
-                }}
-                role="button"
-                tabIndex={0}
-                title="Click to rename"
-              >
-                {resolvedTitle}
-              </h1>
-            )}
-            <p className="text-sm text-muted-foreground">{repoLabel}</p>
+            </div>
+            <div className="hidden md:contents">
+              <ConnectionStatus connected={connected} connecting={connecting} />
+              <SandboxStatus
+                status={sessionState?.sandboxStatus}
+                dashboardUrl={sessionState?.sandboxDashboardUrl}
+              />
+            </div>
           </div>
         </div>
-        <div className="flex items-center gap-4">
-          <button
-            ref={detailsButtonRef}
-            type="button"
-            onClick={onToggleDetails}
-            className="lg:hidden px-3 py-1.5 text-sm text-muted-foreground border border-border-muted hover:text-foreground hover:bg-muted transition"
-            aria-label="Toggle session details"
-            aria-controls="session-details-dialog"
-            aria-expanded={isDetailsOpen}
-          >
-            Details
-          </button>
-          <div className="md:hidden">
-            <CombinedStatusDot
-              connected={connected}
-              connecting={connecting}
-              sandboxStatus={sessionState?.sandboxStatus}
-            />
-          </div>
-          <div className="hidden md:contents">
-            <ConnectionStatus connected={connected} connecting={connecting} />
-            <SandboxStatus
-              status={sessionState?.sandboxStatus}
-              dashboardUrl={sessionState?.sandboxDashboardUrl}
-            />
-          </div>
-        </div>
-      </div>
-    </header>
+      </header>
+
+      <ArchiveSessionDialog
+        open={showArchiveDialog}
+        onOpenChange={setShowArchiveDialog}
+        onConfirm={handleConfirmArchive}
+      />
+    </>
   );
 }
 

--- a/packages/web/src/components/session-prompt-composer.test.tsx
+++ b/packages/web/src/components/session-prompt-composer.test.tsx
@@ -9,7 +9,9 @@ import { SessionPromptComposer } from "./session-prompt-composer";
 
 expect.extend(matchers);
 
-vi.mock("@/components/action-bar", () => ({ ActionBar: () => null }));
+vi.mock("@/components/action-bar", () => ({
+  ActionBar: () => <div data-testid="action-bar">actions</div>,
+}));
 vi.mock("@/components/attachment-preview-strip", () => ({
   AttachmentPreviewStrip: () => null,
 }));
@@ -112,5 +114,63 @@ describe("SessionPromptComposer", () => {
     expect(input).not.toHaveClass("pr-24");
     expect(input.parentElement).toHaveClass("flex-wrap", "justify-end");
     expect(actions).toHaveClass("shrink-0", "sm:absolute");
+  });
+
+  it("hides the action bar row below md without leaving spacing", () => {
+    render(<ComposerHarness />);
+
+    expect(screen.getByTestId("action-bar").parentElement).toHaveClass(
+      "mb-3",
+      "hidden",
+      "md:block"
+    );
+  });
+
+  it("can omit the action bar entirely for phone layouts", () => {
+    function HiddenActionBarHarness() {
+      const inputRef = useRef<HTMLTextAreaElement>(null);
+
+      return (
+        <SessionPromptComposer
+          showActionBar={false}
+          session={{
+            id: "session-1",
+            status: "active",
+            artifacts: [],
+            onArchive: vi.fn(),
+            onUnarchive: vi.fn(),
+            onOpenDetails: vi.fn(),
+          }}
+          prompt={{
+            value: "",
+            isProcessing: false,
+            draftLocked: false,
+            inputRef,
+            onSubmit: vi.fn(),
+            onChange: vi.fn(),
+            onKeyDown: vi.fn(),
+            onStopExecution: vi.fn(),
+          }}
+          attachments={{
+            items: [],
+            error: null,
+            isUploading: false,
+            onAdd: vi.fn(),
+            onRemove: vi.fn(),
+          }}
+          model={{
+            selectedModel: "model-1",
+            reasoningEffort: undefined,
+            items: [],
+            onModelChange: vi.fn(),
+            onReasoningEffortChange: vi.fn(),
+          }}
+        />
+      );
+    }
+
+    render(<HiddenActionBarHarness />);
+
+    expect(screen.queryByTestId("action-bar")).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/session-prompt-composer.tsx
+++ b/packages/web/src/components/session-prompt-composer.tsx
@@ -13,6 +13,7 @@ import { ATTACHMENT_ACCEPT, type PendingAttachment } from "@/hooks/use-session-a
 import type { Artifact } from "@/types/session";
 
 type SessionPromptComposerProps = {
+  showActionBar?: boolean;
   session: {
     id: string;
     status: string;
@@ -49,6 +50,7 @@ type SessionPromptComposerProps = {
 };
 
 export function SessionPromptComposer({
+  showActionBar = true,
   session,
   prompt,
   attachments,
@@ -86,18 +88,19 @@ export function SessionPromptComposer({
   return (
     <footer className="min-w-0 border-t border-border-muted flex-shrink-0">
       <form onSubmit={prompt.onSubmit} className="w-full min-w-0 max-w-4xl mx-auto p-4 pb-6">
-        {/* Action bar above input */}
-        <div className="mb-3">
-          <ActionBar
-            sessionId={session.id}
-            sessionStatus={session.status}
-            artifacts={session.artifacts}
-            primaryRepo={session.primaryRepo}
-            onArchive={session.onArchive}
-            onUnarchive={session.onUnarchive}
-            onOpenDetails={session.onOpenDetails}
-          />
-        </div>
+        {showActionBar && (
+          <div className="mb-3 hidden md:block">
+            <ActionBar
+              sessionId={session.id}
+              sessionStatus={session.status}
+              artifacts={session.artifacts}
+              primaryRepo={session.primaryRepo}
+              onArchive={session.onArchive}
+              onUnarchive={session.onUnarchive}
+              onOpenDetails={session.onOpenDetails}
+            />
+          </div>
+        )}
 
         {/* Input container */}
         <div

--- a/packages/web/src/lib/session-actions.ts
+++ b/packages/web/src/lib/session-actions.ts
@@ -1,0 +1,22 @@
+import { findPrArtifactForRepo } from "@/lib/pr-artifacts";
+import { getSafeExternalUrl } from "@/lib/urls";
+import type { Artifact } from "@/types/session";
+
+type PrimaryRepo = { repoOwner: string; repoName: string } | null | undefined;
+
+export function getSessionActionState(artifacts: Artifact[], primaryRepo?: PrimaryRepo) {
+  const prArtifact = primaryRepo
+    ? findPrArtifactForRepo(artifacts, primaryRepo, true)
+    : artifacts.find((artifact) => artifact.type === "pr");
+  const previewArtifact = artifacts.find((artifact) => artifact.type === "preview");
+
+  return {
+    prArtifact,
+    previewArtifact,
+    prUrl: getSafeExternalUrl(prArtifact?.url),
+    previewUrl: getSafeExternalUrl(previewArtifact?.url),
+    mediaCount: artifacts.filter(
+      (artifact) => artifact.type === "screenshot" || artifact.type === "video"
+    ).length,
+  };
+}


### PR DESCRIPTION
## Summary
- move the phone-only session actions into a single `SessionHeader` kebab labeled `Session actions`
- remove the composer `ActionBar` row below `md` while keeping tablet and desktop behavior intact
- share preview/PR/media action selection logic and extend focused tests for phone ordering, callbacks, archive flows, and responsive visibility

## Verification
- `npm test -w @open-inspect/web -- session-header.test.tsx action-bar.test.tsx session-prompt-composer.test.tsx`
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web`
- `npx prettier --write "packages/web/src/lib/session-actions.ts" "packages/web/src/components/action-bar.tsx" "packages/web/src/components/session-prompt-composer.tsx" "packages/web/src/components/session-header.tsx" "packages/web/src/app/(app)/session/[id]/page.tsx" "packages/web/src/components/session-header.test.tsx" "packages/web/src/components/session-prompt-composer.test.tsx" "packages/web/src/components/action-bar.test.tsx"`
- Visual verification on temporary public route at `390x844`; uploaded viewport screenshot artifact `a77b0a65045cc970752f4f6fc12b5259`

## Notes
- Temporary visual verification route was removed before commit.
- Unrelated pre-existing `package-lock.json` worktree changes were left untouched.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/b475dfed1bd0c2163b41d3cfb15ad09c)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a unified session actions menu for phone layouts, including details, previews, media, copy-link, and archive/unarchive actions.
  - Added archive confirmation and loading feedback for session management actions.
  - Added responsive controls that hide inline actions on smaller screens while keeping the actions menu available.
  - Added the option to hide the action bar in the session prompt composer.

- **Bug Fixes**
  - Improved focus restoration when closing session details on mobile devices.
  - Standardized session links, previews, pull requests, and media counts across session actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->