### PR TITLE
Allow control-plane integration tests to complete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
   test-cp-integration:
     name: Test (control-plane integration)
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     needs: [lint-typescript, typecheck-typescript]
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- increase the control-plane integration job timeout from five to ten minutes
- leave every test command and all other CI limits unchanged

## Why

The complete integration suite now runs close to five minutes after dependency installation and workerd setup. A production validation run reached the existing job limit and GitHub cancelled the still-running test process without a failing assertion. Ten minutes preserves a finite bound while allowing the suite to report its actual result.

## Impact

This changes CI scheduling only. It does not change application code, deployment behavior, or test semantics.

## Validation

- Prettier check passed for the workflow
- git diff --check passed
- the full control-plane integration suite passed locally before this timeout adjustment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the integration test workflow timeout to reduce failures caused by slow test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->