### PR TITLE
Make sandbox session timeout configurable

### DIFF
--- a/packages/control-plane/src/routes/integration-settings.ts
+++ b/packages/control-plane/src/routes/integration-settings.ts
@@ -463,6 +463,7 @@ async function handleGetResolvedConfig(
         // null → use the provider's default reservation (no override configured).
         cpuCores: sandboxSettings.cpuCores ?? null,
         memoryMib: sandboxSettings.memoryMib ?? null,
+        sandboxTimeoutMs: sandboxSettings.sandboxTimeoutMs ?? null,
         enabledRepos,
       },
     });

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -2477,6 +2477,130 @@ describe("SandboxLifecycleManager", () => {
   });
 
   describe("sandbox settings", () => {
+    it("uses the configured sandbox timeout for fresh spawns", async () => {
+      const session = createMockSession({
+        sandbox_settings: '{"sandboxTimeoutMs":14400000}',
+      });
+      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const provider = createMockProvider();
+      const manager = new SandboxLifecycleManager(
+        provider,
+        createMockStorage(session, sandbox),
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      expect(provider.createSandbox).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutSeconds: 14_400 })
+      );
+    });
+
+    it("uses the configured sandbox timeout for snapshot restores", async () => {
+      const session = createMockSession({
+        sandbox_settings: '{"sandboxTimeoutMs":14400000}',
+      });
+      const sandbox = createMockSandbox({
+        status: "stopped",
+        snapshot_image_id: "img-abc123",
+      });
+      const provider = createMockProvider();
+      const manager = new SandboxLifecycleManager(
+        provider,
+        createMockStorage(session, sandbox),
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      expect(provider.restoreFromSnapshot).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutSeconds: 14_400 })
+      );
+    });
+
+    it("uses the configured sandbox timeout when resuming in place", async () => {
+      const session = createMockSession({
+        sandbox_settings: '{"sandboxTimeoutMs":14400000}',
+      });
+      const sandbox = createMockSandbox({
+        status: "stopped",
+        modal_object_id: "provider-obj",
+        snapshot_image_id: null,
+      });
+      const provider = createMockProvider({
+        capabilities: { supportsPersistentResume: true },
+        resumeSandbox: vi.fn(async () => ({ success: true })),
+      });
+      const manager = new SandboxLifecycleManager(
+        provider,
+        createMockStorage(session, sandbox),
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      expect(provider.resumeSandbox).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutSeconds: 14_400 })
+      );
+    });
+
+    it("lets an explicit sandbox timeout override the child-session default", async () => {
+      const session = createMockSession({
+        spawn_source: "agent",
+        sandbox_settings: '{"sandboxTimeoutMs":14400000}',
+      });
+      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const provider = createMockProvider();
+      const manager = new SandboxLifecycleManager(
+        provider,
+        createMockStorage(session, sandbox),
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      expect(provider.createSandbox).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutSeconds: 14_400 })
+      );
+    });
+
+    it("preserves the child-session timeout when no timeout is configured", async () => {
+      const session = createMockSession({ spawn_source: "agent", sandbox_settings: null });
+      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const provider = createMockProvider();
+      const manager = new SandboxLifecycleManager(
+        provider,
+        createMockStorage(session, sandbox),
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      expect(provider.createSandbox).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutSeconds: 3600 })
+      );
+    });
+
     it("doSpawn() passes sandboxSettings from session to provider config", async () => {
       const session = createMockSession({
         sandbox_settings: '{"tunnelPorts":[3000]}',

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   SandboxLifecycleManager,
+  CHILD_SANDBOX_TIMEOUT_MS,
   DEFAULT_LIFECYCLE_CONFIG,
   type SandboxStorage,
   type SandboxBroadcaster,
@@ -290,6 +291,7 @@ function createMockProvider(
   const provider: SandboxProvider = {
     name: "mock",
     capabilities: {
+      supportsSandboxTimeout: true,
       supportsSnapshots: true,
       supportsRestore: true,
       ...overrides.capabilities,
@@ -1257,7 +1259,11 @@ describe("SandboxLifecycleManager", () => {
       const broadcaster = createMockBroadcaster();
       const provider: SandboxProvider = {
         name: "no-snapshot",
-        capabilities: { supportsSnapshots: false, supportsRestore: false },
+        capabilities: {
+          supportsSandboxTimeout: true,
+          supportsSnapshots: false,
+          supportsRestore: false,
+        },
         createSandbox: vi.fn(),
         // No takeSnapshot method
       };
@@ -2597,7 +2603,58 @@ describe("SandboxLifecycleManager", () => {
       await manager.spawnSandbox();
 
       expect(provider.createSandbox).toHaveBeenCalledWith(
-        expect.objectContaining({ timeoutSeconds: 3600 })
+        expect.objectContaining({ timeoutSeconds: CHILD_SANDBOX_TIMEOUT_MS / 1000 })
+      );
+    });
+
+    it("rejects configured timeouts when the provider cannot enforce them", async () => {
+      const session = createMockSession({
+        sandbox_settings: '{"sandboxTimeoutMs":14400000}',
+      });
+      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const provider = createMockProvider({
+        capabilities: { supportsSandboxTimeout: false },
+      });
+      const broadcaster = createMockBroadcaster();
+      const manager = new SandboxLifecycleManager(
+        provider,
+        createMockStorage(session, sandbox),
+        broadcaster,
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      expect(provider.createSandbox).not.toHaveBeenCalled();
+      expect(broadcaster.messages).toContainEqual({
+        type: "sandbox_error",
+        error: "mock does not support configurable sandbox timeouts",
+      });
+    });
+
+    it("does not pass the implicit child timeout to unsupported providers", async () => {
+      const session = createMockSession({ spawn_source: "agent", sandbox_settings: null });
+      const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
+      const provider = createMockProvider({
+        capabilities: { supportsSandboxTimeout: false },
+      });
+      const manager = new SandboxLifecycleManager(
+        provider,
+        createMockStorage(session, sandbox),
+        createMockBroadcaster(),
+        createMockWebSocketManager(false),
+        createMockAlarmScheduler(),
+        createMockIdGenerator(),
+        createTestConfig()
+      );
+
+      await manager.spawnSandbox();
+
+      expect(provider.createSandbox).toHaveBeenCalledWith(
+        expect.objectContaining({ timeoutSeconds: undefined })
       );
     });
 

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -203,8 +203,8 @@ export const DEFAULT_LIFECYCLE_CONFIG: Omit<SandboxLifecycleConfig, "controlPlan
   connectingTimeout: DEFAULT_CONNECTING_TIMEOUT_CONFIG,
 };
 
-/** Child (agent-spawned) sessions get a shorter sandbox timeout. */
-const CHILD_SANDBOX_TIMEOUT_SECONDS = 3600; // 1 hour (vs default 2 hours)
+/** Default sandbox lifetime for agent-spawned child sessions. */
+const CHILD_SANDBOX_TIMEOUT_MS = 3_600_000;
 
 function buildSandboxIdForSession(session: SessionRow, now: number): string {
   const sandboxName = sessionHasRepository(session)
@@ -461,15 +461,12 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       const prebuiltImageId: string | null = selectedImage?.providerImageId ?? null;
       const prebuiltImageSha: string | null = selectedImage?.primaryBaseSha ?? null;
 
-      // Child sessions get a shorter timeout
-      const timeoutSeconds =
-        session.spawn_source === "agent" ? CHILD_SANDBOX_TIMEOUT_SECONDS : undefined;
-
       const mcpServers = await this.loadMcpServers(repositories);
 
       const codeServerEnabled = session.code_server_enabled === 1;
       const agentSlackNotifyEnabled = await this.resolveAgentSlackNotifyEnabled(session);
       const sandboxSettings = this.parseSandboxSettings(session);
+      const timeoutSeconds = this.resolveSandboxTimeoutSeconds(session, sandboxSettings);
       const createConfig: CreateSandboxConfig = {
         sessionId,
         sandboxId: expectedSandboxId,
@@ -756,15 +753,12 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       const userEnvVars = await this.storage.getUserEnvVars();
       const { provider, model: modelId } = this.resolveProviderAndModel(session);
 
-      // Child sessions get a shorter timeout (same logic as doSpawn)
-      const timeoutSeconds =
-        session.spawn_source === "agent" ? CHILD_SANDBOX_TIMEOUT_SECONDS : undefined;
-
       const repositories = this.storage.getSessionRepositories();
       const codeServerEnabled = session.code_server_enabled === 1;
       const agentSlackNotifyEnabled = await this.resolveAgentSlackNotifyEnabled(session);
       const mcpServers = await this.loadMcpServers(repositories);
       const sandboxSettings = this.parseSandboxSettings(session);
+      const timeoutSeconds = this.resolveSandboxTimeoutSeconds(session, sandboxSettings);
       const result = await this.provider.restoreFromSnapshot({
         snapshotImageId,
         sessionId: session.session_name || session.id,
@@ -897,8 +891,8 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       }
       this.broadcaster.broadcast({ type: "sandbox_status", status: "connecting" });
 
-      const timeoutSeconds =
-        session.spawn_source === "agent" ? CHILD_SANDBOX_TIMEOUT_SECONDS : undefined;
+      const sandboxSettings = this.parseSandboxSettings(session);
+      const timeoutSeconds = this.resolveSandboxTimeoutSeconds(session, sandboxSettings);
 
       const result = await this.provider.resumeSandbox({
         providerObjectId,
@@ -906,7 +900,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
         sandboxId: sandbox.modal_sandbox_id,
         timeoutSeconds,
         codeServerEnabled: session.code_server_enabled === 1,
-        sandboxSettings: this.parseSandboxSettings(session),
+        sandboxSettings,
       });
 
       if (!result.success) {
@@ -1391,6 +1385,16 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       this.log.warn("Failed to parse sandbox_settings, using defaults");
       return {};
     }
+  }
+
+  private resolveSandboxTimeoutSeconds(
+    session: SessionRow,
+    sandboxSettings: SandboxSettings
+  ): number | undefined {
+    const timeoutMs =
+      sandboxSettings.sandboxTimeoutMs ??
+      (session.spawn_source === "agent" ? CHILD_SANDBOX_TIMEOUT_MS : undefined);
+    return timeoutMs === undefined ? undefined : timeoutMs / 1000;
   }
 
   private async storeAndBroadcastTunnelUrls(

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -204,7 +204,7 @@ export const DEFAULT_LIFECYCLE_CONFIG: Omit<SandboxLifecycleConfig, "controlPlan
 };
 
 /** Default sandbox lifetime for agent-spawned child sessions. */
-const CHILD_SANDBOX_TIMEOUT_MS = 3_600_000;
+export const CHILD_SANDBOX_TIMEOUT_MS = 3_600_000;
 
 function buildSandboxIdForSession(session: SessionRow, now: number): string {
   const sandboxName = sessionHasRepository(session)
@@ -1391,6 +1391,15 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     session: SessionRow,
     sandboxSettings: SandboxSettings
   ): number | undefined {
+    if (!this.provider.capabilities.supportsSandboxTimeout) {
+      if (sandboxSettings.sandboxTimeoutMs !== undefined) {
+        throw new SandboxProviderError(
+          `${this.provider.name} does not support configurable sandbox timeouts`,
+          "permanent"
+        );
+      }
+      return undefined;
+    }
     const timeoutMs =
       sandboxSettings.sandboxTimeoutMs ??
       (session.spawn_source === "agent" ? CHILD_SANDBOX_TIMEOUT_MS : undefined);

--- a/packages/control-plane/src/sandbox/provider.ts
+++ b/packages/control-plane/src/sandbox/provider.ts
@@ -17,6 +17,8 @@ export const DEFAULT_SANDBOX_TIMEOUT_SECONDS = 7200;
  * Providers can support different feature sets.
  */
 export interface SandboxProviderCapabilities {
+  /** Whether explicit sandbox session lifetimes are enforced by this provider. */
+  supportsSandboxTimeout: boolean;
   /** Whether the provider supports filesystem snapshots */
   supportsSnapshots: boolean;
   /** Whether the provider supports restoring from snapshots */

--- a/packages/control-plane/src/sandbox/providers/daytona-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/daytona-provider.test.ts
@@ -111,6 +111,7 @@ describe("DaytonaSandboxProvider", () => {
       const provider = new DaytonaSandboxProvider(createMockClient(), defaultProviderConfig);
       expect(provider.name).toBe("daytona");
       expect(provider.capabilities).toEqual({
+        supportsSandboxTimeout: false,
         supportsSnapshots: false,
         supportsRestore: false,
         supportsPersistentResume: true,

--- a/packages/control-plane/src/sandbox/providers/daytona-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/daytona-provider.ts
@@ -51,6 +51,7 @@ export class DaytonaSandboxProvider implements SandboxProvider {
   readonly name = "daytona";
 
   readonly capabilities: SandboxProviderCapabilities = {
+    supportsSandboxTimeout: false,
     supportsSnapshots: false,
     supportsRestore: false,
     supportsPersistentResume: true,

--- a/packages/control-plane/src/sandbox/providers/e2b-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/e2b-provider.ts
@@ -58,6 +58,7 @@ export class E2BSandboxProvider implements SandboxProvider {
   private static readonly TERMINAL_STOP_REASONS = new Set(["connecting_timeout"]);
 
   readonly capabilities: SandboxProviderCapabilities = {
+    supportsSandboxTimeout: true,
     supportsSnapshots: false,
     supportsRestore: false,
     // Stop is a resumable pause; the manager treats it as provider-managed state.

--- a/packages/control-plane/src/sandbox/providers/modal-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/modal-provider.ts
@@ -79,6 +79,7 @@ export class ModalSandboxProvider implements SandboxProvider, ModalImageBuildPro
   readonly name = "modal";
 
   readonly capabilities: SandboxProviderCapabilities = {
+    supportsSandboxTimeout: true,
     supportsSnapshots: true,
     supportsRestore: true,
     supportsPersistentResume: false,

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -92,6 +92,7 @@ describe("OpenComputerSandboxProvider", () => {
 
     expect(provider.name).toBe("opencomputer");
     expect(provider.capabilities).toEqual({
+      supportsSandboxTimeout: true,
       supportsSnapshots: true,
       supportsRestore: true,
       supportsPersistentResume: true,

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.test.ts
@@ -823,6 +823,28 @@ describe("OpenComputerSandboxProvider", () => {
     expect(client.startRuntime).toHaveBeenCalledWith("oc-sandbox-1");
   });
 
+  it("renews an explicit timeout when the sandbox is already running", async () => {
+    const client = createMockClient({
+      getSandbox: vi.fn(async () => ({ id: "oc-sandbox-1", state: "running" })),
+    });
+    const provider = new OpenComputerSandboxProvider(client, {
+      scmProvider: "github",
+      codeServerPasswordSecret: "secret",
+    });
+
+    await provider.resumeSandbox({
+      providerObjectId: "oc-sandbox-1",
+      sessionId: "session-1",
+      sandboxId: "sandbox-acme-repo-1",
+      codeServerEnabled: false,
+      timeoutSeconds: 120,
+    });
+
+    expect(client.wakeSandbox).not.toHaveBeenCalled();
+    expect(client.setSandboxTimeout).toHaveBeenCalledWith("oc-sandbox-1", 120);
+    expect(client.startRuntime).not.toHaveBeenCalled();
+  });
+
   it("hibernates sandboxes on stop", async () => {
     const client = createMockClient();
     const provider = new OpenComputerSandboxProvider(client, {

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -96,6 +96,7 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
   readonly name = "opencomputer";
 
   readonly capabilities: SandboxProviderCapabilities = {
+    supportsSandboxTimeout: true,
     supportsSnapshots: true,
     supportsRestore: true,
     supportsPersistentResume: true,

--- a/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
+++ b/packages/control-plane/src/sandbox/providers/opencomputer-provider.ts
@@ -285,11 +285,11 @@ export class OpenComputerSandboxProvider implements SandboxProvider {
         wokeSandbox = true;
       }
 
+      const timeoutSeconds = config.timeoutSeconds;
+      if (timeoutSeconds !== undefined) {
+        await this.client.setSandboxTimeout(config.providerObjectId, timeoutSeconds);
+      }
       if (wokeSandbox) {
-        const timeoutSeconds = config.timeoutSeconds;
-        if (timeoutSeconds !== undefined) {
-          await this.client.setSandboxTimeout(config.providerObjectId, timeoutSeconds);
-        }
         await this.client.startRuntime(config.providerObjectId);
       }
 

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.test.ts
@@ -141,6 +141,7 @@ describe("VercelSandboxProvider", () => {
 
     expect(provider.name).toBe("vercel");
     expect(provider.capabilities).toEqual({
+      supportsSandboxTimeout: true,
       supportsSnapshots: true,
       supportsRestore: true,
       supportsPersistentResume: false,

--- a/packages/control-plane/src/sandbox/providers/vercel/provider.ts
+++ b/packages/control-plane/src/sandbox/providers/vercel/provider.ts
@@ -114,6 +114,7 @@ export class VercelSandboxProvider implements SandboxProvider {
   private baseSnapshotIdPromise?: Promise<string>;
 
   readonly capabilities: SandboxProviderCapabilities = {
+    supportsSandboxTimeout: true,
     supportsSnapshots: true,
     supportsRestore: true,
     supportsPersistentResume: false,

--- a/packages/control-plane/src/sandbox/settings.test.ts
+++ b/packages/control-plane/src/sandbox/settings.test.ts
@@ -75,6 +75,32 @@ describe("normalizeSandboxSettings", () => {
     ).toEqual({ terminalEnabled: true });
   });
 
+  it("accepts a positive integer sandboxTimeoutMs", () => {
+    expect(normalizeSandboxSettings({ sandboxTimeoutMs: 14_400_000 })).toEqual({
+      sandboxTimeoutMs: 14_400_000,
+    });
+  });
+
+  it("requires sandboxTimeoutMs to be a positive whole number of seconds", () => {
+    expect(() => normalizeSandboxSettings({ sandboxTimeoutMs: 0 })).toThrow(
+      SandboxSettingsValidationError
+    );
+    for (const sandboxTimeoutMs of [1, 999, 1500, 1000.5]) {
+      expect(() => normalizeSandboxSettings({ sandboxTimeoutMs })).toThrow(
+        SandboxSettingsValidationError
+      );
+    }
+    expect(normalizeSandboxSettings({ sandboxTimeoutMs: 1000 })).toEqual({
+      sandboxTimeoutMs: 1000,
+    });
+  });
+
+  it("omits an invalid sandboxTimeoutMs while preserving valid fields", () => {
+    expect(
+      normalizeSandboxSettings({ sandboxTimeoutMs: -1, terminalEnabled: true }, { invalid: "omit" })
+    ).toEqual({ terminalEnabled: true });
+  });
+
   it("accepts valid codeServerPort and terminalPort", () => {
     expect(normalizeSandboxSettings({ codeServerPort: 8081, terminalPort: 7000 })).toEqual({
       codeServerPort: 8081,

--- a/packages/control-plane/src/sandbox/settings.ts
+++ b/packages/control-plane/src/sandbox/settings.ts
@@ -122,6 +122,19 @@ export function normalizeSandboxSettings(
     }
   }
 
+  if (settings.sandboxTimeoutMs !== undefined) {
+    if (
+      typeof settings.sandboxTimeoutMs !== "number" ||
+      !Number.isSafeInteger(settings.sandboxTimeoutMs) ||
+      settings.sandboxTimeoutMs < 1000 ||
+      settings.sandboxTimeoutMs % 1000 !== 0
+    ) {
+      reject("sandboxTimeoutMs must be a positive whole number of seconds");
+    } else {
+      result.sandboxTimeoutMs = settings.sandboxTimeoutMs;
+    }
+  }
+
   const buildTimeoutSeconds = normalizePositiveIntegerSetting(
     settings.buildTimeoutSeconds,
     "buildTimeoutSeconds",

--- a/packages/control-plane/src/sandbox/settings.ts
+++ b/packages/control-plane/src/sandbox/settings.ts
@@ -1,5 +1,6 @@
 import {
   findSandboxPortConflict,
+  MIN_SANDBOX_TIMEOUT_MS,
   MAX_TUNNEL_PORTS,
   type ConfiguredSandboxPort,
   type SandboxSettings,
@@ -126,8 +127,8 @@ export function normalizeSandboxSettings(
     if (
       typeof settings.sandboxTimeoutMs !== "number" ||
       !Number.isSafeInteger(settings.sandboxTimeoutMs) ||
-      settings.sandboxTimeoutMs < 1000 ||
-      settings.sandboxTimeoutMs % 1000 !== 0
+      settings.sandboxTimeoutMs < MIN_SANDBOX_TIMEOUT_MS ||
+      settings.sandboxTimeoutMs % MIN_SANDBOX_TIMEOUT_MS !== 0
     ) {
       reject("sandboxTimeoutMs must be a positive whole number of seconds");
     } else {

--- a/packages/control-plane/test/integration/integration-settings.test.ts
+++ b/packages/control-plane/test/integration/integration-settings.test.ts
@@ -516,6 +516,7 @@ describe("Integration settings API", () => {
           maxTotalChildSessions: number;
           cpuCores: number | null;
           memoryMib: number | null;
+          sandboxTimeoutMs: number | null;
           enabledRepos: string[] | null;
         };
       }>();
@@ -525,7 +526,42 @@ describe("Integration settings API", () => {
       // Unset resource reservations resolve to null → provider default applies.
       expect(body.config.cpuCores).toBeNull();
       expect(body.config.memoryMib).toBeNull();
+      expect(body.config.sandboxTimeoutMs).toBeNull();
       expect(body.config.enabledRepos).toBeNull();
+    });
+
+    it("stores and resolves a sandbox session timeout", async () => {
+      const putRes = await serviceFetch("https://test.local/integration-settings/sandbox", {
+        method: "PUT",
+        body: JSON.stringify({
+          settings: {
+            defaults: { sandboxTimeoutMs: 14_400_000 },
+          },
+        }),
+      });
+      expect(putRes.status).toBe(200);
+
+      const res = await serviceFetch(
+        "https://test.local/integration-settings/sandbox/resolved/testowner/testrepo"
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json<{ config: { sandboxTimeoutMs: number | null } }>();
+      expect(body.config.sandboxTimeoutMs).toBe(14_400_000);
+    });
+
+    it("rejects an invalid sandbox session timeout", async () => {
+      const response = await serviceFetch("https://test.local/integration-settings/sandbox", {
+        method: "PUT",
+        body: JSON.stringify({
+          settings: {
+            defaults: { sandboxTimeoutMs: 0 },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      const body = await response.json<{ error: string }>();
+      expect(body.error).toContain("sandboxTimeoutMs must be a positive whole number of seconds");
     });
 
     it("GET /integration-settings/sandbox/resolved returns configured cpuCores and memoryMib", async () => {

--- a/packages/modal-infra/src/web_api.py
+++ b/packages/modal-infra/src/web_api.py
@@ -87,6 +87,23 @@ def _normalize_optional_repository_context(
     return normalized_owner, normalized_name
 
 
+def _timeout_seconds_from_request(request: dict, default_timeout_seconds: int) -> int:
+    value = request.get("timeout_seconds")
+    if value is None:
+        return default_timeout_seconds
+    if isinstance(value, bool):
+        raise HTTPException(status_code=400, detail="timeout_seconds must be a positive integer")
+    try:
+        timeout_seconds = int(value)
+    except (TypeError, ValueError, OverflowError):
+        raise HTTPException(
+            status_code=400, detail="timeout_seconds must be a positive integer"
+        ) from None
+    if timeout_seconds < 1 or timeout_seconds != value:
+        raise HTTPException(status_code=400, detail="timeout_seconds must be a positive integer")
+    return timeout_seconds
+
+
 def _session_config_from_create_request(
     request: dict, *, repo_owner: str | None, repo_name: str | None
 ):
@@ -152,7 +169,11 @@ async def api_create_sandbox(
     require_valid_control_plane_url(control_plane_url)
 
     try:
-        from .sandbox.manager import SandboxConfig, SandboxManager
+        from .sandbox.manager import (
+            DEFAULT_SANDBOX_TIMEOUT_SECONDS,
+            SandboxConfig,
+            SandboxManager,
+        )
 
         manager = SandboxManager()
 
@@ -185,6 +206,7 @@ async def api_create_sandbox(
             code_server_enabled=bool(request.get("code_server_enabled", False)),
             agent_slack_notify_enabled=bool(request.get("agent_slack_notify_enabled", False)),
             settings=request.get("sandbox_settings") or None,
+            timeout_seconds=_timeout_seconds_from_request(request, DEFAULT_SANDBOX_TIMEOUT_SECONDS),
         )
 
         handle = await manager.create_sandbox(config)
@@ -396,7 +418,7 @@ async def api_restore_sandbox(
         sandbox_id = request.get("sandbox_id")
         sandbox_auth_token = request.get("sandbox_auth_token", "")
         user_env_vars = request.get("user_env_vars") or None
-        timeout_seconds = int(request.get("timeout_seconds", DEFAULT_SANDBOX_TIMEOUT_SECONDS))
+        timeout_seconds = _timeout_seconds_from_request(request, DEFAULT_SANDBOX_TIMEOUT_SECONDS)
         repo_owner, repo_name = _normalize_optional_repository_context(
             session_config.get("repo_owner") if isinstance(session_config, dict) else None,
             session_config.get("repo_name") if isinstance(session_config, dict) else None,

--- a/packages/modal-infra/tests/test_web_api_create_sandbox.py
+++ b/packages/modal-infra/tests/test_web_api_create_sandbox.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException
 from sandbox_runtime.types import SandboxStatus
 from src import web_api
 from src.sandbox import manager as manager_module
+from src.sandbox.manager import DEFAULT_SANDBOX_TIMEOUT_SECONDS
 
 
 def _patch_auth(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -95,6 +96,62 @@ async def test_create_sandbox_does_not_resolve_clone_token_for_fresh_boot(monkey
     assert result["success"] is True
     assert calls == []
     assert captured["config"].fallback_clone_token is None
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_forwards_timeout(monkeypatch):
+    captured = {}
+    _patch_auth(monkeypatch)
+    _patch_manager(monkeypatch, captured)
+
+    result = await _call_create_sandbox(
+        {
+            "session_id": "sess-1",
+            "control_plane_url": "https://control-plane.example",
+            "sandbox_auth_token": "sandbox-token",
+            "timeout_seconds": 14_400,
+        }
+    )
+
+    assert result["success"] is True
+    assert captured["config"].timeout_seconds == 14_400
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_uses_default_timeout_when_omitted(monkeypatch):
+    captured = {}
+    _patch_auth(monkeypatch)
+    _patch_manager(monkeypatch, captured)
+
+    result = await _call_create_sandbox(
+        {
+            "session_id": "sess-1",
+            "control_plane_url": "https://control-plane.example",
+            "sandbox_auth_token": "sandbox-token",
+        }
+    )
+
+    assert result["success"] is True
+    assert captured["config"].timeout_seconds == DEFAULT_SANDBOX_TIMEOUT_SECONDS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("timeout_seconds", [0, -1, 1.5, float("inf"), True, "not-a-timeout"])
+async def test_create_sandbox_rejects_invalid_timeout(monkeypatch, timeout_seconds):
+    _patch_auth(monkeypatch)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _call_create_sandbox(
+            {
+                "session_id": "sess-1",
+                "control_plane_url": "https://control-plane.example",
+                "sandbox_auth_token": "sandbox-token",
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "timeout_seconds must be a positive integer"
 
 
 @pytest.mark.asyncio
@@ -262,6 +319,26 @@ async def test_restore_sandbox_without_repo_does_not_resolve_clone_token(monkeyp
     assert result["success"] is True
     assert calls == []
     assert captured["restore"]["clone_token"] is None
+
+
+@pytest.mark.asyncio
+async def test_restore_sandbox_forwards_timeout(monkeypatch):
+    captured = {}
+    _patch_auth(monkeypatch)
+    _patch_restore_manager(monkeypatch, captured)
+
+    result = await _call_restore_sandbox(
+        {
+            "snapshot_image_id": "img-abc",
+            "session_config": {"session_id": "sess-1"},
+            "control_plane_url": "https://control-plane.example",
+            "sandbox_auth_token": "sandbox-token",
+            "timeout_seconds": 14_400,
+        }
+    )
+
+    assert result["success"] is True
+    assert captured["restore"]["timeout_seconds"] == 14_400
 
 
 @pytest.mark.asyncio

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -110,6 +110,9 @@ export const DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS = 5;
 /** Default maximum agent-spawned child sessions per parent session. */
 export const DEFAULT_MAX_TOTAL_CHILD_SESSIONS = 15;
 
+/** Minimum configurable sandbox session lifetime, in milliseconds. */
+export const MIN_SANDBOX_TIMEOUT_MS = 1000;
+
 /**
  * Default repo-image build timeout (the build sandbox lifetime), in seconds.
  * Mirrors `DEFAULT_BUILD_TIMEOUT_SECONDS` in the Modal data plane

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -167,6 +167,12 @@ export interface SandboxSettings {
    */
   memoryMib?: number | null;
   /**
+   * Requested sandbox session lifetime, in milliseconds and whole-second
+   * increments. Unset uses the provider default (or the shorter default for
+   * agent-spawned children). Provider support and limits vary.
+   */
+  sandboxTimeoutMs?: number;
+  /**
    * Repo-image build timeout (the build sandbox lifetime), in seconds.
    * Build-only — sessions are unaffected. Unset → DEFAULT_BUILD_TIMEOUT_SECONDS.
    * The trigger caps the effective value at MAX_BUILD_TIMEOUT_SECONDS via

--- a/packages/web/src/components/settings/sandbox-settings.test.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.test.tsx
@@ -83,6 +83,49 @@ describe("SandboxSettingsPage — tunnel ports editor", () => {
     expect(screen.getByText("No tunnel ports configured.")).toBeInTheDocument();
   });
 
+  it("displays session timeout in minutes and saves milliseconds", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === "PUT") return new Response(JSON.stringify({}), { status: 200 });
+      throw new Error("unexpected fetch");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    render(
+      <SWRConfig
+        value={{
+          provider: () => new Map(),
+          fallback: {
+            [SETTINGS_KEY]: {
+              integrationId: "sandbox",
+              settings: { defaults: { sandboxTimeoutMs: 7_200_000 } },
+            },
+          },
+          dedupingInterval: Infinity,
+          revalidateOnFocus: false,
+          revalidateIfStale: false,
+          revalidateOnReconnect: false,
+        }}
+      >
+        <SandboxSettingsPage />
+      </SWRConfig>
+    );
+
+    const input = screen.getByLabelText("Session Timeout");
+    expect(input).toHaveValue(120);
+    await user.clear(input);
+    await user.type(input, "240");
+    await user.click(screen.getByText("Save Settings"));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        SETTINGS_KEY,
+        expect.objectContaining({
+          method: "PUT",
+          body: expect.stringContaining('"sandboxTimeoutMs":14400000'),
+        })
+      );
+    });
+  });
+
   it("renders existing ports as individual input rows", () => {
     renderWithSWR(globalSettings([3000, 5173]));
 
@@ -1033,7 +1076,14 @@ describe("SandboxSettingsEditor — environment scope", () => {
     const { fetchMock } = renderEnvironmentEditor({
       [SETTINGS_KEY]: {
         integrationId: "sandbox",
-        settings: { defaults: { tunnelPorts: [], cpuCores: 2, buildTimeoutSeconds: 600 } },
+        settings: {
+          defaults: {
+            tunnelPorts: [],
+            cpuCores: 2,
+            buildTimeoutSeconds: 600,
+            sandboxTimeoutMs: 7_200_000,
+          },
+        },
       },
       [repoSettingsKey]: { integrationId: "sandbox", repo: "acme/app", settings: null },
       [environmentSettingsKey]: {
@@ -1046,6 +1096,8 @@ describe("SandboxSettingsEditor — environment scope", () => {
     await user.clear(screen.getByLabelText("Image Build Timeout"));
     await user.type(screen.getByLabelText("Image Build Timeout"), "2400");
     await user.click(screen.getByText("Save Settings"));
+
+    expect(screen.getByLabelText("Session Timeout")).toHaveValue(120);
 
     // Only the edited field is pinned — inherited cpu and the inherited
     // build-timeout base stay inherited.

--- a/packages/web/src/components/settings/sandbox-settings.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRepos } from "@/hooks/use-repos";
-import { useState, useCallback } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { ChevronDownIcon, CheckIcon, PlusIcon } from "@/components/ui/icons";
 import { Combobox } from "@/components/ui/combobox";
@@ -20,9 +20,13 @@ import {
   MAX_BUILD_TIMEOUT_SECONDS,
   MAX_TUNNEL_PORTS,
 } from "@open-inspect/shared";
+import {
+  MIN_SANDBOX_TIMEOUT_MINUTES,
+  sandboxTimeoutMinutesFromMs,
+  sandboxTimeoutMsFromMinutes,
+} from "./sandbox-timeout";
 
 const GLOBAL_SCOPE = "__global__";
-const MILLISECONDS_PER_MINUTE = 60_000;
 type ResourceField = "cpuCores" | "memoryMib";
 
 interface GlobalSettingsResponse {
@@ -67,15 +71,6 @@ function isValidBuildTimeout(value: string): boolean {
   if (!/^\d+$/.test(value)) return false;
   const n = Number(value);
   return n >= 1 && n <= MAX_BUILD_TIMEOUT_SECONDS;
-}
-
-function sandboxTimeoutMsFromMinutes(value: string): number | undefined {
-  if (value === "") return undefined;
-  if (!/^\d+(?:\.\d+)?$/.test(value)) return undefined;
-  const timeoutMs = Number(value) * MILLISECONDS_PER_MINUTE;
-  return Number.isSafeInteger(timeoutMs) && timeoutMs >= 1000 && timeoutMs % 1000 === 0
-    ? timeoutMs
-    : undefined;
 }
 
 /** Trim, filter empty, validate, parse to number, dedupe. */
@@ -307,10 +302,7 @@ export function SandboxSettingsEditor({
     buildTimeoutSeconds ??
     (currentBuildTimeoutSeconds !== undefined ? String(currentBuildTimeoutSeconds) : "");
   const resolvedSandboxTimeoutMinutes =
-    sandboxTimeoutMinutes ??
-    (currentSandboxTimeoutMs !== undefined
-      ? String(currentSandboxTimeoutMs / MILLISECONDS_PER_MINUTE)
-      : "");
+    sandboxTimeoutMinutes ?? sandboxTimeoutMinutesFromMs(currentSandboxTimeoutMs);
 
   const handleAddRow = () => {
     if (rows.length >= MAX_TUNNEL_PORTS) return;
@@ -328,7 +320,7 @@ export function SandboxSettingsEditor({
     setPortRows(updated);
   };
 
-  const handleSave = useCallback(async () => {
+  const handleSave = async () => {
     setError(null);
     setSuccess(false);
 
@@ -514,35 +506,7 @@ export function SandboxSettingsEditor({
     } finally {
       setSaving(false);
     }
-  }, [
-    rows,
-    isGlobal,
-    apiUrl,
-    mutate,
-    enabledRepos,
-    resolvedTerminalEnabled,
-    resolvedMaxConcurrentChildSessions,
-    resolvedMaxTotalChildSessions,
-    resolvedCpuCores,
-    resolvedMemoryMib,
-    resolvedCodeServerPort,
-    resolvedTerminalPort,
-    resolvedBuildTimeoutSeconds,
-    resolvedSandboxTimeoutMinutes,
-    portRows,
-    terminalEnabled,
-    codeServerPort,
-    terminalPort,
-    buildTimeoutSeconds,
-    sandboxTimeoutMinutes,
-    cpuCores,
-    memoryMib,
-    maxConcurrentChildSessions,
-    maxTotalChildSessions,
-    ownSettings,
-    baseDefaults?.codeServerPort,
-    baseDefaults?.terminalPort,
-  ]);
+  };
 
   const hasPortChanges =
     portRows !== null &&
@@ -570,10 +534,7 @@ export function SandboxSettingsEditor({
     currentBuildTimeoutSeconds !== undefined ? String(currentBuildTimeoutSeconds) : "";
   const hasBuildTimeoutChange =
     buildTimeoutSeconds !== null && buildTimeoutSeconds.trim() !== currentBuildTimeoutSecondsString;
-  const currentSandboxTimeoutMinutesString =
-    currentSandboxTimeoutMs !== undefined
-      ? String(currentSandboxTimeoutMs / MILLISECONDS_PER_MINUTE)
-      : "";
+  const currentSandboxTimeoutMinutesString = sandboxTimeoutMinutesFromMs(currentSandboxTimeoutMs);
   const hasSandboxTimeoutChange =
     sandboxTimeoutMinutes !== null &&
     sandboxTimeoutMinutes.trim() !== currentSandboxTimeoutMinutesString;
@@ -818,8 +779,8 @@ export function SandboxSettingsEditor({
           <Input
             id="sandbox-session-timeout"
             type="number"
-            min={1 / 60}
-            step={1 / 60}
+            min={MIN_SANDBOX_TIMEOUT_MINUTES}
+            step={MIN_SANDBOX_TIMEOUT_MINUTES}
             inputMode="decimal"
             value={resolvedSandboxTimeoutMinutes}
             onChange={(e) => setSandboxTimeoutMinutes(e.target.value)}

--- a/packages/web/src/components/settings/sandbox-settings.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.tsx
@@ -22,6 +22,7 @@ import {
 } from "@open-inspect/shared";
 
 const GLOBAL_SCOPE = "__global__";
+const MILLISECONDS_PER_MINUTE = 60_000;
 type ResourceField = "cpuCores" | "memoryMib";
 
 interface GlobalSettingsResponse {
@@ -66,6 +67,15 @@ function isValidBuildTimeout(value: string): boolean {
   if (!/^\d+$/.test(value)) return false;
   const n = Number(value);
   return n >= 1 && n <= MAX_BUILD_TIMEOUT_SECONDS;
+}
+
+function sandboxTimeoutMsFromMinutes(value: string): number | undefined {
+  if (value === "") return undefined;
+  if (!/^\d+(?:\.\d+)?$/.test(value)) return undefined;
+  const timeoutMs = Number(value) * MILLISECONDS_PER_MINUTE;
+  return Number.isSafeInteger(timeoutMs) && timeoutMs >= 1000 && timeoutMs % 1000 === 0
+    ? timeoutMs
+    : undefined;
 }
 
 /** Trim, filter empty, validate, parse to number, dedupe. */
@@ -246,6 +256,9 @@ export function SandboxSettingsEditor({
   const currentBuildTimeoutSeconds: number | undefined =
     ownSettings?.buildTimeoutSeconds ?? baseDefaults?.buildTimeoutSeconds;
 
+  const currentSandboxTimeoutMs: number | undefined =
+    ownSettings?.sandboxTimeoutMs ?? baseDefaults?.sandboxTimeoutMs;
+
   const currentMaxConcurrentChildSessions: number =
     ownSettings?.maxConcurrentChildSessions ??
     baseDefaults?.maxConcurrentChildSessions ??
@@ -264,6 +277,7 @@ export function SandboxSettingsEditor({
   const [codeServerPort, setCodeServerPort] = useState<string | null>(null);
   const [terminalPort, setTerminalPort] = useState<string | null>(null);
   const [buildTimeoutSeconds, setBuildTimeoutSeconds] = useState<string | null>(null);
+  const [sandboxTimeoutMinutes, setSandboxTimeoutMinutes] = useState<string | null>(null);
   const [maxConcurrentChildSessions, setMaxConcurrentChildSessions] = useState<string | null>(null);
   const [maxTotalChildSessions, setMaxTotalChildSessions] = useState<string | null>(null);
   const [cpuCores, setCpuCores] = useState<string | null>(null);
@@ -292,6 +306,11 @@ export function SandboxSettingsEditor({
   const resolvedBuildTimeoutSeconds =
     buildTimeoutSeconds ??
     (currentBuildTimeoutSeconds !== undefined ? String(currentBuildTimeoutSeconds) : "");
+  const resolvedSandboxTimeoutMinutes =
+    sandboxTimeoutMinutes ??
+    (currentSandboxTimeoutMs !== undefined
+      ? String(currentSandboxTimeoutMs / MILLISECONDS_PER_MINUTE)
+      : "");
 
   const handleAddRow = () => {
     if (rows.length >= MAX_TUNNEL_PORTS) return;
@@ -356,6 +375,13 @@ export function SandboxSettingsEditor({
       setError(
         `Build timeout must be a whole number of seconds, at most ${MAX_BUILD_TIMEOUT_SECONDS}.`
       );
+      return;
+    }
+
+    const trimmedSandboxTimeoutMinutes = resolvedSandboxTimeoutMinutes.trim();
+    const editedSandboxTimeoutMs = sandboxTimeoutMsFromMinutes(trimmedSandboxTimeoutMinutes);
+    if (trimmedSandboxTimeoutMinutes !== "" && editedSandboxTimeoutMs === undefined) {
+      setError("Session timeout must be at least one second, in one-second increments.");
       return;
     }
 
@@ -425,6 +451,13 @@ export function SandboxSettingsEditor({
       if (buildTimeoutValue !== undefined) {
         settingsPayload.buildTimeoutSeconds = buildTimeoutValue;
       }
+      const sandboxTimeoutMsValue =
+        isGlobal || sandboxTimeoutMinutes !== null
+          ? editedSandboxTimeoutMs
+          : ownSettings?.sandboxTimeoutMs;
+      if (sandboxTimeoutMsValue !== undefined) {
+        settingsPayload.sandboxTimeoutMs = sandboxTimeoutMsValue;
+      }
       if (
         isGlobal ||
         maxConcurrentChildSessions !== null ||
@@ -473,6 +506,7 @@ export function SandboxSettingsEditor({
       setCodeServerPort(null);
       setTerminalPort(null);
       setBuildTimeoutSeconds(null);
+      setSandboxTimeoutMinutes(null);
       setSuccess(true);
       setTimeout(() => setSuccess(false), 2000);
     } catch (e) {
@@ -494,11 +528,13 @@ export function SandboxSettingsEditor({
     resolvedCodeServerPort,
     resolvedTerminalPort,
     resolvedBuildTimeoutSeconds,
+    resolvedSandboxTimeoutMinutes,
     portRows,
     terminalEnabled,
     codeServerPort,
     terminalPort,
     buildTimeoutSeconds,
+    sandboxTimeoutMinutes,
     cpuCores,
     memoryMib,
     maxConcurrentChildSessions,
@@ -534,6 +570,13 @@ export function SandboxSettingsEditor({
     currentBuildTimeoutSeconds !== undefined ? String(currentBuildTimeoutSeconds) : "";
   const hasBuildTimeoutChange =
     buildTimeoutSeconds !== null && buildTimeoutSeconds.trim() !== currentBuildTimeoutSecondsString;
+  const currentSandboxTimeoutMinutesString =
+    currentSandboxTimeoutMs !== undefined
+      ? String(currentSandboxTimeoutMs / MILLISECONDS_PER_MINUTE)
+      : "";
+  const hasSandboxTimeoutChange =
+    sandboxTimeoutMinutes !== null &&
+    sandboxTimeoutMinutes.trim() !== currentSandboxTimeoutMinutesString;
   const hasChanges =
     hasPortChanges ||
     hasTerminalChange ||
@@ -543,7 +586,8 @@ export function SandboxSettingsEditor({
     hasMemoryChange ||
     hasCodeServerPortChange ||
     hasTerminalPortChange ||
-    hasBuildTimeoutChange;
+    hasBuildTimeoutChange ||
+    hasSandboxTimeoutChange;
 
   if (isLoading) {
     return <p className="text-sm text-muted-foreground">Loading...</p>;
@@ -755,6 +799,32 @@ export function SandboxSettingsEditor({
               placeholder="provider default"
             />
           </div>
+        </div>
+      </div>
+
+      <div>
+        <label
+          htmlFor="sandbox-session-timeout"
+          className="block text-sm font-medium text-foreground mb-1.5"
+        >
+          Session Timeout
+        </label>
+        <p className="text-xs text-muted-foreground mb-2">
+          Requested lifetime for each sandbox session, in minutes. Leave blank to inherit a parent
+          setting, or use the provider default if none is configured. Provider support and limits
+          vary.
+        </p>
+        <div className="max-w-sm">
+          <Input
+            id="sandbox-session-timeout"
+            type="number"
+            min={1 / 60}
+            step={1 / 60}
+            inputMode="decimal"
+            value={resolvedSandboxTimeoutMinutes}
+            onChange={(e) => setSandboxTimeoutMinutes(e.target.value)}
+            placeholder="provider default"
+          />
         </div>
       </div>
 

--- a/packages/web/src/components/settings/sandbox-timeout.test.ts
+++ b/packages/web/src/components/settings/sandbox-timeout.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { sandboxTimeoutMinutesFromMs, sandboxTimeoutMsFromMinutes } from "./sandbox-timeout";
+
+describe("sandbox timeout conversion", () => {
+  it.each([
+    ["0.5166666666666667", 31_000],
+    ["2.05", 123_000],
+    ["4.1", 246_000],
+  ])("converts %s minutes to a whole-second timeout", (minutes, timeoutMs) => {
+    expect(sandboxTimeoutMsFromMinutes(minutes)).toBe(timeoutMs);
+  });
+
+  it("rejects fractional-second durations", () => {
+    expect(sandboxTimeoutMsFromMinutes("2.051")).toBeUndefined();
+  });
+
+  it("formats milliseconds as minutes", () => {
+    expect(sandboxTimeoutMinutesFromMs(123_000)).toBe("2.05");
+    expect(sandboxTimeoutMinutesFromMs(undefined)).toBe("");
+  });
+});

--- a/packages/web/src/components/settings/sandbox-timeout.ts
+++ b/packages/web/src/components/settings/sandbox-timeout.ts
@@ -1,0 +1,26 @@
+import { MIN_SANDBOX_TIMEOUT_MS } from "@open-inspect/shared";
+
+const MILLISECONDS_PER_MINUTE = 60_000;
+
+export const MIN_SANDBOX_TIMEOUT_MINUTES = MIN_SANDBOX_TIMEOUT_MS / MILLISECONDS_PER_MINUTE;
+
+export function sandboxTimeoutMsFromMinutes(value: string): number | undefined {
+  if (value === "" || !/^\d+(?:\.\d+)?$/.test(value)) return undefined;
+
+  const timeoutSeconds = Number(value) * 60;
+  const roundedSeconds = Math.round(timeoutSeconds);
+  const timeoutMs = roundedSeconds * 1000;
+  const tolerance = Math.min(0.000001, Number.EPSILON * Math.max(1, Math.abs(timeoutSeconds)) * 4);
+  if (
+    !Number.isSafeInteger(timeoutMs) ||
+    timeoutMs < MIN_SANDBOX_TIMEOUT_MS ||
+    Math.abs(timeoutSeconds - roundedSeconds) > tolerance
+  ) {
+    return undefined;
+  }
+  return timeoutMs;
+}
+
+export function sandboxTimeoutMinutesFromMs(timeoutMs: number | undefined): string {
+  return timeoutMs === undefined ? "" : String(timeoutMs / MILLISECONDS_PER_MINUTE);
+}


### PR DESCRIPTION
## Summary

- add a layered `sandboxTimeoutMs` sandbox setting with global, repository, and environment support
- expose the timeout in the sandbox settings UI using minutes while preserving millisecond units in TypeScript
- apply configured lifetimes consistently to fresh spawns, snapshot restores, and persistent resumes
- forward and validate timeout values in Modal create and restore APIs
- renew OpenComputer TTLs when resuming already-running sandboxes
- preserve existing provider defaults and the one-hour child-session default when no explicit setting exists

## Testing

- `npm test` (3,391 TypeScript tests passed)
- `npm run typecheck`
- `npm run test:integration -w @open-inspect/control-plane -- test/integration/integration-settings.test.ts`
- `uv run pytest tests/ -q` (226 tests passed)
- changed-file ESLint, Prettier, Ruff lint, and Ruff format checks

## Notes

- provider support and maximum lifetimes vary; Vercel retains its existing cap and Daytona has no absolute-lifetime API in the current provider client
- `npm run build` compiled all packages and the Next.js application, then hit the existing `/automations/new` prerender `useContext` failure in this environment
- root `npm run lint` remains blocked by existing Node-global errors under `.opencode`; all changed files pass ESLint

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/c94770b1e8d7a7a654c190b7628f4721)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable sandbox session timeouts in the settings page.
  * Timeout values are displayed and edited in minutes, with inherited and provider-default settings shown.
  * Configured timeouts now apply consistently when starting, restoring, or resuming sandboxes.
  * Supported providers now enforce explicit session timeouts.

* **Bug Fixes**
  * Improved timeout validation and handling for invalid or unsupported values.
  * Resuming an active sandbox now renews its configured timeout without restarting it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->