### PR TITLE
Import shared auth from its owner module

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -60,6 +60,29 @@ export default tseslint.config(
         "error",
         { prefer: "type-imports", fixStyle: "separate-type-imports" },
       ],
+      "no-restricted-imports": "off",
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@open-inspect/shared",
+              importNames: [
+                "TOKEN_VALIDITY_MS",
+                "timingSafeEqual",
+                "bytesToHex",
+                "computeHmacHex",
+                "generateInternalToken",
+                "verifyCallbackSignature",
+                "verifyCallbackFromControlPlane",
+                "verifyInternalToken",
+              ],
+              message: "Import auth-owned names from @open-inspect/shared/auth.",
+              allowTypeImports: true,
+            },
+          ],
+        },
+      ],
       // Allow console in backend/server code - disable per-file if needed
       "no-console": "off",
     },

--- a/packages/control-plane/src/auth/authenticate.test.ts
+++ b/packages/control-plane/src/auth/authenticate.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 import {
   ACTOR_HEADER,
   buildServiceAuthHeaders,
-  generateInternalToken,
   SERVICE_HEADER,
   SERVICE_SIGNATURE_HEADER,
   type ServiceName,
 } from "@open-inspect/shared";
+import { generateInternalToken } from "@open-inspect/shared/auth";
 
 import { authenticate, isAuthError, SERVICE_REQUEST_MAX_BODY_BYTES } from "./authenticate";
 import type { RequestContext } from "../routes/shared";

