### PR TITLE
fix: enforce enabled models for child sessions

### DIFF
--- a/packages/control-plane/src/db/model-preferences.ts
+++ b/packages/control-plane/src/db/model-preferences.ts
@@ -1,4 +1,9 @@
-import { isValidModel, normalizeValidModels, type ValidModel } from "@open-inspect/shared";
+import {
+  DEFAULT_ENABLED_MODELS,
+  isValidModel,
+  normalizeValidModels,
+  type ValidModel,
+} from "@open-inspect/shared";
 import type { SqlDatabase } from "./sql-database";
 
 export class ModelPreferencesValidationError extends Error {
@@ -57,5 +62,18 @@ export class ModelPreferencesStore {
       .run();
 
     return normalized;
+  }
+}
+
+/** Resolve the currently enabled catalog, falling back safely when preferences are unavailable. */
+export async function getEffectiveEnabledModels(db: SqlDatabase): Promise<ValidModel[]> {
+  try {
+    const stored = await new ModelPreferencesStore(db).getEnabledModels();
+    if (!stored) return DEFAULT_ENABLED_MODELS;
+
+    const normalized = normalizeValidModels(stored);
+    return normalized.length > 0 ? normalized : DEFAULT_ENABLED_MODELS;
+  } catch {
+    return DEFAULT_ENABLED_MODELS;
   }
 }

--- a/packages/control-plane/src/db/model-preferences.ts
+++ b/packages/control-plane/src/db/model-preferences.ts
@@ -65,15 +65,11 @@ export class ModelPreferencesStore {
   }
 }
 
-/** Resolve the currently enabled catalog, falling back safely when preferences are unavailable. */
+/** Resolve the currently enabled catalog, using defaults only when no usable preferences exist. */
 export async function getEffectiveEnabledModels(db: SqlDatabase): Promise<ValidModel[]> {
-  try {
-    const stored = await new ModelPreferencesStore(db).getEnabledModels();
-    if (!stored) return DEFAULT_ENABLED_MODELS;
+  const stored = await new ModelPreferencesStore(db).getEnabledModels();
+  if (!stored) return DEFAULT_ENABLED_MODELS;
 
-    const normalized = normalizeValidModels(stored);
-    return normalized.length > 0 ? normalized : DEFAULT_ENABLED_MODELS;
-  } catch {
-    return DEFAULT_ENABLED_MODELS;
-  }
+  const normalized = normalizeValidModels(stored);
+  return normalized.length > 0 ? normalized : DEFAULT_ENABLED_MODELS;
 }

--- a/packages/control-plane/src/router.spawn-child.test.ts
+++ b/packages/control-plane/src/router.spawn-child.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { handleRequest } from "./router";
 import { signedServiceRequest, TEST_SERVICE_SECRETS } from "./router.test-support";
+import { getEffectiveEnabledModels } from "./db/model-preferences";
 import { SessionIndexStore } from "./db/session-index";
 import { SessionInternalPaths } from "./session/contracts";
 
