### PR TITLE
Standardize Modal image builds on provider sessions

### DIFF
--- a/docs/IMAGE_PREBUILD.md
+++ b/docs/IMAGE_PREBUILD.md
@@ -123,7 +123,8 @@ The build process runs the same setup steps that a normal session would:
 1. Clones every repository in the scope at its base branch (for an environment, **sequentially, in
    position order**)
 2. Runs each repository's `.openinspect/setup.sh` script (if present) in the same order
-3. Saves a provider image artifact for the resulting environment
+3. Calls the control plane with the exact provider sandbox id
+4. Lets the control plane snapshot or checkpoint that sandbox into the provider image artifact
 
 A failing setup script fails the whole build, and for environment builds the error names the
 repository. Build-time secrets are exactly what the scope's sessions get: global + repository
@@ -133,6 +134,11 @@ secrets for a repository scope, global + environment secrets for an environment 
 Everything your setup scripts install — dependencies, build artifacts, caches — is captured in the
 image artifact. Depending on the active sandbox provider, this is stored as a Modal image, Vercel
 snapshot, or OpenComputer checkpoint.
+
+Modal follows the same provider-session lifecycle as Vercel and OpenComputer: the control plane
+creates a dormant sandbox, records its id, starts the runtime, and snapshots it after the success
+callback. The legacy Modal builder remains deployed temporarily so builds already in flight can
+finish during the rollout, but new builds do not use it.
 
 ### What Happens When You Start a Session
 

--- a/packages/control-plane/README.md
+++ b/packages/control-plane/README.md
@@ -163,11 +163,11 @@ statuses are `building | ready | failed | superseded`.
 | `/image-builds/mark-stale`                   | POST   | Mark old `building` rows failed (called by the scheduler)                                                                                                            |
 | `/image-builds/cleanup`                      | POST   | Delete old failed rows and reap superseded rows' provider artifacts                                                                                                  |
 
-Build callbacks authenticate in one of two modes, decided per provider: Modal builders call back
-with the deployment-wide internal HMAC token, while Vercel/OpenComputer build sandboxes use a
-single-use bearer token minted at trigger time — only its HMAC hash is stored on the build row and
+New Modal, Vercel, and OpenComputer builds run in provider sessions. Their sandboxes use a
+single-use bearer token minted at trigger time; only its HMAC hash is stored on the build row and
 bound to the provider session. Success callbacks verify it before payload validation and consume it
-atomically when accepted; failure callbacks consume it while marking the build failed.
+when accepted; failure callbacks consume it while marking the build failed. Unbound Modal rows
+retain the legacy provider-image callback path so builds started before the rollout can finish.
 
 ### Automations
 

