### PR TITLE
Add request-time React login route

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -212,6 +212,21 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    files: [
+      "packages/web/src/components/**/*.{ts,tsx}",
+      "packages/web/src/hooks/**/*.{ts,tsx}",
+    ],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "ImportDeclaration[source.value='@/lib/sign-in-providers']",
+          message: "Provider discovery is server-only; render its result into client components.",
+        },
+      ],
+    },
+  },
 
   // Cloudflare Workers specific config
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -212,22 +212,6 @@ export default tseslint.config(
       ],
     },
   },
-  {
-    files: [
-      "packages/web/src/components/**/*.{ts,tsx}",
-      "packages/web/src/hooks/**/*.{ts,tsx}",
-    ],
-    rules: {
-      "no-restricted-syntax": [
-        "error",
-        {
-          selector: "ImportDeclaration[source.value='@/lib/sign-in-providers']",
-          message: "Provider discovery is server-only; render its result into client components.",
-        },
-      ],
-    },
-  },
-
   // Cloudflare Workers specific config
   {
     files: ["packages/control-plane/**/*.ts"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -14206,6 +14206,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
+    },
     "node_modules/set-cookie-parser": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.2.tgz",
@@ -16483,6 +16489,7 @@
         "rehype-highlight": "^7.0.2",
         "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1",
+        "server-only": "0.0.1",
         "sonner": "^2.0.7",
         "swr": "^2.4.0",
         "tailwind-merge": "^3.5.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -44,6 +44,7 @@
     "rehype-highlight": "^7.0.2",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
+    "server-only": "0.0.1",
     "sonner": "^2.0.7",
     "swr": "^2.4.0",
     "tailwind-merge": "^3.5.0",

--- a/packages/web/src/app/(app)/layout.tsx
+++ b/packages/web/src/app/(app)/layout.tsx
@@ -1,5 +1,10 @@
+import { AppAuthBoundary } from "@/components/app-auth-boundary";
 import { SidebarLayout } from "@/components/sidebar-layout";
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
-  return <SidebarLayout>{children}</SidebarLayout>;
+  return (
+    <AppAuthBoundary>
+      <SidebarLayout>{children}</SidebarLayout>
+    </AppAuthBoundary>
+  );
 }

--- a/packages/web/src/app/login/page.test.tsx
+++ b/packages/web/src/app/login/page.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { cleanup, render, screen } from "@testing-library/react";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getServerAuthSession: vi.fn(),
+  getEnabledSignInProviders: vi.fn(),
+  redirect: vi.fn(),
+  unstableRethrow: vi.fn(),
+}));
+
+vi.mock("@/lib/server-auth-session", () => ({
+  getServerAuthSession: mocks.getServerAuthSession,
+}));
+
+vi.mock("@/lib/sign-in-providers", () => ({
+  getEnabledSignInProviders: mocks.getEnabledSignInProviders,
+}));
+
+vi.mock("@/lib/auth-session", () => ({
+  signIn: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: mocks.redirect,
+  unstable_rethrow: mocks.unstableRethrow,
+}));
+
+import LoginPage, { dynamic } from "./page";
+
+expect.extend(matchers);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mocks.getServerAuthSession.mockResolvedValue(null);
+  mocks.getEnabledSignInProviders.mockResolvedValue(["github", "google"]);
+});
+
+afterEach(cleanup);
+
+describe("LoginPage", () => {
+  it("renders the request-time provider choices in the React application", async () => {
+    render(await LoginPage());
+
+    expect(screen.getByRole("heading", { name: "Sign in to Open-Inspect" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sign in with GitHub" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sign in with Google" })).toBeInTheDocument();
+  });
+
+  it("redirects an authenticated user before querying providers", async () => {
+    mocks.getServerAuthSession.mockResolvedValue({
+      user: { id: "user-1", name: "Ada" },
+    });
+    mocks.redirect.mockImplementation(() => {
+      throw new Error("NEXT_REDIRECT");
+    });
+
+    await expect(LoginPage()).rejects.toThrow("NEXT_REDIRECT");
+    expect(mocks.redirect).toHaveBeenCalledWith("/");
+    expect(mocks.getEnabledSignInProviders).not.toHaveBeenCalled();
+  });
+
+  it.each(["session", "providers"] as const)(
+    "renders a sanitized retryable unavailable state when %s resolution fails",
+    async (failure) => {
+      if (failure === "session") {
+        mocks.getServerAuthSession.mockRejectedValue(new Error("sensitive session error"));
+      } else {
+        mocks.getEnabledSignInProviders.mockRejectedValue(new Error("sensitive provider error"));
+      }
+
+      render(await LoginPage());
+
+      expect(screen.getByRole("alert")).toHaveTextContent("Sign-in is temporarily unavailable.");
+      expect(screen.getByRole("link", { name: "Try again" })).toHaveAttribute("href", "/login");
+      expect(screen.queryByText(/sensitive/)).not.toBeInTheDocument();
+    }
+  );
+
+  it.each(["session", "providers"] as const)(
+    "propagates Next.js control-flow errors from the %s seam",
+    async (failure) => {
+      const frameworkSignal = new Error(`NEXT_${failure.toUpperCase()}_SIGNAL`);
+      mocks.unstableRethrow.mockImplementation((error: unknown) => {
+        if (error === frameworkSignal) throw error;
+      });
+      if (failure === "session") {
+        mocks.getServerAuthSession.mockRejectedValue(frameworkSignal);
+      } else {
+        mocks.getEnabledSignInProviders.mockRejectedValue(frameworkSignal);
+      }
+
+      await expect(LoginPage()).rejects.toBe(frameworkSignal);
+      expect(mocks.unstableRethrow).toHaveBeenCalledWith(frameworkSignal);
+    }
+  );
+
+  it("is always rendered at request time", () => {
+    expect(dynamic).toBe("force-dynamic");
+  });
+});

