### PR TITLE
refactor(control-plane): extract prompt enqueue contract

### DIFF
--- a/packages/control-plane/src/routes/session-child-spawn.ts
+++ b/packages/control-plane/src/routes/session-child-spawn.ts
@@ -15,6 +15,7 @@ import { getEffectiveEnabledModels } from "../db/model-preferences";
 import { SessionIndexStore } from "../db/session-index";
 import { createLogger } from "../logger";
 import { SessionInternalPaths } from "../session/contracts";
+import type { EnqueuePromptRequest } from "../session/enqueue-prompt-contract";
 import { initializeSession, type SessionInitInput } from "../session/initialize";
 import {
   resolveCodeServerEnabled,
@@ -210,15 +211,17 @@ async function handleSpawnChild(
 
   let promptResponse: Response;
   try {
+    const promptRequest = {
+      content: body.prompt,
+      authorId: spawnContext.owner.userId,
+      canonicalUserId: spawnContext.owner.canonicalUserId ?? parentUserId ?? undefined,
+      source: "agent",
+    } satisfies EnqueuePromptRequest;
+
     promptResponse = await ctx.sessionRuntime.fetch(childId, SessionInternalPaths.prompt, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        content: body.prompt,
-        authorId: spawnContext.owner.userId,
-        canonicalUserId: spawnContext.owner.canonicalUserId ?? parentUserId ?? undefined,
-        source: "agent",
-      }),
+      body: JSON.stringify(promptRequest),
     });
   } catch (enqueueError) {
     logger.error("Failed to enqueue initial prompt for child session", {

--- a/packages/control-plane/src/routes/session-prompt.ts
+++ b/packages/control-plane/src/routes/session-prompt.ts
@@ -12,6 +12,7 @@ import { SessionIndexStore } from "../db/session-index";
 import { UserStore } from "../db/user-store";
 import { createLogger } from "../logger";
 import { SessionInternalPaths } from "../session/contracts";
+import type { EnqueuePromptRequest } from "../session/enqueue-prompt-contract";
 import {
   parseAuthorId,
   resolveGitHubEnrichmentForRequest,
@@ -120,30 +121,32 @@ async function handleSessionPrompt(
     }
   }
 
+  const promptRequest = {
+    content: body.content,
+    authorId,
+    canonicalUserId,
+    source: body.source || "web",
+    model: body.model,
+    reasoningEffort: body.reasoningEffort,
+    attachments,
+    callbackContext,
+    scmEnrichment: enrichment
+      ? {
+          userId: enrichment.scmUserId,
+          login: enrichment.scmLogin ?? null,
+          name: enrichment.displayName ?? null,
+          email: enrichment.email ?? null,
+          accessTokenEncrypted: enrichment.accessTokenEncrypted ?? null,
+          refreshTokenEncrypted: enrichment.refreshTokenEncrypted ?? null,
+          tokenExpiresAt: enrichment.tokenExpiresAt ?? null,
+        }
+      : undefined,
+  } satisfies EnqueuePromptRequest;
+
   const response = await ctx.sessionRuntime.fetch(sessionId, SessionInternalPaths.prompt, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      content: body.content,
-      authorId,
-      canonicalUserId,
-      source: body.source || "web",
-      model: body.model,
-      reasoningEffort: body.reasoningEffort,
-      attachments,
-      callbackContext,
-      scmEnrichment: enrichment
-        ? {
-            userId: enrichment.scmUserId,
-            login: enrichment.scmLogin ?? null,
-            name: enrichment.displayName ?? null,
-            email: enrichment.email ?? null,
-            accessTokenEncrypted: enrichment.accessTokenEncrypted ?? null,
-            refreshTokenEncrypted: enrichment.refreshTokenEncrypted ?? null,
-            tokenExpiresAt: enrichment.tokenExpiresAt ?? null,
-          }
-        : undefined,
-    }),
+    body: JSON.stringify(promptRequest),
   });
 
   const store = new SessionIndexStore(ctx.db);

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -51,6 +51,7 @@ import type { Env } from "../types";
 import type { SqlDatabase } from "../db/sql-database";
 import { initializeSession } from "../session/initialize";
 import { resolveSessionScopedSettings } from "../session/integration-settings-resolution";
