### PR TITLE
feat(auth): add OAuth authorization and provider credential stores

### DIFF
--- a/packages/control-plane/src/auth/auth-encryption.test.ts
+++ b/packages/control-plane/src/auth/auth-encryption.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { OAuthFlowVerifierIntegrityError } from "./oauth-flow-verifier";
+import { ProviderCredentialIntegrityError } from "./provider-credential-cipher";
 import {
   InvalidAuthEncryptionRootError,
+  ProviderCredentialCipher,
   ProviderPkceFlowCipher,
   UnsupportedAuthEncryptionVersionError,
   deriveAuthEncryptionKeyBytes,
@@ -12,7 +14,7 @@ const ROOT_KEY_BASE64 = Buffer.from(
   "hex"
 ).toString("base64");
 
-describe("terminal auth encryption key derivation", () => {
+describe("browser auth encryption key derivation", () => {
   it("derives stable, purpose-separated v1 keys from the configured root", async () => {
     const providerKey = await deriveAuthEncryptionKeyBytes(
       ROOT_KEY_BASE64,
@@ -88,5 +90,49 @@ describe("ProviderPkceFlowCipher", () => {
         keyVersion: 1,
       })
     ).rejects.toThrow("Provider PKCE flow IV generator returned an invalid IV");
+  });
+});
+
+describe("ProviderCredentialCipher", () => {
+  it("binds ciphertext to its identity, shape, token role, and row version", async () => {
+    const cipher = new ProviderCredentialCipher(ROOT_KEY_BASE64);
+    const binding = {
+      providerIdentityId: "identity-1",
+      credentialKind: "refreshable" as const,
+      tokenRole: "access" as const,
+      encryptionKeyVersion: 1,
+      rowVersion: 3,
+    };
+    const encrypted = await cipher.encrypt("provider-access-token", binding);
+
+    await expect(cipher.decrypt(encrypted, binding)).resolves.toBe("provider-access-token");
+    await expect(
+      cipher.decrypt(encrypted, { ...binding, providerIdentityId: "identity-2" })
+    ).rejects.toBeInstanceOf(ProviderCredentialIntegrityError);
+    await expect(
+      cipher.decrypt(encrypted, { ...binding, credentialKind: "access_only_expiring" })
+    ).rejects.toBeInstanceOf(ProviderCredentialIntegrityError);
+    await expect(
+      cipher.decrypt(encrypted, { ...binding, tokenRole: "refresh" })
+    ).rejects.toBeInstanceOf(ProviderCredentialIntegrityError);
+    await expect(cipher.decrypt(encrypted, { ...binding, rowVersion: 4 })).rejects.toBeInstanceOf(
+      ProviderCredentialIntegrityError
+    );
+  });
+
+  it("rejects an invalid initialization-vector length", async () => {
+    const cipher = new ProviderCredentialCipher(ROOT_KEY_BASE64, {
+      ivGenerator: { generate: () => new Uint8Array(11) },
+    });
+
+    await expect(
+      cipher.encrypt("provider-access-token", {
+        providerIdentityId: "identity-1",
+        credentialKind: "access_only_nonexpiring",
+        tokenRole: "access",
+        encryptionKeyVersion: 1,
+        rowVersion: 1,
+      })
+    ).rejects.toThrow("Provider credential IV generator returned an invalid IV");
   });
 });

--- a/packages/control-plane/src/auth/auth-encryption.test.ts
+++ b/packages/control-plane/src/auth/auth-encryption.test.ts
@@ -72,6 +72,7 @@ describe("ProviderPkceFlowCipher", () => {
 
     const encrypted = await cipher.encrypt("provider-pkce-verifier", context);
 
+    expect(encrypted).toBe("AAECAwQFBgcICQoLU7ir/zg3qDSh4hffgBH4d57nSJPZYWPWIpEfJ+mJY7P039F+Idk=");
     expect(Buffer.from(encrypted, "base64").subarray(0, initializationVector.byteLength)).toEqual(
       Buffer.from(initializationVector)
     );
@@ -95,7 +96,10 @@ describe("ProviderPkceFlowCipher", () => {
 
 describe("ProviderCredentialCipher", () => {
   it("binds ciphertext to its identity, shape, token role, and row version", async () => {
-    const cipher = new ProviderCredentialCipher(ROOT_KEY_BASE64);
+    const initializationVector = Uint8Array.from({ length: 12 }, (_, index) => index);
+    const cipher = new ProviderCredentialCipher(ROOT_KEY_BASE64, {
+      ivGenerator: { generate: () => initializationVector },
+    });
     const binding = {
       providerIdentityId: "identity-1",
       credentialKind: "refreshable" as const,
@@ -105,6 +109,7 @@ describe("ProviderCredentialCipher", () => {
     };
     const encrypted = await cipher.encrypt("provider-access-token", binding);
 
+    expect(encrypted).toBe("AAECAwQFBgcICQoLiRyTliBzKgjV8xzRi0vqSQPLGq0sVzWGmPuFl+yGTHHBQtlqZQ==");
     await expect(cipher.decrypt(encrypted, binding)).resolves.toBe("provider-access-token");
     await expect(
       cipher.decrypt(encrypted, { ...binding, providerIdentityId: "identity-2" })

--- a/packages/control-plane/src/auth/auth-encryption.ts
+++ b/packages/control-plane/src/auth/auth-encryption.ts
@@ -1,7 +1,13 @@
 import {
   OAuthFlowVerifierIntegrityError,
   type OAuthFlowVerifierBinding,
+  type OAuthFlowVerifierCipher,
 } from "./oauth-flow-verifier";
+import {
+  ProviderCredentialIntegrityError,
+  type ProviderCredentialCipherBinding,
+  type ProviderCredentialCipherPort,
+} from "./provider-credential-cipher";
 
 export type AuthEncryptionPurpose = "provider_credentials" | "provider_pkce_flow";
 
@@ -87,27 +93,28 @@ function encodeCiphertext(iv: Uint8Array, ciphertext: ArrayBuffer): string {
   return btoa(String.fromCharCode(...combined));
 }
 
-function decodeCiphertext(value: string): { iv: Uint8Array; ciphertext: Uint8Array } {
-  if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
-    throw new OAuthFlowVerifierIntegrityError();
-  }
-
+function decodeCiphertext(
+  value: string,
+  integrityError: () => Error
+): { iv: Uint8Array; ciphertext: Uint8Array } {
   try {
+    if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
+      throw new Error("Ciphertext is not canonical base64");
+    }
     const combined = Uint8Array.from(atob(value), (character) => character.charCodeAt(0));
     if (combined.byteLength <= AES_GCM_IV_BYTES + AES_GCM_TAG_BYTES) {
-      throw new OAuthFlowVerifierIntegrityError();
+      throw new Error("Ciphertext is too short");
     }
     return {
       iv: combined.slice(0, AES_GCM_IV_BYTES),
       ciphertext: combined.slice(AES_GCM_IV_BYTES),
     };
-  } catch (error) {
-    if (error instanceof OAuthFlowVerifierIntegrityError) throw error;
-    throw new OAuthFlowVerifierIntegrityError();
+  } catch {
+    throw integrityError();
   }
 }
 
-export class ProviderPkceFlowCipher {
+export class ProviderPkceFlowCipher implements OAuthFlowVerifierCipher {
   private readonly keys = new Map<number, Promise<CryptoKey>>();
   private readonly ivGenerator: InitializationVectorGenerator;
 
@@ -138,7 +145,10 @@ export class ProviderPkceFlowCipher {
   }
 
   async decrypt(encrypted: string, context: OAuthFlowVerifierBinding): Promise<string> {
-    const { iv, ciphertext } = decodeCiphertext(encrypted);
+    const { iv, ciphertext } = decodeCiphertext(
+      encrypted,
+      () => new OAuthFlowVerifierIntegrityError()
+    );
     try {
       const plaintext = await crypto.subtle.decrypt(
         {
@@ -164,6 +174,91 @@ export class ProviderPkceFlowCipher {
     const derived = deriveAuthEncryptionKeyBytes(
       this.rootKeyBase64,
       "provider_pkce_flow",
+      version
+    ).then((bytes) =>
+      crypto.subtle.importKey("raw", bytes, { name: "AES-GCM", length: 256 }, false, [
+        "encrypt",
+        "decrypt",
+      ])
+    );
+    this.keys.set(version, derived);
+    return derived;
+  }
+}
+
+function providerCredentialAssociatedData(context: ProviderCredentialCipherBinding): Uint8Array {
+  return new TextEncoder().encode(
+    JSON.stringify([
+      "provider_credentials",
+      context.providerIdentityId,
+      context.credentialKind,
+      context.tokenRole,
+      context.encryptionKeyVersion,
+      context.rowVersion,
+    ])
+  );
+}
+
+export class ProviderCredentialCipher implements ProviderCredentialCipherPort {
+  private readonly keys = new Map<number, Promise<CryptoKey>>();
+  private readonly ivGenerator: InitializationVectorGenerator;
+
+  constructor(
+    private readonly rootKeyBase64: string,
+    dependencies: { readonly ivGenerator?: InitializationVectorGenerator } = {}
+  ) {
+    this.ivGenerator = dependencies.ivGenerator ?? {
+      generate: () => crypto.getRandomValues(new Uint8Array(AES_GCM_IV_BYTES)),
+    };
+  }
+
+  async encrypt(plaintext: string, context: ProviderCredentialCipherBinding): Promise<string> {
+    const iv = this.ivGenerator.generate();
+    if (iv.byteLength !== AES_GCM_IV_BYTES) {
+      throw new Error("Provider credential IV generator returned an invalid IV");
+    }
+    const ciphertext = await crypto.subtle.encrypt(
+      {
+        name: "AES-GCM",
+        iv,
+        additionalData: providerCredentialAssociatedData(context),
+      },
+      await this.getKey(context.encryptionKeyVersion),
+      new TextEncoder().encode(plaintext)
+    );
+    return encodeCiphertext(iv, ciphertext);
+  }
+
+  async decrypt(encrypted: string, context: ProviderCredentialCipherBinding): Promise<string> {
+    const { iv, ciphertext } = decodeCiphertext(
+      encrypted,
+      () => new ProviderCredentialIntegrityError()
+    );
+    try {
+      const plaintext = await crypto.subtle.decrypt(
+        {
+          name: "AES-GCM",
+          iv,
+          additionalData: providerCredentialAssociatedData(context),
+        },
+        await this.getKey(context.encryptionKeyVersion),
+        ciphertext
+      );
+      return new TextDecoder().decode(plaintext);
+    } catch (error) {
+      if (error instanceof UnsupportedAuthEncryptionVersionError) throw error;
+      if (error instanceof InvalidAuthEncryptionRootError) throw error;
+      throw new ProviderCredentialIntegrityError();
+    }
+  }
+
+  private getKey(version: number): Promise<CryptoKey> {
+    const existing = this.keys.get(version);
+    if (existing) return existing;
+
+    const derived = deriveAuthEncryptionKeyBytes(
+      this.rootKeyBase64,
+      "provider_credentials",
       version
     ).then((bytes) =>
       crypto.subtle.importKey("raw", bytes, { name: "AES-GCM", length: 256 }, false, [

--- a/packages/control-plane/src/auth/auth-encryption.ts
+++ b/packages/control-plane/src/auth/auth-encryption.ts
@@ -114,56 +114,60 @@ function decodeCiphertext(
   }
 }
 
-export class ProviderPkceFlowCipher implements OAuthFlowVerifierCipher {
+interface AesGcmPurposeCipherOptions<Binding> {
+  readonly rootKeyBase64: string;
+  readonly purpose: AuthEncryptionPurpose;
+  readonly associatedData: (binding: Binding) => Uint8Array;
+  readonly keyVersion: (binding: Binding) => number;
+  readonly integrityError: () => Error;
+  readonly invalidIvError: () => Error;
+  readonly ivGenerator?: InitializationVectorGenerator;
+}
+
+class AesGcmPurposeCipher<Binding> {
   private readonly keys = new Map<number, Promise<CryptoKey>>();
   private readonly ivGenerator: InitializationVectorGenerator;
 
-  constructor(
-    private readonly rootKeyBase64: string,
-    dependencies: { readonly ivGenerator?: InitializationVectorGenerator } = {}
-  ) {
-    this.ivGenerator = dependencies.ivGenerator ?? {
+  constructor(private readonly options: AesGcmPurposeCipherOptions<Binding>) {
+    this.ivGenerator = options.ivGenerator ?? {
       generate: () => crypto.getRandomValues(new Uint8Array(AES_GCM_IV_BYTES)),
     };
   }
 
-  async encrypt(plaintext: string, context: OAuthFlowVerifierBinding): Promise<string> {
+  async encrypt(plaintext: string, binding: Binding): Promise<string> {
     const iv = this.ivGenerator.generate();
     if (iv.byteLength !== AES_GCM_IV_BYTES) {
-      throw new Error("Provider PKCE flow IV generator returned an invalid IV");
+      throw this.options.invalidIvError();
     }
     const ciphertext = await crypto.subtle.encrypt(
       {
         name: "AES-GCM",
         iv,
-        additionalData: providerPkceFlowAssociatedData(context),
+        additionalData: this.options.associatedData(binding),
       },
-      await this.getKey(context.keyVersion),
+      await this.getKey(this.options.keyVersion(binding)),
       new TextEncoder().encode(plaintext)
     );
     return encodeCiphertext(iv, ciphertext);
   }
 
-  async decrypt(encrypted: string, context: OAuthFlowVerifierBinding): Promise<string> {
-    const { iv, ciphertext } = decodeCiphertext(
-      encrypted,
-      () => new OAuthFlowVerifierIntegrityError()
-    );
+  async decrypt(encrypted: string, binding: Binding): Promise<string> {
+    const { iv, ciphertext } = decodeCiphertext(encrypted, this.options.integrityError);
     try {
       const plaintext = await crypto.subtle.decrypt(
         {
           name: "AES-GCM",
           iv,
-          additionalData: providerPkceFlowAssociatedData(context),
+          additionalData: this.options.associatedData(binding),
         },
-        await this.getKey(context.keyVersion),
+        await this.getKey(this.options.keyVersion(binding)),
         ciphertext
       );
       return new TextDecoder().decode(plaintext);
     } catch (error) {
       if (error instanceof UnsupportedAuthEncryptionVersionError) throw error;
       if (error instanceof InvalidAuthEncryptionRootError) throw error;
-      throw new OAuthFlowVerifierIntegrityError();
+      throw this.options.integrityError();
     }
   }
 
@@ -172,8 +176,8 @@ export class ProviderPkceFlowCipher implements OAuthFlowVerifierCipher {
     if (existing) return existing;
 
     const derived = deriveAuthEncryptionKeyBytes(
-      this.rootKeyBase64,
-      "provider_pkce_flow",
+      this.options.rootKeyBase64,
+      this.options.purpose,
       version
     ).then((bytes) =>
       crypto.subtle.importKey("raw", bytes, { name: "AES-GCM", length: 256 }, false, [
@@ -183,6 +187,33 @@ export class ProviderPkceFlowCipher implements OAuthFlowVerifierCipher {
     );
     this.keys.set(version, derived);
     return derived;
+  }
+}
+
+export class ProviderPkceFlowCipher implements OAuthFlowVerifierCipher {
+  private readonly cipher: AesGcmPurposeCipher<OAuthFlowVerifierBinding>;
+
+  constructor(
+    rootKeyBase64: string,
+    dependencies: { readonly ivGenerator?: InitializationVectorGenerator } = {}
+  ) {
+    this.cipher = new AesGcmPurposeCipher({
+      rootKeyBase64,
+      purpose: "provider_pkce_flow",
+      associatedData: providerPkceFlowAssociatedData,
+      keyVersion: (binding) => binding.keyVersion,
+      integrityError: () => new OAuthFlowVerifierIntegrityError(),
+      invalidIvError: () => new Error("Provider PKCE flow IV generator returned an invalid IV"),
+      ivGenerator: dependencies.ivGenerator,
+    });
+  }
+
+  encrypt(plaintext: string, context: OAuthFlowVerifierBinding): Promise<string> {
+    return this.cipher.encrypt(plaintext, context);
+  }
+
+  decrypt(encrypted: string, context: OAuthFlowVerifierBinding): Promise<string> {
+    return this.cipher.decrypt(encrypted, context);
   }
 }
 
@@ -200,73 +231,28 @@ function providerCredentialAssociatedData(context: ProviderCredentialCipherBindi
 }
 
 export class ProviderCredentialCipher implements ProviderCredentialCipherPort {
-  private readonly keys = new Map<number, Promise<CryptoKey>>();
-  private readonly ivGenerator: InitializationVectorGenerator;
+  private readonly cipher: AesGcmPurposeCipher<ProviderCredentialCipherBinding>;
 
   constructor(
-    private readonly rootKeyBase64: string,
+    rootKeyBase64: string,
     dependencies: { readonly ivGenerator?: InitializationVectorGenerator } = {}
   ) {
-    this.ivGenerator = dependencies.ivGenerator ?? {
-      generate: () => crypto.getRandomValues(new Uint8Array(AES_GCM_IV_BYTES)),
-    };
+    this.cipher = new AesGcmPurposeCipher({
+      rootKeyBase64,
+      purpose: "provider_credentials",
+      associatedData: providerCredentialAssociatedData,
+      keyVersion: (binding) => binding.encryptionKeyVersion,
+      integrityError: () => new ProviderCredentialIntegrityError(),
+      invalidIvError: () => new Error("Provider credential IV generator returned an invalid IV"),
+      ivGenerator: dependencies.ivGenerator,
+    });
   }
 
-  async encrypt(plaintext: string, context: ProviderCredentialCipherBinding): Promise<string> {
-    const iv = this.ivGenerator.generate();
-    if (iv.byteLength !== AES_GCM_IV_BYTES) {
-      throw new Error("Provider credential IV generator returned an invalid IV");
-    }
-    const ciphertext = await crypto.subtle.encrypt(
-      {
-        name: "AES-GCM",
-        iv,
-        additionalData: providerCredentialAssociatedData(context),
-      },
-      await this.getKey(context.encryptionKeyVersion),
-      new TextEncoder().encode(plaintext)
-    );
-    return encodeCiphertext(iv, ciphertext);
+  encrypt(plaintext: string, context: ProviderCredentialCipherBinding): Promise<string> {
+    return this.cipher.encrypt(plaintext, context);
   }
 
-  async decrypt(encrypted: string, context: ProviderCredentialCipherBinding): Promise<string> {
-    const { iv, ciphertext } = decodeCiphertext(
-      encrypted,
-      () => new ProviderCredentialIntegrityError()
-    );
-    try {
-      const plaintext = await crypto.subtle.decrypt(
-        {
-          name: "AES-GCM",
-          iv,
-          additionalData: providerCredentialAssociatedData(context),
-        },
-        await this.getKey(context.encryptionKeyVersion),
-        ciphertext
-      );
-      return new TextDecoder().decode(plaintext);
-    } catch (error) {
-      if (error instanceof UnsupportedAuthEncryptionVersionError) throw error;
-      if (error instanceof InvalidAuthEncryptionRootError) throw error;
-      throw new ProviderCredentialIntegrityError();
-    }
-  }
-
-  private getKey(version: number): Promise<CryptoKey> {
-    const existing = this.keys.get(version);
-    if (existing) return existing;
-
-    const derived = deriveAuthEncryptionKeyBytes(
-      this.rootKeyBase64,
-      "provider_credentials",
-      version
-    ).then((bytes) =>
-      crypto.subtle.importKey("raw", bytes, { name: "AES-GCM", length: 256 }, false, [
-        "encrypt",
-        "decrypt",
-      ])
-    );
-    this.keys.set(version, derived);
-    return derived;
+  decrypt(encrypted: string, context: ProviderCredentialCipherBinding): Promise<string> {
+    return this.cipher.decrypt(encrypted, context);
   }
 }

--- a/packages/control-plane/src/auth/provider-credential-cipher.ts
+++ b/packages/control-plane/src/auth/provider-credential-cipher.ts
@@ -1,0 +1,30 @@
+export type ProviderCredentialKind =
+  | "refreshable"
+  | "access_only_expiring"
+  | "access_only_nonexpiring";
+
+export interface ProviderCredentialCipherBinding {
+  providerIdentityId: string;
+  credentialKind: ProviderCredentialKind;
+  tokenRole: "access" | "refresh";
+  encryptionKeyVersion: number;
+  rowVersion: number;
+}
+
+/**
+ * Stable integrity failure exposed by the provider-credential cipher port.
+ * Implementations must throw this when ciphertext cannot be authenticated or
+ * decoded.
+ */
+export class ProviderCredentialIntegrityError extends Error {
+  constructor() {
+    super("Provider credential ciphertext could not be verified");
+    this.name = "ProviderCredentialIntegrityError";
+  }
+}
+
+/** Encrypts provider tokens while binding them to their exact persisted row. */
+export interface ProviderCredentialCipherPort {
+  encrypt(plaintext: string, binding: ProviderCredentialCipherBinding): Promise<string>;
+  decrypt(ciphertext: string, binding: ProviderCredentialCipherBinding): Promise<string>;
+}

--- a/packages/control-plane/src/db/errors.ts
+++ b/packages/control-plane/src/db/errors.ts
@@ -7,10 +7,3 @@ export function isUniqueConstraintError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
   return msg.toLowerCase().includes("unique constraint failed");
 }
-
-export function isNotNullConstraintError(err: unknown, qualifiedColumn: string): boolean {
-  const message = err instanceof Error ? err.message : String(err);
-  return message
-    .toLowerCase()
-    .includes(`not null constraint failed: ${qualifiedColumn.toLowerCase()}`);
-}

--- a/packages/control-plane/src/db/errors.ts
+++ b/packages/control-plane/src/db/errors.ts
@@ -7,3 +7,10 @@ export function isUniqueConstraintError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
   return msg.toLowerCase().includes("unique constraint failed");
 }
+
+export function isNotNullConstraintError(err: unknown, qualifiedColumn: string): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return message
+    .toLowerCase()
+    .includes(`not null constraint failed: ${qualifiedColumn.toLowerCase()}`);
+}

--- a/packages/control-plane/src/db/oauth-authorization-codes.ts
+++ b/packages/control-plane/src/db/oauth-authorization-codes.ts
@@ -13,8 +13,7 @@ import {
   type CreatedBrowserAuthSession,
   type TokenHasher,
 } from "./browser-auth-sessions";
-import { isNotNullConstraintError } from "./errors";
-import type { SqlDatabase, SqlResult } from "./sql-database";
+import type { SqlDatabase } from "./sql-database";
 
 export const OAUTH_AUTHORIZATION_CODE_LIFETIME_MS = 60 * 1000;
 
@@ -217,82 +216,60 @@ export class OAuthAuthorizationCodeStore {
     const credential = parseBrowserSessionCredential(
       this.dependencies.browserCredentialGenerator.generate()
     );
-    const redemptionId = this.dependencies.idGenerator.generate();
-    if (!isNonEmptyString(redemptionId)) {
-      throw new Error("OAuth redemption id generator returned an invalid id");
-    }
     const credentialId = parseBrowserSessionId(this.dependencies.idGenerator.generate());
     const credentialHash = await this.dependencies.tokenHasher.hash(credential);
     const expiresAt = now + BROWSER_SESSION_IDLE_LIFETIME_MS;
     const absoluteExpiresAt = now + BROWSER_SESSION_ABSOLUTE_LIFETIME_MS;
 
-    let consumeResult: SqlResult;
-    let sessionResult: SqlResult;
-    try {
-      // The scalar subqueries deliberately yield NULL when this redemption did
-      // not win the CAS. The session NOT NULL constraints then abort the whole
-      // D1 batch, so a code claim can never commit without its browser session.
-      [consumeResult, sessionResult] = await this.db.batch([
-        this.db
-          .prepare(
-            `UPDATE oauth_authorization_codes
-             SET consumed_at = ?, consumed_by = ?
-             WHERE code_hash = ?
-               AND client_id = ?
-               AND redirect_uri = ?
-               AND consumed_at IS NULL
-               AND expires_at > ?`
-          )
-          .bind(now, redemptionId, codeHash, input.clientId, input.redirectUri, now),
-        this.db
-          .prepare(
-            `INSERT INTO browser_auth_sessions (
-               id, token_hash, user_id, client_id, provider_identity_id,
-               created_at, last_used_at, expires_at, absolute_expires_at,
-               revoked_at, revoked_reason
-             ) VALUES (
-               ?, ?,
-               (
-                 SELECT user_id
-                 FROM oauth_authorization_codes
-                 WHERE code_hash = ? AND consumed_by = ? AND consumed_at = ?
-               ),
-               'web',
-               (
-                 SELECT provider_identity_id
-                 FROM oauth_authorization_codes
-                 WHERE code_hash = ? AND consumed_by = ? AND consumed_at = ?
-               ),
-               ?, ?, ?, ?, NULL, NULL
-             )`
-          )
-          .bind(
-            credentialId,
-            credentialHash,
-            codeHash,
-            redemptionId,
-            now,
-            codeHash,
-            redemptionId,
-            now,
-            now,
-            now,
-            expiresAt,
-            absoluteExpiresAt
-          ),
-      ]);
-    } catch (error) {
-      if (
-        !isNotNullConstraintError(error, "browser_auth_sessions.user_id") &&
-        !isNotNullConstraintError(error, "browser_auth_sessions.provider_identity_id")
-      ) {
-        throw error;
-      }
-      return this.throwCurrentRejection(codeHash, now);
+    const results = await this.db.batch([
+      this.db
+        .prepare(
+          `UPDATE oauth_authorization_codes
+           SET consumed_at = ?, consumed_by = ?
+           WHERE code_hash = ?
+             AND client_id = ?
+             AND redirect_uri = ?
+             AND consumed_at IS NULL
+             AND expires_at > ?`
+        )
+        .bind(now, credentialId, codeHash, input.clientId, input.redirectUri, now),
+      this.db
+        .prepare(
+          `INSERT INTO browser_auth_sessions (
+             id, token_hash, user_id, client_id, provider_identity_id,
+             created_at, last_used_at, expires_at, absolute_expires_at,
+             revoked_at, revoked_reason
+           )
+           SELECT
+             ?, ?, user_id, 'web', provider_identity_id,
+             ?, ?, ?, ?, NULL, NULL
+           FROM oauth_authorization_codes
+           WHERE code_hash = ?
+             AND consumed_by = ?
+             AND consumed_at = ?`
+        )
+        .bind(
+          credentialId,
+          credentialHash,
+          now,
+          now,
+          expiresAt,
+          absoluteExpiresAt,
+          codeHash,
+          credentialId,
+          now
+        ),
+    ]);
+    const [consumeResult, sessionResult] = results;
+    if (!consumeResult || !sessionResult) {
+      throw new Error("OAuth authorization code redemption batch returned an invalid result");
     }
 
-    if (consumeResult.meta.changes !== 1 || sessionResult.meta.changes !== 1) {
+    if (consumeResult.meta.changes === 0 && sessionResult.meta.changes === 0) {
       return this.throwCurrentRejection(codeHash, now);
+    }
+    if (consumeResult.meta.changes !== 1 || sessionResult.meta.changes !== 1) {
+      throw new Error("OAuth authorization code redemption batch violated its result invariant");
     }
     return { credential, credentialId, expiresAt, absoluteExpiresAt };
   }

--- a/packages/control-plane/src/db/oauth-authorization-codes.ts
+++ b/packages/control-plane/src/db/oauth-authorization-codes.ts
@@ -1,0 +1,324 @@
+import { timingSafeEqual } from "@open-inspect/shared";
+import {
+  InvalidPkceVerifierError,
+  createPkceS256Challenge,
+  isPkceS256Challenge,
+} from "../auth/pkce";
+import {
+  BROWSER_SESSION_ABSOLUTE_LIFETIME_MS,
+  BROWSER_SESSION_IDLE_LIFETIME_MS,
+  parseBrowserSessionCredential,
+  parseBrowserSessionId,
+  type Clock,
+  type CreatedBrowserAuthSession,
+  type TokenHasher,
+} from "./browser-auth-sessions";
+import { isNotNullConstraintError } from "./errors";
+import type { SqlDatabase, SqlResult } from "./sql-database";
+
+export const OAUTH_AUTHORIZATION_CODE_LIFETIME_MS = 60 * 1000;
+
+const AUTHORIZATION_CODE_PATTERN = /^oi_code_[A-Za-z0-9_-]{43}$/;
+
+export interface OAuthAuthorizationCodeStoreDependencies {
+  readonly clock: Clock;
+  readonly tokenHasher: TokenHasher;
+  readonly authorizationCodeGenerator: { generate(): string };
+  readonly browserCredentialGenerator: { generate(): string };
+  readonly idGenerator: { generate(): string };
+}
+
+export interface IssueOAuthAuthorizationCodeInput {
+  userId: string;
+  providerIdentityId: string;
+  clientId: "web";
+  redirectUri: string;
+  codeChallenge: string;
+}
+
+export interface RedeemOAuthAuthorizationCodeInput {
+  code: string;
+  clientId: "web";
+  redirectUri: string;
+  codeVerifier: string;
+}
+
+type AuthorizationCodeRow = {
+  id: string;
+  client_id: string;
+  redirect_uri: string;
+  code_challenge: string;
+  expires_at: number;
+  consumed_at: number | null;
+};
+
+export type OAuthAuthorizationCodeRejection =
+  | "malformed"
+  | "unknown"
+  | "binding_mismatch"
+  | "pkce_failed"
+  | "expired"
+  | "already_consumed"
+  | "race_lost"
+  | "corrupt";
+
+export class OAuthAuthorizationCodeRedemptionError extends Error {
+  constructor(readonly rejection: OAuthAuthorizationCodeRejection) {
+    super("OAuth authorization code is not valid");
+    this.name = "OAuthAuthorizationCodeRedemptionError";
+  }
+}
+
+export class InvalidOAuthAuthorizationCodeInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidOAuthAuthorizationCodeInputError";
+  }
+}
+
+function isFiniteInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && Number.isInteger(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function decodeAuthorizationCodeRow(value: unknown): AuthorizationCodeRow {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new OAuthAuthorizationCodeRedemptionError("corrupt");
+  }
+  const row = value as Record<string, unknown>;
+  if (
+    !isNonEmptyString(row.id) ||
+    row.client_id !== "web" ||
+    !isNonEmptyString(row.redirect_uri) ||
+    !isPkceS256Challenge(row.code_challenge) ||
+    !isFiniteInteger(row.expires_at) ||
+    (row.consumed_at !== null && !isFiniteInteger(row.consumed_at))
+  ) {
+    throw new OAuthAuthorizationCodeRedemptionError("corrupt");
+  }
+  return {
+    id: row.id,
+    client_id: row.client_id,
+    redirect_uri: row.redirect_uri,
+    code_challenge: row.code_challenge,
+    expires_at: row.expires_at,
+    consumed_at: row.consumed_at,
+  };
+}
+
+function validateIssueInput(input: IssueOAuthAuthorizationCodeInput): void {
+  if (
+    !isNonEmptyString(input.userId) ||
+    !isNonEmptyString(input.providerIdentityId) ||
+    input.clientId !== "web" ||
+    !isNonEmptyString(input.redirectUri) ||
+    !isPkceS256Challenge(input.codeChallenge)
+  ) {
+    throw new InvalidOAuthAuthorizationCodeInputError(
+      "OAuth authorization code binding is malformed"
+    );
+  }
+}
+
+export class OAuthAuthorizationCodeStore {
+  constructor(
+    private readonly db: SqlDatabase,
+    private readonly dependencies: OAuthAuthorizationCodeStoreDependencies
+  ) {}
+
+  async issue(
+    input: IssueOAuthAuthorizationCodeInput
+  ): Promise<{ code: string; expiresAt: number }> {
+    validateIssueInput(input);
+    const code = this.dependencies.authorizationCodeGenerator.generate();
+    if (!AUTHORIZATION_CODE_PATTERN.test(code)) {
+      throw new Error("OAuth authorization code generator returned an invalid code");
+    }
+    const codeId = this.dependencies.idGenerator.generate();
+    if (!isNonEmptyString(codeId)) {
+      throw new Error("OAuth authorization code id generator returned an invalid id");
+    }
+
+    const now = this.dependencies.clock.now();
+    const expiresAt = now + OAUTH_AUTHORIZATION_CODE_LIFETIME_MS;
+    const codeHash = await this.dependencies.tokenHasher.hash(code);
+    const result = await this.db
+      .prepare(
+        `INSERT INTO oauth_authorization_codes (
+           id, code_hash, user_id, provider_identity_id, client_id,
+           redirect_uri, code_challenge, created_at, expires_at,
+           consumed_at, consumed_by
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)`
+      )
+      .bind(
+        codeId,
+        codeHash,
+        input.userId,
+        input.providerIdentityId,
+        input.clientId,
+        input.redirectUri,
+        input.codeChallenge,
+        now,
+        expiresAt
+      )
+      .run();
+    if (result.meta.changes !== 1) {
+      throw new Error("OAuth authorization code was not created");
+    }
+    return { code, expiresAt };
+  }
+
+  async redeem(input: RedeemOAuthAuthorizationCodeInput): Promise<CreatedBrowserAuthSession> {
+    if (!AUTHORIZATION_CODE_PATTERN.test(input.code)) {
+      throw new OAuthAuthorizationCodeRedemptionError("malformed");
+    }
+
+    let presentedChallenge: string;
+    try {
+      presentedChallenge = await createPkceS256Challenge(input.codeVerifier);
+    } catch (error) {
+      if (error instanceof InvalidPkceVerifierError) {
+        throw new OAuthAuthorizationCodeRedemptionError("pkce_failed");
+      }
+      throw error;
+    }
+
+    const codeHash = await this.dependencies.tokenHasher.hash(input.code);
+    const found = await this.db
+      .prepare(
+        `SELECT
+           id, client_id, redirect_uri, code_challenge, expires_at, consumed_at
+         FROM oauth_authorization_codes
+         WHERE code_hash = ?`
+      )
+      .bind(codeHash)
+      .first<Record<string, unknown>>();
+    if (!found) throw new OAuthAuthorizationCodeRedemptionError("unknown");
+
+    const row = decodeAuthorizationCodeRow(found);
+    if (row.client_id !== input.clientId || row.redirect_uri !== input.redirectUri) {
+      throw new OAuthAuthorizationCodeRedemptionError("binding_mismatch");
+    }
+    if (!timingSafeEqual(row.code_challenge, presentedChallenge)) {
+      throw new OAuthAuthorizationCodeRedemptionError("pkce_failed");
+    }
+    if (row.consumed_at !== null) {
+      throw new OAuthAuthorizationCodeRedemptionError("already_consumed");
+    }
+
+    const now = this.dependencies.clock.now();
+    if (row.expires_at <= now) {
+      throw new OAuthAuthorizationCodeRedemptionError("expired");
+    }
+
+    const credential = parseBrowserSessionCredential(
+      this.dependencies.browserCredentialGenerator.generate()
+    );
+    const redemptionId = this.dependencies.idGenerator.generate();
+    if (!isNonEmptyString(redemptionId)) {
+      throw new Error("OAuth redemption id generator returned an invalid id");
+    }
+    const credentialId = parseBrowserSessionId(this.dependencies.idGenerator.generate());
+    const credentialHash = await this.dependencies.tokenHasher.hash(credential);
+    const expiresAt = now + BROWSER_SESSION_IDLE_LIFETIME_MS;
+    const absoluteExpiresAt = now + BROWSER_SESSION_ABSOLUTE_LIFETIME_MS;
+
+    let consumeResult: SqlResult;
+    let sessionResult: SqlResult;
+    try {
+      // The scalar subqueries deliberately yield NULL when this redemption did
+      // not win the CAS. The session NOT NULL constraints then abort the whole
+      // D1 batch, so a code claim can never commit without its browser session.
+      [consumeResult, sessionResult] = await this.db.batch([
+        this.db
+          .prepare(
+            `UPDATE oauth_authorization_codes
+             SET consumed_at = ?, consumed_by = ?
+             WHERE code_hash = ?
+               AND client_id = ?
+               AND redirect_uri = ?
+               AND consumed_at IS NULL
+               AND expires_at > ?`
+          )
+          .bind(now, redemptionId, codeHash, input.clientId, input.redirectUri, now),
+        this.db
+          .prepare(
+            `INSERT INTO browser_auth_sessions (
+               id, token_hash, user_id, client_id, provider_identity_id,
+               created_at, last_used_at, expires_at, absolute_expires_at,
+               revoked_at, revoked_reason
+             ) VALUES (
+               ?, ?,
+               (
+                 SELECT user_id
+                 FROM oauth_authorization_codes
+                 WHERE code_hash = ? AND consumed_by = ? AND consumed_at = ?
+               ),
+               'web',
+               (
+                 SELECT provider_identity_id
+                 FROM oauth_authorization_codes
+                 WHERE code_hash = ? AND consumed_by = ? AND consumed_at = ?
+               ),
+               ?, ?, ?, ?, NULL, NULL
+             )`
+          )
+          .bind(
+            credentialId,
+            credentialHash,
+            codeHash,
+            redemptionId,
+            now,
+            codeHash,
+            redemptionId,
+            now,
+            now,
+            now,
+            expiresAt,
+            absoluteExpiresAt
+          ),
+      ]);
+    } catch (error) {
+      if (
+        !isNotNullConstraintError(error, "browser_auth_sessions.user_id") &&
+        !isNotNullConstraintError(error, "browser_auth_sessions.provider_identity_id")
+      ) {
+        throw error;
+      }
+      return this.throwCurrentRejection(codeHash, now);
+    }
+
+    if (consumeResult.meta.changes !== 1 || sessionResult.meta.changes !== 1) {
+      return this.throwCurrentRejection(codeHash, now);
+    }
+    return { credential, credentialId, expiresAt, absoluteExpiresAt };
+  }
+
+  private async throwCurrentRejection(codeHash: string, now: number): Promise<never> {
+    const current = await this.db
+      .prepare(
+        `SELECT consumed_at, expires_at
+         FROM oauth_authorization_codes
+         WHERE code_hash = ?`
+      )
+      .bind(codeHash)
+      .first<Record<string, unknown>>();
+    if (!current) throw new OAuthAuthorizationCodeRedemptionError("race_lost");
+    if (
+      (current.consumed_at !== null && !isFiniteInteger(current.consumed_at)) ||
+      !isFiniteInteger(current.expires_at)
+    ) {
+      throw new OAuthAuthorizationCodeRedemptionError("corrupt");
+    }
+    if (current.consumed_at !== null) {
+      throw new OAuthAuthorizationCodeRedemptionError("already_consumed");
+    }
+    if (current.expires_at <= now) {
+      throw new OAuthAuthorizationCodeRedemptionError("expired");
+    }
+    throw new OAuthAuthorizationCodeRedemptionError("race_lost");
+  }
+}

--- a/packages/control-plane/src/db/provider-credentials.ts
+++ b/packages/control-plane/src/db/provider-credentials.ts
@@ -1,0 +1,524 @@
+import {
+  ProviderCredentialIntegrityError,
+  type ProviderCredentialCipherBinding,
+  type ProviderCredentialCipherPort,
+  type ProviderCredentialKind,
+} from "../auth/provider-credential-cipher";
+import type { Clock } from "./browser-auth-sessions";
+import { isUniqueConstraintError } from "./errors";
+import type { SqlDatabase, SqlStatement } from "./sql-database";
+
+export const PROVIDER_CREDENTIAL_ENCRYPTION_KEY_VERSION = 1;
+const MAX_SIGN_IN_UPSERT_ATTEMPTS = 4;
+
+export type ProviderCredentialInput =
+  | {
+      kind: "refreshable";
+      accessToken: string;
+      accessExpiresAt: number;
+      refreshToken: string;
+      refreshExpiresAt: number | null;
+    }
+  | {
+      kind: "access_only_expiring";
+      accessToken: string;
+      accessExpiresAt: number;
+    }
+  | {
+      kind: "access_only_nonexpiring";
+      accessToken: string;
+    };
+
+interface ProviderCredentialMetadata {
+  providerIdentityId: string;
+  encryptionKeyVersion: number;
+  rowVersion: number;
+  updatedAt: number;
+}
+
+export type ProviderCredential =
+  | (ProviderCredentialMetadata & {
+      kind: "refreshable";
+      accessToken: string;
+      accessExpiresAt: number;
+      refreshToken: string;
+      refreshExpiresAt: number | null;
+    })
+  | (ProviderCredentialMetadata & {
+      kind: "access_only_expiring";
+      accessToken: string;
+      accessExpiresAt: number;
+    })
+  | (ProviderCredentialMetadata & {
+      kind: "access_only_nonexpiring";
+      accessToken: string;
+    });
+
+interface ProviderCredentialRowMetadata {
+  providerIdentityId: string;
+  accessTokenCiphertext: string;
+  encryptionKeyVersion: number;
+  rowVersion: number;
+  updatedAt: number;
+}
+
+type ProviderCredentialRow =
+  | (ProviderCredentialRowMetadata & {
+      credentialKind: "refreshable";
+      accessExpiresAt: number;
+      refreshTokenCiphertext: string;
+      refreshExpiresAt: number | null;
+    })
+  | (ProviderCredentialRowMetadata & {
+      credentialKind: "access_only_expiring";
+      accessExpiresAt: number;
+      refreshTokenCiphertext: null;
+      refreshExpiresAt: null;
+    })
+  | (ProviderCredentialRowMetadata & {
+      credentialKind: "access_only_nonexpiring";
+      accessExpiresAt: null;
+      refreshTokenCiphertext: null;
+      refreshExpiresAt: null;
+    });
+
+interface EncryptedProviderCredential {
+  accessTokenCiphertext: string;
+  accessExpiresAt: number | null;
+  refreshTokenCiphertext: string | null;
+  refreshExpiresAt: number | null;
+}
+
+export class InvalidProviderCredentialInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidProviderCredentialInputError";
+  }
+}
+
+export class StoredProviderCredentialCorruptError extends Error {
+  constructor() {
+    super("Stored provider credential is invalid");
+    this.name = "StoredProviderCredentialCorruptError";
+  }
+}
+
+export class ProviderCredentialVersionConflictError extends Error {
+  constructor() {
+    super("Provider credential changed concurrently");
+    this.name = "ProviderCredentialVersionConflictError";
+  }
+}
+
+function isFiniteInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && Number.isInteger(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function validateInput(providerIdentityId: string, input: ProviderCredentialInput): void {
+  if (!isNonEmptyString(providerIdentityId) || !isNonEmptyString(input.accessToken)) {
+    throw new InvalidProviderCredentialInputError(
+      "Provider credential requires an identity and access token"
+    );
+  }
+  if ("accessExpiresAt" in input && !isFiniteInteger(input.accessExpiresAt)) {
+    throw new InvalidProviderCredentialInputError(
+      "Provider access-token expiry must be an integer"
+    );
+  }
+  if (
+    input.kind === "refreshable" &&
+    (!isNonEmptyString(input.refreshToken) ||
+      (input.refreshExpiresAt !== null && !isFiniteInteger(input.refreshExpiresAt)))
+  ) {
+    throw new InvalidProviderCredentialInputError("Refreshable provider credential is malformed");
+  }
+}
+
+function validateObservedVersion(providerIdentityId: string, observedRowVersion: number): void {
+  if (
+    !isNonEmptyString(providerIdentityId) ||
+    !isFiniteInteger(observedRowVersion) ||
+    observedRowVersion < 1
+  ) {
+    throw new InvalidProviderCredentialInputError(
+      "Provider identity and positive observed row version are required"
+    );
+  }
+}
+
+function decodeProviderCredentialRow(value: unknown): ProviderCredentialRow {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new StoredProviderCredentialCorruptError();
+  }
+  const row = value as Record<string, unknown>;
+  if (
+    !isNonEmptyString(row.provider_identity_id) ||
+    !isNonEmptyString(row.access_token_ciphertext) ||
+    row.encryption_key_version !== PROVIDER_CREDENTIAL_ENCRYPTION_KEY_VERSION ||
+    !isFiniteInteger(row.row_version) ||
+    row.row_version < 1 ||
+    !isFiniteInteger(row.updated_at)
+  ) {
+    throw new StoredProviderCredentialCorruptError();
+  }
+
+  const metadata = {
+    providerIdentityId: row.provider_identity_id,
+    accessTokenCiphertext: row.access_token_ciphertext,
+    encryptionKeyVersion: row.encryption_key_version,
+    rowVersion: row.row_version,
+    updatedAt: row.updated_at,
+  };
+  if (
+    row.credential_kind === "refreshable" &&
+    isFiniteInteger(row.access_expires_at) &&
+    isNonEmptyString(row.refresh_token_ciphertext) &&
+    (row.refresh_expires_at === null || isFiniteInteger(row.refresh_expires_at))
+  ) {
+    return {
+      ...metadata,
+      credentialKind: "refreshable",
+      accessExpiresAt: row.access_expires_at,
+      refreshTokenCiphertext: row.refresh_token_ciphertext,
+      refreshExpiresAt: row.refresh_expires_at,
+    };
+  }
+  if (
+    row.credential_kind === "access_only_expiring" &&
+    isFiniteInteger(row.access_expires_at) &&
+    row.refresh_token_ciphertext === null &&
+    row.refresh_expires_at === null
+  ) {
+    return {
+      ...metadata,
+      credentialKind: "access_only_expiring",
+      accessExpiresAt: row.access_expires_at,
+      refreshTokenCiphertext: null,
+      refreshExpiresAt: null,
+    };
+  }
+  if (
+    row.credential_kind === "access_only_nonexpiring" &&
+    row.access_expires_at === null &&
+    row.refresh_token_ciphertext === null &&
+    row.refresh_expires_at === null
+  ) {
+    return {
+      ...metadata,
+      credentialKind: "access_only_nonexpiring",
+      accessExpiresAt: null,
+      refreshTokenCiphertext: null,
+      refreshExpiresAt: null,
+    };
+  }
+  throw new StoredProviderCredentialCorruptError();
+}
+
+function cipherBinding(
+  providerIdentityId: string,
+  credentialKind: ProviderCredentialKind,
+  tokenRole: "access" | "refresh",
+  rowVersion: number
+): ProviderCredentialCipherBinding {
+  return {
+    providerIdentityId,
+    credentialKind,
+    tokenRole,
+    encryptionKeyVersion: PROVIDER_CREDENTIAL_ENCRYPTION_KEY_VERSION,
+    rowVersion,
+  };
+}
+
+export class ProviderCredentialStore {
+  constructor(
+    private readonly db: SqlDatabase,
+    private readonly cipher: ProviderCredentialCipherPort,
+    private readonly clock: Clock
+  ) {}
+
+  /**
+   * Prepares, but does not execute, an initial credential insert so identity
+   * resolution can commit the user, identity, email claim, and credential in
+   * one caller-owned database batch.
+   */
+  async prepareInitialInsert(
+    providerIdentityId: string,
+    credential: ProviderCredentialInput,
+    updatedAt = this.clock.now()
+  ): Promise<SqlStatement> {
+    validateInput(providerIdentityId, credential);
+    if (!isFiniteInteger(updatedAt)) {
+      throw new InvalidProviderCredentialInputError(
+        "Provider credential update time must be an integer"
+      );
+    }
+    const rowVersion = 1;
+    const encrypted = await this.encryptCredential(providerIdentityId, credential, rowVersion);
+    return this.prepareInsertStatement(
+      providerIdentityId,
+      credential.kind,
+      encrypted,
+      rowVersion,
+      updatedAt
+    );
+  }
+
+  async upsertFromSignIn(
+    providerIdentityId: string,
+    credential: ProviderCredentialInput
+  ): Promise<number> {
+    validateInput(providerIdentityId, credential);
+
+    for (let attempt = 0; attempt < MAX_SIGN_IN_UPSERT_ATTEMPTS; attempt += 1) {
+      const previousVersion = await this.readRowVersion(providerIdentityId);
+      const rowVersion = (previousVersion ?? 0) + 1;
+      const encrypted = await this.encryptCredential(providerIdentityId, credential, rowVersion);
+      const updatedAt = this.clock.now();
+
+      if (previousVersion === null) {
+        try {
+          const inserted = await this.prepareInsertStatement(
+            providerIdentityId,
+            credential.kind,
+            encrypted,
+            rowVersion,
+            updatedAt
+          ).run();
+          if (inserted.meta.changes === 1) return rowVersion;
+        } catch (error) {
+          if (!isUniqueConstraintError(error)) throw error;
+        }
+        continue;
+      }
+
+      if (
+        await this.updateObservedVersion(
+          providerIdentityId,
+          previousVersion,
+          credential.kind,
+          encrypted,
+          updatedAt
+        )
+      ) {
+        return rowVersion;
+      }
+    }
+
+    throw new ProviderCredentialVersionConflictError();
+  }
+
+  private async readRowVersion(providerIdentityId: string): Promise<number | null> {
+    const row = await this.db
+      .prepare(
+        `SELECT row_version
+         FROM provider_credentials
+         WHERE provider_identity_id = ?`
+      )
+      .bind(providerIdentityId)
+      .first<Record<string, unknown>>();
+    if (!row) return null;
+    if (!isFiniteInteger(row.row_version) || row.row_version < 1) {
+      throw new StoredProviderCredentialCorruptError();
+    }
+    return row.row_version;
+  }
+
+  private async encryptCredential(
+    providerIdentityId: string,
+    credential: ProviderCredentialInput,
+    rowVersion: number
+  ): Promise<EncryptedProviderCredential> {
+    const [accessTokenCiphertext, refreshTokenCiphertext] = await Promise.all([
+      this.cipher.encrypt(
+        credential.accessToken,
+        cipherBinding(providerIdentityId, credential.kind, "access", rowVersion)
+      ),
+      credential.kind === "refreshable"
+        ? this.cipher.encrypt(
+            credential.refreshToken,
+            cipherBinding(providerIdentityId, credential.kind, "refresh", rowVersion)
+          )
+        : Promise.resolve(null),
+    ]);
+    return {
+      accessTokenCiphertext,
+      accessExpiresAt:
+        credential.kind === "access_only_nonexpiring" ? null : credential.accessExpiresAt,
+      refreshTokenCiphertext,
+      refreshExpiresAt: credential.kind === "refreshable" ? credential.refreshExpiresAt : null,
+    };
+  }
+
+  private prepareInsertStatement(
+    providerIdentityId: string,
+    credentialKind: ProviderCredentialKind,
+    encrypted: EncryptedProviderCredential,
+    rowVersion: number,
+    updatedAt: number
+  ): SqlStatement {
+    return this.db
+      .prepare(
+        `INSERT INTO provider_credentials (
+           provider_identity_id, credential_kind,
+           access_token_ciphertext, access_expires_at,
+           refresh_token_ciphertext, refresh_expires_at,
+           encryption_key_version, row_version, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .bind(
+        providerIdentityId,
+        credentialKind,
+        encrypted.accessTokenCiphertext,
+        encrypted.accessExpiresAt,
+        encrypted.refreshTokenCiphertext,
+        encrypted.refreshExpiresAt,
+        PROVIDER_CREDENTIAL_ENCRYPTION_KEY_VERSION,
+        rowVersion,
+        updatedAt
+      );
+  }
+
+  private async updateObservedVersion(
+    providerIdentityId: string,
+    observedRowVersion: number,
+    credentialKind: ProviderCredentialKind,
+    encrypted: EncryptedProviderCredential,
+    updatedAt: number
+  ): Promise<boolean> {
+    const rowVersion = observedRowVersion + 1;
+    const result = await this.db
+      .prepare(
+        `UPDATE provider_credentials
+         SET credential_kind = ?,
+             access_token_ciphertext = ?,
+             access_expires_at = ?,
+             refresh_token_ciphertext = ?,
+             refresh_expires_at = ?,
+             encryption_key_version = ?,
+             row_version = ?,
+             updated_at = ?
+         WHERE provider_identity_id = ? AND row_version = ?`
+      )
+      .bind(
+        credentialKind,
+        encrypted.accessTokenCiphertext,
+        encrypted.accessExpiresAt,
+        encrypted.refreshTokenCiphertext,
+        encrypted.refreshExpiresAt,
+        PROVIDER_CREDENTIAL_ENCRYPTION_KEY_VERSION,
+        rowVersion,
+        updatedAt,
+        providerIdentityId,
+        observedRowVersion
+      )
+      .run();
+    return result.meta.changes === 1;
+  }
+
+  async get(providerIdentityId: string): Promise<ProviderCredential | null> {
+    if (!isNonEmptyString(providerIdentityId)) {
+      throw new InvalidProviderCredentialInputError("Provider identity is required");
+    }
+    const found = await this.db
+      .prepare(
+        `SELECT
+           provider_identity_id, credential_kind, access_token_ciphertext,
+           access_expires_at, refresh_token_ciphertext, refresh_expires_at,
+           encryption_key_version, row_version, updated_at
+         FROM provider_credentials
+         WHERE provider_identity_id = ?`
+      )
+      .bind(providerIdentityId)
+      .first<Record<string, unknown>>();
+    if (!found) return null;
+    const row = decodeProviderCredentialRow(found);
+
+    try {
+      const accessToken = await this.cipher.decrypt(
+        row.accessTokenCiphertext,
+        cipherBinding(row.providerIdentityId, row.credentialKind, "access", row.rowVersion)
+      );
+      if (!isNonEmptyString(accessToken)) {
+        throw new StoredProviderCredentialCorruptError();
+      }
+      const metadata = {
+        providerIdentityId: row.providerIdentityId,
+        accessToken,
+        encryptionKeyVersion: row.encryptionKeyVersion,
+        rowVersion: row.rowVersion,
+        updatedAt: row.updatedAt,
+      };
+      if (row.credentialKind === "refreshable") {
+        const refreshToken = await this.cipher.decrypt(
+          row.refreshTokenCiphertext,
+          cipherBinding(row.providerIdentityId, row.credentialKind, "refresh", row.rowVersion)
+        );
+        if (!isNonEmptyString(refreshToken)) {
+          throw new StoredProviderCredentialCorruptError();
+        }
+        return {
+          ...metadata,
+          kind: row.credentialKind,
+          accessExpiresAt: row.accessExpiresAt,
+          refreshToken,
+          refreshExpiresAt: row.refreshExpiresAt,
+        };
+      }
+      if (row.credentialKind === "access_only_expiring") {
+        return {
+          ...metadata,
+          kind: row.credentialKind,
+          accessExpiresAt: row.accessExpiresAt,
+        };
+      }
+      return { ...metadata, kind: row.credentialKind };
+    } catch (error) {
+      if (error instanceof ProviderCredentialIntegrityError) {
+        throw new StoredProviderCredentialCorruptError();
+      }
+      throw error;
+    }
+  }
+
+  async invalidateObservedVersion(
+    providerIdentityId: string,
+    observedRowVersion: number
+  ): Promise<boolean> {
+    validateObservedVersion(providerIdentityId, observedRowVersion);
+    const result = await this.db
+      .prepare(
+        `DELETE FROM provider_credentials
+         WHERE provider_identity_id = ? AND row_version = ?`
+      )
+      .bind(providerIdentityId, observedRowVersion)
+      .run();
+    return result.meta.changes === 1;
+  }
+
+  async replaceObservedVersion(
+    providerIdentityId: string,
+    observedRowVersion: number,
+    credential: ProviderCredentialInput
+  ): Promise<number> {
+    validateObservedVersion(providerIdentityId, observedRowVersion);
+    validateInput(providerIdentityId, credential);
+    const rowVersion = observedRowVersion + 1;
+    const encrypted = await this.encryptCredential(providerIdentityId, credential, rowVersion);
+    if (
+      !(await this.updateObservedVersion(
+        providerIdentityId,
+        observedRowVersion,
+        credential.kind,
+        encrypted,
+        this.clock.now()
+      ))
+    ) {
+      throw new ProviderCredentialVersionConflictError();
+    }
+    return rowVersion;
+  }
+}

--- a/packages/control-plane/src/db/provider-credentials.ts
+++ b/packages/control-plane/src/db/provider-credentials.ts
@@ -8,7 +8,10 @@ import type { Clock } from "./browser-auth-sessions";
 import { isUniqueConstraintError } from "./errors";
 import type { SqlDatabase, SqlStatement } from "./sql-database";
 
-export const PROVIDER_CREDENTIAL_ENCRYPTION_KEY_VERSION = 1;
+export const CURRENT_PROVIDER_CREDENTIAL_ENCRYPTION_KEY_VERSION = 1;
+const SUPPORTED_PROVIDER_CREDENTIAL_ENCRYPTION_KEY_VERSIONS: ReadonlySet<number> = new Set([
+  CURRENT_PROVIDER_CREDENTIAL_ENCRYPTION_KEY_VERSION,
+]);
 const MAX_SIGN_IN_UPSERT_ATTEMPTS = 4;
 
 export type ProviderCredentialInput =
@@ -118,6 +121,14 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.length > 0;
 }
 
+function isSupportedProviderCredentialEncryptionKeyVersion(value: unknown): value is number {
+  return (
+    isFiniteInteger(value) &&
+    value > 0 &&
+    SUPPORTED_PROVIDER_CREDENTIAL_ENCRYPTION_KEY_VERSIONS.has(value)
+  );
+}
+
 function validateInput(providerIdentityId: string, input: ProviderCredentialInput): void {
   if (!isNonEmptyString(providerIdentityId) || !isNonEmptyString(input.accessToken)) {
     throw new InvalidProviderCredentialInputError(
@@ -158,7 +169,7 @@ function decodeProviderCredentialRow(value: unknown): ProviderCredentialRow {
   if (
     !isNonEmptyString(row.provider_identity_id) ||
     !isNonEmptyString(row.access_token_ciphertext) ||
-    row.encryption_key_version !== PROVIDER_CREDENTIAL_ENCRYPTION_KEY_VERSION ||
+    !isSupportedProviderCredentialEncryptionKeyVersion(row.encryption_key_version) ||
     !isFiniteInteger(row.row_version) ||
     row.row_version < 1 ||
     !isFiniteInteger(row.updated_at)
@@ -222,13 +233,14 @@ function cipherBinding(
   providerIdentityId: string,
   credentialKind: ProviderCredentialKind,
   tokenRole: "access" | "refresh",
+  encryptionKeyVersion: number,
   rowVersion: number
 ): ProviderCredentialCipherBinding {
   return {
     providerIdentityId,
     credentialKind,
     tokenRole,
-    encryptionKeyVersion: PROVIDER_CREDENTIAL_ENCRYPTION_KEY_VERSION,
+    encryptionKeyVersion,
     rowVersion,
   };
 }
@@ -299,6 +311,7 @@ export class ProviderCredentialStore {
         await this.updateObservedVersion(
           providerIdentityId,
           previousVersion,
+          rowVersion,
           credential.kind,
           encrypted,
           updatedAt
@@ -335,12 +348,24 @@ export class ProviderCredentialStore {
     const [accessTokenCiphertext, refreshTokenCiphertext] = await Promise.all([
       this.cipher.encrypt(
         credential.accessToken,
-        cipherBinding(providerIdentityId, credential.kind, "access", rowVersion)
+        cipherBinding(
+          providerIdentityId,
+          credential.kind,
+          "access",
+          CURRENT_PROVIDER_CREDENTIAL_ENCRYPTION_KEY_VERSION,
+          rowVersion
+        )
       ),
       credential.kind === "refreshable"
         ? this.cipher.encrypt(
             credential.refreshToken,
-            cipherBinding(providerIdentityId, credential.kind, "refresh", rowVersion)
+            cipherBinding(
+              providerIdentityId,
+              credential.kind,
+              "refresh",
+              CURRENT_PROVIDER_CREDENTIAL_ENCRYPTION_KEY_VERSION,
+              rowVersion
+            )
           )
         : Promise.resolve(null),
     ]);
@@ -376,7 +401,7 @@ export class ProviderCredentialStore {
         encrypted.accessExpiresAt,
         encrypted.refreshTokenCiphertext,
         encrypted.refreshExpiresAt,
-        PROVIDER_CREDENTIAL_ENCRYPTION_KEY_VERSION,
+        CURRENT_PROVIDER_CREDENTIAL_ENCRYPTION_KEY_VERSION,
         rowVersion,
         updatedAt
       );
@@ -385,11 +410,11 @@ export class ProviderCredentialStore {
   private async updateObservedVersion(
     providerIdentityId: string,
     observedRowVersion: number,
+    rowVersion: number,
     credentialKind: ProviderCredentialKind,
     encrypted: EncryptedProviderCredential,
     updatedAt: number
   ): Promise<boolean> {
-    const rowVersion = observedRowVersion + 1;
     const result = await this.db
       .prepare(
         `UPDATE provider_credentials
@@ -409,7 +434,7 @@ export class ProviderCredentialStore {
         encrypted.accessExpiresAt,
         encrypted.refreshTokenCiphertext,
         encrypted.refreshExpiresAt,
-        PROVIDER_CREDENTIAL_ENCRYPTION_KEY_VERSION,
+        CURRENT_PROVIDER_CREDENTIAL_ENCRYPTION_KEY_VERSION,
         rowVersion,
         updatedAt,
         providerIdentityId,
@@ -440,7 +465,13 @@ export class ProviderCredentialStore {
     try {
       const accessToken = await this.cipher.decrypt(
         row.accessTokenCiphertext,
-        cipherBinding(row.providerIdentityId, row.credentialKind, "access", row.rowVersion)
+        cipherBinding(
+          row.providerIdentityId,
+          row.credentialKind,
+          "access",
+          row.encryptionKeyVersion,
+          row.rowVersion
+        )
       );
       if (!isNonEmptyString(accessToken)) {
         throw new StoredProviderCredentialCorruptError();
@@ -455,7 +486,13 @@ export class ProviderCredentialStore {
       if (row.credentialKind === "refreshable") {
         const refreshToken = await this.cipher.decrypt(
           row.refreshTokenCiphertext,
-          cipherBinding(row.providerIdentityId, row.credentialKind, "refresh", row.rowVersion)
+          cipherBinding(
+            row.providerIdentityId,
+            row.credentialKind,
+            "refresh",
+            row.encryptionKeyVersion,
+            row.rowVersion
+          )
         );
         if (!isNonEmptyString(refreshToken)) {
           throw new StoredProviderCredentialCorruptError();
@@ -512,6 +549,7 @@ export class ProviderCredentialStore {
       !(await this.updateObservedVersion(
         providerIdentityId,
         observedRowVersion,
+        rowVersion,
         credential.kind,
         encrypted,
         this.clock.now()

--- a/packages/control-plane/test/integration/oauth-authorization-codes.test.ts
+++ b/packages/control-plane/test/integration/oauth-authorization-codes.test.ts
@@ -3,13 +3,18 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { hashToken } from "../../src/auth/crypto";
 import { createPkceS256Challenge } from "../../src/auth/pkce";
 import {
+  BROWSER_SESSION_ABSOLUTE_LIFETIME_MS,
+  BROWSER_SESSION_IDLE_LIFETIME_MS,
   BrowserAuthSessionStore,
   parseBrowserSessionCredential,
   type BrowserAuthSessionStoreDependencies,
 } from "../../src/db/browser-auth-sessions";
 import {
+  InvalidOAuthAuthorizationCodeInputError,
+  OAUTH_AUTHORIZATION_CODE_LIFETIME_MS,
   OAuthAuthorizationCodeRedemptionError,
   OAuthAuthorizationCodeStore,
+  type IssueOAuthAuthorizationCodeInput,
 } from "../../src/db/oauth-authorization-codes";
 import { cleanD1Tables } from "./cleanup";
 
@@ -40,13 +45,7 @@ describe("OAuthAuthorizationCodeStore", () => {
   });
 
   function createStore(now = NOW_MS): OAuthAuthorizationCodeStore {
-    const ids = [
-      "code-1",
-      "redemption-1",
-      "browser-session-1",
-      "redemption-2",
-      "browser-session-2",
-    ];
+    const ids = ["code-1", "browser-session-1", "browser-session-2"];
     return new OAuthAuthorizationCodeStore(env.DB, {
       clock: { now: () => now },
       tokenHasher: { hash: hashToken },
@@ -76,7 +75,7 @@ describe("OAuthAuthorizationCodeStore", () => {
       })
     ).resolves.toEqual({
       code: AUTHORIZATION_CODE,
-      expiresAt: NOW_MS + 60_000,
+      expiresAt: NOW_MS + OAUTH_AUTHORIZATION_CODE_LIFETIME_MS,
     });
     await expect(
       env.DB.prepare("SELECT code_hash FROM oauth_authorization_codes WHERE id = 'code-1'").first()
@@ -92,9 +91,14 @@ describe("OAuthAuthorizationCodeStore", () => {
     expect(redeemed).toEqual({
       credential: BROWSER_CREDENTIAL,
       credentialId: "browser-session-1",
-      expiresAt: NOW_MS + 7 * 24 * 60 * 60 * 1000,
-      absoluteExpiresAt: NOW_MS + 30 * 24 * 60 * 60 * 1000,
+      expiresAt: NOW_MS + BROWSER_SESSION_IDLE_LIFETIME_MS,
+      absoluteExpiresAt: NOW_MS + BROWSER_SESSION_ABSOLUTE_LIFETIME_MS,
     });
+    await expect(
+      env.DB.prepare(
+        "SELECT consumed_by FROM oauth_authorization_codes WHERE id = 'code-1'"
+      ).first()
+    ).resolves.toEqual({ consumed_by: redeemed.credentialId });
 
     const sessionDependencies: BrowserAuthSessionStoreDependencies = {
       clock: { now: () => NOW_MS },
@@ -146,6 +150,51 @@ describe("OAuthAuthorizationCodeStore", () => {
     ).resolves.toEqual({ consumed_at: null, consumed_by: null });
   });
 
+  it("distinguishes malformed and unknown authorization codes", async () => {
+    const redemption = {
+      clientId: "web" as const,
+      redirectUri: REDIRECT_URI,
+      codeVerifier: CODE_VERIFIER,
+    };
+
+    await expect(
+      createStore().redeem({ ...redemption, code: "not-an-authorization-code" })
+    ).rejects.toMatchObject({ rejection: "malformed" });
+    await expect(
+      createStore().redeem({ ...redemption, code: `oi_code_${"z".repeat(43)}` })
+    ).rejects.toMatchObject({ rejection: "unknown" });
+  });
+
+  it("rejects malformed authorization-code bindings before persistence", async () => {
+    const validInput: IssueOAuthAuthorizationCodeInput = {
+      userId: "user-1",
+      providerIdentityId: "identity-1",
+      clientId: "web",
+      redirectUri: REDIRECT_URI,
+      codeChallenge: await createPkceS256Challenge(CODE_VERIFIER),
+    };
+    const invalidBindings: Array<
+      [string, Partial<Record<keyof IssueOAuthAuthorizationCodeInput, unknown>>]
+    > = [
+      ["missing user", { userId: "" }],
+      ["missing provider identity", { providerIdentityId: "" }],
+      ["unsupported client", { clientId: "cli" }],
+      ["missing redirect URI", { redirectUri: "" }],
+      ["malformed PKCE challenge", { codeChallenge: "not-a-challenge" }],
+    ];
+
+    for (const [name, override] of invalidBindings) {
+      const issue = createStore().issue({
+        ...validInput,
+        ...override,
+      } as IssueOAuthAuthorizationCodeInput);
+      await expect(issue, name).rejects.toBeInstanceOf(InvalidOAuthAuthorizationCodeInputError);
+    }
+    await expect(
+      env.DB.prepare("SELECT count(*) AS count FROM oauth_authorization_codes").first()
+    ).resolves.toEqual({ count: 0 });
+  });
+
   it("rejects a code at its exact expiry boundary without creating a session", async () => {
     await createStore().issue({
       userId: "user-1",
@@ -156,7 +205,7 @@ describe("OAuthAuthorizationCodeStore", () => {
     });
 
     await expect(
-      createStore(NOW_MS + 60_000).redeem({
+      createStore(NOW_MS + OAUTH_AUTHORIZATION_CODE_LIFETIME_MS).redeem({
         code: AUTHORIZATION_CODE,
         clientId: "web",
         redirectUri: REDIRECT_URI,
@@ -166,6 +215,33 @@ describe("OAuthAuthorizationCodeStore", () => {
     await expect(
       env.DB.prepare("SELECT count(*) AS count FROM browser_auth_sessions").first()
     ).resolves.toEqual({ count: 0 });
+  });
+
+  it("classifies sequential authorization-code replay as already consumed", async () => {
+    const store = createStore();
+    await store.issue({
+      userId: "user-1",
+      providerIdentityId: "identity-1",
+      clientId: "web",
+      redirectUri: REDIRECT_URI,
+      codeChallenge: await createPkceS256Challenge(CODE_VERIFIER),
+    });
+    const redemption = {
+      code: AUTHORIZATION_CODE,
+      clientId: "web" as const,
+      redirectUri: REDIRECT_URI,
+      codeVerifier: CODE_VERIFIER,
+    };
+
+    await expect(store.redeem(redemption)).resolves.toMatchObject({
+      credentialId: "browser-session-1",
+    });
+    await expect(store.redeem(redemption)).rejects.toMatchObject({
+      rejection: "already_consumed",
+    });
+    await expect(
+      env.DB.prepare("SELECT count(*) AS count FROM browser_auth_sessions").first()
+    ).resolves.toEqual({ count: 1 });
   });
 
   it("allows exactly one concurrent redemption without creating an orphan session", async () => {
@@ -195,5 +271,63 @@ describe("OAuthAuthorizationCodeStore", () => {
     await expect(
       env.DB.prepare("SELECT count(*) AS count FROM browser_auth_sessions").first()
     ).resolves.toEqual({ count: 1 });
+  });
+
+  it("rolls back code consumption when browser-session insertion fails", async () => {
+    const store = createStore();
+    await store.issue({
+      userId: "user-1",
+      providerIdentityId: "identity-1",
+      clientId: "web",
+      redirectUri: REDIRECT_URI,
+      codeChallenge: await createPkceS256Challenge(CODE_VERIFIER),
+    });
+    await env.DB.prepare(
+      `INSERT INTO browser_auth_sessions (
+         id, token_hash, user_id, client_id, provider_identity_id,
+         created_at, last_used_at, expires_at, absolute_expires_at,
+         revoked_at, revoked_reason
+       ) VALUES (?, ?, 'user-1', 'web', 'identity-1', ?, ?, ?, ?, NULL, NULL)`
+    )
+      .bind(
+        "browser-session-1",
+        "c".repeat(64),
+        NOW_MS,
+        NOW_MS,
+        NOW_MS + BROWSER_SESSION_IDLE_LIFETIME_MS,
+        NOW_MS + BROWSER_SESSION_ABSOLUTE_LIFETIME_MS
+      )
+      .run();
+
+    await expect(
+      store.redeem({
+        code: AUTHORIZATION_CODE,
+        clientId: "web",
+        redirectUri: REDIRECT_URI,
+        codeVerifier: CODE_VERIFIER,
+      })
+    ).rejects.toThrow();
+    await expect(
+      env.DB.prepare(
+        "SELECT consumed_at, consumed_by FROM oauth_authorization_codes WHERE id = 'code-1'"
+      ).first()
+    ).resolves.toEqual({ consumed_at: null, consumed_by: null });
+    await expect(
+      env.DB.prepare("SELECT count(*) AS count FROM browser_auth_sessions").first()
+    ).resolves.toEqual({ count: 1 });
+
+    await expect(
+      store.redeem({
+        code: AUTHORIZATION_CODE,
+        clientId: "web",
+        redirectUri: REDIRECT_URI,
+        codeVerifier: CODE_VERIFIER,
+      })
+    ).resolves.toMatchObject({ credentialId: "browser-session-2" });
+    await expect(
+      env.DB.prepare(
+        "SELECT consumed_by FROM oauth_authorization_codes WHERE id = 'code-1'"
+      ).first()
+    ).resolves.toEqual({ consumed_by: "browser-session-2" });
   });
 });

--- a/packages/control-plane/test/integration/oauth-authorization-codes.test.ts
+++ b/packages/control-plane/test/integration/oauth-authorization-codes.test.ts
@@ -1,0 +1,199 @@
+import { env } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import { hashToken } from "../../src/auth/crypto";
+import { createPkceS256Challenge } from "../../src/auth/pkce";
+import {
+  BrowserAuthSessionStore,
+  parseBrowserSessionCredential,
+  type BrowserAuthSessionStoreDependencies,
+} from "../../src/db/browser-auth-sessions";
+import {
+  OAuthAuthorizationCodeRedemptionError,
+  OAuthAuthorizationCodeStore,
+} from "../../src/db/oauth-authorization-codes";
+import { cleanD1Tables } from "./cleanup";
+
+const NOW_MS = 1_800_000_000_000;
+const AUTHORIZATION_CODE = `oi_code_${"a".repeat(43)}`;
+const BROWSER_CREDENTIAL = `oi_bsess_${"b".repeat(43)}`;
+const CODE_VERIFIER = "v".repeat(43);
+const REDIRECT_URI = "https://web.example/api/auth/callback";
+
+describe("OAuthAuthorizationCodeStore", () => {
+  beforeEach(async () => {
+    await cleanD1Tables();
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO users
+         (id, display_name, email, avatar_url, created_at, updated_at)
+         VALUES ('user-1', NULL, NULL, NULL, ?, ?)`
+      ).bind(NOW_MS, NOW_MS),
+      env.DB.prepare(
+        `INSERT INTO user_identities
+         (id, user_id, provider, provider_issuer, provider_user_id, created_at)
+         VALUES (
+           'identity-1', 'user-1', 'github', 'https://github.com',
+           'github-subject', ?
+         )`
+      ).bind(NOW_MS),
+    ]);
+  });
+
+  function createStore(now = NOW_MS): OAuthAuthorizationCodeStore {
+    const ids = [
+      "code-1",
+      "redemption-1",
+      "browser-session-1",
+      "redemption-2",
+      "browser-session-2",
+    ];
+    return new OAuthAuthorizationCodeStore(env.DB, {
+      clock: { now: () => now },
+      tokenHasher: { hash: hashToken },
+      authorizationCodeGenerator: { generate: () => AUTHORIZATION_CODE },
+      browserCredentialGenerator: { generate: () => BROWSER_CREDENTIAL },
+      idGenerator: {
+        generate: () => {
+          const id = ids.shift();
+          if (!id) throw new Error("Unexpected id request");
+          return id;
+        },
+      },
+    });
+  }
+
+  it("redeems a bound code into an authenticatable browser session", async () => {
+    const store = createStore();
+    const challenge = await createPkceS256Challenge(CODE_VERIFIER);
+
+    await expect(
+      store.issue({
+        userId: "user-1",
+        providerIdentityId: "identity-1",
+        clientId: "web",
+        redirectUri: REDIRECT_URI,
+        codeChallenge: challenge,
+      })
+    ).resolves.toEqual({
+      code: AUTHORIZATION_CODE,
+      expiresAt: NOW_MS + 60_000,
+    });
+    await expect(
+      env.DB.prepare("SELECT code_hash FROM oauth_authorization_codes WHERE id = 'code-1'").first()
+    ).resolves.toEqual({ code_hash: await hashToken(AUTHORIZATION_CODE) });
+
+    const redeemed = await store.redeem({
+      code: AUTHORIZATION_CODE,
+      clientId: "web",
+      redirectUri: REDIRECT_URI,
+      codeVerifier: CODE_VERIFIER,
+    });
+
+    expect(redeemed).toEqual({
+      credential: BROWSER_CREDENTIAL,
+      credentialId: "browser-session-1",
+      expiresAt: NOW_MS + 7 * 24 * 60 * 60 * 1000,
+      absoluteExpiresAt: NOW_MS + 30 * 24 * 60 * 60 * 1000,
+    });
+
+    const sessionDependencies: BrowserAuthSessionStoreDependencies = {
+      clock: { now: () => NOW_MS },
+      tokenHasher: { hash: hashToken },
+      credentialGenerator: { generate: () => BROWSER_CREDENTIAL },
+      idGenerator: { generate: () => "unused" },
+    };
+    const sessions = new BrowserAuthSessionStore(env.DB, sessionDependencies);
+    await expect(
+      sessions.authenticate(parseBrowserSessionCredential(BROWSER_CREDENTIAL))
+    ).resolves.toMatchObject({
+      credentialId: "browser-session-1",
+      userId: "user-1",
+      providerIdentityId: "identity-1",
+    });
+  });
+
+  it("does not consume a code when its redirect binding or PKCE verifier is wrong", async () => {
+    const store = createStore();
+    await store.issue({
+      userId: "user-1",
+      providerIdentityId: "identity-1",
+      clientId: "web",
+      redirectUri: REDIRECT_URI,
+      codeChallenge: await createPkceS256Challenge(CODE_VERIFIER),
+    });
+
+    await expect(
+      store.redeem({
+        code: AUTHORIZATION_CODE,
+        clientId: "web",
+        redirectUri: "https://attacker.example/callback",
+        codeVerifier: CODE_VERIFIER,
+      })
+    ).rejects.toMatchObject({ rejection: "binding_mismatch" });
+    await expect(
+      store.redeem({
+        code: AUTHORIZATION_CODE,
+        clientId: "web",
+        redirectUri: REDIRECT_URI,
+        codeVerifier: "x".repeat(43),
+      })
+    ).rejects.toMatchObject({ rejection: "pkce_failed" });
+
+    await expect(
+      env.DB.prepare(
+        "SELECT consumed_at, consumed_by FROM oauth_authorization_codes WHERE id = 'code-1'"
+      ).first()
+    ).resolves.toEqual({ consumed_at: null, consumed_by: null });
+  });
+
+  it("rejects a code at its exact expiry boundary without creating a session", async () => {
+    await createStore().issue({
+      userId: "user-1",
+      providerIdentityId: "identity-1",
+      clientId: "web",
+      redirectUri: REDIRECT_URI,
+      codeChallenge: await createPkceS256Challenge(CODE_VERIFIER),
+    });
+
+    await expect(
+      createStore(NOW_MS + 60_000).redeem({
+        code: AUTHORIZATION_CODE,
+        clientId: "web",
+        redirectUri: REDIRECT_URI,
+        codeVerifier: CODE_VERIFIER,
+      })
+    ).rejects.toMatchObject({ rejection: "expired" });
+    await expect(
+      env.DB.prepare("SELECT count(*) AS count FROM browser_auth_sessions").first()
+    ).resolves.toEqual({ count: 0 });
+  });
+
+  it("allows exactly one concurrent redemption without creating an orphan session", async () => {
+    const store = createStore();
+    await store.issue({
+      userId: "user-1",
+      providerIdentityId: "identity-1",
+      clientId: "web",
+      redirectUri: REDIRECT_URI,
+      codeChallenge: await createPkceS256Challenge(CODE_VERIFIER),
+    });
+    const redemption = {
+      code: AUTHORIZATION_CODE,
+      clientId: "web" as const,
+      redirectUri: REDIRECT_URI,
+      codeVerifier: CODE_VERIFIER,
+    };
+
+    const results = await Promise.allSettled([store.redeem(redemption), store.redeem(redemption)]);
+
+    expect(results.filter(({ status }) => status === "fulfilled")).toHaveLength(1);
+    const rejection = results.find(({ status }) => status === "rejected");
+    expect(rejection).toMatchObject({
+      status: "rejected",
+      reason: expect.any(OAuthAuthorizationCodeRedemptionError),
+    });
+    await expect(
+      env.DB.prepare("SELECT count(*) AS count FROM browser_auth_sessions").first()
+    ).resolves.toEqual({ count: 1 });
+  });
+});

--- a/packages/control-plane/test/integration/provider-credentials.test.ts
+++ b/packages/control-plane/test/integration/provider-credentials.test.ts
@@ -1,0 +1,292 @@
+import { env } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ProviderCredentialCipher } from "../../src/auth/auth-encryption";
+import type { ProviderCredentialCipherPort } from "../../src/auth/provider-credential-cipher";
+import {
+  ProviderCredentialStore,
+  ProviderCredentialVersionConflictError,
+  StoredProviderCredentialCorruptError,
+} from "../../src/db/provider-credentials";
+import { cleanD1Tables } from "./cleanup";
+
+const NOW_MS = 1_800_000_000_000;
+const ROOT_KEY_BASE64 = Buffer.from(
+  "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+  "hex"
+).toString("base64");
+
+describe("ProviderCredentialStore", () => {
+  beforeEach(async () => {
+    await cleanD1Tables();
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO users
+         (id, display_name, email, avatar_url, created_at, updated_at)
+         VALUES ('user-1', NULL, NULL, NULL, ?, ?)`
+      ).bind(NOW_MS, NOW_MS),
+      env.DB.prepare(
+        `INSERT INTO user_identities
+         (id, user_id, provider, provider_issuer, provider_user_id, created_at)
+         VALUES (
+           'identity-1', 'user-1', 'github', 'https://github.com',
+           'github-subject', ?
+         )`
+      ).bind(NOW_MS),
+    ]);
+  });
+
+  it("round-trips refreshable credentials without storing plaintext tokens", async () => {
+    const store = new ProviderCredentialStore(
+      env.DB,
+      new ProviderCredentialCipher(ROOT_KEY_BASE64),
+      { now: () => NOW_MS }
+    );
+
+    await expect(
+      store.upsertFromSignIn("identity-1", {
+        kind: "refreshable",
+        accessToken: "github-access-token",
+        accessExpiresAt: NOW_MS + 60_000,
+        refreshToken: "github-refresh-token",
+        refreshExpiresAt: null,
+      })
+    ).resolves.toBe(1);
+    await expect(store.get("identity-1")).resolves.toEqual({
+      providerIdentityId: "identity-1",
+      kind: "refreshable",
+      accessToken: "github-access-token",
+      accessExpiresAt: NOW_MS + 60_000,
+      refreshToken: "github-refresh-token",
+      refreshExpiresAt: null,
+      encryptionKeyVersion: 1,
+      rowVersion: 1,
+      updatedAt: NOW_MS,
+    });
+
+    const persisted = await env.DB.prepare(
+      `SELECT access_token_ciphertext, refresh_token_ciphertext
+       FROM provider_credentials
+       WHERE provider_identity_id = 'identity-1'`
+    ).first();
+    expect(JSON.stringify(persisted)).not.toContain("github-access-token");
+    expect(JSON.stringify(persisted)).not.toContain("github-refresh-token");
+  });
+
+  it("does not let stale invalidation delete credentials from a newer sign-in", async () => {
+    const store = new ProviderCredentialStore(
+      env.DB,
+      new ProviderCredentialCipher(ROOT_KEY_BASE64),
+      { now: () => NOW_MS }
+    );
+    const firstVersion = await store.upsertFromSignIn("identity-1", {
+      kind: "access_only_nonexpiring",
+      accessToken: "old-access-token",
+    });
+
+    const secondVersion = await store.upsertFromSignIn("identity-1", {
+      kind: "access_only_nonexpiring",
+      accessToken: "new-access-token",
+    });
+
+    await expect(store.invalidateObservedVersion("identity-1", firstVersion)).resolves.toBe(false);
+    await expect(store.get("identity-1")).resolves.toMatchObject({
+      accessToken: "new-access-token",
+      rowVersion: secondVersion,
+    });
+  });
+
+  it("serializes concurrent sign-ins through row-version retries", async () => {
+    const store = new ProviderCredentialStore(
+      env.DB,
+      new ProviderCredentialCipher(ROOT_KEY_BASE64),
+      { now: () => NOW_MS }
+    );
+
+    const versions = await Promise.all([
+      store.upsertFromSignIn("identity-1", {
+        kind: "access_only_nonexpiring",
+        accessToken: "first-concurrent-token",
+      }),
+      store.upsertFromSignIn("identity-1", {
+        kind: "access_only_nonexpiring",
+        accessToken: "second-concurrent-token",
+      }),
+    ]);
+
+    expect(versions.sort()).toEqual([1, 2]);
+    await expect(store.get("identity-1")).resolves.toMatchObject({
+      rowVersion: 2,
+    });
+  });
+
+  it("does not let a stale refresh overwrite credentials from a newer sign-in", async () => {
+    const store = new ProviderCredentialStore(
+      env.DB,
+      new ProviderCredentialCipher(ROOT_KEY_BASE64),
+      { now: () => NOW_MS }
+    );
+    const observedVersion = await store.upsertFromSignIn("identity-1", {
+      kind: "refreshable",
+      accessToken: "expired-access-token",
+      accessExpiresAt: NOW_MS - 1,
+      refreshToken: "refresh-token",
+      refreshExpiresAt: null,
+    });
+    const signInVersion = await store.upsertFromSignIn("identity-1", {
+      kind: "access_only_nonexpiring",
+      accessToken: "new-sign-in-token",
+    });
+
+    await expect(
+      store.replaceObservedVersion("identity-1", observedVersion, {
+        kind: "refreshable",
+        accessToken: "stale-refresh-access-token",
+        accessExpiresAt: NOW_MS + 60_000,
+        refreshToken: "stale-refresh-token",
+        refreshExpiresAt: null,
+      })
+    ).rejects.toBeInstanceOf(ProviderCredentialVersionConflictError);
+    await expect(store.get("identity-1")).resolves.toMatchObject({
+      accessToken: "new-sign-in-token",
+      rowVersion: signInVersion,
+    });
+  });
+
+  it("replaces the exact credential version observed by a provider refresh", async () => {
+    const store = new ProviderCredentialStore(
+      env.DB,
+      new ProviderCredentialCipher(ROOT_KEY_BASE64),
+      { now: () => NOW_MS }
+    );
+    const observedVersion = await store.upsertFromSignIn("identity-1", {
+      kind: "refreshable",
+      accessToken: "expired-access-token",
+      accessExpiresAt: NOW_MS - 1,
+      refreshToken: "refresh-token",
+      refreshExpiresAt: null,
+    });
+
+    await expect(
+      store.replaceObservedVersion("identity-1", observedVersion, {
+        kind: "refreshable",
+        accessToken: "refreshed-access-token",
+        accessExpiresAt: NOW_MS + 60_000,
+        refreshToken: "rotated-refresh-token",
+        refreshExpiresAt: NOW_MS + 120_000,
+      })
+    ).resolves.toBe(2);
+    await expect(store.get("identity-1")).resolves.toMatchObject({
+      accessToken: "refreshed-access-token",
+      refreshToken: "rotated-refresh-token",
+      refreshExpiresAt: NOW_MS + 120_000,
+      rowVersion: 2,
+    });
+  });
+
+  it("supports both current access-only credential shapes", async () => {
+    const store = new ProviderCredentialStore(
+      env.DB,
+      new ProviderCredentialCipher(ROOT_KEY_BASE64),
+      { now: () => NOW_MS }
+    );
+
+    await store.upsertFromSignIn("identity-1", {
+      kind: "access_only_expiring",
+      accessToken: "expiring-access-token",
+      accessExpiresAt: NOW_MS + 60_000,
+    });
+    await expect(store.get("identity-1")).resolves.toMatchObject({
+      kind: "access_only_expiring",
+      accessToken: "expiring-access-token",
+      accessExpiresAt: NOW_MS + 60_000,
+      rowVersion: 1,
+    });
+
+    await store.upsertFromSignIn("identity-1", {
+      kind: "access_only_nonexpiring",
+      accessToken: "nonexpiring-access-token",
+    });
+    await expect(store.get("identity-1")).resolves.toEqual({
+      providerIdentityId: "identity-1",
+      kind: "access_only_nonexpiring",
+      accessToken: "nonexpiring-access-token",
+      encryptionKeyVersion: 1,
+      rowVersion: 2,
+      updatedAt: NOW_MS,
+    });
+  });
+
+  it("fails closed when ciphertext is moved to a different row version", async () => {
+    const store = new ProviderCredentialStore(
+      env.DB,
+      new ProviderCredentialCipher(ROOT_KEY_BASE64),
+      { now: () => NOW_MS }
+    );
+    await store.upsertFromSignIn("identity-1", {
+      kind: "access_only_nonexpiring",
+      accessToken: "access-token",
+    });
+    await env.DB.prepare(
+      `UPDATE provider_credentials
+       SET row_version = 2
+       WHERE provider_identity_id = 'identity-1'`
+    ).run();
+
+    await expect(store.get("identity-1")).rejects.toBeInstanceOf(
+      StoredProviderCredentialCorruptError
+    );
+  });
+
+  it("composes initial credential creation into an identity-owned atomic batch", async () => {
+    const store = new ProviderCredentialStore(
+      env.DB,
+      new ProviderCredentialCipher(ROOT_KEY_BASE64),
+      { now: () => NOW_MS }
+    );
+    const credentialInsert = await store.prepareInitialInsert("identity-2", {
+      kind: "access_only_nonexpiring",
+      accessToken: "new-identity-access-token",
+    });
+
+    await env.DB.batch([
+      env.DB.prepare(
+        `INSERT INTO users
+         (id, display_name, email, avatar_url, created_at, updated_at)
+         VALUES ('user-2', NULL, NULL, NULL, ?, ?)`
+      ).bind(NOW_MS, NOW_MS),
+      env.DB.prepare(
+        `INSERT INTO user_identities
+         (id, user_id, provider, provider_issuer, provider_user_id, created_at)
+         VALUES (
+           'identity-2', 'user-2', 'github', 'https://github.com',
+           'github-subject-2', ?
+         )`
+      ).bind(NOW_MS),
+      credentialInsert,
+    ]);
+
+    await expect(store.get("identity-2")).resolves.toMatchObject({
+      providerIdentityId: "identity-2",
+      accessToken: "new-identity-access-token",
+      rowVersion: 1,
+    });
+  });
+
+  it("fails closed when authenticated ciphertext decodes to an empty token", async () => {
+    const emptyPlaintextCipher: ProviderCredentialCipherPort = {
+      encrypt: async () => "authenticated-ciphertext",
+      decrypt: async () => "",
+    };
+    const store = new ProviderCredentialStore(env.DB, emptyPlaintextCipher, {
+      now: () => NOW_MS,
+    });
+    await store.upsertFromSignIn("identity-1", {
+      kind: "access_only_nonexpiring",
+      accessToken: "nonempty-input-token",
+    });
+
+    await expect(store.get("identity-1")).rejects.toBeInstanceOf(
+      StoredProviderCredentialCorruptError
+    );
+  });
+});

--- a/packages/control-plane/test/integration/provider-credentials.test.ts
+++ b/packages/control-plane/test/integration/provider-credentials.test.ts
@@ -16,6 +16,8 @@ const ROOT_KEY_BASE64 = Buffer.from(
 ).toString("base64");
 
 describe("ProviderCredentialStore", () => {
+  let store: ProviderCredentialStore;
+
   beforeEach(async () => {
     await cleanD1Tables();
     await env.DB.batch([
@@ -33,15 +35,12 @@ describe("ProviderCredentialStore", () => {
          )`
       ).bind(NOW_MS),
     ]);
+    store = new ProviderCredentialStore(env.DB, new ProviderCredentialCipher(ROOT_KEY_BASE64), {
+      now: () => NOW_MS,
+    });
   });
 
   it("round-trips refreshable credentials without storing plaintext tokens", async () => {
-    const store = new ProviderCredentialStore(
-      env.DB,
-      new ProviderCredentialCipher(ROOT_KEY_BASE64),
-      { now: () => NOW_MS }
-    );
-
     await expect(
       store.upsertFromSignIn("identity-1", {
         kind: "refreshable",
@@ -73,11 +72,6 @@ describe("ProviderCredentialStore", () => {
   });
 
   it("does not let stale invalidation delete credentials from a newer sign-in", async () => {
-    const store = new ProviderCredentialStore(
-      env.DB,
-      new ProviderCredentialCipher(ROOT_KEY_BASE64),
-      { now: () => NOW_MS }
-    );
     const firstVersion = await store.upsertFromSignIn("identity-1", {
       kind: "access_only_nonexpiring",
       accessToken: "old-access-token",
@@ -96,12 +90,6 @@ describe("ProviderCredentialStore", () => {
   });
 
   it("serializes concurrent sign-ins through row-version retries", async () => {
-    const store = new ProviderCredentialStore(
-      env.DB,
-      new ProviderCredentialCipher(ROOT_KEY_BASE64),
-      { now: () => NOW_MS }
-    );
-
     const versions = await Promise.all([
       store.upsertFromSignIn("identity-1", {
         kind: "access_only_nonexpiring",
@@ -120,11 +108,6 @@ describe("ProviderCredentialStore", () => {
   });
 
   it("does not let a stale refresh overwrite credentials from a newer sign-in", async () => {
-    const store = new ProviderCredentialStore(
-      env.DB,
-      new ProviderCredentialCipher(ROOT_KEY_BASE64),
-      { now: () => NOW_MS }
-    );
     const observedVersion = await store.upsertFromSignIn("identity-1", {
       kind: "refreshable",
       accessToken: "expired-access-token",
@@ -153,11 +136,6 @@ describe("ProviderCredentialStore", () => {
   });
 
   it("replaces the exact credential version observed by a provider refresh", async () => {
-    const store = new ProviderCredentialStore(
-      env.DB,
-      new ProviderCredentialCipher(ROOT_KEY_BASE64),
-      { now: () => NOW_MS }
-    );
     const observedVersion = await store.upsertFromSignIn("identity-1", {
       kind: "refreshable",
       accessToken: "expired-access-token",
@@ -184,12 +162,6 @@ describe("ProviderCredentialStore", () => {
   });
 
   it("supports both current access-only credential shapes", async () => {
-    const store = new ProviderCredentialStore(
-      env.DB,
-      new ProviderCredentialCipher(ROOT_KEY_BASE64),
-      { now: () => NOW_MS }
-    );
-
     await store.upsertFromSignIn("identity-1", {
       kind: "access_only_expiring",
       accessToken: "expiring-access-token",
@@ -217,11 +189,6 @@ describe("ProviderCredentialStore", () => {
   });
 
   it("fails closed when ciphertext is moved to a different row version", async () => {
-    const store = new ProviderCredentialStore(
-      env.DB,
-      new ProviderCredentialCipher(ROOT_KEY_BASE64),
-      { now: () => NOW_MS }
-    );
     await store.upsertFromSignIn("identity-1", {
       kind: "access_only_nonexpiring",
       accessToken: "access-token",
@@ -238,11 +205,6 @@ describe("ProviderCredentialStore", () => {
   });
 
   it("composes initial credential creation into an identity-owned atomic batch", async () => {
-    const store = new ProviderCredentialStore(
-      env.DB,
-      new ProviderCredentialCipher(ROOT_KEY_BASE64),
-      { now: () => NOW_MS }
-    );
     const credentialInsert = await store.prepareInitialInsert("identity-2", {
       kind: "access_only_nonexpiring",
       accessToken: "new-identity-access-token",
@@ -277,15 +239,15 @@ describe("ProviderCredentialStore", () => {
       encrypt: async () => "authenticated-ciphertext",
       decrypt: async () => "",
     };
-    const store = new ProviderCredentialStore(env.DB, emptyPlaintextCipher, {
+    const corruptStore = new ProviderCredentialStore(env.DB, emptyPlaintextCipher, {
       now: () => NOW_MS,
     });
-    await store.upsertFromSignIn("identity-1", {
+    await corruptStore.upsertFromSignIn("identity-1", {
       kind: "access_only_nonexpiring",
       accessToken: "nonempty-input-token",
     });
 
-    await expect(store.get("identity-1")).rejects.toBeInstanceOf(
+    await expect(corruptStore.get("identity-1")).rejects.toBeInstanceOf(
       StoredProviderCredentialCorruptError
     );
   });


### PR DESCRIPTION
## Summary

- add 60-second, single-use OAuth authorization codes stored as SHA-256 hashes and redeemed with exact client, redirect, and PKCE bindings
- atomically consume authorization codes and create stable opaque `oi_bsess_` browser sessions, including concurrent-redemption protection
- add a purpose-derived AES-GCM provider credential cipher with associated-data binding to identity, credential shape, token role, key version, and row version
- add versioned provider credential storage for refreshable, expiring access-only, and non-expiring access-only provider credentials
- protect sign-in, refresh, and invalidation races with compare-and-swap row versions
- expose a prepared initial credential insert so identity creation can include credentials in its caller-owned D1 batch

## Scope and merge safety

This is an additive storage-layer slice built on the browser-auth schema and OAuth flow-state foundations from #1115 and #1116. It does not add routes, provider HTTP adapters, identity resolution, cookies, cutover behavior, legacy dual writes, or dormant CLI/Okta runtime variants. Existing authentication behavior remains unchanged until later composition PRs use these stores.

The authorization-code store owns the code-consumption and browser-session insert SQL because those writes must commit atomically. Provider credential encryption is injected through a narrow port so store concurrency rules are independently testable and the concrete cipher remains in the auth layer.

## TDD coverage

The implementation was developed through red-green-refactor tracer bullets covering:

- code issuance and redemption into an authenticatable browser session
- exact redirect and PKCE binding failures without code consumption
- expiry-boundary and concurrent-redemption behavior
- encrypted credential round trips without plaintext persistence
- concurrent sign-in retries and stale refresh/invalidation protection
- all three executable credential shapes
- authenticated-data substitution and corrupt plaintext rejection
- caller-owned atomic identity-and-credential insertion

## Validation

- `npm run test -w @open-inspect/control-plane` — 133 files, 2,119 tests passed
- `npm run test:integration -w @open-inspect/control-plane` — 59 files, 694 tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure encrypted storage and retrieval for provider credentials.
  * Added credential versioning and concurrency protection to prevent stale updates.
  * Added short-lived OAuth authorization codes with PKCE validation and browser-session creation.
  * Added safeguards against replay, expiration, binding mismatches, and redemption races.

* **Bug Fixes**
  * Improved detection and handling of corrupted or tampered credential data.

* **Tests**
  * Added comprehensive coverage for credential encryption, OAuth redemption, concurrency, rollback, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->