### PR TITLE
feat(auth): make each sign-in provider independently optional

### DIFF
--- a/packages/control-plane/src/auth/user/runtime.test.ts
+++ b/packages/control-plane/src/auth/user/runtime.test.ts
@@ -1,5 +1,27 @@
-import { describe, expect, it } from "vitest";
-import { parsePublicWebOrigin } from "./runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createUserAuthFromEnv, parsePublicWebOrigin } from "./runtime";
+import { createUserAuth } from "./better-auth";
+import type { Env } from "../../types";
+
+// Constructing the real Better Auth instance would initialize a D1 adapter, so the
+// provider-resolution tests below assert the config it is handed instead.
+vi.mock("./better-auth", () => ({ createUserAuth: vi.fn(() => ({}) as never) }));
+
+const BASE_ENV = {
+  WEB_APP_URL: "https://open-inspect.example",
+  BROWSER_AUTH_SECRET: "x".repeat(32),
+} as const;
+
+function envWith(overrides: Record<string, string>): Env {
+  return { ...BASE_ENV, ...overrides } as unknown as Env;
+}
+
+const STUB_DATABASE = {} as D1Database;
+
+function configuredProviders(): string[] {
+  const config = vi.mocked(createUserAuth).mock.calls.at(-1)?.[0] ?? {};
+  return ["github", "google"].filter((provider) => provider in config);
+}
 
 describe("parsePublicWebOrigin", () => {
   it.each([
@@ -22,5 +44,77 @@ describe("parsePublicWebOrigin", () => {
     "https://open-inspect.example?query=1",
   ])("rejects an unsafe or non-origin WEB_APP_URL: %s", (configured) => {
     expect(() => parsePublicWebOrigin(configured)).toThrow();
+  });
+});
+
+describe("createUserAuthFromEnv sign-in provider configuration", () => {
+  beforeEach(() => {
+    vi.mocked(createUserAuth).mockClear();
+  });
+
+  it("accepts a Google-only deployment and wires only Google", () => {
+    expect(() =>
+      createUserAuthFromEnv(
+        envWith({ GOOGLE_CLIENT_ID: "google-id", GOOGLE_CLIENT_SECRET: "google-secret" }),
+        STUB_DATABASE
+      )
+    ).not.toThrow();
+    expect(configuredProviders()).toEqual(["google"]);
+  });
+
+  it("accepts a GitHub-only deployment and wires only GitHub", () => {
+    expect(() =>
+      createUserAuthFromEnv(
+        envWith({ GITHUB_CLIENT_ID: "github-id", GITHUB_CLIENT_SECRET: "github-secret" }),
+        STUB_DATABASE
+      )
+    ).not.toThrow();
+    expect(configuredProviders()).toEqual(["github"]);
+  });
+
+  it("wires both providers when both are configured", () => {
+    createUserAuthFromEnv(
+      envWith({
+        GITHUB_CLIENT_ID: "github-id",
+        GITHUB_CLIENT_SECRET: "github-secret",
+        GOOGLE_CLIENT_ID: "google-id",
+        GOOGLE_CLIENT_SECRET: "google-secret",
+      }),
+      STUB_DATABASE
+    );
+    expect(configuredProviders()).toEqual(["github", "google"]);
+  });
+
+  it("rejects a deployment with no sign-in provider configured", () => {
+    expect(() => createUserAuthFromEnv(envWith({}), STUB_DATABASE)).toThrow(
+      /At least one sign-in provider must be configured/
+    );
+  });
+
+  it.each([
+    ["GITHUB_CLIENT_ID", { GITHUB_CLIENT_ID: "github-id" }],
+    ["GITHUB_CLIENT_SECRET", { GITHUB_CLIENT_SECRET: "github-secret" }],
+  ])("rejects a half-configured GitHub provider: %s alone", (_name, overrides) => {
+    expect(() => createUserAuthFromEnv(envWith(overrides), STUB_DATABASE)).toThrow(
+      /GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET must be configured together/
+    );
+  });
+
+  it.each([
+    ["GOOGLE_CLIENT_ID", { GOOGLE_CLIENT_ID: "google-id" }],
+    ["GOOGLE_CLIENT_SECRET", { GOOGLE_CLIENT_SECRET: "google-secret" }],
+  ])("rejects a half-configured Google provider: %s alone", (_name, overrides) => {
+    expect(() => createUserAuthFromEnv(envWith(overrides), STUB_DATABASE)).toThrow(
+      /GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET must be configured together/
+    );
+  });
+
+  it("treats whitespace-only credentials as unset", () => {
+    expect(() =>
+      createUserAuthFromEnv(
+        envWith({ GITHUB_CLIENT_ID: "   ", GITHUB_CLIENT_SECRET: "   " }),
+        STUB_DATABASE
+      )
+    ).toThrow(/At least one sign-in provider must be configured/);
   });
 });

--- a/packages/control-plane/src/auth/user/runtime.ts
+++ b/packages/control-plane/src/auth/user/runtime.ts
@@ -76,17 +76,26 @@ export function createUserAuthFromEnv(env: Env, database: D1Database) {
     );
   }
 
-  const githubClientId = requireConfig(env.GITHUB_CLIENT_ID, "GITHUB_CLIENT_ID");
-  const githubClientSecret = requireConfig(env.GITHUB_CLIENT_SECRET, "GITHUB_CLIENT_SECRET");
   const admissionPolicy = createAdmissionPolicy(env);
-  const githubIdentityResolver = new GitHubProviderIdentityResolver({
-    issuer: GITHUB_ISSUER,
-    userAgent: `${env.APP_NAME?.trim() || "Open-Inspect"} Control Plane`,
-  });
-  const githubProfile = new GitHubSignInProfileResolver({
-    identityResolver: githubIdentityResolver,
-    admissionPolicy,
-  });
+
+  const githubClientId = env.GITHUB_CLIENT_ID?.trim();
+  const githubClientSecret = env.GITHUB_CLIENT_SECRET?.trim();
+  if (Boolean(githubClientId) !== Boolean(githubClientSecret)) {
+    throw new UserAuthConfigurationError(
+      "GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET must be configured together"
+    );
+  }
+
+  const githubProfile =
+    githubClientId && githubClientSecret
+      ? new GitHubSignInProfileResolver({
+          identityResolver: new GitHubProviderIdentityResolver({
+            issuer: GITHUB_ISSUER,
+            userAgent: `${env.APP_NAME?.trim() || "Open-Inspect"} Control Plane`,
+          }),
+          admissionPolicy,
+        })
+      : null;
 
   const googleClientId = env.GOOGLE_CLIENT_ID?.trim();
   const googleClientSecret = env.GOOGLE_CLIENT_SECRET?.trim();
@@ -104,16 +113,29 @@ export function createUserAuthFromEnv(env: Env, database: D1Database) {
         })
       : null;
 
