### PR TITLE
Import shared resources from owner modules

### DIFF
--- a/packages/control-plane/src/db/environments.ts
+++ b/packages/control-plane/src/db/environments.ts
@@ -8,7 +8,7 @@
  * repository and image rows (design §7.2).
  */
 
-import type { Environment, EnvironmentRepository } from "@open-inspect/shared";
+import type { Environment, EnvironmentRepository } from "@open-inspect/shared/types/environments";
 import { parseJsonStringArray } from "./json-columns";
 import type { SqlDatabase, SqlStatement } from "./sql-database";
 

--- a/packages/control-plane/src/db/image-builds.ts
+++ b/packages/control-plane/src/db/image-builds.ts
@@ -3,7 +3,7 @@ import {
   type ImageBuildScopeKind,
   type ImageBuildStatus,
   type RepositoryShaEntry,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/image-builds";
 import type {
   ImageBuildProvider,
   ImageBuildScope,

--- a/packages/control-plane/src/db/integration-settings.ts
+++ b/packages/control-plane/src/db/integration-settings.ts
@@ -1,13 +1,12 @@
+import { DEFAULT_MENTIONS_POLICY, parseRepositoryFullName } from "@open-inspect/shared";
+import { isEnvironmentId } from "@open-inspect/shared/types/environments";
 import {
-  isEnvironmentId,
   ENVIRONMENT_SETTINGS_INTEGRATION_IDS,
   INTEGRATION_DEFINITIONS,
-  DEFAULT_MENTIONS_POLICY,
   MAX_SESSION_INSTRUCTIONS_LENGTH,
   MAX_SLACK_ROUTING_RULES,
   MAX_SLACK_ROUTING_KEYWORD_LENGTH,
   normalizeRoutingRules,
-  parseRepositoryFullName,
   type EnvironmentSettingsIntegrationId,
   type IntegrationId,
   type IntegrationSettingsMap,
@@ -17,7 +16,7 @@ import {
   type SlackGlobalSettings,
   type SlackMentionsPolicy,
   type SlackRoutingRule,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/integrations";
 import { isValidModel, isValidReasoningEffort } from "@open-inspect/shared/models";
 import { normalizeSandboxSettings } from "../sandbox/settings";
 import type { SqlDatabase } from "./sql-database";

--- a/packages/control-plane/src/image-builds/errors.ts
+++ b/packages/control-plane/src/image-builds/errors.ts
@@ -3,7 +3,7 @@
  * workflow and planner throw these instead of returning Responses.
  */
 
-import type { ImageBuildScopeKind } from "@open-inspect/shared";
+import type { ImageBuildScopeKind } from "@open-inspect/shared/types/image-builds";
 
 export type ImageBuildErrorCode =
   | "scope_not_found"

--- a/packages/control-plane/src/image-builds/model.ts
+++ b/packages/control-plane/src/image-builds/model.ts
@@ -9,12 +9,11 @@
  * (`repository_shas`) and spawn selection is gated by the runtime version
  * baked at build time.
  */
-import {
-  formatRepositoryFullName,
-  parseRepositoryFullName,
-  type ImageBuildScopeKind,
-  type ImageBuildStatus,
-} from "@open-inspect/shared";
+import { formatRepositoryFullName, parseRepositoryFullName } from "@open-inspect/shared";
+import type {
+  ImageBuildScopeKind,
+  ImageBuildStatus,
+} from "@open-inspect/shared/types/image-builds";
 
 /**
  * Providers with image-build support: Modal images, Vercel snapshots,

--- a/packages/control-plane/src/image-builds/types.ts
+++ b/packages/control-plane/src/image-builds/types.ts
@@ -1,4 +1,4 @@
-import type { RepositoryShaEntry } from "@open-inspect/shared";
+import type { RepositoryShaEntry } from "@open-inspect/shared/types/image-builds";
 import type { CorrelationContext } from "../logger";
 import type { ImageBuildProvider, ImageBuildProviderImageRef, ImageBuildScope } from "./model";
 

--- a/packages/control-plane/src/image-builds/workflow.ts
+++ b/packages/control-plane/src/image-builds/workflow.ts
@@ -30,7 +30,7 @@ import {
 import { ImageBuildReaper } from "./reaper";
 import { resolveImageBuildProvider } from "./provider-policy";
 import { createImageBuildAdapterFactory, type ImageBuildAdapterFactory } from "./provider-factory";
-import type { RepositoryShaEntry } from "@open-inspect/shared";
+import type { RepositoryShaEntry } from "@open-inspect/shared/types/image-builds";
 import type {
   ImageBuildAdapter,
   CompleteImageBuildCallback,

--- a/packages/control-plane/src/routes/automations.ts
+++ b/packages/control-plane/src/routes/automations.ts
@@ -36,9 +36,9 @@ import { generateWebhookApiKey, hashApiKey, encryptSentrySecret } from "../auth/
 import { createLogger } from "../logger";
 import {
   automationRepositoriesInputSchema,
-  isEnvironmentId,
   MAX_AUTOMATION_REPOSITORIES,
 } from "@open-inspect/shared";
+import { isEnvironmentId } from "@open-inspect/shared/types/environments";
 import {
   type Route,
   type RequestContext,

--- a/packages/control-plane/src/routes/environments.ts
+++ b/packages/control-plane/src/routes/environments.ts
@@ -6,7 +6,10 @@
  * live in ./environment-secrets.
  */
 
-import { createEnvironmentInputSchema, updateEnvironmentInputSchema } from "@open-inspect/shared";
+import {
+  createEnvironmentInputSchema,
+  updateEnvironmentInputSchema,
+} from "@open-inspect/shared/types/environments";
 import {
   EnvironmentStore,
   toEnvironment,

--- a/packages/control-plane/src/routes/image-builds.ts
+++ b/packages/control-plane/src/routes/image-builds.ts
@@ -8,7 +8,10 @@
  * - Enabled-scope and status queries
  */
 
-import type { ImageBuildRecordView, RepositoryShaEntry } from "@open-inspect/shared";
+import type {
+  ImageBuildRecordView,
+  RepositoryShaEntry,
+} from "@open-inspect/shared/types/image-builds";
 import { ImageBuildStore } from "../db/image-builds";
 import { RepoMetadataStore } from "../db/repo-metadata";
 import { createLogger } from "../logger";

--- a/packages/control-plane/src/sandbox/client.ts
+++ b/packages/control-plane/src/sandbox/client.ts
@@ -5,9 +5,9 @@
  * All requests are authenticated using HMAC-signed tokens.
  */
 
-import type { SandboxSettings } from "@open-inspect/shared";
 import { generateInternalToken } from "@open-inspect/shared/auth";
-import type { ImageBuildScopeKind, McpServerConfig } from "@open-inspect/shared";
+import type { ImageBuildScopeKind } from "@open-inspect/shared/types/image-builds";
+import type { McpServerConfig, SandboxSettings } from "@open-inspect/shared/types/integrations";
 import { z } from "zod";
 import { createLogger } from "../logger";
 import type { CorrelationContext } from "../logger";

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -5,7 +5,7 @@
  * enabling unit testing and future provider abstraction.
  */
 
-import type { ImageBuildScopeKind } from "@open-inspect/shared";
+import type { ImageBuildScopeKind } from "@open-inspect/shared/types/image-builds";
 import { ModalApiError } from "../client";
 import type { ModalClient } from "../client";
 import type { CorrelationContext } from "../../logger";

--- a/packages/linear-bot/src/types.ts
+++ b/packages/linear-bot/src/types.ts
@@ -79,9 +79,11 @@ export type {
   RepoMetadata,
   ControlPlaneRepo,
   ControlPlaneReposResponse,
+} from "@open-inspect/shared";
+export type {
   Environment,
   ListEnvironmentsResponse,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/environments";
 
 /**
  * Project→target mapping stored in KV under "config:project-repos".

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -46,9 +46,21 @@
       "import": "./dist/types/commit-signing.js",
       "types": "./dist/types/commit-signing.d.ts"
     },
+    "./types/environments": {
+      "import": "./dist/types/environments.js",
+      "types": "./dist/types/environments.d.ts"
+    },
     "./types/github-identity": {
       "import": "./dist/types/github-identity.js",
       "types": "./dist/types/github-identity.d.ts"
+    },
+    "./types/image-builds": {
+      "import": "./dist/types/image-builds.js",
+      "types": "./dist/types/image-builds.d.ts"
+    },
+    "./types/integrations": {
+      "import": "./dist/types/integrations.js",
+      "types": "./dist/types/integrations.d.ts"
     }
   },
   "scripts": {

--- a/packages/slack-bot/src/classifier/environments.ts
+++ b/packages/slack-bot/src/classifier/environments.ts
@@ -8,7 +8,10 @@
  * like rules targeting an inaccessible repository.
  */
 
-import type { Environment, ListEnvironmentsResponse } from "@open-inspect/shared";
+import type {
+  Environment,
+  ListEnvironmentsResponse,
+} from "@open-inspect/shared/types/environments";
 import type { Env } from "../types";
 import { createCachedResource } from "./cached-resource";
 import { fetchControlPlaneJson } from "./control-plane";

--- a/packages/slack-bot/src/classifier/routing.ts
+++ b/packages/slack-bot/src/classifier/routing.ts
@@ -6,7 +6,8 @@
  * target-kind dispatch and no fetching (routing rules aside).
  */
 
-import { isEnvironmentId, matchRoutingRules } from "@open-inspect/shared";
+import { isEnvironmentId } from "@open-inspect/shared/types/environments";
+import { matchRoutingRules } from "@open-inspect/shared/types/integrations";
 import type { Env } from "../types";
 import { targetValue, type SlackSessionTarget } from "../targets";
 import { getRoutingRules } from "./repos";

--- a/packages/slack-bot/src/sessions/control-plane-client.test.ts
+++ b/packages/slack-bot/src/sessions/control-plane-client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { Environment } from "@open-inspect/shared";
+import type { Environment } from "@open-inspect/shared/types/environments";
 import type { Env } from "../types";
 import { createSession, sendPrompt } from "./control-plane-client";
 import { OUTBOUND_REQUEST_TIMEOUT_MS } from "../request-options";

--- a/packages/slack-bot/src/targets.ts
+++ b/packages/slack-bot/src/targets.ts
@@ -12,7 +12,8 @@
  * including the types barrel, can import it.
  */
 
-import type { Environment, RepoConfig } from "@open-inspect/shared";
+import type { RepoConfig } from "@open-inspect/shared";
+import type { Environment } from "@open-inspect/shared/types/environments";
 
 export type SlackSessionTarget =
   | { kind: "repository"; repo: RepoConfig }

--- a/packages/slack-bot/src/types/index.ts
+++ b/packages/slack-bot/src/types/index.ts
@@ -81,7 +81,8 @@ export interface ClassificationResult {
   needsClarification: boolean;
 }
 
-export type { ConfidenceLevel, Environment } from "@open-inspect/shared";
+export type { ConfidenceLevel } from "@open-inspect/shared";
+export type { Environment } from "@open-inspect/shared/types/environments";
 export type { SlackSessionTarget } from "../targets";
 
 /**

--- a/packages/web/src/app/api/environments/[id]/images/route.ts
+++ b/packages/web/src/app/api/environments/[id]/images/route.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { getServerAuthSession } from "@/lib/server-auth-session";
-import type { ImageBuildRecordView } from "@open-inspect/shared";
+import type { ImageBuildRecordView } from "@open-inspect/shared/types/image-builds";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import { excludeSupersededBuilds } from "@/lib/image-builds";
 import { supportsRepoImages } from "@/lib/sandbox-provider";

--- a/packages/web/src/app/api/image-builds/route.ts
+++ b/packages/web/src/app/api/image-builds/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getServerAuthSession } from "@/lib/server-auth-session";
-import type { ImageBuildRecordView } from "@open-inspect/shared";
+import type { ImageBuildRecordView } from "@open-inspect/shared/types/image-builds";
 import { controlPlaneUserFetch } from "@/lib/control-plane";
 import {
   excludeSupersededBuilds,

--- a/packages/web/src/components/settings/environment-form.test.tsx
+++ b/packages/web/src/components/settings/environment-form.test.tsx
@@ -5,7 +5,8 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as matchers from "@testing-library/jest-dom/matchers";
-import { MAX_TARGET_REPOSITORIES, type Environment } from "@open-inspect/shared";
+import { MAX_TARGET_REPOSITORIES } from "@open-inspect/shared";
+import type { Environment } from "@open-inspect/shared/types/environments";
 import { EnvironmentForm } from "./environment-form";
 
 expect.extend(matchers);

--- a/packages/web/src/components/settings/environment-form.tsx
+++ b/packages/web/src/components/settings/environment-form.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { useCallback, useMemo, useState } from "react";
+import { parseRepositoryFullName, type RepositoryInput } from "@open-inspect/shared";
 import {
   MAX_ENVIRONMENT_NAME_LENGTH,
   MAX_ENVIRONMENT_DESCRIPTION_LENGTH,
-  parseRepositoryFullName,
   type Environment,
-  type RepositoryInput,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/environments";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";

--- a/packages/web/src/components/settings/environment-integration-settings.tsx
+++ b/packages/web/src/components/settings/environment-integration-settings.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react";
 import useSWR from "swr";
 import { toast } from "sonner";
-import type { CodeServerSettings, EnvironmentRepository } from "@open-inspect/shared";
+import type { EnvironmentRepository } from "@open-inspect/shared/types/environments";
+import type { CodeServerSettings } from "@open-inspect/shared/types/integrations";
 import { Button } from "@/components/ui/button";
 import { browserApiFetch, type BrowserApiPath } from "@/lib/browser-api-fetch";
 import {

--- a/packages/web/src/components/settings/environment-secrets-import.tsx
+++ b/packages/web/src/components/settings/environment-secrets-import.tsx
@@ -3,11 +3,8 @@
 import { useMemo, useState } from "react";
 import useSWR, { mutate } from "swr";
 import { toast } from "sonner";
-import {
-  encodeRepositoryPathSegments,
-  formatRepositoryFullName,
-  type EnvironmentRepository,
-} from "@open-inspect/shared";
+import { encodeRepositoryPathSegments, formatRepositoryFullName } from "@open-inspect/shared";
+import type { EnvironmentRepository } from "@open-inspect/shared/types/environments";
 import { Button } from "@/components/ui/button";
 import { Combobox } from "@/components/ui/combobox";
 import { RepoIcon, ChevronDownIcon } from "@/components/ui/icons";

--- a/packages/web/src/components/settings/environments-settings.tsx
+++ b/packages/web/src/components/settings/environments-settings.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react";
 import useSWR, { mutate } from "swr";
 import { toast } from "sonner";
-import type { Environment, ImageBuildRecordView } from "@open-inspect/shared";
+import type { Environment } from "@open-inspect/shared/types/environments";
+import type { ImageBuildRecordView } from "@open-inspect/shared/types/image-builds";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";

--- a/packages/web/src/components/settings/image-build-status.tsx
+++ b/packages/web/src/components/settings/image-build-status.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ImageBuildStatus as ImageBuildStatusValue } from "@open-inspect/shared";
+import type { ImageBuildStatus as ImageBuildStatusValue } from "@open-inspect/shared/types/image-builds";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { formatRelativeTime } from "@/lib/time";
 

--- a/packages/web/src/components/settings/images-settings.tsx
+++ b/packages/web/src/components/settings/images-settings.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import useSWR, { mutate } from "swr";
-import type { ImageBuildRecordView } from "@open-inspect/shared";
+import type { ImageBuildRecordView } from "@open-inspect/shared/types/image-builds";
 import { useRepos } from "@/hooks/use-repos";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
@@ -5,13 +5,13 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { act, cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as matchers from "@testing-library/jest-dom/matchers";
-import { MAX_SLACK_ROUTING_RULES } from "@open-inspect/shared";
-import type {
-  Environment,
-  SlackGlobalConfig,
-  SlackRepoSettings,
-  EnrichedRepository,
-} from "@open-inspect/shared";
+import type { EnrichedRepository } from "@open-inspect/shared";
+import type { Environment } from "@open-inspect/shared/types/environments";
+import {
+  MAX_SLACK_ROUTING_RULES,
+  type SlackGlobalConfig,
+  type SlackRepoSettings,
+} from "@open-inspect/shared/types/integrations";
 import { SlackIntegrationSettings } from "./slack-integration-settings";
 
 expect.extend(matchers);

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
@@ -6,18 +6,22 @@ import { toast } from "sonner";
 import {
   DEFAULT_MENTIONS_POLICY,
   encodeRepositoryPathSegments,
-  MAX_SESSION_INSTRUCTIONS_LENGTH,
-  MAX_SLACK_ROUTING_RULES,
   parseRepositoryFullName,
   type EnrichedRepository,
-  type Environment,
-  type ListEnvironmentsResponse,
+} from "@open-inspect/shared";
+import type {
+  Environment,
+  ListEnvironmentsResponse,
+} from "@open-inspect/shared/types/environments";
+import {
+  MAX_SESSION_INSTRUCTIONS_LENGTH,
+  MAX_SLACK_ROUTING_RULES,
   type SlackGlobalConfig,
   type SlackGlobalSettings,
   type SlackMentionsPolicy,
   type SlackRepoSettings,
   type SlackRoutingRule,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/integrations";
 import { MODEL_OPTIONS } from "@open-inspect/shared/models";
 import { browserApiFetch } from "@/lib/browser-api-fetch";
 import { useEnabledModels } from "@/hooks/use-enabled-models";

--- a/packages/web/src/hooks/use-environments.ts
+++ b/packages/web/src/hooks/use-environments.ts
@@ -1,6 +1,9 @@
 import useSWR from "swr";
 import { useAuthSession } from "@/lib/auth-session";
-import type { Environment, ListEnvironmentsResponse } from "@open-inspect/shared";
+import type {
+  Environment,
+  ListEnvironmentsResponse,
+} from "@open-inspect/shared/types/environments";
 
 export const ENVIRONMENTS_KEY = "/api/environments";
 

--- a/packages/web/src/hooks/use-session-target-picker.test.ts
+++ b/packages/web/src/hooks/use-session-target-picker.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import type { Environment, ImageBuildRecordView, ImageBuildStatus } from "@open-inspect/shared";
+import type { Environment } from "@open-inspect/shared/types/environments";
+import type {
+  ImageBuildRecordView,
+  ImageBuildStatus,
+} from "@open-inspect/shared/types/image-builds";
 import { foldImageBuildStatusByScope, imageBuildScopeKey } from "@/lib/image-builds";
 import type { Repo } from "@/hooks/use-repos";
 import { describeEnvironment, describeRepository } from "./use-session-target-picker";

--- a/packages/web/src/hooks/use-session-target-picker.ts
+++ b/packages/web/src/hooks/use-session-target-picker.ts
@@ -2,11 +2,9 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
-import {
-  parseRepositoryFullName,
-  type Environment,
-  type ImageBuildStatus,
-} from "@open-inspect/shared";
+import { parseRepositoryFullName } from "@open-inspect/shared";
+import type { Environment } from "@open-inspect/shared/types/environments";
+import type { ImageBuildStatus } from "@open-inspect/shared/types/image-builds";
 import type { ComboboxGroup, ComboboxOption } from "@/components/ui/combobox";
 import { useBranches } from "@/hooks/use-branches";
 import { useEnvironments } from "@/hooks/use-environments";

--- a/packages/web/src/lib/image-builds.test.ts
+++ b/packages/web/src/lib/image-builds.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { ImageBuildRecordView } from "@open-inspect/shared";
+import type { ImageBuildRecordView } from "@open-inspect/shared/types/image-builds";
 import {
   excludeSupersededBuilds,
   foldEnabledRepoScopeIds,

--- a/packages/web/src/lib/image-builds.ts
+++ b/packages/web/src/lib/image-builds.ts
@@ -9,7 +9,7 @@ import type {
   ImageBuildRecordView,
   ImageBuildScopeKind,
   ImageBuildStatus,
-} from "@open-inspect/shared";
+} from "@open-inspect/shared/types/image-builds";
 
 /** SWR key for the unified image-build feed. */
 export const IMAGE_BUILDS_KEY = "/api/image-builds";


### PR DESCRIPTION
## Summary
- expose the existing environment, image-build, and integration type owners as supported shared package entry points
- migrate every environment and image-build consumer in scope, plus integration symbols already touched by those resource files
- preserve the shared root exports for compatibility; analytics and the remaining integration imports stay deferred

## Dependency impact
- updates 30 production files and 5 existing test files
- reduces production imports from the shared root from 217 to 197
- reduces test imports from the shared root from 46 to 43
- introduces no new source modules, facades, cycles, lint ratchets, tests, or ESM changes

This is intentionally a resource-scoped integration migration, not a complete migration of all integration types.

## Validation
- shared, control-plane, web, Slack bot, and Linear bot typechecks
- shared, control-plane, web, Slack bot, and Linear bot production builds
- shared, control-plane unit/integration, web, Slack bot, and Linear bot tests: 4,753 passing
- shared, control-plane, web, Slack bot, and Linear bot lint
- Prettier and `git diff --check`
- independent architecture and simplicity reviews found no blockers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Organized shared environment, image-build, and integration types into dedicated modules.
  * Added direct shared type entry points for improved import consistency across the application.
  * Updated internal imports and re-exports without changing runtime behavior, APIs, or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->