### PR TITLE
refactor(shared): consolidate trigger type ownership

### DIFF
--- a/packages/shared/src/module-boundaries.test.ts
+++ b/packages/shared/src/module-boundaries.test.ts
@@ -95,7 +95,7 @@ function relativePath(filePath: string): string {
   return path.relative(SOURCE_ROOT, filePath).split(path.sep).join("/");
 }
 
-function findRuntimeCycle(graph: ReadonlyMap<string, readonly string[]>): string[] | undefined {
+function findDependencyCycle(graph: ReadonlyMap<string, readonly string[]>): string[] | undefined {
   const visited = new Set<string>();
   const active = new Set<string>();
   const stack: string[] = [];
@@ -171,7 +171,28 @@ describe("shared module boundaries", () => {
         ].sort(),
       ])
     );
-    const cycle = findRuntimeCycle(runtimeGraph)?.map(relativePath);
+    const cycle = findDependencyCycle(runtimeGraph)?.map(relativePath);
+
+    expect(cycle?.join(" -> ")).toBeUndefined();
+  });
+
+  it("has no compile-time dependency cycles", () => {
+    const compileTimeGraph = new Map(
+      modules.map((modulePath) => [
+        modulePath,
+        [
+          ...new Set(
+            (dependencies.get(modulePath) ?? [])
+              .filter(
+                (dependency): dependency is Dependency & { target: string } =>
+                  dependency.target !== undefined
+              )
+              .map(({ target }) => target)
+          ),
+        ].sort(),
+      ])
+    );
+    const cycle = findDependencyCycle(compileTimeGraph)?.map(relativePath);
 
     expect(cycle?.join(" -> ")).toBeUndefined();
   });

--- a/packages/shared/src/module-boundaries.test.ts
+++ b/packages/shared/src/module-boundaries.test.ts
@@ -63,10 +63,14 @@ function exportHasRuntimeEdge(declaration: ts.ExportDeclaration): boolean {
   return elements.length === 0 || elements.some((element) => !element.isTypeOnly);
 }
 
-function collectDependencies(sourcePath: string, modules: ReadonlySet<string>): Dependency[] {
+function collectDependencies(
+  sourcePath: string,
+  modules: ReadonlySet<string>,
+  sourceText = readFileSync(sourcePath, "utf8")
+): Dependency[] {
   const sourceFile = ts.createSourceFile(
     sourcePath,
-    readFileSync(sourcePath, "utf8"),
+    sourceText,
     ts.ScriptTarget.Latest,
     true,
     ts.ScriptKind.TS
@@ -88,6 +92,15 @@ function collectDependencies(sourcePath: string, modules: ReadonlySet<string>): 
       addDependency(statement.moduleSpecifier, exportHasRuntimeEdge(statement));
     }
   }
+
+  function collectImportTypes(node: ts.Node): void {
+    if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument)) {
+      addDependency(node.argument.literal, false);
+    }
+    ts.forEachChild(node, collectImportTypes);
+  }
+  ts.forEachChild(sourceFile, collectImportTypes);
+
   return dependencies;
 }
 
@@ -195,5 +208,21 @@ describe("shared module boundaries", () => {
     const cycle = findDependencyCycle(compileTimeGraph)?.map(relativePath);
 
     expect(cycle?.join(" -> ")).toBeUndefined();
+  });
+});
+
+describe("dependency collection", () => {
+  it("collects import-type expressions as compile-time-only dependencies", () => {
+    const fixtureRoot = path.join(SOURCE_ROOT, "__dependency_fixture__");
+    const sourcePath = path.join(fixtureRoot, "source.ts");
+    const targetPath = path.join(fixtureRoot, "target.ts");
+
+    expect(
+      collectDependencies(
+        sourcePath,
+        new Set([sourcePath, targetPath]),
+        'type Target = import("./target").Target;'
+      )
+    ).toEqual([{ specifier: "./target", target: targetPath, runtime: false }]);
   });
 });

--- a/packages/shared/src/triggers/conditions.ts
+++ b/packages/shared/src/triggers/conditions.ts
@@ -1,53 +1,16 @@
 /**
  * Condition system for trigger-based automations.
  *
- * Each condition type's shape is defined once in ConditionConfigMap.
- * TypeScript derives the discriminated union and typed handler interfaces from it.
+ * TypeScript derives typed handler interfaces from the trigger configuration
+ * shapes, while this module owns runtime validation and evaluation.
  */
 
