### PR TITLE
Add ESLint complexity reporting command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Run ESLint
         run: npm run lint
 
+      - name: Test complexity reporter
+        run: npm run test:lint-complexity
+
       - name: Check Prettier formatting
         run: npm run format:check
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "lint": "eslint .",
+    "lint:complexity": "node scripts/lint-complexity.mjs",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "npm run test --workspaces --if-present",
+    "test:lint-complexity": "node --test scripts/lint-complexity-message.test.mjs",
     "test:coverage": "npm run test:coverage --workspaces --if-present",
     "test:integration": "npm run test:integration --workspaces --if-present",
     "typecheck": "npm run typecheck --workspaces --if-present",

--- a/scripts/lint-complexity-message.mjs
+++ b/scripts/lint-complexity-message.mjs
@@ -1,0 +1,21 @@
+const COMPLEXITY_MESSAGE_ID = "complex";
+const COMPLEXITY_VALUE_PATTERN = /\bcomplexity of (\d+)\b/u;
+
+export function parseComplexityMessage(file, message) {
+  const match =
+    message.messageId === COMPLEXITY_MESSAGE_ID
+      ? COMPLEXITY_VALUE_PATTERN.exec(message.message)
+      : null;
+
+  if (!match) {
+    throw new Error(`Could not parse complexity at ${file}:${message.line}:${message.column}`);
+  }
+
+  return {
+    file,
+    line: message.line,
+    column: message.column,
+    complexity: Number(match[1]),
+    description: message.nodeType ?? "Function",
+  };
+}

--- a/scripts/lint-complexity-message.test.mjs
+++ b/scripts/lint-complexity-message.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ESLint } from "eslint";
+
+import { parseComplexityMessage } from "./lint-complexity-message.mjs";
+
+test("parses the supported ESLint complexity diagnostic shape", async () => {
+  const eslint = new ESLint({
+    overrideConfigFile: true,
+    ruleFilter: ({ ruleId }) => ruleId === "complexity",
+    overrideConfig: {
+      rules: {
+        complexity: ["warn", { max: 0, variant: "classic" }],
+      },
+    },
+  });
+  const [result] = await eslint.lintText(
+    "function example(value) { if (value) return 1; return 0; }"
+  );
+  const [message] = result.messages;
+
+  assert.deepEqual(
+    {
+      ruleId: message.ruleId,
+      messageId: message.messageId,
+      message: message.message,
+      nodeType: message.nodeType,
+    },
+    {
+      ruleId: "complexity",
+      messageId: "complex",
+      message: "Function 'example' has a complexity of 2. Maximum allowed is 0.",
+      nodeType: "FunctionDeclaration",
+    }
+  );
+
+  assert.deepEqual(parseComplexityMessage("packages/example.ts", message), {
+    file: "packages/example.ts",
+    line: 1,
+    column: 1,
+    complexity: 2,
+    description: "FunctionDeclaration",
+  });
+});
+
+test("rejects an unsupported complexity diagnostic shape", () => {
+  assert.throws(
+    () =>
+      parseComplexityMessage("packages/example.ts", {
+        ruleId: "complexity",
+        messageId: "unexpected",
+        message: "Function 'example' has a complexity of 12. Maximum allowed is 0.",
+        nodeType: "FunctionDeclaration",
+        line: 4,
+        column: 1,
+      }),
+    /Could not parse complexity at packages\/example\.ts:4:1/u
+  );
+});

--- a/scripts/lint-complexity.mjs
+++ b/scripts/lint-complexity.mjs
@@ -3,6 +3,8 @@ import process from "node:process";
 
 import { ESLint } from "eslint";
 
+import { parseComplexityMessage } from "./lint-complexity-message.mjs";
+
 const TARGET_GLOB = "packages/**/*.{ts,tsx}";
 const HOTSPOT_THRESHOLD = 20;
 const RESULT_LIMIT = 25;
@@ -33,21 +35,6 @@ function compareFindings(left, right) {
   );
 }
 
