### PR TITLE
fix(control-plane): don't block prompt enqueue on sandbox spawn

### DIFF
--- a/packages/control-plane/src/sandbox/lifecycle/decisions.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.test.ts
@@ -322,6 +322,44 @@ describe("evaluateSpawnDecision", () => {
     }
   });
 
+  it("skips restore when a spawn is already in progress in-memory", () => {
+    // A restore sets the in-memory flag synchronously but persists the
+    // "spawning" status only after its first await; a concurrent evaluation in
+    // that window still sees "stopped" and must not start a second restore.
+    const now = Date.now();
+    const state: SandboxState = {
+      status: "stopped",
+      createdAt: now - 120000,
+      snapshotImageId: "img-abc123",
+      hasActiveWebSocket: false,
+    };
+
+    const decision = evaluateSpawnDecision(state, config, now, true);
+
+    expect(decision.action).toBe("skip");
+    if (decision.action === "skip") {
+      expect(decision.reason).toContain("in-memory flag");
+    }
+  });
+
+  it("skips resume when a spawn is already in progress in-memory", () => {
+    const now = Date.now();
+    const state: SandboxState = {
+      status: "stopped",
+      createdAt: now - 120000,
+      snapshotImageId: null,
+      providerObjectId: "sb-123",
+      hasActiveWebSocket: false,
+    };
+
+    const decision = evaluateSpawnDecision(state, config, now, true, true);
+
+    expect(decision.action).toBe("skip");
+    if (decision.action === "skip") {
+      expect(decision.reason).toContain("in-memory flag");
+    }
+  });
+
   it('returns "spawn" when all conditions pass', () => {
     const now = Date.now();
     const state: SandboxState = {

--- a/packages/control-plane/src/sandbox/lifecycle/decisions.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/decisions.ts
@@ -224,6 +224,14 @@ export function evaluateSpawnDecision(
 ): SpawnAction {
   const timeSinceLastSpawn = now - state.createdAt;
 
+  // In-memory flag first: it is set synchronously when a spawn/restore starts,
+  // but the persisted "spawning" status lands only after the first await. A
+  // second evaluation in that window must not pick resume/restore again, or
+  // concurrent prompts launch duplicate sandboxes.
+  if (isSpawningInMemory) {
+    return { action: "skip", reason: "spawn already in progress (in-memory flag)" };
+  }
+
   if (
     supportsPersistentResume &&
     state.providerObjectId &&
@@ -279,11 +287,6 @@ export function evaluateSpawnDecision(
       action: "wait",
       reason: `last spawn was ${Math.round(timeSinceLastSpawn / 1000)}s ago, waiting`,
     };
-  }
-
-  // Check in-memory flag for same-request protection
-  if (isSpawningInMemory) {
-    return { action: "skip", reason: "spawn already in progress (in-memory flag)" };
   }
 
   // All checks passed - spawn a new sandbox

--- a/packages/control-plane/src/session/message-queue.test.ts
+++ b/packages/control-plane/src/session/message-queue.test.ts
@@ -192,6 +192,39 @@ describe("SessionMessageQueue", () => {
     expect(h.callbackService.notifyStarted).not.toHaveBeenCalled();
   });
 
+  it("does not block queue processing on the sandbox spawn", async () => {
+    const h = buildQueue();
+    h.repository.getNextPendingMessage.mockReturnValue(createMessage());
+    let resolveSpawn!: () => void;
+    h.sandboxLifecycle.spawnSandbox.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveSpawn = resolve;
+      })
+    );
+
+    // Resolves immediately even though the spawn is still in flight; the
+    // spawn is handed to waitUntil so the prompt response is not held open.
+    await h.queue.processMessageQueue();
+
+    expect(h.waitUntil).toHaveBeenCalledTimes(1);
+    resolveSpawn();
+    await h.waitUntil.mock.calls[0][0];
+  });
+
+  it("broadcasts sandbox_error when the background spawn throws", async () => {
+    const h = buildQueue();
+    h.repository.getNextPendingMessage.mockReturnValue(createMessage());
+    h.sandboxLifecycle.spawnSandbox.mockRejectedValue(new Error("modal exploded"));
+
+    await h.queue.processMessageQueue();
+    await h.waitUntil.mock.calls[0][0];
+
+    expect(h.broadcast).toHaveBeenCalledWith({
+      type: "sandbox_error",
+      error: "modal exploded",
+    });
+  });
+
   it("marks session active when a prompt is enqueued", async () => {
     const h = buildQueue();
 

--- a/packages/control-plane/src/session/message-queue.ts
+++ b/packages/control-plane/src/session/message-queue.ts
@@ -173,7 +173,26 @@ export class SessionMessageQueue {
         reason: "no_sandbox",
       });
       this.messenger.broadcast({ type: "sandbox_spawning" });
-      await this.sandboxLifecycle.spawnSandbox();
+      // Spawn in the background: a snapshot restore can take tens of seconds,
+      // and awaiting it here holds the prompt HTTP response open past bot
+      // callers' request timeouts. The message is already persisted as
+      // pending and dispatches when the sandbox WebSocket connects.
+      this.ctx.waitUntil(
+        this.sandboxLifecycle.spawnSandbox().catch((error) => {
+          // Expected provider failures broadcast sandbox_error inside the
+          // lifecycle manager; this catch only sees throws from before those
+          // handlers. Surface them the same way so clients aren't left
+          // watching a silent "sandbox_spawning" forever.
+          this.log.error("prompt.spawn.background_error", {
+            message_id: message.id,
+            error: error instanceof Error ? error : String(error),
+          });
+          this.messenger.broadcast({
+            type: "sandbox_error",
+            error: error instanceof Error ? error.message : "Failed to spawn sandbox",
+          });
+        })
+      );
       return;
     }
 


### PR DESCRIPTION
## Problem

Sending a follow-up in a Slack thread whose session has been idle for a while consistently fails with:

> Sorry, I couldn't send your follow-up. Please try again.

### Root cause

1. After the inactivity timeout, the session's sandbox is snapshotted and terminated.
2. A follow-up makes the slack-bot POST `/sessions/:id/prompt` with a **10s AbortSignal** (`OUTBOUND_REQUEST_TIMEOUT_MS` in `packages/slack-bot/src/request-options.ts`).
3. Inside the session DO, `enqueuePromptFromApi` persists the message, then **synchronously awaits** `processMessageQueue()`. With no sandbox WebSocket connected, that branch `await`s `sandboxLifecycle.spawnSandbox()` — a Modal restore-from-snapshot HTTP call (endpoint cold start + `Sandbox.create` + tunnel setup) that routinely exceeds 10s.
4. The slack-bot fetch aborts, `sendPrompt` returns `{ok: false, reason: "transient"}`, and the user is told the follow-up failed — even though the prompt was already enqueued and often still runs once the restore finishes.

Warm-sandbox follow-ups dispatch over the existing WebSocket in milliseconds, which is why only idle threads are affected. The same latency exposure applies to github-bot and linear-bot prompt delivery, and to web prompts sent immediately after reopening an idle session.

## Fix

The prompt endpoint's contract is already `{status: "queued"}` — it should not block on a sandbox restore.

- **`message-queue.ts`**: the no-sandbox branch of `processMessageQueue()` now schedules `spawnSandbox()` via `ctx.waitUntil()` instead of awaiting it. The persisted pending message dispatches when the sandbox WebSocket connects (existing path in `durable-object.ts`). Unexpected detached-spawn throws broadcast `sandbox_error` (matching the lifecycle manager's own failure UX) instead of being log-only.
- **`decisions.ts`**: fixes a pre-existing duplicate-restore race surfaced during review. `evaluateSpawnDecision` returned `resume`/`restore` before consulting the in-memory `isSpawningInMemory` flag; since a restore persists `status: "spawning"` only after its first `await`, concurrent prompts in that window could each launch a Modal sandbox from the same snapshot. The in-memory guard now runs before resume/restore selection.

No caller of `processMessageQueue()` relies on the spawn having completed before the promise resolves (audited: message-queue, durable-object, sandbox-events, presence-service — the latter awaits `spawnSandbox()` directly and is unaffected).

## Tests

- `processMessageQueue` resolves while the spawn promise is still in flight (hangs if the `await` is reintroduced).
- `sandbox_error` broadcast when the detached spawn rejects.
- Spawn decision skips `restore`/`resume` while the in-memory flag is set.
- control-plane: 2142/2142 unit, 659/659 integration on this base; typecheck + ESLint clean.

## Verified in production

Deployed on our fork: follow-ups to idle Slack threads now ack with 👀 immediately and the session resumes from snapshot, where they previously always surfaced the transient-failure message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox startup and restoration now run in the background, allowing prompt responses to return without waiting.
  * Background startup failures are reported through a `sandbox_error` notification.

* **Bug Fixes**
  * Prevented duplicate sandbox starts when another spawn or restore is already in progress.
  * Added handling for both snapshot restoration and persistent sandbox resumption scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->