-import type { AutomationEvent, AutomationEventSource } from "./types";
-
-// ─── 1. ConditionConfigMap: single source of truth ───────────────────────────
-
-export interface ConditionConfigMap {
-  branch: { operator: "glob_match" | "exact"; value: string[] };
-  target_branch: { operator: "glob_match" | "exact"; value: string[] };
-  label: { operator: "any_of" | "none_of"; value: string[] };
-  path_glob: { operator: "any_match"; value: string[] };
-  actor: { operator: "include" | "exclude"; value: string[] };
-  check_conclusion: { operator: "eq"; value: string };
-  linear_status: { operator: "any_of"; value: string[] };
-  sentry_project: { operator: "any_of"; value: string[] };
-  sentry_level: { operator: "any_of"; value: string[] };
-  jsonpath: { operator: "all_match"; value: JsonPathFilter[] };
-  text_match: { operator: "contains" | "exact" | "regex"; value: TextMatchValue };
-  slack_channel: { operator: "any_of"; value: string[] };
-  slack_actor: { operator: "include" | "exclude"; value: string[] };
-}
-
-export interface JsonPathFilter {
-  path: string;
-  comparison: "eq" | "neq" | "gt" | "gte" | "lt" | "lte" | "contains" | "exists";
-  value?: string | number | boolean;
-}
-
-/** Value shape for the `text_match` condition (keyword / substring / regex). */
-export interface TextMatchValue {
-  /** Keyword/substring (contains/exact) or regular-expression source (regex). */
-  pattern: string;
-  /** Case/regex flags; only an allowlisted subset is accepted (see ALLOWED_REGEX_FLAGS). */
-  flags?: string;
-}
-
-// ─── 2. Derived discriminated union ──────────────────────────────────────────
-
-export type TriggerCondition = {
-  [K in keyof ConditionConfigMap]: { type: K } & ConditionConfigMap[K];
-}[keyof ConditionConfigMap];
-
-// ─── 3. Typed handler interface ──────────────────────────────────────────────
-
-export type ConditionType = keyof ConditionConfigMap;
+import type {
+  AutomationEvent,
+  AutomationEventSource,
+  ConditionType,
+  TriggerCondition,
+} from "./types";
 
 type ConditionOf<K extends ConditionType> = Extract<TriggerCondition, { type: K }>;
 
@@ -62,13 +25,13 @@ export interface ConditionHandler<K extends ConditionType> {
   appliesTo: AutomationEventSource[];
 }
 
-// ─── 4. Typed registry ───────────────────────────────────────────────────────
+// ─── Typed Registry ──────────────────────────────────────────────────────────
 
 export type ConditionRegistry = {
   [K in ConditionType]: ConditionHandler<K>;
 };
 
-// ─── 5. Dispatch ─────────────────────────────────────────────────────────────
+// ─── Dispatch ────────────────────────────────────────────────────────────────
 
 export function matchesConditions(
   conditions: TriggerCondition[],
@@ -81,7 +44,7 @@ export function matchesConditions(
   });
 }
 
-// ─── 6. Validation (called at automation creation time) ──────────────────────
+// ─── Validation (called at automation creation time) ────────────────────────
 
 export function validateConditions(
   conditions: TriggerCondition[],
@@ -99,10 +62,4 @@ export function validateConditions(
     if (err) errors.push(err);
   }
   return errors;
-}
-
-// ─── 7. TriggerConfig (stored as JSON in D1) ────────────────────────────────
-
-export interface TriggerConfig {
-  conditions: TriggerCondition[];
 }

--- a/packages/shared/src/triggers/index.ts
+++ b/packages/shared/src/triggers/index.ts
@@ -13,20 +13,18 @@ export type {
   WebhookAutomationEvent,
   SlackAutomationEvent,
   TriggerSourceDefinition,
+  AutomationTriggerType,
+  ConditionConfigMap,
+  ConditionType,
+  TriggerCondition,
+  JsonPathFilter,
+  TextMatchValue,
+  TriggerConfig,
 } from "./types";
 export { TRIGGER_TYPE_TO_SOURCE, automationEventSchema } from "./types";
 
 // Condition system
-export type {
-  ConditionConfigMap,
-  ConditionType,
-  TriggerCondition,
-  ConditionHandler,
-  ConditionRegistry,
-  JsonPathFilter,
-  TextMatchValue,
-  TriggerConfig,
-} from "./conditions";
+export type { ConditionHandler, ConditionRegistry } from "./conditions";
 export { matchesConditions, validateConditions } from "./conditions";
 
 // Registry

--- a/packages/shared/src/triggers/slack/conditions.test.ts
+++ b/packages/shared/src/triggers/slack/conditions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { matchesConditions, validateConditions } from "../conditions";
-import type { TriggerCondition } from "../conditions";
+import type { TriggerCondition } from "../types";
 import { conditionRegistry } from "../registry";
 import { buildMockEvent } from "../testing";
 import { SLACK_TEXT_MAX_LENGTH } from "./normalizer";

