### PR TITLE
fix: tolerate repo cache invalidation failures

### DIFF
--- a/packages/control-plane/src/routes/repos.test.ts
+++ b/packages/control-plane/src/routes/repos.test.ts
@@ -60,12 +60,19 @@ describe("repository metadata routes", () => {
   });
 
   it("returns success when cache invalidation fails after the metadata update commits", async () => {
+    let resolveUpsert!: () => void;
+    mockUpsert.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveUpsert = resolve;
+        })
+    );
     const cacheError = new Error("KV unavailable");
     mockCacheDelete.mockRejectedValue(cacheError);
     const path = "/repos/Acme/Widget/metadata";
     const { handler, match } = getUpdateHandler(path);
 
-    const response = await handler(
+    const responsePromise = handler(
       new Request(`https://test.local${path}`, {
         method: "PUT",
         body: JSON.stringify({ description: "Updated description" }),
@@ -74,6 +81,11 @@ describe("repository metadata routes", () => {
       match,
       createContext()
     );
+
+    await vi.waitFor(() => expect(mockUpsert).toHaveBeenCalledOnce());
+    expect(mockCacheDelete).not.toHaveBeenCalled();
+    resolveUpsert();
+    const response = await responsePromise;
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
@@ -84,9 +96,7 @@ describe("repository metadata routes", () => {
     expect(mockUpsert).toHaveBeenCalledWith("Acme", "Widget", {
       description: "Updated description",
     });
-    expect(mockUpsert.mock.invocationCallOrder[0]).toBeLessThan(
-      mockCacheDelete.mock.invocationCallOrder[0]
-    );
+    expect(mockCacheDelete).toHaveBeenCalledOnce();
     expect(mockLogger.warn).toHaveBeenCalledWith("Failed to invalidate repos cache", {
       trace_id: "trace-1",
       error: cacheError,

--- a/packages/control-plane/src/routes/repos.test.ts
+++ b/packages/control-plane/src/routes/repos.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SqlDatabase } from "../db/sql-database";
+import type { Env } from "../types";
+import { reposRoutes } from "./repos";
+import type { RequestContext } from "./shared";
+
+const { mockCacheDelete, mockLogger, mockUpsert } = vi.hoisted(() => ({
+  mockCacheDelete: vi.fn(),
+  mockLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  mockUpsert: vi.fn(),
+}));
+
+vi.mock("../db/repo-metadata", () => ({
+  RepoMetadataStore: vi.fn().mockImplementation(function () {
+    return { upsert: mockUpsert };
+  }),
+}));
+
+vi.mock("@open-inspect/shared/cache-store", () => ({
+  createKvCacheStore: vi.fn(() => ({ delete: mockCacheDelete })),
+}));
+
+vi.mock("../logger", () => ({
+  createLogger: vi.fn(() => mockLogger),
+}));
+
+function createContext(): RequestContext {
+  return {
+    trace_id: "trace-1",
+    request_id: "request-1",
+    principal: { kind: "user", userId: "user-1" },
+    db: {} as SqlDatabase,
+    metrics: {
+      d1Queries: [],
+      spans: {},
+      time: async <T>(_name: string, fn: () => Promise<T>) => fn(),
+      summarize: () => ({}),
+    },
+  };
+}
+
+function getUpdateHandler(path: string) {
+  const route = reposRoutes.find((candidate) => candidate.method === "PUT");
+  if (!route) throw new Error("No repository metadata update route found");
+  const match = path.match(route.pattern);
+  if (!match) throw new Error(`Update route did not match ${path}`);
+  return { handler: route.handler, match };
+}
+
+describe("repository metadata routes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpsert.mockResolvedValue(undefined);
+    mockCacheDelete.mockResolvedValue(undefined);
+  });
+
+  it("returns success when cache invalidation fails after the metadata update commits", async () => {
+    const cacheError = new Error("KV unavailable");
+    mockCacheDelete.mockRejectedValue(cacheError);
+    const path = "/repos/Acme/Widget/metadata";
+    const { handler, match } = getUpdateHandler(path);
+
+    const response = await handler(
+      new Request(`https://test.local${path}`, {
+        method: "PUT",
+        body: JSON.stringify({ description: "Updated description" }),
+      }),
+      { REPOS_CACHE: {} as KVNamespace } as Env,
+      match,
+      createContext()
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      status: "updated",
+      repo: "acme/widget",
+      metadata: { description: "Updated description" },
+    });
+    expect(mockUpsert).toHaveBeenCalledWith("Acme", "Widget", {
+      description: "Updated description",
+    });
+    expect(mockUpsert.mock.invocationCallOrder[0]).toBeLessThan(
+      mockCacheDelete.mock.invocationCallOrder[0]
+    );
+    expect(mockLogger.warn).toHaveBeenCalledWith("Failed to invalidate repos cache", {
+      trace_id: "trace-1",
+      error: cacheError,
+      repo_owner: "Acme",
+      repo_name: "Widget",
+    });
+    expect(mockLogger.error).not.toHaveBeenCalled();
+  });
+
+  it("returns an error and skips cache invalidation when the metadata update fails", async () => {
+    const updateError = new Error("D1 unavailable");
+    mockUpsert.mockRejectedValue(updateError);
+    const path = "/repos/acme/widget/metadata";
+    const { handler, match } = getUpdateHandler(path);
+
+    const response = await handler(
+      new Request(`https://test.local${path}`, {
+        method: "PUT",
+        body: JSON.stringify({ description: "Updated description" }),
+      }),
+      { REPOS_CACHE: {} as KVNamespace } as Env,
+      match,
+      createContext()
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: "Failed to update metadata" });
+    expect(mockCacheDelete).not.toHaveBeenCalled();
+    expect(mockLogger.error).toHaveBeenCalledWith("Failed to update repo metadata", {
+      error: updateError,
+    });
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/control-plane/src/routes/repos.ts
+++ b/packages/control-plane/src/routes/repos.ts
@@ -252,23 +252,31 @@ async function handleUpdateRepoMetadata(
 
   try {
     await metadataStore.upsert(owner, name, metadata);
-
-    // Invalidate the KV repos cache so next fetch includes updated metadata
-    await createKvCacheStore(env.REPOS_CACHE).delete(REPOS_CACHE_KEY);
-
-    // Return normalized repo identifier
-    const normalizedRepo = `${owner.toLowerCase()}/${name.toLowerCase()}`;
-    return json({
-      status: "updated",
-      repo: normalizedRepo,
-      metadata,
-    });
   } catch (e) {
     logger.error("Failed to update repo metadata", {
       error: e instanceof Error ? e : String(e),
     });
     return error("Failed to update metadata", 500);
   }
+
+  try {
+    await createKvCacheStore(env.REPOS_CACHE).delete(REPOS_CACHE_KEY);
+  } catch (e) {
+    logger.warn("Failed to invalidate repos cache", {
+      trace_id: ctx.trace_id,
+      error: e instanceof Error ? e : String(e),
+      repo_owner: owner,
+      repo_name: name,
+    });
+  }
+
+  // Return normalized repo identifier
+  const normalizedRepo = `${owner.toLowerCase()}/${name.toLowerCase()}`;
+  return json({
+    status: "updated",
+    repo: normalizedRepo,
+    metadata,
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- separate the authoritative repository metadata D1 upsert from optional KV cache invalidation
- log structured repository and trace context when cache invalidation fails while still returning success
- add regression coverage for KV failures, operation ordering, and preservation of the fatal D1 failure path

## Testing
- `npm test -w @open-inspect/control-plane -- src/routes/repos.test.ts`
- `npm test -w @open-inspect/control-plane` (2,140 tests)
- `npm run typecheck -w @open-inspect/control-plane`
- `npx eslint packages/control-plane/src/routes/repos.ts packages/control-plane/src/routes/repos.test.ts`
- `npx prettier --check packages/control-plane/src/routes/repos.ts packages/control-plane/src/routes/repos.test.ts`
- `git diff --check`

## Review
- completed two independent sub-agent self-reviews
- first review found no defects
- second review requested D1 failure-path and operation-order coverage; both were added and all verification was rerun

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/fc831a168c4a93e6347ec302095e5fc6)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repository metadata updates now return a clear server error when the update fails.
  * Successful metadata updates remain successful even if cache refresh fails.
  * Improved logging distinguishes update failures from cache invalidation warnings.
* **Tests**
  * Expanded Vitest coverage for the repository metadata update handler, including response codes, cache invalidation behavior, and operation ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->