### PR TITLE
Fix mobile media lightbox viewport overflow

### DIFF
--- a/packages/web/src/components/media-lightbox.tsx
+++ b/packages/web/src/components/media-lightbox.tsx
@@ -3,7 +3,14 @@
 import { useEffect, useState } from "react";
 import type { Artifact } from "@/types/session";
 import { buildSessionMediaUrl } from "@/lib/media";
-import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { XIcon } from "@/components/ui/icons";
 
 interface MediaLightboxProps {
   sessionId: string;
@@ -26,14 +33,20 @@ export function MediaLightbox({ sessionId, artifact, open, onOpenChange }: Media
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-[min(96vw,1100px)] gap-4 border-border-muted bg-background p-4">
-        <DialogTitle>{caption}</DialogTitle>
-        <DialogDescription>
+      <DialogContent className="max-h-[calc(100dvh-2rem)] max-w-[min(96vw,1100px)] grid-rows-[auto_auto_minmax(0,1fr)] gap-4 overflow-hidden border-border-muted bg-background p-4">
+        <DialogClose
+          className="absolute right-3 top-3 rounded-sm p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label="Close media viewer"
+        >
+          <XIcon className="h-5 w-5" />
+        </DialogClose>
+        <DialogTitle className="line-clamp-2 pr-8">{caption}</DialogTitle>
+        <DialogDescription className="truncate pr-8">
           {artifact?.metadata?.sourceUrl ||
             (isVideo ? "Session video recording" : "Session screenshot")}
         </DialogDescription>
 
-        <div className="max-h-[80vh] overflow-auto bg-muted">
+        <div className="min-h-0 overflow-auto bg-muted">
           {!artifact ? (
             <div className="flex min-h-[320px] items-center justify-center text-sm text-muted-foreground">
               No media selected
@@ -44,7 +57,7 @@ export function MediaLightbox({ sessionId, artifact, open, onOpenChange }: Media
                 <video
                   src={mediaUrl}
                   aria-label={`${caption} video`}
-                  className={isLoaded ? "mx-auto h-auto max-h-[76vh] max-w-full" : "invisible"}
+                  className={isLoaded ? "mx-auto h-auto max-h-full max-w-full" : "invisible"}
                   controls
                   preload="metadata"
                   onLoadedMetadata={() => setIsLoaded(true)}

--- a/packages/web/src/components/screenshot-media.test.tsx
+++ b/packages/web/src/components/screenshot-media.test.tsx
@@ -86,6 +86,7 @@ describe("ScreenshotArtifactCard", () => {
 
 describe("MediaLightbox", () => {
   it("renders the selected screenshot preview", () => {
+    const onOpenChange = vi.fn();
     render(
       <MediaLightbox
         sessionId="session-1"
@@ -100,7 +101,7 @@ describe("MediaLightbox", () => {
           createdAt: 1234,
         }}
         open={true}
-        onOpenChange={vi.fn()}
+        onOpenChange={onOpenChange}
       />
     );
 
@@ -113,6 +114,9 @@ describe("MediaLightbox", () => {
       "src",
       "/api/sessions/session-1/media/artifact-1"
     );
+
+    fireEvent.click(screen.getByRole("button", { name: "Close media viewer" }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
   it("renders the selected video preview with controls", () => {


### PR DESCRIPTION
## Summary
- constrain the media lightbox to the dynamic mobile viewport
- keep tall screenshots and videos scrollable within the available modal space
- add an always-visible accessible close control
- cover the close interaction with a regression test

## Root cause
The media region could consume `80vh` before accounting for the title, source URL, gaps, and padding. On mobile Safari, browser chrome further reduces the visible dynamic viewport, allowing the centered fixed dialog to extend beyond the screen.

## Verification
- `npm run lint -w @open-inspect/web`
- `npm run typecheck -w @open-inspect/web`
- `npm test -w @open-inspect/web -- src/components/screenshot-media.test.tsx`
- full web test run: 796/797 passed; the single timeout passed when rerun independently
- visual verification at 390x700
  - before artifact: `2fd60db03d6015e885b921a8013e6014`
  - after artifact: `a47f9ac4737c9857397b5484a6499c55`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/de0a4097c37e1465acbb74c39939127a)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearly visible close button to the media viewer.
  * Improved media viewer layout, sizing, and scrolling across screen sizes.
  * Long titles and descriptions are now truncated for a cleaner presentation.

* **Bug Fixes**
  * Improved video preview sizing within the media viewer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->