### PR TITLE
Import shared identity and models from owner modules

### DIFF
--- a/packages/control-plane/src/auth/github.ts
+++ b/packages/control-plane/src/auth/github.ts
@@ -2,7 +2,7 @@
  * GitHub authentication utilities.
  */
 
-import { formatGitHubNoreplyEmail } from "@open-inspect/shared";
+import { formatGitHubNoreplyEmail } from "@open-inspect/shared/types/github-identity";
 import { DEFAULT_APP_NAME } from "@open-inspect/shared/app-name";
 import { z } from "zod";
 import { decryptToken, encryptToken } from "./crypto";

--- a/packages/control-plane/src/auth/user/better-auth.ts
+++ b/packages/control-plane/src/auth/user/better-auth.ts
@@ -1,4 +1,4 @@
-import { BROWSER_AUTH_CLIENT_IP_HEADER } from "@open-inspect/shared";
+import { BROWSER_AUTH_CLIENT_IP_HEADER } from "@open-inspect/shared/browser-auth-routes";
 import { betterAuth } from "better-auth";
 import { generateId } from "../crypto";
 import type { CanonicalUserProjection } from "./canonical-user-projection";

--- a/packages/control-plane/src/db/canonical-user-projection.ts
+++ b/packages/control-plane/src/db/canonical-user-projection.ts
@@ -1,4 +1,4 @@
-import { isCanonicalUserId } from "@open-inspect/shared";
+import { isCanonicalUserId } from "@open-inspect/shared/user-id";
 import type {
   CanonicalUserProjection,
   UserProjectionInput,

--- a/packages/control-plane/src/db/integration-settings.ts
+++ b/packages/control-plane/src/db/integration-settings.ts
@@ -1,7 +1,5 @@
 import {
   isEnvironmentId,
-  isValidModel,
-  isValidReasoningEffort,
   ENVIRONMENT_SETTINGS_INTEGRATION_IDS,
   INTEGRATION_DEFINITIONS,
   DEFAULT_MENTIONS_POLICY,
@@ -19,6 +17,7 @@ import {
   type SlackMentionsPolicy,
   type SlackRoutingRule,
 } from "@open-inspect/shared";
+import { isValidModel, isValidReasoningEffort } from "@open-inspect/shared/models";
 import { normalizeSandboxSettings } from "../sandbox/settings";
 import type { SqlDatabase } from "./sql-database";
 

--- a/packages/control-plane/src/db/model-preferences.ts
+++ b/packages/control-plane/src/db/model-preferences.ts
@@ -3,7 +3,7 @@ import {
   isValidModel,
   normalizeValidModels,
   type ValidModel,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/models";
 import type { SqlDatabase } from "./sql-database";
 
 export class ModelPreferencesValidationError extends Error {

--- a/packages/control-plane/src/router.ts
+++ b/packages/control-plane/src/router.ts
@@ -2,7 +2,7 @@
  * API router for Open-Inspect Control Plane.
  */
 
-import { isBrowserAuthProxyRoute } from "@open-inspect/shared";
+import { isBrowserAuthProxyRoute } from "@open-inspect/shared/browser-auth-routes";
 import type { Env } from "./types";
 import { authenticate, isAuthError } from "./auth/authenticate";
 import type { Principal } from "./auth/principal";

--- a/packages/control-plane/src/routes/automations.ts
+++ b/packages/control-plane/src/routes/automations.ts
@@ -6,9 +6,6 @@ import {
   isValidCron,
   nextCronOccurrence,
   cronIntervalMinutes,
-  isValidModel,
-  isValidReasoningEffort,
-  getValidModelOrDefault,
   validateConditions,
   conditionRegistry,
   listChannels,
@@ -18,6 +15,11 @@ import {
   type AutomationTriggerType,
   type TriggerConfig,
 } from "@open-inspect/shared";
+import {
+  getValidModelOrDefault,
+  isValidModel,
+  isValidReasoningEffort,
+} from "@open-inspect/shared/models";
 import {
   AutomationStore,
   toAutomation,

--- a/packages/control-plane/src/routes/browser-auth.ts
+++ b/packages/control-plane/src/routes/browser-auth.ts
@@ -1,4 +1,4 @@
-import { BROWSER_AUTH_PROXY_ROUTES } from "@open-inspect/shared";
+import { BROWSER_AUTH_PROXY_ROUTES } from "@open-inspect/shared/browser-auth-routes";
 import { type BetterAuthRuntime, UserAuthConfigurationError } from "../auth/user/runtime";
 import { createLogger } from "../logger";
 import { error, parsePattern, type Route } from "./shared";

--- a/packages/control-plane/src/routes/integration-settings.ts
+++ b/packages/control-plane/src/routes/integration-settings.ts
@@ -5,7 +5,6 @@
 import {
   DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS,
   DEFAULT_MAX_TOTAL_CHILD_SESSIONS,
-  isValidReasoningEffort,
   type CodeServerSettings,
   type EnvironmentSettingsIntegrationId,
   type GitHubBotSettings,
@@ -13,6 +12,7 @@ import {
   type LinearBotSettings,
   type SandboxSettings,
 } from "@open-inspect/shared";
+import { isValidReasoningEffort } from "@open-inspect/shared/models";
 import {
   IntegrationSettingsStore,
   IntegrationSettingsValidationError,

--- a/packages/control-plane/src/routes/model-preferences.ts
+++ b/packages/control-plane/src/routes/model-preferences.ts
@@ -2,7 +2,7 @@
  * Model-preferences routes and handlers.
  */
 
-import { DEFAULT_ENABLED_MODELS, normalizeValidModels } from "@open-inspect/shared";
+import { DEFAULT_ENABLED_MODELS, normalizeValidModels } from "@open-inspect/shared/models";
 import { ModelPreferencesStore, ModelPreferencesValidationError } from "../db/model-preferences";
 import { createLogger } from "../logger";
 import type { Env } from "../types";

--- a/packages/control-plane/src/routes/session-child-spawn.ts
+++ b/packages/control-plane/src/routes/session-child-spawn.ts
@@ -1,15 +1,17 @@
 import {
   DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS,
   DEFAULT_MAX_TOTAL_CHILD_SESSIONS,
+  spawnChildSessionRequestSchema,
+  spawnContextSchema,
+} from "@open-inspect/shared";
+import {
   getValidModelOrDefault,
   isValidModel,
   isValidReasoningEffort,
   resolveEnabledModel,
-  spawnChildSessionRequestSchema,
-  spawnContextSchema,
   type ValidModel,
   VALID_MODELS,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/models";
 import { generateId } from "../auth/crypto";
 import { getEffectiveEnabledModels } from "../db/model-preferences";
 import { SessionIndexStore } from "../db/session-index";

--- a/packages/control-plane/src/routes/session-create.ts
+++ b/packages/control-plane/src/routes/session-create.ts
@@ -1,8 +1,5 @@
-import {
-  getValidModelOrDefault,
-  isValidReasoningEffort,
-  type RepositoryRef,
-} from "@open-inspect/shared";
+import type { RepositoryRef } from "@open-inspect/shared";
+import { getValidModelOrDefault, isValidReasoningEffort } from "@open-inspect/shared/models";
 import { generateId } from "../auth/crypto";
 import { resolveGitHubCredentialAuthority } from "../source-control/github-credential-authority";
 import { applyIdentityEnforcement, resolveCanonicalUserId } from "../auth/identity-enforcement";

--- a/packages/control-plane/src/routes/session-index.ts
+++ b/packages/control-plane/src/routes/session-index.ts
@@ -1,4 +1,5 @@
-import { isCanonicalUserId, type SessionStatus } from "@open-inspect/shared";
+import type { SessionStatus } from "@open-inspect/shared";
+import { isCanonicalUserId } from "@open-inspect/shared/user-id";
 import { SessionIndexStore } from "../db/session-index";
 import { error, json, parsePattern, type RequestContext, type Route } from "./shared";
 import type { Env } from "../types";

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -10,11 +10,8 @@
  * spawn attempts within the same request.
  */
 
-import {
-  extractProviderAndModel,
-  type McpServerConfig,
-  type SandboxSettings,
-} from "@open-inspect/shared";
+import type { McpServerConfig, SandboxSettings } from "@open-inspect/shared";
+import { extractProviderAndModel } from "@open-inspect/shared/models";
 import type { SandboxStatus } from "../../types";
 import { sessionHasRepository, type SandboxRow, type SessionRow } from "../../session/types";
 import {

--- a/packages/control-plane/src/session/durable-object.ts
+++ b/packages/control-plane/src/session/durable-object.ts
@@ -10,13 +10,13 @@
 import { DurableObject } from "cloudflare:workers";
 import { initSchema } from "./schema";
 import {
-  DEFAULT_MODEL,
   clientMessageSchema,
   sandboxEventSchema,
   type SessionAttachmentReference,
 } from "@open-inspect/shared";
 import { resolveAppName } from "@open-inspect/shared/app-name";
 import { timingSafeEqual } from "@open-inspect/shared/auth";
+import { DEFAULT_MODEL } from "@open-inspect/shared/models";
 import { generateId, hashToken, encryptToken, decryptToken } from "../auth/crypto";
 import { buildModalSandboxDashboardUrl } from "../sandbox/client";
 import { resolveSandboxBackendName } from "../sandbox/provider-name";

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.test.ts
@@ -3,7 +3,7 @@ import type { Logger } from "../../../logger";
 import type { ParticipantRow, SandboxRow, SessionRow } from "../../types";
 import { createSessionLifecycleHandler } from "./session-lifecycle.handler";
 import type { SessionStatusService } from "../../session-status-service";
-import { getValidModelOrDefault } from "@open-inspect/shared";
+import { getValidModelOrDefault } from "@open-inspect/shared/models";
 
 function createSession(overrides: Partial<SessionRow> = {}): SessionRow {
   return {

--- a/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/session-lifecycle.handler.ts
@@ -1,11 +1,7 @@
 import type { Logger } from "../../../logger";
 import type { ParticipantRow, SandboxRow, SessionRow } from "../../types";
-import {
-  getValidModelOrDefault,
-  isValidModel,
-  type RepositoryRef,
-  type SandboxSettings,
-} from "@open-inspect/shared";
+import type { RepositoryRef, SandboxSettings } from "@open-inspect/shared";
+import { getValidModelOrDefault, isValidModel } from "@open-inspect/shared/models";
 import type { SandboxStatus, SessionStatus, SpawnSource } from "../../../types";
 import type { SessionRepository } from "../../repository";
 import type { SessionStatusService } from "../../session-status-service";

--- a/packages/control-plane/src/session/identity.ts
+++ b/packages/control-plane/src/session/identity.ts
@@ -1,4 +1,7 @@
-import { formatGitHubNoreplyEmail, githubLoginSchema } from "@open-inspect/shared";
+import {
+  formatGitHubNoreplyEmail,
+  githubLoginSchema,
+} from "@open-inspect/shared/types/github-identity";
 import { z } from "zod";
 import { encryptToken } from "../auth/crypto";
 import type {

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -1,14 +1,13 @@
 import { generateId } from "../auth/crypto";
 import type { SessionIndexStore } from "../db/session-index";
 import type { Logger } from "../logger";
+import type { SessionAttachmentReference, ResolvedSessionAttachment } from "@open-inspect/shared";
 import {
   DEFAULT_MODEL,
   getDefaultReasoningEffort,
   getValidModelOrDefault,
   isValidModel,
-  type SessionAttachmentReference,
-  type ResolvedSessionAttachment,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/models";
 import type { ClientInfo, MessageSource, SandboxEvent } from "../types";
 import type { SourceControlProviderName } from "../source-control";
 import type { SandboxLifecycle } from "../sandbox/lifecycle/manager";

--- a/packages/control-plane/src/session/reasoning-effort.ts
+++ b/packages/control-plane/src/session/reasoning-effort.ts
@@ -3,7 +3,7 @@
  * Returns the validated effort string or null if invalid/absent.
  */
 
-import { isValidReasoningEffort } from "@open-inspect/shared";
+import { isValidReasoningEffort } from "@open-inspect/shared/models";
 import type { Logger } from "../logger";
 
 export function validateReasoningEffort(

--- a/packages/control-plane/test/integration/browser-auth-callback.test.ts
+++ b/packages/control-plane/test/integration/browser-auth-callback.test.ts
@@ -1,5 +1,5 @@
 import { env } from "cloudflare:test";
-import { isCanonicalUserId } from "@open-inspect/shared";
+import { isCanonicalUserId } from "@open-inspect/shared/user-id";
 import { buildServiceAuthHeaders } from "@open-inspect/shared/service-auth";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { getUserAuth } from "../../src/auth/user/runtime";

--- a/packages/control-plane/test/integration/browser-auth.test.ts
+++ b/packages/control-plane/test/integration/browser-auth.test.ts
@@ -1,5 +1,5 @@
 import { env } from "cloudflare:test";
-import { BROWSER_AUTH_CLIENT_IP_HEADER } from "@open-inspect/shared";
+import { BROWSER_AUTH_CLIENT_IP_HEADER } from "@open-inspect/shared/browser-auth-routes";
 import { getMigrations } from "better-auth/db/migration";
 import { verifyGoogleIdToken } from "better-auth/social-providers";
 import { describe, expect, it, vi } from "vitest";

--- a/packages/control-plane/test/integration/model-preferences.test.ts
+++ b/packages/control-plane/test/integration/model-preferences.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { env } from "cloudflare:test";
-import { DEFAULT_ENABLED_MODELS } from "@open-inspect/shared";
+import { DEFAULT_ENABLED_MODELS } from "@open-inspect/shared/models";
 import { cleanD1Tables } from "./cleanup";
 import { serviceFetch } from "./helpers";
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -34,9 +34,21 @@
       "import": "./dist/app-name.js",
       "types": "./dist/app-name.d.ts"
     },
+    "./user-id": {
+      "import": "./dist/user-id.js",
+      "types": "./dist/user-id.d.ts"
+    },
+    "./browser-auth-routes": {
+      "import": "./dist/browser-auth-routes.js",
+      "types": "./dist/browser-auth-routes.d.ts"
+    },
     "./types/commit-signing": {
       "import": "./dist/types/commit-signing.js",
       "types": "./dist/types/commit-signing.d.ts"
+    },
+    "./types/github-identity": {
+      "import": "./dist/types/github-identity.js",
+      "types": "./dist/types/github-identity.d.ts"
     }
   },
   "scripts": {

--- a/packages/web/src/app/(app)/automations/[id]/page.tsx
+++ b/packages/web/src/app/(app)/automations/[id]/page.tsx
@@ -3,7 +3,8 @@
 import { useState, use } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { describeCron, getReasoningConfig } from "@open-inspect/shared";
+import { describeCron } from "@open-inspect/shared";
+import { getReasoningConfig } from "@open-inspect/shared/models";
 import { CollapsedSidebarControls, useSidebarContext } from "@/components/sidebar-layout";
 import { useAutomation, useAutomationInvocations } from "@/hooks/use-automations";
 import { useEnvironments } from "@/hooks/use-environments";

--- a/packages/web/src/app/(app)/automations/new/page.test.tsx
+++ b/packages/web/src/app/(app)/automations/new/page.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import type { ReactNode } from "react";
-import { DEFAULT_MODEL } from "@open-inspect/shared";
+import { DEFAULT_MODEL } from "@open-inspect/shared/models";
 import NewAutomationPage from "./page";
 
 expect.extend(matchers);

--- a/packages/web/src/app/(app)/page.test.tsx
+++ b/packages/web/src/app/(app)/page.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as matchers from "@testing-library/jest-dom/matchers";
-import { DEFAULT_MODEL } from "@open-inspect/shared";
+import { DEFAULT_MODEL } from "@open-inspect/shared/models";
 import Home from "./page";
 
 expect.extend(matchers);

--- a/packages/web/src/app/(app)/page.tsx
+++ b/packages/web/src/app/(app)/page.tsx
@@ -12,12 +12,12 @@ import { formatModelNameLower } from "@/lib/format";
 import { SHORTCUT_LABELS } from "@/lib/keyboard-shortcuts";
 import { isUnarchivedSessionListKey } from "@/lib/session-list";
 import { APP_NAME } from "@/lib/site-config";
+import type { SessionAttachmentReference } from "@open-inspect/shared";
 import {
   DEFAULT_MODEL,
   getDefaultReasoningEffort,
-  type SessionAttachmentReference,
   type ModelCategory,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/models";
 import { resolveModelPreference, type ModelPreference } from "@/lib/model-selection";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
 import { useAttachmentDropZone } from "@/hooks/use-attachment-drop-zone";

--- a/packages/web/src/app/(app)/session/[id]/page.tsx
+++ b/packages/web/src/app/(app)/session/[id]/page.tsx
@@ -27,11 +27,8 @@ import {
   type SessionListResponse,
 } from "@/lib/session-list";
 import { useMediaQuery } from "@/hooks/use-media-query";
-import {
-  DEFAULT_MODEL,
-  getDefaultReasoningEffort,
-  type SessionAttachmentReference,
-} from "@open-inspect/shared";
+import type { SessionAttachmentReference } from "@open-inspect/shared";
+import { DEFAULT_MODEL, getDefaultReasoningEffort } from "@open-inspect/shared/models";
 import { resolveModelPreference, type ModelPreference } from "@/lib/model-selection";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
 import {

--- a/packages/web/src/components/automations/automation-form.test.tsx
+++ b/packages/web/src/components/automations/automation-form.test.tsx
@@ -5,7 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as matchers from "@testing-library/jest-dom/matchers";
 import type { ReactNode } from "react";
-import { DEFAULT_MODEL, MAX_AUTOMATION_REPOSITORIES } from "@open-inspect/shared";
+import { MAX_AUTOMATION_REPOSITORIES } from "@open-inspect/shared";
+import { DEFAULT_MODEL } from "@open-inspect/shared/models";
 import { AutomationForm, type AutomationFormValues } from "./automation-form";
 import { CronPicker } from "./cron-picker";
 

--- a/packages/web/src/components/automations/automation-form.tsx
+++ b/packages/web/src/components/automations/automation-form.tsx
@@ -2,10 +2,7 @@
 
 import { useState, useEffect, useMemo } from "react";
 import {
-  DEFAULT_MODEL,
-  getReasoningConfig,
   isValidCron,
-  isValidReasoningEffort,
   triggerSources,
   MAX_AUTOMATION_REPOSITORIES,
   TRIGGER_TYPE_TO_SOURCE,
@@ -15,6 +12,11 @@ import {
   type TriggerCondition,
   type TriggerConfig,
 } from "@open-inspect/shared";
+import {
+  DEFAULT_MODEL,
+  getReasoningConfig,
+  isValidReasoningEffort,
+} from "@open-inspect/shared/models";
 import { useRepos } from "@/hooks/use-repos";
 import { useEnvironments } from "@/hooks/use-environments";
 import { useBranches } from "@/hooks/use-branches";

--- a/packages/web/src/components/reasoning-effort-pills.tsx
+++ b/packages/web/src/components/reasoning-effort-pills.tsx
@@ -2,7 +2,7 @@ import {
   MODEL_REASONING_CONFIG,
   type ValidModel,
   type ReasoningEffort,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/models";
 
 interface ReasoningEffortPillsProps {
   selectedModel: string;

--- a/packages/web/src/components/settings/integrations/github-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/github-integration-settings.tsx
@@ -5,15 +5,17 @@ import useSWR, { mutate } from "swr";
 import { toast } from "sonner";
 import {
   encodeRepositoryPathSegments,
-  MODEL_REASONING_CONFIG,
   parseRepositoryFullName,
-  isValidReasoningEffort,
   type EnrichedRepository,
   type GitHubBotSettings,
   type GitHubGlobalConfig,
+} from "@open-inspect/shared";
+import {
+  MODEL_REASONING_CONFIG,
+  isValidReasoningEffort,
   type ModelCategory,
   type ValidModel,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/models";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
 import { browserApiFetch } from "@/lib/browser-api-fetch";
 import { IntegrationSettingsSkeleton } from "./integration-settings-skeleton";

--- a/packages/web/src/components/settings/integrations/linear-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/linear-integration-settings.tsx
@@ -5,15 +5,17 @@ import useSWR, { mutate } from "swr";
 import { toast } from "sonner";
 import {
   encodeRepositoryPathSegments,
-  MODEL_REASONING_CONFIG,
   parseRepositoryFullName,
-  isValidReasoningEffort,
   type EnrichedRepository,
   type LinearBotSettings,
   type LinearGlobalConfig,
+} from "@open-inspect/shared";
+import {
+  MODEL_REASONING_CONFIG,
+  isValidReasoningEffort,
   type ModelCategory,
   type ValidModel,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/models";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
 import { browserApiFetch } from "@/lib/browser-api-fetch";
 import { IntegrationSettingsSkeleton } from "./integration-settings-skeleton";

--- a/packages/web/src/components/settings/integrations/model-reasoning-defaults-fields.tsx
+++ b/packages/web/src/components/settings/integrations/model-reasoning-defaults-fields.tsx
@@ -4,7 +4,7 @@ import {
   getReasoningConfig,
   isValidReasoningEffort,
   type ModelCategory,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/models";
 import {
   Select,
   SelectContent,

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
@@ -7,7 +7,6 @@ import {
   DEFAULT_MENTIONS_POLICY,
   encodeRepositoryPathSegments,
   MAX_SLACK_ROUTING_RULES,
-  MODEL_OPTIONS,
   parseRepositoryFullName,
   type EnrichedRepository,
   type Environment,
@@ -18,6 +17,7 @@ import {
   type SlackRepoSettings,
   type SlackRoutingRule,
 } from "@open-inspect/shared";
+import { MODEL_OPTIONS } from "@open-inspect/shared/models";
 import { browserApiFetch } from "@/lib/browser-api-fetch";
 import { useEnabledModels } from "@/hooks/use-enabled-models";
 import { ENVIRONMENTS_KEY } from "@/hooks/use-environments";

--- a/packages/web/src/components/settings/models-settings.tsx
+++ b/packages/web/src/components/settings/models-settings.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { mutate } from "swr";
 import { toast } from "sonner";
-import { MODEL_OPTIONS, DEFAULT_ENABLED_MODELS } from "@open-inspect/shared";
+import { MODEL_OPTIONS, DEFAULT_ENABLED_MODELS } from "@open-inspect/shared/models";
 import { MODEL_PREFERENCES_KEY, useEnabledModels } from "@/hooks/use-enabled-models";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";

--- a/packages/web/src/hooks/use-enabled-models.test.tsx
+++ b/packages/web/src/hooks/use-enabled-models.test.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 import { describe, expect, it } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { SWRConfig } from "swr";
-import { DEFAULT_ENABLED_MODELS } from "@open-inspect/shared";
+import { DEFAULT_ENABLED_MODELS } from "@open-inspect/shared/models";
 import { MODEL_PREFERENCES_KEY, useEnabledModels } from "./use-enabled-models";
 
 function wrapper(enabledModels: unknown) {

--- a/packages/web/src/hooks/use-enabled-models.ts
+++ b/packages/web/src/hooks/use-enabled-models.ts
@@ -5,7 +5,7 @@ import {
   DEFAULT_ENABLED_MODELS,
   normalizeValidModels,
   type ModelCategory,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/models";
 
 export const MODEL_PREFERENCES_KEY = "/api/model-preferences";
 

--- a/packages/web/src/lib/automation-templates.test.ts
+++ b/packages/web/src/lib/automation-templates.test.ts
@@ -3,14 +3,12 @@ import {
   triggerSources,
   isValidCron,
   cronIntervalMinutes,
-  isValidModel,
-  isValidReasoningEffort,
   validateConditions,
   conditionRegistry,
   TRIGGER_TYPE_TO_SOURCE,
-  DEFAULT_MODEL,
   type AutomationTriggerType,
 } from "@open-inspect/shared";
+import { DEFAULT_MODEL, isValidModel, isValidReasoningEffort } from "@open-inspect/shared/models";
 import {
   automationTemplates,
   TEMPLATE_CATEGORIES,

--- a/packages/web/src/lib/browser-auth-proxy.ts
+++ b/packages/web/src/lib/browser-auth-proxy.ts
@@ -1,4 +1,7 @@
-import { BROWSER_AUTH_CLIENT_IP_HEADER, isBrowserAuthProxyRoute } from "@open-inspect/shared";
+import {
+  BROWSER_AUTH_CLIENT_IP_HEADER,
+  isBrowserAuthProxyRoute,
+} from "@open-inspect/shared/browser-auth-routes";
 import { dispatchWebServiceRequest } from "./control-plane-service";
 
 const REQUEST_HEADERS = [

--- a/packages/web/src/lib/browser-auth-session-contract.ts
+++ b/packages/web/src/lib/browser-auth-session-contract.ts
@@ -1,4 +1,4 @@
-import { isCanonicalUserId } from "@open-inspect/shared";
+import { isCanonicalUserId } from "@open-inspect/shared/user-id";
 import { z } from "zod";
 
 export const browserAuthSessionUserSchema = z.object({

--- a/packages/web/src/lib/format.ts
+++ b/packages/web/src/lib/format.ts
@@ -2,7 +2,7 @@
  * Utility functions for formatting display values
  */
 
-import { MODEL_OPTIONS, normalizeModelId } from "@open-inspect/shared";
+import { MODEL_OPTIONS, normalizeModelId } from "@open-inspect/shared/models";
 
 // Build a lookup map once at module level
 const MODEL_DISPLAY_NAMES = new Map<string, string>(

--- a/packages/web/src/lib/model-selection.test.ts
+++ b/packages/web/src/lib/model-selection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { DEFAULT_MODEL, getDefaultReasoningEffort } from "@open-inspect/shared";
+import { DEFAULT_MODEL, getDefaultReasoningEffort } from "@open-inspect/shared/models";
 import { resolveEnabledModel, resolveModelPreference } from "./model-selection";
 
 describe("resolveEnabledModel", () => {

--- a/packages/web/src/lib/model-selection.ts
+++ b/packages/web/src/lib/model-selection.ts
@@ -4,7 +4,7 @@ import {
   getValidModelOrDefault,
   isValidReasoningEffort,
   resolveEnabledModel as resolveSharedEnabledModel,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/models";
 
 export interface ModelPreference {
   model: string;


### PR DESCRIPTION
## Summary

- expose the existing user-id, GitHub identity, and browser-auth-route owner modules as direct shared package paths
- migrate every remaining control-plane and web model symbol to the existing models path
- preserve the shared root exports for compatibility and split mixed imports without changing behavior
- deliver the identity/browser and model migrations as separate commits inside one larger CI/review wave

## Dependency impact

- 34 production files and 10 existing test files migrated
- production root consumers: 231 -> 214 (-17) against current main
- no migrated symbols remain imported from the shared root
- no new source modules, facades, dependency cycles, lint ratchets, or tests

## Validation

- shared: build, typecheck, lint, 38 files / 514 tests passed
- control-plane: build, typecheck, lint, 136 files / 2,137 tests passed
- web: production build, typecheck, lint, 105 files / 815 tests passed
- direct runtime resolution for all four owner paths
- Prettier check and git diff check
- independent architecture and simplicity reviews: no findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user record normalization, including consistent email casing, name handling, identifier validation, and reliable timestamp storage.
* **Refactor**
  * Improved consistency in shared authentication, model, browser sign-in, and user-identity handling across the application.
  * Added dedicated shared access points for browser authentication and user identity utilities.
  * Standardized type and model configuration imports without changing existing application behavior.
* **Tests**
  * Updated related authentication, model, automation, and session test coverage to use the reorganized shared utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->