### PR TITLE
Run TypeScript test jobs in parallel with static checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,6 @@ jobs:
     name: Test (control-plane unit)
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [lint-typescript, typecheck-typescript]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -222,7 +221,6 @@ jobs:
     name: Test (control-plane integration)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [lint-typescript, typecheck-typescript]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -249,7 +247,6 @@ jobs:
     name: Test (web)
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [lint-typescript, typecheck-typescript]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -273,7 +270,6 @@ jobs:
     name: Test (bots)
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [lint-typescript, typecheck-typescript]
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- remove the lint/typecheck prerequisites from the control-plane unit, control-plane integration, web, and bot TypeScript test jobs
- allow all four test jobs to start concurrently with TypeScript lint and typecheck
- preserve every existing test command, timeout, and coverage path

## Expected impact

This removes lint and typecheck duration from the TypeScript test critical path, so test results can complete earlier when runners are available.

## Validation

- parsed `.github/workflows/ci.yml` with the installed Node `yaml` parser
- asserted all four target test jobs exist and have no `needs` key
- asserted `lint-typescript` and `typecheck-typescript` remain present
- ran `npx prettier --check .github/workflows/ci.yml`
- ran `git diff --check`
- completed an independent code review with no findings

## Tradeoff

On commits where lint or typecheck fails, the test jobs may continue consuming runner time instead of being skipped. This is the expected cost of reducing CI critical-path latency.

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/92660a5a2522fa8c1b2909847c1a7cf0)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined automated test workflows by allowing control-plane, web, and bots test jobs to run independently.
  * Removed unnecessary prerequisites from unit and integration test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->