### PR TITLE
Import shared commit signing from its owner module

### DIFF
--- a/packages/control-plane/src/auth/openssh-ed25519.ts
+++ b/packages/control-plane/src/auth/openssh-ed25519.ts
@@ -1,4 +1,4 @@
-import { MAX_COMMIT_SIGNING_PRIVATE_KEY_LENGTH } from "@open-inspect/shared";
+import { MAX_COMMIT_SIGNING_PRIVATE_KEY_LENGTH } from "@open-inspect/shared/types/commit-signing";
 
 import { createArmoredGitSshSig, createGitSshSigSignedData } from "./sshsig";
 

--- a/packages/control-plane/src/routes/commit-signing.ts
+++ b/packages/control-plane/src/routes/commit-signing.ts
@@ -1,4 +1,4 @@
-import { commitSigningWriteRequestSchema } from "@open-inspect/shared";
+import { commitSigningWriteRequestSchema } from "@open-inspect/shared/types/commit-signing";
 
 import {
   OpenSshKeyValidationError,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -29,6 +29,10 @@
     "./app-name": {
       "import": "./dist/app-name.js",
       "types": "./dist/app-name.d.ts"
+    },
+    "./types/commit-signing": {
+      "import": "./dist/types/commit-signing.js",
+      "types": "./dist/types/commit-signing.d.ts"
     }
   },
   "scripts": {

--- a/packages/web/src/app/api/commit-signing/route.ts
+++ b/packages/web/src/app/api/commit-signing/route.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { getServerAuthSession } from "@/lib/server-auth-session";
-import { commitSigningMetadataSchema } from "@open-inspect/shared";
+import { commitSigningMetadataSchema } from "@open-inspect/shared/types/commit-signing";
 
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 

--- a/packages/web/src/components/settings/integrations/commit-signing-settings.tsx
+++ b/packages/web/src/components/settings/integrations/commit-signing-settings.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
-import { commitSigningMetadataSchema } from "@open-inspect/shared";
+import { commitSigningMetadataSchema } from "@open-inspect/shared/types/commit-signing";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";


### PR DESCRIPTION
## Summary

- expose the existing `types/commit-signing.ts` owner as `@open-inspect/shared/types/commit-signing`
- migrate its four control-plane/web production consumers from the shared root
- preserve the shared root and local types-barrel exports for compatibility
- add no source modules, tests, behavior changes, or lint enforcement

## Dependency impact

- direct commit-signing consumers: 0 → 4
- root imports containing commit-signing-owned names: 4 → 0
- repository production root consumers: 235 → 231
- no mixed imports or new dependency cycles

## Validation

- shared built first
- shared, control-plane, and web lint/typecheck/build
- shared schema test: 1 passed
- affected control-plane unit test: 1 passed
- affected web tests: 16 passed
- workerd/D1 commit-signing and OpenSSH integration: 39 passed
- post-rebase shared/control-plane/web lint and typecheck
- implementation and independent architecture/simplicity reviews: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal sharing of commit-signing validation definitions across the control plane and web application.
  * Added a dedicated package export for commit-signing types and schemas.
  * Existing commit-signing settings, API requests, validation, and response handling remain unchanged.

* **User Impact**
  * No visible changes to the commit-signing experience or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->