### PR TITLE
Add mobile sidebar pull gesture

### DIFF
--- a/packages/web/src/components/sidebar-layout.test.tsx
+++ b/packages/web/src/components/sidebar-layout.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { CollapsedSidebarControls, SidebarLayout } from "./sidebar-layout";
 import { useAuthSession } from "@/lib/auth-session";
 import { useRouter } from "next/navigation";
+import { MOBILE_SIDEBAR_HOLD_MS } from "@/hooks/use-mobile-sidebar-pull";
 
 expect.extend(matchers);
 
@@ -82,31 +83,34 @@ describe("mobile sidebar drag", () => {
     mocks.isMobile = true;
     mocks.sidebar.isOpen = false;
     vi.mocked(useAuthSession).mockReturnValue({
-      data: { user: { name: "Test User" } },
+      data: { user: { id: "user-1", name: "Test User" } },
       status: "authenticated",
     });
     vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as never);
 
     render(<SidebarLayout>Session</SidebarLayout>);
 
+    vi.spyOn(screen.getByTestId("mobile-sidebar-drawer"), "getBoundingClientRect").mockReturnValue({
+      width: 288,
+    } as DOMRect);
     const dragHandle = screen.getByTestId("mobile-sidebar-drag-handle");
     fireEvent.pointerDown(dragHandle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 8,
+      clientX: 40,
       clientY: 200,
     });
-    act(() => vi.advanceTimersByTime(300));
+    act(() => vi.advanceTimersByTime(MOBILE_SIDEBAR_HOLD_MS));
     fireEvent.pointerMove(dragHandle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 100,
+      clientX: 132,
       clientY: 202,
     });
     fireEvent.pointerUp(dragHandle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 100,
+      clientX: 132,
       clientY: 202,
     });
 
@@ -118,27 +122,30 @@ describe("mobile sidebar drag", () => {
     mocks.isMobile = true;
     mocks.sidebar.isOpen = false;
     vi.mocked(useAuthSession).mockReturnValue({
-      data: { user: { name: "Test User" } },
+      data: { user: { id: "user-1", name: "Test User" } },
       status: "authenticated",
     });
     vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as never);
 
     render(<SidebarLayout>Session</SidebarLayout>);
 
+    vi.spyOn(screen.getByTestId("mobile-sidebar-drawer"), "getBoundingClientRect").mockReturnValue({
+      width: 288,
+    } as DOMRect);
     const dragHandle = screen.getByTestId("mobile-sidebar-drag-handle");
     fireEvent.pointerDown(dragHandle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 8,
+      clientX: 40,
       clientY: 200,
     });
     fireEvent.pointerMove(dragHandle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 30,
+      clientX: 62,
       clientY: 200,
     });
-    act(() => vi.advanceTimersByTime(300));
+    act(() => vi.advanceTimersByTime(MOBILE_SIDEBAR_HOLD_MS));
     fireEvent.pointerUp(dragHandle, { pointerId: 1, pointerType: "touch" });
 
     expect(mocks.sidebar.open).not.toHaveBeenCalled();

--- a/packages/web/src/components/sidebar-layout.test.tsx
+++ b/packages/web/src/components/sidebar-layout.test.tsx
@@ -1,13 +1,12 @@
 // @vitest-environment jsdom
 /// <reference types="@testing-library/jest-dom" />
 
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CollapsedSidebarControls, SidebarLayout } from "./sidebar-layout";
 import { useAuthSession } from "@/lib/auth-session";
 import { useRouter } from "next/navigation";
-import { MOBILE_SIDEBAR_HOLD_MS } from "@/hooks/use-mobile-sidebar-pull";
 
 expect.extend(matchers);
 
