### PR TITLE
Document Better Auth browser authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 New features, integrations, and notable improvements to Open-Inspect — newest first.
 
+## July 26, 2026
+
+**Better Auth browser authentication.** Browser sign-in now uses control-plane-owned Better Auth
+sessions with GitHub and optional Google providers. The web app forwards an exact allowlist of
+authentication routes through a signed proxy, and application requests require both that signed
+web-service channel and the browser session. Legacy browser tokens are retired during migration, so
+existing users must sign in again after upgrading.
+
 ## July 24, 2026
 
 **Claude Opus 5.** Adds `claude-opus-5` to the model picker and integrations, with adaptive thinking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ New features, integrations, and notable improvements to Open-Inspect — newest 
 
 **Better Auth browser authentication.** Browser sign-in now uses control-plane-owned Better Auth
 sessions with GitHub and optional Google providers. The web app forwards an exact allowlist of
-authentication routes through a signed proxy, and application requests require both that signed
+authentication routes through a signed proxy, and browser resource requests require both that signed
 web-service channel and the browser session. Legacy browser tokens are retired during migration, so
 existing users must sign in again after upgrading.
 


### PR DESCRIPTION
## Summary

- add a July 26 changelog entry for the Better Auth browser-authentication cutover
- document control-plane-owned sessions, GitHub and optional Google sign-in, and the signed web proxy
- call out the required sign-in after legacy browser tokens are retired

## Why

The Better Auth runtime and full browser-authentication cutover merged in #1125 and #1126, but the user-facing changelog did not yet describe the change or its upgrade impact.

## Validation

- `prettier --check CHANGELOG.md`
- `git diff --check`
- confirmed the change adds no Markdown links requiring target validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved browser authentication with more secure, control-plane managed sessions.
  * Added signed authentication routing for browser sign-in requests.

* **Breaking Changes**
  * Legacy browser tokens are no longer supported.
  * Existing users must sign in again after upgrading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->