### PR TITLE
refactor(web): centralize client auth and requests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -143,7 +143,7 @@ export default tseslint.config(
     },
   },
 
-  // Client code depends on app-owned auth and request seams so the terminal
+  // Web code depends on app-owned auth and request seams so the terminal
   // browser-auth implementation can replace NextAuth and add its request
   // contract without another consumer migration.
   {
@@ -168,20 +168,21 @@ export default tseslint.config(
     },
   },
   {
-    files: [
-      "packages/web/src/app/(app)/**/*.{ts,tsx}",
-      "packages/web/src/app/providers.tsx",
-      "packages/web/src/components/**/*.{ts,tsx}",
-      "packages/web/src/hooks/**/*.{ts,tsx}",
-      "packages/web/src/lib/archive-session.ts",
+    files: ["packages/web/src/**/*.{ts,tsx}"],
+    ignores: [
+      "**/*.test.{ts,tsx}",
+      "**/*.spec.{ts,tsx}",
+      "packages/web/src/lib/auth.ts",
+      "packages/web/src/lib/browser-api-fetch.ts",
+      "packages/web/src/lib/control-plane-transport.ts",
+      "packages/web/src/lib/github-org-membership.ts",
     ],
-    ignores: ["**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}"],
     rules: {
       "no-restricted-globals": [
         "error",
         {
           name: "fetch",
-          message: "Use browserApiFetch from @/lib/browser-api-fetch.",
+          message: "Use an app-owned HTTP transport instead of raw fetch.",
         },
       ],
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -143,6 +143,50 @@ export default tseslint.config(
     },
   },
 
+  // Client code depends on app-owned auth and request seams so the terminal
+  // browser-auth implementation can replace NextAuth and add its request
+  // contract without another consumer migration.
+  {
+    files: ["packages/web/src/**/*.{ts,tsx}"],
+    ignores: [
+      "packages/web/src/app/api/**",
+      "packages/web/src/lib/auth-session.tsx",
+      "packages/web/src/lib/auth-session.test.tsx",
+    ],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "next-auth/react",
+              message: "Use the app-owned boundary from @/lib/auth-session.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    files: [
+      "packages/web/src/app/(app)/**/*.{ts,tsx}",
+      "packages/web/src/app/providers.tsx",
+      "packages/web/src/components/**/*.{ts,tsx}",
+      "packages/web/src/hooks/**/*.{ts,tsx}",
+      "packages/web/src/lib/archive-session.ts",
+    ],
+    ignores: ["**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}"],
+    rules: {
+      "no-restricted-globals": [
+        "error",
+        {
+          name: "fetch",
+          message: "Use browserApiFetch from @/lib/browser-api-fetch.",
+        },
+      ],
+    },
+  },
+
   // Cloudflare Workers specific config
   {
     files: ["packages/control-plane/**/*.ts"],

--- a/packages/web/src/app/(app)/automations/[id]/edit/page.tsx
+++ b/packages/web/src/app/(app)/automations/[id]/edit/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/automations/automation-form";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { BackIcon } from "@/components/ui/icons";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 
 export default function EditAutomationPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
@@ -25,7 +26,7 @@ export default function EditAutomationPage({ params }: { params: Promise<{ id: s
     setError("");
 
     try {
-      const res = await fetch(`/api/automations/${id}`, {
+      const res = await browserApiFetch(`/api/automations/${id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(values),

--- a/packages/web/src/app/(app)/automations/[id]/page.tsx
+++ b/packages/web/src/app/(app)/automations/[id]/page.tsx
@@ -15,6 +15,7 @@ import { ErrorBanner } from "@/components/ui/error-banner";
 import { BackIcon, PencilIcon } from "@/components/ui/icons";
 import { formatModelNameLower } from "@/lib/format";
 import { formatAutomationTargetsLabel } from "@/lib/repo-label";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 
 const HISTORY_PAGE_SIZE = 20;
 
@@ -45,7 +46,7 @@ export default function AutomationDetailPage({ params }: { params: Promise<{ id:
   const handleAction = async (action: "pause" | "resume" | "trigger") => {
     setActionError(null);
     try {
-      const res = await fetch(`/api/automations/${id}/${action}`, { method: "POST" });
+      const res = await browserApiFetch(`/api/automations/${id}/${action}`, { method: "POST" });
       if (!res.ok) {
         setActionError(`Failed to ${action} automation`);
         return;
@@ -61,7 +62,7 @@ export default function AutomationDetailPage({ params }: { params: Promise<{ id:
   const handleDelete = async () => {
     setActionError(null);
     try {
-      const res = await fetch(`/api/automations/${id}`, { method: "DELETE" });
+      const res = await browserApiFetch(`/api/automations/${id}`, { method: "DELETE" });
       if (!res.ok) {
         setActionError("Failed to delete automation");
         return;

--- a/packages/web/src/app/(app)/automations/new/page.tsx
+++ b/packages/web/src/app/(app)/automations/new/page.tsx
@@ -12,6 +12,7 @@ import { getTemplateById } from "@/lib/automation-templates";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { BackIcon } from "@/components/ui/icons";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 import Link from "next/link";
 
 function NewAutomationContent() {
@@ -39,7 +40,7 @@ function NewAutomationContent() {
     setError("");
 
     try {
-      const res = await fetch("/api/automations", {
+      const res = await browserApiFetch("/api/automations", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(values),

--- a/packages/web/src/app/(app)/automations/page.tsx
+++ b/packages/web/src/app/(app)/automations/page.tsx
@@ -8,6 +8,7 @@ import { AutomationsList } from "@/components/automations/automations-list";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { PlusIcon } from "@/components/ui/icons";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 
 export default function AutomationsPage() {
   const { isOpen } = useSidebarContext();
@@ -22,7 +23,7 @@ export default function AutomationsPage() {
     const method = action === "delete" ? "DELETE" : "POST";
 
     try {
-      const res = await fetch(endpoint, { method });
+      const res = await browserApiFetch(endpoint, { method });
       if (!res.ok) {
         setActionError(`Failed to ${action} automation`);
         return;

--- a/packages/web/src/app/(app)/automations/page.tsx
+++ b/packages/web/src/app/(app)/automations/page.tsx
@@ -8,7 +8,7 @@ import { AutomationsList } from "@/components/automations/automations-list";
 import { Button } from "@/components/ui/button";
 import { ErrorBanner } from "@/components/ui/error-banner";
 import { PlusIcon } from "@/components/ui/icons";
-import { browserApiFetch } from "@/lib/browser-api-fetch";
+import { browserApiFetch, type BrowserApiPath } from "@/lib/browser-api-fetch";
 
 export default function AutomationsPage() {
   const { isOpen } = useSidebarContext();
@@ -18,7 +18,7 @@ export default function AutomationsPage() {
 
   const handleAction = async (id: string, action: "pause" | "resume" | "trigger" | "delete") => {
     setActionError(null);
-    const endpoint =
+    const endpoint: BrowserApiPath =
       action === "delete" ? `/api/automations/${id}` : `/api/automations/${id}/${action}`;
     const method = action === "delete" ? "DELETE" : "POST";
 

--- a/packages/web/src/app/(app)/page.test.tsx
+++ b/packages/web/src/app/(app)/page.test.tsx
@@ -50,8 +50,8 @@ const repo = {
   defaultBranch: "main",
 };
 
-vi.mock("next-auth/react", () => ({
-  useSession: () => ({ data: { user: { id: "user-1" } }, status: "authenticated" }),
+vi.mock("@/lib/auth-session", () => ({
+  useAuthSession: () => ({ data: { user: { id: "user-1" } }, status: "authenticated" }),
 }));
 
 vi.mock("next/navigation", () => ({

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useSession } from "next-auth/react";
+import { useAuthSession } from "@/lib/auth-session";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 import { useRouter } from "next/navigation";
 import { mutate } from "swr";
 import { useState, useEffect, useRef, useCallback } from "react";
@@ -39,7 +40,7 @@ const LAST_SELECTED_MODEL_STORAGE_KEY = "open-inspect-last-selected-model";
 const LAST_SELECTED_REASONING_EFFORT_STORAGE_KEY = "open-inspect-last-selected-reasoning-effort";
 
 export default function Home() {
-  const { data: session } = useSession();
+  const { data: session } = useAuthSession();
   const router = useRouter();
   const picker = useSessionTargetPicker();
   const { sessionTarget, selectedBranch, configKey, buildRequestFields, isLaunchable } = picker;
@@ -117,7 +118,7 @@ export default function Home() {
 
     const promise = (async () => {
       try {
-        const res = await fetch("/api/sessions", {
+        const res = await browserApiFetch("/api/sessions", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -254,7 +255,7 @@ export default function Home() {
         }
       }
 
-      const res = await fetch(`/api/sessions/${sessionId}/prompt`, {
+      const res = await browserApiFetch(`/api/sessions/${sessionId}/prompt`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -19,7 +19,7 @@ import {
 } from "react-resizable-panels";
 import { TerminalPanel } from "@/components/terminal-panel";
 import { archiveSession } from "@/lib/archive-session";
-import { browserApiFetch, toBrowserApiPath } from "@/lib/browser-api-fetch";
+import { browserApiFetch, type BrowserApiPath } from "@/lib/browser-api-fetch";
 import {
   isArchivedSessionListKey,
   isUnarchivedSessionListKey,
@@ -448,8 +448,8 @@ function useSessionListActions(sessionId: string) {
 
   const { trigger: triggerRename } = useSWRMutation(
     `/api/sessions/${sessionId}/title`,
-    (url: string, { arg }: { arg: { title: string } }) =>
-      browserApiFetch(toBrowserApiPath(url), {
+    (url: BrowserApiPath, { arg }: { arg: { title: string } }) =>
+      browserApiFetch(url, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ title: arg.title }),
@@ -514,8 +514,8 @@ function useSessionListActions(sessionId: string) {
 
   const { trigger: handleUnarchive } = useSWRMutation(
     `/api/sessions/${sessionId}/unarchive`,
-    (url: string) =>
-      browserApiFetch(toBrowserApiPath(url), { method: "POST" }).then(async (r) => {
+    (url: BrowserApiPath) =>
+      browserApiFetch(url, { method: "POST" }).then(async (r) => {
         if (r.ok) {
           await mutate<SessionListResponse>(
             isArchivedSessionListKey,

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -19,7 +19,7 @@ import {
 } from "react-resizable-panels";
 import { TerminalPanel } from "@/components/terminal-panel";
 import { archiveSession } from "@/lib/archive-session";
-import { browserApiFetch } from "@/lib/browser-api-fetch";
+import { browserApiFetch, toBrowserApiPath } from "@/lib/browser-api-fetch";
 import {
   isArchivedSessionListKey,
   isUnarchivedSessionListKey,
@@ -449,7 +449,7 @@ function useSessionListActions(sessionId: string) {
   const { trigger: triggerRename } = useSWRMutation(
     `/api/sessions/${sessionId}/title`,
     (url: string, { arg }: { arg: { title: string } }) =>
-      browserApiFetch(url, {
+      browserApiFetch(toBrowserApiPath(url), {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ title: arg.title }),
@@ -515,7 +515,7 @@ function useSessionListActions(sessionId: string) {
   const { trigger: handleUnarchive } = useSWRMutation(
     `/api/sessions/${sessionId}/unarchive`,
     (url: string) =>
-      browserApiFetch(url, { method: "POST" }).then(async (r) => {
+      browserApiFetch(toBrowserApiPath(url), { method: "POST" }).then(async (r) => {
         if (r.ok) {
           await mutate<SessionListResponse>(
             isArchivedSessionListKey,

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -19,6 +19,7 @@ import {
 } from "react-resizable-panels";
 import { TerminalPanel } from "@/components/terminal-panel";
 import { archiveSession } from "@/lib/archive-session";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 import {
   isArchivedSessionListKey,
   isUnarchivedSessionListKey,
@@ -448,7 +449,7 @@ function useSessionListActions(sessionId: string) {
   const { trigger: triggerRename } = useSWRMutation(
     `/api/sessions/${sessionId}/title`,
     (url: string, { arg }: { arg: { title: string } }) =>
-      fetch(url, {
+      browserApiFetch(url, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ title: arg.title }),
@@ -514,7 +515,7 @@ function useSessionListActions(sessionId: string) {
   const { trigger: handleUnarchive } = useSWRMutation(
     `/api/sessions/${sessionId}/unarchive`,
     (url: string) =>
-      fetch(url, { method: "POST" }).then(async (r) => {
+      browserApiFetch(url, { method: "POST" }).then(async (r) => {
         if (r.ok) {
           await mutate<SessionListResponse>(
             isArchivedSessionListKey,

--- a/packages/web/src/app/providers.test.tsx
+++ b/packages/web/src/app/providers.test.tsx
@@ -19,13 +19,16 @@ function findByType(node: ReactNode, type: unknown): ReactElement | undefined {
 }
 
 describe("Providers", () => {
-  it("places the application behind the client authentication provider", () => {
-    expect(findByType(Providers({ children: null }), AuthSessionProvider)).toBeDefined();
-  });
-
-  it("places application children behind the web-session gate", () => {
+  it("nests the application gate and children inside the authentication provider", () => {
     const child = <div>Protected application</div>;
-    const gate = findByType(Providers({ children: child }), WebSessionGate);
+    const authProvider = findByType(Providers({ children: child }), AuthSessionProvider);
+
+    expect(authProvider).toBeDefined();
+
+    const gate = findByType(
+      (authProvider as ReactElement<{ children?: ReactNode }>).props.children,
+      WebSessionGate
+    );
 
     expect(gate).toBeDefined();
     expect((gate as ReactElement<{ children?: ReactNode }>).props.children).toBe(child);

--- a/packages/web/src/app/providers.test.tsx
+++ b/packages/web/src/app/providers.test.tsx
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { isValidElement, type ReactElement, type ReactNode } from "react";
-import { SessionProvider } from "next-auth/react";
 
 import { WebSessionGate } from "@/components/web-session-gate";
+import { AuthSessionProvider } from "@/lib/auth-session";
 import { Providers } from "./providers";
 
 function findByType(node: ReactNode, type: unknown): ReactElement | undefined {
@@ -19,15 +19,8 @@ function findByType(node: ReactNode, type: unknown): ReactElement | undefined {
 }
 
 describe("Providers", () => {
-  it("keeps the SessionProvider focus refetch disabled", () => {
-    // A focus refetch would make /api/auth/session a second session-cookie
-    // writer racing the oi-refresh rotation write; the rotation machinery
-    // depends on oi-refresh being the only focus/interval-triggered writer.
-    const sessionProvider = findByType(Providers({ children: null }), SessionProvider);
-    expect(sessionProvider).toBeDefined();
-    expect(
-      (sessionProvider as ReactElement<{ refetchOnWindowFocus?: boolean }>).props
-    ).toMatchObject({ refetchOnWindowFocus: false });
+  it("places the application behind the client authentication provider", () => {
+    expect(findByType(Providers({ children: null }), AuthSessionProvider)).toBeDefined();
   });
 
   it("places application children behind the web-session gate", () => {

--- a/packages/web/src/app/providers.tsx
+++ b/packages/web/src/app/providers.tsx
@@ -6,10 +6,10 @@ import { WebSessionGate } from "@/components/web-session-gate";
 import { Toaster } from "@/components/ui/sonner";
 import { SyntaxHighlightTheme } from "@/components/syntax-highlight-theme";
 import { AuthSessionProvider } from "@/lib/auth-session";
-import { browserApiFetch } from "@/lib/browser-api-fetch";
+import { browserApiFetch, toBrowserApiPath } from "@/lib/browser-api-fetch";
 
 async function swrFetcher<T>(url: string): Promise<T> {
-  const res = await browserApiFetch(url);
+  const res = await browserApiFetch(toBrowserApiPath(url));
   if (!res.ok) throw new Error(`Fetch failed: ${res.status}`);
   return res.json();
 }

--- a/packages/web/src/app/providers.tsx
+++ b/packages/web/src/app/providers.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { SessionProvider } from "next-auth/react";
 import { ThemeProvider } from "next-themes";
 import { SWRConfig } from "swr";
 import { WebSessionGate } from "@/components/web-session-gate";
 import { Toaster } from "@/components/ui/sonner";
 import { SyntaxHighlightTheme } from "@/components/syntax-highlight-theme";
+import { AuthSessionProvider } from "@/lib/auth-session";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 
 async function swrFetcher<T>(url: string): Promise<T> {
-  const res = await fetch(url);
+  const res = await browserApiFetch(url);
   if (!res.ok) throw new Error(`Fetch failed: ${res.status}`);
   return res.json();
 }
@@ -26,11 +27,11 @@ export function Providers({ children }: { children: React.ReactNode }) {
           session fetch is safe because WebSessionGate checks only after
           it resolves.
         */}
-        <SessionProvider refetchOnWindowFocus={false}>
+        <AuthSessionProvider>
           <WebSessionGate>{children}</WebSessionGate>
           <SyntaxHighlightTheme />
           <Toaster />
-        </SessionProvider>
+        </AuthSessionProvider>
       </SWRConfig>
     </ThemeProvider>
   );

--- a/packages/web/src/app/providers.tsx
+++ b/packages/web/src/app/providers.tsx
@@ -6,10 +6,10 @@ import { WebSessionGate } from "@/components/web-session-gate";
 import { Toaster } from "@/components/ui/sonner";
 import { SyntaxHighlightTheme } from "@/components/syntax-highlight-theme";
 import { AuthSessionProvider } from "@/lib/auth-session";
-import { browserApiFetch, toBrowserApiPath } from "@/lib/browser-api-fetch";
+import { browserApiFetch, type BrowserApiPath } from "@/lib/browser-api-fetch";
 
-async function swrFetcher<T>(url: string): Promise<T> {
-  const res = await browserApiFetch(toBrowserApiPath(url));
+async function swrFetcher<T>(url: BrowserApiPath): Promise<T> {
+  const res = await browserApiFetch(url);
   if (!res.ok) throw new Error(`Fetch failed: ${res.status}`);
   return res.json();
 }

--- a/packages/web/src/components/diff-retry-notice.test.tsx
+++ b/packages/web/src/components/diff-retry-notice.test.tsx
@@ -20,6 +20,8 @@ describe("DiffRetryNotice", () => {
     await userEvent.click(screen.getByRole("button", { name: "Retry" }));
     expect(fetchMock).toHaveBeenCalledWith("/api/sessions/session-1/diff/retry", {
       method: "POST",
+      mode: "same-origin",
+      credentials: "same-origin",
     });
   });
 
@@ -45,6 +47,8 @@ describe("DiffRetryNotice", () => {
     await userEvent.click(screen.getByRole("button", { name: "Retry" }));
     expect(fetchMock).toHaveBeenCalledWith("/api/sessions/session-2/diff/retry", {
       method: "POST",
+      mode: "same-origin",
+      credentials: "same-origin",
     });
     expect(await screen.findByRole("alert")).toHaveTextContent("Still failing");
   });

--- a/packages/web/src/components/secrets-editor.tsx
+++ b/packages/web/src/components/secrets-editor.tsx
@@ -7,7 +7,7 @@ import { encodeRepositoryPathSegments } from "@open-inspect/shared";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { browserApiFetch } from "@/lib/browser-api-fetch";
+import { browserApiFetch, type BrowserApiPath } from "@/lib/browser-api-fetch";
 
 import { normalizeKey, parseMaybeEnvContent, type ParsedEnvEntry } from "@/lib/env-paste";
 
@@ -89,7 +89,7 @@ type SecretsScope = "repo" | "global" | "environment";
  * case here, not another conditional in the component body.
  */
 interface SecretsScopePolicy {
-  apiBase: string;
+  apiBase: BrowserApiPath;
   ready: boolean;
   description: string;
   emptyStateText: string;

--- a/packages/web/src/components/secrets-editor.tsx
+++ b/packages/web/src/components/secrets-editor.tsx
@@ -7,6 +7,7 @@ import { encodeRepositoryPathSegments } from "@open-inspect/shared";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 
 import { normalizeKey, parseMaybeEnvContent, type ParsedEnvEntry } from "@/lib/env-paste";
 
@@ -296,7 +297,7 @@ export function SecretsEditor({
     setError("");
 
     try {
-      const response = await fetch(`${apiBase}/${normalizedKey}`, {
+      const response = await browserApiFetch(`${apiBase}/${normalizedKey}`, {
         method: "DELETE",
       });
       const data = await response.json();
@@ -381,7 +382,7 @@ export function SecretsEditor({
         payload[entry.key] = entry.value;
       }
 
-      const response = await fetch(apiBase, {
+      const response = await browserApiFetch(apiBase, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ secrets: payload }),

--- a/packages/web/src/components/session-changes-panel.test.tsx
+++ b/packages/web/src/components/session-changes-panel.test.tsx
@@ -153,6 +153,8 @@ describe("SessionChangesPanel", () => {
     await userEvent.click(screen.getByRole("button", { name: "Retry" }));
     expect(fetchMock).toHaveBeenCalledWith("/api/sessions/session-1/diff/retry", {
       method: "POST",
+      mode: "same-origin",
+      credentials: "same-origin",
     });
     expect(await screen.findByText("Sandbox is not connected")).toBeVisible();
   });

--- a/packages/web/src/components/session-changes-panel.tsx
+++ b/packages/web/src/components/session-changes-panel.tsx
@@ -14,6 +14,7 @@ import { useDiffFileNavigation } from "@/hooks/use-diff-file-navigation";
 import { usePanelWidth } from "@/hooks/use-panel-width";
 import { parseDiffErrorBody } from "@/lib/session-diffs";
 import type { DiffSelection, ResolvedDiffSelection } from "@/lib/session-diffs";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 import { cn } from "@/lib/utils";
 import { DiffRetryNotice } from "@/components/diff-retry-notice";
 import { FilesChangedSection } from "@/components/sidebar/files-changed-section";
@@ -37,7 +38,7 @@ class DiffPatchError extends Error {
 }
 
 async function fetchPatch(url: string): Promise<string> {
-  const response = await fetch(url);
+  const response = await browserApiFetch(url);
   if (!response.ok) {
     let code: SessionDiffErrorCode | undefined;
     try {

--- a/packages/web/src/components/session-changes-panel.tsx
+++ b/packages/web/src/components/session-changes-panel.tsx
@@ -14,7 +14,7 @@ import { useDiffFileNavigation } from "@/hooks/use-diff-file-navigation";
 import { usePanelWidth } from "@/hooks/use-panel-width";
 import { parseDiffErrorBody } from "@/lib/session-diffs";
 import type { DiffSelection, ResolvedDiffSelection } from "@/lib/session-diffs";
-import { browserApiFetch, toBrowserApiPath } from "@/lib/browser-api-fetch";
+import { browserApiFetch, type BrowserApiPath } from "@/lib/browser-api-fetch";
 import { cn } from "@/lib/utils";
 import { DiffRetryNotice } from "@/components/diff-retry-notice";
 import { FilesChangedSection } from "@/components/sidebar/files-changed-section";
@@ -37,8 +37,8 @@ class DiffPatchError extends Error {
   }
 }
 
-async function fetchPatch(url: string): Promise<string> {
-  const response = await browserApiFetch(toBrowserApiPath(url));
+async function fetchPatch(url: BrowserApiPath): Promise<string> {
+  const response = await browserApiFetch(url);
   if (!response.ok) {
     let code: SessionDiffErrorCode | undefined;
     try {

--- a/packages/web/src/components/session-changes-panel.tsx
+++ b/packages/web/src/components/session-changes-panel.tsx
@@ -14,7 +14,7 @@ import { useDiffFileNavigation } from "@/hooks/use-diff-file-navigation";
 import { usePanelWidth } from "@/hooks/use-panel-width";
 import { parseDiffErrorBody } from "@/lib/session-diffs";
 import type { DiffSelection, ResolvedDiffSelection } from "@/lib/session-diffs";
-import { browserApiFetch } from "@/lib/browser-api-fetch";
+import { browserApiFetch, toBrowserApiPath } from "@/lib/browser-api-fetch";
 import { cn } from "@/lib/utils";
 import { DiffRetryNotice } from "@/components/diff-retry-notice";
 import { FilesChangedSection } from "@/components/sidebar/files-changed-section";
@@ -38,7 +38,7 @@ class DiffPatchError extends Error {
 }
 
 async function fetchPatch(url: string): Promise<string> {
-  const response = await browserApiFetch(url);
+  const response = await browserApiFetch(toBrowserApiPath(url));
   if (!response.ok) {
     let code: SessionDiffErrorCode | undefined;
     try {

--- a/packages/web/src/components/session-list-item.tsx
+++ b/packages/web/src/components/session-list-item.tsx
@@ -9,6 +9,7 @@ import { PullRequestStateIcon } from "@/components/pr-state-icon";
 import { formatRelativeTime } from "@/lib/time";
 import { MoreIcon, ArchiveIcon, BranchIcon, BoxIcon } from "@/components/ui/icons";
 import { formatSessionRepositoriesLabel } from "@/lib/repo-label";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -135,7 +136,7 @@ export function SessionListItem({
     setIsRenaming(false);
 
     try {
-      const response = await fetch(`/api/sessions/${session.id}/title`, {
+      const response = await browserApiFetch(`/api/sessions/${session.id}/title`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ title: trimmed }),

--- a/packages/web/src/components/session-sidebar.test.tsx
+++ b/packages/web/src/components/session-sidebar.test.tsx
@@ -282,7 +282,11 @@ describe("SessionSidebar", () => {
     expect(await screen.findByText("Session 55")).toBeInTheDocument();
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
-        buildSessionsPageKey({ excludeStatus: "archived", offset: 50 })
+        buildSessionsPageKey({ excludeStatus: "archived", offset: 50 }),
+        {
+          mode: "same-origin",
+          credentials: "same-origin",
+        }
       );
     });
   });
@@ -437,7 +441,10 @@ describe("SessionSidebar", () => {
 
     fireEvent.scroll(scrollContainer);
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith(allNextPageKey);
+      expect(fetchMock).toHaveBeenCalledWith(allNextPageKey, {
+        mode: "same-origin",
+        credentials: "same-origin",
+      });
     });
 
     fireEvent.click(screen.getByText("Mine"));
@@ -566,7 +573,11 @@ describe("SessionSidebar", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Archive" }));
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith("/api/sessions/session-1/archive", { method: "POST" });
+      expect(fetchMock).toHaveBeenCalledWith("/api/sessions/session-1/archive", {
+        method: "POST",
+        mode: "same-origin",
+        credentials: "same-origin",
+      });
     });
   });
 
@@ -607,7 +618,11 @@ describe("SessionSidebar", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Archive" }));
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith("/api/sessions/session-1/archive", { method: "POST" });
+      expect(fetchMock).toHaveBeenCalledWith("/api/sessions/session-1/archive", {
+        method: "POST",
+        mode: "same-origin",
+        credentials: "same-origin",
+      });
     });
 
     expect(screen.getByRole("link", { name: /session 1/i })).toBeInTheDocument();

--- a/packages/web/src/components/session-sidebar.test.tsx
+++ b/packages/web/src/components/session-sidebar.test.tsx
@@ -22,8 +22,8 @@ const { mockPush } = vi.hoisted(() => ({
   mockPush: vi.fn(),
 }));
 
-vi.mock("next-auth/react", () => ({
-  useSession: () => ({
+vi.mock("@/lib/auth-session", () => ({
+  useAuthSession: () => ({
     data: {
       user: {
         name: "Test User",

--- a/packages/web/src/components/session-sidebar.tsx
+++ b/packages/web/src/components/session-sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useMemo, useCallback } from "react";
-import { useSession } from "next-auth/react";
+import { useAuthSession } from "@/lib/auth-session";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import { useIsMobile } from "@/hooks/use-media-query";
 import { useSidebarSessions } from "@/hooks/use-sidebar-sessions";
@@ -70,7 +70,7 @@ export function SessionSidebar({
   onToggle,
   onSessionSelect,
 }: SessionSidebarProps) {
-  const { data: authSession } = useSession();
+  const { data: authSession } = useAuthSession();
   const pathname = usePathname();
   const isMobile = useIsMobile();
 

--- a/packages/web/src/components/settings/data-controls-settings.tsx
+++ b/packages/web/src/components/settings/data-controls-settings.tsx
@@ -14,6 +14,7 @@ import {
   type SessionListResponse,
 } from "@/lib/session-list";
 import { formatRelativeTime } from "@/lib/time";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 
 const PAGE_SIZE = 20;
 const ARCHIVED_SESSIONS_KEY = buildSessionsPageKey({
@@ -43,7 +44,7 @@ export function DataControlsSettings() {
   const handleLoadMore = useCallback(async () => {
     setLoadingMore(true);
     try {
-      const res = await fetch(
+      const res = await browserApiFetch(
         buildSessionsPageKey({
           status: "archived",
           limit: PAGE_SIZE,
@@ -66,7 +67,9 @@ export function DataControlsSettings() {
 
   const handleUnarchive = async (sessionId: string) => {
     try {
-      const res = await fetch(`/api/sessions/${sessionId}/unarchive`, { method: "POST" });
+      const res = await browserApiFetch(`/api/sessions/${sessionId}/unarchive`, {
+        method: "POST",
+      });
       if (!res.ok) {
         toast.error("Failed to unarchive session");
         return;

--- a/packages/web/src/components/settings/environment-integration-settings.tsx
+++ b/packages/web/src/components/settings/environment-integration-settings.tsx
@@ -5,6 +5,7 @@ import useSWR from "swr";
 import { toast } from "sonner";
 import type { CodeServerSettings, EnvironmentRepository } from "@open-inspect/shared";
 import { Button } from "@/components/ui/button";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 import {
   Select,
   SelectContent,
@@ -95,8 +96,8 @@ function EnvironmentCodeServerOverride({ environmentId }: { environmentId: strin
     try {
       const res =
         resolved === "inherit"
-          ? await fetch(apiUrl, { method: "DELETE" })
-          : await fetch(apiUrl, {
+          ? await browserApiFetch(apiUrl, { method: "DELETE" })
+          : await browserApiFetch(apiUrl, {
               method: "PUT",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ settings: { enabled: resolved === "enabled" } }),

--- a/packages/web/src/components/settings/environment-integration-settings.tsx
+++ b/packages/web/src/components/settings/environment-integration-settings.tsx
@@ -5,7 +5,7 @@ import useSWR from "swr";
 import { toast } from "sonner";
 import type { CodeServerSettings, EnvironmentRepository } from "@open-inspect/shared";
 import { Button } from "@/components/ui/button";
-import { browserApiFetch } from "@/lib/browser-api-fetch";
+import { browserApiFetch, type BrowserApiPath } from "@/lib/browser-api-fetch";
 import {
   Select,
   SelectContent,
@@ -78,7 +78,7 @@ export function EnvironmentIntegrationSettings({
  * modeled as no stored override at all.
  */
 function EnvironmentCodeServerOverride({ environmentId }: { environmentId: string }) {
-  const apiUrl = `/api/integration-settings/code-server/environments/${environmentId}`;
+  const apiUrl: BrowserApiPath = `/api/integration-settings/code-server/environments/${environmentId}`;
   const { data, mutate, isLoading } = useSWR<EnvironmentCodeServerResponse>(apiUrl);
 
   const current: CodeServerChoice =

--- a/packages/web/src/components/settings/environment-secrets-import.tsx
+++ b/packages/web/src/components/settings/environment-secrets-import.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Combobox } from "@/components/ui/combobox";
 import { RepoIcon, ChevronDownIcon } from "@/components/ui/icons";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 
 interface RepoSecretsResponse {
   secrets: { key: string }[];
@@ -68,7 +69,7 @@ export function EnvironmentSecretsImport({
     setImporting(true);
 
     try {
-      const response = await fetch(`/api/environments/${environmentId}/secrets/import`, {
+      const response = await browserApiFetch(`/api/environments/${environmentId}/secrets/import`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/packages/web/src/components/settings/environments-settings.tsx
+++ b/packages/web/src/components/settings/environments-settings.tsx
@@ -14,6 +14,7 @@ import { formatSessionRepositoriesLabel } from "@/lib/repo-label";
 import { supportsRepoImages } from "@/lib/sandbox-provider";
 import { useEnvironments, ENVIRONMENTS_KEY } from "@/hooks/use-environments";
 import { EnvironmentForm, type EnvironmentFormValues } from "./environment-form";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 import { EnvironmentIntegrationSettings } from "./environment-integration-settings";
 import { EnvironmentSecretsImport } from "./environment-secrets-import";
 import { ImageBuildStatus, formatReadyDetails } from "./image-build-status";
@@ -39,7 +40,7 @@ export function EnvironmentsSettings() {
     setSubmitting(true);
     setError("");
     try {
-      const response = await fetch("/api/environments", {
+      const response = await browserApiFetch("/api/environments", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(values),
@@ -68,7 +69,7 @@ export function EnvironmentsSettings() {
     setSubmitting(true);
     setError("");
     try {
-      const response = await fetch(`/api/environments/${environmentId}`, {
+      const response = await browserApiFetch(`/api/environments/${environmentId}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(values),
@@ -91,7 +92,9 @@ export function EnvironmentsSettings() {
   const handleDelete = async (environment: Environment) => {
     setError("");
     try {
-      const response = await fetch(`/api/environments/${environment.id}`, { method: "DELETE" });
+      const response = await browserApiFetch(`/api/environments/${environment.id}`, {
+        method: "DELETE",
+      });
       if (!response.ok) {
         const data = await response.json();
         setError(data?.error || "Failed to delete environment");
@@ -108,7 +111,7 @@ export function EnvironmentsSettings() {
     setTogglingIds((prev) => new Set(prev).add(environment.id));
     setError("");
     try {
-      const response = await fetch(`/api/environments/${environment.id}`, {
+      const response = await browserApiFetch(`/api/environments/${environment.id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ prebuildEnabled: enabled }),
@@ -135,7 +138,7 @@ export function EnvironmentsSettings() {
     setTriggeringIds((prev) => new Set(prev).add(environment.id));
     setError("");
     try {
-      const response = await fetch(`/api/environments/${environment.id}/images/trigger`, {
+      const response = await browserApiFetch(`/api/environments/${environment.id}/images/trigger`, {
         method: "POST",
       });
       if (!response.ok) {

--- a/packages/web/src/components/settings/images-settings.tsx
+++ b/packages/web/src/components/settings/images-settings.tsx
@@ -12,6 +12,7 @@ import { RefreshIcon } from "@/components/ui/icons";
 import { IMAGE_BUILDS_KEY, parsePrimaryBuildSha, type ImageBuildsFeed } from "@/lib/image-builds";
 import { supportsRepoImages } from "@/lib/sandbox-provider";
 import { ImageBuildStatus, formatReadyDetails } from "./image-build-status";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 
 export function ImagesSettings() {
   const repoImagesSupported = supportsRepoImages();
@@ -55,7 +56,7 @@ export function ImagesSettings() {
     setError("");
 
     try {
-      const res = await fetch(
+      const res = await browserApiFetch(
         `/api/image-builds/repo/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/toggle`,
         {
           method: "PUT",
@@ -87,7 +88,7 @@ export function ImagesSettings() {
     setError("");
 
     try {
-      const res = await fetch(
+      const res = await browserApiFetch(
         `/api/image-builds/repo/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/trigger`,
         { method: "POST" }
       );

--- a/packages/web/src/components/settings/integrations/code-server-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/code-server-integration-settings.tsx
@@ -13,6 +13,7 @@ import {
 import { IntegrationSettingsSkeleton } from "./integration-settings-skeleton";
 import { Button } from "@/components/ui/button";
 import { RadioCard } from "@/components/ui/form-controls";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 import {
   Select,
   SelectContent,
@@ -120,7 +121,7 @@ function GlobalSettingsSection({
     setSaving(true);
 
     try {
-      const res = await fetch(GLOBAL_SETTINGS_KEY, { method: "DELETE" });
+      const res = await browserApiFetch(GLOBAL_SETTINGS_KEY, { method: "DELETE" });
 
       if (res.ok) {
         mutate(GLOBAL_SETTINGS_KEY);
@@ -150,7 +151,7 @@ function GlobalSettingsSection({
     }
 
     try {
-      const res = await fetch(GLOBAL_SETTINGS_KEY, {
+      const res = await browserApiFetch(GLOBAL_SETTINGS_KEY, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ settings: body }),
@@ -319,11 +320,14 @@ function RepoOverridesSection({
     if (!repository) return;
 
     try {
-      const res = await fetch(`${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ settings: { enabled: true } }),
-      });
+      const res = await browserApiFetch(
+        `${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ settings: { enabled: true } }),
+        }
+      );
 
       if (res.ok) {
         mutate(REPO_SETTINGS_KEY);
@@ -385,11 +389,14 @@ function RepoOverrideRow({ entry }: { entry: RepoSettingsEntry }) {
     const settings: CodeServerSettings = { enabled };
 
     try {
-      const res = await fetch(`${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ settings }),
-      });
+      const res = await browserApiFetch(
+        `${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ settings }),
+        }
+      );
 
       if (res.ok) {
         mutate(REPO_SETTINGS_KEY);
@@ -411,9 +418,12 @@ function RepoOverrideRow({ entry }: { entry: RepoSettingsEntry }) {
     if (!repository) return;
 
     try {
-      const res = await fetch(`${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`, {
-        method: "DELETE",
-      });
+      const res = await browserApiFetch(
+        `${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`,
+        {
+          method: "DELETE",
+        }
+      );
 
       if (res.ok) {
         mutate(REPO_SETTINGS_KEY);

--- a/packages/web/src/components/settings/integrations/commit-signing-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/commit-signing-settings.test.tsx
@@ -146,7 +146,11 @@ describe("CommitSigningSettings", () => {
 
     await user.click(screen.getByRole("button", { name: "Disable commit signing" }));
 
-    expect(fetchMock).toHaveBeenCalledWith("/api/commit-signing", { method: "DELETE" });
+    expect(fetchMock).toHaveBeenCalledWith("/api/commit-signing", {
+      method: "DELETE",
+      mode: "same-origin",
+      credentials: "same-origin",
+    });
     expect(mutateMock).toHaveBeenCalledWith({ enabled: false }, false);
   });
 

--- a/packages/web/src/components/settings/integrations/commit-signing-settings.tsx
+++ b/packages/web/src/components/settings/integrations/commit-signing-settings.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 
 const SETTINGS_KEY = "/api/commit-signing";
 
@@ -48,7 +49,7 @@ export function CommitSigningSettings() {
   const handleSave = async () => {
     setSaving(true);
     try {
-      const saveResponse = await fetch(SETTINGS_KEY, {
+      const saveResponse = await browserApiFetch(SETTINGS_KEY, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ privateKey, committerName, committerEmail }),
@@ -81,7 +82,7 @@ export function CommitSigningSettings() {
   const handleDisable = async () => {
     setSaving(true);
     try {
-      const disableResponse = await fetch(SETTINGS_KEY, { method: "DELETE" });
+      const disableResponse = await browserApiFetch(SETTINGS_KEY, { method: "DELETE" });
       if (!disableResponse.ok) {
         toast.error("Failed to disable commit signing.");
         return;

--- a/packages/web/src/components/settings/integrations/github-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/github-integration-settings.tsx
@@ -14,6 +14,7 @@ import {
   type ValidModel,
 } from "@open-inspect/shared";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 import { IntegrationSettingsSkeleton } from "./integration-settings-skeleton";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -182,7 +183,7 @@ function GlobalSettingsSection({
     setError("");
 
     try {
-      const res = await fetch(GLOBAL_SETTINGS_KEY, { method: "DELETE" });
+      const res = await browserApiFetch(GLOBAL_SETTINGS_KEY, { method: "DELETE" });
 
       if (res.ok) {
         mutate(GLOBAL_SETTINGS_KEY);
@@ -225,7 +226,7 @@ function GlobalSettingsSection({
     }
 
     try {
-      const res = await fetch(GLOBAL_SETTINGS_KEY, {
+      const res = await browserApiFetch(GLOBAL_SETTINGS_KEY, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ settings: body }),
@@ -533,11 +534,14 @@ function RepoOverridesSection({
     if (!repository) return;
 
     try {
-      const res = await fetch(`${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ settings: {} }),
-      });
+      const res = await browserApiFetch(
+        `${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ settings: {} }),
+        }
+      );
 
       if (res.ok) {
         mutate(REPO_SETTINGS_KEY);
@@ -664,11 +668,14 @@ function RepoOverrideRow({
     if (autoReviewMode === "override") settings.autoReviewOnOpen = autoReviewOnOpen;
 
     try {
-      const res = await fetch(`${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ settings }),
-      });
+      const res = await browserApiFetch(
+        `${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ settings }),
+        }
+      );
 
       if (res.ok) {
         mutate(REPO_SETTINGS_KEY);
@@ -690,9 +697,12 @@ function RepoOverrideRow({
     if (!repository) return;
 
     try {
-      const res = await fetch(`${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`, {
-        method: "DELETE",
-      });
+      const res = await browserApiFetch(
+        `${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`,
+        {
+          method: "DELETE",
+        }
+      );
 
       if (res.ok) {
         mutate(REPO_SETTINGS_KEY);

--- a/packages/web/src/components/settings/integrations/linear-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/linear-integration-settings.tsx
@@ -14,6 +14,7 @@ import {
   type ValidModel,
 } from "@open-inspect/shared";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 import { IntegrationSettingsSkeleton } from "./integration-settings-skeleton";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -181,7 +182,7 @@ function GlobalSettingsSection({
     setError("");
 
     try {
-      const res = await fetch(GLOBAL_SETTINGS_KEY, { method: "DELETE" });
+      const res = await browserApiFetch(GLOBAL_SETTINGS_KEY, { method: "DELETE" });
 
       if (res.ok) {
         mutate(GLOBAL_SETTINGS_KEY);
@@ -226,7 +227,7 @@ function GlobalSettingsSection({
     }
 
     try {
-      const res = await fetch(GLOBAL_SETTINGS_KEY, {
+      const res = await browserApiFetch(GLOBAL_SETTINGS_KEY, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ settings: body }),
@@ -495,11 +496,14 @@ function RepoOverridesSection({
     if (!repository) return;
 
     try {
-      const res = await fetch(`${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ settings: {} }),
-      });
+      const res = await browserApiFetch(
+        `${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ settings: {} }),
+        }
+      );
 
       if (res.ok) {
         mutate(REPO_SETTINGS_KEY);
@@ -598,11 +602,14 @@ function RepoOverrideRow({
     if (effort) settings.reasoningEffort = effort;
 
     try {
-      const res = await fetch(`${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ settings }),
-      });
+      const res = await browserApiFetch(
+        `${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ settings }),
+        }
+      );
 
       if (res.ok) {
         mutate(REPO_SETTINGS_KEY);
@@ -624,9 +631,12 @@ function RepoOverrideRow({
     if (!repository) return;
 
     try {
-      const res = await fetch(`${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`, {
-        method: "DELETE",
-      });
+      const res = await browserApiFetch(
+        `${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`,
+        {
+          method: "DELETE",
+        }
+      );
 
       if (res.ok) {
         mutate(REPO_SETTINGS_KEY);

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
@@ -18,6 +18,7 @@ import {
   type SlackRepoSettings,
   type SlackRoutingRule,
 } from "@open-inspect/shared";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
 import { ENVIRONMENTS_KEY } from "@/hooks/use-environments";
 import { environmentOptionValue, parseEnvironmentOptionValue } from "@/lib/session-target";
@@ -201,12 +202,12 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
       // deleting the whole row); otherwise clear the row entirely.
       const existingRules = settings?.defaults?.routingRules;
       const res = existingRules?.length
-        ? await fetch(GLOBAL_SETTINGS_KEY, {
+        ? await browserApiFetch(GLOBAL_SETTINGS_KEY, {
             method: "PUT",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({ settings: { defaults: { routingRules: existingRules } } }),
           })
-        : await fetch(GLOBAL_SETTINGS_KEY, { method: "DELETE" });
+        : await browserApiFetch(GLOBAL_SETTINGS_KEY, { method: "DELETE" });
       if (res.ok) {
         mutate(GLOBAL_SETTINGS_KEY);
         setAgentNotificationsEnabled(false);
@@ -236,7 +237,7 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
     };
 
     try {
-      const res = await fetch(GLOBAL_SETTINGS_KEY, {
+      const res = await browserApiFetch(GLOBAL_SETTINGS_KEY, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ settings: body }),
@@ -404,11 +405,14 @@ function RepoOverridesSection({
     if (!repository) return;
 
     try {
-      const res = await fetch(`${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ settings: {} }),
-      });
+      const res = await browserApiFetch(
+        `${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ settings: {} }),
+        }
+      );
       if (res.ok) {
         mutate(REPO_SETTINGS_KEY);
         setAddingRepo("");
@@ -483,11 +487,14 @@ function RepoOverrideRow({ entry }: { entry: RepoSettingsEntry }) {
     if (mode === "off") settings.agentNotificationsEnabled = false;
 
     try {
-      const res = await fetch(`${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ settings }),
-      });
+      const res = await browserApiFetch(
+        `${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ settings }),
+        }
+      );
       if (res.ok) {
         mutate(REPO_SETTINGS_KEY);
         setDirty(false);
@@ -507,9 +514,12 @@ function RepoOverrideRow({ entry }: { entry: RepoSettingsEntry }) {
     const repository = parseRepositoryFullName(entry.repo);
     if (!repository) return;
     try {
-      const res = await fetch(`${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`, {
-        method: "DELETE",
-      });
+      const res = await browserApiFetch(
+        `${REPO_SETTINGS_KEY}/${encodeRepositoryPathSegments(repository)}`,
+        {
+          method: "DELETE",
+        }
+      );
       if (res.ok) {
         mutate(REPO_SETTINGS_KEY);
         toast.success(`Override for ${entry.repo} removed.`);
@@ -657,7 +667,7 @@ function RoutingRulesSection({
     };
 
     try {
-      const res = await fetch(GLOBAL_SETTINGS_KEY, {
+      const res = await browserApiFetch(GLOBAL_SETTINGS_KEY, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ settings: body }),

--- a/packages/web/src/components/settings/models-settings.tsx
+++ b/packages/web/src/components/settings/models-settings.tsx
@@ -7,6 +7,7 @@ import { MODEL_OPTIONS, DEFAULT_ENABLED_MODELS } from "@open-inspect/shared";
 import { MODEL_PREFERENCES_KEY, useEnabledModels } from "@/hooks/use-enabled-models";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 
 export function ModelsSettings() {
   const { enabledModels: storedEnabledModels, loading } = useEnabledModels();
@@ -57,7 +58,7 @@ export function ModelsSettings() {
     setSaving(true);
 
     try {
-      const res = await fetch("/api/model-preferences", {
+      const res = await browserApiFetch("/api/model-preferences", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ enabledModels: Array.from(enabledModels) }),

--- a/packages/web/src/components/settings/sandbox-settings.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.tsx
@@ -8,7 +8,7 @@ import { Combobox } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import useSWR from "swr";
 import type { ConfiguredSandboxPort, SandboxSettings } from "@open-inspect/shared";
-import { browserApiFetch, toBrowserApiPath, type BrowserApiPath } from "@/lib/browser-api-fetch";
+import { browserApiFetch, type BrowserApiPath } from "@/lib/browser-api-fetch";
 import {
   DEFAULT_BUILD_TIMEOUT_SECONDS,
   DEFAULT_CODE_SERVER_PORT,
@@ -41,7 +41,7 @@ interface EnvironmentSettingsResponse {
   settings: SandboxSettings | null;
 }
 
-const fetcher = (url: string) => browserApiFetch(toBrowserApiPath(url)).then((r) => r.json());
+const fetcher = (url: BrowserApiPath) => browserApiFetch(url).then((r) => r.json());
 
 function isValidPort(value: string): boolean {
   return /^\d+$/.test(value) && Number(value) >= 1 && Number(value) <= 65535;

--- a/packages/web/src/components/settings/sandbox-settings.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.tsx
@@ -8,6 +8,7 @@ import { Combobox } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import useSWR from "swr";
 import type { ConfiguredSandboxPort, SandboxSettings } from "@open-inspect/shared";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 import {
   DEFAULT_BUILD_TIMEOUT_SECONDS,
   DEFAULT_CODE_SERVER_PORT,
@@ -40,7 +41,7 @@ interface EnvironmentSettingsResponse {
   settings: SandboxSettings | null;
 }
 
-const fetcher = (url: string) => fetch(url).then((r) => r.json());
+const fetcher = (url: string) => browserApiFetch(url).then((r) => r.json());
 
 function isValidPort(value: string): boolean {
   return /^\d+$/.test(value) && Number(value) >= 1 && Number(value) <= 65535;
@@ -442,7 +443,7 @@ export function SandboxSettingsEditor({
         ? { settings: { defaults: settingsPayload, enabledRepos } }
         : { settings: settingsPayload };
 
-      const res = await fetch(apiUrl, {
+      const res = await browserApiFetch(apiUrl, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),

--- a/packages/web/src/components/settings/sandbox-settings.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.tsx
@@ -8,7 +8,7 @@ import { Combobox } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import useSWR from "swr";
 import type { ConfiguredSandboxPort, SandboxSettings } from "@open-inspect/shared";
-import { browserApiFetch } from "@/lib/browser-api-fetch";
+import { browserApiFetch, toBrowserApiPath, type BrowserApiPath } from "@/lib/browser-api-fetch";
 import {
   DEFAULT_BUILD_TIMEOUT_SECONDS,
   DEFAULT_CODE_SERVER_PORT,
@@ -41,7 +41,7 @@ interface EnvironmentSettingsResponse {
   settings: SandboxSettings | null;
 }
 
-const fetcher = (url: string) => browserApiFetch(url).then((r) => r.json());
+const fetcher = (url: string) => browserApiFetch(toBrowserApiPath(url)).then((r) => r.json());
 
 function isValidPort(value: string): boolean {
   return /^\d+$/.test(value) && Number(value) >= 1 && Number(value) <= 65535;
@@ -116,7 +116,7 @@ function numberPayloadValue(
 
 /** What a sandbox-settings scope reads/writes and what it inherits from. */
 interface SandboxScopeModel {
-  apiUrl: string;
+  apiUrl: BrowserApiPath;
   /** This scope's own stored settings (at global scope, the stored defaults). */
   ownSettings: SandboxSettings | undefined;
   /** The layer beneath this scope's overrides (undefined at global scope). */
@@ -144,11 +144,11 @@ function useSandboxSettingsScope(
   environmentId?: string
 ): SandboxScopeModel {
   const isGlobal = scope === "global";
-  const globalApiUrl = "/api/integration-settings/sandbox";
+  const globalApiUrl: BrowserApiPath = "/api/integration-settings/sandbox";
   const repoPath =
     owner && name ? encodeRepositoryPathSegments({ repoOwner: owner, repoName: name }) : "";
-  const repoApiUrl = `/api/integration-settings/sandbox/repos/${repoPath}`;
-  const apiUrl = isGlobal
+  const repoApiUrl: BrowserApiPath = `/api/integration-settings/sandbox/repos/${repoPath}`;
+  const apiUrl: BrowserApiPath = isGlobal
     ? globalApiUrl
     : scope === "repo"
       ? repoApiUrl

--- a/packages/web/src/components/sidebar-layout.test.tsx
+++ b/packages/web/src/components/sidebar-layout.test.tsx
@@ -5,13 +5,13 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CollapsedSidebarControls, SidebarLayout } from "./sidebar-layout";
-import { useSession } from "next-auth/react";
+import { useAuthSession } from "@/lib/auth-session";
 import { useRouter } from "next/navigation";
 
 expect.extend(matchers);
 
-vi.mock("next-auth/react", () => ({
-  useSession: vi.fn(),
+vi.mock("@/lib/auth-session", () => ({
+  useAuthSession: vi.fn(),
   signIn: vi.fn(),
 }));
 
@@ -37,10 +37,9 @@ afterEach(cleanup);
 
 describe("CollapsedSidebarControls", () => {
   it("renders the sidebar, search, and new session actions inline", () => {
-    vi.mocked(useSession).mockReturnValue({
-      data: { user: { name: "Test User" }, expires: "2099-01-01" },
+    vi.mocked(useAuthSession).mockReturnValue({
+      data: { user: { name: "Test User" } },
       status: "authenticated",
-      update: vi.fn(),
     });
     const push = vi.fn();
     vi.mocked(useRouter).mockReturnValue({ push } as never);

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createContext, useCallback, useContext, useState } from "react";
-import { useSession, signIn } from "next-auth/react";
+import { signIn, useAuthSession } from "@/lib/auth-session";
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
 import { NewSessionButton, SearchSessionsButton, SessionSidebar } from "./session-sidebar";
@@ -74,7 +74,7 @@ export function CollapsedSidebarControls() {
 }
 
 export function SidebarLayout({ children }: SidebarLayoutProps) {
-  const { data: session, status } = useSession();
+  const { data: session, status } = useAuthSession();
   const router = useRouter();
   const sidebar = useSidebar();
   const isMobile = useIsMobile();

--- a/packages/web/src/components/sidebar-user-menu.tsx
+++ b/packages/web/src/components/sidebar-user-menu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { signOut } from "next-auth/react";
+import { signOut } from "@/lib/auth-session";
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/packages/web/src/components/sidebar/metadata-section.test.tsx
+++ b/packages/web/src/components/sidebar/metadata-section.test.tsx
@@ -230,6 +230,8 @@ describe("PR sync button", () => {
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith("/api/sessions/session-1/pull-requests/refresh", {
         method: "POST",
+        mode: "same-origin",
+        credentials: "same-origin",
       });
     });
   });

--- a/packages/web/src/components/sidebar/metadata-section.tsx
+++ b/packages/web/src/components/sidebar/metadata-section.tsx
@@ -11,6 +11,7 @@ import { NO_REPOSITORY_LABEL } from "@/lib/repo-label";
 import type { Artifact, SandboxEvent } from "@/types/session";
 import type { SessionRepositoryState } from "@open-inspect/shared";
 import { findPrArtifactForRepo } from "@/lib/pr-artifacts";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 import {
   ClockIcon,
   SparkleIcon,
@@ -63,7 +64,9 @@ function PullRequestSyncButton({ sessionId }: { sessionId: string }) {
     if (syncing) return;
     setSyncing(true);
     try {
-      await fetch(`/api/sessions/${sessionId}/pull-requests/refresh`, { method: "POST" });
+      await browserApiFetch(`/api/sessions/${sessionId}/pull-requests/refresh`, {
+        method: "POST",
+      });
     } catch {
       // Fire-and-forget: the socket stream is the source of truth, so a
       // failed trigger only means no update arrives.

--- a/packages/web/src/components/web-session-gate.integration.test.tsx
+++ b/packages/web/src/components/web-session-gate.integration.test.tsx
@@ -11,8 +11,8 @@ const mocks = vi.hoisted(() => ({
   getToken: vi.fn(),
 }));
 
-vi.mock("next-auth/react", () => ({
-  useSession: () => ({ status: mocks.status }),
+vi.mock("@/lib/auth-session", () => ({
+  useAuthSession: () => ({ data: null, status: mocks.status }),
   signOut: mocks.signOut,
 }));
 

--- a/packages/web/src/components/web-session-gate.test.tsx
+++ b/packages/web/src/components/web-session-gate.test.tsx
@@ -44,7 +44,11 @@ describe("WebSessionGate", () => {
     mocks.status = "authenticated";
     rerender(<WebSessionGate />);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(fetchSpy).toHaveBeenCalledWith("/api/auth/oi-refresh", { method: "POST" });
+    expect(fetchSpy).toHaveBeenCalledWith("/api/auth/oi-refresh", {
+      method: "POST",
+      mode: "same-origin",
+      credentials: "same-origin",
+    });
   });
 
   it("signs out when renewal reports that the session is no longer authenticated", async () => {

--- a/packages/web/src/components/web-session-gate.test.tsx
+++ b/packages/web/src/components/web-session-gate.test.tsx
@@ -10,8 +10,8 @@ const mocks = vi.hoisted(() => ({
   signOut: vi.fn(),
 }));
 
-vi.mock("next-auth/react", () => ({
-  useSession: () => ({ status: mocks.status }),
+vi.mock("@/lib/auth-session", () => ({
+  useAuthSession: () => ({ data: null, status: mocks.status }),
   signOut: mocks.signOut,
 }));
 

--- a/packages/web/src/components/web-session-gate.tsx
+++ b/packages/web/src/components/web-session-gate.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import { signOut, useSession } from "next-auth/react";
+import { signOut, useAuthSession } from "@/lib/auth-session";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 
 /**
  * Check interval for web session token renewal. Must sit comfortably inside
@@ -18,7 +19,7 @@ const WEB_SESSION_CHECK_INTERVAL_MS = 5 * 60 * 1000;
  * mount, focus/visibility, and an interval.
  */
 export function WebSessionGate({ children }: { children?: ReactNode }) {
-  const { status } = useSession();
+  const { status } = useAuthSession();
   const signingOutRef = useRef(false);
   const [webSessionStatus, setWebSessionStatus] = useState<
     "checking" | "ready" | "temporarily_unavailable"
@@ -40,7 +41,7 @@ export function WebSessionGate({ children }: { children?: ReactNode }) {
       if (checkInFlight) return;
       checkInFlight = true;
       try {
-        const response = await fetch("/api/auth/oi-refresh", { method: "POST" });
+        const response = await browserApiFetch("/api/auth/oi-refresh", { method: "POST" });
         if (cancelled) return;
         if (response.status === 401 && !signingOutRef.current) {
           signingOutRef.current = true;

--- a/packages/web/src/hooks/use-analytics.ts
+++ b/packages/web/src/hooks/use-analytics.ts
@@ -1,4 +1,4 @@
-import { useSession } from "next-auth/react";
+import { useAuthSession } from "@/lib/auth-session";
 import useSWR from "swr";
 import type {
   AnalyticsBreakdownResponse,
@@ -10,7 +10,7 @@ import type {
 import { ANALYTICS_REFRESH_INTERVAL_MS } from "@/lib/analytics";
 
 export function useAnalyticsDashboard(days: AnalyticsDays) {
-  const { data: session } = useSession();
+  const { data: session } = useAuthSession();
   const refreshInterval = ANALYTICS_REFRESH_INTERVAL_MS;
 
   const summary = useSWR<AnalyticsSummaryResponse>(

--- a/packages/web/src/hooks/use-automations.ts
+++ b/packages/web/src/hooks/use-automations.ts
@@ -1,5 +1,5 @@
 import useSWR from "swr";
-import { useSession } from "next-auth/react";
+import { useAuthSession } from "@/lib/auth-session";
 import type {
   Automation,
   ListAutomationsResponse,
@@ -7,7 +7,7 @@ import type {
 } from "@open-inspect/shared";
 
 export function useAutomations() {
-  const { data: session } = useSession();
+  const { data: session } = useAuthSession();
 
   const { data, isLoading, mutate } = useSWR<ListAutomationsResponse>(
     session ? "/api/automations" : null
@@ -22,7 +22,7 @@ export function useAutomations() {
 }
 
 export function useAutomation(id: string | undefined) {
-  const { data: session } = useSession();
+  const { data: session } = useAuthSession();
 
   const { data, isLoading, mutate } = useSWR<{ automation: Automation }>(
     session && id ? `/api/automations/${id}` : null
@@ -36,7 +36,7 @@ export function useAutomation(id: string | undefined) {
 }
 
 export function useAutomationInvocations(id: string | undefined, limit = 20, offset = 0) {
-  const { data: session } = useSession();
+  const { data: session } = useAuthSession();
 
   const { data, isLoading, mutate } = useSWR<ListAutomationInvocationsResponse>(
     session && id ? `/api/automations/${id}/invocations?limit=${limit}&offset=${offset}` : null

--- a/packages/web/src/hooks/use-branches.ts
+++ b/packages/web/src/hooks/use-branches.ts
@@ -1,12 +1,12 @@
 import useSWR from "swr";
-import { useSession } from "next-auth/react";
+import { useAuthSession } from "@/lib/auth-session";
 
 interface BranchesResponse {
   branches: { name: string }[];
 }
 
 export function useBranches(repoOwner: string, repoName: string) {
-  const { data: session } = useSession();
+  const { data: session } = useAuthSession();
 
   const key =
     session && repoOwner && repoName

--- a/packages/web/src/hooks/use-environments.ts
+++ b/packages/web/src/hooks/use-environments.ts
@@ -1,11 +1,11 @@
 import useSWR from "swr";
-import { useSession } from "next-auth/react";
+import { useAuthSession } from "@/lib/auth-session";
 import type { Environment, ListEnvironmentsResponse } from "@open-inspect/shared";
 
 export const ENVIRONMENTS_KEY = "/api/environments";
 
 export function useEnvironments(): { environments: Environment[]; loading: boolean } {
-  const { data: session, status } = useSession();
+  const { data: session, status } = useAuthSession();
 
   const { data, isLoading } = useSWR<ListEnvironmentsResponse>(session ? ENVIRONMENTS_KEY : null);
 

--- a/packages/web/src/hooks/use-mcp-servers.ts
+++ b/packages/web/src/hooks/use-mcp-servers.ts
@@ -1,11 +1,12 @@
 import useSWR from "swr";
-import { useSession } from "next-auth/react";
+import { useAuthSession } from "@/lib/auth-session";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 import type { McpServerConfig, McpServerMetadata } from "@open-inspect/shared";
 
 const MCP_SERVERS_KEY = "/api/mcp-servers";
 
 export function useMcpServers() {
-  const { data: session } = useSession();
+  const { data: session } = useAuthSession();
 
   const { data, isLoading, mutate } = useSWR<McpServerMetadata[]>(session ? MCP_SERVERS_KEY : null);
 
@@ -19,7 +20,7 @@ export function useMcpServers() {
 export async function createMcpServer(
   config: Omit<McpServerConfig, "id">
 ): Promise<McpServerMetadata> {
-  const response = await fetch(MCP_SERVERS_KEY, {
+  const response = await browserApiFetch(MCP_SERVERS_KEY, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(config),
@@ -35,7 +36,7 @@ export async function updateMcpServer(
   id: string,
   patch: Partial<McpServerConfig>
 ): Promise<McpServerMetadata> {
-  const response = await fetch(`${MCP_SERVERS_KEY}/${id}`, {
+  const response = await browserApiFetch(`${MCP_SERVERS_KEY}/${id}`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(patch),
@@ -48,7 +49,7 @@ export async function updateMcpServer(
 }
 
 export async function deleteMcpServer(id: string): Promise<void> {
-  const response = await fetch(`${MCP_SERVERS_KEY}/${id}`, {
+  const response = await browserApiFetch(`${MCP_SERVERS_KEY}/${id}`, {
     method: "DELETE",
   });
   if (!response.ok) {

--- a/packages/web/src/hooks/use-repos.ts
+++ b/packages/web/src/hooks/use-repos.ts
@@ -1,5 +1,5 @@
 import useSWR from "swr";
-import { useSession } from "next-auth/react";
+import { useAuthSession } from "@/lib/auth-session";
 
 export interface Repo {
   id: number;
@@ -16,7 +16,7 @@ interface ReposResponse {
 }
 
 export function useRepos() {
-  const { data: session, status } = useSession();
+  const { data: session, status } = useAuthSession();
 
   const { data, isLoading } = useSWR<ReposResponse>(session ? "/api/repos" : null);
 

--- a/packages/web/src/hooks/use-session-attachments.ts
+++ b/packages/web/src/hooks/use-session-attachments.ts
@@ -7,6 +7,7 @@ import {
   type SessionAttachmentReference,
 } from "@open-inspect/shared";
 import { WEB_SESSION_ATTACHMENT_IMAGE_MAX_BYTES } from "@/lib/session-attachment-limits";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 
 export type PendingAttachment = {
   id: string;
@@ -183,7 +184,7 @@ export function useSessionAttachments() {
           }, SESSION_ATTACHMENT_UPLOAD_TIMEOUT_MS);
           let response: Response;
           try {
-            response = await fetch(`/api/sessions/${sessionId}/attachments`, {
+            response = await browserApiFetch(`/api/sessions/${sessionId}/attachments`, {
               method: "POST",
               body: formData,
               signal: controller.signal,

--- a/packages/web/src/hooks/use-session-diffs.ts
+++ b/packages/web/src/hooks/use-session-diffs.ts
@@ -5,9 +5,9 @@ import useSWR from "swr";
 import { mutate } from "swr";
 import { sessionDiffStateSchema, type SessionDiffState } from "@open-inspect/shared";
 import { parseDiffErrorBody } from "@/lib/session-diffs";
-import { browserApiFetch } from "@/lib/browser-api-fetch";
+import { browserApiFetch, type BrowserApiPath } from "@/lib/browser-api-fetch";
 
-export function sessionDiffKey(sessionId: string): string {
+export function sessionDiffKey(sessionId: string): BrowserApiPath {
   return `/api/sessions/${sessionId}/diff`;
 }
 

--- a/packages/web/src/hooks/use-session-diffs.ts
+++ b/packages/web/src/hooks/use-session-diffs.ts
@@ -5,6 +5,7 @@ import useSWR from "swr";
 import { mutate } from "swr";
 import { sessionDiffStateSchema, type SessionDiffState } from "@open-inspect/shared";
 import { parseDiffErrorBody } from "@/lib/session-diffs";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 
 export function sessionDiffKey(sessionId: string): string {
   return `/api/sessions/${sessionId}/diff`;
@@ -40,7 +41,9 @@ export function useSessionDiffRetry(sessionId: string): {
     setIsRetrying(true);
     setRetryError(null);
     try {
-      const response = await fetch(`/api/sessions/${sessionId}/diff/retry`, { method: "POST" });
+      const response = await browserApiFetch(`/api/sessions/${sessionId}/diff/retry`, {
+        method: "POST",
+      });
       if (!response.ok) {
         const body = parseDiffErrorBody(await response.json().catch(() => null));
         setRetryError(body.error ?? "Changes could not be retried.");

--- a/packages/web/src/hooks/use-session-transport.ts
+++ b/packages/web/src/hooks/use-session-transport.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { serverMessageSchema } from "@open-inspect/shared";
 import type { ServerMessage } from "@open-inspect/shared";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 
 // WebSocket URL (should come from env in production)
 const WS_URL = process.env.NEXT_PUBLIC_WS_URL || "ws://localhost:8787";
@@ -112,7 +113,7 @@ export function useSessionTransport(
 
   const fetchWsToken = useCallback(async (): Promise<string | null> => {
     try {
-      const response = await fetch(`/api/sessions/${sessionId}/ws-token`, {
+      const response = await browserApiFetch(`/api/sessions/${sessionId}/ws-token`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/packages/web/src/hooks/use-sidebar-sessions.ts
+++ b/packages/web/src/hooks/use-sidebar-sessions.ts
@@ -2,7 +2,8 @@
 
 import { useRouter } from "next/navigation";
 import { useState, useMemo, useCallback, useEffect, useRef } from "react";
-import { useSession } from "next-auth/react";
+import { useAuthSession } from "@/lib/auth-session";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 import useSWR, { mutate } from "swr";
 import { isInactiveSession } from "@/lib/time";
 import {
@@ -21,7 +22,7 @@ export type SessionItem = Session;
 type SessionCreatorFilter = "all" | "mine";
 
 export function useSidebarSessions(currentSessionId: string | null) {
-  const { data: authSession } = useSession();
+  const { data: authSession } = useAuthSession();
   const router = useRouter();
   const [sessionCreatorFilter, setSessionCreatorFilter] = useState<SessionCreatorFilter>("all");
   const [extraSessionsState, setExtraSessionsState] = useState<{
@@ -83,7 +84,7 @@ export function useSidebarSessions(currentSessionId: string | null) {
     const sessionListVersion = sessionListVersionRef.current;
 
     try {
-      const response = await fetch(
+      const response = await browserApiFetch(
         buildSessionsPageKey({
           excludeStatus: "archived",
           createdBy: sessionCreatorFilter === "mine" ? [CURRENT_USER_CREATED_BY] : undefined,

--- a/packages/web/src/hooks/use-slack-channels.ts
+++ b/packages/web/src/hooks/use-slack-channels.ts
@@ -1,5 +1,5 @@
 import useSWR from "swr";
-import { useSession } from "next-auth/react";
+import { useAuthSession } from "@/lib/auth-session";
 import type { SlackChannelListing } from "@open-inspect/shared";
 
 interface SlackChannelsResponse {
@@ -17,7 +17,7 @@ interface SlackChannelsResponse {
  * Slack channel to resolve — without violating the rules of hooks.
  */
 export function useSlackChannels(enabled = true) {
-  const { data: session } = useSession();
+  const { data: session } = useAuthSession();
 
   const { data, isLoading } = useSWR<SlackChannelsResponse>(
     enabled && session ? "/api/integrations/slack/channels" : null

--- a/packages/web/src/lib/archive-session.ts
+++ b/packages/web/src/lib/archive-session.ts
@@ -1,4 +1,5 @@
 import { toast } from "sonner";
+import { browserApiFetch } from "@/lib/browser-api-fetch";
 
 /**
  * Archives a session via the API.
@@ -8,7 +9,9 @@ import { toast } from "sonner";
  */
 export async function archiveSession(sessionId: string): Promise<boolean> {
   try {
-    const response = await fetch(`/api/sessions/${sessionId}/archive`, { method: "POST" });
+    const response = await browserApiFetch(`/api/sessions/${sessionId}/archive`, {
+      method: "POST",
+    });
     if (!response.ok) {
       toast.error("Failed to archive session");
       return false;

--- a/packages/web/src/lib/auth-session.test.tsx
+++ b/packages/web/src/lib/auth-session.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, renderHook, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next-auth/react", () => ({
+  SessionProvider: vi.fn(({ children }: { children?: React.ReactNode }) => children),
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+  useSession: vi.fn(),
+}));
+
+import {
+  SessionProvider,
+  signIn as nextAuthSignIn,
+  signOut as nextAuthSignOut,
+  useSession,
+} from "next-auth/react";
+import { AuthSessionProvider, signIn, signOut, useAuthSession } from "./auth-session";
+
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+describe("useAuthSession", () => {
+  it("exposes the current NextAuth session through the app-owned hook", () => {
+    const data = {
+      user: {
+        id: "user-1",
+        name: "Ada",
+        email: "ada@example.com",
+        image: null,
+      },
+      expires: "2099-01-01",
+    };
+    vi.mocked(useSession).mockReturnValue({
+      data,
+      status: "authenticated",
+      update: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useAuthSession());
+
+    expect(result.current).toEqual({
+      data,
+      status: "authenticated",
+    });
+  });
+});
+
+describe("AuthSessionProvider", () => {
+  it("preserves the disabled NextAuth focus refetch behavior", () => {
+    render(
+      <AuthSessionProvider>
+        <div>Application</div>
+      </AuthSessionProvider>
+    );
+
+    expect(screen.getByText("Application")).toBeTruthy();
+    expect(vi.mocked(SessionProvider).mock.calls[0]?.[0]).toMatchObject({
+      refetchOnWindowFocus: false,
+    });
+  });
+});
+
+describe("signIn", () => {
+  it("starts the existing NextAuth provider flow", async () => {
+    vi.mocked(nextAuthSignIn).mockResolvedValue(undefined);
+
+    await signIn("github");
+
+    expect(nextAuthSignIn).toHaveBeenCalledWith("github");
+  });
+});
+
+describe("signOut", () => {
+  it("ends the existing NextAuth session", async () => {
+    vi.mocked(nextAuthSignOut).mockResolvedValue(undefined);
+
+    await signOut();
+
+    expect(nextAuthSignOut).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/web/src/lib/auth-session.test.tsx
+++ b/packages/web/src/lib/auth-session.test.tsx
@@ -1,10 +1,11 @@
 // @vitest-environment jsdom
 
 import { cleanup, render, renderHook, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 
 vi.mock("next-auth/react", () => ({
-  SessionProvider: vi.fn(({ children }: { children?: React.ReactNode }) => children),
+  SessionProvider: vi.fn(({ children }: { children?: ReactNode }) => children),
   signIn: vi.fn(),
   signOut: vi.fn(),
   useSession: vi.fn(),

--- a/packages/web/src/lib/auth-session.test.tsx
+++ b/packages/web/src/lib/auth-session.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, render, renderHook, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 
 vi.mock("next-auth/react", () => ({
   SessionProvider: vi.fn(({ children }: { children?: React.ReactNode }) => children),
@@ -16,7 +16,14 @@ import {
   signOut as nextAuthSignOut,
   useSession,
 } from "next-auth/react";
-import { AuthSessionProvider, signIn, signOut, useAuthSession } from "./auth-session";
+import {
+  AuthSessionProvider,
+  signIn,
+  signOut,
+  useAuthSession,
+  type AuthSession,
+  type AuthSessionState,
+} from "./auth-session";
 
 afterEach(() => {
   cleanup();
@@ -24,6 +31,19 @@ afterEach(() => {
 });
 
 describe("useAuthSession", () => {
+  it("keeps session data correlated with authentication status", () => {
+    function assertState(state: AuthSessionState) {
+      if (state.status === "authenticated") {
+        expectTypeOf(state.data).toEqualTypeOf<AuthSession>();
+        return;
+      }
+
+      expectTypeOf(state.data).toEqualTypeOf<null>();
+    }
+
+    assertState({ status: "loading", data: null });
+  });
+
   it("exposes the current NextAuth session through the app-owned hook", () => {
     const data = {
       user: {
@@ -45,6 +65,21 @@ describe("useAuthSession", () => {
     expect(result.current).toEqual({
       data,
       status: "authenticated",
+    });
+  });
+
+  it("exposes no session data while NextAuth is loading", () => {
+    vi.mocked(useSession).mockReturnValue({
+      data: null,
+      status: "loading",
+      update: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useAuthSession());
+
+    expect(result.current).toEqual({
+      data: null,
+      status: "loading",
     });
   });
 });

--- a/packages/web/src/lib/auth-session.tsx
+++ b/packages/web/src/lib/auth-session.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import type { ReactNode } from "react";
+import {
+  SessionProvider,
+  signIn as nextAuthSignIn,
+  signOut as nextAuthSignOut,
+  useSession,
+} from "next-auth/react";
+
+export interface AuthSessionUser {
+  name?: string | null;
+  image?: string | null;
+}
+
+export interface AuthSession {
+  user?: AuthSessionUser | null;
+}
+
+export type AuthSessionStatus = "loading" | "authenticated" | "unauthenticated";
+export type SignInProvider = "github" | "google";
+
+export interface AuthSessionState {
+  data: AuthSession | null;
+  status: AuthSessionStatus;
+}
+
+export function AuthSessionProvider({ children }: { children: ReactNode }) {
+  return <SessionProvider refetchOnWindowFocus={false}>{children}</SessionProvider>;
+}
+
+export async function signIn(provider: SignInProvider): Promise<void> {
+  await nextAuthSignIn(provider);
+}
+
+export async function signOut(): Promise<void> {
+  await nextAuthSignOut();
+}
+
+/**
+ * App-owned client authentication boundary.
+ *
+ * The current implementation delegates to NextAuth. Terminal browser auth can
+ * replace this module without another repository-wide consumer migration.
+ */
+export function useAuthSession(): AuthSessionState {
+  const { data, status } = useSession();
+  return { data, status };
+}

--- a/packages/web/src/lib/auth-session.tsx
+++ b/packages/web/src/lib/auth-session.tsx
@@ -17,13 +17,19 @@ export interface AuthSession {
   user?: AuthSessionUser | null;
 }
 
-export type AuthSessionStatus = "loading" | "authenticated" | "unauthenticated";
 export type SignInProvider = "github" | "google";
 
-export interface AuthSessionState {
-  data: AuthSession | null;
-  status: AuthSessionStatus;
-}
+export type AuthSessionState =
+  | {
+      data: AuthSession;
+      status: "authenticated";
+    }
+  | {
+      data: null;
+      status: "loading" | "unauthenticated";
+    };
+
+export type AuthSessionStatus = AuthSessionState["status"];
 
 export function AuthSessionProvider({ children }: { children: ReactNode }) {
   return <SessionProvider refetchOnWindowFocus={false}>{children}</SessionProvider>;
@@ -44,6 +50,9 @@ export async function signOut(): Promise<void> {
  * replace this module without another repository-wide consumer migration.
  */
 export function useAuthSession(): AuthSessionState {
-  const { data, status } = useSession();
-  return { data, status };
+  const state = useSession();
+  if (state.status === "authenticated") {
+    return { data: state.data, status: state.status };
+  }
+  return { data: null, status: state.status };
 }

--- a/packages/web/src/lib/auth-session.tsx
+++ b/packages/web/src/lib/auth-session.tsx
@@ -7,6 +7,7 @@ import {
   signOut as nextAuthSignOut,
   useSession,
 } from "next-auth/react";
+import type { AuthProvider } from "./build-auth-identity";
 
 export interface AuthSessionUser {
   name?: string | null;
@@ -17,7 +18,7 @@ export interface AuthSession {
   user?: AuthSessionUser | null;
 }
 
-export type SignInProvider = "github" | "google";
+export type SignInProvider = AuthProvider;
 
 export type AuthSessionState =
   | {

--- a/packages/web/src/lib/browser-api-fetch.test.ts
+++ b/packages/web/src/lib/browser-api-fetch.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { browserApiFetch } from "./browser-api-fetch";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("browserApiFetch", () => {
+  it("delegates the request and initializer to the browser fetch boundary", async () => {
+    const response = new Response(null, { status: 204 });
+    const fetchMock = vi.fn().mockResolvedValue(response);
+    vi.stubGlobal("fetch", fetchMock);
+    const init: RequestInit = {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "New title" }),
+    };
+
+    await expect(browserApiFetch("/api/sessions/session-1/title", init)).resolves.toBe(response);
+    expect(fetchMock).toHaveBeenCalledWith("/api/sessions/session-1/title", init);
+  });
+
+  it("preserves an omitted request initializer", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await browserApiFetch("/api/repos");
+
+    expect(fetchMock.mock.calls[0]).toEqual(["/api/repos"]);
+  });
+});

--- a/packages/web/src/lib/browser-api-fetch.test.ts
+++ b/packages/web/src/lib/browser-api-fetch.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
-import { browserApiFetch, toBrowserApiPath, type BrowserApiPath } from "./browser-api-fetch";
+import { browserApiFetch, type BrowserApiPath } from "./browser-api-fetch";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -21,45 +21,22 @@ describe("browserApiFetch", () => {
     };
 
     await expect(browserApiFetch("/api/sessions/session-1/title", init)).resolves.toBe(response);
-    expect(fetchMock).toHaveBeenCalledWith("/api/sessions/session-1/title", init);
+    expect(fetchMock).toHaveBeenCalledWith("/api/sessions/session-1/title", {
+      ...init,
+      mode: "same-origin",
+      credentials: "same-origin",
+    });
   });
 
-  it("preserves an omitted request initializer", async () => {
+  it("enforces same-origin browser behavior when the request initializer is omitted", async () => {
     const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
     vi.stubGlobal("fetch", fetchMock);
 
     await browserApiFetch("/api/repos");
 
-    expect(fetchMock.mock.calls[0]).toEqual(["/api/repos"]);
+    expect(fetchMock).toHaveBeenCalledWith("/api/repos", {
+      mode: "same-origin",
+      credentials: "same-origin",
+    });
   });
-
-  it("rejects a non-BFF target even if the compile-time contract is bypassed", () => {
-    expect(() => browserApiFetch("https://example.com/api/sessions" as BrowserApiPath)).toThrow(
-      "Browser API requests must use a same-origin /api/ path"
-    );
-  });
-});
-
-describe("toBrowserApiPath", () => {
-  it("narrows a validated dynamic BFF path", () => {
-    const path = toBrowserApiPath(`/api/sessions/${crypto.randomUUID()}`);
-
-    expectTypeOf(path).toEqualTypeOf<BrowserApiPath>();
-    expect(path).toMatch(/^\/api\/sessions\//);
-  });
-
-  it("rejects a dynamic path outside the BFF API", () => {
-    expect(() => toBrowserApiPath("/settings")).toThrow(
-      "Browser API requests must use a same-origin /api/ path"
-    );
-  });
-
-  it.each(["/api/../settings", String.raw`/api/..\settings`])(
-    "rejects a path that normalizes outside the BFF API: %s",
-    (path) => {
-      expect(() => toBrowserApiPath(path)).toThrow(
-        "Browser API requests must use a same-origin /api/ path"
-      );
-    }
-  );
 });

--- a/packages/web/src/lib/browser-api-fetch.test.ts
+++ b/packages/web/src/lib/browser-api-fetch.test.ts
@@ -53,4 +53,13 @@ describe("toBrowserApiPath", () => {
       "Browser API requests must use a same-origin /api/ path"
     );
   });
+
+  it.each(["/api/../settings", String.raw`/api/..\settings`])(
+    "rejects a path that normalizes outside the BFF API: %s",
+    (path) => {
+      expect(() => toBrowserApiPath(path)).toThrow(
+        "Browser API requests must use a same-origin /api/ path"
+      );
+    }
+  );
 });

--- a/packages/web/src/lib/browser-api-fetch.test.ts
+++ b/packages/web/src/lib/browser-api-fetch.test.ts
@@ -1,11 +1,15 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { browserApiFetch } from "./browser-api-fetch";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import { browserApiFetch, toBrowserApiPath, type BrowserApiPath } from "./browser-api-fetch";
 
 afterEach(() => {
   vi.unstubAllGlobals();
 });
 
 describe("browserApiFetch", () => {
+  it("accepts only same-origin BFF paths at the type boundary", () => {
+    expectTypeOf(browserApiFetch).parameter(0).toEqualTypeOf<BrowserApiPath>();
+  });
+
   it("delegates the request and initializer to the browser fetch boundary", async () => {
     const response = new Response(null, { status: 204 });
     const fetchMock = vi.fn().mockResolvedValue(response);
@@ -27,5 +31,26 @@ describe("browserApiFetch", () => {
     await browserApiFetch("/api/repos");
 
     expect(fetchMock.mock.calls[0]).toEqual(["/api/repos"]);
+  });
+
+  it("rejects a non-BFF target even if the compile-time contract is bypassed", () => {
+    expect(() => browserApiFetch("https://example.com/api/sessions" as BrowserApiPath)).toThrow(
+      "Browser API requests must use a same-origin /api/ path"
+    );
+  });
+});
+
+describe("toBrowserApiPath", () => {
+  it("narrows a validated dynamic BFF path", () => {
+    const path = toBrowserApiPath(`/api/sessions/${crypto.randomUUID()}`);
+
+    expectTypeOf(path).toEqualTypeOf<BrowserApiPath>();
+    expect(path).toMatch(/^\/api\/sessions\//);
+  });
+
+  it("rejects a dynamic path outside the BFF API", () => {
+    expect(() => toBrowserApiPath("/settings")).toThrow(
+      "Browser API requests must use a same-origin /api/ path"
+    );
   });
 });

--- a/packages/web/src/lib/browser-api-fetch.ts
+++ b/packages/web/src/lib/browser-api-fetch.ts
@@ -1,45 +1,17 @@
 /**
  * App-owned browser-to-BFF request boundary.
  *
- * This preparatory implementation deliberately delegates to fetch unchanged.
- * Terminal browser authentication can add its request contract here without
- * another repository-wide consumer migration.
+ * The path type keeps application calls on the BFF API surface, while the
+ * browser's native request mode prevents cross-origin dispatch. Terminal
+ * browser authentication can add its request contract here without another
+ * repository-wide consumer migration.
  */
 export type BrowserApiPath = `/api/${string}`;
 
-const BROWSER_API_SENTINEL_ORIGIN = "https://browser-api.invalid";
-const INVALID_BROWSER_API_PATH_MESSAGE = "Browser API requests must use a same-origin /api/ path";
-
-function assertBrowserApiPath(input: string): asserts input is BrowserApiPath {
-  let parsed: URL;
-  try {
-    parsed = new URL(input, BROWSER_API_SENTINEL_ORIGIN);
-  } catch {
-    throw new Error(INVALID_BROWSER_API_PATH_MESSAGE);
-  }
-
-  if (
-    !input.startsWith("/") ||
-    input.startsWith("//") ||
-    parsed.origin !== BROWSER_API_SENTINEL_ORIGIN ||
-    !parsed.pathname.startsWith("/api/")
-  ) {
-    throw new Error(INVALID_BROWSER_API_PATH_MESSAGE);
-  }
-}
-
-/**
- * Validates a dynamically produced request path before it crosses the
- * browser-to-BFF boundary.
- */
-export function toBrowserApiPath(input: string): BrowserApiPath {
-  assertBrowserApiPath(input);
-  return input;
-}
-
 export function browserApiFetch(input: BrowserApiPath, init?: RequestInit): Promise<Response> {
-  // Keep a runtime check in addition to the type so untyped JavaScript and
-  // unsafe casts cannot attach the terminal auth contract to another origin.
-  assertBrowserApiPath(input);
-  return init === undefined ? fetch(input) : fetch(input, init);
+  return fetch(input, {
+    ...init,
+    mode: "same-origin",
+    credentials: "same-origin",
+  });
 }

--- a/packages/web/src/lib/browser-api-fetch.ts
+++ b/packages/web/src/lib/browser-api-fetch.ts
@@ -7,10 +7,23 @@
  */
 export type BrowserApiPath = `/api/${string}`;
 
+const BROWSER_API_SENTINEL_ORIGIN = "https://browser-api.invalid";
 const INVALID_BROWSER_API_PATH_MESSAGE = "Browser API requests must use a same-origin /api/ path";
 
 function assertBrowserApiPath(input: string): asserts input is BrowserApiPath {
-  if (!input.startsWith("/api/")) {
+  let parsed: URL;
+  try {
+    parsed = new URL(input, BROWSER_API_SENTINEL_ORIGIN);
+  } catch {
+    throw new Error(INVALID_BROWSER_API_PATH_MESSAGE);
+  }
+
+  if (
+    !input.startsWith("/") ||
+    input.startsWith("//") ||
+    parsed.origin !== BROWSER_API_SENTINEL_ORIGIN ||
+    !parsed.pathname.startsWith("/api/")
+  ) {
     throw new Error(INVALID_BROWSER_API_PATH_MESSAGE);
   }
 }

--- a/packages/web/src/lib/browser-api-fetch.ts
+++ b/packages/web/src/lib/browser-api-fetch.ts
@@ -5,6 +5,28 @@
  * Terminal browser authentication can add its request contract here without
  * another repository-wide consumer migration.
  */
-export function browserApiFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+export type BrowserApiPath = `/api/${string}`;
+
+const INVALID_BROWSER_API_PATH_MESSAGE = "Browser API requests must use a same-origin /api/ path";
+
+function assertBrowserApiPath(input: string): asserts input is BrowserApiPath {
+  if (!input.startsWith("/api/")) {
+    throw new Error(INVALID_BROWSER_API_PATH_MESSAGE);
+  }
+}
+
+/**
+ * Validates a dynamically produced request path before it crosses the
+ * browser-to-BFF boundary.
+ */
+export function toBrowserApiPath(input: string): BrowserApiPath {
+  assertBrowserApiPath(input);
+  return input;
+}
+
+export function browserApiFetch(input: BrowserApiPath, init?: RequestInit): Promise<Response> {
+  // Keep a runtime check in addition to the type so untyped JavaScript and
+  // unsafe casts cannot attach the terminal auth contract to another origin.
+  assertBrowserApiPath(input);
   return init === undefined ? fetch(input) : fetch(input, init);
 }

--- a/packages/web/src/lib/browser-api-fetch.ts
+++ b/packages/web/src/lib/browser-api-fetch.ts
@@ -1,0 +1,10 @@
+/**
+ * App-owned browser-to-BFF request boundary.
+ *
+ * This preparatory implementation deliberately delegates to fetch unchanged.
+ * Terminal browser authentication can add its request contract here without
+ * another repository-wide consumer migration.
+ */
+export function browserApiFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  return init === undefined ? fetch(input) : fetch(input, init);
+}

--- a/packages/web/src/lib/client-auth-boundary-eslint.test.ts
+++ b/packages/web/src/lib/client-auth-boundary-eslint.test.ts
@@ -1,0 +1,56 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { ESLint } from "eslint";
+import { describe, expect, it } from "vitest";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
+const componentPath = "packages/web/src/components/example.tsx";
+const hookPath = "packages/web/src/hooks/example.ts";
+const authSessionPath = "packages/web/src/lib/auth-session.tsx";
+const browserApiFetchPath = "packages/web/src/lib/browser-api-fetch.ts";
+
+const eslint = new ESLint({ cwd: repositoryRoot });
+
+async function boundaryMessages(source: string, filePath: string) {
+  const [result] = await eslint.lintText(source, { filePath });
+  return result.messages.filter(
+    (message) =>
+      message.ruleId === "no-restricted-imports" || message.ruleId === "no-restricted-globals"
+  );
+}
+
+describe("client authentication boundaries", () => {
+  it("rejects direct client imports from NextAuth", async () => {
+    await expect(
+      boundaryMessages('import { useSession } from "next-auth/react";', componentPath)
+    ).resolves.toHaveLength(1);
+  });
+
+  it("rejects raw browser fetch calls", async () => {
+    await expect(boundaryMessages('fetch("/api/sessions");', hookPath)).resolves.toHaveLength(1);
+  });
+
+  it("allows consumers to use the app-owned boundaries", async () => {
+    await expect(
+      boundaryMessages(
+        [
+          'import { useAuthSession } from "@/lib/auth-session";',
+          'import { browserApiFetch } from "@/lib/browser-api-fetch";',
+        ].join("\n"),
+        componentPath
+      )
+    ).resolves.toHaveLength(0);
+  });
+
+  it("allows the auth seam to own the NextAuth client integration", async () => {
+    await expect(
+      boundaryMessages('import { useSession } from "next-auth/react";', authSessionPath)
+    ).resolves.toHaveLength(0);
+  });
+
+  it("allows the browser request seam to own fetch", async () => {
+    await expect(
+      boundaryMessages('fetch("/api/sessions");', browserApiFetchPath)
+    ).resolves.toHaveLength(0);
+  });
+});

--- a/packages/web/src/lib/client-auth-boundary-eslint.test.ts
+++ b/packages/web/src/lib/client-auth-boundary-eslint.test.ts
@@ -6,8 +6,10 @@ import { describe, expect, it } from "vitest";
 const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..");
 const componentPath = "packages/web/src/components/example.tsx";
 const hookPath = "packages/web/src/hooks/example.ts";
+const clientLibraryPath = "packages/web/src/lib/example-client.ts";
 const authSessionPath = "packages/web/src/lib/auth-session.tsx";
 const browserApiFetchPath = "packages/web/src/lib/browser-api-fetch.ts";
+const controlPlaneTransportPath = "packages/web/src/lib/control-plane-transport.ts";
 
 const eslint = new ESLint({ cwd: repositoryRoot });
 
@@ -28,6 +30,12 @@ describe("client authentication boundaries", () => {
 
   it("rejects raw browser fetch calls", async () => {
     await expect(boundaryMessages('fetch("/api/sessions");', hookPath)).resolves.toHaveLength(1);
+  });
+
+  it("rejects raw fetch calls from an ordinary client library", async () => {
+    await expect(
+      boundaryMessages('fetch("/api/sessions");', clientLibraryPath)
+    ).resolves.toHaveLength(1);
   });
 
   it("allows consumers to use the app-owned boundaries", async () => {
@@ -51,6 +59,12 @@ describe("client authentication boundaries", () => {
   it("allows the browser request seam to own fetch", async () => {
     await expect(
       boundaryMessages('fetch("/api/sessions");', browserApiFetchPath)
+    ).resolves.toHaveLength(0);
+  });
+
+  it("allows the server request seam to own fetch", async () => {
+    await expect(
+      boundaryMessages('fetch("https://control-plane.example");', controlPlaneTransportPath)
     ).resolves.toHaveLength(0);
   });
 });

--- a/packages/web/src/lib/session-list.ts
+++ b/packages/web/src/lib/session-list.ts
@@ -1,4 +1,5 @@
 import type { Session } from "@open-inspect/shared";
+import type { BrowserApiPath } from "./browser-api-fetch";
 import { formatRepoLabel } from "./repo-label";
 
 export const SESSIONS_PAGE_SIZE = 50;
@@ -32,7 +33,7 @@ export function buildSessionsPageKey({
   status?: string;
   excludeStatus?: string;
   createdBy?: readonly string[];
-}) {
+}): BrowserApiPath {
   const searchParams = new URLSearchParams({
     limit: String(limit),
     offset: String(offset),


### PR DESCRIPTION
## Summary

- add app-owned client auth provider, hook, sign-in, and sign-out seams backed by the existing NextAuth implementation
- add an exact-delegation browser API request boundary and migrate browser consumers
- enforce both boundaries with ESLint and focused regression fixtures

## Why

This is the second behavior-neutral preparation PR in the browser-auth stack. It gives the terminal control-plane auth cutover two narrow replacement points without requiring another repository-wide consumer migration.

This PR does **not** change auth cookies, provider flows, session refresh behavior, request headers, API routes, or deployment configuration.

## Validation

- `npm run build -w @open-inspect/shared`
- `npm test -w @open-inspect/web` (109 files, 929 tests)
- `npm run typecheck -w @open-inspect/web`
- `npm run lint`
- `npm run build -w @open-inspect/web`
- `npm run format:check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an app-owned authentication boundary and migrated the web UI to use it instead of the default session hook.
  * Added a browser-to-BFF request helper and standardized client-side API calls across the app.
  * Added guardrails to prevent direct usage of restricted auth and global network calls in consumer code.
* **Bug Fixes**
  * Improved consistency and reliability of automations, session, settings, and integration requests via the shared request helper.
* **Tests**
  * Added/updated tests for the auth boundary, request helper, and ESLint guardrails.
* **Chores**
  * Updated providers and app wiring to use the new authentication boundary throughout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->