### PR TITLE
Resolve createdBy=me in the control plane

### DIFF
--- a/packages/control-plane/src/routes/session-index.test.ts
+++ b/packages/control-plane/src/routes/session-index.test.ts
@@ -3,6 +3,7 @@ import { sessionIndexRoutes } from "./session-index";
 import type { RequestContext } from "./shared";
 import type { SqlDatabase } from "../db/sql-database";
 import type { Env } from "../types";
+import type { Principal } from "../auth/principal";
 
 const mockSessionIndexStore = {
   list: vi.fn(),
@@ -15,7 +16,7 @@ vi.mock("../db/session-index", () => ({
   }),
 }));
 
-function createCtx(): RequestContext {
+function createCtx(principal?: Principal): RequestContext {
   return {
     trace_id: "trace-1",
     request_id: "req-1",
@@ -26,6 +27,7 @@ function createCtx(): RequestContext {
       time: async <T>(_name: string, fn: () => Promise<T>) => fn(),
       summarize: () => ({}),
     },
+    principal,
   };
 }
 
@@ -44,13 +46,13 @@ function getHandler(method: string, path: string) {
   throw new Error(`No route found for ${method} ${path}`);
 }
 
-async function listSessions(query = ""): Promise<Response> {
+async function listSessions(query = "", principal?: Principal): Promise<Response> {
   const { handler, match } = getHandler("GET", "/sessions");
   return handler(
     new Request(`https://test.local/sessions${query}`),
     createEnv(),
     match,
-    createCtx()
+    createCtx(principal)
   );
 }
 
@@ -104,8 +106,77 @@ describe("session index routes", () => {
     });
   });
 
