### PR TITLE
Restrict service access to explicitly allowed endpoints

### DIFF
--- a/packages/control-plane/src/router.analytics.test.ts
+++ b/packages/control-plane/src/router.analytics.test.ts
@@ -1,6 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { handleRequest } from "./router";
-import { signedServiceRequest, TEST_SERVICE_SECRETS } from "./router.test-support";
+
+vi.mock("./auth/authenticate", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    authenticate: vi.fn(async (request: Request) => ({
+      principal: { kind: "user", userId: "user-1" },
+      request,
+    })),
+  };
+});
 
 const mockStore = {
   getSummary: vi.fn(),
@@ -41,7 +51,6 @@ describe("analytics router integration", () => {
     });
 
     const env = {
-      ...TEST_SERVICE_SECRETS,
       SCM_PROVIDER: "gitlab",
       DB: {
         prepare: vi.fn(),
@@ -52,9 +61,7 @@ describe("analytics router integration", () => {
     };
 
     const response = await handleRequest(
-      await signedServiceRequest("https://test.local/analytics/summary", {
-        service: "modal",
-      }),
+      new Request("https://test.local/analytics/summary"),
       env as never
     );
 

--- a/packages/control-plane/src/router.auth.test.ts
+++ b/packages/control-plane/src/router.auth.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { handleRequest } from "./router";
+import { signedServiceRequest, TEST_SERVICE_SECRETS } from "./router.test-support";
 
 function createEnv(verifyStatus: number) {
   const fetch = vi
@@ -14,6 +15,7 @@ function createEnv(verifyStatus: number) {
   };
 
   const env = {
+    ...TEST_SERVICE_SECRETS,
     SCM_PROVIDER: "gitlab",
     GITLAB_ACCESS_TOKEN: "glpat-test",
     DB: {
@@ -75,6 +77,75 @@ describe("router sandbox-token fallback", () => {
 
     expect(response.status).toBe(401);
     expect(doFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("router service authorization", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("allows an explicitly authorized service route", async () => {
+    const { env, doFetch } = createEnv(202);
+    env.SCM_PROVIDER = "github";
+
+    const response = await handleRequest(
+      await signedServiceRequest("https://test.local/sessions/session-1/stop", {
+        method: "POST",
+        service: "linear-bot",
+      }),
+      env as never
+    );
+
+    expect(response.status).toBe(202);
+    expect(doFetch).toHaveBeenCalledOnce();
+  });
+
+  it("denies an authenticated service that is not authorized for the route", async () => {
+    const { env, doFetch } = createEnv(202);
+    env.SCM_PROVIDER = "github";
+
+    const response = await handleRequest(
+      await signedServiceRequest("https://test.local/sessions/session-1/stop", {
+        method: "POST",
+        service: "modal",
+      }),
+      env as never
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "Forbidden" });
+    expect(doFetch).not.toHaveBeenCalled();
+  });
+
+  it("does not let a bot substitute another integration id", async () => {
+    const { env } = createEnv(202);
+    env.SCM_PROVIDER = "github";
+
+    const response = await handleRequest(
+      await signedServiceRequest("https://test.local/integration-settings/github", {
+        service: "slack-bot",
+      }),
+      env as never
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("does not let one bot post another bot's internal event", async () => {
+    const { env } = createEnv(202);
+    env.SCM_PROVIDER = "github";
+
+    const response = await handleRequest(
+      await signedServiceRequest("https://test.local/internal/github-event", {
+        method: "POST",
+        body: "{}",
+        service: "slack-bot",
+      }),
+      env as never
+    );
+
+    expect(response.status).toBe(403);
   });
 });
 

--- a/packages/control-plane/src/router.scm-credentials.test.ts
+++ b/packages/control-plane/src/router.scm-credentials.test.ts
@@ -42,16 +42,16 @@ describe("SCM credentials router provider gate", () => {
     const { env, fetch } = createEnv();
 
     const response = await handleRequest(
-      await signedServiceRequest("https://test.local/sessions/session-1/scm-credentials", {
+      new Request("https://test.local/sessions/session-1/scm-credentials", {
         method: "POST",
-        service: "modal",
+        headers: { Authorization: "Bearer sandbox-token" },
       }),
       env as never
     );
 
     expect(response.status).toBe(202);
-    expect(fetch).toHaveBeenCalledOnce();
-    const request = fetch.mock.calls[0][0];
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const request = fetch.mock.calls[1][0];
     expect(new URL(request.url).pathname).toBe("/internal/scm-credentials");
   });
 
@@ -59,15 +59,15 @@ describe("SCM credentials router provider gate", () => {
     const { env, fetch } = createEnv();
 
     const response = await handleRequest(
-      await signedServiceRequest("https://test.local/sessions/session-1/tunnel-urls", {
-        service: "modal",
+      new Request("https://test.local/sessions/session-1/tunnel-urls", {
+        headers: { Authorization: "Bearer sandbox-token" },
       }),
       env as never
     );
 
     expect(response.status).toBe(202);
-    expect(fetch).toHaveBeenCalledOnce();
-    const request = fetch.mock.calls[0][0];
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const request = fetch.mock.calls[1][0];
     expect(new URL(request.url).pathname).toBe("/internal/tunnel-urls");
   });
 
@@ -99,7 +99,7 @@ describe("SCM credentials router provider gate", () => {
     expect(response.status).toBe(401);
   });
 
-  it("continues blocking unrelated GitLab session routes", async () => {
+  it("denies service access before the provider gate", async () => {
     const { env, fetch } = createEnv();
 
     const response = await handleRequest(
@@ -110,10 +110,8 @@ describe("SCM credentials router provider gate", () => {
       env as never
     );
 
-    expect(response.status).toBe(501);
-    await expect(response.json()).resolves.toEqual({
-      error: "SCM provider 'gitlab' is not implemented in this deployment.",
-    });
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "Forbidden" });
     expect(fetch).not.toHaveBeenCalled();
   });
 });

--- a/packages/control-plane/src/router.spawn-child.test.ts
+++ b/packages/control-plane/src/router.spawn-child.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { handleRequest } from "./router";
-import { signedServiceRequest, TEST_SERVICE_SECRETS } from "./router.test-support";
+import { TEST_SERVICE_SECRETS } from "./router.test-support";
 import { getEffectiveEnabledModels } from "./db/model-preferences";
 import { SessionIndexStore } from "./db/session-index";
 import { SessionInternalPaths } from "./session/contracts";
@@ -87,10 +87,13 @@ describe("handleSpawnChild prompt enqueue handling", () => {
 
   async function makeRequest(env: Record<string, unknown>): Promise<Response> {
     return handleRequest(
-      await signedServiceRequest(`https://test.local/sessions/${parentId}/children`, {
+      new Request(`https://test.local/sessions/${parentId}/children`, {
         method: "POST",
         body: JSON.stringify({ title: "Child task", prompt: "Do the thing" }),
-        service: "modal",
+        headers: {
+          Authorization: "Bearer sandbox-token",
+          "Content-Type": "application/json",
+        },
       }),
       env as never
     );
@@ -216,14 +219,17 @@ describe("handleSpawnChild prompt enqueue handling", () => {
     };
 
     const response = await handleRequest(
-      await signedServiceRequest(`https://test.local/sessions/${parentId}/children`, {
+      new Request(`https://test.local/sessions/${parentId}/children`, {
         method: "POST",
-        service: "modal",
         body: JSON.stringify({
           title: "Child task",
           prompt: "Do the thing",
           model: "not-a-real-model",
         }),
+        headers: {
+          Authorization: "Bearer sandbox-token",
+          "Content-Type": "application/json",
+        },
       }),
       env as never
     );
@@ -273,15 +279,18 @@ describe("handleSpawnChild prompt enqueue handling", () => {
       DB: {},
       SESSION: {
         idFromName: (name: string) => name,
-        get: vi.fn(),
+        get: () => ({ fetch: vi.fn(async () => new Response(null, { status: 204 })) }),
       },
     };
 
     const response = await handleRequest(
-      await signedServiceRequest(`https://test.local/sessions/${parentId}/children`, {
+      new Request(`https://test.local/sessions/${parentId}/children`, {
         method: "POST",
-        service: "modal",
         body: JSON.stringify({ title: "Child task" }),
+        headers: {
+          Authorization: "Bearer sandbox-token",
+          "Content-Type": "application/json",
+        },
       }),
       env as never
     );
@@ -415,14 +424,17 @@ describe("handleSpawnChild prompt enqueue handling", () => {
     };
 
     const response = await handleRequest(
-      await signedServiceRequest(`https://test.local/sessions/${parentId}/children`, {
+      new Request(`https://test.local/sessions/${parentId}/children`, {
         method: "POST",
-        service: "modal",
         body: JSON.stringify({
           title: "Child task",
           prompt: "Do the thing",
           model: "",
         }),
+        headers: {
+          Authorization: "Bearer sandbox-token",
+          "Content-Type": "application/json",
+        },
       }),
       env as never
     );
@@ -439,8 +451,10 @@ describe("handleSpawnChild prompt enqueue handling", () => {
     });
 
     const parentStub: DurableObjectStub = {
-      fetch: vi.fn(async () =>
-        Response.json({ error: "Child sessions require a repository context" }, { status: 400 })
+      fetch: vi.fn(async (request: Request) =>
+        new URL(request.url).pathname === SessionInternalPaths.verifySandboxToken
+          ? new Response(null, { status: 204 })
+          : Response.json({ error: "Child sessions require a repository context" }, { status: 400 })
       ),
     } as never;
 

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -302,6 +302,12 @@ function logPrincipal(principal: Principal, ctx: RequestContext, path: string): 
   });
 }
 
+function authorizeService(route: Route, principal: Principal | undefined): Response | null {
+  if (principal?.kind !== "service") return null;
+  if (route.allowedServices?.includes(principal.service)) return null;
+  return error("Forbidden", 403);
+}
+
 /**
  * Routes definition.
  */
@@ -469,6 +475,19 @@ export async function handleRequest(
 
     if (ctx.principal) {
       logPrincipal(ctx.principal, ctx, path);
+    }
+
+    const authorizationError = authorizeService(matchedRoute.route, ctx.principal);
+    if (authorizationError) {
+      logger.warn("Service route access denied", {
+        event: "auth.service_forbidden",
+        service: ctx.principal?.kind === "service" ? ctx.principal.service : undefined,
+        http_method: method,
+        http_path: path,
+        request_id: ctx.request_id,
+        trace_id: ctx.trace_id,
+      });
+      return withCorsAndTraceHeaders(authorizationError, ctx);
     }
   }
 

--- a/packages/control-plane/src/routes/automations.ts
+++ b/packages/control-plane/src/routes/automations.ts
@@ -1150,6 +1150,7 @@ export const automationRoutes: Route[] = [
   {
     method: "GET",
     pattern: parsePattern("/integration-settings/slack/watched-channels"),
+    allowedServices: ["slack-bot"],
     handler: handleGetWatchedSlackChannels,
   },
   {

--- a/packages/control-plane/src/routes/browser-auth.ts
+++ b/packages/control-plane/src/routes/browser-auth.ts
@@ -87,5 +87,6 @@ const handleBrowserAuth: Route["handler"] = async (request, _env, _match, ctx) =
 export const browserAuthRoutes: Route[] = BROWSER_AUTH_PROXY_ROUTES.map(([method, path]) => ({
   method,
   pattern: parsePattern(path),
+  allowedServices: ["web"],
   handler: requireWebService(handleBrowserAuth),
 }));

--- a/packages/control-plane/src/routes/environments.ts
+++ b/packages/control-plane/src/routes/environments.ts
@@ -258,9 +258,19 @@ async function handleDeleteEnvironment(
 }
 
 export const environmentRoutes: Route[] = [
-  { method: "GET", pattern: parsePattern("/environments"), handler: handleListEnvironments },
+  {
+    method: "GET",
+    pattern: parsePattern("/environments"),
+    allowedServices: ["slack-bot", "linear-bot"],
+    handler: handleListEnvironments,
+  },
   { method: "POST", pattern: parsePattern("/environments"), handler: handleCreateEnvironment },
-  { method: "GET", pattern: parsePattern("/environments/:id"), handler: handleGetEnvironment },
+  {
+    method: "GET",
+    pattern: parsePattern("/environments/:id"),
+    allowedServices: ["github-bot"],
+    handler: handleGetEnvironment,
+  },
   { method: "PUT", pattern: parsePattern("/environments/:id"), handler: handleUpdateEnvironment },
   {
     method: "DELETE",

--- a/packages/control-plane/src/routes/image-builds.ts
+++ b/packages/control-plane/src/routes/image-builds.ts
@@ -671,11 +671,13 @@ export const imageBuildRoutes: Route[] = [
   {
     method: "POST",
     pattern: parsePattern("/image-builds/trigger/environment/:id"),
+    allowedServices: ["modal"],
     handler: handleTriggerEnvironmentBuild,
   },
   {
     method: "POST",
     pattern: parsePattern("/image-builds/trigger/repo/:owner/:name"),
+    allowedServices: ["modal"],
     handler: handleTriggerRepoBuild,
   },
   {
@@ -686,11 +688,13 @@ export const imageBuildRoutes: Route[] = [
   {
     method: "GET",
     pattern: parsePattern("/image-builds/status"),
+    allowedServices: ["modal"],
     handler: handleGetStatus,
   },
   {
     method: "GET",
     pattern: parsePattern("/image-builds/enabled"),
+    allowedServices: ["modal"],
     handler: handleGetEnabledUnits,
   },
   {
@@ -701,11 +705,13 @@ export const imageBuildRoutes: Route[] = [
   {
     method: "POST",
     pattern: parsePattern("/image-builds/mark-stale"),
+    allowedServices: ["modal"],
     handler: handleMarkStale,
   },
   {
     method: "POST",
     pattern: parsePattern("/image-builds/cleanup"),
+    allowedServices: ["modal"],
     handler: handleCleanup,
   },
 ];

--- a/packages/control-plane/src/routes/integration-settings.ts
+++ b/packages/control-plane/src/routes/integration-settings.ts
@@ -472,6 +472,26 @@ async function handleGetResolvedConfig(
 }
 
 export const integrationSettingsRoutes: Route[] = [
+  // Exact bot-facing routes precede the generic user routes so a bot cannot
+  // substitute another integration id in an otherwise allowed URL.
+  {
+    method: "GET",
+    pattern: /^\/integration-settings\/(?<id>slack)$/,
+    allowedServices: ["slack-bot"],
+    handler: handleGetIntegrationSettings,
+  },
+  {
+    method: "GET",
+    pattern: /^\/integration-settings\/(?<id>github)\/resolved\/(?<owner>[^/]+)\/(?<name>[^/]+)$/,
+    allowedServices: ["github-bot"],
+    handler: handleGetResolvedConfig,
+  },
+  {
+    method: "GET",
+    pattern: /^\/integration-settings\/(?<id>linear)\/resolved\/(?<owner>[^/]+)\/(?<name>[^/]+)$/,
+    allowedServices: ["linear-bot"],
+    handler: handleGetResolvedConfig,
+  },
   // Integration settings — global
   {
     method: "GET",

--- a/packages/control-plane/src/routes/model-preferences.ts
+++ b/packages/control-plane/src/routes/model-preferences.ts
@@ -107,6 +107,7 @@ export const modelPreferencesRoutes: Route[] = [
   {
     method: "GET",
     pattern: parsePattern("/model-preferences"),
+    allowedServices: ["slack-bot"],
     handler: handleGetModelPreferences,
   },
   {

--- a/packages/control-plane/src/routes/repos.ts
+++ b/packages/control-plane/src/routes/repos.ts
@@ -334,6 +334,7 @@ export const reposRoutes: Route[] = [
   {
     method: "GET",
     pattern: parsePattern("/repos"),
+    allowedServices: ["slack-bot", "linear-bot"],
     handler: handleListRepos,
   },
   {
@@ -344,6 +345,7 @@ export const reposRoutes: Route[] = [
   {
     method: "GET",
     pattern: parsePattern("/repos/:owner/:name/metadata"),
+    allowedServices: ["github-bot"],
     handler: handleGetRepoMetadata,
   },
   {

--- a/packages/control-plane/src/routes/session-attachments.ts
+++ b/packages/control-plane/src/routes/session-attachments.ts
@@ -224,6 +224,7 @@ export const sessionAttachmentRoutes: Route[] = [
   sessionRoute({
     method: "POST",
     pattern: parsePattern("/sessions/:id/attachments"),
+    allowedServices: ["slack-bot"],
     handler: handleAttachmentPost,
   }),
   sessionRoute({

--- a/packages/control-plane/src/routes/session-create.ts
+++ b/packages/control-plane/src/routes/session-create.ts
@@ -235,6 +235,7 @@ export const sessionCreateRoutes: Route[] = [
   {
     method: "POST",
     pattern: parsePattern("/sessions"),
+    allowedServices: ["slack-bot", "github-bot", "linear-bot"],
     handler: handleCreateSession,
   },
 ];

--- a/packages/control-plane/src/routes/session-media-stream.ts
+++ b/packages/control-plane/src/routes/session-media-stream.ts
@@ -140,6 +140,7 @@ export const sessionMediaStreamRoutes: Route[] = [
   sessionRoute({
     method: "GET",
     pattern: parsePattern("/sessions/:id/media/:artifactId"),
+    allowedServices: ["slack-bot"],
     handler: handleMediaGet,
   }),
 ];

--- a/packages/control-plane/src/routes/session-prompt.ts
+++ b/packages/control-plane/src/routes/session-prompt.ts
@@ -162,6 +162,7 @@ export const sessionPromptRoutes: Route[] = [
   sessionRoute({
     method: "POST",
     pattern: parsePattern("/sessions/:id/prompt"),
+    allowedServices: ["slack-bot", "github-bot", "linear-bot"],
     handler: handleSessionPrompt,
   }),
 ];

--- a/packages/control-plane/src/routes/session-runtime-proxy.ts
+++ b/packages/control-plane/src/routes/session-runtime-proxy.ts
@@ -1,4 +1,5 @@
 import { applyIdentityEnforcement } from "../auth/identity-enforcement";
+import type { ServiceName } from "@open-inspect/shared";
 import { SessionInternalPaths, type SessionInternalPath } from "../session/contracts";
 import type { Env } from "../types";
 import { error, parseJsonBody, parsePattern, type Route } from "./shared";
@@ -11,6 +12,7 @@ type SimpleProxyRouteConfig = {
   runtimeMethod?: string;
   forwardSearch?: boolean;
   notFoundMessage?: string;
+  allowedServices?: readonly ServiceName[];
 };
 
 function getSessionId(match: RegExpMatchArray): string | Response {
@@ -26,6 +28,7 @@ function simpleProxyRoute(config: SimpleProxyRouteConfig): Route {
   return sessionRoute({
     method: config.method,
     pattern: parsePattern(config.routePath),
+    allowedServices: config.allowedServices,
     handler: async (request, _env, match, ctx) => {
       const sessionId = getSessionId(match);
       if (sessionId instanceof Response) return sessionId;
@@ -179,17 +182,20 @@ export const sessionRuntimeProxyRoutes: Route[] = [
     routePath: "/sessions/:id/stop",
     internalPath: SessionInternalPaths.stop,
     runtimeMethod: "POST",
+    allowedServices: ["linear-bot"],
   }),
   simpleProxyRoute({
     method: "GET",
     routePath: "/sessions/:id/events",
     internalPath: SessionInternalPaths.events,
     forwardSearch: true,
+    allowedServices: ["slack-bot", "linear-bot"],
   }),
   simpleProxyRoute({
     method: "GET",
     routePath: "/sessions/:id/artifacts",
     internalPath: SessionInternalPaths.artifacts,
+    allowedServices: ["slack-bot", "linear-bot"],
   }),
   simpleProxyRoute({
     method: "GET",

--- a/packages/control-plane/src/routes/shared.ts
+++ b/packages/control-plane/src/routes/shared.ts
@@ -2,7 +2,7 @@
  * Shared route primitives used by all route modules.
  */
 
-import { decodeRepositoryPathSegments } from "@open-inspect/shared";
+import { decodeRepositoryPathSegments, type ServiceName } from "@open-inspect/shared";
 import type { CorrelationContext } from "../logger";
 import type { AuthenticationContext, Principal } from "../auth/principal";
 import type { RequestMetrics } from "../db/instrumented-d1";
@@ -48,6 +48,8 @@ export type RequestContext = CorrelationContext & {
 export interface Route {
   method: string;
   pattern: RegExp;
+  /** First-party services allowed to call this route. Omitted means service access is denied. */
+  allowedServices?: readonly ServiceName[];
   handler: (
     request: Request,
     env: Env,

--- a/packages/control-plane/src/webhooks/automation-event.ts
+++ b/packages/control-plane/src/webhooks/automation-event.ts
@@ -9,7 +9,7 @@
  * named handler.
  */
 
-import type { AutomationEventSource } from "@open-inspect/shared";
+import type { AutomationEventSource, ServiceName } from "@open-inspect/shared";
 import { requireEventPoster } from "../auth/identity-enforcement";
 import type { Route, RequestContext } from "../routes/shared";
 import { parsePattern, json, error } from "../routes/shared";
@@ -81,6 +81,7 @@ export async function forwardAutomationEventToScheduler(
 export function createAutomationEventRoute(opts: {
   path: string;
   source: AutomationEventSource;
+  allowedServices: readonly ServiceName[];
   /** Validate source-specific required fields. Returns an error message, or null when valid. */
   validate: (event: Record<string, unknown>) => string | null;
 }): Route {
@@ -106,5 +107,10 @@ export function createAutomationEventRoute(opts: {
     return forwardAutomationEventToScheduler(env, validated.event);
   }
 
-  return { method: "POST", pattern: parsePattern(opts.path), handler };
+  return {
+    method: "POST",
+    pattern: parsePattern(opts.path),
+    allowedServices: opts.allowedServices,
+    handler,
+  };
 }

--- a/packages/control-plane/src/webhooks/github.ts
+++ b/packages/control-plane/src/webhooks/github.ts
@@ -145,5 +145,6 @@ async function handleGitHubAutomationEvent(
 export const githubAutomationEventRoute: Route = {
   method: "POST",
   pattern: parsePattern("/internal/github-event"),
+  allowedServices: ["github-bot"],
   handler: handleGitHubAutomationEvent,
 };

--- a/packages/control-plane/src/webhooks/slack.ts
+++ b/packages/control-plane/src/webhooks/slack.ts
@@ -14,6 +14,7 @@ import { createAutomationEventRoute } from "./automation-event";
 export const slackAutomationEventRoute = createAutomationEventRoute({
   path: "/internal/slack-event",
   source: "slack",
+  allowedServices: ["slack-bot"],
   validate: (event) =>
     !event.channelId || !event.ts ? "Invalid event: channelId and ts are required" : null,
 });

--- a/packages/control-plane/test/integration/automations-slack-route.test.ts
+++ b/packages/control-plane/test/integration/automations-slack-route.test.ts
@@ -48,13 +48,9 @@ function createBody(overrides: Record<string, unknown>) {
 }
 
 async function postAutomation(body: Record<string, unknown>): Promise<Response> {
-  // automation-create requires a participant identity: sign as a bot with an
-  // asserted actor (the userless web service credential is rejected, 403).
   return serviceFetch("https://test.local/automations", {
     method: "POST",
     body: JSON.stringify(body),
-    service: "slack-bot",
-    actor: "slack:U0123",
   });
 }
 

--- a/packages/control-plane/test/integration/browser-auth-router.test.ts
+++ b/packages/control-plane/test/integration/browser-auth-router.test.ts
@@ -101,7 +101,7 @@ describe("browser auth router", () => {
 
     const response = await handleRequest(request, env);
 
-    expect(response.status).toBe(401);
+    expect(response.status).toBe(403);
   });
 
   it("does not expose Better Auth endpoints outside the positive allowlist", async () => {

--- a/packages/control-plane/test/integration/image-builds.test.ts
+++ b/packages/control-plane/test/integration/image-builds.test.ts
@@ -29,6 +29,7 @@ import type { AnyImageBuildAdapter, DeleteImageInput } from "../../src/image-bui
 import { evaluateImageBuildForSpawn } from "../../src/sandbox/lifecycle/image-selection";
 import type { Env } from "../../src/types";
 import { cleanD1Tables } from "./cleanup";
+import { serviceFetch } from "./helpers";
 import {
   RUNTIME_VERSION,
   REPOSITORY_SHAS,
@@ -1356,7 +1357,7 @@ describe("Image builds", () => {
       // state never flickers off on a transient resolution failure.
       await enableRepo();
 
-      const response = await modalFetch(`${BASE}/image-builds/enabled-repos`);
+      const response = await serviceFetch(`${BASE}/image-builds/enabled-repos`);
 
       expect(response.status).toBe(200);
       await expect(response.json()).resolves.toEqual({
@@ -1370,7 +1371,7 @@ describe("Image builds", () => {
       // The integration harness has no source-control provider configured, so
       // enabling — which resolves the repo through the trigger path's
       // canonical resolver first — fails without persisting the flag.
-      const enable = await modalFetch(`${BASE}/image-builds/toggle/repo/Acme/Web`, {
+      const enable = await serviceFetch(`${BASE}/image-builds/toggle/repo/Acme/Web`, {
         method: "PUT",
         body: JSON.stringify({ enabled: true }),
       });
@@ -1380,7 +1381,7 @@ describe("Image builds", () => {
       // Disabling never resolves — a repo that became unresolvable must
       // remain disableable.
       await enableRepo();
-      const disable = await modalFetch(`${BASE}/image-builds/toggle/repo/acme/web`, {
+      const disable = await serviceFetch(`${BASE}/image-builds/toggle/repo/acme/web`, {
         method: "PUT",
         body: JSON.stringify({ enabled: false }),
       });
@@ -1390,7 +1391,7 @@ describe("Image builds", () => {
     });
 
     it("rejects a non-boolean toggle body", async () => {
-      const response = await modalFetch(`${BASE}/image-builds/toggle/repo/acme/web`, {
+      const response = await serviceFetch(`${BASE}/image-builds/toggle/repo/acme/web`, {
         method: "PUT",
         body: JSON.stringify({ enabled: "yes" }),
       });
@@ -1411,7 +1412,7 @@ describe("Image builds", () => {
       });
       await seedImageRow({ id: "sec-building", environmentId, status: "building" });
 
-      const response = await modalFetch(`${BASE}/environments/${environmentId}/secrets`, {
+      const response = await serviceFetch(`${BASE}/environments/${environmentId}/secrets`, {
         method: "PUT",
         body: JSON.stringify({ secrets: { API_KEY: "rotated-value" } }),
       });
@@ -1431,7 +1432,7 @@ describe("Image builds", () => {
         status: "ready",
         providerImageId: "im-del",
       });
-      await modalFetch(`${BASE}/environments/${environmentId}/secrets`, {
+      await serviceFetch(`${BASE}/environments/${environmentId}/secrets`, {
         method: "PUT",
         body: JSON.stringify({ secrets: { API_KEY: "v" } }),
       });
@@ -1444,7 +1445,7 @@ describe("Image builds", () => {
         providerImageId: "im-del-2",
       });
 
-      const response = await modalFetch(`${BASE}/environments/${environmentId}/secrets/API_KEY`, {
+      const response = await serviceFetch(`${BASE}/environments/${environmentId}/secrets/API_KEY`, {
         method: "DELETE",
       });
 

--- a/packages/control-plane/test/integration/service-auth.test.ts
+++ b/packages/control-plane/test/integration/service-auth.test.ts
@@ -8,7 +8,6 @@ import {
   SERVICE_SIGNATURE_HEADER,
   type ServiceName,
 } from "@open-inspect/shared";
-import { GlobalSecretsStore } from "../../src/db/global-secrets";
 import { UserStore } from "../../src/db/user-store";
 import { cleanD1Tables } from "./cleanup";
 
@@ -47,19 +46,77 @@ async function signedFetch(p: {
 describe("sig1 service-credential authentication", () => {
   beforeEach(cleanD1Tables);
 
-  it("accepts a signed GET from every non-web service", async () => {
+  it("accepts each non-web service on an explicitly authorized route", async () => {
+    const cases: Array<{
+      service: Exclude<ServiceName, "web">;
+      method: string;
+      url: string;
+      body?: string;
+      expectedStatus: number;
+    }> = [
+      {
+        service: "slack-bot",
+        method: "GET",
+        url: "https://test.local/model-preferences",
+        expectedStatus: 200,
+      },
+      {
+        service: "github-bot",
+        method: "POST",
+        url: "https://test.local/internal/github-event",
+        body: "{}",
+        expectedStatus: 400,
+      },
+      {
+        service: "linear-bot",
+        method: "GET",
+        url: "https://test.local/environments",
+        expectedStatus: 200,
+      },
+      {
+        service: "modal",
+        method: "GET",
+        url: "https://test.local/image-builds/enabled",
+        expectedStatus: 200,
+      },
+    ];
+    for (const testCase of cases) {
+      const response = await signedFetch({
+        service: testCase.service,
+        method: testCase.method,
+        url: testCase.url,
+        body: testCase.body,
+      });
+      expect(response.status, testCase.service).toBe(testCase.expectedStatus);
+    }
+  });
+
+  it("denies authenticated services on routes without an explicit grant", async () => {
     for (const service of Object.keys(SERVICE_SECRET).filter(
       (candidate): candidate is Exclude<ServiceName, "web"> => candidate !== "web"
     )) {
       const response = await signedFetch({
         service,
         method: "GET",
-        url: "https://test.local/sessions",
+        url: "https://test.local/secrets",
       });
-      expect(response.status, service).toBe(200);
-      const body = await response.json<{ sessions: unknown[] }>();
-      expect(body.sessions).toEqual([]);
+      expect(response.status, service).toBe(403);
     }
+  });
+
+  it.each([
+    ["slack-bot", "https://test.local/sessions/missing/events?message_id=msg-1"],
+    ["slack-bot", "https://test.local/sessions/missing/artifacts"],
+    ["slack-bot", "https://test.local/sessions/missing/media/artifact-1"],
+    ["linear-bot", "https://test.local/sessions/missing/events?message_id=msg-1"],
+    ["linear-bot", "https://test.local/sessions/missing/artifacts"],
+    ["slack-bot", "https://test.local/integration-settings/slack"],
+    ["github-bot", "https://test.local/integration-settings/github/resolved/acme/widgets"],
+    ["linear-bot", "https://test.local/integration-settings/linear/resolved/acme/widgets"],
+  ] as const)("allows %s to reach its production route %s", async (service, url) => {
+    const response = await signedFetch({ service, method: "GET", url });
+    expect(response.status).not.toBe(401);
+    expect(response.status).not.toBe(403);
   });
 
   it("requires a browser session in addition to the web service channel", async () => {
@@ -72,8 +129,7 @@ describe("sig1 service-credential authentication", () => {
   });
 
   it("accepts a signed request with a query string regardless of param order", async () => {
-    const createdBy = "a".repeat(32);
-    const signedUrl = `https://test.local/sessions?limit=5&createdBy=${createdBy}`;
+    const signedUrl = "https://test.local/image-builds/status?scope_kind=repo&scope_id=acme%2Fweb";
     const headers = await buildServiceAuthHeaders({
       service: "modal",
       secret: SERVICE_SECRET.modal,
@@ -81,51 +137,60 @@ describe("sig1 service-credential authentication", () => {
       url: signedUrl,
     });
     const response = await SELF.fetch(
-      `https://test.local/sessions?createdBy=${createdBy}&limit=5`,
-      {
-        headers,
-      }
+      "https://test.local/image-builds/status?scope_id=acme%2Fweb&scope_kind=repo",
+      { headers }
     );
     expect(response.status).toBe(200);
   });
 
-  it("delivers the signed body intact to the handler (D1 write lands)", async () => {
-    const response = await signedFetch({
-      service: "modal",
-      method: "PUT",
-      url: "https://test.local/secrets",
-      body: JSON.stringify({ secrets: { SIGNED_BODY_TEST: "intact" } }),
+  it("delivers the signed body intact to the handler", async () => {
+    const body = JSON.stringify({
+      title: "Signed body test",
+      model: "anthropic/claude-haiku-4-5",
     });
-    expect(response.status).toBe(200);
+    const response = await signedFetch({
+      service: "slack-bot",
+      method: "POST",
+      url: "https://test.local/sessions",
+      actor: "slack:U0001",
+      body,
+    });
+    expect(response.status).toBe(201);
 
-    const secrets = await new GlobalSecretsStore(
-      env.DB,
-      env.REPO_SECRETS_ENCRYPTION_KEY!
-    ).getDecryptedSecrets();
-    expect(secrets.SIGNED_BODY_TEST).toBe("intact");
+    const session = await env.DB.prepare("SELECT title FROM sessions WHERE title = ?")
+      .bind("Signed body test")
+      .first<{ title: string }>();
+    expect(session?.title).toBe("Signed body test");
   });
 
   it("rejects a body tampered after signing", async () => {
-    const url = "https://test.local/secrets";
-    const intactBody = JSON.stringify({ secrets: { SIGNED_BODY_TEST: "intact" } });
+    const url = "https://test.local/sessions";
+    const intactBody = JSON.stringify({
+      title: "Intact title",
+      model: "anthropic/claude-haiku-4-5",
+    });
     const headers = await buildServiceAuthHeaders({
-      service: "modal",
-      secret: SERVICE_SECRET.modal,
-      method: "PUT",
+      service: "slack-bot",
+      secret: SERVICE_SECRET["slack-bot"],
+      method: "POST",
       url,
       body: intactBody,
+      actor: "slack:U0001",
     });
     const intact = await SELF.fetch(url, {
-      method: "PUT",
+      method: "POST",
       headers: { "Content-Type": "application/json", ...headers },
       body: intactBody,
     });
-    expect(intact.status).toBe(200);
+    expect(intact.status).toBe(201);
 
     const tampered = await SELF.fetch(url, {
-      method: "PUT",
+      method: "POST",
       headers: { "Content-Type": "application/json", ...headers },
-      body: JSON.stringify({ secrets: { SIGNED_BODY_TEST: "tampered" } }),
+      body: JSON.stringify({
+        title: "Tampered title",
+        model: "anthropic/claude-haiku-4-5",
+      }),
     });
     expect(tampered.status).toBe(401);
   });
@@ -208,22 +273,16 @@ describe("sig1 service-credential authentication", () => {
 
     const identity = await new UserStore(env.DB).getIdentity("slack", "U0001");
     expect(identity).not.toBeNull();
-    const listed = await signedFetch({
-      service: "slack-bot",
-      method: "GET",
-      url: "https://test.local/sessions",
-      actor: "slack:U0001",
+    const session = await env.DB.prepare(
+      "SELECT title, user_id AS userId, spawn_source AS spawnSource FROM sessions WHERE title = ?"
+    )
+      .bind("Slack-owned session")
+      .first<{ title: string; userId: string; spawnSource: string }>();
+    expect(session).toEqual({
+      title: "Slack-owned session",
+      userId: identity!.userId,
+      spawnSource: "slack-bot",
     });
-    const body = await listed.json<{
-      sessions: Array<{ title: string; userId: string; spawnSource: string }>;
-    }>();
-    expect(body.sessions).toContainEqual(
-      expect.objectContaining({
-        title: "Slack-owned session",
-        userId: identity!.userId,
-        spawnSource: "slack-bot",
-      })
-    );
   });
 
   it("requires a user or signed actor before any service can create a session", async () => {


### PR DESCRIPTION
## Summary
- add default-deny route authorization for authenticated service principals
- declare least-privilege endpoint access for the web proxy, Slack, GitHub, Linear, and Modal services
- use exact integration-setting routes so bots cannot substitute another integration ID
- preserve existing user and session-scoped sandbox authorization behavior
- log rejected service calls as `auth.service_forbidden`
- update unit and integration fixtures to use user or sandbox credentials where appropriate
- add service-route contract coverage for completion, media, integration, and scheduler call paths

## Verification
- `npm test -w @open-inspect/control-plane` (2,114 tests)
- `npm run test:integration -w @open-inspect/control-plane` (666 tests)
- `npm run typecheck`
- `npx eslint packages/control-plane/src packages/control-plane/test/integration`
- `npm run format`
- `git diff --check`

## Note
Repository-wide `npm run lint` remains blocked by pre-existing `no-undef` errors in `.opencode/`; the complete changed package source and integration-test directories pass ESLint.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/fb799a09d845523cfc46d5a80669c2d9)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added service-level access controls across analytics, sessions, integrations, repositories, environments, image builds, browser authentication, and automation webhooks.
  * Restricted bot and service actions to their authorized routes, preventing cross-service or identity substitution.

* **Bug Fixes**
  * Unauthorized service requests now consistently return a clear **403 Forbidden** response.
  * Improved protection for session creation, prompts, attachments, media, runtime actions, and integration settings.

* **Tests**
  * Expanded authorization coverage for permitted, denied, malformed, and tampered requests.
  * Updated integration tests to verify route-specific service permissions and request-signing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->