--- a/packages/shared/src/triggers/slack/conditions.ts
+++ b/packages/shared/src/triggers/slack/conditions.ts
@@ -7,8 +7,8 @@
  * matching the sentry/webhook modules.
  */
 
-import type { ConditionRegistry, TextMatchValue } from "../conditions";
-import type { AutomationEvent } from "../types";
+import type { ConditionRegistry } from "../conditions";
+import type { AutomationEvent, TextMatchValue } from "../types";
 import { SLACK_TEXT_MAX_LENGTH } from "./normalizer";
 
 /** Max length of a user-supplied `text_match` regex pattern (characters). */

--- a/packages/shared/src/triggers/testing.ts
+++ b/packages/shared/src/triggers/testing.ts
@@ -11,8 +11,8 @@ import type {
   LinearAutomationEvent,
   SlackAutomationEvent,
 } from "./types";
-import type { TriggerCondition } from "./conditions";
 import { matchesConditions } from "./conditions";
+import type { TriggerCondition } from "./types";
 import { conditionRegistry } from "./registry";
 import type { Automation } from "../types/automations";
 

--- a/packages/shared/src/triggers/types.ts
+++ b/packages/shared/src/triggers/types.ts
@@ -1,10 +1,59 @@
 /**
- * Core types for the trigger-based automation event system.
+ * Core types for trigger-based automation configuration and events.
  */
 
-import type { AutomationTriggerType } from "../types/automations";
-import type { ConditionType } from "./conditions";
 import { z } from "zod";
+
+// ─── Trigger Configuration ───────────────────────────────────────────────────
+
+export type AutomationTriggerType =
+  | "schedule"
+  | "github_event"
+  | "linear_event"
+  | "sentry"
+  | "webhook"
+  | "slack_event";
+
+export interface ConditionConfigMap {
+  branch: { operator: "glob_match" | "exact"; value: string[] };
+  target_branch: { operator: "glob_match" | "exact"; value: string[] };
+  label: { operator: "any_of" | "none_of"; value: string[] };
+  path_glob: { operator: "any_match"; value: string[] };
+  actor: { operator: "include" | "exclude"; value: string[] };
+  check_conclusion: { operator: "eq"; value: string };
+  linear_status: { operator: "any_of"; value: string[] };
+  sentry_project: { operator: "any_of"; value: string[] };
+  sentry_level: { operator: "any_of"; value: string[] };
+  jsonpath: { operator: "all_match"; value: JsonPathFilter[] };
+  text_match: { operator: "contains" | "exact" | "regex"; value: TextMatchValue };
+  slack_channel: { operator: "any_of"; value: string[] };
+  slack_actor: { operator: "include" | "exclude"; value: string[] };
+}
+
+export interface JsonPathFilter {
+  path: string;
+  comparison: "eq" | "neq" | "gt" | "gte" | "lt" | "lte" | "contains" | "exists";
+  value?: string | number | boolean;
+}
+
+/** Value shape for the `text_match` condition (keyword / substring / regex). */
+export interface TextMatchValue {
+  /** Keyword/substring (contains/exact) or regular-expression source (regex). */
+  pattern: string;
+  /** Case/regex flags; only an allowlisted subset is accepted (see ALLOWED_REGEX_FLAGS). */
+  flags?: string;
+}
+
+export type TriggerCondition = {
+  [K in keyof ConditionConfigMap]: { type: K } & ConditionConfigMap[K];
+}[keyof ConditionConfigMap];
+
+export type ConditionType = keyof ConditionConfigMap;
+
+/** Trigger settings stored as JSON in D1. */
+export interface TriggerConfig {
+  conditions: TriggerCondition[];
+}
 
 // ─── Event Sources ────────────────────────────────────────────────────────────
 

--- a/packages/shared/src/triggers/webhook/conditions.ts
+++ b/packages/shared/src/triggers/webhook/conditions.ts
@@ -3,7 +3,7 @@
  */
 
 import type { ConditionRegistry } from "../conditions";