+  it("resolves createdBy=me from the authenticated user principal", async () => {
+    const response = await listSessions("?createdBy=me", {
+      kind: "user",
+      userId: "0123456789abcdef0123456789abcdef",
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockSessionIndexStore.list).toHaveBeenCalledWith({
+      status: undefined,
+      excludeStatus: undefined,
+      createdByUserIds: ["0123456789abcdef0123456789abcdef"],
+      limit: 50,
+      offset: 0,
+    });
+  });
+
+  it("preserves mixed creator filters as OR inputs", async () => {
+    const response = await listSessions(
+      "?createdBy=ffffffffffffffffffffffffffffffff&createdBy=me",
+      { kind: "user", userId: "0123456789abcdef0123456789abcdef" }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSessionIndexStore.list).toHaveBeenCalledWith(
+      expect.objectContaining({
+        createdByUserIds: ["ffffffffffffffffffffffffffffffff", "0123456789abcdef0123456789abcdef"],
+      })
+    );
+  });
+
+  it("deduplicates creator filters after resolving createdBy=me", async () => {
+    const response = await listSessions(
+      "?createdBy=0123456789abcdef0123456789abcdef&createdBy=me&createdBy=me",
+      { kind: "user", userId: "0123456789abcdef0123456789abcdef" }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockSessionIndexStore.list).toHaveBeenCalledWith(
+      expect.objectContaining({
+        createdByUserIds: ["0123456789abcdef0123456789abcdef"],
+      })
+    );
+  });
+
   it("rejects invalid creator filters before querying the store", async () => {
-    const response = await listSessions("?createdBy=me");
+    const response = await listSessions("?createdBy=not-a-user-id", {
+      kind: "user",
+      userId: "0123456789abcdef0123456789abcdef",
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid createdBy" });
+    expect(mockSessionIndexStore.list).not.toHaveBeenCalled();
+  });
+
+  it.each<Principal>([
+    { kind: "service", service: "modal", actor: null },
+    { kind: "sandbox", sessionId: "session-1" },
+  ])("rejects createdBy=me for a $kind principal", async (principal) => {
+    const response = await listSessions("?createdBy=me", principal);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid createdBy" });
+    expect(mockSessionIndexStore.list).not.toHaveBeenCalled();
+  });
+
+  it("rejects createdBy=me for a non-canonical user principal", async () => {
+    const response = await listSessions("?createdBy=me", {
+      kind: "user",
+      userId: "not-canonical",
+    });
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({ error: "Invalid createdBy" });

--- a/packages/control-plane/src/routes/session-index.ts
+++ b/packages/control-plane/src/routes/session-index.ts
@@ -17,19 +17,24 @@ function parseSessionStatus(value: string | null): SessionStatus | undefined {
   return SESSION_STATUSES.includes(value as SessionStatus) ? (value as SessionStatus) : undefined;
 }
 
-function parseCreatedByFilters(searchParams: URLSearchParams): string[] | Response {
+function parseCreatedByFilters(
+  searchParams: URLSearchParams,
+  principal: RequestContext["principal"]
+): string[] | Response {
   const values = searchParams.getAll("createdBy");
   const userIds: string[] = [];
   const seen = new Set<string>();
 
   for (const value of values) {
-    if (!isCanonicalUserId(value)) {
+    const userId = value === "me" ? (principal?.kind === "user" ? principal.userId : null) : value;
+
+    if (!isCanonicalUserId(userId)) {
       return error("Invalid createdBy", 400);
     }
 
-    if (!seen.has(value)) {
-      seen.add(value);
-      userIds.push(value);
+    if (!seen.has(userId)) {
+      seen.add(userId);
+      userIds.push(userId);
     }
   }
 
@@ -61,7 +66,7 @@ async function handleListSessions(
   const excludeStatusParam = url.searchParams.get("excludeStatus");
   const status = parseSessionStatus(statusParam);
   const excludeStatus = parseSessionStatus(excludeStatusParam);
-  const createdByUserIds = parseCreatedByFilters(url.searchParams);
+  const createdByUserIds = parseCreatedByFilters(url.searchParams, ctx.principal);
 
   if (statusParam && !status) {
     return error("Invalid status", 400);

--- a/packages/control-plane/test/integration/auth.test.ts
+++ b/packages/control-plane/test/integration/auth.test.ts
@@ -92,8 +92,54 @@ describe("Edge authentication", () => {
     expect(body.hasMore).toBe(false);
   });
 
+  it("filters and paginates sessions for the authenticated browser user with createdBy=me", async () => {
+    const browserUserId = "11111111111111111111111111111111";
+    const otherUserId = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const store = new SessionIndexStore(env.DB);
+    const now = Date.now();
+
+    for (const [id, userId, ageMs] of [
+      ["mine-newest", browserUserId, 0],
+      ["other-user", otherUserId, 500],
+      ["mine-middle", browserUserId, 1000],
+      ["mine-oldest", browserUserId, 2000],
+    ] as const) {
+      await store.create({
+        id,
+        title: null,
+        repoOwner: "acme",
+        repoName: "api",
+        model: "anthropic/claude-haiku-4-5",
+        reasoningEffort: null,
+        baseBranch: null,
+        status: "active",
+        userId,
+        createdAt: now - ageMs,
+        updatedAt: now - ageMs,
+      });
+    }
+
+    const firstResponse = await serviceFetch(
+      "https://test.local/sessions?createdBy=me&limit=2&offset=0"
+    );
+    const secondResponse = await serviceFetch(
+      "https://test.local/sessions?createdBy=me&limit=2&offset=2"
+    );
+
+    expect(firstResponse.status).toBe(200);
+    await expect(firstResponse.json()).resolves.toMatchObject({
+      sessions: [{ id: "mine-newest" }, { id: "mine-middle" }],
+      hasMore: true,
+    });
+    expect(secondResponse.status).toBe(200);
+    await expect(secondResponse.json()).resolves.toMatchObject({
+      sessions: [{ id: "mine-oldest" }],
+      hasMore: false,
+    });
+  });
+
   it("rejects invalid creator user id filters", async () => {
-    const response = await serviceFetch("https://test.local/sessions?createdBy=me");
+    const response = await serviceFetch("https://test.local/sessions?createdBy=not-a-user-id");
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({ error: "Invalid createdBy" });

--- a/packages/web/src/app/api/sessions/route.test.ts
+++ b/packages/web/src/app/api/sessions/route.test.ts
@@ -35,20 +35,7 @@ describe("sessions API route", () => {
     vi.resetAllMocks();
   });
 
-  it("returns 401 when the user session is missing", async () => {
-    vi.mocked(getServerAuthSession).mockResolvedValue(null);
-
-    const response = await GET(request("/api/sessions?limit=50"));
-
-    expect(response.status).toBe(401);
-    await expect(response.json()).resolves.toEqual({ error: "Unauthorized" });
-    expect(controlPlaneUserFetch).not.toHaveBeenCalled();
-  });
-
   it("forwards allowed session query params", async () => {
-    vi.mocked(getServerAuthSession).mockResolvedValue({
-      user: { id: "0123456789abcdef0123456789abcdef" },
-    });
     vi.mocked(controlPlaneUserFetch).mockResolvedValue(
       Response.json({ sessions: [], hasMore: false }, { status: 200 })
     );
@@ -62,86 +49,30 @@ describe("sessions API route", () => {
     expect(controlPlaneUserFetch).toHaveBeenCalledWith(
       "/sessions?limit=10&offset=20&excludeStatus=archived&createdBy=0123456789abcdef0123456789abcdef"
     );
+    expect(getServerAuthSession).not.toHaveBeenCalled();
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ sessions: [], hasMore: false });
   });
 
-  it("replaces createdBy=me with the canonical session principal", async () => {
-    vi.mocked(getServerAuthSession).mockResolvedValue({
-      user: {
-        id: "0123456789abcdef0123456789abcdef",
-        name: "Ada Lovelace",
-        email: "ada@example.com",
-        image: "https://avatars.githubusercontent.com/u/12345",
-      },
-    });
+  it("forwards repeated and mixed creator filters without resolving createdBy=me", async () => {
     vi.mocked(controlPlaneUserFetch).mockResolvedValueOnce(
       Response.json({ sessions: [], hasMore: false }, { status: 200 })
     );
 
     const response = await GET(
-      request("/api/sessions?limit=50&offset=0&excludeStatus=archived&createdBy=me")
+      request(
+        "/api/sessions?createdBy=ffffffffffffffffffffffffffffffff&createdBy=me&createdBy=me&limit=25&offset=50"
+      )
     );
 
     expect(controlPlaneUserFetch).toHaveBeenCalledWith(
-      "/sessions?limit=50&offset=0&excludeStatus=archived&createdBy=0123456789abcdef0123456789abcdef"
+      "/sessions?limit=25&offset=50&createdBy=ffffffffffffffffffffffffffffffff&createdBy=me&createdBy=me"
     );
+    expect(getServerAuthSession).not.toHaveBeenCalled();
     expect(response.status).toBe(200);
   });
 
-  it("does not branch on the provider used to authenticate the session", async () => {
-    vi.mocked(getServerAuthSession).mockResolvedValue({
-      user: {
-        id: "fedcba9876543210fedcba9876543210",
-        name: "Pat PM",
-        email: "pm@gmail.com",
-        image: "https://lh3.googleusercontent.com/a/pat",
-      },
-    });
-    vi.mocked(controlPlaneUserFetch).mockResolvedValueOnce(
-      Response.json({ sessions: [], hasMore: false }, { status: 200 })
-    );
-
-    const response = await GET(request("/api/sessions?limit=50&createdBy=me"));
-
-    expect(controlPlaneUserFetch).toHaveBeenCalledWith(
-      "/sessions?limit=50&createdBy=fedcba9876543210fedcba9876543210"
-    );
-    expect(response.status).toBe(200);
-  });
-
-  it("resolves createdBy=me alongside explicit creator filters", async () => {
-    vi.mocked(getServerAuthSession).mockResolvedValue({
-      user: {
-        id: "0123456789abcdef0123456789abcdef",
-        name: "Ada Lovelace",
-        email: "ada@example.com",
-        image: "https://avatars.githubusercontent.com/u/12345",
-      },
-    });
-    vi.mocked(controlPlaneUserFetch).mockResolvedValueOnce(
-      Response.json({ sessions: [], hasMore: false }, { status: 200 })
-    );
-
-    const response = await GET(
-      request("/api/sessions?createdBy=ffffffffffffffffffffffffffffffff&createdBy=me&limit=25")
-    );
-
-    expect(controlPlaneUserFetch).toHaveBeenCalledWith(
-      "/sessions?limit=25&createdBy=ffffffffffffffffffffffffffffffff&createdBy=0123456789abcdef0123456789abcdef"
-    );
-    expect(response.status).toBe(200);
-  });
-
-  it("uses the same canonical principal across pagination requests", async () => {
-    vi.mocked(getServerAuthSession).mockResolvedValue({
-      user: {
-        id: "0123456789abcdef0123456789abcdef",
-        name: "Ada Lovelace",
-        email: "ada@example.com",
-        image: "https://avatars.githubusercontent.com/u/12345",
-      },
-    });
+  it("preserves createdBy=me across pagination requests", async () => {
     vi.mocked(controlPlaneUserFetch)
       .mockResolvedValueOnce(Response.json({ sessions: [], hasMore: true }, { status: 200 }))
       .mockResolvedValueOnce(Response.json({ sessions: [], hasMore: false }, { status: 200 }));
@@ -152,12 +83,27 @@ describe("sessions API route", () => {
     expect(controlPlaneUserFetch).toHaveBeenCalledTimes(2);
     expect(controlPlaneUserFetch).toHaveBeenNthCalledWith(
       1,
-      "/sessions?limit=50&offset=0&excludeStatus=archived&createdBy=0123456789abcdef0123456789abcdef"
+      "/sessions?limit=50&offset=0&excludeStatus=archived&createdBy=me"
     );
     expect(controlPlaneUserFetch).toHaveBeenNthCalledWith(
       2,
-      "/sessions?limit=50&offset=50&excludeStatus=archived&createdBy=0123456789abcdef0123456789abcdef"
+      "/sessions?limit=50&offset=50&excludeStatus=archived&createdBy=me"
     );
+    expect(getServerAuthSession).not.toHaveBeenCalled();
+  });
+
+  it.each([401, 400])("propagates a control-plane %i response", async (status) => {
+    vi.mocked(controlPlaneUserFetch).mockResolvedValueOnce(
+      Response.json({ error: status === 401 ? "Unauthorized" : "Invalid createdBy" }, { status })
+    );
+
+    const response = await GET(request("/api/sessions?createdBy=me"));
+
+    expect(response.status).toBe(status);
+    await expect(response.json()).resolves.toEqual({
+      error: status === 401 ? "Unauthorized" : "Invalid createdBy",
+    });
+    expect(getServerAuthSession).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -7,31 +7,12 @@ import {
   buildControlPlanePath,
   SESSION_CONTROL_PLANE_QUERY_PARAMS,
 } from "@/lib/control-plane-query";
-import { CURRENT_USER_CREATED_BY } from "@/lib/session-list";
 
 export async function GET(request: NextRequest) {
   const routeStart = Date.now();
 
-  const session = await getServerAuthSession();
-  const authMs = Date.now() - routeStart;
-
-  if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
   try {
     const searchParams = new URLSearchParams(request.nextUrl.searchParams);
-
-    const createdByValues = searchParams.getAll("createdBy");
-    if (createdByValues.includes(CURRENT_USER_CREATED_BY)) {
-      searchParams.delete("createdBy");
-      for (const value of createdByValues) {
-        searchParams.append(
-          "createdBy",
-          value === CURRENT_USER_CREATED_BY ? session.user.id : value
-        );
-      }
-    }
 
     const path = buildControlPlanePath(
       "/sessions",
@@ -45,9 +26,7 @@ export async function GET(request: NextRequest) {
     const data = await response.json();
     const totalMs = Date.now() - routeStart;
 
-    console.log(
-      `[sessions:GET] total=${totalMs}ms auth=${authMs}ms fetch=${fetchMs}ms status=${response.status}`
-    );
+    console.log(`[sessions:GET] total=${totalMs}ms fetch=${fetchMs}ms status=${response.status}`);
 
     return NextResponse.json(data, { status: response.status });
   } catch (error) {


### PR DESCRIPTION
## Summary

- forward `createdBy=me` unchanged through the web sessions-list BFF
- resolve `me` in the authenticated control plane from canonical browser-user principals
- preserve explicit canonical IDs, repeated/mixed OR filters, post-resolution deduplication, and pagination
- fail closed with 400 for invalid values and non-user or non-canonical principals
- propagate control-plane 401/400 responses through the web route

## TDD Evidence

### Red

Added the intended tests before production edits and confirmed failures:

- control-plane route: 3 failures for user `me`, mixed filters, and post-resolution deduplication
- web route: 5 failures for unchanged forwarding, pagination, no server-session lookup, and 401/400 propagation
- control-plane integration: 1 failure because authenticated `createdBy=me` returned 400

### Green

After the minimal route changes:

- focused control-plane route tests: 10 passed
- focused web sessions route tests: 11 passed
- focused control-plane auth integration tests: 7 passed

## Verification

- `npx prettier --write` on all five changed files
- `npx eslint` on all five changed files
- `npm run build -w @open-inspect/shared`
- `npm run typecheck`: passed across all TypeScript workspaces
- `npm test -w @open-inspect/control-plane`: 136 files, 2,122 tests passed
- `npm test -w @open-inspect/web`: 105 files, 814 tests passed
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/auth.test.ts test/integration/service-auth.test.ts`: 2 files, 22 tests passed
- `git diff --check`: passed

## Independent Review

An independent read-only review of the complete live diff found no correctness, security, regression, scope, or missing-test findings.

The reviewer noted optional integration duplication for service-principal rejection and mixed/deduplicated values. These were not added because the required semantics are directly covered in control-plane route unit tests, while real-D1 integration coverage proves authenticated-user row filtering, exclusion of another user, and stable pagination.

## Scope

- no auth name or profile propagation changes
- no participant-profile architecture changes
- no unrelated session behavior changes
- POST session authentication/profile handling remains unchanged
- no D1 migration

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/6ae4c479ef545809af79422ab0006da5)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `createdBy=me` filtering for session listings, resolving to the authenticated user.
  - Supports combining “me” with explicit creator filters and removes duplicate values.
  - Preserves the “me” filter across paginated requests.

- **Bug Fixes**
  - Improved validation and error handling for invalid creator filters and unsupported authentication contexts.
  - Session listing requests now handle authentication consistently while propagating control-plane errors correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->