### PR TITLE
refactor(web): centralize server session access

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -113,6 +113,36 @@ export default tseslint.config(
     },
   },
 
+  // Web BFF routes depend on the server-auth seam, not directly on the
+  // current authentication framework. The auth endpoints own the framework
+  // integration and are intentionally excluded.
+  {
+    files: [
+      "packages/web/src/app/api/**/*.{ts,tsx}",
+      "packages/web/src/lib/integration-settings-proxy.ts",
+    ],
+    ignores: ["packages/web/src/app/api/auth/**"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "next-auth",
+              importNames: ["getServerSession"],
+              message: "Use getServerAuthSession from @/lib/server-auth-session.",
+            },
+            {
+              name: "@/lib/auth",
+              importNames: ["authOptions"],
+              message: "Use getServerAuthSession from @/lib/server-auth-session.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+
   // Cloudflare Workers specific config
   {
     files: ["packages/control-plane/**/*.ts"],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -129,12 +129,12 @@ export default tseslint.config(
           paths: [
             {
               name: "next-auth",
-              importNames: ["getServerSession"],
               message: "Use getServerAuthSession from @/lib/server-auth-session.",
             },
+          ],
+          patterns: [
             {
-              name: "@/lib/auth",
-              importNames: ["authOptions"],
+              regex: "(?:^|/)lib/auth$",
               message: "Use getServerAuthSession from @/lib/server-auth-session.",
             },
           ],

--- a/packages/web/src/app/api/analytics/breakdown/route.test.ts
+++ b/packages/web/src/app/api/analytics/breakdown/route.test.ts
@@ -1,18 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("next-auth", () => ({
-  getServerSession: vi.fn(),
-}));
-
-vi.mock("@/lib/auth", () => ({
-  authOptions: {},
+vi.mock("@/lib/server-auth-session", () => ({
+  getServerAuthSession: vi.fn(),
 }));
 
 vi.mock("@/lib/control-plane", () => ({
   controlPlaneUserFetch: vi.fn(),
 }));
 
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { GET } from "./route";
 
@@ -22,7 +18,7 @@ describe("analytics breakdown API route", () => {
   });
 
   it("returns 401 when the user session is missing", async () => {
-    vi.mocked(getServerSession).mockResolvedValue(null);
+    vi.mocked(getServerAuthSession).mockResolvedValue(null);
 
     const response = await GET(
       new Request("http://localhost/api/analytics/breakdown?days=30&by=user") as never
@@ -33,7 +29,7 @@ describe("analytics breakdown API route", () => {
   });
 
   it("forwards only days and by query params", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
       Response.json({ entries: [] }, { status: 200 })
     );
@@ -48,7 +44,7 @@ describe("analytics breakdown API route", () => {
   });
 
   it("returns 500 when the control plane request throws", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockRejectedValue(new Error("boom"));
 
     const response = await GET(new Request("http://localhost/api/analytics/breakdown") as never);

--- a/packages/web/src/app/api/analytics/breakdown/route.ts
+++ b/packages/web/src/app/api/analytics/breakdown/route.ts
@@ -1,12 +1,11 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { buildAnalyticsBreakdownPath } from "@/lib/analytics-query";
 
 export async function GET(request: NextRequest) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/analytics/pull-requests/route.ts
+++ b/packages/web/src/app/api/analytics/pull-requests/route.ts
@@ -1,12 +1,11 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { buildAnalyticsPullRequestsPath } from "@/lib/analytics-query";
 
 export async function GET(request: NextRequest) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/analytics/summary/route.test.ts
+++ b/packages/web/src/app/api/analytics/summary/route.test.ts
@@ -1,18 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("next-auth", () => ({
-  getServerSession: vi.fn(),
-}));
-
-vi.mock("@/lib/auth", () => ({
-  authOptions: {},
+vi.mock("@/lib/server-auth-session", () => ({
+  getServerAuthSession: vi.fn(),
 }));
 
 vi.mock("@/lib/control-plane", () => ({
   controlPlaneUserFetch: vi.fn(),
 }));
 
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { GET } from "./route";
 
@@ -22,7 +18,7 @@ describe("analytics summary API route", () => {
   });
 
   it("returns 401 when the user session is missing", async () => {
-    vi.mocked(getServerSession).mockResolvedValue(null);
+    vi.mocked(getServerAuthSession).mockResolvedValue(null);
 
     const response = await GET(
       new Request("http://localhost/api/analytics/summary?days=14") as never
@@ -34,7 +30,7 @@ describe("analytics summary API route", () => {
   });
 
   it("forwards only the allowed summary query params", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
       Response.json({ totalSessions: 5 }, { status: 200 })
     );
@@ -49,7 +45,7 @@ describe("analytics summary API route", () => {
   });
 
   it("returns 500 when the control plane request throws", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockRejectedValue(new Error("boom"));
 
     const response = await GET(new Request("http://localhost/api/analytics/summary") as never);

--- a/packages/web/src/app/api/analytics/summary/route.ts
+++ b/packages/web/src/app/api/analytics/summary/route.ts
@@ -1,12 +1,11 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { buildAnalyticsSummaryPath } from "@/lib/analytics-query";
 
 export async function GET(request: NextRequest) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/analytics/timeseries/route.test.ts
+++ b/packages/web/src/app/api/analytics/timeseries/route.test.ts
@@ -1,18 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("next-auth", () => ({
-  getServerSession: vi.fn(),
-}));
-
-vi.mock("@/lib/auth", () => ({
-  authOptions: {},
+vi.mock("@/lib/server-auth-session", () => ({
+  getServerAuthSession: vi.fn(),
 }));
 
 vi.mock("@/lib/control-plane", () => ({
   controlPlaneUserFetch: vi.fn(),
 }));
 
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { GET } from "./route";
 
@@ -22,7 +18,7 @@ describe("analytics timeseries API route", () => {
   });
 
   it("returns 401 when the user session is missing", async () => {
-    vi.mocked(getServerSession).mockResolvedValue(null);
+    vi.mocked(getServerAuthSession).mockResolvedValue(null);
 
     const response = await GET(
       new Request("http://localhost/api/analytics/timeseries?days=30") as never
@@ -33,7 +29,7 @@ describe("analytics timeseries API route", () => {
   });
 
   it("forwards only the days query param", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
       Response.json({ series: [] }, { status: 200 })
     );
@@ -48,7 +44,7 @@ describe("analytics timeseries API route", () => {
   });
 
   it("passes through upstream error statuses", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
       Response.json({ error: "Bad request" }, { status: 400 })
     );

--- a/packages/web/src/app/api/analytics/timeseries/route.ts
+++ b/packages/web/src/app/api/analytics/timeseries/route.ts
@@ -1,12 +1,11 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { buildAnalyticsTimeseriesPath } from "@/lib/analytics-query";
 
 export async function GET(request: NextRequest) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/automations/[id]/invocations/route.ts
+++ b/packages/web/src/app/api/automations/[id]/invocations/route.ts
@@ -1,12 +1,11 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { buildControlPlanePath } from "@/lib/control-plane-query";
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/automations/[id]/pause/route.ts
+++ b/packages/web/src/app/api/automations/[id]/pause/route.ts
@@ -1,11 +1,10 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/automations/[id]/regenerate-key/route.ts
+++ b/packages/web/src/app/api/automations/[id]/regenerate-key/route.ts
@@ -1,11 +1,10 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/automations/[id]/resume/route.ts
+++ b/packages/web/src/app/api/automations/[id]/resume/route.ts
@@ -1,11 +1,10 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/automations/[id]/route.ts
+++ b/packages/web/src/app/api/automations/[id]/route.ts
@@ -1,11 +1,10 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -23,7 +22,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
 }
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -48,7 +47,7 @@ export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/automations/[id]/runs/[runId]/route.ts
+++ b/packages/web/src/app/api/automations/[id]/runs/[runId]/route.ts
@@ -1,14 +1,13 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string; runId: string }> }
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/automations/[id]/trigger/route.ts
+++ b/packages/web/src/app/api/automations/[id]/trigger/route.ts
@@ -1,11 +1,10 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/automations/route.test.ts
+++ b/packages/web/src/app/api/automations/route.test.ts
@@ -1,12 +1,8 @@
 import type { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("next-auth", () => ({
-  getServerSession: vi.fn(),
-}));
-
-vi.mock("@/lib/auth", () => ({
-  authOptions: {},
+vi.mock("@/lib/server-auth-session", () => ({
+  getServerAuthSession: vi.fn(),
 }));
 
 vi.mock("@/lib/control-plane", () => ({
@@ -15,7 +11,7 @@ vi.mock("@/lib/control-plane", () => ({
 
 // NOTE: @/lib/build-auth-identity is intentionally NOT mocked — these tests
 // exercise the real chokepoint to prove the route's outgoing body is correct.
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { POST } from "./route";
 
@@ -44,7 +40,7 @@ describe("automations API route (POST)", () => {
   });
 
   it("returns 401 when the user session is missing", async () => {
-    vi.mocked(getServerSession).mockResolvedValue(null);
+    vi.mocked(getServerAuthSession).mockResolvedValue(null);
 
     const response = await POST(postRequest(validBody));
 
@@ -53,7 +49,7 @@ describe("automations API route (POST)", () => {
   });
 
   it("sends auth* display and scm* attribution for a GitHub user — never identity or credentials", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: {
         id: "12345",
         login: "ada",
@@ -99,7 +95,7 @@ describe("automations API route (POST)", () => {
   });
 
   it("sends auth* display but no scm* for a Google user (F1/F2: a Google sub must never become a GitHub identity)", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: {
         id: "google-sub-1",
         name: "Pat PM",
@@ -135,7 +131,7 @@ describe("automations API route (POST)", () => {
   });
 
   it("drops non-allowlisted fields (including client-asserted identity) from the forwarded body", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: { id: "12345", login: "ada", provider: "github" },
     } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(

--- a/packages/web/src/app/api/automations/route.ts
+++ b/packages/web/src/app/api/automations/route.ts
@@ -1,13 +1,12 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { buildAuthDisplay, buildScmAttribution } from "@/lib/build-auth-identity";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { buildControlPlanePath } from "@/lib/control-plane-query";
 
 export async function GET(request: NextRequest) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -25,7 +24,7 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/commit-signing/route.test.ts
+++ b/packages/web/src/app/api/commit-signing/route.test.ts
@@ -1,19 +1,15 @@
 import type { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("next-auth", () => ({
-  getServerSession: vi.fn(),
-}));
-
-vi.mock("@/lib/auth", () => ({
-  authOptions: {},
+vi.mock("@/lib/server-auth-session", () => ({
+  getServerAuthSession: vi.fn(),
 }));
 
 vi.mock("@/lib/control-plane", () => ({
   controlPlaneUserFetch: vi.fn(),
 }));
 
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { DELETE, GET, PUT } from "./route";
 
@@ -36,7 +32,7 @@ describe("commit signing BFF", () => {
     ],
     ["DELETE", () => DELETE()],
   ])("rejects unauthenticated %s before contacting the control plane", async (_method, call) => {
-    vi.mocked(getServerSession).mockResolvedValue(null);
+    vi.mocked(getServerAuthSession).mockResolvedValue(null);
 
     const response = await call();
 
@@ -46,7 +42,7 @@ describe("commit signing BFF", () => {
   });
 
   it("forwards authenticated reads with no-store", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(Response.json({ enabled: false }));
 
     const response = await GET();
@@ -58,7 +54,7 @@ describe("commit signing BFF", () => {
   });
 
   it("forwards authenticated writes without persisting or reshaping the key", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
       Response.json({ error: "Invalid commit signing configuration" }, { status: 400 })
     );
@@ -85,7 +81,7 @@ describe("commit signing BFF", () => {
   });
 
   it("forwards authenticated disables with no-store", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(Response.json({ enabled: false }));
 
     const response = await DELETE();
@@ -95,7 +91,7 @@ describe("commit signing BFF", () => {
   });
 
   it("rejects malformed successful metadata from the control plane", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(Response.json({ enabled: true }));
 
     const response = await GET();
@@ -105,7 +101,7 @@ describe("commit signing BFF", () => {
   });
 
   it("does not relay unexpected control-plane error bodies", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
       Response.json({ error: "PRIVATE-KEY-BYTES leaked" }, { status: 500 })
     );

--- a/packages/web/src/app/api/commit-signing/route.ts
+++ b/packages/web/src/app/api/commit-signing/route.ts
@@ -1,9 +1,8 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { commitSigningMetadataSchema } from "@open-inspect/shared";
 
-import { authOptions } from "@/lib/auth";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 const NO_STORE_HEADERS = { "Cache-Control": "no-store" };
@@ -13,7 +12,7 @@ function response(data: unknown, status = 200): NextResponse {
 }
 
 async function authorized(): Promise<boolean> {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   return Boolean(session?.user);
 }
 

--- a/packages/web/src/app/api/environments/[id]/images/route.ts
+++ b/packages/web/src/app/api/environments/[id]/images/route.ts
@@ -1,15 +1,14 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import type { ImageBuildRecordView } from "@open-inspect/shared";
-import { authOptions } from "@/lib/auth";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { excludeSupersededBuilds } from "@/lib/image-builds";
 import { supportsRepoImages } from "@/lib/sandbox-provider";
 
 /** Per-environment image-build status (the environment's recent build rows). */
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/environments/[id]/images/trigger/route.ts
+++ b/packages/web/src/app/api/environments/[id]/images/trigger/route.ts
@@ -1,12 +1,11 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { supportsRepoImages } from "@/lib/sandbox-provider";
 
 export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/environments/[id]/route.ts
+++ b/packages/web/src/app/api/environments/[id]/route.ts
@@ -1,11 +1,10 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -23,7 +22,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
 }
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -50,7 +49,7 @@ export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/environments/[id]/secrets/[key]/route.ts
+++ b/packages/web/src/app/api/environments/[id]/secrets/[key]/route.ts
@@ -1,14 +1,13 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string; key: string }> }
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/environments/[id]/secrets/import/route.ts
+++ b/packages/web/src/app/api/environments/[id]/secrets/import/route.ts
@@ -1,11 +1,10 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/environments/[id]/secrets/route.ts
+++ b/packages/web/src/app/api/environments/[id]/secrets/route.ts
@@ -1,11 +1,10 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -23,7 +22,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
 }
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/environments/images-routes.test.ts
+++ b/packages/web/src/app/api/environments/images-routes.test.ts
@@ -5,12 +5,8 @@ const mocks = vi.hoisted(() => ({
   supportsRepoImagesValue: true,
 }));
 
-vi.mock("next-auth", () => ({
-  getServerSession: vi.fn(),
-}));
-
-vi.mock("@/lib/auth", () => ({
-  authOptions: {},
+vi.mock("@/lib/server-auth-session", () => ({
+  getServerAuthSession: vi.fn(),
 }));
 
 vi.mock("@/lib/control-plane", () => ({
@@ -21,7 +17,7 @@ vi.mock("@/lib/sandbox-provider", () => ({
   supportsRepoImages: () => mocks.supportsRepoImagesValue,
 }));
 
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { GET as getEnvironmentStatus } from "./[id]/images/route";
 import { POST as triggerBuild } from "./[id]/images/trigger/route";
@@ -48,7 +44,7 @@ describe.each(routes)("$name", ({ call }) => {
 
   it("returns 401 before disclosing provider support when unauthenticated", async () => {
     mocks.supportsRepoImagesValue = false;
-    vi.mocked(getServerSession).mockResolvedValue(null);
+    vi.mocked(getServerAuthSession).mockResolvedValue(null);
 
     const response = await call();
 
@@ -58,7 +54,7 @@ describe.each(routes)("$name", ({ call }) => {
 
   it("returns 501 for authenticated users on a provider without image support", async () => {
     mocks.supportsRepoImagesValue = false;
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "12345" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "12345" } } as never);
 
     const response = await call();
 
@@ -67,7 +63,7 @@ describe.each(routes)("$name", ({ call }) => {
   });
 
   it("proxies to the control plane for authenticated users", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "12345" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "12345" } } as never);
     vi.mocked(controlPlaneUserFetch).mockImplementation(async () => Response.json({ images: [] }));
 
     const response = await call();
@@ -81,7 +77,7 @@ describe("unified route consumption", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     mocks.supportsRepoImagesValue = true;
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "12345" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "12345" } } as never);
   });
 
   it("status reads the per-scope unified status and filters superseded rows", async () => {

--- a/packages/web/src/app/api/environments/route.ts
+++ b/packages/web/src/app/api/environments/route.ts
@@ -1,11 +1,10 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function GET() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -21,7 +20,7 @@ export async function GET() {
 }
 
 export async function POST(request: NextRequest) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/image-builds/repo/[owner]/[name]/toggle/route.ts
+++ b/packages/web/src/app/api/image-builds/repo/[owner]/[name]/toggle/route.ts
@@ -1,7 +1,6 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { supportsRepoImages } from "@/lib/sandbox-provider";
 
@@ -9,7 +8,7 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ owner: string; name: string }> }
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/image-builds/repo/[owner]/[name]/trigger/route.ts
+++ b/packages/web/src/app/api/image-builds/repo/[owner]/[name]/trigger/route.ts
@@ -1,7 +1,6 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { supportsRepoImages } from "@/lib/sandbox-provider";
 
@@ -9,7 +8,7 @@ export async function POST(
   _request: NextRequest,
   { params }: { params: Promise<{ owner: string; name: string }> }
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/image-builds/route.test.ts
+++ b/packages/web/src/app/api/image-builds/route.test.ts
@@ -5,12 +5,8 @@ const mocks = vi.hoisted(() => ({
   supportsRepoImagesValue: true,
 }));
 
-vi.mock("next-auth", () => ({
-  getServerSession: vi.fn(),
-}));
-
-vi.mock("@/lib/auth", () => ({
-  authOptions: {},
+vi.mock("@/lib/server-auth-session", () => ({
+  getServerAuthSession: vi.fn(),
 }));
 
 vi.mock("@/lib/control-plane", () => ({
@@ -21,7 +17,7 @@ vi.mock("@/lib/sandbox-provider", () => ({
   supportsRepoImages: () => mocks.supportsRepoImagesValue,
 }));
 
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { GET as getFeed } from "./route";
 import { POST as triggerBuild } from "./repo/[owner]/[name]/trigger/route";
@@ -49,7 +45,7 @@ describe.each(routes)("$name", ({ call }) => {
 
   it("returns 401 before disclosing provider support when unauthenticated", async () => {
     mocks.supportsRepoImagesValue = false;
-    vi.mocked(getServerSession).mockResolvedValue(null);
+    vi.mocked(getServerAuthSession).mockResolvedValue(null);
 
     const response = await call();
 
@@ -59,7 +55,7 @@ describe.each(routes)("$name", ({ call }) => {
 
   it("returns 501 for authenticated users on a provider without image support", async () => {
     mocks.supportsRepoImagesValue = false;
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "12345" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "12345" } } as never);
 
     const response = await call();
 
@@ -68,7 +64,7 @@ describe.each(routes)("$name", ({ call }) => {
   });
 
   it("proxies to the control plane for authenticated users", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "12345" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "12345" } } as never);
     // Fresh Response per call — the feed route consumes three bodies.
     vi.mocked(controlPlaneUserFetch).mockImplementation(async () =>
       Response.json({ units: [], repos: [], images: [] })
@@ -85,7 +81,7 @@ describe("GET /api/image-builds feed", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     mocks.supportsRepoImagesValue = true;
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "12345" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "12345" } } as never);
   });
 
   it("serves enabled scopes plus cross-scope status, failed rows included", async () => {
@@ -212,7 +208,7 @@ describe("proxied control-plane paths", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     mocks.supportsRepoImagesValue = true;
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "12345" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "12345" } } as never);
     vi.mocked(controlPlaneUserFetch).mockImplementation(async () => Response.json({ ok: true }));
   });
 

--- a/packages/web/src/app/api/image-builds/route.ts
+++ b/packages/web/src/app/api/image-builds/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import type { ImageBuildRecordView } from "@open-inspect/shared";
-import { authOptions } from "@/lib/auth";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import {
   excludeSupersededBuilds,
@@ -16,7 +15,7 @@ import { supportsRepoImages } from "@/lib/sandbox-provider";
  * the settings pages and the session-target picker.
  */
 export async function GET() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/integration-settings/[id]/repos/route.ts
+++ b/packages/web/src/app/api/integration-settings/[id]/repos/route.ts
@@ -1,11 +1,10 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/integrations/slack/channels/route.ts
+++ b/packages/web/src/app/api/integrations/slack/channels/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import type { SlackChannelListing } from "@open-inspect/shared";
 
@@ -15,7 +14,7 @@ interface ControlPlaneChannelsResponse {
  * array so the picker degrades to manual channel-ID entry on any failure.
  */
 export async function GET() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/mcp-servers/[id]/route.ts
+++ b/packages/web/src/app/api/mcp-servers/[id]/route.ts
@@ -1,11 +1,10 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -22,7 +21,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
 }
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -51,7 +50,7 @@ export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/mcp-servers/route.ts
+++ b/packages/web/src/app/api/mcp-servers/route.ts
@@ -1,11 +1,10 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function GET(request: NextRequest) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -23,7 +22,7 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/model-preferences/route.ts
+++ b/packages/web/src/app/api/model-preferences/route.ts
@@ -1,11 +1,10 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function GET() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -21,7 +20,7 @@ export async function GET() {
 }
 
 export async function PUT(request: NextRequest) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/repos/[owner]/[name]/branches/route.ts
+++ b/packages/web/src/app/api/repos/[owner]/[name]/branches/route.ts
@@ -1,14 +1,13 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ owner: string; name: string }> }
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/repos/[owner]/[name]/secrets/[key]/route.ts
+++ b/packages/web/src/app/api/repos/[owner]/[name]/secrets/[key]/route.ts
@@ -1,14 +1,13 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ owner: string; name: string; key: string }> }
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/repos/[owner]/[name]/secrets/route.ts
+++ b/packages/web/src/app/api/repos/[owner]/[name]/secrets/route.ts
@@ -1,14 +1,13 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ owner: string; name: string }> }
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -31,7 +30,7 @@ export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ owner: string; name: string }> }
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/repos/route.ts
+++ b/packages/web/src/app/api/repos/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import type { EnrichedRepository } from "@open-inspect/shared";
 
@@ -11,7 +10,7 @@ interface ControlPlaneReposResponse {
 }
 
 export async function GET() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/secrets/[key]/route.ts
+++ b/packages/web/src/app/api/secrets/[key]/route.ts
@@ -1,14 +1,13 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ key: string }> }
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/secrets/route.ts
+++ b/packages/web/src/app/api/secrets/route.ts
@@ -1,11 +1,10 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function GET() {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -21,7 +20,7 @@ export async function GET() {
 }
 
 export async function PUT(request: NextRequest) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/sessions/[id]/archive/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/archive/route.ts
@@ -1,12 +1,11 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   // Verify user is authenticated
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/sessions/[id]/attachments/[attachmentId]/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/attachments/[attachmentId]/route.test.ts
@@ -1,18 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("next-auth", () => ({
-  getServerSession: vi.fn(),
-}));
-
-vi.mock("@/lib/auth", () => ({
-  authOptions: {},
+vi.mock("@/lib/server-auth-session", () => ({
+  getServerAuthSession: vi.fn(),
 }));
 
 vi.mock("@/lib/control-plane", () => ({
   controlPlaneUserFetch: vi.fn(),
 }));
 
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { GET } from "./route";
 
@@ -23,11 +19,11 @@ const PARAMS = {
 describe("session attachment download API route", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
   });
 
   it("rejects unauthenticated downloads before contacting the control plane", async () => {
-    vi.mocked(getServerSession).mockResolvedValue(null);
+    vi.mocked(getServerAuthSession).mockResolvedValue(null);
 
     const response = await GET(
       new Request("http://localhost/api/sessions/session-1/attachments/attachment-1"),

--- a/packages/web/src/app/api/sessions/[id]/attachments/[attachmentId]/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/attachments/[attachmentId]/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 const SESSION_ID_PATTERN = /^[A-Za-z0-9-]+$/;
@@ -10,7 +9,7 @@ export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string; attachmentId: string }> }
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/sessions/[id]/attachments/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/attachments/route.test.ts
@@ -1,18 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("next-auth", () => ({
-  getServerSession: vi.fn(),
-}));
-
-vi.mock("@/lib/auth", () => ({
-  authOptions: {},
+vi.mock("@/lib/server-auth-session", () => ({
+  getServerAuthSession: vi.fn(),
 }));
 
 vi.mock("@/lib/control-plane", () => ({
   controlPlaneUserFetch: vi.fn(),
 }));
 
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { WEB_SESSION_ATTACHMENT_MAX_REQUEST_BYTES } from "@/lib/session-attachment-limits";
 import { POST } from "./route";
@@ -35,11 +31,11 @@ function streamingUploadRequest(size: number): Request {
 describe("session attachment API route", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
   });
 
   it("rejects unauthenticated uploads before reading the body", async () => {
-    vi.mocked(getServerSession).mockResolvedValue(null);
+    vi.mocked(getServerAuthSession).mockResolvedValue(null);
 
     const response = await POST(
       new Request("http://localhost/api/sessions/session-1/attachments", {

--- a/packages/web/src/app/api/sessions/[id]/attachments/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/attachments/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { WEB_SESSION_ATTACHMENT_MAX_REQUEST_BYTES } from "@/lib/session-attachment-limits";
 
@@ -33,7 +32,7 @@ async function readAttachmentRequestBody(request: Request): Promise<ArrayBuffer 
 }
 
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/sessions/[id]/children/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/children/route.ts
@@ -1,11 +1,10 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/sessions/[id]/diff/[revisionId]/files/[fileId]/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/diff/[revisionId]/files/[fileId]/route.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
-vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/server-auth-session", () => ({
+  getServerAuthSession: vi.fn(),
+}));
 vi.mock("@/lib/control-plane", () => ({ controlPlaneUserFetch: vi.fn() }));
 
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { GET } from "./route";
 
@@ -16,9 +17,9 @@ describe("session diff file API route", () => {
   beforeEach(() => vi.resetAllMocks());
 
   it("requires authentication and validates every route identity", async () => {
-    vi.mocked(getServerSession).mockResolvedValue(null);
+    vi.mocked(getServerAuthSession).mockResolvedValue(null);
     expect((await GET(new Request("http://local/patch"), context)).status).toBe(401);
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     const invalid = {
       params: Promise.resolve({ id: "../session", revisionId: "capture-1", fileId: "file-1" }),
     };
@@ -27,7 +28,7 @@ describe("session diff file API route", () => {
   });
 
   it("streams patch text from the revision-pinned control-plane route", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
       new Response("diff --git a/a b/a\n", {
         headers: { "Content-Type": "text/x-diff", ETag: '"patch-1"' },
@@ -45,7 +46,7 @@ describe("session diff file API route", () => {
   });
 
   it("preserves the stale-revision payload and status", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
       Response.json(
         { code: "diff_revision_stale", currentRevisionId: "capture-2" },
@@ -62,7 +63,7 @@ describe("session diff file API route", () => {
   });
 
   it("returns a bounded error when the control plane is unavailable", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockRejectedValue(new Error("offline"));
 
     const response = await GET(new Request("http://local/patch"), context);

--- a/packages/web/src/app/api/sessions/[id]/diff/[revisionId]/files/[fileId]/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/diff/[revisionId]/files/[fileId]/route.ts
@@ -1,7 +1,6 @@
 import { SESSION_DIFF_ID_PATTERN } from "@open-inspect/shared";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 /**
@@ -16,7 +15,7 @@ export async function GET(
     params: Promise<{ id: string; revisionId: string; fileId: string }>;
   }
 ): Promise<Response> {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const { id, revisionId, fileId } = await params;
   if (![id, revisionId, fileId].every((value) => SESSION_DIFF_ID_PATTERN.test(value))) {

--- a/packages/web/src/app/api/sessions/[id]/diff/retry/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/diff/retry/route.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
-vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/server-auth-session", () => ({
+  getServerAuthSession: vi.fn(),
+}));
 vi.mock("@/lib/control-plane", () => ({ controlPlaneUserFetch: vi.fn() }));
 
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { POST } from "./route";
 
@@ -12,7 +13,7 @@ describe("session diff retry API route", () => {
   beforeEach(() => vi.resetAllMocks());
 
   it("requires authentication", async () => {
-    vi.mocked(getServerSession).mockResolvedValue(null);
+    vi.mocked(getServerAuthSession).mockResolvedValue(null);
     const response = await POST(new Request("http://local"), {
       params: Promise.resolve({ id: "session-1" }),
     });
@@ -22,7 +23,7 @@ describe("session diff retry API route", () => {
   });
 
   it("proxies retry responses and preserves the upstream explanation", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
       Response.json({ error: "Sandbox is not connected" }, { status: 409 })
     );

--- a/packages/web/src/app/api/sessions/[id]/diff/retry/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/diff/retry/route.ts
@@ -1,7 +1,6 @@
 import { SESSION_DIFF_ID_PATTERN } from "@open-inspect/shared";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 /** Request a best-effort diff refresh after verifying the browser's NextAuth session. */
@@ -9,7 +8,7 @@ export async function POST(
   _request: Request,
   { params }: { params: Promise<{ id: string }> }
 ): Promise<Response> {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const { id } = await params;
   if (!SESSION_DIFF_ID_PATTERN.test(id)) {

--- a/packages/web/src/app/api/sessions/[id]/diff/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/diff/route.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
-vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("@/lib/server-auth-session", () => ({
+  getServerAuthSession: vi.fn(),
+}));
 vi.mock("@/lib/control-plane", () => ({ controlPlaneUserFetch: vi.fn() }));
 
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { GET } from "./route";
 
@@ -12,7 +13,7 @@ describe("session diff API route", () => {
   beforeEach(() => vi.resetAllMocks());
 
   it("requires authentication", async () => {
-    vi.mocked(getServerSession).mockResolvedValue(null);
+    vi.mocked(getServerAuthSession).mockResolvedValue(null);
     const context = { params: Promise.resolve({ id: "session-1" }) };
 
     expect(
@@ -22,7 +23,7 @@ describe("session diff API route", () => {
   });
 
   it("proxies the latest manifest with private caching", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValueOnce(
       Response.json({ version: 1, current: null, lastError: null, unavailableReason: null })
     );

--- a/packages/web/src/app/api/sessions/[id]/diff/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/diff/route.ts
@@ -1,7 +1,6 @@
 import { SESSION_DIFF_ID_PATTERN } from "@open-inspect/shared";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 /**
@@ -12,7 +11,7 @@ export async function GET(
   _request: Request,
   { params }: { params: Promise<{ id: string }> }
 ): Promise<Response> {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   const { id } = await params;
   if (!SESSION_DIFF_ID_PATTERN.test(id)) {

--- a/packages/web/src/app/api/sessions/[id]/media/[artifactId]/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/media/[artifactId]/route.test.ts
@@ -1,18 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("next-auth", () => ({
-  getServerSession: vi.fn(),
-}));
-
-vi.mock("@/lib/auth", () => ({
-  authOptions: {},
+vi.mock("@/lib/server-auth-session", () => ({
+  getServerAuthSession: vi.fn(),
 }));
 
 vi.mock("@/lib/control-plane", () => ({
   controlPlaneUserFetch: vi.fn(),
 }));
 
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { GET } from "./route";
 
@@ -22,7 +18,7 @@ describe("session media API route", () => {
   });
 
   it("returns 401 when the user session is missing", async () => {
-    vi.mocked(getServerSession).mockResolvedValue(null);
+    vi.mocked(getServerAuthSession).mockResolvedValue(null);
 
     const response = await GET(new Request("http://localhost/api/sessions/session-1/media/a1"), {
       params: Promise.resolve({
@@ -37,7 +33,7 @@ describe("session media API route", () => {
   });
 
   it("rejects invalid artifact IDs before proxying to the control plane", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: { id: "user-1" },
     } as never);
 
@@ -54,7 +50,7 @@ describe("session media API route", () => {
   });
 
   it("rejects invalid session IDs before proxying to the control plane", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: { id: "user-1" },
     } as never);
 
@@ -71,7 +67,7 @@ describe("session media API route", () => {
   });
 
   it("proxies successful media streams with private no-store caching", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: { id: "user-1" },
     } as never);
     const upstreamBody = Uint8Array.from([0x89, 0x50, 0x4e, 0x47]);
@@ -105,7 +101,7 @@ describe("session media API route", () => {
   });
 
   it("forwards range requests and range response headers", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: { id: "user-1" },
     } as never);
     const upstreamBody = Uint8Array.from([0x66, 0x74, 0x79, 0x70]);
@@ -149,7 +145,7 @@ describe("session media API route", () => {
   });
 
   it("passes through upstream error statuses", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: { id: "user-1" },
     } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
@@ -170,7 +166,7 @@ describe("session media API route", () => {
   });
 
   it("returns 500 when the control plane request throws", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: { id: "user-1" },
     } as never);
     vi.mocked(controlPlaneUserFetch).mockRejectedValue(new Error("boom"));

--- a/packages/web/src/app/api/sessions/[id]/media/[artifactId]/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/media/[artifactId]/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 const ARTIFACT_ID_PATTERN = /^[A-Za-z0-9-]+$/;
@@ -10,7 +9,7 @@ export async function GET(
   request: Request,
   { params }: { params: Promise<{ id: string; artifactId: string }> }
 ) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/sessions/[id]/prompt/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/prompt/route.test.ts
@@ -1,25 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("next-auth", () => ({
-  getServerSession: vi.fn(),
-}));
-
-vi.mock("@/lib/auth", () => ({
-  authOptions: {},
+vi.mock("@/lib/server-auth-session", () => ({
+  getServerAuthSession: vi.fn(),
 }));
 
 vi.mock("@/lib/control-plane", () => ({
   controlPlaneUserFetch: vi.fn(),
 }));
 
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { POST } from "./route";
 
 describe("session prompt API route", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "user-1" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "user-1" } } as never);
   });
 
   it("rejects malformed attachment references before proxying", async () => {

--- a/packages/web/src/app/api/sessions/[id]/prompt/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/prompt/route.ts
@@ -1,9 +1,8 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { sessionAttachmentReferencesSchema } from "@open-inspect/shared";
 import { z } from "zod";
-import { authOptions } from "@/lib/auth";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 const promptRequestSchema = z.strictObject({
@@ -14,7 +13,7 @@ const promptRequestSchema = z.strictObject({
 });
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/sessions/[id]/pull-requests/refresh/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/pull-requests/refresh/route.ts
@@ -1,12 +1,11 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   // Verify user is authenticated
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/sessions/[id]/title/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/title/route.ts
@@ -1,7 +1,6 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export function parseSessionTitlePatchBody(body: unknown): { title?: string } | null {
@@ -14,7 +13,7 @@ export function parseSessionTitlePatchBody(body: unknown): { title?: string } | 
 }
 
 export async function PATCH(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/sessions/[id]/unarchive/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/unarchive/route.ts
@@ -1,12 +1,11 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   // Verify user is authenticated
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session?.user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/sessions/[id]/ws-token/route.test.ts
+++ b/packages/web/src/app/api/sessions/[id]/ws-token/route.test.ts
@@ -1,19 +1,15 @@
 import type { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("next-auth", () => ({
-  getServerSession: vi.fn(),
-}));
-
-vi.mock("@/lib/auth", () => ({
-  authOptions: {},
+vi.mock("@/lib/server-auth-session", () => ({
+  getServerAuthSession: vi.fn(),
 }));
 
 vi.mock("@/lib/control-plane", () => ({
   controlPlaneUserFetch: vi.fn(),
 }));
 
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { POST } from "./route";
 
@@ -36,7 +32,7 @@ describe("ws-token API route", () => {
   });
 
   it("returns 401 when the session is missing", async () => {
-    vi.mocked(getServerSession).mockResolvedValue(null);
+    vi.mocked(getServerAuthSession).mockResolvedValue(null);
 
     const response = await POST(request(), params("sess1"));
 
@@ -45,7 +41,7 @@ describe("ws-token API route", () => {
   });
 
   it("sends scm* attribution for a GitHub user — never userId or credentials (forbidden under strict)", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: {
         id: "12345",
         login: "ada",
@@ -76,7 +72,7 @@ describe("ws-token API route", () => {
   });
 
   it("omits scm* entirely for a Google user — identity comes from the Bearer principal", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: {
         id: "google-sub-1",
         name: "Pat PM",

--- a/packages/web/src/app/api/sessions/[id]/ws-token/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/ws-token/route.ts
@@ -1,7 +1,6 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { buildAuthDisplay, buildScmAttribution } from "@/lib/build-auth-identity";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
@@ -17,7 +16,7 @@ import { controlPlaneUserFetch } from "@/lib/control-plane";
 export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const routeStart = Date.now();
 
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   const authMs = Date.now() - routeStart;
 
   if (!session?.user) {

--- a/packages/web/src/app/api/sessions/route.test.ts
+++ b/packages/web/src/app/api/sessions/route.test.ts
@@ -1,19 +1,15 @@
 import type { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("next-auth", () => ({
-  getServerSession: vi.fn(),
-}));
-
-vi.mock("@/lib/auth", () => ({
-  authOptions: {},
+vi.mock("@/lib/server-auth-session", () => ({
+  getServerAuthSession: vi.fn(),
 }));
 
 vi.mock("@/lib/control-plane", () => ({
   controlPlaneUserFetch: vi.fn(),
 }));
 
-import { getServerSession } from "next-auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { clearCurrentUserIdCacheForTests } from "@/lib/current-user";
 import { GET, POST } from "./route";
@@ -42,7 +38,7 @@ describe("sessions API route", () => {
   });
 
   it("returns 401 when the user session is missing", async () => {
-    vi.mocked(getServerSession).mockResolvedValue(null);
+    vi.mocked(getServerAuthSession).mockResolvedValue(null);
 
     const response = await GET(request("/api/sessions?limit=50"));
 
@@ -52,7 +48,7 @@ describe("sessions API route", () => {
   });
 
   it("forwards allowed session query params", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "12345" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({ user: { id: "12345" } } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
       Response.json({ sessions: [], hasMore: false }, { status: 200 })
     );
@@ -71,7 +67,7 @@ describe("sessions API route", () => {
   });
 
   it("resolves createdBy=me before forwarding sessions to the control plane", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: {
         id: "12345",
         login: "ada",
@@ -99,7 +95,9 @@ describe("sessions API route", () => {
   });
 
   it("returns 409 when createdBy=me cannot resolve a user id", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({ user: { email: "ada@example.com" } } as never);
+    vi.mocked(getServerAuthSession).mockResolvedValue({
+      user: { email: "ada@example.com" },
+    } as never);
 
     const response = await GET(request("/api/sessions?createdBy=me"));
 
@@ -109,7 +107,7 @@ describe("sessions API route", () => {
   });
 
   it("resolves createdBy=me for a Google user via the google provider route", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: {
         id: "google-sub-1",
         name: "Pat PM",
@@ -139,7 +137,7 @@ describe("sessions API route", () => {
   });
 
   it("resolves createdBy=me alongside explicit creator filters", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: {
         id: "12345",
         login: "ada",
@@ -167,7 +165,7 @@ describe("sessions API route", () => {
   });
 
   it("reuses the resolved current user across createdBy=me pagination requests", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: {
         id: "12345",
         login: "ada",
@@ -205,7 +203,7 @@ describe("sessions API route (POST)", () => {
   });
 
   it("returns 401 when the user session is missing", async () => {
-    vi.mocked(getServerSession).mockResolvedValue(null);
+    vi.mocked(getServerAuthSession).mockResolvedValue(null);
 
     const response = await POST(postRequest({ repoOwner: "o", repoName: "r" }));
 
@@ -214,7 +212,7 @@ describe("sessions API route (POST)", () => {
   });
 
   it("sends auth* display and scm* attribution for a GitHub session — never identity or credentials", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: {
         id: "12345",
         login: "ada",
@@ -262,7 +260,7 @@ describe("sessions API route (POST)", () => {
   });
 
   it("sends auth* display but no scm* for a Google session", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: {
         id: "google-sub-1",
         name: "Pat PM",
@@ -293,7 +291,7 @@ describe("sessions API route (POST)", () => {
   });
 
   it("forwards environmentId for environment launches", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: { id: "12345", provider: "github" },
     } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
@@ -311,7 +309,7 @@ describe("sessions API route (POST)", () => {
   });
 
   it("forwards the repositories list for ad-hoc multi-repo launches", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: { id: "12345", provider: "github" },
     } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
@@ -331,7 +329,7 @@ describe("sessions API route (POST)", () => {
   });
 
   it("still strips fields outside the allowlist", async () => {
-    vi.mocked(getServerSession).mockResolvedValue({
+    vi.mocked(getServerAuthSession).mockResolvedValue({
       user: { id: "12345", provider: "github" },
     } as never);
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -1,7 +1,6 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { buildAuthDisplay, buildScmAttribution } from "@/lib/build-auth-identity";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import {
@@ -14,7 +13,7 @@ import { CURRENT_USER_CREATED_BY } from "@/lib/session-list";
 export async function GET(request: NextRequest) {
   const routeStart = Date.now();
 
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   const authMs = Date.now() - routeStart;
 
   if (!session) {
@@ -64,7 +63,7 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const session = await getServerSession(authOptions);
+  const session = await getServerAuthSession();
   if (!session) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/lib/integration-settings-proxy.ts
+++ b/packages/web/src/lib/integration-settings-proxy.ts
@@ -1,7 +1,6 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth";
+import { getServerAuthSession } from "@/lib/server-auth-session";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 
 type ProxyMethod = "GET" | "PUT" | "DELETE";
@@ -34,7 +33,7 @@ export function integrationSettingsProxy<P>(
     context: { params: Promise<P> },
     method: ProxyMethod
   ): Promise<NextResponse> => {
-    const session = await getServerSession(authOptions);
+    const session = await getServerAuthSession();
     if (!session?.user) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }

--- a/packages/web/src/lib/server-auth-boundary-eslint.test.ts
+++ b/packages/web/src/lib/server-auth-boundary-eslint.test.ts
@@ -1,0 +1,46 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { ESLint } from "eslint";
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
+const resourceRoutePath = "packages/web/src/app/api/example/route.ts";
+const authRoutePath = "packages/web/src/app/api/auth/example/route.ts";
+
+const eslint = new ESLint({ cwd: repositoryRoot });
+
+async function restrictedImportMessages(source: string, filePath = resourceRoutePath) {
+  const [result] = await eslint.lintText(source, { filePath });
+  return result.messages.filter((message) => message.ruleId === "no-restricted-imports");
+}
+
+describe("server authentication import boundary", () => {
+  it.each([
+    {
+      description: "the authentication framework module",
+      source: 'import NextAuth from "next-auth";',
+    },
+    {
+      description: "the aliased auth implementation",
+      source: 'import { authOptions } from "@/lib/auth";',
+    },
+    {
+      description: "a relative path to the auth implementation",
+      source: 'import { authOptions } from "../../../lib/auth";',
+    },
+  ])("rejects $description", async ({ source }) => {
+    await expect(restrictedImportMessages(source)).resolves.toHaveLength(1);
+  });
+
+  it("allows resource routes to import the server-auth seam", async () => {
+    await expect(
+      restrictedImportMessages('import { getServerAuthSession } from "@/lib/server-auth-session";')
+    ).resolves.toHaveLength(0);
+  });
+
+  it("allows auth endpoints to own the framework integration", async () => {
+    await expect(
+      restrictedImportMessages('import NextAuth from "next-auth";', authRoutePath)
+    ).resolves.toHaveLength(0);
+  });
+});

--- a/packages/web/src/lib/server-auth-session.test.ts
+++ b/packages/web/src/lib/server-auth-session.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("./auth", () => ({
+  authOptions: { providers: [] },
+}));
+
+import { getServerSession } from "next-auth";
+import { authOptions } from "./auth";
+import { getServerAuthSession } from "./server-auth-session";
+
+describe("getServerAuthSession", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("delegates to the current NextAuth server session implementation", async () => {
+    const session = { user: { id: "user-1" } };
+    vi.mocked(getServerSession).mockResolvedValue(session as never);
+
+    await expect(getServerAuthSession()).resolves.toBe(session);
+    expect(getServerSession).toHaveBeenCalledOnce();
+    expect(getServerSession).toHaveBeenCalledWith(authOptions);
+  });
+});

--- a/packages/web/src/lib/server-auth-session.test.ts
+++ b/packages/web/src/lib/server-auth-session.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 
 vi.mock("next-auth", () => ({
   getServerSession: vi.fn(),
@@ -10,7 +10,7 @@ vi.mock("./auth", () => ({
 
 import { getServerSession } from "next-auth";
 import { authOptions } from "./auth";
-import { getServerAuthSession } from "./server-auth-session";
+import { getServerAuthSession, type ServerAuthSession } from "./server-auth-session";
 
 describe("getServerAuthSession", () => {
   beforeEach(() => {
@@ -24,5 +24,9 @@ describe("getServerAuthSession", () => {
     await expect(getServerAuthSession()).resolves.toBe(session);
     expect(getServerSession).toHaveBeenCalledOnce();
     expect(getServerSession).toHaveBeenCalledWith(authOptions);
+  });
+
+  it("exposes an app-owned session contract", () => {
+    expectTypeOf(getServerAuthSession).returns.toEqualTypeOf<Promise<ServerAuthSession | null>>();
   });
 });

--- a/packages/web/src/lib/server-auth-session.ts
+++ b/packages/web/src/lib/server-auth-session.ts
@@ -1,5 +1,18 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "./auth";
+import type { AuthIdentityUser } from "./build-auth-identity";
+
+export type ServerAuthUser = AuthIdentityUser;
+
+/**
+ * App-owned session contract consumed by server-side BFF routes.
+ *
+ * Provider-specific session implementations adapt to this shape at the seam so
+ * route authorization does not depend on framework-owned session types.
+ */
+export interface ServerAuthSession {
+  user?: ServerAuthUser | null;
+}
 
 /**
  * Server-side authentication seam for BFF routes.
@@ -8,6 +21,6 @@ import { authOptions } from "./auth";
  * later terminal-auth change can replace this boundary without another
  * repository-wide route migration.
  */
-export function getServerAuthSession() {
+export function getServerAuthSession(): Promise<ServerAuthSession | null> {
   return getServerSession(authOptions);
 }

--- a/packages/web/src/lib/server-auth-session.ts
+++ b/packages/web/src/lib/server-auth-session.ts
@@ -1,0 +1,13 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "./auth";
+
+/**
+ * Server-side authentication seam for BFF routes.
+ *
+ * This deliberately delegates to the existing NextAuth implementation. A
+ * later terminal-auth change can replace this boundary without another
+ * repository-wide route migration.
+ */
+export function getServerAuthSession() {
+  return getServerSession(authOptions);
+}


### PR DESCRIPTION
## Summary

- add a server-side authentication seam that delegates to the existing NextAuth behavior
- migrate all BFF session checks and their tests to the seam
- enforce the boundary with ESLint so resource routes do not import NextAuth directly

## Why

This is the first behavior-neutral preparation PR for the browser-authentication work. It reduces the eventual terminal-auth cutover by isolating framework replacement to one server boundary. It does not change authentication behavior, cookies, routes, provider handling, or deployment configuration.

## Validation

- npm run build -w @open-inspect/shared
- npm test -w @open-inspect/web (105 files, 912 tests)
- npm run typecheck -w @open-inspect/web
- npm run lint
- npm run build -w @open-inspect/web
- npm run format:check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Reliability**
  * Standardized server-side authentication across analytics, automation, environment, repository, session, integration, and related endpoints.
  * Unauthenticated requests continue to receive consistent authorization errors; authenticated behavior and responses remain unchanged.
  * Added guardrails to discourage inconsistent or forbidden authentication imports in new server routes.

* **Tests**
  * Updated API and route tests to use the standardized authentication flow, covering both authenticated and unauthenticated cases.
  * Added checks ensuring the shared server-auth seam returns the expected session and is used consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->