-import type { JsonPathFilter } from "../conditions";
+import type { JsonPathFilter } from "../types";
 import { evaluateJsonPathFilter } from "./normalizer";
 
 export const conditions = {

--- a/packages/shared/src/triggers/webhook/normalizer.ts
+++ b/packages/shared/src/triggers/webhook/normalizer.ts
@@ -2,8 +2,7 @@
  * Normalize generic webhook payloads into WebhookAutomationEvent.
  */
 
-import type { WebhookAutomationEvent } from "../types";
-import type { JsonPathFilter } from "../conditions";
+import type { JsonPathFilter, WebhookAutomationEvent } from "../types";
 import { buildWebhookContextBlock } from "./context";
 
 /**

--- a/packages/shared/src/types/automations.ts
+++ b/packages/shared/src/types/automations.ts
@@ -1,18 +1,10 @@
-import type { TriggerConfig } from "../triggers/conditions";
+import type { AutomationTriggerType, TriggerConfig } from "../triggers/types";
 import {
   MAX_TARGET_REPOSITORIES,
   repositoriesInputSchema,
   repositoryInputSchema,
 } from "./repositories";
 import type { RepositoryInput, RepositoryRef } from "./repositories";
-
-export type AutomationTriggerType =
-  | "schedule"
-  | "github_event"
-  | "linear_event"
-  | "sentry"
-  | "webhook"
-  | "slack_event";
 
 export type AutomationRunStatus = "starting" | "running" | "completed" | "failed" | "skipped";
 

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -219,11 +219,11 @@ export type {
 } from "./environments";
 
 export type {
-  AutomationTriggerType,
   AutomationRunStatus,
   AutomationInvocationSource,
   AutomationInvocationStatus,
 } from "./automations";
+export type { AutomationTriggerType } from "../triggers/types";
 
 export {
   MAX_AUTOMATION_REPOSITORIES,

--- a/packages/shared/src/types/type-contracts.test.ts
+++ b/packages/shared/src/types/type-contracts.test.ts
@@ -1,6 +1,15 @@
 import type { z } from "zod";
 import { expectTypeOf, it } from "vitest";
 import type {
+  AutomationTriggerType,
+  ConditionConfigMap,
+  ConditionType,
+  JsonPathFilter,
+  TextMatchValue,
+  TriggerCondition,
+  TriggerConfig,
+} from "..";
+import type {
   Automation,
   AutomationRepository,
   AutomationRepositoryInput,
@@ -98,4 +107,25 @@ it("preserves representative automation contracts", () => {
   expectTypeOf<ListAutomationsResponse["automations"]>().toEqualTypeOf<Automation[]>();
 
   void request;
+});
+
+it("preserves public trigger type shapes", () => {
+  const condition = {
+    type: "branch",
+    operator: "glob_match",
+    value: ["main"],
+  } satisfies TriggerCondition;
+  const config = { conditions: [condition] } satisfies TriggerConfig;
+
+  expectTypeOf<ConditionType>().toEqualTypeOf<keyof ConditionConfigMap>();
+  expectTypeOf<Extract<TriggerCondition, { type: "jsonpath" }>["value"]>().toEqualTypeOf<
+    JsonPathFilter[]
+  >();
+  expectTypeOf<
+    Extract<TriggerCondition, { type: "text_match" }>["value"]
+  >().toEqualTypeOf<TextMatchValue>();
+  expectTypeOf<Automation["triggerType"]>().toEqualTypeOf<AutomationTriggerType>();
+  expectTypeOf<Automation["triggerConfig"]>().toEqualTypeOf<TriggerConfig | null>();
+
+  void config;
 });


### PR DESCRIPTION
## Summary

- make the existing trigger type module the canonical owner of trigger identifiers and serialized condition configuration shapes
- keep automation API/persistence models separate from runtime condition evaluation and migrate all internal consumers to the owning module
- enforce an acyclic shared compile graph across static imports, exports, and import-type expressions while preserving public type relationships

## Plan improvement

The original PR 1C plan proposed a new dependency-free module. After reviewing the merged code and feedback from PRs 1A and 1B, this instead reuses `triggers/types.ts`, which already owns the trigger event/source types. This avoids a competing ownership convention and leaves that module with no local imports.

## Dependency result

- before: 1 compile-time SCC / 3 modules
- after: 0 compile-time SCCs / 0 cyclic modules
- runtime SCCs remain 0

## Validation

- `npm run build -w @open-inspect/shared`
- `npm run typecheck -w @open-inspect/shared`
- `npm run lint -w @open-inspect/shared`
- `npm test -w @open-inspect/shared` — 506 tests
- `npm run typecheck`
- `npm test -w @open-inspect/control-plane` — 2,116 tests
- `npm run test:integration -w @open-inspect/control-plane` — 654 tests
- `npm test -w @open-inspect/web` — 815 tests
- `npm test -w @open-inspect/slack-bot` — 379 tests
- `npm test -w @open-inspect/linear-bot` — 202 tests
- `npm test -w @open-inspect/github-bot` — 130 tests
- Prettier and `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Centralized automation trigger and condition type definitions for consistent shared usage across the codebase.
  * Updated shared exports so trigger/condition types are sourced from the same location, improving type stability.
  * Dependency cycle detection now correctly accounts for type-only `import("...")` usage.
* **Tests**
  * Added/expanded type-shape contract tests for trigger and condition configurations.
  * Added coverage to ensure compile-time-only dependencies are tracked separately from runtime edges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->