### PR TITLE
Allow approved bot self-reviews

### DIFF
--- a/packages/github-bot/README.md
+++ b/packages/github-bot/README.md
@@ -123,10 +123,12 @@ All events are processed asynchronously via `executionCtx.waitUntil()`. The webh
 **Pull Request Opened (Auto-Review):**
 
 1. Check `pull_request.draft` — skip draft PRs
-2. Check `pull_request.user.login !== GITHUB_BOT_USERNAME` — prevent loops on bot-created PRs
+2. Apply the configured trigger-user gate — bot-created PRs are reviewed when the bot login is
+   explicitly listed in `allowedTriggerUsers`
 3. Post eyes reaction on the PR (fire-and-forget)
 4. Create session via control plane
-5. Send code review prompt (includes PR metadata + `gh` CLI instructions)
+5. Send code review prompt (includes PR metadata + `gh` CLI instructions). Reviews of the bot's own
+   PRs use `COMMENT`, because GitHub does not allow pull request authors to approve their own PRs.
 
 **Review Requested (compatibility path):**
 

--- a/packages/github-bot/src/handlers.ts
+++ b/packages/github-bot/src/handlers.ts
@@ -291,11 +291,6 @@ export async function handlePullRequestOpened(
     return { outcome: "skipped", skip_reason: "draft_pr" };
   }
 
