### PR TITLE
fix(slack): preserve completion section integrity

### DIFF
--- a/packages/shared/src/slack/client.test.ts
+++ b/packages/shared/src/slack/client.test.ts
@@ -11,6 +11,7 @@ import {
   getUserInfo,
   listChannels,
   openView,
+  postBlocks,
   postMessage,
   publishView,
   removeReaction,
@@ -238,6 +239,30 @@ describe("postMessage", () => {
     const result = await postMessage("xoxb-token", "C123", "hi");
     expect(result.ok).toBe(false);
     expect(result.error).toBe("network_error");
+  });
+});
+
+describe("postBlocks", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("posts blocks without a top-level text field", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ ok: true, ts: "1700000000.000300" }));
+    const blocks = [{ type: "section", text: { type: "mrkdwn", text: "hello" } }];
+
+    const result = await postBlocks("xoxb-token", "C123", blocks, {
+      thread_ts: "1699999999.000100",
+    });
+
+    expect(result.ok).toBe(true);
+    const init = fetchSpy.mock.calls[0]![1];
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body).not.toHaveProperty("text");
+    expect(body.blocks).toEqual(blocks);
+    expect(body.thread_ts).toBe("1699999999.000100");
   });
 });
 

--- a/packages/shared/src/slack/client.ts
+++ b/packages/shared/src/slack/client.ts
@@ -183,7 +183,7 @@ export async function verifySlackSignature(
 export function postMessage(
   token: string,
   channel: string,
-  text: string | undefined,
+  text: string,
   options?: {
     thread_ts?: string;
     blocks?: unknown[];
@@ -192,9 +192,26 @@ export function postMessage(
 ): Promise<SlackEnvelope<{ channel: string; ts: string }>> {
   return slackPost(token, "chat.postMessage", {
     channel,
-    ...(text === undefined ? {} : { text }),
+    text,
     thread_ts: options?.thread_ts,
     blocks: options?.blocks,
+    reply_broadcast: options?.reply_broadcast,
+  });
+}
+
+export function postBlocks(
+  token: string,
+  channel: string,
+  blocks: unknown[],
+  options?: {
+    thread_ts?: string;
+    reply_broadcast?: boolean;
+  }
+): Promise<SlackEnvelope<{ channel: string; ts: string }>> {
+  return slackPost(token, "chat.postMessage", {
+    channel,
+    blocks,
+    thread_ts: options?.thread_ts,
     reply_broadcast: options?.reply_broadcast,
   });
 }

--- a/packages/shared/src/slack/client.ts
+++ b/packages/shared/src/slack/client.ts
@@ -183,7 +183,7 @@ export async function verifySlackSignature(
 export function postMessage(
   token: string,
   channel: string,
-  text: string,
+  text: string | undefined,
   options?: {
     thread_ts?: string;
     blocks?: unknown[];
@@ -192,7 +192,7 @@ export function postMessage(
 ): Promise<SlackEnvelope<{ channel: string; ts: string }>> {
   return slackPost(token, "chat.postMessage", {
     channel,
-    text,
+    ...(text === undefined ? {} : { text }),
     thread_ts: options?.thread_ts,
     blocks: options?.blocks,
     reply_broadcast: options?.reply_broadcast,

--- a/packages/shared/src/slack/index.ts
+++ b/packages/shared/src/slack/index.ts
@@ -10,6 +10,7 @@ export {
   getUserInfo,
   listChannels,
   openView,
+  postBlocks,
   postEphemeral,
   postMessage,
   publishView,

--- a/packages/slack-bot/src/completion/blocks.test.ts
+++ b/packages/slack-bot/src/completion/blocks.test.ts
@@ -211,6 +211,38 @@ describe("long response handling", () => {
     expect(texts.join(" ")).not.toContain("truncated");
   });
 
+  it("preserves whitespace exactly across section boundaries", () => {
+    const textContent = `alpha\n\n\n\n\nbeta\n\n${"x".repeat(4000)}`;
+    const sections = splitIntoSlackSections(textContent);
+
+    expect(sections.join("")).toBe(textContent);
+  });
+
+  it("keeps Unicode code points intact across hard section boundaries", () => {
+    const textContent = `${"a".repeat(2999)}😀${"b".repeat(10)}`;
+    const sections = splitIntoSlackSections(textContent);
+
+    expect(sections.join("")).toBe(textContent);
+    for (const section of sections) {
+      const firstCodeUnit = section.charCodeAt(0);
+      const lastCodeUnit = section.charCodeAt(section.length - 1);
+      expect(firstCodeUnit >= 0xdc00 && firstCodeUnit <= 0xdfff).toBe(false);
+      expect(lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff).toBe(false);
+    }
+  });
+
+  it("keeps Unicode code points intact when adding the truncation marker", () => {
+    for (let prefixLength = 2900; prefixLength <= 3000; prefixLength += 1) {
+      const textContent = `${"a".repeat(prefixLength)}😀${"b".repeat(4000)}\n\nmore`;
+      const [section] = splitIntoSlackSections(textContent, 3000, 1);
+      const markerIndex = section.indexOf("_...truncated");
+      expect(markerIndex).toBeGreaterThanOrEqual(0);
+      const content = section.slice(0, markerIndex).trimEnd();
+      const lastCodeUnit = content.charCodeAt(content.length - 1);
+      expect(lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff).toBe(false);
+    }
+  });
+
   it("never exceeds Slack's per-section character limit", () => {
     const textContent = "x".repeat(25_000);
     const blocks = buildCompletionBlocks(
@@ -251,6 +283,16 @@ describe("long response handling", () => {
     expect(texts.length).toBeGreaterThan(1);
     for (const text of texts) {
       expect((text.match(/```/g) ?? []).length % 2).toBe(0);
+    }
+  });
+
+  it("balances fences that open and close on the same line", () => {
+    const fence = "```";
+    const sections = splitIntoSlackSections(`${fence}code${fence}\n${"after ".repeat(700)}`);
+
+    expect(sections.length).toBeGreaterThan(1);
+    for (const section of sections) {
+      expect((section.match(/```/g) ?? []).length % 2).toBe(0);
     }
   });
 

--- a/packages/slack-bot/src/completion/blocks.test.ts
+++ b/packages/slack-bot/src/completion/blocks.test.ts
@@ -212,7 +212,7 @@ describe("long response handling", () => {
   });
 
   it("preserves whitespace exactly across section boundaries", () => {
-    const textContent = `alpha\n\n\n\n\nbeta\n\n${"x".repeat(4000)}`;
+    const textContent = `\n  alpha\n\n\n\n\nbeta\n\n${"x".repeat(4000)}  \n`;
     const sections = splitIntoSlackSections(textContent);
 
     expect(sections.join("")).toBe(textContent);

--- a/packages/slack-bot/src/completion/blocks.test.ts
+++ b/packages/slack-bot/src/completion/blocks.test.ts
@@ -231,6 +231,12 @@ describe("long response handling", () => {
     }
   });
 
+  it("rejects a section budget that cannot fit the next Unicode code point", () => {
+    expect(() => splitIntoSlackSections("😀", 1)).toThrow(
+      new RangeError("Section budget is too small to fit the next Unicode code point")
+    );
+  });
+
   it("keeps Unicode code points intact when adding the truncation marker", () => {
     for (let prefixLength = 2900; prefixLength <= 3000; prefixLength += 1) {
       const textContent = `${"a".repeat(prefixLength)}😀${"b".repeat(4000)}\n\nmore`;

--- a/packages/slack-bot/src/completion/blocks.ts
+++ b/packages/slack-bot/src/completion/blocks.ts
@@ -199,7 +199,6 @@ function sliceAtCodePointBoundary(text: string, maxChars: number): string {
   const lastCodeUnit = text.charCodeAt(end - 1);
   const nextCodeUnit = text.charCodeAt(end);
   if (
-    end > 1 &&
     lastCodeUnit >= 0xd800 &&
     lastCodeUnit <= 0xdbff &&
     nextCodeUnit >= 0xdc00 &&
@@ -286,6 +285,9 @@ export function splitIntoSlackSections(
       const budget =
         maxChars - reopenPrefix(start).length - (reserveClose ? closeSuffix(OPEN_FENCE).length : 0);
       const taken = sliceAtCodePointBoundary(rest, Math.max(1, budget));
+      if (!taken) {
+        throw new RangeError("Section budget is too small to fit the next Unicode code point");
+      }
       sectionStart = start;
       body = taken;
       sectionEnd = advanceFence(start, taken);

--- a/packages/slack-bot/src/completion/blocks.ts
+++ b/packages/slack-bot/src/completion/blocks.ts
@@ -235,9 +235,8 @@ export function splitIntoSlackSections(
   maxChars: number = SECTION_TEXT_MAX_CHARS,
   maxSections: number = MAX_RESPONSE_SECTIONS
 ): string[] {
-  const trimmed = text.trim();
-  if (!trimmed) return [];
-  if (trimmed.length <= maxChars) return [trimmed];
+  if (!text.trim()) return [];
+  if (text.length <= maxChars) return [text];
 
   const sections: string[] = [];
   // Fence state where the in-progress section began, and where its body now ends.
@@ -302,7 +301,7 @@ export function splitIntoSlackSections(
     return true;
   };
 
-  sourceTokens: for (const sourceToken of trimmed.split(/(\n{2,})/)) {
+  sourceTokens: for (const sourceToken of text.split(/(\n{2,})/)) {
     if (!sourceToken) continue;
     if (sourceToken.startsWith("\n\n") || sourceToken.length <= maxChars) {
       if (!appendToken(sourceToken)) break;

--- a/packages/slack-bot/src/completion/blocks.ts
+++ b/packages/slack-bot/src/completion/blocks.ts
@@ -198,6 +198,8 @@ function sliceAtCodePointBoundary(text: string, maxChars: number): string {
   let end = Math.min(maxChars, text.length);
   const lastCodeUnit = text.charCodeAt(end - 1);
   const nextCodeUnit = text.charCodeAt(end);
+  // Back up when the cut falls between a UTF-16 high and low surrogate, so a
+  // supplementary code point is never split across sections.
   if (
     lastCodeUnit >= 0xd800 &&
     lastCodeUnit <= 0xdbff &&

--- a/packages/slack-bot/src/completion/blocks.ts
+++ b/packages/slack-bot/src/completion/blocks.ts
@@ -25,7 +25,6 @@ const STATUS_EMOJI = {
 /**
  * Truncation limits.
  */
-const FALLBACK_TEXT_LIMIT = 150;
 const ERROR_FOOTER_LIMIT = 200;
 
 /**
@@ -142,13 +141,6 @@ export function buildCompletionBlocks(
   return blocks;
 }
 
-/**
- * Get truncated text for Slack's fallback text field.
- */
-export function getFallbackText(response: AgentResponse): string {
-  return response.textContent.slice(0, FALLBACK_TEXT_LIMIT) || "Agent completed.";
-}
-
 interface FenceState {
   readonly open: boolean;
   readonly info: string;
@@ -175,11 +167,19 @@ function normalizeFenceInfo(raw: string): string {
 function advanceFence(state: FenceState, chunk: string): FenceState {
   let next = state;
   for (const line of chunk.split("\n")) {
-    const trimmed = line.trimStart();
-    if (!trimmed.startsWith(CODE_FENCE)) continue;
-    next = next.open
-      ? CLOSED_FENCE
-      : { open: true, info: normalizeFenceInfo(trimmed.slice(CODE_FENCE.length)) };
+    let cursor = 0;
+    while (cursor < line.length) {
+      const fenceIndex = line.indexOf(CODE_FENCE, cursor);
+      if (fenceIndex === -1) break;
+      const startsLine = line.slice(0, fenceIndex).trim().length === 0;
+      next = next.open
+        ? CLOSED_FENCE
+        : {
+            open: true,
+            info: startsLine ? normalizeFenceInfo(line.slice(fenceIndex + CODE_FENCE.length)) : "",
+          };
+      cursor = fenceIndex + CODE_FENCE.length;
+    }
   }
   return next;
 }
@@ -192,6 +192,22 @@ function reopenPrefix(state: FenceState): string {
 /** Closes a fence still open at the end of a section. */
 function closeSuffix(state: FenceState): string {
   return state.open ? `\n${CODE_FENCE}` : "";
+}
+
+function sliceAtCodePointBoundary(text: string, maxChars: number): string {
+  let end = Math.min(maxChars, text.length);
+  const lastCodeUnit = text.charCodeAt(end - 1);
+  const nextCodeUnit = text.charCodeAt(end);
+  if (
+    end > 1 &&
+    lastCodeUnit >= 0xd800 &&
+    lastCodeUnit <= 0xdbff &&
+    nextCodeUnit >= 0xdc00 &&
+    nextCodeUnit <= 0xdfff
+  ) {
+    end -= 1;
+  }
+  return text.slice(0, end);
 }
 
 /**
@@ -228,6 +244,7 @@ export function splitIntoSlackSections(
   let sectionStart = CLOSED_FENCE;
   let sectionEnd = CLOSED_FENCE;
   let body = "";
+  let truncated = false;
 
   const render = (start: FenceState, content: string, end: FenceState): string =>
     `${reopenPrefix(start)}${content}${closeSuffix(end)}`;
@@ -240,21 +257,25 @@ export function splitIntoSlackSections(
     body = "";
   };
 
-  const appendToken = (token: string, separator: string): void => {
-    const joined = body ? `${body}${separator}${token}` : token;
+  const appendToken = (token: string): boolean => {
+    const joined = body + token;
     const joinedEnd = advanceFence(sectionEnd, token);
     if (render(sectionStart, joined, joinedEnd).length <= maxChars) {
       body = joined;
       sectionEnd = joinedEnd;
-      return;
+      return true;
     }
 
     flush();
+    if (sections.length >= maxSections) {
+      truncated = true;
+      return false;
+    }
     const aloneEnd = advanceFence(sectionEnd, token);
     if (render(sectionStart, token, aloneEnd).length <= maxChars) {
       body = token;
       sectionEnd = aloneEnd;
-      return;
+      return true;
     }
 
     // Token exceeds a whole section on its own: slice it against the real budget.
@@ -265,35 +286,40 @@ export function splitIntoSlackSections(
       const reserveClose = start.open || advanceFence(start, rest).open;
       const budget =
         maxChars - reopenPrefix(start).length - (reserveClose ? closeSuffix(OPEN_FENCE).length : 0);
-      const taken = rest.slice(0, Math.max(1, budget));
+      const taken = sliceAtCodePointBoundary(rest, Math.max(1, budget));
       sectionStart = start;
       body = taken;
       sectionEnd = advanceFence(start, taken);
       rest = rest.slice(taken.length);
-      if (rest.length > 0) flush();
+      if (rest.length > 0) {
+        flush();
+        if (sections.length >= maxSections) {
+          truncated = true;
+          return false;
+        }
+      }
     }
+    return true;
   };
 
-  for (const paragraph of trimmed.split(/\n{2,}/)) {
-    if (paragraph.length <= maxChars) {
-      appendToken(paragraph, "\n\n");
+  sourceTokens: for (const sourceToken of trimmed.split(/(\n{2,})/)) {
+    if (!sourceToken) continue;
+    if (sourceToken.startsWith("\n\n") || sourceToken.length <= maxChars) {
+      if (!appendToken(sourceToken)) break;
       continue;
     }
-    // Oversized paragraph (long table, big code block): break on lines. Only the
-    // first line is a paragraph boundary; the rest are line continuations.
-    let atParagraphStart = true;
-    for (const line of paragraph.split("\n")) {
-      appendToken(line, atParagraphStart ? "\n\n" : "\n");
-      atParagraphStart = false;
+    // Oversized paragraph (long table, big code block): keep its line endings as
+    // source tokens so section boundaries never rewrite the original response.
+    for (const lineToken of sourceToken.split(/(\n)/)) {
+      if (lineToken && !appendToken(lineToken)) break sourceTokens;
     }
   }
-  flush();
+  if (!truncated) flush();
 
-  if (sections.length <= maxSections) return sections;
-  const kept = sections.slice(0, maxSections);
-  const lastIndex = maxSections - 1;
-  kept[lastIndex] = withTruncationMarker(kept[lastIndex], maxChars);
-  return kept;
+  if (!truncated) return sections;
+  const lastIndex = sections.length - 1;
+  sections[lastIndex] = withTruncationMarker(sections[lastIndex], maxChars);
+  return sections;
 }
 
 /**
@@ -309,7 +335,7 @@ function withTruncationMarker(section: string, maxChars: number): string {
   // fence this section opened *and* closed, which no trailing-fence check sees.
   const content = section.endsWith(closing) ? section.slice(0, -closing.length) : section;
   const room = maxChars - marker.length - closing.length;
-  const sliced = content.slice(0, Math.max(0, room));
+  const sliced = sliceAtCodePointBoundary(content, Math.max(0, room));
   const needsClose = (sliced.match(/```/g) ?? []).length % 2 !== 0;
   return `${sliced}${needsClose ? closing : ""}${marker}`;
 }

--- a/packages/slack-bot/src/completion/blocks.ts
+++ b/packages/slack-bot/src/completion/blocks.ts
@@ -211,6 +211,112 @@ function sliceAtCodePointBoundary(text: string, maxChars: number): string {
   return text.slice(0, end);
 }
 
+class SlackSectionAccumulator {
+  private readonly sections: string[] = [];
+  private sectionStart = CLOSED_FENCE;
+  private sectionEnd = CLOSED_FENCE;
+  private body = "";
+  private truncated = false;
+
+  constructor(
+    private readonly maxChars: number,
+    private readonly maxSections: number
+  ) {}
+
+  appendSourceToken(sourceToken: string): boolean {
+    if (!sourceToken) return true;
+    if (sourceToken.startsWith("\n\n") || sourceToken.length <= this.maxChars) {
+      return this.appendToken(sourceToken);
+    }
+
+    // Oversized paragraphs (long tables, big code blocks) fall back to line
+    // tokens while retaining their line endings.
+    for (const lineToken of sourceToken.split(/(\n)/)) {
+      if (lineToken && !this.appendToken(lineToken)) return false;
+    }
+    return true;
+  }
+
+  finish(): string[] {
+    if (!this.truncated) this.flush();
+    if (!this.truncated) return this.sections;
+
+    const lastIndex = this.sections.length - 1;
+    this.sections[lastIndex] = withTruncationMarker(this.sections[lastIndex], this.maxChars);
+    return this.sections;
+  }
+
+  private appendToken(token: string): boolean {
+    if (this.tryAppend(token)) return true;
+
+    this.flush();
+    if (this.stopAtSectionLimit()) return false;
+    if (this.tryAppend(token)) return true;
+
+    return this.appendOversizedToken(token);
+  }
+
+  private tryAppend(token: string): boolean {
+    const joined = this.body + token;
+    const joinedEnd = advanceFence(this.sectionEnd, token);
+    if (this.render(joined, joinedEnd).length > this.maxChars) return false;
+
+    this.body = joined;
+    this.sectionEnd = joinedEnd;
+    return true;
+  }
+
+  private appendOversizedToken(token: string): boolean {
+    let rest = token;
+    while (rest.length > 0) {
+      const taken = this.takeHardSlice(rest);
+      rest = rest.slice(taken.length);
+      if (rest.length === 0) continue;
+
+      this.flush();
+      if (this.stopAtSectionLimit()) return false;
+    }
+    return true;
+  }
+
+  private takeHardSlice(text: string): string {
+    const start = this.sectionEnd;
+    // Reserve the closing fence whenever this slice could end inside one.
+    const reserveClose = start.open || advanceFence(start, text).open;
+    const budget =
+      this.maxChars -
+      reopenPrefix(start).length -
+      (reserveClose ? closeSuffix(OPEN_FENCE).length : 0);
+    const taken = sliceAtCodePointBoundary(text, Math.max(1, budget));
+    if (!taken) {
+      throw new RangeError("Section budget is too small to fit the next Unicode code point");
+    }
+
+    this.sectionStart = start;
+    this.body = taken;
+    this.sectionEnd = advanceFence(start, taken);
+    return taken;
+  }
+
+  private flush(): void {
+    if (!this.body) return;
+    this.sections.push(this.render(this.body, this.sectionEnd));
+    // A fence left open carries into the next section, which reopens it.
+    this.sectionStart = this.sectionEnd;
+    this.body = "";
+  }
+
+  private stopAtSectionLimit(): boolean {
+    if (this.sections.length < this.maxSections) return false;
+    this.truncated = true;
+    return true;
+  }
+
+  private render(content: string, end: FenceState): string {
+    return `${reopenPrefix(this.sectionStart)}${content}${closeSuffix(end)}`;
+  }
+}
+
 /**
  * Split agent prose into Slack section blocks, preferring paragraph boundaries.
  *
@@ -239,90 +345,11 @@ export function splitIntoSlackSections(
   if (!text.trim()) return [];
   if (text.length <= maxChars) return [text];
 
-  const sections: string[] = [];
-  // Fence state where the in-progress section began, and where its body now ends.
-  let sectionStart = CLOSED_FENCE;
-  let sectionEnd = CLOSED_FENCE;
-  let body = "";
-  let truncated = false;
-
-  const render = (start: FenceState, content: string, end: FenceState): string =>
-    `${reopenPrefix(start)}${content}${closeSuffix(end)}`;
-
-  const flush = (): void => {
-    if (!body) return;
-    sections.push(render(sectionStart, body, sectionEnd));
-    // A fence left open carries into the next section, which reopens it.
-    sectionStart = sectionEnd;
-    body = "";
-  };
-
-  const appendToken = (token: string): boolean => {
-    const joined = body + token;
-    const joinedEnd = advanceFence(sectionEnd, token);
-    if (render(sectionStart, joined, joinedEnd).length <= maxChars) {
-      body = joined;
-      sectionEnd = joinedEnd;
-      return true;
-    }
-
-    flush();
-    if (sections.length >= maxSections) {
-      truncated = true;
-      return false;
-    }
-    const aloneEnd = advanceFence(sectionEnd, token);
-    if (render(sectionStart, token, aloneEnd).length <= maxChars) {
-      body = token;
-      sectionEnd = aloneEnd;
-      return true;
-    }
-
-    // Token exceeds a whole section on its own: slice it against the real budget.
-    let rest = token;
-    while (rest.length > 0) {
-      const start = sectionEnd;
-      // Reserve the closing fence whenever this slice could end inside one.
-      const reserveClose = start.open || advanceFence(start, rest).open;
-      const budget =
-        maxChars - reopenPrefix(start).length - (reserveClose ? closeSuffix(OPEN_FENCE).length : 0);
-      const taken = sliceAtCodePointBoundary(rest, Math.max(1, budget));
-      if (!taken) {
-        throw new RangeError("Section budget is too small to fit the next Unicode code point");
-      }
-      sectionStart = start;
-      body = taken;
-      sectionEnd = advanceFence(start, taken);
-      rest = rest.slice(taken.length);
-      if (rest.length > 0) {
-        flush();
-        if (sections.length >= maxSections) {
-          truncated = true;
-          return false;
-        }
-      }
-    }
-    return true;
-  };
-
-  sourceTokens: for (const sourceToken of text.split(/(\n{2,})/)) {
-    if (!sourceToken) continue;
-    if (sourceToken.startsWith("\n\n") || sourceToken.length <= maxChars) {
-      if (!appendToken(sourceToken)) break;
-      continue;
-    }
-    // Oversized paragraph (long table, big code block): keep its line endings as
-    // source tokens so section boundaries never rewrite the original response.
-    for (const lineToken of sourceToken.split(/(\n)/)) {
-      if (lineToken && !appendToken(lineToken)) break sourceTokens;
-    }
+  const accumulator = new SlackSectionAccumulator(maxChars, maxSections);
+  for (const sourceToken of text.split(/(\n{2,})/)) {
+    if (!accumulator.appendSourceToken(sourceToken)) break;
   }
-  if (!truncated) flush();
-
-  if (!truncated) return sections;
-  const lastIndex = sections.length - 1;
-  sections[lastIndex] = withTruncationMarker(sections[lastIndex], maxChars);
-  return sections;
+  return accumulator.finish();
 }
 
 /**

--- a/packages/slack-bot/src/completion/delivery.test.ts
+++ b/packages/slack-bot/src/completion/delivery.test.ts
@@ -113,6 +113,24 @@ describe("processSlackCompletion", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("lets Slack derive accessible fallback text from completion blocks", async () => {
+    vi.mocked(extractAgentResponse).mockResolvedValue({
+      ...successfulAgentResponse(),
+      mediaArtifacts: [],
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(Response.json({ ok: true, channel: "C123", ts: "333.444" }))
+      .mockResolvedValueOnce(Response.json({ ok: true }));
+
+    await processSlackCompletion(job(), makeEnv());
+
+    const request = fetchMock.mock.calls[0]?.[1];
+    const body = JSON.parse(String(request?.body)) as Record<string, unknown>;
+    expect(body).not.toHaveProperty("text");
+    expect(body.blocks).toBeDefined();
+  });
+
   it("skips media when the ordinary completion post fails", async () => {
     vi.mocked(extractAgentResponse).mockResolvedValue(successfulAgentResponse());
     const fetchMock = vi

--- a/packages/slack-bot/src/completion/delivery.ts
+++ b/packages/slack-bot/src/completion/delivery.ts
@@ -1,4 +1,4 @@
-import { postMessage, removeReaction } from "@open-inspect/shared";
+import { postBlocks, postMessage, removeReaction } from "@open-inspect/shared";
 import type { Env } from "../types";
 import { createLogger } from "../logger";
 import { extractAgentResponse } from "./extractor";
@@ -72,13 +72,10 @@ export async function processSlackCompletion(job: SlackCompletionJob, env: Env):
       },
       env.WEB_APP_URL
     );
-    const postResult = await postMessage(
-      env.SLACK_BOT_TOKEN,
-      job.channel,
-      // Without top-level text, Slack derives screen-reader text from the blocks.
-      undefined,
-      { thread_ts: job.threadTs, blocks }
-    );
+    // Without top-level text, Slack derives screen-reader text from the blocks.
+    const postResult = await postBlocks(env.SLACK_BOT_TOKEN, job.channel, blocks, {
+      thread_ts: job.threadTs,
+    });
     if (!postResult.ok) {
       log.warn("slack.completion.post", {
         ...base,

--- a/packages/slack-bot/src/completion/delivery.ts
+++ b/packages/slack-bot/src/completion/delivery.ts
@@ -2,7 +2,7 @@ import { postMessage, removeReaction } from "@open-inspect/shared";
 import type { Env } from "../types";
 import { createLogger } from "../logger";
 import { extractAgentResponse } from "./extractor";
-import { buildCompletionBlocks, getFallbackText, truncateError } from "./blocks";
+import { buildCompletionBlocks, truncateError } from "./blocks";
 import { deliverMediaArtifacts } from "./media-upload";
 import type { SlackCompletionJob } from "./job";
 
@@ -75,7 +75,8 @@ export async function processSlackCompletion(job: SlackCompletionJob, env: Env):
     const postResult = await postMessage(
       env.SLACK_BOT_TOKEN,
       job.channel,
-      getFallbackText(agentResponse),
+      // Without top-level text, Slack derives screen-reader text from the blocks.
+      undefined,
       { thread_ts: job.threadTs, blocks }
     );
     if (!postResult.ok) {


### PR DESCRIPTION
## Summary

Follow-up to #1147.

- preserve completion whitespace exactly and avoid splitting Unicode surrogate pairs at section or truncation boundaries
- recognize fenced spans that open and close on the same line, while retaining language metadata for continued fences
- stop section generation as soon as the 20-section response budget is exhausted
- omit top-level completion text so Slack derives screen-reader text from the full block content

## Root cause

The sectioner normalized paragraph separators, sliced UTF-16 strings at arbitrary code-unit offsets, and tracked at most one fence delimiter per line. It also generated the entire section list before truncating it. Completion delivery continued to send a 150-character top-level fallback, so assistive clients did not receive the expanded block content.

## TDD evidence

Each behavioral fix began with a regression that failed against merged `main`:

- same-line fenced content produced an odd fence count
- repeated blank lines and inter-section separators were not reconstructed exactly
- a boundary after 2,999 ASCII characters split an emoji into lone surrogates
- truncation-marker insertion could also cut through a surrogate pair
- the completion request still contained top-level `text` instead of allowing Slack to derive it from blocks

The existing block-budget regression remains green while generation now exits when the next section would exceed the configured budget.

## Validation

- `npm test -w @open-inspect/shared` — 500 passed
- `npm test -w @open-inspect/slack-bot` — 374 passed
- `npm run typecheck` — all workspaces passed
- shared and Slack-bot lint passed
- shared and Slack-bot builds passed
- Prettier and `git diff --check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a blocks-only Slack message helper, with optional thread context, enabling messages to be sent without a separate top-level text field.

- **Bug Fixes**
  - Improved long-response splitting to preserve whitespace, keep code fences balanced, and avoid breaking Unicode characters.
  - Made truncation more Unicode-safe, including insertion of the “...truncated” marker and safer budget handling.

- **Tests**
  - Added regression tests for section splitting, Unicode boundary behavior, code-fence correctness, truncation edge cases, and blocks-only payload structure.
  - Added coverage for the new blocks-posting helper and completion delivery payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->