-function parseFinding(file, message) {
-  const match = /^(.*?) has a complexity of (\d+)\./u.exec(message.message);
-  if (!match) {
-    throw new Error(`Could not parse complexity at ${file}:${message.line}:${message.column}`);
-  }
-
-  return {
-    file,
-    line: message.line,
-    column: message.column,
-    complexity: Number(match[2]),
-    description: match[1],
-  };
-}
-
 function collectFindings(results) {
   const files = { total: results.length, production: 0, test: 0 };
   const findings = { production: [], test: [] };
@@ -64,7 +51,7 @@ function collectFindings(results) {
         );
       }
       if (message.ruleId === "complexity") {
-        findings[category].push(parseFinding(file, message));
+        findings[category].push(parseComplexityMessage(file, message));
       }
     }
   }
@@ -171,6 +158,7 @@ async function main() {
   }
 
   const eslint = new ESLint({
+    ruleFilter: ({ ruleId }) => ruleId === "complexity",
     overrideConfig: [
       {
         files: [TARGET_GLOB],

--- a/scripts/lint-complexity.mjs
+++ b/scripts/lint-complexity.mjs
@@ -1,0 +1,192 @@
+import path from "node:path";
+import process from "node:process";
+
+import { ESLint } from "eslint";
+
+const TARGET_GLOB = "packages/**/*.{ts,tsx}";
+const HOTSPOT_THRESHOLD = 20;
+const RESULT_LIMIT = 25;
+const DISTRIBUTION_THRESHOLDS = [10, 15, 20, 30, 50];
+
+function toRelativePath(filePath) {
+  return path.relative(process.cwd(), filePath).split(path.sep).join("/");
+}
+
+function isTestFile(filePath) {
+  return (
+    /(?:^|\/)(?:__tests__|tests?)(?:\/|$)/u.test(filePath) ||
+    /\.(?:test|spec)\.[cm]?[jt]sx?$/u.test(filePath)
+  );
+}
+
+function compareText(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function compareFindings(left, right) {
+  return (
+    right.complexity - left.complexity ||
+    compareText(left.file, right.file) ||
+    left.line - right.line ||
+    left.column - right.column ||
+    compareText(left.description, right.description)
+  );
+}
+
+function parseFinding(file, message) {
+  const match = /^(.*?) has a complexity of (\d+)\./u.exec(message.message);
+  if (!match) {
+    throw new Error(`Could not parse complexity at ${file}:${message.line}:${message.column}`);
+  }
+
+  return {
+    file,
+    line: message.line,
+    column: message.column,
+    complexity: Number(match[2]),
+    description: match[1],
+  };
+}
+
+function collectFindings(results) {
+  const files = { total: results.length, production: 0, test: 0 };
+  const findings = { production: [], test: [] };
+
+  for (const result of results) {
+    const file = toRelativePath(result.filePath);
+    const category = isTestFile(file) ? "test" : "production";
+    files[category] += 1;
+
+    for (const message of result.messages) {
+      if (message.fatal) {
+        throw new Error(
+          `ESLint could not analyze ${file}:${message.line ?? 0}:${message.column ?? 0}: ${message.message}`
+        );
+      }
+      if (message.ruleId === "complexity") {
+        findings[category].push(parseFinding(file, message));
+      }
+    }
+  }
+
+  findings.production.sort(compareFindings);
+  findings.test.sort(compareFindings);
+  return { files, findings };
+}
+
+function distribution(findings) {
+  return Object.fromEntries(
+    DISTRIBUTION_THRESHOLDS.map((threshold) => [
+      `over${threshold}`,
+      findings.filter(({ complexity }) => complexity > threshold).length,
+    ])
+  );
+}
+
+function buildReport(results) {
+  const { files, findings } = collectFindings(results);
+  const productionHotspots = findings.production.filter(
+    ({ complexity }) => complexity > HOTSPOT_THRESHOLD
+  );
+  const testHotspots = findings.test.filter(({ complexity }) => complexity > HOTSPOT_THRESHOLD);
+
+  return {
+    analysis: {
+      metric: "cyclomatic-complexity",
+      eslintRule: "complexity",
+      variant: "classic",
+      targetGlob: TARGET_GLOB,
+      hotspotThreshold: HOTSPOT_THRESHOLD,
+      testFilesExcludedFromProductionHotspots: true,
+    },
+    summary: {
+      files,
+      functions: {
+        total: findings.production.length + findings.test.length,
+        production: findings.production.length,
+        test: findings.test.length,
+      },
+      hotspots: {
+        production: productionHotspots.length,
+        test: testHotspots.length,
+      },
+    },
+    distribution: {
+      production: distribution(findings.production),
+      test: distribution(findings.test),
+    },
+    productionHotspots,
+    testHotspots,
+  };
+}
+
+function formatDistribution(counts) {
+  return DISTRIBUTION_THRESHOLDS.map(
+    (threshold) => `>${threshold}: ${counts[`over${threshold}`]}`
+  ).join(" | ");
+}
+
+function formatHotspots(hotspots) {
+  if (hotspots.length === 0) {
+    return "  None";
+  }
+
+  return hotspots
+    .slice(0, RESULT_LIMIT)
+    .map(
+      ({ file, line, column, complexity, description }) =>
+        `  ${String(complexity).padStart(3)}  ${file}:${line}:${column}  ${description}`
+    )
+    .join("\n");
+}
+
+function formatText(report) {
+  const { analysis, summary, distribution: counts, productionHotspots } = report;
+  const shown = Math.min(productionHotspots.length, RESULT_LIMIT);
+  const resultCount =
+    shown === productionHotspots.length
+      ? `${shown} found`
+      : `top ${shown} of ${productionHotspots.length}`;
+
+  return `Cyclomatic complexity analysis (ESLint classic variant)
+
+Files: ${summary.files.total} total (${summary.files.production} production, ${summary.files.test} test)
+Functions: ${summary.functions.total} total (${summary.functions.production} production, ${summary.functions.test} test)
+Production distribution: ${formatDistribution(counts.production)}
+Test distribution: ${formatDistribution(counts.test)}
+
+Production hotspots (complexity >${analysis.hotspotThreshold}; ${resultCount})
+  Cx   Location  Function
+${formatHotspots(productionHotspots)}
+
+Tests are excluded from the hotspot table (${summary.hotspots.test} test hotspots over the configured threshold).
+Complexity findings are report-only and do not affect the exit code.
+`;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.some((argument) => argument !== "--json")) {
+    throw new Error("Only the optional --json flag is supported");
+  }
+
+  const eslint = new ESLint({
+    overrideConfig: [
+      {
+        files: [TARGET_GLOB],
+        rules: {
+          complexity: ["warn", { max: 0, variant: "classic" }],
+        },
+      },
+    ],
+  });
+  const report = buildReport(await eslint.lintFiles([TARGET_GLOB]));
+  const output = args.includes("--json") ? JSON.stringify(report, null, 2) : formatText(report);
+  process.stdout.write(`${output}\n`);
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`Complexity analysis failed: ${message}\n`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- add `npm run lint:complexity` using the installed ESLint 9 Node interface
- rank production cyclomatic-complexity hotspots while reporting tests separately
- support deterministic JSON output for later CI or trend analysis

## Why

The repository had no repeatable way to inventory overly complex TypeScript and TSX functions. This adds a report-only baseline without introducing a new dependency or failing on historical complexity.

## Validation

- `npm run lint:complexity`
- `npm run --silent lint:complexity -- --json` and JSON parse
- `npm run lint`
- `npx prettier --check package.json scripts/lint-complexity.mjs`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a complexity analysis command for reviewing TypeScript code.
  * Reports complexity distributions and hotspots in human-readable or JSON formats.
  * Distinguishes test files from production files and provides clear error handling for invalid analysis results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->