### PR TITLE
Document configurable sign-in providers in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 New features, integrations, and notable improvements to Open-Inspect — newest first.
 
+## July 30, 2026
+
+**Choose GitHub, Google, or both for sign-in.** Deployments can now enable either provider
+independently, and the sign-in page shows only the methods actually configured. Terraform validates
+the setup and includes a post-deploy check. The GitHub App remains required for repository access in
+Google-only deployments.
+
 ## July 26, 2026
 
 **Better Auth browser authentication.** Browser sign-in now uses control-plane-owned Better Auth


### PR DESCRIPTION
## Summary
- add a concise July 30 changelog entry for GitHub-only, Google-only, and combined sign-in
- explain that the login page reflects deployed configuration and Terraform verifies it
- retain the important GitHub App repository-access requirement for Google-only deployments

## Validation
- `npx prettier --check CHANGELOG.md`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes covering sign-in provider configuration for GitHub and Google.
  * Documented sign-in method visibility, Terraform validation, and post-deployment checks.
  * Clarified that the GitHub App remains required for repository access in Google-only deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->