--- a/packages/control-plane/src/image-builds/modal-adapter.test.ts
+++ b/packages/control-plane/src/image-builds/modal-adapter.test.ts
@@ -6,6 +6,11 @@ import type { ModalImageBuildPlan } from "./types";
 function createProvider(): ModalImageBuildProvider {
   return {
     triggerImageBuild: vi.fn(async () => ({ buildId: "build-1", status: "building" })),
+    triggerEnvironmentImageBuild: vi.fn(async () => ({
+      buildId: "build-1",
+      status: "building",
+    })),
+    terminateImageBuildSandbox: vi.fn(async () => undefined),
     snapshotImageBuildSandbox: vi.fn(async () => ({ success: true, imageId: "modal-image-1" })),
     deleteProviderImage: vi.fn(async () => undefined),
   };
@@ -14,7 +19,7 @@ function createProvider(): ModalImageBuildProvider {
 function createPlan(): ModalImageBuildPlan {
   return {
     provider: "modal",
-    callbackMode: "provider_image",
+    callbackMode: "provider_session",
     buildId: "build-1",
     scope: { kind: "repo", id: "acme/repo" },
     repositories: [{ repoOwner: "acme", repoName: "repo", baseBranch: "develop" }],
@@ -22,6 +27,12 @@ function createPlan(): ModalImageBuildPlan {
     callbackUrl: "https://worker.test/image-builds/build-complete",
     failureCallbackUrl: "https://worker.test/image-builds/build-failed",
     callbackToken: "modal-callback-token",
+    cloneAuth: {
+      type: "credential_helper",
+      host: "github.com",
+      username: "x-access-token",
+      token: "clone-token",
+    },
     buildTimeoutMs: 1_800_000,
     userEnvVars: { FOO: "bar" },
     correlation: {
@@ -37,9 +48,10 @@ describe("ModalImageBuildAdapter", () => {
     const adapter = new ModalImageBuildAdapter(provider);
     const plan = createPlan();
 
-    await adapter.startBuild(plan, { bindProviderSession: vi.fn() });
+    const bindProviderSession = vi.fn(async () => undefined);
+    await adapter.startBuild(plan, { bindProviderSession });
 
-    expect(provider.triggerImageBuild).toHaveBeenCalledWith({
+    expect(provider.triggerEnvironmentImageBuild).toHaveBeenCalledWith({
       scopeKind: "repo",
       scopeId: "acme/repo",
       buildId: "build-1",
@@ -47,12 +59,51 @@ describe("ModalImageBuildAdapter", () => {
       callbackUrl: "https://worker.test/image-builds/build-complete",
       failureCallbackUrl: "https://worker.test/image-builds/build-failed",
       callbackToken: "modal-callback-token",
+      cloneToken: "clone-token",
+      cloneHost: "github.com",
+      cloneUsername: "x-access-token",
       buildTimeoutMs: 1_800_000,
       userEnvVars: { FOO: "bar" },
       correlation: {
         request_id: "request-1",
         trace_id: "trace-1",
       },
+      onProviderSessionCreated: bindProviderSession,
+    });
+  });
+
+  it("snapshots the bound Modal build sandbox on completion", async () => {
+    const provider = createProvider();
+    const adapter = new ModalImageBuildAdapter(provider);
+
+    await expect(
+      adapter.finalizeSuccessfulBuild({
+        buildId: "build-1",
+        providerSessionId: "modal-session-1",
+        correlation: { request_id: "request-1", trace_id: "trace-1" },
+      })
+    ).resolves.toEqual({
+      providerImageId: "modal-image-1",
+      providerSessionId: "modal-session-1",
+    });
+  });
+
+  it("terminates failed Modal build sandboxes", async () => {
+    const provider = createProvider();
+    const adapter = new ModalImageBuildAdapter(provider);
+
+    await adapter.cleanupFailedBuild({
+      buildId: "build-1",
+      providerSessionId: "modal-session-1",
+      errorMessage: "setup failed",
+      correlation: { request_id: "request-1", trace_id: "trace-1" },
+    });
+
+    expect(provider.terminateImageBuildSandbox).toHaveBeenCalledWith({
+      buildId: "build-1",
+      providerSessionId: "modal-session-1",
+      reason: "image_build_failed",
+      correlation: { request_id: "request-1", trace_id: "trace-1" },
     });
   });
 

--- a/packages/control-plane/src/image-builds/modal-adapter.ts
+++ b/packages/control-plane/src/image-builds/modal-adapter.ts
@@ -1,36 +1,77 @@
 import type { ModalImageBuildProvider } from "../sandbox/providers/modal-provider";
 import type {
   DeleteImageInput,
+  FailedImageBuildInput,
+  FinalizeImageBuildInput,
   ImageBuildAdapter,
   ImageBuildStartCallbacks,
   ModalImageBuildPlan,
 } from "./types";
 
 /**
- * Modal adapter for direct provider-image callbacks.
- *
- * Modal's data-plane builder returns the final provider image id in its
- * callback, so no session binding or finalization step is needed here.
+ * Modal adapter for provider-session image builds.
  */
 export class ModalImageBuildAdapter implements ImageBuildAdapter<ModalImageBuildPlan> {
   constructor(private readonly provider: ModalImageBuildProvider) {}
 
-  async startBuild(plan: ModalImageBuildPlan, _callbacks: ImageBuildStartCallbacks): Promise<void> {
-    await this.provider.triggerImageBuild({
+  async startBuild(plan: ModalImageBuildPlan, callbacks: ImageBuildStartCallbacks): Promise<void> {
+    await this.provider.triggerEnvironmentImageBuild({
       scopeKind: plan.scope.kind,
       scopeId: plan.scope.id,
       buildId: plan.buildId,
+      repositories: plan.repositories,
+      cloneToken: plan.cloneAuth.type === "credential_helper" ? plan.cloneAuth.token : undefined,
+      cloneHost: plan.cloneAuth.type === "credential_helper" ? plan.cloneAuth.host : undefined,
+      cloneUsername:
+        plan.cloneAuth.type === "credential_helper" ? plan.cloneAuth.username : undefined,
+      userEnvVars: plan.userEnvVars,
+      buildTimeoutMs: plan.buildTimeoutMs,
       callbackUrl: plan.callbackUrl,
       failureCallbackUrl: plan.failureCallbackUrl,
       callbackToken: plan.callbackToken,
-      repositories: plan.repositories,
-      userEnvVars: plan.userEnvVars,
-      buildTimeoutMs: plan.buildTimeoutMs,
+      onProviderSessionCreated: callbacks.bindProviderSession,
       correlation: plan.correlation,
     });
   }
 
+  async finalizeSuccessfulBuild(
+    input: FinalizeImageBuildInput
+  ): Promise<{ providerImageId: string; providerSessionId: string }> {
+    const result = await this.provider.snapshotImageBuildSandbox({
+      buildId: input.buildId,
+      providerSessionId: input.providerSessionId,
+      correlation: { ...input.correlation, sandbox_id: input.providerSessionId },
+    });
+    if (!result.success || !result.imageId) {
+      throw new Error(result.error || "Modal image build snapshot failed");
+    }
+    return {
+      providerImageId: result.imageId,
+      providerSessionId: input.providerSessionId,
+    };
+  }
+
+  async cleanupCompletedBuild(input: FinalizeImageBuildInput): Promise<void> {
+    await this.terminateBuildSandbox(input, "image_build_complete");
+  }
+
+  async cleanupFailedBuild(input: FailedImageBuildInput): Promise<void> {
+    await this.terminateBuildSandbox(input, "image_build_failed");
+  }
+
   async deleteImage(input: DeleteImageInput): Promise<void> {
     await this.provider.deleteProviderImage(input.image.providerImageId, input.correlation);
+  }
+
+  private async terminateBuildSandbox(
+    input: FinalizeImageBuildInput | FailedImageBuildInput,
+    reason: string
+  ): Promise<void> {
+    await this.provider.terminateImageBuildSandbox({
+      buildId: input.buildId,
+      providerSessionId: input.providerSessionId,
+      reason,
+      correlation: input.correlation,
+    });
   }
 }

--- a/packages/control-plane/src/image-builds/opencomputer-adapter.test.ts
+++ b/packages/control-plane/src/image-builds/opencomputer-adapter.test.ts
@@ -23,7 +23,12 @@ function createPlan(): OpenComputerImageBuildPlan {
     callbackUrl: "https://worker.test/image-builds/build-complete",
     failureCallbackUrl: "https://worker.test/image-builds/build-failed",
     callbackToken: "callback-token",
-    cloneAuth: { type: "credential_helper", token: "clone-token" },
+    cloneAuth: {
+      type: "credential_helper",
+      host: "github.com",
+      username: "x-access-token",
+      token: "clone-token",
+    },
     buildTimeoutMs: 1_800_001,
     userEnvVars: { FOO: "bar" },
     correlation: {

--- a/packages/control-plane/src/image-builds/planner.ts
+++ b/packages/control-plane/src/image-builds/planner.ts
@@ -1,6 +1,7 @@
 import { resolveBuildTimeoutSeconds } from "@open-inspect/shared";
 import { createLogger, type CorrelationContext } from "../logger";
-import { createSourceControlProviderFromEnv } from "../source-control";
+import { createSourceControlProviderFromEnv, resolveScmProviderFromEnv } from "../source-control";
+import { scmCloneIdentity } from "../sandbox/sandbox-env";
 import type { Env } from "../types";
 import type { SqlDatabase } from "../db/sql-database";
 import {
@@ -105,8 +106,9 @@ export class ImageBuildPlanner {
           plan: {
             ...basePlan,
             provider: "modal",
-            callbackMode: "provider_image",
+            callbackMode: "provider_session",
             callbackToken: callbackAuth.token,
+            cloneAuth,
           },
           callbackAuth: registration,
         };
@@ -147,7 +149,12 @@ export class ImageBuildPlanner {
     try {
       const provider = createSourceControlProviderFromEnv(this.env);
       const auth = await provider.generateCredentialHelperAuth();
-      return { type: "credential_helper", token: auth.password };
+      return {
+        type: "credential_helper",
+        host: scmCloneIdentity(resolveScmProviderFromEnv(this.env.SCM_PROVIDER)).host,
+        username: auth.username,
+        token: auth.password,
+      };
     } catch (e) {
       logger.warn("image_build.clone_token_failed", {
         error: e instanceof Error ? e.message : String(e),

--- a/packages/control-plane/src/image-builds/provider-policy.ts
+++ b/packages/control-plane/src/image-builds/provider-policy.ts
@@ -21,13 +21,16 @@ export type ImageBuildCallbackMode = "provider_image" | "provider_session";
 export type ImageBuildCloneAuthMode = "credential_helper" | "none";
 
 const IMAGE_BUILD_CALLBACK_MODES = {
+  // Unbound rows belong to legacy builds started before the provider-session
+  // cutover. New Modal builds bind a provider session, which the workflow
+  // treats as provider_session mode independently of this compatibility value.
   modal: "provider_image",
   vercel: "provider_session",
   opencomputer: "provider_session",
 } satisfies Record<ImageBuildProvider, ImageBuildCallbackMode>;
 
 const IMAGE_BUILD_CLONE_AUTH_MODES = {
-  modal: "none",
+  modal: "credential_helper",
   vercel: "credential_helper",
   opencomputer: "credential_helper",
 } satisfies Record<ImageBuildProvider, ImageBuildCloneAuthMode>;

--- a/packages/control-plane/src/image-builds/types.ts
+++ b/packages/control-plane/src/image-builds/types.ts
@@ -50,16 +50,17 @@ interface BaseImageBuildPlan {
   correlation: CorrelationContext;
 }
 
-/** Modal's data-plane builder returns the provider image id directly in its callback. */
+/** Modal builds inside a sandbox; the control plane snapshots it after callback success. */
 export interface ModalImageBuildPlan extends BaseImageBuildPlan {
   provider: "modal";
-  callbackMode: "provider_image";
+  callbackMode: "provider_session";
   callbackToken: string;
+  cloneAuth: ImageBuildCloneAuth;
 }
 
 /** Clone auth handed to provider-session build sandboxes (provider-policy.ts). */
 export type ImageBuildCloneAuth =
-  | { type: "credential_helper"; token: string }
+  | { type: "credential_helper"; host: string; username: string; token: string }
   | { type: "unavailable" };
 
 /** Vercel builds inside a sandbox; the control plane snapshots it after callback success. */
@@ -138,8 +139,7 @@ export interface FailedImageBuildInput {
  * Provider-facing operations for image builds. The workflow owns state
  * transitions; adapters own translating lifecycle steps into provider API
  * calls (start build, snapshot/checkpoint, teardown, artifact deletion).
- * The finalize/cleanup hooks apply to provider_session builds only — Modal's
- * callback already carries the artifact id.
+ * The finalize/cleanup hooks apply to provider_session builds.
  */
 export type ImageBuildAdapter<Plan extends ImageBuildPlan> = {
   startBuild(plan: Plan, callbacks: ImageBuildStartCallbacks): Promise<void>;

--- a/packages/control-plane/src/image-builds/vercel-adapter.test.ts
+++ b/packages/control-plane/src/image-builds/vercel-adapter.test.ts
@@ -23,7 +23,12 @@ function createPlan(): VercelImageBuildPlan {
     callbackUrl: "https://worker.test/image-builds/build-complete",
     failureCallbackUrl: "https://worker.test/image-builds/build-failed",
     callbackToken: "callback-token",
-    cloneAuth: { type: "credential_helper", token: "clone-token" },
+    cloneAuth: {
+      type: "credential_helper",
+      host: "github.com",
+      username: "x-access-token",
+      token: "clone-token",
+    },
     buildTimeoutMs: 1_800_001,
     userEnvVars: { FOO: "bar" },
     correlation: {

--- a/packages/control-plane/src/image-builds/workflow.test.ts
+++ b/packages/control-plane/src/image-builds/workflow.test.ts
@@ -85,8 +85,9 @@ function plannedBuild(overrides: Record<string, unknown> = {}): PlannedImageBuil
       buildTimeoutMs: 1800_000,
       correlation: { trace_id: "t", request_id: "r" },
       provider: "modal",
-      callbackMode: "provider_image",
+      callbackMode: "provider_session",
       callbackToken: MODAL_CALLBACK_TOKEN,
+      cloneAuth: { type: "unavailable" },
       ...overrides,
     },
     callbackAuth: { tokenHash: "hash-modal", expiresAt: 9_999_999_999_999 },
@@ -940,6 +941,48 @@ describe("ImageBuildWorkflow", () => {
         12_500
       );
       expect(adapter.cleanupCompletedBuild).toHaveBeenCalled();
+    });
+
+    it("uses provider-session finalization for newly bound Modal builds", async () => {
+      const store = sessionBuildStore();
+      const modalBuild = {
+        id: "imgb-env_1-1-abcd",
+        scope: ENV_SCOPE,
+        provider: "modal" as const,
+        providerSessionId: "modal-session-1",
+        status: "building" as const,
+      };
+      store.getCallbackBuild.mockResolvedValue(modalBuild);
+      store.consumeCallbackToken.mockResolvedValue(modalBuild);
+      store.tryMarkImageBuildReady.mockResolvedValue({
+        type: "marked_ready",
+        supersededImages: [],
+      });
+      const adapter = createAdapter();
+      const { workflow } = createWorkflow({ store, adapter, provider: "modal" });
+
+      const result = await workflow.acceptBuildComplete({
+        completion: validCompletion({
+          providerImageId: undefined,
+          providerSessionId: "modal-session-1",
+        }),
+        callbackToken: "callback-token",
+        context: ctx,
+      });
+      if (result.type !== "completion_accepted") throw new Error("unreachable");
+      await result.finalization;
+
+      expect(adapter.finalizeSuccessfulBuild).toHaveBeenCalledWith(
+        expect.objectContaining({ providerSessionId: "modal-session-1" })
+      );
+      expect(store.tryMarkImageBuildReady).toHaveBeenCalledWith(
+        "imgb-env_1-1-abcd",
+        "modal",
+        "im-finalized",
+        expect.any(Array),
+        expect.any(String),
+        expect.any(Number)
+      );
     });
 
     it("rejects completion when the callback token does not consume", async () => {

--- a/packages/control-plane/src/image-builds/workflow.ts
+++ b/packages/control-plane/src/image-builds/workflow.ts
@@ -397,7 +397,10 @@ export class ImageBuildWorkflow {
 
     const provider = build.provider;
 
-    if (getImageBuildCallbackMode(provider) === "provider_session") {
+    if (
+      build.providerSessionId !== null ||
+      getImageBuildCallbackMode(provider) === "provider_session"
+    ) {
       // Authenticate before revealing anything about the payload's validity —
       // same ordering as the internal-HMAC path below. A missing
       // provider_session_id can never match the token's stored binding, so it
@@ -723,7 +726,10 @@ export class ImageBuildWorkflow {
       throw new ImageBuildFailureNotAcceptedError("Build is not accepting failure");
     }
 
-    if (getImageBuildCallbackMode(build.provider) === "provider_session") {
+    if (
+      build.providerSessionId !== null ||
+      getImageBuildCallbackMode(build.provider) === "provider_session"
+    ) {
       // Token auth runs (inside the mark helper) before any payload check —
       // a missing provider_session_id can never match the token's stored
       // binding, so it fails as an auth error, indistinguishable from a bad

--- a/packages/control-plane/src/routes/image-builds.trigger.test.ts
+++ b/packages/control-plane/src/routes/image-builds.trigger.test.ts
@@ -30,6 +30,9 @@ const scmProvider = vi.hoisted(() => ({
 
 const modalClient = vi.hoisted(() => ({
   buildImage: vi.fn(),
+  createImageBuildSandbox: vi.fn(),
+  startImageBuildSandbox: vi.fn(),
+  terminateImageBuildSandbox: vi.fn(),
 }));
 
 const vercelProvider = vi.hoisted(() => ({
@@ -210,6 +213,7 @@ const REPO_REPOSITORIES = [{ repoOwner: "acme", repoName: "repo", baseBranch: "d
 // Spy the store boundary so the tests assert the typed contracts rather than
 // the store's SQL text or bound-argument order.
 const registerBuildSpy = vi.spyOn(ImageBuildStore.prototype, "registerBuild");
+const bindProviderSessionSpy = vi.spyOn(ImageBuildStore.prototype, "bindProviderSession");
 const getActiveBuildSpy = vi.spyOn(ImageBuildStore.prototype, "getActiveBuild");
 const hasReadyImageSpy = vi.spyOn(ImageBuildStore.prototype, "hasReadyImageForFingerprint");
 const markBuildFailedSpy = vi.spyOn(ImageBuildStore.prototype, "markBuildFailed");
@@ -218,11 +222,17 @@ const setImageBuildEnabledSpy = vi.spyOn(RepoMetadataStore.prototype, "setImageB
 beforeEach(() => {
   vi.clearAllMocks();
   registerBuildSpy.mockResolvedValue(true);
+  bindProviderSessionSpy.mockResolvedValue(true);
   getActiveBuildSpy.mockResolvedValue(null);
   hasReadyImageSpy.mockResolvedValue(false);
   markBuildFailedSpy.mockResolvedValue(true);
   setImageBuildEnabledSpy.mockResolvedValue(undefined);
   modalClient.buildImage.mockResolvedValue({ buildId: "build-1", status: "building" });
+  modalClient.createImageBuildSandbox.mockResolvedValue({
+    providerSessionId: "modal-session-1",
+  });
+  modalClient.startImageBuildSandbox.mockResolvedValue(undefined);
+  modalClient.terminateImageBuildSandbox.mockResolvedValue(undefined);
   vercelProvider.triggerEnvironmentImageBuild.mockResolvedValue(undefined);
   openComputerProvider.triggerEnvironmentImageBuild.mockResolvedValue(undefined);
   integrationSettings.resolveSandboxSettings.mockResolvedValue({});
@@ -253,17 +263,24 @@ describe("POST /image-builds/trigger/repo/:owner/:name", () => {
 
     // The resolved branch — not "main" — reaches the Modal backend as the
     // one-element repository set...
-    expect(modalClient.buildImage).toHaveBeenCalledTimes(1);
-    expect(modalClient.buildImage).toHaveBeenCalledWith(
+    expect(modalClient.createImageBuildSandbox).toHaveBeenCalledTimes(1);
+    expect(modalClient.createImageBuildSandbox).toHaveBeenCalledWith(
       expect.objectContaining({
         scopeKind: "repo",
         scopeId: "acme/repo",
         repositories: REPO_REPOSITORIES,
+        cloneToken: "clone-token",
+        cloneHost: "github.com",
+        cloneUsername: "x-access-token",
         buildTimeoutSeconds: 1800,
       }),
       expect.any(Object)
     );
-    expect(scmProvider.generateCredentialHelperAuth).not.toHaveBeenCalled();
+    expect(scmProvider.generateCredentialHelperAuth).toHaveBeenCalled();
+    expect(modalClient.startImageBuildSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({ providerSessionId: "modal-session-1" }),
+      expect.any(Object)
+    );
 
     // ...and is baked into the persisted fingerprint.
     expect(registerBuildSpy).toHaveBeenCalledWith(
@@ -330,7 +347,7 @@ describe("POST /image-builds/trigger/repo/:owner/:name", () => {
       "acme",
       "repo"
     );
-    expect(modalClient.buildImage).toHaveBeenCalledWith(
+    expect(modalClient.createImageBuildSandbox).toHaveBeenCalledWith(
       expect.objectContaining({ buildTimeoutSeconds: 3600 }),
       expect.any(Object)
     );
@@ -391,7 +408,7 @@ describe("PUT /image-builds/toggle/repo/:owner/:name", () => {
     expect(registerBuildSpy).toHaveBeenCalledWith(
       expect.objectContaining({ scope: { kind: "repo", id: "acme/repo" } })
     );
-    expect(modalClient.buildImage).toHaveBeenCalledTimes(1);
+    expect(modalClient.createImageBuildSandbox).toHaveBeenCalledTimes(1);
   });
 
   it("skips the build when a ready image already matches the repository set", async () => {
@@ -404,7 +421,7 @@ describe("PUT /image-builds/toggle/repo/:owner/:name", () => {
     expect(response.status).toBe(200);
     await Promise.all(waitUntilTasks);
     expect(registerBuildSpy).not.toHaveBeenCalled();
-    expect(modalClient.buildImage).not.toHaveBeenCalled();
+    expect(modalClient.createImageBuildSandbox).not.toHaveBeenCalled();
   });
 
   it("writes the flag without triggering on toggle-off", async () => {

--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -414,6 +414,66 @@ describe("ModalClient", () => {
     );
   });
 
+  it("creates, starts, and terminates provider-session image builds", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ success: true, data: { provider_session_id: "mo-build-1" } }),
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+      .mockImplementation(async () => {
+        return new Response(JSON.stringify({ success: true, data: {} }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+
+    const client = createModalClient("secret", "acme", "prod-web");
+    await expect(
+      client.createImageBuildSandbox({
+        scopeKind: "repo",
+        scopeId: "acme/repo",
+        buildId: "imgb-1",
+        repositories: [{ repoOwner: "acme", repoName: "repo", baseBranch: "develop" }],
+        cloneToken: "clone-token",
+        cloneHost: "gitlab.com",
+        cloneUsername: "oauth2",
+        buildTimeoutSeconds: 2400,
+      })
+    ).resolves.toEqual({ providerSessionId: "mo-build-1" });
+
+    await client.startImageBuildSandbox({
+      buildId: "imgb-1",
+      providerSessionId: "mo-build-1",
+      callbackUrl: "https://cp.test/image-builds/build-complete",
+      failureCallbackUrl: "https://cp.test/image-builds/build-failed",
+      callbackToken: "callback-token",
+    });
+    await client.terminateImageBuildSandbox({
+      buildId: "imgb-1",
+      providerSessionId: "mo-build-1",
+      reason: "image_build_complete",
+    });
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "https://acme-prod-web--open-inspect-api-create-build-sandbox.modal.run",
+      "https://acme-prod-web--open-inspect-api-start-build-sandbox.modal.run",
+      "https://acme-prod-web--open-inspect-api-terminate-build-sandbox.modal.run",
+    ]);
+    expect(JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string)).toEqual({
+      scope_kind: "repo",
+      scope_id: "acme/repo",
+      build_id: "imgb-1",
+      repositories: [{ repo_owner: "acme", repo_name: "repo", branch: "develop" }],
+      clone_token: "clone-token",
+      clone_host: "gitlab.com",
+      clone_username: "oauth2",
+      build_timeout_seconds: 2400,
+    });
+  });
+
   it("rejects malformed snapshot responses instead of trusting the payload", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ success: true, data: { image_id: 123 } }), {

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -223,6 +223,36 @@ export interface BuildImageResponse {
   status: string;
 }
 
+export interface CreateImageBuildSandboxRequest {
+  scopeKind: ImageBuildScopeKind;
+  scopeId: string;
+  buildId: string;
+  repositories: Array<{ repoOwner: string; repoName: string; baseBranch: string }>;
+  cloneToken?: string;
+  cloneHost?: string;
+  cloneUsername?: string;
+  userEnvVars?: Record<string, string>;
+  buildTimeoutSeconds?: number;
+}
+
+export interface CreateImageBuildSandboxResponse {
+  providerSessionId: string;
+}
+
+export interface StartImageBuildSandboxRequest {
+  buildId: string;
+  providerSessionId: string;
+  callbackUrl: string;
+  failureCallbackUrl: string;
+  callbackToken: string;
+}
+
+export interface TerminateImageBuildSandboxRequest {
+  buildId: string;
+  providerSessionId: string;
+  reason: string;
+}
+
 export interface DeleteProviderImageRequest {
   providerImageId: string;
 }
@@ -263,6 +293,9 @@ export class ModalClient {
   private snapshotBuildSandboxUrl: string;
   private restoreSandboxUrl: string;
   private buildImageUrl: string;
+  private createImageBuildSandboxUrl: string;
+  private startImageBuildSandboxUrl: string;
+  private terminateImageBuildSandboxUrl: string;
   private deleteProviderImageUrl: string;
   private secret: string;
 
@@ -280,6 +313,9 @@ export class ModalClient {
     this.snapshotBuildSandboxUrl = `${baseUrl}-api-snapshot-build-sandbox.modal.run`;
     this.restoreSandboxUrl = `${baseUrl}-api-restore-sandbox.modal.run`;
     this.buildImageUrl = `${baseUrl}-api-build-image.modal.run`;
+    this.createImageBuildSandboxUrl = `${baseUrl}-api-create-build-sandbox.modal.run`;
+    this.startImageBuildSandboxUrl = `${baseUrl}-api-start-build-sandbox.modal.run`;
+    this.terminateImageBuildSandboxUrl = `${baseUrl}-api-terminate-build-sandbox.modal.run`;
     this.deleteProviderImageUrl = `${baseUrl}-api-delete-provider-image.modal.run`;
   }
 
@@ -558,6 +594,144 @@ export class ModalClient {
 
       outcome = "success";
       return { success: true, imageId: result.data.image_id };
+    } finally {
+      log.info("modal.request", {
+        event: "modal.request",
+        endpoint,
+        build_id: request.buildId,
+        sandbox_id: request.providerSessionId,
+        trace_id: correlation?.trace_id,
+        request_id: correlation?.request_id,
+        http_status: httpStatus,
+        duration_ms: Date.now() - startTime,
+        outcome,
+      });
+    }
+  }
+
+  async createImageBuildSandbox(
+    request: CreateImageBuildSandboxRequest,
+    correlation?: CorrelationContext
+  ): Promise<CreateImageBuildSandboxResponse> {
+    const startTime = Date.now();
+    const endpoint = "createImageBuildSandbox";
+    let httpStatus: number | undefined;
+    let outcome: "success" | "error" = "error";
+
+    try {
+      const response = await fetch(this.createImageBuildSandboxUrl, {
+        method: "POST",
+        headers: await this.getPostHeaders(correlation),
+        body: JSON.stringify({
+          scope_kind: request.scopeKind,
+          scope_id: request.scopeId,
+          build_id: request.buildId,
+          repositories: request.repositories.map(toRepositoryConfigPayload),
+          clone_token: request.cloneToken,
+          clone_host: request.cloneHost,
+          clone_username: request.cloneUsername,
+          user_env_vars: request.userEnvVars,
+          build_timeout_seconds: request.buildTimeoutSeconds ?? null,
+        }),
+      });
+
+      httpStatus = response.status;
+      if (!response.ok) {
+        throw new ModalApiError(
+          `Modal API error: ${response.status} ${await response.text()}`,
+          response.status
+        );
+      }
+
+      const result = (await response.json()) as ModalApiResponse<{
+        provider_session_id: string;
+      }>;
+      if (!result.success || !result.data?.provider_session_id) {
+        throw new Error(`Modal API error: ${result.error || "Unknown error"}`);
+      }
+
+      outcome = "success";
+      return { providerSessionId: result.data.provider_session_id };
+    } finally {
+      log.info("modal.request", {
+        event: "modal.request",
+        endpoint,
+        build_id: request.buildId,
+        scope_kind: request.scopeKind,
+        scope_id: request.scopeId,
+        trace_id: correlation?.trace_id,
+        request_id: correlation?.request_id,
+        http_status: httpStatus,
+        duration_ms: Date.now() - startTime,
+        outcome,
+      });
+    }
+  }
+
+  async startImageBuildSandbox(
+    request: StartImageBuildSandboxRequest,
+    correlation?: CorrelationContext
+  ): Promise<void> {
+    await this.postImageBuildOperation(
+      this.startImageBuildSandboxUrl,
+      "startImageBuildSandbox",
+      request,
+      {
+        build_id: request.buildId,
+        provider_session_id: request.providerSessionId,
+        callback_url: request.callbackUrl,
+        failure_callback_url: request.failureCallbackUrl,
+        callback_token: request.callbackToken,
+      },
+      correlation
+    );
+  }
+
+  async terminateImageBuildSandbox(
+    request: TerminateImageBuildSandboxRequest,
+    correlation?: CorrelationContext
+  ): Promise<void> {
+    await this.postImageBuildOperation(
+      this.terminateImageBuildSandboxUrl,
+      "terminateImageBuildSandbox",
+      request,
+      {
+        build_id: request.buildId,
+        provider_session_id: request.providerSessionId,
+        reason: request.reason,
+      },
+      correlation
+    );
+  }
+
+  private async postImageBuildOperation(
+    url: string,
+    endpoint: string,
+    request: { buildId: string; providerSessionId: string },
+    body: Record<string, unknown>,
+    correlation?: CorrelationContext
+  ): Promise<void> {
+    const startTime = Date.now();
+    let httpStatus: number | undefined;
+    let outcome: "success" | "error" = "error";
+    try {
+      const response = await fetch(url, {
+        method: "POST",
+        headers: await this.getPostHeaders(correlation),
+        body: JSON.stringify(body),
+      });
+      httpStatus = response.status;
+      if (!response.ok) {
+        throw new ModalApiError(
+          `Modal API error: ${response.status} ${await response.text()}`,
+          response.status
+        );
+      }
+      const result = (await response.json()) as ModalApiResponse<Record<string, unknown>>;
+      if (!result.success) {
+        throw new Error(`Modal API error: ${result.error || "Unknown error"}`);
+      }
+      outcome = "success";
     } finally {
       log.info("modal.request", {
         event: "modal.request",

--- a/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
@@ -19,6 +19,10 @@ import type {
   SnapshotSandboxResponse,
   BuildImageRequest,
   BuildImageResponse,
+  CreateImageBuildSandboxRequest,
+  CreateImageBuildSandboxResponse,
+  StartImageBuildSandboxRequest,
+  TerminateImageBuildSandboxRequest,
   DeleteProviderImageRequest,
   DeleteProviderImageResponse,
 } from "../client";
@@ -32,6 +36,11 @@ function createMockModalClient(
     snapshotSandbox: (req: SnapshotSandboxRequest) => Promise<SnapshotSandboxResponse>;
     snapshotBuildSandbox: (req: SnapshotBuildSandboxRequest) => Promise<SnapshotSandboxResponse>;
     buildImage: (req: BuildImageRequest) => Promise<BuildImageResponse>;
+    createImageBuildSandbox: (
+      req: CreateImageBuildSandboxRequest
+    ) => Promise<CreateImageBuildSandboxResponse>;
+    startImageBuildSandbox: (req: StartImageBuildSandboxRequest) => Promise<void>;
+    terminateImageBuildSandbox: (req: TerminateImageBuildSandboxRequest) => Promise<void>;
     deleteProviderImage: (req: DeleteProviderImageRequest) => Promise<DeleteProviderImageResponse>;
   }> = {}
 ): ModalClient {
@@ -69,6 +78,13 @@ function createMockModalClient(
         status: "building",
       })
     ),
+    createImageBuildSandbox: vi.fn(
+      async (): Promise<CreateImageBuildSandboxResponse> => ({
+        providerSessionId: "modal-session-123",
+      })
+    ),
+    startImageBuildSandbox: vi.fn(async () => undefined),
+    terminateImageBuildSandbox: vi.fn(async () => undefined),
     deleteProviderImage: vi.fn(
       async (req: DeleteProviderImageRequest): Promise<DeleteProviderImageResponse> => ({
         providerImageId: req.providerImageId,
@@ -492,6 +508,51 @@ describe("ModalSandboxProvider", () => {
   });
 
   describe("image builds", () => {
+    it("creates, binds, then starts a provider-session build", async () => {
+      const client = createMockModalClient();
+      const provider = new ModalSandboxProvider(client);
+      const bindProviderSession = vi.fn(async () => undefined);
+
+      await expect(
+        provider.triggerEnvironmentImageBuild({
+          buildId: "build-123",
+          scopeKind: "repo",
+          scopeId: "acme/repo",
+          repositories: [{ repoOwner: "acme", repoName: "repo", baseBranch: "develop" }],
+          cloneToken: "clone-token",
+          cloneHost: "gitlab.com",
+          cloneUsername: "oauth2",
+          callbackUrl: "https://worker.test/image-builds/build-complete",
+          failureCallbackUrl: "https://worker.test/image-builds/build-failed",
+          callbackToken: "cb-token-1",
+          buildTimeoutMs: 1_800_000,
+          onProviderSessionCreated: bindProviderSession,
+        })
+      ).resolves.toEqual({ buildId: "build-123", status: "building" });
+
+      expect(client.createImageBuildSandbox).toHaveBeenCalledWith(
+        expect.objectContaining({
+          buildId: "build-123",
+          cloneToken: "clone-token",
+          cloneHost: "gitlab.com",
+          cloneUsername: "oauth2",
+          buildTimeoutSeconds: 1800,
+        }),
+        undefined
+      );
+      expect(bindProviderSession).toHaveBeenCalledWith("modal-session-123");
+      expect(client.startImageBuildSandbox).toHaveBeenCalledWith(
+        expect.objectContaining({
+          buildId: "build-123",
+          providerSessionId: "modal-session-123",
+        }),
+        undefined
+      );
+      expect(bindProviderSession.mock.invocationCallOrder[0]).toBeLessThan(
+        vi.mocked(client.startImageBuildSandbox).mock.invocationCallOrder[0]
+      );
+    });
+
     it("triggers image builds through the Modal client with scope fields", async () => {
       const client = createMockModalClient();
       const provider = new ModalSandboxProvider(client);

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -50,6 +50,30 @@ export interface TriggerModalImageBuildResult {
   status: string;
 }
 
+export interface TriggerModalEnvironmentImageBuildConfig {
+  buildId: string;
+  scopeKind: ImageBuildScopeKind;
+  scopeId: string;
+  repositories: Array<{ repoOwner: string; repoName: string; baseBranch: string }>;
+  cloneToken?: string;
+  cloneHost?: string;
+  cloneUsername?: string;
+  userEnvVars?: Record<string, string>;
+  buildTimeoutMs?: number;
+  callbackUrl: string;
+  failureCallbackUrl: string;
+  callbackToken: string;
+  onProviderSessionCreated: (providerSessionId: string) => Promise<void>;
+  correlation?: CorrelationContext;
+}
+
+export interface TerminateModalImageBuildConfig {
+  buildId: string;
+  providerSessionId: string;
+  reason: string;
+  correlation?: CorrelationContext;
+}
+
 export interface SnapshotModalImageBuildConfig {
   buildId: string;
   providerSessionId: string;
@@ -58,6 +82,10 @@ export interface SnapshotModalImageBuildConfig {
 
 export interface ModalImageBuildProvider {
   triggerImageBuild(config: TriggerModalImageBuildConfig): Promise<TriggerModalImageBuildResult>;
+  triggerEnvironmentImageBuild(
+    config: TriggerModalEnvironmentImageBuildConfig
+  ): Promise<TriggerModalImageBuildResult>;
+  terminateImageBuildSandbox(config: TerminateModalImageBuildConfig): Promise<void>;
   snapshotImageBuildSandbox(config: SnapshotModalImageBuildConfig): Promise<SnapshotResult>;
   deleteProviderImage(providerImageId: string, correlation?: CorrelationContext): Promise<void>;
 }
@@ -266,6 +294,54 @@ export class ModalSandboxProvider implements SandboxProvider, ModalImageBuildPro
     }
   }
 
+  async triggerEnvironmentImageBuild(
+    config: TriggerModalEnvironmentImageBuildConfig
+  ): Promise<TriggerModalImageBuildResult> {
+    try {
+      const created = await this.client.createImageBuildSandbox(
+        {
+          scopeKind: config.scopeKind,
+          scopeId: config.scopeId,
+          buildId: config.buildId,
+          repositories: config.repositories,
+          cloneToken: config.cloneToken,
+          cloneHost: config.cloneHost,
+          cloneUsername: config.cloneUsername,
+          userEnvVars: config.userEnvVars,
+          buildTimeoutSeconds:
+            config.buildTimeoutMs === undefined
+              ? undefined
+              : Math.ceil(config.buildTimeoutMs / MS_PER_SECOND),
+        },
+        config.correlation
+      );
+
+      await config.onProviderSessionCreated(created.providerSessionId);
+      await this.client.startImageBuildSandbox(
+        {
+          buildId: config.buildId,
+          providerSessionId: created.providerSessionId,
+          callbackUrl: config.callbackUrl,
+          failureCallbackUrl: config.failureCallbackUrl,
+          callbackToken: config.callbackToken,
+        },
+        config.correlation
+      );
+
+      return { buildId: config.buildId, status: "building" };
+    } catch (error) {
+      throw this.classifyImageBuildError("Failed to start Modal image build sandbox", error);
+    }
+  }
+
+  async terminateImageBuildSandbox(config: TerminateModalImageBuildConfig): Promise<void> {
+    try {
+      await this.client.terminateImageBuildSandbox(config, config.correlation);
+    } catch (error) {
+      throw this.classifyImageBuildError("Failed to terminate Modal image build sandbox", error);
+    }
+  }
+
   /**
    * Trigger a Modal scope-image build (design §4).
    */
@@ -332,6 +408,18 @@ export class ModalSandboxProvider implements SandboxProvider, ModalImageBuildPro
       }
       throw this.classifyError("Failed to delete Modal provider image", error);
     }
+  }
+
+  private classifyImageBuildError(message: string, error: unknown): SandboxProviderError {
+    if (error instanceof SandboxProviderError) return error;
+    if (error instanceof ModalApiError) {
+      return this.classifyErrorWithStatus(
+        `${message} with HTTP ${error.status}: ${error.message}`,
+        error.status,
+        error
+      );
+    }
+    return this.classifyError(message, error);
   }
 
   /**

--- a/packages/modal-infra/src/sandbox/build_session.py
+++ b/packages/modal-infra/src/sandbox/build_session.py
@@ -38,6 +38,8 @@ class ModalBuildSessionService:
         scope_id: str,
         repositories: list[dict],
         clone_token: str = "",
+        clone_host: str | None = None,
+        clone_username: str | None = None,
         user_env_vars: dict[str, str] | None = None,
         timeout_seconds: int = DEFAULT_BUILD_TIMEOUT_SECONDS,
     ) -> str:
@@ -64,7 +66,12 @@ class ModalBuildSessionService:
                 PROVIDER_SESSION_ID_ENV: "",
             }
         )
-        inject_vcs_env_vars(env_vars, clone_token or None)
+        inject_vcs_env_vars(
+            env_vars,
+            clone_token or None,
+            clone_host=clone_host,
+            clone_username=clone_username,
+        )
 
         sandbox = await modal.Sandbox.create.aio(
             "python",

--- a/packages/modal-infra/src/sandbox/vcs_env.py
+++ b/packages/modal-infra/src/sandbox/vcs_env.py
@@ -7,11 +7,16 @@ def inject_vcs_env_vars(
     env_vars: dict[str, str],
     clone_token: str | None,
     *,
+    clone_host: str | None = None,
+    clone_username: str | None = None,
     include_github_cli_aliases: bool = False,
 ) -> None:
     """Inject provider metadata and optional one-shot clone credentials."""
     scm_provider = os.environ.get("SCM_PROVIDER", "github")
-    if scm_provider == "bitbucket":
+    if clone_host and clone_username:
+        env_vars["VCS_HOST"] = clone_host
+        env_vars["VCS_CLONE_USERNAME"] = clone_username
+    elif scm_provider == "bitbucket":
         env_vars["VCS_HOST"] = "bitbucket.org"
         env_vars["VCS_CLONE_USERNAME"] = "x-token-auth"
     elif scm_provider == "gitlab":

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -601,6 +601,8 @@ async def api_create_build_sandbox(
             scope_id=scope_id,
             repositories=repositories,
             clone_token=request.get("clone_token") or "",
+            clone_host=request.get("clone_host") or None,
+            clone_username=request.get("clone_username") or None,
             user_env_vars=request.get("user_env_vars") or None,
             timeout_seconds=timeout_seconds,
         )

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -594,6 +594,8 @@ async def api_create_build_sandbox(
             default_seconds=DEFAULT_BUILD_TIMEOUT_SECONDS,
             max_seconds=MAX_BUILD_TIMEOUT_SECONDS,
         )
+        clone_host = _optional_string(request, "clone_host")
+        clone_username = _optional_string(request, "clone_username")
 
         provider_session_id = await ModalBuildSessionService().create(
             build_id=build_id,
@@ -601,8 +603,8 @@ async def api_create_build_sandbox(
             scope_id=scope_id,
             repositories=repositories,
             clone_token=request.get("clone_token") or "",
-            clone_host=request.get("clone_host") or None,
-            clone_username=request.get("clone_username") or None,
+            clone_host=clone_host,
+            clone_username=clone_username,
             user_env_vars=request.get("user_env_vars") or None,
             timeout_seconds=timeout_seconds,
         )
@@ -750,6 +752,15 @@ def _required_string(request: dict, field: str) -> str:
     value = request.get(field)
     if not isinstance(value, str) or not value:
         raise HTTPException(status_code=400, detail=f"{field} is required")
+    return value
+
+
+def _optional_string(request: dict, field: str) -> str | None:
+    value = request.get(field)
+    if value is None or value == "":
+        return None
+    if not isinstance(value, str):
+        raise HTTPException(status_code=400, detail=f"{field} must be a string")
     return value
 
 

--- a/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
+++ b/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
@@ -26,6 +26,9 @@ async def test_create_provider_session_build_is_dormant_tagged_and_scrubs_callba
         scope_kind="repo",
         scope_id="acme/repo",
         repositories=[{"repo_owner": "acme", "repo_name": "repo", "branch": "main"}],
+        clone_token="clone-token",
+        clone_host="gitlab.com",
+        clone_username="oauth2",
         user_env_vars={"OI_REPO_IMAGE_CALLBACK_TOKEN": "attacker-token"},
     )
 
@@ -33,6 +36,9 @@ async def test_create_provider_session_build_is_dormant_tagged_and_scrubs_callba
     assert create.aio.await_args.args[:2] == ("python", "-c")
     assert create.aio.await_args.kwargs["tags"]["openinspect_build_id"] == "build-1"
     assert create.aio.await_args.kwargs["env"]["OI_REPO_IMAGE_CALLBACK_TOKEN"] == ""
+    assert create.aio.await_args.kwargs["env"]["VCS_HOST"] == "gitlab.com"
+    assert create.aio.await_args.kwargs["env"]["VCS_CLONE_USERNAME"] == "oauth2"
+    assert create.aio.await_args.kwargs["env"]["VCS_CLONE_TOKEN"] == "clone-token"
 
 
 @pytest.mark.asyncio

--- a/packages/modal-infra/tests/test_web_api_build_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_build_sandbox.py
@@ -55,11 +55,24 @@ async def test_create_returns_provider_session_without_removing_legacy_endpoint(
             "scope_id": "acme/repo",
             "build_id": "imgb-1",
             "repositories": [{"repo_owner": "acme", "repo_name": "repo", "branch": "main"}],
+            "clone_token": "clone-token",
+            "clone_host": "gitlab.com",
+            "clone_username": "oauth2",
         },
     )
 
     assert result["data"]["provider_session_id"] == "modal-session-1"
-    service.create.assert_awaited_once()
+    service.create.assert_awaited_once_with(
+        build_id="imgb-1",
+        scope_kind="repo",
+        scope_id="acme/repo",
+        repositories=[{"repo_owner": "acme", "repo_name": "repo", "branch": "main"}],
+        clone_token="clone-token",
+        clone_host="gitlab.com",
+        clone_username="oauth2",
+        user_env_vars=None,
+        timeout_seconds=1800,
+    )
     assert hasattr(web_api, "api_build_image")
 
 

--- a/packages/modal-infra/tests/test_web_api_build_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_build_sandbox.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock
 import pytest
 
 from src import web_api
+from src.sandbox.manager import DEFAULT_BUILD_TIMEOUT_SECONDS
 
 
 def _patch_dependencies(monkeypatch: pytest.MonkeyPatch):
@@ -71,9 +72,36 @@ async def test_create_returns_provider_session_without_removing_legacy_endpoint(
         clone_host="gitlab.com",
         clone_username="oauth2",
         user_env_vars=None,
-        timeout_seconds=1800,
+        timeout_seconds=DEFAULT_BUILD_TIMEOUT_SECONDS,
     )
     assert hasattr(web_api, "api_build_image")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("clone_host", ["gitlab.com"]),
+        ("clone_host", {"host": "gitlab.com"}),
+        ("clone_username", 123),
+    ],
+)
+async def test_create_rejects_non_string_clone_fields(monkeypatch, field, value):
+    service = _patch_dependencies(monkeypatch)
+    request = {
+        "scope_kind": "repo",
+        "scope_id": "acme/repo",
+        "build_id": "imgb-1",
+        "repositories": [{"repo_owner": "acme", "repo_name": "repo", "branch": "main"}],
+        field: value,
+    }
+
+    with pytest.raises(web_api.HTTPException) as exc:
+        await _call(web_api.api_create_build_sandbox, request)
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == f"{field} must be a string"
+    service.create.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/terraform/environments/production/workers-control-plane.tf
+++ b/terraform/environments/production/workers-control-plane.tf
@@ -204,5 +204,6 @@ module "control_plane_worker" {
     module.vercel_sandbox_infra,
     module.opencomputer_infra,
     module.e2b_infra,
+    module.modal_app,
   ]
 }


### PR DESCRIPTION
## Summary

Makes Modal image builds use the same temporary provider-session lifecycle already used by Vercel and OpenComputer, without changing the existing callback finalization architecture.

## Architecture

1. Create a dormant Modal build sandbox.
2. Persist its provider session id in the control plane.
3. Start clone/setup only after that binding succeeds.
4. Reuse the existing callback + deferred snapshot path.
5. Terminate the build sandbox after success or failure.

Unbound Modal rows retain the legacy provider-image callback behavior so builds started before deployment can finish safely.

## Scope

- Adds the Modal create/bind/start provider facade and transport calls.
- Passes exact clone host, username, and token into the build sandbox.
- Routes newly bound Modal callbacks through the existing provider-session workflow.
- Retains the legacy Modal builder temporarily for deployment compatibility.
- Orders Modal deployment before the control-plane cutover.

Queue finalization and periodic rebuild/cleanup scheduling are intentionally split into stacked PR #1204.

## Validation

- Control plane: 2,167 unit tests
- Control-plane integration: 661 tests
- Modal infra: 243 tests
- TypeScript typecheck and ESLint
- Ruff lint and format
- Terraform format check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added sandbox-based image builds with provider-session tracking.
  - Added credential-helper authentication using repository host and username details.
  - Successful builds now finalize with an image snapshot.
  - Completed and failed builds automatically clean up their build sandboxes.
  - Improved build error classification and timeout handling.

- **Documentation**
  - Updated image pre-build guidance with snapshotting, lifecycle behavior, and rollout compatibility details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->