### PR TITLE
fix: pin Vercel CLI to 58.4.0

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -56,9 +56,9 @@ jobs:
         if: steps.check-secrets.outputs.configured == 'true'
         run: npm run build -w @open-inspect/shared
 
-      - name: Install Vercel CLI
+      - name: Install Vercel CLI 58.4.0
         if: steps.check-secrets.outputs.configured == 'true'
-        run: npm install -g vercel
+        run: npm install -g vercel@58.4.0
 
       - name: Pull Vercel Environment
         if: steps.check-secrets.outputs.configured == 'true'


### PR DESCRIPTION
## Summary

- pin the web deployment workflow to Vercel CLI 58.4.0
- make the selected CLI version explicit in the workflow step name

## Root cause

Vercel CLI 58.4.4 changed `vercel deploy --prebuilt` to reapply `.vercelignore` rules to function `filePathMap` sources. This repository's root `/*` rule then excludes traced root dependencies such as `node_modules/client-only/index.js`, while the generated function manifest still references them. The build succeeds, but deployment fails while materializing the prebuilt output.

The last verified successful production deployment used Vercel CLI 58.4.0. This is a temporary compatibility pin until Vercel ships a fix for broad root ignore rules.

## Validation

- `git diff --check`
- `npx --yes prettier@3.4.2 --check .github/workflows/deploy-web.yml`
- parsed `.github/workflows/deploy-web.yml` as YAML
- confirmed `vercel@58.4.0` is available from npm

## Follow-up

Vercel 58.4.4's behavior was introduced as an upload-hardening change, so this pin should be removed once an upstream release supports the repository's prebuilt monorepo layout without dropping traced dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment consistency by using a fixed version of the deployment tool.
  * No end-user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->