### PR TITLE
fix: require explicit child session requests

### DIFF
--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-task.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-task.js
@@ -11,7 +11,7 @@ import { bridgeFetch, extractError } from "./_bridge-client.js";
 export default tool({
   name: "spawn-task",
   description:
-    "Spawn a child coding task in a separate sandbox. Work directly by default. Use only for substantial, self-contained work that can run independently and materially benefits from parallel execution. Do not use for routine exploration, simple edits, tests, sequential steps, or merely multi-part requests. The child inherits the repository, not conversation context, and continues running after the parent responds. Returns a task ID; continue other work and check status only when the result is needed.",
+    "Spawn a child coding task in a separate sandbox. You MUST NOT invoke this tool unless the user's current request explicitly asks for a 'child session' or 'child sessions'. Work directly in all other cases, even when the work is substantial, self-contained, parallelizable, or has multiple parts. Never infer permission from task complexity or potential speed improvements, and do not suggest or ask to use a child session when the user did not request one. The child inherits the repository, not conversation context, and continues running after the parent responds. Returns a task ID; continue other work and check status only when the result is needed.",
   args: {
     title: z.string().describe("Short title describing the child task (shown in the UI)."),
     prompt: z

--- a/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-task.js
+++ b/packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-task.js
@@ -11,7 +11,7 @@ import { bridgeFetch, extractError } from "./_bridge-client.js";
 export default tool({
   name: "spawn-task",
   description:
-    "Spawn a child coding task in a separate sandbox. You MUST NOT invoke this tool unless the user's current request explicitly asks for a 'child session' or 'child sessions'. Work directly in all other cases, even when the work is substantial, self-contained, parallelizable, or has multiple parts. Never infer permission from task complexity or potential speed improvements, and do not suggest or ask to use a child session when the user did not request one. The child inherits the repository, not conversation context, and continues running after the parent responds. Returns a task ID; continue other work and check status only when the result is needed.",
+    "Spawn a child coding task in a separate sandbox. Invoke only when the user's current request explicitly asks for a 'child session' or 'child sessions'; otherwise work directly. Never infer permission or suggest using one. The child inherits the repository, not conversation context, and continues running after the parent responds. Returns a task ID; check status only when its result is needed.",
   args: {
     title: z.string().describe("Short title describing the child task (shown in the UI)."),
     prompt: z


### PR DESCRIPTION
## Summary
- require users to explicitly ask for a `child session` or `child sessions` before `spawn-task` may be invoked
- direct the agent to work locally even when tasks are complex, parallelizable, or multi-part
- prevent the agent from suggesting child sessions without an explicit user request

## Verification
- `npx prettier --check packages/sandbox-runtime/src/sandbox_runtime/tools/spawn-task.js`
- `git diff --check`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/c106f516bfc1edc8dd60684bcfd92b1f)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified task-spawning behavior: child sessions are created only when explicitly requested.
  * Work proceeds directly when a child session is not requested.
  * Simplified guidance by removing automatic recommendations based on task complexity, parallelization, or continued work while a child session runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->