### PR TITLE
Unify phone session actions in the header

### DIFF
--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -130,6 +130,8 @@ function SessionPageContent() {
 
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
   const detailsButtonRef = useRef<HTMLButtonElement>(null);
+  const actionsButtonRef = useRef<HTMLButtonElement>(null);
+  const detailsReturnFocusRef = useRef<HTMLButtonElement>(null);
 
   // Terminal panel state
   const [terminalOpen, setTerminalOpen] = useState(() => {
@@ -150,7 +152,12 @@ function SessionPageContent() {
   const showTerminal = !!(ttydUrl && ttydToken && terminalOpen && !isBelowLg);
 
   const toggleDetails = useCallback(() => {
+    detailsReturnFocusRef.current = detailsButtonRef.current;
     setIsDetailsOpen((prev) => !prev);
+  }, []);
+  const openMobileDetails = useCallback(() => {
+    detailsReturnFocusRef.current = actionsButtonRef.current;
+    setIsDetailsOpen(true);
   }, []);
 
   useEffect(() => {
@@ -167,6 +174,11 @@ function SessionPageContent() {
     () => mediaArtifacts.find((artifact) => artifact.id === selectedMediaArtifactId) ?? null,
     [mediaArtifacts, selectedMediaArtifactId]
   );
+  const primaryRepo =
+    sessionState?.repositories?.[0] ??
+    (sessionState?.repoOwner && sessionState?.repoName
+      ? { repoOwner: sessionState.repoOwner, repoName: sessionState.repoName }
+      : null);
 
   const showTimelineSkeleton = events.length === 0 && (connecting || replaying);
   const resolvedDiff = useMemo(
@@ -249,7 +261,17 @@ function SessionPageContent() {
         connecting={connecting}
         isDetailsOpen={isDetailsOpen}
         detailsButtonRef={detailsButtonRef}
+        actionsButtonRef={actionsButtonRef}
         onToggleDetails={toggleDetails}
+        onOpenMobileDetails={openMobileDetails}
+        actions={{
+          sessionId,
+          sessionStatus: sessionState?.status || "",
+          artifacts,
+          primaryRepo,
+          onArchive: handleArchive,
+          onUnarchive: handleUnarchive,
+        }}
         renameSession={renameSession}
       />
 
@@ -328,7 +350,7 @@ function SessionPageContent() {
           open={isDetailsOpen}
           onOpenChange={setIsDetailsOpen}
           isPhone={isPhone}
-          returnFocusRef={detailsButtonRef}
+          returnFocusRef={detailsReturnFocusRef}
           sessionId={sessionId}
           sessionState={sessionState}
           participants={participants}
@@ -381,11 +403,7 @@ function SessionPageContent() {
           id: sessionId,
           status: sessionState?.status || "",
           artifacts,
-          primaryRepo:
-            sessionState?.repositories?.[0] ??
-            (sessionState?.repoOwner && sessionState?.repoName
-              ? { repoOwner: sessionState.repoOwner, repoName: sessionState.repoName }
-              : null),
+          primaryRepo,
           onArchive: handleArchive,
           onUnarchive: handleUnarchive,
           onOpenDetails: () => setIsDetailsOpen(true),

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/components/session-desktop-layout";
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import { useBrowserLayoutStorage } from "@/hooks/use-browser-layout-storage";
+import { focusSessionDetailsTrigger } from "@/lib/session-details-focus";
 
 type SessionState = ReturnType<typeof useSessionSocket>["sessionState"];
 
@@ -131,7 +132,6 @@ function SessionPageContent() {
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
   const detailsButtonRef = useRef<HTMLButtonElement>(null);
   const actionsButtonRef = useRef<HTMLButtonElement>(null);
-  const detailsReturnFocusRef = useRef<HTMLButtonElement>(null);
 
   // Terminal panel state
   const [terminalOpen, setTerminalOpen] = useState(() => {
@@ -152,13 +152,15 @@ function SessionPageContent() {
   const showTerminal = !!(ttydUrl && ttydToken && terminalOpen && !isBelowLg);
 
   const toggleDetails = useCallback(() => {
-    detailsReturnFocusRef.current = detailsButtonRef.current;
     setIsDetailsOpen((prev) => !prev);
   }, []);
   const openMobileDetails = useCallback(() => {
-    detailsReturnFocusRef.current = actionsButtonRef.current;
     setIsDetailsOpen(true);
   }, []);
+  const focusDetailsTrigger = useCallback(
+    () => focusSessionDetailsTrigger(isPhone, actionsButtonRef.current, detailsButtonRef.current),
+    [isPhone]
+  );
 
   useEffect(() => {
     if (isBelowLg) return;
@@ -221,9 +223,9 @@ function SessionPageContent() {
           return;
         }
       }
-      detailsButtonRef.current?.focus();
+      focusDetailsTrigger();
     });
-  }, [isBelowLg]);
+  }, [focusDetailsTrigger, isBelowLg]);
 
   const sessionWorkspace = (
     <div className="flex h-full flex-1 flex-col overflow-hidden">
@@ -350,7 +352,7 @@ function SessionPageContent() {
           open={isDetailsOpen}
           onOpenChange={setIsDetailsOpen}
           isPhone={isPhone}
-          returnFocusRef={detailsReturnFocusRef}
+          onReturnFocus={focusDetailsTrigger}
           sessionId={sessionId}
           sessionState={sessionState}
           participants={participants}
@@ -406,7 +408,6 @@ function SessionPageContent() {
           primaryRepo,
           onArchive: handleArchive,
           onUnarchive: handleUnarchive,
-          onOpenDetails: () => setIsDetailsOpen(true),
         }}
         prompt={{
           value: prompt,

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -268,7 +268,7 @@ function SessionPageContent() {
         onOpenMobileDetails={openMobileDetails}
         actions={{
           sessionId,
-          sessionStatus: sessionState?.status || "",
+          sessionStatus: sessionState?.status ?? "created",
           artifacts,
           primaryRepo,
           onArchive: handleArchive,
@@ -403,7 +403,7 @@ function SessionPageContent() {
       <SessionPromptComposer
         session={{
           id: sessionId,
-          status: sessionState?.status || "",
+          status: sessionState?.status ?? "created",
           artifacts,
           primaryRepo,
           onArchive: handleArchive,

--- a/packages/web/src/components/action-bar.test.tsx
+++ b/packages/web/src/components/action-bar.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { ActionBar } from "./action-bar";
+import { MobileSessionActions } from "./mobile-session-actions";
 
 expect.extend(matchers);
 
@@ -32,7 +33,6 @@ describe("ActionBar", () => {
             createdAt: 1234,
           },
         ]}
-        onOpenDetails={() => undefined}
       />
     );
 
@@ -80,7 +80,6 @@ describe("ActionBar", () => {
             createdAt: 1236,
           },
         ]}
-        onOpenDetails={() => undefined}
       />
     );
 
@@ -88,14 +87,7 @@ describe("ActionBar", () => {
   });
 
   it("does not render a media count indicator when no media artifacts exist", () => {
-    render(
-      <ActionBar
-        sessionId="session-1"
-        sessionStatus="active"
-        artifacts={[]}
-        onOpenDetails={() => undefined}
-      />
-    );
+    render(<ActionBar sessionId="session-1" sessionStatus="active" artifacts={[]} />);
 
     expect(screen.queryByText(/Media/)).not.toBeInTheDocument();
   });
@@ -104,7 +96,7 @@ describe("ActionBar", () => {
     const onOpenDetails = vi.fn();
     const onOpenMedia = vi.fn();
     render(
-      <ActionBar
+      <MobileSessionActions
         sessionId="session-1"
         sessionStatus="active"
         artifacts={[
@@ -132,7 +124,7 @@ describe("ActionBar", () => {
         ]}
         onOpenDetails={onOpenDetails}
         onOpenMedia={onOpenMedia}
-        variant="mobile-header"
+        triggerRef={{ current: null }}
       />
     );
 
@@ -172,13 +164,14 @@ describe("ActionBar", () => {
         })
     );
     render(
-      <ActionBar
+      <MobileSessionActions
         sessionId="session-1"
         sessionStatus="active"
         artifacts={[]}
         onArchive={onArchive}
         onOpenDetails={vi.fn()}
-        variant="mobile-header"
+        onOpenMedia={vi.fn()}
+        triggerRef={{ current: null }}
       />
     );
 
@@ -223,7 +216,6 @@ describe("repository-aware PR selection", () => {
         sessionStatus="active"
         artifacts={[backendPr, webPr]}
         primaryRepo={{ repoOwner: "acme", repoName: "web" }}
-        onOpenDetails={() => undefined}
       />
     );
 
@@ -233,12 +225,7 @@ describe("repository-aware PR selection", () => {
 
   it("falls back to the first PR artifact without repo context", () => {
     render(
-      <ActionBar
-        sessionId="session-1"
-        sessionStatus="active"
-        artifacts={[backendPr, webPr]}
-        onOpenDetails={() => undefined}
-      />
+      <ActionBar sessionId="session-1" sessionStatus="active" artifacts={[backendPr, webPr]} />
     );
 
     const link = screen.getByRole("link", { name: /view pr/i });

--- a/packages/web/src/components/action-bar.test.tsx
+++ b/packages/web/src/components/action-bar.test.tsx
@@ -2,7 +2,7 @@
 /// <reference types="@testing-library/jest-dom" />
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { ActionBar } from "./action-bar";
 
@@ -102,6 +102,7 @@ describe("ActionBar", () => {
 
   it("consolidates all session actions into the menu on mobile", () => {
     const onOpenDetails = vi.fn();
+    const onOpenMedia = vi.fn();
     render(
       <ActionBar
         sessionId="session-1"
@@ -130,30 +131,72 @@ describe("ActionBar", () => {
           },
         ]}
         onOpenDetails={onOpenDetails}
+        onOpenMedia={onOpenMedia}
+        variant="mobile-header"
       />
     );
 
-    expect(screen.getByRole("link", { name: "View preview" })).toHaveClass(
-      "hidden",
-      "md:inline-flex"
-    );
-    expect(screen.getByRole("link", { name: "View PR" })).toHaveClass("hidden", "md:inline-flex");
-    expect(screen.getByRole("button", { name: "Archive" })).toHaveClass("hidden", "md:inline-flex");
-    expect(screen.getByText("Media (1)")).toHaveClass("hidden", "md:inline-flex");
+    const trigger = screen.getByRole("button", { name: "Session actions" });
+    expect(trigger.parentElement).toHaveClass("md:hidden");
+    expect(screen.queryByRole("button", { name: "Archive" })).not.toBeInTheDocument();
 
-    fireEvent.pointerDown(screen.getByRole("button", { name: "More session actions" }), {
+    fireEvent.pointerDown(trigger, {
       button: 0,
       ctrlKey: false,
     });
 
-    expect(screen.getAllByText("View preview")[1]).toHaveClass("md:hidden");
-    expect(screen.getAllByText("View PR")[1]).toHaveClass("md:hidden");
-    expect(screen.getAllByText("Archive")[1]).toHaveClass("md:hidden");
-    const mediaMenuItem = screen.getAllByText("Media (1)")[1];
-    expect(mediaMenuItem).toHaveClass("md:hidden");
+    expect(screen.getAllByRole("menuitem").map((item) => item.textContent)).toEqual([
+      "Details",
+      "View preview",
+      "View PR",
+      "Media (1)",
+      "Copy link",
+      "Archive",
+    ]);
+    expect(screen.getByRole("separator")).toBeInTheDocument();
 
-    fireEvent.click(mediaMenuItem);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Details" }));
     expect(onOpenDetails).toHaveBeenCalledOnce();
+
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    fireEvent.click(screen.getByRole("menuitem", { name: "Media (1)" }));
+    expect(onOpenMedia).toHaveBeenCalledOnce();
+  });
+
+  it("confirms archive and keeps the action pending until the callback settles", async () => {
+    let resolveArchive: (() => void) | undefined;
+    const onArchive = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveArchive = resolve;
+        })
+    );
+    render(
+      <ActionBar
+        sessionId="session-1"
+        sessionStatus="active"
+        artifacts={[]}
+        onArchive={onArchive}
+        onOpenDetails={vi.fn()}
+        variant="mobile-header"
+      />
+    );
+
+    const trigger = screen.getByRole("button", { name: "Session actions" });
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    fireEvent.click(screen.getByRole("menuitem", { name: "Archive" }));
+
+    expect(onArchive).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Archive" }));
+    expect(onArchive).toHaveBeenCalledOnce();
+
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    expect(screen.getByRole("menuitem", { name: "Archive" })).toHaveAttribute("data-disabled");
+
+    resolveArchive?.();
+    await waitFor(() =>
+      expect(screen.getByRole("menuitem", { name: "Archive" })).not.toHaveAttribute("data-disabled")
+    );
   });
 });
 

--- a/packages/web/src/components/action-bar.tsx
+++ b/packages/web/src/components/action-bar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type RefObject } from "react";
 import { toast } from "sonner";
 import { ArchiveSessionDialog } from "@/components/archive-session-dialog";
 import type { Artifact } from "@/types/session";
@@ -12,18 +12,20 @@ import {
   LinkIcon,
   GitHubIcon,
   FolderIcon,
+  SidebarIcon,
 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { getSafeExternalUrl } from "@/lib/urls";
 import { findPrArtifactForRepo } from "@/lib/pr-artifacts";
 
-interface ActionBarProps {
+export interface ActionBarProps {
   sessionId: string;
   sessionStatus: string;
   artifacts: Artifact[];
@@ -36,6 +38,9 @@ interface ActionBarProps {
   onArchive?: () => void | Promise<void>;
   onUnarchive?: () => void | Promise<void>;
   onOpenDetails: () => void;
+  onOpenMedia?: () => void;
+  variant?: "composer" | "mobile-header";
+  triggerRef?: RefObject<HTMLButtonElement | null>;
 }
 
 export function ActionBar({
@@ -46,6 +51,9 @@ export function ActionBar({
   onArchive,
   onUnarchive,
   onOpenDetails,
+  onOpenMedia = onOpenDetails,
+  variant = "composer",
+  triggerRef,
 }: ActionBarProps) {
   const [isArchiving, setIsArchiving] = useState(false);
   const [showArchiveDialog, setShowArchiveDialog] = useState(false);
@@ -61,6 +69,7 @@ export function ActionBar({
   const prUrl = getSafeExternalUrl(prArtifact?.url);
 
   const isArchived = sessionStatus === "archived";
+  const isMobileHeader = variant === "mobile-header";
 
   const handleArchiveToggle = async () => {
     if (!isArchived) {
@@ -94,9 +103,9 @@ export function ActionBar({
 
   return (
     <>
-      <div className="flex flex-wrap items-stretch gap-2">
+      <div className={isMobileHeader ? "md:hidden" : "flex flex-wrap items-stretch gap-2"}>
         {/* View Preview */}
-        {previewUrl && (
+        {!isMobileHeader && previewUrl && (
           <Button variant="outline" size="sm" className="hidden gap-1.5 md:inline-flex" asChild>
             <a href={previewUrl} target="_blank" rel="noopener noreferrer">
               <GlobeIcon className="w-4 h-4" />
@@ -109,7 +118,7 @@ export function ActionBar({
         )}
 
         {/* View PR */}
-        {prUrl && (
+        {!isMobileHeader && prUrl && (
           <Button variant="outline" size="sm" className="hidden gap-1.5 md:inline-flex" asChild>
             <a href={prUrl} target="_blank" rel="noopener noreferrer">
               <GitPrIcon className="w-4 h-4" />
@@ -119,18 +128,20 @@ export function ActionBar({
         )}
 
         {/* Archive/Unarchive */}
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={handleArchiveToggle}
-          disabled={isArchiving}
-          className="hidden gap-1.5 md:inline-flex"
-        >
-          <ArchiveIcon className="w-4 h-4" />
-          <span>{isArchived ? "Unarchive" : "Archive"}</span>
-        </Button>
+        {!isMobileHeader && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleArchiveToggle}
+            disabled={isArchiving}
+            className="hidden gap-1.5 md:inline-flex"
+          >
+            <ArchiveIcon className="w-4 h-4" />
+            <span>{isArchived ? "Unarchive" : "Archive"}</span>
+          </Button>
+        )}
 
-        {mediaCount > 0 && (
+        {!isMobileHeader && mediaCount > 0 && (
           <div className="hidden items-center rounded-md border border-border-muted px-3 text-sm text-muted-foreground md:inline-flex">
             Media ({mediaCount})
           </div>
@@ -139,13 +150,25 @@ export function ActionBar({
         {/* More menu */}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="sm" className="!px-2" aria-label="More session actions">
+            <Button
+              ref={triggerRef}
+              variant="outline"
+              size="sm"
+              className="!px-2"
+              aria-label={isMobileHeader ? "Session actions" : "More session actions"}
+            >
               <MoreIcon className="w-4 h-4" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" side="top">
+          <DropdownMenuContent align="end" side={isMobileHeader ? "bottom" : "top"}>
+            {isMobileHeader && (
+              <DropdownMenuItem onClick={onOpenDetails}>
+                <SidebarIcon className="w-4 h-4" />
+                Details
+              </DropdownMenuItem>
+            )}
             {previewUrl && (
-              <DropdownMenuItem className="md:hidden" asChild>
+              <DropdownMenuItem className={isMobileHeader ? undefined : "md:hidden"} asChild>
                 <a href={previewUrl} target="_blank" rel="noopener noreferrer">
                   <GlobeIcon className="w-4 h-4" />
                   View preview
@@ -154,23 +177,18 @@ export function ActionBar({
               </DropdownMenuItem>
             )}
             {prUrl && (
-              <DropdownMenuItem className="md:hidden" asChild>
+              <DropdownMenuItem className={isMobileHeader ? undefined : "md:hidden"} asChild>
                 <a href={prUrl} target="_blank" rel="noopener noreferrer">
                   <GitPrIcon className="w-4 h-4" />
                   View PR
                 </a>
               </DropdownMenuItem>
             )}
-            <DropdownMenuItem
-              className="md:hidden"
-              onClick={handleArchiveToggle}
-              disabled={isArchiving}
-            >
-              <ArchiveIcon className="w-4 h-4" />
-              {isArchived ? "Unarchive" : "Archive"}
-            </DropdownMenuItem>
             {mediaCount > 0 && (
-              <DropdownMenuItem className="md:hidden" onClick={onOpenDetails}>
+              <DropdownMenuItem
+                className={isMobileHeader ? undefined : "md:hidden"}
+                onClick={onOpenMedia}
+              >
                 <FolderIcon className="w-4 h-4" />
                 Media ({mediaCount})
               </DropdownMenuItem>
@@ -179,7 +197,7 @@ export function ActionBar({
               <LinkIcon className="w-4 h-4" />
               Copy link
             </DropdownMenuItem>
-            {prUrl && (
+            {!isMobileHeader && prUrl && (
               <DropdownMenuItem className="hidden md:flex" asChild>
                 <a href={prUrl} target="_blank" rel="noopener noreferrer">
                   <GitHubIcon className="w-4 h-4" />
@@ -187,6 +205,15 @@ export function ActionBar({
                 </a>
               </DropdownMenuItem>
             )}
+            {isMobileHeader && <DropdownMenuSeparator />}
+            <DropdownMenuItem
+              className={isMobileHeader ? undefined : "md:hidden"}
+              onClick={handleArchiveToggle}
+              disabled={isArchiving}
+            >
+              <ArchiveIcon className="w-4 h-4" />
+              {isArchived ? "Unarchive" : "Archive"}
+            </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/packages/web/src/components/action-bar.tsx
+++ b/packages/web/src/components/action-bar.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useState, type RefObject } from "react";
-import { toast } from "sonner";
 import { ArchiveSessionDialog } from "@/components/archive-session-dialog";
-import type { Artifact } from "@/types/session";
+import {
+  resolveSessionActions,
+  useSessionActionControls,
+  type SessionActionProps,
+} from "@/components/session-actions";
 import {
   GlobeIcon,
   GitPrIcon,
@@ -11,37 +13,16 @@ import {
   MoreIcon,
   LinkIcon,
   GitHubIcon,
-  FolderIcon,
-  SidebarIcon,
 } from "@/components/ui/icons";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { getSafeExternalUrl } from "@/lib/urls";
-import { findPrArtifactForRepo } from "@/lib/pr-artifacts";
 
-export interface ActionBarProps {
-  sessionId: string;
-  sessionStatus: string;
-  artifacts: Artifact[];
-  /**
-   * The session's primary repository. When present, "View PR" is selected
-   * repository-aware (the primary's PR) instead of taking the first PR
-   * artifact — in a multi-repo session those can differ.
-   */
-  primaryRepo?: { repoOwner: string; repoName: string } | null;
-  onArchive?: () => void | Promise<void>;
-  onUnarchive?: () => void | Promise<void>;
-  onOpenDetails: () => void;
-  onOpenMedia?: () => void;
-  variant?: "composer" | "mobile-header";
-  triggerRef?: RefObject<HTMLButtonElement | null>;
-}
+export type ActionBarProps = SessionActionProps;
 
 export function ActionBar({
   sessionId,
@@ -50,62 +31,23 @@ export function ActionBar({
   primaryRepo,
   onArchive,
   onUnarchive,
-  onOpenDetails,
-  onOpenMedia = onOpenDetails,
-  variant = "composer",
-  triggerRef,
 }: ActionBarProps) {
-  const [isArchiving, setIsArchiving] = useState(false);
-  const [showArchiveDialog, setShowArchiveDialog] = useState(false);
-
-  const prArtifact = primaryRepo
-    ? findPrArtifactForRepo(artifacts, primaryRepo, true)
-    : artifacts.find((a) => a.type === "pr");
-  const previewArtifact = artifacts.find((a) => a.type === "preview");
-  const mediaCount = artifacts.filter(
-    (artifact) => artifact.type === "screenshot" || artifact.type === "video"
-  ).length;
-  const previewUrl = getSafeExternalUrl(previewArtifact?.url);
-  const prUrl = getSafeExternalUrl(prArtifact?.url);
-
-  const isArchived = sessionStatus === "archived";
-  const isMobileHeader = variant === "mobile-header";
-
-  const handleArchiveToggle = async () => {
-    if (!isArchived) {
-      setShowArchiveDialog(true);
-      return;
-    }
-
-    setIsArchiving(true);
-    try {
-      if (onUnarchive) await onUnarchive();
-    } finally {
-      setIsArchiving(false);
-    }
-  };
-
-  const handleConfirmArchive = async () => {
-    setShowArchiveDialog(false);
-    setIsArchiving(true);
-    try {
-      if (onArchive) await onArchive();
-    } finally {
-      setIsArchiving(false);
-    }
-  };
-
-  const handleCopyLink = async () => {
-    const url = `${window.location.origin}/session/${sessionId}`;
-    await navigator.clipboard.writeText(url);
-    toast.success("Link copied to clipboard");
-  };
+  const { previewArtifact, previewUrl, prUrl, mediaCount } = resolveSessionActions(
+    artifacts,
+    primaryRepo
+  );
+  const controls = useSessionActionControls({
+    sessionId,
+    sessionStatus,
+    onArchive,
+    onUnarchive,
+  });
 
   return (
     <>
-      <div className={isMobileHeader ? "md:hidden" : "flex flex-wrap items-stretch gap-2"}>
+      <div className="flex flex-wrap items-stretch gap-2">
         {/* View Preview */}
-        {!isMobileHeader && previewUrl && (
+        {previewUrl && (
           <Button variant="outline" size="sm" className="hidden gap-1.5 md:inline-flex" asChild>
             <a href={previewUrl} target="_blank" rel="noopener noreferrer">
               <GlobeIcon className="w-4 h-4" />
@@ -118,7 +60,7 @@ export function ActionBar({
         )}
 
         {/* View PR */}
-        {!isMobileHeader && prUrl && (
+        {prUrl && (
           <Button variant="outline" size="sm" className="hidden gap-1.5 md:inline-flex" asChild>
             <a href={prUrl} target="_blank" rel="noopener noreferrer">
               <GitPrIcon className="w-4 h-4" />
@@ -128,20 +70,18 @@ export function ActionBar({
         )}
 
         {/* Archive/Unarchive */}
-        {!isMobileHeader && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleArchiveToggle}
-            disabled={isArchiving}
-            className="hidden gap-1.5 md:inline-flex"
-          >
-            <ArchiveIcon className="w-4 h-4" />
-            <span>{isArchived ? "Unarchive" : "Archive"}</span>
-          </Button>
-        )}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={controls.handleArchiveToggle}
+          disabled={controls.isArchiving}
+          className="hidden gap-1.5 md:inline-flex"
+        >
+          <ArchiveIcon className="w-4 h-4" />
+          <span>{controls.isArchived ? "Unarchive" : "Archive"}</span>
+        </Button>
 
-        {!isMobileHeader && mediaCount > 0 && (
+        {mediaCount > 0 && (
           <div className="hidden items-center rounded-md border border-border-muted px-3 text-sm text-muted-foreground md:inline-flex">
             Media ({mediaCount})
           </div>
@@ -150,54 +90,16 @@ export function ActionBar({
         {/* More menu */}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button
-              ref={triggerRef}
-              variant="outline"
-              size="sm"
-              className="!px-2"
-              aria-label={isMobileHeader ? "Session actions" : "More session actions"}
-            >
+            <Button variant="outline" size="sm" className="!px-2" aria-label="More session actions">
               <MoreIcon className="w-4 h-4" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" side={isMobileHeader ? "bottom" : "top"}>
-            {isMobileHeader && (
-              <DropdownMenuItem onClick={onOpenDetails}>
-                <SidebarIcon className="w-4 h-4" />
-                Details
-              </DropdownMenuItem>
-            )}
-            {previewUrl && (
-              <DropdownMenuItem className={isMobileHeader ? undefined : "md:hidden"} asChild>
-                <a href={previewUrl} target="_blank" rel="noopener noreferrer">
-                  <GlobeIcon className="w-4 h-4" />
-                  View preview
-                  {previewArtifact?.metadata?.previewStatus === "outdated" && " (outdated)"}
-                </a>
-              </DropdownMenuItem>
-            )}
-            {prUrl && (
-              <DropdownMenuItem className={isMobileHeader ? undefined : "md:hidden"} asChild>
-                <a href={prUrl} target="_blank" rel="noopener noreferrer">
-                  <GitPrIcon className="w-4 h-4" />
-                  View PR
-                </a>
-              </DropdownMenuItem>
-            )}
-            {mediaCount > 0 && (
-              <DropdownMenuItem
-                className={isMobileHeader ? undefined : "md:hidden"}
-                onClick={onOpenMedia}
-              >
-                <FolderIcon className="w-4 h-4" />
-                Media ({mediaCount})
-              </DropdownMenuItem>
-            )}
-            <DropdownMenuItem onClick={handleCopyLink}>
+          <DropdownMenuContent align="end" side="top">
+            <DropdownMenuItem onClick={controls.handleCopyLink}>
               <LinkIcon className="w-4 h-4" />
               Copy link
             </DropdownMenuItem>
-            {!isMobileHeader && prUrl && (
+            {prUrl && (
               <DropdownMenuItem className="hidden md:flex" asChild>
                 <a href={prUrl} target="_blank" rel="noopener noreferrer">
                   <GitHubIcon className="w-4 h-4" />
@@ -205,23 +107,14 @@ export function ActionBar({
                 </a>
               </DropdownMenuItem>
             )}
-            {isMobileHeader && <DropdownMenuSeparator />}
-            <DropdownMenuItem
-              className={isMobileHeader ? undefined : "md:hidden"}
-              onClick={handleArchiveToggle}
-              disabled={isArchiving}
-            >
-              <ArchiveIcon className="w-4 h-4" />
-              {isArchived ? "Unarchive" : "Archive"}
-            </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
 
       <ArchiveSessionDialog
-        open={showArchiveDialog}
-        onOpenChange={setShowArchiveDialog}
-        onConfirm={handleConfirmArchive}
+        open={controls.showArchiveDialog}
+        onOpenChange={controls.setShowArchiveDialog}
+        onConfirm={controls.handleConfirmArchive}
       />
     </>
   );

--- a/packages/web/src/components/mobile-session-actions.tsx
+++ b/packages/web/src/components/mobile-session-actions.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import type { RefObject } from "react";
+import { ArchiveSessionDialog } from "@/components/archive-session-dialog";
+import {
+  resolveSessionActions,
+  useSessionActionControls,
+  type SessionActionProps,
+} from "@/components/session-actions";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  ArchiveIcon,
+  FolderIcon,
+  GitPrIcon,
+  GlobeIcon,
+  LinkIcon,
+  MoreIcon,
+  SidebarIcon,
+} from "@/components/ui/icons";
+
+interface MobileSessionActionsProps extends SessionActionProps {
+  triggerRef: RefObject<HTMLButtonElement | null>;
+  onOpenDetails: () => void;
+  onOpenMedia: () => void;
+}
+
+export function MobileSessionActions({
+  triggerRef,
+  onOpenDetails,
+  onOpenMedia,
+  ...actions
+}: MobileSessionActionsProps) {
+  const { previewArtifact, previewUrl, prUrl, mediaCount } = resolveSessionActions(
+    actions.artifacts,
+    actions.primaryRepo
+  );
+  const controls = useSessionActionControls(actions);
+
+  return (
+    <>
+      <div className="md:hidden">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              ref={triggerRef}
+              variant="outline"
+              size="sm"
+              className="!px-2"
+              aria-label="Session actions"
+            >
+              <MoreIcon className="w-4 h-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" side="bottom">
+            <DropdownMenuItem onClick={onOpenDetails}>
+              <SidebarIcon className="w-4 h-4" />
+              Details
+            </DropdownMenuItem>
+            {previewUrl && (
+              <DropdownMenuItem asChild>
+                <a href={previewUrl} target="_blank" rel="noopener noreferrer">
+                  <GlobeIcon className="w-4 h-4" />
+                  View preview
+                  {previewArtifact?.metadata?.previewStatus === "outdated" && " (outdated)"}
+                </a>
+              </DropdownMenuItem>
+            )}
+            {prUrl && (
+              <DropdownMenuItem asChild>
+                <a href={prUrl} target="_blank" rel="noopener noreferrer">
+                  <GitPrIcon className="w-4 h-4" />
+                  View PR
+                </a>
+              </DropdownMenuItem>
+            )}
+            {mediaCount > 0 && (
+              <DropdownMenuItem onClick={onOpenMedia}>
+                <FolderIcon className="w-4 h-4" />
+                Media ({mediaCount})
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuItem onClick={controls.handleCopyLink}>
+              <LinkIcon className="w-4 h-4" />
+              Copy link
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={controls.handleArchiveToggle}
+              disabled={controls.isArchiving}
+            >
+              <ArchiveIcon className="w-4 h-4" />
+              {controls.isArchived ? "Unarchive" : "Archive"}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <ArchiveSessionDialog
+        open={controls.showArchiveDialog}
+        onOpenChange={controls.setShowArchiveDialog}
+        onConfirm={controls.handleConfirmArchive}
+      />
+    </>
+  );
+}

--- a/packages/web/src/components/session-actions.test.tsx
+++ b/packages/web/src/components/session-actions.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import { useSessionActionControls } from "./session-actions";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useSessionActionControls", () => {
+  it("reports archive and unarchive failures without rejecting", async () => {
+    const archive = renderHook(() =>
+      useSessionActionControls({
+        sessionId: "session-1",
+        sessionStatus: "active",
+        onArchive: () => Promise.reject(new Error("archive failed")),
+      })
+    );
+    const unarchive = renderHook(() =>
+      useSessionActionControls({
+        sessionId: "session-1",
+        sessionStatus: "archived",
+        onUnarchive: () => Promise.reject(new Error("unarchive failed")),
+      })
+    );
+
+    await act(() => archive.result.current.handleConfirmArchive());
+    await act(() => unarchive.result.current.handleArchiveToggle());
+
+    expect(toast.error).toHaveBeenCalledWith("Failed to archive session");
+    expect(toast.error).toHaveBeenCalledWith("Failed to unarchive session");
+    expect(archive.result.current.isArchiving).toBe(false);
+    expect(unarchive.result.current.isArchiving).toBe(false);
+  });
+
+  it("reports clipboard failures without rejecting", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockRejectedValue(new Error("permission denied")) },
+    });
+    const { result } = renderHook(() =>
+      useSessionActionControls({ sessionId: "session-1", sessionStatus: "active" })
+    );
+
+    await act(() => result.current.handleCopyLink());
+
+    expect(toast.error).toHaveBeenCalledWith("Failed to copy link");
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/components/session-actions.ts
+++ b/packages/web/src/components/session-actions.ts
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { findPrArtifactForRepo } from "@/lib/pr-artifacts";
+import { getSafeExternalUrl } from "@/lib/urls";
+import type { Artifact } from "@/types/session";
+
+export interface SessionActionProps {
+  sessionId: string;
+  sessionStatus: string;
+  artifacts: Artifact[];
+  /** Select the repository's PR instead of the first PR in multi-repo sessions. */
+  primaryRepo?: { repoOwner: string; repoName: string } | null;
+  onArchive?: () => void | Promise<void>;
+  onUnarchive?: () => void | Promise<void>;
+}
+
+export function resolveSessionActions(
+  artifacts: Artifact[],
+  primaryRepo?: SessionActionProps["primaryRepo"]
+) {
+  const prArtifact = primaryRepo
+    ? findPrArtifactForRepo(artifacts, primaryRepo, true)
+    : artifacts.find((artifact) => artifact.type === "pr");
+  const previewArtifact = artifacts.find((artifact) => artifact.type === "preview");
+
+  return {
+    previewArtifact,
+    previewUrl: getSafeExternalUrl(previewArtifact?.url),
+    prUrl: getSafeExternalUrl(prArtifact?.url),
+    mediaCount: artifacts.filter(
+      (artifact) => artifact.type === "screenshot" || artifact.type === "video"
+    ).length,
+  };
+}
+
+export function useSessionActionControls({
+  sessionId,
+  sessionStatus,
+  onArchive,
+  onUnarchive,
+}: Pick<SessionActionProps, "sessionId" | "sessionStatus" | "onArchive" | "onUnarchive">) {
+  const [isArchiving, setIsArchiving] = useState(false);
+  const [showArchiveDialog, setShowArchiveDialog] = useState(false);
+  const isArchived = sessionStatus === "archived";
+
+  const handleArchiveToggle = async () => {
+    if (!isArchived) {
+      setShowArchiveDialog(true);
+      return;
+    }
+
+    setIsArchiving(true);
+    try {
+      if (onUnarchive) await onUnarchive();
+    } finally {
+      setIsArchiving(false);
+    }
+  };
+
+  const handleConfirmArchive = async () => {
+    setShowArchiveDialog(false);
+    setIsArchiving(true);
+    try {
+      if (onArchive) await onArchive();
+    } finally {
+      setIsArchiving(false);
+    }
+  };
+
+  const handleCopyLink = async () => {
+    const url = `${window.location.origin}/session/${sessionId}`;
+    await navigator.clipboard.writeText(url);
+    toast.success("Link copied to clipboard");
+  };
+
+  return {
+    isArchived,
+    isArchiving,
+    showArchiveDialog,
+    setShowArchiveDialog,
+    handleArchiveToggle,
+    handleConfirmArchive,
+    handleCopyLink,
+  };
+}

--- a/packages/web/src/components/session-actions.ts
+++ b/packages/web/src/components/session-actions.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import type { SessionStatus } from "@open-inspect/shared";
 import { toast } from "sonner";
 import { findPrArtifactForRepo } from "@/lib/pr-artifacts";
 import { getSafeExternalUrl } from "@/lib/urls";
@@ -8,7 +9,7 @@ import type { Artifact } from "@/types/session";
 
 export interface SessionActionProps {
   sessionId: string;
-  sessionStatus: string;
+  sessionStatus: SessionStatus;
   artifacts: Artifact[];
   /** Select the repository's PR instead of the first PR in multi-repo sessions. */
   primaryRepo?: { repoOwner: string; repoName: string } | null;
@@ -54,6 +55,8 @@ export function useSessionActionControls({
     setIsArchiving(true);
     try {
       if (onUnarchive) await onUnarchive();
+    } catch {
+      toast.error("Failed to unarchive session");
     } finally {
       setIsArchiving(false);
     }
@@ -64,6 +67,8 @@ export function useSessionActionControls({
     setIsArchiving(true);
     try {
       if (onArchive) await onArchive();
+    } catch {
+      toast.error("Failed to archive session");
     } finally {
       setIsArchiving(false);
     }
@@ -71,8 +76,12 @@ export function useSessionActionControls({
 
   const handleCopyLink = async () => {
     const url = `${window.location.origin}/session/${sessionId}`;
-    await navigator.clipboard.writeText(url);
-    toast.success("Link copied to clipboard");
+    try {
+      await navigator.clipboard.writeText(url);
+      toast.success("Link copied to clipboard");
+    } catch {
+      toast.error("Failed to copy link");
+    }
   };
 
   return {

--- a/packages/web/src/components/session-details-overlay.tsx
+++ b/packages/web/src/components/session-details-overlay.tsx
@@ -6,7 +6,6 @@ import {
   useRef,
   useState,
   type KeyboardEvent as ReactKeyboardEvent,
-  type RefObject,
   type TouchEvent,
 } from "react";
 import {
@@ -18,7 +17,7 @@ interface SessionDetailsOverlayProps extends SessionRightSidebarContentProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   isPhone: boolean;
-  returnFocusRef?: RefObject<HTMLElement | null>;
+  onReturnFocus?: () => void;
 }
 
 const FOCUSABLE_SELECTOR = [
@@ -34,7 +33,7 @@ export function SessionDetailsOverlay({
   open,
   onOpenChange,
   isPhone,
-  returnFocusRef,
+  onReturnFocus,
   sessionId,
   sessionState,
   participants,
@@ -62,8 +61,8 @@ export function SessionDetailsOverlay({
   const closeOverlay = useCallback(() => {
     onOpenChange(false);
     resetSheetDragState();
-    returnFocusRef?.current?.focus();
-  }, [onOpenChange, resetSheetDragState, returnFocusRef]);
+    onReturnFocus?.();
+  }, [onOpenChange, onReturnFocus, resetSheetDragState]);
 
   const handleSheetTouchStart = useCallback((event: TouchEvent<HTMLDivElement>) => {
     const startY = event.touches[0]?.clientY;

--- a/packages/web/src/components/session-header.test.tsx
+++ b/packages/web/src/components/session-header.test.tsx
@@ -2,8 +2,8 @@
 /// <reference types="@testing-library/jest-dom" />
 
 import { createRef } from "react";
-import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { SessionHeader } from "./session-header";
 
@@ -16,6 +16,14 @@ vi.mock("@/components/sidebar-layout", () => ({
   }),
 }));
 
+afterEach(cleanup);
+
+const actions = {
+  sessionId: "session-1",
+  sessionStatus: "active",
+  artifacts: [],
+};
+
 describe("SessionHeader", () => {
   it("renders no-repository fallback data as loaded while socket state is absent", () => {
     render(
@@ -26,7 +34,10 @@ describe("SessionHeader", () => {
         connecting={true}
         isDetailsOpen={false}
         detailsButtonRef={createRef<HTMLButtonElement>()}
+        actionsButtonRef={createRef<HTMLButtonElement>()}
         onToggleDetails={vi.fn()}
+        onOpenMobileDetails={vi.fn()}
+        actions={actions}
         renameSession={vi.fn()}
       />
     );
@@ -34,5 +45,38 @@ describe("SessionHeader", () => {
     expect(screen.getByRole("button", { name: "Incident sweep" })).toBeInTheDocument();
     expect(screen.getByText("No repository")).toBeInTheDocument();
     expect(screen.queryByText("Loading session...")).not.toBeInTheDocument();
+  });
+
+  it("replaces the phone Details control with the unified actions menu", () => {
+    const onToggleDetails = vi.fn();
+    const onOpenMobileDetails = vi.fn();
+    render(
+      <SessionHeader
+        sessionState={null}
+        fallbackSessionInfo={{ repoOwner: "acme", repoName: "web", title: "Mobile menu" }}
+        connected
+        connecting={false}
+        isDetailsOpen={false}
+        detailsButtonRef={createRef<HTMLButtonElement>()}
+        actionsButtonRef={createRef<HTMLButtonElement>()}
+        onToggleDetails={onToggleDetails}
+        onOpenMobileDetails={onOpenMobileDetails}
+        actions={actions}
+        renameSession={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Toggle session details" })).toHaveClass(
+      "hidden",
+      "md:block",
+      "lg:hidden"
+    );
+    const trigger = screen.getByRole("button", { name: "Session actions" });
+    expect(trigger.parentElement).toHaveClass("md:hidden");
+
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+    fireEvent.click(screen.getByRole("menuitem", { name: "Details" }));
+    expect(onOpenMobileDetails).toHaveBeenCalledOnce();
+    expect(onToggleDetails).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/session-header.test.tsx
+++ b/packages/web/src/components/session-header.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { SessionHeader } from "./session-header";
+import type { SessionActionProps } from "./session-actions";
 
 expect.extend(matchers);
 
@@ -18,7 +19,7 @@ vi.mock("@/components/sidebar-layout", () => ({
 
 afterEach(cleanup);
 
-const actions = {
+const actions: SessionActionProps = {
   sessionId: "session-1",
   sessionStatus: "active",
   artifacts: [],

--- a/packages/web/src/components/session-header.tsx
+++ b/packages/web/src/components/session-header.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, type RefObject } from "react";
 import { CollapsedSidebarControls, useSidebarContext } from "@/components/sidebar-layout";
+import { ActionBar, type ActionBarProps } from "@/components/action-bar";
 import type { useSessionSocket } from "@/hooks/use-session-socket";
 import { formatRepoLabel } from "@/lib/repo-label";
 
@@ -30,7 +31,10 @@ export type SessionHeaderProps = {
   connecting: boolean;
   isDetailsOpen: boolean;
   detailsButtonRef: RefObject<HTMLButtonElement | null>;
+  actionsButtonRef: RefObject<HTMLButtonElement | null>;
   onToggleDetails: () => void;
+  onOpenMobileDetails: () => void;
+  actions: Omit<ActionBarProps, "onOpenDetails" | "onOpenMedia" | "variant" | "triggerRef">;
   renameSession: (title: string) => Promise<boolean | undefined>;
 };
 
@@ -41,7 +45,10 @@ export function SessionHeader({
   connecting,
   isDetailsOpen,
   detailsButtonRef,
+  actionsButtonRef,
   onToggleDetails,
+  onOpenMobileDetails,
+  actions,
   renameSession,
 }: SessionHeaderProps) {
   const { isOpen } = useSidebarContext();
@@ -154,13 +161,20 @@ export function SessionHeader({
             ref={detailsButtonRef}
             type="button"
             onClick={onToggleDetails}
-            className="lg:hidden px-3 py-1.5 text-sm text-muted-foreground border border-border-muted hover:text-foreground hover:bg-muted transition"
+            className="hidden md:block lg:hidden px-3 py-1.5 text-sm text-muted-foreground border border-border-muted hover:text-foreground hover:bg-muted transition"
             aria-label="Toggle session details"
             aria-controls="session-details-dialog"
             aria-expanded={isDetailsOpen}
           >
             Details
           </button>
+          <ActionBar
+            {...actions}
+            variant="mobile-header"
+            triggerRef={actionsButtonRef}
+            onOpenDetails={onOpenMobileDetails}
+            onOpenMedia={onOpenMobileDetails}
+          />
           <div className="md:hidden">
             <CombinedStatusDot
               connected={connected}

--- a/packages/web/src/components/session-header.tsx
+++ b/packages/web/src/components/session-header.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState, type RefObject } from "react";
 import { CollapsedSidebarControls, useSidebarContext } from "@/components/sidebar-layout";
-import { ActionBar, type ActionBarProps } from "@/components/action-bar";
+import { MobileSessionActions } from "@/components/mobile-session-actions";
+import type { SessionActionProps } from "@/components/session-actions";
 import type { useSessionSocket } from "@/hooks/use-session-socket";
 import { formatRepoLabel } from "@/lib/repo-label";
 
@@ -34,7 +35,7 @@ export type SessionHeaderProps = {
   actionsButtonRef: RefObject<HTMLButtonElement | null>;
   onToggleDetails: () => void;
   onOpenMobileDetails: () => void;
-  actions: Omit<ActionBarProps, "onOpenDetails" | "onOpenMedia" | "variant" | "triggerRef">;
+  actions: SessionActionProps;
   renameSession: (title: string) => Promise<boolean | undefined>;
 };
 
@@ -168,9 +169,8 @@ export function SessionHeader({
           >
             Details
           </button>
-          <ActionBar
+          <MobileSessionActions
             {...actions}
-            variant="mobile-header"
             triggerRef={actionsButtonRef}
             onOpenDetails={onOpenMobileDetails}
             onOpenMedia={onOpenMobileDetails}

--- a/packages/web/src/components/session-prompt-composer.test.tsx
+++ b/packages/web/src/components/session-prompt-composer.test.tsx
@@ -47,7 +47,6 @@ function ComposerHarness({
         artifacts: [],
         onArchive: vi.fn(),
         onUnarchive: vi.fn(),
-        onOpenDetails: vi.fn(),
       }}
       prompt={{
         value,

--- a/packages/web/src/components/session-prompt-composer.test.tsx
+++ b/packages/web/src/components/session-prompt-composer.test.tsx
@@ -9,7 +9,9 @@ import { SessionPromptComposer } from "./session-prompt-composer";
 
 expect.extend(matchers);
 
-vi.mock("@/components/action-bar", () => ({ ActionBar: () => null }));
+vi.mock("@/components/action-bar", () => ({
+  ActionBar: () => <div data-testid="action-bar" />,
+}));
 vi.mock("@/components/attachment-preview-strip", () => ({
   AttachmentPreviewStrip: () => null,
 }));
@@ -112,5 +114,15 @@ describe("SessionPromptComposer", () => {
     expect(input).not.toHaveClass("pr-24");
     expect(input.parentElement).toHaveClass("flex-wrap", "justify-end");
     expect(actions).toHaveClass("shrink-0", "sm:absolute");
+  });
+
+  it("removes the action bar row and spacing below md", () => {
+    render(<ComposerHarness />);
+
+    expect(screen.getByTestId("action-bar").parentElement).toHaveClass(
+      "hidden",
+      "mb-3",
+      "md:block"
+    );
   });
 });

--- a/packages/web/src/components/session-prompt-composer.tsx
+++ b/packages/web/src/components/session-prompt-composer.tsx
@@ -87,7 +87,7 @@ export function SessionPromptComposer({
     <footer className="min-w-0 border-t border-border-muted flex-shrink-0">
       <form onSubmit={prompt.onSubmit} className="w-full min-w-0 max-w-4xl mx-auto p-4 pb-6">
         {/* Action bar above input */}
-        <div className="mb-3">
+        <div className="hidden mb-3 md:block">
           <ActionBar
             sessionId={session.id}
             sessionStatus={session.status}

--- a/packages/web/src/components/session-prompt-composer.tsx
+++ b/packages/web/src/components/session-prompt-composer.tsx
@@ -20,7 +20,6 @@ type SessionPromptComposerProps = {
     primaryRepo?: { repoOwner: string; repoName: string } | null;
     onArchive: () => void | Promise<void>;
     onUnarchive: () => void | Promise<void>;
-    onOpenDetails: () => void;
   };
   prompt: {
     value: string;
@@ -95,7 +94,6 @@ export function SessionPromptComposer({
             primaryRepo={session.primaryRepo}
             onArchive={session.onArchive}
             onUnarchive={session.onUnarchive}
-            onOpenDetails={session.onOpenDetails}
           />
         </div>
 

--- a/packages/web/src/components/session-prompt-composer.tsx
+++ b/packages/web/src/components/session-prompt-composer.tsx
@@ -11,11 +11,12 @@ import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import { useAttachmentDropZone } from "@/hooks/use-attachment-drop-zone";
 import { ATTACHMENT_ACCEPT, type PendingAttachment } from "@/hooks/use-session-attachments";
 import type { Artifact } from "@/types/session";
+import type { SessionStatus } from "@open-inspect/shared";
 
 type SessionPromptComposerProps = {
   session: {
     id: string;
-    status: string;
+    status: SessionStatus;
     artifacts: Artifact[];
     primaryRepo?: { repoOwner: string; repoName: string } | null;
     onArchive: () => void | Promise<void>;

--- a/packages/web/src/lib/session-details-focus.test.ts
+++ b/packages/web/src/lib/session-details-focus.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { afterEach, describe, expect, it } from "vitest";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { focusSessionDetailsTrigger } from "./session-details-focus";
+
+expect.extend(matchers);
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("focusSessionDetailsTrigger", () => {
+  it("follows the visible trigger across a phone-to-tablet breakpoint change", () => {
+    const actionsButton = document.createElement("button");
+    const detailsButton = document.createElement("button");
+    detailsButton.style.display = "none";
+    document.body.append(actionsButton, detailsButton);
+
+    focusSessionDetailsTrigger(true, actionsButton, detailsButton);
+    expect(actionsButton).toHaveFocus();
+
+    actionsButton.style.display = "none";
+    detailsButton.style.display = "block";
+    focusSessionDetailsTrigger(true, actionsButton, detailsButton);
+    expect(detailsButton).toHaveFocus();
+
+    actionsButton.style.display = "block";
+    detailsButton.style.display = "none";
+    focusSessionDetailsTrigger(false, actionsButton, detailsButton);
+    expect(actionsButton).toHaveFocus();
+  });
+});

--- a/packages/web/src/lib/session-details-focus.test.ts
+++ b/packages/web/src/lib/session-details-focus.test.ts
@@ -13,21 +13,31 @@ afterEach(() => {
 
 describe("focusSessionDetailsTrigger", () => {
   it("follows the visible trigger across a phone-to-tablet breakpoint change", () => {
+    const actionsWrapper = document.createElement("div");
+    const detailsWrapper = document.createElement("div");
     const actionsButton = document.createElement("button");
     const detailsButton = document.createElement("button");
-    detailsButton.style.display = "none";
-    document.body.append(actionsButton, detailsButton);
+    actionsWrapper.append(actionsButton);
+    detailsWrapper.append(detailsButton);
+    document.body.append(actionsWrapper, detailsWrapper);
+    Object.defineProperty(actionsButton, "offsetParent", {
+      get: () => (actionsWrapper.style.display === "none" ? null : actionsWrapper),
+    });
+    Object.defineProperty(detailsButton, "offsetParent", {
+      get: () => (detailsWrapper.style.display === "none" ? null : detailsWrapper),
+    });
+    detailsWrapper.style.display = "none";
 
     focusSessionDetailsTrigger(true, actionsButton, detailsButton);
     expect(actionsButton).toHaveFocus();
 
-    actionsButton.style.display = "none";
-    detailsButton.style.display = "block";
+    actionsWrapper.style.display = "none";
+    detailsWrapper.style.display = "block";
     focusSessionDetailsTrigger(true, actionsButton, detailsButton);
     expect(detailsButton).toHaveFocus();
 
-    actionsButton.style.display = "block";
-    detailsButton.style.display = "none";
+    actionsWrapper.style.display = "block";
+    detailsWrapper.style.display = "none";
     focusSessionDetailsTrigger(false, actionsButton, detailsButton);
     expect(actionsButton).toHaveFocus();
   });

--- a/packages/web/src/lib/session-details-focus.ts
+++ b/packages/web/src/lib/session-details-focus.ts
@@ -6,9 +6,7 @@ export function focusSessionDetailsTrigger(
   const preferred = isPhone ? actionsButton : detailsButton;
   const fallback = isPhone ? detailsButton : actionsButton;
   const isVisible = (button: HTMLButtonElement | null) =>
-    button !== null &&
-    getComputedStyle(button).display !== "none" &&
-    getComputedStyle(button).visibility !== "hidden";
+    button !== null && button.offsetParent !== null;
 
   const target = [preferred, fallback].find(isVisible);
   target?.focus();

--- a/packages/web/src/lib/session-details-focus.ts
+++ b/packages/web/src/lib/session-details-focus.ts
@@ -1,0 +1,15 @@
+export function focusSessionDetailsTrigger(
+  isPhone: boolean,
+  actionsButton: HTMLButtonElement | null,
+  detailsButton: HTMLButtonElement | null
+) {
+  const preferred = isPhone ? actionsButton : detailsButton;
+  const fallback = isPhone ? detailsButton : actionsButton;
+  const isVisible = (button: HTMLButtonElement | null) =>
+    button !== null &&
+    getComputedStyle(button).display !== "none" &&
+    getComputedStyle(button).visibility !== "hidden";
+
+  const target = [preferred, fallback].find(isVisible);
+  target?.focus();
+}


### PR DESCRIPTION
## Summary

- move the phone-only session action kebab into `SessionHeader` and label it `Session actions`
- combine Details, conditional preview/PR/media actions, copy link, and archive/unarchive in the required order
- remove the ActionBar row and its spacing below `md` while preserving the existing tablet and desktop controls
- retain safe/repository-aware links, archive confirmation and pending state, and restore Details overlay focus to the initiating header control
- add focused coverage for responsive visibility, exact menu contents, Details/Media callbacks, and asynchronous archive behavior

This PR supersedes #1109. It was implemented independently from a fresh latest `origin/main` branch and does not close #1109.

## Checks

- `npm run build -w @open-inspect/shared` - passed
- `npm test -w @open-inspect/web -- --run src/components/action-bar.test.tsx src/components/session-header.test.tsx src/components/session-prompt-composer.test.tsx` - 3 files, 12 tests passed
- `npm test -w @open-inspect/web` - 102 files, 906 tests passed
- `npm run typecheck -w @open-inspect/web` - passed
- `npm run lint -w @open-inspect/web` - passed
- Prettier check for all changed files - passed
- `git diff --check` - passed

## Visual Verification

- viewport screenshot with the unified header menu open
- dimensions: `390x844`
- artifact ID: `13b0bf7fc6abba38e6ee3a76ef96fd16`
- the temporary public preview route used for auth-independent verification was removed before commit


---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/afa7562ab2a3dd3c89a91c09fcef2495)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mobile “Session Actions” menu with entries for Details, Media (when available), preview/PR links, copy link, and archive/unarchive.
  * Mobile “Details” and “Media” now open the correct session views from the header.
* **Bug Fixes**
  * Improved focus restoration after closing mobile session details to return focus to the correct control.
  * Archive/unarchive actions are disabled while the request is in progress to prevent duplicate actions.
* **Style**
  * Streamlined mobile layout by hiding redundant composer action controls on small screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->