@@ -11,6 +12,10 @@ const integrationSettingsMocks = vi.hoisted(() => ({
 
 vi.mock("./db/session-index", () => ({
   SessionIndexStore: vi.fn(),
+}));
+
+vi.mock("./db/model-preferences", () => ({
+  getEffectiveEnabledModels: vi.fn(),
 }));
 
 vi.mock("./session/integration-settings-resolution", () => integrationSettingsMocks);
@@ -75,6 +80,7 @@ describe("handleSpawnChild prompt enqueue handling", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getEffectiveEnabledModels).mockResolvedValue(["anthropic/claude-sonnet-4-6"]);
     integrationSettingsMocks.resolveCodeServerEnabled.mockResolvedValue(false);
     integrationSettingsMocks.resolveSandboxSettings.mockResolvedValue({});
   });
@@ -224,6 +230,33 @@ describe("handleSpawnChild prompt enqueue handling", () => {
     const payload = await response.json<{ error: string }>();
     expect(payload.error).toContain('Invalid model "not-a-real-model"');
     expect(payload.error).toContain("Valid models:");
+  });
+
+  it("returns 503 when enabled model preferences cannot be read", async () => {
+    const store = makeStore();
+    vi.mocked(SessionIndexStore).mockImplementation(function () {
+      return store as never;
+    });
+    vi.mocked(getEffectiveEnabledModels).mockRejectedValue(new Error("D1 unavailable"));
+
+    const parentStub: DurableObjectStub = {
+      fetch: vi.fn(async () => Response.json(spawnContext)),
+    } as never;
+    const env = {
+      ...TEST_SERVICE_SECRETS,
+      SCM_PROVIDER: "github",
+      DB: {},
+      SESSION: {
+        idFromName: (name: string) => name,
+        get: () => parentStub,
+      },
+    };
+
+    const response = await makeRequest(env);
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({ error: "Model preferences unavailable" });
+    expect(store.create).not.toHaveBeenCalled();
   });
 
   it("returns 400 for a malformed child spawn request", async () => {

--- a/packages/control-plane/src/routes/session-child-spawn.ts
+++ b/packages/control-plane/src/routes/session-child-spawn.ts
@@ -4,11 +4,13 @@ import {
   getValidModelOrDefault,
   isValidModel,
   isValidReasoningEffort,
+  resolveEnabledModel,
   spawnChildSessionRequestSchema,
   spawnContextSchema,
   VALID_MODELS,
 } from "@open-inspect/shared";
 import { generateId } from "../auth/crypto";
+import { getEffectiveEnabledModels } from "../db/model-preferences";
 import { SessionIndexStore } from "../db/session-index";
 import { createLogger } from "../logger";
 import { SessionInternalPaths } from "../session/contracts";
@@ -121,15 +123,20 @@ async function handleSpawnChild(
     }
   }
 
-  const rawModel = body.model ?? spawnContext.model;
+  const enabledModels = await getEffectiveEnabledModels(ctx.db);
   if (body.model !== undefined && !isValidModel(body.model)) {
     return error(`Invalid model "${body.model}". Valid models: ${VALID_MODELS.join(", ")}`, 400);
   }
-  const model = getValidModelOrDefault(rawModel);
+  const requestedModel = getValidModelOrDefault(body.model ?? spawnContext.model);
+  if (body.model !== undefined && !enabledModels.includes(requestedModel)) {
+    return error(`Model "${body.model}" is not enabled`, 400);
+  }
+  const model = resolveEnabledModel({ model: requestedModel, enabledModels });
+  const requestedReasoningEffort = body.reasoningEffort ?? spawnContext.reasoningEffort;
   const reasoningEffort =
-    body.reasoningEffort && isValidReasoningEffort(model, body.reasoningEffort)
-      ? body.reasoningEffort
-      : spawnContext.reasoningEffort;
+    requestedReasoningEffort && isValidReasoningEffort(model, requestedReasoningEffort)
+      ? requestedReasoningEffort
+      : null;
 
   const childDepth = parentDepth + 1;
   const childId = generateId();

--- a/packages/control-plane/src/routes/session-child-spawn.ts
+++ b/packages/control-plane/src/routes/session-child-spawn.ts
@@ -7,6 +7,7 @@ import {
   resolveEnabledModel,
   spawnChildSessionRequestSchema,
   spawnContextSchema,
+  type ValidModel,
   VALID_MODELS,
 } from "@open-inspect/shared";
 import { generateId } from "../auth/crypto";
@@ -123,7 +124,19 @@ async function handleSpawnChild(
     }
   }
 
-  const enabledModels = await getEffectiveEnabledModels(ctx.db);
+  let enabledModels: ValidModel[];
+  try {
+    enabledModels = await getEffectiveEnabledModels(ctx.db);
+  } catch (e) {
+    logger.error("Failed to resolve enabled models for child session", {
+      event: "session.spawn_child_model_preferences_failed",
+      parent_id: parentId,
+      error: e instanceof Error ? e.message : String(e),
+      trace_id: ctx.trace_id,
+      request_id: ctx.request_id,
+    });
+    return error("Model preferences unavailable", 503);
+  }
   if (body.model !== undefined && !isValidModel(body.model)) {
     return error(`Invalid model "${body.model}". Valid models: ${VALID_MODELS.join(", ")}`, 400);
   }

--- a/packages/control-plane/test/integration/helpers.ts
+++ b/packages/control-plane/test/integration/helpers.ts
@@ -195,6 +195,7 @@ export async function initNamedSession(
     }>;
     title?: string;
     model?: string;
+    reasoningEffort?: string;
     userId?: string;
     scmLogin?: string;
   }

