### PR TITLE
Keep Slack events running when dedupe KV fails

### DIFF
--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -386,18 +386,13 @@ function sessionFetchBodies(fetchMock: { mock: { calls: readonly (readonly unkno
     .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as Record<string, unknown>);
 }
 
-function slackEventRequest(
-  event: Record<string, unknown>,
-  eventId = crypto.randomUUID(),
-  headers: Record<string, string> = {}
-): Request {
+function slackEventRequest(event: Record<string, unknown>, eventId = crypto.randomUUID()): Request {
   return new Request("http://localhost/events", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       "x-slack-signature": "v0=test",
       "x-slack-request-timestamp": `${Math.floor(Date.now() / 1000)}`,
-      ...headers,
     },
     body: JSON.stringify({
       type: "event_callback",
@@ -416,71 +411,6 @@ describe("POST /events", () => {
     mockVerifySlackSignature.mockResolvedValue(true);
     mockGetUserInfo.mockResolvedValue({ ok: true, user: undefined });
   });
-
-  it.each(["get", "put"] as const)(
-    "acknowledges, logs context, and processes the event when dedupe KV %s fails",
-    async (kvOperation) => {
-      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
-      const env = makeEnv();
-      const ctx = makeCtx();
-      const eventId = "Ev-kv-unavailable";
-      mockPublishView.mockResolvedValue({ ok: true });
-      const kv = env.SLACK_KV as unknown as {
-        get: ReturnType<typeof vi.fn>;
-        put: ReturnType<typeof vi.fn>;
-      };
-      kv[kvOperation].mockRejectedValueOnce(
-        Object.assign(new Error("KV unavailable"), { code: "KV_UNAVAILABLE" })
-      );
-
-      const response = await app.fetch(
-        slackEventRequest(
-          {
-            type: "app_home_opened",
-            tab: "home",
-            user: "U123",
-          },
-          eventId,
-          {
-            "x-slack-retry-num": "2",
-            "x-slack-retry-reason": "http_error",
-          }
-        ),
-        env,
-        ctx
-      );
-
-      expect(response.status).toBe(200);
-      expect(await response.json()).toEqual({ ok: true });
-      expect(ctx.waitUntil).toHaveBeenCalledOnce();
-      await flushWaitUntil(ctx);
-      expect(mockPublishView).toHaveBeenCalledOnce();
-
-      const logEntry = consoleError.mock.calls
-        .map(([line]) => JSON.parse(String(line)) as Record<string, unknown>)
-        .find((entry) => entry.msg === "slack.event.dedupe_unavailable");
-      expect(logEntry).toEqual(
-        expect.objectContaining({
-          level: "error",
-          service: "slack-bot",
-          component: "handler",
-          event_id: eventId,
-          event_type: "app_home_opened",
-          kv_operation: kvOperation,
-          slack_retry_num: "2",
-          slack_retry_reason: "http_error",
-          outcome: "degraded",
-          degradation_mode: "process_without_deduplication",
-          error_message: "KV unavailable",
-          error_type: "Error",
-          error_code: "KV_UNAVAILABLE",
-        })
-      );
-      expect(logEntry?.trace_id).toEqual(expect.any(String));
-      expect(logEntry?.error_stack).toEqual(expect.any(String));
-      consoleError.mockRestore();
-    }
-  );
 
   it("publishes App Home when the home tab is opened", async () => {
     mockPublishView.mockResolvedValue({ ok: true });

--- a/packages/slack-bot/src/index.test.ts
+++ b/packages/slack-bot/src/index.test.ts
@@ -386,13 +386,18 @@ function sessionFetchBodies(fetchMock: { mock: { calls: readonly (readonly unkno
     .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as Record<string, unknown>);
 }
 
-function slackEventRequest(event: Record<string, unknown>, eventId = crypto.randomUUID()): Request {
+function slackEventRequest(
+  event: Record<string, unknown>,
+  eventId = crypto.randomUUID(),
+  headers: Record<string, string> = {}
+): Request {
   return new Request("http://localhost/events", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       "x-slack-signature": "v0=test",
       "x-slack-request-timestamp": `${Math.floor(Date.now() / 1000)}`,
+      ...headers,
     },
     body: JSON.stringify({
       type: "event_callback",
@@ -411,6 +416,71 @@ describe("POST /events", () => {
     mockVerifySlackSignature.mockResolvedValue(true);
     mockGetUserInfo.mockResolvedValue({ ok: true, user: undefined });
   });
+
+  it.each(["get", "put"] as const)(
+    "acknowledges, logs context, and processes the event when dedupe KV %s fails",
+    async (kvOperation) => {
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      const env = makeEnv();
+      const ctx = makeCtx();
+      const eventId = "Ev-kv-unavailable";
+      mockPublishView.mockResolvedValue({ ok: true });
+      const kv = env.SLACK_KV as unknown as {
+        get: ReturnType<typeof vi.fn>;
+        put: ReturnType<typeof vi.fn>;
+      };
+      kv[kvOperation].mockRejectedValueOnce(
+        Object.assign(new Error("KV unavailable"), { code: "KV_UNAVAILABLE" })
+      );
+
+      const response = await app.fetch(
+        slackEventRequest(
+          {
+            type: "app_home_opened",
+            tab: "home",
+            user: "U123",
+          },
+          eventId,
+          {
+            "x-slack-retry-num": "2",
+            "x-slack-retry-reason": "http_error",
+          }
+        ),
+        env,
+        ctx
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ ok: true });
+      expect(ctx.waitUntil).toHaveBeenCalledOnce();
+      await flushWaitUntil(ctx);
+      expect(mockPublishView).toHaveBeenCalledOnce();
+
+      const logEntry = consoleError.mock.calls
+        .map(([line]) => JSON.parse(String(line)) as Record<string, unknown>)
+        .find((entry) => entry.msg === "slack.event.dedupe_unavailable");
+      expect(logEntry).toEqual(
+        expect.objectContaining({
+          level: "error",
+          service: "slack-bot",
+          component: "handler",
+          event_id: eventId,
+          event_type: "app_home_opened",
+          kv_operation: kvOperation,
+          slack_retry_num: "2",
+          slack_retry_reason: "http_error",
+          outcome: "degraded",
+          degradation_mode: "process_without_deduplication",
+          error_message: "KV unavailable",
+          error_type: "Error",
+          error_code: "KV_UNAVAILABLE",
+        })
+      );
+      expect(logEntry?.trace_id).toEqual(expect.any(String));
+      expect(logEntry?.error_stack).toEqual(expect.any(String));
+      consoleError.mockRestore();
+    }
+  );
 
   it("publishes App Home when the home tab is opened", async () => {
     mockPublishView.mockResolvedValue({ ok: true });

--- a/packages/slack-bot/src/routes/events.test.ts
+++ b/packages/slack-bot/src/routes/events.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "../types";
+
+const { mockHandleSlackEvent, mockVerifySlackSignature } = vi.hoisted(() => ({
+  mockHandleSlackEvent: vi.fn(),
+  mockVerifySlackSignature: vi.fn(),
+}));
+
+vi.mock("@open-inspect/shared", () => {
+  return { verifySlackSignature: mockVerifySlackSignature };
+});
+
+vi.mock("../events/dispatcher", () => ({
+  handleSlackEvent: mockHandleSlackEvent,
+}));
+
+import { eventRoutes } from "./events";
+
+const EVENT_ID = "Ev-kv-unavailable";
+
+function makeEnv(kvOperation: "get" | "put"): Env {
+  const kv = {
+    get: vi.fn().mockResolvedValue(null),
+    put: vi.fn().mockResolvedValue(undefined),
+  };
+  kv[kvOperation].mockRejectedValueOnce(
+    Object.assign(new Error("KV unavailable"), { code: "KV_UNAVAILABLE" })
+  );
+  return { SLACK_KV: kv } as unknown as Env;
+}
+
+function eventRequest(): Request {
+  return new Request("http://localhost/events", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-slack-signature": "v0=test",
+      "x-slack-request-timestamp": `${Math.floor(Date.now() / 1000)}`,
+      "x-slack-retry-num": "2",
+      "x-slack-retry-reason": "http_error",
+    },
+    body: JSON.stringify({
+      type: "event_callback",
+      event_id: EVENT_ID,
+      event: {
+        type: "app_home_opened",
+        tab: "home",
+        user: "U123",
+      },
+    }),
+  });
+}
+
+function makeCtx() {
+  return {
+    props: {},
+    waitUntil: vi.fn(),
+    passThroughOnException: vi.fn(),
+  } as any;
+}
+
+describe("POST /events deduplication", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVerifySlackSignature.mockResolvedValue(true);
+    mockHandleSlackEvent.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each(["get", "put"] as const)(
+    "acknowledges, logs context, and dispatches when dedupe KV %s fails",
+    async (kvOperation) => {
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      const env = makeEnv(kvOperation);
+      const ctx = makeCtx();
+
+      const response = await eventRoutes.fetch(eventRequest(), env, ctx);
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({ ok: true });
+      expect(ctx.waitUntil).toHaveBeenCalledOnce();
+      await ctx.waitUntil.mock.calls[0][0];
+      expect(mockHandleSlackEvent).toHaveBeenCalledOnce();
+
+      const logEntry = consoleError.mock.calls
+        .map(([line]) => JSON.parse(String(line)) as Record<string, unknown>)
+        .find((entry) => entry.msg === "slack.event.dedupe_unavailable");
+      expect(logEntry).toEqual(
+        expect.objectContaining({
+          level: "error",
+          service: "slack-bot",
+          component: "handler",
+          event_id: EVENT_ID,
+          event_type: "app_home_opened",
+          kv_operation: kvOperation,
+          slack_retry_num: "2",
+          slack_retry_reason: "http_error",
+          outcome: "degraded",
+          degradation_mode: "process_without_deduplication",
+          error_message: "KV unavailable",
+          error_type: "Error",
+          error_code: "KV_UNAVAILABLE",
+        })
+      );
+      expect(logEntry?.trace_id).toEqual(expect.any(String));
+      expect(logEntry?.error_stack).toEqual(expect.any(String));
+    }
+  );
+});

--- a/packages/slack-bot/src/routes/events.ts
+++ b/packages/slack-bot/src/routes/events.ts
@@ -41,11 +41,28 @@ eventRoutes.post("/events", async (c) => {
   if (eventId) {
     const cacheStore = createKvCacheStore(c.env.SLACK_KV);
     const dedupeKey = `event:${eventId}`;
-    if (await cacheStore.get(dedupeKey)) {
-      log.debug("slack.event.duplicate", { trace_id: traceId, event_id: eventId });
-      return c.json({ ok: true });
+    let kvOperation: "get" | "put" = "get";
+    try {
+      if (await cacheStore.get(dedupeKey)) {
+        log.debug("slack.event.duplicate", { trace_id: traceId, event_id: eventId });
+        return c.json({ ok: true });
+      }
+      kvOperation = "put";
+      await cacheStore.put(dedupeKey, "1", { expirationTtl: EVENT_DEDUPE_TTL_MS / 1000 });
+    } catch (error) {
+      // This cache is best-effort. Returning 500 would drop the original work and guarantee retries.
+      log.error("slack.event.dedupe_unavailable", {
+        trace_id: traceId,
+        event_id: eventId,
+        event_type: payload.event?.type,
+        kv_operation: kvOperation,
+        slack_retry_num: c.req.header("x-slack-retry-num"),
+        slack_retry_reason: c.req.header("x-slack-retry-reason"),
+        outcome: "degraded",
+        degradation_mode: "process_without_deduplication",
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
     }
-    await cacheStore.put(dedupeKey, "1", { expirationTtl: EVENT_DEDUPE_TTL_MS / 1000 });
   }
   const scheduleBackground = (promise: Promise<void>) => c.executionCtx.waitUntil(promise);
   const eventTask = Promise.resolve().then(() =>


### PR DESCRIPTION
## Summary

- treat Slack event-deduplication KV as a best-effort cache
- continue dispatching and acknowledge Slack when the dedupe read or write fails
- emit a structured `slack.event.dedupe_unavailable` error with trace, event, retry, operation, degradation, and normalized error context
- cover both KV read and write failures with an observable App Home dispatch

## Root cause

When the Cloudflare account exhausted its Workers KV write allowance, the synchronous event-dedupe write threw before `/events` returned its acknowledgement. Each original Slack event returned `500`, was never dispatched, and was retried three times by Slack. Cloudflare surfaced only bundled stack offsets, which made the storage failure difficult to identify.

## Impact

KV deduplication failures now fail open: Slack receives `200`, the event continues processing, and operators get a searchable structured error. This trades a bounded risk of duplicate processing during a cache outage for continued ingress availability and avoids guaranteed retry storms.

## Validation

- `npm test -w @open-inspect/slack-bot` — 381 tests passed
- `npm run typecheck -w @open-inspect/slack-bot`
- `npm run lint -w @open-inspect/slack-bot`
- `npx prettier --check packages/slack-bot/src/routes/events.ts packages/slack-bot/src/index.test.ts`
- `npm run build -w @open-inspect/slack-bot`
- thermo-nuclear review completed; its test-coverage finding was addressed
- simplification review completed with no remaining findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Slack event processing now continues successfully when event deduplication storage is temporarily unavailable.
  * Duplicate events are still acknowledged safely, while storage failures are logged with additional diagnostic context.
* **Tests**
  * Added coverage for deduplication read and write failures, confirming successful responses, event dispatch, and degraded-operation logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->