### PR TITLE
feat(slack): workspace session instructions for Slack-initiated sessions

### DIFF
--- a/docs/integrations/SLACK.md
+++ b/docs/integrations/SLACK.md
@@ -165,6 +165,16 @@ How matching works:
 Routing rules do not override an active thread: a keyword in a thread reply does not move that
 conversation to a different repository.
 
+### Session instructions
+
+Administrators can define workspace-wide instructions for Slack-started sessions under **Settings →
+Integrations → Slack → Session Instructions** in the web app. When set, the instructions are
+appended to the first prompt of every new Slack-initiated session as an `## Additional Instructions`
+section — use them for standing guidance such as coding standards, preferred tools, or PR
+conventions. They apply to new sessions only (thread follow-ups continue with the session's existing
+context), are limited to 10,000 characters, and mirror the Linear integration's **Issue Session
+Instructions**.
+
 ---
 
 ## Threaded Conversations

--- a/packages/control-plane/src/db/integration-settings.test.ts
+++ b/packages/control-plane/src/db/integration-settings.test.ts
@@ -1059,6 +1059,33 @@ describe("IntegrationSettingsStore", () => {
       ).rejects.toThrow(IntegrationSettingsValidationError);
     });
 
+    it("round-trips global session instructions", async () => {
+      await store.setGlobal("slack", {
+        defaults: { sessionInstructions: "Always run tests before pushing changes." },
+      });
+
+      const result = await store.getGlobal("slack");
+      expect(result?.defaults?.sessionInstructions).toBe(
+        "Always run tests before pushing changes."
+      );
+    });
+
+    it("rejects non-string sessionInstructions", async () => {
+      await expect(
+        store.setGlobal("slack", {
+          defaults: { sessionInstructions: 42 as unknown as string },
+        })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
+
+    it("rejects sessionInstructions over 10000 characters", async () => {
+      await expect(
+        store.setGlobal("slack", {
+          defaults: { sessionInstructions: "x".repeat(10001) },
+        })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
+
     it("round-trips per-repo slack settings", async () => {
       await store.setRepoSettings("slack", "acme/widgets", {
         agentNotificationsEnabled: false,
@@ -1080,6 +1107,14 @@ describe("IntegrationSettingsStore", () => {
       await expect(
         store.setRepoSettings("slack", "acme/widgets", {
           model: "anthropic/claude-sonnet-4-6",
+        } as unknown as { agentNotificationsEnabled?: boolean })
+      ).rejects.toThrow(IntegrationSettingsValidationError);
+    });
+
+    it("rejects sessionInstructions at per-repo level (global-only field)", async () => {
+      await expect(
+        store.setRepoSettings("slack", "acme/widgets", {
+          sessionInstructions: "Prefer minimal diffs.",
         } as unknown as { agentNotificationsEnabled?: boolean })
       ).rejects.toThrow(IntegrationSettingsValidationError);
     });

--- a/packages/control-plane/src/db/integration-settings.test.ts
+++ b/packages/control-plane/src/db/integration-settings.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { MAX_SLACK_ROUTING_KEYWORD_LENGTH, MAX_SLACK_ROUTING_RULES } from "@open-inspect/shared";
+import {
+  MAX_SESSION_INSTRUCTIONS_LENGTH,
+  MAX_SLACK_ROUTING_KEYWORD_LENGTH,
+  MAX_SLACK_ROUTING_RULES,
+} from "@open-inspect/shared";
 import {
   IntegrationSettingsStore,
   IntegrationSettingsValidationError,
@@ -1078,10 +1082,10 @@ describe("IntegrationSettingsStore", () => {
       ).rejects.toThrow(IntegrationSettingsValidationError);
     });
 
-    it("rejects sessionInstructions over 10000 characters", async () => {
+    it("rejects sessionInstructions over the maximum length", async () => {
       await expect(
         store.setGlobal("slack", {
-          defaults: { sessionInstructions: "x".repeat(10001) },
+          defaults: { sessionInstructions: "x".repeat(MAX_SESSION_INSTRUCTIONS_LENGTH + 1) },
         })
       ).rejects.toThrow(IntegrationSettingsValidationError);
     });

--- a/packages/control-plane/src/db/integration-settings.ts
+++ b/packages/control-plane/src/db/integration-settings.ts
@@ -3,6 +3,7 @@ import {
   ENVIRONMENT_SETTINGS_INTEGRATION_IDS,
   INTEGRATION_DEFINITIONS,
   DEFAULT_MENTIONS_POLICY,
+  MAX_SESSION_INSTRUCTIONS_LENGTH,
   MAX_SLACK_ROUTING_RULES,
   MAX_SLACK_ROUTING_KEYWORD_LENGTH,
   normalizeRoutingRules,
@@ -404,10 +405,10 @@ export class IntegrationSettingsStore {
 
     if (
       typeof settings.issueSessionInstructions === "string" &&
-      settings.issueSessionInstructions.length > 10000
+      settings.issueSessionInstructions.length > MAX_SESSION_INSTRUCTIONS_LENGTH
     ) {
       throw new IntegrationSettingsValidationError(
-        "issueSessionInstructions must be 10000 characters or fewer"
+        `issueSessionInstructions must be ${MAX_SESSION_INSTRUCTIONS_LENGTH} characters or fewer`
       );
     }
   }
@@ -466,10 +467,10 @@ export class IntegrationSettingsStore {
 
     if (
       typeof settings.sessionInstructions === "string" &&
-      settings.sessionInstructions.length > 10000
+      settings.sessionInstructions.length > MAX_SESSION_INSTRUCTIONS_LENGTH
     ) {
       throw new IntegrationSettingsValidationError(
-        "sessionInstructions must be 10000 characters or fewer"
+        `sessionInstructions must be ${MAX_SESSION_INSTRUCTIONS_LENGTH} characters or fewer`
       );
     }
 

--- a/packages/control-plane/src/db/integration-settings.ts
+++ b/packages/control-plane/src/db/integration-settings.ts
@@ -424,7 +424,13 @@ export class IntegrationSettingsStore {
   ): SlackGlobalSettings {
     const allowedKeys =
       level === "global"
-        ? new Set(["agentNotificationsEnabled", "model", "mentionsPolicy", "routingRules"])
+        ? new Set([
+            "agentNotificationsEnabled",
+            "model",
+            "mentionsPolicy",
+            "routingRules",
+            "sessionInstructions",
+          ])
         : new Set(["agentNotificationsEnabled"]);
 
     for (const key of Object.keys(settings)) {
@@ -448,6 +454,22 @@ export class IntegrationSettingsStore {
     ) {
       throw new IntegrationSettingsValidationError(
         `mentionsPolicy must be one of: ${SLACK_MENTIONS_POLICIES.join(", ")}`
+      );
+    }
+
+    if (
+      settings.sessionInstructions !== undefined &&
+      typeof settings.sessionInstructions !== "string"
+    ) {
+      throw new IntegrationSettingsValidationError("sessionInstructions must be a string");
+    }
+
+    if (
+      typeof settings.sessionInstructions === "string" &&
+      settings.sessionInstructions.length > 10000
+    ) {
+      throw new IntegrationSettingsValidationError(
+        "sessionInstructions must be 10000 characters or fewer"
       );
     }
 

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -224,6 +224,11 @@ export interface SlackGlobalSettings extends SlackRepoSettings {
   mentionsPolicy?: SlackMentionsPolicy;
   /** Workspace-wide keyword→repository routing rules (global-only, like mentionsPolicy). */
   routingRules?: SlackRoutingRule[];
+  /**
+   * Custom instructions appended to the first prompt of every Slack-initiated
+   * session (global-only, like mentionsPolicy).
+   */
+  sessionInstructions?: string;
 }
 
 /**

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -36,6 +36,13 @@ export interface LinearBotSettings {
   issueSessionInstructions?: string;
 }
 
+/**
+ * Maximum length of a custom session-instructions value (Linear
+ * `issueSessionInstructions`, Slack `sessionInstructions`). Bounds the
+ * settings blob and the prompt section built from it.
+ */
+export const MAX_SESSION_INSTRUCTIONS_LENGTH = 10000;
+
 /** Overridable behavior settings for the code-server integration. */
 export interface CodeServerSettings {
   enabled?: boolean;

--- a/packages/slack-bot/src/sessions/integration-config.test.ts
+++ b/packages/slack-bot/src/sessions/integration-config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Env } from "../types";
-import { getSlackSessionInstructions } from "./integration-config";
+import { getSlackSessionConfig } from "./integration-config";
 
 function makeEnv(fetch: ReturnType<typeof vi.fn>): Env {
   return {
@@ -9,50 +9,56 @@ function makeEnv(fetch: ReturnType<typeof vi.fn>): Env {
   } as unknown as Env;
 }
 
-describe("getSlackSessionInstructions", () => {
-  it("returns configured instructions", async () => {
+function settingsResponse(defaults: Record<string, unknown>) {
+  return new Response(JSON.stringify({ settings: { defaults } }));
+}
+
+describe("getSlackSessionConfig", () => {
+  it("returns the default model and session instructions from one fetch", async () => {
     const fetch = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          settings: { defaults: { sessionInstructions: "Prefer minimal diffs." } },
-        })
-      )
+      settingsResponse({
+        model: "anthropic/claude-sonnet-4-6",
+        sessionInstructions: "Prefer minimal diffs.",
+      })
     );
 
-    await expect(getSlackSessionInstructions(makeEnv(fetch))).resolves.toBe(
-      "Prefer minimal diffs."
-    );
+    await expect(getSlackSessionConfig(makeEnv(fetch))).resolves.toEqual({
+      defaultModel: "anthropic/claude-sonnet-4-6",
+      sessionInstructions: "Prefer minimal diffs.",
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 
-  it("returns undefined when instructions are unset", async () => {
-    const fetch = vi
-      .fn()
-      .mockResolvedValue(new Response(JSON.stringify({ settings: { defaults: {} } })));
+  it("drops an invalid default model", async () => {
+    const fetch = vi.fn().mockResolvedValue(settingsResponse({ model: "not-a-model" }));
 
-    await expect(getSlackSessionInstructions(makeEnv(fetch))).resolves.toBeUndefined();
+    const config = await getSlackSessionConfig(makeEnv(fetch));
+    expect(config.defaultModel).toBeUndefined();
   });
 
-  it("returns undefined for whitespace-only instructions", async () => {
-    const fetch = vi.fn().mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          settings: { defaults: { sessionInstructions: "   \n" } },
-        })
-      )
-    );
+  it("returns no instructions when unset", async () => {
+    const fetch = vi.fn().mockResolvedValue(settingsResponse({}));
 
-    await expect(getSlackSessionInstructions(makeEnv(fetch))).resolves.toBeUndefined();
+    const config = await getSlackSessionConfig(makeEnv(fetch));
+    expect(config.sessionInstructions).toBeUndefined();
   });
 
-  it("returns undefined on a non-OK response", async () => {
+  it("returns no instructions when whitespace-only", async () => {
+    const fetch = vi.fn().mockResolvedValue(settingsResponse({ sessionInstructions: "   \n" }));
+
+    const config = await getSlackSessionConfig(makeEnv(fetch));
+    expect(config.sessionInstructions).toBeUndefined();
+  });
+
+  it("returns an empty config on a non-OK response", async () => {
     const fetch = vi.fn().mockResolvedValue(new Response("nope", { status: 500 }));
 
-    await expect(getSlackSessionInstructions(makeEnv(fetch))).resolves.toBeUndefined();
+    await expect(getSlackSessionConfig(makeEnv(fetch))).resolves.toEqual({});
   });
 
-  it("returns undefined when the fetch throws", async () => {
+  it("returns an empty config when the fetch throws", async () => {
     const fetch = vi.fn().mockRejectedValue(new Error("network down"));
 
-    await expect(getSlackSessionInstructions(makeEnv(fetch))).resolves.toBeUndefined();
+    await expect(getSlackSessionConfig(makeEnv(fetch))).resolves.toEqual({});
   });
 });

--- a/packages/slack-bot/src/sessions/integration-config.test.ts
+++ b/packages/slack-bot/src/sessions/integration-config.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Env } from "../types";
+import { getSlackSessionInstructions } from "./integration-config";
+
+function makeEnv(fetch: ReturnType<typeof vi.fn>): Env {
+  return {
+    SERVICE_AUTH_SECRET: "test-secret",
+    CONTROL_PLANE: { fetch },
+  } as unknown as Env;
+}
+
+describe("getSlackSessionInstructions", () => {
+  it("returns configured instructions", async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          settings: { defaults: { sessionInstructions: "Prefer minimal diffs." } },
+        })
+      )
+    );
+
+    await expect(getSlackSessionInstructions(makeEnv(fetch))).resolves.toBe(
+      "Prefer minimal diffs."
+    );
+  });
+
+  it("returns undefined when instructions are unset", async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify({ settings: { defaults: {} } })));
+
+    await expect(getSlackSessionInstructions(makeEnv(fetch))).resolves.toBeUndefined();
+  });
+
+  it("returns undefined for whitespace-only instructions", async () => {
+    const fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          settings: { defaults: { sessionInstructions: "   \n" } },
+        })
+      )
+    );
+
+    await expect(getSlackSessionInstructions(makeEnv(fetch))).resolves.toBeUndefined();
+  });
+
+  it("returns undefined on a non-OK response", async () => {
+    const fetch = vi.fn().mockResolvedValue(new Response("nope", { status: 500 }));
+
+    await expect(getSlackSessionInstructions(makeEnv(fetch))).resolves.toBeUndefined();
+  });
+
+  it("returns undefined when the fetch throws", async () => {
+    const fetch = vi.fn().mockRejectedValue(new Error("network down"));
+
+    await expect(getSlackSessionInstructions(makeEnv(fetch))).resolves.toBeUndefined();
+  });
+});

--- a/packages/slack-bot/src/sessions/integration-config.ts
+++ b/packages/slack-bot/src/sessions/integration-config.ts
@@ -1,28 +1,42 @@
 import type { SlackGlobalConfig } from "@open-inspect/shared";
+import { isValidModel } from "@open-inspect/shared/models";
 import { signedControlPlaneFetch } from "../internal-auth";
 import type { Env } from "../types";
 
+export interface SlackSessionConfig {
+  /** Workspace default model for Slack-created sessions, when configured and valid. */
+  defaultModel?: string;
+  /** Workspace-wide instructions appended to the first prompt of new sessions. */
+  sessionInstructions?: string;
+}
+
 /**
- * Fetch the workspace-wide session instructions configured in the Slack
- * integration settings. Returns undefined when unset or on any fetch failure —
- * instructions are best effort and must never block session creation.
+ * Fetch the Slack integration settings a session launch needs, in one
+ * control-plane roundtrip. Fields are best effort: on any fetch failure the
+ * config is empty — missing settings must never block session creation.
  */
-export async function getSlackSessionInstructions(
+export async function getSlackSessionConfig(
   env: Env,
   traceId?: string
-): Promise<string | undefined> {
+): Promise<SlackSessionConfig> {
   try {
     const url = "https://internal/integration-settings/slack";
     const response = await signedControlPlaneFetch(env, { method: "GET", url, traceId });
 
     if (!response.ok) {
-      return undefined;
+      return {};
     }
 
     const data = (await response.json()) as { settings: SlackGlobalConfig | null };
-    const instructions = data.settings?.defaults?.sessionInstructions;
-    return typeof instructions === "string" && instructions.trim() ? instructions : undefined;
+    const defaults = data.settings?.defaults;
+    const model = defaults?.model;
+    const instructions = defaults?.sessionInstructions;
+    return {
+      defaultModel: model && isValidModel(model) ? model : undefined,
+      sessionInstructions:
+        typeof instructions === "string" && instructions.trim() ? instructions : undefined,
+    };
   } catch {
-    return undefined;
+    return {};
   }
 }

--- a/packages/slack-bot/src/sessions/integration-config.ts
+++ b/packages/slack-bot/src/sessions/integration-config.ts
@@ -1,0 +1,28 @@
+import type { SlackGlobalConfig } from "@open-inspect/shared";
+import { signedControlPlaneFetch } from "../internal-auth";
+import type { Env } from "../types";
+
+/**
+ * Fetch the workspace-wide session instructions configured in the Slack
+ * integration settings. Returns undefined when unset or on any fetch failure —
+ * instructions are best effort and must never block session creation.
+ */
+export async function getSlackSessionInstructions(
+  env: Env,
+  traceId?: string
+): Promise<string | undefined> {
+  try {
+    const url = "https://internal/integration-settings/slack";
+    const response = await signedControlPlaneFetch(env, { method: "GET", url, traceId });
+
+    if (!response.ok) {
+      return undefined;
+    }
+
+    const data = (await response.json()) as { settings: SlackGlobalConfig | null };
+    const instructions = data.settings?.defaults?.sessionInstructions;
+    return typeof instructions === "string" && instructions.trim() ? instructions : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/slack-bot/src/sessions/session-launcher.test.ts
+++ b/packages/slack-bot/src/sessions/session-launcher.test.ts
@@ -6,6 +6,7 @@ import { getAvailableModels, getSlackDefaultModel } from "../app-home/models";
 import { getUserRepoBranchPreference } from "../branch-preferences";
 import { getResolvedUserPreferences } from "../user-preferences";
 import { createSession } from "./control-plane-client";
+import { getSlackSessionInstructions } from "./integration-config";
 import { deliverPrompt } from "./prompt-delivery";
 import { buildThreadSession, storeThreadSession } from "./thread-session-store";
 import { getUserInfo, postMessage } from "@open-inspect/shared";
@@ -44,6 +45,10 @@ vi.mock("../user-preferences", () => ({
 
 vi.mock("./control-plane-client", () => ({
   createSession: vi.fn(),
+}));
+
+vi.mock("./integration-config", () => ({
+  getSlackSessionInstructions: vi.fn(),
 }));
 
 vi.mock("./thread-session-store", () => ({
@@ -102,6 +107,7 @@ describe("startSessionAndSendPrompt", () => {
       { label: "Claude Sonnet", value: "anthropic/claude-sonnet-4-6" },
     ]);
     vi.mocked(getSlackDefaultModel).mockResolvedValue("anthropic/claude-sonnet-4-6");
+    vi.mocked(getSlackSessionInstructions).mockResolvedValue(undefined);
     vi.mocked(getResolvedUserPreferences).mockResolvedValue({
       model: "openai/gpt-5.4",
       reasoningEffort: "high",
@@ -199,6 +205,31 @@ describe("startSessionAndSendPrompt", () => {
       reasoningEffort: "high",
       createdAt: 123,
     });
+  });
+
+  it("appends configured session instructions to the first prompt", async () => {
+    const env = makeEnv();
+    vi.mocked(getSlackSessionInstructions).mockResolvedValue(
+      "Always run tests before pushing changes."
+    );
+
+    await startSessionAndSendPrompt(env, {
+      target: repositoryTarget,
+      channel: "C123",
+      threadTs: "111.222",
+      messageText: "Fix the failing deploy",
+      userId: "U123",
+      traceId: "trace-1",
+    });
+
+    expect(deliverPrompt).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({
+        content:
+          "Fix the failing deploy\n\n## Additional Instructions\n\n" +
+          "Always run tests before pushing changes.",
+      })
+    );
   });
 
   it("does not apply repository branch overrides to environment sessions", async () => {

--- a/packages/slack-bot/src/sessions/session-launcher.test.ts
+++ b/packages/slack-bot/src/sessions/session-launcher.test.ts
@@ -2,11 +2,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Env } from "../types";
 import type { SlackSessionTarget } from "../targets";
 import { startSessionAndSendPrompt } from "./session-launcher";
-import { getAvailableModels, getSlackDefaultModel } from "../app-home/models";
+import { getAvailableModels } from "../app-home/models";
 import { getUserRepoBranchPreference } from "../branch-preferences";
 import { getResolvedUserPreferences } from "../user-preferences";
 import { createSession } from "./control-plane-client";
-import { getSlackSessionInstructions } from "./integration-config";
+import { getSlackSessionConfig } from "./integration-config";
 import { deliverPrompt } from "./prompt-delivery";
 import { buildThreadSession, storeThreadSession } from "./thread-session-store";
 import { getUserInfo, postMessage } from "@open-inspect/shared";
@@ -32,7 +32,6 @@ vi.mock("./prompt-delivery", () => ({
 
 vi.mock("../app-home/models", () => ({
   getAvailableModels: vi.fn(),
-  getSlackDefaultModel: vi.fn(),
 }));
 
 vi.mock("../branch-preferences", () => ({
@@ -48,7 +47,7 @@ vi.mock("./control-plane-client", () => ({
 }));
 
 vi.mock("./integration-config", () => ({
-  getSlackSessionInstructions: vi.fn(),
+  getSlackSessionConfig: vi.fn(),
 }));
 
 vi.mock("./thread-session-store", () => ({
@@ -106,8 +105,9 @@ describe("startSessionAndSendPrompt", () => {
       { label: "GPT 5.4", value: "openai/gpt-5.4" },
       { label: "Claude Sonnet", value: "anthropic/claude-sonnet-4-6" },
     ]);
-    vi.mocked(getSlackDefaultModel).mockResolvedValue("anthropic/claude-sonnet-4-6");
-    vi.mocked(getSlackSessionInstructions).mockResolvedValue(undefined);
+    vi.mocked(getSlackSessionConfig).mockResolvedValue({
+      defaultModel: "anthropic/claude-sonnet-4-6",
+    });
     vi.mocked(getResolvedUserPreferences).mockResolvedValue({
       model: "openai/gpt-5.4",
       reasoningEffort: "high",
@@ -209,9 +209,10 @@ describe("startSessionAndSendPrompt", () => {
 
   it("appends configured session instructions to the first prompt", async () => {
     const env = makeEnv();
-    vi.mocked(getSlackSessionInstructions).mockResolvedValue(
-      "Always run tests before pushing changes."
-    );
+    vi.mocked(getSlackSessionConfig).mockResolvedValue({
+      defaultModel: "anthropic/claude-sonnet-4-6",
+      sessionInstructions: "Always run tests before pushing changes.",
+    });
 
     await startSessionAndSendPrompt(env, {
       target: repositoryTarget,

--- a/packages/slack-bot/src/sessions/session-launcher.ts
+++ b/packages/slack-bot/src/sessions/session-launcher.ts
@@ -1,5 +1,5 @@
 import { getUserInfo, postMessage, type CallbackContext } from "@open-inspect/shared";
-import { getAvailableModels, getSlackDefaultModel } from "../app-home/models";
+import { getAvailableModels } from "../app-home/models";
 import {
   notifyDroppedAttachments,
   prepareImageAttachments,
@@ -11,7 +11,7 @@ import { branchPreferenceRepo, targetLabel, type SlackSessionTarget } from "../t
 import type { Env } from "../types";
 import { getResolvedUserPreferences } from "../user-preferences";
 import { createSession } from "./control-plane-client";
-import { getSlackSessionInstructions } from "./integration-config";
+import { getSlackSessionConfig } from "./integration-config";
 import { deliverPrompt } from "./prompt-delivery";
 import { buildThreadSession, storeThreadSession } from "./thread-session-store";
 
@@ -67,13 +67,12 @@ export async function startSessionAndSendPrompt(
     );
     return null;
   }
-  const [availableModels, slackDefaultModel, sessionInstructions] = await Promise.all([
+  const [availableModels, slackConfig] = await Promise.all([
     getAvailableModels(env, traceId),
-    getSlackDefaultModel(env, traceId),
-    getSlackSessionInstructions(env, traceId),
+    getSlackSessionConfig(env, traceId),
   ]);
   const userPrefs = await getResolvedUserPreferences(env, userId, {
-    defaultModel: slackDefaultModel ?? env.DEFAULT_MODEL,
+    defaultModel: slackConfig.defaultModel ?? env.DEFAULT_MODEL,
     enabledModels: availableModels.map((modelOption) => modelOption.value),
   });
   const model = userPrefs.model;
@@ -132,8 +131,8 @@ export async function startSessionAndSendPrompt(
   const channelContext = channelName ? formatChannelContext(channelName, channelDescription) : "";
   const threadContext = previousMessages ? formatThreadContext(previousMessages) : "";
   let content = channelContext + threadContext + messageText;
-  if (sessionInstructions) {
-    content += `\n\n## Additional Instructions\n\n${sessionInstructions}`;
+  if (slackConfig.sessionInstructions) {
+    content += `\n\n## Additional Instructions\n\n${slackConfig.sessionInstructions}`;
   }
   const delivery = await deliverPrompt(env, {
     sessionId: session.sessionId,

--- a/packages/slack-bot/src/sessions/session-launcher.ts
+++ b/packages/slack-bot/src/sessions/session-launcher.ts
@@ -11,6 +11,7 @@ import { branchPreferenceRepo, targetLabel, type SlackSessionTarget } from "../t
 import type { Env } from "../types";
 import { getResolvedUserPreferences } from "../user-preferences";
 import { createSession } from "./control-plane-client";
+import { getSlackSessionInstructions } from "./integration-config";
 import { deliverPrompt } from "./prompt-delivery";
 import { buildThreadSession, storeThreadSession } from "./thread-session-store";
 
@@ -66,9 +67,10 @@ export async function startSessionAndSendPrompt(
     );
     return null;
   }
-  const [availableModels, slackDefaultModel] = await Promise.all([
+  const [availableModels, slackDefaultModel, sessionInstructions] = await Promise.all([
     getAvailableModels(env, traceId),
     getSlackDefaultModel(env, traceId),
+    getSlackSessionInstructions(env, traceId),
   ]);
   const userPrefs = await getResolvedUserPreferences(env, userId, {
     defaultModel: slackDefaultModel ?? env.DEFAULT_MODEL,
@@ -129,9 +131,13 @@ export async function startSessionAndSendPrompt(
   };
   const channelContext = channelName ? formatChannelContext(channelName, channelDescription) : "";
   const threadContext = previousMessages ? formatThreadContext(previousMessages) : "";
+  let content = channelContext + threadContext + messageText;
+  if (sessionInstructions) {
+    content += `\n\n## Additional Instructions\n\n${sessionInstructions}`;
+  }
   const delivery = await deliverPrompt(env, {
     sessionId: session.sessionId,
-    content: channelContext + threadContext + messageText,
+    content,
     authorId: `slack:${userId}`,
     attachments: preparedImages,
     imageOnly: Boolean(imageOnly),

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
@@ -405,7 +405,13 @@ describe("SlackIntegrationSettings", () => {
 
     act(() => {
       setupSWR({
-        global: { defaults: { agentNotificationsEnabled: true, mentionsPolicy: "strip" } },
+        global: {
+          defaults: {
+            agentNotificationsEnabled: true,
+            mentionsPolicy: "strip",
+            sessionInstructions: "Prefer minimal diffs.",
+          },
+        },
       });
     });
     rerender(<SlackIntegrationSettings />);
@@ -415,6 +421,7 @@ describe("SlackIntegrationSettings", () => {
       "true"
     );
     expect((screen.getByRole("radio", { name: /strip/i }) as HTMLInputElement).checked).toBe(true);
+    expect(screen.getByLabelText(/session instructions/i)).toHaveValue("Prefer minimal diffs.");
   });
 
   // Regression: dirty edits must not be clobbered by SWR revalidation.

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
@@ -279,6 +279,34 @@ describe("SlackIntegrationSettings", () => {
     });
   });
 
+  it("bounds the session instructions textarea to the shared maximum length", () => {
+    setupSWR({ global: null });
+
+    render(<SlackIntegrationSettings />);
+
+    expect(screen.getByLabelText(/session instructions/i)).toHaveAttribute("maxlength", "10000");
+  });
+
+  // Regression: a save must seed the SWR cache with the saved blob. The other
+  // global section merges against this snapshot, so leaving the pre-save data
+  // in place would let a back-to-back save silently drop the new values.
+  it("seeds the SWR cache with the saved defaults on save", async () => {
+    const user = userEvent.setup();
+    setupSWR({ global: null });
+    fetchMock.mockResolvedValue(okJson({}));
+
+    render(<SlackIntegrationSettings />);
+
+    await user.click(screen.getByRole("switch", { name: /enable agent notifications/i }));
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    expect(mutateMock).toHaveBeenCalledWith("/api/integration-settings/slack", {
+      settings: {
+        defaults: { agentNotificationsEnabled: true, mentionsPolicy: "allow" },
+      },
+    });
+  });
+
   it("clearing session instructions omits the key on save", async () => {
     const user = userEvent.setup();
     setupSWR({

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.test.tsx
@@ -250,6 +250,61 @@ describe("SlackIntegrationSettings", () => {
     });
   });
 
+  it("typing session instructions and saving sends them merged into the defaults", async () => {
+    const user = userEvent.setup();
+    setupSWR({
+      global: {
+        defaults: {
+          agentNotificationsEnabled: true,
+          mentionsPolicy: "strip",
+          routingRules: [{ keyword: "frontend", target: "acme/web" }],
+        },
+      },
+      availableRepos: [repo("acme/web")],
+    });
+    fetchMock.mockResolvedValue(okJson({}));
+
+    render(<SlackIntegrationSettings />);
+
+    await user.type(screen.getByLabelText(/session instructions/i), "Prefer minimal diffs.");
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body as string) as { settings: SlackGlobalConfig };
+    expect(body.settings.defaults).toEqual({
+      agentNotificationsEnabled: true,
+      mentionsPolicy: "strip",
+      routingRules: [{ keyword: "frontend", target: "acme/web" }],
+      sessionInstructions: "Prefer minimal diffs.",
+    });
+  });
+
+  it("clearing session instructions omits the key on save", async () => {
+    const user = userEvent.setup();
+    setupSWR({
+      global: {
+        defaults: {
+          agentNotificationsEnabled: true,
+          mentionsPolicy: "strip",
+          sessionInstructions: "Prefer minimal diffs.",
+        },
+      },
+    });
+    fetchMock.mockResolvedValue(okJson({}));
+
+    render(<SlackIntegrationSettings />);
+
+    await user.clear(screen.getByLabelText(/session instructions/i));
+    await user.click(screen.getByRole("button", { name: /^save$/i }));
+
+    const [, init] = fetchMock.mock.calls[0];
+    const body = JSON.parse(init.body as string) as { settings: SlackGlobalConfig };
+    expect(body.settings.defaults).toEqual({
+      agentNotificationsEnabled: true,
+      mentionsPolicy: "strip",
+    });
+  });
+
   it("renders populated settings with master switch on and policy 'strip'", () => {
     setupSWR({
       global: {

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import {
   DEFAULT_MENTIONS_POLICY,
   encodeRepositoryPathSegments,
+  MAX_SESSION_INSTRUCTIONS_LENGTH,
   MAX_SLACK_ROUTING_RULES,
   parseRepositoryFullName,
   type EnrichedRepository,
@@ -206,15 +207,20 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
       // preserve them by writing a blob that keeps just the rules (rather than
       // deleting the whole row); otherwise clear the row entirely.
       const existingRules = settings?.defaults?.routingRules;
-      const res = existingRules?.length
+      const resetBody: SlackGlobalConfig | null = existingRules?.length
+        ? { defaults: { routingRules: existingRules } }
+        : null;
+      const res = resetBody
         ? await browserApiFetch(GLOBAL_SETTINGS_KEY, {
             method: "PUT",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ settings: { defaults: { routingRules: existingRules } } }),
+            body: JSON.stringify({ settings: resetBody }),
           })
         : await browserApiFetch(GLOBAL_SETTINGS_KEY, { method: "DELETE" });
       if (res.ok) {
-        mutate(GLOBAL_SETTINGS_KEY);
+        // Seed the cache with the post-reset blob before revalidation (see
+        // handleSave for why).
+        mutate(GLOBAL_SETTINGS_KEY, { settings: resetBody });
         setAgentNotificationsEnabled(false);
         setModel("");
         setMentionsPolicy(DEFAULT_MENTIONS_POLICY);
@@ -250,7 +256,10 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
         body: JSON.stringify({ settings: body }),
       });
       if (res.ok) {
-        mutate(GLOBAL_SETTINGS_KEY);
+        // Seed the cache with the saved blob before revalidation: the other
+        // global sections merge against this snapshot, so a stale one would
+        // let a back-to-back save resurrect pre-save defaults.
+        mutate(GLOBAL_SETTINGS_KEY, { settings: body });
         toast.success("Settings saved.");
         setDirty(false);
       } else {
@@ -380,6 +389,7 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
             setDirty(true);
           }}
           rows={3}
+          maxLength={MAX_SESSION_INSTRUCTIONS_LENGTH}
           placeholder="e.g., Always run tests before pushing changes. Prefer minimal diffs."
           className="resize-y"
         />
@@ -706,7 +716,9 @@ function RoutingRulesSection({
         body: JSON.stringify({ settings: body }),
       });
       if (res.ok) {
-        mutate(GLOBAL_SETTINGS_KEY);
+        // Seed the cache with the saved blob before revalidation (see the
+        // Defaults section save for why).
+        mutate(GLOBAL_SETTINGS_KEY, { settings: body });
         toast.success("Routing rules saved.");
         setDirty(false);
       } else {

--- a/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
+++ b/packages/web/src/components/settings/integrations/slack-integration-settings.tsx
@@ -27,6 +27,7 @@ import { Button } from "@/components/ui/button";
 import { APP_NAME } from "@/lib/site-config";
 import { RadioCard } from "@/components/ui/form-controls";
 import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
   SelectContent,
@@ -176,6 +177,9 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
   const [mentionsPolicy, setMentionsPolicy] = useState<SlackMentionsPolicy>(
     settings?.defaults?.mentionsPolicy ?? DEFAULT_MENTIONS_POLICY
   );
+  const [sessionInstructions, setSessionInstructions] = useState(
+    settings?.defaults?.sessionInstructions ?? ""
+  );
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
   const [showResetDialog, setShowResetDialog] = useState(false);
@@ -185,6 +189,7 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
     setAgentNotificationsEnabled(settings?.defaults?.agentNotificationsEnabled ?? false);
     setModel(settings?.defaults?.model ?? "");
     setMentionsPolicy(settings?.defaults?.mentionsPolicy ?? DEFAULT_MENTIONS_POLICY);
+    setSessionInstructions(settings?.defaults?.sessionInstructions ?? "");
   }, [settings, dirty, saving]);
 
   const selectedModelEnabled = model ? enabledModels.includes(model) : true;
@@ -213,6 +218,7 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
         setAgentNotificationsEnabled(false);
         setModel("");
         setMentionsPolicy(DEFAULT_MENTIONS_POLICY);
+        setSessionInstructions("");
         setDirty(false);
         toast.success("Settings reset to defaults.");
       } else {
@@ -233,6 +239,7 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
         agentNotificationsEnabled,
         model: model || undefined,
         mentionsPolicy,
+        sessionInstructions: sessionInstructions || undefined,
       }),
     };
 
@@ -353,6 +360,31 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
         </div>
       </div>
 
+      <div className="mb-4">
+        <label
+          htmlFor="slack-session-instructions"
+          className="block text-sm font-medium text-foreground mb-1"
+        >
+          Session Instructions
+        </label>
+        <p className="text-xs text-muted-foreground mb-2">
+          Custom instructions appended to agent prompts for all Slack-initiated sessions. Use this
+          to guide how the agent approaches requests (e.g., coding standards, preferred tools, PR
+          conventions).
+        </p>
+        <Textarea
+          id="slack-session-instructions"
+          value={sessionInstructions}
+          onChange={(e) => {
+            setSessionInstructions(e.target.value);
+            setDirty(true);
+          }}
+          rows={3}
+          placeholder="e.g., Always run tests before pushing changes. Prefer minimal diffs."
+          className="resize-y"
+        />
+      </div>
+
       <div className="flex items-center gap-2">
         <Button onClick={handleSave} disabled={saving || !dirty}>
           {saving ? "Saving..." : "Save"}
@@ -371,8 +403,9 @@ function GlobalSettingsSection({ settings }: { settings: SlackGlobalConfig | nul
             <AlertDialogTitle>Reset to defaults</AlertDialogTitle>
             <AlertDialogDescription>
               Reset Slack defaults? The master switch will turn off, the default model will use the
-              system default, and mentions policy will return to <strong>allow</strong>.
-              Per-repository overrides and routing rules are not affected.
+              system default, mentions policy will return to <strong>allow</strong>, and session
+              instructions will be cleared. Per-repository overrides and routing rules are not
+              affected.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>


### PR DESCRIPTION
## Summary

Adds a **Session Instructions** field to the Slack integration settings (Settings → Integrations → Slack), mirroring Linear's *Issue Session Instructions*. When set, the instructions are appended to the first prompt of every Slack-initiated session as an `## Additional Instructions` section — standing guidance like coding standards, preferred tools, or PR conventions.

## Implementation (follows the Linear pattern)

- **shared**: `sessionInstructions?: string` on `SlackGlobalSettings` (global-only, like `mentionsPolicy`/`routingRules`). New `MAX_SESSION_INSTRUCTIONS_LENGTH = 10000` constant, now used by both the Linear and Slack validators instead of two inline `10000` literals.
- **control-plane**: added to the strict Slack settings allowlist (global level only — rejected per-repo); validated as a string capped at `MAX_SESSION_INSTRUCTIONS_LENGTH`.
- **web**: textarea in the Slack Defaults section with `maxLength` bound to the shared constant. Saves go through the existing `mergedGlobalDefaults` helper so routing rules are preserved; an empty value omits the key; reset clears it (dialog copy updated). Saves now also seed the SWR cache with the saved blob — previously, saving Defaults and then Routing Rules before revalidation completed would merge against the stale snapshot and silently drop the just-saved fields (this race predates this PR; the new field made it more visible).
- **slack-bot**: new `getSlackSessionConfig` fetcher returns the workspace default model *and* session instructions from a single control-plane roundtrip (replacing the launcher's `getSlackDefaultModel` call rather than adding a second fetch of the same endpoint; App Home callers are unchanged). Best effort — fails open to an empty config so a control-plane hiccup never blocks session creation. Follow-up messages in an existing thread are not re-decorated, matching Linear's first-prompt-only injection.
- **docs**: new "Session instructions" section in `docs/integrations/SLACK.md`.

## Tests

- control-plane: round-trip, non-string rejection, over-cap rejection, per-repo rejection
- web: save merges instructions with existing defaults/routing rules; clearing omits the key; SWR resync populates the textarea; cache seeding on save; maxLength bound
- slack-bot: `getSlackSessionConfig` (model+instructions from one fetch, invalid model, unset/whitespace/500/throw) and launcher prompt-append
- Suites on this branch: slack-bot 386, control-plane unit 2142, web slack-settings 31 — all passing; full lint/typecheck clean

## Verified in production

Deployed on our instance: instructions saved in the web UI are appended to the first prompt of new Slack sessions (mentions and DMs), and thread follow-ups are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace-wide session instructions for Slack integrations.
  * Session instructions are appended to the first prompt of new Slack sessions.
  * Added a 10,000-character limit and validation for session instructions.
  * Added Slack settings controls to create, edit, clear, and reset session instructions.
  * Improved settings updates to preserve changes immediately and prevent stale values.

* **Documentation**
  * Documented Slack session instructions, including their scope and behavior for new sessions and thread follow-ups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->