### PR TITLE
Harden browser auth protocol boundaries

### DIFF
--- a/packages/control-plane/src/auth/user/better-auth.ts
+++ b/packages/control-plane/src/auth/user/better-auth.ts
@@ -72,7 +72,14 @@ export function createUserAuth(config: UserAuthConfig) {
             },
           }
         : {}),
-      ...(config.google ? { google: config.google } : {}),
+      ...(config.google
+        ? {
+            google: {
+              ...config.google,
+              disableIdTokenSignIn: true,
+            },
+          }
+        : {}),
     },
     user: {
       modelName: "auth_users",

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -1192,6 +1192,15 @@ export class SessionDO extends DurableObject<Env> {
         return;
       }
 
+      if (data.type !== "ping" && data.type !== "subscribe" && !this.getClientInfo(ws)) {
+        this.safeSend(ws, {
+          type: "error",
+          code: "NOT_SUBSCRIBED",
+          message: "Must subscribe first",
+        });
+        return;
+      }
+
       switch (data.type) {
         case "ping":
           this.safeSend(ws, { type: "pong", timestamp: Date.now() });

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -339,7 +339,6 @@ export class SessionDO extends DurableObject<Env> {
     if (!this._presenceService) {
       this._presenceService = new PresenceService({
         getAuthenticatedClients: () => this.wsManager.getAuthenticatedClients(),
-        getClientInfo: (ws) => this.getClientInfo(ws),
         messenger: this.messenger,
         send: (ws, msg) => this.safeSend(ws, msg),
         getSandboxSocket: () => this.wsManager.getSandboxSocket(),
@@ -1192,26 +1191,22 @@ export class SessionDO extends DurableObject<Env> {
         return;
       }
 
-      if (data.type !== "ping" && data.type !== "subscribe" && !this.getClientInfo(ws)) {
-        this.safeSend(ws, {
-          type: "error",
-          code: "NOT_SUBSCRIBED",
-          message: "Must subscribe first",
-        });
+      if (data.type === "ping") {
+        this.safeSend(ws, { type: "pong", timestamp: Date.now() });
         return;
       }
 
+      if (data.type === "subscribe") {
+        await this.handleSubscribe(ws, data);
+        return;
+      }
+
+      const client = this.getClientInfo(ws);
+      if (!client) return;
+
       switch (data.type) {
-        case "ping":
-          this.safeSend(ws, { type: "pong", timestamp: Date.now() });
-          break;
-
-        case "subscribe":
-          await this.handleSubscribe(ws, data);
-          break;
-
         case "prompt":
-          await this.handlePromptMessage(ws, data);
+          await this.handlePromptMessage(ws, client, data);
           break;
 
         case "stop":
@@ -1223,11 +1218,11 @@ export class SessionDO extends DurableObject<Env> {
           break;
 
         case "fetch_history":
-          this.handleFetchHistory(ws, data);
+          this.handleFetchHistory(ws, client, data);
           break;
 
         case "presence":
-          this.presenceService.updatePresence(ws, data);
+          this.presenceService.updatePresence(client, data);
           break;
       }
     } catch (e) {
@@ -1428,6 +1423,7 @@ export class SessionDO extends DurableObject<Env> {
    */
   private async handlePromptMessage(
     ws: WebSocket,
+    client: ClientInfo,
     data: {
       content: string;
       model?: string;
@@ -1435,16 +1431,6 @@ export class SessionDO extends DurableObject<Env> {
       attachments?: SessionAttachmentReference[];
     }
   ): Promise<void> {
-    const client = this.getClientInfo(ws);
-    if (!client) {
-      this.safeSend(ws, {
-        type: "error",
-        code: "NOT_SUBSCRIBED",
-        message: "Must subscribe first",
-      });
-      return;
-    }
-
     await this.messageQueue.handlePromptMessage(ws, client, data);
   }
 
@@ -1453,18 +1439,9 @@ export class SessionDO extends DurableObject<Env> {
    */
   private handleFetchHistory(
     ws: WebSocket,
+    client: ClientInfo,
     data: { cursor?: { timestamp: number; id: string }; limit?: number }
   ): void {
-    const client = this.getClientInfo(ws);
-    if (!client) {
-      this.safeSend(ws, {
-        type: "error",
-        code: "NOT_SUBSCRIBED",
-        message: "Must subscribe first",
-      });
-      return;
-    }
-
     // Validate cursor
     if (
       !data.cursor ||

--- a/packages/control-plane/src/session/presence-service.test.ts
+++ b/packages/control-plane/src/session/presence-service.test.ts
@@ -35,7 +35,6 @@ function createTestHarness() {
 
   const deps: PresenceServiceDeps = {
     getAuthenticatedClients: vi.fn(() => clients.values()),
-    getClientInfo: vi.fn(() => null),
     messenger: { broadcast: vi.fn(), sendToSandbox: vi.fn(() => true) },
     send: vi.fn(() => true),
     getSandboxSocket: vi.fn(() => null),
@@ -227,23 +226,12 @@ describe("PresenceService", () => {
   describe("updatePresence", () => {
     it("updates client status/lastSeen and broadcasts", () => {
       const client = createMockClient({ status: "active", lastSeen: 1000 });
-      vi.mocked(harness.deps.getClientInfo).mockReturnValue(client);
-      const ws = {} as WebSocket;
 
-      harness.service.updatePresence(ws, { status: "idle" });
+      harness.service.updatePresence(client, { status: "idle" });
 
       expect(client.status).toBe("idle");
       expect(client.lastSeen).toBeGreaterThan(1000);
       expect(harness.deps.messenger.broadcast).toHaveBeenCalled();
-    });
-
-    it("skips when client not found (no broadcast)", () => {
-      vi.mocked(harness.deps.getClientInfo).mockReturnValue(null);
-      const ws = {} as WebSocket;
-
-      harness.service.updatePresence(ws, { status: "idle" });
-
-      expect(harness.deps.messenger.broadcast).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/control-plane/src/session/presence-service.ts
+++ b/packages/control-plane/src/session/presence-service.ts
@@ -18,7 +18,6 @@ import type { SessionMessenger } from "./messenger";
  */
 export interface PresenceServiceDeps {
   getAuthenticatedClients: () => IterableIterator<ClientInfo>;
-  getClientInfo: (ws: WebSocket) => ClientInfo | null;
   messenger: SessionMessenger;
   send: (ws: WebSocket, message: ServerMessage) => boolean;
   getSandboxSocket: () => WebSocket | null;
@@ -82,15 +81,12 @@ export class PresenceService {
    * Update client presence status and broadcast.
    */
   updatePresence(
-    ws: WebSocket,
+    client: ClientInfo,
     data: { status: "active" | "idle"; cursor?: { line: number; file: string } }
   ): void {
-    const client = this.deps.getClientInfo(ws);
-    if (client) {
-      client.status = data.status;
-      client.lastSeen = Date.now();
-      this.broadcastPresence();
-    }
+    client.status = data.status;
+    client.lastSeen = Date.now();
+    this.broadcastPresence();
   }
 
   /**

--- a/packages/control-plane/test/integration/browser-auth.test.ts
+++ b/packages/control-plane/test/integration/browser-auth.test.ts
@@ -1,7 +1,8 @@
 import { env } from "cloudflare:test";
 import { BROWSER_AUTH_CLIENT_IP_HEADER } from "@open-inspect/shared";
 import { getMigrations } from "better-auth/db/migration";
-import { describe, expect, it } from "vitest";
+import { verifyGoogleIdToken } from "better-auth/social-providers";
+import { describe, expect, it, vi } from "vitest";
 import {
   SESSION_EXPIRES_IN_MS,
   SESSION_UPDATE_AGE_MS,
@@ -13,6 +14,57 @@ const SECRET = "test-only-better-auth-secret-with-at-least-32-characters";
 const MS_PER_SECOND = 1000;
 const UNUSED_PROFILE_RESOLVER = async () => null;
 const UNUSED_USER_PROJECTION = { project: async () => {} };
+
+function encodeBase64Url(value: string | Uint8Array): string {
+  const bytes = typeof value === "string" ? new TextEncoder().encode(value) : value;
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+async function createSignedGoogleIdToken(clientId: string) {
+  const keyId = "test-google-key";
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"]
+  );
+  const issuedAt = Math.floor(Date.now() / MS_PER_SECOND);
+  const header = encodeBase64Url(JSON.stringify({ alg: "RS256", kid: keyId, typ: "JWT" }));
+  const payload = encodeBase64Url(
+    JSON.stringify({
+      iss: "https://accounts.google.com",
+      aud: clientId,
+      sub: "direct-id-token-subject",
+      email: "direct-id-token@example.com",
+      email_verified: true,
+      name: "Direct ID Token User",
+      iat: issuedAt,
+      exp: issuedAt + 300,
+    })
+  );
+  const signingInput = `${header}.${payload}`;
+  const signature = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    keyPair.privateKey,
+    new TextEncoder().encode(signingInput)
+  );
+  const publicKey = await crypto.subtle.exportKey("jwk", keyPair.publicKey);
+  return {
+    token: `${signingInput}.${encodeBase64Url(new Uint8Array(signature))}`,
+    publicKey: {
+      ...publicKey,
+      alg: "RS256",
+      kid: keyId,
+      use: "sig",
+    },
+  };
+}
 
 const EXPECTED_COLUMNS = {
   auth_users: [
@@ -274,8 +326,6 @@ describe("browser authentication", () => {
       },
     });
 
-    expect(auth.options.socialProviders?.google?.disableIdTokenSignIn).toBe(true);
-
     const response = await auth.handler(
       new Request(`${PUBLIC_WEB_ORIGIN}/api/auth/sign-in/social`, {
         method: "POST",
@@ -306,6 +356,69 @@ describe("browser authentication", () => {
     );
     expect(providerUrl.searchParams.get("code_challenge_method")).toBe("S256");
     expect(providerUrl.searchParams.get("state")).toBeTruthy();
+  });
+
+  it("rejects direct Google ID-token sign-in without creating authentication state", async () => {
+    const clientId = "google-client-id";
+    const { token, publicKey } = await createSignedGoogleIdToken(clientId);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url === "https://www.googleapis.com/oauth2/v3/certs") {
+        return Response.json({ keys: [publicKey] });
+      }
+      throw new Error(`Unexpected external request: ${url}`);
+    });
+
+    try {
+      await expect(verifyGoogleIdToken({ token, audience: clientId })).resolves.toMatchObject({
+        sub: "direct-id-token-subject",
+      });
+
+      const auth = createUserAuth({
+        database: env.DB,
+        publicWebOrigin: PUBLIC_WEB_ORIGIN,
+        secret: SECRET,
+        userProjection: UNUSED_USER_PROJECTION,
+        google: {
+          clientId,
+          clientSecret: "google-client-secret",
+          getUserInfo: async () => ({
+            user: {
+              id: "direct-id-token-subject",
+              name: "Direct ID Token User",
+              email: "direct-id-token@example.com",
+              emailVerified: true,
+            },
+            data: null,
+          }),
+        },
+      });
+
+      const response = await auth.handler(
+        new Request(`${PUBLIC_WEB_ORIGIN}/api/auth/sign-in/social`, {
+          method: "POST",
+          headers: {
+            [BROWSER_AUTH_CLIENT_IP_HEADER]: "203.0.113.75",
+            "Content-Type": "application/json",
+            Origin: PUBLIC_WEB_ORIGIN,
+          },
+          body: JSON.stringify({
+            provider: "google",
+            callbackURL: "/",
+            idToken: { token },
+          }),
+        })
+      );
+
+      expect(response.status).toBe(401);
+      expect(response.headers.get("set-cookie")).toBeNull();
+      const sessionCount = await env.DB.prepare(
+        "SELECT COUNT(*) AS count FROM auth_sessions"
+      ).first<{ count: number }>();
+      expect(sessionCount?.count).toBe(0);
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it("uses canonical ids and converts millisecond durations at the library boundary", () => {

--- a/packages/control-plane/test/integration/browser-auth.test.ts
+++ b/packages/control-plane/test/integration/browser-auth.test.ts
@@ -152,6 +152,40 @@ describe("browser authentication", () => {
     expect(stateCookie?.toLowerCase()).not.toContain("domain=");
   });
 
+  it("rejects social sign-in from an untrusted browser origin", async () => {
+    const auth = createUserAuth({
+      database: env.DB,
+      publicWebOrigin: PUBLIC_WEB_ORIGIN,
+      secret: SECRET,
+      userProjection: UNUSED_USER_PROJECTION,
+      github: {
+        clientId: "github-app-client-id",
+        clientSecret: "github-app-client-secret",
+        getUserInfo: UNUSED_PROFILE_RESOLVER,
+      },
+    });
+
+    const response = await auth.handler(
+      new Request(`${PUBLIC_WEB_ORIGIN}/api/auth/sign-in/social`, {
+        method: "POST",
+        headers: {
+          [BROWSER_AUTH_CLIENT_IP_HEADER]: "203.0.113.74",
+          "Content-Type": "application/json",
+          Cookie: "__Secure-openinspect.session_token=invalid",
+          Origin: "https://attacker.example",
+        },
+        body: JSON.stringify({
+          provider: "github",
+          callbackURL: "/",
+          disableRedirect: true,
+        }),
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("set-cookie")).toBeNull();
+  });
+
   it("rate limits repeated browser sign-in attempts by the trusted client IP", async () => {
     const auth = createUserAuth({
       database: env.DB,
@@ -239,6 +273,8 @@ describe("browser authentication", () => {
         getUserInfo: UNUSED_PROFILE_RESOLVER,
       },
     });
+
+    expect(auth.options.socialProviders?.google?.disableIdTokenSignIn).toBe(true);
 
     const response = await auth.handler(
       new Request(`${PUBLIC_WEB_ORIGIN}/api/auth/sign-in/social`, {

--- a/packages/control-plane/test/integration/stop-execution.test.ts
+++ b/packages/control-plane/test/integration/stop-execution.test.ts
@@ -375,4 +375,41 @@ describe("POST /internal/stop", () => {
     clientWs.close();
     if (sandboxWs) sandboxWs.close();
   });
+
+  it("does not stop execution before the client subscribes", async () => {
+    const name = `ws-stop-client-unsubscribed-${Date.now()}`;
+    const { stub } = await initNamedSession(name);
+
+    const participants = await queryDO<{ id: string }>(
+      stub,
+      "SELECT id FROM participants WHERE user_id = 'user-1'"
+    );
+    const participantId = participants[0].id;
+
+    const msgId = "msg-ws-stop-unsubscribed";
+    await seedMessage(stub, {
+      id: msgId,
+      authorId: participantId,
+      content: "Must remain in progress",
+      source: "web",
+      status: "processing",
+      createdAt: Date.now() - 1000,
+      startedAt: Date.now() - 500,
+    });
+
+    const { ws } = await openClientWs(name);
+    const closed = new Promise<{ code: number }>((resolve) => {
+      ws.addEventListener("close", (event) => resolve({ code: event.code }));
+    });
+
+    ws.send(JSON.stringify({ type: "stop" }));
+
+    await expect(closed).resolves.toEqual({ code: 4002 });
+    const messages = await queryDO<{ status: string }>(
+      stub,
+      "SELECT status FROM messages WHERE id = ?",
+      msgId
+    );
+    expect(messages[0].status).toBe("processing");
+  });
 });

--- a/packages/control-plane/test/integration/websocket-client.test.ts
+++ b/packages/control-plane/test/integration/websocket-client.test.ts
@@ -43,6 +43,20 @@ describe("Client WebSocket (via SELF.fetch)", () => {
     expect(rows[0].count).toBe(0);
   });
 
+  it("rejects typing before subscribing", async () => {
+    const name = `ws-client-nosub-typing-${Date.now()}`;
+    await initNamedSession(name);
+
+    const { ws } = await openClientWs(name);
+    const closed = new Promise<{ code: number }>((resolve) => {
+      ws.addEventListener("close", (event) => resolve({ code: event.code }));
+    });
+
+    ws.send(JSON.stringify({ type: "typing" }));
+
+    await expect(closed).resolves.toEqual({ code: 4002 });
+  });
+
   it("subscribe with valid token sends subscribed + state", async () => {
     const name = `ws-client-sub-${Date.now()}`;
     await initNamedSession(name, { repoOwner: "acme", repoName: "web-app" });

--- a/packages/control-plane/vitest.integration.config.ts
+++ b/packages/control-plane/vitest.integration.config.ts
@@ -83,21 +83,27 @@ export default defineConfig({
     include: ["test/integration/**/*.test.ts"],
     setupFiles: ["test/integration/apply-migrations.ts"],
     onUnhandledError(error) {
-      // Better Auth implements OAuth callback redirects as thrown APIError
-      // values. Its handler catches and converts them to the expected 3xx
-      // response, but the Workers pool reports the intermediate rejection as
-      // unhandled. Filter only that library-owned redirect control flow; every
-      // other unhandled error remains fatal.
+      // Better Auth implements redirects and invalid-token responses as thrown
+      // APIError values. Its handler catches and converts them to HTTP responses,
+      // but the Workers pool reports the intermediate rejection as unhandled.
       const betterAuthStack =
         "errorStack" in error && typeof error.errorStack === "string"
           ? error.errorStack
           : error.stack;
+      const betterAuthErrorCode =
+        "body" in error &&
+        typeof error.body === "object" &&
+        error.body !== null &&
+        "code" in error.body &&
+        typeof error.body.code === "string"
+          ? error.body.code
+          : null;
       if (
         error.name === "APIError" &&
         "statusCode" in error &&
         typeof error.statusCode === "number" &&
-        error.statusCode >= 300 &&
-        error.statusCode < 400 &&
+        ((error.statusCode >= 300 && error.statusCode < 400) ||
+          (error.statusCode === 401 && betterAuthErrorCode === "INVALID_TOKEN")) &&
         betterAuthStack?.includes("/better-auth/dist/api/routes/")
       ) {
         return false;


### PR DESCRIPTION
## Summary
- require a subscribed client identity before any non-transport WebSocket message can run
- disable Better Auth direct Google ID-token sign-in while preserving authorization-code + PKCE
- add regression coverage for unauthenticated stop/typing and hostile browser origins

## Security impact
- unauthenticated sockets can no longer stop active work or trigger sandbox warming
- callers cannot exchange a directly supplied Google ID token for an Open Inspect session
- existing signed web-channel and Better Auth origin checks remain unchanged

## Validation
- `npm run test -w @open-inspect/control-plane` (2,111 tests)
- `npm run test:integration -w @open-inspect/control-plane` (654 tests before the final characterization-only additions)
- focused auth/WebSocket integration suite (39 tests)
- `npm run typecheck -w @open-inspect/control-plane`
- `npm run lint -w @open-inspect/control-plane`
- `npm run build -w @open-inspect/control-plane`

## TDD evidence
- the pre-subscription stop test failed by mutating the processing message and timing out before the guard was added
- the Google provider configuration test failed with `disableIdTokenSignIn` unset before the option was added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Google sign-in now uses the approved flow: when Google is configured, ID-token sign-in is disabled.
  * Social sign-in requests from untrusted browser origins (with invalid session cookies) are rejected and do not set cookies.
* **Bug Fixes**
  * WebSocket clients must subscribe before sending actions like typing or stopping execution; pre-subscription typing closes with code `4002`, and stop does not mark the in-flight message as failed.
* **Tests**
  * Added/extended integration coverage for these authentication and WebSocket security boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->