### PR TITLE
Import bot models from their owner module

### DIFF
--- a/packages/linear-bot/src/model-resolution.ts
+++ b/packages/linear-bot/src/model-resolution.ts
@@ -7,7 +7,7 @@ import {
   getDefaultReasoningEffort,
   getValidModelOrDefault,
   isValidReasoningEffort,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/models";
 
 /**
  * Resolve a target (repository or environment) from the static team mapping:

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,6 +18,10 @@
       "import": "./dist/service-auth.js",
       "types": "./dist/service-auth.d.ts"
     },
+    "./models": {
+      "import": "./dist/models.js",
+      "types": "./dist/models.d.ts"
+    },
     "./logger": {
       "import": "./dist/logger.js",
       "types": "./dist/logger.d.ts"

--- a/packages/slack-bot/src/app-home/interactions.ts
+++ b/packages/slack-bot/src/app-home/interactions.ts
@@ -1,4 +1,4 @@
-import { isValidModel, isValidReasoningEffort } from "@open-inspect/shared";
+import { isValidModel, isValidReasoningEffort } from "@open-inspect/shared/models";
 import {
   BRANCH_INPUT_BLOCK_ID,
   BRANCH_MODAL_CALLBACK_ID,

--- a/packages/slack-bot/src/app-home/models.ts
+++ b/packages/slack-bot/src/app-home/models.ts
@@ -1,10 +1,10 @@
+import type { SlackGlobalConfig } from "@open-inspect/shared";
 import {
   DEFAULT_ENABLED_MODELS,
   MODEL_OPTIONS,
   isValidModel,
   normalizeValidModels,
-  type SlackGlobalConfig,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/models";
 import type { Env } from "../types";
 import { signedControlPlaneFetch } from "../internal-auth";
 import type { ModelOption } from "./slack-types";

--- a/packages/slack-bot/src/app-home/view.ts
+++ b/packages/slack-bot/src/app-home/view.ts
@@ -1,4 +1,4 @@
-import { getDefaultReasoningEffort, getReasoningConfig } from "@open-inspect/shared";
+import { getDefaultReasoningEffort, getReasoningConfig } from "@open-inspect/shared/models";
 import { CLEAR_REPO_BRANCH_ACTION_ID, REPO_BRANCH_SELECTOR_ACTION_ID } from "../branch-preferences";
 import type { RepoConfig } from "../types";
 import {

--- a/packages/slack-bot/src/user-preferences.test.ts
+++ b/packages/slack-bot/src/user-preferences.test.ts
@@ -1,4 +1,4 @@
-import { getDefaultReasoningEffort } from "@open-inspect/shared";
+import { getDefaultReasoningEffort } from "@open-inspect/shared/models";
 import { describe, expect, it, vi } from "vitest";
 import type { Env } from "./types";
 import {

--- a/packages/slack-bot/src/user-preferences.ts
+++ b/packages/slack-bot/src/user-preferences.ts
@@ -5,7 +5,7 @@ import {
   isValidReasoningEffort,
   normalizeModelId,
   resolveEnabledModel,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/models";
 import { createKvCacheStore } from "@open-inspect/shared/cache-store";
 import type { Env, UserPreferences } from "./types";
 import {


### PR DESCRIPTION
## Summary

- expose the existing `models.ts` owner as `@open-inspect/shared/models`
- migrate six Slack/Linear consumers to the direct path
- retain unrelated `SlackGlobalConfig` on the shared root and preserve the existing cache-store path
- add no source modules, tests, behavior changes, or lint enforcement

## Stack and merge order

This PR is stacked on #1174.

1. Review and merge #1174 first.
2. Rebase this models commit onto updated `main`.
3. Retarget this PR to `main`.

The current review diff is only the `./models` export and six bot consumer files.

## Dependency impact

- direct `/models` consumers: 0 → 6
- remaining named model imports from the root in Slack/Linear: 0
- bot production root consumers: 40 → 36
- after #1174, repository production root consumers: 231 → 227
- bot test root consumers: 9 → 8

## Validation

- shared built first
- shared, Slack, and Linear lint/typecheck/build
- full existing suites: 1,087 tests passed across 80 files
- exhaustive import inventory and root-consumer metrics verified
- implementation and independent architecture/simplicity reviews: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized model and reasoning configuration access through a dedicated shared module.
  * No user-visible behavior or interface changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->