### PR TITLE
Import bot process foundations from owner modules

### DIFF
--- a/packages/github-bot/src/github-auth.ts
+++ b/packages/github-bot/src/github-auth.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_APP_NAME } from "@open-inspect/shared";
+import { DEFAULT_APP_NAME } from "@open-inspect/shared/app-name";
 import { z } from "zod";
 
 const collaboratorPermissionResponseSchema = z.object({

--- a/packages/github-bot/src/handlers.ts
+++ b/packages/github-bot/src/handlers.ts
@@ -1,9 +1,9 @@
 import {
   createSessionResponseSchema,
   escapeRegExp,
-  resolveAppName,
   sendPromptResponseSchema,
 } from "@open-inspect/shared";
+import { resolveAppName } from "@open-inspect/shared/app-name";
 import { signedControlPlaneFetch } from "./internal-auth";
 import type {
   Env,

--- a/packages/github-bot/src/index.ts
+++ b/packages/github-bot/src/index.ts
@@ -29,7 +29,7 @@ import {
   isReviewRequestedForBot,
   type HandlerResult,
 } from "./handlers";
-import { createKvCacheStore } from "@open-inspect/shared";
+import { createKvCacheStore } from "@open-inspect/shared/cache-store";
 
 const app = new Hono<{ Bindings: Env }>();
 const DELIVERY_DEDUPE_TTL_MS = 7 * 24 * 60 * 60 * 1_000;

--- a/packages/github-bot/src/logger.ts
+++ b/packages/github-bot/src/logger.ts
@@ -5,11 +5,11 @@
  * pre-binding the "github-bot" service name so callers don't repeat it.
  */
 
-import { createLogger as _createLogger, type LogLevel } from "@open-inspect/shared";
-import type { Logger } from "@open-inspect/shared";
-export type { Logger } from "@open-inspect/shared";
-export type { LogLevel } from "@open-inspect/shared";
-export { parseLogLevel } from "@open-inspect/shared";
+import { createLogger as _createLogger, type LogLevel } from "@open-inspect/shared/logger";
+import type { Logger } from "@open-inspect/shared/logger";
+export type { Logger } from "@open-inspect/shared/logger";
+export type { LogLevel } from "@open-inspect/shared/logger";
+export { parseLogLevel } from "@open-inspect/shared/logger";
 
 const SERVICE_NAME = "github-bot";
 

--- a/packages/github-bot/src/session-target.ts
+++ b/packages/github-bot/src/session-target.ts
@@ -10,7 +10,8 @@
  * session must always be able to check out the PR under review.
  */
 
-import { encodeRepositoryPathSegments, resolveAppName } from "@open-inspect/shared";
+import { encodeRepositoryPathSegments } from "@open-inspect/shared";
+import { resolveAppName } from "@open-inspect/shared/app-name";
 import { z } from "zod";
 import type { Env } from "./types";
 import { signedControlPlaneFetch } from "./internal-auth";

--- a/packages/linear-bot/src/cached-resource.ts
+++ b/packages/linear-bot/src/cached-resource.ts
@@ -8,7 +8,7 @@
  * classifier/cached-resource.ts.
  */
 
-import { createKvCacheStore } from "@open-inspect/shared";
+import { createKvCacheStore } from "@open-inspect/shared/cache-store";
 import type { Env } from "./types";
 import {
   ControlPlaneRequestError,

--- a/packages/linear-bot/src/callbacks.ts
+++ b/packages/linear-bot/src/callbacks.ts
@@ -12,7 +12,7 @@ import {
   updateAgentSession,
 } from "./utils/linear-client";
 import { extractAgentResponse, formatAgentResponse } from "./completion/extractor";
-import { resolveAppName } from "@open-inspect/shared";
+import { resolveAppName } from "@open-inspect/shared/app-name";
 import { makePlan } from "./plan";
 import { createLogger } from "./logger";
 import { createStartCallbackRouter } from "./callbacks/start-callback";

--- a/packages/linear-bot/src/index.ts
+++ b/packages/linear-bot/src/index.ts
@@ -14,7 +14,7 @@ import {
 } from "./utils/linear-client";
 import { callbacksRouter } from "./callbacks";
 import { createLogger } from "./logger";
-import { resolveAppName } from "@open-inspect/shared";
+import { resolveAppName } from "@open-inspect/shared/app-name";
 import { handleAgentSessionEvent, escapeHtml } from "./webhook-handler";
 import { isDuplicateEvent } from "./kv-store";
 

--- a/packages/linear-bot/src/logger.ts
+++ b/packages/linear-bot/src/logger.ts
@@ -5,11 +5,11 @@
  * pre-binding the "linear-bot" service name so callers don't repeat it.
  */
 
-import { createLogger as _createLogger, type LogLevel } from "@open-inspect/shared";
-import type { Logger } from "@open-inspect/shared";
-export type { Logger } from "@open-inspect/shared";
-export type { LogLevel } from "@open-inspect/shared";
-export { parseLogLevel } from "@open-inspect/shared";
+import { createLogger as _createLogger, type LogLevel } from "@open-inspect/shared/logger";
+import type { Logger } from "@open-inspect/shared/logger";
+export type { Logger } from "@open-inspect/shared/logger";
+export type { LogLevel } from "@open-inspect/shared/logger";
+export { parseLogLevel } from "@open-inspect/shared/logger";
 
 const SERVICE_NAME = "linear-bot";
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -17,6 +17,18 @@
     "./service-auth": {
       "import": "./dist/service-auth.js",
       "types": "./dist/service-auth.d.ts"
+    },
+    "./logger": {
+      "import": "./dist/logger.js",
+      "types": "./dist/logger.d.ts"
+    },
+    "./cache-store": {
+      "import": "./dist/cache-store.js",
+      "types": "./dist/cache-store.d.ts"
+    },
+    "./app-name": {
+      "import": "./dist/app-name.js",
+      "types": "./dist/app-name.d.ts"
     }
   },
   "scripts": {

--- a/packages/slack-bot/src/app-home/publisher.ts
+++ b/packages/slack-bot/src/app-home/publisher.ts
@@ -1,4 +1,5 @@
-import { publishView, resolveAppName } from "@open-inspect/shared";
+import { publishView } from "@open-inspect/shared";
+import { resolveAppName } from "@open-inspect/shared/app-name";
 import { getUserRepoBranchPreferences } from "../branch-preferences";
 import { getAvailableRepos } from "../classifier/repos";
 import { createLogger } from "../logger";

--- a/packages/slack-bot/src/bot-identity.ts
+++ b/packages/slack-bot/src/bot-identity.ts
@@ -6,7 +6,8 @@
  * the id is effectively static for the lifetime of the Slack app.
  */
 
-import { authTest, createKvCacheStore } from "@open-inspect/shared";
+import { authTest } from "@open-inspect/shared";
+import { createKvCacheStore } from "@open-inspect/shared/cache-store";
 import type { Env } from "./types";
 import { createLogger } from "./logger";
 

--- a/packages/slack-bot/src/branch-preferences.ts
+++ b/packages/slack-bot/src/branch-preferences.ts
@@ -1,6 +1,6 @@
 import type { Env, SlackInteractionPayload } from "./types";
 import { createLogger } from "./logger";
-import { createKvCacheStore } from "@open-inspect/shared";
+import { createKvCacheStore } from "@open-inspect/shared/cache-store";
 
 const log = createLogger("branch-preferences");
 

--- a/packages/slack-bot/src/classifier/cached-resource.ts
+++ b/packages/slack-bot/src/classifier/cached-resource.ts
@@ -10,7 +10,7 @@
  * KV-first, no memory tier).
  */
 
-import { createKvCacheStore } from "@open-inspect/shared";
+import { createKvCacheStore } from "@open-inspect/shared/cache-store";
 import type { Env } from "../types";
 import {
   ControlPlaneRequestError,

--- a/packages/slack-bot/src/classifier/repos.ts
+++ b/packages/slack-bot/src/classifier/repos.ts
@@ -10,12 +10,12 @@ import type { Env, RepoConfig } from "../types";
 import { normalizeRepoId } from "../utils/repo";
 import {
   controlPlaneReposResponseSchema,
-  createKvCacheStore,
   normalizeRoutingRules,
   repoConfigSchema,
   type SlackGlobalConfig,
   type SlackRoutingRule,
 } from "@open-inspect/shared";
+import { createKvCacheStore } from "@open-inspect/shared/cache-store";
 import { createCachedResource } from "./cached-resource";
 import {
   controlPlaneFetch,

--- a/packages/slack-bot/src/logger.ts
+++ b/packages/slack-bot/src/logger.ts
@@ -5,11 +5,11 @@
  * pre-binding the "slack-bot" service name so callers don't repeat it.
  */
 
-import { createLogger as _createLogger, type LogLevel } from "@open-inspect/shared";
-import type { Logger } from "@open-inspect/shared";
-export type { Logger } from "@open-inspect/shared";
-export type { LogLevel } from "@open-inspect/shared";
-export { parseLogLevel } from "@open-inspect/shared";
+import { createLogger as _createLogger, type LogLevel } from "@open-inspect/shared/logger";
+import type { Logger } from "@open-inspect/shared/logger";
+export type { Logger } from "@open-inspect/shared/logger";
+export type { LogLevel } from "@open-inspect/shared/logger";
+export { parseLogLevel } from "@open-inspect/shared/logger";
 
 const SERVICE_NAME = "slack-bot";
 

--- a/packages/slack-bot/src/pending-requests/pending-request-store.ts
+++ b/packages/slack-bot/src/pending-requests/pending-request-store.ts
@@ -1,4 +1,4 @@
-import { createKvCacheStore } from "@open-inspect/shared";
+import { createKvCacheStore } from "@open-inspect/shared/cache-store";
 import { z } from "zod";
 import type { Env } from "../types";
 

--- a/packages/slack-bot/src/routes/events.ts
+++ b/packages/slack-bot/src/routes/events.ts
@@ -1,4 +1,5 @@
-import { createKvCacheStore, verifySlackSignature } from "@open-inspect/shared";
+import { verifySlackSignature } from "@open-inspect/shared";
+import { createKvCacheStore } from "@open-inspect/shared/cache-store";
 import { Hono } from "hono";
 import { handleSlackEvent, type SlackEventPayload } from "../events/dispatcher";
 import { createLogger } from "../logger";

--- a/packages/slack-bot/src/sessions/thread-session-store.ts
+++ b/packages/slack-bot/src/sessions/thread-session-store.ts
@@ -1,4 +1,4 @@
-import { createKvCacheStore } from "@open-inspect/shared";
+import { createKvCacheStore } from "@open-inspect/shared/cache-store";
 import { z } from "zod";
 import { createLogger } from "../logger";
 import { targetId, targetLabel, type SlackSessionTarget } from "../targets";

--- a/packages/slack-bot/src/user-preferences.ts
+++ b/packages/slack-bot/src/user-preferences.ts
@@ -1,12 +1,12 @@
 import {
   DEFAULT_MODEL,
-  createKvCacheStore,
   getDefaultReasoningEffort,
   isValidModel,
   isValidReasoningEffort,
   normalizeModelId,
   resolveEnabledModel,
 } from "@open-inspect/shared";
+import { createKvCacheStore } from "@open-inspect/shared/cache-store";
 import type { Env, UserPreferences } from "./types";
 import {
   getValidatedBranch,


### PR DESCRIPTION
## Summary

- expose the existing `logger.ts`, `cache-store.ts`, and `app-name.ts` owners as direct shared package paths
- migrate all 19 Slack, GitHub, and Linear production consumers to those paths
- preserve each bot's local logger wrapper and service-name binding
- preserve package-root exports and unrelated mixed root imports

## Dependency impact

- bot direct-path consumers: `logger` 3, `cache-store` 10, `app-name` 6
- bot root imports containing these owner symbols: 19 → 0
- repository production root consumers: 252 → 241
- no source movement, behavior changes, new tests, or lint enforcement

## Validation

- shared built first
- shared, Slack, GitHub, and Linear lint/typecheck/build
- full existing suites: 1,217 tests passed across 87 files
- import inventory and root-consumer metrics verified
- implementation self-review and independent architecture/simplicity review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal module organization by separating shared logging, caching, and app-name utilities.
  * Added dedicated access points for shared functionality, supporting clearer and more maintainable integrations across bot services.
  * No user-facing behavior or public functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->