+import type { EnqueuePromptRequest } from "../session/enqueue-prompt-contract";
 import { resolveAutomationRepositories } from "../automation/repository";
 import { resolveAutomationSessionTarget } from "../automation/session-target";
 import type { RequestContext } from "../routes/shared";
@@ -158,6 +159,13 @@ type StartInvocationResult =
   | { outcome: "blocked" }
   /** Idempotency/dedup collision — another firing owns this slot or event. */
   | { outcome: "deduplicated" };
+
+type SchedulerPromptRequest = Pick<
+  EnqueuePromptRequest,
+  "content" | "authorId" | "canonicalUserId" | "source"
+> & {
+  callbackContext: AutomationCallbackContext | SlackCallbackContext;
+};
 
 export class SchedulerDO extends DurableObject<Env> {
   private readonly log: Logger;
@@ -1361,13 +1369,7 @@ export class SchedulerDO extends DurableObject<Env> {
   /** Enqueue a prompt onto a session's queue via its DO `/internal/prompt` route. */
   private async enqueueSessionPrompt(
     sessionId: string,
-    body: {
-      content: string;
-      authorId: string;
-      canonicalUserId?: string | null;
-      source: string;
-      callbackContext: AutomationCallbackContext | SlackCallbackContext;
-    }
+    body: SchedulerPromptRequest
   ): Promise<void> {
     const stub = this.env.SESSION.get(this.env.SESSION.idFromName(sessionId));
     const promptResponse = await stub.fetch("http://internal/internal/prompt", {

--- a/packages/control-plane/src/session/enqueue-prompt-contract.test.ts
+++ b/packages/control-plane/src/session/enqueue-prompt-contract.test.ts
@@ -33,4 +33,14 @@ describe("enqueuePromptRequestSchema", () => {
 
     expect(result.success).toBe(false);
   });
+
+  it("rejects unsupported prompt sources", () => {
+    const result = enqueuePromptRequestSchema.safeParse({
+      content: "hello",
+      authorId: "user-1",
+      source: "unknown",
+    });
+
+    expect(result.success).toBe(false);
+  });
 });

--- a/packages/control-plane/src/session/enqueue-prompt-contract.test.ts
+++ b/packages/control-plane/src/session/enqueue-prompt-contract.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { enqueuePromptRequestSchema } from "./enqueue-prompt-contract";
+
+describe("enqueuePromptRequestSchema", () => {
+  it("parses valid enqueue prompt request bodies", () => {
+    const body = {
+      content: "hello",
+      authorId: "github:123",
+      source: "github",
+      model: "anthropic/claude-haiku-4-5",
+      reasoningEffort: "high",
+      attachments: [{ attachmentId: "attachment-1", name: "screenshot.png" }],
+      callbackContext: { source: "automation", runId: "run-1" },
+      scmEnrichment: {
+        userId: "user-1",
+        login: "octocat",
+        name: null,
+        email: null,
+        accessTokenEncrypted: "encrypted-token",
+        refreshTokenEncrypted: null,
+        tokenExpiresAt: null,
+      },
+    };
+
+    expect(enqueuePromptRequestSchema.safeParse(body).success).toBe(true);
+  });
+
+  it("rejects malformed enqueue prompt request bodies", () => {
+    const result = enqueuePromptRequestSchema.safeParse({
+      content: "hello",
+      authorId: "user-1",
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/control-plane/src/session/enqueue-prompt-contract.ts
+++ b/packages/control-plane/src/session/enqueue-prompt-contract.ts
@@ -1,0 +1,27 @@
+import { sessionAttachmentReferencesSchema } from "@open-inspect/shared";
+import { z } from "zod";
+
+export const enqueuePromptRequestSchema = z.object({
+  content: z.string(),
+  authorId: z.string(),
+  canonicalUserId: z.string().nullable().optional(),
+  source: z.string(),
+  model: z.string().optional(),
+  reasoningEffort: z.string().optional(),
+  attachments: sessionAttachmentReferencesSchema.optional(),
+  callbackContext: z.record(z.string(), z.unknown()).optional(),
+  // Trusted SCM enrichment resolved by the router at prompt time.
+  scmEnrichment: z
+    .object({
+      userId: z.string().nullable(),
+      login: z.string().nullable(),
+      name: z.string().nullable(),
+      email: z.string().nullable(),
+      accessTokenEncrypted: z.string().nullable(),
+      refreshTokenEncrypted: z.string().nullable(),
+      tokenExpiresAt: z.number().nullable(),
+    })
+    .optional(),
+});
+
+export type EnqueuePromptRequest = z.infer<typeof enqueuePromptRequestSchema>;

--- a/packages/control-plane/src/session/enqueue-prompt-contract.ts
+++ b/packages/control-plane/src/session/enqueue-prompt-contract.ts
@@ -1,11 +1,11 @@
-import { sessionAttachmentReferencesSchema } from "@open-inspect/shared";
+import { messageSourceSchema, sessionAttachmentReferencesSchema } from "@open-inspect/shared";
 import { z } from "zod";
 
 export const enqueuePromptRequestSchema = z.object({
   content: z.string(),
   authorId: z.string(),
   canonicalUserId: z.string().nullable().optional(),
-  source: z.string(),
+  source: messageSourceSchema,
   model: z.string().optional(),
   reasoningEffort: z.string().optional(),
   attachments: sessionAttachmentReferencesSchema.optional(),

--- a/packages/control-plane/src/session/http/handlers/messages.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/messages.handler.ts
@@ -2,8 +2,8 @@ import type { Logger } from "../../../logger";
 import {
   enqueuePromptRequestSchema,
   type EnqueuePromptRequest,
-  type MessageService,
-} from "../../services/message.service";
+} from "../../enqueue-prompt-contract";
+import type { MessageService } from "../../services/message.service";
 import { parseEventListCursor } from "../../event-cursor";
 import { SessionAttachmentError } from "../../session-attachment-resolver";
 

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -602,7 +602,7 @@ describe("SessionMessageQueue", () => {
       await h.queue.enqueuePromptFromApi({
         content: "Fix bug",
         authorId: "github:1001",
-        source: "github-bot",
+        source: "github",
         scmEnrichment: {
           userId: "1001",
           login: "octocat",
@@ -624,7 +624,7 @@ describe("SessionMessageQueue", () => {
       await h.queue.enqueuePromptFromApi({
         content: "Fix bug",
         authorId: "github:1001",
-        source: "github-bot",
+        source: "github",
       });
 
       expect(h.participantService.create).toHaveBeenCalledWith("github:1001", "github:1001");
@@ -636,7 +636,7 @@ describe("SessionMessageQueue", () => {
       await h.queue.enqueuePromptFromApi({
         content: "Fix bug",
         authorId: "github:1001",
-        source: "github-bot",
+        source: "github",
         scmEnrichment: {
           userId: "1001",
           login: "octocat",
@@ -665,7 +665,7 @@ describe("SessionMessageQueue", () => {
       await h.queue.enqueuePromptFromApi({
         content: "Fix bug",
         authorId: "github:1001",
-        source: "github-bot",
+        source: "github",
       });
 
       expect(h.repository.updateParticipantCoalesce).not.toHaveBeenCalled();

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -394,7 +394,7 @@ export class SessionMessageQueue {
       participant,
       userId: data.authorId,
       content: data.content,
-      source: data.source as MessageSource,
+      source: data.source,
       model: data.model,
       reasoningEffort: data.reasoningEffort,
       attachments: data.attachments,

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -23,7 +23,7 @@ import type { SessionWebSocketManager } from "./websocket-manager";
 import type { ParticipantService } from "./participant-service";
 import type { CallbackNotificationService } from "./callback-notification-service";
 import type { SessionStatusService } from "./session-status-service";
-import type { EnqueuePromptRequest } from "./services/message.service";
+import type { EnqueuePromptRequest } from "./enqueue-prompt-contract";
 import { getAvatarUrl } from "./participant-service";
 import { resolveParticipantName } from "./participant-name";
 import { resolveGitAuthorIdentity } from "./identity";

--- a/packages/control-plane/src/session/services/message.service.test.ts
+++ b/packages/control-plane/src/session/services/message.service.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { ArtifactRow, EventRow, MessageRow } from "../types";
 import type { SessionRepository } from "../repository";
 import type { SessionMessageQueue } from "../message-queue";
-import { enqueuePromptRequestSchema, MessageService } from "./message.service";
+import { MessageService } from "./message.service";
 
 function createService() {
   const repository = {
@@ -34,38 +34,6 @@ function createService() {
 }
 
 describe("MessageService", () => {
-  it("parses valid enqueue prompt request bodies", () => {
-    const body = {
-      content: "hello",
-      authorId: "github:123",
-      source: "github",
-      model: "anthropic/claude-haiku-4-5",
-      reasoningEffort: "high",
-      attachments: [{ attachmentId: "attachment-1", name: "screenshot.png" }],
-      callbackContext: { source: "automation", runId: "run-1" },
-      scmEnrichment: {
-        userId: "user-1",
-        login: "octocat",
-        name: null,
-        email: null,
-        accessTokenEncrypted: "encrypted-token",
-        refreshTokenEncrypted: null,
-        tokenExpiresAt: null,
-      },
-    };
-
-    expect(enqueuePromptRequestSchema.safeParse(body).success).toBe(true);
-  });
-
-  it("rejects malformed enqueue prompt request bodies", () => {
-    const result = enqueuePromptRequestSchema.safeParse({
-      content: "hello",
-      authorId: "user-1",
-    });
-
-    expect(result.success).toBe(false);
-  });
-
   it("delegates enqueuePrompt to SessionMessageQueue", async () => {
     const { service, messageQueue } = createService();
     vi.mocked(messageQueue.enqueuePromptFromApi).mockResolvedValue({

--- a/packages/control-plane/src/session/services/message.service.ts
+++ b/packages/control-plane/src/session/services/message.service.ts
@@ -1,36 +1,11 @@
 import type { ArtifactRow } from "../types";
-import { sessionAttachmentReferencesSchema, type SessionMessage } from "@open-inspect/shared";
+import type { SessionMessage } from "@open-inspect/shared";
 import type { ArtifactResponse, ListEventsResponse } from "../../types";
 import type { SessionRepository } from "../repository";
 import type { SessionMessageQueue } from "../message-queue";
+import type { EnqueuePromptRequest } from "../enqueue-prompt-contract";
 import { SessionEventStream, type SessionEventListRequest } from "../event-stream";
 import { parseStoredSessionAttachments } from "../session-attachment-resolver";
-import { z } from "zod";
-
-export const enqueuePromptRequestSchema = z.object({
-  content: z.string(),
-  authorId: z.string(),
-  canonicalUserId: z.string().nullable().optional(),
-  source: z.string(),
-  model: z.string().optional(),
-  reasoningEffort: z.string().optional(),
-  attachments: sessionAttachmentReferencesSchema.optional(),
-  callbackContext: z.record(z.string(), z.unknown()).optional(),
-  // Trusted SCM enrichment resolved by the router at prompt time.
-  scmEnrichment: z
-    .object({
-      userId: z.string().nullable(),
-      login: z.string().nullable(),
-      name: z.string().nullable(),
-      email: z.string().nullable(),
-      accessTokenEncrypted: z.string().nullable(),
-      refreshTokenEncrypted: z.string().nullable(),
-      tokenExpiresAt: z.number().nullable(),
-    })
-    .optional(),
-});
-
-export type EnqueuePromptRequest = z.infer<typeof enqueuePromptRequestSchema>;
 
 export type ListEventsRequest = SessionEventListRequest;
 

--- a/packages/shared/src/types/boundary-schemas.test.ts
+++ b/packages/shared/src/types/boundary-schemas.test.ts
@@ -155,6 +155,9 @@ describe("boundary schemas", () => {
       expect(sendPromptRequestSchema.safeParse({ content: 123 }).success).toBe(false);
       expect(sendPromptRequestSchema.safeParse({ source: "web" }).success).toBe(false);
       expect(sendPromptRequestSchema.safeParse({ content: "" }).success).toBe(false);
+      expect(
+        sendPromptRequestSchema.safeParse({ content: "hello", source: "unknown" }).success
+      ).toBe(false);
     });
   });
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -25,7 +25,7 @@ export type {
 export { clientMessageSchema } from "./websocket";
 export type { ClientMessage } from "./websocket";
 
-export { sessionStatusSchema } from "./statuses";
+export { messageSourceSchema, sessionStatusSchema } from "./statuses";
 export type {
   SessionStatus,
   SandboxStatus,

--- a/packages/shared/src/types/session-api.ts
+++ b/packages/shared/src/types/session-api.ts
@@ -3,7 +3,12 @@ import { recordSchema, type AgentResponse } from "./artifacts";
 import { sessionRepositoriesInputSchema } from "./repositories";
 import type { EventResponse } from "./sandbox-events";
 import type { Session } from "./sessions";
-import { sessionStatusSchema, type SandboxStatus, type SessionStatus } from "./statuses";
+import {
+  messageSourceSchema,
+  sessionStatusSchema,
+  type SandboxStatus,
+  type SessionStatus,
+} from "./statuses";
 
 export interface UserPreferences {
   userId: string;
@@ -85,7 +90,7 @@ export type CallbackContext = z.infer<typeof callbackContextSchema>;
 
 export const sendPromptRequestSchema = z.object({
   content: z.string().min(1),
-  source: z.string().optional(),
+  source: messageSourceSchema.optional(),
   model: z.string().optional(),
   reasoningEffort: z.string().optional(),
   attachments: z.unknown().optional(),

--- a/packages/shared/src/types/statuses.ts
+++ b/packages/shared/src/types/statuses.ts
@@ -24,7 +24,16 @@ export type SandboxStatus =
   | "failed";
 export type GitSyncStatus = "pending" | "in_progress" | "completed" | "failed";
 export type MessageStatus = "pending" | "processing" | "completed" | "failed";
-export type MessageSource = "web" | "slack" | "linear" | "extension" | "github" | "automation";
+export const messageSourceSchema = z.enum([
+  "web",
+  "slack",
+  "linear",
+  "extension",
+  "github",
+  "automation",
+  "agent",
+]);
+export type MessageSource = z.infer<typeof messageSourceSchema>;
 export type ArtifactType = "pr" | "screenshot" | "video" | "preview" | "branch";
 export type EventType =
   | "heartbeat"


### PR DESCRIPTION
## Summary
- move the prompt enqueue schema and inferred request type into a neutral session-level contract
- make the HTTP handler, message service, and message queue depend directly on that leaf contract
- move schema validation tests alongside the contract

## Why
`SessionMessageQueue` previously imported its request type from `MessageService`, while `MessageService` imported the queue. Although one edge was type-only, that formed a compile-time dependency cycle and increased propagation cost for changes to the prompt enqueue contract.

This change removes that cycle without changing request validation, queueing, API responses, or runtime behavior.

## Validation
- `npm run test -w @open-inspect/control-plane` (136 files, 2,115 tests)
- `npm run typecheck -w @open-inspect/control-plane`
- ESLint on all touched files
- Prettier check on all touched files
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized enqueue-prompt request validation across the control plane and shared session API, including consistent `source` handling via a shared, schema-backed definition.
  * Updated session prompt and child-spawn prompt submissions to be explicitly type-checked against the validated request shape.
* **Tests**
  * Extended contract/boundary schema tests to confirm malformed requests (including unsupported `source` values) are rejected.
  * Updated enqueue prompt queue tests to use the correct `source` value in relevant cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->