--- a/packages/control-plane/src/auth/crypto.test.ts
+++ b/packages/control-plane/src/auth/crypto.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { timingSafeEqual } from "@open-inspect/shared";
+import { timingSafeEqual } from "@open-inspect/shared/auth";
 import { encryptToken, decryptToken, generateEncryptionKey, generateId, hashToken } from "./crypto";
 
 describe("crypto", () => {

--- a/packages/control-plane/src/auth/service/request-authenticator.ts
+++ b/packages/control-plane/src/auth/service/request-authenticator.ts
@@ -1,7 +1,6 @@
 import {
   ACTOR_HEADER,
   SERVICE_HEADER,
-  TOKEN_VALIDITY_MS,
   isServiceName,
   parseServiceSignatureHeader,
   readBodyCapped,
@@ -9,6 +8,7 @@ import {
   verifyServiceSignature,
   type ServiceName,
 } from "@open-inspect/shared";
+import { TOKEN_VALIDITY_MS } from "@open-inspect/shared/auth";
 import { UserStore } from "../../db/user-store";
 import { createLogger } from "../../logger";
 import type { RequestContext } from "../../routes/shared";

--- a/packages/control-plane/src/auth/webhook-key.ts
+++ b/packages/control-plane/src/auth/webhook-key.ts
@@ -5,7 +5,7 @@
  * Hashed with SHA-256 (brute-force resistance unnecessary for high-entropy random keys).
  */
 
-import { timingSafeEqual } from "@open-inspect/shared";
+import { timingSafeEqual } from "@open-inspect/shared/auth";
 import { encryptToken, decryptToken } from "./crypto";
 import { base64UrlEncode } from "./encoding";
 

--- a/packages/control-plane/src/db/image-builds.ts
+++ b/packages/control-plane/src/db/image-builds.ts
@@ -1,10 +1,10 @@
 import {
-  timingSafeEqual,
   type ImageBuildRecordView,
   type ImageBuildScopeKind,
   type ImageBuildStatus,
   type RepositoryShaEntry,
 } from "@open-inspect/shared";
+import { timingSafeEqual } from "@open-inspect/shared/auth";
 import type {
   ImageBuildCallbackBuild,
   ImageBuildProvider,

--- a/packages/control-plane/src/image-builds/callback-auth.test.ts
+++ b/packages/control-plane/src/image-builds/callback-auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { computeHmacHex } from "@open-inspect/shared";
+import { computeHmacHex } from "@open-inspect/shared/auth";
 import type { Env } from "../types";
 import {
   consumeImageBuildCallbackTokenOrThrow,

--- a/packages/control-plane/src/image-builds/callback-auth.ts
+++ b/packages/control-plane/src/image-builds/callback-auth.ts
@@ -11,7 +11,8 @@
  * (the workflow) log and map to the route-facing error taxonomy.
  */
 
-import { computeHmacHex, type RepositoryShaEntry } from "@open-inspect/shared";
+import type { RepositoryShaEntry } from "@open-inspect/shared";
+import { computeHmacHex } from "@open-inspect/shared/auth";
 import type { ImageBuildStore } from "../db/image-builds";
 import type { Env } from "../types";
 import type { ImageBuildProvider, MarkImageBuildReadyResult } from "./model";

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -5,7 +5,8 @@
  * All requests are authenticated using HMAC-signed tokens.
  */
 
-import { generateInternalToken, type SandboxSettings } from "@open-inspect/shared";
+import type { SandboxSettings } from "@open-inspect/shared";
+import { generateInternalToken } from "@open-inspect/shared/auth";
 import type { ImageBuildScopeKind, McpServerConfig } from "@open-inspect/shared";
 import { z } from "zod";
 import { createLogger } from "../logger";

--- a/packages/control-plane/src/sandbox/providers/daytona-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/daytona-provider.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { computeHmacHex } from "@open-inspect/shared";
+import { computeHmacHex } from "@open-inspect/shared/auth";
 import { DaytonaSandboxProvider, type DaytonaProviderConfig } from "./daytona-provider";
 import { SandboxProviderError } from "../provider";
 import type { CreateSandboxConfig, ResumeConfig, StopConfig } from "../provider";

--- a/packages/control-plane/src/sandbox/providers/e2b-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/e2b-provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { computeHmacHex } from "@open-inspect/shared";
+import { computeHmacHex } from "@open-inspect/shared/auth";
 import { E2BSandboxProvider, type E2BProviderConfig } from "./e2b-provider";
 import { SandboxProviderError } from "../provider";
 import {

--- a/packages/control-plane/src/sandbox/sandbox-env.ts
+++ b/packages/control-plane/src/sandbox/sandbox-env.ts
@@ -1,4 +1,5 @@
-import { computeHmacHex, type McpServerConfig } from "@open-inspect/shared";
+import type { McpServerConfig } from "@open-inspect/shared";
+import { computeHmacHex } from "@open-inspect/shared/auth";
 import type { SourceControlProviderName } from "../source-control";
 import type { CreateSandboxConfig, RestoreConfig, SessionRepositoryInfo } from "./provider";
 import { resolveServicePorts } from "./providers/port-resolution";

--- a/packages/control-plane/src/scheduler/durable-object.ts
+++ b/packages/control-plane/src/scheduler/durable-object.ts
@@ -14,13 +14,13 @@ import {
   nextCronOccurrence,
   matchesConditions,
   conditionRegistry,
-  computeHmacHex,
   type AutomationCallbackContext,
   type AutomationInvocationSource,
   type SlackAutomationEvent,
   type SlackCallbackContext,
   type TriggerConfig,
 } from "@open-inspect/shared";
+import { computeHmacHex } from "@open-inspect/shared/auth";
 import { z } from "zod";
 import { callbackSigningSecret } from "../auth/service/callback-signing";
 import {

--- a/packages/control-plane/src/session/callback-notification-service.ts
+++ b/packages/control-plane/src/session/callback-notification-service.ts
@@ -7,7 +7,7 @@
  * - HMAC payload signing for callback authentication
  */
 
-import { computeHmacHex } from "@open-inspect/shared";
+import { computeHmacHex } from "@open-inspect/shared/auth";
 import { callbackSigningSecret, type CallbackDestination } from "../auth/service/callback-signing";
 import type { Logger } from "../logger";
 import { deliverWithRetry } from "./callback-delivery";

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -14,9 +14,9 @@ import {
   clientMessageSchema,
   resolveAppName,
   sandboxEventSchema,
-  timingSafeEqual,
   type SessionAttachmentReference,
 } from "@open-inspect/shared";
+import { timingSafeEqual } from "@open-inspect/shared/auth";
 import { generateId, hashToken, encryptToken, decryptToken } from "../auth/crypto";
 import { buildModalSandboxDashboardUrl } from "../sandbox/client";
 import { resolveSandboxBackendName } from "../sandbox/provider-name";

--- a/packages/control-plane/src/session/linear-start-callback.ts
+++ b/packages/control-plane/src/session/linear-start-callback.ts
@@ -1,4 +1,4 @@
-import { computeHmacHex } from "@open-inspect/shared";
+import { computeHmacHex } from "@open-inspect/shared/auth";
 import type { Logger } from "../logger";
 import { deliverWithRetry } from "./callback-delivery";
 

--- a/packages/control-plane/test/integration/auth.test.ts
+++ b/packages/control-plane/test/integration/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { generateInternalToken } from "@open-inspect/shared";
+import { generateInternalToken } from "@open-inspect/shared/auth";
 import { SELF, env } from "cloudflare:test";
 import { SessionIndexStore } from "../../src/db/session-index";
 import { cleanD1Tables } from "./cleanup";

--- a/packages/control-plane/test/integration/commit-signing.test.ts
+++ b/packages/control-plane/test/integration/commit-signing.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { SELF, env } from "cloudflare:test";
 
-import { generateInternalToken } from "@open-inspect/shared";
+import { generateInternalToken } from "@open-inspect/shared/auth";
 import { signGitPayloadWithOpenSshEd25519PrivateKey } from "../../src/auth/openssh-ed25519";
 import { CommitSigningStore } from "../../src/db/commit-signing";
 import { cleanD1Tables } from "./cleanup";

--- a/packages/control-plane/test/integration/service-auth.test.ts
+++ b/packages/control-plane/test/integration/service-auth.test.ts
@@ -3,11 +3,11 @@ import { SELF, env } from "cloudflare:test";
 import {
   ACTOR_HEADER,
   buildServiceAuthHeaders,
-  generateInternalToken,
   SERVICE_HEADER,
   SERVICE_SIGNATURE_HEADER,
   type ServiceName,
 } from "@open-inspect/shared";
+import { generateInternalToken } from "@open-inspect/shared/auth";
 import { GlobalSecretsStore } from "../../src/db/global-secrets";
 import { UserStore } from "../../src/db/user-store";
 import { cleanD1Tables } from "./cleanup";

--- a/packages/github-bot/src/verify.ts
+++ b/packages/github-bot/src/verify.ts
@@ -1,4 +1,4 @@
-import { computeHmacHex, timingSafeEqual } from "@open-inspect/shared";
+import { computeHmacHex, timingSafeEqual } from "@open-inspect/shared/auth";
 
 export async function verifyWebhookSignature(
   secret: string,

--- a/packages/linear-bot/src/callbacks.start.test.ts
+++ b/packages/linear-bot/src/callbacks.start.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { callbacksRouter } from "./callbacks";
 import { createStartCallbackRouter } from "./callbacks/start-callback";
-import { computeHmacHex } from "@open-inspect/shared";
+import { computeHmacHex } from "@open-inspect/shared/auth";
 import { createFakeKV, makeExecutionContext, makeLinearBotEnv } from "./test-helpers";
 import type { LinearApiClient } from "./utils/linear-client";
 

--- a/packages/linear-bot/src/callbacks/reject-invalid-callback.ts
+++ b/packages/linear-bot/src/callbacks/reject-invalid-callback.ts
@@ -1,5 +1,5 @@
 import type { Context } from "hono";
-import { verifyCallbackFromControlPlane } from "@open-inspect/shared";
+import { verifyCallbackFromControlPlane } from "@open-inspect/shared/auth";
 import type { Env } from "../types";
 import { createLogger } from "../logger";
 

--- a/packages/linear-bot/src/utils/linear-client.ts
+++ b/packages/linear-bot/src/utils/linear-client.ts
@@ -9,8 +9,7 @@ import {
   type Env,
   type LinearIssueDetails,
 } from "../types";
-import { timingSafeEqual } from "@open-inspect/shared";
-import { computeHmacHex } from "@open-inspect/shared";
+import { computeHmacHex, timingSafeEqual } from "@open-inspect/shared/auth";
 import { createLogger } from "../logger";
 import {
   getClientCredentialsTokenOrThrow,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,6 +9,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./auth": {
+      "import": "./dist/auth.js",
+      "types": "./dist/auth.d.ts"
     }
   },
   "scripts": {

--- a/packages/slack-bot/src/callbacks.test.ts
+++ b/packages/slack-bot/src/callbacks.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
-import { computeHmacHex } from "@open-inspect/shared";
+import { computeHmacHex } from "@open-inspect/shared/auth";
 import { callbacksRouter } from "./callbacks";
 import type { Env } from "./types";
 

--- a/packages/slack-bot/src/callbacks.ts
+++ b/packages/slack-bot/src/callbacks.ts
@@ -2,7 +2,8 @@
  * Callback handlers for control-plane notifications.
  */
 
-import { postEphemeral, verifyCallbackFromControlPlane } from "@open-inspect/shared";
+import { postEphemeral } from "@open-inspect/shared";
+import { verifyCallbackFromControlPlane } from "@open-inspect/shared/auth";
 import { Hono, type Context } from "hono";
 import { z } from "zod";
 import type { Env } from "./types";


### PR DESCRIPTION
## Summary

- expose the existing `packages/shared/src/auth.ts` module as `@open-inspect/shared/auth`
- migrate all 14 production files and 10 tests that consume auth symbols
- preserve the package-root exports and add no facade or re-export-only source module

## Architecture

`auth.ts` remains the owner before and after this change. The new `package.json` entry only maps the package path to the existing emitted JavaScript and declaration files. Shared implementation ownership and package dependency direction are unchanged.

## Dependency delta

- production root-facade consumers: 266 -> 260
- auth imports remaining on the root: 0
- auth-path consumer files: 24
- compile-time and runtime SCCs: unchanged at zero

## Behavior

No runtime behavior, schemas, auth formats, or exported root names change. The root and `/auth` paths resolve to the same function identities.

## Validation

- `npm run build`
- `npm run typecheck`
- `npm run lint`
- shared: 37 files / 506 tests
- control-plane unit: 136 files / 2,116 tests
- control-plane workerd/D1 integration: 56 files / 654 tests
- GitHub bot: 7 files / 130 tests
- Linear bot: 14 files / 202 tests
- Slack bot: 29 files / 379 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed a dedicated shared authentication entry point, enabling auth/crypto helpers to be imported from a dedicated subpath.

* **Refactor**
  * Updated control-plane, bot, and webhook verification code to consistently use the shared authentication module for token generation and cryptographic verification helpers.
  * Kept all existing authentication, webhook verification, and signing behavior the same.

* **Chores**
  * Adjusted lint rules to enforce the new shared authentication import paths (while allowing type-only imports).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->