### PR TITLE
fix: expose GitHub global model defaults

### DIFF
--- a/docs/integrations/GITHUB.md
+++ b/docs/integrations/GITHUB.md
@@ -130,11 +130,13 @@ Open the web app and go to **Settings > Integrations > GitHub** to configure the
 
 ### Defaults and Scope
 
-| Setting               | What it controls                                                                      |
-| --------------------- | ------------------------------------------------------------------------------------- |
-| Auto-review new PRs   | Whether new non-draft PRs should be reviewed automatically                            |
-| Repository Scope      | Whether the bot responds in all accessible repositories or only selected repositories |
-| Allowed Trigger Users | Who can trigger the bot from GitHub                                                   |
+| Setting                  | What it controls                                                                      |
+| ------------------------ | ------------------------------------------------------------------------------------- |
+| Default model            | Model used for GitHub-started sessions when a repository does not override it         |
+| Default reasoning effort | Reasoning depth used with the selected default model                                  |
+| Auto-review new PRs      | Whether new non-draft PRs should be reviewed automatically                            |
+| Repository Scope         | Whether the bot responds in all accessible repositories or only selected repositories |
+| Allowed Trigger Users    | Who can trigger the bot from GitHub                                                   |
 
 If no GitHub Bot settings are configured, Open-Inspect uses permissive defaults: all repositories
 available to the GitHub App are in scope, auto-review is enabled, and users with write, maintain, or
@@ -156,10 +158,8 @@ repository, event type, enabled state, and trigger conditions.
 | Comment Action Instructions | Extra guidance appended to `@mention` action prompts                      |
 | Repository Overrides        | Per-repository overrides for model, reasoning, instructions, and behavior |
 
-Repository overrides take priority over global defaults for the repository they apply to. The web UI
-currently exposes model and reasoning settings on repository overrides. If global model or reasoning
-defaults exist in integration settings, GitHub-started sessions honor them. If neither a repository
-override nor global default sets a model, sessions use the deployment default model.
+Repository overrides take priority over global defaults for the repository they apply to. If neither
+a repository override nor global default sets a model, sessions use the deployment default model.
 
 ### Commit Signing
 

--- a/packages/web/src/components/settings/integrations/github-integration-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/github-integration-settings.test.tsx
@@ -183,6 +183,62 @@ describe("GitHubIntegrationSettings", () => {
     );
   });
 