-  if (pr.user.login === env.GITHUB_BOT_USERNAME) {
-    log.debug("handler.self_pr_ignored", { trace_id: traceId, pull_number: pr.number });
-    return { outcome: "skipped", skip_reason: "self_pr" };
-  }
-
   const config = await getGitHubConfig(env, repoFullName, log);
 
   if (config.enabledRepos !== null && !config.enabledRepos.includes(repoFullName)) {
@@ -360,6 +355,7 @@ export async function handlePullRequestOpened(
     head: pr.head.ref,
     isPublic: !repo.private,
     codeReviewInstructions: config.codeReviewInstructions,
+    isSelfReview: pr.user.login.toLowerCase() === env.GITHUB_BOT_USERNAME.toLowerCase(),
   });
 
   const messageId = await sendPrompt(env, traceId, sessionId, {

--- a/packages/github-bot/src/prompts.ts
+++ b/packages/github-bot/src/prompts.ts
@@ -45,9 +45,25 @@ export function buildCodeReviewPrompt(params: {
   head: string;
   isPublic: boolean;
   codeReviewInstructions?: string | null;
+  isSelfReview?: boolean;
 }): string {
-  const { owner, repo, number, title, body, author, base, head, isPublic, codeReviewInstructions } =
-    params;
+  const {
+    owner,
+    repo,
+    number,
+    title,
+    body,
+    author,
+    base,
+    head,
+    isPublic,
+    codeReviewInstructions,
+    isSelfReview = false,
+  } = params;
+  const reviewEvent = isSelfReview ? "COMMENT" : "COMMENT|APPROVE|REQUEST_CHANGES";
+  const reviewEventGuidance = isSelfReview
+    ? "Use COMMENT because GitHub does not allow pull request authors to approve their own PRs."
+    : "Use APPROVE if the code looks good, REQUEST_CHANGES if changes are needed,\n   or COMMENT for general feedback.";
 
   const prTitleBlock = buildUntrustedUserContentBlock({
     source: "github_pr_title",
@@ -96,10 +112,9 @@ ${prDescriptionBlock}
    gh api repos/${owner}/${repo}/pulls/${number}/reviews \\
      --method POST \\
      -f body="<your review summary>" \\
-     -f event="COMMENT|APPROVE|REQUEST_CHANGES"
+     -f event="${reviewEvent}"
 
-   Use APPROVE if the code looks good, REQUEST_CHANGES if changes are needed,
-   or COMMENT for general feedback.
+   ${reviewEventGuidance}
 
 5. For inline comments on specific files:
 

--- a/packages/github-bot/test/handlers.test.ts
+++ b/packages/github-bot/test/handlers.test.ts
@@ -273,7 +273,11 @@ describe("handlePullRequestOpened", () => {
     expect(log.debug).toHaveBeenCalledWith("handler.draft_pr_skipped", expect.anything());
   });
 
-  it("returns early if PR is from the bot (loop prevention)", async () => {
+  it("reviews a bot-authored PR when the bot is an allowed trigger user", async () => {
+    vi.mocked(getGitHubConfig).mockResolvedValue({
+      ...defaultConfig,
+      allowedTriggerUsers: ["test-bot[bot]"],
+    });
     const env = createMockEnv();
     const log = createMockLogger();
     const payload: PullRequestOpenedPayload = {
@@ -282,13 +286,50 @@ describe("handlePullRequestOpened", () => {
         ...pullRequestOpenedPayload.pull_request,
         user: { login: "test-bot[bot]" },
       },
+      sender: {
+        login: "test-bot[bot]",
+        id: 1004,
+        avatar_url: "https://avatars.githubusercontent.com/u/1004",
+      },
     };
 
     const result = await handlePullRequestOpened(env, log, payload, "trace-0");
 
-    expect(result).toEqual({ outcome: "skipped", skip_reason: "self_pr" });
+    expect(result).toEqual({
+      outcome: "processed",
+      session_id: "session-123",
+      message_id: "msg-456",
+      handler_action: "auto_review",
+    });
+    expect(sessionCreateBody(getControlPlaneFetch(env)).scmLogin).toBe("test-bot[bot]");
+    expect(promptSendBody(getControlPlaneFetch(env)).content).toContain('-f event="COMMENT"');
+  });
+
+  it("rejects a bot-authored PR when the bot is not an allowed trigger user", async () => {
+    vi.mocked(getGitHubConfig).mockResolvedValue({
+      ...defaultConfig,
+      allowedTriggerUsers: ["alice"],
+    });
+    const env = createMockEnv();
+    const log = createMockLogger();
+    const payload: PullRequestOpenedPayload = {
+      ...pullRequestOpenedPayload,
+      pull_request: {
+        ...pullRequestOpenedPayload.pull_request,
+        user: { login: "test-bot[bot]" },
+      },
+      sender: {
+        login: "test-bot[bot]",
+        id: 1004,
+        avatar_url: "https://avatars.githubusercontent.com/u/1004",
+      },
+    };
+
+    const result = await handlePullRequestOpened(env, log, payload, "trace-0");
+
+    expect(result).toEqual({ outcome: "skipped", skip_reason: "sender_not_allowed" });
     expect(generateInstallationToken).not.toHaveBeenCalled();
-    expect(log.debug).toHaveBeenCalledWith("handler.self_pr_ignored", expect.anything());
+    expect(getControlPlaneFetch(env)).not.toHaveBeenCalled();
   });
 
   it("returns early when autoReviewOnOpen is false", async () => {

--- a/packages/github-bot/test/prompts.test.ts
+++ b/packages/github-bot/test/prompts.test.ts
@@ -62,6 +62,13 @@ describe("buildCodeReviewPrompt", () => {
     expect(prompt).toContain("repos/acme/widgets/pulls/42/comments");
   });
 
+  it("limits self-reviews to comments", () => {
+    const prompt = buildCodeReviewPrompt({ ...baseParams, isSelfReview: true });
+    expect(prompt).toContain('-f event="COMMENT"');
+    expect(prompt).toContain("GitHub does not allow pull request authors to approve their own PRs");
+    expect(prompt).not.toContain("COMMENT|APPROVE|REQUEST_CHANGES");
+  });
+
   it("includes custom instructions section when codeReviewInstructions provided", () => {
     const prompt = buildCodeReviewPrompt({
       ...baseParams,


### PR DESCRIPTION
## Summary

- remove the unconditional skip for pull requests authored by the configured GitHub App bot
- route bot-authored pull requests through the existing `allowedTriggerUsers` gate
- make approved self-reviews comment-only because GitHub does not allow PR authors to approve their own pull requests
- document the updated behavior and cover both allowlisted and rejected bot senders

## Why

Automation sessions create pull requests with the GitHub App installation identity. The GitHub bot previously skipped those pull requests before evaluating the configured trigger-user allowlist, so adding `open-inspect[bot]` as an allowed trigger user had no effect.

## Impact

Administrators can now opt into reviews of automation-created pull requests by adding the App bot login, including the `[bot]` suffix, to **Allowed Trigger Users**. Bot-authored pull requests remain rejected when the bot is not on that list.

Self-reviews submit `COMMENT` reviews so findings are published without attempting an invalid self-approval.

## Validation

- `npm test -w @open-inspect/github-bot` — 130 tests passed
- `npm run typecheck -w @open-inspect/github-bot`
- `npm run lint -w @open-inspect/github-bot`
- `npm run build -w @open-inspect/github-bot`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable support for reviewing bot-created pull requests when the bot is included in the allowed trigger list.
  * Bot-authored pull requests now use comment-only reviews, complying with GitHub’s restriction against self-approval.

* **Documentation**
  * Updated guidance for configuring allowed trigger users and handling bot-created pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->