--- a/packages/control-plane/test/integration/spawn-children.test.ts
+++ b/packages/control-plane/test/integration/spawn-children.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { SELF, env } from "cloudflare:test";
+import { ModelPreferencesStore } from "../../src/db/model-preferences";
 import { SessionIndexStore } from "../../src/db/session-index";
 import { cleanD1Tables } from "./cleanup";
 import { initNamedSession, queryDO, seedSandboxAuth } from "./helpers";
@@ -18,6 +19,7 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
     spawnSource?: "user" | "agent";
     environmentId?: string | null;
     model?: string;
+    reasoningEffort?: string | null;
   }) {
     const parentName = `parent-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
     const { stub } = await initNamedSession(parentName, {
@@ -27,6 +29,7 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
       ...(opts?.userId != null && { userId: opts.userId }),
       ...(opts?.scmLogin != null && { scmLogin: opts.scmLogin }),
       ...(opts?.model != null && { model: opts.model }),
+      ...(opts?.reasoningEffort != null && { reasoningEffort: opts.reasoningEffort }),
     });
 
     const sandboxToken = `sb-tok-${Date.now()}`;
@@ -40,7 +43,7 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
       repoOwner: "acme",
       repoName: "web-app",
       model: opts?.model ?? "anthropic/claude-sonnet-4-6",
-      reasoningEffort: null,
+      reasoningEffort: opts?.reasoningEffort ?? null,
       baseBranch: null,
       status: "active",
       parentSessionId: opts?.parentSessionId ?? null,
@@ -198,11 +201,7 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
   it("rejects a disabled model override for grandchildren", async () => {
     const { parentName, sandboxToken } = await setupParent();
 
-    await env.DB.prepare(
-      "INSERT INTO model_preferences (id, enabled_models, updated_at) VALUES ('global', ?, ?)"
-    )
-      .bind(JSON.stringify(["anthropic/claude-sonnet-4-6"]), Date.now())
-      .run();
+    await new ModelPreferencesStore(env.DB).setEnabledModels(["anthropic/claude-sonnet-4-6"]);
 
     const childRes = await SELF.fetch(`https://test.local/sessions/${parentName}/children`, {
       method: "POST",
@@ -246,14 +245,11 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
 
   it("uses an enabled fallback when the inherited parent model was disabled", async () => {
     const { parentName, sandboxToken, store } = await setupParent({
-      model: "opencode/kimi-k2.5",
+      model: "openai/gpt-5.5",
+      reasoningEffort: "xhigh",
     });
 
-    await env.DB.prepare(
-      "INSERT INTO model_preferences (id, enabled_models, updated_at) VALUES ('global', ?, ?)"
-    )
-      .bind(JSON.stringify(["anthropic/claude-sonnet-4-6"]), Date.now())
-      .run();
+    await new ModelPreferencesStore(env.DB).setEnabledModels(["anthropic/claude-haiku-4-5"]);
 
     const response = await SELF.fetch(`https://test.local/sessions/${parentName}/children`, {
       method: "POST",
@@ -266,7 +262,9 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
 
     expect(response.status).toBe(201);
     const child = await response.json<{ sessionId: string }>();
-    expect((await store.get(child.sessionId))?.model).toBe("anthropic/claude-sonnet-4-6");
+    const storedChild = await store.get(child.sessionId);
+    expect(storedChild?.model).toBe("anthropic/claude-haiku-4-5");
+    expect(storedChild?.reasoningEffort).toBeNull();
   });
 
   it("propagates null userId from parent to child", async () => {

--- a/packages/control-plane/test/integration/spawn-children.test.ts
+++ b/packages/control-plane/test/integration/spawn-children.test.ts
@@ -17,6 +17,7 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
     parentSessionId?: string;
     spawnSource?: "user" | "agent";
     environmentId?: string | null;
+    model?: string;
   }) {
     const parentName = `parent-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
     const { stub } = await initNamedSession(parentName, {
@@ -25,6 +26,7 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
       ...(opts?.repoId != null && { repoId: opts.repoId }),
       ...(opts?.userId != null && { userId: opts.userId }),
       ...(opts?.scmLogin != null && { scmLogin: opts.scmLogin }),
+      ...(opts?.model != null && { model: opts.model }),
     });
 
     const sandboxToken = `sb-tok-${Date.now()}`;
@@ -37,7 +39,7 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
       title: "Parent",
       repoOwner: "acme",
       repoName: "web-app",
-      model: "anthropic/claude-sonnet-4-6",
+      model: opts?.model ?? "anthropic/claude-sonnet-4-6",
       reasoningEffort: null,
       baseBranch: null,
       status: "active",
@@ -191,6 +193,80 @@ describe("POST /sessions/:parentId/children — spawn child", () => {
       "SELECT environment_id FROM session"
     );
     expect(session.environment_id).toBe("env_parent");
+  });
+
+  it("rejects a disabled model override for grandchildren", async () => {
+    const { parentName, sandboxToken } = await setupParent();
+
+    await env.DB.prepare(
+      "INSERT INTO model_preferences (id, enabled_models, updated_at) VALUES ('global', ?, ?)"
+    )
+      .bind(JSON.stringify(["anthropic/claude-sonnet-4-6"]), Date.now())
+      .run();
+
+    const childRes = await SELF.fetch(`https://test.local/sessions/${parentName}/children`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${sandboxToken}`,
+      },
+      body: JSON.stringify({ title: "Child", prompt: "Spawn another child" }),
+    });
+    expect(childRes.status).toBe(201);
+    const child = await childRes.json<{ sessionId: string }>();
+
+    const childStub = env.SESSION.get(env.SESSION.idFromName(child.sessionId));
+    const childSandboxToken = `child-sb-tok-${Date.now()}`;
+    await seedSandboxAuth(childStub, {
+      authToken: childSandboxToken,
+      sandboxId: `child-sb-${Date.now()}`,
+    });
+
+    const grandchildRes = await SELF.fetch(
+      `https://test.local/sessions/${child.sessionId}/children`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${childSandboxToken}`,
+        },
+        body: JSON.stringify({
+          title: "Grandchild",
+          prompt: "Use a disabled model",
+          model: "opencode/kimi-k2.5",
+        }),
+      }
+    );
+
+    expect(grandchildRes.status).toBe(400);
+    await expect(grandchildRes.json()).resolves.toEqual({
+      error: 'Model "opencode/kimi-k2.5" is not enabled',
+    });
+  });
+
+  it("uses an enabled fallback when the inherited parent model was disabled", async () => {
+    const { parentName, sandboxToken, store } = await setupParent({
+      model: "opencode/kimi-k2.5",
+    });
+
+    await env.DB.prepare(
+      "INSERT INTO model_preferences (id, enabled_models, updated_at) VALUES ('global', ?, ?)"
+    )
+      .bind(JSON.stringify(["anthropic/claude-sonnet-4-6"]), Date.now())
+      .run();
+
+    const response = await SELF.fetch(`https://test.local/sessions/${parentName}/children`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${sandboxToken}`,
+      },
+      body: JSON.stringify({ title: "Child", prompt: "Use an enabled model" }),
+    });
+
+    expect(response.status).toBe(201);
+    const child = await response.json<{ sessionId: string }>();
+    expect((await store.get(child.sessionId))?.model).toBe("anthropic/claude-sonnet-4-6");
   });
 
   it("propagates null userId from parent to child", async () => {


### PR DESCRIPTION
## Summary

- enforce global model preferences when agents spawn child or grandchild sessions
- reject explicit model overrides that are catalog-valid but currently disabled
- reconcile inherited parent models to an enabled fallback when preferences changed after the parent launched
- clear inherited reasoning effort when it is incompatible with the resolved fallback model
- add integration coverage for disabled grandchild overrides and disabled inherited models

## Root Cause

The child-spawn route used `isValidModel`, which validates against the complete model catalog. It did not consult the global enabled-model preferences, so any sandbox-authenticated child could select an opt-in model for its own child.

## Verification

- `npm run test:integration -w @open-inspect/control-plane -- spawn-children.test.ts`
- `npm test -w @open-inspect/control-plane -- router.spawn-child.test.ts`
- `npm run typecheck -w @open-inspect/control-plane`
- Prettier and `git diff --check`

## Scope

This PR fixes child-session launch enforcement. Root session API creation and per-message model overrides have similar catalog-only validation and should be addressed separately.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/26dc9a29d55983cf4657ba0a03fc2287)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Child sessions now resolve an effective enabled-model set from stored preferences.
  * Explicitly requested models that aren’t enabled are rejected with a clear `400` error.
  * If model preferences can’t be read, child session creation returns `503` (`Model preferences unavailable`).
  * When inherited models are disabled, child sessions fall back to an enabled model from preferences.

* **Bug Fixes**
  * Reasoning effort is now validated against the final selected model; unsupported values are cleared.

* **Tests**
  * Added/updated integration and unit tests to cover preference-based model handling and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->