### PR TITLE
Fix mobile sidebar swipe conflicting with browser back gesture

### DIFF
--- a/packages/web/src/components/sidebar-layout.test.tsx
+++ b/packages/web/src/components/sidebar-layout.test.tsx
@@ -76,7 +76,7 @@ describe("CollapsedSidebarControls", () => {
 });
 
 describe("mobile sidebar drag", () => {
-  it("opens after swiping right from the left edge", () => {
+  it("opens after swiping right from the inset edge handle", () => {
     mocks.isMobile = true;
     mocks.sidebar.isOpen = false;
     vi.mocked(useAuthSession).mockReturnValue({
@@ -91,22 +91,23 @@ describe("mobile sidebar drag", () => {
       width: 288,
     } as DOMRect);
     const dragHandle = screen.getByTestId("mobile-sidebar-drag-handle");
+    expect(dragHandle).toHaveClass("left-6", "w-6");
     fireEvent.pointerDown(dragHandle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 8,
+      clientX: 32,
       clientY: 200,
     });
     fireEvent.pointerMove(dragHandle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 100,
+      clientX: 124,
       clientY: 202,
     });
     fireEvent.pointerUp(dragHandle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 100,
+      clientX: 124,
       clientY: 202,
     });
 
@@ -131,13 +132,13 @@ describe("mobile sidebar drag", () => {
     fireEvent.pointerDown(dragHandle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 8,
+      clientX: 32,
       clientY: 200,
     });
     fireEvent.pointerMove(dragHandle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 50,
+      clientX: 74,
       clientY: 200,
     });
     fireEvent.pointerUp(dragHandle, { pointerId: 1, pointerType: "touch" });

--- a/packages/web/src/components/sidebar-layout.test.tsx
+++ b/packages/web/src/components/sidebar-layout.test.tsx
@@ -76,7 +76,7 @@ describe("CollapsedSidebarControls", () => {
 });
 
 describe("mobile sidebar drag", () => {
-  it("opens after swiping right from the inset edge handle", () => {
+  it("opens after swiping right from the inset activation zone", () => {
     mocks.isMobile = true;
     mocks.sidebar.isOpen = false;
     vi.mocked(useAuthSession).mockReturnValue({
@@ -90,21 +90,21 @@ describe("mobile sidebar drag", () => {
     vi.spyOn(screen.getByTestId("mobile-sidebar-drawer"), "getBoundingClientRect").mockReturnValue({
       width: 288,
     } as DOMRect);
-    const dragHandle = screen.getByTestId("mobile-sidebar-drag-handle");
-    expect(dragHandle).toHaveClass("left-6", "w-6");
-    fireEvent.pointerDown(dragHandle, {
+    const gestureBoundary = screen.getByTestId("mobile-sidebar-gesture-boundary");
+    expect(gestureBoundary).toHaveClass("touch-pan-y");
+    fireEvent.pointerDown(gestureBoundary, {
       pointerId: 1,
       pointerType: "touch",
       clientX: 32,
       clientY: 200,
     });
-    fireEvent.pointerMove(dragHandle, {
+    fireEvent.pointerMove(gestureBoundary, {
       pointerId: 1,
       pointerType: "touch",
       clientX: 124,
       clientY: 202,
     });
-    fireEvent.pointerUp(dragHandle, {
+    fireEvent.pointerUp(gestureBoundary, {
       pointerId: 1,
       pointerType: "touch",
       clientX: 124,
@@ -128,21 +128,60 @@ describe("mobile sidebar drag", () => {
     vi.spyOn(screen.getByTestId("mobile-sidebar-drawer"), "getBoundingClientRect").mockReturnValue({
       width: 288,
     } as DOMRect);
-    const dragHandle = screen.getByTestId("mobile-sidebar-drag-handle");
-    fireEvent.pointerDown(dragHandle, {
+    const gestureBoundary = screen.getByTestId("mobile-sidebar-gesture-boundary");
+    fireEvent.pointerDown(gestureBoundary, {
       pointerId: 1,
       pointerType: "touch",
       clientX: 32,
       clientY: 200,
     });
-    fireEvent.pointerMove(dragHandle, {
+    fireEvent.pointerMove(gestureBoundary, {
       pointerId: 1,
       pointerType: "touch",
       clientX: 74,
       clientY: 200,
     });
-    fireEvent.pointerUp(dragHandle, { pointerId: 1, pointerType: "touch" });
+    fireEvent.pointerUp(gestureBoundary, { pointerId: 1, pointerType: "touch" });
 
+    expect(mocks.sidebar.open).not.toHaveBeenCalled();
+  });
+
+  it("delivers taps in the activation zone to underlying content", () => {
+    mocks.isMobile = true;
+    mocks.sidebar.isOpen = false;
+    vi.mocked(useAuthSession).mockReturnValue({
+      data: { user: { id: "user-1", name: "Test User" } },
+      status: "authenticated",
+    });
+    vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as never);
+    const onPointerDown = vi.fn();
+    const onClick = vi.fn();
+
+    render(
+      <SidebarLayout>
+        <button onPointerDown={onPointerDown} onClick={onClick}>
+          Content action
+        </button>
+      </SidebarLayout>
+    );
+
+    const contentAction = screen.getByRole("button", { name: "Content action" });
+    fireEvent.pointerDown(contentAction, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 32,
+      clientY: 200,
+    });
+    fireEvent.pointerUp(contentAction, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 32,
+      clientY: 200,
+    });
+    fireEvent.click(contentAction);
+
+    expect(onPointerDown).toHaveBeenCalledOnce();
+    expect(onClick).toHaveBeenCalledOnce();
     expect(mocks.sidebar.open).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -171,19 +171,16 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
   return (
     <SidebarContext.Provider value={sidebar}>
       <AppShellActionsContext.Provider value={appShellActions}>
-        <div className="flex h-dvh overflow-hidden">
-          {isMobile && !sidebar.isOpen && (
-            <div
-              data-testid="mobile-sidebar-drag-handle"
-              className="fixed inset-y-0 left-6 z-50 w-6 touch-pan-y"
-              aria-hidden="true"
-              onPointerDown={sidebarPull.handlePointerDown}
-              onPointerMove={sidebarPull.handlePointerMove}
-              onPointerUp={sidebarPull.handlePointerUp}
-              onPointerCancel={sidebarPull.reset}
-              onContextMenu={(event) => event.preventDefault()}
-            />
-          )}
+        <div
+          data-testid="mobile-sidebar-gesture-boundary"
+          className={`flex h-dvh overflow-hidden ${
+            isMobile && !sidebar.isOpen ? "touch-pan-y" : ""
+          }`}
+          onPointerDownCapture={sidebarPull.handlePointerDown}
+          onPointerMoveCapture={sidebarPull.handlePointerMove}
+          onPointerUpCapture={sidebarPull.handlePointerUp}
+          onPointerCancelCapture={sidebarPull.reset}
+        >
           {/* Mobile: overlay backdrop */}
           {isMobile && (
             <div

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -179,7 +179,7 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
           onPointerDownCapture={sidebarPull.handlePointerDown}
           onPointerMoveCapture={sidebarPull.handlePointerMove}
           onPointerUpCapture={sidebarPull.handlePointerUp}
-          onPointerCancelCapture={sidebarPull.reset}
+          onPointerCancelCapture={sidebarPull.handlePointerCancel}
         >
           {/* Mobile: overlay backdrop */}
           {isMobile && (

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -175,7 +175,7 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
           {isMobile && !sidebar.isOpen && (
             <div
               data-testid="mobile-sidebar-drag-handle"
-              className="fixed inset-y-0 left-0 z-50 w-5 touch-pan-y"
+              className="fixed inset-y-0 left-6 z-50 w-6 touch-pan-y"
               aria-hidden="true"
               onPointerDown={sidebarPull.handlePointerDown}
               onPointerMove={sidebarPull.handlePointerMove}

--- a/packages/web/src/hooks/use-mobile-sidebar-pull.test.tsx
+++ b/packages/web/src/hooks/use-mobile-sidebar-pull.test.tsx
@@ -45,13 +45,13 @@ describe("useMobileSidebarPull", () => {
     fireEvent.pointerDown(handle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 8,
+      clientX: 32,
       clientY: 200,
     });
     fireEvent.pointerMove(handle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 12,
+      clientX: 36,
       clientY: 250,
     });
     fireEvent.pointerUp(handle, { pointerId: 1, pointerType: "touch" });
@@ -71,10 +71,32 @@ describe("useMobileSidebarPull", () => {
     fireEvent.pointerDown(handle, {
       pointerId: 1,
       pointerType: "touch",
-      clientX: 8,
+      clientX: 32,
       clientY: 200,
     });
     rerender(<Harness onOpen={onOpen} {...props} />);
+    fireEvent.pointerMove(handle, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 152,
+      clientY: 200,
+    });
+    fireEvent.pointerUp(handle, { pointerId: 1, pointerType: "touch" });
+
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("ignores pulls that start in the browser edge gesture zone", () => {
+    const onOpen = vi.fn();
+    const { getByTestId } = render(<Harness onOpen={onOpen} />);
+    const handle = getByTestId("handle");
+
+    fireEvent.pointerDown(handle, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 8,
+      clientY: 200,
+    });
     fireEvent.pointerMove(handle, {
       pointerId: 1,
       pointerType: "touch",

--- a/packages/web/src/hooks/use-mobile-sidebar-pull.test.tsx
+++ b/packages/web/src/hooks/use-mobile-sidebar-pull.test.tsx
@@ -27,7 +27,7 @@ function Harness({
       onPointerDown={pull.handlePointerDown}
       onPointerMove={pull.handlePointerMove}
       onPointerUp={pull.handlePointerUp}
-      onPointerCancel={pull.reset}
+      onPointerCancel={pull.handlePointerCancel}
     />
   );
 }
@@ -106,5 +106,44 @@ describe("useMobileSidebarPull", () => {
     fireEvent.pointerUp(handle, { pointerId: 1, pointerType: "touch" });
 
     expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("ignores events from pointers that did not initiate the drag", () => {
+    const onOpen = vi.fn();
+    const { getByTestId } = render(<Harness onOpen={onOpen} />);
+    const handle = getByTestId("handle");
+
+    fireEvent.pointerDown(handle, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 32,
+      clientY: 200,
+    });
+    fireEvent.pointerMove(handle, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 112,
+      clientY: 200,
+    });
+    fireEvent.pointerDown(handle, {
+      pointerId: 2,
+      pointerType: "touch",
+      clientX: 32,
+      clientY: 200,
+    });
+    fireEvent.pointerMove(handle, {
+      pointerId: 2,
+      pointerType: "touch",
+      clientX: 152,
+      clientY: 200,
+    });
+    fireEvent.pointerCancel(handle, { pointerId: 2, pointerType: "touch" });
+    fireEvent.pointerUp(handle, { pointerId: 2, pointerType: "touch" });
+
+    expect(handle.dataset.dragging).toBe("true");
+    expect(onOpen).not.toHaveBeenCalled();
+
+    fireEvent.pointerUp(handle, { pointerId: 1, pointerType: "touch" });
+    expect(onOpen).toHaveBeenCalledOnce();
   });
 });

--- a/packages/web/src/hooks/use-mobile-sidebar-pull.ts
+++ b/packages/web/src/hooks/use-mobile-sidebar-pull.ts
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useRef, useState, type PointerEvent } from "rea
 
 const DIRECTION_LOCK_THRESHOLD_PX = 8;
 const OPEN_THRESHOLD_PX = 72;
+const PULL_START_MIN_X_PX = 24;
+const PULL_START_MAX_X_PX = 48;
 
 interface UseMobileSidebarPullOptions {
   isMobile: boolean;
@@ -42,6 +44,7 @@ export function useMobileSidebarPull({
   const handlePointerDown = useCallback(
     (event: PointerEvent<HTMLDivElement>) => {
       if (!isEnabled || (event.pointerType === "mouse" && event.button !== 0)) return;
+      if (event.clientX < PULL_START_MIN_X_PX || event.clientX > PULL_START_MAX_X_PX) return;
 
       const sidebarWidth = getSidebarWidth();
       if (sidebarWidth <= 0) return;
@@ -49,7 +52,6 @@ export function useMobileSidebarPull({
       reset();
       sidebarWidthRef.current = sidebarWidth;
       dragStartRef.current = { x: event.clientX, y: event.clientY };
-      event.currentTarget.setPointerCapture?.(event.pointerId);
       setIsDragging(true);
     },
     [getSidebarWidth, isEnabled, reset]
@@ -70,6 +72,7 @@ export function useMobileSidebarPull({
       }
 
       event.preventDefault();
+      event.currentTarget.setPointerCapture?.(event.pointerId);
       const distance = Math.min(sidebarWidthRef.current, Math.max(0, deltaX));
       dragDistanceRef.current = distance;
       setDragDistance(distance);

--- a/packages/web/src/hooks/use-mobile-sidebar-pull.ts
+++ b/packages/web/src/hooks/use-mobile-sidebar-pull.ts
@@ -26,12 +26,14 @@ export function useMobileSidebarPull({
   const dragStartRef = useRef<{ x: number; y: number } | null>(null);
   const dragDistanceRef = useRef(0);
   const sidebarWidthRef = useRef(0);
+  const activePointerIdRef = useRef<number | null>(null);
   const isEnabled = isMobile && !isSidebarOpen;
 
   const reset = useCallback(() => {
     dragStartRef.current = null;
     dragDistanceRef.current = 0;
     sidebarWidthRef.current = 0;
+    activePointerIdRef.current = null;
     setDragDistance(0);
     setDragProgress(0);
     setIsDragging(false);
@@ -44,12 +46,14 @@ export function useMobileSidebarPull({
   const handlePointerDown = useCallback(
     (event: PointerEvent<HTMLDivElement>) => {
       if (!isEnabled || (event.pointerType === "mouse" && event.button !== 0)) return;
+      if (activePointerIdRef.current !== null) return;
       if (event.clientX < PULL_START_MIN_X_PX || event.clientX > PULL_START_MAX_X_PX) return;
 
       const sidebarWidth = getSidebarWidth();
       if (sidebarWidth <= 0) return;
 
       reset();
+      activePointerIdRef.current = event.pointerId;
       sidebarWidthRef.current = sidebarWidth;
       dragStartRef.current = { x: event.clientX, y: event.clientY };
       setIsDragging(true);
@@ -59,6 +63,8 @@ export function useMobileSidebarPull({
 
   const handlePointerMove = useCallback(
     (event: PointerEvent<HTMLDivElement>) => {
+      if (activePointerIdRef.current !== event.pointerId) return;
+
       const start = dragStartRef.current;
       if (!start) return;
 
@@ -81,11 +87,23 @@ export function useMobileSidebarPull({
     [reset]
   );
 
-  const handlePointerUp = useCallback(() => {
-    const shouldOpen = dragDistanceRef.current >= OPEN_THRESHOLD_PX;
-    reset();
-    if (shouldOpen) onOpen();
-  }, [onOpen, reset]);
+  const handlePointerUp = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (activePointerIdRef.current !== event.pointerId) return;
+
+      const shouldOpen = dragDistanceRef.current >= OPEN_THRESHOLD_PX;
+      reset();
+      if (shouldOpen) onOpen();
+    },
+    [onOpen, reset]
+  );
+
+  const handlePointerCancel = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (activePointerIdRef.current === event.pointerId) reset();
+    },
+    [reset]
+  );
 
   return {
     dragDistance,
@@ -95,5 +113,6 @@ export function useMobileSidebarPull({
     handlePointerDown,
     handlePointerMove,
     handlePointerUp,
+    handlePointerCancel,
   };
 }


### PR DESCRIPTION
## Summary
- inset the mobile sidebar swipe handle away from the viewport edge
- widen the inset gesture target slightly to preserve usability
- update gesture tests to exercise and assert the new activation zone

## Testing
- `npm test -w @open-inspect/web -- src/components/sidebar-layout.test.tsx src/hooks/use-mobile-sidebar-pull.test.tsx`
- `npx eslint src/components/sidebar-layout.tsx src/components/sidebar-layout.test.tsx`
- commit hooks: ESLint and Prettier

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/19614de966e9a6b537df3d4c11df4319)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Reworked the mobile sidebar swipe interaction to use a larger, consistent activation zone for more reliable gestures across the layout.

* **Bug Fixes**
  * Prevented unintended sidebar opens when pulls begin in the browser edge gesture zone.
  * Improved pull cancellation and direction-lock behavior, including handling when the active pointer changes.

* **Tests**
  * Updated mobile sidebar and pull-gesture tests to reflect the new activation zone behavior and pointer handling.
  * Added coverage for ignoring non-initiating pointer interactions and for pointer cancel scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->