### PR TITLE
fix(slack): expand completion response sections

### DIFF
--- a/packages/slack-bot/src/completion/blocks.test.ts
+++ b/packages/slack-bot/src/completion/blocks.test.ts
@@ -211,6 +211,20 @@ describe("long response handling", () => {
     expect(texts.join(" ")).not.toContain("truncated");
   });
 
+  it("requests expanded rendering for every completion response section", () => {
+    const responseSections = buildCompletionBlocks(
+      "sess-1",
+      { ...BASE_RESPONSE, textContent: "x".repeat(4000) },
+      BASE_CONTEXT,
+      "https://inspect.example.com"
+    ).filter((block) => block.type === "section");
+
+    expect(responseSections.length).toBeGreaterThan(1);
+    for (const block of responseSections) {
+      expect(block).toHaveProperty("expand", true);
+    }
+  });
+
   it("preserves whitespace exactly across section boundaries", () => {
     const textContent = `\n  alpha\n\n\n\n\nbeta\n\n${"x".repeat(4000)}  \n`;
     const sections = splitIntoSlackSections(textContent);

--- a/packages/slack-bot/src/completion/blocks.ts
+++ b/packages/slack-bot/src/completion/blocks.ts
@@ -10,6 +10,7 @@ import { escapeMrkdwnText, type ManualPullRequestArtifactMetadata } from "@open-
  */
 interface SlackBlock {
   type: string;
+  expand?: boolean;
   text?: { type: string; text: string };
   elements?: Array<{ type: string; text?: unknown; url?: string; action_id?: string }>;
 }
@@ -61,7 +62,7 @@ export function buildCompletionBlocks(
     blocks.push({ type: "section", text: { type: "mrkdwn", text: "_Agent completed._" } });
   } else {
     for (const section of sections) {
-      blocks.push({ type: "section", text: { type: "mrkdwn", text: section } });
+      blocks.push({ type: "section", expand: true, text: { type: "mrkdwn", text: section } });
     }
   }
 

--- a/packages/slack-bot/src/completion/blocks.ts
+++ b/packages/slack-bot/src/completion/blocks.ts
@@ -3,17 +3,15 @@
  */
 
 import type { AgentResponse, SlackCallbackContext } from "../types";
+import type {
+  SlackActionsBlock,
+  SlackButtonElement,
+  SlackContextBlock,
+  SlackSectionBlock,
+} from "../slack-blocks";
 import { escapeMrkdwnText, type ManualPullRequestArtifactMetadata } from "@open-inspect/shared";
 
-/**
- * Slack Block Kit block type (subset).
- */
-interface SlackBlock {
-  type: string;
-  expand?: boolean;
-  text?: { type: string; text: string };
-  elements?: Array<{ type: string; text?: unknown; url?: string; action_id?: string }>;
-}
+type CompletionSlackBlock = SlackSectionBlock | SlackContextBlock | SlackActionsBlock;
 
 /**
  * Status emoji constants.
@@ -53,8 +51,8 @@ export function buildCompletionBlocks(
   response: AgentResponse,
   context: SlackCallbackContext,
   webAppUrl: string
-): SlackBlock[] {
-  const blocks: SlackBlock[] = [];
+): CompletionSlackBlock[] {
+  const blocks: CompletionSlackBlock[] = [];
 
   // 1. Response text, split across as many section blocks as it needs
   const sections = splitIntoSlackSections(response.textContent);
@@ -110,12 +108,7 @@ export function buildCompletionBlocks(
 
   const hasPrArtifact = response.artifacts.some((artifact) => artifact.type === "pr");
   const manualCreatePrUrl = getManualCreatePrUrl(response.artifacts);
-  const actionElements: Array<{
-    type: string;
-    text: { type: string; text: string };
-    url: string;
-    action_id: string;
-  }> = [
+  const actionElements: SlackButtonElement[] = [
     {
       type: "button",
       text: { type: "plain_text", text: "View Session" },

--- a/packages/slack-bot/src/slack-blocks.ts
+++ b/packages/slack-bot/src/slack-blocks.ts
@@ -34,6 +34,7 @@ export type SlackButtonElement = {
   action_id: string;
   text: SlackPlainText;
   value?: string;
+  url?: string;
   style?: "danger";
   confirm?: SlackConfirmation;
 };
@@ -69,6 +70,7 @@ export type SlackHeaderBlock = { type: "header"; text: SlackPlainText };
 export type SlackSectionBlock = {
   type: "section";
   text: SlackText;
+  expand?: boolean;
   // A section accessory may be a button or a select (the repo clarification
   // picker uses an external_select), not only a button.
   accessory?: SlackBlockElement;


### PR DESCRIPTION
## Summary

- request expanded rendering for every non-empty agent completion section
- preserve the existing 3,000-character section packing and truncation behavior
- add a regression covering multi-section completion payloads

## Context

Slack may render long section blocks behind repeated "Show more" controls when `expand` is omitted. Setting `expand: true` is the documented Slack behavior for long AI responses: https://docs.slack.dev/reference/block-kit/blocks/section-block/

## Test plan

- `npm run test -w @open-inspect/slack-bot -- src/completion/blocks.test.ts`
- `npm run test -w @open-inspect/slack-bot`
- `npm run typecheck`
- `npm run lint -w @open-inspect/slack-bot`
- `npm run build -w @open-inspect/slack-bot`
- Prettier and `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack completion blocks now use expandable sections for long responses to make reading easier in the Slack message.
* **Bug Fixes**
  * Ensures every chunked section of an oversized completion is consistently marked to expand, so they present correctly in the UI.
* **Tests**
  * Added regression coverage for expansion behavior with very large completion text and to prevent regressions in chunking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->