### PR TITLE
fix: inherit parent sandbox timeout in child sessions

### DIFF
--- a/packages/control-plane/src/router.spawn-child.test.ts
+++ b/packages/control-plane/src/router.spawn-child.test.ts
@@ -30,6 +30,7 @@ describe("handleSpawnChild prompt enqueue handling", () => {
     baseBranch?: string | null;
     model: string;
     reasoningEffort: string | null;
+    sandboxTimeoutMs?: number;
     owner: {
       userId: string;
       scmUserId: string | null;
@@ -48,6 +49,7 @@ describe("handleSpawnChild prompt enqueue handling", () => {
     repoId: 12345,
     model: "anthropic/claude-sonnet-4-6",
     reasoningEffort: null,
+    sandboxTimeoutMs: 14_400_000,
     baseBranch: "main",
     owner: {
       userId: "user-1",
@@ -101,6 +103,9 @@ describe("handleSpawnChild prompt enqueue handling", () => {
     vi.mocked(SessionIndexStore).mockImplementation(function () {
       return store as never;
     });
+    integrationSettingsMocks.resolveSandboxSettings.mockResolvedValue({
+      sandboxTimeoutMs: 3_600_000,
+    });
 
     const parentStub: DurableObjectStub = {
       fetch: vi.fn(async () => Response.json(spawnContext)),
@@ -142,8 +147,55 @@ describe("handleSpawnChild prompt enqueue handling", () => {
       return new URL(request.url).pathname === SessionInternalPaths.init;
     })?.[0] as Request | undefined;
     expect(initRequest).toBeDefined();
-    await expect(initRequest!.json()).resolves.toMatchObject({ environmentId: "env_parent" });
+    await expect(initRequest!.json()).resolves.toMatchObject({
+      environmentId: "env_parent",
+      sandboxSettings: { sandboxTimeoutMs: 14_400_000 },
+    });
     expect(store.updateStatus).not.toHaveBeenCalled();
+  });
+
+  it("preserves the provider default when the parent has no snapshotted timeout", async () => {
+    const store = makeStore("canonical-user-123");
+    vi.mocked(SessionIndexStore).mockImplementation(function () {
+      return store as never;
+    });
+    integrationSettingsMocks.resolveSandboxSettings.mockResolvedValue({
+      sandboxTimeoutMs: 3_600_000,
+      tunnelPorts: [3000],
+    });
+
+    const parentStub: DurableObjectStub = {
+      fetch: vi.fn(async () => Response.json({ ...spawnContext, sandboxTimeoutMs: undefined })),
+    } as never;
+    const childStub: DurableObjectStub = {
+      fetch: vi.fn(async (request: Request) => {
+        const path = new URL(request.url).pathname;
+        if (path === SessionInternalPaths.init) return Response.json({ status: "ok" });
+        if (path === SessionInternalPaths.prompt) {
+          return Response.json({ messageId: "msg-1", status: "queued" });
+        }
+        return Response.json({ error: "unexpected" }, { status: 404 });
+      }),
+    } as never;
+    const env = {
+      ...TEST_SERVICE_SECRETS,
+      SCM_PROVIDER: "github",
+      DB: {},
+      SESSION: {
+        idFromName: (name: string) => name,
+        get: (id: string) => (id === parentId ? parentStub : childStub),
+      },
+    };
+
+    const response = await makeRequest(env);
+
+    expect(response.status).toBe(201);
+    const initRequest = vi.mocked(childStub.fetch).mock.calls.find((call) => {
+      const request = call[0] as Request;
+      return new URL(request.url).pathname === SessionInternalPaths.init;
+    })?.[0] as Request;
+    const initBody = await initRequest.json<{ sandboxSettings: Record<string, unknown> }>();
+    expect(initBody.sandboxSettings).toEqual({ tunnelPorts: [3000] });
   });
 
   it("creates repo-less children for repo-less parents", async () => {

--- a/packages/control-plane/src/routes/session-child-spawn.ts
+++ b/packages/control-plane/src/routes/session-child-spawn.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_MAX_TOTAL_CHILD_SESSIONS,
   spawnChildSessionRequestSchema,
   spawnContextSchema,
+  type SandboxSettings,
 } from "@open-inspect/shared";
 import {
   getValidModelOrDefault,
@@ -56,7 +57,7 @@ async function handleSpawnChild(
   const parentEnvironmentId = parentSession?.environmentId ?? null;
   // Children inherit the parent's settings scope: its primary repo plus, for
   // environment-launched parents, that environment's overrides (design §13.5).
-  const childSandboxSettings = parentSession
+  const resolvedChildSandboxSettings = parentSession
     ? await resolveSandboxSettings(
         ctx.db,
         parentSession.repoOwner,
@@ -65,9 +66,10 @@ async function handleSpawnChild(
       )
     : {};
   const maxConcurrentChildren =
-    childSandboxSettings.maxConcurrentChildSessions ?? DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS;
+    resolvedChildSandboxSettings.maxConcurrentChildSessions ??
+    DEFAULT_MAX_CONCURRENT_CHILD_SESSIONS;
   const maxTotalChildren =
-    childSandboxSettings.maxTotalChildSessions ?? DEFAULT_MAX_TOTAL_CHILD_SESSIONS;
+    resolvedChildSandboxSettings.maxTotalChildSessions ?? DEFAULT_MAX_TOTAL_CHILD_SESSIONS;
 
   const parentDepth = await sessionStore.getSpawnDepth(parentId);
   if (parentDepth >= MAX_SPAWN_DEPTH) {
@@ -107,6 +109,12 @@ async function handleSpawnChild(
     return error("Failed to get parent session context", 500);
   }
   const spawnContext = parsedSpawnContext.data;
+  const { sandboxTimeoutMs: _currentTimeoutMs, ...resolvedChildSettingsWithoutTimeout } =
+    resolvedChildSandboxSettings;
+  const childSandboxSettings: SandboxSettings = resolvedChildSettingsWithoutTimeout;
+  if (spawnContext.sandboxTimeoutMs !== undefined) {
+    childSandboxSettings.sandboxTimeoutMs = spawnContext.sandboxTimeoutMs;
+  }
 
   const requestedRepoOwner = body.repoOwner?.trim().toLowerCase() || null;
   const requestedRepoName = body.repoName?.trim().toLowerCase() || null;

--- a/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.test.ts
@@ -7,7 +7,6 @@
 import { describe, it, expect, vi } from "vitest";
 import {
   SandboxLifecycleManager,
-  CHILD_SANDBOX_TIMEOUT_MS,
   DEFAULT_LIFECYCLE_CONFIG,
   type SandboxStorage,
   type SandboxBroadcaster,
@@ -2562,7 +2561,7 @@ describe("SandboxLifecycleManager", () => {
       );
     });
 
-    it("lets an explicit sandbox timeout override the child-session default", async () => {
+    it("uses the configured sandbox timeout for child sessions", async () => {
       const session = createMockSession({
         spawn_source: "agent",
         sandbox_settings: '{"sandboxTimeoutMs":14400000}',
@@ -2586,7 +2585,7 @@ describe("SandboxLifecycleManager", () => {
       );
     });
 
-    it("preserves the child-session timeout when no timeout is configured", async () => {
+    it("uses the provider default for child sessions when no timeout is configured", async () => {
       const session = createMockSession({ spawn_source: "agent", sandbox_settings: null });
       const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
       const provider = createMockProvider();
@@ -2603,12 +2602,13 @@ describe("SandboxLifecycleManager", () => {
       await manager.spawnSandbox();
 
       expect(provider.createSandbox).toHaveBeenCalledWith(
-        expect.objectContaining({ timeoutSeconds: CHILD_SANDBOX_TIMEOUT_MS / 1000 })
+        expect.objectContaining({ timeoutSeconds: undefined })
       );
     });
 
     it("rejects configured timeouts when the provider cannot enforce them", async () => {
       const session = createMockSession({
+        spawn_source: "agent",
         sandbox_settings: '{"sandboxTimeoutMs":14400000}',
       });
       const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
@@ -2635,7 +2635,7 @@ describe("SandboxLifecycleManager", () => {
       });
     });
 
-    it("does not pass the implicit child timeout to unsupported providers", async () => {
+    it("uses the provider default for child sessions on unsupported providers", async () => {
       const session = createMockSession({ spawn_source: "agent", sandbox_settings: null });
       const sandbox = createMockSandbox({ status: "pending", created_at: Date.now() - 60000 });
       const provider = createMockProvider({

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -44,7 +44,7 @@ import { createLogger, type Logger } from "../../logger";
 import { hashToken } from "../../auth/crypto";
 import { mintJwt } from "../../auth/jwt";
 import { repoImageBuildScope, type ImageBuildScope } from "../../image-builds/model";
-import { normalizeSandboxSettings } from "../settings";
+import { parsePersistedSandboxSettings } from "../settings";
 import {
   evaluateImageBuildForSpawn,
   type ImageBuildLookup,
@@ -1374,10 +1374,8 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
   }
 
   private parseSandboxSettings(session: SessionRow): SandboxSettings {
-    if (!session.sandbox_settings) return {};
     try {
-      const parsed: unknown = JSON.parse(session.sandbox_settings);
-      return normalizeSandboxSettings(parsed, { invalid: "omit" });
+      return parsePersistedSandboxSettings(session.sandbox_settings);
     } catch {
       this.log.warn("Failed to parse sandbox_settings, using defaults");
       return {};

--- a/packages/control-plane/src/sandbox/lifecycle/manager.ts
+++ b/packages/control-plane/src/sandbox/lifecycle/manager.ts
@@ -203,9 +203,6 @@ export const DEFAULT_LIFECYCLE_CONFIG: Omit<SandboxLifecycleConfig, "controlPlan
   connectingTimeout: DEFAULT_CONNECTING_TIMEOUT_CONFIG,
 };
 
-/** Default sandbox lifetime for agent-spawned child sessions. */
-export const CHILD_SANDBOX_TIMEOUT_MS = 3_600_000;
-
 function buildSandboxIdForSession(session: SessionRow, now: number): string {
   const sandboxName = sessionHasRepository(session)
     ? `${session.repo_owner}-${session.repo_name}`
@@ -466,7 +463,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       const codeServerEnabled = session.code_server_enabled === 1;
       const agentSlackNotifyEnabled = await this.resolveAgentSlackNotifyEnabled(session);
       const sandboxSettings = this.parseSandboxSettings(session);
-      const timeoutSeconds = this.resolveSandboxTimeoutSeconds(session, sandboxSettings);
+      const timeoutSeconds = this.resolveSandboxTimeoutSeconds(sandboxSettings);
       const createConfig: CreateSandboxConfig = {
         sessionId,
         sandboxId: expectedSandboxId,
@@ -758,7 +755,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       const agentSlackNotifyEnabled = await this.resolveAgentSlackNotifyEnabled(session);
       const mcpServers = await this.loadMcpServers(repositories);
       const sandboxSettings = this.parseSandboxSettings(session);
-      const timeoutSeconds = this.resolveSandboxTimeoutSeconds(session, sandboxSettings);
+      const timeoutSeconds = this.resolveSandboxTimeoutSeconds(sandboxSettings);
       const result = await this.provider.restoreFromSnapshot({
         snapshotImageId,
         sessionId: session.session_name || session.id,
@@ -892,7 +889,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       this.broadcaster.broadcast({ type: "sandbox_status", status: "connecting" });
 
       const sandboxSettings = this.parseSandboxSettings(session);
-      const timeoutSeconds = this.resolveSandboxTimeoutSeconds(session, sandboxSettings);
+      const timeoutSeconds = this.resolveSandboxTimeoutSeconds(sandboxSettings);
 
       const result = await this.provider.resumeSandbox({
         providerObjectId,
@@ -1387,10 +1384,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
     }
   }
 
-  private resolveSandboxTimeoutSeconds(
-    session: SessionRow,
-    sandboxSettings: SandboxSettings
-  ): number | undefined {
+  private resolveSandboxTimeoutSeconds(sandboxSettings: SandboxSettings): number | undefined {
     if (!this.provider.capabilities.supportsSandboxTimeout) {
       if (sandboxSettings.sandboxTimeoutMs !== undefined) {
         throw new SandboxProviderError(
@@ -1400,9 +1394,7 @@ export class SandboxLifecycleManager implements SandboxLifecycle {
       }
       return undefined;
     }
-    const timeoutMs =
-      sandboxSettings.sandboxTimeoutMs ??
-      (session.spawn_source === "agent" ? CHILD_SANDBOX_TIMEOUT_MS : undefined);
+    const timeoutMs = sandboxSettings.sandboxTimeoutMs;
     return timeoutMs === undefined ? undefined : timeoutMs / 1000;
   }
 

--- a/packages/control-plane/src/sandbox/settings.test.ts
+++ b/packages/control-plane/src/sandbox/settings.test.ts
@@ -1,8 +1,28 @@
 import { describe, expect, it } from "vitest";
 import { INTERNAL_TTYD_PORT } from "@open-inspect/shared";
-import { normalizeSandboxSettings, SandboxSettingsValidationError } from "./settings";
+import {
+  normalizeSandboxSettings,
+  parsePersistedSandboxSettings,
+  SandboxSettingsValidationError,
+} from "./settings";
 
 class CustomSettingsValidationError extends Error {}
+
+describe("parsePersistedSandboxSettings", () => {
+  it("returns empty settings when no snapshot is stored", () => {
+    expect(parsePersistedSandboxSettings(null)).toEqual({});
+  });
+
+  it("parses and normalizes persisted settings", () => {
+    expect(
+      parsePersistedSandboxSettings('{"sandboxTimeoutMs":14400000,"tunnelPorts":[3000,"bad"]}')
+    ).toEqual({ sandboxTimeoutMs: 14_400_000, tunnelPorts: [3000] });
+  });
+
+  it("throws when the persisted blob is not valid JSON", () => {
+    expect(() => parsePersistedSandboxSettings("not-json")).toThrow(SyntaxError);
+  });
+});
 
 describe("normalizeSandboxSettings", () => {
   it("throws for invalid settings by default", () => {

--- a/packages/control-plane/src/sandbox/settings.test.ts
+++ b/packages/control-plane/src/sandbox/settings.test.ts
@@ -19,8 +19,8 @@ describe("parsePersistedSandboxSettings", () => {
     ).toEqual({ sandboxTimeoutMs: 14_400_000, tunnelPorts: [3000] });
   });
 
-  it("throws when the persisted blob is not valid JSON", () => {
-    expect(() => parsePersistedSandboxSettings("not-json")).toThrow(SyntaxError);
+  it.each(["", "not-json"])("throws when persisted blob %j is not valid JSON", (settingsJson) => {
+    expect(() => parsePersistedSandboxSettings(settingsJson)).toThrow(SyntaxError);
   });
 });
 

--- a/packages/control-plane/src/sandbox/settings.ts
+++ b/packages/control-plane/src/sandbox/settings.ts
@@ -22,7 +22,7 @@ export class SandboxSettingsValidationError extends Error {
 
 /** Decode and normalize a session's persisted sandbox settings snapshot. */
 export function parsePersistedSandboxSettings(settingsJson: string | null): SandboxSettings {
-  if (!settingsJson) return {};
+  if (settingsJson === null) return {};
   return normalizeSandboxSettings(JSON.parse(settingsJson), { invalid: "omit" });
 }
 

--- a/packages/control-plane/src/sandbox/settings.ts
+++ b/packages/control-plane/src/sandbox/settings.ts
@@ -1,6 +1,6 @@
 import {
   findSandboxPortConflict,
-  MIN_SANDBOX_TIMEOUT_MS,
+  isValidSandboxTimeoutMs,
   MAX_TUNNEL_PORTS,
   type ConfiguredSandboxPort,
   type SandboxSettings,
@@ -18,6 +18,12 @@ export class SandboxSettingsValidationError extends Error {
     super(message);
     this.name = "SandboxSettingsValidationError";
   }
+}
+
+/** Decode and normalize a session's persisted sandbox settings snapshot. */
+export function parsePersistedSandboxSettings(settingsJson: string | null): SandboxSettings {
+  if (!settingsJson) return {};
+  return normalizeSandboxSettings(JSON.parse(settingsJson), { invalid: "omit" });
 }
 
 /**
@@ -124,12 +130,7 @@ export function normalizeSandboxSettings(
   }
 
   if (settings.sandboxTimeoutMs !== undefined) {
-    if (
-      typeof settings.sandboxTimeoutMs !== "number" ||
-      !Number.isSafeInteger(settings.sandboxTimeoutMs) ||
-      settings.sandboxTimeoutMs < MIN_SANDBOX_TIMEOUT_MS ||
-      settings.sandboxTimeoutMs % MIN_SANDBOX_TIMEOUT_MS !== 0
-    ) {
+    if (!isValidSandboxTimeoutMs(settings.sandboxTimeoutMs)) {
       reject("sandboxTimeoutMs must be a positive whole number of seconds");
     } else {
       result.sandboxTimeoutMs = settings.sandboxTimeoutMs;

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.test.ts
@@ -191,7 +191,12 @@ describe("createChildSessionsHandler", () => {
 
   it("maps spawn context from session and owner participant", async () => {
     const { handler, getSession, repository } = createHandler();
-    getSession.mockReturnValue(createSession({ reasoning_effort: "high" }));
+    getSession.mockReturnValue(
+      createSession({
+        reasoning_effort: "high",
+        sandbox_settings: '{"sandboxTimeoutMs":14400000,"tunnelPorts":[3000]}',
+      })
+    );
     repository.listParticipants.mockReturnValue([createParticipant()]);
 
     const response = handler.getSpawnContext();
@@ -204,6 +209,7 @@ describe("createChildSessionsHandler", () => {
       model: "anthropic/claude-haiku-4-5",
       reasoningEffort: "high",
       baseBranch: "main",
+      sandboxTimeoutMs: 14_400_000,
       owner: {
         userId: "user-1",
         scmUserId: null,

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
@@ -1,6 +1,6 @@
 import type { SpawnContext } from "@open-inspect/shared";
 import type { SessionStatus } from "../../../types";
-import { normalizeSandboxSettings } from "../../../sandbox/settings";
+import { parsePersistedSandboxSettings } from "../../../sandbox/settings";
 import type { SessionMessenger } from "../../messenger";
 import type { SessionRepository } from "../../repository";
 import type { ArtifactRow, SandboxRow, SessionRow } from "../../types";
@@ -50,6 +50,12 @@ export function createChildSessionsHandler(deps: ChildSessionsHandlerDeps): Chil
       if (!owner) {
         return Response.json({ error: "No owner participant found" }, { status: 404 });
       }
+      let sandboxTimeoutMs: number | undefined;
+      try {
+        sandboxTimeoutMs = parsePersistedSandboxSettings(session.sandbox_settings).sandboxTimeoutMs;
+      } catch {
+        sandboxTimeoutMs = undefined;
+      }
       const context: SpawnContext = {
         repoOwner: session.repo_owner,
         repoName: session.repo_name,
@@ -57,7 +63,7 @@ export function createChildSessionsHandler(deps: ChildSessionsHandlerDeps): Chil
         model: session.model,
         reasoningEffort: session.reasoning_effort ?? null,
         baseBranch: session.base_branch,
-        sandboxTimeoutMs: parseSandboxTimeoutMs(session.sandbox_settings),
+        sandboxTimeoutMs,
         owner: {
           userId: owner.user_id,
           ...(owner.canonical_user_id ? { canonicalUserId: owner.canonical_user_id } : {}),
@@ -150,13 +156,4 @@ export function createChildSessionsHandler(deps: ChildSessionsHandlerDeps): Chil
       return Response.json({ ok: true });
     },
   };
-}
-
-function parseSandboxTimeoutMs(settingsJson: string | null): number | undefined {
-  if (!settingsJson) return undefined;
-  try {
-    return normalizeSandboxSettings(JSON.parse(settingsJson), { invalid: "omit" }).sandboxTimeoutMs;
-  } catch {
-    return undefined;
-  }
 }

--- a/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
+++ b/packages/control-plane/src/session/http/handlers/child-sessions.handler.ts
@@ -1,5 +1,6 @@
 import type { SpawnContext } from "@open-inspect/shared";
 import type { SessionStatus } from "../../../types";
+import { normalizeSandboxSettings } from "../../../sandbox/settings";
 import type { SessionMessenger } from "../../messenger";
 import type { SessionRepository } from "../../repository";
 import type { ArtifactRow, SandboxRow, SessionRow } from "../../types";
@@ -56,6 +57,7 @@ export function createChildSessionsHandler(deps: ChildSessionsHandlerDeps): Chil
         model: session.model,
         reasoningEffort: session.reasoning_effort ?? null,
         baseBranch: session.base_branch,
+        sandboxTimeoutMs: parseSandboxTimeoutMs(session.sandbox_settings),
         owner: {
           userId: owner.user_id,
           ...(owner.canonical_user_id ? { canonicalUserId: owner.canonical_user_id } : {}),
@@ -148,4 +150,13 @@ export function createChildSessionsHandler(deps: ChildSessionsHandlerDeps): Chil
       return Response.json({ ok: true });
     },
   };
+}
+
+function parseSandboxTimeoutMs(settingsJson: string | null): number | undefined {
+  if (!settingsJson) return undefined;
+  try {
+    return normalizeSandboxSettings(JSON.parse(settingsJson), { invalid: "omit" }).sandboxTimeoutMs;
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/control-plane/test/integration/do-internal-routes.test.ts
+++ b/packages/control-plane/test/integration/do-internal-routes.test.ts
@@ -67,6 +67,7 @@ describe("DO internal sub-session routes", () => {
         userId: "user-1",
         scmLogin: "acmedev",
         model: "anthropic/claude-sonnet-4-6",
+        sandboxSettings: { sandboxTimeoutMs: 14_400_000 },
       });
 
       const res = await stub.fetch("http://internal/internal/spawn-context");
@@ -79,6 +80,7 @@ describe("DO internal sub-session routes", () => {
       expect(context.repoId).toBe(12345);
       expect(context.model).toBe("anthropic/claude-sonnet-4-6");
       expect(context.reasoningEffort).toBeNull();
+      expect(context.sandboxTimeoutMs).toBe(14_400_000);
 
       // Owner fields
       expect(context.owner).toBeDefined();

--- a/packages/control-plane/test/integration/helpers.ts
+++ b/packages/control-plane/test/integration/helpers.ts
@@ -1,4 +1,5 @@
 import { SELF, env, runInDurableObject } from "cloudflare:test";
+import type { SandboxSettings } from "@open-inspect/shared";
 import { buildServiceAuthHeaders, type ServiceName } from "@open-inspect/shared/service-auth";
 import type { SandboxStatus } from "../../src/types";
 import type { SessionDO } from "../../src/session/durable-object";
@@ -165,6 +166,7 @@ export async function initSession(overrides?: {
   title?: string;
   model?: string;
   reasoningEffort?: string;
+  sandboxSettings?: SandboxSettings;
   userId?: string;
   scmLogin?: string;
 }) {

--- a/packages/shared/src/types/boundary-schemas.test.ts
+++ b/packages/shared/src/types/boundary-schemas.test.ts
@@ -606,6 +606,7 @@ describe("boundary schemas", () => {
         model: "anthropic/claude-sonnet-4-6",
         reasoningEffort: null,
         baseBranch: null,
+        sandboxTimeoutMs: 14_400_000,
         owner: {
           userId: "user-1",
           scmUserId: null,
@@ -619,6 +620,9 @@ describe("boundary schemas", () => {
       });
 
       expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.sandboxTimeoutMs).toBe(14_400_000);
+      }
     });
 
     it("parses a repo-less spawn context", () => {
@@ -643,6 +647,33 @@ describe("boundary schemas", () => {
 
       expect(result.success).toBe(true);
     });
+
+    it.each([-1_000, 1_500, Number.MAX_SAFE_INTEGER + 1])(
+      "rejects invalid snapshotted sandbox timeout %s",
+      (sandboxTimeoutMs) => {
+        const result = spawnContextSchema.safeParse({
+          repoOwner: null,
+          repoName: null,
+          repoId: null,
+          model: "anthropic/claude-sonnet-4-6",
+          reasoningEffort: null,
+          baseBranch: null,
+          sandboxTimeoutMs,
+          owner: {
+            userId: "user-1",
+            scmUserId: null,
+            scmLogin: null,
+            scmName: null,
+            scmEmail: null,
+            scmAccessTokenEncrypted: null,
+            scmRefreshTokenEncrypted: null,
+            scmTokenExpiresAt: null,
+          },
+        });
+
+        expect(result.success).toBe(false);
+      }
+    );
 
     it("rejects a malformed partial spawn context", () => {
       const result = spawnContextSchema.safeParse({

--- a/packages/shared/src/types/integrations.test.ts
+++ b/packages/shared/src/types/integrations.test.ts
@@ -3,11 +3,26 @@ import {
   DEFAULT_BUILD_TIMEOUT_SECONDS,
   MAX_BUILD_TIMEOUT_SECONDS,
   MAX_SLACK_ROUTING_RULES,
+  isValidSandboxTimeoutMs,
   matchRoutingRules,
   normalizeRoutingRules,
   resolveBuildTimeoutSeconds,
   type SlackRoutingRule,
 } from "./integrations";
+
+describe("isValidSandboxTimeoutMs", () => {
+  it("accepts safe positive whole-second millisecond values", () => {
+    expect(isValidSandboxTimeoutMs(1_000)).toBe(true);
+    expect(isValidSandboxTimeoutMs(14_400_000)).toBe(true);
+  });
+
+  it.each([undefined, "1000", 0, -1_000, 1_500, 1_000.5, Number.MAX_SAFE_INTEGER + 1])(
+    "rejects invalid timeout %s",
+    (value) => {
+      expect(isValidSandboxTimeoutMs(value)).toBe(false);
+    }
+  );
+});
 
 describe("resolveBuildTimeoutSeconds", () => {
   it("defaults when no setting is present", () => {

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -171,8 +171,8 @@ export interface SandboxSettings {
   memoryMib?: number | null;
   /**
    * Requested sandbox session lifetime, in milliseconds and whole-second
-   * increments. Unset uses the provider default (or the shorter default for
-   * agent-spawned children). Provider support and limits vary.
+   * increments. Unset uses the provider default. Provider support and limits
+   * vary.
    */
   sandboxTimeoutMs?: number;
   /**

--- a/packages/shared/src/types/integrations.ts
+++ b/packages/shared/src/types/integrations.ts
@@ -113,6 +113,16 @@ export const DEFAULT_MAX_TOTAL_CHILD_SESSIONS = 15;
 /** Minimum configurable sandbox session lifetime, in milliseconds. */
 export const MIN_SANDBOX_TIMEOUT_MS = 1000;
 
+/** Whether a sandbox lifetime is a safe positive whole-second millisecond value. */
+export function isValidSandboxTimeoutMs(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isSafeInteger(value) &&
+    value >= MIN_SANDBOX_TIMEOUT_MS &&
+    value % MIN_SANDBOX_TIMEOUT_MS === 0
+  );
+}
+
 /**
  * Default repo-image build timeout (the build sandbox lifetime), in seconds.
  * Mirrors `DEFAULT_BUILD_TIMEOUT_SECONDS` in the Modal data plane

--- a/packages/shared/src/types/session-api.ts
+++ b/packages/shared/src/types/session-api.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { recordSchema, type AgentResponse } from "./artifacts";
-import { MIN_SANDBOX_TIMEOUT_MS } from "./integrations";
+import { isValidSandboxTimeoutMs } from "./integrations";
 import { sessionRepositoriesInputSchema } from "./repositories";
 import type { EventResponse } from "./sandbox-events";
 import type { Session } from "./sessions";
@@ -20,14 +20,7 @@ export interface UserPreferences {
 }
 
 const nonEmptyStringSchema = z.string().trim().min(1);
-const sandboxTimeoutMsSchema = z
-  .number()
-  .refine(
-    (value) =>
-      Number.isSafeInteger(value) &&
-      value >= MIN_SANDBOX_TIMEOUT_MS &&
-      value % MIN_SANDBOX_TIMEOUT_MS === 0
-  );
+const sandboxTimeoutMsSchema = z.number().refine(isValidSandboxTimeoutMs);
 
 export const slackCallbackContextSchema = z.object({
   source: z.literal("slack"),

--- a/packages/shared/src/types/session-api.ts
+++ b/packages/shared/src/types/session-api.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { recordSchema, type AgentResponse } from "./artifacts";
+import { MIN_SANDBOX_TIMEOUT_MS } from "./integrations";
 import { sessionRepositoriesInputSchema } from "./repositories";
 import type { EventResponse } from "./sandbox-events";
 import type { Session } from "./sessions";
@@ -19,6 +20,14 @@ export interface UserPreferences {
 }
 
 const nonEmptyStringSchema = z.string().trim().min(1);
+const sandboxTimeoutMsSchema = z
+  .number()
+  .refine(
+    (value) =>
+      Number.isSafeInteger(value) &&
+      value >= MIN_SANDBOX_TIMEOUT_MS &&
+      value % MIN_SANDBOX_TIMEOUT_MS === 0
+  );
 
 export const slackCallbackContextSchema = z.object({
   source: z.literal("slack"),
@@ -273,6 +282,7 @@ export const spawnContextSchema = z.object({
   model: z.string(),
   reasoningEffort: z.string().nullable(),
   baseBranch: z.string().nullable(),
+  sandboxTimeoutMs: sandboxTimeoutMsSchema.optional(),
   owner: z.object({
     userId: z.string(),
     canonicalUserId: z.string().nullable().optional(),


### PR DESCRIPTION
## Summary

- remove the fixed one-hour timeout for agent-spawned child sessions
- inherit the parent session's snapshotted sandbox timeout through the spawn context
- preserve provider defaults when the parent has no explicit timeout
- preserve explicit rejection when a provider cannot enforce configured timeouts
- validate snapshotted timeout values at the spawn-context boundary

## Testing

- `npm run typecheck`
- `npm test -w @open-inspect/shared`
- `npm test -w @open-inspect/control-plane`
- `npm run test:integration -w @open-inspect/control-plane -- --run test/integration/do-internal-routes.test.ts`
- `npm run lint -w @open-inspect/shared`
- `npm run lint -w @open-inspect/control-plane`
- focused timeout inheritance and boundary-schema tests

## Review

An independent sub-agent review identified that the spawn-context schema initially accepted malformed timeout values. The schema now enforces the same safe positive whole-second constraints as persisted sandbox settings, with regression coverage.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/4c6ee64206b7e593d0d930b267783a15)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Child sessions now inherit the parent session’s configured sandbox timeout.
  * Spawn context responses include the configured sandbox timeout when available.
* **Bug Fixes**
  * Provider and unrelated sandbox settings are preserved when no parent timeout is configured.
  * Sessions without an explicit timeout no longer receive an implicit timeout.
* **Validation**
  * Sandbox timeout values must meet minimum, whole-second, and safe-range requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->