### PR TITLE
Add Modal provider-session image build endpoints

### DIFF
--- a/packages/control-plane/src/image-builds/modal-adapter.test.ts
+++ b/packages/control-plane/src/image-builds/modal-adapter.test.ts
@@ -6,6 +6,7 @@ import type { ModalImageBuildPlan } from "./types";
 function createProvider(): ModalImageBuildProvider {
   return {
     triggerImageBuild: vi.fn(async () => ({ buildId: "build-1", status: "building" })),
+    snapshotImageBuildSandbox: vi.fn(async () => ({ success: true, imageId: "modal-image-1" })),
     deleteProviderImage: vi.fn(async () => undefined),
   };
 }

--- a/packages/control-plane/src/sandbox/client.test.ts
+++ b/packages/control-plane/src/sandbox/client.test.ts
@@ -386,6 +386,34 @@ describe("ModalClient", () => {
     ).resolves.toEqual({ success: true, imageId: "img-1" });
   });
 
+  it("snapshots image builds through the identity-bound build endpoint", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ success: true, data: { image_id: "img-build-1" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+
+    const client = createModalClient("secret", "acme", "prod-web");
+    await expect(
+      client.snapshotBuildSandbox({
+        buildId: "imgb-1",
+        providerSessionId: "mo-build-1",
+      })
+    ).resolves.toEqual({ success: true, imageId: "img-build-1" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://acme-prod-web--open-inspect-api-snapshot-build-sandbox.modal.run",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          build_id: "imgb-1",
+          provider_session_id: "mo-build-1",
+        }),
+      })
+    );
+  });
+
   it("rejects malformed snapshot responses instead of trusting the payload", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ success: true, data: { image_id: 123 } }), {

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -191,6 +191,11 @@ export interface SnapshotSandboxResponse {
   error?: string;
 }
 
+export interface SnapshotBuildSandboxRequest {
+  buildId: string;
+  providerSessionId: string;
+}
+
 export interface BuildImageRequest {
   /** Scope kind ("repo" | "environment") — accepted by Modal for logging only. */
   scopeKind: ImageBuildScopeKind;
@@ -255,6 +260,7 @@ export class ModalApiError extends Error {
 export class ModalClient {
   private createSandboxUrl: string;
   private snapshotSandboxUrl: string;
+  private snapshotBuildSandboxUrl: string;
   private restoreSandboxUrl: string;
   private buildImageUrl: string;
   private deleteProviderImageUrl: string;
@@ -271,6 +277,7 @@ export class ModalClient {
     const baseUrl = getModalBaseUrl(workspace, environmentWebSuffix);
     this.createSandboxUrl = `${baseUrl}-api-create-sandbox.modal.run`;
     this.snapshotSandboxUrl = `${baseUrl}-api-snapshot-sandbox.modal.run`;
+    this.snapshotBuildSandboxUrl = `${baseUrl}-api-snapshot-build-sandbox.modal.run`;
     this.restoreSandboxUrl = `${baseUrl}-api-restore-sandbox.modal.run`;
     this.buildImageUrl = `${baseUrl}-api-build-image.modal.run`;
     this.deleteProviderImageUrl = `${baseUrl}-api-delete-provider-image.modal.run`;
@@ -500,6 +507,63 @@ export class ModalClient {
         endpoint,
         session_id: request.sessionId,
         sandbox_id: request.providerObjectId,
+        trace_id: correlation?.trace_id,
+        request_id: correlation?.request_id,
+        http_status: httpStatus,
+        duration_ms: Date.now() - startTime,
+        outcome,
+      });
+    }
+  }
+
+  /**
+   * Snapshot an image-build sandbox after Modal verifies its bound build tags.
+   */
+  async snapshotBuildSandbox(
+    request: SnapshotBuildSandboxRequest,
+    correlation?: CorrelationContext
+  ): Promise<SnapshotSandboxResponse> {
+    const startTime = Date.now();
+    const endpoint = "snapshotBuildSandbox";
+    let httpStatus: number | undefined;
+    let outcome: "success" | "error" = "error";
+
+    try {
+      const headers = await this.getPostHeaders(correlation);
+      const response = await fetch(this.snapshotBuildSandboxUrl, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          build_id: request.buildId,
+          provider_session_id: request.providerSessionId,
+        }),
+      });
+
+      httpStatus = response.status;
+      if (!response.ok) {
+        const text = await response.text();
+        throw new ModalApiError(`Modal API error: ${response.status} ${text}`, response.status);
+      }
+
+      const result = parseModalApiResponse(
+        snapshotSandboxModalResponseSchema,
+        await response.json()
+      );
+      if (!result.success) {
+        return { success: false, error: result.error || "Unknown snapshot error" };
+      }
+      if (!result.data?.image_id) {
+        return { success: false, error: "Snapshot response missing image_id" };
+      }
+
+      outcome = "success";
+      return { success: true, imageId: result.data.image_id };
+    } finally {
+      log.info("modal.request", {
+        event: "modal.request",
+        endpoint,
+        build_id: request.buildId,
+        sandbox_id: request.providerSessionId,
         trace_id: correlation?.trace_id,
         request_id: correlation?.request_id,
         http_status: httpStatus,

--- a/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
@@ -15,6 +15,7 @@ import type {
   RestoreSandboxRequest,
   RestoreSandboxResponse,
   SnapshotSandboxRequest,
+  SnapshotBuildSandboxRequest,
   SnapshotSandboxResponse,
   BuildImageRequest,
   BuildImageResponse,
@@ -29,6 +30,7 @@ function createMockModalClient(
     createSandbox: (req: CreateSandboxRequest) => Promise<CreateSandboxResponse>;
     restoreSandbox: (req: RestoreSandboxRequest) => Promise<RestoreSandboxResponse>;
     snapshotSandbox: (req: SnapshotSandboxRequest) => Promise<SnapshotSandboxResponse>;
+    snapshotBuildSandbox: (req: SnapshotBuildSandboxRequest) => Promise<SnapshotSandboxResponse>;
     buildImage: (req: BuildImageRequest) => Promise<BuildImageResponse>;
     deleteProviderImage: (req: DeleteProviderImageRequest) => Promise<DeleteProviderImageResponse>;
   }> = {}
@@ -53,6 +55,12 @@ function createMockModalClient(
       async (): Promise<SnapshotSandboxResponse> => ({
         success: true,
         imageId: "image-123",
+      })
+    ),
+    snapshotBuildSandbox: vi.fn(
+      async (): Promise<SnapshotSandboxResponse> => ({
+        success: true,
+        imageId: "build-image-123",
       })
     ),
     buildImage: vi.fn(
@@ -607,6 +615,28 @@ describe("ModalSandboxProvider", () => {
         expect(e).toBeInstanceOf(SandboxProviderError);
         expect((e as SandboxProviderError).errorType).toBe("transient");
       }
+    });
+
+    it("uses the identity-bound snapshot operation for image builds", async () => {
+      const snapshotBuildSandbox = vi.fn(async () => ({
+        success: true,
+        imageId: "build-image-123",
+      }));
+      const provider = new ModalSandboxProvider(createMockModalClient({ snapshotBuildSandbox }));
+
+      await expect(
+        provider.snapshotImageBuildSandbox({
+          buildId: "imgb-1",
+          providerSessionId: "modal-session-1",
+        })
+      ).resolves.toEqual({ success: true, imageId: "build-image-123" });
+      expect(snapshotBuildSandbox).toHaveBeenCalledWith(
+        {
+          buildId: "imgb-1",
+          providerSessionId: "modal-session-1",
+        },
+        undefined
+      );
     });
 
     it("returns providerObjectId from restoreFromSnapshot", async () => {

--- a/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.test.ts
@@ -639,6 +639,26 @@ describe("ModalSandboxProvider", () => {
       );
     });
 
+    it("preserves Modal API errors from image-build snapshots as the provider cause", async () => {
+      const modalError = new ModalApiError("Modal API error: 429 Too Many Requests", 429);
+      const provider = new ModalSandboxProvider(
+        createMockModalClient({
+          snapshotBuildSandbox: vi.fn(async () => {
+            throw modalError;
+          }),
+        })
+      );
+
+      await expect(
+        provider.snapshotImageBuildSandbox({
+          buildId: "imgb-1",
+          providerSessionId: "modal-session-1",
+        })
+      ).rejects.toMatchObject({
+        cause: modalError,
+      });
+    });
+
     it("returns providerObjectId from restoreFromSnapshot", async () => {
       const client = createMockModalClient({
         restoreSandbox: vi.fn(async () => ({

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -256,7 +256,8 @@ export class ModalSandboxProvider implements SandboxProvider, ModalImageBuildPro
       if (error instanceof ModalApiError) {
         throw this.classifyErrorWithStatus(
           `Image build snapshot failed with HTTP ${error.status}`,
-          error.status
+          error.status,
+          error
         );
       }
       if (error instanceof SandboxProviderError) throw error;

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -50,8 +50,15 @@ export interface TriggerModalImageBuildResult {
   status: string;
 }
 
+export interface SnapshotModalImageBuildConfig {
+  buildId: string;
+  providerSessionId: string;
+  correlation?: CorrelationContext;
+}
+
 export interface ModalImageBuildProvider {
   triggerImageBuild(config: TriggerModalImageBuildConfig): Promise<TriggerModalImageBuildResult>;
+  snapshotImageBuildSandbox(config: SnapshotModalImageBuildConfig): Promise<SnapshotResult>;
   deleteProviderImage(providerImageId: string, correlation?: CorrelationContext): Promise<void>;
 }
 
@@ -226,6 +233,34 @@ export class ModalSandboxProvider implements SandboxProvider, ModalImageBuildPro
         throw error;
       }
       throw this.classifyError("Failed to take snapshot", error);
+    }
+  }
+
+  async snapshotImageBuildSandbox(config: SnapshotModalImageBuildConfig): Promise<SnapshotResult> {
+    try {
+      const result = await this.client.snapshotBuildSandbox(
+        {
+          buildId: config.buildId,
+          providerSessionId: config.providerSessionId,
+        },
+        config.correlation
+      );
+      if (result.success && result.imageId) {
+        return { success: true, imageId: result.imageId };
+      }
+      return {
+        success: false,
+        error: result.error || "Unknown image build snapshot error",
+      };
+    } catch (error) {
+      if (error instanceof ModalApiError) {
+        throw this.classifyErrorWithStatus(
+          `Image build snapshot failed with HTTP ${error.status}`,
+          error.status
+        );
+      }
+      if (error instanceof SandboxProviderError) throw error;
+      throw this.classifyError("Failed to snapshot image build sandbox", error);
     }
   }
 

--- a/packages/modal-infra/src/sandbox/build_session.py
+++ b/packages/modal-infra/src/sandbox/build_session.py
@@ -1,0 +1,176 @@
+"""Modal provider-session lifecycle for environment image builds."""
+
+import json
+import time
+
+import modal
+from modal.stream_type import StreamType
+
+from sandbox_runtime.log_config import get_logger
+from sandbox_runtime.repo_image_callback import (
+    BUILD_ID_ENV,
+    CALLBACK_TOKEN_ENV,
+    CALLBACK_URL_ENV,
+    FAILURE_CALLBACK_URL_ENV,
+    PROVIDER_SESSION_ID_ENV,
+)
+
+from ..app import app
+from ..images.base import base_image
+from .manager import DEFAULT_BUILD_TIMEOUT_SECONDS, SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS
+from .vcs_env import inject_vcs_env_vars
+
+log = get_logger("build_session")
+
+
+class BuildSessionNotFoundError(LookupError):
+    """The requested provider session is absent or bound to another build."""
+
+
+class ModalBuildSessionService:
+    """Own the identity-bound lifecycle of one Modal image-build sandbox."""
+
+    async def create(
+        self,
+        *,
+        build_id: str,
+        scope_kind: str,
+        scope_id: str,
+        repositories: list[dict],
+        clone_token: str = "",
+        user_env_vars: dict[str, str] | None = None,
+        timeout_seconds: int = DEFAULT_BUILD_TIMEOUT_SECONDS,
+    ) -> str:
+        start_time = time.time()
+        primary = repositories[0]
+        env_vars = dict(user_env_vars or {})
+        env_vars.update(
+            {
+                "PYTHONUNBUFFERED": "1",
+                "SANDBOX_ID": f"build-{build_id}",
+                "REPO_OWNER": primary["repo_owner"],
+                "REPO_NAME": primary["repo_name"],
+                "IMAGE_BUILD_MODE": "true",
+                "SESSION_CONFIG": json.dumps(
+                    {
+                        "branch": primary["branch"],
+                        "repositories": repositories,
+                    }
+                ),
+                BUILD_ID_ENV: "",
+                CALLBACK_URL_ENV: "",
+                FAILURE_CALLBACK_URL_ENV: "",
+                CALLBACK_TOKEN_ENV: "",
+                PROVIDER_SESSION_ID_ENV: "",
+            }
+        )
+        inject_vcs_env_vars(env_vars, clone_token or None)
+
+        sandbox = await modal.Sandbox.create.aio(
+            "python",
+            "-c",
+            "import signal; signal.pause()",
+            image=base_image,
+            app=app,
+            secrets=[],
+            timeout=timeout_seconds,
+            workdir="/workspace",
+            env=env_vars,
+            tags={
+                "openinspect_kind": "image-build",
+                "openinspect_build_id": build_id,
+                "openinspect_scope_kind": scope_kind,
+                "openinspect_scope_id": scope_id,
+            },
+        )
+        log.info(
+            "sandbox.create_build",
+            build_id=build_id,
+            modal_object_id=sandbox.object_id,
+            repo_owner=primary["repo_owner"],
+            repo_name=primary["repo_name"],
+            duration_ms=int((time.time() - start_time) * 1000),
+            outcome="success",
+        )
+        return sandbox.object_id
+
+    async def start(
+        self,
+        *,
+        build_id: str,
+        provider_session_id: str,
+        callback_url: str,
+        failure_callback_url: str,
+        callback_token: str,
+    ) -> None:
+        sandbox = await self._resolve(build_id, provider_session_id)
+        await sandbox.exec.aio(
+            "python",
+            "-m",
+            "sandbox_runtime.entrypoint",
+            workdir="/workspace",
+            env={
+                BUILD_ID_ENV: build_id,
+                CALLBACK_URL_ENV: callback_url,
+                FAILURE_CALLBACK_URL_ENV: failure_callback_url,
+                CALLBACK_TOKEN_ENV: callback_token,
+                PROVIDER_SESSION_ID_ENV: provider_session_id,
+            },
+            stdout=StreamType.DEVNULL,
+            stderr=StreamType.DEVNULL,
+        )
+        log.info(
+            "sandbox.start_build",
+            build_id=build_id,
+            modal_object_id=provider_session_id,
+        )
+
+    async def terminate(
+        self,
+        *,
+        build_id: str,
+        provider_session_id: str,
+        reason: str,
+    ) -> None:
+        try:
+            sandbox = await self._resolve(build_id, provider_session_id)
+            await sandbox.terminate.aio()
+        except BuildSessionNotFoundError:
+            log.info(
+                "sandbox.terminate_build_not_found",
+                build_id=build_id,
+                modal_object_id=provider_session_id,
+                reason=reason,
+            )
+            return
+        log.info(
+            "sandbox.terminate_build",
+            build_id=build_id,
+            modal_object_id=provider_session_id,
+            reason=reason,
+        )
+
+    async def snapshot(self, *, build_id: str, provider_session_id: str) -> str:
+        sandbox = await self._resolve(build_id, provider_session_id)
+        image = sandbox.snapshot_filesystem(timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS)
+        log.info(
+            "sandbox.snapshot_build",
+            build_id=build_id,
+            modal_object_id=provider_session_id,
+            image_id=image.object_id,
+        )
+        return image.object_id
+
+    @staticmethod
+    async def _resolve(build_id: str, provider_session_id: str):
+        try:
+            sandbox = modal.Sandbox.from_id(provider_session_id)
+            tags = await sandbox.get_tags.aio()
+        except modal.exception.NotFoundError as e:
+            raise BuildSessionNotFoundError("build session not found") from e
+        if (
+            tags.get("openinspect_kind") != "image-build"
+            or tags.get("openinspect_build_id") != build_id
+        ):
+            raise BuildSessionNotFoundError("build session not found")
+        return sandbox

--- a/packages/modal-infra/src/sandbox/build_session.py
+++ b/packages/modal-infra/src/sandbox/build_session.py
@@ -152,7 +152,7 @@ class ModalBuildSessionService:
 
     async def snapshot(self, *, build_id: str, provider_session_id: str) -> str:
         sandbox = await self._resolve(build_id, provider_session_id)
-        image = sandbox.snapshot_filesystem(timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS)
+        image = await sandbox.snapshot_filesystem.aio(timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS)
         log.info(
             "sandbox.snapshot_build",
             build_id=build_id,

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -10,14 +10,12 @@ Updated: 2026-01-15 to fix Sandbox.create API
 
 import asyncio
 import json
-import os
 import secrets
 import time
 from dataclasses import dataclass
 from typing import Any
 
 import modal
-from modal.stream_type import StreamType
 
 from sandbox_runtime.constants import (
     CODE_SERVER_PORT,
@@ -29,17 +27,11 @@ from sandbox_runtime.constants import (
     TUNNEL_ENV_SANDBOX_ID_KEY,
 )
 from sandbox_runtime.log_config import get_logger
-from sandbox_runtime.repo_image_callback import (
-    BUILD_ID_ENV,
-    CALLBACK_TOKEN_ENV,
-    CALLBACK_URL_ENV,
-    FAILURE_CALLBACK_URL_ENV,
-    PROVIDER_SESSION_ID_ENV,
-)
 from sandbox_runtime.types import SandboxStatus, SessionConfig, SessionRepositoryConfig
 
 from ..app import app, llm_secrets
 from ..images.base import base_image
+from .vcs_env import inject_vcs_env_vars
 
 log = get_logger("manager")
 
@@ -323,55 +315,6 @@ class SandboxManager:
                 exc=e,
             )
 
-    @staticmethod
-    def _inject_vcs_env_vars(
-        env_vars: dict[str, str],
-        clone_token: str | None,
-        *,
-        include_github_cli_aliases: bool = False,
-    ) -> None:
-        """Inject SCM provider metadata into the sandbox environment.
-
-        For interactive sandboxes ``clone_token`` should be ``None``. Git
-        authenticates per-request via the system git credential helper, which
-        fetches a fresh token from the control plane — embedding a token in
-        env would silently fail once it expires (or immediately, for
-        providers with short-lived tokens like GitHub Apps).
-
-        For image-build sandboxes (one-shot, no control-plane access)
-        ``clone_token`` is required: the helper falls back to the env-var
-        token when ``CONTROL_PLANE_URL`` / ``SANDBOX_AUTH_TOKEN`` are unset.
-
-        ``include_github_cli_aliases`` adds fallback ``GITHUB_TOKEN`` /
-        ``GITHUB_APP_TOKEN`` for legacy snapshots that predate the
-        gh wrapper. These aliases are only injected when the user has not
-        provided a GitHub CLI token. Fallback injection is marked with
-        ``OI_GITHUB_TOKEN_IS_FALLBACK=1`` so helper-capable boots refresh past
-        the static restore token, while genuine user-provided tokens remain
-        authoritative.
-        """
-        scm_provider = os.environ.get("SCM_PROVIDER", "github")
-        if scm_provider == "bitbucket":
-            env_vars["VCS_HOST"] = "bitbucket.org"
-            env_vars["VCS_CLONE_USERNAME"] = "x-token-auth"
-        elif scm_provider == "gitlab":
-            env_vars["VCS_HOST"] = "gitlab.com"
-            env_vars["VCS_CLONE_USERNAME"] = "oauth2"
-        else:
-            env_vars["VCS_HOST"] = "github.com"
-            env_vars["VCS_CLONE_USERNAME"] = "x-access-token"
-
-        if clone_token:
-            env_vars["VCS_CLONE_TOKEN"] = clone_token
-            if include_github_cli_aliases and scm_provider == "github":
-                has_user_github_cli_token = any(
-                    env_vars.get(key) for key in ("GH_TOKEN", "GITHUB_TOKEN", "GITHUB_APP_TOKEN")
-                )
-                if not has_user_github_cli_token:
-                    env_vars["GITHUB_TOKEN"] = clone_token
-                    env_vars["GITHUB_APP_TOKEN"] = clone_token
-                    env_vars["OI_GITHUB_TOKEN_IS_FALLBACK"] = "1"
-
     async def create_sandbox(
         self,
         config: SandboxConfig,
@@ -421,7 +364,7 @@ class SandboxManager:
         # repository so GitLab/Bitbucket deployments don't fall back to github.com
         # credential-helper behavior; clone tokens stay repository-gated.
         fallback_clone_token = config.fallback_clone_token if has_repository else None
-        self._inject_vcs_env_vars(
+        inject_vcs_env_vars(
             env_vars,
             clone_token=fallback_clone_token,
             include_github_cli_aliases=bool(fallback_clone_token),
@@ -571,7 +514,7 @@ class SandboxManager:
             }
         )
 
-        self._inject_vcs_env_vars(env_vars, clone_token or None)
+        inject_vcs_env_vars(env_vars, clone_token or None)
 
         sandbox = await modal.Sandbox.create.aio(
             "python",
@@ -604,157 +547,6 @@ class SandboxManager:
             created_at=time.time(),
             modal_object_id=modal_object_id,
         )
-
-    async def create_provider_session_build_sandbox(
-        self,
-        build_id: str,
-        scope_kind: str,
-        scope_id: str,
-        repositories: list[dict],
-        clone_token: str = "",
-        user_env_vars: dict[str, str] | None = None,
-        timeout_seconds: int = DEFAULT_BUILD_TIMEOUT_SECONDS,
-    ) -> SandboxHandle:
-        """Create a dormant, tagged sandbox for a later bound build start."""
-        start_time = time.time()
-        primary = repositories[0]
-        repo_owner = primary["repo_owner"]
-        repo_name = primary["repo_name"]
-        sandbox_id = f"build-{build_id}"
-        env_vars = dict(user_env_vars or {})
-        env_vars.update(
-            {
-                "PYTHONUNBUFFERED": "1",
-                "SANDBOX_ID": sandbox_id,
-                "REPO_OWNER": repo_owner,
-                "REPO_NAME": repo_name,
-                "IMAGE_BUILD_MODE": "true",
-                "SESSION_CONFIG": json.dumps(
-                    {
-                        "branch": primary["branch"],
-                        "repositories": repositories,
-                    }
-                ),
-                BUILD_ID_ENV: "",
-                CALLBACK_URL_ENV: "",
-                FAILURE_CALLBACK_URL_ENV: "",
-                CALLBACK_TOKEN_ENV: "",
-                PROVIDER_SESSION_ID_ENV: "",
-            }
-        )
-        self._inject_vcs_env_vars(env_vars, clone_token or None)
-
-        sandbox = await modal.Sandbox.create.aio(
-            "python",
-            "-c",
-            "import signal; signal.pause()",
-            image=base_image,
-            app=app,
-            secrets=[],
-            timeout=timeout_seconds,
-            workdir="/workspace",
-            env=env_vars,
-            tags={
-                "openinspect_kind": "image-build",
-                "openinspect_build_id": build_id,
-                "openinspect_scope_kind": scope_kind,
-                "openinspect_scope_id": scope_id,
-            },
-        )
-
-        modal_object_id = sandbox.object_id
-        log.info(
-            "sandbox.create_provider_session_build",
-            sandbox_id=sandbox_id,
-            modal_object_id=modal_object_id,
-            repo_owner=repo_owner,
-            repo_name=repo_name,
-            build_id=build_id,
-            duration_ms=int((time.time() - start_time) * 1000),
-            outcome="success",
-        )
-        return SandboxHandle(
-            sandbox_id=sandbox_id,
-            modal_sandbox=sandbox,
-            status=SandboxStatus.WARMING,
-            created_at=time.time(),
-            modal_object_id=modal_object_id,
-        )
-
-    async def start_build_sandbox(
-        self,
-        build_id: str,
-        provider_session_id: str,
-        callback_url: str,
-        failure_callback_url: str,
-        callback_token: str,
-    ) -> None:
-        """Launch the runtime only after the control plane binds the exact sandbox."""
-        sandbox = await self._resolve_build_sandbox(build_id, provider_session_id)
-        await sandbox.exec.aio(
-            "python",
-            "-m",
-            "sandbox_runtime.entrypoint",
-            env={
-                BUILD_ID_ENV: build_id,
-                CALLBACK_URL_ENV: callback_url,
-                FAILURE_CALLBACK_URL_ENV: failure_callback_url,
-                CALLBACK_TOKEN_ENV: callback_token,
-                PROVIDER_SESSION_ID_ENV: provider_session_id,
-            },
-            stdout=StreamType.DEVNULL,
-            stderr=StreamType.DEVNULL,
-        )
-
-    async def terminate_build_sandbox(
-        self,
-        build_id: str,
-        provider_session_id: str,
-        reason: str,
-    ) -> None:
-        """Terminate only a sandbox carrying the exact image-build tags."""
-        try:
-            sandbox = await self._resolve_build_sandbox(build_id, provider_session_id)
-            await sandbox.terminate.aio()
-        except modal.exception.NotFoundError:
-            log.info(
-                "sandbox.terminate_build_not_found",
-                build_id=build_id,
-                modal_object_id=provider_session_id,
-                reason=reason,
-            )
-            return
-        log.info(
-            "sandbox.terminate_build",
-            build_id=build_id,
-            modal_object_id=provider_session_id,
-            reason=reason,
-        )
-
-    async def get_build_sandbox_handle(
-        self,
-        build_id: str,
-        provider_session_id: str,
-    ) -> SandboxHandle:
-        """Resolve a build sandbox only after verifying its exact provider tags."""
-        sandbox = await self._resolve_build_sandbox(build_id, provider_session_id)
-        return SandboxHandle(
-            sandbox_id=f"build-{build_id}",
-            modal_sandbox=sandbox,
-            status=SandboxStatus.READY,
-            created_at=time.time(),
-            modal_object_id=provider_session_id,
-        )
-
-    async def _resolve_build_sandbox(self, build_id: str, provider_session_id: str):
-        sandbox = modal.Sandbox.from_id(provider_session_id)
-        tags = await sandbox.get_tags.aio()
-        if (
-            tags.get("openinspect_kind") != "image-build"
-            or tags.get("openinspect_build_id") != build_id
-        ):
-            raise ValueError("sandbox tags do not match the requested image build")
-        return sandbox
 
     def take_snapshot(
         self,
@@ -909,7 +701,7 @@ class SandboxManager:
         # Host scoping is injected even without a repository (matches
         # create_sandbox); clone tokens stay repository-gated.
         restore_clone_token = clone_token if has_repository else None
-        self._inject_vcs_env_vars(
+        inject_vcs_env_vars(
             env_vars, clone_token=restore_clone_token, include_github_cli_aliases=True
         )
 

--- a/packages/modal-infra/src/sandbox/manager.py
+++ b/packages/modal-infra/src/sandbox/manager.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import modal
+from modal.stream_type import StreamType
 
 from sandbox_runtime.constants import (
     CODE_SERVER_PORT,
@@ -28,6 +29,13 @@ from sandbox_runtime.constants import (
     TUNNEL_ENV_SANDBOX_ID_KEY,
 )
 from sandbox_runtime.log_config import get_logger
+from sandbox_runtime.repo_image_callback import (
+    BUILD_ID_ENV,
+    CALLBACK_TOKEN_ENV,
+    CALLBACK_URL_ENV,
+    FAILURE_CALLBACK_URL_ENV,
+    PROVIDER_SESSION_ID_ENV,
+)
 from sandbox_runtime.types import SandboxStatus, SessionConfig, SessionRepositoryConfig
 
 from ..app import app, llm_secrets
@@ -596,6 +604,157 @@ class SandboxManager:
             created_at=time.time(),
             modal_object_id=modal_object_id,
         )
+
+    async def create_provider_session_build_sandbox(
+        self,
+        build_id: str,
+        scope_kind: str,
+        scope_id: str,
+        repositories: list[dict],
+        clone_token: str = "",
+        user_env_vars: dict[str, str] | None = None,
+        timeout_seconds: int = DEFAULT_BUILD_TIMEOUT_SECONDS,
+    ) -> SandboxHandle:
+        """Create a dormant, tagged sandbox for a later bound build start."""
+        start_time = time.time()
+        primary = repositories[0]
+        repo_owner = primary["repo_owner"]
+        repo_name = primary["repo_name"]
+        sandbox_id = f"build-{build_id}"
+        env_vars = dict(user_env_vars or {})
+        env_vars.update(
+            {
+                "PYTHONUNBUFFERED": "1",
+                "SANDBOX_ID": sandbox_id,
+                "REPO_OWNER": repo_owner,
+                "REPO_NAME": repo_name,
+                "IMAGE_BUILD_MODE": "true",
+                "SESSION_CONFIG": json.dumps(
+                    {
+                        "branch": primary["branch"],
+                        "repositories": repositories,
+                    }
+                ),
+                BUILD_ID_ENV: "",
+                CALLBACK_URL_ENV: "",
+                FAILURE_CALLBACK_URL_ENV: "",
+                CALLBACK_TOKEN_ENV: "",
+                PROVIDER_SESSION_ID_ENV: "",
+            }
+        )
+        self._inject_vcs_env_vars(env_vars, clone_token or None)
+
+        sandbox = await modal.Sandbox.create.aio(
+            "python",
+            "-c",
+            "import signal; signal.pause()",
+            image=base_image,
+            app=app,
+            secrets=[],
+            timeout=timeout_seconds,
+            workdir="/workspace",
+            env=env_vars,
+            tags={
+                "openinspect_kind": "image-build",
+                "openinspect_build_id": build_id,
+                "openinspect_scope_kind": scope_kind,
+                "openinspect_scope_id": scope_id,
+            },
+        )
+
+        modal_object_id = sandbox.object_id
+        log.info(
+            "sandbox.create_provider_session_build",
+            sandbox_id=sandbox_id,
+            modal_object_id=modal_object_id,
+            repo_owner=repo_owner,
+            repo_name=repo_name,
+            build_id=build_id,
+            duration_ms=int((time.time() - start_time) * 1000),
+            outcome="success",
+        )
+        return SandboxHandle(
+            sandbox_id=sandbox_id,
+            modal_sandbox=sandbox,
+            status=SandboxStatus.WARMING,
+            created_at=time.time(),
+            modal_object_id=modal_object_id,
+        )
+
+    async def start_build_sandbox(
+        self,
+        build_id: str,
+        provider_session_id: str,
+        callback_url: str,
+        failure_callback_url: str,
+        callback_token: str,
+    ) -> None:
+        """Launch the runtime only after the control plane binds the exact sandbox."""
+        sandbox = await self._resolve_build_sandbox(build_id, provider_session_id)
+        await sandbox.exec.aio(
+            "python",
+            "-m",
+            "sandbox_runtime.entrypoint",
+            env={
+                BUILD_ID_ENV: build_id,
+                CALLBACK_URL_ENV: callback_url,
+                FAILURE_CALLBACK_URL_ENV: failure_callback_url,
+                CALLBACK_TOKEN_ENV: callback_token,
+                PROVIDER_SESSION_ID_ENV: provider_session_id,
+            },
+            stdout=StreamType.DEVNULL,
+            stderr=StreamType.DEVNULL,
+        )
+
+    async def terminate_build_sandbox(
+        self,
+        build_id: str,
+        provider_session_id: str,
+        reason: str,
+    ) -> None:
+        """Terminate only a sandbox carrying the exact image-build tags."""
+        try:
+            sandbox = await self._resolve_build_sandbox(build_id, provider_session_id)
+            await sandbox.terminate.aio()
+        except modal.exception.NotFoundError:
+            log.info(
+                "sandbox.terminate_build_not_found",
+                build_id=build_id,
+                modal_object_id=provider_session_id,
+                reason=reason,
+            )
+            return
+        log.info(
+            "sandbox.terminate_build",
+            build_id=build_id,
+            modal_object_id=provider_session_id,
+            reason=reason,
+        )
+
+    async def get_build_sandbox_handle(
+        self,
+        build_id: str,
+        provider_session_id: str,
+    ) -> SandboxHandle:
+        """Resolve a build sandbox only after verifying its exact provider tags."""
+        sandbox = await self._resolve_build_sandbox(build_id, provider_session_id)
+        return SandboxHandle(
+            sandbox_id=f"build-{build_id}",
+            modal_sandbox=sandbox,
+            status=SandboxStatus.READY,
+            created_at=time.time(),
+            modal_object_id=provider_session_id,
+        )
+
+    async def _resolve_build_sandbox(self, build_id: str, provider_session_id: str):
+        sandbox = modal.Sandbox.from_id(provider_session_id)
+        tags = await sandbox.get_tags.aio()
+        if (
+            tags.get("openinspect_kind") != "image-build"
+            or tags.get("openinspect_build_id") != build_id
+        ):
+            raise ValueError("sandbox tags do not match the requested image build")
+        return sandbox
 
     def take_snapshot(
         self,

--- a/packages/modal-infra/src/sandbox/vcs_env.py
+++ b/packages/modal-infra/src/sandbox/vcs_env.py
@@ -1,0 +1,35 @@
+"""SCM credential environment shared by interactive and build sandboxes."""
+
+import os
+
+
+def inject_vcs_env_vars(
+    env_vars: dict[str, str],
+    clone_token: str | None,
+    *,
+    include_github_cli_aliases: bool = False,
+) -> None:
+    """Inject provider metadata and optional one-shot clone credentials."""
+    scm_provider = os.environ.get("SCM_PROVIDER", "github")
+    if scm_provider == "bitbucket":
+        env_vars["VCS_HOST"] = "bitbucket.org"
+        env_vars["VCS_CLONE_USERNAME"] = "x-token-auth"
+    elif scm_provider == "gitlab":
+        env_vars["VCS_HOST"] = "gitlab.com"
+        env_vars["VCS_CLONE_USERNAME"] = "oauth2"
+    else:
+        env_vars["VCS_HOST"] = "github.com"
+        env_vars["VCS_CLONE_USERNAME"] = "x-access-token"
+
+    if not clone_token:
+        return
+
+    env_vars["VCS_CLONE_TOKEN"] = clone_token
+    if include_github_cli_aliases and scm_provider == "github":
+        has_user_github_cli_token = any(
+            env_vars.get(key) for key in ("GH_TOKEN", "GITHUB_TOKEN", "GITHUB_APP_TOKEN")
+        )
+        if not has_user_github_cli_token:
+            env_vars["GITHUB_TOKEN"] = clone_token
+            env_vars["GITHUB_APP_TOKEN"] = clone_token
+            env_vars["OI_GITHUB_TOKEN_IS_FALLBACK"] = "1"

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -290,8 +290,13 @@ async def api_snapshot_sandbox(
 
         manager = SandboxManager()
 
-        # Get the sandbox handle by ID
-        handle = await manager.get_sandbox_by_id(sandbox_id)
+        # Provider-session image finalization must verify the exact build tags.
+        if reason == "environment_image_build":
+            if not session_id:
+                raise HTTPException(status_code=400, detail="session_id is required")
+            handle = await manager.get_build_sandbox_handle(session_id, sandbox_id)
+        else:
+            handle = await manager.get_sandbox_by_id(sandbox_id)
         if not handle:
             raise HTTPException(status_code=404, detail=f"Sandbox not found: {sandbox_id}")
 
@@ -466,6 +471,117 @@ async def api_restore_sandbox(
             session_id=x_session_id,
             sandbox_id=x_sandbox_id,
         )
+
+
+@app.function(image=function_image, secrets=[internal_api_secret])
+@fastapi_endpoint(method="POST")
+async def api_create_build_sandbox(
+    request: dict,
+    authorization: str | None = Header(None),
+    x_trace_id: str | None = Header(None),
+    x_request_id: str | None = Header(None),
+) -> dict:
+    """Create a dormant provider-session build sandbox."""
+    require_auth(authorization)
+
+    from .sandbox.manager import DEFAULT_BUILD_TIMEOUT_SECONDS, SandboxManager
+
+    build_id = _required_string(request, "build_id")
+    scope_kind = _required_string(request, "scope_kind")
+    scope_id = _required_string(request, "scope_id")
+    if scope_kind not in {"repo", "environment"}:
+        raise HTTPException(status_code=400, detail="scope_kind must be repo or environment")
+    repositories = _validated_build_repositories(request.get("repositories"))
+    timeout_seconds = int(request.get("build_timeout_seconds") or DEFAULT_BUILD_TIMEOUT_SECONDS)
+
+    handle = await SandboxManager().create_provider_session_build_sandbox(
+        build_id=build_id,
+        scope_kind=scope_kind,
+        scope_id=scope_id,
+        repositories=repositories,
+        clone_token=request.get("clone_token") or "",
+        user_env_vars=request.get("user_env_vars") or None,
+        timeout_seconds=timeout_seconds,
+    )
+    return {
+        "success": True,
+        "data": {"provider_session_id": handle.modal_object_id},
+    }
+
+
+@app.function(image=function_image, secrets=[internal_api_secret])
+@fastapi_endpoint(method="POST")
+async def api_start_build_sandbox(
+    request: dict,
+    authorization: str | None = Header(None),
+    x_trace_id: str | None = Header(None),
+    x_request_id: str | None = Header(None),
+) -> dict:
+    """Start a build only after its provider session is bound in D1."""
+    require_auth(authorization)
+
+    from .sandbox.manager import SandboxManager
+
+    callback_url = _required_string(request, "callback_url")
+    failure_callback_url = _required_string(request, "failure_callback_url")
+    if not validate_control_plane_url(callback_url) or not validate_control_plane_url(
+        failure_callback_url
+    ):
+        raise HTTPException(status_code=400, detail="callback URLs must target the control plane")
+
+    await SandboxManager().start_build_sandbox(
+        build_id=_required_string(request, "build_id"),
+        provider_session_id=_required_string(request, "provider_session_id"),
+        callback_url=callback_url,
+        failure_callback_url=failure_callback_url,
+        callback_token=_required_string(request, "callback_token"),
+    )
+    return {"success": True, "data": {"started": True}}
+
+
+@app.function(image=function_image, secrets=[internal_api_secret])
+@fastapi_endpoint(method="POST")
+async def api_terminate_build_sandbox(
+    request: dict,
+    authorization: str | None = Header(None),
+    x_trace_id: str | None = Header(None),
+    x_request_id: str | None = Header(None),
+) -> dict:
+    """Terminate the exactly tagged provider-session build sandbox."""
+    require_auth(authorization)
+
+    from .sandbox.manager import SandboxManager
+
+    await SandboxManager().terminate_build_sandbox(
+        build_id=_required_string(request, "build_id"),
+        provider_session_id=_required_string(request, "provider_session_id"),
+        reason=_required_string(request, "reason"),
+    )
+    return {"success": True, "data": {"terminated": True}}
+
+
+def _required_string(request: dict, field: str) -> str:
+    value = request.get(field)
+    if not isinstance(value, str) or not value:
+        raise HTTPException(status_code=400, detail=f"{field} is required")
+    return value
+
+
+def _validated_build_repositories(value: object) -> list[dict]:
+    if not isinstance(value, list) or not value:
+        raise HTTPException(status_code=400, detail="repositories must be a non-empty list")
+    for entry in value:
+        if (
+            not isinstance(entry, dict)
+            or not entry.get("repo_owner")
+            or not entry.get("repo_name")
+            or not entry.get("branch")
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="repositories entries require repo_owner, repo_name, and branch",
+            )
+    return value
 
 
 @app.function(

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -12,9 +12,12 @@ The control plane must include an Authorization header with a valid token.
 """
 
 import time
+from pathlib import Path
 
 from fastapi import Header, HTTPException
 from modal import fastapi_endpoint
+
+from sandbox_runtime.repo_config import RepoConfigError, parse_repositories
 
 from .app import (
     app,
@@ -290,13 +293,7 @@ async def api_snapshot_sandbox(
 
         manager = SandboxManager()
 
-        # Provider-session image finalization must verify the exact build tags.
-        if reason == "environment_image_build":
-            if not session_id:
-                raise HTTPException(status_code=400, detail="session_id is required")
-            handle = await manager.get_build_sandbox_handle(session_id, sandbox_id)
-        else:
-            handle = await manager.get_sandbox_by_id(sandbox_id)
+        handle = await manager.get_sandbox_by_id(sandbox_id)
         if not handle:
             raise HTTPException(status_code=404, detail=f"Sandbox not found: {sandbox_id}")
 
@@ -335,6 +332,72 @@ async def api_snapshot_sandbox(
             request_id=x_request_id,
             session_id=x_session_id,
             sandbox_id=x_sandbox_id or sandbox_id,
+        )
+
+
+@app.function(image=function_image, secrets=[internal_api_secret])
+@fastapi_endpoint(method="POST")
+async def api_snapshot_build_sandbox(
+    request: dict,
+    authorization: str | None = Header(None),
+    x_trace_id: str | None = Header(None),
+    x_request_id: str | None = Header(None),
+) -> dict:
+    """Snapshot the exact provider session bound to an image build."""
+    start_time = time.time()
+    http_status = 200
+    outcome = "success"
+    build_id = request.get("build_id")
+    provider_session_id = request.get("provider_session_id")
+
+    require_auth(authorization)
+
+    try:
+        from .sandbox.build_session import (
+            BuildSessionNotFoundError,
+            ModalBuildSessionService,
+        )
+
+        build_id = _required_string(request, "build_id")
+        provider_session_id = _required_string(request, "provider_session_id")
+        image_id = await ModalBuildSessionService().snapshot(
+            build_id=build_id,
+            provider_session_id=provider_session_id,
+        )
+        return {
+            "success": True,
+            "data": {
+                "image_id": image_id,
+                "build_id": build_id,
+                "provider_session_id": provider_session_id,
+            },
+        }
+    except BuildSessionNotFoundError as e:
+        outcome = "error"
+        http_status = 404
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except HTTPException as e:
+        outcome = "error"
+        http_status = e.status_code
+        raise
+    except Exception as e:
+        outcome = "error"
+        http_status = 500
+        log.error("api.error", exc=e, endpoint_name="api_snapshot_build_sandbox")
+        return {"success": False, "error": str(e)}
+    finally:
+        log.info(
+            "modal.http_request",
+            http_method="POST",
+            http_path="/api_snapshot_build_sandbox",
+            http_status=http_status,
+            duration_ms=int((time.time() - start_time) * 1000),
+            outcome=outcome,
+            endpoint_name="api_snapshot_build_sandbox",
+            trace_id=x_trace_id,
+            request_id=x_request_id,
+            build_id=build_id,
+            sandbox_id=provider_session_id,
         )
 
 
@@ -482,31 +545,68 @@ async def api_create_build_sandbox(
     x_request_id: str | None = Header(None),
 ) -> dict:
     """Create a dormant provider-session build sandbox."""
+    start_time = time.time()
+    http_status = 200
+    outcome = "success"
+    build_id = request.get("build_id")
+    provider_session_id = None
+
     require_auth(authorization)
 
-    from .sandbox.manager import DEFAULT_BUILD_TIMEOUT_SECONDS, SandboxManager
+    try:
+        from .sandbox.build_session import ModalBuildSessionService
+        from .sandbox.manager import (
+            DEFAULT_BUILD_TIMEOUT_SECONDS,
+            MAX_BUILD_TIMEOUT_SECONDS,
+        )
 
-    build_id = _required_string(request, "build_id")
-    scope_kind = _required_string(request, "scope_kind")
-    scope_id = _required_string(request, "scope_id")
-    if scope_kind not in {"repo", "environment"}:
-        raise HTTPException(status_code=400, detail="scope_kind must be repo or environment")
-    repositories = _validated_build_repositories(request.get("repositories"))
-    timeout_seconds = int(request.get("build_timeout_seconds") or DEFAULT_BUILD_TIMEOUT_SECONDS)
+        build_id = _required_string(request, "build_id")
+        scope_kind = _required_string(request, "scope_kind")
+        scope_id = _required_string(request, "scope_id")
+        if scope_kind not in {"repo", "environment"}:
+            raise HTTPException(status_code=400, detail="scope_kind must be repo or environment")
+        repositories = _validated_build_repositories(request.get("repositories"))
+        timeout_seconds = _validated_timeout_seconds(
+            request,
+            "build_timeout_seconds",
+            default_seconds=DEFAULT_BUILD_TIMEOUT_SECONDS,
+            max_seconds=MAX_BUILD_TIMEOUT_SECONDS,
+        )
 
-    handle = await SandboxManager().create_provider_session_build_sandbox(
-        build_id=build_id,
-        scope_kind=scope_kind,
-        scope_id=scope_id,
-        repositories=repositories,
-        clone_token=request.get("clone_token") or "",
-        user_env_vars=request.get("user_env_vars") or None,
-        timeout_seconds=timeout_seconds,
-    )
-    return {
-        "success": True,
-        "data": {"provider_session_id": handle.modal_object_id},
-    }
+        provider_session_id = await ModalBuildSessionService().create(
+            build_id=build_id,
+            scope_kind=scope_kind,
+            scope_id=scope_id,
+            repositories=repositories,
+            clone_token=request.get("clone_token") or "",
+            user_env_vars=request.get("user_env_vars") or None,
+            timeout_seconds=timeout_seconds,
+        )
+        return {
+            "success": True,
+            "data": {"provider_session_id": provider_session_id},
+        }
+    except HTTPException as e:
+        outcome = "error"
+        http_status = e.status_code
+        raise
+    except Exception as e:
+        outcome = "error"
+        http_status = 500
+        log.error("api.error", exc=e, endpoint_name="api_create_build_sandbox")
+        return {"success": False, "error": str(e)}
+    finally:
+        _log_build_http_request(
+            start_time=start_time,
+            http_path="/api_create_build_sandbox",
+            http_status=http_status,
+            outcome=outcome,
+            endpoint_name="api_create_build_sandbox",
+            trace_id=x_trace_id,
+            request_id=x_request_id,
+            build_id=build_id,
+            provider_session_id=provider_session_id,
+        )
 
 
 @app.function(image=function_image, secrets=[internal_api_secret])
@@ -518,25 +618,57 @@ async def api_start_build_sandbox(
     x_request_id: str | None = Header(None),
 ) -> dict:
     """Start a build only after its provider session is bound in D1."""
+    start_time = time.time()
+    http_status = 200
+    outcome = "success"
+    build_id = request.get("build_id")
+    provider_session_id = request.get("provider_session_id")
+
     require_auth(authorization)
 
-    from .sandbox.manager import SandboxManager
+    try:
+        from .sandbox.build_session import ModalBuildSessionService
 
-    callback_url = _required_string(request, "callback_url")
-    failure_callback_url = _required_string(request, "failure_callback_url")
-    if not validate_control_plane_url(callback_url) or not validate_control_plane_url(
-        failure_callback_url
-    ):
-        raise HTTPException(status_code=400, detail="callback URLs must target the control plane")
+        callback_url = _required_string(request, "callback_url")
+        failure_callback_url = _required_string(request, "failure_callback_url")
+        if not validate_control_plane_url(callback_url) or not validate_control_plane_url(
+            failure_callback_url
+        ):
+            raise HTTPException(
+                status_code=400, detail="callback URLs must target the control plane"
+            )
 
-    await SandboxManager().start_build_sandbox(
-        build_id=_required_string(request, "build_id"),
-        provider_session_id=_required_string(request, "provider_session_id"),
-        callback_url=callback_url,
-        failure_callback_url=failure_callback_url,
-        callback_token=_required_string(request, "callback_token"),
-    )
-    return {"success": True, "data": {"started": True}}
+        build_id = _required_string(request, "build_id")
+        provider_session_id = _required_string(request, "provider_session_id")
+        await ModalBuildSessionService().start(
+            build_id=build_id,
+            provider_session_id=provider_session_id,
+            callback_url=callback_url,
+            failure_callback_url=failure_callback_url,
+            callback_token=_required_string(request, "callback_token"),
+        )
+        return {"success": True, "data": {"started": True}}
+    except HTTPException as e:
+        outcome = "error"
+        http_status = e.status_code
+        raise
+    except Exception as e:
+        outcome = "error"
+        http_status = 500
+        log.error("api.error", exc=e, endpoint_name="api_start_build_sandbox")
+        return {"success": False, "error": str(e)}
+    finally:
+        _log_build_http_request(
+            start_time=start_time,
+            http_path="/api_start_build_sandbox",
+            http_status=http_status,
+            outcome=outcome,
+            endpoint_name="api_start_build_sandbox",
+            trace_id=x_trace_id,
+            request_id=x_request_id,
+            build_id=build_id,
+            provider_session_id=provider_session_id,
+        )
 
 
 @app.function(image=function_image, secrets=[internal_api_secret])
@@ -548,16 +680,46 @@ async def api_terminate_build_sandbox(
     x_request_id: str | None = Header(None),
 ) -> dict:
     """Terminate the exactly tagged provider-session build sandbox."""
+    start_time = time.time()
+    http_status = 200
+    outcome = "success"
+    build_id = request.get("build_id")
+    provider_session_id = request.get("provider_session_id")
+
     require_auth(authorization)
 
-    from .sandbox.manager import SandboxManager
+    try:
+        from .sandbox.build_session import ModalBuildSessionService
 
-    await SandboxManager().terminate_build_sandbox(
-        build_id=_required_string(request, "build_id"),
-        provider_session_id=_required_string(request, "provider_session_id"),
-        reason=_required_string(request, "reason"),
-    )
-    return {"success": True, "data": {"terminated": True}}
+        build_id = _required_string(request, "build_id")
+        provider_session_id = _required_string(request, "provider_session_id")
+        await ModalBuildSessionService().terminate(
+            build_id=build_id,
+            provider_session_id=provider_session_id,
+            reason=_required_string(request, "reason"),
+        )
+        return {"success": True, "data": {"terminated": True}}
+    except HTTPException as e:
+        outcome = "error"
+        http_status = e.status_code
+        raise
+    except Exception as e:
+        outcome = "error"
+        http_status = 500
+        log.error("api.error", exc=e, endpoint_name="api_terminate_build_sandbox")
+        return {"success": False, "error": str(e)}
+    finally:
+        _log_build_http_request(
+            start_time=start_time,
+            http_path="/api_terminate_build_sandbox",
+            http_status=http_status,
+            outcome=outcome,
+            endpoint_name="api_terminate_build_sandbox",
+            trace_id=x_trace_id,
+            request_id=x_request_id,
+            build_id=build_id,
+            provider_session_id=provider_session_id,
+        )
 
 
 def _required_string(request: dict, field: str) -> str:
@@ -565,6 +727,48 @@ def _required_string(request: dict, field: str) -> str:
     if not isinstance(value, str) or not value:
         raise HTTPException(status_code=400, detail=f"{field} is required")
     return value
+
+
+def _log_build_http_request(
+    *,
+    start_time: float,
+    http_path: str,
+    http_status: int,
+    outcome: str,
+    endpoint_name: str,
+    trace_id: str | None,
+    request_id: str | None,
+    build_id: object,
+    provider_session_id: object,
+) -> None:
+    log.info(
+        "modal.http_request",
+        http_method="POST",
+        http_path=http_path,
+        http_status=http_status,
+        duration_ms=int((time.time() - start_time) * 1000),
+        outcome=outcome,
+        endpoint_name=endpoint_name,
+        trace_id=trace_id,
+        request_id=request_id,
+        build_id=build_id,
+        sandbox_id=provider_session_id,
+    )
+
+
+def _validated_timeout_seconds(
+    request: dict,
+    field: str,
+    *,
+    default_seconds: int,
+    max_seconds: int,
+) -> int:
+    value = request.get(field)
+    if value is None:
+        return default_seconds
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise HTTPException(status_code=400, detail=f"{field} must be an integer")
+    return min(max_seconds, max(1, value))
 
 
 def _validated_build_repositories(value: object) -> list[dict]:
@@ -581,6 +785,13 @@ def _validated_build_repositories(value: object) -> list[dict]:
                 status_code=400,
                 detail="repositories entries require repo_owner, repo_name, and branch",
             )
+    try:
+        parse_repositories(
+            {"repositories": value},
+            workspace_path=Path("/workspace"),
+        )
+    except RepoConfigError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     return value
 
 
@@ -624,6 +835,7 @@ async def api_build_image(
     try:
         from .sandbox.manager import (
             DEFAULT_BUILD_TIMEOUT_SECONDS,
+            MAX_BUILD_TIMEOUT_SECONDS,
             build_function_timeout_seconds,
         )
         from .scheduler.image_builder import build_image
@@ -637,8 +849,11 @@ async def api_build_image(
         repositories = request.get("repositories")
         user_env_vars = request.get("user_env_vars") or None
         # Already capped by the control plane; default when absent/null.
-        build_timeout_seconds = int(
-            request.get("build_timeout_seconds") or DEFAULT_BUILD_TIMEOUT_SECONDS
+        build_timeout_seconds = _validated_timeout_seconds(
+            request,
+            "build_timeout_seconds",
+            default_seconds=DEFAULT_BUILD_TIMEOUT_SECONDS,
+            max_seconds=MAX_BUILD_TIMEOUT_SECONDS,
         )
 
         if not build_id:
@@ -656,19 +871,7 @@ async def api_build_image(
             # as 'building' until the stale sweep reaps it. Fail fast instead.
             raise HTTPException(status_code=400, detail="callback_token is required")
 
-        if not isinstance(repositories, list) or not repositories:
-            raise HTTPException(status_code=400, detail="repositories must be a non-empty list")
-        for entry in repositories:
-            if (
-                not isinstance(entry, dict)
-                or not entry.get("repo_owner")
-                or not entry.get("repo_name")
-                or not entry.get("branch")
-            ):
-                raise HTTPException(
-                    status_code=400,
-                    detail="repositories entries require repo_owner, repo_name, and branch",
-                )
+        repositories = _validated_build_repositories(repositories)
 
         function_timeout = build_function_timeout_seconds(build_timeout_seconds)
 

--- a/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
+++ b/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.sandbox.manager import SandboxManager
+from src.sandbox.build_session import BuildSessionNotFoundError, ModalBuildSessionService
 
 
 def _async_method(return_value=None):
@@ -18,9 +18,9 @@ def _async_method(return_value=None):
 async def test_create_provider_session_build_is_dormant_tagged_and_scrubs_callbacks(monkeypatch):
     sandbox = SimpleNamespace(object_id="modal-session-1")
     create = _async_method(sandbox)
-    monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", create)
+    monkeypatch.setattr("src.sandbox.build_session.modal.Sandbox.create", create)
 
-    handle = await SandboxManager().create_provider_session_build_sandbox(
+    provider_session_id = await ModalBuildSessionService().create(
         build_id="build-1",
         scope_kind="repo",
         scope_id="acme/repo",
@@ -28,7 +28,7 @@ async def test_create_provider_session_build_is_dormant_tagged_and_scrubs_callba
         user_env_vars={"OI_REPO_IMAGE_CALLBACK_TOKEN": "attacker-token"},
     )
 
-    assert handle.modal_object_id == "modal-session-1"
+    assert provider_session_id == "modal-session-1"
     assert create.aio.await_args.args[:2] == ("python", "-c")
     assert create.aio.await_args.kwargs["tags"]["openinspect_build_id"] == "build-1"
     assert create.aio.await_args.kwargs["env"]["OI_REPO_IMAGE_CALLBACK_TOKEN"] == ""
@@ -42,9 +42,9 @@ async def test_start_build_verifies_tags_and_injects_exact_callback_identity(mon
         ),
         exec=_async_method(),
     )
-    monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.from_id", lambda _id: sandbox)
+    monkeypatch.setattr("src.sandbox.build_session.modal.Sandbox.from_id", lambda _id: sandbox)
 
-    await SandboxManager().start_build_sandbox(
+    await ModalBuildSessionService().start(
         build_id="build-1",
         provider_session_id="modal-session-1",
         callback_url="https://cp.test/image-builds/build-complete",
@@ -59,6 +59,7 @@ async def test_start_build_verifies_tags_and_injects_exact_callback_identity(mon
         "OI_REPO_IMAGE_CALLBACK_TOKEN": "callback-token",
         "OI_REPO_IMAGE_PROVIDER_SESSION_ID": "modal-session-1",
     }
+    assert sandbox.exec.aio.await_args.kwargs["workdir"] == "/workspace"
 
 
 @pytest.mark.asyncio
@@ -69,10 +70,10 @@ async def test_start_build_refuses_mismatched_tags(monkeypatch):
         ),
         exec=_async_method(),
     )
-    monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.from_id", lambda _id: sandbox)
+    monkeypatch.setattr("src.sandbox.build_session.modal.Sandbox.from_id", lambda _id: sandbox)
 
-    with pytest.raises(ValueError, match="tags do not match"):
-        await SandboxManager().start_build_sandbox(
+    with pytest.raises(BuildSessionNotFoundError, match="build session not found"):
+        await ModalBuildSessionService().start(
             build_id="build-1",
             provider_session_id="modal-session-1",
             callback_url="https://cp.test/image-builds/build-complete",
@@ -89,9 +90,9 @@ async def test_terminate_build_treats_not_found_as_success(monkeypatch):
 
     sandbox = SimpleNamespace(get_tags=_async_method(), terminate=_async_method())
     sandbox.get_tags.aio.side_effect = NotFoundError("sandbox no longer exists")
-    monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.from_id", lambda _id: sandbox)
+    monkeypatch.setattr("src.sandbox.build_session.modal.Sandbox.from_id", lambda _id: sandbox)
 
-    await SandboxManager().terminate_build_sandbox(
+    await ModalBuildSessionService().terminate(
         build_id="build-1",
         provider_session_id="modal-session-1",
         reason="image_build_complete",

--- a/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
+++ b/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from src.sandbox.build_session import BuildSessionNotFoundError, ModalBuildSessionService
+from src.sandbox.manager import SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS
 
 
 def _async_method(return_value=None):
@@ -82,6 +83,27 @@ async def test_start_build_refuses_mismatched_tags(monkeypatch):
         )
 
     sandbox.exec.aio.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_build_awaits_async_snapshot_operation(monkeypatch):
+    snapshot_filesystem = _async_method(SimpleNamespace(object_id="im-snapshot-1"))
+    sandbox = SimpleNamespace(
+        get_tags=_async_method(
+            {"openinspect_kind": "image-build", "openinspect_build_id": "build-1"}
+        ),
+        snapshot_filesystem=snapshot_filesystem,
+    )
+    monkeypatch.setattr("src.sandbox.build_session.modal.Sandbox.from_id", lambda _id: sandbox)
+
+    image_id = await ModalBuildSessionService().snapshot(
+        build_id="build-1",
+        provider_session_id="modal-session-1",
+    )
+
+    assert image_id == "im-snapshot-1"
+    snapshot_filesystem.assert_not_called()
+    snapshot_filesystem.aio.assert_awaited_once_with(timeout=SNAPSHOT_FILESYSTEM_TIMEOUT_SECONDS)
 
 
 @pytest.mark.asyncio

--- a/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
+++ b/packages/modal-infra/tests/test_build_sandbox_lifecycle.py
@@ -1,0 +1,100 @@
+"""Provider-session lifecycle tests for Modal image-build sandboxes."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.sandbox.manager import SandboxManager
+
+
+def _async_method(return_value=None):
+    method = MagicMock()
+    method.aio = AsyncMock(return_value=return_value)
+    return method
+
+
+@pytest.mark.asyncio
+async def test_create_provider_session_build_is_dormant_tagged_and_scrubs_callbacks(monkeypatch):
+    sandbox = SimpleNamespace(object_id="modal-session-1")
+    create = _async_method(sandbox)
+    monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.create", create)
+
+    handle = await SandboxManager().create_provider_session_build_sandbox(
+        build_id="build-1",
+        scope_kind="repo",
+        scope_id="acme/repo",
+        repositories=[{"repo_owner": "acme", "repo_name": "repo", "branch": "main"}],
+        user_env_vars={"OI_REPO_IMAGE_CALLBACK_TOKEN": "attacker-token"},
+    )
+
+    assert handle.modal_object_id == "modal-session-1"
+    assert create.aio.await_args.args[:2] == ("python", "-c")
+    assert create.aio.await_args.kwargs["tags"]["openinspect_build_id"] == "build-1"
+    assert create.aio.await_args.kwargs["env"]["OI_REPO_IMAGE_CALLBACK_TOKEN"] == ""
+
+
+@pytest.mark.asyncio
+async def test_start_build_verifies_tags_and_injects_exact_callback_identity(monkeypatch):
+    sandbox = SimpleNamespace(
+        get_tags=_async_method(
+            {"openinspect_kind": "image-build", "openinspect_build_id": "build-1"}
+        ),
+        exec=_async_method(),
+    )
+    monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.from_id", lambda _id: sandbox)
+
+    await SandboxManager().start_build_sandbox(
+        build_id="build-1",
+        provider_session_id="modal-session-1",
+        callback_url="https://cp.test/image-builds/build-complete",
+        failure_callback_url="https://cp.test/image-builds/build-failed",
+        callback_token="callback-token",
+    )
+
+    assert sandbox.exec.aio.await_args.kwargs["env"] == {
+        "OI_REPO_IMAGE_BUILD_ID": "build-1",
+        "OI_REPO_IMAGE_CALLBACK_URL": "https://cp.test/image-builds/build-complete",
+        "OI_REPO_IMAGE_FAILURE_CALLBACK_URL": "https://cp.test/image-builds/build-failed",
+        "OI_REPO_IMAGE_CALLBACK_TOKEN": "callback-token",
+        "OI_REPO_IMAGE_PROVIDER_SESSION_ID": "modal-session-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_start_build_refuses_mismatched_tags(monkeypatch):
+    sandbox = SimpleNamespace(
+        get_tags=_async_method(
+            {"openinspect_kind": "interactive", "openinspect_build_id": "other-build"}
+        ),
+        exec=_async_method(),
+    )
+    monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.from_id", lambda _id: sandbox)
+
+    with pytest.raises(ValueError, match="tags do not match"):
+        await SandboxManager().start_build_sandbox(
+            build_id="build-1",
+            provider_session_id="modal-session-1",
+            callback_url="https://cp.test/image-builds/build-complete",
+            failure_callback_url="https://cp.test/image-builds/build-failed",
+            callback_token="callback-token",
+        )
+
+    sandbox.exec.aio.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_terminate_build_treats_not_found_as_success(monkeypatch):
+    from modal.exception import NotFoundError
+
+    sandbox = SimpleNamespace(get_tags=_async_method(), terminate=_async_method())
+    sandbox.get_tags.aio.side_effect = NotFoundError("sandbox no longer exists")
+    monkeypatch.setattr("src.sandbox.manager.modal.Sandbox.from_id", lambda _id: sandbox)
+
+    await SandboxManager().terminate_build_sandbox(
+        build_id="build-1",
+        provider_session_id="modal-session-1",
+        reason="image_build_complete",
+    )
+
+    sandbox.terminate.aio.assert_not_awaited()

--- a/packages/modal-infra/tests/test_web_api_build_image.py
+++ b/packages/modal-infra/tests/test_web_api_build_image.py
@@ -121,6 +121,12 @@ async def test_build_forwards_scope_and_repositories(monkeypatch):
         {"repositories": [{"repo_owner": "acme", "repo_name": "repo"}]},
         {"repositories": [{"repo_owner": "acme", "repo_name": "repo", "branch": ""}]},
         {"repositories": [REPOSITORIES[0], {"repo_owner": "acme", "repo_name": "api"}]},
+        {
+            "repositories": [
+                REPOSITORIES[0],
+                {"repo_owner": "other", "repo_name": "REPO", "branch": "main"},
+            ]
+        },
     ],
 )
 async def test_build_requires_core_fields(monkeypatch, overrides):

--- a/packages/modal-infra/tests/test_web_api_build_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_build_sandbox.py
@@ -1,0 +1,74 @@
+"""Tests for the additive Modal provider-session image-build APIs."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src import web_api
+
+
+def _patch_dependencies(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(web_api, "require_auth", lambda _authorization: None)
+    monkeypatch.setattr(web_api, "validate_control_plane_url", lambda _url: True)
+    manager = SimpleNamespace(
+        create_provider_session_build_sandbox=AsyncMock(
+            return_value=SimpleNamespace(modal_object_id="modal-session-1")
+        ),
+        start_build_sandbox=AsyncMock(),
+        terminate_build_sandbox=AsyncMock(),
+    )
+    monkeypatch.setattr("src.sandbox.manager.SandboxManager", lambda: manager)
+    return manager
+
+
+async def _call(endpoint, request: dict) -> dict:
+    return await endpoint.get_raw_f()(
+        request,
+        authorization="Bearer test",
+        x_trace_id=None,
+        x_request_id=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_returns_provider_session_without_removing_legacy_endpoint(monkeypatch):
+    manager = _patch_dependencies(monkeypatch)
+
+    result = await _call(
+        web_api.api_create_build_sandbox,
+        {
+            "scope_kind": "repo",
+            "scope_id": "acme/repo",
+            "build_id": "imgb-1",
+            "repositories": [{"repo_owner": "acme", "repo_name": "repo", "branch": "main"}],
+        },
+    )
+
+    assert result["data"]["provider_session_id"] == "modal-session-1"
+    manager.create_provider_session_build_sandbox.assert_awaited_once()
+    assert hasattr(web_api, "api_build_image")
+
+
+@pytest.mark.asyncio
+async def test_start_passes_bound_identity_and_callbacks(monkeypatch):
+    manager = _patch_dependencies(monkeypatch)
+
+    await _call(
+        web_api.api_start_build_sandbox,
+        {
+            "build_id": "imgb-1",
+            "provider_session_id": "modal-session-1",
+            "callback_url": "https://cp.test/image-builds/build-complete",
+            "failure_callback_url": "https://cp.test/image-builds/build-failed",
+            "callback_token": "callback-token",
+        },
+    )
+
+    manager.start_build_sandbox.assert_awaited_once_with(
+        build_id="imgb-1",
+        provider_session_id="modal-session-1",
+        callback_url="https://cp.test/image-builds/build-complete",
+        failure_callback_url="https://cp.test/image-builds/build-failed",
+        callback_token="callback-token",
+    )

--- a/packages/modal-infra/tests/test_web_api_build_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_build_sandbox.py
@@ -1,7 +1,7 @@
 """Tests for the additive Modal provider-session image-build APIs."""
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
 
@@ -11,15 +11,17 @@ from src import web_api
 def _patch_dependencies(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(web_api, "require_auth", lambda _authorization: None)
     monkeypatch.setattr(web_api, "validate_control_plane_url", lambda _url: True)
-    manager = SimpleNamespace(
-        create_provider_session_build_sandbox=AsyncMock(
-            return_value=SimpleNamespace(modal_object_id="modal-session-1")
-        ),
-        start_build_sandbox=AsyncMock(),
-        terminate_build_sandbox=AsyncMock(),
+    service = SimpleNamespace(
+        create=AsyncMock(return_value="modal-session-1"),
+        start=AsyncMock(),
+        terminate=AsyncMock(),
+        snapshot=AsyncMock(return_value="modal-image-1"),
     )
-    monkeypatch.setattr("src.sandbox.manager.SandboxManager", lambda: manager)
-    return manager
+    monkeypatch.setattr(
+        "src.sandbox.build_session.ModalBuildSessionService",
+        lambda: service,
+    )
+    return service
 
 
 async def _call(endpoint, request: dict) -> dict:
@@ -31,9 +33,20 @@ async def _call(endpoint, request: dict) -> dict:
     )
 
 
+async def _call_generic_snapshot(request: dict) -> dict:
+    return await web_api.api_snapshot_sandbox.get_raw_f()(
+        request,
+        authorization="Bearer test",
+        x_trace_id=None,
+        x_request_id=None,
+        x_session_id=None,
+        x_sandbox_id=None,
+    )
+
+
 @pytest.mark.asyncio
 async def test_create_returns_provider_session_without_removing_legacy_endpoint(monkeypatch):
-    manager = _patch_dependencies(monkeypatch)
+    service = _patch_dependencies(monkeypatch)
 
     result = await _call(
         web_api.api_create_build_sandbox,
@@ -46,13 +59,113 @@ async def test_create_returns_provider_session_without_removing_legacy_endpoint(
     )
 
     assert result["data"]["provider_session_id"] == "modal-session-1"
-    manager.create_provider_session_build_sandbox.assert_awaited_once()
+    service.create.assert_awaited_once()
     assert hasattr(web_api, "api_build_image")
 
 
 @pytest.mark.asyncio
+async def test_create_logs_http_outcome(monkeypatch):
+    _patch_dependencies(monkeypatch)
+    info = MagicMock()
+    monkeypatch.setattr(web_api.log, "info", info)
+
+    await _call(
+        web_api.api_create_build_sandbox,
+        {
+            "scope_kind": "repo",
+            "scope_id": "acme/repo",
+            "build_id": "imgb-1",
+            "repositories": [{"repo_owner": "acme", "repo_name": "repo", "branch": "main"}],
+        },
+    )
+
+    info.assert_called_once_with(
+        "modal.http_request",
+        http_method="POST",
+        http_path="/api_create_build_sandbox",
+        http_status=200,
+        duration_ms=ANY,
+        outcome="success",
+        endpoint_name="api_create_build_sandbox",
+        trace_id=None,
+        request_id=None,
+        build_id="imgb-1",
+        sandbox_id="modal-session-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_non_integer_build_timeout(monkeypatch):
+    service = _patch_dependencies(monkeypatch)
+
+    with pytest.raises(web_api.HTTPException) as exc:
+        await _call(
+            web_api.api_create_build_sandbox,
+            {
+                "scope_kind": "repo",
+                "scope_id": "acme/repo",
+                "build_id": "imgb-1",
+                "repositories": [{"repo_owner": "acme", "repo_name": "repo", "branch": "main"}],
+                "build_timeout_seconds": "1800",
+            },
+        )
+
+    assert exc.value.status_code == 400
+    service.create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_clamps_build_timeout_to_provider_maximum(monkeypatch):
+    service = _patch_dependencies(monkeypatch)
+
+    await _call(
+        web_api.api_create_build_sandbox,
+        {
+            "scope_kind": "repo",
+            "scope_id": "acme/repo",
+            "build_id": "imgb-1",
+            "repositories": [{"repo_owner": "acme", "repo_name": "repo", "branch": "main"}],
+            "build_timeout_seconds": 99999,
+        },
+    )
+
+    assert service.create.await_args.kwargs["timeout_seconds"] == 3600
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_case_insensitive_repository_path_collisions(monkeypatch):
+    service = _patch_dependencies(monkeypatch)
+
+    with pytest.raises(web_api.HTTPException) as exc:
+        await _call(
+            web_api.api_create_build_sandbox,
+            {
+                "scope_kind": "environment",
+                "scope_id": "env-1",
+                "build_id": "imgb-1",
+                "repositories": [
+                    {
+                        "repo_owner": "group/subgroup",
+                        "repo_name": "api",
+                        "branch": "main",
+                    },
+                    {
+                        "repo_owner": "group/subgroup",
+                        "repo_name": "API",
+                        "branch": "develop",
+                    },
+                ],
+            },
+        )
+
+    assert exc.value.status_code == 400
+    assert "duplicate repo_name" in exc.value.detail
+    service.create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_start_passes_bound_identity_and_callbacks(monkeypatch):
-    manager = _patch_dependencies(monkeypatch)
+    service = _patch_dependencies(monkeypatch)
 
     await _call(
         web_api.api_start_build_sandbox,
@@ -65,10 +178,125 @@ async def test_start_passes_bound_identity_and_callbacks(monkeypatch):
         },
     )
 
-    manager.start_build_sandbox.assert_awaited_once_with(
+    service.start.assert_awaited_once_with(
         build_id="imgb-1",
         provider_session_id="modal-session-1",
         callback_url="https://cp.test/image-builds/build-complete",
         failure_callback_url="https://cp.test/image-builds/build-failed",
         callback_token="callback-token",
     )
+
+
+@pytest.mark.asyncio
+async def test_start_logs_callback_validation_failure(monkeypatch):
+    service = _patch_dependencies(monkeypatch)
+    monkeypatch.setattr(web_api, "validate_control_plane_url", lambda _url: False)
+    info = MagicMock()
+    monkeypatch.setattr(web_api.log, "info", info)
+
+    with pytest.raises(web_api.HTTPException) as exc:
+        await _call(
+            web_api.api_start_build_sandbox,
+            {
+                "build_id": "imgb-1",
+                "provider_session_id": "modal-session-1",
+                "callback_url": "https://attacker.test/complete",
+                "failure_callback_url": "https://attacker.test/failed",
+                "callback_token": "callback-token",
+            },
+        )
+
+    assert exc.value.status_code == 400
+    service.start.assert_not_awaited()
+    assert info.call_args.kwargs["http_status"] == 400
+    assert info.call_args.kwargs["outcome"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_terminate_passes_bound_identity_and_reason(monkeypatch):
+    service = _patch_dependencies(monkeypatch)
+
+    result = await _call(
+        web_api.api_terminate_build_sandbox,
+        {
+            "build_id": "imgb-1",
+            "provider_session_id": "modal-session-1",
+            "reason": "image_build_failed",
+        },
+    )
+
+    assert result == {"success": True, "data": {"terminated": True}}
+    service.terminate.assert_awaited_once_with(
+        build_id="imgb-1",
+        provider_session_id="modal-session-1",
+        reason="image_build_failed",
+    )
+
+
+@pytest.mark.asyncio
+async def test_snapshot_build_uses_dedicated_bound_build_endpoint(monkeypatch):
+    service = _patch_dependencies(monkeypatch)
+    service.snapshot.return_value = "im-1"
+
+    result = await _call(
+        web_api.api_snapshot_build_sandbox,
+        {
+            "build_id": "imgb-1",
+            "provider_session_id": "modal-session-1",
+        },
+    )
+
+    assert result == {
+        "success": True,
+        "data": {
+            "image_id": "im-1",
+            "build_id": "imgb-1",
+            "provider_session_id": "modal-session-1",
+        },
+    }
+    service.snapshot.assert_awaited_once_with(
+        build_id="imgb-1",
+        provider_session_id="modal-session-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_snapshot_build_maps_missing_or_mismatched_session_to_not_found(monkeypatch):
+    from src.sandbox.build_session import BuildSessionNotFoundError
+
+    service = _patch_dependencies(monkeypatch)
+    service.snapshot.side_effect = BuildSessionNotFoundError("build session not found")
+
+    with pytest.raises(web_api.HTTPException) as exc:
+        await _call(
+            web_api.api_snapshot_build_sandbox,
+            {
+                "build_id": "imgb-1",
+                "provider_session_id": "modal-session-1",
+            },
+        )
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "build session not found"
+
+
+@pytest.mark.asyncio
+async def test_generic_snapshot_reason_cannot_select_build_identity_rules(monkeypatch):
+    monkeypatch.setattr(web_api, "require_auth", lambda _authorization: None)
+    handle = SimpleNamespace()
+    manager = SimpleNamespace(
+        get_sandbox_by_id=AsyncMock(return_value=handle),
+        take_snapshot=MagicMock(return_value="im-session-1"),
+    )
+    monkeypatch.setattr("src.sandbox.manager.SandboxManager", lambda: manager)
+
+    result = await _call_generic_snapshot(
+        {
+            "sandbox_id": "modal-session-1",
+            "session_id": "imgb-1",
+            "reason": "environment_image_build",
+        }
+    )
+
+    assert result["data"]["image_id"] == "im-session-1"
+    manager.get_sandbox_by_id.assert_awaited_once_with("modal-session-1")


### PR DESCRIPTION
## Summary

- add authenticated create, start, and terminate APIs for Modal image-build sandboxes
- bind and validate the exact build identity before launching the runtime
- keep the legacy Modal image builder intact for a deployment-safe compatibility stage

## Rollout

Deploy this PR before the Queue finalization PR.

## Validation

- Modal: 223 tests passed
- Ruff check and format passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for snapshotting image-build provider sessions and returning the resulting image ID.
  * Extended image-build sandbox lifecycle support for creation, starting, termination, and snapshotting.
* **Enhancements**
  * Improved validation for repositories, build timeouts, callback URLs, and callback credentials.
  * Standardized sandbox snapshot selection by sandbox ID.
* **Bug Fixes**
  * Improved handling when a provider-session sandbox is already missing during termination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->