+  // Each provider is opt-in, but browser sign-in is unreachable with none of
+  // them configured — fail at construction rather than serving a sign-in page
+  // that cannot complete.
+  if (!githubProfile && !googleProfile) {
+    throw new UserAuthConfigurationError(
+      "At least one sign-in provider must be configured: set GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET, or GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET"
+    );
+  }
+
   return createUserAuth({
     database,
     publicWebOrigin,
     secret,
     userProjection: new D1CanonicalUserProjection(database),
-    github: {
-      clientId: githubClientId,
-      clientSecret: githubClientSecret,
-      getUserInfo: githubProfile.getUserInfo,
-    },
+    ...(githubProfile && githubClientId && githubClientSecret
+      ? {
+          github: {
+            clientId: githubClientId,
+            clientSecret: githubClientSecret,
+            getUserInfo: githubProfile.getUserInfo,
+          },
+        }
+      : {}),
     ...(googleProfile && googleClientId && googleClientSecret
       ? {
           google: {


### PR DESCRIPTION
## Summary

`createUserAuthFromEnv` requires GitHub OAuth unconditionally:

```ts
const githubClientId = requireConfig(env.GITHUB_CLIENT_ID, "GITHUB_CLIENT_ID");
const githubClientSecret = requireConfig(env.GITHUB_CLIENT_SECRET, "GITHUB_CLIENT_SECRET");
```

Google, immediately below it, is already treated as optional — both credentials or neither, and the provider is wired only when present. So a deployment that signs in with **Google only** cannot construct the browser auth runtime at all, even though it never intends to offer GitHub sign-in. Because `getUserAuth` is resolved lazily per request, the `requireConfig` throw surfaces on every request that reads a session rather than failing at startup, which makes it look like a runtime fault rather than a configuration one.

This resolves GitHub the same way Google already is. No behaviour changes for a deployment that configures GitHub, or both.

`UserAuthConfig` already declares `github?` and `google?` optional and `createUserAuth` already spreads them conditionally, so the change is confined to env resolution in `runtime.ts` — nothing downstream needed touching.

Browser sign-in is unreachable with neither provider configured, so that case is now an explicit configuration error naming both options, instead of serving a sign-in page that cannot complete:

```
At least one sign-in provider must be configured: set GITHUB_CLIENT_ID and
GITHUB_CLIENT_SECRET, or GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET
```

## Test plan

`runtime.test.ts` previously covered only `parsePublicWebOrigin`. Added the provider-resolution matrix, asserting which providers are handed to `createUserAuth` rather than only that construction succeeds — the real Better Auth instance is mocked so the tests don't initialize a D1 adapter:

- [x] Google-only configuration succeeds and wires only Google
- [x] GitHub-only configuration succeeds and wires only GitHub
- [x] Both configured wires both
- [x] Neither configured raises the configuration error
- [x] Half-configured GitHub (`GITHUB_CLIENT_ID` or `GITHUB_CLIENT_SECRET` alone) raises "must be configured together"
- [x] Half-configured Google likewise (existing behaviour, now pinned)
- [x] Whitespace-only credentials are treated as unset
- [x] `packages/control-plane` suite: no new failures versus `upstream/main` (2062 → 2071 tests, same 8 pre-existing environment-related file failures on both sides)
- [x] `tsc`, `eslint`, `prettier` clean on the touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub sign-in is now optional and is enabled only when both credentials are configured.
  * Google-only, GitHub-only, or combined sign-in configurations are supported.

* **Bug Fixes**
  * Added validation for incomplete or whitespace-only provider credentials.
  * Authentication setup now reports an error when no sign-in provider is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->