@@ -41,7 +40,6 @@ vi.mock("@/hooks/use-sidebar", () => ({
 
 afterEach(() => {
   cleanup();
-  vi.useRealTimers();
   vi.clearAllMocks();
   mocks.isMobile = false;
   mocks.sidebar.isOpen = true;
@@ -78,8 +76,7 @@ describe("CollapsedSidebarControls", () => {
 });
 
 describe("mobile sidebar drag", () => {
-  it("opens after holding the left edge and pulling right", () => {
-    vi.useFakeTimers();
+  it("opens after swiping right from the left edge", () => {
     mocks.isMobile = true;
     mocks.sidebar.isOpen = false;
     vi.mocked(useAuthSession).mockReturnValue({
@@ -97,28 +94,26 @@ describe("mobile sidebar drag", () => {
     fireEvent.pointerDown(dragHandle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 40,
+      clientX: 8,
       clientY: 200,
     });
-    act(() => vi.advanceTimersByTime(MOBILE_SIDEBAR_HOLD_MS));
     fireEvent.pointerMove(dragHandle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 132,
+      clientX: 100,
       clientY: 202,
     });
     fireEvent.pointerUp(dragHandle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 132,
+      clientX: 100,
       clientY: 202,
     });
 
     expect(mocks.sidebar.open).toHaveBeenCalledOnce();
   });
 
-  it("does not open when moved before the hold completes", () => {
-    vi.useFakeTimers();
+  it("does not open when the swipe is too short", () => {
     mocks.isMobile = true;
     mocks.sidebar.isOpen = false;
     vi.mocked(useAuthSession).mockReturnValue({
@@ -136,16 +131,15 @@ describe("mobile sidebar drag", () => {
     fireEvent.pointerDown(dragHandle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 40,
+      clientX: 8,
       clientY: 200,
     });
     fireEvent.pointerMove(dragHandle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 62,
+      clientX: 50,
       clientY: 200,
     });
-    act(() => vi.advanceTimersByTime(MOBILE_SIDEBAR_HOLD_MS));
     fireEvent.pointerUp(dragHandle, { pointerId: 1, pointerType: "touch" });
 
     expect(mocks.sidebar.open).not.toHaveBeenCalled();

--- a/packages/web/src/components/sidebar-layout.test.tsx
+++ b/packages/web/src/components/sidebar-layout.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 /// <reference types="@testing-library/jest-dom" />
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CollapsedSidebarControls, SidebarLayout } from "./sidebar-layout";
@@ -9,6 +9,16 @@ import { useAuthSession } from "@/lib/auth-session";
 import { useRouter } from "next/navigation";
 
 expect.extend(matchers);
+
+const mocks = vi.hoisted(() => ({
+  isMobile: false,
+  sidebar: {
+    isOpen: true,
+    toggle: vi.fn(),
+    open: vi.fn(),
+    close: vi.fn(),
+  },
+}));
 
 vi.mock("@/lib/auth-session", () => ({
   useAuthSession: vi.fn(),
@@ -21,19 +31,20 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("@/hooks/use-media-query", () => ({
-  useIsMobile: () => false,
+  useIsMobile: () => mocks.isMobile,
 }));
 
 vi.mock("@/hooks/use-sidebar", () => ({
-  useSidebar: () => ({
-    isOpen: true,
-    toggle: vi.fn(),
-    open: vi.fn(),
-    close: vi.fn(),
-  }),
+  useSidebar: () => mocks.sidebar,
 }));
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  mocks.isMobile = false;
+  mocks.sidebar.isOpen = true;
+});
 
 describe("CollapsedSidebarControls", () => {
   it("renders the sidebar, search, and new session actions inline", () => {
@@ -62,5 +73,74 @@ describe("CollapsedSidebarControls", () => {
 
     fireEvent.click(buttons![2]);
     expect(push).toHaveBeenCalledWith("/");
+  });
+});
+
+describe("mobile sidebar drag", () => {
+  it("opens after holding the left edge and pulling right", () => {
+    vi.useFakeTimers();
+    mocks.isMobile = true;
+    mocks.sidebar.isOpen = false;
+    vi.mocked(useAuthSession).mockReturnValue({
+      data: { user: { name: "Test User" } },
+      status: "authenticated",
+    });
+    vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as never);
+
+    render(<SidebarLayout>Session</SidebarLayout>);
+
+    const dragHandle = screen.getByTestId("mobile-sidebar-drag-handle");
+    fireEvent.pointerDown(dragHandle, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 8,
+      clientY: 200,
+    });
+    act(() => vi.advanceTimersByTime(300));
+    fireEvent.pointerMove(dragHandle, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 100,
+      clientY: 202,
+    });
+    fireEvent.pointerUp(dragHandle, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 100,
+      clientY: 202,
+    });
+
+    expect(mocks.sidebar.open).toHaveBeenCalledOnce();
+  });
+
+  it("does not open when moved before the hold completes", () => {
+    vi.useFakeTimers();
+    mocks.isMobile = true;
+    mocks.sidebar.isOpen = false;
+    vi.mocked(useAuthSession).mockReturnValue({
+      data: { user: { name: "Test User" } },
+      status: "authenticated",
+    });
+    vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as never);
+
+    render(<SidebarLayout>Session</SidebarLayout>);
+
+    const dragHandle = screen.getByTestId("mobile-sidebar-drag-handle");
+    fireEvent.pointerDown(dragHandle, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 8,
+      clientY: 200,
+    });
+    fireEvent.pointerMove(dragHandle, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 30,
+      clientY: 200,
+    });
+    act(() => vi.advanceTimersByTime(300));
+    fireEvent.pointerUp(dragHandle, { pointerId: 1, pointerType: "touch" });
+
+    expect(mocks.sidebar.open).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -175,7 +175,7 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
           {isMobile && !sidebar.isOpen && (
             <div
               data-testid="mobile-sidebar-drag-handle"
-              className="fixed inset-y-0 left-8 z-50 w-6 touch-pan-y"
+              className="fixed inset-y-0 left-0 z-50 w-5 touch-pan-y"
               aria-hidden="true"
               onPointerDown={sidebarPull.handlePointerDown}
               onPointerMove={sidebarPull.handlePointerMove}

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { signIn, useAuthSession } from "@/lib/auth-session";
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
@@ -29,6 +38,11 @@ interface AppShellActionsContextValue {
 
 const SidebarContext = createContext<SidebarContextValue | null>(null);
 const AppShellActionsContext = createContext<AppShellActionsContextValue | null>(null);
+
+const MOBILE_SIDEBAR_WIDTH_PX = 288;
+const MOBILE_SIDEBAR_HOLD_MS = 300;
+const MOBILE_SIDEBAR_HOLD_TOLERANCE_PX = 10;
+const MOBILE_SIDEBAR_OPEN_THRESHOLD_PX = 72;
 
 export function useSidebarContext() {
   const context = useContext(SidebarContext);
@@ -79,6 +93,79 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
   const sidebar = useSidebar();
   const isMobile = useIsMobile();
   const [isCommandMenuOpen, setIsCommandMenuOpen] = useState(false);
+  const [sidebarDragDistance, setSidebarDragDistance] = useState(0);
+  const [isDraggingSidebar, setIsDraggingSidebar] = useState(false);
+  const sidebarHoldTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const sidebarDragStartRef = useRef<{ x: number; y: number } | null>(null);
+  const sidebarDragDistanceRef = useRef(0);
+  const isSidebarDragActiveRef = useRef(false);
+
+  const resetSidebarDrag = useCallback(() => {
+    if (sidebarHoldTimerRef.current !== null) {
+      clearTimeout(sidebarHoldTimerRef.current);
+      sidebarHoldTimerRef.current = null;
+    }
+    sidebarDragStartRef.current = null;
+    sidebarDragDistanceRef.current = 0;
+    isSidebarDragActiveRef.current = false;
+    setSidebarDragDistance(0);
+    setIsDraggingSidebar(false);
+  }, []);
+
+  useEffect(() => resetSidebarDrag, [resetSidebarDrag]);
+
+  const handleSidebarDragStart = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!isMobile || sidebar.isOpen || (event.pointerType === "mouse" && event.button !== 0)) {
+        return;
+      }
+
+      resetSidebarDrag();
+      sidebarDragStartRef.current = { x: event.clientX, y: event.clientY };
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+      sidebarHoldTimerRef.current = setTimeout(() => {
+        sidebarHoldTimerRef.current = null;
+        isSidebarDragActiveRef.current = true;
+        setIsDraggingSidebar(true);
+      }, MOBILE_SIDEBAR_HOLD_MS);
+    },
+    [isMobile, resetSidebarDrag, sidebar.isOpen]
+  );
+
+  const handleSidebarDragMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const start = sidebarDragStartRef.current;
+      if (!start) return;
+
+      const deltaX = event.clientX - start.x;
+      const deltaY = event.clientY - start.y;
+      if (!isSidebarDragActiveRef.current) {
+        if (Math.hypot(deltaX, deltaY) > MOBILE_SIDEBAR_HOLD_TOLERANCE_PX) {
+          resetSidebarDrag();
+        }
+        return;
+      }
+
+      if (Math.abs(deltaY) > Math.abs(deltaX)) {
+        resetSidebarDrag();
+        return;
+      }
+
+      event.preventDefault();
+      const distance = Math.min(MOBILE_SIDEBAR_WIDTH_PX, Math.max(0, deltaX));
+      sidebarDragDistanceRef.current = distance;
+      setSidebarDragDistance(distance);
+    },
+    [resetSidebarDrag]
+  );
+
+  const handleSidebarDragEnd = useCallback(() => {
+    const shouldOpen =
+      isSidebarDragActiveRef.current &&
+      sidebarDragDistanceRef.current >= MOBILE_SIDEBAR_OPEN_THRESHOLD_PX;
+    resetSidebarDrag();
+    if (shouldOpen) sidebar.open();
+  }, [resetSidebarDrag, sidebar]);
 
   const { data: sessionsResponse } = useSWR<SessionListResponse>(
     status === "authenticated" && Boolean(session) && isCommandMenuOpen
@@ -160,12 +247,31 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
     <SidebarContext.Provider value={sidebar}>
       <AppShellActionsContext.Provider value={appShellActions}>
         <div className="flex h-dvh overflow-hidden">
+          {isMobile && !sidebar.isOpen && (
+            <div
+              data-testid="mobile-sidebar-drag-handle"
+              className="fixed inset-y-0 left-0 z-50 w-6 touch-pan-y"
+              aria-hidden="true"
+              onPointerDown={handleSidebarDragStart}
+              onPointerMove={handleSidebarDragMove}
+              onPointerUp={handleSidebarDragEnd}
+              onPointerCancel={resetSidebarDrag}
+              onContextMenu={(event) => event.preventDefault()}
+            />
+          )}
           {/* Mobile: overlay backdrop */}
           {isMobile && (
             <div
-              className={`fixed inset-0 z-30 bg-overlay transition-opacity duration-200 ${
-                sidebar.isOpen ? "opacity-100" : "opacity-0 pointer-events-none"
-              }`}
+              className={`fixed inset-0 z-30 bg-overlay ${
+                isDraggingSidebar ? "" : "transition-opacity duration-200"
+              } ${sidebar.isOpen ? "opacity-100" : "pointer-events-none"}`}
+              style={
+                !sidebar.isOpen && sidebarDragDistance > 0
+                  ? { opacity: sidebarDragDistance / MOBILE_SIDEBAR_WIDTH_PX }
+                  : !sidebar.isOpen
+                    ? { opacity: 0 }
+                    : undefined
+              }
               role="presentation"
               aria-hidden="true"
               onClick={sidebar.close}
@@ -175,12 +281,17 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
           <div
             className={
               isMobile
-                ? `fixed inset-y-0 left-0 z-40 w-72 transition-transform duration-200 ease-in-out ${
-                    sidebar.isOpen ? "translate-x-0" : "-translate-x-full"
-                  }`
+                ? `fixed inset-y-0 left-0 z-40 w-72 ease-in-out ${
+                    isDraggingSidebar ? "" : "transition-transform duration-200"
+                  } ${sidebar.isOpen ? "translate-x-0" : "-translate-x-full"}`
                 : `transition-all duration-200 ease-in-out ${
                     sidebar.isOpen ? "w-72" : "w-0"
                   } flex-shrink-0 overflow-hidden`
+            }
+            style={
+              isMobile && !sidebar.isOpen && sidebarDragDistance > 0
+                ? { transform: `translateX(calc(-100% + ${sidebarDragDistance}px))` }
+                : undefined
             }
           >
             <SessionSidebar

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -1,15 +1,6 @@
 "use client";
 
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type PointerEvent as ReactPointerEvent,
-} from "react";
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
 import { signIn, useAuthSession } from "@/lib/auth-session";
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
@@ -23,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { GitHubIcon, GoogleIcon, SidebarIcon } from "@/components/ui/icons";
 import { APP_NAME, GOOGLE_LOGIN_ENABLED } from "@/lib/site-config";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
+import { useMobileSidebarPull } from "@/hooks/use-mobile-sidebar-pull";
 
 interface SidebarContextValue {
   isOpen: boolean;
@@ -38,11 +30,6 @@ interface AppShellActionsContextValue {
 
 const SidebarContext = createContext<SidebarContextValue | null>(null);
 const AppShellActionsContext = createContext<AppShellActionsContextValue | null>(null);
-
-const MOBILE_SIDEBAR_WIDTH_PX = 288;
-const MOBILE_SIDEBAR_HOLD_MS = 300;
-const MOBILE_SIDEBAR_HOLD_TOLERANCE_PX = 10;
-const MOBILE_SIDEBAR_OPEN_THRESHOLD_PX = 72;
 
 export function useSidebarContext() {
   const context = useContext(SidebarContext);
@@ -93,79 +80,17 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
   const sidebar = useSidebar();
   const isMobile = useIsMobile();
   const [isCommandMenuOpen, setIsCommandMenuOpen] = useState(false);
-  const [sidebarDragDistance, setSidebarDragDistance] = useState(0);
-  const [isDraggingSidebar, setIsDraggingSidebar] = useState(false);
-  const sidebarHoldTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const sidebarDragStartRef = useRef<{ x: number; y: number } | null>(null);
-  const sidebarDragDistanceRef = useRef(0);
-  const isSidebarDragActiveRef = useRef(false);
-
-  const resetSidebarDrag = useCallback(() => {
-    if (sidebarHoldTimerRef.current !== null) {
-      clearTimeout(sidebarHoldTimerRef.current);
-      sidebarHoldTimerRef.current = null;
-    }
-    sidebarDragStartRef.current = null;
-    sidebarDragDistanceRef.current = 0;
-    isSidebarDragActiveRef.current = false;
-    setSidebarDragDistance(0);
-    setIsDraggingSidebar(false);
-  }, []);
-
-  useEffect(() => resetSidebarDrag, [resetSidebarDrag]);
-
-  const handleSidebarDragStart = useCallback(
-    (event: ReactPointerEvent<HTMLDivElement>) => {
-      if (!isMobile || sidebar.isOpen || (event.pointerType === "mouse" && event.button !== 0)) {
-        return;
-      }
-
-      resetSidebarDrag();
-      sidebarDragStartRef.current = { x: event.clientX, y: event.clientY };
-      event.currentTarget.setPointerCapture?.(event.pointerId);
-      sidebarHoldTimerRef.current = setTimeout(() => {
-        sidebarHoldTimerRef.current = null;
-        isSidebarDragActiveRef.current = true;
-        setIsDraggingSidebar(true);
-      }, MOBILE_SIDEBAR_HOLD_MS);
-    },
-    [isMobile, resetSidebarDrag, sidebar.isOpen]
+  const mobileSidebarRef = useRef<HTMLDivElement>(null);
+  const getMobileSidebarWidth = useCallback(
+    () => mobileSidebarRef.current?.getBoundingClientRect().width ?? 0,
+    []
   );
-
-  const handleSidebarDragMove = useCallback(
-    (event: ReactPointerEvent<HTMLDivElement>) => {
-      const start = sidebarDragStartRef.current;
-      if (!start) return;
-
-      const deltaX = event.clientX - start.x;
-      const deltaY = event.clientY - start.y;
-      if (!isSidebarDragActiveRef.current) {
-        if (Math.hypot(deltaX, deltaY) > MOBILE_SIDEBAR_HOLD_TOLERANCE_PX) {
-          resetSidebarDrag();
-        }
-        return;
-      }
-
-      if (Math.abs(deltaY) > Math.abs(deltaX)) {
-        resetSidebarDrag();
-        return;
-      }
-
-      event.preventDefault();
-      const distance = Math.min(MOBILE_SIDEBAR_WIDTH_PX, Math.max(0, deltaX));
-      sidebarDragDistanceRef.current = distance;
-      setSidebarDragDistance(distance);
-    },
-    [resetSidebarDrag]
-  );
-
-  const handleSidebarDragEnd = useCallback(() => {
-    const shouldOpen =
-      isSidebarDragActiveRef.current &&
-      sidebarDragDistanceRef.current >= MOBILE_SIDEBAR_OPEN_THRESHOLD_PX;
-    resetSidebarDrag();
-    if (shouldOpen) sidebar.open();
-  }, [resetSidebarDrag, sidebar]);
+  const sidebarPull = useMobileSidebarPull({
+    isMobile,
+    isSidebarOpen: sidebar.isOpen,
+    getSidebarWidth: getMobileSidebarWidth,
+    onOpen: sidebar.open,
+  });
 
   const { data: sessionsResponse } = useSWR<SessionListResponse>(
     status === "authenticated" && Boolean(session) && isCommandMenuOpen
@@ -250,12 +175,12 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
           {isMobile && !sidebar.isOpen && (
             <div
               data-testid="mobile-sidebar-drag-handle"
-              className="fixed inset-y-0 left-0 z-50 w-6 touch-pan-y"
+              className="fixed inset-y-0 left-8 z-50 w-6 touch-pan-y"
               aria-hidden="true"
-              onPointerDown={handleSidebarDragStart}
-              onPointerMove={handleSidebarDragMove}
-              onPointerUp={handleSidebarDragEnd}
-              onPointerCancel={resetSidebarDrag}
+              onPointerDown={sidebarPull.handlePointerDown}
+              onPointerMove={sidebarPull.handlePointerMove}
+              onPointerUp={sidebarPull.handlePointerUp}
+              onPointerCancel={sidebarPull.reset}
               onContextMenu={(event) => event.preventDefault()}
             />
           )}
@@ -263,11 +188,11 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
           {isMobile && (
             <div
               className={`fixed inset-0 z-30 bg-overlay ${
-                isDraggingSidebar ? "" : "transition-opacity duration-200"
+                sidebarPull.isDragging ? "" : "transition-opacity duration-200"
               } ${sidebar.isOpen ? "opacity-100" : "pointer-events-none"}`}
               style={
-                !sidebar.isOpen && sidebarDragDistance > 0
-                  ? { opacity: sidebarDragDistance / MOBILE_SIDEBAR_WIDTH_PX }
+                !sidebar.isOpen && sidebarPull.dragProgress > 0
+                  ? { opacity: sidebarPull.dragProgress }
                   : !sidebar.isOpen
                     ? { opacity: 0 }
                     : undefined
@@ -279,18 +204,20 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
           )}
           {/* Sidebar: overlay on mobile, push on desktop */}
           <div
+            ref={mobileSidebarRef}
+            data-testid="mobile-sidebar-drawer"
             className={
               isMobile
                 ? `fixed inset-y-0 left-0 z-40 w-72 ease-in-out ${
-                    isDraggingSidebar ? "" : "transition-transform duration-200"
+                    sidebarPull.isDragging ? "" : "transition-transform duration-200"
                   } ${sidebar.isOpen ? "translate-x-0" : "-translate-x-full"}`
                 : `transition-all duration-200 ease-in-out ${
                     sidebar.isOpen ? "w-72" : "w-0"
                   } flex-shrink-0 overflow-hidden`
             }
             style={
-              isMobile && !sidebar.isOpen && sidebarDragDistance > 0
-                ? { transform: `translateX(calc(-100% + ${sidebarDragDistance}px))` }
+              isMobile && !sidebar.isOpen && sidebarPull.dragDistance > 0
+                ? { transform: `translateX(calc(-100% + ${sidebarPull.dragDistance}px))` }
                 : undefined
             }
           >

--- a/packages/web/src/hooks/use-mobile-sidebar-pull.test.tsx
+++ b/packages/web/src/hooks/use-mobile-sidebar-pull.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MOBILE_SIDEBAR_HOLD_MS, useMobileSidebarPull } from "./use-mobile-sidebar-pull";
+
+function Harness({
+  isMobile = true,
+  isSidebarOpen = false,
+  onOpen,
+}: {
+  isMobile?: boolean;
+  isSidebarOpen?: boolean;
+  onOpen: () => void;
+}) {
+  const pull = useMobileSidebarPull({
+    isMobile,
+    isSidebarOpen,
+    getSidebarWidth: () => 288,
+    onOpen,
+  });
+
+  return (
+    <div
+      data-testid="handle"
+      data-dragging={pull.isDragging}
+      onPointerDown={pull.handlePointerDown}
+      onPointerMove={pull.handlePointerMove}
+      onPointerUp={pull.handlePointerUp}
+      onPointerCancel={pull.reset}
+    />
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("useMobileSidebarPull", () => {
+  it("cancels a held gesture when movement becomes vertical", () => {
+    vi.useFakeTimers();
+    const onOpen = vi.fn();
+    const { getByTestId } = render(<Harness onOpen={onOpen} />);
+    const handle = getByTestId("handle");
+
+    fireEvent.pointerDown(handle, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 40,
+      clientY: 200,
+    });
+    act(() => vi.advanceTimersByTime(MOBILE_SIDEBAR_HOLD_MS));
+    fireEvent.pointerMove(handle, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 38,
+      clientY: 250,
+    });
+    fireEvent.pointerUp(handle, { pointerId: 1, pointerType: "touch" });
+
+    expect(handle.dataset.dragging).toBe("false");
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { change: "leaves mobile layout", props: { isMobile: false } },
+    { change: "opens through another action", props: { isSidebarOpen: true } },
+  ])("cancels a pending hold when the sidebar $change", ({ props }) => {
+    vi.useFakeTimers();
+    const onOpen = vi.fn();
+    const { getByTestId, rerender } = render(<Harness onOpen={onOpen} />);
+    const handle = getByTestId("handle");
+
+    fireEvent.pointerDown(handle, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 40,
+      clientY: 200,
+    });
+    rerender(<Harness onOpen={onOpen} {...props} />);
+    act(() => vi.advanceTimersByTime(MOBILE_SIDEBAR_HOLD_MS));
+    fireEvent.pointerMove(handle, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 128,
+      clientY: 200,
+    });
+    fireEvent.pointerUp(handle, { pointerId: 1, pointerType: "touch" });
+
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/hooks/use-mobile-sidebar-pull.test.tsx
+++ b/packages/web/src/hooks/use-mobile-sidebar-pull.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { MOBILE_SIDEBAR_HOLD_MS, useMobileSidebarPull } from "./use-mobile-sidebar-pull";
+import { useMobileSidebarPull } from "./use-mobile-sidebar-pull";
 
 function Harness({
   isMobile = true,
@@ -34,12 +34,10 @@ function Harness({
 
 afterEach(() => {
   cleanup();
-  vi.useRealTimers();
 });
 
 describe("useMobileSidebarPull", () => {
-  it("cancels a held gesture when movement becomes vertical", () => {
-    vi.useFakeTimers();
+  it("cancels a swipe when movement becomes vertical", () => {
     const onOpen = vi.fn();
     const { getByTestId } = render(<Harness onOpen={onOpen} />);
     const handle = getByTestId("handle");
@@ -47,14 +45,13 @@ describe("useMobileSidebarPull", () => {
     fireEvent.pointerDown(handle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 40,
+      clientX: 8,
       clientY: 200,
     });
-    act(() => vi.advanceTimersByTime(MOBILE_SIDEBAR_HOLD_MS));
     fireEvent.pointerMove(handle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 38,
+      clientX: 12,
       clientY: 250,
     });
     fireEvent.pointerUp(handle, { pointerId: 1, pointerType: "touch" });
@@ -66,8 +63,7 @@ describe("useMobileSidebarPull", () => {
   it.each([
     { change: "leaves mobile layout", props: { isMobile: false } },
     { change: "opens through another action", props: { isSidebarOpen: true } },
-  ])("cancels a pending hold when the sidebar $change", ({ props }) => {
-    vi.useFakeTimers();
+  ])("cancels an active swipe when the sidebar $change", ({ props }) => {
     const onOpen = vi.fn();
     const { getByTestId, rerender } = render(<Harness onOpen={onOpen} />);
     const handle = getByTestId("handle");
@@ -75,11 +71,10 @@ describe("useMobileSidebarPull", () => {
     fireEvent.pointerDown(handle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 40,
+      clientX: 8,
       clientY: 200,
     });
     rerender(<Harness onOpen={onOpen} {...props} />);
-    act(() => vi.advanceTimersByTime(MOBILE_SIDEBAR_HOLD_MS));
     fireEvent.pointerMove(handle, {
       pointerId: 1,
       pointerType: "touch",

--- a/packages/web/src/hooks/use-mobile-sidebar-pull.ts
+++ b/packages/web/src/hooks/use-mobile-sidebar-pull.ts
@@ -1,0 +1,118 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, type PointerEvent } from "react";
+
+export const MOBILE_SIDEBAR_HOLD_MS = 300;
+
+const HOLD_TOLERANCE_PX = 10;
+const OPEN_THRESHOLD_PX = 72;
+
+interface UseMobileSidebarPullOptions {
+  isMobile: boolean;
+  isSidebarOpen: boolean;
+  getSidebarWidth: () => number;
+  onOpen: () => void;
+}
+
+export function useMobileSidebarPull({
+  isMobile,
+  isSidebarOpen,
+  getSidebarWidth,
+  onOpen,
+}: UseMobileSidebarPullOptions) {
+  const [dragDistance, setDragDistance] = useState(0);
+  const [dragProgress, setDragProgress] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const holdTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dragStartRef = useRef<{ x: number; y: number } | null>(null);
+  const dragDistanceRef = useRef(0);
+  const sidebarWidthRef = useRef(0);
+  const isDragActiveRef = useRef(false);
+  const isEnabled = isMobile && !isSidebarOpen;
+
+  const clearHoldTimer = useCallback(() => {
+    if (holdTimerRef.current !== null) {
+      clearTimeout(holdTimerRef.current);
+      holdTimerRef.current = null;
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    clearHoldTimer();
+    dragStartRef.current = null;
+    dragDistanceRef.current = 0;
+    sidebarWidthRef.current = 0;
+    isDragActiveRef.current = false;
+    setDragDistance(0);
+    setDragProgress(0);
+    setIsDragging(false);
+  }, [clearHoldTimer]);
+
+  useEffect(() => {
+    if (!isEnabled) reset();
+  }, [isEnabled, reset]);
+
+  useEffect(() => clearHoldTimer, [clearHoldTimer]);
+
+  const handlePointerDown = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (!isEnabled || (event.pointerType === "mouse" && event.button !== 0)) return;
+
+      const sidebarWidth = getSidebarWidth();
+      if (sidebarWidth <= 0) return;
+
+      reset();
+      sidebarWidthRef.current = sidebarWidth;
+      dragStartRef.current = { x: event.clientX, y: event.clientY };
+      event.currentTarget.setPointerCapture?.(event.pointerId);
+      holdTimerRef.current = setTimeout(() => {
+        holdTimerRef.current = null;
+        isDragActiveRef.current = true;
+        setIsDragging(true);
+      }, MOBILE_SIDEBAR_HOLD_MS);
+    },
+    [getSidebarWidth, isEnabled, reset]
+  );
+
+  const handlePointerMove = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      const start = dragStartRef.current;
+      if (!start) return;
+
+      const deltaX = event.clientX - start.x;
+      const deltaY = event.clientY - start.y;
+      if (!isDragActiveRef.current) {
+        if (Math.hypot(deltaX, deltaY) > HOLD_TOLERANCE_PX) reset();
+        return;
+      }
+
+      if (Math.abs(deltaY) > Math.abs(deltaX)) {
+        reset();
+        return;
+      }
+
+      event.preventDefault();
+      const distance = Math.min(sidebarWidthRef.current, Math.max(0, deltaX));
+      dragDistanceRef.current = distance;
+      setDragDistance(distance);
+      setDragProgress(distance / sidebarWidthRef.current);
+    },
+    [reset]
+  );
+
+  const handlePointerUp = useCallback(() => {
+    const shouldOpen = isDragActiveRef.current && dragDistanceRef.current >= OPEN_THRESHOLD_PX;
+    reset();
+    if (shouldOpen) onOpen();
+  }, [onOpen, reset]);
+
+  return {
+    dragDistance,
+    dragProgress,
+    isDragging,
+    reset,
+    handlePointerDown,
+    handlePointerMove,
+    handlePointerUp,
+  };
+}

--- a/packages/web/src/hooks/use-mobile-sidebar-pull.ts
+++ b/packages/web/src/hooks/use-mobile-sidebar-pull.ts
@@ -2,9 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState, type PointerEvent } from "react";
 
-export const MOBILE_SIDEBAR_HOLD_MS = 300;
-
-const HOLD_TOLERANCE_PX = 10;
+const DIRECTION_LOCK_THRESHOLD_PX = 8;
 const OPEN_THRESHOLD_PX = 72;
 
 interface UseMobileSidebarPullOptions {
@@ -23,36 +21,23 @@ export function useMobileSidebarPull({
   const [dragDistance, setDragDistance] = useState(0);
   const [dragProgress, setDragProgress] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
-  const holdTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const dragStartRef = useRef<{ x: number; y: number } | null>(null);
   const dragDistanceRef = useRef(0);
   const sidebarWidthRef = useRef(0);
-  const isDragActiveRef = useRef(false);
   const isEnabled = isMobile && !isSidebarOpen;
 
-  const clearHoldTimer = useCallback(() => {
-    if (holdTimerRef.current !== null) {
-      clearTimeout(holdTimerRef.current);
-      holdTimerRef.current = null;
-    }
-  }, []);
-
   const reset = useCallback(() => {
-    clearHoldTimer();
     dragStartRef.current = null;
     dragDistanceRef.current = 0;
     sidebarWidthRef.current = 0;
-    isDragActiveRef.current = false;
     setDragDistance(0);
     setDragProgress(0);
     setIsDragging(false);
-  }, [clearHoldTimer]);
+  }, []);
 
   useEffect(() => {
     if (!isEnabled) reset();
   }, [isEnabled, reset]);
-
-  useEffect(() => clearHoldTimer, [clearHoldTimer]);
 
   const handlePointerDown = useCallback(
     (event: PointerEvent<HTMLDivElement>) => {
@@ -65,11 +50,7 @@ export function useMobileSidebarPull({
       sidebarWidthRef.current = sidebarWidth;
       dragStartRef.current = { x: event.clientX, y: event.clientY };
       event.currentTarget.setPointerCapture?.(event.pointerId);
-      holdTimerRef.current = setTimeout(() => {
-        holdTimerRef.current = null;
-        isDragActiveRef.current = true;
-        setIsDragging(true);
-      }, MOBILE_SIDEBAR_HOLD_MS);
+      setIsDragging(true);
     },
     [getSidebarWidth, isEnabled, reset]
   );
@@ -81,12 +62,9 @@ export function useMobileSidebarPull({
 
       const deltaX = event.clientX - start.x;
       const deltaY = event.clientY - start.y;
-      if (!isDragActiveRef.current) {
-        if (Math.hypot(deltaX, deltaY) > HOLD_TOLERANCE_PX) reset();
-        return;
-      }
+      if (Math.hypot(deltaX, deltaY) < DIRECTION_LOCK_THRESHOLD_PX) return;
 
-      if (Math.abs(deltaY) > Math.abs(deltaX)) {
+      if (deltaX <= 0 || Math.abs(deltaY) > deltaX) {
         reset();
         return;
       }
@@ -101,7 +79,7 @@ export function useMobileSidebarPull({
   );
 
   const handlePointerUp = useCallback(() => {
-    const shouldOpen = isDragActiveRef.current && dragDistanceRef.current >= OPEN_THRESHOLD_PX;
+    const shouldOpen = dragDistanceRef.current >= OPEN_THRESHOLD_PX;
     reset();
     if (shouldOpen) onOpen();
   }, [onOpen, reset]);


### PR DESCRIPTION
## Summary
- add a mobile-only left-edge swipe gesture for opening the sessions sidebar
- begin tracking immediately from a conventional 20px edge activation area
- track drawer and backdrop progress before snapping open past the distance threshold
- cancel short, leftward, or predominantly vertical movement to preserve normal scrolling
- isolate gesture state in a focused hook with layout and cancellation tests

## Verification
- `npm test -w @open-inspect/web` (801 tests passed)
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web -- --no-warn-ignored`
- mobile interaction artifact at 390x844: `5a120b8c88d50e076be69c06eeaba7cb`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/a8b167f4a9f2811c869be870d3e2dea1)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mobile drag handle to open the sidebar.
  * Mobile sidebar/backdrop now update in real time based on the drag gesture for smoother motion.
* **Bug Fixes**
  * Prevents accidental opening by canceling gestures when movement is too vertical, the swipe is too short, or the sidebar state changes mid-gesture.
* **Tests**
  * Expanded mobile drag and cancellation coverage for the sidebar behavior.
  * Improved sidebar layout test setup with shared mocking and stronger per-test cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->