--- a/packages/web/src/app/login/page.test.tsx
+++ b/packages/web/src/app/login/page.test.tsx
@@ -9,7 +9,6 @@ const mocks = vi.hoisted(() => ({
   getServerAuthSession: vi.fn(),
   getEnabledSignInProviders: vi.fn(),
   redirect: vi.fn(),
-  unstableRethrow: vi.fn(),
 }));
 
 vi.mock("@/lib/server-auth-session", () => ({
@@ -26,9 +25,9 @@ vi.mock("@/lib/auth-session", () => ({
 
 vi.mock("next/navigation", () => ({
   redirect: mocks.redirect,
-  unstable_rethrow: mocks.unstableRethrow,
 }));
 
+import { AuthenticationUnavailableError } from "@/lib/authentication-unavailable-error";
 import LoginPage, { dynamic } from "./page";
 
 expect.extend(matchers);
@@ -67,9 +66,13 @@ describe("LoginPage", () => {
     "renders a sanitized retryable unavailable state when %s resolution fails",
     async (failure) => {
       if (failure === "session") {
-        mocks.getServerAuthSession.mockRejectedValue(new Error("sensitive session error"));
+        mocks.getServerAuthSession.mockRejectedValue(
+          new AuthenticationUnavailableError(new Error("sensitive session error"))
+        );
       } else {
-        mocks.getEnabledSignInProviders.mockRejectedValue(new Error("sensitive provider error"));
+        mocks.getEnabledSignInProviders.mockRejectedValue(
+          new AuthenticationUnavailableError(new Error("sensitive provider error"))
+        );
       }
 
       render(await LoginPage());
@@ -81,20 +84,16 @@ describe("LoginPage", () => {
   );
 
   it.each(["session", "providers"] as const)(
-    "propagates Next.js control-flow errors from the %s seam",
+    "propagates unexpected errors from the %s seam",
     async (failure) => {
-      const frameworkSignal = new Error(`NEXT_${failure.toUpperCase()}_SIGNAL`);
-      mocks.unstableRethrow.mockImplementation((error: unknown) => {
-        if (error === frameworkSignal) throw error;
-      });
+      const unexpectedError = new Error(`unexpected ${failure} failure`);
       if (failure === "session") {
-        mocks.getServerAuthSession.mockRejectedValue(frameworkSignal);
+        mocks.getServerAuthSession.mockRejectedValue(unexpectedError);
       } else {
-        mocks.getEnabledSignInProviders.mockRejectedValue(frameworkSignal);
+        mocks.getEnabledSignInProviders.mockRejectedValue(unexpectedError);
       }
 
-      await expect(LoginPage()).rejects.toBe(frameworkSignal);
-      expect(mocks.unstableRethrow).toHaveBeenCalledWith(frameworkSignal);
+      await expect(LoginPage()).rejects.toBe(unexpectedError);
     }
   );
 

--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+import { redirect, unstable_rethrow } from "next/navigation";
+import { SignInProviderButtons } from "@/components/sign-in-provider-buttons";
+import { ErrorBanner } from "@/components/ui/error-banner";
+import { getServerAuthSession, type ServerAuthSession } from "@/lib/server-auth-session";
+import { getEnabledSignInProviders } from "@/lib/sign-in-providers";
+import { APP_NAME } from "@/lib/site-config";
+
+export const dynamic = "force-dynamic";
+
+function LoginUnavailable() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center gap-4 px-6">
+      <ErrorBanner role="alert" className="max-w-md px-6 py-4 text-center">
+        Sign-in is temporarily unavailable.
+      </ErrorBanner>
+      <Link href="/login" className="text-accent hover:underline">
+        Try again
+      </Link>
+    </main>
+  );
+}
+
+export default async function LoginPage() {
+  let session: ServerAuthSession | null;
+  try {
+    session = await getServerAuthSession();
+  } catch (error) {
+    unstable_rethrow(error);
+    return <LoginUnavailable />;
+  }
+  if (session) redirect("/");
+
+  let providers;
+  try {
+    providers = await getEnabledSignInProviders();
+  } catch (error) {
+    unstable_rethrow(error);
+    return <LoginUnavailable />;
+  }
+
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center gap-8 px-6">
+      <div className="space-y-3 text-center">
+        <h1 className="text-4xl font-bold text-foreground">Sign in to {APP_NAME}</h1>
+        <p className="text-muted-foreground">Choose an authentication provider to continue.</p>
+      </div>
+      <SignInProviderButtons providers={providers} />
+    </main>
+  );
+}

--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
-import { redirect, unstable_rethrow } from "next/navigation";
+import { redirect } from "next/navigation";
 import { SignInProviderButtons } from "@/components/sign-in-provider-buttons";
 import { ErrorBanner } from "@/components/ui/error-banner";
+import { AuthenticationUnavailableError } from "@/lib/authentication-unavailable-error";
 import { getServerAuthSession, type ServerAuthSession } from "@/lib/server-auth-session";
 import { getEnabledSignInProviders } from "@/lib/sign-in-providers";
 import { APP_NAME } from "@/lib/site-config";
@@ -26,8 +27,8 @@ export default async function LoginPage() {
   try {
     session = await getServerAuthSession();
   } catch (error) {
-    unstable_rethrow(error);
-    return <LoginUnavailable />;
+    if (error instanceof AuthenticationUnavailableError) return <LoginUnavailable />;
+    throw error;
   }
   if (session) redirect("/");
 
@@ -35,8 +36,8 @@ export default async function LoginPage() {
   try {
     providers = await getEnabledSignInProviders();
   } catch (error) {
-    unstable_rethrow(error);
-    return <LoginUnavailable />;
+    if (error instanceof AuthenticationUnavailableError) return <LoginUnavailable />;
+    throw error;
   }
 
   return (

--- a/packages/web/src/components/app-auth-boundary.test.tsx
+++ b/packages/web/src/components/app-auth-boundary.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { cleanup, render, screen } from "@testing-library/react";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAuthSession } from "@/lib/auth-session";
+import { AppAuthBoundary } from "./app-auth-boundary";
+
+expect.extend(matchers);
+
+vi.mock("@/lib/auth-session", () => ({
+  useAuthSession: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("AppAuthBoundary", () => {
+  it("renders the app only for authenticated users", () => {
+    vi.mocked(useAuthSession).mockReturnValue({
+      data: { user: { id: "user-1", name: "Test User" } },
+      status: "authenticated",
+    });
+
+    render(<AppAuthBoundary>Session</AppAuthBoundary>);
+
+    expect(screen.getByText("Session")).toBeInTheDocument();
+  });
+
+  it("renders a loading state before authentication resolves", () => {
+    vi.mocked(useAuthSession).mockReturnValue({ data: null, status: "loading" });
+
+    render(<AppAuthBoundary>Session</AppAuthBoundary>);
+
+    expect(screen.getByRole("status", { name: "Checking authentication" })).toBeInTheDocument();
+    expect(screen.queryByText("Session")).not.toBeInTheDocument();
+  });
+
+  it("links unauthenticated users to the provider-aware login route", () => {
+    vi.mocked(useAuthSession).mockReturnValue({ data: null, status: "unauthenticated" });
+
+    render(<AppAuthBoundary>Session</AppAuthBoundary>);
+
+    expect(screen.getByRole("link", { name: "Sign in" })).toHaveAttribute("href", "/login");
+    expect(screen.queryByText("Session")).not.toBeInTheDocument();
+  });
+
+  it("fails closed when authentication is unavailable", () => {
+    vi.mocked(useAuthSession).mockReturnValue({ data: null, status: "unavailable" });
+
+    render(<AppAuthBoundary>Session</AppAuthBoundary>);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Authentication is temporarily unavailable."
+    );
+    expect(screen.queryByRole("link", { name: "Sign in" })).not.toBeInTheDocument();
+  });
+
+  it("fails closed for an unhandled authentication state", () => {
+    vi.mocked(useAuthSession).mockReturnValue({
+      data: null,
+      status: "future-state",
+    } as never);
+
+    expect(() => render(<AppAuthBoundary>Session</AppAuthBoundary>)).toThrow(
+      "Unhandled authentication state"
+    );
+  });
+});

--- a/packages/web/src/components/app-auth-boundary.tsx
+++ b/packages/web/src/components/app-auth-boundary.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import Link from "next/link";
+import { useAuthSession } from "@/lib/auth-session";
+import { APP_NAME } from "@/lib/site-config";
+import { Button } from "@/components/ui/button";
+import { ErrorBanner } from "@/components/ui/error-banner";
+
+export function AppAuthBoundary({ children }: { children: React.ReactNode }) {
+  const { status } = useAuthSession();
+
+  if (status === "loading") {
+    return (
+      <div
+        role="status"
+        aria-label="Checking authentication"
+        className="min-h-screen flex items-center justify-center"
+      >
+        <div className="animate-spin rounded-full h-6 w-6 border-2 border-current border-t-transparent text-foreground" />
+      </div>
+    );
+  }
+
+  if (status === "unavailable") {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center gap-8 px-6">
+        <h1 className="text-4xl font-bold text-foreground">{APP_NAME}</h1>
+        <ErrorBanner role="alert" className="max-w-md px-6 py-4 text-center">
+          Authentication is temporarily unavailable.
+        </ErrorBanner>
+      </div>
+    );
+  }
+
+  if (status === "unauthenticated") {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center gap-8">
+        <h1 className="text-4xl font-bold text-foreground">{APP_NAME}</h1>
+        <p className="text-muted-foreground max-w-md text-center">
+          Background coding agent for your team. Ship faster with AI-powered code changes.
+        </p>
+        <Button asChild className="px-6 py-3">
+          <Link href="/login">Sign in</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  if (status === "authenticated") {
+    return children;
+  }
+
+  status satisfies never;
+  throw new Error("Unhandled authentication state");
+}

--- a/packages/web/src/components/sidebar-layout.test.tsx
+++ b/packages/web/src/components/sidebar-layout.test.tsx
@@ -185,3 +185,46 @@ describe("mobile sidebar drag", () => {
     expect(mocks.sidebar.open).not.toHaveBeenCalled();
   });
 });
+
+describe("unauthenticated app shell", () => {
+  it("shows one generic sign-in link without provider-specific actions", () => {
+    vi.mocked(useAuthSession).mockReturnValue({
+      data: null,
+      status: "unauthenticated",
+    });
+    vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as never);
+
+    render(<SidebarLayout>Session</SidebarLayout>);
+
+    expect(screen.getByRole("link", { name: "Sign in" })).toHaveAttribute("href", "/login");
+    expect(screen.queryByText("Sign in with GitHub")).not.toBeInTheDocument();
+    expect(screen.queryByText("Sign in with Google")).not.toBeInTheDocument();
+  });
+
+  it("shows an unavailable state instead of treating a session outage as logout", () => {
+    vi.mocked(useAuthSession).mockReturnValue({
+      data: null,
+      status: "unavailable",
+    });
+    vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as never);
+
+    render(<SidebarLayout>Session</SidebarLayout>);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Authentication is temporarily unavailable."
+    );
+    expect(screen.queryByRole("link", { name: "Sign in" })).not.toBeInTheDocument();
+  });
+
+  it("fails closed for an unhandled authentication state", () => {
+    vi.mocked(useAuthSession).mockReturnValue({
+      data: null,
+      status: "future-state",
+    } as never);
+    vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as never);
+
+    expect(() => render(<SidebarLayout>Session</SidebarLayout>)).toThrow(
+      "Unhandled authentication state"
+    );
+  });
+});

--- a/packages/web/src/components/sidebar-layout.test.tsx
+++ b/packages/web/src/components/sidebar-layout.test.tsx
@@ -5,7 +5,6 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CollapsedSidebarControls, SidebarLayout } from "./sidebar-layout";
-import { useAuthSession } from "@/lib/auth-session";
 import { useRouter } from "next/navigation";
 
 expect.extend(matchers);
@@ -18,11 +17,6 @@ const mocks = vi.hoisted(() => ({
     open: vi.fn(),
     close: vi.fn(),
   },
-}));
-
-vi.mock("@/lib/auth-session", () => ({
-  useAuthSession: vi.fn(),
-  signIn: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -47,10 +41,6 @@ afterEach(() => {
 
 describe("CollapsedSidebarControls", () => {
   it("renders the sidebar, search, and new session actions inline", () => {
-    vi.mocked(useAuthSession).mockReturnValue({
-      data: { user: { id: "user-1", name: "Test User" } },
-      status: "authenticated",
-    });
     const push = vi.fn();
     vi.mocked(useRouter).mockReturnValue({ push } as never);
 
@@ -79,10 +69,6 @@ describe("mobile sidebar drag", () => {
   it("opens after swiping right from the inset activation zone", () => {
     mocks.isMobile = true;
     mocks.sidebar.isOpen = false;
-    vi.mocked(useAuthSession).mockReturnValue({
-      data: { user: { id: "user-1", name: "Test User" } },
-      status: "authenticated",
-    });
     vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as never);
 
     render(<SidebarLayout>Session</SidebarLayout>);
@@ -117,10 +103,6 @@ describe("mobile sidebar drag", () => {
   it("does not open when the swipe is too short", () => {
     mocks.isMobile = true;
     mocks.sidebar.isOpen = false;
-    vi.mocked(useAuthSession).mockReturnValue({
-      data: { user: { id: "user-1", name: "Test User" } },
-      status: "authenticated",
-    });
     vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as never);
 
     render(<SidebarLayout>Session</SidebarLayout>);
@@ -149,10 +131,6 @@ describe("mobile sidebar drag", () => {
   it("delivers taps in the activation zone to underlying content", () => {
     mocks.isMobile = true;
     mocks.sidebar.isOpen = false;
-    vi.mocked(useAuthSession).mockReturnValue({
-      data: { user: { id: "user-1", name: "Test User" } },
-      status: "authenticated",
-    });
     vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as never);
     const onPointerDown = vi.fn();
     const onClick = vi.fn();
@@ -183,48 +161,5 @@ describe("mobile sidebar drag", () => {
     expect(onPointerDown).toHaveBeenCalledOnce();
     expect(onClick).toHaveBeenCalledOnce();
     expect(mocks.sidebar.open).not.toHaveBeenCalled();
-  });
-});
-
-describe("unauthenticated app shell", () => {
-  it("shows one generic sign-in link without provider-specific actions", () => {
-    vi.mocked(useAuthSession).mockReturnValue({
-      data: null,
-      status: "unauthenticated",
-    });
-    vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as never);
-
-    render(<SidebarLayout>Session</SidebarLayout>);
-
-    expect(screen.getByRole("link", { name: "Sign in" })).toHaveAttribute("href", "/login");
-    expect(screen.queryByText("Sign in with GitHub")).not.toBeInTheDocument();
-    expect(screen.queryByText("Sign in with Google")).not.toBeInTheDocument();
-  });
-
-  it("shows an unavailable state instead of treating a session outage as logout", () => {
-    vi.mocked(useAuthSession).mockReturnValue({
-      data: null,
-      status: "unavailable",
-    });
-    vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as never);
-
-    render(<SidebarLayout>Session</SidebarLayout>);
-
-    expect(screen.getByRole("alert")).toHaveTextContent(
-      "Authentication is temporarily unavailable."
-    );
-    expect(screen.queryByRole("link", { name: "Sign in" })).not.toBeInTheDocument();
-  });
-
-  it("fails closed for an unhandled authentication state", () => {
-    vi.mocked(useAuthSession).mockReturnValue({
-      data: null,
-      status: "future-state",
-    } as never);
-    vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as never);
-
-    expect(() => render(<SidebarLayout>Session</SidebarLayout>)).toThrow(
-      "Unhandled authentication state"
-    );
   });
 });

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
-import Link from "next/link";
-import { useAuthSession } from "@/lib/auth-session";
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
 import { NewSessionButton, SearchSessionsButton, SessionSidebar } from "./session-sidebar";
@@ -12,9 +10,7 @@ import { useIsMobile } from "@/hooks/use-media-query";
 import { useGlobalShortcuts } from "@/hooks/use-global-shortcuts";
 import { COMMAND_MENU_SESSIONS_KEY, type SessionListResponse } from "@/lib/session-list";
 import { Button } from "@/components/ui/button";
-import { ErrorBanner } from "@/components/ui/error-banner";
 import { SidebarIcon } from "@/components/ui/icons";
-import { APP_NAME } from "@/lib/site-config";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import { useMobileSidebarPull } from "@/hooks/use-mobile-sidebar-pull";
 
@@ -77,7 +73,6 @@ export function CollapsedSidebarControls() {
 }
 
 export function SidebarLayout({ children }: SidebarLayoutProps) {
-  const { data: session, status } = useAuthSession();
   const router = useRouter();
   const sidebar = useSidebar();
   const isMobile = useIsMobile();
@@ -95,9 +90,7 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
   });
 
   const { data: sessionsResponse } = useSWR<SessionListResponse>(
-    status === "authenticated" && Boolean(session) && isCommandMenuOpen
-      ? COMMAND_MENU_SESSIONS_KEY
-      : null
+    isCommandMenuOpen ? COMMAND_MENU_SESSIONS_KEY : null
   );
 
   const handleNewSession = useCallback(() => {
@@ -131,50 +124,11 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
   );
 
   useGlobalShortcuts({
-    enabled: status === "authenticated" && Boolean(session),
+    enabled: true,
     onOpenCommandMenu: handleOpenCommandMenu,
     onNewSession: handleNewSession,
     onToggleSidebar: sidebar.toggle,
   });
-
-  // Show loading state
-  if (status === "loading") {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-6 w-6 border-2 border-current border-t-transparent text-foreground" />
-      </div>
-    );
-  }
-
-  if (status === "unavailable") {
-    return (
-      <div className="min-h-screen flex flex-col items-center justify-center gap-8 px-6">
-        <h1 className="text-4xl font-bold text-foreground">{APP_NAME}</h1>
-        <ErrorBanner role="alert" className="max-w-md px-6 py-4 text-center">
-          Authentication is temporarily unavailable.
-        </ErrorBanner>
-      </div>
-    );
-  }
-
-  if (status === "unauthenticated") {
-    return (
-      <div className="min-h-screen flex flex-col items-center justify-center gap-8">
-        <h1 className="text-4xl font-bold text-foreground">{APP_NAME}</h1>
-        <p className="text-muted-foreground max-w-md text-center">
-          Background coding agent for your team. Ship faster with AI-powered code changes.
-        </p>
-        <Button asChild className="px-6 py-3">
-          <Link href="/login">Sign in</Link>
-        </Button>
-      </div>
-    );
-  }
-
-  if (status !== "authenticated") {
-    status satisfies never;
-    throw new Error("Unhandled authentication state");
-  }
 
   return (
     <SidebarContext.Provider value={sidebar}>

--- a/packages/web/src/components/sidebar-layout.tsx
+++ b/packages/web/src/components/sidebar-layout.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
-import { signIn, useAuthSession } from "@/lib/auth-session";
+import Link from "next/link";
+import { useAuthSession } from "@/lib/auth-session";
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
 import { NewSessionButton, SearchSessionsButton, SessionSidebar } from "./session-sidebar";
@@ -11,8 +12,9 @@ import { useIsMobile } from "@/hooks/use-media-query";
 import { useGlobalShortcuts } from "@/hooks/use-global-shortcuts";
 import { COMMAND_MENU_SESSIONS_KEY, type SessionListResponse } from "@/lib/session-list";
 import { Button } from "@/components/ui/button";
-import { GitHubIcon, GoogleIcon, SidebarIcon } from "@/components/ui/icons";
-import { APP_NAME, GOOGLE_LOGIN_ENABLED } from "@/lib/site-config";
+import { ErrorBanner } from "@/components/ui/error-banner";
+import { SidebarIcon } from "@/components/ui/icons";
+import { APP_NAME } from "@/lib/site-config";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import { useMobileSidebarPull } from "@/hooks/use-mobile-sidebar-pull";
 
@@ -144,28 +146,34 @@ export function SidebarLayout({ children }: SidebarLayoutProps) {
     );
   }
 
-  // Show sign-in page if not authenticated
-  if (!session) {
+  if (status === "unavailable") {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center gap-8 px-6">
+        <h1 className="text-4xl font-bold text-foreground">{APP_NAME}</h1>
+        <ErrorBanner role="alert" className="max-w-md px-6 py-4 text-center">
+          Authentication is temporarily unavailable.
+        </ErrorBanner>
+      </div>
+    );
+  }
+
+  if (status === "unauthenticated") {
     return (
       <div className="min-h-screen flex flex-col items-center justify-center gap-8">
         <h1 className="text-4xl font-bold text-foreground">{APP_NAME}</h1>
         <p className="text-muted-foreground max-w-md text-center">
           Background coding agent for your team. Ship faster with AI-powered code changes.
         </p>
-        <div className="flex flex-col items-stretch gap-3">
-          <Button onClick={() => signIn("github")} className="gap-2 px-6 py-3">
-            <GitHubIcon className="w-5 h-5" />
-            Sign in with GitHub
-          </Button>
-          {GOOGLE_LOGIN_ENABLED && (
-            <Button onClick={() => signIn("google")} variant="outline" className="gap-2 px-6 py-3">
-              <GoogleIcon className="w-5 h-5" />
-              Sign in with Google
-            </Button>
-          )}
-        </div>
+        <Button asChild className="px-6 py-3">
+          <Link href="/login">Sign in</Link>
+        </Button>
       </div>
     );
+  }
+
+  if (status !== "authenticated") {
+    status satisfies never;
+    throw new Error("Unhandled authentication state");
   }
 
   return (

--- a/packages/web/src/components/sign-in-provider-buttons.test.tsx
+++ b/packages/web/src/components/sign-in-provider-buttons.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+/// <reference types="@testing-library/jest-dom" />
+
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as matchers from "@testing-library/jest-dom/matchers";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/auth-session", () => ({
+  signIn: vi.fn(),
+}));
+
+import { SignInProviderButtons } from "./sign-in-provider-buttons";
+import { signIn } from "@/lib/auth-session";
+
+expect.extend(matchers);
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("SignInProviderButtons", () => {
+  it("renders only the configured providers", () => {
+    render(<SignInProviderButtons providers={["google"]} />);
+
+    expect(screen.getByRole("button", { name: "Sign in with Google" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Sign in with GitHub" })).not.toBeInTheDocument();
+  });
+
+  it("invokes only the selected provider and disables every action while pending", async () => {
+    let completeSignIn!: () => void;
+    vi.mocked(signIn).mockReturnValue(
+      new Promise<void>((resolve) => {
+        completeSignIn = resolve;
+      })
+    );
+    const user = userEvent.setup();
+    render(<SignInProviderButtons providers={["github", "google"]} />);
+
+    await user.click(screen.getByRole("button", { name: "Sign in with GitHub" }));
+
+    expect(signIn).toHaveBeenCalledOnce();
+    expect(signIn).toHaveBeenCalledWith("github");
+    expect(screen.getByRole("button", { name: "Sign in with GitHub" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Sign in with Google" })).toBeDisabled();
+    expect(screen.getByRole("status")).toHaveTextContent("Starting sign in");
+
+    await act(async () => {
+      completeSignIn();
+    });
+
+    expect(screen.getByRole("button", { name: "Sign in with GitHub" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Sign in with Google" })).toBeDisabled();
+    expect(screen.getByRole("status")).toHaveTextContent("Starting sign in");
+  });
+
+  it("shows a sanitized retryable error when initiation fails", async () => {
+    vi.mocked(signIn).mockRejectedValue(new Error("sensitive upstream detail"));
+    const user = userEvent.setup();
+    render(<SignInProviderButtons providers={["github"]} />);
+
+    await user.click(screen.getByRole("button", { name: "Sign in with GitHub" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Could not start sign in. Please try again."
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Sign in with GitHub" })).toBeEnabled();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Sign in with GitHub" }));
+    expect(signIn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/web/src/components/sign-in-provider-buttons.tsx
+++ b/packages/web/src/components/sign-in-provider-buttons.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import type { SignInProvider } from "@open-inspect/shared";
+import { useState } from "react";
+import { signIn } from "@/lib/auth-session";
+import { Button } from "@/components/ui/button";
+import { ErrorBanner } from "@/components/ui/error-banner";
+import { GitHubIcon, GoogleIcon } from "@/components/ui/icons";
+
+const PROVIDER_PRESENTATION = {
+  github: {
+    label: "GitHub",
+    icon: GitHubIcon,
+    variant: "primary",
+  },
+  google: {
+    label: "Google",
+    icon: GoogleIcon,
+    variant: "outline",
+  },
+} as const satisfies Record<
+  SignInProvider,
+  {
+    label: string;
+    icon: typeof GitHubIcon;
+    variant: "primary" | "outline";
+  }
+>;
+
+export function SignInProviderButtons({ providers }: { providers: readonly SignInProvider[] }) {
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSignIn(provider: SignInProvider) {
+    setError(null);
+    setPending(true);
+    try {
+      await signIn(provider);
+    } catch {
+      setError("Could not start sign in. Please try again.");
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-stretch gap-3" aria-busy={pending}>
+      {error && <ErrorBanner role="alert">{error}</ErrorBanner>}
+      {pending && (
+        <p role="status" className="sr-only">
+          Starting sign in
+        </p>
+      )}
+      {providers.map((provider) => {
+        const presentation = PROVIDER_PRESENTATION[provider];
+        const Icon = presentation.icon;
+        return (
+          <Button
+            key={provider}
+            type="button"
+            variant={presentation.variant}
+            className="gap-2 px-6 py-3"
+            disabled={pending}
+            onClick={() => void handleSignIn(provider)}
+          >
+            <Icon className="w-5 h-5" />
+            Sign in with {presentation.label}
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/web/src/lib/auth-session.test.tsx
+++ b/packages/web/src/lib/auth-session.test.tsx
@@ -99,7 +99,7 @@ describe("useAuthSession", () => {
     });
   });
 
-  it("fails closed without crashing when the session lookup fails", () => {
+  it("distinguishes a session service failure from an unauthenticated session", () => {
     mocks.useSWR.mockReturnValue({
       data: undefined,
       error: new Error("control plane unavailable"),
@@ -110,7 +110,7 @@ describe("useAuthSession", () => {
 
     expect(result.current).toEqual({
       data: null,
-      status: "unauthenticated",
+      status: "unavailable",
     });
   });
 

--- a/packages/web/src/lib/auth-session.tsx
+++ b/packages/web/src/lib/auth-session.tsx
@@ -24,7 +24,7 @@ export type AuthSessionState =
     }
   | {
       data: null;
-      status: "loading" | "unauthenticated";
+      status: "loading" | "unauthenticated" | "unavailable";
     };
 
 export async function signIn(provider: SignInProvider): Promise<void> {
@@ -81,7 +81,7 @@ export function useAuthSession(): AuthSessionState {
 
   if (data) return { data, status: "authenticated" };
   if (error) {
-    return { data: null, status: "unauthenticated" };
+    return { data: null, status: "unavailable" };
   }
   if (isLoading || data === undefined) {
     return { data: null, status: "loading" };

--- a/packages/web/src/lib/authentication-unavailable-error.ts
+++ b/packages/web/src/lib/authentication-unavailable-error.ts
@@ -1,0 +1,6 @@
+export class AuthenticationUnavailableError extends Error {
+  constructor(cause?: unknown) {
+    super("Authentication is unavailable", { cause });
+    this.name = "AuthenticationUnavailableError";
+  }
+}

--- a/packages/web/src/lib/client-auth-boundary-eslint.test.ts
+++ b/packages/web/src/lib/client-auth-boundary-eslint.test.ts
@@ -17,9 +17,7 @@ async function boundaryMessages(source: string, filePath: string) {
   const [result] = await eslint.lintText(source, { filePath });
   return result.messages.filter(
     (message) =>
-      message.ruleId === "no-restricted-imports" ||
-      message.ruleId === "no-restricted-globals" ||
-      message.ruleId === "no-restricted-syntax"
+      message.ruleId === "no-restricted-imports" || message.ruleId === "no-restricted-globals"
   );
 }
 
@@ -55,15 +53,6 @@ describe("client authentication boundaries", () => {
   it("keeps the app-owned auth seam framework-independent", async () => {
     await expect(
       boundaryMessages('import { useSession } from "next-auth/react";', authSessionPath)
-    ).resolves.toHaveLength(1);
-  });
-
-  it("rejects client component imports of the server-only provider query", async () => {
-    await expect(
-      boundaryMessages(
-        'import { getEnabledSignInProviders } from "@/lib/sign-in-providers";',
-        componentPath
-      )
     ).resolves.toHaveLength(1);
   });
 

--- a/packages/web/src/lib/client-auth-boundary-eslint.test.ts
+++ b/packages/web/src/lib/client-auth-boundary-eslint.test.ts
@@ -17,7 +17,9 @@ async function boundaryMessages(source: string, filePath: string) {
   const [result] = await eslint.lintText(source, { filePath });
   return result.messages.filter(
     (message) =>
-      message.ruleId === "no-restricted-imports" || message.ruleId === "no-restricted-globals"
+      message.ruleId === "no-restricted-imports" ||
+      message.ruleId === "no-restricted-globals" ||
+      message.ruleId === "no-restricted-syntax"
   );
 }
 
@@ -53,6 +55,15 @@ describe("client authentication boundaries", () => {
   it("keeps the app-owned auth seam framework-independent", async () => {
     await expect(
       boundaryMessages('import { useSession } from "next-auth/react";', authSessionPath)
+    ).resolves.toHaveLength(1);
+  });
+
+  it("rejects client component imports of the server-only provider query", async () => {
+    await expect(
+      boundaryMessages(
+        'import { getEnabledSignInProviders } from "@/lib/sign-in-providers";',
+        componentPath
+      )
     ).resolves.toHaveLength(1);
   });
 

--- a/packages/web/src/lib/request-context.ts
+++ b/packages/web/src/lib/request-context.ts
@@ -1,8 +1,5 @@
 import { headers } from "next/headers";
-import { unstable_rethrow } from "next/navigation";
 import {
-  createRequestId,
-  createTraceId,
   INTERNAL_REQUEST_ID_HEADER,
   resolveRequestId,
   resolveTraceId,
@@ -11,17 +8,9 @@ import {
 import type { RequestCorrelation } from "./request-correlation";
 
 export async function getRequestCorrelation(): Promise<RequestCorrelation> {
-  try {
-    const requestHeaders = await headers();
-    return {
-      traceId: resolveTraceId(requestHeaders.get(TRACE_ID_HEADER)),
-      requestId: resolveRequestId(requestHeaders.get(INTERNAL_REQUEST_ID_HEADER)),
-    };
-  } catch (error) {
-    unstable_rethrow(error);
-    return {
-      traceId: createTraceId(),
-      requestId: createRequestId(),
-    };
-  }
+  const requestHeaders = await headers();
+  return {
+    traceId: resolveTraceId(requestHeaders.get(TRACE_ID_HEADER)),
+    requestId: resolveRequestId(requestHeaders.get(INTERNAL_REQUEST_ID_HEADER)),
+  };
 }

--- a/packages/web/src/lib/server-auth-session.test.ts
+++ b/packages/web/src/lib/server-auth-session.test.ts
@@ -14,6 +14,7 @@ vi.mock("./browser-auth-proxy", () => ({
 }));
 
 import { getServerAuthSession, type ServerAuthSession } from "./server-auth-session";
+import { AuthenticationUnavailableError } from "./authentication-unavailable-error";
 
 describe("getServerAuthSession", () => {
   beforeEach(() => {
@@ -63,6 +64,14 @@ describe("getServerAuthSession", () => {
     expect(mocks.dispatchBrowserAuthRequest).not.toHaveBeenCalled();
   });
 
+  it("propagates cookie access failures without wrapping or dispatching", async () => {
+    const frameworkSignal = new Error("NEXT_DYNAMIC_API_SIGNAL");
+    mocks.cookies.mockRejectedValue(frameworkSignal);
+
+    await expect(getServerAuthSession()).rejects.toBe(frameworkSignal);
+    expect(mocks.dispatchBrowserAuthRequest).not.toHaveBeenCalled();
+  });
+
   it("returns null when Better Auth rejects the browser session", async () => {
     mocks.dispatchBrowserAuthRequest.mockResolvedValue(
       Response.json({ error: "Unauthorized" }, { status: 401 })
@@ -77,14 +86,12 @@ describe("getServerAuthSession", () => {
     await expect(getServerAuthSession()).resolves.toBeNull();
   });
 
-  it("throws when the auth service fails instead of treating failure as logout", async () => {
+  it("reports auth-service failure as explicit unavailability instead of logout", async () => {
     mocks.dispatchBrowserAuthRequest.mockResolvedValue(
       Response.json({ error: "Unavailable" }, { status: 503 })
     );
 
-    await expect(getServerAuthSession()).rejects.toThrow(
-      "Browser authentication failed with status 503"
-    );
+    await expect(getServerAuthSession()).rejects.toBeInstanceOf(AuthenticationUnavailableError);
   });
 
   it("rejects malformed successful session responses", async () => {
@@ -107,7 +114,9 @@ describe("getServerAuthSession", () => {
       })
     );
 
-    await expect(getServerAuthSession()).rejects.toThrow(
+    const error = await getServerAuthSession().catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(AuthenticationUnavailableError);
+    expect(String((error as AuthenticationUnavailableError).cause)).toContain(
       "Browser session user id is not canonical"
     );
   });

--- a/packages/web/src/lib/server-auth-session.ts
+++ b/packages/web/src/lib/server-auth-session.ts
@@ -4,6 +4,7 @@ import {
   browserAuthSessionResponseSchema,
   type BrowserAuthSessionUser,
 } from "./browser-auth-session-contract";
+import { AuthenticationUnavailableError } from "./authentication-unavailable-error";
 import { serializeBrowserSessionCookies } from "./browser-session-cookie";
 
 export type ServerAuthUser = BrowserAuthSessionUser;
@@ -29,19 +30,24 @@ export async function getServerAuthSession(): Promise<ServerAuthSession | null> 
   const cookieStore = await cookies();
   const cookieHeader = serializeBrowserSessionCookies(cookieStore.getAll());
   if (!cookieHeader) return null;
-  const response = await dispatchBrowserAuthRequest({
-    method: "GET",
-    pathname: "/api/auth/get-session",
-    headers: { Cookie: cookieHeader },
-  });
 
-  if (response.status === 401) return null;
-  if (!response.ok) {
-    throw new Error(`Browser authentication failed with status ${response.status}`);
+  try {
+    const response = await dispatchBrowserAuthRequest({
+      method: "GET",
+      pathname: "/api/auth/get-session",
+      headers: { Cookie: cookieHeader },
+    });
+
+    if (response.status === 401) return null;
+    if (!response.ok) {
+      throw new Error(`Browser authentication failed with status ${response.status}`);
+    }
+
+    const payload: unknown = await response.json();
+    if (payload === null) return null;
+    const session = browserAuthSessionResponseSchema.parse(payload);
+    return { user: session.user };
+  } catch (cause) {
+    throw new AuthenticationUnavailableError(cause);
   }
-
-  const payload: unknown = await response.json();
-  if (payload === null) return null;
-  const session = browserAuthSessionResponseSchema.parse(payload);
-  return { user: session.user };
 }

--- a/packages/web/src/lib/sign-in-providers.test.ts
+++ b/packages/web/src/lib/sign-in-providers.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  dispatchWebServiceRequest: vi.fn(),
+  getRequestCorrelation: vi.fn(),
+  logError: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("./control-plane-service", () => ({
+  dispatchWebServiceRequest: mocks.dispatchWebServiceRequest,
+}));
+
+vi.mock("./request-context", () => ({
+  getRequestCorrelation: mocks.getRequestCorrelation,
+}));
+
+vi.mock("./logger", () => ({
+  createLogger: () => ({ error: mocks.logError }),
+}));
+
+import { getEnabledSignInProviders } from "./sign-in-providers";
+
+describe("getEnabledSignInProviders", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.getRequestCorrelation.mockResolvedValue({
+      traceId: "trace-1",
+      requestId: "request-1",
+    });
+  });
+
+  it("returns the validated provider set from an exact server-only request", async () => {
+    mocks.dispatchWebServiceRequest.mockResolvedValue(
+      Response.json({ providers: ["github", "google"] })
+    );
+
+    await expect(getEnabledSignInProviders()).resolves.toEqual(["github", "google"]);
+    expect(mocks.dispatchWebServiceRequest).toHaveBeenCalledWith({
+      method: "GET",
+      path: "/internal/auth/sign-in-providers",
+      traceId: "trace-1",
+      correlationFields: {
+        trace_id: "trace-1",
+        request_id: "request-1",
+      },
+      transportOptions: {
+        redirect: "manual",
+        cache: "no-store",
+      },
+    });
+  });
+
+  it.each([
+    Response.json({ providers: [] }),
+    Response.json({ providers: ["github", "github"] }),
+    Response.json({ providers: ["saml"] }),
+    Response.json({ providers: "github" }),
+    Response.json({ error: "sensitive upstream detail" }, { status: 503 }),
+  ])("fails closed on an invalid or unavailable provider response", async (response) => {
+    mocks.dispatchWebServiceRequest.mockResolvedValue(response);
+
+    await expect(getEnabledSignInProviders()).rejects.toThrow("Sign-in providers are unavailable");
+    expect(mocks.logError).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/web/src/lib/sign-in-providers.test.ts
+++ b/packages/web/src/lib/sign-in-providers.test.ts
@@ -20,6 +20,7 @@ vi.mock("./logger", () => ({
   createLogger: () => ({ error: mocks.logError }),
 }));
 
+import { AuthenticationUnavailableError } from "./authentication-unavailable-error";
 import { getEnabledSignInProviders } from "./sign-in-providers";
 
 describe("getEnabledSignInProviders", () => {
@@ -52,6 +53,15 @@ describe("getEnabledSignInProviders", () => {
     });
   });
 
+  it("propagates request-context failures without logging, wrapping, or dispatching", async () => {
+    const frameworkSignal = new Error("NEXT_REQUEST_CONTEXT_SIGNAL");
+    mocks.getRequestCorrelation.mockRejectedValue(frameworkSignal);
+
+    await expect(getEnabledSignInProviders()).rejects.toBe(frameworkSignal);
+    expect(mocks.dispatchWebServiceRequest).not.toHaveBeenCalled();
+    expect(mocks.logError).not.toHaveBeenCalled();
+  });
+
   it.each([
     Response.json({ providers: [] }),
     Response.json({ providers: ["github", "github"] }),
@@ -61,7 +71,9 @@ describe("getEnabledSignInProviders", () => {
   ])("fails closed on an invalid or unavailable provider response", async (response) => {
     mocks.dispatchWebServiceRequest.mockResolvedValue(response);
 
-    await expect(getEnabledSignInProviders()).rejects.toThrow("Sign-in providers are unavailable");
+    await expect(getEnabledSignInProviders()).rejects.toBeInstanceOf(
+      AuthenticationUnavailableError
+    );
     expect(mocks.logError).toHaveBeenCalledOnce();
   });
 });

--- a/packages/web/src/lib/sign-in-providers.ts
+++ b/packages/web/src/lib/sign-in-providers.ts
@@ -1,0 +1,42 @@
+import "server-only";
+
+import { parseEnabledSignInProviders, type SignInProvider } from "@open-inspect/shared";
+import { dispatchWebServiceRequest } from "./control-plane-service";
+import { createLogger } from "./logger";
+import { getCorrelationLogFields } from "./request-correlation";
+import { getRequestCorrelation } from "./request-context";
+
+const log = createLogger("sign-in-providers");
+const SIGN_IN_PROVIDERS_PATH = "/internal/auth/sign-in-providers";
+
+export async function getEnabledSignInProviders(): Promise<readonly SignInProvider[]> {
+  const correlation = await getRequestCorrelation();
+  const correlationFields = getCorrelationLogFields(correlation);
+
+  try {
+    const response = await dispatchWebServiceRequest({
+      method: "GET",
+      path: SIGN_IN_PROVIDERS_PATH,
+      traceId: correlation.traceId,
+      correlationFields,
+      transportOptions: {
+        redirect: "manual",
+        cache: "no-store",
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Provider query failed with status ${response.status}`);
+    }
+
+    const payload: unknown = await response.json();
+    return parseEnabledSignInProviders(payload).providers;
+  } catch (cause) {
+    log.error("auth.providers.fetch_failed", {
+      ...correlationFields,
+      event: "auth.providers.fetch_failed",
+      http_path: SIGN_IN_PROVIDERS_PATH,
+      error: cause instanceof Error ? cause : new Error(String(cause)),
+    });
+    throw new Error("Sign-in providers are unavailable", { cause });
+  }
+}

--- a/packages/web/src/lib/sign-in-providers.ts
+++ b/packages/web/src/lib/sign-in-providers.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { parseEnabledSignInProviders, type SignInProvider } from "@open-inspect/shared";
+import { AuthenticationUnavailableError } from "./authentication-unavailable-error";
 import { dispatchWebServiceRequest } from "./control-plane-service";
 import { createLogger } from "./logger";
 import { getCorrelationLogFields } from "./request-correlation";
@@ -37,6 +38,6 @@ export async function getEnabledSignInProviders(): Promise<readonly SignInProvid
       http_path: SIGN_IN_PROVIDERS_PATH,
       error: cause instanceof Error ? cause : new Error(String(cause)),
     });
-    throw new Error("Sign-in providers are unavailable", { cause });
+    throw new AuthenticationUnavailableError(cause);
   }
 }

--- a/terraform/environments/production/checks.tf
+++ b/terraform/environments/production/checks.tf
@@ -39,8 +39,8 @@ resource "terraform_data" "access_control_gate" {
 resource "terraform_data" "sign_in_provider_gate" {
   lifecycle {
     precondition {
-      condition     = local.github_oauth_enabled
-      error_message = "GitHub OAuth must remain configured until the web runtime consumes the control-plane provider authority."
+      condition     = local.github_oauth_enabled || local.google_enabled
+      error_message = "At least one complete OAuth sign-in provider pair must be configured."
     }
 
     precondition {

--- a/terraform/environments/production/tests/auth_provider_configuration.tftest.hcl
+++ b/terraform/environments/production/tests/auth_provider_configuration.tftest.hcl
@@ -73,7 +73,20 @@ run "google_only" {
     allowed_emails       = "person@example.com"
   }
 
-  expect_failures = [terraform_data.sign_in_provider_gate]
+  assert {
+    condition     = !local.github_oauth_enabled && local.google_enabled
+    error_message = "Google-only credentials must enable only Google."
+  }
+
+  assert {
+    condition = (
+      !contains(module.control_plane_worker.plain_text_binding_names, "GITHUB_CLIENT_ID") &&
+      contains(module.control_plane_worker.plain_text_binding_names, "GOOGLE_CLIENT_ID") &&
+      !contains(module.control_plane_worker.secret_binding_names, "GITHUB_CLIENT_SECRET") &&
+      contains(module.control_plane_worker.secret_binding_names, "GOOGLE_CLIENT_SECRET")
+    )
+    error_message = "The control plane must bind only the enabled Google OAuth credential pair."
+  }
 }
 
 run "github_and_google" {


### PR DESCRIPTION
## Summary
- add a force-dynamic `/login` Server Component in the existing React application
- resolve enabled providers server-to-server through the signed control-plane dispatcher
- keep provider discovery out of browser traffic and static/client bundles
- render focused client buttons with accessible pending, retry, and sanitized failure behavior
- redirect authenticated users and distinguish auth-service unavailability from ordinary signed-out state
- replace provider-specific app-shell actions with one generic `/login` link

## Boundaries
The provider query is marked with the `server-only` poison pill and guarded against client-component imports. No Next.js API route exposes the provider query. Successful OAuth initiation remains pending until navigation; framework control-flow errors propagate through the page error boundary.

## Validation
- full web tests, typecheck, lint, and production build
- build output confirms `ƒ /login`
- internal provider path appears in server chunks only, never `.next/static`
- provider-only, combined, pending, retry, unavailable, redirect, and framework-signal regressions

## Stack
- Base: #1163
- **This PR**
- Next: `remove-web-provider-flags`
- Then: `document-provider-configuration`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authentication boundary that gates app rendering with distinct loading, unauthenticated, and temporary-unavailable UI states.
  * Added sign-in provider buttons with “starting sign-in” progress and sanitized retryable error messaging.
  * Added support for “unavailable” auth state and improved provider availability handling.

* **Bug Fixes**
  * Session/provider failures are now classified as temporary unavailability to avoid exposing sensitive errors and to show a generic “Sign-in is temporarily unavailable” alert with a retry path.

* **Tests**
  * Updated and added coverage for the new auth boundary, sign-in provider behavior, and the revised unavailable/error flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->