### PR TITLE
Import app process foundations from owner modules

### DIFF
--- a/packages/control-plane/src/auth/github-app.test.ts
+++ b/packages/control-plane/src/auth/github-app.test.ts
@@ -10,7 +10,7 @@ import {
   listInstallationRepositories,
   listRepositoryBranches,
 } from "./github-app";
-import type { CacheStore } from "@open-inspect/shared";
+import type { CacheStore } from "@open-inspect/shared/cache-store";
 
 class FakeCacheStore implements CacheStore {
   private readonly store = new Map<string, string>();

--- a/packages/control-plane/src/auth/github-app.ts
+++ b/packages/control-plane/src/auth/github-app.ts
@@ -9,11 +9,9 @@
  * 3. Token valid for 1 hour
  */
 
-import {
-  DEFAULT_APP_NAME,
-  type CacheStore,
-  type InstallationRepository,
-} from "@open-inspect/shared";
+import type { InstallationRepository } from "@open-inspect/shared";
+import { DEFAULT_APP_NAME } from "@open-inspect/shared/app-name";
+import type { CacheStore } from "@open-inspect/shared/cache-store";
 import { z } from "zod";
 
 import { base64UrlEncode } from "./encoding";

--- a/packages/control-plane/src/auth/github.ts
+++ b/packages/control-plane/src/auth/github.ts
@@ -2,7 +2,8 @@
  * GitHub authentication utilities.
  */
 
-import { DEFAULT_APP_NAME, formatGitHubNoreplyEmail } from "@open-inspect/shared";
+import { formatGitHubNoreplyEmail } from "@open-inspect/shared";
+import { DEFAULT_APP_NAME } from "@open-inspect/shared/app-name";
 import { z } from "zod";
 import { decryptToken, encryptToken } from "./crypto";
 import { githubTokenResponseSchema, type GitHubUser, type GitHubTokenResponse } from "../types";

--- a/packages/control-plane/src/logger.ts
+++ b/packages/control-plane/src/logger.ts
@@ -5,11 +5,11 @@
  * pre-binding the "control-plane" service name so callers don't repeat it.
  */
 
-import { createLogger as _createLogger, type LogLevel } from "@open-inspect/shared";
-import type { Logger } from "@open-inspect/shared";
-export type { Logger } from "@open-inspect/shared";
-export type { LogLevel } from "@open-inspect/shared";
-export { parseLogLevel } from "@open-inspect/shared";
+import { createLogger as _createLogger, type LogLevel } from "@open-inspect/shared/logger";
+import type { Logger } from "@open-inspect/shared/logger";
+export type { Logger } from "@open-inspect/shared/logger";
+export type { LogLevel } from "@open-inspect/shared/logger";
+export { parseLogLevel } from "@open-inspect/shared/logger";
 
 const SERVICE_NAME = "control-plane";
 

--- a/packages/control-plane/src/routes/repos.ts
+++ b/packages/control-plane/src/routes/repos.ts
@@ -5,7 +5,7 @@
 import { RepoMetadataStore } from "../db/repo-metadata";
 import type { Env } from "../types";
 import type { SqlDatabase } from "../db/sql-database";
-import { createKvCacheStore } from "@open-inspect/shared";
+import { createKvCacheStore } from "@open-inspect/shared/cache-store";
 import type {
   EnrichedRepository,
   InstallationRepository,

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -12,10 +12,10 @@ import { initSchema } from "./schema";
 import {
   DEFAULT_MODEL,
   clientMessageSchema,
-  resolveAppName,
   sandboxEventSchema,
   type SessionAttachmentReference,
 } from "@open-inspect/shared";
+import { resolveAppName } from "@open-inspect/shared/app-name";
 import { timingSafeEqual } from "@open-inspect/shared/auth";
 import { generateId, hashToken, encryptToken, decryptToken } from "../auth/crypto";
 import { buildModalSandboxDashboardUrl } from "../sandbox/client";

--- a/packages/control-plane/src/source-control/provider-from-env.ts
+++ b/packages/control-plane/src/source-control/provider-from-env.ts
@@ -1,4 +1,5 @@
-import { createKvCacheStore, resolveAppName } from "@open-inspect/shared";
+import { resolveAppName } from "@open-inspect/shared/app-name";
+import { createKvCacheStore } from "@open-inspect/shared/cache-store";
 import { getGitHubAppConfig } from "../auth/github-app";
 import type { Env } from "../types";
 import { resolveScmProviderFromEnv } from "./config";

--- a/packages/control-plane/src/source-control/providers/constants.ts
+++ b/packages/control-plane/src/source-control/providers/constants.ts
@@ -2,7 +2,7 @@
  * Provider constants.
  */
 
-import { DEFAULT_APP_NAME } from "@open-inspect/shared";
+import { DEFAULT_APP_NAME } from "@open-inspect/shared/app-name";
 
 /** Default User-Agent header used when a per-deployment app name is not configured. */
 export const USER_AGENT = DEFAULT_APP_NAME;

--- a/packages/control-plane/src/source-control/providers/types.ts
+++ b/packages/control-plane/src/source-control/providers/types.ts
@@ -3,7 +3,7 @@
  */
 
 import type { GitHubAppConfig } from "../../auth/github-app";
-import type { CacheStore } from "@open-inspect/shared";
+import type { CacheStore } from "@open-inspect/shared/cache-store";
 
 /**
  * Configuration for GitHubSourceControlProvider.

--- a/packages/web/src/lib/logger.ts
+++ b/packages/web/src/lib/logger.ts
@@ -1,4 +1,4 @@
-import { createLogger as createStructuredLogger, parseLogLevel } from "@open-inspect/shared";
+import { createLogger as createStructuredLogger, parseLogLevel } from "@open-inspect/shared/logger";
 
 const SERVICE_NAME = "web";
 

--- a/packages/web/src/lib/site-config.ts
+++ b/packages/web/src/lib/site-config.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_APP_NAME } from "@open-inspect/shared";
+import { DEFAULT_APP_NAME } from "@open-inspect/shared/app-name";
 
 export const APP_NAME = process.env.NEXT_PUBLIC_APP_NAME?.trim() || DEFAULT_APP_NAME;
 


### PR DESCRIPTION
## Summary

- migrate the 11 control-plane/web consumers of `logger`, `cache-store`, and `app-name` to their existing direct package paths
- preserve the control-plane logger wrapper, service-name binding, re-exports, and local `CorrelationContext`
- preserve unrelated mixed root imports and package-root compatibility
- add no source modules, tests, or lint enforcement

## Stack and merge order

This PR is stacked on #1170, which supplies the three package export entries.

1. Review and merge #1170 first.
2. Rebase this consumer commit onto updated `main`.
3. Retarget this PR to `main`.

The current review diff is only the 11 control-plane/web consumer files.

## Dependency impact

- direct-path consumers: `logger` 2, `cache-store` 5, `app-name` 6
- remaining root imports of those owner symbols in control-plane/web: 0
- control-plane/web production root consumers: 201 → 195
- after #1170, repository production root consumers: 241 → 235
- no behavior changes

## Validation

- shared built first
- shared, control-plane, and web lint/typecheck/build
- existing unit suites: 3,442 tests passed
- control-plane workerd/D1 integration: 655 tests passed
- AST import inventory, formatting, and diff checks passed
- implementation self-review and independent architecture/simplicity review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal module organization for shared application names, caching, logging, and authentication utilities.
  * Logging integrations continue to provide the same behavior and public interfaces.
  * No changes to application functionality, routes, responses, or caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->