### PR TITLE
fix(slack-bot): split long answers across sections instead of truncating at 2000 chars

### DIFF
--- a/packages/slack-bot/src/completion/blocks.test.ts
+++ b/packages/slack-bot/src/completion/blocks.test.ts
@@ -181,3 +181,86 @@ describe("buildCompletionBlocks", () => {
     expect(createPrButton?.url).toBe(fallbackUrl);
   });
 });
+
+describe("long response handling", () => {
+  // Regression: responses were capped at 2000 chars in a single section, so
+  // multi-part answers (headings + citations) stopped mid-sentence even though
+  // Slack accepts 3000 per section and 50 blocks per message.
+  const sectionTexts = (blocks: ReturnType<typeof buildCompletionBlocks>): string[] =>
+    blocks
+      .filter((block) => block.type === "section")
+      .map((block) => block.text?.text ?? "")
+      // Drop the artifacts section, which is built separately.
+      .filter((text) => !text.startsWith("*Created:*"));
+
+  it("keeps a long multi-paragraph answer whole across several sections", () => {
+    const paragraphs = Array.from(
+      { length: 8 },
+      (_, i) => `## Section ${i}\n\n${"detail ".repeat(120)}`
+    );
+    const textContent = paragraphs.join("\n\n");
+    const blocks = buildCompletionBlocks(
+      "sess-1",
+      { ...BASE_RESPONSE, textContent },
+      BASE_CONTEXT,
+      "https://inspect.example.com"
+    );
+    const texts = sectionTexts(blocks);
+    expect(texts.length).toBeGreaterThan(1);
+    expect(texts.join("\n\n")).toContain("Section 7");
+    expect(texts.join(" ")).not.toContain("truncated");
+  });
+
+  it("never exceeds Slack's per-section character limit", () => {
+    const textContent = "x".repeat(25_000);
+    const blocks = buildCompletionBlocks(
+      "sess-2",
+      { ...BASE_RESPONSE, textContent },
+      BASE_CONTEXT,
+      "https://inspect.example.com"
+    );
+    for (const text of sectionTexts(blocks)) {
+      expect(text.length).toBeLessThanOrEqual(3000);
+    }
+  });
+
+  it("truncates with a pointer to the session once the block budget is spent", () => {
+    const textContent = Array.from({ length: 200 }, () => "q".repeat(2900)).join("\n\n");
+    const blocks = buildCompletionBlocks(
+      "sess-3",
+      { ...BASE_RESPONSE, textContent },
+      BASE_CONTEXT,
+      "https://inspect.example.com"
+    );
+    const texts = sectionTexts(blocks);
+    expect(texts.length).toBeLessThanOrEqual(20);
+    expect(texts[texts.length - 1]).toContain("truncated");
+    // The View Session button is the escape hatch for the remainder.
+    expect(getActionElements(blocks).some((el) => el.action_id === "view_session")).toBe(true);
+  });
+
+  it("balances code fences when a fenced block spans a split", () => {
+    const code = ["```ts", ...Array.from({ length: 300 }, (_, i) => `const x${i} = ${i};`), "```"];
+    const blocks = buildCompletionBlocks(
+      "sess-4",
+      { ...BASE_RESPONSE, textContent: code.join("\n") },
+      BASE_CONTEXT,
+      "https://inspect.example.com"
+    );
+    const texts = sectionTexts(blocks);
+    expect(texts.length).toBeGreaterThan(1);
+    for (const text of texts) {
+      expect((text.match(/```/g) ?? []).length % 2).toBe(0);
+    }
+  });
+
+  it("still renders a placeholder for an empty response", () => {
+    const blocks = buildCompletionBlocks(
+      "sess-5",
+      { ...BASE_RESPONSE, textContent: "   " },
+      BASE_CONTEXT,
+      "https://inspect.example.com"
+    );
+    expect(sectionTexts(blocks)[0]).toBe("_Agent completed._");
+  });
+});

--- a/packages/slack-bot/src/completion/blocks.ts
+++ b/packages/slack-bot/src/completion/blocks.ts
@@ -25,9 +25,25 @@ const STATUS_EMOJI = {
 /**
  * Truncation limits.
  */
-const TRUNCATE_LIMIT = 2000;
 const FALLBACK_TEXT_LIMIT = 150;
 const ERROR_FOOTER_LIMIT = 200;
+
+/**
+ * Slack's hard cap on a section block's mrkdwn text. Responses longer than this
+ * are split across consecutive section blocks rather than truncated, so a long
+ * answer arrives whole instead of stopping mid-sentence.
+ */
+const SECTION_TEXT_MAX_CHARS = 3000;
+
+/**
+ * How many section blocks a response may occupy. Slack allows 50 blocks per
+ * message; the rest of this builder contributes at most 4 (artifacts, tools,
+ * footer, actions), so this leaves comfortable headroom. Beyond this the tail is
+ * truncated and the View Session button is the way to read the whole thing.
+ */
+const MAX_RESPONSE_SECTIONS = 20;
+
+const CODE_FENCE_RE = /^```/;
 
 /**
  * Build Slack blocks for completion message.
@@ -40,12 +56,15 @@ export function buildCompletionBlocks(
 ): SlackBlock[] {
   const blocks: SlackBlock[] = [];
 
-  // 1. Response text (truncated)
-  const text = truncateForSlack(response.textContent, TRUNCATE_LIMIT);
-  blocks.push({
-    type: "section",
-    text: { type: "mrkdwn", text: text || "_Agent completed._" },
-  });
+  // 1. Response text, split across as many section blocks as it needs
+  const sections = splitIntoSlackSections(response.textContent);
+  if (sections.length === 0) {
+    blocks.push({ type: "section", text: { type: "mrkdwn", text: "_Agent completed._" } });
+  } else {
+    for (const section of sections) {
+      blocks.push({ type: "section", text: { type: "mrkdwn", text: section } });
+    }
+  }
 
   // 2. Artifacts (PRs, branches)
   if (response.artifacts.length > 0) {
@@ -131,16 +150,110 @@ export function getFallbackText(response: AgentResponse): string {
 }
 
 /**
- * Truncate text for Slack display with smart sentence breaks.
+ * Split agent prose into Slack section blocks, preferring paragraph boundaries.
+ *
+ * Long answers used to be cut at 2000 characters in a single block, which stopped
+ * multi-part answers mid-sentence even though Slack accepts far more. Splitting
+ * greedily on blank lines keeps headings with their prose; paragraphs that are
+ * themselves oversized fall back to line boundaries, then to a hard slice.
+ *
+ * Fenced code blocks are closed at the end of a section and reopened at the start
+ * of the next, so a split inside a fence doesn't leak monospace formatting across
+ * the rest of the message.
+ *
+ * Returns [] for empty input so the caller can render its own placeholder.
  */
-function truncateForSlack(text: string, maxLen: number): string {
-  if (text.length <= maxLen) return text;
-  const truncated = text.slice(0, maxLen);
-  const lastPeriod = truncated.lastIndexOf(". ");
-  if (lastPeriod > maxLen * 0.7) {
-    return truncated.slice(0, lastPeriod + 1) + "\n\n_...truncated_";
+export function splitIntoSlackSections(
+  text: string,
+  maxChars: number = SECTION_TEXT_MAX_CHARS,
+  maxSections: number = MAX_RESPONSE_SECTIONS
+): string[] {
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+  if (trimmed.length <= maxChars) return [trimmed];
+
+  const sections: string[] = [];
+  let current = "";
+  // Tracks whether `current` ends inside a fence, so the split can repair it.
+  let fenceOpen = false;
+  let fenceInfo = "";
+
+  const flush = () => {
+    if (!current) return;
+    sections.push(fenceOpen ? `${current}\n\`\`\`` : current);
+    current = "";
+  };
+
+  const appendChunk = (chunk: string) => {
+    const reopen = fenceOpen ? `\`\`\`${fenceInfo}\n` : "";
+    const candidate = current ? `${current}\n\n${chunk}` : `${reopen}${chunk}`;
+    if (candidate.length <= maxChars) {
+      current = candidate;
+      return;
+    }
+    flush();
+    const withReopen = `${fenceOpen ? `\`\`\`${fenceInfo}\n` : ""}${chunk}`;
+    current = withReopen.length <= maxChars ? withReopen : withReopen.slice(0, maxChars);
+  };
+
+  // Track fence state per line so `fenceOpen` is accurate at every boundary.
+  const consumeFences = (chunk: string) => {
+    for (const line of chunk.split("\n")) {
+      if (CODE_FENCE_RE.test(line.trimStart())) {
+        if (fenceOpen) {
+          fenceOpen = false;
+          fenceInfo = "";
+        } else {
+          fenceOpen = true;
+          fenceInfo = line.trimStart().slice(3).trim();
+        }
+      }
+    }
+  };
+
+  for (const paragraph of trimmed.split(/\n{2,}/)) {
+    if (paragraph.length <= maxChars) {
+      appendChunk(paragraph);
+      consumeFences(paragraph);
+      continue;
+    }
+    // Oversized paragraph (long table, big code block): break on lines.
+    let buffer = "";
+    for (const line of paragraph.split("\n")) {
+      const candidate = buffer ? `${buffer}\n${line}` : line;
+      if (candidate.length <= maxChars) {
+        buffer = candidate;
+        continue;
+      }
+      if (buffer) {
+        appendChunk(buffer);
+        consumeFences(buffer);
+      }
+      // A single line longer than the cap has to be sliced.
+      let rest = line;
+      while (rest.length > maxChars) {
+        appendChunk(rest.slice(0, maxChars));
+        consumeFences(rest.slice(0, maxChars));
+        rest = rest.slice(maxChars);
+      }
+      buffer = rest;
+    }
+    if (buffer) {
+      appendChunk(buffer);
+      consumeFences(buffer);
+    }
   }
-  return truncated + "...\n\n_...truncated_";
+  flush();
+
+  if (sections.length <= maxSections) return sections;
+  const kept = sections.slice(0, maxSections);
+  const last = kept[maxSections - 1];
+  const marker = "\n\n_...truncated — open the session to read the rest_";
+  kept[maxSections - 1] =
+    last.length + marker.length <= maxChars
+      ? last + marker
+      : last.slice(0, maxChars - marker.length) + marker;
+  return kept;
 }
 
 /**


### PR DESCRIPTION
## Problem

Completion messages put the agent's whole response into a **single** Slack section block capped at 2000 characters (`packages/slack-bot/src/completion/blocks.ts`):

```ts
const TRUNCATE_LIMIT = 2000;
const text = truncateForSlack(response.textContent, TRUNCATE_LIMIT);
```

Slack allows **3000 characters per section block** and **50 blocks per message**, so a threaded reply can carry far more than 2000 characters. Any answer longer than that stops mid-sentence — I hit this asking a research question whose answer cited several sources, and the reply was cut off partway through the final paragraph.

Raising the constant to 3000 would only move the wall, so this splits instead.

## Change

- Splits the response on paragraph boundaries into consecutive section blocks, so headings stay with their prose.
- Oversized paragraphs (long tables, large code blocks) fall back to line boundaries, then to a hard slice for a single unbroken line.
- Fenced code blocks are closed at the end of a section and reopened at the start of the next, so a split inside a fence can't leak monospace formatting through the rest of the message.
- Past `MAX_RESPONSE_SECTIONS` (20) the tail is truncated with a pointer to the session — the existing **View Session** button already serves as the escape hatch, so nothing is unreachable.
- Empty responses still render the `_Agent completed._` placeholder.
- Removes the now-unused local `truncateForSlack` helper (the identically-named export in `@open-inspect/shared` is a different function and is untouched).

Behaviour for responses under 3000 characters is unchanged: one section block, same as before.

## Tests

`packages/slack-bot/src/completion/blocks.test.ts` gains five cases:

- a long multi-paragraph answer survives whole across several sections
- no section exceeds Slack's per-section limit
- the block budget is enforced, with a truncation marker and the session link
- code fences stay balanced when a fenced block spans a split
- an empty response still renders the placeholder

`vitest run src/completion/blocks.test.ts` → 11 passed (6 existing + 5 new). `npm run lint` and `npm run typecheck` clean.

Note: `packages/slack-bot/src/index.test.ts` has 10 pre-existing failures on `main` (POST /events, POST /interactions) unrelated to this change — verified they fail identically without it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Long Slack responses are now split across multiple readable sections while preserving paragraph formatting and code blocks.
  * Responses respect Slack’s section size limits and provide a link to view the full session when content exceeds the message limit.

* **Bug Fixes**
  * Empty or whitespace-only responses now display an “Agent completed.” placeholder.
  * Improved handling prevents content loss when splitting lengthy responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->