+  it("clears global model defaults without resetting unrelated settings", async () => {
+    const user = userEvent.setup();
+    setupSWR({
+      global: {
+        defaults: {
+          autoReviewOnOpen: false,
+          model: "anthropic/claude-sonnet-4-6",
+          reasoningEffort: "high",
+          codeReviewInstructions: "Focus on security.",
+        },
+      },
+    });
+    fetchMock.mockResolvedValue(okJson({}));
+
+    render(<GitHubIntegrationSettings />);
+
+    await user.click(screen.getByRole("combobox", { name: "Default reasoning effort" }));
+    await user.click(await screen.findByRole("option", { name: "Use model default" }));
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "/api/integration-settings/github",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({
+          settings: {
+            defaults: {
+              autoReviewOnOpen: false,
+              model: "anthropic/claude-sonnet-4-6",
+              codeReviewInstructions: "Focus on security.",
+            },
+          },
+        }),
+      })
+    );
+
+    await user.click(screen.getByRole("combobox", { name: "Default model" }));
+    await user.click(await screen.findByRole("option", { name: "Use system default" }));
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "/api/integration-settings/github",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({
+          settings: {
+            defaults: {
+              autoReviewOnOpen: false,
+              codeReviewInstructions: "Focus on security.",
+            },
+          },
+        }),
+      })
+    );
+  });
+
   it("repo auto-review override without an explicit value seeds from global default when saved", async () => {
     const user = userEvent.setup();
     setupSWR({

--- a/packages/web/src/components/settings/integrations/github-integration-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/github-integration-settings.test.tsx
@@ -31,7 +31,12 @@ vi.mock("swr", () => ({
 
 vi.mock("@/hooks/use-enabled-models", () => ({
   useEnabledModels: () => ({
-    enabledModelOptions: [],
+    enabledModelOptions: [
+      {
+        category: "Anthropic",
+        models: [{ id: "anthropic/claude-sonnet-4-6", name: "Claude Sonnet 4.6" }],
+      },
+    ],
   }),
 }));
 
@@ -134,6 +139,50 @@ afterEach(() => {
 });
 
 describe("GitHubIntegrationSettings", () => {
+  it("renders and preserves global model and reasoning defaults", async () => {
+    const user = userEvent.setup();
+    setupSWR({
+      global: {
+        defaults: {
+          autoReviewOnOpen: true,
+          model: "anthropic/claude-sonnet-4-6",
+          reasoningEffort: "high",
+        },
+      },
+    });
+    fetchMock.mockResolvedValue(okJson({}));
+
+    render(<GitHubIntegrationSettings />);
+
+    expect(screen.getByText("Default model")).toBeInTheDocument();
+    expect(screen.getByText("Default reasoning effort")).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Default model" })).toHaveTextContent(
+      "Claude Sonnet 4.6"
+    );
+    expect(screen.getByRole("combobox", { name: "Default reasoning effort" })).toHaveTextContent(
+      "high"
+    );
+
+    await user.click(screen.getByRole("switch", { name: /auto-review new prs/i }));
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/integration-settings/github",
+      expect.objectContaining({
+        method: "PUT",
+        body: JSON.stringify({
+          settings: {
+            defaults: {
+              autoReviewOnOpen: false,
+              model: "anthropic/claude-sonnet-4-6",
+              reasoningEffort: "high",
+            },
+          },
+        }),
+      })
+    );
+  });
+
   it("repo auto-review override without an explicit value seeds from global default when saved", async () => {
     const user = userEvent.setup();
     setupSWR({

--- a/packages/web/src/components/settings/integrations/github-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/github-integration-settings.tsx
@@ -105,7 +105,11 @@ export function GitHubIntegrationSettings() {
 
       <CommitSigningSettings />
 
-      <GlobalSettingsSection settings={settings} availableRepos={availableRepos} />
+      <GlobalSettingsSection
+        settings={settings}
+        availableRepos={availableRepos}
+        enabledModelOptions={enabledModelOptions}
+      />
 
       <Section
         title="Repository Overrides"
@@ -125,10 +129,14 @@ export function GitHubIntegrationSettings() {
 function GlobalSettingsSection({
   settings,
   availableRepos,
+  enabledModelOptions,
 }: {
   settings: GitHubGlobalConfig | null | undefined;
   availableRepos: EnrichedRepository[];
+  enabledModelOptions: { category: string; models: { id: string; name: string }[] }[];
 }) {
+  const [model, setModel] = useState(settings?.defaults?.model ?? "");
+  const [effort, setEffort] = useState(settings?.defaults?.reasoningEffort ?? "");
   const [autoReviewOnOpen, setAutoReviewOnOpen] = useState(
     settings?.defaults?.autoReviewOnOpen ?? true
   );
@@ -158,6 +166,8 @@ function GlobalSettingsSection({
   useEffect(() => {
     if (settings !== undefined && !initialized) {
       if (settings) {
+        setModel(settings.defaults?.model ?? "");
+        setEffort(settings.defaults?.reasoningEffort ?? "");
         setAutoReviewOnOpen(settings.defaults?.autoReviewOnOpen ?? true);
         setEnabledRepos(settings.enabledRepos ?? []);
         setRepoScopeMode(settings.enabledRepos === undefined ? "all" : "selected");
@@ -173,6 +183,7 @@ function GlobalSettingsSection({
   }, [settings, initialized]);
 
   const isConfigured = settings !== null && settings !== undefined;
+  const reasoningConfig = model ? MODEL_REASONING_CONFIG[model as ValidModel] : undefined;
 
   const handleReset = () => {
     setShowResetDialog(true);
@@ -187,6 +198,8 @@ function GlobalSettingsSection({
 
       if (res.ok) {
         mutate(GLOBAL_SETTINGS_KEY);
+        setModel("");
+        setEffort("");
         setAutoReviewOnOpen(true);
         setEnabledRepos([]);
         setRepoScopeMode("all");
@@ -215,6 +228,8 @@ function GlobalSettingsSection({
     const body: GitHubGlobalConfig = {
       defaults: {
         autoReviewOnOpen,
+        ...(model ? { model } : {}),
+        ...(effort ? { reasoningEffort: effort } : {}),
         ...(triggerUserMode === "specific" ? { allowedTriggerUsers } : {}),
         ...(codeReviewInstructions ? { codeReviewInstructions } : {}),
         ...(commentActionInstructions ? { commentActionInstructions } : {}),
@@ -269,6 +284,63 @@ function GlobalSettingsSection({
   return (
     <Section title="Defaults & Scope" description="Global behavior and repository scope.">
       {error && <Message tone="error" text={error} />}
+
+      <div className="grid sm:grid-cols-2 gap-3 mb-4">
+        <label className="text-sm">
+          <span className="block text-foreground font-medium mb-1">Default model</span>
+          <Select
+            value={model}
+            onValueChange={(nextModel) => {
+              setModel(nextModel);
+              if (effort && !isValidReasoningEffort(nextModel, effort)) {
+                setEffort("");
+              }
+              setDirty(true);
+              setError("");
+            }}
+          >
+            <SelectTrigger className="w-full" aria-label="Default model">
+              <SelectValue placeholder="Use system default" />
+            </SelectTrigger>
+            <SelectContent>
+              {enabledModelOptions.map((group) => (
+                <SelectGroup key={group.category}>
+                  <SelectLabel>{group.category}</SelectLabel>
+                  {group.models.map((option) => (
+                    <SelectItem key={option.id} value={option.id}>
+                      {option.name}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              ))}
+            </SelectContent>
+          </Select>
+        </label>
+
+        <label className="text-sm">
+          <span className="block text-foreground font-medium mb-1">Default reasoning effort</span>
+          <Select
+            value={effort}
+            onValueChange={(value) => {
+              setEffort(value);
+              setDirty(true);
+              setError("");
+            }}
+            disabled={!reasoningConfig}
+          >
+            <SelectTrigger className="w-full" aria-label="Default reasoning effort">
+              <SelectValue placeholder="Use model default" />
+            </SelectTrigger>
+            <SelectContent>
+              {(reasoningConfig?.efforts ?? []).map((value) => (
+                <SelectItem key={value} value={value}>
+                  {value}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </label>
+      </div>
 
       <label
         htmlFor="auto-review-toggle"

--- a/packages/web/src/components/settings/integrations/github-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/github-integration-settings.tsx
@@ -11,6 +11,7 @@ import {
   type EnrichedRepository,
   type GitHubBotSettings,
   type GitHubGlobalConfig,
+  type ModelCategory,
   type ValidModel,
 } from "@open-inspect/shared";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
@@ -42,6 +43,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { CommitSigningSettings } from "./commit-signing-settings";
+import { ModelReasoningDefaultsFields } from "./model-reasoning-defaults-fields";
 
 const GLOBAL_SETTINGS_KEY = "/api/integration-settings/github";
 const REPO_SETTINGS_KEY = "/api/integration-settings/github/repos";
@@ -133,7 +135,7 @@ function GlobalSettingsSection({
 }: {
   settings: GitHubGlobalConfig | null | undefined;
   availableRepos: EnrichedRepository[];
-  enabledModelOptions: { category: string; models: { id: string; name: string }[] }[];
+  enabledModelOptions: ModelCategory[];
 }) {
   const [model, setModel] = useState(settings?.defaults?.model ?? "");
   const [effort, setEffort] = useState(settings?.defaults?.reasoningEffort ?? "");
@@ -183,8 +185,6 @@ function GlobalSettingsSection({
   }, [settings, initialized]);
 
   const isConfigured = settings !== null && settings !== undefined;
-  const reasoningConfig = model ? MODEL_REASONING_CONFIG[model as ValidModel] : undefined;
-
   const handleReset = () => {
     setShowResetDialog(true);
   };
@@ -285,62 +285,17 @@ function GlobalSettingsSection({
     <Section title="Defaults & Scope" description="Global behavior and repository scope.">
       {error && <Message tone="error" text={error} />}
 
-      <div className="grid sm:grid-cols-2 gap-3 mb-4">
-        <label className="text-sm">
-          <span className="block text-foreground font-medium mb-1">Default model</span>
-          <Select
-            value={model}
-            onValueChange={(nextModel) => {
-              setModel(nextModel);
-              if (effort && !isValidReasoningEffort(nextModel, effort)) {
-                setEffort("");
-              }
-              setDirty(true);
-              setError("");
-            }}
-          >
-            <SelectTrigger className="w-full" aria-label="Default model">
-              <SelectValue placeholder="Use system default" />
-            </SelectTrigger>
-            <SelectContent>
-              {enabledModelOptions.map((group) => (
-                <SelectGroup key={group.category}>
-                  <SelectLabel>{group.category}</SelectLabel>
-                  {group.models.map((option) => (
-                    <SelectItem key={option.id} value={option.id}>
-                      {option.name}
-                    </SelectItem>
-                  ))}
-                </SelectGroup>
-              ))}
-            </SelectContent>
-          </Select>
-        </label>
-
-        <label className="text-sm">
-          <span className="block text-foreground font-medium mb-1">Default reasoning effort</span>
-          <Select
-            value={effort}
-            onValueChange={(value) => {
-              setEffort(value);
-              setDirty(true);
-              setError("");
-            }}
-            disabled={!reasoningConfig}
-          >
-            <SelectTrigger className="w-full" aria-label="Default reasoning effort">
-              <SelectValue placeholder="Use model default" />
-            </SelectTrigger>
-            <SelectContent>
-              {(reasoningConfig?.efforts ?? []).map((value) => (
-                <SelectItem key={value} value={value}>
-                  {value}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </label>
-      </div>
+      <ModelReasoningDefaultsFields
+        model={model}
+        reasoningEffort={effort}
+        modelOptions={enabledModelOptions}
+        onChange={(nextModel, nextEffort) => {
+          setModel(nextModel);
+          setEffort(nextEffort);
+          setDirty(true);
+          setError("");
+        }}
+      />
 
       <label
         htmlFor="auto-review-toggle"
@@ -598,7 +553,7 @@ function RepoOverridesSection({
 }: {
   overrides: RepoSettingsEntry[];
   availableRepos: EnrichedRepository[];
-  enabledModelOptions: { category: string; models: { id: string; name: string }[] }[];
+  enabledModelOptions: ModelCategory[];
   defaultAutoReviewOnOpen: boolean;
 }) {
   const [addingRepo, setAddingRepo] = useState("");
@@ -682,7 +637,7 @@ function RepoOverrideRow({
   defaultAutoReviewOnOpen,
 }: {
   entry: RepoSettingsEntry;
-  enabledModelOptions: { category: string; models: { id: string; name: string }[] }[];
+  enabledModelOptions: ModelCategory[];
   defaultAutoReviewOnOpen: boolean;
 }) {
   const [model, setModel] = useState(entry.settings.model ?? "");

--- a/packages/web/src/components/settings/integrations/linear-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/linear-integration-settings.tsx
@@ -11,6 +11,7 @@ import {
   type EnrichedRepository,
   type LinearBotSettings,
   type LinearGlobalConfig,
+  type ModelCategory,
   type ValidModel,
 } from "@open-inspect/shared";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
@@ -39,6 +40,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { ModelReasoningDefaultsFields } from "./model-reasoning-defaults-fields";
 
 const GLOBAL_SETTINGS_KEY = "/api/integration-settings/linear";
 const REPO_SETTINGS_KEY = "/api/integration-settings/linear/repos";
@@ -125,7 +127,7 @@ function GlobalSettingsSection({
 }: {
   settings: LinearGlobalConfig | null | undefined;
   availableRepos: EnrichedRepository[];
-  enabledModelOptions: { category: string; models: { id: string; name: string }[] }[];
+  enabledModelOptions: ModelCategory[];
 }) {
   const [model, setModel] = useState(settings?.defaults?.model ?? "");
   const [effort, setEffort] = useState(settings?.defaults?.reasoningEffort ?? "");
@@ -168,8 +170,6 @@ function GlobalSettingsSection({
   }, [settings, initialized]);
 
   const isConfigured = settings !== null && settings !== undefined;
-  const reasoningConfig = model ? MODEL_REASONING_CONFIG[model as ValidModel] : undefined;
-
   const resetNotice =
     "Reset all Linear settings to defaults? This enables both label/user model overrides.";
 
@@ -264,62 +264,17 @@ function GlobalSettingsSection({
     >
       {error && <Message tone="error" text={error} />}
 
-      <div className="grid sm:grid-cols-2 gap-3 mb-4">
-        <label className="text-sm">
-          <span className="block text-foreground font-medium mb-1">Default model</span>
-          <Select
-            value={model}
-            onValueChange={(nextModel) => {
-              setModel(nextModel);
-              if (effort && nextModel && !isValidReasoningEffort(nextModel, effort)) {
-                setEffort("");
-              }
-              setDirty(true);
-              setError("");
-            }}
-          >
-            <SelectTrigger className="w-full">
-              <SelectValue placeholder="Use system default" />
-            </SelectTrigger>
-            <SelectContent>
-              {enabledModelOptions.map((group) => (
-                <SelectGroup key={group.category}>
-                  <SelectLabel>{group.category}</SelectLabel>
-                  {group.models.map((m) => (
-                    <SelectItem key={m.id} value={m.id}>
-                      {m.name}
-                    </SelectItem>
-                  ))}
-                </SelectGroup>
-              ))}
-            </SelectContent>
-          </Select>
-        </label>
-
-        <label className="text-sm">
-          <span className="block text-foreground font-medium mb-1">Default reasoning effort</span>
-          <Select
-            value={effort}
-            onValueChange={(v) => {
-              setEffort(v);
-              setDirty(true);
-              setError("");
-            }}
-            disabled={!reasoningConfig}
-          >
-            <SelectTrigger className="w-full">
-              <SelectValue placeholder="Use model default" />
-            </SelectTrigger>
-            <SelectContent>
-              {(reasoningConfig?.efforts ?? []).map((value) => (
-                <SelectItem key={value} value={value}>
-                  {value}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </label>
-      </div>
+      <ModelReasoningDefaultsFields
+        model={model}
+        reasoningEffort={effort}
+        modelOptions={enabledModelOptions}
+        onChange={(nextModel, nextEffort) => {
+          setModel(nextModel);
+          setEffort(nextEffort);
+          setDirty(true);
+          setError("");
+        }}
+      />
 
       <div className="grid sm:grid-cols-2 gap-2 mb-4">
         <label className="flex items-center justify-between px-3 py-2 border border-border rounded-sm cursor-pointer hover:bg-muted/50 transition text-sm">
@@ -485,7 +440,7 @@ function RepoOverridesSection({
 }: {
   overrides: RepoSettingsEntry[];
   availableRepos: EnrichedRepository[];
-  enabledModelOptions: { category: string; models: { id: string; name: string }[] }[];
+  enabledModelOptions: ModelCategory[];
 }) {
   const [addingRepo, setAddingRepo] = useState("");
 
@@ -566,7 +521,7 @@ function RepoOverrideRow({
   enabledModelOptions,
 }: {
   entry: RepoSettingsEntry;
-  enabledModelOptions: { category: string; models: { id: string; name: string }[] }[];
+  enabledModelOptions: ModelCategory[];
 }) {
   const [model, setModel] = useState(entry.settings.model ?? "");
   const [effort, setEffort] = useState(entry.settings.reasoningEffort ?? "");

--- a/packages/web/src/components/settings/integrations/model-reasoning-defaults-fields.tsx
+++ b/packages/web/src/components/settings/integrations/model-reasoning-defaults-fields.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import {
+  getReasoningConfig,
+  isValidReasoningEffort,
+  type ModelCategory,
+} from "@open-inspect/shared";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const SYSTEM_DEFAULT_VALUE = "__system_default__";
+const MODEL_DEFAULT_VALUE = "__model_default__";
+
+export function ModelReasoningDefaultsFields({
+  model,
+  reasoningEffort,
+  modelOptions,
+  onChange,
+}: {
+  model: string;
+  reasoningEffort: string;
+  modelOptions: ModelCategory[];
+  onChange: (model: string, reasoningEffort: string) => void;
+}) {
+  const reasoningConfig = getReasoningConfig(model);
+
+  return (
+    <div className="grid sm:grid-cols-2 gap-3 mb-4">
+      <label className="text-sm">
+        <span className="block text-foreground font-medium mb-1">Default model</span>
+        <Select
+          value={model || SYSTEM_DEFAULT_VALUE}
+          onValueChange={(nextModel) => {
+            if (nextModel === SYSTEM_DEFAULT_VALUE) {
+              onChange("", "");
+              return;
+            }
+            onChange(
+              nextModel,
+              reasoningEffort && isValidReasoningEffort(nextModel, reasoningEffort)
+                ? reasoningEffort
+                : ""
+            );
+          }}
+        >
+          <SelectTrigger className="w-full" aria-label="Default model">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={SYSTEM_DEFAULT_VALUE}>Use system default</SelectItem>
+            {modelOptions.map((group) => (
+              <SelectGroup key={group.category}>
+                <SelectLabel>{group.category}</SelectLabel>
+                {group.models.map((option) => (
+                  <SelectItem key={option.id} value={option.id}>
+                    {option.name}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            ))}
+          </SelectContent>
+        </Select>
+      </label>
+
+      <label className="text-sm">
+        <span className="block text-foreground font-medium mb-1">Default reasoning effort</span>
+        <Select
+          value={reasoningEffort || MODEL_DEFAULT_VALUE}
+          onValueChange={(value) => onChange(model, value === MODEL_DEFAULT_VALUE ? "" : value)}
+          disabled={!reasoningConfig}
+        >
+          <SelectTrigger className="w-full" aria-label="Default reasoning effort">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={MODEL_DEFAULT_VALUE}>Use model default</SelectItem>
+            {(reasoningConfig?.efforts ?? []).map((value) => (
+              <SelectItem key={value} value={value}>
+                {value}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </label>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- add global default model and reasoning effort controls to GitHub integration settings
- preserve configured model defaults when saving unrelated GitHub settings
- clear global model/reasoning state when resetting settings
- update GitHub integration documentation to describe the controls

## Root cause

The shared schema, control-plane API, and GitHub bot already supported global `model` and `reasoningEffort` values, but the GitHub web settings component only exposed those fields for repository overrides. Its global save handler reconstructed the defaults object without either field, which could also erase API-configured defaults when another setting was saved.

## TDD

A regression test was added first and confirmed failing because the global controls were absent. It now verifies that existing defaults render and remain in the PUT payload after an unrelated setting changes.

## Verification

- `npm test -w @open-inspect/web -- github-integration-settings.test.tsx`
- `npm test -w @open-inspect/web -- --maxWorkers=2` (105 files, 811 tests)
- `npm run typecheck -w @open-inspect/web`
- `npm run lint -w @open-inspect/web`
- `git diff --check`

Visual verification of the target page was blocked by the local GitHub authentication gate; the route redirected to the sign-in screen without session credentials.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/90855eb39d5729beb0f2020b061cb255)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Default model” and “Default reasoning effort” configuration to GitHub and Linear integration settings.
  * Defaults can now be saved/reset together with validation-driven behavior, including a model-default option.
  * Updated precedence behavior so repository overrides take priority, then global defaults, then the deployment default.
* **Documentation**
  * Updated GitHub “Defaults and Scope” documentation to reflect the new settings and precedence rules.
* **Tests**
  * Expanded coverage for saving/resetting default model and reasoning effort behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->