### PR TITLE
Clarify session timeout unit in settings

### DIFF
--- a/packages/web/src/components/settings/sandbox-settings.test.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.test.tsx
@@ -109,7 +109,7 @@ describe("SandboxSettingsPage — tunnel ports editor", () => {
       </SWRConfig>
     );
 
-    const input = screen.getByLabelText("Session Timeout");
+    const input = screen.getByLabelText("Session Timeout (minutes)");
     expect(input).toHaveValue(120);
     await user.clear(input);
     await user.type(input, "240");
@@ -1097,7 +1097,7 @@ describe("SandboxSettingsEditor — environment scope", () => {
     await user.type(screen.getByLabelText("Image Build Timeout"), "2400");
     await user.click(screen.getByText("Save Settings"));
 
-    expect(screen.getByLabelText("Session Timeout")).toHaveValue(120);
+    expect(screen.getByLabelText("Session Timeout (minutes)")).toHaveValue(120);
 
     // Only the edited field is pinned — inherited cpu and the inherited
     // build-timeout base stay inherited.

--- a/packages/web/src/components/settings/sandbox-settings.tsx
+++ b/packages/web/src/components/settings/sandbox-settings.tsx
@@ -768,7 +768,7 @@ export function SandboxSettingsEditor({
           htmlFor="sandbox-session-timeout"
           className="block text-sm font-medium text-foreground mb-1.5"
         >
-          Session Timeout
+          Session Timeout (minutes)
         </label>
         <p className="text-xs text-muted-foreground mb-2">
           Requested lifetime for each sandbox session, in minutes. Leave blank to inherit a parent


### PR DESCRIPTION
## Summary
- label the session timeout field explicitly in minutes
- update settings tests to use the clarified accessible label

## Testing
- `npm test -w @open-inspect/web -- src/components/settings/sandbox-settings.test.tsx`

---
*Created with [Open-Inspect](https://open-inspect-prod.vercel.app/session/61c1b7f86e41dc6f77344037cb44ca5b)*