### PR TITLE
fix(slack): preserve forwarded message boundaries

### DIFF
--- a/packages/shared/src/slack/client.ts
+++ b/packages/shared/src/slack/client.ts
@@ -412,11 +412,11 @@ export interface SlackMessageFile {
  * A secondary attachment on a Slack message (subset of fields we use).
  *
  * Two very different things arrive in this array. Sharing or forwarding a
- * message produces a *message* attachment — flagged `is_share`/`is_msg_unfurl`,
- * carrying the shared message's author and body — which is the only place that
- * body exists on the new message. Posting a link produces a *link* unfurl,
- * which restates a page the text already links to. Callers that read message
- * bodies must tell the two apart.
+ * message produces a *message* attachment flagged `is_share` (and may also set
+ * `is_msg_unfurl`), carrying the shared message's author and body — which is the
+ * only place that body exists on the new message. A pasted Slack message link
+ * produces an attachment with `is_msg_unfurl` but not `is_share`. Callers that
+ * read message bodies must use `is_share` as the positive discriminator.
  */
 export interface SlackMessageAttachment {
   /** Set when the attachment is a shared/forwarded Slack message. */

--- a/packages/slack-bot/src/events/message-handler.ts
+++ b/packages/slack-bot/src/events/message-handler.ts
@@ -20,7 +20,11 @@ import {
 import { createClassifier } from "../classifier";
 import { loadTargetCatalog } from "../classifier/catalog";
 import { stripMentions } from "../dm-utils";
-import { collectForwardedMessages, FORWARD_ONLY_PROMPT_TEXT } from "../forwarded-messages";
+import {
+  collectForwardedMessages,
+  FORWARD_ONLY_PROMPT_TEXT,
+  type ForwardedMessages,
+} from "../forwarded-messages";
 import { createLogger } from "../logger";
 import {
   buildWorkingMessageBlocks,
@@ -97,20 +101,26 @@ async function fetchThreadHistory(
   }
 }
 
-interface IncomingMessageParams {
+interface IncomingMessageContent {
   text: string;
+  /** Images attached to the Slack message, normalized at event ingress. */
+  images: SlackImageAttachment[];
+  /** Quoted bodies, provenance, and files recovered from explicit Slack shares. */
+  forwarded: ForwardedMessages;
+}
+
+function hasRunnableContent(content: IncomingMessageContent): boolean {
+  return Boolean(content.text) || content.images.length > 0 || content.forwarded.hasBody;
+}
+
+interface IncomingMessageParams {
+  content: IncomingMessageContent;
   user: string;
   channel: string;
   ts: string;
   threadTs?: string;
   channelName?: string;
   channelDescription?: string;
-  /** Images attached to the Slack message, normalized at event ingress. */
-  images: SlackImageAttachment[];
-  /** Quoted entries for the messages forwarded with this request. */
-  forwardedMessages: string[];
-  /** Whether a forwarded entry contains real text rather than only images. */
-  forwardedHasBody: boolean;
   env: Env;
   traceId?: string;
   scheduleBackground: BackgroundTaskScheduler;
@@ -124,21 +134,19 @@ interface IncomingMessageParams {
  */
 async function handleIncomingMessage(params: IncomingMessageParams): Promise<void> {
   const {
-    text: messageText,
+    content,
     user,
     channel,
     ts,
     threadTs,
     channelName,
     channelDescription,
-    images,
-    forwardedMessages,
-    forwardedHasBody,
     env,
     traceId,
     scheduleBackground,
   } = params;
-  if (!messageText && images.length === 0 && !forwardedHasBody) {
+  const { text: messageText, images, forwarded } = content;
+  if (!hasRunnableContent(content)) {
     await postMessage(
       env.SLACK_BOT_TOKEN,
       channel,
@@ -149,13 +157,13 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
   }
   // A message with no text of its own still needs prompt content for the agent
   // to act on; what it carried instead decides which stand-in to use.
-  const imageOnly = !messageText && !forwardedHasBody;
+  const imageOnly = !messageText && !forwarded.hasBody;
   const requestText =
     messageText ||
-    (forwardedMessages.length > 0 ? FORWARD_ONLY_PROMPT_TEXT : IMAGE_ONLY_PROMPT_TEXT);
+    (forwarded.entries.length > 0 ? FORWARD_ONLY_PROMPT_TEXT : IMAGE_ONLY_PROMPT_TEXT);
   // Forwarded bodies lead: the user's own text ("deal with this") is the
   // instruction and reads as one when it comes last.
-  const promptText = formatForwardedContext(forwardedMessages) + requestText;
+  const promptText = formatForwardedContext(forwarded.entries) + requestText;
 
   if (threadTs) {
     const existingSession = await lookupThreadSession(env, channel, threadTs);
@@ -384,8 +392,8 @@ export async function handleAppMention(
   // A forwarded message's own images are Slack-hosted message files, so they
   // join the message's own images on the single attachment path.
   const images = toImageAttachments([...details.files, ...forwarded.files], traceId);
-  const forwardedMessages = forwarded.entries;
-  if (!messageText && (images.length > 0 || forwardedMessages.length > 0)) {
+  const content = { text: messageText, images, forwarded };
+  if (!messageText && hasRunnableContent(content)) {
     scheduleStartingStatus(scheduleBackground, env, event.channel, threadKey, traceId);
   }
   let channelName: string | undefined;
@@ -395,16 +403,13 @@ export async function handleAppMention(
     channelDescription = channelInfo.channel.topic?.value || channelInfo.channel.purpose?.value;
   }
   await handleIncomingMessage({
-    text: messageText,
+    content,
     user: event.user,
     channel: event.channel,
     ts: event.ts,
     threadTs: event.thread_ts,
     channelName,
     channelDescription,
-    images,
-    forwardedMessages,
-    forwardedHasBody: forwarded.hasBody,
     env,
     traceId,
     scheduleBackground,
@@ -432,20 +437,16 @@ export async function handleDirectMessage(
   const messageText = stripMentions(event.text);
   const forwarded = collectForwardedMessages(event.attachments);
   const images = toImageAttachments([...(event.files ?? []), ...forwarded.files], traceId);
-  const forwardedMessages = forwarded.entries;
-  const hasContent = Boolean(messageText) || images.length > 0 || forwardedMessages.length > 0;
+  const content = { text: messageText, images, forwarded };
   const threadKey = event.thread_ts || event.ts;
-  if (hasContent)
+  if (hasRunnableContent(content))
     scheduleStartingStatus(scheduleBackground, env, event.channel, threadKey, traceId);
   await handleIncomingMessage({
-    text: messageText,
+    content,
     user: event.user,
     channel: event.channel,
     ts: event.ts,
     threadTs: event.thread_ts,
-    images,
-    forwardedMessages,
-    forwardedHasBody: forwarded.hasBody,
     env,
     traceId,
     scheduleBackground,

--- a/packages/slack-bot/src/events/message-handler.ts
+++ b/packages/slack-bot/src/events/message-handler.ts
@@ -109,6 +109,8 @@ interface IncomingMessageParams {
   images: SlackImageAttachment[];
   /** Quoted entries for the messages forwarded with this request. */
   forwardedMessages: string[];
+  /** Whether a forwarded entry contains real text rather than only images. */
+  forwardedHasBody: boolean;
   env: Env;
   traceId?: string;
   scheduleBackground: BackgroundTaskScheduler;
@@ -131,11 +133,12 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
     channelDescription,
     images,
     forwardedMessages,
+    forwardedHasBody,
     env,
     traceId,
     scheduleBackground,
   } = params;
-  if (!messageText && images.length === 0 && forwardedMessages.length === 0) {
+  if (!messageText && images.length === 0 && !forwardedHasBody) {
     await postMessage(
       env.SLACK_BOT_TOKEN,
       channel,
@@ -146,7 +149,7 @@ async function handleIncomingMessage(params: IncomingMessageParams): Promise<voi
   }
   // A message with no text of its own still needs prompt content for the agent
   // to act on; what it carried instead decides which stand-in to use.
-  const imageOnly = !messageText && forwardedMessages.length === 0;
+  const imageOnly = !messageText && !forwardedHasBody;
   const requestText =
     messageText ||
     (forwardedMessages.length > 0 ? FORWARD_ONLY_PROMPT_TEXT : IMAGE_ONLY_PROMPT_TEXT);
@@ -401,6 +404,7 @@ export async function handleAppMention(
     channelDescription,
     images,
     forwardedMessages,
+    forwardedHasBody: forwarded.hasBody,
     env,
     traceId,
     scheduleBackground,
@@ -441,6 +445,7 @@ export async function handleDirectMessage(
     threadTs: event.thread_ts,
     images,
     forwardedMessages,
+    forwardedHasBody: forwarded.hasBody,
     env,
     traceId,
     scheduleBackground,

--- a/packages/slack-bot/src/forwarded-messages.test.ts
+++ b/packages/slack-bot/src/forwarded-messages.test.ts
@@ -28,8 +28,12 @@ const sourceLine =
 
 describe("collectForwardedMessages", () => {
   it("returns nothing when the message carried no attachments", () => {
-    expect(collectForwardedMessages(undefined)).toEqual({ entries: [], files: [] });
-    expect(collectForwardedMessages([])).toEqual({ entries: [], files: [] });
+    expect(collectForwardedMessages(undefined)).toEqual({
+      entries: [],
+      files: [],
+      hasBody: false,
+    });
+    expect(collectForwardedMessages([])).toEqual({ entries: [], files: [], hasBody: false });
   });
 
   it("quotes the body under its author, channel, and a fetchable source", () => {
@@ -88,26 +92,30 @@ describe("collectForwardedMessages", () => {
     ]);
     expect(result.entries[0]).toContain("(no text)");
     expect(result.files).toEqual(files);
+    expect(result.hasBody).toBe(false);
   });
 
   it("falls back to Slack's plain-text rendering when the share has no text", () => {
     // Shared app posts keep their content in their own attachments/blocks, so
     // `text` can be empty while `fallback` still renders the message.
-    expect(collectForwardedMessages([shareAttachment({ text: "" })]).entries[0]).toContain(
+    const result = collectForwardedMessages([shareAttachment({ text: "" })]);
+    expect(result.entries[0]).toContain(
       "[February 9th, 2026 12:30 PM] ada: The analytics job has been failing since Tuesday"
     );
+    expect(result.hasBody).toBe(true);
   });
 
   it("skips link unfurls, which only restate a link the text already carries", () => {
     expect(
       collectForwardedMessages([
         {
-          text: "Monitor your errors",
-          fallback: "Rollbar",
-          from_url: "https://app.rollbar.com/a/acme/fix/item/api/431",
+          is_msg_unfurl: true,
+          text: "The referenced Slack message",
+          fallback: "[February 9th, 2026 12:30 PM] ada: The referenced Slack message",
+          from_url: "https://acme.slack.com/archives/C123/p1770652200000000",
         },
       ])
-    ).toEqual({ entries: [], files: [] });
+    ).toEqual({ entries: [], files: [], hasBody: false });
   });
 
   it("treats a whitespace-only body as absent so the fallback still shows", () => {
@@ -119,7 +127,7 @@ describe("collectForwardedMessages", () => {
   it("skips shares with neither a body nor files", () => {
     expect(
       collectForwardedMessages([shareAttachment({ text: "   ", fallback: undefined })])
-    ).toEqual({ entries: [], files: [] });
+    ).toEqual({ entries: [], files: [], hasBody: false });
   });
 
   it("keeps every shared message when several are forwarded at once", () => {
@@ -132,6 +140,7 @@ describe("collectForwardedMessages", () => {
     expect(result.entries[0]).toContain("first");
     expect(result.entries[1]).toContain("from Grace Hopper");
     expect(result.entries[1]).toContain("second");
+    expect(result.hasBody).toBe(true);
   });
 
   it("caps the number of shared messages folded into the prompt", () => {

--- a/packages/slack-bot/src/forwarded-messages.ts
+++ b/packages/slack-bot/src/forwarded-messages.ts
@@ -5,9 +5,10 @@
  * Forwarding a message does not put its body in the new message's `text` —
  * `text` holds only whatever the user typed alongside it ("take a look at
  * this"). The shared message arrives as a *message attachment* flagged
- * `is_share`/`is_msg_unfurl`, carrying its own author, source channel,
- * permalink, body, and any files it had. Reading only `text` therefore hands
- * the agent a bare pronoun and drops the thing the user was pointing at.
+ * `is_share` (and may also have `is_msg_unfurl`), carrying its own author,
+ * source channel, permalink, body, and any files it had. Reading only `text`
+ * therefore hands the agent a bare pronoun and drops the thing the user was
+ * pointing at.
  *
  * Everything the attachment carries is recovered: the body and its links are
  * quoted verbatim, images flow into the same session-attachment path as
@@ -39,6 +40,8 @@ const NO_TEXT_BODY = "(no text)";
 export interface ForwardedMessages {
   /** One quoted entry per shared message, for the prompt's context block. */
   entries: string[];
+  /** Whether at least one entry contains substantive text or fallback content. */
+  hasBody: boolean;
   /**
    * Files the shared messages carried, in Slack's `SlackMessageFile` shape.
    * They are Slack-hosted like any other message file, so they go through the
@@ -55,10 +58,10 @@ export interface ForwardedMessages {
 export function collectForwardedMessages(
   attachments: SlackMessageAttachment[] | undefined
 ): ForwardedMessages {
-  const result: ForwardedMessages = { entries: [], files: [] };
+  const result: ForwardedMessages = { entries: [], files: [], hasBody: false };
   if (!attachments?.length) return result;
   for (const attachment of attachments) {
-    if (!attachment.is_share && !attachment.is_msg_unfurl) continue;
+    if (!attachment.is_share) continue;
     // `fallback` is Slack's own plain-text rendering ("[date] user: body"); it
     // is the only body left when the shared message put its content somewhere
     // `text` does not reach, such as a bot post's own attachments. A `text` of
@@ -68,6 +71,7 @@ export function collectForwardedMessages(
     if (!body && files.length === 0) continue;
     result.entries.push(formatEntry(attachment, body || NO_TEXT_BODY));
     result.files.push(...files);
+    if (body) result.hasBody = true;
     if (result.entries.length === MAX_FORWARDED_MESSAGES) break;
   }
   return result;

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -1297,20 +1297,11 @@ describe("POST /events", () => {
     slackFetch.mockRestore();
   });
 
-  it("starts nothing for an image-only DM whose images all fail to download", async () => {
-    const order: string[] = [];
-    const slackFetch = mockSlackFetch(order, { fileDownloadStatus: 403 });
-    const env = makeSessionEnv(order);
-    const ctx = makeCtx();
-
-    const response = await app.fetch(
-      slackEventRequest({
-        type: "message",
+  it.each([
+    [
+      "a direct image-only DM loses every image",
+      {
         subtype: "file_share",
-        user: "U123",
-        channel: "D123",
-        ts: "444.555",
-        channel_type: "im",
         files: [
           {
             id: "F1",
@@ -1320,29 +1311,104 @@ describe("POST /events", () => {
             size: 16,
           },
         ],
-      }),
-      env,
-      ctx
-    );
+      },
+      true,
+      "didn't start on this request",
+    ],
+    [
+      "an image-only forwarded message loses every image",
+      {
+        text: "",
+        attachments: [
+          {
+            is_msg_unfurl: true,
+            is_share: true,
+            author_name: "Ada Lovelace",
+            channel_id: "C999",
+            ts: "222.111",
+            from_url: "https://acme.slack.com/archives/C999/p222111",
+            text: "",
+            files: [
+              {
+                id: "F1",
+                name: "chart.png",
+                mimetype: "image/png",
+                url_private: "https://files.slack.com/files-pri/T1-F1/chart.png",
+                size: 16,
+              },
+            ],
+          },
+        ],
+      },
+      true,
+      "didn't start on this request",
+    ],
+    [
+      "a body-less forward contains only unsupported files",
+      {
+        text: "",
+        attachments: [
+          {
+            is_msg_unfurl: true,
+            is_share: true,
+            author_name: "Ada Lovelace",
+            text: "",
+            files: [
+              {
+                id: "F1",
+                name: "incident.pdf",
+                mimetype: "application/pdf",
+                url_private: "https://files.slack.com/files-pri/T1-F1/incident.pdf",
+                size: 16,
+              },
+            ],
+          },
+        ],
+      },
+      false,
+      "Please include a message with your request",
+    ],
+  ] satisfies Array<[string, Record<string, unknown>, boolean, string]>)(
+    "starts nothing when %s",
+    async (_caseName, eventFields, downloadsImage, expectedMessage) => {
+      const order: string[] = [];
+      const slackFetch = mockSlackFetch(order, { fileDownloadStatus: 403 });
+      const env = makeSessionEnv(order);
+      const ctx = makeCtx();
 
-    expect(response.status).toBe(200);
-    await flushWaitUntil(ctx);
-
-    // The placeholder prompt would be meaningless with no image attached, so
-    // no session is created and the user is told nothing ran.
-    expect(order).toContain("filedownload");
-    expect(order).not.toContain("session");
-    expect(order).not.toContain("prompt");
-    expect(slackApiBodies(slackFetch, "chat.postMessage")).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          text: expect.stringContaining("didn't start on this request"),
+      const response = await app.fetch(
+        slackEventRequest({
+          type: "message",
+          user: "U123",
+          channel: "D123",
+          ts: "444.555",
+          channel_type: "im",
+          ...eventFields,
         }),
-      ])
-    );
+        env,
+        ctx
+      );
 
-    slackFetch.mockRestore();
-  });
+      expect(response.status).toBe(200);
+      await flushWaitUntil(ctx);
+
+      // The placeholder prompt would be meaningless with no image attached, so
+      // no session is created and the user is told nothing ran.
+      if (downloadsImage) expect(order).toContain("filedownload");
+      else expect(order).not.toContain("filedownload");
+      expect(order).not.toContain("session");
+      expect(order).not.toContain("prompt");
+      expect(slackApiBodies(slackFetch, "chat.postMessage")).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            text: expect.stringContaining(expectedMessage),
+          }),
+        ])
+      );
+
+      slackFetch.mockRestore();
+    }
+  );
 
   it("keeps the interim checkpoint when the thread fetch fails", async () => {
     const order: string[] = [];

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -1313,6 +1313,7 @@ describe("POST /events", () => {
         ],
       },
       true,
+      2,
       "didn't start on this request",
     ],
     [
@@ -1341,6 +1342,7 @@ describe("POST /events", () => {
         ],
       },
       true,
+      2,
       "didn't start on this request",
     ],
     [
@@ -1366,11 +1368,39 @@ describe("POST /events", () => {
         ],
       },
       false,
+      0,
       "Please include a message with your request",
     ],
-  ] satisfies Array<[string, Record<string, unknown>, boolean, string]>)(
+    [
+      "an app mention contains a body-less forward with only unsupported files",
+      {
+        type: "app_mention",
+        text: "<@B123>",
+        attachments: [
+          {
+            is_msg_unfurl: true,
+            is_share: true,
+            author_name: "Ada Lovelace",
+            text: "",
+            files: [
+              {
+                id: "F1",
+                name: "incident.pdf",
+                mimetype: "application/pdf",
+                url_private: "https://files.slack.com/files-pri/T1-F1/incident.pdf",
+                size: 16,
+              },
+            ],
+          },
+        ],
+      },
+      false,
+      0,
+      "Please include a message with your request",
+    ],
+  ] satisfies Array<[string, Record<string, unknown>, boolean, number, string]>)(
     "starts nothing when %s",
-    async (_caseName, eventFields, downloadsImage, expectedMessage) => {
+    async (_caseName, eventFields, downloadsImage, expectedStartingStatuses, expectedMessage) => {
       const order: string[] = [];
       const slackFetch = mockSlackFetch(order, { fileDownloadStatus: 403 });
       const env = makeSessionEnv(order);
@@ -1396,6 +1426,7 @@ describe("POST /events", () => {
       // no session is created and the user is told nothing ran.
       if (downloadsImage) expect(order).toContain("filedownload");
       else expect(order).not.toContain("filedownload");
+      expect(startingStatusBodies(slackFetch)).toHaveLength(expectedStartingStatuses);
       expect(order).not.toContain("session");
       expect(order).not.toContain("prompt");
       expect(slackApiBodies(slackFetch, "chat.postMessage")).toEqual(


### PR DESCRIPTION
## Summary

Follow up on #1143 by tightening the boundary between explicit Slack message shares and message-link previews:

- require `is_share` as the positive forwarded-message discriminator
- preserve whether a forwarded share contains substantive text or only images
- keep image-only forwarded requests fail-closed when every image is lost
- return a visible response when a body-less share contains no supported image

## Root cause

Slack sets `is_msg_unfurl` for both pasted message permalinks and explicit shares, while `is_share` distinguishes the explicit share:

- [pasted Slack permalink payload](https://github.com/r-devel/rcwg/blob/fc38e456139d9f28396df1b1a4849f6a563ad860/slack/gsoc/2026-03-18.json#L7-L31)
- [explicit shared-message payload](https://github.com/de-dale/de-dale.github.io/blob/c4f2ccb7a922fb6b62e3c5aece5653b0e8774045/archives/de-dale-slack-export/spherier/2017-06-07.json#L64-L80)

The original collector admitted either flag, so a pasted permalink could be promoted into forwarded prompt context. It also formatted an image-only share as a non-empty `(no text)` entry before deriving `imageOnly`, bypassing the existing no-image delivery guards.

## Validation

- `npm run build -w @open-inspect/shared -w @open-inspect/slack-bot`
- `npm test -w @open-inspect/shared` — 500 passed
- `npm test -w @open-inspect/slack-bot` — 357 passed
- `npm run typecheck -w @open-inspect/shared -w @open-inspect/slack-bot`
- `npm run lint`
- Prettier check on all changed files
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forwarded Slack message detection so shared content is treated as such only when it includes a real message body.
  * Correctly separates shared messages from permalink/message-link previews to prevent accidental content extraction.
  * Standardized handling for image-only and forwarded messages with no usable text, avoiding unnecessary processing and improving fallback text behavior.

* **Tests**
  * Expanded forwarded-message assertions (including the new “has body” behavior) and added broader table-driven scenarios for image-only messages and failed image downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->