### PR TITLE
Disable iOS autofill suggestions on prompt inputs

### DIFF
--- a/packages/web/src/app/(app)/page.test.tsx
+++ b/packages/web/src/app/(app)/page.test.tsx
@@ -137,6 +137,15 @@ function sessionCreateBody(): Record<string, unknown> {
 }
 
 describe("Home", () => {
+  it("disables autofill suggestions for the prompt", () => {
+    render(<Home />);
+
+    expect(screen.getByPlaceholderText("What do you want to build?")).toHaveAttribute(
+      "autocomplete",
+      "off"
+    );
+  });
+
   it("keeps the attachment control anchored while the sandbox warms", async () => {
     let resolveCreate: ((response: Response) => void) | undefined;
     vi.mocked(fetch).mockImplementation(

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -427,6 +427,7 @@ function HomeContent({
                     onChange={(e) => handlePromptChange(e.target.value)}
                     onKeyDown={handleKeyDown}
                     placeholder="What do you want to build?"
+                    autoComplete="off"
                     disabled={creating}
                     className="w-full resize-none bg-transparent px-4 pt-4 pb-12 focus:outline-none text-foreground placeholder:text-secondary-foreground disabled:opacity-50"
                     rows={3}

--- a/packages/web/src/components/session-prompt-composer.test.tsx
+++ b/packages/web/src/components/session-prompt-composer.test.tsx
@@ -77,6 +77,15 @@ function ComposerHarness({
 }
 
 describe("SessionPromptComposer", () => {
+  it("disables autofill suggestions for the prompt", () => {
+    render(<ComposerHarness />);
+
+    expect(screen.getByPlaceholderText("Ask or build anything")).toHaveAttribute(
+      "autocomplete",
+      "off"
+    );
+  });
+
   it("starts with one row and grows and shrinks with its content", () => {
     const scrollHeight = vi
       .spyOn(HTMLTextAreaElement.prototype, "scrollHeight", "get")

--- a/packages/web/src/components/session-prompt-composer.tsx
+++ b/packages/web/src/components/session-prompt-composer.tsx
@@ -122,6 +122,7 @@ export function SessionPromptComposer({
               onKeyDown={prompt.onKeyDown}
               onPaste={handlePaste}
               disabled={prompt.draftLocked}
+              autoComplete="off"
               placeholder={
                 prompt.isProcessing ? "Type your next message..." : "Ask or build anything"
               }


### PR DESCRIPTION
## Summary
- disable browser autofill on the dashboard prompt textarea
- disable browser autofill on the session detail prompt composer
- add regression coverage for both prompt inputs

## Why
On iOS Safari, the prompt fields could display the password, payment card, and location AutoFill accessory above the keyboard. These are free-form agent prompts and do not accept those data types, so the extra accessory consumes unnecessary screen space.

## Testing
- `npm test -w @open-inspect/web -- "src/app/(app)/page.test.tsx" "src/components/session-prompt-composer.test.tsx"`
- `npm run typecheck -w @open-inspect/web`
- ESLint on the four modified files

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/5f09da46c95ad762b8351a43c386646d)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled browser autocomplete and autofill suggestions for prompt text areas on the home page and in session prompts.
* **Tests**
  * Added coverage to verify autocomplete remains disabled for both prompt inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->