### PR TITLE
docs: note the GitHub App email permission in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ authentication routes through a signed proxy, and browser resource requests requ
 web-service channel and the browser session. Legacy browser tokens are retired during migration, so
 existing users must sign in again after upgrading.
 
+Note: GitHub sign-in requires the GitHub App `Email addresses: Read-only` account permission —
+without it the callback fails with a misleading `state_mismatch` error.
+
 ## July 24, 2026
 
 **Claude Opus 5.** Adds `claude-opus-5` to the model picker and integrations, with adaptive thinking


### PR DESCRIPTION
Adds a one-line note to the July 26 Better Auth changelog entry.

## Why

Before the Better Auth cutover, a missing `Email addresses: Read-only` account permission was harmless unless the deployment used `ALLOWED_EMAILS`/`ALLOWED_EMAIL_DOMAINS` — `getVerifiedGitHubEmails` warned and returned `[]`, and admission by `ALLOWED_USERS`/`ALLOWED_GITHUB_ORGS` never read an email.

After the cutover, GitHub sign-in resolves a verified email for every user, so a deployment without that permission breaks on upgrade. `/user/emails` returns 403, `GitHubProviderIdentityResolver.fetchVerifiedEmails` throws, and because Better Auth consumes the one-time OAuth state before calling `getUserInfo`, a retry surfaces `state_mismatch` — an error that points nowhere near the cause. This hit a customer deployment.

## Note

`docs/GETTING_STARTED.md` still describes that permission as required only for `ALLOWED_EMAILS`/`ALLOWED_EMAIL_DOMAINS`, which is now inaccurate. Left out of this PR to keep it to the changelog; happy to fold it in or open a separate one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for GitHub sign-in: enable the “Email addresses: Read-only” GitHub App permission to avoid sign-in callback errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->