### PR TITLE
test: cover Google authorization-code callback

### DIFF
--- a/packages/control-plane/test/integration/browser-auth-callback.test.ts
+++ b/packages/control-plane/test/integration/browser-auth-callback.test.ts
@@ -12,6 +12,59 @@ import { cleanD1Tables } from "./cleanup";
 const CONTROL_PLANE_ORIGIN = "https://control-plane.test.local";
 const PUBLIC_WEB_ORIGIN = "https://app.test.local";
 const WEB_SERVICE_SECRET = "test-service-secret-web";
+const GOOGLE_CLIENT_ID = "google-client-id";
+const GOOGLE_SUBJECT = "google-subject";
+const MS_PER_SECOND = 1000;
+
+let googleIdToken = "";
+let googlePublicKey: JsonWebKey;
+
+function encodeBase64Url(value: string | Uint8Array): string {
+  const bytes = typeof value === "string" ? new TextEncoder().encode(value) : value;
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+async function createSignedGoogleIdToken() {
+  const keyId = "callback-test-google-key";
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"]
+  );
+  const issuedAt = Math.floor(Date.now() / MS_PER_SECOND);
+  const header = encodeBase64Url(JSON.stringify({ alg: "RS256", kid: keyId, typ: "JWT" }));
+  const payload = encodeBase64Url(
+    JSON.stringify({
+      iss: "https://accounts.google.com",
+      aud: GOOGLE_CLIENT_ID,
+      sub: GOOGLE_SUBJECT,
+      email: "Google.User@Example.COM",
+      email_verified: true,
+      name: "Google User",
+      picture: "https://images.example/google-user",
+      iat: issuedAt,
+      exp: issuedAt + 300,
+    })
+  );
+  const signingInput = `${header}.${payload}`;
+  const signature = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    keyPair.privateKey,
+    new TextEncoder().encode(signingInput)
+  );
+  const publicKey = await crypto.subtle.exportKey("jwk", keyPair.publicKey);
+  return {
+    token: `${signingInput}.${encodeBase64Url(new Uint8Array(signature))}`,
+    publicKey: { ...publicKey, alg: "RS256", kid: keyId, use: "sig" },
+  };
+}
 
 async function signedWebRequest(
   path: string,
@@ -48,8 +101,12 @@ function cookiePair(response: Response, cookieName: string): string {
   return cookie.split(";", 1)[0];
 }
 
-beforeAll(() => {
-  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+beforeAll(async () => {
+  const signedToken = await createSignedGoogleIdToken();
+  googleIdToken = signedToken.token;
+  googlePublicKey = signedToken.publicKey;
+
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
     const url = input instanceof Request ? input.url : String(input);
     if (url === "https://github.com/login/oauth/access_token") {
       return Response.json({
@@ -78,6 +135,27 @@ beforeAll(() => {
         },
       ]);
     }
+    if (url === "https://oauth2.googleapis.com/token") {
+      const body = new URLSearchParams(
+        input instanceof Request ? await input.clone().text() : String(init?.body ?? "")
+      );
+      expect(body.get("grant_type")).toBe("authorization_code");
+      expect(body.get("code")).toBe("google-authorization-code");
+      expect(body.get("client_id")).toBe(GOOGLE_CLIENT_ID);
+      expect(body.get("client_secret")).toBe("google-client-secret");
+      expect(body.get("redirect_uri")).toBe(`${PUBLIC_WEB_ORIGIN}/api/auth/callback/google`);
+      expect(body.get("code_verifier")).toBeTruthy();
+      return Response.json({
+        access_token: "google-access-token",
+        token_type: "Bearer",
+        expires_in: 3600,
+        scope: "openid email profile",
+        id_token: googleIdToken,
+      });
+    }
+    if (url === "https://www.googleapis.com/oauth2/v3/certs") {
+      return Response.json({ keys: [googlePublicKey] });
+    }
     throw new Error(`Unexpected external request: ${url}`);
   });
 });
@@ -89,6 +167,99 @@ afterAll(() => {
 });
 
 describe("browser auth callback", () => {
+  it("creates and resolves a Google browser session through an authorization-code callback", async () => {
+    const initiationResponse = await handleRequest(
+      await signedWebRequest("/api/auth/sign-in/social", {
+        method: "POST",
+        body: JSON.stringify({
+          provider: "google",
+          callbackURL: "/after-sign-in",
+          disableRedirect: true,
+        }),
+      }),
+      env
+    );
+    expect(initiationResponse.status).toBe(200);
+    const providerUrl = new URL((await initiationResponse.json<{ url: string }>()).url);
+    const state = providerUrl.searchParams.get("state");
+    expect(state).toBeTruthy();
+    expect(providerUrl.searchParams.get("code_challenge_method")).toBe("S256");
+    const stateCookie = cookiePair(initiationResponse, "__Secure-openinspect.state");
+
+    const callbackResponse = await handleRequest(
+      await signedWebRequest(
+        `/api/auth/callback/google?code=google-authorization-code&state=${encodeURIComponent(state ?? "")}`,
+        {
+          method: "GET",
+          cookie: stateCookie,
+        }
+      ),
+      env
+    );
+
+    expect(callbackResponse.status).toBe(302);
+    expect(callbackResponse.headers.get("Location")).toBe("/after-sign-in");
+    const sessionCookie = cookiePair(callbackResponse, "__Secure-openinspect.session_token");
+    const sessionResponse = await handleRequest(
+      await signedWebRequest("/api/auth/get-session", {
+        method: "GET",
+        cookie: sessionCookie,
+      }),
+      env
+    );
+    expect(sessionResponse.status).toBe(200);
+    const session = await sessionResponse.json<{
+      user: { id: string; name: string; email: string; image: string };
+      session: { id: string; userId: string };
+    }>();
+    expect(isCanonicalUserId(session.user.id)).toBe(true);
+    expect(session).toMatchObject({
+      user: {
+        name: "Google User",
+        email: "google.user@example.com",
+        image: "https://images.example/google-user",
+      },
+      session: { userId: session.user.id },
+    });
+
+    await expect(
+      env.DB.prepare(
+        `SELECT accountId, providerId, userId
+         FROM auth_accounts
+         WHERE providerId = ?`
+      )
+        .bind("google")
+        .first()
+    ).resolves.toEqual({
+      accountId: GOOGLE_SUBJECT,
+      providerId: "google",
+      userId: session.user.id,
+    });
+    await expect(
+      env.DB.prepare(
+        `SELECT userId
+         FROM auth_sessions
+         WHERE id = ?`
+      )
+        .bind(session.session.id)
+        .first()
+    ).resolves.toEqual({ userId: session.user.id });
+    await expect(
+      env.DB.prepare(
+        `SELECT id, display_name, email, avatar_url
+         FROM users
+         WHERE id = ?`
+      )
+        .bind(session.user.id)
+        .first()
+    ).resolves.toEqual({
+      id: session.user.id,
+      display_name: "Google User",
+      email: "google.user@example.com",
+      avatar_url: "https://images.example/google-user",
+    });
+  });
+
   it("creates and resolves a GitHub browser session through the signed proxy", async () => {
     const initiationBody = JSON.stringify({
       provider: "github",

--- a/packages/control-plane/test/integration/browser-auth-callback.test.ts
+++ b/packages/control-plane/test/integration/browser-auth-callback.test.ts
@@ -8,63 +8,16 @@ import { UserStore } from "../../src/db/user-store";
 import { handleRequest } from "../../src/router";
 import { resolveGitHubEnrichmentForRequest } from "../../src/session/identity";
 import { cleanD1Tables } from "./cleanup";
+import { createSignedGoogleIdToken } from "./google-id-token";
 
 const CONTROL_PLANE_ORIGIN = "https://control-plane.test.local";
 const PUBLIC_WEB_ORIGIN = "https://app.test.local";
 const WEB_SERVICE_SECRET = "test-service-secret-web";
 const GOOGLE_CLIENT_ID = "google-client-id";
 const GOOGLE_SUBJECT = "google-subject";
-const MS_PER_SECOND = 1000;
 
 let googleIdToken = "";
 let googlePublicKey: JsonWebKey;
-
-function encodeBase64Url(value: string | Uint8Array): string {
-  const bytes = typeof value === "string" ? new TextEncoder().encode(value) : value;
-  let binary = "";
-  for (const byte of bytes) binary += String.fromCharCode(byte);
-  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
-}
-
-async function createSignedGoogleIdToken() {
-  const keyId = "callback-test-google-key";
-  const keyPair = await crypto.subtle.generateKey(
-    {
-      name: "RSASSA-PKCS1-v1_5",
-      modulusLength: 2048,
-      publicExponent: new Uint8Array([1, 0, 1]),
-      hash: "SHA-256",
-    },
-    true,
-    ["sign", "verify"]
-  );
-  const issuedAt = Math.floor(Date.now() / MS_PER_SECOND);
-  const header = encodeBase64Url(JSON.stringify({ alg: "RS256", kid: keyId, typ: "JWT" }));
-  const payload = encodeBase64Url(
-    JSON.stringify({
-      iss: "https://accounts.google.com",
-      aud: GOOGLE_CLIENT_ID,
-      sub: GOOGLE_SUBJECT,
-      email: "Google.User@Example.COM",
-      email_verified: true,
-      name: "Google User",
-      picture: "https://images.example/google-user",
-      iat: issuedAt,
-      exp: issuedAt + 300,
-    })
-  );
-  const signingInput = `${header}.${payload}`;
-  const signature = await crypto.subtle.sign(
-    "RSASSA-PKCS1-v1_5",
-    keyPair.privateKey,
-    new TextEncoder().encode(signingInput)
-  );
-  const publicKey = await crypto.subtle.exportKey("jwk", keyPair.publicKey);
-  return {
-    token: `${signingInput}.${encodeBase64Url(new Uint8Array(signature))}`,
-    publicKey: { ...publicKey, alg: "RS256", kid: keyId, use: "sig" },
-  };
-}
 
 async function signedWebRequest(
   path: string,
@@ -102,7 +55,17 @@ function cookiePair(response: Response, cookieName: string): string {
 }
 
 beforeAll(async () => {
-  const signedToken = await createSignedGoogleIdToken();
+  const signedToken = await createSignedGoogleIdToken({
+    audience: GOOGLE_CLIENT_ID,
+    keyId: "callback-test-google-key",
+    claims: {
+      sub: GOOGLE_SUBJECT,
+      email: "Google.User@Example.COM",
+      email_verified: true,
+      name: "Google User",
+      picture: "https://images.example/google-user",
+    },
+  });
   googleIdToken = signedToken.token;
   googlePublicKey = signedToken.publicKey;
 

--- a/packages/control-plane/test/integration/browser-auth-callback.test.ts
+++ b/packages/control-plane/test/integration/browser-auth-callback.test.ts
@@ -15,9 +15,12 @@ const PUBLIC_WEB_ORIGIN = "https://app.test.local";
 const WEB_SERVICE_SECRET = "test-service-secret-web";
 const GOOGLE_CLIENT_ID = "google-client-id";
 const GOOGLE_SUBJECT = "google-subject";
+const MS_PER_SECOND = 1000;
+const GOOGLE_ACCESS_TOKEN_LIFETIME_MS = 60 * 60 * MS_PER_SECOND;
 
 let googleIdToken = "";
 let googlePublicKey: JsonWebKey;
+let googleCertRequestCount = 0;
 
 async function signedWebRequest(
   path: string,
@@ -111,19 +114,23 @@ beforeAll(async () => {
       return Response.json({
         access_token: "google-access-token",
         token_type: "Bearer",
-        expires_in: 3600,
+        expires_in: GOOGLE_ACCESS_TOKEN_LIFETIME_MS / MS_PER_SECOND,
         scope: "openid email profile",
         id_token: googleIdToken,
       });
     }
     if (url === "https://www.googleapis.com/oauth2/v3/certs") {
+      googleCertRequestCount += 1;
       return Response.json({ keys: [googlePublicKey] });
     }
     throw new Error(`Unexpected external request: ${url}`);
   });
 });
 
-beforeEach(cleanD1Tables);
+beforeEach(async () => {
+  await cleanD1Tables();
+  googleCertRequestCount = 0;
+});
 
 afterAll(() => {
   vi.restoreAllMocks();
@@ -162,6 +169,7 @@ describe("browser auth callback", () => {
 
     expect(callbackResponse.status).toBe(302);
     expect(callbackResponse.headers.get("Location")).toBe("/after-sign-in");
+    expect(googleCertRequestCount).toBeGreaterThan(0);
     const sessionCookie = cookiePair(callbackResponse, "__Secure-openinspect.session_token");
     const sessionResponse = await handleRequest(
       await signedWebRequest("/api/auth/get-session", {

--- a/packages/control-plane/test/integration/browser-auth.test.ts
+++ b/packages/control-plane/test/integration/browser-auth.test.ts
@@ -8,63 +8,13 @@ import {
   SESSION_UPDATE_AGE_MS,
   createUserAuth,
 } from "../../src/auth/user/better-auth";
+import { createSignedGoogleIdToken } from "./google-id-token";
 
 const PUBLIC_WEB_ORIGIN = "https://web.test.local";
 const SECRET = "test-only-better-auth-secret-with-at-least-32-characters";
 const MS_PER_SECOND = 1000;
 const UNUSED_PROFILE_RESOLVER = async () => null;
 const UNUSED_USER_PROJECTION = { project: async () => {} };
-
-function encodeBase64Url(value: string | Uint8Array): string {
-  const bytes = typeof value === "string" ? new TextEncoder().encode(value) : value;
-  let binary = "";
-  for (const byte of bytes) binary += String.fromCharCode(byte);
-  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
-}
-
-async function createSignedGoogleIdToken(clientId: string) {
-  const keyId = "test-google-key";
-  const keyPair = await crypto.subtle.generateKey(
-    {
-      name: "RSASSA-PKCS1-v1_5",
-      modulusLength: 2048,
-      publicExponent: new Uint8Array([1, 0, 1]),
-      hash: "SHA-256",
-    },
-    true,
-    ["sign", "verify"]
-  );
-  const issuedAt = Math.floor(Date.now() / MS_PER_SECOND);
-  const header = encodeBase64Url(JSON.stringify({ alg: "RS256", kid: keyId, typ: "JWT" }));
-  const payload = encodeBase64Url(
-    JSON.stringify({
-      iss: "https://accounts.google.com",
-      aud: clientId,
-      sub: "direct-id-token-subject",
-      email: "direct-id-token@example.com",
-      email_verified: true,
-      name: "Direct ID Token User",
-      iat: issuedAt,
-      exp: issuedAt + 300,
-    })
-  );
-  const signingInput = `${header}.${payload}`;
-  const signature = await crypto.subtle.sign(
-    "RSASSA-PKCS1-v1_5",
-    keyPair.privateKey,
-    new TextEncoder().encode(signingInput)
-  );
-  const publicKey = await crypto.subtle.exportKey("jwk", keyPair.publicKey);
-  return {
-    token: `${signingInput}.${encodeBase64Url(new Uint8Array(signature))}`,
-    publicKey: {
-      ...publicKey,
-      alg: "RS256",
-      kid: keyId,
-      use: "sig",
-    },
-  };
-}
 
 const EXPECTED_COLUMNS = {
   auth_users: [
@@ -360,7 +310,15 @@ describe("browser authentication", () => {
 
   it("rejects direct Google ID-token sign-in without creating authentication state", async () => {
     const clientId = "google-client-id";
-    const { token, publicKey } = await createSignedGoogleIdToken(clientId);
+    const { token, publicKey } = await createSignedGoogleIdToken({
+      audience: clientId,
+      claims: {
+        sub: "direct-id-token-subject",
+        email: "direct-id-token@example.com",
+        email_verified: true,
+        name: "Direct ID Token User",
+      },
+    });
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = input instanceof Request ? input.url : String(input);
       if (url === "https://www.googleapis.com/oauth2/v3/certs") {

--- a/packages/control-plane/test/integration/google-id-token.ts
+++ b/packages/control-plane/test/integration/google-id-token.ts
@@ -1,4 +1,5 @@
 const MS_PER_SECOND = 1000;
+const GOOGLE_ID_TOKEN_LIFETIME_MS = 5 * 60 * MS_PER_SECOND;
 
 interface GoogleIdTokenClaims {
   readonly sub: string;
@@ -42,7 +43,7 @@ export async function createSignedGoogleIdToken({
       aud: audience,
       ...claims,
       iat: issuedAt,
-      exp: issuedAt + 300,
+      exp: issuedAt + GOOGLE_ID_TOKEN_LIFETIME_MS / MS_PER_SECOND,
     })
   );
   const signingInput = `${header}.${payload}`;

--- a/packages/control-plane/test/integration/google-id-token.ts
+++ b/packages/control-plane/test/integration/google-id-token.ts
@@ -1,0 +1,59 @@
+const MS_PER_SECOND = 1000;
+
+interface GoogleIdTokenClaims {
+  readonly sub: string;
+  readonly email: string;
+  readonly email_verified: boolean;
+  readonly name?: string;
+  readonly picture?: string;
+}
+
+function encodeBase64Url(value: string | Uint8Array): string {
+  const bytes = typeof value === "string" ? new TextEncoder().encode(value) : value;
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+export async function createSignedGoogleIdToken({
+  audience,
+  claims,
+  keyId = "test-google-key",
+}: {
+  audience: string;
+  claims: GoogleIdTokenClaims;
+  keyId?: string;
+}) {
+  const keyPair = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"]
+  );
+  const issuedAt = Math.floor(Date.now() / MS_PER_SECOND);
+  const header = encodeBase64Url(JSON.stringify({ alg: "RS256", kid: keyId, typ: "JWT" }));
+  const payload = encodeBase64Url(
+    JSON.stringify({
+      iss: "https://accounts.google.com",
+      aud: audience,
+      ...claims,
+      iat: issuedAt,
+      exp: issuedAt + 300,
+    })
+  );
+  const signingInput = `${header}.${payload}`;
+  const signature = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    keyPair.privateKey,
+    new TextEncoder().encode(signingInput)
+  );
+  const publicKey = await crypto.subtle.exportKey("jwk", keyPair.publicKey);
+  return {
+    token: `${signingInput}.${encodeBase64Url(new Uint8Array(signature))}`,
+    publicKey: { ...publicKey, alg: "RS256", kid: keyId, use: "sig" },
+  };
+}


### PR DESCRIPTION
## Summary
- add a complete Google OAuth authorization-code callback integration test
- verify the token exchange includes the expected code, credentials, callback URI, and PKCE verifier
- validate a real RSA-signed Google ID token through the mocked Google JWK endpoint
- assert canonical user, Better Auth account, session persistence, cookie issuance, and session resolution

## Validation
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/browser-auth-callback.test.ts`
- `npm run test:integration -w @open-inspect/control-plane` (57 files, 658 tests)
- `npm run typecheck -w @open-inspect/control-plane`
- `npx prettier --check packages/control-plane/test/integration/browser-auth-callback.test.ts`

Closes COL-23.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/580b370d49ee3f45b4011127389fe2d8)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for Google authorization-code sign-in, including initiation and OAuth callback handling.
  * Verified redirect behavior, session cookie issuance, returned session/profile details, and persistence of authentication/account records.
  * Strengthened OAuth token exchange mocking by validating request grant type, code, client credentials, redirect URI, and code verifier; also verified Google certs retrieval is exercised.
  * Reworked Google ID-token generation tests to use a shared helper with explicit audience and JWT claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->