### PR TITLE
Add collapsible file list to diff reader

### DIFF
--- a/packages/web/src/components/session-changes-panel.test.tsx
+++ b/packages/web/src/components/session-changes-panel.test.tsx
@@ -90,6 +90,68 @@ describe("SessionChangesPanel", () => {
     expect(onSelect).toHaveBeenCalledWith({ repositoryPosition: 0, path: "src/lib.ts" });
   });
 
+  it("collapses and reopens the changed-files sidebar", async () => {
+    render(
+      <SessionChangesPanel
+        sessionId="session-1"
+        state={state}
+        resolved={{
+          status: "ready",
+          revisionId: "revision-1",
+          repository: readyRepository,
+          file: readyRepository.files[0]!,
+        }}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />
+    );
+
+    const sidebar = screen.getByRole("complementary", { name: "Changed files" });
+    const hideButton = screen.getByRole("button", { name: "Hide file list" });
+    expect(hideButton).toHaveAttribute("aria-expanded", "true");
+    expect(hideButton).toHaveAttribute("aria-controls", sidebar.id);
+
+    await userEvent.click(hideButton);
+
+    expect(sidebar).not.toBeVisible();
+    const showButton = screen.getByRole("button", { name: "Show file list" });
+    expect(showButton).toHaveAttribute("aria-expanded", "false");
+
+    await userEvent.click(showButton);
+
+    expect(sidebar).toBeVisible();
+    expect(screen.getByRole("button", { name: "Hide file list" })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+  });
+
+  it("preserves the file filter while the sidebar is collapsed", async () => {
+    render(
+      <SessionChangesPanel
+        sessionId="session-1"
+        state={state}
+        resolved={{
+          status: "ready",
+          revisionId: "revision-1",
+          repository: readyRepository,
+          file: readyRepository.files[0]!,
+        }}
+        onClose={vi.fn()}
+        onSelect={vi.fn()}
+      />
+    );
+
+    const filter = screen.getByRole("searchbox", { name: "Filter changed files" });
+    await userEvent.type(filter, "lib");
+    await userEvent.click(screen.getByRole("button", { name: "Hide file list" }));
+    await userEvent.click(screen.getByRole("button", { name: "Show file list" }));
+
+    expect(filter).toHaveValue("lib");
+    expect(screen.queryByRole("button", { name: /app\.ts.*modified/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /lib\.ts.*modified/i })).toBeVisible();
+  });
+
   it("keeps navigation available when a selected file disappears", () => {
     render(
       <SessionChangesPanel
@@ -106,7 +168,7 @@ describe("SessionChangesPanel", () => {
     expect(screen.getByText(/no longer part of the latest/i)).toBeVisible();
   });
 
-  it("forces a unified-only diff control on mobile", () => {
+  it("supports file-list collapsing with a unified-only diff control on mobile", async () => {
     render(
       <SessionChangesPanel
         mobile
@@ -125,6 +187,14 @@ describe("SessionChangesPanel", () => {
 
     expect(screen.getByRole("button", { name: "Unified" })).toBeVisible();
     expect(screen.queryByRole("button", { name: "Split" })).not.toBeInTheDocument();
+    const sidebar = screen.getByRole("complementary", { name: "Changed files" });
+    expect(sidebar).toHaveClass("max-h-48");
+
+    await userEvent.click(screen.getByRole("button", { name: "Hide file list" }));
+    expect(sidebar).not.toBeVisible();
+
+    await userEvent.click(screen.getByRole("button", { name: "Show file list" }));
+    expect(sidebar).toBeVisible();
   });
 
   it("reports an authoritative retry failure from the explicit retry endpoint", async () => {

--- a/packages/web/src/components/session-changes-panel.tsx
+++ b/packages/web/src/components/session-changes-panel.tsx
@@ -4,7 +4,7 @@ import dynamic from "next/dynamic";
 import { useTheme } from "next-themes";
 import { mutate } from "swr";
 import useSWR from "swr";
-import { useEffect, useRef } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { formatRepositoryFullName, SESSION_DIFF_REVISION_STALE_CODE } from "@open-inspect/shared";
 import type { SessionDiffErrorCode } from "@open-inspect/shared";
 import type { SessionDiffFile, SessionDiffState } from "@open-inspect/shared";
@@ -18,6 +18,7 @@ import { browserApiFetch, type BrowserApiPath } from "@/lib/browser-api-fetch";
 import { cn } from "@/lib/utils";
 import { DiffRetryNotice } from "@/components/diff-retry-notice";
 import { FilesChangedSection } from "@/components/sidebar/files-changed-section";
+import { SidebarIcon } from "@/components/ui/icons";
 
 const PierreDiffRenderer = dynamic(() => import("./pierre-diff-renderer"), {
   ssr: false,
@@ -83,12 +84,18 @@ function ChangesPanelHeader({
   selected,
   selectedIndex,
   fileCount,
+  isFileListOpen,
+  fileListId,
+  onToggleFileList,
   onMoveSelection,
   onClose,
 }: {
   selected: ReadyDiffSelection | null;
   selectedIndex: number;
   fileCount: number;
+  isFileListOpen: boolean;
+  fileListId: string;
+  onToggleFileList: () => void;
   onMoveSelection: (offset: number) => void;
   onClose: () => void;
 }) {
@@ -110,6 +117,16 @@ function ChangesPanelHeader({
           </p>
         )}
       </div>
+      <button
+        type="button"
+        onClick={onToggleFileList}
+        aria-label={isFileListOpen ? "Hide file list" : "Show file list"}
+        aria-controls={fileListId}
+        aria-expanded={isFileListOpen}
+        className="rounded p-1.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        <SidebarIcon className="h-4 w-4" />
+      </button>
       <button
         type="button"
         onClick={() => onMoveSelection(-1)}
@@ -213,6 +230,8 @@ export function SessionChangesPanel({
   mobile?: boolean;
 }) {
   const panelRef = useRef<HTMLElement>(null);
+  const fileListId = useId();
+  const [isFileListOpen, setIsFileListOpen] = useState(true);
   const panelWidth = usePanelWidth(panelRef, { enabled: !mobile });
   const { resolvedTheme } = useTheme();
   const { diffStyle, setDiffStyle, wrap, setWrap } = useSessionDiffPreferences();
@@ -268,6 +287,9 @@ export function SessionChangesPanel({
         selected={selected}
         selectedIndex={selectedIndex}
         fileCount={files.length}
+        isFileListOpen={isFileListOpen}
+        fileListId={fileListId}
+        onToggleFileList={() => setIsFileListOpen((open) => !open)}
         onMoveSelection={moveSelection}
         onClose={onClose}
       />
@@ -287,7 +309,9 @@ export function SessionChangesPanel({
 
       <div className={cn("flex min-h-0 flex-1", mobile && "flex-col")}>
         <aside
+          id={fileListId}
           aria-label="Changed files"
+          hidden={!isFileListOpen}
           className={cn(
             "shrink-0 overflow-auto",
             mobile


### PR DESCRIPTION
## Summary
- add an accessible header control to hide and show the diff reader's changed-files list
- keep the file list mounted while hidden so filters and repository disclosure state survive reopening
- support the same interaction in desktop and mobile diff layouts
- cover collapse, reopen, accessibility state, retained filtering, and mobile behavior with component tests

## Testing
- `npm test -w @open-inspect/web` (109 files, 844 tests)
- `npm run typecheck -w @open-inspect/web`
- ESLint and Prettier checks on changed files
- `git diff --check`

## Review
- completed two independent sub-agent review passes
- addressed the first pass's mobile coverage gap
- second pass reported no findings

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/fc527bf8d440e22d4f9c47d671a3e337)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to collapse and reopen the changed-files sidebar.
  * Preserved file filters while the sidebar is collapsed.
  * Improved mobile diff controls with responsive sizing and sidebar toggle behavior.
  * Added accessibility support for the sidebar toggle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->