### PR TITLE
fix(slack): split long completions across sections instead of truncating at 2000 chars

### DIFF
--- a/packages/slack-bot/src/completion/blocks.test.ts
+++ b/packages/slack-bot/src/completion/blocks.test.ts
@@ -293,6 +293,31 @@ describe("long response handling", () => {
     }
   });
 
+  // The truncation cut can land inside a fence the final section both opened and
+  // closed, which a trailing-fence check cannot detect. Sweep the section length
+  // through the window where slicing actually happens, moving the fence across the
+  // cut point, and assert the invariant holds for every shape.
+  it("keeps fences balanced when the truncation cut lands inside a fence", () => {
+    const fence = "```";
+    for (let sectionLen = 2949; sectionLen <= 3000; sectionLen += 1) {
+      for (const codeLen of [20, 45, 200]) {
+        const block = `\n${fence}ts\n${"h".repeat(codeLen)}\n${fence}`;
+        const fill = sectionLen - block.length;
+        if (fill < 1) continue;
+        const paragraphs = [
+          ...Array.from({ length: 19 }, () => "f".repeat(2900)),
+          "g".repeat(fill) + block,
+          ...Array.from({ length: 5 }, () => "z".repeat(2900)),
+        ];
+        const sections = splitIntoSlackSections(paragraphs.join("\n\n"));
+        const last = sections[sections.length - 1];
+        expect(last).toContain("truncated");
+        expect(last.length).toBeLessThanOrEqual(3000);
+        expect((last.match(/```/g) ?? []).length % 2).toBe(0);
+      }
+    }
+  });
+
   it("carries the fence language across a split", () => {
     const sections = splitIntoSlackSections(`\`\`\`python\n${"c".repeat(6500)}\n\`\`\``);
     expect(sections.length).toBeGreaterThan(1);

--- a/packages/slack-bot/src/completion/blocks.test.ts
+++ b/packages/slack-bot/src/completion/blocks.test.ts
@@ -312,3 +312,42 @@ describe("long response handling", () => {
     expect(sectionTexts(blocks)[0]).toBe("_Agent completed._");
   });
 });
+
+describe("fence info bounding", () => {
+  // Regression: `info` was captured unbounded from the fence line, so an
+  // oversized fence-opener (a single ≥3000-char line beginning with ```) was
+  // re-emitted by reopenPrefix on every continuation section and overflowed
+  // Slack's per-section cap. Slack rejects the whole message on overflow rather
+  // than trimming the block, so the cap has to hold for every input shape.
+  it("keeps sections within the cap for an oversized fence-opener line", () => {
+    const monsterInfo = "x".repeat(4000);
+    const sections = splitIntoSlackSections(`\`\`\`${monsterInfo}\n${"c".repeat(5000)}\n\`\`\``);
+    for (const section of sections) {
+      expect(section.length).toBeLessThanOrEqual(3000);
+    }
+  });
+
+  it("keeps only the language token when the fence line carries trailing text", () => {
+    const sections = splitIntoSlackSections(
+      `\`\`\`python title="a very long annotation ${"y".repeat(200)}"\n${"c".repeat(6500)}\n\`\`\``
+    );
+    expect(sections.length).toBeGreaterThan(1);
+    for (const section of sections.slice(1)) {
+      expect(section.startsWith("```python\n")).toBe(true);
+    }
+  });
+
+  // The bot's review caught the original overflow by fuzzing rather than by a
+  // single case, and a single case would have missed it here too.
+  it("never overflows across a sweep of fence-opener and body lengths", () => {
+    for (let infoLen = 0; infoLen <= 4200; infoLen += 350) {
+      for (let bodyLen = 2900; bodyLen <= 6200; bodyLen += 550) {
+        const text = `\`\`\`${"i".repeat(infoLen)}\n${"b".repeat(bodyLen)}\n\`\`\``;
+        for (const section of splitIntoSlackSections(text)) {
+          expect(section.length).toBeLessThanOrEqual(3000);
+          expect((section.match(/```/g) ?? []).length % 2).toBe(0);
+        }
+      }
+    }
+  });
+});

--- a/packages/slack-bot/src/completion/blocks.test.ts
+++ b/packages/slack-bot/src/completion/blocks.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildCompletionBlocks } from "./blocks";
+import { buildCompletionBlocks, splitIntoSlackSections } from "./blocks";
 import type { AgentResponse, SlackCallbackContext } from "../types";
 
 const BASE_CONTEXT: SlackCallbackContext = {
@@ -251,6 +251,54 @@ describe("long response handling", () => {
     expect(texts.length).toBeGreaterThan(1);
     for (const text of texts) {
       expect((text.match(/```/g) ?? []).length % 2).toBe(0);
+    }
+  });
+
+  // The two checks above pass on fence-free and short-line input respectively, so
+  // neither exercises a split *inside* a fence — which is where the section repair
+  // adds characters after the fit check and where the hard slice drops them.
+  it("respects the section cap when a fence is split (repair chars are budgeted)", () => {
+    const textContent = `\`\`\`json\n${"a".repeat(9000)}\n\`\`\``;
+    const blocks = buildCompletionBlocks(
+      "sess-6",
+      { ...BASE_RESPONSE, textContent },
+      BASE_CONTEXT,
+      "https://inspect.example.com"
+    );
+    for (const text of sectionTexts(blocks)) {
+      expect(text.length).toBeLessThanOrEqual(3000);
+    }
+  });
+
+  it("loses no characters when hard-slicing inside a fence", () => {
+    const payload = "b".repeat(7000);
+    const sections = splitIntoSlackSections(`\`\`\`js\n${payload}\n\`\`\``);
+    const recovered = sections
+      .join("")
+      .split("```")
+      .join("")
+      .replace(/^js$/gm, "")
+      .replace(/\n/g, "");
+    expect(recovered).toBe(payload);
+  });
+
+  it("keeps fences balanced in the truncated final section", () => {
+    const textContent = `\`\`\`ts\n${Array.from({ length: 400 }, () => "y".repeat(2900)).join("\n")}\n\`\`\``;
+    const sections = splitIntoSlackSections(textContent);
+    const last = sections[sections.length - 1];
+    expect(last).toContain("truncated");
+    expect(last.length).toBeLessThanOrEqual(3000);
+    for (const section of sections) {
+      expect((section.match(/```/g) ?? []).length % 2).toBe(0);
+    }
+  });
+
+  it("carries the fence language across a split", () => {
+    const sections = splitIntoSlackSections(`\`\`\`python\n${"c".repeat(6500)}\n\`\`\``);
+    expect(sections.length).toBeGreaterThan(1);
+    // Every continuation section reopens the fence with its original language.
+    for (const section of sections.slice(1)) {
+      expect(section.startsWith("```python\n")).toBe(true);
     }
   });
 

--- a/packages/slack-bot/src/completion/blocks.test.ts
+++ b/packages/slack-bot/src/completion/blocks.test.ts
@@ -181,3 +181,86 @@ describe("buildCompletionBlocks", () => {
     expect(createPrButton?.url).toBe(fallbackUrl);
   });
 });
+
+describe("long response handling", () => {
+  // Regression: responses were capped at 2000 chars in a single section, so
+  // multi-part answers (headings + citations) stopped mid-sentence even though
+  // Slack accepts 3000 per section and 50 blocks per message.
+  const sectionTexts = (blocks: ReturnType<typeof buildCompletionBlocks>): string[] =>
+    blocks
+      .filter((block) => block.type === "section")
+      .map((block) => block.text?.text ?? "")
+      // Drop the artifacts section, which is built separately.
+      .filter((text) => !text.startsWith("*Created:*"));
+
+  it("keeps a long multi-paragraph answer whole across several sections", () => {
+    const paragraphs = Array.from(
+      { length: 8 },
+      (_, i) => `## Section ${i}\n\n${"detail ".repeat(120)}`
+    );
+    const textContent = paragraphs.join("\n\n");
+    const blocks = buildCompletionBlocks(
+      "sess-1",
+      { ...BASE_RESPONSE, textContent },
+      BASE_CONTEXT,
+      "https://inspect.example.com"
+    );
+    const texts = sectionTexts(blocks);
+    expect(texts.length).toBeGreaterThan(1);
+    expect(texts.join("\n\n")).toContain("Section 7");
+    expect(texts.join(" ")).not.toContain("truncated");
+  });
+
+  it("never exceeds Slack's per-section character limit", () => {
+    const textContent = "x".repeat(25_000);
+    const blocks = buildCompletionBlocks(
+      "sess-2",
+      { ...BASE_RESPONSE, textContent },
+      BASE_CONTEXT,
+      "https://inspect.example.com"
+    );
+    for (const text of sectionTexts(blocks)) {
+      expect(text.length).toBeLessThanOrEqual(3000);
+    }
+  });
+
+  it("truncates with a pointer to the session once the block budget is spent", () => {
+    const textContent = Array.from({ length: 200 }, () => "q".repeat(2900)).join("\n\n");
+    const blocks = buildCompletionBlocks(
+      "sess-3",
+      { ...BASE_RESPONSE, textContent },
+      BASE_CONTEXT,
+      "https://inspect.example.com"
+    );
+    const texts = sectionTexts(blocks);
+    expect(texts.length).toBeLessThanOrEqual(20);
+    expect(texts[texts.length - 1]).toContain("truncated");
+    // The View Session button is the escape hatch for the remainder.
+    expect(getActionElements(blocks).some((el) => el.action_id === "view_session")).toBe(true);
+  });
+
+  it("balances code fences when a fenced block spans a split", () => {
+    const code = ["```ts", ...Array.from({ length: 300 }, (_, i) => `const x${i} = ${i};`), "```"];
+    const blocks = buildCompletionBlocks(
+      "sess-4",
+      { ...BASE_RESPONSE, textContent: code.join("\n") },
+      BASE_CONTEXT,
+      "https://inspect.example.com"
+    );
+    const texts = sectionTexts(blocks);
+    expect(texts.length).toBeGreaterThan(1);
+    for (const text of texts) {
+      expect((text.match(/```/g) ?? []).length % 2).toBe(0);
+    }
+  });
+
+  it("still renders a placeholder for an empty response", () => {
+    const blocks = buildCompletionBlocks(
+      "sess-5",
+      { ...BASE_RESPONSE, textContent: "   " },
+      BASE_CONTEXT,
+      "https://inspect.example.com"
+    );
+    expect(sectionTexts(blocks)[0]).toBe("_Agent completed._");
+  });
+});

--- a/packages/slack-bot/src/completion/blocks.test.ts
+++ b/packages/slack-bot/src/completion/blocks.test.ts
@@ -302,6 +302,31 @@ describe("long response handling", () => {
     }
   });
 
+  // The section cap only keeps the message postable in combination with however
+  // many non-section blocks this builder emits, and that coupling lives in a
+  // comment. Assert the real limit with every optional block populated, so raising
+  // the cap or adding a block fails here rather than at the Slack API.
+  it("stays within Slack's 50-block message limit with every block populated", () => {
+    const blocks = buildCompletionBlocks(
+      "sess-7",
+      {
+        ...BASE_RESPONSE,
+        textContent: Array.from({ length: 500 }, () => "z".repeat(2900)).join("\n\n"),
+        artifacts: [{ type: "branch", label: "feature/x", url: "https://example.com/tree/x" }],
+        toolCalls: [
+          { tool: "Edit", summary: "Edit src/a.ts" },
+          { tool: "Write", summary: "Write src/b.ts" },
+          { tool: "Bash", summary: "Bash npm test" },
+        ],
+        success: false,
+        error: "something went wrong",
+      } as AgentResponse,
+      BASE_CONTEXT,
+      "https://inspect.example.com"
+    );
+    expect(blocks.length).toBeLessThanOrEqual(50);
+  });
+
   it("still renders a placeholder for an empty response", () => {
     const blocks = buildCompletionBlocks(
       "sess-5",

--- a/packages/slack-bot/src/completion/blocks.ts
+++ b/packages/slack-bot/src/completion/blocks.ts
@@ -155,6 +155,21 @@ interface FenceState {
 }
 
 const CLOSED_FENCE: FenceState = { open: false, info: "" };
+const OPEN_FENCE: FenceState = { open: true, info: "" };
+
+/**
+ * Cap on the retained fence info string. An info string is a language token
+ * (`ts`, `python`, `json`), so this is generous for real input — but it has to be
+ * bounded: `reopenPrefix` re-emits it on every continuation section, so an
+ * unbounded capture let a pathologically long fence-opener line push sections
+ * past the cap by the length of its info string. Only the first whitespace-
+ * delimited token is kept, since anything after it isn't a language.
+ */
+const FENCE_INFO_MAX_CHARS = 32;
+
+function normalizeFenceInfo(raw: string): string {
+  return raw.trim().split(/\s/, 1)[0].slice(0, FENCE_INFO_MAX_CHARS);
+}
 
 /** Fence state after `chunk` is appended to text that ended in `state`. */
 function advanceFence(state: FenceState, chunk: string): FenceState {
@@ -162,7 +177,9 @@ function advanceFence(state: FenceState, chunk: string): FenceState {
   for (const line of chunk.split("\n")) {
     const trimmed = line.trimStart();
     if (!trimmed.startsWith(CODE_FENCE)) continue;
-    next = next.open ? CLOSED_FENCE : { open: true, info: trimmed.slice(CODE_FENCE.length).trim() };
+    next = next.open
+      ? CLOSED_FENCE
+      : { open: true, info: normalizeFenceInfo(trimmed.slice(CODE_FENCE.length)) };
   }
   return next;
 }
@@ -249,7 +266,7 @@ export function splitIntoSlackSections(
       const budget =
         maxChars -
         reopenPrefix(start).length -
-        (reserveClose ? closeSuffix({ open: true, info: "" }).length : 0);
+        (reserveClose ? closeSuffix(OPEN_FENCE).length : 0);
       const taken = rest.slice(0, Math.max(1, budget));
       sectionStart = start;
       body = taken;

--- a/packages/slack-bot/src/completion/blocks.ts
+++ b/packages/slack-bot/src/completion/blocks.ts
@@ -264,9 +264,7 @@ export function splitIntoSlackSections(
       // Reserve the closing fence whenever this slice could end inside one.
       const reserveClose = start.open || advanceFence(start, rest).open;
       const budget =
-        maxChars -
-        reopenPrefix(start).length -
-        (reserveClose ? closeSuffix(OPEN_FENCE).length : 0);
+        maxChars - reopenPrefix(start).length - (reserveClose ? closeSuffix(OPEN_FENCE).length : 0);
       const taken = rest.slice(0, Math.max(1, budget));
       sectionStart = start;
       body = taken;

--- a/packages/slack-bot/src/completion/blocks.ts
+++ b/packages/slack-bot/src/completion/blocks.ts
@@ -25,9 +25,25 @@ const STATUS_EMOJI = {
 /**
  * Truncation limits.
  */
-const TRUNCATE_LIMIT = 2000;
 const FALLBACK_TEXT_LIMIT = 150;
 const ERROR_FOOTER_LIMIT = 200;
+
+/**
+ * Slack's hard cap on a section block's mrkdwn text. Responses longer than this
+ * are split across consecutive section blocks rather than truncated, so a long
+ * answer arrives whole instead of stopping mid-sentence.
+ */
+const SECTION_TEXT_MAX_CHARS = 3000;
+
+/**
+ * How many section blocks a response may occupy. Slack allows 50 blocks per
+ * message; the rest of this builder contributes at most 4 (artifacts, tools,
+ * footer, actions), so this leaves comfortable headroom. Beyond this the tail is
+ * truncated and the View Session button is the way to read the whole thing.
+ */
+const MAX_RESPONSE_SECTIONS = 20;
+
+const CODE_FENCE_RE = /^```/;
 
 /**
  * Build Slack blocks for completion message.
@@ -40,12 +56,15 @@ export function buildCompletionBlocks(
 ): SlackBlock[] {
   const blocks: SlackBlock[] = [];
 
-  // 1. Response text (truncated)
-  const text = truncateForSlack(response.textContent, TRUNCATE_LIMIT);
-  blocks.push({
-    type: "section",
-    text: { type: "mrkdwn", text: text || "_Agent completed._" },
-  });
+  // 1. Response text, split across as many section blocks as it needs
+  const sections = splitIntoSlackSections(response.textContent);
+  if (sections.length === 0) {
+    blocks.push({ type: "section", text: { type: "mrkdwn", text: "_Agent completed._" } });
+  } else {
+    for (const section of sections) {
+      blocks.push({ type: "section", text: { type: "mrkdwn", text: section } });
+    }
+  }
 
   // 2. Artifacts (PRs, branches)
   if (response.artifacts.length > 0) {
@@ -128,6 +147,113 @@ export function buildCompletionBlocks(
  */
 export function getFallbackText(response: AgentResponse): string {
   return response.textContent.slice(0, FALLBACK_TEXT_LIMIT) || "Agent completed.";
+}
+
+/**
+ * Split agent prose into Slack section blocks, preferring paragraph boundaries.
+ *
+ * Long answers used to be cut at 2000 characters in a single block, which stopped
+ * multi-part answers mid-sentence even though Slack accepts far more. Splitting
+ * greedily on blank lines keeps headings with their prose; paragraphs that are
+ * themselves oversized fall back to line boundaries, then to a hard slice.
+ *
+ * Fenced code blocks are closed at the end of a section and reopened at the start
+ * of the next, so a split inside a fence doesn't leak monospace formatting across
+ * the rest of the message.
+ *
+ * Returns [] for empty input so the caller can render its own placeholder.
+ */
+export function splitIntoSlackSections(
+  text: string,
+  maxChars: number = SECTION_TEXT_MAX_CHARS,
+  maxSections: number = MAX_RESPONSE_SECTIONS
+): string[] {
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+  if (trimmed.length <= maxChars) return [trimmed];
+
+  const sections: string[] = [];
+  let current = "";
+  // Tracks whether `current` ends inside a fence, so the split can repair it.
+  let fenceOpen = false;
+  let fenceInfo = "";
+
+  const flush = () => {
+    if (!current) return;
+    sections.push(fenceOpen ? `${current}\n\`\`\`` : current);
+    current = "";
+  };
+
+  const appendChunk = (chunk: string) => {
+    const reopen = fenceOpen ? `\`\`\`${fenceInfo}\n` : "";
+    const candidate = current ? `${current}\n\n${chunk}` : `${reopen}${chunk}`;
+    if (candidate.length <= maxChars) {
+      current = candidate;
+      return;
+    }
+    flush();
+    const withReopen = `${fenceOpen ? `\`\`\`${fenceInfo}\n` : ""}${chunk}`;
+    current = withReopen.length <= maxChars ? withReopen : withReopen.slice(0, maxChars);
+  };
+
+  // Track fence state per line so `fenceOpen` is accurate at every boundary.
+  const consumeFences = (chunk: string) => {
+    for (const line of chunk.split("\n")) {
+      if (CODE_FENCE_RE.test(line.trimStart())) {
+        if (fenceOpen) {
+          fenceOpen = false;
+          fenceInfo = "";
+        } else {
+          fenceOpen = true;
+          fenceInfo = line.trimStart().slice(3).trim();
+        }
+      }
+    }
+  };
+
+  for (const paragraph of trimmed.split(/\n{2,}/)) {
+    if (paragraph.length <= maxChars) {
+      appendChunk(paragraph);
+      consumeFences(paragraph);
+      continue;
+    }
+    // Oversized paragraph (long table, big code block): break on lines.
+    let buffer = "";
+    for (const line of paragraph.split("\n")) {
+      const candidate = buffer ? `${buffer}\n${line}` : line;
+      if (candidate.length <= maxChars) {
+        buffer = candidate;
+        continue;
+      }
+      if (buffer) {
+        appendChunk(buffer);
+        consumeFences(buffer);
+      }
+      // A single line longer than the cap has to be sliced.
+      let rest = line;
+      while (rest.length > maxChars) {
+        appendChunk(rest.slice(0, maxChars));
+        consumeFences(rest.slice(0, maxChars));
+        rest = rest.slice(maxChars);
+      }
+      buffer = rest;
+    }
+    if (buffer) {
+      appendChunk(buffer);
+      consumeFences(buffer);
+    }
+  }
+  flush();
+
+  if (sections.length <= maxSections) return sections;
+  const kept = sections.slice(0, maxSections);
+  const last = kept[maxSections - 1];
+  const marker = "\n\n_...truncated — open the session to read the rest_";
+  kept[maxSections - 1] =
+    last.length + marker.length <= maxChars
+      ? last + marker
+      : last.slice(0, maxChars - marker.length) + marker;
+  return kept;
 }
 
 /**

--- a/packages/slack-bot/src/completion/blocks.ts
+++ b/packages/slack-bot/src/completion/blocks.ts
@@ -43,7 +43,7 @@ const SECTION_TEXT_MAX_CHARS = 3000;
  */
 const MAX_RESPONSE_SECTIONS = 20;
 
-const CODE_FENCE_RE = /^```/;
+const CODE_FENCE = "```";
 
 /**
  * Build Slack blocks for completion message.
@@ -149,6 +149,34 @@ export function getFallbackText(response: AgentResponse): string {
   return response.textContent.slice(0, FALLBACK_TEXT_LIMIT) || "Agent completed.";
 }
 
+interface FenceState {
+  readonly open: boolean;
+  readonly info: string;
+}
+
+const CLOSED_FENCE: FenceState = { open: false, info: "" };
+
+/** Fence state after `chunk` is appended to text that ended in `state`. */
+function advanceFence(state: FenceState, chunk: string): FenceState {
+  let next = state;
+  for (const line of chunk.split("\n")) {
+    const trimmed = line.trimStart();
+    if (!trimmed.startsWith(CODE_FENCE)) continue;
+    next = next.open ? CLOSED_FENCE : { open: true, info: trimmed.slice(CODE_FENCE.length).trim() };
+  }
+  return next;
+}
+
+/** Reopens, at the top of a section, a fence carried over from the previous one. */
+function reopenPrefix(state: FenceState): string {
+  return state.open ? `${CODE_FENCE}${state.info}\n` : "";
+}
+
+/** Closes a fence still open at the end of a section. */
+function closeSuffix(state: FenceState): string {
+  return state.open ? `\n${CODE_FENCE}` : "";
+}
+
 /**
  * Split agent prose into Slack section blocks, preferring paragraph boundaries.
  *
@@ -160,6 +188,12 @@ export function getFallbackText(response: AgentResponse): string {
  * Fenced code blocks are closed at the end of a section and reopened at the start
  * of the next, so a split inside a fence doesn't leak monospace formatting across
  * the rest of the message.
+ *
+ * Both repairs cost characters, so every fit check measures the text Slack will
+ * actually receive — reopen prefix plus body plus closing fence — and the
+ * hard-slice path advances by exactly what it kept. Measuring the bare body
+ * instead lets an in-fence section overflow by the 4 closing characters, and
+ * Slack rejects the whole message rather than trimming the block.
  *
  * Returns [] for empty input so the caller can render its own placeholder.
  */
@@ -173,87 +207,92 @@ export function splitIntoSlackSections(
   if (trimmed.length <= maxChars) return [trimmed];
 
   const sections: string[] = [];
-  let current = "";
-  // Tracks whether `current` ends inside a fence, so the split can repair it.
-  let fenceOpen = false;
-  let fenceInfo = "";
+  // Fence state where the in-progress section began, and where its body now ends.
+  let sectionStart = CLOSED_FENCE;
+  let sectionEnd = CLOSED_FENCE;
+  let body = "";
 
-  const flush = () => {
-    if (!current) return;
-    sections.push(fenceOpen ? `${current}\n\`\`\`` : current);
-    current = "";
+  const render = (start: FenceState, content: string, end: FenceState): string =>
+    `${reopenPrefix(start)}${content}${closeSuffix(end)}`;
+
+  const flush = (): void => {
+    if (!body) return;
+    sections.push(render(sectionStart, body, sectionEnd));
+    // A fence left open carries into the next section, which reopens it.
+    sectionStart = sectionEnd;
+    body = "";
   };
 
-  const appendChunk = (chunk: string) => {
-    const reopen = fenceOpen ? `\`\`\`${fenceInfo}\n` : "";
-    const candidate = current ? `${current}\n\n${chunk}` : `${reopen}${chunk}`;
-    if (candidate.length <= maxChars) {
-      current = candidate;
+  const appendToken = (token: string, separator: string): void => {
+    const joined = body ? `${body}${separator}${token}` : token;
+    const joinedEnd = advanceFence(sectionEnd, token);
+    if (render(sectionStart, joined, joinedEnd).length <= maxChars) {
+      body = joined;
+      sectionEnd = joinedEnd;
       return;
     }
-    flush();
-    const withReopen = `${fenceOpen ? `\`\`\`${fenceInfo}\n` : ""}${chunk}`;
-    current = withReopen.length <= maxChars ? withReopen : withReopen.slice(0, maxChars);
-  };
 
-  // Track fence state per line so `fenceOpen` is accurate at every boundary.
-  const consumeFences = (chunk: string) => {
-    for (const line of chunk.split("\n")) {
-      if (CODE_FENCE_RE.test(line.trimStart())) {
-        if (fenceOpen) {
-          fenceOpen = false;
-          fenceInfo = "";
-        } else {
-          fenceOpen = true;
-          fenceInfo = line.trimStart().slice(3).trim();
-        }
-      }
+    flush();
+    const aloneEnd = advanceFence(sectionEnd, token);
+    if (render(sectionStart, token, aloneEnd).length <= maxChars) {
+      body = token;
+      sectionEnd = aloneEnd;
+      return;
+    }
+
+    // Token exceeds a whole section on its own: slice it against the real budget.
+    let rest = token;
+    while (rest.length > 0) {
+      const start = sectionEnd;
+      // Reserve the closing fence whenever this slice could end inside one.
+      const reserveClose = start.open || advanceFence(start, rest).open;
+      const budget =
+        maxChars -
+        reopenPrefix(start).length -
+        (reserveClose ? closeSuffix({ open: true, info: "" }).length : 0);
+      const taken = rest.slice(0, Math.max(1, budget));
+      sectionStart = start;
+      body = taken;
+      sectionEnd = advanceFence(start, taken);
+      rest = rest.slice(taken.length);
+      if (rest.length > 0) flush();
     }
   };
 
   for (const paragraph of trimmed.split(/\n{2,}/)) {
     if (paragraph.length <= maxChars) {
-      appendChunk(paragraph);
-      consumeFences(paragraph);
+      appendToken(paragraph, "\n\n");
       continue;
     }
-    // Oversized paragraph (long table, big code block): break on lines.
-    let buffer = "";
+    // Oversized paragraph (long table, big code block): break on lines. Only the
+    // first line is a paragraph boundary; the rest are line continuations.
+    let atParagraphStart = true;
     for (const line of paragraph.split("\n")) {
-      const candidate = buffer ? `${buffer}\n${line}` : line;
-      if (candidate.length <= maxChars) {
-        buffer = candidate;
-        continue;
-      }
-      if (buffer) {
-        appendChunk(buffer);
-        consumeFences(buffer);
-      }
-      // A single line longer than the cap has to be sliced.
-      let rest = line;
-      while (rest.length > maxChars) {
-        appendChunk(rest.slice(0, maxChars));
-        consumeFences(rest.slice(0, maxChars));
-        rest = rest.slice(maxChars);
-      }
-      buffer = rest;
-    }
-    if (buffer) {
-      appendChunk(buffer);
-      consumeFences(buffer);
+      appendToken(line, atParagraphStart ? "\n\n" : "\n");
+      atParagraphStart = false;
     }
   }
   flush();
 
   if (sections.length <= maxSections) return sections;
   const kept = sections.slice(0, maxSections);
-  const last = kept[maxSections - 1];
-  const marker = "\n\n_...truncated — open the session to read the rest_";
-  kept[maxSections - 1] =
-    last.length + marker.length <= maxChars
-      ? last + marker
-      : last.slice(0, maxChars - marker.length) + marker;
+  const lastIndex = maxSections - 1;
+  kept[lastIndex] = withTruncationMarker(kept[lastIndex], maxChars);
   return kept;
+}
+
+/**
+ * Append the truncation pointer to the final kept section, preserving both the
+ * character cap and fence balance — slicing blindly can eat the closing fence and
+ * leak monospace over the marker.
+ */
+function withTruncationMarker(section: string, maxChars: number): string {
+  const marker = "\n\n_...truncated — open the session to read the rest_";
+  if (section.length + marker.length <= maxChars) return section + marker;
+  const closing = section.endsWith(`\n${CODE_FENCE}`) ? `\n${CODE_FENCE}` : "";
+  const content = closing ? section.slice(0, -closing.length) : section;
+  const room = maxChars - marker.length - closing.length;
+  return `${content.slice(0, Math.max(0, room))}${closing}${marker}`;
 }
 
 /**

--- a/packages/slack-bot/src/completion/blocks.ts
+++ b/packages/slack-bot/src/completion/blocks.ts
@@ -257,19 +257,6 @@ export function splitIntoSlackSections(
 }
 
 /**
- * Truncate text for Slack display with smart sentence breaks.
- */
-function truncateForSlack(text: string, maxLen: number): string {
-  if (text.length <= maxLen) return text;
-  const truncated = text.slice(0, maxLen);
-  const lastPeriod = truncated.lastIndexOf(". ");
-  if (lastPeriod > maxLen * 0.7) {
-    return truncated.slice(0, lastPeriod + 1) + "\n\n_...truncated_";
-  }
-  return truncated + "...\n\n_...truncated_";
-}
-
-/**
  * Truncate an error string for Slack display, collapsing whitespace.
  */
 export function truncateError(text: string, maxLen: number): string {

--- a/packages/slack-bot/src/completion/blocks.ts
+++ b/packages/slack-bot/src/completion/blocks.ts
@@ -304,10 +304,14 @@ export function splitIntoSlackSections(
 function withTruncationMarker(section: string, maxChars: number): string {
   const marker = "\n\n_...truncated — open the session to read the rest_";
   if (section.length + marker.length <= maxChars) return section + marker;
-  const closing = section.endsWith(`\n${CODE_FENCE}`) ? `\n${CODE_FENCE}` : "";
-  const content = closing ? section.slice(0, -closing.length) : section;
+  const closing = `\n${CODE_FENCE}`;
+  // Reserve room for a closing fence unconditionally: the cut can land inside a
+  // fence this section opened *and* closed, which no trailing-fence check sees.
+  const content = section.endsWith(closing) ? section.slice(0, -closing.length) : section;
   const room = maxChars - marker.length - closing.length;
-  return `${content.slice(0, Math.max(0, room))}${closing}${marker}`;
+  const sliced = content.slice(0, Math.max(0, room));
+  const needsClose = (sliced.match(/```/g) ?? []).length % 2 !== 0;
+  return `${sliced}${needsClose ? closing : ""}${marker}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Completion messages were capped at 2000 characters in a single `section` block, so any long answer stopped mid-sentence — even though Slack accepts 3000 characters per section and 50 blocks per message. Multi-part answers (headings plus citations, or a summary followed by a code sample) lost their tail.

`buildCompletionBlocks` now splits the response across as many section blocks as it needs, preferring paragraph boundaries, falling back to line boundaries, then to a hard slice. A fenced code block that lands on a split is closed at the end of one section and reopened — with its language — at the start of the next, so monospace formatting doesn't leak across the rest of the message. Past a 20-section budget the tail is truncated with a pointer to the session, which leaves comfortable headroom under Slack's 50-block limit.

Two details that are easy to get wrong, and which the tests here pin:

- **The fence repair costs characters.** The closing fence adds 4 and the reopen prefix adds `3 + len(info) + 1`. Measuring only the section body lets an in-fence section render at 3004 against Slack's 3000 cap — and Slack rejects an oversized section by failing the whole message, so a long fenced answer posts *nothing* rather than being trimmed. Every fit check therefore measures what Slack actually receives: reopen prefix + body + closing fence.
- **The hard-slice path must advance by what it kept.** Slicing the reopen-prefixed string to the cap while advancing the cursor by the full cap silently drops the characters the prefix displaced — content vanishing from the middle of a code block, not a truncated tail.

The fence info string is bounded to its first whitespace-delimited token (32 chars) because `reopenPrefix` re-emits it on every continuation section, so an unbounded capture from a pathological opener line could push sections past the cap.

## Test plan

- [x] `packages/slack-bot/src/completion/blocks.test.ts` — 18 tests pass
- [x] Long multi-paragraph answer arrives whole across several sections, with no truncation marker
- [x] No section exceeds 3000 characters, including when a split falls inside a fence
- [x] No characters are lost when hard-slicing a >3000-char line inside a fence
- [x] Fences stay balanced in every section, including the truncated final one
- [x] Continuation sections reopen the fence with the original language
- [x] Tail truncation past the section budget still renders the View Session button
- [x] Empty/whitespace responses still render the `_Agent completed._` placeholder
- [x] `prettier --check` clean on the touched files

Most of this is @jackmiller92's work; the character-budget accounting is mine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Long Slack completions now render across multiple section blocks instead of truncating into one.
  * Code fences (including the language/info line) are preserved correctly across section boundaries.
  * Empty/whitespace responses show a friendly “completed” placeholder; truncated replies include a clear truncation indicator and a view option for the remainder.
* **Bug Fixes**
  * Prevents oversized sections and ensures generated blocks stay within Slack character/block limits while keeping fences balanced and well-formed.
* **Tests**
  * Added regression tests for long, multi-paragraph splitting, truncation behavior, fence correctness, and strict limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->